### PR TITLE
refactor: render resumes through the layout engine by default (phase 2f)

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -6,10 +6,13 @@ description = "AI Job Hunter — Tauri desktop shell"
 authors = ["Saeed Kolivand"]
 
 [features]
+default = ["layout_pdf"]
+
 # Render resumes through the canonical layout engine (model → LaidOutDoc → PDF)
-# instead of the legacy renderer. Off by default during the strangler-fig
-# migration; enabled by `--all-features` so CI and the pre-push gate exercise the
-# new path. Flips to default once golden-snapshot parity is locked.
+# instead of the legacy renderer. On by default now that gap-by-gap snapshot
+# parity with the legacy renderer is locked (see `layout::tests`). The legacy
+# path stays compiled — it is the parity reference and still renders cover
+# letters — so `--no-default-features` falls back to it.
 layout_pdf = []
 
 [profile.dev]

--- a/apps/tauri/src-tauri/src/export/layout_pdf.rs
+++ b/apps/tauri/src-tauri/src/export/layout_pdf.rs
@@ -7,9 +7,10 @@
 //! link rects) all comes from the engine.
 //!
 //! It is wired into [`super::pdf::generate_pdf`] behind the `layout_pdf` Cargo
-//! feature: the default build keeps the legacy renderer, while `--all-features`
-//! (used by CI and the pre-push gate) exercises this path. The two stay
-//! side-by-side until snapshot parity is locked, then the default flips.
+//! feature, which is **on by default** now that gap-by-gap snapshot parity with
+//! the legacy renderer is locked (see the parity gate in [`crate::layout`]'s
+//! tests). `--no-default-features` falls back to the legacy renderer, which stays
+//! as the parity reference. The two remain side-by-side so neither path rots.
 
 use anyhow::Result;
 use printpdf::*;

--- a/apps/tauri/src-tauri/src/export/pdf/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/mod.rs
@@ -788,10 +788,11 @@ pub fn generate_pdf(request: &ExportRequest) -> Result<Vec<u8>> {
                 Some("### JOB ADVERTISEMENT ###"),
             );
             let text = if text.is_empty() { &request.text } else { text };
-            // Strangler-fig switch: the canonical layout engine path is gated behind
-            // the `layout_pdf` feature (on under --all-features / CI), the legacy
-            // renderer stays the default until snapshot parity is locked. Both arms
-            // are compiled so neither path rots.
+            // Strangler-fig switch: the canonical layout engine renders resumes by
+            // default now that snapshot parity is locked (`layout_pdf` is a default
+            // feature). `--no-default-features` falls back to the legacy renderer,
+            // which also stays the parity reference. Both arms compile via `cfg!`
+            // so neither path rots.
             let result = if cfg!(feature = "layout_pdf") {
                 super::layout_pdf::generate_resume_pdf(
                     text,

--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -79,19 +79,19 @@ former `packages/ai` and `packages/data` Node packages were removed.
 
 ## AI Generation (`apps/tauri/src/renderer/features/ai-generate/`)
 
-| Feature                       | Status | Notes                        |
-| ----------------------------- | ------ | ---------------------------- |
-| Cover letter generation       | ✅     | Streaming                    |
-| Resume generation             | ✅     | Streaming                    |
-| Email generation              | ✅     |                              |
-| Summary generation            | ✅     |                              |
-| Bold keyword extraction       | ✅     | Post-processes output        |
-| DOCX export                   | ✅     | All 9 templates              |
-| PDF export                    | ✅     |                              |
-| ATS-safe linearization        | ✅     | Two-column → single for ATS  |
-| Extended thinking (Anthropic) | ✅     | ThinkingBubble UI            |
-| Locale-aware prompts          | ✅     | 11 languages                 |
-| Template preview              | ✅     | OptionTile with live preview |
+| Feature                       | Status | Notes                                              |
+| ----------------------------- | ------ | -------------------------------------------------- |
+| Cover letter generation       | ✅     | Streaming                                          |
+| Resume generation             | ✅     | Streaming                                          |
+| Email generation              | ✅     |                                                    |
+| Summary generation            | ✅     |                                                    |
+| Bold keyword extraction       | ✅     | Post-processes output                              |
+| DOCX export                   | ✅     | All 9 templates                                    |
+| PDF export                    | ✅     | Canonical layout engine (default); legacy fallback |
+| ATS-safe linearization        | ✅     | Two-column → single for ATS                        |
+| Extended thinking (Anthropic) | ✅     | ThinkingBubble UI                                  |
+| Locale-aware prompts          | ✅     | 11 languages                                       |
+| Template preview              | ✅     | OptionTile with live preview                       |
 
 ---
 


### PR DESCRIPTION
## Phase 2f — flip the PDF default to the canonical layout engine

Completes the strangler-fig PDF migration (phases 2a–2e, #175–#181) by making
`layout_pdf` a **default Cargo feature**. Production builds (`tauri build`, which
uses default features) now render resumes through the canonical layout engine —
`model → LaidOutDoc → printpdf` — instead of the legacy renderer.

### Why this is safe now
Gap-by-gap snapshot parity with the legacy renderer is locked by `layout::tests`:
both backends render the same fixtures and every page-1 baseline gap must sit
within ±5% across all single-column templates, plus a total-span backstop and
two-column structural checks. That gate (added in #178–#181) is the precondition
the plan required before flipping.

### What stays
The legacy renderer remains **fully compiled** — the `cfg!(feature = "layout_pdf")`
switch keeps both arms alive, so it:
- stays the **parity reference** (`layout::tests` calls it directly),
- still renders **cover letters** (not yet migrated to the engine),
- is reachable via `--no-default-features`.

CI already exercised the engine under `--all-features`; that path is now identical
to the shipped default, so `--all-features` runs test exactly what users get.

### Verification
- `cargo clippy --all-targets -- -D warnings` clean under **both** `--all-features`
  and `--no-default-features`.
- Parity + layout + adapter + transform tests green under the **default** feature
  set (engine path): `71 passed, 1 ignored`.

This is the last item in Phase 2 — it unblocks Phase 3 (locale-driven page geometry
+ DOCX font fallback), which builds on the engine being the live PDF path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)