### PR TITLE
fix: pass RELEASE_TOKEN to actions/checkout so git credentials use the PAT

### DIFF
--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -30,6 +30,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Use RELEASE_TOKEN so git credentials are wired with the PAT.
+          # actions/checkout sets up the git credential helper; without this,
+          # @semantic-release/git pushes using the workflow GITHUB_TOKEN which
+          # cannot bypass the main branch ruleset on personal repos.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Root cause

`actions/checkout@v4` sets up a git credential helper for the **entire job**. Without `token:` set, it uses the workflow's `GITHUB_TOKEN`. This means when `@semantic-release/git` runs `git push HEAD:main`, it authenticates with `GITHUB_TOKEN` — not the `RELEASE_TOKEN` PAT set in the semantic-release env — and gets rejected by `GH013`.

## Fix

Pass `token: ${{ secrets.RELEASE_TOKEN }}` to the checkout step so the PAT is wired into the git credential helper from the start. All subsequent git operations in the job (including `@semantic-release/git`'s push) then use the PAT, which has bypass rights on the main branch ruleset.

## Test plan

- [ ] Merge PR → Release Orchestration runs
- [ ] `@semantic-release/git` pushes CHANGELOG + version bump to main without `GH013`
- [ ] GitHub Release created with correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)