### PR TITLE
feat: recommend a template and locale from the job ad and resume signals (phase 7)

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/src/commands/documents.rs
+++ b/apps/tauri/src-tauri/src/commands/documents.rs
@@ -69,6 +69,13 @@ pub async fn documents_import(app: AppHandle, req: DocumentsImportRequest) -> Va
     }
 }
 
+/// Recommend a template + locale from the metadata signals (job title,
+/// seniority, top requirements, languages). Rules-based; always overridable.
+#[tauri::command]
+pub fn documents_recommend_template(req: crate::recommend::RecommendSignals) -> Value {
+    serde_json::to_value(crate::recommend::recommend(&req)).unwrap_or(json!(null))
+}
+
 #[tauri::command]
 pub async fn documents_remove(app: AppHandle, id: String) -> Value {
     let store = app.state::<crate::documents::DocumentStore>();

--- a/apps/tauri/src-tauri/src/locale/mod.rs
+++ b/apps/tauri/src-tauri/src/locale/mod.rs
@@ -90,23 +90,79 @@ const DEFAULT_ORDER: &[SectionId] = &[
     SectionId::Awards,
 ];
 
+/// US résumés lead with experience and skills; education trails.
+const US_ORDER: &[SectionId] = &[
+    SectionId::Summary,
+    SectionId::Experience,
+    SectionId::Skills,
+    SectionId::Projects,
+    SectionId::Education,
+    SectionId::Certifications,
+    SectionId::Awards,
+    SectionId::Languages,
+];
+
+/// UK/EU CVs give education more prominence (right after experience).
+const EDUCATION_FORWARD_ORDER: &[SectionId] = &[
+    SectionId::Summary,
+    SectionId::Experience,
+    SectionId::Education,
+    SectionId::Skills,
+    SectionId::Languages,
+    SectionId::Certifications,
+    SectionId::Projects,
+    SectionId::Awards,
+];
+
 impl LocaleProfile {
     /// Page geometry for this profile.
     pub fn page_geometry(&self) -> PageGeometry {
         self.page_size.geometry()
     }
 
-    /// Resolve a profile by market id. Phase 1 only ships the `en` default;
-    /// unknown ids fall back to it. Phase 7 populates the other markets.
+    /// Resolve a profile by market id (case-insensitive; accepts country codes,
+    /// `en-US`-style tags, and family names). Unknown ids fall back to the
+    /// international default, so a new/unsupported market always works.
     pub fn get(id: &str) -> LocaleProfile {
-        match id {
-            "en" => Self::en(),
-            _ => Self::en(),
+        let key = id.trim().to_lowercase();
+        // Match on the leading region/country token (`de-at` → `de`, `en_us` → `en`).
+        let region = key
+            .split(['-', '_'])
+            .next_back()
+            .filter(|s| s.len() == 2)
+            .unwrap_or(key.as_str());
+        match region {
+            "us" => Self::us(),
+            "uk" | "gb" => Self::uk(),
+            "de" | "at" | "ch" | "dach" => Self::dach(),
+            "fr" => Self::fr(),
+            "nl" => Self::nl(),
+            "eu" => Self::eu(),
+            _ => Self::intl(),
         }
     }
 
+    /// Every supported market profile (for the recommender and UI pickers).
+    pub fn all() -> Vec<LocaleProfile> {
+        vec![
+            Self::us(),
+            Self::uk(),
+            Self::dach(),
+            Self::fr(),
+            Self::nl(),
+            Self::eu(),
+            Self::intl(),
+        ]
+    }
+
     /// English / international default: A4, no photo, no personal details.
+    /// Retained as the `Default` and the backward-compatible `en` profile.
     pub fn en() -> LocaleProfile {
+        Self::intl()
+    }
+
+    /// International default — the safe, photo-free, A4 baseline.
+    pub fn intl() -> LocaleProfile {
         LocaleProfile {
             id: "en",
             page_size: PageSize::A4,
@@ -114,6 +170,78 @@ impl LocaleProfile {
             photo: PhotoPolicy::Never,
             include_personal_details: false,
             default_section_order: DEFAULT_ORDER,
+        }
+    }
+
+    /// United States — US Letter, no photo, no personal details.
+    pub fn us() -> LocaleProfile {
+        LocaleProfile {
+            id: "us",
+            page_size: PageSize::Letter,
+            date_style: DateStyle::MonthYear,
+            photo: PhotoPolicy::Never,
+            include_personal_details: false,
+            default_section_order: US_ORDER,
+        }
+    }
+
+    /// United Kingdom — A4, no photo, education-forward.
+    pub fn uk() -> LocaleProfile {
+        LocaleProfile {
+            id: "uk",
+            page_size: PageSize::A4,
+            date_style: DateStyle::MonthYear,
+            photo: PhotoPolicy::Never,
+            include_personal_details: false,
+            default_section_order: EDUCATION_FORWARD_ORDER,
+        }
+    }
+
+    /// DACH (DE/AT/CH) — A4, photo common, personal details customary.
+    pub fn dach() -> LocaleProfile {
+        LocaleProfile {
+            id: "dach",
+            page_size: PageSize::A4,
+            date_style: DateStyle::NumericSlash,
+            photo: PhotoPolicy::Common,
+            include_personal_details: true,
+            default_section_order: EDUCATION_FORWARD_ORDER,
+        }
+    }
+
+    /// France — A4, photo optional, personal details customary.
+    pub fn fr() -> LocaleProfile {
+        LocaleProfile {
+            id: "fr",
+            page_size: PageSize::A4,
+            date_style: DateStyle::NumericSlash,
+            photo: PhotoPolicy::Optional,
+            include_personal_details: true,
+            default_section_order: EDUCATION_FORWARD_ORDER,
+        }
+    }
+
+    /// Netherlands — A4, photo optional, no personal details.
+    pub fn nl() -> LocaleProfile {
+        LocaleProfile {
+            id: "nl",
+            page_size: PageSize::A4,
+            date_style: DateStyle::MonthYear,
+            photo: PhotoPolicy::Optional,
+            include_personal_details: false,
+            default_section_order: EDUCATION_FORWARD_ORDER,
+        }
+    }
+
+    /// Generic EU — A4, photo optional, education-forward.
+    pub fn eu() -> LocaleProfile {
+        LocaleProfile {
+            id: "eu",
+            page_size: PageSize::A4,
+            date_style: DateStyle::MonthYear,
+            photo: PhotoPolicy::Optional,
+            include_personal_details: false,
+            default_section_order: EDUCATION_FORWARD_ORDER,
         }
     }
 }
@@ -174,5 +302,49 @@ mod tests {
         let order = LocaleProfile::en().default_section_order;
         assert_eq!(order.first(), Some(&SectionId::Summary));
         assert_eq!(order.get(1), Some(&SectionId::Experience));
+    }
+
+    #[test]
+    fn us_is_letter_sized_without_photo() {
+        let us = LocaleProfile::get("us");
+        assert_eq!(us.page_size, PageSize::Letter);
+        assert_eq!(us.photo, PhotoPolicy::Never);
+        assert!(!us.include_personal_details);
+    }
+
+    #[test]
+    fn dach_uses_photo_and_personal_details() {
+        let de = LocaleProfile::get("de");
+        assert_eq!(de.id, "dach");
+        assert_eq!(de.page_size, PageSize::A4);
+        assert_eq!(de.photo, PhotoPolicy::Common);
+        assert!(de.include_personal_details);
+        // AT and CH resolve to the same DACH profile.
+        assert_eq!(LocaleProfile::get("at"), de);
+        assert_eq!(LocaleProfile::get("ch"), de);
+    }
+
+    #[test]
+    fn region_is_parsed_from_locale_tags_case_insensitively() {
+        assert_eq!(LocaleProfile::get("en-US"), LocaleProfile::us());
+        assert_eq!(LocaleProfile::get("de_AT"), LocaleProfile::dach());
+        assert_eq!(LocaleProfile::get("GB"), LocaleProfile::uk());
+    }
+
+    #[test]
+    fn all_markets_are_distinct_and_present() {
+        let all = LocaleProfile::all();
+        assert_eq!(all.len(), 7);
+        let ids: std::collections::HashSet<&str> = all.iter().map(|p| p.id).collect();
+        for id in ["us", "uk", "dach", "fr", "nl", "eu", "en"] {
+            assert!(ids.contains(id), "missing market {id}");
+        }
+    }
+
+    #[test]
+    fn non_us_markets_are_a4() {
+        for id in ["uk", "de", "fr", "nl", "eu", "intl"] {
+            assert_eq!(LocaleProfile::get(id).page_size, PageSize::A4, "{id} should be A4");
+        }
     }
 }

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -44,6 +44,7 @@ mod pipeline;
 mod platform;
 mod postings;
 mod profile_import;
+mod recommend;
 mod scraping;
 mod theme;
 mod updater;
@@ -270,6 +271,7 @@ fn main() {
             // documents
             commands::documents::documents_list,
             commands::documents::documents_import,
+            commands::documents::documents_recommend_template,
             commands::documents::documents_remove,
             commands::documents::documents_set_default,
             commands::documents::documents_embed_text,

--- a/apps/tauri/src-tauri/src/recommend/mod.rs
+++ b/apps/tauri/src-tauri/src/recommend/mod.rs
@@ -1,0 +1,193 @@
+//! Template + locale recommender.
+//!
+//! Maps the signals the TS metadata step already extracts (job title, candidate
+//! seniority, top requirements, resume/job-ad language) to a suggested template,
+//! locale, and whether to enable ATS mode — always with a plain-language
+//! rationale. Rules-first and deterministic (an AI tiebreak can layer on later);
+//! the recommendation is a suggestion the user can always override.
+
+use serde::{Deserialize, Serialize};
+
+use crate::export::types::TemplateId;
+
+/// Inputs to the recommender — mirrors the TS `GenerationMeta` signals.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecommendSignals {
+    pub job_title: Option<String>,
+    /// `junior | mid | senior | lead | executive`
+    pub candidate_seniority: Option<String>,
+    #[serde(default)]
+    pub top_requirements: Vec<String>,
+    pub resume_language: Option<String>,
+    pub job_ad_language: Option<String>,
+    /// The job ad's target country/market (`us`, `de`, `gb`, …), when known —
+    /// e.g. from the posting's location. Takes priority over language for the
+    /// locale, since `en` alone can't tell the US (Letter) from the UK (A4).
+    pub target_country: Option<String>,
+}
+
+/// A template + locale suggestion with a printed reason.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Recommendation {
+    pub template_id: TemplateId,
+    /// Locale/market id resolvable by [`crate::locale::LocaleProfile::get`].
+    pub locale: String,
+    /// Whether to suggest ATS (single-column) mode.
+    pub ats_suggested: bool,
+    pub rationale: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Field {
+    Academia,
+    Conservative,
+    Design,
+    Software,
+    General,
+}
+
+/// Recommend a template + locale from the metadata signals.
+pub fn recommend(signals: &RecommendSignals) -> Recommendation {
+    let haystack = haystack(signals);
+    let field = detect_field(&haystack);
+    let seniority = signals.candidate_seniority.as_deref().unwrap_or("").to_lowercase();
+    let senior_exec = matches!(seniority.as_str(), "executive" | "lead");
+
+    let (template_id, reason) = pick_template(field, senior_exec, &haystack);
+
+    let ats_suggested = matches!(field, Field::Conservative)
+        || haystack.contains("applicant tracking")
+        || haystack.contains(" ats")
+        || haystack.starts_with("ats");
+
+    let locale = pick_locale(signals);
+
+    let mut rationale = reason.to_string();
+    if ats_suggested {
+        rationale.push_str(" ATS mode suggested (single column) for reliable parsing.");
+    }
+    if locale != "en" {
+        rationale.push_str(&format!(" Locale set to {} from the target market.", locale));
+    }
+
+    Recommendation { template_id, locale, ats_suggested, rationale }
+}
+
+fn haystack(signals: &RecommendSignals) -> String {
+    let mut s = signals.job_title.clone().unwrap_or_default();
+    s.push(' ');
+    s.push_str(&signals.top_requirements.join(" "));
+    s.to_lowercase()
+}
+
+fn detect_field(h: &str) -> Field {
+    let has = |kws: &[&str]| kws.iter().any(|k| h.contains(k));
+
+    if has(&[
+        "professor", "researcher", "phd", "postdoc", "post-doc", "lecturer", "academic",
+        "dissertation", "research scientist",
+    ]) {
+        Field::Academia
+    } else if has(&[
+        "lawyer", "attorney", "legal", "paralegal", "accountant", "auditor", "finance",
+        "financial", "compliance", "banker", "investment", "actuary", "government",
+        "public sector", "policy analyst", "tax ",
+    ]) {
+        Field::Conservative
+    } else if has(&[
+        "designer", "ux", "ui ", "ux/ui", "creative", "art director", "brand", "graphic",
+        "illustrator", "motion design", "product design",
+    ]) {
+        Field::Design
+    } else if has(&[
+        "engineer", "developer", "software", "programmer", "data scientist", "data engineer",
+        "devops", "sre", "backend", "frontend", "full stack", "fullstack", "machine learning",
+        "cloud", "architect",
+    ]) {
+        Field::Software
+    } else {
+        Field::General
+    }
+}
+
+fn pick_template(field: Field, senior_exec: bool, h: &str) -> (TemplateId, &'static str) {
+    match field {
+        Field::Academia => (
+            TemplateId::Academic,
+            "Academic / research role → Academic template.",
+        ),
+        Field::Conservative => (
+            TemplateId::Classic,
+            "Conservative field (finance / legal / public sector) → Classic single-column.",
+        ),
+        Field::Design => {
+            if senior_exec {
+                (TemplateId::RefinedExecutive, "Senior design leadership → Refined Executive.")
+            } else {
+                (TemplateId::TwoColumn, "Design role → Two-Column visual template.")
+            }
+        }
+        Field::Software => {
+            if senior_exec {
+                (TemplateId::RefinedExecutive, "Senior engineering leadership → Refined Executive.")
+            } else if is_systems_role(h) {
+                (TemplateId::MonoTechnical, "Systems / low-level role → Mono Technical.")
+            } else {
+                (TemplateId::Modern, "Software / engineering role → Modern template.")
+            }
+        }
+        Field::General => {
+            if senior_exec {
+                (TemplateId::RefinedExecutive, "Senior leadership → Refined Executive.")
+            } else {
+                (TemplateId::Modern, "General role → Modern template.")
+            }
+        }
+    }
+}
+
+fn is_systems_role(h: &str) -> bool {
+    ["embedded", "kernel", "firmware", "compiler", "low-level", "systems programming", "rust", "c++"]
+        .iter()
+        .any(|k| h.contains(k))
+}
+
+fn pick_locale(signals: &RecommendSignals) -> String {
+    // An explicit target country/market wins — resolved through the locale
+    // registry so there's a single source of truth (e.g. `gb` → `uk`).
+    if let Some(country) = signals.target_country.as_deref().map(str::trim).filter(|s| !s.is_empty())
+    {
+        return crate::locale::LocaleProfile::get(country).id.to_string();
+    }
+
+    // Otherwise derive from the job-ad language (preferred) or resume language.
+    let tag = signals
+        .job_ad_language
+        .as_deref()
+        .or(signals.resume_language.as_deref())
+        .unwrap_or("en")
+        .to_lowercase();
+    let mut parts = tag.split(['-', '_']);
+    let lang = parts.next().unwrap_or("en");
+
+    // A region subtag resolves directly (`en-US` → us, `en-GB` → uk).
+    if let Some(region) = parts.next() {
+        let profile = crate::locale::LocaleProfile::get(region);
+        if profile.id != "en" {
+            return profile.id.to_string();
+        }
+    }
+
+    match lang {
+        "de" => "dach",
+        "fr" => "fr",
+        "nl" => "nl",
+        _ => "en",
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/tauri/src-tauri/src/recommend/tests.rs
+++ b/apps/tauri/src-tauri/src/recommend/tests.rs
@@ -1,0 +1,110 @@
+use super::*;
+
+fn signals(title: &str, seniority: &str, reqs: &[&str]) -> RecommendSignals {
+    RecommendSignals {
+        job_title: Some(title.to_string()),
+        candidate_seniority: Some(seniority.to_string()),
+        top_requirements: reqs.iter().map(|s| s.to_string()).collect(),
+        resume_language: None,
+        job_ad_language: None,
+        target_country: None,
+    }
+}
+
+#[test]
+fn software_role_gets_modern() {
+    let r = recommend(&signals("Frontend Engineer", "mid", &["React", "TypeScript"]));
+    assert_eq!(r.template_id, TemplateId::Modern);
+    assert!(!r.ats_suggested);
+}
+
+#[test]
+fn systems_role_gets_mono_technical() {
+    let r = recommend(&signals("Embedded Software Engineer", "mid", &["C++", "firmware"]));
+    assert_eq!(r.template_id, TemplateId::MonoTechnical);
+}
+
+#[test]
+fn conservative_field_gets_classic_and_suggests_ats() {
+    let r = recommend(&signals("Compliance Auditor", "senior", &["finance", "SOX"]));
+    assert_eq!(r.template_id, TemplateId::Classic);
+    assert!(r.ats_suggested, "conservative fields should suggest ATS mode");
+}
+
+#[test]
+fn academia_gets_academic() {
+    let r = recommend(&signals("Postdoctoral Researcher", "mid", &["PhD", "publications"]));
+    assert_eq!(r.template_id, TemplateId::Academic);
+}
+
+#[test]
+fn design_role_gets_two_column() {
+    let r = recommend(&signals("Product Designer", "mid", &["Figma", "UX"]));
+    assert_eq!(r.template_id, TemplateId::TwoColumn);
+}
+
+#[test]
+fn executive_overrides_to_refined_executive() {
+    let r = recommend(&signals("VP of Engineering", "executive", &["leadership", "strategy"]));
+    assert_eq!(r.template_id, TemplateId::RefinedExecutive);
+}
+
+#[test]
+fn conservative_executive_stays_classic() {
+    // A conservative field outranks seniority — a finance exec still reads best
+    // as a clean single column.
+    let r = recommend(&signals("Chief Financial Officer", "executive", &["finance", "audit"]));
+    assert_eq!(r.template_id, TemplateId::Classic);
+    assert!(r.ats_suggested);
+}
+
+#[test]
+fn explicit_ats_mention_suggests_ats() {
+    let r = recommend(&signals("Software Engineer", "mid", &["must pass ATS screening"]));
+    assert!(r.ats_suggested);
+}
+
+#[test]
+fn locale_follows_job_ad_language() {
+    let mut s = signals("Softwareentwickler", "mid", &["Java"]);
+    s.job_ad_language = Some("de".to_string());
+    let r = recommend(&s);
+    assert_eq!(r.locale, "dach");
+    assert!(r.rationale.contains("dach"));
+}
+
+#[test]
+fn locale_defaults_to_international_english() {
+    let r = recommend(&signals("Software Engineer", "mid", &["Go"]));
+    assert_eq!(r.locale, "en");
+}
+
+#[test]
+fn target_country_wins_over_language() {
+    // A US posting written in English → US (Letter), not the international default.
+    let mut s = signals("Software Engineer", "mid", &["Go"]);
+    s.job_ad_language = Some("en".to_string());
+    s.target_country = Some("us".to_string());
+    assert_eq!(recommend(&s).locale, "us");
+
+    // `gb` resolves to the UK market through the locale registry.
+    s.target_country = Some("gb".to_string());
+    assert_eq!(recommend(&s).locale, "uk");
+}
+
+#[test]
+fn region_subtag_resolves_us_vs_uk() {
+    let mut s = signals("Software Engineer", "mid", &["Go"]);
+    s.job_ad_language = Some("en-US".to_string());
+    assert_eq!(recommend(&s).locale, "us");
+
+    s.job_ad_language = Some("en-GB".to_string());
+    assert_eq!(recommend(&s).locale, "uk");
+}
+
+#[test]
+fn rationale_is_always_present() {
+    let r = recommend(&RecommendSignals::default());
+    assert!(!r.rationale.is_empty());
+    assert_eq!(r.template_id, TemplateId::Modern); // empty → general default
+}

--- a/apps/tauri/src/renderer/features/ai-generate/components/LeftPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/LeftPanel/index.tsx
@@ -6,6 +6,7 @@ import { ResumeInputCard } from '@/components/resume/ResumeInputCard';
 import { ModelSelector } from '@/components/ui/ModelSelector';
 import { GenerationConfig } from '@/features/ai-generate/components/GenerationConfig';
 import { GenerationMetadata } from '@/features/ai-generate/components/GenerationMetadata';
+import { TemplateRecommendation } from '@/features/ai-generate/components/TemplateRecommendation';
 import type { GenerationMeta, GenerationMode, TemplateId } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
 
@@ -132,6 +133,17 @@ export function LeftPanel({
 
       {/* Detected metadata — shown after extraction */}
       <GenerationMetadata meta={meta} />
+
+      {/* Template + locale suggestion from the detected metadata */}
+      <TemplateRecommendation
+        meta={meta}
+        templateId={templateId}
+        onApply={(id, atsSuggested) => {
+          setTemplateId(id);
+          if (atsSuggested && id === 'two-column') setAtsMode(true);
+          else if (id !== 'two-column') setAtsMode(false);
+        }}
+      />
 
       {/* Config — target + mode */}
       <GenerationConfig

--- a/apps/tauri/src/renderer/features/ai-generate/components/TemplateRecommendation/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/TemplateRecommendation/index.tsx
@@ -1,0 +1,76 @@
+import { Check, Sparkles } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import type { TemplateRecommendation as Recommendation } from '@ajh/shared';
+import { Button } from '@ajh/ui';
+
+import type { GenerationMeta, TemplateId } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+import { useRecommendTemplate } from '@/services';
+
+interface Props {
+  meta: GenerationMeta | null;
+  templateId: TemplateId;
+  onApply: (templateId: TemplateId, atsSuggested: boolean) => void;
+}
+
+/**
+ * Shows the rules-based template suggestion once generation metadata is known
+ * (job title, requirements, languages). Purely advisory — the user applies it
+ * with one click or ignores it. The recommended locale is derived from the job
+ * ad's language/country and printed in the rationale.
+ */
+export function TemplateRecommendation({ meta, templateId, onApply }: Props) {
+  const { t } = useTranslation();
+  const { mutate } = useRecommendTemplate();
+  const [rec, setRec] = useState<Recommendation | null>(null);
+
+  useEffect(() => {
+    const hasSignals = Boolean(meta?.jobTitle) || (meta?.topRequirements?.length ?? 0) > 0;
+    if (!hasSignals) {
+      setRec(null);
+      return;
+    }
+    mutate(
+      {
+        jobTitle: meta?.jobTitle,
+        topRequirements: meta?.topRequirements,
+        resumeLanguage: meta?.resumeLanguage,
+        jobAdLanguage: meta?.jobAdLanguage,
+      },
+      { onSuccess: setRec }
+    );
+  }, [meta, mutate]);
+
+  if (!rec) return null;
+
+  const isCurrent = rec.templateId === templateId;
+
+  return (
+    <div className="mx-6 mb-3 rounded-lg border border-brand/20 bg-brand/5 px-3 py-2.5">
+      <div className="flex items-start gap-2">
+        <Sparkles size={13} className="mt-0.5 shrink-0 text-brand-soft" />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <p className="text-[11px] font-medium text-foreground/80">
+            {t('aiGenerate.recommendationTitle')}
+          </p>
+          <p className="text-xs text-foreground/55">{rec.rationale}</p>
+          {isCurrent ? (
+            <span className="flex items-center gap-1 text-[11px] text-emerald-400">
+              <Check size={11} /> {t('aiGenerate.recommendationApplied')}
+            </span>
+          ) : (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 px-2 text-[11px] text-brand-soft hover:text-brand"
+              onClick={() => onApply(rec.templateId, rec.atsSuggested)}
+            >
+              {t('aiGenerate.applyRecommendation')}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -395,6 +395,9 @@
   "aiGenerate": {
     "title": "KI-Generierung",
     "subtitle": "Laden Sie Ihren Lebenslauf und die Stellenanzeige hoch, um maßgeschneiderte, ATS-optimierte Dokumente zu erstellen.",
+    "recommendationTitle": "Empfohlene Vorlage",
+    "applyRecommendation": "Vorschlag übernehmen",
+    "recommendationApplied": "Übernommen",
     "resumeLabel": "Lebenslauf",
     "jobAdLabel": "Stellenanzeige",
     "detectedContext": "Erkannter Kontext",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -395,6 +395,9 @@
   "aiGenerate": {
     "title": "AI Generate",
     "subtitle": "Upload your resume and target job ad to generate tailored, ATS-optimized documents.",
+    "recommendationTitle": "Suggested template",
+    "applyRecommendation": "Apply suggestion",
+    "recommendationApplied": "Applied",
     "resumeLabel": "Resume",
     "jobAdLabel": "Job Advertisement",
     "detectedContext": "Detected Context",

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -84,6 +84,12 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
     documents: {
       list: emptyList,
       import: noop,
+      recommendTemplate: async () => ({
+        templateId: 'modern',
+        locale: 'en',
+        atsSuggested: false,
+        rationale: 'Mock recommendation.',
+      }),
       remove: noop,
       setDefault: noop,
       exportDocument: async () => ({ data: [], mimeType: 'text/plain', filename: 'mock.txt' }),

--- a/apps/tauri/src/renderer/services/use-documents/use-documents.ts
+++ b/apps/tauri/src/renderer/services/use-documents/use-documents.ts
@@ -1,6 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { DocumentImportRequest, ResumeExtractTextRequest } from '@ajh/shared';
+import type {
+  DocumentImportRequest,
+  ResumeExtractTextRequest,
+  TemplateRecommendation,
+  TemplateRecommendSignals,
+} from '@ajh/shared';
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
@@ -42,5 +47,12 @@ export const useExtractText = () => {
   const api = useAppClient();
   return useMutation({
     mutationFn: (req: ResumeExtractTextRequest) => api.resume.extractText(req),
+  });
+};
+
+export const useRecommendTemplate = () => {
+  const api = useAppClient();
+  return useMutation<TemplateRecommendation, Error, TemplateRecommendSignals>({
+    mutationFn: (req: TemplateRecommendSignals) => api.documents.recommendTemplate(req),
   });
 };

--- a/apps/tauri/src/tauri-client/namespaces/documents/documents.ts
+++ b/apps/tauri/src/tauri-client/namespaces/documents/documents.ts
@@ -5,6 +5,7 @@ import type { DocumentImportRequest } from '@ajh/shared/schemas';
 export const documents = {
   list: () => invoke('documents_list'),
   import: (req: DocumentImportRequest) => invoke('documents_import', { req }),
+  recommendTemplate: (req: unknown) => invoke('documents_recommend_template', { req }),
   remove: (id: string) => invoke('documents_remove', { id }),
   setDefault: (id: string) => invoke('documents_set_default', { id }),
   exportDocument: (request: unknown) => invoke('documents_export_document', { request }),

--- a/packages/shared/src/ipc/contracts/documents.ts
+++ b/packages/shared/src/ipc/contracts/documents.ts
@@ -113,12 +113,36 @@ export interface StructuredResume {
   warnings: string[];
 }
 
+/** Signals the recommender reads — a subset of the generation metadata. */
+export interface TemplateRecommendSignals {
+  jobTitle?: string;
+  /** `junior | mid | senior | lead | executive` */
+  candidateSeniority?: string;
+  topRequirements?: string[];
+  resumeLanguage?: string;
+  jobAdLanguage?: string;
+  /** Job ad's target country/market (`us`, `de`, `gb`, …); wins over language. */
+  targetCountry?: string;
+}
+
+/** A template + locale suggestion with a printed reason. Always overridable. */
+export interface TemplateRecommendation {
+  templateId: TemplateId;
+  /** Market id (`us`, `dach`, `en`, …). */
+  locale: string;
+  atsSuggested: boolean;
+  rationale: string;
+}
+
 export interface DocumentsContract {
   list(): Promise<DocumentRecord[]>;
 
   import(
     req: DocumentImportRequest
   ): Promise<{ id: string; success: boolean; review?: StructuredResume }>;
+
+  /** Suggest a template + locale from the generation metadata signals. */
+  recommendTemplate(req: TemplateRecommendSignals): Promise<TemplateRecommendation>;
 
   remove(id: string): Promise<void>;
 
@@ -134,6 +158,7 @@ export interface DocumentsContract {
 export const DOCUMENTS_CHANNELS = {
   list: 'documents:list',
   import: 'documents:import',
+  recommendTemplate: 'documents:recommend_template',
   remove: 'documents:remove',
   exportDocument: 'documents:export_document',
   exportAndSave: 'documents:export_and_save',

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -142,6 +142,8 @@ export {
   type SectionSummary,
   type SourceSpan,
   type StructuredResume,
+  type TemplateRecommendation,
+  type TemplateRecommendSignals,
 } from './documents.js';
 export { GEOCODE_CHANNELS, type GeocodeContract } from './geocode.js';
 export { JOB_PREFERENCES_CHANNELS, type JobPreferencesContract } from './jobPreferences.js';


### PR DESCRIPTION
## Phase 7 — intelligence: locale profiles + recommender

A rules-based template + locale recommender and the populated locale registry it
reads — both in **Rust** (one source of truth, consistent with the export/model
engine), exposed over IPC and surfaced in the generate UI.

> **Recommender location** (the plan's open decision): kept in Rust per the
> centralized-architecture preference — it reads the locale registry directly (no
> duplication) and the TS signals are passed in via one IPC call.

### Locale registry (`locale`)
Populated the markets the plan calls for — **US** (Letter), **UK**, **DACH**
(DE/AT/CH), **FR**, **NL**, generic **EU**, **international** — each with page
size, date style, photo policy, personal-details policy, and a default section
order. `get` resolves country codes and `en-US`-style tags case-insensitively and
always falls back to the international default. Photo / personal details stay
**user-supplied only** — never inferred.

### Recommender (`recommend`)
Maps the metadata signals (job title, seniority, top requirements, languages) to
`{ templateId, locale, atsSuggested, rationale }`:

| Field | Template |
|---|---|
| Academia / research | Academic |
| Finance / legal / public sector | Classic + **ATS suggested** |
| Design | Two-Column |
| Software | Modern (Mono for systems roles) |
| Senior leadership | Refined Executive (conservative fields outrank seniority) |

**Locale is derived from the job ad** (your question): an explicit target country
wins (resolved through the registry, `gb` → uk), then a region subtag (`en-US` →
us / Letter, `en-GB` → uk), then the language (de → DACH, fr, nl). Plain `en`
stays international because language alone can't tell US from UK.

### Surfacing
- New `documents_recommend_template` command; shared contract mirrors
  `TemplateRecommendSignals` / `TemplateRecommendation`.
- A `TemplateRecommendation` banner in the generate panel shows the suggestion +
  rationale once metadata is known and applies the template (and ATS mode) in one
  click. en/de strings added.

### Verification
- **23** Rust tests (locale markets/page-sizes/photo-PII/tag-parsing; recommender
  field choice, seniority override, ATS, job-ad locale/country/region).
- clippy `-D warnings`, typecheck, gen:ipc:check, lint:strict, **128** renderer
  tests — all clean.

### Deferred (the "afterwards" bucket)
Threading the recommended locale's page size into export, locale conventions into
the AI prompt, wiring `build_model`, and the live AI structuring stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)