### PR TITLE
feat: persist application answers as a per-job application aggregate (D-1b)

### DIFF
--- a/apps/tauri/src-tauri/src/ai_generations/mod.rs
+++ b/apps/tauri/src-tauri/src/ai_generations/mod.rs
@@ -10,6 +10,14 @@ use crate::data_store::DataStore;
 use crate::db::{run_migrations, Migration};
 use crate::error::AppResult;
 
+/// One answered application question, stored on the application record.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ApplicationAnswer {
+    pub id: String,
+    pub question: String,
+    pub answer: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiGenerationRecord {
     pub id: String,
@@ -47,6 +55,12 @@ pub struct AiGenerationRecord {
     pub job_url: String,
     #[serde(default)]
     pub board: String,
+    // Application extras — answered questions and the company-research brief used,
+    // so the record is the full auditable application aggregate. Stored as JSON.
+    #[serde(rename = "applicationAnswers", default)]
+    pub application_answers: Vec<ApplicationAnswer>,
+    #[serde(rename = "companyBrief", default)]
+    pub company_brief: String,
 }
 
 pub struct AiGenerationStore {
@@ -91,6 +105,17 @@ impl AiGenerationStore {
                 )
             },
         },
+        // Additive: the answered application questions and the company-research
+        // brief used, completing the application aggregate. Old rows default empty.
+        Migration {
+            name: "add_application_answers",
+            up: |conn| {
+                conn.execute_batch(
+                    "ALTER TABLE ai_generations ADD COLUMN application_answers TEXT NOT NULL DEFAULT '[]';
+                     ALTER TABLE ai_generations ADD COLUMN company_brief       TEXT NOT NULL DEFAULT '';",
+                )
+            },
+        },
     ];
 
     pub fn open(data_dir: &PathBuf) -> AppResult<Self> {
@@ -114,48 +139,47 @@ impl AiGenerationStore {
             "SELECT id, created_at, candidate_name, job_title, company_name,
                     resume_language, job_ad_language, target_language, mismatch,
                     top_requirements, mode, resume_text, cover_letter_text, job_ad,
-                    job_url, board
+                    job_url, board, application_answers, company_brief
              FROM ai_generations ORDER BY created_at DESC",
         )
         .ok()
         .and_then(|mut stmt| {
-            stmt.query_map([], |row| {
-                let top_req_json: String = row.get(9)?;
-                Ok(AiGenerationRecord {
-                    id: row.get(0)?,
-                    created_at: row.get::<_, i64>(1)? as u64,
-                    candidate_name: row.get(2)?,
-                    job_title: row.get(3)?,
-                    company_name: row.get(4)?,
-                    resume_language: row.get(5)?,
-                    job_ad_language: row.get(6)?,
-                    target_language: row.get(7)?,
-                    mismatch: row.get::<_, i64>(8)? != 0,
-                    top_requirements: serde_json::from_str(&top_req_json).unwrap_or_default(),
-                    mode: row.get(10)?,
-                    resume_text: row.get(11)?,
-                    cover_letter_text: row.get(12)?,
-                    job_ad: row.get(13)?,
-                    job_url: row.get(14)?,
-                    board: row.get(15)?,
-                })
-            })
-            .ok()
-            .map(|rows| rows.filter_map(|r| r.ok()).collect())
+            stmt.query_map([], row_to_record)
+                .ok()
+                .map(|rows| rows.filter_map(|r| r.ok()).collect())
         })
         .unwrap_or_default()
     }
 
+    /// Most-recent record linked to `job_url`, if any — the row a per-job save
+    /// merges into so each job keeps one application aggregate.
+    fn find_by_job_url(&self, job_url: &str) -> Option<AiGenerationRecord> {
+        if job_url.is_empty() {
+            return None;
+        }
+        let conn = self.conn.lock();
+        conn.prepare(
+            "SELECT id, created_at, candidate_name, job_title, company_name,
+                    resume_language, job_ad_language, target_language, mismatch,
+                    top_requirements, mode, resume_text, cover_letter_text, job_ad,
+                    job_url, board, application_answers, company_brief
+             FROM ai_generations WHERE job_url = ?1 ORDER BY created_at DESC LIMIT 1",
+        )
+        .ok()
+        .and_then(|mut stmt| stmt.query_row(params![job_url], row_to_record).ok())
+    }
+
     pub fn insert(&self, rec: &AiGenerationRecord) -> AppResult<()> {
         let top_req_json = serde_json::to_string(&rec.top_requirements).unwrap_or_default();
+        let answers_json = serde_json::to_string(&rec.application_answers).unwrap_or_default();
         let conn = self.conn.lock();
         conn.execute(
             "INSERT INTO ai_generations
              (id, created_at, candidate_name, job_title, company_name,
               resume_language, job_ad_language, target_language, mismatch,
               top_requirements, mode, resume_text, cover_letter_text, job_ad,
-              job_url, board)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
+              job_url, board, application_answers, company_brief)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)",
             params![
                 rec.id,
                 rec.created_at as i64,
@@ -173,10 +197,66 @@ impl AiGenerationStore {
                 rec.job_ad,
                 rec.job_url,
                 rec.board,
+                answers_json,
+                rec.company_brief,
             ],
         )
         .map_err(|e| e.to_string())?;
         Ok(())
+    }
+
+    /// Overwrite an existing row by id (used by the per-job merge-upsert).
+    fn update(&self, rec: &AiGenerationRecord) -> AppResult<()> {
+        let top_req_json = serde_json::to_string(&rec.top_requirements).unwrap_or_default();
+        let answers_json = serde_json::to_string(&rec.application_answers).unwrap_or_default();
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE ai_generations SET
+              candidate_name = ?2, job_title = ?3, company_name = ?4,
+              resume_language = ?5, job_ad_language = ?6, target_language = ?7,
+              mismatch = ?8, top_requirements = ?9, mode = ?10, resume_text = ?11,
+              cover_letter_text = ?12, job_ad = ?13, job_url = ?14, board = ?15,
+              application_answers = ?16, company_brief = ?17
+             WHERE id = ?1",
+            params![
+                rec.id,
+                rec.candidate_name,
+                rec.job_title,
+                rec.company_name,
+                rec.resume_language,
+                rec.job_ad_language,
+                rec.target_language,
+                rec.mismatch as i64,
+                top_req_json,
+                rec.mode,
+                rec.resume_text,
+                rec.cover_letter_text,
+                rec.job_ad,
+                rec.job_url,
+                rec.board,
+                answers_json,
+                rec.company_brief,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    /// Save an application generation as a **per-job aggregate**: when it carries
+    /// a `job_url`, merge into that job's existing row ([`merge_application`]) so
+    /// résumé, cover letter, answers, and brief from separate user actions land on
+    /// one record; otherwise insert a fresh row (manual generations with no link).
+    /// Returns the id of the affected row.
+    pub fn save_application(&self, incoming: AiGenerationRecord) -> AppResult<String> {
+        if let Some(existing) = self.find_by_job_url(&incoming.job_url) {
+            let merged = merge_application(existing, incoming);
+            let id = merged.id.clone();
+            self.update(&merged)?;
+            return Ok(id);
+        }
+        let id = incoming.id.clone();
+        self.insert(&incoming)?;
+        Ok(id)
     }
 
     /// Distinct non-empty `job_url`s that have at least one saved generation —
@@ -198,6 +278,72 @@ impl AiGenerationStore {
         conn.execute("DELETE FROM ai_generations WHERE id = ?1", params![id])
             .map_err(|e| e.to_string())?;
         Ok(())
+    }
+}
+
+/// Map a DB row (the full 18-column projection) to a record. Shared by `list`
+/// and `find_by_job_url` so the column order lives in one place.
+fn row_to_record(row: &rusqlite::Row) -> rusqlite::Result<AiGenerationRecord> {
+    let top_req_json: String = row.get(9)?;
+    let answers_json: String = row.get(16)?;
+    Ok(AiGenerationRecord {
+        id: row.get(0)?,
+        created_at: row.get::<_, i64>(1)? as u64,
+        candidate_name: row.get(2)?,
+        job_title: row.get(3)?,
+        company_name: row.get(4)?,
+        resume_language: row.get(5)?,
+        job_ad_language: row.get(6)?,
+        target_language: row.get(7)?,
+        mismatch: row.get::<_, i64>(8)? != 0,
+        top_requirements: serde_json::from_str(&top_req_json).unwrap_or_default(),
+        mode: row.get(10)?,
+        resume_text: row.get(11)?,
+        cover_letter_text: row.get(12)?,
+        job_ad: row.get(13)?,
+        job_url: row.get(14)?,
+        board: row.get(15)?,
+        application_answers: serde_json::from_str(&answers_json).unwrap_or_default(),
+        company_brief: row.get(17)?,
+    })
+}
+
+/// Merge an incoming per-job save into the existing application row: keep the
+/// existing id + first-seen time, and take each incoming field only when it
+/// carries content, so independent saves (résumé, cover, answers, brief) layer
+/// onto one aggregate instead of clobbering each other. Pure — unit-tested.
+fn merge_application(
+    existing: AiGenerationRecord,
+    incoming: AiGenerationRecord,
+) -> AiGenerationRecord {
+    let pick = |inc: String, ex: String| if inc.trim().is_empty() { ex } else { inc };
+    AiGenerationRecord {
+        id: existing.id,
+        created_at: existing.created_at,
+        candidate_name: pick(incoming.candidate_name, existing.candidate_name),
+        job_title: pick(incoming.job_title, existing.job_title),
+        company_name: pick(incoming.company_name, existing.company_name),
+        resume_language: pick(incoming.resume_language, existing.resume_language),
+        job_ad_language: pick(incoming.job_ad_language, existing.job_ad_language),
+        target_language: pick(incoming.target_language, existing.target_language),
+        mismatch: incoming.mismatch || existing.mismatch,
+        top_requirements: if incoming.top_requirements.is_empty() {
+            existing.top_requirements
+        } else {
+            incoming.top_requirements
+        },
+        mode: pick(incoming.mode, existing.mode),
+        resume_text: pick(incoming.resume_text, existing.resume_text),
+        cover_letter_text: pick(incoming.cover_letter_text, existing.cover_letter_text),
+        job_ad: pick(incoming.job_ad, existing.job_ad),
+        job_url: pick(incoming.job_url, existing.job_url),
+        board: pick(incoming.board, existing.board),
+        application_answers: if incoming.application_answers.is_empty() {
+            existing.application_answers
+        } else {
+            incoming.application_answers
+        },
+        company_brief: pick(incoming.company_brief, existing.company_brief),
     }
 }
 

--- a/apps/tauri/src-tauri/src/ai_generations/test.rs
+++ b/apps/tauri/src-tauri/src/ai_generations/test.rs
@@ -19,6 +19,16 @@ fn record(id: &str, job_url: &str) -> AiGenerationRecord {
         job_ad: "JD".into(),
         job_url: job_url.into(),
         board: "linkedin".into(),
+        application_answers: vec![],
+        company_brief: String::new(),
+    }
+}
+
+fn answer(id: &str) -> ApplicationAnswer {
+    ApplicationAnswer {
+        id: id.into(),
+        question: format!("Q-{id}"),
+        answer: format!("A-{id}"),
     }
 }
 
@@ -82,4 +92,76 @@ fn migration_defaults_link_fields_for_legacy_records() {
     let list = store.list();
     assert_eq!(list[0].job_url, "");
     assert_eq!(list[0].board, "");
+    assert!(list[0].application_answers.is_empty());
+    assert_eq!(list[0].company_brief, "");
+}
+
+#[test]
+fn insert_round_trips_answers_and_brief() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    let mut rec = record("g1", "https://acme.com/job/1");
+    rec.application_answers = vec![answer("why-company"), answer("strengths")];
+    rec.company_brief = "Acme builds payment rails.".into();
+    store.insert(&rec).unwrap();
+
+    let list = store.list();
+    assert_eq!(list[0].application_answers, rec.application_answers);
+    assert_eq!(list[0].company_brief, "Acme builds payment rails.");
+}
+
+#[test]
+fn merge_layers_answers_onto_an_existing_cover_without_clobbering() {
+    let mut existing = record("g1", "https://acme.com/job/1");
+    existing.cover_letter_text = "COVER".into();
+    existing.application_answers = vec![];
+
+    // An answers-only save: empty résumé/cover, but carries answers + brief.
+    let mut incoming = record("g2", "https://acme.com/job/1");
+    incoming.resume_text = String::new();
+    incoming.cover_letter_text = String::new();
+    incoming.application_answers = vec![answer("why-company")];
+    incoming.company_brief = "brief".into();
+
+    let merged = merge_application(existing, incoming);
+
+    assert_eq!(merged.id, "g1", "keeps the existing row id");
+    assert_eq!(merged.cover_letter_text, "COVER", "cover is not wiped");
+    assert_eq!(merged.application_answers, vec![answer("why-company")]);
+    assert_eq!(merged.company_brief, "brief");
+}
+
+#[test]
+fn save_application_upserts_by_job_url_into_one_aggregate() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    let url = "https://acme.com/job/1";
+
+    // First the tailor flow saves a résumé/cover for the job.
+    store.save_application(record("g1", url)).unwrap();
+
+    // Then the questions assistant saves answers (no résumé/cover) for the same job.
+    let mut answers_save = record("g2", url);
+    answers_save.resume_text = String::new();
+    answers_save.cover_letter_text = String::new();
+    answers_save.application_answers = vec![answer("why-company")];
+    store.save_application(answers_save).unwrap();
+
+    let list = store.list();
+    assert_eq!(list.len(), 1, "one aggregate row per job");
+    assert_eq!(list[0].cover_letter_text, "C", "cover preserved");
+    assert_eq!(list[0].application_answers, vec![answer("why-company")]);
+}
+
+#[test]
+fn save_application_inserts_separate_rows_when_unlinked() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    store.save_application(record("g1", "")).unwrap();
+    store.save_application(record("g2", "")).unwrap();
+    assert_eq!(
+        store.list().len(),
+        2,
+        "manual (unlinked) saves stay separate"
+    );
 }

--- a/apps/tauri/src-tauri/src/commands/ai_generations.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_generations.rs
@@ -30,10 +30,22 @@ pub async fn ai_generations_save(app: AppHandle, req: AiGenerationSaveRequest) -
         job_ad: req.job_ad,
         job_url: req.job_url,
         board: req.board,
+        application_answers: req
+            .application_answers
+            .into_iter()
+            .map(|a| crate::ai_generations::ApplicationAnswer {
+                id: a.id,
+                question: a.question,
+                answer: a.answer,
+            })
+            .collect(),
+        company_brief: req.company_brief,
     };
 
-    match store.insert(&rec) {
-        Ok(()) => json!({ "id": rec.id, "success": true }),
+    // Per-job aggregate: when linked to a job, merge into that job's row so
+    // résumé/cover/answers/brief from separate actions land on one record.
+    match store.save_application(rec) {
+        Ok(id) => json!({ "id": id, "success": true }),
         Err(e) => json!({ "error": e }),
     }
 }

--- a/apps/tauri/src-tauri/src/ipc_contracts/ai.rs
+++ b/apps/tauri/src-tauri/src/ipc_contracts/ai.rs
@@ -67,6 +67,22 @@ pub struct AiGenerationSaveRequest {
     pub job_url: String,
     #[serde(default = "default_ai_generation_save_request_board")]
     pub board: String,
+    #[serde(default = "default_ai_generation_save_request_application_answers")]
+    pub application_answers: Vec<AiGenerationSaveRequestApplicationAnswer>,
+    #[serde(default = "default_ai_generation_save_request_company_brief")]
+    pub company_brief: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct AiGenerationSaveRequestApplicationAnswer {
+    #[serde(default = "default_ai_generation_save_request_application_answer_id")]
+    pub id: String,
+    #[serde(default = "default_ai_generation_save_request_application_answer_question")]
+    pub question: String,
+    #[serde(default = "default_ai_generation_save_request_application_answer_answer")]
+    pub answer: String,
 }
 
 fn default_ai_generation_save_request_candidate_name() -> String {
@@ -122,5 +138,26 @@ fn default_ai_generation_save_request_job_url() -> String {
 }
 
 fn default_ai_generation_save_request_board() -> String {
+    "".to_string()
+}
+
+fn default_ai_generation_save_request_application_answers(
+) -> Vec<AiGenerationSaveRequestApplicationAnswer> {
+    Vec::new()
+}
+
+fn default_ai_generation_save_request_company_brief() -> String {
+    "".to_string()
+}
+
+fn default_ai_generation_save_request_application_answer_id() -> String {
+    "".to_string()
+}
+
+fn default_ai_generation_save_request_application_answer_question() -> String {
+    "".to_string()
+}
+
+fn default_ai_generation_save_request_application_answer_answer() -> String {
     "".to_string()
 }

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/ApplicationQuestions.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/ApplicationQuestions.tsx
@@ -18,6 +18,8 @@ interface Props {
   meta?: GenerationMeta | null;
   canUse: boolean;
   hasDesc: boolean;
+  jobUrl: string;
+  board: string;
 }
 
 /**
@@ -34,13 +36,25 @@ export function ApplicationQuestions({
   meta,
   canUse,
   hasDesc,
+  jobUrl,
+  board,
 }: Props) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const { selected, toggle, answers, generating, error, generate, canGenerate } =
-    useApplicationAnswers({ resume, jobDesc, model, researchCompany, meta, canUse, hasDesc });
+    useApplicationAnswers({
+      resume,
+      jobDesc,
+      model,
+      researchCompany,
+      meta,
+      canUse,
+      hasDesc,
+      jobUrl,
+      board,
+    });
 
   const copy = async (id: string, text: string) => {
     await navigator.clipboard.writeText(text);

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
@@ -243,6 +243,8 @@ export function ApplyJobModal({ job, resumeText, board, onClose }: Props) {
             meta={gen.meta}
             canUse={canUse}
             hasDesc={hasDesc}
+            jobUrl={job.url}
+            board={board}
           />
         </div>
       </div>

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useApplicationAnswers.test.ts
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useApplicationAnswers.test.ts
@@ -1,0 +1,87 @@
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+
+import { useApplicationAnswers } from './useApplicationAnswers';
+
+// Stub the generation lib: metadata + one deterministic answer, no research.
+vi.mock('@/lib/generate', () => ({
+  extractMetadata: vi.fn().mockResolvedValue({
+    candidateName: 'Jane',
+    jobTitle: 'Engineer',
+    companyName: 'Acme',
+    resumeLanguage: 'en',
+    jobAdLanguage: 'en',
+    mismatch: false,
+    targetLanguage: 'en',
+    topRequirements: [],
+  }),
+  generateApplicationAnswer: vi.fn().mockResolvedValue('Because I led a payments migration.'),
+  researchCompany: vi.fn().mockResolvedValue(''),
+}));
+
+const save = vi.fn().mockResolvedValue({ id: 'gen-1', success: true });
+vi.mock('@/providers/AppClientProvider', () => ({
+  useAppClient: () => ({ aiGenerations: { save } }),
+}));
+
+const base = {
+  resume: 'My resume',
+  jobDesc: 'Backend role at Acme',
+  model: 'llama3',
+  researchCompany: false,
+  meta: null,
+  canUse: true,
+  hasDesc: true,
+  jobUrl: 'https://acme.com/job/1',
+  board: 'linkedin',
+};
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(QueryClientProvider, { client: new QueryClient() }, children);
+const render = () => renderHook(() => useApplicationAnswers(base), { wrapper });
+
+describe('useApplicationAnswers', () => {
+  beforeEach(() => save.mockClear());
+
+  it('toggles selection and gates generation on a non-empty selection', () => {
+    const { result } = render();
+    expect(result.current.canGenerate).toBe(false);
+    act(() => result.current.toggle('why-company'));
+    expect(result.current.selected.has('why-company')).toBe(true);
+    expect(result.current.canGenerate).toBe(true);
+  });
+
+  it('drafts answers and persists them linked to the job url', async () => {
+    const { result } = render();
+    act(() => result.current.toggle('why-company'));
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(result.current.answers['why-company']).toContain('payments migration');
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobUrl: 'https://acme.com/job/1',
+        board: 'linkedin',
+        applicationAnswers: [
+          expect.objectContaining({
+            id: 'why-company',
+            answer: 'Because I led a payments migration.',
+          }),
+        ],
+      })
+    );
+  });
+
+  it('does nothing when nothing is selected', async () => {
+    const { result } = render();
+    await act(async () => {
+      await result.current.generate();
+    });
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useApplicationAnswers.ts
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useApplicationAnswers.ts
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { APPLICATION_QUESTIONS } from '@ajh/prompts/generate';
+import type { ApplicationAnswer } from '@ajh/shared/ipc';
 
 import {
   extractMetadata,
@@ -8,6 +10,8 @@ import {
   type GenerationMeta,
   researchCompany as fetchCompanyBrief,
 } from '@/lib/generate';
+import { useAppClient } from '@/providers/AppClientProvider';
+import { keys } from '@/services/query-client';
 
 interface Params {
   resume: string;
@@ -19,6 +23,9 @@ interface Params {
   meta?: GenerationMeta | null;
   canUse: boolean;
   hasDesc: boolean;
+  /** Links the answers to the per-job application record (merge-upsert by url). */
+  jobUrl: string;
+  board: string;
 }
 
 /**
@@ -36,7 +43,11 @@ export function useApplicationAnswers({
   meta,
   canUse,
   hasDesc,
+  jobUrl,
+  board,
 }: Params) {
+  const api = useAppClient();
+  const qc = useQueryClient();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [generating, setGenerating] = useState(false);
@@ -60,6 +71,7 @@ export function useApplicationAnswers({
       const detected = meta ?? (await extractMetadata(resume, jobDesc, model));
       const brief = researchCompany ? await fetchCompanyBrief(jobDesc, model) : '';
       const chosen = APPLICATION_QUESTIONS.filter((q) => selected.has(q.id));
+      const results: ApplicationAnswer[] = [];
       for (const q of chosen) {
         const answer = await generateApplicationAnswer({
           question: q.question,
@@ -69,8 +81,32 @@ export function useApplicationAnswers({
           model,
           companyBrief: brief,
         });
+        results.push({ id: q.id, question: q.question, answer });
         setAnswers((prev) => ({ ...prev, [q.id]: answer }));
       }
+
+      // Persist onto the per-job application record (merge-upsert by jobUrl), so
+      // answers + brief live alongside the résumé/cover the tailor flow saved.
+      await api.aiGenerations.save({
+        candidateName: detected.candidateName,
+        jobTitle: detected.jobTitle,
+        companyName: detected.companyName,
+        resumeLanguage: detected.resumeLanguage,
+        jobAdLanguage: detected.jobAdLanguage,
+        targetLanguage: detected.targetLanguage,
+        mismatch: detected.mismatch,
+        topRequirements: detected.topRequirements,
+        mode: 'ats',
+        resumeText: '',
+        coverLetterText: '',
+        jobAd: jobDesc,
+        jobUrl,
+        board,
+        applicationAnswers: results,
+        companyBrief: brief,
+      });
+      void qc.invalidateQueries({ queryKey: keys.aiGenerations.all });
+      void qc.invalidateQueries({ queryKey: keys.autopilot.all });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to generate answers');
     } finally {

--- a/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
@@ -7,7 +7,9 @@ import {
   Download,
   ExternalLink,
   FileText,
+  HelpCircle,
   Loader2,
+  Search,
   Trash2,
   Wand2,
 } from 'lucide-react';
@@ -39,7 +41,9 @@ export function GenerationCard({ gen }: GenerationCardProps) {
   const { t } = useTranslation();
   const removeAiGeneration = useRemoveAiGeneration();
   const openExternal = useOpenExternal();
-  const [expanded, setExpanded] = useState<'resume' | 'cover' | 'jobAd' | null>(null);
+  const [expanded, setExpanded] = useState<
+    'resume' | 'cover' | 'jobAd' | 'brief' | 'answers' | null
+  >(null);
   const [copied, setCopied] = useState<'resume' | 'cover' | null>(null);
   const [exportFormat, setExportFormat] = useState<ExportFormat>('pdf');
   const [exportTemplate, setExportTemplate] = useState<TemplateId>('modern');
@@ -296,6 +300,12 @@ export function GenerationCard({ gen }: GenerationCardProps) {
           text: gen.jobAd,
           icon: Building2,
         },
+        {
+          key: 'brief' as const,
+          label: t('resumes.generated.companyResearch'),
+          text: gen.companyBrief,
+          icon: Search,
+        },
       ]
         .filter((s) => s.text)
         .map(({ key, label, text, icon: SectionIcon }) => (
@@ -329,6 +339,49 @@ export function GenerationCard({ gen }: GenerationCardProps) {
             </AnimatePresence>
           </div>
         ))}
+
+      {/* Application answers — structured Q/A from the questions assistant. */}
+      {gen.applicationAnswers.length > 0 && (
+        <div className="border-t border-white/[0.04]">
+          <button
+            onClick={() => setExpanded(expanded === 'answers' ? null : 'answers')}
+            className="flex w-full items-center justify-between px-4 py-2.5 text-left text-xs text-foreground/50 transition-colors hover:text-foreground/70"
+          >
+            <span className="flex items-center gap-1.5">
+              <HelpCircle size={11} /> {t('resumes.generated.applicationAnswers')}
+              <span className="rounded-full bg-white/[0.06] px-1.5 py-0.5 text-[9px] text-foreground/45">
+                {gen.applicationAnswers.length}
+              </span>
+            </span>
+            <ChevronDown
+              size={12}
+              className={cn('transition-transform', expanded === 'answers' && 'rotate-180')}
+            />
+          </button>
+          <AnimatePresence initial={false}>
+            {expanded === 'answers' && (
+              <motion.div
+                initial={{ height: 0 }}
+                animate={{ height: 'auto' }}
+                exit={{ height: 0 }}
+                transition={transition.normal}
+                className="overflow-hidden"
+              >
+                <div className="max-h-72 space-y-3 overflow-y-auto px-4 pb-4">
+                  {gen.applicationAnswers.map((qa) => (
+                    <div key={qa.id}>
+                      <p className="text-[11px] font-medium text-foreground/70">{qa.question}</p>
+                      <p className="mt-0.5 whitespace-pre-wrap text-[11px] leading-relaxed text-foreground/50">
+                        {qa.answer}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -870,7 +870,9 @@
       "exportResume": "Lebenslauf",
       "exportCoverLetter": "Anschreiben",
       "applied": "Beworben",
-      "openPosting": "Anzeige öffnen"
+      "openPosting": "Anzeige öffnen",
+      "companyResearch": "Unternehmensrecherche",
+      "applicationAnswers": "Bewerbungsantworten"
     },
     "relativeTime": {
       "justNow": "Gerade eben",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -870,7 +870,9 @@
       "exportResume": "Resume",
       "exportCoverLetter": "Cover Letter",
       "applied": "Applied",
-      "openPosting": "Open posting"
+      "openPosting": "Open posting",
+      "companyResearch": "Company research",
+      "applicationAnswers": "Application answers"
     },
     "relativeTime": {
       "justNow": "Just now",

--- a/packages/shared/scripts/gen-ipc-rust.ts
+++ b/packages/shared/scripts/gen-ipc-rust.ts
@@ -219,7 +219,14 @@ function buildStruct(
 
     if (useDefault) {
       const fn = `default_${snakeCase(name)}_${field}`;
-      struct.helpers.push(`fn ${fn}() -> ${base} {\n    ${rustDefault(prop, base)}\n}`);
+      // Match rustfmt: a zero-arg signature wider than max_width (100) wraps the
+      // empty param list onto its own line, so the generated file stays
+      // `cargo fmt --check`-clean as well as `gen:ipc:check`-stable.
+      const sig =
+        `fn ${fn}() -> ${base} {`.length > 100
+          ? `fn ${fn}(\n) -> ${base} {`
+          : `fn ${fn}() -> ${base} {`;
+      struct.helpers.push(`${sig}\n    ${rustDefault(prop, base)}\n}`);
       struct.fields.push(`    #[serde(default = "${fn}")]`);
       struct.fields.push(`    pub ${field}: ${base},`);
     } else if (override || required.has(key)) {

--- a/packages/shared/src/ipc/contracts/aiGenerations.ts
+++ b/packages/shared/src/ipc/contracts/aiGenerations.ts
@@ -1,3 +1,10 @@
+/** One answered application question stored on the application record. */
+export interface ApplicationAnswer {
+  id: string;
+  question: string;
+  answer: string;
+}
+
 export interface AiGenerationRecord {
   id: string;
   createdAt: number;
@@ -17,6 +24,10 @@ export interface AiGenerationRecord {
   jobUrl: string;
   /** The board the job came from (e.g. "linkedin"). */
   board: string;
+  /** Answered application questions (the questions assistant), if any. */
+  applicationAnswers: ApplicationAnswer[];
+  /** The company-research brief used for this application, if any. */
+  companyBrief: string;
 }
 
 export interface AiGenerationSaveRequest {
@@ -36,6 +47,10 @@ export interface AiGenerationSaveRequest {
   jobUrl?: string;
   /** The board the job came from. */
   board?: string;
+  /** Answered application questions to persist on the (per-job) record. */
+  applicationAnswers?: ApplicationAnswer[];
+  /** The company-research brief used, persisted for audit. */
+  companyBrief?: string;
 }
 
 export interface AiGenerationsContract {

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -125,6 +125,7 @@ export {
   type AiGenerationRecord,
   type AiGenerationSaveRequest,
   type AiGenerationsContract,
+  type ApplicationAnswer,
 } from './aiGenerations.js';
 export { APPLY_CHANNELS, type ApplyContract } from './apply.js';
 export {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -166,6 +166,18 @@ export const AiGenerationSaveSchema = z.object({
   // from. `jobUrl` is what marks an autopilot found job as "applied".
   jobUrl: z.string().default(''),
   board: z.string().default(''),
+  // Application extras — answered questions and the company-research brief used,
+  // merged onto the per-job record so it is the full application aggregate.
+  applicationAnswers: z
+    .array(
+      z.object({
+        id: z.string().default(''),
+        question: z.string().default(''),
+        answer: z.string().default(''),
+      })
+    )
+    .default([]),
+  companyBrief: z.string().default(''),
 });
 // Note: the `AiGenerationSaveRequest` type is declared in the aiGenerations IPC
 // contract (single source for that name); this schema validates the same shape.


### PR DESCRIPTION
## D-1b — persist answers + brief on the application record

Completes the application-questions assistant: the drafted answers (and the company-research brief used) are now **stored on the `ai_generations` record** and shown in the Applications/History view, realizing the plan's "single application aggregate — one row per job".

### What changed
- **Schema** — additive `add_application_answers` migration: `application_answers` (JSON) + `company_brief` (TEXT). New `ApplicationAnswer { id, question, answer }`. Legacy rows default empty.
- **Per-job merge-upsert** — `save_application` merges an incoming save into the existing row for its `jobUrl` via the pure, unit-tested `merge_application` (takes each field only when non-empty). So the résumé/cover (tailor flow) and the answers/brief (questions assistant) — separate user actions — land on **one** row. Unlinked manual generations (no `jobUrl`) still insert separately. Backed by `find_by_job_url` + `update`.
- **Renderer** — the questions assistant persists its answers + brief through the save (merge-upsert by `jobUrl`) and invalidates the history + autopilot queries. The history card gains a **Company research** section and an expandable **Application answers** Q/A list.
- **Contract/IPC** — shared contract + Zod schema += `applicationAnswers` + `companyBrief`; `ai.rs` regenerated. en/de i18n.

### Architecture
- **Single application aggregate** — the record is now the full per-job application (résumé, cover, answers, brief, applied-state) instead of one row per generation. `applied_job_urls` (distinct `jobUrl`) is unaffected.
- **`merge_application` is pure** — re-running layers fields without clobbering; no field is lost when a lighter save (answers-only) arrives after a heavier one (cover).

### Tooling fix (bundled)
The new nested array pushed a generated `#[serde(default)]` fn signature past rustfmt's 100-col width, which `gen:ipc:check` (wants generator output) and `cargo fmt --check` (a pre-push gate) disagreed on. Fixed the **generator** (`gen-ipc-rust.ts`) to wrap long zero-arg signatures exactly as rustfmt does, so generated files stay clean under both gates.

### Tests
- Rust: record round-trips answers/brief; `merge_application` layers answers onto an existing cover without clobbering; `save_application` upserts one aggregate per `jobUrl` and inserts separately when unlinked; legacy rows default empty. (708 Rust tests pass.)
- Renderer: the hook drafts answers and saves them linked to the job url; no-op when nothing selected.

### Gates
`pnpm build:packages` · `lint:strict` · `format` · `typecheck --force` · `gen:ipc:check` · `cargo check/test/clippy` · `cargo fmt --check` — all ✅ (pre-push enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)