### PR TITLE
ci: build installers only on manual dispatch, not on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,19 +3,20 @@ name: 🚀 Release
 # ──────────────────────────────────────────────────────────────────────
 # Release Pipeline
 # ──────────────────────────────────────────────────────────────────────
-# Purpose: Automated semantic release + cross-platform Tauri installer builds
+# Purpose: Automated semantic release (on push) + on-demand Tauri installer builds
 # Triggers:
-#   - push to main      → release + sync-version-files, then auto-build installers
-#   - workflow_dispatch → build installers for a chosen tag (on-demand rebuild)
+#   - push to main      → create the GitHub release + sync version files (NO build)
+#   - workflow_dispatch → build installers for a chosen tag (the only build path)
 # Jobs:
 #   - release: Determine version and create GitHub release (push only)
 #   - sync-version-files: Commit tracked version files for the release (push only)
-#   - build: Build Tauri apps for Windows, Linux, and macOS (push release OR manual)
+#   - build: Build Tauri apps for Windows, Linux, and macOS (manual / dispatch only)
 #   - generate-update-manifest: Publish latest.json for the auto-updater
 #
-# On a release push the whole chain runs automatically. The same build can also
-# be triggered manually from the Actions tab ("Run workflow") to rebuild a tag —
-# leave the version input blank for the latest tag, or pass one to pick another.
+# Merging to main publishes the release + version bump but does NOT build
+# installers — those cross-platform compiles are slow, so they're decoupled from
+# the every-merge release flow. Build installers on demand from the Actions tab
+# ("Run workflow") — leave the version input blank for the latest tag, or pass one.
 # ──────────────────────────────────────────────────────────────────────
 
 on:
@@ -184,17 +185,12 @@ jobs:
 
   build:
     name: 🏗️ Build Tauri Apps
-    # Runs in two ways:
-    #   - automatically after a release on push (needs sync-version-files so the
-    #     tag exists before "latest" is resolved), and
-    #   - manually from the Actions tab to (re)build any tag on demand.
-    # `if: always()` lets the manual path run even though sync-version-files is
-    # skipped on workflow_dispatch.
-    needs: sync-version-files
-    if: >-
-      always() &&
-      (github.event_name == 'workflow_dispatch' ||
-       needs.sync-version-files.outputs.released == 'true')
+    # Manual-only: installers are built on demand from the Actions tab
+    # ("Run workflow"), never automatically on a release push — the cross-platform
+    # compiles are slow, so they're decoupled from the every-merge release flow.
+    # The build self-syncs version files and checks out the resolved tag, so it
+    # needs nothing from the push-only release / sync-version-files jobs.
+    if: github.event_name == 'workflow_dispatch'
 
     # Exposed so generate-update-manifest targets the same release.
     outputs:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -64,7 +64,7 @@ pnpm tauri build
 
 ## Release Pipeline
 
-Releases are **fully automated** via [semantic-release][semantic-release] on push to `main`: a release commit versions the app, drafts the notes, syncs version files, then builds and attaches the cross-platform installers. The same installer build can **also be run manually** from the Actions tab to rebuild any tag on demand (see [CI/CD Pipeline](#cicd-pipeline)).
+Releases are **automated** via [semantic-release][semantic-release] on push to `main`: a release commit versions the app, drafts the notes, and syncs version files. Building the cross-platform **installers is a separate, manual step** — the compiles are slow, so they're decoupled from the every-merge release flow. Run **Actions ▸ "🚀 Release" ▸ "Run workflow"** when you want installers for a tag (see [CI/CD Pipeline](#cicd-pipeline)).
 
 ### Commit → Version mapping
 
@@ -111,8 +111,7 @@ graph LR
     Push["git push to main"] --> Analysis["semantic-release\nanalyzes commits"]
     Analysis --> Tag["git tag + GitHub\nrelease notes"]
     Tag --> Sync["sync version files\n(commit to main)"]
-    Sync --> Build["build matrix"]
-    Dispatch["Manual: Actions ▸\nRun workflow\n(version or latest)"] -.-> Build
+    Dispatch["Manual: Actions ▸\nRun workflow\n(version or latest)"] --> Build["build matrix"]
     Build --> Windows["Windows\nNSIS + MSI"]
     Build --> Mac["macOS\nDMG + APP"]
     Build --> Linux["Linux\nAppImage + DEB"]
@@ -122,16 +121,16 @@ graph LR
 
 ### GitHub Actions workflow
 
-`.github/workflows/release.yml`. A release push runs the whole chain automatically; the build can also be re-run manually.
+`.github/workflows/release.yml`. A release push publishes the release + version bump; installers are built only via the manual **Run workflow** dispatch.
 
 **On `push` to `main`** — `release` + `sync-version-files`:
 
 1. semantic-release analyzes commits → creates the `v*` tag + GitHub release notes
 2. CI commits the synced version files back to `main`
 
-**`build` + `generate-update-manifest`** — run automatically after a release push, **or** manually via **Actions ▸ "🚀 Release" ▸ "Run workflow"** (~60 min/platform):
+**`build` + `generate-update-manifest`** — run **only** via **Actions ▸ "🚀 Release" ▸ "Run workflow"** (~60 min/platform):
 
-1. Resolve the version (latest tag after a release push; or the `version` input / latest tag on manual dispatch), then checkout that tag
+1. Resolve the version (the `version` input, or the latest tag if left blank), then checkout that tag
 2. Install pnpm + Node + Rust stable; `pnpm build:packages`
 3. `pnpm tauri build` — compiles Rust + bundles installers for Windows / macOS / Linux
 4. Upload installers to the release, then generate + upload `latest.json` (the auto-updater manifest)


### PR DESCRIPTION
## Why

Since #248 the installer build auto-fired on **every** release push — a ~20-min cross-platform Tauri build after almost every `feat:`/`fix:` merge. During rapid PR cadence that's mostly unwanted, and the build job's `cargo` step doesn't respond to the normal "Cancel run" (it has to be **force-cancelled** each time).

## Change

- **`build` job → `if: github.event_name == 'workflow_dispatch'`** (was `always() && (workflow_dispatch || released == 'true')`). Dropped its `needs: sync-version-files` — the build already self-syncs version files and checks out the resolved tag, so it depends on nothing from the push-only jobs.
- **Push path unchanged and still ordered:** `release` (create GitHub release + tag) → `sync-version-files` (commit the version bump). Only the slow installer build is decoupled.
- Installers are built **on demand** from **Actions ▸ "🚀 Release" ▸ "Run workflow"** (blank version = latest tag; or pass one).
- `generate-update-manifest` (`needs: build`) naturally only runs with a manual build.

Reverts the auto-build half of #248; keeps the manual button from #247. Docs (`DEPLOYMENT.md` prose + mermaid) updated to match.

## Job graph after this change

| job | runs when |
|-----|-----------|
| `release` | push to main |
| `sync-version-files` | after `release`, if a release was published |
| `build` | **manual dispatch only** |
| `generate-update-manifest` | after `build` (so manual only) |

`ci:` → no version bump. This PR's own merge won't auto-build (the merged workflow is already manual-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)