### PR TITLE
build: bump docx-rs floor to 0.4.20

### DIFF
--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -74,7 +74,7 @@ sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 rusqlite = { version = "0.40", features = ["bundled"] }
 pdf-extract = "0.10"
 zip = "8"
-docx-rs = "0.4.19"
+docx-rs = "0.4.20"
 printpdf = "0.9.1"
 lopdf = "0.40"
 


### PR DESCRIPTION
## What

Bumps the `docx-rs` requirement in `apps/tauri/src-tauri/Cargo.toml` from `0.4.19` → `0.4.20`.

## Why

`"0.4.19"` is a caret (`^0.4.19`) constraint, so the lockfile **already resolves `docx-rs` to 0.4.20**. This change just makes the manifest state the version the build actually compiles against — and pins the floor that the **Phase 5** DOCX-on-model work depends on (the `Table`/`TableCell`/`Shading`/`TableBorders` builders the two-column DOCX table needs).

Prompted by a "update the pdf/docx packages if newer versions exist" check. Audit of the doc crates:

| Crate | Manifest | Latest | Status |
|---|---|---|---|
| `printpdf` | 0.9.1 | 0.9.1 | current |
| `lopdf` | 0.40 | 0.40.0 | current |
| `pdf-extract` | 0.10 | 0.10.0 | current |
| **`docx-rs`** | **0.4.19 → 0.4.20** | 0.4.20 | **bumped** |
| `zip` | 8 | 8 (9.0.0 = prerelease) | stay |
| `ttf-parser` | 0.25 | 0.25.1 | already resolves to .1 |

## Risk

**None.** `Cargo.lock` is unchanged (already 0.4.20), so the compiled binary is byte-identical to `main`. `cargo check --all-features` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)