### PR TITLE
feat: multi-provider AI, resume library, UX polish & updater manifest

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Bash(grep -v \"^$\")"]
+  }
+}

--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -166,6 +166,18 @@ jobs:
           prerelease: false
           projectPath: ./apps/tauri
 
+      - name: Upload Windows .sig files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $tag = "v${{ needs.determine-release.outputs.version }}"
+          $sigs = Get-ChildItem -Recurse -Filter "*.sig" apps/tauri/src-tauri/target 2>$null
+          foreach ($sig in $sigs) {
+            Write-Host "Uploading $($sig.Name)"
+            gh release upload $tag $sig.FullName --repo ${{ github.repository }} --clobber
+          }
+
   build-tauri-macos:
     name: Build macOS Application (Tauri)
 
@@ -255,6 +267,122 @@ jobs:
           projectPath: ./apps/tauri
           args: --target universal-apple-darwin
 
+      - name: Upload macOS .sig files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.determine-release.outputs.version }}"
+          find apps/tauri/src-tauri/target -name "*.sig" 2>/dev/null | while read sig; do
+            echo "Uploading $(basename $sig)"
+            gh release upload "$TAG" "$sig" --repo "${{ github.repository }}" --clobber
+          done
+
+  generate-updater-manifest:
+    name: Generate Updater Manifest (latest.json)
+
+    needs:
+      - determine-release
+      - build-tauri-windows
+      - build-tauri-macos
+
+    if: needs.determine-release.outputs.released == 'true'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Generate and upload latest.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.determine-release.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          TAG="v${VERSION}"
+          BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          # Fetch release notes from the GitHub release body
+          NOTES=$(gh release view "${TAG}" --repo "${REPO}" --json body -q '.body' 2>/dev/null || echo "")
+
+          # Download all .sig files from the release
+          gh release download "${TAG}" \
+            --repo "${REPO}" \
+            --pattern "*.sig" \
+            --dir /tmp/sigs \
+            2>/dev/null || true
+
+          ls /tmp/sigs/ 2>/dev/null || echo "No .sig files found"
+
+          # Read signatures (empty string if file not present)
+          read_sig() {
+            local f="$1"
+            if [ -f "/tmp/sigs/${f}" ]; then
+              cat "/tmp/sigs/${f}"
+            else
+              echo ""
+            fi
+          }
+
+          MACOS_SIG=$(read_sig "AI.Job.Hunter.Assistant_universal.app.tar.gz.sig")
+          WIN_NSIS_SIG=$(read_sig "AI.Job.Hunter.Assistant_${VERSION}_x64-setup.exe.sig")
+          WIN_MSI_SIG=$(read_sig "AI.Job.Hunter.Assistant_${VERSION}_x64_en-US.msi.zip.sig")
+
+          # Prefer NSIS sig for Windows; fall back to MSI
+          WIN_SIG="${WIN_NSIS_SIG:-$WIN_MSI_SIG}"
+          WIN_URL="${BASE_URL}/AI.Job.Hunter.Assistant_${VERSION}_x64-setup.exe"
+          if [ -z "${WIN_SIG}" ] && [ -n "${WIN_MSI_SIG}" ]; then
+            WIN_SIG="${WIN_MSI_SIG}"
+            WIN_URL="${BASE_URL}/AI.Job.Hunter.Assistant_${VERSION}_x64_en-US.msi"
+          fi
+
+          # Build platforms object — only include platforms that have a signature
+          PLATFORMS="{}"
+
+          if [ -n "${MACOS_SIG}" ]; then
+            PLATFORMS=$(echo "${PLATFORMS}" | node -e "
+              const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+              d['darwin-universal'] = {
+                signature: process.env.MACOS_SIG,
+                url: '${BASE_URL}/AI.Job.Hunter.Assistant_universal.app.tar.gz'
+              };
+              process.stdout.write(JSON.stringify(d));
+            " MACOS_SIG="${MACOS_SIG}")
+          fi
+
+          if [ -n "${WIN_SIG}" ]; then
+            PLATFORMS=$(echo "${PLATFORMS}" | node -e "
+              const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+              d['windows-x86_64'] = {
+                signature: process.env.WIN_SIG,
+                url: '${WIN_URL}'
+              };
+              process.stdout.write(JSON.stringify(d));
+            " WIN_SIG="${WIN_SIG}")
+          fi
+
+          # Generate latest.json
+          node -e "
+            const manifest = {
+              version: '${VERSION}',
+              notes: process.env.NOTES || '',
+              pub_date: '${PUB_DATE}',
+              platforms: JSON.parse(process.env.PLATFORMS)
+            };
+            require('fs').writeFileSync('/tmp/latest.json', JSON.stringify(manifest, null, 2));
+            console.log('Generated latest.json:');
+            console.log(JSON.stringify(manifest, null, 2));
+          " NOTES="${NOTES}" PLATFORMS="${PLATFORMS}"
+
+          # Upload latest.json to the release (overwrite if exists)
+          gh release upload "${TAG}" \
+            --repo "${REPO}" \
+            /tmp/latest.json \
+            --clobber
+
+          echo "latest.json uploaded to ${TAG}"
+
   notify-release-success:
     name: Notify Release Success
 
@@ -262,6 +390,7 @@ jobs:
       - determine-release
       - build-tauri-windows
       - build-tauri-macos
+      - generate-updater-manifest
 
     if: needs.determine-release.outputs.released == 'true'
 
@@ -275,7 +404,7 @@ jobs:
           title: 'Production Release Published'
           description: |
             Version v${{ needs.determine-release.outputs.version }} was released successfully.
-            Tauri artifacts uploaded to GitHub Releases.
+            Tauri artifacts and updater manifest uploaded to GitHub Releases.
 
             Repository:
             ${{ github.repository }}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -6,7 +6,7 @@ echo "▶ Running ESLint..."
 pnpm lint
 
 echo "▶ Running TypeScript type check..."
-pnpm typecheck
+pnpm typecheck --force
 
 echo "▶ Building packages..."
 pnpm build:packages

--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -73,7 +73,7 @@ async fn post_sidecar_command(
                             .lock()
                             .unwrap()
                             .complete(job_id, last_done.clone());
-                        let _ = app.emit("jobs:event", json!({"type":"completed","jobId":job_id}));
+                        let _ = app.emit("jobs:event", json!({"type":"job.completed","jobId":job_id}));
                     }
                     "progress" => {
                         let p = event.get("p").and_then(|v| v.as_f64()).unwrap_or(0.0);
@@ -241,6 +241,75 @@ pub fn system_get_metrics() -> Value {
         "totalMemoryMb": total_mem / 1024 / 1024,
         "cpuPercent": (cpu_percent * 10.0).round() / 10.0
     })
+}
+
+// ── Geocoding ────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn geocode_suggest(query: String) -> Value {
+    if query.trim().len() < 2 {
+        return json!([]);
+    }
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .user_agent("AJH-App/1.0")
+        .build()
+        .unwrap_or_default();
+    let Ok(resp) = client
+        .get("https://nominatim.openstreetmap.org/search")
+        .query(&[
+            ("q", query.trim()),
+            ("format", "json"),
+            ("addressdetails", "1"),
+            ("limit", "6"),
+            ("featuretype", "city"),
+        ])
+        .header("Accept-Language", "en")
+        .send()
+        .await
+    else {
+        return json!([]);
+    };
+    let Ok(data) = resp.json::<serde_json::Value>().await else {
+        return json!([]);
+    };
+    let Some(arr) = data.as_array() else {
+        return json!([]);
+    };
+
+    let mut seen = std::collections::HashSet::new();
+    let suggestions: Vec<serde_json::Value> = arr
+        .iter()
+        .filter_map(|item| {
+            let addr = item.get("address")?;
+            let city = addr
+                .get("city")
+                .or_else(|| addr.get("town"))
+                .or_else(|| addr.get("village"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if city.is_empty() {
+                return None;
+            }
+            let parts: Vec<&str> = [
+                city,
+                addr.get("state").and_then(|v| v.as_str()).unwrap_or(""),
+                addr.get("country").and_then(|v| v.as_str()).unwrap_or(""),
+            ]
+            .iter()
+            .filter(|s| !s.is_empty())
+            .copied()
+            .collect();
+            let display = parts.join(", ");
+            if seen.contains(&display) {
+                return None;
+            }
+            seen.insert(display.clone());
+            Some(json!({ "display": display }))
+        })
+        .collect();
+
+    json!(suggestions)
 }
 
 // ── Jobs ─────────────────────────────────────────────────────────────────────

--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -255,15 +255,23 @@ pub async fn geocode_suggest(query: String) -> Value {
         .user_agent("AJH-App/1.0")
         .build()
         .unwrap_or_default();
+    let encoded_q = query
+        .trim()
+        .chars()
+        .flat_map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '~' || c == ' ' {
+                if c == ' ' { vec!['+']} else { vec![c] }
+            } else {
+                format!("%{:02X}", c as u32).chars().collect::<Vec<_>>()
+            }
+        })
+        .collect::<String>();
+    let url = format!(
+        "https://nominatim.openstreetmap.org/search?q={}&format=json&addressdetails=1&limit=6&featuretype=city",
+        encoded_q
+    );
     let Ok(resp) = client
-        .get("https://nominatim.openstreetmap.org/search")
-        .query(&[
-            ("q", query.trim()),
-            ("format", "json"),
-            ("addressdetails", "1"),
-            ("limit", "6"),
-            ("featuretype", "city"),
-        ])
+        .get(&url)
         .header("Accept-Language", "en")
         .send()
         .await

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -236,6 +236,7 @@ fn main() {
             commands::conversations_save_message,
             // native dialogs
             commands::dialog_open_files,
+            commands::geocode_suggest,
             // autopilot
             commands::autopilot_list,
             commands::autopilot_get,

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -31,7 +31,6 @@
     "active": true,
     "targets": ["nsis", "msi", "dmg", "app"],
     "icon": ["icons/icon.ico", "icons/icon.png"],
-    "resources": [],
     "resources": []
   },
   "plugins": {

--- a/apps/tauri/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/tauri/src/renderer/components/layout/Sidebar.tsx
@@ -17,8 +17,6 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useRef, useState } from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
 
-import { Button } from '@ajh/ui';
-
 import { ROUTES } from '@/constants/routes';
 import { cn } from '@/lib/cn';
 import { getTimeGreeting } from '@/lib/greeting';
@@ -162,26 +160,26 @@ export function Sidebar() {
               </span>
             </div>
           </div>
+        </div>
 
-          <div className="relative">
-            <Button
-              onClick={showVersion}
-              className="font-mono text-[9px] tabular-nums text-foreground/20 transition-colors hover:text-foreground/40"
-            >
-              {appVersion}
-            </Button>
-            <AnimatePresence>
-              {versionTooltip && (
-                <motion.div
-                  {...variants.fadeSlideDown}
-                  transition={transition.fast}
-                  className="absolute bottom-full right-0 mb-1.5 whitespace-nowrap rounded-lg border border-white/10 bg-secondary px-2.5 py-1.5 text-[10px] text-foreground/60 shadow-xl"
-                >
-                  {appVersion} · local build
-                </motion.div>
-              )}
-            </AnimatePresence>
-          </div>
+        <div className="relative flex justify-center">
+          <button
+            onClick={showVersion}
+            className="font-mono text-[9px] tabular-nums text-foreground/20 transition-colors hover:text-foreground/40"
+          >
+            {appVersion}
+          </button>
+          <AnimatePresence>
+            {versionTooltip && (
+              <motion.div
+                {...variants.fadeSlideDown}
+                transition={transition.fast}
+                className="absolute bottom-full mb-1.5 whitespace-nowrap rounded-lg border border-white/10 bg-secondary px-2.5 py-1.5 text-[10px] text-foreground/60 shadow-xl"
+              >
+                {appVersion} · local build
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
       </div>
     </aside>

--- a/apps/tauri/src/renderer/components/layout/Titlebar.tsx
+++ b/apps/tauri/src/renderer/components/layout/Titlebar.tsx
@@ -20,7 +20,7 @@ export function Titlebar() {
 
   return (
     <div
-      className="app-drag relative flex h-10 select-none items-center justify-between"
+      className="app-drag relative z-[300] flex h-10 select-none items-center justify-between"
       style={{ paddingLeft: platform === 'darwin' ? 80 : 16 }}
       data-tauri-drag-region
     >

--- a/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
+++ b/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
@@ -1,0 +1,293 @@
+/**
+ * Resume input for AI Generate and Analyze pages.
+ * Lets users: (1) pick a saved resume, (2) upload a new file, (3) paste text.
+ * When a new file is uploaded it shows Save / Set-as-default actions.
+ */
+import type { DocumentRecord } from '@ajh/shared';
+import {
+  BookmarkCheck,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  FileText,
+  Loader2,
+  Save,
+  Sparkles,
+  Upload,
+} from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { Button, TextArea, useToast } from '@ajh/ui';
+
+import { cn } from '@/lib/cn';
+import { useTranslation } from '@/lib/i18n';
+import { useDocuments, useImportDocument } from '@/services';
+import { usePreferencesStore, useResume } from '@/store/preferences-store';
+
+const ACCEPT = '.pdf,.docx,.txt,.md,.markdown';
+const MAX_BYTES = 25 * 1024 * 1024;
+
+interface Props {
+  /** Extracted resume text — controlled by parent */
+  value: string;
+  onChange: (text: string) => void;
+  /** Called when the parent needs to extract text from a raw file */
+  onUpload: (file: File) => Promise<void>;
+  uploading: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+type RawDoc = Omit<DocumentRecord, 'id' | 'importedAt'> & {
+  _id: string;
+  createdAt: number;
+  name?: string;
+  text?: string; // returned by the backend but not in the shared TS type
+};
+
+function normalise(raw: RawDoc): DocumentRecord {
+  return {
+    ...raw,
+    id: raw._id,
+    importedAt: raw.createdAt,
+    source: (raw.source ??
+      (raw.name?.endsWith('.pdf')
+        ? 'pdf'
+        : raw.name?.endsWith('.docx')
+          ? 'docx'
+          : 'txt')) as DocumentRecord['source'],
+  };
+}
+
+export function ResumeInputCard({
+  value,
+  onChange,
+  onUpload,
+  uploading,
+  disabled,
+  placeholder,
+}: Props) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const [expanded, setExpanded] = useState(true);
+  const [showSaved, setShowSaved] = useState(false);
+  const [lastUploadedFile, setLastUploadedFile] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const { data: rawDocs = [] } = useDocuments();
+  const docs = (rawDocs as RawDoc[]).map(normalise);
+  const resumePref = useResume();
+  const setResume = usePreferencesStore((s) => s.setResume);
+  const importDocument = useImportDocument();
+
+  const hasSaved = docs.length > 0;
+  const defaultDoc = docs.find((d) => d.id === resumePref?.defaultId) ?? docs[0];
+
+  // Auto-fill from default resume on first load (only if textarea is still empty)
+  useEffect(() => {
+    if (value) return;
+    const raw =
+      (rawDocs as RawDoc[]).find((d) => d._id === resumePref?.defaultId) ??
+      (rawDocs as RawDoc[])[0];
+    const text = raw?.text?.trim();
+    if (text) onChange(text);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rawDocs.length]);
+
+  /** Load text from a saved document record into the textarea */
+  const handleSelectSaved = (doc: DocumentRecord) => {
+    const raw = (rawDocs as RawDoc[]).find((d) => d._id === doc.id);
+    const text = raw?.text?.trim();
+    if (text) {
+      onChange(text);
+    }
+    setResume({
+      defaultId: doc.id,
+      autoIndex: resumePref?.autoIndex ?? true,
+      autoParse: resumePref?.autoParse ?? true,
+    });
+    setShowSaved(false);
+    setLastUploadedFile(null);
+    toast(t('resumeInput.selectedSaved', { name: doc.title }), 'success');
+  };
+
+  /** Save the freshly-uploaded file to the document library */
+  const handleSaveToLibrary = async (asDefault: boolean) => {
+    if (!lastUploadedFile) return;
+    setSaving(true);
+    try {
+      const bytes = new Uint8Array(await lastUploadedFile.arrayBuffer());
+      await importDocument.mutateAsync({
+        name: lastUploadedFile.name,
+        bytes,
+        title: lastUploadedFile.name,
+      });
+      const saved = (rawDocs as RawDoc[])[0];
+      const id = saved?._id ?? saved?.id;
+      if (asDefault && id) {
+        setResume({ defaultId: String(id), autoIndex: true, autoParse: true });
+      }
+      toast(
+        asDefault ? t('resumeInput.savedAsDefault') : t('resumeInput.savedToLibrary'),
+        'success'
+      );
+      setLastUploadedFile(null);
+    } catch {
+      toast(t('resumeInput.saveFailed'), 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleFileChange = async (file: File) => {
+    if (file.size > MAX_BYTES) {
+      toast(t('resumeInput.tooLarge'), 'error');
+      return;
+    }
+    setLastUploadedFile(file);
+    await onUpload(file);
+  };
+
+  return (
+    <div
+      className={cn(
+        'glass-graphite glass-highlight rounded-xl overflow-hidden transition-colors',
+        value && 'border-brand/20'
+      )}
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between px-3 py-2.5">
+        <div className="flex items-center gap-2">
+          <FileText size={13} className={value ? 'text-brand-soft' : 'text-foreground/30'} />
+          <span className="text-xs font-medium text-foreground/70">{t('resumeInput.label')}</span>
+          {value && <Check size={11} className="text-emerald-400" />}
+        </div>
+        <div className="flex items-center gap-1.5">
+          {/* Pick saved */}
+          {hasSaved && !disabled && (
+            <div className="relative">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowSaved((v) => !v)}
+                className="gap-1 text-[10px] text-foreground/45 hover:text-foreground/70 h-6 px-2"
+              >
+                <BookmarkCheck size={11} />
+                {defaultDoc
+                  ? defaultDoc.title.slice(0, 18) + (defaultDoc.title.length > 18 ? '…' : '')
+                  : t('resumeInput.saved')}
+                {showSaved ? <ChevronUp size={10} /> : <ChevronDown size={10} />}
+              </Button>
+
+              {showSaved && (
+                <div className="absolute right-0 top-full z-50 mt-1 min-w-[200px] rounded-xl glass-elevated shadow-2xl overflow-hidden">
+                  <div className="px-2 py-1.5 space-y-0.5 max-h-48 overflow-y-auto">
+                    {docs.map((doc) => (
+                      <button
+                        key={doc.id}
+                        onClick={() => handleSelectSaved(doc)}
+                        className={cn(
+                          'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs transition-colors',
+                          doc.id === resumePref?.defaultId
+                            ? 'bg-brand/15 text-brand-soft'
+                            : 'text-foreground/65 hover:bg-white/[0.05] hover:text-foreground/90'
+                        )}
+                      >
+                        <FileText size={11} className="shrink-0" />
+                        <span className="truncate flex-1">{doc.title}</span>
+                        {doc.id === resumePref?.defaultId && <Sparkles size={9} />}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Upload button */}
+          {!disabled && (
+            <>
+              <input
+                ref={fileRef}
+                type="file"
+                accept={ACCEPT}
+                className="hidden"
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) void handleFileChange(f);
+                  e.target.value = '';
+                }}
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => fileRef.current?.click()}
+                disabled={uploading}
+                className="h-6 w-6 p-0 text-foreground/40 hover:text-foreground/70"
+              >
+                {uploading ? <Loader2 size={11} className="animate-spin" /> : <Upload size={11} />}
+              </Button>
+            </>
+          )}
+
+          {/* Collapse toggle */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setExpanded((v) => !v)}
+            className="h-6 w-6 p-0 text-foreground/25 hover:text-foreground/50"
+          >
+            {expanded ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+          </Button>
+        </div>
+      </div>
+
+      {/* Text area */}
+      {expanded && (
+        <div className="px-3 pb-3">
+          <TextArea
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={placeholder ?? t('resumeInput.placeholder')}
+            disabled={disabled}
+            rows={6}
+            className="w-full resize-none bg-transparent text-xs text-foreground/80 placeholder:text-foreground/20 disabled:opacity-50"
+          />
+        </div>
+      )}
+
+      {/* Save actions — shown after a fresh file upload */}
+      {lastUploadedFile && value && !saving && (
+        <div className="flex items-center gap-2 border-t border-white/[0.05] px-3 py-2">
+          <span className="flex-1 truncate text-[11px] text-foreground/40">
+            {lastUploadedFile.name}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void handleSaveToLibrary(false)}
+            className="gap-1 text-[11px] text-foreground/45 hover:text-foreground/80 h-6 px-2"
+          >
+            <Save size={10} /> {t('resumeInput.saveToLibrary')}
+          </Button>
+          <Button
+            variant="glass"
+            size="sm"
+            onClick={() => void handleSaveToLibrary(true)}
+            className="gap-1 text-[11px] h-6 px-2 glow-subtle"
+          >
+            <Sparkles size={10} /> {t('resumeInput.setDefault')}
+          </Button>
+        </div>
+      )}
+
+      {saving && (
+        <div className="flex items-center gap-2 border-t border-white/[0.05] px-3 py-2 text-[11px] text-foreground/40">
+          <Loader2 size={10} className="animate-spin" /> {t('resumeInput.saving')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
+++ b/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
@@ -76,8 +76,9 @@ export function ResumeInputCard({
   const [lastUploadedFile, setLastUploadedFile] = useState<File | null>(null);
   const [saving, setSaving] = useState(false);
 
-  const { data: rawDocs = [] } = useDocuments();
-  const docs = (rawDocs as RawDoc[]).map(normalise);
+  const { data: rawDocsUnknown = [] } = useDocuments();
+  const rawDocs = rawDocsUnknown as unknown as RawDoc[];
+  const docs = rawDocs.map(normalise);
   const resumePref = useResume();
   const setResume = usePreferencesStore((s) => s.setResume);
   const importDocument = useImportDocument();
@@ -88,9 +89,7 @@ export function ResumeInputCard({
   // Auto-fill from default resume on first load (only if textarea is still empty)
   useEffect(() => {
     if (value) return;
-    const raw =
-      (rawDocs as RawDoc[]).find((d) => d._id === resumePref?.defaultId) ??
-      (rawDocs as RawDoc[])[0];
+    const raw = rawDocs.find((d) => d._id === resumePref?.defaultId) ?? rawDocs[0];
     const text = raw?.text?.trim();
     if (text) onChange(text);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -98,7 +97,7 @@ export function ResumeInputCard({
 
   /** Load text from a saved document record into the textarea */
   const handleSelectSaved = (doc: DocumentRecord) => {
-    const raw = (rawDocs as RawDoc[]).find((d) => d._id === doc.id);
+    const raw = rawDocs.find((d) => d._id === doc.id);
     const text = raw?.text?.trim();
     if (text) {
       onChange(text);
@@ -124,7 +123,7 @@ export function ResumeInputCard({
         bytes,
         title: lastUploadedFile.name,
       });
-      const saved = (rawDocs as RawDoc[])[0];
+      const saved = rawDocs[0];
       const id = saved?._id ?? saved?.id;
       if (asDefault && id) {
         setResume({ defaultId: String(id), autoIndex: true, autoParse: true });

--- a/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
+++ b/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
@@ -124,7 +124,7 @@ export function ResumeInputCard({
         title: lastUploadedFile.name,
       });
       const saved = rawDocs[0];
-      const id = saved?._id ?? saved?.id;
+      const id = saved?._id;
       if (asDefault && id) {
         setResume({ defaultId: String(id), autoIndex: true, autoParse: true });
       }

--- a/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
+++ b/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
@@ -3,7 +3,6 @@
  * Lets users: (1) pick a saved resume, (2) upload a new file, (3) paste text.
  * When a new file is uploaded it shows Save / Set-as-default actions.
  */
-import type { DocumentRecord } from '@ajh/shared';
 import {
   BookmarkCheck,
   Check,
@@ -17,6 +16,7 @@ import {
 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
+import type { DocumentRecord } from '@ajh/shared';
 import { Button, TextArea, useToast } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';

--- a/apps/tauri/src/renderer/features/dashboard/components/AISystemStatus.tsx
+++ b/apps/tauri/src/renderer/features/dashboard/components/AISystemStatus.tsx
@@ -1,40 +1,94 @@
-import {
-  Activity,
-  CheckCircle,
-  Cpu,
-  Database,
-  Loader2,
-  type LucideIcon,
-  XCircle,
-} from 'lucide-react';
+import { Activity, CheckCircle, Cpu, Database, Loader2, RefreshCw, XCircle } from 'lucide-react';
 
-import { GlassCard } from '@ajh/ui';
+import { Button, GlassCard } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
-
-interface SystemStatus {
-  name: string;
-  status: 'ready' | 'loading' | 'error';
-  icon: LucideIcon;
-  details?: string;
-}
-
-const SYSTEM_STATUS: SystemStatus[] = [
-  { name: 'AI Model', status: 'ready', icon: Cpu, details: 'llama3:8b' },
-  { name: 'Ollama', status: 'ready', icon: Cpu, details: 'Running' },
-  { name: 'Vector DB', status: 'ready', icon: Database, details: 'Indexed' },
-  { name: 'Workers', status: 'ready', icon: Activity, details: '2 active' },
-];
-
-const STATUS_CONFIG = {
-  ready: { icon: CheckCircle, color: 'text-green-400', bg: 'bg-green-500/20' },
-  loading: { icon: Loader2, color: 'text-yellow-400', bg: 'bg-yellow-500/20' },
-  error: { icon: XCircle, color: 'text-red-400', bg: 'bg-red-500/20' },
-};
+import { useSystemHealth, useSystemMetrics } from '@/services';
+import { invalidateHealth } from '@/services/use-system';
 
 export function AISystemStatus() {
   const { t } = useTranslation();
+  const { data: health, isFetching } = useSystemHealth();
+  const { data: metricsRaw } = useSystemMetrics();
+
+  type Health = {
+    ai?: { ready: boolean; model?: string; memoryMB?: number };
+    data?: { ready: boolean; sqlite: boolean; vector: boolean };
+    workers?: { active: number; idle: number; max: number };
+  };
+  type Metrics = { processes?: Array<{ type: string; memory?: { workingSetSize: number } }> };
+
+  const h = health as Health | undefined;
+  const metrics = metricsRaw as Metrics | undefined;
+
+  const rendererMem = metrics?.processes?.find((p) => p.type === 'renderer')?.memory
+    ?.workingSetSize;
+
+  const rows = [
+    {
+      name: t('dashboard.status.aiModel'),
+      icon: Cpu,
+      status: h == null ? 'loading' : h.ai?.ready ? 'ready' : 'error',
+      detail: h?.ai?.ready
+        ? (h.ai.model ?? 'Ready')
+        : h != null
+          ? t('dashboard.status.notAvailable')
+          : t('dashboard.status.checking'),
+    },
+    {
+      name: t('dashboard.status.database'),
+      icon: Database,
+      status: h == null ? 'loading' : h.data?.sqlite ? 'ready' : 'error',
+      detail: h?.data?.sqlite
+        ? t('dashboard.status.connected')
+        : h != null
+          ? t('dashboard.status.notAvailable')
+          : t('dashboard.status.checking'),
+    },
+    {
+      name: t('dashboard.status.vectorDb'),
+      icon: Database,
+      status: h == null ? 'loading' : h.data?.vector ? 'ready' : 'error',
+      detail: h?.data?.vector
+        ? t('dashboard.status.indexed')
+        : h != null
+          ? t('dashboard.status.notAvailable')
+          : t('dashboard.status.checking'),
+    },
+    {
+      name: t('dashboard.status.workers'),
+      icon: Activity,
+      status:
+        h == null
+          ? 'loading'
+          : h.workers && h.workers.active + h.workers.idle > 0
+            ? 'ready'
+            : 'error',
+      detail: h?.workers
+        ? `${h.workers.active} active · ${h.workers.idle} idle`
+        : h != null
+          ? t('dashboard.status.notAvailable')
+          : t('dashboard.status.checking'),
+    },
+  ] as const;
+
+  const statusConfig = {
+    ready: {
+      icon: CheckCircle,
+      color: 'text-emerald-400',
+      bg: 'bg-emerald-500/15',
+      dot: 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.5)]',
+    },
+    loading: {
+      icon: Loader2,
+      color: 'text-amber-400',
+      bg: 'bg-amber-500/15',
+      dot: 'bg-amber-400 animate-pulse',
+    },
+    error: { icon: XCircle, color: 'text-red-400', bg: 'bg-red-500/15', dot: 'bg-red-400' },
+  };
+
   return (
     <GlassCard>
       <div className="mb-4 flex items-center justify-between">
@@ -42,38 +96,57 @@ export function AISystemStatus() {
           <Cpu size={14} />
           {t('dashboard.aiSystemStatus')}
         </div>
+        <Button
+          onClick={() => void invalidateHealth()}
+          disabled={isFetching}
+          className="flex items-center gap-1 rounded-lg bg-white/5 px-2 py-1 text-[10px] text-foreground/40 hover:text-foreground/70 h-auto border-transparent"
+        >
+          <RefreshCw size={10} className={isFetching ? 'animate-spin' : ''} />
+          {t('dashboard.status.refresh')}
+        </Button>
       </div>
 
       <div className="space-y-2">
-        {SYSTEM_STATUS.map((system) => {
-          const config = STATUS_CONFIG[system.status];
-          const StatusIcon = config.icon;
-          const SystemIcon = system.icon;
-
+        {rows.map((row) => {
+          const cfg = statusConfig[row.status];
+          const StatusIcon = cfg.icon;
+          const RowIcon = row.icon;
           return (
             <div
-              key={system.name}
-              className="flex items-center gap-3 rounded-lg bg-white/5 px-3 py-2.5"
+              key={row.name}
+              className="flex items-center gap-3 rounded-lg border border-white/[0.04] bg-white/[0.02] px-3 py-2.5"
             >
-              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-white/5">
-                <SystemIcon size={14} className="text-foreground/40" />
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/[0.04]">
+                <RowIcon size={13} className="text-foreground/35" />
               </div>
-              <div className="flex-1 min-w-0">
-                <div className="text-sm text-foreground">{system.name}</div>
-                <div className="text-xs text-foreground/40">{system.details}</div>
+              <div className="min-w-0 flex-1">
+                <div className="text-xs font-medium text-foreground/80">{row.name}</div>
+                <div className="text-[11px] text-foreground/40">{row.detail}</div>
               </div>
               <div
-                className={cn('flex h-6 w-6 items-center justify-center rounded-full', config.bg)}
+                className={cn(
+                  'flex h-6 w-6 shrink-0 items-center justify-center rounded-full',
+                  cfg.bg
+                )}
               >
                 <StatusIcon
-                  size={14}
-                  className={cn(system.status === 'loading' && 'animate-spin', config.color)}
+                  size={13}
+                  className={cn(cfg.color, row.status === 'loading' && 'animate-spin')}
                 />
               </div>
             </div>
           );
         })}
       </div>
+
+      {rendererMem != null && (
+        <div className="mt-3 flex items-center justify-between rounded-lg border border-white/[0.04] bg-white/[0.02] px-3 py-2">
+          <span className="text-[11px] text-foreground/35">{t('dashboard.status.memory')}</span>
+          <span className="font-mono text-[11px] text-foreground/50">
+            {Math.round(rendererMem / 1024)} MB
+          </span>
+        </div>
+      )}
     </GlassCard>
   );
 }

--- a/apps/tauri/src/renderer/features/dashboard/components/JobPipelineOverview.tsx
+++ b/apps/tauri/src/renderer/features/dashboard/components/JobPipelineOverview.tsx
@@ -1,83 +1,81 @@
-import { Briefcase, CheckCircle, Clock, type LucideIcon, TrendingUp } from 'lucide-react';
+import { Bookmark, Briefcase, CheckCircle, Eye, TrendingUp } from 'lucide-react';
 
 import { GlassCard } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
-
-interface PipelineStat {
-  label: string;
-  labelKey?: string;
-  value: string | number;
-  icon: LucideIcon;
-  color: string;
-  trend?: string;
-}
-
-const PIPELINE_STATS: PipelineStat[] = [
-  {
-    label: 'Saved Jobs',
-    labelKey: 'dashboard.savedJobs',
-    value: 24,
-    icon: Briefcase,
-    color: 'text-blue-400',
-    trend: '+3 this week',
-  },
-  {
-    label: 'Applied',
-    labelKey: 'dashboard.applied',
-    value: 12,
-    icon: CheckCircle,
-    color: 'text-green-400',
-    trend: '+2 this week',
-  },
-  {
-    label: 'Interviews',
-    labelKey: 'dashboard.interviews',
-    value: 3,
-    icon: Clock,
-    color: 'text-orange-400',
-    trend: '+1 this week',
-  },
-  {
-    label: 'AI Matches',
-    labelKey: 'dashboard.aiMatches',
-    value: 45,
-    icon: TrendingUp,
-    color: 'text-purple-400',
-    trend: '+12 this week',
-  },
-];
+import { useInteractions } from '@/services';
 
 export function JobPipelineOverview() {
   const { t } = useTranslation();
 
+  const { data: bookmarked = [] } = useInteractions('bookmarked');
+  const { data: applied = [] } = useInteractions('applied');
+  const { data: viewed = [] } = useInteractions('viewed');
+  const { data: allInteractions = [] } = useInteractions();
+
+  const stats = [
+    {
+      label: t('dashboard.savedJobs'),
+      value: (bookmarked as unknown[]).length,
+      icon: Bookmark,
+      color: 'text-blue-400',
+      bg: 'bg-blue-400/10',
+    },
+    {
+      label: t('dashboard.applied'),
+      value: (applied as unknown[]).length,
+      icon: CheckCircle,
+      color: 'text-emerald-400',
+      bg: 'bg-emerald-400/10',
+    },
+    {
+      label: t('dashboard.viewed'),
+      value: (viewed as unknown[]).length,
+      icon: Eye,
+      color: 'text-orange-400',
+      bg: 'bg-orange-400/10',
+    },
+    {
+      label: t('dashboard.totalTracked'),
+      value: (allInteractions as unknown[]).length,
+      icon: TrendingUp,
+      color: 'text-purple-400',
+      bg: 'bg-purple-400/10',
+    },
+  ];
+
   return (
     <GlassCard>
-      <div className="mb-4 flex items-center justify-between">
-        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-          <Briefcase size={14} />
-          {t('dashboard.jobPipeline')}
-        </div>
+      <div className="mb-4 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+        <Briefcase size={14} />
+        {t('dashboard.jobPipeline')}
       </div>
 
       <div className="grid grid-cols-2 gap-3">
-        {PIPELINE_STATS.map((stat) => {
+        {stats.map((stat) => {
           const Icon = stat.icon;
           return (
             <div
               key={stat.label}
-              className="flex flex-col items-center gap-2 rounded-lg bg-white/5 px-3 py-3"
+              className="flex flex-col items-center gap-2 rounded-xl border border-white/[0.05] bg-white/[0.03] px-3 py-3.5"
             >
-              <Icon size={20} className={stat.color} />
-              <div className="text-2xl font-semibold text-foreground">{stat.value}</div>
-              <div className="text-xs text-foreground/40 text-center">
-                {stat.labelKey ? t(stat.labelKey) : stat.label}
+              <div className={`flex h-8 w-8 items-center justify-center rounded-lg ${stat.bg}`}>
+                <Icon size={15} className={stat.color} />
               </div>
-              {stat.trend && <div className="text-[10px] text-foreground/30">{stat.trend}</div>}
+              <div className="text-2xl font-semibold tabular-nums text-foreground">
+                {stat.value}
+              </div>
+              <div className="text-center text-[11px] text-foreground/40">{stat.label}</div>
             </div>
           );
         })}
       </div>
+
+      {(allInteractions as unknown[]).length === 0 && (
+        <p className="mt-3 text-center text-xs text-foreground/30">
+          {t('dashboard.noJobsTracked')}
+        </p>
+      )}
     </GlassCard>
   );
 }

--- a/apps/tauri/src/renderer/features/onboarding/OnboardingWizard.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/OnboardingWizard.tsx
@@ -7,9 +7,10 @@ import { useOnboardingCompleted, usePreferencesStore } from '@/store/preferences
 import { SpotlightTour } from './SpotlightTour';
 import { OllamaStep } from './steps/OllamaStep';
 import { PrefsStep } from './steps/PrefsStep';
+import { ResumeStep } from './steps/ResumeStep';
 import { WelcomeStep } from './steps/WelcomeStep';
 
-type Step = 'welcome' | 'prefs' | 'ollama' | 'tour';
+type Step = 'welcome' | 'prefs' | 'resume' | 'ollama' | 'tour';
 
 export function OnboardingWizard() {
   const onboardingCompleted = useOnboardingCompleted();
@@ -54,6 +55,14 @@ export function OnboardingWizard() {
             key="prefs"
             direction={direction}
             onBack={() => goBack('welcome')}
+            onNext={() => goNext('resume')}
+          />
+        )}
+        {step === 'resume' && (
+          <ResumeStep
+            key="resume"
+            direction={direction}
+            onBack={() => goBack('prefs')}
             onNext={() => goNext('ollama')}
           />
         )}
@@ -61,7 +70,7 @@ export function OnboardingWizard() {
           <OllamaStep
             key="ollama"
             direction={direction}
-            onBack={() => goBack('prefs')}
+            onBack={() => goBack('resume')}
             onNext={() => goNext('tour')}
           />
         )}

--- a/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
@@ -264,8 +264,8 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
       await setProviderKey.mutateAsync({ provider: cloudProvider, apiKey: cloudApiKey.trim() });
       setCloudApiKey('');
       setAiProviderConfig({
-        provider: cloudProvider,
-        model: CLOUD_DEFAULT_MODELS[cloudProvider] ?? '',
+        activeProvider: cloudProvider,
+        providers: { [cloudProvider]: { model: CLOUD_DEFAULT_MODELS[cloudProvider] ?? '' } },
       });
       toast(`${cloudMeta?.label ?? cloudProvider} API key saved.`, 'success');
     } catch (err) {
@@ -278,12 +278,15 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
   const handleContinue = () => {
     if (mode === 'cloud') {
       setAiProviderConfig({
-        provider: cloudProvider,
-        model: CLOUD_DEFAULT_MODELS[cloudProvider] ?? '',
+        activeProvider: cloudProvider,
+        providers: { [cloudProvider]: { model: CLOUD_DEFAULT_MODELS[cloudProvider] ?? '' } },
       });
     } else if (selectedModel) {
       setAIModel({ defaultModel: selectedModel, temperature: 0.7, maxTokens: 2048 });
-      setAiProviderConfig({ provider: 'ollama', model: selectedModel });
+      setAiProviderConfig({
+        activeProvider: 'ollama',
+        providers: { ollama: { model: selectedModel } },
+      });
     }
     onNext();
   };
@@ -420,15 +423,15 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
                       {(cloudMeta?.docsUrl ?? '').replace('https://', '')}
                     </button>
                   </p>
-                  <div className="flex gap-2">
-                    <div className="relative flex-1">
+                  <div className="flex flex-col gap-2">
+                    <div className="relative">
                       <Input
                         type={showCloudKey ? 'text' : 'password'}
                         value={cloudApiKey}
                         onChange={(e) => setCloudApiKey(e.target.value)}
                         onKeyDown={(e) => e.key === 'Enter' && void handleSaveCloudKey()}
                         placeholder={cloudMeta?.placeholder ?? '…'}
-                        className="pr-9 font-mono text-sm"
+                        className="w-full pr-9 text-sm"
                       />
                       <button
                         onClick={() => setShowCloudKey((v) => !v)}
@@ -437,19 +440,21 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
                         {showCloudKey ? <EyeOff size={13} /> : <Eye size={13} />}
                       </button>
                     </div>
-                    <Button
-                      variant="glass"
-                      size="sm"
-                      disabled={!cloudApiKey.trim() || savingCloudKey}
-                      onClick={() => void handleSaveCloudKey()}
-                      className="shrink-0"
-                    >
-                      {savingCloudKey ? (
-                        <Loader2 size={13} className="animate-spin" />
-                      ) : (
-                        t('settings.aiProvider.saveKey')
-                      )}
-                    </Button>
+                    <div className="flex justify-end">
+                      <Button
+                        variant="glass"
+                        size="sm"
+                        disabled={!cloudApiKey.trim() || savingCloudKey}
+                        onClick={() => void handleSaveCloudKey()}
+                        className={cloudApiKey.trim() && !savingCloudKey ? 'glow-subtle' : ''}
+                      >
+                        {savingCloudKey ? (
+                          <Loader2 size={13} className="animate-spin" />
+                        ) : (
+                          t('settings.aiProvider.saveKey')
+                        )}
+                      </Button>
+                    </div>
                   </div>
                 </div>
               )}

--- a/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep.tsx
@@ -1,8 +1,8 @@
-import type { DocumentRecord } from '@ajh/shared';
 import { ArrowLeft, ArrowRight, FileText, Loader2, Upload } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useRef, useState } from 'react';
 
+import type { DocumentRecord } from '@ajh/shared';
 import { Button, useToast } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';

--- a/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep.tsx
@@ -1,0 +1,155 @@
+import type { DocumentRecord } from '@ajh/shared';
+import { ArrowLeft, ArrowRight, FileText, Loader2, Upload } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useRef, useState } from 'react';
+
+import { Button, useToast } from '@ajh/ui';
+
+import { cn } from '@/lib/cn';
+import { useTranslation } from '@/lib/i18n';
+import { transition } from '@/lib/motion';
+import { useDocuments, useImportDocument } from '@/services';
+import { usePreferencesStore } from '@/store/preferences-store';
+
+interface Props {
+  onBack: () => void;
+  onNext: () => void;
+  direction: number;
+}
+
+export function ResumeStep({ onBack, onNext, direction }: Props) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dragActive, setDragActive] = useState(false);
+
+  const { data: documentsRaw = [] } = useDocuments();
+  const documents = documentsRaw as DocumentRecord[];
+  const importDocument = useImportDocument();
+  const setResume = usePreferencesStore((s) => s.setResume);
+
+  const uploading = importDocument.isPending;
+  const hasResume = documents.length > 0;
+
+  const handleFileUpload = async (file: File) => {
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      await importDocument.mutateAsync({ name: file.name, bytes, title: file.name });
+      const first = (documentsRaw as (DocumentRecord & { _id?: string })[]).find(Boolean);
+      const id = first?._id ?? first?.id;
+      if (id) setResume({ defaultId: String(id), autoIndex: true, autoParse: true });
+      toast(t('onboarding.resume.uploaded'), 'success');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : t('onboarding.resume.uploadFailed'), 'error');
+    }
+  };
+
+  const handleDrag = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(e.type === 'dragenter' || e.type === 'dragover');
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) void handleFileUpload(file);
+  };
+
+  return (
+    <motion.div
+      custom={direction}
+      variants={{
+        initial: (dir: number) => ({ opacity: 0, x: dir * 60 }),
+        animate: { opacity: 1, x: 0 },
+        exit: (dir: number) => ({ opacity: 0, x: dir * -60 }),
+      }}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      transition={transition.modal}
+      className="relative z-10 w-full max-w-lg px-4"
+    >
+      <div className="glass-modal rounded-2xl border border-white/[0.08] p-8 shadow-2xl">
+        {/* Header */}
+        <div className="mb-6 text-center">
+          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-brand/10 ring-1 ring-brand/20">
+            <FileText size={26} className="text-brand-soft/70" />
+          </div>
+          <h2 className="text-xl font-semibold text-foreground">{t('onboarding.resume.title')}</h2>
+          <p className="mt-2 text-sm text-foreground/50">{t('onboarding.resume.description')}</p>
+        </div>
+
+        {/* Upload area */}
+        <div
+          onDragEnter={handleDrag}
+          onDragLeave={handleDrag}
+          onDragOver={handleDrag}
+          onDrop={handleDrop}
+          onClick={() => !uploading && fileInputRef.current?.click()}
+          className={cn(
+            'mb-5 flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-8 transition-all',
+            dragActive
+              ? 'border-brand/50 bg-brand/5'
+              : 'border-white/10 bg-white/[0.02] hover:border-white/20 hover:bg-white/[0.04]',
+            uploading && 'cursor-default opacity-60'
+          )}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf,.doc,.docx,.txt"
+            className="hidden"
+            onChange={(e) => e.target.files?.[0] && void handleFileUpload(e.target.files[0])}
+          />
+          {uploading ? (
+            <div className="flex flex-col items-center gap-3">
+              <Loader2 size={26} className="animate-spin text-brand-soft/60" />
+              <p className="text-sm text-foreground/50">{t('onboarding.resume.uploading')}</p>
+            </div>
+          ) : hasResume ? (
+            <div className="flex flex-col items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/15">
+                <FileText size={20} className="text-emerald-400" />
+              </div>
+              <p className="text-sm font-medium text-foreground/80">{documents[0]?.title}</p>
+              <p className="text-xs text-foreground/35">{t('onboarding.resume.replaceHint')}</p>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-3">
+              <div className={cn('rounded-full p-3', dragActive ? 'bg-brand/15' : 'bg-white/5')}>
+                <Upload
+                  size={22}
+                  className={cn(
+                    'transition-colors',
+                    dragActive ? 'text-brand-soft' : 'text-foreground/35'
+                  )}
+                />
+              </div>
+              <p className="text-sm text-foreground/60">{t('onboarding.resume.dragDrop')}</p>
+              <p className="text-xs text-foreground/35">PDF, DOC, DOCX, TXT · max 50 MB</p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" size="sm" onClick={onBack}>
+            <ArrowLeft size={14} /> {t('onboarding.back')}
+          </Button>
+          <Button
+            variant="glass"
+            size="md"
+            onClick={onNext}
+            className={hasResume ? 'hover:glow-purple px-6 gap-2' : 'px-6 gap-2'}
+          >
+            {hasResume ? t('onboarding.continue') : t('onboarding.resume.skip')}
+            <ArrowRight size={14} />
+          </Button>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
@@ -19,6 +19,7 @@ import { Button, GlassCard, Input, useToast } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
+import { useAppClient } from '@/providers/AppClientProvider';
 import {
   useAIModels,
   useHasProviderKey,
@@ -100,14 +101,15 @@ export function AISettingsTab() {
   const { t } = useTranslation();
   const toast = useToast();
   const qc = useQueryClient();
+  const api = useAppClient();
 
   const providerConfig = useAiProviderConfig();
-  const setAiProviderConfig = usePreferencesStore((s) => s.setAiProviderConfig);
+  const setActiveProvider = usePreferencesStore((s) => s.setActiveProvider);
+  const setProviderSettings = usePreferencesStore((s) => s.setProviderSettings);
   const setAIModel = usePreferencesStore((s) => s.setAIModel);
   const aiModel = useAIModel();
 
-  const activeProvider: AiProvider = providerConfig?.provider ?? 'ollama';
-  const meta = PROVIDERS[activeProvider];
+  const activeProvider: AiProvider = providerConfig?.activeProvider ?? 'ollama';
 
   // Ollama
   const { data: health } = useSystemHealth();
@@ -118,30 +120,43 @@ export function AISettingsTab() {
   const openExternal = useOpenExternal();
   const [pulling, setPulling] = useState<string | null>(null);
 
-  // Cloud provider
-  const { data: hasKeyData } = useHasProviderKey(activeProvider);
-  const hasKey = hasKeyData?.has ?? false;
-  const setProviderKey = useSetProviderKey();
-  const removeProviderKey = useRemoveProviderKey();
-  const { data: cloudModelsRaw = [] } = useListProviderModels(activeProvider, hasKey);
-  const cloudModels = cloudModelsRaw as Array<{ name: string }>;
+  // Key status for every cloud provider (hooks must be called unconditionally)
+  const openaiKey = useHasProviderKey('openai');
+  const anthropicKey = useHasProviderKey('anthropic');
+  const geminiKey = useHasProviderKey('gemini');
+  const compatKey = useHasProviderKey('openai-compatible');
 
-  const [apiKeyInput, setApiKeyInput] = useState('');
-  const [baseUrlInput, setBaseUrlInput] = useState(providerConfig?.baseUrl ?? '');
-  const [showKey, setShowKey] = useState(false);
-  const [savingKey, setSavingKey] = useState(false);
-
-  const selectedModel = providerConfig?.model || aiModel?.defaultModel || '';
-
-  const handleSelectProvider = (provider: AiProvider) => {
-    setAiProviderConfig({ provider, model: '', baseUrl: undefined });
-    setApiKeyInput('');
-    setShowKey(false);
+  const keyStatus: Record<string, boolean> = {
+    ollama: ollamaReady,
+    openai: openaiKey.data?.has ?? false,
+    anthropic: anthropicKey.data?.has ?? false,
+    gemini: geminiKey.data?.has ?? false,
+    'openai-compatible': compatKey.data?.has ?? false,
   };
 
-  const handleSelectModel = (model: string) => {
-    setAiProviderConfig({ ...providerConfig, provider: activeProvider, model });
-    if (activeProvider === 'ollama') {
+  const setProviderKey = useSetProviderKey();
+  const removeProviderKey = useRemoveProviderKey();
+
+  // Which provider row is expanded for editing
+  const [expanded, setExpanded] = useState<AiProvider | null>(null);
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  const [savingKey, setSavingKey] = useState<AiProvider | null>(null);
+  const [baseUrlInput, setBaseUrlInput] = useState(
+    providerConfig?.providers?.['openai-compatible']?.baseUrl ?? ''
+  );
+
+  // Models for the expanded cloud provider
+  const expandedIsCloud = expanded !== null && expanded !== 'ollama';
+  const { data: expandedModelsRaw = [] } = useListProviderModels(
+    expanded ?? 'openai',
+    expandedIsCloud && (keyStatus[expanded ?? 'openai'] ?? false)
+  );
+  const expandedModels = expandedModelsRaw as Array<{ name: string }>;
+
+  const handleSelectModel = (provider: AiProvider, model: string) => {
+    setProviderSettings(provider, { model });
+    if (provider === 'ollama') {
       setAIModel({
         defaultModel: model,
         temperature: aiModel?.temperature ?? 0.7,
@@ -150,24 +165,46 @@ export function AISettingsTab() {
     }
   };
 
-  const handleSaveKey = async () => {
+  const handleSaveKey = async (provider: AiProvider) => {
     if (!apiKeyInput.trim()) return;
-    setSavingKey(true);
+    const meta = PROVIDERS[provider];
+    setSavingKey(provider);
     try {
-      await setProviderKey.mutateAsync({ provider: activeProvider, apiKey: apiKeyInput.trim() });
+      await setProviderKey.mutateAsync({ provider, apiKey: apiKeyInput.trim() });
       setApiKeyInput('');
-      toast(`${meta.label} API key saved.`, 'success');
+      try {
+        const models = await api.ai.listProviderModels({ provider });
+        const count = Array.isArray(models) ? models.length : 0;
+        toast(
+          count > 0
+            ? `${meta.label} connected — ${count} model${count === 1 ? '' : 's'} available.`
+            : `${meta.label} key saved, but no models returned. Double-check the key.`,
+          count > 0 ? 'success' : 'warning'
+        );
+        qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-models', provider] });
+      } catch {
+        toast(
+          `${meta.label} key saved, but couldn't verify it. Check that it's correct.`,
+          'warning'
+        );
+      }
+      // Auto-set as active if no other active provider is connected
+      if (!keyStatus[activeProvider] && activeProvider !== 'ollama') {
+        setActiveProvider(provider);
+      }
     } catch (err) {
       toast(err instanceof Error ? err.message : 'Failed to save key.', 'error');
     } finally {
-      setSavingKey(false);
+      setSavingKey(null);
     }
   };
 
-  const handleRemoveKey = async () => {
+  const handleRemoveKey = async (provider: AiProvider) => {
+    const meta = PROVIDERS[provider];
     try {
-      await removeProviderKey.mutateAsync({ provider: activeProvider });
-      toast(`${meta.label} API key removed.`, 'success');
+      await removeProviderKey.mutateAsync({ provider });
+      toast(`${meta.label} disconnected.`, 'success');
+      if (activeProvider === provider) setActiveProvider('ollama');
     } catch (err) {
       toast(err instanceof Error ? err.message : 'Failed to remove key.', 'error');
     }
@@ -178,7 +215,7 @@ export function AISettingsTab() {
     try {
       await pullModel.mutateAsync(model);
       qc.invalidateQueries({ queryKey: keys.ai.models });
-      handleSelectModel(model);
+      handleSelectModel('ollama', model);
       toast(`${model} downloaded and selected.`, 'success');
     } catch (err) {
       toast(err instanceof Error ? err.message : 'Download failed.', 'error');
@@ -187,12 +224,8 @@ export function AISettingsTab() {
     }
   };
 
-  const modelOptions =
-    activeProvider === 'ollama'
-      ? ollamaModels
-      : cloudModels.length > 0
-        ? cloudModels
-        : (PROVIDERS[activeProvider]?.models ?? []).map((m) => ({ name: m }));
+  // Connected providers available to be set active
+  const connectedProviders = PROVIDER_ORDER.filter((p) => keyStatus[p]);
 
   return (
     <motion.div
@@ -201,245 +234,311 @@ export function AISettingsTab() {
       transition={transition.normal}
       className="space-y-4"
     >
-      {/* Provider selector */}
+      {/* Active provider switcher */}
+      {connectedProviders.length > 1 && (
+        <GlassCard>
+          <div className="mb-3 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+            {t('settings.aiProvider.activeProvider')}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {connectedProviders.map((p) => {
+              const m = PROVIDERS[p];
+              const isActive = p === activeProvider;
+              return (
+                <button
+                  key={p}
+                  onClick={() => setActiveProvider(p)}
+                  className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-all ${
+                    isActive
+                      ? 'border-brand/40 bg-brand/10 text-brand-soft'
+                      : 'border-white/[0.07] bg-white/[0.02] text-foreground/50 hover:border-white/20 hover:text-foreground/80'
+                  }`}
+                >
+                  <Bot size={11} className={isActive ? m.color : ''} />
+                  {m.label}
+                  {isActive && <CheckCircle2 size={10} className="text-brand-soft" />}
+                </button>
+              );
+            })}
+          </div>
+        </GlassCard>
+      )}
+
+      {/* Provider list */}
       <GlassCard>
         <div className="mb-3 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
           {t('settings.aiProvider.title')}
         </div>
-        <p className="mb-4 text-sm text-foreground/55">{t('settings.aiProvider.description')}</p>
         <div className="space-y-2">
           {PROVIDER_ORDER.map((p) => {
             const m = PROVIDERS[p];
+            const connected = keyStatus[p] ?? false;
             const isActive = p === activeProvider;
+            const isExpanded = expanded === p;
+            const providerModel = providerConfig?.providers?.[p]?.model ?? '';
+            const isSaving = savingKey === p;
+
             return (
-              <button
+              <div
                 key={p}
-                onClick={() => handleSelectProvider(p)}
-                className={`flex w-full items-center gap-3 rounded-xl border px-4 py-3 text-left transition-all duration-150 ${
-                  isActive
-                    ? 'border-brand/40 bg-brand/10'
-                    : 'border-white/[0.07] bg-white/[0.02] hover:border-white/20 hover:bg-white/[0.04]'
-                }`}
+                className={`rounded-xl border transition-all ${isExpanded ? 'border-white/15 bg-white/[0.03]' : 'border-white/[0.06] bg-white/[0.01]'}`}
               >
-                <Bot size={16} className={isActive ? m.color : 'text-foreground/30'} />
-                <div className="min-w-0 flex-1">
-                  <div
-                    className={`text-sm font-medium ${isActive ? 'text-foreground/90' : 'text-foreground/60'}`}
-                  >
-                    {m.label}
+                {/* Row header */}
+                <button
+                  onClick={() => {
+                    setExpanded(isExpanded ? null : p);
+                    setApiKeyInput('');
+                    setShowKey(false);
+                  }}
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left"
+                >
+                  <Bot size={15} className={connected ? m.color : 'text-foreground/25'} />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 text-sm font-medium text-foreground/80">
+                      {m.label}
+                      {isActive && connected && (
+                        <span className="rounded-full border border-brand/30 bg-brand/10 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-brand-soft">
+                          Active
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-0.5 text-[11px] text-foreground/35">{m.description}</div>
                   </div>
-                  <div className="mt-0.5 text-xs text-foreground/30">{m.description}</div>
-                </div>
-                {isActive && <CheckCircle2 size={14} className="shrink-0 text-brand-soft" />}
-              </button>
+                  {/* Status badge */}
+                  {p === 'ollama' ? (
+                    connected ? (
+                      <span className="flex items-center gap-1 text-[10px] text-emerald-400/80">
+                        <CheckCircle2 size={10} /> Running
+                      </span>
+                    ) : (
+                      <span className="flex items-center gap-1 text-[10px] text-amber-400/60">
+                        <WifiOff size={10} /> Not detected
+                      </span>
+                    )
+                  ) : connected ? (
+                    <span className="flex items-center gap-1 text-[10px] text-emerald-400/80">
+                      <Key size={10} /> Connected
+                    </span>
+                  ) : (
+                    <span className="text-[10px] text-foreground/30">Not connected</span>
+                  )}
+                </button>
+
+                {/* Expanded config */}
+                {isExpanded && (
+                  <div className="border-t border-white/[0.06] px-4 pb-4 pt-3 space-y-3">
+                    {p === 'ollama' ? (
+                      /* Ollama config */
+                      <>
+                        {!connected && (
+                          <div className="flex gap-2">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-foreground/50"
+                              onClick={() => void openExternal.mutateAsync('https://ollama.com')}
+                            >
+                              <ExternalLink size={11} /> Download Ollama
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-foreground/40"
+                              onClick={() => {
+                                qc.invalidateQueries({ queryKey: keys.system.health });
+                                qc.invalidateQueries({ queryKey: keys.ai.models });
+                              }}
+                            >
+                              <Loader2 size={11} /> Recheck
+                            </Button>
+                          </div>
+                        )}
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+                            {t('settings.aiModel.title')}
+                          </span>
+                          <Button
+                            onClick={() => void qc.invalidateQueries({ queryKey: keys.ai.models })}
+                            disabled={loadingOllama}
+                            className="flex items-center gap-1.5 rounded-lg bg-white/5 px-2 py-1 text-xs text-foreground/60 hover:text-foreground h-auto border-transparent"
+                          >
+                            <RefreshCw size={11} className={loadingOllama ? 'animate-spin' : ''} />
+                            {t('settings.aiModel.refresh')}
+                          </Button>
+                        </div>
+                        {ollamaModels.length === 0 ? (
+                          <div className="space-y-2">
+                            <p className="text-sm text-foreground/50">
+                              {t('settings.aiModel.noModels')}
+                            </p>
+                            {connected &&
+                              QUICK_MODELS.map((qm) => (
+                                <button
+                                  key={qm}
+                                  onClick={() => void handlePullOllama(qm)}
+                                  disabled={pulling !== null}
+                                  className="flex w-full items-center justify-between rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2 text-left text-sm hover:bg-white/[0.04] disabled:opacity-50"
+                                >
+                                  <span className="text-foreground/70">{qm}</span>
+                                  {pulling === qm ? (
+                                    <Loader2 size={13} className="animate-spin text-brand-soft" />
+                                  ) : (
+                                    <Download size={13} className="text-foreground/30" />
+                                  )}
+                                </button>
+                              ))}
+                          </div>
+                        ) : (
+                          <CustomDropdown
+                            models={ollamaModels}
+                            selectedModel={providerModel || aiModel?.defaultModel || ''}
+                            onSelectModel={(m) => handleSelectModel('ollama', m)}
+                          />
+                        )}
+                        {connected && (
+                          <Button
+                            variant="glass"
+                            size="sm"
+                            onClick={() => setActiveProvider('ollama')}
+                            disabled={isActive}
+                            className={isActive ? 'opacity-40' : 'glow-subtle'}
+                          >
+                            {isActive ? 'Currently active' : 'Set as active'}
+                          </Button>
+                        )}
+                      </>
+                    ) : (
+                      /* Cloud provider config */
+                      <>
+                        {connected ? (
+                          <div className="flex items-center justify-between rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-3 py-2">
+                            <div className="flex items-center gap-2 text-sm text-emerald-300/80">
+                              <Key size={12} /> {t('settings.aiProvider.keyStored')}
+                            </div>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-xs text-red-400/60 hover:text-red-400"
+                              onClick={() => void handleRemoveKey(p)}
+                            >
+                              <Trash2 size={11} /> {t('settings.aiProvider.removeKey')}
+                            </Button>
+                          </div>
+                        ) : (
+                          <div className="space-y-2">
+                            <p className="text-xs text-foreground/40">
+                              {t('settings.aiProvider.getKeyAt')}{' '}
+                              <button
+                                onClick={() => void openExternal.mutateAsync(m.docsUrl)}
+                                className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
+                              >
+                                {m.docsUrl.replace('https://', '')}
+                              </button>
+                            </p>
+                            <div className="flex flex-col gap-2">
+                              <div className="relative">
+                                <Input
+                                  type={showKey ? 'text' : 'password'}
+                                  value={apiKeyInput}
+                                  onChange={(e) => setApiKeyInput(e.target.value)}
+                                  onKeyDown={(e) => e.key === 'Enter' && void handleSaveKey(p)}
+                                  placeholder={t('settings.aiProvider.keyPlaceholder')}
+                                  className="w-full pr-9 text-sm"
+                                />
+                                <button
+                                  onClick={() => setShowKey((v) => !v)}
+                                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
+                                >
+                                  {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                                </button>
+                              </div>
+                              <div className="flex justify-end">
+                                <Button
+                                  variant="glass"
+                                  size="sm"
+                                  disabled={!apiKeyInput.trim() || isSaving}
+                                  onClick={() => void handleSaveKey(p)}
+                                  className={apiKeyInput.trim() && !isSaving ? 'glow-subtle' : ''}
+                                >
+                                  {isSaving ? (
+                                    <Loader2 size={13} className="animate-spin" />
+                                  ) : (
+                                    t('settings.aiProvider.saveKey')
+                                  )}
+                                </Button>
+                              </div>
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Base URL for openai-compatible */}
+                        {p === 'openai-compatible' && (
+                          <div className="space-y-1.5">
+                            <label className="text-xs font-medium uppercase tracking-widest text-foreground/30">
+                              {t('settings.aiProvider.baseUrl')}
+                            </label>
+                            <div className="flex gap-2">
+                              <Input
+                                value={baseUrlInput}
+                                onChange={(e) => setBaseUrlInput(e.target.value)}
+                                placeholder="https://api.groq.com/openai/v1"
+                                className="flex-1 text-sm"
+                              />
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="shrink-0"
+                                onClick={() =>
+                                  setProviderSettings('openai-compatible', {
+                                    baseUrl: baseUrlInput || undefined,
+                                  })
+                                }
+                              >
+                                {t('settings.aiProvider.saveUrl')}
+                              </Button>
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Model selector */}
+                        {connected && (
+                          <div className="space-y-1.5">
+                            <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+                              {t('settings.aiModel.title')}
+                            </div>
+                            <CustomDropdown
+                              models={
+                                expandedModels.length > 0
+                                  ? expandedModels
+                                  : (PROVIDERS[p]?.models ?? []).map((n) => ({ name: n }))
+                              }
+                              selectedModel={providerModel}
+                              onSelectModel={(m) => handleSelectModel(p, m)}
+                            />
+                          </div>
+                        )}
+
+                        {/* Set active button */}
+                        {connected && (
+                          <Button
+                            variant="glass"
+                            size="sm"
+                            onClick={() => setActiveProvider(p)}
+                            disabled={isActive}
+                            className={isActive ? 'opacity-40' : 'glow-subtle'}
+                          >
+                            {isActive ? 'Currently active' : 'Set as active'}
+                          </Button>
+                        )}
+                      </>
+                    )}
+                  </div>
+                )}
+              </div>
             );
           })}
         </div>
       </GlassCard>
-
-      {/* Ollama config */}
-      {activeProvider === 'ollama' && (
-        <GlassCard>
-          <div className="mb-3 flex items-center justify-between">
-            <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-              Ollama
-            </div>
-            {ollamaReady ? (
-              <div className="flex items-center gap-1.5 text-xs text-emerald-400">
-                <CheckCircle2 size={12} /> Running
-              </div>
-            ) : (
-              <div className="flex items-center gap-1.5 text-xs text-amber-400/80">
-                <WifiOff size={12} /> Not detected
-              </div>
-            )}
-          </div>
-
-          {!ollamaReady && (
-            <div className="mb-3 flex gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="flex items-center gap-1.5 text-foreground/50"
-                onClick={() => void openExternal.mutateAsync('https://ollama.com')}
-              >
-                <ExternalLink size={11} /> Download Ollama
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="flex items-center gap-1.5 text-foreground/40"
-                onClick={() => {
-                  qc.invalidateQueries({ queryKey: keys.system.health });
-                  qc.invalidateQueries({ queryKey: keys.ai.models });
-                }}
-              >
-                <Loader2 size={11} /> Recheck
-              </Button>
-            </div>
-          )}
-
-          <div className="mb-3 flex items-center justify-between">
-            <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-              {t('settings.aiModel.title')}
-            </div>
-            <Button
-              onClick={() => void qc.invalidateQueries({ queryKey: keys.ai.models })}
-              disabled={loadingOllama}
-              className="flex items-center gap-1.5 rounded-lg bg-white/5 px-2 py-1 text-xs text-foreground/60 hover:text-foreground h-auto border-transparent"
-            >
-              <RefreshCw size={11} className={loadingOllama ? 'animate-spin' : ''} />
-              {t('settings.aiModel.refresh')}
-            </Button>
-          </div>
-
-          {ollamaModels.length === 0 ? (
-            <div className="space-y-3">
-              <p className="text-sm text-foreground/50">{t('settings.aiModel.noModels')}</p>
-              {ollamaReady && (
-                <div className="space-y-2">
-                  <p className="text-xs text-foreground/30">{t('onboarding.ollama.chooseModel')}</p>
-                  {QUICK_MODELS.map((m) => (
-                    <button
-                      key={m}
-                      onClick={() => void handlePullOllama(m)}
-                      disabled={pulling !== null}
-                      className="flex w-full items-center justify-between rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2.5 text-left text-sm transition-colors hover:border-white/20 hover:bg-white/[0.04] disabled:opacity-50"
-                    >
-                      <span className="text-foreground/70">{m}</span>
-                      {pulling === m ? (
-                        <Loader2 size={13} className="animate-spin text-brand-soft" />
-                      ) : (
-                        <Download size={13} className="text-foreground/30" />
-                      )}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          ) : (
-            <CustomDropdown
-              models={ollamaModels}
-              selectedModel={selectedModel}
-              onSelectModel={handleSelectModel}
-            />
-          )}
-        </GlassCard>
-      )}
-
-      {/* Cloud provider config */}
-      {activeProvider !== 'ollama' && (
-        <GlassCard>
-          <div className="mb-3 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-            {t('settings.aiProvider.apiKey')}
-          </div>
-
-          {hasKey ? (
-            <div className="mb-4 flex items-center justify-between rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-4 py-2.5">
-              <div className="flex items-center gap-2 text-sm text-emerald-300/80">
-                <Key size={13} />
-                {t('settings.aiProvider.keyStored')}
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="flex items-center gap-1 text-xs text-red-400/60 hover:text-red-400"
-                onClick={() => void handleRemoveKey()}
-              >
-                <Trash2 size={11} /> {t('settings.aiProvider.removeKey')}
-              </Button>
-            </div>
-          ) : (
-            <div className="mb-4 space-y-2">
-              <p className="text-xs text-foreground/40">
-                {t('settings.aiProvider.getKeyAt')}{' '}
-                <button
-                  onClick={() => void openExternal.mutateAsync(meta.docsUrl)}
-                  className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
-                >
-                  {meta.docsUrl.replace('https://', '')}
-                </button>
-              </p>
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <Input
-                    type={showKey ? 'text' : 'password'}
-                    value={apiKeyInput}
-                    onChange={(e) => setApiKeyInput(e.target.value)}
-                    onKeyDown={(e) => e.key === 'Enter' && void handleSaveKey()}
-                    placeholder={t('settings.aiProvider.keyPlaceholder')}
-                    className="pr-9 font-mono text-sm"
-                  />
-                  <button
-                    onClick={() => setShowKey((v) => !v)}
-                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
-                  >
-                    {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
-                  </button>
-                </div>
-                <Button
-                  variant="glass"
-                  size="sm"
-                  disabled={!apiKeyInput.trim() || savingKey}
-                  onClick={() => void handleSaveKey()}
-                  className="shrink-0"
-                >
-                  {savingKey ? (
-                    <Loader2 size={13} className="animate-spin" />
-                  ) : (
-                    t('settings.aiProvider.saveKey')
-                  )}
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {/* Base URL for openai-compatible */}
-          {activeProvider === 'openai-compatible' && (
-            <div className="mb-4 space-y-2">
-              <label className="text-xs font-medium uppercase tracking-widest text-foreground/30">
-                {t('settings.aiProvider.baseUrl')}
-              </label>
-              <div className="flex gap-2">
-                <Input
-                  value={baseUrlInput}
-                  onChange={(e) => setBaseUrlInput(e.target.value)}
-                  placeholder="https://api.groq.com/openai/v1"
-                  className="flex-1 font-mono text-sm"
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="shrink-0"
-                  onClick={() =>
-                    setAiProviderConfig({
-                      provider: activeProvider,
-                      model: providerConfig?.model ?? '',
-                      baseUrl: baseUrlInput || undefined,
-                    })
-                  }
-                >
-                  {t('settings.aiProvider.saveUrl')}
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {/* Model selector */}
-          {hasKey && modelOptions.length > 0 && (
-            <div className="space-y-2">
-              <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-                {t('settings.aiModel.title')}
-              </div>
-              <CustomDropdown
-                models={modelOptions}
-                selectedModel={selectedModel}
-                onSelectModel={handleSelectModel}
-              />
-            </div>
-          )}
-        </GlassCard>
-      )}
     </motion.div>
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/CustomDropdown.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/CustomDropdown.tsx
@@ -1,19 +1,17 @@
-import { ChevronDown, Cpu, Search } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+/**
+ * Thin compatibility wrapper — new code should use <Dropdown> from '@ajh/ui' directly.
+ * Maps the old model-specific API (models/selectedModel/onSelectModel) to the generic one.
+ */
+import { Cpu } from 'lucide-react';
 
-import { Button } from '@ajh/ui';
+import { Dropdown } from '@ajh/ui';
 
-import { cn } from '@/lib/cn';
-import { transition } from '@/lib/motion';
 import type { Model } from '@/types';
 
 interface CustomDropdownProps {
   models: Model[];
   selectedModel: string;
   onSelectModel: (model: string) => void;
-  /** Show a search box inside the dropdown. Defaults to true when models > 5. */
   searchable?: boolean;
   placeholder?: string;
 }
@@ -25,144 +23,14 @@ export function CustomDropdown({
   searchable,
   placeholder = 'Select a model…',
 }: CustomDropdownProps) {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState('');
-  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
-  const triggerRef = useRef<HTMLDivElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const searchRef = useRef<HTMLInputElement>(null);
-
-  const showSearch = searchable ?? models.length > 5;
-
-  const filtered = useMemo(() => {
-    if (!query.trim()) return models;
-    const q = query.toLowerCase();
-    return models.filter((m) => m.name.toLowerCase().includes(q));
-  }, [models, query]);
-
-  useEffect(() => {
-    if (open && triggerRef.current) {
-      const rect = triggerRef.current.getBoundingClientRect();
-      setPosition({ top: rect.bottom + 6, left: rect.left, width: rect.width });
-    }
-    if (open) {
-      setQuery('');
-      setTimeout(() => searchRef.current?.focus(), 50);
-    }
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (
-        dropdownRef.current?.contains(e.target as Node) ||
-        triggerRef.current?.contains(e.target as Node)
-      )
-        return;
-      setOpen(false);
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
-  const handleSelect = (name: string) => {
-    onSelectModel(name);
-    setOpen(false);
-  };
-
   return (
-    <div ref={triggerRef}>
-      <Button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className={cn(
-          'glass-graphite glass-highlight flex h-9 w-full items-center justify-between gap-2 rounded-xl px-3 text-xs transition-all duration-150',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50',
-          open ? 'border-brand/35' : 'hover:bg-white/[0.02]'
-        )}
-      >
-        <div className="flex items-center gap-2">
-          <Cpu size={13} className="shrink-0 text-foreground/40" />
-          <span
-            className={cn('truncate', selectedModel ? 'text-foreground/90' : 'text-foreground/35')}
-          >
-            {selectedModel || placeholder}
-          </span>
-        </div>
-        <ChevronDown
-          size={12}
-          className={cn(
-            'shrink-0 text-foreground/30 transition-transform duration-150',
-            open && 'rotate-180'
-          )}
-        />
-      </Button>
-
-      {open &&
-        createPortal(
-          <AnimatePresence>
-            <motion.div
-              ref={dropdownRef}
-              initial={{ opacity: 0, y: -6, scale: 0.98 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -6, scale: 0.98 }}
-              transition={transition.fast}
-              style={{
-                position: 'fixed',
-                top: position.top,
-                left: position.left,
-                width: position.width,
-                zIndex: 9999,
-              }}
-              className="glass-elevated overflow-hidden rounded-xl shadow-2xl"
-            >
-              {showSearch && (
-                <div className="border-b border-white/[0.06] px-2 py-2">
-                  <div className="flex items-center gap-2 rounded-lg bg-white/[0.04] px-2.5 py-1.5">
-                    <Search size={11} className="shrink-0 text-foreground/30" />
-                    <input
-                      ref={searchRef}
-                      value={query}
-                      onChange={(e) => setQuery(e.target.value)}
-                      placeholder="Search models…"
-                      className="flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-foreground/25"
-                    />
-                  </div>
-                </div>
-              )}
-
-              <div className="max-h-56 overflow-y-auto px-1 py-1 space-y-1">
-                {filtered.length === 0 ? (
-                  <div className="px-3 py-4 text-center text-xs text-foreground/35">
-                    No models match
-                  </div>
-                ) : (
-                  filtered.map((model) => {
-                    const isSelected = selectedModel === model.name;
-                    return (
-                      <button
-                        key={model.name}
-                        onClick={() => handleSelect(model.name)}
-                        className={cn(
-                          'flex w-full items-center justify-between rounded-lg px-3 py-2 text-xs transition-colors',
-                          isSelected
-                            ? 'bg-brand/15 text-brand-soft'
-                            : 'text-foreground/70 hover:bg-white/[0.05] hover:text-foreground/90'
-                        )}
-                      >
-                        <span>{model.name}</span>
-                        {model.size && (
-                          <span className="text-[10px] text-foreground/35">{model.size}</span>
-                        )}
-                      </button>
-                    );
-                  })
-                )}
-              </div>
-            </motion.div>
-          </AnimatePresence>,
-          document.body
-        )}
-    </div>
+    <Dropdown
+      options={models.map((m) => ({ value: m.name, label: m.name, meta: m.size }))}
+      value={selectedModel}
+      onChange={onSelectModel}
+      placeholder={placeholder}
+      icon={<Cpu size={13} />}
+      searchable={searchable}
+    />
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/CustomDropdown.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/CustomDropdown.tsx
@@ -1,6 +1,6 @@
-import { ChevronDown, Cpu } from 'lucide-react';
+import { ChevronDown, Cpu, Search } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { Button } from '@ajh/ui';
@@ -13,42 +13,62 @@ interface CustomDropdownProps {
   models: Model[];
   selectedModel: string;
   onSelectModel: (model: string) => void;
+  /** Show a search box inside the dropdown. Defaults to true when models > 5. */
+  searchable?: boolean;
+  placeholder?: string;
 }
 
-export function CustomDropdown({ models, selectedModel, onSelectModel }: CustomDropdownProps) {
+export function CustomDropdown({
+  models,
+  selectedModel,
+  onSelectModel,
+  searchable,
+  placeholder = 'Select a model…',
+}: CustomDropdownProps) {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
   const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
   const triggerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const showSearch = searchable ?? models.length > 5;
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return models;
+    const q = query.toLowerCase();
+    return models.filter((m) => m.name.toLowerCase().includes(q));
+  }, [models, query]);
 
   useEffect(() => {
     if (open && triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect();
-      setPosition({
-        top: rect.bottom + 8,
-        left: rect.left,
-        width: rect.width,
-      });
+      setPosition({ top: rect.bottom + 6, left: rect.left, width: rect.width });
+    }
+    if (open) {
+      setQuery('');
+      setTimeout(() => searchRef.current?.focus(), 50);
     }
   }, [open]);
-
-  const handleClickOutside = (e: MouseEvent) => {
-    if (
-      dropdownRef.current &&
-      !dropdownRef.current.contains(e.target as Node) &&
-      triggerRef.current &&
-      !triggerRef.current.contains(e.target as Node)
-    ) {
-      setOpen(false);
-    }
-  };
 
   useEffect(() => {
-    if (open) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
-    }
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        dropdownRef.current?.contains(e.target as Node) ||
+        triggerRef.current?.contains(e.target as Node)
+      )
+        return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
   }, [open]);
+
+  const handleSelect = (name: string) => {
+    onSelectModel(name);
+    setOpen(false);
+  };
 
   return (
     <div ref={triggerRef}>
@@ -66,7 +86,7 @@ export function CustomDropdown({ models, selectedModel, onSelectModel }: CustomD
           <span
             className={cn('truncate', selectedModel ? 'text-foreground/90' : 'text-foreground/35')}
           >
-            {selectedModel || 'Select a model…'}
+            {selectedModel || placeholder}
           </span>
         </div>
         <ChevronDown
@@ -83,9 +103,9 @@ export function CustomDropdown({ models, selectedModel, onSelectModel }: CustomD
           <AnimatePresence>
             <motion.div
               ref={dropdownRef}
-              initial={{ opacity: 0, y: -8, scale: 0.98 }}
+              initial={{ opacity: 0, y: -6, scale: 0.98 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -8, scale: 0.98 }}
+              exit={{ opacity: 0, y: -6, scale: 0.98 }}
               transition={transition.fast}
               style={{
                 position: 'fixed',
@@ -94,27 +114,50 @@ export function CustomDropdown({ models, selectedModel, onSelectModel }: CustomD
                 width: position.width,
                 zIndex: 9999,
               }}
-              className="overflow-hidden rounded-xl border border-white/10 bg-secondary shadow-xl"
+              className="glass-elevated overflow-hidden rounded-xl shadow-2xl"
             >
-              <div className="max-h-64 overflow-y-auto px-1 py-1">
-                {models.map((model) => (
-                  <Button
-                    key={model.name}
-                    variant={selectedModel === model.name ? 'glass' : 'ghost'}
-                    size="md"
-                    onClick={() => {
-                      onSelectModel(model.name);
-                      setOpen(false);
-                    }}
-                    className={cn(
-                      'w-full justify-between px-4 py-2.5',
-                      selectedModel !== model.name && '!bg-transparent hover:bg-white/5'
-                    )}
-                  >
-                    <span>{model.name}</span>
-                    {model.size && <span className="text-xs text-foreground/40">{model.size}</span>}
-                  </Button>
-                ))}
+              {showSearch && (
+                <div className="border-b border-white/[0.06] px-2 py-2">
+                  <div className="flex items-center gap-2 rounded-lg bg-white/[0.04] px-2.5 py-1.5">
+                    <Search size={11} className="shrink-0 text-foreground/30" />
+                    <input
+                      ref={searchRef}
+                      value={query}
+                      onChange={(e) => setQuery(e.target.value)}
+                      placeholder="Search models…"
+                      className="flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-foreground/25"
+                    />
+                  </div>
+                </div>
+              )}
+
+              <div className="max-h-56 overflow-y-auto px-1 py-1 space-y-1">
+                {filtered.length === 0 ? (
+                  <div className="px-3 py-4 text-center text-xs text-foreground/35">
+                    No models match
+                  </div>
+                ) : (
+                  filtered.map((model) => {
+                    const isSelected = selectedModel === model.name;
+                    return (
+                      <button
+                        key={model.name}
+                        onClick={() => handleSelect(model.name)}
+                        className={cn(
+                          'flex w-full items-center justify-between rounded-lg px-3 py-2 text-xs transition-colors',
+                          isSelected
+                            ? 'bg-brand/15 text-brand-soft'
+                            : 'text-foreground/70 hover:bg-white/[0.05] hover:text-foreground/90'
+                        )}
+                      >
+                        <span>{model.name}</span>
+                        {model.size && (
+                          <span className="text-[10px] text-foreground/35">{model.size}</span>
+                        )}
+                      </button>
+                    );
+                  })
+                )}
               </div>
             </motion.div>
           </AnimatePresence>,

--- a/apps/tauri/src/renderer/features/settings/components/ResumePreferences.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ResumePreferences.tsx
@@ -24,19 +24,18 @@ export function ResumePreferences() {
     createdAt: number;
     name?: string;
   };
-  const documents: (DocumentRecord & { _rawSource?: string })[] = (documentsRaw as RawDoc[]).map(
-    (d) => ({
-      ...d,
-      id: d._id,
-      importedAt: d.createdAt,
-      source: (d.source ??
-        (d.name?.endsWith('.pdf')
-          ? 'pdf'
-          : d.name?.endsWith('.docx')
-            ? 'docx'
-            : 'txt')) as DocumentRecord['source'],
-    })
-  );
+  const rawDocs = documentsRaw as unknown as RawDoc[];
+  const documents: DocumentRecord[] = rawDocs.map((d) => ({
+    ...d,
+    id: d._id,
+    importedAt: d.createdAt,
+    source: (d.source ??
+      (d.name?.endsWith('.pdf')
+        ? 'pdf'
+        : d.name?.endsWith('.docx')
+          ? 'docx'
+          : 'txt')) as DocumentRecord['source'],
+  }));
   const importDocument = useImportDocument();
   const removeDocument = useRemoveDocument();
 
@@ -51,9 +50,8 @@ export function ResumePreferences() {
       if (fileInputRef.current) fileInputRef.current.value = '';
       // Set as default only if none already selected
       if (!resume?.defaultId) {
-        const first = (documentsRaw as RawDoc[])[0];
-        const firstId = first?._id ?? first?.id;
-        if (firstId) setResume({ defaultId: String(firstId), autoIndex: true, autoParse: true });
+        const firstId = rawDocs[0]?._id;
+        if (firstId) setResume({ defaultId: firstId, autoIndex: true, autoParse: true });
       }
       toast(t('settings.resume.uploaded'), 'success');
     } catch (err) {

--- a/apps/tauri/src/renderer/features/settings/components/ResumePreferences.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ResumePreferences.tsx
@@ -1,73 +1,78 @@
-import { AlertCircle, Check, FileText, Sparkles, Trash2, Upload } from 'lucide-react';
+import { AlertCircle, FileText, Loader2, Sparkles, Trash2, Upload } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useRef, useState } from 'react';
 
-import { Button, GlassCard } from '@ajh/ui';
+import type { DocumentRecord } from '@ajh/shared';
+import { Button, GlassCard, useToast } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
+import { useDocuments, useImportDocument, useRemoveDocument } from '@/services';
 import { usePreferencesStore, useResume } from '@/store/preferences-store';
-
-interface Resume {
-  id: string;
-  name: string;
-  uploadedAt: string;
-  size: number;
-  indexed: boolean;
-  skillsExtracted: string[];
-  atsScore?: number;
-}
 
 export function ResumePreferences() {
   const { t } = useTranslation();
+  const toast = useToast();
   const resume = useResume();
   const setResume = usePreferencesStore((state) => state.setResume);
-  const [resumes, setResumes] = useState<Resume[]>([]);
-  const [uploading, setUploading] = useState(false);
+
+  const { data: documentsRaw = [], isLoading } = useDocuments();
+  // Rust serialises id as _id and created_at as createdAt — normalise here
+  type RawDoc = Omit<DocumentRecord, 'id' | 'importedAt'> & {
+    _id: string;
+    createdAt: number;
+    name?: string;
+  };
+  const documents: (DocumentRecord & { _rawSource?: string })[] = (documentsRaw as RawDoc[]).map(
+    (d) => ({
+      ...d,
+      id: d._id,
+      importedAt: d.createdAt,
+      source: (d.source ??
+        (d.name?.endsWith('.pdf')
+          ? 'pdf'
+          : d.name?.endsWith('.docx')
+            ? 'docx'
+            : 'txt')) as DocumentRecord['source'],
+    })
+  );
+  const importDocument = useImportDocument();
+  const removeDocument = useRemoveDocument();
+
   const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileUpload = async (file: File) => {
-    setUploading(true);
-    // Simulate upload and processing
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-
-    const newResume: Resume = {
-      id: Date.now().toString(),
-      name: file.name,
-      uploadedAt: new Date().toISOString(),
-      size: file.size,
-      indexed: true,
-      skillsExtracted: ['JavaScript', 'TypeScript', 'React', 'Node.js'],
-      atsScore: 85,
-    };
-
-    setResumes([...resumes, newResume]);
-    if (!resume?.defaultId) {
-      setResume({ defaultId: newResume.id, autoIndex: true, autoParse: true });
+    if (!file) return;
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      await importDocument.mutateAsync({ name: file.name, bytes, title: file.name });
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      // Set as default only if none already selected
+      if (!resume?.defaultId) {
+        const first = (documentsRaw as RawDoc[])[0];
+        const firstId = first?._id ?? first?.id;
+        if (firstId) setResume({ defaultId: String(firstId), autoIndex: true, autoParse: true });
+      }
+      toast(t('settings.resume.uploaded'), 'success');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : t('settings.resume.uploadFailed'), 'error');
     }
-    setUploading(false);
   };
 
   const handleDrag = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (e.type === 'dragenter' || e.type === 'dragover') {
-      setDragActive(true);
-    } else if (e.type === 'dragleave') {
-      setDragActive(false);
-    }
+    setDragActive(e.type === 'dragenter' || e.type === 'dragover');
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setDragActive(false);
-
-    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-      void handleFileUpload(e.dataTransfer.files[0]);
-    }
+    const file = e.dataTransfer.files?.[0];
+    if (file) void handleFileUpload(file);
   };
 
   const handleSetDefault = (id: string) => {
@@ -78,18 +83,27 @@ export function ResumePreferences() {
     });
   };
 
-  const handleDelete = (id: string) => {
-    setResumes(resumes.filter((r) => r.id !== id));
-    if (resume?.defaultId === id) {
-      setResume({
-        defaultId: resumes.find((r) => r.id !== id)?.id,
-        autoIndex: resume?.autoIndex ?? true,
-        autoParse: resume?.autoParse ?? true,
-      });
+  const handleDelete = async (id: string) => {
+    try {
+      await removeDocument.mutateAsync(id);
+      if (resume?.defaultId === id) {
+        const next = documents.find((d) => d.id !== id);
+        setResume({
+          defaultId: next?.id,
+          autoIndex: resume?.autoIndex ?? true,
+          autoParse: resume?.autoParse ?? true,
+        });
+      }
+      toast(t('settings.resume.removed'), 'success');
+    } catch {
+      toast(t('settings.resume.removeFailed'), 'error');
     }
   };
 
-  const formatFileSize = (bytes: number) => {
+  const uploading = importDocument.isPending;
+
+  const formatFileSize = (bytes?: number) => {
+    if (!bytes) return '';
     if (bytes < 1024) return bytes + ' B';
     if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
     return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
@@ -97,208 +111,148 @@ export function ResumePreferences() {
 
   return (
     <GlassCard>
-      <div className="mb-4 flex items-center justify-between">
-        <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-          {t('settings.resume.title')}
-        </div>
+      <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
+        {t('settings.resume.title')}
       </div>
-
       <p className="mb-4 text-sm text-foreground/55">{t('settings.resume.description')}</p>
 
-      {/* Upload Area */}
+      {/* Upload area */}
       <div
         onDragEnter={handleDrag}
         onDragLeave={handleDrag}
         onDragOver={handleDrag}
         onDrop={handleDrop}
-        onClick={() => fileInputRef.current?.click()}
+        onClick={() => !uploading && fileInputRef.current?.click()}
         className={cn(
-          'relative mb-6 flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-8 transition-all',
+          'relative mb-5 flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-8 transition-all',
           dragActive
-            ? 'border-brand-soft/50 bg-brand-soft/5'
-            : 'border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/10'
+            ? 'border-brand/50 bg-brand/5'
+            : 'border-white/10 bg-white/[0.02] hover:border-white/20 hover:bg-white/[0.04]',
+          uploading && 'cursor-default opacity-60'
         )}
       >
         <input
           ref={fileInputRef}
           type="file"
-          accept=".pdf,.doc,.docx"
+          accept=".pdf,.doc,.docx,.txt"
           className="hidden"
-          onChange={(e) => e.target.files?.[0] && handleFileUpload(e.target.files[0])}
+          onChange={(e) => e.target.files?.[0] && void handleFileUpload(e.target.files[0])}
         />
-
         {uploading ? (
           <div className="flex flex-col items-center gap-3">
-            <motion.div animate={{ rotate: 360 }} transition={transition.spin}>
-              <Upload size={32} className="text-brand-soft" />
-            </motion.div>
-            <div className="text-sm text-foreground/60">{t('settings.resume.uploading')}</div>
+            <Loader2 size={28} className="animate-spin text-brand-soft/60" />
+            <div className="text-sm text-foreground/50">{t('settings.resume.uploading')}</div>
           </div>
         ) : (
           <div className="flex flex-col items-center gap-3">
             <div
               className={cn(
                 'rounded-full p-3 transition-colors',
-                dragActive ? 'bg-brand-soft/20' : 'bg-white/5'
+                dragActive ? 'bg-brand/15' : 'bg-white/5'
               )}
             >
               <Upload
-                size={24}
+                size={22}
                 className={cn(
                   'transition-colors',
-                  dragActive ? 'text-brand-soft' : 'text-foreground/40'
+                  dragActive ? 'text-brand-soft' : 'text-foreground/35'
                 )}
               />
             </div>
-            <div className="text-sm text-foreground/70">{t('settings.resume.dragDrop')}</div>
-            <div className="text-xs text-foreground/40">
-              {t('settings.resume.orClick')} ({t('settings.resume.fileTypes')})
+            <div className="text-sm text-foreground/60">{t('settings.resume.dragDrop')}</div>
+            <div className="text-xs text-foreground/35">
+              {t('settings.resume.orClick')} · PDF, DOC, DOCX, TXT
             </div>
           </div>
         )}
       </div>
 
-      {/* Resume List */}
-      <div className="space-y-3">
-        {resumes.map((resumeItem) => {
-          const isDefault = resume?.defaultId === resumeItem.id;
-
-          return (
-            <motion.div
-              key={resumeItem.id}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              className={cn(
-                'flex items-start gap-4 rounded-xl border p-4 transition-all',
-                isDefault
-                  ? 'border-brand-soft/50 bg-brand-soft/10 glow-subtle'
-                  : 'border-white/10 bg-white/5'
-              )}
-            >
-              <div
+      {/* Document list */}
+      {isLoading ? (
+        <div className="flex justify-center py-6">
+          <Loader2 size={20} className="animate-spin text-foreground/20" />
+        </div>
+      ) : documents.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-8 text-center">
+          <AlertCircle size={28} className="text-foreground/15" />
+          <div className="text-sm text-foreground/35">{t('settings.resume.noResumes')}</div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {documents.map((doc) => {
+            const isDefault = resume?.defaultId === doc.id;
+            return (
+              <motion.div
+                key={doc.id}
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={transition.normal}
                 className={cn(
-                  'rounded-lg p-2 transition-colors',
-                  isDefault ? 'bg-brand-soft/20' : 'bg-white/5'
+                  'flex items-center gap-3 rounded-xl border px-4 py-3 transition-all',
+                  isDefault ? 'border-brand/30 bg-brand/8' : 'border-white/[0.06] bg-white/[0.02]'
                 )}
               >
-                <FileText
-                  size={20}
+                <div
                   className={cn(
-                    'transition-colors',
-                    isDefault ? 'text-brand-soft' : 'text-foreground/40'
+                    'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg',
+                    isDefault ? 'bg-brand/15' : 'bg-white/5'
                   )}
-                />
-              </div>
+                >
+                  <FileText
+                    size={16}
+                    className={isDefault ? 'text-brand-soft' : 'text-foreground/35'}
+                  />
+                </div>
 
-              <div className="flex-1 min-w-0">
-                <div className="flex items-start justify-between gap-2 mb-2">
-                  <div className="flex-1 min-w-0">
-                    <div
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span
                       className={cn(
-                        'text-sm font-medium truncate transition-colors',
-                        isDefault ? 'text-foreground' : 'text-foreground/70'
+                        'truncate text-sm font-medium',
+                        isDefault ? 'text-foreground/90' : 'text-foreground/65'
                       )}
                     >
-                      {resumeItem.name}
-                    </div>
-                    <div className="text-xs text-foreground/40 mt-0.5">
-                      {formatFileSize(resumeItem.size)} •{' '}
-                      {new Date(resumeItem.uploadedAt).toLocaleDateString()}
-                    </div>
-                  </div>
-
-                  <div className="flex items-center gap-1">
-                    {resumeItem.indexed && (
-                      <div className="flex items-center gap-1 rounded-full bg-green-500/20 px-2 py-0.5 text-xs text-green-400">
-                        <Check size={10} />
-                        {t('settings.resume.indexed')}
-                      </div>
-                    )}
+                      {doc.title}
+                    </span>
                     {isDefault && (
-                      <div className="flex items-center gap-1 rounded-full bg-brand-soft/20 px-2 py-0.5 text-xs text-brand-soft">
-                        <Sparkles size={10} />
-                        {t('settings.resume.default')}
-                      </div>
+                      <span className="flex shrink-0 items-center gap-1 rounded-full bg-brand/15 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-brand-soft">
+                        <Sparkles size={8} /> {t('settings.resume.default')}
+                      </span>
                     )}
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-2 text-[11px] text-foreground/35">
+                    <span className="uppercase">{doc.source}</span>
+                    {doc.pages && <span>· {doc.pages}p</span>}
+                    <span>· {new Date(doc.importedAt).toLocaleDateString('en-GB')}</span>
                   </div>
                 </div>
 
-                {/* Skills Preview */}
-                {resumeItem.skillsExtracted.length > 0 && (
-                  <div className="mb-2">
-                    <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40 mb-1.5">
-                      {t('settings.resume.extractedSkills')}
-                    </div>
-                    <div className="flex flex-wrap gap-1.5">
-                      {resumeItem.skillsExtracted.slice(0, 4).map((skill) => (
-                        <span
-                          key={skill}
-                          className="rounded-full bg-white/5 px-2 py-0.5 text-xs text-foreground/60"
-                        >
-                          {skill}
-                        </span>
-                      ))}
-                      {resumeItem.skillsExtracted.length > 4 && (
-                        <span className="rounded-full bg-white/5 px-2 py-0.5 text-xs text-foreground/40">
-                          +{resumeItem.skillsExtracted.length - 4} {t('settings.resume.more')}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {/* ATS Score */}
-                {resumeItem.atsScore && (
-                  <div className="flex items-center gap-2">
-                    <div className="text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-                      {t('settings.resume.atsScore')}
-                    </div>
-                    <div
-                      className={cn(
-                        'text-xs font-medium',
-                        resumeItem.atsScore >= 80
-                          ? 'text-green-400'
-                          : resumeItem.atsScore >= 60
-                            ? 'text-yellow-400'
-                            : 'text-red-400'
-                      )}
-                    >
-                      {resumeItem.atsScore}%
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleSetDefault(resumeItem.id)}
-                  className="!bg-transparent hover:bg-white/5"
-                  disabled={isDefault}
-                >
-                  <Sparkles size={14} />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleDelete(resumeItem.id)}
-                  className="!bg-transparent hover:bg-red-500/10 hover:text-red-400"
-                >
-                  <Trash2 size={14} />
-                </Button>
-              </div>
-            </motion.div>
-          );
-        })}
-
-        {resumes.length === 0 && (
-          <div className="flex flex-col items-center gap-3 py-8 text-center">
-            <AlertCircle size={32} className="text-foreground/20" />
-            <div className="text-sm text-foreground/40">{t('settings.resume.noResumes')}</div>
-          </div>
-        )}
-      </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleSetDefault(doc.id)}
+                    disabled={isDefault}
+                    title={t('settings.resume.setDefault')}
+                    className="text-foreground/30 hover:text-brand-soft disabled:opacity-0"
+                  >
+                    <Sparkles size={13} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void handleDelete(doc.id)}
+                    disabled={removeDocument.isPending}
+                    className="text-foreground/30 hover:text-red-400"
+                  >
+                    <Trash2 size={13} />
+                  </Button>
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+      )}
     </GlassCard>
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/ResumePreferences.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ResumePreferences.tsx
@@ -102,7 +102,7 @@ export function ResumePreferences() {
 
   const uploading = importDocument.isPending;
 
-  const formatFileSize = (bytes?: number) => {
+  const _formatFileSize = (bytes?: number) => {
     if (!bytes) return '';
     if (bytes < 1024) return bytes + ' B';
     if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -586,7 +586,11 @@
     "locationPlaceholder": "z.B. Berlin, Deutschland",
     "posted": "Veröffentlicht",
     "anyTime": "Jederzeit",
-    "past8h": "Letzte 8h",
+    "past30m": "Letzte 30 Minuten",
+    "past1h": "Letzte 1 Stunde",
+    "past2h": "Letzte 2 Stunden",
+    "past4h": "Letzte 4 Stunden",
+    "past8h": "Letzte 8 Stunden",
     "past24h": "Letzte 24h",
     "pastWeek": "Letzte Woche",
     "pastMonth": "Letzter Monat",
@@ -666,7 +670,12 @@
       "start": "Bewerbung starten"
     },
     "authHint": "Verbinde dein Konto in den Einstellungen für mehr Ergebnisse und bessere Genauigkeit.",
-    "authHintLink": "Konto verbinden"
+    "authHintLink": "Konto verbinden",
+    "disconnect": "Trennen",
+    "modeAuthenticated": "Authentifiziert",
+    "modeAuthNote": "Volle Ergebnisse · Feine Zeitfilter",
+    "modeGuest": "Gastmodus",
+    "modeGuestNote": "Begrenzte Ergebnisse · nur 24h / Woche / Monat"
   },
   "resumes": {
     "title": "Lebensläufe",

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -247,7 +247,8 @@
       "keyPlaceholder": "API-Schlüssel einfügen…",
       "saveKey": "Speichern",
       "baseUrl": "Basis-URL",
-      "saveUrl": "Speichern"
+      "saveUrl": "Speichern",
+      "activeProvider": "Aktiver Anbieter"
     },
     "aiModel": {
       "title": "KI-Modell",
@@ -338,13 +339,28 @@
       "fileTypes": "PDF, DOC, DOCX",
       "uploading": "Wird hochgeladen und analysiert...",
       "setAsDefault": "Als Standard festlegen",
-      "uploaded": "Hochgeladen",
+      "uploaded": "Lebenslauf erfolgreich hochgeladen",
       "indexed": "Indiziert",
       "default": "Standard",
       "extractedSkills": "Extrahierte Fähigkeiten",
       "more": "mehr",
       "atsScore": "ATS-Score",
-      "noResumes": "Noch keine Lebensläufe hochgeladen"
+      "noResumes": "Noch keine Lebensläufe hochgeladen",
+      "uploadFailed": "Upload fehlgeschlagen",
+      "removed": "Lebenslauf entfernt",
+      "removeFailed": "Entfernen fehlgeschlagen",
+      "setDefault": "Als Standard setzen"
+    },
+    "update": {
+      "title": "Updates",
+      "currentVersion": "Aktuelle Version",
+      "checkNow": "Nach Updates suchen",
+      "checking": "Prüfe…",
+      "upToDate": "Sie sind auf dem neuesten Stand",
+      "download": "{{version}} herunterladen",
+      "install": "Neu starten & installieren",
+      "error": "Prüfung fehlgeschlagen",
+      "whatsNew": "Neu in"
     }
   },
   "aiGenerate": {
@@ -403,7 +419,8 @@
       "extractionFailed": "Extraktion fehlgeschlagen",
       "generationFailed": "Generierung fehlgeschlagen"
     },
-    "localized": "Lokalisiert"
+    "localized": "Lokalisiert",
+    "resumePlaceholder": "Lebenslauftext hier einfügen…"
   },
   "autopilot": {
     "title": "Autopilot",
@@ -527,6 +544,22 @@
       "highMatchDesc": "Basierend auf Ihren Präferenzen und Ihrem Profil",
       "resumeAlertTitle": "Lebenslauf benötigt Aktualisierung",
       "resumeAlertDesc": "Letzter ATS-Score war 65%, erwägen Sie mehr Kennzahlen hinzuzufügen"
+    },
+    "viewed": "Angesehen",
+    "totalTracked": "Gesamt verfolgt",
+    "noJobsTracked": "Öffne einen Job um deine Pipeline zu verfolgen.",
+    "status": {
+      "aiModel": "KI-Modell",
+      "database": "Datenbank",
+      "vectorDb": "Vektor-DB",
+      "workers": "Workers",
+      "ready": "Bereit",
+      "checking": "Prüfe…",
+      "notAvailable": "Nicht verfügbar",
+      "connected": "Verbunden",
+      "indexed": "Indiziert",
+      "memory": "Speichernutzung",
+      "refresh": "Aktualisieren"
     }
   },
   "jobs": {
@@ -631,7 +664,9 @@
       "cancel": "Abbrechen",
       "running": "Läuft…",
       "start": "Bewerbung starten"
-    }
+    },
+    "authHint": "Verbinde dein Konto in den Einstellungen für mehr Ergebnisse und bessere Genauigkeit.",
+    "authHintLink": "Konto verbinden"
   },
   "resumes": {
     "title": "Lebensläufe",
@@ -1187,6 +1222,29 @@
         "title": "KI-Arbeitsbereich",
         "desc": "Chatten Sie mit Ihrem persönlichen Job-Jagd-Assistenten. Stellen Sie Fragen, erhalten Sie Rat, verfeinern Sie Ihre Strategie."
       }
+    },
+    "resume": {
+      "title": "Lebenslauf hochladen",
+      "description": "Füge deinen Lebenslauf hinzu, damit die KI Anschreiben anpassen und dich genau mit Jobs abgleichen kann.",
+      "dragDrop": "Lebenslauf hierher ziehen",
+      "uploading": "Lebenslauf wird verarbeitet…",
+      "uploaded": "Lebenslauf hochgeladen",
+      "uploadFailed": "Upload fehlgeschlagen",
+      "replaceHint": "Klicken zum Ersetzen",
+      "skip": "Vorerst überspringen"
     }
+  },
+  "resumeInput": {
+    "label": "Lebenslauf",
+    "saved": "Gespeichert",
+    "placeholder": "Lebenslauftext hier einfügen…",
+    "saveToLibrary": "Speichern",
+    "setDefault": "Als Standard",
+    "savedAsDefault": "Gespeichert & als Standard gesetzt",
+    "savedToLibrary": "In Bibliothek gespeichert",
+    "saveFailed": "Speichern fehlgeschlagen",
+    "saving": "Speichere…",
+    "tooLarge": "Datei überschreitet 25 MB",
+    "selectedSaved": "{{name}} geladen"
   }
 }

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -247,7 +247,8 @@
       "keyPlaceholder": "Paste your API key…",
       "saveKey": "Save",
       "baseUrl": "Base URL",
-      "saveUrl": "Save"
+      "saveUrl": "Save",
+      "activeProvider": "Active Provider"
     },
     "aiModel": {
       "title": "AI Model",
@@ -338,13 +339,28 @@
       "fileTypes": "PDF, DOC, DOCX",
       "uploading": "Uploading and analyzing...",
       "setAsDefault": "Set as default",
-      "uploaded": "Uploaded",
+      "uploaded": "Resume uploaded successfully",
       "indexed": "Indexed",
       "default": "Default",
       "extractedSkills": "Extracted Skills",
       "more": "more",
       "atsScore": "ATS Score",
-      "noResumes": "No resumes uploaded yet"
+      "noResumes": "No resumes uploaded yet",
+      "uploadFailed": "Failed to upload resume",
+      "removed": "Resume removed",
+      "removeFailed": "Failed to remove resume",
+      "setDefault": "Set as default"
+    },
+    "update": {
+      "title": "Updates",
+      "currentVersion": "Current version",
+      "checkNow": "Check for updates",
+      "checking": "Checking…",
+      "upToDate": "You are up to date",
+      "download": "Download {{version}}",
+      "install": "Restart & install",
+      "error": "Check failed",
+      "whatsNew": "What's new in"
     }
   },
   "aiGenerate": {
@@ -403,7 +419,8 @@
       "extractionFailed": "Extraction failed",
       "generationFailed": "Generation failed"
     },
-    "localized": "Localized"
+    "localized": "Localized",
+    "resumePlaceholder": "Paste your resume text here…"
   },
   "autopilot": {
     "title": "Autopilot",
@@ -527,6 +544,22 @@
       "highMatchDesc": "Based on your preferences and profile",
       "resumeAlertTitle": "Resume needs update",
       "resumeAlertDesc": "Last ATS score was 65%, consider adding more metrics"
+    },
+    "viewed": "Viewed",
+    "totalTracked": "Total Tracked",
+    "noJobsTracked": "Open a job to start tracking your pipeline.",
+    "status": {
+      "aiModel": "AI Model",
+      "database": "Database",
+      "vectorDb": "Vector DB",
+      "workers": "Workers",
+      "ready": "Ready",
+      "checking": "Checking…",
+      "notAvailable": "Not available",
+      "connected": "Connected",
+      "indexed": "Indexed",
+      "memory": "Memory usage",
+      "refresh": "Refresh"
     }
   },
   "jobs": {
@@ -631,7 +664,9 @@
       "cancel": "Cancel",
       "running": "Running…",
       "start": "Start application"
-    }
+    },
+    "authHint": "Connect your account in Settings for more results and better accuracy.",
+    "authHintLink": "Connect account"
   },
   "resumes": {
     "title": "Resumes",
@@ -1187,6 +1222,16 @@
         "title": "AI Workspace",
         "desc": "Chat with your personal job hunting assistant. Ask questions, get advice, refine your strategy."
       }
+    },
+    "resume": {
+      "title": "Upload your resume",
+      "description": "Add your resume so the AI can tailor cover letters and match you to jobs accurately.",
+      "dragDrop": "Drag & drop your resume here",
+      "uploading": "Processing resume…",
+      "uploaded": "Resume uploaded",
+      "uploadFailed": "Upload failed",
+      "replaceHint": "Click to replace",
+      "skip": "Skip for now"
     }
   },
   "updater": {
@@ -1195,5 +1240,18 @@
     "downloaded": "v{{version}} ready to install",
     "downloadButton": "Download",
     "installButton": "Restart & Install"
+  },
+  "resumeInput": {
+    "label": "Resume",
+    "saved": "Saved",
+    "placeholder": "Paste your resume text here…",
+    "saveToLibrary": "Save",
+    "setDefault": "Set as default",
+    "savedAsDefault": "Saved & set as default",
+    "savedToLibrary": "Saved to library",
+    "saveFailed": "Save failed",
+    "saving": "Saving…",
+    "tooLarge": "File exceeds 25 MB limit",
+    "selectedSaved": "{{name}} loaded"
   }
 }

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -586,7 +586,11 @@
     "locationPlaceholder": "e.g. Berlin, Germany",
     "posted": "Posted",
     "anyTime": "Any time",
-    "past8h": "Past 8h",
+    "past30m": "Past 30 minutes",
+    "past1h": "Past 1 hour",
+    "past2h": "Past 2 hours",
+    "past4h": "Past 4 hours",
+    "past8h": "Past 8 hours",
     "past24h": "Past 24h",
     "pastWeek": "Past week",
     "pastMonth": "Past month",
@@ -666,7 +670,12 @@
       "start": "Start application"
     },
     "authHint": "Connect your account in Settings for more results and better accuracy.",
-    "authHintLink": "Connect account"
+    "authHintLink": "Connect account",
+    "disconnect": "Disconnect",
+    "modeAuthenticated": "Authenticated",
+    "modeAuthNote": "Full results · fine-grained time filters",
+    "modeGuest": "Guest mode",
+    "modeGuestNote": "Limited results · 24h / week / month filters only"
   },
   "resumes": {
     "title": "Resumes",

--- a/apps/tauri/src/renderer/lib/generate-ai.ts
+++ b/apps/tauri/src/renderer/lib/generate-ai.ts
@@ -54,7 +54,9 @@ async function streamGenerate(
 ): Promise<string> {
   const api = getClient();
   const providerConfig = usePreferencesStore.getState().aiProviderConfig;
-  const activeModel = providerConfig?.model || model;
+  const activeProvider = providerConfig?.activeProvider ?? 'ollama';
+  const providerSettings = providerConfig?.providers?.[activeProvider];
+  const activeModel = providerSettings?.model || model;
   const res = (await api.ai.generate({
     model: activeModel,
     messages: [
@@ -63,8 +65,8 @@ async function streamGenerate(
     ],
     locale: safeLocale(locale),
     temperature,
-    ...(providerConfig?.provider && providerConfig.provider !== 'ollama'
-      ? { provider: providerConfig.provider, baseUrl: providerConfig.baseUrl }
+    ...(activeProvider !== 'ollama'
+      ? { provider: activeProvider, baseUrl: providerSettings?.baseUrl }
       : {}),
   } as Parameters<typeof api.ai.generate>[0])) as { jobId: string };
 

--- a/apps/tauri/src/renderer/lib/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client.ts
@@ -88,6 +88,10 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       resume: noop,
     },
 
+    geocode: {
+      suggest: async () => [],
+    },
+
     credentials: {
       available: async () => false,
       list: emptyList,

--- a/apps/tauri/src/renderer/lib/web-http-client.ts
+++ b/apps/tauri/src/renderer/lib/web-http-client.ts
@@ -149,6 +149,11 @@ export function createWebHttpClient({ baseUrl, token }: WebHttpClientOptions): A
       resume: (req) => cmd('match', 'resume', req),
     },
 
+    geocode: {
+      suggest: (query: string) =>
+        cmd('geocode', 'suggest', { query }) as Promise<Array<{ display: string }>>,
+    },
+
     credentials: {
       available: () => cmd('credentials', 'available'),
       list: () => cmd('credentials', 'list'),

--- a/apps/tauri/src/renderer/routes/ai-generate.tsx
+++ b/apps/tauri/src/renderer/routes/ai-generate.tsx
@@ -24,6 +24,7 @@ import { OutputPanelDone } from '@/features/ai-generate/components/OutputPanelDo
 import { OutputPanelExtracting } from '@/features/ai-generate/components/OutputPanelExtracting';
 import { OutputPanelGenerating } from '@/features/ai-generate/components/OutputPanelGenerating';
 import { OutputPanelIdle } from '@/features/ai-generate/components/OutputPanelIdle';
+import { ResumeInputCard } from '@/features/ai-workspace/components/ResumeInputCard';
 import { CustomDropdown } from '@/features/settings/components/CustomDropdown';
 import { cn } from '@/lib/cn';
 import {
@@ -316,15 +317,13 @@ function AIGeneratePage() {
 
           <div className="px-6 space-y-3 pb-4">
             {/* Resume input */}
-            <FileInput
-              label={t('aiGenerate.resumeLabel')}
-              icon={FileText}
+            <ResumeInputCard
               value={resume}
               onChange={setResume}
+              onUpload={(f) => handleUpload('resume', f)}
               uploading={uploading === 'resume'}
-              onUpload={(f) => void handleUpload('resume', f)}
               disabled={stage !== 'idle'}
-              t={t}
+              placeholder={t('aiGenerate.resumePlaceholder')}
             />
 
             {/* Job ad input */}

--- a/apps/tauri/src/renderer/routes/ai-generate.tsx
+++ b/apps/tauri/src/renderer/routes/ai-generate.tsx
@@ -4,7 +4,6 @@ import {
   Briefcase,
   Check,
   ChevronDown,
-  FileText,
   RefreshCw,
   RotateCcw,
   Upload,

--- a/apps/tauri/src/renderer/routes/analyze.tsx
+++ b/apps/tauri/src/renderer/routes/analyze.tsx
@@ -29,6 +29,7 @@ import { AnalysisSectionAnalysis } from '@/features/analyze/components/AnalysisS
 import { AnalysisSkills } from '@/features/analyze/components/AnalysisSkills';
 import { AnalysisStrengths } from '@/features/analyze/components/AnalysisStrengths';
 import { AnalysisVerdict } from '@/features/analyze/components/AnalysisVerdict';
+import { ResumeInputCard } from '@/features/ai-workspace/components/ResumeInputCard';
 import { CustomDropdown } from '@/features/settings/components/CustomDropdown';
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
@@ -189,16 +190,13 @@ function Analyze() {
 
           {/* Inputs */}
           <div className="px-6 space-y-3 pb-4">
-            <CollapsibleInput
-              label={t('analyze.resume')}
-              icon={FileText}
+            <ResumeInputCard
               value={resume}
               onChange={setResume}
+              onUpload={(f) => handleUpload('resume', f)}
               uploading={uploading === 'resume'}
-              onUpload={(f) => void handleUpload('resume', f)}
-              placeholder={t('analyze.resumePlaceholder')}
               disabled={stage === 'running'}
-              t={t}
+              placeholder={t('analyze.resumePlaceholder')}
             />
             <CollapsibleInput
               label={t('analyze.jobAd')}

--- a/apps/tauri/src/renderer/routes/analyze.tsx
+++ b/apps/tauri/src/renderer/routes/analyze.tsx
@@ -3,7 +3,6 @@ import {
   Briefcase,
   CheckCircle2,
   ChevronDown,
-  FileText,
   RefreshCw,
   RotateCcw,
   ScanSearch,
@@ -18,6 +17,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { Button, TextArea } from '@ajh/ui';
 
 import { PageTransition } from '@/components/layout/PageTransition';
+import { ResumeInputCard } from '@/features/ai-workspace/components/ResumeInputCard';
 import { AnalysisATSRisks } from '@/features/analyze/components/AnalysisATSRisks';
 import { AnalysisLanguageMismatch } from '@/features/analyze/components/AnalysisLanguageMismatch';
 import { AnalysisLanguageRecommendations } from '@/features/analyze/components/AnalysisLanguageRecommendations';
@@ -29,7 +29,6 @@ import { AnalysisSectionAnalysis } from '@/features/analyze/components/AnalysisS
 import { AnalysisSkills } from '@/features/analyze/components/AnalysisSkills';
 import { AnalysisStrengths } from '@/features/analyze/components/AnalysisStrengths';
 import { AnalysisVerdict } from '@/features/analyze/components/AnalysisVerdict';
-import { ResumeInputCard } from '@/features/ai-workspace/components/ResumeInputCard';
 import { CustomDropdown } from '@/features/settings/components/CustomDropdown';
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';

--- a/apps/tauri/src/renderer/routes/autopilot.tsx
+++ b/apps/tauri/src/renderer/routes/autopilot.tsx
@@ -360,7 +360,7 @@ function EmptyState({ onNew }: { onNew(): void }) {
           </div>
         ))}
       </div>
-      <Button variant="glass" size="md" onClick={onNew} className="hover:glow-purple">
+      <Button variant="glass" size="md" onClick={onNew} className="hover:glow-purple px-6 gap-2">
         <Plus size={14} /> {t('autopilot.empty.createFirst')}
       </Button>
     </div>

--- a/apps/tauri/src/renderer/routes/jobs.tsx
+++ b/apps/tauri/src/renderer/routes/jobs.tsx
@@ -18,11 +18,20 @@ import {
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useMemo, useRef, useState } from 'react';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 
 import type { DATE_FILTER_OPTIONS, JobInteraction } from '@ajh/shared';
-import { Button, GlassCard, Input, SelectDropdown, TextArea, useToast } from '@ajh/ui';
+import {
+  Button,
+  GlassCard,
+  Input,
+  LocationInput,
+  SelectDropdown,
+  TextArea,
+  useToast,
+} from '@ajh/ui';
 
+import { useAppClient } from '@/providers/AppClientProvider';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { PageTransition } from '@/components/layout/PageTransition';
 import { cn } from '@/lib/cn';
@@ -30,9 +39,15 @@ import { useTranslation } from '@/lib/i18n';
 import { staggeredItem, transition } from '@/lib/motion';
 import {
   useApplyJob,
+  useBoardConnect,
+  useBoardStatus,
   useCancelJob,
   useClearPostings,
   useJobEvents,
+  useLinkedInConnect,
+  useLinkedInDisconnect,
+  useLinkedInStatus,
+  useBoardDisconnect,
   useOpenExternal,
   usePersistJob,
   usePostings,
@@ -100,6 +115,7 @@ function Jobs() {
     return t('jobs.timeMonthsAgo', { m: months });
   };
 
+  const api = useAppClient();
   const toast = useToast();
   const { data: postingsData = [] } = usePostings();
   const postings = postingsData as Posting[];
@@ -119,6 +135,47 @@ function Jobs() {
     dateFilter: '' as '' | (typeof DATE_FILTER_OPTIONS)[number],
     locale: 'us',
   });
+
+  // Inline connect — avoids sending user to Settings just to link an account
+  const isLinkedInBoard = scrapeForm.board === 'linkedin';
+  const linkedInStatus = useLinkedInStatus();
+  const boardStatus = useBoardStatus(
+    AUTH_BENEFITS.has(scrapeForm.board) && !isLinkedInBoard ? scrapeForm.board : ''
+  );
+  const linkedInConnect = useLinkedInConnect();
+  const linkedInDisconnect = useLinkedInDisconnect();
+  const boardConnect = useBoardConnect();
+  const boardDisconnect = useBoardDisconnect();
+  const boardConnected = isLinkedInBoard
+    ? ((linkedInStatus.data as { connected?: boolean } | undefined)?.connected ?? false)
+    : ((boardStatus.data as { connected?: boolean } | undefined)?.connected ?? false);
+  const connectPending = isLinkedInBoard ? linkedInConnect.isPending : boardConnect.isPending;
+  const disconnectPending = isLinkedInBoard
+    ? linkedInDisconnect.isPending
+    : boardDisconnect.isPending;
+
+  const handleInlineDisconnect = async () => {
+    try {
+      if (isLinkedInBoard) await linkedInDisconnect.mutateAsync();
+      else await boardDisconnect.mutateAsync(scrapeForm.board);
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Disconnect failed.', 'error');
+    }
+  };
+
+  const handleInlineConnect = async () => {
+    try {
+      const result = isLinkedInBoard
+        ? await linkedInConnect.mutateAsync()
+        : await boardConnect.mutateAsync(scrapeForm.board);
+      const res = result as { connected?: boolean; error?: string } | undefined;
+      if (res?.error) toast(res.error, 'error');
+      else if (!res?.connected)
+        toast(`${scrapeForm.board} sign-in was cancelled or timed out.`, 'warning');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Connection failed.', 'error');
+    }
+  };
   const [scraping, setScraping] = useState(false);
   const [scrapeJobId, setScrapeJobId] = useState<string | null>(null);
   const [scrapeOutcome, setScrapeOutcome] = useState<{ ok: boolean; note?: string } | null>(null);
@@ -166,21 +223,52 @@ function Jobs() {
     return [...extra, ...postings];
   }, [postings, livePostings]);
 
+  const doScrape = async () => {
+    const res = (await scrapeBoard.mutateAsync({
+      board: scrapeForm.board,
+      query: scrapeForm.query,
+      ...(scrapeForm.location ? { location: scrapeForm.location } : {}),
+      pages: scrapeForm.pages,
+      ...(scrapeForm.dateFilter ? { dateFilter: scrapeForm.dateFilter } : {}),
+      ...(scrapeForm.board === 'indeed' ? { locale: scrapeForm.locale } : {}),
+    } as Parameters<typeof scrapeBoard.mutateAsync>[0])) as { jobId: string; error?: string };
+    return res;
+  };
+
   const startScrape = async () => {
     setScrapeOutcome(null);
     setScraping(true);
     setLivePostings([]);
-    try {
-      const res = (await scrapeBoard.mutateAsync({
-        board: scrapeForm.board,
-        query: scrapeForm.query,
-        ...(scrapeForm.location ? { location: scrapeForm.location } : {}),
-        pages: scrapeForm.pages,
-        ...(scrapeForm.dateFilter ? { dateFilter: scrapeForm.dateFilter } : {}),
-        ...(scrapeForm.board === 'indeed' ? { locale: scrapeForm.locale } : {}),
-      } as Parameters<typeof scrapeBoard.mutateAsync>[0])) as { jobId: string; error?: string };
 
-      // Sidecar not running or returned an error — surface it immediately.
+    // Cancel any previously tracked job before starting — prevents concurrency errors
+    // from leftover sidecar jobs the UI lost track of.
+    const prevJobId = scrapeJobRef.current;
+    if (prevJobId) {
+      scrapeJobRef.current = null;
+      setScrapeJobId(null);
+      try {
+        await cancelJob.mutateAsync(prevJobId);
+      } catch {
+        // best-effort
+      }
+    }
+
+    try {
+      let res = await doScrape();
+
+      // Concurrency limit hit despite cancelling the tracked job (e.g. a second
+      // job was started from another session). Cancel via the sidecar and retry once.
+      if (res.error?.includes('Concurrency limit')) {
+        if (res.jobId) {
+          try {
+            await cancelJob.mutateAsync(res.jobId);
+          } catch {
+            // best-effort
+          }
+        }
+        res = await doScrape();
+      }
+
       if (res.error) {
         setScraping(false);
         setScrapeOutcome({ ok: false, note: res.error });
@@ -401,9 +489,57 @@ function Jobs() {
                   </div>
                 </div>
 
-                {/* Auth hint — shown for boards that benefit from a connected account */}
+                {/* Auth mode badge — shown for boards that support authentication */}
                 <AnimatePresence>
                   {AUTH_BENEFITS.has(scrapeForm.board) && (
+                    <motion.div
+                      key={`mode-${scrapeForm.board}-${boardConnected ? 'auth' : 'guest'}`}
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={transition.fast}
+                      className="mb-3 flex items-center gap-1.5"
+                    >
+                      {boardConnected ? (
+                        <>
+                          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
+                            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                            {t('jobs.modeAuthenticated')}
+                          </span>
+                          <span className="text-[10px] text-foreground/35">
+                            {t('jobs.modeAuthNote')}
+                          </span>
+                          <button
+                            type="button"
+                            disabled={disconnectPending}
+                            onClick={() => void handleInlineDisconnect()}
+                            className="ml-auto shrink-0 text-[10px] text-red-400/70 underline-offset-2 hover:text-red-400 hover:underline disabled:opacity-50"
+                          >
+                            {disconnectPending ? (
+                              <Loader2 size={10} className="animate-spin" />
+                            ) : (
+                              t('jobs.disconnect')
+                            )}
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-400">
+                            <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+                            {t('jobs.modeGuest')}
+                          </span>
+                          <span className="text-[10px] text-foreground/35">
+                            {t('jobs.modeGuestNote')}
+                          </span>
+                        </>
+                      )}
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+
+                {/* Auth hint — shown for boards that benefit from a connected account */}
+                <AnimatePresence>
+                  {AUTH_BENEFITS.has(scrapeForm.board) && !boardConnected && (
                     <motion.div
                       key="auth-hint"
                       initial={{ opacity: 0, height: 0, marginBottom: 0 }}
@@ -415,12 +551,18 @@ function Jobs() {
                       <div className="flex items-center gap-2 rounded-lg border border-blue-400/15 bg-blue-400/5 px-3 py-2 text-[11px] text-blue-200/75">
                         <Info size={12} className="shrink-0 text-blue-400/60" />
                         <span>{t('jobs.authHint')}</span>
-                        <Link
-                          to="/settings"
-                          className="ml-auto shrink-0 text-brand-soft underline-offset-2 hover:underline"
+                        <button
+                          type="button"
+                          disabled={connectPending}
+                          onClick={() => void handleInlineConnect()}
+                          className="ml-auto shrink-0 text-brand-soft underline-offset-2 hover:underline disabled:opacity-50"
                         >
-                          {t('jobs.authHintLink')}
-                        </Link>
+                          {connectPending ? (
+                            <Loader2 size={11} className="animate-spin" />
+                          ) : (
+                            t('jobs.authHintLink')
+                          )}
+                        </button>
                       </div>
                     </motion.div>
                   )}
@@ -432,13 +574,12 @@ function Jobs() {
                     <label className="mb-1.5 block text-[10px] font-medium uppercase tracking-[0.18em] text-foreground/35">
                       {t('jobs.location')}
                     </label>
-                    <Input
-                      type="text"
+                    <LocationInput
                       value={scrapeForm.location}
-                      onChange={(e) => setScrapeForm({ ...scrapeForm, location: e.target.value })}
+                      onChange={(v) => setScrapeForm({ ...scrapeForm, location: v })}
                       placeholder={t('jobs.locationPlaceholder')}
                       disabled={scraping}
-                      className="w-full bg-white/[0.03] text-xs text-foreground placeholder:text-foreground/25 disabled:opacity-50"
+                      onFetchSuggestions={(q) => api.geocode.suggest(q)}
                     />
                   </div>
                   <div>
@@ -448,7 +589,15 @@ function Jobs() {
                     <SelectDropdown
                       options={[
                         { value: '', label: t('jobs.anyTime') },
-                        { value: '8h', label: t('jobs.past8h') },
+                        ...(AUTH_BENEFITS.has(scrapeForm.board) && boardConnected
+                          ? [
+                              { value: '30m', label: t('jobs.past30m') },
+                              { value: '1h', label: t('jobs.past1h') },
+                              { value: '2h', label: t('jobs.past2h') },
+                              { value: '4h', label: t('jobs.past4h') },
+                              { value: '8h', label: t('jobs.past8h') },
+                            ]
+                          : []),
                         { value: '24h', label: t('jobs.past24h') },
                         { value: 'week', label: t('jobs.pastWeek') },
                         { value: 'month', label: t('jobs.pastMonth') },

--- a/apps/tauri/src/renderer/routes/jobs.tsx
+++ b/apps/tauri/src/renderer/routes/jobs.tsx
@@ -6,6 +6,7 @@ import {
   CircleCheck,
   ExternalLink,
   Eye,
+  Info,
   Loader2,
   MapPin,
   Plus,
@@ -17,7 +18,7 @@ import {
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useMemo, useRef, useState } from 'react';
-import { createFileRoute } from '@tanstack/react-router';
+import { Link, createFileRoute } from '@tanstack/react-router';
 
 import type { DATE_FILTER_OPTIONS, JobInteraction } from '@ajh/shared';
 import { Button, GlassCard, Input, SelectDropdown, TextArea, useToast } from '@ajh/ui';
@@ -75,6 +76,7 @@ interface ProgressEvent {
 }
 
 const APPLIABLE = new Set(['linkedin', 'indeed', 'greenhouse', 'workday']);
+const AUTH_BENEFITS = new Set(['linkedin', 'indeed', 'xing']);
 
 function Jobs() {
   const { t } = useTranslation();
@@ -398,6 +400,31 @@ function Jobs() {
                     })}
                   </div>
                 </div>
+
+                {/* Auth hint — shown for boards that benefit from a connected account */}
+                <AnimatePresence>
+                  {AUTH_BENEFITS.has(scrapeForm.board) && (
+                    <motion.div
+                      key="auth-hint"
+                      initial={{ opacity: 0, height: 0, marginBottom: 0 }}
+                      animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
+                      exit={{ opacity: 0, height: 0, marginBottom: 0 }}
+                      transition={transition.fast}
+                      className="overflow-hidden"
+                    >
+                      <div className="flex items-center gap-2 rounded-lg border border-blue-400/15 bg-blue-400/5 px-3 py-2 text-[11px] text-blue-200/75">
+                        <Info size={12} className="shrink-0 text-blue-400/60" />
+                        <span>{t('jobs.authHint')}</span>
+                        <Link
+                          to="/settings"
+                          className="ml-auto shrink-0 text-brand-soft underline-offset-2 hover:underline"
+                        >
+                          {t('jobs.authHintLink')}
+                        </Link>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
 
                 {/* Filters row */}
                 <div className="mb-4 grid grid-cols-4 gap-2">

--- a/apps/tauri/src/renderer/routes/jobs.tsx
+++ b/apps/tauri/src/renderer/routes/jobs.tsx
@@ -18,7 +18,7 @@ import {
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useMemo, useRef, useState } from 'react';
-import { Link, createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 
 import type { DATE_FILTER_OPTIONS, JobInteraction } from '@ajh/shared';
 import { Button, GlassCard, Input, SelectDropdown, TextArea, useToast } from '@ajh/ui';

--- a/apps/tauri/src/renderer/routes/jobs.tsx
+++ b/apps/tauri/src/renderer/routes/jobs.tsx
@@ -31,15 +31,16 @@ import {
   useToast,
 } from '@ajh/ui';
 
-import { useAppClient } from '@/providers/AppClientProvider';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { PageTransition } from '@/components/layout/PageTransition';
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
 import { staggeredItem, transition } from '@/lib/motion';
+import { useAppClient } from '@/providers/AppClientProvider';
 import {
   useApplyJob,
   useBoardConnect,
+  useBoardDisconnect,
   useBoardStatus,
   useCancelJob,
   useClearPostings,
@@ -47,7 +48,6 @@ import {
   useLinkedInConnect,
   useLinkedInDisconnect,
   useLinkedInStatus,
-  useBoardDisconnect,
   useOpenExternal,
   usePersistJob,
   usePostings,

--- a/apps/tauri/src/renderer/routes/settings.tsx
+++ b/apps/tauri/src/renderer/routes/settings.tsx
@@ -1,12 +1,17 @@
 import {
   Briefcase,
+  CheckCircle2,
   ChevronRight,
   Cpu,
+  Download,
   FileText,
   Gauge,
   Languages,
+  Loader2,
   Lock,
+  RefreshCw,
   Shield,
+  Sparkles,
   User,
   Wand2,
 } from 'lucide-react';
@@ -31,6 +36,8 @@ import { TechStackPreferences } from '@/features/settings/components/TechStackPr
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
 import { transition, variants } from '@/lib/motion';
+import { useAppVersion } from '@/services';
+import { useUpdater } from '@/services/use-updater';
 import {
   useOnboardingCompleted,
   usePreferencesStore,
@@ -225,6 +232,114 @@ function SettingsPage() {
   );
 }
 
+const NO_RELEASE_PATTERNS = [
+  'valid release json',
+  'release json',
+  'failed to fetch',
+  'network',
+  '404',
+];
+
+function isNoReleaseError(msg: string) {
+  const lower = msg.toLowerCase();
+  return NO_RELEASE_PATTERNS.some((p) => lower.includes(p));
+}
+
+function UpdateSection() {
+  const { t } = useTranslation();
+  const { data: versionRaw = '' } = useAppVersion();
+  const version = versionRaw
+    ? String(versionRaw).startsWith('v')
+      ? String(versionRaw)
+      : `v${versionRaw}`
+    : '';
+  const { status, check, download, install } = useUpdater();
+
+  const noRelease = status.state === 'error' && isNoReleaseError(status.message);
+
+  return (
+    <GlassCard>
+      <div className="mb-4 flex items-center gap-2">
+        <IconBadge icon={Sparkles} size="sm" />
+        <SectionLabel>{t('settings.update.title')}</SectionLabel>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs text-foreground/50">{t('settings.update.currentVersion')}</p>
+          <p className="mt-0.5 font-mono text-sm text-foreground/80">{version || '—'}</p>
+        </div>
+
+        {status.state === 'idle' || status.state === 'not-available' || status.state === 'error' ? (
+          <Button variant="glass" size="sm" onClick={() => void check()} className="shrink-0 gap-2">
+            <RefreshCw size={12} />
+            {t('settings.update.checkNow')}
+          </Button>
+        ) : status.state === 'checking' ? (
+          <div className="flex items-center gap-2 text-xs text-foreground/40">
+            <Loader2 size={13} className="animate-spin" />
+            {t('settings.update.checking')}
+          </div>
+        ) : status.state === 'available' ? (
+          <Button
+            variant="glass"
+            size="sm"
+            onClick={() => void download()}
+            className="gap-2 glow-subtle"
+          >
+            <Download size={12} />
+            {t('settings.update.download', { version: status.version })}
+          </Button>
+        ) : status.state === 'downloading' ? (
+          <div className="flex items-center gap-2 text-xs text-foreground/40">
+            <Loader2 size={13} className="animate-spin" />
+            {status.percent}%
+          </div>
+        ) : status.state === 'downloaded' ? (
+          <Button
+            variant="glass"
+            size="sm"
+            onClick={() => void install()}
+            className="gap-2 glow-subtle"
+          >
+            <RefreshCw size={12} />
+            {t('settings.update.install')}
+          </Button>
+        ) : null}
+      </div>
+
+      {/* Status messages */}
+      {(status.state === 'not-available' || noRelease) && (
+        <div className="mt-3 flex items-center gap-2 text-xs text-emerald-400/70">
+          <CheckCircle2 size={12} />
+          {t('settings.update.upToDate')}
+        </div>
+      )}
+      {status.state === 'error' && !noRelease && (
+        <div className="mt-3 text-xs text-red-400/70">
+          {t('settings.update.error')}: {status.message}
+        </div>
+      )}
+
+      {/* Changelog */}
+      {(status.state === 'available' ||
+        status.state === 'downloading' ||
+        status.state === 'downloaded') &&
+        'releaseNotes' in status &&
+        status.releaseNotes && (
+          <div className="mt-4 space-y-1.5">
+            <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-foreground/30">
+              {t('settings.update.whatsNew')} {'version' in status ? status.version : ''}
+            </div>
+            <div className="max-h-36 overflow-y-auto rounded-lg border border-white/[0.05] bg-white/[0.02] p-3 text-xs text-foreground/50 leading-relaxed whitespace-pre-wrap">
+              {status.releaseNotes}
+            </div>
+          </div>
+        )}
+    </GlassCard>
+  );
+}
+
 function GeneralSection({
   localName,
   setLocalName,
@@ -302,6 +417,8 @@ function GeneralSection({
           </Button>
         </div>
       </GlassCard>
+
+      <UpdateSection />
     </>
   );
 }

--- a/apps/tauri/src/renderer/services/use-ai-provider.ts
+++ b/apps/tauri/src/renderer/services/use-ai-provider.ts
@@ -52,9 +52,11 @@ export const useListProviderModels = (provider: string, enabled = true) => {
 /** Returns the provider/model/baseUrl to inject into every ai_generate call. */
 export const useGenerateConfig = () => {
   const config = useAiProviderConfig();
+  const activeProvider = config?.activeProvider ?? 'ollama';
+  const settings = config?.providers?.[activeProvider];
   return {
-    provider: config?.provider ?? 'ollama',
-    model: config?.model ?? '',
-    baseUrl: config?.baseUrl,
+    provider: activeProvider,
+    model: settings?.model ?? '',
+    baseUrl: settings?.baseUrl,
   };
 };

--- a/apps/tauri/src/renderer/store/preferences-schema.ts
+++ b/apps/tauri/src/renderer/store/preferences-schema.ts
@@ -59,14 +59,22 @@ export const AiProviderSchema = z.enum([
   'openai-compatible',
 ]);
 
-export const AiProviderConfigSchema = z.object({
-  provider: AiProviderSchema.default('ollama'),
+// Per-provider settings (model choice, optional base URL)
+export const PerProviderSettingsSchema = z.object({
   model: z.string().default(''),
-  baseUrl: z.string().optional(), // for openai-compatible endpoints
+  baseUrl: z.string().optional(),
+});
+
+// Multi-provider config: each provider stores its own settings independently;
+// activeProvider is the one used for generation.
+export const AiProviderConfigSchema = z.object({
+  activeProvider: AiProviderSchema.default('ollama'),
+  providers: z.record(z.string(), PerProviderSettingsSchema).default({}),
 });
 
 export type AiProvider = z.infer<typeof AiProviderSchema>;
 export type AiProviderConfig = z.infer<typeof AiProviderConfigSchema>;
+export type PerProviderSettings = z.infer<typeof PerProviderSettingsSchema>;
 
 // Resume preference
 export const ResumePreferenceSchema = z.object({

--- a/apps/tauri/src/renderer/store/preferences-store.ts
+++ b/apps/tauri/src/renderer/store/preferences-store.ts
@@ -1,26 +1,34 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-import type { Preferences } from './preferences-schema';
+import type { AiProvider, PerProviderSettings, Preferences } from './preferences-schema';
 
 // Migration function to handle version updates
-const STORE_VERSION = 1;
+const STORE_VERSION = 2;
 
-const migratePreferences = (state: Record<string, unknown>): Preferences => {
-  const version = (state.version as number | undefined) || 0;
-
-  // Migration from version 0 to 1
-  if (version === 0) {
-    return { ...state, version: 1, lastUpdated: new Date().toISOString() } as Preferences;
+const migratePreferences = (state: Record<string, unknown>, version: number): Preferences => {
+  // v0 → v1: baseline
+  if (version < 1) {
+    state = { ...state, version: 1, lastUpdated: new Date().toISOString() };
   }
 
-  // Future migrations can be added here
-  if (version < STORE_VERSION) {
-    return {
-      ...state,
-      version: STORE_VERSION,
-      lastUpdated: new Date().toISOString(),
-    } as Preferences;
+  // v1 → v2: flatten { provider, model, baseUrl } → { activeProvider, providers: { … } }
+  if (version < 2) {
+    const old = state.aiProviderConfig as
+      | { provider?: string; model?: string; baseUrl?: string }
+      | undefined;
+    if (old && 'provider' in old) {
+      const p = old.provider ?? 'ollama';
+      state = {
+        ...state,
+        aiProviderConfig: {
+          activeProvider: p,
+          providers: { [p]: { model: old.model ?? '', baseUrl: old.baseUrl } },
+        },
+        version: 2,
+        lastUpdated: new Date().toISOString(),
+      };
+    }
   }
 
   return state as Preferences;
@@ -45,6 +53,8 @@ interface PreferencesActions {
   setLanguage: (language: string) => void;
   setAIModel: (aiModel: Preferences['aiModel']) => void;
   setAiProviderConfig: (config: Preferences['aiProviderConfig']) => void;
+  setActiveProvider: (provider: AiProvider) => void;
+  setProviderSettings: (provider: AiProvider, settings: Partial<PerProviderSettings>) => void;
   setOutputTone: (outputTone: Preferences['outputTone']) => void;
   setLocation: (location: Preferences['location']) => void;
   setRemote: (remote: Preferences['remote']) => void;
@@ -92,6 +102,32 @@ export const usePreferencesStore = create<PreferencesStore>()(
           aiProviderConfig,
           lastUpdated: new Date().toISOString(),
         })),
+
+      setActiveProvider: (provider: AiProvider) =>
+        set((state) => ({
+          ...state,
+          aiProviderConfig: {
+            activeProvider: provider,
+            providers: state.aiProviderConfig?.providers ?? {},
+          },
+          lastUpdated: new Date().toISOString(),
+        })),
+
+      setProviderSettings: (provider: AiProvider, settings: Partial<PerProviderSettings>) =>
+        set((state) => {
+          const existing = state.aiProviderConfig?.providers?.[provider] ?? { model: '' };
+          return {
+            ...state,
+            aiProviderConfig: {
+              activeProvider: state.aiProviderConfig?.activeProvider ?? 'ollama',
+              providers: {
+                ...state.aiProviderConfig?.providers,
+                [provider]: { ...existing, ...settings },
+              },
+            },
+            lastUpdated: new Date().toISOString(),
+          };
+        }),
 
       setOutputTone: (outputTone: Preferences['outputTone']) =>
         set((state) => ({
@@ -175,13 +211,9 @@ export const usePreferencesStore = create<PreferencesStore>()(
     {
       name: 'ai-job-hunter-preferences',
       storage: createJSONStorage(() => localStorage),
-      version: 1,
+      version: STORE_VERSION,
       migrate: (persistedState: unknown, version: number) => {
-        const state = persistedState as Record<string, unknown>;
-        if (version === 0) {
-          return migratePreferences(state);
-        }
-        return state;
+        return migratePreferences(persistedState as Record<string, unknown>, version);
       },
     }
   )

--- a/apps/tauri/src/tauri-client.ts
+++ b/apps/tauri/src/tauri-client.ts
@@ -96,6 +96,11 @@ export function createTauriInvokeClient(): AppClient {
       resume: (req) => invoke('match_resume', { req }),
     },
 
+    geocode: {
+      suggest: (query: string) =>
+        invoke('geocode_suggest', { query }) as Promise<Array<{ display: string }>>,
+    },
+
     credentials: {
       available: () => invoke('credentials_available'),
       list: () => invoke('credentials_list'),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import unusedImports from 'eslint-plugin-unused-imports';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import storybookPlugin from 'eslint-plugin-storybook';
 import globals from 'globals';
 
 // ── AST selectors ─────────────────────────────────────────────────────────────
@@ -337,6 +338,19 @@ export default tseslint.config(
       'no-restricted-imports': 'off',
       'no-restricted-syntax': 'off',
       'simple-import-sort/imports': 'off',
+    },
+  },
+
+  // ── Storybook story files ─────────────────────────────────────────────────
+  {
+    files: ['**/*.stories.@(ts|tsx)'],
+    plugins: { storybook: storybookPlugin },
+    rules: {
+      ...Object.fromEntries(
+        Object.entries(storybookPlugin.rules ?? {}).map(([k]) => [`storybook/${k}`, 'warn'])
+      ),
+      // Stories intentionally use raw <button> for demo content
+      'no-restricted-syntax': 'off',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-simple-import-sort": "^13.0.0",
+    "eslint-plugin-storybook": "^10.4.0",
     "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^17.6.0",
     "husky": "^9.1.7",

--- a/packages/data/src/services/linkedin/client/http-client.ts
+++ b/packages/data/src/services/linkedin/client/http-client.ts
@@ -8,8 +8,12 @@
 import { Pool, request } from 'undici';
 import { gunzipSync } from 'zlib';
 
+import { createLogger } from '@ajh/core';
+
 import type { LinkedInSessionData } from '../session/store.js';
 import { linkedinRateLimiter } from './rate-limiter.js';
+
+const logger = createLogger('linkedin.http');
 
 // Create connection pool for better performance
 const pool = new Pool('https://www.linkedin.com', {
@@ -81,12 +85,25 @@ export class LinkedInHttpClient {
    */
   async get<T>(url: string, signal?: AbortSignal): Promise<T> {
     return linkedinRateLimiter.execute(async () => {
+      const hasSession = !!this.sessionData?.li_at;
+      logger.info({ url, hasSession }, 'GET request');
+
       const response = await request(url, {
         method: 'GET',
         headers: this.getDefaultHeaders(),
         signal,
         dispatcher: pool,
       });
+
+      logger.info(
+        {
+          url,
+          status: response.statusCode,
+          contentType: response.headers['content-type'],
+          location: response.headers['location'],
+        },
+        'GET response'
+      );
 
       const buffer = await response.body.arrayBuffer();
       const bodyBuffer = Buffer.from(buffer);
@@ -101,6 +118,10 @@ export class LinkedInHttpClient {
       }
 
       if (response.statusCode !== 200) {
+        logger.error(
+          { url, status: response.statusCode, bodyPreview: body.substring(0, 500) },
+          'Non-200 response from LinkedIn'
+        );
         throw new Error(`HTTP ${response.statusCode}: Request failed`);
       }
 

--- a/packages/data/src/services/linkedin/jobs/api-client.ts
+++ b/packages/data/src/services/linkedin/jobs/api-client.ts
@@ -77,8 +77,12 @@ export class LinkedInJobsApiClient {
 
     // Map date filter to LinkedIn f_TPR parameter
     let f_TPR = '';
-    if (dateFilter === '24h') f_TPR = 'r86400';
+    if (dateFilter === '30m') f_TPR = 'r1800';
+    else if (dateFilter === '1h') f_TPR = 'r3600';
+    else if (dateFilter === '2h') f_TPR = 'r7200';
+    else if (dateFilter === '4h') f_TPR = 'r14400';
     else if (dateFilter === '8h') f_TPR = 'r28800';
+    else if (dateFilter === '24h') f_TPR = 'r86400';
     else if (dateFilter === 'week') f_TPR = 'r604800';
     else if (dateFilter === 'month') f_TPR = 'r2592000';
 
@@ -111,8 +115,24 @@ export class LinkedInJobsApiClient {
     logger.info({ cardsCount: cards.length }, 'Found li elements');
 
     if (cards.length === 0) {
-      logger.info('No job cards found');
-      logger.info({ htmlSample: html.substring(0, 1000) }, 'Sample HTML response');
+      logger.error(
+        {
+          url,
+          htmlLength: html.length,
+          htmlSample: html.substring(0, 2000),
+          // Detect common failure signatures
+          isAuthWall: html.includes('authwall') || html.includes('auth-wall'),
+          isCaptcha: html.includes('captcha') || html.includes('CAPTCHA'),
+          isChallenge: html.includes('challenge') || html.includes('bot'),
+          isRedirect: html.includes('<meta http-equiv="refresh"'),
+          bodySnippet: html
+            .replace(/<[^>]+>/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .substring(0, 500),
+        },
+        'Guest API returned 0 job cards — possible block or HTML structure change'
+      );
       return [];
     }
 

--- a/packages/data/src/services/linkedin/jobs/api-client.ts
+++ b/packages/data/src/services/linkedin/jobs/api-client.ts
@@ -184,18 +184,13 @@ export class LinkedInJobsApiClient {
     onProgress?: (progress: number) => void,
     onItem?: (item: JobPosting) => void
   ): Promise<JobPosting[]> {
-    if (!this.client.hasSession()) {
-      throw new Error(
-        'LinkedIn session not found. Please connect your LinkedIn account in Settings first.'
-      );
-    }
-
+    const authenticated = this.client.hasSession();
     const maxPages = Math.min(Math.max(pages, 1), 10);
     const allJobs: JobPosting[] = [];
     const seen = new Set<string>();
 
     logger.info(
-      { keywords: params.keywords, pages: maxPages, authenticated: true },
+      { keywords: params.keywords, pages: maxPages, authenticated },
       'Starting paginated search'
     );
 

--- a/packages/shared/src/ipc/contracts.ts
+++ b/packages/shared/src/ipc/contracts.ts
@@ -138,6 +138,10 @@ export interface IpcContract {
     resume(req: MatchResumeRequest): Promise<MatchScore>;
   };
 
+  geocode: {
+    suggest(query: string): Promise<Array<{ display: string }>>;
+  };
+
   credentials: {
     /** Whether the OS supports encrypted secret storage. */
 

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -67,7 +67,7 @@ export const BOARD_IDS = [
 ] as const;
 export type BoardId = (typeof BOARD_IDS)[number];
 
-export const DATE_FILTER_OPTIONS = ['24h', '8h', 'week', 'month'] as const;
+export const DATE_FILTER_OPTIONS = ['30m', '1h', '2h', '4h', '8h', '24h', 'week', 'month'] as const;
 export type DateFilterOption = (typeof DATE_FILTER_OPTIONS)[number];
 
 export const ScrapeBoardRequestSchema = z.object({

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,12 +39,13 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "eslint-plugin-storybook": "^10.4.0",
+    "jsdom": "^26.1.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "storybook": "^10.4.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.13",
-    "jsdom": "^26.1.0"
+    "vite": "^8.0.13"
   }
 }

--- a/packages/ui/src/components/ConfirmModal.tsx
+++ b/packages/ui/src/components/ConfirmModal.tsx
@@ -23,7 +23,8 @@ const variantConfig: Record<
     iconBg: string;
     iconColor: string;
     border: string;
-    confirmVariant: NonNullable<React.ComponentProps<typeof Button>['variant']>;
+    confirmClass: string;
+    glow: string;
   }
 > = {
   danger: {
@@ -31,28 +32,34 @@ const variantConfig: Record<
     iconBg: 'bg-red-500/20',
     iconColor: 'text-red-400',
     border: 'border-red-500/30',
-    confirmVariant: 'danger',
+    confirmClass: 'border-red-500/50 text-red-400 hover:border-red-500/70 hover:text-red-300',
+    glow: '0 0 16px rgba(239,68,68,0.25)',
   },
   warning: {
     icon: AlertTriangle,
     iconBg: 'bg-orange-500/20',
     iconColor: 'text-orange-400',
     border: 'border-orange-500/30',
-    confirmVariant: 'warning',
+    confirmClass:
+      'border-amber-500/50 text-amber-400 hover:border-amber-500/70 hover:text-amber-300',
+    glow: '0 0 16px rgba(245,158,11,0.25)',
   },
   info: {
     icon: Info,
     iconBg: 'bg-blue-500/20',
     iconColor: 'text-blue-400',
     border: 'border-blue-500/30',
-    confirmVariant: 'info',
+    confirmClass: 'border-blue-500/50 text-blue-400 hover:border-blue-500/70 hover:text-blue-300',
+    glow: '0 0 16px rgba(59,130,246,0.25)',
   },
   success: {
     icon: CheckCircle,
     iconBg: 'bg-green-500/20',
     iconColor: 'text-green-400',
     border: 'border-green-500/30',
-    confirmVariant: 'success',
+    confirmClass:
+      'border-emerald-500/50 text-emerald-400 hover:border-emerald-500/70 hover:text-emerald-300',
+    glow: '0 0 16px rgba(16,185,129,0.25)',
   },
 };
 
@@ -103,18 +110,31 @@ export function ConfirmModal({
       </div>
 
       {/* Footer */}
-      <div className="flex items-center justify-end gap-3 border-t border-white/5 px-6 py-4">
-        <Button variant="ghost" size="md" onClick={onClose} disabled={isConfirming}>
+      <div className="flex items-center justify-end gap-2 border-t border-white/5 px-6 py-4">
+        <Button
+          variant="ghost"
+          size="md"
+          onClick={onClose}
+          disabled={isConfirming}
+          className="px-5"
+        >
           {cancelText}
         </Button>
-        <Button
-          variant={config.confirmVariant}
-          size="md"
-          loading={isConfirming}
+        <button
+          disabled={isConfirming}
           onClick={onConfirm}
+          style={{ boxShadow: isConfirming ? 'none' : config.glow }}
+          className={cn(
+            'inline-flex h-8 items-center gap-2 rounded-lg border bg-transparent px-5 text-sm font-medium transition-all duration-150',
+            'disabled:pointer-events-none disabled:opacity-45',
+            config.confirmClass
+          )}
         >
+          {isConfirming && (
+            <span className="h-3 w-3 animate-spin rounded-full border-[1.5px] border-current border-t-transparent" />
+          )}
           {confirmText}
-        </Button>
+        </button>
       </div>
     </ModalShell>
   );

--- a/packages/ui/src/components/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown.tsx
@@ -1,0 +1,178 @@
+import { ChevronDown, Search } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { cn } from '../lib/cn';
+import { transition } from '../lib/motion';
+import { Button } from './Button';
+
+export interface DropdownOption {
+  value: string;
+  label: string;
+  /** Secondary text shown on the right (e.g. model size) */
+  meta?: string;
+}
+
+export interface DropdownProps {
+  options: DropdownOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** Leading icon in the trigger button */
+  icon?: ReactNode;
+  /** Show search box. Defaults to true when options > 5. */
+  searchable?: boolean;
+  disabled?: boolean;
+}
+
+export function Dropdown({
+  options,
+  value,
+  onChange,
+  placeholder = 'Select…',
+  icon,
+  searchable,
+  disabled,
+}: DropdownProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const showSearch = searchable ?? options.length > 5;
+  const selected = options.find((o) => o.value === value);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return options;
+    const q = query.toLowerCase();
+    return options.filter((o) => o.label.toLowerCase().includes(q));
+  }, [options, query]);
+
+  useEffect(() => {
+    if (open && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPosition({ top: rect.bottom + 6, left: rect.left, width: rect.width });
+    }
+    if (open) {
+      setQuery('');
+      setTimeout(() => searchRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        dropdownRef.current?.contains(e.target as Node) ||
+        triggerRef.current?.contains(e.target as Node)
+      )
+        return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div ref={triggerRef}>
+      <Button
+        type="button"
+        disabled={disabled}
+        onClick={() => !disabled && setOpen((o) => !o)}
+        className={cn(
+          'glass-graphite glass-highlight flex h-9 w-full items-center justify-between gap-2 rounded-xl px-3 text-xs transition-all duration-150',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50',
+          open ? 'border-brand/35' : 'hover:bg-white/[0.02]'
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {icon && <span className="shrink-0 text-foreground/40">{icon}</span>}
+          <span className={cn('truncate', selected ? 'text-foreground/90' : 'text-foreground/35')}>
+            {selected?.label ?? placeholder}
+          </span>
+        </div>
+        <ChevronDown
+          size={12}
+          className={cn(
+            'shrink-0 text-foreground/30 transition-transform duration-150',
+            open && 'rotate-180'
+          )}
+        />
+      </Button>
+
+      {createPortal(
+        <AnimatePresence>
+          {open && (
+            <motion.div
+              ref={dropdownRef}
+              initial={{ opacity: 0, y: -6, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -6, scale: 0.98 }}
+              transition={transition.fast}
+              style={{
+                position: 'fixed',
+                top: position.top,
+                left: position.left,
+                width: position.width,
+                zIndex: 9999,
+              }}
+              className="glass-elevated overflow-hidden rounded-xl shadow-2xl"
+            >
+              {showSearch && (
+                <div className="border-b border-white/[0.06] px-2 py-2">
+                  <div className="flex items-center gap-2 rounded-lg bg-white/[0.04] px-2.5 py-1.5">
+                    <Search size={11} className="shrink-0 text-foreground/30" />
+                    <input
+                      ref={searchRef}
+                      value={query}
+                      onChange={(e) => setQuery(e.target.value)}
+                      placeholder="Search…"
+                      className="flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-foreground/25"
+                    />
+                  </div>
+                </div>
+              )}
+
+              <div className="max-h-56 space-y-0.5 overflow-y-auto px-1 py-1">
+                {filtered.length === 0 ? (
+                  <div className="px-3 py-4 text-center text-xs text-foreground/35">No results</div>
+                ) : (
+                  filtered.map((opt) => {
+                    const isSelected = opt.value === value;
+                    return (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => {
+                          onChange(opt.value);
+                          setOpen(false);
+                        }}
+                        className={cn(
+                          'flex w-full items-center justify-between rounded-lg px-3 py-2 text-xs transition-colors',
+                          isSelected
+                            ? 'bg-brand/15 text-brand-soft'
+                            : 'text-foreground/70 hover:bg-white/[0.05] hover:text-foreground/90'
+                        )}
+                      >
+                        <span className="truncate">{opt.label}</span>
+                        {opt.meta && (
+                          <span className="ml-2 shrink-0 text-[10px] text-foreground/35">
+                            {opt.meta}
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -1,10 +1,11 @@
-import { MapPin } from 'lucide-react';
+import { ChevronDown, MapPin, Search, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { cn } from '../lib/cn';
 import { transition } from '../lib/motion';
+import { Button } from './Button';
 
 interface Suggestion {
   display: string;
@@ -16,7 +17,6 @@ export interface LocationInputProps {
   placeholder?: string;
   disabled?: boolean;
   className?: string;
-  /** Custom async fetcher — defaults to Nominatim via browser fetch (may be blocked by CSP in Tauri; pass a Tauri invoke wrapper instead). */
   onFetchSuggestions?: (query: string) => Promise<Suggestion[]>;
 }
 
@@ -56,62 +56,42 @@ async function defaultFetch(query: string): Promise<Suggestion[]> {
 export function LocationInput({
   value,
   onChange,
-  placeholder,
+  placeholder = 'Any location',
   disabled,
   className,
   onFetchSuggestions = defaultFetch,
 }: LocationInputProps) {
-  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [activeIndex, setActiveIndex] = useState(-1);
   const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+
+  const triggerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fetchRef = useRef(onFetchSuggestions);
   fetchRef.current = onFetchSuggestions;
 
-  const measure = useCallback(() => {
-    if (inputRef.current) {
-      const rect = inputRef.current.getBoundingClientRect();
+  // Measure trigger position when opening
+  useEffect(() => {
+    if (open && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
       setPosition({ top: rect.bottom + 6, left: rect.left, width: rect.width });
-    }
-  }, []);
-
-  useEffect(() => {
-    if (open) measure();
-  }, [open, measure]);
-
-  useEffect(() => {
-    const trimmed = value.trim();
-    if (trimmed.length < 2) {
+      setQuery(value); // pre-fill with current value so user can edit
       setSuggestions([]);
-      setOpen(false);
-      return;
+      setTimeout(() => inputRef.current?.focus(), 50);
     }
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => {
-      fetchRef
-        .current(trimmed)
-        .then((s) => {
-          setSuggestions(s);
-          setOpen(s.length > 0);
-          setActiveIndex(-1);
-          measure();
-        })
-        .catch(() => {});
-    }, 300);
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, [value, measure]);
+  }, [open, value]);
 
+  // Close on outside click
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
       if (
         dropdownRef.current?.contains(e.target as Node) ||
-        inputRef.current?.contains(e.target as Node)
+        triggerRef.current?.contains(e.target as Node)
       )
         return;
       setOpen(false);
@@ -120,25 +100,53 @@ export function LocationInput({
     return () => document.removeEventListener('mousedown', handler);
   }, [open]);
 
-  const select = (s: Suggestion) => {
-    onChange(s.display);
+  // Debounced fetch
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      fetchRef
+        .current(trimmed)
+        .then((s) => {
+          setSuggestions(s);
+          setActiveIndex(-1);
+        })
+        .catch(() => {});
+    }, 300);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [query]);
+
+  const select = (display: string) => {
+    onChange(display);
     setOpen(false);
     setSuggestions([]);
   };
 
+  const clear = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onChange('');
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!open) return;
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setActiveIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === 'Enter' && activeIndex >= 0) {
-      const s = suggestions[activeIndex];
+    } else if (e.key === 'Enter') {
+      const s = activeIndex >= 0 ? suggestions[activeIndex] : null;
       if (s) {
         e.preventDefault();
-        select(s);
+        select(s.display);
+      } else if (query.trim()) {
+        select(query.trim());
       }
     } else if (e.key === 'Escape') {
       setOpen(false);
@@ -146,32 +154,46 @@ export function LocationInput({
   };
 
   return (
-    <div className="relative">
-      <div className="relative">
-        <MapPin
-          size={12}
-          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-foreground/30"
-        />
-        <input
-          ref={inputRef}
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onFocus={() => suggestions.length > 0 && setOpen(true)}
-          placeholder={placeholder}
-          disabled={disabled}
-          autoComplete="off"
-          className={cn(
-            'input-field glass-dropdown w-full rounded-lg bg-white/[0.03] pl-8 pr-3 text-sm text-foreground placeholder:text-foreground/25',
-            className
+    <div ref={triggerRef} className={className}>
+      <Button
+        type="button"
+        disabled={disabled}
+        onClick={() => !disabled && setOpen((o) => !o)}
+        className={cn(
+          'glass-graphite glass-highlight flex h-9 w-full items-center justify-between gap-2 rounded-xl px-3 text-xs transition-all duration-150',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50',
+          open ? 'border-brand/35' : 'hover:bg-white/[0.02]'
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <MapPin size={13} className="shrink-0 text-foreground/40" />
+          <span className={cn('truncate', value ? 'text-foreground/90' : 'text-foreground/35')}>
+            {value || placeholder}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {value && !disabled && (
+            <span
+              role="button"
+              onClick={clear}
+              className="rounded p-0.5 text-foreground/30 hover:text-foreground/70"
+            >
+              <X size={10} />
+            </span>
           )}
-        />
-      </div>
+          <ChevronDown
+            size={12}
+            className={cn(
+              'text-foreground/30 transition-transform duration-150',
+              open && 'rotate-180'
+            )}
+          />
+        </div>
+      </Button>
 
       {createPortal(
         <AnimatePresence>
-          {open && suggestions.length > 0 && (
+          {open && (
             <motion.div
               ref={dropdownRef}
               initial={{ opacity: 0, y: -6, scale: 0.98 }}
@@ -187,27 +209,60 @@ export function LocationInput({
               }}
               className="glass-elevated overflow-hidden rounded-xl shadow-2xl"
             >
-              <div className="max-h-56 overflow-y-auto px-1 py-1 space-y-0.5">
-                {suggestions.map((s, i) => (
-                  <button
-                    key={s.display}
-                    type="button"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      select(s);
-                    }}
-                    onMouseEnter={() => setActiveIndex(i)}
-                    className={cn(
-                      'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-xs transition-colors',
-                      i === activeIndex
-                        ? 'bg-brand/15 text-brand-soft'
-                        : 'text-foreground/70 hover:bg-white/[0.05] hover:text-foreground/90'
-                    )}
-                  >
-                    <MapPin size={11} className="shrink-0 text-foreground/35" />
-                    <span className="truncate">{s.display}</span>
-                  </button>
-                ))}
+              {/* Search input */}
+              <div className="border-b border-white/[0.06] px-2 py-2">
+                <div className="flex items-center gap-2 rounded-lg bg-white/[0.04] px-2.5 py-1.5">
+                  <Search size={11} className="shrink-0 text-foreground/30" />
+                  <input
+                    ref={inputRef}
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder="Search city or postcode…"
+                    className="flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-foreground/25"
+                  />
+                  {query && (
+                    <button
+                      type="button"
+                      onClick={() => setQuery('')}
+                      className="text-foreground/30 hover:text-foreground/60"
+                    >
+                      <X size={10} />
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {/* Suggestions */}
+              <div className="max-h-56 space-y-0.5 overflow-y-auto px-1 py-1">
+                {suggestions.length === 0 && query.trim().length >= 2 ? (
+                  <div className="px-3 py-4 text-center text-xs text-foreground/35">No results</div>
+                ) : suggestions.length === 0 ? (
+                  <div className="px-3 py-4 text-center text-xs text-foreground/25">
+                    Type to search…
+                  </div>
+                ) : (
+                  suggestions.map((s, i) => (
+                    <button
+                      key={s.display}
+                      type="button"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        select(s.display);
+                      }}
+                      onMouseEnter={() => setActiveIndex(i)}
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-xs transition-colors',
+                        i === activeIndex
+                          ? 'bg-brand/15 text-brand-soft'
+                          : 'text-foreground/70 hover:bg-white/[0.05] hover:text-foreground/90'
+                      )}
+                    >
+                      <MapPin size={11} className="shrink-0 text-foreground/35" />
+                      <span className="truncate">{s.display}</span>
+                    </button>
+                  ))
+                )}
               </div>
             </motion.div>
           )}

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -1,8 +1,10 @@
 import { MapPin } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { cn } from '../lib/cn';
+import { transition } from '../lib/motion';
 
 interface Suggestion {
   display: string;
@@ -62,27 +64,22 @@ export function LocationInput({
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
-  const [rect, setRect] = useState<DOMRect | null>(null);
+  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const fetchRef = useRef(onFetchSuggestions);
   fetchRef.current = onFetchSuggestions;
 
-  // Measure input position for the portal dropdown
   const measure = useCallback(() => {
-    if (inputRef.current) setRect(inputRef.current.getBoundingClientRect());
+    if (inputRef.current) {
+      const rect = inputRef.current.getBoundingClientRect();
+      setPosition({ top: rect.bottom + 6, left: rect.left, width: rect.width });
+    }
   }, []);
 
   useEffect(() => {
-    if (!open) return;
-    measure();
-    window.addEventListener('scroll', measure, true);
-    window.addEventListener('resize', measure);
-    return () => {
-      window.removeEventListener('scroll', measure, true);
-      window.removeEventListener('resize', measure);
-    };
+    if (open) measure();
   }, [open, measure]);
 
   useEffect(() => {
@@ -109,14 +106,15 @@ export function LocationInput({
     };
   }, [value, measure]);
 
-  // Close on outside click
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (!inputRef.current?.contains(target) && !listRef.current?.contains(target)) {
-        setOpen(false);
-      }
+      if (
+        dropdownRef.current?.contains(e.target as Node) ||
+        inputRef.current?.contains(e.target as Node)
+      )
+        return;
+      setOpen(false);
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
@@ -147,10 +145,6 @@ export function LocationInput({
     }
   };
 
-  const dropdownStyle: React.CSSProperties = rect
-    ? { position: 'fixed', left: rect.left, top: rect.bottom + 4, width: rect.width, zIndex: 9999 }
-    : { display: 'none' };
-
   return (
     <div className="relative">
       <div className="relative">
@@ -175,39 +169,51 @@ export function LocationInput({
         />
       </div>
 
-      {open &&
-        suggestions.length > 0 &&
-        createPortal(
-          <ul
-            ref={listRef}
-            role="listbox"
-            style={dropdownStyle}
-            className="glass-modal overflow-hidden rounded-xl py-1.5 shadow-2xl shadow-black/60"
-          >
-            {suggestions.map((s, i) => (
-              <li
-                key={s.display}
-                role="option"
-                aria-selected={i === activeIndex}
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  select(s);
-                }}
-                onMouseEnter={() => setActiveIndex(i)}
-                className={cn(
-                  'flex cursor-pointer items-center gap-2.5 px-3 py-2 text-xs transition-colors duration-75',
-                  i === activeIndex
-                    ? 'bg-brand/20 text-foreground'
-                    : 'text-foreground/60 hover:bg-white/[0.06] hover:text-foreground/90'
-                )}
-              >
-                <MapPin size={11} className="shrink-0 text-foreground/35" />
-                <span className="truncate">{s.display}</span>
-              </li>
-            ))}
-          </ul>,
-          document.body
-        )}
+      {createPortal(
+        <AnimatePresence>
+          {open && suggestions.length > 0 && (
+            <motion.div
+              ref={dropdownRef}
+              initial={{ opacity: 0, y: -6, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -6, scale: 0.98 }}
+              transition={transition.fast}
+              style={{
+                position: 'fixed',
+                top: position.top,
+                left: position.left,
+                width: position.width,
+                zIndex: 9999,
+              }}
+              className="glass-elevated overflow-hidden rounded-xl shadow-2xl"
+            >
+              <div className="max-h-56 overflow-y-auto px-1 py-1 space-y-0.5">
+                {suggestions.map((s, i) => (
+                  <button
+                    key={s.display}
+                    type="button"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      select(s);
+                    }}
+                    onMouseEnter={() => setActiveIndex(i)}
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-xs transition-colors',
+                      i === activeIndex
+                        ? 'bg-brand/15 text-brand-soft'
+                        : 'text-foreground/70 hover:bg-white/[0.05] hover:text-foreground/90'
+                    )}
+                  >
+                    <MapPin size={11} className="shrink-0 text-foreground/35" />
+                    <span className="truncate">{s.display}</span>
+                  </button>
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -1,5 +1,6 @@
 import { MapPin } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { cn } from '../lib/cn';
 
@@ -61,10 +62,28 @@ export function LocationInput({
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
+  const [rect, setRect] = useState<DOMRect | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
   const fetchRef = useRef(onFetchSuggestions);
   fetchRef.current = onFetchSuggestions;
+
+  // Measure input position for the portal dropdown
+  const measure = useCallback(() => {
+    if (inputRef.current) setRect(inputRef.current.getBoundingClientRect());
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    measure();
+    window.addEventListener('scroll', measure, true);
+    window.addEventListener('resize', measure);
+    return () => {
+      window.removeEventListener('scroll', measure, true);
+      window.removeEventListener('resize', measure);
+    };
+  }, [open, measure]);
 
   useEffect(() => {
     const trimmed = value.trim();
@@ -81,23 +100,27 @@ export function LocationInput({
           setSuggestions(s);
           setOpen(s.length > 0);
           setActiveIndex(-1);
+          measure();
         })
         .catch(() => {});
     }, 300);
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [value]);
+  }, [value, measure]);
 
+  // Close on outside click
   useEffect(() => {
+    if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      if (!inputRef.current?.contains(target) && !listRef.current?.contains(target)) {
         setOpen(false);
       }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
-  }, []);
+  }, [open]);
 
   const select = (s: Suggestion) => {
     onChange(s.display);
@@ -124,14 +147,19 @@ export function LocationInput({
     }
   };
 
+  const dropdownStyle: React.CSSProperties = rect
+    ? { position: 'fixed', left: rect.left, top: rect.bottom + 4, width: rect.width, zIndex: 9999 }
+    : { display: 'none' };
+
   return (
-    <div ref={containerRef} className="relative">
+    <div className="relative">
       <div className="relative">
         <MapPin
-          size={11}
-          className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-foreground/30"
+          size={12}
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-foreground/30"
         />
         <input
+          ref={inputRef}
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
@@ -141,40 +169,45 @@ export function LocationInput({
           disabled={disabled}
           autoComplete="off"
           className={cn(
-            'h-8 w-full rounded-md border border-white/[0.07] bg-white/[0.03] pl-7 pr-3 text-xs text-foreground outline-none transition-colors placeholder:text-foreground/25 focus:border-brand/40 focus:ring-1 focus:ring-brand/20 disabled:cursor-not-allowed disabled:opacity-50',
+            'input-field glass-dropdown w-full rounded-lg pl-8 pr-3 text-sm text-foreground placeholder:text-foreground/30',
             className
           )}
         />
       </div>
 
-      {open && suggestions.length > 0 && (
-        <ul
-          role="listbox"
-          className="absolute z-50 mt-1.5 w-full overflow-hidden rounded-xl border border-white/[0.12] bg-[oklch(0.14_0.02_270)] py-1.5 shadow-2xl shadow-black/60 backdrop-blur-xl"
-        >
-          {suggestions.map((s, i) => (
-            <li
-              key={s.display}
-              role="option"
-              aria-selected={i === activeIndex}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                select(s);
-              }}
-              onMouseEnter={() => setActiveIndex(i)}
-              className={cn(
-                'flex cursor-pointer items-center gap-2.5 px-3 py-2 text-xs transition-colors duration-75',
-                i === activeIndex
-                  ? 'bg-brand/20 text-foreground'
-                  : 'text-foreground/60 hover:bg-white/[0.06] hover:text-foreground/90'
-              )}
-            >
-              <MapPin size={11} className="shrink-0 text-foreground/35" />
-              <span className="truncate">{s.display}</span>
-            </li>
-          ))}
-        </ul>
-      )}
+      {open &&
+        suggestions.length > 0 &&
+        createPortal(
+          <ul
+            ref={listRef}
+            role="listbox"
+            style={dropdownStyle}
+            className="overflow-hidden rounded-xl border border-white/[0.12] bg-[oklch(0.14_0.02_270)] py-1.5 shadow-2xl shadow-black/60 backdrop-blur-xl"
+          >
+            {suggestions.map((s, i) => (
+              <li
+                key={s.display}
+                role="option"
+                aria-selected={i === activeIndex}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  select(s);
+                }}
+                onMouseEnter={() => setActiveIndex(i)}
+                className={cn(
+                  'flex cursor-pointer items-center gap-2.5 px-3 py-2 text-xs transition-colors duration-75',
+                  i === activeIndex
+                    ? 'bg-brand/20 text-foreground'
+                    : 'text-foreground/60 hover:bg-white/[0.06] hover:text-foreground/90'
+                )}
+              >
+                <MapPin size={11} className="shrink-0 text-foreground/35" />
+                <span className="truncate">{s.display}</span>
+              </li>
+            ))}
+          </ul>,
+          document.body
+        )}
     </div>
   );
 }

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -1,0 +1,174 @@
+import { MapPin } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { cn } from '../lib/cn';
+
+interface Suggestion {
+  display: string;
+}
+
+export interface LocationInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  /** Custom async fetcher — defaults to Nominatim via browser fetch (may be blocked by CSP in Tauri; pass a Tauri invoke wrapper instead). */
+  onFetchSuggestions?: (query: string) => Promise<Suggestion[]>;
+}
+
+async function defaultFetch(query: string): Promise<Suggestion[]> {
+  const url =
+    `https://nominatim.openstreetmap.org/search` +
+    `?q=${encodeURIComponent(query)}` +
+    `&format=json&addressdetails=1&limit=6&featuretype=city`;
+  try {
+    const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
+    if (!res.ok) return [];
+    const data = (await res.json()) as Array<{
+      address?: {
+        city?: string;
+        town?: string;
+        village?: string;
+        state?: string;
+        country?: string;
+      };
+    }>;
+    const seen = new Set<string>();
+    return data.flatMap((item) => {
+      const addr = item.address ?? {};
+      const city = addr.city ?? addr.town ?? addr.village ?? '';
+      if (!city) return [];
+      const parts = [city, addr.state, addr.country].filter(Boolean);
+      const display = parts.join(', ');
+      if (seen.has(display)) return [];
+      seen.add(display);
+      return [{ display }];
+    });
+  } catch {
+    return [];
+  }
+}
+
+export function LocationInput({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  className,
+  onFetchSuggestions = defaultFetch,
+}: LocationInputProps) {
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const trimmed = value.trim();
+    if (trimmed.length < 2) {
+      setSuggestions([]);
+      setOpen(false);
+      return;
+    }
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      onFetchSuggestions(trimmed)
+        .then((s) => {
+          setSuggestions(s);
+          setOpen(s.length > 0);
+          setActiveIndex(-1);
+        })
+        .catch(() => {});
+    }, 300);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [value]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const select = (s: Suggestion) => {
+    onChange(s.display);
+    setOpen(false);
+    setSuggestions([]);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault();
+      select(suggestions[activeIndex]);
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="relative">
+        <MapPin
+          size={11}
+          className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-foreground/30"
+        />
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={() => suggestions.length > 0 && setOpen(true)}
+          placeholder={placeholder}
+          disabled={disabled}
+          autoComplete="off"
+          className={cn(
+            'h-8 w-full rounded-md border border-white/[0.07] bg-white/[0.03] pl-7 pr-3 text-xs text-foreground outline-none transition-colors placeholder:text-foreground/25 focus:border-brand/40 focus:ring-1 focus:ring-brand/20 disabled:cursor-not-allowed disabled:opacity-50',
+            className
+          )}
+        />
+      </div>
+
+      {open && suggestions.length > 0 && (
+        <ul
+          role="listbox"
+          className="absolute z-50 mt-1 w-full overflow-hidden rounded-lg border border-white/[0.08] bg-[#1a1a2e] py-1 shadow-xl"
+        >
+          {suggestions.map((s, i) => (
+            <li
+              key={s.display}
+              role="option"
+              aria-selected={i === activeIndex}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                select(s);
+              }}
+              onMouseEnter={() => setActiveIndex(i)}
+              className={cn(
+                'flex cursor-pointer items-center gap-2 px-3 py-1.5 text-xs',
+                i === activeIndex
+                  ? 'bg-brand/15 text-foreground'
+                  : 'text-foreground/70 hover:bg-white/[0.04]'
+              )}
+            >
+              <MapPin size={10} className="shrink-0 text-foreground/30" />
+              <span>{s.display}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -169,7 +169,7 @@ export function LocationInput({
           disabled={disabled}
           autoComplete="off"
           className={cn(
-            'input-field glass-dropdown w-full rounded-lg pl-8 pr-3 text-sm text-foreground placeholder:text-foreground/30',
+            'input-field glass-dropdown w-full rounded-lg bg-white/[0.03] pl-8 pr-3 text-sm text-foreground placeholder:text-foreground/25',
             className
           )}
         />
@@ -182,7 +182,7 @@ export function LocationInput({
             ref={listRef}
             role="listbox"
             style={dropdownStyle}
-            className="overflow-hidden rounded-xl border border-white/[0.12] bg-[oklch(0.14_0.02_270)] py-1.5 shadow-2xl shadow-black/60 backdrop-blur-xl"
+            className="glass-modal overflow-hidden rounded-xl py-1.5 shadow-2xl shadow-black/60"
           >
             {suggestions.map((s, i) => (
               <li

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -113,9 +113,9 @@ export function LocationInput({
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setActiveIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === 'Enter' && activeIndex >= 0) {
+    } else if (e.key === 'Enter' && activeIndex >= 0 && suggestions[activeIndex]) {
       e.preventDefault();
-      select(suggestions[activeIndex]);
+      select(suggestions[activeIndex]!);
     } else if (e.key === 'Escape') {
       setOpen(false);
     }

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -113,9 +113,12 @@ export function LocationInput({
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setActiveIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === 'Enter' && activeIndex >= 0 && suggestions[activeIndex]) {
-      e.preventDefault();
-      select(suggestions[activeIndex]!);
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      const s = suggestions[activeIndex];
+      if (s) {
+        e.preventDefault();
+        select(s);
+      }
     } else if (e.key === 'Escape') {
       setOpen(false);
     }

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -63,6 +63,8 @@ export function LocationInput({
   const [activeIndex, setActiveIndex] = useState(-1);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const fetchRef = useRef(onFetchSuggestions);
+  fetchRef.current = onFetchSuggestions;
 
   useEffect(() => {
     const trimmed = value.trim();
@@ -73,7 +75,8 @@ export function LocationInput({
     }
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
-      onFetchSuggestions(trimmed)
+      fetchRef
+        .current(trimmed)
         .then((s) => {
           setSuggestions(s);
           setOpen(s.length > 0);
@@ -144,7 +147,7 @@ export function LocationInput({
       {open && suggestions.length > 0 && (
         <ul
           role="listbox"
-          className="absolute z-50 mt-1 w-full overflow-hidden rounded-lg border border-white/[0.08] bg-[#1a1a2e] py-1 shadow-xl"
+          className="absolute z-50 mt-1 w-full overflow-hidden rounded-lg border border-white/[0.08] bg-secondary py-1 shadow-xl"
         >
           {suggestions.map((s, i) => (
             <li

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -150,7 +150,7 @@ export function LocationInput({
       {open && suggestions.length > 0 && (
         <ul
           role="listbox"
-          className="absolute z-50 mt-1 w-full overflow-hidden rounded-lg border border-white/[0.08] bg-secondary py-1 shadow-xl"
+          className="absolute z-50 mt-1.5 w-full overflow-hidden rounded-xl border border-white/[0.12] bg-[oklch(0.14_0.02_270)] py-1.5 shadow-2xl shadow-black/60 backdrop-blur-xl"
         >
           {suggestions.map((s, i) => (
             <li
@@ -163,14 +163,14 @@ export function LocationInput({
               }}
               onMouseEnter={() => setActiveIndex(i)}
               className={cn(
-                'flex cursor-pointer items-center gap-2 px-3 py-1.5 text-xs',
+                'flex cursor-pointer items-center gap-2.5 px-3 py-2 text-xs transition-colors duration-75',
                 i === activeIndex
-                  ? 'bg-brand/15 text-foreground'
-                  : 'text-foreground/70 hover:bg-white/[0.04]'
+                  ? 'bg-brand/20 text-foreground'
+                  : 'text-foreground/60 hover:bg-white/[0.06] hover:text-foreground/90'
               )}
             >
-              <MapPin size={10} className="shrink-0 text-foreground/30" />
-              <span>{s.display}</span>
+              <MapPin size={11} className="shrink-0 text-foreground/35" />
+              <span className="truncate">{s.display}</span>
             </li>
           ))}
         </ul>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,6 +6,7 @@ export { applyTheme, getActiveTheme, restoreTheme, type ThemeId, THEMES } from '
 // ── Primitives ────────────────────────────────────────────────────────────
 export { ActionTile } from './components/ActionTile';
 export { Button, type ButtonProps } from './components/Button';
+export { Dropdown, type DropdownProps, type DropdownOption } from './components/Dropdown';
 export { GlassCard, type GlassCardProps } from './components/GlassCard';
 export { IconBadge, type IconBadgeProps } from './components/IconBadge';
 export { IconText } from './components/IconText';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,7 @@ export { applyTheme, getActiveTheme, restoreTheme, type ThemeId, THEMES } from '
 
 // ── Primitives ────────────────────────────────────────────────────────────
 export { ActionTile } from './components/ActionTile';
+export { LocationInput, type LocationInputProps } from './components/LocationInput';
 export { Button, type ButtonProps } from './components/Button';
 export { GlassCard, type GlassCardProps } from './components/GlassCard';
 export { IconBadge, type IconBadgeProps } from './components/IconBadge';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,12 +5,12 @@ export { applyTheme, getActiveTheme, restoreTheme, type ThemeId, THEMES } from '
 
 // ── Primitives ────────────────────────────────────────────────────────────
 export { ActionTile } from './components/ActionTile';
-export { LocationInput, type LocationInputProps } from './components/LocationInput';
 export { Button, type ButtonProps } from './components/Button';
 export { GlassCard, type GlassCardProps } from './components/GlassCard';
 export { IconBadge, type IconBadgeProps } from './components/IconBadge';
 export { IconText } from './components/IconText';
 export { Input, type InputProps } from './components/Input';
+export { LocationInput, type LocationInputProps } from './components/LocationInput';
 export { SectionHeader } from './components/SectionHeader';
 export { SectionLabel } from './components/SectionLabel';
 export { SelectDropdown } from './components/SelectDropdown';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,7 +6,7 @@ export { applyTheme, getActiveTheme, restoreTheme, type ThemeId, THEMES } from '
 // ── Primitives ────────────────────────────────────────────────────────────
 export { ActionTile } from './components/ActionTile';
 export { Button, type ButtonProps } from './components/Button';
-export { Dropdown, type DropdownProps, type DropdownOption } from './components/Dropdown';
+export { Dropdown, type DropdownOption, type DropdownProps } from './components/Dropdown';
 export { GlassCard, type GlassCardProps } from './components/GlassCard';
 export { IconBadge, type IconBadgeProps } from './components/IconBadge';
 export { IconText } from './components/IconText';

--- a/packages/ui/src/stories/Dropdown.stories.tsx
+++ b/packages/ui/src/stories/Dropdown.stories.tsx
@@ -1,0 +1,88 @@
+import { Cpu, Globe, Search } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { Dropdown } from '../components/Dropdown';
+
+const meta: Meta<typeof Dropdown> = {
+  title: 'Primitives/Dropdown',
+  component: Dropdown,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+};
+export default meta;
+type Story = StoryObj<typeof Dropdown>;
+
+const AI_MODELS = [
+  { value: 'llama3.2', label: 'llama3.2', meta: '2.0 GB' },
+  { value: 'mistral', label: 'mistral', meta: '4.1 GB' },
+  { value: 'gemma2', label: 'gemma2', meta: '5.4 GB' },
+  { value: 'phi3', label: 'phi3', meta: '2.2 GB' },
+];
+
+const BOARDS = [
+  { value: 'linkedin', label: 'LinkedIn' },
+  { value: 'indeed', label: 'Indeed' },
+  { value: 'stepstone', label: 'StepStone' },
+];
+
+function ModelDemo() {
+  const [value, setValue] = useState('llama3.2');
+  return (
+    <div className="w-72">
+      <Dropdown options={AI_MODELS} value={value} onChange={setValue} icon={<Cpu size={13} />} />
+    </div>
+  );
+}
+
+function BoardDemo() {
+  const [value, setValue] = useState('');
+  return (
+    <div className="w-72">
+      <Dropdown
+        options={BOARDS}
+        value={value}
+        onChange={setValue}
+        placeholder="Select a board…"
+        icon={<Globe size={13} />}
+      />
+    </div>
+  );
+}
+
+function SearchableDemo() {
+  const [value, setValue] = useState('');
+  const many = Array.from({ length: 10 }, (_, i) => ({
+    value: `model-${i}`,
+    label: `model-option-${i}`,
+    meta: `${((i + 1) * 1.2) | 0}.0 GB`,
+  }));
+  return (
+    <div className="w-72">
+      <Dropdown
+        options={many}
+        value={value}
+        onChange={setValue}
+        icon={<Search size={13} />}
+        placeholder="Choose model…"
+      />
+    </div>
+  );
+}
+
+export const WithModels: Story = { render: () => <ModelDemo /> };
+export const WithBoards: Story = { render: () => <BoardDemo /> };
+export const Searchable: Story = { render: () => <SearchableDemo /> };
+export const Disabled: Story = {
+  render: () => (
+    <div className="w-72">
+      <Dropdown
+        options={AI_MODELS}
+        value="llama3.2"
+        onChange={() => {}}
+        icon={<Cpu size={13} />}
+        disabled
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/stories/Dropdown.stories.tsx
+++ b/packages/ui/src/stories/Dropdown.stories.tsx
@@ -1,15 +1,15 @@
 import { Cpu, Globe, Search } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { Dropdown } from '../components/Dropdown';
 
-const meta: Meta<typeof Dropdown> = {
+const meta = {
   title: 'Primitives/Dropdown',
   component: Dropdown,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
-};
+} satisfies Meta<typeof Dropdown>;
 export default meta;
 type Story = StoryObj<typeof Dropdown>;
 

--- a/packages/ui/src/stories/ErrorState.stories.tsx
+++ b/packages/ui/src/stories/ErrorState.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ErrorState } from '../components/ErrorState';
+
+const meta: Meta<typeof ErrorState> = {
+  title: 'Feedback/ErrorState',
+  component: ErrorState,
+  tags: ['autodocs'],
+  argTypes: {
+    onRetry: { action: 'retry clicked' },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof ErrorState>;
+
+export const Default: Story = {};
+
+export const WithMessage: Story = {
+  args: {
+    title: 'Failed to load jobs',
+    description: 'There was a problem connecting to the scraper. Check your network and try again.',
+  },
+};
+
+export const WithRetry: Story = {
+  args: {
+    title: 'Something went wrong',
+    description: 'The request timed out.',
+    onRetry: () => {},
+  },
+};

--- a/packages/ui/src/stories/GlassOverlay.stories.tsx
+++ b/packages/ui/src/stories/GlassOverlay.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { GlassOverlay } from '../components/GlassOverlay';
+
+const meta: Meta<typeof GlassOverlay> = {
+  title: 'Overlays/GlassOverlay',
+  component: GlassOverlay,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+type Story = StoryObj<typeof GlassOverlay>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="relative h-64 overflow-hidden rounded-xl bg-gradient-to-br from-purple-900 to-slate-900 p-6">
+      <p className="text-sm text-white/60">Content behind the overlay</p>
+      <GlassOverlay zIndex={10} />
+    </div>
+  ),
+};
+
+export const Clickable: Story = {
+  render: () => (
+    <div className="relative h-64 overflow-hidden rounded-xl bg-gradient-to-br from-purple-900 to-slate-900 p-6">
+      <p className="text-sm text-white/60">Click the overlay</p>
+      <GlassOverlay zIndex={10} onClick={() => alert('overlay clicked')} />
+    </div>
+  ),
+};

--- a/packages/ui/src/stories/IconText.stories.tsx
+++ b/packages/ui/src/stories/IconText.stories.tsx
@@ -1,0 +1,43 @@
+import { Sparkles, Star, Zap } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { IconText } from '../components/IconText';
+
+const meta: Meta<typeof IconText> = {
+  title: 'Primitives/IconText',
+  component: IconText,
+  tags: ['autodocs'],
+  argTypes: {
+    gap: { control: 'select', options: ['sm', 'md', 'lg'] },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof IconText>;
+
+export const Default: Story = {
+  args: { icon: <Sparkles size={14} />, children: 'Generate', gap: 'md' },
+};
+
+export const AllGaps: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 text-sm text-foreground/80">
+      <IconText icon={<Star size={14} />} gap="sm">
+        Small gap
+      </IconText>
+      <IconText icon={<Star size={14} />} gap="md">
+        Medium gap
+      </IconText>
+      <IconText icon={<Star size={14} />} gap="lg">
+        Large gap
+      </IconText>
+    </div>
+  ),
+};
+
+export const InText: Story = {
+  render: () => (
+    <p className="text-sm text-foreground/80">
+      Click <IconText icon={<Zap size={12} />}>Run</IconText> to start.
+    </p>
+  ),
+};

--- a/packages/ui/src/stories/LocationInput.stories.tsx
+++ b/packages/ui/src/stories/LocationInput.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { LocationInput } from '../components/LocationInput';
 

--- a/packages/ui/src/stories/LocationInput.stories.tsx
+++ b/packages/ui/src/stories/LocationInput.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { LocationInput } from '../components/LocationInput';
+
+const meta: Meta<typeof LocationInput> = {
+  title: 'Primitives/LocationInput',
+  component: LocationInput,
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: { control: 'boolean' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Location autocomplete backed by Nominatim (OpenStreetMap). Supports city names and postcodes. Debounces at 300 ms.',
+      },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof LocationInput>;
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <div className="w-72">
+        <LocationInput
+          value={value}
+          onChange={setValue}
+          placeholder="e.g. Berlin, Germany or 10115"
+        />
+      </div>
+    );
+  },
+};
+
+export const Prefilled: Story = {
+  render: () => {
+    const [value, setValue] = useState('Berlin, Berlin, Germany');
+    return (
+      <div className="w-72">
+        <LocationInput value={value} onChange={setValue} />
+      </div>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="w-72">
+      <LocationInput value="Munich, Bavaria, Germany" onChange={() => {}} disabled />
+    </div>
+  ),
+};

--- a/packages/ui/src/stories/LocationInput.stories.tsx
+++ b/packages/ui/src/stories/LocationInput.stories.tsx
@@ -22,32 +22,30 @@ const meta: Meta<typeof LocationInput> = {
 export default meta;
 type Story = StoryObj<typeof LocationInput>;
 
-export const Default: Story = {
-  render: () => {
-    const [value, setValue] = useState('');
-    return (
-      <div className="w-72">
-        <LocationInput
-          value={value}
-          onChange={setValue}
-          placeholder="e.g. Berlin, Germany or 10115"
-        />
-      </div>
-    );
-  },
-};
+function DefaultDemo() {
+  const [value, setValue] = useState('');
+  return (
+    <div className="w-72">
+      <LocationInput
+        value={value}
+        onChange={setValue}
+        placeholder="e.g. Berlin, Germany or 10115"
+      />
+    </div>
+  );
+}
 
-export const Prefilled: Story = {
-  render: () => {
-    const [value, setValue] = useState('Berlin, Berlin, Germany');
-    return (
-      <div className="w-72">
-        <LocationInput value={value} onChange={setValue} />
-      </div>
-    );
-  },
-};
+function PrefilledDemo() {
+  const [value, setValue] = useState('Berlin, Berlin, Germany');
+  return (
+    <div className="w-72">
+      <LocationInput value={value} onChange={setValue} />
+    </div>
+  );
+}
 
+export const Default: Story = { render: () => <DefaultDemo /> };
+export const Prefilled: Story = { render: () => <PrefilledDemo /> };
 export const Disabled: Story = {
   render: () => (
     <div className="w-72">

--- a/packages/ui/src/stories/MarkdownMessage.stories.tsx
+++ b/packages/ui/src/stories/MarkdownMessage.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { MarkdownMessage } from '../components/MarkdownMessage';
+
+const meta: Meta<typeof MarkdownMessage> = {
+  title: 'Content/MarkdownMessage',
+  component: MarkdownMessage,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof MarkdownMessage>;
+
+export const Paragraph: Story = {
+  args: { content: 'This is a plain paragraph with **bold** and *italic* and `code` inline.' },
+};
+
+export const Headings: Story = {
+  args: {
+    content: `# Heading 1\n## Heading 2\n### Heading 3\n\nBody text below headings.`,
+  },
+};
+
+export const Lists: Story = {
+  args: {
+    content: `**Unordered:**\n- First item\n- Second item\n- Third item\n\n**Ordered:**\n1. Step one\n2. Step two\n3. Step three`,
+  },
+};
+
+export const CodeBlock: Story = {
+  args: {
+    content:
+      'Here is a code block:\n\n```ts\nconst greet = (name: string) => `Hello, ${name}!`;\n```',
+  },
+};
+
+export const Blockquote: Story = {
+  args: { content: '> This is a blockquote.\n> It can span multiple lines.' },
+};
+
+export const Full: Story = {
+  args: {
+    content: `# AI Analysis\n\nYour resume matches **85%** of the requirements.\n\n## Strengths\n- Strong TypeScript skills\n- 3 years React experience\n- Open source contributions\n\n## Suggestions\n1. Add quantified achievements\n2. Highlight leadership experience\n\n> Tip: Tailor your summary to each job description.\n\n\`\`\`json\n{ "score": 85, "match": "strong" }\n\`\`\``,
+  },
+};

--- a/packages/ui/src/stories/ModalShell.stories.tsx
+++ b/packages/ui/src/stories/ModalShell.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '../components/Button';
 import { ModalShell } from '../components/ModalShell';

--- a/packages/ui/src/stories/ModalShell.stories.tsx
+++ b/packages/ui/src/stories/ModalShell.stories.tsx
@@ -13,58 +13,56 @@ const meta: Meta<typeof ModalShell> = {
 export default meta;
 type Story = StoryObj<typeof ModalShell>;
 
-export const Default: Story = {
-  render: () => {
-    const [open, setOpen] = useState(false);
-    return (
-      <>
-        <Button onClick={() => setOpen(true)}>Open Modal</Button>
-        <ModalShell open={open} onClose={() => setOpen(false)}>
-          <div className="p-6">
-            <h2 className="mb-2 text-base font-semibold text-foreground/90">Modal Title</h2>
-            <p className="mb-4 text-sm text-foreground/60">Modal content goes here.</p>
-            <Button size="sm" onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </div>
-        </ModalShell>
-      </>
-    );
-  },
-};
+function DefaultDemo() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Modal</Button>
+      <ModalShell open={open} onClose={() => setOpen(false)}>
+        <div className="p-6">
+          <h2 className="mb-2 text-base font-semibold text-foreground/90">Modal Title</h2>
+          <p className="mb-4 text-sm text-foreground/60">Modal content goes here.</p>
+          <Button size="sm" onClick={() => setOpen(false)}>
+            Close
+          </Button>
+        </div>
+      </ModalShell>
+    </>
+  );
+}
 
-export const Wide: Story = {
-  render: () => {
-    const [open, setOpen] = useState(false);
-    return (
-      <>
-        <Button onClick={() => setOpen(true)}>Open Wide Modal</Button>
-        <ModalShell open={open} onClose={() => setOpen(false)} maxWidth="max-w-2xl">
-          <div className="p-6">
-            <h2 className="mb-2 text-base font-semibold text-foreground/90">Wide Modal</h2>
-            <p className="text-sm text-foreground/60">This modal uses max-w-2xl.</p>
-          </div>
-        </ModalShell>
-      </>
-    );
-  },
-};
+function WideDemo() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Wide Modal</Button>
+      <ModalShell open={open} onClose={() => setOpen(false)} maxWidth="max-w-2xl">
+        <div className="p-6">
+          <h2 className="mb-2 text-base font-semibold text-foreground/90">Wide Modal</h2>
+          <p className="text-sm text-foreground/60">This modal uses max-w-2xl.</p>
+        </div>
+      </ModalShell>
+    </>
+  );
+}
 
-export const CustomBorder: Story = {
-  render: () => {
-    const [open, setOpen] = useState(false);
-    return (
-      <>
-        <Button variant="danger" onClick={() => setOpen(true)}>
-          Danger Modal
-        </Button>
-        <ModalShell open={open} onClose={() => setOpen(false)} borderClass="border-red-500/30">
-          <div className="p-6">
-            <h2 className="mb-2 text-base font-semibold text-red-400">Danger Zone</h2>
-            <p className="text-sm text-foreground/60">This action cannot be undone.</p>
-          </div>
-        </ModalShell>
-      </>
-    );
-  },
-};
+function DangerDemo() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant="danger" onClick={() => setOpen(true)}>
+        Danger Modal
+      </Button>
+      <ModalShell open={open} onClose={() => setOpen(false)} borderClass="border-red-500/30">
+        <div className="p-6">
+          <h2 className="mb-2 text-base font-semibold text-red-400">Danger Zone</h2>
+          <p className="text-sm text-foreground/60">This action cannot be undone.</p>
+        </div>
+      </ModalShell>
+    </>
+  );
+}
+
+export const Default: Story = { render: () => <DefaultDemo /> };
+export const Wide: Story = { render: () => <WideDemo /> };
+export const CustomBorder: Story = { render: () => <DangerDemo /> };

--- a/packages/ui/src/stories/ModalShell.stories.tsx
+++ b/packages/ui/src/stories/ModalShell.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { Button } from '../components/Button';
+import { ModalShell } from '../components/ModalShell';
+
+const meta: Meta<typeof ModalShell> = {
+  title: 'Overlays/ModalShell',
+  component: ModalShell,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+};
+export default meta;
+type Story = StoryObj<typeof ModalShell>;
+
+export const Default: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+        <ModalShell open={open} onClose={() => setOpen(false)}>
+          <div className="p-6">
+            <h2 className="mb-2 text-base font-semibold text-foreground/90">Modal Title</h2>
+            <p className="mb-4 text-sm text-foreground/60">Modal content goes here.</p>
+            <Button size="sm" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </div>
+        </ModalShell>
+      </>
+    );
+  },
+};
+
+export const Wide: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Wide Modal</Button>
+        <ModalShell open={open} onClose={() => setOpen(false)} maxWidth="max-w-2xl">
+          <div className="p-6">
+            <h2 className="mb-2 text-base font-semibold text-foreground/90">Wide Modal</h2>
+            <p className="text-sm text-foreground/60">This modal uses max-w-2xl.</p>
+          </div>
+        </ModalShell>
+      </>
+    );
+  },
+};
+
+export const CustomBorder: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button variant="danger" onClick={() => setOpen(true)}>
+          Danger Modal
+        </Button>
+        <ModalShell open={open} onClose={() => setOpen(false)} borderClass="border-red-500/30">
+          <div className="p-6">
+            <h2 className="mb-2 text-base font-semibold text-red-400">Danger Zone</h2>
+            <p className="text-sm text-foreground/60">This action cannot be undone.</p>
+          </div>
+        </ModalShell>
+      </>
+    );
+  },
+};

--- a/packages/ui/src/stories/OptionTile.stories.tsx
+++ b/packages/ui/src/stories/OptionTile.stories.tsx
@@ -1,0 +1,58 @@
+import { Brain, Globe, Zap } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { OptionTile } from '../components/OptionTile';
+
+const meta: Meta<typeof OptionTile> = {
+  title: 'Primitives/OptionTile',
+  component: OptionTile,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof OptionTile>;
+
+export const Selected: Story = {
+  args: {
+    icon: Brain,
+    label: 'AI Analysis',
+    description: 'Powered by local model',
+    selected: true,
+    onClick: () => {},
+  },
+};
+
+export const Unselected: Story = {
+  args: {
+    icon: Globe,
+    label: 'Web Scraping',
+    description: 'Fetch live job data',
+    selected: false,
+    onClick: () => {},
+  },
+};
+
+export const Group: Story = {
+  render: () => {
+    const [selected, setSelected] = useState('ai');
+    return (
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          { id: 'ai', icon: Brain, label: 'AI Mode', description: 'Local inference' },
+          { id: 'web', icon: Globe, label: 'Web Mode', description: 'Live scraping' },
+          { id: 'fast', icon: Zap, label: 'Fast Mode', description: 'Cached results' },
+        ].map(({ id, icon, label, description }) => (
+          <OptionTile
+            key={id}
+            icon={icon}
+            label={label}
+            description={description}
+            selected={selected === id}
+            onClick={() => setSelected(id)}
+            layoutId="option-group"
+          />
+        ))}
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/stories/OptionTile.stories.tsx
+++ b/packages/ui/src/stories/OptionTile.stories.tsx
@@ -1,6 +1,6 @@
 import { Brain, Globe, Zap } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { OptionTile } from '../components/OptionTile';
 

--- a/packages/ui/src/stories/OptionTile.stories.tsx
+++ b/packages/ui/src/stories/OptionTile.stories.tsx
@@ -32,27 +32,27 @@ export const Unselected: Story = {
   },
 };
 
-export const Group: Story = {
-  render: () => {
-    const [selected, setSelected] = useState('ai');
-    return (
-      <div className="grid grid-cols-3 gap-3">
-        {[
-          { id: 'ai', icon: Brain, label: 'AI Mode', description: 'Local inference' },
-          { id: 'web', icon: Globe, label: 'Web Mode', description: 'Live scraping' },
-          { id: 'fast', icon: Zap, label: 'Fast Mode', description: 'Cached results' },
-        ].map(({ id, icon, label, description }) => (
-          <OptionTile
-            key={id}
-            icon={icon}
-            label={label}
-            description={description}
-            selected={selected === id}
-            onClick={() => setSelected(id)}
-            layoutId="option-group"
-          />
-        ))}
-      </div>
-    );
-  },
-};
+function GroupDemo() {
+  const [selected, setSelected] = useState('ai');
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      {[
+        { id: 'ai', icon: Brain, label: 'AI Mode', description: 'Local inference' },
+        { id: 'web', icon: Globe, label: 'Web Mode', description: 'Live scraping' },
+        { id: 'fast', icon: Zap, label: 'Fast Mode', description: 'Cached results' },
+      ].map(({ id, icon, label, description }) => (
+        <OptionTile
+          key={id}
+          icon={icon}
+          label={label}
+          description={description}
+          selected={selected === id}
+          onClick={() => setSelected(id)}
+          layoutId="option-group"
+        />
+      ))}
+    </div>
+  );
+}
+
+export const Group: Story = { render: () => <GroupDemo /> };

--- a/packages/ui/src/stories/SectionHeader.stories.tsx
+++ b/packages/ui/src/stories/SectionHeader.stories.tsx
@@ -1,0 +1,41 @@
+import { Brain, Settings, Shield } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SectionHeader } from '../components/SectionHeader';
+
+const meta: Meta<typeof SectionHeader> = {
+  title: 'Primitives/SectionHeader',
+  component: SectionHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md'] },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof SectionHeader>;
+
+export const Default: Story = {
+  args: { icon: Settings, title: 'Settings', size: 'md' },
+};
+
+export const WithDescription: Story = {
+  args: {
+    icon: Brain,
+    title: 'AI Configuration',
+    description: 'Configure your local model and provider settings.',
+    size: 'md',
+  },
+};
+
+export const Small: Story = {
+  args: { icon: Shield, title: 'Security', description: 'Manage credentials.', size: 'sm' },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <SectionHeader icon={Settings} title="Medium Header" description="Default size" size="md" />
+      <SectionHeader icon={Settings} title="Small Header" description="Compact size" size="sm" />
+    </div>
+  ),
+};

--- a/packages/ui/src/stories/SectionLabel.stories.tsx
+++ b/packages/ui/src/stories/SectionLabel.stories.tsx
@@ -1,0 +1,29 @@
+import { Filter, Star } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SectionLabel } from '../components/SectionLabel';
+
+const meta: Meta<typeof SectionLabel> = {
+  title: 'Primitives/SectionLabel',
+  component: SectionLabel,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof SectionLabel>;
+
+export const Default: Story = {
+  args: { children: 'Filters' },
+};
+
+export const WithIcon: Story = {
+  args: { icon: Filter, children: 'Filters' },
+};
+
+export const InContext: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 rounded-xl border border-white/10 bg-white/5 p-4">
+      <SectionLabel icon={Star}>Highlights</SectionLabel>
+      <p className="text-sm text-foreground/60">Section content goes here.</p>
+    </div>
+  ),
+};

--- a/packages/ui/src/stories/SelectDropdown.stories.tsx
+++ b/packages/ui/src/stories/SelectDropdown.stories.tsx
@@ -1,0 +1,71 @@
+import { Globe } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { SelectDropdown } from '../components/SelectDropdown';
+
+const meta: Meta<typeof SelectDropdown> = {
+  title: 'Primitives/SelectDropdown',
+  component: SelectDropdown,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof SelectDropdown>;
+
+const OPTIONS = [
+  { value: 'linkedin', label: 'LinkedIn' },
+  { value: 'indeed', label: 'Indeed' },
+  { value: 'stepstone', label: 'StepStone' },
+  { value: 'xing', label: 'Xing' },
+  { value: 'greenhouse', label: 'Greenhouse' },
+];
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <SelectDropdown
+        options={OPTIONS}
+        value={value}
+        onChange={setValue}
+        placeholder="Select board…"
+      />
+    );
+  },
+};
+
+export const WithIcon: Story = {
+  render: () => {
+    const [value, setValue] = useState('linkedin');
+    return (
+      <SelectDropdown
+        options={OPTIONS}
+        value={value}
+        onChange={setValue}
+        icon={<Globe size={12} />}
+      />
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: () => <SelectDropdown options={OPTIONS} value="linkedin" onChange={() => {}} disabled />,
+};
+
+export const Searchable: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    const many = Array.from({ length: 12 }, (_, i) => ({
+      value: String(i),
+      label: `Option ${i + 1}`,
+    }));
+    return (
+      <SelectDropdown
+        options={many}
+        value={value}
+        onChange={setValue}
+        placeholder="Search options…"
+      />
+    );
+  },
+};

--- a/packages/ui/src/stories/SelectDropdown.stories.tsx
+++ b/packages/ui/src/stories/SelectDropdown.stories.tsx
@@ -20,52 +20,49 @@ const OPTIONS = [
   { value: 'greenhouse', label: 'Greenhouse' },
 ];
 
-export const Default: Story = {
-  render: () => {
-    const [value, setValue] = useState('');
-    return (
-      <SelectDropdown
-        options={OPTIONS}
-        value={value}
-        onChange={setValue}
-        placeholder="Select board…"
-      />
-    );
-  },
-};
+function DefaultDemo() {
+  const [value, setValue] = useState('');
+  return (
+    <SelectDropdown
+      options={OPTIONS}
+      value={value}
+      onChange={setValue}
+      placeholder="Select board…"
+    />
+  );
+}
 
-export const WithIcon: Story = {
-  render: () => {
-    const [value, setValue] = useState('linkedin');
-    return (
-      <SelectDropdown
-        options={OPTIONS}
-        value={value}
-        onChange={setValue}
-        icon={<Globe size={12} />}
-      />
-    );
-  },
-};
+function WithIconDemo() {
+  const [value, setValue] = useState('linkedin');
+  return (
+    <SelectDropdown
+      options={OPTIONS}
+      value={value}
+      onChange={setValue}
+      icon={<Globe size={12} />}
+    />
+  );
+}
 
+function SearchableDemo() {
+  const [value, setValue] = useState('');
+  const many = Array.from({ length: 12 }, (_, i) => ({
+    value: String(i),
+    label: `Option ${i + 1}`,
+  }));
+  return (
+    <SelectDropdown
+      options={many}
+      value={value}
+      onChange={setValue}
+      placeholder="Search options…"
+    />
+  );
+}
+
+export const Default: Story = { render: () => <DefaultDemo /> };
+export const WithIcon: Story = { render: () => <WithIconDemo /> };
 export const Disabled: Story = {
   render: () => <SelectDropdown options={OPTIONS} value="linkedin" onChange={() => {}} disabled />,
 };
-
-export const Searchable: Story = {
-  render: () => {
-    const [value, setValue] = useState('');
-    const many = Array.from({ length: 12 }, (_, i) => ({
-      value: String(i),
-      label: `Option ${i + 1}`,
-    }));
-    return (
-      <SelectDropdown
-        options={many}
-        value={value}
-        onChange={setValue}
-        placeholder="Search options…"
-      />
-    );
-  },
-};
+export const Searchable: Story = { render: () => <SearchableDemo /> };

--- a/packages/ui/src/stories/SelectDropdown.stories.tsx
+++ b/packages/ui/src/stories/SelectDropdown.stories.tsx
@@ -1,6 +1,6 @@
 import { Globe } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { SelectDropdown } from '../components/SelectDropdown';
 

--- a/packages/ui/src/stories/SettingsSection.stories.tsx
+++ b/packages/ui/src/stories/SettingsSection.stories.tsx
@@ -1,0 +1,37 @@
+import { Bell, Shield } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Button } from '../components/Button';
+import { SettingsSection } from '../components/SettingsSection';
+
+const meta: Meta<typeof SettingsSection> = {
+  title: 'Composition/SettingsSection',
+  component: SettingsSection,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof SettingsSection>;
+
+export const Default: Story = {
+  args: {
+    icon: Bell,
+    label: 'Notifications',
+    children: <p className="text-sm text-foreground/60">Notification settings go here.</p>,
+  },
+};
+
+export const WithActions: Story = {
+  render: () => (
+    <SettingsSection icon={Shield} label="Security">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-foreground/80">Two-factor authentication</p>
+          <p className="text-xs text-foreground/40">Add an extra layer of security.</p>
+        </div>
+        <Button size="sm" variant="glass">
+          Enable
+        </Button>
+      </div>
+    </SettingsSection>
+  ),
+};

--- a/packages/ui/src/stories/StreamingText.stories.tsx
+++ b/packages/ui/src/stories/StreamingText.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { StreamingText } from '../components/StreamingText';
 
@@ -16,50 +16,44 @@ export default meta;
 type Story = StoryObj<typeof StreamingText>;
 
 export const Static: Story = {
-  args: {
-    text: 'This is static text that has already finished streaming.',
-    isStreaming: false,
-  },
+  args: { text: 'This is static text that has already finished streaming.', isStreaming: false },
 };
 
 export const Streaming: Story = {
-  args: {
-    text: 'Analyzing your resume',
-    isStreaming: true,
-  },
+  args: { text: 'Analyzing your resume', isStreaming: true },
 };
 
-export const Live: Story = {
-  render: () => {
-    const full = 'The quick brown fox jumps over the lazy dog. AI is transforming job hunting.';
-    const [text, setText] = useState('');
-    const [streaming, setStreaming] = useState(false);
+function LiveDemo() {
+  const full = 'The quick brown fox jumps over the lazy dog. AI is transforming job hunting.';
+  const [text, setText] = useState('');
+  const [streaming, setStreaming] = useState(false);
 
-    const start = () => {
-      setText('');
-      setStreaming(true);
-      let i = 0;
-      const id = setInterval(() => {
-        i++;
-        setText(full.slice(0, i));
-        if (i >= full.length) {
-          clearInterval(id);
-          setStreaming(false);
-        }
-      }, 40);
-    };
+  const start = () => {
+    setText('');
+    setStreaming(true);
+    let i = 0;
+    const id = setInterval(() => {
+      i++;
+      setText(full.slice(0, i));
+      if (i >= full.length) {
+        clearInterval(id);
+        setStreaming(false);
+      }
+    }, 40);
+  };
 
-    return (
-      <div className="flex flex-col gap-3">
-        <StreamingText text={text} isStreaming={streaming} />
-        <button
-          type="button"
-          onClick={start}
-          className="self-start rounded-lg bg-brand/20 px-3 py-1 text-xs text-brand-soft"
-        >
-          Replay
-        </button>
-      </div>
-    );
-  },
-};
+  return (
+    <div className="flex flex-col gap-3">
+      <StreamingText text={text} isStreaming={streaming} />
+      <button
+        type="button"
+        onClick={start}
+        className="self-start rounded-lg bg-brand/20 px-3 py-1 text-xs text-brand-soft"
+      >
+        Replay
+      </button>
+    </div>
+  );
+}
+
+export const Live: Story = { render: () => <LiveDemo /> };

--- a/packages/ui/src/stories/StreamingText.stories.tsx
+++ b/packages/ui/src/stories/StreamingText.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect, useState } from 'react';
+
+import { StreamingText } from '../components/StreamingText';
+
+const meta: Meta<typeof StreamingText> = {
+  title: 'Content/StreamingText',
+  component: StreamingText,
+  tags: ['autodocs'],
+  argTypes: {
+    isStreaming: { control: 'boolean' },
+    autoScroll: { control: 'boolean' },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof StreamingText>;
+
+export const Static: Story = {
+  args: {
+    text: 'This is static text that has already finished streaming.',
+    isStreaming: false,
+  },
+};
+
+export const Streaming: Story = {
+  args: {
+    text: 'Analyzing your resume',
+    isStreaming: true,
+  },
+};
+
+export const Live: Story = {
+  render: () => {
+    const full = 'The quick brown fox jumps over the lazy dog. AI is transforming job hunting.';
+    const [text, setText] = useState('');
+    const [streaming, setStreaming] = useState(false);
+
+    const start = () => {
+      setText('');
+      setStreaming(true);
+      let i = 0;
+      const id = setInterval(() => {
+        i++;
+        setText(full.slice(0, i));
+        if (i >= full.length) {
+          clearInterval(id);
+          setStreaming(false);
+        }
+      }, 40);
+    };
+
+    return (
+      <div className="flex flex-col gap-3">
+        <StreamingText text={text} isStreaming={streaming} />
+        <button
+          type="button"
+          onClick={start}
+          className="self-start rounded-lg bg-brand/20 px-3 py-1 text-xs text-brand-soft"
+        >
+          Replay
+        </button>
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/stories/StreamingText.stories.tsx
+++ b/packages/ui/src/stories/StreamingText.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { StreamingText } from '../components/StreamingText';
 

--- a/packages/ui/src/stories/TextArea.stories.tsx
+++ b/packages/ui/src/stories/TextArea.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { TextArea } from '../components/TextArea';
+
+const meta: Meta<typeof TextArea> = {
+  title: 'Primitives/TextArea',
+  component: TextArea,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'glass'] },
+    disabled: { control: 'boolean' },
+    rows: { control: 'number' },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof TextArea>;
+
+export const Default: Story = {
+  args: { placeholder: 'Write your cover letter…', rows: 4, variant: 'default' },
+};
+
+export const Glass: Story = {
+  args: { placeholder: 'Glass variant…', rows: 4, variant: 'glass' },
+};
+
+export const Disabled: Story = {
+  args: { value: 'This textarea is disabled.', rows: 3, disabled: true },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <TextArea placeholder="Default variant" rows={3} variant="default" />
+      <TextArea placeholder="Glass variant" rows={3} variant="glass" />
+    </div>
+  ),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^13.0.0
         version: 13.0.0(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-storybook:
+        specifier: ^10.4.0
+        version: 10.4.0(eslint@10.4.0(jiti@2.7.0))(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       eslint-plugin-unused-imports:
         specifier: ^4.4.1
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      eslint-plugin-storybook:
+        specifier: ^10.4.0
+        version: 10.4.0(eslint@10.4.0(jiti@2.7.0))(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -2956,6 +2959,12 @@ packages:
     resolution: {integrity: sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==}
     peerDependencies:
       eslint: '>=5.0.0'
+
+  eslint-plugin-storybook@10.4.0:
+    resolution: {integrity: sha512-YYdQSup9zPoZPIzlyxZwq/R7+yCEiBtFh/iKUA0q/iWZXyA4zlaxx/t/LyM14mw/McvwS+DdSBo0JaBbCMPM9g==}
+    peerDependencies:
+      eslint: '>=8'
+      storybook: ^10.4.0
 
   eslint-plugin-unused-imports@4.4.1:
     resolution: {integrity: sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==}
@@ -8135,6 +8144,15 @@ snapshots:
   eslint-plugin-simple-import-sort@13.0.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       eslint: 10.4.0(jiti@2.7.0)
+
+  eslint-plugin-storybook@10.4.0(eslint@10.4.0(jiti@2.7.0))(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.0(jiti@2.7.0)
+      storybook: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.0)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)):
     dependencies:


### PR DESCRIPTION
## Summary

- **Multi-provider AI** — Connect OpenAI, Anthropic, Gemini, and Ollama simultaneously; each stores its own model selection independently; active provider switcher; API key validated by fetching models on save; schema migrated v1→v2 with backward-compat migration
- **Resume library** — Onboarding now includes a resume upload step; resume settings wired to real IPC (was fully mocked); `ResumeInputCard` shared component auto-fills default resume on page load, lets users pick from saved library, and offers Save/Set-as-default after a fresh upload; fixes `_id`/`createdAt` field mapping from Rust backend
- **Jobs** — LinkedIn guest mode unblocked (removed incorrect `hasSession()` guard blocking the guest API); auth hint banner shown when selecting LinkedIn/Indeed/Xing
- **Dashboard** — `JobPipelineOverview` shows live counts from `useInteractions()`; `AISystemStatus` shows live health from `useSystemHealth()` + `useSystemMetrics()`
- **Settings** — Check for Updates card in General with changelog display; `CustomDropdown` gets glass-elevated background + search box; `ConfirmModal` buttons match `ActionCard` colors with per-variant glow; `settings.aiProvider.activeProvider` i18n key added
- **CI/CD** — Release workflow adds explicit `.sig` upload steps and a `generate-updater-manifest` job that assembles `latest.json` from both platform builds; fixes duplicate `resources` key in `tauri.conf.json`
- **UX fixes** — Titlebar `z-[300]` so window controls appear above the onboarding overlay; version display moved out of the AI status pill into its own line

## Test plan

- [ ] Connect a second AI provider in Settings → AI; verify both show as connected and active provider switcher appears
- [ ] Upload a resume in onboarding; verify it appears in Resume settings
- [ ] Open AI Generate / Analyze with a saved default resume; verify textarea is pre-filled
- [ ] Select a different saved resume from the dropdown; verify text changes
- [ ] Scrape LinkedIn without a session; verify results return (guest mode)
- [ ] Check for updates in General Settings; verify no crash on "no release" error
- [ ] Verify window controls visible during onboarding
- [ ] Dashboard shows real job counts and system status

🤖 Generated with [Claude Code](https://claude.com/claude-code)