### PR TITLE
chore: add MIT license and expand README badges

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Saeed Kolivand
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@
 > Your local-first, AI-native desktop assistant for intelligent job searching, resume generation, and automated applications — run it fully offline with Ollama, or plug in your own OpenAI, Anthropic, or Gemini key.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue)](https://www.typescriptlang.org/)
-[![Tauri](https://img.shields.io/badge/Tauri-2.x-purple)](https://tauri.app)
+[![Release](https://img.shields.io/github/v/release/saeedkolivand/ai-job-hunter-assistant-app?color=e24b4a)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases)
 [![Live site](https://img.shields.io/badge/Live-site-e24b4a)](https://saeedkolivand.github.io/ai-job-hunter-assistant-app/)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/pulls)
+
+[![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB?logo=tauri&logoColor=white)](https://tauri.app)
+[![Rust](https://img.shields.io/badge/Rust-stable-000000?logo=rust&logoColor=white)](https://www.rust-lang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev/)
+[![Vite](https://img.shields.io/badge/Vite-8-646CFF?logo=vite&logoColor=white)](https://vite.dev/)
+[![TailwindCSS](https://img.shields.io/badge/Tailwind-v4-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
+[![pnpm](https://img.shields.io/badge/pnpm-11-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
+[![Ollama](https://img.shields.io/badge/Ollama-local-000000?logo=ollama&logoColor=white)](https://ollama.com/)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.23.1",
   "description": "AI Job Hunter — local-first, AI-native desktop application",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@11.1.3",
   "engines": {


### PR DESCRIPTION
## Summary

Resolves the licensing inconsistency and gives the README a fuller badge set.

### License
- Add a root `LICENSE` file (MIT, © 2026 Saeed Kolivand) — GitHub will now auto-detect and display the license.
- Set `package.json` `"license"` from `UNLICENSED` → `MIT`, matching the existing README MIT badge.

Previously the README advertised MIT, `package.json` said `UNLICENSED`, and there was no `LICENSE` file at all — three conflicting signals.

### README badges
Expanded the badge block from 4 to 13, split into two rows:
- **Meta:** License · Release (dynamic) · Live site · Platform · PRs Welcome
- **Stack:** Tauri · Rust · TypeScript · React · Vite · TailwindCSS · pnpm · Ollama

Versions match the actual stack (TS 6.0, React 19, Vite 8, Tailwind v4, pnpm 11).

## Notes
- The Release badge is dynamic (GitHub Releases API); renders the latest semantic-release version.
- No source/behavior changes — docs + metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
