### PR TITLE
perf: optimistically delete generations and autopilots with rollback

### DIFF
--- a/apps/tauri/src/renderer/services/use-ai-generations/use-ai-generations.test.ts
+++ b/apps/tauri/src/renderer/services/use-ai-generations/use-ai-generations.test.ts
@@ -1,11 +1,53 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { act, waitFor } from '@testing-library/react';
 
-import { exerciseServiceHooks } from '@/test-support';
+import { createMockClient, exerciseServiceHooks, renderHookWithClient } from '@/test-support';
 
+import { keys } from '../query-client';
 import * as mod from './use-ai-generations';
+import { useRemoveAiGeneration } from './use-ai-generations';
+
+// gcTime: Infinity so cache seeded without an active observer is not collected.
+const persistentClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
 
 describe('use-ai-generations services', () => {
   it('renders every exported hook without crashing', async () => {
     await exerciseServiceHooks(mod);
+  });
+});
+
+describe('useRemoveAiGeneration — optimistic delete', () => {
+  it('removes the item before the backend resolves, then rolls back on error', async () => {
+    let reject!: (e: unknown) => void;
+    const remove = vi.fn(() => new Promise((_res, rej) => (reject = rej)));
+    const list = vi.fn().mockResolvedValue([{ id: 'a' }, { id: 'b' }]);
+    const client = createMockClient({
+      'aiGenerations.remove': remove,
+      'aiGenerations.list': list,
+    });
+    const queryClient = persistentClient();
+    queryClient.setQueryData(keys.aiGenerations.all, [{ id: 'a' }, { id: 'b' }]);
+
+    const { result } = renderHookWithClient(() => useRemoveAiGeneration(), { client, queryClient });
+
+    act(() => result.current.mutate('a'));
+
+    // Optimistic: 'a' is gone immediately, before remove() ever resolves.
+    await waitFor(() =>
+      expect(queryClient.getQueryData(keys.aiGenerations.all)).toEqual([{ id: 'b' }])
+    );
+
+    // Backend fails → the snapshot is restored.
+    act(() => reject(new Error('boom')));
+    await waitFor(() =>
+      expect(queryClient.getQueryData(keys.aiGenerations.all)).toEqual([{ id: 'a' }, { id: 'b' }])
+    );
   });
 });

--- a/apps/tauri/src/renderer/services/use-ai-generations/use-ai-generations.ts
+++ b/apps/tauri/src/renderer/services/use-ai-generations/use-ai-generations.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { AiGenerationSaveRequest } from '@ajh/shared/ipc';
+import type { AiGenerationRecord, AiGenerationSaveRequest } from '@ajh/shared/ipc';
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
@@ -28,6 +28,18 @@ export const useRemoveAiGeneration = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.aiGenerations.remove(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: keys.aiGenerations.all }),
+    // Optimistic delete: drop the card immediately, restore it if the backend fails.
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: keys.aiGenerations.all });
+      const previous = qc.getQueryData<AiGenerationRecord[]>(keys.aiGenerations.all);
+      qc.setQueryData<AiGenerationRecord[]>(keys.aiGenerations.all, (old) =>
+        (old ?? []).filter((g) => g.id !== id)
+      );
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) qc.setQueryData(keys.aiGenerations.all, ctx.previous);
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: keys.aiGenerations.all }),
   });
 };

--- a/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.test.ts
+++ b/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.test.ts
@@ -1,11 +1,48 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { act, waitFor } from '@testing-library/react';
 
-import { exerciseServiceHooks } from '@/test-support';
+import { createMockClient, exerciseServiceHooks, renderHookWithClient } from '@/test-support';
 
+import { keys } from '../query-client';
 import * as mod from './use-autopilot';
+import { useRemoveAutopilot } from './use-autopilot';
+
+// gcTime: Infinity so cache seeded without an active observer is not collected.
+const persistentClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
 
 describe('use-autopilot services', () => {
   it('renders every exported hook without crashing', async () => {
     await exerciseServiceHooks(mod);
+  });
+});
+
+describe('useRemoveAutopilot — optimistic delete', () => {
+  it('removes the card before the backend resolves, then rolls back on error', async () => {
+    let reject!: (e: unknown) => void;
+    const remove = vi.fn(() => new Promise((_res, rej) => (reject = rej)));
+    const list = vi.fn().mockResolvedValue([{ _id: 'a' }, { _id: 'b' }]);
+    const client = createMockClient({ 'autopilot.remove': remove, 'autopilot.list': list });
+    const queryClient = persistentClient();
+    queryClient.setQueryData(keys.autopilot.all, [{ _id: 'a' }, { _id: 'b' }]);
+
+    const { result } = renderHookWithClient(() => useRemoveAutopilot(), { client, queryClient });
+
+    act(() => result.current.mutate('a'));
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(keys.autopilot.all)).toEqual([{ _id: 'b' }])
+    );
+
+    act(() => reject(new Error('boom')));
+    await waitFor(() =>
+      expect(queryClient.getQueryData(keys.autopilot.all)).toEqual([{ _id: 'a' }, { _id: 'b' }])
+    );
   });
 });

--- a/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.ts
+++ b/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { AutopilotCreate, AutopilotStepEvent, AutopilotUpdate } from '@ajh/shared';
+import type { Autopilot, AutopilotCreate, AutopilotStepEvent, AutopilotUpdate } from '@ajh/shared';
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
@@ -46,7 +46,19 @@ export const useRemoveAutopilot = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.autopilot.remove({ autopilotId: id }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: keys.autopilot.all }),
+    // Optimistic delete: remove the card immediately, restore it if the backend fails.
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: keys.autopilot.all });
+      const previous = qc.getQueryData<Autopilot[]>(keys.autopilot.all);
+      qc.setQueryData<Autopilot[]>(keys.autopilot.all, (old) =>
+        (old ?? []).filter((a) => a._id !== id)
+      );
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) qc.setQueryData(keys.autopilot.all, ctx.previous);
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: keys.autopilot.all }),
   });
 };
 


### PR DESCRIPTION
## What
PR 5 — optimistic updates. Both delete hooks used `onSuccess → invalidateQueries`, so the deleted card sat on screen (with a spinner) until the SQLite round-trip returned. Now they update the cache **immediately**:

- `useRemoveAiGeneration` and `useRemoveAutopilot` gain `onMutate` (cancel in-flight, **snapshot** the list, optimistically filter the item out) + `onError` (restore the snapshot) + `onSettled` (invalidate to reconcile with the backend).

## Why
The card disappears the instant you confirm the delete; if the backend genuinely fails, it reappears and the error surfaces — no perceived lag for the common (successful) case.

## Tests
Each hook gains a test that drives a *deferred* backend call and asserts:
1. the item leaves the cache **before** the backend resolves (optimism), and
2. it is **restored** when the backend rejects (rollback).

## Scope note
The audit's PR 5 also mentioned "bookmark/applied counters" and "board move":
- **PostingRow** already updates its applied/viewed/saved badges via local `useState` (instant) — no cache change needed.
- There is **no drag-and-drop job board** (DnD is explicitly out of scope per the audit), so "board move" doesn't apply.

So the genuinely clean, high-value optimistic targets were the two deletes.

## Verification
`pnpm typecheck` ✅ · `pnpm lint:strict` ✅ · both service-hook suites ✅ (smoke + new optimistic/rollback tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)