### PR TITLE
refactor: render resumes through the layout engine behind a feature flag (phase 2e)

### DIFF
--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -5,6 +5,13 @@ edition = "2021"
 description = "AI Job Hunter — Tauri desktop shell"
 authors = ["Saeed Kolivand"]
 
+[features]
+# Render resumes through the canonical layout engine (model → LaidOutDoc → PDF)
+# instead of the legacy renderer. Off by default during the strangler-fig
+# migration; enabled by `--all-features` so CI and the pre-push gate exercise the
+# new path. Flips to default once golden-snapshot parity is locked.
+layout_pdf = []
+
 [profile.dev]
 incremental = true
 

--- a/apps/tauri/src-tauri/src/export/layout_pdf.rs
+++ b/apps/tauri/src-tauri/src/export/layout_pdf.rs
@@ -1,0 +1,203 @@
+//! PDF backend for the canonical layout engine.
+//!
+//! Strangler-fig step: this renders a resume by building the [`DocumentModel`],
+//! laying it out with [`crate::layout::layout_document`] into a backend-agnostic
+//! [`LaidOutDoc`], and translating that display list to `printpdf` ops. It does
+//! **no** layout itself — geometry (wrapping, centering, columns, pagination,
+//! link rects) all comes from the engine.
+//!
+//! It is wired into [`super::pdf::generate_pdf`] behind the `layout_pdf` Cargo
+//! feature: the default build keeps the legacy renderer, while `--all-features`
+//! (used by CI and the pre-push gate) exercises this path. The two stay
+//! side-by-side until snapshot parity is locked, then the default flips.
+
+use anyhow::Result;
+use printpdf::*;
+
+use crate::export::pdf_renderer::{
+    build_line, load_all_fonts, resolve_fonts, rgb_to_color, LoadedFontSet,
+};
+use crate::export::templates::Template;
+use crate::export::types::GenerationMeta;
+use crate::layout::{layout_document, FillRect, LaidOutDoc, LinkRect, PlacedText, RuleLine};
+use crate::locale::PageSize;
+use crate::measure::FontMetrics;
+use crate::model::adapter::model_from_resume_text;
+use crate::model::transform;
+
+const PT_PER_MM: f32 = 2.834_645_7;
+
+/// Render a resume to PDF bytes via the canonical layout engine.
+pub(crate) fn generate_resume_pdf(
+    text: &str,
+    meta: Option<&GenerationMeta>,
+    template: &Template,
+    ats_mode: bool,
+) -> Result<Vec<u8>> {
+    let mut model = model_from_resume_text(text);
+
+    // Header name override from generation metadata (mirrors the legacy renderer).
+    if let Some(name) = meta.and_then(|m| m.candidate_name.as_deref()) {
+        if !name.is_empty() {
+            model.header.name = name.to_string();
+        }
+    }
+
+    // ATS mode: collapse to a single column and put sections in ATS reading order.
+    let effective_template = if ats_mode && template.two_column.is_some() {
+        let mut t = template.clone();
+        t.two_column = None;
+        t.margin_in = 1.0;
+        t
+    } else {
+        template.clone()
+    };
+    if ats_mode {
+        transform::linearize(&mut model);
+    }
+
+    // Page geometry: A4, matching the legacy renderer (locale-driven in a later phase).
+    let geom = PageSize::A4.geometry();
+    let laid = layout_document(&model, &effective_template, geom, &FontMetrics);
+    emit_pdf(&laid)
+}
+
+/// Translate a [`LaidOutDoc`] (mm from top-left) into a `printpdf` document
+/// (mm from bottom-left), drawing fills, then rules, then text, then links.
+fn emit_pdf(laid: &LaidOutDoc) -> Result<Vec<u8>> {
+    let mut doc = PdfDocument::new("Resume");
+    let fonts = load_all_fonts(&mut doc)?;
+    let page_h = laid.page_height_mm;
+
+    let pages: Vec<PdfPage> = laid
+        .pages
+        .iter()
+        .map(|page| {
+            let mut ops: Vec<Op> = Vec::new();
+            for fill in &page.fills {
+                ops.extend(fill_ops(fill, page_h));
+            }
+            for rule in &page.rules {
+                ops.extend(rule_ops(rule, page_h));
+            }
+            for text in &page.texts {
+                ops.extend(text_ops(text, page_h, &fonts));
+            }
+            for link in &page.links {
+                ops.push(link_op(link, page_h));
+            }
+            PdfPage::new(Mm(laid.page_width_mm), Mm(page_h), ops)
+        })
+        .collect();
+
+    let mut warnings = Vec::new();
+    Ok(doc
+        .with_pages(pages)
+        .save(&PdfSaveOptions::default(), &mut warnings))
+}
+
+/// Filled rectangle. The engine gives a top-left origin + height; printpdf wants
+/// bottom-up coordinates.
+fn fill_ops(f: &FillRect, page_h: f32) -> Vec<Op> {
+    if f.width_mm <= 0.0 || f.height_mm <= 0.0 {
+        return Vec::new();
+    }
+    let x = f.x_mm;
+    let w = f.width_mm;
+    let h = f.height_mm;
+    let y_bottom = page_h - (f.y_top_mm + h);
+    let polygon = Polygon {
+        rings: vec![PolygonRing {
+            points: vec![
+                LinePoint {
+                    p: Point::new(Mm(x), Mm(y_bottom)),
+                    bezier: false,
+                },
+                LinePoint {
+                    p: Point::new(Mm(x + w), Mm(y_bottom)),
+                    bezier: false,
+                },
+                LinePoint {
+                    p: Point::new(Mm(x + w), Mm(y_bottom + h)),
+                    bezier: false,
+                },
+                LinePoint {
+                    p: Point::new(Mm(x), Mm(y_bottom + h)),
+                    bezier: false,
+                },
+            ],
+        }],
+        mode: PaintMode::Fill,
+        winding_order: WindingOrder::EvenOdd,
+    };
+    vec![
+        Op::SetFillColor {
+            col: rgb_to_color(f.color),
+        },
+        Op::DrawPolygon { polygon },
+    ]
+}
+
+fn rule_ops(r: &RuleLine, page_h: f32) -> Vec<Op> {
+    build_line(
+        r.x1_mm,
+        page_h - r.y_mm,
+        r.x2_mm,
+        rgb_to_color(r.color),
+        r.thickness_pt,
+    )
+}
+
+fn text_ops(t: &PlacedText, page_h: f32, fonts: &LoadedFontSet) -> Vec<Op> {
+    let (reg, bold, italic) = resolve_fonts(fonts, t.family);
+    let font = if t.italic {
+        italic.unwrap_or(if t.bold { bold } else { reg })
+    } else if t.bold {
+        bold
+    } else {
+        reg
+    };
+    let pos = Point {
+        x: Mm(t.x_mm).into(),
+        y: Mm(page_h - t.baseline_y_mm).into(),
+    };
+    vec![
+        Op::StartTextSection,
+        Op::SetFillColor {
+            col: rgb_to_color(t.color),
+        },
+        Op::SetTextCursor { pos },
+        Op::SetFont {
+            font: PdfFontHandle::External(font.clone()),
+            size: Pt(t.size_pt),
+        },
+        Op::ShowText {
+            items: vec![TextItem::Text(t.text.clone())],
+        },
+        Op::EndTextSection,
+    ]
+}
+
+fn link_op(l: &LinkRect, page_h: f32) -> Op {
+    let y_bottom_pt = (page_h - (l.y_top_mm + l.height_mm)) * PT_PER_MM;
+    let rect = Rect {
+        x: Pt(l.x_mm * PT_PER_MM),
+        y: Pt(y_bottom_pt),
+        width: Pt(l.width_mm * PT_PER_MM),
+        height: Pt(l.height_mm * PT_PER_MM),
+        mode: None,
+        winding_order: None,
+    };
+    Op::LinkAnnotation {
+        link: LinkAnnotation::new(
+            rect,
+            Actions::Uri(l.url.clone()),
+            Some(BorderArray::Solid([0.0, 0.0, 0.0])),
+            Some(ColorArray::Transparent),
+            None,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/apps/tauri/src-tauri/src/export/layout_pdf/test.rs
+++ b/apps/tauri/src-tauri/src/export/layout_pdf/test.rs
@@ -1,0 +1,153 @@
+//! Parity / round-trip tests for the layout-engine PDF backend. These run
+//! regardless of the `layout_pdf` feature (they call the backend directly), so
+//! the new path is always validated. Text survival is checked with `pdf-extract`
+//! and link annotations with `lopdf` — the same tools the eventual Phase 4
+//! round-trip gate uses.
+
+use super::*;
+use crate::export::types::TemplateId;
+
+const RESUME: &str = "\
+Jane Doe
+jane@example.com | [LinkedIn](https://linkedin.com/in/jane) | https://janedoe.dev
+
+Professional summary about building reliable software systems end to end.
+
+EXPERIENCE
+Acme Corp  2020 - Present
+Senior Engineer
+- Led a team of five engineers
+- Shipped three major features
+
+SKILLS
+- Rust, TypeScript, React
+";
+
+fn extract(bytes: &[u8]) -> String {
+    pdf_extract::extract_text_from_mem(bytes).expect("extract text from generated pdf")
+}
+
+/// Recursively collect every `/URI` action target in a parsed PDF.
+fn collect_uris(doc: &lopdf::Document) -> Vec<String> {
+    fn from_dict(d: &lopdf::Dictionary, out: &mut Vec<String>) {
+        if let Ok(u) = d.get(b"URI") {
+            if let Ok(bytes) = u.as_str() {
+                out.push(String::from_utf8_lossy(bytes).into_owned());
+            }
+        }
+        for (_, v) in d.iter() {
+            from_obj(v, out);
+        }
+    }
+    fn from_obj(o: &lopdf::Object, out: &mut Vec<String>) {
+        match o {
+            lopdf::Object::Dictionary(d) => from_dict(d, out),
+            lopdf::Object::Stream(s) => from_dict(&s.dict, out),
+            lopdf::Object::Array(a) => a.iter().for_each(|v| from_obj(v, out)),
+            _ => {}
+        }
+    }
+    let mut out = Vec::new();
+    for obj in doc.objects.values() {
+        from_obj(obj, &mut out);
+    }
+    out
+}
+
+#[test]
+fn resume_text_survives_round_trip() {
+    let t = Template::get(TemplateId::Modern);
+    let bytes = generate_resume_pdf(RESUME, None, &t, false).expect("pdf");
+    let text = extract(&bytes);
+    for needle in [
+        "Jane Doe",
+        "EXPERIENCE",
+        "Acme Corp",
+        "Senior Engineer",
+        "Led a team",
+        "SKILLS",
+        "Rust",
+    ] {
+        assert!(
+            text.contains(needle),
+            "missing {needle:?} in extracted text:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn resume_embeds_contact_link_annotations() {
+    let t = Template::get(TemplateId::Modern);
+    let bytes = generate_resume_pdf(RESUME, None, &t, false).expect("pdf");
+    let doc = lopdf::Document::load_mem(&bytes).expect("parse generated pdf");
+    let uris = collect_uris(&doc);
+    assert!(
+        uris.iter().any(|u| u == "https://linkedin.com/in/jane"),
+        "linkedin link missing: {uris:?}"
+    );
+    assert!(
+        uris.iter().any(|u| u == "mailto:jane@example.com"),
+        "mailto missing: {uris:?}"
+    );
+    assert!(
+        uris.iter().any(|u| u == "https://janedoe.dev"),
+        "website link missing: {uris:?}"
+    );
+}
+
+#[test]
+fn two_column_resume_renders_both_columns() {
+    let t = Template::get(TemplateId::TwoColumn);
+    let bytes = generate_resume_pdf(RESUME, None, &t, false).expect("pdf");
+    let text = extract(&bytes);
+    assert!(text.contains("Jane Doe"), "header");
+    assert!(text.contains("Acme Corp"), "main column content");
+    assert!(text.contains("Rust"), "sidebar column content");
+}
+
+#[test]
+fn ats_mode_keeps_all_content_single_column() {
+    let t = Template::get(TemplateId::TwoColumn);
+    let bytes = generate_resume_pdf(RESUME, None, &t, true).expect("pdf");
+    let text = extract(&bytes);
+    for needle in ["Jane Doe", "EXPERIENCE", "SKILLS", "Acme Corp", "Rust"] {
+        assert!(text.contains(needle), "ats mode lost content: {needle:?}");
+    }
+}
+
+#[test]
+fn generation_meta_name_overrides_header() {
+    let t = Template::get(TemplateId::Classic);
+    let meta = GenerationMeta {
+        candidate_name: Some("Override Name".to_string()),
+        job_title: None,
+        company_name: None,
+        target_language: None,
+    };
+    let bytes = generate_resume_pdf(RESUME, Some(&meta), &t, false).expect("pdf");
+    let text = extract(&bytes);
+    assert!(
+        text.contains("Override Name"),
+        "meta candidate_name should appear in the header:\n{text}"
+    );
+}
+
+#[test]
+fn every_template_renders_a_valid_pdf() {
+    for id in [
+        TemplateId::Classic,
+        TemplateId::Modern,
+        TemplateId::Executive,
+        TemplateId::EditorialSerif,
+        TemplateId::SwissMinimal,
+        TemplateId::TwoColumn,
+        TemplateId::MonoTechnical,
+        TemplateId::RefinedExecutive,
+        TemplateId::Academic,
+    ] {
+        let t = Template::get(id);
+        let bytes = generate_resume_pdf(RESUME, None, &t, false).expect("pdf");
+        assert!(bytes.len() > 1000, "{id:?} produced a trivial PDF");
+        lopdf::Document::load_mem(&bytes).expect("generated pdf must parse");
+    }
+}

--- a/apps/tauri/src-tauri/src/export/mod.rs
+++ b/apps/tauri/src-tauri/src/export/mod.rs
@@ -11,6 +11,7 @@
  */
 
 pub mod links;
+pub mod layout_pdf;
 pub mod parser;
 pub mod docx;
 pub mod docx_renderer;

--- a/apps/tauri/src-tauri/src/export/pdf/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/mod.rs
@@ -602,8 +602,21 @@ pub fn generate_pdf(request: &ExportRequest) -> Result<Vec<u8>> {
         DocumentType::Resume => {
             let text = extract_section(&request.text, "### CANDIDATE RESUME ###", Some("### JOB ADVERTISEMENT ###"));
             let text = if text.is_empty() { &request.text } else { text };
-            generate_resume_pdf(text, request.meta.as_ref(), &template, request.ats_mode)
-                .context("Failed to generate resume PDF")
+            // Strangler-fig switch: the canonical layout engine path is gated behind
+            // the `layout_pdf` feature (on under --all-features / CI), the legacy
+            // renderer stays the default until snapshot parity is locked. Both arms
+            // are compiled so neither path rots.
+            let result = if cfg!(feature = "layout_pdf") {
+                super::layout_pdf::generate_resume_pdf(
+                    text,
+                    request.meta.as_ref(),
+                    &template,
+                    request.ats_mode,
+                )
+            } else {
+                generate_resume_pdf(text, request.meta.as_ref(), &template, request.ats_mode)
+            };
+            result.context("Failed to generate resume PDF")
         }
         DocumentType::CoverLetter => {
             let text = extract_section(&request.text, "### COMPLETE COVER LETTER ###", None);

--- a/landing/index.html
+++ b/landing/index.html
@@ -45,6 +45,9 @@ body::after{
 .dood-fill{fill:var(--line,#e7ecf3); stroke:none}
 .doodle{position:relative; filter:drop-shadow(2px 3px 0 rgba(0,0,0,.18))}
 .doodle svg{width:100%; height:auto; overflow:visible}
+/* Poking the guys (each click pops a speech bubble) must never highlight the SVG
+   or bubble text — disable selection on every doodle and its bubble. */
+.doodle, .bubble, .dc-text{user-select:none; -webkit-user-select:none; -webkit-touch-callout:none}
 
 /* speech bubble for clickable doodles */
 .bubble{


### PR DESCRIPTION
## Phase 2e — the payoff: PDF backend on the layout engine

The engine finally renders real output. `export::layout_pdf` builds a `DocumentModel` from the resume text → lays it out with `layout_document` into a `LaidOutDoc` → translates that display list to `printpdf` ops (top-left mm → printpdf's bottom-left), reusing `pdf_renderer`'s font loading / colors / line helpers. **It does no layout itself** — wrapping, centering, columns, pagination, and link rects all come from the engine.

### Feature-flag dispatch (no dead code, CI-validated)
Wired into `pdf::generate_pdf` behind the **`layout_pdf` Cargo feature** via `cfg!(feature = "layout_pdf")`:
- **Default build** → legacy renderer (**zero behavior change**).
- **`--all-features`** (CI + pre-push) → resumes route through the engine.

Both arms are compiled and *referenced*, so neither path rots and there's no dead code under either config (clippy `-D warnings` verified both ways).

### Behavior
- **ATS mode** linearizes the model (`transform::linearize`) and collapses two-column → single-column before layout.
- **Generation-meta** `candidate_name` overrides the header name.
- Page geometry is **A4**, matching the legacy renderer (locale-driven geometry is a later phase).
- **Cover letters stay on the legacy path** (modeled later).

### Parity tests (6, run regardless of the feature)
- **`pdf-extract` (text survival):** name, section headings, and bullets survive ✅ (confirms printpdf output is cleanly extractable)
- **`lopdf` (annotations):** LinkedIn, website, and `mailto:` links are embedded
- Two-column renders **both** columns; **ATS mode** keeps all content single-column; meta name overrides; **all 9 templates** produce a valid, parseable PDF

### Gate
- `cargo test` → **562 passed** · `cargo test --all-features` → **562 passed**
- `cargo clippy --all-targets [--all-features] -- -D warnings` → clean under **both** configs
- new files rustfmt-clean · no IPC change · full local pre-push gate green

---

### Also in this branch (per request, no separate branch): landing `user-select` fix
`ui:` commit — disables text selection on the `landing/index.html` doodle guys (`.doodle`/`.bubble`/`.dc-text`) so rapidly poking them (each click pops a speech bubble) never highlights the SVG or bubble text. `+ -webkit-touch-callout:none` to suppress the iOS long-press menu. Landing-only (deploys via `pages.yml`), `ui:` so it doesn't trigger an app release. `landing/` is in `.prettierignore`, so the format gate is unaffected.

### Next
**Phase 2f (flip):** once you've eyeballed a few engine-rendered PDFs, flip `layout_pdf` to default (or drop the legacy resume path). Then Phase 3 (cross-viewer page-size/font parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)