### PR TITLE
fix: build desktop app before packaging in release workflow

### DIFF
--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -121,7 +121,10 @@ jobs:
       - name: Build Packages
         run: pnpm build:packages
 
-      - name: Build & Package Windows
+      - name: Build Desktop App
+        run: pnpm --filter @ajh/desktop build
+
+      - name: Package Windows
         run: pnpm --filter @ajh/desktop package -- --win
 
       - name: Upload Windows Artifacts
@@ -178,7 +181,10 @@ jobs:
       - name: Build Packages
         run: pnpm build:packages
 
-      - name: Build & Package macOS
+      - name: Build Desktop App
+        run: pnpm --filter @ajh/desktop build
+
+      - name: Package macOS
         run: pnpm --filter @ajh/desktop package -- --mac
 
       - name: Upload macOS Artifacts


### PR DESCRIPTION
## Summary

electron-builder looks for `out/main/index.mjs` inside the asar — but that file is only created by `electron-vite build`. The workflow was calling `electron-builder package` directly without first compiling the desktop app, causing:

```
Application entry file "out/main/index.mjs" was not found in this archive
```

**Fix:** added `pnpm --filter @ajh/desktop build` between `build:packages` and `package -- --win/--mac` in both build jobs.

**Build order is now:**
1. `pnpm build:packages` — compile shared/ui/ai/data/etc packages
2. `pnpm --filter @ajh/desktop build` — run electron-vite build → produces `out/`
3. `pnpm --filter @ajh/desktop package` — electron-builder packages the compiled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)