### PR TITLE
feat: configurable context window and output limits for local models

### DIFF
--- a/apps/tauri/src-tauri/src/commands/ai.rs
+++ b/apps/tauri/src-tauri/src/commands/ai.rs
@@ -162,6 +162,14 @@ pub async fn ai_list_models() -> Value {
     json!(ollama::list_tag_models(&client).await)
 }
 
+/// Inspect a local (Ollama) model's real context window + size via `/api/show`,
+/// to suggest safe generation limits. Returns `Null` when Ollama is unreachable
+/// or the model has no usable info — the UI only calls this for the local provider.
+#[tauri::command]
+pub async fn ai_inspect_model(model: String) -> Value {
+    ollama::show_model(&model).await
+}
+
 #[tauri::command]
 pub async fn ai_pull_model(app: AppHandle, model: String) -> Value {
     let job_id = uuid_v4();

--- a/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
@@ -216,6 +216,76 @@ pub async fn embed_with(model: &str, text: &str) -> AppResult<Vec<f64>> {
     Ok(arr.iter().filter_map(|v| v.as_f64()).collect())
 }
 
+/// Inspect a local model via `/api/show` — its real trained context length and
+/// size labels — normalized to the `ModelInspectResult` shape. Returns
+/// `Value::Null` when Ollama is unreachable, errors, or returns nothing useful,
+/// so the caller can surface "no info" without failing.
+pub async fn show_model(model: &str) -> Value {
+    let body = json!({ "model": model });
+    let resp = match crate::net::http::shared()
+        .post(format!("{}/api/show", host()))
+        .timeout(std::time::Duration::from_secs(15))
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => return Value::Null,
+    };
+    if !resp.status().is_success() {
+        return Value::Null;
+    }
+    match resp.json::<Value>().await {
+        Ok(data) => normalize_show(&data),
+        Err(_) => Value::Null,
+    }
+}
+
+/// Map an Ollama `/api/show` response to the `ModelInspectResult` shape
+/// (camelCase keys), omitting fields the server didn't provide. Pure +
+/// unit-tested. `model_info.*.context_length` is keyed by architecture (e.g.
+/// `llama.context_length`, `qwen2.context_length`), so we scan for the first key
+/// ending in `.context_length` rather than hardcoding an architecture. Returns
+/// `Value::Null` when nothing usable is present.
+fn normalize_show(data: &Value) -> Value {
+    let context_length = data
+        .get("model_info")
+        .and_then(|mi| mi.as_object())
+        .and_then(|obj| {
+            obj.iter()
+                .find(|(k, _)| k.ends_with(".context_length"))
+                .and_then(|(_, v)| v.as_u64())
+        });
+    let details = data.get("details");
+    let str_field = |key: &str| -> Option<String> {
+        details
+            .and_then(|d| d.get(key))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+
+    let mut out = serde_json::Map::new();
+    if let Some(c) = context_length {
+        out.insert("contextLength".to_string(), json!(c));
+    }
+    if let Some(p) = str_field("parameter_size") {
+        out.insert("parameterSize".to_string(), json!(p));
+    }
+    if let Some(q) = str_field("quantization_level") {
+        out.insert("quantization".to_string(), json!(q));
+    }
+    if let Some(f) = str_field("family") {
+        out.insert("family".to_string(), json!(f));
+    }
+
+    if out.is_empty() {
+        Value::Null
+    } else {
+        Value::Object(out)
+    }
+}
+
 /// Stream a model pull, emitting `jobs:event` progress. Returns when complete.
 pub async fn pull(app: &AppHandle, job_id: &str, model: &str) -> AppResult<()> {
     let mut response = crate::net::http::shared()
@@ -284,6 +354,11 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
     }
     if let Some(mt) = req.max_tokens {
         options.insert("num_predict".to_string(), json!(mt));
+    }
+    // Context window (num_ctx) — large résumé/job-ad prompts overflow Ollama's
+    // small default context and get silently truncated without this.
+    if let Some(ctx) = req.context_window {
+        options.insert("num_ctx".to_string(), json!(ctx));
     }
     if !options.is_empty() {
         body["options"] = Value::Object(options);
@@ -386,4 +461,45 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
         .complete(job_id, json!({ "done": true }));
     trace.end(Some(status.as_u16()), true);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_show;
+    use serde_json::json;
+
+    #[test]
+    fn normalize_extracts_context_and_details_by_architecture() {
+        // `context_length` is keyed by architecture — scan for the suffix, not a
+        // hardcoded `llama.` prefix, so qwen2/phi3/etc. all work unchanged.
+        let data = json!({
+            "model_info": { "qwen2.context_length": 32768, "qwen2.embedding_length": 3584 },
+            "details": { "parameter_size": "7.6B", "quantization_level": "Q4_K_M", "family": "qwen2" }
+        });
+        let out = normalize_show(&data);
+        assert_eq!(out["contextLength"], json!(32768));
+        assert_eq!(out["parameterSize"], json!("7.6B"));
+        assert_eq!(out["quantization"], json!("Q4_K_M"));
+        assert_eq!(out["family"], json!("qwen2"));
+    }
+
+    #[test]
+    fn normalize_omits_missing_fields() {
+        let data = json!({
+            "model_info": { "llama.context_length": 8192 },
+            "details": { "parameter_size": "8B" }
+        });
+        let out = normalize_show(&data);
+        assert_eq!(out["contextLength"], json!(8192));
+        assert_eq!(out["parameterSize"], json!("8B"));
+        // Absent fields are omitted (not null), so the TS optional schema accepts it.
+        assert!(out.get("quantization").is_none());
+        assert!(out.get("family").is_none());
+    }
+
+    #[test]
+    fn normalize_returns_null_when_nothing_usable() {
+        assert!(normalize_show(&json!({})).is_null());
+        assert!(normalize_show(&json!({ "model_info": {}, "details": {} })).is_null());
+    }
 }

--- a/apps/tauri/src-tauri/src/ipc_contracts/ai.rs
+++ b/apps/tauri/src-tauri/src/ipc_contracts/ai.rs
@@ -12,6 +12,7 @@ pub struct AiGenerateRequest {
     pub locale: String,
     pub temperature: Option<f64>,
     pub max_tokens: Option<u32>,
+    pub context_window: Option<u32>,
     pub stream: Option<bool>,
     pub provider: Option<String>,
     pub base_url: Option<String>,

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -274,6 +274,7 @@ fn main() {
             // ai
             commands::ai::ai_generate,
             commands::ai::ai_list_models,
+            commands::ai::ai_inspect_model,
             commands::ai::ai_pull_model,
             commands::ai::ai_unload_model,
             commands::ai::ai_embed,

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/LocalModelLimits.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/LocalModelLimits.tsx
@@ -1,0 +1,150 @@
+import { Button } from '@ajh/ui';
+
+import { useTranslation } from '@/lib/i18n';
+import { useInspectModel, useSystemResources } from '@/services';
+import { usePreferencesStore } from '@/store/preferences-store';
+
+import { suggestLocalLimits } from './suggest-local-limits';
+
+interface Props {
+  selectedModel?: string;
+}
+
+const CTX_MIN = 2048;
+const CTX_MAX = 131072;
+const OUT_MIN = 512;
+const OUT_MAX = 8192;
+
+// Shared slider styling — mirrors the SalaryPreferences range inputs.
+const SLIDER_CLASS =
+  'w-full h-2 appearance-none rounded-lg bg-white/5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-brand-soft [&::-webkit-slider-thumb]:cursor-pointer';
+
+/**
+ * Per-local-model generation limits: an "Analyze model" action that reads the
+ * model's real context window via `/api/show`, sliders for the context window
+ * (num_ctx) + max output (num_predict) persisted per model, a "Use suggested"
+ * button driven by hardware, and a hardware-lag warning mirroring onboarding.
+ */
+export function LocalModelLimits({ selectedModel }: Props) {
+  const { t } = useTranslation();
+  const inspect = useInspectModel();
+  const { resources } = useSystemResources(selectedModel);
+  const setLocalModelLimits = usePreferencesStore((s) => s.setLocalModelLimits);
+  const limits = usePreferencesStore((s) =>
+    selectedModel ? s.aiProviderConfig?.providers?.ollama?.modelLimits?.[selectedModel] : undefined
+  );
+
+  if (!selectedModel) return null;
+
+  const inspected = inspect.data;
+  const detectedMax = inspected?.contextLength;
+  const ctxMax = Math.min(CTX_MAX, detectedMax ?? CTX_MAX);
+
+  const contextWindow = Math.min(limits?.contextWindow ?? Math.min(8192, ctxMax), ctxMax);
+  const maxTokens = limits?.maxTokens ?? 2048;
+
+  const suggestion = suggestLocalLimits({
+    modelMaxContext: detectedMax,
+    freeRamGb: resources.freeRamGb,
+    hasGpu: resources.hasGpu,
+    freeVramGb: resources.freeVramGb,
+  });
+
+  // Mirror onboarding: warn when the chosen context exceeds what memory comfortably fits.
+  const mightLag = contextWindow > suggestion.contextWindow;
+
+  return (
+    <div className="mt-2 space-y-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-foreground/60">
+          {t('settings.ai.localLimits.title')}
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => inspect.mutate({ model: selectedModel })}
+          disabled={inspect.isPending}
+        >
+          {inspect.isPending
+            ? t('settings.ai.localLimits.analyzing')
+            : t('settings.ai.localLimits.analyze')}
+        </Button>
+      </div>
+
+      {inspected && (
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-foreground/45">
+          {detectedMax != null && (
+            <span>
+              {t('settings.ai.localLimits.maxContext')}: {detectedMax.toLocaleString()}
+            </span>
+          )}
+          {inspected.parameterSize && <span>{inspected.parameterSize}</span>}
+          {inspected.quantization && <span>{inspected.quantization}</span>}
+        </div>
+      )}
+      {inspect.isSuccess && !inspected && (
+        <p className="text-xs text-foreground/40">{t('settings.ai.localLimits.noInfo')}</p>
+      )}
+
+      {/* Context window (num_ctx) */}
+      <div>
+        <div className="mb-2 flex justify-between text-xs">
+          <span className="text-foreground/55">{t('settings.ai.localLimits.contextWindow')}</span>
+          <span className="text-foreground/80">{contextWindow.toLocaleString()}</span>
+        </div>
+        <input
+          type="range"
+          min={CTX_MIN}
+          max={ctxMax}
+          step={512}
+          value={contextWindow}
+          onChange={(e) =>
+            setLocalModelLimits(selectedModel, { contextWindow: Number(e.target.value) })
+          }
+          className={SLIDER_CLASS}
+        />
+      </div>
+
+      {/* Max output (num_predict) */}
+      <div>
+        <div className="mb-2 flex justify-between text-xs">
+          <span className="text-foreground/55">{t('settings.ai.localLimits.maxOutput')}</span>
+          <span className="text-foreground/80">{maxTokens.toLocaleString()}</span>
+        </div>
+        <input
+          type="range"
+          min={OUT_MIN}
+          max={OUT_MAX}
+          step={256}
+          value={maxTokens}
+          onChange={(e) =>
+            setLocalModelLimits(selectedModel, { maxTokens: Number(e.target.value) })
+          }
+          className={SLIDER_CLASS}
+        />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setLocalModelLimits(selectedModel, suggestion)}
+        >
+          {t('settings.ai.localLimits.useSuggested')}
+        </Button>
+        <span className="text-xs text-foreground/35">
+          {t('settings.ai.localLimits.suggested')}: {suggestion.contextWindow.toLocaleString()}
+        </span>
+      </div>
+
+      {mightLag && (
+        <p className="text-xs text-amber-400/80">
+          ⚠️{' '}
+          {resources.hasGpu
+            ? t('settings.ai.localLimits.mayLagVram')
+            : t('settings.ai.localLimits.mayLagRam')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/index.tsx
@@ -9,6 +9,7 @@ import { ActiveProviderSwitcher } from '../ActiveProviderSwitcher';
 import { EmbeddingsSettings } from '../EmbeddingsSettings';
 import { ProviderDebugBadge } from '../ProviderDebugBadge';
 import { ProviderRow } from '../ProviderRow';
+import { LocalModelLimits } from './LocalModelLimits';
 import { OllamaResourcesPanel } from './OllamaResourcesPanel';
 import { useProviderKeys } from './useProviderKeys';
 
@@ -104,7 +105,10 @@ export function AISettingsTab() {
                 onRecheck={recheck}
               >
                 {p === 'ollama' && connected && (
-                  <OllamaResourcesPanel selectedModel={selectedOllamaModel} />
+                  <>
+                    <OllamaResourcesPanel selectedModel={selectedOllamaModel} />
+                    <LocalModelLimits selectedModel={selectedOllamaModel} />
+                  </>
                 )}
               </ProviderRow>
             );

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/suggest-local-limits.test.ts
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/suggest-local-limits.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { suggestLocalLimits } from './suggest-local-limits';
+
+describe('suggestLocalLimits', () => {
+  it('caps the context window at the model max on a high-memory machine', () => {
+    const s = suggestLocalLimits({
+      modelMaxContext: 8192,
+      freeRamGb: 64,
+      hasGpu: false,
+      freeVramGb: 0,
+    });
+    expect(s.contextWindow).toBe(8192); // never exceeds the model's trained max
+  });
+
+  it('drops the context window on a low-RAM machine', () => {
+    const low = suggestLocalLimits({
+      modelMaxContext: 131072,
+      freeRamGb: 2,
+      hasGpu: false,
+      freeVramGb: 0,
+    });
+    const high = suggestLocalLimits({
+      modelMaxContext: 131072,
+      freeRamGb: 64,
+      hasGpu: false,
+      freeVramGb: 0,
+    });
+    expect(low.contextWindow).toBeLessThan(high.contextWindow);
+    expect(low.contextWindow).toBeGreaterThanOrEqual(2048); // never below the floor
+  });
+
+  it('budgets against VRAM when a GPU is present', () => {
+    // Lots of RAM but tiny VRAM → the GPU budget governs and keeps it small.
+    const s = suggestLocalLimits({
+      modelMaxContext: 131072,
+      freeRamGb: 64,
+      hasGpu: true,
+      freeVramGb: 2,
+    });
+    expect(s.contextWindow).toBeLessThan(32768);
+  });
+
+  it('stays within the schema bounds and rounds to a 512-token step', () => {
+    const s = suggestLocalLimits({
+      modelMaxContext: 200000, // beyond the schema ceiling
+      freeRamGb: 1024,
+      hasGpu: false,
+      freeVramGb: 0,
+    });
+    expect(s.contextWindow).toBeLessThanOrEqual(131072);
+    expect(s.contextWindow % 512).toBe(0);
+    expect(s.maxTokens).toBeGreaterThanOrEqual(512);
+    expect(s.maxTokens).toBeLessThanOrEqual(8192);
+  });
+
+  it('falls back to a safe default when the model max is unknown', () => {
+    const s = suggestLocalLimits({ freeRamGb: 16, hasGpu: false, freeVramGb: 0 });
+    expect(s.contextWindow).toBeGreaterThanOrEqual(2048);
+    expect(s.contextWindow).toBeLessThanOrEqual(131072);
+  });
+});

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/suggest-local-limits.ts
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/suggest-local-limits.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure heuristics for suggesting safe local-model (Ollama) generation limits from
+ * the model's real context length (`/api/show`) and the machine's free memory.
+ * Kept separate from the UI so it is unit-testable.
+ */
+
+export interface LimitSuggestion {
+  /** Suggested context window (num_ctx), in tokens. */
+  contextWindow: number;
+  /** Suggested max output (num_predict), in tokens. */
+  maxTokens: number;
+}
+
+export interface SuggestInput {
+  /** Model's trained max context from `/api/show`, if known. */
+  modelMaxContext?: number;
+  /** Free system RAM in GB. */
+  freeRamGb: number;
+  /** Whether a GPU is present (KV cache then lives in VRAM). */
+  hasGpu: boolean;
+  /** Free VRAM in GB (0 when no GPU). */
+  freeVramGb: number;
+}
+
+/** Schema bounds — keep in lockstep with `LocalModelLimitsSchema`. */
+const CTX_FLOOR = 2048;
+const CTX_CEIL = 131072;
+const OUT_FLOOR = 512;
+const OUT_CEIL = 8192;
+
+/** Rough KV-cache budget for a typical 7–8B GQA model. */
+const TOKENS_PER_GB = 8192;
+const HEADROOM_GB = 1;
+
+/**
+ * Suggest a context window that fits the available memory (capped at the model's
+ * trained max) plus a sensible max output.
+ *
+ * KV-cache memory scales ~linearly with `num_ctx`. We budget ~8K tokens per GB of
+ * free memory (VRAM when a GPU is present, else system RAM), keep ~1 GB headroom,
+ * and never exceed the model's trained context length — so the suggestion **caps
+ * at the model max** and **drops on low-memory machines**.
+ */
+export function suggestLocalLimits(input: SuggestInput): LimitSuggestion {
+  const { modelMaxContext, freeRamGb, hasGpu, freeVramGb } = input;
+
+  const modelCap = modelMaxContext && modelMaxContext > 0 ? modelMaxContext : OUT_CEIL;
+  const budgetGb = Math.max(0, hasGpu ? freeVramGb : freeRamGb);
+  const tokensFromMemory = Math.max(0, budgetGb - HEADROOM_GB) * TOKENS_PER_GB;
+
+  // Fit memory, cap at the model max, then clamp to the schema range and round to
+  // a 512-token step.
+  let contextWindow = Math.min(modelCap, tokensFromMemory) || CTX_FLOOR;
+  contextWindow = Math.max(CTX_FLOOR, Math.min(CTX_CEIL, contextWindow));
+  contextWindow = Math.round(contextWindow / 512) * 512;
+
+  // Output budget: a slice of the context, within sane bounds.
+  const maxTokens = Math.max(OUT_FLOOR, Math.min(OUT_CEIL, Math.round(contextWindow / 4)));
+
+  return { contextWindow, maxTokens };
+}

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -365,6 +365,21 @@
       "searchPlaceholder": "Technologien suchen...",
       "popular": "Beliebt"
     },
+    "ai": {
+      "localLimits": {
+        "title": "Generierungslimits",
+        "analyze": "Modell analysieren",
+        "analyzing": "Analysiere…",
+        "maxContext": "Max. Kontext",
+        "noInfo": "Keine Modelldetails verfügbar",
+        "contextWindow": "Kontextfenster",
+        "maxOutput": "Max. Ausgabe-Tokens",
+        "useSuggested": "Vorschlag übernehmen",
+        "suggested": "Vorschlag",
+        "mayLagRam": "Ein großes Kontextfenster kann bei Ihrem verfügbaren RAM ruckeln",
+        "mayLagVram": "Ein großes Kontextfenster kann bei Ihrem verfügbaren VRAM ruckeln"
+      }
+    },
     "salary": {
       "title": "Gehaltserwartungen",
       "description": "Legen Sie Ihre Gehaltserwartungen fest, um Job-Empfehlungen zu filtern.",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -365,6 +365,21 @@
       "searchPlaceholder": "Search technologies...",
       "popular": "Popular"
     },
+    "ai": {
+      "localLimits": {
+        "title": "Generation limits",
+        "analyze": "Analyze model",
+        "analyzing": "Analyzing…",
+        "maxContext": "Max context",
+        "noInfo": "No model details available",
+        "contextWindow": "Context window",
+        "maxOutput": "Max output tokens",
+        "useSuggested": "Use suggested",
+        "suggested": "Suggested",
+        "mayLagRam": "A large context window may lag on your available RAM",
+        "mayLagVram": "A large context window may lag on your available VRAM"
+      }
+    },
     "salary": {
       "title": "Salary Expectations",
       "description": "Set your salary expectations to filter job recommendations.",

--- a/apps/tauri/src/renderer/lib/generate/generation/generation.test.ts
+++ b/apps/tauri/src/renderer/lib/generate/generation/generation.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { usePreferencesStore } from '@/store/preferences-store';
+
 import { _registerClient } from '../../app-client';
 import { createMockClient } from '../../mock-client';
 import { extractMetadata, generateCoverLetter, generateResume } from './generation';
@@ -39,6 +41,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  usePreferencesStore.setState({ aiProviderConfig: undefined });
 });
 
 describe('extractMetadata', () => {
@@ -131,5 +134,59 @@ describe('generateCoverLetter', () => {
     done();
     const out = await p;
     expect(out).toContain('Dear Hiring Team');
+  });
+});
+
+describe('local model limits wiring', () => {
+  it('sends the per-model contextWindow + maxTokens on the ollama path', async () => {
+    usePreferencesStore.setState({
+      aiProviderConfig: {
+        activeProvider: 'ollama',
+        providers: {
+          ollama: {
+            model: 'llama3',
+            modelLimits: { llama3: { contextWindow: 16384, maxTokens: 4096 } },
+          },
+        },
+      },
+    });
+    const client = register();
+    const p = extractMetadata('resume', 'job ad', 'llama3');
+    await flushUntilStreaming();
+    emit('{}');
+    done();
+    await p;
+
+    expect(client.ai.generatePipeline).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'ollama', contextWindow: 16384, maxTokens: 4096 })
+    );
+  });
+
+  it('omits the local context window for cloud providers', async () => {
+    usePreferencesStore.setState({
+      aiProviderConfig: {
+        activeProvider: 'openai',
+        providers: {
+          openai: { model: 'gpt-4o' },
+          // Even with ollama limits stored, the cloud path must not send them.
+          ollama: {
+            model: 'llama3',
+            modelLimits: { llama3: { contextWindow: 16384, maxTokens: 4096 } },
+          },
+        },
+      },
+    });
+    const client = register();
+    const p = extractMetadata('resume', 'job ad', 'gpt-4o');
+    await flushUntilStreaming();
+    emit('{}');
+    done();
+    await p;
+
+    const call = (client.ai.generatePipeline as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call).toBeDefined();
+    const arg = call?.[0] as { provider: string; contextWindow?: number };
+    expect(arg.provider).toBe('openai');
+    expect(arg.contextWindow).toBeUndefined();
   });
 });

--- a/apps/tauri/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/tauri/src/renderer/lib/generate/generation/generation.ts
@@ -69,6 +69,10 @@ async function streamGenerate(
   const activeProvider = providerConfig?.activeProvider ?? 'ollama';
   const providerSettings = providerConfig?.providers?.[activeProvider];
   const activeModel = providerSettings?.model || model;
+  // Per-model generation limits are local (Ollama) only — cloud/CLI providers
+  // ignore them, and the backend only applies num_predict/num_ctx for Ollama.
+  const localLimits =
+    activeProvider === 'ollama' ? providerSettings?.modelLimits?.[activeModel] : undefined;
   // Resume + cover-letter generation runs through the backend orchestration
   // pipeline (a composable Pipeline of stages), not the raw generate command.
   // Same streaming contract: emits `ai:stream` deltas under the returned jobId.
@@ -86,6 +90,10 @@ async function streamGenerate(
     baseUrl: providerSettings?.baseUrl,
     // Reasoning effort for CLI agents that support it (e.g. Codex).
     effort: providerSettings?.effort,
+    // Per-model local limits (Ollama) — context window (num_ctx) + max output
+    // (num_predict). Omitted (undefined) for cloud/CLI or when unset.
+    maxTokens: localLimits?.maxTokens,
+    contextWindow: localLimits?.contextWindow,
   } as Parameters<typeof api.ai.generatePipeline>[0])) as { jobId: string };
 
   const jobId = res.jobId;

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -57,6 +57,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       generate: noop,
       generatePipeline: noop,
       listModels: emptyList,
+      inspectModel: async () => null,
       pullModel: noop,
       unloadModel: noop,
       embed: noop,

--- a/apps/tauri/src/renderer/services/use-ai-provider/use-ai-provider.ts
+++ b/apps/tauri/src/renderer/services/use-ai-provider/use-ai-provider.ts
@@ -57,6 +57,17 @@ export const useTestProviderKey = () => {
   });
 };
 
+/**
+ * Inspect a local (Ollama) model's real context window + size via `/api/show`.
+ * On-demand (the settings "Analyze model" button), so a mutation rather than a query.
+ */
+export const useInspectModel = () => {
+  const api = useAppClient();
+  return useMutation({
+    mutationFn: ({ model }: { model: string }) => api.ai.inspectModel({ model }),
+  });
+};
+
 /** Active embedding space, per-space vector counts, and document index coverage. */
 export const useEmbeddingStatus = () => {
   const api = useAppClient();

--- a/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
+++ b/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
@@ -32,12 +32,23 @@ export const AiProviderSchema = z.enum([
   'gemini-cli',
 ]);
 
+// Per-local-model generation limits (Ollama only). Keyed by model name so each
+// model remembers its own context window + max output. Cloud/CLI providers ignore these.
+export const LocalModelLimitsSchema = z.object({
+  contextWindow: z.number().int().min(512).max(131072).optional(),
+  maxTokens: z.number().int().min(1).max(32768).optional(),
+});
+
 // Per-provider settings (model choice, optional base URL, optional CLI effort)
 export const PerProviderSettingsSchema = z.object({
   model: z.string().default(''),
   baseUrl: z.string().optional(),
   // Reasoning effort for CLI agents that support it (e.g. Codex: low/medium/high).
   effort: z.string().optional(),
+  // Per-model generation limits, keyed by model name (local/Ollama only).
+  // Optional so existing per-provider settings (and the many `{ model }` literals)
+  // stay valid; readers default it to `{}`.
+  modelLimits: z.record(z.string(), LocalModelLimitsSchema).optional(),
 });
 
 // Multi-provider config: each provider stores its own settings independently;
@@ -50,6 +61,7 @@ export const AiProviderConfigSchema = z.object({
 export type AiProvider = z.infer<typeof AiProviderSchema>;
 export type AiProviderConfig = z.infer<typeof AiProviderConfigSchema>;
 export type PerProviderSettings = z.infer<typeof PerProviderSettingsSchema>;
+export type LocalModelLimits = z.infer<typeof LocalModelLimitsSchema>;
 
 // Resume preference
 export const ResumePreferenceSchema = z.object({

--- a/apps/tauri/src/renderer/store/preferences-store/preferences-store.test.ts
+++ b/apps/tauri/src/renderer/store/preferences-store/preferences-store.test.ts
@@ -49,6 +49,17 @@ describe('usePreferencesStore', () => {
     });
   });
 
+  it('stores per-model local limits under ollama, keyed by model and deep-merged', () => {
+    const s = usePreferencesStore.getState();
+    s.setLocalModelLimits('llama3', { contextWindow: 16384 });
+    s.setLocalModelLimits('llama3', { maxTokens: 4096 }); // independent field, merged
+    s.setLocalModelLimits('qwen3', { contextWindow: 32768 }); // a different model
+
+    const limits = usePreferencesStore.getState().aiProviderConfig?.providers?.ollama?.modelLimits;
+    expect(limits?.llama3).toEqual({ contextWindow: 16384, maxTokens: 4096 });
+    expect(limits?.qwen3).toEqual({ contextWindow: 32768 });
+  });
+
   it('marks onboarding complete and resets to defaults', () => {
     usePreferencesStore.getState().setOnboardingComplete();
     expect(usePreferencesStore.getState().onboardingCompleted).toBe(true);

--- a/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
+++ b/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
@@ -3,6 +3,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 import type {
   AiProvider,
+  LocalModelLimits,
   PerProviderSettings,
   Preferences,
   PromptQuality,
@@ -65,6 +66,7 @@ interface PreferencesActions {
   setAiProviderConfig: (config: Preferences['aiProviderConfig']) => void;
   setActiveProvider: (provider: AiProvider) => void;
   setProviderSettings: (provider: AiProvider, settings: Partial<PerProviderSettings>) => void;
+  setLocalModelLimits: (model: string, limits: Partial<LocalModelLimits>) => void;
   setOutputTone: (outputTone: Preferences['outputTone']) => void;
   setResume: (resume: Preferences['resume']) => void;
   setPerformanceMode: (performanceMode: Preferences['performanceMode']) => void;
@@ -129,6 +131,32 @@ export const usePreferencesStore = create<PreferencesStore>()(
               providers: {
                 ...state.aiProviderConfig?.providers,
                 [provider]: { ...existing, ...settings },
+              },
+            },
+            lastUpdated: new Date().toISOString(),
+          };
+        }),
+
+      // Per-model limits live under the local (ollama) provider, keyed by model
+      // name, and are deep-merged so context-window and max-output update
+      // independently.
+      setLocalModelLimits: (model: string, limits: Partial<LocalModelLimits>) =>
+        set((state) => {
+          const ollama = state.aiProviderConfig?.providers?.ollama ?? { model: '' };
+          const existingLimits = ollama.modelLimits ?? {};
+          return {
+            ...state,
+            aiProviderConfig: {
+              activeProvider: state.aiProviderConfig?.activeProvider ?? 'ollama',
+              providers: {
+                ...state.aiProviderConfig?.providers,
+                ollama: {
+                  ...ollama,
+                  modelLimits: {
+                    ...existingLimits,
+                    [model]: { ...existingLimits[model], ...limits },
+                  },
+                },
               },
             },
             lastUpdated: new Date().toISOString(),

--- a/apps/tauri/src/tauri-client/namespaces/ai/ai.ts
+++ b/apps/tauri/src/tauri-client/namespaces/ai/ai.ts
@@ -10,6 +10,7 @@ export const ai = {
   generate: (req: AiGenerateRequest) => invoke('ai_generate', { req }),
   generatePipeline: (req: AiGenerateRequest) => invoke('generate_pipeline', { req }),
   listModels: () => invoke('ai_list_models'),
+  inspectModel: ({ model }: { model: string }) => invoke('ai_inspect_model', { model }),
   pullModel: (model: string) => invoke('ai_pull_model', { model }),
   unloadModel: (model: string) => invoke('ai_unload_model', { model }),
   embed: (req: EmbedRequest) => invoke('ai_embed', { req }),

--- a/packages/shared/src/ipc/contracts/ai.ts
+++ b/packages/shared/src/ipc/contracts/ai.ts
@@ -1,4 +1,4 @@
-import type { AiGenerateRequest } from '../../schemas/index.js';
+import type { AiGenerateRequest, ModelInspectResult } from '../../schemas/index.js';
 import type { AiStreamChunk } from '../../types/index.js';
 
 export interface AiContract {
@@ -14,6 +14,13 @@ export interface AiContract {
   onStream(handler: (chunk: AiStreamChunk) => void): () => void;
 
   listModels(): Promise<Array<{ name: string }>>;
+
+  /**
+   * Inspect a local (Ollama) model's real context window + size via `/api/show`,
+   * to suggest safe generation limits. Returns `null` for non-local providers or
+   * an unreachable Ollama server.
+   */
+  inspectModel(req: { model: string }): Promise<ModelInspectResult | null>;
 
   pullModel(model: string): Promise<{ jobId: string }>;
 

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -25,6 +25,12 @@ export const AiGenerateRequestSchema = z.object({
   locale: LocaleSchema,
   temperature: z.number().min(0).max(2).optional(),
   maxTokens: z.number().int().min(1).max(32768).optional(),
+  /**
+   * Context window in tokens (Ollama `num_ctx`). Local models only — large
+   * résumé/job-ad prompts overflow Ollama's small default context and get
+   * silently truncated without this. Ignored by cloud/CLI providers.
+   */
+  contextWindow: z.number().int().min(512).max(131072).optional(),
   stream: z.boolean().optional(),
   /**
    * AI backend — 'ollama' (default), 'openai', 'openai-compatible', 'anthropic',
@@ -35,6 +41,22 @@ export const AiGenerateRequestSchema = z.object({
   baseUrl: z.string().optional(),
   /** Reasoning effort for CLI agents that support it (e.g. Codex: low/medium/high). */
   effort: z.string().optional(),
+});
+
+/**
+ * Inspection of a local (Ollama) model via `/api/show` — its real maximum
+ * context window and size, used to suggest safe generation limits. All fields
+ * optional: older Ollama servers omit some of `model_info`/`details`.
+ */
+export const ModelInspectResultSchema = z.object({
+  /** Trained context length in tokens (e.g. 8192, 131072). */
+  contextLength: z.number().int().positive().optional(),
+  /** Parameter size label from `details` (e.g. "7B", "70.6B"). */
+  parameterSize: z.string().optional(),
+  /** Quantization level (e.g. "Q4_K_M"). */
+  quantization: z.string().optional(),
+  /** Model family (e.g. "llama", "qwen2"). */
+  family: z.string().optional(),
 });
 
 export const DocumentImportRequestSchema = z.object({
@@ -226,6 +248,7 @@ export type AutopilotUpdate = z.infer<typeof AutopilotUpdateSchema>;
 export type JobPreferences = z.infer<typeof JobPreferencesSchema>;
 
 export type AiGenerateRequest = z.infer<typeof AiGenerateRequestSchema>;
+export type ModelInspectResult = z.infer<typeof ModelInspectResultSchema>;
 export type DocumentImportRequest = z.infer<typeof DocumentImportRequestSchema>;
 export type ScrapeBoardRequest = z.infer<typeof ScrapeBoardRequestSchema>;
 export type ScrapeUrlRequest = z.infer<typeof ScrapeUrlRequestSchema>;


### PR DESCRIPTION
## Problem

Local (Ollama) generation ignored user limits: the stored `maxTokens` never reached the request, and the **context window (`num_ctx`) was never sent at all** — so large résumé/job-ad prompts silently overflowed Ollama's small default context and got truncated.

## What this adds

An **"Analyze model"** action and **per-model, user-adjustable** generation limits that actually take effect.

- **Analyze model** (`ai_inspect_model` → Ollama `/api/show`) reads the model's real trained context length + parameter size / quantization. The context-length lookup scans for the `*.context_length` key **by suffix**, so every architecture (llama, qwen2, phi3, …) works with **no per-model code**.
- **Per-model limits** stored under the local provider keyed by model name (`PerProviderSettings.modelLimits`): context window (`num_ctx`) + max output (`num_predict`). Generation forwards them **only on the Ollama path**; cloud/CLI providers omit them, and **nothing is sent unless the user sets it** (no default drift).
- **Suggested limits** from a pure `suggestLocalLimits(inspect, resources)` util — fits free RAM/VRAM, **caps at the model's trained max**, **drops on low-memory machines** — with a "Use suggested" button.
- **Hardware-lag warning** mirroring onboarding when the chosen context exceeds what memory comfortably fits.

## Layers (centralized, future-proof)

shared schema (`contextWindow`, `ModelInspectResultSchema`) → IPC contract (`inspectModel`) → regenerated Rust contract → Ollama adapter (`num_ctx` + `show_model`/`normalize_show`) → command + handler → tauri-client + mock → `useInspectModel` hook → preferences (`LocalModelLimitsSchema`, `setLocalModelLimits`) → generation wiring → settings `LocalModelLimits` panel → en/de i18n.

## Tests

- Rust `/api/show` normalize: architecture-agnostic context lookup, omits missing fields, `Null` when empty.
- `suggestLocalLimits`: caps at model max, drops with low RAM, VRAM budget governs with a GPU, stays within schema bounds.
- Generation wiring: Ollama path sends `contextWindow` + `maxTokens`; cloud path omits them.
- Per-model `setLocalModelLimits` deep-merge (independent fields, multiple models).
- Rust 698 tests + clippy + fmt; TS typecheck (`--force`) + lint:strict + vitest — all green.

## Review routing
Primary: **ai-provider-expert** · Secondary: **frontend-reviewer**, **tauri-security-reviewer** (new IPC command). Part A of the multi-PR plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)