### PR TITLE
feat: ui polish, ci/cd consolidation, and auto-updater

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,6 +35,7 @@
     "@tanstack/react-router": "^1.170.4",
     "clsx": "^2.1.1",
     "docx": "^9.6.1",
+    "electron-updater": "^6.8.3",
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "jspdf": "^4.2.1",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -17,6 +17,7 @@ import { createMainWindow } from './window.js';
 import { installMenu } from './menus.js';
 import { bootstrap } from './bootstrap.js';
 import { registerIpc } from './ipc/router.js';
+import { setupUpdater } from './updater.js';
 import { createLogger } from '@ajh/core';
 
 const logger = createLogger('main');
@@ -47,6 +48,7 @@ app.whenReady().then(async () => {
     registerIpc(core);
     mainWindow = await createMainWindow();
     installMenu(mainWindow);
+    if (app.isPackaged) void setupUpdater();
     core.onShuttingDown = async () => {
       /* hook for graceful shutdown */
     };

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -21,8 +21,10 @@ function broadcast(status: UpdateStatus) {
 
 export async function setupUpdater() {
   // Lazy import — electron-updater is heavy and should not load at startup
-  const { default: pkg } = await import('electron-updater');
-  const { autoUpdater } = pkg as typeof import('electron-updater');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { default: pkg } = (await import('electron-updater')) as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { autoUpdater } = pkg as { autoUpdater: any };
 
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = true;

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,0 +1,75 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import { IPC_CHANNELS } from '@ajh/shared';
+import { createLogger } from '@ajh/core';
+
+const logger = createLogger('updater');
+
+export type UpdateStatus =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'available'; version: string; releaseNotes?: string }
+  | { state: 'not-available' }
+  | { state: 'downloading'; percent: number }
+  | { state: 'downloaded'; version: string }
+  | { state: 'error'; message: string };
+
+function broadcast(status: UpdateStatus) {
+  BrowserWindow.getAllWindows().forEach((win) => {
+    win.webContents.send(IPC_CHANNELS.updater.onStatus, status);
+  });
+}
+
+export async function setupUpdater() {
+  // Lazy import — electron-updater is heavy and should not load at startup
+  const { default: pkg } = await import('electron-updater');
+  const { autoUpdater } = pkg as typeof import('electron-updater');
+
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.logger = logger;
+
+  autoUpdater.on('checking-for-update', () => {
+    broadcast({ state: 'checking' });
+  });
+
+  autoUpdater.on('update-available', (info) => {
+    broadcast({
+      state: 'available',
+      version: info.version,
+      releaseNotes: typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined,
+    });
+  });
+
+  autoUpdater.on('update-not-available', () => {
+    broadcast({ state: 'not-available' });
+  });
+
+  autoUpdater.on('download-progress', (progress) => {
+    broadcast({ state: 'downloading', percent: Math.round(progress.percent) });
+  });
+
+  autoUpdater.on('update-downloaded', (info) => {
+    broadcast({ state: 'downloaded', version: info.version });
+  });
+
+  autoUpdater.on('error', (err: Error) => {
+    logger.error({ err }, 'auto-updater error');
+    broadcast({ state: 'error', message: err.message });
+  });
+
+  ipcMain.handle(IPC_CHANNELS.updater.check, async () => {
+    await autoUpdater.checkForUpdates();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.updater.download, async () => {
+    await autoUpdater.downloadUpdate();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.updater.install, () => {
+    autoUpdater.quitAndInstall(false, true);
+  });
+
+  // Silent check 10 s after launch, then every 4 h
+  setTimeout(() => void autoUpdater.checkForUpdates().catch(() => {}), 10_000);
+  setInterval(() => void autoUpdater.checkForUpdates().catch(() => {}), 4 * 60 * 60 * 1_000);
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -95,6 +95,16 @@ const api = {
     }) => invoke(IPC_CHANNELS.apply.start, req),
     catalog: () => invoke(IPC_CHANNELS.apply.catalog),
   },
+  updater: {
+    check: () => invoke(IPC_CHANNELS.updater.check),
+    download: () => invoke(IPC_CHANNELS.updater.download),
+    install: () => invoke(IPC_CHANNELS.updater.install),
+    onStatus: (handler: (status: unknown) => void) => {
+      const listener = (_: unknown, status: unknown) => handler(status);
+      ipcRenderer.on(IPC_CHANNELS.updater.onStatus, listener);
+      return () => ipcRenderer.off(IPC_CHANNELS.updater.onStatus, listener);
+    },
+  },
   shortcuts: {
     onCommandPalette: (handler: () => void) => {
       const listener = () => handler();

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -75,7 +75,7 @@ export function Sidebar() {
                     border: '1px solid rgba(168,85,247,0.25)',
                     boxShadow: '0 0 16px rgba(168,85,247,0.12)',
                   }}
-                  transition={transition.spring}
+                  transition={{ type: 'spring', stiffness: 600, damping: 40, mass: 0.6 }}
                 />
               )}
               <Link

--- a/apps/desktop/src/renderer/components/ui/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/ui/UpdateBanner.tsx
@@ -1,0 +1,89 @@
+import { AnimatePresence, motion } from 'motion/react';
+import { Download, RefreshCw, X, Sparkles, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { useUpdater } from '@/services/use-updater';
+import { transition } from '@/lib/motion';
+import { useTranslation } from '@/lib/i18n';
+
+export function UpdateBanner() {
+  const { status, download, install } = useUpdater();
+  const { t } = useTranslation();
+  const [dismissed, setDismissed] = useState(false);
+
+  const visible =
+    !dismissed &&
+    (status.state === 'available' ||
+      status.state === 'downloading' ||
+      status.state === 'downloaded');
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ opacity: 0, y: -40 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -40 }}
+          transition={transition.normal}
+          className="fixed left-1/2 top-3 z-[300] -translate-x-1/2"
+        >
+          <div
+            className="flex items-center gap-3 rounded-xl border border-brand/30 px-4 py-2.5 shadow-2xl shadow-black/40"
+            style={{
+              background:
+                'linear-gradient(135deg, rgba(168,85,247,0.15) 0%, rgba(99,102,241,0.10) 100%)',
+              backdropFilter: 'blur(16px)',
+            }}
+          >
+            {/* Icon */}
+            {status.state === 'downloading' ? (
+              <Loader2 size={14} className="shrink-0 animate-spin text-brand-soft" />
+            ) : status.state === 'downloaded' ? (
+              <RefreshCw size={14} className="shrink-0 text-brand-soft" />
+            ) : (
+              <Sparkles size={14} className="shrink-0 text-brand-soft" />
+            )}
+
+            {/* Message */}
+            <span className="text-xs text-foreground/85">
+              {status.state === 'available' && t('updater.available', { version: status.version })}
+              {status.state === 'downloading' &&
+                t('updater.downloading', { percent: status.percent })}
+              {status.state === 'downloaded' &&
+                t('updater.downloaded', { version: status.version })}
+            </span>
+
+            {/* Action button */}
+            {status.state === 'available' && (
+              <button
+                onClick={() => void download()}
+                className="flex items-center gap-1.5 rounded-lg border border-brand/40 bg-brand/20 px-2.5 py-1 text-[11px] font-medium text-brand-soft transition-colors hover:bg-brand/30"
+              >
+                <Download size={11} />
+                {t('updater.downloadButton')}
+              </button>
+            )}
+            {status.state === 'downloaded' && (
+              <button
+                onClick={() => void install()}
+                className="flex items-center gap-1.5 rounded-lg border border-brand/40 bg-brand/20 px-2.5 py-1 text-[11px] font-medium text-brand-soft transition-colors hover:bg-brand/30"
+              >
+                <RefreshCw size={11} />
+                {t('updater.installButton')}
+              </button>
+            )}
+
+            {/* Dismiss */}
+            {status.state !== 'downloading' && (
+              <button
+                onClick={() => setDismissed(true)}
+                className="ml-1 text-foreground/30 transition-colors hover:text-foreground/60"
+              >
+                <X size={13} />
+              </button>
+            )}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/apps/desktop/src/renderer/i18n/locales/en.json
+++ b/apps/desktop/src/renderer/i18n/locales/en.json
@@ -1146,5 +1146,12 @@
         "desc": "Chat with your personal job hunting assistant. Ask questions, get advice, refine your strategy."
       }
     }
+  },
+  "updater": {
+    "available": "v{{version}} is available",
+    "downloading": "Downloading update… {{percent}}%",
+    "downloaded": "v{{version}} ready to install",
+    "downloadButton": "Download",
+    "installButton": "Restart & Install"
   }
 }

--- a/apps/desktop/src/renderer/routes/__root.tsx
+++ b/apps/desktop/src/renderer/routes/__root.tsx
@@ -7,6 +7,7 @@ import { CommandPalette } from '@/components/command-palette/CommandPalette';
 import { CapabilityProvider } from '@/providers/CapabilityProvider';
 import { OnboardingWizard } from '@/features/onboarding/OnboardingWizard';
 import { ToastProvider } from '@/components/ui/Toast';
+import { UpdateBanner } from '@/components/ui/UpdateBanner';
 
 export const Route = createRootRoute({
   component: () => (
@@ -24,6 +25,7 @@ export const Route = createRootRoute({
           <StatusBar />
           <CommandPalette />
           <OnboardingWizard />
+          <UpdateBanner />
         </div>
       </CapabilityProvider>
     </ToastProvider>

--- a/apps/desktop/src/renderer/services/use-updater.ts
+++ b/apps/desktop/src/renderer/services/use-updater.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export type UpdateStatus =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'available'; version: string; releaseNotes?: string }
+  | { state: 'not-available' }
+  | { state: 'downloading'; percent: number }
+  | { state: 'downloaded'; version: string }
+  | { state: 'error'; message: string };
+
+export function useUpdater() {
+  const [status, setStatus] = useState<UpdateStatus>({ state: 'idle' });
+
+  useEffect(() => {
+    const off = window.api.updater.onStatus((s) => setStatus(s as UpdateStatus));
+    return off;
+  }, []);
+
+  const check = useCallback(() => window.api.updater.check(), []);
+  const download = useCallback(() => window.api.updater.download(), []);
+  const install = useCallback(() => window.api.updater.install(), []);
+
+  return { status, check, download, install };
+}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -51,5 +51,8 @@ nsis:
   perMachine: false
   allowToChangeInstallationDirectory: true
 
-publish: null
+publish:
+  provider: github
+  owner: saeedkolivand
+  repo: ai-job-hunter-assistant-app
 npmRebuild: true

--- a/packages/shared/src/ipc/contracts.ts
+++ b/packages/shared/src/ipc/contracts.ts
@@ -486,6 +486,13 @@ export const IPC_CHANNELS = {
 
     resume: 'autopilot:resume',
   },
+
+  updater: {
+    check: 'updater:check',
+    download: 'updater:download',
+    install: 'updater:install',
+    onStatus: 'updater:status',
+  },
 } as const;
 
 export type IpcChannel =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       docx:
         specifier: ^9.6.1
         version: 9.6.1
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
       i18next:
         specifier: ^26.2.0
         version: 26.2.0(typescript@6.0.3)
@@ -2786,6 +2789,9 @@ packages:
   electron-to-chromium@1.5.357:
     resolution: {integrity: sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==}
 
+  electron-updater@6.8.3:
+    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
+
   electron-vite@6.0.0-beta.1:
     resolution: {integrity: sha512-jltST77AwNxIeTTDtYhnIEA8ZM0RW9jmSJcqS8x/dQcgeeLlxlcJoYNNJ1tv7/Swor0AbXMYteBGdezoAOt+Nw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3926,6 +3932,10 @@ packages:
 
   lodash.escaperegexp@4.1.2:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -5240,6 +5250,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -8332,6 +8345,19 @@ snapshots:
 
   electron-to-chromium@1.5.357: {}
 
+  electron-updater@6.8.3:
+    dependencies:
+      builder-util-runtime: 9.5.1
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-vite@6.0.0-beta.1(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
@@ -9620,6 +9646,8 @@ snapshots:
   lodash.capitalize@4.2.1: {}
 
   lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -11014,6 +11042,8 @@ snapshots:
       semver: 5.7.2
 
   tiny-invariant@1.3.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary

- **UI fixes** — input backdrop-filter white background in Electron (Input, TextArea, SelectDropdown, search bars); placeholder contrast and padding improvements; glass-graphite card style unified across analyze/ai-generate panels and model selector
- **Onboarding** — backdrop no longer flashes on step transitions; directional slide animations (next→left, back→right) with correct stale-prop fix via variant functions; SpotlightTour visible with backdrop hidden; full keyboard navigation (Enter/arrows) on all steps
- **Toast** — rebuilt as global queued system (`ToastProvider` / `useToast`) supporting multiple stacked toasts with independent timers; migrated `PrivacySettingsTab` to the new hook
- **CI/CD** — consolidated `ci.yml` + `build.yml` + `release.yml` into a single `pipeline.yml` with a manual approval gate (`environment: release`) before any publish step
- **Auto-updater** — `electron-updater` wired end-to-end (IPC contract → main service → preload → `useUpdater` hook → `UpdateBanner` UI); lazy-loaded to avoid startup overhead; only active in packaged builds
- **Sidebar** — `layoutId` pill transition replaced with high-stiffness spring (stiffness 600) to eliminate animation queue lag on rapid clicks
- **Version reset** — root `package.json` set to `0.1.0`, all old tags removed, `v0.1.0` pushed as clean baseline

## Test plan

- [ ] Verify inputs in New Scrape modal have correct dark background (no white flash)
- [ ] Verify search bars in Jobs and Resumes pages render correctly on hover/focus
- [ ] Step through onboarding wizard — confirm no backdrop flash, directional slides, keyboard nav works
- [ ] Trigger multiple toasts in Settings → Privacy and confirm they stack and dismiss independently
- [ ] Push a `feat:` commit to main and confirm pipeline reaches the manual approval step before releasing
- [ ] Confirm sidebar pill animates smoothly when clicking items rapidly

🤖 Generated with [Claude Code](https://claude.com/claude-code)