### PR TITLE
fix: sort imports in bootstrap.ts to unblock semantic-release

### DIFF
--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -23,8 +23,8 @@ import { type BoardSessionMap, createBoardSessions } from './board-sessions/inde
 import { CredentialStore } from './credentials.js';
 import { ElectronBrowserController } from './electron-browser-controller.js';
 import {
-  InProcessScraperRuntime,
   type ApplyJobPayload,
+  InProcessScraperRuntime,
   type ScrapeBoardPayload,
 } from './scraper-runtime.js';
 


### PR DESCRIPTION
## Summary

- Autofix the import sort order in `bootstrap.ts` that was causing the ESLint pre-push hook to fail during semantic-release's `prepare` step
- The `InProcessScraperRuntime` and payload type imports were in the wrong group order

## Root cause

The `fix: resolve lint errors blocking push` commit used `--amend` after the pre-push hook had already reformatted files, so the amended commit contained a different import ordering than what ESLint expected on CI.

## Test plan

- [ ] ESLint passes locally (`pnpm lint`)
- [ ] Semantic-release can push changelog/version commits back to main without hook failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)