### PR TITLE
perf: drop modal subtree-blur and virtualize the jobs list

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -22,6 +22,7 @@
     "@ajh/ui": "workspace:*",
     "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-router": "^1.170.8",
+    "@tanstack/react-virtual": "^3.14.2",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-notification": "^2.3.1",
     "clsx": "^2.1.1",

--- a/apps/tauri/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -1,17 +1,9 @@
 import { Plus, Search, Trash2 } from 'lucide-react';
-import { motion } from 'motion/react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
 import type { DATE_FILTER_OPTIONS } from '@ajh/shared';
-import {
-  Button,
-  EmptyState,
-  GlassCard,
-  Input,
-  SelectDropdown,
-  staggeredItem,
-  useNotification,
-} from '@ajh/ui';
+import { Button, EmptyState, GlassCard, Input, SelectDropdown, useNotification } from '@ajh/ui';
 
 import { PageHeader } from '@/components/layout/PageHeader';
 import { PageTransition } from '@/components/layout/PageTransition';
@@ -139,9 +131,22 @@ export function JobsPage() {
     return result;
   }, [allPostings, filter, sortBy]);
 
+  // Windowed list: only the visible rows (plus a small overscan) are mounted, so
+  // a long postings list doesn't paint hundreds of glass rows at once. Keyed by
+  // posting id so measurement survives live-prepended rows during a scrape.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: filtered.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 88,
+    overscan: 6,
+    getItemKey: (index) => filtered[index]?.id ?? index,
+  });
+
   return (
-    <PageTransition className="flex h-full overflow-hidden">
-      <div className="flex-1 overflow-y-auto px-10 py-10">
+    <PageTransition className="flex h-full flex-col overflow-hidden">
+      {/* Pinned header + scrape form; the list below owns the scroll. */}
+      <div className="px-10 pt-10">
         <PageHeader
           title={t('jobs.title')}
           subtitle={t('jobs.subtitle')}
@@ -211,7 +216,9 @@ export function JobsPage() {
           onDisconnect={handleInlineDisconnect}
           onGeocode={(q) => api.geocode.suggest(q)}
         />
+      </div>
 
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-10 pb-10">
         {filtered.length === 0 ? (
           <GlassCard tone="graphite" highlight>
             <EmptyState
@@ -226,17 +233,31 @@ export function JobsPage() {
             />
           </GlassCard>
         ) : (
-          <div className="flex flex-col gap-2">
-            {filtered.map((p, i) => (
-              <motion.div
-                key={p.id}
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={staggeredItem(i)}
-              >
-                <PostingRow posting={p} formatRelativeTime={formatRelativeTime} />
-              </motion.div>
-            ))}
+          <div style={{ height: virtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
+            {virtualizer.getVirtualItems().map((vi) => {
+              const posting = filtered[vi.index];
+              if (!posting) return null;
+              return (
+                <div
+                  key={vi.key}
+                  data-index={vi.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${vi.start}px)`,
+                  }}
+                >
+                  {/* pb-2 reproduces the old gap-2 between rows (included in the
+                      measured height so virtual offsets stay correct). */}
+                  <div className="pb-2">
+                    <PostingRow posting={posting} formatRelativeTime={formatRelativeTime} />
+                  </div>
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/apps/tauri/src/renderer/features/jobs/components/PostingRow/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/PostingRow/index.tsx
@@ -8,11 +8,10 @@ import {
   MapPin,
   Wand2,
 } from 'lucide-react';
-import { motion } from 'motion/react';
 import { useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 
-import { Button, SourceBadge, transition, useNotification } from '@ajh/ui';
+import { Button, SourceBadge, useNotification } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 import { useOpenExternal, usePersistJob } from '@/services';
@@ -98,13 +97,13 @@ export function PostingRow({ posting, formatRelativeTime }: PostingRowProps) {
   };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={transition.normal}
-      className="relative group"
-    >
-      <div className="glass-graphite glass-highlight relative flex items-center gap-5 rounded-xl p-4 pl-5 transition-all duration-300 hover:bg-white/[0.03] hover:shadow-lg hover:shadow-brand/5 overflow-hidden">
+    // No entry animation: rows are windowed (mount/unmount on scroll), so a
+    // per-mount fade would re-fire every time a row scrolls into view.
+    <div className="relative group">
+      {/* `no-backdrop-filter` drops glass-graphite's per-row backdrop blur —
+          compositing a blur for every row is the dominant paint cost on a long
+          list, and the gradient is opaque enough to read fine without it. */}
+      <div className="glass-graphite glass-highlight no-backdrop-filter relative flex items-center gap-5 rounded-xl p-4 pl-5 transition-all duration-300 hover:bg-white/[0.03] hover:shadow-lg hover:shadow-brand/5 overflow-hidden">
         {/* Subtle ambient glow for whole card */}
         <div
           className="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-out"
@@ -187,6 +186,6 @@ export function PostingRow({ posting, formatRelativeTime }: PostingRowProps) {
           </Button>
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/apps/tauri/src/renderer/styles/globals.css
+++ b/apps/tauri/src/renderer/styles/globals.css
@@ -44,18 +44,20 @@ html[data-color-scheme='light'][data-performance-mode='low-memory'] body {
   background: #e4e7ef;
 }
 
-/* ── Modal background blur ───────────────────────────────────────────────── */
-/* When any ModalShell is open, blur the entire app content layer.
-   ModalShell sets data-modal-open on document.body; we blur .app-content. */
-body[data-modal-open] .app-content {
-  filter: blur(6px) brightness(0.7);
-  transition: filter 200ms ease;
-  pointer-events: none;
+/* Opt an element out of inherited backdrop-filter. Used on long virtualized
+   lists (Jobs) where compositing a backdrop blur per row is the dominant paint
+   cost; the glass surface is opaque enough to read fine without it. */
+.no-backdrop-filter {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
 }
 
-.app-content {
-  transition: filter 200ms ease;
-}
+/* ── Modal background blur ───────────────────────────────────────────────── */
+/* The blur + dim behind a modal comes from GlassOverlay's fixed-overlay
+   `backdrop-blur` + `bg-black/40` — which only composites the region behind the
+   overlay rect. We intentionally do NOT `filter: blur` the whole .app-content
+   subtree: that forces a full-subtree re-rasterization every frame of the
+   transition (and while open), which is far more expensive than the overlay. */
 
 /* ── Onboarding glass modal ─────────────────────────────────────────────────── */
 .onboarding-glass-modal {

--- a/packages/ui/src/components/ModalShell/ModalShell.tsx
+++ b/packages/ui/src/components/ModalShell/ModalShell.tsx
@@ -50,20 +50,9 @@ export function ModalShell({
     return () => window.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
-  // Blur the app content behind the modal by toggling a body attribute.
-  // CSS in globals.css targets [data-modal-open] .app-content to apply filter:blur().
-  useEffect(() => {
-    if (!open) return;
-    const prev = document.body.dataset.modalDepth;
-    const depth = (parseInt(prev ?? '0', 10) || 0) + 1;
-    document.body.dataset.modalDepth = String(depth);
-    document.body.setAttribute('data-modal-open', '');
-    return () => {
-      const next = (parseInt(document.body.dataset.modalDepth ?? '1', 10) || 1) - 1;
-      document.body.dataset.modalDepth = String(next);
-      if (next <= 0) document.body.removeAttribute('data-modal-open');
-    };
-  }, [open]);
+  // The blur + dim behind the modal comes from GlassOverlay (fixed-overlay
+  // backdrop-blur), which only composites the area behind it — far cheaper than
+  // filtering the whole app subtree, so we no longer toggle a body attribute.
 
   return createPortal(
     <AnimatePresence>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.170.8
         version: 1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.2
+        version: 3.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
@@ -1619,6 +1622,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.14.2':
+    resolution: {integrity: sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.171.6':
     resolution: {integrity: sha512-Ol6DQ+j6rf/rPVELIzo8LHwOQV2KL+zry3b+39kL/GKrt7YId52WJRAFMzuseY4XceSW+PU7sG/Cc1QkwJr0hg==}
     engines: {node: '>=20.19'}
@@ -1658,6 +1667,9 @@ packages:
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/virtual-core@3.17.0':
+    resolution: {integrity: sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==}
 
   '@tanstack/virtual-file-routes@1.162.0':
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
@@ -5997,6 +6009,12 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
 
+  '@tanstack/react-virtual@3.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   '@tanstack/router-core@1.171.6':
     dependencies:
       '@tanstack/history': 1.162.0
@@ -6064,6 +6082,8 @@ snapshots:
       - webpack
 
   '@tanstack/store@0.9.3': {}
+
+  '@tanstack/virtual-core@3.17.0': {}
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 


### PR DESCRIPTION
## What

PR 12 slices **b + c** on one branch (per request). Both are paint-cost cuts.

### 12b — modal: stop blurring the whole app subtree
Opening a modal previously set `data-modal-open` on `<body>` and globals.css applied `filter: blur(6px) brightness(0.7)` to the **entire `.app-content` subtree** — a full-subtree re-rasterization every frame of the open/close transition (and while open). The blur + dim already come from `GlassOverlay`'s fixed-overlay `backdrop-blur` + `bg-black/40`, which only composites the region **behind the overlay rect**. Removed the CSS rule and `ModalShell`'s body-attribute effect; the visual is effectively unchanged (the overlay's `backdrop-blur-md` is actually a stronger blur than the old 6px).

### 12c — Jobs list: windowing + no per-row blur
- **Windowed** with `@tanstack/react-virtual` — the list is now its **own scroll container** (header + scrape form pinned above it), so only the visible rows + a small overscan mount instead of every posting. Keyed by **posting id** (`getItemKey`) so row measurement survives the live-prepended rows during a scrape, and dynamic-measured (`measureElement`) for variable row heights.
- **Dropped the per-row `backdrop-filter`** — `glass-graphite` composited a backdrop blur for *every* row (the dominant paint cost on a long list). Added a `.no-backdrop-filter` opt-out in the app's globals.css; the row gradient is opaque enough to read fine without it.
- **Dropped `PostingRow`'s per-mount entry animation** — with windowing it would re-fire every time a row scrolls into view.

## Notes for review
- **New dependency:** `@tanstack/react-virtual@^3.14.2` (same org as the already-used `@tanstack/react-query`) — security-secondary glance per the dep-manifest rule. JS-only, so `cargo deny` n/a.
- **UX change:** the Jobs header + scrape form are now pinned (the list scrolls beneath them) — the standard, reliable layout for a windowed list. I can't run the Tauri app in this environment, so scroll smoothness / row-height correctness should be eyeballed on merge.

## Verify
- `@ajh/ui` build OK · typecheck 0 · lint:strict 0 · `@ajh/ui` vitest 140/140 · renderer vitest **224/224** · pre-push hook green.

This **completes PR 12.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)