### PR TITLE
feat: resume text extraction via sidecar (p0 blocker)

### DIFF
--- a/apps/scraper-runtime/src/engine.ts
+++ b/apps/scraper-runtime/src/engine.ts
@@ -10,7 +10,12 @@
  *  - Clean shutdown: close the browser and cancel running jobs on exit.
  */
 import { createLogger } from '@ajh/core';
-import { BrowserController, ScraperRegistry } from '@ajh/data';
+import {
+  BrowserController,
+  extractDocxFromBytes,
+  extractPdfFromBytes,
+  ScraperRegistry,
+} from '@ajh/data';
 import type { JobPosting } from '@ajh/shared';
 
 import type { FileCredentialStore } from './credentials.js';
@@ -187,6 +192,29 @@ export class ScraperEngine {
   disconnectBoard(boardId: string): void {
     this.loginManager.disconnect(boardId);
     logger.info({ boardId }, 'board disconnected');
+  }
+
+  // ── Text extraction ───────────────────────────────────────────────────────
+
+  /**
+   * Extract plain text from a document file (PDF, DOCX, TXT, MD).
+   * Bytes are passed as base64 to stay within the JSON protocol.
+   */
+  async extractText(name: string, bytesBase64: string): Promise<{ text: string }> {
+    const bytes = new Uint8Array(Buffer.from(bytesBase64, 'base64'));
+    const ext = name.toLowerCase().split('.').pop() ?? '';
+
+    if (ext === 'pdf') {
+      const { text } = await extractPdfFromBytes(bytes);
+      return { text };
+    }
+    if (ext === 'docx') {
+      return extractDocxFromBytes(bytes);
+    }
+    if (ext === 'txt' || ext === 'md' || ext === 'markdown') {
+      return { text: Buffer.from(bytes).toString('utf-8').trim() };
+    }
+    throw new Error(`unsupported file type: .${ext}`);
   }
 
   // ── Shutdown ───────────────────────────────────────────────────────────────

--- a/apps/scraper-runtime/src/protocol.ts
+++ b/apps/scraper-runtime/src/protocol.ts
@@ -35,6 +35,7 @@ export type ScraperCommand =
   | { kind: 'open.login'; boardId: string }
   | { kind: 'board.status'; boardId: string }
   | { kind: 'board.disconnect'; boardId: string }
+  | { kind: 'extract.text'; jobId: string; payload: { name: string; bytesBase64: string } }
   | { kind: 'health' }
   | { kind: 'catalog' };
 

--- a/apps/scraper-runtime/src/server.ts
+++ b/apps/scraper-runtime/src/server.ts
@@ -117,6 +117,17 @@ async function handleCommand(
       break;
     }
 
+    case 'extract.text': {
+      const { jobId, payload } = cmd;
+      try {
+        const result = await engine.extractText(payload.name, payload.bytesBase64);
+        sendEvent(res, { kind: 'done', jobId, result });
+      } catch (err) {
+        sendEvent(res, { kind: 'error', jobId, message: String(err) });
+      }
+      break;
+    }
+
     case 'health': {
       const health: ScraperRuntimeHealth = { ...engine.health(), port: _port };
       sendEvent(res, { kind: 'health.reply', health });

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1"
 reqwest = { version = "0.12", features = ["json"], default-features = false }
 tokio = { version = "1", features = ["time"] }
 uuid = { version = "1", features = ["v4"] }
+base64 = "0.22"
 # OS-native secret storage: DPAPI (Windows), Keychain (macOS), libsecret (Linux).
 # Same underlying primitives as Electron's safeStorage.
 keyring = { version = "3", features = ["windows-native", "apple-native", "sync-secret-service"] }

--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -672,9 +672,43 @@ pub async fn apply_catalog(app: AppHandle) -> Value {
 
 // ── Resume ───────────────────────────────────────────────────────────────────
 
+/// Extract plain text from a resume file (PDF, DOCX, TXT, MD).
+///
+/// The renderer passes `{ name: string, bytes: Uint8Array }`.
+/// Bytes are re-encoded as base64 before sending to the sidecar because the
+/// sidecar protocol is JSON-over-HTTP and binary data needs encoding.
 #[tauri::command]
-pub fn resume_extract_text(_req: Value) -> Value {
-    json!({ "error": "Resume extraction not yet available in Tauri spike" })
+pub async fn resume_extract_text(app: AppHandle, req: Value) -> Value {
+    let Some(port) = sidecar_port(&app) else {
+        return json!({ "error": "scraper sidecar not ready" });
+    };
+
+    let name = req.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
+
+    // Bytes arrive as a JSON array of integers (Tauri serialises Uint8Array).
+    let bytes_b64 = match req.get("bytes") {
+        Some(serde_json::Value::Array(arr)) => {
+            let bytes: Vec<u8> = arr
+                .iter()
+                .filter_map(|v| v.as_u64().map(|n| n as u8))
+                .collect();
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(&bytes)
+        }
+        _ => return json!({ "error": "bytes field missing or invalid" }),
+    };
+
+    let job_id = uuid_v4();
+    let cmd = json!({
+        "kind": "extract.text",
+        "jobId": job_id,
+        "payload": { "name": name, "bytesBase64": bytes_b64 },
+    });
+
+    match post_sidecar_command(&app, port, &cmd, &job_id).await {
+        Ok(result) => result,
+        Err(e) => json!({ "error": e }),
+    }
 }
 
 // ── Support ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the P0 resume extraction blocker. The AI workspace file upload and AI generate route both call `resume.extractText` — previously this returned an error in Tauri. Now it proxies through the sidecar.

**Flow:**
```
renderer sends { name, bytes: Uint8Array }
  → Tauri resume_extract_text command
    → encodes bytes as base64
    → POST /command { kind:"extract.text", payload: { name, bytesBase64 } }
      → sidecar ScraperEngine.extractText()
        → extractPdfFromBytes / extractDocxFromBytes / UTF-8 decode
      → SSE done { text }
    → returns { text } to renderer
```

- **`protocol.ts`** — `extract.text` command variant added
- **`engine.ts`** — `extractText()` uses `@ajh/data` `extractPdfFromBytes` (pdf-parse) and `extractDocxFromBytes` (mammoth); already available as sidecar dependencies
- **`server.ts`** — handler wraps engine call, emits `done` with `{ text }`
- **`commands.rs`** — decodes `Uint8Array` (JSON integer array from Tauri) → base64 → sidecar proxy
- **`Cargo.toml`** — `base64 = "0.22"` for STANDARD engine encode

## Test plan

- [ ] `cargo check` + `pnpm typecheck` + `pnpm lint:strict` pass
- [ ] Upload a PDF in AI workspace → text extracted and shown
- [ ] Upload a DOCX in AI generate route → text extracted
- [ ] Upload a .txt file → raw text returned
- [ ] Unsupported extension → error returned gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)