### PR TITLE
fix: remove invalid signing property from tauri bundle config

### DIFF
--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -31,10 +31,7 @@
     "active": true,
     "targets": ["nsis", "msi", "dmg", "app"],
     "icon": ["icons/icon.ico", "icons/icon.png"],
-    "resources": [],
-    "signing": {
-      "targets": ["nsis", "msi", "dmg", "app"]
-    }
+    "resources": []
   },
   "plugins": {
     "shell": {


### PR DESCRIPTION
Remove the 'signing' property from bundle config as it's not allowed in Tauri v2 schema. This fixes CI build failures on both macOS and Windows.