### PR TITLE
feat: clipboard copy commands via tauri-plugin-clipboard-manager (p1)

### DIFF
--- a/apps/desktop/src/main/ipc/router.ts
+++ b/apps/desktop/src/main/ipc/router.ts
@@ -11,7 +11,15 @@
  */
 import fs from 'node:fs/promises';
 
-import { app, BrowserWindow, dialog, ipcMain, type IpcMainInvokeEvent, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  ipcMain,
+  type IpcMainInvokeEvent,
+  shell,
+} from 'electron';
 import { z, type ZodTypeAny } from 'zod';
 
 import { createLogger } from '@ajh/core';
@@ -576,6 +584,30 @@ export function registerIpc(core: AppCore): void {
     } catch {
       return { success: false };
     }
+  });
+
+  handle(IPC_CHANNELS.support.copyEnvironmentDetails, undefined, async () => {
+    const text = [
+      `AI Job Hunter`,
+      `Version: ${app.getVersion()}`,
+      `Shell: electron`,
+      `Electron: ${process.versions.electron}`,
+      `Node: ${process.version}`,
+      `OS: ${process.platform} ${process.arch}`,
+    ].join('\n');
+    clipboard.writeText(text);
+    return { success: true };
+  });
+
+  handle(IPC_CHANNELS.support.copyAppVersion, undefined, async () => {
+    clipboard.writeText(app.getVersion());
+    return { success: true };
+  });
+
+  handle(IPC_CHANNELS.support.copySystemInfo, undefined, async () => {
+    const text = [`OS: ${process.platform}`, `Arch: ${process.arch}`].join('\n');
+    clipboard.writeText(text);
+    return { success: true };
   });
 
   // ── conversations ───────────────────────────────────────────────────────

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # HTTP client for proxying scraper commands to the sidecar process.

--- a/apps/tauri/src-tauri/capabilities/default.json
+++ b/apps/tauri/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "opener:default",
     "dialog:default",
     "shell:default",
-    "updater:default"
+    "updater:default",
+    "clipboard-manager:default"
   ]
 }

--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -769,18 +769,45 @@ pub fn support_clear_scraping_queue() -> Value {
 }
 
 #[tauri::command]
-pub fn support_copy_environment_details() -> Value {
-    json!(null)
+pub fn support_copy_environment_details(app: AppHandle) -> Value {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+    let text = format!(
+        "AI Job Hunter (Tauri)\nVersion: {}\nShell: tauri\nOS: {} {}\nArch: {}",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        // Reading OS release is impractical from Rust without extra crates;
+        // the OS name + arch is the practical diagnostic minimum.
+        std::env::consts::FAMILY,
+        std::env::consts::ARCH,
+    );
+    match app.clipboard().write_text(text) {
+        Ok(()) => json!({ "success": true }),
+        Err(e) => json!({ "error": e.to_string() }),
+    }
 }
 
 #[tauri::command]
-pub fn support_copy_app_version() -> Value {
-    json!(null)
+pub fn support_copy_app_version(app: AppHandle) -> Value {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+    match app.clipboard().write_text(env!("CARGO_PKG_VERSION").to_string()) {
+        Ok(()) => json!({ "success": true }),
+        Err(e) => json!({ "error": e.to_string() }),
+    }
 }
 
 #[tauri::command]
-pub fn support_copy_system_info() -> Value {
-    json!(null)
+pub fn support_copy_system_info(app: AppHandle) -> Value {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+    let text = format!(
+        "OS: {}\nFamily: {}\nArch: {}",
+        std::env::consts::OS,
+        std::env::consts::FAMILY,
+        std::env::consts::ARCH,
+    );
+    match app.clipboard().write_text(text) {
+        Ok(()) => json!({ "success": true }),
+        Err(e) => json!({ "error": e.to_string() }),
+    }
 }
 
 // ── Conversations ────────────────────────────────────────────────────────────

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -104,6 +104,7 @@ fn main() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .manage(Mutex::new(ScraperSidecarState::default()))
         .setup(|app| {
             let handle = app.handle();


### PR DESCRIPTION
## Summary

Implements the P1 clipboard commands. These three buttons on the Settings → Support page were silent no-ops on **both** Electron and Tauri — the Electron router never registered handlers and Tauri returned `null`.

**Tauri** (`tauri-plugin-clipboard-manager`):
- `support_copy_environment_details` → version + OS + arch + family
- `support_copy_app_version` → `CARGO_PKG_VERSION`
- `support_copy_system_info` → OS + family + arch

**Electron** (also fixed in this PR):
- `copyEnvironmentDetails` → version + electron/node versions + platform/arch
- `copyAppVersion` → `app.getVersion()`
- `copySystemInfo` → platform + arch

## Test plan

- [ ] Rust + TS typecheck + lint all pass
- [ ] Settings → Support → "Copy App Version" button copies version to clipboard
- [ ] "Copy System Info" copies OS details
- [ ] "Copy Environment Details" copies full diagnostic block
- [ ] Works on both Electron and Tauri builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)