### PR TITLE
ci: fix semantic-release protected branch push and add stale branch rule

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -37,6 +37,17 @@ git push origin HEAD
 
 Conventional commit prefixes: `feat:` `fix:` `perf:` `refactor:` `docs:` `chore:` `ci:` `test:`
 
+**Before starting any work, verify the current branch still exists on the remote:**
+```bash
+git fetch origin
+git branch -r | grep $(git branch --show-current)
+```
+If the branch is gone (PR was merged, branch deleted on GitHub), switch to main first:
+```bash
+git checkout main && git pull origin main
+```
+Never commit to a dead branch — the work cannot be pushed and will be orphaned.
+
 ---
 
 ## Architecture

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -41,6 +41,17 @@ Never commit directly to `main`. Workflow:
 2. Commit with conventional prefix (`feat:`, `fix:`, `refactor:`, `ci:`, `docs:`, `test:`)
 3. Open PR → CI must pass before merge
 
+**Before starting any work, check that the current branch still exists on the remote:**
+```bash
+git fetch origin
+git branch -r | grep $(git branch --show-current)
+```
+If the branch is gone (PR merged + branch deleted on GitHub), switch to main before doing anything:
+```bash
+git checkout main && git pull origin main
+```
+Never commit to a branch that no longer exists on the remote — it cannot be pushed and the work is orphaned.
+
 ---
 
 ## Architecture

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,21 @@ Never push directly to `main`. Always:
 2. Commit with conventional prefixes (`feat:`, `fix:`, `refactor:`, `ci:`, `docs:`, `test:`)
 3. Open a PR targeting `main` — CI must pass before merge
 
+**Before starting any work, verify the current branch still exists on the remote:**
+
+```bash
+git fetch origin
+git branch -r | grep $(git branch --show-current)
+```
+
+If the branch is gone (PR was merged and GitHub deleted it), switch to main immediately:
+
+```bash
+git checkout main && git pull origin main
+```
+
+Never commit to a branch that no longer exists on the remote — the work will be orphaned.
+
 ---
 
 ## Critical rules

--- a/.github/workflows/02-pull-request-validation.yml
+++ b/.github/workflows/02-pull-request-validation.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build Dependency Packages
+        run: pnpm -r --filter=!@ajh/desktop build
+
       - name: Run ESLint
         run: pnpm lint
 
@@ -45,7 +48,7 @@ jobs:
         run: pnpm test
 
       - name: Verify Production Build
-        run: pnpm build
+        run: pnpm --filter @ajh/desktop build
 
       - name: Notify Discord Failure
         if: failure()

--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -48,14 +48,13 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         env:
-          # GITHUB_TOKEN cannot push to protected branches even with contents:write.
-          # RELEASE_TOKEN must be a PAT with repo scope created by a Repository Admin.
-          # How to create it:
-          #   1. GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
-          #   2. Repository access: this repo only
-          #   3. Permissions: Contents = Read & Write, Pull requests = Read & Write
-          #   4. Copy the token → repo Settings → Secrets → Actions → New secret → RELEASE_TOKEN
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN has contents:write (declared above) which is sufficient for
+          # semantic-release to create tags and GitHub Releases.
+          # To allow it to push the version bump commit to the protected main branch,
+          # add github-actions[bot] as a bypass actor in the branch ruleset:
+          #   GitHub → Settings → Rules → Rulesets → main → Bypass list
+          #   → Add bypass → search "github actions" → select GitHub Actions (App • github)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Discord Release Failure
         if: failure()

--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -48,7 +48,14 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN cannot push to protected branches even with contents:write.
+          # RELEASE_TOKEN must be a PAT with repo scope created by a Repository Admin.
+          # How to create it:
+          #   1. GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
+          #   2. Repository access: this repo only
+          #   3. Permissions: Contents = Read & Write, Pull requests = Read & Write
+          #   4. Copy the token → repo Settings → Secrets → Actions → New secret → RELEASE_TOKEN
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Notify Discord Release Failure
         if: failure()

--- a/.roorules
+++ b/.roorules
@@ -34,6 +34,17 @@ git commit -m "feat: add job board integration"
 # 3. PR — CI must pass
 ```
 
+**Before starting any work, verify the current branch still exists on the remote:**
+```bash
+git fetch origin
+git branch -r | grep $(git branch --show-current)
+```
+If not found (PR was merged and branch deleted on GitHub), switch to main first:
+```bash
+git checkout main && git pull origin main
+```
+Never commit to a branch that no longer exists on the remote.
+
 ---
 
 ## Architecture overview

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -33,6 +33,18 @@ Before marking any task complete:
 3. Open a pull request targeting `main`
 4. CI must pass before merging
 
+**Always verify your branch exists on the remote before starting work:**
+```bash
+git fetch origin
+git branch -r | grep $(git branch --show-current)
+```
+If the branch no longer exists on the remote (PR was merged and branch deleted on GitHub),
+switch back to main immediately — do not commit to a dead branch:
+```bash
+git checkout main && git pull origin main
+```
+Then create a new branch for the next piece of work.
+
 ---
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,27 @@ ESLint errors on main-process package imports in any renderer file.
 
 ---
 
-### 13. New IPC capabilities
+### 13. Stale branch check — always verify before starting work
+
+Before writing any code, confirm the current branch still exists on the remote:
+
+```bash
+git fetch origin
+git branch -r | grep $(git branch --show-current)
+```
+
+If the branch is gone (PR was merged and GitHub auto-deleted it), switch to main immediately:
+
+```bash
+git checkout main && git pull origin main
+```
+
+Never commit to a branch that no longer exists on the remote — work will be orphaned and
+cannot be pushed.
+
+---
+
+### 14. New IPC capabilities
 
 1. Add method signature to `packages/shared/src/ipc/contracts.ts`
 2. Implement in `apps/desktop/src/main/ipc/router.ts`


### PR DESCRIPTION
## Summary

- **Workflow fix**: revert RELEASE_TOKEN approach — the correct fix is adding `github-actions[bot]` as a bypass actor in the GitHub ruleset (Settings → Rules → Rulesets → main → Bypass list → search 'github actions'). `GITHUB_TOKEN` with `contents: write` is sufficient once the bypass is configured.
- **Stale branch rule**: all AI rule files (`CLAUDE.md`, `.windsurfrules`, `.clinerules`, `.roorules`, `.cursor/rules/project.mdc`, `copilot-instructions.md`) now instruct AI assistants to verify the current branch still exists on the remote before starting work, and switch to `main` if the branch was deleted after a merged PR.

## Test plan

- [ ] CI passes on this PR
- [ ] After merging: confirm semantic-release can push to main once `github-actions[bot]` bypass is added to the ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)