### PR TITLE
feat: phase f — flip default from electron to tauri

### DIFF
--- a/.github/workflows/02-pull-request-validation.yml
+++ b/.github/workflows/02-pull-request-validation.yml
@@ -82,7 +82,7 @@ jobs:
       - run: pnpm test
 
   build:
-    name: Build Verification
+    name: Build Verification (Tauri frontend + Electron)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -101,6 +101,9 @@ jobs:
           restore-keys: turbo-${{ runner.os }}-
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:packages
+      # Primary: Tauri frontend build (Vite — no Rust toolchain needed in PR check)
+      - run: pnpm --filter @ajh/tauri build
+      # Legacy: Electron build — kept to catch regressions during transition
       - run: pnpm --filter @ajh/desktop build
 
   notify:

--- a/.github/workflows/02-pull-request-validation.yml
+++ b/.github/workflows/02-pull-request-validation.yml
@@ -82,7 +82,7 @@ jobs:
       - run: pnpm test
 
   build:
-    name: Build Verification (Tauri frontend + Electron)
+    name: Build Verification
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,21 +17,31 @@ Rules enforced by ESLint, TypeScript, and CI — violations block commits and fa
 
 ## Architecture
 
-Local-first Electron desktop app in a pnpm monorepo.
+Local-first desktop app in a pnpm monorepo. **Tauri is the production shell.**
+Electron remains as a legacy shell during the transition cycle.
 
 ```
-packages/shared    ← IPC contracts, Zod schemas, shared types (no UI, no Node)
-packages/ui        ← React component library + design system (no app logic)
-packages/prompts   ← AI prompt templates (pure TS, zero deps)
-packages/core      ← EventBus, JobQueue, Logger
-packages/ai        ← Ollama client + AI runtime
-packages/data      ← DB, scraping, matching, files
-packages/workers   ← Worker thread pool
-apps/desktop       ← Electron app (main + preload + renderer)
+packages/shared       ← IPC contracts, Zod schemas, shared types (no UI, no Node)
+packages/ui           ← React component library + design system (no app logic)
+packages/prompts      ← AI prompt templates (pure TS, zero deps)
+packages/core         ← EventBus, JobQueue, Logger
+packages/ai           ← Ollama client + AI runtime
+packages/data         ← DB, scraping, matching, files
+packages/workers      ← Worker thread pool
+apps/tauri            ← Tauri app (production shell — Rust + React via sidecar)
+apps/desktop          ← Electron app (legacy — keep for one release cycle)
+apps/scraper-runtime  ← Node.js HTTP sidecar (scraping, login, documents, AI)
 ```
 
-Renderer → main communication: `window.api.*` only (IPC bridge via `AppClient` context).
+Renderer → shell communication: `AppClient` context only.
+
+- **Tauri (default):** `createTauriInvokeClient()` in `apps/tauri/src/tauri-client.ts`
+- **Electron (legacy):** `createDesktopIpcClient()` → `window.api.*`
+
 IPC contract: `packages/shared/src/ipc/contracts.ts`.
+
+**Default dev:** `pnpm dev` → Tauri app.
+**Electron legacy:** `pnpm dev:electron` → Electron app.
 
 ---
 
@@ -150,19 +160,24 @@ No `// eslint-disable`, no `@ts-ignore`. Add scoped overrides to `eslint.config.
 
 ## Quick Reference
 
-| What           | Where                                                       |
-| -------------- | ----------------------------------------------------------- |
-| IPC contract   | `packages/shared/src/ipc/contracts.ts`                      |
-| Service hooks  | `apps/desktop/src/renderer/services/`                       |
-| UI package     | `packages/ui/src/index.ts` → `@ajh/ui`                      |
-| Motion tokens  | `packages/ui/src/lib/motion.ts` (import via `@/lib/motion`) |
-| State machines | `apps/desktop/src/renderer/lib/machines/`                   |
-| Design tokens  | `packages/ui/src/css/tokens.css`                            |
-| i18n wrapper   | `apps/desktop/src/renderer/lib/i18n.ts`                     |
-| Architecture   | `docs/ARCHITECTURE.md`                                      |
-| Patterns       | `docs/PATTERNS.md`                                          |
-| Design system  | `docs/DESIGN_SYSTEM.md`                                     |
-| Dev setup      | `docs/DEVELOPMENT.md`                                       |
+| What                   | Where                                                       |
+| ---------------------- | ----------------------------------------------------------- |
+| IPC contract           | `packages/shared/src/ipc/contracts.ts`                      |
+| Tauri commands         | `apps/tauri/src-tauri/src/commands.rs`                      |
+| Tauri client (TS)      | `apps/tauri/src/tauri-client.ts`                            |
+| Sidecar entry          | `apps/scraper-runtime/src/index.ts`                         |
+| Sidecar protocol       | `apps/scraper-runtime/src/protocol.ts`                      |
+| Service hooks          | `apps/desktop/src/renderer/services/`                       |
+| UI package             | `packages/ui/src/index.ts` → `@ajh/ui`                      |
+| Motion tokens          | `packages/ui/src/lib/motion.ts` (import via `@/lib/motion`) |
+| State machines         | `apps/desktop/src/renderer/lib/machines/`                   |
+| Design tokens          | `packages/ui/src/css/tokens.css`                            |
+| i18n wrapper           | `apps/desktop/src/renderer/lib/i18n.ts`                     |
+| Architecture status    | `docs/ARCHITECTURE_STATUS.md`                               |
+| Architecture (general) | `docs/ARCHITECTURE.md`                                      |
+| Patterns               | `docs/PATTERNS.md`                                          |
+| Design system          | `docs/DESIGN_SYSTEM.md`                                     |
+| Dev setup              | `docs/DEVELOPMENT.md`                                       |
 
 ## Release Pipeline
 

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -7,6 +7,7 @@
     "dev": "tauri dev",
     "build": "vite build",
     "package": "tauri build",
+    "tauri": "tauri",
     "dev:frontend": "vite --port 5174",
     "build:frontend": "vite build",
     "typecheck": "tsc --noEmit"

--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -136,26 +136,27 @@ or indexing in main. GPU/rendering flags are guarded by `rollbackFlags.lowEndMod
 
 ---
 
-### Thin Desktop Shell (Tauri — spike)
+### Thin Desktop Shell (Tauri — production)
 
-**Status:** ⚠️ spike
+**Status:** ✅ production
 
 **Where:** `apps/tauri/src-tauri/src/`
 
-**Notes:** Native menu, system tray, file dialog plugin all wired. Sidecar
-launched and port-discovered via stdout. Uses same React frontend as Electron
-shell. Not production-ready — keeps Electron as the production shell until
-parity is proven.
+**Notes:** Native menu, system tray, file dialog, clipboard, updater all
+wired. Sidecar launched and port-discovered via stdout. Uses the same React
+renderer as the Electron shell via Vite alias. **Tauri is now the default
+shell** (`pnpm dev` / `pnpm package`). Electron is kept for one release cycle
+as `pnpm dev:electron` / `pnpm package:electron`.
 
 ---
 
 ### Native Shell Duties
 
-| Duty               | Electron                           | Tauri spike                    |
+| Duty               | Tauri (production)                 | Electron (legacy)              |
 | ------------------ | ---------------------------------- | ------------------------------ |
-| Window management  | ✅ `window.ts`                     | ✅ `main.rs`                   |
-| App menu           | ✅ `menus.ts`                      | ✅ `main.rs` `build_app_menu`  |
-| System tray        | —                                  | ✅ `main.rs` `build_tray`      |
+| Window management  | ✅ `main.rs`                       | ✅ `window.ts`                 |
+| App menu           | ✅ `main.rs` `build_app_menu`      | ✅ `menus.ts`                  |
+| System tray        | ✅ `main.rs` `build_tray`          | —                              |
 | Native dialogs     | ✅ `IPC_CHANNELS.dialog.openFiles` | ✅ `dialog_open_files` command |
 | Auto-update        | ✅ `updater.ts`                    | 🔲 Tauri updater plugin        |
 | Credential storage | ✅ `credentials.ts` (keytar)       | 🔲 Tauri stronghold plugin     |
@@ -276,32 +277,33 @@ Idle unload is triggered by the `AiRuntime` idle timer.
 
 ---
 
-## Verdict: where we are vs. the target
+## Verdict: Phase F — Tauri is the default shell
 
 ```
-✅  UI is transport-neutral and reusable across all three shells
-✅  AppClient abstraction complete — three adapters (IPC, Tauri, HTTP skeleton)
-✅  Electron shell is thin — no AI/scraping/indexing in main process
-✅  RuntimeBroker (RuntimeManager) controls start/stop/lazy health
-✅  Scraper runtime behind a stable interface with rollback env var
-✅  AI runtime lazy-starts and unloads on idle
-✅  Data runtime opens DB/vector only when needed
+✅  UI transport-neutral, reusable across all three shells
+✅  AppClient abstraction — three adapters (IPC, Tauri invoke, web HTTP skeleton)
+✅  Electron shell thin — no AI/scraping/indexing in main process
 ✅  Rollback flags for every phase (rollback-flags.ts)
-✅  Tauri spike: same frontend, sidecar protocol proven, native shell complete
-⚠️  Web HTTP adapter: skeleton in place, runtime server not yet deployed
-⚠️  Tauri: spike only — Electron stays production until parity proven
-🔲  Tauri auto-updater (Tauri updater plugin)
-🔲  Tauri credential storage (Tauri stronghold plugin)
-🔲  HTTP scraper adapters ported from @ajh/data to the sidecar
-🔲  apps/web/ entry point using createWebHttpClient()
+✅  Scraper runtime sidecar — 19 boards, login, apply, documents, vector search
+✅  AI streaming via direct Ollama HTTP (chat, embed, pull, list models)
+✅  Credential storage — OS keychain via keyring crate
+✅  Auto-updater — tauri-plugin-updater with GitHub release endpoint
+✅  Native shell — menu, tray, file dialogs, clipboard, window drag
+✅  Release pipeline — Windows NSIS/MSI + macOS universal DMG, signed
+✅  Tauri is production shell — pnpm dev / pnpm package target Tauri
+✅  Electron legacy — pnpm dev:electron / pnpm package:electron for one cycle
+⚠️  Web HTTP adapter: skeleton ready, web backend server not yet deployed
+⚠️  11 support panel actions: stubs in both Tauri and Electron (TODO)
+⚠️  Conversations persistence: no-op in both shells (TODO)
+🔲  apps/web/ entry using createWebHttpClient()
+🔲  Electron fully removed (after one legacy release cycle)
 ```
 
-The architectural verdict from the document holds:
+The architectural goal from the document is achieved:
 
-> Keep Electron for now, but make it boring.
-> The highest-value move is making Electron a replaceable host around runtimes
-> that start late, stop when idle, and can eventually run as Tauri sidecars or
-> web backends.
+> Keep Electron for now, but make it boring. The highest-value move is making
+> Electron a replaceable host around runtimes that start late, stop when idle,
+> and can eventually run as Tauri sidecars or web backends.
 
-That path is now in place. Each remaining item above is an independent,
-reversible step — none require touching the React feature code.
+Electron is now boring — replaceable by `pnpm dev:electron`. Tauri is the
+production shell. Each remaining item above is independent and reversible.

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "pnpm": ">=9.0.0"
   },
   "scripts": {
-    "dev": "pnpm build && pnpm --filter @ajh/desktop dev",
+    "dev": "pnpm build:packages && pnpm --filter @ajh/tauri dev",
+    "dev:electron": "pnpm build && pnpm --filter @ajh/desktop dev",
     "build": "turbo build",
-    "build:packages": "turbo build --filter=!@ajh/desktop",
-    "package": "pnpm build && pnpm --filter @ajh/desktop package",
+    "build:packages": "turbo build --filter=!@ajh/desktop --filter=!@ajh/tauri",
+    "package": "pnpm build:packages && pnpm --filter @ajh/tauri package",
+    "package:electron": "pnpm build && pnpm --filter @ajh/desktop package",
     "typecheck": "turbo typecheck",
     "lint": "eslint .",
     "lint:strict": "eslint . --max-warnings 0",


### PR DESCRIPTION
## Summary

Phase F: Tauri is now the production shell. Electron is demoted to a legacy path kept for one release cycle.

### Changes

**`package.json` (root scripts)**
| Command | Before | After |
|---------|--------|-------|
| `pnpm dev` | Electron dev | **Tauri dev** |
| `pnpm package` | Electron package | **Tauri package** |
| `pnpm dev:electron` | — | Electron dev (legacy) |
| `pnpm package:electron` | — | Electron package (legacy) |
| `pnpm build:packages` | excludes `@ajh/desktop` | also excludes `@ajh/tauri` |

**`02-pull-request-validation.yml`**
- Build job now runs `pnpm --filter @ajh/tauri build` (Vite frontend) as the primary check
- Electron build kept as a regression guard

**`CLAUDE.md`**
- Architecture section: Tauri = production, Electron = legacy, sidecar added to diagram
- Quick reference table: Tauri commands, sidecar entry, protocol added
- Default dev command documented

**`docs/ARCHITECTURE_STATUS.md`**
- Tauri shell: ⚠️ spike → ✅ production
- Native shell duties table: columns swapped (Tauri first)
- Verdict section: reflects Phase F completion

## What didn't change

- All Electron code remains intact — `pnpm dev:electron` works
- CI still builds Electron to catch regressions
- Electron appears in the release pipeline alongside Tauri for this cycle

## Test plan

- [ ] `pnpm lint:strict` + `pnpm typecheck` pass
- [ ] `pnpm build:packages` succeeds (excludes both desktop and tauri)
- [ ] CI build job runs both Tauri frontend and Electron builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)