### PR TITLE
feat: track autopilot run status and flag interrupted runs

### DIFF
--- a/apps/tauri/src-tauri/src/autopilot/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot/mod.rs
@@ -84,6 +84,22 @@ pub enum AutopilotStatus {
     Archived,
 }
 
+/// Outcome of the most recent run. Distinct from [`AutopilotStatus`] (the
+/// agent's enabled/paused lifecycle): this tracks a single run so the UI can
+/// show a live/failed/interrupted indicator.
+///
+/// `Interrupted` is not set by a run — it's reconciled at startup from a run
+/// left `InProgress` when the app closed or crashed mid-run (see
+/// [`AutopilotStore::mark_interrupted_runs`]).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum RunStatus {
+    InProgress,
+    Completed,
+    Failed,
+    Interrupted,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Autopilot {
@@ -105,6 +121,10 @@ pub struct Autopilot {
     /// Jobs surfaced by the most recent run. Defaulted so older records load.
     #[serde(default)]
     pub found_jobs: Vec<FoundJob>,
+    /// Outcome of the most recent run. `None` until the first run. Drives the
+    /// live/failed/interrupted badge.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_status: Option<RunStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_run_at: Option<u64>,
     pub created_at: u64,
@@ -170,6 +190,7 @@ impl AutopilotStore {
             total_found: 0,
             total_applied: 0,
             found_jobs: Vec::new(),
+            run_status: None,
             last_run_at: None,
             created_at: now,
             updated_at: now,
@@ -234,6 +255,37 @@ impl AutopilotStore {
         self.save(map);
     }
 
+    /// Set the most-recent-run outcome. `InProgress` is set at run start,
+    /// `Failed` on a run error; `record_run` sets `Completed` on success.
+    pub fn set_run_status(&self, id: &str, status: RunStatus) {
+        let mut map = self.load();
+        if let Some(ap) = map.get_mut(id) {
+            ap.run_status = Some(status);
+            ap.updated_at = now_ms();
+        }
+        self.save(map);
+    }
+
+    /// Reconcile runs left mid-flight: any autopilot still marked `InProgress`
+    /// when the app starts was interrupted by a crash or close, so flip it to
+    /// `Interrupted` for an honest badge instead of a stuck "running" state.
+    /// Returns how many were reconciled. Called once at startup.
+    pub fn mark_interrupted_runs(&self) -> usize {
+        let mut map = self.load();
+        let mut count = 0;
+        for ap in map.values_mut() {
+            if ap.run_status == Some(RunStatus::InProgress) {
+                ap.run_status = Some(RunStatus::Interrupted);
+                ap.updated_at = now_ms();
+                count += 1;
+            }
+        }
+        if count > 0 {
+            self.save(map);
+        }
+        count
+    }
+
     /// Persist the outcome of a run: counts, last-run time, and the found-jobs
     /// list **merged** with prior runs by URL — so re-running keeps history
     /// (first-seen + any state) instead of replacing it, and genuinely new
@@ -256,6 +308,7 @@ impl AutopilotStore {
             ap.found_jobs = merge_found_jobs(&ap.found_jobs, found_jobs);
             // `merge_found_jobs` flags only never-before-seen URLs as `is_new`.
             new_count = ap.found_jobs.iter().filter(|j| j.is_new).count() as u32;
+            ap.run_status = Some(RunStatus::Completed);
             ap.last_run_at = Some(now);
             ap.updated_at = now;
         }

--- a/apps/tauri/src-tauri/src/autopilot/test.rs
+++ b/apps/tauri/src-tauri/src/autopilot/test.rs
@@ -123,6 +123,59 @@ fn test_clear_all_removes_every_autopilot() {
 }
 
 #[test]
+fn mark_interrupted_runs_flips_only_in_progress() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+
+    let make = |name: &str| {
+        store.create(serde_json::json!({
+            "name": name,
+            "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+            "filter": { "minMatchScore": 50.0 },
+            "schedule": "manual",
+        }))
+    };
+    let running = make("running");
+    let done = make("done");
+
+    store.set_run_status(&running.id, RunStatus::InProgress);
+    store.set_run_status(&done.id, RunStatus::Completed);
+
+    let reconciled = store.mark_interrupted_runs();
+    assert_eq!(reconciled, 1, "only the in-progress run is reconciled");
+
+    let status = |id: &str| store.get(id).unwrap().run_status;
+    assert_eq!(status(&running.id), Some(RunStatus::Interrupted));
+    assert_eq!(status(&done.id), Some(RunStatus::Completed));
+
+    // Idempotent: a second startup sweep finds nothing to reconcile.
+    assert_eq!(store.mark_interrupted_runs(), 0);
+}
+
+#[test]
+fn record_run_marks_the_run_completed() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+    let ap = store.create(serde_json::json!({
+        "name": "ap",
+        "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+        "filter": { "minMatchScore": 50.0 },
+        "schedule": "manual",
+    }));
+    store.set_run_status(&ap.id, RunStatus::InProgress);
+
+    store.record_run(&ap.id, 3, 0, Vec::new());
+    assert_eq!(
+        store.get(&ap.id).unwrap().run_status,
+        Some(RunStatus::Completed)
+    );
+}
+
+#[test]
 fn test_data_store_export_import_preserves_id() {
     use crate::data_store::DataStore;
     use tempfile::TempDir;

--- a/apps/tauri/src-tauri/src/autopilot_scheduler.rs
+++ b/apps/tauri/src-tauri/src/autopilot_scheduler.rs
@@ -59,6 +59,11 @@ pub fn start(app: AppHandle) {
     let store: Arc<Mutex<AutopilotStore>> =
         app.state::<Arc<Mutex<AutopilotStore>>>().inner().clone();
 
+    // Reconcile any run left mid-flight by a crash/close before the first sweep
+    // could start a new one, so the UI shows an honest "interrupted" badge
+    // rather than a stuck "running" state.
+    store.lock().mark_interrupted_runs();
+
     tauri::async_runtime::spawn(async move {
         // Catch up on autopilots that fell overdue while the app was closed:
         // run one sweep shortly after launch rather than waiting a full tick
@@ -125,6 +130,7 @@ mod test {
             total_found: 0,
             total_applied: 0,
             found_jobs: Vec::new(),
+            run_status: None,
             last_run_at,
             created_at: 0,
             updated_at: 0,

--- a/apps/tauri/src-tauri/src/commands/autopilot.rs
+++ b/apps/tauri/src-tauri/src/commands/autopilot.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use crate::autopilot::{AutopilotFilter, AutopilotStatus, AutopilotStore, FoundJob};
+use crate::autopilot::{AutopilotFilter, AutopilotStatus, AutopilotStore, FoundJob, RunStatus};
 use crate::autopilot_helpers::autopilot_scrape;
 use crate::scraping::{JobPosting, ScraperEngine};
 use serde_json::{json, Value};
@@ -118,6 +118,12 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
         .lock()
         .start(&job_id, "autopilot.run");
 
+    // Mark the run live so the UI shows a "running" badge and a crash mid-run
+    // is later reconciled to "interrupted" (see `mark_interrupted_runs`).
+    store(&app)
+        .lock()
+        .set_run_status(&autopilot_id, RunStatus::InProgress);
+
     let engine = app.state::<Arc<ScraperEngine>>().inner().clone();
     let cancel_token = CancellationToken::new();
     engine.register_token(&job_id, cancel_token.clone()).await;
@@ -141,6 +147,9 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
         Ok(p) => p,
         Err(e) => {
             engine.unregister_token(&job_id).await;
+            store(&app)
+                .lock()
+                .set_run_status(&autopilot_id, RunStatus::Failed);
             app.state::<Mutex<crate::jobs::JobTracker>>()
                 .lock()
                 .fail(&job_id, e.to_string());
@@ -228,6 +237,11 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
     // not overwrites, the slot), so cancels during scrape land here too.
     if cancel_token.is_cancelled() {
         engine.unregister_token(&job_id).await;
+        // User-initiated stop, not a failure or crash — clear the live status so
+        // it isn't later reconciled to "interrupted".
+        store(&app)
+            .lock()
+            .set_run_status(&autopilot_id, RunStatus::Completed);
         app.state::<Mutex<crate::jobs::JobTracker>>()
             .lock()
             .cancel(&job_id);

--- a/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -111,6 +111,22 @@ export function AutopilotCard({
             <span className="text-[10px] text-foreground/30 bg-white/[0.04] px-1.5 py-0.5 rounded capitalize">
               {ap.schedule.replace('_', ' ')}
             </span>
+            {!running && (ap.runStatus === 'failed' || ap.runStatus === 'interrupted') && (
+              <span
+                className={cn(
+                  'shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium',
+                  ap.runStatus === 'failed'
+                    ? 'bg-red-400/15 text-red-300'
+                    : 'bg-amber-400/15 text-amber-300'
+                )}
+              >
+                {t(
+                  ap.runStatus === 'failed'
+                    ? 'autopilot.badge.failed'
+                    : 'autopilot.badge.interrupted'
+                )}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-4 text-[10px] text-foreground/35">
             <span>"{ap.target.query}"</span>

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -595,7 +595,9 @@
     "deleteDescription": "Dies stoppt den Zeitplan und entfernt den Autopilot und seinen Verlauf gefundener Jobs dauerhaft.",
     "badge": {
       "new": "Neu",
-      "applied": "Beworben"
+      "applied": "Beworben",
+      "failed": "Fehlgeschlagen",
+      "interrupted": "Unterbrochen"
     },
     "apply": {
       "jobDescription": "Stellenbeschreibung",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -610,7 +610,9 @@
     "deleteDescription": "This stops its schedule and permanently removes the autopilot and its found-jobs history.",
     "badge": {
       "new": "New",
-      "applied": "Applied"
+      "applied": "Applied",
+      "failed": "Failed",
+      "interrupted": "Interrupted"
     },
     "apply": {
       "jobDescription": "Job description",

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -192,6 +192,10 @@ export type AuthCapableBoard = (typeof AUTH_CAPABLE_BOARDS)[number];
 export type AutopilotStatus = 'active' | 'paused' | 'archived';
 export type AutopilotSchedule = 'manual' | 'hourly' | 'daily' | 'twice_daily';
 
+/** Outcome of an autopilot's most recent run. `interrupted` is reconciled at
+ *  startup from a run left running when the app closed/crashed mid-run. */
+export type AutopilotRunStatus = 'inProgress' | 'completed' | 'failed' | 'interrupted';
+
 /** Autopilot job-discovery agent — persisted entity. Finds & ranks matching
  *  jobs on a schedule and notifies you; you apply with the tailoring assistant. */
 export interface Autopilot {
@@ -221,6 +225,9 @@ export interface Autopilot {
   totalApplied: number;
   /** Jobs surfaced by the most recent run. */
   foundJobs?: AutopilotFoundJob[];
+  /** Outcome of the most recent run — drives the live/failed/interrupted
+   *  badge. Absent until the first run. */
+  runStatus?: AutopilotRunStatus;
   lastRunAt?: number;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
Second slice of the plan's **PR 9 (Autopilot reliability)** — the observable-status half (`9a` was the pure `fix:` core, merged in #245).

## What

Each autopilot now records the outcome of its most recent run — `inProgress | completed | failed | interrupted` — so the UI can show an honest indicator instead of silently looking idle after a failed or cut-off run.

- **Transitions** (`commands/autopilot.rs`): set `inProgress` at run start, `failed` on a scrape error, `completed` on success (`record_run`) or user cancel.
- **Crash reconciliation** (`autopilot_scheduler.rs`): at startup the scheduler flips any run left `inProgress` (the app closed/crashed mid-run) to `interrupted` — synchronously, *before* the first catch-up sweep could start a new run.
- **Badge** (`AutopilotCard`): amber **Interrupted** / red **Failed** chip when the last run didn't finish cleanly; hidden while a run is live (the status dot + step log already cover "running").

## Notes

- The full `Autopilot` record is hand-typed in `@ajh/shared` and returned raw from Rust (no Zod validation on the response), so this adds `runStatus?` to the **type only** — no `gen:ipc` regeneration.
- `runStatus` is optional and serde-`skip_serializing_if`-None, so existing saved autopilots load unchanged (absent = never run).
- en/de copy added (`autopilot.badge.failed` / `.interrupted`).

## Tests

Store reconciliation + transitions: `mark_interrupted_runs` flips only `inProgress` (and is idempotent); `record_run` marks `completed`.

Green locally: clippy `-D warnings` clean, 28 autopilot Rust tests, typecheck + lint:strict clean, 223 renderer + 80 shared vitest.

## Follow-up (last PR 9 slice)

- **9c** (`feat:`) — battery-aware pause + optional launch-at-login (new deps → security review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)