### PR TITLE
fix: enable tauri devtools feature for release builds

### DIFF
--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ strip = true
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "image-ico", "image-png"] }
+tauri = { version = "2", features = ["tray-icon", "image-ico", "image-png", "devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"


### PR DESCRIPTION
## Summary

- Adds `"devtools"` to the Tauri feature list in `Cargo.toml`
- Without this feature, `WebviewWindow::open_devtools()` does not exist as a method in release builds, causing a compile error on macOS (`no method named open_devtools found`)
- The Open DevTools button in Settings → Developer now works in both debug and release builds

## Root cause

`open_devtools()` is gated behind the `devtools` Cargo feature in Tauri v2. Debug builds implicitly enable it; release builds do not unless it is explicitly listed in features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)