### PR TITLE
fix: set releasetype to release in electron-builder publish config

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -55,4 +55,5 @@ publish:
   provider: github
   owner: saeedkolivand
   repo: ai-job-hunter-assistant-app
+  releaseType: release
 npmRebuild: true


### PR DESCRIPTION
## Root cause

The logs showed:
\`\`\`
skipped publishing reason=existing type not compatible with publishing type
tag=v1.0.4 existingType=release publishingType=draft
\`\`\`

electron-builder defaults to \`publishingType=draft\` but semantic-release creates **published** releases. When the types don't match, electron-builder skips every file upload silently.

## Fix

Added \`releaseType: release\` to the \`publish\` block in \`electron-builder.yml\`.

## Test plan

- [ ] Installers (`.exe`, `.zip`, `.dmg`) appear on the GitHub Release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)