### PR TITLE
ci: make readme release badge static and sync it on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,8 @@ jobs:
             package.json \
             apps/tauri/package.json \
             apps/tauri/src-tauri/Cargo.toml \
-            apps/tauri/src-tauri/tauri.conf.json; then
+            apps/tauri/src-tauri/tauri.conf.json \
+            README.md; then
             echo "Version files are already synced."
             exit 0
           fi
@@ -155,7 +156,8 @@ jobs:
             package.json \
             apps/tauri/package.json \
             apps/tauri/src-tauri/Cargo.toml \
-            apps/tauri/src-tauri/tauri.conf.json
+            apps/tauri/src-tauri/tauri.conf.json \
+            README.md
           git commit -m "chore: sync version files to v${{ needs.release.outputs.version }} [skip ci]"
           git push git@github.com:saeedkolivand/ai-job-hunter-assistant-app.git HEAD:main
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > Your local-first, AI-native desktop assistant for intelligent job searching, resume generation, and automated applications — run it fully offline with Ollama, or plug in your own OpenAI, Anthropic, or Gemini key.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/saeedkolivand/ai-job-hunter-assistant-app?color=e24b4a)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases)
+[![Release](https://img.shields.io/badge/release-v0.23.1-e24b4a)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases)
 [![Live site](https://img.shields.io/badge/Live-site-e24b4a)](https://saeedkolivand.github.io/ai-job-hunter-assistant-app/)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/pulls)

--- a/scripts/sync-tauri-version.cjs
+++ b/scripts/sync-tauri-version.cjs
@@ -17,6 +17,7 @@
  *   apps/tauri/src-tauri/Cargo.toml       — [package] version
  *   apps/tauri/package.json               — version
  *   package.json                          — version
+ *   README.md                             — static release badge version
  */
 
 'use strict';
@@ -63,3 +64,21 @@ const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, 'utf8'));
 rootPkg.version = version;
 fs.writeFileSync(rootPkgPath, JSON.stringify(rootPkg, null, 2) + '\n');
 console.log(`package.json → version=${version}`);
+
+// ── README.md release badge ──────────────────────────────────────────────────
+//
+// The release badge is a STATIC shields.io badge (img.shields.io/badge/...) so
+// it never calls the GitHub API — the dynamic /github/v/release endpoint
+// intermittently renders "Unable to select next GitHub token from pool" when
+// shields' shared token pool is rate-limited. We keep it accurate by rewriting
+// the version here on every release. Matches: release-v<version>-<6-hex-color>.
+
+const readmePath = path.join(root, 'README.md');
+const readme = fs.readFileSync(readmePath, 'utf8');
+const badgeRe = /(img\.shields\.io\/badge\/release-v)[0-9][0-9.]*(-[0-9a-fA-F]{6})/;
+if (badgeRe.test(readme)) {
+  fs.writeFileSync(readmePath, readme.replace(badgeRe, `$1${version}$2`));
+  console.log(`README.md → release badge v${version}`);
+} else {
+  console.warn('README.md → release badge not found (skipped)');
+}


### PR DESCRIPTION
## Why

The README **Release** badge used the dynamic shields.io endpoint:

```
https://img.shields.io/github/v/release/saeedkolivand/ai-job-hunter-assistant-app?color=e24b4a
```

That calls the GitHub API via shields' shared token pool, which intermittently renders **"Unable to select next GitHub token from pool"** instead of the version when the pool is rate-limited. It's the only badge in the README that hits an API.

## What

Make it a **static** badge and keep it accurate automatically — no API call, so it never flakes:

- **`README.md`** — badge is now `img.shields.io/badge/release-v0.23.1-e24b4a`.
- **`scripts/sync-tauri-version.cjs`** — already syncs the release version into `package.json`, `Cargo.toml`, `tauri.conf.json`; now also rewrites the README badge version (regex `release-v<version>-<hex>`, idempotent, warns+skips if not found).
- **`.github/workflows/release.yml`** — the existing `sync-version-files` job adds `README.md` to the diff-check and `git add`, so the badge is bumped and committed to `main` on every release (same `chore: sync version files to vX [skip ci]` commit).

Verified the regex against the current README (matches `v0.23.1`, rewrites cleanly). `ci:` type → no release triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)