### PR TITLE
perf: pause background raf when hidden, budget aurora layers, ref-based parallax

### DIFF
--- a/apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx
+++ b/apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx
@@ -16,13 +16,18 @@ import { usePerformanceMode } from '@/store/preferences-store';
  *   7. Film grain
  *   8. Radial vignette
  *
- * Cursor blob uses a JavaScript lerp loop (not CSS transition) for organic
- * smoothness: each RAF tick the blob moves 8% closer to the real cursor.
- * Transform is applied directly to the DOM node — zero React re-renders.
+ * Performance:
+ *   - Cursor blob uses a JavaScript lerp loop (not CSS transition) for organic
+ *     smoothness; the transform is applied directly to the DOM node — zero React
+ *     re-renders. The loop is paused while the tab/window is hidden.
+ *   - Parallax orbs read `--parallax-x/y` written by {@link useMouseParallax} on
+ *     the container ref — also zero re-renders (no state on pointer move).
+ *   - `low-memory` renders nothing; `balanced` renders a reduced layer budget;
+ *     `performance` adds the extra depth layers.
  */
 export function CinematicBackground() {
   const mode = usePerformanceMode();
-  const { x, y } = useMouseParallax();
+  const bgRef = useMouseParallax<HTMLDivElement>();
 
   // ── Lerp cursor blob ──────────────────────────────────────────────────────
   const blobRef = useRef<HTMLDivElement>(null);
@@ -58,11 +63,20 @@ export function CinematicBackground() {
       rafRef.current = requestAnimationFrame(tick);
     };
 
+    // Pause the loop while hidden (background tab / minimized window) so we don't
+    // burn frames animating something nobody can see; resume on return.
+    const onVisibility = () => {
+      cancelAnimationFrame(rafRef.current);
+      if (!document.hidden) rafRef.current = requestAnimationFrame(tick);
+    };
+
     window.addEventListener('pointermove', onMove, { passive: true });
-    rafRef.current = requestAnimationFrame(tick);
+    document.addEventListener('visibilitychange', onVisibility);
+    if (!document.hidden) rafRef.current = requestAnimationFrame(tick);
 
     return () => {
       window.removeEventListener('pointermove', onMove);
+      document.removeEventListener('visibilitychange', onVisibility);
       cancelAnimationFrame(rafRef.current);
     };
   }, [mode]); // re-run if mode changes so RAF is cleaned up correctly
@@ -71,12 +85,12 @@ export function CinematicBackground() {
   // Body is already #07060f in low-memory mode; skip all GPU layers.
   if (mode === 'low-memory') return null;
 
-  const orbA = { transform: `translate3d(${x * 30}px, ${y * 20}px, 0)` };
-  const orbB = { transform: `translate3d(${x * -25}px, ${y * 15}px, 0)` };
-  const orbC = { transform: `translate3d(${x * 15}px, ${y * -10}px, 0)` };
+  // Extra depth layers only on the high-end budget; balanced trims them to cut
+  // the number of large blurred/composited layers on the default mode.
+  const full = mode === 'performance';
 
   return (
-    <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+    <div ref={bgRef} className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
       {/* Aurora ribbons */}
       <div
         className="absolute -top-1/4 left-0 h-[60vh] w-[60vw] rounded-full opacity-40 animate-aurora-1"
@@ -99,13 +113,15 @@ export function CinematicBackground() {
           willChange: 'transform',
         }}
       />
-      <div
-        className="absolute top-1/2 left-0 h-[45vh] w-[45vw] rounded-full opacity-25 animate-aurora-4"
-        style={{
-          background: 'radial-gradient(closest-side, var(--aurora-cyan) 0%, transparent 70%)',
-          willChange: 'transform',
-        }}
-      />
+      {full && (
+        <div
+          className="absolute top-1/2 left-0 h-[45vh] w-[45vw] rounded-full opacity-25 animate-aurora-4"
+          style={{
+            background: 'radial-gradient(closest-side, var(--aurora-cyan) 0%, transparent 70%)',
+            willChange: 'transform',
+          }}
+        />
+      )}
 
       {/* Nebulae */}
       <div
@@ -115,19 +131,25 @@ export function CinematicBackground() {
           willChange: 'transform',
         }}
       />
-      <div
-        className="absolute top-[60vh] left-0 h-[25vh] w-[25vw] rounded-full opacity-35 animate-nebula-2"
-        style={{
-          background: 'radial-gradient(closest-side, var(--nebula-indigo) 0%, transparent 70%)',
-          willChange: 'transform',
-        }}
-      />
+      {full && (
+        <div
+          className="absolute top-[60vh] left-0 h-[25vh] w-[25vw] rounded-full opacity-35 animate-nebula-2"
+          style={{
+            background: 'radial-gradient(closest-side, var(--nebula-indigo) 0%, transparent 70%)',
+            willChange: 'transform',
+          }}
+        />
+      )}
 
       {/* Soft streaks */}
       <div className="light-streak absolute top-[20%] left-1/4 h-px w-[40vw] bg-white/10 animate-streak-1" />
       <div className="light-streak absolute top-[55%] left-1/3 h-px w-[35vw] bg-white/10 animate-streak-2" />
-      <div className="light-streak absolute top-[75%] left-1/4 h-px w-[30vw] bg-white/5  animate-streak-3" />
-      <div className="light-streak absolute top-[35%] left-1/2 h-px w-[25vw] bg-white/5  animate-streak-4" />
+      {full && (
+        <>
+          <div className="light-streak absolute top-[75%] left-1/4 h-px w-[30vw] bg-white/5  animate-streak-3" />
+          <div className="light-streak absolute top-[35%] left-1/2 h-px w-[25vw] bg-white/5  animate-streak-4" />
+        </>
+      )}
 
       {/* Cursor blob — 900px lerp-smoothed glow.
           Position is updated every RAF tick via ref mutation (no React renders).
@@ -152,11 +174,13 @@ export function CinematicBackground() {
         }}
       />
 
-      {/* Floating glow orbs with mouse parallax */}
+      {/* Floating glow orbs — parallax driven by the container's --parallax-x/y
+          CSS vars (written on pointer move via the ref, no React re-renders). */}
       <div
         className="glow-orb absolute top-[15%] right-[10%] h-40 w-40 rounded-full transition-transform duration-75"
         style={{
-          ...orbA,
+          transform:
+            'translate3d(calc(var(--parallax-x, 0) * 30px), calc(var(--parallax-y, 0) * 20px), 0)',
           background:
             'radial-gradient(circle, rgba(168,85,247,0.35) 0%, rgba(168,85,247,0.12) 50%, transparent 75%)',
           filter: 'blur(12px)',
@@ -165,21 +189,25 @@ export function CinematicBackground() {
       <div
         className="glow-orb absolute bottom-[12%] left-[8%] h-32 w-32 rounded-full transition-transform duration-75"
         style={{
-          ...orbB,
+          transform:
+            'translate3d(calc(var(--parallax-x, 0) * -25px), calc(var(--parallax-y, 0) * 15px), 0)',
           background:
             'radial-gradient(circle, rgba(99,102,241,0.35) 0%, rgba(99,102,241,0.12) 50%, transparent 75%)',
           filter: 'blur(10px)',
         }}
       />
-      <div
-        className="glow-orb absolute top-[40%] left-[55%] h-24 w-24 rounded-full transition-transform duration-75"
-        style={{
-          ...orbC,
-          background:
-            'radial-gradient(circle, rgba(168,85,247,0.2) 0%, rgba(99,102,241,0.08) 50%, transparent 75%)',
-          filter: 'blur(8px)',
-        }}
-      />
+      {full && (
+        <div
+          className="glow-orb absolute top-[40%] left-[55%] h-24 w-24 rounded-full transition-transform duration-75"
+          style={{
+            transform:
+              'translate3d(calc(var(--parallax-x, 0) * 15px), calc(var(--parallax-y, 0) * -10px), 0)',
+            background:
+              'radial-gradient(circle, rgba(168,85,247,0.2) 0%, rgba(99,102,241,0.08) 50%, transparent 75%)',
+            filter: 'blur(8px)',
+          }}
+        />
+      )}
 
       {/* Grid + grain + vignette */}
       <div className="absolute inset-0 bg-grid-texture" />

--- a/apps/tauri/src/renderer/hooks/use-mouse-parallax/use-mouse-parallax.test.ts
+++ b/apps/tauri/src/renderer/hooks/use-mouse-parallax/use-mouse-parallax.test.ts
@@ -1,25 +1,26 @@
+import { createElement } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import { useMouseParallax } from './use-mouse-parallax';
+
+// Attaches the ref to a real DOM node so the hook can write CSS vars to it.
+function Probe() {
+  const ref = useMouseParallax<HTMLDivElement>();
+  return createElement('div', { ref, 'data-testid': 'bg' });
+}
 
 describe('useMouseParallax', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('starts centred with 50%/50% CSS vars', () => {
-    const { result } = renderHook(() => useMouseParallax());
-    expect(result.current.x).toBe(0);
-    expect(result.current.y).toBe(0);
-    expect(result.current.mouseVars).toEqual({ '--mx': '50%', '--my': '50%' });
-  });
-
-  it('updates normalized position on pointer movement', async () => {
+  it('writes normalized pointer offset to CSS vars on the ref element', () => {
     // rAF runs the update; run it synchronously for the test.
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
       cb(0);
       return 1;
     });
-    const { result } = renderHook(() => useMouseParallax());
+    const { getByTestId } = render(createElement(Probe));
+    const el = getByTestId('bg');
 
     act(() => {
       window.innerWidth = 1000;
@@ -29,15 +30,13 @@ describe('useMouseParallax', () => {
       window.dispatchEvent(new MouseEvent('pointermove', { clientX: 1000, clientY: 0 }));
     });
 
-    await waitFor(() => {
-      expect(result.current.x).toBeCloseTo(1);
-      expect(result.current.y).toBeCloseTo(-1);
-    });
+    expect(el.style.getPropertyValue('--parallax-x')).toBe('1.0000');
+    expect(el.style.getPropertyValue('--parallax-y')).toBe('-1.0000');
   });
 
   it('cleans up the listener on unmount', () => {
     const remove = vi.spyOn(window, 'removeEventListener');
-    const { unmount } = renderHook(() => useMouseParallax());
+    const { unmount } = render(createElement(Probe));
     unmount();
     expect(remove).toHaveBeenCalledWith('pointermove', expect.any(Function));
   });

--- a/apps/tauri/src/renderer/hooks/use-mouse-parallax/use-mouse-parallax.ts
+++ b/apps/tauri/src/renderer/hooks/use-mouse-parallax/use-mouse-parallax.ts
@@ -1,22 +1,21 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 /**
- * Tracks pointer position as normalized [-1..1] values relative to viewport center.
- * Returns x, y values and a CSS-var binder for `--mx` / `--my` percentages.
+ * Ref-based mouse parallax. Attach the returned ref to a container element; on
+ * pointer movement the hook writes the normalized pointer offset (each axis in
+ * `[-1..1]`, relative to viewport centre) to the CSS custom properties
+ * `--parallax-x` / `--parallax-y` on that element — directly, via RAF-throttled
+ * DOM mutation, with **no React state and no re-renders**.
  *
- * Use cases:
- *  - `transform: translate3d(calc(x * 30px), calc(y * 20px), 0)` for parallax orbs
- *  - `<div style={mouseVars}>` to drive `.bg-mouse-reactive`
+ * Children consume the vars in CSS, e.g.:
+ *   `transform: translate3d(calc(var(--parallax-x) * 30px), calc(var(--parallax-y) * 20px), 0)`
  */
-export function useMouseParallax(): {
-  x: number;
-  y: number;
-  mouseVars: { '--mx': string; '--my': string };
-} {
-  const [pos, setPos] = useState({ x: 0, y: 0 });
+export function useMouseParallax<T extends HTMLElement = HTMLDivElement>() {
+  const ref = useRef<T>(null);
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
+    const el = ref.current;
+    if (!el || typeof window === 'undefined') return;
 
     let frame = 0;
     const onMove = (e: PointerEvent) => {
@@ -24,10 +23,12 @@ export function useMouseParallax(): {
       frame = requestAnimationFrame(() => {
         const x = (e.clientX / window.innerWidth) * 2 - 1;
         const y = (e.clientY / window.innerHeight) * 2 - 1;
-        setPos({ x, y });
+        el.style.setProperty('--parallax-x', x.toFixed(4));
+        el.style.setProperty('--parallax-y', y.toFixed(4));
         frame = 0;
       });
     };
+
     window.addEventListener('pointermove', onMove, { passive: true });
     return () => {
       window.removeEventListener('pointermove', onMove);
@@ -35,10 +36,5 @@ export function useMouseParallax(): {
     };
   }, []);
 
-  const mouseVars = {
-    '--mx': `${((pos.x + 1) / 2) * 100}%`,
-    '--my': `${((pos.y + 1) / 2) * 100}%`,
-  };
-
-  return { x: pos.x, y: pos.y, mouseVars };
+  return ref;
 }


### PR DESCRIPTION
## What

First slice of **PR 12** (perf pass) — the always-on `CinematicBackground` is the most continuously-active subtree, so three cuts there:

1. **Pause RAF while hidden.** The cursor-blob `requestAnimationFrame` lerp loop now stops on `visibilitychange` (background tab / minimized window) and resumes on return — no frames spent animating something nobody sees.
2. **Aurora-layer budget per performance mode.** `balanced` (the default) now drops the extra depth layers — the 4th aurora, 2nd nebula, two light streaks, and the 3rd parallax orb; only `performance` renders the full set. Fewer large blurred/composited layers on the common path. `low-memory` still renders nothing.
3. **Ref-based parallax (zero re-renders).** `useMouseParallax` no longer holds React state — it writes `--parallax-x` / `--parallax-y` CSS vars to a container ref on pointer move (RAF-throttled), and the orbs read them via `calc()` transforms. Previously every (throttled) pointer move called `setState`, re-rendering the entire `CinematicBackground` subtree; now it's pure DOM mutation.

`useMouseParallax` is consumed only by `CinematicBackground`, so the hook's API change is contained; its test is rewritten for the ref-based contract.

## Verify

- typecheck 0 · lint:strict 0 · parallax hook test 2/2. No `@ajh/ui` change, no new deps.

## Next (PR 12 remaining)

- **12b** — modal: drop the `[data-modal-open] .app-content { filter: blur }` whole-subtree blur (expensive full-subtree repaint), relying on `GlassOverlay`'s cheap fixed-overlay `backdrop-blur`.
- **12c** — virtualize the Jobs list (`@tanstack/react-virtual`, new dep) + drop per-row `backdrop-filter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)