### PR TITLE
fix: correct invalid bg-brand/08 opacity and guard it in eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ playwright/.cache/
 test-results/
 vitest.config.*.timestamp-*
 
+# UX-audit screenshots — captured locally for review only; large binaries, never committed
+docs/assets/ux-audit/
+
 # ── OS files ───────────────────────────────────────────────────────────────────
 # macOS
 .DS_Store

--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepAction/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepAction/index.tsx
@@ -61,7 +61,7 @@ export function StepAction({ form, set }: StepActionProps) {
               className={cn(
                 'w-full flex items-start gap-3 rounded-xl border px-4 py-3 text-left transition-all h-auto',
                 form.action === id
-                  ? 'border-brand/35 bg-brand/08'
+                  ? 'border-brand/35 bg-brand/10'
                   : 'border-white/[0.05] hover:border-white/[0.08]'
               )}
             >

--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepSchedule/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepSchedule/index.tsx
@@ -55,7 +55,7 @@ export function StepSchedule({ form, set }: StepScheduleProps) {
             className={cn(
               'w-full flex items-center gap-3 rounded-xl border px-4 py-3 text-left transition-all h-auto',
               form.schedule === id
-                ? 'border-brand/35 bg-brand/08'
+                ? 'border-brand/35 bg-brand/10'
                 : 'border-white/[0.05] hover:border-white/[0.08]'
             )}
           >

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,12 @@ import globals from 'globals';
 const HARDCODED_HEX_IN_CLASSNAME =
   'JSXAttribute[name.name="className"] Literal[value=/\\[#[0-9a-fA-F]{3,6}/]';
 
+// Invalid Tailwind opacity modifier with a leading zero (e.g. `bg-brand/08`):
+// Tailwind drops it silently and the element renders with NO value, so a
+// "selected" state looks identical to unselected. Match `/0` directly followed
+// by a digit, anywhere in a className string literal.
+const INVALID_OPACITY_IN_CLASSNAME = 'JSXAttribute[name.name="className"] Literal[value=/\\/0\\d/]';
+
 const HARDCODED_HEX_IN_STYLE =
   'JSXAttribute[name.name="style"] Property > Literal[value=/#[0-9a-fA-F]{3,6}/]';
 
@@ -201,6 +207,11 @@ export default tseslint.config(
           message:
             'Use CSS custom properties (var(--color-brand), var(--color-brand-soft)) instead of hardcoded hex in style objects.',
         },
+        {
+          selector: INVALID_OPACITY_IN_CLASSNAME,
+          message:
+            'Invalid Tailwind opacity (leading zero, e.g. bg-brand/08) is silently dropped — use a valid step like /10.',
+        },
       ],
     },
   },
@@ -247,6 +258,11 @@ export default tseslint.config(
           selector: HARDCODED_HEX_IN_STYLE,
           message:
             'Use CSS custom properties (var(--color-brand)) instead of hardcoded hex in style objects.',
+        },
+        {
+          selector: INVALID_OPACITY_IN_CLASSNAME,
+          message:
+            'Invalid Tailwind opacity (leading zero, e.g. bg-brand/08) is silently dropped — use a valid step like /10.',
         },
         {
           selector: INLINE_TRANSITION_OBJECT,


### PR DESCRIPTION
## Why
`bg-brand/08` is an **invalid Tailwind opacity** (leading zero) — it's dropped at build, so the element gets **no background**. The selected Autopilot **schedule** and **action** wizard cards therefore rendered with no fill (invisible selection). No lint rule caught it. _(UX audit §3.1 — the one concrete consistency defect.)_

## What
- `bg-brand/08` → `bg-brand/10` in `wizard-steps/StepSchedule` + `StepAction`.
- New ESLint `no-restricted-syntax` guard (`/0<digit>` in `className`) registered in both the base (warn) and UI-layer (error) blocks, so this class of typo can't silently ship again.
- gitignore `docs/assets/ux-audit/` — UX-audit review screenshots are large binaries and should never be committed.

## Verify
- Guard fires on a planted `bg-brand/08` (confirmed) and matches **nothing** valid across the repo.
- `pnpm lint:strict` → 0.

First of the UX-audit §12 backlog (full program).

🤖 Generated with [Claude Code](https://claude.com/claude-code)