### PR TITLE
feat: register the ajh:// deep-link scheme through the validated guard

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ajh-tauri"
-version = "0.52.0"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -94,6 +94,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-notification",
@@ -1043,7 +1044,7 @@ dependencies = [
  "tracing",
  "url",
  "which",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -1265,6 +1266,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1784,6 +1805,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2878,6 +2908,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -4925,6 +4961,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6125,6 +6171,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7289,6 +7345,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7689,6 +7766,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -9381,6 +9467,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -48,6 +48,9 @@ tauri-plugin-log = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-notification = "2"
+# `ajh://` deep links → focus a specific autopilot. Every incoming URL/argv is
+# validated against a strict route allowlist before navigation (see `deeplink`).
+tauri-plugin-deep-link = "2"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -142,8 +142,36 @@ fn main() {
         // width/height/center in tauri.conf.json become first-run defaults only.
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_deep_link::init())
         .setup(|app| {
             let handle = app.handle();
+
+            // `ajh://` deep links. The OS routes a cold/click-launched URL here
+            // (macOS via `on_open_url`; Windows/Linux a second instance forwards
+            // it as argv → the single-instance guard above). Every URL is funneled
+            // through the same strict allowlist (`deeplink::parse_focus_target`)
+            // before any navigation — a hostile URL focuses the window and stops.
+            #[cfg(desktop)]
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+                // Register the scheme at runtime (no-op once the installer has;
+                // required for Linux + `pnpm dev`). Best-effort.
+                let _ = app.deep_link().register_all();
+                let dl_handle = handle.clone();
+                app.deep_link().on_open_url(move |event| {
+                    let urls: Vec<String> = event.urls().iter().map(|u| u.to_string()).collect();
+                    if let Some(deeplink::FocusTarget::Autopilot(id)) =
+                        deeplink::parse_focus_target(&urls)
+                    {
+                        if let Some(win) = dl_handle.get_webview_window("main") {
+                            let _ = win.show();
+                            let _ = win.unminimize();
+                            let _ = win.set_focus();
+                        }
+                        tray::emit_focus(&dl_handle, &id);
+                    }
+                });
+            }
 
             // Data dir for all persistent state. Resolved + exported once here so
             // AppHandle-less workers (scrapers/appliers) reach the same path.

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -52,6 +52,11 @@
   },
   "plugins": {
     "dialog": null,
+    "deep-link": {
+      "desktop": {
+        "schemes": ["ajh"]
+      }
+    },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQxQzk4NkM0NEJGQkQ0RjkKUldUNTFQdEx4SWJKUWJNU29HRk9JU3RRL0luZ3pmK1hzVmljajFvWjJicEJ2MEJ3Zzg4Q3hwSmsK",
       "endpoints": [


### PR DESCRIPTION
## Why

Completes the deep-link feature flagged as a follow-up in #242. External `ajh://autopilot/<id>` URLs now open/focus the app and jump to that autopilot's found-jobs. #242 landed the **security guard** first; this PR only registers the OS scheme and routes URLs through that already-validated entry point.

## What

- Add `tauri-plugin-deep-link`; register the `ajh` scheme in `tauri.conf.json` (installer-time registration on Windows/macOS) + `register_all()` at startup (runtime registration for Linux + `pnpm dev`).
- `on_open_url` (macOS + runtime-registered schemes) funnels every incoming URL through the **same** strict allowlist as the single-instance argv path (`deeplink::parse_focus_target`) before any navigation, then focuses the window + emits `autopilot.focus`. Windows/Linux relaunch already routes via the single-instance guard from #242, so both delivery paths share one validated entry point.

## Security

No new capability — deep links are handled entirely in Rust (no JS plugin API), so the IPC surface is unchanged. Only `ajh://autopilot/<id>` with a valid id navigates; everything else is denied (guard + tests from #242). `cargo deny` clean (advisories / licenses / bans / sources).

## Verification

`cargo check` · `cargo clippy -D warnings` · `cargo fmt --check` · `cargo test` (763) · `cargo deny check` — all green. No FE/TS changes.

## Note

This wires **external URL → app**. Clicking the OS *notification* itself is separate (see PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)