### PR TITLE
feat: validate exports and auto-fix unreadable two-column layouts (phase 4)

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/src/export/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/export/commands/mod.rs
@@ -7,6 +7,7 @@ use super::{
     types::{ExportFormat, ExportRequest, ExportResult},
 };
 use crate::error::{AppError, AppResult};
+use crate::validate::{validate_and_fix, ExportReport, Severity};
 
 /// Tauri command to export resume or cover letter
 #[command]
@@ -22,27 +23,37 @@ pub async fn documents_export_document(mut request: ExportRequest) -> AppResult<
     // as replacement boxes in PDF/DOCX output.
     request.text = super::parser::normalize_unicode(&request.text);
 
-    // Generate based on format
-    let (data, mime_type, extension) = match request.format {
+    // Generate based on format. PDF/DOCX run through the validation gate, which
+    // re-extracts the bytes, auto-fixes a two-column layout that doesn't survive
+    // extraction, and reports what it found.
+    let (data, mime_type, extension, report) = match request.format {
         ExportFormat::Docx => {
-            let bytes = generate_docx(&request)
+            let (bytes, report) = validate_and_fix(request.clone(), |r| generate_docx(r))
                 .map_err(|e| format!("DOCX generation failed: {}", e))?;
             (
                 bytes,
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document".to_string(),
                 "docx",
+                Some(report),
             )
         }
         ExportFormat::Pdf => {
-            let bytes = generate_pdf(&request)
+            let (bytes, report) = validate_and_fix(request.clone(), |r| generate_pdf(r))
                 .map_err(|e| format!("PDF generation failed: {}", e))?;
-            (bytes, "application/pdf".to_string(), "pdf")
+            (bytes, "application/pdf".to_string(), "pdf", Some(report))
         }
         ExportFormat::Txt => {
             let text = super::parser::strip_md(&request.text);
-            (text.into_bytes(), "text/plain".to_string(), "txt")
+            (text.into_bytes(), "text/plain".to_string(), "txt", None)
         }
     };
+
+    // Block only when a critical defect survived auto-fix.
+    if let Some(report) = &report {
+        if !report.ok {
+            return Err(AppError::Validation(blocking_reason(report)));
+        }
+    }
 
     // Generate filename
     let filename = generate_filename(&request, extension);
@@ -51,7 +62,24 @@ pub async fn documents_export_document(mut request: ExportRequest) -> AppResult<
         data,
         mime_type,
         filename,
+        report,
     })
+}
+
+/// Plain-language reason an export was blocked, from its critical issues.
+fn blocking_reason(report: &ExportReport) -> String {
+    let reasons = report
+        .issues
+        .iter()
+        .filter(|i| i.severity == Severity::Critical)
+        .map(|i| i.message.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    if reasons.is_empty() {
+        "Export blocked: the document failed validation.".to_string()
+    } else {
+        format!("Export blocked: {reasons}")
+    }
 }
 
 /// Tauri command to export and save document with file dialog

--- a/apps/tauri/src-tauri/src/export/types.rs
+++ b/apps/tauri/src-tauri/src/export/types.rs
@@ -74,10 +74,15 @@ pub struct ExportRequest {
 
 /// Export result (binary data)
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExportResult {
     pub data: Vec<u8>,
     pub mime_type: String,
     pub filename: String,
+    /// Pre-export validation report (PDF/DOCX). `None` for TXT, which has no
+    /// layout to validate. Optional on the wire so older frontends keep working.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub report: Option<crate::validate::ExportReport>,
 }
 
 /// Line kind in parsed document

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -47,6 +47,7 @@ mod profile_import;
 mod scraping;
 mod theme;
 mod updater;
+mod validate;
 
 use parking_lot::Mutex;
 

--- a/apps/tauri/src-tauri/src/validate/mod.rs
+++ b/apps/tauri/src-tauri/src/validate/mod.rs
@@ -1,0 +1,305 @@
+//! Pre-export validation + ATS round-trip gate.
+//!
+//! After a backend renders a resume / cover letter to bytes, this module
+//! re-extracts the text from those bytes the way an ATS parser (or a human
+//! pasting into a form) would, and checks that the document's critical content
+//! survived in a sane reading order.
+//!
+//! The dangerous failure mode is a two-column PDF whose columns interleave when
+//! read top-to-bottom — ATS parsers then shred the resume. When that is detected
+//! the document is re-exported single-column (ATS-safe via `ats_mode`) and
+//! re-checked. An export is **blocked** only when a *critical* defect survives
+//! that auto-fix (e.g. the exported file has no extractable text at all).
+//!
+//! DOCX already linearizes two-column templates to a single column, so its
+//! round-trip is a content-survival check rather than a column-order gate.
+
+use std::io::Read;
+use std::sync::LazyLock;
+
+use anyhow::Result;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::export::parser::{parse_resume, strip_md};
+use crate::export::types::{DocumentType, ExportFormat, ExportRequest, LineKind, TemplateId};
+
+static EMAIL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[\w.+-]+@[\w-]+\.[\w.-]+").unwrap());
+
+/// How serious an export issue is. Only [`Severity::Critical`] issues can block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Critical,
+    Warning,
+}
+
+/// A single problem found while re-reading an exported document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportIssue {
+    pub severity: Severity,
+    /// Stable machine code (`section_order`, `missing_section`, …).
+    pub code: String,
+    /// Plain-language explanation for the user.
+    pub message: String,
+}
+
+impl ExportIssue {
+    fn critical(code: &str, message: impl Into<String>) -> Self {
+        Self { severity: Severity::Critical, code: code.into(), message: message.into() }
+    }
+    fn warning(code: &str, message: impl Into<String>) -> Self {
+        Self { severity: Severity::Warning, code: code.into(), message: message.into() }
+    }
+}
+
+/// Outcome of validating (and possibly auto-fixing) an export.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportReport {
+    /// `false` only when a critical defect survived auto-fix — the caller blocks.
+    pub ok: bool,
+    /// Whether the *returned* bytes were rendered in ATS (single-column) mode.
+    pub ats_mode: bool,
+    /// Remaining issues after any auto-fix (criticals here mean `ok == false`).
+    pub issues: Vec<ExportIssue>,
+    /// Human-readable description of each auto-fix that was applied.
+    pub fixed: Vec<String>,
+}
+
+fn has_critical(issues: &[ExportIssue]) -> bool {
+    issues.iter().any(|i| i.severity == Severity::Critical)
+}
+
+/// Render an export, validate the bytes by re-extraction, and auto-fix a
+/// two-column layout that does not survive extraction by re-exporting it
+/// single-column. Returns the (possibly re-rendered) bytes and a report.
+///
+/// `generate` renders the request to bytes; it is called again if an auto-fix is
+/// needed. TXT has no layout, so it is returned unvalidated.
+pub fn validate_and_fix(
+    mut request: ExportRequest,
+    generate: impl Fn(&ExportRequest) -> Result<Vec<u8>>,
+) -> Result<(Vec<u8>, ExportReport)> {
+    let mut bytes = generate(&request)?;
+
+    if matches!(request.format, ExportFormat::Txt) {
+        return Ok((
+            bytes,
+            ExportReport { ok: true, ats_mode: request.ats_mode, issues: vec![], fixed: vec![] },
+        ));
+    }
+
+    let mut issues = run_validators(&request, &bytes);
+    let mut fixed = Vec::new();
+
+    // Auto-fix: a two-column layout whose sections interleave when read back is
+    // re-exported single-column (linearized), then re-checked.
+    let can_linearize = matches!(request.template_id, TemplateId::TwoColumn) && !request.ats_mode;
+    if has_critical(&issues) && can_linearize {
+        request.ats_mode = true;
+        bytes = generate(&request)?;
+        issues = run_validators(&request, &bytes);
+        fixed.push(
+            "Re-exported in ATS-safe single-column layout because the two-column \
+             layout's sections interleaved when read back."
+                .to_string(),
+        );
+    }
+
+    let ok = !has_critical(&issues);
+    Ok((bytes, ExportReport { ok, ats_mode: request.ats_mode, issues, fixed }))
+}
+
+/// Critical content expected to survive a round trip, parsed from the source.
+struct Expected {
+    name: Option<String>,
+    email: Option<String>,
+    /// Section headings in source order (empty for cover letters).
+    headings: Vec<String>,
+}
+
+fn expected_from_request(request: &ExportRequest) -> Expected {
+    let parsed = parse_resume(&request.text);
+
+    let mut name = None;
+    let mut headings = Vec::new();
+    for line in &parsed.lines {
+        match line.kind {
+            LineKind::Name if name.is_none() => name = Some(strip_md(&line.text)),
+            LineKind::SectionHeader => headings.push(strip_md(&line.text)),
+            _ => {}
+        }
+    }
+
+    // The candidate name from metadata overrides the parsed first line.
+    if let Some(meta_name) = request.meta.as_ref().and_then(|m| m.candidate_name.as_deref()) {
+        if !meta_name.trim().is_empty() {
+            name = Some(meta_name.to_string());
+        }
+    }
+
+    let email = EMAIL_RE.find(&request.text).map(|m| m.as_str().to_string());
+
+    Expected { name, email, headings }
+}
+
+fn run_validators(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> {
+    let extracted = match request.format {
+        ExportFormat::Pdf => extract_pdf_text(bytes),
+        ExportFormat::Docx => extract_docx_text(bytes),
+        ExportFormat::Txt => return Vec::new(),
+    };
+
+    let extracted = match extracted {
+        Ok(t) => t,
+        // Never block on a tooling failure — surface it as a note instead.
+        Err(_) => {
+            return vec![ExportIssue::warning(
+                "roundtrip_unavailable",
+                "Could not re-read the exported file to verify it; export proceeded unchecked.",
+            )]
+        }
+    };
+
+    let expected = expected_from_request(request);
+    // Column interleaving is only possible for a two-column layout that has not
+    // been linearized to a single column.
+    let two_column = matches!(request.template_id, TemplateId::TwoColumn) && !request.ats_mode;
+    evaluate(&expected, &extracted, two_column, request.document_type)
+}
+
+/// Compare the expected content against the re-extracted text.
+fn evaluate(
+    expected: &Expected,
+    extracted: &str,
+    two_column: bool,
+    doc_type: DocumentType,
+) -> Vec<ExportIssue> {
+    let mut issues = Vec::new();
+    let hay = normalize(extracted);
+
+    // A document that produces (almost) no extractable text is broken in a way
+    // that linearizing cannot fix — block it.
+    let has_expected_content =
+        expected.name.is_some() || expected.email.is_some() || !expected.headings.is_empty();
+    if has_expected_content && hay.len() < 20 {
+        issues.push(ExportIssue::critical(
+            "no_extractable_text",
+            "The exported file has no machine-readable text — most parsers and ATS \
+             systems would see an empty document.",
+        ));
+        return issues; // nothing else is meaningful
+    }
+
+    // Identity: extraction is imperfect, so a miss is a warning, not a block.
+    if let Some(name) = &expected.name {
+        let n = normalize(name);
+        if !n.is_empty() && !hay.contains(&n) {
+            issues.push(ExportIssue::warning(
+                "missing_name",
+                format!("The name \u{201c}{name}\u{201d} was not found when re-reading the exported file."),
+            ));
+        }
+    }
+    if let Some(email) = &expected.email {
+        if !hay.contains(&normalize(email)) {
+            issues.push(ExportIssue::warning(
+                "missing_email",
+                "The email address was not found when re-reading the exported file.",
+            ));
+        }
+    }
+
+    // Section presence + reading order (resumes only).
+    if matches!(doc_type, DocumentType::Resume) && !expected.headings.is_empty() {
+        let mut positions: Vec<usize> = Vec::new();
+        for h in &expected.headings {
+            let hn = normalize(h);
+            if hn.is_empty() {
+                continue;
+            }
+            match hay.find(&hn) {
+                Some(pos) => positions.push(pos),
+                None => issues.push(ExportIssue::warning(
+                    "missing_section",
+                    format!("Section \u{201c}{h}\u{201d} was not found when re-reading the exported file."),
+                )),
+            }
+        }
+
+        // Only judge order when we recovered enough headings that a mismatch
+        // means interleaving rather than an extraction gap.
+        let recovered = positions.len();
+        if recovered >= 2 && recovered * 2 >= expected.headings.len() {
+            let out_of_order = positions.windows(2).any(|w| w[1] < w[0]);
+            if out_of_order {
+                if two_column {
+                    issues.push(ExportIssue::critical(
+                        "section_order",
+                        "The two-column layout's sections interleave when read top-to-bottom, \
+                         which ATS parsers misread.",
+                    ));
+                } else {
+                    issues.push(ExportIssue::warning(
+                        "section_order",
+                        "Sections appear out of order when re-reading the exported file.",
+                    ));
+                }
+            }
+        }
+    }
+
+    issues
+}
+
+/// Lowercased, whitespace-collapsed, alphanumeric-only form for tolerant
+/// `contains` / ordering checks against imperfect extraction.
+fn normalize(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn extract_pdf_text(bytes: &[u8]) -> Result<String> {
+    pdf_extract::extract_text_from_mem(bytes).map_err(|e| anyhow::anyhow!("pdf extract: {e}"))
+}
+
+fn extract_docx_text(bytes: &[u8]) -> Result<String> {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes))?;
+    let mut xml = String::new();
+    zip.by_name("word/document.xml")?.read_to_string(&mut xml)?;
+    Ok(strip_xml_tags(&xml))
+}
+
+/// Strip XML tags, replacing each with a space so adjacent runs don't fuse, then
+/// decode the handful of entities docx-rs emits.
+fn strip_xml_tags(xml: &str) -> String {
+    let mut out = String::with_capacity(xml.len());
+    let mut in_tag = false;
+    for c in xml.chars() {
+        match c {
+            '<' => {
+                in_tag = true;
+                out.push(' ');
+            }
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/tauri/src-tauri/src/validate/tests.rs
+++ b/apps/tauri/src-tauri/src/validate/tests.rs
@@ -1,0 +1,171 @@
+//! Validation tests. The `evaluate` logic is unit-tested on synthetic extracted
+//! text (deterministic, no rendering), and `validate_and_fix` is exercised
+//! end-to-end against real generated PDFs/DOCX to guard against false-positive
+//! blocking of valid documents.
+
+use super::*;
+
+fn expected(headings: &[&str]) -> Expected {
+    Expected {
+        name: Some("Jane Doe".to_string()),
+        email: Some("jane@example.com".to_string()),
+        headings: headings.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+// ─── evaluate: section order / presence ───────────────────────────────────────
+
+#[test]
+fn in_order_sections_are_clean() {
+    let e = expected(&["EXPERIENCE", "SKILLS", "EDUCATION"]);
+    let extracted = "Jane Doe jane@example.com EXPERIENCE lots of work SKILLS rust EDUCATION uni";
+    let issues = evaluate(&e, extracted, true, DocumentType::Resume);
+    assert!(!has_critical(&issues), "in-order two-column should be clean: {issues:?}");
+    assert!(issues.is_empty(), "no issues expected: {issues:?}");
+}
+
+#[test]
+fn interleaved_two_column_is_critical() {
+    let e = expected(&["EXPERIENCE", "SKILLS", "EDUCATION"]);
+    // SKILLS (a sidebar section) surfaces before EXPERIENCE → reading order broken.
+    let extracted = "Jane Doe jane@example.com SKILLS rust EXPERIENCE lots of work EDUCATION uni";
+    let issues = evaluate(&e, extracted, true, DocumentType::Resume);
+    assert!(
+        issues.iter().any(|i| i.code == "section_order" && i.severity == Severity::Critical),
+        "interleaved two-column must be critical: {issues:?}"
+    );
+}
+
+#[test]
+fn out_of_order_single_column_is_only_a_warning() {
+    let e = expected(&["EXPERIENCE", "SKILLS", "EDUCATION"]);
+    let extracted = "Jane Doe jane@example.com SKILLS rust EXPERIENCE lots of work EDUCATION uni";
+    let issues = evaluate(&e, extracted, false, DocumentType::Resume);
+    assert!(!has_critical(&issues), "single-column order is non-blocking: {issues:?}");
+    assert!(issues.iter().any(|i| i.code == "section_order" && i.severity == Severity::Warning));
+}
+
+#[test]
+fn missing_section_is_a_warning_not_a_block() {
+    let e = expected(&["EXPERIENCE", "SKILLS", "EDUCATION"]);
+    let extracted = "Jane Doe jane@example.com EXPERIENCE lots of work EDUCATION uni"; // SKILLS dropped
+    let issues = evaluate(&e, extracted, false, DocumentType::Resume);
+    assert!(!has_critical(&issues));
+    assert!(issues.iter().any(|i| i.code == "missing_section"));
+}
+
+#[test]
+fn no_extractable_text_is_critical() {
+    let e = expected(&["EXPERIENCE", "SKILLS"]);
+    let issues = evaluate(&e, "   ", true, DocumentType::Resume);
+    assert!(
+        issues.iter().any(|i| i.code == "no_extractable_text" && i.severity == Severity::Critical),
+        "empty extraction must be critical: {issues:?}"
+    );
+}
+
+#[test]
+fn missing_name_and_email_are_warnings() {
+    let e = expected(&["EXPERIENCE"]);
+    let extracted = "Somebody Else nobody@nowhere.test EXPERIENCE lots of work here too";
+    let issues = evaluate(&e, extracted, false, DocumentType::Resume);
+    assert!(!has_critical(&issues));
+    assert!(issues.iter().any(|i| i.code == "missing_name"));
+    assert!(issues.iter().any(|i| i.code == "missing_email"));
+}
+
+// ─── pure helpers ─────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_collapses_to_lowercase_alphanumeric() {
+    assert_eq!(normalize("  Hello,  World!  "), "hello world");
+    assert_eq!(normalize("EXPERIENCE"), "experience");
+}
+
+#[test]
+fn strip_xml_tags_keeps_run_text_separated() {
+    let xml = "<w:p><w:r><w:t>Hello</w:t></w:r><w:r><w:t>World</w:t></w:r></w:p>";
+    assert_eq!(normalize(&strip_xml_tags(xml)), "hello world");
+    assert_eq!(strip_xml_tags("a &amp; b").trim(), "a & b");
+}
+
+// ─── end-to-end: real renders must not be falsely blocked ─────────────────────
+
+const RESUME: &str = "\
+Jane Doe
+jane@example.com
+
+EXPERIENCE
+Acme Corp  2020 - Present
+Senior Engineer
+- Led a team of five engineers delivering the core platform
+
+SKILLS
+- Rust, TypeScript, React
+
+EDUCATION
+State University  2013 - 2017
+BSc Computer Science
+";
+
+fn req(format: ExportFormat, template_id: TemplateId, ats_mode: bool) -> ExportRequest {
+    ExportRequest {
+        text: RESUME.to_string(),
+        format,
+        document_type: DocumentType::Resume,
+        template_id,
+        meta: None,
+        ats_mode,
+    }
+}
+
+#[test]
+fn single_column_pdf_is_not_blocked() {
+    let (bytes, report) =
+        validate_and_fix(req(ExportFormat::Pdf, TemplateId::Modern, false), |r| {
+            crate::export::pdf::generate_pdf(r)
+        })
+        .expect("pdf export");
+    assert!(!bytes.is_empty());
+    assert!(report.ok, "a valid single-column resume must export: {:?}", report.issues);
+    assert!(report.fixed.is_empty(), "no auto-fix expected for single column");
+}
+
+#[test]
+fn resume_docx_is_not_blocked() {
+    let (bytes, report) =
+        validate_and_fix(req(ExportFormat::Docx, TemplateId::Modern, false), |r| {
+            crate::export::docx::generate_docx(r)
+        })
+        .expect("docx export");
+    assert!(!bytes.is_empty());
+    assert!(report.ok, "{:?}", report.issues);
+}
+
+#[test]
+fn two_column_pdf_is_never_blocked() {
+    let (bytes, report) =
+        validate_and_fix(req(ExportFormat::Pdf, TemplateId::TwoColumn, false), |r| {
+            crate::export::pdf::generate_pdf(r)
+        })
+        .expect("pdf export");
+    assert!(!bytes.is_empty());
+    assert!(report.ok, "two-column export must auto-fix rather than block: {:?}", report.issues);
+    // If extraction showed interleaving, the fix linearized to ATS single-column.
+    if !report.fixed.is_empty() {
+        assert!(report.ats_mode, "a linearize fix was applied but ats_mode is false");
+    }
+}
+
+#[test]
+fn txt_is_returned_unvalidated() {
+    let (bytes, report) =
+        validate_and_fix(req(ExportFormat::Txt, TemplateId::Modern, false), |r| {
+            Ok(crate::export::parser::strip_md(&r.text).into_bytes())
+        })
+        .expect("txt export");
+    assert!(!bytes.is_empty());
+    assert!(report.ok);
+    assert!(report.issues.is_empty());
+    assert!(report.fixed.is_empty());
+}

--- a/packages/shared/src/ipc/contracts/documents.ts
+++ b/packages/shared/src/ipc/contracts/documents.ts
@@ -29,6 +29,32 @@ interface BaseExportRequest {
   atsMode?: boolean;
 }
 
+export type ExportIssueSeverity = 'critical' | 'warning';
+
+/** A single problem found while re-reading an exported document. */
+export interface ExportIssue {
+  severity: ExportIssueSeverity;
+  /** Stable machine code (e.g. `section_order`, `missing_section`). */
+  code: string;
+  /** Plain-language explanation for the user. */
+  message: string;
+}
+
+/**
+ * Pre-export validation report. Present for PDF/DOCX, absent for TXT. The
+ * backend auto-fixes a two-column layout that doesn't survive extraction and
+ * blocks the export only when a critical issue survives, so `ok` is `false`
+ * only on a hard failure the user must address.
+ */
+export interface ExportReport {
+  ok: boolean;
+  /** Whether the returned bytes were rendered in ATS (single-column) mode. */
+  atsMode: boolean;
+  issues: ExportIssue[];
+  /** Human-readable description of each auto-fix that was applied. */
+  fixed: string[];
+}
+
 export interface CoverLetterExportRequest {
   templateId: TemplateId;
   /** Recipient first/last name — used for salutation. */
@@ -57,7 +83,7 @@ export interface DocumentsContract {
 
   exportDocument(
     req: BaseExportRequest
-  ): Promise<{ data: number[]; mimeType: string; filename: string }>;
+  ): Promise<{ data: number[]; mimeType: string; filename: string; report?: ExportReport }>;
 
   exportAndSave(req: BaseExportRequest): Promise<string>;
 }


### PR DESCRIPTION
## Phase 4 — pre-export validation + ATS round-trip gate

After a resume/cover letter is rendered, the bytes are **re-extracted** the way a
parser (or a human pasting into a form) would read them, and checked for content
survival and sane reading order. The export is auto-fixed where possible and
blocked only as a last resort.

### New `validate` module
- `validate_and_fix(request, generate)` → renders, re-extracts (`pdf-extract` for
  PDF, unzipped `document.xml` for DOCX), evaluates, and returns the (possibly
  re-rendered) bytes plus an `ExportReport { ok, atsMode, issues, fixed }`.
- **Auto-fix:** a two-column layout whose sections interleave when read back is
  re-exported single-column (ATS-safe via `ats_mode`), re-checked, and the fix
  is recorded in `report.fixed`.
- **Block:** only when a critical issue *survives* auto-fix → returns a
  plain-language error, no file (the behavior chosen for this phase).

### Severity model — tuned to never false-block a valid document
| Issue | Severity |
|---|---|
| Two-column sections interleave on read-back | **Critical** (auto-fixable → linearize) |
| No extractable text at all | **Critical** (unfixable → blocks) |
| Missing name / email / a section, single-column order quirks | Warning (surfaced, non-blocking) |

Because the only auto-fixable critical is two-column interleave (always fixed by
linearizing) and the only unfixable critical is an empty-text document (never
true for a real render), valid exports are never blocked — verified by
end-to-end tests.

### Wiring
- `documents_export_document` routes PDF/DOCX through the gate, so **both** the
  download and the save-to-disk flow receive auto-fixed bytes.
- `ExportResult` gains an optional `report` and now serializes camelCase
  (incidentally fixing the long-latent `mime_type`/`mimeType` mismatch — no real
  consumer read the old field). TXT has no layout and carries no report.
- IPC contract mirrors `ExportReport`/`ExportIssue` as **optional** on the
  `exportDocument` result (backward-compatible). The renderer surfacing UI is
  Phase 6.

### Tests / gates
- `evaluate` unit-tested on synthetic extracted text (interleave→critical,
  single-column reorder→warning, empty→critical, missing section→warning).
- `validate_and_fix` exercised end-to-end: real single-column PDF, DOCX, and
  two-column PDF exports are never falsely blocked; TXT returns unvalidated.
- `cargo test --all-features` green incl. the Phase 2 **layout parity gate**;
  `clippy -D warnings` clean; `pnpm typecheck` + `gen:ipc:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)