### PR TITLE
style: tone down deep-fried landing section glare to moody amber

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -243,11 +243,11 @@ body::after{
 /* ================= BEAT 3 — DEEP FRIED ================= */
 .beat3{--line:#0b0b0b; --seam-prev:#130c10; --seam-next:#ffb24d; justify-content:flex-start; min-height:128vh; padding-top:clamp(110px,30vh,360px)}
 .beat3 .photo{background:
-  repeating-conic-gradient(from 0deg at 50% 42%, rgba(255,255,255,.55) 0deg 5deg, rgba(255,210,0,0) 5deg 11deg),
-  radial-gradient(60% 50% at 50% 42%, #fffbe0 0%, #ffe600 30%, #ffb300 70%, #ff7a00 100%);
-  filter:saturate(1.7) contrast(1.25);
+  repeating-conic-gradient(from 0deg at 50% 42%, rgba(255,255,255,.16) 0deg 5deg, rgba(255,210,0,0) 5deg 11deg),
+  radial-gradient(64% 54% at 50% 42%, #eec46c 0%, #d98e26 36%, #ad5b0d 70%, #6f2f05 100%);
+  filter:saturate(1.35) contrast(1.1) brightness(.9);
 }
-.beat3 .grade{background:radial-gradient(70% 60% at 50% 42%,rgba(255,255,255,.85),rgba(255,255,255,0) 55%); mix-blend-mode:screen}
+.beat3 .grade{background:radial-gradient(70% 60% at 50% 42%,rgba(255,255,255,.14),rgba(255,255,255,0) 55%); mix-blend-mode:screen}
 .beat3{color:#0b0b0b}
 .beat3-dood{width:clamp(200px,38vw,300px); margin:0 auto 6px; filter:drop-shadow(0 0 10px #ff00d4) drop-shadow(0 0 4px #00fff0)}
 .fried{


### PR DESCRIPTION
## What

Tones down §4 — the "DEEP FRIED" beat (`.beat3`) — on the landing page. It was the page's brightest section (near-white radial core, 55% white sunburst rays, and an 85% `mix-blend-mode:screen` white overlay) and read as a flashbang next to the dark navy sections above it.

## Changes (`landing/index.html`, `.beat3` only)

- Radial gradient recoloured to a moody amber: warm cream core `#eec46c` → `#d98e26` → `#ad5b0d` → burnt-brown edge `#6f2f05`
- Sunburst rays white opacity `55% → 16%`
- Screen-overlay white-out `85% → 14%` (keeps a soft hotspot, no blow-out)
- Filter `saturate(1.7) contrast(1.25)` → `saturate(1.35) contrast(1.1) brightness(.9)`

Text and doodle layers are untouched — black ink, the white-stroked headline and the neon doodle stay high-contrast on the amber.

## Verification

Static page, no build step: open `landing/index.html` and scroll past the dark §1/§2 into §4 — it now reads as a warm amber glow rather than a bright wall. Headline, body copy, the "Are you sure?" dialog and the doodle stay legible; the §3→§4 and §4→§5 cross-fades are intact.

## Deploy

`pages.yml` auto-deploys `landing/` to GitHub Pages on merge to `main` — independent of the app release pipeline, and this `style:` commit triggers no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)