### PR TITLE
ci: also auto-build installers on release, keep the manual button

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,19 +3,19 @@ name: 🚀 Release
 # ──────────────────────────────────────────────────────────────────────
 # Release Pipeline
 # ──────────────────────────────────────────────────────────────────────
-# Purpose: Automated semantic release; cross-platform Tauri builds on demand
+# Purpose: Automated semantic release + cross-platform Tauri installer builds
 # Triggers:
-#   - push to main      → release + sync-version-files (NO installer build)
-#   - workflow_dispatch → build: compile + attach installers for a release
+#   - push to main      → release + sync-version-files, then auto-build installers
+#   - workflow_dispatch → build installers for a chosen tag (on-demand rebuild)
 # Jobs:
 #   - release: Determine version and create GitHub release (push only)
 #   - sync-version-files: Commit tracked version files for the release (push only)
-#   - build: Build Tauri apps for Windows, Linux, and macOS (manual only)
+#   - build: Build Tauri apps for Windows, Linux, and macOS (push release OR manual)
+#   - generate-update-manifest: Publish latest.json for the auto-updater
 #
-# Rationale: a 3-platform Tauri build is ~60 min/runner each, so it no longer
-# runs on every merge. semantic-release still versions + drafts release notes on
-# push; click "Run workflow" in the Actions tab to build + attach the installers
-# (defaults to the latest tag, or pass a version to (re)build a specific one).
+# On a release push the whole chain runs automatically. The same build can also
+# be triggered manually from the Actions tab ("Run workflow") to rebuild a tag —
+# leave the version input blank for the latest tag, or pass one to pick another.
 # ──────────────────────────────────────────────────────────────────────
 
 on:
@@ -184,10 +184,17 @@ jobs:
 
   build:
     name: 🏗️ Build Tauri Apps
-    # Manual only — trigger from the Actions tab ("Run workflow") to build and
-    # attach installers for a release. Runs independently of the push-time
-    # release jobs, so it can (re)build any existing tag on demand.
-    if: github.event_name == 'workflow_dispatch'
+    # Runs in two ways:
+    #   - automatically after a release on push (needs sync-version-files so the
+    #     tag exists before "latest" is resolved), and
+    #   - manually from the Actions tab to (re)build any tag on demand.
+    # `if: always()` lets the manual path run even though sync-version-files is
+    # skipped on workflow_dispatch.
+    needs: sync-version-files
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+       needs.sync-version-files.outputs.released == 'true')
 
     # Exposed so generate-update-manifest targets the same release.
     outputs:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -64,7 +64,7 @@ pnpm tauri build
 
 ## Release Pipeline
 
-Versioning and release notes are **automated** via [semantic-release][semantic-release] on push to `main`. The cross-platform **installer build is a separate manual step** — a 3-platform Tauri build is ~60 min/runner each, so it no longer runs on every merge. Trigger it from the Actions tab when you want to ship binaries (see [CI/CD Pipeline](#cicd-pipeline)).
+Releases are **fully automated** via [semantic-release][semantic-release] on push to `main`: a release commit versions the app, drafts the notes, syncs version files, then builds and attaches the cross-platform installers. The same installer build can **also be run manually** from the Actions tab to rebuild any tag on demand (see [CI/CD Pipeline](#cicd-pipeline)).
 
 ### Commit → Version mapping
 
@@ -108,38 +108,35 @@ When semantic-release creates a new tag, a CI step automatically syncs the versi
 
 ```mermaid
 graph LR
-    subgraph auto["On push to main — automatic"]
-        Push["git push to main"] --> Analysis["semantic-release\nanalyzes commits"]
-        Analysis --> Tag["git tag + GitHub\nrelease notes"]
-        Tag --> Sync["sync version files\n(commit to main)"]
-    end
-    subgraph manual["Manual — Actions ▸ Run workflow"]
-        Dispatch["workflow_dispatch\n(version input, or\nlatest tag if blank)"] --> Build["GitHub Actions\nbuild matrix"]
-        Build --> Windows["Windows\nNSIS + MSI"]
-        Build --> Mac["macOS\nDMG + APP"]
-        Build --> Linux["Linux\nAppImage + DEB"]
-        Windows & Mac & Linux --> Upload["Upload installers\nto the release"]
-        Upload --> UpdateServer["Tauri Updater\nlatest.json published"]
-    end
+    Push["git push to main"] --> Analysis["semantic-release\nanalyzes commits"]
+    Analysis --> Tag["git tag + GitHub\nrelease notes"]
+    Tag --> Sync["sync version files\n(commit to main)"]
+    Sync --> Build["build matrix"]
+    Dispatch["Manual: Actions ▸\nRun workflow\n(version or latest)"] -.-> Build
+    Build --> Windows["Windows\nNSIS + MSI"]
+    Build --> Mac["macOS\nDMG + APP"]
+    Build --> Linux["Linux\nAppImage + DEB"]
+    Windows & Mac & Linux --> Upload["Upload installers\nto the release"]
+    Upload --> UpdateServer["Tauri Updater\nlatest.json published"]
 ```
 
 ### GitHub Actions workflow
 
-`.github/workflows/release.yml` runs in two phases:
+`.github/workflows/release.yml`. A release push runs the whole chain automatically; the build can also be re-run manually.
 
-**On `push` to `main` (automatic)** — `release` + `sync-version-files` jobs:
+**On `push` to `main`** — `release` + `sync-version-files`:
 
 1. semantic-release analyzes commits → creates the `v*` tag + GitHub release notes
 2. CI commits the synced version files back to `main`
 
-**Manual — Actions ▸ "🚀 Release" ▸ "Run workflow" (~60 min/platform)** — `build` + `generate-update-manifest` jobs:
+**`build` + `generate-update-manifest`** — run automatically after a release push, **or** manually via **Actions ▸ "🚀 Release" ▸ "Run workflow"** (~60 min/platform):
 
-1. Resolve the version (the `version` input, or the latest tag when blank), then checkout that tag
+1. Resolve the version (latest tag after a release push; or the `version` input / latest tag on manual dispatch), then checkout that tag
 2. Install pnpm + Node + Rust stable; `pnpm build:packages`
 3. `pnpm tauri build` — compiles Rust + bundles installers for Windows / macOS / Linux
 4. Upload installers to the release, then generate + upload `latest.json` (the auto-updater manifest)
 
-> The heavy 3-platform build is decoupled from merges on purpose — run it from the Actions tab when you actually want to ship installers for a release.
+> Manual dispatch is for **rebuilding an existing tag** (e.g. a runner flaked, or you want to re-attach assets) — it does not create a new release. Leave the version blank for the latest tag, or pass one like `0.62.0`.
 
 ---
 


### PR DESCRIPTION
Follow-up to #247's manual-dispatch build (owner: *"I'd rather **also** have the manual button"*). Restores the **automatic** installer build on a release push while **keeping** the manual trigger.

## Change

`build` (and the `generate-update-manifest` job that follows it) now run on **both** paths:

```yaml
needs: sync-version-files
if: >-
  always() &&
  (github.event_name == 'workflow_dispatch' ||
   needs.sync-version-files.outputs.released == 'true')
```

- **Release push** → `release` → `sync-version-files` → **build** → `generate-update-manifest`, fully automatic (as it was before #247).
- **Manual** (Actions ▸ 🚀 Release ▸ Run workflow) → still builds a chosen tag on demand.

## Why it's correct

- `needs: sync-version-files` makes the **push** path wait until semantic-release has created the tag before the resolve step picks "latest tag".
- `if: always()` lets the **manual** path run even though `sync-version-files` is skipped on `workflow_dispatch` (release is push-only).
- `build` exposes the resolved version as a job output, so `generate-update-manifest` targets the exact same release on either path.
- On a push with **no** release commit, `sync-version-files` is skipped → `build`'s condition is false → build + manifest skip (no wasted runners).

Manual dispatch now means **"rebuild an existing tag"** (a runner flaked, re-attach assets) rather than a separate release path. `docs/DEPLOYMENT.md` updated to match.

YAML validated; job graph confirmed (release/sync push-only; build/manifest = release-push **or** manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)