### PR TITLE
feat: drive export page size from the recommended locale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,7 @@ No `// eslint-disable`, no `@ts-ignore`. Add scoped overrides to `eslint.config.
 | Architecture principles | `docs/PATTERNS.md` §13                                                          |
 | Architecture status     | `docs/ARCHITECTURE_STATUS.md`                                                   |
 | Architecture (general)  | `docs/ARCHITECTURE.md`                                                          |
+| Export templates        | `docs/EXPORT_TEMPLATES.md` (9-template + backend contract)                      |
 | Patterns                | `docs/PATTERNS.md`                                                              |
 | Design system           | `docs/DESIGN_SYSTEM.md`                                                         |
 | Dev setup               | `docs/DEVELOPMENT.md`                                                           |

--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/src/export/commands/test.rs
+++ b/apps/tauri/src-tauri/src/export/commands/test.rs
@@ -23,6 +23,7 @@ fn test_generate_filename() {
             target_language: None,
         }),
         ats_mode: false,
+        locale: None,
     };
 
     let filename = generate_filename(&request, "docx");

--- a/apps/tauri/src-tauri/src/export/docx/mod.rs
+++ b/apps/tauri/src-tauri/src/export/docx/mod.rs
@@ -300,11 +300,12 @@ pub fn generate_docx(request: &ExportRequest) -> Result<Vec<u8>> {
             // by default; `--no-default-features` falls back to the legacy renderer.
             // Both arms compile via `cfg!` so neither path rots.
             if cfg!(feature = "model_docx") {
-                crate::export::model_docx::generate_resume_docx(
+                crate::export::model_docx::generate_resume_docx_in(
                     text,
                     request.meta.as_ref(),
                     &template,
                     request.ats_mode,
+                    request.page_geometry(),
                 )
                 .context("Failed to generate resume DOCX")?
             } else {

--- a/apps/tauri/src-tauri/src/export/docx/test.rs
+++ b/apps/tauri/src-tauri/src/export/docx/test.rs
@@ -24,6 +24,7 @@ fn resume_request(template_id: TemplateId) -> ExportRequest {
         template_id,
         meta: None,
         ats_mode: false,
+        locale: None,
     }
 }
 
@@ -39,6 +40,22 @@ fn resume_docx_declares_a4_page_size() {
 }
 
 #[test]
+fn us_locale_drives_letter_page_size() {
+    let mut request = resume_request(TemplateId::Modern);
+    request.locale = Some("us".to_string());
+    let xml = document_xml(&generate_docx(&request).expect("docx"));
+    // US Letter in dxa (12240 × 15840), not the A4 default.
+    assert!(
+        xml.contains(r#"w:w="12240""#) && xml.contains(r#"w:h="15840""#),
+        "US locale should yield a Letter page size"
+    );
+
+    // No locale → international A4.
+    let a4 = document_xml(&generate_docx(&resume_request(TemplateId::Modern)).expect("docx"));
+    assert!(a4.contains(r#"w:w="11906""#), "default stays A4");
+}
+
+#[test]
 fn cover_letter_docx_declares_a4_page_size() {
     let request = ExportRequest {
         text: "Dear Hiring Manager,\n\nI am writing to apply.\n\nSincerely,\nJane Doe".to_string(),
@@ -47,6 +64,7 @@ fn cover_letter_docx_declares_a4_page_size() {
         template_id: TemplateId::Classic,
         meta: None,
         ats_mode: false,
+        locale: None,
     };
     let bytes = generate_docx(&request).expect("docx");
     let xml = document_xml(&bytes);
@@ -100,6 +118,7 @@ fn test_generate_simple_resume() {
         template_id: TemplateId::Modern,
         meta: None,
         ats_mode: false,
+        locale: None,
     };
 
     let result = generate_docx(&request);
@@ -151,6 +170,7 @@ fn test_generate_cover_letter() {
         template_id: TemplateId::Classic,
         meta: None,
         ats_mode: false,
+        locale: None,
     };
 
     let result = generate_docx(&request);
@@ -172,6 +192,7 @@ fn test_generate_resume_with_meta() {
             target_language: None,
         }),
         ats_mode: false,
+        locale: None,
     };
 
     let result = generate_docx(&request);

--- a/apps/tauri/src-tauri/src/export/layout_pdf.rs
+++ b/apps/tauri/src-tauri/src/export/layout_pdf.rs
@@ -21,19 +21,39 @@ use crate::export::pdf_renderer::{
 use crate::export::templates::Template;
 use crate::export::types::GenerationMeta;
 use crate::layout::{layout_document, FillRect, LaidOutDoc, LinkRect, PlacedText, RuleLine};
-use crate::locale::LocaleProfile;
+use crate::locale::PageGeometry;
 use crate::measure::FontMetrics;
 use crate::model::adapter::model_from_resume_text;
 use crate::model::transform;
 
 const PT_PER_MM: f32 = 2.834_645_7;
 
-/// Render a resume to PDF bytes via the canonical layout engine.
+/// Render a resume to PDF bytes via the canonical layout engine, on the default
+/// (international A4) page geometry. A test convenience — the export command uses
+/// [`generate_resume_pdf_in`] with the request's locale geometry.
+#[cfg(test)]
 pub(crate) fn generate_resume_pdf(
     text: &str,
     meta: Option<&GenerationMeta>,
     template: &Template,
     ats_mode: bool,
+) -> Result<Vec<u8>> {
+    generate_resume_pdf_in(
+        text,
+        meta,
+        template,
+        ats_mode,
+        crate::locale::LocaleProfile::default().page_geometry(),
+    )
+}
+
+/// Render a resume to PDF bytes on a specific page geometry (locale-driven).
+pub(crate) fn generate_resume_pdf_in(
+    text: &str,
+    meta: Option<&GenerationMeta>,
+    template: &Template,
+    ats_mode: bool,
+    geom: PageGeometry,
 ) -> Result<Vec<u8>> {
     let mut model = model_from_resume_text(text);
 
@@ -57,10 +77,6 @@ pub(crate) fn generate_resume_pdf(
         transform::linearize(&mut model);
     }
 
-    // Page geometry from the active locale profile (defaults to A4), the same
-    // source the legacy renderer and DOCX read. Per-request locale sizing arrives
-    // in a later phase.
-    let geom = LocaleProfile::default().page_geometry();
     let laid = layout_document(&model, &effective_template, geom, &FontMetrics);
     emit_pdf(&laid)
 }

--- a/apps/tauri/src-tauri/src/export/model_docx.rs
+++ b/apps/tauri/src-tauri/src/export/model_docx.rs
@@ -21,7 +21,7 @@ use crate::export::docx_renderer::{
 };
 use crate::export::templates::Template;
 use crate::export::types::{FontFamily, GenerationMeta};
-use crate::locale::LocaleProfile;
+use crate::locale::PageGeometry;
 use crate::model::adapter::model_from_resume_text;
 use crate::model::document::{Block, DocumentModel, EntryBlock, HeaderBlock, Placement, Section};
 use crate::model::rich::RichText;
@@ -39,12 +39,32 @@ struct Ctx<'a> {
     right_align_date: bool,
 }
 
-/// Render a resume to a `Docx` via the canonical document model.
+/// Render a resume to a `Docx` via the canonical document model, on the default
+/// (international A4) page geometry. A test convenience — the export command uses
+/// [`generate_resume_docx_in`] with the request's locale geometry.
+#[cfg(test)]
 pub(crate) fn generate_resume_docx(
     text: &str,
     meta: Option<&GenerationMeta>,
     template: &Template,
     ats_mode: bool,
+) -> Result<Docx> {
+    generate_resume_docx_in(
+        text,
+        meta,
+        template,
+        ats_mode,
+        crate::locale::LocaleProfile::default().page_geometry(),
+    )
+}
+
+/// Render a resume to a `Docx` on a specific page geometry (locale-driven).
+pub(crate) fn generate_resume_docx_in(
+    text: &str,
+    meta: Option<&GenerationMeta>,
+    template: &Template,
+    ats_mode: bool,
+    geom: PageGeometry,
 ) -> Result<Docx> {
     let mut model = model_from_resume_text(text);
 
@@ -68,13 +88,13 @@ pub(crate) fn generate_resume_docx(
     docx = add_header(docx, &model.header, template, &colors);
 
     if two_column {
-        docx = add_two_column_body(docx, &model, template, &colors);
+        docx = add_two_column_body(docx, &model, template, &colors, geom);
     } else {
         let ctx = Ctx {
             template,
             colors: &colors,
             link: theme::link_style(template.id),
-            width_dxa: content_width_dxa(template),
+            width_dxa: content_width_dxa(template, geom),
             right_align_date: true,
         };
         for section in &model.sections {
@@ -84,7 +104,6 @@ pub(crate) fn generate_resume_docx(
         }
     }
 
-    let geom = LocaleProfile::default().page_geometry();
     let page_margin = PageMargin::new()
         .top(inch_to_dxa(0.9))
         .bottom(inch_to_dxa(0.9))
@@ -98,9 +117,8 @@ pub(crate) fn generate_resume_docx(
     Ok(docx)
 }
 
-/// Printable width (page minus both margins) in dxa.
-fn content_width_dxa(template: &Template) -> usize {
-    let geom = LocaleProfile::default().page_geometry();
+/// Printable width (page minus both margins) in dxa for the given geometry.
+fn content_width_dxa(template: &Template, geom: PageGeometry) -> usize {
     let page = mm_to_dxa(geom.width_mm) as i64;
     let margin = inch_to_dxa(template.margin_in) as i64;
     (page - 2 * margin).max(1) as usize
@@ -158,13 +176,14 @@ fn add_two_column_body(
     model: &DocumentModel,
     template: &Template,
     colors: &DocxColors,
+    geom: PageGeometry,
 ) -> Docx {
     let tc = template
         .two_column
         .as_ref()
         .expect("add_two_column_body requires a two-column config");
 
-    let content = content_width_dxa(template);
+    let content = content_width_dxa(template, geom);
     let sidebar_w = (content as f32 * tc.sidebar_width_ratio) as usize;
     let main_w = content.saturating_sub(sidebar_w).max(1);
 

--- a/apps/tauri/src-tauri/src/export/pdf/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/mod.rs
@@ -794,11 +794,12 @@ pub fn generate_pdf(request: &ExportRequest) -> Result<Vec<u8>> {
             // which also stays the parity reference. Both arms compile via `cfg!`
             // so neither path rots.
             let result = if cfg!(feature = "layout_pdf") {
-                super::layout_pdf::generate_resume_pdf(
+                super::layout_pdf::generate_resume_pdf_in(
                     text,
                     request.meta.as_ref(),
                     &template,
                     request.ats_mode,
+                    request.page_geometry(),
                 )
             } else {
                 generate_resume_pdf(text, request.meta.as_ref(), &template, request.ats_mode)

--- a/apps/tauri/src-tauri/src/export/pdf/test.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/test.rs
@@ -81,6 +81,7 @@ fn test_generate_pdf_resume_basic() {
         template_id: super::super::types::TemplateId::Classic,
         meta: None,
         ats_mode: false,
+        locale: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -95,6 +96,7 @@ fn test_generate_pdf_cover_letter_basic() {
         template_id: super::super::types::TemplateId::Modern,
         meta: None,
         ats_mode: false,
+        locale: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -114,6 +116,7 @@ fn test_generate_pdf_resume_with_meta() {
             target_language: None,
         }),
         ats_mode: false,
+        locale: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -129,6 +132,7 @@ fn test_generate_pdf_resume_with_section_markers() {
         template_id: super::super::types::TemplateId::Classic,
         meta: None,
         ats_mode: false,
+        locale: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -145,6 +149,7 @@ fn test_generate_pdf_cover_letter_with_section_markers() {
         template_id: super::super::types::TemplateId::Modern,
         meta: None,
         ats_mode: false,
+        locale: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -191,6 +196,7 @@ fn resume_pdf_embeds_contact_link_annotations() {
         template_id: super::super::types::TemplateId::Modern,
         meta: None,
         ats_mode: false,
+        locale: None,
     };
     let bytes = generate_pdf(&request).expect("resume pdf");
     let doc = lopdf::Document::load_mem(&bytes).expect("parse generated pdf");
@@ -218,6 +224,7 @@ fn centered_template_resume_pdf_is_generated() {
         template_id: super::super::types::TemplateId::Executive,
         meta: None,
         ats_mode: false,
+        locale: None,
     };
     let bytes = generate_pdf(&request).expect("executive resume pdf");
     assert!(

--- a/apps/tauri/src-tauri/src/export/types.rs
+++ b/apps/tauri/src-tauri/src/export/types.rs
@@ -70,6 +70,18 @@ pub struct ExportRequest {
     /// Defaults to false so existing frontends that omit it keep working.
     #[serde(default)]
     pub ats_mode: bool,
+    /// Target market id (`us`, `uk`, `de`, …) resolved by
+    /// [`crate::locale::LocaleProfile::get`]; drives the page size (US → Letter,
+    /// the rest → A4). Optional so frontends that omit it keep the A4 default.
+    #[serde(default)]
+    pub locale: Option<String>,
+}
+
+impl ExportRequest {
+    /// Page geometry for this request's locale (international A4 by default).
+    pub fn page_geometry(&self) -> crate::locale::PageGeometry {
+        crate::locale::LocaleProfile::get(self.locale.as_deref().unwrap_or("en")).page_geometry()
+    }
 }
 
 /// Export result (binary data)

--- a/apps/tauri/src-tauri/src/layout/tests.rs
+++ b/apps/tauri/src-tauri/src/layout/tests.rs
@@ -60,6 +60,17 @@ fn lays_out_a_single_page_with_the_name() {
 }
 
 #[test]
+fn letter_geometry_widens_the_page() {
+    // A US-locale export uses Letter geometry; the engine honors it.
+    let model = model_from_resume_text(SAMPLE);
+    let t = Template::get(TemplateId::Modern);
+    let doc = layout_document(&model, &t, PageSize::Letter.geometry(), &FontMetrics);
+    assert_eq!(doc.page_width_mm, 215.9);
+    assert_eq!(doc.page_height_mm, 279.4);
+    assert!(all_text(&doc).contains("Jane Doe"));
+}
+
+#[test]
 fn name_is_left_aligned_for_classic() {
     let doc = sample_doc(TemplateId::Classic);
     let t = Template::get(TemplateId::Classic);

--- a/apps/tauri/src-tauri/src/validate/tests.rs
+++ b/apps/tauri/src-tauri/src/validate/tests.rs
@@ -116,6 +116,7 @@ fn req(format: ExportFormat, template_id: TemplateId, ats_mode: bool) -> ExportR
         template_id,
         meta: None,
         ats_mode,
+        locale: None,
     }
 }
 

--- a/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
@@ -39,6 +39,7 @@ export function AIGeneratePage() {
     target,
     templateId,
     atsMode,
+    locale,
     resumeOut,
     coverOut,
     activeOut,
@@ -52,6 +53,7 @@ export function AIGeneratePage() {
   const setTarget = (v: GenTarget) => setAIGenerate({ target: v });
   const setTemplateId = (v: TemplateId) => setAIGenerate({ templateId: v });
   const setAtsMode = (v: boolean) => setAIGenerate({ atsMode: v });
+  const setLocale = (v: string) => setAIGenerate({ locale: v });
   const setResumeOut = (v: string | ((p: string) => string)) =>
     setAIGenerate({ resumeOut: typeof v === 'function' ? v(resumeOut) : v });
   const setCoverOut = (v: string | ((p: string) => string)) =>
@@ -162,10 +164,10 @@ export function AIGeneratePage() {
       fmt
     );
     if (fmt === 'pdf') {
-      await exportPDF(text, name, type, meta ?? undefined, templateId, atsMode);
+      await exportPDF(text, name, type, meta ?? undefined, templateId, atsMode, locale);
     }
     if (fmt === 'docx') {
-      await exportDOCX(text, name, type, meta ?? undefined, templateId, atsMode);
+      await exportDOCX(text, name, type, meta ?? undefined, templateId, atsMode, locale);
     }
     if (fmt === 'txt') {
       exportTXT(text, name);
@@ -198,6 +200,7 @@ export function AIGeneratePage() {
           setTarget={setTarget}
           setTemplateId={setTemplateId}
           setAtsMode={setAtsMode}
+          setLocale={setLocale}
           onUpload={handleUpload}
           onReset={reset}
           onAnalyze={handleAnalyze}

--- a/apps/tauri/src/renderer/features/ai-generate/components/LeftPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/LeftPanel/index.tsx
@@ -31,6 +31,7 @@ interface Props {
   setTarget: (v: 'resume' | 'cover' | 'both') => void;
   setTemplateId: (v: TemplateId) => void;
   setAtsMode: (v: boolean) => void;
+  setLocale: (v: string) => void;
   onUpload: (target: 'resume' | 'jobAd', file: File) => Promise<void>;
   onReset: () => void;
   onAnalyze: () => void;
@@ -59,6 +60,7 @@ export function LeftPanel({
   setTarget,
   setTemplateId,
   setAtsMode,
+  setLocale,
   onUpload,
   onReset,
   onAnalyze,
@@ -138,8 +140,9 @@ export function LeftPanel({
       <TemplateRecommendation
         meta={meta}
         templateId={templateId}
-        onApply={(id, atsSuggested) => {
+        onApply={(id, atsSuggested, recommendedLocale) => {
           setTemplateId(id);
+          setLocale(recommendedLocale);
           if (atsSuggested && id === 'two-column') setAtsMode(true);
           else if (id !== 'two-column') setAtsMode(false);
         }}

--- a/apps/tauri/src/renderer/features/ai-generate/components/TemplateRecommendation/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/TemplateRecommendation/index.tsx
@@ -11,7 +11,7 @@ import { useRecommendTemplate } from '@/services';
 interface Props {
   meta: GenerationMeta | null;
   templateId: TemplateId;
-  onApply: (templateId: TemplateId, atsSuggested: boolean) => void;
+  onApply: (templateId: TemplateId, atsSuggested: boolean, locale: string) => void;
 }
 
 /**
@@ -64,7 +64,7 @@ export function TemplateRecommendation({ meta, templateId, onApply }: Props) {
               size="sm"
               variant="ghost"
               className="h-6 px-2 text-[11px] text-brand-soft hover:text-brand"
-              onClick={() => onApply(rec.templateId, rec.atsSuggested)}
+              onClick={() => onApply(rec.templateId, rec.atsSuggested, rec.locale)}
             >
               {t('aiGenerate.applyRecommendation')}
             </Button>

--- a/apps/tauri/src/renderer/lib/generate/export/export.ts
+++ b/apps/tauri/src/renderer/lib/generate/export/export.ts
@@ -70,7 +70,8 @@ export async function exportDOCX(
   type: 'resume' | 'cover-letter' = 'resume',
   meta?: GenerationMeta,
   templateId: TemplateId = 'modern',
-  atsMode = false
+  atsMode = false,
+  locale?: string
 ): Promise<void> {
   try {
     if (!text || text.trim().length === 0) {
@@ -92,6 +93,7 @@ export async function exportDOCX(
       documentType: type,
       templateId,
       atsMode,
+      locale,
       meta: meta
         ? {
             candidateName: meta.candidateName,
@@ -116,7 +118,8 @@ export async function exportPDF(
   type: 'resume' | 'cover-letter' = 'resume',
   meta?: GenerationMeta,
   templateId: TemplateId = 'modern',
-  atsMode = false
+  atsMode = false,
+  locale?: string
 ): Promise<void> {
   try {
     if (!text || text.trim().length === 0) {
@@ -138,6 +141,7 @@ export async function exportPDF(
       documentType: type,
       templateId,
       atsMode,
+      locale,
       meta: meta
         ? {
             candidateName: meta.candidateName,

--- a/apps/tauri/src/renderer/store/session-store/session-store.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.ts
@@ -18,6 +18,8 @@ interface AIGenerateSlice {
   target: AIGenerateTarget;
   templateId: TemplateId;
   atsMode: boolean;
+  /** Target market id (`us`, `de`, …); drives export page size. */
+  locale: string;
   resumeOut: string;
   coverOut: string;
   activeOut: 'resume' | 'cover';
@@ -77,6 +79,7 @@ const AI_GENERATE_DEFAULTS: AIGenerateSlice = {
   target: 'both',
   templateId: 'modern',
   atsMode: false,
+  locale: 'en',
   resumeOut: '',
   coverOut: '',
   activeOut: 'resume',

--- a/docs/EXPORT_TEMPLATES.md
+++ b/docs/EXPORT_TEMPLATES.md
@@ -1,0 +1,173 @@
+# Export Templates — the resume/cover-letter rendering contract
+
+The normative reference for the document export system: the nine templates, the
+two backends, and the cross-cutting rules (page size, ATS mode, links, fonts,
+validation). This is a **contract** — behavior described here is locked by tests;
+changing it means changing the tests too.
+
+Source of truth in code:
+
+| Concern                          | Where                                                      |
+| -------------------------------- | ---------------------------------------------------------- |
+| Template registry (styling data) | `apps/tauri/src-tauri/src/export/templates/mod.rs`         |
+| Canonical document model         | `apps/tauri/src-tauri/src/model/`                          |
+| PDF layout engine (fixed)        | `apps/tauri/src-tauri/src/layout/`, `export/layout_pdf.rs` |
+| DOCX backend (flow)              | `apps/tauri/src-tauri/src/export/model_docx.rs`            |
+| Section placement / link style   | `apps/tauri/src-tauri/src/theme/mod.rs`                    |
+| Locale profiles (page size, …)   | `apps/tauri/src-tauri/src/locale/mod.rs`                   |
+| Validation + ATS gate            | `apps/tauri/src-tauri/src/validate/mod.rs`                 |
+| IPC contract                     | `packages/shared/src/ipc/contracts/documents.ts`           |
+
+---
+
+## Architecture
+
+A resume is rendered from a single canonical `DocumentModel` (header + titled
+sections of paragraphs / bullets / entries with rich-text runs). Backends
+**translate** the model; they never re-parse text:
+
+```
+resume text ──adapter──▶ DocumentModel ──▶ layout engine ──▶ PDF   (fixed pages)
+                                       └──▶ model_docx    ──▶ DOCX  (Word reflow)
+                              TXT = stripped markdown
+```
+
+The two backends are **asymmetric by design** and this is intentional:
+
+- **PDF** is a _fixed_ backend — the engine measures glyphs (real font metrics),
+  places every line at an absolute position, paginates itself, and draws the
+  two-column sidebar band per page. Deterministic, pixel-stable.
+- **DOCX** is a _flow_ backend — it emits paragraphs / a borderless table and
+  lets Word measure, wrap, and paginate. `keepNext` / `keepLines` keep headings
+  with their content and bullets intact.
+
+The shared layer is `DocumentModel` + `MeasureText` + `Theme` + `LocaleProfile` +
+section routing — **not** a shared paginator.
+
+---
+
+## The nine templates
+
+`TemplateId` (kebab-case on the wire) → template. Fonts list `name / heading /
+body`; the DOCX backend substitutes a system fallback (see [Fonts](#fonts)).
+
+| Id                  | Name              | Fonts                                            | Character                                    | Layout         | Best for                                            |
+| ------------------- | ----------------- | ------------------------------------------------ | -------------------------------------------- | -------------- | --------------------------------------------------- |
+| `classic`           | ATS Classic       | Calibri / Calibri / Calibri                      | Black, no color, underlined headings         | Single column  | Maximum ATS safety; finance / legal / public sector |
+| `modern`            | Modern Technical  | Calibri / Calibri / Calibri                      | Navy, ruled headings                         | Single column  | Software / engineering                              |
+| `executive`         | Executive         | Calibri / Calibri / Calibri                      | Charcoal, centered name, generous whitespace | Single column  | Senior / leadership                                 |
+| `editorial-serif`   | Editorial Serif   | Source Serif 4 / Source Serif 4 / Inter          | Indigo accent, op-ed serif                   | Single column  | Editorial / communications                          |
+| `swiss-minimal`     | Swiss Minimal     | Manrope / Manrope / Manrope                      | Geometric sans, minimal                      | Single column  | Design-adjacent / product                           |
+| `two-column`        | Two Column        | Inter / Inter / Inter                            | Shaded sidebar band                          | **Two column** | Design; skills-forward                              |
+| `mono-technical`    | Mono Technical    | JetBrains Mono / JetBrains Mono / Inter          | Monospace headings                           | Single column  | Systems / low-level engineering                     |
+| `refined-executive` | Refined Executive | Playfair Display / Inter / Inter                 | Display-serif name                           | Single column  | Executive / brand-forward                           |
+| `academic`          | Academic          | Source Serif 4 / Source Serif 4 / Source Serif 4 | Full serif, formal                           | Single column  | Academia / research                                 |
+
+Adding a template is **localized and additive**: one `TemplateId` variant + one
+`Template::*` constructor in the registry. The backends, validation, and locale
+logic consume it unchanged.
+
+---
+
+## Page size & locale
+
+Page geometry comes from the request's locale (`LocaleProfile::get`), resolved to
+**one source of truth** read by every backend:
+
+- **US** market → **US Letter** (215.9 × 279.4 mm).
+- Every other market and the omitted default → **A4** (210 × 297 mm).
+
+The recommender derives the locale from the job ad (explicit target country wins,
+then an `en-US` / `en-GB` region subtag, then the language). PDF and DOCX always
+agree on the page size for a given request.
+
+---
+
+## ATS mode
+
+`atsMode` makes the document parser-safe:
+
+- The model is **linearized** (`transform::linearize`) into a single canonical
+  reading order, and two-column templates collapse to one column.
+- The DOCX backend therefore emits **no table** in ATS mode; the PDF backend lays
+  out a single column.
+
+ATS mode is the answer to position-based parsers (e.g. some modern ATS) that can
+still interleave a visually two-column PDF. The recommender suggests it for
+conservative fields.
+
+---
+
+## Two-column layout
+
+Only `two-column` is two-column. Section → column assignment is the canonical
+`theme::placement_for` decision (not a per-template string list):
+
+- **Sidebar**: Skills, Education, Languages, Certifications.
+- **Main**: everything else (Summary, Experience, Projects, custom sections).
+
+The header (name + contact) always spans the full width above the columns.
+
+- **PDF**: a shaded sidebar band drawn per page behind an independent sidebar
+  flow; the main flow paginates separately and pages are merged.
+- **DOCX**: a borderless, single-row two-cell table — a shaded sidebar cell
+  (`Shading.fill` = the template tint) + a main cell, fixed layout, borders
+  cleared — so Word flows and paginates it.
+
+---
+
+## Links
+
+Contact and body hyperlinks are first-class rich-text runs, rendered as real
+clickable links (PDF `/Link /URI` annotations; DOCX `w:hyperlink` with the URL in
+the relationships part). The visible label is shown, never the raw URL.
+
+`theme::link_style` per template:
+
+- `classic` → body color, **no** underline (maximum parser/printer safety).
+- all others → accent color + underline.
+
+---
+
+## Fonts
+
+Six families are bundled as TTFs and embedded in the PDF. The DOCX is **not**
+embedded yet, so it references a widely-available fallback so output is
+predictable on machines without the bundled fonts (true OOXML embedding is a
+tracked follow-up):
+
+| Bundled family   | DOCX fallback |
+| ---------------- | ------------- |
+| Calibri          | Calibri       |
+| Inter            | Calibri       |
+| Manrope          | Calibri       |
+| Source Serif 4   | Georgia       |
+| Playfair Display | Cambria       |
+| JetBrains Mono   | Consolas      |
+
+The fallback is applied to both the ASCII and high-ANSI ranges so accented Latin
+(common in DACH names) renders in the same face.
+
+---
+
+## Validation + ATS gate
+
+Every PDF/DOCX export runs through `validate::validate_and_fix` after rendering:
+
+1. **Round-trip** — the bytes are re-extracted (pdf-extract for PDF, the unzipped
+   `document.xml` for DOCX) and checked for content survival and sane reading
+   order.
+2. **Auto-fix** — a two-column layout whose sections interleave when read back is
+   re-exported single-column (ATS-safe) and re-checked.
+3. **Block** — only when a critical defect _survives_ auto-fix (e.g. no
+   extractable text at all). Missing name/email/section and single-column order
+   quirks are warnings, never blocks.
+
+The report (`ok`, `atsMode`, `issues`, `fixed`) rides back on the export result.
+
+---
+
+## TXT
+
+`txt` is produced client-side: the markdown is stripped of `**bold**` markers.
+No layout, no validation report.

--- a/packages/shared/src/ipc/contracts/documents.ts
+++ b/packages/shared/src/ipc/contracts/documents.ts
@@ -27,6 +27,8 @@ interface BaseExportRequest {
   meta?: ExportMeta;
   /** Linearize two-column layouts for ATS parsers. Only affects two-column template. */
   atsMode?: boolean;
+  /** Target market id (`us`, `de`, …); drives the page size (US → Letter, else A4). */
+  locale?: string;
 }
 
 export type ExportIssueSeverity = 'critical' | 'warning';


### PR DESCRIPTION
## Locale-driven export page size

Completes the deferral from phases 3 and 7: the recommended locale now flows all
the way to the page geometry. A **US** export renders **US Letter**; every other
market renders **A4**.

### Rust
- `ExportRequest` gains an optional `locale` (`#[serde(default)]`) and a
  `page_geometry()` that resolves it through `LocaleProfile::get` (US → Letter,
  else → A4; omitted → A4).
- The default production resume backends take the geometry as a parameter:
  `layout_pdf` and `model_docx` gain `…_in(geom)` variants the export command
  calls with `request.page_geometry()`. The old default-geometry helpers become
  test-only conveniences (`#[cfg(test)]`).

### Renderer (end-to-end)
- The session store carries the active `locale`; **applying a template
  recommendation also applies its locale**, and `exportPDF` / `exportDOCX` pass it
  through `BaseExportRequest`. So a US recommendation → Letter export, no extra
  clicks.

### Tests
- The layout engine honors Letter geometry; a `locale = "us"` DOCX declares the
  Letter `pgSz` (`12240 × 15840` dxa) while the default stays A4.
- The PDF↔legacy **parity gate is unaffected** (A4 unchanged).
- clippy `-D warnings` clean under **both** feature configs; typecheck,
  gen:ipc:check, lint:strict, **132** Rust and **128** renderer tests all pass.

This is the first item of the deferred "afterwards" bucket. Next: `docs/EXPORT_TEMPLATES.md`.
The `build_model` wiring stays forward-looking (it belongs to a "render the
*imported* resume" feature that doesn't exist yet — export renders AI-*generated*
text), and live AI structuring stays deferred (not CI-verifiable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)