### PR TITLE
feat: badge new/applied autopilot jobs and link generations to applications (D-7b)

### DIFF
--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
@@ -18,6 +18,8 @@ interface Props {
   job: AutopilotFoundJob;
   /** The resume the autopilot used — pre-fills the resume input. */
   resumeText?: string;
+  /** The board this autopilot searches — stored on the saved application record. */
+  board: string;
   onClose: () => void;
 }
 
@@ -25,7 +27,7 @@ interface Props {
  * Tailor a resume / cover letter for a single autopilot-found job, inline.
  * Reuses the AI Generate primitives so the user never leaves the Autopilot page.
  */
-export function ApplyJobModal({ job, resumeText, onClose }: Props) {
+export function ApplyJobModal({ job, resumeText, board, onClose }: Props) {
   const { t } = useTranslation();
   const model = useSelectedModel();
   const { canUse, reason } = useCanUseAI();
@@ -51,6 +53,8 @@ export function ApplyJobModal({ job, resumeText, onClose }: Props) {
     model,
     canUse,
     hasDesc,
+    jobUrl: job.url,
+    board,
   });
 
   // Closing the modal no longer cancels — generation finishes in the background

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.test.ts
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.test.ts
@@ -1,4 +1,6 @@
+import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 
 import { useGenerationStore } from '@/store/generation-store';
@@ -7,6 +9,12 @@ import { useTailorGeneration } from './useTailorGeneration';
 
 // i18n: identity translator so phaseLabel resolves without the i18n runtime.
 vi.mock('@/lib/i18n', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+// Capture the saved application record so we can assert the job link is attached.
+const save = vi.fn().mockResolvedValue({ id: 'gen-1', success: true });
+vi.mock('@/providers/AppClientProvider', () => ({
+  useAppClient: () => ({ aiGenerations: { save } }),
+}));
 
 // Stub the generation pipeline. Resume/cover stubs emit a reasoning token via
 // the `onThinking` callback (last arg) so we can assert it threads through.
@@ -67,14 +75,25 @@ const params = {
   model: 'llama',
   canUse: true,
   hasDesc: true,
+  jobUrl: 'https://acme.com/job/42',
+  board: 'linkedin',
 };
+
+// useTailorGeneration uses useQueryClient (to invalidate after save), so the hook
+// must render under a QueryClientProvider.
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(QueryClientProvider, { client: new QueryClient() }, children);
+const render = (p = params) => renderHook(() => useTailorGeneration(p), { wrapper });
 
 describe('useTailorGeneration', () => {
   // The session lives in the shared store — reset it so tests don't leak state.
-  beforeEach(() => useGenerationStore.setState({ sessions: {} }));
+  beforeEach(() => {
+    useGenerationStore.setState({ sessions: {} });
+    save.mockClear();
+  });
 
   it('starts idle with empty buffers', () => {
-    const { result } = renderHook(() => useTailorGeneration(params));
+    const { result } = render();
     expect(result.current.phase).toBe('idle');
     expect(result.current.resumeOut).toBe('');
     expect(result.current.coverOut).toBe('');
@@ -82,7 +101,7 @@ describe('useTailorGeneration', () => {
   });
 
   it('threads reasoning into `thinking`, clearing it between phases', async () => {
-    const { result } = renderHook(() => useTailorGeneration(params));
+    const { result } = render();
 
     await act(async () => {
       await result.current.generate('my resume', 'both');
@@ -95,12 +114,33 @@ describe('useTailorGeneration', () => {
     expect(result.current.phase).toBe('idle');
   });
 
-  it('does not generate when AI is unavailable', async () => {
-    const { result } = renderHook(() => useTailorGeneration({ ...params, canUse: false }));
+  it('saves the application linked to the job url + board after a clean run', async () => {
+    const { result } = render();
+
+    await act(async () => {
+      await result.current.generate('my resume', 'both');
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobUrl: 'https://acme.com/job/42',
+        board: 'linkedin',
+        jobAd: 'JD',
+        resumeText: 'RESUME',
+        coverLetterText: 'COVER',
+        mode: 'ats',
+      })
+    );
+  });
+
+  it('does not generate or save when AI is unavailable', async () => {
+    const { result } = render({ ...params, canUse: false });
     await act(async () => {
       await result.current.generate('my resume', 'resume');
     });
     expect(result.current.resumeOut).toBe('');
     expect(result.current.generating).toBe(false);
+    expect(save).not.toHaveBeenCalled();
   });
 });

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.ts
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import {
   buildFilename,
@@ -10,7 +11,14 @@ import {
   type TemplateId,
 } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
-import { EMPTY_SESSION, type TailorTarget, useGenerationStore } from '@/store/generation-store';
+import { useAppClient } from '@/providers/AppClientProvider';
+import { keys } from '@/services/query-client';
+import {
+  EMPTY_SESSION,
+  type GenerationResult,
+  type TailorTarget,
+  useGenerationStore,
+} from '@/store/generation-store';
 
 export type { TailorTarget };
 
@@ -25,6 +33,11 @@ interface Params {
   model: string;
   canUse: boolean;
   hasDesc: boolean;
+  /** The found job's URL — links the saved generation to it so the backend
+   *  derives the "Applied" badge from a matching `jobUrl`. */
+  jobUrl: string;
+  /** The board the job came from (e.g. "linkedin"), stored on the record. */
+  board: string;
 }
 
 /**
@@ -33,8 +46,18 @@ interface Params {
  * only selects the session and keeps modal-local UI state (copy/export). Closing
  * the modal no longer aborts — generation continues and reappears on reopen.
  */
-export function useTailorGeneration({ contextId, jobDesc, model, canUse, hasDesc }: Params) {
+export function useTailorGeneration({
+  contextId,
+  jobDesc,
+  model,
+  canUse,
+  hasDesc,
+  jobUrl,
+  board,
+}: Params) {
   const { t } = useTranslation();
+  const api = useAppClient();
+  const qc = useQueryClient();
 
   const session = useGenerationStore((s) => s.sessions[contextId] ?? EMPTY_SESSION);
   const runTailor = useGenerationStore((s) => s.runTailor);
@@ -49,9 +72,50 @@ export function useTailorGeneration({ contextId, jobDesc, model, canUse, hasDesc
 
   const output = activeOut === 'resume' ? resumeOut : coverOut;
 
+  // Persist the finished application linked to this job. Called by the store on a
+  // clean run — bypasses the React Query mutation hook (which the modal may have
+  // unmounted) and talks to the client directly, so a background generation still
+  // records and flips the job to "Applied". Best-effort: a save failure never
+  // surfaces over the already-shown output.
+  const persist = ({ meta: m, resumeText, coverLetterText }: GenerationResult) => {
+    void api.aiGenerations
+      .save({
+        candidateName: m.candidateName,
+        jobTitle: m.jobTitle,
+        companyName: m.companyName,
+        resumeLanguage: m.resumeLanguage,
+        jobAdLanguage: m.jobAdLanguage,
+        targetLanguage: m.targetLanguage,
+        mismatch: m.mismatch,
+        topRequirements: m.topRequirements,
+        mode: MODE,
+        resumeText,
+        coverLetterText,
+        jobAd: jobDesc,
+        jobUrl,
+        board,
+      })
+      .then(() => {
+        void qc.invalidateQueries({ queryKey: keys.aiGenerations.all });
+        void qc.invalidateQueries({ queryKey: keys.autopilot.all });
+      })
+      .catch(() => {
+        /* best-effort persistence — the generation is already shown to the user */
+      });
+  };
+
   const generate = (resume: string, target: TailorTarget) => {
     if (!canUse || !hasDesc) return Promise.resolve();
-    return runTailor({ contextId, resume, jobDesc, model, mode: MODE, target, t });
+    return runTailor({
+      contextId,
+      resume,
+      jobDesc,
+      model,
+      mode: MODE,
+      target,
+      t,
+      onComplete: persist,
+    });
   };
 
   const abort = () => cancel(contextId);

--- a/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -1,5 +1,6 @@
 import {
   Briefcase,
+  Check,
   ChevronUp,
   ExternalLink,
   Pause,
@@ -224,7 +225,21 @@ export function AutopilotCard({
                       className="flex min-w-0 flex-1 items-center gap-2 text-left"
                     >
                       <div className="min-w-0 flex-1">
-                        <div className="truncate text-[11px] text-foreground/80">{job.title}</div>
+                        <div className="flex items-center gap-1.5">
+                          <span className="truncate text-[11px] text-foreground/80">
+                            {job.title}
+                          </span>
+                          {job.isNew && (
+                            <span className="shrink-0 rounded-full bg-brand/15 px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-wider text-brand-soft">
+                              {t('autopilot.badge.new')}
+                            </span>
+                          )}
+                          {job.applied && (
+                            <span className="flex shrink-0 items-center gap-0.5 rounded-full bg-emerald-400/15 px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-wider text-emerald-300">
+                              <Check size={8} /> {t('autopilot.badge.applied')}
+                            </span>
+                          )}
+                        </div>
                         <div className="flex items-center gap-1.5 text-[10px] text-foreground/40">
                           <span className="truncate">{job.company}</span>
                           {job.location && <span className="truncate">· {job.location}</span>}
@@ -256,6 +271,7 @@ export function AutopilotCard({
         <ApplyJobModal
           job={applyJob}
           resumeText={ap.resumeText}
+          board={ap.target.board}
           onClose={() => setApplyJob(null)}
         />
       )}

--- a/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
@@ -1,9 +1,11 @@
 import {
   Building2,
   Calendar,
+  Check,
   ChevronDown,
   Copy,
   Download,
+  ExternalLink,
   FileText,
   Loader2,
   Trash2,
@@ -17,6 +19,7 @@ import { Button, cn, transition } from '@ajh/ui';
 
 import { buildFilename, exportDOCX, exportPDF, exportTXT, type TemplateId } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
+import { useOpenExternal } from '@/services';
 import { useRemoveAiGeneration } from '@/services/use-ai-generations';
 
 const EXPORT_FORMATS = ['pdf', 'docx', 'txt'] as const;
@@ -35,6 +38,7 @@ interface GenerationCardProps {
 export function GenerationCard({ gen }: GenerationCardProps) {
   const { t } = useTranslation();
   const removeAiGeneration = useRemoveAiGeneration();
+  const openExternal = useOpenExternal();
   const [expanded, setExpanded] = useState<'resume' | 'cover' | 'jobAd' | null>(null);
   const [copied, setCopied] = useState<'resume' | 'cover' | null>(null);
   const [exportFormat, setExportFormat] = useState<ExportFormat>('pdf');
@@ -122,6 +126,28 @@ export function GenerationCard({ gen }: GenerationCardProps) {
             <span className="rounded-full border border-brand/20 bg-brand/8 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-brand-soft">
               {gen.mode}
             </span>
+            {gen.board && (
+              <span className="rounded-full border border-white/[0.06] bg-white/[0.03] px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-foreground/45">
+                {gen.board}
+              </span>
+            )}
+            {/* A linked job means this generation was an application — surface the
+                "Applied" state and a link back to the original posting. */}
+            {gen.jobUrl && (
+              <span className="flex items-center gap-0.5 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-emerald-300">
+                <Check size={9} /> {t('resumes.generated.applied')}
+              </span>
+            )}
+            {gen.jobUrl && (
+              <button
+                type="button"
+                onClick={() => void openExternal.mutate(gen.jobUrl)}
+                title={t('resumes.generated.openPosting')}
+                className="flex items-center gap-1 text-foreground/35 transition-colors hover:text-brand-soft"
+              >
+                <ExternalLink size={10} /> {t('resumes.generated.openPosting')}
+              </button>
+            )}
           </div>
         </div>
 

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -542,6 +542,10 @@
     "collapse": "Einklappen",
     "viewJob": "Anzeige öffnen",
     "applyJob": "Bewerben",
+    "badge": {
+      "new": "Neu",
+      "applied": "Beworben"
+    },
     "apply": {
       "jobDescription": "Stellenbeschreibung",
       "noDescription": "Für diesen Job wurde keine Beschreibung erfasst.",
@@ -849,7 +853,9 @@
       "noCoverLetter": "Kein Anschreiben generiert",
       "export": "Exportieren",
       "exportResume": "Lebenslauf",
-      "exportCoverLetter": "Anschreiben"
+      "exportCoverLetter": "Anschreiben",
+      "applied": "Beworben",
+      "openPosting": "Anzeige öffnen"
     },
     "relativeTime": {
       "justNow": "Gerade eben",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -542,6 +542,10 @@
     "collapse": "Collapse",
     "viewJob": "Open posting",
     "applyJob": "Apply",
+    "badge": {
+      "new": "New",
+      "applied": "Applied"
+    },
     "apply": {
       "jobDescription": "Job description",
       "noDescription": "No description was captured for this job.",
@@ -849,7 +853,9 @@
       "noCoverLetter": "No cover letter generated",
       "export": "Export",
       "exportResume": "Resume",
-      "exportCoverLetter": "Cover Letter"
+      "exportCoverLetter": "Cover Letter",
+      "applied": "Applied",
+      "openPosting": "Open posting"
     },
     "relativeTime": {
       "justNow": "Just now",

--- a/apps/tauri/src/renderer/store/generation-store/generation-store.test.ts
+++ b/apps/tauri/src/renderer/store/generation-store/generation-store.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { generateResume } from '@/lib/generate';
+
 import { EMPTY_SESSION, useGenerationStore } from './generation-store';
 
 // Stub the generation pipeline; resume/cover emit one reasoning + one content token.
@@ -95,5 +97,30 @@ describe('generation store', () => {
     useGenerationStore.setState({ sessions: { [id]: { ...EMPTY_SESSION, resumeOut: 'X' } } });
     useGenerationStore.getState().reset(id);
     expect(useGenerationStore.getState().getSession(id)).toBe(EMPTY_SESSION);
+  });
+
+  it('calls onComplete with the finished documents + metadata after a clean run', async () => {
+    const onComplete = vi.fn();
+    await useGenerationStore
+      .getState()
+      .runTailor({ contextId: 'c1', target: 'both', onComplete, ...base });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({
+      meta: expect.objectContaining({ resumeLanguage: 'en' }),
+      resumeText: 'RESUME',
+      coverLetterText: 'COVER',
+    });
+  });
+
+  it('does not call onComplete when the run fails (so a failed application is never saved)', async () => {
+    vi.mocked(generateResume).mockRejectedValueOnce(new Error('boom'));
+    const onComplete = vi.fn();
+    await useGenerationStore
+      .getState()
+      .runTailor({ contextId: 'c2', target: 'resume', onComplete, ...base });
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(useGenerationStore.getState().getSession('c2').error).toBe('boom');
   });
 });

--- a/apps/tauri/src/renderer/store/generation-store/generation-store.ts
+++ b/apps/tauri/src/renderer/store/generation-store/generation-store.ts
@@ -43,6 +43,13 @@ export const EMPTY_SESSION: GenerationSession = {
   meta: null,
 };
 
+/** The finished documents + detected metadata, handed to {@link RunTailorParams.onComplete}. */
+export interface GenerationResult {
+  meta: GenerationMeta;
+  resumeText: string;
+  coverLetterText: string;
+}
+
 export interface RunTailorParams {
   contextId: string;
   resume: string;
@@ -52,6 +59,13 @@ export interface RunTailorParams {
   target: TailorTarget;
   /** Translator for the failure message. */
   t: (key: string) => string;
+  /**
+   * Called once after a run completes successfully (not on cancel/error). The
+   * store stays a pure state container — persistence (e.g. saving the application
+   * record) lives in the caller. Fires even if the originating component has
+   * unmounted, so a background generation still records its result.
+   */
+  onComplete?: (result: GenerationResult) => void;
 }
 
 interface GenerationStore {
@@ -105,7 +119,7 @@ export const useGenerationStore = create<GenerationStore>((set, get) => {
         return { sessions: next };
       }),
 
-    runTailor: async ({ contextId: id, resume, jobDesc, model, mode, target, t }) => {
+    runTailor: async ({ contextId: id, resume, jobDesc, model, mode, target, t, onComplete }) => {
       if (get().sessions[id]?.generating || !resume.trim()) return;
 
       const controller = new AbortController();
@@ -125,9 +139,12 @@ export const useGenerationStore = create<GenerationStore>((set, get) => {
         const detected = await extractMetadata(resume, jobDesc, model);
         patch(id, { meta: detected });
 
+        let resumeText = '';
+        let coverLetterText = '';
+
         if (target === 'resume' || target === 'both') {
           patch(id, { activeOut: 'resume', phase: 'resume', thinking: '' });
-          const r = await generateResume(
+          resumeText = await generateResume(
             resume,
             jobDesc,
             detected,
@@ -138,12 +155,12 @@ export const useGenerationStore = create<GenerationStore>((set, get) => {
             controller.signal,
             onThink
           );
-          patch(id, { resumeOut: r });
+          patch(id, { resumeOut: resumeText });
         }
 
         if (target === 'cover' || target === 'both') {
           patch(id, { activeOut: 'cover', phase: 'cover', thinking: '' });
-          const c = await generateCoverLetter(
+          coverLetterText = await generateCoverLetter(
             resume,
             jobDesc,
             detected,
@@ -154,8 +171,11 @@ export const useGenerationStore = create<GenerationStore>((set, get) => {
             controller.signal,
             onThink
           );
-          patch(id, { coverOut: c });
+          patch(id, { coverOut: coverLetterText });
         }
+
+        // Persist after a clean run only — a cancel/error throws and skips this.
+        onComplete?.({ meta: detected, resumeText, coverLetterText });
       } catch (err) {
         patch(id, { error: err instanceof Error ? err.message : t('autopilot.apply.failed') });
       } finally {


### PR DESCRIPTION
## D-7b — applied/new badges + Applications/History view

Renders the dedup + applied-state model landed in **D-7a (#210)** and closes the loop: the autopilot **Apply Job** flow now persists its generation linked to the job, so found jobs actually flip to **Applied**.

### What changed
- **Found-jobs badges** (`AutopilotCard`) — each found-job row shows a **New** badge (`isNew`) and an emerald **Applied** badge (`applied`), driven by the `AutopilotFoundJob` fields the backend derives from the generation `jobUrl` link.
- **Persist the application** (`useTailorGeneration` + generation store) — on a clean run the tailor flow saves the generation with `jobUrl` + `board`. A new optional `onComplete` callback on `runTailor` keeps the store a **pure state container** (persistence lives in the caller). The save bypasses the React Query mutation hook and talks to the client directly, so a **background** generation (modal closed / navigated away) still records its result and invalidates the autopilot + history queries.
- **Applications/History view** (`GenerationCard` on the Résumés → Generated tab) — surfaces the **board** chip, an **Applied** badge, and an **Open posting** link whenever a record carries a `jobUrl`.
- **i18n** — `autopilot.badge.{new,applied}` + `resumes.generated.{applied,openPosting}` in `en` + `de`.

### Future-proof / architecture
- `applied` is **derived** from a real link (a saved generation's `jobUrl` matching a found job's `url`) — no hand-set flag to drift, consistent with D-7a.
- The generation store stays the **single** generation-session source of truth and remains business-logic-free; saving is injected by the caller, so every surface keeps one contract.
- Save is best-effort and unmount-safe — preserves the D-3 background-completion behaviour.

### Tests
- Store: `onComplete` fires with the finished documents + metadata on a clean run, and **not** when the run fails (a failed application is never saved).
- Hook: saves the record with `jobUrl`/`board`/`jobAd` after a clean run; **no** save when AI is unavailable.

### Gates
- `pnpm typecheck --force` ✅ · `pnpm lint:strict` (`--max-warnings 0`) ✅ · vitest (11 tests, store + hook) ✅. Frontend-only — no Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)