### PR TITLE
refactor: typed error hierarchy (AppError) for the Rust core (Phase 3)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -633,6 +633,22 @@ jobs:
           echo "OK — reqwest clients are built solely in net/http.rs"
           echo "::endgroup::"
 
+      # Architecture guardrail (see docs/ARCHITECTURE_ROADMAP.md, Phase 3).
+      # Internal fallible code uses AppResult/AppError, not Result<_, String>.
+      # (Test files and error.rs are exempt.)
+      - name: 🚧 Architecture Guardrail — typed errors
+        working-directory: apps/tauri/src-tauri/src
+        run: |
+          echo "::group::Checking for Result<_, String> outside error.rs"
+          matches=$(grep -rnE "Result<[^=]*, String>" . --include="*.rs" | grep -v "test.rs:" | grep -v "^./error.rs:" || true)
+          if [ -n "$matches" ]; then
+            echo "::error::Use AppResult/AppError (crate::error) instead of Result<_, String>."
+            echo "$matches"
+            exit 1
+          fi
+          echo "OK — no stringly-typed Result outside error.rs"
+          echo "::endgroup::"
+
       - name: 📝 Job Summary
         if: always()
         run: |

--- a/apps/tauri/src-tauri/src/ai_generations/mod.rs
+++ b/apps/tauri/src-tauri/src/ai_generations/mod.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use crate::data_store::DataStore;
 use crate::db::{run_migrations, Migration};
+use crate::error::AppResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiGenerationRecord {
@@ -70,7 +71,7 @@ impl AiGenerationStore {
         },
     }];
 
-    pub fn open(data_dir: &PathBuf) -> Result<Self, String> {
+    pub fn open(data_dir: &PathBuf) -> AppResult<Self> {
         std::fs::create_dir_all(data_dir).map_err(|e| e.to_string())?;
         let path = data_dir.join("ai_generations.db");
         let conn = Connection::open(&path).map_err(|e| e.to_string())?;
@@ -118,7 +119,7 @@ impl AiGenerationStore {
         .unwrap_or_default()
     }
 
-    pub fn insert(&self, rec: &AiGenerationRecord) -> Result<(), String> {
+    pub fn insert(&self, rec: &AiGenerationRecord) -> AppResult<()> {
         let top_req_json = serde_json::to_string(&rec.top_requirements).unwrap_or_default();
         let conn = self.conn.lock();
         conn.execute(
@@ -148,7 +149,7 @@ impl AiGenerationStore {
         Ok(())
     }
 
-    pub fn remove(&self, id: &str) -> Result<(), String> {
+    pub fn remove(&self, id: &str) -> AppResult<()> {
         let conn = self.conn.lock();
         conn.execute("DELETE FROM ai_generations WHERE id = ?1", params![id])
             .map_err(|e| e.to_string())?;
@@ -176,7 +177,7 @@ impl DataStore for AiGenerationStore {
         serde_json::json!(self.list())
     }
 
-    fn import(&self, data: &serde_json::Value) -> Result<usize, String> {
+    fn import(&self, data: &serde_json::Value) -> AppResult<usize> {
         let items = data.as_array().ok_or("aiGenerations: expected an array")?;
         self.clear_all();
         let mut count = 0;

--- a/apps/tauri/src-tauri/src/autopilot/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot/mod.rs
@@ -11,6 +11,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::error::AppResult;
+
 // ── Data model ────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -318,7 +320,7 @@ impl crate::data_store::DataStore for AutopilotStore {
         serde_json::json!(self.list())
     }
 
-    fn import(&self, data: &serde_json::Value) -> Result<usize, String> {
+    fn import(&self, data: &serde_json::Value) -> AppResult<usize> {
         let items: Vec<Autopilot> =
             serde_json::from_value(data.clone()).map_err(|e| e.to_string())?;
         let count = items.len();

--- a/apps/tauri/src-tauri/src/autopilot_helpers/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot_helpers/mod.rs
@@ -1,5 +1,6 @@
 use crate::scraping::{BoardSearchInput, JobPosting, ScraperEngine};
 use crate::autopilot::AutopilotTarget;
+use crate::error::{AppError, AppResult};
 use tauri::{AppHandle, Emitter};
 use tokio_util::sync::CancellationToken;
 
@@ -9,7 +10,7 @@ pub async fn autopilot_scrape(
     target: &AutopilotTarget,
     job_id: &str,
     app: &AppHandle,
-) -> Result<Vec<JobPosting>, String> {
+) -> AppResult<Vec<JobPosting>> {
     let input = BoardSearchInput {
         query: target.query.clone(),
         location: target.location.clone(),
@@ -50,7 +51,7 @@ pub async fn autopilot_scrape(
         )
         .await;
 
-    result.map_err(|e| e.to_string())
+    result.map_err(AppError::from)
 }
 
 /// Rank job postings by semantic similarity to resume

--- a/apps/tauri/src-tauri/src/commands/ai.rs
+++ b/apps/tauri/src-tauri/src/commands/ai.rs
@@ -53,11 +53,11 @@ pub async fn ai_generate(app: AppHandle, req: AiGenerateRequest) -> Value {
     // 2. Provider must be known.
     let provider_id = match ProviderId::parse(&provider_str) {
         Ok(id) => id,
-        Err(e) => return fail(&app, &job_id, e),
+        Err(e) => return fail(&app, &job_id, e.to_string()),
     };
     // 3. Model must belong to the active provider.
     if let Err(e) = provider_id.validate_model(&req.model) {
-        return fail(&app, &job_id, e);
+        return fail(&app, &job_id, e.to_string());
     }
 
     log::info!(
@@ -72,11 +72,12 @@ pub async fn ai_generate(app: AppHandle, req: AiGenerateRequest) -> Value {
     tauri::async_runtime::spawn(async move {
         let provider = resolve(provider_id, base_url);
         if let Err(e) = provider.chat_stream(&app_clone, &job_id_clone, &req).await {
-            emit_stream_error(&app_clone, &job_id_clone, &e);
+            let msg = e.to_string();
+            emit_stream_error(&app_clone, &job_id_clone, &msg);
             app_clone
                 .state::<Mutex<JobTracker>>()
                 .lock()
-                .fail(&job_id_clone, e);
+                .fail(&job_id_clone, msg);
         }
     });
 
@@ -207,7 +208,7 @@ pub async fn ai_pull_model(app: AppHandle, model: String) -> Value {
                 app_clone
                     .state::<Mutex<JobTracker>>()
                     .lock()
-                    .fail(&job_id_clone, e);
+                    .fail(&job_id_clone, e.to_string());
             }
         }
     });

--- a/apps/tauri/src-tauri/src/commands/ai_provider/anthropic.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/anthropic.rs
@@ -8,6 +8,8 @@ use tauri::{AppHandle, Emitter, Manager};
 use crate::commands::ai::get_provider_key;
 use crate::jobs::JobTracker;
 
+use crate::error::{AppError, AppResult};
+
 use super::{
     friendly_api_error, AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, RequestTrace,
     TokenParam,
@@ -43,7 +45,7 @@ impl AiProvider for AnthropicClient {
         app: &AppHandle,
         job_id: &str,
         req: &AiGenerateRequest,
-    ) -> Result<(), String> {
+    ) -> AppResult<()> {
         let api_key = get_provider_key(app, self.id().credential_key()).unwrap_or_default();
         let endpoint = format!("{BASE}/messages");
         let trace = RequestTrace::begin(ProviderId::Anthropic, &req.model, "/messages", BASE, true);
@@ -96,7 +98,7 @@ impl AiProvider for AnthropicClient {
             Ok(r) => r,
             Err(e) => {
                 trace.end(None, false);
-                return Err(format!("Anthropic unreachable: {e}"));
+                return Err(AppError::Network(format!("Anthropic unreachable: {e}")));
             }
         };
 
@@ -114,7 +116,7 @@ impl AiProvider for AnthropicClient {
                 if job.status == crate::jobs::JobStatus::Cancelled {
                     drop(response);
                     trace.end(Some(status.as_u16()), false);
-                    return Err("Job cancelled".to_string());
+                    return Err(AppError::Message("Job cancelled".to_string()));
                 }
             }
 
@@ -187,7 +189,7 @@ impl AiProvider for AnthropicClient {
                 Ok(None) => break,
                 Err(e) => {
                     trace.end(Some(status.as_u16()), false);
-                    return Err(format!("Stream error: {e}"));
+                    return Err(AppError::Network(format!("Stream error: {e}")));
                 }
             }
         }
@@ -207,7 +209,7 @@ impl AiProvider for AnthropicClient {
         system: &str,
         user: &str,
         temperature: Option<f64>,
-    ) -> Result<String, String> {
+    ) -> AppResult<String> {
         let api_key = get_provider_key(app, self.id().credential_key()).unwrap_or_default();
         let endpoint = format!("{BASE}/messages");
         let trace = RequestTrace::begin(ProviderId::Anthropic, model, "/messages", BASE, false);
@@ -234,7 +236,7 @@ impl AiProvider for AnthropicClient {
             Ok(r) => r,
             Err(e) => {
                 trace.end(None, false);
-                return Err(format!("Anthropic unreachable: {e}"));
+                return Err(AppError::Network(format!("Anthropic unreachable: {e}")));
             }
         };
         let status = resp.status();
@@ -256,11 +258,13 @@ impl AiProvider for AnthropicClient {
                     .join("")
             })
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| "Anthropic: unexpected response shape".to_string())
+            .ok_or_else(|| AppError::Provider("Anthropic: unexpected response shape".to_string()))
     }
 
-    async fn embed(&self, _app: &AppHandle, _model: &str, _text: &str) -> Result<Vec<f64>, String> {
-        Err("Anthropic has no embeddings API. Use OpenAI, Gemini, or Ollama for embeddings.".to_string())
+    async fn embed(&self, _app: &AppHandle, _model: &str, _text: &str) -> AppResult<Vec<f64>> {
+        Err(AppError::Provider(
+            "Anthropic has no embeddings API. Use OpenAI, Gemini, or Ollama for embeddings.".to_string(),
+        ))
     }
 
     fn default_embedding_model(&self) -> Option<&'static str> {
@@ -289,7 +293,7 @@ impl AiProvider for AnthropicClient {
         vec![]
     }
 
-    async fn test_key(&self, client: &reqwest::Client, api_key: &str) -> Result<(), String> {
+    async fn test_key(&self, client: &reqwest::Client, api_key: &str) -> AppResult<()> {
         let resp = client
             .post(format!("{BASE}/messages"))
             .header("x-api-key", api_key)
@@ -307,7 +311,7 @@ impl AiProvider for AnthropicClient {
         if resp.status().is_success() || resp.status() == 400 {
             Ok(())
         } else {
-            Err(format!("API returned status: {}", resp.status()))
+            Err(AppError::Provider(format!("API returned status: {}", resp.status())))
         }
     }
 }

--- a/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
@@ -8,6 +8,8 @@ use tauri::{AppHandle, Emitter, Manager};
 use crate::commands::ai::get_provider_key;
 use crate::jobs::JobTracker;
 
+use crate::error::{AppError, AppResult};
+
 use super::{
     friendly_api_error, AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, RequestTrace,
     TokenParam,
@@ -41,7 +43,7 @@ impl AiProvider for GeminiClient {
         app: &AppHandle,
         job_id: &str,
         req: &AiGenerateRequest,
-    ) -> Result<(), String> {
+    ) -> AppResult<()> {
         let api_key = get_provider_key(app, self.id().credential_key()).unwrap_or_default();
         let endpoint_label = format!("/v1beta/models/{}:streamGenerateContent", req.model);
         let trace = RequestTrace::begin(ProviderId::Gemini, &req.model, &endpoint_label, BASE, true);
@@ -85,7 +87,7 @@ impl AiProvider for GeminiClient {
             Ok(r) => r,
             Err(e) => {
                 trace.end(None, false);
-                return Err(format!("Gemini unreachable: {e}"));
+                return Err(AppError::Network(format!("Gemini unreachable: {e}")));
             }
         };
 
@@ -106,7 +108,7 @@ impl AiProvider for GeminiClient {
                 if job.status == crate::jobs::JobStatus::Cancelled {
                     drop(response);
                     trace.end(Some(status.as_u16()), false);
-                    return Err("Job cancelled".to_string());
+                    return Err(AppError::Message("Job cancelled".to_string()));
                 }
             }
 
@@ -162,7 +164,7 @@ impl AiProvider for GeminiClient {
                 Ok(None) => break,
                 Err(e) => {
                     trace.end(Some(status.as_u16()), false);
-                    return Err(format!("Stream error: {e}"));
+                    return Err(AppError::Network(format!("Stream error: {e}")));
                 }
             }
         }
@@ -182,7 +184,7 @@ impl AiProvider for GeminiClient {
         system: &str,
         user: &str,
         temperature: Option<f64>,
-    ) -> Result<String, String> {
+    ) -> AppResult<String> {
         let api_key = get_provider_key(app, self.id().credential_key()).unwrap_or_default();
         let m = model.strip_prefix("models/").unwrap_or(model);
         let endpoint_label = format!("/v1beta/models/{m}:generateContent");
@@ -207,7 +209,7 @@ impl AiProvider for GeminiClient {
             Ok(r) => r,
             Err(e) => {
                 trace.end(None, false);
-                return Err(format!("Gemini unreachable: {e}"));
+                return Err(AppError::Network(format!("Gemini unreachable: {e}")));
             }
         };
         let status = resp.status();
@@ -231,10 +233,10 @@ impl AiProvider for GeminiClient {
                     .join("")
             })
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| "Gemini: unexpected response shape".to_string())
+            .ok_or_else(|| AppError::Provider("Gemini: unexpected response shape".to_string()))
     }
 
-    async fn embed(&self, app: &AppHandle, model: &str, text: &str) -> Result<Vec<f64>, String> {
+    async fn embed(&self, app: &AppHandle, model: &str, text: &str) -> AppResult<Vec<f64>> {
         let api_key = get_provider_key(app, self.id().credential_key()).unwrap_or_default();
         let m = model.strip_prefix("models/").unwrap_or(model);
         let endpoint_label = format!("/v1beta/models/{m}:embedContent");
@@ -263,7 +265,7 @@ impl AiProvider for GeminiClient {
             .and_then(|e| e.get("values"))
             .and_then(|v| v.as_array())
             .map(|arr| arr.iter().filter_map(|v| v.as_f64()).collect())
-            .ok_or_else(|| "Gemini: missing embedding in response".to_string())
+            .ok_or_else(|| AppError::Provider("Gemini: missing embedding in response".to_string()))
     }
 
     fn default_embedding_model(&self) -> Option<&'static str> {
@@ -290,7 +292,7 @@ impl AiProvider for GeminiClient {
         vec![]
     }
 
-    async fn test_key(&self, client: &reqwest::Client, api_key: &str) -> Result<(), String> {
+    async fn test_key(&self, client: &reqwest::Client, api_key: &str) -> AppResult<()> {
         let resp = client
             .get(format!("{BASE}/v1/models?key={api_key}"))
             .send()
@@ -299,7 +301,7 @@ impl AiProvider for GeminiClient {
         if resp.status().is_success() {
             Ok(())
         } else {
-            Err(format!("API returned status: {}", resp.status()))
+            Err(AppError::Provider(format!("API returned status: {}", resp.status())))
         }
     }
 }

--- a/apps/tauri/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/mod.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Emitter};
 
+use crate::error::{AppError, AppResult};
 pub use crate::ipc_contracts::ai::AiGenerateRequest;
 
 mod anthropic;
@@ -45,16 +46,16 @@ pub enum ProviderId {
 
 impl ProviderId {
     /// Parse a wire string. Unknown values are a hard error — never a fallback.
-    pub fn parse(s: &str) -> Result<Self, String> {
+    pub fn parse(s: &str) -> AppResult<Self> {
         match s {
             "ollama" => Ok(Self::Ollama),
             "openai" => Ok(Self::OpenAi),
             "openai-compatible" => Ok(Self::OpenAiCompatible),
             "anthropic" => Ok(Self::Anthropic),
             "gemini" => Ok(Self::Gemini),
-            other => Err(format!(
+            other => Err(AppError::Config(format!(
                 "Unknown AI provider '{other}'. Select a configured provider in Settings → AI."
-            )),
+            ))),
         }
     }
 
@@ -82,10 +83,12 @@ impl ProviderId {
     /// Reject obvious provider/model mismatches server-side (do not trust the UI).
     /// Lenient for Ollama and OpenAI-compatible servers, where model names are
     /// arbitrary; strict for the native cloud providers with namespaced models.
-    pub fn validate_model(&self, model: &str) -> Result<(), String> {
+    pub fn validate_model(&self, model: &str) -> AppResult<()> {
         let m = model.trim().to_ascii_lowercase();
         if m.is_empty() {
-            return Err("No model selected for the active provider.".to_string());
+            return Err(AppError::Config(
+                "No model selected for the active provider.".to_string(),
+            ));
         }
         let looks_anthropic = m.starts_with("claude");
         let looks_gemini = m.starts_with("gemini") || m.starts_with("models/gemini");
@@ -96,11 +99,11 @@ impl ProviderId {
             || m.starts_with("o4");
 
         let mismatch = |family: &str| {
-            Err(format!(
+            Err(AppError::Validation(format!(
                 "Model '{model}' looks like a {family} model, but the active provider is {}. \
                  Pick a matching model or switch providers.",
                 self.as_str()
-            ))
+            )))
         };
 
         match self {
@@ -160,7 +163,7 @@ pub trait AiProvider: Send + Sync {
         app: &AppHandle,
         job_id: &str,
         req: &AiGenerateRequest,
-    ) -> Result<(), String>;
+    ) -> AppResult<()>;
 
     /// Non-streaming completion: returns the full assistant text in one shot.
     /// Unlike `chat_stream` it emits no `ai:stream` events and never touches the
@@ -174,11 +177,11 @@ pub trait AiProvider: Send + Sync {
         system: &str,
         user: &str,
         temperature: Option<f64>,
-    ) -> Result<String, String>;
+    ) -> AppResult<String>;
 
     /// Embed a single text, returning the raw vector. Errors when this provider
     /// has no embeddings API (callers gate on `capabilities().supports_embeddings`).
-    async fn embed(&self, app: &AppHandle, model: &str, text: &str) -> Result<Vec<f64>, String>;
+    async fn embed(&self, app: &AppHandle, model: &str, text: &str) -> AppResult<Vec<f64>>;
 
     /// The provider's default embedding model, or `None` if it has no embeddings API.
     fn default_embedding_model(&self) -> Option<&'static str>;
@@ -187,7 +190,7 @@ pub trait AiProvider: Send + Sync {
     async fn list_models(&self, client: &reqwest::Client, api_key: &str) -> Vec<Value>;
 
     /// Validate the stored API key — Ok(()) when the provider is reachable/authed.
-    async fn test_key(&self, client: &reqwest::Client, api_key: &str) -> Result<(), String>;
+    async fn test_key(&self, client: &reqwest::Client, api_key: &str) -> AppResult<()>;
 }
 
 /// Single routing point. `base_url` only applies to OpenAI-compatible servers.
@@ -204,7 +207,7 @@ pub fn resolve(id: ProviderId, base_url: Option<String>) -> Box<dyn AiProvider> 
 }
 
 /// Parse + resolve in one step (used by the settings commands).
-pub fn resolve_by_name(name: &str, base_url: Option<String>) -> Result<Box<dyn AiProvider>, String> {
+pub fn resolve_by_name(name: &str, base_url: Option<String>) -> AppResult<Box<dyn AiProvider>> {
     Ok(resolve(ProviderId::parse(name)?, base_url))
 }
 
@@ -243,22 +246,28 @@ pub async fn embed_text(
     model: &str,
     base_url: Option<String>,
     text: &str,
-) -> Result<EmbeddingVector, String> {
+) -> AppResult<EmbeddingVector> {
     let client = resolve(provider, base_url);
     let model = if model.trim().is_empty() {
         client
             .default_embedding_model()
-            .ok_or_else(|| format!("{} does not support embeddings.", provider.as_str()))?
+            .ok_or_else(|| AppError::Config(format!("{} does not support embeddings.", provider.as_str())))?
             .to_string()
     } else {
         model.to_string()
     };
     if !client.capabilities(&model).supports_embeddings {
-        return Err(format!("{} does not support embeddings.", provider.as_str()));
+        return Err(AppError::Config(format!(
+            "{} does not support embeddings.",
+            provider.as_str()
+        )));
     }
     let values = client.embed(app, &model, text).await?;
     if values.is_empty() {
-        return Err(format!("{} returned an empty embedding.", provider.as_str()));
+        return Err(AppError::Provider(format!(
+            "{} returned an empty embedding.",
+            provider.as_str()
+        )));
     }
     let dim = values.len();
     Ok(EmbeddingVector {
@@ -274,12 +283,12 @@ pub async fn embed_text(
 /// Cosine similarity between two vectors that MUST share an embedding space.
 /// Returns `Err` on a space mismatch — incomparable vectors are never silently
 /// scored (the old behavior returned 0.0 and hid the bug).
-pub fn compare(a: &EmbeddingVector, b: &EmbeddingVector) -> Result<f64, String> {
+pub fn compare(a: &EmbeddingVector, b: &EmbeddingVector) -> AppResult<f64> {
     if a.space != b.space {
-        return Err(format!(
+        return Err(AppError::Validation(format!(
             "refusing to compare embeddings from different spaces: {} vs {}",
             a.space, b.space
-        ));
+        )));
     }
     Ok(cosine(&a.values, &b.values))
 }
@@ -378,19 +387,21 @@ pub fn extract_error_message(body: &str) -> String {
 }
 
 /// Map a provider HTTP error to a clear, actionable message.
-pub fn friendly_api_error(provider: ProviderId, status: reqwest::StatusCode, body: &str) -> String {
+pub fn friendly_api_error(provider: ProviderId, status: reqwest::StatusCode, body: &str) -> AppError {
     let name = provider.as_str();
     let code = status.as_u16();
     let detail = extract_error_message(body);
     match code {
-        401 | 403 => format!("{name}: invalid or unauthorized API key."),
-        404 => format!("{name}: model or endpoint not found — {detail}"),
-        413 => format!("{name}: request too large — try a smaller resume/job ad."),
-        422 => format!("{name}: this model rejected the request — {detail}"),
-        429 => format!("{name}: rate limit or quota reached. Wait a moment or check your plan."),
-        400 => format!("{name}: request rejected — {detail}"),
-        500..=599 => format!("{name}: service error ({code}). Try again shortly."),
-        _ => format!("{name} {code}: {detail}"),
+        401 | 403 => AppError::Config(format!("{name}: invalid or unauthorized API key.")),
+        404 => AppError::Provider(format!("{name}: model or endpoint not found — {detail}")),
+        413 => AppError::Provider(format!("{name}: request too large — try a smaller resume/job ad.")),
+        422 => AppError::Provider(format!("{name}: this model rejected the request — {detail}")),
+        429 => AppError::Network(format!(
+            "{name}: rate limit or quota reached. Wait a moment or check your plan."
+        )),
+        400 => AppError::Provider(format!("{name}: request rejected — {detail}")),
+        500..=599 => AppError::Network(format!("{name}: service error ({code}). Try again shortly.")),
+        _ => AppError::Provider(format!("{name} {code}: {detail}")),
     }
 }
 

--- a/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
@@ -10,6 +10,7 @@ use parking_lot::Mutex;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Emitter, Manager};
 
+use crate::error::{AppError, AppResult};
 use crate::jobs::JobTracker;
 
 use super::{
@@ -52,7 +53,7 @@ impl AiProvider for OllamaClient {
         app: &AppHandle,
         job_id: &str,
         req: &AiGenerateRequest,
-    ) -> Result<(), String> {
+    ) -> AppResult<()> {
         stream_chat(app, job_id, req).await
     }
 
@@ -63,7 +64,7 @@ impl AiProvider for OllamaClient {
         system: &str,
         user: &str,
         temperature: Option<f64>,
-    ) -> Result<String, String> {
+    ) -> AppResult<String> {
         let base = host();
         let endpoint = format!("{base}/api/chat");
         let trace = RequestTrace::begin(ProviderId::Ollama, model, "/api/chat", &base, false);
@@ -90,14 +91,14 @@ impl AiProvider for OllamaClient {
             Ok(r) => r,
             Err(e) => {
                 trace.end(None, false);
-                return Err(format!("Ollama unreachable: {e}"));
+                return Err(AppError::Network(format!("Ollama unreachable: {e}")));
             }
         };
         let status = resp.status();
         if !status.is_success() {
             let body_text = resp.text().await.unwrap_or_default();
             trace.end(Some(status.as_u16()), false);
-            return Err(format!("Ollama {status}: {body_text}"));
+            return Err(AppError::Provider(format!("Ollama {status}: {body_text}")));
         }
         let data: Value = resp.json().await.map_err(|e| format!("Ollama parse: {e}"))?;
         trace.end(Some(status.as_u16()), true);
@@ -105,10 +106,10 @@ impl AiProvider for OllamaClient {
             .and_then(|m| m.get("content"))
             .and_then(|c| c.as_str())
             .map(String::from)
-            .ok_or_else(|| "Ollama: unexpected response shape".to_string())
+            .ok_or_else(|| AppError::Provider("Ollama: unexpected response shape".to_string()))
     }
 
-    async fn embed(&self, _app: &AppHandle, model: &str, text: &str) -> Result<Vec<f64>, String> {
+    async fn embed(&self, _app: &AppHandle, model: &str, text: &str) -> AppResult<Vec<f64>> {
         embed_with(model, text).await
     }
 
@@ -120,12 +121,12 @@ impl AiProvider for OllamaClient {
         list_tag_models(client).await
     }
 
-    async fn test_key(&self, client: &reqwest::Client, _api_key: &str) -> Result<(), String> {
+    async fn test_key(&self, client: &reqwest::Client, _api_key: &str) -> AppResult<()> {
         // Ollama needs no key — a reachable host counts as healthy.
         match client.get(format!("{}/api/tags", host())).send().await {
             Ok(r) if r.status().is_success() => Ok(()),
-            Ok(r) => Err(format!("Ollama returned status: {}", r.status())),
-            Err(e) => Err(format!("Ollama unreachable: {e}")),
+            Ok(r) => Err(AppError::Provider(format!("Ollama returned status: {}", r.status()))),
+            Err(e) => Err(AppError::Network(format!("Ollama unreachable: {e}"))),
         }
     }
 }
@@ -178,7 +179,7 @@ pub async fn reachable_model() -> (bool, Option<String>) {
 
 /// Embed `text` with a specific Ollama embedding model. Returns a clear error
 /// (not `None`) so callers can surface why embedding failed.
-pub async fn embed_with(model: &str, text: &str) -> Result<Vec<f64>, String> {
+pub async fn embed_with(model: &str, text: &str) -> AppResult<Vec<f64>> {
     // Char-boundary-safe truncation (avoids panics on multi-byte input).
     let truncated: String = text.chars().take(8000).collect();
     let body = json!({ "model": model, "prompt": truncated });
@@ -192,7 +193,7 @@ pub async fn embed_with(model: &str, text: &str) -> Result<Vec<f64>, String> {
     let status = resp.status();
     if !status.is_success() {
         let body_text = resp.text().await.unwrap_or_default();
-        return Err(format!("Ollama {status}: {body_text}"));
+        return Err(AppError::Provider(format!("Ollama {status}: {body_text}")));
     }
     let data: Value = resp.json().await.map_err(|e| format!("Ollama parse: {e}"))?;
     let arr = data
@@ -203,7 +204,7 @@ pub async fn embed_with(model: &str, text: &str) -> Result<Vec<f64>, String> {
 }
 
 /// Stream a model pull, emitting `jobs:event` progress. Returns when complete.
-pub async fn pull(app: &AppHandle, job_id: &str, model: &str) -> Result<(), String> {
+pub async fn pull(app: &AppHandle, job_id: &str, model: &str) -> AppResult<()> {
     let mut response = crate::net::http::shared()
         .post(format!("{}/api/pull", host()))
         .timeout(std::time::Duration::from_secs(3600))
@@ -215,7 +216,7 @@ pub async fn pull(app: &AppHandle, job_id: &str, model: &str) -> Result<(), Stri
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        return Err(format!("Ollama {status}: {body}"));
+        return Err(AppError::Provider(format!("Ollama {status}: {body}")));
     }
 
     let mut line_buf = String::new();
@@ -251,7 +252,7 @@ async fn stream_chat(
     app: &AppHandle,
     job_id: &str,
     req: &AiGenerateRequest,
-) -> Result<(), String> {
+) -> AppResult<()> {
     let base = host();
     let endpoint = format!("{base}/api/chat");
     let trace = RequestTrace::begin(ProviderId::Ollama, &req.model, "/api/chat", &base, true);
@@ -287,7 +288,7 @@ async fn stream_chat(
         Ok(r) => r,
         Err(e) => {
             trace.end(None, false);
-            return Err(format!("Ollama unreachable: {e}"));
+            return Err(AppError::Network(format!("Ollama unreachable: {e}")));
         }
     };
 
@@ -295,7 +296,7 @@ async fn stream_chat(
     if !status.is_success() {
         let body_text = response.text().await.unwrap_or_default();
         trace.end(Some(status.as_u16()), false);
-        return Err(format!("Ollama {status}: {body_text}"));
+        return Err(AppError::Provider(format!("Ollama {status}: {body_text}")));
     }
 
     let mut line_buf = String::new();
@@ -304,7 +305,7 @@ async fn stream_chat(
             if job.status == crate::jobs::JobStatus::Cancelled {
                 let _ = response.error_for_status_ref();
                 trace.end(Some(status.as_u16()), false);
-                return Err("Job cancelled".to_string());
+                return Err(AppError::Message("Job cancelled".to_string()));
             }
         }
 
@@ -343,7 +344,7 @@ async fn stream_chat(
             Ok(None) => break,
             Err(e) => {
                 trace.end(Some(status.as_u16()), false);
-                return Err(format!("Stream error: {e}"));
+                return Err(AppError::Network(format!("Stream error: {e}")));
             }
         }
     }

--- a/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
@@ -10,6 +10,8 @@ use tauri::{AppHandle, Emitter, Manager};
 use crate::commands::ai::get_provider_key;
 use crate::jobs::JobTracker;
 
+use crate::error::{AppError, AppResult};
+
 use super::{
     friendly_api_error, AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, RequestTrace,
     TokenParam,
@@ -69,7 +71,7 @@ impl AiProvider for OpenAiClient {
         app: &AppHandle,
         job_id: &str,
         req: &AiGenerateRequest,
-    ) -> Result<(), String> {
+    ) -> AppResult<()> {
         let api_key = get_provider_key(app, self.id.credential_key()).unwrap_or_default();
         let caps = self.capabilities(&req.model);
         let endpoint = format!("{}/chat/completions", self.base_url);
@@ -105,7 +107,7 @@ impl AiProvider for OpenAiClient {
             Ok(r) => r,
             Err(e) => {
                 trace.end(None, false);
-                return Err(format!("{} unreachable: {e}", self.id.as_str()));
+                return Err(AppError::Network(format!("{} unreachable: {e}", self.id.as_str())));
             }
         };
 
@@ -122,7 +124,7 @@ impl AiProvider for OpenAiClient {
                 if job.status == crate::jobs::JobStatus::Cancelled {
                     drop(response);
                     trace.end(Some(status.as_u16()), false);
-                    return Err("Job cancelled".to_string());
+                    return Err(AppError::Message("Job cancelled".to_string()));
                 }
             }
 
@@ -170,7 +172,7 @@ impl AiProvider for OpenAiClient {
                 Ok(None) => break,
                 Err(e) => {
                     trace.end(Some(status.as_u16()), false);
-                    return Err(format!("Stream error: {e}"));
+                    return Err(AppError::Network(format!("Stream error: {e}")));
                 }
             }
         }
@@ -190,7 +192,7 @@ impl AiProvider for OpenAiClient {
         system: &str,
         user: &str,
         temperature: Option<f64>,
-    ) -> Result<String, String> {
+    ) -> AppResult<String> {
         let api_key = get_provider_key(app, self.id.credential_key()).unwrap_or_default();
         let caps = self.capabilities(model);
         let endpoint = format!("{}/chat/completions", self.base_url);
@@ -219,7 +221,7 @@ impl AiProvider for OpenAiClient {
             Ok(r) => r,
             Err(e) => {
                 trace.end(None, false);
-                return Err(format!("{} unreachable: {e}", self.id.as_str()));
+                return Err(AppError::Network(format!("{} unreachable: {e}", self.id.as_str())));
             }
         };
         let status = resp.status();
@@ -236,10 +238,10 @@ impl AiProvider for OpenAiClient {
             .and_then(|m| m.get("content"))
             .and_then(|t| t.as_str())
             .map(String::from)
-            .ok_or_else(|| format!("{}: unexpected response shape", self.id.as_str()))
+            .ok_or_else(|| AppError::Provider(format!("{}: unexpected response shape", self.id.as_str())))
     }
 
-    async fn embed(&self, app: &AppHandle, model: &str, text: &str) -> Result<Vec<f64>, String> {
+    async fn embed(&self, app: &AppHandle, model: &str, text: &str) -> AppResult<Vec<f64>> {
         let api_key = get_provider_key(app, self.id.credential_key()).unwrap_or_default();
         let endpoint = format!("{}/embeddings", self.base_url);
         let trace = RequestTrace::begin(self.id, model, "/embeddings", &self.base_url, false);
@@ -264,7 +266,7 @@ impl AiProvider for OpenAiClient {
             .and_then(|e| e.get("embedding"))
             .and_then(|v| v.as_array())
             .map(|arr| arr.iter().filter_map(|v| v.as_f64()).collect())
-            .ok_or_else(|| format!("{}: missing embedding in response", self.id.as_str()))
+            .ok_or_else(|| AppError::Provider(format!("{}: missing embedding in response", self.id.as_str())))
     }
 
     fn default_embedding_model(&self) -> Option<&'static str> {
@@ -301,7 +303,7 @@ impl AiProvider for OpenAiClient {
         vec![]
     }
 
-    async fn test_key(&self, client: &reqwest::Client, api_key: &str) -> Result<(), String> {
+    async fn test_key(&self, client: &reqwest::Client, api_key: &str) -> AppResult<()> {
         let resp = client
             .get(format!("{}/models", self.base_url))
             .bearer_auth(api_key)
@@ -311,7 +313,7 @@ impl AiProvider for OpenAiClient {
         if resp.status().is_success() {
             Ok(())
         } else {
-            Err(format!("API returned status: {}", resp.status()))
+            Err(AppError::Provider(format!("API returned status: {}", resp.status())))
         }
     }
 }

--- a/apps/tauri/src-tauri/src/commands/autopilot.rs
+++ b/apps/tauri/src-tauri/src/commands/autopilot.rs
@@ -98,7 +98,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
         Ok(p) => p,
         Err(e) => {
             engine.unregister_token(&job_id).await;
-            app.state::<Mutex<crate::jobs::JobTracker>>().lock().fail(&job_id, e.clone());
+            app.state::<Mutex<crate::jobs::JobTracker>>().lock().fail(&job_id, e.to_string());
             return json!({ "error": e, "jobId": job_id });
         }
     };

--- a/apps/tauri/src-tauri/src/commands/cover_letter.rs
+++ b/apps/tauri/src-tauri/src/commands/cover_letter.rs
@@ -1,6 +1,7 @@
 use tauri::AppHandle;
 
 use crate::cover_letter::{CoverLetterRequest, CoverLetterResponse};
+use crate::error::AppResult;
 
 /// Generate a cover letter entirely server-side.
 /// API keys never leave Rust — they are read from the OS keychain.
@@ -8,6 +9,6 @@ use crate::cover_letter::{CoverLetterRequest, CoverLetterResponse};
 pub async fn generate_cover_letter(
     app: AppHandle,
     req: CoverLetterRequest,
-) -> Result<CoverLetterResponse, String> {
+) -> AppResult<CoverLetterResponse> {
     crate::cover_letter::run_pipeline(app, req).await
 }

--- a/apps/tauri/src-tauri/src/commands/pipeline.rs
+++ b/apps/tauri/src-tauri/src/commands/pipeline.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 
 use crate::commands::ai_provider::{emit_stream_error, resolve, AiGenerateRequest, ProviderId};
+use crate::error::AppResult;
 use crate::jobs::JobTracker;
 use crate::pipeline::{Pipeline, Stage};
 
@@ -34,7 +35,7 @@ impl Stage<GenerationContext> for StreamGenerateStage {
     fn name(&self) -> &'static str {
         "generate"
     }
-    async fn run(&self, ctx: &mut GenerationContext) -> Result<(), String> {
+    async fn run(&self, ctx: &mut GenerationContext) -> AppResult<()> {
         let provider = resolve(ctx.provider_id, ctx.req.base_url.clone());
         provider.chat_stream(&ctx.app, &ctx.job_id, &ctx.req).await
     }
@@ -68,10 +69,10 @@ pub async fn generate_pipeline(app: AppHandle, req: AiGenerateRequest) -> Value 
     };
     let provider_id = match ProviderId::parse(&provider_str) {
         Ok(id) => id,
-        Err(e) => return fail(&app, &job_id, e),
+        Err(e) => return fail(&app, &job_id, e.to_string()),
     };
     if let Err(e) = provider_id.validate_model(&req.model) {
-        return fail(&app, &job_id, e);
+        return fail(&app, &job_id, e.to_string());
     }
 
     let job_id_clone = job_id.clone();
@@ -85,11 +86,12 @@ pub async fn generate_pipeline(app: AppHandle, req: AiGenerateRequest) -> Value 
         };
         let pipeline = Pipeline::new("generate").add(StreamGenerateStage);
         if let Err(e) = pipeline.run(&mut ctx).await {
-            emit_stream_error(&app_clone, &job_id_clone, &e);
+            let msg = e.to_string();
+            emit_stream_error(&app_clone, &job_id_clone, &msg);
             app_clone
                 .state::<Mutex<JobTracker>>()
                 .lock()
-                .fail(&job_id_clone, e);
+                .fail(&job_id_clone, msg);
         }
     });
 

--- a/apps/tauri/src-tauri/src/commands/system/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/system/mod.rs
@@ -1,5 +1,6 @@
 use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
+use crate::error::{AppError, AppResult};
 use crate::scraping::ScraperEngine;
 
 #[tauri::command]
@@ -87,11 +88,11 @@ pub fn system_open_devtools(app: AppHandle) {
 }
 
 #[tauri::command]
-pub async fn system_open_external(app: AppHandle, url: String) -> Result<(), String> {
+pub async fn system_open_external(app: AppHandle, url: String) -> AppResult<()> {
     use tauri_plugin_opener::OpenerExt;
     app.opener()
         .open_url(&url, None::<&str>)
-        .map_err(|e| e.to_string())
+        .map_err(|e| AppError::Message(e.to_string()))
 }
 
 #[tauri::command]

--- a/apps/tauri/src-tauri/src/conversations/mod.rs
+++ b/apps/tauri/src-tauri/src/conversations/mod.rs
@@ -4,6 +4,7 @@ use parking_lot::Mutex;
 use tauri::{AppHandle, Manager};
 
 use crate::db::{run_migrations, Migration};
+use crate::error::AppResult;
 
 pub struct ConversationDb(pub Mutex<Connection>);
 
@@ -40,7 +41,7 @@ impl ConversationDb {
         std::fs::create_dir_all(&data_dir).ok();
         let conn = Connection::open(data_dir.join("conversations.db"))?;
         run_migrations(&conn, Self::MIGRATIONS)
-            .map_err(|e| rusqlite::Error::InvalidParameterName(e))?;
+            .map_err(|e| rusqlite::Error::InvalidParameterName(e.to_string()))?;
         Ok(Self(Mutex::new(conn)))
     }
 
@@ -84,7 +85,7 @@ impl crate::data_store::DataStore for ConversationDb {
         json!({ "conversations": conversations, "messages": messages })
     }
 
-    fn import(&self, data: &Value) -> Result<usize, String> {
+    fn import(&self, data: &Value) -> AppResult<usize> {
         let conversations = data.get("conversations").and_then(|v| v.as_array());
         let messages = data.get("messages").and_then(|v| v.as_array());
         let conn = self.0.lock();

--- a/apps/tauri/src-tauri/src/cover_letter/leakage/mod.rs
+++ b/apps/tauri/src-tauri/src/cover_letter/leakage/mod.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 use tauri::Emitter;
 
+use crate::error::AppResult;
 use crate::pipeline::validation::{ValidationIssue, ValidationReport, Validator};
 use crate::pipeline::Completer;
 
@@ -32,7 +33,7 @@ impl Validator for LeakageValidator {
         "leakage"
     }
 
-    async fn validate(&self, completer: &Completer, draft: &str) -> Result<ValidationReport, String> {
+    async fn validate(&self, completer: &Completer, draft: &str) -> AppResult<ValidationReport> {
         let _ = completer.app().emit("cover_letter:validation:start", json!({}));
 
         let user = format!(

--- a/apps/tauri/src-tauri/src/cover_letter/mod.rs
+++ b/apps/tauri/src-tauri/src/cover_letter/mod.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Emitter};
 
+use crate::error::AppResult;
 use crate::pipeline::retry::{self, DraftGenerator, RetryPolicy};
 use crate::pipeline::validation::Validator;
 use crate::pipeline::{Completer, Pipeline, Stage};
@@ -154,7 +155,7 @@ impl Stage<CoverLetterContext> for ResearchStage {
     fn name(&self) -> &'static str {
         "research"
     }
-    async fn run(&self, ctx: &mut CoverLetterContext) -> Result<(), String> {
+    async fn run(&self, ctx: &mut CoverLetterContext) -> AppResult<()> {
         if !ctx.enable_research {
             return Ok(());
         }
@@ -180,7 +181,7 @@ impl Stage<CoverLetterContext> for GenerateValidatedStage {
     fn name(&self) -> &'static str {
         "generate"
     }
-    async fn run(&self, ctx: &mut CoverLetterContext) -> Result<(), String> {
+    async fn run(&self, ctx: &mut CoverLetterContext) -> AppResult<()> {
         let generator = CoverLetterDraftGenerator {
             resume_summary: ctx.resume_summary.clone(),
             job_ad: ctx.job_ad.clone(),
@@ -223,7 +224,7 @@ struct CoverLetterDraftGenerator {
 
 #[async_trait]
 impl DraftGenerator for CoverLetterDraftGenerator {
-    async fn generate(&self, completer: &Completer, attempt: u8) -> Result<String, String> {
+    async fn generate(&self, completer: &Completer, attempt: u8) -> AppResult<String> {
         let _ = completer
             .app()
             .emit("cover_letter:generation:start", json!({ "attempt": attempt }));
@@ -243,7 +244,7 @@ impl DraftGenerator for CoverLetterDraftGenerator {
 pub async fn run_pipeline(
     app: AppHandle,
     req: CoverLetterRequest,
-) -> Result<CoverLetterResponse, String> {
+) -> AppResult<CoverLetterResponse> {
     // Resolve the active provider + model through the centralized layer.
     let completer =
         Completer::resolve(&app, req.provider.as_deref(), req.model.as_deref(), req.base_url.clone())

--- a/apps/tauri/src-tauri/src/cover_letter/research/brief.rs
+++ b/apps/tauri/src-tauri/src/cover_letter/research/brief.rs
@@ -1,4 +1,5 @@
 use crate::cover_letter::research::search::SearchResult;
+use crate::error::AppResult;
 use crate::pipeline::Completer;
 
 const SYSTEM: &str = "\
@@ -12,7 +13,7 @@ pub async fn synthesise(
     company: &str,
     role: &str,
     results: &[SearchResult],
-) -> Result<String, String> {
+) -> AppResult<String> {
     if results.is_empty() {
         return Ok(String::new());
     }

--- a/apps/tauri/src-tauri/src/cover_letter/research/search.rs
+++ b/apps/tauri/src-tauri/src/cover_letter/research/search.rs
@@ -1,5 +1,7 @@
 use serde_json::Value;
 
+use crate::error::{AppError, AppResult};
+
 const BRAVE_SEARCH_URL: &str = "https://api.search.brave.com/res/v1/web/search";
 
 /// A single search result snippet.
@@ -18,7 +20,7 @@ pub async fn brave_search(
     api_key: &str,
     query: &str,
     limit: usize,
-) -> Result<Vec<SearchResult>, String> {
+) -> AppResult<Vec<SearchResult>> {
     let resp = client
         .get(BRAVE_SEARCH_URL)
         .header("Accept", "application/json")
@@ -32,7 +34,7 @@ pub async fn brave_search(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(format!("brave search {status}: {body}"));
+        return Err(AppError::Network(format!("brave search {status}: {body}")));
     }
 
     let body: Value = resp.json().await.map_err(|e| format!("brave search parse: {e}"))?;

--- a/apps/tauri/src-tauri/src/credentials/mod.rs
+++ b/apps/tauri/src-tauri/src/credentials/mod.rs
@@ -21,6 +21,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use keyring_core::Entry;
 use serde::{Deserialize, Serialize};
 
+use crate::error::AppResult;
+
 const SERVICE: &str = "com.ajh.tauri";
 
 /// Initialise the OS-native keyring backend. Must be called once before any
@@ -88,7 +90,7 @@ impl CredentialStore {
         meta.values().cloned().collect()
     }
 
-    pub fn set(&self, board_id: &str, username: &str, password: &str) -> Result<(), String> {
+    pub fn set(&self, board_id: &str, username: &str, password: &str) -> AppResult<()> {
         Entry::new(SERVICE, board_id)
             .map_err(|e| format!("keyring entry error: {e}"))?
             .set_password(password)
@@ -107,7 +109,7 @@ impl CredentialStore {
         Ok(())
     }
 
-    pub fn remove(&self, board_id: &str) -> Result<(), String> {
+    pub fn remove(&self, board_id: &str) -> AppResult<()> {
         if let Ok(entry) = Entry::new(SERVICE, board_id) {
             // Ignore "not found" — the metadata may exist without a keychain
             // entry if the keychain was cleared externally.

--- a/apps/tauri/src-tauri/src/data_store.rs
+++ b/apps/tauri/src-tauri/src/data_store.rs
@@ -11,6 +11,8 @@
 
 use serde_json::Value;
 
+use crate::error::AppResult;
+
 pub trait DataStore {
     /// Key under which this store's data lives in the export bundle.
     fn key(&self) -> &'static str;
@@ -20,5 +22,5 @@ pub trait DataStore {
 
     /// Replace the store's contents from previously-exported data.
     /// Returns the number of records restored.
-    fn import(&self, data: &Value) -> Result<usize, String>;
+    fn import(&self, data: &Value) -> AppResult<usize>;
 }

--- a/apps/tauri/src-tauri/src/db.rs
+++ b/apps/tauri/src-tauri/src/db.rs
@@ -7,13 +7,15 @@
 /// Migrations must be idempotent where possible (use IF NOT EXISTS, etc.).
 use rusqlite::Connection;
 
+use crate::error::AppResult;
+
 pub struct Migration {
     pub name: &'static str,
     pub up: fn(&Connection) -> rusqlite::Result<()>,
 }
 
 /// Run all pending migrations against `conn`.
-pub fn run_migrations(conn: &Connection, migrations: &[Migration]) -> Result<(), String> {
+pub fn run_migrations(conn: &Connection, migrations: &[Migration]) -> AppResult<()> {
     let current: i64 = conn
         .query_row("PRAGMA user_version", [], |row| row.get(0))
         .map_err(|e| e.to_string())?;

--- a/apps/tauri/src-tauri/src/documents/mod.rs
+++ b/apps/tauri/src-tauri/src/documents/mod.rs
@@ -17,6 +17,7 @@ use tauri::{AppHandle, Manager};
 use crate::commands::ai_provider::{EmbeddingSpace, EmbeddingVector, ProviderId};
 use crate::data_store::DataStore;
 use crate::db::{column_exists, run_migrations, Migration};
+use crate::error::AppResult;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -141,7 +142,7 @@ impl DocumentStore {
         },
     ];
 
-    pub fn open(data_dir: &PathBuf) -> Result<Self, String> {
+    pub fn open(data_dir: &PathBuf) -> AppResult<Self> {
         std::fs::create_dir_all(data_dir).map_err(|e| e.to_string())?;
         let path = data_dir.join("documents.db");
         let conn = Connection::open(&path).map_err(|e| e.to_string())?;
@@ -231,7 +232,7 @@ impl DocumentStore {
         .ok()
     }
 
-    pub fn insert(&self, rec: &DocumentRecord) -> Result<(), String> {
+    pub fn insert(&self, rec: &DocumentRecord) -> AppResult<()> {
         let conn = self.conn.lock();
         // If this is the first document, automatically set it as default
         let count: i64 = conn
@@ -258,14 +259,14 @@ impl DocumentStore {
         Ok(())
     }
 
-    pub fn set_indexed(&self, id: &str) -> Result<(), String> {
+    pub fn set_indexed(&self, id: &str) -> AppResult<()> {
         let conn = self.conn.lock();
         conn.execute("UPDATE documents SET indexed = 1 WHERE id = ?1", params![id])
             .map_err(|e| e.to_string())?;
         Ok(())
     }
 
-    pub fn remove(&self, id: &str) -> Result<(), String> {
+    pub fn remove(&self, id: &str) -> AppResult<()> {
         let conn = self.conn.lock();
         conn.execute("DELETE FROM documents WHERE id = ?1", params![id])
             .map_err(|e| e.to_string())?;
@@ -274,7 +275,7 @@ impl DocumentStore {
         Ok(())
     }
 
-    pub fn set_default(&self, id: &str) -> Result<(), String> {
+    pub fn set_default(&self, id: &str) -> AppResult<()> {
         let conn = self.conn.lock();
         // Clear all defaults, then set the new one
         conn.execute("UPDATE documents SET is_default = 0", [])
@@ -286,7 +287,7 @@ impl DocumentStore {
 
     /// Store a space-tagged vector. The space (`provider`/`model`/`dim`) travels
     /// with the values so comparisons can reject incompatible vectors.
-    pub fn upsert_vector(&self, doc_id: &str, v: &EmbeddingVector) -> Result<(), String> {
+    pub fn upsert_vector(&self, doc_id: &str, v: &EmbeddingVector) -> AppResult<()> {
         let json = serde_json::to_string(&v.values).map_err(|e| e.to_string())?;
         let conn = self.conn.lock();
         conn.execute(
@@ -407,7 +408,7 @@ impl DocumentStore {
         })
     }
 
-    pub fn set_embedding_config(&self, cfg: &EmbeddingConfig) -> Result<(), String> {
+    pub fn set_embedding_config(&self, cfg: &EmbeddingConfig) -> AppResult<()> {
         let conn = self.conn.lock();
         conn.execute(
             "INSERT INTO embedding_config (id, provider, model, base_url, updated_at)
@@ -504,7 +505,7 @@ impl DataStore for DocumentStore {
         serde_json::json!(docs)
     }
 
-    fn import(&self, data: &serde_json::Value) -> Result<usize, String> {
+    fn import(&self, data: &serde_json::Value) -> AppResult<usize> {
         let items = data.as_array().ok_or("documents: expected an array")?;
         self.clear_all();
         let mut count = 0;

--- a/apps/tauri/src-tauri/src/error.rs
+++ b/apps/tauri/src-tauri/src/error.rs
@@ -1,0 +1,156 @@
+//! Unified typed error hierarchy.
+//!
+//! `AppError` replaces stringly-typed `Result<_, String>` across the Rust core.
+//! Every error carries a category (variant) and a human-readable message.
+//!
+//! **Wire format:** `AppError` serializes to its message *string*, so commands
+//! that return `Result<_, AppError>` reject with the same string the renderer
+//! already expects — no frontend change required. The structured
+//! `{ code, retriable }` metadata is available via [`AppError::code`] /
+//! [`AppError::retriable`] for logging today and a structured wire format later.
+
+#[derive(Debug, thiserror::Error)]
+pub enum AppError {
+    /// Misconfiguration: missing provider/model/key, invalid settings.
+    #[error("{0}")]
+    Config(String),
+    /// Transport/IO over the network (reqwest, sockets, timeouts).
+    #[error("{0}")]
+    Network(String),
+    /// An external API / AI provider rejected or failed the request.
+    #[error("{0}")]
+    Provider(String),
+    /// Persistence: SQLite, filesystem, keychain.
+    #[error("{0}")]
+    Storage(String),
+    /// Decoding/encoding: serde, document text extraction.
+    #[error("{0}")]
+    Parse(String),
+    /// A requested entity does not exist.
+    #[error("{0}")]
+    NotFound(String),
+    /// Input failed validation / a precondition was not met.
+    #[error("{0}")]
+    Validation(String),
+    /// The operation was cancelled (user abort, shutdown).
+    /// The operation was cancelled (user abort, shutdown). Reserved for the
+    /// cancellation paths that currently surface bespoke messages.
+    #[allow(dead_code)]
+    #[error("operation cancelled")]
+    Cancelled,
+    /// Uncategorized error. Default target for `From<String>` so existing
+    /// messages migrate verbatim.
+    #[error("{0}")]
+    Message(String),
+}
+
+/// Crate-wide result alias for the typed error.
+pub type AppResult<T> = Result<T, AppError>;
+
+// `code`/`retriable`/`message` are the structured-error surface consumed by a
+// future `{ code, message, retriable }` IPC envelope (roadmap Phase 3 follow-up)
+// and by logging; allowed-dead until that wire format lands.
+#[allow(dead_code)]
+impl AppError {
+    /// Stable machine-readable category code (for logs and a future structured
+    /// wire format).
+    pub fn code(&self) -> &'static str {
+        match self {
+            AppError::Config(_) => "CONFIG",
+            AppError::Network(_) => "NETWORK",
+            AppError::Provider(_) => "PROVIDER",
+            AppError::Storage(_) => "STORAGE",
+            AppError::Parse(_) => "PARSE",
+            AppError::NotFound(_) => "NOT_FOUND",
+            AppError::Validation(_) => "VALIDATION",
+            AppError::Cancelled => "CANCELLED",
+            AppError::Message(_) => "ERROR",
+        }
+    }
+
+    /// Whether retrying the same operation could plausibly succeed.
+    pub fn retriable(&self) -> bool {
+        matches!(self, AppError::Network(_))
+    }
+
+    /// Convenience constructor for an uncategorized message.
+    pub fn message(msg: impl Into<String>) -> Self {
+        AppError::Message(msg.into())
+    }
+}
+
+// Serialize AS A STRING — preserves the existing command wire format exactly
+// (the renderer treats command errors as strings).
+impl serde::Serialize for AppError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+// ── Conversions ──────────────────────────────────────────────────────────────
+// Broad `From` set so existing `?` and `.map_err(|e| e.to_string())?` sites keep
+// compiling after only a signature change, with messages preserved.
+
+impl From<String> for AppError {
+    fn from(s: String) -> Self {
+        AppError::Message(s)
+    }
+}
+
+impl From<&str> for AppError {
+    fn from(s: &str) -> Self {
+        AppError::Message(s.to_string())
+    }
+}
+
+impl From<std::io::Error> for AppError {
+    fn from(e: std::io::Error) -> Self {
+        AppError::Storage(e.to_string())
+    }
+}
+
+impl From<rusqlite::Error> for AppError {
+    fn from(e: rusqlite::Error) -> Self {
+        AppError::Storage(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for AppError {
+    fn from(e: serde_json::Error) -> Self {
+        AppError::Parse(e.to_string())
+    }
+}
+
+impl From<reqwest::Error> for AppError {
+    fn from(e: reqwest::Error) -> Self {
+        AppError::Network(e.to_string())
+    }
+}
+
+impl From<anyhow::Error> for AppError {
+    fn from(e: anyhow::Error) -> Self {
+        AppError::Message(e.to_string())
+    }
+}
+
+impl From<crate::extraction::types::ExtractionError> for AppError {
+    fn from(e: crate::extraction::types::ExtractionError) -> Self {
+        AppError::Parse(e.to_string())
+    }
+}
+
+impl From<crate::applying::error_handler::ApplyError> for AppError {
+    fn from(e: crate::applying::error_handler::ApplyError) -> Self {
+        use crate::applying::error_handler::ApplyError as A;
+        let msg = e.to_string();
+        match e {
+            A::RateLimited | A::NetworkError(_) => AppError::Network(msg),
+            A::SessionExpired => AppError::Config(msg),
+            A::FormNotFound => AppError::NotFound(msg),
+            A::CaptchaDetected | A::Unknown(_) => AppError::Message(msg),
+        }
+    }
+}

--- a/apps/tauri/src-tauri/src/export/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/export/commands/mod.rs
@@ -6,13 +6,16 @@ use super::{
     pdf::generate_pdf,
     types::{ExportFormat, ExportRequest, ExportResult},
 };
+use crate::error::{AppError, AppResult};
 
 /// Tauri command to export resume or cover letter
 #[command]
-pub async fn documents_export_document(mut request: ExportRequest) -> Result<ExportResult, String> {
+pub async fn documents_export_document(mut request: ExportRequest) -> AppResult<ExportResult> {
     // Validate input
     if request.text.trim().is_empty() {
-        return Err("Cannot export empty document. Please generate content first.".to_string());
+        return Err(AppError::Validation(
+            "Cannot export empty document. Please generate content first.".to_string(),
+        ));
     }
 
     // Normalize Unicode before any rendering so unsupported glyphs don't appear
@@ -56,7 +59,7 @@ pub async fn documents_export_document(mut request: ExportRequest) -> Result<Exp
 pub async fn documents_export_and_save(
     app: tauri::AppHandle,
     request: ExportRequest,
-) -> Result<String, String> {
+) -> AppResult<String> {
     // Generate the document
     let result = documents_export_document(request).await?;
 
@@ -78,7 +81,7 @@ pub async fn documents_export_and_save(
     let path = match file_path {
         tauri_plugin_dialog::FilePath::Path(p) => p,
         #[allow(unreachable_patterns)]
-        _ => return Err("Unsupported file path type".to_string()),
+        _ => return Err(AppError::Message("Unsupported file path type".to_string())),
     };
 
     // Write bytes to file

--- a/apps/tauri/src-tauri/src/extraction/docx.rs
+++ b/apps/tauri/src-tauri/src/extraction/docx.rs
@@ -11,8 +11,7 @@ pub fn extract(bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
         ZipArchive::new(cursor).map_err(|e| ExtractionError::DocxError(e.to_string()))?;
 
     let relationships = read_relationships(&mut archive);
-    let document_xml = read_zip_entry(&mut archive, "word/document.xml")
-        .map_err(|e| ExtractionError::DocxError(e))?;
+    let document_xml = read_zip_entry(&mut archive, "word/document.xml")?;
 
     let (text, links) = parse_document(&document_xml, &relationships);
     let confidence = crate::extraction::confidence::score(&text, SourceFormat::Docx);
@@ -28,14 +27,17 @@ pub fn extract(bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
 
 // ── ZIP helpers ───────────────────────────────────────────────────────────────
 
-fn read_zip_entry(archive: &mut ZipArchive<std::io::Cursor<&[u8]>>, name: &str) -> Result<String, String> {
+fn read_zip_entry(
+    archive: &mut ZipArchive<std::io::Cursor<&[u8]>>,
+    name: &str,
+) -> Result<String, ExtractionError> {
     let mut entry = archive
         .by_name(name)
-        .map_err(|_| format!("missing {name} in DOCX archive"))?;
+        .map_err(|_| ExtractionError::DocxError(format!("missing {name} in DOCX archive")))?;
     let mut buf = String::new();
     entry
         .read_to_string(&mut buf)
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| ExtractionError::DocxError(e.to_string()))?;
     Ok(buf)
 }
 

--- a/apps/tauri/src-tauri/src/extraction/mod.rs
+++ b/apps/tauri/src-tauri/src/extraction/mod.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use tracing::{instrument, warn};
 
+use crate::error::{AppError, AppResult};
 use types::{ExtractionError, ExtractedResume, SourceFormat};
 
 const MAX_BYTES: usize = 10 * 1024 * 1024; // 10 MB
@@ -19,18 +20,18 @@ const MAX_BYTES: usize = 10 * 1024 * 1024; // 10 MB
 /// `Display` form of `ExtractionError` reaches the frontend.
 #[tauri::command]
 #[instrument(skip_all, fields(path))]
-pub async fn extract_resume(path: String) -> Result<ExtractedResume, String> {
+pub async fn extract_resume(path: String) -> AppResult<ExtractedResume> {
     tracing::Span::current().record("path", &path.as_str());
 
     let bytes = std::fs::read(&path).map_err(|e| {
         let err = ExtractionError::IoError(e.to_string());
         warn!(%err, "failed to read file");
-        err.to_string()
+        AppError::from(err)
     })?;
 
     route(&path, &bytes).map_err(|e| {
         warn!(error = %e, "extraction failed");
-        e.to_string()
+        AppError::from(e)
     })
 }
 

--- a/apps/tauri/src-tauri/src/job_preferences/mod.rs
+++ b/apps/tauri/src-tauri/src/job_preferences/mod.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::data_store::DataStore;
 use crate::db::{run_migrations, Migration};
+use crate::error::AppResult;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -60,7 +61,7 @@ impl JobPreferencesStore {
         },
     }];
 
-    pub fn open(data_dir: &PathBuf) -> Result<Self, String> {
+    pub fn open(data_dir: &PathBuf) -> AppResult<Self> {
         std::fs::create_dir_all(data_dir).map_err(|e| e.to_string())?;
         let path = data_dir.join("job_preferences.db");
         let conn = Connection::open(&path).map_err(|e| e.to_string())?;
@@ -98,7 +99,7 @@ impl JobPreferencesStore {
         })
     }
 
-    pub fn set(&self, prefs: &JobPreferences) -> Result<(), String> {
+    pub fn set(&self, prefs: &JobPreferences) -> AppResult<()> {
         let conn = self.conn.lock();
         let tech_stack_json = prefs.tech_stack.as_ref()
             .and_then(|ts| serde_json::to_string(ts).ok());
@@ -131,7 +132,7 @@ impl DataStore for JobPreferencesStore {
         serde_json::to_value(self.get()).unwrap_or_else(|_| serde_json::json!({}))
     }
 
-    fn import(&self, data: &serde_json::Value) -> Result<usize, String> {
+    fn import(&self, data: &serde_json::Value) -> AppResult<usize> {
         // Single settings row; treat null/missing as "nothing to restore".
         if data.is_null() {
             return Ok(0);

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -29,6 +29,7 @@ mod conversations;
 mod credentials;
 mod data_store;
 mod documents;
+mod error;
 mod export;
 mod ipc_contracts;
 mod job_preferences;

--- a/apps/tauri/src-tauri/src/pipeline/cache.rs
+++ b/apps/tauri/src-tauri/src/pipeline/cache.rs
@@ -9,6 +9,7 @@ use parking_lot::Mutex;
 use rusqlite::{params, Connection};
 
 use crate::db::{run_migrations, Migration};
+use crate::error::AppResult;
 
 pub struct KvCache {
     conn: Mutex<Connection>,
@@ -30,7 +31,7 @@ impl KvCache {
         },
     }];
 
-    pub fn open(data_dir: &Path) -> Result<Self, String> {
+    pub fn open(data_dir: &Path) -> AppResult<Self> {
         let path = data_dir.join("pipeline_cache.db");
         let conn = Connection::open(&path).map_err(|e| format!("kv cache open: {e}"))?;
         run_migrations(&conn, Self::MIGRATIONS)?;

--- a/apps/tauri/src-tauri/src/pipeline/mod.rs
+++ b/apps/tauri/src-tauri/src/pipeline/mod.rs
@@ -25,6 +25,7 @@ use async_trait::async_trait;
 use tauri::AppHandle;
 
 use crate::commands::ai_provider::{resolve, AiProvider, ProviderId};
+use crate::error::AppResult;
 
 // ── Completer ───────────────────────────────────────────────────────────────────
 
@@ -47,7 +48,7 @@ impl Completer {
         provider: Option<&str>,
         model: Option<&str>,
         base_url: Option<String>,
-    ) -> Result<Self, String> {
+    ) -> AppResult<Self> {
         let provider_str = provider
             .map(str::trim)
             .filter(|s| !s.is_empty())
@@ -71,7 +72,7 @@ impl Completer {
         system: &str,
         user: &str,
         temperature: Option<f64>,
-    ) -> Result<String, String> {
+    ) -> AppResult<String> {
         self.provider
             .complete(&self.app, &self.model, system, user, temperature)
             .await
@@ -90,7 +91,7 @@ impl Completer {
 #[async_trait]
 pub trait Stage<C>: Send + Sync {
     fn name(&self) -> &'static str;
-    async fn run(&self, ctx: &mut C) -> Result<(), String>;
+    async fn run(&self, ctx: &mut C) -> AppResult<()>;
 }
 
 /// An ordered sequence of [`Stage`]s sharing a context. Runs each stage in order,
@@ -110,7 +111,7 @@ impl<C> Pipeline<C> {
         self
     }
 
-    pub async fn run(&self, ctx: &mut C) -> Result<(), String> {
+    pub async fn run(&self, ctx: &mut C) -> AppResult<()> {
         for stage in &self.stages {
             let trace = StageTrace::begin(self.name, stage.name());
             match stage.run(ctx).await {

--- a/apps/tauri/src-tauri/src/pipeline/retry.rs
+++ b/apps/tauri/src-tauri/src/pipeline/retry.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 
 use super::validation::{ValidationReport, Validator};
 use super::Completer;
+use crate::error::AppResult;
 
 /// How many generation attempts a [`generate_validated`] loop may make.
 pub struct RetryPolicy {
@@ -21,7 +22,7 @@ impl RetryPolicy {
 /// (via `completer.app()`); the loop stays generic.
 #[async_trait]
 pub trait DraftGenerator: Send + Sync {
-    async fn generate(&self, completer: &Completer, attempt: u8) -> Result<String, String>;
+    async fn generate(&self, completer: &Completer, attempt: u8) -> AppResult<String>;
 }
 
 /// Result of a generate/validate loop.
@@ -40,7 +41,7 @@ pub async fn generate_validated(
     policy: RetryPolicy,
     generator: &dyn DraftGenerator,
     validator: Option<&dyn Validator>,
-) -> Result<ValidatedDraft, String> {
+) -> AppResult<ValidatedDraft> {
     let mut text = String::new();
     let mut report: Option<ValidationReport> = None;
     let mut retries = 0u8;

--- a/apps/tauri/src-tauri/src/pipeline/test.rs
+++ b/apps/tauri/src-tauri/src/pipeline/test.rs
@@ -3,6 +3,7 @@ use tempfile::TempDir;
 
 use super::cache::KvCache;
 use super::{Pipeline, Stage};
+use crate::error::{AppError, AppResult};
 
 // ── Pipeline ordering / abort ───────────────────────────────────────────────────
 
@@ -16,7 +17,7 @@ impl Stage<Ctx> for Step {
     fn name(&self) -> &'static str {
         self.0
     }
-    async fn run(&self, ctx: &mut Ctx) -> Result<(), String> {
+    async fn run(&self, ctx: &mut Ctx) -> AppResult<()> {
         ctx.log.push(self.0);
         Ok(())
     }
@@ -28,9 +29,9 @@ impl Stage<Ctx> for Boom {
     fn name(&self) -> &'static str {
         "boom"
     }
-    async fn run(&self, ctx: &mut Ctx) -> Result<(), String> {
+    async fn run(&self, ctx: &mut Ctx) -> AppResult<()> {
         ctx.log.push("boom");
-        Err("boom".to_string())
+        Err(AppError::Message("boom".to_string()))
     }
 }
 

--- a/apps/tauri/src-tauri/src/pipeline/validation.rs
+++ b/apps/tauri/src-tauri/src/pipeline/validation.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 
 use super::Completer;
+use crate::error::AppResult;
 
 /// A single problem found in generated content.
 pub struct ValidationIssue {
@@ -30,5 +31,5 @@ impl ValidationReport {
 #[async_trait]
 pub trait Validator: Send + Sync {
     fn name(&self) -> &'static str;
-    async fn validate(&self, completer: &Completer, draft: &str) -> Result<ValidationReport, String>;
+    async fn validate(&self, completer: &Completer, draft: &str) -> AppResult<ValidationReport>;
 }

--- a/apps/tauri/src-tauri/src/profile_import/linkedin.rs
+++ b/apps/tauri/src-tauri/src/profile_import/linkedin.rs
@@ -2,13 +2,14 @@ use scraper::{Html, Selector};
 use serde_json::Value;
 
 use super::ProfileData;
+use crate::error::{AppError, AppResult};
 
 /// Fetch a LinkedIn public profile page and extract structured data.
 ///
 /// LinkedIn embeds `application/ld+json` blocks with schema.org Person/Organization
 /// data on public profile pages. We parse those first; visible HTML sections serve
 /// as a fallback for experience, education, and skills.
-pub async fn import(url: &str) -> Result<ProfileData, String> {
+pub async fn import(url: &str) -> AppResult<ProfileData> {
     let html = fetch_page(url).await?;
     let document = Html::parse_document(&html);
 
@@ -48,9 +49,9 @@ pub async fn import(url: &str) -> Result<ProfileData, String> {
     });
 
     if name.is_none() && experience.is_empty() && skills.is_empty() {
-        return Err(
+        return Err(AppError::Parse(
             "could not extract profile data — the page may require LinkedIn login".to_string(),
-        );
+        ));
     }
 
     Ok(ProfileData {
@@ -67,7 +68,7 @@ pub async fn import(url: &str) -> Result<ProfileData, String> {
 
 // ── HTTP ─────────────────────────────────────────────────────────────────────
 
-async fn fetch_page(url: &str) -> Result<String, String> {
+async fn fetch_page(url: &str) -> AppResult<String> {
     let resp = crate::net::http::shared()
         .get(url)
         .timeout(std::time::Duration::from_secs(15))
@@ -78,12 +79,12 @@ async fn fetch_page(url: &str) -> Result<String, String> {
 
     if !resp.status().is_success() {
         let status = resp.status();
-        return Err(format!(
+        return Err(AppError::Provider(format!(
             "linkedin returned {status} — you may need to log in first"
-        ));
+        )));
     }
 
-    resp.text().await.map_err(|e| format!("read body: {e}"))
+    resp.text().await.map_err(|e| AppError::Network(format!("read body: {e}")))
 }
 
 // ── JSON-LD ───────────────────────────────────────────────────────────────────

--- a/apps/tauri/src-tauri/src/profile_import/mod.rs
+++ b/apps/tauri/src-tauri/src/profile_import/mod.rs
@@ -1,5 +1,7 @@
 pub mod linkedin;
 
+use crate::error::AppResult;
+
 /// Platform-agnostic profile scraping result.
 #[derive(Debug)]
 pub struct ProfileData {
@@ -66,7 +68,7 @@ impl ProfileData {
 }
 
 /// Detects the platform from a URL and delegates to the matching provider.
-pub async fn import_from_url(url: &str) -> Result<ProfileData, String> {
+pub async fn import_from_url(url: &str) -> AppResult<ProfileData> {
     let platform = detect_platform(url).ok_or_else(|| {
         "unsupported profile URL — only LinkedIn is supported at this time".to_string()
     })?;

--- a/docs/ARCHITECTURE_ROADMAP.md
+++ b/docs/ARCHITECTURE_ROADMAP.md
@@ -214,6 +214,14 @@ blast radius.
 
 ### Phase 3 — Unified typed error hierarchy (L, medium risk)
 
+> **Status: in review** (branch `refactor/phase3-typed-errors`). Introduced
+> `error::AppError` (thiserror, `code()`/`retriable()`, broad `From` set) that
+> serializes to its message string — behavior-preserving on the wire. Migrated
+> **all internal `Result<_, String>` → `AppResult`** (sites: 68 → 0 outside
+> `error.rs`/tests); domain enums (`ExtractionError`) compose via `From`; CI grep
+> guardrail added. Deferred (renderer-coupled): the structured `{code,message,
+retriable}` IPC envelope + normalizing the `-> Value`+`{error}` command contract.
+
 - **Pain:** ~68 `Result<_, String>` sites; only `ApplyError`/`ExtractionError`
   typed; no stable error codes to the renderer (P4/P5).
 - **Target:** an `error::AppError` (via `thiserror`) with variants per failure

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -423,6 +423,7 @@ coupling the [architecture roadmap](ARCHITECTURE_ROADMAP.md) is eliminating.
 | env vars, data dir, filesystem paths | `platform::config`      | `platform::config::data_dir()` — never read `AJH_DATA_DIR` or rebuild `~/.ajh` yourself                                       |
 | AI provider routing + capabilities   | `commands::ai_provider` | `resolve(ProviderId, ..)`                                                                                                     |
 | HTTP clients (TLS, pool, user-agent) | `net::http`             | `net::http::shared()` + per-request `.timeout()`, or `build_client()` for a cookie jar — never `reqwest::Client::new/builder` |
+| error types                          | `error::AppError`       | return `AppResult<T>` from fallible internals — never `Result<_, String>` (domain enums like `ExtractionError` add `From`)    |
 | workflow orchestration               | `pipeline`              | compose `Stage`/`Pipeline`                                                                                                    |
 
 This table grows one row per roadmap phase. Where practical, a CI guardrail
@@ -444,3 +445,4 @@ enforces ownership (e.g. `AJH_DATA_DIR` is grep-banned outside `platform/config.
 | Storing credentials in SQLite                    | OS keychain via `client.credentials`                                  |
 | Reading `AJH_DATA_DIR` / rebuilding `~/.ajh`     | `platform::config::data_dir()`                                        |
 | `reqwest::Client::new()` / `::builder()`         | `net::http::shared()` or `net::http::build_client()`                  |
+| `Result<_, String>` for fallible internals       | `AppResult<_>` / `AppError` from `crate::error`                       |


### PR DESCRIPTION
## Summary

Phase 3 of the architecture standardization roadmap (`docs/ARCHITECTURE_ROADMAP.md`). Replaces stringly-typed errors across the Rust core with a unified typed hierarchy.

- **New `error::AppError`** (thiserror) with categorized variants (Config, Network, Provider, Storage, Parse, NotFound, Validation, Cancelled, Message), `code()` + `retriable()`, and a broad `From` set (`String`, `io`, `rusqlite`, `serde_json`, `reqwest`, `anyhow`, `ExtractionError`, `ApplyError`).
- **Behavior-preserving wire format:** `AppError` serializes to its **message string**, so commands that return `Result<_, AppError>` reject with the same string the renderer already expects — no frontend change. (`code`/`retriable` are ready for a future structured `{code,message,retriable}` envelope.)
- **Migrated all internal `Result<_, String>` → `AppResult`** across AI providers, pipeline, cover-letter, the stores/data layer, extraction, profile-import, and the `Result`-returning command handlers. Domain enums (`ExtractionError`) stay distinct and compose via `From`. **Internal `Result<_, String>` sites: 68 → 0** (outside `error.rs`/tests).
- **CI guardrail** (quality-checks job): fails on `Result<_, String>` outside `error.rs` (tests exempt).
- **Docs**: module-ownership + anti-pattern rows; Phase 3 status in the roadmap.

### Explicitly out of scope (renderer-coupled, future phase)
The command boundary is mostly `-> Value` returning `json!({ error })` (promise *resolves*), not `Result` (rejects). Normalizing that contract and shipping the structured `{code,message,retriable}` envelope requires coordinated renderer changes and is deferred.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (no issues)
- [x] `cargo test --all-features` (450 passed)
- [x] Guardrail: zero `Result<_, String>` outside `error.rs`/tests
- [x] Message preservation: `AppError` Display == prior strings (From<String> + per-site categorization keep messages verbatim)
- [ ] Reviewer smoke (optional): trigger a failing flow (AI call without a key, bad scrape URL) and confirm the same error message reaches the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)