### PR TITLE
fix: bump reqwest 0.12 → 0.13 in tauri cargo.toml

### DIFF
--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # HTTP client for proxying scraper commands to the sidecar process.
-reqwest = { version = "0.12", features = ["json"], default-features = false }
+reqwest = { version = "0.13", features = ["json"], default-features = false }
 tokio = { version = "1", features = ["time"] }
 uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"


### PR DESCRIPTION
## Summary

- Bumps `reqwest` from `0.12` to `0.13` in `apps/tauri/src-tauri/Cargo.toml`
- Usage is limited to `Client::new()` / `Client::builder()` which are API-stable across this bump
- The `json` feature and `default-features = false` setup are unchanged

## Not updated

- **`keyring` 3 → 4**: keyring v4 is a breaking API overhaul — the upstream crate README explicitly says to migrate to `keyring-core` instead. Keeping v3.
- **`toml`/`toml_edit`/`toml_datetime`/`generic-array`**: these are transitive deps pinned by Tauri's own dependency tree, not direct deps. No change is possible here without upstream loosening their constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)