### PR TITLE
fix: restore visible focus rings and add dialog + toggle aria semantics

### DIFF
--- a/apps/tauri/src/renderer/features/ai-generate/components/GenerationConfig/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/GenerationConfig/index.tsx
@@ -208,6 +208,8 @@ export function GenerationConfig({
         <Button
           variant="unstyled"
           type="button"
+          role="switch"
+          aria-checked={atsMode}
           onClick={() => onAtsModeChange(!atsMode)}
           className={cn(
             'w-full flex items-center justify-between rounded-lg border px-3 py-2.5 transition-all text-left',

--- a/apps/tauri/src/renderer/features/settings/components/preferences/DeveloperPreferences/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/DeveloperPreferences/index.tsx
@@ -25,6 +25,8 @@ export function DeveloperPreferences() {
         <Button
           variant="unstyled"
           type="button"
+          role="switch"
+          aria-checked={debugMode}
           onClick={() => setDebugMode(!debugMode)}
           className={cn(
             'w-full flex items-center justify-between rounded-lg border px-3 py-2.5 transition-all text-left',

--- a/packages/ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import { AlertOctagon, AlertTriangle, CheckCircle, Info, type LucideIcon, X } from 'lucide-react';
+import { useId } from 'react';
 
 import { cn } from '../../lib/cn';
 import { Button } from '../Button';
@@ -76,9 +77,16 @@ export function ConfirmModal({
 }: ConfirmModalProps) {
   const config = variantConfig[variant];
   const Icon = config.icon;
+  const titleId = useId();
 
   return (
-    <ModalShell open={open} onClose={onClose} borderClass={config.border} zIndex={600}>
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      borderClass={config.border}
+      zIndex={600}
+      ariaLabelledby={titleId}
+    >
       {/* Header */}
       <div className="flex items-start justify-between border-b border-white/5 px-6 py-5">
         <div className="flex items-center gap-3">
@@ -91,7 +99,7 @@ export function ConfirmModal({
           >
             <Icon size={18} aria-hidden="true" />
           </div>
-          <div className="text-base font-medium text-foreground" id="modal-title">
+          <div className="text-base font-medium text-foreground" id={titleId}>
             {title}
           </div>
         </div>

--- a/packages/ui/src/components/ModalShell/ModalShell.tsx
+++ b/packages/ui/src/components/ModalShell/ModalShell.tsx
@@ -19,6 +19,10 @@ export interface ModalShellProps {
   zIndex?: number;
   /** Border color class applied to the panel — e.g. "border-red-500/30" */
   borderClass?: string;
+  /** id of the element labelling the dialog (wired to aria-labelledby). */
+  ariaLabelledby?: string;
+  /** Accessible name when there is no visible title element to reference. */
+  ariaLabel?: string;
 }
 
 /**
@@ -33,6 +37,8 @@ export function ModalShell({
   className,
   zIndex = 600,
   borderClass,
+  ariaLabelledby,
+  ariaLabel,
 }: ModalShellProps) {
   const trapRef = useFocusTrap(open);
 
@@ -78,6 +84,8 @@ export function ModalShell({
               ref={trapRef as React.RefObject<HTMLDivElement>}
               role="dialog"
               aria-modal="true"
+              aria-labelledby={ariaLabelledby}
+              aria-label={ariaLabel}
               className={cn(
                 'glass-modal relative w-full overflow-hidden rounded-2xl border shadow-xl',
                 maxWidth,

--- a/packages/ui/src/css/utilities.css
+++ b/packages/ui/src/css/utilities.css
@@ -186,7 +186,7 @@
 /* ── Input ───────────────────────────────────────────────────────────────── */
 .input-field:focus-visible {
   outline: none;
-  box-shadow: none;
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--color-brand) 50%, transparent);
 }
 
 /* ── Animations ──────────────────────────────────────────────────────────── */
@@ -508,8 +508,13 @@
 }
 
 /* ── Focus rings ─────────────────────────────────────────────────────────── */
+/* Visible default focus ring for every keyboard-focusable element. Components
+   that render their own ring pair `focus-visible:outline-none` with it (higher
+   specificity than this bare `:focus-visible`), so they opt out automatically —
+   no double ring. This closes the WCAG 2.4.7 hole left by a blanket reset. */
 :focus-visible {
-  outline: none;
+  outline: 2px solid var(--color-brand);
+  outline-offset: 2px;
 }
 
 /* ── Theme-switch crossfade (View Transition API) ────────────────────────────


### PR DESCRIPTION
## Why
`:focus-visible { outline: none }` was set **globally** with no compensating ring, so any element that doesn't bring its own ring (links, `<label>`s, `div[role=button]` rows) focused **invisibly** — a WCAG 2.4.7 failure. Inputs/textareas had their focus indicator explicitly zeroed. Dialogs had no accessible name; the ATS/debug toggles had no switch semantics. _(UX audit §4.)_

## What
- **Global focus ring:** `:focus-visible` now draws a visible `2px solid var(--color-brand)` outline. Components that own a ring already pair `focus-visible:outline-none` (higher specificity than a bare `:focus-visible`), so they **opt out automatically — no double ring** (verified visually).
- **Inputs + textareas:** `.input-field:focus-visible` now shows a brand ring (was `box-shadow: none`), covering `<Input>` and `<TextArea>` centrally.
- **Dialogs:** `ModalShell` gains `ariaLabelledby`/`ariaLabel` props; `ConfirmModal` wires its title via `useId()` → `aria-labelledby`.
- **Toggles:** `role="switch"` + `aria-checked` on the ATS-mode and debug-mode toggles.

## Verify
- `pnpm lint:strict` → 0 · `typecheck` → 7/7 · `@ajh/ui` tests → 129 pass.
- Keyboard-focus capture confirms the ring renders and primitives don't double-ring.

UX-audit §12 backlog, PR 2/13. Independent of #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)