### PR TITLE
docs: require lowercase commit subjects in all ai assistant rules

### DIFF
--- a/.aider/system-prompt.md
+++ b/.aider/system-prompt.md
@@ -68,3 +68,4 @@ Read these files for full details before making structural changes:
 **Release:** Never manually tag releases or edit CHANGELOG.md/versions.
 Releases are automated via semantic-release on push to main.
 feat → minor, fix/perf → patch, BREAKING CHANGE → major.
+Commit subject must be lowercase (commitlint subject-case) — lowercase acronyms too (url, api, docx). Subject ≤ 100 chars; body lines ≤ 200.

--- a/.clinerules
+++ b/.clinerules
@@ -37,6 +37,8 @@ git push origin HEAD
 
 Conventional commit prefixes: `feat:` `fix:` `perf:` `refactor:` `docs:` `chore:` `ci:` `test:`
 
+Commit subject must be lowercase (commitlint `subject-case`) — lowercase acronyms too (`url`, `api`, `docx`). Subject ≤ 100 chars; body lines ≤ 200.
+
 **Before starting any work, verify the current branch still exists on the remote:**
 ```bash
 git fetch origin

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -89,4 +89,4 @@ If branch gone: `rtk git checkout main && rtk git pull origin main`.
 ## Commit conventions
 
 `feat:` minor · `fix:`/`perf:` patch · `BREAKING CHANGE` major · everything else: no release.
-Subject must be lowercase. Never tag manually or edit CHANGELOG.md.
+Subject must be lowercase (commitlint `subject-case`) — lowercase acronyms too (`url`, `api`, `docx`); subject ≤ 100 chars, body lines ≤ 200. Never tag manually or edit CHANGELOG.md.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,3 +93,4 @@ If branch gone: `rtk git checkout main && rtk git pull origin main`.
 
 `feat:` → minor · `fix:`/`perf:` → patch · `BREAKING CHANGE` → major.
 Never manually tag, edit CHANGELOG.md, or bump versions.
+Commit subject must be lowercase (commitlint `subject-case`) — lowercase acronyms too (`url`, `api`, `docx`). Subject ≤ 100 chars; body lines ≤ 200.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -102,4 +102,4 @@ Renderer → main: `window.api.*` only (via `AppClient` context → service hook
 ## Commit conventions
 
 `feat:` → minor release · `fix:`/`perf:` → patch · `BREAKING CHANGE` footer → major
-`refactor:`, `docs:`, `chore:`, `ci:`, `test:` → no release. Subject must be lowercase.
+`refactor:`, `docs:`, `chore:`, `ci:`, `test:` → no release. Subject must be lowercase (commitlint `subject-case`) — lowercase acronyms too (`url`, `api`, `docx`); subject ≤ 100 chars, body lines ≤ 200.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,4 @@ If branch is gone: `rtk git checkout main && rtk git pull origin main`.
 
 `feat:` → minor, `fix:`/`perf:` → patch, `BREAKING CHANGE` footer → major.
 Never manually tag releases or edit CHANGELOG.md.
+Commit subject must be **lowercase** (commitlint `subject-case`) — lowercase acronyms too (`url`, `api`, `docx`). Subject ≤ 100 chars; body lines ≤ 200.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,3 +202,12 @@ Automated via semantic-release on push to `main`. Do not manually tag or bump ve
 | `fix:`, `perf:`                                | patch (1.0.x) |
 | `BREAKING CHANGE` footer                       | major (x.0.0) |
 | `refactor:`, `docs:`, `chore:`, `ci:`, `test:` | no release    |
+
+### Commit messages — enforced by commitlint (`commit-msg` hook)
+
+Violations **fail the commit**. See `commitlint.config.mjs`.
+
+- **Subject MUST be lower-case** (`subject-case`). `fix: admit website links` ✅ — `fix: Admit Website URLs` ❌ (capitalized words and acronyms like `URL`/`API`/`DOCX` are rejected in the subject; reword or lowercase them).
+- **Subject ≤ 100 chars**; **body lines ≤ 200 chars**; blank line between subject and body.
+- **Type** is one of: `feat`, `fix`, `perf`, `refactor`, `ui`, `style`, `test`, `docs`, `build`, `ci`, `chore`, `revert` (`type-enum`). Only the types in the table above affect releases.
+- Imperative mood, no trailing period in the subject.


### PR DESCRIPTION
## Why

`commitlint.config.mjs` enforces (via the `commit-msg` Husky hook):
- `subject-case` = **lower-case**
- `subject-max-length` = **100**
- `body-max-line-length` = **200**

…but most of the per-tool AI rule files didn't document it, so AI-generated commits kept getting rejected by the hook — most often because of a capitalized word or an acronym (`URL`, `API`, `DOCX`) in the subject.

## What

Document the rule consistently across **every** AI assistant rule file:

| File | Change |
| --- | --- |
| `CLAUDE.md` | Added a "Commit messages" subsection under Release Pipeline |
| `AGENTS.md` | Added lowercase + length note to `## Release` |
| `.clinerules` | Added note after the conventional-prefixes line |
| `.github/copilot-instructions.md` | Added note to `## Release` |
| `.aider/system-prompt.md` | Added note to the Release block |
| `.windsurfrules` | Expanded the existing "Subject must be lowercase" line |
| `.cursor/rules/project.mdc` | Expanded the existing "Subject must be lowercase" line |

Docs-only; no code, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)