### PR TITLE
fix: surface company on job-url import + detect it for generic boards

### DIFF
--- a/apps/tauri/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/scrape_url/mod.rs
@@ -307,12 +307,14 @@ async fn generic_html(url: &str) -> Result<Option<JobPosting>> {
         .ok()
         .and_then(|u| u.host_str().map(str::to_string))
         .unwrap_or_default();
+    // Prefer a real employer name (JSON-LD / og:site_name) over the bare host.
+    let company = parse_generic_company(&html).unwrap_or(host);
 
     Ok(Some(JobPosting {
         id: format!("url:{}", url),
         external_id: None,
         title,
-        company: host,
+        company,
         location: None,
         url: url.to_string(),
         source: "url".to_string(),
@@ -339,6 +341,62 @@ fn parse_generic_html(html: &str) -> (String, Option<String>) {
         .next()
         .and_then(|e| e.value().attr("content").map(str::to_string));
     (title, description)
+}
+
+/// Best-effort real employer name for the generic fallback. Tries JSON-LD
+/// (`JobPosting.hiringOrganization.name`, incl. an `@graph` array), then
+/// `og:site_name`. Returns `None` when neither is present so the caller can
+/// fall back to the host.
+fn parse_generic_company(html: &str) -> Option<String> {
+    let doc = Html::parse_document(html);
+
+    if let Ok(sel) = Selector::parse(r#"script[type="application/ld+json"]"#) {
+        for node in doc.select(&sel) {
+            let raw = node.text().collect::<String>();
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) {
+                if let Some(name) = json_ld_company(&json) {
+                    let name = name.trim();
+                    if !name.is_empty() {
+                        return Some(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    if let Ok(sel) = Selector::parse(r#"meta[property="og:site_name"]"#) {
+        if let Some(name) = doc
+            .select(&sel)
+            .next()
+            .and_then(|e| e.value().attr("content"))
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return Some(name.to_string());
+        }
+    }
+
+    None
+}
+
+/// Pull `hiringOrganization.name` from a JSON-LD value, tolerating a single
+/// object, a string org, and an `@graph` array of nodes.
+fn json_ld_company(json: &serde_json::Value) -> Option<String> {
+    fn org_name(node: &serde_json::Value) -> Option<String> {
+        match node.get("hiringOrganization")? {
+            serde_json::Value::String(s) => Some(s.clone()),
+            org @ serde_json::Value::Object(_) => {
+                org.get("name").and_then(|n| n.as_str()).map(str::to_string)
+            }
+            _ => None,
+        }
+    }
+    if let Some(name) = org_name(json) {
+        return Some(name);
+    }
+    json.get("@graph")
+        .and_then(|g| g.as_array())
+        .and_then(|nodes| nodes.iter().find_map(org_name))
 }
 
 // ── LinkedIn ────────────────────────────────────────────────────────────────

--- a/apps/tauri/src-tauri/src/scraping/scrape_url/test.rs
+++ b/apps/tauri/src-tauri/src/scraping/scrape_url/test.rs
@@ -238,6 +238,49 @@ fn test_parse_generic_html_whitespace() {
 }
 
 #[test]
+fn test_parse_generic_company_json_ld() {
+    let html = r#"<html><head>
+        <script type="application/ld+json">
+        {"@type":"JobPosting","title":"Engineer","hiringOrganization":{"@type":"Organization","name":"Acme Inc"}}
+        </script>
+    </head></html>"#;
+    assert_eq!(parse_generic_company(html), Some("Acme Inc".to_string()));
+}
+
+#[test]
+fn test_parse_generic_company_og_site_name() {
+    let html = r#"<html><head><meta property="og:site_name" content="BRANDUNG"></head></html>"#;
+    assert_eq!(parse_generic_company(html), Some("BRANDUNG".to_string()));
+}
+
+#[test]
+fn test_parse_generic_company_json_ld_graph() {
+    let html = r#"<html><head>
+        <script type="application/ld+json">
+        {"@graph":[{"@type":"WebPage"},{"@type":"JobPosting","hiringOrganization":{"name":"Globex"}}]}
+        </script>
+    </head></html>"#;
+    assert_eq!(parse_generic_company(html), Some("Globex".to_string()));
+}
+
+#[test]
+fn test_parse_generic_company_prefers_json_ld_over_og() {
+    let html = r#"<html><head>
+        <meta property="og:site_name" content="Careers Portal">
+        <script type="application/ld+json">
+        {"@type":"JobPosting","hiringOrganization":{"name":"Initech"}}
+        </script>
+    </head></html>"#;
+    assert_eq!(parse_generic_company(html), Some("Initech".to_string()));
+}
+
+#[test]
+fn test_parse_generic_company_none() {
+    let html = "<html><head><title>Job</title></head></html>";
+    assert_eq!(parse_generic_company(html), None);
+}
+
+#[test]
 fn test_parse_lever_url_with_query() {
     let url = "https://jobs.lever.co/stripe/abc123?ref=source";
     let result = parse_lever_url(url);

--- a/apps/tauri/src/renderer/components/job/JobUrlImport/index.tsx
+++ b/apps/tauri/src/renderer/components/job/JobUrlImport/index.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Link2, Loader2 } from 'lucide-react';
+import { AlertCircle, Check, Link2, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
 import { Button, Input } from '@ajh/ui';
@@ -22,6 +22,9 @@ export function JobUrlImport({ onImport, disabled }: Props) {
   const importJob = useImportJobUrl();
   const [url, setUrl] = useState('');
   const [error, setError] = useState<string | null>(null);
+  // What the last successful import resolved to — shown so the user sees the
+  // detected role and company, not just a silently-filled job-ad field.
+  const [imported, setImported] = useState<{ title?: string; company?: string } | null>(null);
 
   const busy = importJob.isPending;
 
@@ -38,6 +41,7 @@ export function JobUrlImport({ onImport, disabled }: Props) {
       }
       const header = [posting?.title, posting?.company].filter(Boolean).join(' — ');
       onImport(header ? `${header}\n\n${description}` : description);
+      setImported({ title: posting?.title, company: posting?.company });
       setUrl('');
     } catch {
       setError(t('jobUrlImport.failed'));
@@ -50,7 +54,11 @@ export function JobUrlImport({ onImport, disabled }: Props) {
         <Input
           autoFocus
           value={url}
-          onChange={(e) => setUrl(e.target.value)}
+          onChange={(e) => {
+            setUrl(e.target.value);
+            if (error) setError(null);
+            if (imported) setImported(null);
+          }}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
               e.preventDefault();
@@ -74,6 +82,15 @@ export function JobUrlImport({ onImport, disabled }: Props) {
         <div className="flex items-center gap-1.5 text-[10px] text-amber-300/80">
           <AlertCircle size={10} className="shrink-0" />
           {error}
+        </div>
+      )}
+      {!error && imported && (imported.title || imported.company) && (
+        <div className="flex items-center gap-1.5 text-[10px] text-brand-soft/90">
+          <Check size={10} className="shrink-0" />
+          <span className="truncate">
+            {t('jobUrlImport.imported')}:{' '}
+            {[imported.title, imported.company].filter(Boolean).join(' · ')}
+          </span>
         </div>
       )}
     </div>

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -1444,7 +1444,8 @@
     "placeholder": "LinkedIn-Job-URL einfügen…",
     "import": "Importieren",
     "notFound": "Diese Stellenanzeige konnte nicht gelesen werden — Beschreibung manuell einfügen.",
-    "failed": "Import fehlgeschlagen. URL prüfen und erneut versuchen."
+    "failed": "Import fehlgeschlagen. URL prüfen und erneut versuchen.",
+    "imported": "Importiert"
   },
   "resumeReview": {
     "title": "Extrahierten Lebenslauf prüfen",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -1444,7 +1444,8 @@
     "placeholder": "Paste a LinkedIn job URL…",
     "import": "Import",
     "notFound": "Couldn't read that job posting — paste the description manually.",
-    "failed": "Import failed. Check the URL and try again."
+    "failed": "Import failed. Check the URL and try again.",
+    "imported": "Imported"
   },
   "updater": {
     "available": "v{{version}} is available",


### PR DESCRIPTION
## What & why
Part D-6. When importing a job by URL, the company wasn't surfaced like the role — the resolver fell back to the bare host for generic/career-page URLs, and the import gave no visible confirmation of what was pulled.

## Changes
- **Visible import confirmation** — `JobUrlImport` now shows an `Imported: role · company` chip after a successful resolve (clears when the URL field changes). Used by AI Generate + Resume Analyzer.
- **Real company for generic boards** — the generic HTML fallback (`scrape_url::generic_html`) now extracts the employer from JSON-LD `JobPosting.hiringOrganization.name` (incl. `@graph`) or `og:site_name`, falling back to the host only when neither exists. Board-specific resolvers (Greenhouse/Lever/Ashby/LinkedIn/Workday/SmartRecruiters/Personio) already populate `company`.
- i18n: new `jobUrlImport.imported` key (en, de).

## Tests
- 5 new Rust tests for `parse_generic_company` (JSON-LD object, `@graph` array, og:site_name, JSON-LD-over-og precedence, none) — `cargo test parse_generic` → 15 passed.
- `turbo typecheck --filter=@ajh/tauri` clean · `eslint --max-warnings 0` on the changed component clean.

## Notes
Autopilot already shows company in the Apply modal header; this targets the paste-URL path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)