### PR TITLE
docs: sync knowledge base + ADRs, refresh README, add SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,107 +2,191 @@
   <img src="docs/banner.png" alt="AI Job Hunter" width="100%">
 </p>
 
-# AI Job Hunter
+<h1 align="center">AI Job Hunter</h1>
 
-> Your local-first, AI-native desktop assistant for intelligent job searching, resume generation, and automated applications — run it fully offline with Ollama, or plug in your own OpenAI, Anthropic, or Gemini key.
+<p align="center">
+  <em>Your local-first, AI-native desktop assistant for intelligent job searching, résumé &amp; cover-letter generation, and assisted applications — run it fully offline with Ollama, or plug in your own OpenAI, Anthropic, or Gemini key.</em>
+</p>
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/badge/release-v0.44.0-e24b4a)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases)
-[![Live site](https://img.shields.io/badge/Live-site-e24b4a)](https://saeedkolivand.github.io/ai-job-hunter-assistant-app/)
-[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/pulls)
+<p align="center">
+  <a href="https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases"><strong>⬇️ Download the latest release</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://saeedkolivand.github.io/ai-job-hunter-assistant-app/">🌐 Live site</a>
+  &nbsp;·&nbsp;
+  <a href="#-installation">📦 Install</a>
+  &nbsp;·&nbsp;
+  <a href="#-features">✨ Features</a>
+  &nbsp;·&nbsp;
+  <a href="docs/">📚 Docs</a>
+</p>
 
-[![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB?logo=tauri&logoColor=white)](https://tauri.app)
-[![Rust](https://img.shields.io/badge/Rust-stable-000000?logo=rust&logoColor=white)](https://www.rust-lang.org/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev/)
-[![Vite](https://img.shields.io/badge/Vite-8-646CFF?logo=vite&logoColor=white)](https://vite.dev/)
-[![TailwindCSS](https://img.shields.io/badge/Tailwind-v4-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com/)
-[![pnpm](https://img.shields.io/badge/pnpm-11-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
-[![Ollama](https://img.shields.io/badge/Ollama-local-000000?logo=ollama&logoColor=white)](https://ollama.com/)
+<p align="center">
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
+  <a href="https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases"><img alt="Release" src="https://img.shields.io/badge/release-v0.44.0-e24b4a"></a>
+  <a href="https://saeedkolivand.github.io/ai-job-hunter-assistant-app/"><img alt="Live site" src="https://img.shields.io/badge/Live-site-e24b4a"></a>
+  <a href="https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey"></a>
+  <a href="SECURITY.md"><img alt="Security policy" src="https://img.shields.io/badge/security-policy-2ea44f"></a>
+  <a href="https://github.com/saeedkolivand/ai-job-hunter-assistant-app/pulls"><img alt="PRs Welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
+</p>
+
+<p align="center">
+  <a href="https://tauri.app"><img alt="Tauri" src="https://img.shields.io/badge/Tauri-2.x-24C8DB?logo=tauri&logoColor=white"></a>
+  <a href="https://www.rust-lang.org/"><img alt="Rust" src="https://img.shields.io/badge/Rust-stable-000000?logo=rust&logoColor=white"></a>
+  <a href="https://www.typescriptlang.org/"><img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-6.0-3178C6?logo=typescript&logoColor=white"></a>
+  <a href="https://react.dev/"><img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black"></a>
+  <a href="https://tailwindcss.com/"><img alt="TailwindCSS" src="https://img.shields.io/badge/Tailwind-v4-06B6D4?logo=tailwindcss&logoColor=white"></a>
+  <a href="https://ollama.com/"><img alt="Ollama" src="https://img.shields.io/badge/Ollama-local-000000?logo=ollama&logoColor=white"></a>
+</p>
 
 ---
+
+<details>
+<summary><strong>📑 Table of contents</strong></summary>
+
+- [What It Does](#what-it-does)
+- [Quick Start](#quick-start)
+- [Features](#-features)
+- [AI Provider Flexibility](#ai-provider-flexibility)
+- [Installation](#-installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Tech Stack](#tech-stack)
+- [For Developers](#for-developers)
+- [Project Structure](#project-structure)
+- [Scripts](#scripts)
+- [Documentation](#documentation)
+- [Security](#security)
+- [License](#license)
+
+</details>
+
+## Quick Start
+
+```bash
+# 🚀 Try it           → download a build for your OS:
+#                        https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases
+#
+# 🛠️  Develop it       → run the full desktop app from source:
+git clone https://github.com/saeedkolivand/ai-job-hunter-assistant-app.git
+cd ai-job-hunter-assistant-app && pnpm install
+ollama pull mistral   # optional: a local model for the offline Ollama provider
+pnpm dev              # launches the Tauri app with hot reload
+```
+
+No API key required to start — run fully offline with Ollama, or add a cloud key later in **Settings → AI**. New here? See **[Installation](#-installation)** for prerequisites and per-OS notes.
 
 ## What It Does
 
-AI Job Hunter is a desktop application built with Tauri that brings the full power of AI-driven job hunting to your local machine. It scrapes 18+ job boards, semantically matches postings to your resume, and generates tailored cover letters and resumes using your AI provider of choice — all while keeping your data and credentials stored locally on your device. Autonomous job application (**Autopilot**) is **coming soon**.
+AI Job Hunter is a desktop application built with **Tauri** (a Rust core with a React renderer) that brings AI-driven job hunting to your local machine. It scrapes 18+ job boards, semantically matches postings to your résumé, generates tailored cover letters and résumés with your AI provider of choice, drafts grounded answers to application questions, and tracks everything you apply to — all while keeping your data and credentials on your device.
 
-### AI Provider Flexibility
+The only outbound calls are to the AI provider **you** configure (and an optional web search you explicitly enable). Everything else — jobs, résumés, generations, applications — lives in a local database on your machine.
 
-Choose how you want to run the AI — you can switch providers at any time in Settings → AI:
+---
+
+## ✨ Features
+
+<details open>
+<summary><strong>📝 Résumé &amp; cover-letter generation</strong></summary>
+
+- **Streaming generation** with 9 professional templates, DOCX / PDF / TXT export, ATS-safe formatting.
+- **Universal "thinking" view** — see the model's reasoning stream live across **every** provider (Anthropic, OpenAI, Gemini, Ollama, CLI agents), not just one.
+- **Background generation** — switch tabs, close the modal, or navigate away; generation keeps running and the result is there when you come back.
+- **Smaller PDFs** — fonts are glyph-subsetted per export (only the characters you actually use), shrinking a typical résumé PDF from ~3 MB to ~120 KB.
+</details>
+
+<details>
+<summary><strong>🎯 Matching, ATS &amp; analysis</strong></summary>
+
+- **Semantic job matching** — hybrid vector + keyword search; scores each posting against your résumé.
+- **Résumé analysis** — ATS scoring, skill-gap detection, language-mismatch warnings, and improvement recommendations.
+</details>
+
+<details>
+<summary><strong>🤖 Autopilot &amp; application tracking</strong></summary>
+
+- **Autopilot workflows** — define a search (board, query, location, schedule, filters); it finds and scores matching jobs.
+- **Dedup + New/Applied badges** — re-running a workflow merges results by URL: prior finds are kept, genuinely new ones are badged **New**, and jobs you've generated for are badged **Applied** (derived automatically from your saved generations).
+- **One-click assisted apply** — from any found job, generate a tailored résumé + cover letter and **résumé-grounded answers** to common application questions, with optional company research.
+- **Applications / History** — every generated application is stored as a single per-job record (résumé, cover, answers, brief, board, date) and browsable in the Résumés → Generated tab.
+</details>
+
+<details>
+<summary><strong>🔎 Company research (opt-in)</strong></summary>
+
+- Before writing a cover letter or answers, optionally research the company on the web (Brave Search → a concise, factual brief: what they do, size/stage, products, recent news).
+- Default **off**, cached for a week, and treated as **untrusted** reference context — it never becomes a candidate fact, and the no-fabrication grounding rule still governs every claim.
+</details>
+
+<details>
+<summary><strong>🧠 AI providers &amp; local tuning</strong></summary>
+
+- **Multi-provider** — Ollama (local), OpenAI, Anthropic, Gemini, any OpenAI-compatible server (LM Studio, vLLM, remote Ollama), plus headless **CLI agents** (Claude Code, Codex, Gemini CLI).
+- **Per-model local limits** — analyze a local model's real context window via Ollama's `/api/show`, then set the context window + max output tokens per model, with a hardware-lag warning so large prompts aren't silently truncated.
+</details>
+
+<details>
+<summary><strong>🔒 Privacy &amp; data</strong></summary>
+
+- **Credentials in the OS keychain** — encrypted, never in plain text or config files.
+- **All data local** — jobs, résumés, generations, applications in a local SQLite database; **zero telemetry**.
+- **Full reset** — one action wipes every store (documents, generations, autopilots, contact/job preferences, caches, keychain entries) back to a clean install.
+- **Multilingual** — UI and generation in 11 languages: en, de, fr, es, it, tr, pt, ru, zh, ja, ko.
+</details>
+
+---
+
+## AI Provider Flexibility
+
+Switch providers at any time in **Settings → AI**:
 
 | Provider               | Models                                           | Notes                                                                      |
 | ---------------------- | ------------------------------------------------ | -------------------------------------------------------------------------- |
-| **Ollama** (local)     | mistral, llama3.2, neural-chat, any Ollama model | No API key needed; fully offline                                           |
-| **OpenAI**             | GPT-4o, GPT-4 Turbo, GPT-3.5 Turbo               | Requires API key                                                           |
-| **Anthropic**          | Claude 3.5 Sonnet, Claude 3 Opus                 | Requires API key; supports extended thinking                               |
-| **Google Gemini**      | Gemini 1.5 Pro, Gemini 1.5 Flash                 | Requires API key                                                           |
-| **OpenAI-compatible**  | Any (LM Studio, remote Ollama, etc.)             | Custom base URL                                                            |
+| **Ollama** (local)     | mistral, llama3.2, deepseek-r1, any Ollama model | No API key needed; fully offline; per-model context/output limits          |
+| **OpenAI**             | GPT-4o, o-series, GPT-4 Turbo                    | Requires API key                                                           |
+| **Anthropic**          | Claude (Sonnet / Opus), extended thinking        | Requires API key; reasoning streamed to the thinking view                  |
+| **Google Gemini**      | Gemini 2.5 / 1.5 (Pro, Flash)                    | Requires API key; thinking models supported                                |
+| **OpenAI-compatible**  | Any (LM Studio, vLLM, remote Ollama, …)          | Custom base URL                                                            |
 | **CLI agents** (local) | Claude Code, Codex, Gemini CLI                   | Run headless via the installed CLI — no API key (uses the CLI's own login) |
 
-API keys are stored encrypted in the OS keychain — never in plain text or config files. CLI agents run as a headless subprocess and reuse whatever login that CLI already has, so they need no key in the app.
-
-### Why It Exists
-
-Modern job searching is repetitive, time-consuming, and emotionally draining. AI Job Hunter automates the mechanical parts — scraping, matching, writing — so you can focus on the interviews that matter. All application data (jobs, resumes, interactions) stays in a local SQLite database on your machine; the only outbound calls are to the AI provider you explicitly configure.
+API keys are stored encrypted in the OS keychain. CLI agents run as a headless subprocess and reuse whatever login that CLI already has, so they need no key in the app.
 
 ---
 
-## Key Features
+## 📦 Installation
 
-- **Multi-board scraping** — LinkedIn, Indeed, StepStone, Xing, Greenhouse, Lever, Workday, and 11 more boards in one pass
-- **AI resume & cover letter generation** — Streaming generation with 9 professional templates, DOCX/PDF export, ATS-safe formatting
-- **Semantic job matching** — Hybrid vector + keyword search powered by LanceDB; scores each posting against your resume
-- **Resume analysis** — ATS scoring, skill gap detection, language mismatch warnings, and improvement recommendations
-- **Autopilot** _(coming soon)_ — Define a workflow (board, schedule, resume, message) and let the app apply to jobs automatically
-- **Document processing** — Import PDF, DOCX, TXT, images (OCR via Tesseract); extract and chunk for embedding
-- **Multi-provider AI** — Ollama (local), OpenAI, Anthropic (extended thinking), Gemini, LM Studio, plus headless **CLI agents** (Claude Code, Codex, Gemini CLI)
-- **Multilingual** — UI and generation in 11 languages: en, de, fr, es, it, tr, pt, ru, zh, ja, ko
-- **Privacy-first** — Credentials in OS keychain; all data in local SQLite/LanceDB; zero telemetry
+<details open>
+<summary><strong>Download a released build</strong> (recommended)</summary>
 
----
+Grab the latest installer for your OS from the **[Releases](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases)** page.
 
-## Tech Stack
-
-| Layer               | Technology                                 |
-| ------------------- | ------------------------------------------ |
-| Desktop shell       | Tauri 2.x (Rust)                           |
-| UI framework        | React 19, TypeScript 6                     |
-| Routing             | TanStack Router 1.x (file-based)           |
-| Server state        | TanStack Query 5.x                         |
-| Client state        | Zustand 5                                  |
-| Styling             | TailwindCSS v4 + CSS custom properties     |
-| Animations          | motion/react (Framer Motion)               |
-| Build system        | Vite 8 + Turbo (monorepo)                  |
-| Package manager     | pnpm 11 (workspaces)                       |
-| Local AI            | Ollama 0.6                                 |
-| Relational DB       | SQLite via better-sqlite3 + Drizzle ORM    |
-| Vector DB           | LanceDB                                    |
-| Scraping            | Playwright + Cheerio                       |
-| File processing     | pdfjs-dist, mammoth, Tesseract.js          |
-| Document generation | docx-rs + printpdf (Rust) · jsPDF (client) |
-| Validation          | Zod 4                                      |
-| Logging             | Pino 10                                    |
-
----
-
-## Installation
-
-### Running a released build (macOS)
-
-Download the latest `.dmg` from the [Releases](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases) page and drag the app into your Applications folder.
-
-Because the app is not notarized by Apple, macOS Gatekeeper may refuse to open it (e.g. "app is damaged and can't be opened"). Clear the quarantine attribute once after installing:
+**macOS** — open the `.dmg` and drag the app into Applications. Because the app isn't notarized by Apple, Gatekeeper may refuse to open it the first time ("app is damaged and can't be opened"). Clear the quarantine attribute once:
 
 ```bash
-xattr -cr /Applications/AI\ Job\ Hunter\ Assistant.app
+xattr -cr "/Applications/AI Job Hunter Assistant.app"
 ```
 
-Then launch the app normally.
+**Windows / Linux** — run the installer / AppImage from the Releases page.
 
-### Build from source
+</details>
 
-#### Prerequisites
+<details>
+<summary><strong>Homebrew (macOS)</strong></summary>
+
+> ⚠️ The Homebrew cask/tap is not published yet — once it is, install with:
+
+```bash
+brew tap saeedkolivand/tap
+brew install --cask ai-job-hunter
+```
+
+Until then, use the `.dmg` from the [Releases](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases) page.
+
+</details>
+
+<details>
+<summary><strong>Build from source</strong></summary>
+
+**Prerequisites**
 
 | Requirement    | Version | Notes                                           |
 | -------------- | ------- | ----------------------------------------------- |
@@ -111,91 +195,161 @@ Then launch the app normally.
 | Rust toolchain | stable  | `rustup install stable`                         |
 | Ollama         | latest  | [ollama.com](https://ollama.com) — for local AI |
 
-#### Clone and install
-
 ```bash
 git clone https://github.com/saeedkolivand/ai-job-hunter-assistant-app.git
 cd ai-job-hunter-assistant-app
 pnpm install
-```
 
-#### Pull an AI model
+# Pull a local model (optional — only for the Ollama provider)
+ollama pull mistral        # or: ollama pull llama3.2
 
-```bash
-ollama pull mistral
-# or for better quality:
-ollama pull llama3.2
-```
-
-#### Start in development mode
-
-```bash
+# Start the full Tauri desktop app with hot reload
 pnpm dev
 ```
 
-This launches the full Tauri desktop app with hot-module reloading on the React side.
+</details>
+
+<details>
+<summary><strong>Troubleshooting</strong></summary>
+
+| Symptom                                       | Fix                                                                                                           |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| macOS: _"app is damaged and can't be opened"_ | Not notarized — clear quarantine once: `xattr -cr "/Applications/AI Job Hunter Assistant.app"`                |
+| No models in the picker / "select a model"    | Start Ollama and `ollama pull <model>`, or add a cloud key in **Settings → AI**                               |
+| Company research does nothing                 | It's opt-in and needs a **Brave Search** key (Settings → AI); without it, generation proceeds without a brief |
+| Scraping can't find a browser                 | Set the browser path in **Settings → Scraping**                                                               |
+| `pnpm dev` fails to build the Rust core       | Ensure the stable Rust toolchain is installed (`rustup install stable`) and re-run                            |
+
+</details>
 
 ---
 
-## Usage Examples
+## Usage
 
-### Generate a cover letter
+<details open>
+<summary><strong>Generate a tailored résumé / cover letter</strong></summary>
 
 ```
 1. Open the app → AI Generate
-2. Paste your resume text, or upload a PDF/DOCX/TXT file
+2. Paste your résumé text, or upload a PDF/DOCX/TXT file
 3. Paste the job ad text, or upload a job description file
-4. Click Continue → app detects languages, role, company, top requirements
-5. Choose a template and style, then click Generate → watch streaming output
-6. Export as DOCX, PDF, or TXT
+4. Click Continue → the app detects languages, role, company, top requirements
+5. Choose a template + style; optionally enable "Research the company"
+6. Generate → watch streaming output (with live reasoning) → export as DOCX / PDF / TXT
 ```
 
-### Scrape job boards
+</details>
+
+<details>
+<summary><strong>Run Autopilot &amp; answer application questions</strong></summary>
 
 ```
-1. Navigate to Jobs → Scrape
-2. Select boards (e.g. LinkedIn + Greenhouse)
-3. Enter search query, location, date filter
-4. Start scrape → results stream into the jobs table
+1. Autopilot → New → set board, query, location, schedule, filters
+2. Run it → found jobs appear, scored and deduped (New badges on fresh results)
+3. Open a found job → Apply:
+   • generate a tailored résumé + cover letter (target: Both)
+   • pick application questions → get résumé-grounded answers
+   • the job flips to "Applied" and is saved to Résumés → Generated
 ```
 
-### Semantic search
+</details>
 
-```typescript
-// Via IPC service hook
-const { data } = useSearch({
-  query: 'senior TypeScript engineer remote',
-  collection: 'jobs',
-  topK: 20,
-  semanticWeight: 0.7,
-});
-```
-
-### Set up Autopilot _(coming soon)_
-
-> ⏳ Autopilot / auto-apply is under active development and not yet available in released builds. The planned flow:
+<details>
+<summary><strong>Scrape boards &amp; search semantically</strong></summary>
 
 ```
-1. Navigate to Autopilot → New Workflow
-2. Step 1 – Target: board + salary + remote preference
-3. Step 2 – Schedule: daily at 09:00
-4. Step 3 – Action: attach resume, custom message
-5. Save & Enable
+1. Jobs → Scrape → select boards (e.g. LinkedIn + Greenhouse) → query + location → Start
+2. Results stream into the jobs table
+3. Semantic search ranks postings against your résumé (hybrid vector + keyword)
 ```
+
+</details>
 
 ---
 
 ## Configuration
 
-The app uses the OS keychain for secrets — no `.env` files needed. API keys and credentials are stored via Settings → AI and encrypted using Tauri's keychain plugin.
+The app uses the OS keychain for secrets — no `.env` files. Keys and credentials are set in the UI and encrypted via Tauri's keychain plugin.
 
-| Setting          | Location            | Description                          |
-| ---------------- | ------------------- | ------------------------------------ |
-| AI provider      | Settings → AI       | Ollama / OpenAI / Anthropic / Gemini |
-| API keys         | Settings → AI       | Stored in OS keychain                |
-| Performance mode | Settings → General  | Low / Balanced / Performance         |
-| Language         | Settings → General  | UI and generation locale             |
-| Browser          | Settings → Scraping | Path to system browser               |
+| Setting            | Location            | Description                                       |
+| ------------------ | ------------------- | ------------------------------------------------- |
+| AI provider + key  | Settings → AI       | Ollama / OpenAI / Anthropic / Gemini / compatible |
+| Local model limits | Settings → AI       | Context window + max output, per Ollama model     |
+| Brave Search key   | Settings → AI       | Optional — enables company research               |
+| Performance mode   | Settings → General  | Low / Balanced / Performance                      |
+| Language           | Settings → General  | UI and generation locale                          |
+| Browser            | Settings → Scraping | Path to system browser                            |
+
+---
+
+## Tech Stack
+
+| Layer               | Technology                                       |
+| ------------------- | ------------------------------------------------ |
+| Desktop shell       | Tauri 2.x — Rust core + React renderer           |
+| UI framework        | React 19, TypeScript 6                           |
+| Routing             | TanStack Router 1.x (file-based)                 |
+| Server state        | TanStack Query 5.x                               |
+| Client state        | Zustand 5                                        |
+| Styling             | TailwindCSS v4 + CSS custom properties           |
+| Animations          | motion/react                                     |
+| Build system        | Vite 8 + Turbo (monorepo)                        |
+| Package manager     | pnpm 11 (workspaces)                             |
+| Local AI            | Ollama                                           |
+| Relational DB       | SQLite via `rusqlite` (Rust core)                |
+| Vector search       | Hybrid vector + keyword matching                 |
+| Browser automation  | `chromiumoxide` (Rust) — Playwright for e2e only |
+| Document generation | `printpdf` + `docx-rs` (Rust)                    |
+| Validation          | Zod (shared schemas → generated Rust structs)    |
+
+---
+
+## For Developers
+
+**Architecture in one line:** the React renderer never calls the OS directly — it talks to the Rust core over a typed IPC contract.
+
+```
+React renderer  →  service hook (React Query)  →  tauri-client  →  Rust #[tauri::command]  →  core (scrape · AI · export · DB)
+                         apps/tauri/src/renderer/services            apps/tauri/src-tauri/src
+```
+
+IPC request shapes have a single source of truth: **Zod schemas in `packages/shared`**, from which `pnpm gen:ipc` generates the matching Rust structs — so the TS and Rust sides can't drift.
+
+<details>
+<summary><strong>Add a new IPC capability (5 hand-synced touchpoints)</strong></summary>
+
+1. `packages/shared/src/ipc/contracts/*.ts` — add the method signature.
+2. `apps/tauri/src-tauri/src/commands/*.rs` — implement the `#[tauri::command]` and register it in `main.rs`.
+3. `apps/tauri/src/tauri-client/namespaces/*` — wire the `invoke(...)` call.
+4. `apps/tauri/src/renderer/services/*` — add the React Query service hook.
+5. If the request has a new shape: add a Zod schema and run `pnpm gen:ipc`.
+
+</details>
+
+<details>
+<summary><strong>Add an AI provider / a job board (config + adapter, no business-logic changes)</strong></summary>
+
+- **AI provider** — implement the provider adapter and register it; the rest of the app routes through the centralized provider abstraction (`Completer` / streaming contract). Reasoning, limits, and job state are normalized at the adapter boundary, so the renderer holds one contract and zero per-provider branching.
+- **Job board** — add an entry to the scraper registry (`scraping/boards/mod.rs` `SCRAPERS`) / applier registry (`applying/registry/mod.rs` `APPLIERS`); discovery is registry-driven, so no caller changes.
+
+</details>
+
+<details>
+<summary><strong>Conventions &amp; guardrails</strong></summary>
+
+- **PRs only** — never push to `main`; Conventional Commits; ESLint + commitlint + architecture tests gate every change.
+- **Ports &amp; adapters** — UI imports `@ajh/ui` primitives and service hooks, never `window.api` directly; design-system tokens (`text-brand`, motion tokens) over hardcoded values.
+- **Backend owns business logic** — Rust-first; the renderer is a thin client.
+- See **[CLAUDE.md](CLAUDE.md)** for the enforced rules and **[docs/PATTERNS.md](docs/PATTERNS.md)** for the patterns.
+
+</details>
+
+<details>
+<summary><strong>Knowledge base &amp; AI agent system</strong></summary>
+
+This repo ships a knowledge base under [docs/knowledge/](docs/knowledge/) — domain notes plus **architecture decision records** ([ADRs](docs/knowledge/decision-records/)) — and a Claude Code agent system under `.claude/` (specialized reviewers + commands). When in doubt about _why_ something is built a certain way, the ADRs are the fastest answer.
+
+</details>
 
 ---
 
@@ -204,24 +358,20 @@ The app uses the OS keychain for secrets — no `.env` files needed. API keys an
 ```
 ai-job-hunter-assistant-app/
 ├── apps/
-│   └── tauri/                    # Main desktop app (Rust core + React renderer)
-│       ├── src-tauri/            # Rust core (commands, scraping, DB)
+│   └── tauri/                    # Main desktop app
+│       ├── src-tauri/            # Rust core (commands, scraping, AI, export, DB)
 │       └── src/renderer/         # React frontend
 │           ├── features/         # Feature-scoped components
 │           ├── routes/           # TanStack Router pages
 │           ├── services/         # React Query IPC hooks
-│           ├── lib/              # Utilities (motion, i18n, machine)
+│           ├── lib/              # Utilities (generate, motion, i18n, machines)
 │           ├── store/            # Zustand stores
 │           └── providers/        # React context providers
 ├── packages/
 │   ├── shared/                   # IPC contracts, Zod schemas, shared types
 │   ├── ui/                       # @ajh/ui — React component library
-│   ├── core/                     # EventBus, JobQueue, Logger, RuntimeManager
-│   ├── ai/                       # Ollama client + AI runtime
-│   ├── data/                     # DB, matching, file processing
-│   ├── prompts/                  # AI prompt templates
-│   └── workers/                  # Web Workers (OCR, embeddings, chunking)
-├── docs/                         # All project documentation
+│   └── prompts/                  # Provider-aware, locale-driven AI prompt templates
+├── docs/                         # Documentation + knowledge base (ADRs)
 ├── turbo.json                    # Turbo build configuration
 ├── pnpm-workspace.yaml           # pnpm workspaces
 └── package.json                  # Root scripts
@@ -237,46 +387,57 @@ pnpm dev:frontend     # Frontend-only Vite dev server
 pnpm build            # Build all packages (Turbo)
 pnpm build:packages   # Build packages only (excludes Tauri)
 pnpm package          # Package desktop installers
-pnpm typecheck        # TypeScript check across monorepo
-pnpm test             # Run Vitest suite
-pnpm lint             # ESLint across monorepo
-pnpm lint:fix         # ESLint auto-fix
+pnpm gen:ipc          # Regenerate Rust IPC structs from the shared Zod schemas
+pnpm typecheck        # TypeScript check across the monorepo
+pnpm test             # Run the Vitest suite
 pnpm lint:strict      # Lint with --max-warnings 0 (CI mode)
 pnpm format           # Prettier format
-pnpm clean            # Clean build artifacts
 ```
 
 ---
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for branching strategy, commit conventions, code style, and PR guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branching, commit conventions, code style, and PR guidelines. Quick rules:
 
-Quick rules:
-
-- All changes go through PRs — never push directly to `main`
-- Use Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
-- Run `pnpm lint:fix && pnpm typecheck` before pushing
-- ESLint errors block commits — no `// eslint-disable` suppressions
+- All changes go through PRs — never push directly to `main`.
+- Use Conventional Commits (`feat:`, `fix:`, `chore:`, …).
+- Run `pnpm lint:fix && pnpm typecheck` before pushing; ESLint errors block commits.
 
 ---
 
 ## Documentation
 
-| Document                                                   | Description                                            |
-| ---------------------------------------------------------- | ------------------------------------------------------ |
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)               | System design, data flow, Mermaid diagrams             |
-| [docs/DESIGN_SYSTEM.md](docs/DESIGN_SYSTEM.md)             | Tokens, components, motion, theming                    |
-| [docs/PATTERNS.md](docs/PATTERNS.md)                       | IPC, state machines, AI streaming, search patterns     |
-| [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)                 | Full local dev environment setup                       |
-| [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)                   | Building and releasing installers                      |
-| [docs/API.md](docs/API.md)                                 | All 21 IPC namespaces documented                       |
-| [docs/ARCHITECTURE_STATUS.md](docs/ARCHITECTURE_STATUS.md) | Implementation status tracker                          |
-| [docs/DESIGN_DECISIONS.md](docs/DESIGN_DECISIONS.md)       | Architecture decisions, patterns, and design rationale |
-| [CONTRIBUTING.md](CONTRIBUTING.md)                         | Code style, branching, PR process                      |
+| Document                                                   | Description                                           |
+| ---------------------------------------------------------- | ----------------------------------------------------- |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)               | System design, data flow, diagrams                    |
+| [docs/PATTERNS.md](docs/PATTERNS.md)                       | IPC, state machines, AI streaming, search patterns    |
+| [docs/API.md](docs/API.md)                                 | IPC namespaces + commands                             |
+| [docs/EXPORT_TEMPLATES.md](docs/EXPORT_TEMPLATES.md)       | Templates, theming, PDF/DOCX export                   |
+| [docs/DESIGN_SYSTEM.md](docs/DESIGN_SYSTEM.md)             | Tokens, components, motion, theming                   |
+| [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)                 | Local dev environment setup                           |
+| [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)                   | Building and releasing installers                     |
+| [docs/ARCHITECTURE_STATUS.md](docs/ARCHITECTURE_STATUS.md) | Implementation status tracker                         |
+| [docs/knowledge/](docs/knowledge/)                         | Knowledge base + architecture decision records (ADRs) |
+| [SECURITY.md](SECURITY.md)                                 | Security policy &amp; vulnerability reporting         |
+| [CONTRIBUTING.md](CONTRIBUTING.md)                         | Code style, branching, PR process                     |
+
+---
+
+## Security
+
+Found a vulnerability? Please report it privately — see **[SECURITY.md](SECURITY.md)**. Don't open a public issue for security reports.
 
 ---
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE).
+
+---
+
+## Star History
+
+<a href="https://star-history.com/#saeedkolivand/ai-job-hunter-assistant-app&Date">
+  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=saeedkolivand/ai-job-hunter-assistant-app&type=Date" width="600">
+</a>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+Thanks for helping keep **AI Job Hunter** and its users safe.
+
+## Supported versions
+
+AI Job Hunter ships frequently from `main`. Security fixes land in the **latest release** — please reproduce on the most recent version from the [Releases](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases) page (or current `main`) before reporting.
+
+| Version        | Supported           |
+| -------------- | ------------------- |
+| Latest release | ✅                  |
+| Older releases | ❌ (please upgrade) |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue, PR, or discussion for security problems.**
+
+Report privately through one of:
+
+1. **GitHub Private Vulnerability Reporting** (preferred) — open the repository's **[Security → Report a vulnerability](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/security/advisories/new)** form. This keeps the report private until a fix is ready.
+2. **Email** — `saeedkolivand1997@gmail.com` with the subject `SECURITY: ai-job-hunter`.
+
+Please include:
+
+- A clear description and the impact (what an attacker can do).
+- Steps to reproduce, a proof-of-concept, and affected version / OS.
+- Any relevant logs or configuration — **with secrets redacted**.
+
+### What to expect
+
+- **Acknowledgement** within ~5 business days.
+- An assessment and, if accepted, a fix targeted at the next release.
+- Coordinated disclosure: we'll agree on timing with you and credit you in the release notes unless you prefer to stay anonymous.
+
+## Scope
+
+**In scope** — the desktop application and this repository: the Rust core and IPC surface (`#[tauri::command]` handlers), credential storage, AI-provider request handling and prompt construction, browser automation / scraping, document import/OCR, the local data stores, the auto-updater, and the build/dependency supply chain.
+
+**Out of scope**
+
+- Vulnerabilities in **third-party AI providers** (OpenAI, Anthropic, Google, Ollama, LM Studio, CLI agents) or **job boards** — report those to the respective vendor.
+- Issues that require a **already-compromised machine** or physical access to the user's device.
+- Findings against your **own** configured infrastructure (e.g. your self-hosted OpenAI-compatible server).
+- Missing hardening that has no demonstrated exploit (e.g. "best-practice" suggestions without impact).
+
+## Security posture
+
+AI Job Hunter is built local-first to minimize attack surface:
+
+- **Local-first** — jobs, résumés, generations, and applications stay in a local database on your machine; there is **no telemetry** and no app-operated backend. The only outbound calls are to the AI provider you configure and an optional, opt-in web search.
+- **Credentials in the OS keychain** — API keys and board credentials are stored encrypted via the OS keychain, never in plain text or config files.
+- **Untrusted external content is fenced** — web-sourced company research is wrapped in an untrusted block before reaching any prompt (reference-only; the model is told to ignore embedded instructions), and AI output is treated as untrusted by the renderer.
+- **Strict IPC boundary** — the renderer talks to the Rust core only through a typed, validated contract; request shapes are generated from shared schemas.
+- **Supply-chain gates** — `cargo-deny` and `cargo-machete` run in CI alongside the lint/type/test/clippy gates.
+
+Thank you for reporting responsibly. 🙏

--- a/docs/API.md
+++ b/docs/API.md
@@ -92,6 +92,14 @@ interface ModelInfo {
 
 Downloads an Ollama model. Progress is emitted as `ai:pull-progress` events.
 
+#### `ai.inspectModel(req: { model: string }): Promise<ModelInspectResult | null>`
+
+Returns per-model context-window and max-token limits from Ollama (`/api/show`). Returns `null` for non-local providers or when the Ollama server is unreachable. Used to populate `modelLimits` in the preferences store and show hardware-lag warnings. See `commands/ai.rs: ai_inspect_model`.
+
+#### `ai.researchCompany(req: { jobAd: string; provider?: string; model?: string; baseUrl?: string }): Promise<{ company: string; brief: string }>`
+
+Accepts the full **job ad text** (not a company name). The backend extracts the company internally via the `CompanyResearch` enricher (`cover_letter/research/`), runs Brave search + provider synthesis, and caches the result in `KvCache`. Returns `{ company, brief }`. Degrades gracefully — returns `{ company: "", brief: "" }` when there is no Brave key or the search/synthesis fails, so generation always proceeds. The brief is folded into cover-letter and application-answer prompts as an untrusted-fenced block (see ADR-010). See `commands/ai.rs: ai_research_company`.
+
 #### `ai.embed(text: string): Promise<number[]>`
 
 Generates a vector embedding for the given text using the configured embedding model.
@@ -113,7 +121,7 @@ interface StreamChunk {
   id: string; // generationId from generate()
   delta: string; // text fragment
   done: boolean; // true on last chunk
-  thinking?: string; // Anthropic extended thinking block
+  thinking?: string; // reasoning content — normalized across all providers (OpenAI reasoning_content, Gemini thought parts, Ollama message.thinking, inline <think> blocks)
 }
 ```
 
@@ -149,19 +157,31 @@ Tracks metadata for all AI-generated documents.
 #### `aiGenerations.delete(id: string): Promise<void>`
 
 ```typescript
+interface ApplicationAnswer {
+  id: string;
+  question: string;
+  answer: string;
+}
+
 interface AIGenerationRecord {
   id: string;
   type: 'cover-letter' | 'resume' | 'email' | 'summary';
   documentId: string;
   jobId?: string;
+  jobUrl?: string; // links record to a FoundJob for applied-status derivation
+  board?: string; // board the job came from
   model: string;
   provider: AIProvider;
   content: string;
   language: string;
   template?: string;
+  applicationAnswers?: ApplicationAnswer[]; // answered application questions
+  companyBrief?: string; // cached company research (untrusted)
   createdAt: string;
 }
 ```
+
+`aiGenerations.save` performs a **per-job merge-upsert by `jobUrl`** (`merge_application` in `ai_generations/mod.rs`): résumé, cover letter, answers, and brief from separate generation actions all land on one row when they share a `jobUrl`. Manual generations without a `jobUrl` insert as separate rows. See `commands/ai_generations.rs`.
 
 ---
 

--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -2,7 +2,7 @@
 
 Implementation status tracker. Updated as features ship.
 
-Last updated: 2026-05-29
+Last updated: 2026-06-01
 
 ---
 
@@ -26,13 +26,14 @@ Last updated: 2026-05-29
 | Vite + HMR for renderer          | ✅     |                                                                                                                                                       |
 | TanStack Router (file-based)     | ✅     | All 9 routes                                                                                                                                          |
 | TanStack Query + service hooks   | ✅     | All 21 namespaces                                                                                                                                     |
-| Zustand stores                   | ✅     | preferences-store, others                                                                                                                             |
+| Zustand stores                   | ✅     | preferences-store, generation-store (`store/generation-store/`), others                                                                               |
 | AppClient / mock transport       | ✅     | Tauri + mock implementations                                                                                                                          |
 | ESLint + Prettier                | ✅     | Enforced in CI                                                                                                                                        |
 | Husky + commitlint               | ✅     | Pre-commit hooks                                                                                                                                      |
 | Semantic release pipeline        | ✅     | Auto-versioning on main                                                                                                                               |
 | Auto-updater                     | ✅     | GitHub Releases integration                                                                                                                           |
 | Data backup / restore            | ✅     | `DataStore` trait → full export/import bundle (Settings → Privacy)                                                                                    |
+| Full app reset                   | ✅     | `privacy_reset_app` wipes every store registered in the `Resettable` registry (`commands/privacy.rs`)                                                 |
 | Shared platform layers           | ✅     | `platform::config`, `net::http`, `error::AppError`, `observability::Span` + provider/board registries (Phases 1–6 — see PATTERNS.md §13)              |
 | Architecture CI guardrails       | ✅     | grep bans: `std::env::var` outside `platform/config.rs`; `reqwest::Client::new/builder` outside `net/http.rs`; `Result<_, String>` outside `error.rs` |
 
@@ -79,19 +80,22 @@ former `packages/ai` and `packages/data` Node packages were removed.
 
 ## AI Generation (`apps/tauri/src/renderer/features/ai-generate/`)
 
-| Feature                       | Status | Notes                                                                                                     |
-| ----------------------------- | ------ | --------------------------------------------------------------------------------------------------------- |
-| Cover letter generation       | ✅     | Streaming                                                                                                 |
-| Resume generation             | ✅     | Streaming                                                                                                 |
-| Email generation              | ✅     |                                                                                                           |
-| Summary generation            | ✅     |                                                                                                           |
-| Bold keyword extraction       | ✅     | Post-processes output                                                                                     |
-| DOCX export                   | ✅     | Canonical model engine (default): real two-column table + native ATS; A4 + font fallback; legacy fallback |
-| PDF export                    | ✅     | Canonical layout engine (default); legacy fallback                                                        |
-| ATS-safe linearization        | ✅     | Two-column → single for ATS                                                                               |
-| Extended thinking (Anthropic) | ✅     | ThinkingBubble UI                                                                                         |
-| Locale-aware prompts          | ✅     | 11 languages                                                                                              |
-| Template preview              | ✅     | OptionTile with live preview                                                                              |
+| Feature                    | Status | Notes                                                                                                     |
+| -------------------------- | ------ | --------------------------------------------------------------------------------------------------------- |
+| Cover letter generation    | ✅     | Streaming                                                                                                 |
+| Resume generation          | ✅     | Streaming                                                                                                 |
+| Email generation           | ✅     |                                                                                                           |
+| Summary generation         | ✅     |                                                                                                           |
+| Bold keyword extraction    | ✅     | Post-processes output                                                                                     |
+| DOCX export                | ✅     | Canonical model engine (default): real two-column table + native ATS; A4 + font fallback; legacy fallback |
+| PDF export                 | ✅     | Canonical layout engine; glyph-subset fonts (`pdf_renderer/fonts.rs`) ~120 KB vs ~3 MB full embed         |
+| ATS-safe linearization     | ✅     | Two-column → single for ATS                                                                               |
+| Universal thinking display | ✅     | All providers normalized via `think-split.ts`; `ThinkingBubble` UI (`ai-generate/components/`)            |
+| Local model limits         | ✅     | `ai_inspect_model` IPC; `modelLimits` in preferences-store; `num_ctx`/`num_predict` on Ollama path only   |
+| Company research           | ✅     | `ai_research_company` IPC; opt-in; Brave + provider synthesis; untrusted-fenced in prompt                 |
+| Application questions      | ✅     | `APPLICATION_QUESTIONS` registry + grounded answer prompt; answers persist on per-job record              |
+| Locale-aware prompts       | ✅     | 11 languages                                                                                              |
+| Template preview           | ✅     | OptionTile with live preview                                                                              |
 
 ---
 
@@ -111,16 +115,20 @@ former `packages/ai` and `packages/data` Node packages were removed.
 
 ## Autopilot (`apps/tauri/src-tauri/src/autopilot/`)
 
-| Feature                      | Status | Notes                              |
-| ---------------------------- | ------ | ---------------------------------- |
-| Workflow definition wizard   | ✅     | 3-step UI                          |
-| Workflow persistence         | ✅     | SQLite                             |
-| Manual trigger               | ✅     |                                    |
-| Scheduled execution          | ✅     | Cron-like scheduler                |
-| Real-time step events        | ✅     | autopilot:step stream              |
-| Pause / resume               | ✅     |                                    |
-| Auto-apply integration       | 🚧     | Apply success rate varies by board |
-| Batch application throttling | 🚧     | Rate limiting per board            |
+| Feature                      | Status | Notes                                                                                                          |
+| ---------------------------- | ------ | -------------------------------------------------------------------------------------------------------------- |
+| Workflow definition wizard   | ✅     | 3-step UI                                                                                                      |
+| Workflow persistence         | ✅     | SQLite                                                                                                         |
+| Manual trigger               | ✅     |                                                                                                                |
+| Scheduled execution          | ✅     | Cron-like scheduler                                                                                            |
+| Real-time step events        | ✅     | autopilot:step stream                                                                                          |
+| Pause / resume               | ✅     |                                                                                                                |
+| Found-job dedup + tracking   | ✅     | `merge_found_jobs` dedup by URL; `FoundJob.is_new`; `applied` derived from `ai_generations.job_url`            |
+| Generation-session store     | ✅     | `store/generation-store/` — app-wide, keyed by context id, survives navigation; Apply modal uses it            |
+| `ai_generations` aggregate   | ✅     | `job_url`, `board`, `application_answers`, `company_brief` columns; per-job merge-upsert (`merge_application`) |
+| Applications/History view    | ✅     | Generated tab — new/applied badges; per-job record in history card                                             |
+| Auto-apply integration       | 🚧     | Apply success rate varies by board                                                                             |
+| Batch application throttling | 🚧     | Rate limiting per board                                                                                        |
 
 ---
 
@@ -159,4 +167,3 @@ former `packages/ai` and `packages/data` Node packages were removed.
 | Cloud sync                              | Low      | Deferred — needs a remote backend; the backup bundle + `DataStore` trait are the substrate |
 | Team/shared job tracking                | Low      | Would require cloud sync                                                                   |
 | Interview preparation AI                | Medium   | Mock interview Q&A                                                                         |
-| Application analytics dashboard         | Medium   | Track apply→response rates                                                                 |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -132,11 +132,7 @@ apps/
 packages/
   shared/               ← IPC contracts + Zod schemas + shared types
   ui/                   ← @ajh/ui component library
-  core/                 ← EventBus, JobQueue, Scheduler
-  ai/                   ← Ollama client + AI runtime
-  data/                 ← SQLite + LanceDB + scrapers + matchers
   prompts/              ← AI prompt templates
-  workers/              ← Web Worker threads (OCR, embed, chunk)
 ```
 
 ---
@@ -157,10 +153,11 @@ The renderer imports `@ajh/ui` via the workspace symlink. After rebuilding, Vite
 ### Modifying IPC contracts (`packages/shared`)
 
 1. Edit `packages/shared/src/ipc/contracts/<namespace>.ts`
-2. Run `pnpm typecheck` to verify no breakage
-3. Update the Rust command handler in `apps/tauri/src-tauri/src/commands/`
-4. Update `apps/tauri/src/tauri-client.ts`
-5. Update the service hook in `apps/tauri/src/renderer/services/`
+2. Run `pnpm --filter @ajh/shared gen:ipc` to regenerate `ipc_contracts/*.rs` (CI runs `gen:ipc:check` to enforce this)
+3. Run `pnpm typecheck` to verify no breakage
+4. Update the Rust command handler in `apps/tauri/src-tauri/src/commands/`
+5. Update `apps/tauri/src/tauri-client.ts`
+6. Update the service hook in `apps/tauri/src/renderer/services/`
 
 ### Modifying Rust code (`apps/tauri/src-tauri`)
 

--- a/docs/EXPORT_TEMPLATES.md
+++ b/docs/EXPORT_TEMPLATES.md
@@ -131,10 +131,16 @@ the relationships part). The visible label is shown, never the raw URL.
 
 ## Fonts
 
-Six families are bundled as TTFs and embedded in the PDF. The DOCX is **not**
-embedded yet, so it references a widely-available fallback so output is
-predictable on machines without the bundled fonts (true OOXML embedding is a
-tracked follow-up):
+Six families are bundled as TTFs and embedded in the PDF. Each font is
+**glyph-subsetted per export** to only the codepoints actually rendered
+(`export/pdf_renderer/fonts.rs: parse_font`), using `printpdf::subset_font` with
+a safe fallback to the full font on failure. This reduces typical PDF size from
+~3 MB (full embed) to ~120 KB. A size-budget guardrail test in
+`export/pdf/test.rs` enforces this.
+
+The DOCX is **not** embedded yet, so it references a widely-available fallback so
+output is predictable on machines without the bundled fonts (true OOXML embedding
+is a tracked follow-up):
 
 | Bundled family   | DOCX fallback |
 | ---------------- | ------------- |

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -222,13 +222,21 @@ interface StreamChunk {
   id: string; // generationId
   delta: string; // text fragment
   done: boolean; // final chunk marker
-  thinking?: string; // Anthropic extended thinking block
+  thinking?: string; // reasoning content — present for any provider that exposes it
 }
 ```
 
+### Thinking normalization at the boundary
+
+`thinking` is normalized **at the provider-adapter boundary**, never in the renderer. Each adapter maps its provider-specific reasoning format (OpenAI `reasoning_content`/`reasoning`, Gemini `thought:true` parts, Ollama structured `message.thinking`) to the single `thinking` field. For providers that emit reasoning inline as `<think>…</think>` tags, the shared `createThinkSplitter` (`lib/generate/think-split.ts`) splits the stream — zero per-provider branching in rendering code.
+
 ### ThinkingBubble Component
 
-When `chunk.thinking` is present (Anthropic only), render it in a collapsible `ThinkingBubble` component before the main output.
+When `chunk.thinking` is present, render it in a collapsible `ThinkingBubble` component (`features/ai-generate/components/ThinkingBubble/`) before the main output. The component is provider-agnostic.
+
+### Generation-session store
+
+All in-flight and completed generation sessions are held in a single Zustand store at `store/generation-store/`, keyed by a context id (e.g. autopilot job id). It survives navigation and panel close so the Apply modal can display an ongoing or finished generation without re-triggering it. This is the **sole** source of truth for generation state app-wide — do not duplicate this in local component state or React Query.
 
 ---
 
@@ -465,17 +473,19 @@ it; `std::env::var` only in `platform/**`; `reqwest::Client::new/builder` only i
 
 ## Anti-Patterns to Avoid
 
-| Anti-Pattern                                     | Correct Approach                                                                              |
-| ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| `useState + useEffect` for IPC data              | React Query service hook                                                                      |
-| `window.__TAURI_INVOKE__` directly               | `useAppClient()` service hook                                                                 |
-| `import { useTranslation } from "react-i18next"` | `import { useTranslation } from "@/lib/i18n"`                                                 |
-| Cross-feature imports                            | Only import from `@ajh/ui`, `services/`, `lib/`                                               |
-| `// eslint-disable` comment                      | Fix the underlying issue or add a scoped `eslint.config.mjs` override                         |
-| Inline `{ duration: 0.2, ease: "easeOut" }`      | `transition.fast` from `@/lib/motion`                                                         |
-| Hardcoded colors in className                    | `text-brand`, `bg-brand`, etc.                                                                |
-| Storing credentials in SQLite                    | OS keychain via `client.credentials`                                                          |
-| Reading `AJH_DATA_DIR` / rebuilding `~/.ajh`     | `platform::config::data_dir()`                                                                |
-| Per-page `?` that aborts a partial scrape        | First-page error propagates as `Err`; a later page logs + `break`s, keeping the partial (P10) |
-| `reqwest::Client::new()` / `::builder()`         | `net::http::shared()` or `net::http::build_client()`                                          |
-| `Result<_, String>` for fallible internals       | `AppResult<_>` / `AppError` from `crate::error`                                               |
+| Anti-Pattern                                      | Correct Approach                                                                                                                       |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `useState + useEffect` for IPC data               | React Query service hook                                                                                                               |
+| `window.__TAURI_INVOKE__` directly                | `useAppClient()` service hook                                                                                                          |
+| `import { useTranslation } from "react-i18next"`  | `import { useTranslation } from "@/lib/i18n"`                                                                                          |
+| Cross-feature imports                             | Only import from `@ajh/ui`, `services/`, `lib/`                                                                                        |
+| `// eslint-disable` comment                       | Fix the underlying issue or add a scoped `eslint.config.mjs` override                                                                  |
+| Inline `{ duration: 0.2, ease: "easeOut" }`       | `transition.fast` from `@/lib/motion`                                                                                                  |
+| Hardcoded colors in className                     | `text-brand`, `bg-brand`, etc.                                                                                                         |
+| Storing credentials in SQLite                     | OS keychain via `client.credentials`                                                                                                   |
+| Reading `AJH_DATA_DIR` / rebuilding `~/.ajh`      | `platform::config::data_dir()`                                                                                                         |
+| Per-page `?` that aborts a partial scrape         | First-page error propagates as `Err`; a later page logs + `break`s, keeping the partial (P10)                                          |
+| `reqwest::Client::new()` / `::builder()`          | `net::http::shared()` or `net::http::build_client()`                                                                                   |
+| `Result<_, String>` for fallible internals        | `AppResult<_>` / `AppError` from `crate::error`                                                                                        |
+| Folding web-fetched content directly into prompts | Wrap in an untrusted-content fence (see `packages/prompts/src/emphasis.ts`); label the block so the model treats it as untrusted input |
+| Per-provider `thinking` handling in the renderer  | Normalize at the adapter boundary; consume the unified `chunk.thinking` field everywhere                                               |

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -24,7 +24,22 @@ Read the minimum; **stop at ~90% confidence**.
 | [automation-domain.md](automation-domain.md) | Scraping + AI-provider: registries, resilience, provider abstraction, embeddings, streaming, prompts |
 | [performance-rules.md](performance-rules.md) | Hot paths, async-runtime discipline, query-client tuning, token/cost                                 |
 | [security-rules.md](security-rules.md)       | Capabilities, CSP, deps, secrets, privacy/GDPR, updater                                              |
-| [decision-records/](decision-records/)       | ADRs (maintained by `project-steward`)                                                               |
+| [decision-records/](decision-records/)       | ADRs (maintained by `project-steward`) — see table below                                             |
+
+## Decision records index
+
+| ADR                                                                          | Title                                                                       |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [ADR-001](decision-records/adr-001-rust-first-business-logic.md)             | Rust-first business logic                                                   |
+| [ADR-002](decision-records/adr-002-dual-pdf-docx-backends-golden-parity.md)  | Dual PDF + DOCX backends with golden-parity tests                           |
+| [ADR-003](decision-records/adr-003-centralized-platform-net-error-layers.md) | Centralized platform/net/error layers                                       |
+| [ADR-004](decision-records/adr-004-ports-and-adapters-frontend.md)           | Ports & adapters in the renderer                                            |
+| [ADR-005](decision-records/adr-005-universal-thinking-normalization.md)      | Universal thinking/reasoning normalization at the provider-adapter boundary |
+| [ADR-006](decision-records/adr-006-generation-session-store.md)              | Single app-wide generation-session store                                    |
+| [ADR-007](decision-records/adr-007-ai-generations-application-aggregate.md)  | `ai_generations` as the application aggregate with merge-upsert by job URL  |
+| [ADR-008](decision-records/adr-008-pdf-glyph-subsetting.md)                  | PDF glyph subsetting at export time via `parse_font`                        |
+| [ADR-009](decision-records/adr-009-full-reset-lockstep-list.md)              | Full factory reset via explicit lockstep store list in `privacy_reset_app`  |
+| [ADR-010](decision-records/adr-010-untrusted-input-fencing.md)               | Untrusted-input fencing for web-sourced company research                    |
 
 ## Canonical docs (do not duplicate — link)
 

--- a/docs/knowledge/automation-domain.md
+++ b/docs/knowledge/automation-domain.md
@@ -19,6 +19,7 @@ Merged knowledge for `scraping-applier-expert` and `ai-provider-expert`. Source 
 
 - **Abstraction (architectural rule — HIGH if violated)** — `ollama.rs`, `openai.rs`, `anthropic.rs`, `gemini.rs`, `cli_agent/` behind a shared interface (`mod.rs`). **No business logic depends on a provider-specific API.** Adding OpenAI/Anthropic/Gemini/Ollama/OpenRouter/LM Studio/future = **config + adapter only**.
 - **Embeddings** — `documents/mod.rs`: storage + **embedding-space invalidation** when the model/space changes (stale embeddings across a model switch = HIGH).
-- **Streaming** — partial responses + cancellation handled; no resource leak on cancel.
+- **Streaming / thinking normalization** — every provider maps reasoning to `ai:stream { delta, thinking:true }`; inline `<think>` blocks for local models are split by `renderer/lib/generate/think-split.ts: createThinkSplitter`. See [ADR-005](decision-records/adr-005-universal-thinking-normalization.md).
+- **Generation session store** — `renderer/store/generation-store/` (Zustand), keyed by context id, survives navigation/close. See [ADR-006](decision-records/adr-006-generation-session-store.md).
 - **Prompts** — `packages/prompts` (provider-aware, locale-driven, pure TS, zero deps); reusable/composable templates.
 - **Cost/token** — minimize prompt/context; reuse embedded context; pick the cheapest viable model (`performance-profiler` co-reviews hot AI paths).

--- a/docs/knowledge/decision-records/adr-005-universal-thinking-normalization.md
+++ b/docs/knowledge/decision-records/adr-005-universal-thinking-normalization.md
@@ -1,0 +1,18 @@
+# ADR-005: Universal thinking/reasoning normalization at the provider-adapter boundary
+
+**Status:** Accepted
+
+## Context
+
+Different AI providers surface model reasoning in incompatible ways: OpenAI uses `reasoning_content` / `reasoning` fields on the stream delta, Gemini marks thought parts with `thought: true`, Ollama surfaces `message.thinking`, and local models (DeepSeek-R1, Qwen3, etc.) embed reasoning inline as `<think>…</think>` tags in the content stream. Surfaces that consume streaming output (AI Generate, analyze, the autopilot apply modal) each needed to handle these differences — or they would diverge.
+
+## Decision
+
+Every provider adapter maps its reasoning signal to the same `ai:stream` event shape — `{ delta, thinking: true }` — before emitting to the renderer. Inline `<think>…</think>` blocks (local models) are parsed by a shared stateful splitter (`apps/tauri/src/renderer/lib/generate/think-split.ts: createThinkSplitter`) that is called by the streaming surface before the delta is passed on, so the renderer has **zero per-provider branching**. Visible answer text goes to `onToken`; reasoning text goes to `onThinking`.
+
+## Consequences
+
+- Any new provider whose reasoning is structured (not inline tags) normalizes in its adapter; inline-tag models work via the shared splitter at the consumption point.
+- All streaming surfaces automatically support multi-provider reasoning with no per-surface changes.
+- `createThinkSplitter` is stateful across deltas; callers must create one instance per stream and call `flush()` at stream end.
+- Adding a provider with a new reasoning signal = adapter change only, no renderer change.

--- a/docs/knowledge/decision-records/adr-006-generation-session-store.md
+++ b/docs/knowledge/decision-records/adr-006-generation-session-store.md
@@ -1,0 +1,18 @@
+# ADR-006: Single app-wide generation-session store
+
+**Status:** Accepted
+
+## Context
+
+Generation (résumé tailoring, cover letter) can be triggered from a modal (autopilot apply flow) and must survive the modal being closed or the user navigating away — desktop users expect background work to continue and results to be retrievable. Component-local state is lost on unmount; multiple isolated stores would diverge.
+
+## Decision
+
+A single Zustand store (`apps/tauri/src/renderer/store/generation-store/`) holds all active and completed generation sessions. Each session is keyed by a **caller-supplied context id** (e.g. `autopilot:<jobUrl>`). The store is the canonical source for any cross-surface generation state — `GenerationSession` tracks phase, streamed text (`resumeOut`, `coverOut`), reasoning (`thinking`), error, and result metadata. Surfaces read from and write to this store; they never duplicate session state locally.
+
+## Consequences
+
+- Closing a modal or navigating away does not cancel or lose an in-progress generation.
+- Multiple surfaces displaying the same generation (e.g. modal + background indicator) stay in sync automatically.
+- Context ids must be stable and collision-free within a session; callers own this convention.
+- The store outlives any single component mount, so stale sessions must be explicitly cleared when no longer needed.

--- a/docs/knowledge/decision-records/adr-007-ai-generations-application-aggregate.md
+++ b/docs/knowledge/decision-records/adr-007-ai-generations-application-aggregate.md
@@ -1,0 +1,22 @@
+# ADR-007: `ai_generations` as the application aggregate with merge-upsert by job URL
+
+**Status:** Accepted
+
+## Context
+
+A single job application involves multiple separate AI actions: résumé tailoring, cover-letter generation, application-question answers, and company-research brief. Storing each as an independent row would scatter them across the table and make it impossible to query "everything generated for this application" without a join.
+
+The `applied` status of a job (whether the user has generated documents for it) was previously stored explicitly — creating a dual-write risk if a save succeeded but the status update failed.
+
+## Decision
+
+`ai_generations` is the **application aggregate**: one row per job URL. `save_application` in `apps/tauri/src-tauri/src/ai_generations/mod.rs` performs a **merge-upsert by `job_url`**: when an incoming record shares a `job_url` with an existing row, it calls the pure `merge_application` function to combine fields (résumé text, cover-letter text, answers, brief) into the existing row rather than inserting a new one. Records without a `job_url` (manual generations) always insert as fresh rows.
+
+`applied` status is **derived**, not stored: `applied_job_urls()` queries `DISTINCT job_url` from the table and returns the set. Schema additions (e.g. `application_answers` column, `job_link` column) are additive migrations — no destructive column changes.
+
+## Consequences
+
+- One row in `ai_generations` = one full application bundle; easy to query, audit, and export.
+- `applied` derivation eliminates dual-write risk; autopilot reads `applied_job_urls()` to skip already-applied jobs.
+- `merge_application` is a pure function, independently testable (`ai_generations/test.rs`).
+- New fields on the aggregate require an additive migration; the lockstep comment in `commands/data.rs::build_bundle` must be updated to include any new persistent fields in exports/backups.

--- a/docs/knowledge/decision-records/adr-008-pdf-glyph-subsetting.md
+++ b/docs/knowledge/decision-records/adr-008-pdf-glyph-subsetting.md
@@ -1,0 +1,18 @@
+# ADR-008: PDF glyph subsetting at export time via `parse_font`
+
+**Status:** Accepted
+
+## Context
+
+The PDF renderer bundles multiple font families (Calibri, Inter, SourceSerif4, Manrope, JetBrains Mono, Playfair Display) compiled into the binary. Full-font embedding produces exports well over 3 MB. `printpdf` 0.9.1 ships with its own font-subsetting hard-disabled at serialize time (`if false && do_subset …` in `serialize.rs`), so without explicit subsetting every export embeds every glyph of every face.
+
+## Decision
+
+`apps/tauri/src-tauri/src/export/pdf_renderer/fonts.rs: parse_font` subsets each font to the codepoints actually rendered in the document before embedding, using `printpdf::subset_font`. `collect_codepoints` gathers the used character set (plus a `BASELINE_GLYPHS` safety set) from the document content before any font is loaded. On subset failure the function falls back to embedding the full font so the export never hard-errors. A guardrail test (`export/pdf/test.rs: classic_resume_pdf_is_glyph_subset_under_budget`) asserts the output of the default template stays under 800 KB, catching a full-font regression by an order of magnitude.
+
+## Consequences
+
+- Typical PDF export size is a fraction of the full-font baseline.
+- The 800 KB budget is generous enough to be stable across content changes but detects a subsetting regression immediately.
+- `parse_font` is the only font-loading entry point; all templates call `load_all_fonts`, which calls `parse_font` for every face.
+- If `printpdf::subset_font` is upgraded or replaced, the guardrail test validates the new path without code-review action.

--- a/docs/knowledge/decision-records/adr-009-full-reset-lockstep-list.md
+++ b/docs/knowledge/decision-records/adr-009-full-reset-lockstep-list.md
@@ -1,0 +1,18 @@
+# ADR-009: Full factory reset via explicit lockstep store list in `privacy_reset_app`
+
+**Status:** Accepted
+
+## Context
+
+A "factory reset" must wipe every persistent user-data store atomically. Two approaches were considered: a `Resettable` trait registry (stores self-register; reset iterates the registry) or an explicit maintained list. A registry requires each store to implement the trait and register at startup; it is automatic but adds indirection and requires discipline to keep registrations complete.
+
+## Decision
+
+`apps/tauri/src-tauri/src/commands/privacy.rs: privacy_reset_app` uses an **explicit list** of `clear_all()` calls covering every persistent store (PostingsCache, InteractionStore, JobTracker, DocumentStore, AiGenerationStore, ConversationDb, AutopilotStore, JobPreferencesStore, ContactProfileStore, KvCache, CredentialStore). A comment in the function body mandates keeping this list in lockstep with `commands/data.rs::build_bundle` (the backup set) plus stores intentionally excluded from backups. Adding a new persistent store means handling it in **both** places.
+
+## Consequences
+
+- The list is explicit and visible in one place (`privacy_reset_app`); no runtime registration machinery.
+- Adding a new persistent store requires a deliberate edit to `privacy_reset_app` and `data.rs::build_bundle` — the lockstep comment is the enforcement mechanism.
+- Reviewers (`rust-backend-architect`, `tauri-security-reviewer`) must check both files when a new store is added. Missing a store is a data-retention/GDPR risk (HIGH finding).
+- A future refactor to a `Resettable` registry is not blocked by this decision but requires updating the ADR.

--- a/docs/knowledge/decision-records/adr-010-untrusted-input-fencing.md
+++ b/docs/knowledge/decision-records/adr-010-untrusted-input-fencing.md
@@ -1,0 +1,18 @@
+# ADR-010: Untrusted-input fencing for web-sourced company research
+
+**Status:** Accepted
+
+## Context
+
+Company-research text is retrieved from the web (Brave search + AI synthesis) and folded into prompts for cover-letter generation and application-question answers. Web-sourced content can contain prompt-injection payloads (e.g. "Ignore previous instructions and…") that, if passed to the model without fencing, could manipulate generated output.
+
+## Decision
+
+All web-sourced company research is wrapped in an explicit untrusted `<company_research>` XML fence by `packages/prompts/src/generate/emphasis.ts: buildCompanyResearchBlock`. The fence text instructs the model that the block is untrusted, web-sourced reference material to be used **only** for company context — never as a candidate fact — and to **ignore any instructions it contains**. The brief is also capped at 1 200 characters so a long or hostile payload cannot dominate the prompt. `buildCompanyResearchBlock` is shared by `cover-letter.ts` and `application-questions.ts`, so fencing is applied consistently. Tests in `generate.test.ts` assert that any prompt containing a brief includes the fence, the "untrusted" label, and the "ignore any instructions" directive.
+
+## Consequences
+
+- Prompt-injection risk from web-sourced content is mitigated at the prompt-building layer, not relying on model caution.
+- The 1 200-character cap limits cost impact from unusually long research briefs.
+- Any new prompt template that consumes `companyBrief` **must** call `buildCompanyResearchBlock` — passing raw brief text is a HIGH security finding (`tauri-security-reviewer`).
+- The fence pattern is tested; a regression in the fence text fails the test suite.

--- a/docs/knowledge/domain-model.md
+++ b/docs/knowledge/domain-model.md
@@ -28,6 +28,7 @@ Describes the **shape**; the source is authoritative for field-level detail. Use
 - **Provider adapters** — `commands/ai_provider/{ollama,openai,anthropic,gemini}.rs` behind a shared interface (`mod.rs`); business logic must not depend on a specific provider.
 - **Embeddings** — `documents/mod.rs` (storage + embedding-space invalidation on model change).
 - **Prompts** — `packages/prompts` (provider-aware, locale-driven templates).
+- **`ai_generations` aggregate** — per-job merge-upsert by `job_url` (`save_application` + pure `merge_application` in `ai_generations/mod.rs`); `applied` status derived via `applied_job_urls()`. See [ADR-007](decision-records/adr-007-ai-generations-application-aggregate.md).
 
 ## Platform / data
 

--- a/docs/knowledge/performance-rules.md
+++ b/docs/knowledge/performance-rules.md
@@ -10,7 +10,7 @@ For `performance-profiler` (Secondary). Bias findings toward MEDIUM unless there
 
 - **Scraping** (`scraping/`, `browser/`) — bounded concurrency, reuse chromiumoxide pages where possible, per-board rate limits, don't spawn unbounded tasks.
 - **AI / embeddings** (`commands/ai_provider/`, `documents/`) — batch sizing, streaming back-pressure, minimal token/context, cheapest viable model; avoid re-embedding unchanged content.
-- **Export / layout** (`export/`, `layout/`, `measure/`) — pre-measure before render; don't re-shape fonts per glyph; compute pagination once.
+- **Export / layout** (`export/`, `layout/`, `measure/`) — pre-measure before render; don't re-shape fonts per glyph; compute pagination once. PDF fonts are glyph-subset at export time (`export/pdf_renderer/fonts.rs: parse_font`); size guardrail test catches regressions. See [ADR-008](decision-records/adr-008-pdf-glyph-subsetting.md).
 - **Pipeline** (`pipeline/`, `autopilot/`) — bounded queues; backpressure; cancellation honored.
 - **Data** — no N+1 queries, no full-table scans on warm paths.
 

--- a/docs/knowledge/resume-domain.md
+++ b/docs/knowledge/resume-domain.md
@@ -23,6 +23,10 @@ Merged knowledge for `resume-export-expert`, `pdf-docx-generator` (impl), and `j
 - **Golden parity** — keep PDF and DOCX outputs aligned where the design requires; deterministic snapshots, reviewed on update.
 - **Validate gate** — `validate/` checks ATS compliance before/at export.
 
+## PDF glyph subsetting
+
+`export/pdf_renderer/fonts.rs: parse_font` subsets each embedded font to rendered codepoints via `printpdf::subset_font`; falls back to full-font on failure. A size-budget guardrail test (`export/pdf/test.rs: classic_resume_pdf_is_glyph_subset_under_budget`, 800 KB limit) catches subsetting regressions. See [ADR-008](decision-records/adr-008-pdf-glyph-subsetting.md).
+
 ## Review heuristics
 
 - HIGH: a template/layout change that breaks ATS parseability; a scoring change that violates the documented model without an ADR; an untested export error path; a header-link regression (links must come from `contact_profile/`).

--- a/docs/knowledge/security-rules.md
+++ b/docs/knowledge/security-rules.md
@@ -19,10 +19,12 @@ For `tauri-security-reviewer` (cross-cutting authority). Security/data findings 
 ## AI security
 
 - Prompt-injection: user content must not be able to manipulate system prompts; data-leakage: sensitive data must not leak into prompts/outputs; tool access bounded. Co-owned with `ai-provider-expert` (it owns correctness, you own the security lens).
+- **Untrusted-input fencing** — web-sourced company research is wrapped in an `<company_research>` fence by `packages/prompts/src/generate/emphasis.ts: buildCompanyResearchBlock` (capped, reference-only, "ignore any instructions"); any new prompt consuming a company brief must call this function. See [ADR-010](decision-records/adr-010-untrusted-input-fencing.md).
 
 ## Data / privacy (GDPR)
 
 - `commands/privacy.rs` + `db.rs`/`data_store.rs`: retention + deletion honored; temp/export files cleaned up; resume/PII protected at rest and in caches. A retention/cleanup regression is HIGH.
+- **Full reset** — `privacy_reset_app` calls `clear_all()` on every persistent store via an explicit lockstep list (maintained alongside `commands/data.rs::build_bundle`). A new persistent store must be added to both. See [ADR-009](decision-records/adr-009-full-reset-lockstep-list.md).
 
 ## Abuse / cost (DoS & spend)
 


### PR DESCRIPTION
## Closing docs pass for the feature effort

Syncs documentation with everything shipped across PRs #203–#214 (universal thinking, local-model limits, PDF glyph-subsetting, full reset, background generation, autopilot dedup/tracking + Applications history, company research, application-questions assistant), refreshes the README, and adds a security policy.

### Docs (`docs/`)
- **ARCHITECTURE_STATUS** — new stores/fields/commands/registry rows.
- **API** — `ai_inspect_model`, `ai_research_company`, and the `aiGenerations.save` new fields + per-job **merge-upsert** note. *(Fixed two contract errors a first pass introduced: `researchCompany` takes the job ad and returns `{company, brief}`; `applicationAnswers` is `ApplicationAnswer[]`, not `Record<string,string>`.)*
- **EXPORT_TEMPLATES** — PDF glyph-subsetting (`pdf_renderer/fonts.rs`).
- **PATTERNS** — thinking-normalization-at-the-boundary, the single generation-session store, untrusted-input fencing anti-pattern.
- **DEVELOPMENT** — `pnpm gen:ipc` step; pruned the deleted `packages/core|ai|data|workers`.

### Knowledge base (`docs/knowledge/`)
- **6 new ADRs** (adr-005..010): universal-thinking normalization · generation-session store · `ai_generations` application aggregate (merge-upsert, derived `applied`) · PDF glyph-subsetting · **full-reset lockstep list** · untrusted-input fencing — plus thin pointers from the domain files and a decision-records index in the knowledge README.
  - Note: **adr-009 documents reality** — the full reset is an explicit lockstep `clear_all()` list in `privacy_reset_app`, *not* a `Resettable` trait/registry (no such registry exists in source).

### README
- Overhauled for the shipped features; collapsible "tab" sections; **Quick Start**; a **For Developers** guide (IPC flow, "add an IPC command / provider / board", conventions, knowledge-base pointer); **Troubleshooting**; **Homebrew** note (flagged: tap not yet published); prominent **Releases** link; **star-history** chart.
- Fixed stale stack/structure: `rusqlite` + `chromiumoxide` (not better-sqlite3/Drizzle/Playwright-for-scraping); packages are only `shared`/`ui`/`prompts`; Autopilot is no longer "coming soon".

### `SECURITY.md`
- Private vulnerability reporting (GitHub advisories + email), supported versions, in/out-of-scope, and the local-first security posture.

### Gates
Docs-only — full pre-push gate (build:packages · lint:strict · format · typecheck · cargo check/test/clippy/fmt) passed. `graphify update .` run.

### ⚠️ Follow-ups flagged for you
- **Homebrew cask isn't published** — the README documents the `brew tap … && brew install --cask …` command but the tap/cask repo doesn't exist yet. Want me to scaffold a `Casks/ai-job-hunter.rb`?
- **adr-009 discrepancy** — D-5 was planned as a `Resettable` registry but shipped as a manual lockstep list. Worth a real registry refactor later if you want the "new store wiped automatically" guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)