### PR TITLE
feat: structured resume extraction with html/rtf formats and a review step (phase 6)

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/src/commands/documents.rs
+++ b/apps/tauri/src-tauri/src/commands/documents.rs
@@ -44,6 +44,12 @@ pub async fn documents_import(app: AppHandle, req: DocumentsImportRequest) -> Va
         tracing::warn!(warning = %w, file = %req.name, "extraction warning");
     }
 
+    // Structured review: per-field confidence + missing/low-confidence flags the
+    // renderer surfaces before generation. Computed before `extraction.text` is
+    // moved into the record.
+    let review = serde_json::to_value(crate::extraction::structured::structure(&extraction))
+        .unwrap_or(json!(null));
+
     let store = app.state::<crate::documents::DocumentStore>();
     let doc_id = crate::documents::make_doc_id();
     let record = crate::documents::DocumentRecord {
@@ -58,7 +64,7 @@ pub async fn documents_import(app: AppHandle, req: DocumentsImportRequest) -> Va
         is_default: false,
     };
     match store.insert(&record) {
-        Ok(()) => json!({ "id": doc_id, "success": true }),
+        Ok(()) => json!({ "id": doc_id, "success": true, "review": review }),
         Err(e) => json!({ "error": e.to_string() }),
     }
 }

--- a/apps/tauri/src-tauri/src/export/parser/mod.rs
+++ b/apps/tauri/src-tauri/src/export/parser/mod.rs
@@ -52,6 +52,11 @@ pub fn normalize_unicode(text: &str) -> String {
             '\u{2116}' => "No.",
             '\u{2020}' | '\u{2021}' => "*",                               // daggers
             '\u{00B7}' => ".",                                             // middle dot
+            // Private Use Area + icon-font glyphs + replacement char: these render
+            // as boxes/garbage (or nothing) in the bundled fonts — drop them.
+            c if is_private_use(c) || c == '\u{FFFD}' => "",
+            // C0/C1 control characters other than the whitespace we keep.
+            c if c.is_control() && c != '\n' && c != '\r' && c != '\t' => "",
             _ => {
                 out.push(ch);
                 continue;
@@ -60,6 +65,16 @@ pub fn normalize_unicode(text: &str) -> String {
         out.push_str(replacement);
     }
     out
+}
+
+/// Unicode Private Use Area code points (BMP + planes 15/16). Icon fonts
+/// (Font Awesome, etc.) map glyphs here, so extracted/pasted text often contains
+/// PUA code points that are meaningless without the original font.
+pub fn is_private_use(c: char) -> bool {
+    matches!(
+        c as u32,
+        0xE000..=0xF8FF | 0xF_0000..=0xF_FFFD | 0x10_0000..=0x10_FFFD
+    )
 }
 
 // Lazy-initialized regexes for performance

--- a/apps/tauri/src-tauri/src/extraction/clean.rs
+++ b/apps/tauri/src-tauri/src/extraction/clean.rs
@@ -1,0 +1,46 @@
+//! Shared post-extraction text cleanup.
+//!
+//! Resumes built with icon fonts (Font Awesome and friends) embed glyphs in the
+//! Unicode Private Use Area; a text extractor recovers those code points as
+//! meaningless boxes. We strip them — plus the replacement char and stray C0/C1
+//! control characters — so the recovered text is clean for the AI, the structured
+//! pre-pass, and the renderer.
+
+use crate::export::parser::is_private_use;
+
+/// Remove Private Use Area glyphs, the replacement char, and control characters
+/// (keeping the `\n` / `\t` / `\r` whitespace that carries layout).
+pub fn strip_icon_glyphs(text: &str) -> String {
+    text.chars()
+        .filter(|&c| {
+            !(is_private_use(c)
+                || c == '\u{FFFD}'
+                || (c.is_control() && c != '\n' && c != '\r' && c != '\t'))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removes_private_use_glyphs() {
+        let input = "Email \u{f0e0} jane@example.com \u{f08c} LinkedIn";
+        let out = strip_icon_glyphs(input);
+        assert!(!out.contains('\u{f0e0}'));
+        assert!(!out.contains('\u{f08c}'));
+        assert!(out.contains("jane@example.com"));
+        assert!(out.contains("LinkedIn"));
+    }
+
+    #[test]
+    fn keeps_newlines_and_tabs() {
+        assert_eq!(strip_icon_glyphs("a\nb\tc"), "a\nb\tc");
+    }
+
+    #[test]
+    fn removes_replacement_char_and_controls() {
+        assert_eq!(strip_icon_glyphs("a\u{FFFD}b\u{0007}c"), "abc");
+    }
+}

--- a/apps/tauri/src-tauri/src/extraction/docx.rs
+++ b/apps/tauri/src-tauri/src/extraction/docx.rs
@@ -14,6 +14,7 @@ pub fn extract(bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
     let document_xml = read_zip_entry(&mut archive, "word/document.xml")?;
 
     let (text, links) = parse_document(&document_xml, &relationships);
+    let text = crate::extraction::clean::strip_icon_glyphs(&text);
     let confidence = crate::extraction::confidence::score(&text, SourceFormat::Docx);
 
     Ok(ExtractedResume {

--- a/apps/tauri/src-tauri/src/extraction/html.rs
+++ b/apps/tauri/src-tauri/src/extraction/html.rs
@@ -1,0 +1,180 @@
+//! HTML resume extraction.
+//!
+//! Resumes exported as HTML (e.g. "Save as Web Page", or a portfolio page) carry
+//! their structure in tags. We drop `<script>` / `<style>` / `<head>`, turn
+//! `<a href>` anchors into `[label](url)` markdown (and collect them as links),
+//! convert block-level boundaries to newlines, strip the remaining tags, and
+//! decode the common entities — yielding the same markdown-with-inline-links
+//! shape the other extractors produce.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::extraction::types::{ExtractedResume, ExtractionError, Link, SourceFormat};
+
+static SCRIPT_STYLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?is)<(script|style|head)\b[^>]*>.*?</\s*(script|style|head)\s*>").unwrap()
+});
+
+/// `<a … href="URL" …>LABEL</a>` — captures URL and the inner (possibly tagged) label.
+static ANCHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?is)<a\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>(.*?)</\s*a\s*>"#).unwrap()
+});
+
+/// Block-level boundaries that should become a line break.
+static BLOCK_BREAK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?is)<\s*/?\s*(p|div|br|li|tr|h[1-6]|ul|ol|table|section|header|footer|article)\b[^>]*>")
+        .unwrap()
+});
+
+static TAG_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)<[^>]+>").unwrap());
+
+static WS_RUN_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[ \t]+").unwrap());
+/// Adjacent block tags (e.g. `</div><div>`) yield several newlines; collapse a
+/// run of blank/whitespace-only lines to a single break so each block is one line.
+static NEWLINE_RUN_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n[ \t\n]*").unwrap());
+
+pub fn extract(bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
+    let html = String::from_utf8_lossy(bytes);
+    let (text, links) = parse_html(&html);
+
+    if text.trim().is_empty() {
+        return Err(ExtractionError::EncodingError(
+            "HTML contained no readable text".to_string(),
+        ));
+    }
+
+    let confidence = crate::extraction::confidence::score(&text, SourceFormat::Html);
+    Ok(ExtractedResume {
+        text,
+        links,
+        confidence,
+        warnings: vec![],
+        source_format: SourceFormat::Html,
+    })
+}
+
+/// Returns `(markdown_text, links)`.
+fn parse_html(html: &str) -> (String, Vec<Link>) {
+    // 1. Drop non-content blocks.
+    let without_noise = SCRIPT_STYLE_RE.replace_all(html, " ");
+
+    // 2. Anchors → [label](url) markdown, collecting external links.
+    let mut links = Vec::new();
+    let with_links = ANCHOR_RE.replace_all(&without_noise, |caps: &regex::Captures| {
+        let url = caps[1].trim().to_string();
+        let label = decode_entities(&TAG_RE.replace_all(&caps[2], "")).trim().to_string();
+        let label = if label.is_empty() { url.clone() } else { label };
+        if is_keepable_link(&url) {
+            links.push(Link {
+                anchor_text: label.clone(),
+                url: url.clone(),
+            });
+            format!("[{label}]({url})")
+        } else {
+            label
+        }
+    });
+
+    // 3. Block boundaries → newlines, then strip remaining tags.
+    let broken = BLOCK_BREAK_RE.replace_all(&with_links, "\n");
+    let stripped = TAG_RE.replace_all(&broken, "");
+
+    // 4. Decode entities and normalize whitespace.
+    let decoded = decode_entities(&stripped);
+    let text = normalize_ws(&decoded);
+
+    (text, links)
+}
+
+fn is_keepable_link(url: &str) -> bool {
+    let u = url.trim();
+    u.starts_with("http://") || u.starts_with("https://") || u.starts_with("mailto:")
+}
+
+fn decode_entities(s: &str) -> String {
+    s.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&middot;", "·")
+        .replace("&bull;", "•")
+        .replace("&mdash;", "—")
+        .replace("&ndash;", "–")
+}
+
+fn normalize_ws(s: &str) -> String {
+    let collapsed = WS_RUN_RE.replace_all(s, " ");
+    let collapsed = NEWLINE_RUN_RE.replace_all(&collapsed, "\n");
+    collapsed
+        .lines()
+        .map(|l| l.trim())
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_text_and_drops_script_style() {
+        let html = r#"<html><head><title>x</title></head><body>
+            <style>.a{color:red}</style>
+            <h1>Jane Doe</h1>
+            <script>var x = 1;</script>
+            <p>Senior Engineer</p>
+        </body></html>"#;
+        let (text, _) = parse_html(html);
+        assert!(text.contains("Jane Doe"));
+        assert!(text.contains("Senior Engineer"));
+        assert!(!text.contains("color:red"));
+        assert!(!text.contains("var x"));
+    }
+
+    #[test]
+    fn converts_anchors_to_markdown_links() {
+        let html =
+            r#"<p>Contact: <a href="https://linkedin.com/in/jane">LinkedIn</a> | <a href="mailto:jane@example.com">Email</a></p>"#;
+        let (text, links) = parse_html(html);
+        assert!(text.contains("[LinkedIn](https://linkedin.com/in/jane)"));
+        assert!(text.contains("[Email](mailto:jane@example.com)"));
+        assert_eq!(links.len(), 2);
+        assert!(links.iter().any(|l| l.url == "https://linkedin.com/in/jane"));
+    }
+
+    #[test]
+    fn block_tags_become_line_breaks() {
+        let html = "<div>Experience</div><div>Acme Corp</div>";
+        let (text, _) = parse_html(html);
+        assert_eq!(text, "Experience\nAcme Corp");
+    }
+
+    #[test]
+    fn decodes_entities() {
+        let html = "<p>R&amp;D &middot; Tools&nbsp;&amp;&nbsp;Tech</p>";
+        let (text, _) = parse_html(html);
+        assert!(text.contains("R&D"));
+        assert!(text.contains("·"));
+    }
+
+    #[test]
+    fn full_extract_sets_html_source() {
+        let html = b"<html><body><h1>Jane</h1><p>jane@example.com</p></body></html>";
+        let r = extract(html).expect("html");
+        assert_eq!(r.source_format, SourceFormat::Html);
+        assert!(r.text.contains("Jane"));
+    }
+
+    #[test]
+    fn empty_html_errors() {
+        let html = b"<html><head></head><body></body></html>";
+        assert!(extract(html).is_err());
+    }
+}

--- a/apps/tauri/src-tauri/src/extraction/mod.rs
+++ b/apps/tauri/src-tauri/src/extraction/mod.rs
@@ -1,7 +1,12 @@
+pub mod clean;
 pub mod confidence;
 pub mod docx;
+pub mod html;
 pub mod pdf;
 pub mod plain;
+pub mod registry;
+pub mod rtf;
+pub mod structured;
 pub mod types;
 
 use std::path::Path;
@@ -9,7 +14,7 @@ use std::path::Path;
 use tracing::{instrument, warn};
 
 use crate::error::{AppError, AppResult};
-use types::{ExtractionError, ExtractedResume, SourceFormat};
+use types::{ExtractionError, ExtractedResume};
 
 const MAX_BYTES: usize = 10 * 1024 * 1024; // 10 MB
 
@@ -36,6 +41,9 @@ pub async fn extract_resume(path: String) -> AppResult<ExtractedResume> {
 }
 
 /// Pure (non-async) router — easier to unit-test without a Tauri runtime.
+///
+/// Dispatch is data-driven: the extension is resolved against the
+/// [`registry`], so adding a format never touches this function.
 pub fn route(path: &str, bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
     if bytes.len() > MAX_BYTES {
         return Err(ExtractionError::FileTooLarge { size: bytes.len() });
@@ -47,49 +55,10 @@ pub fn route(path: &str, bytes: &[u8]) -> Result<ExtractedResume, ExtractionErro
         .unwrap_or("")
         .to_lowercase();
 
-    match ext.as_str() {
-        "pdf" => route_pdf(bytes),
-        "docx" => docx::extract(bytes),
-        "txt" | "md" | "markdown" => plain::extract(bytes),
-        "png" | "jpg" | "jpeg" | "webp" => route_image(bytes),
-        "doc" => Err(ExtractionError::LegacyDoc),
-        other => Err(ExtractionError::UnsupportedFormat {
-            ext: other.to_string(),
-        }),
+    match registry::extractor_for(&ext) {
+        Some(extractor) => extractor.extract(bytes),
+        None => Err(ExtractionError::UnsupportedFormat { ext }),
     }
-}
-
-fn route_pdf(bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
-    let result = pdf::extract(bytes)?;
-
-    let word_count = result.text.split_whitespace().count();
-    if word_count >= 30 && result.text.len() >= 200 {
-        return Ok(result);
-    }
-
-    warn!(
-        word_count,
-        chars = result.text.len(),
-        "PDF direct extraction yielded sparse text"
-    );
-
-    if word_count == 0 {
-        return Err(ExtractionError::ScannedPdfWithoutOcr);
-    }
-
-    let mut out = result;
-    out.warnings.push(
-        "Extracted text is sparse. The PDF may contain scanned pages."
-            .to_string(),
-    );
-    out.source_format = SourceFormat::PdfScanned;
-    Ok(out)
-}
-
-fn route_image(_bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
-    Err(ExtractionError::OcrError(
-        "Image extraction is not supported in this build.".to_string(),
-    ))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/apps/tauri/src-tauri/src/extraction/pdf.rs
+++ b/apps/tauri/src-tauri/src/extraction/pdf.rs
@@ -6,6 +6,7 @@ use crate::extraction::types::{ExtractionError, ExtractedResume, Link, SourceFor
 pub fn extract(bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
     let text = pdf_extract::extract_text_from_mem(bytes)
         .map_err(|e| ExtractionError::PdfError(e.to_string()))?;
+    let text = crate::extraction::clean::strip_icon_glyphs(&text);
 
     let links = extract_links(bytes);
     let text = inline_links(&text, &links);

--- a/apps/tauri/src-tauri/src/extraction/registry.rs
+++ b/apps/tauri/src-tauri/src/extraction/registry.rs
@@ -1,0 +1,158 @@
+//! Extractor registry — the single dispatch table mapping a file extension to an
+//! [`Extractor`]. Adding a format is one entry here plus its module; the router
+//! ([`super::route`]) carries no per-format `match`.
+
+use std::sync::LazyLock;
+
+use tracing::warn;
+
+use crate::extraction::types::{ExtractedResume, ExtractionError, SourceFormat};
+
+/// A pluggable extractor for one or more file extensions (lowercase, no dot).
+pub trait Extractor: Send + Sync {
+    fn extensions(&self) -> &'static [&'static str];
+    fn extract(&self, bytes: &[u8]) -> Result<ExtractedResume, ExtractionError>;
+}
+
+struct PdfExtractor;
+impl Extractor for PdfExtractor {
+    fn extensions(&self) -> &'static [&'static str] {
+        &["pdf"]
+    }
+    fn extract(&self, bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
+        let result = crate::extraction::pdf::extract(bytes)?;
+
+        let word_count = result.text.split_whitespace().count();
+        if word_count >= 30 && result.text.len() >= 200 {
+            return Ok(result);
+        }
+
+        warn!(word_count, chars = result.text.len(), "PDF direct extraction yielded sparse text");
+
+        // Empty text layer → a scanned PDF; the renderer's OCR fallback handles it.
+        if word_count == 0 {
+            return Err(ExtractionError::ScannedPdfWithoutOcr);
+        }
+
+        let mut out = result;
+        out.warnings
+            .push("Extracted text is sparse. The PDF may contain scanned pages.".to_string());
+        out.source_format = SourceFormat::PdfScanned;
+        Ok(out)
+    }
+}
+
+struct DocxExtractor;
+impl Extractor for DocxExtractor {
+    fn extensions(&self) -> &'static [&'static str] {
+        &["docx"]
+    }
+    fn extract(&self, bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
+        crate::extraction::docx::extract(bytes)
+    }
+}
+
+struct PlainExtractor;
+impl Extractor for PlainExtractor {
+    fn extensions(&self) -> &'static [&'static str] {
+        &["txt", "md", "markdown"]
+    }
+    fn extract(&self, bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
+        crate::extraction::plain::extract(bytes)
+    }
+}
+
+struct HtmlExtractor;
+impl Extractor for HtmlExtractor {
+    fn extensions(&self) -> &'static [&'static str] {
+        &["html", "htm"]
+    }
+    fn extract(&self, bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
+        crate::extraction::html::extract(bytes)
+    }
+}
+
+struct RtfExtractor;
+impl Extractor for RtfExtractor {
+    fn extensions(&self) -> &'static [&'static str] {
+        &["rtf"]
+    }
+    fn extract(&self, bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
+        crate::extraction::rtf::extract(bytes)
+    }
+}
+
+/// Images can't be read in the Rust core — OCR runs in the renderer
+/// (Tesseract.js). Returning an OCR error signals the frontend to run it.
+struct ImageExtractor;
+impl Extractor for ImageExtractor {
+    fn extensions(&self) -> &'static [&'static str] {
+        &["png", "jpg", "jpeg", "webp"]
+    }
+    fn extract(&self, _bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
+        Err(ExtractionError::OcrError(
+            "Image files are read with OCR, which runs in the app.".to_string(),
+        ))
+    }
+}
+
+struct LegacyDocExtractor;
+impl Extractor for LegacyDocExtractor {
+    fn extensions(&self) -> &'static [&'static str] {
+        &["doc"]
+    }
+    fn extract(&self, _bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
+        Err(ExtractionError::LegacyDoc)
+    }
+}
+
+static REGISTRY: LazyLock<Vec<Box<dyn Extractor>>> = LazyLock::new(|| {
+    vec![
+        Box::new(PdfExtractor),
+        Box::new(DocxExtractor),
+        Box::new(PlainExtractor),
+        Box::new(HtmlExtractor),
+        Box::new(RtfExtractor),
+        Box::new(ImageExtractor),
+        Box::new(LegacyDocExtractor),
+    ]
+});
+
+/// The extractor registered for `ext` (lowercase, no leading dot), if any.
+pub fn extractor_for(ext: &str) -> Option<&'static dyn Extractor> {
+    REGISTRY
+        .iter()
+        .find(|e| e.extensions().contains(&ext))
+        .map(|b| b.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_supported_extension_resolves() {
+        for ext in [
+            "pdf", "docx", "txt", "md", "markdown", "html", "htm", "rtf", "png", "jpg", "jpeg",
+            "webp", "doc",
+        ] {
+            assert!(extractor_for(ext).is_some(), "no extractor for .{ext}");
+        }
+    }
+
+    #[test]
+    fn unknown_extension_is_unregistered() {
+        assert!(extractor_for("pages").is_none());
+        assert!(extractor_for("").is_none());
+    }
+
+    #[test]
+    fn no_extension_is_claimed_twice() {
+        let mut seen = std::collections::HashSet::new();
+        for e in REGISTRY.iter() {
+            for ext in e.extensions() {
+                assert!(seen.insert(*ext), "extension .{ext} is registered twice");
+            }
+        }
+    }
+}

--- a/apps/tauri/src-tauri/src/extraction/rtf.rs
+++ b/apps/tauri/src-tauri/src/extraction/rtf.rs
@@ -1,0 +1,300 @@
+//! RTF resume extraction.
+//!
+//! A pragmatic RTF reader: it walks the control-word stream, skips the
+//! non-content destinations (font/color/style tables, pictures, info), maps the
+//! paragraph/line/tab/unicode/hex control words to text, and recovers `HYPERLINK`
+//! field targets as links. Output is the same markdown-with-a-link-reference-list
+//! shape the PDF extractor produces, so downstream code treats every format
+//! uniformly.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::extraction::types::{ExtractedResume, ExtractionError, Link, SourceFormat};
+use crate::model::rich::url_label;
+
+/// Destinations whose contents are not body text.
+const SKIP_DESTINATIONS: &[&str] = &[
+    "fonttbl", "colortbl", "stylesheet", "info", "pict", "themedata", "colorschememapping",
+    "latentstyles", "listtable", "listoverridetable", "rsidtbl", "generator", "datastore",
+    "mmathPr", "wgrffmtfilter", "xmlnstbl", "header", "footer", "headerl", "headerr", "footerl",
+    "footerr", "headerf", "footerf", "fldinst",
+];
+
+static HYPERLINK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"HYPERLINK\s+"([^"]+)""#).unwrap());
+
+pub fn extract(bytes: &[u8]) -> Result<ExtractedResume, ExtractionError> {
+    let rtf = String::from_utf8_lossy(bytes);
+    if !rtf.trim_start().starts_with("{\\rtf") {
+        return Err(ExtractionError::EncodingError("not a valid RTF document".to_string()));
+    }
+
+    let text = rtf_to_text(&rtf);
+    let links = extract_hyperlinks(&rtf);
+    let text = append_link_reference(text, &links);
+
+    if text.trim().is_empty() {
+        return Err(ExtractionError::EncodingError(
+            "RTF contained no readable text".to_string(),
+        ));
+    }
+
+    let confidence = crate::extraction::confidence::score(&text, SourceFormat::Rtf);
+    Ok(ExtractedResume {
+        text,
+        links,
+        confidence,
+        warnings: vec![],
+        source_format: SourceFormat::Rtf,
+    })
+}
+
+/// HYPERLINK field targets, de-duplicated, in first-seen order.
+fn extract_hyperlinks(rtf: &str) -> Vec<Link> {
+    let mut seen = std::collections::HashSet::new();
+    let mut links = Vec::new();
+    for caps in HYPERLINK_RE.captures_iter(rtf) {
+        let url = caps[1].trim().to_string();
+        if (url.starts_with("http://") || url.starts_with("https://") || url.starts_with("mailto:"))
+            && seen.insert(url.clone())
+        {
+            links.push(Link {
+                anchor_text: url_label(&url),
+                url,
+            });
+        }
+    }
+    links
+}
+
+fn append_link_reference(text: String, links: &[Link]) -> String {
+    if links.is_empty() {
+        return text;
+    }
+    let mut out = text;
+    out.push_str("\n\n---\n");
+    for link in links {
+        out.push_str(&format!("- [{}]({})\n", link.anchor_text, link.url));
+    }
+    out
+}
+
+/// Walk the RTF control stream into plain text.
+fn rtf_to_text(rtf: &str) -> String {
+    let bytes = rtf.as_bytes();
+    let n = bytes.len();
+    let mut out = String::new();
+    // One skip-flag per open group; a group is skipped if it (or an ancestor) is
+    // a non-content destination.
+    let mut skip_stack: Vec<bool> = vec![false];
+    let mut uc_skip = 1usize; // chars to swallow after a \uN (set by \ucN)
+    let mut to_swallow = 0usize;
+    let mut i = 0usize;
+
+    while i < n {
+        let skipping = *skip_stack.last().unwrap_or(&false);
+        let c = bytes[i];
+        match c {
+            b'{' => {
+                skip_stack.push(skipping);
+                i += 1;
+            }
+            b'}' => {
+                skip_stack.pop();
+                if skip_stack.is_empty() {
+                    skip_stack.push(false);
+                }
+                i += 1;
+            }
+            b'\\' => {
+                if i + 1 >= n {
+                    break;
+                }
+                let d = bytes[i + 1];
+                match d {
+                    b'\\' | b'{' | b'}' => {
+                        if !skipping && to_swallow == 0 {
+                            out.push(d as char);
+                        }
+                        to_swallow = to_swallow.saturating_sub(1);
+                        i += 2;
+                    }
+                    b'*' => {
+                        // Ignorable destination — skip the whole group.
+                        if let Some(top) = skip_stack.last_mut() {
+                            *top = true;
+                        }
+                        i += 2;
+                    }
+                    b'\'' => {
+                        // \'xx hex byte (Windows-1252).
+                        if i + 3 < n {
+                            if let Ok(v) = u8::from_str_radix(&rtf[i + 2..i + 4], 16) {
+                                if !skipping {
+                                    if to_swallow > 0 {
+                                        to_swallow -= 1;
+                                    } else {
+                                        out.push(win1252(v));
+                                    }
+                                }
+                            }
+                            i += 4;
+                        } else {
+                            i = n;
+                        }
+                    }
+                    _ if d.is_ascii_alphabetic() => {
+                        let mut j = i + 1;
+                        while j < n && bytes[j].is_ascii_alphabetic() {
+                            j += 1;
+                        }
+                        let word = &rtf[i + 1..j];
+                        // Optional signed numeric parameter.
+                        let mut k = j;
+                        let neg = k < n && bytes[k] == b'-';
+                        if neg {
+                            k += 1;
+                        }
+                        let ps = k;
+                        while k < n && bytes[k].is_ascii_digit() {
+                            k += 1;
+                        }
+                        let param = if k > ps {
+                            rtf[ps..k].parse::<i64>().ok().map(|v| if neg { -v } else { v })
+                        } else {
+                            None
+                        };
+                        // A single trailing space delimits the control word.
+                        let mut next = k;
+                        if next < n && bytes[next] == b' ' {
+                            next += 1;
+                        }
+                        i = next;
+
+                        if SKIP_DESTINATIONS.contains(&word) {
+                            if let Some(top) = skip_stack.last_mut() {
+                                *top = true;
+                            }
+                            continue;
+                        }
+                        if skipping {
+                            continue;
+                        }
+                        match word {
+                            "par" | "line" | "sect" | "page" => out.push('\n'),
+                            "tab" => out.push('\t'),
+                            "uc" => uc_skip = param.unwrap_or(1).max(0) as usize,
+                            "u" => {
+                                if let Some(code) = param {
+                                    let cp = if code < 0 { (code + 65536) as u32 } else { code as u32 };
+                                    if let Some(ch) = char::from_u32(cp) {
+                                        out.push(ch);
+                                    }
+                                    to_swallow = uc_skip;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    b'~' => {
+                        if !skipping {
+                            out.push(' ');
+                        }
+                        i += 2;
+                    }
+                    b'-' | b'_' | b':' | b'|' => i += 2, // optional hyphen, etc.
+                    b'\r' | b'\n' => i += 2,             // escaped line break → ignore
+                    _ => i += 2,
+                }
+            }
+            b'\r' | b'\n' => i += 1, // raw line breaks are not text in RTF
+            _ => {
+                if !skipping {
+                    if to_swallow > 0 {
+                        to_swallow -= 1;
+                    } else {
+                        out.push(c as char);
+                    }
+                }
+                i += 1;
+            }
+        }
+    }
+
+    normalize(&out)
+}
+
+/// Map a Windows-1252 byte to its Unicode char (ASCII passes through).
+fn win1252(b: u8) -> char {
+    match b {
+        0x91 | 0x92 => '\'',
+        0x93 | 0x94 => '"',
+        0x95 => '•',
+        0x96 => '–',
+        0x97 => '—',
+        0x85 => '…',
+        0xA0 => ' ',
+        _ => b as char,
+    }
+}
+
+fn normalize(s: &str) -> String {
+    s.lines()
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_paragraph_text() {
+        let rtf = r"{\rtf1\ansi\deff0 {\fonttbl{\f0 Calibri;}} Jane Doe\par Senior Engineer\par}";
+        let text = rtf_to_text(rtf);
+        assert!(text.contains("Jane Doe"), "got: {text:?}");
+        assert!(text.contains("Senior Engineer"));
+        // font table content must not leak
+        assert!(!text.contains("Calibri"));
+    }
+
+    #[test]
+    fn decodes_unicode_and_hex() {
+        // \u233 = é (with a '?' ANSI fallback to swallow), \'e9 = é in win-1252
+        let rtf = r"{\rtf1\ansi caf\u233?\par r\'e9sum\'e9\par}";
+        let text = rtf_to_text(rtf);
+        assert!(text.contains("café"), "unicode escape failed: {text:?}");
+        assert!(text.contains("résumé"), "hex escape failed: {text:?}");
+    }
+
+    #[test]
+    fn recovers_hyperlink_fields() {
+        let rtf = r#"{\rtf1 {\field{\*\fldinst{ HYPERLINK "https://linkedin.com/in/jane" }}{\fldrslt LinkedIn}}\par}"#;
+        let links = extract_hyperlinks(rtf);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].url, "https://linkedin.com/in/jane");
+        assert_eq!(links[0].anchor_text, "LinkedIn");
+        // The field instruction text (HYPERLINK "...") must not appear in body text.
+        assert!(!rtf_to_text(rtf).contains("HYPERLINK"));
+    }
+
+    #[test]
+    fn full_extract_sets_rtf_source_and_appends_links() {
+        let rtf = br#"{\rtf1\ansi Jane Doe\par jane@example.com\par {\field{\*\fldinst{ HYPERLINK "https://janedoe.dev" }}{\fldrslt Site}}\par}"#;
+        let r = extract(rtf).expect("rtf");
+        assert_eq!(r.source_format, SourceFormat::Rtf);
+        assert!(r.text.contains("Jane Doe"));
+        assert!(r.text.contains("[janedoe.dev](https://janedoe.dev)"));
+        assert_eq!(r.links.len(), 1);
+    }
+
+    #[test]
+    fn rejects_non_rtf() {
+        assert!(extract(b"just plain text").is_err());
+    }
+}

--- a/apps/tauri/src-tauri/src/extraction/structured.rs
+++ b/apps/tauri/src-tauri/src/extraction/structured.rs
@@ -1,0 +1,285 @@
+//! Structured resume extraction.
+//!
+//! Turns the flat [`ExtractedResume`] text into a typed [`StructuredResume`]:
+//! contact fields (name / email / phone / location / links) and a section
+//! inventory, each carrying a [`Confidence`] and the byte span it was found at.
+//!
+//! This is the **deterministic pre-pass** the plan describes. It runs offline,
+//! is fully testable, and never drops content. An AI structuring stage can later
+//! refine the body into rich entries; for contact fields the deterministic result
+//! wins (a regex-matched email is more trustworthy than an LLM guess). The whole
+//! document [`Confidence`] from [`crate::extraction::confidence`] stays as the
+//! fast gate; this adds the per-field detail a review UI needs.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::extraction::types::{Confidence, ExtractedResume};
+use crate::model::adapter::model_from_resume_text;
+use crate::model::document::{DocumentModel, HeaderBlock, SectionId};
+use crate::model::rich::tokenize_rich;
+
+static EMAIL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}").unwrap());
+
+/// Phone numbers: at least 7 digits, optional `+`, spaces, dashes, parens.
+static PHONE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\+?\d[\d\s().\-]{6,}\d").unwrap()
+});
+
+/// A byte span `[start, end)` into the source text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// One extracted field: its value, how sure we are, and where it came from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Field<T> {
+    pub value: T,
+    pub confidence: Confidence,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_span: Option<Span>,
+}
+
+impl<T> Field<T> {
+    fn new(value: T, confidence: Confidence, source_span: Option<Span>) -> Self {
+        Self { value, confidence, source_span }
+    }
+}
+
+/// A detected section, for the review inventory (not the full block tree).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SectionSummary {
+    /// Heading as written.
+    pub heading: String,
+    /// Canonical section kind (`experience`, `skills`, `custom`, …).
+    pub kind: String,
+    pub confidence: Confidence,
+}
+
+/// Typed view of a resume with per-field confidence, for the review step.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StructuredResume {
+    pub name: Field<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<Field<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<Field<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<Field<String>>,
+    pub links: Vec<Field<String>>,
+    pub sections: Vec<SectionSummary>,
+    /// Whole-document confidence (the fast gate).
+    pub overall: Confidence,
+    /// True when a human should review before generating (low confidence or a
+    /// missing critical field). Never blocks — just flags.
+    pub review_required: bool,
+    /// Plain-language notes about what is missing or uncertain.
+    pub warnings: Vec<String>,
+}
+
+/// Run the deterministic structuring pre-pass over an extraction result.
+pub fn structure(extracted: &ExtractedResume) -> StructuredResume {
+    let text = &extracted.text;
+
+    let name = extract_name(text);
+    let email = find_span(text, &EMAIL_RE).map(|(v, s)| Field::new(v, Confidence::High, Some(s)));
+    let phone = find_span(text, &PHONE_RE)
+        .filter(|(v, _)| v.chars().filter(|c| c.is_ascii_digit()).count() >= 7)
+        .map(|(v, s)| Field::new(v.trim().to_string(), Confidence::Medium, Some(s)));
+    let location = extract_location(text);
+
+    // Links come from real hyperlinks (high confidence); fall back to bare URLs.
+    let links = extracted
+        .links
+        .iter()
+        .map(|l| {
+            let span = find_literal(text, &l.url);
+            Field::new(l.url.clone(), Confidence::High, span)
+        })
+        .collect::<Vec<_>>();
+
+    let sections = section_inventory(text);
+
+    let mut warnings = Vec::new();
+    if name.value.trim().is_empty() {
+        warnings.push("No name was detected — add it before generating.".to_string());
+    }
+    if email.is_none() {
+        warnings.push("No email address was detected.".to_string());
+    }
+    if sections.len() < 2 {
+        warnings.push("Few resume sections were detected — the layout may be hard to read.".to_string());
+    }
+
+    let review_required = matches!(extracted.confidence, Confidence::Low)
+        || name.value.trim().is_empty()
+        || email.is_none()
+        || sections.len() < 2;
+
+    StructuredResume {
+        name,
+        email,
+        phone,
+        location,
+        links,
+        sections,
+        overall: extracted.confidence,
+        review_required,
+        warnings,
+    }
+}
+
+/// Build a [`DocumentModel`] from the structured fields, reconciling the header
+/// with the deterministic contact fields (which win over the text round-trip).
+///
+/// The body sections come from the canonical text adapter (which already groups
+/// entries / bullets); the header is rebuilt from the typed contact fields so the
+/// name and links are the trustworthy regex/hyperlink values, not re-parsed text.
+///
+/// The structured render path that consumes this (export building the model from
+/// `StructuredResume` rather than re-parsing text) lands in a follow-up; the
+/// reconcile is implemented and tested here so that wiring is a one-line swap.
+#[allow(dead_code)]
+pub fn build_model(extracted: &ExtractedResume, structured: &StructuredResume) -> DocumentModel {
+    let mut model = model_from_resume_text(&extracted.text);
+    model.header = reconcile_header(&model.header, structured);
+    model
+}
+
+#[allow(dead_code)]
+fn reconcile_header(parsed: &HeaderBlock, sr: &StructuredResume) -> HeaderBlock {
+    let name = if sr.name.value.trim().is_empty() {
+        parsed.name.clone()
+    } else {
+        sr.name.value.clone()
+    };
+
+    // Rebuild the contact line from the typed fields, preserving links as runs.
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(email) = &sr.email {
+        parts.push(email.value.clone());
+    }
+    if let Some(phone) = &sr.phone {
+        parts.push(phone.value.clone());
+    }
+    if let Some(loc) = &sr.location {
+        parts.push(loc.value.clone());
+    }
+    for link in &sr.links {
+        parts.push(link.value.clone());
+    }
+
+    let contact = if parts.is_empty() {
+        parsed.contact.clone()
+    } else {
+        tokenize_rich(&parts.join(" · "))
+    };
+
+    HeaderBlock { name, title: parsed.title.clone(), contact }
+}
+
+// ── Field extractors ──────────────────────────────────────────────────────────
+
+fn extract_name(text: &str) -> Field<String> {
+    let model = model_from_resume_text(text);
+    let name = model.header.name.trim().to_string();
+    if name.is_empty() {
+        return Field::new(String::new(), Confidence::Low, None);
+    }
+    // A real name is short and free of email/digit noise.
+    let words = name.split_whitespace().count();
+    let looks_like_name =
+        words <= 5 && !name.contains('@') && !name.chars().any(|c| c.is_ascii_digit());
+    let confidence = if looks_like_name { Confidence::High } else { Confidence::Medium };
+    let span = find_literal(text, &name);
+    Field::new(name, confidence, span)
+}
+
+/// Best-effort location: a short, comma-bearing line near the top that isn't the
+/// contact/email line. Low confidence by nature.
+fn extract_location(text: &str) -> Option<Field<String>> {
+    for line in text.lines().take(6) {
+        let l = line.trim();
+        if l.len() < 3 || l.len() > 60 || !l.contains(',') {
+            continue;
+        }
+        if l.contains('@') || EMAIL_RE.is_match(l) || PHONE_RE.is_match(l) || l.contains("](") {
+            continue;
+        }
+        // Two short comma-separated tokens look like "City, Country".
+        let tokens: Vec<&str> = l.split(',').map(str::trim).filter(|t| !t.is_empty()).collect();
+        if tokens.len() == 2 && tokens.iter().all(|t| t.split_whitespace().count() <= 3) {
+            let span = find_literal(text, l);
+            return Some(Field::new(l.to_string(), Confidence::Low, span));
+        }
+    }
+    None
+}
+
+fn section_inventory(text: &str) -> Vec<SectionSummary> {
+    model_from_resume_text(text)
+        .sections
+        .iter()
+        .filter(|s| !s.heading.trim().is_empty()) // skip the untitled preamble
+        .map(|s| {
+            let confidence = match s.id {
+                SectionId::Custom(_) => Confidence::Medium,
+                _ => Confidence::High,
+            };
+            SectionSummary {
+                heading: s.heading.clone(),
+                kind: section_kind(&s.id),
+                confidence,
+            }
+        })
+        .collect()
+}
+
+fn section_kind(id: &SectionId) -> String {
+    match id {
+        SectionId::Summary => "summary",
+        SectionId::Experience => "experience",
+        SectionId::Education => "education",
+        SectionId::Skills => "skills",
+        SectionId::Projects => "projects",
+        SectionId::Certifications => "certifications",
+        SectionId::Languages => "languages",
+        SectionId::Awards => "awards",
+        SectionId::Publications => "publications",
+        SectionId::Volunteer => "volunteer",
+        SectionId::Interests => "interests",
+        SectionId::References => "references",
+        SectionId::Custom(_) => "custom",
+    }
+    .to_string()
+}
+
+// ── span helpers ──────────────────────────────────────────────────────────────
+
+fn find_span(text: &str, re: &Regex) -> Option<(String, Span)> {
+    re.find(text).map(|m| {
+        (
+            m.as_str().to_string(),
+            Span { start: m.start(), end: m.end() },
+        )
+    })
+}
+
+fn find_literal(text: &str, needle: &str) -> Option<Span> {
+    if needle.is_empty() {
+        return None;
+    }
+    text.find(needle).map(|start| Span { start, end: start + needle.len() })
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/tauri/src-tauri/src/extraction/structured/tests.rs
+++ b/apps/tauri/src-tauri/src/extraction/structured/tests.rs
@@ -1,0 +1,123 @@
+use super::*;
+use crate::extraction::types::{ExtractedResume, Link, SourceFormat};
+use crate::model::document::Block;
+
+const RESUME: &str = "\
+Jane Doe
+jane@example.com | +31 6 12345678
+
+Experienced engineer building reliable web applications end to end.
+
+EXPERIENCE
+Acme Corp  2020 - Present
+Senior Engineer
+- Led a team of five engineers
+
+SKILLS
+- Rust, TypeScript, React
+
+EDUCATION
+State University  2013 - 2017
+BSc Computer Science
+";
+
+fn extracted(text: &str, links: Vec<Link>) -> ExtractedResume {
+    ExtractedResume {
+        text: text.to_string(),
+        links,
+        confidence: Confidence::High,
+        warnings: vec![],
+        source_format: SourceFormat::PlainText,
+    }
+}
+
+#[test]
+fn extracts_name_email_and_phone_with_confidence() {
+    let sr = structure(&extracted(RESUME, vec![]));
+    assert_eq!(sr.name.value, "Jane Doe");
+    assert_eq!(sr.name.confidence, Confidence::High);
+
+    let email = sr.email.expect("email");
+    assert_eq!(email.value, "jane@example.com");
+    assert_eq!(email.confidence, Confidence::High);
+    // The span points back at the email in the source.
+    let span = email.source_span.expect("email span");
+    assert_eq!(&RESUME[span.start..span.end], "jane@example.com");
+
+    assert!(sr.phone.is_some(), "phone should be detected");
+}
+
+#[test]
+fn section_inventory_classifies_and_skips_preamble() {
+    let sr = structure(&extracted(RESUME, vec![]));
+    let kinds: Vec<&str> = sr.sections.iter().map(|s| s.kind.as_str()).collect();
+    assert_eq!(kinds, vec!["experience", "skills", "education"]);
+    // The untitled summary preamble is not listed as a heading.
+    assert!(sr.sections.iter().all(|s| !s.heading.is_empty()));
+}
+
+#[test]
+fn good_resume_does_not_require_review() {
+    let sr = structure(&extracted(RESUME, vec![]));
+    assert!(!sr.review_required, "warnings: {:?}", sr.warnings);
+    assert!(sr.warnings.is_empty());
+}
+
+#[test]
+fn missing_email_flags_review_with_a_warning() {
+    let no_email = "Jane Doe\n\nEXPERIENCE\nAcme Corp\n- did things\n\nSKILLS\n- Rust";
+    let sr = structure(&extracted(no_email, vec![]));
+    assert!(sr.email.is_none());
+    assert!(sr.review_required);
+    assert!(sr.warnings.iter().any(|w| w.contains("email")));
+}
+
+#[test]
+fn missing_name_scores_low_and_flags_review() {
+    // Leading blank lines so the parser finds no name line.
+    let sr = structure(&extracted("\n\nEXPERIENCE\nAcme Corp\n- x\n\nSKILLS\n- Rust", vec![]));
+    assert_eq!(sr.name.confidence, Confidence::Low);
+    assert!(sr.name.value.is_empty());
+    assert!(sr.review_required);
+}
+
+#[test]
+fn links_carry_high_confidence_and_spans() {
+    let text = "Jane Doe\nhttps://janedoe.dev\n\nEXPERIENCE\nAcme\n- x\n\nSKILLS\n- Rust";
+    let links = vec![Link {
+        anchor_text: "janedoe.dev".to_string(),
+        url: "https://janedoe.dev".to_string(),
+    }];
+    let sr = structure(&extracted(text, links));
+    assert_eq!(sr.links.len(), 1);
+    assert_eq!(sr.links[0].confidence, Confidence::High);
+    assert!(sr.links[0].source_span.is_some());
+}
+
+#[test]
+fn build_model_reconciles_header_from_typed_fields() {
+    let links = vec![Link {
+        anchor_text: "LinkedIn".to_string(),
+        url: "https://linkedin.com/in/jane".to_string(),
+    }];
+    let ex = extracted(RESUME, links);
+    let sr = structure(&ex);
+    let model = build_model(&ex, &sr);
+
+    assert_eq!(model.header.name, "Jane Doe");
+    // Contact runs include the email and the link as a clickable run.
+    let contact_text: String = model.header.contact.iter().map(|r| r.text.as_str()).collect();
+    assert!(contact_text.contains("jane@example.com"), "got: {contact_text}");
+    assert!(
+        model
+            .header
+            .contact
+            .iter()
+            .any(|r| r.link.as_deref() == Some("https://linkedin.com/in/jane")),
+        "link run missing"
+    );
+    // Body sections survive from the adapter.
+    assert!(model.sections.iter().any(|s| {
+        s.heading == "EXPERIENCE" && s.blocks.iter().any(|b| matches!(b, Block::Entry(_)))
+    }));
+}

--- a/apps/tauri/src-tauri/src/extraction/types.rs
+++ b/apps/tauri/src-tauri/src/extraction/types.rs
@@ -23,6 +23,8 @@ pub enum SourceFormat {
     Docx,
     Image,
     PlainText,
+    Html,
+    Rtf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/tauri/src/renderer/components/resume/ResumeInputCard/index.tsx
+++ b/apps/tauri/src/renderer/components/resume/ResumeInputCard/index.tsx
@@ -19,12 +19,13 @@ import { Button, cn, TextArea } from '@ajh/ui';
 import { useTranslation } from '@/lib/i18n';
 
 import { ProfileUrlInput } from '../ProfileUrlInput';
+import { ResumeReviewPanel } from '../ResumeReviewPanel';
 import { SaveActions } from '../SaveActions';
 import { SavedResumeMenu } from '../SavedResumeMenu';
 import { UploadZone } from '../UploadZone';
 import { useResumeInput } from './useResumeInput';
 
-const ACCEPT = '.pdf,.docx,.txt,.md,.markdown';
+const ACCEPT = '.pdf,.docx,.txt,.md,.markdown,.html,.htm,.rtf';
 
 interface Props {
   /** Extracted resume text — controlled by parent */
@@ -77,6 +78,8 @@ export function ResumeInputCard({
     handleFileChange,
     handleProfileUrlSubmit,
     toggleUrlInput,
+    review,
+    clearReview,
   } = useResumeInput({ value, onChange, onUpload });
 
   return (
@@ -266,6 +269,13 @@ export function ResumeInputCard({
           onSaveToLibrary={() => void handleSaveToLibrary(false)}
           onSetDefault={() => void handleSaveToLibrary(true)}
         />
+      )}
+
+      {/* Structured-extraction review — shown when a saved import needs a look */}
+      {review?.reviewRequired && (
+        <div className="px-3 pb-3">
+          <ResumeReviewPanel review={review} onDismiss={clearReview} />
+        </div>
       )}
     </div>
   );

--- a/apps/tauri/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
+++ b/apps/tauri/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
@@ -60,7 +60,7 @@ export function useResumeInput({ value, onChange, onUpload }: Params) {
   const { data: rawDocsUnknown = [] } = useDocuments();
   const rawDocs = rawDocsUnknown as unknown as RawDoc[];
   const docs = rawDocs.map(normalise);
-  const { importFile } = useImportWithOcr();
+  const { importFile, review, clearReview } = useImportWithOcr();
   const setDefaultDocument = useSetDefaultDocument();
   const profileImport = useProfileImport();
 
@@ -208,5 +208,7 @@ export function useResumeInput({ value, onChange, onUpload }: Params) {
     handleFileChange,
     handleProfileUrlSubmit,
     toggleUrlInput,
+    review,
+    clearReview,
   };
 }

--- a/apps/tauri/src/renderer/components/resume/ResumeReviewPanel/index.tsx
+++ b/apps/tauri/src/renderer/components/resume/ResumeReviewPanel/index.tsx
@@ -1,0 +1,121 @@
+import type { ConfidenceLevel, ResumeField, StructuredResume } from '@ajh/shared';
+import { Button, cn, GlassCard } from '@ajh/ui';
+
+import { useTranslation } from '@/lib/i18n';
+
+interface Props {
+  review: StructuredResume;
+  onDismiss: () => void;
+}
+
+const CONFIDENCE_STYLE: Record<ConfidenceLevel, string> = {
+  high: 'bg-emerald-500/15 text-emerald-400',
+  medium: 'bg-amber-500/15 text-amber-400',
+  low: 'bg-rose-500/15 text-rose-400',
+};
+
+function ConfidenceBadge({ level }: { level: ConfidenceLevel }) {
+  const { t } = useTranslation();
+  return (
+    <span
+      className={cn(
+        'rounded-full px-2 py-0.5 text-[11px] font-medium leading-none',
+        CONFIDENCE_STYLE[level]
+      )}
+    >
+      {t(`resumeReview.confidence.${level}`)}
+    </span>
+  );
+}
+
+function FieldRow({ label, field }: { label: string; field?: ResumeField<string> }) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center justify-between gap-3 py-1.5">
+      <span className="text-sm text-white/60">{label}</span>
+      <span className="flex items-center gap-2">
+        <span className={cn('text-sm', field ? 'text-foreground' : 'italic text-white/40')}>
+          {field?.value || t('resumeReview.notDetected')}
+        </span>
+        {field && <ConfidenceBadge level={field.confidence} />}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Surfaces the structured-extraction review for a freshly imported resume:
+ * detected contact fields with per-field confidence, the section inventory, and
+ * any missing/low-confidence warnings. Informational — it never blocks; the user
+ * dismisses it and proceeds.
+ */
+export function ResumeReviewPanel({ review, onDismiss }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <GlassCard className="space-y-4 p-4">
+      <header className="space-y-1">
+        <h3 className="text-sm font-semibold text-foreground">{t('resumeReview.title')}</h3>
+        <p className="text-xs text-white/60">{t('resumeReview.subtitle')}</p>
+      </header>
+
+      {review.warnings.length > 0 && (
+        <ul className="space-y-1">
+          {review.warnings.map((w) => (
+            <li key={w} className="flex items-start gap-2 text-sm text-amber-400">
+              <span aria-hidden className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-current" />
+              <span>{w}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="divide-y divide-white/10">
+        <FieldRow label={t('resumeReview.name')} field={review.name} />
+        <FieldRow label={t('resumeReview.email')} field={review.email} />
+        <FieldRow label={t('resumeReview.phone')} field={review.phone} />
+        <FieldRow label={t('resumeReview.location')} field={review.location} />
+      </div>
+
+      {review.links.length > 0 && (
+        <div className="space-y-1.5">
+          <span className="text-xs font-medium text-white/60">{t('resumeReview.links')}</span>
+          <div className="flex flex-wrap gap-1.5">
+            {review.links.map((link) => (
+              <span
+                key={link.value}
+                className="max-w-[14rem] truncate rounded-md bg-white/5 px-2 py-1 text-xs text-foreground"
+                title={link.value}
+              >
+                {link.value}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {review.sections.length > 0 && (
+        <div className="space-y-1.5">
+          <span className="text-xs font-medium text-white/60">{t('resumeReview.sections')}</span>
+          <div className="flex flex-wrap gap-1.5">
+            {review.sections.map((section) => (
+              <span
+                key={`${section.kind}-${section.heading}`}
+                className="flex items-center gap-1.5 rounded-md bg-white/5 px-2 py-1 text-xs text-foreground"
+              >
+                {section.heading}
+                <ConfidenceBadge level={section.confidence} />
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <Button size="sm" variant="ghost" onClick={onDismiss}>
+          {t('resumeReview.dismiss')}
+        </Button>
+      </div>
+    </GlassCard>
+  );
+}

--- a/apps/tauri/src/renderer/hooks/use-import-with-ocr/use-import-with-ocr.ts
+++ b/apps/tauri/src/renderer/hooks/use-import-with-ocr/use-import-with-ocr.ts
@@ -1,10 +1,19 @@
 import i18n from 'i18next';
 import { useState } from 'react';
 
+import type { StructuredResume } from '@ajh/shared';
+
 import { ocrFile } from '@/lib/ocr';
 import { useImportDocument } from '@/services';
 
 export type ImportWithOcrStatus = 'idle' | 'importing' | 'ocr' | 'retrying';
+
+type ImportResult = {
+  id?: string;
+  success?: boolean;
+  error?: string;
+  review?: StructuredResume;
+};
 
 /**
  * Wraps useImportDocument with a Tesseract.js fallback for scanned PDFs.
@@ -15,8 +24,11 @@ export type ImportWithOcrStatus = 'idle' | 'importing' | 'ocr' | 'retrying';
 export function useImportWithOcr() {
   const importDocument = useImportDocument();
   const [status, setStatus] = useState<ImportWithOcrStatus>('idle');
+  // Structured-extraction review from the most recent import (per-field
+  // confidence + missing-field warnings); surfaced when `reviewRequired`.
+  const [review, setReview] = useState<StructuredResume | null>(null);
 
-  const importFile = async (file: File) => {
+  const importFile = async (file: File): Promise<ImportResult> => {
     setStatus('importing');
     try {
       const bytes = new Uint8Array(await file.arrayBuffer());
@@ -24,9 +36,10 @@ export function useImportWithOcr() {
         name: file.name,
         bytes,
         title: file.name,
-      })) as { id?: string; success?: boolean; error?: string };
+      })) as ImportResult;
 
       if (result?.error !== 'scanned_pdf') {
+        setReview(result?.review ?? null);
         return result;
       }
 
@@ -41,11 +54,13 @@ export function useImportWithOcr() {
       setStatus('retrying');
       const ocrBytes = new TextEncoder().encode(text);
       const baseName = file.name.replace(/\.[^.]+$/, '');
-      return await importDocument.mutateAsync({
+      const retried = (await importDocument.mutateAsync({
         name: `${baseName}.txt`,
         bytes: new Uint8Array(ocrBytes),
         title: file.name,
-      });
+      })) as ImportResult;
+      setReview(retried?.review ?? null);
+      return retried;
     } finally {
       setStatus('idle');
     }
@@ -56,5 +71,7 @@ export function useImportWithOcr() {
     status,
     isPending: status !== 'idle',
     isOcr: status === 'ocr',
+    review,
+    clearReview: () => setReview(null),
   };
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -1389,6 +1389,23 @@
       "next": "KI einrichten"
     }
   },
+  "resumeReview": {
+    "title": "Extrahierten Lebenslauf prüfen",
+    "subtitle": "Prüfe die erkannten Angaben vor der Generierung. Es wird nichts blockiert — nur ein Hinweis.",
+    "notDetected": "Nicht erkannt",
+    "name": "Name",
+    "email": "E-Mail",
+    "phone": "Telefon",
+    "location": "Ort",
+    "links": "Links",
+    "sections": "Abschnitte",
+    "dismiss": "Sieht gut aus",
+    "confidence": {
+      "high": "Hoch",
+      "medium": "Mittel",
+      "low": "Niedrig"
+    }
+  },
   "resumeInput": {
     "label": "Lebenslauf",
     "saved": "Gespeichert",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -1396,6 +1396,23 @@
     "downloadButton": "Download",
     "installButton": "Restart & Install"
   },
+  "resumeReview": {
+    "title": "Review extracted resume",
+    "subtitle": "Check the detected details before generating. Nothing is blocked — this is just a heads-up.",
+    "notDetected": "Not detected",
+    "name": "Name",
+    "email": "Email",
+    "phone": "Phone",
+    "location": "Location",
+    "links": "Links",
+    "sections": "Sections",
+    "dismiss": "Looks good",
+    "confidence": {
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
+    }
+  },
   "resumeInput": {
     "label": "Resume",
     "saved": "Saved",

--- a/packages/shared/src/ipc/contracts/documents.ts
+++ b/packages/shared/src/ipc/contracts/documents.ts
@@ -72,10 +72,53 @@ export interface CoverLetterExportRequest {
   locale?: 'en' | 'de';
 }
 
+export type ConfidenceLevel = 'high' | 'medium' | 'low';
+
+/** Byte span `[start, end)` into the extracted source text. */
+export interface SourceSpan {
+  start: number;
+  end: number;
+}
+
+/** One structured-extraction field: value, confidence, and where it was found. */
+export interface ResumeField<T> {
+  value: T;
+  confidence: ConfidenceLevel;
+  sourceSpan?: SourceSpan;
+}
+
+/** A detected section in the review inventory. */
+export interface SectionSummary {
+  heading: string;
+  /** Canonical kind: `experience`, `skills`, `custom`, … */
+  kind: string;
+  confidence: ConfidenceLevel;
+}
+
+/**
+ * Typed view of an imported resume with per-field confidence. Returned by
+ * `import` so the renderer can surface low-confidence / missing fields for
+ * review before generation. `reviewRequired` flags (never blocks).
+ */
+export interface StructuredResume {
+  name: ResumeField<string>;
+  email?: ResumeField<string>;
+  phone?: ResumeField<string>;
+  location?: ResumeField<string>;
+  links: ResumeField<string>[];
+  sections: SectionSummary[];
+  /** Whole-document confidence (the fast gate). */
+  overall: ConfidenceLevel;
+  reviewRequired: boolean;
+  warnings: string[];
+}
+
 export interface DocumentsContract {
   list(): Promise<DocumentRecord[]>;
 
-  import(req: DocumentImportRequest): Promise<{ id: string; success: boolean }>;
+  import(
+    req: DocumentImportRequest
+  ): Promise<{ id: string; success: boolean; review?: StructuredResume }>;
 
   remove(id: string): Promise<void>;
 

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -134,7 +134,15 @@ export { CONVERSATIONS_CHANNELS, type ConversationsContract } from './conversati
 export { CREDENTIALS_CHANNELS, type CredentialsContract } from './credentials.js';
 export { DATA_CHANNELS, type DataContract } from './data.js';
 export { DIALOG_CHANNELS, type DialogContract } from './dialog.js';
-export { DOCUMENTS_CHANNELS, type DocumentsContract } from './documents.js';
+export {
+  type ConfidenceLevel,
+  DOCUMENTS_CHANNELS,
+  type DocumentsContract,
+  type ResumeField,
+  type SectionSummary,
+  type SourceSpan,
+  type StructuredResume,
+} from './documents.js';
 export { GEOCODE_CHANNELS, type GeocodeContract } from './geocode.js';
 export { JOB_PREFERENCES_CHANNELS, type JobPreferencesContract } from './jobPreferences.js';
 export { JOBS_CHANNELS, type JobsContract } from './jobs.js';


### PR DESCRIPTION
## Phase 6 — structured extraction + new formats + review

The deterministic, fully-testable backbone of Phase 6. **OCR stays in the
renderer** (Tesseract.js — already wired in `ocr.ts` + `use-import-with-ocr`; the
plan's "unwired" note was stale), so Rust extraction is text-only.

> **Why not leptess?** Evaluated and declined: it binds native
> Leptonica/Tesseract via bindgen, which aren't present here or on the bare
> `ubuntu-latest` cargo runner — it wouldn't compile, blocking *all* Rust gates —
> and it duplicates the working TS OCR.

### Extraction registry
`match ext{}` → `trait Extractor` + registry. Adding a format is one entry plus a
module. pdf/docx/plain refactored into impls; image/legacy-doc keep returning the
errors the renderer OCR fallback relies on.

### New formats
- **HTML** — drop script/style/head, `<a href>` → `[label](url)` (+ link
  collection), block tags → line breaks, entity decode.
- **RTF** — control-word state machine: skips non-content destinations
  (font/color/style tables, pictures, info), maps par/line/tab/`\uN`/`\'xx`,
  recovers `HYPERLINK` field targets.

### Layout-aware cleanup
Strip Unicode **Private Use Area** + icon-font glyphs, the replacement char, and
control chars from extracted PDF/DOCX text (`extraction::clean`); `normalize_unicode`
extended to drop PUA on the render side too.

### Structured extraction
`extraction::structured` turns flat text into a typed **`StructuredResume`**:
name / email / phone / location / links + a section inventory, each with a
`Confidence` and the **byte span** it was found at, plus `reviewRequired` +
warnings. Never drops content. `build_model` reconciles the typed contact fields
into a `DocumentModel` (deterministic contact wins) — implemented + tested, wired
into export as a follow-up.

### Surfacing (IPC + UI)
- `documents_import` returns the structured `review`; shared contract mirrors
  `StructuredResume` / `ResumeField` / `SectionSummary` (optional, backward-compatible).
- New **`ResumeReviewPanel`** — detected fields with per-field confidence badges,
  links, sections, warnings — shown from `ResumeInputCard` when `reviewRequired`.
  HTML/RTF added to the upload accept list; en/de strings added.

### Verification
- **44** extraction tests (registry, HTML, RTF, PUA, structured pre-pass);
  broader Rust suite **204** passed; **128** renderer tests passed.
- `clippy -D warnings` clean (both feature configs), `typecheck`, `gen:ipc:check`,
  `lint:strict` all clean.

### Deferred (follow-ups)
Live AI JSON structuring stage (not CI-verifiable), exporting from `build_model`,
and adopting the review panel in the onboarding/settings import surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)