### PR TITLE
refactor: extract shared segmented-control primitive and consolidate glass cards

### DIFF
--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
@@ -41,8 +41,9 @@ describe('OutputPanelDone — preview/edit', () => {
 
   it('switches to a raw textarea with markers intact (export source untouched)', () => {
     const { onOutputChange } = renderPanel();
-    // The toggle button's label resolves to "Edit" (or the raw i18n key) — both match.
-    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    // The Preview/Edit switch is a SegmentedControl radio group; the "Edit" radio's
+    // accessible name resolves to "Edit" (or the raw i18n key) — both match.
+    fireEvent.click(screen.getByRole('radio', { name: /edit/i }));
 
     const textarea = screen.getByRole<HTMLTextAreaElement>('textbox');
     // Raw text — including the **payments** markers the export pipeline reads.

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
@@ -2,7 +2,7 @@ import { Check, Copy, Download, Eye, FileText, Pencil, RotateCcw } from 'lucide-
 import { motion } from 'motion/react';
 import { useEffect, useState } from 'react';
 
-import { Button, cn, MarkdownMessage, TextArea } from '@ajh/ui';
+import { Button, cn, MarkdownMessage, SegmentedControl, TextArea } from '@ajh/ui';
 
 import { buildFilename, type GenerationMeta, MODES, type TemplateId } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
@@ -118,32 +118,18 @@ export function OutputPanelDone({
 
       {/* Output — prettified Preview or raw Edit (display-only; export uses the raw text) */}
       <div className="flex flex-1 flex-col overflow-hidden px-6 py-4">
-        <div className="mb-2 flex shrink-0 items-center gap-0.5 self-end rounded-lg bg-white/[0.04] p-0.5">
-          <Button
-            variant="unstyled"
-            onClick={() => setView('preview')}
-            className={cn(
-              'flex items-center gap-1 rounded px-2 py-1 text-[10px] transition-colors',
-              view === 'preview'
-                ? 'bg-brand/15 text-brand-soft'
-                : 'text-foreground/45 hover:text-foreground/70'
-            )}
-          >
-            <Eye size={11} /> {t('aiGenerate.preview')}
-          </Button>
-          <Button
-            variant="unstyled"
-            onClick={() => setView('edit')}
-            className={cn(
-              'flex items-center gap-1 rounded px-2 py-1 text-[10px] transition-colors',
-              view === 'edit'
-                ? 'bg-brand/15 text-brand-soft'
-                : 'text-foreground/45 hover:text-foreground/70'
-            )}
-          >
-            <Pencil size={11} /> {t('aiGenerate.edit')}
-          </Button>
-        </div>
+        <SegmentedControl<'preview' | 'edit'>
+          ariaLabel={t('aiGenerate.viewMode')}
+          size="sm"
+          tone="brand"
+          value={view}
+          onChange={setView}
+          options={[
+            { value: 'preview', label: t('aiGenerate.preview'), icon: Eye },
+            { value: 'edit', label: t('aiGenerate.edit'), icon: Pencil },
+          ]}
+          className="mb-2 shrink-0 self-end"
+        />
 
         {view === 'edit' ? (
           <TextArea

--- a/apps/tauri/src/renderer/features/ai-workspace/components/AIWorkspace/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-workspace/components/AIWorkspace/index.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangle, Sparkles, Zap } from 'lucide-react';
 
-import { Button, cn } from '@ajh/ui';
+import { SegmentedControl } from '@ajh/ui';
 
 import { ModelSelector, useSelectedModel } from '@/components/ui/ModelSelector';
 import { useTranslation } from '@/lib/i18n';
@@ -45,31 +45,17 @@ export function AIWorkspace() {
         <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/55">
           {t('ai.promptQuality')}
         </div>
-        <div className="grid grid-cols-3 gap-1.5">
-          {(
-            [
-              { id: 'full' as PromptQuality, label: 'Full' },
-              { id: 'auto' as PromptQuality, label: 'Auto' },
-              { id: 'compact' as PromptQuality, label: 'Fast' },
-            ] as const
-          ).map(({ id, label }) => (
-            <Button
-              key={id}
-              variant="unstyled"
-              type="button"
-              onClick={() => setPromptQuality(id)}
-              className={cn(
-                'flex items-center justify-center gap-1 rounded-lg border py-1.5 text-[11px] font-medium transition-all',
-                promptQuality === id
-                  ? 'border-brand/40 bg-brand/10 text-brand-soft'
-                  : 'border-white/[0.06] bg-white/[0.02] text-foreground/45 hover:border-white/10 hover:text-foreground/70'
-              )}
-            >
-              {id === 'compact' && <Zap size={11} />}
-              {label}
-            </Button>
-          ))}
-        </div>
+        <SegmentedControl<PromptQuality>
+          variant="grid"
+          ariaLabel={t('ai.promptQuality')}
+          value={promptQuality}
+          onChange={setPromptQuality}
+          options={[
+            { value: 'full', label: 'Full' },
+            { value: 'auto', label: 'Auto' },
+            { value: 'compact', label: 'Fast', icon: Zap },
+          ]}
+        />
         {promptQuality === 'compact' && (
           <div className="mt-2 flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2">
             <Zap size={11} className="text-amber-400 mt-0.5 shrink-0" />

--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
@@ -1,6 +1,6 @@
 import { AlertCircle, AlertTriangle, RefreshCw, ScanSearch, Sparkles, Zap } from 'lucide-react';
 
-import { Button, cn } from '@ajh/ui';
+import { Button, cn, SegmentedControl } from '@ajh/ui';
 
 import { JobAdField } from '@/components/job/JobAdField';
 import { ResumeInputCard } from '@/components/resume/ResumeInputCard';
@@ -85,31 +85,17 @@ export function AnalyzeLeftPanel({
         <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/55">
           Prompt Quality
         </div>
-        <div className="grid grid-cols-3 gap-1.5">
-          {(
-            [
-              { id: 'full' as PromptQuality, label: 'Full' },
-              { id: 'auto' as PromptQuality, label: 'Auto' },
-              { id: 'compact' as PromptQuality, label: 'Fast' },
-            ] as const
-          ).map(({ id, label }) => (
-            <Button
-              key={id}
-              variant="unstyled"
-              type="button"
-              onClick={() => setPromptQuality(id)}
-              className={cn(
-                'flex items-center justify-center gap-1 rounded-lg border py-1.5 text-[11px] font-medium transition-all',
-                promptQuality === id
-                  ? 'border-brand/40 bg-brand/10 text-brand-soft'
-                  : 'border-white/[0.06] bg-white/[0.02] text-foreground/45 hover:border-white/10 hover:text-foreground/70'
-              )}
-            >
-              {id === 'compact' && <Zap size={11} />}
-              {label}
-            </Button>
-          ))}
-        </div>
+        <SegmentedControl<PromptQuality>
+          variant="grid"
+          ariaLabel={t('ai.promptQuality')}
+          value={promptQuality}
+          onChange={setPromptQuality}
+          options={[
+            { value: 'full', label: 'Full' },
+            { value: 'auto', label: 'Auto' },
+            { value: 'compact', label: 'Fast', icon: Zap },
+          ]}
+        />
         {promptQuality === 'compact' && (
           <div className="mt-2 flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2">
             <Zap size={11} className="text-amber-400 mt-0.5 shrink-0" />

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
@@ -2,7 +2,7 @@ import { Loader2, Sparkles, Wand2, X } from 'lucide-react';
 import { useState } from 'react';
 
 import type { AutopilotFoundJob } from '@ajh/shared';
-import { Button, cn, ModalShell } from '@ajh/ui';
+import { Button, ModalShell, SegmentedControl } from '@ajh/ui';
 
 import { ResumeInputCard } from '@/components/resume/ResumeInputCard';
 import { ModelSelector, useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
@@ -150,24 +150,12 @@ export function ApplyJobModal({ job, resumeText, board, onClose }: Props) {
 
           {/* Target + generate */}
           <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-1 rounded-lg bg-white/[0.04] p-0.5">
-              {targets.map(({ id, label }) => (
-                <Button
-                  key={id}
-                  variant="unstyled"
-                  type="button"
-                  onClick={() => setTarget(id)}
-                  className={cn(
-                    'rounded-md px-3 py-1 text-[11px] font-medium transition-all',
-                    target === id
-                      ? 'bg-white/[0.08] text-foreground/90 shadow-sm'
-                      : 'text-foreground/40 hover:text-foreground/60'
-                  )}
-                >
-                  {label}
-                </Button>
-              ))}
-            </div>
+            <SegmentedControl<TailorTarget>
+              ariaLabel={t('autopilot.apply.target.label')}
+              value={target}
+              onChange={setTarget}
+              options={targets.map(({ id, label }) => ({ value: id, label }))}
+            />
             <div className="flex items-center gap-2">
               {gen.generating && (
                 <Button

--- a/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
@@ -17,7 +17,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 
 import type { AiGenerationRecord } from '@ajh/shared/ipc';
-import { Button, cn, transition } from '@ajh/ui';
+import { Button, cn, GlassCard, SegmentedControl, transition } from '@ajh/ui';
 
 import { ExternalLink } from '@/components/ui/ExternalLink';
 import {
@@ -110,7 +110,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
   };
 
   return (
-    <div className="glass-graphite glass-highlight rounded-xl overflow-hidden">
+    <GlassCard tone="graphite" className="rounded-xl overflow-hidden p-0">
       {/* Header */}
       <div className="flex items-center gap-4 p-4">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-brand/10">
@@ -200,43 +200,23 @@ export function GenerationCard({ gen }: GenerationCardProps) {
           </span>
 
           {/* Format picker */}
-          <div className="flex items-center gap-0.5 rounded-lg border border-white/[0.06] bg-white/[0.03] p-0.5">
-            {EXPORT_FORMATS.map((fmt) => (
-              <Button
-                key={fmt}
-                variant="unstyled"
-                onClick={() => setExportFormat(fmt)}
-                className={cn(
-                  'rounded-md px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors',
-                  exportFormat === fmt
-                    ? 'bg-white/10 text-foreground/80'
-                    : 'text-foreground/35 hover:text-foreground/60'
-                )}
-              >
-                {fmt}
-              </Button>
-            ))}
-          </div>
+          <SegmentedControl<ExportFormat>
+            ariaLabel={t('resumes.generated.format')}
+            size="sm"
+            value={exportFormat}
+            onChange={setExportFormat}
+            options={EXPORT_FORMATS.map((fmt) => ({ value: fmt, label: fmt.toUpperCase() }))}
+          />
 
           {/* Template picker — only for pdf/docx */}
           {exportFormat !== 'txt' && (
-            <div className="flex items-center gap-0.5 rounded-lg border border-white/[0.06] bg-white/[0.03] p-0.5">
-              {TEMPLATE_OPTIONS.map(({ id, label }) => (
-                <Button
-                  key={id}
-                  variant="unstyled"
-                  onClick={() => setExportTemplate(id)}
-                  className={cn(
-                    'rounded-md px-2 py-0.5 text-[10px] transition-colors',
-                    exportTemplate === id
-                      ? 'bg-white/10 text-foreground/80'
-                      : 'text-foreground/35 hover:text-foreground/60'
-                  )}
-                >
-                  {label}
-                </Button>
-              ))}
-            </div>
+            <SegmentedControl<TemplateId>
+              ariaLabel={t('resumes.generated.template')}
+              size="sm"
+              value={exportTemplate}
+              onChange={setExportTemplate}
+              options={TEMPLATE_OPTIONS.map(({ id, label }) => ({ value: id, label }))}
+            />
           )}
 
           <div className="flex items-center gap-1 ml-auto">
@@ -390,6 +370,6 @@ export function GenerationCard({ gen }: GenerationCardProps) {
           </AnimatePresence>
         </div>
       )}
-    </div>
+    </GlassCard>
   );
 }

--- a/apps/tauri/src/renderer/features/resumes/components/InteractionRow/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/InteractionRow/index.tsx
@@ -1,6 +1,6 @@
 import { Building2, Clock, ExternalLink, MapPin } from 'lucide-react';
 
-import { Button, cn } from '@ajh/ui';
+import { Button, cn, GlassCard } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { useOpenExternal } from '@/services/use-system';
@@ -47,7 +47,10 @@ export function InteractionRow({ row, tabCfg }: InteractionRowProps) {
   const Icon = tabCfg.icon;
 
   return (
-    <div className="glass-graphite glass-highlight flex items-center gap-4 rounded-xl p-4 transition-colors hover:bg-white/[0.02]">
+    <GlassCard
+      tone="graphite"
+      className="flex items-center gap-4 rounded-xl p-4 transition-colors hover:bg-white/[0.02]"
+    >
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/5 text-[10px] uppercase tracking-wider text-brand-soft">
         {row.source.slice(0, 2)}
       </div>
@@ -91,6 +94,6 @@ export function InteractionRow({ row, tabCfg }: InteractionRowProps) {
           <ExternalLink size={11} /> {t('resumes.open')}
         </Button>
       )}
-    </div>
+    </GlassCard>
   );
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -522,6 +522,7 @@
     "regenerate": "Neu generieren",
     "preview": "Vorschau",
     "edit": "Bearbeiten",
+    "viewMode": "Ansichtsmodus",
     "placeholder": "Generierte Ausgabe erscheint hier…",
     "stages": {
       "analyzing": "Anforderungen werden analysiert…",
@@ -611,6 +612,7 @@
         "copy": "Antwort kopieren"
       },
       "target": {
+        "label": "Dokumenttyp",
         "resume": "Lebenslauf",
         "cover": "Anschreiben",
         "both": "Beides"
@@ -899,6 +901,8 @@
       "noResume": "Kein Lebenslauf generiert",
       "noCoverLetter": "Kein Anschreiben generiert",
       "export": "Exportieren",
+      "format": "Exportformat",
+      "template": "Vorlage",
       "exportResume": "Lebenslauf",
       "exportCoverLetter": "Anschreiben",
       "applied": "Beworben",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -537,6 +537,7 @@
     "regenerate": "Regenerate",
     "preview": "Preview",
     "edit": "Edit",
+    "viewMode": "View mode",
     "placeholder": "Generated output will appear here…",
     "stages": {
       "analyzing": "Analyzing job requirements…",
@@ -626,6 +627,7 @@
         "copy": "Copy answer"
       },
       "target": {
+        "label": "Document type",
         "resume": "Resume",
         "cover": "Cover letter",
         "both": "Both"
@@ -914,6 +916,8 @@
       "noResume": "No resume generated",
       "noCoverLetter": "No cover letter generated",
       "export": "Export",
+      "format": "Export format",
+      "template": "Template",
       "exportResume": "Resume",
       "exportCoverLetter": "Cover Letter",
       "applied": "Applied",

--- a/packages/ui/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/ui/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SegmentedControl, type SegmentedOption } from './SegmentedControl';
+
+type Quality = 'full' | 'auto' | 'compact';
+
+const OPTIONS: readonly SegmentedOption<Quality>[] = [
+  { value: 'full', label: 'Full' },
+  { value: 'auto', label: 'Auto' },
+  { value: 'compact', label: 'Fast' },
+];
+
+function Harness({
+  initial = 'auto' as Quality,
+  onChange,
+}: {
+  initial?: Quality;
+  onChange?: (v: Quality) => void;
+}) {
+  const [value, setValue] = useState<Quality>(initial);
+  return (
+    <SegmentedControl
+      ariaLabel="Prompt quality"
+      options={OPTIONS}
+      value={value}
+      onChange={(v) => {
+        setValue(v);
+        onChange?.(v);
+      }}
+    />
+  );
+}
+
+describe('SegmentedControl', () => {
+  it('renders a radiogroup with one checked radio reflecting value', () => {
+    render(<Harness initial="auto" />);
+    expect(screen.getByRole('radiogroup', { name: 'Prompt quality' })).toBeInTheDocument();
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(3);
+    expect(screen.getByRole('radio', { name: 'Auto' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Full' })).not.toBeChecked();
+  });
+
+  it('only the selected radio is in the tab order (roving tabindex)', () => {
+    render(<Harness initial="auto" />);
+    expect(screen.getByRole('radio', { name: 'Auto' })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('radio', { name: 'Full' })).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('fires onChange when a radio is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness initial="auto" onChange={onChange} />);
+    await user.click(screen.getByRole('radio', { name: 'Fast' }));
+    expect(onChange).toHaveBeenCalledWith('compact');
+    expect(screen.getByRole('radio', { name: 'Fast' })).toBeChecked();
+  });
+
+  it('moves selection with arrow keys and wraps at the ends', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness initial="auto" onChange={onChange} />);
+    const auto = screen.getByRole('radio', { name: 'Auto' });
+    auto.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith('compact');
+    expect(screen.getByRole('radio', { name: 'Fast' })).toBeChecked();
+    // wrap forward: compact -> full
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith('full');
+    // End jumps to last
+    await user.keyboard('{End}');
+    expect(onChange).toHaveBeenLastCalledWith('compact');
+    // Home jumps back to first
+    await user.keyboard('{Home}');
+    expect(onChange).toHaveBeenLastCalledWith('full');
+  });
+
+  it('renders the grid variant with explicit column count', () => {
+    render(
+      <SegmentedControl
+        ariaLabel="Quality"
+        variant="grid"
+        options={OPTIONS}
+        value="full"
+        onChange={() => {}}
+      />
+    );
+    const group = screen.getByRole('radiogroup', { name: 'Quality' });
+    expect(group.style.gridTemplateColumns).toBe('repeat(3, minmax(0, 1fr))');
+  });
+});

--- a/packages/ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,155 @@
+import type { LucideIcon } from 'lucide-react';
+import { type KeyboardEvent, type ReactNode, useRef } from 'react';
+
+import { cn } from '../../lib/cn';
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: ReactNode;
+  /** Optional leading icon. */
+  icon?: LucideIcon;
+  /** Native title / tooltip. */
+  title?: string;
+}
+
+export interface SegmentedControlProps<T extends string> {
+  options: readonly SegmentedOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  /**
+   * Visual genre:
+   * - `track` (default) — iOS-style segmented control sitting in a tinted track.
+   * - `grid` — equal-width bordered cards in a single row.
+   */
+  variant?: 'track' | 'grid';
+  /** Track density. Ignored for `grid`. Default `md`. */
+  size?: 'sm' | 'md';
+  /** Active-fill family for the `track` variant. Default `neutral`. */
+  tone?: 'brand' | 'neutral';
+  /** Accessible name for the group (wired to `aria-label`). */
+  ariaLabel?: string;
+  className?: string;
+}
+
+const TRACK_ITEM_SIZE: Record<NonNullable<SegmentedControlProps<string>['size']>, string> = {
+  sm: 'rounded-md px-2 py-1 text-[10px]',
+  md: 'rounded-md px-3 py-1 text-[11px] font-medium',
+};
+
+const TRACK_ACTIVE: Record<NonNullable<SegmentedControlProps<string>['tone']>, string> = {
+  brand: 'bg-brand/15 text-brand-soft',
+  neutral: 'bg-white/10 text-foreground/90',
+};
+
+const ICON_SIZE = { sm: 11, md: 13 } as const;
+
+/**
+ * Single-select control rendered as a radio group. Covers the two segmented
+ * patterns that recur across the app — the tinted iOS `track` and the bordered
+ * `grid` — so the `role="radiogroup"` + roving arrow-key semantics live in one
+ * place instead of being re-implemented per feature.
+ */
+export function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  variant = 'track',
+  size = 'md',
+  tone = 'neutral',
+  ariaLabel,
+  className,
+}: SegmentedControlProps<T>) {
+  const btnRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const currentIndex = options.findIndex((o) => o.value === value);
+
+  // Arrow keys move selection *and* focus, per the WAI-ARIA radio-group pattern.
+  const move = (toIndex: number) => {
+    const n = options.length;
+    if (n === 0) return;
+    const idx = ((toIndex % n) + n) % n;
+    const next = options[idx];
+    if (!next) return;
+    if (next.value !== value) onChange(next.value);
+    btnRefs.current[idx]?.focus();
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    switch (e.key) {
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault();
+        move(currentIndex - 1);
+        break;
+      case 'ArrowRight':
+      case 'ArrowDown':
+        e.preventDefault();
+        move(currentIndex + 1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        move(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        move(options.length - 1);
+        break;
+    }
+  };
+
+  const isGrid = variant === 'grid';
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      onKeyDown={onKeyDown}
+      className={cn(
+        isGrid
+          ? 'grid gap-1.5'
+          : 'inline-flex items-center gap-0.5 rounded-lg bg-white/[0.04] p-0.5',
+        className
+      )}
+      style={
+        isGrid ? { gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` } : undefined
+      }
+    >
+      {options.map((opt, i) => {
+        const selected = opt.value === value;
+        const Icon = opt.icon;
+        return (
+          <button
+            key={opt.value}
+            ref={(el) => {
+              btnRefs.current[i] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            tabIndex={selected || (currentIndex === -1 && i === 0) ? 0 : -1}
+            title={opt.title}
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              'inline-flex items-center justify-center gap-1 whitespace-nowrap transition-all',
+              isGrid
+                ? cn(
+                    'rounded-lg border py-1.5 text-[11px] font-medium',
+                    selected
+                      ? 'border-brand/40 bg-brand/10 text-brand-soft'
+                      : 'border-white/[0.06] bg-white/[0.02] text-foreground/45 hover:border-white/10 hover:text-foreground/70'
+                  )
+                : cn(
+                    TRACK_ITEM_SIZE[size],
+                    selected ? TRACK_ACTIVE[tone] : 'text-foreground/45 hover:text-foreground/70'
+                  )
+            )}
+          >
+            {Icon ? (
+              <Icon size={isGrid ? ICON_SIZE.sm : ICON_SIZE[size]} aria-hidden="true" />
+            ) : null}
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui/src/components/SegmentedControl/index.ts
+++ b/packages/ui/src/components/SegmentedControl/index.ts
@@ -1,0 +1,1 @@
+export * from './SegmentedControl';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -32,6 +32,11 @@ export { ProgressBar, type ProgressBarProps } from './components/ProgressBar/ind
 export { RefreshButton } from './components/RefreshButton/index';
 export { SectionHeader } from './components/SectionHeader/index';
 export { SectionLabel } from './components/SectionLabel/index';
+export {
+  SegmentedControl,
+  type SegmentedControlProps,
+  type SegmentedOption,
+} from './components/SegmentedControl/index';
 export { SelectDropdown } from './components/SelectDropdown/index';
 export { SourceBadge, type SourceBadgeProps } from './components/SourceBadge/index';
 export { TextArea, type TextAreaProps } from './components/TextArea/index';


### PR DESCRIPTION
## What

Part of the Premium-Glass UX-audit backlog (PR 3/13 — consistency & a11y residue).

### New primitive — `SegmentedControl` (`@ajh/ui`)
A single-select control rendered as a proper **radio group**:
- `role="radiogroup"` + `role="radio"` + `aria-checked`
- roving tabindex + **arrow-key / Home / End** navigation (WAI-ARIA radio pattern)
- two variants: `track` (iOS-style tinted segmented) and `grid` (equal-width bordered cards), with `size` (`sm`/`md`) and active `tone` (`brand`/`neutral`).

### Migrations (6 hand-rolled `Button variant="unstyled"` groups → `SegmentedControl`)
| Site | Variant |
|------|---------|
| `AnalyzeLeftPanel` prompt-quality | `grid` |
| `AIWorkspace` prompt-quality | `grid` |
| `OutputPanelDone` preview/edit | `track` brand |
| `ApplyJobModal` target picker | `track` neutral |
| `GenerationCard` format picker | `track` |
| `GenerationCard` template picker | `track` |

### GlassCard consolidation
Raw `glass-graphite glass-highlight` `<div>`s in `GenerationCard` and `InteractionRow` → `<GlassCard tone="graphite">`, so tone tokens propagate from one place.

## Why
The segmented pattern was re-implemented ≥6× with subtly divergent markup and **no a11y semantics** (plain buttons, no group role, no keyboard model). This centralizes the role/keyboard behaviour once and trims ~57 lines of duplication.

## Notes for review
- **Deliberate visual normalization**: the `track` skins converged to one canonical look (borderless track, `/45` inactive text for better contrast, `bg-white/10` neutral active). The `grid` pickers are class-for-class identical to before. Verified **light + dark** via local mock-client Playwright capture (not committed).
- `OutputPanelDone.test.tsx` updated: the Edit toggle is now queried as `role="radio"` (was `button`).
- Adds 4 group-label i18n keys (`en`/`de`).

## Verification
- `pnpm typecheck` ✅ · `pnpm lint:strict` ✅
- `@ajh/ui` 134 tests ✅ (incl. new `SegmentedControl` suite: click, keyboard nav, aria, grid columns)
- affected feature tests (ai-generate / autopilot / resumes / analyze / ai-workspace) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)