### PR TITLE
feat: autopilot new-jobs notifications + tray surface + deep-link focus guard

### DIFF
--- a/apps/tauri/src-tauri/src/autopilot/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot/mod.rs
@@ -238,23 +238,29 @@ impl AutopilotStore {
     /// list **merged** with prior runs by URL — so re-running keeps history
     /// (first-seen + any state) instead of replacing it, and genuinely new
     /// postings are flagged `is_new`.
+    /// Returns the number of **newly surfaced** jobs in this run (postings whose
+    /// URL was never seen before) — drives the "N new jobs" notification + tray.
     pub fn record_run(
         &self,
         id: &str,
         total_found: u32,
         total_applied: u32,
         found_jobs: Vec<FoundJob>,
-    ) {
+    ) -> u32 {
         let mut map = self.load();
+        let mut new_count = 0u32;
         if let Some(ap) = map.get_mut(id) {
             let now = now_ms();
             ap.total_found = total_found;
             ap.total_applied = total_applied;
             ap.found_jobs = merge_found_jobs(&ap.found_jobs, found_jobs);
+            // `merge_found_jobs` flags only never-before-seen URLs as `is_new`.
+            new_count = ap.found_jobs.iter().filter(|j| j.is_new).count() as u32;
             ap.last_run_at = Some(now);
             ap.updated_at = now;
         }
         self.save(map);
+        new_count
     }
 
     pub fn stamp_last_run(&self, id: &str) {

--- a/apps/tauri/src-tauri/src/autopilot/test.rs
+++ b/apps/tauri/src-tauri/src/autopilot/test.rs
@@ -204,3 +204,41 @@ fn merge_keeps_prior_jobs_not_in_the_new_run() {
     );
     assert!(merged.iter().any(|j| j.url == "old"));
 }
+
+#[test]
+fn record_run_reports_only_newly_surfaced_jobs() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+    let ap = store.create(serde_json::json!({
+        "name": "AP",
+        "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+        "filter": { "minMatchScore": 50.0 },
+        "schedule": "manual",
+    }));
+    let id = ap.id;
+
+    // First run — both URLs are brand new → drives a "2 new jobs" notification.
+    assert_eq!(
+        store.record_run(&id, 2, 0, vec![found_job("u1", 1), found_job("u2", 2)]),
+        2
+    );
+    // Re-run with the two seen URLs + one unseen → only the unseen counts.
+    assert_eq!(
+        store.record_run(
+            &id,
+            3,
+            0,
+            vec![found_job("u1", 9), found_job("u2", 9), found_job("u3", 9)]
+        ),
+        1
+    );
+    // Nothing unseen → no notification.
+    assert_eq!(store.record_run(&id, 3, 0, vec![found_job("u1", 9)]), 0);
+    // Unknown autopilot → 0 (no panic).
+    assert_eq!(
+        store.record_run("missing", 5, 0, vec![found_job("x", 1)]),
+        0
+    );
+}

--- a/apps/tauri/src-tauri/src/commands/autopilot.rs
+++ b/apps/tauri/src-tauri/src/commands/autopilot.rs
@@ -210,9 +210,13 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
         &format!("Scored {scored_count} of {total_found} jobs"),
     );
 
-    store(&app)
+    let new_count = store(&app)
         .lock()
         .record_run(&autopilot_id, total_found as u32, 0, found_jobs);
+
+    // Surface genuinely-new finds while the user is away: a permission-gated
+    // notification + a "New jobs: N" tray counter that jumps back to this run.
+    crate::tray::on_new_jobs(&app, &autopilot_id, &autopilot.name, new_count);
 
     engine.unregister_token(&job_id).await;
 

--- a/apps/tauri/src-tauri/src/deeplink/mod.rs
+++ b/apps/tauri/src-tauri/src/deeplink/mod.rs
@@ -1,0 +1,59 @@
+//! Deep-link / single-instance argv guard.
+//!
+//! When the app is re-launched (or a second instance starts) with an `ajh://…`
+//! URL on its argv, we must NOT blindly drive the renderer to whatever route the
+//! URL names — a hostile argv (`ajh://settings/wipe`, `ajh://../../x`) is an
+//! injection vector. This parses argv and accepts ONLY the allowlisted
+//! `ajh://autopilot/<id>` shape with a syntactically valid id; everything else
+//! yields `None` (the caller then just focuses the window, navigating nowhere).
+//!
+//! The OS URI scheme itself is not registered yet (a follow-up will add
+//! `tauri-plugin-deep-link`); the guard lives here first so it is in place and
+//! unit-tested before any externally-controlled URL can reach navigation.
+
+/// A validated, allowlisted deep-link target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FocusTarget {
+    /// Focus a specific autopilot's found-jobs panel.
+    Autopilot(String),
+}
+
+const SCHEME: &str = "ajh://";
+
+/// Scan argv for the first valid `ajh://autopilot/<id>` URL. Returns `None` for
+/// any other scheme, host/action, extra path segments, query/fragment, or a
+/// malformed id — the deny-by-default posture for an externally-controlled input.
+pub fn parse_focus_target(argv: &[String]) -> Option<FocusTarget> {
+    argv.iter().find_map(|arg| parse_one(arg.trim()))
+}
+
+fn parse_one(arg: &str) -> Option<FocusTarget> {
+    let rest = arg.strip_prefix(SCHEME)?; // exact scheme, case-sensitive
+                                          // Reject query/fragment/backslash outright — we only accept `<action>/<id>`.
+    if rest.contains(['?', '#', '\\']) {
+        return None;
+    }
+    let mut parts = rest.split('/');
+    let action = parts.next()?;
+    let id = parts.next()?;
+    if parts.next().is_some() {
+        return None; // exactly two segments — no deeper path
+    }
+    match action {
+        "autopilot" if is_valid_id(id) => Some(FocusTarget::Autopilot(id.to_string())),
+        _ => None,
+    }
+}
+
+/// Conservative id shape: 1–64 chars of `[A-Za-z0-9_-]`. Autopilot ids are uuids
+/// or `job-<hex>`; this rejects path traversal, separators, dots, and anything odd.
+fn is_valid_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+#[cfg(test)]
+mod test;

--- a/apps/tauri/src-tauri/src/deeplink/test.rs
+++ b/apps/tauri/src-tauri/src/deeplink/test.rs
@@ -1,0 +1,70 @@
+use super::*;
+
+fn argv(s: &str) -> Vec<String> {
+    // Mimic a real launch: exe path first, then the URL the OS appends.
+    vec!["C:/app/ajh.exe".to_string(), s.to_string()]
+}
+
+#[test]
+fn accepts_a_valid_autopilot_url() {
+    assert_eq!(
+        parse_focus_target(&argv("ajh://autopilot/job-1a2b3c")),
+        Some(FocusTarget::Autopilot("job-1a2b3c".to_string()))
+    );
+    // uuid-shaped id
+    assert_eq!(
+        parse_focus_target(&argv(
+            "ajh://autopilot/550e8400-e29b-41d4-a716-446655440000"
+        )),
+        Some(FocusTarget::Autopilot(
+            "550e8400-e29b-41d4-a716-446655440000".to_string()
+        ))
+    );
+}
+
+#[test]
+fn rejects_unknown_scheme_or_action() {
+    assert_eq!(parse_focus_target(&argv("https://autopilot/x")), None);
+    assert_eq!(parse_focus_target(&argv("ajhx://autopilot/x")), None);
+    assert_eq!(parse_focus_target(&argv("AJH://autopilot/x")), None); // case-sensitive
+    assert_eq!(parse_focus_target(&argv("ajh://settings/wipe")), None);
+    assert_eq!(parse_focus_target(&argv("ajh://privacy/reset")), None);
+}
+
+#[test]
+fn rejects_path_traversal_and_injection_shapes() {
+    assert_eq!(
+        parse_focus_target(&argv("ajh://autopilot/../../settings")),
+        None
+    );
+    assert_eq!(parse_focus_target(&argv("ajh://autopilot/a/b")), None); // extra segment
+    assert_eq!(parse_focus_target(&argv("ajh://autopilot/")), None); // empty id
+    assert_eq!(parse_focus_target(&argv("ajh://autopilot")), None); // no id segment
+    assert_eq!(parse_focus_target(&argv("ajh://autopilot/id?x=1")), None); // query
+    assert_eq!(parse_focus_target(&argv("ajh://autopilot/id#frag")), None); // fragment
+    assert_eq!(parse_focus_target(&argv("ajh://autopilot/a b")), None); // space
+    assert_eq!(parse_focus_target(&argv("ajh://autopilot/a\\b")), None); // backslash
+    assert_eq!(
+        parse_focus_target(&argv(&format!("ajh://autopilot/{}", "x".repeat(65)))),
+        None
+    );
+}
+
+#[test]
+fn ignores_normal_launch_argv() {
+    assert_eq!(parse_focus_target(&["C:/app/ajh.exe".to_string()]), None);
+    assert_eq!(parse_focus_target(&[]), None);
+}
+
+#[test]
+fn finds_the_url_among_other_args() {
+    let v = vec![
+        "C:/app/ajh.exe".to_string(),
+        "--flag".to_string(),
+        "ajh://autopilot/abc".to_string(),
+    ];
+    assert_eq!(
+        parse_focus_target(&v),
+        Some(FocusTarget::Autopilot("abc".to_string()))
+    );
+}

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -16,6 +16,7 @@ mod cover_letter;
 mod credentials;
 mod data_store;
 mod db;
+mod deeplink;
 mod documents;
 mod error;
 mod export;
@@ -34,15 +35,13 @@ mod profile_import;
 mod recommend;
 mod scraping;
 mod theme;
+mod tray;
 mod updater;
 mod validate;
 
 use parking_lot::Mutex;
 
-use tauri::menu::{
-    AboutMetadataBuilder, MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder,
-};
-use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri::menu::{AboutMetadataBuilder, MenuBuilder, PredefinedMenuItem, SubmenuBuilder};
 use tauri::{AppHandle, Manager};
 
 use autopilot::AutopilotStore;
@@ -102,50 +101,6 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
         .build()
 }
 
-// ── System tray ───────────────────────────────────────────────────────────────
-
-fn build_tray(app: &AppHandle) -> tauri::Result<()> {
-    let show = MenuItemBuilder::with_id("tray_show", "Show AI Job Hunter").build(app)?;
-    let quit = MenuItemBuilder::with_id("tray_quit", "Quit").build(app)?;
-    let tray_menu = MenuBuilder::new(app)
-        .item(&show)
-        .separator()
-        .item(&quit)
-        .build()?;
-
-    TrayIconBuilder::new()
-        .menu(&tray_menu)
-        .tooltip("AI Job Hunter")
-        .on_menu_event(|app, event| match event.id().as_ref() {
-            "tray_show" => {
-                if let Some(win) = app.get_webview_window("main") {
-                    let _ = win.show();
-                    let _ = win.set_focus();
-                }
-            }
-            "tray_quit" => app.exit(0),
-            _ => {}
-        })
-        .on_tray_icon_event(|tray, event| {
-            // Left-click on the tray icon shows/focuses the main window.
-            if let TrayIconEvent::Click {
-                button: MouseButton::Left,
-                button_state: MouseButtonState::Up,
-                ..
-            } = event
-            {
-                let app = tray.app_handle();
-                if let Some(win) = app.get_webview_window("main") {
-                    let _ = win.show();
-                    let _ = win.set_focus();
-                }
-            }
-        })
-        .build(app)?;
-
-    Ok(())
-}
-
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 fn main() {
@@ -153,12 +108,19 @@ fn main() {
 
     tauri::Builder::default()
         // Single-instance must be the FIRST plugin: on a second launch it focuses
-        // the already-running window instead of spawning another process.
-        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+        // the already-running window instead of spawning another process. If that
+        // launch carried an `ajh://autopilot/<id>` deep link, the guard validates
+        // it against a strict route allowlist before driving any navigation — a
+        // hostile argv navigates nowhere (see `deeplink`).
+        .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             if let Some(win) = app.get_webview_window("main") {
                 let _ = win.show();
                 let _ = win.unminimize();
                 let _ = win.set_focus();
+            }
+            if let Some(deeplink::FocusTarget::Autopilot(id)) = deeplink::parse_focus_target(&argv)
+            {
+                tray::emit_focus(app, &id);
             }
         }))
         .plugin(
@@ -280,7 +242,7 @@ fn main() {
             }
 
             // Build system tray.
-            if let Err(e) = build_tray(handle) {
+            if let Err(e) = tray::build(handle) {
                 log::warn!("[setup] tray build error (non-fatal): {e}");
             }
 

--- a/apps/tauri/src-tauri/src/tray/mod.rs
+++ b/apps/tauri/src-tauri/src/tray/mod.rs
@@ -1,0 +1,180 @@
+//! System tray + the "new jobs" notification surface (L3 shell).
+//!
+//! Autopilot is a background discovery agent: when a scheduled run surfaces
+//! brand-new postings the user isn't looking at the app, so we (1) raise a
+//! permission-gated OS notification and (2) bump a "New jobs: N" tray counter.
+//! Clicking that counter focuses the window and emits `autopilot.focus` so the
+//! renderer jumps to the autopilot whose run produced the newest finds.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tauri::menu::{MenuBuilder, MenuItem, MenuItemBuilder};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri::{AppHandle, Emitter, Manager, Wry};
+use tauri_plugin_notification::{NotificationExt, PermissionState};
+
+use crate::autopilot::{AutopilotStatus, AutopilotStore};
+
+const SHOW_ID: &str = "tray_show";
+const NEW_JOBS_ID: &str = "tray_new_jobs";
+const PAUSE_ALL_ID: &str = "tray_pause_all";
+const QUIT_ID: &str = "tray_quit";
+
+/// Renderer event: focus an autopilot's found-jobs panel. An empty `autopilotId`
+/// is a pure "refresh autopilots" signal (e.g. after a tray Pause-All) with no
+/// navigation.
+const FOCUS_EVENT: &str = "autopilot.focus";
+
+/// Tray-owned state: the dynamic "New jobs" menu item handle plus the running
+/// unseen-jobs total and which autopilot to focus when the user clicks it.
+pub struct TrayState {
+    new_jobs_item: MenuItem<Wry>,
+    inner: Mutex<NewJobs>,
+}
+
+#[derive(Default)]
+struct NewJobs {
+    total: u32,
+    last_autopilot: Option<String>,
+}
+
+/// Build the tray icon + menu and register `TrayState`. Called once from setup.
+pub fn build(app: &AppHandle) -> tauri::Result<()> {
+    let show = MenuItemBuilder::with_id(SHOW_ID, "Show AI Job Hunter").build(app)?;
+    // Non-clickable until a run surfaces new jobs (label updates in place).
+    let new_jobs = MenuItemBuilder::with_id(NEW_JOBS_ID, "New jobs: 0")
+        .enabled(false)
+        .build(app)?;
+    let pause_all_item =
+        MenuItemBuilder::with_id(PAUSE_ALL_ID, "Pause all autopilots").build(app)?;
+    let quit = MenuItemBuilder::with_id(QUIT_ID, "Quit").build(app)?;
+    let menu = MenuBuilder::new(app)
+        .item(&show)
+        .separator()
+        .item(&new_jobs)
+        .item(&pause_all_item)
+        .separator()
+        .item(&quit)
+        .build()?;
+
+    TrayIconBuilder::new()
+        .menu(&menu)
+        .tooltip("AI Job Hunter")
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            SHOW_ID => show_focus(app),
+            NEW_JOBS_ID => on_new_jobs_click(app),
+            PAUSE_ALL_ID => pause_all(app),
+            QUIT_ID => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                show_focus(tray.app_handle());
+            }
+        })
+        .build(app)?;
+
+    app.manage(TrayState {
+        new_jobs_item: new_jobs,
+        inner: Mutex::new(NewJobs::default()),
+    });
+    Ok(())
+}
+
+fn show_focus(app: &AppHandle) {
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.show();
+        let _ = win.unminimize();
+        let _ = win.set_focus();
+    }
+}
+
+/// After a run surfaces `new_count` brand-new jobs (>0): raise a permission-gated
+/// notification and bump the tray "New jobs: N" counter, remembering which
+/// autopilot to focus when the user clicks it.
+pub fn on_new_jobs(app: &AppHandle, autopilot_id: &str, autopilot_name: &str, new_count: u32) {
+    if new_count == 0 {
+        return;
+    }
+    notify(app, autopilot_name, new_count);
+    if let Some(state) = app.try_state::<TrayState>() {
+        let total = {
+            let mut g = state.inner.lock();
+            g.total = g.total.saturating_add(new_count);
+            g.last_autopilot = Some(autopilot_id.to_string());
+            g.total
+        };
+        let _ = state.new_jobs_item.set_text(format!("New jobs: {total}"));
+    }
+}
+
+/// Emit a focus event so the renderer jumps to a specific autopilot's found-jobs
+/// panel (or, with an empty id, just refreshes the list). Shared by the tray and
+/// the single-instance deep-link guard.
+pub fn emit_focus(app: &AppHandle, autopilot_id: &str) {
+    let _ = app.emit(
+        FOCUS_EVENT,
+        serde_json::json!({ "autopilotId": autopilot_id }),
+    );
+}
+
+fn notify(app: &AppHandle, name: &str, count: u32) {
+    // Permission gate: send only if granted; request once when not, skip on deny.
+    let granted = matches!(
+        app.notification().permission_state(),
+        Ok(PermissionState::Granted)
+    ) || matches!(
+        app.notification().request_permission(),
+        Ok(PermissionState::Granted)
+    );
+    if !granted {
+        return;
+    }
+    let body = if count == 1 {
+        format!("1 new job for “{name}”")
+    } else {
+        format!("{count} new jobs for “{name}”")
+    };
+    let _ = app
+        .notification()
+        .builder()
+        .title("AI Job Hunter")
+        .body(body)
+        .show();
+}
+
+fn on_new_jobs_click(app: &AppHandle) {
+    show_focus(app);
+    let Some(state) = app.try_state::<TrayState>() else {
+        return;
+    };
+    let target = {
+        let mut g = state.inner.lock();
+        let t = g.last_autopilot.take();
+        g.total = 0;
+        t
+    };
+    let _ = state.new_jobs_item.set_text("New jobs: 0");
+    if let Some(id) = target {
+        emit_focus(app, &id);
+    }
+}
+
+fn pause_all(app: &AppHandle) {
+    let Some(store) = app.try_state::<Arc<Mutex<AutopilotStore>>>() else {
+        return;
+    };
+    let store = store.inner().clone();
+    let ids: Vec<String> = store.lock().list().into_iter().map(|a| a.id).collect();
+    for id in ids {
+        store.lock().set_status(&id, AutopilotStatus::Paused);
+    }
+    // Empty id = "refresh autopilots" so the renderer reflects the pause.
+    emit_focus(app, "");
+}

--- a/apps/tauri/src-tauri/tests/architecture.rs
+++ b/apps/tauri/src-tauri/tests/architecture.rs
@@ -57,7 +57,14 @@ const L2: &[&str] = &[
     "autopilot_helpers",
     "recommend",
 ];
-const L3: &[&str] = &["commands", "ipc_contracts", "main", "updater"];
+const L3: &[&str] = &[
+    "commands",
+    "ipc_contracts",
+    "main",
+    "updater",
+    "tray",
+    "deeplink",
+];
 
 fn layer_of(module: &str) -> Option<u8> {
     if L0.contains(&module) {

--- a/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -11,7 +11,7 @@ import {
   Wand2,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { Autopilot, AutopilotFoundJob } from '@ajh/shared';
 import { Button, cn, ConfirmModal, GlassCard, transition } from '@ajh/ui';
@@ -32,6 +32,10 @@ interface AutopilotCardProps {
   autopilot: Autopilot;
   runState: AutopilotRunState;
   stepLogs: StepLog[];
+  /** When true (tray/deep-link focus), auto-expand found-jobs + scroll into view. */
+  focused?: boolean;
+  /** Called once the focus has been consumed, so the page can clear it. */
+  onFocusHandled?: () => void;
   onRun(): void;
   onTogglePause(): void;
   onEdit(): void;
@@ -50,6 +54,8 @@ export function AutopilotCard({
   autopilot: ap,
   runState,
   stepLogs,
+  focused,
+  onFocusHandled,
   onRun,
   onTogglePause,
   onEdit,
@@ -62,7 +68,17 @@ export function AutopilotCard({
   const [showFound, setShowFound] = useState(false);
   const [applyJob, setApplyJob] = useState<AutopilotFoundJob | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const headerRef = useRef<HTMLDivElement>(null);
   const foundJobs = ap.foundJobs ?? [];
+
+  // Tray "New jobs" / deep-link focus: open this card's found-jobs and scroll to
+  // it, then tell the page to clear the focus so a later click re-triggers.
+  useEffect(() => {
+    if (!focused) return;
+    setShowFound(true);
+    headerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    onFocusHandled?.();
+  }, [focused, onFocusHandled]);
 
   const lastRun = ap.lastRunAt
     ? new Date(ap.lastRunAt).toLocaleString()
@@ -70,7 +86,7 @@ export function AutopilotCard({
 
   return (
     <GlassCard className="flex flex-col gap-3">
-      <div className="flex items-center gap-4">
+      <div ref={headerRef} className="flex items-center gap-4">
         {/* Status dot */}
         <div
           className={cn(

--- a/apps/tauri/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
@@ -19,7 +19,7 @@ function AutopilotPage() {
   const { data: autopilotList = [], isLoading: loading } = useAutopilots();
   const autopilots = autopilotList;
   const { autopilot, setAutopilot, resetAutopilotWizard } = useSessionStore();
-  const { creating } = autopilot;
+  const { creating, focusedId } = autopilot;
   const setCreating = (v: boolean) => setAutopilot({ creating: v });
   const resetWizard = resetAutopilotWizard;
 
@@ -94,6 +94,8 @@ function AutopilotPage() {
                     autopilot={ap}
                     runState={runState}
                     stepLogs={stepLogs[ap._id] ?? []}
+                    focused={focusedId === ap._id}
+                    onFocusHandled={() => setAutopilot({ focusedId: null })}
                     onRun={() => void handleRun(ap._id)}
                     onTogglePause={() => void handleTogglePause(ap)}
                     onEdit={() => handleEdit(ap)}

--- a/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.ts
+++ b/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+
+import type { AutopilotFocusEvent } from '@ajh/shared';
+
+import { keys, useAutopilotFocusEvents } from '@/services';
+import { useSessionStore } from '@/store/session-store';
+
+/**
+ * App-global listener for the shell's `autopilot.focus` event (raised by a tray
+ * "New jobs" click or a validated deep link). Always refreshes the autopilot
+ * list so tray-side changes (e.g. Pause-All) reflect; when an `autopilotId` is
+ * present, it also routes to /autopilot and flags the card to auto-expand its
+ * found-jobs. An empty id is a pure refresh signal (no navigation).
+ *
+ * Mounted once in the root layout so it fires regardless of the current route.
+ */
+export function useAutopilotFocusNavigation() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const setAutopilot = useSessionStore((s) => s.setAutopilot);
+
+  const onFocus = useCallback(
+    (event: AutopilotFocusEvent) => {
+      void qc.invalidateQueries({ queryKey: keys.autopilot.all });
+      const id = event.autopilotId?.trim();
+      if (!id) return;
+      setAutopilot({ focusedId: id });
+      void navigate({ to: '/autopilot' });
+    },
+    [navigate, qc, setAutopilot]
+  );
+
+  useAutopilotFocusEvents(onFocus);
+}

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -210,6 +210,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       pause: noop,
       resume: noop,
       onStep: () => () => {},
+      onFocus: () => () => {},
     },
 
     dialog: {

--- a/apps/tauri/src/renderer/routes/__root.tsx
+++ b/apps/tauri/src/renderer/routes/__root.tsx
@@ -11,10 +11,14 @@ import { StatusBar } from '@/components/layout/StatusBar';
 import { Titlebar } from '@/components/layout/Titlebar';
 import { UpdateBanner } from '@/components/ui/UpdateBanner';
 import { OnboardingWizard } from '@/features/onboarding/OnboardingWizard';
+import { useAutopilotFocusNavigation } from '@/hooks/use-autopilot-focus-navigation';
 import { CapabilityProvider } from '@/providers/CapabilityProvider';
 
 function RootLayout() {
   const router = useRouter();
+
+  // Route to an autopilot's found-jobs when the tray/deep-link asks (app-global).
+  useAutopilotFocusNavigation();
   useEffect(() => {
     // Prevent mouse side-buttons (back/forward, buttons 3 & 4) from triggering
     // browser history navigation which leads to unhandled routes in the SPA.

--- a/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.ts
+++ b/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.ts
@@ -1,7 +1,13 @@
 import { useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { Autopilot, AutopilotCreate, AutopilotStepEvent, AutopilotUpdate } from '@ajh/shared';
+import type {
+  Autopilot,
+  AutopilotCreate,
+  AutopilotFocusEvent,
+  AutopilotStepEvent,
+  AutopilotUpdate,
+} from '@ajh/shared';
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
@@ -106,4 +112,14 @@ export const useAutopilotStepEvents = (onStep?: (event: AutopilotStepEvent) => v
     });
     return () => off?.();
   }, [api, onStep]);
+};
+
+export const useAutopilotFocusEvents = (onFocus?: (event: AutopilotFocusEvent) => void) => {
+  const api = useAppClient();
+  useEffect(() => {
+    const off = api.autopilot.onFocus((event: unknown) => {
+      onFocus?.(event as AutopilotFocusEvent);
+    });
+    return () => off?.();
+  }, [api, onFocus]);
 };

--- a/apps/tauri/src/renderer/store/session-store/session-store.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.ts
@@ -67,6 +67,9 @@ interface AutopilotSlice {
   editingId: string | null;
   wizardStep: number;
   wizardForm: WizardState | null;
+  // Set by a tray "New jobs" click / deep link to auto-expand & scroll to a
+  // card's found-jobs; the card clears it once handled.
+  focusedId: string | null;
 }
 
 // ─── Defaults ─────────────────────────────────────────────────────────────────
@@ -125,7 +128,7 @@ export const useSessionStore = create<SessionState>((set) => ({
   jobs: { filter: '', sortBy: 'newest' },
   resumes: { tab: 'applied', filter: '' },
   settings: { activeSection: 'general' },
-  autopilot: { creating: false, editingId: null, wizardStep: 0, wizardForm: null },
+  autopilot: { creating: false, editingId: null, wizardStep: 0, wizardForm: null, focusedId: null },
 
   setAIGenerate: (patch) => set((s) => ({ aiGenerate: { ...s.aiGenerate, ...patch } })),
   resetAIGenerate: () => set({ aiGenerate: { ...AI_GENERATE_DEFAULTS } }),

--- a/apps/tauri/src/tauri-client/namespaces/autopilot/autopilot.ts
+++ b/apps/tauri/src/tauri-client/namespaces/autopilot/autopilot.ts
@@ -12,6 +12,10 @@ export interface AutopilotStepEvent {
   detail: string;
 }
 
+export interface AutopilotFocusEvent {
+  autopilotId: string;
+}
+
 export const autopilot = {
   list: () => invoke('autopilot_list'),
   get: ({ autopilotId }: { autopilotId: string }) => invoke('autopilot_get', { autopilotId }),
@@ -24,4 +28,6 @@ export const autopilot = {
   resume: ({ autopilotId }: { autopilotId: string }) => invoke('autopilot_resume', { autopilotId }),
   onStep: (handler: (event: AutopilotStepEvent) => void) =>
     asyncUnsub(() => listen<AutopilotStepEvent>('autopilot.step', (e) => handler(e.payload))),
+  onFocus: (handler: (event: AutopilotFocusEvent) => void) =>
+    asyncUnsub(() => listen<AutopilotFocusEvent>('autopilot.focus', (e) => handler(e.payload))),
 };

--- a/docs/architecture-rules.md
+++ b/docs/architecture-rules.md
@@ -17,7 +17,7 @@ lower layer; a lower layer may never use a higher one). Layer = the first path s
 a module under `src/`.
 
 ```
-L3  Shell / IPC        commands, ipc_contracts, main, updater
+L3  Shell / IPC        commands, ipc_contracts, main, updater, tray, deeplink
 L2  Application        pipeline, cover_letter, autopilot, autopilot_scheduler,
                        autopilot_helpers, recommend
 L1  Domain             scraping, extraction, export, documents, jobs, postings,
@@ -80,7 +80,7 @@ L0  Shared infra       error, observability, db, data_store, net, platform, brow
   `crate::commands::ai_provider` for embeddings/provider routing. All allowlisted with
   `TODO(arch)` (target: inject an emitter port + relocate `ai_provider`).
 
-### L3 — Shell / IPC (`commands`, `ipc_contracts`, `main`, `updater`)
+### L3 — Shell / IPC (`commands`, `ipc_contracts`, `main`, `updater`, `tray`, `deeplink`)
 
 - **Allowed deps:** anything below (L0/L1/L2).
 - **Forbidden deps:** none structurally — but L3 must stay **thin**: command handlers

--- a/packages/shared/src/ipc/contracts/autopilot.ts
+++ b/packages/shared/src/ipc/contracts/autopilot.ts
@@ -19,6 +19,11 @@ export interface AutopilotContract {
   resume(req: { autopilotId: string }): Promise<void>;
 
   onStep(handler: (event: AutopilotStepEvent) => void): () => void;
+
+  /** Fired by the shell (tray "New jobs" click or a validated deep link) to
+   *  focus an autopilot's found-jobs panel. An empty `autopilotId` is a pure
+   *  "refresh the list" signal (e.g. after a tray Pause-All) with no navigation. */
+  onFocus(handler: (event: AutopilotFocusEvent) => void): () => void;
 }
 
 export interface AutopilotStepEvent {
@@ -26,6 +31,10 @@ export interface AutopilotStepEvent {
   autopilotId: string;
   step: string;
   detail: string;
+}
+
+export interface AutopilotFocusEvent {
+  autopilotId: string;
 }
 
 export const AUTOPILOT_CHANNELS = {
@@ -37,4 +46,5 @@ export const AUTOPILOT_CHANNELS = {
   run: 'autopilot:run',
   pause: 'autopilot:pause',
   resume: 'autopilot:resume',
+  focus: 'autopilot:focus',
 } as const;

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -127,6 +127,7 @@ export {
 export {
   AUTOPILOT_CHANNELS,
   type AutopilotContract,
+  type AutopilotFocusEvent,
   type AutopilotStepEvent,
 } from './autopilot.js';
 export { BOARDS_CHANNELS, type BoardsContract } from './boards.js';


### PR DESCRIPTION
## Why

Autopilot is a background discovery agent — but a scheduled run that surfaced new jobs while you were away was **invisible** (no notification was ever sent, the tray was Show/Quit only). This makes the "notify" half real: find → rank → **notify → click → jump to the finds**.

Per owner decision, the **OS-registered `ajh://` scheme is deferred** to a follow-up (it adds `tauri-plugin-deep-link` + platform-specific dev/prod behavior). This PR lands everything else **plus** the argv security guard, so the deep-link follow-up is a thin, pre-hardened add.

## What

**Notifications** — `record_run` now returns the count of newly-surfaced postings (never-seen URLs). After a run, that drives a **permission-gated** OS notification (request once when not granted; skip on deny).

**Tray** (new L3 `tray` module) — dynamic **"New jobs: N"** (click → focus window + emit `autopilot.focus` to that run's autopilot, reset counter) + **"Pause all autopilots"**, alongside Show/Quit.

**Renderer focus flow** — new `autopilot.focus` event (contract + client + mock + service hook) → an app-global hook (`useAutopilotFocusNavigation`, mounted in `__root`) that invalidates the autopilot list and, for a non-empty id, routes to `/autopilot` and auto-expands + scrolls that card's found-jobs. Empty id = pure refresh (used by tray Pause-All so the renderer reflects it).

## Security (tauri-security-reviewer lens)

The single-instance handler previously **ignored argv**. It now validates argv via the new L3 `deeplink` module against a **strict route allowlist** — only `ajh://autopilot/<id>` with a syntactically valid id (`[A-Za-z0-9_-]{1,64}`) navigates. Unknown schemes/actions, path traversal (`ajh://autopilot/../../settings`), query/fragment, separators, and oversized ids are **denied** (navigate nowhere). Unit-tested with injection cases. The OS scheme is not registered yet, so no external URL can reach this path today — the guard lands first by design.

## Tests

- Rust: `deeplink::parse_focus_target` (valid / unknown scheme+action / path-traversal+injection / normal-launch / found-among-args); `record_run` new-count (first run, re-run dedup, none-new, unknown id).
- Arch test + `architecture-rules.md` classify `tray` + `deeplink` as L3.

## Verification

`pnpm typecheck` ✓ · `pnpm lint:strict` ✓ · `pnpm gen:ipc:check` ✓ · 80 shared + 223 renderer vitest ✓ · `cargo clippy -D warnings` ✓ · `cargo test` (763) ✓.

## Follow-ups (tracked)

- OS `ajh://` scheme via `tauri-plugin-deep-link` (scheme config + capabilities) — guard already in place.
- Notification/tray strings are English (matches the existing English-only tray menu); localize later.
- The two interactive HTML arch-viz docs still depict the removed applier subsystem (from #241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)