### PR TITLE
fix: enable auto-update detection with createUpdaterArtifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,20 +297,96 @@ jobs:
           fi
           echo "::endgroup::"
 
-      - name: 📤 Upload Release Assets
+      - name: � Generate latest.json
+        if: success()
+        shell: bash
+        run: |
+          echo "::group::Generating latest.json"
+          cd apps/tauri/src-tauri/target/release/bundle
+
+          # Collect signature files and URLs
+          VERSION="${{ needs.sync-version-files.outputs.version }}"
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          # Start JSON structure
+          cat > latest.json << EOF
+          {
+            "version": "$VERSION",
+            "notes": "See https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/tag/v$VERSION for details",
+            "pub_date": "$PUB_DATE",
+            "platforms": {
+          EOF
+
+          # Add Windows signatures if they exist
+          if [ -d "nsis" ] && ls nsis/*.sig 1> /dev/null 2>&1; then
+            SIG=$(cat nsis/*.sig | tr -d '\n')
+            echo '    "windows-x86_64": {' >> latest.json
+            echo "      \"signature\": \"$SIG\"," >> latest.json
+            echo "      \"url\": \"https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/download/v$VERSION/AI_Job_Hunter_Assistant_${VERSION}_x64-setup.exe\"" >> latest.json
+            echo '    },' >> latest.json
+          fi
+
+          if [ -d "msi" ] && ls msi/*.sig 1> /dev/null 2>&1; then
+            SIG=$(cat msi/*.sig | tr -d '\n')
+            echo '    "windows-x86_64-msi": {' >> latest.json
+            echo "      \"signature\": \"$SIG\"," >> latest.json
+            echo "      \"url\": \"https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/download/v$VERSION/AI_Job_Hunter_Assistant_${VERSION}_x64_en-US.msi\"" >> latest.json
+            echo '    },' >> latest.json
+          fi
+
+          # Add Linux signatures if they exist
+          if [ -d "appimage" ] && ls appimage/*.sig 1> /dev/null 2>&1; then
+            SIG=$(cat appimage/*.sig | tr -d '\n')
+            echo '    "linux-x86_64": {' >> latest.json
+            echo "      \"signature\": \"$SIG\"," >> latest.json
+            echo "      \"url\": \"https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/download/v$VERSION/AI-Job-Hunter-Assistant-${VERSION}-x86_64.AppImage\"" >> latest.json
+            echo '    },' >> latest.json
+          fi
+
+          # Add macOS signatures if they exist
+          if [ -d "../../x86_64-apple-darwin/release/bundle/dmg" ] && ls ../../x86_64-apple-darwin/release/bundle/dmg/*.sig 1> /dev/null 2>&1; then
+            SIG=$(cat ../../x86_64-apple-darwin/release/bundle/dmg/*.sig | tr -d '\n')
+            echo '    "darwin-x86_64": {' >> latest.json
+            echo "      \"signature\": \"$SIG\"," >> latest.json
+            echo "      \"url\": \"https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/download/v$VERSION/AI-Job-Hunter-Assistant-${VERSION}-intel.dmg\"" >> latest.json
+            echo '    },' >> latest.json
+          fi
+
+          if [ -d "../../aarch64-apple-darwin/release/bundle/dmg" ] && ls ../../aarch64-apple-darwin/release/bundle/dmg/*.sig 1> /dev/null 2>&1; then
+            SIG=$(cat ../../aarch64-apple-darwin/release/bundle/dmg/*.sig | tr -d '\n')
+            echo '    "darwin-aarch64": {' >> latest.json
+            echo "      \"signature\": \"$SIG\"," >> latest.json
+            echo "      \"url\": \"https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/download/v$VERSION/AI-Job-Hunter-Assistant-${VERSION}-apple-silicon.dmg\"" >> latest.json
+            echo '    },' >> latest.json
+          fi
+
+          # Close JSON (remove trailing comma and close)
+          sed -i '$ s/,$//' latest.json
+          echo '  }' >> latest.json
+          echo '}' >> latest.json
+
+          # Move to a consistent location
+          mv latest.json ../../../release/bundle/latest.json || true
+          echo "::endgroup::"
+
+      - name: Upload Release Assets
         if: success()
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.sync-version-files.outputs.version }}
           files: |
             apps/tauri/src-tauri/target/release/bundle/nsis/*.exe
+            apps/tauri/src-tauri/target/release/bundle/nsis/*.sig
             apps/tauri/src-tauri/target/release/bundle/msi/*.msi
+            apps/tauri/src-tauri/target/release/bundle/msi/*.sig
             apps/tauri/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
+            apps/tauri/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.sig
             apps/tauri/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+            apps/tauri/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.sig
             apps/tauri/src-tauri/target/release/bundle/deb/*.deb
             apps/tauri/src-tauri/target/release/bundle/rpm/*.rpm
             apps/tauri/src-tauri/target/release/bundle/appimage/*.AppImage
-            apps/tauri/src-tauri/target/release/bundle/*/*.sig
+            apps/tauri/src-tauri/target/release/bundle/appimage/*.sig
             apps/tauri/src-tauri/target/release/bundle/latest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -31,19 +31,9 @@
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "nsis",
-      "msi",
-      "dmg",
-      "app",
-      "deb",
-      "rpm",
-      "appimage"
-    ],
-    "icon": [
-      "icons/icon.ico",
-      "icons/icon.png"
-    ],
+    "createUpdaterArtifacts": true,
+    "targets": ["nsis", "msi", "dmg", "app", "deb", "rpm", "appimage"],
+    "icon": ["icons/icon.ico", "icons/icon.png"],
     "resources": []
   },
   "plugins": {

--- a/docs/UPDATER_SETUP.md
+++ b/docs/UPDATER_SETUP.md
@@ -1,23 +1,52 @@
 # Tauri Updater Setup Guide
 
-## Problem
+## Overview
 
-The updater is failing with two errors:
+The auto-updater is configured to automatically detect and install updates from GitHub releases. The setup uses Tauri v2's built-in updater plugin with signature verification for security.
 
-1. **"check failed: missing field 'signature'"** - When checking for updates
-2. **"invalid encoding in minisign data"** - When downloading updates
+## Current Configuration
 
-## Root Cause
+The updater is already configured in `apps/tauri/src-tauri/tauri.conf.json`:
 
-Tauri v2's updater plugin requires:
+```json
+{
+  "bundle": {
+    "createUpdaterArtifacts": true,
+    ...
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "YOUR_PUBLIC_KEY",
+      "endpoints": [
+        "https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/latest/download/latest.json"
+      ]
+    }
+  }
+}
+```
 
-1. A properly formatted `latest.json` file in GitHub releases
-2. `.sig` signature files for each platform installer
-3. The public key must match the private key used to sign releases
+## How It Works
 
-## Solution
+1. **Build Process**: When `createUpdaterArtifacts: true` is set, Tauri automatically generates:
+   - `.sig` signature files for each installer (MSI, NSIS, DMG, AppImage)
+   - These files contain cryptographic signatures of the installers
 
-### Step 1: Generate Signing Keys (One-Time Setup)
+2. **Release Workflow**: The GitHub Actions workflow:
+   - Builds the app for all platforms
+   - Collects the generated `.sig` files
+   - Constructs `latest.json` with version info, URLs, and signatures
+   - Uploads all artifacts to the GitHub release
+
+3. **Update Detection**: The app checks `latest.json` on startup and when manually triggered:
+   - Compares version in `latest.json` with current version
+   - If newer, shows update available
+   - Downloads and verifies signature before installing
+
+## Manual Setup (If Needed)
+
+### Generate Signing Keys
+
+If you need to regenerate the signing keys (only do this if the private key is lost):
 
 ```bash
 # Install tauri-cli if not already installed
@@ -34,190 +63,56 @@ tauri signer generate -w ~/.tauri/myapp.key
 
 **Important:** Save the private key securely! You'll need it for every release.
 
-### Step 2: Update tauri.conf.json
+## GitHub Secrets Configuration
 
-Replace the `pubkey` in `apps/tauri/src-tauri/tauri.conf.json` with your new public key:
+The release workflow requires these secrets in your GitHub repository settings:
 
-```json
-{
-  "plugins": {
-    "updater": {
-      "pubkey": "YOUR_NEW_PUBLIC_KEY_HERE",
-      "endpoints": [
-        "https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/latest/download/latest.json"
-      ]
-    }
-  }
-}
-```
+- `TAURI_SIGNING_PRIVATE_KEY_BASE64` - Base64-encoded content of your private key file
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` - Password if you set one (optional)
 
-### Step 3: Sign Your Releases
-
-When building for release, sign each platform installer:
+To encode your private key:
 
 ```bash
-# Build the app
+base64 -i ~/.tauri/myapp.key
+# Copy the output and add it as TAURI_SIGNING_PRIVATE_KEY_BASE64 in GitHub secrets
+```
+
+## Testing Updates Locally
+
+To test the updater without releasing:
+
+1. Build the app locally with signing:
+
+```bash
+export TAURI_SIGNING_PRIVATE_KEY="~/.tauri/myapp.key"
 pnpm tauri build
-
-# Sign each installer (do this for EVERY platform)
-# Windows (.msi)
-tauri signer sign \
-  "apps/tauri/src-tauri/target/release/bundle/msi/AI Job Hunter Assistant_1.3.1_x64_en-US.msi" \
-  -k ~/.tauri/myapp.key
-
-# Windows (.exe)
-tauri signer sign \
-  "apps/tauri/src-tauri/target/release/bundle/nsis/AI Job Hunter Assistant_1.3.1_x64-setup.exe" \
-  -k ~/.tauri/myapp.key
-
-# macOS (.dmg)
-tauri signer sign \
-  "apps/tauri/src-tauri/target/release/bundle/dmg/AI Job Hunter Assistant_1.3.1_x64.dmg" \
-  -k ~/.tauri/myapp.key
-
-# macOS (.app)
-tauri signer sign \
-  "apps/tauri/src-tauri/target/release/bundle/macos/AI Job Hunter Assistant.app" \
-  -k ~/.tauri/myapp.key
 ```
 
-This creates `.sig` files next to each installer:
+2. Manually create a `latest.json` in your test location with a higher version
+3. Point the updater endpoint to your test location
+4. Run the app and check for updates
 
-- `AI Job Hunter Assistant_1.3.1_x64_en-US.msi.sig`
-- `AI Job Hunter Assistant_1.3.1_x64-setup.exe.sig`
-- etc.
+## Troubleshooting
 
-### Step 4: Create latest.json
+### "Update check failed: missing field 'signature'"
 
-Create a `latest.json` file with this format:
+- Ensure `createUpdaterArtifacts: true` is set in `tauri.conf.json`
+- Verify the build completed successfully and generated `.sig` files
+- Check that `latest.json` contains the signature field for your platform
 
-```json
-{
-  "version": "1.3.1",
-  "notes": "Release notes go here",
-  "pub_date": "2026-05-22T09:00:00Z",
-  "platforms": {
-    "windows-x86_64": {
-      "signature": "CONTENT_OF_MSI_SIG_FILE",
-      "url": "https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/download/v1.3.1/AI_Job_Hunter_Assistant_1.3.1_x64_en-US.msi"
-    },
-    "darwin-x86_64": {
-      "signature": "CONTENT_OF_DMG_SIG_FILE",
-      "url": "https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/download/v1.3.1/AI_Job_Hunter_Assistant_1.3.1_x64.dmg"
-    },
-    "darwin-aarch64": {
-      "signature": "CONTENT_OF_AARCH64_DMG_SIG_FILE",
-      "url": "https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/download/v1.3.1/AI_Job_Hunter_Assistant_1.3.1_aarch64.dmg"
-    }
-  }
-}
-```
+### "Update check failed: No releases found"
 
-**To get signature content:**
+- Verify the GitHub release exists and is published (not draft)
+- Check that `latest.json` is uploaded to the release assets
+- Ensure the endpoint URL in `tauri.conf.json` is correct
 
-```bash
-cat "AI Job Hunter Assistant_1.3.1_x64_en-US.msi.sig"
-# Copy the entire output into the "signature" field
-```
+### "Download failed: Signature verification failed"
 
-### Step 5: Upload to GitHub Release
-
-1. Create a new GitHub release (e.g., `v1.3.1`)
-2. Upload ALL files:
-   - `AI Job Hunter Assistant_1.3.1_x64_en-US.msi`
-   - `AI Job Hunter Assistant_1.3.1_x64_en-US.msi.sig`
-   - `AI Job Hunter Assistant_1.3.1_x64-setup.exe`
-   - `AI Job Hunter Assistant_1.3.1_x64-setup.exe.sig`
-   - `AI Job Hunter Assistant_1.3.1_x64.dmg`
-   - `AI Job Hunter Assistant_1.3.1_x64.dmg.sig`
-   - `latest.json`
-3. Publish the release
-
-## Alternative: Disable Signature Verification (NOT RECOMMENDED)
-
-If you want to disable signature verification for testing:
-
-```json
-{
-  "plugins": {
-    "updater": {
-      "pubkey": "",
-      "endpoints": [
-        "https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/latest/download/latest.json"
-      ]
-    }
-  }
-}
-```
-
-**Warning:** This makes your app vulnerable to man-in-the-middle attacks!
-
-## Automated Release Script
-
-Create `.github/workflows/release.yml`:
-
-```yaml
-name: Release
-
-on:
-  push:
-    tags:
-      - 'v*'
-
-jobs:
-  release:
-    strategy:
-      matrix:
-        platform: [macos-latest, ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build Tauri app
-        run: pnpm tauri build
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-
-      - name: Upload Release Assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            apps/tauri/src-tauri/target/release/bundle/**/*.msi
-            apps/tauri/src-tauri/target/release/bundle/**/*.exe
-            apps/tauri/src-tauri/target/release/bundle/**/*.dmg
-            apps/tauri/src-tauri/target/release/bundle/**/*.app
-            apps/tauri/src-tauri/target/release/bundle/**/*.sig
-```
-
-Add secrets to GitHub repository settings:
-
-- `TAURI_SIGNING_PRIVATE_KEY` - Content of `~/.tauri/myapp.key`
-- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` - Password if you set one
-
-## Testing
-
-```bash
-# Test update check locally
-pnpm tauri dev
-
-# In the app, go to Settings → Check for Updates
-```
+- The public key in `tauri.conf.json` doesn't match the private key used for signing
+- The `.sig` file may be corrupted or missing
+- Rebuild the release with the correct signing key
 
 ## References
 
 - [Tauri Updater Plugin Docs](https://v2.tauri.app/plugin/updater/)
 - [Tauri Signer CLI](https://v2.tauri.app/reference/cli/#signer)
-- [GitHub Actions for Tauri](https://tauri.app/v1/guides/building/cross-platform/)


### PR DESCRIPTION
## Problem
The auto-updater was not detecting new releases even when a newer version was available on GitHub. Users checking for updates would see "latest version" regardless of actual release status.

## Root Cause
The `createUpdaterArtifacts` configuration was missing from \[tauri.conf.json\](cci:9://file:///apps/tauri/src-tauri/tauri.conf.json:0:0-0:0). This setting is required for Tauri v2 to automatically generate:
- `.sig` signature files for each platform installer
- Proper update metadata for version comparison

Without this, the build process didn't create the required update artifacts, so the updater couldn't detect new releases.

## Changes

### 1. apps/tauri/src-tauri/tauri.conf.json
- Added `"createUpdaterArtifacts": true` to the bundle section
- Enables automatic generation of signature files during build

### 2. .github/workflows/release.yml
- Added step to generate `latest.json` after build
- Collects signatures from generated `.sig` files
- Constructs proper JSON with version info, URLs, and signatures for all platforms
- Updated artifact upload paths to explicitly include `.sig` files:
  - Windows: nsis/*.sig, msi/*.sig
  - macOS: x86_64-apple-darwin/dmg/*.sig, aarch64-apple-darwin/dmg/*.sig
  - Linux: appimage/*.sig

### 3. docs/UPDATER_SETUP.md
- Updated documentation to reflect the new automated workflow
- Removed manual signing steps (now handled by createUpdaterArtifacts)
- Added troubleshooting section for common errors
- Added GitHub secrets configuration instructions

## Testing
After this merge, the next release will automatically generate proper update artifacts. Users will be able to detect and install updates correctly via Settings → Check for Updates.