### PR TITLE
refactor: route every settings tab through the shared section card

### DIFF
--- a/apps/tauri/src/renderer/features/settings/components/accounts/AccountsSettingsTab/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/accounts/AccountsSettingsTab/index.tsx
@@ -1,4 +1,6 @@
-import { ShieldAlert } from 'lucide-react';
+import { Lock, ShieldAlert } from 'lucide-react';
+
+import { SettingsSection } from '@ajh/ui';
 
 import { AUTH_BOARDS } from '@/constants/auth';
 import { useTranslation } from '@/lib/i18n';
@@ -24,9 +26,13 @@ export function AccountsSettingsTab() {
         </div>
       )}
 
-      {AUTH_BOARDS.map((board) => (
-        <BoardSessionRow key={board.id} board={board} />
-      ))}
+      <SettingsSection icon={Lock} label={t('settings.accounts.boardsTitle')}>
+        <div className="space-y-3">
+          {AUTH_BOARDS.map((board) => (
+            <BoardSessionRow key={board.id} board={board} />
+          ))}
+        </div>
+      </SettingsSection>
     </div>
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/ai-settings/CompanyResearchSettings/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/ai-settings/CompanyResearchSettings/index.tsx
@@ -1,7 +1,7 @@
 import { Check, Eye, EyeOff, Key, Loader2, Search, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
-import { Button, GlassCard, IconBadge, Input, SectionLabel, useNotification } from '@ajh/ui';
+import { Button, Input, SettingsSection, useNotification } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import {
@@ -56,12 +56,7 @@ export function CompanyResearchSettings() {
   };
 
   return (
-    <GlassCard>
-      <div className="mb-3 flex items-center gap-2">
-        <IconBadge icon={Search} size="sm" />
-        <SectionLabel>{t('settings.companyResearch.title')}</SectionLabel>
-      </div>
-
+    <SettingsSection icon={Search} label={t('settings.companyResearch.title')}>
       <p className="mb-3 text-xs leading-relaxed text-foreground/50">
         {t('settings.companyResearch.description')}
       </p>
@@ -131,6 +126,6 @@ export function CompanyResearchSettings() {
           </div>
         </div>
       )}
-    </GlassCard>
+    </SettingsSection>
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx
@@ -7,9 +7,7 @@ import {
   cn,
   type ColorScheme,
   getThemePrefs,
-  GlassCard,
-  IconBadge,
-  SectionLabel,
+  SettingsSection,
   type TextScale,
   type ThemePrefs,
 } from '@ajh/ui';
@@ -78,12 +76,7 @@ export function AppearanceCard() {
   };
 
   return (
-    <GlassCard>
-      <div className="mb-4 flex items-center gap-2">
-        <IconBadge icon={Palette} size="sm" />
-        <SectionLabel>{t('settings.appearance.title')}</SectionLabel>
-      </div>
-
+    <SettingsSection icon={Palette} label={t('settings.appearance.title')}>
       <div className="space-y-4">
         <div>
           <div className="mb-2 text-xs font-medium text-foreground/55">
@@ -163,6 +156,6 @@ export function AppearanceCard() {
           onChange={(v) => update({ contrast: v ? 'more' : 'normal' })}
         />
       </div>
-    </GlassCard>
+    </SettingsSection>
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/general-section/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/general-section/index.tsx
@@ -1,6 +1,6 @@
 import { Languages, Power, User, Wand2 } from 'lucide-react';
 
-import { Button, cn, GlassCard, IconBadge, Input, SectionLabel } from '@ajh/ui';
+import { Button, cn, Input, SettingsSection } from '@ajh/ui';
 
 import { AppearanceCard } from '@/features/settings/components/general-section/AppearanceCard';
 import { LanguageSelector } from '@/features/settings/components/shared/LanguageSelector';
@@ -32,11 +32,7 @@ export function GeneralSection({
 
   return (
     <>
-      <GlassCard>
-        <div className="mb-4 flex items-center gap-2">
-          <IconBadge icon={User} size="sm" />
-          <SectionLabel>{t('settings.profile.title')}</SectionLabel>
-        </div>
+      <SettingsSection icon={User} label={t('settings.profile.title')}>
         <div className="space-y-3">
           <label className="block">
             <div className="mb-1.5 text-[11px] font-medium text-foreground/50">
@@ -63,23 +59,15 @@ export function GeneralSection({
             </div>
           </label>
         </div>
-      </GlassCard>
+      </SettingsSection>
 
-      <GlassCard>
-        <div className="mb-4 flex items-center gap-2">
-          <IconBadge icon={Languages} size="sm" />
-          <SectionLabel>{t('settings.language.title')}</SectionLabel>
-        </div>
+      <SettingsSection icon={Languages} label={t('settings.language.title')}>
         <LanguageSelector />
-      </GlassCard>
+      </SettingsSection>
 
       <AppearanceCard />
 
-      <GlassCard>
-        <div className="mb-4 flex items-center gap-2">
-          <IconBadge icon={Wand2} size="sm" />
-          <SectionLabel>{t('settings.onboarding.title')}</SectionLabel>
-        </div>
+      <SettingsSection icon={Wand2} label={t('settings.onboarding.title')}>
         <div className="flex items-center justify-between">
           <p className="text-xs text-foreground/45">{t('settings.onboarding.description')}</p>
           <Button
@@ -92,13 +80,9 @@ export function GeneralSection({
             {t('settings.onboarding.replay')}
           </Button>
         </div>
-      </GlassCard>
+      </SettingsSection>
 
-      <GlassCard>
-        <div className="mb-4 flex items-center gap-2">
-          <IconBadge icon={Power} size="sm" />
-          <SectionLabel>{t('settings.startup.title')}</SectionLabel>
-        </div>
+      <SettingsSection icon={Power} label={t('settings.startup.title')}>
         <Button
           variant="unstyled"
           type="button"
@@ -140,7 +124,7 @@ export function GeneralSection({
             />
           </div>
         </Button>
-      </GlassCard>
+      </SettingsSection>
 
       <UpdateSection />
     </>

--- a/apps/tauri/src/renderer/features/settings/components/privacy/PrivacySettingsTab/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/privacy/PrivacySettingsTab/index.tsx
@@ -1,7 +1,7 @@
-import { Download, LogOut, RotateCcw, Trash2, Upload } from 'lucide-react';
+import { Download, LogOut, RotateCcw, Shield, Trash2, Upload } from 'lucide-react';
 import { useState } from 'react';
 
-import { ConfirmModal, useNotification } from '@ajh/ui';
+import { ConfirmModal, SettingsSection, useNotification } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import {
@@ -193,9 +193,13 @@ export function PrivacySettingsTab() {
 
   return (
     <div className="space-y-3">
-      {cards.map(({ key, ...card }) => (
-        <ActionCard key={key} {...card} />
-      ))}
+      <SettingsSection icon={Shield} label={t('settings.privacy.dataTitle')}>
+        <div className="space-y-3">
+          {cards.map(({ key, ...card }) => (
+            <ActionCard key={key} {...card} />
+          ))}
+        </div>
+      </SettingsSection>
 
       {/* ── Danger Zone ─────────────────────────────────────────────── */}
       <div className="mt-2 rounded-xl border border-rose-700/40 bg-rose-950/20 p-3">

--- a/apps/tauri/src/renderer/features/settings/components/update-section/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/update-section/index.tsx
@@ -9,15 +9,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 
-import {
-  Button,
-  cn,
-  GlassCard,
-  IconBadge,
-  MarkdownMessage,
-  RefreshButton,
-  SectionLabel,
-} from '@ajh/ui';
+import { Button, cn, MarkdownMessage, RefreshButton, SettingsSection } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { useAppVersion, useOpenExternal } from '@/services';
@@ -55,12 +47,7 @@ export function UpdateSection() {
     'https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases/latest';
 
   return (
-    <GlassCard>
-      <div className="mb-4 flex items-center gap-2">
-        <IconBadge icon={Sparkles} size="sm" />
-        <SectionLabel>{t('settings.update.title')}</SectionLabel>
-      </div>
-
+    <SettingsSection icon={Sparkles} label={t('settings.update.title')}>
       <div className="flex items-center justify-between">
         <div>
           <p className="text-xs text-foreground/50">{t('settings.update.currentVersion')}</p>
@@ -225,6 +212,6 @@ export function UpdateSection() {
           </div>
         )}
       </div>
-    </GlassCard>
+    </SettingsSection>
   );
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -355,10 +355,12 @@
       "saveError": "Schlüssel konnte nicht gespeichert werden."
     },
     "accounts": {
+      "boardsTitle": "Jobbörsen-Konten",
       "credentialsWarning": "Anmeldedaten werden lokal verschlüsselt auf Ihrem Gerät gespeichert. Sie werden niemals an einen Server gesendet.",
       "noEncryptionWarning": "Sichere Speicherung von Anmeldedaten ist auf diesem System nicht verfügbar. Anmeldedaten können nicht gespeichert werden."
     },
     "privacy": {
+      "dataTitle": "Ihre Daten",
       "exportData": "Daten exportieren",
       "exportDataDescription": "Speichern Sie Ihre beworbenen, angesehenen und gespeicherten Jobs in einer JSON-Datei.",
       "export": "Exportieren",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -370,10 +370,12 @@
       "saveError": "Couldn't save the key."
     },
     "accounts": {
+      "boardsTitle": "Job board accounts",
       "credentialsWarning": "Credentials are stored locally and encrypted on your device. They are never sent to any server.",
       "noEncryptionWarning": "Secure credential storage is not available on this system. Credentials cannot be saved."
     },
     "privacy": {
+      "dataTitle": "Your data",
       "exportData": "Export Data",
       "exportDataDescription": "Save your applied, viewed, and bookmarked jobs to a JSON file.",
       "export": "Export",


### PR DESCRIPTION
PR 10 slice 2 — the settings-consistency sweep (slice 1 = #249, merged).

## What

The settings card header (`GlassCard > IconBadge + SectionLabel > body`) was hand-rolled in many places. Route them all through the existing `@ajh/ui` `SettingsSection` primitive so the header lives in one spot — **and give the two bare tabs (Accounts, Privacy) the same titled-card treatment** they were missing:

- **general**: Profile, Language, Onboarding, Startup cards
- **AppearanceCard**, **UpdateSection**, **CompanyResearchSettings**
- **Accounts**: wrap the job-board rows in a titled `SettingsSection` (Lock · "Job board accounts")
- **Privacy**: wrap the data/session action cards in a titled `SettingsSection` (Shield · "Your data"); the **Danger Zone keeps its own distinct red container**

## Visual impact

Near-zero — `SettingsSection` emits the identical markup the cards already used, so the only changes are: one header's spacing normalised (`mb-3`→`mb-4`), and Accounts/Privacy gaining a consistent section header. `ActionCard`/`BoardSessionRow` are light item-rows, so the wrapping reads as "titled section with items," not nested cards.

## Scope notes

- The icon-less preference cards (Performance/Developer/Output-tone/etc.) still use a bare `SectionLabel` — adopting `SettingsSection` there needs an icon chosen per card, a separate pass.
- +2 i18n keys (en/de): `settings.accounts.boardsTitle`, `settings.privacy.dataTitle`.

Green: typecheck + lint:strict clean, 225 renderer vitest. FE-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)