### PR TITLE
migrate job preferences from frontend to backend sqlite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,22 +244,56 @@ jobs:
         run: |
           echo "${{ secrets.TAURI_SIGNING_PRIVATE_KEY_BASE64 }}" | base64 --decode > tauri.key
 
-      - name: 🏗️ Build Tauri Application
-        id: tauri-build
+      - name: � Add ARM64 Target (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          echo "::group::Adding ARM64 target"
+          rustup target add aarch64-apple-darwin
+          echo "::endgroup::"
+
+      - name: 🏗️ Build Tauri Application (Intel)
+        id: tauri-build-intel
         continue-on-error: true
         env:
           TAURI_SIGNING_PRIVATE_KEY: ./tauri.key
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          echo "::group::Building Tauri application"
-          pnpm --filter @ajh/tauri tauri build
+          echo "::group::Building Tauri application (Intel x86_64)"
+          pnpm --filter @ajh/tauri tauri build --target x86_64-apple-darwin
+          echo "::endgroup::"
+
+      - name: �️ Build Tauri Application (Apple Silicon)
+        id: tauri-build-arm
+        if: runner.os == 'macOS'
+        continue-on-error: true
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ./tauri.key
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          echo "::group::Building Tauri application (ARM64)"
+          pnpm --filter @ajh/tauri tauri build --target aarch64-apple-darwin
           echo "::endgroup::"
 
       - name: ❌ Check for Build Failures
-        if: steps.tauri-build.outcome == 'failure'
+        if: steps.tauri-build-intel.outcome == 'failure' || (runner.os == 'macOS' && steps.tauri-build-arm.outcome == 'failure')
         run: |
           echo "::error::Tauri build failed on ${{ matrix.platform }}. Please review the build output above."
           exit 1
+
+      - name: 🏷️ Rename macOS Artifacts
+        if: runner.os == 'macOS' && success()
+        run: |
+          echo "::group::Renaming macOS artifacts"
+          cd apps/tauri/src-tauri/target
+          # Rename Intel DMG
+          if [ -d "x86_64-apple-darwin/release/bundle/dmg" ]; then
+            mv x86_64-apple-darwin/release/bundle/dmg/*.dmg x86_64-apple-darwin/release/bundle/dmg/AI-Job-Hunter-Assistant-${{ needs.release.outputs.version }}-intel.dmg || true
+          fi
+          # Rename ARM64 DMG
+          if [ -d "aarch64-apple-darwin/release/bundle/dmg" ]; then
+            mv aarch64-apple-darwin/release/bundle/dmg/*.dmg aarch64-apple-darwin/release/bundle/dmg/AI-Job-Hunter-Assistant-${{ needs.release.outputs.version }}-apple-silicon.dmg || true
+          fi
+          echo "::endgroup::"
 
       - name: 📤 Upload Release Assets
         if: success()
@@ -269,7 +303,8 @@ jobs:
           files: |
             apps/tauri/src-tauri/target/release/bundle/nsis/*.exe
             apps/tauri/src-tauri/target/release/bundle/msi/*.msi
-            apps/tauri/src-tauri/target/release/bundle/dmg/*.dmg
+            apps/tauri/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
+            apps/tauri/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
             apps/tauri/src-tauri/target/release/bundle/deb/*.deb
             apps/tauri/src-tauri/target/release/bundle/rpm/*.rpm
             apps/tauri/src-tauri/target/release/bundle/appimage/*.AppImage
@@ -296,7 +331,10 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Build Details" >> $GITHUB_STEP_SUMMARY
           echo "- **Platform**: ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Build Status**: ${{ steps.tauri-build.outcome == 'success' && '✅ Success' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Status**: ${{ steps.tauri-build-intel.outcome == 'success' && '✅ Success' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ runner.os }}" == "macOS" ]; then
+            echo "- **ARM64 Build**: ${{ steps.tauri-build-arm.outcome == 'success' && '✅ Success' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "- **Version**: v${{ needs.release.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Environment" >> $GITHUB_STEP_SUMMARY
@@ -305,7 +343,7 @@ jobs:
           echo "- **pnpm**: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
           echo "- **Runner OS**: ${{ runner.os }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.tauri-build.outcome }}" == "failure" ]; then
+          if [ "${{ steps.tauri-build-intel.outcome }}" == "failure" ] || [ "${{ runner.os }}" == "macOS" && "${{ steps.tauri-build-arm.outcome }}" == "failure" ]; then
             echo "### 📊 Artifacts" >> $GITHUB_STEP_SUMMARY
             echo "Build logs uploaded as artifact: \`build-logs-${{ matrix.platform }}-${{ github.run_id }}\`" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    outputs:
+      released: ${{ needs.release.outputs.released }}
+      version: ${{ needs.release.outputs.version }}
+
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4
@@ -153,8 +157,8 @@ jobs:
 
   build:
     name: 🏗️ Build Tauri Apps
-    needs: release
-    if: needs.release.outputs.released == 'true'
+    needs: sync-version-files
+    if: needs.sync-version-files.outputs.released == 'true'
 
     strategy:
       fail-fast: false
@@ -174,7 +178,7 @@ jobs:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: v${{ needs.release.outputs.version }}
+          ref: v${{ needs.sync-version-files.outputs.version }}
           fetch-depth: 0
 
       - name: 📦 Setup pnpm
@@ -229,7 +233,7 @@ jobs:
           TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
         run: |
           echo "::group::Syncing Tauri release metadata"
-          node scripts/sync-tauri-version.cjs ${{ needs.release.outputs.version }}
+          node scripts/sync-tauri-version.cjs ${{ needs.sync-version-files.outputs.version }}
           echo "::endgroup::"
 
       - name: 🔨 Build Workspace
@@ -287,11 +291,11 @@ jobs:
           cd apps/tauri/src-tauri/target
           # Rename Intel DMG
           if [ -d "x86_64-apple-darwin/release/bundle/dmg" ]; then
-            mv x86_64-apple-darwin/release/bundle/dmg/*.dmg x86_64-apple-darwin/release/bundle/dmg/AI-Job-Hunter-Assistant-${{ needs.release.outputs.version }}-intel.dmg || true
+            mv x86_64-apple-darwin/release/bundle/dmg/*.dmg x86_64-apple-darwin/release/bundle/dmg/AI-Job-Hunter-Assistant-${{ needs.sync-version-files.outputs.version }}-intel.dmg || true
           fi
           # Rename ARM64 DMG
           if [ -d "aarch64-apple-darwin/release/bundle/dmg" ]; then
-            mv aarch64-apple-darwin/release/bundle/dmg/*.dmg aarch64-apple-darwin/release/bundle/dmg/AI-Job-Hunter-Assistant-${{ needs.release.outputs.version }}-apple-silicon.dmg || true
+            mv aarch64-apple-darwin/release/bundle/dmg/*.dmg aarch64-apple-darwin/release/bundle/dmg/AI-Job-Hunter-Assistant-${{ needs.sync-version-files.outputs.version }}-apple-silicon.dmg || true
           fi
           echo "::endgroup::"
 
@@ -299,7 +303,7 @@ jobs:
         if: success()
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ needs.release.outputs.version }}
+          tag_name: v${{ needs.sync-version-files.outputs.version }}
           files: |
             apps/tauri/src-tauri/target/release/bundle/nsis/*.exe
             apps/tauri/src-tauri/target/release/bundle/msi/*.msi
@@ -335,7 +339,7 @@ jobs:
           if [ "${{ runner.os }}" == "macOS" ]; then
             echo "- **ARM64 Build**: ${{ steps.tauri-build-arm.outcome == 'success' && '✅ Success' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
           fi
-          echo "- **Version**: v${{ needs.release.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: v${{ needs.sync-version-files.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Environment" >> $GITHUB_STEP_SUMMARY
           echo "- **Node**: $(node --version)" >> $GITHUB_STEP_SUMMARY

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,25 +1,31 @@
 #!/usr/bin/env sh
 # Runs before `git push`.
-# Quality gate: lint + typecheck + build + tests + rust clippy.
+# Quality gate: matches CI workflow checks (lint, format, typecheck, build, tests, rust clippy).
 
 if [ -n "$GITHUB_ACTIONS" ]; then
   exit 0
 fi
 
-echo "▶ Running ESLint..."
-pnpm lint
+echo "▶ Building shared packages..."
+pnpm build:packages
+
+echo "▶ Running ESLint strict..."
+pnpm lint:strict
+
+echo "▶ Checking formatting..."
+pnpm format:check
 
 echo "▶ Running TypeScript type check..."
 pnpm typecheck --force
 
-echo "▶ Building packages..."
-pnpm build:packages
-
-echo "▶ Building Tauri frontend..."
-pnpm --filter @ajh/tauri build:frontend
+echo "▶ Running cargo check..."
+cd apps/tauri/src-tauri && cargo check --all-targets --all-features
 
 echo "▶ Running package tests..."
-pnpm -r test
+pnpm test
+
+echo "▶ Running Rust tests..."
+cd apps/tauri/src-tauri && cargo test --all-features
 
 echo "▶ Running Rust clippy..."
-cd apps/tauri/src-tauri && cargo clippy --all-targets -- -D warnings
+cd apps/tauri/src-tauri && cargo clippy --all-targets --all-features -- -D warnings

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -6,6 +6,10 @@ if [ -n "$GITHUB_ACTIONS" ]; then
   exit 0
 fi
 
+# Get the git root directory
+GIT_ROOT=$(git rev-parse --show-toplevel)
+cd "$GIT_ROOT" || exit 1
+
 echo "▶ Building shared packages..."
 pnpm build:packages
 
@@ -22,10 +26,10 @@ echo "▶ Running cargo check..."
 cd apps/tauri/src-tauri && cargo check --all-targets --all-features
 
 echo "▶ Running package tests..."
-pnpm test
+cd "$GIT_ROOT" && pnpm test
 
 echo "▶ Running Rust tests..."
 cd apps/tauri/src-tauri && cargo test --all-features
 
 echo "▶ Running Rust clippy..."
-cd apps/tauri/src-tauri && cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings

--- a/apps/tauri/index.html
+++ b/apps/tauri/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark">
     <title>AI Job Hunter (Tauri)</title>
   </head>
   <body>

--- a/apps/tauri/index.html
+++ b/apps/tauri/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="dark">
+    <meta name="color-scheme" content="dark" />
     <title>AI Job Hunter (Tauri)</title>
   </head>
   <body>

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ajh-tauri"
 version = "0.2.13"
-edition = "2021"
+edition = "2024"
 description = "AI Job Hunter — Tauri desktop shell"
 authors = ["Saeed Kolivand"]
 
@@ -19,7 +19,7 @@ strip = true
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-ico", "image-png"] }
+tauri = { version = "2", features = ["tray-icon", "image-ico", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
@@ -67,3 +67,7 @@ unicode-segmentation = "1.10"
 
 [target.'cfg(windows)'.dependencies]
 wmi = "0.14"
+tauri = { version = "2", features = ["macos-private-api"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tauri = { version = "2", features = ["macos-private-api"] }

--- a/apps/tauri/src-tauri/src/commands/documents.rs
+++ b/apps/tauri/src-tauri/src/commands/documents.rs
@@ -48,6 +48,7 @@ pub async fn documents_import(app: AppHandle, req: Value) -> Value {
         pages: None,
         created_at: crate::documents::now_ms(),
         indexed: false,
+        is_default: false, // Will be set to true by insert() if it's the first document
     };
     match store.insert(&record) {
         Ok(()) => json!({ "id": doc_id, "success": true }),
@@ -56,9 +57,18 @@ pub async fn documents_import(app: AppHandle, req: Value) -> Value {
 }
 
 #[tauri::command]
-pub async fn documents_delete(app: AppHandle, id: String) -> Value {
+pub async fn documents_remove(app: AppHandle, id: String) -> Value {
     let store = app.state::<crate::documents::DocumentStore>();
     match store.remove(&id) {
+        Ok(()) => json!({ "success": true }),
+        Err(e) => json!({ "error": e.to_string() }),
+    }
+}
+
+#[tauri::command]
+pub async fn documents_set_default(app: AppHandle, id: String) -> Value {
+    let store = app.state::<crate::documents::DocumentStore>();
+    match store.set_default(&id) {
         Ok(()) => json!({ "success": true }),
         Err(e) => json!({ "error": e.to_string() }),
     }

--- a/apps/tauri/src-tauri/src/commands/job_preferences.rs
+++ b/apps/tauri/src-tauri/src/commands/job_preferences.rs
@@ -1,0 +1,29 @@
+use tauri::AppHandle;
+use tauri::Manager;
+use serde_json::json;
+use serde_json::Value;
+
+#[tauri::command]
+pub async fn job_preferences_get(app: AppHandle) -> Value {
+    let store = app.state::<crate::job_preferences::JobPreferencesStore>();
+    let prefs = store.get();
+    json!(prefs)
+}
+
+#[tauri::command]
+pub async fn job_preferences_set(app: AppHandle, prefs: Value) -> Value {
+    let store = app.state::<crate::job_preferences::JobPreferencesStore>();
+    let job_prefs: crate::job_preferences::JobPreferences = serde_json::from_value(prefs)
+        .unwrap_or_else(|_| crate::job_preferences::JobPreferences {
+            location: None,
+            remote: None,
+            seniority: None,
+            salary_min: None,
+            salary_max: None,
+            tech_stack: None,
+        });
+    match store.set(&job_prefs) {
+        Ok(()) => json!({ "success": true }),
+        Err(e) => json!({ "error": e.to_string() }),
+    }
+}

--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -16,3 +16,4 @@ pub mod geocoding;
 pub mod privacy;
 pub mod support;
 pub mod dialog;
+pub mod job_preferences;

--- a/apps/tauri/src-tauri/src/documents.rs
+++ b/apps/tauri/src-tauri/src/documents.rs
@@ -29,6 +29,8 @@ pub struct DocumentRecord {
     #[serde(rename = "createdAt")]
     pub created_at: u64,
     pub indexed: bool,
+    #[serde(rename = "isDefault")]
+    pub is_default: bool,
 }
 
 // ── DocumentStore ─────────────────────────────────────────────────────────────
@@ -51,7 +53,8 @@ impl DocumentStore {
                 text        TEXT NOT NULL,
                 pages       INTEGER,
                 created_at  INTEGER NOT NULL,
-                indexed     INTEGER NOT NULL DEFAULT 0
+                indexed     INTEGER NOT NULL DEFAULT 0,
+                is_default  INTEGER NOT NULL DEFAULT 0
             );
             CREATE TABLE IF NOT EXISTS vectors (
                 doc_id  TEXT PRIMARY KEY,
@@ -59,13 +62,27 @@ impl DocumentStore {
             );",
         )
         .map_err(|e| e.to_string())?;
+        
+        // Migration: add is_default column if it doesn't exist
+        // SQLite doesn't support IF NOT EXISTS for ALTER TABLE, so we check first
+        let has_column: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('documents') WHERE name = 'is_default'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+        if has_column == 0 {
+            conn.execute("ALTER TABLE documents ADD COLUMN is_default INTEGER NOT NULL DEFAULT 0", [])
+                .map_err(|e| e.to_string())?;
+        }
         Ok(Self { conn: Mutex::new(conn) })
     }
 
     pub fn list(&self) -> Vec<DocumentRecord> {
         let conn = self.conn.lock().unwrap();
         conn.prepare(
-            "SELECT id, title, name, locale, text, pages, created_at, indexed
+            "SELECT id, title, name, locale, text, pages, created_at, indexed, is_default
              FROM documents ORDER BY created_at DESC",
         )
         .ok()
@@ -80,6 +97,7 @@ impl DocumentStore {
                     pages: row.get(5)?,
                     created_at: row.get::<_, i64>(6)? as u64,
                     indexed: row.get::<_, i64>(7)? != 0,
+                    is_default: row.get::<_, i64>(8).unwrap_or(0) != 0,
                 })
             })
             .ok()
@@ -90,9 +108,15 @@ impl DocumentStore {
 
     pub fn insert(&self, rec: &DocumentRecord) -> Result<(), String> {
         let conn = self.conn.lock().unwrap();
+        // If this is the first document, automatically set it as default
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM documents", [], |row| row.get(0))
+            .unwrap_or(0);
+        let is_default = if count == 0 { true } else { rec.is_default };
+        
         conn.execute(
-            "INSERT INTO documents (id, title, name, locale, text, pages, created_at, indexed)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT INTO documents (id, title, name, locale, text, pages, created_at, indexed, is_default)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
                 rec.id,
                 rec.title,
@@ -102,6 +126,7 @@ impl DocumentStore {
                 rec.pages,
                 rec.created_at as i64,
                 rec.indexed as i64,
+                is_default as i64,
             ],
         )
         .map_err(|e| e.to_string())?;
@@ -120,6 +145,16 @@ impl DocumentStore {
         conn.execute("DELETE FROM documents WHERE id = ?1", params![id])
             .map_err(|e| e.to_string())?;
         conn.execute("DELETE FROM vectors WHERE doc_id = ?1", params![id])
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn set_default(&self, id: &str) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        // Clear all defaults, then set the new one
+        conn.execute("UPDATE documents SET is_default = 0", [])
+            .map_err(|e| e.to_string())?;
+        conn.execute("UPDATE documents SET is_default = 1 WHERE id = ?1", params![id])
             .map_err(|e| e.to_string())?;
         Ok(())
     }

--- a/apps/tauri/src-tauri/src/job_preferences.rs
+++ b/apps/tauri/src-tauri/src/job_preferences.rs
@@ -1,0 +1,119 @@
+/// Job preferences store (SQLite-backed).
+/// Stores user's job search preferences: location, tech stack, seniority, salary, remote.
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobPreferences {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seniority: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub salary_min: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub salary_max: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tech_stack: Option<Vec<TechStackItem>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TechStackItem {
+    pub name: String,
+    pub category: String,
+}
+
+// ── JobPreferencesStore ─────────────────────────────────────────────────────────
+
+pub struct JobPreferencesStore {
+    conn: Mutex<Connection>,
+}
+
+impl JobPreferencesStore {
+    pub fn open(data_dir: &PathBuf) -> Result<Self, String> {
+        std::fs::create_dir_all(data_dir).map_err(|e| e.to_string())?;
+        let path = data_dir.join("job_preferences.db");
+        let conn = Connection::open(&path).map_err(|e| e.to_string())?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS job_preferences (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                location TEXT,
+                remote TEXT,
+                seniority TEXT,
+                salary_min INTEGER,
+                salary_max INTEGER,
+                tech_stack TEXT
+            );",
+        )
+        .map_err(|e| e.to_string())?;
+        
+        // Ensure the single row exists
+        conn.execute(
+            "INSERT OR IGNORE INTO job_preferences (id) VALUES (1)",
+            [],
+        )
+        .map_err(|e| e.to_string())?;
+        
+        Ok(Self { conn: Mutex::new(conn) })
+    }
+
+    pub fn get(&self) -> JobPreferences {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT location, remote, seniority, salary_min, salary_max, tech_stack
+             FROM job_preferences WHERE id = 1",
+            [],
+            |row| {
+                let tech_stack_json: Option<String> = row.get(5)?;
+                let tech_stack = tech_stack_json
+                    .and_then(|s| serde_json::from_str(&s).ok());
+                Ok(JobPreferences {
+                    location: row.get(0)?,
+                    remote: row.get(1)?,
+                    seniority: row.get(2)?,
+                    salary_min: row.get(3)?,
+                    salary_max: row.get(4)?,
+                    tech_stack,
+                })
+            },
+        )
+        .unwrap_or_else(|_| JobPreferences {
+            location: None,
+            remote: None,
+            seniority: None,
+            salary_min: None,
+            salary_max: None,
+            tech_stack: None,
+        })
+    }
+
+    pub fn set(&self, prefs: &JobPreferences) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        let tech_stack_json = prefs.tech_stack.as_ref()
+            .and_then(|ts| serde_json::to_string(ts).ok());
+        
+        conn.execute(
+            "UPDATE job_preferences 
+             SET location = ?1, remote = ?2, seniority = ?3, 
+                 salary_min = ?4, salary_max = ?5, tech_stack = ?6
+             WHERE id = 1",
+            params![
+                prefs.location,
+                prefs.remote,
+                prefs.seniority,
+                prefs.salary_min,
+                prefs.salary_max,
+                tech_stack_json,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -22,6 +22,7 @@ mod conversations;
 mod credentials;
 mod documents;
 mod export;
+mod job_preferences;
 mod jobs;
 mod platform;
 mod postings;
@@ -143,6 +144,10 @@ fn main() {
                 Ok(store) => { app.manage(store); }
                 Err(e) => eprintln!("[setup] document store failed to open (non-fatal): {e}"),
             }
+            match job_preferences::JobPreferencesStore::open(&data_dir) {
+                Ok(store) => { app.manage(store); }
+                Err(e) => eprintln!("[setup] job preferences store failed to open (non-fatal): {e}"),
+            }
             app.manage(Mutex::new(JobTracker::default()));
             app.manage(Mutex::new(PostingsCache::default()));
             app.manage(Mutex::new(InteractionStore::new(&data_dir)));
@@ -197,7 +202,8 @@ fn main() {
             // documents
             commands::documents::documents_list,
             commands::documents::documents_import,
-            commands::documents::documents_delete,
+            commands::documents::documents_remove,
+            commands::documents::documents_set_default,
             commands::documents::documents_embed_text,
             commands::documents::documents_set_indexed,
             commands::documents::documents_upsert_vector,
@@ -205,6 +211,9 @@ fn main() {
             commands::documents::documents_all_vectors,
             commands::documents::documents_cosine_similarity,
             commands::documents::documents_strip_extension,
+            // job preferences
+            commands::job_preferences::job_preferences_get,
+            commands::job_preferences::job_preferences_set,
             // search
             commands::search::search_postings,
             // scrape

--- a/apps/tauri/src-tauri/src/scraping/linkedin/api_client.rs
+++ b/apps/tauri/src-tauri/src/scraping/linkedin/api_client.rs
@@ -8,6 +8,36 @@ use std::collections::HashSet;
 
 const PAGE_SIZE: usize = 25;
 
+/// Parse relative time strings like "1 hour ago", "2 weeks ago" into a DateTime
+fn parse_relative_time(text: &str) -> Option<chrono::DateTime<chrono::FixedOffset>> {
+    let now = chrono::Utc::now();
+    let text = text.to_lowercase();
+    
+    // Parse patterns like "1 hour ago", "2 hours ago", "1h ago", etc.
+    if let Some(num_str) = text.split_whitespace().next() {
+        if let Ok(num) = num_str.parse::<i64>() {
+            let duration = if text.contains("hour") || text.contains("h") {
+                chrono::Duration::hours(num)
+            } else if text.contains("day") || text.contains("d") {
+                chrono::Duration::days(num)
+            } else if text.contains("week") || text.contains("w") {
+                chrono::Duration::weeks(num)
+            } else if text.contains("month") || text.contains("m") {
+                chrono::Duration::days(num * 30)
+            } else if text.contains("minute") || text.contains("min") {
+                chrono::Duration::minutes(num)
+            } else {
+                return None;
+            };
+            
+            let posted = now - duration;
+            return Some(posted.into());
+        }
+    }
+    
+    None
+}
+
 #[derive(Debug, Clone)]
 pub struct JobsSearchParams {
     pub keywords: String,
@@ -164,12 +194,10 @@ impl LinkedInJobsApiClient {
                 .trim()
                 .to_string();
 
-            let date_attr = element
-                .select(&time_selector)
-                .next()
-                .and_then(|el| el.value().attr("datetime"));
-
-            let posted_at = date_attr.and_then(|d| chrono::DateTime::parse_from_rfc3339(d).ok());
+            let posted_at = element.select(&time_selector).next().and_then(|el| {
+                let text = el.text().collect::<String>().trim().to_lowercase();
+                parse_relative_time(&text)
+            });
 
             let job = JobPosting {
                 id: format!("linkedin:{}", id),

--- a/apps/tauri/src-tauri/src/scraping/types.rs
+++ b/apps/tauri/src-tauri/src/scraping/types.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobPosting {
     pub id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "externalId")]
     pub external_id: Option<String>,
     pub title: String,
     pub company: String,
@@ -18,8 +18,9 @@ pub struct JobPosting {
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requirements: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "postedAt")]
     pub posted_at: Option<i64>,
+    #[serde(rename = "capturedAt")]
     pub captured_at: i64,
     /// Board-specific metadata (salary, remote status, etc.)
     #[serde(flatten)]

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -24,23 +24,15 @@
         "titleBarStyle": "Overlay"
       }
     ],
-    "macOSPrivateApi": true,
+    "macOSPrivateApi": false,
     "security": {
       "csp": "default-src 'self' tauri: asset: https://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: https://asset.localhost; font-src 'self' data: asset: https://asset.localhost; connect-src 'self' http://127.0.0.1:11434 http://127.0.0.1:* ws://127.0.0.1:* tauri: ipc: http://ipc.localhost"
     }
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "nsis",
-      "msi",
-      "dmg",
-      "app"
-    ],
-    "icon": [
-      "icons/icon.ico",
-      "icons/icon.png"
-    ],
+    "targets": ["nsis", "msi", "dmg", "app"],
+    "icon": ["icons/icon.ico", "icons/icon.png"],
     "resources": []
   },
   "plugins": {

--- a/apps/tauri/src/renderer/components/background/CinematicBackground.tsx
+++ b/apps/tauri/src/renderer/components/background/CinematicBackground.tsx
@@ -34,7 +34,7 @@ export function CinematicBackground() {
   const posRef = useRef({ x: 0, y: 0 }); // where the blob IS (lerped)
   const rafRef = useRef(0);
   const HALF = 450; // half of 900px blob
-  const LERP = 0.08; // 8% per frame → silky trail at 60 fps
+  const LERP = 0.005; // 0.5% per frame → extremely slow, dreamy floating effect
 
   useEffect(() => {
     // Skip RAF loop in low-memory mode — component returns null below.

--- a/apps/tauri/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/tauri/src/renderer/components/layout/Sidebar.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from '@/lib/i18n';
 import { transition, variants } from '@/lib/motion';
 import { useAICapability } from '@/providers/CapabilityProvider';
 import { useAppVersion } from '@/services/use-system';
-import { useUserName } from '@/store/preferences-store';
+import { useAIModel, useUserName } from '@/store/preferences-store';
 
 const NAV_ITEMS = [
   { to: ROUTES.DASHBOARD, label: 'nav.dashboard', icon: LayoutDashboard, tourId: 'dashboard' },
@@ -44,6 +44,7 @@ export function Sidebar() {
   const { t } = useTranslation();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const userName = useUserName();
+  const aiModel = useAIModel();
   const ai = useAICapability(); // from CapabilityProvider — no duplicate polling
   const { data: version = 'v0.1.0' } = useAppVersion();
   const appVersion = version.startsWith('v') ? version : `v${version}`;
@@ -151,8 +152,8 @@ export function Sidebar() {
               />
               <span className="truncate text-[10px] text-foreground/45">
                 {aiStatus === 'ready'
-                  ? ai.model
-                    ? ai.model.split(':')[0]
+                  ? aiModel?.defaultModel
+                    ? aiModel.defaultModel.split(':')[0]
                     : 'Ollama ready'
                   : aiStatus === 'offline'
                     ? 'Ollama offline'

--- a/apps/tauri/src/renderer/components/ui/UpdateBanner.tsx
+++ b/apps/tauri/src/renderer/components/ui/UpdateBanner.tsx
@@ -1,8 +1,8 @@
-import { Download, Loader2, RefreshCw, Sparkles, X } from 'lucide-react';
+import { Download, Loader2, Sparkles, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 
-import { Button } from '@ajh/ui';
+import { Button, RefreshButton } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
@@ -49,8 +49,6 @@ export function UpdateBanner() {
             {/* Icon */}
             {status.state === 'downloading' ? (
               <Loader2 size={14} className="shrink-0 animate-spin text-brand-soft" />
-            ) : status.state === 'downloaded' ? (
-              <RefreshCw size={14} className="shrink-0 text-brand-soft" />
             ) : (
               <Sparkles size={14} className="shrink-0 text-brand-soft" />
             )}
@@ -89,13 +87,12 @@ export function UpdateBanner() {
               </Button>
             )}
             {status.state === 'downloaded' && (
-              <Button
-                onClick={() => void install()}
+              <RefreshButton
+                onRefresh={install}
                 className="flex items-center gap-1.5 rounded-lg border border-brand/40 bg-brand/20 px-2.5 py-1 text-[11px] font-medium text-brand-soft transition-colors hover:bg-brand/30"
               >
-                <RefreshCw size={11} />
                 {t('updater.installButton')}
-              </Button>
+              </RefreshButton>
             )}
 
             {/* Dismiss */}

--- a/apps/tauri/src/renderer/features/ai-generate/components/GenerationConfig.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/GenerationConfig.tsx
@@ -124,7 +124,7 @@ export function GenerationConfig({
         onClick={onGenerate}
         disabled={isGenerating}
         loading={isGenerating}
-        className="w-full justify-center hover:glow-purple"
+        className="w-full justify-center transition-all duration-150 ease-out"
       >
         {!isGenerating && <Sparkles size={14} />}
         {isGenerating ? t('aiGenerate.generating') : t('aiGenerate.generate')}

--- a/apps/tauri/src/renderer/features/ai-workspace/components/AIWorkspace.tsx
+++ b/apps/tauri/src/renderer/features/ai-workspace/components/AIWorkspace.tsx
@@ -1,11 +1,11 @@
-import { Check, ChevronDown, Copy, RefreshCw, Send, Sparkles, Upload, X } from 'lucide-react';
+import { Check, Copy, Send, Sparkles, Upload, X } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { buildWorkspaceSystemPrompt } from '@ajh/prompts';
 import type { AiStreamChunk, JobEvent } from '@ajh/shared';
-import { Button, Input, MarkdownMessage } from '@ajh/ui';
+import { Button, Input, MarkdownMessage, RefreshButton, SelectDropdown } from '@ajh/ui';
 
 import i18n from '@/i18n';
 import { cn } from '@/lib/cn';
@@ -46,7 +46,6 @@ export function AIWorkspace() {
   const [resumeFileName, setResumeFileName] = useState<string>('');
   const [uploading, setUploading] = useState(false);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
-  const [showModelPicker, setShowModelPicker] = useState(false);
   const activeJobRef = useRef<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -212,83 +211,36 @@ export function AIWorkspace() {
       {/* Header with model selector */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-white/5">
         <h2 className="text-sm font-medium text-foreground/70">{t('ai.title')}</h2>
-        <div className="relative">
-          <button
-            onClick={() => setShowModelPicker(!showModelPicker)}
-            className="flex items-center gap-2 rounded-lg border border-white/[0.08] bg-white/[0.03] px-3 py-1.5 text-xs text-foreground/70 hover:bg-white/[0.06] hover:text-foreground/90 transition-all backdrop-blur-sm"
-          >
-            <Sparkles size={12} className="text-brand-soft" />
-            <span className="max-w-[120px] truncate">
-              {aiModel?.defaultModel || 'Select model'}
-            </span>
-            <ChevronDown
-              size={12}
-              className={cn('transition-transform', showModelPicker && 'rotate-180')}
+        <div className="flex items-center gap-2">
+          <RefreshButton
+            onRefresh={() => qc.invalidateQueries({ queryKey: keys.ai.models })}
+            disabled={loadingModels}
+            size={11}
+            className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs text-foreground/60 hover:bg-white/[0.05] hover:text-foreground/80 transition-colors disabled:opacity-40"
+            title="Refresh models"
+          />
+          <div className="w-48">
+            <SelectDropdown
+              options={models.map((m) => ({ value: m.name, label: m.name }))}
+              value={aiModel?.defaultModel ?? ''}
+              onChange={(value) => {
+                setAIModel({
+                  defaultModel: value,
+                  temperature: 0.7,
+                  maxTokens: 2000,
+                });
+              }}
+              placeholder="Select model"
+              icon={<Sparkles size={11} className="text-brand-soft" />}
             />
-          </button>
-
-          {/* Model picker dropdown */}
-          {showModelPicker && (
-            <>
-              {/* Backdrop to close dropdown */}
-              <div className="fixed inset-0 z-20" onClick={() => setShowModelPicker(false)} />
-              <div className="absolute right-0 top-full mt-2 w-64 rounded-xl border border-white/[0.08] bg-black/95 backdrop-blur-xl shadow-2xl z-30 overflow-hidden">
-                {/* Refresh button */}
-                <div className="border-b border-white/[0.06] p-2">
-                  <button
-                    onClick={() => void qc.invalidateQueries({ queryKey: keys.ai.models })}
-                    disabled={loadingModels}
-                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-xs text-foreground/60 hover:bg-white/[0.05] hover:text-foreground/80 transition-colors disabled:opacity-40"
-                  >
-                    <RefreshCw size={12} className={loadingModels ? 'animate-spin' : ''} />
-                    Refresh models
-                  </button>
-                </div>
-
-                {/* Model list */}
-                <div className="max-h-80 overflow-y-auto p-2">
-                  {models.length === 0 ? (
-                    <div className="px-3 py-4 text-center text-xs text-foreground/40">
-                      No models available
-                    </div>
-                  ) : (
-                    models.map((model) => {
-                      const isSelected = model.name === aiModel?.defaultModel;
-                      return (
-                        <button
-                          key={model.name}
-                          onClick={() => {
-                            setAIModel({
-                              defaultModel: model.name,
-                              temperature: 0.7,
-                              maxTokens: 2000,
-                            });
-                            setShowModelPicker(false);
-                          }}
-                          className={cn(
-                            'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors',
-                            isSelected
-                              ? 'bg-brand/20 text-brand-soft'
-                              : 'text-foreground/70 hover:bg-white/[0.05] hover:text-foreground/90'
-                          )}
-                        >
-                          {isSelected && <Check size={12} className="shrink-0" />}
-                          <span className="flex-1 truncate">{model.name}</span>
-                        </button>
-                      );
-                    })
-                  )}
-                </div>
-              </div>
-            </>
-          )}
+          </div>
         </div>
       </div>
 
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-8 py-6">
         {messages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center text-center">
-            <div className="glass-elevated mb-5 flex h-14 w-14 items-center justify-center rounded-2xl glow-subtle">
+            <div className="glass-elevated mb-5 flex h-14 w-14 items-center justify-center rounded-2xl ring-1 ring-brand/20">
               <Sparkles size={22} className="text-brand-soft" />
             </div>
             <h2 className="text-gradient text-2xl font-semibold tracking-tight">{t('nav.ai')}</h2>
@@ -319,7 +271,7 @@ export function AIWorkspace() {
                   className={cn(
                     'glass-card rounded-2xl px-4 py-3',
                     m.role === 'user'
-                      ? 'self-end max-w-[80%] glow-subtle text-sm leading-relaxed'
+                      ? 'self-end max-w-[80%] ring-1 ring-brand/20 text-sm leading-relaxed'
                       : 'self-start max-w-[85%]'
                   )}
                 >
@@ -393,7 +345,7 @@ export function AIWorkspace() {
         <motion.div
           className={cn(
             'glass-elevated mx-auto flex max-w-3xl items-center gap-2 rounded-2xl px-4 py-2.5',
-            isInputFocused && 'glow-subtle'
+            isInputFocused && 'ring-1 ring-brand/20'
           )}
           animate={{
             boxShadow: isInputFocused ? '0 0 20px rgba(192, 132, 252, 0.3)' : 'none',

--- a/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
+++ b/apps/tauri/src/renderer/features/ai-workspace/components/ResumeInputCard.tsx
@@ -21,8 +21,7 @@ import { Button, TextArea, useNotification } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
-import { useDocuments, useImportDocument } from '@/services';
-import { usePreferencesStore, useResume } from '@/store/preferences-store';
+import { useDocuments, useImportDocument, useSetDefaultDocument } from '@/services';
 
 const ACCEPT = '.pdf,.docx,.txt,.md,.markdown';
 const MAX_BYTES = 25 * 1024 * 1024;
@@ -79,33 +78,29 @@ export function ResumeInputCard({
   const { data: rawDocsUnknown = [] } = useDocuments();
   const rawDocs = rawDocsUnknown as unknown as RawDoc[];
   const docs = rawDocs.map(normalise);
-  const resumePref = useResume();
-  const setResume = usePreferencesStore((s) => s.setResume);
   const importDocument = useImportDocument();
+  const setDefaultDocument = useSetDefaultDocument();
 
   const hasSaved = docs.length > 0;
-  const defaultDoc = docs.find((d) => d.id === resumePref?.defaultId) ?? docs[0];
+  const defaultDoc = docs.find((d) => d.isDefault) ?? docs[0];
 
   // Auto-fill from default resume on first load (only if textarea is still empty)
   useEffect(() => {
     if (value) return;
-    const raw = rawDocs.find((d) => d._id === resumePref?.defaultId) ?? rawDocs[0];
+    const raw = rawDocs.find((d) => d.isDefault) ?? rawDocs[0];
     const text = raw?.text?.trim();
     if (text) onChange(text);
-  }, [value, rawDocs, resumePref?.defaultId, onChange]);
+  }, [value, rawDocs, onChange]);
 
   /** Load text from a saved document record into the textarea */
-  const handleSelectSaved = (doc: DocumentRecord) => {
+  const handleSelectSaved = async (doc: DocumentRecord) => {
     const raw = rawDocs.find((d) => d._id === doc.id);
     const text = raw?.text?.trim();
     if (text) {
       onChange(text);
     }
-    setResume({
-      defaultId: doc.id,
-      autoIndex: resumePref?.autoIndex ?? true,
-      autoParse: resumePref?.autoParse ?? true,
-    });
+    // Set as default in backend
+    await setDefaultDocument.mutateAsync(doc.id);
     setShowSaved(false);
     setLastUploadedFile(null);
     notify(t('resumeInput.selectedSaved', { name: doc.title }), 'success');
@@ -117,15 +112,13 @@ export function ResumeInputCard({
     setSaving(true);
     try {
       const bytes = new Uint8Array(await lastUploadedFile.arrayBuffer());
-      await importDocument.mutateAsync({
+      const result = await importDocument.mutateAsync({
         name: lastUploadedFile.name,
         bytes,
         title: lastUploadedFile.name,
       });
-      const saved = rawDocs[0];
-      const id = saved?._id;
-      if (asDefault && id) {
-        setResume({ defaultId: String(id), autoIndex: true, autoParse: true });
+      if (asDefault && result?.id) {
+        await setDefaultDocument.mutateAsync(result.id);
       }
       notify(
         asDefault ? t('resumeInput.savedAsDefault') : t('resumeInput.savedToLibrary'),
@@ -188,14 +181,14 @@ export function ResumeInputCard({
                         onClick={() => handleSelectSaved(doc)}
                         className={cn(
                           'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs transition-colors',
-                          doc.id === resumePref?.defaultId
+                          doc.isDefault
                             ? 'bg-brand/15 text-brand-soft'
                             : 'text-foreground/65 hover:bg-white/[0.05] hover:text-foreground/90'
                         )}
                       >
                         <FileText size={11} className="shrink-0" />
                         <span className="truncate flex-1">{doc.title}</span>
-                        {doc.id === resumePref?.defaultId && <Sparkles size={9} />}
+                        {doc.isDefault && <Sparkles size={9} />}
                       </button>
                     ))}
                   </div>
@@ -274,7 +267,7 @@ export function ResumeInputCard({
             variant="glass"
             size="sm"
             onClick={() => void handleSaveToLibrary(true)}
-            className="gap-1 text-[11px] h-6 px-2 glow-subtle"
+            className="gap-1 text-[11px] h-6 px-2 ring-1 ring-brand/20"
           >
             <Sparkles size={10} /> {t('resumeInput.setDefault')}
           </Button>

--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepTarget.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepTarget.tsx
@@ -1,8 +1,9 @@
 import { BOARD_IDS } from '@ajh/shared';
-import { Button, Input, SelectDropdown } from '@ajh/ui';
+import { Button, Input, LocationInput, SelectDropdown } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
+import { useAppClient } from '@/providers/AppClientProvider';
 import type { Prefilled, SetFn, WizardState } from '@/routes/autopilot';
 
 import { PrefilledBadge } from './PrefilledBadge';
@@ -19,6 +20,7 @@ interface StepTargetProps {
 
 export function StepTarget({ form, set, prefilled }: StepTargetProps) {
   const { t } = useTranslation();
+  const api = useAppClient();
   return (
     <div className="space-y-4">
       <div>
@@ -70,11 +72,11 @@ export function StepTarget({ form, set, prefilled }: StepTargetProps) {
           hint={t('autopilot.wizard.target.locationOptional')}
         >
           <div className="space-y-1.5">
-            <Input
-              className={inputCls}
-              placeholder={t('autopilot.wizard.target.locationPlaceholder')}
+            <LocationInput
               value={form.location}
-              onChange={(e) => set('location', e.target.value)}
+              onChange={(value) => set('location', value)}
+              placeholder={t('autopilot.wizard.target.locationPlaceholder')}
+              onFetchSuggestions={(q) => api.geocode.suggest(q)}
             />
             {prefilled.location && (
               <PrefilledBadge field={t('autopilot.wizard.target.fromLocationSettings')} />

--- a/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/OllamaStep.tsx
@@ -480,7 +480,9 @@ export function OllamaStep({ onBack, onNext, direction }: Props) {
                           size="sm"
                           disabled={!cloudApiKey.trim() || savingCloudKey}
                           onClick={() => void handleSaveCloudKey()}
-                          className={cloudApiKey.trim() && !savingCloudKey ? 'glow-subtle' : ''}
+                          className={
+                            cloudApiKey.trim() && !savingCloudKey ? 'ring-1 ring-brand/20' : ''
+                          }
                         >
                           {savingCloudKey ? (
                             <Loader2 size={13} className="animate-spin" />

--- a/apps/tauri/src/renderer/features/onboarding/steps/PrefsStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/PrefsStep.tsx
@@ -9,7 +9,7 @@ import i18n from '@/i18n';
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
-import type { RemotePreference } from '@/store/preferences-schema';
+import { useJobPreferences, useSetJobPreferences } from '@/services';
 import { usePreferencesStore } from '@/store/preferences-store';
 
 interface Props {
@@ -18,7 +18,7 @@ interface Props {
   direction: number;
 }
 
-const REMOTE_OPTIONS: { id: RemotePreference; emoji: string }[] = [
+const REMOTE_OPTIONS: { id: string; emoji: string }[] = [
   { id: 'remote', emoji: '🌍' },
   { id: 'hybrid', emoji: '🏠' },
   { id: 'on-site', emoji: '🏢' },
@@ -27,14 +27,21 @@ const REMOTE_OPTIONS: { id: RemotePreference; emoji: string }[] = [
 
 export function PrefsStep({ onBack, onNext, direction }: Props) {
   const { t } = useTranslation();
-  const remote = usePreferencesStore((s) => s.remote);
-  const setRemote = usePreferencesStore((s) => s.setRemote);
+  const { data: jobPrefs } = useJobPreferences();
+  const setJobPreferences = useSetJobPreferences();
   const setLanguage = usePreferencesStore((s) => s.setLanguage);
   const currentLang = i18n.language;
 
   const selectLanguage = (code: string) => {
     void i18n.changeLanguage(code);
     setLanguage(code);
+  };
+
+  const selectRemote = (remote: string) => {
+    setJobPreferences.mutate({
+      ...jobPrefs,
+      remote,
+    });
   };
 
   useEffect(() => {
@@ -111,11 +118,11 @@ export function PrefsStep({ onBack, onNext, direction }: Props) {
           </div>
           <div className="grid grid-cols-4 gap-1.5">
             {REMOTE_OPTIONS.map(({ id, emoji }) => {
-              const active = remote === id;
+              const active = jobPrefs?.remote === id;
               return (
                 <Button
                   key={id}
-                  onClick={() => setRemote(id)}
+                  onClick={() => selectRemote(id)}
                   className={cn(
                     'flex flex-col items-center gap-1.5 rounded-xl border px-2 py-3 text-center transition-all duration-150 h-auto',
                     active

--- a/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep.tsx
@@ -143,7 +143,7 @@ export function ResumeStep({ onBack, onNext, direction }: Props) {
             variant="glass"
             size="md"
             onClick={onNext}
-            className={hasResume ? 'hover:glow-purple px-6 gap-2' : 'px-6 gap-2'}
+            className="transition-all duration-150 ease-out px-6 gap-2"
           >
             {hasResume ? t('onboarding.resume.next') : t('onboarding.resume.skip')}
             <ArrowRight size={14} />

--- a/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/AISettingsTab.tsx
@@ -435,7 +435,7 @@ export function AISettingsTab() {
                               size="sm"
                               onClick={() => setActiveProvider('ollama')}
                               disabled={isActive}
-                              className={isActive ? 'opacity-40' : 'glow-subtle'}
+                              className={isActive ? 'opacity-40' : 'ring-1 ring-brand/20'}
                             >
                               {isActive ? 'Currently active' : 'Set as active'}
                             </Button>
@@ -493,7 +493,9 @@ export function AISettingsTab() {
                                   size="sm"
                                   disabled={!apiKeyInput.trim() || isSaving}
                                   onClick={() => void handleSaveKey(p)}
-                                  className={apiKeyInput.trim() && !isSaving ? 'glow-subtle' : ''}
+                                  className={
+                                    apiKeyInput.trim() && !isSaving ? 'ring-1 ring-brand/20' : ''
+                                  }
                                 >
                                   {isSaving ? (
                                     <Loader2 size={13} className="animate-spin" />

--- a/apps/tauri/src/renderer/features/settings/components/AccountRow.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/AccountRow.tsx
@@ -144,7 +144,7 @@ export function AccountRow({ board, saved, disabled, onSaved, onRemoved }: Accou
                     loading={busy}
                     disabled={!username.trim() || !password}
                     onClick={() => void save()}
-                    className={cn(!username.trim() || !password ? '' : 'glow-subtle')}
+                    className={cn(!username.trim() || !password ? '' : 'ring-1 ring-brand/20')}
                   >
                     {t('settings.accounts.save')}
                   </Button>

--- a/apps/tauri/src/renderer/features/settings/components/JobLocationPreferences.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/JobLocationPreferences.tsx
@@ -7,7 +7,7 @@ import { Button, GlassCard, Input } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
-import { useLocation, usePreferencesStore } from '@/store/preferences-store';
+import { useJobPreferences, useSetJobPreferences } from '@/services';
 
 const COMMON_LOCATIONS = [
   'San Francisco, CA',
@@ -22,8 +22,8 @@ const COMMON_LOCATIONS = [
 
 export function JobLocationPreferences() {
   const { t } = useTranslation();
-  const location = useLocation();
-  const setLocation = usePreferencesStore((state) => state.setLocation);
+  const { data: jobPrefs } = useJobPreferences();
+  const setJobPreferences = useSetJobPreferences();
   const [inputValue, setInputValue] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [recentLocations, setRecentLocations] = useState<string[]>([]);
@@ -39,11 +39,10 @@ export function JobLocationPreferences() {
   );
 
   const handleAddLocation = (loc: string) => {
-    if (!location) {
-      setLocation({ city: loc });
-    } else if (!location.city) {
-      setLocation({ ...location, city: loc });
-    }
+    setJobPreferences.mutate({
+      ...jobPrefs,
+      location: loc,
+    });
     setInputValue('');
     setShowSuggestions(false);
 
@@ -54,7 +53,10 @@ export function JobLocationPreferences() {
   };
 
   const handleRemoveLocation = () => {
-    setLocation(undefined);
+    setJobPreferences.mutate({
+      ...jobPrefs,
+      location: undefined,
+    });
   };
 
   const updateDropdownPosition = () => {
@@ -79,7 +81,7 @@ export function JobLocationPreferences() {
       <p className="mb-4 text-sm text-foreground/55">{t('settings.location.description')}</p>
 
       {/* Current Location Display */}
-      {location?.city && (
+      {jobPrefs?.location && (
         <motion.div
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -87,7 +89,7 @@ export function JobLocationPreferences() {
           className="mb-4 flex items-center gap-2 rounded-lg bg-white/5 px-4 py-3"
         >
           <MapPin size={16} className="text-brand-soft" />
-          <span className="flex-1 text-sm text-foreground">{location.city}</span>
+          <span className="flex-1 text-sm text-foreground">{jobPrefs.location}</span>
           <Button
             variant="ghost"
             size="sm"

--- a/apps/tauri/src/renderer/features/settings/components/LanguageSelector.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/LanguageSelector.tsx
@@ -23,7 +23,6 @@ export function LanguageSelector() {
           <motion.button
             key={code}
             onClick={() => select(code)}
-            whileTap={{ scale: 0.97 }}
             className={cn(
               'relative flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left text-xs transition-all duration-150',
               active

--- a/apps/tauri/src/renderer/features/settings/components/LinkedInSessionRow.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/LinkedInSessionRow.tsx
@@ -70,12 +70,22 @@ export function LinkedInSessionRow({ board }: LinkedInSessionRowProps) {
               <Loader2 size={14} className="animate-spin" />
             </Button>
           ) : (status as { connected?: boolean } | undefined)?.connected ? (
-            <Button size="sm" variant="glass" onClick={handleDisconnect} className="hover:glow-red">
+            <Button
+              size="sm"
+              variant="glass"
+              onClick={handleDisconnect}
+              className="transition-all duration-150 ease-out"
+            >
               <LogOut size={14} />
               Disconnect
             </Button>
           ) : (
-            <Button size="sm" variant="glass" onClick={handleConnect} className="hover:glow-purple">
+            <Button
+              size="sm"
+              variant="glass"
+              onClick={handleConnect}
+              className="transition-all duration-150 ease-out"
+            >
               <LinkIcon size={14} />
               Connect
             </Button>

--- a/apps/tauri/src/renderer/features/settings/components/PerformancePreferences.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/PerformancePreferences.tsx
@@ -20,12 +20,7 @@ const PERFORMANCE_OPTIONS: {
     label: 'Low Memory',
     icon: Cpu,
     description: 'Optimized for older hardware',
-    details: [
-      'Reduced blur intensity',
-      'Minimal animations',
-      'Aggressive model unloading',
-      'Lower concurrency',
-    ],
+    details: ['Reduced blur intensity', 'Aggressive model unloading', 'Lower concurrency'],
   },
   {
     value: 'balanced',
@@ -69,12 +64,10 @@ export function PerformancePreferences() {
               key={opt.value}
               type="button"
               onClick={() => setPerformanceMode(opt.value)}
-              whileHover={{ scale: 1.01 }}
-              whileTap={{ scale: 0.99 }}
               className={cn(
                 'relative flex items-start gap-4 rounded-xl border p-4 text-left transition-all duration-150',
                 isSelected
-                  ? 'border-brand-soft/50 bg-brand-soft/10 glow-subtle'
+                  ? 'border-brand-soft/50 bg-brand-soft/10 ring-1 ring-brand/20'
                   : 'border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/10'
               )}
             >

--- a/apps/tauri/src/renderer/features/settings/components/RemotePreferences.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/RemotePreferences.tsx
@@ -3,11 +3,10 @@ import { Building2, Globe, Home, type LucideIcon } from 'lucide-react';
 import { GlassCard, OptionTile, SectionLabel } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
-import type { RemotePreference } from '@/store/preferences-schema';
-import { usePreferencesStore, useRemote } from '@/store/preferences-store';
+import { useJobPreferences, useSetJobPreferences } from '@/services';
 
 const REMOTE_OPTIONS: {
-  value: RemotePreference;
+  value: string;
   labelKey: string;
   descriptionKey: string;
   icon: LucideIcon;
@@ -40,8 +39,8 @@ const REMOTE_OPTIONS: {
 
 export function RemotePreferences() {
   const { t } = useTranslation();
-  const remote = useRemote();
-  const setRemote = usePreferencesStore((s) => s.setRemote);
+  const { data: jobPrefs } = useJobPreferences();
+  const setJobPreferences = useSetJobPreferences();
 
   return (
     <GlassCard>
@@ -56,8 +55,8 @@ export function RemotePreferences() {
             icon={opt.icon}
             label={t(opt.labelKey)}
             description={t(opt.descriptionKey)}
-            selected={remote === opt.value}
-            onClick={() => setRemote(opt.value)}
+            selected={jobPrefs?.remote === opt.value}
+            onClick={() => setJobPreferences.mutate({ ...jobPrefs, remote: opt.value })}
             layoutId="remote-selection"
           />
         ))}

--- a/apps/tauri/src/renderer/features/settings/components/ResumePreferences.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ResumePreferences.tsx
@@ -8,14 +8,16 @@ import { Button, GlassCard, useNotification } from '@ajh/ui';
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
-import { useDocuments, useImportDocument, useRemoveDocument } from '@/services';
-import { usePreferencesStore, useResume } from '@/store/preferences-store';
+import {
+  useDocuments,
+  useImportDocument,
+  useRemoveDocument,
+  useSetDefaultDocument,
+} from '@/services';
 
 export function ResumePreferences() {
   const { t } = useTranslation();
   const notify = useNotification();
-  const resume = useResume();
-  const setResume = usePreferencesStore((state) => state.setResume);
 
   const { data: documentsRaw = [], isLoading } = useDocuments();
   // Rust serialises id as _id and created_at as createdAt — normalise here
@@ -38,6 +40,7 @@ export function ResumePreferences() {
   }));
   const importDocument = useImportDocument();
   const removeDocument = useRemoveDocument();
+  const setDefaultDocument = useSetDefaultDocument();
 
   const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -48,11 +51,6 @@ export function ResumePreferences() {
       const bytes = new Uint8Array(await file.arrayBuffer());
       await importDocument.mutateAsync({ name: file.name, bytes, title: file.name });
       if (fileInputRef.current) fileInputRef.current.value = '';
-      // Set as default only if none already selected
-      if (!resume?.defaultId) {
-        const firstId = rawDocs[0]?._id;
-        if (firstId) setResume({ defaultId: firstId, autoIndex: true, autoParse: true });
-      }
       notify(t('settings.resume.uploaded'), 'success');
     } catch (err) {
       notify(err instanceof Error ? err.message : t('settings.resume.uploadFailed'), 'error');
@@ -73,25 +71,18 @@ export function ResumePreferences() {
     if (file) void handleFileUpload(file);
   };
 
-  const handleSetDefault = (id: string) => {
-    setResume({
-      defaultId: id,
-      autoIndex: resume?.autoIndex ?? true,
-      autoParse: resume?.autoParse ?? true,
-    });
+  const handleSetDefault = async (id: string) => {
+    try {
+      await setDefaultDocument.mutateAsync(id);
+      notify(t('settings.resume.defaultSet'), 'success');
+    } catch {
+      notify(t('settings.resume.defaultSetFailed'), 'error');
+    }
   };
 
   const handleDelete = async (id: string) => {
     try {
       await removeDocument.mutateAsync(id);
-      if (resume?.defaultId === id) {
-        const next = documents.find((d) => d.id !== id);
-        setResume({
-          defaultId: next?.id,
-          autoIndex: resume?.autoIndex ?? true,
-          autoParse: resume?.autoParse ?? true,
-        });
-      }
       notify(t('settings.resume.removed'), 'success');
     } catch {
       notify(t('settings.resume.removeFailed'), 'error');
@@ -193,7 +184,7 @@ export function ResumePreferences() {
       ) : (
         <div className="space-y-2">
           {documents.map((doc) => {
-            const isDefault = resume?.defaultId === doc.id;
+            const isDefault = doc.isDefault ?? false;
             return (
               <motion.div
                 key={doc.id}
@@ -244,8 +235,8 @@ export function ResumePreferences() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => handleSetDefault(doc.id)}
-                    disabled={isDefault}
+                    onClick={() => void handleSetDefault(doc.id)}
+                    disabled={isDefault || setDefaultDocument.isPending}
                     title={t('settings.resume.setDefault')}
                     className="text-foreground/30 hover:text-brand-soft disabled:opacity-0"
                   >

--- a/apps/tauri/src/renderer/features/settings/components/SalaryPreferences.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SalaryPreferences.tsx
@@ -5,10 +5,8 @@ import { Button, GlassCard } from '@ajh/ui';
 
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
-import type { SalaryExpectation } from '@/store/preferences-schema';
-import { usePreferencesStore, useSalary } from '@/store/preferences-store';
+import { useJobPreferences, useSetJobPreferences } from '@/services';
 
-const CURRENCIES = ['USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY'] as const;
 const PERIODS = ['hourly', 'monthly', 'yearly'] as const;
 
 const SALARY_RANGES = {
@@ -26,40 +24,46 @@ const formatSalary = (value: number, period: string) => {
 
 export function SalaryPreferences() {
   const { t } = useTranslation();
-  const salary = useSalary();
-  const setSalary = usePreferencesStore((state) => state.setSalary);
+  const { data: jobPrefs } = useJobPreferences();
+  const setJobPreferences = useSetJobPreferences();
 
-  const [minValue, setMinValue] = useState(salary?.min || 50000);
-  const [maxValue, setMaxValue] = useState(salary?.max || 150000);
-  const [currency, setCurrency] = useState(salary?.currency || 'USD');
-  const [period, setPeriod] = useState<SalaryExpectation['period']>(salary?.period || 'yearly');
+  const [minValue, setMinValue] = useState(jobPrefs?.salaryMin || 50000);
+  const [maxValue, setMaxValue] = useState(jobPrefs?.salaryMax || 150000);
+  const [period, setPeriod] = useState('yearly');
 
   const handleMinChange = (value: number) => {
     const newMin = Math.min(value, maxValue - 10000);
     setMinValue(newMin);
-    setSalary({ min: newMin, max: maxValue, currency, period });
+    setJobPreferences.mutate({
+      ...jobPrefs,
+      salaryMin: newMin,
+      salaryMax: maxValue,
+    });
   };
 
   const handleMaxChange = (value: number) => {
     const newMax = Math.max(value, minValue + 10000);
     setMaxValue(newMax);
-    setSalary({ min: minValue, max: newMax, currency, period });
+    setJobPreferences.mutate({
+      ...jobPrefs,
+      salaryMin: minValue,
+      salaryMax: newMax,
+    });
   };
 
-  const handleCurrencyChange = (newCurrency: string) => {
-    setCurrency(newCurrency);
-    setSalary({ min: minValue, max: maxValue, currency: newCurrency, period });
-  };
-
-  const handlePeriodChange = (newPeriod: SalaryExpectation['period']) => {
+  const handlePeriodChange = (newPeriod: string) => {
     setPeriod(newPeriod);
-    const range = SALARY_RANGES[newPeriod];
+    const range = SALARY_RANGES[newPeriod as keyof typeof SALARY_RANGES];
     setMinValue(range.min);
     setMaxValue(range.max * 0.5);
-    setSalary({ min: range.min, max: range.max * 0.5, currency, period: newPeriod });
+    setJobPreferences.mutate({
+      ...jobPrefs,
+      salaryMin: range.min,
+      salaryMax: range.max * 0.5,
+    });
   };
 
-  const range = SALARY_RANGES[period];
+  const range = SALARY_RANGES[period as keyof typeof SALARY_RANGES];
 
   return (
     <GlassCard>
@@ -73,28 +77,6 @@ export function SalaryPreferences() {
 
       {/* Currency & Period Selection */}
       <div className="mb-6 grid grid-cols-2 gap-3">
-        <div>
-          <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
-            {t('settings.salary.currency')}
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {CURRENCIES.map((curr) => (
-              <Button
-                key={curr}
-                onClick={() => handleCurrencyChange(curr)}
-                className={cn(
-                  'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors h-auto',
-                  currency === curr
-                    ? 'bg-brand-soft/20 text-brand-soft'
-                    : 'bg-white/5 text-foreground/60 hover:bg-white/10 hover:text-foreground'
-                )}
-              >
-                {curr}
-              </Button>
-            ))}
-          </div>
-        </div>
-
         <div>
           <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-foreground/40">
             {t('settings.salary.period')}

--- a/apps/tauri/src/renderer/features/settings/components/TechStackPreferences.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/TechStackPreferences.tsx
@@ -8,7 +8,7 @@ import { Button, GlassCard, Input } from '@ajh/ui';
 import { cn } from '@/lib/cn';
 import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
-import { usePreferencesStore, useTechStack } from '@/store/preferences-store';
+import { useJobPreferences, useSetJobPreferences } from '@/services';
 
 const COMMON_TECH = [
   { name: 'JavaScript', category: 'language' },
@@ -38,9 +38,9 @@ const CATEGORY_COLORS: Record<string, string> = {
 
 export function TechStackPreferences() {
   const { t } = useTranslation();
-  const techStack = useTechStack();
-  const addTechStackItem = usePreferencesStore((state) => state.addTechStackItem);
-  const removeTechStackItem = usePreferencesStore((state) => state.removeTechStackItem);
+  const { data: jobPrefs } = useJobPreferences();
+  const setJobPreferences = useSetJobPreferences();
+  const techStack = jobPrefs?.techStack || [];
   const [inputValue, setInputValue] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
@@ -55,16 +55,19 @@ export function TechStackPreferences() {
   );
 
   const handleAddTech = (name: string, category: string) => {
-    addTechStackItem({
-      name,
-      category: category as 'language' | 'framework' | 'database' | 'tool' | 'other',
+    setJobPreferences.mutate({
+      ...jobPrefs,
+      techStack: [...techStack, { name, category }],
     });
     setInputValue('');
     setShowSuggestions(false);
   };
 
   const handleRemoveTech = (name: string) => {
-    removeTechStackItem(name);
+    setJobPreferences.mutate({
+      ...jobPrefs,
+      techStack: techStack.filter((item) => item.name !== name),
+    });
   };
 
   useEffect(() => {

--- a/apps/tauri/src/renderer/features/support/components/HealthCard.tsx
+++ b/apps/tauri/src/renderer/features/support/components/HealthCard.tsx
@@ -10,7 +10,7 @@ interface HealthCardProps {
 
 export function HealthCard({ name, status, description }: HealthCardProps) {
   const statusConfig = {
-    healthy: { icon: CheckCircle2, color: 'text-emerald-400', glow: 'glow-subtle' },
+    healthy: { icon: CheckCircle2, color: 'text-emerald-400', glow: 'ring-1 ring-emerald-400/20' },
     warning: { icon: AlertTriangle, color: 'text-amber-400', glow: '' },
     error: { icon: XCircle, color: 'text-red-400', glow: '' },
     disabled: { icon: XCircle, color: 'text-foreground/40', glow: '' },

--- a/apps/tauri/src/renderer/lib/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client.ts
@@ -67,8 +67,14 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       list: emptyList,
       import: noop,
       remove: noop,
+      setDefault: noop,
       exportDocument: async () => ({ data: [], mimeType: 'text/plain', filename: 'mock.txt' }),
       exportAndSave: noop,
+    },
+
+    jobPreferences: {
+      get: async () => ({}),
+      set: noop,
     },
 
     search: {

--- a/apps/tauri/src/renderer/lib/web-http-client.ts
+++ b/apps/tauri/src/renderer/lib/web-http-client.ts
@@ -128,8 +128,14 @@ export function createWebHttpClient({ baseUrl, token }: WebHttpClientOptions): A
       list: () => cmd('documents', 'list'),
       import: (req) => cmd('documents', 'import', req),
       remove: (id) => cmd('documents', 'remove', { id }),
+      setDefault: (id) => cmd('documents', 'setDefault', { id }),
       exportDocument: (req) => cmd('documents', 'exportDocument', req),
       exportAndSave: (req) => cmd('documents', 'exportAndSave', req),
+    },
+
+    jobPreferences: {
+      get: () => cmd('jobPreferences', 'get'),
+      set: (prefs) => cmd('jobPreferences', 'set', prefs),
     },
 
     search: {

--- a/apps/tauri/src/renderer/providers/PerformanceModeProvider.tsx
+++ b/apps/tauri/src/renderer/providers/PerformanceModeProvider.tsx
@@ -1,17 +1,14 @@
-import { MotionConfig } from 'motion/react';
 import { type ReactNode, useEffect, useRef } from 'react';
 
 import { useAppClient } from '@/providers/AppClientProvider';
 import { usePerformanceMode } from '@/store/preferences-store';
 
 /**
- * Syncs the renderer's performanceMode preference to three side effects:
+ * Syncs the renderer's performanceMode preference to two side effects:
  *   1. data-performance-mode attribute on <html> — drives CSS-level blur
- *      reduction and kills CSS transitions/keyframe animations.
+ *      reduction.
  *   2. system.setPerformanceMode IPC — lets the main process adjust JobQueue
  *      concurrency and AiRuntime idle-unload timeout accordingly.
- *   3. MotionConfig reducedMotion — disables all Framer Motion JS animations
- *      in low-memory mode (CSS override alone does not reach them).
  *
  * Place this inside <AppClientProvider> so getClient() is always ready.
  */
@@ -31,9 +28,5 @@ export function PerformanceModeProvider({ children }: { children: ReactNode }) {
     });
   }, [client, mode]);
 
-  return (
-    <MotionConfig reducedMotion={mode === 'low-memory' ? 'always' : 'user'}>
-      {children}
-    </MotionConfig>
-  );
+  return <>{children}</>;
 }

--- a/apps/tauri/src/renderer/routes/ai-generate.tsx
+++ b/apps/tauri/src/renderer/routes/ai-generate.tsx
@@ -397,7 +397,7 @@ function AIGeneratePage() {
                 variant={canGenerate ? 'glass' : 'ghost'}
                 onClick={() => void handleAnalyze()}
                 disabled={!canGenerate}
-                className={cn('w-full justify-center', canGenerate && 'hover:glow-purple')}
+                className="w-full justify-center transition-all duration-150 ease-out"
               >
                 <ArrowRight size={14} />
                 {!aiModel?.defaultModel

--- a/apps/tauri/src/renderer/routes/analyze.tsx
+++ b/apps/tauri/src/renderer/routes/analyze.tsx
@@ -37,12 +37,7 @@ import { transition } from '@/lib/motion';
 import { type AnalysisResult, runAnalysis } from '@/lib/resume-ai';
 import { useAIModels, useDocuments, useExtractText } from '@/services';
 import { keys } from '@/services/query-client';
-import {
-  useAIModel,
-  useOutputTone,
-  usePreferencesStore,
-  useResume,
-} from '@/store/preferences-store';
+import { useAIModel, useOutputTone, usePreferencesStore } from '@/store/preferences-store';
 import type { Model } from '@/types';
 
 export const Route = createFileRoute('/analyze')({ component: Analyze });
@@ -72,17 +67,16 @@ function Analyze() {
   const outputTone = useOutputTone();
   const setAIModel = usePreferencesStore((s) => s.setAIModel);
   const extractTextMutation = useExtractText();
-  const resumePref = useResume();
   const { data: documentsRaw = [] } = useDocuments();
 
   // Auto-fill default resume on mount
   useEffect(() => {
     if (resume) return; // Don't override if user already has content
     const docs = documentsRaw as Array<DocumentRecord & { _id?: string; text?: string }>;
-    const defaultDoc = docs.find((d) => (d._id ?? d.id) === resumePref?.defaultId) ?? docs[0];
+    const defaultDoc = docs.find((d) => d.isDefault) ?? docs[0];
     const text = defaultDoc?.text?.trim();
     if (text) setResume(text);
-  }, [documentsRaw, resumePref?.defaultId, resume]);
+  }, [documentsRaw, resume]);
 
   // Reset state when component unmounts (route change)
   useEffect(() => {
@@ -268,10 +262,7 @@ function Analyze() {
               onClick={() => void run()}
               loading={stage === 'running'}
               disabled={!canRun || stage === 'running'}
-              className={cn(
-                'w-full justify-center',
-                canRun && stage !== 'running' && 'hover:glow-purple'
-              )}
+              className={cn('w-full justify-center', 'transition-all duration-150 ease-out')}
             >
               {stage !== 'running' && <Sparkles size={14} />}
               {stage === 'running'

--- a/apps/tauri/src/renderer/routes/autopilot.tsx
+++ b/apps/tauri/src/renderer/routes/autopilot.tsx
@@ -20,7 +20,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 
-import type { Autopilot, AutopilotAction, AutopilotSchedule } from '@ajh/shared';
+import type { Autopilot, AutopilotAction, AutopilotSchedule, JobPreferences } from '@ajh/shared';
 import { Button, GlassCard } from '@ajh/ui';
 
 import { PageTransition } from '@/components/layout/PageTransition';
@@ -34,12 +34,12 @@ import { transition } from '@/lib/motion';
 import {
   useAutopilots,
   useCreateAutopilot,
+  useJobPreferences,
   usePauseAutopilot,
   useRemoveAutopilot,
   useResumeAutopilot,
   useRunAutopilot,
 } from '@/services';
-import { useLocation, useRemote, useTechStack } from '@/store/preferences-store';
 
 export const Route = createFileRoute('/autopilot')({ component: AutopilotPage });
 
@@ -67,24 +67,20 @@ export interface WizardState {
   schedule: AutopilotSchedule;
 }
 
-function buildDefaults(
-  location?: { city?: string },
-  remote?: string,
-  techStack?: { name: string }[]
-): WizardState {
+function buildDefaults(jobPrefs?: JobPreferences): WizardState {
   const validWorkType = ['remote', 'hybrid', 'on-site', 'any'] as const;
   return {
     name: '',
     board: 'linkedin',
     query: '',
-    location: location?.city ?? '',
-    workType: validWorkType.includes(remote as (typeof validWorkType)[number])
-      ? (remote as WizardState['workType'])
+    location: jobPrefs?.location ?? '',
+    workType: validWorkType.includes(jobPrefs?.remote as (typeof validWorkType)[number])
+      ? (jobPrefs?.remote as WizardState['workType'])
       : 'any',
     pages: 2,
     dateFilter: '24h',
     minMatchScore: 50,
-    keywords: techStack?.map((t) => t.name).join(', ') ?? '',
+    keywords: jobPrefs?.techStack?.map((t) => t.name).join(', ') ?? '',
     excludeKeywords: '',
     resumeText: '',
     action: 'save',
@@ -193,7 +189,7 @@ function AutopilotPage() {
             variant="glass"
             size="sm"
             onClick={() => setCreating(true)}
-            className="hover:glow-purple"
+            className="transition-all duration-150 ease-out"
           >
             <Plus size={13} /> {t('autopilot.newAutopilot')}
           </Button>
@@ -360,7 +356,12 @@ function EmptyState({ onNew }: { onNew(): void }) {
           </div>
         ))}
       </div>
-      <Button variant="glass" size="md" onClick={onNew} className="hover:glow-purple px-6 gap-2">
+      <Button
+        variant="glass"
+        size="md"
+        onClick={onNew}
+        className="transition-all duration-150 ease-out px-6 gap-2"
+      >
         <Plus size={14} /> {t('autopilot.empty.createFirst')}
       </Button>
     </div>
@@ -371,22 +372,18 @@ function EmptyState({ onNew }: { onNew(): void }) {
 
 function CreationWizard({ onDone, onCancel }: { onDone(ap: Autopilot): void; onCancel(): void }) {
   const { t } = useTranslation();
-  const prefLocation = useLocation();
-  const prefRemote = useRemote();
-  const prefTechStack = useTechStack();
+  const { data: jobPrefs } = useJobPreferences();
 
   const [step, setStep] = useState(0);
-  const [form, setForm] = useState<WizardState>(() =>
-    buildDefaults(prefLocation, prefRemote, prefTechStack)
-  );
+  const [form, setForm] = useState<WizardState>(() => buildDefaults(jobPrefs));
   const [error, setError] = useState<string | null>(null);
   const createAutopilot = useCreateAutopilot();
   const saving = createAutopilot.isPending;
 
   // Track which fields were pre-filled so we can show a hint
   const prefilledFields = {
-    location: !!prefLocation?.city,
-    keywords: (prefTechStack?.length ?? 0) > 0,
+    location: !!jobPrefs?.location,
+    keywords: (jobPrefs?.techStack?.length ?? 0) > 0,
   };
 
   const set: SetFn = <K extends keyof WizardState>(k: K, v: WizardState[K]) =>
@@ -635,7 +632,7 @@ function CreationWizard({ onDone, onCancel }: { onDone(ap: Autopilot): void; onC
               size="sm"
               disabled={!canNext()}
               onClick={() => setStep((s) => s + 1)}
-              className={canNext() ? 'hover:glow-purple' : ''}
+              className="transition-all duration-150 ease-out"
             >
               {t('autopilot.wizard.next')} <ChevronRight size={13} />
             </Button>
@@ -645,7 +642,7 @@ function CreationWizard({ onDone, onCancel }: { onDone(ap: Autopilot): void; onC
               size="sm"
               loading={saving}
               onClick={() => void save()}
-              className="hover:glow-purple"
+              className="transition-all duration-150 ease-out"
             >
               {!saving && <Zap size={13} />} {t('autopilot.wizard.create')}
             </Button>

--- a/apps/tauri/src/renderer/routes/jobs.tsx
+++ b/apps/tauri/src/renderer/routes/jobs.tsx
@@ -27,6 +27,7 @@ import {
   Input,
   LocationInput,
   SelectDropdown,
+  SourceBadge,
   TextArea,
   useNotification,
 } from '@ajh/ui';
@@ -355,7 +356,7 @@ function Jobs() {
                 size="sm"
                 variant="glass"
                 onClick={() => setShowScrapeForm(!showScrapeForm)}
-                className="hover:glow-purple"
+                className="transition-all duration-150 ease-out"
               >
                 <Plus size={12} />
                 {t('jobs.scrapeJobs')}
@@ -711,7 +712,7 @@ function Jobs() {
                     onClick={() => void startScrape()}
                     disabled={scraping || !scrapeForm.query.trim()}
                     loading={scraping}
-                    className={!scraping && scrapeForm.query.trim() ? 'hover:glow-purple' : ''}
+                    className="transition-all duration-150 ease-out"
                   >
                     {!scraping && <Search size={12} />}
                     {scraping ? t('jobs.scraping') : t('jobs.startScrape')}
@@ -815,71 +816,92 @@ function PostingRow({
   };
 
   return (
-    <div className="glass-graphite glass-highlight flex items-center gap-4 rounded-xl p-4 transition-colors hover:bg-white/[0.02]">
-      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/5 text-[10px] uppercase tracking-wider text-brand-soft">
-        {posting.source.slice(0, 2)}
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2 text-sm font-medium text-foreground/90">
-          <span className="truncate">{posting.title}</span>
-          {posting.remote && (
-            <span className="rounded-full border border-emerald-400/20 bg-emerald-400/5 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-emerald-200/85">
-              {t('jobs.remote')}
-            </span>
-          )}
-          {/* Interaction indicators */}
-          {interactionTypes.has('applied') && (
-            <span className="rounded-full border border-purple-400/20 bg-purple-400/5 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-purple-200/85 flex items-center gap-1">
-              <CircleCheck size={8} /> {t('jobs.applied')}
-            </span>
-          )}
-          {interactionTypes.has('opened') && (
-            <span className="rounded-full border border-blue-400/20 bg-blue-400/5 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-blue-200/85 flex items-center gap-1">
-              <Eye size={8} /> {t('jobs.viewed')}
-            </span>
-          )}
-          {interactionTypes.has('bookmarked') && (
-            <span className="rounded-full border border-amber-400/20 bg-amber-400/5 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-amber-200/85 flex items-center gap-1">
-              <Bookmark size={8} /> {t('jobs.saved')}
-            </span>
-          )}
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={transition.normal}
+      className="relative group"
+    >
+      <div className="glass-graphite glass-highlight relative flex items-center gap-5 rounded-xl p-4 pl-5 transition-all duration-300 hover:bg-white/[0.03] hover:shadow-lg hover:shadow-brand/5 overflow-hidden">
+        {/* Subtle ambient glow for whole card */}
+        <div
+          className="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-out"
+          style={{
+            background:
+              'linear-gradient(135deg, rgba(168,85,247,0.12) 0%, rgba(99,102,241,0.08) 50%, rgba(168,85,247,0.12) 100%)',
+            filter: 'blur-xl',
+          }}
+        />
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-white/10 to-white/5 text-[11px] uppercase tracking-wider text-brand-soft font-semibold shadow-inner">
+          {posting.source.slice(0, 2)}
         </div>
-        <div className="mt-0.5 flex items-center gap-3 text-[11px] text-foreground/55">
-          <span className="flex items-center gap-1">
-            <Building2 size={11} /> {posting.company}
-          </span>
-          {posting.location && (
-            <span className="flex items-center gap-1">
-              <MapPin size={11} /> {posting.location}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground/95 tracking-tight">
+            <span className="truncate">{posting.title}</span>
+            {posting.remote && (
+              <span className="rounded-full border border-emerald-400/20 bg-emerald-400/5 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-emerald-200/85">
+                {t('jobs.remote')}
+              </span>
+            )}
+            {/* Interaction indicators */}
+            {interactionTypes.has('applied') && (
+              <span className="rounded-full border border-purple-400/20 bg-purple-400/5 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-purple-200/85 flex items-center gap-1">
+                <CircleCheck size={8} /> {t('jobs.applied')}
+              </span>
+            )}
+            {interactionTypes.has('opened') && (
+              <span className="rounded-full border border-blue-400/20 bg-blue-400/5 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-blue-200/85 flex items-center gap-1">
+                <Eye size={8} /> {t('jobs.viewed')}
+              </span>
+            )}
+            {interactionTypes.has('bookmarked') && (
+              <span className="rounded-full border border-amber-400/20 bg-amber-400/5 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-amber-200/85 flex items-center gap-1">
+                <Bookmark size={8} /> {t('jobs.saved')}
+              </span>
+            )}
+          </div>
+          <div className="mt-1 flex items-center gap-4 text-[11px]">
+            <span className="flex items-center gap-1.5 text-foreground/85">
+              <Building2 size={10} /> {posting.company}
             </span>
-          )}
-          <span className="text-foreground/35">· {posting.source}</span>
-          {posting.postedAt && (
-            <span className="text-foreground/35">· {formatRelativeTime(posting.postedAt)}</span>
-          )}
+            {posting.location && (
+              <span className="flex items-center gap-1.5 text-foreground/60">
+                <MapPin size={10} /> {posting.location}
+              </span>
+            )}
+            <SourceBadge source={posting.source} url={posting.url} />
+            {posting.postedAt && (
+              <span className="text-foreground/40">· {formatRelativeTime(posting.postedAt)}</span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <a
+            href={posting.url}
+            onClick={(e) => {
+              e.preventDefault();
+              void handleOpen();
+            }}
+            className="flex items-center gap-1.5 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/70 hover:text-foreground hover:bg-white/10 transition-all duration-200"
+          >
+            <ExternalLink size={10} /> {t('jobs.open')}
+          </a>
+          <Button
+            size="sm"
+            variant={canApply ? 'glass' : 'ghost'}
+            onClick={handleApply}
+            disabled={!canApply}
+            title={canApply ? '' : t('jobs.applyNotSupported')}
+            className={cn(
+              'transition-all duration-150 ease-out',
+              canApply ? '' : 'cursor-not-allowed'
+            )}
+          >
+            <Send size={11} /> {t('jobs.apply')}
+          </Button>
         </div>
       </div>
-      <a
-        href={posting.url}
-        onClick={(e) => {
-          e.preventDefault();
-          void handleOpen();
-        }}
-        className="flex items-center gap-1 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/70 hover:text-foreground transition-colors"
-      >
-        <ExternalLink size={11} /> {t('jobs.open')}
-      </a>
-      <Button
-        size="sm"
-        variant={canApply ? 'glass' : 'ghost'}
-        onClick={handleApply}
-        disabled={!canApply}
-        title={canApply ? '' : t('jobs.applyNotSupported')}
-        className={canApply ? 'hover:glow-purple' : 'cursor-not-allowed'}
-      >
-        <Send size={11} /> {t('jobs.apply')}
-      </Button>
-    </div>
+    </motion.div>
   );
 }
 
@@ -1099,7 +1121,7 @@ function ApplyDrawer({ posting, onClose }: { posting: Posting; onClose: () => vo
               onClick={() => void start()}
               disabled={running}
               loading={running}
-              className={!running ? 'hover:glow-purple' : ''}
+              className="transition-all duration-150 ease-out"
             >
               {!running && <Send size={14} />}
               {running ? t('jobs.applyDrawer.running') : t('jobs.applyDrawer.start')}

--- a/apps/tauri/src/renderer/routes/settings.tsx
+++ b/apps/tauri/src/renderer/routes/settings.tsx
@@ -9,7 +9,6 @@ import {
   Languages,
   Loader2,
   Lock,
-  RefreshCw,
   Shield,
   Sparkles,
   User,
@@ -19,7 +18,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 
-import { Button, GlassCard, IconBadge, Input, SectionLabel } from '@ajh/ui';
+import { Button, GlassCard, IconBadge, Input, RefreshButton, SectionLabel } from '@ajh/ui';
 
 import { PageTransition } from '@/components/layout/PageTransition';
 import { AccountsSettingsTab } from '@/features/settings/components/AccountsSettingsTab';
@@ -271,10 +270,9 @@ function UpdateSection() {
         </div>
 
         {status.state === 'idle' || status.state === 'not-available' || status.state === 'error' ? (
-          <Button variant="glass" size="sm" onClick={() => void check()} className="shrink-0 gap-2">
-            <RefreshCw size={12} />
+          <RefreshButton onRefresh={check} variant="glass" size={12} className="shrink-0 gap-2">
             {t('settings.update.checkNow')}
-          </Button>
+          </RefreshButton>
         ) : status.state === 'checking' ? (
           <div className="flex items-center gap-2 text-xs text-foreground/40">
             <Loader2 size={13} className="animate-spin" />
@@ -285,7 +283,7 @@ function UpdateSection() {
             variant="glass"
             size="sm"
             onClick={() => void download()}
-            className="gap-2 glow-subtle"
+            className="gap-2 ring-1 ring-brand/20"
           >
             <Download size={12} />
             {t('settings.update.download', { version: status.version })}
@@ -296,15 +294,14 @@ function UpdateSection() {
             {status.percent}%
           </div>
         ) : status.state === 'downloaded' ? (
-          <Button
+          <RefreshButton
+            onRefresh={install}
             variant="glass"
-            size="sm"
-            onClick={() => void install()}
-            className="gap-2 glow-subtle"
+            size={12}
+            className="gap-2 ring-1 ring-brand/20"
           >
-            <RefreshCw size={12} />
             {t('settings.update.install')}
-          </Button>
+          </RefreshButton>
         ) : null}
       </div>
 

--- a/apps/tauri/src/renderer/services/index.ts
+++ b/apps/tauri/src/renderer/services/index.ts
@@ -21,6 +21,7 @@ export * from './use-boards';
 export * from './use-conversations';
 export * from './use-credentials';
 export * from './use-documents';
+export * from './use-job-preferences';
 export * from './use-jobs';
 export * from './use-postings';
 export * from './use-privacy';

--- a/apps/tauri/src/renderer/services/query-client.ts
+++ b/apps/tauri/src/renderer/services/query-client.ts
@@ -43,6 +43,7 @@ export const keys = {
   jobs: { all: ['jobs'] as const, detail: (id: string) => ['jobs', id] as const },
   ai: { models: ['ai', 'models'] as const },
   documents: { all: ['documents'] as const },
+  jobPreferences: { all: ['jobPreferences'] as const },
   postings: {
     all: ['postings'] as const,
     interactions: (type?: string) => ['postings', 'interactions', type] as const,

--- a/apps/tauri/src/renderer/services/use-documents.ts
+++ b/apps/tauri/src/renderer/services/use-documents.ts
@@ -29,6 +29,15 @@ export const useRemoveDocument = () => {
   });
 };
 
+export const useSetDefaultDocument = () => {
+  const api = useAppClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.documents.setDefault(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: keys.documents.all }),
+  });
+};
+
 export const useExtractText = () => {
   const api = useAppClient();
   return useMutation({

--- a/apps/tauri/src/renderer/services/use-job-preferences.ts
+++ b/apps/tauri/src/renderer/services/use-job-preferences.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { JobPreferences } from '@ajh/shared';
+
+import { useAppClient } from '@/providers/AppClientProvider';
+
+import { keys } from './query-client';
+
+export const useJobPreferences = () => {
+  const api = useAppClient();
+  return useQuery({
+    queryKey: keys.jobPreferences.all,
+    queryFn: () => api.jobPreferences.get(),
+  });
+};
+
+export const useSetJobPreferences = () => {
+  const api = useAppClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (prefs: JobPreferences) => api.jobPreferences.set(prefs),
+    onSuccess: () => qc.invalidateQueries({ queryKey: keys.jobPreferences.all }),
+  });
+};

--- a/apps/tauri/src/renderer/store/preferences-schema.ts
+++ b/apps/tauri/src/renderer/store/preferences-schema.ts
@@ -1,47 +1,10 @@
 import { z } from 'zod';
 
-// Remote preference options
-export const RemotePreferenceSchema = z.enum(['remote', 'hybrid', 'on-site', 'any']);
-
-// Seniority levels
-export const SenioritySchema = z.enum([
-  'entry',
-  'junior',
-  'mid',
-  'senior',
-  'lead',
-  'principal',
-  'any',
-]);
-
 // Performance modes
 export const PerformanceModeSchema = z.enum(['low-memory', 'balanced', 'performance']);
 
 // Output tone options
 export const OutputToneSchema = z.enum(['professional', 'casual', 'formal', 'creative']);
-
-// Location preference
-export const LocationPreferenceSchema = z.object({
-  city: z.string().optional(),
-  country: z.string().optional(),
-  region: z.string().optional(),
-  radius: z.number().min(0).max(500).optional(), // km
-});
-
-// Tech stack item
-export const TechStackItemSchema = z.object({
-  name: z.string(),
-  category: z.enum(['language', 'framework', 'database', 'tool', 'other']),
-  proficiency: z.enum(['beginner', 'intermediate', 'advanced', 'expert']).optional(),
-});
-
-// Salary expectations
-export const SalaryExpectationSchema = z.object({
-  min: z.number().min(0).optional(),
-  max: z.number().min(0).optional(),
-  currency: z.string().default('USD'),
-  period: z.enum(['hourly', 'monthly', 'yearly']).default('yearly'),
-});
 
 // AI model preference
 export const AIModelPreferenceSchema = z.object({
@@ -96,13 +59,6 @@ export const PreferencesSchema = z.object({
   aiProviderConfig: AiProviderConfigSchema.optional(),
   outputTone: OutputToneSchema.default('professional'),
 
-  // Job Preferences
-  location: LocationPreferenceSchema.optional(),
-  remote: RemotePreferenceSchema.default('any'),
-  techStack: z.array(TechStackItemSchema).default([]),
-  seniority: SenioritySchema.default('any'),
-  salary: SalaryExpectationSchema.optional(),
-
   // Resume Preferences
   resume: ResumePreferenceSchema.optional(),
 
@@ -117,12 +73,7 @@ export const PreferencesSchema = z.object({
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
-export type RemotePreference = z.infer<typeof RemotePreferenceSchema>;
-export type Seniority = z.infer<typeof SenioritySchema>;
 export type PerformanceMode = z.infer<typeof PerformanceModeSchema>;
 export type OutputTone = z.infer<typeof OutputToneSchema>;
-export type LocationPreference = z.infer<typeof LocationPreferenceSchema>;
-export type TechStackItem = z.infer<typeof TechStackItemSchema>;
-export type SalaryExpectation = z.infer<typeof SalaryExpectationSchema>;
 export type AIModelPreference = z.infer<typeof AIModelPreferenceSchema>;
 export type ResumePreference = z.infer<typeof ResumePreferenceSchema>;

--- a/apps/tauri/src/renderer/store/preferences-store.ts
+++ b/apps/tauri/src/renderer/store/preferences-store.ts
@@ -39,9 +39,6 @@ const defaultPreferences: Preferences = {
   version: 1,
   language: 'en',
   outputTone: 'professional',
-  remote: 'any',
-  techStack: [],
-  seniority: 'any',
   performanceMode: 'balanced',
   onboardingCompleted: false,
   lastUpdated: new Date().toISOString(),
@@ -56,13 +53,6 @@ interface PreferencesActions {
   setActiveProvider: (provider: AiProvider) => void;
   setProviderSettings: (provider: AiProvider, settings: Partial<PerProviderSettings>) => void;
   setOutputTone: (outputTone: Preferences['outputTone']) => void;
-  setLocation: (location: Preferences['location']) => void;
-  setRemote: (remote: Preferences['remote']) => void;
-  setTechStack: (techStack: Preferences['techStack']) => void;
-  addTechStackItem: (item: Preferences['techStack'][number]) => void;
-  removeTechStackItem: (name: string) => void;
-  setSeniority: (seniority: Preferences['seniority']) => void;
-  setSalary: (salary: Preferences['salary']) => void;
   setResume: (resume: Preferences['resume']) => void;
   setPerformanceMode: (performanceMode: Preferences['performanceMode']) => void;
   setOnboardingComplete: () => void;
@@ -136,55 +126,6 @@ export const usePreferencesStore = create<PreferencesStore>()(
           lastUpdated: new Date().toISOString(),
         })),
 
-      setLocation: (location: Preferences['location']) =>
-        set((state) => ({
-          ...state,
-          location,
-          lastUpdated: new Date().toISOString(),
-        })),
-
-      setRemote: (remote: Preferences['remote']) =>
-        set((state) => ({
-          ...state,
-          remote,
-          lastUpdated: new Date().toISOString(),
-        })),
-
-      setTechStack: (techStack: Preferences['techStack']) =>
-        set((state) => ({
-          ...state,
-          techStack,
-          lastUpdated: new Date().toISOString(),
-        })),
-
-      addTechStackItem: (item: Preferences['techStack'][number]) =>
-        set((state) => ({
-          ...state,
-          techStack: [...state.techStack, item],
-          lastUpdated: new Date().toISOString(),
-        })),
-
-      removeTechStackItem: (name: string) =>
-        set((state) => ({
-          ...state,
-          techStack: state.techStack.filter((item) => item.name !== name),
-          lastUpdated: new Date().toISOString(),
-        })),
-
-      setSeniority: (seniority: Preferences['seniority']) =>
-        set((state) => ({
-          ...state,
-          seniority,
-          lastUpdated: new Date().toISOString(),
-        })),
-
-      setSalary: (salary: Preferences['salary']) =>
-        set((state) => ({
-          ...state,
-          salary,
-          lastUpdated: new Date().toISOString(),
-        })),
-
       setResume: (resume: Preferences['resume']) =>
         set((state) => ({
           ...state,
@@ -225,12 +166,7 @@ export const useLanguage = () => usePreferencesStore((state) => state.language);
 export const useAIModel = () => usePreferencesStore((state) => state.aiModel);
 export const useAiProviderConfig = () => usePreferencesStore((state) => state.aiProviderConfig);
 export const useOutputTone = () => usePreferencesStore((state) => state.outputTone);
-export const useLocation = () => usePreferencesStore((state) => state.location);
-export const useRemote = () => usePreferencesStore((state) => state.remote);
-export const useTechStack = () => usePreferencesStore((state) => state.techStack);
-export const useSeniority = () => usePreferencesStore((state) => state.seniority);
 export const useOnboardingCompleted = () =>
   usePreferencesStore((state) => state.onboardingCompleted);
-export const useSalary = () => usePreferencesStore((state) => state.salary);
 export const useResume = () => usePreferencesStore((state) => state.resume);
 export const usePerformanceMode = () => usePreferencesStore((state) => state.performanceMode);

--- a/apps/tauri/src/renderer/styles/globals.css
+++ b/apps/tauri/src/renderer/styles/globals.css
@@ -11,6 +11,7 @@ html,
 body,
 #root {
   height: 100%;
+  color-scheme: dark;
 }
 
 body {
@@ -49,14 +50,6 @@ html[data-performance-mode='low-memory'] {
   --blur-xl: 12px;
   --blur-2xl: 16px;
   --blur-3xl: 24px;
-}
-html[data-performance-mode='low-memory'] * {
-  /* Stop all CSS keyframe animations and transitions.
-     animation: none is used instead of animation-duration: 0.01ms because
-     near-zero durations cause infinite rapid looping on continuous animations
-     (e.g. CinematicBackground blobs), which produces a visible flash. */
-  animation: none !important;
-  transition: none !important;
 }
 html[data-performance-mode='low-memory'] body {
   /* Remove expensive radial gradient — flat colour is composited cheaply. */

--- a/apps/tauri/src/tauri-client.ts
+++ b/apps/tauri/src/tauri-client.ts
@@ -75,8 +75,14 @@ export function createTauriInvokeClient(): AppClient {
       list: () => invoke('documents_list'),
       import: (req) => invoke('documents_import', { req }),
       remove: (id) => invoke('documents_remove', { id }),
+      setDefault: (id) => invoke('documents_set_default', { id }),
       exportDocument: (request) => invoke('documents_export_document', { request }),
       exportAndSave: (request) => invoke('documents_export_and_save', { request }),
+    },
+
+    jobPreferences: {
+      get: () => invoke('job_preferences_get'),
+      set: (prefs) => invoke('job_preferences_set', { prefs }),
     },
 
     search: {

--- a/docs/MACOS_SIGNING.md
+++ b/docs/MACOS_SIGNING.md
@@ -1,0 +1,112 @@
+# macOS Build Configuration
+
+## Current Status: No Private APIs on macOS
+
+The app uses **standard macOS APIs** to avoid Apple Developer Program requirements and code signing complexity.
+
+## Platform-Specific Configuration
+
+### macOS
+
+- **Private APIs**: Disabled (`macOSPrivateApi: false`)
+- **Window decorations**: Standard macOS title bar
+- **Code signing**: Ad-hoc (no Apple Developer certificate required)
+- **Entitlements**: Not needed
+- **Distribution**: Can be distributed without Apple notarization
+
+### Windows & Linux
+
+- **Private APIs**: Enabled (via target-specific Cargo features)
+- **Window decorations**: Custom title bar with overlay style
+- **Code signing**: Standard platform signing (optional)
+
+## Technical Details
+
+### Cargo.toml Configuration
+
+```toml
+[dependencies]
+tauri = { version = "2", features = ["tray-icon", "image-ico", "image-png"] }
+
+[target.'cfg(windows)'.dependencies]
+tauri = { version = "2", features = ["macos-private-api"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tauri = { version = "2", features = ["macos-private-api"] }
+```
+
+### tauri.conf.json Configuration
+
+```json
+{
+  "app": {
+    "macOSPrivateApi": false,
+    "windows": [
+      {
+        "decorations": false,
+        "titleBarStyle": "Overlay"
+      }
+    ]
+  }
+}
+```
+
+**Note**: On macOS, `decorations: false` with `macOSPrivateApi: false` will use standard window decorations (native title bar).
+
+## Building for macOS
+
+### Local Development
+
+#### Intel (x86_64)
+
+```bash
+cd apps/tauri
+pnpm tauri build --target x86_64-apple-darwin
+```
+
+#### Apple Silicon (ARM64)
+
+```bash
+cd apps/tauri
+rustup target add aarch64-apple-darwin
+pnpm tauri build --target aarch64-apple-darwin
+```
+
+The resulting `.app` bundle can be opened directly on your Mac without any special signing.
+
+### CI/CD Builds
+
+The release workflow builds **separate artifacts** for both architectures and renames them with the version:
+
+- **Intel (x86_64)**: `AI-Job-Hunter-Assistant-{version}-intel.dmg`
+- **Apple Silicon (ARM64)**: `AI-Job-Hunter-Assistant-{version}-apple-silicon.dmg`
+
+Example for version 0.2.13:
+
+- `AI-Job-Hunter-Assistant-0.2.13-intel.dmg`
+- `AI-Job-Hunter-Assistant-0.2.13-apple-silicon.dmg`
+
+Both are uploaded to GitHub Releases. Users download the appropriate version for their Mac:
+
+- Intel Macs (2019 and earlier) → `intel` version
+- Apple Silicon Macs (M1/M2/M3 and later) → `apple-silicon` version
+
+**No Apple Developer secrets required** - builds use standard ad-hoc signing.
+
+## Future: Enabling Custom UI on macOS
+
+If you want custom window decorations on macOS in the future, you'll need to:
+
+1. Join Apple Developer Program ($99/year)
+2. Enable `macos-private-api` feature for macOS target
+3. Set `macOSPrivateApi: true` in tauri.conf.json
+4. Create entitlements.plist file
+5. Add Apple Developer certificate and notarization to CI workflow
+6. Configure code signing identity
+
+See the original commit history for the removed entitlements and workflow configuration if needed.
+
+## References
+
+- [Tauri macOS Private API](https://tauri.app/v2/guides/features/private-api/)
+- [Apple Developer Program](https://developer.apple.com/programs/)

--- a/packages/shared/src/ipc/contracts.ts
+++ b/packages/shared/src/ipc/contracts.ts
@@ -16,6 +16,7 @@ import type {
   AutopilotUpdate,
   DocumentImportRequest,
   HybridSearchRequest,
+  JobPreferences,
   MatchResumeRequest,
   ScrapeBoardRequest,
   ScrapeUrlRequest,
@@ -96,9 +97,11 @@ export interface IpcContract {
   documents: {
     list(): Promise<DocumentRecord[]>;
 
-    import(req: DocumentImportRequest): Promise<{ jobId: string }>;
+    import(req: DocumentImportRequest): Promise<{ id: string; success: boolean }>;
 
     remove(id: string): Promise<void>;
+
+    setDefault(id: string): Promise<void>;
 
     exportDocument(req: {
       text: string;
@@ -125,6 +128,12 @@ export interface IpcContract {
         targetLanguage?: string;
       };
     }): Promise<string>;
+  };
+
+  jobPreferences: {
+    get(): Promise<JobPreferences>;
+
+    set(prefs: JobPreferences): Promise<void>;
   };
 
   search: {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -172,8 +172,23 @@ export const AutopilotUpdateSchema = AutopilotCreateSchema.partial().extend({
 
 export const AutopilotIdSchema = z.object({ autopilotId: z.string().min(1) });
 
+export const TechStackItemSchema = z.object({
+  name: z.string().min(1),
+  category: z.string().min(1),
+});
+
+export const JobPreferencesSchema = z.object({
+  location: z.string().optional(),
+  remote: z.string().optional(),
+  seniority: z.string().optional(),
+  salaryMin: z.number().int().optional(),
+  salaryMax: z.number().int().optional(),
+  techStack: z.array(TechStackItemSchema).optional(),
+});
+
 export type AutopilotCreate = z.infer<typeof AutopilotCreateSchema>;
 export type AutopilotUpdate = z.infer<typeof AutopilotUpdateSchema>;
+export type JobPreferences = z.infer<typeof JobPreferencesSchema>;
 
 export type AiGenerateRequest = z.infer<typeof AiGenerateRequestSchema>;
 export type DocumentImportRequest = z.infer<typeof DocumentImportRequestSchema>;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -77,6 +77,7 @@ export interface DocumentRecord {
   language?: string;
   pages?: number;
   importedAt: number;
+  isDefault?: boolean;
 }
 
 export interface JobPosting {

--- a/packages/ui/src/components/ActionTile.tsx
+++ b/packages/ui/src/components/ActionTile.tsx
@@ -30,9 +30,8 @@ export function ActionTile({
   return (
     <GlassCard
       className={cn(
-        'group cursor-pointer transition-all duration-200',
-        'hover:scale-[1.02] hover:glow-subtle active:scale-[0.98]',
-        active && 'ring-1 ring-brand/40 glow-subtle',
+        'group cursor-pointer transition-all duration-150 ease-out',
+        active && 'ring-1 ring-brand/40',
         className
       )}
       onClick={onClick}
@@ -41,13 +40,13 @@ export function ActionTile({
         <Icon
           size={20}
           className={cn(
-            'transition-all duration-200 group-hover:scale-110 group-hover:rotate-3',
+            'transition-all duration-150 ease-out group-hover:rotate-3',
             active ? 'text-brand-soft' : 'text-foreground/50 group-hover:text-brand-soft'
           )}
         />
         {badge}
       </div>
-      <div className="text-sm font-medium text-foreground/80 transition-colors duration-200 group-hover:text-foreground">
+      <div className="text-sm font-medium text-foreground/80 transition-colors duration-150 ease-out group-hover:text-foreground">
         {label}
       </div>
       {description && <div className="mt-0.5 text-xs text-foreground/40">{description}</div>}

--- a/packages/ui/src/components/ErrorBoundary.tsx
+++ b/packages/ui/src/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
-import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 
-import { Button } from './Button';
+import { RefreshButton } from './RefreshButton';
 
 interface Props {
   children: ReactNode;
@@ -41,22 +41,25 @@ export class ErrorBoundary extends Component<Props, State> {
 
     if (this.props.fallback) return this.props.fallback(error, this.reset);
 
-    return (
-      <div className="flex h-full flex-col items-center justify-center gap-4 p-10 text-center">
-        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-red-500/10 ring-1 ring-red-500/20">
-          <AlertTriangle size={24} className="text-red-400/70" />
-        </div>
-        <div className="space-y-1">
-          <p className="text-sm font-medium text-foreground/70">Something went wrong</p>
-          <p className="max-w-xs text-xs text-foreground/40">
-            {error.message || 'An unexpected error occurred in this panel.'}
-          </p>
-        </div>
-        <Button variant="ghost" size="sm" onClick={this.reset}>
-          <RefreshCw size={13} />
-          Try again
-        </Button>
-      </div>
-    );
+    return <ErrorBoundaryFallback onReset={this.reset} error={error} />;
   }
+}
+
+function ErrorBoundaryFallback({ onReset, error }: { onReset: () => void; error: Error }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 p-10 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-red-500/10 ring-1 ring-red-500/20">
+        <AlertTriangle size={24} className="text-red-400/70" />
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground/70">Something went wrong</p>
+        <p className="max-w-xs text-xs text-foreground/40">
+          {error.message || 'An unexpected error occurred in this panel.'}
+        </p>
+      </div>
+      <RefreshButton onRefresh={onReset} size={13}>
+        Try again
+      </RefreshButton>
+    </div>
+  );
 }

--- a/packages/ui/src/components/ErrorState.tsx
+++ b/packages/ui/src/components/ErrorState.tsx
@@ -1,13 +1,13 @@
-import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 import { cn } from '../lib/cn';
-import { Button } from './Button';
+import { RefreshButton } from './RefreshButton';
 
 interface ErrorStateProps {
   title?: string;
   description?: string;
-  onRetry?: () => void;
+  onRetry?: () => void | Promise<void>;
   action?: ReactNode;
   className?: string;
 }
@@ -34,10 +34,9 @@ export function ErrorState({
         {description && <p className="max-w-xs text-xs text-foreground/40">{description}</p>}
       </div>
       {onRetry && (
-        <Button variant="ghost" size="sm" onClick={onRetry}>
-          <RefreshCw size={13} />
+        <RefreshButton onRefresh={onRetry} size={13}>
           Try again
-        </Button>
+        </RefreshButton>
       )}
       {action}
     </div>

--- a/packages/ui/src/components/GlassCard.tsx
+++ b/packages/ui/src/components/GlassCard.tsx
@@ -32,7 +32,7 @@ export function GlassCard({
         toneClass[tone],
         'p-5',
         highlight && 'glass-highlight',
-        glow && 'glow-subtle',
+        glow && 'ring-1 ring-brand/20',
         className
       )}
       {...rest}

--- a/packages/ui/src/components/OptionTile.tsx
+++ b/packages/ui/src/components/OptionTile.tsx
@@ -29,12 +29,10 @@ export function OptionTile({
     <motion.button
       type="button"
       onClick={onClick}
-      whileHover={{ scale: 1.02 }}
-      whileTap={{ scale: 0.98 }}
       className={cn(
         'relative flex flex-col items-center gap-2 rounded-xl border p-4 text-center transition-all duration-150',
         selected
-          ? 'border-brand-soft/50 bg-brand-soft/10 glow-subtle'
+          ? 'border-brand-soft/50 bg-brand-soft/10'
           : 'border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/10'
       )}
     >

--- a/packages/ui/src/components/RefreshButton.tsx
+++ b/packages/ui/src/components/RefreshButton.tsx
@@ -1,0 +1,54 @@
+import { RefreshCw } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from './Button';
+
+interface RefreshButtonProps {
+  onRefresh: () => void | Promise<void>;
+  size?: number;
+  variant?: 'ghost' | 'glass';
+  disabled?: boolean;
+  className?: string;
+  title?: string;
+  children?: React.ReactNode;
+}
+
+/**
+ * Reusable refresh button with spinning animation during async operations.
+ * Handles local loading state and disables during refresh.
+ */
+export function RefreshButton({
+  onRefresh,
+  size = 12,
+  variant = 'ghost',
+  disabled,
+  className,
+  title,
+  children,
+}: RefreshButtonProps) {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    if (refreshing || disabled) return;
+    setRefreshing(true);
+    try {
+      await onRefresh();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <Button
+      variant={variant}
+      size="sm"
+      onClick={handleRefresh}
+      disabled={disabled || refreshing}
+      className={className}
+      title={title}
+    >
+      <RefreshCw size={size} className={refreshing ? 'animate-spin' : ''} />
+      {children}
+    </Button>
+  );
+}

--- a/packages/ui/src/components/SourceBadge.tsx
+++ b/packages/ui/src/components/SourceBadge.tsx
@@ -1,0 +1,74 @@
+import { Briefcase, Globe, type LucideIcon } from 'lucide-react';
+import { motion } from 'motion/react';
+import type { ReactNode } from 'react';
+
+import { cn } from '../lib/cn';
+import { transition } from '../lib/motion';
+
+const PLATFORM_CONFIG: Record<string, { icon: LucideIcon; color: string; label: string }> = {
+  linkedin: {
+    icon: Globe,
+    color: '#0A66C2',
+    label: 'LinkedIn',
+  },
+  indeed: {
+    icon: Briefcase,
+    color: '#2557A7',
+    label: 'Indeed',
+  },
+  xing: {
+    icon: Globe,
+    color: '#006567',
+    label: 'XING',
+  },
+  glassdoor: {
+    icon: Briefcase,
+    color: '#0CAA41',
+    label: 'Glassdoor',
+  },
+};
+
+export interface SourceBadgeProps {
+  source: string;
+  url?: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+export function SourceBadge({ source, url, className, children }: SourceBadgeProps) {
+  const config = PLATFORM_CONFIG[source.toLowerCase()] || {
+    icon: Globe,
+    color: '#6366F1',
+    label: source,
+  };
+  const Icon = config.icon;
+
+  const handleClick = () => {
+    if (url) {
+      window.open(url, '_blank');
+    }
+  };
+
+  return (
+    <motion.div
+      transition={transition.fast}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold',
+        'backdrop-blur-md transition-all duration-150',
+        'hover:shadow-lg',
+        className
+      )}
+      style={{
+        backgroundColor: `${config.color}10`,
+        borderColor: `${config.color}30`,
+        color: config.color,
+      }}
+      onClick={handleClick}
+      title={`Scraped from ${config.label}`}
+    >
+      <Icon size={11} />
+      <span>{config.label}</span>
+      {children}
+    </motion.div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,9 +12,11 @@ export { IconBadge, type IconBadgeProps } from './components/IconBadge';
 export { IconText } from './components/IconText';
 export { Input, type InputProps } from './components/Input';
 export { LocationInput, type LocationInputProps } from './components/LocationInput';
+export { RefreshButton } from './components/RefreshButton';
 export { SectionHeader } from './components/SectionHeader';
 export { SectionLabel } from './components/SectionLabel';
 export { SelectDropdown } from './components/SelectDropdown';
+export { SourceBadge, type SourceBadgeProps } from './components/SourceBadge';
 export { TextArea, type TextAreaProps } from './components/TextArea';
 
 // ── Overlays & Modals ─────────────────────────────────────────────────────

--- a/packages/ui/src/stories/SourceBadge.stories.tsx
+++ b/packages/ui/src/stories/SourceBadge.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { SourceBadge } from '../components/SourceBadge';
+
+const meta = {
+  component: SourceBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    source: { control: 'text' },
+    url: { control: 'text' },
+  },
+} satisfies Meta<typeof SourceBadge>;
+export default meta;
+type Story = StoryObj<typeof SourceBadge>;
+
+export const Default: Story = {
+  args: { source: 'linkedin' },
+};
+
+export const AllPlatforms: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-3">
+      <SourceBadge source="linkedin" />
+      <SourceBadge source="indeed" />
+      <SourceBadge source="xing" />
+      <SourceBadge source="glassdoor" />
+      <SourceBadge source="greenhouse" />
+      <SourceBadge source="lever" />
+      <SourceBadge source="workday" />
+    </div>
+  ),
+};
+
+export const WithUrl: Story = {
+  args: {
+    source: 'linkedin',
+    url: 'https://linkedin.com',
+  },
+};
+
+export const UnknownPlatform: Story = {
+  args: { source: 'custom-platform' },
+};
+
+export const InContext: Story = {
+  render: () => (
+    <div className="space-y-3 w-80">
+      {[
+        { source: 'linkedin', title: 'Senior Frontend Engineer' },
+        { source: 'indeed', title: 'Full Stack Developer' },
+        { source: 'xing', title: 'Software Engineer' },
+        { source: 'glassdoor', title: 'Product Manager' },
+      ].map(({ source, title }) => (
+        <div key={title} className="glass-surface rounded-xl p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1">
+              <h3 className="text-sm font-semibold text-foreground/90">{title}</h3>
+              <p className="mt-1 text-xs text-foreground/50">Company Name</p>
+            </div>
+            <SourceBadge source={source} />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary
Migrates all job-related preferences (location, remote, seniority, salary, tech stack) from frontend Zustand store (localStorage) to Rust backend with SQLite persistence.
 
## Changes
- **Backend**: Created [job_preferences.rs](cci:7://file:///c:/Users/Saeed/Documents/js_projects/ai-job-hunter-assistant-app/apps/tauri/src-tauri/src/commands/job_preferences.rs:0:0-0:0) module with SQLite table and  with get/set methods
- **IPC**: Added [job_preferences_get](cci:1://file:///c:/Users/Saeed/Documents/js_projects/ai-job-hunter-assistant-app/apps/tauri/src-tauri/src/commands/job_preferences.rs:5:0-10:1) and [job_preferences_set](cci:1://file:///c:/Users/Saeed/Documents/js_projects/ai-job-hunter-assistant-app/apps/tauri/src-tauri/src/commands/job_preferences.rs:12:0-28:1) commands, registered in main.rs
- **Shared types**: Added  and [TechStackItem](cci:2://file:///c:/Users/Saeed/Documents/js_projects/ai-job-hunter-assistant-app/apps/tauri/src/renderer/store/preferences-schema.ts:117:0-117:64) types and Zod schemas
- **Clients**: Updated Tauri client, web HTTP client, and mock client
- **Frontend**: Created React Query hooks (, )
- **Components**: Updated all job preference components to use backend hooks
- **Cleanup**: Removed job preferences from frontend Zustand store and cleaned up unused type definitions
- **UI**: Slowed cursor blob animation for more ambient effect
 
## Files added
- 
- [apps/tauri/src-tauri/src/commands/job_preferences.rs](cci:7://file:///c:/Users/Saeed/Documents/js_projects/ai-job-hunter-assistant-app/apps/tauri/src-tauri/src/commands/job_preferences.rs:0:0-0:0)
- 