### PR TITLE
fix: ui and monitoring improvements

### DIFF
--- a/apps/tauri/src/renderer/features/ai-generate/components/GenerationConfig/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/GenerationConfig/index.tsx
@@ -3,12 +3,12 @@ import {
   FileCheck,
   FileText,
   Gauge,
+  type LucideIcon,
   SlidersHorizontal,
   Sparkles,
   Zap,
 } from 'lucide-react';
 import { motion } from 'motion/react';
-import type React from 'react';
 
 import { Button, cn } from '@ajh/ui';
 
@@ -31,7 +31,7 @@ interface GenerationConfigProps {
   isGenerating: boolean;
 }
 
-const QUALITY_OPTIONS: { id: PromptQuality; label: string; icon: React.ElementType }[] = [
+const QUALITY_OPTIONS: { id: PromptQuality; label: string; icon: LucideIcon }[] = [
   { id: 'full', label: 'Full', icon: SlidersHorizontal },
   { id: 'auto', label: 'Auto', icon: Gauge },
   { id: 'compact', label: 'Fast', icon: Zap },


### PR DESCRIPTION
## Summary

- Fix `NaNh` timestamps in activity feed — guard against missing/NaN timestamps in `useAgo`, fall back to `createdAt` when `finishedAt`/`updatedAt` are absent
- Remove Clear button from activity feed (was broken and confusing)
- Add prompt quality selector to AI workspace chat header
- Add icons to all three prompt quality options in AI Generate page (Full/Auto/Fast were inconsistent — only Fast had an icon)
- Fix import sort lint error in `GenerationConfig` (use `LucideIcon` type instead of `React.ElementType`)

## Test plan

- [ ] Open Monitoring page — timestamps should show `5s`, `2m`, `1h` etc. instead of `NaNh`
- [ ] AI Workspace header shows Full / Auto / Fast prompt quality selector
- [ ] AI Generate page shows icons on all three quality buttons
- [ ] `pnpm lint:strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)