### PR TITLE
fix: factory reset now wipes every persistent store

### DIFF
--- a/apps/tauri/src-tauri/src/autopilot/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot/mod.rs
@@ -218,6 +218,11 @@ impl AutopilotStore {
         self.save(map);
     }
 
+    /// Remove every autopilot and its found-jobs history (factory reset).
+    pub fn clear_all(&self) {
+        self.save(HashMap::new());
+    }
+
     pub fn set_status(&self, id: &str, status: AutopilotStatus) {
         let mut map = self.load();
         if let Some(ap) = map.get_mut(id) {

--- a/apps/tauri/src-tauri/src/autopilot/test.rs
+++ b/apps/tauri/src-tauri/src/autopilot/test.rs
@@ -51,6 +51,27 @@ fn test_now_ms() {
 }
 
 #[test]
+fn test_clear_all_removes_every_autopilot() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+    for name in ["AP1", "AP2"] {
+        store.create(serde_json::json!({
+            "name": name,
+            "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+            "filter": { "minMatchScore": 50.0 },
+            "action": "save",
+            "schedule": "manual",
+        }));
+    }
+    assert_eq!(store.list().len(), 2);
+
+    store.clear_all();
+    assert!(store.list().is_empty());
+}
+
+#[test]
 fn test_data_store_export_import_preserves_id() {
     use crate::data_store::DataStore;
     use tempfile::TempDir;

--- a/apps/tauri/src-tauri/src/commands/privacy.rs
+++ b/apps/tauri/src-tauri/src/commands/privacy.rs
@@ -4,9 +4,14 @@ use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 
 use crate::ai_generations::AiGenerationStore;
+use crate::autopilot::AutopilotStore;
+use crate::contact_profile::ContactProfileStore;
 use crate::conversations::ConversationDb;
 use crate::credentials::CredentialStore;
 use crate::documents::DocumentStore;
+use crate::job_preferences::JobPreferencesStore;
+use crate::jobs::JobTracker;
+use crate::pipeline::cache::KvCache;
 use crate::postings::{InteractionStore, PostingsCache};
 
 #[tauri::command]
@@ -56,21 +61,32 @@ pub fn privacy_reset_app(app: AppHandle) -> Value {
         crate::scraping::board_login::disconnect(&data_dir, board_id);
     }
 
-    // Clear in-memory + JSON-backed stores
+    // Wipe EVERY persistent user-data store. Keep this list in lockstep with
+    // `commands/data.rs::build_bundle` (the backup set) plus the stores that are
+    // intentionally excluded from backups (secrets, caches, the job log) — adding
+    // a new persistent store means handling it in BOTH places.
     app.state::<Mutex<PostingsCache>>().lock().clear_all();
     app.state::<Mutex<InteractionStore>>().lock().clear_all();
-
-    // Clear SQLite databases
+    app.state::<Mutex<JobTracker>>().lock().clear();
     app.state::<DocumentStore>().clear_all();
     app.state::<AiGenerationStore>().clear_all();
     app.state::<ConversationDb>().clear_all();
-
-    // Clear all AI provider API keys from keychain
-    let store = app.state::<Mutex<CredentialStore>>();
-    let guard = store.lock();
-    for provider in &["openai", "anthropic", "gemini", "openai-compatible"] {
-        let _ = guard.remove(&format!("ai:{provider}"));
+    if let Some(s) = app.try_state::<std::sync::Arc<Mutex<AutopilotStore>>>() {
+        s.lock().clear_all();
     }
+    if let Some(s) = app.try_state::<JobPreferencesStore>() {
+        let _ = s.clear();
+    }
+    if let Some(s) = app.try_state::<ContactProfileStore>() {
+        let _ = s.clear();
+    }
+    if let Some(s) = app.try_state::<KvCache>() {
+        s.clear();
+    }
+
+    // Remove every stored secret — all AI/provider keys (incl. Brave) and board
+    // passwords — driven off the credential metadata index (no hardcoded list).
+    let _ = app.state::<Mutex<CredentialStore>>().lock().clear_all();
 
     json!({ "success": true })
 }

--- a/apps/tauri/src-tauri/src/contact_profile/mod.rs
+++ b/apps/tauri/src-tauri/src/contact_profile/mod.rs
@@ -439,6 +439,11 @@ impl ContactProfileStore {
         .map_err(|e| e.to_string())?;
         Ok(())
     }
+
+    /// Reset the contact profile to empty (factory reset).
+    pub fn clear(&self) -> AppResult<()> {
+        self.set(&ContactProfile::default())
+    }
 }
 
 impl DataStore for ContactProfileStore {

--- a/apps/tauri/src-tauri/src/credentials/mod.rs
+++ b/apps/tauri/src-tauri/src/credentials/mod.rs
@@ -121,6 +121,16 @@ impl CredentialStore {
         Ok(())
     }
 
+    /// Remove every stored credential — board passwords and all AI/provider keys
+    /// (including the Brave search key). Driven off the metadata index, so it
+    /// needs no hardcoded provider list. Used by the factory reset.
+    pub fn clear_all(&self) -> AppResult<()> {
+        for meta in self.list() {
+            self.remove(&meta.board_id)?;
+        }
+        Ok(())
+    }
+
     /// Returns (username, password) for internal use only (scraper/applier).
     /// Never exposed directly over IPC — the renderer only ever sees metadata.
     pub fn get_decrypted(&self, board_id: &str) -> Option<(String, String)> {

--- a/apps/tauri/src-tauri/src/job_preferences/mod.rs
+++ b/apps/tauri/src-tauri/src/job_preferences/mod.rs
@@ -100,6 +100,18 @@ impl JobPreferencesStore {
         })
     }
 
+    /// Reset all job preferences to empty (factory reset).
+    pub fn clear(&self) -> AppResult<()> {
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE job_preferences SET location = NULL, remote = NULL, seniority = NULL,
+                 salary_min = NULL, salary_max = NULL, tech_stack = NULL WHERE id = 1",
+            [],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
     pub fn set(&self, prefs: &JobPreferences) -> AppResult<()> {
         let conn = self.conn.lock();
         let tech_stack_json = prefs

--- a/apps/tauri/src-tauri/src/job_preferences/test.rs
+++ b/apps/tauri/src-tauri/src/job_preferences/test.rs
@@ -25,6 +25,29 @@ fn test_get_default() {
 }
 
 #[test]
+fn test_clear_resets_to_empty() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = JobPreferencesStore::open(&temp_dir.path().to_path_buf()).unwrap();
+    store
+        .set(&JobPreferences {
+            location: Some("Berlin".to_string()),
+            remote: Some("remote".to_string()),
+            seniority: None,
+            salary_min: Some(60000),
+            salary_max: None,
+            tech_stack: None,
+        })
+        .unwrap();
+    assert!(store.get().location.is_some());
+
+    store.clear().unwrap();
+    let prefs = store.get();
+    assert_eq!(prefs.location, None);
+    assert_eq!(prefs.remote, None);
+    assert_eq!(prefs.salary_min, None);
+}
+
+#[test]
 fn test_set_and_get() {
     let temp_dir = TempDir::new().unwrap();
     let store = JobPreferencesStore::open(&temp_dir.path().to_path_buf()).unwrap();

--- a/apps/tauri/src-tauri/src/jobs/mod.rs
+++ b/apps/tauri/src-tauri/src/jobs/mod.rs
@@ -157,6 +157,15 @@ impl JobTracker {
         self.jobs.insert(id.to_string(), record);
     }
 
+    /// Wipe the job-execution log — in-memory records and the `jobs` table.
+    /// Used by the factory reset.
+    pub fn clear(&mut self) {
+        self.jobs.clear();
+        if let Some(db) = &self.db {
+            let _ = db.execute("DELETE FROM jobs", []);
+        }
+    }
+
     pub fn update_progress(&mut self, id: &str, p: f64) {
         if let Some(job) = self.jobs.get_mut(id) {
             job.progress = p;

--- a/apps/tauri/src-tauri/src/pipeline/cache/mod.rs
+++ b/apps/tauri/src-tauri/src/pipeline/cache/mod.rs
@@ -59,6 +59,12 @@ impl KvCache {
             params![namespace, key, value, now_secs()],
         );
     }
+
+    /// Drop every cached entry (e.g. company briefs, OCR results). Factory reset.
+    pub fn clear(&self) {
+        let conn = self.conn.lock();
+        let _ = conn.execute("DELETE FROM kv_cache", []);
+    }
 }
 
 fn now_secs() -> i64 {

--- a/apps/tauri/src-tauri/src/pipeline/cache/test.rs
+++ b/apps/tauri/src-tauri/src/pipeline/cache/test.rs
@@ -46,3 +46,13 @@ fn keys_are_case_insensitive_per_schema() {
     cache.set("ns", "Acme", "v");
     assert_eq!(cache.get("ns", "acme", 3600), Some("v".to_string()));
 }
+
+#[test]
+fn clear_drops_every_entry() {
+    let (_dir, cache) = cache();
+    cache.set("company_brief", "acme", "v1");
+    cache.set("ocr", "doc1", "v2");
+    cache.clear();
+    assert_eq!(cache.get("company_brief", "acme", 3600), None);
+    assert_eq!(cache.get("ocr", "doc1", 3600), None);
+}


### PR DESCRIPTION
## What

Full factory reset (`privacy_reset_app`) previously left several persistent stores behind, so a "Reset app" did not return the user to a fresh-install state.

This change makes the reset clear **every** managed persistent store, keeping it in lockstep with `commands/data.rs::build_bundle` (the backup set) plus the stores intentionally excluded from backups (secrets, caches, the job log).

## Stores now wiped

- `JobTracker` (the job-execution log) — new `clear()`
- `AutopilotStore` — new `clear_all()`
- `JobPreferencesStore` — new `clear()`
- `ContactProfileStore` — new `clear()`
- `KvCache` (company-research / OCR cache) — new `clear()`
- All stored secrets (every AI/provider key incl. Brave, and board passwords) — driven off the credential **metadata index** via `CredentialStore::clear_all()` (no hardcoded provider list)

Already-cleared stores (documents, ai_generations, conversations, postings cache, interactions, board sessions) are unchanged.

## Future-proofing

- `CredentialStore::clear_all()` iterates the metadata index, so a newly-stored secret type is wiped automatically — no list to hand-maintain.
- A comment on `privacy_reset_app` ties the wipe-set to `build_bundle` so adding a new persistent store forces handling in both places.

## Tests

New unit tests (all `tempfile`-backed):
- `autopilot::test_clear_all_removes_every_autopilot`
- `job_preferences::test_clear_resets_to_empty`
- `pipeline::cache::clear_drops_every_entry`

`cargo test` for the touched modules: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)