### PR TITLE
fix: replace placeholder updater pubkey with real minisign public key

### DIFF
--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
     },
     "dialog": null,
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXkKUlVTVF9QTEFDRUhPTERFUl9QVUJLRVkK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEEwMTU2OTFCMzgyQjg4MzIKUldReWlDczRHMmtWb0Y3WmdtV09ZRkZ6UEx0K1UyVmlaV0pHb3NxSVR1UVRPRjhPUklIUTlLRWEK",
       "endpoints": [
         "https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary
- Replaces the `RUST_PLACEHOLDER_PUBKEY` stub in `tauri.conf.json` with the real minisign public key from `~/.tauri/ajh.key.pub`
- `TAURI_SIGNING_PRIVATE_KEY`, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`, and `TAURI_SIGNING_PUBLIC_KEY` are already set in GitHub secrets
- This unblocks the check-for-updates flow — release builds signed by CI will now pass signature verification

## Test plan
- [ ] Release build signed in CI passes updater signature check
- [ ] Check for updates in app returns correct state (available/not-available) instead of error