### PR TITLE
feat: ollama onboarding step with hardware-based model recommendation

### DIFF
--- a/apps/tauri/src/renderer/features/onboarding/OnboardingWizard.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/OnboardingWizard.tsx
@@ -5,10 +5,11 @@ import { transition } from '@/lib/motion';
 import { useOnboardingCompleted, usePreferencesStore } from '@/store/preferences-store';
 
 import { SpotlightTour } from './SpotlightTour';
+import { OllamaStep } from './steps/OllamaStep';
 import { PrefsStep } from './steps/PrefsStep';
 import { WelcomeStep } from './steps/WelcomeStep';
 
-type Step = 'welcome' | 'prefs' | 'tour';
+type Step = 'welcome' | 'prefs' | 'ollama' | 'tour';
 
 export function OnboardingWizard() {
   const onboardingCompleted = useOnboardingCompleted();
@@ -53,6 +54,14 @@ export function OnboardingWizard() {
             key="prefs"
             direction={direction}
             onBack={() => goBack('welcome')}
+            onNext={() => goNext('ollama')}
+          />
+        )}
+        {step === 'ollama' && (
+          <OllamaStep
+            key="ollama"
+            direction={direction}
+            onBack={() => goBack('prefs')}
             onNext={() => goNext('tour')}
           />
         )}

--- a/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
@@ -1,0 +1,491 @@
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  Bot,
+  CheckCircle2,
+  ChevronRight,
+  Download,
+  ExternalLink,
+  Loader2,
+  Cpu,
+  MemoryStick,
+  SkipForward,
+  WifiOff,
+} from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { Button, useToast } from '@ajh/ui';
+
+import { useTranslation } from '@/lib/i18n';
+import { transition } from '@/lib/motion';
+import { useAIModels, usePullModel } from '@/services';
+import { useSystemHealth, useSystemMetrics, useOpenExternal } from '@/services';
+import { keys } from '@/services/query-client';
+import { useAIModel, usePreferencesStore } from '@/store/preferences-store';
+
+interface Props {
+  onBack: () => void;
+  onNext: () => void;
+  direction: number;
+}
+
+interface ModelRec {
+  name: string;
+  label: string;
+  description: string;
+  sizeGb: number;
+  minRamGb: number;
+}
+
+const MODEL_RECS: ModelRec[] = [
+  {
+    name: 'llama3.2:1b',
+    label: 'Llama 3.2 (1B)',
+    description: 'Ultra-lightweight — works on almost any device',
+    sizeGb: 1.3,
+    minRamGb: 4,
+  },
+  {
+    name: 'llama3.2',
+    label: 'Llama 3.2 (3B)',
+    description: 'Great balance of speed and quality for everyday tasks',
+    sizeGb: 2.0,
+    minRamGb: 6,
+  },
+  {
+    name: 'mistral',
+    label: 'Mistral 7B',
+    description: 'Strong reasoning, ideal for resume analysis',
+    sizeGb: 4.1,
+    minRamGb: 10,
+  },
+  {
+    name: 'llama3.1:8b',
+    label: 'Llama 3.1 (8B)',
+    description: 'Best quality for powerful machines',
+    sizeGb: 4.7,
+    minRamGb: 12,
+  },
+];
+
+function getRecommended(totalRamGb: number): ModelRec {
+  if (totalRamGb >= 12) return MODEL_RECS[3]!;
+  if (totalRamGb >= 10) return MODEL_RECS[2]!;
+  if (totalRamGb >= 6) return MODEL_RECS[1]!;
+  return MODEL_RECS[0]!;
+}
+
+function getRamTier(totalRamGb: number): { label: string; color: string } {
+  if (totalRamGb >= 16) return { label: 'High-end', color: 'text-emerald-400' };
+  if (totalRamGb >= 8) return { label: 'Mid-range', color: 'text-blue-400' };
+  return { label: 'Low-end', color: 'text-amber-400' };
+}
+
+type PullState = 'idle' | 'pulling' | 'done' | 'error';
+
+export function OllamaStep({ onBack, onNext, direction }: Props) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const qc = useQueryClient();
+  const setAIModel = usePreferencesStore((s) => s.setAIModel);
+  const currentAIModel = useAIModel();
+  const openExternal = useOpenExternal();
+  const pullModel = usePullModel();
+
+  const { data: health, isLoading: healthLoading } = useSystemHealth();
+  const { data: metricsRaw } = useSystemMetrics();
+  const metrics = metricsRaw as { totalMemoryMb?: number; memoryMb?: number } | undefined;
+  const { data: modelsRaw, refetch: refetchModels } = useAIModels();
+  const models = (modelsRaw as Array<{ name: string }> | undefined) ?? [];
+
+  const totalRamGb = Math.round((metrics?.totalMemoryMb ?? 8192) / 1024);
+  const recommended = getRecommended(totalRamGb);
+  const ramTier = getRamTier(totalRamGb);
+
+  const ollamaReady = (health as { ai?: { ready: boolean } } | undefined)?.ai?.ready ?? false;
+
+  const [selectedModel, setSelectedModel] = useState<string>(
+    currentAIModel?.defaultModel ?? recommended.name
+  );
+  const [pullState, setPullState] = useState<PullState>('idle');
+  const [pullProgress, setPullProgress] = useState(0);
+  const [skipping, setSkipping] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Auto-select a model when models load
+  useEffect(() => {
+    if (models.length > 0 && !currentAIModel?.defaultModel) {
+      const found = models.find((m) => m.name === recommended.name);
+      setSelectedModel(found?.name ?? models[0]?.name ?? recommended.name);
+    }
+  }, [models, currentAIModel?.defaultModel, recommended.name]);
+
+  const installedNames = new Set(models.map((m) => m.name));
+  const selectedInstalled = installedNames.has(selectedModel);
+
+  const handlePull = async () => {
+    setPullState('pulling');
+    setPullProgress(0);
+    // Fake incremental progress while the pull runs
+    let p = 0;
+    pollRef.current = setInterval(() => {
+      p = Math.min(p + Math.random() * 3, 92);
+      setPullProgress(p);
+    }, 800);
+    try {
+      await pullModel.mutateAsync(selectedModel);
+      clearInterval(pollRef.current!);
+      setPullProgress(100);
+      setPullState('done');
+      await refetchModels();
+      qc.invalidateQueries({ queryKey: keys.ai.models });
+      toast(`${selectedModel} downloaded successfully.`, 'success');
+    } catch (err) {
+      clearInterval(pollRef.current!);
+      setPullState('error');
+      toast(err instanceof Error ? err.message : 'Download failed.', 'error');
+    }
+  };
+
+  const handleContinue = () => {
+    if (selectedModel) {
+      setAIModel({ defaultModel: selectedModel, temperature: 0.7, maxTokens: 2048 });
+    }
+    onNext();
+  };
+
+  const handleSkip = () => {
+    setSkipping(true);
+    setTimeout(() => onNext(), 1200);
+  };
+
+  const canContinue = ollamaReady && selectedInstalled;
+
+  return (
+    <motion.div
+      className="relative z-10 w-full max-w-lg mx-4"
+      custom={direction}
+      variants={{
+        initial: (dir: number) => ({ opacity: 0, x: dir * 60 }),
+        animate: { opacity: 1, x: 0 },
+        exit: (dir: number) => ({ opacity: 0, x: dir * -60 }),
+      }}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      transition={transition.modal}
+    >
+      <div
+        className="rounded-2xl border border-white/[0.08] p-8"
+        style={{
+          background: 'linear-gradient(145deg, rgba(20,14,36,0.97) 0%, rgba(12,10,24,0.97) 100%)',
+          boxShadow:
+            '0 32px 80px rgba(0,0,0,0.6), 0 0 0 1px rgba(168,85,247,0.08), inset 0 1px 0 rgba(255,255,255,0.04)',
+        }}
+      >
+        {/* Icon */}
+        <div className="mb-6 flex justify-center">
+          <div
+            className="flex h-14 w-14 items-center justify-center rounded-2xl"
+            style={{
+              background:
+                'linear-gradient(135deg, rgba(168,85,247,0.25) 0%, rgba(99,102,241,0.15) 100%)',
+              border: '1px solid rgba(168,85,247,0.3)',
+              boxShadow: '0 0 32px rgba(168,85,247,0.2)',
+            }}
+          >
+            <Bot size={24} className="text-brand-soft" />
+          </div>
+        </div>
+
+        {/* Heading */}
+        <div className="mb-6 text-center">
+          <h1 className="mb-2 text-xl font-semibold text-foreground/95">
+            {t('onboarding.ollama.title')}
+          </h1>
+          <p className="text-sm text-foreground/50">{t('onboarding.ollama.subtitle')}</p>
+        </div>
+
+        {/* Content — switches between not-installed and model selection */}
+        <AnimatePresence mode="wait">
+          {healthLoading ? (
+            <motion.div
+              key="checking"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="mb-6 flex flex-col items-center gap-3 py-6"
+            >
+              <Loader2 size={24} className="animate-spin text-brand-soft" />
+              <p className="text-sm text-foreground/40">{t('onboarding.ollama.checking')}</p>
+            </motion.div>
+          ) : !ollamaReady ? (
+            /* ── Ollama not found ─────────────────────────── */
+            <motion.div
+              key="not-installed"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={transition.normal}
+              className="mb-6 space-y-4"
+            >
+              <div className="flex items-start gap-3 rounded-xl border border-amber-400/20 bg-amber-400/5 p-4">
+                <WifiOff size={16} className="mt-0.5 shrink-0 text-amber-400" />
+                <div>
+                  <p className="text-sm font-medium text-amber-200">
+                    {t('onboarding.ollama.notFound')}
+                  </p>
+                  <p className="mt-1 text-xs text-amber-200/60">
+                    {t('onboarding.ollama.notFoundDesc')}
+                  </p>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-xs font-medium uppercase tracking-widest text-foreground/30">
+                  {t('onboarding.ollama.installSteps')}
+                </p>
+                {['download', 'install', 'run'].map((step, i) => (
+                  <div key={step} className="flex items-center gap-3 text-sm text-foreground/60">
+                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-white/10 text-[10px] text-foreground/30">
+                      {i + 1}
+                    </span>
+                    {t(`onboarding.ollama.step.${step}`)}
+                  </div>
+                ))}
+              </div>
+
+              <Button
+                variant="glass"
+                size="sm"
+                className="w-full justify-center gap-2"
+                onClick={() => void openExternal.mutateAsync('https://ollama.com')}
+              >
+                <ExternalLink size={13} />
+                {t('onboarding.ollama.downloadButton')}
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full justify-center gap-1.5 text-foreground/40 hover:text-foreground/70"
+                onClick={() => {
+                  qc.invalidateQueries({ queryKey: keys.system.health });
+                  qc.invalidateQueries({ queryKey: keys.ai.models });
+                }}
+              >
+                <Loader2 size={12} />
+                {t('onboarding.ollama.recheck')}
+              </Button>
+            </motion.div>
+          ) : (
+            /* ── Ollama ready — model selection ──────────── */
+            <motion.div
+              key="model-select"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={transition.normal}
+              className="mb-6 space-y-4"
+            >
+              {/* Ollama ready badge */}
+              <div className="flex items-center gap-2 rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-4 py-2.5">
+                <CheckCircle2 size={14} className="text-emerald-400" />
+                <span className="text-sm text-emerald-200/80">{t('onboarding.ollama.ready')}</span>
+              </div>
+
+              {/* Hardware info */}
+              <div className="flex items-center gap-3 rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                <MemoryStick size={14} className="text-foreground/30" />
+                <div className="flex-1">
+                  <span className="text-xs text-foreground/40">{t('onboarding.ollama.ram')}</span>
+                  <span className="ml-2 text-xs font-medium text-foreground/70">
+                    {totalRamGb} GB
+                  </span>
+                </div>
+                <span className={`text-xs font-medium ${ramTier.color}`}>{ramTier.label}</span>
+              </div>
+
+              {/* Model list */}
+              <div className="space-y-2">
+                <p className="text-xs font-medium uppercase tracking-widest text-foreground/30">
+                  {t('onboarding.ollama.chooseModel')}
+                </p>
+                {MODEL_RECS.map((rec) => {
+                  const installed = installedNames.has(rec.name);
+                  const isRec = rec.name === recommended.name;
+                  const isSelected = selectedModel === rec.name;
+                  const tooHeavy = rec.minRamGb > totalRamGb + 2;
+
+                  return (
+                    <button
+                      key={rec.name}
+                      onClick={() => !tooHeavy && setSelectedModel(rec.name)}
+                      disabled={tooHeavy}
+                      className={`group relative w-full rounded-xl border px-4 py-3 text-left transition-all duration-150 ${
+                        isSelected
+                          ? 'border-brand/40 bg-brand/10'
+                          : tooHeavy
+                            ? 'border-white/[0.04] bg-white/[0.01] opacity-40 cursor-not-allowed'
+                            : 'border-white/[0.07] bg-white/[0.02] hover:border-white/20 hover:bg-white/[0.04]'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className={`text-sm font-medium ${isSelected ? 'text-foreground/90' : 'text-foreground/70'}`}
+                            >
+                              {rec.label}
+                            </span>
+                            {isRec && (
+                              <span className="rounded-full border border-brand/30 bg-brand/15 px-1.5 py-0.5 text-[10px] font-medium text-brand-soft">
+                                {t('onboarding.ollama.recommended')}
+                              </span>
+                            )}
+                            {installed && <CheckCircle2 size={12} className="text-emerald-400" />}
+                          </div>
+                          <p className="mt-0.5 text-xs text-foreground/35">{rec.description}</p>
+                        </div>
+                        <div className="shrink-0 text-right">
+                          <span className="text-xs text-foreground/30">{rec.sizeGb} GB</span>
+                        </div>
+                      </div>
+
+                      {/* Selected indicator */}
+                      {isSelected && (
+                        <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                          <ChevronRight size={14} className="text-brand-soft" />
+                        </div>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Pull button or progress */}
+              {!selectedInstalled && pullState !== 'done' && (
+                <AnimatePresence mode="wait">
+                  {pullState === 'idle' || pullState === 'error' ? (
+                    <motion.div
+                      key="pull-btn"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                    >
+                      {pullState === 'error' && (
+                        <p className="mb-2 text-xs text-red-400">
+                          {t('onboarding.ollama.pullError')}
+                        </p>
+                      )}
+                      <Button
+                        variant="glass"
+                        size="sm"
+                        className="w-full justify-center gap-2"
+                        onClick={() => void handlePull()}
+                      >
+                        <Download size={13} />
+                        {t('onboarding.ollama.download')} {selectedModel}
+                      </Button>
+                    </motion.div>
+                  ) : (
+                    <motion.div
+                      key="pull-progress"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      className="space-y-2"
+                    >
+                      <div className="flex items-center justify-between text-xs text-foreground/40">
+                        <span className="flex items-center gap-1.5">
+                          <Loader2 size={11} className="animate-spin" />
+                          {t('onboarding.ollama.downloading')} {selectedModel}…
+                        </span>
+                        <span>{Math.round(pullProgress)}%</span>
+                      </div>
+                      <div className="h-1 overflow-hidden rounded-full bg-white/[0.06]">
+                        <motion.div
+                          className="h-full rounded-full bg-gradient-to-r from-violet-700 via-brand to-brand-soft"
+                          animate={{ width: `${pullProgress}%` }}
+                          transition={{ duration: 0.4 }}
+                        />
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Step dots */}
+        <div className="mb-6 flex justify-center gap-1.5">
+          {[0, 1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className={`h-1 rounded-full transition-all duration-300 ${
+                i === 2 ? 'w-5 bg-brand' : 'w-1.5 bg-white/15'
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onBack}
+            className="flex items-center gap-1.5"
+            disabled={pullState === 'pulling'}
+          >
+            <ArrowLeft size={13} />
+            {t('onboarding.ollama.back')}
+          </Button>
+
+          <div className="flex-1" />
+
+          {/* Skip */}
+          {!canContinue && !skipping && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleSkip}
+              className="flex items-center gap-1.5 text-foreground/35 hover:text-foreground/60"
+              disabled={pullState === 'pulling'}
+            >
+              <SkipForward size={12} />
+              {t('onboarding.ollama.skip')}
+            </Button>
+          )}
+
+          {skipping && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="flex items-center gap-2 text-xs text-amber-400/70"
+            >
+              <AlertTriangle size={12} />
+              {t('onboarding.ollama.skipWarning')}
+            </motion.div>
+          )}
+
+          {/* Continue */}
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handleContinue}
+            disabled={!canContinue || pullState === 'pulling'}
+            className="flex items-center gap-1.5"
+          >
+            {t('onboarding.ollama.next')}
+            <ArrowRight size={13} />
+          </Button>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
@@ -8,21 +8,25 @@ import {
   Download,
   ExternalLink,
   Loader2,
-  Cpu,
   MemoryStick,
   SkipForward,
   WifiOff,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { Button, useToast } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
-import { useAIModels, usePullModel } from '@/services';
-import { useSystemHealth, useSystemMetrics, useOpenExternal } from '@/services';
+import {
+  useAIModels,
+  useOpenExternal,
+  usePullModel,
+  useSystemHealth,
+  useSystemMetrics,
+} from '@/services';
 import { keys } from '@/services/query-client';
 import { useAIModel, usePreferencesStore } from '@/store/preferences-store';
 
@@ -72,10 +76,51 @@ const MODEL_RECS: ModelRec[] = [
 ];
 
 function getRecommended(totalRamGb: number): ModelRec {
-  if (totalRamGb >= 12) return MODEL_RECS[3]!;
-  if (totalRamGb >= 10) return MODEL_RECS[2]!;
-  if (totalRamGb >= 6) return MODEL_RECS[1]!;
-  return MODEL_RECS[0]!;
+  if (totalRamGb >= 12)
+    return (
+      MODEL_RECS[3] ??
+      MODEL_RECS[0] ??
+      MODEL_RECS[1] ??
+      MODEL_RECS[2] ?? {
+        name: 'llama3.2',
+        label: 'Llama 3.2',
+        description: '',
+        sizeGb: 2,
+        minRamGb: 6,
+      }
+    );
+  if (totalRamGb >= 10)
+    return (
+      MODEL_RECS[2] ??
+      MODEL_RECS[1] ??
+      MODEL_RECS[0] ?? {
+        name: 'mistral',
+        label: 'Mistral 7B',
+        description: '',
+        sizeGb: 4.1,
+        minRamGb: 10,
+      }
+    );
+  if (totalRamGb >= 6)
+    return (
+      MODEL_RECS[1] ??
+      MODEL_RECS[0] ?? {
+        name: 'llama3.2',
+        label: 'Llama 3.2',
+        description: '',
+        sizeGb: 2,
+        minRamGb: 6,
+      }
+    );
+  return (
+    MODEL_RECS[0] ?? {
+      name: 'llama3.2:1b',
+      label: 'Llama 3.2 (1B)',
+      description: '',
+      sizeGb: 1.3,
+      minRamGb: 4,
+    }
+  );
 }
 
 function getRamTier(totalRamGb: number): { label: string; color: string } {
@@ -99,7 +144,10 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
   const { data: metricsRaw } = useSystemMetrics();
   const metrics = metricsRaw as { totalMemoryMb?: number; memoryMb?: number } | undefined;
   const { data: modelsRaw, refetch: refetchModels } = useAIModels();
-  const models = (modelsRaw as Array<{ name: string }> | undefined) ?? [];
+  const models = useMemo(
+    () => (modelsRaw as Array<{ name: string }> | undefined) ?? [],
+    [modelsRaw]
+  );
 
   const totalRamGb = Math.round((metrics?.totalMemoryMb ?? 8192) / 1024);
   const recommended = getRecommended(totalRamGb);
@@ -137,14 +185,14 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
     }, 800);
     try {
       await pullModel.mutateAsync(selectedModel);
-      clearInterval(pollRef.current!);
+      if (pollRef.current) clearInterval(pollRef.current);
       setPullProgress(100);
       setPullState('done');
       await refetchModels();
       qc.invalidateQueries({ queryKey: keys.ai.models });
       toast(`${selectedModel} downloaded successfully.`, 'success');
     } catch (err) {
-      clearInterval(pollRef.current!);
+      if (pollRef.current) clearInterval(pollRef.current);
       setPullState('error');
       toast(err instanceof Error ? err.message : 'Download failed.', 'error');
     }

--- a/apps/tauri/src/renderer/features/onboarding/steps/PrefsStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/PrefsStep.tsx
@@ -140,7 +140,7 @@ export function PrefsStep({ onBack, onNext, direction }: Props) {
 
         {/* Step dots */}
         <div className="mb-6 flex justify-center gap-1.5">
-          {[0, 1, 2].map((i) => (
+          {[0, 1, 2, 3].map((i) => (
             <div
               key={i}
               className={`h-1 rounded-full transition-all duration-300 ${

--- a/apps/tauri/src/renderer/features/onboarding/steps/WelcomeStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/WelcomeStep.tsx
@@ -92,7 +92,7 @@ export function WelcomeStep({ onNext, direction }: Props) {
 
         {/* Step dots */}
         <div className="mb-6 flex justify-center gap-1.5">
-          {[0, 1, 2].map((i) => (
+          {[0, 1, 2, 3].map((i) => (
             <div
               key={i}
               className={`h-1 rounded-full transition-all duration-300 ${

--- a/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
@@ -1,25 +1,34 @@
-import { RefreshCw } from 'lucide-react';
+import { CheckCircle2, Download, ExternalLink, Loader2, RefreshCw, WifiOff } from 'lucide-react';
 import { motion } from 'motion/react';
+import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { Button, GlassCard } from '@ajh/ui';
+import { Button, GlassCard, useToast } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
-import { useAIModels } from '@/services';
+import { useAIModels, usePullModel, useSystemHealth, useOpenExternal } from '@/services';
 import { keys } from '@/services/query-client';
 import { useAIModel, usePreferencesStore } from '@/store/preferences-store';
 import type { Model } from '@/types';
 
 import { CustomDropdown } from './CustomDropdown';
 
+const QUICK_MODELS = ['llama3.2', 'mistral', 'llama3.1:8b', 'llama3.2:1b'];
+
 export function AISettingsTab() {
   const { t } = useTranslation();
+  const toast = useToast();
   const qc = useQueryClient();
   const { data: modelList = [], isFetching: loadingModels } = useAIModels();
   const models = modelList as Model[];
   const aiModel = useAIModel();
   const setAIModel = usePreferencesStore((state) => state.setAIModel);
+  const { data: health } = useSystemHealth();
+  const ollamaReady = (health as { ai?: { ready: boolean } } | undefined)?.ai?.ready ?? false;
+  const pullModel = usePullModel();
+  const openExternal = useOpenExternal();
+  const [pulling, setPulling] = useState<string | null>(null);
 
   const selectedModel = aiModel?.defaultModel || '';
 
@@ -31,12 +40,71 @@ export function AISettingsTab() {
     });
   };
 
+  const handlePull = async (model: string) => {
+    setPulling(model);
+    try {
+      await pullModel.mutateAsync(model);
+      qc.invalidateQueries({ queryKey: keys.ai.models });
+      handleSelectModel(model);
+      toast(`${model} downloaded and selected.`, 'success');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Download failed.', 'error');
+    } finally {
+      setPulling(null);
+    }
+  };
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={transition.normal}
+      className="space-y-4"
     >
+      {/* Ollama status */}
+      <GlassCard>
+        <div className="mb-3 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+          Ollama
+        </div>
+        {ollamaReady ? (
+          <div className="flex items-center gap-2 text-sm text-emerald-400">
+            <CheckCircle2 size={14} />
+            {t('onboarding.ollama.ready')}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 text-sm text-amber-400/80">
+              <WifiOff size={14} />
+              {t('onboarding.ollama.notFound')}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="flex items-center gap-1.5 text-foreground/50"
+                onClick={() => void openExternal.mutateAsync('https://ollama.com')}
+              >
+                <ExternalLink size={12} />
+                {t('onboarding.ollama.downloadButton')}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="flex items-center gap-1.5 text-foreground/40"
+                onClick={() => {
+                  qc.invalidateQueries({ queryKey: keys.system.health });
+                  qc.invalidateQueries({ queryKey: keys.ai.models });
+                }}
+              >
+                <Loader2 size={12} />
+                {t('onboarding.ollama.recheck')}
+              </Button>
+            </div>
+          </div>
+        )}
+      </GlassCard>
+
+      {/* Model selection */}
       <GlassCard>
         <div className="mb-3 flex items-center justify-between">
           <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
@@ -56,7 +124,29 @@ export function AISettingsTab() {
         {loadingModels ? (
           <div className="text-sm text-foreground/50">{t('settings.aiModel.loading')}</div>
         ) : models.length === 0 ? (
-          <div className="text-sm text-foreground/50">{t('settings.aiModel.noModels')}</div>
+          <div className="space-y-3">
+            <p className="text-sm text-foreground/50">{t('settings.aiModel.noModels')}</p>
+            {ollamaReady && (
+              <div className="space-y-2">
+                <p className="text-xs text-foreground/30">{t('onboarding.ollama.chooseModel')}</p>
+                {QUICK_MODELS.map((m) => (
+                  <button
+                    key={m}
+                    onClick={() => void handlePull(m)}
+                    disabled={pulling !== null}
+                    className="flex w-full items-center justify-between rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2.5 text-left text-sm transition-colors hover:border-white/20 hover:bg-white/[0.04] disabled:opacity-50"
+                  >
+                    <span className="text-foreground/70">{m}</span>
+                    {pulling === m ? (
+                      <Loader2 size={13} className="animate-spin text-brand-soft" />
+                    ) : (
+                      <Download size={13} className="text-foreground/30" />
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
         ) : (
           <CustomDropdown
             models={models}

--- a/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
@@ -7,7 +7,7 @@ import { Button, GlassCard, useToast } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
-import { useAIModels, usePullModel, useSystemHealth, useOpenExternal } from '@/services';
+import { useAIModels, useOpenExternal, usePullModel, useSystemHealth } from '@/services';
 import { keys } from '@/services/query-client';
 import { useAIModel, usePreferencesStore } from '@/store/preferences-store';
 import type { Model } from '@/types';

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -1132,7 +1132,7 @@
       "downloading": "Wird heruntergeladen",
       "pullError": "Download fehlgeschlagen. Verbindung prüfen und erneut versuchen.",
       "back": "Zurück",
-      "next": "Weiter",
+      "next": "Funktionen ansehen",
       "skip": "Vorerst überspringen",
       "skipWarning": "KI-Funktionen sind ohne Modell nicht verfügbar"
     },

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -1110,6 +1110,32 @@
       "back": "Zurück",
       "next": "Funktionen ansehen"
     },
+    "ollama": {
+      "title": "KI einrichten",
+      "subtitle": "AI Job Hunter führt Modelle lokal über Ollama aus – keine API-Schlüssel, keine Cloud.",
+      "checking": "Suche nach Ollama…",
+      "notFound": "Ollama nicht gefunden",
+      "notFoundDesc": "Ollama muss installiert und aktiv sein, bevor KI-Funktionen verfügbar sind.",
+      "installSteps": "So installieren Sie es",
+      "step": {
+        "download": "Ollama von ollama.com herunterladen",
+        "install": "Installationsprogramm ausführen",
+        "run": "Ollama startet automatisch"
+      },
+      "downloadButton": "Ollama herunterladen",
+      "recheck": "Installiert – erneut prüfen",
+      "ready": "Ollama läuft",
+      "ram": "Verfügbarer RAM",
+      "chooseModel": "Modell wählen",
+      "recommended": "Empfohlen",
+      "download": "Herunterladen",
+      "downloading": "Wird heruntergeladen",
+      "pullError": "Download fehlgeschlagen. Verbindung prüfen und erneut versuchen.",
+      "back": "Zurück",
+      "next": "Weiter",
+      "skip": "Vorerst überspringen",
+      "skipWarning": "KI-Funktionen sind ohne Modell nicht verfügbar"
+    },
     "tour": {
       "title": "Kurze Tour",
       "subtitle": "Hier ist, was Sie tun können",

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -1108,7 +1108,7 @@
         "any": "Alles offen"
       },
       "back": "Zurück",
-      "next": "Funktionen ansehen"
+      "next": "KI einrichten"
     },
     "ollama": {
       "title": "KI einrichten",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -1108,7 +1108,7 @@
         "any": "Open to all"
       },
       "back": "Back",
-      "next": "See the features"
+      "next": "Set up AI"
     },
     "ollama": {
       "title": "Set up your AI",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -1132,7 +1132,7 @@
       "downloading": "Downloading",
       "pullError": "Download failed. Check your connection and try again.",
       "back": "Back",
-      "next": "Continue",
+      "next": "See the features",
       "skip": "Skip for now",
       "skipWarning": "AI features won't work without a model"
     },

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -1110,6 +1110,32 @@
       "back": "Back",
       "next": "See the features"
     },
+    "ollama": {
+      "title": "Set up your AI",
+      "subtitle": "AI Job Hunter runs models locally via Ollama — no API keys, no cloud.",
+      "checking": "Checking for Ollama…",
+      "notFound": "Ollama not detected",
+      "notFoundDesc": "Ollama needs to be installed and running before AI features will work.",
+      "installSteps": "How to install",
+      "step": {
+        "download": "Download Ollama from ollama.com",
+        "install": "Run the installer",
+        "run": "Ollama starts automatically"
+      },
+      "downloadButton": "Download Ollama",
+      "recheck": "I've installed it — check again",
+      "ready": "Ollama is running",
+      "ram": "Available RAM",
+      "chooseModel": "Choose a model",
+      "recommended": "Recommended",
+      "download": "Download",
+      "downloading": "Downloading",
+      "pullError": "Download failed. Check your connection and try again.",
+      "back": "Back",
+      "next": "Continue",
+      "skip": "Skip for now",
+      "skipWarning": "AI features won't work without a model"
+    },
     "tour": {
       "title": "Quick tour",
       "subtitle": "Here's what you can do",


### PR DESCRIPTION
## Summary

Adds a new **AI Setup** step between Prefs and Tour in the onboarding wizard:

- **Ollama detection** — checks system health on mount; shows spinner while checking
- **Not installed** — shows install instructions (3 steps) + Download Ollama button + recheck button
- **Installed, no models** — shows 4 model options with recommended badge based on detected RAM
- **Hardware detection** — reads total RAM via `system.getMetrics()` and recommends the best-fit model:
  - < 6 GB → Llama 3.2 (1B)
  - 6–10 GB → Llama 3.2 (3B)  
  - 10–12 GB → Mistral 7B
  - 12 GB+ → Llama 3.1 (8B)
- **Model pull** — animated progress bar while downloading; shows installed checkmark
- **Skip option** — skip with a visible warning that AI features won't work
- **Sets model in preferences** on continue

**AI Settings tab** also gains:
- Ollama status card (running ✅ / not found ⚠️ with download + recheck)
- Quick-pull list when Ollama is running but no models are installed

**Wizard changes:**
- Step 2 (Prefs) next button: "Set up AI" → leads to new Ollama step
- Step 3 (Ollama) next button: "See the features" → leads to tour
- Step dots updated from 3 to 4 across all steps

## Test plan

- [ ] Fresh install — wizard shows Ollama step with "not found" state
- [ ] With Ollama running but no models — shows model list with recommendation for your RAM
- [ ] Download a model from the wizard — progress bar animates, model selected on continue
- [ ] Skip — proceeds to tour with warning shown
- [ ] AI Settings → Ollama card shows correct status

🤖 Generated with [Claude Code](https://claude.com/claude-code)