### PR TITLE
fix: bugs — toast, analyzer, mouse nav, linkedin errors, modal blur

### DIFF
--- a/apps/tauri/src/renderer/features/settings/components/AccountRow.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/AccountRow.tsx
@@ -2,7 +2,7 @@ import { Check, Lock, Trash2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 
-import { Button, Input } from '@ajh/ui';
+import { Button, Input, useToast } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
@@ -23,22 +23,39 @@ export function AccountRow({ board, saved, disabled, onSaved, onRemoved }: Accou
   const [open, setOpen] = useState(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const toast = useToast();
   const setCredential = useSetCredential();
   const removeCredential = useRemoveCredential();
   const busy = setCredential.isPending || removeCredential.isPending;
 
   const save = async () => {
     if (!username.trim() || !password) return;
-    await setCredential.mutateAsync({ boardId: board.id, username: username.trim(), password });
-    setPassword('');
-    setUsername('');
-    setOpen(false);
-    onSaved();
+    try {
+      await setCredential.mutateAsync({ boardId: board.id, username: username.trim(), password });
+      setPassword('');
+      setUsername('');
+      setOpen(false);
+      onSaved();
+      toast(`${board.name} credentials saved.`, 'success');
+    } catch (err) {
+      toast(
+        err instanceof Error ? err.message : `Failed to save ${board.name} credentials.`,
+        'error'
+      );
+    }
   };
 
   const remove = async () => {
-    await removeCredential.mutateAsync(board.id);
-    onRemoved();
+    try {
+      await removeCredential.mutateAsync(board.id);
+      onRemoved();
+      toast(`${board.name} credentials removed.`, 'success');
+    } catch (err) {
+      toast(
+        err instanceof Error ? err.message : `Failed to remove ${board.name} credentials.`,
+        'error'
+      );
+    }
   };
 
   return (

--- a/apps/tauri/src/renderer/features/settings/components/BoardSessionRow.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/BoardSessionRow.tsx
@@ -1,7 +1,7 @@
 import { Check, Link as LinkIcon, LogOut } from 'lucide-react';
 import { useState } from 'react';
 
-import { Button, ConfirmModal } from '@ajh/ui';
+import { Button, ConfirmModal, useToast } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';
 import {
@@ -31,6 +31,7 @@ const FALLBACK = { iconBg: 'bg-brand', glowColor: 'rgba(168,85,247,0.2)', abbr: 
 
 export function BoardSessionRow({ board }: { board: Board }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const toast = useToast();
 
   const isLinkedIn = board.id === 'linkedin';
   const style = BOARD_STYLE[board.id] ?? FALLBACK;
@@ -52,13 +53,17 @@ export function BoardSessionRow({ board }: { board: Board }) {
 
   const handleConnect = async () => {
     try {
-      if (isLinkedIn) {
-        await linkedInConnect.mutateAsync();
-      } else {
-        await boardConnect.mutateAsync(board.id);
+      const result = isLinkedIn
+        ? await linkedInConnect.mutateAsync()
+        : await boardConnect.mutateAsync(board.id);
+      const res = result as { connected?: boolean; error?: string } | undefined;
+      if (res?.error) {
+        toast(res.error, 'error');
+      } else if (!res?.connected) {
+        toast(`${board.name} sign-in was cancelled or timed out.`, 'warning');
       }
     } catch (err) {
-      console.error(`${board.name} connection failed:`, err);
+      toast(err instanceof Error ? err.message : `Failed to connect to ${board.name}.`, 'error');
     }
   };
 
@@ -70,8 +75,12 @@ export function BoardSessionRow({ board }: { board: Board }) {
       } else {
         await boardDisconnect.mutateAsync(board.id);
       }
+      toast(`Disconnected from ${board.name}.`, 'success');
     } catch (err) {
-      console.error(`${board.name} disconnection failed:`, err);
+      toast(
+        err instanceof Error ? err.message : `Failed to disconnect from ${board.name}.`,
+        'error'
+      );
     }
   };
 

--- a/apps/tauri/src/renderer/features/settings/components/LinkedInSessionRow.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/LinkedInSessionRow.tsx
@@ -1,7 +1,7 @@
 import { Check, Link as LinkIcon, Loader2, LogOut } from 'lucide-react';
 import { motion } from 'motion/react';
 
-import { Button } from '@ajh/ui';
+import { Button, useToast } from '@ajh/ui';
 
 import { useLinkedInConnect, useLinkedInDisconnect, useLinkedInStatus } from '@/services';
 
@@ -10,6 +10,7 @@ interface LinkedInSessionRowProps {
 }
 
 export function LinkedInSessionRow({ board }: LinkedInSessionRowProps) {
+  const toast = useToast();
   const { data: status } = useLinkedInStatus();
   const linkedInConnect = useLinkedInConnect();
   const linkedInDisconnect = useLinkedInDisconnect();
@@ -17,17 +18,24 @@ export function LinkedInSessionRow({ board }: LinkedInSessionRowProps) {
 
   const handleConnect = async () => {
     try {
-      await linkedInConnect.mutateAsync();
+      const result = await linkedInConnect.mutateAsync();
+      const res = result as { connected?: boolean; error?: string } | undefined;
+      if (res?.error) {
+        toast(res.error, 'error');
+      } else if (!res?.connected) {
+        toast('LinkedIn sign-in was cancelled or timed out.', 'warning');
+      }
     } catch (err) {
-      console.error('LinkedIn connection failed:', err);
+      toast(err instanceof Error ? err.message : 'LinkedIn connection failed.', 'error');
     }
   };
 
   const handleDisconnect = async () => {
     try {
       await linkedInDisconnect.mutateAsync();
+      toast('Disconnected from LinkedIn.', 'success');
     } catch (err) {
-      console.error('LinkedIn disconnection failed:', err);
+      toast(err instanceof Error ? err.message : 'Failed to disconnect from LinkedIn.', 'error');
     }
   };
 

--- a/apps/tauri/src/renderer/features/support/components/ContactFeedback.tsx
+++ b/apps/tauri/src/renderer/features/support/components/ContactFeedback.tsx
@@ -1,7 +1,7 @@
 import { Copy } from 'lucide-react';
 import { useState } from 'react';
 
-import { Button, SelectDropdown, TextArea } from '@ajh/ui';
+import { Button, SelectDropdown, TextArea, useToast } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import {
@@ -26,6 +26,7 @@ export function ContactFeedback() {
   const [feedbackType, setFeedbackType] = useState<string>('bugReport');
   const [description, setDescription] = useState('');
 
+  const toast = useToast();
   const exportDiagnostics = useExportDiagnostics();
   const copyEnvDetails = useCopyEnvironmentDetails();
   const copyAppVersion = useCopyAppVersion();
@@ -67,7 +68,18 @@ export function ContactFeedback() {
           variant="glass"
           className="mt-4"
           loading={exportDiagnostics.isPending}
-          onClick={() => void exportDiagnostics.mutateAsync()}
+          onClick={async () => {
+            try {
+              const res = (await exportDiagnostics.mutateAsync()) as {
+                success: boolean;
+                bundlePath?: string;
+              };
+              if (res.success) toast('Diagnostics bundle exported.', 'success');
+              else toast('Export failed.', 'error');
+            } catch (err) {
+              toast(err instanceof Error ? err.message : 'Export failed.', 'error');
+            }
+          }}
         >
           {t('support.contact.exportBundle')}
         </Button>
@@ -112,7 +124,10 @@ export function ContactFeedback() {
             variant="ghost"
             className="w-full justify-start"
             loading={copyEnvDetails.isPending}
-            onClick={() => void copyEnvDetails.mutateAsync()}
+            onClick={async () => {
+              await copyEnvDetails.mutateAsync();
+              toast('Copied to clipboard.', 'success');
+            }}
           >
             <Copy size={14} className="mr-2" />
             {t('support.contact.copyEnvironmentDetails')}
@@ -122,7 +137,10 @@ export function ContactFeedback() {
             variant="ghost"
             className="w-full justify-start"
             loading={copyAppVersion.isPending}
-            onClick={() => void copyAppVersion.mutateAsync()}
+            onClick={async () => {
+              await copyAppVersion.mutateAsync();
+              toast('Copied to clipboard.', 'success');
+            }}
           >
             <Copy size={14} className="mr-2" />
             {t('support.contact.copyAppVersion')}
@@ -132,7 +150,10 @@ export function ContactFeedback() {
             variant="ghost"
             className="w-full justify-start"
             loading={copySystemInfo.isPending}
-            onClick={() => void copySystemInfo.mutateAsync()}
+            onClick={async () => {
+              await copySystemInfo.mutateAsync();
+              toast('Copied to clipboard.', 'success');
+            }}
           >
             <Copy size={14} className="mr-2" />
             {t('support.contact.copySystemInfo')}

--- a/apps/tauri/src/renderer/features/support/components/RecoveryAction.tsx
+++ b/apps/tauri/src/renderer/features/support/components/RecoveryAction.tsx
@@ -1,6 +1,7 @@
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { useState } from 'react';
 
-import { Button } from '@ajh/ui';
+import { Button, useToast } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';
 
@@ -9,6 +10,7 @@ interface RecoveryActionProps {
   description: string;
   destructive: boolean;
   action: string;
+  successMessage?: string;
   onAction?: () => void | Promise<void>;
 }
 
@@ -17,11 +19,22 @@ export function RecoveryAction({
   description,
   destructive,
   action,
+  successMessage,
   onAction,
 }: RecoveryActionProps) {
+  const toast = useToast();
+  const [pending, setPending] = useState(false);
+
   const handleClick = async () => {
-    if (onAction) {
+    if (!onAction) return;
+    setPending(true);
+    try {
       await onAction();
+      toast(successMessage ?? `${title} completed.`, 'success');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : `${title} failed.`, 'error');
+    } finally {
+      setPending(false);
     }
   };
 
@@ -43,9 +56,10 @@ export function RecoveryAction({
         size="sm"
         variant={destructive ? 'ghost' : 'glass'}
         className={cn('text-xs', destructive && 'text-red-400 hover:text-red-300')}
-        onClick={handleClick}
+        disabled={pending}
+        onClick={() => void handleClick()}
       >
-        {action}
+        {pending ? <Loader2 size={12} className="animate-spin" /> : action}
       </Button>
     </div>
   );

--- a/apps/tauri/src/renderer/features/support/components/RecoveryTools.tsx
+++ b/apps/tauri/src/renderer/features/support/components/RecoveryTools.tsx
@@ -49,6 +49,7 @@ export function RecoveryTools() {
             description={t('support.recovery.rebuildIndexesDesc')}
             destructive={true}
             action="rebuildIndexes"
+            successMessage="Vector indexes rebuilt."
             onAction={() => void rebuildIndexes.mutateAsync()}
           />
           <RecoveryAction
@@ -56,6 +57,7 @@ export function RecoveryTools() {
             description={t('support.recovery.clearCacheDesc')}
             destructive={true}
             action="clearCache"
+            successMessage="Embeddings cache cleared."
             onAction={() => void clearCache.mutateAsync()}
           />
           <RecoveryAction
@@ -63,6 +65,7 @@ export function RecoveryTools() {
             description={t('support.recovery.resetDatabaseDesc')}
             destructive={true}
             action="resetDatabase"
+            successMessage="Vector database reset."
             onAction={() => void resetDatabase.mutateAsync()}
           />
         </div>
@@ -76,6 +79,7 @@ export function RecoveryTools() {
             description={t('support.recovery.reloadRuntimeDesc')}
             destructive={false}
             action="reloadRuntime"
+            successMessage="AI runtime reloaded."
             onAction={() => void reloadRuntime.mutateAsync()}
           />
           <RecoveryAction
@@ -83,6 +87,7 @@ export function RecoveryTools() {
             description={t('support.recovery.unloadModelsDesc')}
             destructive={false}
             action="unloadModels"
+            successMessage="All models unloaded."
             onAction={() => void unloadModels.mutateAsync()}
           />
           <RecoveryAction
@@ -90,6 +95,7 @@ export function RecoveryTools() {
             description={t('support.recovery.resetConfigDesc')}
             destructive={false}
             action="resetConfig"
+            successMessage="Model configuration reset."
             onAction={() => void resetConfig.mutateAsync()}
           />
         </div>
@@ -103,6 +109,7 @@ export function RecoveryTools() {
             description={t('support.recovery.clearOcrCacheDesc')}
             destructive={true}
             action="clearOcrCache"
+            successMessage="OCR cache cleared."
             onAction={() => void clearOcrCache.mutateAsync()}
           />
           <RecoveryAction
@@ -110,6 +117,7 @@ export function RecoveryTools() {
             description={t('support.recovery.reindexDocsDesc')}
             destructive={false}
             action="reindexDocs"
+            successMessage="Documents reindexed."
             onAction={() => void reindexDocs.mutateAsync()}
           />
         </div>
@@ -123,6 +131,7 @@ export function RecoveryTools() {
             description={t('support.recovery.resetSessionsDesc')}
             destructive={true}
             action="resetSessions"
+            successMessage="All sessions reset."
             onAction={() => void resetSessions.mutateAsync()}
           />
           <RecoveryAction
@@ -130,6 +139,7 @@ export function RecoveryTools() {
             description={t('support.recovery.clearQueueDesc')}
             destructive={false}
             action="clearQueue"
+            successMessage="Scraping queue cleared."
             onAction={() => void clearQueue.mutateAsync()}
           />
         </div>

--- a/apps/tauri/src/renderer/routes/__root.tsx
+++ b/apps/tauri/src/renderer/routes/__root.tsx
@@ -1,4 +1,5 @@
-import { createRootRoute, Outlet } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { createRootRoute, Outlet, useRouter } from '@tanstack/react-router';
 
 import { ToastProvider } from '@ajh/ui';
 
@@ -11,8 +12,41 @@ import { UpdateBanner } from '@/components/ui/UpdateBanner';
 import { OnboardingWizard } from '@/features/onboarding/OnboardingWizard';
 import { CapabilityProvider } from '@/providers/CapabilityProvider';
 
-export const Route = createRootRoute({
-  component: () => (
+function RootLayout() {
+  const router = useRouter();
+
+  useEffect(() => {
+    // Prevent mouse side-buttons (back/forward, buttons 3 & 4) from triggering
+    // browser history navigation which leads to unhandled routes in the SPA.
+    const block = (e: MouseEvent) => {
+      if (e.button === 3 || e.button === 4) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+    window.addEventListener('mousedown', block, true);
+    window.addEventListener('mouseup', block, true);
+    window.addEventListener('click', block, true);
+    return () => {
+      window.removeEventListener('mousedown', block, true);
+      window.removeEventListener('mouseup', block, true);
+      window.removeEventListener('click', block, true);
+    };
+  }, []);
+
+  // Redirect unknown paths to home instead of showing a blank screen.
+  useEffect(() => {
+    return router.subscribe('onResolved', ({ toLocation }) => {
+      const known = (router.routesByPath as unknown as Record<string, unknown>)[
+        toLocation.pathname
+      ];
+      if (toLocation.pathname !== '/' && !known) {
+        void router.navigate({ to: '/', replace: true });
+      }
+    });
+  }, [router]);
+
+  return (
     <ToastProvider>
       <CapabilityProvider>
         <div className="relative flex h-screen flex-col overflow-hidden pt-3">
@@ -31,5 +65,15 @@ export const Route = createRootRoute({
         </div>
       </CapabilityProvider>
     </ToastProvider>
+  );
+}
+
+export const Route = createRootRoute({
+  component: RootLayout,
+  notFoundComponent: () => (
+    <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+      <p className="text-base font-semibold text-foreground/50">Page not found</p>
+      <p className="text-sm text-foreground/30">Redirecting…</p>
+    </div>
   ),
 });

--- a/apps/tauri/src/renderer/routes/__root.tsx
+++ b/apps/tauri/src/renderer/routes/__root.tsx
@@ -49,7 +49,7 @@ function RootLayout() {
   return (
     <ToastProvider>
       <CapabilityProvider>
-        <div className="relative flex h-screen flex-col overflow-hidden pt-3">
+        <div className="app-content relative flex h-screen flex-col overflow-hidden pt-3">
           <CinematicBackground />
           <Titlebar />
           <div className="flex flex-1 overflow-hidden">

--- a/apps/tauri/src/renderer/routes/analyze.tsx
+++ b/apps/tauri/src/renderer/routes/analyze.tsx
@@ -57,6 +57,7 @@ function Analyze() {
   const [stream, setStream] = useState('');
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [uploading, setUploading] = useState<'resume' | 'jobAd' | null>(null);
+  const [runId, setRunId] = useState(0);
   const { data: modelList = [], isFetching: loadingModels } = useAIModels();
   const models = modelList as Model[];
   const qc = useQueryClient();
@@ -103,6 +104,7 @@ function Analyze() {
 
   const run = async () => {
     if (!canRun) return;
+    setRunId((n) => n + 1);
     setStage('running');
     setError(null);
     setResult(null);
@@ -133,6 +135,8 @@ function Analyze() {
     setError(null);
     setUploadError(null);
     setStage('idle');
+    setRunId(0);
+    extractTextMutation.reset();
   };
 
   return (
@@ -301,7 +305,7 @@ function Analyze() {
             {/* Done */}
             {stage === 'done' && result && (
               <motion.div
-                key="done"
+                key={`done-${runId}`}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 className="flex flex-1 flex-col overflow-hidden"

--- a/apps/tauri/src/renderer/styles/globals.css
+++ b/apps/tauri/src/renderer/styles/globals.css
@@ -25,6 +25,19 @@ body {
   overflow: hidden;
 }
 
+/* ── Modal background blur ───────────────────────────────────────────────── */
+/* When any ModalShell is open, blur the entire app content layer.
+   ModalShell sets data-modal-open on document.body; we blur .app-content. */
+body[data-modal-open] .app-content {
+  filter: blur(6px) brightness(0.7);
+  transition: filter 200ms ease;
+  pointer-events: none;
+}
+
+.app-content {
+  transition: filter 200ms ease;
+}
+
 /* ── Low-memory mode ─────────────────────────────────────────────────────── */
 /* Reduces GPU-heavy effects when the user selects Low Memory performance mode. */
 html[data-performance-mode='low-memory'] {

--- a/packages/ui/src/components/ModalShell.tsx
+++ b/packages/ui/src/components/ModalShell.tsx
@@ -44,6 +44,21 @@ export function ModalShell({
     return () => window.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
+  // Blur the app content behind the modal by toggling a body attribute.
+  // CSS in globals.css targets [data-modal-open] .app-content to apply filter:blur().
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.dataset.modalDepth;
+    const depth = (parseInt(prev ?? '0', 10) || 0) + 1;
+    document.body.dataset.modalDepth = String(depth);
+    document.body.setAttribute('data-modal-open', '');
+    return () => {
+      const next = (parseInt(document.body.dataset.modalDepth ?? '1', 10) || 1) - 1;
+      document.body.dataset.modalDepth = String(next);
+      if (next <= 0) document.body.removeAttribute('data-modal-open');
+    };
+  }, [open]);
+
   return createPortal(
     <AnimatePresence>
       {open && (


### PR DESCRIPTION
## Summary

- **Toast notifications**: `useToast` wired into all action components that were silently swallowing errors — `BoardSessionRow`, `LinkedInSessionRow`, `AccountRow`, `RecoveryAction` (all support page cache/reset actions), `ContactFeedback`
- **Resume analyzer**: Increments a `runId` on each run, used as the AnimatePresence key for the results panel — forces a full re-mount so repeated runs never appear to reuse a previous result. Calls `extractTextMutation.reset()` on full reset
- **Mouse side-buttons → not found**: Intercepts `mousedown`/`mouseup`/`click` for buttons 3 & 4 in root layout. Also redirects unknown paths back to home via router subscription. Adds `notFoundComponent` fallback
- **LinkedIn / board connect errors**: `handleConnect` now inspects the response `error` field and shows appropriate toast rather than silently ignoring it
- **Modal/command palette backdrop blur**: `ModalShell` sets `data-modal-open` on `document.body` when open. `globals.css` applies `filter: blur(6px) brightness(0.7)` to `.app-content` so the entire app background blurs behind any modal or command palette

## Test plan

- [ ] Open any confirm modal (e.g. clear cache in Support) → toast appears after action, app background blurs
- [ ] Open command palette (Ctrl+K) → app background blurs
- [ ] Press mouse side-buttons → no navigation occurs
- [ ] Run resume analyzer → re-run shows fresh animated result
- [ ] Connect/disconnect LinkedIn → success or error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)