### PR TITLE
refactor: shared observability span helper (Phase 4)

### DIFF
--- a/apps/tauri/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/mod.rs
@@ -9,8 +9,6 @@
 //! arm. This keeps OpenRouter / DeepSeek / Azure / Groq / Together / LM Studio /
 //! vLLM (all OpenAI-compatible) and future native APIs cheap to add.
 
-use std::time::Instant;
-
 use async_trait::async_trait;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -310,16 +308,12 @@ pub fn cosine(a: &[f64], b: &[f64]) -> f64 {
 
 // ── Request tracing ─────────────────────────────────────────────────────────────
 
-/// Structured per-request log. Emits a `→` line at dispatch and a `←` line with
-/// status + duration at completion, e.g.:
-/// `[ai] ← provider=openai model=gpt-4o endpoint=/chat/completions status=200 duration=1842ms ok=true`
+/// Structured per-request log over the shared [`crate::observability::Span`].
+/// Emits a `→` line at dispatch and a `←` line with status + duration at
+/// completion, e.g.:
+/// `[ai] ← provider=openai model=gpt-4o endpoint=/chat/completions … status=200 duration=1842ms ok=true`
 pub struct RequestTrace {
-    provider: ProviderId,
-    model: String,
-    endpoint: String,
-    base_url: String,
-    streaming: bool,
-    start: Instant,
+    span: crate::observability::Span,
 }
 
 impl RequestTrace {
@@ -330,36 +324,20 @@ impl RequestTrace {
         base_url: &str,
         streaming: bool,
     ) -> Self {
-        log::info!(
-            "[ai] → provider={} model={} endpoint={} baseUrl={} streaming={}",
+        let fields = format!(
+            "provider={} model={} endpoint={} baseUrl={} streaming={}",
             provider.as_str(),
             model,
             endpoint,
             base_url,
             streaming
         );
-        Self {
-            provider,
-            model: model.to_string(),
-            endpoint: endpoint.to_string(),
-            base_url: base_url.to_string(),
-            streaming,
-            start: Instant::now(),
-        }
+        Self { span: crate::observability::Span::begin("ai", fields) }
     }
 
     pub fn end(&self, status: Option<u16>, ok: bool) {
-        log::info!(
-            "[ai] ← provider={} model={} endpoint={} baseUrl={} streaming={} status={} duration={}ms ok={}",
-            self.provider.as_str(),
-            self.model,
-            self.endpoint,
-            self.base_url,
-            self.streaming,
-            status.map(|s| s.to_string()).unwrap_or_else(|| "-".to_string()),
-            self.start.elapsed().as_millis(),
-            ok
-        );
+        let status = status.map(|s| s.to_string()).unwrap_or_else(|| "-".to_string());
+        self.span.end_with(&format!("status={status}"), ok);
     }
 }
 

--- a/apps/tauri/src-tauri/src/commands/apply.rs
+++ b/apps/tauri/src-tauri/src/commands/apply.rs
@@ -40,7 +40,12 @@ pub async fn apply_start(app: AppHandle, req: ApplyStartRequest) -> Value {
         on_progress,
     );
 
+    let span = crate::observability::Span::begin("apply", format!("board={board}"));
     let result = applier.apply(url.to_string(), ctx).await;
+    match &result {
+        Ok(r) => span.end_with(&format!("stage={} submitted={}", r.stage, r.submitted), r.ok),
+        Err(_) => span.end(false),
+    }
 
     engine.unregister_token(&job_id).await;
     cleanup_temp_resume(temp_resume);

--- a/apps/tauri/src-tauri/src/commands/autopilot.rs
+++ b/apps/tauri/src-tauri/src/commands/autopilot.rs
@@ -75,6 +75,11 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
     let target = autopilot.target.clone();
     let filter = autopilot.filter.clone();
 
+    let span = crate::observability::Span::begin(
+        "autopilot",
+        format!("run={autopilot_id} board={}", target.board),
+    );
+
     let job_id = uuid_v4();
     app.state::<Mutex<crate::jobs::JobTracker>>()
         .lock()
@@ -99,6 +104,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
         Err(e) => {
             engine.unregister_token(&job_id).await;
             app.state::<Mutex<crate::jobs::JobTracker>>().lock().fail(&job_id, e.to_string());
+            span.end(false);
             return json!({ "error": e, "jobId": job_id });
         }
     };
@@ -194,6 +200,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
 
     emit_step(&app, &job_id, "complete", &format!("Found {total_found}, applied to {applied}"));
 
+    span.end_with(&format!("found={total_found} applied={applied}"), true);
     json!({ "jobId": job_id, "found": total_found, "applied": applied })
 }
 

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -35,6 +35,7 @@ mod ipc_contracts;
 mod job_preferences;
 mod jobs;
 mod net;
+mod observability;
 mod pipeline;
 mod platform;
 mod postings;

--- a/apps/tauri/src-tauri/src/observability.rs
+++ b/apps/tauri/src-tauri/src/observability.rs
@@ -1,0 +1,60 @@
+//! Centralized observability — timed, structured operation spans.
+//!
+//! `Span` is the single owner of the begin/elapsed/end log mechanics shared by
+//! every subsystem. It emits a `→` line at start and a `←` line with duration
+//! and outcome at end, in one consistent format:
+//!
+//! ```text
+//! [<target>] → <fields>
+//! [<target>] ← <fields> [<extra>] duration=<n>ms ok=<bool>
+//! ```
+//!
+//! `target` is the log prefix (`ai`, `scrape`, `apply`, `autopilot`,
+//! `pipeline:<name>`); `fields` are pre-rendered `key=value` pairs. Domain
+//! wrappers (`RequestTrace`, `StageTrace`) compose this instead of reimplementing
+//! the timing logic.
+
+use std::time::Instant;
+
+pub struct Span {
+    target: String,
+    fields: String,
+    start: Instant,
+}
+
+impl Span {
+    /// Begin a span: logs `[target] → fields` and starts the timer.
+    pub fn begin(target: impl Into<String>, fields: impl Into<String>) -> Self {
+        let target = target.into();
+        let fields = fields.into();
+        log::info!("[{target}] → {fields}");
+        Self { target, fields, start: Instant::now() }
+    }
+
+    /// End the span: logs `[target] ← fields duration=<n>ms ok=<ok>`.
+    pub fn end(&self, ok: bool) {
+        log::info!(
+            "[{}] ← {} duration={}ms ok={}",
+            self.target,
+            self.fields,
+            self.start.elapsed().as_millis(),
+            ok
+        );
+    }
+
+    /// End with trailing fields rendered before `duration` (e.g. `status=200`,
+    /// `count=12`). Empty `extra` is equivalent to [`Span::end`].
+    pub fn end_with(&self, extra: &str, ok: bool) {
+        if extra.is_empty() {
+            return self.end(ok);
+        }
+        log::info!(
+            "[{}] ← {} {} duration={}ms ok={}",
+            self.target,
+            self.fields,
+            extra,
+            self.start.elapsed().as_millis(),
+            ok
+        );
+    }
+}

--- a/apps/tauri/src-tauri/src/pipeline/mod.rs
+++ b/apps/tauri/src-tauri/src/pipeline/mod.rs
@@ -19,8 +19,6 @@ pub mod enrichment;
 pub mod retry;
 pub mod validation;
 
-use std::time::Instant;
-
 use async_trait::async_trait;
 use tauri::AppHandle;
 
@@ -128,28 +126,24 @@ impl<C> Pipeline<C> {
 
 // ── Stage tracing ───────────────────────────────────────────────────────────────
 
-/// Structured per-stage log, mirroring the provider `RequestTrace` style:
+/// Structured per-stage log over the shared [`crate::observability::Span`]:
 /// `[pipeline:cover_letter] → stage=research` / `← stage=research duration=..ms ok=true`.
 struct StageTrace {
-    pipeline: &'static str,
-    stage: &'static str,
-    start: Instant,
+    span: crate::observability::Span,
 }
 
 impl StageTrace {
     fn begin(pipeline: &'static str, stage: &'static str) -> Self {
-        log::info!("[pipeline:{pipeline}] → stage={stage}");
-        Self { pipeline, stage, start: Instant::now() }
+        Self {
+            span: crate::observability::Span::begin(
+                format!("pipeline:{pipeline}"),
+                format!("stage={stage}"),
+            ),
+        }
     }
 
     fn end(&self, ok: bool) {
-        log::info!(
-            "[pipeline:{}] ← stage={} duration={}ms ok={}",
-            self.pipeline,
-            self.stage,
-            self.start.elapsed().as_millis(),
-            ok
-        );
+        self.span.end(ok);
     }
 }
 

--- a/apps/tauri/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/engine/mod.rs
@@ -111,6 +111,7 @@ impl ScraperEngine {
             on_item,
         };
 
+        let span = crate::observability::Span::begin("scrape", format!("board={board} job={job_id}"));
         let result = match board {
             "ycombinator" => Scraper::search(&YCombinatorScraper, input, ctx).await,
             "remotive" => Scraper::search(&RemotiveScraper, input, ctx).await,
@@ -137,6 +138,11 @@ impl ScraperEngine {
 
         // Always clear the token slot, even on error.
         self.jobs.lock().await.remove(&job_id);
+
+        match &result {
+            Ok(items) => span.end_with(&format!("count={}", items.len()), true),
+            Err(_) => span.end(false),
+        }
         result
     }
 

--- a/docs/ARCHITECTURE_ROADMAP.md
+++ b/docs/ARCHITECTURE_ROADMAP.md
@@ -239,6 +239,13 @@ retriable}` IPC envelope + normalizing the `-> Value`+`{error}` command contract
 
 ### Phase 4 — Shared observability (M, low risk)
 
+> **Status: in review** (branch `refactor/phase4-observability`). Extracted
+> `observability::Span` (timed `→`/`←` structured logging); refactored
+> `RequestTrace` (AI) and `StageTrace` (pipeline) to compose it — no parallel
+> trace types, log formats unchanged. Adopted in `scrape_board`, `apply_start`,
+> and `autopilot_run` (previously had no timing/outcome spans). No CI grep
+> guardrail (no clean banned token); enforced structurally + module-ownership table.
+
 - **Pain:** `RequestTrace`/`StageTrace` are AI-only; scraping/applying/autopilot
   debugging is guesswork (P9).
 - **Target:** an `observability::trace` span helper (begin/end, timing, status,

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -418,13 +418,14 @@ Cross-cutting concerns have exactly **one owning module**. No other module may
 reconstruct that concern's logic — this prevents the duplication and hidden
 coupling the [architecture roadmap](ARCHITECTURE_ROADMAP.md) is eliminating.
 
-| Concern                              | Sole owner              | Use instead of rolling your own                                                                                               |
-| ------------------------------------ | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| env vars, data dir, filesystem paths | `platform::config`      | `platform::config::data_dir()` — never read `AJH_DATA_DIR` or rebuild `~/.ajh` yourself                                       |
-| AI provider routing + capabilities   | `commands::ai_provider` | `resolve(ProviderId, ..)`                                                                                                     |
-| HTTP clients (TLS, pool, user-agent) | `net::http`             | `net::http::shared()` + per-request `.timeout()`, or `build_client()` for a cookie jar — never `reqwest::Client::new/builder` |
-| error types                          | `error::AppError`       | return `AppResult<T>` from fallible internals — never `Result<_, String>` (domain enums like `ExtractionError` add `From`)    |
-| workflow orchestration               | `pipeline`              | compose `Stage`/`Pipeline`                                                                                                    |
+| Concern                              | Sole owner              | Use instead of rolling your own                                                                                                  |
+| ------------------------------------ | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| env vars, data dir, filesystem paths | `platform::config`      | `platform::config::data_dir()` — never read `AJH_DATA_DIR` or rebuild `~/.ajh` yourself                                          |
+| AI provider routing + capabilities   | `commands::ai_provider` | `resolve(ProviderId, ..)`                                                                                                        |
+| HTTP clients (TLS, pool, user-agent) | `net::http`             | `net::http::shared()` + per-request `.timeout()`, or `build_client()` for a cookie jar — never `reqwest::Client::new/builder`    |
+| timed/structured trace spans         | `observability::Span`   | `Span::begin(target, fields)` + `end`/`end_with` — never reimplement begin/elapsed/end logging (RequestTrace/StageTrace wrap it) |
+| error types                          | `error::AppError`       | return `AppResult<T>` from fallible internals — never `Result<_, String>` (domain enums like `ExtractionError` add `From`)       |
+| workflow orchestration               | `pipeline`              | compose `Stage`/`Pipeline`                                                                                                       |
 
 This table grows one row per roadmap phase. Where practical, a CI guardrail
 enforces ownership (e.g. `AJH_DATA_DIR` is grep-banned outside `platform/config.rs`).


### PR DESCRIPTION
## Summary

Phase 4 of the architecture standardization roadmap (`docs/ARCHITECTURE_ROADMAP.md`). Extracts the duplicated, AI-only timing/log helpers into one shared span and adopts it in flows that previously had no observability.

- **New `observability::Span`** — single owner of timed, structured begin/end logging: `[target] → fields` / `[target] ← fields [extra] duration=Nms ok=B`, via `begin` + `end`/`end_with`.
- **Refactored `RequestTrace` (AI) and `StageTrace` (pipeline)** to compose `Span` — no parallel trace types. Their **log formats are byte-identical** and call sites are untouched (public APIs unchanged).
- **Adopted `Span`** in `scrape_board` (`board`/`count`), `apply_start` (`board`/`stage`/`submitted`), and `autopilot_run` (`run`/`board`/`found`/`applied`) — these had no timing or outcome spans before, so scraping/apply/autopilot now log start, duration, and success.
- **Docs**: module-ownership row (`observability::Span`) + Phase 4 status in the roadmap.

No CI grep guardrail this phase — there's no clean banned token for "ad-hoc timing"; the guarantee is structural (the two domain traces now compose `Span`, no duplication) plus the module-ownership table.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (no issues)
- [x] `cargo test --all-features` (450 passed)
- [x] AI/pipeline log lines unchanged (RequestTrace/StageTrace wrap Span with the same field order)
- [ ] Smoke (reviewer, optional): run a scrape + an apply and confirm new `[scrape]`/`[apply]` `←` lines with `duration`/`ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)