### PR TITLE
feat: render changelog and generated output as markdown

### DIFF
--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import type { TemplateId } from '@/lib/generate';
+
+import { OutputPanelDone } from './index';
+
+const RAW = 'Led **payments** migration at scale.';
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof OutputPanelDone>> = {}) {
+  const onOutputChange = vi.fn();
+  const onExport = vi.fn();
+  const onCopy = vi.fn();
+  render(
+    <OutputPanelDone
+      resumeOut={RAW}
+      coverOut=""
+      activeOut="resume"
+      meta={null}
+      mode="ats"
+      templateId={'classic' as TemplateId}
+      onActiveOutChange={vi.fn()}
+      onCopy={onCopy}
+      onExport={onExport}
+      onOutputChange={onOutputChange}
+      onRegenerate={vi.fn()}
+      copied={false}
+      {...overrides}
+    />
+  );
+  return { onOutputChange, onExport, onCopy };
+}
+
+describe('OutputPanelDone — preview/edit', () => {
+  it('renders prettified markdown by default, hiding the raw ** emphasis markers', () => {
+    renderPanel();
+    // The **keyword** marker renders as bold, not as literal asterisks.
+    expect(screen.getByText('payments').tagName).toBe('STRONG');
+    expect(screen.queryByText(/\*\*payments\*\*/)).toBeNull();
+    // No editable textarea while previewing.
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('switches to a raw textarea with markers intact (export source untouched)', () => {
+    const { onOutputChange } = renderPanel();
+    // The toggle button's label resolves to "Edit" (or the raw i18n key) — both match.
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    // Raw text — including the **payments** markers the export pipeline reads.
+    expect(textarea.value).toBe(RAW);
+    // Switching views must not mutate the canonical output.
+    expect(onOutputChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
@@ -1,8 +1,8 @@
-import { Check, Copy, Download, FileText, RotateCcw } from 'lucide-react';
+import { Check, Copy, Download, Eye, FileText, Pencil, RotateCcw } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useEffect, useState } from 'react';
 
-import { Button, cn, TextArea } from '@ajh/ui';
+import { Button, cn, MarkdownMessage, TextArea } from '@ajh/ui';
 
 import { buildFilename, type GenerationMeta, MODES, type TemplateId } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
@@ -42,6 +42,10 @@ export function OutputPanelDone({
 }: OutputPanelDoneProps) {
   const { t } = useTranslation();
   const [exportOpen, setExportOpen] = useState(false);
+  // Preview (prettified markdown) vs Edit (raw text). Display-only: the raw
+  // string stays canonical — copy, export, and the **keyword** emphasis markers
+  // are never touched, so a Preview/Edit switch can't change the exported file.
+  const [view, setView] = useState<'preview' | 'edit'>('preview');
 
   // If the active tab has no content but the other does, switch automatically
   useEffect(() => {
@@ -112,15 +116,50 @@ export function OutputPanelDone({
         </div>
       )}
 
-      {/* Editable output */}
-      <div className="flex-1 overflow-hidden px-6 py-4">
-        <TextArea
-          value={currentOutput}
-          onChange={(e) => onOutputChange(e.target.value)}
-          className="h-full w-full bg-transparent font-mono text-[12px] leading-relaxed text-foreground/80 placeholder:text-foreground/20"
-          spellCheck={false}
-          placeholder={t('aiGenerate.placeholder')}
-        />
+      {/* Output — prettified Preview or raw Edit (display-only; export uses the raw text) */}
+      <div className="flex flex-1 flex-col overflow-hidden px-6 py-4">
+        <div className="mb-2 flex shrink-0 items-center gap-0.5 self-end rounded-lg bg-white/[0.04] p-0.5">
+          <button
+            onClick={() => setView('preview')}
+            className={cn(
+              'flex items-center gap-1 rounded px-2 py-1 text-[10px] transition-colors',
+              view === 'preview'
+                ? 'bg-brand/15 text-brand-soft'
+                : 'text-foreground/45 hover:text-foreground/70'
+            )}
+          >
+            <Eye size={11} /> {t('aiGenerate.preview')}
+          </button>
+          <button
+            onClick={() => setView('edit')}
+            className={cn(
+              'flex items-center gap-1 rounded px-2 py-1 text-[10px] transition-colors',
+              view === 'edit'
+                ? 'bg-brand/15 text-brand-soft'
+                : 'text-foreground/45 hover:text-foreground/70'
+            )}
+          >
+            <Pencil size={11} /> {t('aiGenerate.edit')}
+          </button>
+        </div>
+
+        {view === 'edit' ? (
+          <TextArea
+            value={currentOutput}
+            onChange={(e) => onOutputChange(e.target.value)}
+            className="h-full w-full bg-transparent font-mono text-[12px] leading-relaxed text-foreground/80 placeholder:text-foreground/20"
+            spellCheck={false}
+            placeholder={t('aiGenerate.placeholder')}
+          />
+        ) : (
+          <div className="h-full w-full overflow-y-auto rounded-lg">
+            {currentOutput ? (
+              <MarkdownMessage content={currentOutput} className="text-[12px] text-foreground/80" />
+            ) : (
+              <p className="text-[12px] text-foreground/20">{t('aiGenerate.placeholder')}</p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Re-generate option */}

--- a/apps/tauri/src/renderer/features/settings/components/update-section/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/update-section/index.tsx
@@ -9,7 +9,15 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 
-import { Button, cn, GlassCard, IconBadge, RefreshButton, SectionLabel } from '@ajh/ui';
+import {
+  Button,
+  cn,
+  GlassCard,
+  IconBadge,
+  MarkdownMessage,
+  RefreshButton,
+  SectionLabel,
+} from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { useAppVersion, useOpenExternal } from '@/services';
@@ -129,8 +137,11 @@ export function UpdateSection() {
             <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-foreground/30">
               {t('settings.update.whatsNew')} {'version' in status ? status.version : ''}
             </div>
-            <div className="max-h-36 overflow-y-auto rounded-lg border border-white/[0.05] bg-white/[0.02] p-3 text-xs text-foreground/50 leading-relaxed whitespace-pre-wrap">
-              {status.releaseNotes}
+            <div className="max-h-36 overflow-y-auto rounded-lg border border-white/[0.05] bg-white/[0.02] p-3">
+              <MarkdownMessage
+                content={status.releaseNotes}
+                className="text-xs text-foreground/60"
+              />
             </div>
           </div>
         )}
@@ -199,8 +210,11 @@ export function UpdateSection() {
                     )}
                   </div>
                   {release.body && (
-                    <div className="whitespace-pre-wrap rounded-lg border border-white/[0.05] bg-white/[0.02] p-3 text-xs leading-relaxed text-foreground/50">
-                      {release.body}
+                    <div className="rounded-lg border border-white/[0.05] bg-white/[0.02] p-3">
+                      <MarkdownMessage
+                        content={release.body}
+                        className="text-xs text-foreground/60"
+                      />
                     </div>
                   )}
                 </div>

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -515,6 +515,8 @@
     "error": "Fehler",
     "upload": "Hochladen",
     "regenerate": "Neu generieren",
+    "preview": "Vorschau",
+    "edit": "Bearbeiten",
     "placeholder": "Generierte Ausgabe erscheint hier…",
     "stages": {
       "analyzing": "Anforderungen werden analysiert…",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -515,6 +515,8 @@
     "error": "Error",
     "upload": "Upload",
     "regenerate": "Regenerate",
+    "preview": "Preview",
+    "edit": "Edit",
     "placeholder": "Generated output will appear here…",
     "stages": {
       "analyzing": "Analyzing job requirements…",


### PR DESCRIPTION
## What & why

Two spots dumped raw text that should be styled. Both now reuse the existing **`MarkdownMessage`** renderer from `@ajh/ui` — **no new dependency**.

### 1. Changelog — Settings → Updates
The release body and "what's new" notes were rendered as raw `whitespace-pre-wrap`, so GitHub/semantic-release markdown (`### Features`, `* fix: …`) showed as unstyled text. Now rendered as styled headings/bold/lists.

### 2. Generated résumé / cover letter — AI Generate output
Adds a small **Edit / Preview** toggle:
- **Preview** (default) renders the output as prettified markdown — bold ATS keywords, bullets, headings.
- **Edit** keeps the raw textarea.

**Display-only and export-safe:** the raw string stays canonical — copy, export, and the `**keyword**` emphasis markers (which the export pipeline reads) are untouched, so switching views can never change the exported file. The streaming view stays raw live tokens; prettify applies only to the completed output.

## Tests
- New `OutputPanelDone` test: Preview hides raw `**` markers (renders `<strong>`); Edit shows the raw textarea with markers intact; switching views never calls `onOutputChange`.
- `typecheck` + `lint:strict` + targeted vitest green.

Follow-up to #224 (independent — UI-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)