### PR TITLE
feat: contact-profile header autofill, wrapping, link editor, and first-run prompt

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.33.2"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src-tauri/src/commands/documents.rs
+++ b/apps/tauri/src-tauri/src/commands/documents.rs
@@ -50,20 +50,37 @@ pub async fn documents_import(app: AppHandle, req: DocumentsImportRequest) -> Va
     let structured = crate::extraction::structured::structure(&extraction);
     let review = serde_json::to_value(&structured).unwrap_or(json!(null));
 
-    // Seed the contact profile from the résumé's links — but ONLY when the user
-    // has no profile yet, so an existing (edited) profile is never clobbered. The
-    // classifier picks the personal LinkedIn/GitHub/Website by NAME and rejects
-    // company / job-board pages; the user reviews & edits it in settings. This is
-    // what stops a company link from ever reaching the document header.
+    // Seed/complete the contact profile from the résumé. `classify_contact_links`
+    // picks the personal LinkedIn/GitHub/Website by NAME (rejecting company /
+    // job-board pages) and keeps every other personal link as a labelled extra;
+    // email / phone / location come from the deterministic structuring pass. We
+    // MERGE into the existing profile, filling only empty fields — so a profile the
+    // user edited is never clobbered, but a sparse one (e.g. website-only) is
+    // completed with the résumé's email / phone / location / extra links. The
+    // header builds from these named fields, which is what keeps a company link
+    // out of the document header.
     if let Some(cp_store) = app.try_state::<crate::contact_profile::ContactProfileStore>() {
-        if cp_store.get().is_effectively_empty() {
-            let mut suggested = crate::contact_profile::classify_contact_links(&extraction.links);
-            if let Some(email) = structured.email.as_ref().map(|f| f.value.clone()) {
-                suggested.email.get_or_insert(email);
+        let mut suggested = crate::contact_profile::classify_contact_links(&extraction.links);
+        if let Some(email) = structured.email.as_ref().map(|f| f.value.clone()) {
+            suggested.email.get_or_insert(email);
+        }
+        if let Some(phone) = structured.phone.as_ref().map(|f| f.value.clone()) {
+            suggested.phone.get_or_insert(phone);
+        }
+        if let Some(loc) = structured.location.as_ref().map(|f| f.value.clone()) {
+            if !loc.trim().is_empty() {
+                suggested
+                    .location
+                    .get_or_insert_with(|| crate::contact_profile::LocalizedText {
+                        default: loc,
+                        ..Default::default()
+                    });
             }
-            if !suggested.is_effectively_empty() {
-                let _ = cp_store.set(&suggested);
-            }
+        }
+        if !suggested.is_effectively_empty() {
+            let mut current = cp_store.get();
+            current.fill_empty_from(&suggested);
+            let _ = cp_store.set(&current);
         }
     }
 

--- a/apps/tauri/src-tauri/src/contact_profile/mod.rs
+++ b/apps/tauri/src-tauri/src/contact_profile/mod.rs
@@ -10,8 +10,13 @@
 //!
 //! Persistence mirrors [`crate::job_preferences`]: a single-row SQLite settings
 //! table. Seeding from an imported résumé uses [`classify_contact_links`], which
-//! picks the personal profile/site by name and rejects company / job-board pages —
-//! the result is a *suggestion* the user can edit, never silently trusted.
+//! picks the personal profile/site by name, rejects company / job-board pages, and
+//! keeps every other personal link as a labelled extra; the import adds email /
+//! phone / location from the deterministic structuring pass. The result is
+//! *merged* into the stored profile via [`ContactProfile::fill_empty_from`] —
+//! filling only empty fields so a sparse profile is completed while every value
+//! the user edited is preserved. It is a *suggestion* the user can edit, never
+//! silently trusted.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -24,7 +29,7 @@ use crate::data_store::DataStore;
 use crate::db::{run_migrations, Migration};
 use crate::error::AppResult;
 use crate::extraction::types::Link;
-use crate::model::rich::{tokenize_rich, RichText};
+use crate::model::rich::{tokenize_rich, url_label, RichText};
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -191,6 +196,47 @@ impl ContactProfile {
         }
         out
     }
+
+    /// Fill only the **empty/None** fields of `self` from `other`, never
+    /// overwriting a value the user already set, and merge in any of `other`'s
+    /// extra links that `self` does not already have (by URL). This lets an
+    /// import complete a sparse profile (e.g. add the résumé's email / phone /
+    /// location / Dribbble) while preserving every field the user edited.
+    pub fn fill_empty_from(&mut self, other: &ContactProfile) {
+        fn fill(slot: &mut Option<String>, src: &Option<String>) {
+            if non_empty(slot).is_none() {
+                if let Some(v) = non_empty(src) {
+                    *slot = Some(v.to_string());
+                }
+            }
+        }
+        fill(&mut self.email, &other.email);
+        fill(&mut self.phone, &other.phone);
+        fill(&mut self.linkedin, &other.linkedin);
+        fill(&mut self.github, &other.github);
+        fill(&mut self.website, &other.website);
+
+        if self
+            .location
+            .as_ref()
+            .map(LocalizedText::is_empty)
+            .unwrap_or(true)
+        {
+            if let Some(loc) = &other.location {
+                if !loc.is_empty() {
+                    self.location = Some(loc.clone());
+                }
+            }
+        }
+
+        for link in &other.extra_links {
+            let url = link.url.trim();
+            if url.is_empty() || self.extra_links.iter().any(|e| e.url.trim() == url) {
+                continue;
+            }
+            self.extra_links.push(link.clone());
+        }
+    }
 }
 
 fn non_empty(v: &Option<String>) -> Option<&str> {
@@ -264,8 +310,11 @@ fn is_job_board(url: &str) -> bool {
 /// Classify extracted résumé links into a [`ContactProfile`] by NAME, not by
 /// position. Picks the first personal LinkedIn (`/in/`), the first GitHub, and a
 /// personal website (a known link-in-bio host, else the first non-job-board,
-/// non-platform `http(s)` link). Company / job-board links are rejected. This is a
-/// suggestion to seed the editable profile, never the final header on its own.
+/// non-platform `http(s)` link). Every remaining personal `http(s)` link (e.g.
+/// Dribbble, Behance, a portfolio) is kept as a labelled [`ContactLink`] in
+/// `extra_links`, so the header is seeded with the candidate's full link set —
+/// never a job-board / employer page. This is a suggestion to seed the editable
+/// profile, never the final header on its own.
 pub fn classify_contact_links(links: &[Link]) -> ContactProfile {
     let mut profile = ContactProfile::default();
     for link in links {
@@ -308,6 +357,31 @@ pub fn classify_contact_links(links: &[Link]) -> ContactProfile {
                 break;
             }
         }
+    }
+    // Extras: every other personal http(s) link, labelled by domain (Dribbble,
+    // Behance, …). Skips job boards and the links already promoted to a named
+    // field, and de-dupes by URL so the same link is never listed twice.
+    let named: std::collections::BTreeSet<&str> = [
+        profile.linkedin.as_deref(),
+        profile.github.as_deref(),
+        profile.website.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    for link in links {
+        let url = link.url.trim();
+        if !(url.starts_with("http://") || url.starts_with("https://"))
+            || is_job_board(url)
+            || named.contains(url)
+            || profile.extra_links.iter().any(|e| e.url == url)
+        {
+            continue;
+        }
+        profile.extra_links.push(ContactLink {
+            label: url_label(url),
+            url: url.to_string(),
+        });
     }
     profile
 }

--- a/apps/tauri/src-tauri/src/contact_profile/test.rs
+++ b/apps/tauri/src-tauri/src/contact_profile/test.rs
@@ -121,6 +121,104 @@ fn empty_profile_is_detected() {
 }
 
 #[test]
+fn classify_keeps_other_personal_links_as_labelled_extras() {
+    // A personal profile + a known website host + two portfolio links + a job board.
+    let links = vec![
+        link("https://www.linkedin.com/in/zohreh/"),
+        link("https://solo.to/zohreh"), // website-host → Website slot
+        link("https://dribbble.com/zohreh-nejati"),
+        link("https://www.behance.net/zohreh"),
+        link("https://www.indeed.com/cmp/acme"), // job board → never surfaced
+    ];
+    let p = classify_contact_links(&links);
+    assert_eq!(p.website.as_deref(), Some("https://solo.to/zohreh"));
+
+    let labels: Vec<&str> = p.extra_links.iter().map(|e| e.label.as_str()).collect();
+    assert!(labels.contains(&"Dribbble"), "extras = {labels:?}");
+    assert!(labels.contains(&"Behance"), "extras = {labels:?}");
+    assert!(
+        !p.extra_links.iter().any(|e| e.url.contains("linkedin.com")
+            || e.url.contains("solo.to")
+            || e.url.contains("indeed.com")),
+        "named fields and job boards must not leak into extras: {:?}",
+        p.extra_links
+    );
+}
+
+#[test]
+fn fill_empty_from_completes_sparse_profile_without_clobbering() {
+    // The user edited only the website (their portfolio); an import suggests a full set.
+    let mut current = ContactProfile {
+        website: Some("https://my.portfolio/".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        email: Some("z@example.com".into()),
+        phone: Some("+31 6 3478 0936".into()),
+        location: Some(LocalizedText {
+            default: "Zaandam, Netherlands".into(),
+            ..Default::default()
+        }),
+        linkedin: Some("https://www.linkedin.com/in/zohreh/".into()),
+        website: Some("https://drive.google.com/xyz".into()), // must NOT overwrite the user's
+        extra_links: vec![ContactLink {
+            label: "Dribbble".into(),
+            url: "https://dribbble.com/z".into(),
+        }],
+        ..Default::default()
+    };
+    current.fill_empty_from(&suggested);
+
+    assert_eq!(
+        current.website.as_deref(),
+        Some("https://my.portfolio/"),
+        "a user-set field is never overwritten"
+    );
+    assert_eq!(current.email.as_deref(), Some("z@example.com"));
+    assert_eq!(current.phone.as_deref(), Some("+31 6 3478 0936"));
+    assert_eq!(
+        current.location.as_ref().map(|l| l.default.as_str()),
+        Some("Zaandam, Netherlands")
+    );
+    assert_eq!(
+        current.linkedin.as_deref(),
+        Some("https://www.linkedin.com/in/zohreh/")
+    );
+    assert!(current.extra_links.iter().any(|e| e.label == "Dribbble"));
+}
+
+#[test]
+fn fill_empty_from_merges_extras_by_url_without_duplicates() {
+    let mut current = ContactProfile {
+        extra_links: vec![ContactLink {
+            label: "Dribbble".into(),
+            url: "https://dribbble.com/z".into(),
+        }],
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        extra_links: vec![
+            ContactLink {
+                label: "Dribbble".into(),
+                url: "https://dribbble.com/z".into(), // duplicate by URL → skipped
+            },
+            ContactLink {
+                label: "Behance".into(),
+                url: "https://behance.net/z".into(),
+            },
+        ],
+        ..Default::default()
+    };
+    current.fill_empty_from(&suggested);
+    assert_eq!(
+        current.extra_links.len(),
+        2,
+        "duplicate deduped, new extra added: {:?}",
+        current.extra_links
+    );
+}
+
+#[test]
 fn localized_text_resolves_primary_subtag() {
     let loc = LocalizedText {
         default: "Netherlands".into(),

--- a/apps/tauri/src-tauri/src/export/pdf/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/mod.rs
@@ -401,6 +401,15 @@ fn generate_two_column_resume_pdf(
 
 // ─── Cover letter PDF ─────────────────────────────────────────────────────────
 
+/// Does this cleaned line look like a contact line (e.g. `City | a@b.com | +49 …
+/// | LinkedIn`)? Detected structurally — an email `@` or ≥2 `|` separators — so a
+/// contact line the generated letter still carries is dropped from the body
+/// regardless of what the profile-derived letterhead renders. Plain recipient
+/// lines ("JAKALA", "Hiring Team") and the date have neither, so they survive.
+fn looks_like_contact_line(clean: &str) -> bool {
+    clean.contains('@') || clean.matches('|').count() >= 2
+}
+
 fn generate_cover_letter_pdf(
     text: &str,
     meta: Option<&GenerationMeta>,
@@ -475,11 +484,19 @@ fn generate_cover_letter_pdf(
         let trimmed = raw_line.trim();
         let clean = strip_md(trimmed);
 
-        // Skip lines that were part of the header (name + contact)
+        // Skip lines that were part of the header (name + blank lines + the
+        // profile-derived contact line if it echoes here).
         if skip_lines < 3
             && (clean.is_empty() || trimmed == name_text || contact_line.contains(&clean))
         {
             skip_lines += 1;
+            continue;
+        }
+        // Drop any stray contact line the generated text still carries before the
+        // body proper — the letterhead already renders the contact from the
+        // profile, so leaving it here would duplicate it and leak raw markdown
+        // (e.g. `[Dribbble](…`) into the recipient block.
+        if !body_started && looks_like_contact_line(&clean) {
             continue;
         }
 

--- a/apps/tauri/src-tauri/src/export/pdf/test.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/test.rs
@@ -241,6 +241,231 @@ fn centered_template_resume_pdf_is_generated() {
     );
 }
 
+#[test]
+fn looks_like_contact_line_detects_contact_lines_only() {
+    // Contact lines: an email, or ≥2 "|" separators.
+    assert!(looks_like_contact_line("Zaandam | a@b.com | +31 6 1234"));
+    assert!(looks_like_contact_line("a@b.com"));
+    assert!(looks_like_contact_line("City | Phone | LinkedIn"));
+    // Plain recipient / address lines are NOT contact lines.
+    assert!(!looks_like_contact_line("JAKALA"));
+    assert!(!looks_like_contact_line("Hiring Team"));
+    assert!(!looks_like_contact_line("123 Main St | Suite 5")); // single separator
+}
+
+#[test]
+fn cover_letter_does_not_leak_generated_contact_line() {
+    // The generated letter still carries its own contact line (with a markdown
+    // link). With a contact profile present, the letterhead renders the profile and
+    // the text's contact line must be dropped — never leaked into the body as raw
+    // markdown (the `[Dribbble](…` / truncation symptom).
+    let text = "Zohreh Nejati\n\
+        Zaandam, Netherlands | z@example.com | +31 6 3478 0936 | [LinkedIn](https://linkedin.com/in/z) | [Dribbble](https://dribbble.com/zohreh-nejati)\n\
+        31. Mai 2026\n\
+        JAKALA\n\
+        Hiring Team\n\
+        Sehr geehrtes JAKALA-Team,\n\n\
+        Mit mehr als vier Jahren Erfahrung bringe ich die Faehigkeit mit.\n\n\
+        Mit freundlichen Gruessen,\n\
+        Zohreh Nejati";
+    let request = ExportRequest {
+        text: text.to_string(),
+        format: super::super::types::ExportFormat::Pdf,
+        document_type: DocumentType::CoverLetter,
+        template_id: super::super::types::TemplateId::Modern,
+        meta: Some(GenerationMeta {
+            candidate_name: Some("Zohreh Nejati".to_string()),
+            job_title: None,
+            company_name: None,
+            target_language: None,
+        }),
+        ats_mode: false,
+        locale: None,
+        contact: Some(crate::contact_profile::ContactProfile {
+            website: Some("https://drive.google.com/file/d/abc/view".to_string()),
+            ..Default::default()
+        }),
+    };
+    let bytes = generate_pdf(&request).expect("cover letter pdf");
+    let rendered = pdf_extract::extract_text_from_mem(&bytes).expect("extract text");
+
+    assert!(
+        !rendered.contains("[Dribbble]") && !rendered.to_lowercase().contains("dribbble.com"),
+        "the generated contact line leaked into the body: {rendered}"
+    );
+    assert!(
+        rendered.contains("Sehr geehrtes") && rendered.contains("Mit mehr als"),
+        "the letter body must still render: {rendered}"
+    );
+}
+
+/// Collect every link annotation's `[x0,y0,x1,y1]` rect (points) + target URL.
+/// printpdf writes `/Annots` as **inline** dictionaries nested in the page object,
+/// so we recurse through arrays/dicts (not just top-level objects).
+fn collect_link_rects(doc: &lopdf::Document) -> Vec<([f32; 4], String)> {
+    fn from_dict(d: &lopdf::Dictionary, out: &mut Vec<([f32; 4], String)>) {
+        let is_link = d
+            .get(b"Subtype")
+            .ok()
+            .and_then(|v| v.as_name().ok())
+            .map(|n| n == b"Link")
+            .unwrap_or(false);
+        if is_link {
+            let rect = d
+                .get(b"Rect")
+                .ok()
+                .and_then(|v| v.as_array().ok())
+                .and_then(|a| {
+                    let v: Vec<f32> = a.iter().filter_map(|o| o.as_float().ok()).collect();
+                    <[f32; 4]>::try_from(v).ok()
+                });
+            let uri = match d.get(b"A") {
+                Ok(lopdf::Object::Dictionary(ad)) => ad
+                    .get(b"URI")
+                    .ok()
+                    .and_then(|u| u.as_str().ok())
+                    .map(|b| String::from_utf8_lossy(b).into_owned()),
+                _ => None,
+            };
+            if let (Some(rect), Some(uri)) = (rect, uri) {
+                out.push((rect, uri));
+            }
+        }
+        for (_, v) in d.iter() {
+            from_obj(v, out);
+        }
+    }
+    fn from_obj(o: &lopdf::Object, out: &mut Vec<([f32; 4], String)>) {
+        match o {
+            lopdf::Object::Dictionary(d) => from_dict(d, out),
+            lopdf::Object::Stream(s) => from_dict(&s.dict, out),
+            lopdf::Object::Array(a) => a.iter().for_each(|v| from_obj(v, out)),
+            _ => {}
+        }
+    }
+    let mut out = Vec::new();
+    for obj in doc.objects.values() {
+        from_obj(obj, &mut out);
+    }
+    out
+}
+
+/// A long contact profile (many links) used to exercise header wrapping in both
+/// the résumé layout engine and the legacy cover-letter letterhead.
+fn long_contact_profile() -> crate::contact_profile::ContactProfile {
+    use crate::contact_profile::{ContactLink, ContactProfile, LocalizedText};
+    let extra = |label: &str, url: &str| ContactLink {
+        label: label.to_string(),
+        url: url.to_string(),
+    };
+    ContactProfile {
+        location: Some(LocalizedText {
+            default: "Zaandam, Netherlands".to_string(),
+            ..Default::default()
+        }),
+        email: Some("zohrehnejati0@gmail.com".to_string()),
+        phone: Some("+31 6 3478 0936".to_string()),
+        linkedin: Some("https://www.linkedin.com/in/zohreh-nejati/".to_string()),
+        website: Some("https://drive.google.com/file/d/abc/view".to_string()),
+        extra_links: vec![
+            extra("Dribbble", "https://dribbble.com/zohreh"),
+            extra("Behance", "https://behance.net/zohreh"),
+            extra("Portfolio", "https://zohreh.example/portfolio"),
+            extra("YouTube", "https://youtube.com/@zohreh"),
+            extra("Instagram", "https://instagram.com/zohreh"),
+            extra("Medium", "https://medium.com/@zohreh"),
+        ],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn resume_long_contact_line_wraps_within_page() {
+    let request = ExportRequest {
+        text: "Zohreh Nejati\n\nEXPERIENCE\nAcme  2020 - Present\nDesigner\n- Did work".to_string(),
+        format: super::super::types::ExportFormat::Pdf,
+        document_type: DocumentType::Resume,
+        template_id: super::super::types::TemplateId::Modern,
+        meta: Some(GenerationMeta {
+            candidate_name: Some("Zohreh Nejati".to_string()),
+            job_title: None,
+            company_name: None,
+            target_language: None,
+        }),
+        ats_mode: false,
+        locale: None,
+        contact: Some(long_contact_profile()),
+    };
+    let bytes = generate_pdf(&request).expect("resume pdf");
+    let doc = lopdf::Document::load_mem(&bytes).expect("parse pdf");
+    let rects = collect_link_rects(&doc);
+    assert!(!rects.is_empty(), "expected header link annotations");
+
+    let page_w_pt = request.page_geometry().width_mm * 2.834_645_7;
+    for (r, uri) in &rects {
+        let right = r[0].max(r[2]);
+        assert!(
+            right <= page_w_pt + 1.0,
+            "link {uri} overflows the page (right={right}, page={page_w_pt})"
+        );
+    }
+    // Wrapping happened → header links sit on ≥2 distinct baselines.
+    let mut ys: Vec<i64> = rects
+        .iter()
+        .map(|(r, _)| r[1].min(r[3]).round() as i64)
+        .collect();
+    ys.sort_unstable();
+    ys.dedup();
+    assert!(
+        ys.len() >= 2,
+        "a long contact line must wrap onto multiple lines, baselines={ys:?}"
+    );
+}
+
+#[test]
+fn cover_letter_long_contact_line_wraps_within_page() {
+    let request = ExportRequest {
+        text:
+            "Sehr geehrtes Team,\n\nIch bewerbe mich.\n\nMit freundlichen Gruessen,\nZohreh Nejati"
+                .to_string(),
+        format: super::super::types::ExportFormat::Pdf,
+        document_type: DocumentType::CoverLetter,
+        template_id: super::super::types::TemplateId::Modern,
+        meta: Some(GenerationMeta {
+            candidate_name: Some("Zohreh Nejati".to_string()),
+            job_title: None,
+            company_name: None,
+            target_language: None,
+        }),
+        ats_mode: false,
+        locale: None,
+        contact: Some(long_contact_profile()),
+    };
+    let bytes = generate_pdf(&request).expect("cover letter pdf");
+    let doc = lopdf::Document::load_mem(&bytes).expect("parse pdf");
+    let rects = collect_link_rects(&doc);
+    assert!(!rects.is_empty(), "expected letterhead link annotations");
+
+    let page_w_pt = request.page_geometry().width_mm * 2.834_645_7;
+    for (r, uri) in &rects {
+        let right = r[0].max(r[2]);
+        assert!(
+            right <= page_w_pt + 1.0,
+            "letterhead link {uri} overflows the page (right={right}, page={page_w_pt})"
+        );
+    }
+    let mut ys: Vec<i64> = rects
+        .iter()
+        .map(|(r, _)| r[1].min(r[3]).round() as i64)
+        .collect();
+    ys.sort_unstable();
+    ys.dedup();
+    assert!(
+        ys.len() >= 2,
+        "a long letterhead contact line must wrap, baselines={ys:?}"
+    );
+}
+
 /// Dev tool (ignored): write legacy-vs-engine sample resume PDFs for every
 /// template to `target/sample_pdfs/`, so the canonical layout engine's output
 /// can be eyeballed against the legacy renderer before the `layout_pdf` flag is

--- a/apps/tauri/src-tauri/src/export/pdf_renderer/contact_layout.rs
+++ b/apps/tauri/src-tauri/src/export/pdf_renderer/contact_layout.rs
@@ -1,0 +1,95 @@
+//! Contact-line geometry: clickable-rect placement and separator-aware wrapping
+//! for the header contact line, shared by the résumé layout and the legacy
+//! cover-letter letterhead. Split out of `pdf_renderer/mod.rs` to keep that module
+//! under the architecture LOC cap (R8).
+
+use crate::export::links::{display_text, split_urls, Span};
+use crate::export::types::FontFamily;
+use crate::measure::MeasureText;
+
+use super::text_advance_mm;
+
+/// A clickable link rectangle in page millimetres (x measured from the page left).
+pub(crate) struct ContactLinkRect {
+    pub x_left_mm: f32,
+    pub width_mm: f32,
+    pub url: String,
+}
+
+/// Exact clickable rects for every link in a contact line. Walks the line's spans
+/// accumulating the *visible* text, so each link's left edge is the real advance of
+/// everything drawn before it and its width is the real advance of the label —
+/// overlapping the glyphs the PDF engine actually paints. Replaces the per-character
+/// `× 0.52` estimate, which also mis-measured multi-byte text (it counted bytes).
+pub(crate) fn contact_link_rects(
+    text: &str,
+    x_start_mm: f32,
+    family: FontFamily,
+    font_size: f32,
+    m: &dyn MeasureText,
+) -> Vec<ContactLinkRect> {
+    let mut out = Vec::new();
+    let mut visible = String::new();
+    for span in split_urls(text) {
+        match span {
+            Span::Text(t) => visible.push_str(&t),
+            Span::Link { label, url } => {
+                let x_left_mm = x_start_mm + m.advance_mm(&visible, family, false, font_size);
+                let width_mm = m.advance_mm(&label, family, false, font_size);
+                out.push(ContactLinkRect {
+                    x_left_mm,
+                    width_mm,
+                    url,
+                });
+                visible.push_str(&label);
+            }
+        }
+    }
+    out
+}
+
+/// Greedily wrap a contact-line markdown string into multiple lines that each fit
+/// `max_width_mm`, splitting only on its separator (`" | "` or `" · "`) so a part
+/// (a label, an email, a `[Label](url)` link) is never broken apart. Measures the
+/// *visible* width (links collapsed to their label). Returns the original string
+/// as a single line when it has no separator or already fits.
+pub(crate) fn wrap_contact_markdown(
+    text: &str,
+    max_width_mm: f32,
+    family: FontFamily,
+    font_size: f32,
+) -> Vec<String> {
+    let sep = if text.contains(" | ") {
+        " | "
+    } else if text.contains(" · ") {
+        " · "
+    } else {
+        return vec![text.to_string()];
+    };
+    let sep_w = text_advance_mm(&display_text(sep), family, false, font_size);
+
+    let mut lines: Vec<String> = Vec::new();
+    let mut cur: Vec<&str> = Vec::new();
+    let mut cur_w = 0.0_f32;
+    for part in text.split(sep) {
+        let pw = text_advance_mm(&display_text(part), family, false, font_size);
+        if cur.is_empty() {
+            cur.push(part);
+            cur_w = pw;
+        } else if cur_w + sep_w + pw <= max_width_mm {
+            cur.push(part);
+            cur_w += sep_w + pw;
+        } else {
+            lines.push(cur.join(sep));
+            cur = vec![part];
+            cur_w = pw;
+        }
+    }
+    if !cur.is_empty() {
+        lines.push(cur.join(sep));
+    }
+    if lines.is_empty() {
+        lines.push(text.to_string());
+    }
+    lines
+}

--- a/apps/tauri/src-tauri/src/export/pdf_renderer/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf_renderer/mod.rs
@@ -6,6 +6,9 @@ use crate::measure::{FontMetrics, MeasureText};
 use anyhow::Context;
 use printpdf::*;
 
+mod contact_layout;
+pub(crate) use contact_layout::{contact_link_rects, wrap_contact_markdown};
+
 // ─── Font loading ─────────────────────────────────────────────────────────────
 
 /// Per-family font IDs (regular + bold + optional italic).
@@ -238,46 +241,6 @@ fn text_advance_mm(text: &str, family: FontFamily, bold: bool, size_pt: f32) -> 
 /// Left x (mm) that horizontally centers `advance_mm`-wide content on the page.
 fn centered_x(page_width: f32, advance_mm: f32) -> f32 {
     (page_width - advance_mm) / 2.0
-}
-
-/// A clickable link rectangle in page millimetres (x measured from the page left).
-pub(crate) struct ContactLinkRect {
-    pub x_left_mm: f32,
-    pub width_mm: f32,
-    pub url: String,
-}
-
-/// Exact clickable rects for every link in a contact line. Walks the line's spans
-/// accumulating the *visible* text, so each link's left edge is the real advance of
-/// everything drawn before it and its width is the real advance of the label —
-/// overlapping the glyphs the PDF engine actually paints. Replaces the per-character
-/// `× 0.52` estimate, which also mis-measured multi-byte text (it counted bytes).
-pub(crate) fn contact_link_rects(
-    text: &str,
-    x_start_mm: f32,
-    family: FontFamily,
-    font_size: f32,
-    m: &dyn MeasureText,
-) -> Vec<ContactLinkRect> {
-    use crate::export::links::{split_urls, Span};
-    let mut out = Vec::new();
-    let mut visible = String::new();
-    for span in split_urls(text) {
-        match span {
-            Span::Text(t) => visible.push_str(&t),
-            Span::Link { label, url } => {
-                let x_left_mm = x_start_mm + m.advance_mm(&visible, family, false, font_size);
-                let width_mm = m.advance_mm(&label, family, false, font_size);
-                out.push(ContactLinkRect {
-                    x_left_mm,
-                    width_mm,
-                    url,
-                });
-                visible.push_str(&label);
-            }
-        }
-    }
-    out
 }
 
 /// Build a clickable link annotation `Op` from a rectangle given in **top-down**
@@ -668,34 +631,47 @@ pub fn render_letterhead(
 
             if !contact_line.is_empty() {
                 let font_size = 9.0_f32;
-                let visible_contact = crate::export::links::display_text(contact_line);
-                let contact_x = if template.name_centered {
-                    centered_x(
-                        layout.page_width,
-                        text_advance_mm(
-                            &visible_contact,
-                            template.fonts.body_family,
-                            false,
-                            font_size,
-                        ),
-                    )
-                } else {
-                    layout.margin_left
-                };
-                render_contact_text_with_links(
-                    contact_line,
-                    ContactSpanCtx {
-                        x_start: contact_x,
-                        y: current_y,
-                        font_size,
-                        page_height: layout.page_height,
-                        reg_id: body_reg,
-                        fill_color: colors.date.clone(),
-                        family: template.fonts.body_family,
-                    },
-                    &mut ops,
+                let fam = template.fonts.body_family;
+                let content_w = layout.page_width - layout.margin_left - layout.margin_right;
+                let full_w = text_advance_mm(
+                    &crate::export::links::display_text(contact_line),
+                    fam,
+                    false,
+                    font_size,
                 );
-                current_y -= pt_to_mm(font_size) * 1.2;
+                // Fits on one line → unchanged single-line path (preserves golden
+                // parity). Otherwise wrap on separators so a long contact line stacks
+                // instead of overflowing the page margins, centring each line.
+                let lines = if full_w <= content_w {
+                    vec![contact_line.to_string()]
+                } else {
+                    wrap_contact_markdown(contact_line, content_w, fam, font_size)
+                };
+                for line in &lines {
+                    let visible = crate::export::links::display_text(line);
+                    let contact_x = if template.name_centered {
+                        centered_x(
+                            layout.page_width,
+                            text_advance_mm(&visible, fam, false, font_size),
+                        )
+                    } else {
+                        layout.margin_left
+                    };
+                    render_contact_text_with_links(
+                        line,
+                        ContactSpanCtx {
+                            x_start: contact_x,
+                            y: current_y,
+                            font_size,
+                            page_height: layout.page_height,
+                            reg_id: body_reg,
+                            fill_color: colors.date.clone(),
+                            family: fam,
+                        },
+                        &mut ops,
+                    );
+                    current_y -= pt_to_mm(font_size) * 1.2;
+                }
             }
 
             // Hairline rule — thickness from template (e.g. 0.25 pt for Editorial Serif)

--- a/apps/tauri/src-tauri/src/layout/mod.rs
+++ b/apps/tauri/src-tauri/src/layout/mod.rs
@@ -375,20 +375,31 @@ fn lay_header(
 
     if !h.contact.is_empty() {
         let fam = t.fonts.body_family;
-        let total = line_width(&h.contact, fam, CONTACT_PT, m);
-        let x = if t.name_centered {
-            (frame.geom.width_mm - total) / 2.0
-        } else {
-            frame.left
-        };
         let style = LineStyle {
             family: fam,
             size_pt: CONTACT_PT,
             normal: t.date_color,
             bold: t.date_color,
         };
-        place_line(page, &h.contact, x, *y, style, m);
-        *y += pt_to_mm(CONTACT_PT) * 1.2;
+        let total = line_width(&h.contact, fam, CONTACT_PT, m);
+        // Fits on one line → unchanged single-line path (preserves golden parity).
+        // Otherwise wrap to the content width so a long contact line (many links)
+        // stacks instead of overflowing the page margins, centring each line.
+        let lines = if total <= frame.width() {
+            vec![h.contact.clone()]
+        } else {
+            wrap_runs(&h.contact, frame.width(), fam, CONTACT_PT, m)
+        };
+        for line in &lines {
+            let lw = line_width(line, fam, CONTACT_PT, m);
+            let x = if t.name_centered {
+                (frame.geom.width_mm - lw) / 2.0
+            } else {
+                frame.left
+            };
+            place_line(page, line, x, *y, style, m);
+            *y += pt_to_mm(CONTACT_PT) * 1.2;
+        }
     }
 
     page.rules.push(RuleLine {

--- a/apps/tauri/src-tauri/src/validate/mod.rs
+++ b/apps/tauri/src-tauri/src/validate/mod.rs
@@ -224,6 +224,7 @@ fn stray_markdown_issues(extracted: &str) -> Vec<ExportIssue> {
 
 /// A link annotation read back from the rendered PDF: its `/Rect` in PDF user
 /// space (points, bottom-up origin) and target URL.
+#[derive(Debug)]
 struct PdfLink {
     /// `[x0, y0, x1, y1]` — bottom-left and top-right corners in points.
     rect: [f32; 4],
@@ -236,10 +237,12 @@ struct PdfLink {
 /// résumé engine and the legacy cover-letter path are both covered):
 ///   * `empty_anchor_link` — every link rect overlaps rendered text (catches the
 ///     header links dumped to the page bottom with no glyphs under them).
-///   * `header_url_mismatch` — when a contact profile is the source of truth, every
-///     header-region link URL must be one of the profile's named fields, and every
-///     profile URL must appear in the header (catches a company-link displacing a
-///     personal profile / site).
+///   * `header_url_mismatch` (critical) — when a contact profile is the source of
+///     truth, every header-region link URL must be one of the profile's named
+///     fields (catches a company-link displacing a personal profile / site).
+///   * `header_url_missing` (warning) — the reverse completeness check (a profile
+///     link that did not surface in the header band); advisory only, as it leans on
+///     the band heuristic and a missing link never corrupts the document.
 fn pdf_render_issues(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> {
     let doc = match lopdf::Document::load_mem(bytes) {
         Ok(d) => d,
@@ -294,6 +297,9 @@ fn pdf_render_issues(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> 
             .filter(|l| l.page == 0 && l.rect[1].max(l.rect[3]) >= header_band_bottom)
             .collect();
 
+        // A header-band link that is NOT one of the profile's own fields means a
+        // body/company link displaced a personal one (the URL-swap regression) —
+        // the document shows a wrong link, so this stays blocking.
         for link in &header_links {
             if !allowed.contains(&link.url) {
                 issues.push(ExportIssue::critical(
@@ -306,10 +312,14 @@ fn pdf_render_issues(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> 
                 ));
             }
         }
+        // The reverse (a profile link that did not surface in the header band) is a
+        // *completeness* signal that depends on the 144 pt band heuristic, so it is
+        // advisory — a missing/displaced contact link is a quality note, never a
+        // reason to stop the user exporting an otherwise-valid, readable document.
         for url in &allowed {
             if !header_links.iter().any(|l| &l.url == url) {
-                issues.push(ExportIssue::critical(
-                    "header_url_mismatch",
+                issues.push(ExportIssue::warning(
+                    "header_url_missing",
                     format!("Contact profile link {url} is missing from the rendered header."),
                 ));
             }
@@ -344,17 +354,47 @@ fn text_baseline_ys(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> Vec<f32>
     ys
 }
 
+/// Read a page's `/Annots` entries as concrete dictionaries, handling BOTH the
+/// inline-dictionary and the indirect-reference encodings — at the array level
+/// and per element.
+///
+/// lopdf's own [`lopdf::Document::get_page_annotations`] keeps only entries that
+/// are *indirect references* (`flat_map(Object::as_reference)`). Our PDF renderer
+/// (printpdf) writes `/Annots` as an array of **inline dictionaries**, so that
+/// helper returns nothing for every PDF we generate — which silently made the
+/// header-link checks below see zero links and report every profile URL as
+/// "missing", blocking any export that had a contact profile. Reading the array
+/// ourselves keeps the validator working against our own renderer's output.
+fn page_annot_dicts(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> Vec<lopdf::Dictionary> {
+    let Ok(page) = doc.get_dictionary(page_id) else {
+        return Vec::new();
+    };
+    let array = match page.get(b"Annots") {
+        Ok(lopdf::Object::Reference(id)) => doc.get_object(*id).and_then(|o| o.as_array()).ok(),
+        Ok(lopdf::Object::Array(a)) => Some(a),
+        _ => None,
+    };
+    let Some(array) = array else {
+        return Vec::new();
+    };
+    array
+        .iter()
+        .filter_map(|o| match o {
+            lopdf::Object::Dictionary(d) => Some(d.clone()),
+            lopdf::Object::Reference(id) => doc.get_dictionary(*id).ok().cloned(),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Collect `/Link` annotations (rect + `/A /URI`) for one page.
 fn page_link_annotations(
     doc: &lopdf::Document,
     page_id: lopdf::ObjectId,
     page_idx: usize,
 ) -> Vec<PdfLink> {
-    let Ok(annots) = doc.get_page_annotations(page_id) else {
-        return Vec::new();
-    };
     let mut out = Vec::new();
-    for annot in annots {
+    for annot in page_annot_dicts(doc, page_id) {
         let is_link = annot
             .get(b"Subtype")
             .and_then(|v| v.as_name())

--- a/apps/tauri/src-tauri/src/validate/tests.rs
+++ b/apps/tauri/src-tauri/src/validate/tests.rs
@@ -185,6 +185,97 @@ fn two_column_pdf_is_never_blocked() {
     }
 }
 
+// ─── header link annotations (printpdf inline-dict /Annots) ───────────────────
+
+/// Read every link annotation our renderer wrote, the way the header checks do.
+fn rendered_links(bytes: &[u8]) -> Vec<PdfLink> {
+    let doc = lopdf::Document::load_mem(bytes).expect("load pdf");
+    doc.get_pages()
+        .into_values()
+        .enumerate()
+        .flat_map(|(idx, page_id)| page_link_annotations(&doc, page_id, idx))
+        .collect()
+}
+
+fn profile_with(website: &str) -> crate::contact_profile::ContactProfile {
+    crate::contact_profile::ContactProfile {
+        website: Some(website.to_string()),
+        ..Default::default()
+    }
+}
+
+/// Regression: lopdf's `get_page_annotations` only resolves *reference* entries,
+/// but printpdf writes `/Annots` as inline dictionaries — so the header-link
+/// reader used to see zero links. It must now read our own renderer's output.
+#[test]
+fn reads_inline_dict_link_annotations_from_our_renderer() {
+    let mut request = req(ExportFormat::Pdf, TemplateId::Modern, false);
+    request.contact = Some(profile_with("https://example.dev/portfolio"));
+    let bytes = crate::export::pdf::generate_pdf(&request).expect("pdf");
+
+    let links = rendered_links(&bytes);
+    assert!(
+        links
+            .iter()
+            .any(|l| l.url == "https://example.dev/portfolio" && l.page == 0),
+        "the contact-profile header link must be read back, got {links:?}"
+    );
+}
+
+/// The reading regression meant ANY non-empty contact profile produced a phantom
+/// "missing from the rendered header" critical and blocked every export. A profile
+/// whose link the renderer actually draws must export cleanly.
+#[test]
+fn contact_profile_export_is_not_falsely_blocked() {
+    let mut request = req(ExportFormat::Pdf, TemplateId::Modern, false);
+    request.contact = Some(profile_with(
+        "https://drive.google.com/file/d/abc123/view?usp=drive_link",
+    ));
+    let (bytes, report) =
+        validate_and_fix(request, crate::export::pdf::generate_pdf).expect("pdf export");
+    assert!(!bytes.is_empty());
+    assert!(
+        report.ok,
+        "a résumé with a contact profile must export, not block: {:?}",
+        report.issues
+    );
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|i| i.severity == Severity::Critical),
+        "no critical header issues expected: {:?}",
+        report.issues
+    );
+}
+
+/// A profile link that genuinely does not surface in the header is advisory
+/// (warning), never blocking — a missing contact link does not corrupt the doc.
+#[test]
+fn missing_header_link_is_warning_not_block() {
+    // A `mailto:` is in the profile's header_urls, but a website-only header line
+    // can leave it unrendered depending on layout; whatever surfaces, a non-matching
+    // profile URL must downgrade to a warning rather than block.
+    let mut profile = profile_with("https://example.dev/site");
+    profile.extra_links = vec![crate::contact_profile::ContactLink {
+        label: String::new(), // empty label → header_markdown never renders it…
+        url: "https://example.dev/never-rendered".to_string(), // …but header_urls lists it
+    }];
+    let mut request = req(ExportFormat::Pdf, TemplateId::Modern, false);
+    request.contact = Some(profile);
+    let (_bytes, report) =
+        validate_and_fix(request, crate::export::pdf::generate_pdf).expect("pdf export");
+    assert!(report.ok, "missing header link must not block: {report:?}");
+    assert!(
+        report
+            .issues
+            .iter()
+            .any(|i| i.code == "header_url_missing" && i.severity == Severity::Warning),
+        "the unrendered profile link must surface as a warning: {:?}",
+        report.issues
+    );
+}
+
 #[test]
 fn txt_is_returned_unvalidated() {
     let (bytes, report) =

--- a/apps/tauri/src/renderer/components/contact/ContactProfileForm/index.tsx
+++ b/apps/tauri/src/renderer/components/contact/ContactProfileForm/index.tsx
@@ -1,0 +1,233 @@
+import { Plus, Trash2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import type { ContactProfile } from '@ajh/shared';
+import { Button, Input } from '@ajh/ui';
+
+import { useTranslation } from '@/lib/i18n';
+import { useContactProfile, useSaveContactProfile } from '@/services';
+
+const FIELD_CLASS = 'flex flex-col gap-1.5';
+const LABEL_CLASS = 'text-xs font-medium text-foreground/70';
+
+/** A locally-keyed extra-link row, so React keeps input focus across edits. */
+interface LinkRow {
+  id: number;
+  label: string;
+  url: string;
+}
+
+/**
+ * The editable contact-profile form — the single source of truth for the document
+ * header contact line (name fields → clickable links). Shared between the Settings
+ * tab and the first-run pre-generation prompt, so both edit the exact same fields.
+ *
+ * "Other links" are the free-form extras beyond the named platforms (Dribbble,
+ * Behance, a portfolio); they are autofilled from an imported résumé and editable
+ * here as label/URL pairs.
+ *
+ * Location is a single value used for every document language (the backend's
+ * `LocalizedText` still supports per-language overrides, but the form writes only
+ * `default`). Changes persist on blur — no explicit save button.
+ */
+export function ContactProfileForm() {
+  const { t } = useTranslation();
+  const { data: profile } = useContactProfile();
+  const { mutate: save } = useSaveContactProfile();
+
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [location, setLocation] = useState('');
+  const [linkedin, setLinkedin] = useState('');
+  const [github, setGithub] = useState('');
+  const [website, setWebsite] = useState('');
+  const [extraLinks, setExtraLinks] = useState<LinkRow[]>([]);
+  const rowId = useRef(0);
+
+  // Hydrate the form once the stored profile loads (or changes).
+  useEffect(() => {
+    if (!profile) return;
+    setFullName(profile.fullName ?? '');
+    setEmail(profile.email ?? '');
+    setPhone(profile.phone ?? '');
+    setLocation(profile.location?.default ?? '');
+    setLinkedin(profile.linkedin ?? '');
+    setGithub(profile.github ?? '');
+    setWebsite(profile.website ?? '');
+    setExtraLinks(
+      (profile.extraLinks ?? []).map((l) => ({ id: rowId.current++, label: l.label, url: l.url }))
+    );
+  }, [profile]);
+
+  // Build the whole profile from current field state. Extra links keep only rows
+  // with a URL (an empty draft row is dropped) and are trimmed.
+  const buildProfile = (rows: LinkRow[]): ContactProfile => {
+    const clean = (s: string) => s.trim() || undefined;
+    const extra = rows
+      .map((l) => ({ label: l.label.trim(), url: l.url.trim() }))
+      .filter((l) => l.url !== '');
+    return {
+      fullName: clean(fullName),
+      email: clean(email),
+      phone: clean(phone),
+      // One location for every document language — no per-language overrides.
+      location: location.trim() ? { default: location.trim() } : undefined,
+      linkedin: clean(linkedin),
+      github: clean(github),
+      website: clean(website),
+      extraLinks: extra.length ? extra : undefined,
+    };
+  };
+
+  // Persist on blur (named fields + extra-link edits).
+  const persist = () => save(buildProfile(extraLinks));
+
+  const updateLink = (id: number, patch: Partial<LinkRow>) =>
+    setExtraLinks((prev) => prev.map((l) => (l.id === id ? { ...l, ...patch } : l)));
+
+  const addLink = () =>
+    setExtraLinks((prev) => [...prev, { id: rowId.current++, label: '', url: '' }]);
+
+  // Add/remove persist immediately with the next array (state is async).
+  const removeLink = (id: number) => {
+    const next = extraLinks.filter((l) => l.id !== id);
+    setExtraLinks(next);
+    save(buildProfile(next));
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-name">
+            {t('settings.contactProfile.fullName')}
+          </label>
+          <Input
+            id="cp-name"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            onBlur={persist}
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-email">
+            {t('settings.contactProfile.email')}
+          </label>
+          <Input
+            id="cp-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onBlur={persist}
+            placeholder={t('settings.contactProfile.emailPlaceholder')}
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-phone">
+            {t('settings.contactProfile.phone')}
+          </label>
+          <Input
+            id="cp-phone"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            onBlur={persist}
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-location">
+            {t('settings.contactProfile.location')}
+          </label>
+          <Input
+            id="cp-location"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            onBlur={persist}
+            placeholder={t('settings.contactProfile.locationPlaceholder')}
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-linkedin">
+            {t('settings.contactProfile.linkedin')}
+          </label>
+          <Input
+            id="cp-linkedin"
+            value={linkedin}
+            onChange={(e) => setLinkedin(e.target.value)}
+            onBlur={persist}
+            placeholder={t('settings.contactProfile.linkedinPlaceholder')}
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-github">
+            {t('settings.contactProfile.github')}
+          </label>
+          <Input
+            id="cp-github"
+            value={github}
+            onChange={(e) => setGithub(e.target.value)}
+            onBlur={persist}
+            placeholder={t('settings.contactProfile.githubPlaceholder')}
+          />
+        </div>
+
+        <div className={FIELD_CLASS}>
+          <label className={LABEL_CLASS} htmlFor="cp-website">
+            {t('settings.contactProfile.website')}
+          </label>
+          <Input
+            id="cp-website"
+            value={website}
+            onChange={(e) => setWebsite(e.target.value)}
+            onBlur={persist}
+            placeholder={t('settings.contactProfile.websitePlaceholder')}
+          />
+        </div>
+      </div>
+
+      <div className="mt-6 flex flex-col gap-2">
+        <span className={LABEL_CLASS}>{t('settings.contactProfile.extraLinks')}</span>
+        <p className="text-xs text-foreground/55">{t('settings.contactProfile.extraLinksHint')}</p>
+
+        {extraLinks.map((row) => (
+          <div key={row.id} className="flex items-start gap-2">
+            <Input
+              aria-label={t('settings.contactProfile.linkLabel')}
+              value={row.label}
+              onChange={(e) => updateLink(row.id, { label: e.target.value })}
+              onBlur={persist}
+              placeholder={t('settings.contactProfile.linkLabelPlaceholder')}
+              className="w-1/3"
+            />
+            <Input
+              aria-label={t('settings.contactProfile.linkUrl')}
+              value={row.url}
+              onChange={(e) => updateLink(row.id, { url: e.target.value })}
+              onBlur={persist}
+              placeholder={t('settings.contactProfile.linkUrlPlaceholder')}
+              className="flex-1"
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label={t('settings.contactProfile.removeLink')}
+              onClick={() => removeLink(row.id)}
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
+        ))}
+
+        <Button variant="ghost" size="sm" onClick={addLink} className="mt-1 self-start gap-1.5">
+          <Plus className="size-4" />
+          {t('settings.contactProfile.addLink')}
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/apps/tauri/src/renderer/components/contact/ContactPromptModal/index.tsx
+++ b/apps/tauri/src/renderer/components/contact/ContactPromptModal/index.tsx
@@ -1,0 +1,51 @@
+import { Contact } from 'lucide-react';
+
+import { Button, ModalShell } from '@ajh/ui';
+
+import { ContactProfileForm } from '@/components/contact/ContactProfileForm';
+import { useTranslation } from '@/lib/i18n';
+
+interface ContactPromptModalProps {
+  open: boolean;
+  /** Dismiss without proceeding (Escape / backdrop / Cancel). */
+  onClose: () => void;
+  /** Proceed with the gated action (e.g. start generation). */
+  onContinue: () => void;
+}
+
+/**
+ * One-time pre-generation prompt: before the user's first résumé / cover-letter
+ * generation we surface the contact profile so the document header is complete.
+ * Reuses the same [`ContactProfileForm`] as Settings, so the fields never drift.
+ * Whether this appears at all is gated by the persisted `contactPromptSeen` flag.
+ */
+export function ContactPromptModal({ open, onClose, onContinue }: ContactPromptModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <ModalShell open={open} onClose={onClose} maxWidth="max-w-2xl">
+      <div className="flex max-h-[85vh] flex-col">
+        <div className="flex items-start gap-2 border-b border-white/[0.08] px-6 py-5">
+          <Contact size={16} className="mt-0.5 shrink-0 text-brand-soft" />
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-semibold text-foreground/85">
+              {t('contactPrompt.title')}
+            </span>
+            <p className="text-xs text-foreground/55">{t('contactPrompt.description')}</p>
+          </div>
+        </div>
+
+        <div className="overflow-y-auto px-6 py-5">
+          <ContactProfileForm />
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-white/[0.08] px-6 py-4">
+          <Button variant="ghost" onClick={onClose}>
+            {t('contactPrompt.cancel')}
+          </Button>
+          <Button onClick={onContinue}>{t('contactPrompt.continue')}</Button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}

--- a/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from 'motion/react';
 import { useRef, useState } from 'react';
 
+import { ContactPromptModal } from '@/components/contact/ContactPromptModal';
 import { PageTransition } from '@/components/layout/PageTransition';
 import { useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
 import { LeftPanel } from '@/features/ai-generate/components/LeftPanel';
@@ -22,6 +23,7 @@ import {
 import { useTranslation } from '@/lib/i18n';
 import { useExtractText } from '@/services';
 import { useSaveAiGeneration } from '@/services/use-ai-generations';
+import { useContactPromptSeen, usePreferencesStore } from '@/store/preferences-store';
 import { useSessionStore } from '@/store/session-store';
 
 type GenTarget = 'resume' | 'cover' | 'both';
@@ -123,6 +125,27 @@ export function AIGeneratePage() {
   const canProceed = resume.trim().length > 50 && jobAd.trim().length > 50;
   const canGenerate = canProceed && canUseAI;
 
+  // First-run nudge: before the very first generation, surface the contact profile
+  // so the document header is complete. Shown once (persisted flag), then never
+  // again — afterwards Generate runs straight through.
+  const contactPromptSeen = useContactPromptSeen();
+  const setContactPromptSeen = usePreferencesStore((s) => s.setContactPromptSeen);
+  const [contactModalOpen, setContactModalOpen] = useState(false);
+
+  const requestGenerate = () => {
+    if (!contactPromptSeen) {
+      setContactPromptSeen();
+      setContactModalOpen(true);
+      return;
+    }
+    void handleGenerate();
+  };
+
+  const continueFromContactPrompt = () => {
+    setContactModalOpen(false);
+    void handleGenerate();
+  };
+
   const reset = () => {
     if (abortControllerRef.current && stage === 'generating') {
       abortControllerRef.current.abort();
@@ -204,7 +227,7 @@ export function AIGeneratePage() {
           onUpload={handleUpload}
           onReset={reset}
           onAnalyze={handleAnalyze}
-          onGenerate={handleGenerate}
+          onGenerate={requestGenerate}
           isGenerating={isGenerating}
         />
 
@@ -257,6 +280,12 @@ export function AIGeneratePage() {
           )}
         </div>
       </div>
+
+      <ContactPromptModal
+        open={contactModalOpen}
+        onClose={() => setContactModalOpen(false)}
+        onContinue={continueFromContactPrompt}
+      />
     </PageTransition>
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/contact/ContactProfileTab/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/contact/ContactProfileTab/index.tsx
@@ -1,168 +1,25 @@
 import { Contact } from 'lucide-react';
-import { useEffect, useState } from 'react';
 
-import type { ContactProfile } from '@ajh/shared';
-import { Input, SettingsSection } from '@ajh/ui';
+import { SettingsSection } from '@ajh/ui';
 
+import { ContactProfileForm } from '@/components/contact/ContactProfileForm';
 import { useTranslation } from '@/lib/i18n';
-import { useContactProfile, useSaveContactProfile } from '@/services';
-
-const FIELD_CLASS = 'flex flex-col gap-1.5';
-const LABEL_CLASS = 'text-xs font-medium text-foreground/70';
 
 /**
  * Edit the contact profile — the single source of truth for the document header
  * contact line. The résumé, cover letter, and DOCX all build their header from
  * these named fields (never the résumé's company-link pool), so a personal
  * LinkedIn / Website can't be displaced by an employer URL. Seeded from an
- * uploaded résumé on import, then freely editable here.
- *
- * Location is a single value used for every document language: the backend's
- * `LocalizedText` still supports per-language overrides, but we no longer expose
- * an input per language (that doesn't scale as languages are added), so the form
- * writes only `default` and clears any legacy override on save.
- *
- * Follows the settings convention: changes persist on blur, no explicit save.
+ * uploaded résumé on import, then freely editable here. The form itself is shared
+ * with the first-run pre-generation prompt ([`ContactProfileForm`]).
  */
 export function ContactProfileTab() {
   const { t } = useTranslation();
-  const { data: profile } = useContactProfile();
-  const { mutate: save } = useSaveContactProfile();
-
-  const [fullName, setFullName] = useState('');
-  const [email, setEmail] = useState('');
-  const [phone, setPhone] = useState('');
-  const [location, setLocation] = useState('');
-  const [linkedin, setLinkedin] = useState('');
-  const [github, setGithub] = useState('');
-  const [website, setWebsite] = useState('');
-
-  // Hydrate the form once the stored profile loads (or changes).
-  useEffect(() => {
-    if (!profile) return;
-    setFullName(profile.fullName ?? '');
-    setEmail(profile.email ?? '');
-    setPhone(profile.phone ?? '');
-    setLocation(profile.location?.default ?? '');
-    setLinkedin(profile.linkedin ?? '');
-    setGithub(profile.github ?? '');
-    setWebsite(profile.website ?? '');
-  }, [profile]);
-
-  // Persist the whole profile from current field state (called on blur).
-  const persist = () => {
-    const clean = (s: string) => s.trim() || undefined;
-
-    const next: ContactProfile = {
-      fullName: clean(fullName),
-      email: clean(email),
-      phone: clean(phone),
-      // One location for every document language — no per-language overrides.
-      location: location.trim() ? { default: location.trim() } : undefined,
-      linkedin: clean(linkedin),
-      github: clean(github),
-      website: clean(website),
-      // Preserve any extra links seeded on import — the form doesn't edit them.
-      extraLinks: profile?.extraLinks,
-    };
-    save(next);
-  };
 
   return (
     <SettingsSection icon={Contact} label={t('settings.contactProfile.title')}>
       <p className="mb-4 text-xs text-foreground/55">{t('settings.contactProfile.description')}</p>
-
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div className={FIELD_CLASS}>
-          <label className={LABEL_CLASS} htmlFor="cp-name">
-            {t('settings.contactProfile.fullName')}
-          </label>
-          <Input
-            id="cp-name"
-            value={fullName}
-            onChange={(e) => setFullName(e.target.value)}
-            onBlur={persist}
-          />
-        </div>
-
-        <div className={FIELD_CLASS}>
-          <label className={LABEL_CLASS} htmlFor="cp-email">
-            {t('settings.contactProfile.email')}
-          </label>
-          <Input
-            id="cp-email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            onBlur={persist}
-            placeholder={t('settings.contactProfile.emailPlaceholder')}
-          />
-        </div>
-
-        <div className={FIELD_CLASS}>
-          <label className={LABEL_CLASS} htmlFor="cp-phone">
-            {t('settings.contactProfile.phone')}
-          </label>
-          <Input
-            id="cp-phone"
-            value={phone}
-            onChange={(e) => setPhone(e.target.value)}
-            onBlur={persist}
-          />
-        </div>
-
-        <div className={FIELD_CLASS}>
-          <label className={LABEL_CLASS} htmlFor="cp-location">
-            {t('settings.contactProfile.location')}
-          </label>
-          <Input
-            id="cp-location"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            onBlur={persist}
-            placeholder={t('settings.contactProfile.locationPlaceholder')}
-          />
-        </div>
-
-        <div className={FIELD_CLASS}>
-          <label className={LABEL_CLASS} htmlFor="cp-linkedin">
-            {t('settings.contactProfile.linkedin')}
-          </label>
-          <Input
-            id="cp-linkedin"
-            value={linkedin}
-            onChange={(e) => setLinkedin(e.target.value)}
-            onBlur={persist}
-            placeholder={t('settings.contactProfile.linkedinPlaceholder')}
-          />
-        </div>
-
-        <div className={FIELD_CLASS}>
-          <label className={LABEL_CLASS} htmlFor="cp-github">
-            {t('settings.contactProfile.github')}
-          </label>
-          <Input
-            id="cp-github"
-            value={github}
-            onChange={(e) => setGithub(e.target.value)}
-            onBlur={persist}
-            placeholder={t('settings.contactProfile.githubPlaceholder')}
-          />
-        </div>
-
-        <div className={FIELD_CLASS}>
-          <label className={LABEL_CLASS} htmlFor="cp-website">
-            {t('settings.contactProfile.website')}
-          </label>
-          <Input
-            id="cp-website"
-            value={website}
-            onChange={(e) => setWebsite(e.target.value)}
-            onBlur={persist}
-            placeholder={t('settings.contactProfile.websitePlaceholder')}
-          />
-        </div>
-      </div>
+      <ContactProfileForm />
     </SettingsSection>
   );
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -253,7 +253,15 @@
       "github": "GitHub",
       "githubPlaceholder": "https://github.com/ihr-handle",
       "website": "Website",
-      "websitePlaceholder": "https://ihre-website.com"
+      "websitePlaceholder": "https://ihre-website.com",
+      "extraLinks": "Weitere Links",
+      "extraLinksHint": "Portfolio, Dribbble, Behance oder andere persönliche Links. Beim Import eines Lebenslaufs werden diese automatisch ausgefüllt.",
+      "addLink": "Link hinzufügen",
+      "linkLabel": "Bezeichnung",
+      "linkLabelPlaceholder": "Dribbble",
+      "linkUrl": "URL",
+      "linkUrlPlaceholder": "https://…",
+      "removeLink": "Link entfernen"
     },
     "developer": {
       "title": "Entwickler-Werkzeuge",
@@ -419,6 +427,12 @@
       "changelogError": "Änderungsprotokoll konnte nicht geladen werden.",
       "changelogEmpty": "Keine Releases gefunden."
     }
+  },
+  "contactPrompt": {
+    "title": "Kontaktdaten bestätigen",
+    "description": "Diese erscheinen in der Kopfzeile jedes Lebenslaufs und Anschreibens, das Sie erstellen. Wir haben ausgefüllt, was wir gefunden haben — bitte prüfen und ergänzen Sie sie. Sie können sie jederzeit in den Einstellungen ändern.",
+    "continue": "Speichern & fortfahren",
+    "cancel": "Abbrechen"
   },
   "aiGenerate": {
     "title": "KI-Generierung",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -253,7 +253,15 @@
       "github": "GitHub",
       "githubPlaceholder": "https://github.com/your-handle",
       "website": "Website",
-      "websitePlaceholder": "https://your-site.com"
+      "websitePlaceholder": "https://your-site.com",
+      "extraLinks": "Other links",
+      "extraLinksHint": "Portfolio, Dribbble, Behance, or any other personal link. Imported résumés fill these in automatically.",
+      "addLink": "Add link",
+      "linkLabel": "Label",
+      "linkLabelPlaceholder": "Dribbble",
+      "linkUrl": "URL",
+      "linkUrlPlaceholder": "https://…",
+      "removeLink": "Remove link"
     },
     "developer": {
       "title": "Developer Tools",
@@ -419,6 +427,12 @@
       "changelogError": "Couldn't load the changelog.",
       "changelogEmpty": "No releases found."
     }
+  },
+  "contactPrompt": {
+    "title": "Confirm your contact details",
+    "description": "These appear in the header of every résumé and cover letter you generate. We filled in what we found — please review and complete them. You can change them anytime in Settings.",
+    "continue": "Save & continue",
+    "cancel": "Cancel"
   },
   "aiGenerate": {
     "title": "AI Generate",

--- a/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
+++ b/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
@@ -86,6 +86,10 @@ export const PreferencesSchema = z.object({
   // Onboarding
   onboardingCompleted: z.boolean().default(false),
 
+  // One-time nudge to review/complete the contact profile before the first
+  // résumé / cover-letter generation.
+  contactPromptSeen: z.boolean().default(false),
+
   // Metadata
   lastUpdated: z.string().optional(),
 });

--- a/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
+++ b/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
@@ -53,6 +53,7 @@ const defaultPreferences: Preferences = {
   promptQuality: 'auto',
   debugMode: false,
   onboardingCompleted: false,
+  contactPromptSeen: false,
   lastUpdated: new Date().toISOString(),
 };
 
@@ -70,6 +71,7 @@ interface PreferencesActions {
   setPromptQuality: (promptQuality: PromptQuality) => void;
   setDebugMode: (enabled: boolean) => void;
   setOnboardingComplete: () => void;
+  setContactPromptSeen: () => void;
   resetPreferences: () => void;
 }
 
@@ -175,6 +177,13 @@ export const usePreferencesStore = create<PreferencesStore>()(
           lastUpdated: new Date().toISOString(),
         })),
 
+      setContactPromptSeen: () =>
+        set((state) => ({
+          ...state,
+          contactPromptSeen: true,
+          lastUpdated: new Date().toISOString(),
+        })),
+
       resetPreferences: () => set(defaultPreferences),
     }),
     {
@@ -196,6 +205,8 @@ export const useAiProviderConfig = () => usePreferencesStore((state) => state.ai
 export const useOutputTone = () => usePreferencesStore((state) => state.outputTone);
 export const useOnboardingCompleted = () =>
   usePreferencesStore((state) => state.onboardingCompleted);
+export const useContactPromptSeen = () =>
+  usePreferencesStore((state) => state.contactPromptSeen ?? false);
 export const useResume = () => usePreferencesStore((state) => state.resume);
 export const usePerformanceMode = () => usePreferencesStore((state) => state.performanceMode);
 export const usePromptQuality = () => usePreferencesStore((state) => state.promptQuality ?? 'auto');


### PR DESCRIPTION
## Summary

Fixes a chain of contact-profile header problems (exports were fully blocked, then produced broken headers once unblocked) and adds the missing editing + first-run UX. Backend fix + frontend feature, split into two commits.

## Background

The pre-export validator read PDF link annotations via lopdf's `get_page_annotations`, which only resolves *indirect-reference* `/Annots`. Our renderer (printpdf) writes them as **inline dictionaries**, so the validator saw **zero** header links and reported every contact-profile URL as "missing from the rendered header" → **every export with a contact profile was hard-blocked**. Removing that false block then exposed pre-existing header bugs from the contact-profile feature.

## Backend (`fix:`)

- **Read `/Annots` ourselves** (inline dictionaries *and* references) so the header-link validation works against our own renderer; downgrade the geometry-fragile "missing header link" check from blocking to advisory (the leak/URL-swap direction stays blocking).
- **Autofill the contact profile on import** — `classify_contact_links` keeps every other personal link as a labelled extra (Dribbble, Behance, …); email/phone/location come from the structuring pass; merged via `fill_empty_from`, filling only empty fields so user edits are never clobbered.
- **Stop the cover-letter contact-line leak** — drop any pre-salutation line that looks like a contact line (an `@` or ≥2 separators), so the generated letter's own contact line never leaks into the body as raw markdown.
- **Wrap long header contact lines** instead of overflowing the page margins, in both the résumé layout engine and the legacy letterhead; the single-line path stays byte-identical when it fits (golden parity). Contact-line geometry extracted into a `contact_layout` submodule to stay under the R8 LOC cap.

## Frontend (`feat:`)

- **"Other links" editor** (label/URL rows, add/remove) in the contact profile so autofilled extras are editable, not just visible. Fields extracted into a shared `ContactProfileForm` reused by Settings and the new prompt.
- **First-run prompt** — before the first résumé/cover-letter generation, a one-time modal surfaces that same form so the header is complete. Gated by a persisted `contactPromptSeen` flag (shows once, never again).

## Recovery

An already-sparse stored profile completes itself on the next résumé **re-import** (the merge fills email/phone/location/extras and keeps the user's edits).

## Testing

- New Rust tests: inline-dict annotation reading, no false block with a contact profile, advisory "missing" warning, classify extras, `fill_empty_from`, cover-letter no-leak, résumé + cover-letter long-line wrapping (links on ≥2 baselines, within page).
- Full backend suite green; clippy `-D warnings` clean; `cargo fmt` clean; R8 architecture cap satisfied.
- Frontend: ESLint, prettier, `@ajh/tauri` typecheck, preferences-store tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)