### PR TITLE
feat: surface model reasoning across openai, gemini and ollama

### DIFF
--- a/apps/tauri/src-tauri/src/commands/ai_provider/cli_agent/codex.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/cli_agent/codex.rs
@@ -73,6 +73,12 @@ impl CliAgentBackend for CodexAgent {
             // Emit at message granularity (Codex's canonical assistant output).
             return text_of(m).map(CliEvent::Delta);
         }
+        if ty.contains("reasoning") {
+            // Codex streams chain-of-thought as `agent_reasoning*` events; surface
+            // it as thinking, like the cloud providers. Section-break markers carry
+            // no text and are dropped by `text_of`.
+            return text_of(m).map(CliEvent::Thinking);
+        }
         if ty.contains("task_complete") || ty.contains("turn_complete") {
             return Some(CliEvent::Done);
         }
@@ -168,6 +174,22 @@ mod tests {
     fn task_complete_is_done() {
         let line = r#"{"msg":{"type":"task_complete"}}"#;
         assert_eq!(CodexAgent.parse_stream_line(line), Some(CliEvent::Done));
+    }
+
+    #[test]
+    fn agent_reasoning_becomes_thinking() {
+        let line = r#"{"msg":{"type":"agent_reasoning","text":"weighing options"}}"#;
+        assert_eq!(
+            CodexAgent.parse_stream_line(line),
+            Some(CliEvent::Thinking("weighing options".to_string()))
+        );
+    }
+
+    #[test]
+    fn empty_reasoning_section_break_is_ignored() {
+        // Section-break markers carry no text — `text_of` filters them out.
+        let line = r#"{"msg":{"type":"agent_reasoning_section_break"}}"#;
+        assert_eq!(CodexAgent.parse_stream_line(line), None);
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
@@ -17,6 +17,42 @@ use super::{
 
 const BASE: &str = "https://generativelanguage.googleapis.com";
 
+/// Whether to request `thinkingConfig.includeThoughts`. Gemini 1.5 and the GA
+/// 2.0 models reject `thinkingConfig` with a 400, so we only enable it for the
+/// 2.5 family and any explicit `*-thinking-*` model. Unknown future models simply
+/// don't surface thoughts (a graceful miss, never a broken request).
+fn gemini_supports_thinking(model: &str) -> bool {
+    let m = model.to_ascii_lowercase();
+    m.contains("2.5") || m.contains("thinking")
+}
+
+/// Extract a Gemini chunk's streamed parts as `(is_thought, text)` pairs. 2.5
+/// thinking models flag reasoning parts with `"thought": true`; the rest are
+/// normal answer text. Pure + unit-tested so the streaming loop stays a thin
+/// emitter.
+fn parse_gemini_parts(event: &Value) -> Vec<(bool, &str)> {
+    event
+        .get("candidates")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("content"))
+        .and_then(|c| c.get("parts"))
+        .and_then(|p| p.as_array())
+        .map(|parts| {
+            parts
+                .iter()
+                .filter_map(|part| {
+                    let text = part.get("text").and_then(|t| t.as_str())?;
+                    let thought = part
+                        .get("thought")
+                        .and_then(|t| t.as_bool())
+                        .unwrap_or(false);
+                    Some((thought, text))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 pub struct GeminiClient;
 
 #[async_trait]
@@ -74,6 +110,10 @@ impl AiProvider for GeminiClient {
         let mut generation_config = json!({ "temperature": temperature });
         if let Some(mt) = req.max_tokens {
             generation_config["maxOutputTokens"] = json!(mt);
+        }
+        // Ask thinking-capable models to stream their reasoning as `thought` parts.
+        if gemini_supports_thinking(&req.model) {
+            generation_config["thinkingConfig"] = json!({ "includeThoughts": true });
         }
         let mut body = json!({ "contents": contents, "generationConfig": generation_config });
         if !system_text.is_empty() {
@@ -146,20 +186,18 @@ impl AiProvider for GeminiClient {
                         if depth == 0 && buf.trim_start().starts_with('{') && !buf.trim().is_empty()
                         {
                             if let Ok(event) = serde_json::from_str::<Value>(buf.trim()) {
-                                let delta = event
-                                    .get("candidates")
-                                    .and_then(|c| c.get(0))
-                                    .and_then(|c| c.get("content"))
-                                    .and_then(|c| c.get("parts"))
-                                    .and_then(|p| p.get(0))
-                                    .and_then(|p| p.get("text"))
-                                    .and_then(|t| t.as_str())
-                                    .unwrap_or("");
-                                if !delta.is_empty() {
-                                    let _ = app.emit(
-                                        "ai:stream",
-                                        json!({ "jobId": job_id, "delta": delta, "done": false }),
-                                    );
+                                // Split every part: `thought` parts stream as reasoning,
+                                // the rest as the normal answer.
+                                for (thought, text) in parse_gemini_parts(&event) {
+                                    if text.is_empty() {
+                                        continue;
+                                    }
+                                    let chunk = if thought {
+                                        json!({ "jobId": job_id, "delta": text, "done": false, "thinking": true })
+                                    } else {
+                                        json!({ "jobId": job_id, "delta": text, "done": false })
+                                    };
+                                    let _ = app.emit("ai:stream", chunk);
                                 }
                             }
                             buf.clear();
@@ -325,5 +363,50 @@ impl AiProvider for GeminiClient {
                 resp.status()
             )))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{gemini_supports_thinking, parse_gemini_parts};
+    use serde_json::json;
+
+    #[test]
+    fn thinking_gate_enables_only_known_models() {
+        for m in [
+            "gemini-2.5-pro",
+            "gemini-2.5-flash",
+            "gemini-2.0-flash-thinking",
+        ] {
+            assert!(gemini_supports_thinking(m), "{m} should enable thinking");
+        }
+        for m in ["gemini-1.5-pro", "gemini-1.5-flash", "gemini-2.0-flash"] {
+            assert!(
+                !gemini_supports_thinking(m),
+                "{m} must not request thinkingConfig (it 400s)"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_parts_splits_thought_from_answer() {
+        let ev = json!({
+            "candidates": [{
+                "content": { "parts": [
+                    { "text": "reasoning…", "thought": true },
+                    { "text": "the answer" }
+                ] }
+            }]
+        });
+        assert_eq!(
+            parse_gemini_parts(&ev),
+            vec![(true, "reasoning…"), (false, "the answer")]
+        );
+    }
+
+    #[test]
+    fn parse_parts_empty_without_candidates() {
+        assert!(parse_gemini_parts(&json!({})).is_empty());
+        assert!(parse_gemini_parts(&json!({ "candidates": [] })).is_empty());
     }
 }

--- a/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
@@ -334,12 +334,28 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
                         Ok(v) => v,
                         Err(_) => continue,
                     };
-                    let delta = event
-                        .get("message")
+                    let message = event.get("message");
+                    let delta = message
                         .and_then(|m| m.get("content"))
                         .and_then(|c| c.as_str())
                         .unwrap_or("");
+                    // Structured reasoning from thinking models (DeepSeek-R1, Qwen3)
+                    // when the server populates `message.thinking`. Models that instead
+                    // embed <think>…</think> in `content` are split renderer-side. We do
+                    // not force Ollama's `think` flag here — it 400s on non-thinking
+                    // models, so capability-gated enablement rides with the /api/show
+                    // work (Part A).
+                    let thinking = message
+                        .and_then(|m| m.get("thinking"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
                     let done = event.get("done").and_then(|d| d.as_bool()).unwrap_or(false);
+                    if !thinking.is_empty() {
+                        let _ = app.emit(
+                            "ai:stream",
+                            json!({ "jobId": job_id, "delta": thinking, "done": false, "thinking": true }),
+                        );
+                    }
                     let _ = app.emit(
                         "ai:stream",
                         json!({ "jobId": job_id, "delta": delta, "done": done }),

--- a/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
@@ -29,6 +29,32 @@ fn is_reasoning_model(model: &str) -> bool {
     matches!((bytes.next(), bytes.next()), (Some(b'o'), Some(d)) if d.is_ascii_digit())
 }
 
+/// Split one streaming chunk into `(reasoning, content)` deltas.
+///
+/// OpenAI-compatible servers that expose chain-of-thought put it on
+/// `delta.reasoning_content` (DeepSeek-R1, vLLM, LM Studio, Ollama's OpenAI
+/// shim) or `delta.reasoning` (OpenRouter); the visible answer stays on
+/// `delta.content`. Either may be empty/absent. Pure + unit-tested so the
+/// streaming loop stays a thin emitter.
+///
+/// Honest limitation: OpenAI's own o-series hide their reasoning text over Chat
+/// Completions, so there is nothing to surface there — only the answer streams.
+fn parse_openai_delta(event: &Value) -> (&str, &str) {
+    let delta = event
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("delta"));
+    let reasoning = delta
+        .and_then(|d| d.get("reasoning_content").or_else(|| d.get("reasoning")))
+        .and_then(|c| c.as_str())
+        .unwrap_or("");
+    let content = delta
+        .and_then(|d| d.get("content"))
+        .and_then(|c| c.as_str())
+        .unwrap_or("");
+    (reasoning, content)
+}
+
 pub struct OpenAiClient {
     id: ProviderId,
     base_url: String,
@@ -166,13 +192,13 @@ impl AiProvider for OpenAiClient {
                             Ok(v) => v,
                             Err(_) => continue,
                         };
-                        let delta = event
-                            .get("choices")
-                            .and_then(|c| c.get(0))
-                            .and_then(|c| c.get("delta"))
-                            .and_then(|d| d.get("content"))
-                            .and_then(|c| c.as_str())
-                            .unwrap_or("");
+                        let (reasoning, delta) = parse_openai_delta(&event);
+                        if !reasoning.is_empty() {
+                            let _ = app.emit(
+                                "ai:stream",
+                                json!({ "jobId": job_id, "delta": reasoning, "done": false, "thinking": true }),
+                            );
+                        }
                         if !delta.is_empty() {
                             let _ = app.emit(
                                 "ai:stream",
@@ -359,7 +385,8 @@ impl AiProvider for OpenAiClient {
 
 #[cfg(test)]
 mod tests {
-    use super::is_reasoning_model;
+    use super::{is_reasoning_model, parse_openai_delta};
+    use serde_json::json;
 
     #[test]
     fn detects_o_series_including_future_models() {
@@ -378,5 +405,29 @@ mod tests {
                 "{m} should not be a reasoning model"
             );
         }
+    }
+
+    #[test]
+    fn parse_delta_splits_reasoning_from_content() {
+        // DeepSeek-R1 / vLLM style: reasoning on `reasoning_content`.
+        let ev = json!({ "choices": [{ "delta": { "reasoning_content": "let me think" } }] });
+        assert_eq!(parse_openai_delta(&ev), ("let me think", ""));
+
+        // OpenRouter style: reasoning on `reasoning`.
+        let ev = json!({ "choices": [{ "delta": { "reasoning": "pondering" } }] });
+        assert_eq!(parse_openai_delta(&ev), ("pondering", ""));
+
+        // Normal answer content.
+        let ev = json!({ "choices": [{ "delta": { "content": "the answer" } }] });
+        assert_eq!(parse_openai_delta(&ev), ("", "the answer"));
+    }
+
+    #[test]
+    fn parse_delta_empty_when_no_choices_or_fields() {
+        assert_eq!(parse_openai_delta(&json!({})), ("", ""));
+        assert_eq!(
+            parse_openai_delta(&json!({ "choices": [{ "delta": {} }] })),
+            ("", "")
+        );
     }
 }

--- a/apps/tauri/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/tauri/src/renderer/lib/generate/generation/generation.ts
@@ -28,6 +28,7 @@ import { detectLanguages } from '@ajh/shared/language-detection';
 import { usePreferencesStore } from '@/store/preferences-store';
 
 import { getClient } from '../../app-client';
+import { createThinkSplitter } from '../think-split';
 
 type ModelTier = 'large' | 'medium' | 'small';
 
@@ -90,10 +91,16 @@ async function streamGenerate(
   const jobId = res.jobId;
   let buffer = '';
 
-  // Tracks whether we're inside an inline <think>...</think> block emitted
-  // token-by-token by local reasoning models (DeepSeek, Qwen, etc.)
-  let inThinkBlock = false;
-  let thinkAccum = '';
+  // Local reasoning models embed <think>…</think> inline; the shared splitter
+  // separates that reasoning from the answer. Cloud providers instead flag
+  // reasoning structurally (the `thinking` chunk flag handled below).
+  const splitter = createThinkSplitter(
+    (text) => {
+      buffer += text;
+      onToken(text);
+    },
+    (text) => onThinking?.(text)
+  );
 
   return new Promise((resolve, reject) => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -123,61 +130,16 @@ async function streamGenerate(
       }
       if (c.delta) {
         if (c.thinking) {
-          // Anthropic-style separate thinking flag
+          // Provider-flagged reasoning (Anthropic, and now OpenAI/Gemini/Ollama
+          // via the normalized `thinking` chunk flag).
           onThinking?.(c.delta);
         } else {
-          // Accumulate to detect inline <think> tags from local models
-          thinkAccum += c.delta;
-
-          // Flush any complete non-thinking content from the accumulator
-          let out = '';
-          let remaining = thinkAccum;
-
-          while (remaining.length > 0) {
-            if (inThinkBlock) {
-              const closeIdx = remaining.indexOf('</think>');
-              if (closeIdx !== -1) {
-                onThinking?.(remaining.slice(0, closeIdx));
-                inThinkBlock = false;
-                remaining = remaining.slice(closeIdx + 8);
-              } else {
-                // Still inside think block — forward to thinking handler, keep nothing
-                onThinking?.(remaining);
-                remaining = '';
-              }
-            } else {
-              const openIdx = remaining.indexOf('<think>');
-              if (openIdx !== -1) {
-                out += remaining.slice(0, openIdx);
-                inThinkBlock = true;
-                remaining = remaining.slice(openIdx + 7);
-              } else {
-                // No open tag — but it might be a partial tag at the end, hold back 7 chars
-                const holdBack = 7;
-                if (remaining.length > holdBack) {
-                  out += remaining.slice(0, remaining.length - holdBack);
-                  remaining = remaining.slice(remaining.length - holdBack);
-                }
-                break;
-              }
-            }
-          }
-
-          thinkAccum = remaining;
-
-          if (out) {
-            buffer += out;
-            onToken(out);
-          }
+          // Local models embed reasoning inline as <think>…</think>.
+          splitter.push(c.delta);
         }
       }
       if (c.done) {
-        // Flush whatever remains — even if a think block never closed, discard it;
-        // flush any trailing non-think content so the buffer is complete.
-        if (thinkAccum && !inThinkBlock) {
-          buffer += thinkAccum;
-          onToken(thinkAccum);
-        }
+        splitter.flush();
         off();
         cleanup();
         resolve(buffer);

--- a/apps/tauri/src/renderer/lib/generate/think-split.test.ts
+++ b/apps/tauri/src/renderer/lib/generate/think-split.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { createThinkSplitter } from './think-split';
+
+/** Drive a splitter with a list of deltas, then flush, collecting both channels. */
+function run(deltas: string[]): { answer: string; thinking: string } {
+  let answer = '';
+  let thinking = '';
+  const splitter = createThinkSplitter(
+    (t) => {
+      answer += t;
+    },
+    (t) => {
+      thinking += t;
+    }
+  );
+  for (const d of deltas) splitter.push(d);
+  splitter.flush();
+  return { answer, thinking };
+}
+
+describe('createThinkSplitter', () => {
+  it('passes plain content straight through to onToken', () => {
+    expect(run(['Hello ', 'world'])).toEqual({ answer: 'Hello world', thinking: '' });
+  });
+
+  it('routes an inline <think> block to onThinking and the rest to onToken', () => {
+    const { answer, thinking } = run(['<think>reasoning here</think>the answer']);
+    expect(thinking).toBe('reasoning here');
+    expect(answer).toBe('the answer');
+  });
+
+  it('detects a <think> tag split across deltas', () => {
+    // The opening tag arrives in two chunks: "<thi" then "nk>".
+    const { answer, thinking } = run(['before <thi', 'nk>secret</think> after']);
+    expect(answer).toBe('before  after');
+    expect(thinking).toBe('secret');
+  });
+
+  it('streams reasoning across multiple deltas while inside a block', () => {
+    const { answer, thinking } = run(['<think>part one ', 'part two</think>done']);
+    expect(thinking).toBe('part one part two');
+    expect(answer).toBe('done');
+  });
+
+  it('discards an unclosed think block on flush (no leak into the answer)', () => {
+    const { answer, thinking } = run(['visible <think>never closes...']);
+    expect(answer).toBe('visible ');
+    expect(thinking).toBe('never closes...');
+  });
+
+  it('handles several think blocks in one stream', () => {
+    const { answer, thinking } = run(['a<think>x</think>b<think>y</think>c']);
+    expect(answer).toBe('abc');
+    expect(thinking).toBe('xy');
+  });
+
+  it('flush emits trailing held-back content shorter than a tag', () => {
+    // "end" is shorter than "<think>" so it is held back until flush.
+    const { answer } = run(['the end']);
+    expect(answer).toBe('the end');
+  });
+});

--- a/apps/tauri/src/renderer/lib/generate/think-split.ts
+++ b/apps/tauri/src/renderer/lib/generate/think-split.ts
@@ -1,0 +1,83 @@
+/**
+ * Streaming splitter for inline `<think>…</think>` reasoning that local models
+ * (DeepSeek-R1, Qwen3, …) embed directly in their content stream.
+ *
+ * Cloud providers that flag reasoning structurally (`thinking: true` on the
+ * stream chunk) are handled by the caller *before* `push` — this util only deals
+ * with the embedded-tag case, so every streaming surface (AI Generate, analyze,
+ * the autopilot apply modal) separates reasoning the same way instead of each
+ * re-implementing the parser.
+ *
+ * Stateful across deltas: it holds back a few trailing characters so a `<think>`
+ * tag split across two deltas is still detected. Visible answer text goes to
+ * `onToken`; reasoning text goes to `onThinking`. Call `flush()` once at stream
+ * end to emit any buffered trailing content (an unterminated think block is
+ * discarded).
+ */
+export interface ThinkSplitter {
+  /** Feed one non-thinking content delta from the stream. */
+  push(delta: string): void;
+  /** Emit trailing buffered visible content at stream end. */
+  flush(): void;
+}
+
+const OPEN = '<think>';
+const CLOSE = '</think>';
+
+export function createThinkSplitter(
+  onToken: (text: string) => void,
+  onThinking: (text: string) => void
+): ThinkSplitter {
+  let inThinkBlock = false;
+  let accum = '';
+
+  const push = (delta: string): void => {
+    accum += delta;
+
+    let out = '';
+    let remaining = accum;
+
+    while (remaining.length > 0) {
+      if (inThinkBlock) {
+        const closeIdx = remaining.indexOf(CLOSE);
+        if (closeIdx !== -1) {
+          onThinking(remaining.slice(0, closeIdx));
+          inThinkBlock = false;
+          remaining = remaining.slice(closeIdx + CLOSE.length);
+        } else {
+          // Still inside the think block — forward all of it as reasoning.
+          onThinking(remaining);
+          remaining = '';
+        }
+      } else {
+        const openIdx = remaining.indexOf(OPEN);
+        if (openIdx !== -1) {
+          out += remaining.slice(0, openIdx);
+          inThinkBlock = true;
+          remaining = remaining.slice(openIdx + OPEN.length);
+        } else {
+          // No open tag — but the tail might be a partial `<think>` arriving
+          // split across deltas, so hold back its length and re-check next push.
+          if (remaining.length > OPEN.length) {
+            out += remaining.slice(0, remaining.length - OPEN.length);
+            remaining = remaining.slice(remaining.length - OPEN.length);
+          }
+          break;
+        }
+      }
+    }
+
+    accum = remaining;
+    if (out) onToken(out);
+  };
+
+  const flush = (): void => {
+    // An unterminated think block is discarded; any trailing visible content is emitted.
+    if (accum && !inThinkBlock) {
+      onToken(accum);
+    }
+    accum = '';
+  };
+
+  return { push, flush };
+}

--- a/apps/tauri/src/renderer/lib/resume-ai/resume-ai.test.ts
+++ b/apps/tauri/src/renderer/lib/resume-ai/resume-ai.test.ts
@@ -72,7 +72,9 @@ describe('runAnalysis', () => {
 
     const result = await promise;
     expect(result.scores.ats).toBe(72);
-    expect(onToken).toHaveBeenCalledWith('{"scores":{"ats":72}}');
+    // The shared <think> splitter may chunk the streamed content (it holds back a
+    // few trailing chars to detect split tags), so assert the reassembled stream.
+    expect(onToken.mock.calls.map((c) => c[0]).join('')).toBe('{"scores":{"ats":72}}');
     expect(result.detectedLanguages).toHaveProperty('mismatch');
   });
 

--- a/apps/tauri/src/renderer/lib/resume-ai/resume-ai.ts
+++ b/apps/tauri/src/renderer/lib/resume-ai/resume-ai.ts
@@ -23,6 +23,7 @@ import { detectLanguages } from '@ajh/shared/language-detection';
 import { usePreferencesStore } from '@/store/preferences-store';
 
 import { getClient } from '../app-client';
+import { createThinkSplitter } from '../generate/think-split';
 
 type ModelTier = 'large' | 'medium' | 'small';
 
@@ -116,6 +117,15 @@ export async function runAnalysis({
   // Collect streamed tokens into the full response
   const full = await new Promise<string>((resolve, reject) => {
     let buffer = '';
+    // Local models embed reasoning inline as <think>…</think>; the shared splitter
+    // keeps it out of the analysis JSON. Cloud providers flag it structurally below.
+    const splitter = createThinkSplitter(
+      (text) => {
+        buffer += text;
+        onToken?.(text);
+      },
+      (text) => onThinking?.(text)
+    );
     const off = api.ai.onStream((chunk: unknown) => {
       const c = chunk as {
         jobId: string;
@@ -134,11 +144,11 @@ export async function runAnalysis({
         if (c.thinking) {
           onThinking?.(c.delta);
         } else {
-          buffer += c.delta;
-          onToken?.(c.delta);
+          splitter.push(c.delta);
         }
       }
       if (c.done) {
+        splitter.flush();
         off();
         resolve(buffer);
       }
@@ -161,6 +171,7 @@ export async function runAnalysis({
       () => {
         off();
         if (abortListener && signal) signal.removeEventListener('abort', abortListener);
+        splitter.flush();
         resolve(buffer);
       },
       5 * 60 * 1000
@@ -187,6 +198,7 @@ export async function runAnalysis({
             clearTimeout(timeoutId);
             off();
             if (abortListener && signal) signal.removeEventListener('abort', abortListener);
+            splitter.flush();
             // Use the job result text if the stream already buffered everything,
             // otherwise fall back to whatever the job stored.
             resolve(buffer || job.result?.text || '');


### PR DESCRIPTION
## Problem

Only Anthropic and the Claude-Code CLI agent surfaced their reasoning, so the existing `ThinkingBubble` never lit up for OpenAI, Gemini, or Ollama. The renderer plumbing was **already universal** (the normalized `thinking` stream flag) — the gap was **backend emission parity**.

## Fix — normalize reasoning at the provider boundary

Every adapter now emits reasoning as the same `ai:stream { delta, thinking: true }` shape, so the UI keeps one contract with **zero per-provider branching** and self-gates (the bubble only shows when reasoning text exists).

| Provider | Change |
|---|---|
| **OpenAI / compatible** | Emit `delta.reasoning_content` (DeepSeek-R1, vLLM, LM Studio, Ollama OpenAI shim) and `delta.reasoning` (OpenRouter). *o-series hide reasoning over Chat Completions — documented, not faked.* |
| **Gemini** | Request `thinkingConfig.includeThoughts` for thinking-capable models (**gated** — 1.5 / GA-2.0 reject it with a 400) and split `thought: true` parts. |
| **Ollama** | Emit structured `message.thinking` when present. We **do not** force the `think` flag (it 400s on non-thinking models) — capability-gated enablement rides with the `/api/show` work (Part A); tag-embedding models keep working via the splitter. |
| **Codex CLI** | Map `agent_reasoning*` events to the existing thinking channel. |
| **Gemini CLI** | No headless reasoning channel — left as-is (noted). |

## Renderer — centralize the inline `<think>` splitter

The inline `<think>…</think>` parser moves out of `generation.ts` into a shared `lib/generate/think-split.ts`, consumed by **both** the generation and analyze stream readers. This also **fixes analyze**, which previously only handled the structured flag and would leak raw `<think>` tags into the analysis JSON for tag-embedding local models.

## Tests

- Pure-parser unit tests: OpenAI reasoning split, Gemini `thought` split + thinking gate, Codex reasoning mapping.
- Shared-splitter tests: partial tags split across deltas, unclosed blocks (discarded), multi-block streams.
- Updated the analyze stream test to assert reassembled content (chunking-agnostic).
- Rust 695 tests + clippy + fmt; TS 26 tests + typecheck + lint:strict — all green.

## Review routing
Primary: **ai-provider-expert** · Secondary: **tauri-security-reviewer** (reasoning leakage), **frontend-reviewer** (splitter). Part B of the multi-PR plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)