### PR TITLE
fix: give docx an explicit page size and predictable font fallback (phase 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,7 @@ CHANGELOG.md
 .cargo
 target/llvm-cov/
 .mcp.json
+graphify-out/
+
+post-checkout
+post-commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,3 +211,14 @@ Violations **fail the commit**. See `commitlint.config.mjs`.
 - **Subject ≤ 100 chars**; **body lines ≤ 200 chars**; blank line between subject and body.
 - **Type** is one of: `feat`, `fix`, `perf`, `refactor`, `ui`, `style`, `test`, `docs`, `build`, `ci`, `chore`, `revert` (`type-enum`). Only the types in the table above affect releases.
 - Imperative mood, no trailing period in the subject.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/apps/tauri/src-tauri/src/export/docx/mod.rs
+++ b/apps/tauri/src-tauri/src/export/docx/mod.rs
@@ -6,8 +6,19 @@ use super::{
     templates::{calculate_spacing, Template},
     types::{DocumentType, ExportRequest, GenerationMeta, LineKind, TemplateId},
 };
+use crate::locale::LocaleProfile;
 
 use super::docx_renderer::*;
+
+/// Page size (in DOCX `dxa`) for the active locale. Defaults to the `en` profile
+/// (A4), keeping DOCX on the same page geometry as the PDF backends. Set
+/// explicitly rather than relying on the docx-rs default so the source of truth
+/// is `LocaleProfile`/`PageGeometry`; per-request locale sizing arrives in a
+/// later phase.
+fn page_size_dxa() -> (u32, u32) {
+    let geom = LocaleProfile::default().page_geometry();
+    (mm_to_dxa(geom.width_mm), mm_to_dxa(geom.height_mm))
+}
 
 // ─── Resume DOCX ──────────────────────────────────────────────────────────────
 
@@ -22,7 +33,6 @@ fn generate_resume_docx(text: &str, meta: Option<&GenerationMeta>, template: &Te
         .right(inch_to_dxa(template.margin_in));
 
     let colors = setup_colors(template);
-    let _font_name = docx_font_name(template.fonts.body_family);
 
     let mut name_written = false;
     let mut previous_kind: Option<LineKind> = None;
@@ -97,9 +107,11 @@ fn generate_resume_docx(text: &str, meta: Option<&GenerationMeta>, template: &Te
 
     let (abstract_num, num) = create_bullet_numbering();
 
+    let (page_w, page_h) = page_size_dxa();
     docx = docx
         .add_abstract_numbering(abstract_num)
         .add_numbering(num)
+        .page_size(page_w, page_h)
         .page_margin(page_margin);
 
     Ok(docx)
@@ -121,8 +133,8 @@ fn generate_cover_letter_docx(
         .right(inch_to_dxa(template.margin_in + 0.15));
 
     let colors = setup_colors(template);
-    let font_name = docx_font_name(template.fonts.body_family);
-    let name_font = docx_font_name(template.fonts.name_family);
+    let body_family = template.fonts.body_family;
+    let name_family = template.fonts.name_family;
 
     let lines: Vec<&str> = text.lines().collect();
     let mut header_done = false;
@@ -161,7 +173,7 @@ fn generate_cover_letter_docx(
                             .size(pt_to_dxa(template.name_pt))
                             .bold()
                             .color(&colors.name)
-                            .fonts(RunFonts::new().ascii(name_font)),
+                            .fonts(docx_run_fonts(name_family)),
                     )
                     .line_spacing(LineSpacing::new().after(60)),
             );
@@ -179,7 +191,7 @@ fn generate_cover_letter_docx(
                             .add_text(&clean)
                             .size(pt_to_dxa(9.0))
                             .color(&colors.date)
-                            .fonts(RunFonts::new().ascii(font_name)),
+                            .fonts(docx_run_fonts(body_family)),
                     )
                     .line_spacing(LineSpacing::new().after(40)),
             );
@@ -197,7 +209,7 @@ fn generate_cover_letter_docx(
                             .add_text(&clean)
                             .size(pt_to_dxa(template.body_pt))
                             .color(&colors.body)
-                            .fonts(RunFonts::new().ascii(font_name)),
+                            .fonts(docx_run_fonts(body_family)),
                     )
                     .line_spacing(LineSpacing::new().before(160).after(160)),
             );
@@ -213,7 +225,7 @@ fn generate_cover_letter_docx(
                             .add_text(&clean)
                             .size(pt_to_dxa(template.body_pt))
                             .color(&colors.body)
-                            .fonts(RunFonts::new().ascii(font_name)),
+                            .fonts(docx_run_fonts(body_family)),
                     )
                     .line_spacing(LineSpacing::new().before(240).after(480)),
             );
@@ -229,7 +241,7 @@ fn generate_cover_letter_docx(
                             .add_text(&clean)
                             .size(pt_to_dxa(template.body_pt))
                             .color(&colors.date)
-                            .fonts(RunFonts::new().ascii(font_name)),
+                            .fonts(docx_run_fonts(body_family)),
                     )
                     .line_spacing(LineSpacing::new().after(40)),
             );
@@ -237,11 +249,12 @@ fn generate_cover_letter_docx(
         }
 
         // Body paragraphs — use proper spacing via pPr, no blank-paragraph spacers
-        let para = render_cover_letter_paragraph(&clean, template, &colors, font_name);
+        let para = render_cover_letter_paragraph(&clean, template, &colors, body_family);
         docx = docx.add_paragraph(para);
     }
 
-    docx = docx.page_margin(page_margin);
+    let (page_w, page_h) = page_size_dxa();
+    docx = docx.page_size(page_w, page_h).page_margin(page_margin);
     Ok(docx)
 }
 

--- a/apps/tauri/src-tauri/src/export/docx/test.rs
+++ b/apps/tauri/src-tauri/src/export/docx/test.rs
@@ -1,5 +1,95 @@
+use std::io::{Cursor, Read};
+
 use super::*;
-use crate::export::types::TemplateId;
+use crate::export::types::{ExportFormat, TemplateId};
+
+/// Unzip a generated DOCX and return its `word/document.xml` (where the body
+/// runs and the section's `pgSz` live).
+fn document_xml(bytes: &[u8]) -> String {
+    let mut zip = zip::ZipArchive::new(Cursor::new(bytes)).expect("docx is a zip archive");
+    let mut file = zip
+        .by_name("word/document.xml")
+        .expect("docx contains word/document.xml");
+    let mut xml = String::new();
+    file.read_to_string(&mut xml).expect("read document.xml");
+    xml
+}
+
+fn resume_request(template_id: TemplateId) -> ExportRequest {
+    ExportRequest {
+        // Name + contact + section + entry + bullet exercise name/heading/body fonts.
+        text: "Jane Doe\njane@example.com\n\nEXPERIENCE\nAcme Corp  2020 - Present\nSenior Engineer\n- Built things that mattered".to_string(),
+        format: ExportFormat::Docx,
+        document_type: DocumentType::Resume,
+        template_id,
+        meta: None,
+        ats_mode: false,
+    }
+}
+
+#[test]
+fn resume_docx_declares_a4_page_size() {
+    let bytes = generate_docx(&resume_request(TemplateId::Modern)).expect("docx");
+    let xml = document_xml(&bytes);
+    // A4 in dxa, set explicitly from LocaleProfile rather than inherited.
+    assert!(
+        xml.contains(r#"w:w="11906""#) && xml.contains(r#"w:h="16838""#),
+        "resume DOCX should declare an explicit A4 page size, got sectPr in: {xml}"
+    );
+}
+
+#[test]
+fn cover_letter_docx_declares_a4_page_size() {
+    let request = ExportRequest {
+        text: "Dear Hiring Manager,\n\nI am writing to apply.\n\nSincerely,\nJane Doe".to_string(),
+        format: ExportFormat::Docx,
+        document_type: DocumentType::CoverLetter,
+        template_id: TemplateId::Classic,
+        meta: None,
+        ats_mode: false,
+    };
+    let bytes = generate_docx(&request).expect("docx");
+    let xml = document_xml(&bytes);
+    assert!(
+        xml.contains(r#"w:w="11906""#) && xml.contains(r#"w:h="16838""#),
+        "cover-letter DOCX should declare an explicit A4 page size"
+    );
+}
+
+#[test]
+fn resume_docx_uses_fallback_fonts_not_bundled_names() {
+    // MonoTechnical: name/heading JetBrains Mono → Consolas, body Inter → Calibri.
+    let bytes = generate_docx(&resume_request(TemplateId::MonoTechnical)).expect("docx");
+    let xml = document_xml(&bytes);
+    assert!(xml.contains(r#"w:ascii="Consolas""#), "JetBrains Mono should fall back to Consolas");
+    assert!(xml.contains(r#"w:ascii="Calibri""#), "Inter should fall back to Calibri");
+    // Both ranges are set so accented Latin renders in the same face.
+    assert!(xml.contains(r#"w:hAnsi="Consolas""#), "fallback must also cover the high-ANSI range");
+    for bundled in ["JetBrains Mono", "Inter"] {
+        assert!(
+            !xml.contains(&format!(r#""{bundled}""#)),
+            "un-embedded bundled font {bundled:?} must not be referenced in the DOCX"
+        );
+    }
+}
+
+#[test]
+fn serif_and_display_templates_fall_back_predictably() {
+    // Academic: Source Serif 4 → Georgia.
+    let academic = document_xml(&generate_docx(&resume_request(TemplateId::Academic)).expect("docx"));
+    assert!(academic.contains(r#"w:ascii="Georgia""#), "Source Serif 4 should fall back to Georgia");
+    assert!(!academic.contains(r#""Source Serif 4""#), "bundled Source Serif 4 must not leak");
+
+    // RefinedExecutive: name Playfair Display → Cambria.
+    let refined = document_xml(&generate_docx(&resume_request(TemplateId::RefinedExecutive)).expect("docx"));
+    assert!(refined.contains(r#"w:ascii="Cambria""#), "Playfair Display should fall back to Cambria");
+    assert!(!refined.contains(r#""Playfair Display""#), "bundled Playfair Display must not leak");
+
+    // SwissMinimal: Manrope → Calibri.
+    let swiss = document_xml(&generate_docx(&resume_request(TemplateId::SwissMinimal)).expect("docx"));
+    assert!(swiss.contains(r#"w:ascii="Calibri""#), "Manrope should fall back to Calibri");
+    assert!(!swiss.contains(r#""Manrope""#), "bundled Manrope must not leak");
+}
 
 #[test]
 fn test_generate_simple_resume() {

--- a/apps/tauri/src-tauri/src/export/docx_renderer.rs
+++ b/apps/tauri/src-tauri/src/export/docx_renderer.rs
@@ -15,21 +15,42 @@ pub fn inch_to_dxa(inch: f32) -> i32 {
     (inch * 1440.0) as i32
 }
 
+/// Convert millimetres to twentieths of a point (the DOCX `dxa` unit used for
+/// page geometry). `1 in = 25.4 mm = 1440 dxa`, so A4's 210 × 297 mm becomes
+/// 11906 × 16838 dxa — the same page size Word writes for A4.
+pub fn mm_to_dxa(mm: f32) -> u32 {
+    (mm * 1440.0 / 25.4).round() as u32
+}
+
 /// Convert RGB tuple to hex string.
 pub fn rgb_to_hex(rgb: (u8, u8, u8)) -> String {
     format!("{:02X}{:02X}{:02X}", rgb.0, rgb.1, rgb.2)
 }
 
-/// Map FontFamily to the font name string used in DOCX run properties.
-pub fn docx_font_name(family: FontFamily) -> &'static str {
+/// Map a bundled [`FontFamily`] to a widely-available system font.
+///
+/// The bundled TTFs (Inter, Source Serif 4, Manrope, …) are **not** embedded in
+/// the DOCX yet — true font embedding is deferred to Phase 5 — so a reader that
+/// lacks them would silently substitute an arbitrary face. Referencing these
+/// common fallbacks instead (present on Windows/Office, with close cross-platform
+/// equivalents) keeps the output predictable everywhere.
+pub fn docx_fallback_font(family: FontFamily) -> &'static str {
     match family {
         FontFamily::Calibri => "Calibri",
-        FontFamily::Inter => "Inter",
-        FontFamily::SourceSerif4 => "Source Serif 4",
-        FontFamily::Manrope => "Manrope",
-        FontFamily::JetBrainsMono => "JetBrains Mono",
-        FontFamily::PlayfairDisplay => "Playfair Display",
+        FontFamily::Inter => "Calibri",
+        FontFamily::Manrope => "Calibri",
+        FontFamily::SourceSerif4 => "Georgia",
+        FontFamily::PlayfairDisplay => "Cambria",
+        FontFamily::JetBrainsMono => "Consolas",
     }
+}
+
+/// Run fonts for a bundled family, resolved to its predictable DOCX fallback and
+/// applied to both the ASCII and high-ANSI ranges so accented Latin characters
+/// (common in DACH names) render in the same face, not the reader's default.
+pub fn docx_run_fonts(family: FontFamily) -> RunFonts {
+    let name = docx_fallback_font(family);
+    RunFonts::new().ascii(name).hi_ansi(name)
 }
 
 /// Color palette for DOCX rendering.
@@ -53,13 +74,13 @@ pub fn setup_colors(template: &Template) -> DocxColors {
 }
 
 /// Create text runs from segments with bold formatting.
-/// Uses the template's body_family font name.
+/// Uses the predictable DOCX fallback for the given bundled family.
 pub fn create_runs(
     segments: &[TextSegment],
     font_size: usize,
     color: &str,
     bold_color: Option<&str>,
-    font_name: &str,
+    family: FontFamily,
 ) -> Vec<Run> {
     segments
         .iter()
@@ -67,7 +88,7 @@ pub fn create_runs(
             let mut run = Run::new()
                 .add_text(&seg.text)
                 .size(font_size)
-                .fonts(RunFonts::new().ascii(font_name));
+                .fonts(docx_run_fonts(family));
 
             if seg.bold {
                 run = run.bold();
@@ -97,8 +118,6 @@ pub fn render_name_line(
         .map(|s| s.as_str())
         .unwrap_or(text);
 
-    let font_name = docx_font_name(template.fonts.name_family);
-
     let mut para = Paragraph::new()
         .add_run(
             Run::new()
@@ -106,7 +125,7 @@ pub fn render_name_line(
                 .size(pt_to_dxa(template.name_pt))
                 .bold()
                 .color(&colors.name)
-                .fonts(RunFonts::new().ascii(font_name)),
+                .fonts(docx_run_fonts(template.fonts.name_family)),
         );
 
     if template.name_centered {
@@ -122,7 +141,7 @@ pub fn render_contact_line(
     template: &Template,
     colors: &DocxColors,
 ) -> Paragraph {
-    let font_name = docx_font_name(template.fonts.body_family);
+    let family = template.fonts.body_family;
     let spans = split_urls(text);
 
     let mut para = Paragraph::new();
@@ -135,7 +154,7 @@ pub fn render_contact_line(
                         .add_text(&t)
                         .size(pt_to_dxa(9.0))
                         .color(&colors.date)
-                        .fonts(RunFonts::new().ascii(font_name)),
+                        .fonts(docx_run_fonts(family)),
                 );
             }
             Span::Link { label, url } => {
@@ -143,7 +162,7 @@ pub fn render_contact_line(
                     .add_text(&label)
                     .size(pt_to_dxa(9.0))
                     .color(&colors.date)
-                    .fonts(RunFonts::new().ascii(font_name));
+                    .fonts(docx_run_fonts(family));
                 let hyperlink = Hyperlink::new(&url, HyperlinkType::External).add_run(link_run);
                 para = para.add_hyperlink(hyperlink);
             }
@@ -163,8 +182,6 @@ pub fn render_section_header(
     template: &Template,
     colors: &DocxColors,
 ) -> Paragraph {
-    let font_name = docx_font_name(template.fonts.heading_family);
-
     let (header_text, effective_pt) = if template.section_small_caps {
         (text.to_uppercase(), template.section_pt * 0.85)
     } else if template.section_all_caps {
@@ -182,7 +199,7 @@ pub fn render_section_header(
                 .size(pt_to_dxa(effective_pt))
                 .bold()
                 .color(&colors.section)
-                .fonts(RunFonts::new().ascii(font_name))
+                .fonts(docx_run_fonts(template.fonts.heading_family))
                 .character_spacing(char_spacing),
         );
 
@@ -197,13 +214,13 @@ pub fn render_job_entry(
     template: &Template,
     colors: &DocxColors,
 ) -> Paragraph {
-    let font_name = docx_font_name(template.fonts.body_family);
+    let family = template.fonts.body_family;
     let runs = create_runs(
         segments,
         pt_to_dxa(template.body_pt),
         &colors.body,
         Some(&colors.emphasis),
-        font_name,
+        family,
     );
 
     let mut para = Paragraph::new();
@@ -220,7 +237,7 @@ pub fn render_job_entry(
                     .add_text(date)
                     .size(pt_to_dxa(9.5))
                     .color(&colors.date)
-                    .fonts(RunFonts::new().ascii(font_name)),
+                    .fonts(docx_run_fonts(family)),
             );
     }
 
@@ -239,13 +256,13 @@ pub fn render_job_title(
     template: &Template,
     colors: &DocxColors,
 ) -> Paragraph {
-    let font_name = docx_font_name(template.fonts.body_family);
+    let family = template.fonts.body_family;
     let runs = create_runs(
         segments,
         pt_to_dxa(template.body_pt - 0.5),
         &colors.date,
         Some(&colors.emphasis),
-        font_name,
+        family,
     );
 
     let mut para = Paragraph::new();
@@ -264,13 +281,13 @@ pub fn render_bullet_line(
     template: &Template,
     colors: &DocxColors,
 ) -> Paragraph {
-    let font_name = docx_font_name(template.fonts.body_family);
+    let family = template.fonts.body_family;
     let runs = create_runs(
         segments,
         pt_to_dxa(template.body_pt),
         &colors.body,
         Some(&colors.emphasis),
-        font_name,
+        family,
     );
 
     let mut para = Paragraph::new()
@@ -295,13 +312,13 @@ pub fn render_text_line(
     template: &Template,
     colors: &DocxColors,
 ) -> Paragraph {
-    let font_name = docx_font_name(template.fonts.body_family);
+    let family = template.fonts.body_family;
     let runs = create_runs(
         segments,
         pt_to_dxa(template.body_pt),
         &colors.body,
         Some(&colors.emphasis),
-        font_name,
+        family,
     );
 
     let mut para = Paragraph::new();
@@ -319,7 +336,7 @@ pub fn render_cover_letter_paragraph(
     text: &str,
     template: &Template,
     colors: &DocxColors,
-    font_name: &str,
+    family: FontFamily,
 ) -> Paragraph {
     use crate::export::templates::ParagraphIndent;
 
@@ -329,7 +346,7 @@ pub fn render_cover_letter_paragraph(
         pt_to_dxa(template.body_pt),
         &colors.body,
         Some(&colors.emphasis),
-        font_name,
+        family,
     );
 
     // spacing_after in twentieths-of-a-point (1pt = 20 dxa)
@@ -374,4 +391,30 @@ pub fn create_bullet_numbering() -> (AbstractNumbering, Numbering) {
     let num = Numbering::new(1, 1);
 
     (abstract_num, num)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mm_to_dxa_matches_word_a4_and_letter() {
+        // Word writes A4 as 11906 × 16838 dxa and US Letter as 12240 × 15840.
+        assert_eq!(mm_to_dxa(210.0), 11906);
+        assert_eq!(mm_to_dxa(297.0), 16838);
+        assert_eq!(mm_to_dxa(215.9), 12240);
+        assert_eq!(mm_to_dxa(279.4), 15840);
+    }
+
+    #[test]
+    fn fallback_fonts_are_common_system_faces() {
+        // Every bundled family resolves to a face present on Windows/Office so the
+        // reader never has to silently substitute an un-embedded bundled font.
+        assert_eq!(docx_fallback_font(FontFamily::Calibri), "Calibri");
+        assert_eq!(docx_fallback_font(FontFamily::Inter), "Calibri");
+        assert_eq!(docx_fallback_font(FontFamily::Manrope), "Calibri");
+        assert_eq!(docx_fallback_font(FontFamily::SourceSerif4), "Georgia");
+        assert_eq!(docx_fallback_font(FontFamily::PlayfairDisplay), "Cambria");
+        assert_eq!(docx_fallback_font(FontFamily::JetBrainsMono), "Consolas");
+    }
 }

--- a/apps/tauri/src-tauri/src/export/layout_pdf.rs
+++ b/apps/tauri/src-tauri/src/export/layout_pdf.rs
@@ -21,7 +21,7 @@ use crate::export::pdf_renderer::{
 use crate::export::templates::Template;
 use crate::export::types::GenerationMeta;
 use crate::layout::{layout_document, FillRect, LaidOutDoc, LinkRect, PlacedText, RuleLine};
-use crate::locale::PageSize;
+use crate::locale::LocaleProfile;
 use crate::measure::FontMetrics;
 use crate::model::adapter::model_from_resume_text;
 use crate::model::transform;
@@ -57,8 +57,10 @@ pub(crate) fn generate_resume_pdf(
         transform::linearize(&mut model);
     }
 
-    // Page geometry: A4, matching the legacy renderer (locale-driven in a later phase).
-    let geom = PageSize::A4.geometry();
+    // Page geometry from the active locale profile (defaults to A4), the same
+    // source the legacy renderer and DOCX read. Per-request locale sizing arrives
+    // in a later phase.
+    let geom = LocaleProfile::default().page_geometry();
     let laid = layout_document(&model, &effective_template, geom, &FontMetrics);
     emit_pdf(&laid)
 }

--- a/apps/tauri/src-tauri/src/export/pdf_renderer/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf_renderer/mod.rs
@@ -297,26 +297,32 @@ pub fn setup_layout(template: &Template) -> LayoutConfig {
     const MM_PER_INCH: f32 = 25.4;
     const PT_PER_MM: f32 = 2.834_645_7;
 
+    // Page geometry from the active locale profile (defaults to A4), so the legacy
+    // renderer, the layout engine, and DOCX all read one source of truth.
+    let geom = crate::locale::LocaleProfile::default().page_geometry();
+    let page_width = geom.width_mm;
+    let page_height = geom.height_mm;
+
     let margin_left = template.margin_in * MM_PER_INCH;
     let margin_right = template.margin_in * MM_PER_INCH;
     let line_height = (template.body_pt / PT_PER_MM) * template.line_spacing;
 
     let (sidebar_width, main_x, main_width) = if let Some(tc) = &template.two_column {
-        let content_w = 210.0 - margin_left - margin_right;
+        let content_w = page_width - margin_left - margin_right;
         let sb = content_w * tc.sidebar_width_ratio;
         let gap = 5.0; // mm gap between columns
         let mx = margin_left + sb + gap;
-        let mw = 210.0 - margin_right - mx;
+        let mw = page_width - margin_right - mx;
         (sb, mx, mw)
     } else {
-        (0.0, margin_left, 210.0 - margin_left - margin_right)
+        (0.0, margin_left, page_width - margin_left - margin_right)
     };
 
     LayoutConfig {
         margin_left,
         margin_right,
-        page_width: 210.0,
-        page_height: 297.0,
+        page_width,
+        page_height,
         line_height,
         top_margin_pt: 54.0, // 0.75 inch
         margin_in: template.margin_in,

--- a/apps/tauri/src-tauri/src/export/pdf_renderer/test.rs
+++ b/apps/tauri/src-tauri/src/export/pdf_renderer/test.rs
@@ -45,6 +45,11 @@ fn test_setup_colors() {
 fn test_setup_layout() {
     let template = Template::get(crate::export::types::TemplateId::Modern);
     let layout = setup_layout(&template);
+    // Page geometry is sourced from the locale profile (A4 by default), the same
+    // source the layout engine and DOCX read.
+    let geom = crate::locale::LocaleProfile::default().page_geometry();
+    assert_eq!(layout.page_width, geom.width_mm);
+    assert_eq!(layout.page_height, geom.height_mm);
     assert_eq!(layout.page_width, 210.0);
     assert_eq!(layout.page_height, 297.0);
     assert!(layout.line_height > 0.0);

--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -79,19 +79,19 @@ former `packages/ai` and `packages/data` Node packages were removed.
 
 ## AI Generation (`apps/tauri/src/renderer/features/ai-generate/`)
 
-| Feature                       | Status | Notes                                              |
-| ----------------------------- | ------ | -------------------------------------------------- |
-| Cover letter generation       | ✅     | Streaming                                          |
-| Resume generation             | ✅     | Streaming                                          |
-| Email generation              | ✅     |                                                    |
-| Summary generation            | ✅     |                                                    |
-| Bold keyword extraction       | ✅     | Post-processes output                              |
-| DOCX export                   | ✅     | All 9 templates                                    |
-| PDF export                    | ✅     | Canonical layout engine (default); legacy fallback |
-| ATS-safe linearization        | ✅     | Two-column → single for ATS                        |
-| Extended thinking (Anthropic) | ✅     | ThinkingBubble UI                                  |
-| Locale-aware prompts          | ✅     | 11 languages                                       |
-| Template preview              | ✅     | OptionTile with live preview                       |
+| Feature                       | Status | Notes                                                  |
+| ----------------------------- | ------ | ------------------------------------------------------ |
+| Cover letter generation       | ✅     | Streaming                                              |
+| Resume generation             | ✅     | Streaming                                              |
+| Email generation              | ✅     |                                                        |
+| Summary generation            | ✅     |                                                        |
+| Bold keyword extraction       | ✅     | Post-processes output                                  |
+| DOCX export                   | ✅     | All 9 templates; explicit A4 page size + font fallback |
+| PDF export                    | ✅     | Canonical layout engine (default); legacy fallback     |
+| ATS-safe linearization        | ✅     | Two-column → single for ATS                            |
+| Extended thinking (Anthropic) | ✅     | ThinkingBubble UI                                      |
+| Locale-aware prompts          | ✅     | 11 languages                                           |
+| Template preview              | ✅     | OptionTile with live preview                           |
 
 ---
 


### PR DESCRIPTION
## Phase 3 — cross-viewer consistency (page size + DOCX fonts)

Low-risk consistency wins between the PDF and DOCX backends, with a single source
of truth for page geometry. No full model migration required.

### Page size — one source of truth
- The legacy PDF renderer (`pdf_renderer::setup_layout`) and the layout engine
  (`layout_pdf`) now read geometry from `LocaleProfile::default().page_geometry()`
  (A4) instead of hardcoded `210.0 × 297.0` literals.
- DOCX now sets its section page size **explicitly** (A4 in `dxa`, via the new
  `mm_to_dxa`) instead of relying on the docx-rs default.

> 📝 The plan assumed docx-rs defaulted to **Letter**. After the `0.4.20` bump
> (#174) it actually defaults to **A4** — so this isn't fixing a visible Letter
> bug, but setting the size explicitly makes `LocaleProfile`/`PageGeometry` the
> source of truth and guards against future default drift. Default stays
> consistent PDF↔DOCX.

### DOCX font fallback
The bundled TTFs (Inter, Source Serif 4, Manrope, JetBrains Mono, Playfair
Display) are **not embedded** yet (true embedding is Phase 5), so a reader
without them silently substitutes an arbitrary face. `docx_fallback_font` now
maps each bundled family to a common system font:

| Bundled | Fallback |
|---|---|
| Inter, Manrope, Calibri | Calibri |
| Source Serif 4 | Georgia |
| Playfair Display | Cambria |
| JetBrains Mono | Consolas |

Runs reference the fallback on **both** the ASCII and high-ANSI ranges, so
accented Latin (common in DACH names) renders in the same face. Output is now
predictable everywhere instead of depending on the reader's silent substitution.

### Tests
- **DOCX unzip invariants** (`word/document.xml`): explicit A4 `pgSz`
  (`11906 × 16838` dxa) for resume **and** cover letter; fallback fonts present
  (`w:ascii`/`w:hAnsi`), no bundled font names leak.
- `mm_to_dxa` matches Word's A4/Letter dxa; `docx_fallback_font` mapping locked.
- Legacy PDF `setup_layout` geometry asserted equal to the locale profile.

### Verification
- PDF A4 values unchanged → the Phase 2 layout-engine **parity gate stays green**.
- `clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo test --all-features` (export/layout/locale/pdf): **86 passed, 1 ignored**.

True OOXML font embedding and locale-driven per-request page sizing are
intentionally deferred (Phases 5 and 7 respectively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)