### PR TITLE
fix: add tauri signing config and fallback for unsigned builds

### DIFF
--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -337,9 +337,10 @@ jobs:
             WIN_URL="${BASE_URL}/AI.Job.Hunter.Assistant_${VERSION}_x64_en-US.msi"
           fi
 
-          # Build platforms object — only include platforms that have a signature
+          # Build platforms object — include platforms with or without signatures
           PLATFORMS="{}"
 
+          # Always include macOS if the artifact exists (with or without signature)
           if [ -n "${MACOS_SIG}" ]; then
             PLATFORMS=$(echo "${PLATFORMS}" | node -e "
               const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
@@ -349,8 +350,18 @@ jobs:
               };
               process.stdout.write(JSON.stringify(d));
             " MACOS_SIG="${MACOS_SIG}")
+          else
+            # Fallback: include macOS without signature (for unsigned builds)
+            PLATFORMS=$(echo "${PLATFORMS}" | node -e "
+              const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+              d['darwin-universal'] = {
+                url: '${BASE_URL}/AI.Job.Hunter.Assistant_universal.app.tar.gz'
+              };
+              process.stdout.write(JSON.stringify(d));
+            ")
           fi
 
+          # Always include Windows if the artifact exists (with or without signature)
           if [ -n "${WIN_SIG}" ]; then
             PLATFORMS=$(echo "${PLATFORMS}" | node -e "
               const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
@@ -360,6 +371,15 @@ jobs:
               };
               process.stdout.write(JSON.stringify(d));
             " WIN_SIG="${WIN_SIG}")
+          else
+            # Fallback: include Windows without signature (for unsigned builds)
+            PLATFORMS=$(echo "${PLATFORMS}" | node -e "
+              const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+              d['windows-x86_64'] = {
+                url: '${BASE_URL}/AI.Job.Hunter.Assistant_${VERSION}_x64-setup.exe'
+              };
+              process.stdout.write(JSON.stringify(d));
+            ")
           fi
 
           # Generate latest.json

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -31,7 +31,10 @@
     "active": true,
     "targets": ["nsis", "msi", "dmg", "app"],
     "icon": ["icons/icon.ico", "icons/icon.png"],
-    "resources": []
+    "resources": [],
+    "signing": {
+      "targets": ["nsis", "msi", "dmg", "app"]
+    }
   },
   "plugins": {
     "shell": {
@@ -39,7 +42,7 @@
     },
     "dialog": null,
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEEwMTU2OTFCMzgyQjg4MzIKUldReWlDczRHMmtWb0Y3WmdtV09ZRkZ6UEx0K1UyVmlaV0pHb3NxSVR1UVRPRjhPUklIUTlLRWEK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRFRDI2NkFFQkMwQzQ1QTAKUldTZ1JReThybWJTVGpkYm9ZVXh5cGNaUUk2elA3dnVlcjhxdUkrYVBGeEZpbm55Mm5VZk1kVHkK",
       "endpoints": [
         "https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/latest/download/latest.json"
       ]

--- a/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
+++ b/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
@@ -92,8 +92,7 @@ export function ResumeInputCard({
     const raw = rawDocs.find((d) => d._id === resumePref?.defaultId) ?? rawDocs[0];
     const text = raw?.text?.trim();
     if (text) onChange(text);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rawDocs.length]);
+  }, [value, rawDocs, resumePref?.defaultId, onChange]);
 
   /** Load text from a saved document record into the textarea */
   const handleSelectSaved = (doc: DocumentRecord) => {

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -47,11 +47,32 @@ attach-to-release
 
 ## GitHub Secrets Required
 
-| Secret         | Purpose                                                            |
-| -------------- | ------------------------------------------------------------------ |
-| `GITHUB_TOKEN` | Auto-provided by GitHub Actions — creates releases, uploads assets |
+| Secret                               | Purpose                                                            |
+| ------------------------------------ | ------------------------------------------------------------------ |
+| `GITHUB_TOKEN`                       | Auto-provided by GitHub Actions — creates releases, uploads assets |
+| `TAURI_SIGNING_PRIVATE_KEY`          | Minisign private key for signing Tauri artifacts (optional)        |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the private key (empty string if none)                |
+| `TAURI_SIGNING_PUBLIC_KEY`           | Minisign public key for verifying updates                          |
+| `DISCORD_WEBHOOK_URL`                | Optional: Discord webhook for release notifications                |
 
-No additional secrets are required for unsigned builds. For macOS code signing, you would add `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` secrets — but these are optional (unsigned builds work; users bypass Gatekeeper).
+### Setting Up Tauri Signing (Optional but Recommended)
+
+To enable artifact signing for secure updates:
+
+1. Generate a minisign key pair:
+
+   ```bash
+   bash scripts/generate-tauri-signing-key.sh
+   ```
+
+2. Add the following secrets to your GitHub repository:
+   - `TAURI_SIGNING_PRIVATE_KEY` — contents of `~/.tauri/ajh.key`
+   - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — password you entered (or empty string)
+   - `TAURI_SIGNING_PUBLIC_KEY` — contents of `~/.tauri/ajh.key.pub`
+
+3. The CI pipeline automatically injects the public key into `tauri.conf.json` during builds.
+
+**Note:** The workflow will work without signing secrets (unsigned builds), but signed builds provide better security for auto-updates.
 
 ---
 

--- a/packages/ui/src/stories/ActionTile.stories.tsx
+++ b/packages/ui/src/stories/ActionTile.stories.tsx
@@ -1,16 +1,15 @@
 import { Briefcase, FileText, Search, Settings, Sparkles, Zap } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { ActionTile } from '../components/ActionTile';
 
-const meta: Meta<typeof ActionTile> = {
-  title: 'Primitives/ActionTile',
+const meta = {
   component: ActionTile,
   tags: ['autodocs'],
   argTypes: {
     active: { control: 'boolean' },
   },
-};
+} satisfies Meta<typeof ActionTile>;
 export default meta;
 type Story = StoryObj<typeof ActionTile>;
 

--- a/packages/ui/src/stories/Button.stories.tsx
+++ b/packages/ui/src/stories/Button.stories.tsx
@@ -1,10 +1,9 @@
 import { Download, Sparkles, Trash2 } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Button } from '../components/Button';
 
-const meta: Meta<typeof Button> = {
-  title: 'Primitives/Button',
+const meta = {
   component: Button,
   tags: ['autodocs'],
   argTypes: {
@@ -16,7 +15,7 @@ const meta: Meta<typeof Button> = {
     loading: { control: 'boolean' },
     disabled: { control: 'boolean' },
   },
-};
+} satisfies Meta<typeof Button>;
 export default meta;
 type Story = StoryObj<typeof Button>;
 

--- a/packages/ui/src/stories/ConfirmModal.stories.tsx
+++ b/packages/ui/src/stories/ConfirmModal.stories.tsx
@@ -1,15 +1,14 @@
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Button } from '../components/Button';
 import { ConfirmModal } from '../components/ConfirmModal';
 
-const meta: Meta<typeof ConfirmModal> = {
-  title: 'Overlays/ConfirmModal',
+const meta = {
   component: ConfirmModal,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },
-};
+} satisfies Meta<typeof ConfirmModal>;
 export default meta;
 type Story = StoryObj<typeof ConfirmModal>;
 

--- a/packages/ui/src/stories/Dropdown.stories.tsx
+++ b/packages/ui/src/stories/Dropdown.stories.tsx
@@ -1,11 +1,10 @@
 import { Cpu, Globe, Search } from 'lucide-react';
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Dropdown } from '../components/Dropdown';
 
 const meta = {
-  title: 'Primitives/Dropdown',
   component: Dropdown,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },

--- a/packages/ui/src/stories/EmptyState.stories.tsx
+++ b/packages/ui/src/stories/EmptyState.stories.tsx
@@ -1,14 +1,13 @@
 import { Briefcase, FileText, Search, Sparkles } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Button } from '../components/Button';
 import { EmptyState } from '../components/EmptyState';
 
-const meta: Meta<typeof EmptyState> = {
-  title: 'Feedback/EmptyState',
+const meta = {
   component: EmptyState,
   tags: ['autodocs'],
-};
+} satisfies Meta<typeof EmptyState>;
 export default meta;
 type Story = StoryObj<typeof EmptyState>;
 

--- a/packages/ui/src/stories/ErrorBoundary.stories.tsx
+++ b/packages/ui/src/stories/ErrorBoundary.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { ErrorState } from '../components/ErrorState';
 
-const meta: Meta = {
-  title: 'Feedback/ErrorBoundary',
+const meta = {
+  component: ErrorBoundary,
   tags: ['autodocs'],
-};
+} satisfies Meta;
 export default meta;
 type Story = StoryObj;
 

--- a/packages/ui/src/stories/ErrorState.stories.tsx
+++ b/packages/ui/src/stories/ErrorState.stories.tsx
@@ -1,15 +1,14 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { ErrorState } from '../components/ErrorState';
 
-const meta: Meta<typeof ErrorState> = {
-  title: 'Feedback/ErrorState',
+const meta = {
   component: ErrorState,
   tags: ['autodocs'],
   argTypes: {
     onRetry: { action: 'retry clicked' },
   },
-};
+} satisfies Meta<typeof ErrorState>;
 export default meta;
 type Story = StoryObj<typeof ErrorState>;
 

--- a/packages/ui/src/stories/GlassCard.stories.tsx
+++ b/packages/ui/src/stories/GlassCard.stories.tsx
@@ -1,9 +1,8 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { GlassCard } from '../components/GlassCard';
 
-const meta: Meta<typeof GlassCard> = {
-  title: 'Surfaces/GlassCard',
+const meta = {
   component: GlassCard,
   tags: ['autodocs'],
   argTypes: {
@@ -11,7 +10,7 @@ const meta: Meta<typeof GlassCard> = {
     highlight: { control: 'boolean' },
     glow: { control: 'boolean' },
   },
-};
+} satisfies Meta<typeof GlassCard>;
 export default meta;
 type Story = StoryObj<typeof GlassCard>;
 

--- a/packages/ui/src/stories/GlassOverlay.stories.tsx
+++ b/packages/ui/src/stories/GlassOverlay.stories.tsx
@@ -1,13 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { GlassOverlay } from '../components/GlassOverlay';
 
-const meta: Meta<typeof GlassOverlay> = {
-  title: 'Overlays/GlassOverlay',
+const meta = {
   component: GlassOverlay,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },
-};
+} satisfies Meta<typeof GlassOverlay>;
 export default meta;
 type Story = StoryObj<typeof GlassOverlay>;
 

--- a/packages/ui/src/stories/IconBadge.stories.tsx
+++ b/packages/ui/src/stories/IconBadge.stories.tsx
@@ -1,17 +1,16 @@
 import { Lock, Settings, Shield, Sparkles, User } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { IconBadge } from '../components/IconBadge';
 
-const meta: Meta<typeof IconBadge> = {
-  title: 'Primitives/IconBadge',
+const meta = {
   component: IconBadge,
   tags: ['autodocs'],
   argTypes: {
     size: { control: 'select', options: ['xs', 'sm', 'md', 'lg'] },
     shape: { control: 'select', options: ['rounded', 'circle', 'square'] },
   },
-};
+} satisfies Meta<typeof IconBadge>;
 export default meta;
 type Story = StoryObj<typeof IconBadge>;
 

--- a/packages/ui/src/stories/IconText.stories.tsx
+++ b/packages/ui/src/stories/IconText.stories.tsx
@@ -1,16 +1,15 @@
 import { Sparkles, Star, Zap } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { IconText } from '../components/IconText';
 
-const meta: Meta<typeof IconText> = {
-  title: 'Primitives/IconText',
+const meta = {
   component: IconText,
   tags: ['autodocs'],
   argTypes: {
     gap: { control: 'select', options: ['sm', 'md', 'lg'] },
   },
-};
+} satisfies Meta<typeof IconText>;
 export default meta;
 type Story = StoryObj<typeof IconText>;
 

--- a/packages/ui/src/stories/Input.stories.tsx
+++ b/packages/ui/src/stories/Input.stories.tsx
@@ -1,16 +1,15 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Input } from '../components/Input';
 
-const meta: Meta<typeof Input> = {
-  title: 'Primitives/Input',
+const meta = {
   component: Input,
   tags: ['autodocs'],
   argTypes: {
     variant: { control: 'select', options: ['default', 'glass'] },
     disabled: { control: 'boolean' },
   },
-};
+} satisfies Meta<typeof Input>;
 export default meta;
 type Story = StoryObj<typeof Input>;
 

--- a/packages/ui/src/stories/LoadingSkeleton.stories.tsx
+++ b/packages/ui/src/stories/LoadingSkeleton.stories.tsx
@@ -1,11 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { CardSkeleton, RowSkeleton, Skeleton } from '../components/LoadingSkeleton';
 
-const meta: Meta = {
-  title: 'Feedback/LoadingSkeleton',
+const meta = {
+  component: Skeleton,
   tags: ['autodocs'],
-};
+} satisfies Meta;
 export default meta;
 type Story = StoryObj;
 

--- a/packages/ui/src/stories/LocationInput.stories.tsx
+++ b/packages/ui/src/stories/LocationInput.stories.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { LocationInput } from '../components/LocationInput';
 
-const meta: Meta<typeof LocationInput> = {
-  title: 'Primitives/LocationInput',
+const meta = {
   component: LocationInput,
   tags: ['autodocs'],
   argTypes: {
@@ -18,7 +17,7 @@ const meta: Meta<typeof LocationInput> = {
       },
     },
   },
-};
+} satisfies Meta<typeof LocationInput>;
 export default meta;
 type Story = StoryObj<typeof LocationInput>;
 

--- a/packages/ui/src/stories/MarkdownMessage.stories.tsx
+++ b/packages/ui/src/stories/MarkdownMessage.stories.tsx
@@ -1,12 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { MarkdownMessage } from '../components/MarkdownMessage';
 
-const meta: Meta<typeof MarkdownMessage> = {
-  title: 'Content/MarkdownMessage',
+const meta = {
   component: MarkdownMessage,
   tags: ['autodocs'],
-};
+} satisfies Meta<typeof MarkdownMessage>;
 export default meta;
 type Story = StoryObj<typeof MarkdownMessage>;
 

--- a/packages/ui/src/stories/ModalShell.stories.tsx
+++ b/packages/ui/src/stories/ModalShell.stories.tsx
@@ -1,15 +1,14 @@
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Button } from '../components/Button';
 import { ModalShell } from '../components/ModalShell';
 
-const meta: Meta<typeof ModalShell> = {
-  title: 'Overlays/ModalShell',
+const meta = {
   component: ModalShell,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
-};
+} satisfies Meta<typeof ModalShell>;
 export default meta;
 type Story = StoryObj<typeof ModalShell>;
 

--- a/packages/ui/src/stories/OptionTile.stories.tsx
+++ b/packages/ui/src/stories/OptionTile.stories.tsx
@@ -1,14 +1,13 @@
 import { Brain, Globe, Zap } from 'lucide-react';
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { OptionTile } from '../components/OptionTile';
 
-const meta: Meta<typeof OptionTile> = {
-  title: 'Primitives/OptionTile',
+const meta = {
   component: OptionTile,
   tags: ['autodocs'],
-};
+} satisfies Meta<typeof OptionTile>;
 export default meta;
 type Story = StoryObj<typeof OptionTile>;
 

--- a/packages/ui/src/stories/SectionHeader.stories.tsx
+++ b/packages/ui/src/stories/SectionHeader.stories.tsx
@@ -1,16 +1,15 @@
 import { Brain, Settings, Shield } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { SectionHeader } from '../components/SectionHeader';
 
-const meta: Meta<typeof SectionHeader> = {
-  title: 'Primitives/SectionHeader',
+const meta = {
   component: SectionHeader,
   tags: ['autodocs'],
   argTypes: {
     size: { control: 'select', options: ['sm', 'md'] },
   },
-};
+} satisfies Meta<typeof SectionHeader>;
 export default meta;
 type Story = StoryObj<typeof SectionHeader>;
 

--- a/packages/ui/src/stories/SectionLabel.stories.tsx
+++ b/packages/ui/src/stories/SectionLabel.stories.tsx
@@ -1,13 +1,12 @@
 import { Filter, Star } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { SectionLabel } from '../components/SectionLabel';
 
-const meta: Meta<typeof SectionLabel> = {
-  title: 'Primitives/SectionLabel',
+const meta = {
   component: SectionLabel,
   tags: ['autodocs'],
-};
+} satisfies Meta<typeof SectionLabel>;
 export default meta;
 type Story = StoryObj<typeof SectionLabel>;
 

--- a/packages/ui/src/stories/SelectDropdown.stories.tsx
+++ b/packages/ui/src/stories/SelectDropdown.stories.tsx
@@ -1,14 +1,13 @@
 import { Globe } from 'lucide-react';
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { SelectDropdown } from '../components/SelectDropdown';
 
-const meta: Meta<typeof SelectDropdown> = {
-  title: 'Primitives/SelectDropdown',
+const meta = {
   component: SelectDropdown,
   tags: ['autodocs'],
-};
+} satisfies Meta<typeof SelectDropdown>;
 export default meta;
 type Story = StoryObj<typeof SelectDropdown>;
 

--- a/packages/ui/src/stories/SettingsSection.stories.tsx
+++ b/packages/ui/src/stories/SettingsSection.stories.tsx
@@ -1,14 +1,13 @@
 import { Bell, Shield } from 'lucide-react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Button } from '../components/Button';
 import { SettingsSection } from '../components/SettingsSection';
 
-const meta: Meta<typeof SettingsSection> = {
-  title: 'Composition/SettingsSection',
+const meta = {
   component: SettingsSection,
   tags: ['autodocs'],
-};
+} satisfies Meta<typeof SettingsSection>;
 export default meta;
 type Story = StoryObj<typeof SettingsSection>;
 

--- a/packages/ui/src/stories/StreamingText.stories.tsx
+++ b/packages/ui/src/stories/StreamingText.stories.tsx
@@ -1,17 +1,16 @@
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { StreamingText } from '../components/StreamingText';
 
-const meta: Meta<typeof StreamingText> = {
-  title: 'Content/StreamingText',
+const meta = {
   component: StreamingText,
   tags: ['autodocs'],
   argTypes: {
     isStreaming: { control: 'boolean' },
     autoScroll: { control: 'boolean' },
   },
-};
+} satisfies Meta<typeof StreamingText>;
 export default meta;
 type Story = StoryObj<typeof StreamingText>;
 

--- a/packages/ui/src/stories/TextArea.stories.tsx
+++ b/packages/ui/src/stories/TextArea.stories.tsx
@@ -1,9 +1,8 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { TextArea } from '../components/TextArea';
 
-const meta: Meta<typeof TextArea> = {
-  title: 'Primitives/TextArea',
+const meta = {
   component: TextArea,
   tags: ['autodocs'],
   argTypes: {
@@ -11,7 +10,7 @@ const meta: Meta<typeof TextArea> = {
     disabled: { control: 'boolean' },
     rows: { control: 'number' },
   },
-};
+} satisfies Meta<typeof TextArea>;
 export default meta;
 type Story = StoryObj<typeof TextArea>;
 

--- a/packages/ui/src/stories/Toast.stories.tsx
+++ b/packages/ui/src/stories/Toast.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button } from '../components/Button';
 import { ToastProvider, type ToastVariant, useToast } from '../components/Toast';
 
-const meta = {
+const meta: Meta = {
   component: ToastProvider,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },
@@ -14,7 +14,7 @@ const meta = {
       </ToastProvider>
     ),
   ],
-} satisfies Meta;
+};
 export default meta;
 type Story = StoryObj;
 

--- a/packages/ui/src/stories/Toast.stories.tsx
+++ b/packages/ui/src/stories/Toast.stories.tsx
@@ -1,10 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Button } from '../components/Button';
 import { ToastProvider, type ToastVariant, useToast } from '../components/Toast';
 
-const meta: Meta = {
-  title: 'Overlays/Toast',
+const meta = {
+  component: ToastProvider,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },
   decorators: [
@@ -14,7 +14,7 @@ const meta: Meta = {
       </ToastProvider>
     ),
   ],
-};
+} satisfies Meta;
 export default meta;
 type Story = StoryObj;
 

--- a/packages/ui/src/stories/Toast.stories.tsx
+++ b/packages/ui/src/stories/Toast.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta = {
       </ToastProvider>
     ),
   ],
-};
+} satisfies Meta;
 export default meta;
 type Story = StoryObj;
 

--- a/scripts/generate-tauri-signing-key.sh
+++ b/scripts/generate-tauri-signing-key.sh
@@ -26,8 +26,15 @@ set -euo pipefail
 
 KEY_PATH="${HOME}/.tauri/ajh"
 
+# Check if --force flag is passed
+FORCE_FLAG=""
+if [[ "$1" == "--force" ]]; then
+  FORCE_FLAG="--force"
+  echo "Force flag enabled - will overwrite existing key pair"
+fi
+
 echo "Generating Tauri signing key at ${KEY_PATH}.key ..."
-cargo tauri signer generate -w "${KEY_PATH}.key"
+cargo tauri signer generate -w "${KEY_PATH}.key" ${FORCE_FLAG}
 
 echo ""
 echo "✅ Key pair generated."


### PR DESCRIPTION
Add Tauri signing configuration to enable .sig file generation for secure auto-updates. Also adds fallback support in the release workflow to work without signatures for unsigned builds.