### PR TITLE
feat: export resume & cover letter from resumes page with format/template picker

### DIFF
--- a/apps/tauri/src-tauri/src/ai_generations/mod.rs
+++ b/apps/tauri/src-tauri/src/ai_generations/mod.rs
@@ -1,0 +1,154 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiGenerationRecord {
+    pub id: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: u64,
+    // GenerationMeta fields
+    #[serde(rename = "candidateName")]
+    pub candidate_name: String,
+    #[serde(rename = "jobTitle")]
+    pub job_title: String,
+    #[serde(rename = "companyName")]
+    pub company_name: String,
+    #[serde(rename = "resumeLanguage")]
+    pub resume_language: String,
+    #[serde(rename = "jobAdLanguage")]
+    pub job_ad_language: String,
+    #[serde(rename = "targetLanguage")]
+    pub target_language: String,
+    pub mismatch: bool,
+    #[serde(rename = "topRequirements")]
+    pub top_requirements: Vec<String>, // stored as JSON
+    // Generation settings
+    pub mode: String,
+    // Content
+    #[serde(rename = "resumeText")]
+    pub resume_text: String,
+    #[serde(rename = "coverLetterText")]
+    pub cover_letter_text: String,
+    #[serde(rename = "jobAd")]
+    pub job_ad: String,
+}
+
+pub struct AiGenerationStore {
+    conn: Mutex<Connection>,
+}
+
+impl AiGenerationStore {
+    pub fn open(data_dir: &PathBuf) -> Result<Self, String> {
+        std::fs::create_dir_all(data_dir).map_err(|e| e.to_string())?;
+        let path = data_dir.join("ai_generations.db");
+        let conn = Connection::open(&path).map_err(|e| e.to_string())?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS ai_generations (
+                id                TEXT PRIMARY KEY,
+                created_at        INTEGER NOT NULL,
+                candidate_name    TEXT NOT NULL DEFAULT '',
+                job_title         TEXT NOT NULL DEFAULT '',
+                company_name      TEXT NOT NULL DEFAULT '',
+                resume_language   TEXT NOT NULL DEFAULT 'en',
+                job_ad_language   TEXT NOT NULL DEFAULT 'en',
+                target_language   TEXT NOT NULL DEFAULT 'en',
+                mismatch          INTEGER NOT NULL DEFAULT 0,
+                top_requirements  TEXT NOT NULL DEFAULT '[]',
+                mode              TEXT NOT NULL DEFAULT 'ats',
+                resume_text       TEXT NOT NULL DEFAULT '',
+                cover_letter_text TEXT NOT NULL DEFAULT '',
+                job_ad            TEXT NOT NULL DEFAULT ''
+            );",
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(Self { conn: Mutex::new(conn) })
+    }
+
+    pub fn list(&self) -> Vec<AiGenerationRecord> {
+        let conn = self.conn.lock().unwrap();
+        conn.prepare(
+            "SELECT id, created_at, candidate_name, job_title, company_name,
+                    resume_language, job_ad_language, target_language, mismatch,
+                    top_requirements, mode, resume_text, cover_letter_text, job_ad
+             FROM ai_generations ORDER BY created_at DESC",
+        )
+        .ok()
+        .and_then(|mut stmt| {
+            stmt.query_map([], |row| {
+                let top_req_json: String = row.get(9)?;
+                Ok(AiGenerationRecord {
+                    id: row.get(0)?,
+                    created_at: row.get::<_, i64>(1)? as u64,
+                    candidate_name: row.get(2)?,
+                    job_title: row.get(3)?,
+                    company_name: row.get(4)?,
+                    resume_language: row.get(5)?,
+                    job_ad_language: row.get(6)?,
+                    target_language: row.get(7)?,
+                    mismatch: row.get::<_, i64>(8)? != 0,
+                    top_requirements: serde_json::from_str(&top_req_json).unwrap_or_default(),
+                    mode: row.get(10)?,
+                    resume_text: row.get(11)?,
+                    cover_letter_text: row.get(12)?,
+                    job_ad: row.get(13)?,
+                })
+            })
+            .ok()
+            .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        })
+        .unwrap_or_default()
+    }
+
+    pub fn insert(&self, rec: &AiGenerationRecord) -> Result<(), String> {
+        let top_req_json = serde_json::to_string(&rec.top_requirements).unwrap_or_default();
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO ai_generations
+             (id, created_at, candidate_name, job_title, company_name,
+              resume_language, job_ad_language, target_language, mismatch,
+              top_requirements, mode, resume_text, cover_letter_text, job_ad)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)",
+            params![
+                rec.id,
+                rec.created_at as i64,
+                rec.candidate_name,
+                rec.job_title,
+                rec.company_name,
+                rec.resume_language,
+                rec.job_ad_language,
+                rec.target_language,
+                rec.mismatch as i64,
+                top_req_json,
+                rec.mode,
+                rec.resume_text,
+                rec.cover_letter_text,
+                rec.job_ad,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn remove(&self, id: &str) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM ai_generations WHERE id = ?1", params![id])
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+pub fn make_generation_id() -> String {
+    format!("gen-{}-{}", now_ms(), &Uuid::new_v4().to_string()[..8])
+}

--- a/apps/tauri/src-tauri/src/commands/ai_generations.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_generations.rs
@@ -1,0 +1,50 @@
+use serde_json::{json, Value};
+use tauri::{AppHandle, Manager};
+
+#[tauri::command]
+pub async fn ai_generations_list(app: AppHandle) -> Value {
+    let store = app.state::<crate::ai_generations::AiGenerationStore>();
+    serde_json::to_value(store.list()).unwrap_or(json!([]))
+}
+
+#[tauri::command]
+pub async fn ai_generations_save(app: AppHandle, req: Value) -> Value {
+    let store = app.state::<crate::ai_generations::AiGenerationStore>();
+
+    let top_requirements: Vec<String> = req
+        .get("topRequirements")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+
+    let rec = crate::ai_generations::AiGenerationRecord {
+        id: crate::ai_generations::make_generation_id(),
+        created_at: crate::ai_generations::now_ms(),
+        candidate_name: req.get("candidateName").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+        job_title: req.get("jobTitle").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+        company_name: req.get("companyName").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+        resume_language: req.get("resumeLanguage").and_then(|v| v.as_str()).unwrap_or("en").to_string(),
+        job_ad_language: req.get("jobAdLanguage").and_then(|v| v.as_str()).unwrap_or("en").to_string(),
+        target_language: req.get("targetLanguage").and_then(|v| v.as_str()).unwrap_or("en").to_string(),
+        mismatch: req.get("mismatch").and_then(|v| v.as_bool()).unwrap_or(false),
+        top_requirements,
+        mode: req.get("mode").and_then(|v| v.as_str()).unwrap_or("ats").to_string(),
+        resume_text: req.get("resumeText").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+        cover_letter_text: req.get("coverLetterText").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+        job_ad: req.get("jobAd").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+    };
+
+    match store.insert(&rec) {
+        Ok(()) => json!({ "id": rec.id, "success": true }),
+        Err(e) => json!({ "error": e }),
+    }
+}
+
+#[tauri::command]
+pub async fn ai_generations_remove(app: AppHandle, id: String) -> Value {
+    let store = app.state::<crate::ai_generations::AiGenerationStore>();
+    match store.remove(&id) {
+        Ok(()) => json!({ "success": true }),
+        Err(e) => json!({ "error": e }),
+    }
+}

--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 // Tauri command implementations organized by domain
 
+pub mod ai_generations;
 pub mod system;
 pub mod ai;
 pub mod scrape;

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::double_ended_iterator_last)]
 #![allow(clippy::wrong_self_convention)]
 
+mod ai_generations;
 mod autopilot;
 mod autopilot_helpers;
 mod apply_helpers;
@@ -145,6 +146,10 @@ fn main() {
             match documents::DocumentStore::open(&data_dir) {
                 Ok(store) => { app.manage(store); }
                 Err(e) => eprintln!("[setup] document store failed to open (non-fatal): {e}"),
+            }
+            match ai_generations::AiGenerationStore::open(&data_dir) {
+                Ok(store) => { app.manage(store); }
+                Err(e) => eprintln!("[setup] ai generations store failed to open (non-fatal): {e}"),
             }
             match job_preferences::JobPreferencesStore::open(&data_dir) {
                 Ok(store) => { app.manage(store); }
@@ -288,6 +293,10 @@ fn main() {
             commands::autopilot::autopilot_run,
             commands::autopilot::autopilot_pause,
             commands::autopilot::autopilot_resume,
+            // ai generations
+            commands::ai_generations::ai_generations_list,
+            commands::ai_generations::ai_generations_save,
+            commands::ai_generations::ai_generations_remove,
             // export
             export::commands::documents_export_document,
             export::commands::documents_export_and_save,

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelGenerating.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelGenerating.tsx
@@ -46,8 +46,8 @@ export function OutputPanelGenerating({
           <motion.div
             className="h-full rounded-full bg-gradient-to-r from-brand to-primary"
             initial={{ width: '0%' }}
-            animate={{ width: '90%' }}
-            transition={transition.fakeProgressSlow}
+            animate={{ width: streamBuffer.length > 0 ? '90%' : '0%' }}
+            transition={streamBuffer.length > 0 ? transition.fakeProgressSlow : { duration: 0 }}
           />
         </div>
       </div>

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -686,7 +686,27 @@
     "tabs": {
       "applied": "Beworben",
       "viewed": "Angesehen",
-      "bookmarked": "Gespeichert"
+      "bookmarked": "Gespeichert",
+      "generated": "Generiert"
+    },
+    "generated": {
+      "noGenerationsYet": "Noch keine KI-generierten Dokumente",
+      "noGenerationsDesc": "Generiere einen angepassten Lebenslauf oder ein Anschreiben, um es hier zu sehen.",
+      "resume": "Lebenslauf",
+      "coverLetter": "Anschreiben",
+      "mode": "Modus",
+      "requirements": "Top-Anforderungen",
+      "jobAd": "Stellenanzeige",
+      "viewJobAd": "Stellenanzeige anzeigen",
+      "copyResume": "Lebenslauf kopieren",
+      "copyCoverLetter": "Anschreiben kopieren",
+      "copied": "Kopiert",
+      "delete": "Löschen",
+      "noResume": "Kein Lebenslauf generiert",
+      "noCoverLetter": "Kein Anschreiben generiert",
+      "export": "Exportieren",
+      "exportResume": "Lebenslauf",
+      "exportCoverLetter": "Anschreiben"
     },
     "relativeTime": {
       "justNow": "Gerade eben",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -686,7 +686,27 @@
     "tabs": {
       "applied": "Applied",
       "viewed": "Viewed",
-      "bookmarked": "Bookmarked"
+      "bookmarked": "Bookmarked",
+      "generated": "Generated"
+    },
+    "generated": {
+      "noGenerationsYet": "No AI-generated documents yet",
+      "noGenerationsDesc": "Generate a tailored resume or cover letter to see it here.",
+      "resume": "Resume",
+      "coverLetter": "Cover Letter",
+      "mode": "Mode",
+      "requirements": "Top requirements",
+      "jobAd": "Job Ad",
+      "viewJobAd": "View job ad",
+      "copyResume": "Copy resume",
+      "copyCoverLetter": "Copy cover letter",
+      "copied": "Copied",
+      "delete": "Delete",
+      "noResume": "No resume generated",
+      "noCoverLetter": "No cover letter generated",
+      "export": "Export",
+      "exportResume": "Resume",
+      "exportCoverLetter": "Cover Letter"
     },
     "relativeTime": {
       "justNow": "Just now",

--- a/apps/tauri/src/renderer/lib/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client.ts
@@ -64,6 +64,12 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       listProviderModels: emptyList,
     },
 
+    aiGenerations: {
+      list: emptyList,
+      save: noop,
+      remove: noop,
+    },
+
     documents: {
       list: emptyList,
       import: noop,

--- a/apps/tauri/src/renderer/lib/web-http-client/index.ts
+++ b/apps/tauri/src/renderer/lib/web-http-client/index.ts
@@ -64,6 +64,11 @@ import type { WebHttpClientOptions } from './utils.js';
 
 export function createWebHttpClient(opts: WebHttpClientOptions): AppClient {
   return {
+    aiGenerations: {
+      list: async () => [],
+      save: async () => ({ id: '', success: true }),
+      remove: async () => undefined,
+    } as AppClient['aiGenerations'],
     system: system(opts) as AppClient['system'],
     jobs: jobs(opts) as AppClient['jobs'],
     ai: ai(opts) as AppClient['ai'],

--- a/apps/tauri/src/renderer/routes/ai-generate.tsx
+++ b/apps/tauri/src/renderer/routes/ai-generate.tsx
@@ -42,6 +42,7 @@ import { useTranslation } from '@/lib/i18n';
 import { transition } from '@/lib/motion';
 import { useAIModels, useExtractText } from '@/services';
 import { keys } from '@/services/query-client';
+import { useSaveAiGeneration } from '@/services/use-ai-generations';
 import { useAIModel, usePreferencesStore } from '@/store/preferences-store';
 import type { Model } from '@/types';
 
@@ -188,6 +189,9 @@ function AIGeneratePage() {
     const controller = new AbortController();
     abortControllerRef.current = controller;
 
+    let finalResume = '';
+    let finalCover = '';
+
     try {
       if (target === 'resume' || target === 'both') {
         setActiveOut('resume');
@@ -199,6 +203,7 @@ function AIGeneratePage() {
           mode,
           aiModel.defaultModel,
           (tok) => {
+            finalResume += tok;
             setResumeOut((p) => p + tok);
             setStreamBuffer((p) => (p + tok).slice(-600));
           },
@@ -217,6 +222,7 @@ function AIGeneratePage() {
           mode,
           aiModel.defaultModel,
           (tok) => {
+            finalCover += tok;
             setCoverOut((p) => p + tok);
             setStreamBuffer((p) => (p + tok).slice(-600));
           },
@@ -229,6 +235,21 @@ function AIGeneratePage() {
       setStreamBuffer('');
       setStage('done');
       setActiveOut(target === 'cover' ? 'cover' : 'resume');
+
+      void saveAiGeneration.mutate({
+        candidateName: meta.candidateName,
+        jobTitle: meta.jobTitle,
+        companyName: meta.companyName,
+        resumeLanguage: meta.resumeLanguage,
+        jobAdLanguage: meta.jobAdLanguage,
+        targetLanguage: meta.targetLanguage,
+        mismatch: meta.mismatch,
+        topRequirements: meta.topRequirements,
+        mode,
+        resumeText: finalResume,
+        coverLetterText: finalCover,
+        jobAd,
+      });
     } catch (err) {
       stopStageRotation();
       setError(err instanceof Error ? err.message : t('aiGenerate.errors.generationFailed'));
@@ -292,6 +313,8 @@ function AIGeneratePage() {
       exportTXT(text, name);
     }
   };
+
+  const saveAiGeneration = useSaveAiGeneration();
 
   const isGenerating = stage === 'generating';
 

--- a/apps/tauri/src/renderer/routes/resumes.tsx
+++ b/apps/tauri/src/renderer/routes/resumes.tsx
@@ -1,25 +1,42 @@
 import {
   Bookmark,
   Building2,
+  Calendar,
+  ChevronDown,
   Clock,
+  Copy,
+  Download,
   ExternalLink,
   Eye,
+  FileText,
+  Loader2,
   MapPin,
   RefreshCw,
   Search,
   Send,
+  Trash2,
+  Wand2,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useMemo, useState } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 
+import type { AiGenerationRecord } from '@ajh/shared/ipc';
 import { Button, CardSkeleton, EmptyState, Input } from '@ajh/ui';
 
 import { PageHeader } from '@/components/layout/PageHeader';
 import { PageTransition } from '@/components/layout/PageTransition';
 import { cn } from '@/lib/cn';
+import {
+  buildFilename,
+  exportDOCX,
+  exportPDF,
+  exportTXT,
+  type TemplateId,
+} from '@/lib/generate-ai';
 import { useTranslation } from '@/lib/i18n';
 import { stagger, transition } from '@/lib/motion';
+import { useAiGenerations, useRemoveAiGeneration } from '@/services/use-ai-generations';
 import { useInteractions } from '@/services/use-postings';
 import { useOpenExternal } from '@/services/use-system';
 
@@ -36,7 +53,7 @@ interface Interaction {
   location: string;
 }
 
-type Tab = 'applied' | 'viewed' | 'bookmarked';
+type Tab = 'applied' | 'viewed' | 'bookmarked' | 'generated';
 
 const TAB_CONFIG = [
   {
@@ -60,6 +77,13 @@ const TAB_CONFIG = [
     color: 'text-amber-300',
     ringColor: 'border-amber-400/30 bg-amber-400/10',
   },
+  {
+    id: 'generated' as Tab,
+    labelKey: 'resumes.tabs.generated',
+    icon: Wand2,
+    color: 'text-brand-soft',
+    ringColor: 'border-brand/30 bg-brand/10',
+  },
 ] as const;
 
 function formatRelative(ts: number, t: ReturnType<typeof useTranslation>['t']): string {
@@ -79,7 +103,11 @@ function Resumes() {
   const [tab, setTab] = useState<Tab>('applied');
   const [filter, setFilter] = useState('');
 
-  const { data: rows = [], isLoading, refetch } = useInteractions(tab);
+  const isGeneratedTab = tab === 'generated';
+
+  const { data: rows = [], isLoading, refetch } = useInteractions(isGeneratedTab ? 'applied' : tab);
+
+  const { data: generations = [] } = useAiGenerations();
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -90,7 +118,21 @@ function Resumes() {
       : (rows as Interaction[]);
   }, [rows, filter]);
 
+  const filteredGenerations = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    return q
+      ? (generations as AiGenerationRecord[]).filter(
+          (g) =>
+            g.jobTitle.toLowerCase().includes(q) ||
+            g.companyName.toLowerCase().includes(q) ||
+            g.candidateName.toLowerCase().includes(q)
+        )
+      : (generations as AiGenerationRecord[]);
+  }, [generations, filter]);
+
   const tabCfg = TAB_CONFIG.find((c) => c.id === tab) as (typeof TAB_CONFIG)[number];
+
+  const tabCount = isGeneratedTab ? generations.length : rows.length;
 
   return (
     <PageTransition className="flex h-full flex-col overflow-hidden">
@@ -111,9 +153,11 @@ function Resumes() {
                   variant="default"
                 />
               </div>
-              <Button size="sm" variant="ghost" onClick={() => void refetch()} title="Refresh">
-                <RefreshCw size={12} className={isLoading ? 'animate-spin' : ''} />
-              </Button>
+              {!isGeneratedTab && (
+                <Button size="sm" variant="ghost" onClick={() => void refetch()} title="Refresh">
+                  <RefreshCw size={12} className={isLoading ? 'animate-spin' : ''} />
+                </Button>
+              )}
             </div>
           }
         />
@@ -136,17 +180,45 @@ function Resumes() {
             >
               <Icon size={12} className={tab === id ? color : ''} />
               {t(labelKey)}
-              {tab === id && rows.length > 0 && (
+              {tab === id && tabCount > 0 && (
                 <span className="rounded-full bg-white/10 px-1.5 py-0.5 text-[10px] text-foreground/60">
-                  {rows.length}
+                  {tabCount}
                 </span>
               )}
             </Button>
           ))}
         </div>
 
-        {/* Content */}
-        {isLoading ? (
+        {/* Generated tab content */}
+        {isGeneratedTab ? (
+          filteredGenerations.length === 0 ? (
+            <EmptyState
+              icon={Wand2}
+              title={t('resumes.generated.noGenerationsYet')}
+              description={t('resumes.generated.noGenerationsDesc')}
+            />
+          ) : (
+            <motion.div
+              className="flex flex-col gap-3"
+              variants={stagger.container}
+              initial="hidden"
+              animate="show"
+            >
+              <AnimatePresence initial={false}>
+                {filteredGenerations.map((gen) => (
+                  <motion.div
+                    key={gen.id}
+                    variants={stagger.item}
+                    transition={transition.normal}
+                    exit={{ opacity: 0, y: -6 }}
+                  >
+                    <GenerationCard gen={gen} />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            </motion.div>
+          )
+        ) : isLoading ? (
           <div className="space-y-2">
             <CardSkeleton /> <CardSkeleton /> <CardSkeleton />
           </div>
@@ -240,6 +312,278 @@ function InteractionRow({
           <ExternalLink size={11} /> {t('resumes.open')}
         </Button>
       )}
+    </div>
+  );
+}
+
+const EXPORT_FORMATS = ['pdf', 'docx', 'txt'] as const;
+type ExportFormat = (typeof EXPORT_FORMATS)[number];
+
+const TEMPLATE_OPTIONS: { id: TemplateId; label: string }[] = [
+  { id: 'modern', label: 'Modern' },
+  { id: 'classic', label: 'Classic' },
+  { id: 'executive', label: 'Executive' },
+];
+
+function GenerationCard({ gen }: { gen: AiGenerationRecord }) {
+  const { t } = useTranslation();
+  const removeAiGeneration = useRemoveAiGeneration();
+  const [expanded, setExpanded] = useState<'resume' | 'cover' | 'jobAd' | null>(null);
+  const [copied, setCopied] = useState<'resume' | 'cover' | null>(null);
+  const [exportFormat, setExportFormat] = useState<ExportFormat>('pdf');
+  const [exportTemplate, setExportTemplate] = useState<TemplateId>('modern');
+  const [exporting, setExporting] = useState<'resume' | 'cover' | null>(null);
+
+  const copy = async (type: 'resume' | 'cover') => {
+    const text = type === 'resume' ? gen.resumeText : gen.coverLetterText;
+    await navigator.clipboard.writeText(text);
+    setCopied(type);
+    setTimeout(() => setCopied(null), 1800);
+  };
+
+  const meta = {
+    candidateName: gen.candidateName,
+    jobTitle: gen.jobTitle,
+    companyName: gen.companyName,
+    resumeLanguage: gen.resumeLanguage,
+    jobAdLanguage: gen.jobAdLanguage,
+    targetLanguage: gen.targetLanguage,
+    topRequirements: gen.topRequirements,
+    mismatch: gen.mismatch,
+  };
+
+  const doExport = async (type: 'resume' | 'cover') => {
+    const text = type === 'resume' ? gen.resumeText : gen.coverLetterText;
+    if (!text) return;
+    const docType = type === 'resume' ? 'resume' : 'cover-letter';
+    const filename = buildFilename(meta, docType, exportFormat);
+    setExporting(type);
+    try {
+      if (exportFormat === 'pdf') {
+        await exportPDF(text, filename.replace('.pdf', ''), docType, meta, exportTemplate);
+      } else if (exportFormat === 'docx') {
+        await exportDOCX(text, filename.replace('.docx', ''), docType, meta, exportTemplate);
+      } else {
+        exportTXT(text, filename.replace('.txt', ''));
+      }
+    } finally {
+      setExporting(null);
+    }
+  };
+
+  const generatedDate = new Date(gen.createdAt).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return (
+    <div className="glass-graphite glass-highlight rounded-xl overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-4 p-4">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-brand/10">
+          <Wand2 size={14} className="text-brand-soft" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground/90">
+            <span className="truncate">{gen.jobTitle || t('resumes.unknownPosition')}</span>
+            {gen.companyName && (
+              <span className="text-foreground/40 text-xs font-normal shrink-0">
+                @ {gen.companyName}
+              </span>
+            )}
+          </div>
+          <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-foreground/50">
+            {gen.candidateName && <span>{gen.candidateName}</span>}
+            <span className="flex items-center gap-1 text-foreground/35">
+              <Calendar size={10} />
+              <span title={formatRelative(gen.createdAt, t)}>{generatedDate}</span>
+            </span>
+            <span className="rounded-full border border-brand/20 bg-brand/8 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-brand-soft">
+              {gen.mode}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 shrink-0">
+          {gen.resumeText && (
+            <Button
+              onClick={() => void copy('resume')}
+              className="flex items-center gap-1 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto border-transparent"
+            >
+              <Copy size={10} />
+              {copied === 'resume'
+                ? t('resumes.generated.copied')
+                : t('resumes.generated.copyResume')}
+            </Button>
+          )}
+          {gen.coverLetterText && (
+            <Button
+              onClick={() => void copy('cover')}
+              className="flex items-center gap-1 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto border-transparent"
+            >
+              <Copy size={10} />
+              {copied === 'cover'
+                ? t('resumes.generated.copied')
+                : t('resumes.generated.copyCoverLetter')}
+            </Button>
+          )}
+          <Button
+            onClick={() => void removeAiGeneration.mutate(gen.id)}
+            className="flex items-center gap-1 rounded-lg bg-white/5 px-2 py-1.5 text-[11px] text-foreground/40 transition-colors hover:text-red-400 h-auto border-transparent"
+          >
+            <Trash2 size={10} />
+          </Button>
+        </div>
+      </div>
+
+      {/* Export bar */}
+      {(gen.resumeText || gen.coverLetterText) && (
+        <div className="border-t border-white/[0.04] px-4 py-2.5 flex items-center gap-2 flex-wrap">
+          <Download size={11} className="text-foreground/30 shrink-0" />
+          <span className="text-[11px] text-foreground/40 mr-1">
+            {t('resumes.generated.export')}
+          </span>
+
+          {/* Format picker */}
+          <div className="flex items-center gap-0.5 rounded-lg border border-white/[0.06] bg-white/[0.03] p-0.5">
+            {EXPORT_FORMATS.map((fmt) => (
+              <button
+                key={fmt}
+                onClick={() => setExportFormat(fmt)}
+                className={cn(
+                  'rounded-md px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors',
+                  exportFormat === fmt
+                    ? 'bg-white/10 text-foreground/80'
+                    : 'text-foreground/35 hover:text-foreground/60'
+                )}
+              >
+                {fmt}
+              </button>
+            ))}
+          </div>
+
+          {/* Template picker — only for pdf/docx */}
+          {exportFormat !== 'txt' && (
+            <div className="flex items-center gap-0.5 rounded-lg border border-white/[0.06] bg-white/[0.03] p-0.5">
+              {TEMPLATE_OPTIONS.map(({ id, label }) => (
+                <button
+                  key={id}
+                  onClick={() => setExportTemplate(id)}
+                  className={cn(
+                    'rounded-md px-2 py-0.5 text-[10px] transition-colors',
+                    exportTemplate === id
+                      ? 'bg-white/10 text-foreground/80'
+                      : 'text-foreground/35 hover:text-foreground/60'
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center gap-1 ml-auto">
+            {gen.resumeText && (
+              <Button
+                disabled={exporting === 'resume'}
+                onClick={() => void doExport('resume')}
+                className="flex items-center gap-1 rounded-lg bg-brand/10 border-brand/20 px-2.5 py-1.5 text-[11px] text-brand-soft transition-colors hover:bg-brand/20 h-auto"
+              >
+                {exporting === 'resume' ? (
+                  <Loader2 size={10} className="animate-spin" />
+                ) : (
+                  <Download size={10} />
+                )}
+                {t('resumes.generated.exportResume')}
+              </Button>
+            )}
+            {gen.coverLetterText && (
+              <Button
+                disabled={exporting === 'cover'}
+                onClick={() => void doExport('cover')}
+                className="flex items-center gap-1 rounded-lg bg-white/5 border-white/[0.06] px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto"
+              >
+                {exporting === 'cover' ? (
+                  <Loader2 size={10} className="animate-spin" />
+                ) : (
+                  <Download size={10} />
+                )}
+                {t('resumes.generated.exportCoverLetter')}
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Top requirements */}
+      {gen.topRequirements.length > 0 && (
+        <div className="px-4 pb-3 flex flex-wrap gap-1">
+          {gen.topRequirements.slice(0, 8).map((req) => (
+            <span
+              key={req}
+              className="rounded-full border border-white/[0.06] bg-white/[0.03] px-2 py-0.5 text-[10px] text-foreground/50"
+            >
+              {req}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Expandable sections */}
+      {[
+        {
+          key: 'resume' as const,
+          label: t('resumes.generated.resume'),
+          text: gen.resumeText,
+          icon: FileText,
+        },
+        {
+          key: 'cover' as const,
+          label: t('resumes.generated.coverLetter'),
+          text: gen.coverLetterText,
+          icon: FileText,
+        },
+        {
+          key: 'jobAd' as const,
+          label: t('resumes.generated.jobAd'),
+          text: gen.jobAd,
+          icon: Building2,
+        },
+      ]
+        .filter((s) => s.text)
+        .map(({ key, label, text, icon: SectionIcon }) => (
+          <div key={key} className="border-t border-white/[0.04]">
+            <button
+              onClick={() => setExpanded(expanded === key ? null : key)}
+              className="flex w-full items-center justify-between px-4 py-2.5 text-left text-xs text-foreground/50 hover:text-foreground/70 transition-colors"
+            >
+              <span className="flex items-center gap-1.5">
+                <SectionIcon size={11} /> {label}
+              </span>
+              <ChevronDown
+                size={12}
+                className={cn('transition-transform', expanded === key && 'rotate-180')}
+              />
+            </button>
+            <AnimatePresence initial={false}>
+              {expanded === key && (
+                <motion.div
+                  initial={{ height: 0 }}
+                  animate={{ height: 'auto' }}
+                  exit={{ height: 0 }}
+                  transition={transition.normal}
+                  className="overflow-hidden"
+                >
+                  <pre className="px-4 pb-4 whitespace-pre-wrap font-mono text-[10px] leading-relaxed text-foreground/50 max-h-64 overflow-y-auto">
+                    {text}
+                  </pre>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        ))}
     </div>
   );
 }

--- a/apps/tauri/src/renderer/services/query-client.ts
+++ b/apps/tauri/src/renderer/services/query-client.ts
@@ -54,4 +54,5 @@ export const keys = {
   autopilot: { all: ['autopilot'] as const, detail: (id: string) => ['autopilot', id] as const },
   conversations: { detail: (id: string) => ['conversations', id] as const },
   apply: { catalog: ['apply', 'catalog'] as const },
+  aiGenerations: { all: ['aiGenerations'] as const },
 } as const;

--- a/apps/tauri/src/renderer/services/use-ai-generations.ts
+++ b/apps/tauri/src/renderer/services/use-ai-generations.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { AiGenerationSaveRequest } from '@ajh/shared/ipc';
+
+import { useAppClient } from '@/providers/AppClientProvider';
+
+import { keys } from './query-client';
+
+export const useAiGenerations = () => {
+  const api = useAppClient();
+  return useQuery({
+    queryKey: keys.aiGenerations.all,
+    queryFn: () => api.aiGenerations.list(),
+  });
+};
+
+export const useSaveAiGeneration = () => {
+  const api = useAppClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (req: AiGenerationSaveRequest) => api.aiGenerations.save(req),
+    onSuccess: () => qc.invalidateQueries({ queryKey: keys.aiGenerations.all }),
+  });
+};
+
+export const useRemoveAiGeneration = () => {
+  const api = useAppClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.aiGenerations.remove(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: keys.aiGenerations.all }),
+  });
+};

--- a/apps/tauri/src/tauri-client/index.ts
+++ b/apps/tauri/src/tauri-client/index.ts
@@ -14,8 +14,8 @@
  */
 import type { AppClient } from '@/lib/app-client';
 
-import { aiGenerations } from './namespaces/aiGenerations.js';
 import { ai } from './namespaces/ai.js';
+import { aiGenerations } from './namespaces/aiGenerations.js';
 import { apply } from './namespaces/apply.js';
 import { autopilot } from './namespaces/autopilot.js';
 import { boards } from './namespaces/boards.js';

--- a/apps/tauri/src/tauri-client/index.ts
+++ b/apps/tauri/src/tauri-client/index.ts
@@ -14,6 +14,7 @@
  */
 import type { AppClient } from '@/lib/app-client';
 
+import { aiGenerations } from './namespaces/aiGenerations.js';
 import { ai } from './namespaces/ai.js';
 import { apply } from './namespaces/apply.js';
 import { autopilot } from './namespaces/autopilot.js';
@@ -38,6 +39,7 @@ import { updater } from './namespaces/updater.js';
 
 export function createTauriInvokeClient(): AppClient {
   return {
+    aiGenerations: aiGenerations as AppClient['aiGenerations'],
     system: system as AppClient['system'],
     jobs: jobs as AppClient['jobs'],
     ai: ai as AppClient['ai'],

--- a/apps/tauri/src/tauri-client/namespaces/aiGenerations.ts
+++ b/apps/tauri/src/tauri-client/namespaces/aiGenerations.ts
@@ -1,0 +1,7 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export const aiGenerations = {
+  list: () => invoke('ai_generations_list'),
+  save: (req: unknown) => invoke('ai_generations_save', { req }),
+  remove: (id: string) => invoke('ai_generations_remove', { id }),
+};

--- a/packages/shared/src/ipc/contracts/aiGenerations.ts
+++ b/packages/shared/src/ipc/contracts/aiGenerations.ts
@@ -1,0 +1,43 @@
+export interface AiGenerationRecord {
+  id: string;
+  createdAt: number;
+  candidateName: string;
+  jobTitle: string;
+  companyName: string;
+  resumeLanguage: string;
+  jobAdLanguage: string;
+  targetLanguage: string;
+  mismatch: boolean;
+  topRequirements: string[];
+  mode: string;
+  resumeText: string;
+  coverLetterText: string;
+  jobAd: string;
+}
+
+export interface AiGenerationSaveRequest {
+  candidateName: string;
+  jobTitle: string;
+  companyName: string;
+  resumeLanguage: string;
+  jobAdLanguage: string;
+  targetLanguage: string;
+  mismatch: boolean;
+  topRequirements: string[];
+  mode: string;
+  resumeText: string;
+  coverLetterText: string;
+  jobAd: string;
+}
+
+export interface AiGenerationsContract {
+  list(): Promise<AiGenerationRecord[]>;
+  save(req: AiGenerationSaveRequest): Promise<{ id: string; success: boolean }>;
+  remove(id: string): Promise<void>;
+}
+
+export const AI_GENERATIONS_CHANNELS = {
+  list: 'aiGenerations:list',
+  save: 'aiGenerations:save',
+  remove: 'aiGenerations:remove',
+} as const;

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -16,6 +16,7 @@
 
  */
 
+import { AI_GENERATIONS_CHANNELS, type AiGenerationsContract } from './aiGenerations.js';
 import { AI_CHANNELS, type AiContract } from './ai.js';
 import { APPLY_CHANNELS, type ApplyContract } from './apply.js';
 import { AUTOPILOT_CHANNELS, type AutopilotContract } from './autopilot.js';
@@ -41,6 +42,7 @@ import { UPDATER_CHANNELS, type UpdaterContract } from './updater.js';
 // Combine all namespace contracts into the original IpcContract interface
 
 export interface IpcContract {
+  aiGenerations: AiGenerationsContract;
   system: SystemContract;
   jobs: JobsContract;
   ai: AiContract;
@@ -67,6 +69,7 @@ export interface IpcContract {
 // Combine all channel constants into the original IPC_CHANNELS object
 
 export const IPC_CHANNELS = {
+  aiGenerations: AI_GENERATIONS_CHANNELS,
   system: SYSTEM_CHANNELS,
   jobs: JOBS_CHANNELS,
   ai: AI_CHANNELS,
@@ -97,6 +100,12 @@ export type IpcChannel =
 
 // Re-export individual namespace contracts for direct imports if needed
 
+export {
+  AI_GENERATIONS_CHANNELS,
+  type AiGenerationRecord,
+  type AiGenerationSaveRequest,
+  type AiGenerationsContract,
+} from './aiGenerations.js';
 export { AI_CHANNELS, type AiContract } from './ai.js';
 export { APPLY_CHANNELS, type ApplyContract } from './apply.js';
 export { AUTOPILOT_CHANNELS, type AutopilotContract } from './autopilot.js';

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -16,8 +16,8 @@
 
  */
 
-import { AI_GENERATIONS_CHANNELS, type AiGenerationsContract } from './aiGenerations.js';
 import { AI_CHANNELS, type AiContract } from './ai.js';
+import { AI_GENERATIONS_CHANNELS, type AiGenerationsContract } from './aiGenerations.js';
 import { APPLY_CHANNELS, type ApplyContract } from './apply.js';
 import { AUTOPILOT_CHANNELS, type AutopilotContract } from './autopilot.js';
 import { BOARDS_CHANNELS, type BoardsContract } from './boards.js';
@@ -100,13 +100,13 @@ export type IpcChannel =
 
 // Re-export individual namespace contracts for direct imports if needed
 
+export { AI_CHANNELS, type AiContract } from './ai.js';
 export {
   AI_GENERATIONS_CHANNELS,
   type AiGenerationRecord,
   type AiGenerationSaveRequest,
   type AiGenerationsContract,
 } from './aiGenerations.js';
-export { AI_CHANNELS, type AiContract } from './ai.js';
 export { APPLY_CHANNELS, type ApplyContract } from './apply.js';
 export { AUTOPILOT_CHANNELS, type AutopilotContract } from './autopilot.js';
 export { BOARDS_CHANNELS, type BoardsContract } from './boards.js';


### PR DESCRIPTION
## Summary

- **Export bar on generation cards** — each AI generation card in the Resumes → Generated tab now shows an export bar with a format picker (PDF / DOCX / TXT) and a template picker (Modern / Classic / Executive, hidden for TXT). Separate download buttons for Resume and Cover Letter with a spinner during export.
- **Consistent with AI Generate page** — uses the same `exportPDF` / `exportDOCX` / `exportTXT` pipeline and template system so output formatting is identical to what was produced during generation.
- **Generated date** — replaced the relative "Xm ago" clock with a full formatted date (`May 25, 2026`); relative time is preserved as a tooltip on hover.
- **New `aiGenerations` IPC namespace** — Rust backend (`src/ai_generations/mod.rs`) persists records to SQLite; TS client, React Query service, and shared IPC contracts wire the full stack (`list`, `save`, `remove`). The AI Generate page saves each generation on completion.
- **i18n** — `export`, `exportResume`, `exportCoverLetter` keys added to EN and DE locales.

## Files changed

| Layer | Files |
|---|---|
| Rust | `src/ai_generations/mod.rs`, `commands/ai_generations.rs`, `commands/mod.rs`, `main.rs` |
| Shared IPC | `packages/shared/src/ipc/contracts/aiGenerations.ts`, `contracts/index.ts` |
| TS client | `tauri-client/namespaces/aiGenerations.ts`, `tauri-client/index.ts` |
| Services | `renderer/services/use-ai-generations.ts`, `services/query-client.ts` |
| UI | `renderer/routes/resumes.tsx`, `renderer/routes/ai-generate.tsx`, `features/ai-generate/components/OutputPanelGenerating.tsx` |
| i18n | `locales/en.json`, `locales/de.json` |
| Mock/web | `lib/mock-client.ts`, `lib/web-http-client/index.ts` |

## Test plan

- [ ] Generate a resume + cover letter on the AI Generate page — confirm it appears in Resumes → Generated tab
- [ ] Export as PDF (all 3 templates), DOCX (all 3 templates), TXT — verify file dialog opens and file is saved
- [ ] Confirm spinner appears during export and clears on completion
- [ ] Confirm generated date shows full date; hover shows relative time
- [ ] Copy buttons still work alongside export buttons
- [ ] Delete a generation — confirm it disappears from the list
- [ ] Filter by job title / company name works in Generated tab
- [ ] DE locale: verify export labels are translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)