### PR TITLE
feat: add global keyboard shortcuts and a ? cheat-sheet

### DIFF
--- a/apps/tauri/src/renderer/components/layout/ShortcutsOverlay/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/ShortcutsOverlay/index.tsx
@@ -1,0 +1,103 @@
+import { Command } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useRouter } from '@tanstack/react-router';
+
+import { ModalShell, SectionLabel } from '@ajh/ui';
+
+import { type AppRoute, useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts';
+import { useTranslation } from '@/lib/i18n';
+
+const IS_MAC = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
+const MOD = IS_MAC ? '⌘' : 'Ctrl';
+
+interface Row {
+  keys: string[];
+  labelKey: string;
+}
+
+const NAVIGATE: Row[] = [
+  { keys: ['g', 'd'], labelKey: 'nav.dashboard' },
+  { keys: ['g', 'a'], labelKey: 'nav.analyze' },
+  { keys: ['g', 'g'], labelKey: 'nav.generate' },
+  { keys: ['g', 'j'], labelKey: 'nav.jobs' },
+  { keys: ['g', 'p'], labelKey: 'nav.autopilot' },
+  { keys: ['g', 'r'], labelKey: 'nav.resumes' },
+  { keys: ['g', 'm'], labelKey: 'nav.monitoring' },
+  { keys: ['g', 'i'], labelKey: 'nav.ai' },
+  { keys: ['g', 's'], labelKey: 'nav.settings' },
+];
+
+const ACTIONS: Row[] = [
+  { keys: [MOD, 'K'], labelKey: 'nav.search' },
+  { keys: [MOD, ','], labelKey: 'nav.settings' },
+  { keys: ['?'], labelKey: 'shortcuts.help' },
+];
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className="inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-md border border-white/10 bg-white/[0.06] px-1.5 font-mono text-[11px] text-foreground/70">
+      {children}
+    </kbd>
+  );
+}
+
+function ShortcutList({ rows, t }: { rows: Row[]; t: (k: string) => string }) {
+  return (
+    <div className="space-y-1.5">
+      {rows.map((row) => (
+        <div
+          key={row.labelKey + row.keys.join()}
+          className="flex items-center justify-between gap-4"
+        >
+          <span className="text-xs text-foreground/65">{t(row.labelKey)}</span>
+          <span className="flex shrink-0 items-center gap-1">
+            {row.keys.map((k, i) => (
+              <Kbd key={i}>{k}</Kbd>
+            ))}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Mounts the global keyboard-shortcut handler and the `?` cheat-sheet. Rendered
+ * once in the root layout.
+ */
+export function ShortcutsOverlay() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const onNavigate = useCallback((to: AppRoute) => void router.navigate({ to }), [router]);
+  const onToggleHelp = useCallback(() => setOpen((o) => !o), []);
+  useKeyboardShortcuts({ onNavigate, onToggleHelp });
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={() => setOpen(false)}
+      ariaLabel={t('shortcuts.title')}
+      maxWidth="max-w-lg"
+    >
+      <div className="flex items-center gap-2 border-b border-white/5 px-6 py-4">
+        <Command size={15} className="text-brand-soft" />
+        <span className="text-sm font-medium text-foreground/90">{t('shortcuts.title')}</span>
+      </div>
+      <div className="grid grid-cols-2 gap-x-8 gap-y-4 px-6 py-5">
+        <div className="space-y-2.5">
+          <SectionLabel>{t('shortcuts.navigate')}</SectionLabel>
+          <ShortcutList rows={NAVIGATE} t={t} />
+        </div>
+        <div className="space-y-2.5">
+          <SectionLabel>{t('shortcuts.actions')}</SectionLabel>
+          <ShortcutList rows={ACTIONS} t={t} />
+        </div>
+      </div>
+      <div className="border-t border-white/5 px-6 py-3 text-center text-[11px] text-foreground/35">
+        {t('shortcuts.hint')}
+      </div>
+    </ModalShell>
+  );
+}

--- a/apps/tauri/src/renderer/hooks/use-keyboard-shortcuts.test.ts
+++ b/apps/tauri/src/renderer/hooks/use-keyboard-shortcuts.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useKeyboardShortcuts } from './use-keyboard-shortcuts';
+
+function press(key: string, opts: KeyboardEventInit = {}, target?: HTMLElement) {
+  const ev = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...opts });
+  (target ?? window).dispatchEvent(ev);
+  return ev;
+}
+
+describe('useKeyboardShortcuts', () => {
+  it('jumps to a route on the g-then-letter chord', () => {
+    const onNavigate = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNavigate, onToggleHelp: vi.fn() }));
+    press('g');
+    press('j');
+    expect(onNavigate).toHaveBeenCalledExactlyOnceWith('/jobs');
+  });
+
+  it('maps Ctrl/Cmd+K to search and Ctrl/Cmd+, to settings', () => {
+    const onNavigate = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNavigate, onToggleHelp: vi.fn() }));
+    press('k', { ctrlKey: true });
+    expect(onNavigate).toHaveBeenLastCalledWith('/search');
+    press(',', { metaKey: true });
+    expect(onNavigate).toHaveBeenLastCalledWith('/settings');
+  });
+
+  it('toggles the cheat-sheet on ?', () => {
+    const onToggleHelp = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNavigate: vi.fn(), onToggleHelp }));
+    press('?');
+    expect(onToggleHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire single-key shortcuts while typing in a field', () => {
+    const onNavigate = vi.fn();
+    const onToggleHelp = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNavigate, onToggleHelp }));
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    press('g', {}, input);
+    press('j', {}, input);
+    press('?', {}, input);
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(onToggleHelp).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it('still allows Cmd+K from within a field', () => {
+    const onNavigate = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNavigate, onToggleHelp: vi.fn() }));
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    press('k', { metaKey: true }, input);
+    expect(onNavigate).toHaveBeenCalledWith('/search');
+    input.remove();
+  });
+});

--- a/apps/tauri/src/renderer/hooks/use-keyboard-shortcuts.ts
+++ b/apps/tauri/src/renderer/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+
+import { ROUTES } from '@/constants/routes/routes';
+
+export type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];
+
+/** `g`-prefixed route jumps: press `g`, then the letter, within ~1.2s. */
+const GO_TO: Record<string, AppRoute> = {
+  d: ROUTES.DASHBOARD,
+  a: ROUTES.ANALYZE,
+  g: ROUTES.GENERATE,
+  j: ROUTES.JOBS,
+  p: ROUTES.AUTOPILOT,
+  r: ROUTES.RESUMES,
+  m: ROUTES.MONITORING,
+  i: ROUTES.AI,
+  s: ROUTES.SETTINGS,
+};
+
+/** Don't hijack keystrokes the user is typing into a field. */
+function isTypingTarget(el: EventTarget | null): boolean {
+  return (
+    el instanceof HTMLElement &&
+    (el instanceof HTMLInputElement ||
+      el instanceof HTMLTextAreaElement ||
+      el.isContentEditable ||
+      el.getAttribute('role') === 'textbox')
+  );
+}
+
+interface Options {
+  onNavigate: (to: AppRoute) => void;
+  onToggleHelp: () => void;
+}
+
+/**
+ * Global keyboard shortcuts (mounted once, app-wide):
+ *   - ⌘/Ctrl+K → Search, ⌘/Ctrl+, → Settings (work even from a field)
+ *   - `?` → toggle the shortcuts cheat-sheet
+ *   - `g` then d/a/g/j/p/r/m/i/s → jump to that route
+ * Intentionally NOT a command palette (out of scope).
+ */
+export function useKeyboardShortcuts({ onNavigate, onToggleHelp }: Options) {
+  // Keep the latest callbacks in a ref so the listener registers exactly once.
+  const cbs = useRef({ onNavigate, onToggleHelp });
+  cbs.current = { onNavigate, onToggleHelp };
+
+  const pendingG = useRef(false);
+  const gTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const clearG = () => {
+      pendingG.current = false;
+      if (gTimer.current) clearTimeout(gTimer.current);
+      gTimer.current = null;
+    };
+
+    const handler = (e: KeyboardEvent) => {
+      const { onNavigate, onToggleHelp } = cbs.current;
+      const mod = e.ctrlKey || e.metaKey;
+
+      // Modifier combos fire from anywhere, including inputs.
+      if (mod && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        onNavigate(ROUTES.SEARCH);
+        return;
+      }
+      if (mod && e.key === ',') {
+        e.preventDefault();
+        onNavigate(ROUTES.SETTINGS);
+        return;
+      }
+
+      // Single-key shortcuts never fire while typing or with a modifier held.
+      if (mod || e.altKey || isTypingTarget(e.target)) return;
+
+      if (e.key === '?') {
+        e.preventDefault();
+        onToggleHelp();
+        return;
+      }
+
+      if (pendingG.current) {
+        const to = GO_TO[e.key.toLowerCase()];
+        clearG();
+        if (to) {
+          e.preventDefault();
+          onNavigate(to);
+        }
+        return;
+      }
+      if (e.key.toLowerCase() === 'g') {
+        pendingG.current = true;
+        gTimer.current = setTimeout(clearG, 1200);
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      clearG();
+    };
+  }, []);
+}

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -17,6 +17,13 @@
     "support": "Hilfe & Support",
     "settings": "Einstellungen"
   },
+  "shortcuts": {
+    "title": "Tastenkürzel",
+    "navigate": "Navigieren",
+    "actions": "Aktionen",
+    "help": "Kürzel anzeigen",
+    "hint": "Drücke jederzeit ?, um diese Liste zu öffnen"
+  },
   "analyze": {
     "title": "Lebenslauf-Analyse",
     "subtitle": "Füge deinen Lebenslauf und eine Stellenanzeige ein. Erhalte sofort einen lokalen ATS-Score, semantischen Abgleich, Lückenanalyse und maßgeschneiderte Empfehlungen.",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -17,6 +17,13 @@
     "support": "Help & Support",
     "settings": "Settings"
   },
+  "shortcuts": {
+    "title": "Keyboard shortcuts",
+    "navigate": "Navigate",
+    "actions": "Actions",
+    "help": "Show shortcuts",
+    "hint": "Press ? anytime to open this list"
+  },
   "analyze": {
     "title": "Resume Analyzer",
     "subtitle": "Paste your resume and a job ad. Get an instant local ATS score, semantic match, gap analysis, and tailored recommendations.",

--- a/apps/tauri/src/renderer/routes/__root.tsx
+++ b/apps/tauri/src/renderer/routes/__root.tsx
@@ -5,6 +5,7 @@ import { NotificationProvider } from '@ajh/ui';
 
 import { CinematicBackground } from '@/components/background/CinematicBackground';
 import { ProtocolVersionGate } from '@/components/layout/ProtocolVersionGate';
+import { ShortcutsOverlay } from '@/components/layout/ShortcutsOverlay';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { StatusBar } from '@/components/layout/StatusBar';
 import { Titlebar } from '@/components/layout/Titlebar';
@@ -96,6 +97,7 @@ function RootLayout() {
             <StatusBar />
             <OnboardingWizard />
             <UpdateBanner />
+            <ShortcutsOverlay />
           </div>
         </CapabilityProvider>
       </ProtocolVersionGate>


### PR DESCRIPTION
## What
PR 6 (first half) — global **keyboard shortcuts** + a discoverable **`?` cheat-sheet**.

One global keydown handler (`useKeyboardShortcuts`), mounted once in the root layout:

| Shortcut | Action |
|----------|--------|
| `⌘/Ctrl + K` | Search |
| `⌘/Ctrl + ,` | Settings |
| `g` then `d/a/g/j/p/r/m/i/s` | jump to Dashboard / Analyze / Generate / Jobs / Autopilot / Résumés / Monitoring / AI / Settings |
| `?` | toggle the cheat-sheet |

- Modifier combos fire even from a focused field; **single-key** shortcuts (`g…`, `?`) are suppressed while typing in inputs / textareas / contenteditable.
- The cheat-sheet is a `ModalShell` (Escape + focus-trap for free), reuses the existing `nav.*` labels, and shows the platform modifier (`⌘` vs `Ctrl`) correctly.
- **Not a command palette** — out of scope per the audit.

## Tests
`use-keyboard-shortcuts.test.ts` covers the `g`-chord navigation, the `⌘/Ctrl+K` / `⌘/Ctrl+,` combos (incl. firing from inside a field), the `?` toggle, and the typing guard. Verified end-to-end via a local mock capture: `?` opens the sheet and `g` `j` navigates to /jobs (eyeballed, not committed).

## Scope
This is the **keyboard-shortcuts** half of the audit's PR 6. The other half — generalizing the `ScrapeForm/AuthHint` inline one-click setup to other blocked flows — is a follow-up, kept separate to stay reviewable.

## Verification
`pnpm typecheck` ✅ · `pnpm lint:strict` ✅ · hook test ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)