### PR TITLE
feat: section-aware resume context and skill grounding for tailored generation

### DIFF
--- a/packages/prompts/src/generate/cover-letter.ts
+++ b/packages/prompts/src/generate/cover-letter.ts
@@ -1,7 +1,8 @@
 /** Cover-letter generation — system prompt (brief / task / full) + user prompt. */
 
+import { truncateResume } from '../context-manager/index.js';
 import { type PromptTarget, resolveProfile } from '../provider/index.js';
-import { buildEmphasisBlock } from './emphasis.js';
+import { buildEmphasisBlock, buildGroundingBlock } from './emphasis.js';
 import { parseLinksFromResume, stripLinkBlock } from './links.js';
 import { type GenerationMeta, type GenerationMode, MODES } from './modes.js';
 
@@ -109,7 +110,7 @@ export function buildCoverLetterPrompt(
   _mode: GenerationMode,
   target: PromptTarget = 'large'
 ): string {
-  const { resumeChars, jobAdChars } = resolveProfile(target);
+  const { jobAdChars, truncation } = resolveProfile(target);
   // Date in the target language's convention, following the job-ad locale.
   const today = new Date().toLocaleDateString(meta.targetLanguage || 'en', {
     day: 'numeric',
@@ -121,12 +122,16 @@ export function buildCoverLetterPrompt(
     ? `Write entirely in ${meta.targetLanguage}. Use native phrasing and professional conventions for that market. Do NOT translate literally.`
     : `Write in ${meta.targetLanguage}.`;
 
-  const emphasisBlock = buildEmphasisBlock(meta.topRequirements ?? []);
   const { block: linksBlock } = parseLinksFromResume(resume);
-  const resumeBody = stripLinkBlock(resume);
+  // Section-aware truncation: keep the whole résumé when it fits the budget,
+  // else preserve high-value sections instead of cutting the tail.
+  const resumeBody = truncateResume(stripLinkBlock(resume), truncation);
+
+  const emphasisBlock = buildEmphasisBlock(meta.topRequirements ?? []);
+  const groundingBlock = buildGroundingBlock(resumeBody, meta.topRequirements ?? []);
 
   return `${linksBlock ? `${linksBlock}\n\n` : ''}<candidate_resume>
-${resumeBody.slice(0, resumeChars)}
+${resumeBody}
 </candidate_resume>
 
 <job_ad>
@@ -153,7 +158,7 @@ Role: ${meta.jobTitle || 'this role'} at ${meta.companyName || 'this company'}
 Today: ${today}
 ${langNote}
 ${emphasisBlock}
-
+${groundingBlock ? `\n${groundingBlock}\n` : ''}
 ### WRITING PROCESS (internal — do NOT output any of this) ###
 
 Think through the following privately before writing:

--- a/packages/prompts/src/generate/emphasis.ts
+++ b/packages/prompts/src/generate/emphasis.ts
@@ -1,4 +1,53 @@
-/** Keyword-emphasis instruction block. */
+/** Keyword-emphasis + résumé-grounding instruction blocks. */
+
+/**
+ * Whether the résumé body actually mentions `term`.
+ *
+ * Multi-word terms or terms containing punctuation (e.g. `Node.js`, `CI/CD`,
+ * `REST API`) match by case-insensitive substring; single alphanumeric tokens
+ * (e.g. `React`, `Go`, `AWS`) match on a word boundary so `Go` does not match
+ * "category". Heuristic by design — the model still sees the full résumé and is
+ * told never to fabricate — but it lets us tell the model which job-ad
+ * requirements are genuinely backed by the résumé.
+ */
+export function resumeMentions(resumeBody: string, term: string): boolean {
+  const t = term.trim().toLowerCase();
+  if (!t) return false;
+  if (/[^a-z0-9]/.test(t)) return resumeBody.toLowerCase().includes(t);
+  const esc = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`\\b${esc}\\b`, 'i').test(resumeBody);
+}
+
+/**
+ * Build a grounding block that splits the job-ad's top requirements into those
+ * the résumé actually supports and those it does not — so the model emphasizes
+ * real strengths and never claims absent skills. Complements
+ * {@link buildEmphasisBlock} (which only bolds keywords "when they appear
+ * naturally"); this makes the present/absent split explicit and verifiable.
+ * Returns '' when there are no requirements to classify.
+ */
+export function buildGroundingBlock(resumeBody: string, topRequirements: string[]): string {
+  const reqs = topRequirements.slice(0, 12);
+  if (!reqs.length) return '';
+
+  const present: string[] = [];
+  const absent: string[] = [];
+  for (const req of reqs) {
+    (resumeMentions(resumeBody, req) ? present : absent).push(req);
+  }
+  if (!present.length && !absent.length) return '';
+
+  const lines = ['SKILL GROUNDING — verified against the résumé (do NOT contradict):'];
+  if (present.length) {
+    lines.push(`- PRESENT — safe to emphasize and weave in naturally: ${present.join(', ')}`);
+  }
+  if (absent.length) {
+    lines.push(
+      `- ABSENT — the résumé does NOT show these; NEVER claim, imply, or bold them as the candidate's: ${absent.join(', ')}`
+    );
+  }
+  return lines.join('\n');
+}
 
 /**
  * Build the bold emphasis instruction block for prompts.

--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -4,6 +4,7 @@ import urlLabels from '../fixtures/url-labels.json';
 import {
   buildCoverLetterPrompt,
   buildCoverLetterSystemPrompt,
+  buildGroundingBlock,
   buildMetadataPrompt,
   buildResumePrompt,
   buildResumeSystemPrompt,
@@ -13,6 +14,7 @@ import {
   injectLinksIntoGeneratedText,
   MODES,
   parseLinksFromResume,
+  resumeMentions,
   urlToFriendlyLabel,
   validateMetadata,
 } from './index';
@@ -193,6 +195,87 @@ describe('buildResumePrompt', () => {
       'ats'
     );
     expect(prompt).toContain('Rewrite entirely');
+  });
+});
+
+const RESUME_FOR_GROUNDING = `Jane Dev
+Senior Engineer
+jane@example.com
+
+PROFESSIONAL SUMMARY
+Backend engineer who ships React apps written in TypeScript.
+
+WORK EXPERIENCE
+Acme — Engineer (2020 - Present)
+Built services in TypeScript and React with PostgreSQL.
+
+SKILLS
+React, TypeScript, PostgreSQL`;
+
+describe('resumeMentions', () => {
+  it('matches single tokens on word boundaries (not substrings)', () => {
+    expect(resumeMentions('Built React apps', 'React')).toBe(true);
+    expect(resumeMentions('Worked in the category team', 'Go')).toBe(false);
+    expect(resumeMentions('Wrote services in Go', 'Go')).toBe(true);
+  });
+
+  it('matches punctuated / multi-word terms as substrings', () => {
+    expect(resumeMentions('Built with Node.js', 'node.js')).toBe(true);
+    expect(resumeMentions('Designed a REST API for payments', 'REST API')).toBe(true);
+    expect(resumeMentions('No cloud here', 'AWS')).toBe(false);
+  });
+});
+
+describe('buildGroundingBlock', () => {
+  it('splits requirements into résumé-backed present vs absent', () => {
+    const block = buildGroundingBlock(RESUME_FOR_GROUNDING, [
+      'React',
+      'TypeScript',
+      'AWS',
+      'Kubernetes',
+    ]);
+    expect(block).toContain('PRESENT');
+    expect(block).toContain('React');
+    expect(block).toContain('TypeScript');
+    expect(block).toContain('ABSENT');
+    expect(block).toContain('AWS');
+    expect(block).toContain('Kubernetes');
+  });
+
+  it('returns empty string when there are no requirements', () => {
+    expect(buildGroundingBlock(RESUME_FOR_GROUNDING, [])).toBe('');
+  });
+});
+
+describe('résumé context wiring', () => {
+  it('embeds the grounding split in the résumé prompt', () => {
+    const prompt = buildResumePrompt(RESUME_FOR_GROUNDING, 'Job ad', META, 'ats');
+    expect(prompt).toContain('SKILL GROUNDING');
+    expect(prompt).toContain('PRESENT');
+  });
+
+  it('embeds the grounding split in the cover-letter prompt', () => {
+    const prompt = buildCoverLetterPrompt(RESUME_FOR_GROUNDING, 'Job ad', META, 'recruiter');
+    expect(prompt).toContain('SKILL GROUNDING');
+  });
+
+  it('no longer hard-cuts the résumé tail at 2500 chars for local tiers', () => {
+    const tail = 'UNIQUE_TAIL_MARKER';
+    const longResume = [
+      'Jane Dev',
+      'Senior Engineer',
+      'jane@example.com',
+      '',
+      'PROFESSIONAL SUMMARY',
+      'Experienced engineer. '.repeat(150), // ~3.3k chars, well past the old 2500 cap
+      '',
+      'SKILLS',
+      `${tail} React, TypeScript`,
+    ].join('\n');
+    // 'medium' resolves to the brief depth that previously sliced at 2500 chars;
+    // the résumé fits the section-aware token budget, so the tail survives.
+    const prompt = buildResumePrompt(longResume, 'Job ad', META, 'ats', 'medium');
+    expect(prompt).toContain(tail);
   });
 });
 

--- a/packages/prompts/src/generate/metadata.ts
+++ b/packages/prompts/src/generate/metadata.ts
@@ -27,7 +27,7 @@ ${resumeBody.slice(0, 3000)}
 </candidate_resume>
 
 <job_ad>
-${jobAd.slice(0, 2000)}
+${jobAd.slice(0, 4000)}
 </job_ad>
 
 Return this exact JSON (no other text):

--- a/packages/prompts/src/generate/resume.ts
+++ b/packages/prompts/src/generate/resume.ts
@@ -1,8 +1,9 @@
 /** Resume generation — system prompt (brief / task / full) + user prompt. */
 
+import { truncateResume } from '../context-manager/index.js';
 import { resumeConventions } from '../locale/index.js';
 import { type PromptTarget, resolveProfile } from '../provider/index.js';
-import { buildEmphasisBlock } from './emphasis.js';
+import { buildEmphasisBlock, buildGroundingBlock } from './emphasis.js';
 import { parseLinksFromResume, stripLinkBlock } from './links.js';
 import { type GenerationMeta, type GenerationMode, MODES } from './modes.js';
 
@@ -202,7 +203,7 @@ export function buildResumePrompt(
   _mode: GenerationMode,
   target: PromptTarget = 'large'
 ): string {
-  const { resumeChars, jobAdChars } = resolveProfile(target);
+  const { jobAdChars, truncation } = resolveProfile(target);
   // Section headers + date format follow the JOB-AD locale, not a fixed market.
   const conv = resumeConventions(meta.jobAdLanguage ?? meta.targetLanguage);
 
@@ -211,12 +212,17 @@ export function buildResumePrompt(
     : `Write in ${meta.targetLanguage}.`;
   const conventionsNote = `CONVENTIONS (target market: ${meta.targetLanguage}): use these section headers — ${conv.headers.summary} / ${conv.headers.experience} / ${conv.headers.education} / ${conv.headers.skills}; and one consistent date format like ${conv.dateExample}.`;
 
-  const emphasisBlock = buildEmphasisBlock(meta.topRequirements ?? []);
   const { block: linksBlock } = parseLinksFromResume(resume);
-  const resumeBody = stripLinkBlock(resume);
+  // Section-aware truncation: keep the whole résumé when it fits the model's
+  // token budget, otherwise preserve high-value sections (Experience, Skills)
+  // instead of blindly cutting the tail.
+  const resumeBody = truncateResume(stripLinkBlock(resume), truncation);
+
+  const emphasisBlock = buildEmphasisBlock(meta.topRequirements ?? []);
+  const groundingBlock = buildGroundingBlock(resumeBody, meta.topRequirements ?? []);
 
   return `${linksBlock ? `${linksBlock}\n\n` : ''}<candidate_resume>
-${resumeBody.slice(0, resumeChars)}
+${resumeBody}
 </candidate_resume>
 
 <job_ad>
@@ -232,7 +238,7 @@ Company: ${meta.companyName || 'Unknown'}
 ${langNote}
 ${conventionsNote}
 ${emphasisBlock}
-
+${groundingBlock ? `\n${groundingBlock}\n` : ''}
 EXAMPLE — MISSING SKILLS (follow this exactly):
 
 Resume mentions: Python, PostgreSQL, AWS

--- a/packages/prompts/src/provider/index.ts
+++ b/packages/prompts/src/provider/index.ts
@@ -121,8 +121,13 @@ export function resolveProfile(target: PromptTarget = 'large'): ResolvedProfile 
     includeRewrites: schema === 'full',
     structuredOutput,
     truncation: resolveTruncation(profile, tier),
+    // resumeChars is retained for backward-compat / callers that still slice;
+    // the generation builders now feed the résumé via `truncation` +
+    // truncateResume() instead, which preserves whole high-value sections.
     resumeChars: depth === 'brief' ? 2500 : profile.kind === 'cloud' ? 8000 : 5000,
-    jobAdChars: depth === 'brief' ? 1500 : 3000,
+    // Job ads are not the candidate's data and often bury requirements late, so
+    // give the extractor/generator more of the ad to read.
+    jobAdChars: depth === 'brief' ? 2500 : profile.kind === 'cloud' ? 6000 : 5000,
   };
 }
 


### PR DESCRIPTION
## Summary

Improves the accuracy of tailored résumé and cover-letter generation by fixing **how the résumé is fed to the model**, not by rewording the (already thorough) prompts.

### The bottleneck

`buildResumePrompt` / `buildCoverLetterPrompt` fed the résumé with a blind prefix slice:

```ts
resumeBody.slice(0, resumeChars)   // 2,500 chars for local tiers
```

A typical 2-page résumé is 4–6k chars, so the **tail (Skills, Education, older-but-relevant roles) was silently dropped** and the model tailored against a partial résumé. The package already shipped a section-aware `truncateResume()` + a per-tier `TruncationStrategy` (via `resolveProfile().truncation`) — but the builders never called it.

### Changes (prompts package only)

- **Section-aware context** — `resume.ts` / `cover-letter.ts` now feed the résumé through `truncateResume(body, truncation)`:
  - keeps the **whole résumé** when it fits the model's token budget (the common case);
  - otherwise preserves high-value sections (Experience, Skills) instead of cutting the tail.
  - This also raises the effective budget well past the old 2,500-char cap.
- **Skill grounding** — new `buildGroundingBlock()` splits the job-ad top requirements into **PRESENT** (résumé-backed → safe to emphasize) and **ABSENT** (never claim/imply/bold). A verifiable anti-hallucination signal, wired into both prompts next to the existing emphasis block. Matching is heuristic (`resumeMentions`: word-boundary for tokens, substring for `Node.js`/`REST API`).
- **Job-ad budgets** — raised `jobAdChars` (provider) and the metadata job-ad slice so late requirements aren't truncated before extraction/generation read them.

**Résumé extraction is intentionally untouched** (separate subsystem; left exactly as-is).

## Notes / follow-ups

- Generation passes a tier string, so cloud models currently use the local `large` strategy rather than their full context window. Plumbing a `ProviderProfile` (with `contextWindow`) would unlock the larger cloud budget — left as a follow-up.
- `truncateResume` processes sections in document order; a pathologically huge early section can still crowd out later ones. Real résumés don't hit this; noted for future hardening.

## Test plan

- `pnpm --filter @ajh/prompts test` — 87 pass, incl. new `resumeMentions`, `buildGroundingBlock`, and wiring tests (grounding present in both prompts; résumé tail past 2,500 chars now survives on local tiers). Typecheck + ESLint clean.
- Manual: generate a tailored résumé/cover letter from a 2-page résumé on a local model and confirm later sections (Skills/Education) are now reflected, and that job-ad skills the résumé lacks are no longer asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)