### PR TITLE
fix: use RELEASE_TOKEN PAT for semantic-release to bypass main ruleset

### DIFF
--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -49,13 +49,16 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         env:
-          # GITHUB_TOKEN has contents:write (declared above) which is sufficient for
-          # semantic-release to create tags and GitHub Releases.
-          # To allow it to push the version bump commit to the protected main branch,
-          # add github-actions[bot] as a bypass actor in the branch ruleset:
-          #   GitHub → Settings → Rules → Rulesets → main → Bypass list
-          #   → Add bypass → search "github actions" → select GitHub Actions (App • github)
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_TOKEN must be a PAT (classic, repo scope) from the repo owner.
+          # The GITHUB_TOKEN cannot bypass the main branch ruleset on personal repos
+          # because Integration bypass actors are org-only. A PAT from the owner
+          # inherits the bypass (current_user_can_bypass: always).
+          #
+          # To create: GitHub → Settings → Developer settings → Personal access tokens
+          #   → Tokens (classic) → Generate new token → scope: repo → copy
+          # To add: Repository → Settings → Secrets → Actions → New secret
+          #   → Name: RELEASE_TOKEN → Value: <your PAT>
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Notify Discord Release Failure
         if: failure()


### PR DESCRIPTION
## Problem

`semantic-release` fails when pushing the version bump commit (`CHANGELOG.md`, `package.json`) back to `main`:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
```

`GITHUB_TOKEN` cannot bypass the main branch ruleset on **personal repos** — Integration bypass actors (like `github-actions[bot]`) are an org-only feature. The `RepositoryRole: Admin` bypass also doesn't help because `GITHUB_TOKEN` in Actions runs as the bot, not as the repo owner.

## Fix

Switch to `secrets.RELEASE_TOKEN` — a classic PAT from the repo owner. The owner has `current_user_can_bypass: always` on the ruleset, so a PAT issued by the owner can push directly to `main`.

## Action required — add the secret before merging

1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
2. Generate a new token with **`repo`** scope
3. Go to **Repository → Settings → Secrets and variables → Actions → New repository secret**
4. Name: `RELEASE_TOKEN` · Value: paste the token

Once the secret exists, merging this PR will re-trigger the release and it will succeed.

## Test plan

- [ ] Add `RELEASE_TOKEN` secret as described above
- [ ] Merge this PR
- [ ] Release Orchestration workflow completes without `GH013` error
- [ ] `v1.4.0` (or next patch) GitHub Release is created with CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)