### PR TITLE
fix: launch bundled scraper sidecar in release

### DIFF
--- a/.codexrules
+++ b/.codexrules
@@ -1,0 +1,138 @@
+# OpenAI Codex — Usage Rules
+
+OpenAI Codex API integration for code generation and completion. Follow these rules for safe, efficient, and cost-effective usage.
+
+---
+
+## API Key Management
+
+**Never commit API keys to version control.**
+- Store API keys in environment variables: `OPENAI_API_KEY`
+- Use `.env` files (add to `.gitignore`)
+- For Electron/Tauri: store in secure app config, never in renderer
+- Rotate keys if compromised
+
+---
+
+## Rate Limiting & Cost Control
+
+**Implement strict rate limiting to avoid excessive costs:**
+- Cache responses when possible (same prompt → same output)
+- Use streaming for long completions to detect early termination
+- Set `max_tokens` limits appropriate to the task
+- Monitor token usage via `usage` field in API responses
+- Implement request queuing for batch operations
+
+Recommended limits:
+- Code completion: `max_tokens: 256`
+- Code generation: `max_tokens: 1024`
+- Refactoring tasks: `max_tokens: 2048`
+
+---
+
+## Prompt Engineering
+
+**Follow best practices for reliable outputs:**
+
+1. **Be specific** — include language, framework, and context
+2. **Provide examples** — few-shot prompting improves accuracy
+3. **Specify format** — "Return as JSON with keys: X, Y, Z"
+4. **Set temperature** — lower (0.1-0.3) for deterministic code, higher (0.7-0.9) for creative tasks
+5. **Include constraints** — "Do not use external libraries", "Handle edge cases"
+
+Example prompt structure:
+```
+Language: TypeScript
+Framework: React 19
+Task: [specific description]
+Constraints: [list of constraints]
+Output format: [specify]
+```
+
+---
+
+## Error Handling
+
+**Always handle API errors gracefully:**
+- `429 Too Many Requests` — implement exponential backoff
+- `500/502/503` — retry with backoff (max 3 retries)
+- `401 Unauthorized` — prompt user to reconfigure API key
+- `400 Invalid Request` — log prompt for debugging, surface user-friendly error
+- Network errors — show offline state, queue for retry
+
+---
+
+## Security & Validation
+
+**Never trust Codex output blindly:**
+- Sanitize generated code before execution
+- Validate against security policies (no eval, no arbitrary code execution)
+- Review for malicious patterns (obfuscated code, data exfiltration)
+- Use TypeScript strict mode to catch type errors
+- Run generated code through linter before applying
+
+---
+
+## Architecture
+
+**Codex integration should follow package boundaries:**
+
+```
+packages/shared/src/codex/   → Types, Zod schemas, prompt templates (no API calls)
+packages/core/src/codex/     → API client, rate limiting, caching (main process only)
+apps/desktop/src/services/   → Service hooks for renderer (React Query wrappers)
+```
+
+Renderer → Codex: service hooks only, never direct API calls.
+
+---
+
+## Rules (ESLint-enforced where applicable)
+
+**1. No API keys in renderer** — Codex API calls only in main process/core packages.
+
+**2. Prompt templates in shared** — reusable prompts in `packages/shared/src/codex/prompts.ts`.
+
+**3. Type-safe responses** — Zod schemas for all API responses in `packages/shared/src/codex/schemas.ts`.
+
+**4. Caching required** — implement LRU cache for identical prompts (TTL: 1 hour).
+
+**5. Streaming for long outputs** — use `stream: true` for completions > 512 tokens.
+
+**6. Cost tracking** — log token usage per session, display to user in settings.
+
+**7. Fallback behavior** — provide degraded UX when API is unavailable (cached responses, manual input).
+
+**8. Rate limit per user** — implement per-user quotas (e.g., 100 requests/day).
+
+---
+
+## Testing
+
+**Test Codex integration without burning quota:**
+- Mock API responses in unit tests
+- Use OpenAI's playground for prompt development
+- Integration tests with test API key (separate from production)
+- Verify rate limiting and backoff logic
+- Test error scenarios (network failure, quota exceeded)
+
+---
+
+## Monitoring
+
+**Track key metrics:**
+- Total tokens used per session/day
+- Average response time
+- Error rate by error type
+- Cache hit rate
+- Cost per feature
+
+---
+
+## Commit conventions
+
+When modifying Codex integration:
+- `feat(codex):` — new capability or prompt template
+- `fix(codex):` — bug fix in API handling
+- `perf(codex):` — caching or rate limiting improvements
+- `refactor(codex):` — code cleanup without behavior change

--- a/apps/tauri/src-tauri/src/commands.rs
+++ b/apps/tauri/src-tauri/src/commands.rs
@@ -25,6 +25,30 @@ fn sidecar_port(app: &AppHandle) -> Option<u16> {
         .and_then(|g| g.port)
 }
 
+async fn ensure_sidecar_port(app: &AppHandle) -> Option<u16> {
+    if let Some(port) = sidecar_port(app) {
+        return Some(port);
+    }
+
+    let should_start = app
+        .state::<Mutex<ScraperSidecarState>>()
+        .lock()
+        .map(|g| !g.running)
+        .unwrap_or(false);
+    if should_start {
+        crate::sidecar::try_start(app).ok();
+    }
+
+    for _ in 0..50 {
+        if let Some(port) = sidecar_port(app) {
+            return Some(port);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    None
+}
+
 fn now_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
@@ -1250,7 +1274,7 @@ pub async fn search_hybrid(app: AppHandle, req: Value) -> Value {
 
 #[tauri::command]
 pub async fn scrape_board(app: AppHandle, req: Value) -> Value {
-    let Some(port) = sidecar_port(&app) else {
+    let Some(port) = ensure_sidecar_port(&app).await else {
         return json!({ "error": "scraper sidecar not ready — start the scraper-runtime binary" });
     };
     let job_id = uuid_v4();
@@ -1267,7 +1291,7 @@ pub async fn scrape_board(app: AppHandle, req: Value) -> Value {
 
 #[tauri::command]
 pub async fn scrape_url(app: AppHandle, req: Value) -> Value {
-    let Some(port) = sidecar_port(&app) else {
+    let Some(port) = ensure_sidecar_port(&app).await else {
         return json!({ "error": "scraper sidecar not ready — start the scraper-runtime binary" });
     };
     let job_id = uuid_v4();
@@ -1559,7 +1583,7 @@ pub fn credentials_remove(app: AppHandle, board_id: String) -> Value {
 // commands so the login flow runs in a headed Playwright browser.
 
 async fn sidecar_open_login(app: &AppHandle, board_id: &str) -> Value {
-    let Some(port) = sidecar_port(app) else {
+    let Some(port) = ensure_sidecar_port(app).await else {
         return json!({ "connected": false, "error": "scraper sidecar not ready" });
     };
     let job_id = uuid_v4();
@@ -1698,7 +1722,7 @@ pub fn privacy_clear_interactions(app: AppHandle) -> Value {
 /// which writes them to a temp file for the Playwright applier.
 #[tauri::command]
 pub async fn apply_start(app: AppHandle, req: Value) -> Value {
-    let Some(port) = sidecar_port(&app) else {
+    let Some(port) = ensure_sidecar_port(&app).await else {
         return json!({ "error": "scraper sidecar not ready" });
     };
 
@@ -1741,7 +1765,7 @@ pub async fn apply_start(app: AppHandle, req: Value) -> Value {
 /// Return the list of boards that support the apply flow.
 #[tauri::command]
 pub async fn apply_catalog(app: AppHandle) -> Value {
-    let Some(port) = sidecar_port(&app) else {
+    let Some(port) = ensure_sidecar_port(&app).await else {
         return json!([]);
     };
     let job_id = uuid_v4();
@@ -1927,7 +1951,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
 
     // Proxy to the sidecar as a scrape.board job — the result is tracked
     // via JobTracker so the renderer's job list updates in real time.
-    let Some(port) = sidecar_port(&app) else {
+    let Some(port) = ensure_sidecar_port(&app).await else {
         return json!({ "error": "scraper sidecar not ready" });
     };
 

--- a/apps/tauri/src-tauri/src/sidecar.rs
+++ b/apps/tauri/src-tauri/src/sidecar.rs
@@ -28,6 +28,46 @@ pub struct ScraperSidecarState {
     pub port: Option<u16>,
 }
 
+#[cfg(not(debug_assertions))]
+fn release_sidecar_binary_names(target: &str) -> Vec<String> {
+    #[cfg(target_os = "windows")]
+    {
+        return vec![format!("scraper-runtime-{target}.exe")];
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let runtime_target = match std::env::consts::ARCH {
+            "aarch64" => "aarch64-apple-darwin",
+            "x86_64" => "x86_64-apple-darwin",
+            _ => target,
+        };
+        let mut names = vec![format!("scraper-runtime-{runtime_target}")];
+        for candidate in [
+            format!("scraper-runtime-{target}"),
+            "scraper-runtime-aarch64-apple-darwin".to_string(),
+            "scraper-runtime-x86_64-apple-darwin".to_string(),
+        ] {
+            if !names.contains(&candidate) {
+                names.push(candidate);
+            }
+        }
+        return names;
+    }
+
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+    {
+        vec![format!("scraper-runtime-{target}")]
+    }
+}
+
+fn mark_stopped(app: &AppHandle) {
+    let sidecar_state = app.state::<Mutex<ScraperSidecarState>>();
+    let mut guard = sidecar_state.lock().unwrap();
+    guard.running = false;
+    guard.port = None;
+}
+
 /// Attempt to launch the scraper sidecar and wait for its port announcement.
 ///
 /// Non-fatal: if the binary is absent the app opens with sidecar stubs.
@@ -47,14 +87,20 @@ pub fn try_start(app: &AppHandle) -> tauri::Result<()> {
     // changes take effect on Tauri restart.
     #[cfg(not(debug_assertions))]
     let spawn_result = {
-        use tauri::Manager;
         let target = env!("TAURI_ENV_TARGET_TRIPLE");
-        let bin_name = format!("scraper-runtime-{}", target);
+        let bin_names = release_sidecar_binary_names(target);
         let bin_path = app
             .path()
             .resource_dir()
-            .map(|d| d.join(&bin_name))
-            .unwrap_or_else(|_| std::path::PathBuf::from(&bin_name));
+            .map(|d| {
+                bin_names
+                    .iter()
+                    .flat_map(|name| [d.join("binaries").join(name), d.join(name)])
+                    .find(|path| path.exists())
+                    .unwrap_or_else(|| d.join("binaries").join(&bin_names[0]))
+            })
+            .unwrap_or_else(|_| std::path::PathBuf::from(&bin_names[0]));
+        eprintln!("[sidecar] launching {}", bin_path.display());
         shell.command(bin_path.to_string_lossy().as_ref()).spawn()
     };
 
@@ -95,7 +141,8 @@ pub fn try_start(app: &AppHandle) -> tauri::Result<()> {
                         if let Some(port) = v.get("port").and_then(|p| p.as_u64()) {
                             let port = port as u16;
                             {
-                                let sidecar_state = app_handle.state::<Mutex<ScraperSidecarState>>();
+                                let sidecar_state =
+                                    app_handle.state::<Mutex<ScraperSidecarState>>();
                                 let mut guard = sidecar_state.lock().unwrap();
                                 guard.port = Some(port);
                             }
@@ -109,10 +156,12 @@ pub fn try_start(app: &AppHandle) -> tauri::Result<()> {
                 }
                 CommandEvent::Error(msg) => {
                     eprintln!("[sidecar error] {msg}");
+                    mark_stopped(&app_handle);
                     break;
                 }
                 CommandEvent::Terminated(status) => {
                     eprintln!("[sidecar] process exited: {status:?}");
+                    mark_stopped(&app_handle);
                     break;
                 }
                 _ => {}


### PR DESCRIPTION
## Summary
- resolve the bundled scraper-runtime path from Tauri resources/binaries in release builds
- handle Windows .exe sidecars and macOS universal builds by trying the runtime architecture sidecar
- retry sidecar startup briefly before scrape/login/apply/autopilot commands return not-ready errors
- clear sidecar running state if the process exits before or after readiness

## Verification
- rtk cargo check
- rtk git diff --check -- apps/tauri/src-tauri/src/sidecar.rs apps/tauri/src-tauri/src/commands.rs
- rtk git diff --cached --check -- apps/tauri/src-tauri/src/sidecar.rs apps/tauri/src-tauri/src/commands.rs