### PR TITLE
feat: external ai providers — openai, anthropic, gemini, openai-compatible

### DIFF
--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -297,8 +297,11 @@ pub fn jobs_retry(_app: AppHandle, _job_id: String) -> Value {
 /// before the first chunk arrives.
 #[tauri::command]
 pub async fn ai_generate(app: AppHandle, req: Value) -> Value {
-    let base = std::env::var("OLLAMA_HOST")
-        .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string());
+    let provider = req
+        .get("provider")
+        .and_then(|v| v.as_str())
+        .unwrap_or("ollama")
+        .to_string();
 
     let job_id = uuid_v4();
     app.state::<Mutex<JobTracker>>()
@@ -310,8 +313,33 @@ pub async fn ai_generate(app: AppHandle, req: Value) -> Value {
     let app_clone = app.clone();
 
     tauri::async_runtime::spawn(async move {
-        if let Err(e) = stream_ollama_chat(&app_clone, &base, &job_id_clone, req).await {
-            // Emit an error chunk so the renderer's onStream handler can surface it.
+        let result = match provider.as_str() {
+            "openai" | "openai-compatible" => {
+                let api_key = get_provider_key(&app_clone, &provider).unwrap_or_default();
+                let base_url = req
+                    .get("baseUrl")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("https://api.openai.com/v1")
+                    .to_string();
+                stream_openai_chat(&app_clone, &base_url, &api_key, &job_id_clone, req).await
+            }
+            "anthropic" => {
+                let api_key = get_provider_key(&app_clone, "anthropic").unwrap_or_default();
+                stream_anthropic_chat(&app_clone, &api_key, &job_id_clone, req).await
+            }
+            "gemini" => {
+                let api_key = get_provider_key(&app_clone, "gemini").unwrap_or_default();
+                stream_gemini_chat(&app_clone, &api_key, &job_id_clone, req).await
+            }
+            _ => {
+                // Default: Ollama
+                let base = std::env::var("OLLAMA_HOST")
+                    .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string());
+                stream_ollama_chat(&app_clone, &base, &job_id_clone, req).await
+            }
+        };
+
+        if let Err(e) = result {
             let _ = app_clone.emit(
                 "ai:stream",
                 json!({ "jobId": job_id_clone, "delta": format!("\n\nError: {e}"), "done": true }),
@@ -423,6 +451,415 @@ async fn stream_ollama_chat(
         .unwrap()
         .complete(job_id, json!({ "done": true }));
 
+    Ok(())
+}
+
+// ── Cloud AI provider helpers ─────────────────────────────────────────────────
+
+/// Read a provider API key from the OS keychain.
+/// Keys are stored with board_id = "ai:{provider}" e.g. "ai:openai".
+fn get_provider_key(app: &AppHandle, provider: &str) -> Option<String> {
+    use crate::credentials::CredentialStore;
+    let store = app.state::<Mutex<CredentialStore>>();
+    let guard = store.lock().unwrap();
+    guard
+        .get_decrypted(&format!("ai:{provider}"))
+        .map(|(_, password)| password)
+}
+
+/// Store a cloud AI provider API key in the OS keychain.
+#[tauri::command]
+pub fn ai_set_provider_key(app: AppHandle, provider: String, api_key: String) -> Value {
+    use crate::credentials::CredentialStore;
+    let store = app.state::<Mutex<CredentialStore>>();
+    let guard = store.lock().unwrap();
+    match guard.set(&format!("ai:{provider}"), "apikey", &api_key) {
+        Ok(()) => json!({ "success": true }),
+        Err(e) => json!({ "success": false, "error": e }),
+    }
+}
+
+/// Remove a cloud AI provider API key from the OS keychain.
+#[tauri::command]
+pub fn ai_remove_provider_key(app: AppHandle, provider: String) -> Value {
+    use crate::credentials::CredentialStore;
+    let store = app.state::<Mutex<CredentialStore>>();
+    let guard = store.lock().unwrap();
+    match guard.remove(&format!("ai:{provider}")) {
+        Ok(()) => json!({ "success": true }),
+        Err(e) => json!({ "success": false, "error": e }),
+    }
+}
+
+/// Check whether an API key is stored for a provider (does not return the key).
+#[tauri::command]
+pub fn ai_has_provider_key(app: AppHandle, provider: String) -> Value {
+    json!({ "has": get_provider_key(&app, &provider).is_some() })
+}
+
+/// Fetch available models from a cloud provider using the stored API key.
+/// Returns [] gracefully if the key is missing or the request fails.
+#[tauri::command]
+pub async fn ai_list_provider_models(app: AppHandle, provider: String) -> Value {
+    let api_key = match get_provider_key(&app, &provider) {
+        Some(k) => k,
+        None => return json!([]),
+    };
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return json!([]),
+    };
+
+    match provider.as_str() {
+        "openai" | "openai-compatible" => {
+            let resp = client
+                .get("https://api.openai.com/v1/models")
+                .bearer_auth(&api_key)
+                .send()
+                .await;
+            if let Ok(r) = resp {
+                if let Ok(body) = r.json::<serde_json::Value>().await {
+                    if let Some(data) = body.get("data").and_then(|d| d.as_array()) {
+                        let models: Vec<Value> = data
+                            .iter()
+                            .filter_map(|m| m.get("id").and_then(|id| id.as_str()))
+                            .filter(|id| {
+                                id.starts_with("gpt-")
+                                    || id.starts_with("o1")
+                                    || id.starts_with("o3")
+                                    || id.starts_with("o4")
+                            })
+                            .map(|id| json!({ "name": id }))
+                            .collect();
+                        return json!(models);
+                    }
+                }
+            }
+            // Fallback hardcoded list
+            json!([
+                { "name": "gpt-4o" }, { "name": "gpt-4o-mini" },
+                { "name": "gpt-4-turbo" }, { "name": "gpt-3.5-turbo" },
+                { "name": "o1" }, { "name": "o1-mini" }
+            ])
+        }
+        "anthropic" => json!([
+            { "name": "claude-opus-4-7" },
+            { "name": "claude-sonnet-4-6" },
+            { "name": "claude-haiku-4-5-20251001" }
+        ]),
+        "gemini" => json!([
+            { "name": "gemini-2.0-flash" },
+            { "name": "gemini-1.5-pro" },
+            { "name": "gemini-1.5-flash" },
+            { "name": "gemini-1.0-pro" }
+        ]),
+        _ => json!([]),
+    }
+}
+
+// ── Cloud provider streaming ───────────────────────────────────────────────────
+
+/// Stream from OpenAI-compatible API (OpenAI, Groq, Together, LM Studio, etc.)
+async fn stream_openai_chat(
+    app: &AppHandle,
+    base_url: &str,
+    api_key: &str,
+    job_id: &str,
+    req: Value,
+) -> Result<(), String> {
+    let model = req
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("gpt-4o")
+        .to_string();
+    let messages = req.get("messages").cloned().unwrap_or(json!([]));
+    let temperature = req.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.7);
+
+    let body = json!({
+        "model": model,
+        "messages": messages,
+        "stream": true,
+        "temperature": temperature,
+    });
+
+    let mut response = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|e| e.to_string())?
+        .post(format!("{base_url}/chat/completions"))
+        .bearer_auth(api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("OpenAI unreachable: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body_text = response.text().await.unwrap_or_default();
+        return Err(format!("OpenAI {status}: {body_text}"));
+    }
+
+    let mut line_buf = String::new();
+
+    while let Some(bytes) = response.chunk().await.map_err(|e| e.to_string())? {
+        line_buf.push_str(&String::from_utf8_lossy(&bytes));
+
+        while let Some(nl) = line_buf.find('\n') {
+            let line = line_buf[..nl].trim().to_string();
+            line_buf = line_buf[nl + 1..].to_string();
+
+            let data = match line.strip_prefix("data: ") {
+                Some(d) => d.trim(),
+                None => continue,
+            };
+
+            if data == "[DONE]" {
+                let _ = app.emit("ai:stream", json!({ "jobId": job_id, "delta": "", "done": true }));
+                app.state::<Mutex<JobTracker>>().lock().unwrap().complete(job_id, json!({ "done": true }));
+                return Ok(());
+            }
+
+            let event: Value = match serde_json::from_str(data) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            let delta = event
+                .get("choices")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("delta"))
+                .and_then(|d| d.get("content"))
+                .and_then(|c| c.as_str())
+                .unwrap_or("");
+
+            if !delta.is_empty() {
+                let _ = app.emit("ai:stream", json!({ "jobId": job_id, "delta": delta, "done": false }));
+            }
+        }
+    }
+
+    let _ = app.emit("ai:stream", json!({ "jobId": job_id, "delta": "", "done": true }));
+    app.state::<Mutex<JobTracker>>().lock().unwrap().complete(job_id, json!({ "done": true }));
+    Ok(())
+}
+
+/// Stream from Anthropic Claude API.
+async fn stream_anthropic_chat(
+    app: &AppHandle,
+    api_key: &str,
+    job_id: &str,
+    req: Value,
+) -> Result<(), String> {
+    let model = req
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("claude-sonnet-4-6")
+        .to_string();
+    let temperature = req.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.7);
+
+    // Anthropic separates system messages from user/assistant messages.
+    let messages_raw = req.get("messages").and_then(|m| m.as_array()).cloned().unwrap_or_default();
+    let system_content: String = messages_raw
+        .iter()
+        .filter(|m| m.get("role").and_then(|r| r.as_str()) == Some("system"))
+        .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let messages: Vec<Value> = messages_raw
+        .iter()
+        .filter(|m| m.get("role").and_then(|r| r.as_str()) != Some("system"))
+        .cloned()
+        .collect();
+
+    let mut body = json!({
+        "model": model,
+        "messages": messages,
+        "max_tokens": 4096,
+        "stream": true,
+        "temperature": temperature,
+    });
+    if !system_content.is_empty() {
+        body["system"] = json!(system_content);
+    }
+
+    let mut response = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|e| e.to_string())?
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Anthropic unreachable: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body_text = response.text().await.unwrap_or_default();
+        return Err(format!("Anthropic {status}: {body_text}"));
+    }
+
+    let mut line_buf = String::new();
+    let mut last_event = String::new();
+
+    while let Some(bytes) = response.chunk().await.map_err(|e| e.to_string())? {
+        line_buf.push_str(&String::from_utf8_lossy(&bytes));
+
+        while let Some(nl) = line_buf.find('\n') {
+            let line = line_buf[..nl].trim().to_string();
+            line_buf = line_buf[nl + 1..].to_string();
+
+            if let Some(event) = line.strip_prefix("event: ") {
+                last_event = event.trim().to_string();
+                continue;
+            }
+
+            let data = match line.strip_prefix("data: ") {
+                Some(d) => d.trim(),
+                None => continue,
+            };
+
+            if last_event == "message_stop" || data.contains("\"type\":\"message_stop\"") {
+                let _ = app.emit("ai:stream", json!({ "jobId": job_id, "delta": "", "done": true }));
+                app.state::<Mutex<JobTracker>>().lock().unwrap().complete(job_id, json!({ "done": true }));
+                return Ok(());
+            }
+
+            let event: Value = match serde_json::from_str(data) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            let delta = event
+                .get("delta")
+                .and_then(|d| d.get("text"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("");
+
+            if !delta.is_empty() {
+                let _ = app.emit("ai:stream", json!({ "jobId": job_id, "delta": delta, "done": false }));
+            }
+        }
+    }
+
+    let _ = app.emit("ai:stream", json!({ "jobId": job_id, "delta": "", "done": true }));
+    app.state::<Mutex<JobTracker>>().lock().unwrap().complete(job_id, json!({ "done": true }));
+    Ok(())
+}
+
+/// Stream from Google Gemini API.
+async fn stream_gemini_chat(
+    app: &AppHandle,
+    api_key: &str,
+    job_id: &str,
+    req: Value,
+) -> Result<(), String> {
+    let model = req
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("gemini-2.0-flash")
+        .to_string();
+    let temperature = req.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.7);
+
+    let messages_raw = req.get("messages").and_then(|m| m.as_array()).cloned().unwrap_or_default();
+
+    // Gemini uses "user"/"model" roles; extract system prompt into systemInstruction.
+    let system_text: String = messages_raw
+        .iter()
+        .filter(|m| m.get("role").and_then(|r| r.as_str()) == Some("system"))
+        .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let contents: Vec<Value> = messages_raw
+        .iter()
+        .filter(|m| m.get("role").and_then(|r| r.as_str()) != Some("system"))
+        .map(|m| {
+            let role = if m.get("role").and_then(|r| r.as_str()) == Some("assistant") {
+                "model"
+            } else {
+                "user"
+            };
+            let text = m.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            json!({ "role": role, "parts": [{ "text": text }] })
+        })
+        .collect();
+
+    let mut body = json!({
+        "contents": contents,
+        "generationConfig": { "temperature": temperature },
+    });
+    if !system_text.is_empty() {
+        body["systemInstruction"] = json!({ "parts": [{ "text": system_text }] });
+    }
+
+    let url = format!(
+        "https://generativelanguage.googleapis.com/v1beta/models/{}:streamGenerateContent?key={}",
+        model, api_key
+    );
+
+    let mut response = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|e| e.to_string())?
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Gemini unreachable: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body_text = response.text().await.unwrap_or_default();
+        return Err(format!("Gemini {status}: {body_text}"));
+    }
+
+    // Gemini streams a JSON array — accumulate chunks and parse each complete object.
+    let mut buf = String::new();
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut escape = false;
+
+    while let Some(bytes) = response.chunk().await.map_err(|e| e.to_string())? {
+        let chunk = String::from_utf8_lossy(&bytes).to_string();
+        for ch in chunk.chars() {
+            if escape { escape = false; buf.push(ch); continue; }
+            if ch == '\\' && in_string { escape = true; buf.push(ch); continue; }
+            if ch == '"' { in_string = !in_string; }
+            if !in_string {
+                if ch == '{' { depth += 1; }
+                else if ch == '}' { depth -= 1; }
+            }
+            buf.push(ch);
+
+            // Each top-level object is a complete candidate chunk.
+            if depth == 0 && buf.trim_start().starts_with('{') && !buf.trim().is_empty() {
+                if let Ok(event) = serde_json::from_str::<Value>(buf.trim()) {
+                    let delta = event
+                        .get("candidates")
+                        .and_then(|c| c.get(0))
+                        .and_then(|c| c.get("content"))
+                        .and_then(|c| c.get("parts"))
+                        .and_then(|p| p.get(0))
+                        .and_then(|p| p.get("text"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
+                    if !delta.is_empty() {
+                        let _ = app.emit("ai:stream", json!({ "jobId": job_id, "delta": delta, "done": false }));
+                    }
+                }
+                buf.clear();
+            }
+        }
+    }
+
+    let _ = app.emit("ai:stream", json!({ "jobId": job_id, "delta": "", "done": true }));
+    app.state::<Mutex<JobTracker>>().lock().unwrap().complete(job_id, json!({ "done": true }));
     Ok(())
 }
 

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -169,6 +169,10 @@ fn main() {
             commands::ai_pull_model,
             commands::ai_unload_model,
             commands::ai_embed,
+            commands::ai_set_provider_key,
+            commands::ai_remove_provider_key,
+            commands::ai_has_provider_key,
+            commands::ai_list_provider_models,
             // documents
             commands::documents_list,
             commands::documents_import,

--- a/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
@@ -5,8 +5,13 @@ import {
   Bot,
   CheckCircle2,
   ChevronRight,
+  Cloud,
+  Computer,
   Download,
   ExternalLink,
+  Eye,
+  EyeOff,
+  Key,
   Loader2,
   MemoryStick,
   SkipForward,
@@ -16,19 +21,59 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { Button, useToast } from '@ajh/ui';
+import { Button, Input, useToast } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
 import {
   useAIModels,
+  useHasProviderKey,
   useOpenExternal,
   usePullModel,
+  useSetProviderKey,
   useSystemHealth,
   useSystemMetrics,
 } from '@/services';
 import { keys } from '@/services/query-client';
+import type { AiProvider } from '@/store/preferences-schema';
 import { useAIModel, usePreferencesStore } from '@/store/preferences-store';
+
+// Cloud providers available in onboarding (simpler list than settings)
+const CLOUD_PROVIDERS: Array<{
+  id: AiProvider;
+  label: string;
+  placeholder: string;
+  docsUrl: string;
+  color: string;
+}> = [
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    placeholder: 'sk-...',
+    docsUrl: 'https://platform.openai.com/api-keys',
+    color: 'text-green-400',
+  },
+  {
+    id: 'anthropic',
+    label: 'Anthropic (Claude)',
+    placeholder: 'sk-ant-...',
+    docsUrl: 'https://console.anthropic.com/settings/keys',
+    color: 'text-orange-400',
+  },
+  {
+    id: 'gemini',
+    label: 'Google Gemini',
+    placeholder: 'AIza...',
+    docsUrl: 'https://aistudio.google.com/app/apikey',
+    color: 'text-blue-400',
+  },
+];
+
+const CLOUD_DEFAULT_MODELS: Record<string, string> = {
+  openai: 'gpt-4o',
+  anthropic: 'claude-sonnet-4-6',
+  gemini: 'gemini-2.0-flash',
+};
 
 interface Props {
   onBack: () => void;
@@ -136,9 +181,21 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
   const toast = useToast();
   const qc = useQueryClient();
   const setAIModel = usePreferencesStore((s) => s.setAIModel);
+  const setAiProviderConfig = usePreferencesStore((s) => s.setAiProviderConfig);
   const currentAIModel = useAIModel();
   const openExternal = useOpenExternal();
   const pullModel = usePullModel();
+  const setProviderKey = useSetProviderKey();
+
+  // Tab: 'local' = Ollama, 'cloud' = cloud provider
+  const [mode, setMode] = useState<'local' | 'cloud'>('local');
+  const [cloudProvider, setCloudProvider] = useState<AiProvider>('openai');
+  const [cloudApiKey, setCloudApiKey] = useState('');
+  const [showCloudKey, setShowCloudKey] = useState(false);
+  const [savingCloudKey, setSavingCloudKey] = useState(false);
+
+  const cloudMeta = CLOUD_PROVIDERS.find((p) => p.id === cloudProvider) ?? CLOUD_PROVIDERS[0];
+  const { data: hasCloudKeyData } = useHasProviderKey(cloudProvider);
 
   const { data: health, isLoading: healthLoading } = useSystemHealth();
   const { data: metricsRaw } = useSystemMetrics();
@@ -198,9 +255,35 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
     }
   };
 
+  const hasCloudKey = hasCloudKeyData?.has ?? false;
+
+  const handleSaveCloudKey = async () => {
+    if (!cloudApiKey.trim()) return;
+    setSavingCloudKey(true);
+    try {
+      await setProviderKey.mutateAsync({ provider: cloudProvider, apiKey: cloudApiKey.trim() });
+      setCloudApiKey('');
+      setAiProviderConfig({
+        provider: cloudProvider,
+        model: CLOUD_DEFAULT_MODELS[cloudProvider] ?? '',
+      });
+      toast(`${cloudMeta?.label ?? cloudProvider} API key saved.`, 'success');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Failed to save key.', 'error');
+    } finally {
+      setSavingCloudKey(false);
+    }
+  };
+
   const handleContinue = () => {
-    if (selectedModel) {
+    if (mode === 'cloud') {
+      setAiProviderConfig({
+        provider: cloudProvider,
+        model: CLOUD_DEFAULT_MODELS[cloudProvider] ?? '',
+      });
+    } else if (selectedModel) {
       setAIModel({ defaultModel: selectedModel, temperature: 0.7, maxTokens: 2048 });
+      setAiProviderConfig({ provider: 'ollama', model: selectedModel });
     }
     onNext();
   };
@@ -210,7 +293,7 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
     setTimeout(() => onNext(), 1200);
   };
 
-  const canContinue = ollamaReady && selectedInstalled;
+  const canContinue = mode === 'cloud' ? hasCloudKey : ollamaReady && selectedInstalled;
 
   return (
     <motion.div
@@ -250,16 +333,130 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
         </div>
 
         {/* Heading */}
-        <div className="mb-6 text-center">
+        <div className="mb-5 text-center">
           <h1 className="mb-2 text-xl font-semibold text-foreground/95">
             {t('onboarding.ollama.title')}
           </h1>
           <p className="text-sm text-foreground/50">{t('onboarding.ollama.subtitle')}</p>
         </div>
 
+        {/* Local / Cloud tab switcher */}
+        <div className="mb-5 flex rounded-xl border border-white/[0.07] bg-white/[0.02] p-1">
+          {[
+            { id: 'local' as const, label: 'Local (Ollama)', icon: Computer },
+            { id: 'cloud' as const, label: 'Cloud AI', icon: Cloud },
+          ].map(({ id, label, icon: Icon }) => (
+            <button
+              key={id}
+              onClick={() => setMode(id)}
+              className={`flex flex-1 items-center justify-center gap-2 rounded-lg py-2 text-sm font-medium transition-all duration-150 ${
+                mode === id
+                  ? 'bg-brand/15 text-brand-soft border border-brand/30'
+                  : 'text-foreground/40 hover:text-foreground/70'
+              }`}
+            >
+              <Icon size={14} />
+              {label}
+            </button>
+          ))}
+        </div>
+
         {/* Content — switches between not-installed and model selection */}
         <AnimatePresence mode="wait">
-          {healthLoading ? (
+          {/* ── Cloud provider panel ──────────────────────── */}
+          {mode === 'cloud' && (
+            <motion.div
+              key="cloud"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={transition.normal}
+              className="mb-6 space-y-4"
+            >
+              {/* Provider selector */}
+              <div className="space-y-2">
+                {CLOUD_PROVIDERS.map((p) => (
+                  <button
+                    key={p.id}
+                    onClick={() => setCloudProvider(p.id)}
+                    className={`flex w-full items-center gap-3 rounded-xl border px-4 py-2.5 text-left transition-all duration-150 ${
+                      cloudProvider === p.id
+                        ? 'border-brand/40 bg-brand/10'
+                        : 'border-white/[0.07] bg-white/[0.02] hover:border-white/20'
+                    }`}
+                  >
+                    <Bot
+                      size={14}
+                      className={cloudProvider === p.id ? p.color : 'text-foreground/30'}
+                    />
+                    <span
+                      className={`text-sm font-medium ${cloudProvider === p.id ? 'text-foreground/90' : 'text-foreground/60'}`}
+                    >
+                      {p.label}
+                    </span>
+                    {cloudProvider === p.id && hasCloudKey && (
+                      <CheckCircle2 size={12} className="ml-auto text-emerald-400" />
+                    )}
+                  </button>
+                ))}
+              </div>
+
+              {/* API key input */}
+              {hasCloudKey ? (
+                <div className="flex items-center gap-2 rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-4 py-2.5">
+                  <Key size={13} className="text-emerald-400" />
+                  <span className="text-sm text-emerald-300/80">
+                    {t('settings.aiProvider.keyStored')}
+                  </span>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <p className="text-xs text-foreground/35">
+                    {t('settings.aiProvider.getKeyAt')}{' '}
+                    <button
+                      onClick={() => void openExternal.mutateAsync(cloudMeta?.docsUrl ?? '')}
+                      className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
+                    >
+                      {(cloudMeta?.docsUrl ?? '').replace('https://', '')}
+                    </button>
+                  </p>
+                  <div className="flex gap-2">
+                    <div className="relative flex-1">
+                      <Input
+                        type={showCloudKey ? 'text' : 'password'}
+                        value={cloudApiKey}
+                        onChange={(e) => setCloudApiKey(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && void handleSaveCloudKey()}
+                        placeholder={cloudMeta?.placeholder ?? '…'}
+                        className="pr-9 font-mono text-sm"
+                      />
+                      <button
+                        onClick={() => setShowCloudKey((v) => !v)}
+                        className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
+                      >
+                        {showCloudKey ? <EyeOff size={13} /> : <Eye size={13} />}
+                      </button>
+                    </div>
+                    <Button
+                      variant="glass"
+                      size="sm"
+                      disabled={!cloudApiKey.trim() || savingCloudKey}
+                      onClick={() => void handleSaveCloudKey()}
+                      className="shrink-0"
+                    >
+                      {savingCloudKey ? (
+                        <Loader2 size={13} className="animate-spin" />
+                      ) : (
+                        t('settings.aiProvider.saveKey')
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </motion.div>
+          )}
+
+          {mode === 'local' && healthLoading ? (
             <motion.div
               key="checking"
               initial={{ opacity: 0 }}
@@ -270,7 +467,7 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
               <Loader2 size={24} className="animate-spin text-brand-soft" />
               <p className="text-sm text-foreground/40">{t('onboarding.ollama.checking')}</p>
             </motion.div>
-          ) : !ollamaReady ? (
+          ) : mode === 'local' && !ollamaReady ? (
             /* ── Ollama not found ─────────────────────────── */
             <motion.div
               key="not-installed"
@@ -329,7 +526,7 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
                 {t('onboarding.ollama.recheck')}
               </Button>
             </motion.div>
-          ) : (
+          ) : mode === 'local' ? (
             /* ── Ollama ready — model selection ──────────── */
             <motion.div
               key="model-select"
@@ -466,7 +663,7 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
                 </AnimatePresence>
               )}
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
 
         {/* Step dots */}

--- a/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
@@ -1,46 +1,179 @@
-import { CheckCircle2, Download, ExternalLink, Loader2, RefreshCw, WifiOff } from 'lucide-react';
+import {
+  Bot,
+  CheckCircle2,
+  Download,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Key,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  WifiOff,
+} from 'lucide-react';
 import { motion } from 'motion/react';
 import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { Button, GlassCard, useToast } from '@ajh/ui';
+import { Button, GlassCard, Input, useToast } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
-import { useAIModels, useOpenExternal, usePullModel, useSystemHealth } from '@/services';
+import type { AiProvider } from '@/store/preferences-schema';
+import {
+  useAIModels,
+  useHasProviderKey,
+  useListProviderModels,
+  useOpenExternal,
+  usePullModel,
+  useRemoveProviderKey,
+  useSetProviderKey,
+  useSystemHealth,
+} from '@/services';
 import { keys } from '@/services/query-client';
-import { useAIModel, usePreferencesStore } from '@/store/preferences-store';
+import { useAIModel, useAiProviderConfig, usePreferencesStore } from '@/store/preferences-store';
 import type { Model } from '@/types';
 
 import { CustomDropdown } from './CustomDropdown';
 
+// ─── Provider metadata ────────────────────────────────────────────────────────
+
+interface ProviderMeta {
+  label: string;
+  description: string;
+  docsUrl: string;
+  color: string;
+  models: string[];
+}
+
+const PROVIDERS: Record<AiProvider, ProviderMeta> = {
+  ollama: {
+    label: 'Ollama (Local)',
+    description: 'Run models locally — no API key, no cloud, fully private.',
+    docsUrl: 'https://ollama.com',
+    color: 'text-emerald-400',
+    models: [],
+  },
+  openai: {
+    label: 'OpenAI',
+    description: 'GPT-4o, GPT-4 Turbo, and more via the OpenAI API.',
+    docsUrl: 'https://platform.openai.com/api-keys',
+    color: 'text-green-400',
+    models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-3.5-turbo', 'o1', 'o1-mini'],
+  },
+  anthropic: {
+    label: 'Anthropic (Claude)',
+    description: 'Claude Opus, Sonnet, and Haiku via the Anthropic API.',
+    docsUrl: 'https://console.anthropic.com/settings/keys',
+    color: 'text-orange-400',
+    models: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+  },
+  gemini: {
+    label: 'Google Gemini',
+    description: 'Gemini 2.0 Flash and Gemini 1.5 Pro via the Gemini API.',
+    docsUrl: 'https://aistudio.google.com/app/apikey',
+    color: 'text-blue-400',
+    models: ['gemini-2.0-flash', 'gemini-1.5-pro', 'gemini-1.5-flash'],
+  },
+  'openai-compatible': {
+    label: 'OpenAI-Compatible',
+    description: 'Any server that speaks the OpenAI API: Groq, Together, LM Studio, etc.',
+    docsUrl: 'https://platform.openai.com/docs/api-reference',
+    color: 'text-purple-400',
+    models: [],
+  },
+};
+
+const PROVIDER_ORDER: AiProvider[] = [
+  'ollama',
+  'openai',
+  'anthropic',
+  'gemini',
+  'openai-compatible',
+];
+
 const QUICK_MODELS = ['llama3.2', 'mistral', 'llama3.1:8b', 'llama3.2:1b'];
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export function AISettingsTab() {
   const { t } = useTranslation();
   const toast = useToast();
   const qc = useQueryClient();
-  const { data: modelList = [], isFetching: loadingModels } = useAIModels();
-  const models = modelList as Model[];
+
+  const providerConfig = useAiProviderConfig();
+  const setAiProviderConfig = usePreferencesStore((s) => s.setAiProviderConfig);
+  const setAIModel = usePreferencesStore((s) => s.setAIModel);
   const aiModel = useAIModel();
-  const setAIModel = usePreferencesStore((state) => state.setAIModel);
+
+  const activeProvider: AiProvider = providerConfig?.provider ?? 'ollama';
+  const meta = PROVIDERS[activeProvider];
+
+  // Ollama
   const { data: health } = useSystemHealth();
   const ollamaReady = (health as { ai?: { ready: boolean } } | undefined)?.ai?.ready ?? false;
+  const { data: ollamaModelsRaw = [], isFetching: loadingOllama } = useAIModels();
+  const ollamaModels = ollamaModelsRaw as Model[];
   const pullModel = usePullModel();
   const openExternal = useOpenExternal();
   const [pulling, setPulling] = useState<string | null>(null);
 
-  const selectedModel = aiModel?.defaultModel || '';
+  // Cloud provider
+  const { data: hasKeyData } = useHasProviderKey(activeProvider);
+  const hasKey = hasKeyData?.has ?? false;
+  const setProviderKey = useSetProviderKey();
+  const removeProviderKey = useRemoveProviderKey();
+  const { data: cloudModelsRaw = [] } = useListProviderModels(activeProvider, hasKey);
+  const cloudModels = cloudModelsRaw as Array<{ name: string }>;
 
-  const handleSelectModel = (modelName: string) => {
-    setAIModel({
-      defaultModel: modelName,
-      temperature: aiModel?.temperature || 0.7,
-      maxTokens: aiModel?.maxTokens || 2048,
-    });
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const [baseUrlInput, setBaseUrlInput] = useState(providerConfig?.baseUrl ?? '');
+  const [showKey, setShowKey] = useState(false);
+  const [savingKey, setSavingKey] = useState(false);
+
+  const selectedModel = providerConfig?.model || aiModel?.defaultModel || '';
+
+  const handleSelectProvider = (provider: AiProvider) => {
+    setAiProviderConfig({ provider, model: '', baseUrl: undefined });
+    setApiKeyInput('');
+    setShowKey(false);
   };
 
-  const handlePull = async (model: string) => {
+  const handleSelectModel = (model: string) => {
+    setAiProviderConfig({ ...providerConfig, provider: activeProvider, model });
+    if (activeProvider === 'ollama') {
+      setAIModel({
+        defaultModel: model,
+        temperature: aiModel?.temperature ?? 0.7,
+        maxTokens: aiModel?.maxTokens ?? 2048,
+      });
+    }
+  };
+
+  const handleSaveKey = async () => {
+    if (!apiKeyInput.trim()) return;
+    setSavingKey(true);
+    try {
+      await setProviderKey.mutateAsync({ provider: activeProvider, apiKey: apiKeyInput.trim() });
+      setApiKeyInput('');
+      toast(`${meta.label} API key saved.`, 'success');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Failed to save key.', 'error');
+    } finally {
+      setSavingKey(false);
+    }
+  };
+
+  const handleRemoveKey = async () => {
+    try {
+      await removeProviderKey.mutateAsync({ provider: activeProvider });
+      toast(`${meta.label} API key removed.`, 'success');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Failed to remove key.', 'error');
+    }
+  };
+
+  const handlePullOllama = async (model: string) => {
     setPulling(model);
     try {
       await pullModel.mutateAsync(model);
@@ -54,6 +187,13 @@ export function AISettingsTab() {
     }
   };
 
+  const modelOptions =
+    activeProvider === 'ollama'
+      ? ollamaModels
+      : cloudModels.length > 0
+        ? cloudModels
+        : (PROVIDERS[activeProvider]?.models ?? []).map((m) => ({ name: m }));
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 10 }}
@@ -61,31 +201,69 @@ export function AISettingsTab() {
       transition={transition.normal}
       className="space-y-4"
     >
-      {/* Ollama status */}
+      {/* Provider selector */}
       <GlassCard>
         <div className="mb-3 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-          Ollama
+          {t('settings.aiProvider.title')}
         </div>
-        {ollamaReady ? (
-          <div className="flex items-center gap-2 text-sm text-emerald-400">
-            <CheckCircle2 size={14} />
-            {t('onboarding.ollama.ready')}
-          </div>
-        ) : (
-          <div className="space-y-3">
-            <div className="flex items-center gap-2 text-sm text-amber-400/80">
-              <WifiOff size={14} />
-              {t('onboarding.ollama.notFound')}
+        <p className="mb-4 text-sm text-foreground/55">{t('settings.aiProvider.description')}</p>
+        <div className="space-y-2">
+          {PROVIDER_ORDER.map((p) => {
+            const m = PROVIDERS[p];
+            const isActive = p === activeProvider;
+            return (
+              <button
+                key={p}
+                onClick={() => handleSelectProvider(p)}
+                className={`flex w-full items-center gap-3 rounded-xl border px-4 py-3 text-left transition-all duration-150 ${
+                  isActive
+                    ? 'border-brand/40 bg-brand/10'
+                    : 'border-white/[0.07] bg-white/[0.02] hover:border-white/20 hover:bg-white/[0.04]'
+                }`}
+              >
+                <Bot size={16} className={isActive ? m.color : 'text-foreground/30'} />
+                <div className="min-w-0 flex-1">
+                  <div
+                    className={`text-sm font-medium ${isActive ? 'text-foreground/90' : 'text-foreground/60'}`}
+                  >
+                    {m.label}
+                  </div>
+                  <div className="mt-0.5 text-xs text-foreground/30">{m.description}</div>
+                </div>
+                {isActive && <CheckCircle2 size={14} className="shrink-0 text-brand-soft" />}
+              </button>
+            );
+          })}
+        </div>
+      </GlassCard>
+
+      {/* Ollama config */}
+      {activeProvider === 'ollama' && (
+        <GlassCard>
+          <div className="mb-3 flex items-center justify-between">
+            <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+              Ollama
             </div>
-            <div className="flex gap-2">
+            {ollamaReady ? (
+              <div className="flex items-center gap-1.5 text-xs text-emerald-400">
+                <CheckCircle2 size={12} /> Running
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5 text-xs text-amber-400/80">
+                <WifiOff size={12} /> Not detected
+              </div>
+            )}
+          </div>
+
+          {!ollamaReady && (
+            <div className="mb-3 flex gap-2">
               <Button
                 variant="ghost"
                 size="sm"
                 className="flex items-center gap-1.5 text-foreground/50"
                 onClick={() => void openExternal.mutateAsync('https://ollama.com')}
               >
-                <ExternalLink size={12} />
-                {t('onboarding.ollama.downloadButton')}
+                <ExternalLink size={11} /> Download Ollama
               </Button>
               <Button
                 variant="ghost"
@@ -96,65 +274,172 @@ export function AISettingsTab() {
                   qc.invalidateQueries({ queryKey: keys.ai.models });
                 }}
               >
-                <Loader2 size={12} />
-                {t('onboarding.ollama.recheck')}
+                <Loader2 size={11} /> Recheck
               </Button>
             </div>
-          </div>
-        )}
-      </GlassCard>
+          )}
 
-      {/* Model selection */}
-      <GlassCard>
-        <div className="mb-3 flex items-center justify-between">
-          <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-            {t('settings.aiModel.title')}
+          <div className="mb-3 flex items-center justify-between">
+            <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+              {t('settings.aiModel.title')}
+            </div>
+            <Button
+              onClick={() => void qc.invalidateQueries({ queryKey: keys.ai.models })}
+              disabled={loadingOllama}
+              className="flex items-center gap-1.5 rounded-lg bg-white/5 px-2 py-1 text-xs text-foreground/60 hover:text-foreground h-auto border-transparent"
+            >
+              <RefreshCw size={11} className={loadingOllama ? 'animate-spin' : ''} />
+              {t('settings.aiModel.refresh')}
+            </Button>
           </div>
-          <Button
-            onClick={() => void qc.invalidateQueries({ queryKey: keys.ai.models })}
-            disabled={loadingModels}
-            className="flex items-center gap-1.5 rounded-lg bg-white/5 px-3 py-1.5 text-xs text-foreground/70 hover:text-foreground transition-colors disabled:opacity-50 h-auto border-transparent"
-          >
-            <RefreshCw size={12} className={loadingModels ? 'animate-spin' : ''} />
-            {t('settings.aiModel.refresh')}
-          </Button>
-        </div>
-        <p className="mb-4 text-sm text-foreground/55">{t('settings.aiModel.description')}</p>
 
-        {loadingModels ? (
-          <div className="text-sm text-foreground/50">{t('settings.aiModel.loading')}</div>
-        ) : models.length === 0 ? (
-          <div className="space-y-3">
-            <p className="text-sm text-foreground/50">{t('settings.aiModel.noModels')}</p>
-            {ollamaReady && (
-              <div className="space-y-2">
-                <p className="text-xs text-foreground/30">{t('onboarding.ollama.chooseModel')}</p>
-                {QUICK_MODELS.map((m) => (
-                  <button
-                    key={m}
-                    onClick={() => void handlePull(m)}
-                    disabled={pulling !== null}
-                    className="flex w-full items-center justify-between rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2.5 text-left text-sm transition-colors hover:border-white/20 hover:bg-white/[0.04] disabled:opacity-50"
-                  >
-                    <span className="text-foreground/70">{m}</span>
-                    {pulling === m ? (
-                      <Loader2 size={13} className="animate-spin text-brand-soft" />
-                    ) : (
-                      <Download size={13} className="text-foreground/30" />
-                    )}
-                  </button>
-                ))}
+          {ollamaModels.length === 0 ? (
+            <div className="space-y-3">
+              <p className="text-sm text-foreground/50">{t('settings.aiModel.noModels')}</p>
+              {ollamaReady && (
+                <div className="space-y-2">
+                  <p className="text-xs text-foreground/30">{t('onboarding.ollama.chooseModel')}</p>
+                  {QUICK_MODELS.map((m) => (
+                    <button
+                      key={m}
+                      onClick={() => void handlePullOllama(m)}
+                      disabled={pulling !== null}
+                      className="flex w-full items-center justify-between rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2.5 text-left text-sm transition-colors hover:border-white/20 hover:bg-white/[0.04] disabled:opacity-50"
+                    >
+                      <span className="text-foreground/70">{m}</span>
+                      {pulling === m ? (
+                        <Loader2 size={13} className="animate-spin text-brand-soft" />
+                      ) : (
+                        <Download size={13} className="text-foreground/30" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <CustomDropdown
+              models={ollamaModels}
+              selectedModel={selectedModel}
+              onSelectModel={handleSelectModel}
+            />
+          )}
+        </GlassCard>
+      )}
+
+      {/* Cloud provider config */}
+      {activeProvider !== 'ollama' && (
+        <GlassCard>
+          <div className="mb-3 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+            {t('settings.aiProvider.apiKey')}
+          </div>
+
+          {hasKey ? (
+            <div className="mb-4 flex items-center justify-between rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-4 py-2.5">
+              <div className="flex items-center gap-2 text-sm text-emerald-300/80">
+                <Key size={13} />
+                {t('settings.aiProvider.keyStored')}
               </div>
-            )}
-          </div>
-        ) : (
-          <CustomDropdown
-            models={models}
-            selectedModel={selectedModel}
-            onSelectModel={handleSelectModel}
-          />
-        )}
-      </GlassCard>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="flex items-center gap-1 text-xs text-red-400/60 hover:text-red-400"
+                onClick={() => void handleRemoveKey()}
+              >
+                <Trash2 size={11} /> {t('settings.aiProvider.removeKey')}
+              </Button>
+            </div>
+          ) : (
+            <div className="mb-4 space-y-2">
+              <p className="text-xs text-foreground/40">
+                {t('settings.aiProvider.getKeyAt')}{' '}
+                <button
+                  onClick={() => void openExternal.mutateAsync(meta.docsUrl)}
+                  className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
+                >
+                  {meta.docsUrl.replace('https://', '')}
+                </button>
+              </p>
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Input
+                    type={showKey ? 'text' : 'password'}
+                    value={apiKeyInput}
+                    onChange={(e) => setApiKeyInput(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && void handleSaveKey()}
+                    placeholder={t('settings.aiProvider.keyPlaceholder')}
+                    className="pr-9 font-mono text-sm"
+                  />
+                  <button
+                    onClick={() => setShowKey((v) => !v)}
+                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
+                  >
+                    {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                  </button>
+                </div>
+                <Button
+                  variant="glass"
+                  size="sm"
+                  disabled={!apiKeyInput.trim() || savingKey}
+                  onClick={() => void handleSaveKey()}
+                  className="shrink-0"
+                >
+                  {savingKey ? (
+                    <Loader2 size={13} className="animate-spin" />
+                  ) : (
+                    t('settings.aiProvider.saveKey')
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Base URL for openai-compatible */}
+          {activeProvider === 'openai-compatible' && (
+            <div className="mb-4 space-y-2">
+              <label className="text-xs font-medium uppercase tracking-widest text-foreground/30">
+                {t('settings.aiProvider.baseUrl')}
+              </label>
+              <div className="flex gap-2">
+                <Input
+                  value={baseUrlInput}
+                  onChange={(e) => setBaseUrlInput(e.target.value)}
+                  placeholder="https://api.groq.com/openai/v1"
+                  className="flex-1 font-mono text-sm"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() =>
+                    setAiProviderConfig({
+                      provider: activeProvider,
+                      model: providerConfig?.model ?? '',
+                      baseUrl: baseUrlInput || undefined,
+                    })
+                  }
+                >
+                  {t('settings.aiProvider.saveUrl')}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Model selector */}
+          {hasKey && modelOptions.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+                {t('settings.aiModel.title')}
+              </div>
+              <CustomDropdown
+                models={modelOptions}
+                selectedModel={selectedModel}
+                onSelectModel={handleSelectModel}
+              />
+            </div>
+          )}
+        </GlassCard>
+      )}
     </motion.div>
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
@@ -19,7 +19,6 @@ import { Button, GlassCard, Input, useToast } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
-import type { AiProvider } from '@/store/preferences-schema';
 import {
   useAIModels,
   useHasProviderKey,
@@ -31,6 +30,7 @@ import {
   useSystemHealth,
 } from '@/services';
 import { keys } from '@/services/query-client';
+import type { AiProvider } from '@/store/preferences-schema';
 import { useAIModel, useAiProviderConfig, usePreferencesStore } from '@/store/preferences-store';
 import type { Model } from '@/types';
 

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -237,6 +237,18 @@
       "description": "Den Einführungsassistenten erneut abspielen, um die Funktionsübersicht zu wiederholen.",
       "replay": "Assistent erneut abspielen"
     },
+    "aiProvider": {
+      "title": "KI-Anbieter",
+      "description": "Wählen Sie, wo Ihre KI läuft — lokal über Ollama oder über eine Cloud-API.",
+      "apiKey": "API-Schlüssel",
+      "keyStored": "API-Schlüssel sicher im OS-Schlüsselbund gespeichert",
+      "removeKey": "Entfernen",
+      "getKeyAt": "Holen Sie sich Ihren API-Schlüssel unter",
+      "keyPlaceholder": "API-Schlüssel einfügen…",
+      "saveKey": "Speichern",
+      "baseUrl": "Basis-URL",
+      "saveUrl": "Speichern"
+    },
     "aiModel": {
       "title": "KI-Modell",
       "refresh": "Aktualisieren",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -237,6 +237,18 @@
       "description": "Replay the introductory wizard to revisit the feature tour.",
       "replay": "Replay wizard"
     },
+    "aiProvider": {
+      "title": "AI Provider",
+      "description": "Choose where your AI runs — locally via Ollama or through a cloud API.",
+      "apiKey": "API Key",
+      "keyStored": "API key stored securely in OS keychain",
+      "removeKey": "Remove",
+      "getKeyAt": "Get your API key at",
+      "keyPlaceholder": "Paste your API key…",
+      "saveKey": "Save",
+      "baseUrl": "Base URL",
+      "saveUrl": "Save"
+    },
     "aiModel": {
       "title": "AI Model",
       "refresh": "Refresh",

--- a/apps/tauri/src/renderer/lib/generate-ai.ts
+++ b/apps/tauri/src/renderer/lib/generate-ai.ts
@@ -28,8 +28,9 @@ import {
   validateMetadata,
 } from '@ajh/prompts/generate';
 
-import { getClient } from './app-client';
 import { usePreferencesStore } from '@/store/preferences-store';
+
+import { getClient } from './app-client';
 
 export type { GenerationMeta, GenerationMode };
 export { MODES } from '@ajh/prompts/generate';

--- a/apps/tauri/src/renderer/lib/generate-ai.ts
+++ b/apps/tauri/src/renderer/lib/generate-ai.ts
@@ -29,6 +29,7 @@ import {
 } from '@ajh/prompts/generate';
 
 import { getClient } from './app-client';
+import { usePreferencesStore } from '@/store/preferences-store';
 
 export type { GenerationMeta, GenerationMode };
 export { MODES } from '@ajh/prompts/generate';
@@ -51,15 +52,20 @@ async function streamGenerate(
   locale = 'en'
 ): Promise<string> {
   const api = getClient();
+  const providerConfig = usePreferencesStore.getState().aiProviderConfig;
+  const activeModel = providerConfig?.model || model;
   const res = (await api.ai.generate({
-    model,
+    model: activeModel,
     messages: [
       { role: 'system', content: system },
       { role: 'user', content: user },
     ],
     locale: safeLocale(locale),
     temperature,
-  })) as { jobId: string };
+    ...(providerConfig?.provider && providerConfig.provider !== 'ollama'
+      ? { provider: providerConfig.provider, baseUrl: providerConfig.baseUrl }
+      : {}),
+  } as Parameters<typeof api.ai.generate>[0])) as { jobId: string };
 
   const jobId = res.jobId;
   let buffer = '';

--- a/apps/tauri/src/renderer/lib/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client.ts
@@ -57,6 +57,10 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       unloadModel: noop,
       embed: noop,
       onStream: unsub,
+      setProviderKey: noop,
+      removeProviderKey: noop,
+      hasProviderKey: async () => ({ has: false }),
+      listProviderModels: emptyList,
     },
 
     documents: {

--- a/apps/tauri/src/renderer/lib/web-http-client.ts
+++ b/apps/tauri/src/renderer/lib/web-http-client.ts
@@ -118,6 +118,10 @@ export function createWebHttpClient({ baseUrl, token }: WebHttpClientOptions): A
       unloadModel: (model) => cmd('ai', 'unloadModel', { model }),
       embed: (req) => cmd('ai', 'embed', req),
       onStream: (handler) => subscribe('ai.stream', handler),
+      setProviderKey: (req) => cmd('ai', 'setProviderKey', req),
+      removeProviderKey: (req) => cmd('ai', 'removeProviderKey', req),
+      hasProviderKey: (req) => cmd('ai', 'hasProviderKey', req),
+      listProviderModels: (req) => cmd('ai', 'listProviderModels', req),
     },
 
     documents: {

--- a/apps/tauri/src/renderer/services/index.ts
+++ b/apps/tauri/src/renderer/services/index.ts
@@ -14,6 +14,7 @@
  */
 export * from './query-client';
 export * from './use-ai';
+export * from './use-ai-provider';
 export * from './use-apply';
 export * from './use-autopilot';
 export * from './use-boards';

--- a/apps/tauri/src/renderer/services/use-ai-provider.ts
+++ b/apps/tauri/src/renderer/services/use-ai-provider.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useAppClient } from '@/providers/AppClientProvider';
+import { useAiProviderConfig } from '@/store/preferences-store';
+
+import { keys } from './query-client';
+
+export const useHasProviderKey = (provider: string) => {
+  const api = useAppClient();
+  return useQuery({
+    queryKey: [...keys.ai.models, 'provider-key', provider],
+    queryFn: () => api.ai.hasProviderKey({ provider }),
+    enabled: provider !== 'ollama',
+    staleTime: 30_000,
+  });
+};
+
+export const useSetProviderKey = () => {
+  const api = useAppClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ provider, apiKey }: { provider: string; apiKey: string }) =>
+      api.ai.setProviderKey({ provider, apiKey }),
+    onSuccess: (_data, { provider }) => {
+      qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-key', provider] });
+      qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-models', provider] });
+    },
+  });
+};
+
+export const useRemoveProviderKey = () => {
+  const api = useAppClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ provider }: { provider: string }) => api.ai.removeProviderKey({ provider }),
+    onSuccess: (_data, { provider }) => {
+      qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-key', provider] });
+    },
+  });
+};
+
+export const useListProviderModels = (provider: string, enabled = true) => {
+  const api = useAppClient();
+  return useQuery({
+    queryKey: [...keys.ai.models, 'provider-models', provider],
+    queryFn: () => api.ai.listProviderModels({ provider }),
+    enabled: enabled && provider !== 'ollama',
+    staleTime: 300_000,
+  });
+};
+
+/** Returns the provider/model/baseUrl to inject into every ai_generate call. */
+export const useGenerateConfig = () => {
+  const config = useAiProviderConfig();
+  return {
+    provider: config?.provider ?? 'ollama',
+    model: config?.model ?? '',
+    baseUrl: config?.baseUrl,
+  };
+};

--- a/apps/tauri/src/renderer/store/preferences-schema.ts
+++ b/apps/tauri/src/renderer/store/preferences-schema.ts
@@ -50,6 +50,24 @@ export const AIModelPreferenceSchema = z.object({
   maxTokens: z.number().min(1).max(8192).default(2048),
 });
 
+// AI provider selection (API key stored in OS keychain, not here)
+export const AiProviderSchema = z.enum([
+  'ollama',
+  'openai',
+  'anthropic',
+  'gemini',
+  'openai-compatible',
+]);
+
+export const AiProviderConfigSchema = z.object({
+  provider: AiProviderSchema.default('ollama'),
+  model: z.string().default(''),
+  baseUrl: z.string().optional(), // for openai-compatible endpoints
+});
+
+export type AiProvider = z.infer<typeof AiProviderSchema>;
+export type AiProviderConfig = z.infer<typeof AiProviderConfigSchema>;
+
 // Resume preference
 export const ResumePreferenceSchema = z.object({
   defaultId: z.string().optional(),
@@ -67,6 +85,7 @@ export const PreferencesSchema = z.object({
   // AI Preferences
   language: z.string().default('en'),
   aiModel: AIModelPreferenceSchema.optional(),
+  aiProviderConfig: AiProviderConfigSchema.optional(),
   outputTone: OutputToneSchema.default('professional'),
 
   // Job Preferences

--- a/apps/tauri/src/renderer/store/preferences-store.ts
+++ b/apps/tauri/src/renderer/store/preferences-store.ts
@@ -44,6 +44,7 @@ interface PreferencesActions {
   setUserName: (userName: string) => void;
   setLanguage: (language: string) => void;
   setAIModel: (aiModel: Preferences['aiModel']) => void;
+  setAiProviderConfig: (config: Preferences['aiProviderConfig']) => void;
   setOutputTone: (outputTone: Preferences['outputTone']) => void;
   setLocation: (location: Preferences['location']) => void;
   setRemote: (remote: Preferences['remote']) => void;
@@ -82,6 +83,13 @@ export const usePreferencesStore = create<PreferencesStore>()(
         set((state) => ({
           ...state,
           aiModel,
+          lastUpdated: new Date().toISOString(),
+        })),
+
+      setAiProviderConfig: (aiProviderConfig: Preferences['aiProviderConfig']) =>
+        set((state) => ({
+          ...state,
+          aiProviderConfig,
           lastUpdated: new Date().toISOString(),
         })),
 
@@ -183,6 +191,7 @@ export const usePreferencesStore = create<PreferencesStore>()(
 export const useUserName = () => usePreferencesStore((state) => state.userName);
 export const useLanguage = () => usePreferencesStore((state) => state.language);
 export const useAIModel = () => usePreferencesStore((state) => state.aiModel);
+export const useAiProviderConfig = () => usePreferencesStore((state) => state.aiProviderConfig);
 export const useOutputTone = () => usePreferencesStore((state) => state.outputTone);
 export const useLocation = () => usePreferencesStore((state) => state.location);
 export const useRemote = () => usePreferencesStore((state) => state.remote);

--- a/apps/tauri/src/tauri-client.ts
+++ b/apps/tauri/src/tauri-client.ts
@@ -65,6 +65,10 @@ export function createTauriInvokeClient(): AppClient {
       embed: (req) => invoke('ai_embed', { req }),
       onStream: (handler) =>
         asyncUnsub(() => listen<AiStreamChunk>('ai:stream', (e) => handler(e.payload))),
+      setProviderKey: ({ provider, apiKey }) => invoke('ai_set_provider_key', { provider, apiKey }),
+      removeProviderKey: ({ provider }) => invoke('ai_remove_provider_key', { provider }),
+      hasProviderKey: ({ provider }) => invoke('ai_has_provider_key', { provider }),
+      listProviderModels: ({ provider }) => invoke('ai_list_provider_models', { provider }),
     },
 
     documents: {

--- a/packages/shared/src/ipc/contracts.ts
+++ b/packages/shared/src/ipc/contracts.ts
@@ -78,8 +78,19 @@ export interface IpcContract {
     unloadModel(model: string): Promise<void>;
 
     /** Synchronous embedding — returns the vector. Falls back gracefully if Ollama is offline. */
-
     embed(req: { text: string; model?: string }): Promise<{ vector: number[]; dim: number } | null>;
+
+    /** Store an API key for a cloud AI provider in the OS keychain. */
+    setProviderKey(req: { provider: string; apiKey: string }): Promise<{ success: boolean }>;
+
+    /** Remove a stored provider API key from the OS keychain. */
+    removeProviderKey(req: { provider: string }): Promise<{ success: boolean }>;
+
+    /** Check whether a provider API key is stored (does not return the key). */
+    hasProviderKey(req: { provider: string }): Promise<{ has: boolean }>;
+
+    /** Fetch available models from a cloud provider using its stored API key. */
+    listProviderModels(req: { provider: string }): Promise<Array<{ name: string }>>;
   };
 
   documents: {


### PR DESCRIPTION
## Summary

Adds full support for cloud AI providers alongside Ollama.

### Rust (`commands.rs`)
- `stream_openai_chat` — SSE streaming for OpenAI and any OpenAI-compatible endpoint (Groq, Together, LM Studio…)
- `stream_anthropic_chat` — Anthropic Claude SSE with system prompt separation
- `stream_gemini_chat` — Google Gemini streaming with role mapping (`assistant → model`)
- `ai_generate` now routes to the correct provider based on `provider` field in the request
- `ai_set_provider_key` / `ai_remove_provider_key` / `ai_has_provider_key` — API keys stored in OS keychain under `ai:{provider}`
- `ai_list_provider_models` — fetches from OpenAI API; hardcoded defaults for Anthropic/Gemini

### Preferences
- `aiProviderConfig: { provider, model, baseUrl? }` added to schema
- `setAiProviderConfig` action + `useAiProviderConfig` selector

### IPC
- `ai.setProviderKey`, `removeProviderKey`, `hasProviderKey`, `listProviderModels` added to contract and `tauri-client.ts`

### Settings (`AISettingsTab`)
- Provider selector: Ollama / OpenAI / Anthropic / Gemini / OpenAI-Compatible
- API key input with show/hide, stored securely in OS keychain
- Base URL field for OpenAI-compatible endpoints
- Model selector per provider

### Onboarding (`OllamaStep`)
- Added **Local / Cloud AI** tab switcher
- Cloud tab: pick OpenAI / Anthropic / Gemini, enter API key → saved to keychain → continue

### Generation
- `generate-ai.ts` reads `aiProviderConfig` from preferences store and injects `provider` + `baseUrl` into every `ai_generate` call

## Test plan

- [ ] Settings → AI → select OpenAI → enter API key → save → model list loads
- [ ] Select a GPT-4o model → run Resume Analyzer → response streams in
- [ ] Onboarding wizard → AI Setup → Cloud AI tab → enter Anthropic key → continue
- [ ] Switch back to Ollama → existing Ollama flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)