### PR TITLE
feat: in-app changelog and windows cli-agent console-flash suppression

### DIFF
--- a/apps/tauri/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
@@ -17,14 +17,17 @@
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::process::Stdio;
-use std::time::Duration;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 
 use crate::error::{AppError, AppResult};
 use crate::jobs::JobTracker;
+use crate::platform::NoWindow;
 
 use super::{
     AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, RequestTrace, TokenParam,
@@ -239,10 +242,26 @@ impl AiProvider for CliAgentClient {
 
 // ── Detection ────────────────────────────────────────────────────────────────────
 
+/// How long a `<binary> --version` result is trusted before re-probing. Install
+/// status changes rarely, so [`detect_cached`] collapses the 5 s health poll from
+/// a subprocess spawn per tick to at most one per binary per TTL.
+const DETECT_TTL: Duration = Duration::from_secs(300);
+
+struct Detected {
+    ok: bool,
+    version: Option<String>,
+    at: Instant,
+}
+
+fn detect_cache() -> &'static Mutex<HashMap<String, Detected>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Detected>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 /// Whether the binary is installed (`<binary> --version` succeeds), plus its
 /// reported version. Mirrors `ollama::reachable_model()` as the health signal.
 pub async fn detect(binary: &str) -> (bool, Option<String>) {
-    let fut = Command::new(binary).arg("--version").output();
+    let fut = Command::new(binary).arg("--version").no_window().output();
     match tokio::time::timeout(Duration::from_secs(5), fut).await {
         Ok(Ok(out)) if out.status.success() => {
             let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
@@ -250,6 +269,26 @@ pub async fn detect(binary: &str) -> (bool, Option<String>) {
         }
         _ => (false, None),
     }
+}
+
+/// Cached [`detect`]: re-probes a binary at most once per [`DETECT_TTL`], so the
+/// recurring `system_health` poll stops spawning a subprocess every few seconds.
+/// The lock is released before the `.await`, never held across it.
+pub async fn detect_cached(binary: &str) -> (bool, Option<String>) {
+    {
+        let cache = detect_cache().lock();
+        if let Some(d) = cache.get(binary) {
+            if d.at.elapsed() < DETECT_TTL {
+                return (d.ok, d.version.clone());
+            }
+        }
+    }
+    let (ok, version) = detect(binary).await;
+    detect_cache().lock().insert(
+        binary.to_string(),
+        Detected { ok, version: version.clone(), at: Instant::now() },
+    );
+    (ok, version)
 }
 
 // ── Streaming engine ─────────────────────────────────────────────────────────────
@@ -447,6 +486,7 @@ fn spawn(binary: &str, inv: &CliInvocation, prompt: &str) -> std::io::Result<tok
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)
+        .no_window()
         .spawn()
 }
 
@@ -546,5 +586,20 @@ mod tests {
         let (ok, version) = detect("ajh-definitely-not-a-real-binary-x9z").await;
         assert!(!ok);
         assert!(version.is_none());
+    }
+
+    #[tokio::test]
+    async fn detect_cached_serves_cached_result_within_ttl() {
+        let bin = "ajh-cache-probe-binary-not-real-q7w";
+        // First call probes (binary missing) and caches the negative result.
+        assert_eq!(detect_cached(bin).await, (false, None));
+        // Poison the cache with a value a real probe could never produce, then
+        // confirm the next call returns it — proving it read the cache, not the
+        // binary (i.e. no re-spawn within the TTL).
+        detect_cache().lock().insert(
+            bin.to_string(),
+            Detected { ok: true, version: Some("9.9.9".into()), at: Instant::now() },
+        );
+        assert_eq!(detect_cached(bin).await, (true, Some("9.9.9".to_string())));
     }
 }

--- a/apps/tauri/src-tauri/src/commands/system/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/system/mod.rs
@@ -16,7 +16,7 @@ pub async fn system_health(app: AppHandle) -> Value {
     // from the registry so new agents appear here automatically.
     let mut cli_agents = Map::new();
     for backend in cli_agent::all() {
-        let (detected, version) = cli_agent::detect(&backend.binary()).await;
+        let (detected, version) = cli_agent::detect_cached(&backend.binary()).await;
         cli_agents.insert(
             backend.id().as_str().to_string(),
             json!({ "detected": detected, "version": version }),

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -360,6 +360,7 @@ fn main() {
             updater::updater_check,
             updater::updater_download,
             updater::updater_install,
+            updater::updater_changelog,
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri application");

--- a/apps/tauri/src-tauri/src/platform/chrome/mod.rs
+++ b/apps/tauri/src-tauri/src/platform/chrome/mod.rs
@@ -29,6 +29,8 @@ pub fn detect_system_chrome() -> Option<std::path::PathBuf> {
 fn detect_chrome_windows() -> Option<std::path::PathBuf> {
     use std::process::Command;
 
+    use crate::platform::NoWindow;
+
     // Query Windows registry for Chrome or Edge.
     for key in &[
         r"HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe",
@@ -36,6 +38,7 @@ fn detect_chrome_windows() -> Option<std::path::PathBuf> {
     ] {
         let output = Command::new("reg")
             .args(&["query", key, "/ve"])
+            .no_window()
             .output();
         if let Ok(out) = output {
             if out.status.success() {

--- a/apps/tauri/src-tauri/src/platform/mod.rs
+++ b/apps/tauri/src-tauri/src/platform/mod.rs
@@ -1,4 +1,6 @@
 pub mod chrome;
 pub mod config;
+pub mod process;
 
 pub use chrome::detect_system_chrome;
+pub use process::NoWindow;

--- a/apps/tauri/src-tauri/src/platform/process.rs
+++ b/apps/tauri/src-tauri/src/platform/process.rs
@@ -1,0 +1,40 @@
+//! Shared subprocess helpers.
+//!
+//! On Windows, spawning a console subprocess flashes a transient console window;
+//! `CREATE_NO_WINDOW` suppresses it. Every subprocess we spawn calls
+//! [`NoWindow::no_window`] so this behavior is defined in exactly one place — new
+//! spawn sites opt in with a single call. It is a compile-time no-op on macOS and
+//! Linux, which don't show a window for a spawned child.
+
+/// Adds `.no_window()` to the `Command` builders we use (`std` and `tokio`).
+/// Returns `&mut Self` so it chains inside an existing builder expression.
+pub trait NoWindow {
+    /// Suppress the transient console window Windows shows when spawning a console
+    /// subprocess. No-op on non-Windows.
+    fn no_window(&mut self) -> &mut Self;
+}
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+impl NoWindow for std::process::Command {
+    fn no_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            self.creation_flags(CREATE_NO_WINDOW);
+        }
+        self
+    }
+}
+
+impl NoWindow for tokio::process::Command {
+    fn no_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            // tokio's Command exposes `creation_flags` inherently on Windows.
+            self.creation_flags(CREATE_NO_WINDOW);
+        }
+        self
+    }
+}

--- a/apps/tauri/src-tauri/src/updater/mod.rs
+++ b/apps/tauri/src-tauri/src/updater/mod.rs
@@ -20,8 +20,10 @@
 /// The Update object is stored across commands so the download URL and signature
 /// are never re-fetched, avoiding race conditions and unnecessary network calls.
 use std::sync::Arc;
+use std::time::Duration;
 use parking_lot::Mutex;
 
+use serde::Deserialize;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_updater::{Update, UpdaterExt};
@@ -181,6 +183,76 @@ pub async fn updater_install(app: AppHandle) -> Value {
             emit_status(&app, json!({ "state": "error", "message": msg }));
             json!({ "error": msg })
         }
+    }
+}
+
+// ── Changelog (release history) ────────────────────────────────────────────────
+
+/// Most recent releases to surface in the in-app changelog.
+const CHANGELOG_LIMIT: u32 = 15;
+
+/// GitHub Releases API for this repo. The renderer's CSP forbids talking to GitHub
+/// directly, so the changelog is fetched here (Rust is not bound by the webview
+/// CSP) and returned over IPC, reusing the shared HTTP client.
+fn releases_api_url() -> String {
+    format!(
+        "https://api.github.com/repos/saeedkolivand/ai-job-hunter-assistant-app/releases?per_page={CHANGELOG_LIMIT}"
+    )
+}
+
+/// Subset of the GitHub release payload we surface.
+#[derive(Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    name: Option<String>,
+    body: Option<String>,
+    published_at: Option<String>,
+    html_url: String,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
+    draft: bool,
+}
+
+/// Recent release history (newest first) for the in-app changelog. Returns
+/// `{ releases: [...] }` or `{ error }` — never throws, so the UI can render a
+/// friendly empty/error state instead of only linking out to GitHub.
+#[tauri::command]
+pub async fn updater_changelog() -> Value {
+    let resp = crate::net::http::shared()
+        .get(releases_api_url())
+        .header("Accept", "application/vnd.github+json")
+        .timeout(Duration::from_secs(15))
+        .send()
+        .await;
+
+    let resp = match resp {
+        Ok(r) if r.status().is_success() => r,
+        Ok(r) => {
+            return json!({ "error": format!("Changelog unavailable (HTTP {}).", r.status().as_u16()) })
+        }
+        Err(e) => return json!({ "error": format!("Could not reach GitHub: {e}") }),
+    };
+
+    match resp.json::<Vec<GithubRelease>>().await {
+        Ok(releases) => {
+            let items: Vec<Value> = releases
+                .into_iter()
+                .filter(|r| !r.draft)
+                .map(|r| {
+                    json!({
+                        "version": r.tag_name.trim_start_matches('v'),
+                        "name": r.name,
+                        "body": r.body,
+                        "publishedAt": r.published_at,
+                        "url": r.html_url,
+                        "prerelease": r.prerelease,
+                    })
+                })
+                .collect();
+            json!({ "releases": items })
+        }
+        Err(e) => json!({ "error": format!("Could not parse changelog: {e}") }),
     }
 }
 

--- a/apps/tauri/src/renderer/features/settings/components/update-section/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/update-section/index.tsx
@@ -1,10 +1,19 @@
-import { CheckCircle2, Download, ExternalLink, Loader2, Sparkles } from 'lucide-react';
+import {
+  CheckCircle2,
+  ChevronDown,
+  Download,
+  ExternalLink,
+  History,
+  Loader2,
+  Sparkles,
+} from 'lucide-react';
+import { useState } from 'react';
 
-import { Button, GlassCard, IconBadge, RefreshButton, SectionLabel } from '@ajh/ui';
+import { Button, cn, GlassCard, IconBadge, RefreshButton, SectionLabel } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { useAppVersion, useOpenExternal } from '@/services';
-import { useUpdater } from '@/services/use-updater';
+import { useChangelog, useUpdater } from '@/services/use-updater';
 
 const NO_RELEASE_PATTERNS = [
   'valid release json',
@@ -29,6 +38,9 @@ export function UpdateSection() {
     : '';
   const { status, check, download, install } = useUpdater();
   const openExternal = useOpenExternal();
+  const [showChangelog, setShowChangelog] = useState(false);
+  const changelog = useChangelog(showChangelog);
+  const currentVersion = String(versionRaw).replace(/^v/, '');
 
   const noRelease = status.state === 'error' && isNoReleaseError(status.message);
   const GITHUB_RELEASES_URL =
@@ -107,7 +119,7 @@ export function UpdateSection() {
         </div>
       )}
 
-      {/* Changelog */}
+      {/* What's new in the available update */}
       {(status.state === 'available' ||
         status.state === 'downloading' ||
         status.state === 'downloaded') &&
@@ -122,6 +134,81 @@ export function UpdateSection() {
             </div>
           </div>
         )}
+
+      {/* Changelog history (current + previous versions) */}
+      <div className="mt-4 border-t border-white/[0.05] pt-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setShowChangelog((v) => !v)}
+          className="gap-2 text-xs text-foreground/50 hover:text-foreground/80"
+        >
+          <History size={12} />
+          {showChangelog ? t('settings.update.hideChangelog') : t('settings.update.viewChangelog')}
+          <ChevronDown
+            size={12}
+            className={cn('transition-transform', showChangelog && 'rotate-180')}
+          />
+        </Button>
+
+        {showChangelog && (
+          <div className="mt-3 max-h-80 space-y-4 overflow-y-auto pr-1">
+            {changelog.isPending && (
+              <div className="flex items-center gap-2 text-xs text-foreground/40">
+                <Loader2 size={13} className="animate-spin" />
+                {t('settings.update.loadingChangelog')}
+              </div>
+            )}
+
+            {changelog.data?.error && (
+              <div className="space-y-2 text-xs text-foreground/50">
+                <p>{t('settings.update.changelogError')}</p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => openExternal.mutate(GITHUB_RELEASES_URL)}
+                  className="gap-2 text-foreground/50 hover:text-foreground/80"
+                >
+                  <ExternalLink size={12} />
+                  {t('settings.update.downloadFromGitHub')}
+                </Button>
+              </div>
+            )}
+
+            {!changelog.isPending &&
+              !changelog.data?.error &&
+              changelog.data?.releases?.length === 0 && (
+                <p className="text-xs text-foreground/40">{t('settings.update.changelogEmpty')}</p>
+              )}
+
+            {changelog.data?.releases?.map((release) => {
+              const isCurrent = release.version === currentVersion;
+              return (
+                <div key={release.version} className="space-y-1.5">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs text-foreground/80">v{release.version}</span>
+                    {isCurrent && (
+                      <span className="rounded-full bg-brand/15 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-brand-soft">
+                        {t('settings.update.current')}
+                      </span>
+                    )}
+                    {release.publishedAt && (
+                      <span className="text-[10px] text-foreground/30">
+                        {new Date(release.publishedAt).toLocaleDateString()}
+                      </span>
+                    )}
+                  </div>
+                  {release.body && (
+                    <div className="whitespace-pre-wrap rounded-lg border border-white/[0.05] bg-white/[0.02] p-3 text-xs leading-relaxed text-foreground/50">
+                      {release.body}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </GlassCard>
   );
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -389,7 +389,13 @@
       "install": "Neu starten & installieren",
       "error": "Prüfung fehlgeschlagen",
       "whatsNew": "Neu in",
-      "downloadFromGitHub": "Von GitHub herunterladen"
+      "downloadFromGitHub": "Von GitHub herunterladen",
+      "viewChangelog": "Änderungsprotokoll anzeigen",
+      "hideChangelog": "Änderungsprotokoll ausblenden",
+      "current": "Aktuell",
+      "loadingChangelog": "Änderungsprotokoll wird geladen…",
+      "changelogError": "Änderungsprotokoll konnte nicht geladen werden.",
+      "changelogEmpty": "Keine Releases gefunden."
     }
   },
   "aiGenerate": {

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -389,7 +389,13 @@
       "install": "Restart & install",
       "error": "Check failed",
       "whatsNew": "What's new in",
-      "downloadFromGitHub": "Download from GitHub"
+      "downloadFromGitHub": "Download from GitHub",
+      "viewChangelog": "View changelog",
+      "hideChangelog": "Hide changelog",
+      "current": "Current",
+      "loadingChangelog": "Loading changelog…",
+      "changelogError": "Couldn't load the changelog.",
+      "changelogEmpty": "No releases found."
     }
   },
   "aiGenerate": {

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -162,6 +162,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       check: noop,
       download: noop,
       install: noop,
+      changelog: () => Promise.resolve({ releases: [] }),
       onStatus: unsub,
     },
 

--- a/apps/tauri/src/renderer/services/query-client/query-client.ts
+++ b/apps/tauri/src/renderer/services/query-client/query-client.ts
@@ -60,4 +60,5 @@ export const keys = {
   conversations: { detail: (id: string) => ['conversations', id] as const },
   apply: { catalog: ['apply', 'catalog'] as const },
   aiGenerations: { all: ['aiGenerations'] as const },
+  updater: { changelog: ['updater', 'changelog'] as const },
 } as const;

--- a/apps/tauri/src/renderer/services/use-updater/use-updater.ts
+++ b/apps/tauri/src/renderer/services/use-updater/use-updater.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import {
   calculateDownloadSpeed,
@@ -9,6 +10,8 @@ import {
 } from '@ajh/shared';
 
 import { useAppClient } from '@/providers/AppClientProvider';
+
+import { keys } from '../query-client';
 
 export type UpdateStatus =
   | { state: 'idle' }
@@ -107,4 +110,20 @@ export function useUpdater() {
     timeRemaining,
     formatBytes,
   };
+}
+
+/**
+ * Recent release history (current + previous versions) for the in-app changelog.
+ * Fetched lazily — pass `enabled` so the GitHub round-trip only happens once the
+ * user expands the changelog. Release data changes rarely, so it stays fresh for
+ * 10 minutes.
+ */
+export function useChangelog(enabled: boolean) {
+  const api = useAppClient();
+  return useQuery({
+    queryKey: keys.updater.changelog,
+    queryFn: () => api.updater.changelog(),
+    enabled,
+    staleTime: 10 * 60_000,
+  });
 }

--- a/apps/tauri/src/tauri-client/namespaces/updater/updater.ts
+++ b/apps/tauri/src/tauri-client/namespaces/updater/updater.ts
@@ -1,12 +1,15 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 
+import type { ChangelogResult } from '@ajh/shared';
+
 import { asyncUnsub } from '../../utils.js';
 
 export const updater = {
   check: () => invoke('updater_check'),
   download: () => invoke('updater_download'),
   install: () => invoke('updater_install'),
+  changelog: () => invoke<ChangelogResult>('updater_changelog'),
   onStatus: (handler: (status: unknown) => void) =>
     asyncUnsub(() => listen<unknown>('updater:status', (e) => handler(e.payload))),
 };

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -157,4 +157,9 @@ export { SEARCH_CHANNELS, type SearchContract } from './search.js';
 export { SHORTCUTS_CHANNELS, type ShortcutsContract } from './shortcuts.js';
 export { SUPPORT_CHANNELS, type SupportContract } from './support.js';
 export { SYSTEM_CHANNELS, type SystemContract } from './system.js';
-export { UPDATER_CHANNELS, type UpdaterContract } from './updater.js';
+export {
+  type ChangelogRelease,
+  type ChangelogResult,
+  UPDATER_CHANNELS,
+  type UpdaterContract,
+} from './updater.js';

--- a/packages/shared/src/ipc/contracts/updater.ts
+++ b/packages/shared/src/ipc/contracts/updater.ts
@@ -1,9 +1,33 @@
+/** One release entry surfaced in the in-app changelog. */
+export interface ChangelogRelease {
+  /** Version without a leading `v` (e.g. `"0.28.0"`). */
+  version: string;
+  /** Release title, if GitHub has one. */
+  name: string | null;
+  /** Release notes body (Markdown), if any. */
+  body: string | null;
+  /** ISO 8601 publish timestamp, if any. */
+  publishedAt: string | null;
+  /** GitHub release page URL. */
+  url: string;
+  prerelease: boolean;
+}
+
+/** Result of {@link UpdaterContract.changelog}. Never rejects — errors surface here. */
+export interface ChangelogResult {
+  releases?: ChangelogRelease[];
+  error?: string;
+}
+
 export interface UpdaterContract {
   check(): Promise<void>;
 
   download(): Promise<void>;
 
   install(): Promise<void>;
+
+  /** Recent release history (newest first) for the in-app changelog. */
+  changelog(): Promise<ChangelogResult>;
 
   onStatus(handler: (status: unknown) => void): () => void;
 }
@@ -12,5 +36,6 @@ export const UPDATER_CHANNELS = {
   check: 'updater:check',
   download: 'updater:download',
   install: 'updater:install',
+  changelog: 'updater:changelog',
   onStatus: 'updater:status',
 } as const;


### PR DESCRIPTION
@
## Summary

Two independent, self-contained changes (both verified green):

### fix: suppress Windows console flashing from CLI-agent detection
The `system_health` poll runs every 5s and probed each registered CLI agent (Claude Code, Codex, Gemini CLI) by spawning `<binary> --version`. On Windows that spawned an unhidden console window each time, so a console flashed open/closed continuously while the app was open.

- New centralized `NoWindow` trait (`apps/tauri/src-tauri/src/platform/process.rs`) for both `std` and `tokio` `Command`, gated on `#[cfg(windows)]` — a compile-time no-op on macOS/Linux. Applied at every subprocess spawn site (CLI-agent detect + generation, Chrome registry probe).
- Cache CLI-agent detection behind a 5-minute TTL so the health poll stops re-spawning subprocesses every tick.
- Covers all CLI agents via the shared engine; future agents inherit the fix.

### feat: show in-app changelog with version history
Release notes previously rendered only for an available newer update; otherwise the app effectively just linked out to GitHub, with no way to read the current or previous versions in-app.

- New `updater_changelog` command fetches recent GitHub releases in Rust (the webview CSP forbids the renderer from calling GitHub directly) via the shared HTTP client.
- Settings → Updates gains an expandable "View changelog": recent releases newest-first, current version badged, with loading/error/empty states. Wired through the IPC contract, tauri + mock clients, a lazy `useChangelog` hook, and en/de strings.

## Testing
- Rust: `cargo check` + `cargo clippy` clean; 25 cli_agent + 11 updater tests pass.
- TS: `pnpm typecheck` clean; `eslint --max-warnings 0` clean; 12 updater/contracts/mock-client tests pass.
- Windows console-flash fix needs a manual check on Windows with a CLI agent on PATH.

## Notes
- The autopilot creation-form audit/changes are planned separately and will land in a fresh branch after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@