### PR TITLE
fix: remove @semantic-release/git to stop direct branch push to main

### DIFF
--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -30,11 +30,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Use RELEASE_TOKEN so git credentials are wired with the PAT.
-          # actions/checkout sets up the git credential helper; without this,
-          # @semantic-release/git pushes using the workflow GITHUB_TOKEN which
-          # cannot bypass the main branch ruleset on personal repos.
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -54,16 +49,10 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         env:
-          # RELEASE_TOKEN must be a PAT (classic, repo scope) from the repo owner.
-          # The GITHUB_TOKEN cannot bypass the main branch ruleset on personal repos
-          # because Integration bypass actors are org-only. A PAT from the owner
-          # inherits the bypass (current_user_can_bypass: always).
-          #
-          # To create: GitHub → Settings → Developer settings → Personal access tokens
-          #   → Tokens (classic) → Generate new token → scope: repo → copy
-          # To add: Repository → Settings → Secrets → Actions → New secret
-          #   → Name: RELEASE_TOKEN → Value: <your PAT>
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          # GITHUB_TOKEN has contents:write which is sufficient for creating
+          # tags and GitHub Releases via the API. @semantic-release/git has
+          # been removed so no direct push to main is attempted.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Discord Release Failure
         if: failure()

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -43,13 +43,6 @@
         }
       }
     ],
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog\n\nAll notable changes to AI Job Hunter are documented here.\nThis project follows [Semantic Versioning](https://semver.org) and [Conventional Commits](https://www.conventionalcommits.org)."
-      }
-    ],
     ["@semantic-release/npm", { "npmPublish": false }],
     ["@semantic-release/npm", { "npmPublish": false, "pkgRoot": "apps/desktop" }],
     [
@@ -58,13 +51,6 @@
         "successComment": "🎉 This is included in version ${nextRelease.version}.",
         "failComment": false,
         "addReleases": "bottom"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json", "apps/desktop/package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]
   ]


### PR DESCRIPTION
## Problem

The main branch ruleset now has `bypass_actors: []` — nobody can push directly to `main`. `@semantic-release/git` was running `git push HEAD:main` to commit the CHANGELOG + version bump, which gets rejected with `GH013`.

## Solution

Remove `@semantic-release/git` and `@semantic-release/changelog` from the plugin list. The release pipeline still works fully:

| Step | How | Status |
|---|---|---|
| Analyse commits | `@semantic-release/commit-analyzer` | ✅ unchanged |
| Generate release notes | `@semantic-release/release-notes-generator` | ✅ unchanged |
| Create git tag | core semantic-release (`refs/tags/*`, not blocked) | ✅ unchanged |
| Create GitHub Release | `@semantic-release/github` via API | ✅ unchanged |
| Bump package.json locally | `@semantic-release/npm` × 2 | ✅ (local only, not pushed) |
| Commit CHANGELOG to main | `@semantic-release/git` | ❌ removed — trade-off |

**Trade-off:** CHANGELOG.md is no longer committed to the repo. Release notes live on the GitHub Release page instead, which is where users look anyway.

Also reverts the workflow `token:` and `GITHUB_TOKEN` back to `secrets.GITHUB_TOKEN` — `RELEASE_TOKEN` is no longer needed.

## Test plan

- [ ] Merge → Release Orchestration runs without `GH013`
- [ ] Git tag `vX.Y.Z` created
- [ ] GitHub Release created with release notes
- [ ] No direct push to `main` attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)