### PR TITLE
fix: use gh_token for semantic-release api calls

### DIFF
--- a/.github/workflows/04-release-orchestration.yml
+++ b/.github/workflows/04-release-orchestration.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -51,6 +52,7 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
           TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}


### PR DESCRIPTION
## Changes

- Use `GH_TOKEN` secret for semantic-release API calls instead of `GITHUB_TOKEN`
- Add `id-token: write` permission to workflow for better authentication

## Issues Fixed

- Semantic-release failed with HTTP 401 "Bad credentials" when trying to create releases
- `GITHUB_TOKEN` has insufficient permissions for release creation

## Testing

- Workflow changes validated by GitHub Actions syntax check
- Uses existing `GH_TOKEN` secret which has proper release permissions