### PR TITLE
ci: fix update-cask release job (setup-node v5 pnpm cache)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -622,6 +622,10 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          # This job has no pnpm/action-setup step (it only runs a dependency-free
+          # node script), so disable setup-node@v5's default package-manager cache,
+          # which would otherwise try to invoke pnpm and fail to locate it.
+          package-manager-cache: false
 
       - name: 🍺 Sync cask to the built dmgs
         env:


### PR DESCRIPTION
## Problem

The [🚀 Release run](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/actions/runs/26906933897) failed in the **🍺 Update Homebrew Cask** job at the **Setup Node.js** step:

```
##[error]Unable to locate executable file: pnpm. Please verify either the file
path exists or the file can be found within a directory specified by the PATH
environment variable.
```

## Root cause

`actions/setup-node@v5` enables package-manager caching **by default** (`package-manager-cache: true`) and auto-detects pnpm from the repo's lockfile/`packageManager` field. To compute the cache key it invokes `pnpm` — but the `update-cask` job has **no `pnpm/action-setup` step** before `setup-node`, so pnpm isn't on PATH and the step fails.

Every other job in `release.yml` sets up pnpm first and passes `cache: pnpm`, which is why only `update-cask` broke. This surfaced after the v4 → v5 bump (caching was opt-in under v4).

## Fix

The `update-cask` job runs only `node scripts/sync-cask.cjs` — a script that imports nothing but `node:fs`/`node:path` and installs **no dependencies** — so the pnpm store cache is pointless here. Set `package-manager-cache: false` on this job's `setup-node` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
