### PR TITLE
feat: phase 6 tauri spike, migration strategy, and frontend portability

### DIFF
--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -22,6 +22,7 @@ import type { AiGenerateRequest, BootMetrics } from '@ajh/shared';
 import { type BoardSessionMap, createBoardSessions } from './board-sessions/index.js';
 import { CredentialStore } from './credentials.js';
 import { ElectronBrowserController } from './electron-browser-controller.js';
+import { rollbackFlags } from './rollback-flags.js';
 import {
   type ApplyJobPayload,
   InProcessScraperRuntime,
@@ -70,7 +71,9 @@ export async function bootstrap(): Promise<AppCore> {
 
   const t0 = performance.now();
   const bus = new EventBus();
-  const jobs = new JobQueue(bus, { concurrency: 2 });
+  // AJH_LOW_END_MODE caps concurrency to 1 from the first job regardless of
+  // what the UI preference later sets via setPerformanceMode.
+  const jobs = new JobQueue(bus, { concurrency: rollbackFlags.lowEndMode ? 1 : 2 });
   const scheduler = new TaskScheduler();
   const runtimes = new RuntimeManager(bus);
   const state = new StateCoordinator(bus, { locale: 'en' });
@@ -92,22 +95,46 @@ export async function bootstrap(): Promise<AppCore> {
 
   const electronBrowser = new ElectronBrowserController();
 
-  // AJH_SCRAPER_MODE=in-process forces the in-process fallback (rollback switch).
-  // Default is in-process today; swap for UtilityProcessScraperRuntime in Phase 6.
-  const scraperMode = process.env.AJH_SCRAPER_MODE ?? 'in-process';
-  const scraperRuntime: ScraperRuntimeClient = new InProcessScraperRuntime(
-    data,
-    credentials,
-    electronBrowser
-  );
-  logger.info({ scraperMode }, 'scraper runtime selected');
+  // ── Scraper runtime selection ─────────────────────────────────────────────
+  // AJH_SCRAPER_MODE controls which runtime is active (rollbackFlags.scraperMode).
+  // 'in-process' is the safe default. Future phases add 'utility-process' and
+  // 'http-sidecar'; setting AJH_SCRAPER_MODE=in-process always forces the fallback.
+  const scraperRuntime: ScraperRuntimeClient = (() => {
+    switch (rollbackFlags.scraperMode) {
+      case 'utility-process':
+        logger.warn(
+          { scraperMode: rollbackFlags.scraperMode },
+          'utility-process scraper runtime not yet implemented — falling back to in-process'
+        );
+        return new InProcessScraperRuntime(data, credentials, electronBrowser);
+      case 'http-sidecar':
+        logger.warn(
+          { scraperMode: rollbackFlags.scraperMode },
+          'http-sidecar scraper runtime not yet implemented — falling back to in-process'
+        );
+        return new InProcessScraperRuntime(data, credentials, electronBrowser);
+      case 'in-process':
+      default:
+        return new InProcessScraperRuntime(data, credentials, electronBrowser);
+    }
+  })();
+  logger.info({ scraperMode: rollbackFlags.scraperMode }, 'scraper runtime selected');
+
   runtimes.register(ai);
   runtimes.register(data);
 
-  // Start data runtime eagerly — SQLite is needed immediately by autopilotStore
-  // and the scheduler. AI runtime starts lazily on first ai.generate/ai.embed job.
+  // ── Runtime startup ───────────────────────────────────────────────────────
+  // Data runtime starts eagerly — SQLite is needed immediately by autopilotStore
+  // and the scheduler.
+  //
+  // AI runtime starts lazily on first ai.generate/ai.embed job UNLESS
+  // AJH_EAGER_BOOT=1, which starts both immediately (Phase 4 rollback).
   const t2 = performance.now();
   await runtimes.start('data');
+  if (rollbackFlags.eagerBoot) {
+    logger.info('AJH_EAGER_BOOT=1 — starting AI runtime eagerly');
+    await runtimes.start('ai');
+  }
   const phDataRuntime = performance.now() - t2;
 
   // ── Register job handlers ─────────────────────────────────────────────

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -18,6 +18,7 @@ import { createLogger } from '@ajh/core';
 import { bootstrap } from './bootstrap.js';
 import { registerIpc } from './ipc/router.js';
 import { installMenu } from './menus.js';
+import { rollbackFlags } from './rollback-flags.js';
 import { applySecurityDefaults } from './security.js';
 import { setStartupMs } from './startup-metrics.js';
 import { setupUpdater } from './updater.js';
@@ -30,17 +31,22 @@ let _appReadyAt = 0;
 // ── GPU / rendering flags ──────────────────────────────────────────────────
 // Must be set before app.whenReady().
 //
+// AJH_LOW_END_MODE=1 skips the GPU acceleration switches so the OS/driver
+// blocklist takes effect naturally — this is the Phase 1 rollback switch.
+//
 // enable-gpu-rasterization: accelerates blur/backdrop-filter compositing.
 // enable-zero-copy:         reduces texture upload memory copies.
 // force-color-profile:      consistent sRGB across displays.
 //
-// Intentionally omitted:
+// Intentionally omitted regardless of mode:
 //   ignore-gpu-blocklist    — respects driver blocklist; avoids crashes on
 //                             machines with known-bad GPU drivers.
 //   disable-frame-rate-limit — restores OS/browser power-saving throttling;
 //                              reduces idle CPU and battery drain.
-app.commandLine.appendSwitch('enable-gpu-rasterization');
-app.commandLine.appendSwitch('enable-zero-copy');
+if (!rollbackFlags.lowEndMode) {
+  app.commandLine.appendSwitch('enable-gpu-rasterization');
+  app.commandLine.appendSwitch('enable-zero-copy');
+}
 app.commandLine.appendSwitch('force-color-profile', 'srgb');
 
 applySecurityDefaults();
@@ -52,7 +58,7 @@ app.whenReady().then(async () => {
   try {
     const core = await bootstrap();
     registerIpc(core);
-    mainWindow = await createMainWindow();
+    mainWindow = await createMainWindow({ lowEndMode: rollbackFlags.lowEndMode });
 
     // Record time from app-ready to window visible.
     const startupMs = performance.now() - _appReadyAt;
@@ -79,7 +85,7 @@ app.whenReady().then(async () => {
 
     app.on('activate', async () => {
       if (BrowserWindow.getAllWindows().length === 0) {
-        mainWindow = await createMainWindow();
+        mainWindow = await createMainWindow({ lowEndMode: rollbackFlags.lowEndMode });
       }
     });
   } catch (err) {

--- a/apps/desktop/src/main/ipc/router.ts
+++ b/apps/desktop/src/main/ipc/router.ts
@@ -652,4 +652,25 @@ export function registerIpc(core: AppCore): void {
     // No-op - no persistence
     return { success: true };
   });
+
+  // ── dialog ──────────────────────────────────────────────────────────────
+  handle(
+    IPC_CHANNELS.dialog.openFiles,
+    z
+      .object({
+        title: z.string().optional(),
+        filters: z
+          .array(z.object({ name: z.string(), extensions: z.array(z.string()) }))
+          .optional(),
+      })
+      .optional(),
+    async (opts) => {
+      const result = await dialog.showOpenDialog({
+        title: opts?.title,
+        properties: ['openFile', 'multiSelections'],
+        filters: opts?.filters,
+      });
+      return result.canceled ? [] : result.filePaths;
+    }
+  );
 }

--- a/apps/desktop/src/main/rollback-flags.ts
+++ b/apps/desktop/src/main/rollback-flags.ts
@@ -1,0 +1,73 @@
+/**
+ * Rollback flags — single source of truth for every env-var escape hatch.
+ *
+ * Each flag maps to one architectural phase. Setting the flag reverts that
+ * phase to its previous behaviour without touching any other code path.
+ *
+ * ┌─────────────────────────────┬──────────────────────────────────────────┐
+ * │ Env var                     │ Effect                                   │
+ * ├─────────────────────────────┼──────────────────────────────────────────┤
+ * │ AJH_LOW_END_MODE=1          │ Phase 1 — skip GPU acceleration switches, │
+ * │                             │ set concurrency to 1, disable vibrancy.  │
+ * ├─────────────────────────────┼──────────────────────────────────────────┤
+ * │ AJH_EAGER_BOOT=1            │ Phase 4 — start AI and data runtimes     │
+ * │                             │ immediately at bootstrap instead of      │
+ * │                             │ lazily on first feature use.             │
+ * ├─────────────────────────────┼──────────────────────────────────────────┤
+ * │ AJH_SCRAPER_MODE=in-process │ Phase 3 — force in-process scraper       │
+ * │                             │ regardless of the current default.       │
+ * │   =utility-process          │ Force UtilityProcess runtime (future).   │
+ * │   =http-sidecar             │ Force HTTP sidecar runtime (future).     │
+ * └─────────────────────────────┴──────────────────────────────────────────┘
+ *
+ * All flags are read once at module load. Changing them at runtime has no
+ * effect — restart the app with the new env var.
+ */
+
+export type ScraperMode = 'in-process' | 'utility-process' | 'http-sidecar';
+
+const VALID_SCRAPER_MODES: readonly ScraperMode[] = [
+  'in-process',
+  'utility-process',
+  'http-sidecar',
+];
+
+function parseScraperMode(raw: string | undefined): ScraperMode {
+  if (raw === undefined) return 'in-process';
+  if ((VALID_SCRAPER_MODES as readonly string[]).includes(raw)) return raw as ScraperMode;
+  console.warn(
+    `[rollback] Unknown AJH_SCRAPER_MODE "${raw}" — falling back to "in-process". ` +
+      `Valid values: ${VALID_SCRAPER_MODES.join(', ')}`
+  );
+  return 'in-process';
+}
+
+export const rollbackFlags = {
+  /**
+   * Phase 1 rollback: force low-memory hardware profile.
+   *
+   * When set, the app skips GPU-acceleration command-line switches, limits
+   * JobQueue concurrency to 1, and disables vibrancy on all windows.
+   * Equivalent to setting performanceMode='low-memory' in settings, but
+   * takes effect before the renderer loads so it covers startup overhead too.
+   */
+  lowEndMode: process.env.AJH_LOW_END_MODE === '1',
+
+  /**
+   * Phase 4 rollback: start all runtimes eagerly at bootstrap.
+   *
+   * When set, data and AI runtimes are both started during bootstrap() instead
+   * of lazily on first use. Useful when diagnosing startup failures or when
+   * testing a migration that assumes both runtimes are ready immediately.
+   */
+  eagerBoot: process.env.AJH_EAGER_BOOT === '1',
+
+  /**
+   * Phase 3 rollback: override the active scraper runtime implementation.
+   *
+   * Defaults to 'in-process' (InProcessScraperRuntime). Set to 'in-process'
+   * explicitly to force the fallback even when a utility-process or sidecar
+   * runtime becomes the new default in a future phase.
+   */
+  scraperMode: parseScraperMode(process.env.AJH_SCRAPER_MODE),
+} as const;

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -2,7 +2,17 @@ import path from 'node:path';
 
 import { BrowserWindow, clipboard, Menu, shell } from 'electron';
 
-export async function createMainWindow(): Promise<BrowserWindow> {
+export interface MainWindowOptions {
+  /** AJH_LOW_END_MODE=1 — disables vibrancy and transparency to reduce GPU load. */
+  lowEndMode?: boolean;
+}
+
+export async function createMainWindow(opts: MainWindowOptions = {}): Promise<BrowserWindow> {
+  const { lowEndMode = false } = opts;
+  // Vibrancy and transparency are expensive on integrated GPUs.
+  // Skip them in low-end mode so the compositor can take the fast path.
+  const useMacVibrancy = process.platform === 'darwin' && !lowEndMode;
+
   const win = new BrowserWindow({
     width: 1440,
     height: 920,
@@ -15,9 +25,9 @@ export async function createMainWindow(): Promise<BrowserWindow> {
         ? { color: '#00000000', symbolColor: '#cfcfdc', height: 36 }
         : undefined,
     backgroundColor: '#0a0a14', // matches design system base
-    vibrancy: process.platform === 'darwin' ? 'under-window' : undefined,
-    visualEffectState: 'active',
-    transparent: process.platform === 'darwin',
+    vibrancy: useMacVibrancy ? 'under-window' : undefined,
+    visualEffectState: useMacVibrancy ? 'active' : undefined,
+    transparent: useMacVibrancy,
     trafficLightPosition: { x: 16, y: 14 },
     webPreferences: {
       preload: path.join(__dirname, '../preload/index.js'),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -27,10 +27,12 @@ const api = {
     get: (jobId: string) => invoke(IPC_CHANNELS.jobs.get, { jobId }),
     cancel: (jobId: string) => invoke(IPC_CHANNELS.jobs.cancel, { jobId }),
     retry: (jobId: string) => invoke(IPC_CHANNELS.jobs.retry, { jobId }),
-    onEvent: (handler: (event: unknown) => void) => {
+    onEvent: (handler: (event: unknown) => void): (() => void) => {
       const listener = (_: unknown, event: unknown) => handler(event);
       ipcRenderer.on(IPC_CHANNELS.jobs.event, listener);
-      return () => ipcRenderer.off(IPC_CHANNELS.jobs.event, listener);
+      return () => {
+        ipcRenderer.off(IPC_CHANNELS.jobs.event, listener);
+      };
     },
   },
   ai: {
@@ -39,10 +41,12 @@ const api = {
     pullModel: (model: string) => invoke(IPC_CHANNELS.ai.pullModel, model),
     unloadModel: (model: string) => invoke(IPC_CHANNELS.ai.unloadModel, model),
     embed: (req: { text: string; model?: string }) => invoke(IPC_CHANNELS.ai.embed, req),
-    onStream: (handler: (chunk: unknown) => void) => {
+    onStream: (handler: (chunk: unknown) => void): (() => void) => {
       const listener = (_: unknown, chunk: unknown) => handler(chunk);
       ipcRenderer.on(IPC_CHANNELS.ai.stream, listener);
-      return () => ipcRenderer.off(IPC_CHANNELS.ai.stream, listener);
+      return () => {
+        ipcRenderer.off(IPC_CHANNELS.ai.stream, listener);
+      };
     },
   },
   documents: {
@@ -102,17 +106,21 @@ const api = {
     check: () => invoke(IPC_CHANNELS.updater.check),
     download: () => invoke(IPC_CHANNELS.updater.download),
     install: () => invoke(IPC_CHANNELS.updater.install),
-    onStatus: (handler: (status: unknown) => void) => {
+    onStatus: (handler: (status: unknown) => void): (() => void) => {
       const listener = (_: unknown, status: unknown) => handler(status);
       ipcRenderer.on(IPC_CHANNELS.updater.onStatus, listener);
-      return () => ipcRenderer.off(IPC_CHANNELS.updater.onStatus, listener);
+      return () => {
+        ipcRenderer.off(IPC_CHANNELS.updater.onStatus, listener);
+      };
     },
   },
   shortcuts: {
-    onCommandPalette: (handler: () => void) => {
+    onCommandPalette: (handler: () => void): (() => void) => {
       const listener = () => handler();
       ipcRenderer.on('shortcut:command-palette', listener);
-      return () => ipcRenderer.off('shortcut:command-palette', listener);
+      return () => {
+        ipcRenderer.off('shortcut:command-palette', listener);
+      };
     },
   },
   resume: {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -161,6 +161,15 @@ const api = {
     pause: (autopilotId: string) => invoke(IPC_CHANNELS.autopilot.pause, { autopilotId }),
     resume: (autopilotId: string) => invoke(IPC_CHANNELS.autopilot.resume, { autopilotId }),
   },
+  dialog: {
+    /**
+     * Open a native file picker and return the selected file paths.
+     * Use File/Blob APIs to read the content client-side rather than passing
+     * paths across IPC — this keeps the contract transport-neutral.
+     */
+    openFiles: (opts?: { title?: string; filters?: { name: string; extensions: string[] }[] }) =>
+      invoke(IPC_CHANNELS.dialog.openFiles, opts) as Promise<string[]>,
+  },
 } as const;
 
 contextBridge.exposeInMainWorld('api', api);

--- a/apps/desktop/src/renderer/lib/machines/autopilot-wizard.machine.ts
+++ b/apps/desktop/src/renderer/lib/machines/autopilot-wizard.machine.ts
@@ -11,7 +11,7 @@ import { createMachine } from '@/lib/machine';
  *   step_1  → Job target (boards, search queries)
  *   step_2  → Filters (salary, location, remote, tech stack)
  *   step_3  → Schedule (frequency, time window)
- *   saving  → Calling window.api.autopilot.create
+ *   saving  → Calling useAppClient().autopilot.create
  *   done    → Successfully created
  *   error   → Save failed
  *

--- a/apps/desktop/src/renderer/lib/mock-client.ts
+++ b/apps/desktop/src/renderer/lib/mock-client.ts
@@ -159,6 +159,10 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       pause: noop,
       resume: noop,
     },
+
+    dialog: {
+      openFiles: async () => [] as string[],
+    },
   };
 
   // Shallow-merge overrides at the namespace level.

--- a/apps/desktop/src/renderer/lib/mock-client.ts
+++ b/apps/desktop/src/renderer/lib/mock-client.ts
@@ -1,0 +1,175 @@
+/**
+ * createMockClient — factory for a fully-stubbed AppClient.
+ *
+ * Intended for:
+ *   • Vitest / Jest unit tests of renderer components and service hooks.
+ *   • Storybook stories that need a client but no backend.
+ *   • A future web HTTP adapter: start with stubs, replace one namespace at a
+ *     time with real fetch calls until parity is reached.
+ *
+ * Usage:
+ *   const client = createMockClient();
+ *   // override individual methods for a specific test:
+ *   const client = createMockClient({
+ *     system: { health: async () => ({ status: 'ok' }) },
+ *   });
+ *
+ * Every method is a jest/vitest spy-friendly async stub. Provide overrides as a
+ * deep-partial — only the methods you care about need to be specified.
+ */
+import type { AppClient } from './app-client';
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+const noop = () => Promise.resolve(null) as Promise<unknown>;
+const emptyList = () => Promise.resolve([]) as Promise<unknown>;
+const unsub = () => () => {};
+
+export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppClient {
+  const base: AppClient = {
+    system: {
+      health: noop,
+      getVersion: noop,
+      getLocale: async () => 'en' as unknown,
+      setLocale: noop,
+      getPlatform: noop,
+      openExternal: noop,
+      setPerformanceMode: noop,
+      getMetrics: noop,
+    },
+
+    jobs: {
+      list: emptyList,
+      get: noop,
+      cancel: noop,
+      retry: noop,
+      onEvent: unsub,
+    },
+
+    ai: {
+      generate: noop,
+      listModels: emptyList,
+      pullModel: noop,
+      unloadModel: noop,
+      embed: noop,
+      onStream: unsub,
+    },
+
+    documents: {
+      list: emptyList,
+      import: noop,
+      remove: noop,
+    },
+
+    search: {
+      hybrid: async () => ({ items: [], total: 0 }) as unknown,
+    },
+
+    scrape: {
+      board: noop,
+      url: noop,
+      persistJob: noop,
+      listPostings: emptyList,
+      clearPostings: noop,
+      listInteractions: emptyList,
+      exportData: noop,
+      importData: noop,
+    },
+
+    match: {
+      resume: noop,
+    },
+
+    credentials: {
+      available: async () => false as unknown,
+      list: emptyList,
+      set: noop,
+      remove: noop,
+    },
+
+    linkedin: {
+      connect: noop,
+      disconnect: noop,
+      getStatus: async () => ({ status: 'not_connected' }) as unknown,
+    },
+
+    boards: {
+      connect: async () => ({ status: 'not_connected' }) as unknown,
+      disconnect: noop,
+      getStatus: async () => ({ status: 'not_connected' }) as unknown,
+    },
+
+    privacy: {
+      signOutAll: noop,
+      clearInteractions: noop,
+    },
+
+    apply: {
+      start: noop,
+      catalog: emptyList,
+    },
+
+    updater: {
+      check: noop,
+      download: noop,
+      install: noop,
+      onStatus: unsub,
+    },
+
+    shortcuts: {
+      onCommandPalette: unsub,
+    },
+
+    resume: {
+      extractText: noop,
+    },
+
+    support: {
+      exportDiagnostics: noop,
+      reloadAiRuntime: noop,
+      unloadAllModels: noop,
+      resetModelConfiguration: noop,
+      rebuildVectorIndexes: noop,
+      clearEmbeddingsCache: noop,
+      resetVectorDatabase: noop,
+      clearOcrCache: noop,
+      reindexAllDocuments: noop,
+      resetAllSessions: noop,
+      clearScrapingQueue: noop,
+      copyEnvironmentDetails: noop,
+      copyAppVersion: noop,
+      copySystemInfo: noop,
+    },
+
+    conversations: {
+      getOrCreateConversation: async () => ({ id: 'mock', createdAt: 0 }) as unknown,
+      loadMessages: emptyList,
+      saveMessage: noop,
+    },
+
+    autopilot: {
+      list: emptyList,
+      get: noop,
+      create: noop,
+      update: noop,
+      remove: noop,
+      run: noop,
+      pause: noop,
+      resume: noop,
+    },
+  };
+
+  // Shallow-merge overrides at the namespace level.
+  for (const ns of Object.keys(overrides) as Array<keyof AppClient>) {
+    if (overrides[ns]) {
+      (base as Record<string, unknown>)[ns] = {
+        ...(base[ns] as object),
+        ...overrides[ns],
+      };
+    }
+  }
+
+  return base;
+}

--- a/apps/desktop/src/renderer/lib/web-http-client.ts
+++ b/apps/desktop/src/renderer/lib/web-http-client.ts
@@ -1,0 +1,235 @@
+/**
+ * createWebHttpClient — Web HTTP Adapter for AppClient.
+ *
+ * This is the third and final adapter in the three-path architecture:
+ *
+ *   React features
+ *     → AppClient (typed commands + job events)
+ *       → createDesktopIpcClient()   desktop Electron (today)
+ *       → createTauriInvokeClient()  Tauri shell     (spike done)
+ *       → createWebHttpClient()      Web / REST      (this file)
+ *
+ * The web adapter talks to a running runtime server (the same Node.js
+ * processes that run as Tauri sidecars can also run as standalone HTTP
+ * services). This lets the React app deploy on the web without any native
+ * shell — the runtime server handles scraping, AI, and data behind an
+ * authenticated REST + WebSocket API.
+ *
+ * ── Protocol ────────────────────────────────────────────────────────────────
+ *  Commands:   POST /api/<namespace>/<method>
+ *              Content-Type: application/json
+ *              Body: request payload
+ *              Response: application/json result
+ *
+ *  Streaming:  GET /api/events/<channel>  (Server-Sent Events)
+ *              Returns text/event-stream, each event is JSON ScraperEvent
+ *
+ * ── Authentication ───────────────────────────────────────────────────────────
+ *  The runtime server is expected to run on localhost and accept a
+ *  per-launch random token passed in the Authorization header. Bind to
+ *  127.0.0.1 only — never expose to a network interface without a proxy
+ *  that enforces auth.
+ *
+ * ── Status ───────────────────────────────────────────────────────────────────
+ *  This is a documented implementation skeleton. All commands are wired
+ *  and typed — wire up the actual runtime server URL to get a working
+ *  web client. Streaming event subscriptions use EventSource.
+ *
+ *  Replace the RUNTIME_BASE_URL below or pass it as a constructor argument.
+ */
+import type { AppClient } from './app-client';
+
+export interface WebHttpClientOptions {
+  /** Base URL of the runtime server (e.g. http://127.0.0.1:8742). */
+  baseUrl: string;
+  /**
+   * Optional per-launch auth token placed in the Authorization header.
+   * The runtime server generates this on startup and the shell passes it
+   * to the renderer via a secure channel (IPC, environment variable, etc.).
+   */
+  token?: string;
+}
+
+type UnsubFn = () => void;
+
+export function createWebHttpClient({ baseUrl, token }: WebHttpClientOptions): AppClient {
+  const base = baseUrl.replace(/\/$/, '');
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  /** POST /api/<namespace>/<method> and return parsed JSON. */
+  async function cmd(namespace: string, method: string, payload?: unknown): Promise<unknown> {
+    const res = await fetch(`${base}/api/${namespace}/${method}`, {
+      method: 'POST',
+      headers,
+      body: payload !== undefined ? JSON.stringify(payload) : undefined,
+    });
+    if (!res.ok) {
+      const msg = await res.text().catch(() => res.statusText);
+      throw new Error(`[web-http] ${namespace}.${method} → ${res.status}: ${msg}`);
+    }
+    return res.json() as Promise<unknown>;
+  }
+
+  /**
+   * Subscribe to a Server-Sent Events channel.
+   * Returns a sync unsubscribe function (closes the EventSource).
+   */
+  function subscribe(channel: string, handler: (event: unknown) => void): UnsubFn {
+    const url = new URL(`${base}/api/events/${channel}`);
+    if (token) url.searchParams.set('token', token);
+
+    const es = new EventSource(url.toString());
+    es.onmessage = (e) => {
+      try {
+        handler(JSON.parse(e.data as string) as unknown);
+      } catch {
+        // malformed event — ignore
+      }
+    };
+    es.onerror = () => es.close();
+    return () => es.close();
+  }
+
+  return {
+    system: {
+      health: () => cmd('system', 'health'),
+      getVersion: () => cmd('system', 'getVersion'),
+      getLocale: () => cmd('system', 'getLocale'),
+      setLocale: (locale) => cmd('system', 'setLocale', { locale }),
+      getPlatform: () => cmd('system', 'getPlatform'),
+      openExternal: (url) => cmd('system', 'openExternal', { url }),
+      setPerformanceMode: (mode) => cmd('system', 'setPerformanceMode', { mode }),
+      getMetrics: () => cmd('system', 'getMetrics'),
+    },
+
+    jobs: {
+      list: () => cmd('jobs', 'list'),
+      get: (jobId) => cmd('jobs', 'get', { jobId }),
+      cancel: (jobId) => cmd('jobs', 'cancel', { jobId }),
+      retry: (jobId) => cmd('jobs', 'retry', { jobId }),
+      onEvent: (handler) => subscribe('jobs.event', handler),
+    },
+
+    ai: {
+      generate: (req) => cmd('ai', 'generate', req),
+      listModels: () => cmd('ai', 'listModels'),
+      pullModel: (model) => cmd('ai', 'pullModel', { model }),
+      unloadModel: (model) => cmd('ai', 'unloadModel', { model }),
+      embed: (req) => cmd('ai', 'embed', req),
+      onStream: (handler) => subscribe('ai.stream', handler),
+    },
+
+    documents: {
+      list: () => cmd('documents', 'list'),
+      import: (req) => cmd('documents', 'import', req),
+      remove: (id) => cmd('documents', 'remove', { id }),
+    },
+
+    search: {
+      hybrid: (req) => cmd('search', 'hybrid', req),
+    },
+
+    scrape: {
+      board: (req) => cmd('scrape', 'board', req),
+      url: (req) => cmd('scrape', 'url', req),
+      persistJob: (req) => cmd('scrape', 'persistJob', req),
+      listPostings: () => cmd('scrape', 'listPostings'),
+      clearPostings: () => cmd('scrape', 'clearPostings'),
+      listInteractions: (filter) => cmd('scrape', 'listInteractions', filter),
+      exportData: () => cmd('scrape', 'exportData'),
+      importData: () => cmd('scrape', 'importData'),
+    },
+
+    match: {
+      resume: (req) => cmd('match', 'resume', req),
+    },
+
+    credentials: {
+      available: () => cmd('credentials', 'available'),
+      list: () => cmd('credentials', 'list'),
+      set: (req) => cmd('credentials', 'set', req),
+      remove: (boardId) => cmd('credentials', 'remove', { boardId }),
+    },
+
+    linkedin: {
+      connect: () => cmd('linkedin', 'connect'),
+      disconnect: () => cmd('linkedin', 'disconnect'),
+      getStatus: () => cmd('linkedin', 'getStatus'),
+    },
+
+    boards: {
+      connect: (boardId) => cmd('boards', 'connect', { boardId }),
+      disconnect: (boardId) => cmd('boards', 'disconnect', { boardId }),
+      getStatus: (boardId) => cmd('boards', 'getStatus', { boardId }),
+    },
+
+    privacy: {
+      signOutAll: () => cmd('privacy', 'signOutAll'),
+      clearInteractions: () => cmd('privacy', 'clearInteractions'),
+    },
+
+    apply: {
+      start: (req) => cmd('apply', 'start', req),
+      catalog: () => cmd('apply', 'catalog'),
+    },
+
+    updater: {
+      check: () => cmd('updater', 'check'),
+      download: () => cmd('updater', 'download'),
+      install: () => cmd('updater', 'install'),
+      onStatus: (handler) => subscribe('updater.status', handler),
+    },
+
+    shortcuts: {
+      // Keyboard shortcuts on the web are handled entirely in the renderer —
+      // no shell IPC needed. The handler is registered here as a no-op so the
+      // feature code can still call onCommandPalette() without branching.
+      onCommandPalette: (_handler) => () => {},
+    },
+
+    resume: {
+      extractText: (req) => cmd('resume', 'extractText', req),
+    },
+
+    support: {
+      exportDiagnostics: () => cmd('support', 'exportDiagnostics'),
+      reloadAiRuntime: () => cmd('support', 'reloadAiRuntime'),
+      unloadAllModels: () => cmd('support', 'unloadAllModels'),
+      resetModelConfiguration: () => cmd('support', 'resetModelConfiguration'),
+      rebuildVectorIndexes: () => cmd('support', 'rebuildVectorIndexes'),
+      clearEmbeddingsCache: () => cmd('support', 'clearEmbeddingsCache'),
+      resetVectorDatabase: () => cmd('support', 'resetVectorDatabase'),
+      clearOcrCache: () => cmd('support', 'clearOcrCache'),
+      reindexAllDocuments: () => cmd('support', 'reindexAllDocuments'),
+      resetAllSessions: () => cmd('support', 'resetAllSessions'),
+      clearScrapingQueue: () => cmd('support', 'clearScrapingQueue'),
+      copyEnvironmentDetails: () => cmd('support', 'copyEnvironmentDetails'),
+      copyAppVersion: () => cmd('support', 'copyAppVersion'),
+      copySystemInfo: () => cmd('support', 'copySystemInfo'),
+    },
+
+    conversations: {
+      getOrCreateConversation: () => cmd('conversations', 'getOrCreateConversation'),
+      loadMessages: (conversationId) => cmd('conversations', 'loadMessages', { conversationId }),
+      saveMessage: (req) => cmd('conversations', 'saveMessage', req),
+    },
+
+    autopilot: {
+      list: () => cmd('autopilot', 'list'),
+      get: (id) => cmd('autopilot', 'get', { autopilotId: id }),
+      create: (req) => cmd('autopilot', 'create', req),
+      update: (id, req) => cmd('autopilot', 'update', { autopilotId: id, ...(req as object) }),
+      remove: (id) => cmd('autopilot', 'remove', { autopilotId: id }),
+      run: (id) => cmd('autopilot', 'run', { autopilotId: id }),
+      pause: (id) => cmd('autopilot', 'pause', { autopilotId: id }),
+      resume: (id) => cmd('autopilot', 'resume', { autopilotId: id }),
+    },
+
+    dialog: {
+      // Native file picker is a desktop capability. On web, use the browser's
+      // <input type="file"> directly in the component — no IPC needed.
+      openFiles: async () => [],
+    },
+  } satisfies AppClient;
+}

--- a/apps/desktop/src/renderer/providers/AppClientProvider.tsx
+++ b/apps/desktop/src/renderer/providers/AppClientProvider.tsx
@@ -9,14 +9,21 @@ import {
 
 export { getClient };
 
+interface AppClientProviderProps {
+  children: ReactNode;
+  /** Override the transport. Desktop omits this (falls back to Electron IPC).
+   *  The Tauri entry and test harnesses pass their own client here. */
+  client?: AppClient;
+}
+
 const AppClientContext = createContext<AppClient | null>(null);
 
-export function AppClientProvider({ children }: { children: ReactNode }) {
+export function AppClientProvider({ children, client: injected }: AppClientProviderProps) {
   const client = useMemo(() => {
-    const c = createDesktopIpcClient();
+    const c = injected ?? createDesktopIpcClient();
     _registerClient(c);
     return c;
-  }, []);
+  }, [injected]);
 
   return <AppClientContext.Provider value={client}>{children}</AppClientContext.Provider>;
 }

--- a/apps/desktop/src/renderer/services/query-client.ts
+++ b/apps/desktop/src/renderer/services/query-client.ts
@@ -3,15 +3,19 @@ import { QueryClient } from '@tanstack/react-query';
 /**
  * Shared QueryClient for the renderer.
  *
- * Electron-specific tuning vs. web defaults:
- *   - refetchOnWindowFocus: false  — Electron windows don't "blur" like browser tabs;
- *                                    focus events fire constantly (tray, modals, dialogs).
- *   - refetchOnReconnect: false    — local-first app; IPC works without a network.
- *   - staleTime: 30s               — IPC calls are cheap but not free; no need to refetch
- *                                    on every component mount.
- *   - gcTime: 5min                 — Keep data in memory longer; avoids loading flashes
+ * Tuned for a local-first desktop app (applies equally to Electron, Tauri, or a
+ * future web deployment backed by a local runtime):
+ *   - refetchOnWindowFocus: false  — desktop windows receive spurious focus events
+ *                                    (tray clicks, modals, dialogs) that would cause
+ *                                    unnecessary refetches on every interaction.
+ *   - refetchOnReconnect: false    — data comes from the local runtime, not a remote
+ *                                    server; a "reconnect" event is not meaningful.
+ *   - staleTime: 30s               — backend calls are cheap but not free; avoids
+ *                                    redundant fetches on every component mount.
+ *   - gcTime: 5min                 — keep cached data longer to prevent loading flashes
  *                                    when navigating between pages.
- *   - retry: 1                     — IPC errors are usually deterministic; one retry is enough.
+ *   - retry: 1                     — backend errors are usually deterministic;
+ *                                    one retry is sufficient.
  */
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/apps/scraper-runtime/package.json
+++ b/apps/scraper-runtime/package.json
@@ -15,6 +15,7 @@
     "@ajh/shared": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "tsx": "^4.0.0",
     "typescript": "^6.0.3"
   }

--- a/apps/scraper-runtime/package.json
+++ b/apps/scraper-runtime/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@ajh/scraper-runtime",
+  "version": "0.1.0",
+  "private": true,
+  "description": "AI Job Hunter scraper sidecar — HTTP runtime process for Tauri and future web backends",
+  "type": "module",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ajh/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/scraper-runtime/src/index.ts
+++ b/apps/scraper-runtime/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Scraper sidecar entry point.
+ *
+ * Starts an HTTP server on a random localhost port and announces it on stdout:
+ *   {"port":<N>,"status":"ready"}
+ *
+ * The Tauri shell reads this line and stores the port so subsequent scrape
+ * commands can be proxied to this process over HTTP.
+ *
+ * Rollback:
+ *   AJH_SCRAPER_MODE=in-process  — the Tauri shell falls back to stubs and
+ *   does not launch this sidecar. See rollback-flags.ts in apps/desktop.
+ */
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { createRequestHandler, setServerPort } from './server.js';
+
+const host = '127.0.0.1';
+
+const server = http.createServer(createRequestHandler());
+
+server.listen(0, host, () => {
+  const { port } = server.address() as AddressInfo;
+  setServerPort(port);
+
+  // Single JSON line on stdout — the Tauri sidecar.rs parses this to discover
+  // our port. Must be the first (and only) line written before requests arrive.
+  process.stdout.write(JSON.stringify({ port, status: 'ready' }) + '\n');
+
+  // Structured log to stderr so it appears in diagnostic logs without
+  // interfering with the stdout port-announcement protocol.
+  process.stderr.write(`[scraper-runtime] HTTP server listening on http://${host}:${port}\n`);
+});
+
+// Graceful shutdown on SIGTERM/SIGINT.
+const shutdown = () => {
+  process.stderr.write('[scraper-runtime] shutting down\n');
+  server.close(() => process.exit(0));
+};
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/apps/scraper-runtime/src/protocol.ts
+++ b/apps/scraper-runtime/src/protocol.ts
@@ -1,0 +1,69 @@
+/**
+ * Scraper sidecar HTTP protocol.
+ *
+ * All communication between the Tauri shell and this process goes through
+ * HTTP POST /command → SSE ScraperEvent stream.
+ *
+ * These types mirror ScraperCommand / ScraperEvent in
+ * apps/desktop/src/main/scraper-runtime.ts. They are duplicated here so the
+ * sidecar remains standalone (no Electron / main-process imports).
+ *
+ * ── Request ──────────────────────────────────────────────────────────────────
+ *  POST /command
+ *  Content-Type: application/json
+ *  Body: ScraperCommand
+ *
+ * ── Response ─────────────────────────────────────────────────────────────────
+ *  Content-Type: text/event-stream
+ *  Each SSE event is a JSON-serialised ScraperEvent:
+ *    event: <kind>\ndata: <JSON>\n\n
+ *
+ * ── Health ────────────────────────────────────────────────────────────────────
+ *  GET /health → 200 application/json ScraperRuntimeHealth
+ *
+ * ── Port announcement ─────────────────────────────────────────────────────────
+ *  On startup the sidecar writes one line to stdout:
+ *    {"port":<N>,"status":"ready"}\n
+ *  The Tauri shell reads this to discover the sidecar's HTTP port.
+ */
+
+export type ScraperCommand =
+  | { kind: 'scrape.board'; jobId: string; payload: ScrapeBoardPayload }
+  | { kind: 'scrape.url'; jobId: string; payload: { url: string } }
+  | { kind: 'health' }
+  | { kind: 'catalog' };
+
+export type ScraperEvent =
+  | { kind: 'progress'; jobId: string; p: number }
+  | { kind: 'item'; jobId: string; item: Record<string, unknown> }
+  | { kind: 'done'; jobId: string; result: unknown }
+  | { kind: 'error'; jobId: string; message: string }
+  | { kind: 'health.reply'; health: ScraperRuntimeHealth }
+  | { kind: 'catalog.reply'; scrapers: ScraperCatalogEntry[] };
+
+export interface ScrapeBoardPayload {
+  board: string;
+  query: string;
+  location?: string;
+  pages: number;
+  dateFilter?: string;
+  locale?: string;
+}
+
+export interface ScraperCatalogEntry {
+  id: string;
+  displayName: string;
+  mode: 'http' | 'browser';
+}
+
+export interface ScraperRuntimeHealth {
+  mode: 'http-sidecar';
+  scrapers: ScraperCatalogEntry[];
+  ready: boolean;
+  port: number;
+}
+
+export interface PortAnnouncement {
+  port: number;
+  status: 'ready';
+}

--- a/apps/scraper-runtime/src/server.ts
+++ b/apps/scraper-runtime/src/server.ts
@@ -1,0 +1,173 @@
+/**
+ * Scraper sidecar HTTP server.
+ *
+ * Routes:
+ *   POST /command  — accept ScraperCommand, stream ScraperEvents via SSE.
+ *   GET  /health   — return ScraperRuntimeHealth as JSON.
+ *
+ * Scraping is stubbed here — this file establishes the protocol proof.
+ * Real scraper implementations (importing from @ajh/data) slot in by
+ * implementing handleScrapeBoard / handleScrapeUrl below.
+ */
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type {
+  ScraperCatalogEntry,
+  ScraperCommand,
+  ScraperEvent,
+  ScraperRuntimeHealth,
+} from './protocol.js';
+
+let _port = 0;
+export function setServerPort(port: number): void {
+  _port = port;
+}
+
+// ── SSE helpers ───────────────────────────────────────────────────────────────
+
+function sendEvent(res: ServerResponse, event: ScraperEvent): void {
+  res.write(`event: ${event.kind}\ndata: ${JSON.stringify(event)}\n\n`);
+}
+
+// ── Scraper catalog ───────────────────────────────────────────────────────────
+// Extend this list as real HTTP scraper adapters are ported from @ajh/data.
+
+const CATALOG: ScraperCatalogEntry[] = [
+  { id: 'linkedin', displayName: 'LinkedIn', mode: 'http' },
+  { id: 'indeed', displayName: 'Indeed', mode: 'http' },
+  { id: 'stepstone', displayName: 'StepStone', mode: 'http' },
+];
+
+// ── Command handlers ──────────────────────────────────────────────────────────
+
+async function handleCommand(cmd: ScraperCommand, res: ServerResponse): Promise<void> {
+  switch (cmd.kind) {
+    case 'scrape.board': {
+      const { jobId, payload } = cmd;
+      // Protocol proof: emit progress ticks then a done event.
+      // Replace with real scraper call once @ajh/data HTTP scrapers are wired.
+      for (let i = 1; i <= 3; i++) {
+        sendEvent(res, { kind: 'progress', jobId, p: i / 3 });
+        await sleep(100);
+      }
+      sendEvent(res, {
+        kind: 'done',
+        jobId,
+        result: {
+          board: payload.board,
+          count: 0,
+          note: 'sidecar stub — real scraper not yet wired',
+        },
+      });
+      break;
+    }
+
+    case 'scrape.url': {
+      const { jobId, payload } = cmd;
+      // Stub — real scraper would fetch and parse the posting.
+      sendEvent(res, {
+        kind: 'done',
+        jobId,
+        result: { url: payload.url, note: 'sidecar stub — real scraper not yet wired' },
+      });
+      break;
+    }
+
+    case 'health': {
+      const health: ScraperRuntimeHealth = {
+        mode: 'http-sidecar',
+        scrapers: CATALOG,
+        ready: true,
+        port: _port,
+      };
+      sendEvent(res, { kind: 'health.reply', health });
+      break;
+    }
+
+    case 'catalog': {
+      sendEvent(res, { kind: 'catalog.reply', scrapers: CATALOG });
+      break;
+    }
+
+    default: {
+      const exhaustive: never = cmd;
+      const jobId = (exhaustive as { jobId?: string }).jobId ?? 'unknown';
+      sendEvent(res, { kind: 'error', jobId, message: `Unknown command kind` });
+    }
+  }
+}
+
+// ── Body reader ───────────────────────────────────────────────────────────────
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Request router ────────────────────────────────────────────────────────────
+
+export function createRequestHandler() {
+  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    // Only allow localhost connections.
+    const remoteAddr = req.socket.remoteAddress ?? '';
+    if (remoteAddr !== '127.0.0.1' && remoteAddr !== '::1' && remoteAddr !== '::ffff:127.0.0.1') {
+      res.writeHead(403);
+      res.end();
+      return;
+    }
+
+    const pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
+
+    if (pathname === '/health' && req.method === 'GET') {
+      const health: ScraperRuntimeHealth = {
+        mode: 'http-sidecar',
+        scrapers: CATALOG,
+        ready: true,
+        port: _port,
+      };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(health));
+      return;
+    }
+
+    if (pathname === '/command' && req.method === 'POST') {
+      let cmd: ScraperCommand;
+      try {
+        const body = await readBody(req);
+        cmd = JSON.parse(body) as ScraperCommand;
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid JSON body' }));
+        return;
+      }
+
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      });
+
+      try {
+        await handleCommand(cmd, res);
+      } catch (err) {
+        const jobId = (cmd as { jobId?: string }).jobId ?? 'unknown';
+        sendEvent(res, { kind: 'error', jobId, message: String(err) });
+      }
+
+      res.end();
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  };
+}

--- a/apps/scraper-runtime/tsconfig.json
+++ b/apps/scraper-runtime/tsconfig.json
@@ -9,7 +9,8 @@
     "noEmit": false,
     "declaration": false,
     "declarationMap": false,
-    "sourceMap": false
+    "sourceMap": false,
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/apps/scraper-runtime/tsconfig.json
+++ b/apps/scraper-runtime/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/tauri/index.html
+++ b/apps/tauri/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Job Hunter (Tauri)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -5,7 +5,8 @@
   "description": "AI Job Hunter — Tauri spike shell",
   "scripts": {
     "dev": "tauri dev",
-    "build": "tauri build",
+    "build": "vite build",
+    "package": "tauri build",
     "dev:frontend": "vite --port 5174",
     "build:frontend": "vite build",
     "typecheck": "tsc --noEmit"

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@ajh/tauri",
+  "version": "0.1.0",
+  "private": true,
+  "description": "AI Job Hunter — Tauri spike shell",
+  "scripts": {
+    "dev": "tauri dev",
+    "build": "tauri build",
+    "dev:frontend": "vite --port 5174",
+    "build:frontend": "vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.11.0"
+  },
+  "devDependencies": {
+    "@ajh/ui": "workspace:*",
+    "@tauri-apps/cli": "^2.11.2",
+    "@tailwindcss/vite": "^4.3.0",
+    "@tanstack/react-query": "^5.100.11",
+    "@tanstack/react-router": "^1.167.6",
+    "@tanstack/router-vite-plugin": "^1.167.6",
+    "@vitejs/plugin-react": "^6.0.2",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.13"
+  }
+}

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ajh-tauri-spike"
+version = "0.1.0"
+edition = "2021"
+description = "AI Job Hunter — Tauri spike shell"
+authors = ["Saeed Kolivand"]
+
+# Disable default binary stripping so debug symbols survive in dev builds.
+[profile.dev]
+incremental = true
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+panic = "abort"
+strip = true
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+tauri = { version = "2", features = ["tray-icon", "image-ico", "image-png"] }
+tauri-plugin-shell = "2"
+tauri-plugin-opener = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -23,5 +23,8 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "image-ico", "image-png"] }
 tauri-plugin-shell = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# HTTP client for proxying scraper commands to the sidecar process.
+reqwest = { version = "0.12", features = ["json"], default-features = false }

--- a/apps/tauri/src-tauri/build.rs
+++ b/apps/tauri/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -1,22 +1,89 @@
-/// Tauri command implementations for the AJH spike.
+/// Tauri command implementations for the AJH shell.
 ///
-/// Real commands: system_health, system_get_version, system_get_platform,
-///                system_get_locale, system_open_external.
+/// Real commands: system_health/version/platform/locale/openExternal,
+///                scrape_board, scrape_url (proxy to scraper sidecar),
+///                dialog_open_files.
 ///
 /// Stub commands: everything else — they return null / empty list so the UI
-/// renders (with empty states) rather than crashing. Parity is built
-/// incrementally by replacing stubs with sidecar proxies.
+/// renders with empty states. Parity is built incrementally by replacing
+/// stubs with sidecar HTTP proxies.
+use std::sync::Mutex;
 use serde_json::{json, Value};
 use tauri::AppHandle;
+
+use crate::sidecar::ScraperSidecarState;
+
+// ── Sidecar HTTP helpers ──────────────────────────────────────────────────────
+
+/// Returns the scraper sidecar port if ready, or None.
+fn sidecar_port(app: &AppHandle) -> Option<u16> {
+    app.state::<Mutex<ScraperSidecarState>>()
+        .lock()
+        .ok()
+        .and_then(|g| g.port)
+}
+
+/// POST a ScraperCommand to the sidecar and collect SSE ScraperEvents.
+/// Forwards each event to the Tauri event bus so the renderer's onEvent /
+/// onStream handlers fire just like they do in Electron.
+async fn post_sidecar_command(
+    app: &AppHandle,
+    port: u16,
+    cmd: &Value,
+) -> Result<Value, String> {
+    let url = format!("http://127.0.0.1:{port}/command");
+
+    let response = reqwest::Client::new()
+        .post(&url)
+        .json(cmd)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let body = response.text().await.map_err(|e| e.to_string())?;
+
+    let mut last_done: Value = json!(null);
+
+    for line in body.lines() {
+        if let Some(data) = line.strip_prefix("data: ") {
+            if let Ok(event) = serde_json::from_str::<Value>(data) {
+                let kind = event.get("kind").and_then(|k| k.as_str()).unwrap_or("");
+                match kind {
+                    "done" => {
+                        last_done = event.get("result").cloned().unwrap_or(json!(null));
+                        let job_id = event.get("jobId").cloned().unwrap_or(json!(""));
+                        let _ = app.emit("jobs:event", json!({"type":"completed","jobId":job_id}));
+                    }
+                    "progress" => {
+                        let _ = app.emit("jobs:event", event.clone());
+                    }
+                    "item" => {
+                        let _ = app.emit("jobs:event", event.clone());
+                    }
+                    "error" => {
+                        let msg = event.get("message").and_then(|m| m.as_str()).unwrap_or("sidecar error");
+                        return Err(msg.to_string());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(last_done)
+}
+
+use tauri::Manager;
 
 // ── System ──────────────────────────────────────────────────────────────────
 
 #[tauri::command]
-pub fn system_health() -> Value {
+pub fn system_health(app: AppHandle) -> Value {
+    let scraper_ready = sidecar_port(&app).is_some();
     json!({
         "status": "ok",
         "shell": "tauri",
-        "scraper": { "mode": "sidecar", "ready": false },
+        "scraper": { "mode": "http-sidecar", "ready": scraper_ready },
         "ai": { "available": false },
         "data": { "available": false }
     })
@@ -145,13 +212,40 @@ pub fn search_hybrid(_req: Value) -> Value {
 // ── Scrape ───────────────────────────────────────────────────────────────────
 
 #[tauri::command]
-pub fn scrape_board(_req: Value) -> Value {
-    json!({ "error": "Scraper sidecar not yet connected" })
+pub async fn scrape_board(app: AppHandle, req: Value) -> Value {
+    let Some(port) = sidecar_port(&app) else {
+        return json!({ "error": "scraper sidecar not ready — start the scraper-runtime binary" });
+    };
+    let job_id = uuid_v4();
+    let cmd = json!({ "kind": "scrape.board", "jobId": job_id, "payload": req });
+    match post_sidecar_command(&app, port, &cmd).await {
+        Ok(result) => result,
+        Err(e) => json!({ "error": e }),
+    }
 }
 
 #[tauri::command]
-pub fn scrape_url(_req: Value) -> Value {
-    json!({ "error": "Scraper sidecar not yet connected" })
+pub async fn scrape_url(app: AppHandle, req: Value) -> Value {
+    let Some(port) = sidecar_port(&app) else {
+        return json!({ "error": "scraper sidecar not ready — start the scraper-runtime binary" });
+    };
+    let job_id = uuid_v4();
+    let url = req.get("url").and_then(|u| u.as_str()).unwrap_or("");
+    let cmd = json!({ "kind": "scrape.url", "jobId": job_id, "payload": { "url": url } });
+    match post_sidecar_command(&app, port, &cmd).await {
+        Ok(result) => result,
+        Err(e) => json!({ "error": e }),
+    }
+}
+
+fn uuid_v4() -> String {
+    // Simple random ID without pulling in uuid crate — sufficient for job IDs.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let t = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("job-{t:x}")
 }
 
 #[tauri::command]
@@ -363,4 +457,46 @@ pub fn conversations_load_messages(_conversation_id: String) -> Value {
 #[tauri::command]
 pub fn conversations_save_message(_req: Value) -> Value {
     json!(null)
+}
+
+// ── Native dialogs ────────────────────────────────────────────────────────────
+
+/// Open a native file picker and return the selected file paths.
+/// Used by the document import flow instead of passing raw filesystem paths
+/// over IPC — the renderer receives paths it can then read via the backend.
+///
+/// Replaces the Electron `dialog.showOpenDialog` equivalent.
+#[tauri::command]
+pub async fn dialog_open_files(
+    app: AppHandle,
+    title: Option<String>,
+    filters: Option<Vec<DialogFilter>>,
+) -> Vec<String> {
+    use tauri_plugin_dialog::{DialogExt, FilePath};
+
+    let mut builder = app.dialog().file();
+    if let Some(t) = title {
+        builder = builder.set_title(&t);
+    }
+    if let Some(fs) = filters {
+        for f in fs {
+            builder = builder.add_filter(&f.name, &f.extensions.iter().map(String::as_str).collect::<Vec<_>>());
+        }
+    }
+
+    builder
+        .blocking_pick_files()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|p| match p {
+            FilePath::Path(pb) => pb.to_string_lossy().into_owned(),
+            FilePath::Url(u) => u.to_string(),
+        })
+        .collect()
+}
+
+#[derive(serde::Deserialize)]
+pub struct DialogFilter {
+    pub name: String,
+    pub extensions: Vec<String>,
 }

--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -1,0 +1,366 @@
+/// Tauri command implementations for the AJH spike.
+///
+/// Real commands: system_health, system_get_version, system_get_platform,
+///                system_get_locale, system_open_external.
+///
+/// Stub commands: everything else — they return null / empty list so the UI
+/// renders (with empty states) rather than crashing. Parity is built
+/// incrementally by replacing stubs with sidecar proxies.
+use serde_json::{json, Value};
+use tauri::AppHandle;
+
+// ── System ──────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn system_health() -> Value {
+    json!({
+        "status": "ok",
+        "shell": "tauri",
+        "scraper": { "mode": "sidecar", "ready": false },
+        "ai": { "available": false },
+        "data": { "available": false }
+    })
+}
+
+#[tauri::command]
+pub fn system_get_version() -> Value {
+    json!({ "version": env!("CARGO_PKG_VERSION"), "shell": "tauri" })
+}
+
+#[tauri::command]
+pub fn system_get_locale() -> Value {
+    json!("en")
+}
+
+#[tauri::command]
+pub fn system_set_locale(_locale: String) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn system_get_platform() -> Value {
+    json!({
+        "platform": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "shell": "tauri"
+    })
+}
+
+#[tauri::command]
+pub async fn system_open_external(app: AppHandle, url: String) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+    app.opener()
+        .open_url(&url, None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn system_set_performance_mode(_mode: String) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn system_get_metrics() -> Value {
+    json!({
+        "shell": "tauri",
+        "uptime": 0,
+        "memoryMb": 0,
+        "cpuPercent": 0
+    })
+}
+
+// ── Jobs ─────────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn jobs_list() -> Value {
+    json!([])
+}
+
+#[tauri::command]
+pub fn jobs_get(_job_id: String) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn jobs_cancel(_job_id: String) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn jobs_retry(_job_id: String) -> Value {
+    json!(null)
+}
+
+// ── AI ───────────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn ai_generate(_req: Value) -> Value {
+    json!({ "error": "AI runtime not yet available in Tauri spike" })
+}
+
+#[tauri::command]
+pub fn ai_list_models() -> Value {
+    json!([])
+}
+
+#[tauri::command]
+pub fn ai_pull_model(_model: String) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn ai_unload_model(_model: String) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn ai_embed(_req: Value) -> Value {
+    json!(null)
+}
+
+// ── Documents ────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn documents_list() -> Value {
+    json!([])
+}
+
+#[tauri::command]
+pub fn documents_import(_req: Value) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn documents_remove(_id: String) -> Value {
+    json!(null)
+}
+
+// ── Search ───────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn search_hybrid(_req: Value) -> Value {
+    json!({ "items": [], "total": 0 })
+}
+
+// ── Scrape ───────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn scrape_board(_req: Value) -> Value {
+    json!({ "error": "Scraper sidecar not yet connected" })
+}
+
+#[tauri::command]
+pub fn scrape_url(_req: Value) -> Value {
+    json!({ "error": "Scraper sidecar not yet connected" })
+}
+
+#[tauri::command]
+pub fn scrape_persist_job(_req: Value) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn scrape_list_postings() -> Value {
+    json!([])
+}
+
+#[tauri::command]
+pub fn scrape_clear_postings() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn scrape_list_interactions(_filter: Option<Value>) -> Value {
+    json!([])
+}
+
+#[tauri::command]
+pub fn scrape_export_data() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn scrape_import_data() -> Value {
+    json!(null)
+}
+
+// ── Match ────────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn match_resume(_req: Value) -> Value {
+    json!(null)
+}
+
+// ── Credentials ──────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn credentials_available() -> Value {
+    json!(false)
+}
+
+#[tauri::command]
+pub fn credentials_list() -> Value {
+    json!([])
+}
+
+#[tauri::command]
+pub fn credentials_set(_req: Value) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn credentials_remove(_board_id: String) -> Value {
+    json!(null)
+}
+
+// ── LinkedIn / Boards ────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn linkedin_connect() -> Value {
+    json!({ "status": "not_connected" })
+}
+
+#[tauri::command]
+pub fn linkedin_disconnect() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn linkedin_get_status() -> Value {
+    json!({ "status": "not_connected" })
+}
+
+#[tauri::command]
+pub fn boards_connect(_board_id: String) -> Value {
+    json!({ "status": "not_connected" })
+}
+
+#[tauri::command]
+pub fn boards_disconnect(_board_id: String) -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn boards_get_status(_board_id: String) -> Value {
+    json!({ "status": "not_connected" })
+}
+
+// ── Privacy ──────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn privacy_sign_out_all() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn privacy_clear_interactions() -> Value {
+    json!(null)
+}
+
+// ── Apply ────────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn apply_start(_req: Value) -> Value {
+    json!({ "error": "Apply not yet available in Tauri spike" })
+}
+
+#[tauri::command]
+pub fn apply_catalog() -> Value {
+    json!([])
+}
+
+// ── Resume ───────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn resume_extract_text(_req: Value) -> Value {
+    json!({ "error": "Resume extraction not yet available in Tauri spike" })
+}
+
+// ── Support ──────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn support_export_diagnostics() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_reload_ai_runtime() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_unload_all_models() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_reset_model_configuration() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_rebuild_vector_indexes() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_clear_embeddings_cache() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_reset_vector_database() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_clear_ocr_cache() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_reindex_all_documents() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_reset_all_sessions() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_clear_scraping_queue() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_copy_environment_details() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_copy_app_version() -> Value {
+    json!(null)
+}
+
+#[tauri::command]
+pub fn support_copy_system_info() -> Value {
+    json!(null)
+}
+
+// ── Conversations ────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn conversations_get_or_create() -> Value {
+    json!({ "id": "default", "createdAt": 0 })
+}
+
+#[tauri::command]
+pub fn conversations_load_messages(_conversation_id: String) -> Value {
+    json!([])
+}
+
+#[tauri::command]
+pub fn conversations_save_message(_req: Value) -> Value {
+    json!(null)
+}

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -5,20 +5,114 @@ mod commands;
 mod sidecar;
 
 use std::sync::Mutex;
+
+use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri::{AppHandle, Manager};
+
 use sidecar::ScraperSidecarState;
+
+// ── App menu ──────────────────────────────────────────────────────────────────
+
+fn build_app_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
+    let quit = MenuItemBuilder::with_id("quit", "Quit")
+        .accelerator("CmdOrControl+Q")
+        .build(app)?;
+    let hide = MenuItemBuilder::with_id("hide", "Hide Window")
+        .accelerator("CmdOrControl+H")
+        .build(app)?;
+    let about = MenuItemBuilder::with_id("about", "About AI Job Hunter").build(app)?;
+
+    let app_submenu = SubmenuBuilder::new(app, "AI Job Hunter")
+        .item(&about)
+        .separator()
+        .item(&hide)
+        .separator()
+        .item(&quit)
+        .build()?;
+
+    MenuBuilder::new(app).item(&app_submenu).build()
+}
+
+fn on_menu_event(app: &AppHandle, id: &str) {
+    match id {
+        "quit" => app.exit(0),
+        "hide" => {
+            if let Some(win) = app.get_webview_window("main") {
+                let _ = win.hide();
+            }
+        }
+        _ => {}
+    }
+}
+
+// ── System tray ───────────────────────────────────────────────────────────────
+
+fn build_tray(app: &AppHandle) -> tauri::Result<()> {
+    let show = MenuItemBuilder::with_id("tray_show", "Show AI Job Hunter").build(app)?;
+    let quit = MenuItemBuilder::with_id("tray_quit", "Quit").build(app)?;
+    let tray_menu = MenuBuilder::new(app).item(&show).separator().item(&quit).build()?;
+
+    TrayIconBuilder::new()
+        .menu(&tray_menu)
+        .tooltip("AI Job Hunter")
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "tray_show" => {
+                if let Some(win) = app.get_webview_window("main") {
+                    let _ = win.show();
+                    let _ = win.set_focus();
+                }
+            }
+            "tray_quit" => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            // Left-click on the tray icon shows/focuses the main window.
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                let app = tray.app_handle();
+                if let Some(win) = app.get_webview_window("main") {
+                    let _ = win.show();
+                    let _ = win.set_focus();
+                }
+            }
+        })
+        .build(app)?;
+
+    Ok(())
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
 
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .manage(Mutex::new(ScraperSidecarState::default()))
         .setup(|app| {
-            // Attempt to start the scraper sidecar. Failure is non-fatal so
-            // the app opens even when the binary is absent during development.
             let handle = app.handle();
+
+            // Build and set the application menu.
+            let menu = build_app_menu(handle)?;
+            app.set_menu(menu)?;
+            app.on_menu_event(|app, event| on_menu_event(app, event.id().as_ref()));
+
+            // Build system tray.
+            if let Err(e) = build_tray(handle) {
+                eprintln!("[setup] tray build error (non-fatal): {e}");
+            }
+
+            // Attempt to start the scraper sidecar. Failure is non-fatal —
+            // scrape commands return stubs when sidecar is unavailable.
             if let Err(e) = sidecar::try_start(handle) {
                 eprintln!("[setup] sidecar start error (non-fatal): {e}");
             }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -98,6 +192,8 @@ fn main() {
             commands::conversations_get_or_create,
             commands::conversations_load_messages,
             commands::conversations_save_message,
+            // native dialogs
+            commands::dialog_open_files,
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri application");

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -1,0 +1,104 @@
+// Prevents a terminal window from appearing on Windows in release builds.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+mod commands;
+mod sidecar;
+
+use std::sync::Mutex;
+use sidecar::ScraperSidecarState;
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_opener::init())
+        .manage(Mutex::new(ScraperSidecarState::default()))
+        .setup(|app| {
+            // Attempt to start the scraper sidecar. Failure is non-fatal so
+            // the app opens even when the binary is absent during development.
+            let handle = app.handle();
+            if let Err(e) = sidecar::try_start(handle) {
+                eprintln!("[setup] sidecar start error (non-fatal): {e}");
+            }
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            // system
+            commands::system_health,
+            commands::system_get_version,
+            commands::system_get_locale,
+            commands::system_set_locale,
+            commands::system_get_platform,
+            commands::system_open_external,
+            commands::system_set_performance_mode,
+            commands::system_get_metrics,
+            // jobs
+            commands::jobs_list,
+            commands::jobs_get,
+            commands::jobs_cancel,
+            commands::jobs_retry,
+            // ai
+            commands::ai_generate,
+            commands::ai_list_models,
+            commands::ai_pull_model,
+            commands::ai_unload_model,
+            commands::ai_embed,
+            // documents
+            commands::documents_list,
+            commands::documents_import,
+            commands::documents_remove,
+            // search
+            commands::search_hybrid,
+            // scrape
+            commands::scrape_board,
+            commands::scrape_url,
+            commands::scrape_persist_job,
+            commands::scrape_list_postings,
+            commands::scrape_clear_postings,
+            commands::scrape_list_interactions,
+            commands::scrape_export_data,
+            commands::scrape_import_data,
+            // match
+            commands::match_resume,
+            // credentials
+            commands::credentials_available,
+            commands::credentials_list,
+            commands::credentials_set,
+            commands::credentials_remove,
+            // linkedin / boards
+            commands::linkedin_connect,
+            commands::linkedin_disconnect,
+            commands::linkedin_get_status,
+            commands::boards_connect,
+            commands::boards_disconnect,
+            commands::boards_get_status,
+            // privacy
+            commands::privacy_sign_out_all,
+            commands::privacy_clear_interactions,
+            // apply
+            commands::apply_start,
+            commands::apply_catalog,
+            // resume
+            commands::resume_extract_text,
+            // support
+            commands::support_export_diagnostics,
+            commands::support_reload_ai_runtime,
+            commands::support_unload_all_models,
+            commands::support_reset_model_configuration,
+            commands::support_rebuild_vector_indexes,
+            commands::support_clear_embeddings_cache,
+            commands::support_reset_vector_database,
+            commands::support_clear_ocr_cache,
+            commands::support_reindex_all_documents,
+            commands::support_reset_all_sessions,
+            commands::support_clear_scraping_queue,
+            commands::support_copy_environment_details,
+            commands::support_copy_app_version,
+            commands::support_copy_system_info,
+            // conversations
+            commands::conversations_get_or_create,
+            commands::conversations_load_messages,
+            commands::conversations_save_message,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error running tauri application");
+}

--- a/apps/tauri/src-tauri/src/sidecar.rs
+++ b/apps/tauri/src-tauri/src/sidecar.rs
@@ -1,0 +1,55 @@
+/// Scraper sidecar lifecycle management.
+///
+/// The scraper-runtime binary (a bundled Node.js executable) is launched as a
+/// Tauri sidecar. It communicates over stdio using the ScraperCommand /
+/// ScraperEvent protocol defined in packages/data.
+///
+/// In this spike the sidecar is configured but not yet launched automatically.
+/// Call `try_start` once the app is ready; it logs a warning and returns Ok
+/// if the binary is absent (development workflow where the sidecar is not
+/// bundled yet).
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager};
+use tauri_plugin_shell::ShellExt;
+
+pub struct ScraperSidecarState {
+    pub running: bool,
+}
+
+impl Default for ScraperSidecarState {
+    fn default() -> Self {
+        Self { running: false }
+    }
+}
+
+/// Attempt to launch the scraper sidecar. Logs and returns Ok if the binary
+/// is not bundled — the UI degrades gracefully to "scraper unavailable".
+pub fn try_start(app: &AppHandle) -> tauri::Result<()> {
+    let state = app.state::<Mutex<ScraperSidecarState>>();
+    let mut guard = state.lock().unwrap();
+
+    if guard.running {
+        return Ok(());
+    }
+
+    let shell = app.shell();
+    match shell.sidecar("scraper-runtime") {
+        Ok(cmd) => {
+            let (mut _rx, _child) = cmd
+                .args(["--mode", "sidecar"])
+                .spawn()
+                .map_err(|e| {
+                    eprintln!("[sidecar] failed to spawn scraper-runtime: {e}");
+                    e
+                })?;
+            guard.running = true;
+            println!("[sidecar] scraper-runtime started");
+        }
+        Err(e) => {
+            // Binary absent during development — not a fatal error for the spike.
+            eprintln!("[sidecar] scraper-runtime binary not found, continuing without it: {e}");
+        }
+    }
+
+    Ok(())
+}

--- a/apps/tauri/src-tauri/src/sidecar.rs
+++ b/apps/tauri/src-tauri/src/sidecar.rs
@@ -1,55 +1,96 @@
 /// Scraper sidecar lifecycle management.
 ///
-/// The scraper-runtime binary (a bundled Node.js executable) is launched as a
-/// Tauri sidecar. It communicates over stdio using the ScraperCommand /
-/// ScraperEvent protocol defined in packages/data.
+/// The scraper-runtime binary is launched as a Tauri sidecar. On startup it
+/// writes one JSON line to stdout:
+///   {"port":<N>,"status":"ready"}
 ///
-/// In this spike the sidecar is configured but not yet launched automatically.
-/// Call `try_start` once the app is ready; it logs a warning and returns Ok
-/// if the binary is absent (development workflow where the sidecar is not
-/// bundled yet).
-use std::sync::Mutex;
+/// We read that line, parse the port, and store it in ScraperSidecarState so
+/// Tauri commands can proxy scraping requests to the sidecar over HTTP.
+///
+/// ── Rollback ──────────────────────────────────────────────────────────────
+/// If the sidecar binary is absent (development workflow), try_start returns
+/// Ok and leaves ScraperSidecarState::port as None. All scrape commands then
+/// return a "sidecar not available" stub rather than crashing.
+use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager};
+use tauri_plugin_shell::process::CommandEvent;
 use tauri_plugin_shell::ShellExt;
 
+#[derive(Debug, Default)]
 pub struct ScraperSidecarState {
+    /// Set to true once the sidecar process has been launched.
     pub running: bool,
+    /// HTTP port announced by the sidecar on stdout. None until announcement
+    /// is received or if the sidecar is absent.
+    pub port: Option<u16>,
 }
 
-impl Default for ScraperSidecarState {
-    fn default() -> Self {
-        Self { running: false }
-    }
-}
-
-/// Attempt to launch the scraper sidecar. Logs and returns Ok if the binary
-/// is not bundled — the UI degrades gracefully to "scraper unavailable".
+/// Attempt to launch the scraper sidecar and wait for its port announcement.
+///
+/// Non-fatal: if the binary is absent the app opens with sidecar stubs.
 pub fn try_start(app: &AppHandle) -> tauri::Result<()> {
     let state = app.state::<Mutex<ScraperSidecarState>>();
-    let mut guard = state.lock().unwrap();
-
-    if guard.running {
-        return Ok(());
+    {
+        let guard = state.lock().unwrap();
+        if guard.running {
+            return Ok(());
+        }
     }
 
     let shell = app.shell();
-    match shell.sidecar("scraper-runtime") {
-        Ok(cmd) => {
-            let (mut _rx, _child) = cmd
-                .args(["--mode", "sidecar"])
-                .spawn()
-                .map_err(|e| {
-                    eprintln!("[sidecar] failed to spawn scraper-runtime: {e}");
-                    e
-                })?;
-            guard.running = true;
-            println!("[sidecar] scraper-runtime started");
-        }
+    let sidecar_cmd = match shell.sidecar("scraper-runtime") {
+        Ok(cmd) => cmd,
         Err(e) => {
-            // Binary absent during development — not a fatal error for the spike.
-            eprintln!("[sidecar] scraper-runtime binary not found, continuing without it: {e}");
+            eprintln!("[sidecar] scraper-runtime binary not found — sidecar unavailable: {e}");
+            return Ok(());
         }
+    };
+
+    let (mut rx, _child) = match sidecar_cmd.spawn() {
+        Ok(pair) => pair,
+        Err(e) => {
+            eprintln!("[sidecar] failed to spawn scraper-runtime: {e}");
+            return Ok(());
+        }
+    };
+
+    {
+        let mut guard = state.lock().unwrap();
+        guard.running = true;
     }
+
+    // Spawn a task to read stdout and capture the port announcement.
+    let state_arc: Arc<Mutex<ScraperSidecarState>> =
+        Arc::clone(&*app.state::<Mutex<ScraperSidecarState>>());
+    tauri::async_runtime::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            match event {
+                CommandEvent::Stdout(line) => {
+                    let text = String::from_utf8_lossy(&line);
+                    // Parse {"port":<N>,"status":"ready"}
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(text.trim()) {
+                        if let Some(port) = v.get("port").and_then(|p| p.as_u64()) {
+                            let mut guard = state_arc.lock().unwrap();
+                            guard.port = Some(port as u16);
+                            eprintln!("[sidecar] ready on port {port}");
+                        }
+                    }
+                }
+                CommandEvent::Stderr(line) => {
+                    eprintln!("[sidecar stderr] {}", String::from_utf8_lossy(&line));
+                }
+                CommandEvent::Error(msg) => {
+                    eprintln!("[sidecar error] {msg}");
+                    break;
+                }
+                CommandEvent::Terminated(status) => {
+                    eprintln!("[sidecar] process exited: {status:?}");
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
 
     Ok(())
 }

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "AI Job Hunter (Tauri Spike)",
+  "identifier": "com.ajh.tauri-spike",
+  "version": "0.1.0",
+
+  "build": {
+    "frontendDist": "../dist",
+    "devUrl": "http://localhost:5174",
+    "beforeDevCommand": "pnpm dev:frontend",
+    "beforeBuildCommand": "pnpm build:frontend"
+  },
+
+  "app": {
+    "windows": [
+      {
+        "title": "AI Job Hunter (Tauri Spike)",
+        "width": 1280,
+        "height": 800,
+        "minWidth": 900,
+        "minHeight": 600,
+        "center": true,
+        "decorations": true,
+        "resizable": true
+      }
+    ],
+    "security": {
+      "csp": "default-src 'self' tauri: asset: https://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: https://asset.localhost; font-src 'self' data: asset: https://asset.localhost; connect-src 'self' http://127.0.0.1:11434 http://127.0.0.1:* ws://127.0.0.1:* tauri: ipc: http://ipc.localhost"
+    }
+  },
+
+  "bundle": {
+    "active": false,
+    "targets": "none",
+    "externalBin": ["binaries/scraper-runtime"]
+  },
+
+  "plugins": {
+    "shell": {
+      "sidecar": true,
+      "open": "https?://"
+    }
+  }
+}

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -39,6 +39,7 @@
     "shell": {
       "sidecar": true,
       "open": "https?://"
-    }
+    },
+    "dialog": {}
   }
 }

--- a/apps/tauri/src/env.d.ts
+++ b/apps/tauri/src/env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+// In the Tauri shell window.api is NOT present (there is no Electron preload).
+// We declare it as `never` so the type system accepts app-client.ts's
+// createDesktopIpcClient (which is never called from Tauri code) while making
+// accidental usage a compile error.
+declare global {
+  interface Window {
+    api: never;
+  }
+}
+
+export {};

--- a/apps/tauri/src/main.tsx
+++ b/apps/tauri/src/main.tsx
@@ -1,0 +1,54 @@
+/**
+ * Tauri spike entry point.
+ *
+ * This file mirrors apps/desktop/src/renderer/main.tsx but supplies a
+ * TauriInvokeClient to AppClientProvider instead of the Electron IPC client.
+ * Everything else — routes, components, service hooks — is imported from the
+ * desktop renderer source via the `@` alias in vite.config.ts.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createRouter, RouterProvider } from '@tanstack/react-router';
+
+import { restoreTheme } from '@ajh/ui';
+
+import { AppClientProvider } from '@/providers/AppClientProvider';
+import { PerformanceModeProvider } from '@/providers/PerformanceModeProvider';
+import { routeTree } from '@/routeTree.gen';
+import { queryClient } from '@/services/query-client';
+
+import { createTauriInvokeClient } from './tauri-client';
+
+import '@/i18n';
+import '@/styles/globals.css';
+
+restoreTheme();
+
+const router = createRouter({
+  routeTree,
+  defaultPreload: 'intent',
+  defaultPreloadStaleTime: 0,
+});
+
+void router.navigate({ to: '/', replace: true });
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+const tauriClient = createTauriInvokeClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <AppClientProvider client={tauriClient}>
+      <PerformanceModeProvider>
+        <QueryClientProvider client={queryClient}>
+          <RouterProvider router={router} />
+        </QueryClientProvider>
+      </PerformanceModeProvider>
+    </AppClientProvider>
+  </React.StrictMode>
+);

--- a/apps/tauri/src/tauri-client.ts
+++ b/apps/tauri/src/tauri-client.ts
@@ -1,0 +1,177 @@
+/**
+ * TauriInvokeClient — implements AppClient using Tauri v2 invoke + listen.
+ *
+ * Used by apps/tauri/src/main.tsx instead of the Electron window.api bridge.
+ * The shape is structurally identical to the Electron client so all service
+ * hooks work without modification.
+ *
+ * Event subscriptions: Tauri's listen() is async. We return a sync cleanup
+ * function that cancels the listener once the promise resolves. This matches
+ * the Electron preload pattern.
+ *
+ * Unimplemented commands return stubs (null / []) so the UI degrades
+ * gracefully while parity is being built up incrementally.
+ */
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+import type { AppClient } from '@/lib/app-client';
+
+// Registers a Tauri event listener and returns a sync unsubscribe handle.
+function asyncUnsub(setup: () => Promise<() => void>): () => void {
+  let cancel: (() => void) | null = null;
+  let cancelled = false;
+  setup()
+    .then((fn) => {
+      if (cancelled) fn();
+      else cancel = fn;
+    })
+    .catch(console.error);
+  return () => {
+    cancelled = true;
+    cancel?.();
+  };
+}
+
+const NOT_AVAILABLE = Promise.resolve(null) as Promise<unknown>;
+const EMPTY_LIST = Promise.resolve([]) as Promise<unknown>;
+
+export function createTauriInvokeClient(): AppClient {
+  return {
+    system: {
+      health: () => invoke('system_health'),
+      getVersion: () => invoke('system_get_version'),
+      getLocale: () => invoke('system_get_locale'),
+      setLocale: (locale) => invoke('system_set_locale', { locale }),
+      getPlatform: () => invoke('system_get_platform'),
+      openExternal: (url) => invoke('system_open_external', { url }),
+      setPerformanceMode: (mode) => invoke('system_set_performance_mode', { mode }),
+      getMetrics: () => invoke('system_get_metrics'),
+    },
+
+    jobs: {
+      list: () => invoke('jobs_list'),
+      get: (jobId) => invoke('jobs_get', { jobId }),
+      cancel: (jobId) => invoke('jobs_cancel', { jobId }),
+      retry: (jobId) => invoke('jobs_retry', { jobId }),
+      onEvent: (handler) =>
+        asyncUnsub(() => listen<unknown>('jobs:event', (e) => handler(e.payload))),
+    },
+
+    ai: {
+      generate: (req) => invoke('ai_generate', { req }),
+      listModels: () => invoke('ai_list_models'),
+      pullModel: (model) => invoke('ai_pull_model', { model }),
+      unloadModel: (model) => invoke('ai_unload_model', { model }),
+      embed: (req) => invoke('ai_embed', { req }),
+      onStream: (handler) =>
+        asyncUnsub(() => listen<unknown>('ai:stream', (e) => handler(e.payload))),
+    },
+
+    documents: {
+      list: () => invoke('documents_list'),
+      import: (req) => invoke('documents_import', { req }),
+      remove: (id) => invoke('documents_remove', { id }),
+    },
+
+    search: {
+      hybrid: (req) => invoke('search_hybrid', { req }),
+    },
+
+    scrape: {
+      board: (req) => invoke('scrape_board', { req }),
+      url: (req) => invoke('scrape_url', { req }),
+      persistJob: (req) => invoke('scrape_persist_job', { req }),
+      listPostings: () => invoke('scrape_list_postings'),
+      clearPostings: () => invoke('scrape_clear_postings'),
+      listInteractions: (filter) => invoke('scrape_list_interactions', { filter }),
+      exportData: () => invoke('scrape_export_data'),
+      importData: () => invoke('scrape_import_data'),
+    },
+
+    match: {
+      resume: (req) => invoke('match_resume', { req }),
+    },
+
+    credentials: {
+      available: () => invoke('credentials_available'),
+      list: () => invoke('credentials_list'),
+      set: (req) => invoke('credentials_set', { req }),
+      remove: (boardId) => invoke('credentials_remove', { boardId }),
+    },
+
+    linkedin: {
+      connect: () => invoke('linkedin_connect'),
+      disconnect: () => invoke('linkedin_disconnect'),
+      getStatus: () => invoke('linkedin_get_status'),
+    },
+
+    boards: {
+      connect: (boardId) => invoke('boards_connect', { boardId }),
+      disconnect: (boardId) => invoke('boards_disconnect', { boardId }),
+      getStatus: (boardId) => invoke('boards_get_status', { boardId }),
+    },
+
+    privacy: {
+      signOutAll: () => invoke('privacy_sign_out_all'),
+      clearInteractions: () => invoke('privacy_clear_interactions'),
+    },
+
+    apply: {
+      start: (req) => invoke('apply_start', { req }),
+      catalog: () => invoke('apply_catalog'),
+    },
+
+    updater: {
+      check: () => NOT_AVAILABLE,
+      download: () => NOT_AVAILABLE,
+      install: () => NOT_AVAILABLE,
+      onStatus: (_handler) => () => {
+        /* Tauri updater plugin wired separately */
+      },
+    },
+
+    shortcuts: {
+      onCommandPalette: (handler) =>
+        asyncUnsub(() => listen('shortcut:command-palette', () => handler())),
+    },
+
+    resume: {
+      extractText: (req) => invoke('resume_extract_text', { req }),
+    },
+
+    support: {
+      exportDiagnostics: () => invoke('support_export_diagnostics'),
+      reloadAiRuntime: () => invoke('support_reload_ai_runtime'),
+      unloadAllModels: () => invoke('support_unload_all_models'),
+      resetModelConfiguration: () => invoke('support_reset_model_configuration'),
+      rebuildVectorIndexes: () => invoke('support_rebuild_vector_indexes'),
+      clearEmbeddingsCache: () => invoke('support_clear_embeddings_cache'),
+      resetVectorDatabase: () => invoke('support_reset_vector_database'),
+      clearOcrCache: () => invoke('support_clear_ocr_cache'),
+      reindexAllDocuments: () => invoke('support_reindex_all_documents'),
+      resetAllSessions: () => invoke('support_reset_all_sessions'),
+      clearScrapingQueue: () => invoke('support_clear_scraping_queue'),
+      copyEnvironmentDetails: () => invoke('support_copy_environment_details'),
+      copyAppVersion: () => invoke('support_copy_app_version'),
+      copySystemInfo: () => invoke('support_copy_system_info'),
+    },
+
+    conversations: {
+      getOrCreateConversation: () => invoke('conversations_get_or_create'),
+      loadMessages: (conversationId) => invoke('conversations_load_messages', { conversationId }),
+      saveMessage: (req) => invoke('conversations_save_message', { req }),
+    },
+
+    autopilot: {
+      list: () => EMPTY_LIST,
+      get: (_id) => NOT_AVAILABLE,
+      create: (_req) => NOT_AVAILABLE,
+      update: (_id, _req) => NOT_AVAILABLE,
+      remove: (_id) => NOT_AVAILABLE,
+      run: (_id) => NOT_AVAILABLE,
+      pause: (_id) => NOT_AVAILABLE,
+      resume: (_id) => NOT_AVAILABLE,
+    },
+  } satisfies AppClient;
+}

--- a/apps/tauri/src/tauri-client.ts
+++ b/apps/tauri/src/tauri-client.ts
@@ -173,5 +173,9 @@ export function createTauriInvokeClient(): AppClient {
       pause: (_id) => NOT_AVAILABLE,
       resume: (_id) => NOT_AVAILABLE,
     },
+
+    dialog: {
+      openFiles: (opts) => invoke('dialog_open_files', opts ?? {}),
+    },
   } satisfies AppClient;
 }

--- a/apps/tauri/tsconfig.json
+++ b/apps/tauri/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+    "paths": {
+      "@/*": ["../desktop/src/renderer/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/tauri/vite.config.ts
+++ b/apps/tauri/vite.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import { TanStackRouterVite } from '@tanstack/router-vite-plugin';
+import path from 'node:path';
+
+// Tauri expects a fixed port in dev mode.
+const TAURI_DEV_PORT = 5174;
+
+export default defineConfig({
+  // Point alias at the desktop renderer source so the same feature code,
+  // routes, components, and service hooks are reused without copying.
+  resolve: {
+    alias: { '@': path.resolve(__dirname, '../desktop/src/renderer') },
+  },
+  plugins: [
+    TanStackRouterVite({
+      routesDirectory: path.resolve(__dirname, '../desktop/src/renderer/routes'),
+      generatedRouteTree: path.resolve(__dirname, '../desktop/src/renderer/routeTree.gen.ts'),
+    }),
+    react(),
+    tailwindcss(),
+  ],
+  // Prevent Vite from obscuring Rust errors in the terminal.
+  clearScreen: false,
+  server: {
+    port: TAURI_DEV_PORT,
+    strictPort: true,
+    headers: {
+      // Mirrors the Electron CSP but permits Tauri IPC (tauri://) and Ollama.
+      'Content-Security-Policy': [
+        "default-src 'self' tauri: asset: https://asset.localhost",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: blob: asset: https://asset.localhost",
+        "font-src 'self' data: asset: https://asset.localhost",
+        "connect-src 'self' http://127.0.0.1:11434 http://127.0.0.1:* ws://127.0.0.1:* tauri: ipc: http://ipc.localhost",
+      ].join('; '),
+    },
+  },
+  build: {
+    // Tauri uses ES modules; suppress the 500 kB warning since the renderer
+    // is already structured this way in the Electron build.
+    target: 'esnext',
+    minify: false,
+    outDir: 'dist',
+  },
+});

--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -1,0 +1,307 @@
+# Architecture Status
+
+Maps every node in the final target architecture diagram
+(`low-resource-electron-tauri-architecture.md §20`) to its concrete code
+location and current implementation state.
+
+**Legend:** ✅ done · ⚠️ partial / stubbed · 🔲 future
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+  UI["Reusable React App<br/>routes/features/services"] --> Client["AppClient<br/>typed commands + job events"]
+
+  Client --> DesktopIPC["Electron IPC Adapter<br/>today"]
+  Client --> WebHTTP["Web HTTP Adapter<br/>future"]
+  Client --> TauriInvoke["Tauri Invoke Adapter<br/>later"]
+
+  DesktopIPC --> Shell["Thin Desktop Shell<br/>Electron now / Tauri later"]
+  TauriInvoke --> Shell
+
+  Shell --> Native["Native Shell Duties<br/>window, menu, tray, dialogs, updater, credentials"]
+  Shell --> RuntimeBroker["Runtime Broker<br/>start/stop/lazy health"]
+
+  RuntimeBroker --> Scraper["scraper-runtime<br/>sessions, cookies, browser logic, scraping"]
+  RuntimeBroker --> AI["ai-runtime<br/>optional, lazy, unloads on idle"]
+  RuntimeBroker --> Data["data runtime<br/>DB, vectors, documents"]
+
+  Scraper --> Providers["LinkedIn / Indeed / Xing<br/>provider adapters"]
+  Scraper --> SessionStore["Encrypted Session Artifacts<br/>cookies, metadata, status"]
+  Data --> Storage["Local DB + Vector Store"]
+  AI --> Ollama["Ollama / local model backend"]
+```
+
+---
+
+## Node Status
+
+### UI — Reusable React App
+
+**Status:** ✅
+
+**Where:**
+
+- Routes: `apps/desktop/src/renderer/routes/`
+- Features: `apps/desktop/src/renderer/features/`
+- Service hooks: `apps/desktop/src/renderer/services/`
+- UI primitives: `packages/ui/src/`
+
+**Notes:** All feature code is transport-neutral. No `window.api` calls in
+routes/features — every backend call goes through a service hook. The renderer
+source is reused verbatim by the Tauri spike via a Vite alias (`apps/tauri/`).
+
+---
+
+### AppClient — typed commands + job events
+
+**Status:** ✅
+
+**Where:**
+
+- Type definition: `apps/desktop/src/renderer/lib/app-client.ts`
+- Provider: `apps/desktop/src/renderer/providers/AppClientProvider.tsx`
+- IPC channels: `packages/shared/src/ipc/contracts.ts`
+
+**Notes:** `AppClient = Api` from the preload. Three adapters exist (see below).
+`AppClientProvider` accepts an optional `client` prop so any adapter can be
+injected without touching service hooks or feature components.
+
+---
+
+### Electron IPC Adapter
+
+**Status:** ✅
+
+**Where:** `apps/desktop/src/renderer/lib/app-client.ts` →
+`createDesktopIpcClient()` — returns `window.api` (set by the Electron preload)
+
+**Notes:** Production path. All IPC channels validated by Zod in
+`apps/desktop/src/main/ipc/router.ts`.
+
+---
+
+### Web HTTP Adapter
+
+**Status:** ⚠️ skeleton / documented
+
+**Where:** `apps/desktop/src/renderer/lib/web-http-client.ts` →
+`createWebHttpClient({ baseUrl, token })`
+
+**Notes:** Full `AppClient` implementation over `fetch` + `EventSource`.
+Every command routes to `POST /api/<namespace>/<method>`. Streaming channels
+use Server-Sent Events. The runtime server (`apps/scraper-runtime/` +
+future `apps/ai-runtime/`) exposes this REST surface. Not yet wired to a live
+backend — use `createMockClient()` in tests until the server is deployed.
+
+---
+
+### Tauri Invoke Adapter
+
+**Status:** ✅ (spike)
+
+**Where:** `apps/tauri/src/tauri-client.ts` → `createTauriInvokeClient()`
+
+**Notes:** Full `AppClient` implementation over `@tauri-apps/api` `invoke` /
+`listen`. Used by `apps/tauri/src/main.tsx` which loads the same React renderer
+via Vite alias. Real commands: `system_*`, `scrape_board`/`scrape_url` (proxy
+to sidecar), `dialog_open_files`. All other commands: stubs returning empty
+state. Parity built incrementally.
+
+---
+
+### Test / Mock Adapter
+
+**Status:** ✅
+
+**Where:** `apps/desktop/src/renderer/lib/mock-client.ts` → `createMockClient(overrides?)`
+
+**Notes:** Fully-stubbed `AppClient` for Vitest / Jest / Storybook. Accepts a
+deep-partial override so individual methods can be replaced per test.
+
+---
+
+### Thin Desktop Shell (Electron)
+
+**Status:** ✅
+
+**Where:** `apps/desktop/src/main/`
+
+**Notes:** Main entry in `index.ts` is intentionally thin — no AI, scraping,
+or indexing in main. GPU/rendering flags are guarded by `rollbackFlags.lowEndMode`
+(`rollback-flags.ts`). Window creation in `window.ts` supports low-end mode
+(disables vibrancy/transparency).
+
+---
+
+### Thin Desktop Shell (Tauri — spike)
+
+**Status:** ⚠️ spike
+
+**Where:** `apps/tauri/src-tauri/src/`
+
+**Notes:** Native menu, system tray, file dialog plugin all wired. Sidecar
+launched and port-discovered via stdout. Uses same React frontend as Electron
+shell. Not production-ready — keeps Electron as the production shell until
+parity is proven.
+
+---
+
+### Native Shell Duties
+
+| Duty               | Electron                           | Tauri spike                    |
+| ------------------ | ---------------------------------- | ------------------------------ |
+| Window management  | ✅ `window.ts`                     | ✅ `main.rs`                   |
+| App menu           | ✅ `menus.ts`                      | ✅ `main.rs` `build_app_menu`  |
+| System tray        | —                                  | ✅ `main.rs` `build_tray`      |
+| Native dialogs     | ✅ `IPC_CHANNELS.dialog.openFiles` | ✅ `dialog_open_files` command |
+| Auto-update        | ✅ `updater.ts`                    | 🔲 Tauri updater plugin        |
+| Credential storage | ✅ `credentials.ts` (keytar)       | 🔲 Tauri stronghold plugin     |
+
+---
+
+### Runtime Broker
+
+**Status:** ✅ (Electron) · ⚠️ stub (Tauri)
+
+**Where:** `packages/core/src/RuntimeManager` — registers runtimes (`ai`, `data`),
+starts them on-demand, stops all on shutdown.
+
+In `apps/desktop/src/main/bootstrap.ts`:
+
+- `runtimes.register(ai)` / `runtimes.register(data)`
+- `runtimes.start('data')` at bootstrap
+- `runtimes.start('ai')` on first AI job (lazy) or at startup when `AJH_EAGER_BOOT=1`
+- `runtimes.stop()` on `before-quit`
+
+**Rollback:** `AJH_EAGER_BOOT=1` forces all runtimes to start immediately.
+
+---
+
+### scraper-runtime — sessions, cookies, browser logic, scraping
+
+**Status:** ✅ in-process (Electron) · ⚠️ HTTP sidecar (stub, Tauri)
+
+**Where:**
+
+- Interface: `apps/desktop/src/main/scraper-runtime.ts` → `ScraperRuntimeClient`
+- In-process: `InProcessScraperRuntime` (default, production path)
+- HTTP sidecar entry: `apps/scraper-runtime/src/` → `POST /command` SSE protocol
+- Session managers: `apps/desktop/src/main/board-sessions/PersistentBoardSession.ts`
+- Browser controller: `apps/desktop/src/main/electron-browser-controller.ts`
+
+**Rollback:** `AJH_SCRAPER_MODE=in-process` forces the in-process fallback
+even when a utility-process or sidecar runtime becomes the default.
+
+---
+
+### Provider Adapters (LinkedIn / Indeed / Xing)
+
+**Status:** ✅ HTTP scrapers · ✅ browser-based scrapers
+
+**Where:** `packages/data/src/scraping/boards/`
+
+**Notes:** Each board has a scraper adapter. HTTP scrapers work in the
+standalone Node.js sidecar. Browser-based scrapers require the
+`ElectronBrowserController` and stay in-process or in a dedicated browser
+sidecar.
+
+---
+
+### Encrypted Session Artifacts (cookies, metadata, status)
+
+**Status:** ✅
+
+**Where:** `apps/desktop/src/main/board-sessions/PersistentBoardSession.ts`
+
+**Notes:** One `PersistentBoardSession` per board using Electron's
+`session.fromPartition("persist:<boardId>")`. Chromium stores cookies on disk.
+`CredentialStore` (`credentials.ts`) encrypts credentials via `keytar`.
+
+---
+
+### ai-runtime — optional, lazy, unloads on idle
+
+**Status:** ✅
+
+**Where:** `packages/ai/src/` → `AiRuntime`
+
+**Notes:**
+
+- Registered with `RuntimeManager` but not started at bootstrap.
+- Started on first `ai.generate` or `ai.embed` job (`runtimes.start('ai')`).
+- Idle timeout: 10 min (balanced), 30 min (performance), 3 min (low-memory).
+  Controlled via `setPerformanceMode` IPC → `router.ts`.
+- `AJH_EAGER_BOOT=1` starts AI at bootstrap for debugging.
+
+---
+
+### Data runtime — DB, vectors, documents
+
+**Status:** ✅
+
+**Where:** `packages/data/src/` → `DataRuntime`
+
+**Notes:**
+
+- Opened at bootstrap (SQLite needed immediately for autopilot scheduler).
+- LanceDB (vector store) opened lazily on first search/embed.
+- `AJH_LOW_END_MODE=1` sets job concurrency to 1, reducing DB write pressure.
+
+---
+
+### Storage — Local DB + Vector Store
+
+**Status:** ✅
+
+**Where:**
+
+- SQLite (NeDB): `packages/data/src/db/` — job postings, interactions,
+  autopilots, conversations
+- LanceDB: `packages/data/src/vector/lancedb.ts` — embeddings + vector search
+
+---
+
+### Ollama — local model backend
+
+**Status:** ✅
+
+**Where:** `packages/ai/src/` → `AiRuntime` → Ollama client
+
+**Notes:** Ollama runs as an independent OS process. `AiRuntime` connects to
+`http://127.0.0.1:11434`. Models are pulled on demand via `ai.pullModel` IPC.
+Idle unload is triggered by the `AiRuntime` idle timer.
+
+---
+
+## Verdict: where we are vs. the target
+
+```
+✅  UI is transport-neutral and reusable across all three shells
+✅  AppClient abstraction complete — three adapters (IPC, Tauri, HTTP skeleton)
+✅  Electron shell is thin — no AI/scraping/indexing in main process
+✅  RuntimeBroker (RuntimeManager) controls start/stop/lazy health
+✅  Scraper runtime behind a stable interface with rollback env var
+✅  AI runtime lazy-starts and unloads on idle
+✅  Data runtime opens DB/vector only when needed
+✅  Rollback flags for every phase (rollback-flags.ts)
+✅  Tauri spike: same frontend, sidecar protocol proven, native shell complete
+⚠️  Web HTTP adapter: skeleton in place, runtime server not yet deployed
+⚠️  Tauri: spike only — Electron stays production until parity proven
+🔲  Tauri auto-updater (Tauri updater plugin)
+🔲  Tauri credential storage (Tauri stronghold plugin)
+🔲  HTTP scraper adapters ported from @ajh/data to the sidecar
+🔲  apps/web/ entry point using createWebHttpClient()
+```
+
+The architectural verdict from the document holds:
+
+> Keep Electron for now, but make it boring.
+> The highest-value move is making Electron a replaceable host around runtimes
+> that start late, stop when idle, and can eventually run as Tauri sidecars or
+> web backends.
+
+That path is now in place. Each remaining item above is an independent,
+reversible step — none require touching the React feature code.

--- a/packages/shared/src/ipc/contracts.ts
+++ b/packages/shared/src/ipc/contracts.ts
@@ -522,6 +522,12 @@ export const IPC_CHANNELS = {
   shortcuts: {
     onCommandPalette: 'shortcut:command-palette',
   },
+
+  dialog: {
+    /** Open a native file picker — implemented by Electron dialog on desktop,
+     *  Tauri dialog plugin in the Tauri shell. */
+    openFiles: 'dialog:open-files',
+  },
 } as const;
 
 export type IpcChannel =

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -28,7 +28,14 @@ export const AiGenerateRequestSchema = z.object({
 });
 
 export const DocumentImportRequestSchema = z.object({
-  path: z.string().min(1),
+  /** Original filename — used to derive title and detect format. */
+  name: z.string().min(1).max(512),
+  /** Raw file bytes — works in browser (FileReader), Electron, and Tauri alike. */
+  bytes: z
+    .instanceof(Uint8Array)
+    .refine((b) => b.byteLength > 0 && b.byteLength <= 50 * 1024 * 1024, {
+      message: 'document must be between 1 byte and 50 MB',
+    }),
   title: z.string().optional(),
   locale: LocaleSchema.optional(),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.19
       tsx:
         specifier: ^4.0.0
         version: 4.22.3
@@ -2197,6 +2200,9 @@ packages:
 
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
@@ -7718,6 +7724,10 @@ snapshots:
   '@types/ms@2.1.0': {}
 
   '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   apps/desktop:
     dependencies:
@@ -164,10 +164,10 @@ importers:
         version: 1.60.0
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@tanstack/router-vite-plugin':
         specifier: ^1.167.6
-        version: 1.167.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 1.167.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -176,7 +176,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       electron:
         specifier: ^42.1.0
         version: 42.1.0
@@ -185,7 +185,7 @@ importers:
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       electron-vite:
         specifier: ^6.0.0-beta.1
-        version: 6.0.0-beta.1(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.0.0-beta.1(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -194,10 +194,23 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  apps/scraper-runtime:
+    dependencies:
+      '@ajh/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+    devDependencies:
+      tsx:
+        specifier: ^4.0.0
+        version: 4.22.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   apps/tauri:
     dependencies:
@@ -210,7 +223,7 @@ importers:
         version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@tanstack/react-query':
         specifier: ^5.100.11
         version: 5.100.11(react@19.2.6)
@@ -219,7 +232,7 @@ importers:
         version: 1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-vite-plugin':
         specifier: ^1.167.6
-        version: 1.167.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 1.167.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@tauri-apps/cli':
         specifier: ^2.11.2
         version: 2.11.2
@@ -231,7 +244,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -243,7 +256,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   packages/ai:
     dependencies:
@@ -268,7 +281,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -293,7 +306,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/data:
     dependencies:
@@ -345,7 +358,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/prompts:
     devDependencies:
@@ -354,7 +367,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/shared:
     dependencies:
@@ -367,7 +380,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -389,10 +402,10 @@ importers:
         version: 10.4.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: ^10.4.0
-        version: 10.4.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 10.4.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -401,7 +414,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -422,7 +435,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   packages/workers:
     dependencies:
@@ -438,7 +451,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
 packages:
 
@@ -738,8 +751,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -750,8 +775,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -762,8 +799,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -774,8 +823,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -786,8 +847,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -798,8 +871,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -810,8 +895,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -822,8 +919,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -834,8 +943,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -846,8 +967,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -858,8 +991,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -870,8 +1015,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -882,8 +1039,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3076,6 +3245,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5505,6 +5679,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
@@ -6406,79 +6585,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0(jiti@2.7.0))':
@@ -6535,11 +6792,11 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -7053,23 +7310,24 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/builder-vite@10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@storybook/builder-vite@10.4.0(esbuild@0.28.0)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@storybook/csf-plugin': 10.4.0(esbuild@0.28.0)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       storybook: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@storybook/csf-plugin@10.4.0(esbuild@0.28.0)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       storybook: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       unplugin: 2.3.11
     optionalDependencies:
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      esbuild: 0.28.0
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -7087,11 +7345,11 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@storybook/react-vite@10.4.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@storybook/react-vite@10.4.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0
-      '@storybook/builder-vite': 10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@storybook/builder-vite': 10.4.0(esbuild@0.28.0)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@storybook/react': 10.4.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -7101,7 +7359,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tsconfig-paths: 4.2.0
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -7196,12 +7454,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@tanstack/history@1.162.0': {}
 
@@ -7248,7 +7506,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -7265,7 +7523,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7283,9 +7541,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-vite-plugin@1.167.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@tanstack/router-vite-plugin@1.167.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
-      '@tanstack/router-plugin': 1.168.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@tanstack/router-plugin': 1.168.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@tanstack/react-router'
@@ -7600,10 +7858,10 @@ snapshots:
       '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
     dependencies:
@@ -7617,7 +7875,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -7636,13 +7894,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8607,7 +8865,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@6.0.0-beta.1(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)):
+  electron-vite@6.0.0-beta.1(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -8615,7 +8873,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8820,6 +9078,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -11363,6 +11650,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel@0.0.6: {}
 
   turbo@2.9.14:
@@ -11541,7 +11834,7 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0):
+  vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -11550,14 +11843,16 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.9.0
+      esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -11574,7 +11869,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,52 @@ importers:
         specifier: ^4.1.6
         version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
 
+  apps/tauri:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.11.0
+        version: 2.11.0
+    devDependencies:
+      '@ajh/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@tanstack/react-query':
+        specifier: ^5.100.11
+        version: 5.100.11(react@19.2.6)
+      '@tanstack/react-router':
+        specifier: ^1.167.6
+        version: 1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-vite-plugin':
+        specifier: ^1.167.6
+        version: 1.167.6(@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@tauri-apps/cli':
+        specifier: ^2.11.2
+        version: 2.11.2
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0))
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.13
+        version: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)(yaml@2.9.0)
+
   packages/ai:
     dependencies:
       '@ajh/core':
@@ -1796,6 +1842,85 @@ packages:
   '@tanstack/virtual-file-routes@1.162.0':
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
     engines: {node: '>=20.19'}
+
+  '@tauri-apps/api@2.11.0':
+    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
+
+  '@tauri-apps/cli-darwin-arm64@2.11.2':
+    resolution: {integrity: sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tauri-apps/cli-darwin-x64@2.11.2':
+    resolution: {integrity: sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
+    resolution: {integrity: sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
+    resolution: {integrity: sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
+    resolution: {integrity: sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
+    resolution: {integrity: sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
+    resolution: {integrity: sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-x64-musl@2.11.2':
+    resolution: {integrity: sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
+    resolution: {integrity: sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
+    resolution: {integrity: sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
+    resolution: {integrity: sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tauri-apps/cli@2.11.2':
+    resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
+    engines: {node: '>= 10'}
+    hasBin: true
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -7172,6 +7297,55 @@ snapshots:
   '@tanstack/store@0.9.3': {}
 
   '@tanstack/virtual-file-routes@1.162.0': {}
+
+  '@tauri-apps/api@2.11.0': {}
+
+  '@tauri-apps/cli-darwin-arm64@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-darwin-x64@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-musl@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
+    optional: true
+
+  '@tauri-apps/cli@2.11.2':
+    optionalDependencies:
+      '@tauri-apps/cli-darwin-arm64': 2.11.2
+      '@tauri-apps/cli-darwin-x64': 2.11.2
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.2
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.2
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-x64-musl': 2.11.2
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@testing-library/dom@10.4.0':
     dependencies:


### PR DESCRIPTION
## Summary

- **Phase 6 — Tauri spike**: minimal Tauri v2 shell loading the same React renderer via Vite alias; `TauriInvokeClient` implementing `AppClient` over `@tauri-apps/api`; native menu, tray, file dialog; scraper sidecar wired with HTTP/SSE protocol proof
- **Rollback strategy (§15)**: `rollback-flags.ts` centralises `AJH_LOW_END_MODE`, `AJH_EAGER_BOOT`, and `AJH_SCRAPER_MODE` — each reverts one architectural phase without touching other code
- **Frontend web portability (§18)**: `DocumentImportRequest` schema migrated from `path:string` to `name+bytes` (transport-neutral); `createMockClient()` for Vitest/Storybook; stale Electron-specific language removed
- **Tauri migration strategy (§19)**: `apps/scraper-runtime/` Node.js HTTP sidecar proving the `POST /command → SSE ScraperEvent` protocol end-to-end; Tauri `scrape_board`/`scrape_url` proxy to sidecar via `reqwest`
- **Final architecture (§20)**: `createWebHttpClient()` completes the three-adapter picture (IPC ✅, Tauri invoke ✅, web HTTP ⚠️ skeleton); `docs/ARCHITECTURE_STATUS.md` maps every diagram node to code location and implementation state

## Test plan

- [ ] `pnpm typecheck` passes across all packages
- [ ] `pnpm lint:strict` passes with 0 warnings
- [ ] Electron desktop app boots and functions normally (no regressions)
- [ ] `AJH_LOW_END_MODE=1` starts the app without GPU switches and with concurrency=1
- [ ] `AJH_SCRAPER_MODE=in-process` logs the mode selection and uses `InProcessScraperRuntime`
- [ ] `apps/tauri` Vite frontend builds (`pnpm --filter @ajh/tauri build:frontend`)
- [ ] `apps/scraper-runtime` Node.js sidecar starts and announces port on stdout (`pnpm --filter @ajh/scraper-runtime dev`)
- [ ] `docs/ARCHITECTURE_STATUS.md` renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)