### PR TITLE
perf: glyph-subset embedded fonts to shrink exported pdf size

### DIFF
--- a/apps/tauri/src-tauri/src/export/layout_pdf.rs
+++ b/apps/tauri/src-tauri/src/export/layout_pdf.rs
@@ -16,7 +16,8 @@ use anyhow::Result;
 use printpdf::*;
 
 use crate::export::pdf_renderer::{
-    build_line, link_annotation_op, load_all_fonts, resolve_fonts, rgb_to_color, LoadedFontSet,
+    build_line, collect_codepoints, link_annotation_op, load_all_fonts, resolve_fonts,
+    rgb_to_color, LoadedFontSet,
 };
 use crate::export::templates::Template;
 use crate::export::types::GenerationMeta;
@@ -97,7 +98,15 @@ pub(crate) fn generate_resume_pdf_in(
 /// (mm from bottom-left), drawing fills, then rules, then text, then links.
 fn emit_pdf(laid: &LaidOutDoc) -> Result<Vec<u8>> {
     let mut doc = PdfDocument::new("Resume");
-    let fonts = load_all_fonts(&mut doc)?;
+    // Subset every embedded font to exactly the glyphs this laid-out document
+    // draws — the placed runs are the authoritative set of rendered text.
+    let used = collect_codepoints(
+        laid.pages
+            .iter()
+            .flat_map(|p| p.texts.iter())
+            .map(|t| t.text.as_str()),
+    );
+    let fonts = load_all_fonts(&mut doc, &used)?;
     let page_h = laid.page_height_mm;
 
     let pages: Vec<PdfPage> = laid

--- a/apps/tauri/src-tauri/src/export/pdf/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/mod.rs
@@ -38,7 +38,10 @@ pub(crate) fn generate_resume_pdf(
 
     let parsed = parse_resume(text);
     let mut doc = PdfDocument::new("Resume");
-    let fonts = load_all_fonts(&mut doc)?;
+    let used = collect_codepoints(
+        std::iter::once(text).chain(meta.and_then(|m| m.candidate_name.as_deref())),
+    );
+    let fonts = load_all_fonts(&mut doc, &used)?;
     let layout = setup_layout(&effective_template);
     let colors = setup_colors(&effective_template);
 
@@ -192,7 +195,10 @@ fn generate_two_column_resume_pdf(
         .expect("two_column config required");
     let parsed = parse_resume(text);
     let mut doc = PdfDocument::new("Resume");
-    let fonts = load_all_fonts(&mut doc)?;
+    let used = collect_codepoints(
+        std::iter::once(text).chain(meta.and_then(|m| m.candidate_name.as_deref())),
+    );
+    let fonts = load_all_fonts(&mut doc, &used)?;
     let layout = setup_layout(template);
     let colors = setup_colors(template);
 
@@ -418,7 +424,15 @@ fn generate_cover_letter_pdf(
     lang: &str,
 ) -> Result<Vec<u8>> {
     let mut doc = PdfDocument::new("Cover Letter");
-    let fonts = load_all_fonts(&mut doc)?;
+    // Seed the subset with every text input the letter can draw: the body, the
+    // candidate name override, and the profile-derived contact header.
+    let header = contact.map(|c| c.header_markdown(lang));
+    let used = collect_codepoints(
+        std::iter::once(text)
+            .chain(meta.and_then(|m| m.candidate_name.as_deref()))
+            .chain(header.as_deref()),
+    );
+    let fonts = load_all_fonts(&mut doc, &used)?;
     let layout = setup_layout(template);
     let colors = setup_colors(template);
     let cl = &template.cover_letter;

--- a/apps/tauri/src-tauri/src/export/pdf/test.rs
+++ b/apps/tauri/src-tauri/src/export/pdf/test.rs
@@ -554,3 +554,60 @@ LANGUAGES
 
     eprintln!("wrote sample PDFs to apps/tauri/src-tauri/target/sample_pdfs/");
 }
+
+/// Size guardrail: the default (Calibri) template must glyph-subset its embedded
+/// fonts. The full Calibri regular+bold faces are ~3.2 MB, so an unsubsetted
+/// export blows past 3 MB. printpdf 0.9.1 has its own subsetting disabled, so if
+/// our `parse_font` subsetting ever regresses (or silently falls back to the full
+/// font for every glyph) this fails loudly. Budget is generous (800 KB) to stay
+/// stable across content/font-table changes while still catching a full-font
+/// regression by an order of magnitude.
+#[test]
+fn classic_resume_pdf_is_glyph_subset_under_budget() {
+    use super::super::types::{ExportFormat, TemplateId};
+
+    let text = "\
+Jane Doe
+jane@example.com | +1 555 0100 | [LinkedIn](https://linkedin.com/in/janedoe)
+
+EXPERIENCE
+Acme Corp  2020 - Present
+Senior Software Engineer
+- Led a team of five engineers delivering the core billing platform
+- Cut p95 API latency from 800ms to 180ms via caching and query work
+
+SKILLS
+- Rust, TypeScript, React, PostgreSQL
+
+EDUCATION
+State University  2013 - 2017
+BSc Computer Science
+";
+
+    let request = ExportRequest {
+        text: text.to_string(),
+        format: ExportFormat::Pdf,
+        document_type: DocumentType::Resume,
+        template_id: TemplateId::Classic, // TemplateFonts::default() = Calibri (the 3.2 MB face)
+        meta: None,
+        ats_mode: false,
+        locale: None,
+        contact: None,
+    };
+
+    let bytes = generate_pdf(&request).expect("classic resume pdf");
+
+    // Sanity: a real, parseable PDF (not an empty/short error stub).
+    assert!(bytes.starts_with(b"%PDF"), "output is not a PDF");
+    assert!(
+        lopdf::Document::load_mem(&bytes).is_ok(),
+        "subsetted PDF must still parse"
+    );
+
+    assert!(
+        bytes.len() < 800_000,
+        "Calibri résumé PDF must be glyph-subset (<800 KB); got {} bytes — \
+         full-font embedding has regressed",
+        bytes.len()
+    );
+}

--- a/apps/tauri/src-tauri/src/export/pdf_renderer/fonts.rs
+++ b/apps/tauri/src-tauri/src/export/pdf_renderer/fonts.rs
@@ -1,0 +1,185 @@
+//! Font loading + glyph subsetting for the PDF renderer.
+//!
+//! Bundled faces are compiled into the binary but **glyph-subset per export**, so
+//! a document only embeds the glyphs it actually draws. printpdf 0.9.1 ships with
+//! its own subsetting disabled at serialize time, so we subset up front in
+//! [`parse_font`] (see its docs for the why).
+
+use anyhow::Context;
+use printpdf::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::export::types::FontFamily;
+
+/// Printable ASCII plus the typographic glyphs the renderers inject directly —
+/// bullets, separators, en/em dashes, smart quotes, the arrow, NBSP, the common
+/// currency marks, and the German umlauts (a supported export locale) — so glyph
+/// subsetting can never drop a glyph the layout actually draws even when the
+/// source text never contained it.
+const BASELINE_GLYPHS: &str = concat!(
+    " !\"#$%&'()*+,-./0123456789:;<=>?@",
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`",
+    "abcdefghijklmnopqrstuvwxyz{|}~",
+    "•·–—‘’“”…→€£",
+    "äöüÄÖÜß",
+    "\u{00A0}",
+);
+
+/// Collect the distinct codepoints a document draws, seeded with
+/// [`BASELINE_GLYPHS`]. Drives glyph subsetting so every embedded font carries
+/// only the glyphs actually in use.
+pub fn collect_codepoints<'a>(texts: impl IntoIterator<Item = &'a str>) -> BTreeSet<char> {
+    let mut set: BTreeSet<char> = BASELINE_GLYPHS.chars().collect();
+    for t in texts {
+        set.extend(t.chars());
+    }
+    set
+}
+
+/// Per-family font IDs (regular + bold + optional italic).
+#[derive(Clone)]
+pub struct FamilyFonts {
+    pub regular: FontId,
+    pub bold: FontId,
+    pub italic: Option<FontId>,
+}
+
+/// All template fonts embedded at compile time regardless of which template the
+/// user selects. This keeps the renderer stateless and avoids runtime font-file IO
+/// at the cost of ~4.2 MB binary size. Switch to a lazy font registry keyed by
+/// FontFamily if bundle size becomes a concern.
+pub struct LoadedFontSet {
+    pub calibri: FamilyFonts,
+    pub inter: FamilyFonts,
+    pub source_serif4: FamilyFonts,
+    pub manrope: FamilyFonts,
+    pub jetbrains_mono: FamilyFonts,
+    pub playfair_display: FamilyFonts,
+}
+
+impl LoadedFontSet {
+    pub fn family(&self, fam: FontFamily) -> &FamilyFonts {
+        match fam {
+            FontFamily::Calibri => &self.calibri,
+            FontFamily::Inter => &self.inter,
+            FontFamily::SourceSerif4 => &self.source_serif4,
+            FontFamily::Manrope => &self.manrope,
+            FontFamily::JetBrainsMono => &self.jetbrains_mono,
+            FontFamily::PlayfairDisplay => &self.playfair_display,
+        }
+    }
+}
+
+/// Parse a bundled font and embed only the glyphs in `used` (glyph subsetting).
+///
+/// printpdf 0.9.1 ships with font subsetting hard-disabled at serialize time
+/// (`serialize.rs`: `if false && do_subset …`), and it already prunes any face
+/// that no glyph references — so without this every export embeds the *full*
+/// remaining face. Calibri regular+bold alone is ~3.2 MB, which is the bulk of
+/// the oversized ~3 MB résumé PDFs.
+///
+/// We subset the face to the document's codepoints up front via printpdf's own
+/// allsorts subsetter (compiled in through the default `html` → `text_layout`
+/// feature) and embed the result. Any failure (parse, subset, or re-parse) falls
+/// back to embedding the full font, so the worst case is exactly today's output —
+/// never a missing glyph.
+fn parse_font(
+    bytes: &[u8],
+    doc: &mut PdfDocument,
+    used: &BTreeSet<char>,
+) -> anyhow::Result<FontId> {
+    let mut warnings = Vec::new();
+    let full = ParsedFont::from_bytes(bytes, 0, &mut warnings).context("Failed to parse font")?;
+
+    // Map each used codepoint to its glyph id in this face, skipping any the face
+    // lacks (the subset only needs the glyphs that actually resolve here).
+    let glyph_ids: BTreeMap<u16, char> = used
+        .iter()
+        .filter_map(|&ch| full.lookup_glyph_index(ch as u32).map(|gid| (gid, ch)))
+        .collect();
+
+    if !glyph_ids.is_empty() {
+        if let Ok(subset) = printpdf::subset_font(&full, &glyph_ids) {
+            if !subset.bytes.is_empty() {
+                let mut w = Vec::new();
+                if let Some(parsed) = ParsedFont::from_bytes(&subset.bytes, 0, &mut w) {
+                    return Ok(doc.add_font(&parsed));
+                }
+            }
+        }
+    }
+
+    Ok(doc.add_font(&full))
+}
+
+/// Load all template fonts into the PDF document, glyph-subset to `used` (the
+/// document's codepoints — see [`collect_codepoints`]).
+/// Returns LoadedFontSet ready to use across all render functions.
+pub fn load_all_fonts(
+    doc: &mut PdfDocument,
+    used: &BTreeSet<char>,
+) -> anyhow::Result<LoadedFontSet> {
+    // Calibri (existing — bundled separately)
+    let cal_reg = include_bytes!("../../../fonts/calibri.ttf");
+    let cal_bol = include_bytes!("../../../fonts/calibrib.ttf");
+
+    // Inter
+    let int_reg = include_bytes!("../../../fonts/inter_regular.ttf");
+    let int_bol = include_bytes!("../../../fonts/inter_bold.ttf");
+
+    // Source Serif 4
+    let ss4_reg = include_bytes!("../../../fonts/source_serif4_regular.ttf");
+    let ss4_bol = include_bytes!("../../../fonts/source_serif4_bold.ttf");
+    let ss4_ita = include_bytes!("../../../fonts/source_serif4_italic.ttf");
+
+    // Manrope
+    let man_reg = include_bytes!("../../../fonts/manrope_regular.ttf");
+    let man_bol = include_bytes!("../../../fonts/manrope_bold.ttf");
+
+    // JetBrains Mono
+    let jbm_reg = include_bytes!("../../../fonts/jetbrains_mono_regular.ttf");
+    let jbm_bol = include_bytes!("../../../fonts/jetbrains_mono_bold.ttf");
+
+    // Playfair Display
+    let pfd_reg = include_bytes!("../../../fonts/playfair_display_regular.ttf");
+    let pfd_bol = include_bytes!("../../../fonts/playfair_display_bold.ttf");
+
+    Ok(LoadedFontSet {
+        calibri: FamilyFonts {
+            regular: parse_font(cal_reg, doc, used)?,
+            bold: parse_font(cal_bol, doc, used)?,
+            italic: None,
+        },
+        inter: FamilyFonts {
+            regular: parse_font(int_reg, doc, used)?,
+            bold: parse_font(int_bol, doc, used)?,
+            italic: None,
+        },
+        source_serif4: FamilyFonts {
+            regular: parse_font(ss4_reg, doc, used)?,
+            bold: parse_font(ss4_bol, doc, used)?,
+            italic: Some(parse_font(ss4_ita, doc, used)?),
+        },
+        manrope: FamilyFonts {
+            regular: parse_font(man_reg, doc, used)?,
+            bold: parse_font(man_bol, doc, used)?,
+            italic: None,
+        },
+        jetbrains_mono: FamilyFonts {
+            regular: parse_font(jbm_reg, doc, used)?,
+            bold: parse_font(jbm_bol, doc, used)?,
+            italic: None,
+        },
+        playfair_display: FamilyFonts {
+            regular: parse_font(pfd_reg, doc, used)?,
+            bold: parse_font(pfd_bol, doc, used)?,
+            italic: None,
+        },
+    })
+}
+
+/// Resolve the (regular, bold, italic_opt) font IDs for a given family.
+pub fn resolve_fonts(set: &LoadedFontSet, fam: FontFamily) -> (&FontId, &FontId, Option<&FontId>) {
+    let f = set.family(fam);
+    (&f.regular, &f.bold, f.italic.as_ref())
+}

--- a/apps/tauri/src-tauri/src/export/pdf_renderer/mod.rs
+++ b/apps/tauri/src-tauri/src/export/pdf_renderer/mod.rs
@@ -3,121 +3,13 @@ use crate::export::{
     types::{FontFamily, GenerationMeta, TextSegment},
 };
 use crate::measure::{FontMetrics, MeasureText};
-use anyhow::Context;
 use printpdf::*;
 
 mod contact_layout;
 pub(crate) use contact_layout::{contact_link_rects, wrap_contact_markdown};
 
-// ─── Font loading ─────────────────────────────────────────────────────────────
-
-/// Per-family font IDs (regular + bold + optional italic).
-#[derive(Clone)]
-pub struct FamilyFonts {
-    pub regular: FontId,
-    pub bold: FontId,
-    pub italic: Option<FontId>,
-}
-
-/// All template fonts embedded at compile time regardless of which template the
-/// user selects. This keeps the renderer stateless and avoids runtime font-file IO
-/// at the cost of ~4.2 MB binary size. Switch to a lazy font registry keyed by
-/// FontFamily if bundle size becomes a concern.
-pub struct LoadedFontSet {
-    pub calibri: FamilyFonts,
-    pub inter: FamilyFonts,
-    pub source_serif4: FamilyFonts,
-    pub manrope: FamilyFonts,
-    pub jetbrains_mono: FamilyFonts,
-    pub playfair_display: FamilyFonts,
-}
-
-impl LoadedFontSet {
-    pub fn family(&self, fam: FontFamily) -> &FamilyFonts {
-        match fam {
-            FontFamily::Calibri => &self.calibri,
-            FontFamily::Inter => &self.inter,
-            FontFamily::SourceSerif4 => &self.source_serif4,
-            FontFamily::Manrope => &self.manrope,
-            FontFamily::JetBrainsMono => &self.jetbrains_mono,
-            FontFamily::PlayfairDisplay => &self.playfair_display,
-        }
-    }
-}
-
-fn parse_font(bytes: &[u8], doc: &mut PdfDocument) -> anyhow::Result<FontId> {
-    let mut w = Vec::new();
-    let f = ParsedFont::from_bytes(bytes, 0, &mut w).context("Failed to parse font")?;
-    Ok(doc.add_font(&f))
-}
-
-/// Load all template fonts into the PDF document.
-/// Returns LoadedFontSet ready to use across all render functions.
-pub fn load_all_fonts(doc: &mut PdfDocument) -> anyhow::Result<LoadedFontSet> {
-    // Calibri (existing — bundled separately)
-    let cal_reg = include_bytes!("../../../fonts/calibri.ttf");
-    let cal_bol = include_bytes!("../../../fonts/calibrib.ttf");
-
-    // Inter
-    let int_reg = include_bytes!("../../../fonts/inter_regular.ttf");
-    let int_bol = include_bytes!("../../../fonts/inter_bold.ttf");
-
-    // Source Serif 4
-    let ss4_reg = include_bytes!("../../../fonts/source_serif4_regular.ttf");
-    let ss4_bol = include_bytes!("../../../fonts/source_serif4_bold.ttf");
-    let ss4_ita = include_bytes!("../../../fonts/source_serif4_italic.ttf");
-
-    // Manrope
-    let man_reg = include_bytes!("../../../fonts/manrope_regular.ttf");
-    let man_bol = include_bytes!("../../../fonts/manrope_bold.ttf");
-
-    // JetBrains Mono
-    let jbm_reg = include_bytes!("../../../fonts/jetbrains_mono_regular.ttf");
-    let jbm_bol = include_bytes!("../../../fonts/jetbrains_mono_bold.ttf");
-
-    // Playfair Display
-    let pfd_reg = include_bytes!("../../../fonts/playfair_display_regular.ttf");
-    let pfd_bol = include_bytes!("../../../fonts/playfair_display_bold.ttf");
-
-    Ok(LoadedFontSet {
-        calibri: FamilyFonts {
-            regular: parse_font(cal_reg, doc)?,
-            bold: parse_font(cal_bol, doc)?,
-            italic: None,
-        },
-        inter: FamilyFonts {
-            regular: parse_font(int_reg, doc)?,
-            bold: parse_font(int_bol, doc)?,
-            italic: None,
-        },
-        source_serif4: FamilyFonts {
-            regular: parse_font(ss4_reg, doc)?,
-            bold: parse_font(ss4_bol, doc)?,
-            italic: Some(parse_font(ss4_ita, doc)?),
-        },
-        manrope: FamilyFonts {
-            regular: parse_font(man_reg, doc)?,
-            bold: parse_font(man_bol, doc)?,
-            italic: None,
-        },
-        jetbrains_mono: FamilyFonts {
-            regular: parse_font(jbm_reg, doc)?,
-            bold: parse_font(jbm_bol, doc)?,
-            italic: None,
-        },
-        playfair_display: FamilyFonts {
-            regular: parse_font(pfd_reg, doc)?,
-            bold: parse_font(pfd_bol, doc)?,
-            italic: None,
-        },
-    })
-}
-
-/// Resolve the (regular, bold, italic_opt) font IDs for a given family.
-pub fn resolve_fonts(set: &LoadedFontSet, fam: FontFamily) -> (&FontId, &FontId, Option<&FontId>) {
-    let f = set.family(fam);
-    (&f.regular, &f.bold, f.italic.as_ref())
-}
+mod fonts;
+pub use fonts::*;
 
 /// Bundles the four common render parameters so functions stay under the arg limit.
 pub struct RenderCtx<'a> {

--- a/apps/tauri/src-tauri/src/export/pdf_renderer/test.rs
+++ b/apps/tauri/src-tauri/src/export/pdf_renderer/test.rs
@@ -4,6 +4,32 @@ use crate::export::types::FontFamily;
 use crate::measure::FontMetrics;
 
 #[test]
+fn collect_codepoints_seeds_baseline_and_adds_text() {
+    let used = collect_codepoints(["Zürich", "naïve café"]);
+
+    // Baseline glyphs the renderers inject are always present, even though none
+    // of the input strings contained them.
+    for ch in ['•', '·', '–', '—', ' ', 'A', 'z', '0', '|'] {
+        assert!(used.contains(&ch), "baseline glyph {ch:?} missing");
+    }
+    // Codepoints from the text are folded in (incl. non-ASCII names).
+    for ch in ['Z', 'ü', 'r', 'ï', 'é', 'c', 'f'] {
+        assert!(used.contains(&ch), "text glyph {ch:?} missing");
+    }
+    // A glyph in neither the baseline nor the text is absent.
+    assert!(!used.contains(&'😀'));
+}
+
+#[test]
+fn collect_codepoints_is_deduplicated() {
+    let once = collect_codepoints(["a"]);
+    let many = collect_codepoints(["aaa", "a", "aa"]);
+    // BTreeSet dedupes — repeating 'a' adds nothing beyond the first.
+    assert_eq!(once.len(), many.len());
+    assert!(once.contains(&'a'));
+}
+
+#[test]
 fn test_rgb_to_color() {
     let color = rgb_to_color((255, 0, 0));
     if let Color::Rgb(rgb) = color {


### PR DESCRIPTION
## Problem

Résumé PDFs export at **~3 MB** while the equivalent DOCX is ~32 KB.

**Root cause:** font embedding. printpdf 0.9.1 has its own font subsetting **hard-disabled** at serialize time (`serialize.rs`: `if false && do_subset …`) and it already prunes any face that no glyph references — so every export embeds the **full** remaining face. Calibri regular+bold alone is ~3.2 MB, which is essentially the whole file.

> The plan's other proposed lever — "template-aware font loading" — turned out to be a **no-op for output size**: printpdf already skips faces with no used glyphs, so only the selected template's face was ever embedded. Dropped it.

## Fix

Subset each face to the document's **actual codepoints** before `add_font`, using printpdf's own allsorts subsetter — already compiled in via the default `html` → `text_layout` feature, so **no new dependency**.

- `collect_codepoints` gathers the glyphs a document draws: from the **laid-out runs** on the engine path (the authoritative rendered text), and from the text/name/contact inputs on the legacy path — seeded with a **baseline** of the punctuation/bullet/quote/umlaut glyphs the renderers inject directly.
- `parse_font` maps those codepoints → glyph ids, subsets, re-parses, and embeds the subset.
- **Graceful fallback:** any failure (parse, subset, or re-parse) embeds the full font, so the worst case is exactly today's output — never a missing glyph.
- The font loading/subsetting code moves to a new `pdf_renderer/fonts.rs` submodule (re-exported, no API change) to keep `pdf_renderer/mod.rs` under the **R8** module-size cap.

## Result (sample résumé, engine path)

| Template | Before | After |
|---|---|---|
| ATS Classic (Calibri) | ~3 MB | **~120 KB** |
| Modern (Inter) | — | ~120 KB |
| Mono Technical | — | ~55 KB |
| Two-Column | — | ~56 KB |

## Tests

- **Size guardrail**: a Calibri résumé must stay **< 800 KB** (catches a full-font regression by an order of magnitude).
- `collect_codepoints` unit tests: baseline seeding + dedup.
- All 688 Rust tests pass; clippy `-D warnings`, fmt, and the R8 architecture cap all green.

## Review routing
Primary: **pdf-docx-generator** / **resume-export-expert** (export domain) · Secondary: **performance-profiler**. Part D-2 of the multi-PR plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)