### PR TITLE
refactor: registry-driven board dispatch + catalog (Phase 5)

### DIFF
--- a/apps/tauri/src-tauri/src/applying/registry/mod.rs
+++ b/apps/tauri/src-tauri/src/applying/registry/mod.rs
@@ -8,28 +8,25 @@ use super::types::Applier;
 
 pub struct ApplierRegistry;
 
+/// Every applier, registered exactly once (catalog display order). Both dispatch
+/// ([`ApplierRegistry::get`]) and the catalog derive from this list via the
+/// `Applier` trait — no parallel match or hardcoded array.
+static APPLIERS: &[&dyn Applier] = &[
+    &LinkedInApplier,
+    &IndeedApplier,
+    &GreenhouseApplier,
+    &WorkdayApplier,
+    &XingApplier,
+    &GlassdoorApplier,
+];
+
 impl ApplierRegistry {
     pub fn catalog() -> Vec<(&'static str, &'static str)> {
-        vec![
-            ("linkedin", "LinkedIn"),
-            ("indeed", "Indeed"),
-            ("greenhouse", "Greenhouse"),
-            ("workday", "Workday"),
-            ("xing", "Xing"),
-            ("glassdoor", "Glassdoor"),
-        ]
+        APPLIERS.iter().map(|a| (a.board_id(), a.display_name())).collect()
     }
 
-    pub fn get(board_id: &str) -> Option<Box<dyn Applier>> {
-        match board_id {
-            "linkedin" => Some(Box::new(LinkedInApplier)),
-            "indeed" => Some(Box::new(IndeedApplier)),
-            "greenhouse" => Some(Box::new(GreenhouseApplier)),
-            "workday" => Some(Box::new(WorkdayApplier)),
-            "xing" => Some(Box::new(XingApplier)),
-            "glassdoor" => Some(Box::new(GlassdoorApplier)),
-            _ => None,
-        }
+    pub fn get(board_id: &str) -> Option<&'static dyn Applier> {
+        APPLIERS.iter().copied().find(|a| a.board_id() == board_id)
     }
 }
 

--- a/apps/tauri/src-tauri/src/scraping/boards/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/mod.rs
@@ -39,3 +39,42 @@ pub use wwr::WeWorkRemotelyScraper;
 pub use workday::WorkdayScraper;
 pub use xing::XingScraper;
 pub use ycombinator::YCombinatorScraper;
+
+use super::types::Scraper;
+
+/// Every scraper, registered exactly once — in catalog display order. Both
+/// dispatch ([`get`]) and the UI catalog ([`all`] → `ScraperEngine::catalog`)
+/// derive from this list via the `Scraper` trait, so adding a board is one
+/// implementation module + one line here (no parallel match or hardcoded array).
+static SCRAPERS: &[&dyn Scraper] = &[
+    &YCombinatorScraper,
+    &RemotiveScraper,
+    &RemoteOkScraper,
+    &WeWorkRemotelyScraper,
+    &ArbeitnowScraper,
+    &BerlinStartupJobsScraper,
+    &GermanTechJobsScraper,
+    &GreenhouseScraper,
+    &LeverScraper,
+    &StepStoneScraper,
+    &SmartRecruitersScraper,
+    &PersonioScraper,
+    &RecruiteeScraper,
+    &WorkdayScraper,
+    &AshbyScraper,
+    &ArbeitsagenturScraper,
+    &LinkedInScraper,
+    &IndeedScraper,
+    &XingScraper,
+    &GlassdoorScraper,
+];
+
+/// All registered scrapers, in catalog display order.
+pub fn all() -> &'static [&'static dyn Scraper] {
+    SCRAPERS
+}
+
+/// Resolve a scraper by its `id()`. `None` for an unknown board.
+pub fn get(id: &str) -> Option<&'static dyn Scraper> {
+    SCRAPERS.iter().copied().find(|s| s.id() == id)
+}

--- a/apps/tauri/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/engine/mod.rs
@@ -3,8 +3,7 @@
 /// Uses interior mutability so `Arc<ScraperEngine>` can be cloned into Tauri
 /// commands and scrape jobs run concurrently (bounded by `semaphore`) without
 /// serializing on an outer mutex.
-use super::boards::*;
-use super::types::{BoardSearchInput, JobPosting, Scraper, ScrapeContext};
+use super::types::{BoardSearchInput, JobPosting, ScraperMode, ScrapeContext};
 use arc_swap::ArcSwap;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -43,33 +42,16 @@ impl ScraperEngine {
     }
 
     pub fn catalog(&self) -> Vec<ScraperCatalogEntry> {
-        const ROWS: &[(&str, &str, &str)] = &[
-            ("ycombinator", "Y Combinator", "http"),
-            ("remotive", "Remotive", "http"),
-            ("remoteok", "RemoteOK", "http"),
-            ("wwr", "We Work Remotely", "http"),
-            ("arbeitnow", "Arbeitnow", "http"),
-            ("berlinstartupjobs", "Berlin Startup Jobs", "http"),
-            ("germantechjobs", "German Tech Jobs", "http"),
-            ("greenhouse", "Greenhouse", "http"),
-            ("lever", "Lever", "http"),
-            ("stepstone", "StepStone", "http"),
-            ("smartrecruiters", "SmartRecruiters", "http"),
-            ("personio", "Personio", "http"),
-            ("recruitee", "Recruitee", "http"),
-            ("workday", "Workday", "http"),
-            ("ashby", "Ashby", "http"),
-            ("arbeitsagentur", "Arbeitsagentur", "http"),
-            ("linkedin", "LinkedIn", "http"),
-            ("indeed", "Indeed", "browser"),
-            ("xing", "Xing", "browser"),
-            ("glassdoor", "Glassdoor", "browser"),
-        ];
-        ROWS.iter()
-            .map(|(id, name, mode)| ScraperCatalogEntry {
-                id: (*id).to_string(),
-                display_name: (*name).to_string(),
-                mode: (*mode).to_string(),
+        super::boards::all()
+            .iter()
+            .map(|s| ScraperCatalogEntry {
+                id: s.id().to_string(),
+                display_name: s.display_name().to_string(),
+                mode: match s.mode() {
+                    ScraperMode::Http => "http",
+                    ScraperMode::Browser => "browser",
+                }
+                .to_string(),
             })
             .collect()
     }
@@ -112,28 +94,9 @@ impl ScraperEngine {
         };
 
         let span = crate::observability::Span::begin("scrape", format!("board={board} job={job_id}"));
-        let result = match board {
-            "ycombinator" => Scraper::search(&YCombinatorScraper, input, ctx).await,
-            "remotive" => Scraper::search(&RemotiveScraper, input, ctx).await,
-            "remoteok" => Scraper::search(&RemoteOkScraper, input, ctx).await,
-            "wwr" => Scraper::search(&WeWorkRemotelyScraper, input, ctx).await,
-            "arbeitnow" => Scraper::search(&ArbeitnowScraper, input, ctx).await,
-            "berlinstartupjobs" => Scraper::search(&BerlinStartupJobsScraper, input, ctx).await,
-            "germantechjobs" => Scraper::search(&GermanTechJobsScraper, input, ctx).await,
-            "greenhouse" => Scraper::search(&GreenhouseScraper, input, ctx).await,
-            "lever" => Scraper::search(&LeverScraper, input, ctx).await,
-            "stepstone" => Scraper::search(&StepStoneScraper, input, ctx).await,
-            "smartrecruiters" => Scraper::search(&SmartRecruitersScraper, input, ctx).await,
-            "personio" => Scraper::search(&PersonioScraper, input, ctx).await,
-            "recruitee" => Scraper::search(&RecruiteeScraper, input, ctx).await,
-            "workday" => Scraper::search(&WorkdayScraper, input, ctx).await,
-            "ashby" => Scraper::search(&AshbyScraper, input, ctx).await,
-            "arbeitsagentur" => Scraper::search(&ArbeitsagenturScraper, input, ctx).await,
-            "linkedin" => Scraper::search(&LinkedInScraper, input, ctx).await,
-            "indeed" => Scraper::search(&IndeedScraper, input, ctx).await,
-            "xing" => Scraper::search(&XingScraper, input, ctx).await,
-            "glassdoor" => Scraper::search(&GlassdoorScraper, input, ctx).await,
-            _ => Err(anyhow::anyhow!("Unknown board: {}", board)),
+        let result = match super::boards::get(board) {
+            Some(scraper) => scraper.search(input, ctx).await,
+            None => Err(anyhow::anyhow!("Unknown board: {}", board)),
         };
 
         // Always clear the token slot, even on error.

--- a/docs/ARCHITECTURE_ROADMAP.md
+++ b/docs/ARCHITECTURE_ROADMAP.md
@@ -258,6 +258,17 @@ retriable}` IPC envelope + normalizing the `-> Value`+`{error}` command contract
 
 ### Phase 5 — Registry + capability elevation (L, medium risk)
 
+> **Status: in review** (branch `refactor/phase5-board-registry`). Replaced the
+> scraping 20-arm string `match` + hardcoded `catalog()` ROWS, and the applier
+> hardcoded `catalog()` vec + `get()` match, with a single registry-of-trait-objects
+> per domain (`scraping::boards::{SCRAPERS,get,all}`, `applying::registry::APPLIERS`):
+> dispatch + catalog both derive from one list via the existing `Scraper`/`Applier`
+> trait metadata (`id`/`display_name`/`mode`). Behavior-preserving (catalog
+> ids/names/modes/order unchanged). Used registry-of-trait-objects rather than a
+> `BoardId` enum — the board id is the string wire format and the trait already
+> carries capabilities. No CI grep guardrail (board dispatch never used `.starts_with`
+> sniffing); the single registry list is the structural guarantee.
+
 - **Pain:** scraping/applying dispatch via string `match` + a parallel hardcoded
   `catalog()`; adding a board touches ≥2 sites; no capability model (P5/P6/P7).
 - **Target:** `BoardId` enum + `BoardCapabilities` (`mode: Http|Browser`,

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -418,14 +418,15 @@ Cross-cutting concerns have exactly **one owning module**. No other module may
 reconstruct that concern's logic — this prevents the duplication and hidden
 coupling the [architecture roadmap](ARCHITECTURE_ROADMAP.md) is eliminating.
 
-| Concern                              | Sole owner              | Use instead of rolling your own                                                                                                  |
-| ------------------------------------ | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| env vars, data dir, filesystem paths | `platform::config`      | `platform::config::data_dir()` — never read `AJH_DATA_DIR` or rebuild `~/.ajh` yourself                                          |
-| AI provider routing + capabilities   | `commands::ai_provider` | `resolve(ProviderId, ..)`                                                                                                        |
-| HTTP clients (TLS, pool, user-agent) | `net::http`             | `net::http::shared()` + per-request `.timeout()`, or `build_client()` for a cookie jar — never `reqwest::Client::new/builder`    |
-| timed/structured trace spans         | `observability::Span`   | `Span::begin(target, fields)` + `end`/`end_with` — never reimplement begin/elapsed/end logging (RequestTrace/StageTrace wrap it) |
-| error types                          | `error::AppError`       | return `AppResult<T>` from fallible internals — never `Result<_, String>` (domain enums like `ExtractionError` add `From`)       |
-| workflow orchestration               | `pipeline`              | compose `Stage`/`Pipeline`                                                                                                       |
+| Concern                              | Sole owner                                | Use instead of rolling your own                                                                                                          |
+| ------------------------------------ | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| env vars, data dir, filesystem paths | `platform::config`                        | `platform::config::data_dir()` — never read `AJH_DATA_DIR` or rebuild `~/.ajh` yourself                                                  |
+| AI provider routing + capabilities   | `commands::ai_provider`                   | `resolve(ProviderId, ..)`                                                                                                                |
+| HTTP clients (TLS, pool, user-agent) | `net::http`                               | `net::http::shared()` + per-request `.timeout()`, or `build_client()` for a cookie jar — never `reqwest::Client::new/builder`            |
+| timed/structured trace spans         | `observability::Span`                     | `Span::begin(target, fields)` + `end`/`end_with` — never reimplement begin/elapsed/end logging (RequestTrace/StageTrace wrap it)         |
+| job board scrapers / appliers        | `scraping::boards` / `applying::registry` | register in the `SCRAPERS` / `APPLIERS` list — dispatch + catalog derive from it via the trait; never a parallel match + hardcoded array |
+| error types                          | `error::AppError`                         | return `AppResult<T>` from fallible internals — never `Result<_, String>` (domain enums like `ExtractionError` add `From`)               |
+| workflow orchestration               | `pipeline`                                | compose `Stage`/`Pipeline`                                                                                                               |
 
 This table grows one row per roadmap phase. Where practical, a CI guardrail
 enforces ownership (e.g. `AJH_DATA_DIR` is grep-banned outside `platform/config.rs`).


### PR DESCRIPTION
## Summary

Phase 5 of the architecture standardization roadmap (`docs/ARCHITECTURE_ROADMAP.md`). Both scraping and applying duplicated per-board info in **two** hand-maintained sites — a string-`match` dispatch **and** a hardcoded catalog. Each is now a single **registry of trait objects** from which dispatch and catalog derive via the existing `Scraper`/`Applier` trait methods.

- **Scraping** (`scraping/boards/mod.rs`): new `SCRAPERS` list + `get()`/`all()`. `ScraperEngine::scrape_board` dispatches via `boards::get(board)` (the 20-arm `match` is gone); `catalog()` maps `boards::all()` → `id()`/`display_name()`/`mode()` (the hardcoded `ROWS` is gone).
- **Applying** (`applying/registry/mod.rs`): new `APPLIERS` list; `catalog()` and `get()` derive from it (`get` now returns `&'static dyn Applier` instead of `Box`).

Adding a board is now **one implementation module + one registry line**.

### Design note
Used a registry of trait objects rather than a `BoardId` enum: the board id is the string wire format at the IPC boundary, and the `Scraper`/`Applier` traits already carry the capability metadata (`mode`, etc.). Behavior-preserving — catalog **ids/display names/modes/order are unchanged** vs the previous arrays (verified against each trait impl + the registry tests).

No CI grep guardrail this phase — board dispatch never used `.starts_with` sniffing (the `.starts_with` hits are AI model-family heuristics in `validate_model`, which are legitimate). The single `SCRAPERS`/`APPLIERS` list is the structural guarantee.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (no issues)
- [x] `cargo test --all-features` (450 passed, incl. `scraping/engine` + `applying/registry` tests)
- [x] Catalog parity: ids/names/modes/order match the prior hardcoded arrays
- [ ] Smoke (reviewer, optional): scrape one HTTP board + one browser board, and one apply — dispatch resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)