### PR TITLE
feat: reframe the résumés page as documents with three lenses

### DIFF
--- a/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
@@ -43,9 +43,9 @@ const NAV_SECTIONS: { labelKey: string; items: readonly NavItem[] }[] = [
       { to: ROUTES.JOBS, label: 'nav.jobs', icon: Briefcase, tourId: 'jobs' },
       { to: ROUTES.ANALYZE, label: 'nav.analyze', icon: Gauge, tourId: 'analyze' },
       { to: ROUTES.GENERATE, label: 'nav.generate', icon: Wand2, tourId: 'generate' },
-      // tourId 'documents' matches the onboarding tour (the visible label is
-      // relabelled "Documents" in the IA pass; the route stays /resumes).
-      { to: ROUTES.RESUMES, label: 'nav.resumes', icon: FileText, tourId: 'documents' },
+      // Labelled "Documents" (résumés + cover letters + activity); the route
+      // stays /resumes and the tour anchor is 'documents'.
+      { to: ROUTES.RESUMES, label: 'nav.documents', icon: FileText, tourId: 'documents' },
     ],
   },
   {

--- a/apps/tauri/src/renderer/features/resumes/components/InteractionRow/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/InteractionRow/index.tsx
@@ -1,33 +1,10 @@
-import { Building2, Clock, ExternalLink, MapPin } from 'lucide-react';
+import { Building2, Clock, ExternalLink, MapPin, Tag } from 'lucide-react';
 
 import { Button, cn, GlassCard } from '@ajh/ui';
 
+import { type Interaction, INTERACTION_TYPES } from '@/features/resumes/constants';
 import { useTranslation } from '@/lib/i18n';
 import { useOpenExternal } from '@/services/use-system';
-
-interface Interaction {
-  jobId: string;
-  interactionType: string;
-  timestamp: number;
-  title: string;
-  company: string;
-  url: string;
-  source: string;
-  location: string;
-}
-
-interface TabConfig {
-  id: string;
-  labelKey: string;
-  icon: React.ElementType;
-  color: string;
-  ringColor: string;
-}
-
-interface InteractionRowProps {
-  row: Interaction;
-  tabCfg: TabConfig;
-}
 
 function formatRelative(ts: number, t: ReturnType<typeof useTranslation>['t']): string {
   const diff = Date.now() - ts;
@@ -41,10 +18,20 @@ function formatRelative(ts: number, t: ReturnType<typeof useTranslation>['t']): 
   return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
-export function InteractionRow({ row, tabCfg }: InteractionRowProps) {
+interface InteractionRowProps {
+  row: Interaction;
+}
+
+export function InteractionRow({ row }: InteractionRowProps) {
   const { t } = useTranslation();
   const openExternal = useOpenExternal();
-  const Icon = tabCfg.icon;
+
+  // Self-describing: the Activity feed mixes applied / viewed / bookmarked in one
+  // list, so each row's badge reflects its own interaction type. Unknown types
+  // (forward-compat) fall back to a neutral badge showing the raw type string.
+  const cfg = INTERACTION_TYPES[row.interactionType];
+  const Icon = cfg?.icon ?? Tag;
+  const label = cfg ? t(cfg.labelKey) : row.interactionType;
 
   return (
     <GlassCard
@@ -61,11 +48,11 @@ export function InteractionRow({ row, tabCfg }: InteractionRowProps) {
           <span
             className={cn(
               'flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] uppercase tracking-wider',
-              tabCfg.ringColor,
-              tabCfg.color
+              cfg?.ringColor ?? 'border-white/10 bg-white/5',
+              cfg?.color ?? 'text-foreground/50'
             )}
           >
-            <Icon size={8} /> {t(tabCfg.labelKey)}
+            <Icon size={8} /> {label}
           </span>
         </div>
         <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-foreground/50">

--- a/apps/tauri/src/renderer/features/resumes/components/ResumesPage/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/ResumesPage/index.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, Search, Wand2 } from 'lucide-react';
+import { Activity, Mail, RefreshCw, Search, Wand2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useMemo } from 'react';
 
@@ -8,7 +8,7 @@ import { PageHeader } from '@/components/layout/PageHeader';
 import { PageTransition } from '@/components/layout/PageTransition';
 import { GenerationCard } from '@/features/resumes/components/GenerationCard';
 import { InteractionRow } from '@/features/resumes/components/InteractionRow';
-import { type Interaction, type Tab, TAB_CONFIG } from '@/features/resumes/constants';
+import { DOC_TABS, type DocTab, type Interaction } from '@/features/resumes/constants';
 import { useTranslation } from '@/lib/i18n';
 import { useAiGenerations } from '@/services/use-ai-generations';
 import { useInteractions } from '@/services/use-postings';
@@ -18,39 +18,50 @@ function ResumesPage() {
   const { t } = useTranslation();
   const { resumes, setResumes } = useSessionStore();
   const { tab, filter } = resumes;
-  const setTab = (v: Tab) => setResumes({ tab: v });
+  const setTab = (v: DocTab) => setResumes({ tab: v });
   const setFilter = (v: string) => setResumes({ filter: v });
 
-  const isGeneratedTab = tab === 'generated';
+  const isActivity = tab === 'activity';
 
-  const { data: rows = [], isLoading, refetch } = useInteractions(isGeneratedTab ? 'applied' : tab);
-
+  // Activity = the full interaction log (all types, recent first). Résumés and
+  // Cover Letters are lenses over the same generations list.
+  const { data: interactions = [], isLoading, refetch } = useInteractions();
   const { data: generations = [] } = useAiGenerations();
 
-  const filtered = useMemo(() => {
-    const q = filter.trim().toLowerCase();
-    return q
-      ? (rows as Interaction[]).filter(
-          (r) => r.title.toLowerCase().includes(q) || r.company.toLowerCase().includes(q)
-        )
-      : rows;
-  }, [rows, filter]);
+  const q = filter.trim().toLowerCase();
 
-  const filteredGenerations = useMemo(() => {
-    const q = filter.trim().toLowerCase();
+  const counts: Record<DocTab, number> = useMemo(
+    () => ({
+      resumes: generations.filter((g) => g.resumeText.trim()).length,
+      coverLetters: generations.filter((g) => g.coverLetterText.trim()).length,
+      activity: interactions.length,
+    }),
+    [generations, interactions]
+  );
+
+  const generationDocs = useMemo(() => {
+    const base =
+      tab === 'coverLetters'
+        ? generations.filter((g) => g.coverLetterText.trim())
+        : generations.filter((g) => g.resumeText.trim());
     return q
-      ? generations.filter(
+      ? base.filter(
           (g) =>
             g.jobTitle.toLowerCase().includes(q) ||
             g.companyName.toLowerCase().includes(q) ||
             g.candidateName.toLowerCase().includes(q)
         )
-      : generations;
-  }, [generations, filter]);
+      : base;
+  }, [generations, tab, q]);
 
-  const tabCfg = TAB_CONFIG.find((c) => c.id === tab) as (typeof TAB_CONFIG)[number];
-
-  const tabCount = isGeneratedTab ? generations.length : rows.length;
+  const activityRows = useMemo(() => {
+    const sorted = [...(interactions as Interaction[])].sort((a, b) => b.timestamp - a.timestamp);
+    return q
+      ? sorted.filter(
+          (r) => r.title.toLowerCase().includes(q) || r.company.toLowerCase().includes(q)
+        )
+      : sorted;
+  }, [interactions, q]);
 
   return (
     <PageTransition className="flex h-full flex-col overflow-hidden">
@@ -58,7 +69,6 @@ function ResumesPage() {
         <PageHeader
           title={t('resumes.title')}
           subtitle={t('resumes.subtitle')}
-          badge={t('resumes.badge')}
           actions={
             <div className="flex items-center gap-2">
               <div className="flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-1.5 transition-colors focus-within:border-brand/35">
@@ -71,8 +81,13 @@ function ResumesPage() {
                   variant="default"
                 />
               </div>
-              {!isGeneratedTab && (
-                <Button size="sm" variant="ghost" onClick={() => void refetch()} title="Refresh">
+              {isActivity && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => void refetch()}
+                  title={t('resumes.open')}
+                >
                   <RefreshCw size={12} className={isLoading ? 'animate-spin' : ''} />
                 </Button>
               )}
@@ -82,7 +97,7 @@ function ResumesPage() {
 
         {/* Tabs */}
         <div className="mb-5 flex items-center gap-1">
-          {TAB_CONFIG.map(({ id, labelKey, icon: Icon, color }) => (
+          {DOC_TABS.map(({ id, labelKey, icon: Icon, color }) => (
             <Button
               key={id}
               onClick={() => {
@@ -98,72 +113,83 @@ function ResumesPage() {
             >
               <Icon size={12} className={tab === id ? color : ''} />
               {t(labelKey)}
-              {tab === id && tabCount > 0 && (
+              {counts[id] > 0 && (
                 <span className="rounded-full bg-white/10 px-1.5 py-0.5 text-[10px] text-foreground/60">
-                  {tabCount}
+                  {counts[id]}
                 </span>
               )}
             </Button>
           ))}
         </div>
 
-        {/* Generated tab content */}
-        {isGeneratedTab ? (
-          filteredGenerations.length === 0 ? (
+        {/* Activity tab — the job-interaction log */}
+        {isActivity ? (
+          isLoading ? (
+            <div className="space-y-2">
+              <CardSkeleton /> <CardSkeleton /> <CardSkeleton />
+            </div>
+          ) : activityRows.length === 0 ? (
             <EmptyState
-              icon={Wand2}
-              title={t('resumes.generated.noGenerationsYet')}
-              description={t('resumes.generated.noGenerationsDesc')}
+              icon={Activity}
+              title={filter ? t('resumes.noResults') : t('resumes.activity.empty')}
+              description={!filter ? t('resumes.activity.emptyDesc') : undefined}
             />
           ) : (
             <motion.div
-              className="flex flex-col gap-3"
+              className="flex flex-col gap-2"
               variants={stagger.container}
               initial="hidden"
               animate="show"
             >
               <AnimatePresence initial={false}>
-                {filteredGenerations.map((gen) => (
+                {activityRows.map((row) => (
                   <motion.div
-                    key={gen.id}
+                    key={`${row.jobId}-${row.interactionType}`}
                     variants={stagger.item}
                     transition={transition.normal}
                     exit={{ opacity: 0, y: -6 }}
                   >
-                    <GenerationCard gen={gen} />
+                    <InteractionRow row={row} />
                   </motion.div>
                 ))}
               </AnimatePresence>
             </motion.div>
           )
-        ) : isLoading ? (
-          <div className="space-y-2">
-            <CardSkeleton /> <CardSkeleton /> <CardSkeleton />
-          </div>
-        ) : filtered.length === 0 ? (
+        ) : /* Résumés / Cover Letters — lenses over the generations list */
+        generationDocs.length === 0 ? (
           <EmptyState
-            icon={tabCfg.icon}
+            icon={tab === 'coverLetters' ? Mail : Wand2}
             title={
-              filter ? t('resumes.noResults') : t('resumes.noJobsYet', { tab: t(tabCfg.labelKey) })
+              filter
+                ? t('resumes.noResults')
+                : tab === 'coverLetters'
+                  ? t('resumes.coverLettersEmpty')
+                  : t('resumes.generated.noGenerationsYet')
             }
-            description={!filter ? t('resumes.jobsWillAppear') : undefined}
+            description={
+              filter
+                ? undefined
+                : tab === 'coverLetters'
+                  ? t('resumes.coverLettersEmptyDesc')
+                  : t('resumes.generated.noGenerationsDesc')
+            }
           />
         ) : (
           <motion.div
-            className="flex flex-col gap-2"
+            className="flex flex-col gap-3"
             variants={stagger.container}
             initial="hidden"
             animate="show"
           >
             <AnimatePresence initial={false}>
-              {filtered.map((row) => (
+              {generationDocs.map((gen) => (
                 <motion.div
-                  key={`${row.jobId}-${row.interactionType}`}
+                  key={gen.id}
                   variants={stagger.item}
                   transition={transition.normal}
                   exit={{ opacity: 0, y: -6 }}
                 >
-                  <InteractionRow row={row} tabCfg={tabCfg} />
+                  <GenerationCard gen={gen} />
                 </motion.div>
               ))}
             </AnimatePresence>

--- a/apps/tauri/src/renderer/features/resumes/constants.ts
+++ b/apps/tauri/src/renderer/features/resumes/constants.ts
@@ -1,4 +1,4 @@
-import { Bookmark, Eye, Send, Wand2 } from 'lucide-react';
+import { Activity, Bookmark, Eye, FileText, type LucideIcon, Mail, Send } from 'lucide-react';
 
 export interface Interaction {
   jobId: string;
@@ -11,35 +11,47 @@ export interface Interaction {
   location: string;
 }
 
-export type Tab = 'applied' | 'viewed' | 'bookmarked' | 'generated';
+/**
+ * The three Documents lenses. Résumés + Cover Letters are lenses over the same
+ * `AiGenerationRecord` set — each record bundles a résumé and an optional cover
+ * letter — while Activity is the job-interaction log.
+ */
+export type DocTab = 'resumes' | 'coverLetters' | 'activity';
 
-export const TAB_CONFIG = [
-  {
-    id: 'applied' as Tab,
-    labelKey: 'resumes.tabs.applied',
+export const DOC_TABS: { id: DocTab; labelKey: string; icon: LucideIcon; color: string }[] = [
+  { id: 'resumes', labelKey: 'resumes.tabs.resumes', icon: FileText, color: 'text-brand-soft' },
+  { id: 'coverLetters', labelKey: 'resumes.tabs.coverLetters', icon: Mail, color: 'text-blue-300' },
+  { id: 'activity', labelKey: 'resumes.tabs.activity', icon: Activity, color: 'text-emerald-300' },
+];
+
+/**
+ * Per-interaction-type badge config — lets each InteractionRow describe its own
+ * type in the mixed Activity feed (rather than inheriting one active-tab style).
+ */
+export interface InteractionTypeConfig {
+  labelKey: string;
+  icon: LucideIcon;
+  color: string;
+  ringColor: string;
+}
+
+export const INTERACTION_TYPES: Record<string, InteractionTypeConfig> = {
+  applied: {
+    labelKey: 'resumes.activity.applied',
     icon: Send,
     color: 'text-purple-300',
     ringColor: 'border-purple-400/30 bg-purple-400/10',
   },
-  {
-    id: 'viewed' as Tab,
-    labelKey: 'resumes.tabs.viewed',
+  viewed: {
+    labelKey: 'resumes.activity.viewed',
     icon: Eye,
     color: 'text-blue-300',
     ringColor: 'border-blue-400/30 bg-blue-400/10',
   },
-  {
-    id: 'bookmarked' as Tab,
-    labelKey: 'resumes.tabs.bookmarked',
+  bookmarked: {
+    labelKey: 'resumes.activity.bookmarked',
     icon: Bookmark,
     color: 'text-amber-300',
     ringColor: 'border-amber-400/30 bg-amber-400/10',
   },
-  {
-    id: 'generated' as Tab,
-    labelKey: 'resumes.tabs.generated',
-    icon: Wand2,
-    color: 'text-brand-soft',
-    ringColor: 'border-brand/30 bg-brand/10',
-  },
-] as const;
+};

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -881,15 +881,23 @@
     "modeGuestNote": "Begrenzte Ergebnisse · nur 24h / Woche / Monat"
   },
   "resumes": {
-    "title": "Lebensläufe",
-    "subtitle": "Verfolgen Sie Ihre beworbenen, angesehenen und gespeicherten Jobs über alle Boards hinweg.",
-    "badge": "Interaktionen",
+    "title": "Dokumente",
+    "subtitle": "Deine maßgeschneiderten Lebensläufe und Anschreiben sowie deine Job-Aktivität über alle Boards hinweg.",
+    "badge": "Dokumente",
     "tabs": {
+      "resumes": "Lebensläufe",
+      "coverLetters": "Anschreiben",
+      "activity": "Aktivität"
+    },
+    "activity": {
       "applied": "Beworben",
       "viewed": "Angesehen",
       "bookmarked": "Gespeichert",
-      "generated": "Generiert"
+      "empty": "Noch keine Aktivität",
+      "emptyDesc": "Jobs, die du ansiehst, speicherst oder auf die du dich bewirbst, erscheinen hier."
     },
+    "coverLettersEmpty": "Noch keine Anschreiben",
+    "coverLettersEmptyDesc": "Generiere ein maßgeschneidertes Anschreiben, um es hier zu sehen.",
     "generated": {
       "noGenerationsYet": "Noch keine KI-generierten Dokumente",
       "noGenerationsDesc": "Generiere einen angepassten Lebenslauf oder ein Anschreiben, um es hier zu sehen.",
@@ -926,8 +934,6 @@
     },
     "filterPlaceholder": "Nach Titel oder Unternehmen suchen...",
     "noResults": "Keine Ergebnisse gefunden",
-    "noJobsYet": "Noch keine {{tab}} Jobs",
-    "jobsWillAppear": "Jobs erscheinen hier, wenn Sie mit Job-Anzeigen interagieren.",
     "unknownPosition": "Unbekannte Position",
     "open": "Öffnen"
   },

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -896,15 +896,23 @@
     "modeGuestNote": "Limited results · 24h / week / month filters only"
   },
   "resumes": {
-    "title": "Resumes",
-    "subtitle": "Track your applied, viewed, and bookmarked jobs across all boards.",
-    "badge": "Interactions",
+    "title": "Documents",
+    "subtitle": "Your tailored résumés and cover letters, plus your job activity across every board.",
+    "badge": "Documents",
     "tabs": {
+      "resumes": "Résumés",
+      "coverLetters": "Cover Letters",
+      "activity": "Activity"
+    },
+    "activity": {
       "applied": "Applied",
       "viewed": "Viewed",
       "bookmarked": "Bookmarked",
-      "generated": "Generated"
+      "empty": "No activity yet",
+      "emptyDesc": "Jobs you view, bookmark, or apply to will appear here."
     },
+    "coverLettersEmpty": "No cover letters yet",
+    "coverLettersEmptyDesc": "Generate a tailored cover letter to see it here.",
     "generated": {
       "noGenerationsYet": "No AI-generated documents yet",
       "noGenerationsDesc": "Generate a tailored resume or cover letter to see it here.",
@@ -941,8 +949,6 @@
     },
     "filterPlaceholder": "Search by title or company...",
     "noResults": "No results found",
-    "noJobsYet": "No {{tab}} jobs yet",
-    "jobsWillAppear": "Jobs will appear here as you interact with job listings.",
     "unknownPosition": "Unknown position",
     "open": "Open"
   },

--- a/apps/tauri/src/renderer/store/session-store/session-store.test.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.test.ts
@@ -31,8 +31,8 @@ describe('useSessionStore', () => {
     useSessionStore.getState().setJobs({ filter: 'react', sortBy: 'company' });
     expect(useSessionStore.getState().jobs).toEqual({ filter: 'react', sortBy: 'company' });
 
-    useSessionStore.getState().setResumes({ tab: 'generated' });
-    expect(useSessionStore.getState().resumes.tab).toBe('generated');
+    useSessionStore.getState().setResumes({ tab: 'activity' });
+    expect(useSessionStore.getState().resumes.tab).toBe('activity');
 
     useSessionStore.getState().setSettings({ activeSection: 'ai' });
     expect(useSessionStore.getState().settings.activeSection).toBe('ai');

--- a/apps/tauri/src/renderer/store/session-store/session-store.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.ts
@@ -39,7 +39,7 @@ interface JobsSlice {
   sortBy: 'newest' | 'oldest' | 'company';
 }
 
-type ResumesTab = 'applied' | 'viewed' | 'bookmarked' | 'generated';
+type ResumesTab = 'resumes' | 'coverLetters' | 'activity';
 
 interface ResumesSlice {
   tab: ResumesTab;
@@ -126,7 +126,7 @@ export const useSessionStore = create<SessionState>((set) => ({
   aiGenerate: { ...AI_GENERATE_DEFAULTS },
   analyze: { ...ANALYZE_DEFAULTS },
   jobs: { filter: '', sortBy: 'newest' },
-  resumes: { tab: 'applied', filter: '' },
+  resumes: { tab: 'resumes', filter: '' },
   settings: { activeSection: 'general' },
   autopilot: { creating: false, editingId: null, wizardStep: 0, wizardForm: null, focusedId: null },
 


### PR DESCRIPTION
## What

Second slice of **PR 11** (the **Documents IA** half; sidebar regroup was #252). The Résumés page becomes **Documents** with three tabs:

| Tab | Source |
|-----|--------|
| **Résumés** | generations that produced a résumé |
| **Cover Letters** | generations that produced a cover letter |
| **Activity** | the job-interaction log (applied + viewed + bookmarked), one feed, recent first |

**Data-model finding that shaped this:** an `AiGenerationRecord` isn't a résumé *or* a cover letter — each record bundles a `resumeText` **and** an optional `coverLetterText` (plus the targeted job). So Résumés and Cover Letters are **lenses over the same generations list**, not a record-type split (a record with both appears in both). The shared `GenerationCard` already renders + exports whichever it has, so no card change.

**Activity** is fetched in one call — `useInteractions()` with no type filter returns all interactions (`InteractionStore::list(None)`), sorted recent-first. `InteractionRow` now derives its badge from each row's **own** `interactionType` (applied/viewed/bookmarked, with a neutral fallback for unknown types) instead of inheriting one active-tab style, since Activity mixes types in one list.

## Scope kept tight

- **`/resumes` route unchanged** — only the UI label flips, so no deep links break. The sidebar entry now reads **Documents** (`nav.documents`, which already existed in both locales), completing the rename deferred from #252.
- Per-tab counts on every tab; per-tab empty states (Activity / Résumés / Cover Letters).
- Delete is already gated by `ConfirmModal` on `GenerationCard` (PR 4a) — no change needed.
- i18n: repurposed the `resumes.*` block (kept the namespace + `features/resumes/` folder to avoid churn in the card/row internals); en/de in parity. `session-store` tab type/default updated (`resumes` default).

## Verify

- typecheck 0 · lint:strict 0 · affected vitest **14/14** (session-store, use-postings, resumes/GenerationCard, constants). No `@ajh/ui` change.

This **completes PR 11.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)