### PR TITLE
feat: autopilot json-file store and tauri commands (p0 blocker)

### DIFF
--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 # HTTP client for proxying scraper commands to the sidecar process.
 reqwest = { version = "0.12", features = ["json"], default-features = false }
 tokio = { version = "1", features = ["time"] }
+uuid = { version = "1", features = ["v4"] }
 # OS-native secret storage: DPAPI (Windows), Keychain (macOS), libsecret (Linux).
 # Same underlying primitives as Electron's safeStorage.
 keyring = { version = "3", features = ["windows-native", "apple-native", "sync-secret-service"] }

--- a/apps/tauri/src-tauri/src/autopilot.rs
+++ b/apps/tauri/src-tauri/src/autopilot.rs
@@ -1,0 +1,244 @@
+/// AutopilotStore — JSON-file-backed CRUD for Autopilot records.
+///
+/// Mirrors packages/data/src/autopilot/store.ts (NeDB) with the same public
+/// API surface so the renderer's existing autopilot hooks work unchanged.
+///
+/// Records are persisted to <dataDir>/autopilots.json as a flat JSON array.
+/// All field names are serialised in camelCase to match the TypeScript schema
+/// (`#[serde(rename_all = "camelCase")]`).
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ── Data model ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutopilotTarget {
+    pub board: String,
+    pub query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_type: Option<String>,
+    pub pages: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_filter: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutopilotFilter {
+    pub min_match_score: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keywords: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclude_keywords: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum AutopilotStatus {
+    Active,
+    Paused,
+    Archived,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Autopilot {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub name: String,
+    pub status: AutopilotStatus,
+    pub target: AutopilotTarget,
+    pub filter: AutopilotFilter,
+    pub action: String,
+    pub schedule: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resume_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cover_letter: Option<String>,
+    pub auto_submit: bool,
+    pub total_found: u32,
+    pub total_applied: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_run_at: Option<u64>,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+// ── Store ─────────────────────────────────────────────────────────────────────
+
+pub struct AutopilotStore {
+    data_file: PathBuf,
+    cache: Mutex<Option<HashMap<String, Autopilot>>>,
+}
+
+impl AutopilotStore {
+    pub fn new(data_dir: &PathBuf) -> Self {
+        std::fs::create_dir_all(data_dir).ok();
+        Self {
+            data_file: data_dir.join("autopilots.json"),
+            cache: Mutex::new(None),
+        }
+    }
+
+    // ── CRUD ──────────────────────────────────────────────────────────────────
+
+    pub fn list(&self) -> Vec<Autopilot> {
+        let map = self.load();
+        let mut items: Vec<Autopilot> = map.into_values().collect();
+        items.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        items
+    }
+
+    pub fn get(&self, id: &str) -> Option<Autopilot> {
+        self.load().remove(id)
+    }
+
+    pub fn create(&self, input: serde_json::Value) -> Autopilot {
+        let now = now_ms();
+        let ap = Autopilot {
+            id: Uuid::new_v4().to_string(),
+            name: str_field(&input, "name"),
+            status: AutopilotStatus::Active,
+            target: serde_json::from_value(input["target"].clone()).unwrap_or_else(|_| {
+                AutopilotTarget {
+                    board: String::new(),
+                    query: String::new(),
+                    location: None,
+                    work_type: None,
+                    pages: 1,
+                    date_filter: None,
+                }
+            }),
+            filter: serde_json::from_value(input["filter"].clone()).unwrap_or_else(|_| {
+                AutopilotFilter {
+                    min_match_score: 50.0,
+                    keywords: None,
+                    exclude_keywords: None,
+                }
+            }),
+            action: str_field(&input, "action"),
+            schedule: str_field(&input, "schedule"),
+            resume_text: input["resumeText"].as_str().map(String::from),
+            cover_letter: input["coverLetter"].as_str().map(String::from),
+            auto_submit: input["autoSubmit"].as_bool().unwrap_or(false),
+            total_found: 0,
+            total_applied: 0,
+            last_run_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        let mut map = self.load();
+        map.insert(ap.id.clone(), ap.clone());
+        self.save(map);
+        ap
+    }
+
+    pub fn update(&self, id: &str, patch: serde_json::Value) -> Option<Autopilot> {
+        let mut map = self.load();
+        let ap = map.get_mut(id)?;
+        ap.updated_at = now_ms();
+        if let Some(v) = patch.get("name").and_then(|v| v.as_str()) {
+            ap.name = v.to_string();
+        }
+        if let Some(v) = patch.get("status").and_then(|v| v.as_str()) {
+            ap.status = match v {
+                "paused" => AutopilotStatus::Paused,
+                "archived" => AutopilotStatus::Archived,
+                _ => AutopilotStatus::Active,
+            };
+        }
+        if let Ok(t) = serde_json::from_value::<AutopilotTarget>(patch["target"].clone()) {
+            ap.target = t;
+        }
+        if let Ok(f) = serde_json::from_value::<AutopilotFilter>(patch["filter"].clone()) {
+            ap.filter = f;
+        }
+        if let Some(v) = patch.get("action").and_then(|v| v.as_str()) {
+            ap.action = v.to_string();
+        }
+        if let Some(v) = patch.get("schedule").and_then(|v| v.as_str()) {
+            ap.schedule = v.to_string();
+        }
+        if let Some(v) = patch.get("resumeText").and_then(|v| v.as_str()) {
+            ap.resume_text = Some(v.to_string());
+        }
+        if let Some(v) = patch.get("coverLetter").and_then(|v| v.as_str()) {
+            ap.cover_letter = Some(v.to_string());
+        }
+        if let Some(v) = patch.get("autoSubmit").and_then(|v| v.as_bool()) {
+            ap.auto_submit = v;
+        }
+        let result = ap.clone();
+        self.save(map);
+        Some(result)
+    }
+
+    pub fn remove(&self, id: &str) {
+        let mut map = self.load();
+        map.remove(id);
+        self.save(map);
+    }
+
+    pub fn set_status(&self, id: &str, status: AutopilotStatus) {
+        let mut map = self.load();
+        if let Some(ap) = map.get_mut(id) {
+            ap.status = status;
+            ap.updated_at = now_ms();
+        }
+        self.save(map);
+    }
+
+    // ── Persistence ───────────────────────────────────────────────────────────
+
+    fn load(&self) -> HashMap<String, Autopilot> {
+        let mut guard = self.cache.lock().unwrap();
+        if let Some(ref c) = *guard {
+            return c.clone();
+        }
+        let map: HashMap<String, Autopilot> = std::fs::read_to_string(&self.data_file)
+            .ok()
+            .and_then(|s| serde_json::from_str::<Vec<Autopilot>>(&s).ok())
+            .unwrap_or_default()
+            .into_iter()
+            .map(|ap| (ap.id.clone(), ap))
+            .collect();
+        *guard = Some(map.clone());
+        map
+    }
+
+    fn save(&self, map: HashMap<String, Autopilot>) {
+        let list: Vec<&Autopilot> = {
+            let mut v: Vec<&Autopilot> = map.values().collect();
+            v.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+            v
+        };
+        if let Ok(json) = serde_json::to_string_pretty(&list) {
+            std::fs::write(&self.data_file, json).ok();
+        }
+        *self.cache.lock().unwrap() = Some(map);
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn str_field(v: &serde_json::Value, key: &str) -> String {
+    v.get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}

--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -10,6 +10,7 @@
 use std::sync::Mutex;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Emitter, Manager};
+use crate::autopilot::{AutopilotStatus, AutopilotStore};
 use crate::credentials::CredentialStore;
 use crate::jobs::JobTracker;
 use crate::postings::{InteractionRecord, InteractionStore, PostingsCache};
@@ -749,6 +750,100 @@ pub fn support_copy_system_info() -> Value {
 }
 
 // ── Conversations ────────────────────────────────────────────────────────────
+
+// ── Autopilot ─────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn autopilot_list(app: AppHandle) -> Value {
+    let binding = app.state::<Mutex<AutopilotStore>>();
+    let list = binding.lock().unwrap().list();
+    json!(list)
+}
+
+#[tauri::command]
+pub fn autopilot_get(app: AppHandle, autopilot_id: String) -> Value {
+    let binding = app.state::<Mutex<AutopilotStore>>();
+    let ap = binding.lock().unwrap().get(&autopilot_id);
+    json!(ap)
+}
+
+#[tauri::command]
+pub fn autopilot_create(app: AppHandle, req: Value) -> Value {
+    let store = app.state::<Mutex<AutopilotStore>>();
+    let ap = store.lock().unwrap().create(req);
+    json!(ap)
+}
+
+#[tauri::command]
+pub fn autopilot_update(app: AppHandle, autopilot_id: String, req: Value) -> Value {
+    let binding = app.state::<Mutex<AutopilotStore>>();
+    let ap = binding.lock().unwrap().update(&autopilot_id, req);
+    json!(ap)
+}
+
+#[tauri::command]
+pub fn autopilot_remove(app: AppHandle, autopilot_id: String) -> Value {
+    let store = app.state::<Mutex<AutopilotStore>>();
+    store.lock().unwrap().remove(&autopilot_id);
+    json!(null)
+}
+
+#[tauri::command]
+pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
+    let target = {
+        let store = app.state::<Mutex<AutopilotStore>>();
+        let guard = store.lock().unwrap();
+        guard.get(&autopilot_id).map(|ap| ap.target.clone())
+    };
+
+    let Some(target) = target else {
+        return json!({ "error": format!("autopilot not found: {autopilot_id}") });
+    };
+
+    // Proxy to the sidecar as a scrape.board job — the result is tracked
+    // via JobTracker so the renderer's job list updates in real time.
+    let Some(port) = sidecar_port(&app) else {
+        return json!({ "error": "scraper sidecar not ready" });
+    };
+
+    let job_id = uuid_v4();
+    app.state::<Mutex<JobTracker>>()
+        .lock()
+        .unwrap()
+        .start(&job_id, "autopilot.run");
+
+    let payload = serde_json::json!({
+        "board": target.board,
+        "query": target.query,
+        "location": target.location,
+        "pages": target.pages,
+        "dateFilter": target.date_filter,
+    });
+    let cmd = serde_json::json!({ "kind": "scrape.board", "jobId": job_id, "payload": payload });
+
+    let job_id_ret = job_id.clone();
+    tauri::async_runtime::spawn(async move {
+        post_sidecar_command(&app, port, &cmd, &job_id).await.ok();
+    });
+
+    json!({ "jobId": job_id_ret })
+}
+
+#[tauri::command]
+pub fn autopilot_pause(app: AppHandle, autopilot_id: String) -> Value {
+    let store = app.state::<Mutex<AutopilotStore>>();
+    store.lock().unwrap().set_status(&autopilot_id, AutopilotStatus::Paused);
+    json!(null)
+}
+
+#[tauri::command]
+pub fn autopilot_resume(app: AppHandle, autopilot_id: String) -> Value {
+    let store = app.state::<Mutex<AutopilotStore>>();
+    store.lock().unwrap().set_status(&autopilot_id, AutopilotStatus::Active);
+    json!(null)
+}
+
+// ── Conversations ─────────────────────────────────────────────────────────────
 
 #[tauri::command]
 pub fn conversations_get_or_create() -> Value {

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents a terminal window from appearing on Windows in release builds.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod autopilot;
 mod commands;
 mod credentials;
 mod jobs;
@@ -14,6 +15,7 @@ use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Manager};
 
+use autopilot::AutopilotStore;
 use credentials::CredentialStore;
 use jobs::JobTracker;
 use postings::{InteractionStore, PostingsCache};
@@ -111,6 +113,7 @@ fn main() {
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default()).join(".ajh")
             });
 
+            app.manage(Mutex::new(AutopilotStore::new(&data_dir)));
             app.manage(Mutex::new(CredentialStore::new(&data_dir)));
             app.manage(Mutex::new(JobTracker::default()));
             app.manage(Mutex::new(PostingsCache::default()));
@@ -217,6 +220,15 @@ fn main() {
             commands::conversations_save_message,
             // native dialogs
             commands::dialog_open_files,
+            // autopilot
+            commands::autopilot_list,
+            commands::autopilot_get,
+            commands::autopilot_create,
+            commands::autopilot_update,
+            commands::autopilot_remove,
+            commands::autopilot_run,
+            commands::autopilot_pause,
+            commands::autopilot_resume,
             // updater
             updater::updater_check,
             updater::updater_download,

--- a/apps/tauri/src/tauri-client.ts
+++ b/apps/tauri/src/tauri-client.ts
@@ -33,9 +33,6 @@ function asyncUnsub(setup: () => Promise<() => void>): () => void {
   };
 }
 
-const NOT_AVAILABLE = Promise.resolve(null) as Promise<unknown>;
-const EMPTY_LIST = Promise.resolve([]) as Promise<unknown>;
-
 export function createTauriInvokeClient(): AppClient {
   return {
     system: {
@@ -163,14 +160,14 @@ export function createTauriInvokeClient(): AppClient {
     },
 
     autopilot: {
-      list: () => EMPTY_LIST,
-      get: (_id) => NOT_AVAILABLE,
-      create: (_req) => NOT_AVAILABLE,
-      update: (_id, _req) => NOT_AVAILABLE,
-      remove: (_id) => NOT_AVAILABLE,
-      run: (_id) => NOT_AVAILABLE,
-      pause: (_id) => NOT_AVAILABLE,
-      resume: (_id) => NOT_AVAILABLE,
+      list: () => invoke('autopilot_list'),
+      get: (autopilotId) => invoke('autopilot_get', { autopilotId }),
+      create: (req) => invoke('autopilot_create', { req }),
+      update: (autopilotId, req) => invoke('autopilot_update', { autopilotId, req }),
+      remove: (autopilotId) => invoke('autopilot_remove', { autopilotId }),
+      run: (autopilotId) => invoke('autopilot_run', { autopilotId }),
+      pause: (autopilotId) => invoke('autopilot_pause', { autopilotId }),
+      resume: (autopilotId) => invoke('autopilot_resume', { autopilotId }),
     },
 
     dialog: {


### PR DESCRIPTION
## Summary

Implements the P0 autopilot blocker from the Phase F gap analysis. The autopilot route was loading but all 8 CRUD commands returned `NOT_AVAILABLE` errors.

- **`autopilot.rs`** — `AutopilotStore` backed by `<dataDir>/autopilots.json`; full CRUD with camelCase serialisation matching the TypeScript `Autopilot` schema; target/filter nested structs deserialise directly from the renderer payload
- **`commands.rs`** — 8 autopilot Tauri commands; `autopilot_run` proxies to the sidecar as a `scrape.board` job so the renderer's job list shows real-time progress
- **`main.rs`** — `AutopilotStore` registered in managed state
- **`Cargo.toml`** — `uuid v4` for `_id` generation
- **`tauri-client.ts`** — all 8 autopilot stubs replaced with real `invoke` calls; unused `NOT_AVAILABLE`/`EMPTY_LIST` constants removed

## Test plan

- [ ] `cargo check` passes with 0 errors
- [ ] `pnpm typecheck` + `pnpm lint:strict` pass clean
- [ ] Autopilot page loads and list is empty (no crash)
- [ ] Create autopilot → persisted to `~/.ajh/autopilots.json`
- [ ] Edit / delete autopilot works
- [ ] Run autopilot → job appears in job list with sidecar scrape progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)