### PR TITLE
fix: sync desktop app version with release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -51,6 +51,7 @@
       }
     ],
     ["@semantic-release/npm", { "npmPublish": false }],
+    ["@semantic-release/npm", { "npmPublish": false, "pkgRoot": "apps/desktop" }],
     [
       "@semantic-release/github",
       {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajh/desktop",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "AI Job Hunter desktop application",
   "homepage": "https://github.com/saeedkolivand/ai-job-hunter-assistant-app",

--- a/apps/desktop/src/renderer/providers/AppClientProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AppClientProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext, useEffect, useMemo } from 'react';
+import { createContext, type ReactNode, useContext, useMemo } from 'react';
 
 import {
   _registerClient,
@@ -12,12 +12,11 @@ export { getClient };
 const AppClientContext = createContext<AppClient | null>(null);
 
 export function AppClientProvider({ children }: { children: ReactNode }) {
-  const client = useMemo(() => createDesktopIpcClient(), []);
-
-  // Register module-level reference so getClient() works outside React.
-  useEffect(() => {
-    _registerClient(client);
-  }, [client]);
+  const client = useMemo(() => {
+    const c = createDesktopIpcClient();
+    _registerClient(c);
+    return c;
+  }, []);
 
   return <AppClientContext.Provider value={client}>{children}</AppClientContext.Provider>;
 }

--- a/apps/desktop/src/renderer/providers/PerformanceModeProvider.tsx
+++ b/apps/desktop/src/renderer/providers/PerformanceModeProvider.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useEffect, useRef } from 'react';
 
-import { getClient } from '@/providers/AppClientProvider';
+import { useAppClient } from '@/providers/AppClientProvider';
 import { usePerformanceMode } from '@/store/preferences-store';
 
 /**
@@ -9,10 +9,9 @@ import { usePerformanceMode } from '@/store/preferences-store';
  *      and blur reduction without touching framer-motion.
  *   2. system.setPerformanceMode IPC — lets the main process adjust JobQueue
  *      concurrency and AiRuntime idle-unload timeout accordingly.
- *
- * Place this inside <AppClientProvider> so getClient() is always ready.
  */
 export function PerformanceModeProvider({ children }: { children: ReactNode }) {
+  const client = useAppClient();
   const mode = usePerformanceMode();
   const prevMode = useRef<string | null>(null);
 
@@ -22,12 +21,10 @@ export function PerformanceModeProvider({ children }: { children: ReactNode }) {
 
     document.documentElement.setAttribute('data-performance-mode', mode);
 
-    getClient()
-      .system.setPerformanceMode(mode)
-      .catch(() => {
-        // Silently ignore — main process may not be ready on first render.
-      });
-  }, [mode]);
+    client.system.setPerformanceMode(mode).catch(() => {
+      // Silently ignore — main process may not be ready on first render.
+    });
+  }, [client, mode]);
 
   return <>{children}</>;
 }

--- a/apps/desktop/src/renderer/providers/PerformanceModeProvider.tsx
+++ b/apps/desktop/src/renderer/providers/PerformanceModeProvider.tsx
@@ -9,6 +9,8 @@ import { usePerformanceMode } from '@/store/preferences-store';
  *      and blur reduction without touching framer-motion.
  *   2. system.setPerformanceMode IPC — lets the main process adjust JobQueue
  *      concurrency and AiRuntime idle-unload timeout accordingly.
+ *
+ * Place this inside <AppClientProvider> so getClient() is always ready.
  */
 export function PerformanceModeProvider({ children }: { children: ReactNode }) {
   const client = useAppClient();


### PR DESCRIPTION
## Summary

- `apps/desktop/package.json` version was stuck at `0.1.0` while the root was `1.2.0` — Electron's `app.getVersion()` reads from the desktop package, so the sidebar always showed the wrong version
- Bumped desktop version to `1.2.0` to match the current release
- Added a second `@semantic-release/npm` step in `.releaserc.json` with `pkgRoot: "apps/desktop"` so every future release automatically keeps the desktop package version in sync
- Moved `_registerClient` call into `useMemo` in `AppClientProvider` to register synchronously and eliminate the init race that could occur between the `useMemo` and `useEffect`

## Test plan

- [ ] Run the desktop app and confirm the sidebar shows `v1.2.0`
- [ ] Trigger a release and verify `apps/desktop/package.json` version is bumped alongside root `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)