### PR TITLE
fix: remove unsupported differentialPackage from electron-builder config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,10 @@ Never push directly to `main`. Always:
 
 1. `git checkout -b feat/description` (use `fix/`, `chore/`, `refactor/` etc. as appropriate)
 2. Commit with conventional prefixes (`feat:`, `fix:`, `refactor:`, `ci:`, `docs:`, `test:`)
-3. Open a PR targeting `main` — CI must pass before merge
+3. Push the branch: `git push -u origin <branch>`
+4. Open a PR with `gh pr create` — always include a summary and test plan
+5. CI must pass before merging
+6. Wait for user approval before merging
 
 **Before starting any work, verify the current branch still exists on the remote:**
 

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -30,8 +30,10 @@ Before marking any task complete:
 **Never push directly to `main`.** For every change:
 1. Create a feature branch: `git checkout -b feat/your-description` (or `fix/`, `chore/` etc.)
 2. Make commits with conventional commit prefixes (`feat:`, `fix:`, `refactor:`, etc.)
-3. Open a pull request targeting `main`
-4. CI must pass before merging
+3. Push the branch: `git push -u origin <branch>`
+4. Open a pull request with `gh pr create` — always include a summary and test plan
+5. CI must pass before merging
+6. Wait for user approval before merging
 
 **Always verify your branch exists on the remote before starting work:**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,20 @@ The IPC contract lives in `packages/shared/src/ipc/contracts.ts`.
 
 ## Rules You Must Follow
 
+### 0. Always open a PR — never push directly to main
+
+**Never push code directly to `main`.** All changes must go through a pull request:
+
+1. Create a feature branch: `git checkout -b feat/your-feature-name`
+2. Commit your changes to that branch
+3. Push the branch: `git push -u origin <branch>`
+4. Open a PR with `gh pr create` — always include a summary and test plan
+5. Wait for user approval before merging
+
+This applies to every change, no matter how small. Direct pushes to `main` are not allowed.
+
+---
+
 ### 1. Ports & Adapters — never call window.api directly in UI
 
 **❌ Wrong — direct IPC in a component or route:**

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -50,10 +50,6 @@ nsis:
   perMachine: false
   allowToChangeInstallationDirectory: true
 
-# Disable blockmap generation — delta updates are not needed and the
-# extra upload was causing timeout failures on the GitHub Releases API.
-differentialPackage: false
-
 publish:
   provider: github
   owner: saeedkolivand


### PR DESCRIPTION
## Summary

- Removes `differentialPackage: false` from `electron-builder.yml` — this property no longer exists in electron-builder 26.8.1's schema
- Also updates AI rules files (CLAUDE.md, .windsurfrules, .github/copilot-instructions.md) to require `gh pr create` before pushing

## Test plan

- [ ] Windows CI build completes without schema validation error
- [ ] macOS CI build completes without schema validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)