### PR TITLE
fix: contact settings, landing cross-browser, and cover-letter/export/analyze bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,5 @@ graphify-out/
 
 post-checkout
 post-commit
+
+CLAUDE.local.md

--- a/apps/tauri/src-tauri/src/export/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/export/commands/mod.rs
@@ -105,15 +105,24 @@ pub async fn documents_export_and_save(
         .to_string();
     let filter_name = format!("{} files", ext.to_uppercase());
 
-    // Open save dialog (blocking)
-    let file_path = app
-        .dialog()
-        .file()
-        .add_filter(&filter_name, &[&ext])
-        .set_title("Save Document")
-        .set_file_name(&result.filename)
-        .blocking_save_file()
-        .ok_or_else(|| "Save dialog was cancelled".to_string())?;
+    // Run the native save dialog OFF the async-runtime worker. `blocking_save_file()`
+    // blocks its caller until the dialog closes; calling it directly inside this
+    // `async` command stalls the runtime and dead-locks on a *subsequent* export —
+    // the dialog never reappears and the invoke never resolves (the "spinner spins
+    // forever on the 2nd export" symptom). `spawn_blocking` keeps the wait on a
+    // dedicated blocking thread so repeat exports work.
+    let filename = result.filename.clone();
+    let file_path = tauri::async_runtime::spawn_blocking(move || {
+        app.dialog()
+            .file()
+            .add_filter(&filter_name, &[&ext])
+            .set_title("Save Document")
+            .set_file_name(&filename)
+            .blocking_save_file()
+    })
+    .await
+    .map_err(|e| format!("Save dialog failed: {e}"))?
+    .ok_or_else(|| "Save dialog was cancelled".to_string())?;
 
     // Resolve to PathBuf
     let path = match file_path {

--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
@@ -46,6 +46,12 @@ export function AnalyzeLeftPanel({
 }: Props) {
   const { t } = useTranslation();
 
+  // Which half is missing — so the disabled CTA names the exact next step
+  // ("Add your résumé" / "Add the job ad") instead of the generic prompt. Mirrors
+  // the `canRun` length threshold in AnalyzePage so the label can't disagree.
+  const hasResume = resume.trim().length > 50;
+  const hasJobAd = jobAd.trim().length > 50;
+
   return (
     <div className="flex w-[400px] shrink-0 flex-col border-r border-white/[0.05] overflow-y-auto">
       {/* Header */}
@@ -170,7 +176,11 @@ export function AnalyzeLeftPanel({
                     ? t('analyze.installCli')
                     : t('analyze.selectModel')
                 : !canRun
-                  ? t('analyze.pasteContent')
+                  ? !hasResume && !hasJobAd
+                    ? t('analyze.pasteContent')
+                    : !hasResume
+                      ? t('analyze.addResume')
+                      : t('analyze.addJobAd')
                   : t('analyze.run')}
         </Button>
       </div>

--- a/apps/tauri/src/renderer/features/settings/components/contact/ContactProfileTab/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/contact/ContactProfileTab/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import type { ContactProfile } from '@ajh/shared';
 import { Input, SettingsSection } from '@ajh/ui';
 
+import { useTranslation } from '@/lib/i18n';
 import { useContactProfile, useSaveContactProfile } from '@/services';
 
 const FIELD_CLASS = 'flex flex-col gap-1.5';
@@ -16,17 +17,22 @@ const LABEL_CLASS = 'text-xs font-medium text-foreground/70';
  * LinkedIn / Website can't be displaced by an employer URL. Seeded from an
  * uploaded résumé on import, then freely editable here.
  *
+ * Location is a single value used for every document language: the backend's
+ * `LocalizedText` still supports per-language overrides, but we no longer expose
+ * an input per language (that doesn't scale as languages are added), so the form
+ * writes only `default` and clears any legacy override on save.
+ *
  * Follows the settings convention: changes persist on blur, no explicit save.
  */
 export function ContactProfileTab() {
+  const { t } = useTranslation();
   const { data: profile } = useContactProfile();
   const { mutate: save } = useSaveContactProfile();
 
   const [fullName, setFullName] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
-  const [locationDefault, setLocationDefault] = useState('');
-  const [locationDe, setLocationDe] = useState('');
+  const [location, setLocation] = useState('');
   const [linkedin, setLinkedin] = useState('');
   const [github, setGithub] = useState('');
   const [website, setWebsite] = useState('');
@@ -37,8 +43,7 @@ export function ContactProfileTab() {
     setFullName(profile.fullName ?? '');
     setEmail(profile.email ?? '');
     setPhone(profile.phone ?? '');
-    setLocationDefault(profile.location?.default ?? '');
-    setLocationDe(profile.location?.byLang?.de ?? '');
+    setLocation(profile.location?.default ?? '');
     setLinkedin(profile.linkedin ?? '');
     setGithub(profile.github ?? '');
     setWebsite(profile.website ?? '');
@@ -47,19 +52,13 @@ export function ContactProfileTab() {
   // Persist the whole profile from current field state (called on blur).
   const persist = () => {
     const clean = (s: string) => s.trim() || undefined;
-    const byLang: Record<string, string> = {};
-    if (locationDe.trim()) byLang.de = locationDe.trim();
 
     const next: ContactProfile = {
       fullName: clean(fullName),
       email: clean(email),
       phone: clean(phone),
-      location: locationDefault.trim()
-        ? {
-            default: locationDefault.trim(),
-            byLang: Object.keys(byLang).length ? byLang : undefined,
-          }
-        : undefined,
+      // One location for every document language — no per-language overrides.
+      location: location.trim() ? { default: location.trim() } : undefined,
       linkedin: clean(linkedin),
       github: clean(github),
       website: clean(website),
@@ -70,17 +69,13 @@ export function ContactProfileTab() {
   };
 
   return (
-    <SettingsSection icon={Contact} label="Contact Profile">
-      <p className="mb-4 text-xs text-foreground/55">
-        The header on your résumé and cover letter is built from these fields — your name, email,
-        phone, location, and personal profile links. Editing them keeps every generated document
-        correct and consistent. Changes save automatically.
-      </p>
+    <SettingsSection icon={Contact} label={t('settings.contactProfile.title')}>
+      <p className="mb-4 text-xs text-foreground/55">{t('settings.contactProfile.description')}</p>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div className={FIELD_CLASS}>
           <label className={LABEL_CLASS} htmlFor="cp-name">
-            Full name
+            {t('settings.contactProfile.fullName')}
           </label>
           <Input
             id="cp-name"
@@ -92,7 +87,7 @@ export function ContactProfileTab() {
 
         <div className={FIELD_CLASS}>
           <label className={LABEL_CLASS} htmlFor="cp-email">
-            Email
+            {t('settings.contactProfile.email')}
           </label>
           <Input
             id="cp-email"
@@ -100,13 +95,13 @@ export function ContactProfileTab() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             onBlur={persist}
-            placeholder="name@example.com"
+            placeholder={t('settings.contactProfile.emailPlaceholder')}
           />
         </div>
 
         <div className={FIELD_CLASS}>
           <label className={LABEL_CLASS} htmlFor="cp-phone">
-            Phone
+            {t('settings.contactProfile.phone')}
           </label>
           <Input
             id="cp-phone"
@@ -118,66 +113,53 @@ export function ContactProfileTab() {
 
         <div className={FIELD_CLASS}>
           <label className={LABEL_CLASS} htmlFor="cp-location">
-            Location (English documents)
+            {t('settings.contactProfile.location')}
           </label>
           <Input
             id="cp-location"
-            value={locationDefault}
-            onChange={(e) => setLocationDefault(e.target.value)}
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
             onBlur={persist}
-            placeholder="Netherlands"
-          />
-        </div>
-
-        <div className={FIELD_CLASS}>
-          <label className={LABEL_CLASS} htmlFor="cp-location-de">
-            Location (German documents)
-          </label>
-          <Input
-            id="cp-location-de"
-            value={locationDe}
-            onChange={(e) => setLocationDe(e.target.value)}
-            onBlur={persist}
-            placeholder="Niederlande"
+            placeholder={t('settings.contactProfile.locationPlaceholder')}
           />
         </div>
 
         <div className={FIELD_CLASS}>
           <label className={LABEL_CLASS} htmlFor="cp-linkedin">
-            LinkedIn
+            {t('settings.contactProfile.linkedin')}
           </label>
           <Input
             id="cp-linkedin"
             value={linkedin}
             onChange={(e) => setLinkedin(e.target.value)}
             onBlur={persist}
-            placeholder="https://www.linkedin.com/in/your-profile/"
+            placeholder={t('settings.contactProfile.linkedinPlaceholder')}
           />
         </div>
 
         <div className={FIELD_CLASS}>
           <label className={LABEL_CLASS} htmlFor="cp-github">
-            GitHub
+            {t('settings.contactProfile.github')}
           </label>
           <Input
             id="cp-github"
             value={github}
             onChange={(e) => setGithub(e.target.value)}
             onBlur={persist}
-            placeholder="https://github.com/your-handle"
+            placeholder={t('settings.contactProfile.githubPlaceholder')}
           />
         </div>
 
         <div className={FIELD_CLASS}>
           <label className={LABEL_CLASS} htmlFor="cp-website">
-            Website
+            {t('settings.contactProfile.website')}
           </label>
           <Input
             id="cp-website"
             value={website}
             onChange={(e) => setWebsite(e.target.value)}
             onBlur={persist}
-            placeholder="https://your-site.com"
+            placeholder={t('settings.contactProfile.websitePlaceholder')}
           />
         </div>
       </div>

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -204,6 +204,10 @@
         "label": "Allgemein",
         "description": "Name, Sprache, Aussehen"
       },
+      "contact": {
+        "label": "Kontaktprofil",
+        "description": "Kopfzeilen-Details & Profillinks"
+      },
       "ai": {
         "label": "KI",
         "description": "Modelle, Ton, Generierung"
@@ -232,6 +236,22 @@
         "label": "Entwickler",
         "description": "Debug-Werkzeuge & Diagnose"
       }
+    },
+    "contactProfile": {
+      "title": "Kontaktprofil",
+      "description": "Die Kopfzeile Ihres Lebenslaufs und Anschreibens wird aus diesen Feldern erstellt — Name, E-Mail, Telefon, Standort und persönliche Profillinks. Wenn Sie sie bearbeiten, bleibt jedes generierte Dokument korrekt und einheitlich. Änderungen werden automatisch gespeichert.",
+      "fullName": "Vollständiger Name",
+      "email": "E-Mail",
+      "emailPlaceholder": "name@example.com",
+      "phone": "Telefon",
+      "location": "Standort",
+      "locationPlaceholder": "Niederlande",
+      "linkedin": "LinkedIn",
+      "linkedinPlaceholder": "https://www.linkedin.com/in/ihr-profil/",
+      "github": "GitHub",
+      "githubPlaceholder": "https://github.com/ihr-handle",
+      "website": "Website",
+      "websitePlaceholder": "https://ihre-website.com"
     },
     "developer": {
       "title": "Entwickler-Werkzeuge",

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -57,6 +57,8 @@
     "addApiKey": "API-Schlüssel in Einstellungen hinzufügen",
     "installCli": "CLI-Agent installieren",
     "pasteContent": "Lebenslauf & Stellenanzeige einfügen",
+    "addResume": "Lebenslauf hinzufügen",
+    "addJobAd": "Stellenanzeige hinzufügen",
     "idleTitle": "Lebenslauf-Analysator",
     "idleSubtitle": "Lebenslauf und Stellenanzeige einfügen für eine vollständige KI-Analyse",
     "features": {

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -57,6 +57,8 @@
     "addApiKey": "Add API key in Settings",
     "installCli": "Install the CLI agent",
     "pasteContent": "Paste resume & job ad",
+    "addResume": "Add your résumé",
+    "addJobAd": "Add the job ad",
     "idleTitle": "Resume Analyser",
     "idleSubtitle": "Paste your resume and a job ad to get a full AI analysis",
     "features": {

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -204,6 +204,10 @@
         "label": "General",
         "description": "Name, language, appearance"
       },
+      "contact": {
+        "label": "Contact Profile",
+        "description": "Header details & profile links"
+      },
       "ai": {
         "label": "AI",
         "description": "Models, tone, generation"
@@ -232,6 +236,22 @@
         "label": "Developer",
         "description": "Debug tools & diagnostics"
       }
+    },
+    "contactProfile": {
+      "title": "Contact Profile",
+      "description": "The header on your résumé and cover letter is built from these fields — your name, email, phone, location, and personal profile links. Editing them keeps every generated document correct and consistent. Changes save automatically.",
+      "fullName": "Full name",
+      "email": "Email",
+      "emailPlaceholder": "name@example.com",
+      "phone": "Phone",
+      "location": "Location",
+      "locationPlaceholder": "Netherlands",
+      "linkedin": "LinkedIn",
+      "linkedinPlaceholder": "https://www.linkedin.com/in/your-profile/",
+      "github": "GitHub",
+      "githubPlaceholder": "https://github.com/your-handle",
+      "website": "Website",
+      "websitePlaceholder": "https://your-site.com"
     },
     "developer": {
       "title": "Developer Tools",

--- a/landing/index.html
+++ b/landing/index.html
@@ -23,7 +23,7 @@
   --red:#e24b4a;
 }
 *{box-sizing:border-box}
-html{scroll-behavior:smooth}
+html{scroll-behavior:smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%}
 body{
   margin:0; background:#0a0c11; color:#e7ecf3;
   font-family:var(--hand); font-size:18px; line-height:1.6;
@@ -35,7 +35,7 @@ img,svg{display:block}
 
 /* grain + film texture over everything */
 body::after{
-  content:""; position:fixed; inset:0; z-index:60; pointer-events:none; opacity:.06;
+  content:""; position:fixed; top:0; right:0; bottom:0; left:0; z-index:60; pointer-events:none; opacity:.06;
   background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='120' height='120' filter='url(%23n)'/></svg>");
   mix-blend-mode:overlay;
 }
@@ -90,7 +90,7 @@ body::after{
 
 /* loader */
 #loader{
-  position:fixed; inset:0; z-index:100; background:#0a0c11; display:flex; align-items:center; justify-content:center;
+  position:fixed; top:0; right:0; bottom:0; left:0; z-index:100; background:#0a0c11; display:flex; align-items:center; justify-content:center;
   font-family:var(--scrawl); font-size:clamp(18px,4vw,26px); color:#c7d0dd; text-align:center; padding:24px;
   transition:opacity .6s, visibility .6s;
 }
@@ -99,8 +99,8 @@ body::after{
 
 /* ---------- generic section ---------- */
 .stage{min-height:100vh; position:relative; display:flex; flex-direction:column; align-items:center; justify-content:center; padding:64px 22px; overflow:hidden; text-align:center}
-.photo{position:absolute; inset:0; z-index:0}      /* PHOTO SWAP: set background:url('your.jpg') center/cover */
-.grade{position:absolute; inset:0; z-index:1; pointer-events:none}
+.photo{position:absolute; top:0; right:0; bottom:0; left:0; z-index:0}      /* PHOTO SWAP: set background:url('your.jpg') center/cover */
+.grade{position:absolute; top:0; right:0; bottom:0; left:0; z-index:1; pointer-events:none}
 .stage > .inner{position:relative; z-index:2; width:100%; max-width:880px}
 
 /* ---------- seamless section blending ---------- */
@@ -304,7 +304,8 @@ body::after{
 .testi .small{font-family:var(--mono); font-size:12px; color:#7a7058}
 .wall{column-count:3; column-gap:18px; max-width:980px; margin:0 auto}
 .quote{
-  break-inside:avoid; margin:0 0 18px; background:#fffdf6; border:2.4px solid var(--ink);
+  -webkit-column-break-inside:avoid; page-break-inside:avoid; break-inside:avoid;
+  margin:0 0 18px; background:#fffdf6; border:2.4px solid var(--ink);
   border-radius:13px 10px 15px 9px; padding:14px 16px; box-shadow:3px 4px 0 rgba(0,0,0,.13); text-align:left;
 }
 .quote:nth-child(even){transform:rotate(.7deg)} .quote:nth-child(3n){transform:rotate(-.8deg)}
@@ -353,6 +354,24 @@ body::after{
   .scrollhint .arr,.feed .scroller{animation:none}
   .doodle.flailing{animation:none}
   html{scroll-behavior:auto}
+}
+
+/* ---------- legacy WebKit (Safari < 14.1) hardening ----------
+   Safari before 14.1 supports neither the `inset` shorthand (handled with
+   top/right/bottom/left longhand on the overlays above) nor flexbox `gap`.
+   Without `gap` the collage cards, chip swarm, recruiter row and dialog buttons
+   collapse together. Re-create that spacing with child margins. `@supports not
+   (inset:0)` is a tight proxy — the engines lacking `inset` are the same ones
+   lacking flex `gap` — so every modern browser (incl. current Safari) skips this
+   block and never double-spaces. Grid `gap` (.feat-grid) is fine far back, so
+   it's intentionally left alone. */
+@supports not (inset:0){
+  .collage>*{margin:7px}
+  .swarm>*{margin:4px}
+  .npcs>*{margin:3px}
+  .ats>*{margin:0 5px}
+  .dialog .btns>*{margin:0 5px}
+  .dc-inner>*{margin:0 1px}
 }
 </style>
 </head>

--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -122,6 +122,55 @@ describe('injectLinksIntoGeneratedText', () => {
     expect(out).toContain('[Website](https://janedoe.dev)');
     expect(out).toContain('[GitHub](https://github.com/jd)');
   });
+
+  it('finds the cover-letter contact line below the top (past the old 6-line window)', () => {
+    // Regression: cover letters carry the contact line under a marker / name /
+    // preamble, so the old fixed first-6-lines scan silently skipped it and
+    // LinkedIn never got hyperlinked (Dribbble survived only as a bare URL).
+    const coverLetter = [
+      'COMPLETE COVER LETTER ###',
+      '',
+      'preamble one',
+      'preamble two',
+      'preamble three',
+      'preamble four',
+      'preamble five',
+      'Zohreh Nejati',
+      'Zaandam, Niederlande | zohreh@example.com | +31 6 | LinkedIn | Dribbble',
+      '',
+      'Sehr geehrte Damen und Herren,',
+    ].join('\n');
+    const out = injectLinksIntoGeneratedText(coverLetter, {
+      LinkedIn: 'https://linkedin.com/in/zohreh',
+      Dribbble: 'https://dribbble.com/zohreh',
+    });
+    expect(out).toContain('[LinkedIn](https://linkedin.com/in/zohreh)');
+    expect(out).toContain('[Dribbble](https://dribbble.com/zohreh)');
+  });
+
+  it('links only the email-bearing contact line, not body prose mentioning a platform', () => {
+    const text = [
+      'Zohreh Nejati',
+      'Zaandam | zohreh@example.com | LinkedIn',
+      '',
+      'I doubled our GitHub | community and shipped on LinkedIn weekly.',
+    ].join('\n');
+    const out = injectLinksIntoGeneratedText(text, {
+      LinkedIn: 'https://linkedin.com/in/zohreh',
+      GitHub: 'https://github.com/zohreh',
+    });
+    expect(out).toContain('[LinkedIn](https://linkedin.com/in/zohreh)');
+    // The body sentence has a pipe but no email → left untouched.
+    expect(out).toContain('I doubled our GitHub | community and shipped on LinkedIn weekly.');
+    expect(out).not.toContain('[GitHub](https://github.com/zohreh)');
+  });
+
+  it('is idempotent — a second pass does not double-wrap links', () => {
+    const text = 'Name\nCity | n@example.com | LinkedIn';
+    const once = injectLinksIntoGeneratedText(text, { LinkedIn: 'https://linkedin.com/in/n' });
+    const twice = injectLinksIntoGeneratedText(once, { LinkedIn: 'https://linkedin.com/in/n' });
+    expect(twice).toBe(once);
+  });
 });
 
 describe('parseLinksFromResume', () => {

--- a/packages/prompts/src/generate/links.ts
+++ b/packages/prompts/src/generate/links.ts
@@ -153,29 +153,80 @@ export function getLinkMap(resume: string): Record<string, string> {
   return map;
 }
 
+/** Escape a string for literal use inside a `RegExp`. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** The candidate's email — the reliable signal for "this is the contact line". */
+const CONTACT_EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/;
+const SECTION_HEADER_RE = /^(PROFESSIONAL|WORK|EDUCATION|SKILLS|SUMMARY)/i;
+/** An already-injected `[label](url)` span — protected so re-runs stay idempotent. */
+const MD_LINK_SPAN_RE = /\[[^\]]+\]\([^)]+\)/g;
+
 /**
- * Post-process AI-generated resume/cover-letter text.
- * Scans the first 6 lines for the contact line (contains |) and replaces
- * known profile labels (e.g. "LinkedIn") with [LinkedIn](https://...) so the
- * Rust renderer can attach the hyperlink without displaying the full URL.
+ * Post-process AI-generated resume/cover-letter text: replace the short profile
+ * labels the model wrote ("LinkedIn", "GitHub", "Website") in the contact line
+ * with `[label](https://…)` markdown, so the Rust renderer can attach the
+ * hyperlink without displaying the raw URL.
+ *
+ * The contact line is found by CONTENT, not position. Résumés keep it at the very
+ * top, but cover letters place it below a marker / name / salutation — past any
+ * fixed line window — which is why LinkedIn silently stayed unlinked in cover
+ * letters (a résumé header and a cover-letter header share this same function).
+ * We inject into every pipe-delimited line that carries the candidate's email
+ * (the contact-line signal, wherever the model put it); the email guard keeps
+ * body prose that merely mentions a platform untouched. Falls back to the first
+ * pipe line bearing a known label when no email line is present. Idempotent: the
+ * `(?<!\[)` lookbehind skips labels already inside a `[…]` link.
  */
 export function injectLinksIntoGeneratedText(
   text: string,
   linkMap: Record<string, string>
 ): string {
-  if (!Object.keys(linkMap).length) return text;
-  const lines = text.split('\n');
-  for (let i = 0; i < Math.min(lines.length, 6); i++) {
-    const line = lines[i] ?? '';
-    if (!line.includes('|')) continue;
-    if (/^(PROFESSIONAL|WORK|EDUCATION|SKILLS|SUMMARY)/i.test(line.trim())) continue;
-    let newLine = line;
-    for (const [label, url] of Object.entries(linkMap)) {
-      // Match the label at word boundaries; skip if already inside a markdown link [...]
-      const esc = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      newLine = newLine.replace(new RegExp(`(?<!\\[)\\b${esc}\\b`, 'gi'), `[${label}](${url})`);
+  const labels = Object.keys(linkMap);
+  if (!labels.length) return text;
+
+  const injectPlain = (segment: string): string => {
+    let out = segment;
+    for (const label of labels) {
+      out = out.replace(
+        new RegExp(`\\b${escapeRegExp(label)}\\b`, 'gi'),
+        `[${label}](${linkMap[label]})`
+      );
     }
-    if (i < lines.length) lines[i] = newLine;
+    return out;
+  };
+  // Inject into the plain text only, stepping over any pre-existing `[label](url)`
+  // spans — so a label that recurs inside an already-injected URL (linkedin.com)
+  // is never re-wrapped and the pass is idempotent.
+  const inject = (line: string): string => {
+    let out = '';
+    let last = 0;
+    for (const m of line.matchAll(MD_LINK_SPAN_RE)) {
+      const idx = m.index ?? 0;
+      out += injectPlain(line.slice(last, idx)) + m[0];
+      last = idx + m[0].length;
+    }
+    return out + injectPlain(line.slice(last));
+  };
+  const hasLabel = (line: string): boolean =>
+    labels.some((l) => new RegExp(`(?<!\\[)\\b${escapeRegExp(l)}\\b`, 'i').test(line));
+  const isContactCandidate = (line: string): boolean =>
+    line.includes('|') && !SECTION_HEADER_RE.test(line.trim());
+
+  const lines = text.split('\n');
+  let injected = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    if (isContactCandidate(line) && CONTACT_EMAIL_RE.test(line)) {
+      lines[i] = inject(line);
+      injected = true;
+    }
+  }
+  if (!injected) {
+    const i = lines.findIndex((l) => isContactCandidate(l) && hasLabel(l));
+    if (i !== -1) lines[i] = inject(lines[i] ?? '');
   }
   return lines.join('\n');
 }


### PR DESCRIPTION
Three rounds of work, bundled on one branch per request.

## 1. Contact settings (`fix:`)
- The Settings → Contact section showed raw i18n keys (`settings.sections.contact.*`) — they were missing from the **top-level** `settings.sections` namespace. Added to `en.json` + `de.json`.
- Collapsed the two per-language **Location** inputs into one. The form writes only `location.default`; the Rust `LocalizedText::resolve()` already falls back to it, so one value renders for every document language (no new input per future language). No backend/export changes.
- Internationalized the whole `ContactProfileTab` (was hardcoded English).

## 2. Landing page cross-browser hardening (`ui:`)
- `inset:0` → `top/right/bottom/left` longhand on the background/overlay layers (old Safari ignores the shorthand → backgrounds vanished).
- `-webkit-column-break-inside`/`page-break-inside` fallbacks on testimonial cards.
- `@supports not (inset:0)` flex-gap fallback for old Safari; `-webkit-text-size-adjust`.
- Reproduced across Chromium/Firefox/WebKit (Playwright); render-identical on current engines.

## 3. Three reported bugs (`fix:`)
- **Cover-letter LinkedIn link** — link injection only scanned the first 6 lines, so it missed the cover-letter contact line (which sits below the marker/name/salutation) and never hyperlinked LinkedIn. Now finds the contact line by content (email/label), idempotently. New unit tests.
- **Repeat-export hang** — `documents_export_and_save` ran `blocking_save_file()` inside the async command, dead-locking the 2nd export. Now wrapped in `spawn_blocking`.
- **Analyze button** — the disabled CTA showed a generic prompt; now names the missing half ("Add your résumé" / "Add the job ad").

## Verification
- prompts tests 37/37 · ESLint clean · `tsc --noEmit` clean (renderer + prompts) · `cargo check` clean · locale JSON valid · pre-push hook passed.

## Notes / follow-ups
- The export fix only covers `documents_export_and_save`. `data_export`, `data_import`, and `dialog_open_files` share the same `blocking_*`-in-async pattern (rarely repeated, so untouched here).
- Runtime behaviors (cover-letter link, repeat export, button label) were verified statically; worth a quick manual pass in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)