### PR TITLE
feat: ai list models via direct ollama http (p1)

### DIFF
--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -222,9 +222,47 @@ pub fn ai_generate(_req: Value) -> Value {
     json!({ "error": "AI runtime not yet available in Tauri spike" })
 }
 
+/// List models available in the local Ollama instance.
+///
+/// Calls GET <OLLAMA_HOST>/api/tags (default http://127.0.0.1:11434).
+/// Returns [] gracefully if Ollama is not running — the renderer shows an
+/// empty model picker rather than an error.
+/// Shape matches the Electron router: Array<{ name: string }>.
 #[tauri::command]
-pub fn ai_list_models() -> Value {
-    json!([])
+pub async fn ai_list_models() -> Value {
+    let base = std::env::var("OLLAMA_HOST")
+        .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string());
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return json!([]),
+    };
+
+    let resp = match client.get(format!("{base}/api/tags")).send().await {
+        Ok(r) if r.status().is_success() => r,
+        _ => return json!([]),
+    };
+
+    let body: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(_) => return json!([]),
+    };
+
+    let models: Vec<serde_json::Value> = body
+        .get("models")
+        .and_then(|m| m.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| m.get("name").and_then(|n| n.as_str()))
+                .map(|name| json!({ "name": name }))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    json!(models)
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary

`ai_list_models` was returning `[]` — the model picker was always empty in Tauri. Single focused change: calls `GET <OLLAMA_HOST>/api/tags` using the existing `reqwest` client (no new deps).

- 5 s timeout so the app doesn't hang when Ollama isn't running
- Returns `[]` gracefully on any error (connection refused, timeout, bad JSON)
- Maps to `[{ name }]` matching the Electron router shape exactly
- Respects `OLLAMA_HOST` env var (default `http://127.0.0.1:11434`)

## Test plan

- [ ] `cargo check` passes
- [ ] With Ollama running: model picker shows installed models
- [ ] With Ollama stopped: model picker shows empty state, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)