### PR TITLE
fix: build dependency packages before typecheck in all workflows

### DIFF
--- a/.github/workflows/01-branch-quality-gate.yml
+++ b/.github/workflows/01-branch-quality-gate.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build Dependency Packages
+        run: pnpm -r --filter=!@ajh/desktop build
+
       - name: Run ESLint
         run: pnpm lint
 


### PR DESCRIPTION
## Summary

`packages/core` (and other packages) import from `@ajh/shared` which only exists after a build. Running `pnpm typecheck` without building first causes `TS2307: Cannot find module '@ajh/shared'` in CI.

Added `pnpm -r --filter=!@ajh/desktop build` before lint/typecheck in:
- `01-branch-quality-gate.yml` (this PR)
- `02-pull-request-validation.yml` (fixed in previous PR)

## Test plan

- [ ] Branch Quality Gate passes
- [ ] Pull Request Validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)