### PR TITLE
refactor: reactivate design-system eslint rules and clear all violations

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
@@ -17,7 +17,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useRef, useState } from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
 
-import { cn, transition, variants } from '@ajh/ui';
+import { Button, cn, transition, variants } from '@ajh/ui';
 
 import { ROUTES } from '@/constants/routes';
 import { getTimeGreeting } from '@/lib/greeting';
@@ -174,12 +174,13 @@ export function Sidebar() {
         </div>
 
         <div className="relative flex justify-center">
-          <button
+          <Button
+            variant="unstyled"
             onClick={showVersion}
             className="font-mono text-[9px] tabular-nums text-foreground/20 transition-colors hover:text-foreground/40"
           >
             {appVersion}
-          </button>
+          </Button>
           <AnimatePresence>
             {versionTooltip && (
               <motion.div

--- a/apps/tauri/src/renderer/components/resume/ProfileUrlInput/index.tsx
+++ b/apps/tauri/src/renderer/components/resume/ProfileUrlInput/index.tsx
@@ -1,6 +1,6 @@
 import { Loader2, X } from 'lucide-react';
 
-import { Button } from '@ajh/ui';
+import { Button, Input } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 
@@ -30,7 +30,8 @@ export function ProfileUrlInput({
   return (
     <div className="flex flex-col border-t border-white/[0.05]">
       <div className="flex items-center gap-2 px-3 py-2">
-        <input
+        <Input
+          variant="unstyled"
           type="url"
           value={url}
           onChange={(e) => onChange(e.target.value)}

--- a/apps/tauri/src/renderer/components/resume/ResumeInputCard/index.tsx
+++ b/apps/tauri/src/renderer/components/resume/ResumeInputCard/index.tsx
@@ -186,7 +186,8 @@ export function ResumeInputCard({
         <div className="px-3 pb-3 space-y-2">
           {/* Segmented control */}
           <div className="flex items-center gap-1 rounded-lg bg-white/[0.04] p-0.5 w-fit">
-            <button
+            <Button
+              variant="unstyled"
               onClick={() => setInputMode('upload')}
               className={cn(
                 'flex items-center gap-1.5 rounded-md px-3 py-1 text-[11px] font-medium transition-all',
@@ -197,8 +198,9 @@ export function ResumeInputCard({
             >
               <Upload size={10} />
               {t('resumeInput.modeUpload')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="unstyled"
               onClick={() => setInputMode('paste')}
               className={cn(
                 'flex items-center gap-1.5 rounded-md px-3 py-1 text-[11px] font-medium transition-all',
@@ -209,7 +211,7 @@ export function ResumeInputCard({
             >
               <ClipboardPaste size={10} />
               {t('resumeInput.modePaste')}
-            </button>
+            </Button>
           </div>
 
           {/* Upload zone */}

--- a/apps/tauri/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
+++ b/apps/tauri/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
@@ -23,12 +23,9 @@ function normalise(raw: RawDoc): DocumentRecord {
     ...raw,
     id: raw._id,
     importedAt: raw.createdAt,
-    source: (raw.source ??
-      (raw.name?.endsWith('.pdf')
-        ? 'pdf'
-        : raw.name?.endsWith('.docx')
-          ? 'docx'
-          : 'txt')) as DocumentRecord['source'],
+    source:
+      raw.source ??
+      (raw.name?.endsWith('.pdf') ? 'pdf' : raw.name?.endsWith('.docx') ? 'docx' : 'txt'),
   };
 }
 

--- a/apps/tauri/src/renderer/components/resume/SavedResumeMenu/index.tsx
+++ b/apps/tauri/src/renderer/components/resume/SavedResumeMenu/index.tsx
@@ -52,7 +52,8 @@ export function SavedResumeMenu({
                 isSelected ? 'bg-brand/15' : 'hover:bg-white/[0.05]'
               )}
             >
-              <button
+              <Button
+                variant="unstyled"
                 type="button"
                 onClick={() => onSelect(doc)}
                 className={cn(
@@ -63,7 +64,7 @@ export function SavedResumeMenu({
                 <FileText size={11} className="shrink-0" />
                 <span className="truncate flex-1">{doc.title}</span>
                 {isSelected && <Check size={11} className="shrink-0 text-brand-soft" />}
-              </button>
+              </Button>
 
               {doc.isDefault ? (
                 <span

--- a/apps/tauri/src/renderer/components/ui/ModelSelector/index.tsx
+++ b/apps/tauri/src/renderer/components/ui/ModelSelector/index.tsx
@@ -64,10 +64,7 @@ export function ModelSelector({ className }: ModelSelectorProps) {
     })),
   });
   const cloudModelNames = new Map<AiProvider, string[]>(
-    cloudProviders.map((p, i) => [
-      p,
-      ((modelQueries[i]?.data as Array<{ name: string }> | undefined) ?? []).map((m) => m.name),
-    ])
+    cloudProviders.map((p, i) => [p, (modelQueries[i]?.data ?? []).map((m) => m.name)])
   );
 
   // CLI-agent availability (binary detected) from the system health probe.

--- a/apps/tauri/src/renderer/features/ai-generate/components/GenerationConfig/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/GenerationConfig/index.tsx
@@ -205,7 +205,8 @@ export function GenerationConfig({
 
       {/* ATS safe mode — only for two-column templates (Atelier, Portrait) */}
       {isTwoColumnTemplate(templateId) && (
-        <button
+        <Button
+          variant="unstyled"
           type="button"
           onClick={() => onAtsModeChange(!atsMode)}
           className={cn(
@@ -241,7 +242,7 @@ export function GenerationConfig({
               )}
             />
           </div>
-        </button>
+        </Button>
       )}
 
       <Button

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
@@ -1,8 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import type { TemplateId } from '@/lib/generate';
-
 import { OutputPanelDone } from './index';
 
 const RAW = 'Led **payments** migration at scale.';
@@ -18,7 +16,7 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof OutputPanelD
       activeOut="resume"
       meta={null}
       mode="ats"
-      templateId={'classic' as TemplateId}
+      templateId="classic"
       onActiveOutChange={vi.fn()}
       onCopy={onCopy}
       onExport={onExport}
@@ -46,7 +44,7 @@ describe('OutputPanelDone — preview/edit', () => {
     // The toggle button's label resolves to "Edit" (or the raw i18n key) — both match.
     fireEvent.click(screen.getByRole('button', { name: /edit/i }));
 
-    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    const textarea = screen.getByRole<HTMLTextAreaElement>('textbox');
     // Raw text — including the **payments** markers the export pipeline reads.
     expect(textarea.value).toBe(RAW);
     // Switching views must not mutate the canonical output.

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
@@ -119,7 +119,8 @@ export function OutputPanelDone({
       {/* Output — prettified Preview or raw Edit (display-only; export uses the raw text) */}
       <div className="flex flex-1 flex-col overflow-hidden px-6 py-4">
         <div className="mb-2 flex shrink-0 items-center gap-0.5 self-end rounded-lg bg-white/[0.04] p-0.5">
-          <button
+          <Button
+            variant="unstyled"
             onClick={() => setView('preview')}
             className={cn(
               'flex items-center gap-1 rounded px-2 py-1 text-[10px] transition-colors',
@@ -129,8 +130,9 @@ export function OutputPanelDone({
             )}
           >
             <Eye size={11} /> {t('aiGenerate.preview')}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="unstyled"
             onClick={() => setView('edit')}
             className={cn(
               'flex items-center gap-1 rounded px-2 py-1 text-[10px] transition-colors',
@@ -140,7 +142,7 @@ export function OutputPanelDone({
             )}
           >
             <Pencil size={11} /> {t('aiGenerate.edit')}
-          </button>
+          </Button>
         </div>
 
         {view === 'edit' ? (

--- a/apps/tauri/src/renderer/features/ai-generate/components/ThinkingBubble/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/ThinkingBubble/index.tsx
@@ -2,7 +2,7 @@ import { Brain, ChevronDown } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 
-import { transition } from '@ajh/ui';
+import { Button, transition } from '@ajh/ui';
 
 interface ThinkingBubbleProps {
   thinking: string;
@@ -35,7 +35,8 @@ export function ThinkingBubble({ thinking, done = false }: ThinkingBubbleProps) 
       className="mx-1 mb-3 rounded-xl border border-violet-500/20 bg-violet-500/[0.04]"
     >
       {/* Header */}
-      <button
+      <Button
+        variant="unstyled"
         onClick={() => setExpanded((v) => !v)}
         className="flex w-full items-center gap-2 px-3 py-2 text-left"
       >
@@ -57,7 +58,7 @@ export function ThinkingBubble({ thinking, done = false }: ThinkingBubbleProps) 
         <motion.div animate={{ rotate: expanded ? 0 : -90 }} transition={transition.fast}>
           <ChevronDown size={12} className="text-violet-400/40" />
         </motion.div>
-      </button>
+      </Button>
 
       {/* Content */}
       <AnimatePresence initial={false}>

--- a/apps/tauri/src/renderer/features/ai-generate/samples/template-previews.ts
+++ b/apps/tauri/src/renderer/features/ai-generate/samples/template-previews.ts
@@ -26,4 +26,4 @@ export const TEMPLATE_PREVIEWS: Partial<Record<TemplateId, string>> = Object.fro
         ?.replace(/\.png$/, '') ?? '';
     return [id, url];
   })
-) as Partial<Record<TemplateId, string>>;
+);

--- a/apps/tauri/src/renderer/features/ai-workspace/components/AIWorkspace/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-workspace/components/AIWorkspace/index.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangle, Sparkles, Zap } from 'lucide-react';
 
-import { cn } from '@ajh/ui';
+import { Button, cn } from '@ajh/ui';
 
 import { ModelSelector, useSelectedModel } from '@/components/ui/ModelSelector';
 import { useTranslation } from '@/lib/i18n';
@@ -53,8 +53,9 @@ export function AIWorkspace() {
               { id: 'compact' as PromptQuality, label: 'Fast' },
             ] as const
           ).map(({ id, label }) => (
-            <button
+            <Button
               key={id}
+              variant="unstyled"
               type="button"
               onClick={() => setPromptQuality(id)}
               className={cn(
@@ -66,7 +67,7 @@ export function AIWorkspace() {
             >
               {id === 'compact' && <Zap size={11} />}
               {label}
-            </button>
+            </Button>
           ))}
         </div>
         {promptQuality === 'compact' && (

--- a/apps/tauri/src/renderer/features/ai-workspace/hooks/useChat.ts
+++ b/apps/tauri/src/renderer/features/ai-workspace/hooks/useChat.ts
@@ -38,10 +38,14 @@ export function useChat() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const selectedModel = useRef('');
-  const generateConfig = useRef({
+  const generateConfig = useRef<{
+    provider: string;
+    baseUrl: string | undefined;
+    effort: string | undefined;
+  }>({
     provider: 'ollama',
-    baseUrl: '' as string | undefined,
-    effort: undefined as string | undefined,
+    baseUrl: '',
+    effort: undefined,
   });
 
   const getOrCreateConversation = useGetOrCreateConversation();
@@ -126,7 +130,7 @@ export function useChat() {
     setUploading(true);
     try {
       const bytes = new Uint8Array(await file.arrayBuffer());
-      const res = (await extractText.mutateAsync({ name: file.name, bytes })) as { text: string };
+      const res = await extractText.mutateAsync({ name: file.name, bytes });
       const text = (res?.text ?? '').trim();
       if (!text) {
         alert(t('ai.errors.failedToExtractText'));
@@ -184,7 +188,7 @@ export function useChat() {
         ...history,
       ];
 
-      const res = (await generateAI.mutateAsync({
+      const res = await generateAI.mutateAsync({
         model: selectedModel.current,
         messages: contextMessages,
         locale,
@@ -192,7 +196,7 @@ export function useChat() {
         provider: generateConfig.current.provider,
         baseUrl: generateConfig.current.baseUrl,
         effort: generateConfig.current.effort,
-      })) as { jobId: string };
+      });
 
       activeJobRef.current = res.jobId;
     } catch {

--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
@@ -93,8 +93,9 @@ export function AnalyzeLeftPanel({
               { id: 'compact' as PromptQuality, label: 'Fast' },
             ] as const
           ).map(({ id, label }) => (
-            <button
+            <Button
               key={id}
+              variant="unstyled"
               type="button"
               onClick={() => setPromptQuality(id)}
               className={cn(
@@ -106,7 +107,7 @@ export function AnalyzeLeftPanel({
             >
               {id === 'compact' && <Zap size={11} />}
               {label}
-            </button>
+            </Button>
           ))}
         </div>
         {promptQuality === 'compact' && (

--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
@@ -73,9 +73,7 @@ function AnalyzePage() {
     setUploading(target);
     try {
       const bytes = new Uint8Array(await file.arrayBuffer());
-      const res = (await extractTextMutation.mutateAsync({ name: file.name, bytes })) as {
-        text: string;
-      };
+      const res = await extractTextMutation.mutateAsync({ name: file.name, bytes });
       const text = (res?.text ?? '').trim();
       if (!text) {
         setUploadError(t('analyze.upload.empty'));

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/ApplicationQuestions.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/ApplicationQuestions.tsx
@@ -64,7 +64,8 @@ export function ApplicationQuestions({
 
   return (
     <div className="overflow-hidden rounded-lg border border-white/[0.06] bg-white/[0.02]">
-      <button
+      <Button
+        variant="unstyled"
         type="button"
         onClick={() => setOpen((v) => !v)}
         className="flex w-full items-center justify-between px-3 py-2.5 text-left"
@@ -82,7 +83,7 @@ export function ApplicationQuestions({
           size={13}
           className={cn('text-foreground/30 transition-transform', open && 'rotate-180')}
         />
-      </button>
+      </Button>
 
       <AnimatePresence initial={false}>
         {open && (
@@ -118,14 +119,15 @@ export function ApplicationQuestions({
                             <p className="whitespace-pre-wrap pr-6 text-[11px] leading-relaxed text-foreground/70">
                               {answer}
                             </p>
-                            <button
+                            <Button
+                              variant="unstyled"
                               type="button"
                               onClick={() => void copy(q.id, answer)}
                               title={t('autopilot.apply.questions.copy')}
                               className="absolute right-1.5 top-1.5 rounded p-0.5 text-foreground/30 transition-colors hover:text-foreground/70"
                             >
                               {copiedId === q.id ? <Check size={11} /> : <Copy size={11} />}
-                            </button>
+                            </Button>
                           </div>
                         </div>
                       )}

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/GenerationOutput.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/GenerationOutput.tsx
@@ -37,8 +37,9 @@ export function GenerationOutput({
         {target === 'both' ? (
           <div className="flex items-center gap-1">
             {(['resume', 'cover'] as const).map((o) => (
-              <button
+              <Button
                 key={o}
+                variant="unstyled"
                 type="button"
                 onClick={() => setActiveOut(o)}
                 className={cn(
@@ -51,7 +52,7 @@ export function GenerationOutput({
                 {o === 'resume'
                   ? t('autopilot.apply.target.resume')
                   : t('autopilot.apply.target.cover')}
-              </button>
+              </Button>
             ))}
           </div>
         ) : (
@@ -84,15 +85,16 @@ export function GenerationOutput({
                 <div className="fixed inset-0 z-[650]" onClick={() => setExportOpen(false)} />
                 <div className="absolute right-0 top-full z-[700] mt-1.5 w-32 overflow-hidden rounded-lg border border-white/10 bg-secondary shadow-2xl">
                   {(['pdf', 'docx', 'txt'] as const).map((fmt) => (
-                    <button
+                    <Button
                       key={fmt}
+                      variant="unstyled"
                       type="button"
                       onClick={() => void onExport(fmt)}
                       className="flex w-full items-center gap-2 px-3 py-2 text-[11px] text-foreground/65 transition-colors hover:bg-white/[0.05] hover:text-foreground"
                     >
                       <Download size={10} />
                       {t('aiGenerate.download', { fmt: fmt.toUpperCase() })}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </>

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
@@ -69,10 +69,10 @@ export function ApplyJobModal({ job, resumeText, board, onClose }: Props) {
     setUploading(true);
     try {
       const bytes = new Uint8Array(await file.arrayBuffer());
-      const res = (await extractTextMutation.mutateAsync({
+      const res = await extractTextMutation.mutateAsync({
         name: file.name,
         bytes,
-      })) as { text: string };
+      });
       const text = (res?.text ?? '').trim();
       if (text) setResume(text);
     } finally {
@@ -152,8 +152,9 @@ export function ApplyJobModal({ job, resumeText, board, onClose }: Props) {
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-1 rounded-lg bg-white/[0.04] p-0.5">
               {targets.map(({ id, label }) => (
-                <button
+                <Button
                   key={id}
+                  variant="unstyled"
                   type="button"
                   onClick={() => setTarget(id)}
                   className={cn(
@@ -164,7 +165,7 @@ export function ApplyJobModal({ job, resumeText, board, onClose }: Props) {
                   )}
                 >
                   {label}
-                </button>
+                </Button>
               ))}
             </div>
             <div className="flex items-center gap-2">

--- a/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -170,7 +170,7 @@ export function AutopilotCard({
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.2 }}
+            transition={transition.normal}
             className="overflow-hidden"
           >
             <div className="rounded-lg bg-white/[0.03] border border-white/[0.05] px-3 py-2 space-y-1 max-h-32 overflow-y-auto">
@@ -202,7 +202,8 @@ export function AutopilotCard({
                 <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-foreground/40">
                   {t('autopilot.foundJobs')} · {foundJobs.length}
                 </span>
-                <button
+                <Button
+                  variant="unstyled"
                   type="button"
                   onClick={() => setShowFound(false)}
                   aria-label={t('autopilot.collapse')}
@@ -210,7 +211,7 @@ export function AutopilotCard({
                   className="rounded p-0.5 text-foreground/30 transition-colors hover:text-foreground/70"
                 >
                   <ChevronUp size={12} />
-                </button>
+                </Button>
               </div>
               <div className="max-h-64 divide-y divide-white/[0.04] overflow-y-auto">
                 {foundJobs.map((job, i) => (
@@ -218,7 +219,8 @@ export function AutopilotCard({
                     key={`${job.url}-${i}`}
                     className="flex items-center gap-2 px-3 py-2 transition-colors hover:bg-white/[0.03]"
                   >
-                    <button
+                    <Button
+                      variant="unstyled"
                       type="button"
                       onClick={() => void openExternal.mutate(job.url)}
                       title={t('autopilot.viewJob')}
@@ -251,7 +253,7 @@ export function AutopilotCard({
                         </span>
                       )}
                       <ExternalLink size={11} className="shrink-0 text-foreground/25" />
-                    </button>
+                    </Button>
                     <Button
                       onClick={() => setApplyJob(job)}
                       title={t('autopilot.applyJob')}

--- a/apps/tauri/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
@@ -17,7 +17,7 @@ import { useSessionStore } from '@/store/session-store';
 function AutopilotPage() {
   const { t } = useTranslation();
   const { data: autopilotList = [], isLoading: loading } = useAutopilots();
-  const autopilots = autopilotList as Autopilot[];
+  const autopilots = autopilotList;
   const { autopilot, setAutopilot, resetAutopilotWizard } = useSessionStore();
   const { creating } = autopilot;
   const setCreating = (v: boolean) => setAutopilot({ creating: v });

--- a/apps/tauri/src/renderer/features/autopilot/components/CreationWizard/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/CreationWizard/index.tsx
@@ -2,7 +2,7 @@ import { AlertCircle, Check, ChevronLeft, ChevronRight, X, Zap } from 'lucide-re
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useState } from 'react';
 
-import type { Autopilot, JobPreferences } from '@ajh/shared';
+import type { Autopilot } from '@ajh/shared';
 import { Button, cn, transition } from '@ajh/ui';
 
 import { StepAction } from '@/features/autopilot/components/wizard-steps/StepAction';
@@ -36,7 +36,7 @@ export function CreationWizard({ onDone, onCancel }: CreationWizardProps) {
     (v: WizardState) => setAutopilot({ wizardForm: v }),
     [setAutopilot]
   );
-  const form = wizardForm ?? buildDefaults(jobPrefs as JobPreferences | undefined);
+  const form = wizardForm ?? buildDefaults(jobPrefs);
   const [error, setError] = useState<string | null>(null);
   const createAutopilot = useCreateAutopilot();
   const updateAutopilot = useUpdateAutopilot();
@@ -45,7 +45,7 @@ export function CreationWizard({ onDone, onCancel }: CreationWizardProps) {
   // Initialize form in the store on first open (when wizardForm is null)
   useEffect(() => {
     if (!wizardForm) {
-      setWizardForm(buildDefaults(jobPrefs as JobPreferences | undefined));
+      setWizardForm(buildDefaults(jobPrefs));
     }
   }, [wizardForm, jobPrefs, setWizardForm]);
 
@@ -53,7 +53,7 @@ export function CreationWizard({ onDone, onCancel }: CreationWizardProps) {
   // Suppressed when editing — those values come from the autopilot, not settings.
   const prefilledFields = {
     location: !editing && !!jobPrefs?.location,
-    keywords: !editing && ((jobPrefs as JobPreferences | undefined)?.techStack?.length ?? 0) > 0,
+    keywords: !editing && (jobPrefs?.techStack?.length ?? 0) > 0,
   };
 
   const set: SetFn = <K extends keyof WizardState>(k: K, v: WizardState[K]) =>
@@ -99,11 +99,10 @@ export function CreationWizard({ onDone, onCancel }: CreationWizardProps) {
       schedule: form.schedule,
     };
     try {
-      const ap = (
+      const ap =
         editingId !== null
           ? await updateAutopilot.mutateAsync({ id: editingId, ...payload })
-          : await createAutopilot.mutateAsync(payload)
-      ) as Autopilot;
+          : await createAutopilot.mutateAsync(payload);
       onDone(ap);
     } catch (err) {
       setError(

--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepFilter/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepFilter/index.tsx
@@ -28,7 +28,7 @@ export function StepFilter({ form, set, prefilled }: StepFilterProps) {
     setUploadingResume(true);
     try {
       const bytes = new Uint8Array(await file.arrayBuffer());
-      const res = (await extractText.mutateAsync({ name: file.name, bytes })) as { text: string };
+      const res = await extractText.mutateAsync({ name: file.name, bytes });
       const text = (res?.text ?? '').trim();
       if (text) set('resumeText', text);
     } finally {

--- a/apps/tauri/src/renderer/features/dashboard/components/ContinueWorking/index.tsx
+++ b/apps/tauri/src/renderer/features/dashboard/components/ContinueWorking/index.tsx
@@ -1,7 +1,7 @@
 import { Bookmark, Briefcase, FileText, Play } from 'lucide-react';
 import { useMemo } from 'react';
 
-import type { DocumentRecord, JobInteraction } from '@ajh/shared';
+import type { JobInteraction } from '@ajh/shared';
 import { GlassCard } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
@@ -24,7 +24,7 @@ export function ContinueWorking() {
   const { data: appliedRaw = [] } = useInteractions('applied');
 
   const items = useMemo(() => {
-    const docs = (docsRaw as DocumentRecord[]).slice(0, 3).map((d) => ({
+    const docs = docsRaw.slice(0, 3).map((d) => ({
       id: `doc-${d.id}`,
       name: d.title,
       sub: d.source.toUpperCase(),

--- a/apps/tauri/src/renderer/features/dashboard/components/RecentActivity/index.tsx
+++ b/apps/tauri/src/renderer/features/dashboard/components/RecentActivity/index.tsx
@@ -1,7 +1,7 @@
 import { Bookmark, Briefcase, Clock, ExternalLink, FileText, type LucideIcon } from 'lucide-react';
 import { useMemo } from 'react';
 
-import type { DocumentRecord, JobInteraction } from '@ajh/shared';
+import type { JobInteraction } from '@ajh/shared';
 import { GlassCard } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
@@ -32,7 +32,7 @@ export function RecentActivity() {
   const { data: interactionsRaw = [] } = useInteractions();
 
   const items = useMemo<ActivityItem[]>(() => {
-    const docs = (docsRaw as DocumentRecord[]).map((d) => ({
+    const docs = docsRaw.map((d) => ({
       key: `doc-${d.id}`,
       title: d.title,
       sub: d.source.toUpperCase(),

--- a/apps/tauri/src/renderer/features/jobs/components/ApplyDrawer/useApplyRun.ts
+++ b/apps/tauri/src/renderer/features/jobs/components/ApplyDrawer/useApplyRun.ts
@@ -58,12 +58,12 @@ export function useApplyRun(posting: Posting) {
     setOutcome(null);
     setRunning(true);
     try {
-      const res = (await applyJob.mutateAsync({
+      const res = await applyJob.mutateAsync({
         board: posting.source,
         url: posting.url,
         ...(coverLetter.trim() ? { coverLetter: coverLetter.trim() } : {}),
         autoSubmit,
-      })) as { jobId: string };
+      });
       jobRef.current = res.jobId;
       setJobId(res.jobId);
     } catch (err) {

--- a/apps/tauri/src/renderer/features/jobs/components/MatchScoreCard/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/MatchScoreCard/index.tsx
@@ -35,7 +35,7 @@ function ScoreBar({ label, value }: { label: string; value: number }) {
 export function MatchScoreCard({ jobId }: { jobId: string }) {
   const resumeId = useDefaultResumeId();
   const match = useMatchResume();
-  const result = match.data as (MatchScore & { error?: string }) | undefined;
+  const result: (MatchScore & { error?: string }) | undefined = match.data;
 
   return (
     <GlassCard tone="violet" className="mb-4">

--- a/apps/tauri/src/renderer/features/jobs/components/PostingRow/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/PostingRow/index.tsx
@@ -163,13 +163,14 @@ export function PostingRow({ posting, onApply, formatRelativeTime }: PostingRowP
           >
             <ExternalLink size={10} /> {t('jobs.open')}
           </a>
-          <button
+          <Button
+            variant="unstyled"
             onClick={handleCopyLink}
             className="flex items-center gap-1.5 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/70 hover:text-foreground hover:bg-white/10 transition-all duration-200"
             title={t('jobs.copyLink')}
           >
             <Copy size={10} />
-          </button>
+          </Button>
           <Button
             size="sm"
             variant={canApply ? 'glass' : 'ghost'}

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/AuthHint.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/AuthHint.tsx
@@ -1,7 +1,7 @@
 import { Info, Loader2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 
-import { transition } from '@ajh/ui';
+import { Button, transition } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 
@@ -28,7 +28,8 @@ export function AuthHint({ show, connectPending, onConnect }: Props) {
           <div className="flex items-center gap-2 rounded-lg border border-blue-400/15 bg-blue-400/5 px-3 py-2 text-[11px] text-blue-200/75">
             <Info size={12} className="shrink-0 text-blue-400/60" />
             <span>{t('jobs.authHint')}</span>
-            <button
+            <Button
+              variant="unstyled"
               type="button"
               disabled={connectPending}
               onClick={onConnect}
@@ -39,7 +40,7 @@ export function AuthHint({ show, connectPending, onConnect }: Props) {
               ) : (
                 t('jobs.authHintLink')
               )}
-            </button>
+            </Button>
           </div>
         </motion.div>
       )}

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/AuthModeBadge.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/AuthModeBadge.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 
-import { transition } from '@ajh/ui';
+import { Button, transition } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 
@@ -40,7 +40,8 @@ export function AuthModeBadge({
                 {t('jobs.modeAuthenticated')}
               </span>
               <span className="text-[10px] text-foreground/35">{t('jobs.modeAuthNote')}</span>
-              <button
+              <Button
+                variant="unstyled"
                 type="button"
                 disabled={disconnectPending}
                 onClick={onDisconnect}
@@ -51,7 +52,7 @@ export function AuthModeBadge({
                 ) : (
                   t('jobs.disconnect')
                 )}
-              </button>
+              </Button>
             </>
           ) : (
             <>

--- a/apps/tauri/src/renderer/features/monitoring/components/MonitoringPage/index.tsx
+++ b/apps/tauri/src/renderer/features/monitoring/components/MonitoringPage/index.tsx
@@ -20,21 +20,20 @@ export function MonitoringPage() {
   const { t } = useTranslation();
 
   const KIND_LABEL_MAP = useMemo(
-    () =>
-      ({
-        'ai.generate': t('monitoring.jobKinds.aiGenerate'),
-        'ai.embed': t('monitoring.jobKinds.aiEmbed'),
-        'document.import': t('monitoring.jobKinds.documentImport'),
-        'document.ocr': t('monitoring.jobKinds.documentOcr'),
-        'document.chunk': t('monitoring.jobKinds.documentChunk'),
-        'document.index': t('monitoring.jobKinds.documentIndex'),
-        'scrape.board': t('monitoring.jobKinds.scrapeBoard'),
-        'scrape.url': t('monitoring.jobKinds.scrapeUrl'),
-        'persist.job': t('monitoring.jobKinds.persistJob'),
-        'match.resume': t('monitoring.jobKinds.matchResume'),
-        'apply.job': t('monitoring.jobKinds.applyJob'),
-        'autopilot.run': t('monitoring.jobKinds.autopilotRun'),
-      }) as Record<string, string>,
+    () => ({
+      'ai.generate': t('monitoring.jobKinds.aiGenerate'),
+      'ai.embed': t('monitoring.jobKinds.aiEmbed'),
+      'document.import': t('monitoring.jobKinds.documentImport'),
+      'document.ocr': t('monitoring.jobKinds.documentOcr'),
+      'document.chunk': t('monitoring.jobKinds.documentChunk'),
+      'document.index': t('monitoring.jobKinds.documentIndex'),
+      'scrape.board': t('monitoring.jobKinds.scrapeBoard'),
+      'scrape.url': t('monitoring.jobKinds.scrapeUrl'),
+      'persist.job': t('monitoring.jobKinds.persistJob'),
+      'match.resume': t('monitoring.jobKinds.matchResume'),
+      'apply.job': t('monitoring.jobKinds.applyJob'),
+      'autopilot.run': t('monitoring.jobKinds.autopilotRun'),
+    }),
     [t]
   );
 
@@ -45,7 +44,7 @@ export function MonitoringPage() {
   };
   const { data: allJobsData } = useJobQueue();
   const { data: appVersionData } = useAppVersion();
-  const appVersion = (appVersionData as string | undefined) ?? '';
+  const appVersion = appVersionData ?? '';
 
   const allJobs = useMemo(() => (allJobsData ?? []) as JobRecord[], [allJobsData]);
 

--- a/apps/tauri/src/renderer/features/onboarding/steps/AISelectionStep/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/AISelectionStep/index.tsx
@@ -3,7 +3,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { getRecommended } from '@ajh/shared';
-import { Button, FloatingIcon } from '@ajh/ui';
+import { Button, FloatingIcon, withDelay } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { useAIModels, useSystemHealth, useSystemResources } from '@/services';
@@ -48,10 +48,7 @@ export function AISelectionStep({ onBack, onNext, direction, stepIndex, totalSte
 
   const { data: health, isLoading: healthLoading } = useSystemHealth();
   const { data: modelsRaw } = useAIModels();
-  const models = useMemo(
-    () => (modelsRaw as Array<{ name: string }> | undefined) ?? [],
-    [modelsRaw]
-  );
+  const models = useMemo(() => modelsRaw ?? [], [modelsRaw]);
 
   const ollamaReady = health?.ai.ready ?? false;
   const cliDetected = health?.cliAgents?.[cliProvider]?.detected ?? false;
@@ -114,8 +111,8 @@ export function AISelectionStep({ onBack, onNext, direction, stepIndex, totalSte
   };
 
   const handleRecheck = () => {
-    queryClient.invalidateQueries({ queryKey: keys.system.health });
-    queryClient.invalidateQueries({ queryKey: keys.ai.models });
+    void queryClient.invalidateQueries({ queryKey: keys.system.health });
+    void queryClient.invalidateQueries({ queryKey: keys.ai.models });
   };
 
   const canContinue =
@@ -143,7 +140,7 @@ export function AISelectionStep({ onBack, onNext, direction, stepIndex, totalSte
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.1 }}
+        transition={withDelay(0.1)}
         className="mb-5 text-center"
       >
         <h1 className="mb-2 text-xl font-semibold text-foreground/95">
@@ -159,7 +156,7 @@ export function AISelectionStep({ onBack, onNext, direction, stepIndex, totalSte
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.2 }}
+        transition={withDelay(0.2)}
         layout
         className="overflow-hidden"
       >
@@ -213,7 +210,7 @@ export function AISelectionStep({ onBack, onNext, direction, stepIndex, totalSte
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.15 }}
+        transition={withDelay(0.15)}
         className="flex items-center gap-3"
       >
         <Button variant="ghost" size="sm" onClick={onBack} className="flex items-center gap-1.5">

--- a/apps/tauri/src/renderer/features/onboarding/steps/ResearchStep/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ResearchStep/index.tsx
@@ -2,7 +2,7 @@ import { ArrowLeft, ArrowRight, Check, Eye, EyeOff, Key, Loader2, Search } from 
 import { motion } from 'motion/react';
 import { useState } from 'react';
 
-import { Button, FloatingIcon, Input, useNotification } from '@ajh/ui';
+import { Button, FloatingIcon, Input, useNotification, withDelay } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { useHasProviderKey, useOpenExternal, useSetProviderKey } from '@/services';
@@ -66,7 +66,7 @@ export function ResearchStep({ onBack, onNext, direction, stepIndex, totalSteps 
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.1 }}
+        transition={withDelay(0.1)}
         className="mb-5 text-center"
       >
         <h1 className="mb-2 text-xl font-semibold text-foreground/95">
@@ -78,7 +78,7 @@ export function ResearchStep({ onBack, onNext, direction, stepIndex, totalSteps 
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.15 }}
+        transition={withDelay(0.15)}
         className="mb-6"
       >
         {connected ? (
@@ -90,12 +90,13 @@ export function ResearchStep({ onBack, onNext, direction, stepIndex, totalSteps 
           <div className="space-y-2">
             <p className="text-xs text-foreground/40">
               {t('onboarding.research.getKeyAt')}{' '}
-              <button
+              <Button
+                variant="unstyled"
                 onClick={() => void openExternal.mutateAsync(KEYS_URL)}
                 className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
               >
                 {KEYS_URL.replace('https://', '')}
-              </button>
+              </Button>
             </p>
             <div className="relative">
               <Input
@@ -106,12 +107,13 @@ export function ResearchStep({ onBack, onNext, direction, stepIndex, totalSteps 
                 placeholder={t('onboarding.research.keyPlaceholder')}
                 className="w-full pr-9 text-sm"
               />
-              <button
+              <Button
+                variant="unstyled"
                 onClick={() => setShowKey((v) => !v)}
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
               >
                 {showKey ? <EyeOff size={13} /> : <Eye size={13} />}
-              </button>
+              </Button>
             </div>
             <div className="flex justify-end">
               <Button
@@ -140,7 +142,7 @@ export function ResearchStep({ onBack, onNext, direction, stepIndex, totalSteps 
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.2 }}
+        transition={withDelay(0.2)}
         className="flex items-center gap-3"
       >
         <Button variant="ghost" size="sm" onClick={onBack} className="flex items-center gap-1.5">

--- a/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep/index.tsx
@@ -3,7 +3,7 @@ import { motion } from 'motion/react';
 import { useRef, useState } from 'react';
 
 import type { DocumentRecord } from '@ajh/shared';
-import { Button, cn, FloatingIcon, useNotification } from '@ajh/ui';
+import { Button, cn, FloatingIcon, useNotification, withDelay } from '@ajh/ui';
 
 import { ProfileUrlImport } from '@/features/resume/components/ProfileUrlImport';
 import { useImportWithOcr } from '@/hooks/use-import-with-ocr';
@@ -28,7 +28,7 @@ export function ResumeStep({ onBack, onNext, direction, stepIndex, totalSteps }:
   const [dragActive, setDragActive] = useState(false);
 
   const { data: documentsRaw = [] } = useDocuments();
-  const documents = documentsRaw as DocumentRecord[];
+  const documents = documentsRaw;
   const { importFile, isPending: uploading, isOcr } = useImportWithOcr();
   const setResume = usePreferencesStore((s) => s.setResume);
 
@@ -73,7 +73,7 @@ export function ResumeStep({ onBack, onNext, direction, stepIndex, totalSteps }:
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.05 }}
+        transition={withDelay(0.05)}
         className="mb-6 text-center"
       >
         <div className="mx-auto mb-4 relative flex justify-center">
@@ -87,7 +87,7 @@ export function ResumeStep({ onBack, onNext, direction, stepIndex, totalSteps }:
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.1 }}
+        transition={withDelay(0.1)}
         onDragEnter={handleDrag}
         onDragLeave={handleDrag}
         onDragOver={handleDrag}
@@ -144,7 +144,7 @@ export function ResumeStep({ onBack, onNext, direction, stepIndex, totalSteps }:
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.15 }}
+        transition={withDelay(0.15)}
         className="mb-5"
       >
         <ProfileUrlImport
@@ -158,7 +158,7 @@ export function ResumeStep({ onBack, onNext, direction, stepIndex, totalSteps }:
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.1 }}
+        transition={withDelay(0.1)}
         className="flex items-center justify-between"
       >
         <Button variant="ghost" size="sm" onClick={onBack}>

--- a/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserDetectedState/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserDetectedState/index.tsx
@@ -2,7 +2,7 @@ import { ArrowLeft, ArrowRight, ChevronDown, ChevronUp, Globe } from 'lucide-rea
 import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 
-import { Button } from '@ajh/ui';
+import { Button, transition, withDelay } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 
@@ -23,14 +23,14 @@ export function BrowserDetectedState({ browserPath, onBack, onNext }: BrowserDet
         <motion.div
           initial={{ scale: 0.8, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
-          transition={{ duration: 0.5, type: 'spring' }}
+          transition={transition.spring}
           className="relative"
         >
           <motion.div
             animate={{
               boxShadow: ['0 0 0 0 rgba(52, 211, 153, 0.4)', '0 0 0 20px rgba(52, 211, 153, 0)'],
             }}
-            transition={{ duration: 2, repeat: Infinity }}
+            transition={transition.ping}
             className="absolute inset-0 rounded-full bg-emerald-500/20 blur-xl"
           />
           <div className="relative flex h-20 w-20 items-center justify-center rounded-2xl bg-emerald-500/10 ring-1 ring-emerald-500/30">
@@ -44,7 +44,7 @@ export function BrowserDetectedState({ browserPath, onBack, onNext }: BrowserDet
         <motion.h2
           initial={{ y: 10, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          transition={{ delay: 0.1 }}
+          transition={withDelay(0.1)}
           className="text-2xl font-semibold text-foreground/95"
         >
           Chrome Ready
@@ -52,7 +52,7 @@ export function BrowserDetectedState({ browserPath, onBack, onNext }: BrowserDet
         <motion.p
           initial={{ y: 10, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          transition={{ delay: 0.1 }}
+          transition={withDelay(0.1)}
           className="mt-2 text-sm text-foreground/50"
         >
           We'll use Chrome for secure LinkedIn authentication
@@ -63,7 +63,7 @@ export function BrowserDetectedState({ browserPath, onBack, onNext }: BrowserDet
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.2 }}
+        transition={withDelay(0.2)}
         className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-4"
       >
         <div className="flex items-center gap-3">
@@ -81,11 +81,12 @@ export function BrowserDetectedState({ browserPath, onBack, onNext }: BrowserDet
       <motion.div
         initial={{ y: 10, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.15 }}
+        transition={withDelay(0.15)}
       >
-        <button
+        <Button
+          variant="default"
           onClick={() => setShowTechnicalDetails(!showTechnicalDetails)}
-          className="flex w-full items-center justify-between rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-2.5 text-left transition-all hover:border-white/10 hover:bg-white/[0.04]"
+          className="h-auto w-full justify-between rounded-lg border-white/[0.06] bg-white/[0.02] px-4 py-2.5 text-left font-normal hover:border-white/10 hover:bg-white/[0.04]"
         >
           <span className="text-xs text-foreground/40">View technical details</span>
           {showTechnicalDetails ? (
@@ -93,14 +94,14 @@ export function BrowserDetectedState({ browserPath, onBack, onNext }: BrowserDet
           ) : (
             <ChevronDown size={14} className="text-foreground/30" />
           )}
-        </button>
+        </Button>
         <AnimatePresence>
           {showTechnicalDetails && (
             <motion.div
               initial={{ height: 0, opacity: 0 }}
               animate={{ height: 'auto', opacity: 1 }}
               exit={{ height: 0, opacity: 0 }}
-              transition={{ duration: 0.2 }}
+              transition={transition.normal}
               className="overflow-hidden"
             >
               <div className="mt-2 rounded-lg border border-white/[0.06] bg-black/30 p-3">

--- a/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserErrorState/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserErrorState/index.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft, X } from 'lucide-react';
 import { motion } from 'motion/react';
 
-import { Button } from '@ajh/ui';
+import { Button, transition } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 
@@ -19,7 +19,7 @@ export function BrowserErrorState({ onBack, onNext }: BrowserErrorStateProps) {
         <motion.div
           initial={{ scale: 0.8, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
-          transition={{ duration: 0.4 }}
+          transition={transition.slow}
           className="relative"
         >
           <div className="absolute inset-0 rounded-full bg-orange-500/20 blur-xl" />

--- a/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserLoadingState/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserLoadingState/index.tsx
@@ -1,6 +1,8 @@
 import { Globe } from 'lucide-react';
 import { motion } from 'motion/react';
 
+import { transition } from '@ajh/ui';
+
 interface BrowserLoadingStateProps {
   message: string;
 }
@@ -8,11 +10,7 @@ interface BrowserLoadingStateProps {
 export function BrowserLoadingState({ message }: BrowserLoadingStateProps) {
   return (
     <div className="flex flex-col items-center gap-4 py-8">
-      <motion.div
-        animate={{ rotate: 360 }}
-        transition={{ duration: 2, repeat: Infinity, ease: 'linear' }}
-        className="relative"
-      >
+      <motion.div animate={{ rotate: 360 }} transition={transition.spinSlow} className="relative">
         <div className="absolute inset-0 rounded-full bg-brand/20 blur-xl" />
         <div className="relative flex h-20 w-20 items-center justify-center rounded-2xl bg-brand/10 ring-1 ring-brand/30">
           <Globe size={32} className="text-brand-soft" />

--- a/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserNotDetectedState/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserNotDetectedState/index.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft, ArrowRight, ExternalLink, Globe, X } from 'lucide-react';
 import { motion } from 'motion/react';
 
-import { Button } from '@ajh/ui';
+import { Button, transition, withDelay } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { useOpenExternal } from '@/services';
@@ -27,7 +27,7 @@ export function BrowserNotDetectedState({ onBack, onNext }: BrowserNotDetectedSt
     <motion.div
       initial={{ y: 10, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
-      transition={{ delay: 0.1 }}
+      transition={withDelay(0.1)}
       className="space-y-5"
     >
       {/* Icon */}
@@ -36,7 +36,7 @@ export function BrowserNotDetectedState({ onBack, onNext }: BrowserNotDetectedSt
           animate={{
             y: [0, -8, 0],
           }}
-          transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+          transition={transition.breathe}
           className="relative"
         >
           <div className="absolute inset-0 rounded-full bg-brand/20 blur-xl" />

--- a/apps/tauri/src/renderer/features/onboarding/steps/ollama/CliAgentPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ollama/CliAgentPanel/index.tsx
@@ -75,8 +75,9 @@ export function CliAgentPanel({ selectedProvider, onProviderChange }: CliAgentPa
           const isSelected = selectedProvider === a.id;
           const isDetected = cliAgents[a.id]?.detected ?? false;
           return (
-            <button
+            <Button
               key={a.id}
+              variant="unstyled"
               onClick={() => onProviderChange(a.id)}
               className={`flex w-full items-center gap-3 rounded-xl border px-4 py-2.5 text-left transition-all duration-150 ${
                 isSelected
@@ -103,7 +104,7 @@ export function CliAgentPanel({ selectedProvider, onProviderChange }: CliAgentPa
                   </span>
                 )}
               </span>
-            </button>
+            </Button>
           );
         })}
       </div>

--- a/apps/tauri/src/renderer/features/onboarding/steps/ollama/CloudProviderPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ollama/CloudProviderPanel/index.tsx
@@ -140,8 +140,9 @@ export function CloudProviderPanel({
       {/* Provider selector */}
       <div className="space-y-2">
         {CLOUD_PROVIDERS.map((p) => (
-          <button
+          <Button
             key={p.id}
+            variant="unstyled"
             onClick={() => onProviderChange(p.id)}
             className={`flex w-full items-center gap-3 rounded-xl border px-4 py-2.5 text-left transition-all duration-150 ${
               selectedProvider === p.id
@@ -160,7 +161,7 @@ export function CloudProviderPanel({
             {selectedProvider === p.id && hasKey && (
               <CheckCircle2 size={12} className="ml-auto text-emerald-400" />
             )}
-          </button>
+          </Button>
         ))}
       </div>
 
@@ -192,12 +193,13 @@ export function CloudProviderPanel({
         <div className="space-y-2">
           <p className="text-xs text-foreground/35">
             {t('onboarding.ai.getApiKeyAt')}{' '}
-            <button
+            <Button
+              variant="unstyled"
               onClick={() => void openExternal.mutateAsync(cloudMeta?.docsUrl ?? '')}
               className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
             >
               {(cloudMeta?.docsUrl ?? '').replace('https://', '')}
-            </button>
+            </Button>
           </p>
           <div className="flex flex-col gap-2">
             <div className="relative">
@@ -209,12 +211,13 @@ export function CloudProviderPanel({
                 placeholder={cloudMeta?.placeholder ?? '…'}
                 className="w-full pr-9 text-sm"
               />
-              <button
+              <Button
+                variant="unstyled"
                 onClick={() => setShowKey((v) => !v)}
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
               >
                 {showKey ? <EyeOff size={13} /> : <Eye size={13} />}
-              </button>
+              </Button>
             </div>
             <div className="flex justify-end">
               <Button

--- a/apps/tauri/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/ModelCard.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/ModelCard.tsx
@@ -1,4 +1,5 @@
 import type { MODEL_RECS } from '@ajh/shared';
+import { Button } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 
@@ -28,7 +29,8 @@ export function ModelCard({
   const { t } = useTranslation();
 
   return (
-    <button
+    <Button
+      variant="unstyled"
       onClick={() => !tooHeavy && onSelect()}
       disabled={tooHeavy}
       className={`group relative w-full rounded-xl border px-4 py-3 text-left transition-all duration-150 ${
@@ -76,6 +78,6 @@ export function ModelCard({
           <span className="text-xs text-foreground/30">{rec.sizeGb} GB</span>
         </div>
       </div>
-    </button>
+    </Button>
   );
 }

--- a/apps/tauri/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/index.tsx
@@ -169,7 +169,7 @@ export function ModelSelectionPanel({
                       pullState === 'done' ? 'bg-emerald-500' : ''
                     }`}
                     animate={{ width: `${pullProgress}%` }}
-                    transition={{ duration: 0.4 }}
+                    transition={transition.slow}
                   />
                 </div>
               </motion.div>

--- a/apps/tauri/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
@@ -62,7 +62,7 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
     setPullProgress(0);
     try {
       const result = await pullModel.mutateAsync(selectedModel);
-      setPullJobId((result as { jobId: string }).jobId);
+      setPullJobId(result.jobId);
     } catch (err) {
       setPullState('error');
       notify(err instanceof Error ? err.message : 'Download failed.', 'error');

--- a/apps/tauri/src/renderer/features/onboarding/steps/ollama/OllamaCheckingState/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ollama/OllamaCheckingState/index.tsx
@@ -1,6 +1,8 @@
 import { Loader2 } from 'lucide-react';
 import { motion } from 'motion/react';
 
+import { transition } from '@ajh/ui';
+
 interface OllamaCheckingStateProps {
   message: string;
 }
@@ -12,7 +14,7 @@ export function OllamaCheckingState({ message }: OllamaCheckingStateProps) {
       initial={{ opacity: 0, y: 20, scale: 0.95 }}
       animate={{ opacity: 1, y: 0, scale: 1 }}
       exit={{ opacity: 0, y: -20, scale: 0.95 }}
-      transition={{ duration: 0.3 }}
+      transition={transition.slow}
       className="mb-6 flex flex-col items-center gap-3 py-6"
     >
       <Loader2 size={24} className="animate-spin text-brand-soft" />

--- a/apps/tauri/src/renderer/features/onboarding/steps/ollama/TabSwitcher/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ollama/TabSwitcher/index.tsx
@@ -1,6 +1,8 @@
 import { Cloud, Computer, type LucideIcon, Terminal } from 'lucide-react';
 import { motion } from 'motion/react';
 
+import { Button, withDelay } from '@ajh/ui';
+
 import { useTranslation } from '@/lib/i18n';
 
 export type TabMode = 'local' | 'cloud' | 'cli';
@@ -28,12 +30,13 @@ export function TabSwitcher({ mode, onModeChange }: TabSwitcherProps) {
     <motion.div
       initial={{ y: 10, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
-      transition={{ delay: 0.1 }}
+      transition={withDelay(0.1)}
       className="mb-5 flex rounded-xl border border-white/[0.07] bg-white/[0.02] p-1"
     >
       {TABS.map(({ id, label, icon: Icon }) => (
-        <button
+        <Button
           key={id}
+          variant="unstyled"
           onClick={() => onModeChange(id)}
           className={`flex flex-1 items-center justify-center gap-2 rounded-lg py-2 text-sm font-medium transition-all duration-150 ${
             mode === id
@@ -43,7 +46,7 @@ export function TabSwitcher({ mode, onModeChange }: TabSwitcherProps) {
         >
           <Icon size={14} />
           {label}
-        </button>
+        </Button>
       ))}
     </motion.div>
   );

--- a/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
@@ -202,8 +202,9 @@ export function GenerationCard({ gen }: GenerationCardProps) {
           {/* Format picker */}
           <div className="flex items-center gap-0.5 rounded-lg border border-white/[0.06] bg-white/[0.03] p-0.5">
             {EXPORT_FORMATS.map((fmt) => (
-              <button
+              <Button
                 key={fmt}
+                variant="unstyled"
                 onClick={() => setExportFormat(fmt)}
                 className={cn(
                   'rounded-md px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors',
@@ -213,7 +214,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
                 )}
               >
                 {fmt}
-              </button>
+              </Button>
             ))}
           </div>
 
@@ -221,8 +222,9 @@ export function GenerationCard({ gen }: GenerationCardProps) {
           {exportFormat !== 'txt' && (
             <div className="flex items-center gap-0.5 rounded-lg border border-white/[0.06] bg-white/[0.03] p-0.5">
               {TEMPLATE_OPTIONS.map(({ id, label }) => (
-                <button
+                <Button
                   key={id}
+                  variant="unstyled"
                   onClick={() => setExportTemplate(id)}
                   className={cn(
                     'rounded-md px-2 py-0.5 text-[10px] transition-colors',
@@ -232,7 +234,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
                   )}
                 >
                   {label}
-                </button>
+                </Button>
               ))}
             </div>
           )}
@@ -314,7 +316,8 @@ export function GenerationCard({ gen }: GenerationCardProps) {
         .filter((s) => s.text)
         .map(({ key, label, text, icon: SectionIcon }) => (
           <div key={key} className="border-t border-white/[0.04]">
-            <button
+            <Button
+              variant="unstyled"
               onClick={() => setExpanded(expanded === key ? null : key)}
               className="flex w-full items-center justify-between px-4 py-2.5 text-left text-xs text-foreground/50 hover:text-foreground/70 transition-colors"
             >
@@ -325,7 +328,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
                 size={12}
                 className={cn('transition-transform', expanded === key && 'rotate-180')}
               />
-            </button>
+            </Button>
             <AnimatePresence initial={false}>
               {expanded === key && (
                 <motion.div
@@ -347,7 +350,8 @@ export function GenerationCard({ gen }: GenerationCardProps) {
       {/* Application answers — structured Q/A from the questions assistant. */}
       {gen.applicationAnswers.length > 0 && (
         <div className="border-t border-white/[0.04]">
-          <button
+          <Button
+            variant="unstyled"
             onClick={() => setExpanded(expanded === 'answers' ? null : 'answers')}
             className="flex w-full items-center justify-between px-4 py-2.5 text-left text-xs text-foreground/50 transition-colors hover:text-foreground/70"
           >
@@ -361,7 +365,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
               size={12}
               className={cn('transition-transform', expanded === 'answers' && 'rotate-180')}
             />
-          </button>
+          </Button>
           <AnimatePresence initial={false}>
             {expanded === 'answers' && (
               <motion.div

--- a/apps/tauri/src/renderer/features/resumes/components/ResumesPage/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/ResumesPage/index.tsx
@@ -2,7 +2,6 @@ import { RefreshCw, Search, Wand2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useMemo } from 'react';
 
-import type { AiGenerationRecord } from '@ajh/shared/ipc';
 import { Button, CardSkeleton, cn, EmptyState, Input, stagger, transition } from '@ajh/ui';
 
 import { PageHeader } from '@/components/layout/PageHeader';
@@ -34,19 +33,19 @@ function ResumesPage() {
       ? (rows as Interaction[]).filter(
           (r) => r.title.toLowerCase().includes(q) || r.company.toLowerCase().includes(q)
         )
-      : (rows as Interaction[]);
+      : rows;
   }, [rows, filter]);
 
   const filteredGenerations = useMemo(() => {
     const q = filter.trim().toLowerCase();
     return q
-      ? (generations as AiGenerationRecord[]).filter(
+      ? generations.filter(
           (g) =>
             g.jobTitle.toLowerCase().includes(q) ||
             g.companyName.toLowerCase().includes(q) ||
             g.candidateName.toLowerCase().includes(q)
         )
-      : (generations as AiGenerationRecord[]);
+      : generations;
   }, [generations, filter]);
 
   const tabCfg = TAB_CONFIG.find((c) => c.id === tab) as (typeof TAB_CONFIG)[number];

--- a/apps/tauri/src/renderer/features/settings/components/SettingsPage/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SettingsPage/index.tsx
@@ -17,7 +17,7 @@ export function SettingsPage() {
   const { t } = useTranslation();
 
   const { settings, setSettings } = useSessionStore();
-  const activeSection = settings.activeSection as SectionId;
+  const activeSection = settings.activeSection;
   const setActiveSection = (v: SectionId) => setSettings({ activeSection: v });
   const userName = useUserName();
   const setUserName = usePreferencesStore((s) => s.setUserName);

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.ts
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.ts
@@ -131,7 +131,7 @@ export function useProviderKeys() {
             : `${meta.label} key saved, but no models returned. Double-check the key.`,
           count > 0 ? 'success' : 'warning'
         );
-        qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-models', provider] });
+        void qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-models', provider] });
       } catch {
         notify(
           `${meta.label} key saved, but couldn't verify it. Check that it's correct.`,
@@ -181,7 +181,7 @@ export function useProviderKeys() {
     setPulling(model);
     try {
       await pullModel.mutateAsync(model);
-      qc.invalidateQueries({ queryKey: keys.ai.models });
+      void qc.invalidateQueries({ queryKey: keys.ai.models });
       handleSelectModel('ollama', model);
       notify(`${model} downloaded and selected.`, 'success');
     } catch (err) {
@@ -198,8 +198,8 @@ export function useProviderKeys() {
   };
 
   const recheck = () => {
-    qc.invalidateQueries({ queryKey: keys.system.health });
-    qc.invalidateQueries({ queryKey: keys.ai.models });
+    void qc.invalidateQueries({ queryKey: keys.system.health });
+    void qc.invalidateQueries({ queryKey: keys.ai.models });
   };
 
   const openDocs = (url: string) => void openExternal.mutateAsync(url);

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/ActiveProviderSwitcher/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/ActiveProviderSwitcher/index.tsx
@@ -1,6 +1,6 @@
 import { Bot, CheckCircle2 } from 'lucide-react';
 
-import { GlassCard } from '@ajh/ui';
+import { Button, GlassCard } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import type { AiProvider } from '@/store/preferences-schema';
@@ -32,8 +32,9 @@ export function ActiveProviderSwitcher({ providers, meta, activeProvider, onSetA
           const m = meta[p];
           const isActive = p === activeProvider;
           return (
-            <button
+            <Button
               key={p}
+              variant="unstyled"
               onClick={() => onSetActive(p)}
               className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-all ${
                 isActive
@@ -44,7 +45,7 @@ export function ActiveProviderSwitcher({ providers, meta, activeProvider, onSetA
               <Bot size={11} className={isActive ? m.color : ''} />
               {m.label}
               {isActive && <CheckCircle2 size={10} className="text-brand-soft" />}
-            </button>
+            </Button>
           );
         })}
       </div>

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/index.tsx
@@ -80,12 +80,13 @@ export function CloudProviderConfig({
         <div className="space-y-2">
           <p className="text-xs text-foreground/40">
             {t('settings.aiProvider.getKeyAt')}{' '}
-            <button
+            <Button
+              variant="unstyled"
               onClick={onOpenDocs}
               className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
             >
               {meta.docsUrl.replace('https://', '')}
-            </button>
+            </Button>
           </p>
           <div className="flex flex-col gap-2">
             <div className="relative">
@@ -97,12 +98,13 @@ export function CloudProviderConfig({
                 placeholder={t('settings.aiProvider.keyPlaceholder')}
                 className="w-full pr-9 text-sm"
               />
-              <button
+              <Button
+                variant="unstyled"
                 onClick={onToggleShowKey}
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
               >
                 {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
-              </button>
+              </Button>
             </div>
             <div className="flex justify-end gap-2">
               <Button

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/CompanyResearchSettings/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/CompanyResearchSettings/index.tsx
@@ -84,12 +84,13 @@ export function CompanyResearchSettings() {
         <div className="space-y-2">
           <p className="text-xs text-foreground/40">
             {t('settings.companyResearch.getKeyAt')}{' '}
-            <button
+            <Button
+              variant="unstyled"
               onClick={() => void openExternal.mutateAsync(KEYS_URL)}
               className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
             >
               {KEYS_URL.replace('https://', '')}
-            </button>
+            </Button>
           </p>
           <div className="relative">
             <Input
@@ -100,12 +101,13 @@ export function CompanyResearchSettings() {
               placeholder={t('settings.companyResearch.keyPlaceholder')}
               className="w-full pr-9 text-sm"
             />
-            <button
+            <Button
+              variant="unstyled"
               onClick={() => setShowKey((v) => !v)}
               className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
             >
               {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
-            </button>
+            </Button>
           </div>
           <div className="flex items-center justify-between gap-2">
             <span className="text-[10px] text-foreground/30">

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/OllamaConfig/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/OllamaConfig/index.tsx
@@ -73,8 +73,9 @@ export function OllamaConfig({
           <p className="text-sm text-foreground/50">{t('settings.aiModel.noModels')}</p>
           {connected &&
             QUICK_MODELS.map((qm) => (
-              <button
+              <Button
                 key={qm}
+                variant="unstyled"
                 onClick={() => void onPull(qm)}
                 disabled={pulling !== null}
                 className="flex w-full items-center justify-between rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-2 text-left text-sm hover:bg-white/[0.04] disabled:opacity-50"
@@ -85,7 +86,7 @@ export function OllamaConfig({
                 ) : (
                   <Download size={13} className="text-foreground/30" />
                 )}
-              </button>
+              </Button>
             ))}
         </div>
       ) : (

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/ProviderRow/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/ProviderRow/index.tsx
@@ -76,7 +76,8 @@ export function ProviderRow({
       className={`rounded-xl border transition-all ${isExpanded ? 'border-white/15 bg-white/[0.03]' : 'border-white/[0.06] bg-white/[0.01]'}`}
     >
       {/* Row header */}
-      <button
+      <Button
+        variant="unstyled"
         onClick={onToggleExpand}
         className="flex w-full items-center gap-3 px-4 py-3 text-left"
       >
@@ -123,7 +124,7 @@ export function ProviderRow({
         ) : (
           <span className="text-[10px] text-foreground/30">Not connected</span>
         )}
-      </button>
+      </Button>
 
       {/* Expanded config */}
       {isExpanded && (

--- a/apps/tauri/src/renderer/features/settings/components/preferences/DeveloperPreferences/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/DeveloperPreferences/index.tsx
@@ -1,21 +1,17 @@
 import { Bug, Terminal } from 'lucide-react';
-import { useMutation } from '@tanstack/react-query';
 
 import { Button, cn, GlassCard, SectionLabel } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
-import { useAppClient } from '@/providers/AppClientProvider';
+import { useOpenDevtools } from '@/services';
 import { useDebugMode, usePreferencesStore } from '@/store/preferences-store';
 
 export function DeveloperPreferences() {
   const { t } = useTranslation();
-  const api = useAppClient();
   const debugMode = useDebugMode();
   const setDebugMode = usePreferencesStore((s) => s.setDebugMode);
 
-  const { mutate: openDevtools, isPending } = useMutation({
-    mutationFn: () => api.system.openDevtools() as Promise<void>,
-  });
+  const { mutate: openDevtools, isPending } = useOpenDevtools();
 
   return (
     <GlassCard>
@@ -26,7 +22,8 @@ export function DeveloperPreferences() {
 
       <div className="space-y-3">
         {/* Debug mode toggle */}
-        <button
+        <Button
+          variant="unstyled"
           type="button"
           onClick={() => setDebugMode(!debugMode)}
           className={cn(
@@ -62,7 +59,7 @@ export function DeveloperPreferences() {
               )}
             />
           </div>
-        </button>
+        </Button>
 
         {/* Open DevTools */}
         <Button

--- a/apps/tauri/src/renderer/features/settings/components/preferences/ResumePreferences/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/ResumePreferences/index.tsx
@@ -26,12 +26,8 @@ export function ResumePreferences() {
     ...d,
     id: d._id,
     importedAt: d.createdAt,
-    source: (d.source ??
-      (d.name?.endsWith('.pdf')
-        ? 'pdf'
-        : d.name?.endsWith('.docx')
-          ? 'docx'
-          : 'txt')) as DocumentRecord['source'],
+    source:
+      d.source ?? (d.name?.endsWith('.pdf') ? 'pdf' : d.name?.endsWith('.docx') ? 'docx' : 'txt'),
   }));
   const { importFile, isPending: uploading, isOcr } = useImportWithOcr();
   const removeDocument = useRemoveDocument();

--- a/apps/tauri/src/renderer/features/settings/components/privacy/PrivacySettingsTab/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/privacy/PrivacySettingsTab/index.tsx
@@ -81,11 +81,7 @@ export function PrivacySettingsTab() {
 
   const handleImport = async () => {
     try {
-      const res = (await importData.mutateAsync()) as {
-        success: boolean;
-        imported?: Record<string, number | { error: string }>;
-        error?: string;
-      };
+      const res = await importData.mutateAsync();
       if (res.success) {
         const count = Object.values(res.imported ?? {}).reduce<number>(
           (sum, v) => sum + (typeof v === 'number' ? v : 0),

--- a/apps/tauri/src/renderer/features/support/components/ContactFeedback/index.tsx
+++ b/apps/tauri/src/renderer/features/support/components/ContactFeedback/index.tsx
@@ -70,10 +70,7 @@ export function ContactFeedback() {
           loading={exportDiagnostics.isPending}
           onClick={async () => {
             try {
-              const res = (await exportDiagnostics.mutateAsync()) as {
-                success: boolean;
-                bundlePath?: string;
-              };
+              const res = await exportDiagnostics.mutateAsync();
               if (res.success) notify('Diagnostics bundle exported.', 'success');
               else notify('Export failed.', 'error');
             } catch (err) {

--- a/apps/tauri/src/renderer/hooks/use-import-with-ocr/use-import-with-ocr.ts
+++ b/apps/tauri/src/renderer/hooks/use-import-with-ocr/use-import-with-ocr.ts
@@ -1,8 +1,8 @@
-import i18n from 'i18next';
 import { useState } from 'react';
 
 import type { StructuredResume } from '@ajh/shared';
 
+import i18n from '@/i18n';
 import { ocrFile } from '@/lib/ocr';
 import { useImportDocument } from '@/services';
 

--- a/apps/tauri/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/tauri/src/renderer/lib/generate/generation/generation.ts
@@ -79,7 +79,7 @@ async function streamGenerate(
   // Resume + cover-letter generation runs through the backend orchestration
   // pipeline (a composable Pipeline of stages), not the raw generate command.
   // Same streaming contract: emits `ai:stream` deltas under the returned jobId.
-  const res = (await api.ai.generatePipeline({
+  const res = await api.ai.generatePipeline({
     model: activeModel,
     messages: [
       { role: 'system', content: system },
@@ -97,7 +97,7 @@ async function streamGenerate(
     // (num_predict). Omitted (undefined) for cloud/CLI or when unset.
     maxTokens: localLimits?.maxTokens,
     contextWindow: localLimits?.contextWindow,
-  } as Parameters<typeof api.ai.generatePipeline>[0])) as { jobId: string };
+  });
 
   const jobId = res.jobId;
   let buffer = '';
@@ -283,7 +283,7 @@ export async function researchCompany(
     const providerConfig = usePreferencesStore.getState().aiProviderConfig;
     const activeProvider = providerConfig?.activeProvider ?? 'ollama';
     const providerSettings = providerConfig?.providers?.[activeProvider];
-    const res = (await getClient().ai.researchCompany({
+    const res = await getClient().ai.researchCompany({
       jobAd,
       // The AI-extracted company name is far more reliable than the backend's
       // heuristic job-ad scan (which can grab a tagline), so send it when known.
@@ -291,7 +291,7 @@ export async function researchCompany(
       provider: activeProvider,
       model: providerSettings?.model || model,
       baseUrl: providerSettings?.baseUrl,
-    })) as { company: string; brief: string };
+    });
     return res?.brief ?? '';
   } catch {
     return '';

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -17,7 +17,7 @@
  * Every method is a jest/vitest spy-friendly async stub. Provide overrides as a
  * deep-partial — only the methods you care about need to be specified.
  */
-import type { Locale, SearchHit } from '@ajh/shared/types';
+import type { SearchHit } from '@ajh/shared/types';
 
 import type { AppClient } from '../app-client';
 
@@ -34,7 +34,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
     system: {
       health: noop,
       getVersion: noop,
-      getLocale: async () => 'en' as Locale,
+      getLocale: async () => 'en',
       setLocale: noop,
       getPlatform: noop,
       openExternal: noop,

--- a/apps/tauri/src/renderer/lib/resume-ai/resume-ai.ts
+++ b/apps/tauri/src/renderer/lib/resume-ai/resume-ai.ts
@@ -96,7 +96,7 @@ export async function runAnalysis({
   const providerConfig = usePreferencesStore.getState().aiProviderConfig;
   const activeProvider = providerConfig?.activeProvider ?? 'ollama';
   const providerSettings = providerConfig?.providers?.[activeProvider];
-  const res = (await api.ai.generate({
+  const res = await api.ai.generate({
     model: providerSettings?.model || model,
     messages: [
       { role: 'system', content: systemPrompt },
@@ -109,7 +109,7 @@ export async function runAnalysis({
     baseUrl: providerSettings?.baseUrl,
     // Reasoning effort for CLI agents that support it (e.g. Codex).
     effort: providerSettings?.effort,
-  } as Parameters<typeof api.ai.generate>[0])) as { jobId: string };
+  });
 
   const jobId = res.jobId;
   onJobId?.(jobId);

--- a/apps/tauri/src/renderer/providers/CapabilityProvider/CapabilityProvider.tsx
+++ b/apps/tauri/src/renderer/providers/CapabilityProvider/CapabilityProvider.tsx
@@ -77,7 +77,7 @@ interface CapabilityProviderProps {
  */
 export function CapabilityProvider({ children }: CapabilityProviderProps) {
   const { data: health } = useSystemHealth();
-  const caps = parseHealth(health as RuntimeHealth | undefined);
+  const caps = parseHealth(health);
 
   return <CapabilityContext.Provider value={caps}>{children}</CapabilityContext.Provider>;
 }

--- a/apps/tauri/src/renderer/services/use-ai-provider/use-ai-provider.ts
+++ b/apps/tauri/src/renderer/services/use-ai-provider/use-ai-provider.ts
@@ -22,8 +22,8 @@ export const useSetProviderKey = () => {
     mutationFn: ({ provider, apiKey }: { provider: string; apiKey: string }) =>
       api.ai.setProviderKey({ provider, apiKey }),
     onSuccess: (_data, { provider }) => {
-      qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-key', provider] });
-      qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-models', provider] });
+      void qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-key', provider] });
+      void qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-models', provider] });
     },
   });
 };
@@ -34,7 +34,7 @@ export const useRemoveProviderKey = () => {
   return useMutation({
     mutationFn: ({ provider }: { provider: string }) => api.ai.removeProviderKey({ provider }),
     onSuccess: (_data, { provider }) => {
-      qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-key', provider] });
+      void qc.invalidateQueries({ queryKey: [...keys.ai.models, 'provider-key', provider] });
     },
   });
 };
@@ -85,7 +85,7 @@ export const useSetEmbeddingConfig = () => {
     mutationFn: (req: { provider: string; model?: string; baseUrl?: string }) =>
       api.ai.setEmbeddingConfig(req),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
+      void qc.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
     },
   });
 };

--- a/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.ts
+++ b/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.ts
@@ -92,6 +92,6 @@ export const useAutopilotStepEvents = (onStep?: (event: AutopilotStepEvent) => v
     const off = api.autopilot.onStep((event: unknown) => {
       onStep?.(event as AutopilotStepEvent);
     });
-    return () => (off as unknown as () => void)?.();
+    return () => off?.();
   }, [api, onStep]);
 };

--- a/apps/tauri/src/renderer/services/use-profile-import/use-profile-import.ts
+++ b/apps/tauri/src/renderer/services/use-profile-import/use-profile-import.ts
@@ -16,7 +16,7 @@ export const useProfileImport = () => {
       api.linkedin.importProfileFromUrl(url) as Promise<ProfileImportResult>,
     onSuccess: (result) => {
       if (!('error' in result)) {
-        qc.invalidateQueries({ queryKey: keys.documents.all });
+        void qc.invalidateQueries({ queryKey: keys.documents.all });
       }
     },
   });

--- a/apps/tauri/src/renderer/services/use-system/use-system.ts
+++ b/apps/tauri/src/renderer/services/use-system/use-system.ts
@@ -75,6 +75,12 @@ export const useOpenExternal = () => {
   return useMutation({ mutationFn: (url: string) => api.system.openExternal(url) });
 };
 
+/** Open the webview devtools (Developer settings). On-demand, so a mutation. */
+export const useOpenDevtools = () => {
+  const api = useAppClient();
+  return useMutation({ mutationFn: () => api.system.openDevtools() });
+};
+
 export const useSetPerformanceMode = () => {
   const api = useAppClient();
   return useMutation({

--- a/apps/tauri/src/renderer/test-support.tsx
+++ b/apps/tauri/src/renderer/test-support.tsx
@@ -36,7 +36,7 @@ export function createMockClient(
           return target[method];
         },
       }
-    ) as Record<string, unknown>;
+    );
 
   return new Proxy(
     {},

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -118,18 +118,24 @@ import { Button, Input, GlassCard, Modal } from '@ajh/ui';
 #### `Button`
 
 ```typescript
-<Button variant="primary" size="md" loading={false} disabled={false}>
+<Button variant="default" size="md" loading={false} disabled={false}>
   Apply Now
 </Button>
 ```
 
-| Prop                     | Type      | Values                                             |
-| ------------------------ | --------- | -------------------------------------------------- |
-| `variant`                | string    | `primary` `secondary` `ghost` `destructive` `link` |
-| `size`                   | string    | `xs` `sm` `md` `lg`                                |
-| `loading`                | boolean   | Shows spinner, disables click                      |
-| `disabled`               | boolean   | Greyed out, no interaction                         |
-| `leftIcon` / `rightIcon` | ReactNode | Lucide icon component                              |
+| Prop       | Type    | Values                                                                   |
+| ---------- | ------- | ------------------------------------------------------------------------ |
+| `variant`  | string  | `default` `glass` `ghost` `danger` `warning` `info` `success` `unstyled` |
+| `size`     | string  | `sm` `md` `lg`                                                           |
+| `loading`  | boolean | Shows spinner, disables click                                            |
+| `disabled` | boolean | Greyed out, no interaction                                               |
+
+> **`unstyled`** is an escape hatch for custom interactive surfaces — segmented controls,
+> icon toggles, inline text links, clickable cards — that supply their own appearance via
+> `className`. It injects no chrome (no border / background / size / layout) but still routes
+> through `Button` for consistent focus-visible + disabled handling. Prefer a semantic variant;
+> reach for `unstyled` only when a styled variant would fight the call site. `Input` ships the
+> same `unstyled` variant for inline/borderless fields.
 
 #### `Input`
 
@@ -411,15 +417,16 @@ import { cn } from "@/lib/cn";
 
 These are enforced in CI (`pnpm lint:strict`) by [ESLint][eslint]:
 
-| Rule                                 | What it prevents                 |
-| ------------------------------------ | -------------------------------- |
-| No `[#RRGGBB]` in className          | Hardcoded hex colors             |
-| No `<button>` raw element            | Missing Button primitive         |
-| No `<select>` raw element            | Missing SelectDropdown primitive |
-| No `<textarea>` raw element          | Missing TextArea primitive       |
-| No inline `{duration, ease}` objects | Missing motion token             |
-| No `window.api.*` in features/routes | Direct IPC bypass                |
-| No `react-i18next` direct import     | Missing i18n wrapper             |
+| Rule                                 | What it prevents                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------------------- |
+| No `[#RRGGBB]` in className          | Hardcoded hex colors                                                             |
+| No `<button>` raw element            | Missing Button primitive (use `variant="unstyled"` for custom surfaces)          |
+| No `<select>` raw element            | Missing SelectDropdown primitive                                                 |
+| No `<textarea>` raw element          | Missing TextArea primitive                                                       |
+| No `<input>` raw element             | Missing Input primitive — `type=range\|file\|checkbox\|radio\|hidden` are exempt |
+| No inline `{duration, ease}` objects | Missing motion token (use `transition.*`, `withDelay()`)                         |
+| No `window.api.*` in features/routes | Direct IPC bypass                                                                |
+| No `react-i18next` direct import     | Missing i18n wrapper                                                             |
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,11 +26,15 @@ const WINDOW_API_DIRECT =
 const RAW_BUTTON = 'JSXOpeningElement[name.name="button"]';
 const RAW_SELECT = 'JSXOpeningElement[name.name="select"]';
 const RAW_TEXTAREA = 'JSXOpeningElement[name.name="textarea"]';
-const RAW_INPUT = 'JSXOpeningElement[name.name="input"]';
+// <Input> is a styled text field; native structural types (range slider, file
+// picker, checkbox, radio, hidden) must NOT be forced through it. The selector
+// excludes those literal types so it matches its own documented message.
+const RAW_INPUT =
+  'JSXOpeningElement[name.name="input"]:not(:has(JSXAttribute[name.name="type"] > Literal[value=/^(?:range|file|checkbox|radio|hidden)$/]))';
 
 // ── Forbidden deep UI import paths (all resolve to @ajh/ui exports) ──────────
 // UpdateBanner is intentionally omitted — it is app-specific and lives only
-// in apps/desktop/src/renderer/components/ui/UpdateBanner.tsx.
+// in apps/tauri/src/renderer/components/ui/UpdateBanner.tsx.
 const DEEP_UI_IMPORTS = [
   '@/components/ui/ActionTile',
   '@/components/ui/Button',
@@ -203,7 +207,7 @@ export default tseslint.config(
 
   // ── All renderer source — i18n adapter + package boundary ──────────────────
   {
-    files: ['apps/desktop/src/renderer/**/*.ts', 'apps/desktop/src/renderer/**/*.tsx'],
+    files: ['apps/tauri/src/renderer/**/*.ts', 'apps/tauri/src/renderer/**/*.tsx'],
     rules: {
       'no-restricted-imports': ['error', { ...I18N_IMPORT_RESTRICTION }],
     },
@@ -213,9 +217,9 @@ export default tseslint.config(
   // These files have the full set of design system + architecture restrictions.
   {
     files: [
-      'apps/desktop/src/renderer/features/**/*.tsx',
-      'apps/desktop/src/renderer/routes/**/*.tsx',
-      'apps/desktop/src/renderer/components/**/*.tsx',
+      'apps/tauri/src/renderer/features/**/*.tsx',
+      'apps/tauri/src/renderer/routes/**/*.tsx',
+      'apps/tauri/src/renderer/components/**/*.tsx',
     ],
     rules: {
       // Extends the renderer-level restriction with deep UI import ban
@@ -281,7 +285,7 @@ export default tseslint.config(
   // To disable: comment out this entire block. Rules here catch async misuse
   // that plain type checking won't surface until runtime.
   {
-    files: ['apps/desktop/src/renderer/**/*.ts', 'apps/desktop/src/renderer/**/*.tsx'],
+    files: ['apps/tauri/src/renderer/**/*.ts', 'apps/tauri/src/renderer/**/*.tsx'],
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -300,7 +304,7 @@ export default tseslint.config(
 
   // ── Service layer — allowed to call window.api directly ───────────────────
   {
-    files: ['apps/desktop/src/renderer/services/**/*.ts'],
+    files: ['apps/tauri/src/renderer/services/**/*.ts'],
     rules: {
       'no-restricted-syntax': 'off',
     },
@@ -309,26 +313,32 @@ export default tseslint.config(
   // ── React Query boundary — only services can use React Query directly ───────
   {
     files: [
-      'apps/desktop/src/renderer/features/**/*.tsx',
-      'apps/desktop/src/renderer/routes/**/*.tsx',
-      'apps/desktop/src/renderer/components/**/*.tsx',
+      'apps/tauri/src/renderer/features/**/*.tsx',
+      'apps/tauri/src/renderer/routes/**/*.tsx',
+      'apps/tauri/src/renderer/components/**/*.tsx',
     ],
     rules: {
       'no-restricted-imports': [
         'error',
         {
-          ...I18N_IMPORT_RESTRICTION,
-          patterns: [
-            {
-              group: DEEP_UI_IMPORTS,
-              message:
-                "Import from '@ajh/ui' directly instead of deep component paths. Example: import { Button } from '@ajh/ui'. The only exception is UpdateBanner: import { UpdateBanner } from '@/components/ui/UpdateBanner'.",
-            },
+          // `paths` restricts named modules (name + importNames); `patterns`
+          // restricts globs (group). React Query is a named module, so it must
+          // live in `paths` — putting it in `patterns` is a schema error that
+          // was masked while this block's glob matched no files.
+          paths: [
+            ...I18N_IMPORT_RESTRICTION.paths,
             {
               name: '@tanstack/react-query',
               importNames: ['useQuery', 'useMutation', 'useQueryClient', 'QueryClient'],
               message:
                 "Don't use React Query hooks directly in UI components. Use service hooks from '@/services/' instead (e.g. useDocuments, useJobs). This enforces the Ports & Adapters boundary.",
+            },
+          ],
+          patterns: [
+            {
+              group: DEEP_UI_IMPORTS,
+              message:
+                "Import from '@ajh/ui' directly instead of deep component paths. Example: import { Button } from '@ajh/ui'. The only exception is UpdateBanner: import { UpdateBanner } from '@/components/ui/UpdateBanner'.",
             },
           ],
         },
@@ -338,7 +348,7 @@ export default tseslint.config(
 
   // ── i18n adapter and setup — allowed to import react-i18next directly ──────
   {
-    files: ['apps/desktop/src/renderer/lib/i18n.ts', 'apps/desktop/src/renderer/i18n/index.ts'],
+    files: ['apps/tauri/src/renderer/lib/i18n/i18n.ts', 'apps/tauri/src/renderer/i18n/index.ts'],
     rules: {
       'no-restricted-imports': 'off',
     },
@@ -368,17 +378,6 @@ export default tseslint.config(
       ),
       // Stories intentionally use raw <button> for demo content
       'no-restricted-syntax': 'off',
-    },
-  },
-
-  // ── Approved `any` exceptions — complex dynamic ESM types ──────────────────
-  // These files use dynamic import() with external libraries whose types are
-  // only resolvable at runtime. Inline suppression is banned; this is the
-  // approved exception point.
-  {
-    files: ['apps/desktop/src/main/updater.ts', 'apps/desktop/src/renderer/lib/generate-ai.ts'],
-    rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
     },
   },
 

--- a/packages/ui/src/components/Button/Button.test.tsx
+++ b/packages/ui/src/components/Button/Button.test.tsx
@@ -43,4 +43,21 @@ describe('Button', () => {
     expect(btn.className).toContain('custom');
     expect(btn.className).toContain('h-10');
   });
+
+  it('injects no chrome for the unstyled variant but keeps a11y essentials', () => {
+    render(
+      <Button variant="unstyled" className="custom-surface">
+        Bare
+      </Button>
+    );
+    const btn = screen.getByRole('button');
+    // Call site owns the look…
+    expect(btn.className).toContain('custom-surface');
+    // …so no layout/size chrome is injected.
+    expect(btn.className).not.toContain('inline-flex');
+    expect(btn.className).not.toContain('h-8');
+    // Focus + disabled handling still apply (the reason to route through Button).
+    expect(btn.className).toContain('focus-visible:ring-2');
+    expect(btn.className).toContain('disabled:opacity-45');
+  });
 });

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -4,22 +4,31 @@ import { type ButtonHTMLAttributes, forwardRef } from 'react';
 import { cn } from '../../lib/cn';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'default' | 'glass' | 'ghost' | 'danger' | 'warning' | 'info' | 'success';
+  variant?: 'default' | 'glass' | 'ghost' | 'danger' | 'warning' | 'info' | 'success' | 'unstyled';
   size?: 'sm' | 'md' | 'lg';
   loading?: boolean;
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = 'default', size = 'md', loading, disabled, children, ...props }, ref) => {
+    // `unstyled` is an escape hatch for custom interactive surfaces (clickable
+    // cards, segmented controls, icon toggles, inline text links) that supply
+    // their own appearance via className. It still routes through this primitive
+    // for consistent focus-visible + disabled handling, but injects no chrome.
+    const unstyled = variant === 'unstyled';
     return (
       <button
         ref={ref}
         disabled={disabled || loading}
         className={cn(
-          // Base
-          'inline-flex items-center gap-2 rounded-lg font-medium transition-all duration-150',
+          // Base (skipped for `unstyled` — the call site owns layout/look)
+          !unstyled && [
+            'inline-flex items-center gap-2 rounded-lg font-medium transition-all duration-150',
+            'active:scale-[0.97]',
+          ],
+          // Accessibility essentials apply to every variant
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent',
-          'active:scale-[0.97] disabled:pointer-events-none disabled:opacity-45',
+          'disabled:pointer-events-none disabled:opacity-45',
 
           // Variants
           variant === 'ghost' && [
@@ -51,10 +60,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             'hover:border-emerald-500/40 hover:bg-emerald-500/20 hover:text-emerald-200',
           ],
 
-          // Sizes
-          size === 'sm' && 'h-7 px-2.5 text-xs',
-          size === 'md' && 'h-8 px-3.5 text-sm',
-          size === 'lg' && 'h-10 px-5 text-sm',
+          // Sizes (skipped for `unstyled`)
+          !unstyled && size === 'sm' && 'h-7 px-2.5 text-xs',
+          !unstyled && size === 'md' && 'h-8 px-3.5 text-sm',
+          !unstyled && size === 'lg' && 'h-10 px-5 text-sm',
 
           className
         )}

--- a/packages/ui/src/components/Input/Input.test.tsx
+++ b/packages/ui/src/components/Input/Input.test.tsx
@@ -25,4 +25,12 @@ describe('Input', () => {
     render(<Input variant="default" placeholder="x" />);
     expect(screen.getByPlaceholderText('x').className).toContain('bg-white/5');
   });
+
+  it('injects no field chrome for the unstyled variant', () => {
+    render(<Input variant="unstyled" className="bare" placeholder="u" />);
+    const input = screen.getByPlaceholderText('u');
+    expect(input.className).toContain('bare');
+    expect(input.className).not.toContain('input-field');
+    expect(input.className).not.toContain('glass-dropdown');
+  });
 });

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -3,17 +3,22 @@ import { forwardRef, type InputHTMLAttributes } from 'react';
 import { cn } from '../../lib/cn';
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
-  variant?: 'default' | 'glass';
+  variant?: 'default' | 'glass' | 'unstyled';
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, variant = 'glass', type = 'text', ...props }, ref) => {
+    // `unstyled` is an escape hatch for inline/embedded fields (e.g. a borderless
+    // input sitting inside a card row) that supply their own appearance via
+    // className. It still routes through this primitive for consistency.
+    const unstyled = variant === 'unstyled';
     return (
       <input
         ref={ref}
         type={type}
         className={cn(
-          'input-field rounded-lg px-3 py-2 text-sm text-foreground placeholder:text-foreground/30',
+          !unstyled &&
+            'input-field rounded-lg px-3 py-2 text-sm text-foreground placeholder:text-foreground/30',
           variant === 'default' && 'bg-white/5',
           variant === 'glass' && 'glass-dropdown',
           className

--- a/packages/ui/src/lib/motion.test.ts
+++ b/packages/ui/src/lib/motion.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { prefersReducedMotion, resolveTransition, staggeredItem, transition } from './motion';
+import {
+  prefersReducedMotion,
+  resolveTransition,
+  staggeredItem,
+  transition,
+  withDelay,
+} from './motion';
 
 describe('staggeredItem', () => {
   it('scales the delay with the index', () => {
@@ -11,6 +17,15 @@ describe('staggeredItem', () => {
   it('caps the delay at maxDelay', () => {
     expect(staggeredItem(1000).delay).toBe(0.2);
     expect(staggeredItem(1000, 0.5).delay).toBe(0.5);
+  });
+});
+
+describe('withDelay', () => {
+  it('wraps transition.normal with an explicit delay', () => {
+    const t = withDelay(0.15);
+    expect(t.delay).toBe(0.15);
+    expect(t.duration).toBe(transition.normal.duration);
+    expect(t.ease).toBe(transition.normal.ease);
   });
 });
 

--- a/packages/ui/src/lib/motion.ts
+++ b/packages/ui/src/lib/motion.ts
@@ -62,6 +62,12 @@ export const transition = {
   spin: { duration: 1, repeat: Infinity, ease: 'linear' },
   /** Pulsing / breathing ambient animation */
   pulse: { duration: 1.5, repeat: Infinity, ease: 'easeInOut' },
+  /** Slow continuous rotation — large loader rings (half the speed of `spin`) */
+  spinSlow: { duration: 2, repeat: Infinity, ease: 'linear' },
+  /** Gentle floating / breathing motion — hero icons (slower than `pulse`) */
+  breathe: { duration: 3, repeat: Infinity, ease: 'easeInOut' },
+  /** Expanding ring ripple / ping halo */
+  ping: { duration: 2, repeat: Infinity },
   /** Progress bar fill */
   progress: { duration: 0.8, ease: 'easeOut' },
   /** Data / score bar fill with smooth ease */
@@ -83,6 +89,12 @@ export const staggeredItem = (index: number, maxDelay = 0.2) => ({
   ...transition.normal,
   delay: Math.min(index * 0.01, maxDelay),
 });
+
+/**
+ * `transition.normal` with an explicit entrance delay — for sequenced reveals
+ * (headings → content → actions) where the delay is hand-tuned, not index-based.
+ */
+export const withDelay = (delay: number) => ({ ...transition.normal, delay });
 
 // ── Animation variant sets ────────────────────────────────────────────────
 // Spread onto motion elements: `{...variants.fadeSlideUp}`


### PR DESCRIPTION
## Why

The design-system ESLint ruleset **and** the type-checked rules (`no-floating-promises`, `no-misused-promises`, `no-unnecessary-type-assertion`) were silently **inert**: their file globs targeted `apps/desktop` — a directory that no longer exists — so every rule matched zero files. Raw `<button>`/`<input>`, inline motion objects, `window.api`/react-query boundary leaks, and floating promises were never caught.

## What

**Config repair + hardening** (`eslint.config.mjs`)
- Retarget all globs `apps/desktop/src/renderer` → `apps/tauri/src/renderer`; fix the i18n adapter path (`lib/i18n/i18n.ts`).
- Fix a latent schema bug: the `@tanstack/react-query` restriction lived under `patterns` (which only accepts `group`) — moved to `paths`.
- Teach `RAW_INPUT` to honor its own documented exceptions (`range|file|checkbox|radio|hidden`). **12 of 13** flagged inputs were false positives the message already said were allowed.

**Cleared all 92 surfaced violations**
- **11** floating promises → `void`.
- **2** restricted imports → import the i18n instance from `@/i18n`; add a `useOpenDevtools` service hook (Ports & Adapters).
- **25** inline `transition={{…}}` → motion tokens. Added a `withDelay()` helper + `spinSlow`/`breathe`/`ping` ambient tokens so delayed/continuous animations stay in the token layer.
- **41** raw `<button>` → `<Button>` and **1** raw `<input>` → `<Input>`, via a new **`unstyled`** variant. It routes custom surfaces (segmented controls, icon toggles, inline links, clickable cards) through the primitive for consistent focus-visible + disabled handling **without injecting chrome** — so each call site keeps its exact look (className preserved verbatim).

**Tooling-discrepancy fix**
- Reverted spurious `no-unnecessary-type-assertion` autofixes that removed load-bearing assertions (e.g. `match.data as (MatchScore & { error? })`, `'' as string | undefined`, `as HTMLTextAreaElement`) and broke `tsc`. Replaced with explicit type annotations / generics so ESLint and `tsc` agree.

## Verification

- `pnpm lint:strict` → **0** (was 92).
- `pnpm typecheck` → **7/7 tasks**.
- `@ajh/ui` tests **124 + 3 new** (unstyled Button/Input + `withDelay`); affected `apps/tauri` suites green.
- Button/input conversions are **className-faithful by construction** (same element, same classes; `unstyled` injects no visual chrome — covered by a test). A visual spot-check of high-conversion screens (onboarding, AI settings) is a good optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)