### PR TITLE
feat: require confirmation before deleting autopilots and generated documents

### DIFF
--- a/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -14,7 +14,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 
 import type { Autopilot, AutopilotFoundJob } from '@ajh/shared';
-import { Button, cn, GlassCard, transition } from '@ajh/ui';
+import { Button, cn, ConfirmModal, GlassCard, transition } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { type AutopilotRunState, RUN_STATE_LABEL } from '@/lib/machines/autopilot-run.machine';
@@ -63,6 +63,7 @@ export function AutopilotCard({
   const openExternal = useOpenExternal();
   const [showFound, setShowFound] = useState(false);
   const [applyJob, setApplyJob] = useState<AutopilotFoundJob | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const foundJobs = ap.foundJobs ?? [];
 
   const lastRun = ap.lastRunAt
@@ -155,7 +156,9 @@ export function AutopilotCard({
             <Pencil size={13} />
           </Button>
           <Button
-            onClick={onDelete}
+            onClick={() => setConfirmDelete(true)}
+            aria-label={t('autopilot.delete')}
+            title={t('autopilot.delete')}
             className="rounded-lg p-1.5 text-foreground/30 hover:bg-red-400/10 hover:text-red-400/70 transition-colors h-auto bg-transparent border-transparent"
           >
             <Trash2 size={13} />
@@ -277,6 +280,19 @@ export function AutopilotCard({
           onClose={() => setApplyJob(null)}
         />
       )}
+
+      <ConfirmModal
+        open={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        onConfirm={() => {
+          setConfirmDelete(false);
+          onDelete();
+        }}
+        title={t('autopilot.deleteTitle')}
+        description={t('autopilot.deleteDescription')}
+        confirmText={t('autopilot.delete')}
+        variant="danger"
+      />
     </GlassCard>
   );
 }

--- a/apps/tauri/src/renderer/features/resumes/components/GenerationCard/GenerationCard.test.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/GenerationCard/GenerationCard.test.tsx
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import type { AiGenerationRecord } from '@ajh/shared/ipc';
+
+import { GenerationCard } from './index';
+
+// Mock the service barrel (ExternalLink reaches for useOpenExternal) and the
+// remove hook so the card renders without a provider tree. We capture the
+// mutate spy to prove deletion only fires *after* confirmation.
+const mockMutate = vi.fn();
+
+vi.mock('@/services', () => ({
+  useOpenExternal: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/services/use-ai-generations', () => ({
+  useRemoveAiGeneration: () => ({ mutate: mockMutate, isPending: false }),
+}));
+
+// Translate to the raw key so assertions don't depend on locale resolution.
+vi.mock('@/lib/i18n', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const GEN: AiGenerationRecord = {
+  id: 'gen-1',
+  jobTitle: 'Senior Engineer',
+  companyName: 'Acme',
+  candidateName: 'Jane Doe',
+  createdAt: Date.now(),
+  mode: 'ats',
+  board: '',
+  jobUrl: '',
+  resumeText: '',
+  coverLetterText: '',
+  jobAd: '',
+  companyBrief: '',
+  resumeLanguage: 'en',
+  jobAdLanguage: 'en',
+  targetLanguage: 'en',
+  mismatch: false,
+  topRequirements: [],
+  applicationAnswers: [],
+};
+
+describe('GenerationCard — delete confirmation', () => {
+  beforeEach(() => mockMutate.mockClear());
+
+  const DELETE = 'resumes.generated.delete';
+
+  it('does not delete until the confirm dialog is accepted', () => {
+    render(<GenerationCard gen={GEN} />);
+
+    // The icon-only trash button is the only delete control before the dialog.
+    fireEvent.click(screen.getByRole('button', { name: DELETE }));
+
+    // Clicking the trash must NOT delete immediately — that was the data-loss bug.
+    expect(mockMutate).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('resumes.generated.deleteTitle')).toBeInTheDocument();
+
+    // Accept inside the dialog (scoped so we don't match the trash button).
+    fireEvent.click(within(dialog).getByRole('button', { name: DELETE }));
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    expect(mockMutate).toHaveBeenCalledWith('gen-1');
+  });
+
+  it('dismisses without deleting when cancelled', () => {
+    render(<GenerationCard gen={GEN} />);
+
+    fireEvent.click(screen.getByRole('button', { name: DELETE }));
+    const dialog = screen.getByRole('dialog');
+    // ConfirmModal's cancel label is a literal default ("Cancel"), not translated.
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
@@ -17,7 +17,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 
 import type { AiGenerationRecord } from '@ajh/shared/ipc';
-import { Button, cn, GlassCard, SegmentedControl, transition } from '@ajh/ui';
+import { Button, cn, ConfirmModal, GlassCard, SegmentedControl, transition } from '@ajh/ui';
 
 import { ExternalLink } from '@/components/ui/ExternalLink';
 import {
@@ -53,6 +53,12 @@ export function GenerationCard({ gen }: GenerationCardProps) {
   const [exportFormat, setExportFormat] = useState<ExportFormat>('pdf');
   const [exportTemplate, setExportTemplate] = useState<TemplateId>('modern');
   const [exporting, setExporting] = useState<'resume' | 'cover' | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const handleDelete = () => {
+    setConfirmDelete(false);
+    removeAiGeneration.mutate(gen.id);
+  };
 
   const copy = async (type: 'resume' | 'cover') => {
     const text = type === 'resume' ? gen.resumeText : gen.coverLetterText;
@@ -110,207 +116,247 @@ export function GenerationCard({ gen }: GenerationCardProps) {
   };
 
   return (
-    <GlassCard tone="graphite" className="rounded-xl overflow-hidden p-0">
-      {/* Header */}
-      <div className="flex items-center gap-4 p-4">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-brand/10">
-          <Wand2 size={14} className="text-brand-soft" />
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 text-sm font-medium text-foreground/90">
-            <span className="truncate">{gen.jobTitle || t('resumes.unknownPosition')}</span>
-            {gen.companyName && (
-              <span className="text-foreground/40 text-xs font-normal shrink-0">
-                @ {gen.companyName}
-              </span>
-            )}
+    <>
+      <GlassCard tone="graphite" className="rounded-xl overflow-hidden p-0">
+        {/* Header */}
+        <div className="flex items-center gap-4 p-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-brand/10">
+            <Wand2 size={14} className="text-brand-soft" />
           </div>
-          <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-foreground/50">
-            {gen.candidateName && <span>{gen.candidateName}</span>}
-            <span className="flex items-center gap-1 text-foreground/35">
-              <Calendar size={10} />
-              <span title={formatRelative(gen.createdAt)}>{generatedDate}</span>
-            </span>
-            <span className="rounded-full border border-brand/20 bg-brand/8 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-brand-soft">
-              {gen.mode}
-            </span>
-            {gen.board && (
-              <span className="rounded-full border border-white/[0.06] bg-white/[0.03] px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-foreground/55">
-                {gen.board}
+
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 text-sm font-medium text-foreground/90">
+              <span className="truncate">{gen.jobTitle || t('resumes.unknownPosition')}</span>
+              {gen.companyName && (
+                <span className="text-foreground/40 text-xs font-normal shrink-0">
+                  @ {gen.companyName}
+                </span>
+              )}
+            </div>
+            <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-foreground/50">
+              {gen.candidateName && <span>{gen.candidateName}</span>}
+              <span className="flex items-center gap-1 text-foreground/35">
+                <Calendar size={10} />
+                <span title={formatRelative(gen.createdAt)}>{generatedDate}</span>
               </span>
-            )}
-            {/* A linked job means this generation was an application — surface the
+              <span className="rounded-full border border-brand/20 bg-brand/8 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-brand-soft">
+                {gen.mode}
+              </span>
+              {gen.board && (
+                <span className="rounded-full border border-white/[0.06] bg-white/[0.03] px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-foreground/55">
+                  {gen.board}
+                </span>
+              )}
+              {/* A linked job means this generation was an application — surface the
                 "Applied" state and a link back to the original posting. */}
-            {gen.jobUrl && (
-              <span className="flex items-center gap-0.5 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-emerald-300">
-                <Check size={9} /> {t('resumes.generated.applied')}
-              </span>
-            )}
-            {gen.jobUrl && (
-              <ExternalLink
-                href={gen.jobUrl}
-                title={t('resumes.generated.openPosting')}
-                className="flex items-center gap-1 text-foreground/35 transition-colors hover:text-brand-soft"
-              >
-                <ExternalLinkIcon size={10} /> {t('resumes.generated.openPosting')}
-              </ExternalLink>
-            )}
+              {gen.jobUrl && (
+                <span className="flex items-center gap-0.5 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-emerald-300">
+                  <Check size={9} /> {t('resumes.generated.applied')}
+                </span>
+              )}
+              {gen.jobUrl && (
+                <ExternalLink
+                  href={gen.jobUrl}
+                  title={t('resumes.generated.openPosting')}
+                  className="flex items-center gap-1 text-foreground/35 transition-colors hover:text-brand-soft"
+                >
+                  <ExternalLinkIcon size={10} /> {t('resumes.generated.openPosting')}
+                </ExternalLink>
+              )}
+            </div>
           </div>
-        </div>
 
-        <div className="flex items-center gap-1 shrink-0">
-          {gen.resumeText && (
-            <Button
-              onClick={() => void copy('resume')}
-              className="flex items-center gap-1 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto border-transparent"
-            >
-              <Copy size={10} />
-              {copied === 'resume'
-                ? t('resumes.generated.copied')
-                : t('resumes.generated.copyResume')}
-            </Button>
-          )}
-          {gen.coverLetterText && (
-            <Button
-              onClick={() => void copy('cover')}
-              className="flex items-center gap-1 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto border-transparent"
-            >
-              <Copy size={10} />
-              {copied === 'cover'
-                ? t('resumes.generated.copied')
-                : t('resumes.generated.copyCoverLetter')}
-            </Button>
-          )}
-          <Button
-            onClick={() => void removeAiGeneration.mutate(gen.id)}
-            className="flex items-center gap-1 rounded-lg bg-white/5 px-2 py-1.5 text-[11px] text-foreground/40 transition-colors hover:text-red-400 h-auto border-transparent"
-          >
-            <Trash2 size={10} />
-          </Button>
-        </div>
-      </div>
-
-      {/* Export bar */}
-      {(gen.resumeText || gen.coverLetterText) && (
-        <div className="border-t border-white/[0.04] px-4 py-2.5 flex items-center gap-2 flex-wrap">
-          <Download size={11} className="text-foreground/30 shrink-0" />
-          <span className="text-[11px] text-foreground/40 mr-1">
-            {t('resumes.generated.export')}
-          </span>
-
-          {/* Format picker */}
-          <SegmentedControl<ExportFormat>
-            ariaLabel={t('resumes.generated.format')}
-            size="sm"
-            value={exportFormat}
-            onChange={setExportFormat}
-            options={EXPORT_FORMATS.map((fmt) => ({ value: fmt, label: fmt.toUpperCase() }))}
-          />
-
-          {/* Template picker — only for pdf/docx */}
-          {exportFormat !== 'txt' && (
-            <SegmentedControl<TemplateId>
-              ariaLabel={t('resumes.generated.template')}
-              size="sm"
-              value={exportTemplate}
-              onChange={setExportTemplate}
-              options={TEMPLATE_OPTIONS.map(({ id, label }) => ({ value: id, label }))}
-            />
-          )}
-
-          <div className="flex items-center gap-1 ml-auto">
+          <div className="flex items-center gap-1 shrink-0">
             {gen.resumeText && (
               <Button
-                disabled={exporting === 'resume'}
-                onClick={() => void doExport('resume')}
-                className="flex items-center gap-1 rounded-lg bg-brand/10 border-brand/20 px-2.5 py-1.5 text-[11px] text-brand-soft transition-colors hover:bg-brand/20 h-auto"
+                onClick={() => void copy('resume')}
+                className="flex items-center gap-1 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto border-transparent"
               >
-                {exporting === 'resume' ? (
-                  <Loader2 size={10} className="animate-spin" />
-                ) : (
-                  <Download size={10} />
-                )}
-                {t('resumes.generated.exportResume')}
+                <Copy size={10} />
+                {copied === 'resume'
+                  ? t('resumes.generated.copied')
+                  : t('resumes.generated.copyResume')}
               </Button>
             )}
             {gen.coverLetterText && (
               <Button
-                disabled={exporting === 'cover'}
-                onClick={() => void doExport('cover')}
-                className="flex items-center gap-1 rounded-lg bg-white/5 border-white/[0.06] px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto"
+                onClick={() => void copy('cover')}
+                className="flex items-center gap-1 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto border-transparent"
               >
-                {exporting === 'cover' ? (
-                  <Loader2 size={10} className="animate-spin" />
-                ) : (
-                  <Download size={10} />
-                )}
-                {t('resumes.generated.exportCoverLetter')}
+                <Copy size={10} />
+                {copied === 'cover'
+                  ? t('resumes.generated.copied')
+                  : t('resumes.generated.copyCoverLetter')}
               </Button>
             )}
+            <Button
+              onClick={() => setConfirmDelete(true)}
+              aria-label={t('resumes.generated.delete')}
+              title={t('resumes.generated.delete')}
+              className="flex items-center gap-1 rounded-lg bg-white/5 px-2 py-1.5 text-[11px] text-foreground/40 transition-colors hover:text-red-400 h-auto border-transparent"
+            >
+              <Trash2 size={10} />
+            </Button>
           </div>
         </div>
-      )}
 
-      {/* Top requirements */}
-      {gen.topRequirements.length > 0 && (
-        <div className="px-4 pb-3 flex flex-wrap gap-1">
-          {gen.topRequirements.slice(0, 8).map((req) => (
-            <span
-              key={req}
-              className="rounded-full border border-white/[0.06] bg-white/[0.03] px-2 py-0.5 text-[10px] text-foreground/50"
-            >
-              {req}
+        {/* Export bar */}
+        {(gen.resumeText || gen.coverLetterText) && (
+          <div className="border-t border-white/[0.04] px-4 py-2.5 flex items-center gap-2 flex-wrap">
+            <Download size={11} className="text-foreground/30 shrink-0" />
+            <span className="text-[11px] text-foreground/40 mr-1">
+              {t('resumes.generated.export')}
             </span>
-          ))}
-        </div>
-      )}
 
-      {/* Expandable sections */}
-      {[
-        {
-          key: 'resume' as const,
-          label: t('resumes.generated.resume'),
-          text: gen.resumeText,
-          icon: FileText,
-        },
-        {
-          key: 'cover' as const,
-          label: t('resumes.generated.coverLetter'),
-          text: gen.coverLetterText,
-          icon: FileText,
-        },
-        {
-          key: 'jobAd' as const,
-          label: t('resumes.generated.jobAd'),
-          text: gen.jobAd,
-          icon: Building2,
-        },
-        {
-          key: 'brief' as const,
-          label: t('resumes.generated.companyResearch'),
-          text: gen.companyBrief,
-          icon: Search,
-        },
-      ]
-        .filter((s) => s.text)
-        .map(({ key, label, text, icon: SectionIcon }) => (
-          <div key={key} className="border-t border-white/[0.04]">
+            {/* Format picker */}
+            <SegmentedControl<ExportFormat>
+              ariaLabel={t('resumes.generated.format')}
+              size="sm"
+              value={exportFormat}
+              onChange={setExportFormat}
+              options={EXPORT_FORMATS.map((fmt) => ({ value: fmt, label: fmt.toUpperCase() }))}
+            />
+
+            {/* Template picker — only for pdf/docx */}
+            {exportFormat !== 'txt' && (
+              <SegmentedControl<TemplateId>
+                ariaLabel={t('resumes.generated.template')}
+                size="sm"
+                value={exportTemplate}
+                onChange={setExportTemplate}
+                options={TEMPLATE_OPTIONS.map(({ id, label }) => ({ value: id, label }))}
+              />
+            )}
+
+            <div className="flex items-center gap-1 ml-auto">
+              {gen.resumeText && (
+                <Button
+                  disabled={exporting === 'resume'}
+                  onClick={() => void doExport('resume')}
+                  className="flex items-center gap-1 rounded-lg bg-brand/10 border-brand/20 px-2.5 py-1.5 text-[11px] text-brand-soft transition-colors hover:bg-brand/20 h-auto"
+                >
+                  {exporting === 'resume' ? (
+                    <Loader2 size={10} className="animate-spin" />
+                  ) : (
+                    <Download size={10} />
+                  )}
+                  {t('resumes.generated.exportResume')}
+                </Button>
+              )}
+              {gen.coverLetterText && (
+                <Button
+                  disabled={exporting === 'cover'}
+                  onClick={() => void doExport('cover')}
+                  className="flex items-center gap-1 rounded-lg bg-white/5 border-white/[0.06] px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto"
+                >
+                  {exporting === 'cover' ? (
+                    <Loader2 size={10} className="animate-spin" />
+                  ) : (
+                    <Download size={10} />
+                  )}
+                  {t('resumes.generated.exportCoverLetter')}
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Top requirements */}
+        {gen.topRequirements.length > 0 && (
+          <div className="px-4 pb-3 flex flex-wrap gap-1">
+            {gen.topRequirements.slice(0, 8).map((req) => (
+              <span
+                key={req}
+                className="rounded-full border border-white/[0.06] bg-white/[0.03] px-2 py-0.5 text-[10px] text-foreground/50"
+              >
+                {req}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Expandable sections */}
+        {[
+          {
+            key: 'resume' as const,
+            label: t('resumes.generated.resume'),
+            text: gen.resumeText,
+            icon: FileText,
+          },
+          {
+            key: 'cover' as const,
+            label: t('resumes.generated.coverLetter'),
+            text: gen.coverLetterText,
+            icon: FileText,
+          },
+          {
+            key: 'jobAd' as const,
+            label: t('resumes.generated.jobAd'),
+            text: gen.jobAd,
+            icon: Building2,
+          },
+          {
+            key: 'brief' as const,
+            label: t('resumes.generated.companyResearch'),
+            text: gen.companyBrief,
+            icon: Search,
+          },
+        ]
+          .filter((s) => s.text)
+          .map(({ key, label, text, icon: SectionIcon }) => (
+            <div key={key} className="border-t border-white/[0.04]">
+              <Button
+                variant="unstyled"
+                onClick={() => setExpanded(expanded === key ? null : key)}
+                className="flex w-full items-center justify-between px-4 py-2.5 text-left text-xs text-foreground/50 hover:text-foreground/70 transition-colors"
+              >
+                <span className="flex items-center gap-1.5">
+                  <SectionIcon size={11} /> {label}
+                </span>
+                <ChevronDown
+                  size={12}
+                  className={cn('transition-transform', expanded === key && 'rotate-180')}
+                />
+              </Button>
+              <AnimatePresence initial={false}>
+                {expanded === key && (
+                  <motion.div
+                    initial={{ height: 0 }}
+                    animate={{ height: 'auto' }}
+                    exit={{ height: 0 }}
+                    transition={transition.normal}
+                    className="overflow-hidden"
+                  >
+                    <pre className="select-text px-4 pb-4 whitespace-pre-wrap font-mono text-[10px] leading-relaxed text-foreground/50 max-h-64 overflow-y-auto">
+                      {text}
+                    </pre>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          ))}
+
+        {/* Application answers — structured Q/A from the questions assistant. */}
+        {gen.applicationAnswers.length > 0 && (
+          <div className="border-t border-white/[0.04]">
             <Button
               variant="unstyled"
-              onClick={() => setExpanded(expanded === key ? null : key)}
-              className="flex w-full items-center justify-between px-4 py-2.5 text-left text-xs text-foreground/50 hover:text-foreground/70 transition-colors"
+              onClick={() => setExpanded(expanded === 'answers' ? null : 'answers')}
+              className="flex w-full items-center justify-between px-4 py-2.5 text-left text-xs text-foreground/50 transition-colors hover:text-foreground/70"
             >
               <span className="flex items-center gap-1.5">
-                <SectionIcon size={11} /> {label}
+                <HelpCircle size={11} /> {t('resumes.generated.applicationAnswers')}
+                <span className="rounded-full bg-white/[0.06] px-1.5 py-0.5 text-[9px] text-foreground/45">
+                  {gen.applicationAnswers.length}
+                </span>
               </span>
               <ChevronDown
                 size={12}
-                className={cn('transition-transform', expanded === key && 'rotate-180')}
+                className={cn('transition-transform', expanded === 'answers' && 'rotate-180')}
               />
             </Button>
             <AnimatePresence initial={false}>
-              {expanded === key && (
+              {expanded === 'answers' && (
                 <motion.div
                   initial={{ height: 0 }}
                   animate={{ height: 'auto' }}
@@ -318,58 +364,33 @@ export function GenerationCard({ gen }: GenerationCardProps) {
                   transition={transition.normal}
                   className="overflow-hidden"
                 >
-                  <pre className="select-text px-4 pb-4 whitespace-pre-wrap font-mono text-[10px] leading-relaxed text-foreground/50 max-h-64 overflow-y-auto">
-                    {text}
-                  </pre>
+                  <div className="select-text max-h-72 space-y-3 overflow-y-auto px-4 pb-4">
+                    {gen.applicationAnswers.map((qa) => (
+                      <div key={qa.id}>
+                        <p className="text-[11px] font-medium text-foreground/70">{qa.question}</p>
+                        <p className="mt-0.5 whitespace-pre-wrap text-[11px] leading-relaxed text-foreground/50">
+                          {qa.answer}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
                 </motion.div>
               )}
             </AnimatePresence>
           </div>
-        ))}
+        )}
+      </GlassCard>
 
-      {/* Application answers — structured Q/A from the questions assistant. */}
-      {gen.applicationAnswers.length > 0 && (
-        <div className="border-t border-white/[0.04]">
-          <Button
-            variant="unstyled"
-            onClick={() => setExpanded(expanded === 'answers' ? null : 'answers')}
-            className="flex w-full items-center justify-between px-4 py-2.5 text-left text-xs text-foreground/50 transition-colors hover:text-foreground/70"
-          >
-            <span className="flex items-center gap-1.5">
-              <HelpCircle size={11} /> {t('resumes.generated.applicationAnswers')}
-              <span className="rounded-full bg-white/[0.06] px-1.5 py-0.5 text-[9px] text-foreground/45">
-                {gen.applicationAnswers.length}
-              </span>
-            </span>
-            <ChevronDown
-              size={12}
-              className={cn('transition-transform', expanded === 'answers' && 'rotate-180')}
-            />
-          </Button>
-          <AnimatePresence initial={false}>
-            {expanded === 'answers' && (
-              <motion.div
-                initial={{ height: 0 }}
-                animate={{ height: 'auto' }}
-                exit={{ height: 0 }}
-                transition={transition.normal}
-                className="overflow-hidden"
-              >
-                <div className="select-text max-h-72 space-y-3 overflow-y-auto px-4 pb-4">
-                  {gen.applicationAnswers.map((qa) => (
-                    <div key={qa.id}>
-                      <p className="text-[11px] font-medium text-foreground/70">{qa.question}</p>
-                      <p className="mt-0.5 whitespace-pre-wrap text-[11px] leading-relaxed text-foreground/50">
-                        {qa.answer}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
-      )}
-    </GlassCard>
+      <ConfirmModal
+        open={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        onConfirm={handleDelete}
+        title={t('resumes.generated.deleteTitle')}
+        description={t('resumes.generated.deleteDescription')}
+        confirmText={t('resumes.generated.delete')}
+        variant="danger"
+        isConfirming={removeAiGeneration.isPending}
+      />
+    </>
   );
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -579,6 +579,9 @@
     "collapse": "Einklappen",
     "viewJob": "Anzeige öffnen",
     "applyJob": "Bewerben",
+    "delete": "Löschen",
+    "deleteTitle": "Diesen Autopilot löschen?",
+    "deleteDescription": "Dies stoppt den Zeitplan und entfernt den Autopilot und seinen Verlauf gefundener Jobs dauerhaft.",
     "badge": {
       "new": "Neu",
       "applied": "Beworben"
@@ -907,6 +910,9 @@
       "exportCoverLetter": "Anschreiben",
       "applied": "Beworben",
       "openPosting": "Anzeige öffnen",
+      "delete": "Löschen",
+      "deleteTitle": "Dieses Dokument löschen?",
+      "deleteDescription": "Dies entfernt den generierten Lebenslauf und das Anschreiben dauerhaft. Dies kann nicht rückgängig gemacht werden.",
       "companyResearch": "Unternehmensrecherche",
       "applicationAnswers": "Bewerbungsantworten"
     },

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -594,6 +594,9 @@
     "collapse": "Collapse",
     "viewJob": "Open posting",
     "applyJob": "Apply",
+    "delete": "Delete",
+    "deleteTitle": "Delete this autopilot?",
+    "deleteDescription": "This stops its schedule and permanently removes the autopilot and its found-jobs history.",
     "badge": {
       "new": "New",
       "applied": "Applied"
@@ -922,6 +925,9 @@
       "exportCoverLetter": "Cover Letter",
       "applied": "Applied",
       "openPosting": "Open posting",
+      "delete": "Delete",
+      "deleteTitle": "Delete this document?",
+      "deleteDescription": "This permanently removes the generated resume and cover letter. This can't be undone.",
       "companyResearch": "Company research",
       "applicationAnswers": "Application answers"
     },


### PR DESCRIPTION
## What
Part of the Premium-Glass UX-audit backlog (PR 4 — state coverage). This slice covers the **destructive-action** items: gating irreversible deletes behind a confirm dialog.

- **`AutopilotCard`** — the trash button deleted the autopilot (config + found-jobs history) on first click. Now opens a `ConfirmModal` (danger).
- **`GenerationCard`** — the trash button deleted a generated resume/cover letter instantly. Now opens a `ConfirmModal` (danger).
- Both icon-only trash buttons gained an `aria-label`/`title` (they had **no accessible name** before).
- en/de copy for both dialogs.

## Why
Both were one-click, no-undo **data-loss paths**. Deleting a generation or an automation is irreversible, so a confirm step is the expected safeguard. Reuses the existing `@ajh/ui` `ConfirmModal` — no new primitive.

## Tests
New `GenerationCard.test.tsx` proves the fix holds:
- clicking the trash button does **not** call the delete mutation (regression guard for the old instant-delete bug);
- the mutation fires only after the dialog's confirm;
- cancelling deletes nothing.

## Scope note
This PR is the **destructive-action slice** of the audit's broader state-coverage work. The remaining pieces — `EmptyState` CTAs / `ErrorState`+retry / loading skeletons, and the settings **credential/key** confirmations (AccountRow, CloudProviderConfig, CompanyResearchSettings, LinkedInSessionRow) — follow as the next slice, kept separate to stay reviewable.

## Verification
`pnpm typecheck` ✅ · `pnpm lint:strict` ✅ · resumes + autopilot feature tests ✅ (incl. new GenerationCard suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)