### PR TITLE
docs: sync docs + knowledge base to the merged ux-audit backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,29 +169,29 @@ No `// eslint-disable`, no `@ts-ignore`. Add scoped overrides to `eslint.config.
 
 ## Quick Reference
 
-| What                    | Where                                                                           |
-| ----------------------- | ------------------------------------------------------------------------------- |
-| IPC contract            | `packages/shared/src/ipc/contracts.ts`                                          |
-| Tauri commands          | `apps/tauri/src-tauri/src/commands.rs`                                          |
-| Tauri client (TS)       | `apps/tauri/src/tauri-client.ts`                                                |
-| Service hooks           | `apps/tauri/src/renderer/services/`                                             |
-| UI package              | `packages/ui/src/index.ts` → `@ajh/ui`                                          |
-| Motion tokens           | `packages/ui/src/lib/motion.ts` (import via `@/lib/motion`)                     |
-| State machines          | `apps/tauri/src/renderer/lib/machines/`                                         |
-| Design tokens           | `packages/ui/src/css/tokens.css`                                                |
-| i18n wrapper            | `apps/tauri/src/renderer/lib/i18n.ts`                                           |
-| Config / paths (Rust)   | `apps/tauri/src-tauri/src/platform/config.rs` (`data_dir()`)                    |
-| HTTP client (Rust)      | `apps/tauri/src-tauri/src/net/http.rs` (`shared()` / `build_client()`)          |
-| Errors (Rust)           | `apps/tauri/src-tauri/src/error.rs` (`AppError` / `AppResult`)                  |
-| Trace spans (Rust)      | `apps/tauri/src-tauri/src/observability.rs` (`Span`)                            |
-| Board registries        | `scraping/boards/mod.rs` (`SCRAPERS`) · `applying/registry/mod.rs` (`APPLIERS`) |
-| Architecture principles | `docs/PATTERNS.md` §13                                                          |
-| Architecture status     | `docs/ARCHITECTURE_STATUS.md`                                                   |
-| Architecture (general)  | `docs/ARCHITECTURE.md`                                                          |
-| Export templates        | `docs/EXPORT_TEMPLATES.md` (9-template + backend contract)                      |
-| Patterns                | `docs/PATTERNS.md`                                                              |
-| Design system           | `docs/DESIGN_SYSTEM.md`                                                         |
-| Dev setup               | `docs/DEVELOPMENT.md`                                                           |
+| What                    | Where                                                                              |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| IPC contract            | `packages/shared/src/ipc/contracts.ts`                                             |
+| Tauri commands          | `apps/tauri/src-tauri/src/commands.rs`                                             |
+| Tauri client (TS)       | `apps/tauri/src/tauri-client.ts`                                                   |
+| Service hooks           | `apps/tauri/src/renderer/services/`                                                |
+| UI package              | `packages/ui/src/index.ts` → `@ajh/ui`                                             |
+| Motion tokens           | `packages/ui/src/lib/motion.ts` (import via `@/lib/motion`)                        |
+| State machines          | `apps/tauri/src/renderer/lib/machines/`                                            |
+| Design tokens           | `packages/ui/src/css/tokens.css`                                                   |
+| i18n wrapper            | `apps/tauri/src/renderer/lib/i18n.ts`                                              |
+| Config / paths (Rust)   | `apps/tauri/src-tauri/src/platform/config.rs` (`data_dir()`)                       |
+| HTTP client (Rust)      | `apps/tauri/src-tauri/src/net/http.rs` (`shared()` / `build_client()`)             |
+| Errors (Rust)           | `apps/tauri/src-tauri/src/error.rs` (`AppError` / `AppResult`)                     |
+| Trace spans (Rust)      | `apps/tauri/src-tauri/src/observability.rs` (`Span`)                               |
+| Board registry          | `scraping/boards/mod.rs` (`SCRAPERS`) — no applier registry (apply engine removed) |
+| Architecture principles | `docs/PATTERNS.md` §13                                                             |
+| Architecture status     | `docs/ARCHITECTURE_STATUS.md`                                                      |
+| Architecture (general)  | `docs/ARCHITECTURE.md`                                                             |
+| Export templates        | `docs/EXPORT_TEMPLATES.md` (9-template + backend contract)                         |
+| Patterns                | `docs/PATTERNS.md`                                                                 |
+| Design system           | `docs/DESIGN_SYSTEM.md`                                                            |
+| Dev setup               | `docs/DEVELOPMENT.md`                                                              |
 
 ## Release Pipeline
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ The only outbound calls are to the AI provider **you** configure (and an optiona
 
 - **Autopilot workflows** — define a search (board, query, location, schedule, filters); it finds and scores matching jobs.
 - **Dedup + New/Applied badges** — re-running a workflow merges results by URL: prior finds are kept, genuinely new ones are badged **New**, and jobs you've generated for are badged **Applied** (derived automatically from your saved generations).
-- **One-click assisted apply** — from any found job, generate a tailored résumé + cover letter and **résumé-grounded answers** to common application questions, with optional company research.
-- **Applications / History** — every generated application is stored as a single per-job record (résumé, cover, answers, brief, board, date) and browsable in the Résumés → Generated tab.
+- **One-click tailoring** — from any found job, click **Tailor** to seed the AI Generate workspace, open the posting, and mark it applied — on any board. Generate a tailored résumé + cover letter and **résumé-grounded answers** to common application questions, with optional company research.
+- **Documents / Activity** — every generated application is stored as a single per-job record (résumé, cover, answers, brief, board, date) and browsable in the **Documents** page (Résumés / Cover Letters / Activity tabs).
 </details>
 
 <details>
@@ -262,10 +262,10 @@ pnpm dev
 ```
 1. Autopilot → New → set board, query, location, schedule, filters
 2. Run it → found jobs appear, scored and deduped (New badges on fresh results)
-3. Open a found job → Apply:
+3. Open a found job → Tailor:
    • generate a tailored résumé + cover letter (target: Both)
    • pick application questions → get résumé-grounded answers
-   • the job flips to "Applied" and is saved to Résumés → Generated
+   • the job flips to "Applied" and is saved in Documents → Activity
 ```
 
 </details>
@@ -300,23 +300,23 @@ The app uses the OS keychain for secrets — no `.env` files. Keys and credentia
 
 ## Tech Stack
 
-| Layer               | Technology                                                              |
-| ------------------- | ----------------------------------------------------------------------- |
-| Desktop shell       | [Tauri][tauri] 2.x — [Rust][rust] core + [React][react] renderer        |
-| UI framework        | [React][react] 19, [TypeScript][typescript] 6                           |
-| Routing             | [TanStack Router][tanstack-router] 1.x (file-based)                     |
-| Server state        | [TanStack Query][tanstack-query] 5.x                                    |
-| Client state        | [Zustand][zustand] 5                                                    |
-| Styling             | [Tailwind CSS][tailwindcss] v4 + CSS custom properties                  |
-| Animations          | [motion/react][motion-react]                                            |
-| Build system        | [Vite][vite] 8 + [Turborepo][turborepo] (monorepo)                      |
-| Package manager     | [pnpm][pnpm] 11 (workspaces)                                            |
-| Local AI            | [Ollama][ollama]                                                        |
-| Relational DB       | [SQLite][sqlite] via [rusqlite][rusqlite] ([Rust][rust] core)           |
-| Vector search       | Hybrid vector + keyword matching                                        |
-| Browser automation  | [chromiumoxide][chromiumoxide] ([Rust][rust]) — Playwright for e2e only |
-| Document generation | [printpdf][printpdf] + [docx-rs][docx-rs] ([Rust][rust])                |
-| Validation          | [Zod][zod] (shared schemas → generated [Rust][rust] structs)            |
+| Layer               | Technology                                                                |
+| ------------------- | ------------------------------------------------------------------------- |
+| Desktop shell       | [Tauri][tauri] 2.x — [Rust][rust] core + [React][react] renderer          |
+| UI framework        | [React][react] 19, [TypeScript][typescript] 6                             |
+| Routing             | [TanStack Router][tanstack-router] 1.x (file-based)                       |
+| Server state        | [TanStack Query][tanstack-query] 5.x                                      |
+| Client state        | [Zustand][zustand] 5                                                      |
+| Styling             | [Tailwind CSS][tailwindcss] v4 + CSS custom properties                    |
+| Animations          | [motion/react][motion-react]                                              |
+| Build system        | [Vite][vite] 8 + [Turborepo][turborepo] (monorepo)                        |
+| Package manager     | [pnpm][pnpm] 11 (workspaces)                                              |
+| Local AI            | [Ollama][ollama]                                                          |
+| Relational DB       | [SQLite][sqlite] via [rusqlite][rusqlite] ([Rust][rust] core)             |
+| Vector search       | Hybrid vector + keyword matching                                          |
+| Browser automation  | [chromiumoxide][chromiumoxide] ([Rust][rust]) — Playwright for e2e only   |
+| Document generation | Typst engine (`export/typst_engine/`) + [docx-rs][docx-rs] ([Rust][rust]) |
+| Validation          | [Zod][zod] (shared schemas → generated [Rust][rust] structs)              |
 
 ---
 
@@ -468,7 +468,6 @@ MIT — see [LICENSE](LICENSE).
 [sqlite]: https://www.sqlite.org
 [rusqlite]: https://github.com/rusqlite/rusqlite
 [chromiumoxide]: https://github.com/mattsse/chromiumoxide
-[printpdf]: https://github.com/fschutt/printpdf
 [docx-rs]: https://github.com/bokuweb/docx-rs
 [zod]: https://zod.dev
 [conventional-commits]: https://www.conventionalcommits.org

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture — AI Job Hunter
 
-Last updated: 2026-06-01
+Last updated: 2026-06-03
 
 ## High-Level Overview
 
@@ -22,7 +22,7 @@ graph TB
     end
 
     subgraph Tauri["Tauri Core (Rust)"]
-        Commands["IPC Commands\n(21 namespaces)"]
+        Commands["IPC Commands\n(23 namespaces)"]
         Keychain["OS Keychain\n(credentials)"]
         Updater["Auto-Updater"]
         Window["Window / Tray / Menu"]
@@ -81,31 +81,33 @@ The Tauri app is split into two processes:
 
 **Rust core (`src-tauri/`)** — thin orchestration layer:
 
-| Module               | Responsibility                                                                                                            |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `commands/`          | IPC endpoint handlers; routes invocations to the appropriate runtime                                                      |
-| `platform::config`   | **Sole owner** of env vars + data-dir / filesystem path resolution                                                        |
-| `net::http`          | **Sole owner** of `reqwest::Client` construction — one pooled rustls client; per-request timeouts                         |
-| `error` (`AppError`) | Unified typed error hierarchy (`AppResult`); serializes to its message string                                             |
-| `observability`      | Shared timed trace `Span`s (`→`/`←` + duration) for AI, scraping, autopilot                                               |
-| `scraping/`          | Board scrapers (chromiumoxide for browser boards, HTTP for API boards) via a single `SCRAPERS` registry + `Scraper` trait |
-| `documents/`         | Document import, OCR dispatch, [SQLite][sqlite] storage                                                                   |
-| `jobs/`              | Job tracker state machine (queued → running → done/failed)                                                                |
-| `credentials/`       | OS keychain CRUD via Tauri keychain plugin                                                                                |
-| `conversations/`     | Chat history persistence                                                                                                  |
-| `autopilot/`         | Job-discovery agent + step scheduler (finds → ranks → notifies; the user tailors & applies)                               |
-| `ai_generations/`    | Metadata tracking for generated documents                                                                                 |
-| `export/`            | DOCX/PDF rendering — PDF via Typst (`export/typst_engine/`), DOCX via docx-rs (`export/docx/`)                            |
-| `updater/`           | Auto-update state (check, download, install)                                                                              |
-| `browser/`           | System browser detection and launch                                                                                       |
-| `data_store.rs`      | `DataStore` trait (export/import) implemented by every persistent store                                                   |
-| `commands/data.rs`   | Full backup/restore — one versioned bundle across all stores                                                              |
+| Module               | Responsibility                                                                                                                                              |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `commands/`          | IPC endpoint handlers; routes invocations to the appropriate runtime                                                                                        |
+| `platform::config`   | **Sole owner** of env vars + data-dir / filesystem path resolution                                                                                          |
+| `net::http`          | **Sole owner** of `reqwest::Client` construction — one pooled rustls client; per-request timeouts                                                           |
+| `error` (`AppError`) | Unified typed error hierarchy (`AppResult`); serializes to its message string                                                                               |
+| `observability`      | Shared timed trace `Span`s (`→`/`←` + duration) for AI, scraping, autopilot                                                                                 |
+| `scraping/`          | Board scrapers (chromiumoxide for browser boards, HTTP for API boards) via a single `SCRAPERS` registry + `Scraper` trait                                   |
+| `documents/`         | Document import, OCR dispatch, [SQLite][sqlite] storage                                                                                                     |
+| `jobs/`              | Job tracker state machine (queued → running → done/failed)                                                                                                  |
+| `credentials/`       | OS keychain — AI provider keys (`ai:*`) + `credentials_available` encryption-check; board login uses the separate `boards.*`/`linkedin.*` session-auth path |
+| `conversations/`     | Chat history persistence                                                                                                                                    |
+| `autopilot/`         | Job-discovery agent + step scheduler (finds → ranks → notifies; the user tailors & applies); `run_status` + crash reconciliation                            |
+| `tray/`              | System-tray module — dynamic "New jobs: N" + "Pause all autopilots" (L3 entrypoint)                                                                         |
+| `deeplink/`          | Deep-link guard — `ajh://autopilot/<id>` validated against strict allowlist; OS scheme registered via `tauri-plugin-deep-link`                              |
+| `ai_generations/`    | Metadata tracking for generated documents                                                                                                                   |
+| `export/`            | DOCX/PDF rendering — PDF via Typst (`export/typst_engine/`), DOCX via docx-rs (`export/docx/`)                                                              |
+| `updater/`           | Auto-update state (check, download, install)                                                                                                                |
+| `browser/`           | System browser detection and launch                                                                                                                         |
+| `data_store.rs`      | `DataStore` trait (export/import) implemented by every persistent store                                                                                     |
+| `commands/data.rs`   | Full backup/restore — one versioned bundle across all stores                                                                                                |
 
 **[React][react] renderer (`src/renderer/`)** — feature-scoped UI:
 
 | Directory            | Responsibility                                                      |
 | -------------------- | ------------------------------------------------------------------- |
-| `routes/`            | [TanStack Router][tanstack-router] file-based pages (9 routes)      |
+| `routes/`            | [TanStack Router][tanstack-router] file-based pages                 |
 | `features/`          | Feature-scoped component trees (never cross-import)                 |
 | `services/`          | [TanStack Query][tanstack-query] hooks wrapping every IPC namespace |
 | `lib/`               | Pure utilities: motion tokens, i18n, state machine, `cn()`          |
@@ -123,14 +125,15 @@ The single source of truth for renderer ↔ Rust communication:
 ```
 packages/shared/src/
 ├── ipc/
-│   ├── contracts/          # 21 typed namespace definitions
+│   ├── contracts/          # 23 typed namespace definitions
 │   │   ├── ai.ts
 │   │   ├── aiGenerations.ts
-│   │   ├── apply.ts
 │   │   ├── autopilot.ts
 │   │   ├── boards.ts
+│   │   ├── contactProfile.ts
 │   │   ├── conversations.ts
 │   │   ├── credentials.ts
+│   │   ├── data.ts
 │   │   ├── dialog.ts
 │   │   ├── documents.ts
 │   │   ├── geocode.ts

--- a/docs/ARCHITECTURE_STATUS.md
+++ b/docs/ARCHITECTURE_STATUS.md
@@ -2,7 +2,7 @@
 
 Implementation status tracker. Updated as features ship.
 
-Last updated: 2026-06-02
+Last updated: 2026-06-03
 
 ---
 
@@ -25,7 +25,7 @@ Last updated: 2026-06-02
 | [TypeScript][typescript] 6 across all packages   | ✅     | Strict mode enabled                                                                                                                                                                             |
 | [Vite][vite] + HMR for renderer                  | ✅     |                                                                                                                                                                                                 |
 | [TanStack Router][tanstack-router] (file-based)  | ✅     | All 9 routes                                                                                                                                                                                    |
-| [TanStack Query][tanstack-query] + service hooks | ✅     | All 21 namespaces                                                                                                                                                                               |
+| [TanStack Query][tanstack-query] + service hooks | ✅     | All 23 namespaces                                                                                                                                                                               |
 | [Zustand][zustand] stores                        | ✅     | preferences-store, generation-store (`store/generation-store/`), others                                                                                                                         |
 | AppClient / mock transport                       | ✅     | [Tauri][tauri] + mock implementations                                                                                                                                                           |
 | [ESLint][eslint] + [Prettier][prettier]          | ✅     | Enforced in CI                                                                                                                                                                                  |
@@ -117,43 +117,56 @@ former `packages/ai` and `packages/data` Node packages were removed.
 
 ## Autopilot (`apps/tauri/src-tauri/src/autopilot/`)
 
-| Feature                      | Status | Notes                                                                                                          |
-| ---------------------------- | ------ | -------------------------------------------------------------------------------------------------------------- |
-| Workflow definition wizard   | ✅     | 3-step UI                                                                                                      |
-| Workflow persistence         | ✅     | [SQLite][sqlite]                                                                                               |
-| Manual trigger               | ✅     |                                                                                                                |
-| Scheduled execution          | ✅     | Cron-like scheduler                                                                                            |
-| Real-time step events        | ✅     | autopilot:step stream                                                                                          |
-| Pause / resume               | ✅     |                                                                                                                |
-| Found-job dedup + tracking   | ✅     | `merge_found_jobs` dedup by URL; `FoundJob.is_new`; `applied` derived from `ai_generations.job_url`            |
-| Generation-session store     | ✅     | `store/generation-store/` — app-wide, keyed by context id, survives navigation; Apply modal uses it            |
-| `ai_generations` aggregate   | ✅     | `job_url`, `board`, `application_answers`, `company_brief` columns; per-job merge-upsert (`merge_application`) |
-| Applications/History view    | ✅     | Generated tab — new/applied badges; per-job record in history card                                             |
-| Auto-apply integration       | 🚧     | Apply success rate varies by board                                                                             |
-| Batch application throttling | 🚧     | Rate limiting per board                                                                                        |
+| Feature                     | Status | Notes                                                                                                            |
+| --------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------- |
+| Workflow definition wizard  | ✅     | 3-step UI                                                                                                        |
+| Workflow persistence        | ✅     | [SQLite][sqlite]                                                                                                 |
+| Manual trigger              | ✅     |                                                                                                                  |
+| Scheduled execution         | ✅     | Cron-like scheduler                                                                                              |
+| Real-time step events       | ✅     | autopilot:step stream                                                                                            |
+| Pause / resume              | ✅     |                                                                                                                  |
+| Found-job dedup + tracking  | ✅     | `merge_found_jobs` dedup by URL; `FoundJob.is_new`; `applied` derived from `ai_generations.job_url`              |
+| Generation-session store    | ✅     | `store/generation-store/` — app-wide, keyed by context id, survives navigation; Tailor modal uses it             |
+| `ai_generations` aggregate  | ✅     | `job_url`, `board`, `application_answers`, `company_brief` columns; per-job merge-upsert (`merge_application`)   |
+| `run_status` + status badge | ✅     | `inProgress\|completed\|failed\|interrupted`; amber/red chip on `AutopilotCard`; crash reconciliation on startup |
+| OS notification on new jobs | ✅     | Permission-gated; clicking the notification navigates to `/autopilot`                                            |
+| Tray module                 | ✅     | Dynamic "New jobs: N" click→focus; "Pause all" — `apps/tauri/src-tauri/src/tray/`                                |
+| Deep-link focus guard       | ✅     | `ajh://autopilot/<id>` validated against strict allowlist; registered OS scheme — `deeplink/`                    |
+| Startup catch-up sweep      | ✅     | Fires ~5 s after launch instead of waiting a full tick interval                                                  |
+| `minMatchScore` enforcement | ✅     | Scorable postings below threshold dropped before `record_run`; unscored postings kept                            |
+| Cancellation token reuse    | ✅     | Tray/UI cancel reaches the running token across the whole run                                                    |
+| Launch-at-login             | ✅     | Opt-in (default OFF); `system_get/set_launch_at_login` via `tauri-plugin-autostart`                              |
 
 ---
 
 ## UI / UX
 
-| Feature                   | Status | Notes                                    |
-| ------------------------- | ------ | ---------------------------------------- |
-| Dashboard route           | ✅     | Pipeline overview, recent activity       |
-| Jobs route                | ✅     | List, filter, interaction history        |
-| Search route              | ✅     | Hybrid semantic search                   |
-| AI route                  | ✅     | Model selection, [Ollama][ollama] health |
-| AI Generate route         | ✅     | Full generation UI                       |
-| Analyze route             | ✅     | Resume analysis panels                   |
-| Autopilot route           | ✅     | Workflow builder + runner                |
-| Settings route            | ✅     | All settings tabs                        |
-| Support route             | ✅     | Diagnostics, FAQ, logs                   |
-| Onboarding wizard         | ✅     | First-run experience                     |
-| Light/dark theme          | ✅     |                                          |
-| i18n (11 languages)       | ✅     | UI translations                          |
-| Keyboard shortcuts        | ✅     | Configurable                             |
-| Auto-updater banner       | ✅     |                                          |
-| Performance mode selector | ✅     |                                          |
-| Spotlight tour            | ✅     | Interactive tutorial                     |
+| Feature                   | Status | Notes                                                                                                           |
+| ------------------------- | ------ | --------------------------------------------------------------------------------------------------------------- |
+| Dashboard route           | ✅     | Pipeline overview, recent activity                                                                              |
+| Jobs route                | ✅     | List (virtualized via `@tanstack/react-virtual`), filter, interaction history                                   |
+| Search route              | ✅     | Hybrid semantic search (⌘/Ctrl+K only — removed from sidebar)                                                   |
+| AI route                  | ✅     | Model selection, [Ollama][ollama] health                                                                        |
+| AI Generate route         | ✅     | Full generation UI                                                                                              |
+| Analyze route             | ✅     | Resume analysis panels                                                                                          |
+| Autopilot route           | ✅     | Workflow builder + runner                                                                                       |
+| Documents route           | ✅     | Three-tab view — Résumés / Cover Letters / Activity (lenses over `ai_generations`); route stays `/resumes`      |
+| Settings route            | ✅     | All settings tabs; keyboard-reachable sidebar (`@ajh/ui Button` + `aria-current`); `SettingsSection` throughout |
+| Support route             | ✅     | Diagnostics, FAQ, logs                                                                                          |
+| Onboarding wizard         | ✅     | First-run experience                                                                                            |
+| Light/dark/system theme   | ✅     |                                                                                                                 |
+| i18n (11 languages)       | ✅     | UI translations                                                                                                 |
+| Keyboard shortcuts        | ✅     | Global handler + `?` cheat-sheet modal (`useKeyboardShortcuts`)                                                 |
+| Auto-updater banner       | ✅     |                                                                                                                 |
+| Performance mode selector | ✅     |                                                                                                                 |
+| Spotlight tour            | ✅     | Interactive tutorial                                                                                            |
+| Sidebar nav groups        | ✅     | Workspace / Automation / pinned — `nav.sections.workspace\|automation` i18n keys                                |
+| Grouped nav pill          | ✅     | `@ajh/ui NavPill` slides within each list (`layoutId` scoped per group)                                         |
+| `SegmentedControl`        | ✅     | `@ajh/ui` — radiogroup + roving arrow-key nav; `track`/`grid` variants                                          |
+| `SetupHint`               | ✅     | `@ajh/ui` — generalized contextual setup nudge (AI + future board/chrome)                                       |
+| Visible focus rings       | ✅     | Global `:focus-visible` ring; `ModalShell` `aria-labelledby`; `role="switch"` toggles                           |
+| Optimistic delete         | ✅     | `onMutate` snapshot+filter / `onError` rollback on generations + autopilots                                     |
+| macOS window vibrancy     | ⬜     | Deferred — requires a Mac-capable dev session (`window-vibrancy` crate)                                         |
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment — AI Job Hunter
 
-Last updated: 2026-06-01
+Last updated: 2026-06-03
 
 AI Job Hunter is distributed as a native desktop installer built by [Tauri][tauri]. There is no server to deploy — the entire app runs on the end user's machine.
 
@@ -128,7 +128,7 @@ graph LR
 1. semantic-release analyzes commits → creates the `v*` tag + GitHub release notes
 2. CI commits the synced version files back to `main`
 
-**`build` + `generate-update-manifest`** — run **only** via **Actions ▸ "🚀 Release" ▸ "Run workflow"** (~60 min/platform):
+**`build` + `generate-update-manifest`** — run **only** via **Actions ▸ "🚀 Release" ▸ "Run workflow"** (macOS Intel + Apple Silicon build as two parallel matrix legs, so wall-clock is roughly the slowest single platform rather than the sum of all three):
 
 1. Resolve the version (the `version` input, or the latest tag if left blank), then checkout that tag
 2. Install pnpm + Node + Rust stable; `pnpm build:packages`

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,6 +1,6 @@
 # Design System — AI Job Hunter
 
-Last updated: 2026-06-01
+Last updated: 2026-06-03
 
 The design system lives in `packages/ui` and is published as the `@ajh/ui` internal package. It provides design tokens, a component library, motion primitives, and theming infrastructure.
 
@@ -345,6 +345,42 @@ Selectable card for option groups (AI model selection, template picker):
 ---
 
 ### Layout Primitives
+
+#### `SegmentedControl`
+
+Radiogroup with roving arrow-key navigation. Two layout variants:
+
+```typescript
+<SegmentedControl
+  variant="track"   // or "grid"
+  value={tab}
+  onChange={setTab}
+  options={[
+    { value: "resumes", label: "Résumés" },
+    { value: "cover-letters", label: "Cover Letters" },
+    { value: "activity", label: "Activity" },
+  ]}
+/>
+```
+
+#### `SetupHint`
+
+Contextual setup nudge — used when a feature requires configuration (e.g. no AI provider set up). Generalises the former `AuthHint`.
+
+```typescript
+<SetupHint
+  label="No AI provider configured"
+  action={{ label: "Go to Settings", href: "/settings#ai" }}
+/>
+```
+
+#### `NavPill`
+
+Decorative sliding active-indicator for navigation lists. `aria-hidden` + `pointer-events-none`; scoped by `layoutId` so the pill animates within one list only.
+
+```typescript
+<NavPill layoutId="sidebar-nav" isActive={isActive} />
+```
 
 #### `ActionTile`
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -1,6 +1,6 @@
 # Patterns — AI Job Hunter
 
-Last updated: 2026-06-01
+Last updated: 2026-06-03
 
 This document describes the recurring architectural and implementation patterns used throughout the codebase. Understanding these patterns is essential for contributing consistently.
 
@@ -364,17 +364,14 @@ Translation keys follow dot notation by feature:
 
 ## 10. Credential Storage Pattern
 
-Never store API keys or passwords in localStorage, SQLite, or env vars. Always use the keychain:
+Never store API keys or passwords in localStorage, SQLite, or env vars. Always use the keychain.
+
+**AI provider keys** are stored via `credentials.set` internally (the `ai:*` key namespace) and cleared via factory reset. Board login uses a separate session-auth path (`boards.*` / `linkedin.*`) — there is no board-level username/password CRUD.
+
+To check whether the OS supports encrypted storage (shows an encryption-warning banner if `false`):
 
 ```typescript
-// Store
-await client.credentials.set({ board: 'linkedin', username: 'user@email.com', password: '...' });
-
-// Check
-const has = await client.credentials.hasCredential('linkedin');
-
-// Remove
-await client.credentials.remove('linkedin');
+const { data: available } = useCredentialsAvailable(); // services/use-credentials
 ```
 
 The [Tauri][tauri] keychain plugin encrypts secrets using the OS credential store (Windows Credential Manager, macOS Keychain, libsecret on Linux).
@@ -484,7 +481,7 @@ it; `std::env::var` only in `platform/**`; `reqwest::Client::new/builder` only i
 | `// eslint-disable` comment                       | Fix the underlying issue or add a scoped `eslint.config.mjs` override                                                                        |
 | Inline `{ duration: 0.2, ease: "easeOut" }`       | `transition.fast` from `@/lib/motion`                                                                                                        |
 | Hardcoded colors in className                     | `text-brand`, `bg-brand`, etc.                                                                                                               |
-| Storing credentials in SQLite                     | OS keychain via `client.credentials`                                                                                                         |
+| Storing credentials in SQLite                     | OS keychain (AI keys via `credentials` module; board sessions via `boards.*`/`linkedin.*`)                                                   |
 | Reading `AJH_DATA_DIR` / rebuilding `~/.ajh`      | `platform::config::data_dir()`                                                                                                               |
 | Per-page `?` that aborts a partial scrape         | First-page error propagates as `Err`; a later page logs + `break`s, keeping the partial (P10)                                                |
 | `reqwest::Client::new()` / `::builder()`          | `net::http::shared()` or `net::http::build_client()`                                                                                         |

--- a/docs/architecture-analysis.md
+++ b/docs/architecture-analysis.md
@@ -1,6 +1,6 @@
 # Architecture Analysis — Rust/Tauri Core
 
-Last updated: 2026-06-01
+Last updated: 2026-06-03
 
 > **Status:** discovery report (Phase 1). Read-only — describes the architecture **as it
 > actually exists** in `apps/tauri/src-tauri/`, measured from the source tree, not an
@@ -54,8 +54,9 @@ replace them:
 - **Single-owner shared infrastructure** — `platform::config` (env + paths), `net::http`
   (one pooled rustls client), `error::AppError`/`AppResult` (typed errors),
   `observability::Span` (timed `→`/`←` traces). Each has exactly one owner.
-- **Registry dispatch** — `scraping::boards::SCRAPERS`, `applying::registry::APPLIERS`,
+- **Registry dispatch** — `scraping::boards::SCRAPERS`,
   `commands::ai_provider::resolve(ProviderId)`. Dispatch + catalog derive from one list.
+  _(Note: `applying::registry::APPLIERS` was removed in v0.58.0 — the auto-apply engine is gone; the app is an apply assistant.)_
 - **Store-per-domain behind one trait** — every persistent store implements
   `data_store::DataStore` (`export`/`import`); `commands/data.rs` assembles one versioned
   backup bundle.
@@ -241,17 +242,17 @@ blocks **new** drift.
 
 Extends the `docs/PATTERNS.md` §13 ownership table with the boundaries this analysis adds:
 
-| Concern                          | Sole owner                                                             | Rule                                                |
-| -------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------- |
-| env vars, data dir, FS paths     | `platform::config` (+ `platform::process`/`chrome` for OS-process env) | never read env elsewhere (W-5)                      |
-| HTTP client construction         | `net::http`                                                            | `shared()` / `build_client()` only                  |
-| timed trace spans                | `observability::Span`                                                  | never reimplement begin/elapsed/end                 |
-| error types                      | `error::AppError`                                                      | `AppResult<T>`; domain enums add `From`             |
-| SQLite handle + access           | `db` + per-domain `*/mod.rs` stores                                    | no `rusqlite` in logic/helper files (W-4)           |
-| AI provider routing + embeddings | **`ai_provider`** (to be relocated out of `commands/`)                 | `resolve(ProviderId)`, `embed_text`, `cosine` (W-1) |
-| job board scrapers / appliers    | `scraping::boards` / `applying::registry`                              | register in `SCRAPERS` / `APPLIERS`                 |
-| workflow orchestration           | `pipeline`                                                             | compose `Stage`/`Pipeline`                          |
-| Tauri command surface            | `commands/*`                                                           | the only place `#[tauri::command]` is defined (W-2) |
+| Concern                          | Sole owner                                                             | Rule                                                           |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------- |
+| env vars, data dir, FS paths     | `platform::config` (+ `platform::process`/`chrome` for OS-process env) | never read env elsewhere (W-5)                                 |
+| HTTP client construction         | `net::http`                                                            | `shared()` / `build_client()` only                             |
+| timed trace spans                | `observability::Span`                                                  | never reimplement begin/elapsed/end                            |
+| error types                      | `error::AppError`                                                      | `AppResult<T>`; domain enums add `From`                        |
+| SQLite handle + access           | `db` + per-domain `*/mod.rs` stores                                    | no `rusqlite` in logic/helper files (W-4)                      |
+| AI provider routing + embeddings | **`ai_provider`** (to be relocated out of `commands/`)                 | `resolve(ProviderId)`, `embed_text`, `cosine` (W-1)            |
+| job board scrapers               | `scraping::boards`                                                     | register in `SCRAPERS` (no applier registry — removed v0.58.0) |
+| workflow orchestration           | `pipeline`                                                             | compose `Stage`/`Pipeline`                                     |
+| Tauri command surface            | `commands/*`                                                           | the only place `#[tauri::command]` is defined (W-2)            |
 
 ---
 

--- a/docs/architecture-map.html
+++ b/docs/architecture-map.html
@@ -1,4 +1,8 @@
 <!doctype html>
+<!-- NOTICE (2026-06-03): This diagram predates the apply→assist pivot (v0.58.0).
+     The embedded graph still depicts the removed auto-apply engine (applying/,
+     APPLIERS registry, apply IPC contract). Source code is authoritative.
+     See docs/ARCHITECTURE.md for the current architecture. -->
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/docs/architecture/how-it-works.html
+++ b/docs/architecture/how-it-works.html
@@ -1,4 +1,8 @@
 <!doctype html>
+<!-- NOTICE (2026-06-03): This diagram predates the apply→assist pivot (v0.58.0).
+     The embedded graph still depicts the removed auto-apply engine (applying/,
+     APPLIERS registry, apply IPC contract). Source code is authoritative.
+     See docs/ARCHITECTURE.md for the current architecture. -->
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/docs/knowledge/domain-model.md
+++ b/docs/knowledge/domain-model.md
@@ -1,6 +1,6 @@
 # Domain model (core types, traits, registries)
 
-Last updated: 2026-06-01
+Last updated: 2026-06-03
 
 Describes the **shape**; the source is authoritative for field-level detail. Use `graphify explain "<type>"` then read the owning file.
 
@@ -13,7 +13,7 @@ Describes the **shape**; the source is authoritative for field-level detail. Use
 ## Export contract
 
 - **`ExportRequest` / `ExportResult`** — `apps/tauri/src-tauri/src/export/types.rs` (the request/response shape: target format, template, ATS mode, locale). Owned by `resume-export-expert`; **implemented** by `pdf-docx-generator`.
-- PDF path: `export/pdf/`, `export/pdf_renderer/`, `export/layout_pdf/` ([printpdf][printpdf] + ttf-parser). DOCX path: `export/docx/`, `export/model_docx/`, `export/docx_renderer.rs` ([docx-rs][docx-rs]). Templates: `export/templates/`. Gate: `validate/`.
+- PDF path: `export/typst_engine/` (sole PDF backend — printpdf removed). DOCX path: `export/docx/`, `export/model_docx/` ([docx-rs][docx-rs]). Templates: `export/templates/`. Gate: `validate/`.
 
 ## Job / matching
 
@@ -37,7 +37,6 @@ Describes the **shape**; the source is authoritative for field-level detail. Use
 - **Errors** — `error.rs` (`AppError`/`AppResult`). **Config/paths** — `platform/config.rs` (`data_dir()`). **HTTP** — `net/http.rs` (`shared()`). **Tracing** — `observability.rs` (`Span`).
 - **Data** — `db.rs`, `data_store.rs` ([SQLite][sqlite] via [rusqlite][rusqlite]); migrations + GDPR (`commands/privacy.rs`) owned by `rust-backend-architect` (data security lens → `tauri-security-reviewer`).
 
-[printpdf]: https://github.com/fschutt/printpdf
 [docx-rs]: https://github.com/bokuweb/docx-rs
 [sqlite]: https://www.sqlite.org
 [rusqlite]: https://github.com/rusqlite/rusqlite


### PR DESCRIPTION
## What

Closes out the UX-audit §12 program (PRs 1–12 + release/packaging changes, all merged → `main` v0.64.2) by syncing the docs, knowledge base, and lessons log to merged reality. Done by **`project-steward`** (sole docs/knowledge/lessons owner); the main session reviewed the diff and softened one unverified figure.

Drift-only edits (not a rewrite) — 11 files:

| Area | Fix |
|---|---|
| **Apply→assist** | Removed live `APPLIERS`/auto-apply references (`ARCHITECTURE`, `architecture-analysis`, `CLAUDE.md` quick-ref); "Apply" → "Tailor" (`README`, `ARCHITECTURE_STATUS`); added a banner to the two HTML arch-viz diagrams noting they predate the v0.58.0 pivot and still depict the removed applier subsystem |
| **IPC** | Dropped the `apply` contract; corrected the `credentials` namespace (board CRUD removed; AI keys + `available()` remain; board login is the session-auth path) in `ARCHITECTURE` + `PATTERNS` §10 |
| **Autopilot** | Documented tray, deeplink, `run_status`, startup catch-up sweep, `minMatchScore`, cancellation reuse, launch-at-login |
| **UI/IA** | Documents route + Résumés/Cover-Letters/Activity, sidebar regroup, Search→⌘K, Settings keyboard a11y, virtualized Jobs list |
| **Design system** | Added `SegmentedControl`, `SetupHint`, `NavPill` primitive sections |
| **Release/build** | Manual-only installer build + parallel macOS arches; restored max-optimized release profile; verified cask docs |
| **Export** | Fixed stale `printpdf` → Typst engine paths (`README`, `domain-model`) |

## Notes
- **macOS window vibrancy** recorded as **deferred** (unverifiable in Windows-only dev/CI).
- `graphify update .` ran (AST-only; `graphify-out/` is gitignored, not in this diff).
- Lessons persisted to the local log (apply→assist rationale, manual-build + force-cancel, cask-sha-in-build-not-sync, vibrancy-deferral, `rtk` output masking, commitlint subject-case).
- The old "~60 min/platform" build-time figure was replaced with a qualitative note (wall-clock ≈ slowest single platform) rather than an unmeasured number.

Docs-only — no source changed. `docs:` → no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)