### PR TITLE
feat: render resume docx from the canonical model with real two-column (phase 5)

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.23.4"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ description = "AI Job Hunter — Tauri desktop shell"
 authors = ["Saeed Kolivand"]
 
 [features]
-default = ["layout_pdf"]
+default = ["layout_pdf", "model_docx"]
 
 # Render resumes through the canonical layout engine (model → LaidOutDoc → PDF)
 # instead of the legacy renderer. On by default now that gap-by-gap snapshot
@@ -14,6 +14,13 @@ default = ["layout_pdf"]
 # path stays compiled — it is the parity reference and still renders cover
 # letters — so `--no-default-features` falls back to it.
 layout_pdf = []
+
+# Render resume DOCX from the canonical document model (real two-column table,
+# native ats_mode) instead of the legacy line-based renderer. On by default;
+# locked by golden invariants in `export::model_docx::test`. The legacy DOCX
+# path stays compiled (it still renders cover letters), so `--no-default-features`
+# falls back to it.
+model_docx = []
 
 [profile.dev]
 incremental = true

--- a/apps/tauri/src-tauri/src/export/docx/mod.rs
+++ b/apps/tauri/src-tauri/src/export/docx/mod.rs
@@ -278,25 +278,44 @@ fn extract_section<'a>(text: &'a str, start_marker: &str, end_marker: Option<&st
 // ─── Public entry point ───────────────────────────────────────────────────────
 
 pub fn generate_docx(request: &ExportRequest) -> Result<Vec<u8>> {
-    // Two-column is PDF-only — DOCX always linearizes to single column.
-    let effective_id = request.template_id;
-    let mut template = Template::get(effective_id);
-    if matches!(effective_id, TemplateId::TwoColumn) {
-        template.two_column = None;
-        template.margin_in = 1.0;
-    }
+    let template = Template::get(request.template_id);
+
+    // The legacy DOCX path can't lay out columns, so it collapses two-column
+    // templates to a single column. The model path renders a real two-column
+    // table, so it keeps the config.
+    let single_column = || {
+        let mut t = template.clone();
+        if matches!(request.template_id, TemplateId::TwoColumn) {
+            t.two_column = None;
+            t.margin_in = 1.0;
+        }
+        t
+    };
 
     let docx = match request.document_type {
         DocumentType::Resume => {
             let text = extract_section(&request.text, "### CANDIDATE RESUME ###", Some("### JOB ADVERTISEMENT ###"));
             let text = if text.is_empty() { request.text.as_str() } else { text };
-            generate_resume_docx(text, request.meta.as_ref(), &template)
+            // Strangler-fig switch: the canonical model backend renders resume DOCX
+            // by default; `--no-default-features` falls back to the legacy renderer.
+            // Both arms compile via `cfg!` so neither path rots.
+            if cfg!(feature = "model_docx") {
+                crate::export::model_docx::generate_resume_docx(
+                    text,
+                    request.meta.as_ref(),
+                    &template,
+                    request.ats_mode,
+                )
                 .context("Failed to generate resume DOCX")?
+            } else {
+                generate_resume_docx(text, request.meta.as_ref(), &single_column())
+                    .context("Failed to generate resume DOCX")?
+            }
         }
         DocumentType::CoverLetter => {
             let text = extract_section(&request.text, "### COMPLETE COVER LETTER ###", None);
             let text = if text.is_empty() { request.text.as_str() } else { text };
-            generate_cover_letter_docx(text, request.meta.as_ref(), &template)
+            generate_cover_letter_docx(text, request.meta.as_ref(), &single_column())
                 .context("Failed to generate cover letter DOCX")?
         }
     };

--- a/apps/tauri/src-tauri/src/export/mod.rs
+++ b/apps/tauri/src-tauri/src/export/mod.rs
@@ -15,6 +15,7 @@ pub mod layout_pdf;
 pub mod parser;
 pub mod docx;
 pub mod docx_renderer;
+pub mod model_docx;
 pub mod pdf;
 pub mod pdf_renderer;
 pub mod templates;

--- a/apps/tauri/src-tauri/src/export/model_docx.rs
+++ b/apps/tauri/src-tauri/src/export/model_docx.rs
@@ -1,0 +1,456 @@
+//! DOCX backend for the canonical document model (Phase 5).
+//!
+//! Strangler-fig step mirroring [`super::layout_pdf`]: builds a [`DocumentModel`]
+//! from resume text and translates it to a `docx-rs` document. Unlike the legacy
+//! DOCX path (which re-parses text and always collapses to one column), this
+//! backend renders a genuine **two-column** layout as a borderless, single-row
+//! two-cell table (shaded sidebar cell + main cell) and honors `ats_mode`
+//! natively by linearizing the model to a single column before rendering.
+//!
+//! Wired into [`super::docx::generate_docx`] behind the `model_docx` Cargo
+//! feature. Reuses the Phase-3 font fallback and page-size helpers from
+//! [`super::docx_renderer`]; cover letters stay on the legacy path until they are
+//! modeled explicitly.
+
+use anyhow::Result;
+use docx_rs::*;
+
+use crate::export::docx_renderer::{
+    create_bullet_numbering, docx_run_fonts, inch_to_dxa, mm_to_dxa, pt_to_dxa, rgb_to_hex,
+    setup_colors, DocxColors,
+};
+use crate::export::templates::Template;
+use crate::export::types::{FontFamily, GenerationMeta};
+use crate::locale::LocaleProfile;
+use crate::model::adapter::model_from_resume_text;
+use crate::model::document::{Block, DocumentModel, EntryBlock, HeaderBlock, Placement, Section};
+use crate::model::rich::RichText;
+use crate::model::transform;
+use crate::theme::{self, LinkStyle};
+
+/// Per-flow rendering context (full page width, or a single table cell).
+struct Ctx<'a> {
+    template: &'a Template,
+    colors: &'a DocxColors,
+    link: LinkStyle,
+    /// Width of this flow in dxa — used to right-align entry dates.
+    width_dxa: usize,
+    /// Right-align entry dates with a tab (false inside the narrow sidebar).
+    right_align_date: bool,
+}
+
+/// Render a resume to a `Docx` via the canonical document model.
+pub(crate) fn generate_resume_docx(
+    text: &str,
+    meta: Option<&GenerationMeta>,
+    template: &Template,
+    ats_mode: bool,
+) -> Result<Docx> {
+    let mut model = model_from_resume_text(text);
+
+    if let Some(name) = meta.and_then(|m| m.candidate_name.as_deref()) {
+        if !name.trim().is_empty() {
+            model.header.name = name.to_string();
+        }
+    }
+
+    // ATS mode collapses to a single column and reorders sections for reading.
+    let two_column = template.two_column.is_some() && !ats_mode;
+    if ats_mode {
+        transform::linearize(&mut model);
+    }
+
+    let colors = setup_colors(template);
+    let (abstract_num, num) = create_bullet_numbering();
+    let mut docx = Docx::new().add_abstract_numbering(abstract_num).add_numbering(num);
+
+    // Header spans the full width, above any columns.
+    docx = add_header(docx, &model.header, template, &colors);
+
+    if two_column {
+        docx = add_two_column_body(docx, &model, template, &colors);
+    } else {
+        let ctx = Ctx {
+            template,
+            colors: &colors,
+            link: theme::link_style(template.id),
+            width_dxa: content_width_dxa(template),
+            right_align_date: true,
+        };
+        for section in &model.sections {
+            for para in section_paragraphs(section, &ctx) {
+                docx = docx.add_paragraph(para);
+            }
+        }
+    }
+
+    let geom = LocaleProfile::default().page_geometry();
+    let page_margin = PageMargin::new()
+        .top(inch_to_dxa(0.9))
+        .bottom(inch_to_dxa(0.9))
+        .left(inch_to_dxa(template.margin_in))
+        .right(inch_to_dxa(template.margin_in));
+
+    docx = docx
+        .page_size(mm_to_dxa(geom.width_mm), mm_to_dxa(geom.height_mm))
+        .page_margin(page_margin);
+
+    Ok(docx)
+}
+
+/// Printable width (page minus both margins) in dxa.
+fn content_width_dxa(template: &Template) -> usize {
+    let geom = LocaleProfile::default().page_geometry();
+    let page = mm_to_dxa(geom.width_mm) as i64;
+    let margin = inch_to_dxa(template.margin_in) as i64;
+    (page - 2 * margin).max(1) as usize
+}
+
+// ─── Header ───────────────────────────────────────────────────────────────────
+
+fn add_header(mut docx: Docx, header: &HeaderBlock, t: &Template, colors: &DocxColors) -> Docx {
+    if !header.name.is_empty() {
+        let mut p = Paragraph::new().add_run(
+            Run::new()
+                .add_text(&header.name)
+                .size(pt_to_dxa(t.name_pt))
+                .bold()
+                .color(colors.name.as_str())
+                .fonts(docx_run_fonts(t.fonts.name_family)),
+        );
+        if t.name_centered {
+            p = p.align(AlignmentType::Center);
+        }
+        docx = docx.add_paragraph(p);
+    }
+
+    if let Some(title) = &header.title {
+        let mut p = Paragraph::new().add_run(
+            Run::new()
+                .add_text(title)
+                .size(pt_to_dxa(t.body_pt))
+                .color(colors.date.as_str())
+                .fonts(docx_run_fonts(t.fonts.body_family)),
+        );
+        if t.name_centered {
+            p = p.align(AlignmentType::Center);
+        }
+        docx = docx.add_paragraph(p);
+    }
+
+    if !header.contact.is_empty() {
+        let opts = RunOpts::contact(t, colors);
+        let mut p = add_rich(Paragraph::new(), &header.contact, &opts)
+            .line_spacing(LineSpacing::new().after(120));
+        if t.name_centered {
+            p = p.align(AlignmentType::Center);
+        }
+        docx = docx.add_paragraph(p);
+    }
+
+    docx
+}
+
+// ─── Two-column body (borderless shaded table) ────────────────────────────────
+
+fn add_two_column_body(
+    mut docx: Docx,
+    model: &DocumentModel,
+    template: &Template,
+    colors: &DocxColors,
+) -> Docx {
+    let tc = template
+        .two_column
+        .as_ref()
+        .expect("add_two_column_body requires a two-column config");
+
+    let content = content_width_dxa(template);
+    let sidebar_w = (content as f32 * tc.sidebar_width_ratio) as usize;
+    let main_w = content.saturating_sub(sidebar_w).max(1);
+
+    let mut sidebar_paras = Vec::new();
+    let mut main_paras = Vec::new();
+    let sidebar_ctx = Ctx {
+        template,
+        colors,
+        link: theme::link_style(template.id),
+        width_dxa: sidebar_w,
+        right_align_date: false,
+    };
+    let main_ctx = Ctx {
+        template,
+        colors,
+        link: theme::link_style(template.id),
+        width_dxa: main_w,
+        right_align_date: true,
+    };
+    for section in &model.sections {
+        match theme::placement_for(&section.id) {
+            Placement::Sidebar => sidebar_paras.extend(section_paragraphs(section, &sidebar_ctx)),
+            Placement::Main => main_paras.extend(section_paragraphs(section, &main_ctx)),
+        }
+    }
+
+    // A table cell must hold at least one block-level element.
+    if sidebar_paras.is_empty() {
+        sidebar_paras.push(Paragraph::new());
+    }
+    if main_paras.is_empty() {
+        main_paras.push(Paragraph::new());
+    }
+
+    let mut sidebar_cell = TableCell::new()
+        .width(sidebar_w, WidthType::Dxa)
+        .set_borders(TableCellBorders::new().clear_all())
+        .vertical_align(VAlignType::Top)
+        .shading(
+            Shading::new()
+                .shd_type(ShdType::Clear)
+                .color("auto")
+                .fill(rgb_to_hex(tc.sidebar_bg_color)),
+        );
+    for p in sidebar_paras {
+        sidebar_cell = sidebar_cell.add_paragraph(p);
+    }
+
+    let mut main_cell = TableCell::new()
+        .width(main_w, WidthType::Dxa)
+        .set_borders(TableCellBorders::new().clear_all())
+        .vertical_align(VAlignType::Top);
+    for p in main_paras {
+        main_cell = main_cell.add_paragraph(p);
+    }
+
+    let table = Table::new(vec![TableRow::new(vec![sidebar_cell, main_cell])])
+        .set_grid(vec![sidebar_w, main_w])
+        .layout(TableLayoutType::Fixed)
+        .width(content, WidthType::Dxa)
+        .clear_all_border();
+
+    docx = docx.add_table(table);
+    docx
+}
+
+// ─── Section / block → paragraphs ─────────────────────────────────────────────
+
+fn section_paragraphs(section: &Section, ctx: &Ctx) -> Vec<Paragraph> {
+    let mut out = Vec::new();
+    if let Some(h) = heading_paragraph(&section.heading, ctx) {
+        out.push(h);
+    }
+    for block in &section.blocks {
+        match block {
+            Block::Paragraph(rt) => out.push(body_paragraph(rt, ctx)),
+            Block::Bullet(rt) => out.push(bullet_paragraph(rt, ctx)),
+            Block::Entry(e) => out.extend(entry_paragraphs(e, ctx)),
+        }
+    }
+    out
+}
+
+fn heading_paragraph(heading: &str, ctx: &Ctx) -> Option<Paragraph> {
+    if heading.is_empty() {
+        return None;
+    }
+    let t = ctx.template;
+    let (text, pt) = if t.section_small_caps {
+        (heading.to_uppercase(), t.section_pt * 0.85)
+    } else if t.section_all_caps {
+        (heading.to_uppercase(), t.section_pt)
+    } else {
+        (heading.to_string(), t.section_pt)
+    };
+    let char_spacing = if t.section_small_caps || t.section_all_caps { 30 } else { 0 };
+
+    Some(
+        Paragraph::new()
+            .add_run(
+                Run::new()
+                    .add_text(&text)
+                    .size(pt_to_dxa(pt))
+                    .bold()
+                    .color(ctx.colors.section.as_str())
+                    .fonts(docx_run_fonts(t.fonts.heading_family))
+                    .character_spacing(char_spacing),
+            )
+            .line_spacing(
+                LineSpacing::new()
+                    .before(pt_to_dxa(t.section_spacing_before) as u32)
+                    .after(60),
+            )
+            // Keep a heading with the content that follows it (no orphaned header
+            // at the foot of a page/column).
+            .keep_next(true),
+    )
+}
+
+fn body_paragraph(rt: &RichText, ctx: &Ctx) -> Paragraph {
+    add_rich(Paragraph::new(), rt, &RunOpts::body(ctx.template, ctx.colors, ctx.link))
+        .keep_lines(true)
+}
+
+fn bullet_paragraph(rt: &RichText, ctx: &Ctx) -> Paragraph {
+    let para = Paragraph::new().indent(
+        Some(inch_to_dxa(0.2)),
+        Some(SpecialIndentType::Hanging(inch_to_dxa(0.2))),
+        None,
+        None,
+    );
+    add_rich(para, rt, &RunOpts::body(ctx.template, ctx.colors, ctx.link))
+        .numbering(NumberingId::new(1), IndentLevel::new(0))
+        .keep_lines(true)
+}
+
+fn entry_paragraphs(e: &EntryBlock, ctx: &Ctx) -> Vec<Paragraph> {
+    let t = ctx.template;
+    let mut out = Vec::new();
+
+    // Title line — bold — with the date either right-aligned (wide flows) or
+    // appended inline (the narrow sidebar).
+    let mut title = add_rich(Paragraph::new(), &e.title, &RunOpts::entry_title(t, ctx.colors));
+    if let Some(date) = &e.date {
+        if ctx.right_align_date {
+            title = title
+                .add_run(Run::new().add_tab())
+                .add_run(
+                    Run::new()
+                        .add_text(date)
+                        .size(pt_to_dxa(9.5))
+                        .color(ctx.colors.date.as_str())
+                        .fonts(docx_run_fonts(t.fonts.body_family)),
+                )
+                .add_tab(Tab::new().val(TabValueType::Right).pos(ctx.width_dxa));
+        } else {
+            title = title.add_run(
+                Run::new()
+                    .add_text(format!("  ·  {date}"))
+                    .size(pt_to_dxa(9.5))
+                    .color(ctx.colors.date.as_str())
+                    .fonts(docx_run_fonts(t.fonts.body_family)),
+            );
+        }
+    }
+    // Keep the entry title with its subtitle / first bullet.
+    out.push(title.keep_next(true));
+
+    if let Some(subtitle) = &e.subtitle {
+        let para = add_rich(Paragraph::new(), subtitle, &RunOpts::subtitle(t, ctx.colors))
+            .line_spacing(LineSpacing::new().after(60))
+            .keep_next(true);
+        out.push(para);
+    }
+
+    for bullet in &e.bullets {
+        out.push(bullet_paragraph(bullet, ctx));
+    }
+
+    out
+}
+
+// ─── Rich text → runs / hyperlinks ────────────────────────────────────────────
+
+/// Styling for a run of rich text. Built per context so the same `add_rich`
+/// walker handles header contact, body, bold entry titles, and italic subtitles.
+struct RunOpts {
+    size: usize,
+    color: String,
+    link_color: String,
+    underline: bool,
+    family: FontFamily,
+    force_bold: bool,
+    force_italic: bool,
+}
+
+impl RunOpts {
+    fn link_color(colors: &DocxColors, link: LinkStyle) -> String {
+        if link.use_accent {
+            colors.emphasis.clone()
+        } else {
+            colors.body.clone()
+        }
+    }
+
+    fn contact(t: &Template, colors: &DocxColors) -> Self {
+        let link = theme::link_style(t.id);
+        Self {
+            size: pt_to_dxa(9.0),
+            color: colors.date.clone(),
+            link_color: Self::link_color(colors, link),
+            underline: link.underline,
+            family: t.fonts.body_family,
+            force_bold: false,
+            force_italic: false,
+        }
+    }
+
+    fn body(t: &Template, colors: &DocxColors, link: LinkStyle) -> Self {
+        Self {
+            size: pt_to_dxa(t.body_pt),
+            color: colors.body.clone(),
+            link_color: Self::link_color(colors, link),
+            underline: link.underline,
+            family: t.fonts.body_family,
+            force_bold: false,
+            force_italic: false,
+        }
+    }
+
+    fn entry_title(t: &Template, colors: &DocxColors) -> Self {
+        let link = theme::link_style(t.id);
+        Self {
+            size: pt_to_dxa(t.body_pt),
+            color: colors.body.clone(),
+            link_color: Self::link_color(colors, link),
+            underline: link.underline,
+            family: t.fonts.body_family,
+            force_bold: true,
+            force_italic: false,
+        }
+    }
+
+    fn subtitle(t: &Template, colors: &DocxColors) -> Self {
+        let link = theme::link_style(t.id);
+        Self {
+            size: pt_to_dxa(t.body_pt - 0.5),
+            color: colors.date.clone(),
+            link_color: Self::link_color(colors, link),
+            underline: link.underline,
+            family: t.fonts.body_family,
+            force_bold: false,
+            force_italic: t.job_title_italic,
+        }
+    }
+}
+
+fn add_rich(mut para: Paragraph, rt: &RichText, opts: &RunOpts) -> Paragraph {
+    for run in rt {
+        let mut r = Run::new()
+            .add_text(&run.text)
+            .size(opts.size)
+            .fonts(docx_run_fonts(opts.family));
+        if run.bold || opts.force_bold {
+            r = r.bold();
+        }
+        if run.italic || opts.force_italic {
+            r = r.italic();
+        }
+
+        match &run.link {
+            Some(url) => {
+                r = r.color(opts.link_color.as_str());
+                if opts.underline {
+                    r = r.underline("single");
+                }
+                para = para
+                    .add_hyperlink(Hyperlink::new(url.clone(), HyperlinkType::External).add_run(r));
+            }
+            None => {
+                para = para.add_run(r.color(opts.color.as_str()));
+            }
+        }
+    }
+    para
+}
+
+#[cfg(test)]
+mod test;

--- a/apps/tauri/src-tauri/src/export/model_docx/test.rs
+++ b/apps/tauri/src-tauri/src/export/model_docx/test.rs
@@ -1,0 +1,129 @@
+//! Golden invariants for the model-based DOCX backend. Each test builds a real
+//! DOCX and inspects the unzipped OOXML parts (`document.xml` and the hyperlink
+//! relationships), since DOCX is flow-based and has no pixel geometry to compare.
+
+use std::io::{Cursor, Read};
+
+use super::*;
+use crate::export::types::TemplateId;
+
+const RESUME: &str = "\
+Jane Doe
+jane@example.com | [LinkedIn](https://linkedin.com/in/jane)
+
+Experienced engineer building reliable web applications end to end.
+
+EXPERIENCE
+Acme Corp  2020 - Present
+Senior Engineer
+- Led a team of five engineers delivering the core platform
+
+SKILLS
+- Rust, TypeScript, React
+
+EDUCATION
+State University  2013 - 2017
+BSc Computer Science
+";
+
+fn build(template_id: TemplateId, ats_mode: bool) -> Vec<u8> {
+    let template = Template::get(template_id);
+    let docx = generate_resume_docx(RESUME, None, &template, ats_mode).expect("generate docx");
+    let mut buffer = Cursor::new(Vec::new());
+    docx.build().pack(&mut buffer).expect("pack docx");
+    buffer.into_inner()
+}
+
+/// Read a named part out of the DOCX zip.
+fn part(bytes: &[u8], name: &str) -> String {
+    let mut zip = zip::ZipArchive::new(Cursor::new(bytes)).expect("docx zip");
+    let mut s = String::new();
+    zip.by_name(name).expect(name).read_to_string(&mut s).expect("read part");
+    s
+}
+
+/// Strip XML tags so body text can be checked for content survival.
+fn text_of(xml: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    for c in xml.chars() {
+        match c {
+            '<' => {
+                in_tag = true;
+                out.push(' ');
+            }
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out
+}
+
+#[test]
+fn two_column_renders_a_borderless_shaded_table() {
+    let xml = part(&build(TemplateId::TwoColumn, false), "word/document.xml");
+    assert!(xml.contains("<w:tbl"), "two-column DOCX must use a table");
+    // Sidebar tint (240,244,248) → F0F4F8 fill on the sidebar cell.
+    assert!(xml.contains(r#"w:fill="F0F4F8""#), "sidebar cell should carry the template tint");
+}
+
+#[test]
+fn two_column_splits_sections_between_columns() {
+    // SKILLS + EDUCATION are sidebar sections; EXPERIENCE is a main section.
+    // All three must survive somewhere in the document.
+    let text = text_of(&part(&build(TemplateId::TwoColumn, false), "word/document.xml"));
+    for needle in ["EXPERIENCE", "SKILLS", "EDUCATION", "Acme Corp", "Rust"] {
+        assert!(text.contains(needle), "two-column lost content: {needle:?}");
+    }
+}
+
+#[test]
+fn ats_mode_emits_no_table() {
+    // ATS mode linearizes to a single column — no two-column table.
+    let xml = part(&build(TemplateId::TwoColumn, true), "word/document.xml");
+    assert!(!xml.contains("<w:tbl"), "ATS mode must not emit a two-column table");
+    let text = text_of(&xml);
+    for needle in ["EXPERIENCE", "SKILLS", "EDUCATION"] {
+        assert!(text.contains(needle), "ATS linearization dropped {needle:?}");
+    }
+}
+
+#[test]
+fn single_column_template_has_no_table() {
+    let xml = part(&build(TemplateId::Modern, false), "word/document.xml");
+    assert!(!xml.contains("<w:tbl"), "single-column template must not use a table");
+    let text = text_of(&xml);
+    for needle in ["Jane Doe", "EXPERIENCE", "Rust, TypeScript, React", "BSc Computer Science"] {
+        assert!(text.contains(needle), "single-column lost content: {needle:?}");
+    }
+}
+
+#[test]
+fn contact_links_become_hyperlinks_with_correct_targets() {
+    let bytes = build(TemplateId::Modern, false);
+    let doc = part(&bytes, "word/document.xml");
+    assert!(doc.contains("<w:hyperlink"), "contact links must render as hyperlinks");
+
+    // External hyperlink targets live in the relationships part.
+    let rels = part(&bytes, "word/_rels/document.xml.rels");
+    assert!(rels.contains("https://linkedin.com/in/jane"), "LinkedIn URL must be a hyperlink target");
+    assert!(rels.contains("mailto:jane@example.com"), "email must be a mailto hyperlink target");
+
+    // The visible label, not the raw URL, is shown.
+    let text = text_of(&doc);
+    assert!(text.contains("LinkedIn"), "link label should display");
+    assert!(!text.contains("https://linkedin.com/in/jane"), "raw URL must not be visible text");
+}
+
+#[test]
+fn declares_a4_page_size_and_fallback_fonts() {
+    // MonoTechnical: name/heading JetBrains Mono → Consolas, body Inter → Calibri.
+    let xml = part(&build(TemplateId::MonoTechnical, false), "word/document.xml");
+    assert!(xml.contains(r#"w:w="11906""#) && xml.contains(r#"w:h="16838""#), "A4 page size");
+    assert!(xml.contains(r#"w:ascii="Consolas""#), "JetBrains Mono → Consolas");
+    assert!(xml.contains(r#"w:ascii="Calibri""#), "Inter → Calibri");
+    for bundled in ["JetBrains Mono", "Inter"] {
+        assert!(!xml.contains(&format!(r#""{bundled}""#)), "bundled font {bundled:?} must not leak");
+    }
+}

--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -79,19 +79,19 @@ former `packages/ai` and `packages/data` Node packages were removed.
 
 ## AI Generation (`apps/tauri/src/renderer/features/ai-generate/`)
 
-| Feature                       | Status | Notes                                                  |
-| ----------------------------- | ------ | ------------------------------------------------------ |
-| Cover letter generation       | ✅     | Streaming                                              |
-| Resume generation             | ✅     | Streaming                                              |
-| Email generation              | ✅     |                                                        |
-| Summary generation            | ✅     |                                                        |
-| Bold keyword extraction       | ✅     | Post-processes output                                  |
-| DOCX export                   | ✅     | All 9 templates; explicit A4 page size + font fallback |
-| PDF export                    | ✅     | Canonical layout engine (default); legacy fallback     |
-| ATS-safe linearization        | ✅     | Two-column → single for ATS                            |
-| Extended thinking (Anthropic) | ✅     | ThinkingBubble UI                                      |
-| Locale-aware prompts          | ✅     | 11 languages                                           |
-| Template preview              | ✅     | OptionTile with live preview                           |
+| Feature                       | Status | Notes                                                                                                     |
+| ----------------------------- | ------ | --------------------------------------------------------------------------------------------------------- |
+| Cover letter generation       | ✅     | Streaming                                                                                                 |
+| Resume generation             | ✅     | Streaming                                                                                                 |
+| Email generation              | ✅     |                                                                                                           |
+| Summary generation            | ✅     |                                                                                                           |
+| Bold keyword extraction       | ✅     | Post-processes output                                                                                     |
+| DOCX export                   | ✅     | Canonical model engine (default): real two-column table + native ATS; A4 + font fallback; legacy fallback |
+| PDF export                    | ✅     | Canonical layout engine (default); legacy fallback                                                        |
+| ATS-safe linearization        | ✅     | Two-column → single for ATS                                                                               |
+| Extended thinking (Anthropic) | ✅     | ThinkingBubble UI                                                                                         |
+| Locale-aware prompts          | ✅     | 11 languages                                                                                              |
+| Template preview              | ✅     | OptionTile with live preview                                                                              |
 
 ---
 


### PR DESCRIPTION
## Phase 5 — DOCX onto the canonical model

Migrates the resume DOCX backend onto the `DocumentModel`, mirroring the PDF
layout engine. New `export::model_docx`, gated behind the `model_docx` Cargo
feature (**on by default**; `--no-default-features` falls back to the legacy
line-based renderer, which still renders cover letters). Both arms compile via
`cfg!` so neither path rots — the same strangler-fig pattern as `layout_pdf`.

### What the model backend does differently
- **Builds a `DocumentModel`** from resume text via the shared adapter instead of
  re-parsing flat lines.
- **Real two-column** = borderless, single-row two-cell table: a shaded sidebar
  cell (fill = template tint) + a main cell, fixed layout, borders cleared,
  letting Word flow/paginate. Section → column assignment uses the canonical
  `theme::placement_for` decision — the **same source the PDF engine uses** — so
  PDF and DOCX agree on the sidebar.
- **Native `ats_mode`**: `transform::linearize` reorders the model and the table
  is dropped for a single column — removing the old *"DOCX ignores ats_mode"* gap
  (it previously always force-collapsed two-column to one column).
- **First-class links**: contact/body links become real hyperlinks
  (`Hyperlink::new` + relationship targets), showing the label, not the raw URL.
- Reuses the Phase-3 **font fallback** + explicit **A4** page size, and adds
  `keepNext` on headings/entry titles and `keepLines` on bullets (no orphaned
  headings, no split bullets).

### Tests — golden OOXML invariants (`export::model_docx::test`)
- two-column emits a shaded borderless `<w:tbl>` and splits sections between columns;
- ATS mode emits **no** table and keeps every section;
- single-column templates use no table;
- contact links become `<w:hyperlink>` with correct `.rels` targets, no raw URLs as text;
- A4 page size + font fallback hold.

The existing `export::docx` and Phase-4 `validate` suites now run **through** the
model path and pass; the PDF parity gate is unaffected.

### Verification
- `cargo test --all-features` (model_docx + docx + validate + layout parity) green.
- `clippy -D warnings` clean under **both** `--all-features` and `--no-default-features`.
- DOCX-only Rust change — no IPC/TS surface touched.

Cover-letter modeling and true OOXML font embedding remain deferred (a stretch
goal even in the plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)