### PR TITLE
feat: upgrade empty, error, and loading states to shared primitives

### DIFF
--- a/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
@@ -1,6 +1,8 @@
 import { AnimatePresence } from 'motion/react';
 import { useRef, useState } from 'react';
 
+import { ErrorState } from '@ajh/ui';
+
 import { ContactPromptModal } from '@/components/contact/ContactPromptModal';
 import { PageTransition } from '@/components/layout/PageTransition';
 import { useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
@@ -306,9 +308,13 @@ export function AIGeneratePage() {
           </AnimatePresence>
 
           {error && (
-            <div className="shrink-0 mx-6 mb-4 rounded-xl border border-red-400/20 bg-red-400/5 px-4 py-3 text-xs text-red-300/80">
-              <div className="font-medium mb-0.5">{t('aiGenerate.error')}</div>
-              {error}
+            <div className="shrink-0 mx-6 mb-4">
+              <ErrorState
+                title={t('aiGenerate.error')}
+                description={error}
+                onRetry={() => void handleGenerate()}
+                className="rounded-xl border border-red-400/20 bg-red-400/5 py-6"
+              />
             </div>
           )}
         </div>

--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useMemo, useState } from 'react';
 
 import type { DocumentRecord } from '@ajh/shared';
+import { ErrorState } from '@ajh/ui';
 
 import { PageTransition } from '@/components/layout/PageTransition';
 import { useCanUseAI, useSelectedModel, useSelectedProvider } from '@/components/ui/ModelSelector';
@@ -209,9 +210,13 @@ function AnalyzePage() {
           </AnimatePresence>
 
           {error && (
-            <div className="shrink-0 mx-6 mb-4 rounded-lg border border-red-400/20 bg-red-400/5 px-3 py-2.5 text-xs text-red-300/80">
-              <div className="font-medium mb-0.5">{t('analyze.error')}</div>
-              <div className="text-red-300/60">{error}</div>
+            <div className="shrink-0 mx-6 mb-4">
+              <ErrorState
+                title={t('analyze.error')}
+                description={error}
+                onRetry={() => void run()}
+                className="rounded-lg border border-red-400/20 bg-red-400/5 py-6"
+              />
             </div>
           )}
         </div>

--- a/apps/tauri/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
@@ -2,7 +2,7 @@ import { AlertCircle, Plus, X, Zap } from 'lucide-react';
 import { AnimatePresence } from 'motion/react';
 
 import type { Autopilot } from '@ajh/shared';
-import { Button } from '@ajh/ui';
+import { Button, CardSkeleton } from '@ajh/ui';
 
 import { PageTransition } from '@/components/layout/PageTransition';
 import { AutopilotCard } from '@/features/autopilot/components/AutopilotCard';
@@ -78,8 +78,9 @@ function AutopilotPage() {
           )}
 
           {loading ? (
-            <div className="flex items-center justify-center h-40 text-foreground/30 text-sm">
-              {t('autopilot.loading')}
+            <div className="space-y-3">
+              <CardSkeleton />
+              <CardSkeleton />
             </div>
           ) : autopilots.length === 0 ? (
             <EmptyState onNew={() => setCreating(true)} />

--- a/apps/tauri/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import type { DATE_FILTER_OPTIONS } from '@ajh/shared';
 import {
   Button,
+  EmptyState,
   GlassCard,
   Input,
   SelectDropdown,
@@ -215,8 +216,17 @@ export function JobsPage() {
         />
 
         {filtered.length === 0 ? (
-          <GlassCard tone="graphite" highlight className="text-center text-sm text-foreground/55">
-            {t('jobs.empty')}
+          <GlassCard tone="graphite" highlight>
+            <EmptyState
+              icon={Search}
+              title={t('jobs.empty')}
+              action={
+                <Button variant="glass" size="sm" onClick={() => setShowScrapeForm(true)}>
+                  <Search size={13} /> {t('jobs.emptyCta')}
+                </Button>
+              }
+              className="py-10"
+            />
           </GlassCard>
         ) : (
           <div className="flex flex-col gap-2">

--- a/apps/tauri/src/renderer/features/monitoring/components/ActiveJobsSection/index.tsx
+++ b/apps/tauri/src/renderer/features/monitoring/components/ActiveJobsSection/index.tsx
@@ -1,7 +1,7 @@
 import { Activity } from 'lucide-react';
 import { AnimatePresence } from 'motion/react';
 
-import { GlassCard } from '@ajh/ui';
+import { EmptyState, GlassCard } from '@ajh/ui';
 
 import { ActiveJobRow } from '@/features/monitoring/components/ActiveJobRow';
 import type { JobRecord } from '@/features/monitoring/types';
@@ -31,9 +31,11 @@ export function ActiveJobsSection({ activeJobs, kindLabel, t }: Props) {
 
       <div className="space-y-2 min-h-[120px]">
         {activeJobs.length === 0 ? (
-          <div className="flex h-24 items-center justify-center text-xs text-foreground/25">
-            {t('monitoring.emptyStates.noActiveJobs')}
-          </div>
+          <EmptyState
+            icon={Activity}
+            title={t('monitoring.emptyStates.noActiveJobs')}
+            className="py-8"
+          />
         ) : (
           <AnimatePresence initial={false}>
             {activeJobs.map((job) => (

--- a/apps/tauri/src/renderer/features/monitoring/components/ActivityFeedSection/index.tsx
+++ b/apps/tauri/src/renderer/features/monitoring/components/ActivityFeedSection/index.tsx
@@ -1,6 +1,7 @@
+import { Inbox } from 'lucide-react';
 import { AnimatePresence } from 'motion/react';
 
-import { GlassCard } from '@ajh/ui';
+import { EmptyState, GlassCard } from '@ajh/ui';
 
 import { ActivityRow } from '@/features/monitoring/components/ActivityRow';
 import type { ActivityItem } from '@/features/monitoring/types';
@@ -29,9 +30,11 @@ export function ActivityFeedSection({ activity, t }: Props) {
       <div className="max-h-72 space-y-1.5 overflow-y-auto pr-1">
         <AnimatePresence initial={false}>
           {activity.length === 0 ? (
-            <div className="py-8 text-center text-xs text-foreground/30">
-              {t('monitoring.emptyStates.waitingForActivity')}
-            </div>
+            <EmptyState
+              icon={Inbox}
+              title={t('monitoring.emptyStates.waitingForActivity')}
+              className="py-8"
+            />
           ) : (
             activity.map((a) => <ActivityRow key={a.id} a={a} />)
           )}

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -767,6 +767,7 @@
     "subtitle": "Gescrapte Job-Anzeigen von Ihren konfigurierten Boards. Filtern, ansehen und direkt bewerben.",
     "searchPlaceholder": "Nach Titel, Unternehmen, Ort suchen…",
     "empty": "Noch keine Anzeigen. Starten Sie einen Scrape, um dieses Board zu füllen.",
+    "emptyCta": "Jobs suchen",
     "open": "Öffnen",
     "copyLink": "Link kopieren",
     "apply": "Bewerben",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -782,6 +782,7 @@
     "subtitle": "Scraped job postings from your configured boards. Filter, view, and apply directly.",
     "searchPlaceholder": "Search by title, company, location…",
     "empty": "No postings yet. Start a scrape to populate this board.",
+    "emptyCta": "Search jobs",
     "open": "Open",
     "copyLink": "Copy link",
     "apply": "Apply",


### PR DESCRIPTION
## What
PR 4b — the **state-feedback** half of the audit's state-coverage work (the destructive-action half shipped in #236). Swaps ad-hoc inline markup for the `@ajh/ui` state primitives on the screens that still used bare text:

| Screen | Before | After |
|--------|--------|-------|
| **Jobs** (empty board) | text in a card | `EmptyState` (Search badge) + **"Search jobs"** CTA that opens the scrape form |
| **Monitoring · Active Jobs** | "No active jobs" text | `EmptyState` (Activity badge) |
| **Monitoring · Activity Feed** | "Waiting for activity…" text | `EmptyState` (Inbox badge) |
| **Analyze** (AI error) | inline red strip | `ErrorState` + **"Try again"** (re-runs analyze) |
| **AI Generate** (error) | inline red strip | `ErrorState` + **"Try again"** (re-runs generate) |
| **Autopilot** (loading) | "loading" string | `CardSkeleton` ×2 |

## Why
A prior survey found the app already had *functional* empty/error/loading coverage on most screens (Dashboard, Search, Résumés, plus per-row health status on Dashboard) — but several spots used inline text instead of the shared primitives, and the AI error banners had no explicit retry. This closes those gaps so the states look and behave consistently, with retry where it was missing.

## Notes
- The Analyze/Generate `ErrorState` is compacted (`py-6` + the original red-tint border) so it stays a results-panel banner rather than a full-screen takeover.
- `jobs.emptyCta` added (en/de).
- ResumesPage/SearchPage already use `EmptyState`; left as-is. Dashboard `JobPipelineOverview` (stats card) and `AISystemStatus` (already has per-row error + refresh) were intentionally left — the primitives don't fit a stats/status card.

## Verification
`pnpm typecheck` ✅ · `pnpm lint:strict` ✅ · monitoring + autopilot + jobs + analyze + ai-generate + resumes tests ✅. Empty states eyeballed in dark mode via local mock capture (Jobs CTA + Monitoring sections) — not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)