### PR TITLE
feat: open the autopilot page when the new-jobs notification is clicked

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-router": "^1.170.8",
     "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-notification": "^2.3.1",
     "clsx": "^2.1.1",
     "i18next": "^26.3.0",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/apps/tauri/src-tauri/capabilities/default.json
+++ b/apps/tauri/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
     "notification:allow-request-permission",
     "notification:allow-check-permissions",
     "notification:allow-is-permission-granted",
-    "notification:allow-permission-state"
+    "notification:allow-permission-state",
+    "notification:allow-register-listener"
   ]
 }

--- a/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.ts
+++ b/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.ts
@@ -4,17 +4,18 @@ import { useNavigate } from '@tanstack/react-router';
 
 import type { AutopilotFocusEvent } from '@ajh/shared';
 
-import { keys, useAutopilotFocusEvents } from '@/services';
+import { keys, useAutopilotFocusEvents, useAutopilotNotificationClick } from '@/services';
 import { useSessionStore } from '@/store/session-store';
 
 /**
- * App-global listener for the shell's `autopilot.focus` event (raised by a tray
- * "New jobs" click or a validated deep link). Always refreshes the autopilot
- * list so tray-side changes (e.g. Pause-All) reflect; when an `autopilotId` is
- * present, it also routes to /autopilot and flags the card to auto-expand its
- * found-jobs. An empty id is a pure refresh signal (no navigation).
+ * App-global listeners for the autopilot "go look at the finds" signals:
+ *  - the shell `autopilot.focus` event (tray "New jobs" click or a validated
+ *    deep link) — refreshes the list and, with an `autopilotId`, routes to
+ *    /autopilot + flags the card to auto-expand (empty id = refresh only);
+ *  - the OS notification click — opens the autopilot page (no specific card,
+ *    since the notification carries no id; the run's card shows a New badge).
  *
- * Mounted once in the root layout so it fires regardless of the current route.
+ * Mounted once in the root layout so they fire regardless of the current route.
  */
 export function useAutopilotFocusNavigation() {
   const navigate = useNavigate();
@@ -32,5 +33,11 @@ export function useAutopilotFocusNavigation() {
     [navigate, qc, setAutopilot]
   );
 
+  const onNotificationClick = useCallback(() => {
+    void qc.invalidateQueries({ queryKey: keys.autopilot.all });
+    void navigate({ to: '/autopilot' });
+  }, [navigate, qc]);
+
   useAutopilotFocusEvents(onFocus);
+  useAutopilotNotificationClick(onNotificationClick);
 }

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -211,6 +211,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       resume: noop,
       onStep: () => () => {},
       onFocus: () => () => {},
+      onNotificationClick: () => () => {},
     },
 
     dialog: {

--- a/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.ts
+++ b/apps/tauri/src/renderer/services/use-autopilot/use-autopilot.ts
@@ -123,3 +123,11 @@ export const useAutopilotFocusEvents = (onFocus?: (event: AutopilotFocusEvent) =
     return () => off?.();
   }, [api, onFocus]);
 };
+
+export const useAutopilotNotificationClick = (onClick?: () => void) => {
+  const api = useAppClient();
+  useEffect(() => {
+    const off = api.autopilot.onNotificationClick(() => onClick?.());
+    return () => off?.();
+  }, [api, onClick]);
+};

--- a/apps/tauri/src/tauri-client/namespaces/autopilot/autopilot.ts
+++ b/apps/tauri/src/tauri-client/namespaces/autopilot/autopilot.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import { onAction } from '@tauri-apps/plugin-notification';
 
 import type { AutopilotCreate, AutopilotUpdate } from '@ajh/shared/schemas';
 
@@ -30,4 +31,11 @@ export const autopilot = {
     asyncUnsub(() => listen<AutopilotStepEvent>('autopilot.step', (e) => handler(e.payload))),
   onFocus: (handler: (event: AutopilotFocusEvent) => void) =>
     asyncUnsub(() => listen<AutopilotFocusEvent>('autopilot.focus', (e) => handler(e.payload))),
+  // Clicking the OS notification (autopilot is the only notification source) →
+  // open the autopilot page. Body-click fires `onAction` on macOS + packaged
+  // Windows; best-effort on Linux. The payload is unused — any click navigates.
+  onNotificationClick: (handler: () => void) =>
+    asyncUnsub(() =>
+      onAction(() => handler()).then((listener) => () => void listener.unregister())
+    ),
 };

--- a/packages/shared/src/ipc/contracts/autopilot.ts
+++ b/packages/shared/src/ipc/contracts/autopilot.ts
@@ -24,6 +24,10 @@ export interface AutopilotContract {
    *  focus an autopilot's found-jobs panel. An empty `autopilotId` is a pure
    *  "refresh the list" signal (e.g. after a tray Pause-All) with no navigation. */
   onFocus(handler: (event: AutopilotFocusEvent) => void): () => void;
+
+  /** Fired when the user clicks the OS "new jobs" notification. Autopilot is the
+   *  only notification source, so any click opens the autopilot page. */
+  onNotificationClick(handler: () => void): () => void;
 }
 
 export interface AutopilotStepEvent {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
+      '@tauri-apps/plugin-notification':
+        specifier: ^2.3.1
+        version: 2.3.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1738,6 +1741,9 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -6109,6 +6115,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Why

The "new jobs" OS notification shipped in #242 was **alert-only** — clicking it didn't take you anywhere. This makes the natural gesture work: **click the notification → open the autopilot page** to act on the finds.

## What

- Add the **`@tauri-apps/plugin-notification`** JS package and route its `onAction` (notification body-click) through the **AppClient adapter** as `autopilot.onNotificationClick` — keeping the renderer off direct plugin APIs (ports-and-adapters rule).
- An app-global listener (folded into the existing `useAutopilotFocusNavigation` hook, mounted in `__root`) invalidates the autopilot list and navigates to `/autopilot` on click. Autopilot is the only notification source today, so any click maps there; the run's card already shows its **New** badge.
- Capability: the **minimal** `notification:allow-register-listener` (the command `onAction` registers behind) — not the broad `notification:default`.

## Platform reality (as discussed)

Body-click → `onAction` is reliable on **macOS** and **packaged Windows**; best-effort on Linux (depends on the notification daemon), and toast activation needs the installer-registered AUMID so it's not testable in `pnpm dev`. The **tray "New jobs: N"** item and the **`ajh://` deep link** (#243) remain the fully-reliable jump paths on every platform.

## Verification

`pnpm typecheck` · `pnpm lint:strict` · 80 shared + 223 renderer vitest — all green. No Rust changes (the notification is already sent Rust-side; this is the click handler). Independent of #243 (no file overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)