### PR TITLE
docs: reposition landing page from auto-apply to draft-and-you-send

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>AI Job Hunter — please hire him</title>
-<meta name="description" content="Scrapes 18 job boards, writes your cover letters, applies while you dissociate. A real desktop app. Also a cry for help.">
-<meta property="og:title" content="IT APPLIES FOR ME.">
-<meta property="og:description" content="I sent 1,000 applications and got 0 replies. So I built a robot. (the OG image should be the deep-fried 'IT APPLIES FOR ME' frame)">
+<meta name="description" content="Scrapes 19 job boards, writes your cover letters, does everything but hit submit. A real desktop app. Also a cry for help.">
+<meta property="og:title" content="IT DOES EVERYTHING ELSE.">
+<meta property="og:description" content="I sent 1,000 applications and got 0 replies. So I built a robot. It does everything but press send. (the OG image should be the deep-fried 'IT DOES EVERYTHING ELSE' frame)">
 <meta property="og:type" content="website">
 <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -426,7 +426,7 @@ body::after{
       </svg>
     </div>
     <h1 class="reveal">Job hunting broke me.<br>So I built a robot to do it.</h1>
-    <p class="sub reveal">AI Job Hunter scrapes 18 job boards, writes your cover letters, and applies while you dissociate. Runs fully offline. <b>Built by a guy who is, himself, still unemployed.</b></p>
+    <p class="sub reveal">AI Job Hunter scrapes 19 job boards, writes your cover letters, and drafts your applications while you dissociate — you just press send. Runs fully offline. <b>Built by a guy who is, himself, still unemployed.</b></p>
     <div class="scrollhint reveal">scroll to watch a man fall apart<span class="arr">↓</span></div>
   </div>
 </section>
@@ -487,7 +487,7 @@ body::after{
       </svg>
     </div>
     <div class="swarm reveal" id="swarm">
-      <span class="chip x">LinkedIn</span><span class="chip x">Indeed</span><span class="chip x">StepStone</span><span class="chip x">Xing</span><span class="chip x">Greenhouse</span><span class="chip x">Lever</span><span class="chip x">Workday</span><span class="chip">+11 more</span>
+      <span class="chip x">LinkedIn</span><span class="chip x">Indeed</span><span class="chip x">StepStone</span><span class="chip x">Xing</span><span class="chip x">Greenhouse</span><span class="chip x">Lever</span><span class="chip x">Workday</span><span class="chip">+12 more</span>
     </div>
     <p class="tag reveal" style="margin:6px auto 26px; max-width:42ch; color:#d1c6e6">entry level: 5 yrs experience required · easy apply (47 fields) · create a Workday account <i>(for the 9th time)</i></p>
 
@@ -537,7 +537,7 @@ body::after{
 <section class="stage beat3">
   <div class="photo"></div><div class="grade"></div>
   <div class="inner">
-    <div class="doodle beat3-dood reveal tap" data-scream data-voice="fried" data-lines="IT APPLIES FOR ME|I HAVE THE POWER|NO MORE FORMS|unlimited POWER|YESSS">
+    <div class="doodle beat3-dood reveal tap" data-scream data-voice="fried" data-lines="IT WRITES IT FOR ME|I HAVE THE POWER|NO MORE COVER LETTERS|unlimited POWER|YESSS">
       <div class="bubble"></div>
       <svg viewBox="0 0 260 240">
         <circle class="dood" cx="130" cy="104" r="48" style="stroke-width:4"/>
@@ -553,11 +553,11 @@ body::after{
         <path class="dood" d="M130 196 L108 232 M130 196 L152 232" style="stroke-width:4"/>
       </svg>
     </div>
-    <div class="fried huge reveal">WAIT.<br>IT APPLIES<br>FOR ME.</div>
-    <div class="fried mid reveal">one click. eighteen job boards. zero tears.</div>
-    <p class="fried-line reveal">it <b>scrapes 18 boards</b> while you do NOTHING. it <b>writes the cover letter</b> — the one you CRIED over. GONE. it <b>scores your résumé</b> so the regex blob can't hurt you anymore. <b>semantic matching????</b> it KNOWS which jobs want you. it knows things you don't.</p>
+    <div class="fried huge reveal">WAIT.<br>IT DOES<br>EVERYTHING ELSE.</div>
+    <div class="fried mid reveal">it finds them. it writes them. you press send.</div>
+    <p class="fried-line reveal">it <b>scrapes 19 boards</b> while you do NOTHING. it <b>writes the cover letter</b> — the one you CRIED over. GONE. it <b>scores your résumé</b> so the regex blob can't hurt you anymore. <b>semantic matching????</b> it KNOWS which jobs want you. it knows things you don't. the one thing it <b>won't</b> do? press submit. that terror stays yours.</p>
     <div class="dialog reveal">
-      Are you sure?<br><span style="font-size:12px; color:#444">(you were not supposed to find this)</span>
+      <span class="dq">Are you sure?</span><br><span style="font-size:12px; color:#444">(you were not supposed to find this)</span>
       <div class="btns"><button>yes</button><button class="y2">YES</button></div>
     </div>
   </div>
@@ -584,8 +584,8 @@ body::after{
       </svg>
     </div>
     <p class="big reveal">"i haven't opened LinkedIn in 3 weeks and i've never been happier."</p>
-    <p class="counter reveal">applications: <span data-to="247">0</span> (auto) · interviews: <span data-to="6">0</span> · effort: 0</p>
-    <p class="line reveal">while you sleep, it applies. while you cry, it applies. it does not cry. be like the autopilot.</p>
+    <p class="counter reveal">matches found: <span data-to="247">0</span> · drafts written: <span data-to="247">0</span> · applications you actually sent: <span data-to="6">0</span></p>
+    <p class="line reveal">while you sleep, it hunts. while you cry, it writes. it does not cry. be like the autopilot.</p>
     <p class="line reveal">runs 100% offline with Ollama. your 4am desperation is between you, your laptop, and God. not OpenAI. <b>God.</b></p>
   </div>
 </section>
@@ -597,13 +597,15 @@ body::after{
     <p class="lede reveal">(in between the breakdowns, real software happened)</p>
     <svg class="crayon-arrow" viewBox="0 0 120 60"><path d="M8 12 q40 36 90 30" fill="none" stroke="var(--ink)" stroke-width="3" stroke-linecap="round"/><path d="M84 48 l14 -6 m-14 6 l8 -13" fill="none" stroke="var(--ink)" stroke-width="3" stroke-linecap="round"/></svg>
     <div class="feat-grid">
-      <div class="feat reveal"><h3>18+ boards, one scrape</h3><p>LinkedIn, Indeed, StepStone, Xing, Greenhouse, Lever, Workday, and 11 others you'll also be rejected from — but faster.</p></div>
-      <div class="feat reveal"><h3>AI cover letters & résumés</h3><p>Writes it for you. 9 templates, DOCX & PDF export. The AI is more passionate about this role than you could ever convincingly fake.</p></div>
+      <div class="feat reveal"><h3>19 boards, one scrape</h3><p>LinkedIn, Indeed, StepStone, Xing, Greenhouse, Lever, Workday, plus the whole German/DACH lineup and a stack of ATS platforms — 12 more places to be rejected, but faster.</p></div>
+      <div class="feat reveal"><h3>AI cover letters &amp; résumés</h3><p>Writes it for you. 9 templates — 5 premium ones (Meridian, Atelier, Throughline, Portrait, Lebenslauf), two with a headshot — rendered by a pure-Rust Typst engine to DOCX, PDF &amp; TXT. The AI is more passionate about this role than you could ever convincingly fake.</p></div>
       <div class="feat reveal"><h3>ATS scoring</h3><p>Your résumé was reviewed by a piece of regex that has never felt joy. Now you score back.</p></div>
       <div class="feat reveal"><h3>Semantic matching</h3><p>Hybrid vector search. Understands your résumé better than your mother, who still thinks you "do computers."</p></div>
-      <div class="feat reveal"><h3>Autopilot</h3><p>Pick a board, pick a schedule, walk away. It applies at 9am sharp while you achieve REM sleep.</p></div>
-      <div class="feat reveal"><h3>Local, cloud, or CLI agents</h3><p>Run it free and offline with Ollama, drop in your own OpenAI/Anthropic/Gemini key, or route it through a CLI agent you already pay for — no key needed. Your coding-agent subscription can finally do something about the unemployment.</p></div>
-      <div class="feat reveal"><h3>11 languages</h3><p>en, de, fr, es, it, tr, pt, ru, zh, ja, ko. Cosmopolitan failure.</p></div>
+      <div class="feat reveal"><h3>Autopilot</h3><p>Pick a board and a schedule, walk away. At 9am it scrapes, ranks the matches, pings you, and pre-writes each tailored application. The submit button it leaves to you — some dignity must remain.</p></div>
+      <div class="feat reveal"><h3>Local, cloud, or CLI agents</h3><p>Run it free and offline with Ollama, drop in your own OpenAI/Anthropic/Gemini key, or route it through a CLI agent you already pay for — Claude Code, Codex, or Gemini CLI, no key needed. Your coding-agent subscription can finally do something about the unemployment.</p></div>
+      <div class="feat reveal"><h3>Company research, on tap</h3><p>Before it writes the letter, it quietly looks the company up — provider-native web search folded right into the prompt — so you don't have to fake admiring their "mission." Opt-in. The robot does the admiring.</p></div>
+      <div class="feat reveal"><h3>Import anything (even a photo)</h3><p>Feed it your old résumé as a PDF, DOCX, or a cursed phone photo — Tesseract OCRs it, the app re-parses it, and politely says nothing about the typos.</p></div>
+      <div class="feat reveal"><h3>11 languages (well, almost)</h3><p>It <i>writes</i> your résumé in 11 — en, de, fr, es, it, tr, pt, ru, zh, ja, ko. The app's own interface speaks two for now, English and German; the other nine are "coming soon," same as my big break. Cosmopolitan failure, localized.</p></div>
       <div class="feat reveal"><h3>Privacy-first</h3><p>OS keychain, local SQLite, zero telemetry. No one is watching you spiral. For once.</p></div>
     </div>
   </div>
@@ -615,7 +617,7 @@ body::after{
   <div class="wall">
     <div class="quote"><p>"I applied to 0 jobs and got 0 rejections. 10/10."</p><span class="who">— a guy</span></div>
     <div class="quote"><p>"haven't felt my hands in weeks. great app."</p><span class="who">— power user</span></div>
-    <div class="quote"><p>"the autopilot got me 6 interviews. i ghosted all of them. we are the same now."</p><span class="who">— finally, revenge</span></div>
+    <div class="quote"><p>"let it write every application. landed 6 interviews. ghosted all of them. we are the same now."</p><span class="who">— finally, revenge</span></div>
     <div class="quote"><p>"my therapist asked where the rage went. it's in the regex now."</p><span class="who">— anonymous</span></div>
     <div class="quote"><p>"downloaded it, my MacBook said the app was 'damaged.' relatable."</p><span class="who">— early adopter</span></div>
     <div class="quote"><p>"I don't have a job but I have a workflow."</p><span class="who">— verified ✓ (not verified)</span></div>
@@ -639,11 +641,11 @@ body::after{
       <path class="dood" d="M100 138 L82 172"/><path class="dood" d="M100 138 L118 172"/>
     </svg>
   </div>
-  <p class="honest">yes, this app is real. yes, it actually scrapes LinkedIn, Indeed, StepStone, Xing, and 14 others. yes, it's built with Tauri + Rust + React 19 + a vector database — because I had a lot of free time, on account of the unemployment. no, I still don't have a job. the autopilot is doing its best.</p>
+  <p class="honest">yes, this app is real. yes, it actually scrapes LinkedIn, Indeed, StepStone, Xing, and 15 others. yes, it's built with Tauri + Rust + React 19 + a vector database + a pure-Rust Typst engine that renders every PDF — because I had a lot of free time, on account of the unemployment. no, it does not auto-apply — it finds the jobs and writes the whole application; hitting submit is the one job left to you. no, I still don't have a job. the autopilot is doing its best.</p>
   <button class="cta" id="cta">ok fine, take the app →</button>
   <a class="src-link" href="https://github.com/saeedkolivand/ai-job-hunter-assistant-app">view the source — it's MIT, like my prospects: open and freely available.</a>
   <p class="footnote">macOS will say the app is "damaged." it's not damaged. it's just unsigned — like a contract I was never offered. run <code>xattr -cr</code> and we move on.</p>
-  <p class="builtwith">Tauri · Rust · React 19 · TanStack · LanceDB · Ollama · pure spite</p>
+  <p class="builtwith">Tauri · Rust · React 19 · TanStack · LanceDB · Typst · Ollama · pure spite</p>
   <p class="byline">made by Saeed, between rejections.</p>
 </section>
 
@@ -743,7 +745,7 @@ body::after{
   AUDIO.bind(document.getElementById('sound-toggle'));
 
   /* ---- loader cycle ---- */
-  var msgs = ["summoning a sad little man…","applying to jobs you didn't ask for…","scraping LinkedIn (allegedly)…","calculating your worth (loading forever)…"];
+  var msgs = ["summoning a sad little man…","drafting applications you didn't ask for…","scraping LinkedIn (allegedly)…","calculating your worth (loading forever)…"];
   var lt = document.getElementById('loader-text'), loader = document.getElementById('loader'), i=0;
   function lift(){ loader.classList.add('gone'); }
   if(reduce){ setTimeout(lift, 500); }
@@ -850,6 +852,38 @@ body::after{
   cta.addEventListener('mouseenter', function(){ fb.textContent="you sure? …ok."; fb.classList.add('show'); });
   cta.addEventListener('mouseleave', function(){ fb.classList.remove('show'); });
   cta.addEventListener('click', function(){ location.href='https://github.com/saeedkolivand/ai-job-hunter-assistant-app'; });
+
+  /* ---- the secret "Are you sure?" dialog: yes / YES do nothing (by design),
+          but the fried guy completely loses it — escalating, reuses the shared
+          voice engine, and finally admits the buttons are fake (you still press
+          send yourself). ---- */
+  (function(){
+    var dlg=document.querySelector('.beat3 .dialog'); if(!dlg) return;
+    var guy=document.querySelector('.beat3-dood'), gb=guy?guy.querySelector('.bubble'):null;
+    var dq=dlg.querySelector('.dq'), y2=dlg.querySelector('.y2');
+    var steps=[
+      {yell:"YESSS",             ask:"…are you SURE sure?"},
+      {yell:"NO TAKEBACKS",      ask:"there is no undo button. you get that?"},
+      {yell:"DOING IT DOING IT", ask:"ok. ok ok ok. okay."},
+      {yell:"IT'S HAPPENING",    ask:"IT'S HAPPENING."},
+      {yell:"…oh",               ask:"(it did nothing. these buttons are fake. you still have to press send yourself. sorry.)"}
+    ];
+    var n=0, gt;
+    dlg.querySelectorAll('button').forEach(function(b){
+      b.addEventListener('click', function(){
+        var s=steps[Math.min(n, steps.length-1)];
+        if(gb){ gb.textContent=s.yell; gb.classList.add('show'); clearTimeout(gt);
+          gt=setTimeout(function(){ gb.classList.remove('show'); }, 1500); }
+        if(guy && !reduce){ guy.classList.remove('flailing'); void guy.offsetWidth;
+          guy.classList.add('flailing'); setTimeout(function(){ guy.classList.remove('flailing'); }, 440); }
+        if(dq) dq.textContent=s.ask;
+        b.style.transform='scale(1.16)'; setTimeout(function(){ b.style.transform=''; }, 150);
+        if(y2) y2.style.fontSize=(13*Math.min(1 + n*0.16, 1.8)).toFixed(0)+'px';
+        AUDIO.say(VOICES.fried, Math.min(n*0.25, 1));
+        n++;
+      });
+    });
+  })();
 
   /* ---- konami: rejections become offers for 3s ---- */
   var seq=[38,38,40,40,37,39,37,39,66,65], pos=0;


### PR DESCRIPTION
## What

Repositions the marketing landing page (`landing/index.html`) from the stale **"IT APPLIES FOR ME"** auto-apply framing to **"IT DOES EVERYTHING ELSE"** — it finds, ranks, and drafts every application; you press send. The apply engine was removed, so the old framing was inaccurate.

## Changes

- Headline + OG/meta copy reframed to "does everything but hit submit"
- Counter reframed: matches found / drafts written / applications you actually sent
- New feature cards: **company research** (provider-native web search), **import anything incl. a photo** (Tesseract OCR), expanded **CLI agents** (Claude Code, Codex, Gemini CLI), and the **pure-Rust Typst** rendering engine + premium template names
- Honesty note now states plainly it does *not* auto-apply
- Adds a secret escalating "are you sure?" dialog that admits the buttons are fake

## Notes

Content-only change to the static landing page — no app code touched.

> ⚠️ Known nit (left as-is per request): board count is written as **19**, but the `SCRAPERS` registry currently has **20** (Glassdoor is the 20th). Not changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)