### PR TITLE
fix: stop cleared number inputs snapping back to 0

### DIFF
--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
@@ -1,5 +1,5 @@
 import { BOARD_IDS } from '@ajh/shared';
-import { Button, cn, Input, LocationInput, SelectDropdown } from '@ajh/ui';
+import { Button, cn, Input, LocationInput, NumberField, SelectDropdown } from '@ajh/ui';
 
 import type { Prefilled, SetFn, WizardState } from '@/features/autopilot/types';
 import { useTranslation } from '@/lib/i18n';
@@ -106,13 +106,13 @@ export function StepTarget({ form, set, prefilled }: StepTargetProps) {
 
       <div className="grid grid-cols-2 gap-3">
         <WizardField label={t('autopilot.wizard.target.pages')}>
-          <Input
-            type="number"
+          <NumberField
             min={1}
             max={10}
+            fallback={1}
             className={inputCls}
             value={form.pages}
-            onChange={(e) => set('pages', Number(e.target.value))}
+            onChange={(n) => set('pages', n)}
           />
         </WizardField>
         <WizardField label={t('autopilot.wizard.target.postedWithin')}>

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.tsx
@@ -1,5 +1,5 @@
 import type { DATE_FILTER_OPTIONS } from '@ajh/shared';
-import { Input, LocationInput, SelectDropdown } from '@ajh/ui';
+import { LocationInput, NumberField, SelectDropdown } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
 
@@ -62,12 +62,12 @@ export function ScrapeFilters({ form, scraping, boardConnected, onFormChange, on
         <label className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/55">
           {t('jobs.pages')}
         </label>
-        <Input
-          type="number"
-          min="1"
-          max="20"
+        <NumberField
+          min={1}
+          max={20}
+          fallback={1}
           value={form.pages}
-          onChange={(e) => onFormChange({ pages: parseInt(e.target.value) || 1 })}
+          onChange={(n) => onFormChange({ pages: n })}
           disabled={scraping}
           className="w-full bg-white/[0.03] text-xs text-foreground disabled:opacity-50"
         />

--- a/packages/ui/src/components/NumberField/NumberField.test.tsx
+++ b/packages/ui/src/components/NumberField/NumberField.test.tsx
@@ -1,0 +1,213 @@
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { NumberField } from './NumberField';
+
+describe('NumberField', () => {
+  it('renders the current value in the field', () => {
+    render(<NumberField aria-label="count" value={42} onChange={vi.fn()} fallback={0} />);
+    expect(screen.getByRole('spinbutton', { name: 'count' })).toHaveValue(42);
+  });
+
+  it('clear-to-empty: leaves the field empty and emits no onChange; typing then emits the new number', async () => {
+    const onChange = vi.fn();
+    render(<NumberField aria-label="count" value={5} onChange={onChange} fallback={0} />);
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    await userEvent.clear(input);
+    expect(input).toHaveValue(null); // empty — NOT 0
+    expect(onChange).not.toHaveBeenCalled();
+
+    await userEvent.type(input, '5');
+    expect(input).toHaveValue(5);
+    expect(onChange).toHaveBeenLastCalledWith(5);
+  });
+
+  it('does not clamp mid-typing: typing a value above max emits the over-limit value while focused', async () => {
+    const onChange = vi.fn();
+    render(<NumberField aria-label="count" value={0} onChange={onChange} max={10} fallback={0} />);
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '15');
+    expect(onChange).toHaveBeenLastCalledWith(15);
+    // Input should still show 15 while the field is focused (no blur yet)
+    expect(input).toHaveValue(15);
+  });
+
+  // -- Blur emissions (each asserts exactly one emission) ----------------------
+
+  it('blur with empty field: displays fallback and emits fallback exactly once', async () => {
+    const onChange = vi.fn();
+    render(<NumberField aria-label="count" value={5} onChange={onChange} fallback={1} />);
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    await userEvent.clear(input);
+    expect(onChange).not.toHaveBeenCalled();
+
+    onChange.mockClear();
+    await userEvent.tab(); // trigger blur
+    expect(input).toHaveValue(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('blur above max: clamps to max and emits max exactly once', async () => {
+    const onChange = vi.fn();
+    render(
+      <NumberField aria-label="count" value={5} onChange={onChange} min={1} max={10} fallback={1} />
+    );
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '99');
+    onChange.mockClear();
+    await userEvent.tab();
+
+    expect(input).toHaveValue(10);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(10);
+  });
+
+  it('blur below min: clamps to min and emits min exactly once', async () => {
+    const onChange = vi.fn();
+    render(
+      <NumberField aria-label="count" value={5} onChange={onChange} min={1} max={10} fallback={1} />
+    );
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '0');
+    onChange.mockClear();
+    await userEvent.tab();
+
+    expect(input).toHaveValue(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('blur within range: emits the unchanged value exactly once', async () => {
+    const onChange = vi.fn();
+    render(
+      <NumberField aria-label="count" value={5} onChange={onChange} min={1} max={10} fallback={1} />
+    );
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '5');
+    onChange.mockClear();
+    await userEvent.tab();
+
+    expect(input).toHaveValue(5);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(5);
+  });
+
+  it('NaN buffer on blur: falls back to fallback and emits fallback exactly once', async () => {
+    const onChange = vi.fn();
+    render(<NumberField aria-label="count" value={5} onChange={onChange} fallback={3} />);
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    // userEvent.type won't type letters into a number input, so drive the
+    // change event directly to force a NaN buffer.
+    fireEvent.change(input, { target: { value: 'abc' } });
+    expect(onChange).not.toHaveBeenCalled();
+
+    onChange.mockClear();
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue(3);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  // -- Resync (external value prop) -------------------------------------------
+
+  it('external resync: rerender with a new value prop updates the displayed buffer without calling onChange', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <NumberField aria-label="count" value={3} onChange={onChange} fallback={0} />
+    );
+    expect(screen.getByRole('spinbutton', { name: 'count' })).toHaveValue(3);
+
+    onChange.mockClear();
+    rerender(<NumberField aria-label="count" value={99} onChange={onChange} fallback={0} />);
+    expect(screen.getByRole('spinbutton', { name: 'count' })).toHaveValue(99);
+    // Resync must NOT emit onChange (infinite-loop guard)
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // -- Negative numbers --------------------------------------------------------
+
+  it('negative numbers: clearing then typing -5 emits -5 (no min set)', async () => {
+    const onChange = vi.fn();
+    render(<NumberField aria-label="count" value={0} onChange={onChange} fallback={0} />);
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '-5');
+    expect(onChange).toHaveBeenLastCalledWith(-5);
+    expect(input).toHaveValue(-5);
+  });
+
+  it('negative numbers: a lone "-" mid-type does not emit onChange', async () => {
+    const onChange = vi.fn();
+    render(<NumberField aria-label="count" value={0} onChange={onChange} fallback={0} />);
+    const input = screen.getByRole('spinbutton', { name: 'count' });
+
+    await userEvent.clear(input);
+    // Drive a raw change so the buffer holds just "-" (not parseable to a number)
+    fireEvent.change(input, { target: { value: '-' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // -- Pass-through attributes -------------------------------------------------
+
+  it('passes through aria-label, className, disabled, and step', () => {
+    render(
+      <NumberField
+        aria-label="seats"
+        value={2}
+        onChange={vi.fn()}
+        fallback={0}
+        disabled
+        step={0.5}
+        className="extra-class"
+      />
+    );
+    const input = screen.getByRole('spinbutton', { name: 'seats' });
+    expect(input).toBeDisabled();
+    expect(input.className).toContain('extra-class');
+    expect(input).toHaveAttribute('step', '0.5');
+  });
+
+  // -- onBlur forwarding -------------------------------------------------------
+
+  it('forwards a caller-supplied onBlur with the blur event after its own handler runs', async () => {
+    const onBlur = vi.fn();
+    render(
+      <NumberField aria-label="amount" value={3} onChange={vi.fn()} fallback={0} onBlur={onBlur} />
+    );
+    const input = screen.getByRole('spinbutton', { name: 'amount' });
+    await userEvent.click(input);
+    await userEvent.tab(); // triggers blur → internal handleBlur → rest.onBlur?.(e)
+
+    expect(onBlur).toHaveBeenCalledTimes(1);
+    // The forwarded argument must be the actual FocusEvent, not undefined
+    expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({ type: 'blur' }));
+  });
+
+  // -- ref forwarding ----------------------------------------------------------
+
+  it('forwards ref to the underlying input element', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<NumberField aria-label="count" value={7} onChange={vi.fn()} fallback={0} ref={ref} />);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('INPUT');
+    // Ref must point at the same DOM node that testing-library resolves
+    expect(ref.current).toBe(screen.getByRole('spinbutton', { name: 'count' }));
+  });
+});

--- a/packages/ui/src/components/NumberField/NumberField.tsx
+++ b/packages/ui/src/components/NumberField/NumberField.tsx
@@ -1,0 +1,109 @@
+import { type ComponentProps, forwardRef, useEffect, useRef, useState } from 'react';
+
+import { Input } from '../Input';
+
+export interface NumberFieldProps extends Omit<
+  ComponentProps<typeof Input>,
+  'type' | 'value' | 'onChange' | 'min' | 'max' | 'step'
+> {
+  /** Current numeric value (controlled). */
+  value: number;
+  /**
+   * Emitted when the buffer parses to a finite number, and again (clamped) on
+   * blur. Clamping to `[min, max]` is blur-only, so values emitted **while
+   * typing may fall outside `[min, max]`** — callers persisting the value must
+   * not assume it is in-range mid-edit (it is reconciled on blur).
+   */
+  onChange: (value: number) => void;
+  /** Lower clamp bound, applied on blur only. */
+  min?: number;
+  /** Upper clamp bound, applied on blur only. */
+  max?: number;
+  /** Native step. */
+  step?: number;
+  /** Value to fall back to when the field is left empty / invalid on blur. */
+  fallback: number;
+}
+
+const clamp = (n: number, min?: number, max?: number): number => {
+  let out = n;
+  if (typeof min === 'number') out = Math.max(min, out);
+  if (typeof max === 'number') out = Math.min(max, out);
+  return out;
+};
+
+/**
+ * Numeric input that keeps an internal string buffer so the field can be empty
+ * or mid-edit while the user types — fixing the "can't clear the 0" bug where
+ * `Number('') === 0` snaps controlled inputs back to `0` and traps the cursor.
+ *
+ * - While typing: emits `onChange` only when the buffer parses to a finite
+ *   number; never clamps mid-typing so intermediate values aren't blocked.
+ *   Because clamping is blur-only, mid-edit `onChange` values may be outside
+ *   `[min, max]` — don't treat the value as in-range until blur.
+ * - On blur: empty/NaN → `fallback`; otherwise clamps to `[min, max]`.
+ * - Resyncs the buffer when the external `value` changes (e.g. a prefill).
+ *
+ * Forwards `ref` to the underlying `<input>` element.
+ */
+export const NumberField = forwardRef<HTMLInputElement, NumberFieldProps>(function NumberField(
+  { value, onChange, min, max, step, fallback, ...rest },
+  ref
+) {
+  const [buffer, setBuffer] = useState(() => String(value));
+  // Tracks the numeric value the buffer currently represents, so the resync
+  // effect can compare against an external `value` change without depending on
+  // (and re-running for) every keystroke.
+  const lastValueRef = useRef(value);
+
+  // Resync when the controlled value changes externally (prefill, "use
+  // suggested", programmatic reset) to something the buffer isn't reflecting.
+  useEffect(() => {
+    if (value !== lastValueRef.current) {
+      lastValueRef.current = value;
+      setBuffer(String(value));
+    }
+  }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    setBuffer(next);
+    if (next.trim() === '') return; // allow empty while typing — don't emit
+    const parsed = Number(next);
+    if (Number.isFinite(parsed)) {
+      lastValueRef.current = parsed;
+      onChange(parsed);
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const parsed = Number(buffer);
+    if (buffer.trim() === '' || !Number.isFinite(parsed)) {
+      setBuffer(String(fallback));
+      lastValueRef.current = fallback;
+      onChange(fallback);
+    } else {
+      const clamped = clamp(parsed, min, max);
+      setBuffer(String(clamped));
+      lastValueRef.current = clamped;
+      onChange(clamped);
+    }
+    rest.onBlur?.(e);
+  };
+
+  return (
+    <Input
+      {...rest}
+      ref={ref}
+      type="number"
+      min={min}
+      max={max}
+      step={step}
+      value={buffer}
+      onChange={handleChange}
+      onBlur={handleBlur}
+    />
+  );
+});
+
+NumberField.displayName = 'NumberField';

--- a/packages/ui/src/components/NumberField/index.ts
+++ b/packages/ui/src/components/NumberField/index.ts
@@ -1,0 +1,1 @@
+export * from './NumberField';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -28,6 +28,7 @@ export { IconBadge, type IconBadgeProps } from './components/IconBadge/index';
 export { IconText } from './components/IconText/index';
 export { Input, type InputProps } from './components/Input/index';
 export { LocationInput, type LocationInputProps } from './components/LocationInput/index';
+export { NumberField, type NumberFieldProps } from './components/NumberField/index';
 export { ProgressBar, type ProgressBarProps } from './components/ProgressBar/index';
 export { RefreshButton } from './components/RefreshButton/index';
 export { SectionHeader } from './components/SectionHeader/index';


### PR DESCRIPTION
## What

`type="number"` fields used `onChange={(e) => set(x, Number(e.target.value))}`. Because `Number('') === 0`, clearing a field snapped it back to `0` and the `0` couldn't be deleted to retype — most visibly the Autopilot wizard's **Pages to scrape** input.

## Fix

A shared `@ajh/ui` primitive, **`NumberField`**, fixes the whole class:

- keeps an internal **string buffer**, so the field can be empty / mid-edit while typing
- emits `onChange` only when the buffer parses to a finite number (never clamps mid-typing)
- on **blur**: clamps to `[min, max]`, or applies `fallback` when left empty/invalid
- **resyncs** the buffer when the controlled `value` changes externally (prefill/reset), via a ref guard so it doesn't re-run per keystroke
- `forwardRef` to the underlying input

Migrated the **two genuine `type="number"` fields** to it:
- `StepTarget` — pages (`1–10`, fallback `1`)
- `ScrapeFilters` — pages (`1–20`, fallback `1`)

The other numeric controls (`minMatchScore`, local-model `contextWindow`/`maxTokens`) are `<input type="range">` **sliders**, which can't reach this bug (and CLAUDE.md permits raw range inputs), so they're intentionally left unchanged.

## Tests

`packages/ui/src/components/NumberField/NumberField.test.tsx` — clear-to-empty (the core bug), no-emit-while-empty, no-mid-typing-clamp, blur→fallback, blur→clamp (min & max, asserting a single emission), blur-within-range, **external resync must not emit** (infinite-loop guard), NaN-on-blur, negative numbers, `step` pass-through, `onBlur` event forwarding, and ref forwarding. Full `@ajh/ui` suite green (154 tests); `lint:strict` clean.

## Review

Implemented and reviewed via the agent pipeline: `frontend-reviewer` (no HIGH/CRITICAL) + `testing-reviewer` (HIGH findings resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)