### PR TITLE
feat: apply flow via sidecar browser automation (p2 phase d extension)

### DIFF
--- a/apps/scraper-runtime/src/engine.ts
+++ b/apps/scraper-runtime/src/engine.ts
@@ -9,8 +9,13 @@
  *    server.ts calls directly.
  *  - Clean shutdown: close the browser and cancel running jobs on exit.
  */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { createLogger } from '@ajh/core';
 import {
+  ApplierRegistry,
   BrowserController,
   extractDocxFromBytes,
   extractPdfFromBytes,
@@ -21,6 +26,8 @@ import type { JobPosting } from '@ajh/shared';
 import type { FileCredentialStore } from './credentials.js';
 import { LoginManager } from './login.js';
 import type {
+  ApplyJobPayload,
+  ApplyResult,
   ScrapeBoardPayload,
   ScraperCatalogEntry,
   ScraperEvent,
@@ -36,6 +43,7 @@ export interface ScrapeResult {
 
 export class ScraperEngine {
   private readonly registry = new ScraperRegistry();
+  private readonly appliers = new ApplierRegistry();
   private browser?: BrowserController;
   private readonly loginManager: LoginManager;
   /** jobId → AbortController (lets the caller cancel a running job). */
@@ -192,6 +200,63 @@ export class ScraperEngine {
   disconnectBoard(boardId: string): void {
     this.loginManager.disconnect(boardId);
     logger.info({ boardId }, 'board disconnected');
+  }
+
+  // ── Apply flow ────────────────────────────────────────────────────────────
+
+  applierCatalog(): Array<{ id: string; displayName: string }> {
+    return this.appliers.catalog();
+  }
+
+  async applyJob(
+    payload: ApplyJobPayload,
+    jobId: string,
+    emit: (event: ScraperEvent) => void
+  ): Promise<ApplyResult> {
+    const applier = this.appliers.get(payload.board);
+    if (!applier) throw new Error(`No applier registered for board: ${payload.board}`);
+
+    const browser = await this.ensureBrowser();
+    const creds = await this.credentials.get(payload.board);
+    const statePath = this.credentials.storageStatePath(payload.board);
+
+    // Write resume bytes to a temp file if provided — appliers expect a path.
+    let resumePath: string | undefined;
+    let tempFile: string | undefined;
+    if (payload.resumeBytesBase64 && payload.resumeName) {
+      const ext = path.extname(payload.resumeName) || '.pdf';
+      tempFile = path.join(os.tmpdir(), `ajh-resume-${jobId}${ext}`);
+      fs.writeFileSync(tempFile, Buffer.from(payload.resumeBytesBase64, 'base64'));
+      resumePath = tempFile;
+    }
+
+    try {
+      const result = await applier.apply(payload.url, {
+        signal: new AbortController().signal,
+        browser: browser as never,
+        storageStatePath: statePath,
+        credentials: creds ?? null,
+        coverLetter: payload.coverLetter,
+        resumePath,
+        autoSubmit: payload.autoSubmit ?? false,
+        onProgress: (p, _stage) => emit({ kind: 'progress', jobId, p }),
+        onStep: (step) =>
+          emit({
+            kind: 'done',
+            jobId,
+            result: { type: 'step', ...step },
+          }),
+      });
+      return result;
+    } finally {
+      if (tempFile) {
+        try {
+          fs.unlinkSync(tempFile);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
   }
 
   // ── Text extraction ───────────────────────────────────────────────────────

--- a/apps/scraper-runtime/src/protocol.ts
+++ b/apps/scraper-runtime/src/protocol.ts
@@ -36,6 +36,8 @@ export type ScraperCommand =
   | { kind: 'board.status'; boardId: string }
   | { kind: 'board.disconnect'; boardId: string }
   | { kind: 'extract.text'; jobId: string; payload: { name: string; bytesBase64: string } }
+  | { kind: 'apply.job'; jobId: string; payload: ApplyJobPayload }
+  | { kind: 'apply.catalog' }
   | { kind: 'health' }
   | { kind: 'catalog' };
 
@@ -47,6 +49,24 @@ export type ScraperEvent =
   | { kind: 'health.reply'; health: ScraperRuntimeHealth }
   | { kind: 'catalog.reply'; scrapers: ScraperCatalogEntry[] }
   | { kind: 'login.status'; boardId: string; connected: boolean; note?: string };
+
+export interface ApplyJobPayload {
+  board: string;
+  url: string;
+  coverLetter?: string;
+  /** Base64-encoded resume bytes. The sidecar writes them to a temp file. */
+  resumeBytesBase64?: string;
+  resumeName?: string;
+  autoSubmit?: boolean;
+}
+
+export interface ApplyResult {
+  ok: boolean;
+  stage: string;
+  submitted: boolean;
+  url: string;
+  note?: string;
+}
 
 export interface ScrapeBoardPayload {
   board: string;

--- a/apps/scraper-runtime/src/server.ts
+++ b/apps/scraper-runtime/src/server.ts
@@ -117,6 +117,23 @@ async function handleCommand(
       break;
     }
 
+    case 'apply.job': {
+      const { jobId, payload } = cmd;
+      try {
+        const result = await engine.applyJob(payload, jobId, (event) => sendEvent(res, event));
+        sendEvent(res, { kind: 'done', jobId, result });
+      } catch (err) {
+        sendEvent(res, { kind: 'error', jobId, message: String(err) });
+      }
+      break;
+    }
+
+    case 'apply.catalog': {
+      const catalog = engine.applierCatalog();
+      sendEvent(res, { kind: 'done', jobId: 'apply.catalog', result: catalog });
+      break;
+    }
+
     case 'extract.text': {
       const { jobId, payload } = cmd;
       try {

--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -689,21 +689,63 @@ pub fn privacy_clear_interactions(app: AppHandle) -> Value {
 
 // ── Apply ────────────────────────────────────────────────────────────────────
 
+/// Start a job application via the scraper sidecar.
+///
+/// The renderer passes `{ board, url, coverLetter?, bytes?: Uint8Array, name?: string, autoSubmit? }`.
+/// Resume bytes (if provided) are base64-encoded before sending to the sidecar,
+/// which writes them to a temp file for the Playwright applier.
 #[tauri::command]
-pub fn apply_start(_req: Value) -> Value {
-    json!({ "error": "Apply not yet available in Tauri spike" })
+pub async fn apply_start(app: AppHandle, req: Value) -> Value {
+    let Some(port) = sidecar_port(&app) else {
+        return json!({ "error": "scraper sidecar not ready" });
+    };
+
+    let board = req.get("board").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let url = req.get("url").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let cover_letter = req.get("coverLetter").and_then(|v| v.as_str()).map(String::from);
+    let auto_submit = req.get("autoSubmit").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    // Encode resume bytes as base64 if provided.
+    let (resume_bytes_b64, resume_name) = match req.get("bytes") {
+        Some(serde_json::Value::Array(arr)) => {
+            let bytes: Vec<u8> = arr.iter().filter_map(|v| v.as_u64().map(|n| n as u8)).collect();
+            use base64::Engine;
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            let name = req.get("resumeName").and_then(|v| v.as_str()).unwrap_or("resume.pdf").to_string();
+            (Some(b64), Some(name))
+        }
+        _ => (None, None),
+    };
+
+    let job_id = uuid_v4();
+    app.state::<Mutex<JobTracker>>().lock().unwrap().start(&job_id, "apply.job");
+
+    let payload = serde_json::json!({
+        "board": board,
+        "url": url,
+        "coverLetter": cover_letter,
+        "resumeBytesBase64": resume_bytes_b64,
+        "resumeName": resume_name,
+        "autoSubmit": auto_submit,
+    });
+    let cmd = json!({ "kind": "apply.job", "jobId": job_id, "payload": payload });
+
+    match post_sidecar_command(&app, port, &cmd, &job_id).await {
+        Ok(result) => json!({ "jobId": job_id, "result": result }),
+        Err(e) => json!({ "error": e, "jobId": job_id }),
+    }
 }
 
+/// Return the list of boards that support the apply flow.
 #[tauri::command]
 pub async fn apply_catalog(app: AppHandle) -> Value {
-    // Return the sidecar's scraper catalog — these are the boards the applier supports.
     let Some(port) = sidecar_port(&app) else {
         return json!([]);
     };
-    let cmd = json!({ "kind": "catalog" });
     let job_id = uuid_v4();
+    let cmd = json!({ "kind": "apply.catalog" });
     match post_sidecar_command(&app, port, &cmd, &job_id).await {
-        Ok(_) => json!([]), // catalog reply comes via the event bus as catalog.reply
+        Ok(result) => result,
         Err(_) => json!([]),
     }
 }


### PR DESCRIPTION
## Summary

Wires the full job application flow through the scraper sidecar. `apply_start` was returning `"Apply not yet available"` — now it proxies to `ApplierRegistry` from `@ajh/data` using the existing Playwright `BrowserController`.

**Flow:**
```
renderer { board, url, coverLetter?, bytes?, autoSubmit }
  → apply_start Tauri command
    → base64-encode resume bytes
    → POST /command { kind:"apply.job", payload }
      → ScraperEngine.applyJob()
        → ApplierRegistry.get(board) → LinkedInApplier / IndeedApplier / ...
        → BrowserController (Playwright headed via storageStatePath)
        → write resume bytes → temp file → cleanup in finally
        → applier.apply(url, ctx)  ← streams progress/step events
      → SSE done { ok, stage, submitted, url }
    → { jobId, result } back to renderer
```

**`apply.catalog`** now returns the actual applier registry (`[{ id, displayName }]` for linkedin/indeed/greenhouse/workday) instead of the scraper catalog.

Note: The appliers in `@ajh/data` are scaffolded — they open the apply modal and walk form pages but stop before `autoSubmit` by default. Real form completion requires per-employer selector work.

## Test plan

- [ ] `cargo check` + `pnpm typecheck` + `pnpm lint:strict` pass
- [ ] Apply catalog returns `[linkedin, indeed, greenhouse, workday]`
- [ ] Apply flow starts, browser opens, progress events stream to renderer
- [ ] Temp resume file is cleaned up after apply completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)