### PR TITLE
ci: verify + auto-sync the homebrew cask, restore max-optimized release profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ name: 🚀 Release
 #   - sync-version-files: Commit tracked version files for the release (push only)
 #   - build: Build Tauri apps for Windows, Linux, and macOS (manual / dispatch only)
 #   - generate-update-manifest: Publish latest.json for the auto-updater
+#   - update-cask: Pin the Homebrew cask to the built dmgs (version + per-arch sha256)
 #
 # Merging to main publishes the release + version bump but does NOT build
 # installers — those cross-platform compiles are slow, so they're decoupled from
@@ -595,3 +596,61 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-cask:
+    name: 🍺 Update Homebrew Cask
+    # Pins the cask to the just-built dmgs (version + per-arch sha256). Runs after
+    # the build because that's the only point the dmgs — and their hashes — exist;
+    # deliberately NOT in sync-version-files, which runs on every release push
+    # before any build (so there'd be nothing to hash, and bumping the version
+    # there would point the cask at dmgs that never ship). Reads each asset's
+    # sha256 digest straight from the GitHub API (no download) and commits the
+    # refreshed cask back to main. Skipped on the push path (build is manual).
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: 📥 Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 1
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: 🍺 Sync cask to the built dmgs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "::group::Reading dmg sha256 digests for v$VERSION"
+          arm="$(gh release view "v$VERSION" --json assets \
+            -q '.assets[] | select(.name | endswith("aarch64-apple-silicon.dmg")) | .digest' | sed 's/^sha256://')"
+          intel="$(gh release view "v$VERSION" --json assets \
+            -q '.assets[] | select(.name | endswith("x64-intel.dmg")) | .digest' | sed 's/^sha256://')"
+          if [ -z "$arm" ] || [ -z "$intel" ]; then
+            echo "::warning::dmg digests not found for v$VERSION — skipping cask update"
+            exit 0
+          fi
+          node scripts/sync-cask.cjs "$VERSION" "$arm" "$intel"
+          echo "::endgroup::"
+
+      - name: 📤 Commit cask
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- Casks/ai-job-hunter.rb; then
+            echo "Cask already up to date."
+            exit 0
+          fi
+          git add Casks/ai-job-hunter.rb
+          git commit -m "chore: sync homebrew cask to v${VERSION} [skip ci]"
+          git push git@github.com:saeedkolivand/ai-job-hunter-assistant-app.git HEAD:main

--- a/Casks/ai-job-hunter.rb
+++ b/Casks/ai-job-hunter.rb
@@ -6,15 +6,17 @@
 #   brew install --cask ai-job-hunter
 #
 # Maintenance:
-#   • Keep `version` in sync with the latest GitHub release tag — CI can run
-#     `brew bump-cask-pr`. The dmg assets are named
-#     "AI-Job-Hunter-Assistant_<version>_<arch>.dmg".
-#   • `sha256 :no_check` skips hash verification; pin per-arch shas for a
-#     verified install once they are published with the release.
+#   • `version` tracks the latest release that ships macOS .dmg artifacts (the
+#     installer build is manual, so not every release has them). The dmg assets
+#     are named "AI-Job-Hunter-Assistant_<version>_<arch>.dmg".
+#   • When a new build publishes dmgs, bump `version` and refresh both per-arch
+#     `sha256` values — `brew bump-cask-pr` does this, or read the assets'
+#     sha256 digests from `gh release view v<version> --json assets`.
 
 cask "ai-job-hunter" do
-  version "0.52.0"
-  sha256 :no_check # TODO: pin per-arch .dmg sha256 for verified installs
+  version "0.62.1"
+  sha256 arm:   "f530340469542496203149241fc9bc56ba90d9a51cfc201a62a1f81e063c8294",
+         intel: "72e258a33f6e5eba563ff26eb660a3d6db58e848fab82b6b95c9f217ac75a37b"
 
   arch arm: "aarch64-apple-silicon", intel: "x64-intel"
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ brew install --cask ai-job-hunter
 
 The cask clears the Gatekeeper quarantine flag for you (the app isn't notarized). Prefer a one-off download? Grab the `.dmg` straight from the [Releases](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/releases) page.
 
-> The cask currently uses `sha256 :no_check` (no checksum verification). Pin per-arch checksums for a verified install.
+> The cask pins per-arch `sha256` checksums for a verified install, tracking the latest release that ships macOS `.dmg`s. Since the installer build is manual, bump the cask `version` + both checksums when a newer build publishes dmgs (`brew bump-cask-pr`).
 
 </details>
 

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -28,13 +28,13 @@ model_docx = []
 [profile.dev]
 incremental = true
 
-# Tuned for build speed over the last few % of size/perf: thin LTO compiles
-# much faster than fat LTO (it parallelizes across crates) and codegen-units =
-# 16 lets the large ajh-tauri crate codegen in parallel. opt-level "s" + strip
-# keep installers (and so auto-update downloads) small.
+# Maximally optimized release binary (smallest + fastest): fat LTO + a single
+# codegen unit + opt-level "s" + strip. The slow compile is acceptable — installer
+# builds are manual and infrequent (see release.yml), so we trade build time for
+# the best shipped artifact / smallest auto-update download.
 [profile.release]
-codegen-units = 16
-lto = "thin"
+codegen-units = 1
+lto = true
 opt-level = "s"
 panic = "abort"
 strip = true

--- a/scripts/sync-cask.cjs
+++ b/scripts/sync-cask.cjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/*
+ * Sync the Homebrew cask (Casks/ai-job-hunter.rb) to a published release's
+ * macOS .dmg assets: rewrites `version` and pins both per-arch `sha256` values.
+ *
+ *   node scripts/sync-cask.cjs <version> <armSha256> <intelSha256>
+ *
+ * Run by the release pipeline's `update-cask` job AFTER the installer build,
+ * which is the only point where the dmgs — and therefore their hashes — exist.
+ * It is NOT part of `sync-tauri-version.cjs`: that runs on every release push,
+ * before (and usually without) a build, so there would be no dmgs to hash and
+ * bumping the cask version there would point it at assets that never ship.
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const [version, armSha, intelSha] = process.argv.slice(2);
+if (!version || !armSha || !intelSha) {
+  console.error('usage: sync-cask.cjs <version> <armSha256> <intelSha256>');
+  process.exit(1);
+}
+
+const SHA_RE = /^[0-9a-f]{64}$/;
+for (const [name, value] of [
+  ['arm', armSha],
+  ['intel', intelSha],
+]) {
+  if (!SHA_RE.test(value)) {
+    console.error(`invalid ${name} sha256 (expected 64 lowercase hex chars): ${value}`);
+    process.exit(1);
+  }
+}
+
+const caskPath = path.join(__dirname, '..', 'Casks', 'ai-job-hunter.rb');
+const before = fs.readFileSync(caskPath, 'utf8');
+
+const versionRe = /^(\s*version\s+)"[^"]*"/m;
+// The sha256 stanza — whether it's `:no_check` or an existing two-line
+// arm:/intel: block — gets rewritten to verified per-arch hashes.
+const sha256Re = /^(\s*)sha256\b[^\n]*(\n[^\n]*intel:[^\n]*)?/m;
+
+if (!versionRe.test(before) || !sha256Re.test(before)) {
+  console.error('cask format unexpected — version/sha256 stanza not found');
+  process.exit(1);
+}
+
+const cask = before
+  .replace(versionRe, `$1"${version}"`)
+  .replace(sha256Re, `$1sha256 arm:   "${armSha}",\n$1       intel: "${intelSha}"`);
+
+if (cask === before) {
+  console.log(`Cask already at v${version} with these hashes — no change.`);
+  process.exit(0);
+}
+
+fs.writeFileSync(caskPath, cask);
+console.log(`Cask synced to v${version} (arm + intel sha256 pinned).`);


### PR DESCRIPTION
## Why

Two adjustments that follow from **installer builds being manual now** (#253).

## 1. Homebrew cask — verified checksums + self-maintaining

The cask shipped `sha256 :no_check`, so `brew install --cask` ran **no integrity check**.

- **Pinned verified per-arch `sha256`** for **v0.62.1** (the latest release that actually has macOS `.dmg` assets — newer tags ship none because the build is manual). Hashes read from the release's asset digests.
- **`scripts/sync-cask.cjs`** rewrites the cask `version` + both per-arch `sha256` (handles `:no_check` → pinned; idempotent; validated locally on both the no-op and change paths).
- **`update-cask` job** (`needs: build`) runs after the manual installer build, reads each dmg's `sha256` digest straight from the GitHub release API (no download), runs the script, and commits the refreshed cask to `main`.

**Answering "can we bump it in `sync-version-files`?" — no:** that job runs on *every release push, before/without a build*, so there'd be no dmgs to hash, and bumping the version there would point the cask at assets that never ship. The hash only exists after the build, so the update lives in the build pipeline.

## 2. Restore the max-optimized release profile

Reverts the build-speed relaxation from the speedup PR (`codegen-units` 1→16, `lto` true→`"thin"`). With builds now manual + infrequent, the slow compile is fine, so we go back to the **smallest/fastest shipped binary** (fat LTO + single codegen unit). The **per-arch macOS build parallelization** from that speedup is **kept** (pure wall-clock win, no binary cost).

## Notes
- `update-cask` only runs on the manual `workflow_dispatch` build path (like `generate-update-manifest`); skipped on release pushes.
- macOS window vibrancy (the original intent of this branch) is **deferred** to a future Mac-capable session — it can't be compiled or visually validated in a Windows-only dev/CI setup.

## Verify
- `sync-cask.cjs` run locally (idempotent no-op + change paths) · cask at v0.62.1 with verified hashes · `cargo verify-project` ok · release.yml YAML valid (job graph: `update-cask` needs `build`) · lint:strict 0 · pre-push hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)