### PR TITLE
refactor: centralize data-dir resolution in platform::config (Phase 1)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -602,6 +602,21 @@ jobs:
           cargo clippy --all-targets --all-features -- -D warnings
           echo "::endgroup::"
 
+      # Architecture guardrail (see docs/ARCHITECTURE_ROADMAP.md, Phase 1).
+      # The data-dir env var + path fallback must live ONLY in platform/config.rs.
+      - name: 🚧 Architecture Guardrail — centralized data dir
+        working-directory: apps/tauri/src-tauri/src
+        run: |
+          echo "::group::Checking AJH_DATA_DIR ownership"
+          matches=$(grep -rn "AJH_DATA_DIR" . --include="*.rs" | grep -v "^./platform/config.rs:" || true)
+          if [ -n "$matches" ]; then
+            echo "::error::AJH_DATA_DIR must only be referenced in platform/config.rs. Use platform::config::data_dir() instead."
+            echo "$matches"
+            exit 1
+          fi
+          echo "OK — AJH_DATA_DIR is owned solely by platform/config.rs"
+          echo "::endgroup::"
+
       - name: 📝 Job Summary
         if: always()
         run: |

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.19.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/src/applying/boards/linkedin.rs
+++ b/apps/tauri/src-tauri/src/applying/boards/linkedin.rs
@@ -37,7 +37,7 @@ async fn linkedin_easy_apply(
     posting_url: String,
     ctx: ApplyContext,
 ) -> Result<ApplyResult> {
-    let app_data_dir = resolve_data_dir();
+    let app_data_dir = crate::platform::config::data_dir();
     let selectors = FormSelectors::linkedin();
 
     emit_step(&ctx, "launching", true, Some("Opening LinkedIn posting…"));
@@ -244,14 +244,4 @@ fn emit_step(ctx: &ApplyContext, stage: &str, ok: bool, note: Option<&str>) {
             note: note.map(str::to_string),
         });
     }
-}
-
-fn resolve_data_dir() -> std::path::PathBuf {
-    if let Ok(dir) = std::env::var("AJH_DATA_DIR") {
-        return std::path::PathBuf::from(dir);
-    }
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    std::path::PathBuf::from(home).join(".ajh")
 }

--- a/apps/tauri/src-tauri/src/applying/boards/shared/mod.rs
+++ b/apps/tauri/src-tauri/src/applying/boards/shared/mod.rs
@@ -25,7 +25,7 @@ pub async fn navigate_and_assist(
     selectors: FormSelectors,
     apply_button_selectors: &[&str],
 ) -> Result<ApplyResult> {
-    let app_data_dir = resolve_data_dir();
+    let app_data_dir = crate::platform::config::data_dir();
     let _ = &selectors; // reserved for future form-filling
 
     emit_step(&ctx, "launching", true, Some("Opening browser…"));
@@ -135,16 +135,6 @@ fn emit_step(ctx: &ApplyContext, stage: &str, ok: bool, note: Option<&str>) {
             note: note.map(str::to_string),
         });
     }
-}
-
-fn resolve_data_dir() -> std::path::PathBuf {
-    if let Ok(dir) = std::env::var("AJH_DATA_DIR") {
-        return std::path::PathBuf::from(dir);
-    }
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    std::path::PathBuf::from(home).join(".ajh")
 }
 
 #[cfg(test)]

--- a/apps/tauri/src-tauri/src/applying/boards/shared/test.rs
+++ b/apps/tauri/src-tauri/src/applying/boards/shared/test.rs
@@ -1,20 +1,5 @@
 use super::*;
 
-// Env-var override and default are exercised in a single test: `AJH_DATA_DIR` is
-// process-global, so splitting them into parallel tests races (one's remove_var
-// can land between the other's set_var and read).
-#[test]
-fn test_resolve_data_dir() {
-    // Override via env var.
-    unsafe { std::env::set_var("AJH_DATA_DIR", "/custom/path"); }
-    assert_eq!(resolve_data_dir().to_string_lossy(), "/custom/path");
-
-    // Default falls back to USERPROFILE/HOME and ends with .ajh.
-    unsafe { std::env::remove_var("AJH_DATA_DIR"); }
-    let dir_str = resolve_data_dir().to_string_lossy().to_string();
-    assert!(dir_str.contains(".ajh"));
-}
-
 #[test]
 fn test_emit_step_with_callback() {
     let ctx = ApplyContext {

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -157,16 +157,10 @@ fn main() {
         .setup(|app| {
             let handle = app.handle();
 
-            // Data dir for all persistent state.
-            let data_dir = app.path().app_data_dir().unwrap_or_else(|_| {
-                std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default()).join(".ajh")
-            });
-            // Export so scrapers (which don't have an AppHandle) can resolve
-            // the same directory via `std::env::var("AJH_DATA_DIR")`.
-            if std::env::var_os("AJH_DATA_DIR").is_none() {
-                // SAFETY: only writer, called once before any worker spawns.
-                unsafe { std::env::set_var("AJH_DATA_DIR", &data_dir); }
-            }
+            // Data dir for all persistent state. Resolved + exported once here so
+            // AppHandle-less workers (scrapers/appliers) reach the same path.
+            // All path/env knowledge lives in `platform::config`.
+            let data_dir = platform::config::resolve_and_export_data_dir(handle);
 
             app.manage(std::sync::Arc::new(Mutex::new(AutopilotStore::new(&data_dir))));
             app.manage(Mutex::new(CredentialStore::new(&data_dir)));

--- a/apps/tauri/src-tauri/src/platform/config.rs
+++ b/apps/tauri/src-tauri/src/platform/config.rs
@@ -1,0 +1,71 @@
+//! Centralized configuration & path resolution.
+//!
+//! This module is the **sole owner** of the application data-directory env var
+//! and its filesystem fallback. No other module may read `AJH_DATA_DIR` or
+//! reconstruct the `~/.ajh` path — a CI guardrail enforces this.
+//!
+//! Two resolution contexts exist and must agree on the same directory:
+//! * **Setup** (`resolve_and_export_data_dir`) has an `AppHandle` and uses
+//!   Tauri's authoritative `app_data_dir()`, exporting it so workers can find it.
+//! * **Workers** (`data_dir`) — scrapers/appliers run in spawned tasks with no
+//!   `AppHandle`, so they read the exported env var (falling back to `~/.ajh`).
+
+use std::path::PathBuf;
+
+/// Env var carrying the resolved data dir to AppHandle-less workers.
+const DATA_DIR_ENV: &str = "AJH_DATA_DIR";
+
+/// Fallback directory name under the user's home when the env var is unset.
+const FALLBACK_DIR_NAME: &str = ".ajh";
+
+/// Worker-side resolver (no `AppHandle`). The single copy of this logic.
+///
+/// Reads `AJH_DATA_DIR` (exported by [`resolve_and_export_data_dir`] at setup),
+/// falling back to `<home>/.ajh` where home is `USERPROFILE` (Windows) or `HOME`.
+pub fn data_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var(DATA_DIR_ENV) {
+        return PathBuf::from(dir);
+    }
+    let home = std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .unwrap_or_default();
+    PathBuf::from(home).join(FALLBACK_DIR_NAME)
+}
+
+/// Setup-side resolver (has an `AppHandle`). Resolves the authoritative app data
+/// dir via Tauri and exports it as `AJH_DATA_DIR` so AppHandle-less workers
+/// resolve the same path. Returns the resolved directory.
+pub fn resolve_and_export_data_dir(app: &tauri::AppHandle) -> PathBuf {
+    use tauri::Manager;
+    let dir = app.path().app_data_dir().unwrap_or_else(|_| data_dir());
+    if std::env::var_os(DATA_DIR_ENV).is_none() {
+        // SAFETY: single writer, called once during setup before any worker spawns.
+        unsafe {
+            std::env::set_var(DATA_DIR_ENV, &dir);
+        }
+    }
+    dir
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Env-var override and default are exercised in a single test: `AJH_DATA_DIR`
+    // is process-global, so splitting them into parallel tests races (one's
+    // remove_var can land between the other's set_var and read).
+    #[test]
+    fn data_dir_honors_env_then_falls_back() {
+        // Override via env var.
+        unsafe {
+            std::env::set_var(DATA_DIR_ENV, "/custom/path");
+        }
+        assert_eq!(data_dir().to_string_lossy(), "/custom/path");
+
+        // Default falls back to USERPROFILE/HOME and ends with .ajh.
+        unsafe {
+            std::env::remove_var(DATA_DIR_ENV);
+        }
+        assert!(data_dir().to_string_lossy().contains(FALLBACK_DIR_NAME));
+    }
+}

--- a/apps/tauri/src-tauri/src/platform/mod.rs
+++ b/apps/tauri/src-tauri/src/platform/mod.rs
@@ -1,3 +1,4 @@
 pub mod chrome;
+pub mod config;
 
 pub use chrome::detect_system_chrome;

--- a/apps/tauri/src-tauri/src/scraping/boards/indeed/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/indeed/mod.rs
@@ -50,7 +50,7 @@ impl Scraper for IndeedScraper {
         input: BoardSearchInput,
         ctx: ScrapeContext,
     ) -> anyhow::Result<Vec<JobPosting>> {
-        let data_dir = resolve_data_dir();
+        let data_dir = crate::platform::config::data_dir();
         let client = board_login::build_authed_client(&data_dir, "indeed")?;
 
         let domain = INDEED_DOMAINS
@@ -199,16 +199,6 @@ fn extract_jk_from_href(href: &str) -> Option<&str> {
     let after = &href[jk_start + 3..];
     let end = after.find('&').unwrap_or(after.len());
     Some(&after[..end])
-}
-
-fn resolve_data_dir() -> std::path::PathBuf {
-    if let Ok(dir) = std::env::var("AJH_DATA_DIR") {
-        return std::path::PathBuf::from(dir);
-    }
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    std::path::PathBuf::from(home).join(".ajh")
 }
 
 #[cfg(test)]

--- a/apps/tauri/src-tauri/src/scraping/boards/linkedin/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/linkedin/mod.rs
@@ -26,7 +26,7 @@ impl Scraper for LinkedInScraper {
         let session_data = self.load_session_data().await;
         if session_data.is_some() {
             // Touch the auth-status heartbeat so freshness countdown restarts.
-            crate::scraping::board_login::touch_session(&resolve_data_dir(), "linkedin");
+            crate::scraping::board_login::touch_session(&crate::platform::config::data_dir(), "linkedin");
         }
 
         // Create HTTP client with session
@@ -72,7 +72,7 @@ impl LinkedInScraper {
         use crate::scraping::board_login;
         use crate::scraping::linkedin::session::{Cookie, LinkedInSessionData};
 
-        let data_dir = resolve_data_dir();
+        let data_dir = crate::platform::config::data_dir();
         if board_login::session_is_stale(&data_dir, "linkedin") {
             log::warn!("[linkedin] session is stale — falling back to guest mode");
             return None;
@@ -117,18 +117,6 @@ impl LinkedInScraper {
             last_updated: chrono::Utc::now().timestamp_millis() as u64,
         })
     }
-}
-
-/// Resolve the AJH data directory. `main()` exports `AJH_DATA_DIR` at startup
-/// so scrapers reach the right path even though they have no `AppHandle`.
-fn resolve_data_dir() -> std::path::PathBuf {
-    if let Ok(dir) = std::env::var("AJH_DATA_DIR") {
-        return std::path::PathBuf::from(dir);
-    }
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    std::path::PathBuf::from(home).join(".ajh")
 }
 
 #[cfg(test)]

--- a/apps/tauri/src-tauri/src/scraping/boards/xing/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/xing/mod.rs
@@ -29,7 +29,7 @@ impl Scraper for XingScraper {
         input: BoardSearchInput,
         ctx: ScrapeContext,
     ) -> anyhow::Result<Vec<JobPosting>> {
-        let data_dir = resolve_data_dir();
+        let data_dir = crate::platform::config::data_dir();
         let client = board_login::build_authed_client(&data_dir, "xing")?;
 
         let max_pages = input.pages.min(5).max(1) as usize;
@@ -157,16 +157,6 @@ fn extract_id_from_href(href: &str) -> String {
         .next()
         .unwrap_or("")
         .to_string()
-}
-
-fn resolve_data_dir() -> std::path::PathBuf {
-    if let Ok(dir) = std::env::var("AJH_DATA_DIR") {
-        return std::path::PathBuf::from(dir);
-    }
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    std::path::PathBuf::from(home).join(".ajh")
 }
 
 #[cfg(test)]

--- a/apps/tauri/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/scrape_url/mod.rs
@@ -357,7 +357,7 @@ async fn try_linkedin(url: &str) -> Result<Option<JobPosting>> {
         return Ok(None);
     }
 
-    let data_dir = resolve_data_dir();
+    let data_dir = crate::platform::config::data_dir();
     let client = crate::scraping::board_login::build_authed_client(&data_dir, "linkedin")?;
 
     let res = client.get(url).send().await?;
@@ -663,16 +663,6 @@ async fn try_personio(url: &str) -> Result<Option<JobPosting>> {
     }
 
     Ok(None)
-}
-
-fn resolve_data_dir() -> std::path::PathBuf {
-    if let Ok(dir) = std::env::var("AJH_DATA_DIR") {
-        return std::path::PathBuf::from(dir);
-    }
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_default();
-    std::path::PathBuf::from(home).join(".ajh")
 }
 
 #[cfg(test)]

--- a/docs/ARCHITECTURE_ROADMAP.md
+++ b/docs/ARCHITECTURE_ROADMAP.md
@@ -1,0 +1,330 @@
+# Architecture Standardization Roadmap — AI Job Hunter
+
+Status: **Proposed** · Owner: core · Last updated: 2026-05-28
+
+This document is the source of truth for transforming the codebase from a set of
+independently-built features into a **platform architecture**: centralized
+infrastructure, isolated modules, strict boundaries, observable flows.
+
+It extends — does not replace — [ARCHITECTURE.md](ARCHITECTURE.md) (current
+system shape) and [PATTERNS.md](PATTERNS.md) (recurring patterns). Where this
+roadmap and those docs disagree, those docs describe _today_; this one describes
+_where we are going_ and the sequence to get there.
+
+> **No code changes are made by this document.** Each phase below ships as its
+> own reviewed PR, validated independently, in plan-mode (edits approved before
+> they are written).
+
+---
+
+## 1. North Star — the reference pattern
+
+The AI provider layer is the proven template every other subsystem should
+converge toward:
+
+- [`commands/ai_provider/mod.rs`](../apps/tauri/src-tauri/src/commands/ai_provider/mod.rs)
+- [`pipeline/mod.rs`](../apps/tauri/src-tauri/src/pipeline/mod.rs)
+
+It already embodies all ten principles:
+
+| Principle             | How the reference does it                                                       |
+| --------------------- | ------------------------------------------------------------------------------- |
+| Single responsibility | one client module per provider (`ollama`/`openai`/`anthropic`/`gemini`)         |
+| Centralized infra     | one `resolve()` routing point; one trait; shared auth/trace                     |
+| Strict boundaries     | Ollama host/`/api/*` assumptions isolated in `ollama.rs`                        |
+| No hidden fallbacks   | unknown provider/model = hard error, never a silent default                     |
+| Strong typing         | `ProviderId` enum, `TokenParam` enum, `ModelCapabilities` struct                |
+| Registry              | add a provider = 1 module + 1 enum arm + 1 `resolve` arm                        |
+| Capability-driven     | `capabilities(model).supports_*` gates features, not `model.starts_with(...)`   |
+| Unified flows         | `chat_stream` / `complete` / `embed` lifecycle is identical per provider        |
+| Observability         | `RequestTrace` emits `→`/`←` lines with provider/model/endpoint/status/duration |
+| Isolated failure      | one provider failing returns its own error; others unaffected                   |
+
+And [`pipeline/mod.rs`](../apps/tauri/src-tauri/src/pipeline/mod.rs) composes it:
+`Completer` (bound provider+model+auth), `Stage`/`Pipeline` (ordered steps over a
+shared context), `StageTrace` (per-stage timing). Multi-step generators are
+_workflows on shared infra_, not bespoke feature code.
+
+**Goal of this program:** make the rest of the Rust core look like this.
+
+---
+
+## 2. The principles, mapped to enforcement
+
+Principles only hold if a machine enforces them. Each principle below names the
+mechanism that will keep it true (built incrementally in the phases that follow).
+
+| #   | Principle                  | Enforcement mechanism                                                                                               |
+| --- | -------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| 1   | Single responsibility      | module-ownership convention + review checklist                                                                      |
+| 2   | Centralized infrastructure | shared crates/modules (`platform::config`, `net::http`, `observability`) + clippy/grep lint for banned constructors |
+| 3   | Strict module boundaries   | `pub(crate)` discipline; path/schema/endpoint knowledge confined to owning module                                   |
+| 4   | No hidden fallbacks        | typed errors; `parse()`-style hard-fail constructors; lint banning `unwrap_or_default()` on config                  |
+| 5   | Strong typing over strings | enums + discriminated unions + capability structs; lint banning `.starts_with(` provider/board sniffing             |
+| 6   | Registry-based systems     | one registration site per registry (no parallel catalog + match)                                                    |
+| 7   | Capability-driven          | `*Capabilities` structs; features gate on flags, not identity                                                       |
+| 8   | Unified flows              | shared HTTP / retry / cancellation / trace primitives composed everywhere                                           |
+| 9   | Observability              | `RequestTrace`/`StageTrace` generalized into a shared trace-span helper                                             |
+| 10  | Isolated failure domains   | per-subsystem `Result`; one board/provider/parser failure never aborts the batch                                    |
+
+---
+
+## 3. Current-state gap analysis (grounded)
+
+The renderer and IPC layer are already mature and **not** the priority. Drift
+lives almost entirely in the **Rust core outside AI**.
+
+### Already good ✅
+
+- **Frontend state / IPC.** Per-namespace Zod contracts in
+  [`packages/shared/src/ipc/contracts/`](../packages/shared/src/ipc/contracts/)
+  mirrored as Rust structs in
+  [`ipc_contracts/`](../apps/tauri/src-tauri/src/ipc_contracts/); ports-and-adapters
+  service hooks in [`renderer/services/`](../apps/tauri/src/renderer/services/);
+  state machines in `renderer/lib/machines/`; Zustand stores for UI state.
+- **Logging transport.** Uses the `log` crate everywhere; zero `println!`/`eprintln!`.
+- **AI + pipeline.** The reference pattern (§1).
+
+### Drift, with evidence 🚧 / ❌
+
+| Area              | Principle | State                                                                                                                                                       | Evidence                                                                                                                                                     |
+| ----------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Config + paths    | P2, P3    | ❌ `AJH_DATA_DIR → USERPROFILE/HOME → .ajh` resolution copy-pasted in 6+ files                                                                              | scrape_url:669, boards/xing:163, boards/linkedin:125, boards/indeed:205, applying/boards/shared:141, applying/boards/linkedin:250, plus main.rs:162          |
+| HTTP networking   | P2, P8    | 🚧 A scraping HTTP layer exists but builds a fresh `Client` per request (no pooling); AI / geocoding / profile-import / scrape_url each construct their own | 27 client constructions across 12 files; [`scraping/http/mod.rs:55`](../apps/tauri/src-tauri/src/scraping/http/mod.rs#L55)                                   |
+| Error model       | P4, P5    | ❌ `Result<_, String>` pervasive (~68 sites / 29 files); only 2 typed enums                                                                                 | [`ApplyError`](../apps/tauri/src-tauri/src/applying/error_handler.rs#L6), [`ExtractionError`](../apps/tauri/src-tauri/src/extraction/types.rs#L40)           |
+| Scraping registry | P5, P6    | 🚧 Hardcoded `catalog()` array **and** a separate `match board { "x" => ... }` dispatch — two edit sites per board, magic strings, no capability model      | [`engine/mod.rs:46`](../apps/tauri/src-tauri/src/scraping/engine/mod.rs#L46), [`engine/mod.rs:114`](../apps/tauri/src-tauri/src/scraping/engine/mod.rs#L114) |
+| Observability     | P9        | 🚧 `RequestTrace`/`StageTrace` are excellent but AI-only; scraping/applying/autopilot/jobs have no equivalent span                                          | AI-only in ai_provider + pipeline                                                                                                                            |
+| Failure isolation | P10       | 🚧 Mixed; scraping engine isolates per-job, but batch flows (autopilot, multi-board search) need an explicit per-unit failure boundary audit                | engine isolates per `job_id`; batch policy unconfirmed elsewhere                                                                                             |
+
+---
+
+## 4. Target platform architecture
+
+Introduce a thin set of **shared infrastructure modules** that every feature
+composes. Ownership is explicit: only the named module may know the named detail.
+
+```mermaid
+graph TB
+    subgraph Infra["Shared Infrastructure (compose, never duplicate)"]
+        Config["platform::config\nenv + data dir + paths"]
+        Http["net::http\npooled client, retry, timeout, cancel"]
+        Errors["error::AppError\ntyped hierarchy + IPC envelope"]
+        Obs["observability::trace\nspan helper (timing, status)"]
+    end
+
+    subgraph Features["Feature / domain modules"]
+        Ai["commands::ai_provider\n(reference)"]
+        Pipe["pipeline"]
+        Scrape["scraping (BoardId registry)"]
+        Apply["applying (BoardId registry)"]
+        Docs["documents / extraction / export"]
+        Auto["autopilot + scheduler"]
+        Jobs["jobs / postings / conversations"]
+    end
+
+    Ai --> Http & Errors & Obs & Config
+    Pipe --> Obs & Errors
+    Scrape --> Http & Errors & Obs & Config
+    Apply --> Http & Errors & Obs & Config
+    Docs --> Config & Errors
+    Auto --> Errors & Obs
+    Jobs --> Config & Errors
+```
+
+### Ownership boundaries (target)
+
+| Concern                                                           | Sole owner (target module)                 | Today                                 |
+| ----------------------------------------------------------------- | ------------------------------------------ | ------------------------------------- |
+| env vars, data dir, file paths, storage keys                      | `platform::config`                         | scattered across 6+ files + `main.rs` |
+| HTTP client, headers, retry, timeout, abort                       | `net::http` (generalize `scraping::http`)  | per-feature `reqwest::Client::new()`  |
+| error types + user-facing message + IPC `{code,message}` envelope | `error::AppError`                          | `Result<_, String>` + ad-hoc strings  |
+| request/stage spans (timing, status, context)                     | `observability::trace`                     | `RequestTrace`/`StageTrace` (AI-only) |
+| provider routing + capabilities                                   | `commands::ai_provider`                    | ✅ already                            |
+| board routing + capabilities                                      | `scraping::registry`, `applying::registry` | string `match` + parallel catalog     |
+| SQLite schema + migrations                                        | `db` + per-domain stores                   | mostly ✅ (audit for leaks)           |
+
+---
+
+## 5. Phased roadmap
+
+Foundational-first: build the layers everything composes onto, then migrate
+features onto them, then lock with guardrails. Each phase is **one PR**, ordered
+so later phases depend on earlier ones. Effort is rough (S/M/L); risk reflects
+blast radius.
+
+### Phase 0 — Guardrails scaffold (S, low risk)
+
+- **Goal:** make regression visible before refactoring starts.
+- **Deliver:** this roadmap; a `module-ownership` section in
+  [PATTERNS.md](PATTERNS.md); a CI grep/clippy check skeleton (initially
+  warn-only) for the banned constructs introduced in later phases.
+- **Validate:** doc review; CI job runs and is green (no rules active yet).
+
+### Phase 1 — Centralized config + paths (M, low risk) ⭐ recommended start
+
+> **Status: in review** (branch `refactor/phase1-centralized-config`). Introduced
+> `platform::config` as sole owner of the data-dir env var + path fallback;
+> removed the 6 duplicated `resolve_data_dir()` copies (`env::var("AJH_DATA_DIR")`
+> sites: 9 → 1); added the CI grep guardrail. `OLLAMA_HOST`/`CHROME` deferred.
+
+- **Pain:** the `AJH_DATA_DIR → USERPROFILE/HOME → .ajh` block is duplicated 6+
+  times; storage-path knowledge leaks into scrapers and appliers (violates P2/P3).
+- **Target:** a `platform::config` module owning **all** env reads and path
+  resolution, exposed as a typed, validated `AppPaths` / `AppConfig` resolved
+  once at startup and threaded through managed state.
+
+  ```rust
+  // platform/config.rs (sketch)
+  pub struct AppPaths { data_dir: PathBuf, /* sessions, cache, db ... */ }
+  impl AppPaths {
+      pub fn resolve() -> Result<Self, ConfigError> { /* the ONE copy */ }
+      pub fn session_dir(&self) -> PathBuf { ... }
+  }
+  ```
+
+- **Migration:** introduce module → replace the 6 duplicated blocks with calls →
+  delete the dead helpers. No behavior change (same precedence order).
+- **Validate:** `cargo build` + `cargo test`; manual smoke that data dir resolves
+  identically with/without `AJH_DATA_DIR`.
+- **Guardrail:** lint bans `std::env::var(` outside `platform::config`.
+
+### Phase 2 — Shared HTTP infrastructure (M, medium risk)
+
+- **Pain:** 27 client constructions / 12 files; `scraping::http` rebuilds a
+  `Client` per request (no connection reuse); AI/geocoding/profile-import roll
+  their own (P2/P8).
+- **Target:** generalize `scraping::http` into `net::http` — one pooled
+  `reqwest::Client` (built once, stored in managed state), typed `FetchOptions`
+  (retry/timeout/cancel), size caps, and a `RequestTrace` hook. Providers and
+  scrapers compose it instead of constructing clients.
+- **Migration:** stand up `net::http` with a shared client → migrate
+  `scraping::http` to delegate → migrate AI provider clients → migrate
+  geocoding/profile-import/scrape_url. One provider/scraper per commit inside the PR.
+- **Validate:** build/test; live smoke of one HTTP scraper + one cloud provider
+  call; confirm cancellation still aborts mid-request.
+- **Guardrail:** lint bans `reqwest::Client::new()` / `::builder()` outside `net::http`.
+
+### Phase 3 — Unified typed error hierarchy (L, medium risk)
+
+- **Pain:** ~68 `Result<_, String>` sites; only `ApplyError`/`ExtractionError`
+  typed; no stable error codes to the renderer (P4/P5).
+- **Target:** an `error::AppError` (via `thiserror`) with variants per failure
+  class (Config, Network, Provider, Parse, Storage, Validation, Cancelled, …),
+  each mapping to a stable IPC envelope `{ code, message, retriable }`. Generalize
+  the existing `friendly_api_error` mapping. Subsystem errors become typed and
+  convert into `AppError` at the command boundary.
+- **Migration:** define `AppError` + `From` impls → migrate command-by-command
+  (boundary first, then internals) → fold `ApplyError`/`ExtractionError` in.
+  Incremental; `Result<_, String>` count is the burn-down metric.
+- **Validate:** build/test per subsystem; renderer still renders error states
+  (error envelope shape is additive/back-compatible).
+- **Guardrail:** new commands must return `Result<_, AppError>`; lint warns on new
+  `Result<_, String>` in `commands/`.
+
+### Phase 4 — Shared observability (M, low risk)
+
+- **Pain:** `RequestTrace`/`StageTrace` are AI-only; scraping/applying/autopilot
+  debugging is guesswork (P9).
+- **Target:** an `observability::trace` span helper (begin/end, timing, status,
+  structured fields) that AI keeps using and that scraping engine, applying
+  runtime, autopilot scheduler, and long jobs adopt.
+- **Migration:** extract the shared helper from the AI/pipeline traces (no
+  behavior change there) → add spans to scraping `scrape_board`, applying
+  `runtime`, autopilot scheduler.
+- **Validate:** build/test; confirm log lines appear for a scrape + an autopilot run.
+
+### Phase 5 — Registry + capability elevation (L, medium risk)
+
+- **Pain:** scraping/applying dispatch via string `match` + a parallel hardcoded
+  `catalog()`; adding a board touches ≥2 sites; no capability model (P5/P6/P7).
+- **Target:** `BoardId` enum + `BoardCapabilities` (`mode: Http|Browser`,
+  `requires_session`, `supports_apply`, …) + a single `resolve(BoardId) ->
+&dyn Scraper` registry, exactly mirroring `ProviderId`/`resolve()`. `catalog()`
+  derives from the registry — one registration site.
+- **Migration:** introduce `BoardId` + registry → derive `catalog()` from it →
+  delete the `match` dispatch → repeat for `applying`.
+- **Validate:** build/test; smoke a representative HTTP board, a browser board,
+  and one apply flow.
+- **Guardrail:** lint bans board/provider `.starts_with(` sniffing; adding a board
+  must compile-fail until registered (exhaustive match on `BoardId`).
+
+### Phase 6 — Failure-domain isolation audit (M, medium risk)
+
+- **Goal:** guarantee one unit failing never aborts a batch (P10).
+- **Scope:** audit multi-board search, autopilot batch apply, ingestion/parsing
+  loops; ensure per-unit `Result` with collected partial results + per-unit error
+  reporting (not early-return on first failure).
+- **Validate:** targeted tests injecting a single-unit failure; confirm the batch
+  completes with that unit marked failed.
+
+### Sequencing summary
+
+```
+Phase 0 (guardrail scaffold)
+   └─> Phase 1 (config/paths)  ──┐
+                                 ├─> Phase 3 (errors) ──┐
+   ┌──> Phase 2 (http) ─────────┘                       ├─> Phase 5 (registries)
+   │                                                     │
+   └──> Phase 4 (observability) ─────────────────────────┘ ──> Phase 6 (failure domains)
+```
+
+Phases 1, 2, 4 are largely independent and can interleave; 3 benefits from 1+2
+landing first; 5 benefits from 3; 6 is last.
+
+---
+
+## 6. Guardrails — preventing regression
+
+Built up across phases; each rule lands with the phase that makes it safe.
+
+- **Lint / grep rules (CI, warn → error):**
+  - `std::env::var(` only in `platform::config` (Phase 1)
+  - `reqwest::Client::new()` / `::builder()` only in `net::http` (Phase 2)
+  - new `Result<_, String>` in `commands/` (Phase 3)
+  - provider/board `.starts_with(` identity sniffing (Phase 5)
+- **Type-level:** discriminated-union enums (`ProviderId`, `BoardId`) with
+  exhaustive `match` so adding a variant fails to compile until handled.
+- **Convention:** a "module ownership" table in [PATTERNS.md](PATTERNS.md) — one
+  owner per cross-cutting concern; PR review checklist references it.
+- **Tests:** each shared module ships unit tests; failure-isolation tests in Phase 6.
+
+---
+
+## 7. Per-refactor documentation template
+
+Every phase PR description must include:
+
+1. **Architecture summary** — what the target module owns.
+2. **Data/flow diagram** — request or data lifecycle (Mermaid or ASCII).
+3. **Ownership boundaries** — what moved in, what was deleted.
+4. **Migration notes** — order of operations, back-compat stance.
+5. **Anti-patterns removed** — with before/after counts (e.g. "env::var sites: 9 → 1").
+6. **Tech debt remaining** — what this phase deliberately left.
+7. **Future extension strategy** — how to add the next provider/board/etc.
+
+---
+
+## 8. Out of scope / tech debt acknowledged
+
+- **Renderer refactor.** Already mature; no changes planned beyond consuming the
+  new error envelope (Phase 3).
+- **Cloud sync / remote backend.** Remains backlog (see [ARCHITECTURE_STATUS.md](ARCHITECTURE_STATUS.md)).
+- **Prompt content.** Stays authored in `packages/prompts` (TS); never ported to Rust.
+- **No big-bang rewrite.** Every phase preserves behavior and ships independently.
+
+---
+
+## 9. Future extension strategy
+
+After this program, adding capability is uniform and cheap:
+
+- **New AI provider:** 1 client module + 1 `ProviderId` arm + 1 `resolve` arm (already true).
+- **New job board:** 1 scraper module + 1 `BoardId` arm + capabilities row (Phase 5).
+- **New exporter / parser / integration:** register in its registry; compose
+  `net::http`, `AppError`, `observability::trace`, `platform::config`.
+- **New IPC capability:** unchanged 5-step checklist in [PATTERNS.md](PATTERNS.md),
+  now returning `AppError`.
+
+The test for success: a new feature requires **one implementation file + one
+registration**, composes shared infra, and adds **zero** duplicated config / HTTP
+/ error / trace logic.

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -412,6 +412,23 @@ Never swallow errors silently. If caught by boundary, log via the Pino logger an
 
 ---
 
+## 13. Module Ownership Pattern (Rust core)
+
+Cross-cutting concerns have exactly **one owning module**. No other module may
+reconstruct that concern's logic — this prevents the duplication and hidden
+coupling the [architecture roadmap](ARCHITECTURE_ROADMAP.md) is eliminating.
+
+| Concern                              | Sole owner              | Use instead of rolling your own                                                         |
+| ------------------------------------ | ----------------------- | --------------------------------------------------------------------------------------- |
+| env vars, data dir, filesystem paths | `platform::config`      | `platform::config::data_dir()` — never read `AJH_DATA_DIR` or rebuild `~/.ajh` yourself |
+| AI provider routing + capabilities   | `commands::ai_provider` | `resolve(ProviderId, ..)`                                                               |
+| workflow orchestration               | `pipeline`              | compose `Stage`/`Pipeline`                                                              |
+
+This table grows one row per roadmap phase. Where practical, a CI guardrail
+enforces ownership (e.g. `AJH_DATA_DIR` is grep-banned outside `platform/config.rs`).
+
+---
+
 ## Anti-Patterns to Avoid
 
 | Anti-Pattern                                     | Correct Approach                                                      |
@@ -424,3 +441,4 @@ Never swallow errors silently. If caught by boundary, log via the Pino logger an
 | Inline `{ duration: 0.2, ease: "easeOut" }`      | `transition.fast` from `@/lib/motion`                                 |
 | Hardcoded colors in className                    | `text-brand`, `bg-brand`, etc.                                        |
 | Storing credentials in SQLite                    | OS keychain via `client.credentials`                                  |
+| Reading `AJH_DATA_DIR` / rebuilding `~/.ajh`     | `platform::config::data_dir()`                                        |


### PR DESCRIPTION
## Summary

Phase 1 of the architecture standardization roadmap (`docs/ARCHITECTURE_ROADMAP.md`). Establishes a single owner for the app data-directory env var and filesystem-path fallback, eliminating copy-pasted resolution logic.

- **New `platform::config`** — sole owner of `AJH_DATA_DIR` + the `~/.ajh` fallback:
  - `data_dir()` — worker-side resolver (no `AppHandle`; scrapers/appliers)
  - `resolve_and_export_data_dir(app)` — setup-side resolve via Tauri `app_data_dir()` + export
- **Removed 6 byte-identical `resolve_data_dir()` copies** across scrapers/appliers and the 7th inline copy in `main.rs`. Call sites now use `platform::config::data_dir()`. `env::var("AJH_DATA_DIR")` sites: **9 → 1**.
- **CI guardrail** (quality-checks job): greps `AJH_DATA_DIR` and fails if referenced outside `platform/config.rs`.
- **Docs**: module-ownership pattern in `PATTERNS.md`; Phase 1 status in the roadmap.

Behavior-preserving. One intentional micro-change: `main.rs`'s rare `app_data_dir()`-failed fallback now also tries `USERPROFILE` (via `data_dir()`), unifying it with the worker fallback. `Cargo.lock` aligns `ajh-tauri` 0.19.1 → 0.21.0 to match the already-committed `Cargo.toml`.

Out of scope (deferred): `OLLAMA_HOST` / `CHROME` env reads; typed sub-path accessors.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (no issues)
- [x] `cargo test --all-features` (450 passed, incl. moved `data_dir` test in `platform::config`)
- [x] Guardrail: `AJH_DATA_DIR` appears only in `platform/config.rs`
- [ ] Smoke (reviewer, optional): run a scrape; confirm data dir resolves identically, and `AJH_DATA_DIR=<tmp>` is honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)