### PR TITLE
ci: add manual trigger to release workflow

### DIFF
--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` to `04-release-orchestration.yml` so the release can be triggered manually from **GitHub → Actions → Release Orchestration → Run workflow**.

Semantic-release will still only publish a new version if there are releasable commits (`feat:`, `fix:`, `perf:`) since the last tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)