### PR TITLE
ci: add turborepo build caching and electron binary cache

### DIFF
--- a/.github/workflows/01-branch-quality-gate.yml
+++ b/.github/workflows/01-branch-quality-gate.yml
@@ -37,11 +37,18 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - name: Restore Turbo Cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build Dependency Packages
-        run: pnpm -r --filter=!@ajh/desktop build
+        run: pnpm build:packages
 
       - name: Run ESLint
         run: pnpm lint

--- a/.github/workflows/02-pull-request-validation.yml
+++ b/.github/workflows/02-pull-request-validation.yml
@@ -32,11 +32,18 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - name: Restore Turbo Cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build Dependency Packages
-        run: pnpm -r --filter=!@ajh/desktop build
+        run: pnpm build:packages
 
       - name: Run ESLint
         run: pnpm lint

--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -99,11 +99,27 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - name: Restore Turbo Cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
+      - name: Restore Electron Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~\AppData\Local\electron\Cache
+            ~\AppData\Local\electron-builder\Cache
+          key: electron-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          restore-keys: electron-${{ runner.os }}-
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build Packages
-        run: pnpm -r --filter=!@ajh/desktop build
+        run: pnpm build:packages
 
       - name: Build & Package Windows
         run: pnpm --filter @ajh/desktop package -- --win
@@ -140,11 +156,27 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - name: Restore Turbo Cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
+      - name: Restore Electron Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+          key: electron-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          restore-keys: electron-${{ runner.os }}-
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build Packages
-        run: pnpm -r --filter=!@ajh/desktop build
+        run: pnpm build:packages
 
       - name: Build & Package macOS
         run: pnpm --filter @ajh/desktop package -- --mac

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   },
   "scripts": {
     "dev": "pnpm build && pnpm --filter @ajh/desktop dev",
-    "build": "pnpm -r --filter=!@ajh/desktop build && pnpm --filter @ajh/desktop build",
+    "build": "turbo build",
+    "build:packages": "turbo build --filter=!@ajh/desktop",
     "package": "pnpm build && pnpm --filter @ajh/desktop package",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "turbo typecheck",
     "lint": "eslint .",
     "lint:strict": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
@@ -49,6 +50,7 @@
     "prettier": "^3.8.3",
     "rimraf": "^6.1.3",
     "semantic-release": "^25.0.3",
+    "turbo": "^2.9.14",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4",
     "vitest": "^4.1.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       semantic-release:
         specifier: ^25.0.3
         version: 25.0.3(typescript@6.0.3)
+      turbo:
+        specifier: ^2.9.14
+        version: 2.9.14
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1807,6 +1810,36 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@turbo/darwin-64@2.9.14':
+    resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.14':
+    resolution: {integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.14':
+    resolution: {integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.14':
+    resolution: {integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.14':
+    resolution: {integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.14':
+    resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
+    cpu: [arm64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -5351,6 +5384,10 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
+  turbo@2.9.14:
+    resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -7159,6 +7196,24 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
+
+  '@turbo/darwin-64@2.9.14':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.14':
+    optional: true
+
+  '@turbo/linux-64@2.9.14':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.14':
+    optional: true
+
+  '@turbo/windows-64@2.9.14':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.14':
+    optional: true
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -11135,6 +11190,15 @@ snapshots:
   tslib@2.8.1: {}
 
   tunnel@0.0.6: {}
+
+  turbo@2.9.14:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.14
+      '@turbo/darwin-arm64': 2.9.14
+      '@turbo/linux-64': 2.9.14
+      '@turbo/linux-arm64': 2.9.14
+      '@turbo/windows-64': 2.9.14
+      '@turbo/windows-arm64': 2.9.14
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsconfig*.json", "package.json"],
+      "outputs": ["dist/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsconfig*.json"],
+      "outputs": [],
+      "cache": false
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsconfig*.json"],
+      "outputs": ["coverage/**"]
+    },
+    "lint": {
+      "inputs": ["src/**", "*.config.*", "eslint.config.*"],
+      "outputs": [],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

### Turborepo
- Installed `turbo` as root dev dependency
- `turbo.json` defines the task pipeline — `build` caches `dist/**` output keyed by `src/**` + `tsconfig` inputs; downstream packages only rebuild when their inputs change
- All CI workflows restore the `.turbo` cache directory (keyed by commit SHA with OS-level fallback)
- `package.json` `build` and `typecheck` scripts now use `turbo`

### Electron binary cache
- Windows: `~\AppData\Local\electron\Cache` + `electron-builder\Cache`
- macOS: `~/Library/Caches/electron` + `~/Library/Caches/electron-builder`
- Keyed by `package.json` hash — busts automatically when Electron version changes

### pnpm store cache
Already handled by `actions/setup-node` with `cache: pnpm` (was already in all workflows).

## Expected improvements

| Scenario | Before | After |
|---|---|---|
| Unchanged packages rebuild | Always | Skipped by Turbo |
| Electron binary download | Every run (~30s) | Cached after first run |
| Repeated CI on same branch | Full rebuild | ~70-90% faster |

## Test plan

- [ ] Branch Quality Gate passes
- [ ] Pull Request Validation passes
- [ ] Turbo cache hit visible in build logs on second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)