### PR TITLE
refactor: migrate routes to folder/index pattern and fix route references

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -7193,18 +7193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -7218,11 +7206,9 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -7507,12 +7493,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ reqwest = { version = "0.13", features = ["json", "native-tls", "rustls", "rustl
 
 log = "0.4"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "std", "ansi"], default-features = false }
 
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"

--- a/apps/tauri/src/main.tsx
+++ b/apps/tauri/src/main.tsx
@@ -33,7 +33,7 @@ const router = createRouter({
   defaultPreloadStaleTime: 0,
 });
 
-void router.navigate({ to: '/', replace: true });
+void router.navigate({ to: '/index', replace: true });
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
@@ -72,7 +72,7 @@ export function Sidebar() {
     <aside className="glass-surface m-3 mr-0 flex w-60 flex-col rounded-2xl p-3">
       <nav className="flex flex-col gap-1">
         {NAV_ITEMS.map(({ to, label, icon: Icon, tourId }) => {
-          const active = pathname === to || (to !== '/' && pathname.startsWith(to + '/'));
+          const active = pathname === to || pathname.startsWith(to);
           return (
             <div key={to} className="relative" data-tour-id={tourId}>
               {active && (

--- a/apps/tauri/src/renderer/constants/routes.ts
+++ b/apps/tauri/src/renderer/constants/routes.ts
@@ -1,5 +1,5 @@
 export const ROUTES = {
-  DASHBOARD: '/',
+  DASHBOARD: '/index',
   ANALYZE: '/analyze',
   GENERATE: '/ai-generate',
   JOBS: '/jobs',

--- a/apps/tauri/src/renderer/main.tsx
+++ b/apps/tauri/src/renderer/main.tsx
@@ -23,7 +23,7 @@ const router = createRouter({
 });
 
 // Ensure the app starts at the dashboard
-void router.navigate({ to: '/', replace: true });
+void router.navigate({ to: '/index', replace: true });
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/apps/tauri/src/renderer/routeTree.gen.ts
+++ b/apps/tauri/src/renderer/routeTree.gen.ts
@@ -9,135 +9,135 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as SupportRouteImport } from './routes/support'
-import { Route as SettingsRouteImport } from './routes/settings'
-import { Route as SearchRouteImport } from './routes/search'
-import { Route as ResumesRouteImport } from './routes/resumes'
-import { Route as MonitoringRouteImport } from './routes/monitoring'
-import { Route as JobsRouteImport } from './routes/jobs'
-import { Route as AutopilotRouteImport } from './routes/autopilot'
-import { Route as AnalyzeRouteImport } from './routes/analyze'
-import { Route as AiGenerateRouteImport } from './routes/ai-generate'
-import { Route as AiRouteImport } from './routes/ai'
-import { Route as IndexRouteImport } from './routes/index'
+import { Route as IndexIndexRouteImport } from './routes/index/index'
+import { Route as SupportIndexRouteImport } from './routes/support/index'
+import { Route as SettingsIndexRouteImport } from './routes/settings/index'
+import { Route as SearchIndexRouteImport } from './routes/search/index'
+import { Route as ResumesIndexRouteImport } from './routes/resumes/index'
+import { Route as MonitoringIndexRouteImport } from './routes/monitoring/index'
+import { Route as JobsIndexRouteImport } from './routes/jobs/index'
+import { Route as AutopilotIndexRouteImport } from './routes/autopilot/index'
+import { Route as AnalyzeIndexRouteImport } from './routes/analyze/index'
+import { Route as AiIndexRouteImport } from './routes/ai/index'
+import { Route as AiGenerateIndexRouteImport } from './routes/ai-generate/index'
 
-const SupportRoute = SupportRouteImport.update({
-  id: '/support',
-  path: '/support',
+const IndexIndexRoute = IndexIndexRouteImport.update({
+  id: '/index/',
+  path: '/index/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SettingsRoute = SettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
+const SupportIndexRoute = SupportIndexRouteImport.update({
+  id: '/support/',
+  path: '/support/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SearchRoute = SearchRouteImport.update({
-  id: '/search',
-  path: '/search',
+const SettingsIndexRoute = SettingsIndexRouteImport.update({
+  id: '/settings/',
+  path: '/settings/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ResumesRoute = ResumesRouteImport.update({
-  id: '/resumes',
-  path: '/resumes',
+const SearchIndexRoute = SearchIndexRouteImport.update({
+  id: '/search/',
+  path: '/search/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const MonitoringRoute = MonitoringRouteImport.update({
-  id: '/monitoring',
-  path: '/monitoring',
+const ResumesIndexRoute = ResumesIndexRouteImport.update({
+  id: '/resumes/',
+  path: '/resumes/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const JobsRoute = JobsRouteImport.update({
-  id: '/jobs',
-  path: '/jobs',
+const MonitoringIndexRoute = MonitoringIndexRouteImport.update({
+  id: '/monitoring/',
+  path: '/monitoring/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AutopilotRoute = AutopilotRouteImport.update({
-  id: '/autopilot',
-  path: '/autopilot',
+const JobsIndexRoute = JobsIndexRouteImport.update({
+  id: '/jobs/',
+  path: '/jobs/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AnalyzeRoute = AnalyzeRouteImport.update({
-  id: '/analyze',
-  path: '/analyze',
+const AutopilotIndexRoute = AutopilotIndexRouteImport.update({
+  id: '/autopilot/',
+  path: '/autopilot/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AiGenerateRoute = AiGenerateRouteImport.update({
-  id: '/ai-generate',
-  path: '/ai-generate',
+const AnalyzeIndexRoute = AnalyzeIndexRouteImport.update({
+  id: '/analyze/',
+  path: '/analyze/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AiRoute = AiRouteImport.update({
-  id: '/ai',
-  path: '/ai',
+const AiIndexRoute = AiIndexRouteImport.update({
+  id: '/ai/',
+  path: '/ai/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const AiGenerateIndexRoute = AiGenerateIndexRouteImport.update({
+  id: '/ai-generate/',
+  path: '/ai-generate/',
   getParentRoute: () => rootRouteImport,
 } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/ai': typeof AiRoute
-  '/ai-generate': typeof AiGenerateRoute
-  '/analyze': typeof AnalyzeRoute
-  '/autopilot': typeof AutopilotRoute
-  '/jobs': typeof JobsRoute
-  '/monitoring': typeof MonitoringRoute
-  '/resumes': typeof ResumesRoute
-  '/search': typeof SearchRoute
-  '/settings': typeof SettingsRoute
-  '/support': typeof SupportRoute
+  '/ai-generate/': typeof AiGenerateIndexRoute
+  '/ai/': typeof AiIndexRoute
+  '/analyze/': typeof AnalyzeIndexRoute
+  '/autopilot/': typeof AutopilotIndexRoute
+  '/index/': typeof IndexIndexRoute
+  '/jobs/': typeof JobsIndexRoute
+  '/monitoring/': typeof MonitoringIndexRoute
+  '/resumes/': typeof ResumesIndexRoute
+  '/search/': typeof SearchIndexRoute
+  '/settings/': typeof SettingsIndexRoute
+  '/support/': typeof SupportIndexRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/ai': typeof AiRoute
-  '/ai-generate': typeof AiGenerateRoute
-  '/analyze': typeof AnalyzeRoute
-  '/autopilot': typeof AutopilotRoute
-  '/jobs': typeof JobsRoute
-  '/monitoring': typeof MonitoringRoute
-  '/resumes': typeof ResumesRoute
-  '/search': typeof SearchRoute
-  '/settings': typeof SettingsRoute
-  '/support': typeof SupportRoute
+  '/ai-generate': typeof AiGenerateIndexRoute
+  '/ai': typeof AiIndexRoute
+  '/analyze': typeof AnalyzeIndexRoute
+  '/autopilot': typeof AutopilotIndexRoute
+  '/index': typeof IndexIndexRoute
+  '/jobs': typeof JobsIndexRoute
+  '/monitoring': typeof MonitoringIndexRoute
+  '/resumes': typeof ResumesIndexRoute
+  '/search': typeof SearchIndexRoute
+  '/settings': typeof SettingsIndexRoute
+  '/support': typeof SupportIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/ai': typeof AiRoute
-  '/ai-generate': typeof AiGenerateRoute
-  '/analyze': typeof AnalyzeRoute
-  '/autopilot': typeof AutopilotRoute
-  '/jobs': typeof JobsRoute
-  '/monitoring': typeof MonitoringRoute
-  '/resumes': typeof ResumesRoute
-  '/search': typeof SearchRoute
-  '/settings': typeof SettingsRoute
-  '/support': typeof SupportRoute
+  '/ai-generate/': typeof AiGenerateIndexRoute
+  '/ai/': typeof AiIndexRoute
+  '/analyze/': typeof AnalyzeIndexRoute
+  '/autopilot/': typeof AutopilotIndexRoute
+  '/index/': typeof IndexIndexRoute
+  '/jobs/': typeof JobsIndexRoute
+  '/monitoring/': typeof MonitoringIndexRoute
+  '/resumes/': typeof ResumesIndexRoute
+  '/search/': typeof SearchIndexRoute
+  '/settings/': typeof SettingsIndexRoute
+  '/support/': typeof SupportIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | '/'
-    | '/ai'
-    | '/ai-generate'
-    | '/analyze'
-    | '/autopilot'
-    | '/jobs'
-    | '/monitoring'
-    | '/resumes'
-    | '/search'
-    | '/settings'
-    | '/support'
+    | '/ai-generate/'
+    | '/ai/'
+    | '/analyze/'
+    | '/autopilot/'
+    | '/index/'
+    | '/jobs/'
+    | '/monitoring/'
+    | '/resumes/'
+    | '/search/'
+    | '/settings/'
+    | '/support/'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | '/'
-    | '/ai'
     | '/ai-generate'
+    | '/ai'
     | '/analyze'
     | '/autopilot'
+    | '/index'
     | '/jobs'
     | '/monitoring'
     | '/resumes'
@@ -146,127 +146,127 @@ export interface FileRouteTypes {
     | '/support'
   id:
     | '__root__'
-    | '/'
-    | '/ai'
-    | '/ai-generate'
-    | '/analyze'
-    | '/autopilot'
-    | '/jobs'
-    | '/monitoring'
-    | '/resumes'
-    | '/search'
-    | '/settings'
-    | '/support'
+    | '/ai-generate/'
+    | '/ai/'
+    | '/analyze/'
+    | '/autopilot/'
+    | '/index/'
+    | '/jobs/'
+    | '/monitoring/'
+    | '/resumes/'
+    | '/search/'
+    | '/settings/'
+    | '/support/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  AiRoute: typeof AiRoute
-  AiGenerateRoute: typeof AiGenerateRoute
-  AnalyzeRoute: typeof AnalyzeRoute
-  AutopilotRoute: typeof AutopilotRoute
-  JobsRoute: typeof JobsRoute
-  MonitoringRoute: typeof MonitoringRoute
-  ResumesRoute: typeof ResumesRoute
-  SearchRoute: typeof SearchRoute
-  SettingsRoute: typeof SettingsRoute
-  SupportRoute: typeof SupportRoute
+  AiGenerateIndexRoute: typeof AiGenerateIndexRoute
+  AiIndexRoute: typeof AiIndexRoute
+  AnalyzeIndexRoute: typeof AnalyzeIndexRoute
+  AutopilotIndexRoute: typeof AutopilotIndexRoute
+  IndexIndexRoute: typeof IndexIndexRoute
+  JobsIndexRoute: typeof JobsIndexRoute
+  MonitoringIndexRoute: typeof MonitoringIndexRoute
+  ResumesIndexRoute: typeof ResumesIndexRoute
+  SearchIndexRoute: typeof SearchIndexRoute
+  SettingsIndexRoute: typeof SettingsIndexRoute
+  SupportIndexRoute: typeof SupportIndexRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/support': {
-      id: '/support'
+    '/index/': {
+      id: '/index/'
+      path: '/index'
+      fullPath: '/index/'
+      preLoaderRoute: typeof IndexIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/support/': {
+      id: '/support/'
       path: '/support'
-      fullPath: '/support'
-      preLoaderRoute: typeof SupportRouteImport
+      fullPath: '/support/'
+      preLoaderRoute: typeof SupportIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/settings': {
-      id: '/settings'
+    '/settings/': {
+      id: '/settings/'
       path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteImport
+      fullPath: '/settings/'
+      preLoaderRoute: typeof SettingsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/search': {
-      id: '/search'
+    '/search/': {
+      id: '/search/'
       path: '/search'
-      fullPath: '/search'
-      preLoaderRoute: typeof SearchRouteImport
+      fullPath: '/search/'
+      preLoaderRoute: typeof SearchIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/resumes': {
-      id: '/resumes'
+    '/resumes/': {
+      id: '/resumes/'
       path: '/resumes'
-      fullPath: '/resumes'
-      preLoaderRoute: typeof ResumesRouteImport
+      fullPath: '/resumes/'
+      preLoaderRoute: typeof ResumesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/monitoring': {
-      id: '/monitoring'
+    '/monitoring/': {
+      id: '/monitoring/'
       path: '/monitoring'
-      fullPath: '/monitoring'
-      preLoaderRoute: typeof MonitoringRouteImport
+      fullPath: '/monitoring/'
+      preLoaderRoute: typeof MonitoringIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/jobs': {
-      id: '/jobs'
+    '/jobs/': {
+      id: '/jobs/'
       path: '/jobs'
-      fullPath: '/jobs'
-      preLoaderRoute: typeof JobsRouteImport
+      fullPath: '/jobs/'
+      preLoaderRoute: typeof JobsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/autopilot': {
-      id: '/autopilot'
+    '/autopilot/': {
+      id: '/autopilot/'
       path: '/autopilot'
-      fullPath: '/autopilot'
-      preLoaderRoute: typeof AutopilotRouteImport
+      fullPath: '/autopilot/'
+      preLoaderRoute: typeof AutopilotIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/analyze': {
-      id: '/analyze'
+    '/analyze/': {
+      id: '/analyze/'
       path: '/analyze'
-      fullPath: '/analyze'
-      preLoaderRoute: typeof AnalyzeRouteImport
+      fullPath: '/analyze/'
+      preLoaderRoute: typeof AnalyzeIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/ai-generate': {
-      id: '/ai-generate'
-      path: '/ai-generate'
-      fullPath: '/ai-generate'
-      preLoaderRoute: typeof AiGenerateRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/ai': {
-      id: '/ai'
+    '/ai/': {
+      id: '/ai/'
       path: '/ai'
-      fullPath: '/ai'
-      preLoaderRoute: typeof AiRouteImport
+      fullPath: '/ai/'
+      preLoaderRoute: typeof AiIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/ai-generate/': {
+      id: '/ai-generate/'
+      path: '/ai-generate'
+      fullPath: '/ai-generate/'
+      preLoaderRoute: typeof AiGenerateIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  AiRoute: AiRoute,
-  AiGenerateRoute: AiGenerateRoute,
-  AnalyzeRoute: AnalyzeRoute,
-  AutopilotRoute: AutopilotRoute,
-  JobsRoute: JobsRoute,
-  MonitoringRoute: MonitoringRoute,
-  ResumesRoute: ResumesRoute,
-  SearchRoute: SearchRoute,
-  SettingsRoute: SettingsRoute,
-  SupportRoute: SupportRoute,
+  AiGenerateIndexRoute: AiGenerateIndexRoute,
+  AiIndexRoute: AiIndexRoute,
+  AnalyzeIndexRoute: AnalyzeIndexRoute,
+  AutopilotIndexRoute: AutopilotIndexRoute,
+  IndexIndexRoute: IndexIndexRoute,
+  JobsIndexRoute: JobsIndexRoute,
+  MonitoringIndexRoute: MonitoringIndexRoute,
+  ResumesIndexRoute: ResumesIndexRoute,
+  SearchIndexRoute: SearchIndexRoute,
+  SettingsIndexRoute: SettingsIndexRoute,
+  SupportIndexRoute: SupportIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/tauri/src/renderer/routes/__root.tsx
+++ b/apps/tauri/src/renderer/routes/__root.tsx
@@ -73,8 +73,8 @@ function RootLayout() {
       const known = (router.routesByPath as unknown as Record<string, unknown>)[
         toLocation.pathname
       ];
-      if (toLocation.pathname !== '/' && !known) {
-        void router.navigate({ to: '/', replace: true });
+      if (toLocation.pathname !== '/index' && !known) {
+        void router.navigate({ to: '/index', replace: true });
       }
     });
   }, [router]);

--- a/apps/tauri/src/renderer/routes/ai-generate/index.tsx
+++ b/apps/tauri/src/renderer/routes/ai-generate/index.tsx
@@ -26,7 +26,7 @@ import { useFileUpload } from './hooks/useFileUpload';
 import { useGeneration } from './hooks/useGeneration';
 import { useStageRotation } from './hooks/useStageRotation';
 
-export const Route = createFileRoute('/ai-generate')({ component: AIGeneratePage });
+export const Route = createFileRoute('/ai-generate/')({ component: AIGeneratePage });
 
 type GenTarget = 'resume' | 'cover' | 'both';
 

--- a/apps/tauri/src/renderer/routes/ai/index.tsx
+++ b/apps/tauri/src/renderer/routes/ai/index.tsx
@@ -2,4 +2,4 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { AIWorkspace } from '@/features/ai-workspace/components/AIWorkspace';
 
-export const Route = createFileRoute('/ai')({ component: AIWorkspace });
+export const Route = createFileRoute('/ai/')({ component: AIWorkspace });

--- a/apps/tauri/src/renderer/routes/analyze/index.tsx
+++ b/apps/tauri/src/renderer/routes/analyze/index.tsx
@@ -36,7 +36,7 @@ import type { PromptQuality } from '@/store/preferences-schema';
 import { useOutputTone, usePreferencesStore, usePromptQuality } from '@/store/preferences-store';
 import { useSessionStore } from '@/store/session-store';
 
-export const Route = createFileRoute('/analyze')({ component: Analyze });
+export const Route = createFileRoute('/analyze/')({ component: Analyze });
 
 const ACCEPTED_EXTS = ['pdf', 'docx', 'txt', 'md', 'markdown'] as const;
 const MAX_BYTES = 25 * 1024 * 1024;

--- a/apps/tauri/src/renderer/routes/autopilot/index.tsx
+++ b/apps/tauri/src/renderer/routes/autopilot/index.tsx
@@ -2,4 +2,4 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { AutopilotPage } from './components/AutopilotPage';
 
-export const Route = createFileRoute('/autopilot')({ component: AutopilotPage });
+export const Route = createFileRoute('/autopilot/')({ component: AutopilotPage });

--- a/apps/tauri/src/renderer/routes/index/index.tsx
+++ b/apps/tauri/src/renderer/routes/index/index.tsx
@@ -2,4 +2,4 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { Dashboard } from './components/Dashboard';
 
-export const Route = createFileRoute('/')({ component: Dashboard });
+export const Route = createFileRoute('/index/')({ component: Dashboard });

--- a/apps/tauri/src/renderer/routes/jobs/index.tsx
+++ b/apps/tauri/src/renderer/routes/jobs/index.tsx
@@ -28,7 +28,7 @@ import { useFormatRelativeTime } from './hooks/useFormatRelativeTime';
 import { useScraping } from './hooks/useScraping';
 import type { JobEvent, Posting } from './types';
 
-export const Route = createFileRoute('/jobs')({ component: Jobs });
+export const Route = createFileRoute('/jobs/')({ component: Jobs });
 
 function Jobs() {
   const { t } = useTranslation();

--- a/apps/tauri/src/renderer/routes/monitoring/index.tsx
+++ b/apps/tauri/src/renderer/routes/monitoring/index.tsx
@@ -18,7 +18,7 @@ import { useActivityFeed } from './hooks/useActivityFeed';
 import { useJobMetrics } from './hooks/useJobMetrics';
 import type { JobRecord } from './types';
 
-export const Route = createFileRoute('/monitoring')({ component: MonitoringPage });
+export const Route = createFileRoute('/monitoring/')({ component: MonitoringPage });
 
 function MonitoringPage() {
   const { t } = useTranslation();

--- a/apps/tauri/src/renderer/routes/resumes/index.tsx
+++ b/apps/tauri/src/renderer/routes/resumes/index.tsx
@@ -2,4 +2,4 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { ResumesPage } from './components/ResumesPage';
 
-export const Route = createFileRoute('/resumes')({ component: ResumesPage });
+export const Route = createFileRoute('/resumes/')({ component: ResumesPage });

--- a/apps/tauri/src/renderer/routes/search/index.tsx
+++ b/apps/tauri/src/renderer/routes/search/index.tsx
@@ -2,4 +2,4 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { SearchPage } from './components/SearchPage';
 
-export const Route = createFileRoute('/search')({ component: SearchPage });
+export const Route = createFileRoute('/search/')({ component: SearchPage });

--- a/apps/tauri/src/renderer/routes/settings/index.tsx
+++ b/apps/tauri/src/renderer/routes/settings/index.tsx
@@ -10,7 +10,7 @@ import { SettingsContent } from './components/SettingsContent';
 import { SettingsSidebar } from './components/SettingsSidebar';
 import { NAV_GROUPS, type NavGroup, type NavItem, type SectionId } from './constants';
 
-export const Route = createFileRoute('/settings')({ component: SettingsPage });
+export const Route = createFileRoute('/settings/')({ component: SettingsPage });
 
 function SettingsPage() {
   const { t } = useTranslation();

--- a/apps/tauri/src/renderer/routes/support/index.tsx
+++ b/apps/tauri/src/renderer/routes/support/index.tsx
@@ -2,4 +2,4 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { SupportPage } from './components/SupportPage';
 
-export const Route = createFileRoute('/support')({ component: SupportPage });
+export const Route = createFileRoute('/support/')({ component: SupportPage });


### PR DESCRIPTION
## Summary

- Migrated all route `createFileRoute` paths to trailing-slash form (`/ai` → `/ai/`) following the folder/index file structure
- Regenerated `routeTree.gen.ts` to import from `routes/*/index` instead of flat `routes/*`
- Updated `ROUTES.DASHBOARD` from `'/'` to `'/index'` and all navigate/redirect calls accordingly
- Fixed `Sidebar` active-check logic after the index route path change
- Scoped `tracing-subscriber` to explicit features with `default-features = false` to slim Rust build

## Test plan

- [ ] App launches and lands on the dashboard (`/index`)
- [ ] All sidebar navigation links route correctly
- [ ] Unknown paths redirect to dashboard
- [ ] Rust build passes with updated `tracing-subscriber` features

🤖 Generated with [Claude Code](https://claude.com/claude-code)