### PR TITLE
fix: admit website/portfolio links in resume contact line

### DIFF
--- a/apps/tauri/src-tauri/src/export/links/test.rs
+++ b/apps/tauri/src-tauri/src/export/links/test.rs
@@ -71,3 +71,42 @@ fn split_urls_prefers_markdown_links_over_bare_urls() {
         Span::Text(_) => panic!("expected a link span"),
     }
 }
+
+#[test]
+fn split_urls_labels_arbitrary_website_with_bare_domain() {
+    // A non-platform personal site / portfolio URL must survive with a bare-domain
+    // label (mirrors the TS "Website" admission for the contact line).
+    let spans = split_urls("portfolio: https://janedoe.dev/work today");
+    let link = spans
+        .iter()
+        .find_map(|s| match s {
+            Span::Link { label, url } => Some((label.clone(), url.clone())),
+            Span::Text(_) => None,
+        })
+        .expect("expected a link span");
+    assert_eq!(link.0, "janedoe.dev");
+    assert_eq!(link.1, "https://janedoe.dev/work");
+}
+
+#[test]
+fn url_label_matches_ts_url_to_friendly_label_fixture() {
+    // Cross-language parity guard: this exact fixture is also asserted by the TS
+    // urlToFriendlyLabel() test in packages/prompts/src/generate.test.ts. Both read
+    // the same file, so the two implementations can never silently drift.
+    #[derive(serde::Deserialize)]
+    struct Case {
+        url: String,
+        label: String,
+    }
+
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../packages/prompts/src/fixtures/url-labels.json");
+    let raw = std::fs::read_to_string(&path)
+        .expect("read url-labels parity fixture (packages/prompts/src/fixtures/url-labels.json)");
+    let cases: Vec<Case> = serde_json::from_str(&raw).expect("parse url-labels parity fixture");
+
+    assert!(!cases.is_empty(), "url-labels parity fixture must not be empty");
+    for c in &cases {
+        assert_eq!(url_label(&c.url), c.label, "url_label drift for {}", c.url);
+    }
+}

--- a/packages/prompts/src/fixtures/url-labels.json
+++ b/packages/prompts/src/fixtures/url-labels.json
@@ -1,0 +1,23 @@
+[
+  { "url": "https://www.linkedin.com/in/jane", "label": "LinkedIn" },
+  { "url": "http://github.com/jane", "label": "GitHub" },
+  { "url": "https://gitlab.com/jane", "label": "GitLab" },
+  { "url": "https://twitter.com/jane", "label": "Twitter" },
+  { "url": "https://x.com/jane", "label": "Twitter" },
+  { "url": "https://www.behance.net/jane", "label": "Behance" },
+  { "url": "https://dribbble.com/jane", "label": "Dribbble" },
+  { "url": "https://medium.com/@jane", "label": "Medium" },
+  { "url": "https://stackoverflow.com/users/1/jane", "label": "Stack Overflow" },
+  { "url": "https://dev.to/jane", "label": "Dev.to" },
+  { "url": "https://codepen.io/jane", "label": "CodePen" },
+  { "url": "https://www.youtube.com/@jane", "label": "YouTube" },
+  { "url": "https://youtu.be/abc123", "label": "YouTube" },
+  { "url": "https://notion.so/jane", "label": "Notion" },
+  { "url": "https://figma.com/@jane", "label": "Figma" },
+  { "url": "https://npmjs.com/~jane", "label": "npm" },
+  { "url": "https://crates.io/crates/serde", "label": "crates.io" },
+  { "url": "https://www.example.com/path/to/page", "label": "example.com" },
+  { "url": "http://my-portfolio.dev", "label": "my-portfolio.dev" },
+  { "url": "https://janedoe.dev/work", "label": "janedoe.dev" },
+  { "url": "https://solo.to/jane", "label": "solo.to" }
+]

--- a/packages/prompts/src/generate.test.ts
+++ b/packages/prompts/src/generate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import urlLabels from './fixtures/url-labels.json';
 import {
   buildCoverLetterPrompt,
   buildCoverLetterSystemPrompt,
@@ -12,6 +13,7 @@ import {
   injectLinksIntoGeneratedText,
   MODES,
   parseLinksFromResume,
+  urlToFriendlyLabel,
   validateMetadata,
 } from './generate';
 
@@ -49,12 +51,31 @@ describe('MODES', () => {
 });
 
 describe('getLinkMap', () => {
-  it('maps profile labels to URLs and skips email + non-profile links', () => {
+  it('maps profile labels to URLs, drops email, and admits one Website link', () => {
     const map = getLinkMap(RESUME_WITH_LINKS);
     expect(map.LinkedIn).toBe('https://linkedin.com/in/johndoe');
     expect(map.GitHub).toBe('https://github.com/johndoe');
     expect(map.Email).toBeUndefined();
+    // The single non-platform URL is admitted under a generic "Website" label —
+    // never under its raw anchor text.
+    expect(map.Website).toBe('https://not-a-profile.example.com');
     expect(map.Personal).toBeUndefined();
+  });
+
+  it('admits exactly one Website link and drops later non-platform URLs', () => {
+    const resume = [
+      'Body',
+      '---',
+      '- [LinkedIn](https://linkedin.com/in/jane)',
+      '- [Portfolio](https://janedoe.dev)',
+      '- [Blog](https://janeblog.example)',
+      '- [Email](mailto:jane@example.com)',
+    ].join('\n');
+    const map = getLinkMap(resume);
+    expect(map.LinkedIn).toBe('https://linkedin.com/in/jane');
+    expect(map.Website).toBe('https://janedoe.dev'); // first non-platform wins
+    expect(Object.values(map)).not.toContain('https://janeblog.example'); // 2nd dropped
+    expect(Object.values(map)).not.toContain('mailto:jane@example.com'); // mailto dropped
   });
 
   it('returns an empty map when there is no reference block', () => {
@@ -89,18 +110,41 @@ describe('injectLinksIntoGeneratedText', () => {
     const out = injectLinksIntoGeneratedText(text, { LinkedIn: 'https://linkedin.com/in/x' });
     expect(out).toBe(text);
   });
+
+  it('injects a Website link in the contact line', () => {
+    const text = `Jane Doe\nDesigner\nBerlin | jane@example.com | Website | GitHub\n\nSUMMARY`;
+    const out = injectLinksIntoGeneratedText(text, {
+      Website: 'https://janedoe.dev',
+      GitHub: 'https://github.com/jd',
+    });
+    expect(out).toContain('[Website](https://janedoe.dev)');
+    expect(out).toContain('[GitHub](https://github.com/jd)');
+  });
 });
 
 describe('parseLinksFromResume', () => {
-  it('extracts a clean email and profile labels', () => {
+  it('extracts a clean email, profile labels, and the Website label', () => {
     const { block, cleanEmail } = parseLinksFromResume(RESUME_WITH_LINKS);
     expect(cleanEmail).toBe('john@example.com');
     expect(block).toContain('LinkedIn');
     expect(block).toContain('GitHub');
+    expect(block).toContain('Website'); // non-platform URL surfaced for the AI to write
   });
 
   it('returns empty result when there is no reference block', () => {
     expect(parseLinksFromResume('No block here')).toEqual({ block: '', cleanEmail: '' });
+  });
+});
+
+describe('urlToFriendlyLabel ↔ Rust url_label parity', () => {
+  // Shared source of truth with `cargo test export::links` — both suites read
+  // fixtures/url-labels.json so the two implementations can never silently drift.
+  it('matches the shared fixture for every URL', () => {
+    const cases = urlLabels as { url: string; label: string }[];
+    expect(cases.length).toBeGreaterThan(0);
+    for (const { url, label } of cases) {
+      expect(urlToFriendlyLabel(url)).toBe(label);
+    }
   });
 });
 

--- a/packages/prompts/src/generate.ts
+++ b/packages/prompts/src/generate.ts
@@ -151,8 +151,9 @@ function isProfileUrl(url: string): boolean {
 /**
  * Derive a friendly label from a URL — mirrors the Rust url_label() in links.rs.
  * Used when a PDF annotation stores the raw URL as its anchor text instead of a label.
+ * Exported for the cross-language parity test against Rust url_label().
  */
-function urlToFriendlyLabel(url: string): string {
+export function urlToFriendlyLabel(url: string): string {
   try {
     const host = new URL(url).hostname.replace(/^www\./, '').toLowerCase();
     if (host.startsWith('linkedin.com')) return 'LinkedIn';
@@ -170,8 +171,10 @@ function urlToFriendlyLabel(url: string): string {
     if (host.startsWith('figma.com')) return 'Figma';
     if (host.startsWith('npmjs.com')) return 'npm';
     if (host.startsWith('crates.io')) return 'crates.io';
-    // Unknown: use bare domain without TLD as fallback label
-    return host.split('.')[0] ?? host;
+    // Unknown domain: the bare host (www-stripped, no path). Mirrors the Rust
+    // url_label() fallback exactly so the two implementations cannot drift — see
+    // the parity test (fixtures/url-labels.json, cargo test export::links).
+    return host;
   } catch {
     return url;
   }
@@ -184,25 +187,74 @@ interface ParsedResumeLinks {
   cleanEmail: string;
 }
 
+/** Generic label for a single non-platform personal site / portfolio URL. */
+const WEBSITE_LABEL = 'Website';
+
+interface LinkBlockEntry {
+  anchor: string;
+  url: string;
+}
+
 /**
- * Build a label→url map for all profile links in the extracted reference block.
- * Used for post-processing: replacing plain labels with [label](url) markdown.
+ * Parse the `\n---\n` markdown reference block (appended by the Rust extractor)
+ * into raw `[anchor](url)` entries, in document order. Returns [] when absent.
  */
-export function getLinkMap(resume: string): Record<string, string> {
+function parseLinkBlock(resume: string): LinkBlockEntry[] {
   const sep = resume.lastIndexOf('\n---\n');
-  if (sep === -1) return {};
+  if (sep === -1) return [];
   const block = resume.slice(sep + 5);
-  const map: Record<string, string> = {};
+  const entries: LinkBlockEntry[] = [];
   for (const l of block.split('\n')) {
     if (!l.startsWith('- [')) continue;
     const m = l.match(/^- \[([^\]]+)\]\(([^)]+)\)$/);
     if (!m) continue;
     const anchor = m[1] ?? '';
-    const url = m[2];
-    if (!anchor || !url || url.startsWith('mailto:') || !isProfileUrl(url)) continue;
-    // Normalise: PDFs often store the raw URL as the anchor text instead of a label.
-    // Derive a friendly label (e.g. "LinkedIn") so injection matches what the AI writes.
-    const label = /^https?:\/\//i.test(anchor) ? urlToFriendlyLabel(anchor) : anchor;
+    const url = m[2] ?? '';
+    if (anchor && url) entries.push({ anchor, url });
+  }
+  return entries;
+}
+
+/**
+ * Resolve the reference block into ordered contact links for the header line.
+ *
+ * Every known platform link keeps its brand label. In addition, the FIRST
+ * non-platform http(s) URL is admitted ONCE under a generic "Website" label —
+ * this is the website/portfolio fix: previously such URLs were dropped wholesale
+ * by the PROFILE_DOMAINS allowlist. Subsequent non-platform URLs are still
+ * dropped, so a single header-scoped site is surfaced without letting arbitrary
+ * inline body URLs leak in. `mailto:` is excluded here (handled separately as the
+ * clean email).
+ *
+ * Both getLinkMap() (post-generation injection) and parseLinksFromResume()
+ * (prompt instruction) build on this, so the label the AI is told to write and
+ * the label injection later looks for can never drift.
+ */
+function resolveContactLinks(resume: string): { label: string; url: string }[] {
+  const out: { label: string; url: string }[] = [];
+  let websiteAdmitted = false;
+  for (const { anchor, url } of parseLinkBlock(resume)) {
+    if (url.startsWith('mailto:')) continue;
+    if (isProfileUrl(url)) {
+      // PDFs often store the raw URL as the anchor; derive the friendly label
+      // (e.g. "LinkedIn") so injection matches what the AI writes.
+      const label = /^https?:\/\//i.test(anchor) ? urlToFriendlyLabel(anchor) : anchor;
+      out.push({ label, url });
+    } else if (!websiteAdmitted && /^https?:\/\//i.test(url)) {
+      out.push({ label: WEBSITE_LABEL, url });
+      websiteAdmitted = true;
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a label→url map for the contact links in the extracted reference block.
+ * Used for post-processing: replacing plain labels with [label](url) markdown.
+ */
+export function getLinkMap(resume: string): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const { label, url } of resolveContactLinks(resume)) {
     map[label] = url;
   }
   return map;
@@ -242,27 +294,15 @@ export function injectLinksIntoGeneratedText(
  * post-generation by injectLinksIntoGeneratedText().
  */
 export function parseLinksFromResume(resume: string): ParsedResumeLinks {
-  const sep = resume.lastIndexOf('\n---\n');
-  if (sep === -1) return { block: '', cleanEmail: '' };
-  const block = resume.slice(sep + 5);
-  const lines = block.split('\n').filter((l) => l.startsWith('- ['));
+  const entries = parseLinkBlock(resume);
+  if (!entries.length) return { block: '', cleanEmail: '' };
 
-  let cleanEmail = '';
-  const labelEntries: string[] = [];
+  const mailto = entries.find((e) => e.url.startsWith('mailto:'));
+  const cleanEmail = mailto ? mailto.url.slice('mailto:'.length) : '';
 
-  for (const l of lines) {
-    const m = l.match(/^- \[([^\]]+)\]\(([^)]+)\)$/);
-    if (!m) continue;
-    const anchor = m[1] ?? '';
-    const url = m[2];
-    if (!url) continue;
-    if (url.startsWith('mailto:')) {
-      cleanEmail = url.slice('mailto:'.length);
-      continue;
-    }
-    if (!isProfileUrl(url)) continue;
-    labelEntries.push(anchor);
-  }
+  // Exactly the labels (platform brands + one "Website") getLinkMap() will inject,
+  // so the AI is instructed to write the same short labels we later hyperlink.
+  const labelEntries = resolveContactLinks(resume).map((e) => e.label);
 
   if (!labelEntries.length && !cleanEmail) return { block: '', cleanEmail: '' };
 
@@ -274,7 +314,7 @@ export function parseLinksFromResume(resume: string): ParsedResumeLinks {
     parts.push(
       `CANDIDATE PROFILE LINKS — write ONLY these short labels in the contact line (NOT the full URL):\n` +
         labelEntries.join(', ') +
-        `\nExample: Haarlem, Netherlands | milanbehnam97@gmail.com | +31... | LinkedIn | GitHub`
+        `\nExample: Haarlem, Netherlands | name@example.com | +31... | LinkedIn | GitHub | Website`
     );
   }
 


### PR DESCRIPTION
## PR #1 of the Resume & Cover-Letter Engine plan

First, isolated deliverable (TS-only fix + parity tests) from the strangler-fig migration plan. Independent of the rest of the refactor.

### Problem
`getLinkMap()` and `parseLinksFromResume()` dropped **every** non-platform `http(s)` URL via the `PROFILE_DOMAINS` allowlist, so a candidate's personal **website / portfolio** link never made it into the generated resume or cover letter — even though the Rust extractor (`extraction/pdf.rs`, `extraction/docx.rs`) already captured it into the `\n---\n` reference block.

### Fix
- New shared `resolveContactLinks()` keeps every known platform link **and** admits the **first** non-platform `http(s)` URL once, under a generic **`Website`** label. Later non-platform URLs and `mailto:` are still dropped, so arbitrary inline body URLs can't leak in (single header-scoped admission).
- `getLinkMap()` (post-generation injection) and `parseLinksFromResume()` (prompt instruction) now both build on `resolveContactLinks()`, so the label the AI is told to write and the label injection later looks for **can never drift**.
- Reconciled `urlToFriendlyLabel()`'s unknown-domain fallback with the Rust `url_label()` (full bare domain, e.g. `solo.to`, not the first dotted segment `solo`) — they had silently diverged despite the docstring claiming parity.

### Tests
- TS: `getLinkMap` admits one `Website` link, drops a 2nd non-platform URL, drops `mailto:`; `injectLinksIntoGeneratedText` covers `Website`.
- Rust: `split_urls` labels an arbitrary site by bare domain (regression lock).
- **Cross-language parity golden:** `url_label` (Rust) ≡ `urlToFriendlyLabel` (TS) over a single shared `packages/prompts/src/fixtures/url-labels.json` read by both test suites — they can't drift.

### Gates
- `pnpm --filter @ajh/prompts test` → 64 passed
- `pnpm typecheck` → clean
- `pnpm lint:strict` → clean
- `cargo test export::links` → 10 passed

No IPC contracts touched. External `ExportRequest` / `BaseExportRequest` contract unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)