### PR TITLE
feat: dedup autopilot finds and track applied jobs via the generation link

### DIFF
--- a/apps/tauri/src-tauri/src/ai_generations/mod.rs
+++ b/apps/tauri/src-tauri/src/ai_generations/mod.rs
@@ -40,6 +40,13 @@ pub struct AiGenerationRecord {
     pub cover_letter_text: String,
     #[serde(rename = "jobAd")]
     pub job_ad: String,
+    // Application link — makes the record the single "application" aggregate: the
+    // job it targets and the board it came from. `job_url` is what derives a found
+    // job's `applied` flag (a matching url means the user generated for it).
+    #[serde(rename = "jobUrl", default)]
+    pub job_url: String,
+    #[serde(default)]
+    pub board: String,
 }
 
 pub struct AiGenerationStore {
@@ -47,11 +54,12 @@ pub struct AiGenerationStore {
 }
 
 impl AiGenerationStore {
-    const MIGRATIONS: &'static [Migration] = &[Migration {
-        name: "create_ai_generations",
-        up: |conn| {
-            conn.execute_batch(
-                "CREATE TABLE IF NOT EXISTS ai_generations (
+    const MIGRATIONS: &'static [Migration] = &[
+        Migration {
+            name: "create_ai_generations",
+            up: |conn| {
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS ai_generations (
                     id                TEXT PRIMARY KEY,
                     created_at        INTEGER NOT NULL,
                     candidate_name    TEXT NOT NULL DEFAULT '',
@@ -67,9 +75,23 @@ impl AiGenerationStore {
                     cover_letter_text TEXT NOT NULL DEFAULT '',
                     job_ad            TEXT NOT NULL DEFAULT ''
                 );",
-            )
+                )
+            },
         },
-    }];
+        // Additive: link a generation to the job it targets (and its board), so
+        // each row is the full "application" record. Old rows default to ''.
+        Migration {
+            name: "add_job_link",
+            up: |conn| {
+                conn.execute_batch(
+                    "ALTER TABLE ai_generations ADD COLUMN job_url TEXT NOT NULL DEFAULT '';
+                     ALTER TABLE ai_generations ADD COLUMN board   TEXT NOT NULL DEFAULT '';
+                     CREATE INDEX IF NOT EXISTS idx_ai_generations_job_url
+                         ON ai_generations(job_url);",
+                )
+            },
+        },
+    ];
 
     pub fn open(data_dir: &PathBuf) -> AppResult<Self> {
         std::fs::create_dir_all(data_dir).map_err(|e| e.to_string())?;
@@ -91,7 +113,8 @@ impl AiGenerationStore {
         conn.prepare(
             "SELECT id, created_at, candidate_name, job_title, company_name,
                     resume_language, job_ad_language, target_language, mismatch,
-                    top_requirements, mode, resume_text, cover_letter_text, job_ad
+                    top_requirements, mode, resume_text, cover_letter_text, job_ad,
+                    job_url, board
              FROM ai_generations ORDER BY created_at DESC",
         )
         .ok()
@@ -113,6 +136,8 @@ impl AiGenerationStore {
                     resume_text: row.get(11)?,
                     cover_letter_text: row.get(12)?,
                     job_ad: row.get(13)?,
+                    job_url: row.get(14)?,
+                    board: row.get(15)?,
                 })
             })
             .ok()
@@ -128,8 +153,9 @@ impl AiGenerationStore {
             "INSERT INTO ai_generations
              (id, created_at, candidate_name, job_title, company_name,
               resume_language, job_ad_language, target_language, mismatch,
-              top_requirements, mode, resume_text, cover_letter_text, job_ad)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)",
+              top_requirements, mode, resume_text, cover_letter_text, job_ad,
+              job_url, board)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
             params![
                 rec.id,
                 rec.created_at as i64,
@@ -145,10 +171,26 @@ impl AiGenerationStore {
                 rec.resume_text,
                 rec.cover_letter_text,
                 rec.job_ad,
+                rec.job_url,
+                rec.board,
             ],
         )
         .map_err(|e| e.to_string())?;
         Ok(())
+    }
+
+    /// Distinct non-empty `job_url`s that have at least one saved generation —
+    /// the set used to derive a found job's `applied` flag.
+    pub fn applied_job_urls(&self) -> std::collections::HashSet<String> {
+        let conn = self.conn.lock();
+        conn.prepare("SELECT DISTINCT job_url FROM ai_generations WHERE job_url != ''")
+            .ok()
+            .and_then(|mut stmt| {
+                stmt.query_map([], |row| row.get::<_, String>(0))
+                    .ok()
+                    .map(|rows| rows.filter_map(|r| r.ok()).collect())
+            })
+            .unwrap_or_default()
     }
 
     pub fn remove(&self, id: &str) -> AppResult<()> {
@@ -192,3 +234,6 @@ impl DataStore for AiGenerationStore {
         Ok(count)
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/apps/tauri/src-tauri/src/ai_generations/test.rs
+++ b/apps/tauri/src-tauri/src/ai_generations/test.rs
@@ -1,0 +1,85 @@
+use super::*;
+use tempfile::TempDir;
+
+fn record(id: &str, job_url: &str) -> AiGenerationRecord {
+    AiGenerationRecord {
+        id: id.into(),
+        created_at: now_ms(),
+        candidate_name: "Jane".into(),
+        job_title: "Engineer".into(),
+        company_name: "Acme".into(),
+        resume_language: "en".into(),
+        job_ad_language: "en".into(),
+        target_language: "en".into(),
+        mismatch: false,
+        top_requirements: vec!["rust".into()],
+        mode: "ats".into(),
+        resume_text: "R".into(),
+        cover_letter_text: "C".into(),
+        job_ad: "JD".into(),
+        job_url: job_url.into(),
+        board: "linkedin".into(),
+    }
+}
+
+#[test]
+fn insert_round_trips_the_job_link() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    store
+        .insert(&record("g1", "https://acme.com/job/1"))
+        .unwrap();
+
+    let list = store.list();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].job_url, "https://acme.com/job/1");
+    assert_eq!(list[0].board, "linkedin");
+}
+
+#[test]
+fn applied_job_urls_returns_only_non_empty_links() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    store
+        .insert(&record("g1", "https://acme.com/job/1"))
+        .unwrap();
+    store
+        .insert(&record("g2", "https://acme.com/job/2"))
+        .unwrap();
+    store.insert(&record("g3", "")).unwrap(); // manual generation, no job link
+
+    let urls = store.applied_job_urls();
+    assert_eq!(urls.len(), 2);
+    assert!(urls.contains("https://acme.com/job/1"));
+    assert!(urls.contains("https://acme.com/job/2"));
+    assert!(!urls.contains(""));
+}
+
+#[test]
+fn migration_defaults_link_fields_for_legacy_records() {
+    // A record exported before the link columns existed (no jobUrl/board) must
+    // import via serde defaults, not fail.
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    let legacy = serde_json::json!([{
+        "id": "old-1",
+        "createdAt": 1,
+        "candidateName": "Jane",
+        "jobTitle": "Engineer",
+        "companyName": "Acme",
+        "resumeLanguage": "en",
+        "jobAdLanguage": "en",
+        "targetLanguage": "en",
+        "mismatch": false,
+        "topRequirements": [],
+        "mode": "ats",
+        "resumeText": "",
+        "coverLetterText": "",
+        "jobAd": ""
+    }]);
+    let n = crate::data_store::DataStore::import(&store, &legacy).unwrap();
+    assert_eq!(n, 1);
+    let list = store.list();
+    assert_eq!(list[0].job_url, "");
+    assert_eq!(list[0].board, "");
+}

--- a/apps/tauri/src-tauri/src/autopilot/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot/mod.rs
@@ -64,6 +64,16 @@ pub struct FoundJob {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<f64>,
     pub found_at: u64,
+    /// First surfaced in the most recent run (set by the dedup merge in
+    /// [`AutopilotStore::record_run`]). Drives the "New" badge.
+    #[serde(default)]
+    pub is_new: bool,
+    /// Whether the user has generated an application for this job. **Derived** at
+    /// read time from a saved generation whose `job_url` matches `url` (see
+    /// `commands::autopilot`), never hand-set, so it can't drift. Stored value is
+    /// always `false`; the read path fills it in.
+    #[serde(default)]
+    pub applied: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -232,7 +242,10 @@ impl AutopilotStore {
         self.save(map);
     }
 
-    /// Persist the outcome of a run: counts, the found-jobs list, and last-run time.
+    /// Persist the outcome of a run: counts, last-run time, and the found-jobs
+    /// list **merged** with prior runs by URL — so re-running keeps history
+    /// (first-seen + any state) instead of replacing it, and genuinely new
+    /// postings are flagged `is_new`.
     pub fn record_run(
         &self,
         id: &str,
@@ -245,7 +258,7 @@ impl AutopilotStore {
             let now = now_ms();
             ap.total_found = total_found;
             ap.total_applied = total_applied;
-            ap.found_jobs = found_jobs;
+            ap.found_jobs = merge_found_jobs(&ap.found_jobs, found_jobs);
             ap.last_run_at = Some(now);
             ap.updated_at = now;
         }
@@ -314,6 +327,58 @@ fn str_field(v: &serde_json::Value, key: &str) -> String {
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string()
+}
+
+/// Merge a fresh run's postings into the cumulative found-jobs list, idempotently:
+///
+/// - existing rows are kept (preserving `found_at`/first-seen) and have `is_new`
+///   cleared; if the run re-surfaced them, volatile fields (title/company/
+///   description/score/location) are refreshed,
+/// - postings whose URL was never seen are appended and flagged `is_new`.
+///
+/// Re-running with the same postings yields the same set — only `is_new` moves.
+/// `applied` is derived on read, so it is left at its default here.
+fn merge_found_jobs(existing: &[FoundJob], incoming: Vec<FoundJob>) -> Vec<FoundJob> {
+    use std::collections::HashMap;
+
+    let incoming_by_url: HashMap<&str, &FoundJob> =
+        incoming.iter().map(|j| (j.url.as_str(), j)).collect();
+
+    let mut merged: Vec<FoundJob> = existing
+        .iter()
+        .map(|e| {
+            let mut row = e.clone();
+            row.is_new = false;
+            if let Some(inc) = incoming_by_url.get(e.url.as_str()) {
+                row.title = inc.title.clone();
+                row.company = inc.company.clone();
+                if inc.location.is_some() {
+                    row.location = inc.location.clone();
+                }
+                if inc.description.is_some() {
+                    row.description = inc.description.clone();
+                }
+                if inc.score.is_some() {
+                    row.score = inc.score;
+                }
+            }
+            row
+        })
+        .collect();
+
+    let existing_urls: std::collections::HashSet<&str> =
+        existing.iter().map(|j| j.url.as_str()).collect();
+    for inc in incoming {
+        if !existing_urls.contains(inc.url.as_str()) {
+            merged.push(FoundJob {
+                is_new: true,
+                applied: false,
+                ..inc
+            });
+        }
+    }
+
+    merged
 }
 
 impl crate::data_store::DataStore for AutopilotStore {

--- a/apps/tauri/src-tauri/src/autopilot/test.rs
+++ b/apps/tauri/src-tauri/src/autopilot/test.rs
@@ -99,3 +99,58 @@ fn test_data_store_export_import_preserves_id() {
     assert_eq!(list[0].id, id); // id preserved across restore
     assert_eq!(list[0].name, "Test AP");
 }
+
+fn found_job(url: &str, found_at: u64) -> FoundJob {
+    FoundJob {
+        title: "Engineer".into(),
+        company: "Acme".into(),
+        url: url.into(),
+        location: None,
+        description: None,
+        score: None,
+        found_at,
+        is_new: false,
+        applied: false,
+    }
+}
+
+#[test]
+fn merge_dedups_by_url_preserving_first_seen_and_flagging_new() {
+    let existing = vec![found_job("https://a.com/1", 100)];
+    let incoming = vec![
+        found_job("https://a.com/1", 999), // re-surfaced — keep found_at=100
+        found_job("https://a.com/2", 200), // genuinely new
+    ];
+
+    let merged = merge_found_jobs(&existing, incoming);
+
+    assert_eq!(merged.len(), 2, "no duplicate row for the same url");
+    let a1 = merged.iter().find(|j| j.url == "https://a.com/1").unwrap();
+    assert_eq!(a1.found_at, 100, "first-seen time preserved");
+    assert!(!a1.is_new, "an existing job is not new");
+    let a2 = merged.iter().find(|j| j.url == "https://a.com/2").unwrap();
+    assert!(a2.is_new, "a never-seen url is flagged new");
+}
+
+#[test]
+fn merge_is_idempotent_on_a_repeated_run() {
+    let first = merge_found_jobs(&[], vec![found_job("u1", 1), found_job("u2", 2)]);
+    assert!(first.iter().all(|j| j.is_new));
+
+    // Re-running with the same postings yields the same set; only is_new clears.
+    let second = merge_found_jobs(&first, vec![found_job("u1", 9), found_job("u2", 9)]);
+    assert_eq!(second.len(), 2);
+    assert!(second.iter().all(|j| !j.is_new));
+}
+
+#[test]
+fn merge_keeps_prior_jobs_not_in_the_new_run() {
+    let existing = vec![found_job("old", 1)];
+    let merged = merge_found_jobs(&existing, vec![found_job("fresh", 2)]);
+    assert_eq!(
+        merged.len(),
+        2,
+        "prior finds are retained, new ones appended"
+    );
+    assert!(merged.iter().any(|j| j.url == "old"));
+}

--- a/apps/tauri/src-tauri/src/commands/ai_generations.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_generations.rs
@@ -28,6 +28,8 @@ pub async fn ai_generations_save(app: AppHandle, req: AiGenerationSaveRequest) -
         resume_text: req.resume_text,
         cover_letter_text: req.cover_letter_text,
         job_ad: req.job_ad,
+        job_url: req.job_url,
+        board: req.board,
     };
 
     match store.insert(&rec) {

--- a/apps/tauri/src-tauri/src/commands/autopilot.rs
+++ b/apps/tauri/src-tauri/src/commands/autopilot.rs
@@ -34,15 +34,39 @@ fn store(app: &AppHandle) -> Arc<Mutex<AutopilotStore>> {
     app.state::<Arc<Mutex<AutopilotStore>>>().inner().clone()
 }
 
+/// Fill each found job's `applied` from the set of `job_url`s that have a saved
+/// generation — so the badge reflects a real link (a generation exists for that
+/// job) rather than a hand-set flag that could drift.
+fn enrich_applied(app: &AppHandle, list: &mut [crate::autopilot::Autopilot]) {
+    let applied = app
+        .try_state::<crate::ai_generations::AiGenerationStore>()
+        .map(|s| s.applied_job_urls())
+        .unwrap_or_default();
+    if applied.is_empty() {
+        return;
+    }
+    for ap in list.iter_mut() {
+        for job in ap.found_jobs.iter_mut() {
+            job.applied = applied.contains(&job.url);
+        }
+    }
+}
+
 #[tauri::command]
 pub fn autopilot_list(app: AppHandle) -> Value {
-    let list = store(&app).lock().list();
+    let mut list = store(&app).lock().list();
+    enrich_applied(&app, &mut list);
     json!(list)
 }
 
 #[tauri::command]
 pub fn autopilot_get(app: AppHandle, autopilot_id: String) -> Value {
-    let ap = store(&app).lock().get(&autopilot_id);
+    let ap = store(&app).lock().get(&autopilot_id).map(|a| {
+        let mut one = [a];
+        enrich_applied(&app, &mut one);
+        let [ap] = one;
+        ap
+    });
     json!(ap)
 }
 
@@ -163,6 +187,9 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
                 description: p.description.clone(),
                 score,
                 found_at,
+                // Set by the dedup merge in `record_run`; `applied` is derived on read.
+                is_new: false,
+                applied: false,
             }
         })
         .collect();

--- a/apps/tauri/src-tauri/src/ipc_contracts/ai.rs
+++ b/apps/tauri/src-tauri/src/ipc_contracts/ai.rs
@@ -63,6 +63,10 @@ pub struct AiGenerationSaveRequest {
     pub cover_letter_text: String,
     #[serde(default = "default_ai_generation_save_request_job_ad")]
     pub job_ad: String,
+    #[serde(default = "default_ai_generation_save_request_job_url")]
+    pub job_url: String,
+    #[serde(default = "default_ai_generation_save_request_board")]
+    pub board: String,
 }
 
 fn default_ai_generation_save_request_candidate_name() -> String {
@@ -110,5 +114,13 @@ fn default_ai_generation_save_request_cover_letter_text() -> String {
 }
 
 fn default_ai_generation_save_request_job_ad() -> String {
+    "".to_string()
+}
+
+fn default_ai_generation_save_request_job_url() -> String {
+    "".to_string()
+}
+
+fn default_ai_generation_save_request_board() -> String {
     "".to_string()
 }

--- a/packages/shared/src/ipc/contracts/aiGenerations.ts
+++ b/packages/shared/src/ipc/contracts/aiGenerations.ts
@@ -13,6 +13,10 @@ export interface AiGenerationRecord {
   resumeText: string;
   coverLetterText: string;
   jobAd: string;
+  /** The job this generation targets — links the record to an autopilot found job. */
+  jobUrl: string;
+  /** The board the job came from (e.g. "linkedin"). */
+  board: string;
 }
 
 export interface AiGenerationSaveRequest {
@@ -28,6 +32,10 @@ export interface AiGenerationSaveRequest {
   resumeText: string;
   coverLetterText: string;
   jobAd: string;
+  /** The job this generation targets (marks the autopilot found job "applied"). */
+  jobUrl?: string;
+  /** The board the job came from. */
+  board?: string;
 }
 
 export interface AiGenerationsContract {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -162,6 +162,10 @@ export const AiGenerationSaveSchema = z.object({
   resumeText: z.string().default(''),
   coverLetterText: z.string().default(''),
   jobAd: z.string().default(''),
+  // Application link — the job this generation targets and the board it came
+  // from. `jobUrl` is what marks an autopilot found job as "applied".
+  jobUrl: z.string().default(''),
+  board: z.string().default(''),
 });
 // Note: the `AiGenerationSaveRequest` type is declared in the aiGenerations IPC
 // contract (single source for that name); this schema validates the same shape.

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -237,6 +237,11 @@ export interface AutopilotFoundJob {
   /** Match score (0–100) when the posting passed ranking. */
   score?: number;
   foundAt: number;
+  /** First surfaced in the most recent run — drives the "New" badge. */
+  isNew?: boolean;
+  /** The user has generated an application for this job (derived from a saved
+   *  generation whose `jobUrl` matches `url`). Drives the "Applied" badge. */
+  applied?: boolean;
 }
 
 /** Result record for a single autopilot run. */


### PR DESCRIPTION
## Problem

Re-running an autopilot **replaced** its found-jobs list wholesale (`record_run` overwrote the array), so prior context was lost and there was no way to tell new postings from already-seen ones, or which jobs the user had applied to.

## Fix (backend — the data model)

- **Dedup/merge by URL.** `record_run` now merges via an idempotent `merge_found_jobs`: existing rows keep their first-seen time (and re-running refreshes title/company/description/score); genuinely new URLs are appended and flagged `is_new`. Re-running the same set only moves `is_new`.
- **New `FoundJob` fields.** `is_new` (persisted by the merge) and `applied`.
- **`applied` is derived, not stored.** `autopilot_list` / `autopilot_get` fill it from the set of generation `job_url`s (`applied_job_urls()`), so it reflects a **real link** (a generation exists for that job) and can't drift.
- **`ai_generations` = the "application" record.** An additive migration adds `job_url` + `board` (indexed); the save command persists them. Old rows/exports default the new fields → backward-compatible.

## Shared

`AutopilotFoundJob.isNew/applied`, `AiGenerationSaveRequest.jobUrl/board`, the record type; Rust contract regenerated.

## Scope

This is **D-7a** (Rust dedup/stores/migration). The renderer wiring — **New/Applied badges**, the **Applications/History** view, and saving an autopilot generation with its `jobUrl` — lands in **D-7b**. Existing save calls omit `jobUrl` (optional), so nothing breaks meanwhile.

## Tests

- `merge_found_jobs`: dedups by URL, preserves first-seen, flags new, idempotent on repeat, retains prior finds.
- `ai_generations`: round-trips the link, `applied_job_urls` ignores empty links, a legacy export imports via defaults.
- Rust 704 tests + clippy + fmt; TS typecheck + lint:strict — green.

## Review routing
Primary: **scraping-applier-expert** · Secondary: **rust-backend-architect**, **tauri-security-reviewer**. Part D-7a of the multi-PR plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)