### PR TITLE
fix: anchor header links, contact-profile header source of truth, export typography + validation

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.33.0"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/src/commands/contact_profile.rs
+++ b/apps/tauri/src-tauri/src/commands/contact_profile.rs
@@ -1,0 +1,25 @@
+use serde_json::json;
+use serde_json::Value;
+use tauri::AppHandle;
+use tauri::Manager;
+
+use crate::contact_profile::{ContactProfile, ContactProfileStore};
+
+#[tauri::command]
+pub async fn contact_profile_get(app: AppHandle) -> Value {
+    let store = app.state::<ContactProfileStore>();
+    json!(store.get())
+}
+
+#[tauri::command]
+pub async fn contact_profile_set(app: AppHandle, profile: Value) -> Value {
+    let store = app.state::<ContactProfileStore>();
+    let parsed: ContactProfile = match serde_json::from_value(profile) {
+        Ok(p) => p,
+        Err(e) => return json!({ "error": format!("invalid contact profile: {e}") }),
+    };
+    match store.set(&parsed) {
+        Ok(()) => json!({ "success": true }),
+        Err(e) => json!({ "error": e.to_string() }),
+    }
+}

--- a/apps/tauri/src-tauri/src/commands/data.rs
+++ b/apps/tauri/src-tauri/src/commands/data.rs
@@ -10,6 +10,7 @@ use tauri::{AppHandle, Manager};
 
 use crate::ai_generations::AiGenerationStore;
 use crate::autopilot::AutopilotStore;
+use crate::contact_profile::ContactProfileStore;
 use crate::conversations::ConversationDb;
 use crate::data_store::DataStore;
 use crate::documents::DocumentStore;
@@ -59,6 +60,9 @@ fn build_bundle(app: &AppHandle) -> Value {
         stores.insert(s.key().to_string(), s.export());
     }
     if let Some(s) = app.try_state::<JobPreferencesStore>() {
+        stores.insert(s.key().to_string(), s.export());
+    }
+    if let Some(s) = app.try_state::<ContactProfileStore>() {
         stores.insert(s.key().to_string(), s.export());
     }
     if let Some(s) = app.try_state::<std::sync::Arc<Mutex<AutopilotStore>>>() {
@@ -171,6 +175,9 @@ pub async fn data_import(app: AppHandle) -> Value {
     }
     if let Some(s) = app.try_state::<JobPreferencesStore>() {
         import_into("jobPreferences", s.inner());
+    }
+    if let Some(s) = app.try_state::<ContactProfileStore>() {
+        import_into("contactProfile", s.inner());
     }
     if let Some(s) = app.try_state::<std::sync::Arc<Mutex<AutopilotStore>>>() {
         let guard = s.lock();

--- a/apps/tauri/src-tauri/src/commands/documents.rs
+++ b/apps/tauri/src-tauri/src/commands/documents.rs
@@ -47,8 +47,25 @@ pub async fn documents_import(app: AppHandle, req: DocumentsImportRequest) -> Va
     // Structured review: per-field confidence + missing/low-confidence flags the
     // renderer surfaces before generation. Computed before `extraction.text` is
     // moved into the record.
-    let review = serde_json::to_value(crate::extraction::structured::structure(&extraction))
-        .unwrap_or(json!(null));
+    let structured = crate::extraction::structured::structure(&extraction);
+    let review = serde_json::to_value(&structured).unwrap_or(json!(null));
+
+    // Seed the contact profile from the résumé's links — but ONLY when the user
+    // has no profile yet, so an existing (edited) profile is never clobbered. The
+    // classifier picks the personal LinkedIn/GitHub/Website by NAME and rejects
+    // company / job-board pages; the user reviews & edits it in settings. This is
+    // what stops a company link from ever reaching the document header.
+    if let Some(cp_store) = app.try_state::<crate::contact_profile::ContactProfileStore>() {
+        if cp_store.get().is_effectively_empty() {
+            let mut suggested = crate::contact_profile::classify_contact_links(&extraction.links);
+            if let Some(email) = structured.email.as_ref().map(|f| f.value.clone()) {
+                suggested.email.get_or_insert(email);
+            }
+            if !suggested.is_effectively_empty() {
+                let _ = cp_store.set(&suggested);
+            }
+        }
+    }
 
     let store = app.state::<crate::documents::DocumentStore>();
     let doc_id = crate::documents::make_doc_id();

--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod ai_provider;
 pub mod apply;
 pub mod autopilot;
 pub mod boards;
+pub mod contact_profile;
 pub mod conversations;
 pub mod cover_letter;
 pub mod credentials;

--- a/apps/tauri/src-tauri/src/contact_profile/mod.rs
+++ b/apps/tauri/src-tauri/src/contact_profile/mod.rs
@@ -1,0 +1,391 @@
+//! Contact profile — the single source of truth for the document header.
+//!
+//! Resumes and cover letters used to build their header contact line from links
+//! scavenged out of the uploaded résumé by a domain heuristic + document
+//! position, which swapped a personal LinkedIn for a company page and a personal
+//! site for an employer URL (the URL-swap symptom). The header is now assembled
+//! from **named fields** held here — never by index, never from the company-link
+//! pool — and the same builder feeds the résumé, cover letter, and DOCX, localized
+//! per language.
+//!
+//! Persistence mirrors [`crate::job_preferences`]: a single-row SQLite settings
+//! table. Seeding from an imported résumé uses [`classify_contact_links`], which
+//! picks the personal profile/site by name and rejects company / job-board pages —
+//! the result is a *suggestion* the user can edit, never silently trusted.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use parking_lot::Mutex;
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use crate::data_store::DataStore;
+use crate::db::{run_migrations, Migration};
+use crate::error::AppResult;
+use crate::extraction::types::Link;
+use crate::model::rich::{tokenize_rich, RichText};
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+/// A free-text value with optional per-language overrides (e.g. a location that
+/// reads "Netherlands" in English documents and "Niederlande" in German ones).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalizedText {
+    /// Value used when no language-specific override matches.
+    pub default: String,
+    /// ISO-639-1 (`de`, `en`, …) → localized value.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub by_lang: BTreeMap<String, String>,
+}
+
+impl LocalizedText {
+    /// Resolve for `lang` (its primary subtag), falling back to [`Self::default`].
+    pub fn resolve(&self, lang: &str) -> &str {
+        let primary = lang.split(['-', '_']).next().unwrap_or(lang).to_lowercase();
+        self.by_lang
+            .get(&primary)
+            .map(String::as_str)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&self.default)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.default.trim().is_empty() && self.by_lang.values().all(|v| v.trim().is_empty())
+    }
+}
+
+/// One additional labelled link beyond the named platform fields.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactLink {
+    pub label: String,
+    pub url: String,
+}
+
+/// The header contact fields, by name. Every field is optional so a partial
+/// profile still produces a valid (shorter) header. The order the header renders
+/// in is fixed by [`Self::header_markdown`], not by field discovery order.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContactProfile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phone: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<LocalizedText>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub linkedin: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub website: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_links: Vec<ContactLink>,
+}
+
+impl ContactProfile {
+    /// True when there is nothing to render from (caller should fall back to the
+    /// text-derived header).
+    pub fn is_effectively_empty(&self) -> bool {
+        let location_empty = self
+            .location
+            .as_ref()
+            .map(LocalizedText::is_empty)
+            .unwrap_or(true);
+        self.email.is_none()
+            && self.phone.is_none()
+            && self.linkedin.is_none()
+            && self.github.is_none()
+            && self.website.is_none()
+            && self.extra_links.is_empty()
+            && location_empty
+    }
+
+    /// Build the header contact line as a markdown string, localized for `lang`,
+    /// in the canonical order **location | email | phone | LinkedIn | GitHub |
+    /// Website | extras**. Links are emitted as `[Label](url)` and the email bare
+    /// (the renderers turn it into a `mailto:` link); the existing
+    /// [`tokenize_rich`] / `split_urls` machinery makes every part clickable.
+    ///
+    /// This is the single header builder shared by the résumé, cover letter, and
+    /// DOCX paths — there is no other place a header URL is chosen.
+    pub fn header_markdown(&self, lang: &str) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(loc) = &self.location {
+            let v = loc.resolve(lang);
+            if !v.trim().is_empty() {
+                parts.push(v.to_string());
+            }
+        }
+        if let Some(email) = non_empty(&self.email) {
+            parts.push(email.to_string());
+        }
+        if let Some(phone) = non_empty(&self.phone) {
+            parts.push(phone.to_string());
+        }
+        if let Some(url) = non_empty(&self.linkedin) {
+            parts.push(format!("[LinkedIn]({url})"));
+        }
+        if let Some(url) = non_empty(&self.github) {
+            parts.push(format!("[GitHub]({url})"));
+        }
+        if let Some(url) = non_empty(&self.website) {
+            parts.push(format!("[Website]({url})"));
+        }
+        for link in &self.extra_links {
+            if !link.label.trim().is_empty() && !link.url.trim().is_empty() {
+                parts.push(format!("[{}]({})", link.label.trim(), link.url.trim()));
+            }
+        }
+        parts.join(" | ")
+    }
+
+    /// The header contact line as [`RichText`] (link runs first-class) for the
+    /// model-based résumé / DOCX backends. Empty when the profile has no contact
+    /// parts, so the caller keeps the text-derived header.
+    pub fn header_rich(&self, lang: &str) -> RichText {
+        let md = self.header_markdown(lang);
+        if md.is_empty() {
+            Vec::new()
+        } else {
+            tokenize_rich(&md)
+        }
+    }
+
+    /// Override a document header's contact line from this profile, localized for
+    /// `lang`. No-op when the profile has no contact parts, so the caller keeps the
+    /// text-derived header. The name is left untouched (handled by generation
+    /// metadata); this fixes only the contact/link line (the URL-swap symptom).
+    pub fn apply_to_header(&self, header: &mut crate::model::document::HeaderBlock, lang: &str) {
+        let rich = self.header_rich(lang);
+        if !rich.is_empty() {
+            header.contact = rich;
+        }
+    }
+
+    /// The set of header URLs this profile would render (for validation parity
+    /// checks across documents). Email is included as a `mailto:` link.
+    pub fn header_urls(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if let Some(email) = non_empty(&self.email) {
+            out.push(format!("mailto:{email}"));
+        }
+        for url in [
+            non_empty(&self.linkedin),
+            non_empty(&self.github),
+            non_empty(&self.website),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            out.push(url.to_string());
+        }
+        for link in &self.extra_links {
+            if !link.url.trim().is_empty() {
+                out.push(link.url.trim().to_string());
+            }
+        }
+        out
+    }
+}
+
+fn non_empty(v: &Option<String>) -> Option<&str> {
+    v.as_deref().map(str::trim).filter(|s| !s.is_empty())
+}
+
+// ── Link classification (seeding suggestions) ─────────────────────────────────
+
+/// Hosts that are job boards / aggregators / employer ATS — never a personal
+/// contact link, so they must not seed LinkedIn / GitHub / Website.
+const JOB_BOARD_HOSTS: &[&str] = &[
+    "indeed.com",
+    "glassdoor.com",
+    "stepstone.de",
+    "stepstone.com",
+    "monster.com",
+    "ziprecruiter.com",
+    "lever.co",
+    "greenhouse.io",
+    "workday.com",
+    "myworkdayjobs.com",
+    "ashbyhq.com",
+    "smartrecruiters.com",
+    "recruitee.com",
+    "personio.de",
+    "arbeitnow.com",
+    "xing.com",
+];
+
+fn host_of(url: &str) -> Option<String> {
+    let lower = url.trim().to_lowercase();
+    let no_scheme = lower
+        .strip_prefix("https://")
+        .or_else(|| lower.strip_prefix("http://"))
+        .unwrap_or(&lower);
+    let host = no_scheme.split(['/', '?', '#']).next()?;
+    Some(host.trim_start_matches("www.").to_string())
+}
+
+fn host_is(url: &str, domain: &str) -> bool {
+    host_of(url).is_some_and(|h| h == domain || h.ends_with(&format!(".{domain}")))
+}
+
+/// A personal LinkedIn profile is `/in/…`. Company (`/company/…`), school
+/// (`/school/…`) and job (`/jobs/…`) pages are NOT the candidate's profile — these
+/// are exactly the company-link pool that used to leak into the header.
+fn is_personal_linkedin(url: &str) -> bool {
+    host_is(url, "linkedin.com") && url.to_lowercase().contains("/in/")
+}
+
+/// A personal GitHub profile/repo (any github.com URL that isn't an org settings
+/// page is acceptable as the candidate's GitHub).
+fn is_github(url: &str) -> bool {
+    host_is(url, "github.com")
+}
+
+/// Personal-site / link-in-bio hosts that belong under "Website".
+const WEBSITE_HOSTS: &[&str] = &[
+    "solo.to",
+    "bio.link",
+    "linktr.ee",
+    "bento.me",
+    "about.me",
+    "carrd.co",
+];
+
+fn is_job_board(url: &str) -> bool {
+    JOB_BOARD_HOSTS.iter().any(|d| host_is(url, d))
+}
+
+/// Classify extracted résumé links into a [`ContactProfile`] by NAME, not by
+/// position. Picks the first personal LinkedIn (`/in/`), the first GitHub, and a
+/// personal website (a known link-in-bio host, else the first non-job-board,
+/// non-platform `http(s)` link). Company / job-board links are rejected. This is a
+/// suggestion to seed the editable profile, never the final header on its own.
+pub fn classify_contact_links(links: &[Link]) -> ContactProfile {
+    let mut profile = ContactProfile::default();
+    for link in links {
+        let url = link.url.trim();
+        if url.is_empty() {
+            continue;
+        }
+        if let Some(email) = url.strip_prefix("mailto:") {
+            profile.email.get_or_insert_with(|| email.to_string());
+            continue;
+        }
+        if !(url.starts_with("http://") || url.starts_with("https://")) {
+            continue;
+        }
+        if profile.linkedin.is_none() && is_personal_linkedin(url) {
+            profile.linkedin = Some(url.to_string());
+            continue;
+        }
+        if profile.github.is_none() && is_github(url) {
+            profile.github = Some(url.to_string());
+            continue;
+        }
+        if profile.website.is_none() && WEBSITE_HOSTS.iter().any(|d| host_is(url, d)) {
+            profile.website = Some(url.to_string());
+            continue;
+        }
+    }
+    // Website fallback: the first non-job-board, non-platform http(s) link, so a
+    // personal portfolio on an arbitrary domain is still surfaced — but an
+    // employer / company URL never is.
+    if profile.website.is_none() {
+        for link in links {
+            let url = link.url.trim();
+            if (url.starts_with("http://") || url.starts_with("https://"))
+                && !is_job_board(url)
+                && !host_is(url, "linkedin.com")
+                && !is_github(url)
+            {
+                profile.website = Some(url.to_string());
+                break;
+            }
+        }
+    }
+    profile
+}
+
+// ── Store (single-row SQLite settings table) ──────────────────────────────────
+
+pub struct ContactProfileStore {
+    conn: Mutex<Connection>,
+}
+
+impl ContactProfileStore {
+    const MIGRATIONS: &'static [Migration] = &[Migration {
+        name: "create_contact_profile",
+        up: |conn| {
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS contact_profile (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    data TEXT
+                );",
+            )?;
+            conn.execute("INSERT OR IGNORE INTO contact_profile (id) VALUES (1)", [])?;
+            Ok(())
+        },
+    }];
+
+    pub fn open(data_dir: &PathBuf) -> AppResult<Self> {
+        std::fs::create_dir_all(data_dir).map_err(|e| e.to_string())?;
+        let path = data_dir.join("contact_profile.db");
+        let conn = Connection::open(&path).map_err(|e| e.to_string())?;
+        run_migrations(&conn, Self::MIGRATIONS)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    pub fn get(&self) -> ContactProfile {
+        let conn = self.conn.lock();
+        conn.query_row("SELECT data FROM contact_profile WHERE id = 1", [], |row| {
+            let json: Option<String> = row.get(0)?;
+            Ok(json)
+        })
+        .ok()
+        .flatten()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+    }
+
+    pub fn set(&self, profile: &ContactProfile) -> AppResult<()> {
+        let json = serde_json::to_string(profile).map_err(|e| e.to_string())?;
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE contact_profile SET data = ?1 WHERE id = 1",
+            rusqlite::params![json],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+
+impl DataStore for ContactProfileStore {
+    fn key(&self) -> &'static str {
+        "contactProfile"
+    }
+
+    fn export(&self) -> serde_json::Value {
+        serde_json::to_value(self.get()).unwrap_or_else(|_| serde_json::json!({}))
+    }
+
+    fn import(&self, data: &serde_json::Value) -> AppResult<usize> {
+        if data.is_null() {
+            return Ok(0);
+        }
+        let profile: ContactProfile =
+            serde_json::from_value(data.clone()).map_err(|e| e.to_string())?;
+        self.set(&profile)?;
+        Ok(1)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/apps/tauri/src-tauri/src/contact_profile/test.rs
+++ b/apps/tauri/src-tauri/src/contact_profile/test.rs
@@ -1,0 +1,133 @@
+use super::*;
+use crate::extraction::types::Link;
+
+fn link(url: &str) -> Link {
+    Link {
+        anchor_text: url.to_string(),
+        url: url.to_string(),
+    }
+}
+
+#[test]
+fn header_markdown_uses_named_fields_in_canonical_order() {
+    let p = ContactProfile {
+        full_name: Some("Milan Behnam".into()),
+        email: Some("milanbehnam97@gmail.com".into()),
+        phone: Some("+31 6 12345678".into()),
+        location: Some(LocalizedText {
+            default: "Netherlands".into(),
+            by_lang: [("de".to_string(), "Niederlande".to_string())].into(),
+        }),
+        linkedin: Some("https://www.linkedin.com/in/milan-behnam/".into()),
+        github: Some("https://github.com/MilanBehnam".into()),
+        website: Some("https://solo.to/milanb".into()),
+        extra_links: vec![],
+    };
+
+    // German doc: localized location, canonical order.
+    assert_eq!(
+        p.header_markdown("de"),
+        "Niederlande | milanbehnam97@gmail.com | +31 6 12345678 | \
+         [LinkedIn](https://www.linkedin.com/in/milan-behnam/) | \
+         [GitHub](https://github.com/MilanBehnam) | [Website](https://solo.to/milanb)"
+    );
+    // English doc: default location.
+    assert!(p.header_markdown("en").starts_with("Netherlands | "));
+}
+
+#[test]
+fn header_rich_makes_each_named_link_clickable_with_the_right_url() {
+    let p = ContactProfile {
+        email: Some("milanbehnam97@gmail.com".into()),
+        linkedin: Some("https://www.linkedin.com/in/milan-behnam/".into()),
+        github: Some("https://github.com/MilanBehnam".into()),
+        website: Some("https://solo.to/milanb".into()),
+        ..Default::default()
+    };
+    let rich = p.header_rich("en");
+    // The LinkedIn label is bound to the PERSONAL profile URL (not a company page).
+    let linkedin = rich
+        .iter()
+        .find(|r| r.text == "LinkedIn")
+        .expect("LinkedIn run");
+    assert_eq!(
+        linkedin.link.as_deref(),
+        Some("https://www.linkedin.com/in/milan-behnam/")
+    );
+    let website = rich.iter().find(|r| r.text == "Website").expect("Website");
+    assert_eq!(website.link.as_deref(), Some("https://solo.to/milanb"));
+    assert!(rich
+        .iter()
+        .any(|r| r.link.as_deref() == Some("mailto:milanbehnam97@gmail.com")));
+}
+
+#[test]
+fn classify_picks_personal_links_and_rejects_company_pool() {
+    // Mirrors the bug data set: a personal profile, a company page, an employer
+    // site, plus the real personal site — in document order.
+    let links = vec![
+        link("https://www.linkedin.com/in/milan-behnam/"),
+        link("https://github.com/MilanBehnam"),
+        link("https://www.linkedin.com/company/jibit/about/"),
+        link("http://rabobank.com"),
+        link("https://solo.to/milanb"),
+    ];
+    let p = classify_contact_links(&links);
+    assert_eq!(
+        p.linkedin.as_deref(),
+        Some("https://www.linkedin.com/in/milan-behnam/"),
+        "must pick the personal /in/ profile, never the /company/ page"
+    );
+    assert_eq!(p.github.as_deref(), Some("https://github.com/MilanBehnam"));
+    assert_eq!(
+        p.website.as_deref(),
+        Some("https://solo.to/milanb"),
+        "a known link-in-bio host wins the Website slot over an employer URL"
+    );
+}
+
+#[test]
+fn classify_does_not_use_a_job_board_as_website() {
+    let links = vec![
+        link("https://www.indeed.com/cmp/acme"),
+        link("https://my-portfolio.dev"),
+    ];
+    let p = classify_contact_links(&links);
+    assert_eq!(
+        p.website.as_deref(),
+        Some("https://my-portfolio.dev"),
+        "job-board URL must be skipped; the real portfolio takes Website"
+    );
+}
+
+#[test]
+fn classify_extracts_mailto_email() {
+    let links = vec![link("mailto:milanbehnam97@gmail.com")];
+    let p = classify_contact_links(&links);
+    assert_eq!(p.email.as_deref(), Some("milanbehnam97@gmail.com"));
+}
+
+#[test]
+fn empty_profile_is_detected() {
+    assert!(ContactProfile::default().is_effectively_empty());
+    let only_name = ContactProfile {
+        full_name: Some("x".into()),
+        ..Default::default()
+    };
+    assert!(
+        only_name.is_effectively_empty(),
+        "name alone is not a header"
+    );
+}
+
+#[test]
+fn localized_text_resolves_primary_subtag() {
+    let loc = LocalizedText {
+        default: "Netherlands".into(),
+        by_lang: [("de".to_string(), "Niederlande".to_string())].into(),
+    };
+    assert_eq!(loc.resolve("de"), "Niederlande");
+    assert_eq!(loc.resolve("de-DE"), "Niederlande");
+    assert_eq!(loc.resolve("en"), "Netherlands");
+    assert_eq!(loc.resolve("fr"), "Netherlands");
+}

--- a/apps/tauri/src-tauri/src/export/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/export/commands/mod.rs
@@ -19,9 +19,13 @@ pub async fn documents_export_document(mut request: ExportRequest) -> AppResult<
         ));
     }
 
-    // Normalize Unicode before any rendering so unsupported glyphs don't appear
-    // as replacement boxes in PDF/DOCX output.
+    // Normalize Unicode, strip stray Markdown the model leaked, and run the dash
+    // typography pass — all before any rendering so unsupported glyphs never appear
+    // as replacement boxes and no `*` / backtick or mangled sentence-break dash
+    // reaches the page.
     request.text = super::parser::normalize_unicode(&request.text);
+    request.text = super::parser::sanitize_markdown(&request.text);
+    request.text = super::parser::typography(&request.text);
 
     // Generate based on format. PDF/DOCX run through the validation gate, which
     // re-extracts the bytes, auto-fixes a two-column layout that doesn't survive

--- a/apps/tauri/src-tauri/src/export/commands/test.rs
+++ b/apps/tauri/src-tauri/src/export/commands/test.rs
@@ -24,6 +24,7 @@ fn test_generate_filename() {
         }),
         ats_mode: false,
         locale: None,
+        contact: None,
     };
 
     let filename = generate_filename(&request, "docx");

--- a/apps/tauri/src-tauri/src/export/docx/mod.rs
+++ b/apps/tauri/src-tauri/src/export/docx/mod.rs
@@ -128,8 +128,17 @@ fn generate_cover_letter_docx(
     text: &str,
     meta: Option<&GenerationMeta>,
     template: &Template,
+    contact: Option<&crate::contact_profile::ContactProfile>,
+    lang: &str,
 ) -> Result<Docx> {
     let mut docx = Docx::new();
+
+    // Named contact profile is the source of truth for the header contact line
+    // (shared with the résumé), emitted as real hyperlinks. When present, the
+    // scraped contact lines from the generated text are skipped.
+    let profile_contact_md: Option<String> = contact
+        .filter(|p| !p.is_effectively_empty())
+        .map(|p| p.header_markdown(lang));
 
     let page_margin = PageMargin::new()
         .top(inch_to_dxa(1.0))
@@ -182,6 +191,15 @@ fn generate_cover_letter_docx(
                     )
                     .line_spacing(LineSpacing::new().after(60)),
             );
+            // Emit the profile-derived contact line right after the name, in place
+            // of the scraped contact lines. `render_contact_line` runs `split_urls`,
+            // so `[LinkedIn](url)` markdown and bare emails become real hyperlinks.
+            if let Some(md) = &profile_contact_md {
+                docx = docx.add_paragraph(
+                    super::docx_renderer::render_contact_line(md, template, &colors)
+                        .line_spacing(LineSpacing::new().after(40)),
+                );
+            }
             continue;
         }
 
@@ -192,6 +210,10 @@ fn generate_cover_letter_docx(
                 || clean.contains('·')
                 || clean.chars().filter(|c| c.is_numeric()).count() > 5)
         {
+            // Profile is the source of truth — drop the scraped contact line.
+            if profile_contact_md.is_some() {
+                continue;
+            }
             docx = docx.add_paragraph(
                 Paragraph::new()
                     .add_run(
@@ -328,6 +350,8 @@ pub fn generate_docx(request: &ExportRequest) -> Result<Vec<u8>> {
                     &template,
                     request.ats_mode,
                     request.page_geometry(),
+                    request.contact.as_ref(),
+                    &request.target_lang(),
                 )
                 .context("Failed to generate resume DOCX")?
             } else {
@@ -342,8 +366,14 @@ pub fn generate_docx(request: &ExportRequest) -> Result<Vec<u8>> {
             } else {
                 text
             };
-            generate_cover_letter_docx(text, request.meta.as_ref(), &single_column())
-                .context("Failed to generate cover letter DOCX")?
+            generate_cover_letter_docx(
+                text,
+                request.meta.as_ref(),
+                &single_column(),
+                request.contact.as_ref(),
+                &request.target_lang(),
+            )
+            .context("Failed to generate cover letter DOCX")?
         }
     };
 

--- a/apps/tauri/src-tauri/src/export/docx/test.rs
+++ b/apps/tauri/src-tauri/src/export/docx/test.rs
@@ -25,6 +25,7 @@ fn resume_request(template_id: TemplateId) -> ExportRequest {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     }
 }
 
@@ -65,6 +66,7 @@ fn cover_letter_docx_declares_a4_page_size() {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     };
     let bytes = generate_docx(&request).expect("docx");
     let xml = document_xml(&bytes);
@@ -149,6 +151,7 @@ fn test_generate_simple_resume() {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     };
 
     let result = generate_docx(&request);
@@ -201,6 +204,7 @@ fn test_generate_cover_letter() {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     };
 
     let result = generate_docx(&request);
@@ -223,6 +227,7 @@ fn test_generate_resume_with_meta() {
         }),
         ats_mode: false,
         locale: None,
+        contact: None,
     };
 
     let result = generate_docx(&request);

--- a/apps/tauri/src-tauri/src/export/layout_pdf.rs
+++ b/apps/tauri/src-tauri/src/export/layout_pdf.rs
@@ -42,16 +42,25 @@ pub(crate) fn generate_resume_pdf(
         template,
         ats_mode,
         crate::locale::LocaleProfile::default().page_geometry(),
+        None,
+        "en",
     )
 }
 
 /// Render a resume to PDF bytes on a specific page geometry (locale-driven).
+///
+/// `contact` (when present) is the single source of truth for the header contact
+/// line, localized by `lang` — it overrides whatever links the generated text
+/// carried, so the header can never display a company-link in place of the
+/// candidate's own profile / site.
 pub(crate) fn generate_resume_pdf_in(
     text: &str,
     meta: Option<&GenerationMeta>,
     template: &Template,
     ats_mode: bool,
     geom: PageGeometry,
+    contact: Option<&crate::contact_profile::ContactProfile>,
+    lang: &str,
 ) -> Result<Vec<u8>> {
     let mut model = model_from_resume_text(text);
 
@@ -60,6 +69,11 @@ pub(crate) fn generate_resume_pdf_in(
         if !name.is_empty() {
             model.header.name = name.to_string();
         }
+    }
+
+    // Header contact line from the named profile fields (never the company-link pool).
+    if let Some(profile) = contact {
+        profile.apply_to_header(&mut model.header, lang);
     }
 
     // ATS mode: collapse to a single column and put sections in ATS reading order.

--- a/apps/tauri/src-tauri/src/export/layout_pdf.rs
+++ b/apps/tauri/src-tauri/src/export/layout_pdf.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use printpdf::*;
 
 use crate::export::pdf_renderer::{
-    build_line, load_all_fonts, resolve_fonts, rgb_to_color, LoadedFontSet,
+    build_line, link_annotation_op, load_all_fonts, resolve_fonts, rgb_to_color, LoadedFontSet,
 };
 use crate::export::templates::Template;
 use crate::export::types::GenerationMeta;
@@ -25,8 +25,6 @@ use crate::locale::PageGeometry;
 use crate::measure::FontMetrics;
 use crate::model::adapter::model_from_resume_text;
 use crate::model::transform;
-
-const PT_PER_MM: f32 = 2.834_645_7;
 
 /// Render a resume to PDF bytes via the canonical layout engine, on the default
 /// (international A4) page geometry. A test convenience — the export command uses
@@ -198,24 +196,18 @@ fn text_ops(t: &PlacedText, page_h: f32, fonts: &LoadedFontSet) -> Vec<Op> {
 }
 
 fn link_op(l: &LinkRect, page_h: f32) -> Op {
-    let y_bottom_pt = (page_h - (l.y_top_mm + l.height_mm)) * PT_PER_MM;
-    let rect = Rect {
-        x: Pt(l.x_mm * PT_PER_MM),
-        y: Pt(y_bottom_pt),
-        width: Pt(l.width_mm * PT_PER_MM),
-        height: Pt(l.height_mm * PT_PER_MM),
-        mode: None,
-        winding_order: None,
-    };
-    Op::LinkAnnotation {
-        link: LinkAnnotation::new(
-            rect,
-            Actions::Uri(l.url.clone()),
-            Some(BorderArray::Solid([0.0, 0.0, 0.0])),
-            Some(ColorArray::Transparent),
-            None,
-        ),
-    }
+    // The display list already carries the rect in top-down mm; the single shared
+    // builder does the one correct flip into printpdf's bottom-up point space. The
+    // legacy contact / cover-letter path calls the very same function, so the two
+    // PDF documents can never diverge on link-rect geometry.
+    link_annotation_op(
+        l.x_mm,
+        l.y_top_mm,
+        l.width_mm,
+        l.height_mm,
+        page_h,
+        l.url.clone(),
+    )
 }
 
 #[cfg(test)]

--- a/apps/tauri/src-tauri/src/export/model_docx.rs
+++ b/apps/tauri/src-tauri/src/export/model_docx.rs
@@ -55,16 +55,24 @@ pub(crate) fn generate_resume_docx(
         template,
         ats_mode,
         crate::locale::LocaleProfile::default().page_geometry(),
+        None,
+        "en",
     )
 }
 
 /// Render a resume to a `Docx` on a specific page geometry (locale-driven).
+///
+/// `contact` (when present) is the single source of truth for the header contact
+/// line, localized by `lang` — shared with the PDF backend so both documents'
+/// headers carry identical, correctly-named links.
 pub(crate) fn generate_resume_docx_in(
     text: &str,
     meta: Option<&GenerationMeta>,
     template: &Template,
     ats_mode: bool,
     geom: PageGeometry,
+    contact: Option<&crate::contact_profile::ContactProfile>,
+    lang: &str,
 ) -> Result<Docx> {
     let mut model = model_from_resume_text(text);
 
@@ -72,6 +80,10 @@ pub(crate) fn generate_resume_docx_in(
         if !name.trim().is_empty() {
             model.header.name = name.to_string();
         }
+    }
+
+    if let Some(profile) = contact {
+        profile.apply_to_header(&mut model.header, lang);
     }
 
     // ATS mode collapses to a single column and reorders sections for reading.

--- a/apps/tauri/src-tauri/src/export/parser/mod.rs
+++ b/apps/tauri/src-tauri/src/export/parser/mod.rs
@@ -9,10 +9,13 @@ pub fn normalize_unicode(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     for ch in text.chars() {
         let replacement: &str = match ch {
-            // Dashes / hyphens
-            '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' => "-", // hyphen / non-breaking hyphen / figure dash / en-dash
-            '\u{2014}' | '\u{2015}' => " - ",                         // em-dash / horizontal bar
-            '\u{2212}' => "-",                                        // minus sign
+            // Dashes / hyphens. En-dash (U+2013) and em-dash (U+2014) are PRESERVED
+            // (the bundled fonts contain both glyphs — asserted by a unit test); the
+            // later `typography` pass normalizes their spacing. Collapsing them to a
+            // bare hyphen used to mangle sentence-break dashes into "word- word".
+            '\u{2010}' | '\u{2011}' | '\u{2012}' => "-", // hyphen / non-breaking hyphen / figure dash
+            '\u{2015}' => "\u{2014}",                    // horizontal bar → em-dash
+            '\u{2212}' => "-",                           // minus sign
             // Quotes
             '\u{201C}' | '\u{201D}' | '\u{201E}' | '\u{201F}' => "\"", // double quotes
             '\u{2018}' | '\u{2019}' | '\u{201A}' | '\u{201B}' => "'", // single quotes / apostrophes
@@ -50,7 +53,7 @@ pub fn normalize_unicode(text: &str) -> String {
             '\u{00B9}' => "1",
             // Other
             '\u{2116}' => "No.",
-            '\u{2020}' | '\u{2021}' => "*", // daggers
+            '\u{2020}' | '\u{2021}' => "", // daggers — drop (never emit a stray asterisk)
             '\u{00B7}' => ".",              // middle dot
             // Private Use Area + icon-font glyphs + replacement char: these render
             // as boxes/garbage (or nothing) in the bundled fonts — drop them.
@@ -66,6 +69,66 @@ pub fn normalize_unicode(text: &str) -> String {
     }
     out
 }
+
+/// Strip stray Markdown emphasis the model occasionally leaks (`*React`, `AWS*`,
+/// `AWS*-Services`) WITHOUT touching valid `**bold**` runs (the renderer turns those
+/// into real bold) or in-word punctuation like `snake_case`. Runs after
+/// [`normalize_unicode`], before any Markdown parsing.
+pub fn sanitize_markdown(text: &str) -> String {
+    // Protect valid bold pairs, drop every remaining lone '*' and stray backtick,
+    // then restore the bold markers.
+    const BOLD: &str = "\u{0}B\u{0}";
+    text.replace("**", BOLD)
+        .chars()
+        .filter(|&c| c != '*' && c != '`')
+        .collect::<String>()
+        .replace(BOLD, "**")
+}
+
+/// Typography pass for dash usage. With en/em-dashes preserved by
+/// [`normalize_unicode`], normalize clause-level dash spacing to a spaced en-dash
+/// (" – ") and rewrite the residual ASCII "word- word" sentence-break pattern the
+/// same way — but never a German suspended hyphen (`Backend- und …`) or a tight
+/// compound / range (`2020–2023`, `state-of-the-art`).
+pub fn typography(text: &str) -> String {
+    let out = HYPHEN_BREAK_RE.replace_all(text, |c: &regex::Captures| {
+        let prev = &c[1];
+        let next = &c[2];
+        if SUSPENDED_HYPHEN_WORDS.contains(&next.to_lowercase().as_str()) {
+            format!("{prev}- {next}")
+        } else {
+            format!("{prev} \u{2013} {next}")
+        }
+    });
+    DASH_CLAUSE_SPACING_RE
+        .replace_all(&out, " \u{2013} ")
+        .into_owned()
+}
+
+/// A complete word, an ASCII hyphen, a space, then the next word — a sentence-break
+/// hyphen the model sometimes emits instead of a dash. (`e-mail`, `state-of-the-art`
+/// have no space after the hyphen and never match.)
+static HYPHEN_BREAK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(\p{L})- (\p{L}[\p{L}.]*)").unwrap());
+
+/// An en/em-dash used between clauses (a space on at least one side) → cleanly spaced
+/// en-dash. A tight range like `2020–2023` has no surrounding space and is left alone.
+static DASH_CLAUSE_SPACING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\s*[\u{2013}\u{2014}]\s+|\s+[\u{2013}\u{2014}]\s*").unwrap());
+
+/// German suspended-hyphen continuations: `Backend- und Frontend-…` is correct German
+/// and must keep its hyphen rather than become a dash.
+const SUSPENDED_HYPHEN_WORDS: &[&str] = &[
+    "und",
+    "oder",
+    "bzw",
+    "sowie",
+    "als",
+    "wie",
+    "bis",
+    "beziehungsweise",
+    "respektive",
+];
 
 /// Unicode Private Use Area code points (BMP + planes 15/16). Icon fonts
 /// (Font Awesome, etc.) map glyphs here, so extracted/pasted text often contains

--- a/apps/tauri/src-tauri/src/export/parser/mod.rs
+++ b/apps/tauri/src-tauri/src/export/parser/mod.rs
@@ -54,7 +54,7 @@ pub fn normalize_unicode(text: &str) -> String {
             // Other
             '\u{2116}' => "No.",
             '\u{2020}' | '\u{2021}' => "", // daggers — drop (never emit a stray asterisk)
-            '\u{00B7}' => ".",              // middle dot
+            '\u{00B7}' => ".",             // middle dot
             // Private Use Area + icon-font glyphs + replacement char: these render
             // as boxes/garbage (or nothing) in the bundled fonts — drop them.
             c if is_private_use(c) || c == '\u{FFFD}' => "",

--- a/apps/tauri/src-tauri/src/export/parser/test.rs
+++ b/apps/tauri/src-tauri/src/export/parser/test.rs
@@ -81,3 +81,28 @@ fn test_parse_resume() {
     assert!(doc.has_contact);
     assert!(doc.section_count > 0);
 }
+
+#[test]
+fn sanitize_markdown_strips_stray_emphasis_but_keeps_bold() {
+    // The observed symptom: lone asterisks leaked by the model.
+    assert_eq!(sanitize_markdown("*React and AWS*"), "React and AWS");
+    assert_eq!(sanitize_markdown("AWS*-Services"), "AWS-Services");
+    // Valid bold survives (the renderer turns it into real bold).
+    assert_eq!(sanitize_markdown("Use **React** today"), "Use **React** today");
+    // Stray backticks go; in-word underscores (snake_case) are left untouched.
+    assert_eq!(sanitize_markdown("a `code` span"), "a code span");
+    assert_eq!(sanitize_markdown("create_react_app"), "create_react_app");
+}
+
+#[test]
+fn typography_fixes_sentence_break_dashes_only() {
+    // En-dash glued to the previous word (cover-letter symptom) → spaced en-dash.
+    assert_eq!(typography("zu Hause\u{2013} die"), "zu Hause \u{2013} die");
+    // ASCII hyphen used as a sentence break → spaced en-dash.
+    assert_eq!(typography("zu Hause- die"), "zu Hause \u{2013} die");
+    // German suspended hyphen is preserved (NOT turned into a dash).
+    assert_eq!(typography("Backend- und Frontend"), "Backend- und Frontend");
+    // A tight numeric range and a real compound are left alone.
+    assert_eq!(typography("2020\u{2013}2023"), "2020\u{2013}2023");
+    assert_eq!(typography("state-of-the-art"), "state-of-the-art");
+}

--- a/apps/tauri/src-tauri/src/export/parser/test.rs
+++ b/apps/tauri/src-tauri/src/export/parser/test.rs
@@ -88,7 +88,10 @@ fn sanitize_markdown_strips_stray_emphasis_but_keeps_bold() {
     assert_eq!(sanitize_markdown("*React and AWS*"), "React and AWS");
     assert_eq!(sanitize_markdown("AWS*-Services"), "AWS-Services");
     // Valid bold survives (the renderer turns it into real bold).
-    assert_eq!(sanitize_markdown("Use **React** today"), "Use **React** today");
+    assert_eq!(
+        sanitize_markdown("Use **React** today"),
+        "Use **React** today"
+    );
     // Stray backticks go; in-word underscores (snake_case) are left untouched.
     assert_eq!(sanitize_markdown("a `code` span"), "a code span");
     assert_eq!(sanitize_markdown("create_react_app"), "create_react_app");

--- a/apps/tauri/src-tauri/src/export/pdf/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/mod.rs
@@ -405,6 +405,8 @@ fn generate_cover_letter_pdf(
     text: &str,
     meta: Option<&GenerationMeta>,
     template: &Template,
+    contact: Option<&crate::contact_profile::ContactProfile>,
+    lang: &str,
 ) -> Result<Vec<u8>> {
     let mut doc = PdfDocument::new("Cover Letter");
     let fonts = load_all_fonts(&mut doc)?;
@@ -422,18 +424,23 @@ fn generate_cover_letter_pdf(
         .map(|s| s.as_str())
         .unwrap_or("");
 
-    // Parse a contact line: join all lines that look like contact info
+    // Contact line: the named profile fields are the source of truth (shared with
+    // the résumé header, so both documents show identical correctly-named links).
+    // Fall back to scraping the generated text only when no profile is supplied.
     let raw_lines: Vec<&str> = text.lines().collect();
-    let contact_line: String = raw_lines
-        .iter()
-        .take(4)
-        .filter(|l| {
-            let c = strip_md(l.trim());
-            c.contains('@') || c.contains('|') || c.contains('·')
-        })
-        .map(|l| strip_md(l.trim()))
-        .collect::<Vec<_>>()
-        .join(" · ");
+    let contact_line: String = match contact {
+        Some(profile) if !profile.is_effectively_empty() => profile.header_markdown(lang),
+        _ => raw_lines
+            .iter()
+            .take(4)
+            .filter(|l| {
+                let c = strip_md(l.trim());
+                c.contains('@') || c.contains('|') || c.contains('·')
+            })
+            .map(|l| strip_md(l.trim()))
+            .collect::<Vec<_>>()
+            .join(" · "),
+    };
 
     // Render letterhead
     let render_ctx = RenderCtx {
@@ -800,6 +807,8 @@ pub fn generate_pdf(request: &ExportRequest) -> Result<Vec<u8>> {
                     &template,
                     request.ats_mode,
                     request.page_geometry(),
+                    request.contact.as_ref(),
+                    &request.target_lang(),
                 )
             } else {
                 generate_resume_pdf(text, request.meta.as_ref(), &template, request.ats_mode)
@@ -809,8 +818,14 @@ pub fn generate_pdf(request: &ExportRequest) -> Result<Vec<u8>> {
         DocumentType::CoverLetter => {
             let text = extract_section(&request.text, "### COMPLETE COVER LETTER ###", None);
             let text = if text.is_empty() { &request.text } else { text };
-            generate_cover_letter_pdf(text, request.meta.as_ref(), &template)
-                .context("Failed to generate cover letter PDF")
+            generate_cover_letter_pdf(
+                text,
+                request.meta.as_ref(),
+                &template,
+                request.contact.as_ref(),
+                &request.target_lang(),
+            )
+            .context("Failed to generate cover letter PDF")
         }
     }
 }

--- a/apps/tauri/src-tauri/src/export/pdf/test.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/test.rs
@@ -82,6 +82,7 @@ fn test_generate_pdf_resume_basic() {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -97,6 +98,7 @@ fn test_generate_pdf_cover_letter_basic() {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -117,6 +119,7 @@ fn test_generate_pdf_resume_with_meta() {
         }),
         ats_mode: false,
         locale: None,
+        contact: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -133,6 +136,7 @@ fn test_generate_pdf_resume_with_section_markers() {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -150,6 +154,7 @@ fn test_generate_pdf_cover_letter_with_section_markers() {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     };
     let result = generate_pdf(&request);
     assert!(result.is_ok());
@@ -197,6 +202,7 @@ fn resume_pdf_embeds_contact_link_annotations() {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     };
     let bytes = generate_pdf(&request).expect("resume pdf");
     let doc = lopdf::Document::load_mem(&bytes).expect("parse generated pdf");
@@ -225,6 +231,7 @@ fn centered_template_resume_pdf_is_generated() {
         meta: None,
         ats_mode: false,
         locale: None,
+        contact: None,
     };
     let bytes = generate_pdf(&request).expect("executive resume pdf");
     assert!(

--- a/apps/tauri/src-tauri/src/export/pdf_renderer/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf_renderer/mod.rs
@@ -280,6 +280,43 @@ pub(crate) fn contact_link_rects(
     out
 }
 
+/// Build a clickable link annotation `Op` from a rectangle given in **top-down**
+/// millimetres (x, top edge, width, height measured from the page top), doing the
+/// single correct flip into printpdf's bottom-up point space.
+///
+/// Shared by the modern layout engine ([`super::layout_pdf`]) and the legacy
+/// contact / cover-letter path so there is exactly ONE annotation code path — no
+/// per-renderer coordinate math that can diverge (which is what dumped the cover
+/// letter's header links to the page bottom).
+pub fn link_annotation_op(
+    x_mm: f32,
+    y_top_mm: f32,
+    width_mm: f32,
+    height_mm: f32,
+    page_height_mm: f32,
+    url: String,
+) -> Op {
+    const PT_PER_MM: f32 = 2.834_645_7;
+    let y_bottom_pt = (page_height_mm - (y_top_mm + height_mm)) * PT_PER_MM;
+    let rect = Rect {
+        x: Pt(x_mm * PT_PER_MM),
+        y: Pt(y_bottom_pt),
+        width: Pt(width_mm * PT_PER_MM),
+        height: Pt(height_mm * PT_PER_MM),
+        mode: None,
+        winding_order: None,
+    };
+    Op::LinkAnnotation {
+        link: LinkAnnotation::new(
+            rect,
+            Actions::Uri(url),
+            Some(BorderArray::Solid([0.0, 0.0, 0.0])),
+            Some(ColorArray::Transparent),
+            None,
+        ),
+    }
+}
+
 /// Setup color palette from template.
 pub fn setup_colors(template: &Template) -> ColorPalette {
     ColorPalette {
@@ -922,31 +959,25 @@ fn render_contact_text_with_links(text: &str, ctx: ContactSpanCtx<'_>, ops: &mut
         Op::EndTextSection,
     ]);
 
-    // Clickable rects, positioned by real glyph advances (not a char-count guess).
-    let page_h_pt = page_height * 2.834_645_7;
-    let rect_y_bottom = page_h_pt - (y * 2.834_645_7);
-    let rect_y_top = rect_y_bottom + font_size * 1.1;
+    // Clickable rects, anchored to the SAME baseline the text uses. `y` is the
+    // baseline in printpdf bottom-up mm (the text above is drawn at `Mm(y)`), so
+    // the rect's top edge expressed in top-down mm is `(page_height - y) - ascent`.
+    // `link_annotation_op` then performs the single flip into point space. The old
+    // code recomputed `page_height - y` here AND flipped again, which placed every
+    // rect near the page bottom (the cover-letter header-link bug).
+    let ascent_mm = pt_to_mm(font_size * 0.8);
+    let height_mm = pt_to_mm(font_size * 1.1);
+    let y_top_mm = (page_height - y) - ascent_mm;
 
     for link in contact_link_rects(text, x_start, family, font_size, &FontMetrics) {
-        let x_left = link.x_left_mm * 2.834_645_7;
-        let width = link.width_mm * 2.834_645_7;
-        let rect = Rect {
-            x: Pt(x_left),
-            y: Pt(rect_y_bottom),
-            width: Pt(width),
-            height: Pt(rect_y_top - rect_y_bottom),
-            mode: None,
-            winding_order: None,
-        };
-        ops.push(Op::LinkAnnotation {
-            link: LinkAnnotation::new(
-                rect,
-                Actions::Uri(link.url),
-                Some(BorderArray::Solid([0.0, 0.0, 0.0])),
-                Some(ColorArray::Transparent),
-                None,
-            ),
-        });
+        ops.push(link_annotation_op(
+            link.x_left_mm,
+            y_top_mm,
+            link.width_mm,
+            height_mm,
+            page_height,
+            link.url,
+        ));
     }
 }
 

--- a/apps/tauri/src-tauri/src/export/types.rs
+++ b/apps/tauri/src-tauri/src/export/types.rs
@@ -75,12 +75,31 @@ pub struct ExportRequest {
     /// the rest → A4). Optional so frontends that omit it keep the A4 default.
     #[serde(default)]
     pub locale: Option<String>,
+    /// User contact profile — the single source of truth for the header contact
+    /// line (name fields → `[Label](url)`), localized per language. When present
+    /// it overrides whatever links the generated text carried, so a personal
+    /// LinkedIn / Website can never be displaced by a company-link. Optional so
+    /// older frontends keep the text-derived header.
+    #[serde(default)]
+    pub contact: Option<crate::contact_profile::ContactProfile>,
 }
 
 impl ExportRequest {
     /// Page geometry for this request's locale (international A4 by default).
     pub fn page_geometry(&self) -> crate::locale::PageGeometry {
         crate::locale::LocaleProfile::get(self.locale.as_deref().unwrap_or("en")).page_geometry()
+    }
+
+    /// Language the document is written in (drives the localized header location).
+    /// Falls back to the request locale, then `en`.
+    pub fn target_lang(&self) -> String {
+        self.meta
+            .as_ref()
+            .and_then(|m| m.target_language.as_deref())
+            .filter(|s| !s.is_empty())
+            .or(self.locale.as_deref())
+            .unwrap_or("en")
+            .to_string()
     }
 }
 

--- a/apps/tauri/src-tauri/src/layout/mod.rs
+++ b/apps/tauri/src-tauri/src/layout/mod.rs
@@ -686,7 +686,11 @@ impl<'a> Flow<'a> {
         // legacy renderer wouldn't — preserving the parity gate. A role longer than a
         // page still breaks later via the per-line guards below.
         let keep_together_h = self.body_line()
-            + if e.subtitle.is_some() { self.body_line() } else { 0.0 }
+            + if e.subtitle.is_some() {
+                self.body_line()
+            } else {
+                0.0
+            }
             + self.body_line();
         if self.would_overflow(before + keep_together_h) && !self.cur.texts.is_empty() {
             self.new_page();

--- a/apps/tauri/src-tauri/src/layout/mod.rs
+++ b/apps/tauri/src-tauri/src/layout/mod.rs
@@ -679,8 +679,16 @@ impl<'a> Flow<'a> {
         } else {
             (0.0, 0.0)
         };
-        // Keep the title with at least its subtitle / first bullet.
-        if self.would_overflow(before + self.body_line() * 2.0) && !self.cur.texts.is_empty() {
+        // Keep-with-next: bind the entry title to its subtitle (role) and the first
+        // bullet line, so a title is never orphaned at the foot of a page and a role
+        // never splits onto a near-empty next page. Sized at or below the legacy
+        // renderer's reservation (title + ~2 lines), so it never breaks a page the
+        // legacy renderer wouldn't — preserving the parity gate. A role longer than a
+        // page still breaks later via the per-line guards below.
+        let keep_together_h = self.body_line()
+            + if e.subtitle.is_some() { self.body_line() } else { 0.0 }
+            + self.body_line();
+        if self.would_overflow(before + keep_together_h) && !self.cur.texts.is_empty() {
             self.new_page();
         } else {
             self.y += before;

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ mod autopilot_helpers;
 mod autopilot_scheduler;
 mod browser;
 mod commands;
+mod contact_profile;
 mod conversations;
 mod cover_letter;
 mod credentials;
@@ -195,6 +196,14 @@ fn main() {
                     log::warn!("[setup] job preferences store failed to open (non-fatal): {e}")
                 }
             }
+            match contact_profile::ContactProfileStore::open(&data_dir) {
+                Ok(store) => {
+                    app.manage(store);
+                }
+                Err(e) => {
+                    log::warn!("[setup] contact profile store failed to open (non-fatal): {e}")
+                }
+            }
             app.manage(Mutex::new(JobTracker::open(&data_dir)));
             app.manage(Mutex::new(PostingsCache::default()));
             app.manage(Mutex::new(InteractionStore::new(&data_dir)));
@@ -295,6 +304,9 @@ fn main() {
             // job preferences
             commands::job_preferences::job_preferences_get,
             commands::job_preferences::job_preferences_set,
+            // contact profile (header source of truth)
+            commands::contact_profile::contact_profile_get,
+            commands::contact_profile::contact_profile_set,
             // search
             commands::search::search_hybrid,
             // scrape

--- a/apps/tauri/src-tauri/src/measure/mod.rs
+++ b/apps/tauri/src-tauri/src/measure/mod.rs
@@ -178,4 +178,25 @@ mod tests {
             0.0
         );
     }
+
+    #[test]
+    fn bundled_faces_contain_en_and_em_dash_glyphs() {
+        // The export pipeline now PRESERVES U+2013 / U+2014 instead of collapsing
+        // them to '-', so every embedded face must actually carry both glyphs or a
+        // sentence-break dash would render as a missing-glyph box.
+        for f in ALL {
+            for bold in [false, true] {
+                let face = FontMetrics::face(f, bold)
+                    .unwrap_or_else(|| panic!("face must parse for {f:?} bold={bold}"));
+                assert!(
+                    face.glyph_index('\u{2013}').is_some(),
+                    "{f:?} bold={bold} is missing the en-dash (U+2013) glyph"
+                );
+                assert!(
+                    face.glyph_index('\u{2014}').is_some(),
+                    "{f:?} bold={bold} is missing the em-dash (U+2014) glyph"
+                );
+            }
+        }
+    }
 }

--- a/apps/tauri/src-tauri/src/validate/mod.rs
+++ b/apps/tauri/src-tauri/src/validate/mod.rs
@@ -197,7 +197,206 @@ fn run_validators(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> {
     // Column interleaving is only possible for a two-column layout that has not
     // been linearized to a single column.
     let two_column = matches!(request.template_id, TemplateId::TwoColumn) && !request.ats_mode;
-    evaluate(&expected, &extracted, two_column, request.document_type)
+    let mut issues = evaluate(&expected, &extracted, two_column, request.document_type);
+
+    // Render-correctness gates that must hold for EVERY generated document, so the
+    // header-link and stray-markdown defects can't regress for a future résumé.
+    issues.extend(stray_markdown_issues(&extracted));
+    if matches!(request.format, ExportFormat::Pdf) {
+        issues.extend(pdf_render_issues(request, bytes));
+    }
+    issues
+}
+
+/// Reject stray Markdown emphasis (`*`, backtick) that survived sanitization into
+/// the rendered text — the leaked-asterisk symptom. Applies to PDF and DOCX.
+fn stray_markdown_issues(extracted: &str) -> Vec<ExportIssue> {
+    if extracted.contains('*') || extracted.contains('`') {
+        vec![ExportIssue::critical(
+            "stray_markdown",
+            "The exported document contains stray Markdown markers (* or `) that should \
+             have been stripped — emphasis leaked into the visible text.",
+        )]
+    } else {
+        Vec::new()
+    }
+}
+
+/// A link annotation read back from the rendered PDF: its `/Rect` in PDF user
+/// space (points, bottom-up origin) and target URL.
+struct PdfLink {
+    /// `[x0, y0, x1, y1]` — bottom-left and top-right corners in points.
+    rect: [f32; 4],
+    url: String,
+    /// 0-based page index the annotation lives on.
+    page: usize,
+}
+
+/// Render-level checks over the actual PDF bytes (renderer-agnostic, so the modern
+/// résumé engine and the legacy cover-letter path are both covered):
+///   * `empty_anchor_link` — every link rect overlaps rendered text (catches the
+///     header links dumped to the page bottom with no glyphs under them).
+///   * `header_url_mismatch` — when a contact profile is the source of truth, every
+///     header-region link URL must be one of the profile's named fields, and every
+///     profile URL must appear in the header (catches a company-link displacing a
+///     personal profile / site).
+fn pdf_render_issues(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> {
+    let doc = match lopdf::Document::load_mem(bytes) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(), // tooling failure never blocks
+    };
+    let page_h_pt = request.page_geometry().height_mm * 2.834_645_7;
+
+    let pages: Vec<(usize, lopdf::ObjectId)> = doc.get_pages().into_values().enumerate().collect();
+    let mut links: Vec<PdfLink> = Vec::new();
+    let mut baselines_by_page: Vec<Vec<f32>> = Vec::new();
+
+    for (idx, page_id) in &pages {
+        baselines_by_page.push(text_baseline_ys(&doc, *page_id));
+        links.extend(page_link_annotations(&doc, *page_id, *idx));
+    }
+
+    let mut issues = Vec::new();
+
+    // (1) Every link must overlap text on its page (no empty-anchor / floating rect).
+    for link in &links {
+        let y0 = link.rect[1].min(link.rect[3]);
+        let y1 = link.rect[1].max(link.rect[3]);
+        let baselines = baselines_by_page
+            .get(link.page)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let anchored = baselines.iter().any(|&y| y >= y0 - 3.0 && y <= y1 + 3.0);
+        if !anchored {
+            issues.push(ExportIssue::critical(
+                "empty_anchor_link",
+                format!(
+                    "A hyperlink to {} has no text beneath it — the clickable area is \
+                     misplaced (likely a coordinate-origin flip).",
+                    link.url
+                ),
+            ));
+        }
+    }
+
+    // (2) Header URL correctness against the contact profile (when supplied).
+    if let Some(profile) = request
+        .contact
+        .as_ref()
+        .filter(|p| !p.is_effectively_empty())
+    {
+        let allowed: std::collections::BTreeSet<String> =
+            profile.header_urls().into_iter().collect();
+        // Header region: the top ~2 inches (144 pt) of the first page.
+        let header_band_bottom = page_h_pt - 144.0;
+        let header_links: Vec<&PdfLink> = links
+            .iter()
+            .filter(|l| l.page == 0 && l.rect[1].max(l.rect[3]) >= header_band_bottom)
+            .collect();
+
+        for link in &header_links {
+            if !allowed.contains(&link.url) {
+                issues.push(ExportIssue::critical(
+                    "header_url_mismatch",
+                    format!(
+                        "Header link {} is not one of the contact profile's fields — a \
+                         body/company link leaked into the header.",
+                        link.url
+                    ),
+                ));
+            }
+        }
+        for url in &allowed {
+            if !header_links.iter().any(|l| &l.url == url) {
+                issues.push(ExportIssue::critical(
+                    "header_url_mismatch",
+                    format!("Contact profile link {url} is missing from the rendered header."),
+                ));
+            }
+        }
+    }
+
+    issues
+}
+
+/// Collect text baseline Y positions (points, bottom-up) from a page's content
+/// stream, from the text-positioning operators the renderers emit.
+fn text_baseline_ys(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> Vec<f32> {
+    let Ok(content) = doc.get_page_content(page_id) else {
+        return Vec::new();
+    };
+    let Ok(decoded) = lopdf::content::Content::decode(&content) else {
+        return Vec::new();
+    };
+    let mut ys = Vec::new();
+    for op in &decoded.operations {
+        let y = match op.operator.as_str() {
+            // `x y Td` / `x y TD` — operand[1] is the baseline y.
+            "Td" | "TD" => op.operands.get(1).and_then(|o| o.as_float().ok()),
+            // `a b c d e f Tm` — operand[5] is the baseline y.
+            "Tm" => op.operands.get(5).and_then(|o| o.as_float().ok()),
+            _ => None,
+        };
+        if let Some(y) = y {
+            ys.push(y);
+        }
+    }
+    ys
+}
+
+/// Collect `/Link` annotations (rect + `/A /URI`) for one page.
+fn page_link_annotations(
+    doc: &lopdf::Document,
+    page_id: lopdf::ObjectId,
+    page_idx: usize,
+) -> Vec<PdfLink> {
+    let Ok(annots) = doc.get_page_annotations(page_id) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for annot in annots {
+        let is_link = annot
+            .get(b"Subtype")
+            .and_then(|v| v.as_name())
+            .map(|n| n == b"Link")
+            .unwrap_or(false);
+        if !is_link {
+            continue;
+        }
+        let Some(rect) = annot
+            .get(b"Rect")
+            .ok()
+            .and_then(|v| v.as_array().ok())
+            .and_then(|a| {
+                let v: Vec<f32> = a.iter().filter_map(|o| o.as_float().ok()).collect();
+                <[f32; 4]>::try_from(v).ok()
+            })
+        else {
+            continue;
+        };
+        let url = annot
+            .get(b"A")
+            .ok()
+            .and_then(|a| match a {
+                lopdf::Object::Dictionary(d) => Some(d.clone()),
+                lopdf::Object::Reference(id) => doc.get_dictionary(*id).ok().cloned(),
+                _ => None,
+            })
+            .and_then(|d| {
+                d.get(b"URI")
+                    .ok()
+                    .and_then(|u| u.as_str().ok())
+                    .map(|b| String::from_utf8_lossy(b).into_owned())
+            });
+        if let Some(url) = url {
+            out.push(PdfLink {
+                rect,
+                url,
+                page: page_idx,
+            });
+        }
+    }
+    out
 }
 
 /// Compare the expected content against the re-extracted text.

--- a/apps/tauri/src-tauri/src/validate/tests.rs
+++ b/apps/tauri/src-tauri/src/validate/tests.rs
@@ -129,6 +129,7 @@ fn req(format: ExportFormat, template_id: TemplateId, ats_mode: bool) -> ExportR
         meta: None,
         ats_mode,
         locale: None,
+        contact: None,
     }
 }
 

--- a/apps/tauri/src-tauri/tests/architecture.rs
+++ b/apps/tauri/src-tauri/tests/architecture.rs
@@ -40,6 +40,7 @@ const L1: &[&str] = &[
     "conversations",
     "credentials",
     "job_preferences",
+    "contact_profile",
     "ai_generations",
     "profile_import",
     "model",
@@ -295,6 +296,7 @@ const R3_ALLOW: &[&str] = &[
     "conversations/mod.rs",
     "documents/mod.rs",
     "job_preferences/mod.rs",
+    "contact_profile/mod.rs",
     "jobs/mod.rs",
     "pipeline/cache/mod.rs",
 ];

--- a/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.tsx
@@ -4,6 +4,7 @@ import { IconBadge, transition, variants } from '@ajh/ui';
 
 import { AccountsSettingsTab } from '@/features/settings/components/accounts/AccountsSettingsTab';
 import { AISettingsTab } from '@/features/settings/components/ai-settings/AISettingsTab';
+import { ContactProfileTab } from '@/features/settings/components/contact/ContactProfileTab';
 import { GeneralSection } from '@/features/settings/components/general-section';
 import { DeveloperPreferences } from '@/features/settings/components/preferences/DeveloperPreferences';
 import { JobLocationPreferences } from '@/features/settings/components/preferences/JobLocationPreferences';
@@ -63,6 +64,7 @@ export function SettingsContent({
                 userName={userName}
               />
             )}
+            {activeSection === 'contact' && <ContactProfileTab />}
             {activeSection === 'ai' && (
               <>
                 <AISettingsTab />

--- a/apps/tauri/src/renderer/features/settings/components/contact/ContactProfileTab/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/contact/ContactProfileTab/index.tsx
@@ -1,0 +1,186 @@
+import { Contact } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import type { ContactProfile } from '@ajh/shared';
+import { Input, SettingsSection } from '@ajh/ui';
+
+import { useContactProfile, useSaveContactProfile } from '@/services';
+
+const FIELD_CLASS = 'flex flex-col gap-1.5';
+const LABEL_CLASS = 'text-xs font-medium text-foreground/70';
+
+/**
+ * Edit the contact profile — the single source of truth for the document header
+ * contact line. The résumé, cover letter, and DOCX all build their header from
+ * these named fields (never the résumé's company-link pool), so a personal
+ * LinkedIn / Website can't be displaced by an employer URL. Seeded from an
+ * uploaded résumé on import, then freely editable here.
+ *
+ * Follows the settings convention: changes persist on blur, no explicit save.
+ */
+export function ContactProfileTab() {
+  const { data: profile } = useContactProfile();
+  const { mutate: save } = useSaveContactProfile();
+
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [locationDefault, setLocationDefault] = useState('');
+  const [locationDe, setLocationDe] = useState('');
+  const [linkedin, setLinkedin] = useState('');
+  const [github, setGithub] = useState('');
+  const [website, setWebsite] = useState('');
+
+  // Hydrate the form once the stored profile loads (or changes).
+  useEffect(() => {
+    if (!profile) return;
+    setFullName(profile.fullName ?? '');
+    setEmail(profile.email ?? '');
+    setPhone(profile.phone ?? '');
+    setLocationDefault(profile.location?.default ?? '');
+    setLocationDe(profile.location?.byLang?.de ?? '');
+    setLinkedin(profile.linkedin ?? '');
+    setGithub(profile.github ?? '');
+    setWebsite(profile.website ?? '');
+  }, [profile]);
+
+  // Persist the whole profile from current field state (called on blur).
+  const persist = () => {
+    const clean = (s: string) => s.trim() || undefined;
+    const byLang: Record<string, string> = {};
+    if (locationDe.trim()) byLang.de = locationDe.trim();
+
+    const next: ContactProfile = {
+      fullName: clean(fullName),
+      email: clean(email),
+      phone: clean(phone),
+      location: locationDefault.trim()
+        ? {
+            default: locationDefault.trim(),
+            byLang: Object.keys(byLang).length ? byLang : undefined,
+          }
+        : undefined,
+      linkedin: clean(linkedin),
+      github: clean(github),
+      website: clean(website),
+      // Preserve any extra links seeded on import — the form doesn't edit them.
+      extraLinks: profile?.extraLinks,
+    };
+    save(next);
+  };
+
+  return (
+    <SettingsSection icon={Contact} label="Contact Profile">
+      <p className="mb-4 text-xs text-foreground/55">
+        The header on your résumé and cover letter is built from these fields — your name, email,
+        phone, location, and personal profile links. Editing them keeps every generated document
+        correct and consistent. Changes save automatically.
+      </p>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-name">
+            Full name
+          </label>
+          <Input
+            id="cp-name"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            onBlur={persist}
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-email">
+            Email
+          </label>
+          <Input
+            id="cp-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onBlur={persist}
+            placeholder="name@example.com"
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-phone">
+            Phone
+          </label>
+          <Input
+            id="cp-phone"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            onBlur={persist}
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-location">
+            Location (English documents)
+          </label>
+          <Input
+            id="cp-location"
+            value={locationDefault}
+            onChange={(e) => setLocationDefault(e.target.value)}
+            onBlur={persist}
+            placeholder="Netherlands"
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-location-de">
+            Location (German documents)
+          </label>
+          <Input
+            id="cp-location-de"
+            value={locationDe}
+            onChange={(e) => setLocationDe(e.target.value)}
+            onBlur={persist}
+            placeholder="Niederlande"
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-linkedin">
+            LinkedIn
+          </label>
+          <Input
+            id="cp-linkedin"
+            value={linkedin}
+            onChange={(e) => setLinkedin(e.target.value)}
+            onBlur={persist}
+            placeholder="https://www.linkedin.com/in/your-profile/"
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-github">
+            GitHub
+          </label>
+          <Input
+            id="cp-github"
+            value={github}
+            onChange={(e) => setGithub(e.target.value)}
+            onBlur={persist}
+            placeholder="https://github.com/your-handle"
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-website">
+            Website
+          </label>
+          <Input
+            id="cp-website"
+            value={website}
+            onChange={(e) => setWebsite(e.target.value)}
+            onBlur={persist}
+            placeholder="https://your-site.com"
+          />
+        </div>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/tauri/src/renderer/features/settings/constants.ts
+++ b/apps/tauri/src/renderer/features/settings/constants.ts
@@ -1,7 +1,18 @@
-import { Briefcase, Cpu, FileText, Gauge, Languages, Lock, Shield, Terminal } from 'lucide-react';
+import {
+  Briefcase,
+  Contact,
+  Cpu,
+  FileText,
+  Gauge,
+  Languages,
+  Lock,
+  Shield,
+  Terminal,
+} from 'lucide-react';
 
 export type SectionId =
   | 'general'
+  | 'contact'
   | 'ai'
   | 'job'
   | 'resume'
@@ -31,6 +42,12 @@ export const NAV_GROUPS: NavGroup[] = [
         label: 'settings.sections.general.label',
         icon: Languages,
         description: 'settings.sections.general.description',
+      },
+      {
+        id: 'contact',
+        label: 'settings.sections.contact.label',
+        icon: Contact,
+        description: 'settings.sections.contact.description',
       },
       {
         id: 'ai',

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -996,6 +996,10 @@
           "label": "Allgemein",
           "description": "Name, Sprache, Aussehen"
         },
+        "contact": {
+          "label": "Kontaktprofil",
+          "description": "Kopfzeilen-Angaben & Profillinks"
+        },
         "ai": {
           "label": "KI",
           "description": "Modelle, Ton, Generierung"

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -996,6 +996,10 @@
           "label": "General",
           "description": "Name, language, appearance"
         },
+        "contact": {
+          "label": "Contact Profile",
+          "description": "Header details & profile links"
+        },
         "ai": {
           "label": "AI",
           "description": "Models, tone, generation"

--- a/apps/tauri/src/renderer/lib/generate/export/export.ts
+++ b/apps/tauri/src/renderer/lib/generate/export/export.ts
@@ -87,6 +87,11 @@ export async function exportDOCX(
 
     const api = getClient();
     const exportText = type === 'cover-letter' ? extractCoverLetterText(text) : text;
+    // The stored contact profile is the source of truth for the header contact
+    // line — passing it lets the backend build the header from named fields
+    // (never the résumé's company-link pool). Missing profile → undefined (the
+    // backend falls back to the text-derived header).
+    const contact = await api.contactProfile.get().catch(() => undefined);
     const _filePath = await api.documents.exportAndSave({
       text: exportText,
       format: 'docx',
@@ -94,6 +99,7 @@ export async function exportDOCX(
       templateId,
       atsMode,
       locale,
+      contact,
       meta: meta
         ? {
             candidateName: meta.candidateName,
@@ -135,6 +141,8 @@ export async function exportPDF(
 
     const api = getClient();
     const exportText = type === 'cover-letter' ? extractCoverLetterText(text) : text;
+    // See exportDOCX: the contact profile is the header source of truth.
+    const contact = await api.contactProfile.get().catch(() => undefined);
     const _filePath = await api.documents.exportAndSave({
       text: exportText,
       format: 'pdf',
@@ -142,6 +150,7 @@ export async function exportPDF(
       templateId,
       atsMode,
       locale,
+      contact,
       meta: meta
         ? {
             candidateName: meta.candidateName,

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -101,6 +101,11 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       set: noop,
     },
 
+    contactProfile: {
+      get: async () => ({}),
+      set: async () => ({ success: true }),
+    },
+
     search: {
       hybrid: async () => [] as SearchHit<unknown>[],
     },

--- a/apps/tauri/src/renderer/services/index.ts
+++ b/apps/tauri/src/renderer/services/index.ts
@@ -18,6 +18,7 @@ export * from './use-ai-provider';
 export * from './use-apply';
 export * from './use-autopilot';
 export * from './use-boards';
+export * from './use-contact-profile';
 export * from './use-conversations';
 export * from './use-credentials';
 export * from './use-data';

--- a/apps/tauri/src/renderer/services/query-client/query-client.ts
+++ b/apps/tauri/src/renderer/services/query-client/query-client.ts
@@ -49,6 +49,7 @@ export const keys = {
   },
   documents: { all: ['documents'] as const },
   jobPreferences: { all: ['jobPreferences'] as const },
+  contactProfile: { all: ['contactProfile'] as const },
   postings: {
     all: ['postings'] as const,
     interactions: (type?: string) => ['postings', 'interactions', type] as const,

--- a/apps/tauri/src/renderer/services/use-contact-profile/index.ts
+++ b/apps/tauri/src/renderer/services/use-contact-profile/index.ts
@@ -1,0 +1,1 @@
+export * from './use-contact-profile';

--- a/apps/tauri/src/renderer/services/use-contact-profile/use-contact-profile.ts
+++ b/apps/tauri/src/renderer/services/use-contact-profile/use-contact-profile.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { ContactProfile } from '@ajh/shared';
+
+import { useAppClient } from '@/providers/AppClientProvider';
+
+import { keys } from '../query-client';
+
+export const useContactProfile = () => {
+  const api = useAppClient();
+  return useQuery({
+    queryKey: keys.contactProfile.all,
+    queryFn: () => api.contactProfile.get(),
+  });
+};
+
+export const useSaveContactProfile = () => {
+  const api = useAppClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (profile: ContactProfile) => api.contactProfile.set(profile),
+    onSuccess: () => qc.invalidateQueries({ queryKey: keys.contactProfile.all }),
+  });
+};

--- a/apps/tauri/src/renderer/store/session-store/session-store.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.ts
@@ -48,6 +48,7 @@ interface ResumesSlice {
 
 type SettingsSection =
   | 'general'
+  | 'contact'
   | 'ai'
   | 'job'
   | 'resume'

--- a/apps/tauri/src/tauri-client/index.ts
+++ b/apps/tauri/src/tauri-client/index.ts
@@ -19,6 +19,7 @@ import { aiGenerations } from './namespaces/aiGenerations/index.js';
 import { apply } from './namespaces/apply/index.js';
 import { autopilot } from './namespaces/autopilot/index.js';
 import { boards } from './namespaces/boards/index.js';
+import { contactProfile } from './namespaces/contactProfile/index.js';
 import { conversations } from './namespaces/conversations/index.js';
 import { credentials } from './namespaces/credentials/index.js';
 import { data } from './namespaces/data/index.js';
@@ -46,6 +47,7 @@ export function createTauriInvokeClient(): AppClient {
     ai: ai as AppClient['ai'],
     documents: documents as AppClient['documents'],
     jobPreferences: jobPreferences as AppClient['jobPreferences'],
+    contactProfile: contactProfile as AppClient['contactProfile'],
     search: search as AppClient['search'],
     scrape: scrape as AppClient['scrape'],
     match: match as AppClient['match'],

--- a/apps/tauri/src/tauri-client/namespaces/contactProfile/contactProfile.ts
+++ b/apps/tauri/src/tauri-client/namespaces/contactProfile/contactProfile.ts
@@ -1,0 +1,6 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export const contactProfile = {
+  get: () => invoke('contact_profile_get'),
+  set: (profile: unknown) => invoke('contact_profile_set', { profile }),
+};

--- a/apps/tauri/src/tauri-client/namespaces/contactProfile/index.ts
+++ b/apps/tauri/src/tauri-client/namespaces/contactProfile/index.ts
@@ -1,0 +1,1 @@
+export { contactProfile } from './contactProfile';

--- a/packages/shared/src/ipc/contracts.test.ts
+++ b/packages/shared/src/ipc/contracts.test.ts
@@ -19,6 +19,7 @@ describe('IPC_CHANNELS', () => {
         'documents',
         'geocode',
         'jobPreferences',
+        'contactProfile',
         'jobs',
         'linkedin',
         'match',

--- a/packages/shared/src/ipc/contracts/contactProfile.ts
+++ b/packages/shared/src/ipc/contracts/contactProfile.ts
@@ -1,0 +1,42 @@
+/**
+ * Contact profile — the single source of truth for the document header contact
+ * line (name fields → clickable links), localized per language. Built from the
+ * named fields here, never scavenged from the résumé's link pool, so a company
+ * link can't displace the candidate's own profile / site.
+ */
+
+/** A free-text value with optional per-language (ISO-639-1) overrides. */
+export interface LocalizedText {
+  /** Value used when no language override matches. */
+  default: string;
+  /** ISO-639-1 (`de`, `en`, …) → localized value. */
+  byLang?: Record<string, string>;
+}
+
+/** One additional labelled link beyond the named platform fields. */
+export interface ContactLink {
+  label: string;
+  url: string;
+}
+
+/** Header contact fields, by name. Every field is optional. */
+export interface ContactProfile {
+  fullName?: string;
+  email?: string;
+  phone?: string;
+  location?: LocalizedText;
+  linkedin?: string;
+  github?: string;
+  website?: string;
+  extraLinks?: ContactLink[];
+}
+
+export interface ContactProfileContract {
+  get(): Promise<ContactProfile>;
+  set(profile: ContactProfile): Promise<{ success?: boolean; error?: string }>;
+}
+
+export const CONTACT_PROFILE_CHANNELS = {
+  get: 'contact_profile_get',
+  set: 'contact_profile_set',
+} as const;

--- a/packages/shared/src/ipc/contracts/documents.ts
+++ b/packages/shared/src/ipc/contracts/documents.ts
@@ -1,5 +1,6 @@
 import type { DocumentImportRequest } from '../../schemas/index.js';
 import type { DocumentRecord } from '../../types/index.js';
+import type { ContactProfile } from './contactProfile.js';
 
 export type TemplateId =
   | 'classic'
@@ -29,6 +30,12 @@ interface BaseExportRequest {
   atsMode?: boolean;
   /** Target market id (`us`, `de`, …); drives the page size (US → Letter, else A4). */
   locale?: string;
+  /**
+   * Header contact source of truth — named fields rendered as clickable links,
+   * localized per language. When present it overrides whatever links the
+   * generated text carried, so a company link can't displace a personal profile.
+   */
+  contact?: ContactProfile;
 }
 
 export type ExportIssueSeverity = 'critical' | 'warning';

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -21,6 +21,7 @@ import { AI_GENERATIONS_CHANNELS, type AiGenerationsContract } from './aiGenerat
 import { APPLY_CHANNELS, type ApplyContract } from './apply.js';
 import { AUTOPILOT_CHANNELS, type AutopilotContract } from './autopilot.js';
 import { BOARDS_CHANNELS, type BoardsContract } from './boards.js';
+import { CONTACT_PROFILE_CHANNELS, type ContactProfileContract } from './contactProfile.js';
 import { CONVERSATIONS_CHANNELS, type ConversationsContract } from './conversations.js';
 import { CREDENTIALS_CHANNELS, type CredentialsContract } from './credentials.js';
 import { DATA_CHANNELS, type DataContract } from './data.js';
@@ -49,6 +50,7 @@ export interface IpcContract {
   ai: AiContract;
   documents: DocumentsContract;
   jobPreferences: JobPreferencesContract;
+  contactProfile: ContactProfileContract;
   search: SearchContract;
   scrape: ScrapeContract;
   match: MatchContract;
@@ -77,6 +79,7 @@ export const IPC_CHANNELS = {
   ai: AI_CHANNELS,
   documents: DOCUMENTS_CHANNELS,
   jobPreferences: JOB_PREFERENCES_CHANNELS,
+  contactProfile: CONTACT_PROFILE_CHANNELS,
   search: SEARCH_CHANNELS,
   scrape: SCRAPE_CHANNELS,
   match: MATCH_CHANNELS,
@@ -130,6 +133,13 @@ export {
   type AutopilotStepEvent,
 } from './autopilot.js';
 export { BOARDS_CHANNELS, type BoardsContract } from './boards.js';
+export {
+  CONTACT_PROFILE_CHANNELS,
+  type ContactLink,
+  type ContactProfile,
+  type ContactProfileContract,
+  type LocalizedText,
+} from './contactProfile.js';
 export { CONVERSATIONS_CHANNELS, type ConversationsContract } from './conversations.js';
 export { CREDENTIALS_CHANNELS, type CredentialsContract } from './credentials.js';
 export { DATA_CHANNELS, type DataContract } from './data.js';


### PR DESCRIPTION
Fixes the five PDF/DOCX export defects surfaced by PyMuPDF inspection, generalized to any résumé (not the one data set), plus a validation gate so they can't regress. Two commits: `28ea867f` (Symptoms 1/3/4/5) + `abec14a3` (Symptom 2 + contact model + Step 3 validation).

## Root causes & fixes

**Symptom 1 — cover-letter header links dumped at page bottom (y≈752/842).** The legacy contact renderer's `y` is already bottom-up, but the link rect re-subtracted it from page height → a second flip, so all five header link rects landed at the bottom with no text under them. Extracted one shared `link_annotation_op` (top-down mm → single correct flip) used by **both** the modern layout engine and the legacy cover-letter/contact path, anchored to the text's own baseline. No fixed coordinates, one annotation code path. (The résumé was fine because it renders through the modern engine, which flips correctly.)

**Symptom 2 — résumé header URLs swapped (a company LinkedIn / employer site displacing the candidate's own).** The header was assembled from links scavenged out of the résumé by a domain heuristic + document position, so `linkedin.com/company/jibit` and `rabobank.com` could win header slots. Replaced with a **`ContactProfile`** model (single-row SQLite store, mirrors `job_preferences`) as the single source of truth: the header is built from **named fields only**, localized per language, identical across résumé / cover letter / DOCX. A name-based classifier seeds it on import (personal `/in/` LinkedIn, GitHub, personal site; rejects `/company/`, `/school/`, job-board hosts) as an **editable suggestion**, never silently trusted. Full IPC (`contact_profile_get/set`), shared contract, tauri-client namespace, React Query hook, and a Contact Profile settings tab (en/de).

**Symptom 3 — stray asterisks (`*React`, `AWS*`).** Added `sanitize_markdown` to drop lone `*`/`_`/backtick that aren't part of a valid `**bold**` pair; stopped `normalize_unicode` mapping daggers (U+2020/2021) → `*`.

**Symptom 4 — sentence-break dash glued to the previous word (`zu Hause- die`).** `normalize_unicode` was collapsing en/em-dash to a bare `-`. Now preserves U+2013/U+2014 (a font-glyph test asserts every bundled face carries them) and a `typography` pass normalizes clause dashes to a spaced en-dash and rewrites the `word- word` break pattern — excluding German suspended hyphens (`Backend- und …`) and tight compounds/ranges (`2020–2023`, `state-of-the-art`).

**Symptom 5 — orphaned role title / role split onto a near-empty page.** Keep-with-next in `layout::lay_entry` binds title + subtitle + first bullet, sized at/below the legacy reservation so the gap-by-gap parity gate still holds.

## Validation (can't regress)
`validate/mod.rs` now hard-fails **every** generated document on:
- `empty_anchor_link` — a link rect with no text under it (the cover-letter bottom bug),
- `header_url_mismatch` — a header link URL not in the contact profile (the URL-swap bug),
- `stray_markdown` — `*` / backtick that leaked into rendered text.

Wired into the existing export gate (blocks on `Critical`) and covered by `validate` tests. `tests/architecture.rs` updated: `contact_profile` classified L1 + R3 rusqlite allowlist.

## Verification
- `cargo test` green (layout parity, architecture rules, new validate gates).
- `@ajh/shared` 80 + `@ajh/prompts` 87 vitest passing; tauri typecheck + `lint:strict` clean.
- Full pre-push CI gate passed (cargo check/test/clippy/fmt + JS build/lint/typecheck/test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)