### PR TITLE
fix: separate portable artifact name and disable blockmap generation

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -33,7 +33,6 @@ win:
   icon: build/icon.ico
   target:
     - nsis
-    - portable
     - zip
 
 # linux:
@@ -50,9 +49,6 @@ nsis:
   oneClick: false
   perMachine: false
   allowToChangeInstallationDirectory: true
-
-portable:
-  artifactName: '${productName}-${version}-${os}-${arch}-portable.${ext}'
 
 # Disable blockmap generation — delta updates are not needed and the
 # extra upload was causing timeout failures on the GitHub Releases API.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -51,6 +51,13 @@ nsis:
   perMachine: false
   allowToChangeInstallationDirectory: true
 
+portable:
+  artifactName: '${productName}-${version}-${os}-${arch}-portable.${ext}'
+
+# Disable blockmap generation — delta updates are not needed and the
+# extra upload was causing timeout failures on the GitHub Releases API.
+differentialPackage: false
+
 publish:
   provider: github
   owner: saeedkolivand


### PR DESCRIPTION
## Summary

- **Portable target removed**: both `nsis` and `portable` targets were producing `AIJobHunter-{version}-win-x64.exe`. electron-builder would upload the NSIS installer first, then attempt to overwrite it with the portable build — this second upload was timing out against the GitHub Releases API and failing the Windows build job. Portable dropped entirely.
- **Blockmap disabled**: `.blockmap` files are no longer generated (`differentialPackage: false`). Delta update support is not needed; removing it also eliminates extra uploads.

## Changes

- `win.target`: removed `portable`, keeping `nsis` and `zip` only
- `differentialPackage: false` — skips `.blockmap` generation for all targets

## Result after merge

Windows release assets will be:
- `AIJobHunter-{version}-win-x64.exe` — NSIS installer
- `AIJobHunter-{version}-win-x64.zip` — zip archive
- `latest.yml` — auto-updater manifest (auto-update still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)