### PR TITLE
refactor: centralize HTTP client construction in net::http (Phase 2)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -617,6 +617,22 @@ jobs:
           echo "OK — AJH_DATA_DIR is owned solely by platform/config.rs"
           echo "::endgroup::"
 
+      # Architecture guardrail (see docs/ARCHITECTURE_ROADMAP.md, Phase 2).
+      # reqwest clients must be built ONLY in net/http.rs; everything else
+      # composes net::http::shared() / build_client().
+      - name: 🚧 Architecture Guardrail — centralized HTTP client
+        working-directory: apps/tauri/src-tauri/src
+        run: |
+          echo "::group::Checking reqwest::Client construction ownership"
+          matches=$(grep -rnE "reqwest::Client::(new|builder)\(" . --include="*.rs" | grep -v "^./net/http.rs:" || true)
+          if [ -n "$matches" ]; then
+            echo "::error::reqwest::Client must only be constructed in net/http.rs. Use net::http::shared() or net::http::build_client() instead."
+            echo "$matches"
+            exit 1
+          fi
+          echo "OK — reqwest clients are built solely in net/http.rs"
+          echo "::endgroup::"
+
       - name: 📝 Job Summary
         if: always()
         run: |

--- a/apps/tauri/src-tauri/src/commands/ai.rs
+++ b/apps/tauri/src-tauri/src/commands/ai.rs
@@ -130,10 +130,10 @@ pub async fn ai_test_provider_key(
         Some(k) => k,
         None => return json!({ "success": false, "error": "No API key found" }),
     };
-    let client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-    {
+    let client = match crate::net::http::build_client(crate::net::http::ClientConfig {
+        timeout: Some(std::time::Duration::from_secs(10)),
+        ..Default::default()
+    }) {
         Ok(c) => c,
         Err(e) => {
             return json!({ "success": false, "error": format!("Failed to create client: {}", e) })
@@ -160,10 +160,10 @@ pub async fn ai_list_provider_models(
         Some(k) => k,
         None => return json!([]),
     };
-    let client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-    {
+    let client = match crate::net::http::build_client(crate::net::http::ClientConfig {
+        timeout: Some(std::time::Duration::from_secs(10)),
+        ..Default::default()
+    }) {
         Ok(c) => c,
         Err(_) => return json!([]),
     };
@@ -175,10 +175,10 @@ pub async fn ai_list_provider_models(
 /// section. Cloud models come from `ai_list_provider_models`.
 #[tauri::command]
 pub async fn ai_list_models() -> Value {
-    let client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-    {
+    let client = match crate::net::http::build_client(crate::net::http::ClientConfig {
+        timeout: Some(std::time::Duration::from_secs(5)),
+        ..Default::default()
+    }) {
         Ok(c) => c,
         Err(_) => return json!([]),
     };

--- a/apps/tauri/src-tauri/src/commands/ai_provider/anthropic.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/anthropic.rs
@@ -83,11 +83,9 @@ impl AiProvider for AnthropicClient {
             body["system"] = json!(system_content);
         }
 
-        let response = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(300))
-            .build()
-            .map_err(|e| e.to_string())?
+        let response = crate::net::http::shared()
             .post(&endpoint)
+            .timeout(std::time::Duration::from_secs(300))
             .header("x-api-key", &api_key)
             .header("anthropic-version", VERSION)
             .json(&body)
@@ -224,11 +222,9 @@ impl AiProvider for AnthropicClient {
             body["system"] = json!(system);
         }
 
-        let resp = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(120))
-            .build()
-            .map_err(|e| e.to_string())?
+        let resp = crate::net::http::shared()
             .post(&endpoint)
+            .timeout(std::time::Duration::from_secs(120))
             .header("x-api-key", &api_key)
             .header("anthropic-version", VERSION)
             .json(&body)

--- a/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
@@ -74,11 +74,9 @@ impl AiProvider for GeminiClient {
         }
 
         let url = format!("{BASE}{endpoint_label}?key={api_key}");
-        let response = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(300))
-            .build()
-            .map_err(|e| e.to_string())?
+        let response = crate::net::http::shared()
             .post(&url)
+            .timeout(std::time::Duration::from_secs(300))
             .json(&body)
             .send()
             .await;
@@ -199,11 +197,9 @@ impl AiProvider for GeminiClient {
         }
 
         let url = format!("{BASE}{endpoint_label}?key={api_key}");
-        let resp = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(120))
-            .build()
-            .map_err(|e| e.to_string())?
+        let resp = crate::net::http::shared()
             .post(&url)
+            .timeout(std::time::Duration::from_secs(120))
             .json(&body)
             .send()
             .await;
@@ -248,11 +244,9 @@ impl AiProvider for GeminiClient {
             "content": { "parts": [{ "text": text }] },
         });
         let url = format!("{BASE}{endpoint_label}?key={api_key}");
-        let resp = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(|e| e.to_string())?
+        let resp = crate::net::http::shared()
             .post(&url)
+            .timeout(std::time::Duration::from_secs(30))
             .json(&body)
             .send()
             .await

--- a/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
@@ -24,13 +24,6 @@ pub fn host() -> String {
     std::env::var("OLLAMA_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string())
 }
 
-fn build_client(timeout_secs: u64) -> Option<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(timeout_secs))
-        .build()
-        .ok()
-}
-
 // ── Provider impl ───────────────────────────────────────────────────────────────
 
 pub struct OllamaClient;
@@ -87,8 +80,13 @@ impl AiProvider for OllamaClient {
             body["options"] = json!({ "temperature": t });
         }
 
-        let client = build_client(300).ok_or_else(|| "Failed to build Ollama client".to_string())?;
-        let resp = match client.post(&endpoint).json(&body).send().await {
+        let resp = match crate::net::http::shared()
+            .post(&endpoint)
+            .timeout(std::time::Duration::from_secs(300))
+            .json(&body)
+            .send()
+            .await
+        {
             Ok(r) => r,
             Err(e) => {
                 trace.end(None, false);
@@ -157,10 +155,12 @@ pub async fn list_tag_models(client: &reqwest::Client) -> Vec<Value> {
 
 /// `(reachable, first_model_name)` for the system health probe.
 pub async fn reachable_model() -> (bool, Option<String>) {
-    let Some(client) = build_client(3) else {
-        return (false, None);
-    };
-    match client.get(format!("{}/api/tags", host())).send().await {
+    match crate::net::http::shared()
+        .get(format!("{}/api/tags", host()))
+        .timeout(std::time::Duration::from_secs(3))
+        .send()
+        .await
+    {
         Ok(r) if r.status().is_success() => {
             let body: Value = r.json().await.unwrap_or_default();
             let model = body
@@ -179,12 +179,12 @@ pub async fn reachable_model() -> (bool, Option<String>) {
 /// Embed `text` with a specific Ollama embedding model. Returns a clear error
 /// (not `None`) so callers can surface why embedding failed.
 pub async fn embed_with(model: &str, text: &str) -> Result<Vec<f64>, String> {
-    let client = build_client(15).ok_or_else(|| "Failed to build Ollama client".to_string())?;
     // Char-boundary-safe truncation (avoids panics on multi-byte input).
     let truncated: String = text.chars().take(8000).collect();
     let body = json!({ "model": model, "prompt": truncated });
-    let resp = client
+    let resp = crate::net::http::shared()
         .post(format!("{}/api/embeddings", host()))
+        .timeout(std::time::Duration::from_secs(15))
         .json(&body)
         .send()
         .await
@@ -204,11 +204,9 @@ pub async fn embed_with(model: &str, text: &str) -> Result<Vec<f64>, String> {
 
 /// Stream a model pull, emitting `jobs:event` progress. Returns when complete.
 pub async fn pull(app: &AppHandle, job_id: &str, model: &str) -> Result<(), String> {
-    let mut response = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(3600))
-        .build()
-        .map_err(|e| e.to_string())?
+    let mut response = crate::net::http::shared()
         .post(format!("{}/api/pull", host()))
+        .timeout(std::time::Duration::from_secs(3600))
         .json(&json!({ "model": model, "stream": true }))
         .send()
         .await
@@ -278,11 +276,9 @@ async fn stream_chat(
         body["options"] = Value::Object(options);
     }
 
-    let response = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(300))
-        .build()
-        .map_err(|e| e.to_string())?
+    let response = crate::net::http::shared()
         .post(&endpoint)
+        .timeout(std::time::Duration::from_secs(300))
         .json(&body)
         .send()
         .await;

--- a/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
@@ -93,11 +93,9 @@ impl AiProvider for OpenAiClient {
             body[field] = json!(mt);
         }
 
-        let response = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(300))
-            .build()
-            .map_err(|e| e.to_string())?
+        let response = crate::net::http::shared()
             .post(&endpoint)
+            .timeout(std::time::Duration::from_secs(300))
             .bearer_auth(&api_key)
             .json(&body)
             .send()
@@ -210,11 +208,9 @@ impl AiProvider for OpenAiClient {
             body["temperature"] = json!(temperature.unwrap_or(0.7));
         }
 
-        let resp = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(120))
-            .build()
-            .map_err(|e| e.to_string())?
+        let resp = crate::net::http::shared()
             .post(&endpoint)
+            .timeout(std::time::Duration::from_secs(120))
             .bearer_auth(&api_key)
             .json(&body)
             .send()
@@ -247,11 +243,9 @@ impl AiProvider for OpenAiClient {
         let api_key = get_provider_key(app, self.id.credential_key()).unwrap_or_default();
         let endpoint = format!("{}/embeddings", self.base_url);
         let trace = RequestTrace::begin(self.id, model, "/embeddings", &self.base_url, false);
-        let resp = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(|e| e.to_string())?
+        let resp = crate::net::http::shared()
             .post(&endpoint)
+            .timeout(std::time::Duration::from_secs(30))
             .bearer_auth(&api_key)
             .json(&json!({ "model": model, "input": text }))
             .send()

--- a/apps/tauri/src-tauri/src/commands/geocoding.rs
+++ b/apps/tauri/src-tauri/src/commands/geocoding.rs
@@ -6,22 +6,18 @@ pub async fn geocode_suggest(query: String) -> Value {
         return json!([]);
     }
 
-    let client = reqwest::Client::builder()
-        .user_agent("ai-job-hunter/1.0")
-        .timeout(std::time::Duration::from_secs(5))
-        .build();
-
-    let client = match client {
-        Ok(c) => c,
-        Err(_) => return json!([]),
-    };
-
     let url = format!(
         "https://nominatim.openstreetmap.org/search?format=json&q={}&limit=5&addressdetails=1",
         urlencoding::encode(&query)
     );
 
-    let response = match client.get(&url).send().await {
+    let response = match crate::net::http::shared()
+        .get(&url)
+        .header(reqwest::header::USER_AGENT, "ai-job-hunter/1.0")
+        .timeout(std::time::Duration::from_secs(5))
+        .send()
+        .await
+    {
         Ok(r) => r,
         Err(_) => return json!([]),
     };

--- a/apps/tauri/src-tauri/src/cover_letter/research/mod.rs
+++ b/apps/tauri/src-tauri/src/cover_letter/research/mod.rs
@@ -53,11 +53,10 @@ impl Enricher for CompanyResearch {
             }
         };
 
-        let http = match reqwest::Client::builder()
-            .use_rustls_tls()
-            .timeout(Duration::from_secs(10))
-            .build()
-        {
+        let http = match crate::net::http::build_client(crate::net::http::ClientConfig {
+            timeout: Some(Duration::from_secs(10)),
+            ..Default::default()
+        }) {
             Ok(c) => c,
             Err(e) => {
                 tracing::error!("research: http client build failed: {e}");

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -33,6 +33,7 @@ mod export;
 mod ipc_contracts;
 mod job_preferences;
 mod jobs;
+mod net;
 mod pipeline;
 mod platform;
 mod postings;

--- a/apps/tauri/src-tauri/src/net/http.rs
+++ b/apps/tauri/src-tauri/src/net/http.rs
@@ -1,0 +1,65 @@
+//! Centralized HTTP client infrastructure.
+//!
+//! This module is the **sole** caller of `reqwest::Client::builder()` /
+//! `reqwest::Client::new()` — a CI guardrail enforces this. Every subsystem
+//! (AI providers, scrapers, geocoding, research, profile import) composes
+//! [`shared`] (or [`build_client`] for stateful variations) instead of building
+//! its own client.
+//!
+//! Design:
+//! * **One pooled client** ([`shared`]), built once and cheaply cloned. It has
+//!   **no global timeout** — callers set per-request timeouts via
+//!   `RequestBuilder::timeout`, so the 5s…3600s spread across the app reuses the
+//!   same connection pool.
+//! * **One TLS backend** (rustls). Unified deliberately so there is a single
+//!   network behavior to reason about.
+//! * [`build_client`] for the one stateful case: a per-session cookie jar
+//!   (board login). Same rustls/pool/UA base.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Default desktop user-agent. Individual requests may override the `User-Agent`
+/// header (e.g. geocoding identifies itself to Nominatim).
+pub const DEFAULT_UA: &str =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+fn base_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .use_rustls_tls()
+        .user_agent(DEFAULT_UA)
+        .pool_max_idle_per_host(10)
+        .pool_idle_timeout(Duration::from_secs(60))
+}
+
+/// The single pooled HTTP client. Built on first use, then cloned (cheap — a
+/// `reqwest::Client` is internally reference-counted). No global timeout: set one
+/// per request with `.timeout(..)`.
+pub fn shared() -> reqwest::Client {
+    static SHARED: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    SHARED
+        .get_or_init(|| base_builder().build().expect("failed to build shared HTTP client"))
+        .clone()
+}
+
+/// Per-client configuration for stateful variations that cannot share the global
+/// pool (currently: a per-session cookie jar).
+#[derive(Default)]
+pub struct ClientConfig {
+    pub timeout: Option<Duration>,
+    pub cookie_jar: Option<Arc<reqwest::cookie::Jar>>,
+}
+
+/// Build a dedicated client from [`ClientConfig`], on the same rustls/pool/UA
+/// base as [`shared`]. Use only when a request-scoped client cannot reuse the
+/// shared pool (e.g. it needs its own cookie jar).
+pub fn build_client(cfg: ClientConfig) -> reqwest::Result<reqwest::Client> {
+    let mut builder = base_builder();
+    if let Some(timeout) = cfg.timeout {
+        builder = builder.timeout(timeout);
+    }
+    if let Some(jar) = cfg.cookie_jar {
+        builder = builder.cookie_provider(jar);
+    }
+    builder.build()
+}

--- a/apps/tauri/src-tauri/src/net/mod.rs
+++ b/apps/tauri/src-tauri/src/net/mod.rs
@@ -1,0 +1,3 @@
+//! Shared networking infrastructure. See [`http`] for the centralized client.
+
+pub mod http;

--- a/apps/tauri/src-tauri/src/profile_import/linkedin.rs
+++ b/apps/tauri/src-tauri/src/profile_import/linkedin.rs
@@ -68,18 +68,9 @@ pub async fn import(url: &str) -> Result<ProfileData, String> {
 // ── HTTP ─────────────────────────────────────────────────────────────────────
 
 async fn fetch_page(url: &str) -> Result<String, String> {
-    let client = reqwest::Client::builder()
-        .user_agent(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
-             AppleWebKit/537.36 (KHTML, like Gecko) \
-             Chrome/124.0.0.0 Safari/537.36",
-        )
-        .timeout(std::time::Duration::from_secs(15))
-        .build()
-        .map_err(|e| format!("http client: {e}"))?;
-
-    let resp = client
+    let resp = crate::net::http::shared()
         .get(url)
+        .timeout(std::time::Duration::from_secs(15))
         .header("Accept-Language", "en-US,en;q=0.9")
         .send()
         .await

--- a/apps/tauri/src-tauri/src/scraping/board_login/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/board_login/mod.rs
@@ -407,15 +407,11 @@ pub fn build_authed_client(app_data_dir: &Path, board_id: &str) -> Result<reqwes
         jar.add_cookie_str(&cookie_str, &url);
     }
 
-    reqwest::Client::builder()
-        .cookie_provider(jar)
-        .user_agent(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
-             (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-        )
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| anyhow!("reqwest client build failed: {e}"))
+    crate::net::http::build_client(crate::net::http::ClientConfig {
+        timeout: Some(std::time::Duration::from_secs(30)),
+        cookie_jar: Some(jar),
+    })
+    .map_err(|e| anyhow!("reqwest client build failed: {e}"))
 }
 
 /// Convenience: build cookie param vec for chromiumoxide page restoration.

--- a/apps/tauri/src-tauri/src/scraping/http/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/http/mod.rs
@@ -52,7 +52,7 @@ pub async fn fetch_text(
             return Err(anyhow::anyhow!("Request cancelled"));
         }
 
-        let client = reqwest::Client::new();
+        let client = crate::net::http::shared();
         let mut request = match opts.method.clone().unwrap_or(reqwest::Method::GET) {
             reqwest::Method::GET => client.get(url),
             reqwest::Method::POST => client.post(url),

--- a/apps/tauri/src-tauri/src/scraping/linkedin/client/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/linkedin/client/mod.rs
@@ -19,12 +19,11 @@ impl LinkedInHttpClient {
         Self {
             session_data,
             user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36".to_string(),
-            client: Client::builder()
-                .pool_max_idle_per_host(10)
-                .pool_idle_timeout(Duration::from_secs(60))
-                .timeout(Duration::from_secs(30))
-                .build()
-                .unwrap(),
+            client: crate::net::http::build_client(crate::net::http::ClientConfig {
+                timeout: Some(Duration::from_secs(30)),
+                ..Default::default()
+            })
+            .expect("failed to build LinkedIn HTTP client"),
             rate_limiter: super::rate_limiter::linkedin_rate_limiter(),
         }
     }

--- a/apps/tauri/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/scrape_url/mod.rs
@@ -58,7 +58,7 @@ async fn try_greenhouse(url: &str) -> Result<Option<JobPosting>> {
         urlencoding::encode(&company),
         urlencoding::encode(&job_id),
     );
-    let client = reqwest::Client::new();
+    let client = crate::net::http::shared();
     let res = client.get(&api).send().await?;
     if !res.status().is_success() {
         return Ok(None);
@@ -146,7 +146,7 @@ async fn try_lever(url: &str) -> Result<Option<JobPosting>> {
         urlencoding::encode(&company),
         urlencoding::encode(&job_id),
     );
-    let client = reqwest::Client::new();
+    let client = crate::net::http::shared();
     let res = client.get(&api).send().await?;
     if !res.status().is_success() {
         return Ok(None);
@@ -237,7 +237,7 @@ async fn try_ashby(url: &str) -> Result<Option<JobPosting>> {
         "variables": { "organizationHostedJobsPageName": company, "jobPostingId": job_id },
         "query": "query ApiJobPosting($organizationHostedJobsPageName: String!, $jobPostingId: String!) { jobPosting(organizationHostedJobsPageName: $organizationHostedJobsPageName, jobPostingId: $jobPostingId) { title locationName departmentName descriptionPlain } }"
     });
-    let client = reqwest::Client::new();
+    let client = crate::net::http::shared();
     let res = client
         .post("https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobPosting")
         .header("content-type", "application/json")
@@ -276,14 +276,11 @@ async fn try_ashby(url: &str) -> Result<Option<JobPosting>> {
 // ── Generic HTML fallback ───────────────────────────────────────────────────
 
 async fn generic_html(url: &str) -> Result<Option<JobPosting>> {
-    let client = reqwest::Client::builder()
-        .user_agent(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
-             (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-        )
+    let res = crate::net::http::shared()
+        .get(url)
         .timeout(std::time::Duration::from_secs(20))
-        .build()?;
-    let res = client.get(url).send().await?;
+        .send()
+        .await?;
     if !res.status().is_success() {
         return Ok(None);
     }
@@ -457,7 +454,7 @@ async fn try_workday(url: &str) -> Result<Option<JobPosting>> {
         tenant, host, tenant, site, req_id
     );
 
-    let client = reqwest::Client::new();
+    let client = crate::net::http::shared();
     let res = client.get(&api).send().await?;
     if !res.status().is_success() {
         return Ok(None);
@@ -525,7 +522,7 @@ async fn try_smartrecruiters(url: &str) -> Result<Option<JobPosting>> {
         urlencoding::encode(job_id)
     );
 
-    let client = reqwest::Client::new();
+    let client = crate::net::http::shared();
     let res = client.get(&api).send().await?;
     if !res.status().is_success() {
         return Ok(None);
@@ -609,7 +606,7 @@ async fn try_personio(url: &str) -> Result<Option<JobPosting>> {
 
     // Fetch the XML feed and find the matching position.
     let feed_url = format!("https://{}", host);
-    let client = reqwest::Client::new();
+    let client = crate::net::http::shared();
     let res = client.get(&feed_url).send().await?;
     if !res.status().is_success() {
         return Ok(None);

--- a/docs/ARCHITECTURE_ROADMAP.md
+++ b/docs/ARCHITECTURE_ROADMAP.md
@@ -190,6 +190,14 @@ blast radius.
 
 ### Phase 2 — Shared HTTP infrastructure (M, medium risk)
 
+> **Status: in review** (branch `refactor/phase2-shared-http`). Introduced
+> `net::http` as the sole owner of `reqwest::Client` construction: one pooled
+> `shared()` client (unified on rustls, no global timeout — callers set
+> per-request timeouts) + `build_client()` for the per-session cookie-jar case.
+> Migrated all 27 constructions across AI providers, scrapers, geocoding,
+> profile-import, and research; added the CI grep guardrail. `native-tls` Cargo
+> feature is now unused (left in place; drop in a later phase).
+
 - **Pain:** 27 client constructions / 12 files; `scraping::http` rebuilds a
   `Client` per request (no connection reuse); AI/geocoding/profile-import roll
   their own (P2/P8).

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -418,11 +418,12 @@ Cross-cutting concerns have exactly **one owning module**. No other module may
 reconstruct that concern's logic — this prevents the duplication and hidden
 coupling the [architecture roadmap](ARCHITECTURE_ROADMAP.md) is eliminating.
 
-| Concern                              | Sole owner              | Use instead of rolling your own                                                         |
-| ------------------------------------ | ----------------------- | --------------------------------------------------------------------------------------- |
-| env vars, data dir, filesystem paths | `platform::config`      | `platform::config::data_dir()` — never read `AJH_DATA_DIR` or rebuild `~/.ajh` yourself |
-| AI provider routing + capabilities   | `commands::ai_provider` | `resolve(ProviderId, ..)`                                                               |
-| workflow orchestration               | `pipeline`              | compose `Stage`/`Pipeline`                                                              |
+| Concern                              | Sole owner              | Use instead of rolling your own                                                                                               |
+| ------------------------------------ | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| env vars, data dir, filesystem paths | `platform::config`      | `platform::config::data_dir()` — never read `AJH_DATA_DIR` or rebuild `~/.ajh` yourself                                       |
+| AI provider routing + capabilities   | `commands::ai_provider` | `resolve(ProviderId, ..)`                                                                                                     |
+| HTTP clients (TLS, pool, user-agent) | `net::http`             | `net::http::shared()` + per-request `.timeout()`, or `build_client()` for a cookie jar — never `reqwest::Client::new/builder` |
+| workflow orchestration               | `pipeline`              | compose `Stage`/`Pipeline`                                                                                                    |
 
 This table grows one row per roadmap phase. Where practical, a CI guardrail
 enforces ownership (e.g. `AJH_DATA_DIR` is grep-banned outside `platform/config.rs`).
@@ -442,3 +443,4 @@ enforces ownership (e.g. `AJH_DATA_DIR` is grep-banned outside `platform/config.
 | Hardcoded colors in className                    | `text-brand`, `bg-brand`, etc.                                        |
 | Storing credentials in SQLite                    | OS keychain via `client.credentials`                                  |
 | Reading `AJH_DATA_DIR` / rebuilding `~/.ajh`     | `platform::config::data_dir()`                                        |
+| `reqwest::Client::new()` / `::builder()`         | `net::http::shared()` or `net::http::build_client()`                  |


### PR DESCRIPTION
## Summary

Phase 2 of the architecture standardization roadmap (`docs/ARCHITECTURE_ROADMAP.md`). Establishes a single owner for `reqwest::Client` construction, replacing 27 ad-hoc client builds.

- **New `net::http`** — sole caller of `reqwest::Client::builder()`/`::new()`:
  - `shared()` — one pooled client, built once and cheaply cloned, **no global timeout** (callers set per-request `.timeout()`), unified on **rustls**.
  - `build_client(ClientConfig)` — dedicated client for the per-session cookie-jar case (board login) and callers that pass a client into a function (configured client-level timeout).
- **Migrated all 27 constructions** across AI providers (openai/anthropic/gemini/ollama), `commands/ai.rs`, geocoding, profile-import, cover-letter research, and scrapers (`scrape_url`, `scraping::http`, `board_login`, linkedin client). `reqwest::Client` construction sites: **27 → 1**.
- **CI guardrail** (quality-checks job): fails if `reqwest::Client::new(`/`::builder(` appears outside `net/http.rs`.
- **Docs**: `net::http` row in the module-ownership table + anti-pattern row; Phase 2 status in the roadmap.

### Behavior notes
- **TLS unified on rustls** for the whole app (decision: single network behavior). Previously AI + scrapers used the default native-tls; only research used rustls. The `native-tls` Cargo feature is now unused — left in place (dropping it is a dependency change for a later phase).
- Per-request timeouts preserve every prior timeout (5s…3600s); geocoding keeps its Nominatim `User-Agent` via a per-request header.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (no issues)
- [x] `cargo test --all-features` (450 passed)
- [x] Guardrail: `reqwest::Client::new(`/`::builder(` appear only in `net/http.rs`
- [ ] Smoke (reviewer — TLS backend changed for AI + scrapers): (a) one cloud AI generation streams OK over rustls; (b) one HTTP scrape returns results; (c) a geocoding lookup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)