### PR TITLE
docs: add marketing landing page and github pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: 🌐 Deploy Landing Page
+
+# ──────────────────────────────────────────────────────────────────────
+# GitHub Pages Deploy
+# ──────────────────────────────────────────────────────────────────────
+# Purpose: Publish the static marketing landing page (landing/) to GitHub Pages
+# Triggers: push to main touching landing/ or this workflow, plus manual dispatch
+# Source:   landing/ is a self-contained single-page site (no build step)
+# Note:     Runs independently of release.yml (also push-to-main) — separate jobs.
+# ──────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'landing/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one Pages deploy at a time; don't cancel an in-flight publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: landing
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ node_modules/
 pnpm-lock.yaml
 CHANGELOG.md
 **/tauri.conf.json
+landing/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue)](https://www.typescriptlang.org/)
 [![Tauri](https://img.shields.io/badge/Tauri-2.x-purple)](https://tauri.app)
+[![Live site](https://img.shields.io/badge/Live-site-e24b4a)](https://saeedkolivand.github.io/ai-job-hunter-assistant-app/)
 
 ---
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,767 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AI Job Hunter — please hire him</title>
+<meta name="description" content="Scrapes 18 job boards, writes your cover letters, applies while you dissociate. A real desktop app. Also a cry for help.">
+<meta property="og:title" content="IT APPLIES FOR ME.">
+<meta property="og:description" content="I sent 1,000 applications and got 0 replies. So I built a robot. (the OG image should be the deep-fried 'IT APPLIES FOR ME' frame)">
+<meta property="og:type" content="website">
+<link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Anton&family=Caveat:wght@600;700&family=Gloria+Hallelujah&family=Patrick+Hand&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+<style>
+:root{
+  --scrawl:'Gloria Hallelujah', cursive;
+  --hand:'Patrick Hand', cursive;
+  --impact:'Anton', Impact, sans-serif;
+  --mono:'Space Mono', monospace;
+  --paper:#f4ecdc;
+  --ink:#1c1812;
+  --red:#e24b4a;
+}
+*{box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  margin:0; background:#0a0c11; color:#e7ecf3;
+  font-family:var(--hand); font-size:18px; line-height:1.6;
+  overflow-x:hidden;
+  cursor:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 28 28'><path d='M4 24 L9 19 L20 8 L22 6 L24 8 L22 10 L11 21 L6 26 Z' fill='orange' stroke='black' stroke-width='1.4' stroke-linejoin='round'/><path d='M9 19 L11 21' stroke='black' stroke-width='1.4'/></svg>") 4 24, auto;
+}
+a,button,.tap{cursor:pointer}
+img,svg{display:block}
+
+/* grain + film texture over everything */
+body::after{
+  content:""; position:fixed; inset:0; z-index:60; pointer-events:none; opacity:.06;
+  background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='120' height='120' filter='url(%23n)'/></svg>");
+  mix-blend-mode:overlay;
+}
+
+/* ---------- doodle ink ---------- */
+.dood{fill:none; stroke:var(--line,#e7ecf3); stroke-width:3.2; stroke-linecap:round; stroke-linejoin:round}
+.dood-fill{fill:var(--line,#e7ecf3); stroke:none}
+.doodle{position:relative; filter:drop-shadow(2px 3px 0 rgba(0,0,0,.18))}
+.doodle svg{width:100%; height:auto; overflow:visible}
+
+/* speech bubble for clickable doodles */
+.bubble{
+  position:absolute; left:50%; top:-14px; transform:translate(-50%,-100%) scale(.6); transform-origin:bottom center;
+  background:#fffef8; color:#1c1812; border:2.6px solid #1c1812; border-radius:16px 14px 18px 10px;
+  padding:8px 14px; font-family:var(--scrawl); font-size:15px; white-space:nowrap;
+  opacity:0; pointer-events:none; transition:opacity .18s, transform .18s; box-shadow:3px 4px 0 rgba(0,0,0,.15); z-index:5;
+}
+.bubble::after{content:""; position:absolute; left:50%; bottom:-12px; transform:translateX(-50%); border:8px solid transparent; border-top-color:#1c1812}
+.bubble.show{opacity:1; transform:translate(-50%,-100%) scale(1)}
+
+/* ---------- fixed chrome ---------- */
+#progress-wrap{position:fixed; top:0; left:0; right:0; z-index:50; pointer-events:none}
+#progress{height:7px; width:0%; background:repeating-linear-gradient(45deg,var(--red) 0 8px,#b73a39 8px 16px); transition:width .12s linear}
+#progress-label{font-family:var(--mono); font-size:11px; padding:3px 8px; color:#cfd6e0; background:rgba(8,10,16,.55); display:inline-block; border-bottom-right-radius:8px}
+
+#odometer{
+  position:fixed; left:12px; bottom:12px; z-index:50;
+  font-family:var(--mono); font-size:12px; color:#cfd6e0;
+  background:rgba(8,10,16,.6); border:1px solid rgba(255,255,255,.12); border-radius:8px; padding:6px 10px;
+  transition:color .3s, background .3s;
+}
+#sound-toggle{position:fixed; top:14px; right:12px; z-index:55; width:34px; height:34px; display:flex; align-items:center; justify-content:center; background:rgba(8,10,16,.62); border:1px solid rgba(255,255,255,.14); border-radius:9px; color:#cfd6e0; opacity:0; transform:translateY(-6px); pointer-events:none; transition:opacity .3s, transform .3s; cursor:pointer}
+#sound-toggle.show{opacity:1; transform:none; pointer-events:auto}
+#sound-toggle:hover{background:rgba(22,26,36,.82)}
+#sound-toggle svg{width:18px; height:18px}
+#sound-toggle .slash{display:none}
+#sound-toggle.muted{color:#7e8a9c}
+#sound-toggle.muted .waves{display:none}
+#sound-toggle.muted .slash{display:block}
+
+#cookie{
+  position:fixed; right:12px; bottom:12px; z-index:55; max-width:320px;
+  background:#fffef8; color:#1c1812; border:2.6px solid #1c1812; border-radius:14px;
+  padding:12px 14px; font-family:var(--hand); box-shadow:4px 5px 0 rgba(0,0,0,.2);
+  transform:translateY(20px); opacity:0; animation:cookiein .5s .8s forwards;
+}
+@keyframes cookiein{to{transform:none;opacity:1}}
+#cookie button{font-family:var(--hand); font-size:16px; margin-top:8px; background:var(--ink); color:#fffef8; border:none; border-radius:10px; padding:5px 16px}
+
+/* loader */
+#loader{
+  position:fixed; inset:0; z-index:100; background:#0a0c11; display:flex; align-items:center; justify-content:center;
+  font-family:var(--scrawl); font-size:clamp(18px,4vw,26px); color:#c7d0dd; text-align:center; padding:24px;
+  transition:opacity .6s, visibility .6s;
+}
+#loader.gone{opacity:0; visibility:hidden}
+#loader .lt{max-width:18ch}
+
+/* ---------- generic section ---------- */
+.stage{min-height:100vh; position:relative; display:flex; flex-direction:column; align-items:center; justify-content:center; padding:64px 22px; overflow:hidden; text-align:center}
+.photo{position:absolute; inset:0; z-index:0}      /* PHOTO SWAP: set background:url('your.jpg') center/cover */
+.grade{position:absolute; inset:0; z-index:1; pointer-events:none}
+.stage > .inner{position:relative; z-index:2; width:100%; max-width:880px}
+
+.kicker{font-family:var(--mono); font-size:12px; letter-spacing:.18em; text-transform:uppercase; opacity:.8; margin-bottom:14px}
+.counter{font-family:var(--mono); font-size:clamp(13px,2.4vw,17px); letter-spacing:.02em}
+
+/* reveal */
+.reveal{opacity:0; transform:translateY(26px); transition:opacity .7s cubic-bezier(.2,.7,.2,1), transform .7s cubic-bezier(.2,.7,.2,1)}
+.in .reveal{opacity:1; transform:none}
+.in .reveal:nth-child(2){transition-delay:.08s}
+.in .reveal:nth-child(3){transition-delay:.16s}
+.in .reveal:nth-child(4){transition-delay:.24s}
+.in .reveal:nth-child(5){transition-delay:.32s}
+
+/* ================= HERO ================= */
+.hero .photo{background:radial-gradient(130% 90% at 50% 30%,#1b2433 0%,#11151d 55%,#0a0c11 100%)}
+.hero .grade{background:radial-gradient(60% 40% at 50% 38%,rgba(108,198,255,.10),transparent 70%)}
+.hero{--line:#e7ecf3}
+.hero h1{font-family:var(--caveat,'Caveat'),cursive; font-weight:700; font-size:clamp(40px,9vw,104px); line-height:.95; margin:0 0 4px; color:#fff; text-shadow:3px 4px 0 rgba(0,0,0,.35)}
+.hero .sub{font-family:var(--hand); font-size:clamp(16px,2.6vw,22px); color:#b9c4d4; max-width:30ch; margin:18px auto 0}
+.hero .sub b{color:#fff}
+.hero-dood{width:clamp(130px,22vw,190px); margin:6px auto -8px}
+.scrollhint{margin-top:34px; font-family:var(--scrawl); font-size:15px; color:#8e9bad}
+.scrollhint .arr{display:block; font-size:26px; animation:bob 1.6s ease-in-out infinite}
+@keyframes bob{0%,100%{transform:translateY(0)}50%{transform:translateY(8px)}}
+.dontclick{position:absolute; left:calc(100% - 6px); top:-6px; pointer-events:none; z-index:6}
+.dc-inner{display:flex; align-items:center; gap:2px; transform:rotate(6deg); transform-origin:left center; animation:dcwiggle 1.5s ease-in-out infinite}
+@keyframes dcwiggle{0%,100%{transform:rotate(6deg)}50%{transform:rotate(1deg) translateY(-3px)}}
+.dc-arrow{width:44px; height:auto; flex:none}
+.dc-text{background:#ffe27a; color:#3a2c00; font-family:var(--scrawl); font-size:14px; line-height:1.12; padding:5px 11px; border:2.4px solid #1c1812; border-radius:12px 9px 13px 8px; box-shadow:3px 4px 0 rgba(0,0,0,.3); white-space:nowrap}
+@media(max-width:560px){
+  .dontclick{left:auto; right:0; top:-14px; transform:scale(.82); transform-origin:right center}
+  .dc-inner{transform-origin:right center}
+}
+.dc-text.pop{animation:dcpop .32s ease}
+@keyframes dcpop{0%{transform:scale(1)}40%{transform:scale(1.16) rotate(-1.5deg)}100%{transform:scale(1)}}
+.hero-dood.shake{animation:heroshake .32s ease}
+@keyframes heroshake{0%,100%{transform:none}25%{transform:translateX(-4px) rotate(-2deg)}60%{transform:translateX(4px) rotate(2deg)}}
+
+/* ================= BEAT 1 — slump ================= */
+.beat1{--line:#e7ecf3}
+.beat1 .photo{background:radial-gradient(120% 80% at 50% 34%,#1e2737 0%,#12161f 55%,#090b10 100%)}
+.beat1 .grade{background:radial-gradient(40% 30% at 62% 56%,rgba(120,150,200,.16),transparent 70%)}
+.section-label{font-family:var(--scrawl); font-size:14px; letter-spacing:.04em; opacity:.75; margin-bottom:8px}
+.beat1-dood{width:clamp(260px,46vw,420px); margin:0 auto 18px}
+.tag{font-family:var(--hand); font-size:clamp(16px,2.6vw,21px); color:#cec5de; letter-spacing:.01em}
+.screencap{font-family:var(--mono); font-size:13px; color:#9fb0c6; background:rgba(20,28,44,.6); border:1px solid rgba(255,255,255,.08); border-radius:8px; padding:8px 12px; display:inline-block; margin:6px 5px; text-align:left}
+.tabs{margin-top:14px}
+.thought{font-family:var(--scrawl); color:#bcc7d8; margin-top:18px}
+
+/* ================= BEAT 2 — descent ================= */
+.beat2{--line:#efe6f3}
+.beat2 .photo{background:radial-gradient(110% 100% at 50% 45%,#26203a 0%,#16111f 65%,#0b0810 100%)}
+.beat2 .grade{background:radial-gradient(60% 60% at 50% 55%,rgba(226,75,74,.10),transparent 70%)}
+.beat2 h2{font-family:var(--scrawl); font-size:clamp(22px,5vw,40px); color:#cdbfe0; margin:0 0 28px}
+.beat2-dood{width:clamp(180px,32vw,260px); margin:4px auto 6px}
+.collage{display:flex; flex-wrap:wrap; gap:14px; justify-content:center; align-items:flex-start; max-width:820px; margin:0 auto}
+.card{
+  background:#1a1426; border:2px solid rgba(255,255,255,.12); border-radius:12px; padding:14px 16px;
+  max-width:300px; text-align:left; font-family:var(--hand); font-size:15px; color:#cabbdb; box-shadow:4px 5px 0 rgba(0,0,0,.3);
+}
+.card.tilt-l{transform:rotate(-2.4deg)} .card.tilt-r{transform:rotate(2.1deg)} .card.tilt-s{transform:rotate(-.8deg)}
+.card .ct{font-family:var(--hand); font-size:14px; color:#c4b6da; display:block; margin-bottom:6px}
+.blackhole{
+  width:170px; height:170px; border-radius:50%; margin:6px auto;
+  background:radial-gradient(circle at 50% 50%,#000 35%,#2a1140 70%,#3a1a55 100%);
+  box-shadow:0 0 40px rgba(120,40,180,.45), inset 0 0 30px #000;
+  display:flex; align-items:center; justify-content:center; flex-direction:column; color:#caa7e6; font-family:var(--scrawl); font-size:13px; text-align:center; padding:18px;
+}
+.blackhole .yell{font-family:var(--impact); font-size:22px; color:#fff; letter-spacing:.03em}
+.echo{font-family:var(--mono); font-size:12px; color:#9d8fb3; margin-top:6px}
+.npcs{display:flex; gap:6px; flex-wrap:wrap; justify-content:center}
+.npc{display:flex; flex-direction:column; align-items:center; width:78px; font-family:var(--mono); font-size:11px; color:#a99cc4; text-align:center}
+.npc svg{width:38px}
+.ats{display:flex; align-items:center; gap:10px}
+.ats svg{width:64px; flex:none}
+.feed{
+  width:230px; height:84px; overflow:hidden; border:2px solid rgba(255,255,255,.12); border-radius:10px; background:#120d1c; position:relative;
+}
+.feed .scroller{position:absolute; left:0; top:0; width:100%; animation:feed 7s linear infinite}
+@keyframes feed{0%{transform:translateY(0)}100%{transform:translateY(-50%)}}
+.feed p{margin:0; padding:7px 10px; font-family:var(--hand); font-size:13px; color:#c2b4d6; border-bottom:1px dashed rgba(255,255,255,.08)}
+.beat2 .counter{margin-top:30px; color:#cabbdb}
+.swarm{display:flex; flex-wrap:wrap; gap:8px; justify-content:center; max-width:560px; margin:4px auto 0}
+.chip{position:relative; font-family:var(--mono); font-size:12px; padding:5px 11px; border:1.6px solid rgba(255,255,255,.22); border-radius:20px; color:#bdb0d2; background:rgba(255,255,255,.03)}
+.chip.x::after{content:""; position:absolute; left:8%; right:8%; top:50%; height:2.4px; background:var(--red); transform:rotate(-9deg); border-radius:2px}
+
+/* the flail */
+@keyframes flail{0%,100%{transform:rotate(-3deg)}25%{transform:rotate(4deg) translateY(-3px)}50%{transform:rotate(-5deg)}75%{transform:rotate(3deg)}}
+.doodle.flailing{animation:flail .28s linear infinite}
+
+/* ================= BEAT 3 — DEEP FRIED ================= */
+.beat3{--line:#0b0b0b}
+.beat3 .photo{background:
+  repeating-conic-gradient(from 0deg at 50% 42%, rgba(255,255,255,.55) 0deg 5deg, rgba(255,210,0,0) 5deg 11deg),
+  radial-gradient(60% 50% at 50% 42%, #fffbe0 0%, #ffe600 30%, #ffb300 70%, #ff7a00 100%);
+  filter:saturate(1.7) contrast(1.25);
+}
+.beat3 .grade{background:radial-gradient(70% 60% at 50% 42%,rgba(255,255,255,.85),rgba(255,255,255,0) 55%); mix-blend-mode:screen}
+.beat3{color:#0b0b0b}
+.beat3-dood{width:clamp(200px,38vw,300px); margin:0 auto 6px; filter:drop-shadow(0 0 10px #ff00d4) drop-shadow(0 0 4px #00fff0)}
+.fried{
+  font-family:var(--impact); text-transform:uppercase; line-height:.92; letter-spacing:.01em;
+  color:#fff; -webkit-text-stroke:3px #000;
+  text-shadow:4px 4px 0 #ff00d4, -3px -3px 0 #00fff0, 0 0 26px #fff300;
+}
+.fried.huge{font-size:clamp(40px,11vw,118px)}
+.fried.mid{font-size:clamp(22px,5.5vw,52px); -webkit-text-stroke:2px #000; margin-top:8px}
+.fried-line{font-family:var(--impact); text-transform:uppercase; color:#111; font-size:clamp(15px,3.2vw,26px); margin:14px auto; max-width:24ch; text-shadow:1px 1px 0 #fff}
+.fried-line b{color:#c1006f}
+.dialog{
+  display:inline-block; margin-top:18px; background:#dfdfdf; border:2px solid #000; border-radius:6px; padding:14px 18px;
+  box-shadow:5px 6px 0 rgba(0,0,0,.5); font-family:var(--mono); font-size:14px; color:#111;
+}
+.dialog .btns{margin-top:12px; display:flex; gap:10px; justify-content:center}
+.dialog button{font-family:var(--mono); border:2px solid #000; background:#fff; padding:5px 18px; border-radius:4px; font-size:13px; box-shadow:2px 2px 0 #000}
+.dialog button.y2{background:#111; color:#fff}
+@keyframes jolt{0%,100%{transform:translate(0,0) rotate(0)}20%{transform:translate(-2px,1px) rotate(-.4deg)}40%{transform:translate(2px,-1px) rotate(.4deg)}60%{transform:translate(-1px,1px)}80%{transform:translate(1px,-1px)}}
+.in.beat3 .beat3-dood{animation:jolt .5s linear 3}
+
+/* ================= BEAT 4 — godmode ================= */
+.beat4{--line:#2a1808}
+.beat4 .photo{background:linear-gradient(180deg,#ffd884 0%,#ffb84d 42%,#ff8a3d 100%)}
+.beat4 .grade{background:radial-gradient(40% 30% at 78% 22%,rgba(255,255,255,.6),transparent 60%)}
+.beat4{color:#3a2208}
+.sun{position:absolute; right:8%; top:10%; width:90px; height:90px; border-radius:50%; background:#fff3c4; box-shadow:0 0 60px 18px rgba(255,240,180,.85); z-index:1}
+.beat4-dood{width:clamp(220px,40vw,300px); margin:0 auto 10px}
+.beat4 .big{font-family:var(--hand); font-size:clamp(21px,4.6vw,36px); color:#3a2208; max-width:24ch; margin:0 auto}
+.beat4 .counter{font-size:clamp(15px,3vw,22px); color:#5a3610; margin-top:22px; font-weight:700}
+.beat4 .line{font-family:var(--hand); font-size:clamp(15px,2.6vw,20px); color:#5a3610; max-width:34ch; margin:18px auto 0}
+.stonks{position:absolute; left:7%; bottom:14%; width:90px; opacity:.9; z-index:1}
+
+/* ================= FEATURES ================= */
+.features{background:var(--paper); color:var(--ink); --line:var(--ink); padding:90px 22px; text-align:center; position:relative}
+.features::before{content:""; position:absolute; inset:0; opacity:.5; background-image:radial-gradient(circle,rgba(0,0,0,.05) 1px,transparent 1px); background-size:22px 22px}
+.features .inner{position:relative; max-width:960px; margin:0 auto}
+.features h2{font-family:var(--scrawl); font-size:clamp(24px,5vw,44px); margin:0 0 6px}
+.features .lede{font-family:var(--hand); font-size:18px; color:#5b5341; margin:0 auto 40px; max-width:40ch}
+.feat-grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:22px; text-align:left}
+.feat{
+  background:#fffdf6; border:2.6px solid var(--ink); padding:18px 20px;
+  border-radius:16px 11px 18px 9px/9px 17px 11px 16px; box-shadow:4px 5px 0 rgba(0,0,0,.14);
+}
+.feat:nth-child(even){transform:rotate(.5deg)} .feat:nth-child(3n){transform:rotate(-.6deg)}
+.feat h3{font-family:var(--hand); font-size:22px; margin:0 0 6px}
+.feat p{margin:0; font-family:var(--hand); font-size:16px; color:#4a4332; line-height:1.5}
+.crayon-arrow{width:120px; margin:6px auto 30px; transform:rotate(-4deg)}
+
+/* ================= TESTIMONIALS ================= */
+.testi{background:var(--paper); color:var(--ink); --line:var(--ink); padding:30px 22px 90px; text-align:center; position:relative}
+.testi h2{font-family:var(--scrawl); font-size:clamp(22px,4.6vw,38px); margin:0 0 30px}
+.testi .small{font-family:var(--mono); font-size:12px; color:#7a7058}
+.wall{column-count:3; column-gap:18px; max-width:980px; margin:0 auto}
+.quote{
+  break-inside:avoid; margin:0 0 18px; background:#fffdf6; border:2.4px solid var(--ink);
+  border-radius:13px 10px 15px 9px; padding:14px 16px; box-shadow:3px 4px 0 rgba(0,0,0,.13); text-align:left;
+}
+.quote:nth-child(even){transform:rotate(.7deg)} .quote:nth-child(3n){transform:rotate(-.8deg)}
+.quote p{margin:0 0 8px; font-family:var(--hand); font-size:16px}
+.quote .who{font-family:var(--scrawl); font-size:12px; color:#7a6f55}
+.stars{color:#e0a32a; letter-spacing:2px}
+.featured{margin:34px auto 0; font-family:var(--mono); font-size:13px; color:#6f6650}
+.featured b{color:var(--ink)}
+
+/* ================= FINALE ================= */
+.finale{background:#ece2cf; color:var(--ink); --line:var(--ink); padding:90px 22px; text-align:center; position:relative}
+.finale .honest{font-family:var(--mono); font-size:clamp(14px,2.4vw,17px); line-height:1.85; max-width:60ch; margin:0 auto 30px; color:#2c271c}
+.finale-dood{width:120px; margin:0 auto 22px}
+.cta{
+  font-family:var(--hand); font-size:20px; background:var(--ink); color:#f4ecdc; border:none;
+  border-radius:12px 9px 13px 8px; padding:12px 26px; box-shadow:4px 5px 0 rgba(0,0,0,.25); transition:transform .15s;
+}
+.cta:hover{transform:translateY(-2px)}
+.src-link{display:block; margin-top:18px; font-family:var(--hand); font-size:16px; color:#4a4233}
+.footnote{font-family:var(--mono); font-size:12px; color:#6f6650; max-width:54ch; margin:30px auto 0; line-height:1.7}
+.footnote code{background:#dccfb6; padding:1px 6px; border-radius:4px}
+.builtwith{font-family:var(--mono); font-size:12px; color:#8a7f64; margin-top:24px}
+.byline{font-family:var(--scrawl); font-size:14px; color:#6f6650; margin-top:18px}
+
+/* slowdown toast */
+#slowdown{
+  position:fixed; top:50%; left:50%; transform:translate(-50%,-50%) rotate(-4deg); z-index:58;
+  font-family:var(--impact); text-transform:uppercase; font-size:clamp(20px,5vw,40px); color:#fff;
+  -webkit-text-stroke:2px #000; text-shadow:3px 3px 0 var(--red); opacity:0; transition:opacity .12s; pointer-events:none;
+}
+#slowdown.show{opacity:1}
+
+/* konami toast */
+#jk{position:fixed; top:18px; left:50%; transform:translateX(-50%); z-index:80; font-family:var(--scrawl); font-size:18px; background:#fffef8; color:#1c1812; border:2.4px solid #1c1812; border-radius:12px; padding:8px 18px; opacity:0; transition:opacity .3s; box-shadow:3px 4px 0 rgba(0,0,0,.2)}
+#jk.show{opacity:1}
+
+@media (max-width:560px){
+  .wall{column-count:1}
+  #cookie{left:12px; right:12px; max-width:none}
+  .collage{gap:12px}
+}
+
+/* reduced motion */
+@media (prefers-reduced-motion: reduce){
+  *{animation-duration:.001s !important; animation-iteration-count:1 !important; transition-duration:.001s !important}
+  .scrollhint .arr,.feed .scroller{animation:none}
+  .doodle.flailing{animation:none}
+  html{scroll-behavior:auto}
+}
+</style>
+</head>
+<body>
+
+<div id="loader"><div class="lt" id="loader-text">summoning a sad little man…</div></div>
+
+<div id="progress-wrap"><div id="progress"></div><div id="progress-label">job search: 0% complete · est. time remaining: ∞</div></div>
+<div id="odometer">rejections survived: 1,247</div>
+<button id="sound-toggle" aria-label="mute the guy" title="mute the guy" aria-pressed="false">
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M3 9 h4 l5 -4 v14 l-5 -4 h-4 z" fill="currentColor"/>
+    <g class="waves" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+      <path d="M15 9.5 q2.4 2.5 0 5"/>
+      <path d="M17.6 7.5 q4 4.5 0 9"/>
+    </g>
+    <line class="slash" x1="14.5" y1="6.5" x2="21.5" y2="17.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+  </svg>
+</button>
+
+<div id="cookie">
+  we don't track you. we can barely track ourselves.
+  <div><button onclick="document.getElementById('cookie').remove()">ok</button></div>
+</div>
+
+<div id="slowdown">slow down — you're making it worse</div>
+<div id="jk">just kidding.</div>
+
+<main>
+
+<!-- ============ HERO ============ -->
+<section class="stage hero">
+  <div class="photo"></div><div class="grade"></div>
+  <div class="inner">
+    <div class="kicker reveal">a real desktop app · also a cry for help</div>
+    <div class="doodle hero-dood reveal tap" id="hero-dood">
+      <div class="bubble"></div>
+      <div class="dontclick" aria-hidden="true">
+        <div class="dc-inner">
+          <svg class="dc-arrow" viewBox="0 0 50 44"><path d="M46 10 Q22 10 8 32" fill="none" stroke="#ffe27a" stroke-width="3.6" stroke-linecap="round"/><path d="M8 32 l13 -2 M8 32 l4 -13" fill="none" stroke="#ffe27a" stroke-width="3.6" stroke-linecap="round"/></svg>
+          <span class="dc-text">don't click me</span>
+        </div>
+      </div>
+      <svg viewBox="0 0 200 175">
+        <circle class="dood" cx="100" cy="66" r="26"/>
+        <path class="dood" d="M86 64 q6 6 12 0"/><path class="dood" d="M102 64 q6 6 12 0"/>
+        <path class="dood" d="M86 88 q14 -10 28 0"/>
+        <ellipse class="dood-fill" cx="84" cy="92" rx="3" ry="5" style="fill:#6cc6ff"/>
+        <path class="dood" d="M100 92 L100 138"/>
+        <path class="dood" d="M100 104 q-22 12 -30 34"/><path class="dood" d="M100 104 q22 12 30 34"/>
+        <path class="dood" d="M100 138 L82 172"/><path class="dood" d="M100 138 L118 172"/>
+      </svg>
+    </div>
+    <h1 class="reveal">Job hunting broke me.<br>So I built a robot to do it.</h1>
+    <p class="sub reveal">AI Job Hunter scrapes 18 job boards, writes your cover letters, and applies while you dissociate. Runs fully offline. <b>Built by a guy who is, himself, still unemployed.</b></p>
+    <div class="scrollhint reveal">scroll to watch a man fall apart<span class="arr">↓</span></div>
+  </div>
+</section>
+
+<!-- ============ BEAT 1 — SLUMP ============ -->
+<section class="stage beat1">
+  <div class="photo"></div><div class="grade"></div>
+  <div class="inner">
+    <div class="section-label reveal">2:47 AM</div>
+    <div class="doodle beat1-dood reveal tap" data-scream data-voice="sad" data-lines="...hi.|please hire me|i haven't slept|anyone? hello?">
+      <div class="bubble"></div>
+      <svg viewBox="0 0 320 240">
+        <rect x="26" y="198" width="268" height="9" rx="3" class="dood-fill" style="fill:#5a6273"/>
+        <rect x="186" y="166" width="74" height="34" rx="3" class="dood" style="fill:#26303f"/>
+        <rect x="180" y="200" width="86" height="6" rx="2" class="dood-fill" style="fill:#3a4250"/>
+        <circle class="dood" cx="108" cy="92" r="25"/>
+        <path class="dood" d="M95 90 q6 6 12 0"/><path class="dood" d="M111 90 q6 6 12 0"/>
+        <path class="dood" d="M95 112 q13 -9 26 0"/>
+        <ellipse class="dood-fill" cx="93" cy="116" rx="3" ry="5.5" style="fill:#6cc6ff"><animate attributeName="cy" values="116;150;116" dur="2.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="1;0;1" dur="2.6s" repeatCount="indefinite"/></ellipse>
+        <path class="dood" d="M108 117 L108 200"/>
+        <path class="dood" d="M108 128 q-26 24 -42 70"/>
+        <path class="dood" d="M108 128 q44 20 70 70"/>
+      </svg>
+    </div>
+    <div class="tabs reveal">
+      <span class="screencap">cover_letter_FINAL_v9.docx — "please. please. please. please. pl—"</span>
+      <span class="screencap">draft: "I have always dreamed of working at [COMPANY NAME]."</span>
+      <span class="screencap">rejections (final)(final2)(FINAL_real)(use_this_one).pdf</span>
+      <span class="screencap">tab: how to answer "what's your biggest weakness"</span>
+      <span class="screencap">tab: is it normal to cry on a tuesday</span>
+    </div>
+    <p class="thought reveal">"maybe i'll hear back monday"</p>
+    <p class="counter reveal" style="margin-top:18px">applications submitted: <span data-to="247">0</span> · unfortunatelies received: <span data-to="248">0</span> · est. callback: ∞</p>
+    <p class="reveal" style="font-family:var(--hand); font-size:14px; color:#8e9bb0; margin-top:6px; font-style:italic">the 248th wasn't a job. it was your crush. we don't talk about it.</p>
+  </div>
+</section>
+
+<!-- ============ BEAT 2 — DESCENT ============ -->
+<section class="stage beat2">
+  <div class="photo"></div><div class="grade"></div>
+  <div class="inner">
+    <h2 class="reveal">the descent</h2>
+    <div class="doodle beat2-dood reveal tap" data-scream data-flail data-voice="frazzled" data-lines="WHY won't they reply|i can't keep up|so many tabs|make it STOP|aaaaaa">
+      <div class="bubble"></div>
+      <svg viewBox="0 0 240 220">
+        <circle class="dood" cx="120" cy="80" r="24"/>
+        <path class="dood" d="M112 60 L108 48"/><path class="dood" d="M120 58 L120 46"/><path class="dood" d="M128 60 L132 48"/><path class="dood" d="M104 66 L92 60"/><path class="dood" d="M136 66 L148 60"/>
+        <circle class="dood-fill" cx="113" cy="80" r="2.4"/><circle class="dood-fill" cx="127" cy="80" r="2.4"/>
+        <path class="dood" d="M106 72 L116 76"/><path class="dood" d="M134 72 L124 76"/>
+        <ellipse class="dood" cx="120" cy="94" rx="5" ry="6"/>
+        <ellipse class="dood-fill" cx="146" cy="78" rx="2.6" ry="3.8" style="fill:#6cc6ff"/>
+        <polyline class="dood" points="120,104 100,92 112,80 92,66"/>
+        <polyline class="dood" points="120,104 140,92 128,80 148,66"/>
+        <polyline class="dood" points="120,108 96,108 104,120 86,124"/>
+        <polyline class="dood" points="120,108 144,108 136,120 154,124"/>
+        <path class="dood" d="M120 108 L120 150"/>
+        <path class="dood" d="M120 150 L100 188"/><path class="dood" d="M120 150 L140 188"/>
+      </svg>
+    </div>
+    <div class="swarm reveal" id="swarm">
+      <span class="chip x">LinkedIn</span><span class="chip x">Indeed</span><span class="chip x">StepStone</span><span class="chip x">Xing</span><span class="chip x">Greenhouse</span><span class="chip x">Lever</span><span class="chip x">Workday</span><span class="chip">+11 more</span>
+    </div>
+    <p class="tag reveal" style="margin:6px auto 26px; max-width:42ch; color:#d1c6e6">entry level: 5 yrs experience required · easy apply (47 fields) · create a Workday account <i>(for the 9th time)</i></p>
+
+    <div class="collage">
+      <div class="card tilt-l reveal">
+        <div class="blackhole">
+          <span class="yell">HELLO??</span>
+          <span style="margin-top:6px">"thank you for your interest, we'll be in touch."</span>
+          <span class="echo">(it will not be in touch)</span>
+        </div>
+        <span class="ct" style="text-align:center; display:block; margin-top:8px">↑ application status</span>
+      </div>
+
+      <div class="card tilt-r reveal">
+        <span class="ct">the résumé robot</span>
+        <div class="ats">
+          <svg viewBox="0 0 80 80"><rect x="10" y="20" width="60" height="46" rx="10" class="dood" style="fill:#2a1f1f; stroke:#e24b4a"/><circle cx="30" cy="36" r="9" fill="#fff" stroke="#e24b4a" stroke-width="2"/><circle cx="52" cy="36" r="9" fill="#fff" stroke="#e24b4a" stroke-width="2"/><circle cx="32" cy="38" r="3" fill="#111"/><circle cx="54" cy="34" r="3" fill="#111"/><path d="M24 54 q16 8 32 0" fill="none" stroke="#e24b4a" stroke-width="3" stroke-linecap="round"/><path d="M26 54 l4 6 m6 -6 l3 7 m6 -7 l4 6 m6 -6 l3 7" stroke="#e24b4a" stroke-width="2"/></svg>
+          <span><b>BEEP. REJECTED.</b><br>a human will never see this.</span>
+        </div>
+      </div>
+
+      <div class="card tilt-s reveal">
+        <span class="ct">recruiters (every one of them)</span>
+        <div class="npcs">
+          <div class="npc"><svg viewBox="0 0 40 46"><circle cx="20" cy="14" r="10" fill="none" stroke="#8e80a4" stroke-width="2.4"/><path d="M8 44 q12 -16 24 0" fill="none" stroke="#8e80a4" stroke-width="2.4"/><path d="M14 14 h3 m6 0 h3" stroke="#8e80a4" stroke-width="2"/><path d="M15 19 q5 3 10 0" stroke="#8e80a4" stroke-width="2" fill="none"/></svg>"on file"</div>
+          <div class="npc"><svg viewBox="0 0 40 46"><circle cx="20" cy="14" r="10" fill="none" stroke="#8e80a4" stroke-width="2.4"/><path d="M8 44 q12 -16 24 0" fill="none" stroke="#8e80a4" stroke-width="2.4"/><path d="M14 14 h3 m6 0 h3" stroke="#8e80a4" stroke-width="2"/><path d="M15 19 q5 3 10 0" stroke="#8e80a4" stroke-width="2" fill="none"/></svg>"more senior"</div>
+          <div class="npc"><svg viewBox="0 0 40 46"><circle cx="20" cy="14" r="10" fill="none" stroke="#8e80a4" stroke-width="2.4"/><path d="M8 44 q12 -16 24 0" fill="none" stroke="#8e80a4" stroke-width="2.4"/><path d="M14 14 h3 m6 0 h3" stroke="#8e80a4" stroke-width="2"/><path d="M15 19 q5 3 10 0" stroke="#8e80a4" stroke-width="2" fill="none"/></svg>"more junior"</div>
+          <div class="npc"><svg viewBox="0 0 40 46"><circle cx="20" cy="14" r="10" fill="none" stroke="#8e80a4" stroke-width="2.4"/><path d="M8 44 q12 -16 24 0" fill="none" stroke="#8e80a4" stroke-width="2.4"/><path d="M14 14 h3 m6 0 h3" stroke="#8e80a4" stroke-width="2"/><path d="M15 19 q5 3 10 0" stroke="#8e80a4" stroke-width="2" fill="none"/></svg>"someone"</div>
+        </div>
+      </div>
+
+      <div class="card tilt-l reveal">
+        <span class="ct">meanwhile, on LinkedIn</span>
+        <div class="feed"><div class="scroller">
+          <p>🎉 thrilled to announce</p><p>humbled and honored</p><p>after 47 rounds of interviews, delighted to share…</p><p>so grateful for this journey</p>
+          <p>🎉 thrilled to announce</p><p>humbled and honored</p><p>after 47 rounds of interviews, delighted to share…</p><p>so grateful for this journey</p>
+        </div></div>
+        <span class="ct" style="margin-top:8px">ghosted by 14 companies and one (1) person you actually liked.</span>
+      </div>
+    </div>
+
+    <p class="counter reveal">applications: <span data-to="1000">0</span> · responses: 0 · dignity: offline</p>
+  </div>
+</section>
+
+<!-- ============ BEAT 3 — DEEP FRIED ============ -->
+<section class="stage beat3">
+  <div class="photo"></div><div class="grade"></div>
+  <div class="inner">
+    <div class="doodle beat3-dood reveal tap" data-scream data-voice="fried" data-lines="IT APPLIES FOR ME|I HAVE THE POWER|NO MORE FORMS|unlimited POWER|YESSS">
+      <div class="bubble"></div>
+      <svg viewBox="0 0 260 240">
+        <circle class="dood" cx="130" cy="104" r="48" style="stroke-width:4"/>
+        <circle cx="110" cy="96" r="19" fill="#fff" stroke="#000" stroke-width="3"/>
+        <circle cx="150" cy="96" r="19" fill="#fff" stroke="#000" stroke-width="3"/>
+        <path d="M96 92 l8 6 m6 -10 l5 9 M152 92 l8 6 m-2 -10 l-3 10" stroke="#e24b4a" stroke-width="1.6"/>
+        <circle cx="112" cy="98" r="4.5" fill="#000"/><circle cx="148" cy="98" r="4.5" fill="#000"/>
+        <path class="dood" d="M86 60 l-8 -12 M120 50 l-2 -14 M160 58 l10 -12" style="stroke-width:3"/>
+        <path d="M96 132 q34 40 68 0 q-34 14 -68 0 Z" fill="#fff" stroke="#000" stroke-width="3.4"/>
+        <path d="M108 138 v14 M124 141 v15 M140 141 v15 M152 138 v13" stroke="#000" stroke-width="2.4"/>
+        <path class="dood" d="M130 152 L130 196" style="stroke-width:4"/>
+        <path class="dood" d="M130 164 L96 150 M130 164 L164 150" style="stroke-width:4"/>
+        <path class="dood" d="M130 196 L108 232 M130 196 L152 232" style="stroke-width:4"/>
+      </svg>
+    </div>
+    <div class="fried huge reveal">WAIT.<br>IT APPLIES<br>FOR ME.</div>
+    <div class="fried mid reveal">one click. eighteen job boards. zero tears.</div>
+    <p class="fried-line reveal">it <b>scrapes 18 boards</b> while you do NOTHING. it <b>writes the cover letter</b> — the one you CRIED over. GONE. it <b>scores your résumé</b> so the regex blob can't hurt you anymore. <b>semantic matching????</b> it KNOWS which jobs want you. it knows things you don't.</p>
+    <div class="dialog reveal">
+      Are you sure?<br><span style="font-size:12px; color:#444">(you were not supposed to find this)</span>
+      <div class="btns"><button>yes</button><button class="y2">YES</button></div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ BEAT 4 — GODMODE ============ -->
+<section class="stage beat4">
+  <div class="photo"></div><div class="grade"></div>
+  <div class="sun"></div>
+  <svg class="stonks" viewBox="0 0 100 70"><path d="M6 64 L34 40 L52 50 L92 8" fill="none" stroke="#2a7d2a" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/><path d="M74 8 L92 8 L92 26" fill="none" stroke="#2a7d2a" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  <div class="inner">
+    <div class="doodle beat4-dood reveal tap" data-scream data-voice="smug" data-lines="effortless.|told you.|still got it.|too easy.|yawn.">
+      <div class="bubble"></div>
+      <svg viewBox="0 0 280 200">
+        <circle class="dood" cx="120" cy="74" r="26"/>
+        <rect x="104" y="68" width="34" height="9" rx="4" class="dood-fill"/>
+        <path class="dood" d="M138 72 l8 1"/>
+        <path class="dood" d="M106 90 q12 9 24 2"/>
+        <path class="dood" d="M120 100 q14 26 44 30"/>
+        <path class="dood" d="M120 112 q-30 6 -40 -18"/>
+        <path class="dood" d="M164 130 q22 2 30 -8"/>
+        <path class="dood" d="M164 130 q-6 24 8 44"/>
+        <path class="dood" d="M170 174 l22 -8"/>
+      </svg>
+    </div>
+    <p class="big reveal">"i haven't opened LinkedIn in 3 weeks and i've never been happier."</p>
+    <p class="counter reveal">applications: <span data-to="247">0</span> (auto) · interviews: <span data-to="6">0</span> · effort: 0</p>
+    <p class="line reveal">while you sleep, it applies. while you cry, it applies. it does not cry. be like the autopilot.</p>
+    <p class="line reveal">runs 100% offline with Ollama. your 4am desperation is between you, your laptop, and God. not OpenAI. <b>God.</b></p>
+  </div>
+</section>
+
+<!-- ============ FEATURES ============ -->
+<section class="stage features">
+  <div class="inner">
+    <h2 class="reveal">what it actually does</h2>
+    <p class="lede reveal">(in between the breakdowns, real software happened)</p>
+    <svg class="crayon-arrow" viewBox="0 0 120 60"><path d="M8 12 q40 36 90 30" fill="none" stroke="var(--ink)" stroke-width="3" stroke-linecap="round"/><path d="M84 48 l14 -6 m-14 6 l8 -13" fill="none" stroke="var(--ink)" stroke-width="3" stroke-linecap="round"/></svg>
+    <div class="feat-grid">
+      <div class="feat reveal"><h3>18+ boards, one scrape</h3><p>LinkedIn, Indeed, StepStone, Xing, Greenhouse, Lever, Workday, and 11 others you'll also be rejected from — but faster.</p></div>
+      <div class="feat reveal"><h3>AI cover letters & résumés</h3><p>Writes it for you. 9 templates, DOCX & PDF export. The AI is more passionate about this role than you could ever convincingly fake.</p></div>
+      <div class="feat reveal"><h3>ATS scoring</h3><p>Your résumé was reviewed by a piece of regex that has never felt joy. Now you score back.</p></div>
+      <div class="feat reveal"><h3>Semantic matching</h3><p>Hybrid vector search. Understands your résumé better than your mother, who still thinks you "do computers."</p></div>
+      <div class="feat reveal"><h3>Autopilot</h3><p>Pick a board, pick a schedule, walk away. It applies at 9am sharp while you achieve REM sleep.</p></div>
+      <div class="feat reveal"><h3>Local, cloud, or CLI agents</h3><p>Run it free and offline with Ollama, drop in your own OpenAI/Anthropic/Gemini key, or route it through a CLI agent you already pay for — no key needed. Your coding-agent subscription can finally do something about the unemployment.</p></div>
+      <div class="feat reveal"><h3>11 languages</h3><p>en, de, fr, es, it, tr, pt, ru, zh, ja, ko. Cosmopolitan failure.</p></div>
+      <div class="feat reveal"><h3>Privacy-first</h3><p>OS keychain, local SQLite, zero telemetry. No one is watching you spiral. For once.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ TESTIMONIALS ============ -->
+<section class="testi">
+  <h2>what the people are saying<br><span class="small">(the people are not real)</span></h2>
+  <div class="wall">
+    <div class="quote"><p>"I applied to 0 jobs and got 0 rejections. 10/10."</p><span class="who">— a guy</span></div>
+    <div class="quote"><p>"haven't felt my hands in weeks. great app."</p><span class="who">— power user</span></div>
+    <div class="quote"><p>"the autopilot got me 6 interviews. i ghosted all of them. we are the same now."</p><span class="who">— finally, revenge</span></div>
+    <div class="quote"><p>"my therapist asked where the rage went. it's in the regex now."</p><span class="who">— anonymous</span></div>
+    <div class="quote"><p>"downloaded it, my MacBook said the app was 'damaged.' relatable."</p><span class="who">— early adopter</span></div>
+    <div class="quote"><p>"I don't have a job but I have a workflow."</p><span class="who">— verified ✓ (not verified)</span></div>
+    <div class="quote"><p>"it scraped Workday so I never had to make a Workday account again. I wept — the good kind."</p><span class="who">— survivor</span></div>
+    <div class="quote"><p>"5 stars. would dissociate again."</p><span class="who">— a review I'll never get, this isn't on the App Store</span></div>
+    <div class="quote"><p class="stars">★★★★★</p><span class="who">— my mom (still confused about what I do)</span></div>
+  </div>
+  <p class="featured">as featured in: <b>your group chat</b> · <b>one (1) reddit comment</b> · <b>my mom's facebook</b></p>
+</section>
+
+<!-- ============ FINALE ============ -->
+<section class="finale">
+  <div class="doodle finale-dood tap" id="finale-dood" data-scream data-voice="smug" data-lines="we're still here?|ok, last one|…just go apply">
+    <div class="bubble"></div>
+    <svg viewBox="0 0 200 175">
+      <circle class="dood" cx="100" cy="66" r="26"/>
+      <circle class="dood-fill" cx="90" cy="64" r="2.6"/><circle class="dood-fill" cx="110" cy="64" r="2.6"/>
+      <path class="dood" d="M88 86 q12 8 24 0" id="finale-mouth"/>
+      <path class="dood" d="M100 92 L100 138"/>
+      <path class="dood" d="M100 104 q-22 12 -30 34"/><path class="dood" d="M100 104 q22 12 30 34"/>
+      <path class="dood" d="M100 138 L82 172"/><path class="dood" d="M100 138 L118 172"/>
+    </svg>
+  </div>
+  <p class="honest">yes, this app is real. yes, it actually scrapes LinkedIn, Indeed, StepStone, Xing, and 14 others. yes, it's built with Tauri + Rust + React 19 + a vector database — because I had a lot of free time, on account of the unemployment. no, I still don't have a job. the autopilot is doing its best.</p>
+  <button class="cta" id="cta">ok fine, take the app →</button>
+  <a class="src-link" href="https://github.com/saeedkolivand/ai-job-hunter-assistant-app">view the source — it's MIT, like my prospects: open and freely available.</a>
+  <p class="footnote">macOS will say the app is "damaged." it's not damaged. it's just unsigned — like a contract I was never offered. run <code>xattr -cr</code> and we move on.</p>
+  <p class="builtwith">Tauri · Rust · React 19 · TanStack · LanceDB · Ollama · pure spite</p>
+  <p class="byline">made by Saeed, between rejections.</p>
+</section>
+
+</main>
+
+<script>
+(function(){
+  var reduce = matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /* ===== shared "gibberish voice" engine — one context, one mute, a voice per mood ===== */
+  /* each guy's emotion lives in these knobs: base pitch, tempo (dur), syllable count,
+     glide (>1 rises within a syllable, <1 falls), drift (pitch trend across syllables),
+     jitter (wobble), timbre (wave + optional lowpass lp + optional distortion drive).
+     pitchUp/sylUp/faster = how it escalates the more you poke. */
+  var VOICES = {
+    annoyed:  { wave:'sawtooth', base:200, q:7, syl:2, dur:0.105, glide:1.06, vol:0.15, climb:0.05,  jitter:0.20, pitchUp:0.55, sylUp:3, faster:0.32 },
+    sad:      { wave:'sawtooth', base:140, q:5, syl:2, dur:0.17,  glide:0.82, vol:0.17, climb:-0.05, drift:-0.18, jitter:0.07, pitchUp:0.04, sylUp:1, faster:0, lp:1500 },
+    frazzled: { wave:'sawtooth', base:300, q:9, syl:4, dur:0.07,  glide:1.12, vol:0.13, climb:0.03,  jitter:0.50, pitchUp:0.25, sylUp:3, faster:0.25 },
+    fried:    { wave:'sawtooth', base:300, q:7, syl:3, dur:0.085, glide:1.12, vol:0.11, climb:0.12,  jitter:0.22, pitchUp:0.25, sylUp:2, faster:0.12, lp:2400 },
+    smug:     { wave:'sawtooth', base:165, q:9, syl:2, dur:0.14,  glide:0.90, vol:0.16, climb:-0.03, drift:-0.06, jitter:0.06, pitchUp:0.04, sylUp:1, faster:0, lp:2100 }
+  };
+
+  var AUDIO = (function(){
+    var ac=null, comp=null, muted=reduce, toggle=null, shown=false, curves={};
+    var vowels=[[730,1090],[530,1840],[570,840],[400,2000],[300,870],[660,1700]];
+    function curve(k){ if(curves[k]) return curves[k]; var n=1024,c=new Float32Array(n);
+      for(var i=0;i<n;i++){ var x=i/(n-1)*2-1; c[i]=Math.tanh(x*k); } return curves[k]=c; }
+    function ctx(){
+      if(!ac){ try{ ac=new (window.AudioContext||window.webkitAudioContext)(); }catch(e){ ac=null; } }
+      if(ac && !comp){ comp=ac.createDynamicsCompressor(); comp.connect(ac.destination); }
+      if(ac && ac.state==='suspended'){ ac.resume(); }
+      return ac;
+    }
+    function syllable(when, freq, dur, vol, p){
+      var t=ac.currentTime+when, g=p.glide||1.05;
+      var o=ac.createOscillator(); o.type=p.wave||'sawtooth';
+      o.frequency.setValueAtTime(freq/g, t);
+      o.frequency.linearRampToValueAtTime(freq*g, t+dur);
+      var v=vowels[(Math.random()*vowels.length)|0];
+      var f1=ac.createBiquadFilter(); f1.type='bandpass'; f1.frequency.value=v[0]; f1.Q.value=p.q||7;
+      var f2=ac.createBiquadFilter(); f2.type='bandpass'; f2.frequency.value=v[1]; f2.Q.value=(p.q||7)+2;
+      var amp=ac.createGain();
+      amp.gain.setValueAtTime(0.0001, t);
+      amp.gain.linearRampToValueAtTime(vol, t+(p.attack||0.012));
+      amp.gain.exponentialRampToValueAtTime(0.0001, t+dur);
+      o.connect(f1); o.connect(f2);
+      var stage=null;
+      if(p.drive){ var ws=ac.createWaveShaper(); ws.curve=curve(p.drive); ws.oversample='2x'; f1.connect(ws); f2.connect(ws); stage=ws; }
+      if(p.lp){ var lp=ac.createBiquadFilter(); lp.type='lowpass'; lp.frequency.value=p.lp;
+        if(stage){ stage.connect(lp); } else { f1.connect(lp); f2.connect(lp); } stage=lp; }
+      if(stage){ stage.connect(amp); } else { f1.connect(amp); f2.connect(amp); }
+      amp.connect(comp||ac.destination);
+      o.start(t); o.stop(t+dur+0.04);
+    }
+    function say(p, e){
+      reveal();                       /* surface the mute button on first poke, even if muted */
+      if(muted || !p) return;
+      ctx(); if(!ac) return;
+      e = Math.max(0, Math.min(e||0, 1));
+      var syl = Math.max(1, Math.round((p.syl||2) + (p.sylUp||0)*e));
+      var dur = (p.dur||0.1) * (1 - (p.faster||0)*e);
+      var base = (p.base||220) * (1 + (p.pitchUp||0)*e);
+      var jit = (p.jitter!=null?p.jitter:0.18);
+      for(var i=0;i<syl;i++){
+        var prog = syl>1 ? i/(syl-1) : 0;
+        var f = base * (1 + (p.climb||0)*i) * (1 + (p.drift||0)*prog) * (1 + (Math.random()*2-1)*jit);
+        syllable(i*dur, f, dur*0.9, p.vol||0.14, p);
+      }
+    }
+    function reveal(){ if(toggle && !shown){ toggle.classList.add('show'); shown=true; } }
+    function bind(btn){
+      toggle=btn; if(!toggle) return;
+      toggle.classList.toggle('muted', muted);
+      toggle.setAttribute('aria-pressed', muted?'true':'false');
+      toggle.addEventListener('click', function(){
+        muted=!muted;
+        toggle.classList.toggle('muted', muted);
+        toggle.setAttribute('aria-pressed', muted?'true':'false');
+        if(!muted) ctx();
+      });
+    }
+    return { say:say, bind:bind, reveal:reveal };
+  })();
+  AUDIO.bind(document.getElementById('sound-toggle'));
+
+  /* ---- loader cycle ---- */
+  var msgs = ["summoning a sad little man…","applying to jobs you didn't ask for…","scraping LinkedIn (allegedly)…","calculating your worth (loading forever)…"];
+  var lt = document.getElementById('loader-text'), loader = document.getElementById('loader'), i=0;
+  function lift(){ loader.classList.add('gone'); }
+  if(reduce){ setTimeout(lift, 500); }
+  else {
+    var iv = setInterval(function(){ i++; if(i<msgs.length){ lt.textContent = msgs[i]; } else { clearInterval(iv); lift(); } }, 1500);
+  }
+  loader.addEventListener('click', function(){ try{clearInterval(iv);}catch(e){} lift(); });
+
+  /* ---- reveal + counters ---- */
+  function runCounters(sec){
+    sec.querySelectorAll('[data-to]').forEach(function(el){
+      if(el.dataset.done) return; el.dataset.done="1";
+      var to=+el.dataset.to, dur=1100, t0=null;
+      function step(t){ if(!t0)t0=t; var p=Math.min((t-t0)/dur,1); var v=Math.floor(p*to);
+        el.textContent = v.toLocaleString('en-US'); if(p<1) requestAnimationFrame(step); else el.textContent=to.toLocaleString('en-US'); }
+      requestAnimationFrame(step);
+    });
+  }
+  var io = new IntersectionObserver(function(entries){
+    entries.forEach(function(e){ if(e.isIntersecting){ e.target.classList.add('in'); runCounters(e.target); } });
+  }, {threshold:0.3});
+  document.querySelectorAll('.stage').forEach(function(s){ io.observe(s); });
+
+  /* ---- progress bar + odometer ---- */
+  var bar=document.getElementById('progress'), plabel=document.getElementById('progress-label'), odo=document.getElementById('odometer');
+  function onScroll(){
+    var h=document.documentElement.scrollHeight-innerHeight;
+    var f=h>0?scrollY/h:0; var pct=Math.round(f*100);
+    bar.style.width=pct+'%';
+    plabel.textContent='job search: '+pct+'% complete · est. time remaining: ∞';
+    odo.textContent='rejections survived: '+(1247+Math.floor(f*312)).toLocaleString('en-US');
+  }
+  addEventListener('scroll', onScroll, {passive:true}); onScroll();
+
+  /* ---- poke a doodle: it mumbles in-character (voice per mood) ---- */
+  var screams=["AAAAAAA","STOP TOUCHING ME","i'm trying my BEST","do you have any openings??","please"];
+  document.querySelectorAll('[data-scream]').forEach(function(d){
+    var b=d.querySelector('.bubble'), n=0, to;
+    var lines = d.dataset.lines ? d.dataset.lines.split('|') : screams;
+    var voice = VOICES[d.dataset.voice] || null;
+    d.addEventListener('click', function(){
+      if(b){ b.textContent = lines[n % lines.length];
+        b.classList.add('show'); clearTimeout(to); to=setTimeout(function(){ b.classList.remove('show'); }, 1600); }
+      AUDIO.say(voice, Math.min(n*0.18, 1));
+      n++;
+    });
+  });
+
+  /* ---- hero: the bait sign + escalating annoyed mumbles (uses shared engine) ---- */
+  (function(){
+    var hero=document.getElementById('hero-dood');
+    if(!hero) return;
+    var bubble=hero.querySelector('.bubble');
+    var sign=hero.querySelector('.dc-text');
+    var protests=["i said don't click me","stop. seriously.","...why are you like this","okay— you win.","...are you hiring?? hiring?? HIRING??"];
+    var n=0, to;
+    hero.addEventListener('click', function(){
+      var step=n % protests.length;
+      if(bubble){ bubble.textContent=protests[step];
+        bubble.classList.add('show'); clearTimeout(to); to=setTimeout(function(){ bubble.classList.remove('show'); }, 1600); }
+      if(sign){ sign.classList.remove('pop'); void sign.offsetWidth; sign.classList.add('pop'); }
+      hero.classList.remove('shake'); void hero.offsetWidth; hero.classList.add('shake');
+      AUDIO.say(VOICES.annoyed, step/4);
+      n++;
+    });
+  })();
+
+  /* ---- scroll-speed flail ---- */
+  var lastY=scrollY, lastT=performance.now(), toast=document.getElementById('slowdown'), flailEls=document.querySelectorAll('[data-flail]'), ft;
+  addEventListener('scroll', function(){
+    var now=performance.now(), dy=Math.abs(scrollY-lastY), dt=now-lastT||1, v=dy/dt;
+    lastY=scrollY; lastT=now;
+    if(v>2.6 && !reduce){
+      flailEls.forEach(function(el){ el.classList.add('flailing'); });
+      toast.classList.add('show'); clearTimeout(ft);
+      ft=setTimeout(function(){ flailEls.forEach(function(el){ el.classList.remove('flailing'); }); toast.classList.remove('show'); }, 360);
+    }
+  }, {passive:true});
+
+  /* ---- download hover: doodle nods ---- */
+  var cta=document.getElementById('cta'), fd=document.getElementById('finale-dood'), fb=fd.querySelector('.bubble');
+  cta.addEventListener('mouseenter', function(){ fb.textContent="you sure? …ok."; fb.classList.add('show'); });
+  cta.addEventListener('mouseleave', function(){ fb.classList.remove('show'); });
+  cta.addEventListener('click', function(){ location.href='https://github.com/saeedkolivand/ai-job-hunter-assistant-app'; });
+
+  /* ---- konami: rejections become offers for 3s ---- */
+  var seq=[38,38,40,40,37,39,37,39,66,65], pos=0;
+  var flips=[
+    {el:document.querySelector('.beat1 .counter'), offer:'applications sent: 247 · OFFERS: 247'},
+    {el:document.querySelector('.beat2 .counter'), offer:'applications: 1,000 · OFFERS: 1,000 · dignity: restored'}
+  ];
+  var jk=document.getElementById('jk');
+  addEventListener('keydown', function(e){
+    pos = (e.keyCode===seq[pos]) ? pos+1 : (e.keyCode===seq[0]?1:0);
+    if(pos===seq.length){ pos=0;
+      flips.forEach(function(f){ if(f.el){ f.el.dataset.orig=f.el.innerHTML; f.el.innerHTML=f.offer; f.el.style.color='#39d353'; } });
+      setTimeout(function(){
+        flips.forEach(function(f){ if(f.el){ f.el.innerHTML=f.el.dataset.orig; f.el.style.color=''; } });
+        jk.classList.add('show'); setTimeout(function(){ jk.classList.remove('show'); }, 1800);
+      }, 3000);
+    }
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Publishes the AI Job Hunter marketing landing page to **GitHub Pages**.

The page is a self-contained single HTML file (inline CSS/JS, all graphics inline SVG, fonts from Google's CDN, links absolute) — **no build step, no relative asset paths**, so the Pages project sub-path is harmless.

## Changes

- `landing/index.html` + `landing/.nojekyll` — the site, in a top-level folder kept **outside** the pnpm workspace globs so it stays out of lint/type/test/turbo.
- `.github/workflows/pages.yml` — Actions deploy (`upload-pages-artifact` → `deploy-pages`), triggered only on push to `main` touching `landing/**` (plus manual dispatch). Independent of `release.yml`.
- `.prettierignore` — skip `landing/` to preserve the hand-crafted formatting.
- `README.md` — add a **Live site** badge.

## Deploy method

Chosen over an orphan `gh-pages` branch so the source stays version-controlled, discoverable, and PR-gated (per the repo's "PRs only" rule). Landed as `docs:` to stay release-neutral (no Tauri build/release).

Pages will be enabled in **GitHub Actions** mode via `gh api` (repo Pages not yet configured).

## Live URL (after merge + deploy)

https://saeedkolivand.github.io/ai-job-hunter-assistant-app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)