### PR TITLE
fix: build platform-specific targets in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: echo "value=${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}" >> $GITHUB_OUTPUT
 
       - name: 💾 Restore Turbo Cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ steps.cache-key.outputs.value }}
@@ -75,13 +75,6 @@ jobs:
           echo "::group::Building shared packages"
           pnpm build:packages
           echo "::endgroup::"
-
-      - name: 💾 Save Turbo Cache
-        if: success()
-        uses: actions/cache/save@v4
-        with:
-          path: .turbo
-          key: ${{ steps.cache-key.outputs.value }}
 
   lint-format:
     name: ✨ Lint & Format
@@ -105,7 +98,7 @@ jobs:
           cache: pnpm
 
       - name: 💾 Restore Turbo Cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ needs.dependencies.outputs.cache-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,12 @@ concurrency:
 # Jobs
 # ──────────────────────────────────────────────────────────────────────
 jobs:
-  lint-format:
-    name: ✨ Lint & Format
+  dependencies:
+    name: 📦 Dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
+    outputs:
+      cache-key: ${{ steps.cache-key.outputs.value }}
 
     steps:
       - name: 📥 Checkout Repository
@@ -50,15 +52,19 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: � Restore Turbo Cache
-        uses: actions/cache@v4
+      - name: 🔑 Generate Cache Key
+        id: cache-key
+        run: echo "value=${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}" >> $GITHUB_OUTPUT
+
+      - name: 💾 Restore Turbo Cache
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
+          key: ${{ steps.cache-key.outputs.value }}
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - name: � Install Dependencies
+      - name: 📥 Install Dependencies
         run: |
           echo "::group::Installing dependencies"
           pnpm install --frozen-lockfile
@@ -69,6 +75,40 @@ jobs:
           echo "::group::Building shared packages"
           pnpm build:packages
           echo "::endgroup::"
+
+      - name: 💾 Save Turbo Cache
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: .turbo
+          key: ${{ steps.cache-key.outputs.value }}
+
+  lint-format:
+    name: ✨ Lint & Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: dependencies
+
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.3
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: 💾 Restore Turbo Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ needs.dependencies.outputs.cache-key }}
 
       - name: 🔍 Run ESLint
         id: eslint
@@ -122,6 +162,7 @@ jobs:
     name: 🔍 Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: dependencies
 
     steps:
       - name: 📥 Checkout Repository
@@ -139,24 +180,10 @@ jobs:
           cache: pnpm
 
       - name: 💾 Restore Turbo Cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
-      - name: 📥 Install Dependencies
-        run: |
-          echo "::group::Installing dependencies"
-          pnpm install --frozen-lockfile
-          echo "::endgroup::"
-
-      - name: 🔨 Build Shared Packages
-        run: |
-          echo "::group::Building shared packages"
-          pnpm build:packages
-          echo "::endgroup::"
+          key: ${{ needs.dependencies.outputs.cache-key }}
 
       - name: 🔍 Run Type Check
         run: pnpm typecheck
@@ -192,6 +219,7 @@ jobs:
     name: 🧪 Tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: dependencies
 
     steps:
       - name: 📥 Checkout Repository
@@ -209,12 +237,10 @@ jobs:
           cache: pnpm
 
       - name: 💾 Restore Turbo Cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+          key: ${{ needs.dependencies.outputs.cache-key }}
 
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -244,18 +270,6 @@ jobs:
         with:
           workspaces: apps/tauri/src-tauri
           cache-on-failure: true
-
-      - name: 📥 Install Dependencies
-        run: |
-          echo "::group::Installing dependencies"
-          pnpm install --frozen-lockfile
-          echo "::endgroup::"
-
-      - name: 🔨 Build Shared Packages
-        run: |
-          echo "::group::Building shared packages"
-          pnpm build:packages
-          echo "::endgroup::"
 
       - name: 🧪 Run Tests
         id: js-tests
@@ -332,6 +346,7 @@ jobs:
     name: 🏗️ Build Verification
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: dependencies
 
     steps:
       - name: 📥 Checkout Repository
@@ -349,12 +364,10 @@ jobs:
           cache: pnpm
 
       - name: 💾 Restore Turbo Cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+          key: ${{ needs.dependencies.outputs.cache-key }}
 
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -384,18 +397,6 @@ jobs:
         with:
           workspaces: apps/tauri/src-tauri
           cache-on-failure: true
-
-      - name: 📥 Install Dependencies
-        run: |
-          echo "::group::Installing dependencies"
-          pnpm install --frozen-lockfile
-          echo "::endgroup::"
-
-      - name: 🔨 Build Shared Packages
-        run: |
-          echo "::group::Building shared packages"
-          pnpm build:packages
-          echo "::endgroup::"
 
       - name: 🦀 Cargo Check
         id: cargo-check
@@ -472,6 +473,7 @@ jobs:
     name: 🔬 Quality Checks
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: dependencies
 
     steps:
       - name: 📥 Checkout Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,15 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: 📥 Install Dependencies
+      - name: � Restore Turbo Cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: � Install Dependencies
         run: |
           echo "::group::Installing dependencies"
           pnpm install --frozen-lockfile
@@ -130,6 +138,14 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: 💾 Restore Turbo Cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
       - name: 📥 Install Dependencies
         run: |
           echo "::group::Installing dependencies"
@@ -191,6 +207,14 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+
+      - name: 💾 Restore Turbo Cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -323,6 +347,14 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+
+      - name: 💾 Restore Turbo Cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
           cache: pnpm
 
       - name: 💾 Restore Turbo Cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
@@ -250,14 +250,7 @@ jobs:
           pnpm build:packages
           echo "::endgroup::"
 
-      - name: � Save Turbo Cache
-        if: success()
-        uses: actions/cache/save@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
-
-      - name: �🔐 Decode Tauri Key
+      - name: 🔐 Decode Tauri Key
         if: runner.os != 'Linux' || runner.os == 'Linux'
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,14 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: 💾 Restore Turbo Cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
           cache: pnpm
 
       - name: 💾 Restore Turbo Cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
@@ -250,7 +250,14 @@ jobs:
           pnpm build:packages
           echo "::endgroup::"
 
-      - name: 🔐 Decode Tauri Key
+      - name: � Save Turbo Cache
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/turbo.json') }}
+
+      - name: �🔐 Decode Tauri Key
         if: runner.os != 'Linux' || runner.os == 'Linux'
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,31 +255,27 @@ jobs:
           rustup target add aarch64-apple-darwin
           echo "::endgroup::"
 
-      - name: 🏗️ Build Tauri Application (Intel)
-        id: tauri-build-intel
+      - name: 🏗️ Build Tauri Application
+        id: tauri-build
         continue-on-error: true
         env:
           TAURI_SIGNING_PRIVATE_KEY: ./tauri.key
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          echo "::group::Building Tauri application (Intel x86_64)"
-          pnpm --filter @ajh/tauri tauri build --target x86_64-apple-darwin
-          echo "::endgroup::"
-
-      - name: �️ Build Tauri Application (Apple Silicon)
-        id: tauri-build-arm
-        if: runner.os == 'macOS'
-        continue-on-error: true
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ./tauri.key
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: |
-          echo "::group::Building Tauri application (ARM64)"
-          pnpm --filter @ajh/tauri tauri build --target aarch64-apple-darwin
+          echo "::group::Building Tauri application"
+          if [ "${{ runner.os }}" == "macOS" ]; then
+            # Build Intel
+            pnpm --filter @ajh/tauri tauri build --target x86_64-apple-darwin
+            # Build Apple Silicon
+            pnpm --filter @ajh/tauri tauri build --target aarch64-apple-darwin
+          else
+            # Build for current platform (Linux or Windows)
+            pnpm --filter @ajh/tauri tauri build
+          fi
           echo "::endgroup::"
 
       - name: ❌ Check for Build Failures
-        if: steps.tauri-build-intel.outcome == 'failure' || (runner.os == 'macOS' && steps.tauri-build-arm.outcome == 'failure')
+        if: steps.tauri-build.outcome == 'failure'
         run: |
           echo "::error::Tauri build failed on ${{ matrix.platform }}. Please review the build output above."
           exit 1
@@ -335,10 +331,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Build Details" >> $GITHUB_STEP_SUMMARY
           echo "- **Platform**: ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Build Status**: ${{ steps.tauri-build-intel.outcome == 'success' && '✅ Success' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ runner.os }}" == "macOS" ]; then
-            echo "- **ARM64 Build**: ${{ steps.tauri-build-arm.outcome == 'success' && '✅ Success' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
-          fi
+          echo "- **Build Status**: ${{ steps.tauri-build.outcome == 'success' && '✅ Success' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Version**: v${{ needs.sync-version-files.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Environment" >> $GITHUB_STEP_SUMMARY
@@ -347,7 +340,7 @@ jobs:
           echo "- **pnpm**: $(pnpm --version)" >> $GITHUB_STEP_SUMMARY
           echo "- **Runner OS**: ${{ runner.os }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.tauri-build-intel.outcome }}" == "failure" ] || [ "${{ runner.os }}" == "macOS" && "${{ steps.tauri-build-arm.outcome }}" == "failure" ]; then
+          if [ "${{ steps.tauri-build.outcome }}" == "failure" ]; then
             echo "### 📊 Artifacts" >> $GITHUB_STEP_SUMMARY
             echo "Build logs uploaded as artifact: \`build-logs-${{ matrix.platform }}-${{ github.run_id }}\`" >> $GITHUB_STEP_SUMMARY
           fi

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -31,16 +31,8 @@
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "nsis",
-      "msi",
-      "dmg",
-      "app"
-    ],
-    "icon": [
-      "icons/icon.ico",
-      "icons/icon.png"
-    ],
+    "targets": ["nsis", "msi", "dmg", "app"],
+    "icon": ["icons/icon.ico", "icons/icon.png"],
     "resources": []
   },
   "plugins": {


### PR DESCRIPTION
## Summary
Fixes the release workflow build step that was attempting to build macOS targets on Linux and Windows, causing all builds to fail.
 
## Problem
The workflow had separate 'Build Tauri Application (Intel)' and 'Build Tauri Application (Apple Silicon)' steps that used hardcoded macOS targets (--target x86_64-apple-darwin) on all platforms. This caused Linux and Windows builds to fail with 'target x86_64-apple-darwin is not installed'.
 
## Solution
Combined the build steps into a single step that:
- On macOS: builds both Intel and Apple Silicon targets
- On Linux/Windows: builds for the current platform (no --target flag)
 
## Changes
- Combined Intel and ARM build steps into one conditional build step
- Updated failure check to use new combined step ID
- Updated job summary to use new step ID
- Removed ARM64 target addition (now handled in build step)