### PR TITLE
refactor: add measure/theme/locale foundations + eval corpus (phase 1b)

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.23.0"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -103,6 +103,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "ttf-parser",
  "urlencoding",
  "uuid",
  "windows-native-keyring-store",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -43,6 +43,11 @@ chromiumoxide = { version = "0.9", features = ["fetcher", "zip8"] }
 
 futures = "0.3"
 regex = "1"
+# Font metrics for the canonical text-measurement layer (measure/): real glyph
+# advances/line-heights from the bundled TTFs — the future replacement for the
+# `× 0.52` char-width estimate in the PDF renderer. Pinned to match the version
+# already present transitively so the tree carries a single ttf-parser.
+ttf-parser = "0.25"
 anyhow = "1"
 thiserror = "2"
 chrono = "0.4"

--- a/apps/tauri/src-tauri/src/locale/mod.rs
+++ b/apps/tauri/src-tauri/src/locale/mod.rs
@@ -1,0 +1,178 @@
+//! Locale profiles — per-market document conventions: page size, date style,
+//! photo/PII policy, and default section order.
+//!
+//! Page size + date style feed both backends; section order + photo/PII feed the
+//! AI prompt and model build. Phase 1 ships the `en` default (A4, photos Never,
+//! no personal details) plus the types; the full registry (US, UK, DE/AT/CH, FR,
+//! NL, generic-EU/INTL) is populated in Phase 7.
+//!
+//! Privacy: photo / personal details are **user-supplied only** — never inferred
+//! or auto-added.
+#![allow(dead_code)]
+
+use crate::model::document::SectionId;
+
+/// Physical page size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PageSize {
+    A4,
+    Letter,
+}
+
+/// Page dimensions in millimetres, derived from a [`PageSize`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PageGeometry {
+    pub width_mm: f32,
+    pub height_mm: f32,
+}
+
+impl PageSize {
+    /// Physical dimensions for this page size, in mm.
+    pub fn geometry(self) -> PageGeometry {
+        match self {
+            PageSize::A4 => PageGeometry {
+                width_mm: 210.0,
+                height_mm: 297.0,
+            },
+            PageSize::Letter => PageGeometry {
+                width_mm: 215.9,
+                height_mm: 279.4,
+            },
+        }
+    }
+}
+
+/// How date ranges are written in the target market.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateStyle {
+    /// "January 2021 – March 2023"
+    MonthYear,
+    /// "01/2021 – 03/2023"
+    NumericSlash,
+    /// "2021-01 – 2023-03"
+    IsoMonth,
+}
+
+/// Whether a photo is customary on a CV in this market.
+/// User-supplied only — never inferred or auto-added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhotoPolicy {
+    Never,
+    Optional,
+    Common,
+}
+
+/// Per-market document conventions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocaleProfile {
+    /// Market id ("en", "de", "us", …).
+    pub id: &'static str,
+    pub page_size: PageSize,
+    pub date_style: DateStyle,
+    pub photo: PhotoPolicy,
+    /// Whether personal details (DOB, nationality, marital status) are customary
+    /// in this market. User-supplied only.
+    pub include_personal_details: bool,
+    /// Canonical section ordering for this market (consumed by
+    /// `transform::reorder_sections`).
+    pub default_section_order: &'static [SectionId],
+}
+
+/// Default single-column section order shared by the English/international profile.
+const DEFAULT_ORDER: &[SectionId] = &[
+    SectionId::Summary,
+    SectionId::Experience,
+    SectionId::Skills,
+    SectionId::Projects,
+    SectionId::Education,
+    SectionId::Certifications,
+    SectionId::Languages,
+    SectionId::Awards,
+];
+
+impl LocaleProfile {
+    /// Page geometry for this profile.
+    pub fn page_geometry(&self) -> PageGeometry {
+        self.page_size.geometry()
+    }
+
+    /// Resolve a profile by market id. Phase 1 only ships the `en` default;
+    /// unknown ids fall back to it. Phase 7 populates the other markets.
+    pub fn get(id: &str) -> LocaleProfile {
+        match id {
+            "en" => Self::en(),
+            _ => Self::en(),
+        }
+    }
+
+    /// English / international default: A4, no photo, no personal details.
+    pub fn en() -> LocaleProfile {
+        LocaleProfile {
+            id: "en",
+            page_size: PageSize::A4,
+            date_style: DateStyle::MonthYear,
+            photo: PhotoPolicy::Never,
+            include_personal_details: false,
+            default_section_order: DEFAULT_ORDER,
+        }
+    }
+}
+
+impl Default for LocaleProfile {
+    fn default() -> Self {
+        Self::en()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a4_and_letter_have_expected_dimensions() {
+        assert_eq!(
+            PageSize::A4.geometry(),
+            PageGeometry {
+                width_mm: 210.0,
+                height_mm: 297.0
+            }
+        );
+        assert_eq!(
+            PageSize::Letter.geometry(),
+            PageGeometry {
+                width_mm: 215.9,
+                height_mm: 279.4
+            }
+        );
+    }
+
+    #[test]
+    fn default_profile_is_en_a4_never() {
+        let p = LocaleProfile::default();
+        assert_eq!(p, LocaleProfile::en());
+        assert_eq!(p.id, "en");
+        assert_eq!(p.page_size, PageSize::A4);
+        assert_eq!(p.photo, PhotoPolicy::Never);
+        assert!(!p.include_personal_details);
+        assert_eq!(
+            p.page_geometry(),
+            PageGeometry {
+                width_mm: 210.0,
+                height_mm: 297.0
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_market_falls_back_to_en() {
+        assert_eq!(LocaleProfile::get("zz"), LocaleProfile::en());
+        assert_eq!(LocaleProfile::get("en"), LocaleProfile::en());
+    }
+
+    #[test]
+    fn default_order_starts_with_summary_then_experience() {
+        let order = LocaleProfile::en().default_section_order;
+        assert_eq!(order.first(), Some(&SectionId::Summary));
+        assert_eq!(order.get(1), Some(&SectionId::Experience));
+    }
+}

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -34,6 +34,8 @@ mod export;
 mod ipc_contracts;
 mod job_preferences;
 mod jobs;
+mod locale;
+mod measure;
 mod model;
 mod net;
 mod observability;
@@ -42,6 +44,7 @@ mod platform;
 mod postings;
 mod profile_import;
 mod scraping;
+mod theme;
 mod updater;
 
 use parking_lot::Mutex;

--- a/apps/tauri/src-tauri/src/measure/mod.rs
+++ b/apps/tauri/src-tauri/src/measure/mod.rs
@@ -1,0 +1,181 @@
+//! Text measurement — the single source of truth for glyph advances and line
+//! heights, computed from the actual bundled TrueType fonts via `ttf-parser`.
+//!
+//! This is the principled replacement for the `pt_to_mm(font_size) * 0.52`
+//! char-width estimate the PDF renderer uses today (for link rects and name
+//! centering). Phase 1 introduces it with no consumers yet — the PDF/DOCX
+//! layout paths move onto it in Phase 2+.
+#![allow(dead_code)]
+
+use crate::export::types::FontFamily;
+
+/// Points → millimetres (1 pt = 1/72 in = 25.4/72 mm).
+const PT_TO_MM: f32 = 25.4 / 72.0;
+
+/// Measures rendered text in millimetres for a given font + size.
+///
+/// `bold` selects the bold face (which has different metrics than the regular
+/// face — important for centering bold names and sizing bold link labels).
+pub trait MeasureText {
+    /// Horizontal advance width of `text` in mm at `size_pt`.
+    fn advance_mm(&self, text: &str, font: FontFamily, bold: bool, size_pt: f32) -> f32;
+
+    /// Single-line height in mm at `size_pt` (ascender − descender + line gap).
+    fn line_height_mm(&self, font: FontFamily, bold: bool, size_pt: f32) -> f32;
+}
+
+/// `MeasureText` backed by the `include_bytes!`-bundled TTFs (the same faces the
+/// PDF renderer embeds). Stateless: faces are parsed on demand (cheap — just
+/// table-offset reads), so there's nothing to cache or keep `Sync`.
+pub struct FontMetrics;
+
+impl FontMetrics {
+    /// Raw TTF bytes for a family + weight. Mirrors the PDF renderer's font set;
+    /// families without a dedicated bold face fall back to the regular bytes.
+    fn bytes(font: FontFamily, bold: bool) -> &'static [u8] {
+        match (font, bold) {
+            (FontFamily::Calibri, false) => include_bytes!("../../fonts/calibri.ttf"),
+            (FontFamily::Calibri, true) => include_bytes!("../../fonts/calibrib.ttf"),
+            (FontFamily::Inter, false) => include_bytes!("../../fonts/inter_regular.ttf"),
+            (FontFamily::Inter, true) => include_bytes!("../../fonts/inter_bold.ttf"),
+            (FontFamily::SourceSerif4, false) => {
+                include_bytes!("../../fonts/source_serif4_regular.ttf")
+            }
+            (FontFamily::SourceSerif4, true) => {
+                include_bytes!("../../fonts/source_serif4_bold.ttf")
+            }
+            (FontFamily::Manrope, false) => include_bytes!("../../fonts/manrope_regular.ttf"),
+            (FontFamily::Manrope, true) => include_bytes!("../../fonts/manrope_bold.ttf"),
+            (FontFamily::JetBrainsMono, false) => {
+                include_bytes!("../../fonts/jetbrains_mono_regular.ttf")
+            }
+            (FontFamily::JetBrainsMono, true) => {
+                include_bytes!("../../fonts/jetbrains_mono_bold.ttf")
+            }
+            (FontFamily::PlayfairDisplay, false) => {
+                include_bytes!("../../fonts/playfair_display_regular.ttf")
+            }
+            (FontFamily::PlayfairDisplay, true) => {
+                include_bytes!("../../fonts/playfair_display_bold.ttf")
+            }
+        }
+    }
+
+    fn face(font: FontFamily, bold: bool) -> Option<ttf_parser::Face<'static>> {
+        ttf_parser::Face::parse(Self::bytes(font, bold), 0).ok()
+    }
+}
+
+impl MeasureText for FontMetrics {
+    fn advance_mm(&self, text: &str, font: FontFamily, bold: bool, size_pt: f32) -> f32 {
+        let Some(face) = Self::face(font, bold) else {
+            // Parsing should never fail for a bundled font; degrade to the legacy
+            // estimate rather than panicking in a render path.
+            return size_pt * PT_TO_MM * 0.52 * text.chars().count() as f32;
+        };
+        let upm = face.units_per_em() as f32;
+        if upm <= 0.0 {
+            return 0.0;
+        }
+        // Sum glyph horizontal advances; unmapped chars fall back to a half-em.
+        let units: f32 = text
+            .chars()
+            .map(|ch| {
+                face.glyph_index(ch)
+                    .and_then(|g| face.glyph_hor_advance(g))
+                    .map(|a| a as f32)
+                    .unwrap_or(upm * 0.5)
+            })
+            .sum();
+        units / upm * size_pt * PT_TO_MM
+    }
+
+    fn line_height_mm(&self, font: FontFamily, bold: bool, size_pt: f32) -> f32 {
+        let Some(face) = Self::face(font, bold) else {
+            return size_pt * PT_TO_MM * 1.2;
+        };
+        let upm = face.units_per_em() as f32;
+        if upm <= 0.0 {
+            return size_pt * PT_TO_MM * 1.2;
+        }
+        let span = face.ascender() as f32 - face.descender() as f32 + face.line_gap() as f32;
+        span / upm * size_pt * PT_TO_MM
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL: [FontFamily; 6] = [
+        FontFamily::Calibri,
+        FontFamily::Inter,
+        FontFamily::SourceSerif4,
+        FontFamily::Manrope,
+        FontFamily::JetBrainsMono,
+        FontFamily::PlayfairDisplay,
+    ];
+
+    #[test]
+    fn every_bundled_face_parses_and_measures() {
+        let m = FontMetrics;
+        for f in ALL {
+            for bold in [false, true] {
+                assert!(
+                    m.advance_mm("Resume", f, bold, 11.0) > 0.0,
+                    "advance should be positive for {f:?} bold={bold}"
+                );
+                assert!(
+                    m.line_height_mm(f, bold, 11.0) > 0.0,
+                    "line height should be positive for {f:?} bold={bold}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn advance_scales_with_length_and_size() {
+        let m = FontMetrics;
+        let one = m.advance_mm("M", FontFamily::Inter, false, 11.0);
+        let many = m.advance_mm("MMMM", FontFamily::Inter, false, 11.0);
+        assert!(many > one * 3.0, "4×M should be ~4× a single M");
+
+        let small = m.advance_mm("Hello", FontFamily::Inter, false, 10.0);
+        let big = m.advance_mm("Hello", FontFamily::Inter, false, 20.0);
+        assert!(
+            (big - small * 2.0).abs() < 0.01,
+            "advance is linear in size"
+        );
+    }
+
+    #[test]
+    fn proportional_font_widths_differ_by_glyph() {
+        let m = FontMetrics;
+        // In a proportional font, wide glyphs advance more than narrow ones.
+        let wide = m.advance_mm("WWWW", FontFamily::Inter, false, 12.0);
+        let narrow = m.advance_mm("iiii", FontFamily::Inter, false, 12.0);
+        assert!(
+            wide > narrow,
+            "W should be wider than i in a proportional face"
+        );
+    }
+
+    #[test]
+    fn monospace_font_widths_are_uniform() {
+        let m = FontMetrics;
+        let wide = m.advance_mm("WWWW", FontFamily::JetBrainsMono, false, 12.0);
+        let narrow = m.advance_mm("iiii", FontFamily::JetBrainsMono, false, 12.0);
+        assert!(
+            (wide - narrow).abs() < 0.01,
+            "mono advances should be uniform"
+        );
+    }
+
+    #[test]
+    fn empty_string_has_zero_advance() {
+        assert_eq!(
+            FontMetrics.advance_mm("", FontFamily::Calibri, false, 11.0),
+            0.0
+        );
+    }
+}

--- a/apps/tauri/src-tauri/src/theme/mod.rs
+++ b/apps/tauri/src-tauri/src/theme/mod.rs
@@ -1,0 +1,120 @@
+//! Theme — the single source of truth for per-template styling and the
+//! structural rules the canonical layout engine needs (section placement, link
+//! styling).
+//!
+//! Phase 1 introduces `theme` as the canonical *seam* alongside the existing
+//! renderers: it exposes the template registry via [`template`] and adds the
+//! model-level decisions (`placement_for`, `link_style`) that the new layout
+//! path will consume. The `Template` data itself still lives in
+//! `export::templates` (which the legacy PDF/DOCX renderers import directly); it
+//! migrates physically into this module when the backends move onto
+//! `DocumentModel` in Phase 2, so nothing here changes current behavior.
+#![allow(dead_code)]
+
+use crate::export::templates::Template;
+use crate::export::types::TemplateId;
+use crate::model::document::{Placement, SectionId};
+
+/// Canonical accessor for a template's style data. Thin wrapper over
+/// [`Template::get`] so callers depend on `theme`, not the legacy module path.
+pub fn template(id: TemplateId) -> Template {
+    Template::get(id)
+}
+
+/// Default column placement for a section in a two-column layout, independent of
+/// any single template's (string-keyed, locale-specific) `sidebar_sections` list
+/// that still drives the legacy renderer.
+///
+/// Sidebar-leaning sections (skills / education / languages / certifications) go
+/// to the sidebar; everything else flows in the main column. Contact details
+/// live in the document header (handled by the layout engine), so they are not a
+/// [`SectionId`] here.
+pub fn placement_for(id: &SectionId) -> Placement {
+    match id {
+        SectionId::Skills
+        | SectionId::Education
+        | SectionId::Languages
+        | SectionId::Certifications => Placement::Sidebar,
+        _ => Placement::Main,
+    }
+}
+
+/// How hyperlinks render for a template.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LinkStyle {
+    /// Draw links in the template accent color (vs. plain body-text color).
+    pub use_accent: bool,
+    /// Underline links.
+    pub underline: bool,
+}
+
+/// Link styling per template: accent color + underline by default. The ATS
+/// Classic template keeps links in body color with no underline, for maximum
+/// parser/printer safety.
+pub fn link_style(id: TemplateId) -> LinkStyle {
+    match id {
+        TemplateId::Classic => LinkStyle {
+            use_accent: false,
+            underline: false,
+        },
+        _ => LinkStyle {
+            use_accent: true,
+            underline: true,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_accessor_matches_registry() {
+        assert_eq!(template(TemplateId::Classic).id, TemplateId::Classic);
+        assert_eq!(template(TemplateId::TwoColumn).id, TemplateId::TwoColumn);
+    }
+
+    #[test]
+    fn sidebar_sections_go_to_the_sidebar() {
+        for id in [
+            SectionId::Skills,
+            SectionId::Education,
+            SectionId::Languages,
+            SectionId::Certifications,
+        ] {
+            assert_eq!(
+                placement_for(&id),
+                Placement::Sidebar,
+                "{id:?} should be sidebar"
+            );
+        }
+    }
+
+    #[test]
+    fn main_sections_stay_in_the_main_column() {
+        for id in [
+            SectionId::Summary,
+            SectionId::Experience,
+            SectionId::Projects,
+        ] {
+            assert_eq!(placement_for(&id), Placement::Main, "{id:?} should be main");
+        }
+        assert_eq!(
+            placement_for(&SectionId::Custom("Patents".into())),
+            Placement::Main
+        );
+    }
+
+    #[test]
+    fn classic_links_are_plain_others_accented() {
+        assert_eq!(
+            link_style(TemplateId::Classic),
+            LinkStyle {
+                use_accent: false,
+                underline: false
+            }
+        );
+        let modern = link_style(TemplateId::Modern);
+        assert!(modern.use_accent && modern.underline);
+    }
+}

--- a/apps/tauri/src-tauri/tests/corpus/README.md
+++ b/apps/tauri/src-tauri/tests/corpus/README.md
@@ -1,0 +1,33 @@
+# Eval corpus
+
+Synthetic, **no-PII** resume fixtures for the export/extraction eval harness
+(`tests/eval.rs`). Each `<name>.txt` is a fake resume; its `<name>.tags` sidecar
+declares the expected extraction in a simple line format:
+
+```
+# comment line
+key: value
+```
+
+Recognized keys (repeatable keys accumulate in order):
+
+| key       | repeatable | meaning                                    |
+| --------- | ---------- | ------------------------------------------ |
+| `name`    | no         | candidate full name                        |
+| `email`   | no\*       | contact email (must be a synthetic domain) |
+| `phone`   | no         | contact phone                              |
+| `section` | yes        | each expected section heading              |
+| `link`    | yes        | each expected profile/portfolio label      |
+
+## Rules
+
+- Emails MUST use a reserved example domain (`example.test` / `example.com`) —
+  the harness asserts this and that the email also appears verbatim in the `.txt`.
+- No real names, phone numbers, or addresses.
+
+## Status
+
+Phase 1 only validates corpus **shape** (sidecar present, tags parse, required
+fields, synthetic emails). Field-level precision/recall against the real
+extractor is computed in `tests/eval.rs` in **Phase 6**, using these same tags as
+ground truth.

--- a/apps/tauri/src-tauri/tests/corpus/synthetic_designer.tags
+++ b/apps/tauri/src-tauri/tests/corpus/synthetic_designer.tags
@@ -1,0 +1,8 @@
+# synthetic fixture — no real PII
+name: Jordan Lee
+email: jordan.lee@example.com
+section: Summary
+section: Experience
+section: Skills
+section: Education
+link: Portfolio

--- a/apps/tauri/src-tauri/tests/corpus/synthetic_designer.txt
+++ b/apps/tauri/src-tauri/tests/corpus/synthetic_designer.txt
@@ -1,0 +1,22 @@
+Jordan Lee
+Product Designer
+Amsterdam, Netherlands | jordan.lee@example.com | Portfolio
+
+SUMMARY
+Product designer focused on design systems and accessibility, partnering with
+engineering to ship cohesive, inclusive interfaces.
+
+EXPERIENCE
+Product Designer, Initech (2019 – 2024)
+• Shipped a cross-platform design system adopted by six product squads
+• Ran usability studies that lifted onboarding activation 18%
+• Established accessibility audits as a release gate
+
+Junior Designer, Hooli (2017 – 2019)
+• Redesigned the checkout flow, reducing drop-off 12%
+
+SKILLS
+Figma, prototyping, design systems, accessibility, user research
+
+EDUCATION
+BA Design, Art Academy (2014 – 2018)

--- a/apps/tauri/src-tauri/tests/corpus/synthetic_swe.tags
+++ b/apps/tauri/src-tauri/tests/corpus/synthetic_swe.tags
@@ -1,0 +1,10 @@
+# synthetic fixture — no real PII
+name: Alex Carter
+email: alex.carter@example.test
+phone: +49 30 0000000
+section: Professional Summary
+section: Work Experience
+section: Skills
+section: Education
+link: LinkedIn
+link: GitHub

--- a/apps/tauri/src-tauri/tests/corpus/synthetic_swe.txt
+++ b/apps/tauri/src-tauri/tests/corpus/synthetic_swe.txt
@@ -1,0 +1,24 @@
+Alex Carter
+Senior Backend Engineer
+Berlin, Germany | alex.carter@example.test | +49 30 0000000 | LinkedIn | GitHub
+
+PROFESSIONAL SUMMARY
+Backend engineer with 8 years building distributed services for high-traffic
+platforms. Focused on reliability, observability, and pragmatic delivery.
+
+WORK EXPERIENCE
+Senior Backend Engineer, Globex (Jan 2020 – Present)
+• Led migration of the order service to microservices, cutting p99 latency 40%
+• Built an event pipeline processing 5M events/day with Kafka and Go
+• Mentored four engineers and introduced trunk-based development
+
+Backend Engineer, Initrode (Jun 2016 – Dec 2019)
+• Designed REST APIs serving 200k daily requests with Redis caching
+• Cut cloud spend 25% by right-sizing services and adding autoscaling
+
+SKILLS
+Languages: Go, Python, Rust
+Platforms: AWS, Kubernetes, PostgreSQL
+
+EDUCATION
+B.Sc. Computer Science, Technical University (2012 – 2016)

--- a/apps/tauri/src-tauri/tests/eval.rs
+++ b/apps/tauri/src-tauri/tests/eval.rs
@@ -1,0 +1,81 @@
+//! Eval-corpus harness — Phase 1 skeleton.
+//!
+//! Loads the synthetic, no-PII fixtures under `tests/corpus/` and validates the
+//! corpus is well-formed: every resume `.txt` has a `.tags` sidecar, every tag
+//! line parses, the expected fields are present, and emails are synthetic.
+//!
+//! Field-level precision/recall against the real extractor is wired up in
+//! Phase 6 — this stub just guards the corpus shape so later phases can rely on
+//! it. (Standalone integration test: `ajh-tauri` is a binary crate, so this uses
+//! only `std`, not the crate's internals.)
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/corpus")
+}
+
+/// Parse a `.tags` sidecar: `key: value` lines; `#` comments and blanks ignored.
+/// Repeatable keys (`section`, `link`) accumulate in order.
+fn parse_tags(text: &str) -> BTreeMap<String, Vec<String>> {
+    let mut map: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (i, raw) in text.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((k, v)) = line.split_once(':') else {
+            panic!("tag line {} is not `key: value`: {raw:?}", i + 1);
+        };
+        map.entry(k.trim().to_string())
+            .or_default()
+            .push(v.trim().to_string());
+    }
+    map
+}
+
+#[test]
+fn corpus_fixtures_are_well_formed() {
+    let dir = corpus_dir();
+    let mut resumes = 0;
+
+    for entry in fs::read_dir(&dir).expect("read tests/corpus directory") {
+        let path = entry.expect("read dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("txt") {
+            continue;
+        }
+        resumes += 1;
+
+        let body = fs::read_to_string(&path).expect("read resume fixture");
+        assert!(!body.trim().is_empty(), "{path:?} is empty");
+
+        let tags_path = path.with_extension("tags");
+        assert!(tags_path.exists(), "missing .tags sidecar for {path:?}");
+        let tags = parse_tags(&fs::read_to_string(&tags_path).expect("read .tags sidecar"));
+
+        // Every fixture declares at least a name, an email, and one section.
+        for key in ["name", "email", "section"] {
+            assert!(tags.contains_key(key), "{tags_path:?} tags missing `{key}`");
+        }
+
+        // No-PII guard: every declared email must be on a reserved example domain,
+        // and must also literally appear in the resume body.
+        for email in tags.get("email").into_iter().flatten() {
+            assert!(
+                email.contains("@example."),
+                "fixture email must be synthetic: {email}"
+            );
+            assert!(
+                body.contains(email.as_str()),
+                "tagged email {email} not found in {path:?}"
+            );
+        }
+    }
+
+    assert!(
+        resumes >= 2,
+        "expected at least two corpus fixtures, found {resumes}"
+    );
+}


### PR DESCRIPTION
## Phase 1b of the Resume & Cover-Letter Engine plan

Second half of Phase 1 (Foundations). Introduces the remaining single-source-of-truth layers **alongside** the existing renderers, with **zero behavior change** — nothing consumes them yet; the PDF/DOCX backends move onto them in Phase 2+. Follows #171 (Phase 1a: the canonical `model/`).

### New modules

- **`measure/`** — `trait MeasureText` + `FontMetrics`: real glyph advances and line heights from the bundled TTFs via **`ttf-parser`** (`advance_mm` / `line_height_mm`, per family + weight). This is the principled replacement for the `pt_to_mm(size) * 0.52` char-width estimate the PDF renderer uses today for link rects and name centering (`pdf_renderer/mod.rs:493/669/732`).
- **`theme/`** — the canonical *seam* over the template registry: `template(id)` plus the new model-level rules `placement_for(SectionId)` (skills/education/languages/certifications → sidebar) and `link_style(TemplateId)` (accent + underline by default; ATS Classic = plain body color). The `Template` data stays in `export::templates` for now (the legacy renderers import it directly) and relocates with its consumers in Phase 2 — so renderers are untouched.
- **`locale/`** — `LocaleProfile` registry + `PageGeometry`/`PageSize` (A4/Letter), `DateStyle`, `PhotoPolicy`. Ships the **en / A4 / photos-Never** default; US/UK/DE/AT/CH/FR/NL/etc. are populated in Phase 7. Photo/PII are **user-supplied only, never inferred**.
- **Eval skeleton** — `tests/corpus/` synthetic **no-PII** fixtures + a simple `.tags` ground-truth format; `tests/eval.rs` validates corpus shape now (sidecars present, tags parse, required fields, synthetic emails). Field-level precision/recall vs the real extractor lands in **Phase 6**, using these same tags.

### Notes
- `ttf-parser` pinned to **0.25** to match the version already present transitively → a single copy in the tree (deduped; lockfile diff is 2 lines).
- `#![allow(dead_code)]` scoped to the new modules (foundations, no callers yet), mirroring 1a / `export::types`.
- `Cargo.lock` also picks up the `ajh-tauri` version correction (0.23.0 → 0.23.2) the release version-sync leaves behind.

### Gates
- `cargo test --all-features` → **524 passed** (523 unit + 1 eval integration)
- `cargo clippy --all-targets --all-features -- -D warnings` → **clean**
- new files `rustfmt`-clean · `pnpm gen:ipc:check` → up to date (no contract change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)