### PR TITLE
feat: autopilot apply modal — reasoning box, cancel, default to both

### DIFF
--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
@@ -6,6 +6,7 @@ import { Button, cn, ModalShell } from '@ajh/ui';
 
 import { ResumeInputCard } from '@/components/resume/ResumeInputCard';
 import { ModelSelector, useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
+import { ThinkingBubble } from '@/features/ai-generate/components/ThinkingBubble';
 import { useTranslation } from '@/lib/i18n';
 import { useExtractText, useResolveJobUrl } from '@/services';
 
@@ -31,7 +32,7 @@ export function ApplyJobModal({ job, resumeText, onClose }: Props) {
   const extractTextMutation = useExtractText();
 
   const [resume, setResume] = useState(resumeText ?? '');
-  const [target, setTarget] = useState<TailorTarget>('cover');
+  const [target, setTarget] = useState<TailorTarget>('both');
   const [uploading, setUploading] = useState(false);
 
   // Fetch the description on demand when the board's list scrape omitted it.
@@ -65,8 +66,8 @@ export function ApplyJobModal({ job, resumeText, onClose }: Props) {
   };
 
   const targets: { id: TailorTarget; label: string }[] = [
-    { id: 'cover', label: t('autopilot.apply.target.cover') },
     { id: 'resume', label: t('autopilot.apply.target.resume') },
+    { id: 'cover', label: t('autopilot.apply.target.cover') },
     { id: 'both', label: t('autopilot.apply.target.both') },
   ];
 
@@ -132,16 +133,28 @@ export function ApplyJobModal({ job, resumeText, onClose }: Props) {
                 </button>
               ))}
             </div>
-            <Button
-              variant="glass"
-              size="sm"
-              loading={gen.generating}
-              disabled={!canUse || !hasDesc || gen.generating || !resume.trim()}
-              onClick={() => void gen.generate(resume, target)}
-            >
-              {!gen.generating && <Sparkles size={13} />}
-              {gen.generating ? t('autopilot.apply.generating') : t('autopilot.apply.generate')}
-            </Button>
+            <div className="flex items-center gap-2">
+              {gen.generating && (
+                <Button
+                  variant="glass"
+                  size="sm"
+                  onClick={() => gen.abort()}
+                  className="border-red-400/20 text-red-300/80 hover:text-red-200"
+                >
+                  {t('autopilot.apply.cancel')}
+                </Button>
+              )}
+              <Button
+                variant="glass"
+                size="sm"
+                loading={gen.generating}
+                disabled={!canUse || !hasDesc || gen.generating || !resume.trim()}
+                onClick={() => void gen.generate(resume, target)}
+              >
+                {!gen.generating && <Sparkles size={13} />}
+                {gen.generating ? t('autopilot.apply.generating') : t('autopilot.apply.generate')}
+              </Button>
+            </div>
           </div>
 
           {!canUse && (
@@ -167,6 +180,9 @@ export function ApplyJobModal({ job, resumeText, onClose }: Props) {
               )}
             </div>
           )}
+
+          {/* Model reasoning — same box as AI Generate; self-hides when empty */}
+          <ThinkingBubble thinking={gen.thinking} done={!gen.generating} />
 
           {/* Output */}
           {(gen.resumeOut || gen.coverOut) && (

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.test.ts
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useTailorGeneration } from './useTailorGeneration';
+
+// i18n: identity translator so phaseLabel resolves without the i18n runtime.
+vi.mock('@/lib/i18n', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+// Stub the generation pipeline. Resume/cover stubs emit a reasoning token via
+// the `onThinking` callback (last arg) so we can assert it threads through.
+vi.mock('@/lib/generate', () => ({
+  extractMetadata: vi.fn().mockResolvedValue({
+    candidateName: '',
+    jobTitle: '',
+    companyName: '',
+    resumeLanguage: 'en',
+    jobAdLanguage: 'en',
+    mismatch: false,
+    targetLanguage: 'en',
+    topRequirements: [],
+  }),
+  generateResume: vi.fn(
+    async (
+      _resume: string,
+      _jobAd: string,
+      _meta: unknown,
+      _mode: string,
+      _model: string,
+      onToken: (t: string) => void,
+      _locale?: string,
+      _signal?: AbortSignal,
+      onThinking?: (t: string) => void
+    ) => {
+      onThinking?.('R-think');
+      onToken('R');
+      return 'RESUME';
+    }
+  ),
+  generateCoverLetter: vi.fn(
+    async (
+      _resume: string,
+      _jobAd: string,
+      _meta: unknown,
+      _mode: string,
+      _model: string,
+      onToken: (t: string) => void,
+      _locale?: string,
+      _signal?: AbortSignal,
+      onThinking?: (t: string) => void
+    ) => {
+      onThinking?.('C-think');
+      onToken('C');
+      return 'COVER';
+    }
+  ),
+  buildFilename: vi.fn(),
+  exportDOCX: vi.fn(),
+  exportPDF: vi.fn(),
+  exportTXT: vi.fn(),
+}));
+
+const params = { jobDesc: 'JD', model: 'llama', canUse: true, hasDesc: true };
+
+describe('useTailorGeneration', () => {
+  it('starts idle with empty buffers', () => {
+    const { result } = renderHook(() => useTailorGeneration(params));
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.resumeOut).toBe('');
+    expect(result.current.coverOut).toBe('');
+    expect(result.current.thinking).toBe('');
+  });
+
+  it('threads reasoning into `thinking`, clearing it between phases', async () => {
+    const { result } = renderHook(() => useTailorGeneration(params));
+
+    await act(async () => {
+      await result.current.generate('my resume', 'both');
+    });
+
+    expect(result.current.resumeOut).toBe('RESUME');
+    expect(result.current.coverOut).toBe('COVER');
+    // Cleared at the cover phase, so only the cover-letter reasoning remains.
+    expect(result.current.thinking).toBe('C-think');
+    expect(result.current.phase).toBe('idle');
+  });
+
+  it('does not generate when AI is unavailable', async () => {
+    const { result } = renderHook(() => useTailorGeneration({ ...params, canUse: false }));
+    await act(async () => {
+      await result.current.generate('my resume', 'resume');
+    });
+    expect(result.current.resumeOut).toBe('');
+    expect(result.current.generating).toBe(false);
+  });
+});

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.ts
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.ts
@@ -34,6 +34,7 @@ export function useTailorGeneration({ jobDesc, model, canUse, hasDesc }: Params)
   const [phase, setPhase] = useState<'idle' | 'analyzing' | 'resume' | 'cover'>('idle');
   const [resumeOut, setResumeOut] = useState('');
   const [coverOut, setCoverOut] = useState('');
+  const [thinking, setThinking] = useState('');
   const [activeOut, setActiveOut] = useState<'resume' | 'cover'>('cover');
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -52,14 +53,19 @@ export function useTailorGeneration({ jobDesc, model, canUse, hasDesc }: Params)
     setPhase('analyzing');
     setResumeOut('');
     setCoverOut('');
+    setThinking('');
     const controller = new AbortController();
     abortRef.current = controller;
+    // Reasoning deltas (Anthropic-style flag or inline <think> tags) accumulate
+    // here and render in the ThinkingBubble; cleared at the start of each phase.
+    const onThink = (tok: string) => setThinking((p) => p + tok);
     try {
       const detected = await extractMetadata(resume, jobDesc, model);
       setMeta(detected);
       if (target === 'resume' || target === 'both') {
         setActiveOut('resume');
         setPhase('resume');
+        setThinking('');
         const r = await generateResume(
           resume,
           jobDesc,
@@ -68,13 +74,15 @@ export function useTailorGeneration({ jobDesc, model, canUse, hasDesc }: Params)
           model,
           (tok) => setResumeOut((p) => p + tok),
           'en',
-          controller.signal
+          controller.signal,
+          onThink
         );
         setResumeOut(r);
       }
       if (target === 'cover' || target === 'both') {
         setActiveOut('cover');
         setPhase('cover');
+        setThinking('');
         const c = await generateCoverLetter(
           resume,
           jobDesc,
@@ -83,7 +91,8 @@ export function useTailorGeneration({ jobDesc, model, canUse, hasDesc }: Params)
           model,
           (tok) => setCoverOut((p) => p + tok),
           'en',
-          controller.signal
+          controller.signal,
+          onThink
         );
         setCoverOut(c);
       }
@@ -137,6 +146,7 @@ export function useTailorGeneration({ jobDesc, model, canUse, hasDesc }: Params)
     generating,
     phase,
     phaseLabel,
+    thinking,
     resumeOut,
     coverOut,
     activeOut,

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -534,6 +534,7 @@
       "fetchingDescription": "Stellenbeschreibung wird abgerufen…",
       "generate": "Generieren",
       "generating": "Generiere…",
+      "cancel": "Abbrechen",
       "analyzing": "Stellenbeschreibung wird analysiert…",
       "writingResume": "Lebenslauf wird geschrieben…",
       "writingCover": "Anschreiben wird geschrieben…",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -534,6 +534,7 @@
       "fetchingDescription": "Fetching job description…",
       "generate": "Generate",
       "generating": "Generating…",
+      "cancel": "Cancel",
       "analyzing": "Analyzing job description…",
       "writingResume": "Writing resume…",
       "writingCover": "Writing cover letter…",


### PR DESCRIPTION
## What & why
Part C of the AI/desktop plan. The autopilot **Apply Job** modal now mirrors the AI Generate flow so users see what the model is doing and control it.

## Changes
- **Default target → Both** (was Cover letter).
- **Button order → Resume · Cover letter · Both**.
- **Cancel button** while generating — aborts the in-flight job (`gen.abort()`); previously only a disabled "Generating…" state showed.
- **Model reasoning box** — reuses `ThinkingBubble` (same component AI Generate + Analyze already use), fed by a new `onThinking` buffer in `useTailorGeneration` that clears at the start of each phase. Self-hides when the model emits no reasoning. (Once provider-side emission parity lands, every provider/model fills it.)
- i18n: new `autopilot.apply.cancel` key (en, de).

## Tests
- New `useTailorGeneration.test.ts`: idle defaults, reasoning threads into `thinking` and clears between résumé/cover phases, guarded when AI unavailable.
- `pnpm exec vitest run …` → 3 passed · `turbo typecheck --filter=@ajh/tauri` → clean · `eslint --max-warnings 0` on the changed files → clean.

## Notes
Result-loss on tab switch / modal close is a separate, larger change (background generation store) tracked as **D-3** in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)