### PR TITLE
fix: repair auto-updater key mismatch and macos release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           HUSKY: 0
-          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
 
       - name: 📝 Release Summary
         if: always()
@@ -133,8 +132,6 @@ jobs:
           cache: pnpm
 
       - name: 🔖 Sync Version Files
-        env:
-          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
         run: |
           echo "::group::Syncing tracked version files"
           node scripts/sync-tauri-version.cjs ${{ needs.release.outputs.version }}
@@ -230,16 +227,9 @@ jobs:
           echo "::endgroup::"
 
       - name: 🔖 Sync Release Version
-        env:
-          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
         run: |
           echo "::group::Syncing Tauri release metadata"
           node scripts/sync-tauri-version.cjs ${{ needs.sync-version-files.outputs.version }}
-          echo "::endgroup::"
-
-          echo "::group::Verifying public key"
-          echo "Public key configured in tauri.conf.json:"
-          cat apps/tauri/src-tauri/tauri.conf.json | grep -A 1 '"pubkey"'
           echo "::endgroup::"
 
       - name: 🔨 Build Workspace
@@ -288,6 +278,17 @@ jobs:
           echo "::error::Tauri build failed on ${{ matrix.platform }}. Please review the build output above."
           exit 1
 
+      - name: 🔐 Verify Updater Signing Key
+        if: steps.tauri-build.outcome == 'success'
+        shell: bash
+        run: |
+          echo "::group::Verifying updater signature key matches committed pubkey"
+          # Fails the build if artifacts were signed with a key that does not
+          # match the pubkey shipped in the app — which would break the
+          # auto-updater for every user. See docs/DEPLOYMENT.md (Updater signing keys).
+          node scripts/verify-updater-key.cjs
+          echo "::endgroup::"
+
       - name: 🏷️ Normalize Artifact Names
         if: success()
         shell: bash
@@ -310,20 +311,35 @@ jobs:
           fi
           echo "::endgroup::"
 
-      - name: 🏷️ Disambiguate macOS DMG Architecture
+      - name: 🏷️ Disambiguate macOS Artifact Architecture
         if: runner.os == 'macOS' && success()
         shell: bash
         run: |
-          echo "::group::Tagging macOS DMGs with architecture suffix"
+          echo "::group::Tagging macOS artifacts with architecture suffix"
           shopt -s nullglob
-          for f in apps/tauri/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg; do
-            mv "$f" "${f%.dmg}-intel.dmg"
-            echo "Renamed (intel): $(basename "$f")"
-          done
-          for f in apps/tauri/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg; do
-            mv "$f" "${f%.dmg}-apple-silicon.dmg"
-            echo "Renamed (apple-silicon): $(basename "$f")"
-          done
+          # Both arch builds emit identically named .app.tar.gz / .dmg files.
+          # Uploading two assets with the same name to one release races in the
+          # upload action and intermittently fails the job. Suffix every macOS
+          # artifact (and its updater .sig) with its architecture so names are
+          # unique and latest.json can serve the correct binary per arch.
+          tag_macos_artifacts() {
+            local triple="$1" suffix="$2" base
+            base="apps/tauri/src-tauri/target/${triple}/release/bundle"
+            for f in "${base}"/dmg/*.dmg; do
+              mv "$f" "${f%.dmg}-${suffix}.dmg"
+              echo "Renamed (${suffix}): $(basename "$f")"
+            done
+            for f in "${base}"/macos/*.app.tar.gz; do
+              mv "$f" "${f%.app.tar.gz}-${suffix}.app.tar.gz"
+              echo "Renamed (${suffix}): $(basename "$f")"
+            done
+            for f in "${base}"/macos/*.app.tar.gz.sig; do
+              mv "$f" "${f%.app.tar.gz.sig}-${suffix}.app.tar.gz.sig"
+              echo "Renamed (${suffix}): $(basename "$f")"
+            done
+          }
+          tag_macos_artifacts x86_64-apple-darwin intel
+          tag_macos_artifacts aarch64-apple-darwin apple-silicon
           echo "::endgroup::"
 
       - name: Upload Release Assets
@@ -478,18 +494,30 @@ jobs:
             echo "::warning::Linux AppImage signature not found at $APPIMAGE_SIG"
           fi
 
-          # macOS (single .app.tar.gz served for both architectures)
-          MAC_SIG="temp/AI-Job-Hunter-Assistant.app.tar.gz.sig"
-          if [ -f "$MAC_SIG" ]; then
-            SIG=$(tr -d '\n' < "$MAC_SIG")
-            for triple in darwin-x86_64 darwin-aarch64; do
-              echo "    \"$triple\": {" >> latest.json
-              echo "      \"signature\": \"$SIG\"," >> latest.json
-              echo "      \"url\": \"${BASE_URL}/AI-Job-Hunter-Assistant.app.tar.gz\"" >> latest.json
-              echo '    },' >> latest.json
-            done
+          # macOS — arch-specific .app.tar.gz bundles. Each arch build produces
+          # its own (non-universal) bundle, so each updater target must point at
+          # the matching file + signature. Names come from the macOS
+          # disambiguation step in the build job (-intel / -apple-silicon).
+          MAC_INTEL_SIG="temp/AI-Job-Hunter-Assistant-intel.app.tar.gz.sig"
+          if [ -f "$MAC_INTEL_SIG" ]; then
+            SIG=$(tr -d '\n' < "$MAC_INTEL_SIG")
+            echo '    "darwin-x86_64": {' >> latest.json
+            echo "      \"signature\": \"$SIG\"," >> latest.json
+            echo "      \"url\": \"${BASE_URL}/AI-Job-Hunter-Assistant-intel.app.tar.gz\"" >> latest.json
+            echo '    },' >> latest.json
           else
-            echo "::warning::macOS app bundle signature not found at $MAC_SIG"
+            echo "::warning::macOS Intel app bundle signature not found at $MAC_INTEL_SIG"
+          fi
+
+          MAC_ARM_SIG="temp/AI-Job-Hunter-Assistant-apple-silicon.app.tar.gz.sig"
+          if [ -f "$MAC_ARM_SIG" ]; then
+            SIG=$(tr -d '\n' < "$MAC_ARM_SIG")
+            echo '    "darwin-aarch64": {' >> latest.json
+            echo "      \"signature\": \"$SIG\"," >> latest.json
+            echo "      \"url\": \"${BASE_URL}/AI-Job-Hunter-Assistant-apple-silicon.app.tar.gz\"" >> latest.json
+            echo '    },' >> latest.json
+          else
+            echo "::warning::macOS Apple Silicon app bundle signature not found at $MAC_ARM_SIG"
           fi
 
           # Close JSON (remove trailing comma and close)

--- a/apps/tauri/src-tauri/src/updater/mod.rs
+++ b/apps/tauri/src-tauri/src/updater/mod.rs
@@ -85,7 +85,7 @@ pub async fn updater_check(app: AppHandle) -> Value {
         Err(e) => {
             let msg = e.to_string();
             let user_msg = if msg.contains("missing field") && msg.contains("signature") {
-                "Update check failed: Release is not properly signed. Please check UPDATER_SETUP.md for instructions.".to_string()
+                "Update check failed: Release is not properly signed. See docs/DEPLOYMENT.md (Updater signing keys).".to_string()
             } else if msg.contains("invalid encoding") || msg.contains("minisign") {
                 "Update check failed: Signature file is corrupted or invalid.".to_string()
             } else if msg.contains("404") || msg.contains("not found") {

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
   "plugins": {
     "dialog": null,
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENCOEQxRUVBQkM4NjA1NzIKUldSeUJZYTg2aDZOeXloRU5kYXora3UxOExlYUtsSWtDM2l6UHUvMy94Y3ZHT0JZWml0N3FPRGoK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQxQzk4NkM0NEJGQkQ0RjkKUldUNTFQdEx4SWJKUWJNU29HRk9JU3RRL0luZ3pmK1hzVmljajFvWjJicEJ2MEJ3Zzg4Q3hwSmsK",
       "endpoints": [
         "https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/latest/download/latest.json"
       ]

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -153,6 +153,30 @@ In `apps/tauri/src-tauri/tauri.conf.json`:
 }
 ```
 
+### Updater signing keys
+
+Every release artifact the updater consumes (NSIS `.exe`, Linux `.AppImage`, macOS `.app.tar.gz`) is signed with a **minisign** key. The shipped app verifies each downloaded update against the public key baked into it.
+
+There are exactly two halves of **one** key pair, and they must always match:
+
+| Half        | Where it lives                                                     | Secret? |
+| ----------- | ------------------------------------------------------------------ | ------- |
+| Private key | GitHub secret `TAURI_SIGNING_PRIVATE_KEY` (+ `…_PASSWORD`) — signs | Yes     |
+| Public key  | `plugins.updater.pubkey` in `tauri.conf.json` — verifies           | No      |
+
+The public key is **committed in `tauri.conf.json` as the single source of truth.** CI does not inject it — `scripts/sync-tauri-version.cjs` only syncs version numbers. If the committed public key ever stops matching `TAURI_SIGNING_PRIVATE_KEY`, every shipped update fails at download with `invalid encoding in minisign data` (or a signature error), because the app cannot verify an artifact signed by an unknown key.
+
+`scripts/verify-updater-key.cjs` runs in the release build and **fails the build before publishing** if a freshly-signed artifact's key id does not match the committed public key — so this can never silently regress.
+
+#### Rotating the key
+
+1. Generate a new pair: `bash scripts/generate-tauri-signing-key.sh`
+2. Set the GitHub secrets `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` to the new private key + password.
+3. Put the matching public key (contents of `~/.tauri/ajh.key.pub`) into `plugins.updater.pubkey` in `tauri.conf.json` and commit it.
+4. Cut a release. The CI guard confirms the pair matches.
+
+> **One-time break across a rotation:** users on a build signed by the _old_ key cannot auto-update to a release signed by the _new_ key — their app only trusts the old public key. They must download and reinstall once. Every release after that auto-updates normally.
+
 ---
 
 ## Code Signing

--- a/scripts/generate-tauri-signing-key.sh
+++ b/scripts/generate-tauri-signing-key.sh
@@ -15,12 +15,12 @@
 #         Content: the entire contents of ~/.tauri/ajh.key
 #   2. Add TAURI_SIGNING_PRIVATE_KEY_PASSWORD to GitHub Secrets:
 #         Content: the password you entered (or empty string if none)
-#   3. Add TAURI_SIGNING_PUBLIC_KEY to GitHub Secrets:
-#         Content: the public key printed below (also in ~/.tauri/ajh.key.pub)
-#   4. In apps/tauri/src-tauri/tauri.conf.json, replace the placeholder
-#      pubkey with the real public key from TAURI_SIGNING_PUBLIC_KEY.
-#      The CI pipeline injects this automatically via the sync-tauri-version
-#      script, but the value in the repo must be valid base64.
+#   3. Commit the PUBLIC key into apps/tauri/src-tauri/tauri.conf.json at
+#      plugins.updater.pubkey — paste the contents of ~/.tauri/ajh.key.pub
+#      verbatim. The public key is NOT a secret; it is the single source of
+#      truth the app verifies updates against, so it lives in the repo (CI does
+#      not inject it). It must match the private key from step 1, or the
+#      auto-updater breaks. See docs/DEPLOYMENT.md (Updater signing keys).
 
 set -euo pipefail
 
@@ -45,5 +45,6 @@ echo ""
 echo "Next steps:"
 echo "  1. Add the private key file contents as GitHub secret TAURI_SIGNING_PRIVATE_KEY"
 echo "  2. Add your key password as TAURI_SIGNING_PRIVATE_KEY_PASSWORD (empty string if none)"
-echo "  3. Add the public key above as TAURI_SIGNING_PUBLIC_KEY"
-echo "  4. The CI pipeline reads TAURI_SIGNING_PUBLIC_KEY and injects it into tauri.conf.json"
+echo "  3. Paste the public key above into plugins.updater.pubkey in"
+echo "     apps/tauri/src-tauri/tauri.conf.json and commit it (it is not a secret)"
+echo "  4. CI verifies the committed pubkey matches the signing key on every release"

--- a/scripts/sync-tauri-version.cjs
+++ b/scripts/sync-tauri-version.cjs
@@ -2,20 +2,21 @@
 /**
  * sync-tauri-version.js
  *
- * Syncs the semantic-release version into all three Tauri version fields and
- * injects the minisign public key from the environment.
+ * Syncs the semantic-release version into all Tauri version fields.
  *
  * Usage:
  *   node scripts/sync-tauri-version.js <version>
  *
- * Required env vars:
- *   TAURI_SIGNING_PUBLIC_KEY  — base64-encoded minisign public key
- *                               (from the TAURI_SIGNING_PUBLIC_KEY GitHub secret)
+ * The updater public key is NOT touched here. It is committed directly in
+ * tauri.conf.json (a public key is not a secret) so it is the single source of
+ * truth and cannot silently diverge from the signing key. See
+ * docs/DEPLOYMENT.md (Updater signing keys).
  *
  * Files updated:
- *   apps/tauri/src-tauri/tauri.conf.json  — version + plugins.updater.pubkey
+ *   apps/tauri/src-tauri/tauri.conf.json  — version
  *   apps/tauri/src-tauri/Cargo.toml       — [package] version
  *   apps/tauri/package.json               — version
+ *   package.json                          — version
  */
 
 'use strict';
@@ -29,12 +30,6 @@ if (!version) {
   process.exit(1);
 }
 
-const pubkey = process.env.TAURI_SIGNING_PUBLIC_KEY;
-if (!pubkey) {
-  console.error('TAURI_SIGNING_PUBLIC_KEY environment variable is required');
-  process.exit(1);
-}
-
 const root = path.resolve(__dirname, '..');
 
 // ── tauri.conf.json ────────────────────────────────────────────────────────
@@ -42,11 +37,8 @@ const root = path.resolve(__dirname, '..');
 const confPath = path.join(root, 'apps/tauri/src-tauri/tauri.conf.json');
 const conf = JSON.parse(fs.readFileSync(confPath, 'utf8'));
 conf.version = version;
-conf.plugins = conf.plugins ?? {};
-conf.plugins.updater = conf.plugins.updater ?? {};
-conf.plugins.updater.pubkey = pubkey;
 fs.writeFileSync(confPath, JSON.stringify(conf, null, 2) + '\n');
-console.log(`tauri.conf.json  → version=${version}, pubkey injected`);
+console.log(`tauri.conf.json  → version=${version}`);
 
 // ── Cargo.toml ─────────────────────────────────────────────────────────────
 

--- a/scripts/verify-updater-key.cjs
+++ b/scripts/verify-updater-key.cjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * verify-updater-key.cjs
+ *
+ * CI guard against a broken auto-updater. It proves that the public key
+ * committed in tauri.conf.json (the key shipped apps verify updates with) is
+ * the public half of the private key that just signed the release artifacts.
+ *
+ * If they diverge, every shipped update fails minisign verification at download
+ * time ("invalid encoding in minisign data" / signature errors) and the build
+ * is aborted before anything is published.
+ *
+ * Usage:
+ *   node scripts/verify-updater-key.cjs [sigFileOrDir ...]
+ *
+ * With no arguments it recursively scans the Tauri bundle output for *.sig
+ * files. Pass explicit paths to narrow the check.
+ *
+ * Exit codes: 0 = all signatures match the committed key · 1 = mismatch / no
+ * signatures found / unreadable key.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const CONF_PATH = path.join(root, 'apps/tauri/src-tauri/tauri.conf.json');
+const DEFAULT_SCAN_DIR = path.join(root, 'apps/tauri/src-tauri/target');
+
+// Directories under target/ that are large and never hold updater bundles.
+const SKIP_DIRS = new Set([
+  'deps',
+  'incremental',
+  '.fingerprint',
+  'build',
+  'examples',
+  '.cargo',
+  'node_modules',
+]);
+
+/**
+ * Extract the 8-byte minisign key id from a minisign blob.
+ * Accepts either the raw two/four-line text or its base64 wrapping (the form
+ * Tauri writes into .sig files and the updater `pubkey` field).
+ */
+function keyIdFromMinisign(value, { label }) {
+  let text = value.trim();
+  if (!text.includes('untrusted comment')) {
+    text = Buffer.from(text, 'base64').toString('utf8');
+  }
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  if (lines.length < 2) {
+    throw new Error(`${label}: not a valid minisign blob (missing key line)`);
+  }
+  const raw = Buffer.from(lines[1].trim(), 'base64');
+  // layout: 2-byte signature algorithm + 8-byte key id + payload
+  if (raw.length < 10) {
+    throw new Error(`${label}: minisign payload too short (got ${raw.length} bytes)`);
+  }
+  const keyId = Buffer.from(raw.subarray(2, 10)).reverse().toString('hex').toUpperCase();
+  return { keyId, algo: raw.subarray(0, 2).toString('latin1') };
+}
+
+function readCommittedPubKeyId() {
+  const conf = JSON.parse(fs.readFileSync(CONF_PATH, 'utf8'));
+  const pubkey = conf?.plugins?.updater?.pubkey;
+  if (!pubkey || typeof pubkey !== 'string') {
+    throw new Error('tauri.conf.json has no plugins.updater.pubkey');
+  }
+  return keyIdFromMinisign(pubkey, { label: 'tauri.conf.json pubkey' }).keyId;
+}
+
+function collectSigFiles(target) {
+  const stat = fs.statSync(target);
+  if (stat.isFile()) return target.endsWith('.sig') ? [target] : [];
+
+  const found = [];
+  const stack = [target];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) stack.push(path.join(dir, entry.name));
+      } else if (entry.name.endsWith('.sig')) {
+        found.push(path.join(dir, entry.name));
+      }
+    }
+  }
+  return found;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const targets = args.length ? args : [DEFAULT_SCAN_DIR];
+
+  let expectedKeyId;
+  try {
+    expectedKeyId = readCommittedPubKeyId();
+  } catch (err) {
+    console.error(`✗ Could not read committed updater public key: ${err.message}`);
+    process.exit(1);
+  }
+
+  const sigFiles = [...new Set(targets.flatMap((t) => collectSigFiles(t)))];
+  if (sigFiles.length === 0) {
+    console.error('✗ No .sig files found to verify.');
+    console.error(`  Searched: ${targets.join(', ')}`);
+    process.exit(1);
+  }
+
+  console.log(`Committed updater public key id: ${expectedKeyId}`);
+  console.log(`Checking ${sigFiles.length} signature file(s)…`);
+
+  const mismatches = [];
+  for (const sig of sigFiles) {
+    const rel = path.relative(root, sig);
+    try {
+      const { keyId } = keyIdFromMinisign(fs.readFileSync(sig, 'utf8'), { label: rel });
+      if (keyId === expectedKeyId) {
+        console.log(`  ✓ ${rel} (${keyId})`);
+      } else {
+        console.log(`  ✗ ${rel} (${keyId})`);
+        mismatches.push({ rel, keyId });
+      }
+    } catch (err) {
+      console.log(`  ✗ ${rel} — ${err.message}`);
+      mismatches.push({ rel, keyId: 'unreadable' });
+    }
+  }
+
+  if (mismatches.length) {
+    console.error('');
+    console.error('✗ Updater key mismatch — shipped apps would reject these updates.');
+    console.error(`  Committed pubkey id: ${expectedKeyId}`);
+    for (const m of mismatches) console.error(`  Signed with:         ${m.keyId}  (${m.rel})`);
+    console.error('');
+    console.error('  The TAURI_SIGNING_PRIVATE_KEY used to sign must match the pubkey');
+    console.error('  in tauri.conf.json. See docs/DEPLOYMENT.md (Updater signing keys).');
+    process.exit(1);
+  }
+
+  console.log('✓ All signatures match the committed updater public key.');
+}
+
+main();


### PR DESCRIPTION
## Summary

Fixes two independent bugs in the release/updater pipeline that left the auto-updater broken for a long time.

**1. Updater verified against the wrong signing key** — the app shipped with public key `CB8D1EEABC860572`, but every release (v0.17.0, v0.18.0, …) is signed with `41C986C44BFBD4F9`, so `download()` always failed with `invalid encoding in minisign data`. The build also overwrote the committed key from a wrong/malformed `TAURI_SIGNING_PUBLIC_KEY` secret on every run, so fixing `tauri.conf.json` alone never stuck.

- Commit the correct public key (`41C986…`) and make `tauri.conf.json` the single source of truth.
- Stop injecting the pubkey from a secret in `sync-tauri-version.cjs` (a public key isn't secret).
- New `scripts/verify-updater-key.cjs` CI guard fails the build if a freshly-signed artifact's key id ≠ the committed key — so this can't silently regress.

**2. v0.19.0 release failed (macOS)** — the macOS leg builds two bundles (Intel + Apple Silicon) that both emit the identical filename `AI-Job-Hunter-Assistant.app.tar.gz`. Uploading two same-named assets to one release races in `softprops/action-gh-release`; v0.18.0 won the race, v0.19.0 lost → macOS job failed → manifest job skipped → no `latest.json`.

- Suffix each macOS artifact + `.sig` with `-intel` / `-apple-silicon`.
- Map each `darwin-*` entry in `latest.json` to its own tarball + signature (also fixes serving the wrong-arch binary to one Mac architecture).

## Verification

- [x] Decoded key ids: committed pubkey now `41C986…`, matches published release signatures.
- [x] `verify-updater-key.cjs` passes against the real v0.18.0 signature; exits non-zero on mismatch.
- [x] `release.yml` parses as valid YAML; macOS rename logic dry-run produces unique `-intel` / `-apple-silicon` names.
- [x] `node --check` + ESLint clean on changed scripts.

## After merge (manual)

- A `fix:` → patch release will build with the corrected key and unique macOS names. Re-running the failed v0.19.0 job won't help (that tag predates this fix).
- Existing installs (≤ v0.19.0) must be **reinstalled once** — their baked-in key can't verify the corrected updates.
- The `TAURI_SIGNING_PUBLIC_KEY` GitHub secret is now unused and can be deleted. Leave `TAURI_SIGNING_PRIVATE_KEY` (+ password) as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)