### PR TITLE
fix(deps): scope tracing-subscriber to explicit features

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ reqwest = { version = "0.13", features = ["json", "native-tls", "rustls", "rustl
 
 log = "0.4"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "std", "ansi"], default-features = false }
 
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"


### PR DESCRIPTION
## Summary

- Set `default-features = false` on `tracing-subscriber` to avoid pulling in unused default features
- Explicitly list required features: `env-filter`, `fmt`, `std`, `ansi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)