### PR TITLE
fix: correct electron build commands in release workflow

### DIFF
--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -101,14 +101,17 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Electron Application
-        run: pnpm electron:build
+      - name: Build Packages
+        run: pnpm -r --filter=!@ajh/desktop build
+
+      - name: Build & Package Windows
+        run: pnpm --filter @ajh/desktop package -- --win
 
       - name: Upload Windows Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: windows-build
-          path: dist/**
+          path: apps/desktop/release/**
 
   build-macos:
     name: Build macOS Application
@@ -139,14 +142,17 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Electron Application
-        run: pnpm electron:build
+      - name: Build Packages
+        run: pnpm -r --filter=!@ajh/desktop build
+
+      - name: Build & Package macOS
+        run: pnpm --filter @ajh/desktop package -- --mac
 
       - name: Upload macOS Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: macos-build
-          path: dist/**
+          path: apps/desktop/release/**
 
   notify-release-success:
     name: Notify Release Success


### PR DESCRIPTION
## Summary

- `pnpm electron:build` does not exist — replaced with the correct two-step sequence:
  1. `pnpm -r --filter=!@ajh/desktop build` — build all dependency packages first
  2. `pnpm --filter @ajh/desktop package -- --win/--mac` — package the Electron app
- Fixed artifact upload path to `apps/desktop/release/**` matching `output: release` in `electron-builder.yml`

## Test plan

- [ ] Build Windows job passes
- [ ] Build macOS job passes
- [ ] Artifacts are uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)