### PR TITLE
fix: tauri titlebar — decorations false + data-tauri-drag-region

### DIFF
--- a/apps/desktop/src/renderer/components/layout/Titlebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Titlebar.tsx
@@ -15,6 +15,7 @@ export function Titlebar() {
     <div
       className="app-drag relative flex h-10 items-center justify-between px-4 select-none"
       style={{ paddingLeft: platform === 'darwin' ? 80 : 16 }}
+      data-tauri-drag-region
     >
       <div className="flex items-center gap-2 text-xs font-medium text-foreground/70">
         <Sparkles size={14} className="opacity-80" />

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -50,7 +50,9 @@ html[data-performance-mode='low-memory'] body {
   background: #07060f;
 }
 
-/* ── Electron drag regions ───────────────────────────────────────────────── */
+/* ── Window drag regions (Electron + Tauri) ──────────────────────────────── */
+/* Electron: -webkit-app-region on the element is sufficient.               */
+/* Tauri:    also requires data-tauri-drag-region on the element (Windows).  */
 .app-drag {
   -webkit-app-region: drag;
 }

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -20,8 +20,9 @@
         "minWidth": 900,
         "minHeight": 600,
         "center": true,
-        "decorations": true,
-        "resizable": true
+        "decorations": false,
+        "resizable": true,
+        "backgroundColor": "#0a0a14"
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary

Fixes the P0 titlebar blocker identified in the Phase F gap analysis.

- `tauri.conf.json`: `decorations: false` removes the OS-drawn titlebar so the custom renderer chrome takes over (matches Electron's `titleBarStyle: 'hidden'`); adds `backgroundColor: "#0a0a14"` so there's no white flash before the WebView paints
- `Titlebar.tsx`: adds `data-tauri-drag-region` attribute — Tauri requires this on Windows in addition to `-webkit-app-region: drag` for the drag region to work
- `globals.css`: updates the stale "Electron drag regions" comment to reflect the dual Electron + Tauri mechanism

## Test plan

- [ ] Tauri app opens with no OS titlebar (custom renderer titlebar visible)
- [ ] Window can be dragged by clicking the titlebar area
- [ ] Command palette button is NOT draggable (has `app-no-drag`)
- [ ] macOS: padding left is 80 px (space for traffic lights area, even if not shown)
- [ ] Electron app unchanged — `data-tauri-drag-region` is a no-op attribute in Electron WebContents

🤖 Generated with [Claude Code](https://claude.com/claude-code)