### PR TITLE
fix: add x86_64-apple-darwin target for universal macos tauri build

### DIFF
--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Restore Rust Cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

macOS Tauri build failed with:
```
failed to build x86_64-apple-darwin binary: Target x86_64-apple-darwin is not installed
(installed targets: aarch64-apple-darwin).
Please run `rustup target add x86_64-apple-darwin`.
```

`--target universal-apple-darwin` requires **both** `aarch64-apple-darwin` (Apple Silicon) and `x86_64-apple-darwin` (Intel) to be installed. The workflow only installed `aarch64-apple-darwin`.

**Fix:** Add `x86_64-apple-darwin` to the targets list — one character change.

## References

- Failing job: https://github.com/saeedkolivand/ai-job-hunter-assistant-app/actions/runs/26194152058/job/77069719707

🤖 Generated with [Claude Code](https://claude.com/claude-code)