### PR TITLE
feat: nudge one-click ai-provider setup when a flow is blocked

### DIFF
--- a/apps/tauri/src/renderer/components/ui/AiSetupHint/index.tsx
+++ b/apps/tauri/src/renderer/components/ui/AiSetupHint/index.tsx
@@ -1,0 +1,46 @@
+import { useRouter } from '@tanstack/react-router';
+
+import { SetupHint } from '@ajh/ui';
+
+import { ROUTES } from '@/constants/routes/routes';
+import { useTranslation } from '@/lib/i18n';
+import { useSessionStore } from '@/store/session-store';
+
+/** Maps a {@link useCanUseAI} block reason to its hint copy. */
+const MESSAGE_KEY: Record<string, string> = {
+  addApiKey: 'aiSetup.addApiKey',
+  selectModel: 'aiSetup.selectModel',
+  installCli: 'aiSetup.installCli',
+};
+
+interface Props {
+  /** Whether AI is currently blocked (typically `!canUseAI`). */
+  show: boolean;
+  /** The block reason from `useCanUseAI` (`addApiKey` | `selectModel` | `installCli`). */
+  reason?: string;
+}
+
+/**
+ * One-click setup nudge shown when an AI provider isn't ready, so the user can
+ * jump straight to the AI settings section instead of hunting for it. The fix
+ * for every reason lives in the same section, so the action is uniform.
+ */
+export function AiSetupHint({ show, reason }: Props) {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const setSettings = useSessionStore((s) => s.setSettings);
+
+  const openAiSettings = () => {
+    setSettings({ activeSection: 'ai' });
+    void router.navigate({ to: ROUTES.SETTINGS });
+  };
+
+  return (
+    <SetupHint
+      show={show}
+      message={t((reason && MESSAGE_KEY[reason]) || 'aiSetup.addApiKey')}
+      actionLabel={t('aiSetup.action')}
+      onAction={openAiSettings}
+    />
+  );
+}

--- a/apps/tauri/src/renderer/features/ai-generate/components/LeftPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/LeftPanel/index.tsx
@@ -4,6 +4,7 @@ import { Button, SelectDropdown } from '@ajh/ui';
 
 import { JobAdField } from '@/components/job/JobAdField';
 import { ResumeInputCard } from '@/components/resume/ResumeInputCard';
+import { AiSetupHint } from '@/components/ui/AiSetupHint';
 import { ModelSelector } from '@/components/ui/ModelSelector';
 import { GenerationConfig } from '@/features/ai-generate/components/GenerationConfig';
 import { GenerationMetadata } from '@/features/ai-generate/components/GenerationMetadata';
@@ -138,6 +139,11 @@ export function LeftPanel({
       {/* Model selector */}
       <div className="px-6 pb-4">
         <ModelSelector />
+      </div>
+
+      {/* One-click AI setup when no provider is ready */}
+      <div className="px-6">
+        <AiSetupHint show={!canUseAI} reason={aiReason} />
       </div>
 
       <div className="px-6 space-y-3 pb-4">

--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
@@ -4,6 +4,7 @@ import { Button, cn, SegmentedControl } from '@ajh/ui';
 
 import { JobAdField } from '@/components/job/JobAdField';
 import { ResumeInputCard } from '@/components/resume/ResumeInputCard';
+import { AiSetupHint } from '@/components/ui/AiSetupHint';
 import { ModelSelector } from '@/components/ui/ModelSelector';
 import type { Stage } from '@/features/analyze/constants';
 import { useTranslation } from '@/lib/i18n';
@@ -78,6 +79,11 @@ export function AnalyzeLeftPanel({
       {/* Model selector */}
       <div className="px-6 pb-4">
         <ModelSelector />
+      </div>
+
+      {/* One-click AI setup when no provider is ready */}
+      <div className="px-6">
+        <AiSetupHint show={!canUseAI} reason={aiReason} />
       </div>
 
       {/* Prompt quality selector */}

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/AuthHint.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/AuthHint.tsx
@@ -1,7 +1,4 @@
-import { Info, Loader2 } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
-
-import { Button, transition } from '@ajh/ui';
+import { SetupHint } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 
@@ -15,35 +12,12 @@ export function AuthHint({ show, connectPending, onConnect }: Props) {
   const { t } = useTranslation();
 
   return (
-    <AnimatePresence>
-      {show && (
-        <motion.div
-          key="auth-hint"
-          initial={{ opacity: 0, height: 0, marginBottom: 0 }}
-          animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
-          exit={{ opacity: 0, height: 0, marginBottom: 0 }}
-          transition={transition.fast}
-          className="overflow-hidden"
-        >
-          <div className="flex items-center gap-2 rounded-lg border border-blue-400/15 bg-blue-400/5 px-3 py-2 text-[11px] text-blue-200/75">
-            <Info size={12} className="shrink-0 text-blue-400/60" />
-            <span>{t('jobs.authHint')}</span>
-            <Button
-              variant="unstyled"
-              type="button"
-              disabled={connectPending}
-              onClick={onConnect}
-              className="ml-auto shrink-0 text-brand-soft underline-offset-2 hover:underline disabled:opacity-50"
-            >
-              {connectPending ? (
-                <Loader2 size={11} className="animate-spin" />
-              ) : (
-                t('jobs.authHintLink')
-              )}
-            </Button>
-          </div>
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <SetupHint
+      show={show}
+      message={t('jobs.authHint')}
+      actionLabel={t('jobs.authHintLink')}
+      onAction={onConnect}
+      pending={connectPending}
+    />
   );
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -24,6 +24,12 @@
     "help": "Kürzel anzeigen",
     "hint": "Drücke jederzeit ?, um diese Liste zu öffnen"
   },
+  "aiSetup": {
+    "addApiKey": "Füge einen KI-Anbieter-Schlüssel hinzu, um zu generieren.",
+    "selectModel": "Wähle ein KI-Modell, um zu generieren.",
+    "installCli": "Installiere deinen KI-CLI-Agenten, um fortzufahren.",
+    "action": "KI-Einstellungen öffnen"
+  },
   "analyze": {
     "title": "Lebenslauf-Analyse",
     "subtitle": "Füge deinen Lebenslauf und eine Stellenanzeige ein. Erhalte sofort einen lokalen ATS-Score, semantischen Abgleich, Lückenanalyse und maßgeschneiderte Empfehlungen.",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -24,6 +24,12 @@
     "help": "Show shortcuts",
     "hint": "Press ? anytime to open this list"
   },
+  "aiSetup": {
+    "addApiKey": "Add an AI provider key to start generating.",
+    "selectModel": "Choose an AI model to start generating.",
+    "installCli": "Install your AI CLI agent to continue.",
+    "action": "Open AI settings"
+  },
   "analyze": {
     "title": "Resume Analyzer",
     "subtitle": "Paste your resume and a job ad. Get an instant local ATS score, semantic match, gap analysis, and tailored recommendations.",

--- a/packages/ui/src/components/SetupHint/SetupHint.test.tsx
+++ b/packages/ui/src/components/SetupHint/SetupHint.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SetupHint } from './SetupHint';
+
+describe('SetupHint', () => {
+  it('renders the message and action, firing onAction on click', async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    render(
+      <SetupHint message="Connect a provider" actionLabel="Open settings" onAction={onAction} />
+    );
+    expect(screen.getByText('Connect a provider')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Open settings' }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when show is false', () => {
+    render(<SetupHint show={false} message="hidden message" actionLabel="x" onAction={() => {}} />);
+    expect(screen.queryByText('hidden message')).toBeNull();
+  });
+
+  it('disables the action and hides its label while pending', () => {
+    render(<SetupHint message="m" actionLabel="Connect" onAction={() => {}} pending />);
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.queryByText('Connect')).toBeNull();
+  });
+
+  it('omits the action button when no actionLabel is given', () => {
+    render(<SetupHint message="info only" />);
+    expect(screen.getByText('info only')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/SetupHint/SetupHint.tsx
+++ b/packages/ui/src/components/SetupHint/SetupHint.tsx
@@ -1,0 +1,82 @@
+import { Info, Loader2, type LucideIcon } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import type { ReactNode } from 'react';
+
+import { cn } from '../../lib/cn';
+import { transition } from '../../lib/motion';
+
+type Tone = 'info' | 'amber';
+
+const TONE: Record<Tone, { box: string; icon: string }> = {
+  info: { box: 'border-blue-400/15 bg-blue-400/5 text-blue-200/75', icon: 'text-blue-400/60' },
+  amber: {
+    box: 'border-amber-400/15 bg-amber-400/5 text-amber-200/80',
+    icon: 'text-amber-400/60',
+  },
+};
+
+export interface SetupHintProps {
+  /** Collapses (with animation) when false. Default true. */
+  show?: boolean;
+  message: ReactNode;
+  /** Label of the inline one-click action. Omit for a message-only hint. */
+  actionLabel?: string;
+  onAction?: () => void;
+  /** Shows a spinner and disables the action while a fix is in flight. */
+  pending?: boolean;
+  icon?: LucideIcon;
+  tone?: Tone;
+  className?: string;
+}
+
+/**
+ * Inline "a prerequisite blocks this flow — here's the one-click fix" banner.
+ * Generalized from the jobs ScrapeForm auth hint so every blocked flow (no AI
+ * provider, disconnected board, …) gets the same nudge + action affordance.
+ */
+export function SetupHint({
+  show = true,
+  message,
+  actionLabel,
+  onAction,
+  pending = false,
+  icon: Icon = Info,
+  tone = 'info',
+  className,
+}: SetupHintProps) {
+  const c = TONE[tone];
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          initial={{ opacity: 0, height: 0, marginBottom: 0 }}
+          animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
+          exit={{ opacity: 0, height: 0, marginBottom: 0 }}
+          transition={transition.fast}
+          className="overflow-hidden"
+        >
+          <div
+            className={cn(
+              'flex items-center gap-2 rounded-lg border px-3 py-2 text-[11px]',
+              c.box,
+              className
+            )}
+          >
+            <Icon size={12} className={cn('shrink-0', c.icon)} />
+            <span>{message}</span>
+            {actionLabel && onAction && (
+              <button
+                type="button"
+                disabled={pending}
+                onClick={onAction}
+                className="ml-auto shrink-0 text-brand-soft underline-offset-2 hover:underline disabled:opacity-50"
+              >
+                {pending ? <Loader2 size={11} className="animate-spin" /> : actionLabel}
+              </button>
+            )}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/ui/src/components/SetupHint/index.ts
+++ b/packages/ui/src/components/SetupHint/index.ts
@@ -1,0 +1,1 @@
+export * from './SetupHint';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -38,6 +38,7 @@ export {
   type SegmentedOption,
 } from './components/SegmentedControl/index';
 export { SelectDropdown } from './components/SelectDropdown/index';
+export { SetupHint, type SetupHintProps } from './components/SetupHint/index';
 export { SourceBadge, type SourceBadgeProps } from './components/SourceBadge/index';
 export { TextArea, type TextAreaProps } from './components/TextArea/index';
 


### PR DESCRIPTION
## What
PR 6b — the **contextual inline-setup** half of PR 6 (keyboard shortcuts shipped in #239).

- **New `@ajh/ui` `SetupHint`** — a reusable inline "a prerequisite blocks this flow → here's the one-click fix" banner, generalized from the jobs `ScrapeForm` auth hint. `AuthHint` is refactored onto it (net smaller, same behavior).
- **New `AiSetupHint`** on the **Analyze** and **AI Generate** panels: when no AI provider is ready, it shows a reason-specific nudge —
  - `addApiKey` → "Add an AI provider key to start generating."
  - `selectModel` → "Choose an AI model to start generating."
  - `installCli` → "Install your AI CLI agent to continue."
  
  …with an **"Open AI settings"** action that deep-links straight to the AI settings section (`setSettings({ activeSection: 'ai' })` + navigate), instead of leaving the user to find it.

## Why
The core features (Analyze, Generate) are unusable without an AI provider; previously the only signal was a disabled CTA label. This turns the dead-end into a one-click path to the fix — the audit's "inline one-click setup" idea.

## Tests
`SetupHint` unit test (renders message+action, fires `onAction`, collapses when `show=false`, disables + spins while `pending`, omits the button when message-only). Verified visually: the hint renders under the model selector on Analyze with the correct reason copy + action (screenshot eyeballed, not committed).

## Scope
The board-not-connected (Autopilot) and no-Chrome (wizard) nudges are natural follow-ups that can adopt `SetupHint` next — kept out to keep this reviewable.

## Verification
`pnpm typecheck` ✅ · `pnpm lint:strict` ✅ · `@ajh/ui` SetupHint + jobs/analyze/ai-generate suites ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)