### PR TITLE
feat: edit generated text before export with inline ai rewrite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ ESLint errors on inline `{ duration, ease }` objects in feature/route files.
 | ------------------- | -------------------------------------------------- |
 | Button              | `Button` from `@ajh/ui`                            |
 | Input / Textarea    | `Input` / `TextArea` from `@ajh/ui`                |
+| Number input        | `NumberField` from `@ajh/ui`                       |
 | Dropdown            | `SelectDropdown` from `@ajh/ui`                    |
 | Modal / Confirm     | `ModalShell` / `ConfirmModal` from `@ajh/ui`       |
 | Empty / Error state | `EmptyState` / `ErrorState` from `@ajh/ui`         |

--- a/apps/tauri/src-tauri/src/ai_generations/mod.rs
+++ b/apps/tauri/src-tauri/src/ai_generations/mod.rs
@@ -279,6 +279,48 @@ impl AiGenerationStore {
             .map_err(|e| e.to_string())?;
         Ok(())
     }
+
+    /// Edit the résumé and/or cover-letter text of an existing row, selected by
+    /// `id`. Unlike the per-job merge-upsert ([`save_application`]) this is a
+    /// direct overwrite of exactly the provided fields, so a user editing a saved
+    /// generation can blank out or fully replace text the merge would have kept.
+    /// Each `None` field is left untouched; passing both `None` is a no-op.
+    /// (The schema has no `updated_at` column, so there is no timestamp to bump.)
+    pub fn update_texts(
+        &self,
+        id: &str,
+        resume_text: Option<String>,
+        cover_letter_text: Option<String>,
+    ) -> AppResult<()> {
+        let conn = self.conn.lock();
+        let changed = match (resume_text, cover_letter_text) {
+            (Some(resume), Some(cover)) => conn
+                .execute(
+                    "UPDATE ai_generations SET resume_text = ?2, cover_letter_text = ?3 WHERE id = ?1",
+                    params![id, resume, cover],
+                )
+                .map_err(|e| e.to_string())?,
+            (Some(resume), None) => conn
+                .execute(
+                    "UPDATE ai_generations SET resume_text = ?2 WHERE id = ?1",
+                    params![id, resume],
+                )
+                .map_err(|e| e.to_string())?,
+            (None, Some(cover)) => conn
+                .execute(
+                    "UPDATE ai_generations SET cover_letter_text = ?2 WHERE id = ?1",
+                    params![id, cover],
+                )
+                .map_err(|e| e.to_string())?,
+            // Both fields absent: no UPDATE is issued, so there is no
+            // rows-changed count to check — an explicit no-op success.
+            (None, None) => return Ok(()),
+        };
+        if changed == 0 {
+            return Err(format!("generation not found: {id}").into());
+        }
+        Ok(())
+    }
 }
 
 /// Map a DB row (the full 18-column projection) to a record. Shared by `list`

--- a/apps/tauri/src-tauri/src/ai_generations/test.rs
+++ b/apps/tauri/src-tauri/src/ai_generations/test.rs
@@ -165,3 +165,122 @@ fn save_application_inserts_separate_rows_when_unlinked() {
         "manual (unlinked) saves stay separate"
     );
 }
+
+// ── update_texts tests (F1 edit-before-export) ────────────────────────────────
+
+#[test]
+fn update_texts_resume_only_leaves_cover_untouched() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    store.insert(&record("g1", "")).unwrap();
+
+    store
+        .update_texts("g1", Some("new resume".into()), None)
+        .unwrap();
+
+    let list = store.list();
+    assert_eq!(list[0].resume_text, "new resume");
+    assert_eq!(list[0].cover_letter_text, "C", "cover must be untouched");
+}
+
+#[test]
+fn update_texts_cover_only_leaves_resume_untouched() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    store.insert(&record("g1", "")).unwrap();
+
+    store
+        .update_texts("g1", None, Some("new cover".into()))
+        .unwrap();
+
+    let list = store.list();
+    assert_eq!(list[0].resume_text, "R", "resume must be untouched");
+    assert_eq!(list[0].cover_letter_text, "new cover");
+}
+
+#[test]
+fn update_texts_both_fields_updates_both() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    store.insert(&record("g1", "")).unwrap();
+
+    store
+        .update_texts(
+            "g1",
+            Some("updated resume".into()),
+            Some("updated cover".into()),
+        )
+        .unwrap();
+
+    let list = store.list();
+    assert_eq!(list[0].resume_text, "updated resume");
+    assert_eq!(list[0].cover_letter_text, "updated cover");
+}
+
+#[test]
+fn update_texts_both_none_is_a_noop_and_returns_ok() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+    store.insert(&record("g1", "")).unwrap();
+
+    // Both-None must succeed without issuing an UPDATE — no rows-changed path.
+    store.update_texts("g1", None, None).unwrap();
+
+    let list = store.list();
+    assert_eq!(list[0].resume_text, "R", "resume unchanged");
+    assert_eq!(list[0].cover_letter_text, "C", "cover unchanged");
+}
+
+#[test]
+fn update_texts_unknown_id_resume_only_returns_err() {
+    // (Some(resume), None) arm — rows==0 guard must surface an Err.
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+
+    let result = store.update_texts("does-not-exist", Some("x".into()), None);
+    assert!(
+        result.is_err(),
+        "must return Err for an unknown id (resume-only arm)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("does-not-exist"),
+        "error message must include the id: {msg}"
+    );
+}
+
+#[test]
+fn update_texts_unknown_id_cover_only_returns_err() {
+    // (None, Some(cover)) arm — each arm has its own rows==0 guard.
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+
+    let result = store.update_texts("does-not-exist", None, Some("y".into()));
+    assert!(
+        result.is_err(),
+        "must return Err for an unknown id (cover-only arm)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("does-not-exist"),
+        "error message must include the id: {msg}"
+    );
+}
+
+#[test]
+fn update_texts_unknown_id_both_fields_returns_err() {
+    // (Some(resume), Some(cover)) arm — rows==0 guard must also fire here.
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+
+    let result = store.update_texts("does-not-exist", Some("x".into()), Some("y".into()));
+    assert!(
+        result.is_err(),
+        "must return Err for an unknown id (both-fields arm)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("does-not-exist"),
+        "error message must include the id: {msg}"
+    );
+}

--- a/apps/tauri/src-tauri/src/commands/ai_generations.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_generations.rs
@@ -1,7 +1,7 @@
 use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 
-use crate::ipc_contracts::ai::AiGenerationSaveRequest;
+use crate::ipc_contracts::ai::{AiGenerationSaveRequest, AiGenerationUpdateRequest};
 
 #[tauri::command]
 pub async fn ai_generations_list(app: AppHandle) -> Value {
@@ -46,6 +46,18 @@ pub async fn ai_generations_save(app: AppHandle, req: AiGenerationSaveRequest) -
     // résumé/cover/answers/brief from separate actions land on one record.
     match store.save_application(rec) {
         Ok(id) => json!({ "id": id, "success": true }),
+        Err(e) => json!({ "error": e }),
+    }
+}
+
+#[tauri::command]
+pub async fn ai_generations_update(app: AppHandle, req: AiGenerationUpdateRequest) -> Value {
+    let store = app.state::<crate::ai_generations::AiGenerationStore>();
+    // Direct overwrite of exactly the provided text fields, selected by id —
+    // distinct from the save merge-upsert, so a user edit can replace text the
+    // merge would have kept.
+    match store.update_texts(&req.id, req.resume_text, req.cover_letter_text) {
+        Ok(()) => json!({ "success": true }),
         Err(e) => json!({ "error": e }),
     }
 }

--- a/apps/tauri/src-tauri/src/ipc_contracts/ai.rs
+++ b/apps/tauri/src-tauri/src/ipc_contracts/ai.rs
@@ -85,6 +85,15 @@ pub struct AiGenerationSaveRequestApplicationAnswer {
     pub answer: String,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct AiGenerationUpdateRequest {
+    pub id: String,
+    pub resume_text: Option<String>,
+    pub cover_letter_text: Option<String>,
+}
+
 fn default_ai_generation_save_request_candidate_name() -> String {
     "".to_string()
 }

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -404,6 +404,7 @@ fn main() {
             // ai generations
             commands::ai_generations::ai_generations_list,
             commands::ai_generations::ai_generations_save,
+            commands::ai_generations::ai_generations_update,
             commands::ai_generations::ai_generations_remove,
             // profile import
             commands::profile_import::profile_import_from_url,

--- a/apps/tauri/src/renderer/components/generation/EditableOutput/EditableOutput.test.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/EditableOutput.test.tsx
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import type * as AjhUi from '@ajh/ui';
+
+import type * as Generate from '@/lib/generate';
+
+import { EditableOutput } from './index';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+// useFocusTrap needs a stable ref-like object — return a callback ref that is
+// compatible with the `ref={trapRef as React.RefObject<HTMLDivElement>}` cast.
+vi.mock('@ajh/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof AjhUi>();
+  return {
+    ...actual,
+    useFocusTrap: () => ({ current: null }),
+  };
+});
+
+// Stub the model selector — the component calls this on every render.
+vi.mock('@/components/ui/ModelSelector', () => ({
+  useSelectedModel: () => 'test-model',
+}));
+
+vi.mock('@/lib/i18n', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+// rewriteSelection is the only async side-effect we need to control.
+const mockRewriteSelection = vi.fn();
+vi.mock('@/lib/generate', async (importOriginal) => {
+  const actual = await importOriginal<typeof Generate>();
+  return {
+    ...actual,
+    rewriteSelection: (...args: Parameters<typeof mockRewriteSelection>) =>
+      mockRewriteSelection(...args),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const FULL_TEXT = 'Hello world. This is the middle part. Goodbye world.';
+// selection covers "This is the middle part." (characters 13–37)
+const SEL_START = 13;
+const SEL_END = 37;
+const REPLACEMENT = 'This is the REPLACED part.';
+
+/** Switch EditableOutput from its default Preview view to Edit view. */
+function switchToEdit() {
+  fireEvent.click(screen.getByRole('radio', { name: /edit/i }));
+}
+
+/**
+ * Simulate a text selection in the Edit textarea.
+ * jsdom does not fire native selection events from programmatic setSelectionRange,
+ * so we set selectionStart/End directly and dispatch the mouseUp event that
+ * EditableOutput's `onMouseUp={updateSelection}` handler listens to.
+ */
+function simulateSelection(start: number, end: number) {
+  // The textarea is the only <textarea> element; the popover has an <input>.
+  const textarea = screen.getByRole<HTMLTextAreaElement>('textbox');
+  Object.defineProperty(textarea, 'selectionStart', { writable: true, value: start });
+  Object.defineProperty(textarea, 'selectionEnd', { writable: true, value: end });
+  fireEvent.mouseUp(textarea);
+}
+
+function openRewritePopover() {
+  fireEvent.click(screen.getByRole('button', { name: /aiGenerate\.rewrite\.trigger/i }));
+}
+
+/**
+ * Returns the <textarea> element — there is exactly one in Edit mode before the
+ * popover opens. After the popover opens the popover's <input> is also a textbox
+ * so use `getAllByRole` + find by tag.
+ */
+function getTextarea(): HTMLTextAreaElement {
+  const el = screen
+    .getAllByRole('textbox')
+    .find((e): e is HTMLTextAreaElement => e.tagName === 'TEXTAREA');
+  if (!el) throw new Error('No <textarea> found in the rendered output');
+  return el;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('EditableOutput — F4 inline rewrite splice', () => {
+  let onChange: Mock<(value: string) => void>;
+
+  beforeEach(() => {
+    onChange = vi.fn<(value: string) => void>();
+    mockRewriteSelection.mockReset();
+  });
+
+  it('selecting a range + accepting a rewrite splices exactly [start,end) with the replacement', async () => {
+    // Arrange: rewriteSelection calls onToken once then resolves the full result.
+    mockRewriteSelection.mockImplementation(
+      async ({ onToken }: { onToken: (tok: string) => void }) => {
+        onToken(REPLACEMENT);
+        return REPLACEMENT;
+      }
+    );
+
+    render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
+
+    switchToEdit();
+    simulateSelection(SEL_START, SEL_END);
+    openRewritePopover();
+
+    // Click a preset to start the rewrite.
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /aiGenerate\.rewrite\.presets\.shorten/i })
+      );
+    });
+
+    // Wait for streaming to finish and Accept to be enabled.
+    const acceptBtn = screen.getByRole('button', { name: /aiGenerate\.rewrite\.accept/i });
+    await waitFor(() => expect(acceptBtn).not.toBeDisabled());
+
+    fireEvent.click(acceptBtn);
+
+    // onChange must receive the splice: text before + replacement + text after.
+    const expected = FULL_TEXT.slice(0, SEL_START) + REPLACEMENT + FULL_TEXT.slice(SEL_END);
+    expect(onChange).toHaveBeenCalledWith(expected);
+
+    // Surrounding context is intact.
+    const [firstCall] = onChange.mock.calls;
+    if (!firstCall) throw new Error('onChange was not called');
+    const result = firstCall[0];
+    expect(result.startsWith('Hello world. ')).toBe(true);
+    expect(result.endsWith(' Goodbye world.')).toBe(true);
+  });
+
+  it('splice at offset 0 (selection starts at the very beginning of text)', async () => {
+    mockRewriteSelection.mockImplementation(
+      async ({ onToken }: { onToken: (tok: string) => void }) => {
+        onToken('PREFIX');
+        return 'PREFIX';
+      }
+    );
+
+    // Selection covers the first 5 characters: "Hello"
+    const START_BOUNDARY = 0;
+    const END_BOUNDARY = 5;
+
+    render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
+
+    switchToEdit();
+    simulateSelection(START_BOUNDARY, END_BOUNDARY);
+    openRewritePopover();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /aiGenerate\.rewrite\.presets\.shorten/i })
+      );
+    });
+
+    const acceptBtn = screen.getByRole('button', { name: /aiGenerate\.rewrite\.accept/i });
+    await waitFor(() => expect(acceptBtn).not.toBeDisabled());
+
+    fireEvent.click(acceptBtn);
+
+    // Expected: '' + 'PREFIX' + FULL_TEXT.slice(5)
+    const expected = '' + 'PREFIX' + FULL_TEXT.slice(END_BOUNDARY);
+    expect(onChange).toHaveBeenCalledWith(expected);
+    // Sanity: result starts with the replacement, not original text.
+    const [firstCall] = onChange.mock.calls;
+    if (!firstCall) throw new Error('onChange was not called');
+    expect(firstCall[0].startsWith('PREFIX')).toBe(true);
+  });
+
+  it('splice ending at text.length (selection ends at the very end of text)', async () => {
+    mockRewriteSelection.mockImplementation(
+      async ({ onToken }: { onToken: (tok: string) => void }) => {
+        onToken('SUFFIX');
+        return 'SUFFIX';
+      }
+    );
+
+    // Selection covers the last 14 characters: "Goodbye world."
+    const END_BOUNDARY = FULL_TEXT.length;
+    const START_BOUNDARY = END_BOUNDARY - 14;
+
+    render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
+
+    switchToEdit();
+    simulateSelection(START_BOUNDARY, END_BOUNDARY);
+    openRewritePopover();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /aiGenerate\.rewrite\.presets\.shorten/i })
+      );
+    });
+
+    const acceptBtn = screen.getByRole('button', { name: /aiGenerate\.rewrite\.accept/i });
+    await waitFor(() => expect(acceptBtn).not.toBeDisabled());
+
+    fireEvent.click(acceptBtn);
+
+    // Expected: FULL_TEXT.slice(0, START_BOUNDARY) + 'SUFFIX' + '' (empty after-slice)
+    const expected = FULL_TEXT.slice(0, START_BOUNDARY) + 'SUFFIX';
+    expect(onChange).toHaveBeenCalledWith(expected);
+    const [firstCall] = onChange.mock.calls;
+    if (!firstCall) throw new Error('onChange was not called');
+    expect(firstCall[0].endsWith('SUFFIX')).toBe(true);
+  });
+
+  it('Cancel leaves onChange uncalled and text unchanged', () => {
+    mockRewriteSelection.mockImplementation(async () => REPLACEMENT);
+
+    render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
+
+    switchToEdit();
+    simulateSelection(SEL_START, SEL_END);
+    openRewritePopover();
+
+    // Two Cancel controls exist: the X icon in the header and the text button in
+    // the footer — both call onClose. Click the first (header X).
+    const cancelBtns = screen.getAllByRole('button', { name: /aiGenerate\.rewrite\.cancel/i });
+    const [firstCancel] = cancelBtns;
+    if (!firstCancel) throw new Error('no cancel button rendered');
+    fireEvent.click(firstCancel);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('stream rejection: onChange is NOT called, error is surfaced, Accept is disabled', async () => {
+    // Make rewriteSelection reject outright — simulates a network or provider failure.
+    mockRewriteSelection.mockImplementation(() => Promise.reject(new Error('provider error')));
+
+    render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
+
+    switchToEdit();
+    simulateSelection(SEL_START, SEL_END);
+    openRewritePopover();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /aiGenerate\.rewrite\.presets\.shorten/i })
+      );
+    });
+
+    // The popover's .catch() at ~line 119 sets an error string — it must appear in the DOM.
+    // (The rendered error text comes from the 'aiGenerate.rewrite.failed' i18n key, which
+    // our stub returns verbatim as the key itself.)
+    await waitFor(() => {
+      expect(screen.getByText('aiGenerate.rewrite.failed')).toBeInTheDocument();
+    });
+
+    // Accept must be disabled — canAccept = !streaming && !!result.trim() && !error.
+    const acceptBtn = screen.getByRole('button', { name: /aiGenerate\.rewrite\.accept/i });
+    expect(acceptBtn).toBeDisabled();
+
+    // onChange must never have been called — the selection text must not be deleted.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('empty/whitespace result: onChange is NOT called, error is surfaced, Accept is disabled', async () => {
+    // Resolve with only whitespace — the popover trims and checks !cleaned in the .then().
+    mockRewriteSelection.mockImplementation(
+      async ({ onToken }: { onToken: (tok: string) => void }) => {
+        onToken('   ');
+        return '   ';
+      }
+    );
+
+    render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
+
+    switchToEdit();
+    simulateSelection(SEL_START, SEL_END);
+    openRewritePopover();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /aiGenerate\.rewrite\.presets\.shorten/i })
+      );
+    });
+
+    // The .then() guard: `if (!cleaned) setError(t('aiGenerate.rewrite.empty'))`.
+    await waitFor(() => {
+      expect(screen.getByText('aiGenerate.rewrite.empty')).toBeInTheDocument();
+    });
+
+    // Accept must be disabled — prevents silently deleting the selected text.
+    const acceptBtn = screen.getByRole('button', { name: /aiGenerate\.rewrite\.accept/i });
+    expect(acceptBtn).toBeDisabled();
+
+    // onChange must never have been called.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('textarea is readOnly (not disabled) while a rewrite streams', async () => {
+    // Keep the stream unresolved so we can inspect the locked state mid-flight.
+    let resolveStream!: (v: string) => void;
+    mockRewriteSelection.mockImplementation(
+      async ({ onToken }: { onToken: (tok: string) => void }) => {
+        onToken('partial…');
+        return new Promise<string>((res) => {
+          resolveStream = res;
+        });
+      }
+    );
+
+    render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
+
+    switchToEdit();
+    simulateSelection(SEL_START, SEL_END);
+    openRewritePopover();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /aiGenerate\.rewrite\.presets\.shorten/i })
+      );
+    });
+
+    // The textarea must be readOnly (accessible) rather than disabled (hidden from
+    // screen readers) while the popover is showing.
+    const textarea = getTextarea();
+    expect(textarea).toHaveAttribute('readonly');
+    expect(textarea).not.toBeDisabled();
+
+    // Resolve so the component can clean up without act() warnings.
+    await act(async () => {
+      resolveStream(REPLACEMENT);
+    });
+  });
+});

--- a/apps/tauri/src/renderer/components/generation/EditableOutput/RewritePopover.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/RewritePopover.tsx
@@ -1,0 +1,276 @@
+import { Check, Loader2, Sparkles, X } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useEffect, useRef, useState } from 'react';
+
+import { Button, Input, transition, useFocusTrap } from '@ajh/ui';
+
+import { type RewriteDocType, rewriteSelection } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+
+/** The quick-action presets — id maps to an i18n label + a preset instruction. */
+const PRESETS = ['shorten', 'expand', 'rephrase', 'impact', 'grammar'] as const;
+type Preset = (typeof PRESETS)[number];
+
+export interface RewriteTarget {
+  /** The frozen selection text being rewritten. */
+  selection: string;
+  /** Frozen text before the selection (context, never rewritten). */
+  before: string;
+  /** Frozen text after the selection (context, never rewritten). */
+  after: string;
+}
+
+interface RewritePopoverProps {
+  target: RewriteTarget;
+  docType: RewriteDocType;
+  model: string;
+  /** Document language (the generation's `meta.targetLanguage`) so the rewrite
+   *  streams in the same language as the document. Defaults to 'en'. */
+  locale?: string;
+  /** Called with the accepted replacement text for the frozen range. */
+  onAccept: (replacement: string) => void;
+  /** Called to dismiss the popover (Cancel / Escape / backdrop). */
+  onClose: () => void;
+}
+
+/**
+ * Floating rewrite popover (F4). Streams an AI rewrite of the frozen selection
+ * into its own preview (never the textarea), and on Accept hands the result back
+ * to the caller to splice into the raw text. A single rewrite is in flight at a
+ * time — starting a new one (preset, submit, or regenerate) aborts the previous
+ * via an AbortController. Modal + keyboard accessible: it traps focus while open
+ * (reusing `useFocusTrap` from @ajh/ui — the same mechanism ModalShell uses),
+ * autofocuses the instruction field, closes on Escape from anywhere, restores
+ * focus to the trigger on close (handled by the caller), and the actions are
+ * real buttons.
+ */
+export function RewritePopover({
+  target,
+  docType,
+  model,
+  locale = 'en',
+  onAccept,
+  onClose,
+}: RewritePopoverProps) {
+  const { t } = useTranslation();
+  const [instruction, setInstruction] = useState('');
+  const [streaming, setStreaming] = useState(false);
+  const [result, setResult] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  // Trap keyboard focus inside the popover while it is open so Tab cannot escape
+  // into the page behind it. `useFocusTrap` also auto-focuses the first focusable
+  // element; we still explicitly focus the instruction field below.
+  const trapRef = useFocusTrap(true);
+
+  // The instruction that produced the current result — lets Regenerate re-run the
+  // same instruction without the user retyping it.
+  const lastInstructionRef = useRef('');
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    // Abort any in-flight rewrite when the popover unmounts.
+    return () => abortRef.current?.abort();
+  }, []);
+
+  // Escape closes from anywhere while the popover is open — not only when focus is
+  // inside it (a bare onKeyDown on the dialog misses clicks/focus elsewhere).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const run = (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed || streaming) return;
+    // Single in-flight rewrite — abort the previous before starting a new one.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    lastInstructionRef.current = trimmed;
+    setError(null);
+    setResult('');
+    setStreaming(true);
+
+    rewriteSelection({
+      selection: target.selection,
+      instruction: trimmed,
+      before: target.before,
+      after: target.after,
+      docType,
+      model,
+      locale,
+      onToken: (tok) => setResult((prev) => prev + tok),
+      signal: controller.signal,
+    })
+      .then((full) => {
+        if (controller.signal.aborted) return;
+        const cleaned = full.trim();
+        setResult(cleaned);
+        if (!cleaned) setError(t('aiGenerate.rewrite.empty'));
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        setError(t('aiGenerate.rewrite.failed'));
+      })
+      .finally(() => {
+        // Only clear `streaming` for the run that owns the current controller. A
+        // newer run() has already set `streaming = true` and swapped `abortRef`;
+        // clearing unconditionally here would re-enable the buttons mid-flight.
+        // Guarding on the controller (rather than `aborted`) also re-enables the
+        // buttons after an abort that wasn't followed by a new run — so a cancelled
+        // rewrite never wedges the UI with permanently disabled buttons.
+        if (abortRef.current === controller) setStreaming(false);
+      });
+  };
+
+  const onPreset = (preset: Preset) => {
+    const presetInstruction = t(`aiGenerate.rewrite.presetInstructions.${preset}`);
+    setInstruction(presetInstruction);
+    run(presetInstruction);
+  };
+
+  const canAccept = !streaming && !!result.trim() && !error;
+
+  return (
+    <motion.div
+      ref={trapRef as React.RefObject<HTMLDivElement>}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('aiGenerate.rewrite.title')}
+      initial={{ opacity: 0, y: 6, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: 6, scale: 0.98 }}
+      transition={transition.fast}
+      className="w-[22rem] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-white/10 bg-secondary shadow-2xl"
+    >
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-3 py-2">
+        <span className="flex items-center gap-1.5 text-[11px] font-medium text-foreground/70">
+          <Sparkles size={12} className="text-brand-soft" />
+          {t('aiGenerate.rewrite.title')}
+        </span>
+        <Button
+          variant="unstyled"
+          type="button"
+          onClick={onClose}
+          aria-label={t('aiGenerate.rewrite.cancel')}
+          className="rounded p-0.5 text-foreground/40 transition-colors hover:text-foreground/80"
+        >
+          <X size={13} />
+        </Button>
+      </div>
+
+      <div className="space-y-2.5 px-3 py-2.5">
+        {/* Selected text — read-only echo so the user knows what will change. */}
+        <div>
+          <p className="mb-1 text-[9px] font-semibold uppercase tracking-wider text-foreground/35">
+            {t('aiGenerate.rewrite.selectionLabel')}
+          </p>
+          <p className="max-h-16 overflow-y-auto whitespace-pre-wrap rounded-md bg-white/[0.03] px-2 py-1.5 text-[11px] leading-relaxed text-foreground/55">
+            {target.selection}
+          </p>
+        </div>
+
+        {/* Quick-action chips */}
+        <div className="flex flex-wrap gap-1">
+          {PRESETS.map((preset) => (
+            <Button
+              key={preset}
+              variant="unstyled"
+              type="button"
+              disabled={streaming}
+              onClick={() => onPreset(preset)}
+              className="rounded-full border border-white/[0.08] bg-white/[0.03] px-2 py-0.5 text-[10px] text-foreground/60 transition-colors hover:border-brand/30 hover:text-brand-soft disabled:opacity-40 disabled:pointer-events-none"
+            >
+              {t(`aiGenerate.rewrite.presets.${preset}`)}
+            </Button>
+          ))}
+        </div>
+
+        {/* Free instruction + submit */}
+        <div className="flex items-center gap-1.5">
+          <Input
+            ref={inputRef}
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                run(instruction);
+              }
+            }}
+            disabled={streaming}
+            placeholder={t('aiGenerate.rewrite.instructionPlaceholder')}
+            aria-label={t('aiGenerate.rewrite.instructionLabel')}
+            className="flex-1 text-[11px]"
+          />
+          <Button
+            type="button"
+            disabled={streaming || !instruction.trim()}
+            onClick={() => run(instruction)}
+            className="flex h-auto items-center gap-1 rounded-lg bg-brand/15 px-2.5 py-1.5 text-[11px] font-medium text-brand-soft transition-colors hover:bg-brand/20 disabled:opacity-40 disabled:pointer-events-none"
+          >
+            {streaming ? <Loader2 size={11} className="animate-spin" /> : null}
+            {t('aiGenerate.rewrite.submit')}
+          </Button>
+        </div>
+
+        {/* Streaming preview / result */}
+        {(streaming || result || error) && (
+          <div>
+            <p className="mb-1 flex items-center gap-1 text-[9px] font-semibold uppercase tracking-wider text-foreground/35">
+              {streaming && <Loader2 size={9} className="animate-spin" />}
+              {streaming ? t('aiGenerate.rewrite.streaming') : t('aiGenerate.rewrite.resultLabel')}
+            </p>
+            {error ? (
+              <p className="rounded-md bg-red-400/10 px-2 py-1.5 text-[11px] text-red-300">
+                {error}
+              </p>
+            ) : (
+              <p className="max-h-32 overflow-y-auto whitespace-pre-wrap rounded-md border border-brand/15 bg-brand/[0.04] px-2 py-1.5 text-[11px] leading-relaxed text-foreground/80">
+                {result || '…'}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-end gap-2 border-t border-white/[0.06] px-3 py-2">
+        <Button
+          variant="unstyled"
+          type="button"
+          onClick={onClose}
+          className="rounded-lg px-2 py-1 text-[11px] text-foreground/50 transition-colors hover:text-foreground/80"
+        >
+          {t('aiGenerate.rewrite.cancel')}
+        </Button>
+        {result && !streaming && (
+          <Button
+            type="button"
+            onClick={() => run(lastInstructionRef.current)}
+            className="rounded-lg border-transparent bg-white/[0.05] px-2.5 py-1 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto"
+          >
+            {t('aiGenerate.rewrite.regenerate')}
+          </Button>
+        )}
+        <Button
+          type="button"
+          disabled={!canAccept}
+          onClick={() => onAccept(result.trim())}
+          className="flex h-auto items-center gap-1 rounded-lg bg-brand/15 px-2.5 py-1 text-[11px] font-medium text-brand-soft transition-colors hover:bg-brand/20 disabled:opacity-40 disabled:pointer-events-none"
+        >
+          <Check size={11} />
+          {t('aiGenerate.rewrite.accept')}
+        </Button>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
@@ -1,0 +1,221 @@
+import { Eye, Pencil, Sparkles } from 'lucide-react';
+import { AnimatePresence } from 'motion/react';
+import { useCallback, useRef, useState } from 'react';
+
+import { Button, MarkdownMessage, SegmentedControl, TextArea } from '@ajh/ui';
+
+import { useSelectedModel } from '@/components/ui/ModelSelector';
+import type { GenerationMeta, RewriteDocType } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+
+import { RewritePopover, type RewriteTarget } from './RewritePopover';
+
+interface EditableOutputProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  /** Document kind — drives the rewrite prompt's framing. */
+  docType: RewriteDocType;
+  /** Detected metadata — `targetLanguage` drives the rewrite locale (default 'en'). */
+  meta?: GenerationMeta | null;
+  /** Model override; defaults to the active provider's selected model. */
+  model?: string;
+  /** Enable the F4 inline-rewrite popover. Default true. */
+  enableRewrite?: boolean;
+  className?: string;
+  textAreaClassName?: string;
+  placeholder?: string;
+}
+
+/** The frozen selection range + text snapshot captured when a rewrite starts. */
+interface FrozenRange {
+  start: number;
+  end: number;
+  /** The exact text value at freeze time — guards the splice against drift. */
+  snapshot: string;
+  target: RewriteTarget;
+}
+
+/**
+ * Shared Preview | Edit surface for generated documents.
+ *
+ * - **Preview** renders prettified markdown (`MarkdownMessage`).
+ * - **Edit** is a raw `TextArea`; the raw string stays canonical, so copy/export
+ *   read exactly what the user typed.
+ * - **F4 inline rewrite** (when `enableRewrite`): selecting text in Edit reveals a
+ *   "Rewrite with AI" trigger. Triggering freezes the selection range + a text
+ *   snapshot, locks the textarea while a single rewrite streams into the popover
+ *   preview (never the textarea), and on Accept splices the result into the raw
+ *   text at the frozen range via `onChange`.
+ *
+ * The popover is anchored to a toolbar above the editor rather than the caret — a
+ * `<textarea>` exposes no per-character pixel coordinates, so caret-pixel math is
+ * deliberately avoided.
+ */
+export function EditableOutput({
+  value,
+  onChange,
+  disabled = false,
+  docType,
+  meta,
+  model,
+  enableRewrite = true,
+  className,
+  textAreaClassName,
+  placeholder,
+}: EditableOutputProps) {
+  const { t } = useTranslation();
+  const selectedModel = useSelectedModel();
+  const effectiveModel = model ?? selectedModel;
+  // Rewrite in the document's language (falls back to English) so the AI reply
+  // matches the document instead of forcing English.
+  const rewriteLocale = meta?.targetLanguage ?? 'en';
+
+  const [view, setView] = useState<'preview' | 'edit'>('preview');
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Live selection (range only) used to show/hide the rewrite trigger.
+  const [hasSelection, setHasSelection] = useState(false);
+  // Frozen range while a rewrite popover is open — null when closed.
+  const [frozen, setFrozen] = useState<FrozenRange | null>(null);
+
+  const updateSelection = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    setHasSelection(el.selectionStart !== el.selectionEnd);
+  }, []);
+
+  const openRewrite = () => {
+    const el = textareaRef.current;
+    if (!el) return;
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    if (start === end) return;
+    const selection = value.slice(start, end);
+    setFrozen({
+      start,
+      end,
+      snapshot: value,
+      target: {
+        selection,
+        before: value.slice(0, start),
+        after: value.slice(end),
+      },
+    });
+  };
+
+  const closeRewrite = () => {
+    setFrozen(null);
+    // Return focus to the editor for keyboard continuity.
+    textareaRef.current?.focus();
+  };
+
+  const acceptRewrite = (replacement: string) => {
+    if (!frozen) return;
+    // Splice into the snapshot at the frozen range — the textarea was locked while
+    // streaming, so `value` cannot have drifted, but splice against the snapshot
+    // for safety.
+    const base = frozen.snapshot;
+    const next = base.slice(0, frozen.start) + replacement + base.slice(frozen.end);
+    onChange(next);
+    setFrozen(null);
+    // Restore focus + place the caret after the inserted text.
+    const caret = frozen.start + replacement.length;
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(caret, caret);
+      setHasSelection(false);
+    });
+  };
+
+  const rewriteVisible = enableRewrite && view === 'edit';
+
+  return (
+    <div className={className}>
+      <div className="mb-2 flex shrink-0 items-center justify-between gap-2">
+        {/* Rewrite trigger — left, only in edit mode with a live selection. */}
+        <div className="flex items-center">
+          {rewriteVisible && hasSelection && !frozen && (
+            <Button
+              type="button"
+              onClick={openRewrite}
+              className="flex h-auto items-center gap-1.5 rounded-lg bg-brand/15 px-2.5 py-1 text-[11px] font-medium text-brand-soft transition-colors hover:bg-brand/20"
+            >
+              <Sparkles size={11} />
+              {t('aiGenerate.rewrite.trigger')}
+            </Button>
+          )}
+        </div>
+
+        <SegmentedControl<'preview' | 'edit'>
+          ariaLabel={t('aiGenerate.viewMode')}
+          size="sm"
+          tone="brand"
+          value={view}
+          onChange={setView}
+          options={[
+            { value: 'preview', label: t('aiGenerate.preview'), icon: Eye },
+            { value: 'edit', label: t('aiGenerate.edit'), icon: Pencil },
+          ]}
+          className="shrink-0"
+        />
+      </div>
+
+      {view === 'edit' ? (
+        <div className="relative h-full w-full">
+          <TextArea
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onSelect={updateSelection}
+            onMouseUp={updateSelection}
+            onKeyUp={updateSelection}
+            // Lock with readOnly (not disabled) while a rewrite streams so the
+            // textarea stays focusable/readable for screen readers; `disabled`
+            // reflects only the outer prop.
+            disabled={disabled}
+            readOnly={frozen !== null}
+            className={
+              textAreaClassName ??
+              'h-full w-full bg-transparent font-mono text-[12px] leading-relaxed text-foreground/80 placeholder:text-foreground/20'
+            }
+            spellCheck={false}
+            placeholder={placeholder ?? t('aiGenerate.placeholder')}
+          />
+
+          {/* Rewrite popover — anchored to a toolbar position above the editor
+              (textarea has no per-char coords, so no caret-pixel math). */}
+          <AnimatePresence>
+            {frozen && (
+              <>
+                <div className="fixed inset-0 z-[680]" onClick={closeRewrite} aria-hidden="true" />
+                <div className="absolute right-0 top-0 z-[700]">
+                  <RewritePopover
+                    target={frozen.target}
+                    docType={docType}
+                    model={effectiveModel}
+                    locale={rewriteLocale}
+                    onAccept={acceptRewrite}
+                    onClose={closeRewrite}
+                  />
+                </div>
+              </>
+            )}
+          </AnimatePresence>
+        </div>
+      ) : (
+        <div className="h-full w-full overflow-y-auto rounded-lg">
+          {value ? (
+            <MarkdownMessage content={value} className="text-[12px] text-foreground/80" />
+          ) : (
+            <p className="text-[12px] text-foreground/20">
+              {placeholder ?? t('aiGenerate.placeholder')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
@@ -1,9 +1,10 @@
-import { Check, Copy, Download, Eye, FileText, Pencil, RotateCcw } from 'lucide-react';
+import { Check, Copy, Download, FileText, RotateCcw } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useEffect, useState } from 'react';
 
-import { Button, cn, MarkdownMessage, SegmentedControl, TextArea } from '@ajh/ui';
+import { Button, cn } from '@ajh/ui';
 
+import { EditableOutput } from '@/components/generation/EditableOutput';
 import { buildFilename, type GenerationMeta, MODES, type TemplateId } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
 
@@ -42,10 +43,6 @@ export function OutputPanelDone({
 }: OutputPanelDoneProps) {
   const { t } = useTranslation();
   const [exportOpen, setExportOpen] = useState(false);
-  // Preview (prettified markdown) vs Edit (raw text). Display-only: the raw
-  // string stays canonical — copy, export, and the **keyword** emphasis markers
-  // are never touched, so a Preview/Edit switch can't change the exported file.
-  const [view, setView] = useState<'preview' | 'edit'>('preview');
 
   // If the active tab has no content but the other does, switch automatically
   useEffect(() => {
@@ -116,38 +113,17 @@ export function OutputPanelDone({
         </div>
       )}
 
-      {/* Output — prettified Preview or raw Edit (display-only; export uses the raw text) */}
+      {/* Output — prettified Preview or raw Edit; the raw string stays canonical,
+          so copy/export read exactly what's edited (incl. inline AI rewrites). */}
       <div className="flex flex-1 flex-col overflow-hidden px-6 py-4">
-        <SegmentedControl<'preview' | 'edit'>
-          ariaLabel={t('aiGenerate.viewMode')}
-          size="sm"
-          tone="brand"
-          value={view}
-          onChange={setView}
-          options={[
-            { value: 'preview', label: t('aiGenerate.preview'), icon: Eye },
-            { value: 'edit', label: t('aiGenerate.edit'), icon: Pencil },
-          ]}
-          className="mb-2 shrink-0 self-end"
+        <EditableOutput
+          value={currentOutput}
+          onChange={onOutputChange}
+          disabled={isGenerating}
+          docType={activeOut === 'resume' ? 'resume' : 'cover-letter'}
+          meta={meta}
+          className="flex h-full w-full flex-col overflow-hidden"
         />
-
-        {view === 'edit' ? (
-          <TextArea
-            value={currentOutput}
-            onChange={(e) => onOutputChange(e.target.value)}
-            className="h-full w-full bg-transparent font-mono text-[12px] leading-relaxed text-foreground/80 placeholder:text-foreground/20"
-            spellCheck={false}
-            placeholder={t('aiGenerate.placeholder')}
-          />
-        ) : (
-          <div className="h-full w-full overflow-y-auto rounded-lg">
-            {currentOutput ? (
-              <MarkdownMessage content={currentOutput} className="text-[12px] text-foreground/80" />
-            ) : (
-              <p className="text-[12px] text-foreground/20">{t('aiGenerate.placeholder')}</p>
-            )}
-          </div>
-        )}
       </div>
 
       {/* Re-generate option */}

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/GenerationOutput.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/GenerationOutput.tsx
@@ -2,6 +2,8 @@ import { Check, Copy, Download } from 'lucide-react';
 
 import { Button, cn } from '@ajh/ui';
 
+import { EditableOutput } from '@/components/generation/EditableOutput';
+import type { GenerationMeta } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
 
 import type { TailorTarget } from './useTailorGeneration';
@@ -11,6 +13,11 @@ interface Props {
   activeOut: 'resume' | 'cover';
   setActiveOut: (o: 'resume' | 'cover') => void;
   output: string;
+  /** Inline edit (F1) of the active document — session-immediate + debounced persist. */
+  onEdit: (text: string) => void;
+  /** Disable editing while a generation is still streaming. */
+  editable: boolean;
+  meta: GenerationMeta | null;
   copied: boolean;
   onCopy: () => void;
   exportOpen: boolean;
@@ -23,6 +30,9 @@ export function GenerationOutput({
   activeOut,
   setActiveOut,
   output,
+  onEdit,
+  editable,
+  meta,
   copied,
   onCopy,
   exportOpen,
@@ -102,8 +112,16 @@ export function GenerationOutput({
           </div>
         </div>
       </div>
-      <div className="max-h-56 overflow-y-auto whitespace-pre-wrap px-3 py-2 text-[11px] leading-relaxed text-foreground/75">
-        {output || '…'}
+      <div className="flex h-56 flex-col px-3 py-2">
+        <EditableOutput
+          value={output}
+          onChange={onEdit}
+          disabled={!editable}
+          docType={activeOut === 'resume' ? 'resume' : 'cover-letter'}
+          meta={meta}
+          className="flex h-full flex-col overflow-hidden"
+          textAreaClassName="h-full w-full bg-transparent text-[11px] leading-relaxed text-foreground/75 placeholder:text-foreground/20"
+        />
       </div>
     </div>
   );

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/index.tsx
@@ -218,6 +218,9 @@ export function ApplyJobModal({ job, resumeText, baseCoverLetter, board, onClose
               activeOut={gen.activeOut}
               setActiveOut={gen.setActiveOut}
               output={gen.output}
+              onEdit={gen.editActiveOutput}
+              editable={!gen.generating}
+              meta={gen.meta}
               copied={gen.copied}
               onCopy={gen.copy}
               exportOpen={gen.exportOpen}

--- a/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.ts
+++ b/apps/tauri/src/renderer/features/autopilot/components/ApplyJobModal/useTailorGeneration.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import {
@@ -8,11 +8,13 @@ import {
   exportTXT,
   type GenerationMeta,
   type GenerationMode,
+  PERSIST_DEBOUNCE_MS,
   type TemplateId,
 } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
 import { useAppClient } from '@/providers/AppClientProvider';
 import { keys } from '@/services/query-client';
+import { useUpdateAiGeneration } from '@/services/use-ai-generations';
 import {
   EMPTY_SESSION,
   type GenerationResult,
@@ -65,17 +67,34 @@ export function useTailorGeneration({
   const { t } = useTranslation();
   const api = useAppClient();
   const qc = useQueryClient();
+  const updateAiGeneration = useUpdateAiGeneration();
 
   const session = useGenerationStore((s) => s.sessions[contextId] ?? EMPTY_SESSION);
   const runTailor = useGenerationStore((s) => s.runTailor);
   const cancel = useGenerationStore((s) => s.cancel);
   const setActiveOutInStore = useGenerationStore((s) => s.setActiveOut);
+  const setOutputInStore = useGenerationStore((s) => s.setOutput);
+  const setSavedIdInStore = useGenerationStore((s) => s.setSavedId);
 
-  const { generating, phase, resumeOut, coverOut, thinking, activeOut, error, meta } = session;
+  const { generating, phase, resumeOut, coverOut, thinking, activeOut, error, meta, savedId } =
+    session;
 
   // Modal-local, ephemeral UI — fine to reset when the modal remounts.
   const [copied, setCopied] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
+
+  // Debounced persistence of inline edits — one timer per field; flushed on unmount.
+  const persistTimers = useRef<{
+    resume?: ReturnType<typeof setTimeout>;
+    cover?: ReturnType<typeof setTimeout>;
+  }>({});
+  useEffect(() => {
+    const timers = persistTimers.current;
+    return () => {
+      if (timers.resume) clearTimeout(timers.resume);
+      if (timers.cover) clearTimeout(timers.cover);
+    };
+  }, []);
 
   const output = activeOut === 'resume' ? resumeOut : coverOut;
 
@@ -102,13 +121,35 @@ export function useTailorGeneration({
         jobUrl,
         board,
       })
-      .then(() => {
+      .then((res) => {
+        // Stash the persisted id on the session so later inline edits can patch
+        // this exact record (F1) without a separate save.
+        if (res?.id) setSavedIdInStore(contextId, res.id);
         void qc.invalidateQueries({ queryKey: keys.aiGenerations.all });
         void qc.invalidateQueries({ queryKey: keys.autopilot.all });
       })
       .catch(() => {
         /* best-effort persistence — the generation is already shown to the user */
       });
+  };
+
+  // Inline edit (F1) of the active document. Updates the session immediately for a
+  // smooth typing experience; once the record has been saved, debounced-persist
+  // the edit to that record. Before a save lands (`savedId === null`) the edit is
+  // session-only — the eventual `persist` will write the latest session text.
+  const editActiveOutput = (text: string) => {
+    setOutputInStore(contextId, activeOut, text);
+    if (!savedId) return;
+    const field = activeOut === 'resume' ? 'resume' : 'cover';
+    const existing = persistTimers.current[field];
+    if (existing) clearTimeout(existing);
+    persistTimers.current[field] = setTimeout(() => {
+      updateAiGeneration.mutate(
+        activeOut === 'resume'
+          ? { id: savedId, resumeText: text }
+          : { id: savedId, coverLetterText: text }
+      );
+    }, PERSIST_DEBOUNCE_MS);
   };
 
   const generate = (resume: string, target: TailorTarget) => {
@@ -185,6 +226,8 @@ export function useTailorGeneration({
     abort,
     copy,
     exportAs,
+    // Inline edit of the active document (F1) — session-immediate + debounced persist.
+    editActiveOutput,
     // Detected metadata — lets the questions assistant reuse it instead of re-extracting.
     meta,
   };

--- a/apps/tauri/src/renderer/features/resumes/components/GenerationCard/GenerationCard.test.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/GenerationCard/GenerationCard.test.tsx
@@ -1,7 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 
 import type { AiGenerationRecord } from '@ajh/shared/ipc';
+
+import type * as Generate from '@/lib/generate';
+import { PERSIST_DEBOUNCE_MS } from '@/lib/generate';
 
 import { GenerationCard } from './index';
 
@@ -9,6 +12,7 @@ import { GenerationCard } from './index';
 // remove hook so the card renders without a provider tree. We capture the
 // mutate spy to prove deletion only fires *after* confirmation.
 const mockMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
 
 vi.mock('@/services', () => ({
   useOpenExternal: () => ({ mutate: vi.fn() }),
@@ -16,12 +20,26 @@ vi.mock('@/services', () => ({
 
 vi.mock('@/services/use-ai-generations', () => ({
   useRemoveAiGeneration: () => ({ mutate: mockMutate, isPending: false }),
+  // The card debounce-persists inline edits through this hook; the delete tests
+  // don't edit, but the component calls it on render so the mock must provide it.
+  useUpdateAiGeneration: () => ({ mutate: mockUpdateMutate, isPending: false }),
 }));
 
 // Translate to the raw key so assertions don't depend on locale resolution.
 vi.mock('@/lib/i18n', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }));
+
+// Export helpers reach for Tauri IPC — stub them so tests stay offline.
+vi.mock('@/lib/generate', async (importOriginal) => {
+  const actual = await importOriginal<typeof Generate>();
+  return {
+    ...actual,
+    exportPDF: vi.fn(),
+    exportDOCX: vi.fn(),
+    exportTXT: vi.fn(),
+  };
+});
 
 const GEN: AiGenerationRecord = {
   id: 'gen-1',
@@ -32,8 +50,8 @@ const GEN: AiGenerationRecord = {
   mode: 'ats',
   board: '',
   jobUrl: '',
-  resumeText: '',
-  coverLetterText: '',
+  resumeText: 'Original resume text.',
+  coverLetterText: 'Original cover letter text.',
   jobAd: '',
   companyBrief: '',
   resumeLanguage: 'en',
@@ -43,6 +61,8 @@ const GEN: AiGenerationRecord = {
   topRequirements: [],
   applicationAnswers: [],
 };
+
+// ── Delete confirmation (pre-existing coverage) ───────────────────────────────
 
 describe('GenerationCard — delete confirmation', () => {
   beforeEach(() => mockMutate.mockClear());
@@ -76,5 +96,161 @@ describe('GenerationCard — delete confirmation', () => {
     fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
 
     expect(mockMutate).not.toHaveBeenCalled();
+  });
+});
+
+// ── Debounced persist (F1 edit-before-export) ─────────────────────────────────
+
+describe('GenerationCard — debounced persist', () => {
+  beforeEach(() => {
+    mockUpdateMutate.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Open the resume section and switch EditableOutput to Edit mode so a
+   * <textarea> is accessible. The section toggle is a `Button variant="unstyled"`
+   * whose text content is the translation key for "Resume". EditableOutput opens
+   * in Preview mode; the Edit radio must be clicked to surface the textarea.
+   */
+  function expandResumeAndSwitchToEdit() {
+    // Click the section toggle whose visible text contains the resume key.
+    const toggles = screen.queryAllByRole('button');
+    const resumeToggle = toggles.find((b) =>
+      (b.textContent ?? '').includes('resumes.generated.resume')
+    );
+    if (!resumeToggle) throw new Error('Resume section toggle not found');
+    fireEvent.click(resumeToggle);
+
+    // EditableOutput renders Preview by default; switch to Edit to get the textarea.
+    fireEvent.click(screen.getByRole('radio', { name: /edit/i }));
+  }
+
+  /**
+   * Open the cover-letter section and switch EditableOutput to Edit mode.
+   * Symmetric to expandResumeAndSwitchToEdit but targets the coverLetter key.
+   */
+  function expandCoverAndSwitchToEdit() {
+    const toggles = screen.queryAllByRole('button');
+    const coverToggle = toggles.find((b) =>
+      (b.textContent ?? '').includes('resumes.generated.coverLetter')
+    );
+    if (!coverToggle) throw new Error('Cover letter section toggle not found');
+    fireEvent.click(coverToggle);
+
+    fireEvent.click(screen.getByRole('radio', { name: /edit/i }));
+  }
+
+  it('editing the resume draft schedules a debounced update after PERSIST_DEBOUNCE_MS', () => {
+    render(<GenerationCard gen={GEN} />);
+    expandResumeAndSwitchToEdit();
+
+    const textarea = screen.getByRole<HTMLTextAreaElement>('textbox');
+    fireEvent.change(textarea, { target: { value: 'Edited resume text.' } });
+
+    // Before the debounce fires: no call yet.
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+
+    // Advance past the debounce window — use the imported constant so this test
+    // stays in lockstep with the production code's PERSIST_DEBOUNCE_MS value.
+    act(() => {
+      vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS);
+    });
+
+    expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMutate).toHaveBeenCalledWith({
+      id: 'gen-1',
+      resumeText: 'Edited resume text.',
+    });
+  });
+
+  it('rapid successive edits debounce to a single update call — proves timer cancellation', () => {
+    render(<GenerationCard gen={GEN} />);
+    expandResumeAndSwitchToEdit();
+
+    const textarea = screen.getByRole<HTMLTextAreaElement>('textbox');
+
+    // First edit starts the debounce timer.
+    fireEvent.change(textarea, { target: { value: 'edit 1' } });
+
+    // Advance to just before the debounce would fire — proves the first timer is
+    // still pending and has NOT triggered a call yet.
+    act(() => {
+      vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS - 1);
+    });
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+
+    // Second edit cancels the first timer and starts a new one.
+    fireEvent.change(textarea, { target: { value: 'edit 2' } });
+    act(() => {
+      vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS - 1);
+    });
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+
+    // Third (final) edit — again cancels the previous timer.
+    fireEvent.change(textarea, { target: { value: 'edit 3' } });
+
+    // Still no call before the debounce window for the third edit expires.
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+
+    // Now let the final debounce fully expire.
+    act(() => {
+      vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS);
+    });
+
+    // Exactly one call, with the last value — no stale earlier values were flushed.
+    expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMutate).toHaveBeenCalledWith({
+      id: 'gen-1',
+      resumeText: 'edit 3',
+    });
+  });
+
+  it('editing the cover letter draft debounces update({ id, coverLetterText })', () => {
+    render(<GenerationCard gen={GEN} />);
+    expandCoverAndSwitchToEdit();
+
+    const textarea = screen.getByRole<HTMLTextAreaElement>('textbox');
+    fireEvent.change(textarea, { target: { value: 'Edited cover letter text.' } });
+
+    // No call before the window closes.
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS);
+    });
+
+    // Must use the coverLetterText key — not resumeText — proving the symmetric data path.
+    expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMutate).toHaveBeenCalledWith({
+      id: 'gen-1',
+      coverLetterText: 'Edited cover letter text.',
+    });
+  });
+
+  it('copy button reads the edited draft text, not the original gen prop', async () => {
+    // Stub clipboard so the copy flow completes without a real Clipboard API.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<GenerationCard gen={GEN} />);
+    expandResumeAndSwitchToEdit();
+
+    const textarea = screen.getByRole<HTMLTextAreaElement>('textbox');
+    fireEvent.change(textarea, { target: { value: 'Draft resume after edit.' } });
+
+    // The copy button is always visible in the card header when draft has content.
+    const copyBtn = screen.getByRole('button', {
+      name: /resumes\.generated\.copyResume/i,
+    });
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    expect(writeText).toHaveBeenCalledWith('Draft resume after edit.');
   });
 });

--- a/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
+++ b/apps/tauri/src/renderer/features/resumes/components/GenerationCard/index.tsx
@@ -14,22 +14,24 @@ import {
   Wand2,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { AiGenerationRecord } from '@ajh/shared/ipc';
 import { Button, cn, ConfirmModal, GlassCard, SegmentedControl, transition } from '@ajh/ui';
 
+import { EditableOutput } from '@/components/generation/EditableOutput';
 import { ExternalLink } from '@/components/ui/ExternalLink';
 import {
   buildFilename,
   exportDOCX,
   exportPDF,
   exportTXT,
+  PERSIST_DEBOUNCE_MS,
   type TemplateId,
   TEMPLATES,
 } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
-import { useRemoveAiGeneration } from '@/services/use-ai-generations';
+import { useRemoveAiGeneration, useUpdateAiGeneration } from '@/services/use-ai-generations';
 
 const EXPORT_FORMATS = ['pdf', 'docx', 'txt'] as const;
 type ExportFormat = (typeof EXPORT_FORMATS)[number];
@@ -46,6 +48,7 @@ interface GenerationCardProps {
 export function GenerationCard({ gen }: GenerationCardProps) {
   const { t } = useTranslation();
   const removeAiGeneration = useRemoveAiGeneration();
+  const updateAiGeneration = useUpdateAiGeneration();
   const [expanded, setExpanded] = useState<
     'resume' | 'cover' | 'jobAd' | 'brief' | 'answers' | null
   >(null);
@@ -55,13 +58,52 @@ export function GenerationCard({ gen }: GenerationCardProps) {
   const [exporting, setExporting] = useState<'resume' | 'cover' | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
+  // Local editing buffers keep typing smooth and own the edit truth for the card's
+  // lifetime. The card is keyed by `gen.id` at the list (it remounts per record),
+  // so drafts are seeded once from the record on mount; thereafter the optimistic
+  // update hook patches the list cache (with rollback on failure) and we do NOT
+  // re-sync the drafts from `gen`. A re-sync here would let the post-`onSettled`
+  // refetch overwrite the buffer with debounce-stale text, clobbering keystrokes
+  // typed during the 800ms debounce window.
+  const [resumeDraft, setResumeDraft] = useState(gen.resumeText);
+  const [coverDraft, setCoverDraft] = useState(gen.coverLetterText);
+
+  // Debounced persistence — one timer per field; flushed on unmount.
+  const persistTimers = useRef<{
+    resume?: ReturnType<typeof setTimeout>;
+    cover?: ReturnType<typeof setTimeout>;
+  }>({});
+  useEffect(() => {
+    const timers = persistTimers.current;
+    return () => {
+      if (timers.resume) clearTimeout(timers.resume);
+      if (timers.cover) clearTimeout(timers.cover);
+    };
+  }, []);
+
+  const persistEdit = (type: 'resume' | 'cover', text: string) => {
+    const existing = persistTimers.current[type];
+    if (existing) clearTimeout(existing);
+    persistTimers.current[type] = setTimeout(() => {
+      updateAiGeneration.mutate(
+        type === 'resume' ? { id: gen.id, resumeText: text } : { id: gen.id, coverLetterText: text }
+      );
+    }, PERSIST_DEBOUNCE_MS);
+  };
+
+  const onEdit = (type: 'resume' | 'cover', text: string) => {
+    if (type === 'resume') setResumeDraft(text);
+    else setCoverDraft(text);
+    persistEdit(type, text);
+  };
+
   const handleDelete = () => {
     setConfirmDelete(false);
     removeAiGeneration.mutate(gen.id);
   };
 
   const copy = async (type: 'resume' | 'cover') => {
-    const text = type === 'resume' ? gen.resumeText : gen.coverLetterText;
+    const text = type === 'resume' ? resumeDraft : coverDraft;
     await navigator.clipboard.writeText(text);
     setCopied(type);
     setTimeout(() => setCopied(null), 1800);
@@ -79,7 +121,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
   };
 
   const doExport = async (type: 'resume' | 'cover') => {
-    const text = type === 'resume' ? gen.resumeText : gen.coverLetterText;
+    const text = type === 'resume' ? resumeDraft : coverDraft;
     if (!text) return;
     const docType = type === 'resume' ? 'resume' : 'cover-letter';
     const filename = buildFilename(meta, docType, exportFormat);
@@ -167,7 +209,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
           </div>
 
           <div className="flex items-center gap-1 shrink-0">
-            {gen.resumeText && (
+            {resumeDraft && (
               <Button
                 onClick={() => void copy('resume')}
                 className="flex items-center gap-1 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto border-transparent"
@@ -178,7 +220,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
                   : t('resumes.generated.copyResume')}
               </Button>
             )}
-            {gen.coverLetterText && (
+            {coverDraft && (
               <Button
                 onClick={() => void copy('cover')}
                 className="flex items-center gap-1 rounded-lg bg-white/5 px-2.5 py-1.5 text-[11px] text-foreground/60 transition-colors hover:text-foreground h-auto border-transparent"
@@ -201,7 +243,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
         </div>
 
         {/* Export bar */}
-        {(gen.resumeText || gen.coverLetterText) && (
+        {(resumeDraft || coverDraft) && (
           <div className="border-t border-white/[0.04] px-4 py-2.5 flex items-center gap-2 flex-wrap">
             <Download size={11} className="text-foreground/30 shrink-0" />
             <span className="text-[11px] text-foreground/40 mr-1">
@@ -229,7 +271,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
             )}
 
             <div className="flex items-center gap-1 ml-auto">
-              {gen.resumeText && (
+              {resumeDraft && (
                 <Button
                   disabled={exporting === 'resume'}
                   onClick={() => void doExport('resume')}
@@ -243,7 +285,7 @@ export function GenerationCard({ gen }: GenerationCardProps) {
                   {t('resumes.generated.exportResume')}
                 </Button>
               )}
-              {gen.coverLetterText && (
+              {coverDraft && (
                 <Button
                   disabled={exporting === 'cover'}
                   onClick={() => void doExport('cover')}
@@ -275,35 +317,46 @@ export function GenerationCard({ gen }: GenerationCardProps) {
           </div>
         )}
 
-        {/* Expandable sections */}
-        {[
-          {
-            key: 'resume' as const,
-            label: t('resumes.generated.resume'),
-            text: gen.resumeText,
-            icon: FileText,
-          },
-          {
-            key: 'cover' as const,
-            label: t('resumes.generated.coverLetter'),
-            text: gen.coverLetterText,
-            icon: FileText,
-          },
-          {
-            key: 'jobAd' as const,
-            label: t('resumes.generated.jobAd'),
-            text: gen.jobAd,
-            icon: Building2,
-          },
-          {
-            key: 'brief' as const,
-            label: t('resumes.generated.companyResearch'),
-            text: gen.companyBrief,
-            icon: Search,
-          },
-        ]
+        {/* Expandable sections. Resume + cover letter are editable (F1 + inline
+            rewrite); the job ad and company brief stay read-only references. */}
+        {(
+          [
+            {
+              key: 'resume' as const,
+              label: t('resumes.generated.resume'),
+              text: resumeDraft,
+              icon: FileText,
+              editType: 'resume' as const,
+              docType: 'resume' as const,
+            },
+            {
+              key: 'cover' as const,
+              label: t('resumes.generated.coverLetter'),
+              text: coverDraft,
+              icon: FileText,
+              editType: 'cover' as const,
+              docType: 'cover-letter' as const,
+            },
+            {
+              key: 'jobAd' as const,
+              label: t('resumes.generated.jobAd'),
+              text: gen.jobAd,
+              icon: Building2,
+              editType: null,
+              docType: null,
+            },
+            {
+              key: 'brief' as const,
+              label: t('resumes.generated.companyResearch'),
+              text: gen.companyBrief,
+              icon: Search,
+              editType: null,
+              docType: null,
+            },
+          ] as const
+        )
           .filter((s) => s.text)
-          .map(({ key, label, text, icon: SectionIcon }) => (
+          .map(({ key, label, text, icon: SectionIcon, editType, docType }) => (
             <div key={key} className="border-t border-white/[0.04]">
               <Button
                 variant="unstyled"
@@ -327,9 +380,22 @@ export function GenerationCard({ gen }: GenerationCardProps) {
                     transition={transition.normal}
                     className="overflow-hidden"
                   >
-                    <pre className="select-text px-4 pb-4 whitespace-pre-wrap font-mono text-[10px] leading-relaxed text-foreground/50 max-h-64 overflow-y-auto">
-                      {text}
-                    </pre>
+                    {editType && docType ? (
+                      <div className="flex h-72 flex-col px-4 pb-4">
+                        <EditableOutput
+                          value={text}
+                          onChange={(v) => onEdit(editType, v)}
+                          docType={docType}
+                          meta={meta}
+                          className="flex h-full flex-col overflow-hidden"
+                          textAreaClassName="h-full w-full bg-transparent font-mono text-[10px] leading-relaxed text-foreground/60 placeholder:text-foreground/20"
+                        />
+                      </div>
+                    ) : (
+                      <pre className="select-text px-4 pb-4 whitespace-pre-wrap font-mono text-[10px] leading-relaxed text-foreground/50 max-h-64 overflow-y-auto">
+                        {text}
+                      </pre>
+                    )}
                   </motion.div>
                 )}
               </AnimatePresence>

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -546,6 +546,35 @@
     "edit": "Bearbeiten",
     "viewMode": "Ansichtsmodus",
     "placeholder": "Generierte Ausgabe erscheint hier…",
+    "rewrite": {
+      "trigger": "Mit KI umschreiben",
+      "title": "Auswahl umschreiben",
+      "instructionPlaceholder": "Beschreiben, wie umgeschrieben werden soll…",
+      "instructionLabel": "Anweisung zum Umschreiben",
+      "submit": "Umschreiben",
+      "accept": "Übernehmen",
+      "cancel": "Abbrechen",
+      "regenerate": "Neu generieren",
+      "selectionLabel": "Ausgewählter Text",
+      "resultLabel": "Umschreibung",
+      "streaming": "Wird umgeschrieben…",
+      "empty": "Die Umschreibung war leer. Versuche eine andere Anweisung.",
+      "failed": "Umschreiben fehlgeschlagen. Bitte erneut versuchen.",
+      "presets": {
+        "shorten": "Kürzen",
+        "expand": "Erweitern",
+        "rephrase": "Umformulieren",
+        "impact": "Mehr Wirkung",
+        "grammar": "Grammatik korrigieren"
+      },
+      "presetInstructions": {
+        "shorten": "Formuliere das prägnanter, ohne konkrete Fakten zu verlieren.",
+        "expand": "Erweitere das um relevante Details, ohne neue Fakten zu erfinden.",
+        "rephrase": "Formuliere das mit anderen Worten um, behalte aber die Bedeutung bei.",
+        "impact": "Schreibe das wirkungsvoller und selbstbewusster um, halte dabei alle Fakten korrekt.",
+        "grammar": "Korrigiere Grammatik, Rechtschreibung und Zeichensetzung, behalte Bedeutung und Wortwahl so weit wie möglich bei."
+      }
+    },
     "stages": {
       "analyzing": "Anforderungen werden analysiert…",
       "extracting": "Prioritäten werden extrahiert…",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -561,6 +561,35 @@
     "edit": "Edit",
     "viewMode": "View mode",
     "placeholder": "Generated output will appear here…",
+    "rewrite": {
+      "trigger": "Rewrite with AI",
+      "title": "Rewrite selection",
+      "instructionPlaceholder": "Describe how to rewrite…",
+      "instructionLabel": "Rewrite instruction",
+      "submit": "Rewrite",
+      "accept": "Accept",
+      "cancel": "Cancel",
+      "regenerate": "Regenerate",
+      "selectionLabel": "Selected text",
+      "resultLabel": "Rewrite",
+      "streaming": "Rewriting…",
+      "empty": "The rewrite came back empty. Try a different instruction.",
+      "failed": "Rewrite failed. Try again.",
+      "presets": {
+        "shorten": "Shorten",
+        "expand": "Expand",
+        "rephrase": "Rephrase",
+        "impact": "More impact",
+        "grammar": "Fix grammar"
+      },
+      "presetInstructions": {
+        "shorten": "Make this more concise without losing any concrete facts.",
+        "expand": "Expand this with more relevant detail, without inventing new facts.",
+        "rephrase": "Rephrase this in different words while keeping the same meaning.",
+        "impact": "Rewrite this to be more impactful and confident, keeping every fact accurate.",
+        "grammar": "Fix any grammar, spelling, and punctuation issues while keeping the meaning and wording as close as possible."
+      }
+    },
     "stages": {
       "analyzing": "Analyzing job requirements…",
       "extracting": "Extracting recruiter priorities…",

--- a/apps/tauri/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/tauri/src/renderer/lib/generate/generation/generation.ts
@@ -18,12 +18,14 @@ import {
   buildMetadataPrompt,
   buildResumePrompt,
   buildResumeSystemPrompt,
+  buildRewritePrompt,
   extractPlainText,
   type GenerationMeta,
   type GenerationMode,
   getLinkMap,
   injectLinksIntoGeneratedText,
   resolveMarket,
+  type RewriteDocType,
   validateMetadata,
 } from '@ajh/prompts/generate';
 import { detectLanguages } from '@ajh/shared/language-detection';
@@ -418,5 +420,52 @@ export async function generateApplicationAnswer(params: {
     meta.targetLanguage || 'en',
     signal
   );
+  return extractPlainText(raw);
+}
+
+/**
+ * Inline AI rewrite of a selected span (F4). Mirrors {@link generateApplicationAnswer}:
+ * reads the active provider config, computes the effective prompt tier, builds the
+ * grounded rewrite prompt, and streams through the shared pipeline — so it works
+ * for every provider with zero per-provider code and adds NO new IPC. The model is
+ * instructed to return ONLY the rewritten span; `extractPlainText` strips any
+ * stray markdown/thinking the model echoes. Pass `onToken` to stream the rewrite
+ * into a preview and `signal` to abort an in-flight rewrite.
+ */
+export async function rewriteSelection(params: {
+  selection: string;
+  instruction: string;
+  before: string;
+  after: string;
+  docType: RewriteDocType;
+  model: string;
+  /** Document language so the rewrite streams in the right locale (default 'en').
+   *  Pass the generation's `meta.targetLanguage`. `streamGenerate` clamps it to a
+   *  supported locale via `safeLocale`. */
+  locale?: string;
+  onToken?: (tok: string) => void;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const {
+    selection,
+    instruction,
+    before,
+    after,
+    docType,
+    model,
+    locale = 'en',
+    onToken,
+    signal,
+  } = params;
+  const providerConfig = usePreferencesStore.getState().aiProviderConfig;
+  const activeProvider = providerConfig?.activeProvider ?? 'ollama';
+  const activeModel = providerConfig?.providers?.[activeProvider]?.model || model;
+  const tier = effectiveTier(activeModel, activeProvider);
+
+  const { system, user } = buildRewritePrompt(
+    { selection, instruction, before, after, docType },
+    tier
+  );
+  const raw = await streamGenerate(model, system, user, onToken ?? (() => {}), 0.3, locale, signal);
   return extractPlainText(raw);
 }

--- a/apps/tauri/src/renderer/lib/generate/index.ts
+++ b/apps/tauri/src/renderer/lib/generate/index.ts
@@ -8,6 +8,15 @@ export {
   type GenerationMode,
   MODES,
   researchCompany,
+  rewriteSelection,
 } from './generation';
 export { isTwoColumnTemplate, TEMPLATE_IDS, type TemplateId, TEMPLATES } from './templates';
+
+/**
+ * Debounce window (ms) for persisting an in-progress inline edit to a saved
+ * generation. Shared so the two edit surfaces (GenerationCard, ApplyJobModal's
+ * useTailorGeneration) stay in lockstep.
+ */
+export const PERSIST_DEBOUNCE_MS = 800;
+export type { RewriteDocType } from '@ajh/prompts/generate';
 export { LETTER_MARKET_IDS, letterConventions, resolveMarket } from '@ajh/prompts/generate';

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -82,6 +82,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
     aiGenerations: {
       list: emptyList,
       save: noop,
+      update: noop,
       remove: noop,
     },
 

--- a/apps/tauri/src/renderer/services/use-ai-generations/use-ai-generations.ts
+++ b/apps/tauri/src/renderer/services/use-ai-generations/use-ai-generations.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { AiGenerationRecord, AiGenerationSaveRequest } from '@ajh/shared/ipc';
+import type {
+  AiGenerationRecord,
+  AiGenerationSaveRequest,
+  AiGenerationUpdateRequest,
+} from '@ajh/shared/ipc';
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
@@ -20,6 +24,39 @@ export const useSaveAiGeneration = () => {
   return useMutation({
     mutationFn: (req: AiGenerationSaveRequest) => api.aiGenerations.save(req),
     onSuccess: () => qc.invalidateQueries({ queryKey: keys.aiGenerations.all }),
+  });
+};
+
+export const useUpdateAiGeneration = () => {
+  const api = useAppClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (req: AiGenerationUpdateRequest) => api.aiGenerations.update(req),
+    // Optimistic edit: patch the matching record's text in place so the UI
+    // reflects the edit immediately; restore the snapshot if the backend fails.
+    // Patching (rather than refetching) avoids clobbering an in-flight edit.
+    onMutate: async (req) => {
+      await qc.cancelQueries({ queryKey: keys.aiGenerations.all });
+      const previous = qc.getQueryData<AiGenerationRecord[]>(keys.aiGenerations.all);
+      qc.setQueryData<AiGenerationRecord[]>(keys.aiGenerations.all, (old) =>
+        (old ?? []).map((g) =>
+          g.id === req.id
+            ? {
+                ...g,
+                ...(req.resumeText !== undefined ? { resumeText: req.resumeText } : {}),
+                ...(req.coverLetterText !== undefined
+                  ? { coverLetterText: req.coverLetterText }
+                  : {}),
+              }
+            : g
+        )
+      );
+      return { previous };
+    },
+    onError: (_err, _req, ctx) => {
+      if (ctx?.previous) qc.setQueryData(keys.aiGenerations.all, ctx.previous);
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: keys.aiGenerations.all }),
   });
 };
 

--- a/apps/tauri/src/renderer/store/generation-store/generation-store.ts
+++ b/apps/tauri/src/renderer/store/generation-store/generation-store.ts
@@ -29,6 +29,9 @@ export interface GenerationSession {
   activeOut: 'resume' | 'cover';
   error: string | null;
   meta: GenerationMeta | null;
+  /** Persisted record id once {@link RunTailorParams.onComplete} has saved this
+   *  session's result — lets the modal persist later edits to the right record. */
+  savedId: string | null;
 }
 
 /** Stable empty session — returned for unknown ids so selectors keep one reference. */
@@ -41,6 +44,7 @@ export const EMPTY_SESSION: GenerationSession = {
   activeOut: 'cover',
   error: null,
   meta: null,
+  savedId: null,
 };
 
 /** The finished documents + detected metadata, handed to {@link RunTailorParams.onComplete}. */
@@ -78,6 +82,10 @@ interface GenerationStore {
   /** Current session for a context id (or the stable empty session). */
   getSession: (id: string) => GenerationSession;
   setActiveOut: (id: string, which: 'resume' | 'cover') => void;
+  /** Replace one document's text in a session (e.g. an inline edit/rewrite). */
+  setOutput: (id: string, which: 'resume' | 'cover', text: string) => void;
+  /** Record the persisted id after a clean run saves the session's result. */
+  setSavedId: (id: string, savedId: string) => void;
   /** Cancel an in-flight run for a context id. */
   cancel: (id: string) => void;
   /** Drop a session entirely. */
@@ -113,6 +121,11 @@ export const useGenerationStore = create<GenerationStore>((set, get) => {
     getSession: (id) => get().sessions[id] ?? EMPTY_SESSION,
 
     setActiveOut: (id, which) => patch(id, { activeOut: which }),
+
+    setOutput: (id, which, text) =>
+      patch(id, which === 'resume' ? { resumeOut: text } : { coverOut: text }),
+
+    setSavedId: (id, savedId) => patch(id, { savedId }),
 
     cancel: (id) => controllers.get(id)?.abort(),
 

--- a/apps/tauri/src/tauri-client/namespaces/aiGenerations/aiGenerations.ts
+++ b/apps/tauri/src/tauri-client/namespaces/aiGenerations/aiGenerations.ts
@@ -1,9 +1,10 @@
 import { invoke } from '@tauri-apps/api/core';
 
-import type { AiGenerationSaveRequest } from '@ajh/shared';
+import type { AiGenerationSaveRequest, AiGenerationUpdateRequest } from '@ajh/shared';
 
 export const aiGenerations = {
   list: () => invoke('ai_generations_list'),
   save: (req: AiGenerationSaveRequest) => invoke('ai_generations_save', { req }),
+  update: (req: AiGenerationUpdateRequest) => invoke('ai_generations_update', { req }),
   remove: (id: string) => invoke('ai_generations_remove', { id }),
 };

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -193,6 +193,14 @@ Async geocode lookup with debounce:
 <LocationInput value={location} onChange={setLocation} />
 ```
 
+#### `NumberField`
+
+Controlled numeric input with string-buffer internals: suppresses `onChange` while empty/NaN, clamps to `[min, max]` on blur, and re-syncs from the external value only when it genuinely changes. Eliminates the `Number('') === 0` snap-to-zero regression. Source: `packages/ui/src/components/NumberField/NumberField.tsx`.
+
+```typescript
+<NumberField value={count} onChange={setCount} min={1} max={100} step={1} />
+```
+
 ---
 
 ### Cards & Layout

--- a/packages/prompts/src/generate/index.ts
+++ b/packages/prompts/src/generate/index.ts
@@ -11,6 +11,7 @@ export * from './links.js';
 export * from './metadata.js';
 export * from './modes.js';
 export * from './resume.js';
+export * from './rewrite.js';
 export * from './text.js';
 
 // Market resolution lives in the locale module but is consumed alongside the

--- a/packages/prompts/src/generate/rewrite.test.ts
+++ b/packages/prompts/src/generate/rewrite.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildRewritePrompt, type RewriteDocType } from './rewrite.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const BASE_PARAMS = {
+  selection: 'Led a team of engineers to deliver the migration.',
+  instruction: 'Make it more impactful with a quantified outcome.',
+  before: 'WORK EXPERIENCE\nAcme Corp — Senior Engineer (2021–2024)\n',
+  after: '\nSkills: TypeScript, React, PostgreSQL',
+  docType: 'resume' as RewriteDocType,
+};
+
+// ─── System prompt contract ───────────────────────────────────────────────────
+
+describe('buildRewritePrompt — system prompt', () => {
+  it('instructs the model to return ONLY the rewritten span (no preamble, no quotes)', () => {
+    const { system } = buildRewritePrompt(BASE_PARAMS);
+    // Rule 2 in the source: "Output the rewritten span ONLY — no preamble, no
+    // explanation, no quotation marks, no surrounding context, no labels."
+    expect(system).toMatch(/output the rewritten span only/i);
+    expect(system).toMatch(/no preamble/i);
+    expect(system).toMatch(/no quotation marks/i);
+  });
+
+  it('instructs the model to preserve language, tense, voice, and grammatical person', () => {
+    const { system } = buildRewritePrompt(BASE_PARAMS);
+    expect(system).toMatch(/tense/i);
+    expect(system).toMatch(/voice/i);
+    expect(system).toMatch(/grammatical person/i);
+    expect(system).toMatch(/same language/i);
+  });
+
+  it('forbids fabricating facts', () => {
+    const { system } = buildRewritePrompt(BASE_PARAMS);
+    expect(system).toMatch(/never fabricate/i);
+    // The source specifically mentions keeping concrete claims.
+    expect(system).toMatch(/skills|employers|titles|metrics|dates/i);
+  });
+
+  it('instructs the model to treat <before> and <after> as read-only context', () => {
+    const { system } = buildRewritePrompt(BASE_PARAMS);
+    expect(system).toMatch(/read-only context/i);
+    expect(system).toMatch(/<before>/);
+    expect(system).toMatch(/<after>/);
+  });
+});
+
+// ─── User prompt content ──────────────────────────────────────────────────────
+
+describe('buildRewritePrompt — user prompt', () => {
+  it('contains the <selection> tag wrapping the selected span', () => {
+    const { user } = buildRewritePrompt(BASE_PARAMS);
+    expect(user).toContain('<selection>');
+    expect(user).toContain('</selection>');
+    expect(user).toContain(BASE_PARAMS.selection);
+  });
+
+  it('contains the before context', () => {
+    const { user } = buildRewritePrompt(BASE_PARAMS);
+    expect(user).toContain('<before>');
+    // The before text is sliced from the tail — check that the text appears.
+    expect(user).toContain('Senior Engineer');
+  });
+
+  it('contains the after context', () => {
+    const { user } = buildRewritePrompt(BASE_PARAMS);
+    expect(user).toContain('<after>');
+    expect(user).toContain('TypeScript, React, PostgreSQL');
+  });
+
+  it('contains the instruction', () => {
+    const { user } = buildRewritePrompt(BASE_PARAMS);
+    expect(user).toContain(BASE_PARAMS.instruction);
+  });
+});
+
+// ─── Selection cap ────────────────────────────────────────────────────────────
+
+describe('buildRewritePrompt — selection cap', () => {
+  it('truncates a selection longer than 4000 chars in the user prompt', () => {
+    const longSelection = 'A'.repeat(5000);
+    const { user } = buildRewritePrompt({ ...BASE_PARAMS, selection: longSelection });
+
+    // The capped span (4000 chars of 'A') must appear; the full 5000 must not
+    // be present as a contiguous run.
+    expect(user).toContain('A'.repeat(4000));
+    expect(user).not.toContain('A'.repeat(4001));
+  });
+
+  it('passes through a selection exactly at the 4000-char boundary unchanged', () => {
+    const exactSelection = 'B'.repeat(4000);
+    const { user } = buildRewritePrompt({ ...BASE_PARAMS, selection: exactSelection });
+    expect(user).toContain('B'.repeat(4000));
+  });
+});
+
+// ─── Context budget scales with provider tier ─────────────────────────────────
+
+// Expected budgets — derived once from the source formula (Math.max(400, floor(jobAdChars/2)))
+// and pinned as hard constants so the tests break if the code diverges from resolveProfile.
+// large (ollama/large): jobAdChars=5000 → budget=2500
+// medium (ollama/medium): jobAdChars=2500 → budget=1250
+// small (ollama/small): jobAdChars=2500 → budget=1250
+const BUDGET_LARGE = 2500;
+const BUDGET_MEDIUM = 1250;
+const BUDGET_SMALL = 1250;
+
+/** Extract the text captured by a named tag-pair regex; throws if the match is absent. */
+function extractTag(user: string, tagRegex: RegExp): string {
+  const m = tagRegex.exec(user);
+  if (!m) throw new Error(`Tag not found in rendered user prompt. Regex: ${tagRegex}`);
+  const captured = m[1];
+  if (captured === undefined)
+    throw new Error(`Capture group 1 missing in match. Regex: ${tagRegex}`);
+  return captured;
+}
+
+describe('buildRewritePrompt — context budget vs provider tier', () => {
+  it('large target gives more surrounding-context chars than small target', () => {
+    const longBefore = 'X'.repeat(8000);
+
+    const { user: userLarge } = buildRewritePrompt({ ...BASE_PARAMS, before: longBefore }, 'large');
+    const { user: userSmall } = buildRewritePrompt({ ...BASE_PARAMS, before: longBefore }, 'small');
+
+    // Count how many 'X's made it into each user prompt — large must have more.
+    const xCountLarge = (userLarge.match(/X/g) ?? []).length;
+    const xCountSmall = (userSmall.match(/X/g) ?? []).length;
+
+    expect(xCountLarge).toBeGreaterThan(xCountSmall);
+  });
+
+  it('the rendered <before> context length in the user prompt equals the exact budget for "large"', () => {
+    // Pass a before string longer than the largest budget so truncation always triggers.
+    const overlong = 'X'.repeat(BUDGET_LARGE + 500);
+    const { user } = buildRewritePrompt({ ...BASE_PARAMS, before: overlong }, 'large');
+
+    // extractTag throws if the tag is absent — no non-null assertion needed.
+    const renderedBefore = extractTag(user, /<before>\n([\s\S]*?)\n<\/before>/);
+
+    // The rendered before context must be EXACTLY BUDGET_LARGE characters of 'X'.
+    // If buildRewritePrompt stopped using resolveProfile (e.g. hardcoded a constant),
+    // this assertion breaks unless that constant happens to equal 2500.
+    expect(renderedBefore.length).toBe(BUDGET_LARGE);
+    expect(renderedBefore).toBe('X'.repeat(BUDGET_LARGE));
+  });
+
+  it('the rendered <after> context length in the user prompt equals the exact budget for "large"', () => {
+    const overlong = 'Y'.repeat(BUDGET_LARGE + 500);
+    const { user } = buildRewritePrompt({ ...BASE_PARAMS, after: overlong }, 'large');
+
+    const renderedAfter = extractTag(user, /<after>\n([\s\S]*?)\n<\/after>/);
+
+    expect(renderedAfter.length).toBe(BUDGET_LARGE);
+    expect(renderedAfter).toBe('Y'.repeat(BUDGET_LARGE));
+  });
+
+  it('the rendered <before> context for "medium" is exactly BUDGET_MEDIUM chars (smaller than large)', () => {
+    const overlong = 'X'.repeat(BUDGET_LARGE + 500);
+    const { user } = buildRewritePrompt({ ...BASE_PARAMS, before: overlong }, 'medium');
+
+    const renderedBefore = extractTag(user, /<before>\n([\s\S]*?)\n<\/before>/);
+
+    expect(renderedBefore.length).toBe(BUDGET_MEDIUM);
+    // Medium budget must be strictly smaller than large, proving tier differentiation.
+    expect(BUDGET_MEDIUM).toBeLessThan(BUDGET_LARGE);
+  });
+
+  it('the rendered <before> context for "small" is exactly BUDGET_SMALL chars', () => {
+    const overlong = 'X'.repeat(BUDGET_LARGE + 500);
+    const { user } = buildRewritePrompt({ ...BASE_PARAMS, before: overlong }, 'small');
+
+    const renderedBefore = extractTag(user, /<before>\n([\s\S]*?)\n<\/before>/);
+
+    expect(renderedBefore.length).toBe(BUDGET_SMALL);
+  });
+
+  it('the context budget is derived from resolveProfile — changing tier changes the rendered budget', () => {
+    // This is the regression guard: pass identical inputs to all three tiers and
+    // assert the rendered before-context lengths differ for large vs. medium/small.
+    const overlong = 'X'.repeat(BUDGET_LARGE + 500);
+    const extractBeforeLen = (tier: 'large' | 'medium' | 'small') => {
+      const { user } = buildRewritePrompt({ ...BASE_PARAMS, before: overlong }, tier);
+      return extractTag(user, /<before>\n([\s\S]*?)\n<\/before>/).length;
+    };
+
+    expect(extractBeforeLen('large')).toBe(BUDGET_LARGE);
+    expect(extractBeforeLen('medium')).toBe(BUDGET_MEDIUM);
+    expect(extractBeforeLen('small')).toBe(BUDGET_SMALL);
+    // large must be strictly greater than both sub-tiers.
+    expect(BUDGET_LARGE).toBeGreaterThan(BUDGET_MEDIUM);
+    expect(BUDGET_LARGE).toBeGreaterThan(BUDGET_SMALL);
+  });
+});
+
+// ─── DOC_LABELS — both document types are handled ────────────────────────────
+
+describe('buildRewritePrompt — docType label in system prompt', () => {
+  it('embeds "résumé" in the system prompt for docType "resume"', () => {
+    const { system } = buildRewritePrompt({ ...BASE_PARAMS, docType: 'resume' });
+    expect(system).toContain('résumé');
+  });
+
+  it('embeds "cover letter" in the system prompt for docType "cover-letter"', () => {
+    const { system } = buildRewritePrompt({ ...BASE_PARAMS, docType: 'cover-letter' });
+    expect(system).toContain('cover letter');
+  });
+});

--- a/packages/prompts/src/generate/rewrite.ts
+++ b/packages/prompts/src/generate/rewrite.ts
@@ -1,0 +1,104 @@
+/**
+ * Inline rewrite of a selected span (F4).
+ *
+ * Given a selected span plus its surrounding context, ask the model to rewrite
+ * ONLY that span per a user instruction, returning the replacement text with no
+ * preamble or quoting. Grounded: the surrounding `before`/`after` is supplied so
+ * the rewrite stays consistent in tense, voice, person, and the document's style;
+ * the model is told never to fabricate facts. Provider-aware via
+ * {@link resolveProfile} — like every other builder, it accepts a bare tier or a
+ * full provider profile, so it adapts across ollama / cloud / cli with zero
+ * per-provider code: the resolved profile sizes how much surrounding context the
+ * prompt carries (more for large-context providers, bounded for small models).
+ */
+
+import { type PromptTarget, resolveProfile } from '../provider/index.js';
+
+export type RewriteDocType = 'resume' | 'cover-letter';
+
+export interface RewriteParams {
+  /** The exact selected span the user wants rewritten. */
+  selection: string;
+  /**
+   * The user's free-text instruction (or a preset's instruction).
+   *
+   * SECURITY: this MUST be user-originated — it is deliberately treated as an
+   * instruction the model obeys. Never build it from other users' data, scraped
+   * job-ad text, company-research briefs, or any untrusted source; doing so would
+   * turn a prompt-injection payload into a live instruction. The grounded
+   * before/after/selection context is fenced; the instruction is not.
+   */
+  instruction: string;
+  /** Text immediately preceding the selection — context only, never rewritten. */
+  before: string;
+  /** Text immediately following the selection — context only, never rewritten. */
+  after: string;
+  docType: RewriteDocType;
+}
+
+/**
+ * Typed doc label map — a Record keyed by RewriteDocType so adding a new doc type
+ * is a compile-time error here until a label is provided (exhaustiveness).
+ */
+const DOC_LABELS: Record<RewriteDocType, string> = {
+  resume: 'résumé',
+  'cover-letter': 'cover letter',
+};
+
+// Hard cap on the selected span itself so a huge selection can't blow a small
+// model's context (the selection is echoed verbatim into the prompt). Generous
+// enough for any realistic paragraph-level rewrite.
+const MAX_SELECTION_CHARS = 4000;
+
+/**
+ * Build the rewrite system + user prompt. The system prompt fixes the contract
+ * (return only the span, preserve style, no fabrication); the user prompt carries
+ * the grounded context, the instruction, and the span to rewrite.
+ */
+export function buildRewritePrompt(
+  params: RewriteParams,
+  target: PromptTarget = 'large'
+): { system: string; user: string } {
+  const { selection, instruction, before, after, docType } = params;
+  // Resolve the provider profile and size the surrounding-context budget from it:
+  // larger-context providers (cloud / large local) get more grounding for a
+  // more consistent rewrite, while small models stay bounded. Derived from the
+  // resolved job-ad slice (a comparable "reference text" budget) rather than a
+  // fixed constant, so the rewrite participates in the provider abstraction
+  // instead of discarding it. Both neighbours share the budget (÷2), floored so
+  // even the smallest tier keeps a usable style cue.
+  const { jobAdChars } = resolveProfile(target);
+  const contextChars = Math.max(400, Math.floor(jobAdChars / 2));
+
+  const doc = DOC_LABELS[docType];
+  const span = selection.slice(0, MAX_SELECTION_CHARS);
+  const beforeCtx = before.slice(-contextChars);
+  const afterCtx = after.slice(0, contextChars);
+
+  const system = `You rewrite a single selected span inside a candidate's ${doc}.
+
+ABSOLUTE RULES — never break these:
+1. Rewrite ONLY the text inside <selection>. Treat <before> and <after> as read-only context — never repeat, continue, or alter them.
+2. Output the rewritten span ONLY — no preamble, no explanation, no quotation marks, no surrounding context, no labels.
+3. Preserve the document's tense, voice, grammatical person, and overall style so the rewrite reads as one continuous piece with the surrounding text.
+4. Never fabricate facts: keep every concrete claim (skills, employers, titles, metrics, dates) that the original span asserts. You may rephrase, tighten, or expand wording, but do not invent new facts not present in the span.
+5. Follow the user's instruction. If it conflicts with these rules, keep the rules.
+6. Stay in the same language as the selected span.`;
+
+  const user = `<before>
+${beforeCtx}
+</before>
+<selection>
+${span}
+</selection>
+<after>
+${afterCtx}
+</after>
+
+### INSTRUCTION ###
+${instruction}
+
+Rewrite <selection> following the instruction. Output ONLY the rewritten span — nothing else:`;
+
+  return { system, user };
+}

--- a/packages/shared/scripts/gen-ipc-rust.ts
+++ b/packages/shared/scripts/gen-ipc-rust.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import {
   AiGenerateRequestSchema,
   AiGenerationSaveSchema,
+  AiGenerationUpdateSchema,
   AutopilotCreateSchema,
   AutopilotUpdateSchema,
   ConversationSaveMessageSchema,
@@ -60,6 +61,7 @@ const MODULES: ModuleSpec[] = [
       { rustName: 'AiGenerateRequest', schema: AiGenerateRequestSchema },
       { rustName: 'AiEmbedRequest', schema: EmbedRequestSchema },
       { rustName: 'AiGenerationSaveRequest', schema: AiGenerationSaveSchema },
+      { rustName: 'AiGenerationUpdateRequest', schema: AiGenerationUpdateSchema },
     ],
   },
   {

--- a/packages/shared/src/ipc/contracts/aiGenerations.ts
+++ b/packages/shared/src/ipc/contracts/aiGenerations.ts
@@ -53,14 +53,29 @@ export interface AiGenerationSaveRequest {
   companyBrief?: string;
 }
 
+/**
+ * Edit the résumé/cover-letter text of an existing saved generation, selected by
+ * `id`. Unlike {@link AiGenerationSaveRequest} (a per-job merge-upsert that keeps
+ * existing non-empty text), this is a direct overwrite — so a user editing a
+ * saved generation can blank out or fully replace the text. Each text field is
+ * optional; an absent field is left unchanged.
+ */
+export interface AiGenerationUpdateRequest {
+  id: string;
+  resumeText?: string;
+  coverLetterText?: string;
+}
+
 export interface AiGenerationsContract {
   list(): Promise<AiGenerationRecord[]>;
   save(req: AiGenerationSaveRequest): Promise<{ id: string; success: boolean }>;
+  update(req: AiGenerationUpdateRequest): Promise<void>;
   remove(id: string): Promise<void>;
 }
 
 export const AI_GENERATIONS_CHANNELS = {
   list: 'aiGenerations:list',
   save: 'aiGenerations:save',
+  update: 'aiGenerations:update',
   remove: 'aiGenerations:remove',
 } as const;

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -122,6 +122,7 @@ export {
   type AiGenerationRecord,
   type AiGenerationSaveRequest,
   type AiGenerationsContract,
+  type AiGenerationUpdateRequest,
   type ApplicationAnswer,
 } from './aiGenerations.js';
 export {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -182,6 +182,18 @@ export const AiGenerationSaveSchema = z.object({
 // Note: the `AiGenerationSaveRequest` type is declared in the aiGenerations IPC
 // contract (single source for that name); this schema validates the same shape.
 
+// Edit the résumé/cover-letter text of an existing saved generation, selected by
+// `id`. Unlike the save merge-upsert this is a direct overwrite, so the user can
+// blank out or fully replace text the merge would otherwise have kept. Each text
+// field is optional — absent means "leave that field unchanged".
+export const AiGenerationUpdateSchema = z.object({
+  id: z.string(),
+  resumeText: z.string().optional(),
+  coverLetterText: z.string().optional(),
+});
+// Note: the `AiGenerationUpdateRequest` type is declared in the aiGenerations IPC
+// contract (single source for that name); this schema validates the same shape.
+
 export const ConversationSaveMessageSchema = z.object({
   conversationId: z.string().default('default'),
   role: z.string().default('user'),

--- a/packages/ui/src/components/TextArea/TextArea.tsx
+++ b/packages/ui/src/components/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import type { TextareaHTMLAttributes } from 'react';
+import { forwardRef, type TextareaHTMLAttributes } from 'react';
 
 import { cn } from '../../lib/cn';
 
@@ -6,16 +6,21 @@ export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
   variant?: 'default' | 'glass';
 }
 
-export function TextArea({ className, variant = 'default', ...props }: TextAreaProps) {
-  return (
-    <textarea
-      className={cn(
-        'input-field w-full resize-none text-sm leading-relaxed text-foreground placeholder:text-foreground/30',
-        variant === 'glass' && 'glass-dropdown rounded-lg px-3 py-2',
-        variant === 'default' && 'bg-transparent',
-        className
-      )}
-      {...props}
-    />
-  );
-}
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  ({ className, variant = 'default', ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        className={cn(
+          'input-field w-full resize-none text-sm leading-relaxed text-foreground placeholder:text-foreground/30',
+          variant === 'glass' && 'glass-dropdown rounded-lg px-3 py-2',
+          variant === 'default' && 'bg-transparent',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+TextArea.displayName = 'TextArea';


### PR DESCRIPTION
## What

Two features (the editor work + the inline rewrite ride together because F4 is built into the shared editor), plus a carried-over docs commit.

### F1 — Edit generated text before export, everywhere
Editing already worked in the main **AI Generate** flow, but the two other export surfaces were read-only. This extracts the Preview|Edit pattern into a shared `EditableOutput` component and uses it on all three:
- **AI Generate** (`OutputPanelDone`) — refactored onto the shared component (and the misleading "display-only" comment removed).
- **Saved generations** (`GenerationCard`) — now editable; edits persist to the record via a new `generation_update` IPC (optimistic cache, debounced on blur).
- **Autopilot apply modal** (`GenerationOutput`) — now editable; `save` returns the row id, captured on the session so edits persist via `generation_update`.

Raw-text editing only — the exporter re-parses the text as before, so no export-pipeline changes.

### F4 — Inline AI rewrite of a selection
Highlight a span in the editor and rewrite just that span via quick presets (Shorten, Expand, Rephrase, More impact, Fix grammar) or a free instruction. The streamed result previews in a popover and replaces **only** the selection on Accept.
- New provider-aware `buildRewritePrompt` + `rewriteSelection` **reuse the existing `streamGenerate` pipeline — no new generation IPC** (zero-change provider rule).
- The popover **freezes the selection range + snapshot**, locks the textarea (`readOnly`, not `disabled`) while streaming, runs a single in-flight request (aborts on reselect/cancel/unmount), traps focus (`aria-modal` + `useFocusTrap`), and is keyboard/Escape accessible.
- Guards against silent data loss: a failed or empty/whitespace result surfaces an error and **disables Accept** so the selection is never deleted.

### Backend / IPC
- New `aiGenerations.update({ id, resumeText?, coverLetterText? })` (Zod schema → codegen → command → store `update_texts` → client → optimistic hook → mock client). `update_texts` is a field-selective UPDATE that **errors when no row matches** (prevents a silent optimistic-cache divergence).

### Carried docs
Includes the `docs: document the numberfield primitive` commit (the `NumberField` design-system + CLAUDE.md entries authored after #261 was pushed), per the agreed fold-forward.

## Notes / UX
- The rewrite trigger lives in **Edit view** (the editor defaults to Preview) — by design, since selecting text is an editing action. Discoverability could be revisited if desired.

## Tests
- Rust: `update_texts` — per-field updates, both-None no-op, and unknown-id error across all three arms.
- Prompts: `buildRewritePrompt` — return-only-span contract, selection cap, and context budget pinned against the **rendered output** (non-tautological), `DOC_LABELS`.
- Renderer: `EditableOutput` splice (incl. offset-0 and end boundaries), stream-rejection + empty-result guards (no `onChange`, Accept disabled), `readOnly`-while-streaming; `GenerationCard` debounced persist (single call with last value, cancellation proof, resume + cover paths).

## Review
Implemented and reviewed via the agent pipeline: `rust-backend-architect` (IPC/store), `ai-provider-expert` (rewrite prompt), `frontend-reviewer` (renderer) — all HIGH findings resolved; `test-author` → `testing-reviewer` (all HIGH test findings resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)