### PR TITLE
feat: warn on contact mismatch when importing a resume

### DIFF
--- a/apps/tauri/src-tauri/src/commands/documents.rs
+++ b/apps/tauri/src-tauri/src/commands/documents.rs
@@ -59,6 +59,13 @@ pub async fn documents_import(app: AppHandle, req: DocumentsImportRequest) -> Va
     // completed with the résumé's email / phone / location / extra links. The
     // header builds from these named fields, which is what keeps a company link
     // out of the document header.
+    // Conflicts between the imported contact and the saved profile (both sides
+    // non-empty, normalized values differ). The import NEVER blocks on these — it
+    // still silently fills empty fields below — but they (plus the full extracted
+    // contact) are returned so the renderer can let the user resolve each one. If
+    // there is no contact-profile state, conflicts are empty and `suggested` null.
+    let mut contact_conflicts: Vec<crate::contact_profile::ContactFieldConflict> = Vec::new();
+    let mut suggested_contact: Value = json!(null);
     if let Some(cp_store) = app.try_state::<crate::contact_profile::ContactProfileStore>() {
         let mut suggested = crate::contact_profile::classify_contact_links(&extraction.links);
         if let Some(email) = structured.email.as_ref().map(|f| f.value.clone()) {
@@ -77,12 +84,22 @@ pub async fn documents_import(app: AppHandle, req: DocumentsImportRequest) -> Va
                     });
             }
         }
+        let current = cp_store.get();
+        contact_conflicts = crate::contact_profile::detect_contact_conflicts(&current, &suggested);
+        suggested_contact = serde_json::to_value(&suggested).unwrap_or(json!(null));
         if !suggested.is_effectively_empty() {
-            let mut current = cp_store.get();
-            current.fill_empty_from(&suggested);
-            let _ = cp_store.set(&current);
+            // Empty fields still fill silently; conflicting (already-set) fields
+            // are preserved and reported above for the user to resolve.
+            let mut merged = current.clone();
+            merged.fill_empty_from(&suggested);
+            if let Err(e) = cp_store.set(&merged) {
+                // Import still succeeds; only the autofill persist failed. Log the
+                // error WITHOUT any contact values (no email/phone/name/url — PII).
+                tracing::warn!(error = %e, "failed to persist autofilled contact profile on import");
+            }
         }
     }
+    let conflicts_json = serde_json::to_value(&contact_conflicts).unwrap_or(json!([]));
 
     let store = app.state::<crate::documents::DocumentStore>();
     let doc_id = crate::documents::make_doc_id();
@@ -98,7 +115,13 @@ pub async fn documents_import(app: AppHandle, req: DocumentsImportRequest) -> Va
         is_default: false,
     };
     match store.insert(&record) {
-        Ok(()) => json!({ "id": doc_id, "success": true, "review": review }),
+        Ok(()) => json!({
+            "id": doc_id,
+            "success": true,
+            "review": review,
+            "contactConflicts": conflicts_json,
+            "suggestedContact": suggested_contact,
+        }),
         Err(e) => json!({ "error": e.to_string() }),
     }
 }

--- a/apps/tauri/src-tauri/src/contact_profile/mod.rs
+++ b/apps/tauri/src-tauri/src/contact_profile/mod.rs
@@ -68,6 +68,24 @@ pub struct ContactLink {
     pub url: String,
 }
 
+/// A single identity field where the imported résumé's value CONFLICTS with the
+/// value already saved in the contact profile (both non-empty, normalized values
+/// differ). The import never blocks on these — it still silently fills empty
+/// fields — but the renderer surfaces them so the user can resolve each one. The
+/// values reported are the ORIGINAL (un-normalized) strings so the UI shows them
+/// faithfully.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContactFieldConflict {
+    /// Stable key: `email`, `phone`, `linkedin`, `github`, `website`, or
+    /// `location`.
+    pub field: String,
+    /// The value currently saved in the profile (un-normalized).
+    pub current: String,
+    /// The value extracted from the imported résumé (un-normalized).
+    pub suggested: String,
+}
+
 /// The header contact fields, by name. Every field is optional so a partial
 /// profile still produces a valid (shorter) header. The order the header renders
 /// in is fixed by [`Self::header_markdown`], not by field discovery order.
@@ -249,6 +267,136 @@ impl ContactProfile {
 
 fn non_empty(v: &Option<String>) -> Option<&str> {
     v.as_deref().map(str::trim).filter(|s| !s.is_empty())
+}
+
+// ── Conflict detection (resolvable mismatches on import) ──────────────────────
+
+/// Normalize an email for comparison: trim + lowercase.
+fn norm_email(s: &str) -> String {
+    s.trim().to_lowercase()
+}
+
+/// Normalize a phone for comparison: digits only (drops spaces, `()`, `-`, `+`,
+/// `.`, and any other formatting), so `+1 (555) 123-4567` == `15551234567`.
+fn norm_phone(s: &str) -> String {
+    s.chars().filter(char::is_ascii_digit).collect()
+}
+
+/// Normalize a URL for comparison: lowercase host (via [`host_of`], which already
+/// strips scheme + `www.`) joined with the trimmed path (lowercased, trailing
+/// slash removed). Keeps `http` vs `https`, a trailing slash, and a `www.` prefix
+/// from registering as conflicts, e.g. `linkedin.com/in/x`,
+/// `https://www.linkedin.com/in/x/`, and `http://linkedin.com/in/x` all normalize
+/// equal.
+fn norm_url(s: &str) -> String {
+    let host = host_of(s).unwrap_or_default();
+    let lower = s.trim().to_lowercase();
+    let no_scheme = lower
+        .strip_prefix("https://")
+        .or_else(|| lower.strip_prefix("http://"))
+        .unwrap_or(&lower);
+    let path = no_scheme
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(no_scheme)
+        .split_once('/')
+        .map(|(_, rest)| rest)
+        .unwrap_or("");
+    let path = path.trim_end_matches('/');
+    if path.is_empty() {
+        host
+    } else {
+        format!("{host}/{path}")
+    }
+}
+
+/// Normalize a plain text value (full name / location) for comparison: trim +
+/// lowercase (case-insensitive).
+fn norm_text(s: &str) -> String {
+    s.trim().to_lowercase()
+}
+
+/// Detect the identity fields where `current` (the saved profile) and `suggested`
+/// (the imported résumé's extracted contact) CONFLICT — i.e. BOTH are non-empty
+/// after trimming AND their normalized values differ. Compares only the
+/// single-valued identity fields (email, phone, linkedin, github, website, and
+/// `location.default`); `extra_links` is a list merged by URL and is
+/// never reported here. The conflict carries the ORIGINAL values so the UI shows
+/// them as written. Conservative by design: scheme, trailing slash, and `www.`
+/// differences on URLs are NOT conflicts (see [`norm_url`]).
+pub fn detect_contact_conflicts(
+    current: &ContactProfile,
+    suggested: &ContactProfile,
+) -> Vec<ContactFieldConflict> {
+    let mut out = Vec::new();
+
+    fn push_if_conflict(
+        out: &mut Vec<ContactFieldConflict>,
+        field: &str,
+        cur: Option<&str>,
+        sug: Option<&str>,
+        normalize: impl Fn(&str) -> String,
+    ) {
+        if let (Some(cur), Some(sug)) = (cur, sug) {
+            if normalize(cur) != normalize(sug) {
+                out.push(ContactFieldConflict {
+                    field: field.to_string(),
+                    current: cur.to_string(),
+                    suggested: sug.to_string(),
+                });
+            }
+        }
+    }
+
+    push_if_conflict(
+        &mut out,
+        "email",
+        non_empty(&current.email),
+        non_empty(&suggested.email),
+        norm_email,
+    );
+    push_if_conflict(
+        &mut out,
+        "phone",
+        non_empty(&current.phone),
+        non_empty(&suggested.phone),
+        norm_phone,
+    );
+    push_if_conflict(
+        &mut out,
+        "linkedin",
+        non_empty(&current.linkedin),
+        non_empty(&suggested.linkedin),
+        norm_url,
+    );
+    push_if_conflict(
+        &mut out,
+        "github",
+        non_empty(&current.github),
+        non_empty(&suggested.github),
+        norm_url,
+    );
+    push_if_conflict(
+        &mut out,
+        "website",
+        non_empty(&current.website),
+        non_empty(&suggested.website),
+        norm_url,
+    );
+
+    let cur_loc = current
+        .location
+        .as_ref()
+        .map(|l| l.default.trim())
+        .filter(|s| !s.is_empty());
+    let sug_loc = suggested
+        .location
+        .as_ref()
+        .map(|l| l.default.trim())
+        .filter(|s| !s.is_empty());
+    push_if_conflict(&mut out, "location", cur_loc, sug_loc, norm_text);
+
+    out
 }
 
 // ── Link classification (seeding suggestions) ─────────────────────────────────

--- a/apps/tauri/src-tauri/src/contact_profile/test.rs
+++ b/apps/tauri/src-tauri/src/contact_profile/test.rs
@@ -230,3 +230,441 @@ fn localized_text_resolves_primary_subtag() {
     assert_eq!(loc.resolve("en"), "Netherlands");
     assert_eq!(loc.resolve("fr"), "Netherlands");
 }
+
+// ── detect_contact_conflicts — no-conflict (normalized-equal) cases ───────────
+
+/// Same email differing only in case → normalized equal → no conflict.
+#[test]
+fn no_conflict_email_case_insensitive() {
+    let current = ContactProfile {
+        email: Some("Alex.Carter@Example.COM".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        email: Some("alex.carter@example.com".into()),
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "same email differing only by case must not produce a conflict"
+    );
+}
+
+/// Same phone formatted differently → digits-only normalization → no conflict.
+#[test]
+fn no_conflict_phone_formatting_differences() {
+    let current = ContactProfile {
+        phone: Some("+1 (555) 123-4567".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        phone: Some("15551234567".into()),
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "same phone with different formatting must not produce a conflict"
+    );
+}
+
+/// Same LinkedIn URL differing by scheme, www., and trailing slash → no conflict.
+#[test]
+fn no_conflict_url_scheme_www_trailing_slash() {
+    let current = ContactProfile {
+        linkedin: Some("https://www.linkedin.com/in/x/".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        linkedin: Some("http://linkedin.com/in/x".into()),
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "same URL differing only by scheme/www./trailing-slash must not produce a conflict"
+    );
+}
+
+/// Same website URL differing by https vs http → no conflict.
+#[test]
+fn no_conflict_website_scheme_only() {
+    let current = ContactProfile {
+        website: Some("https://my-portfolio.dev/work".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        website: Some("http://my-portfolio.dev/work".into()),
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "same website URL differing only by http/https scheme must not produce a conflict"
+    );
+}
+
+// ── detect_contact_conflicts — real conflict cases ────────────────────────────
+
+/// Genuinely different email values → one conflict with correct field key and
+/// original (un-normalized) current/suggested values.
+#[test]
+fn conflict_different_email() {
+    let current = ContactProfile {
+        email: Some("alice@example.com".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        email: Some("bob@example.com".into()),
+        ..Default::default()
+    };
+    let conflicts = detect_contact_conflicts(&current, &suggested);
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "expected exactly one conflict: {conflicts:?}"
+    );
+    let c = &conflicts[0];
+    assert_eq!(c.field, "email");
+    assert_eq!(c.current, "alice@example.com");
+    assert_eq!(c.suggested, "bob@example.com");
+}
+
+/// Genuinely different phone numbers → one conflict with original values.
+#[test]
+fn conflict_different_phone() {
+    let current = ContactProfile {
+        phone: Some("+31 6 12345678".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        phone: Some("+1 (800) 555-0199".into()),
+        ..Default::default()
+    };
+    let conflicts = detect_contact_conflicts(&current, &suggested);
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "expected exactly one conflict: {conflicts:?}"
+    );
+    let c = &conflicts[0];
+    assert_eq!(c.field, "phone");
+    assert_eq!(c.current, "+31 6 12345678");
+    assert_eq!(c.suggested, "+1 (800) 555-0199");
+}
+
+/// Genuinely different LinkedIn paths → one conflict.
+#[test]
+fn conflict_different_linkedin() {
+    let current = ContactProfile {
+        linkedin: Some("https://linkedin.com/in/alice".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        linkedin: Some("https://linkedin.com/in/bob".into()),
+        ..Default::default()
+    };
+    let conflicts = detect_contact_conflicts(&current, &suggested);
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "expected exactly one conflict: {conflicts:?}"
+    );
+    assert_eq!(conflicts[0].field, "linkedin");
+    assert_eq!(conflicts[0].current, "https://linkedin.com/in/alice");
+    assert_eq!(conflicts[0].suggested, "https://linkedin.com/in/bob");
+}
+
+/// Genuinely different GitHub usernames → one conflict with correct field key
+/// and original un-normalized current/suggested values.
+#[test]
+fn conflict_different_github() {
+    let current = ContactProfile {
+        github: Some("https://github.com/alice".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        github: Some("https://github.com/bob".into()),
+        ..Default::default()
+    };
+    let conflicts = detect_contact_conflicts(&current, &suggested);
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "expected exactly one conflict: {conflicts:?}"
+    );
+    let c = &conflicts[0];
+    assert_eq!(c.field, "github");
+    // Original (un-normalized) strings are preserved in the conflict.
+    assert_eq!(c.current, "https://github.com/alice");
+    assert_eq!(c.suggested, "https://github.com/bob");
+}
+
+/// Genuinely different website URLs → one conflict.
+#[test]
+fn conflict_different_website() {
+    let current = ContactProfile {
+        website: Some("https://alice.dev".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        website: Some("https://bob.dev".into()),
+        ..Default::default()
+    };
+    let conflicts = detect_contact_conflicts(&current, &suggested);
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "expected exactly one conflict: {conflicts:?}"
+    );
+    assert_eq!(conflicts[0].field, "website");
+}
+
+/// Genuinely different location.default values → one conflict.
+#[test]
+fn conflict_different_location_default() {
+    let current = ContactProfile {
+        location: Some(LocalizedText {
+            default: "Amsterdam, Netherlands".into(),
+            by_lang: Default::default(),
+        }),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        location: Some(LocalizedText {
+            default: "Berlin, Germany".into(),
+            by_lang: Default::default(),
+        }),
+        ..Default::default()
+    };
+    let conflicts = detect_contact_conflicts(&current, &suggested);
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "expected exactly one conflict: {conflicts:?}"
+    );
+    let c = &conflicts[0];
+    assert_eq!(c.field, "location");
+    assert_eq!(c.current, "Amsterdam, Netherlands");
+    assert_eq!(c.suggested, "Berlin, Germany");
+}
+
+/// location.default case-insensitive → no conflict.
+#[test]
+fn no_conflict_location_case_insensitive() {
+    let current = ContactProfile {
+        location: Some(LocalizedText {
+            default: "Netherlands".into(),
+            by_lang: Default::default(),
+        }),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        location: Some(LocalizedText {
+            default: "netherlands".into(),
+            by_lang: Default::default(),
+        }),
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "location.default differing only by case must not produce a conflict"
+    );
+}
+
+/// Differing byLang with same .default → no conflict (only .default is compared).
+#[test]
+fn no_conflict_location_differing_bylang_only() {
+    let current = ContactProfile {
+        location: Some(LocalizedText {
+            default: "Netherlands".into(),
+            by_lang: [("de".to_string(), "Niederlande".to_string())].into(),
+        }),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        location: Some(LocalizedText {
+            default: "Netherlands".into(),
+            by_lang: [("de".to_string(), "Holland".to_string())].into(),
+        }),
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "identical location.default with differing byLang must not produce a conflict"
+    );
+}
+
+// ── detect_contact_conflicts — one-side-empty cases ──────────────────────────
+
+/// Field present only on current side → not a conflict.
+#[test]
+fn no_conflict_when_suggested_field_empty() {
+    let current = ContactProfile {
+        email: Some("alice@example.com".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        email: None,
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "a field present only on the current side must not produce a conflict"
+    );
+}
+
+/// Field present only on suggested side → not a conflict.
+#[test]
+fn no_conflict_when_current_field_empty() {
+    let current = ContactProfile {
+        email: None,
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        email: Some("bob@example.com".into()),
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "a field present only on the suggested side must not produce a conflict"
+    );
+}
+
+/// Whitespace-only value on suggested side → treated as empty → not a conflict.
+/// `non_empty` is the gate: it trims and rejects blank strings before any
+/// field-comparison normalizer is reached.
+#[test]
+fn no_conflict_when_suggested_whitespace_only() {
+    let current = ContactProfile {
+        phone: Some("+31 6 12345678".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        phone: Some("   ".into()),
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "whitespace-only suggested value must be treated as empty"
+    );
+}
+
+// ── norm_url no-host / malformed-value edge cases ────────────────────────────
+//
+// `non_empty` is the gate: whitespace-only values are filtered before conflict
+// detection and never reach `norm_url`. What follows documents the behavior for
+// the non-empty malformed inputs that DO reach `norm_url`.
+//
+// Finding (no source bug): all cases are deterministic.
+//
+// - A bare non-URL string (e.g. "not-a-url") has no http(s) scheme prefix, so
+//   `norm_url` treats the whole trimmed string as the "host". It normalizes to
+//   itself, which differs from any real URL's normalized form → conflict IS
+//   generated. This is correct behavior: the user stored a malformed value and
+//   the import has a real URL; surfacing the mismatch is the right call.
+//
+// - A scheme-only value (e.g. "https://") passes `non_empty` (it is non-empty
+//   after trimming). `norm_url` strips the scheme, finds no host segment, and
+//   returns "". This differs from any real URL → conflict IS generated.
+//   Documented as expected: the empty-host path produces an empty normal form,
+//   which collides with nothing and correctly triggers a conflict report.
+
+/// A bare non-URL string on the current side vs a real URL on the suggested
+/// side: `non_empty` lets it through; `norm_url` treats the bare string as its
+/// own "host" → the values normalize differently → one conflict is generated.
+#[test]
+fn norm_url_no_host_bare_string_yields_conflict() {
+    let current = ContactProfile {
+        website: Some("not-a-url".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        website: Some("https://alice.dev".into()),
+        ..Default::default()
+    };
+    let conflicts = detect_contact_conflicts(&current, &suggested);
+    // Deterministic: one conflict, original values preserved.
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "bare non-URL vs real URL must produce a conflict: {conflicts:?}"
+    );
+    let c = &conflicts[0];
+    assert_eq!(c.field, "website");
+    assert_eq!(c.current, "not-a-url");
+    assert_eq!(c.suggested, "https://alice.dev");
+}
+
+/// A scheme-only value ("https://") passes `non_empty` (it is non-whitespace)
+/// and normalizes via `norm_url` to "" (no host, no path). A real URL on the
+/// other side normalizes to its host → they differ → one conflict is generated.
+#[test]
+fn norm_url_no_host_scheme_only_yields_conflict() {
+    let current = ContactProfile {
+        linkedin: Some("https://linkedin.com/in/alice".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        linkedin: Some("https://".into()),
+        ..Default::default()
+    };
+    let conflicts = detect_contact_conflicts(&current, &suggested);
+    // Deterministic: one conflict, original values preserved.
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "scheme-only value vs real URL must produce a conflict: {conflicts:?}"
+    );
+    let c = &conflicts[0];
+    assert_eq!(c.field, "linkedin");
+    assert_eq!(c.current, "https://linkedin.com/in/alice");
+    assert_eq!(c.suggested, "https://");
+}
+
+/// extra_links differences are never reported as conflicts.
+#[test]
+fn no_conflict_for_extra_links() {
+    let current = ContactProfile {
+        extra_links: vec![ContactLink {
+            label: "Dribbble".into(),
+            url: "https://dribbble.com/alice".into(),
+        }],
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        extra_links: vec![ContactLink {
+            label: "Behance".into(),
+            url: "https://behance.net/alice".into(),
+        }],
+        ..Default::default()
+    };
+    assert!(
+        detect_contact_conflicts(&current, &suggested).is_empty(),
+        "extra_links differences must never be reported as conflicts"
+    );
+}
+
+/// Multiple genuinely conflicting fields → all reported, in field order.
+#[test]
+fn multiple_conflicts_reported_independently() {
+    let current = ContactProfile {
+        email: Some("alice@example.com".into()),
+        phone: Some("+31 6 00000001".into()),
+        github: Some("https://github.com/alice".into()),
+        ..Default::default()
+    };
+    let suggested = ContactProfile {
+        email: Some("bob@example.com".into()),
+        phone: Some("+31 6 99999999".into()),
+        github: Some("https://github.com/bob".into()),
+        ..Default::default()
+    };
+    let conflicts = detect_contact_conflicts(&current, &suggested);
+    assert_eq!(
+        conflicts.len(),
+        3,
+        "all three conflicts must be reported: {conflicts:?}"
+    );
+    let fields: Vec<&str> = conflicts.iter().map(|c| c.field.as_str()).collect();
+    assert!(fields.contains(&"email"), "email conflict missing");
+    assert!(fields.contains(&"phone"), "phone conflict missing");
+    assert!(fields.contains(&"github"), "github conflict missing");
+}

--- a/apps/tauri/src/renderer/components/contact/ContactConflictModal/ContactConflictModal.test.tsx
+++ b/apps/tauri/src/renderer/components/contact/ContactConflictModal/ContactConflictModal.test.tsx
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+import type { ContactFieldConflict, ContactProfile } from '@ajh/shared';
+import type * as AjhUi from '@ajh/ui';
+
+import { ContactConflictModal } from './index';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+// Vitest hoists vi.mock() calls before any imports at runtime, so the import
+// order above has no effect on mock resolution.
+
+vi.mock('@/lib/i18n', () => ({
+  useTranslation: () => ({ t: (k: string, _opts?: Record<string, unknown>) => k }),
+}));
+
+// useNotification: return a spy; tests assert it is/isn't called.
+const mockNotify = vi.fn<(message: string, variant: string) => void>();
+
+vi.mock('@ajh/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof AjhUi>();
+  return {
+    ...actual,
+    useNotification: () => mockNotify,
+  };
+});
+
+// useContactProfile returns a fixed base profile with a location.byLang.
+// useSaveContactProfile exposes a typed mutateAsync spy.
+const mockMutateAsync = vi.fn<(profile: ContactProfile) => Promise<void>>();
+
+vi.mock('@/services', () => ({
+  useContactProfile: (): { data: ContactProfile } => ({
+    data: BASE_PROFILE,
+  }),
+  useSaveContactProfile: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const BASE_PROFILE: ContactProfile = {
+  fullName: 'Alex Carter',
+  email: 'alex@example.com',
+  phone: '+31 6 12345678',
+  location: {
+    default: 'Amsterdam, Netherlands',
+    byLang: { de: 'Amsterdam, Niederlande' },
+  },
+  linkedin: 'https://linkedin.com/in/alexcarter',
+  github: 'https://github.com/alexcarter',
+  website: 'https://alex.dev',
+};
+
+// NOTE: EMAIL_CONFLICT.current is intentionally DIFFERENT from BASE_PROFILE.email
+// so the keep-mine test is observable: if the component ignores `fields[field].value`
+// and blindly spreads BASE_PROFILE, saved.email would be 'alex@example.com' (the
+// base profile value) rather than 'old.alex@example.com' (the conflict's current).
+const EMAIL_CONFLICT: ContactFieldConflict = {
+  field: 'email',
+  current: 'old.alex@example.com',
+  suggested: 'alex.carter@resume.com',
+};
+
+const PHONE_CONFLICT: ContactFieldConflict = {
+  field: 'phone',
+  current: '+31 6 12345678',
+  suggested: '+1 (800) 555-0199',
+};
+
+const LOCATION_CONFLICT: ContactFieldConflict = {
+  field: 'location',
+  current: 'Amsterdam, Netherlands',
+  suggested: 'Berlin, Germany',
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+interface RenderOpts {
+  conflicts?: ContactFieldConflict[];
+  onClose?: () => void;
+  onResolved?: () => void;
+}
+
+function renderModal({
+  conflicts = [EMAIL_CONFLICT],
+  onClose = vi.fn<() => void>(),
+  onResolved = vi.fn<() => void>(),
+}: RenderOpts = {}) {
+  render(
+    <ContactConflictModal
+      open={true}
+      conflicts={conflicts}
+      onClose={onClose}
+      onResolved={onResolved}
+    />
+  );
+  return { onClose, onResolved };
+}
+
+/** Click the Save button and wait for async save to settle. */
+async function clickSave() {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /contactConflict\.save/i }));
+  });
+}
+
+/** Find the SegmentedControl radio for a given i18n label key. */
+function getRadio(labelKey: string) {
+  return screen.getByRole('radio', { name: labelKey });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ContactConflictModal — F2 contact-mismatch warning', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset();
+    mockNotify.mockReset();
+    mockMutateAsync.mockResolvedValue(undefined);
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it('renders one row per conflict, showing both current and suggested values', () => {
+    renderModal({ conflicts: [EMAIL_CONFLICT, PHONE_CONFLICT] });
+
+    // Both current values appear.
+    expect(screen.getByText(EMAIL_CONFLICT.current)).toBeInTheDocument();
+    expect(screen.getByText(PHONE_CONFLICT.current)).toBeInTheDocument();
+    // Both suggested values appear.
+    expect(screen.getByText(EMAIL_CONFLICT.suggested)).toBeInTheDocument();
+    expect(screen.getByText(PHONE_CONFLICT.suggested)).toBeInTheDocument();
+  });
+
+  it('renders one editable Input per conflict, pre-seeded with the current value', () => {
+    renderModal({ conflicts: [EMAIL_CONFLICT, PHONE_CONFLICT] });
+
+    const inputs = screen.getAllByRole('textbox');
+    const inputValues = inputs.map((el) => (el as HTMLInputElement).value);
+    expect(inputValues).toContain(EMAIL_CONFLICT.current);
+    expect(inputValues).toContain(PHONE_CONFLICT.current);
+  });
+
+  // ── Default keep-mine ──────────────────────────────────────────────────────
+
+  it('default keep-mine: Save routes through fields[field].value seeded to conflict.current', async () => {
+    // EMAIL_CONFLICT.current ('old.alex@example.com') differs from BASE_PROFILE.email
+    // ('alex@example.com'). A no-op implementation that blindly spreads the base
+    // profile would save BASE_PROFILE.email — this test catches that regression.
+    renderModal({ conflicts: [EMAIL_CONFLICT] });
+
+    // 'mine' radio is default (aria-checked=true on keep-mine option).
+    const keepMineRadio = getRadio('settings.contactConflict.keepMine');
+    expect(keepMineRadio).toHaveAttribute('aria-checked', 'true');
+
+    await clickSave();
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    const saved = mockMutateAsync.mock.calls[0]?.[0] as ContactProfile;
+
+    // Must equal conflict.current — the value seeded into fields[email].value —
+    // NOT BASE_PROFILE.email. Asserts the full computed payload shape too.
+    expect(saved.email).toBe(EMAIL_CONFLICT.current);
+    expect(saved.email).not.toBe(BASE_PROFILE.email);
+    // Non-conflicting fields are preserved from the base profile.
+    expect(saved.phone).toBe(BASE_PROFILE.phone);
+    expect(saved.linkedin).toBe(BASE_PROFILE.linkedin);
+    expect(saved.github).toBe(BASE_PROFILE.github);
+    expect(saved.website).toBe(BASE_PROFILE.website);
+  });
+
+  // ── Switch to use-résumé ───────────────────────────────────────────────────
+
+  it('switch to use-résumé: Save payload has the field set to conflict.suggested', async () => {
+    renderModal({ conflicts: [EMAIL_CONFLICT] });
+
+    // Switch to use-résumé.
+    fireEvent.click(getRadio('settings.contactConflict.useResume'));
+    await clickSave();
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    const saved = mockMutateAsync.mock.calls[0]?.[0] as ContactProfile;
+    expect(saved.email).toBe(EMAIL_CONFLICT.suggested);
+  });
+
+  // ── Edit the Input then use-résumé ────────────────────────────────────────
+
+  it('editing the Input then choosing use-résumé: Save payload uses the EDITED value', async () => {
+    renderModal({ conflicts: [EMAIL_CONFLICT] });
+
+    // Switch to use-résumé first — seeds the input with suggested.
+    fireEvent.click(getRadio('settings.contactConflict.useResume'));
+
+    // Now hand-edit the Input to a custom value.
+    const input = screen
+      .getAllByRole('textbox')
+      .find((el) => (el as HTMLInputElement).value === EMAIL_CONFLICT.suggested);
+    if (!input) throw new Error('input seeded with suggested value not found');
+    fireEvent.change(input, { target: { value: 'custom@edited.com' } });
+
+    await clickSave();
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    const saved = mockMutateAsync.mock.calls[0]?.[0] as ContactProfile;
+    expect(saved.email).toBe('custom@edited.com');
+  });
+
+  // ── location field: byLang preserved ──────────────────────────────────────
+
+  it('location use-résumé: payload location.default = suggested AND existing byLang preserved', async () => {
+    renderModal({ conflicts: [LOCATION_CONFLICT] });
+
+    fireEvent.click(getRadio('settings.contactConflict.useResume'));
+    await clickSave();
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    const saved = mockMutateAsync.mock.calls[0]?.[0] as ContactProfile;
+    expect(saved.location?.default).toBe(LOCATION_CONFLICT.suggested);
+    // byLang from BASE_PROFILE must be preserved intact.
+    expect(saved.location?.byLang).toEqual(BASE_PROFILE.location?.byLang);
+  });
+
+  // ── Clearing the location Input ────────────────────────────────────────────
+
+  it('clearing the location Input: location kept as current (no empty default written)', async () => {
+    renderModal({ conflicts: [LOCATION_CONFLICT] });
+
+    // Switch to use-résumé, then clear the input.
+    fireEvent.click(getRadio('settings.contactConflict.useResume'));
+    const input = screen
+      .getAllByRole('textbox')
+      .find((el) => (el as HTMLInputElement).value === LOCATION_CONFLICT.suggested);
+    if (!input) throw new Error('location input not found');
+    fireEvent.change(input, { target: { value: '' } });
+
+    await clickSave();
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    const saved = mockMutateAsync.mock.calls[0]?.[0] as ContactProfile;
+    // An empty value must NOT write an empty-string default — location stays
+    // as it was on the base profile.
+    expect(saved.location?.default).toBe(BASE_PROFILE.location?.default);
+  });
+
+  // ── Dismiss / cancel ───────────────────────────────────────────────────────
+
+  it('clicking the Dismiss button does not call mutateAsync', () => {
+    const onClose = vi.fn<() => void>();
+    renderModal({ conflicts: [EMAIL_CONFLICT], onClose });
+
+    fireEvent.click(screen.getByRole('button', { name: /contactConflict\.dismiss/i }));
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Multiple conflicts, partial resolution ─────────────────────────────────
+
+  it('multiple conflicts: each field resolved independently', async () => {
+    renderModal({ conflicts: [EMAIL_CONFLICT, PHONE_CONFLICT] });
+
+    // Each SegmentedControl renders as a radiogroup. The conflicts array order
+    // matches the DOM order: index 0 = email, index 1 = phone.
+    const [emailGroup, phoneGroup] = screen.getAllByRole('radiogroup');
+    if (!emailGroup || !phoneGroup) throw new Error('radiogroups not found');
+
+    // For email: switch to use-résumé using a scoped query inside that group.
+    fireEvent.click(
+      within(emailGroup).getByRole('radio', { name: 'settings.contactConflict.useResume' })
+    );
+    // For phone: leave as keep-mine (already the default).
+
+    await clickSave();
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    const saved = mockMutateAsync.mock.calls[0]?.[0] as ContactProfile;
+    expect(saved.email).toBe(EMAIL_CONFLICT.suggested);
+    // phone must be the conflict.current value (keep-mine path via fields state).
+    expect(saved.phone).toBe(PHONE_CONFLICT.current);
+  });
+
+  // ── onResolved callback ────────────────────────────────────────────────────
+
+  it('Save calls onResolved and onClose after successful mutateAsync', async () => {
+    const onResolved = vi.fn<() => void>();
+    const onClose = vi.fn<() => void>();
+    renderModal({ conflicts: [EMAIL_CONFLICT], onResolved, onClose });
+
+    await clickSave();
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+    // Success path must close the modal.
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Save does NOT call onResolved or onClose when mutateAsync rejects', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('save failed'));
+    const onResolved = vi.fn<() => void>();
+    const onClose = vi.fn<() => void>();
+    renderModal({ conflicts: [EMAIL_CONFLICT], onResolved, onClose });
+
+    await clickSave();
+
+    await waitFor(() => expect(mockNotify).toHaveBeenCalled());
+    // Error path must keep the modal open.
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/tauri/src/renderer/components/contact/ContactConflictModal/index.tsx
+++ b/apps/tauri/src/renderer/components/contact/ContactConflictModal/index.tsx
@@ -1,0 +1,221 @@
+import { UserCheck } from 'lucide-react';
+import { useState } from 'react';
+
+import type { ContactFieldConflict, ContactProfile } from '@ajh/shared';
+import { Button, Input, ModalShell, SegmentedControl, useNotification } from '@ajh/ui';
+
+import { useTranslation } from '@/lib/i18n';
+import { useContactProfile, useSaveContactProfile } from '@/services';
+
+interface ContactConflictModalProps {
+  open: boolean;
+  conflicts: ContactFieldConflict[];
+  /** Dismiss without changing the saved profile (Escape / backdrop / Cancel). */
+  onClose: () => void;
+  /** Fired after the merged profile is persisted. */
+  onResolved?: () => void;
+}
+
+/** Plain string properties on `ContactProfile` that a conflict can target. */
+type StringProfileField = 'fullName' | 'email' | 'phone' | 'linkedin' | 'github' | 'website';
+
+const STRING_FIELDS: readonly StringProfileField[] = [
+  'fullName',
+  'email',
+  'phone',
+  'linkedin',
+  'github',
+  'website',
+];
+
+/** Per-field resolution choice. `mine` keeps the saved value (non-destructive default). */
+type Choice = 'mine' | 'resume';
+
+interface FieldState {
+  choice: Choice;
+  /** The editable value, seeded from the chosen side and tweakable before saving. */
+  value: string;
+}
+
+/** Maps a stable conflict `field` key to the i18n label key for that field. */
+function labelKey(field: string): string {
+  // Identity fields reuse the existing contact-profile labels where possible.
+  switch (field) {
+    case 'fullName':
+      return 'settings.contactProfile.fullName';
+    case 'email':
+      return 'settings.contactProfile.email';
+    case 'phone':
+      return 'settings.contactProfile.phone';
+    case 'location':
+      return 'settings.contactProfile.location';
+    case 'linkedin':
+      return 'settings.contactProfile.linkedin';
+    case 'github':
+      return 'settings.contactProfile.github';
+    case 'website':
+      return 'settings.contactProfile.website';
+    default:
+      return field;
+  }
+}
+
+/**
+ * Post-import follow-up that lets the user reconcile saved contact fields with
+ * the values extracted from a freshly-imported résumé. It is never a gate — the
+ * résumé is already imported and empty fields were already autofilled silently.
+ * Dismissing keeps the current profile untouched.
+ *
+ * Per conflict the user picks "keep mine" or "use résumé's", and can edit the
+ * resulting value inline before saving. On save we read the current profile as
+ * the base and apply each chosen value onto the matching `ContactProfile`
+ * property (string props directly; `location` → `location.default`, preserving
+ * any existing `byLang`).
+ */
+export function ContactConflictModal({
+  open,
+  conflicts,
+  onClose,
+  onResolved,
+}: ContactConflictModalProps) {
+  const { t } = useTranslation();
+  const notify = useNotification();
+  const { data: profile } = useContactProfile();
+  const { mutateAsync: save, isPending } = useSaveContactProfile();
+
+  // Seed one row per conflict — default to keeping the saved value (the
+  // non-destructive choice), with the editable value primed to that same side.
+  const seed = (list: ContactFieldConflict[]): Record<string, FieldState> => {
+    const next: Record<string, FieldState> = {};
+    for (const c of list) next[c.field] = { choice: 'mine', value: c.current };
+    return next;
+  };
+
+  // Seeds once per mount. Call sites remount the modal (via a `key` that changes
+  // per import) so a fresh conflict set always re-runs this initializer cleanly —
+  // no render-phase re-seeding needed.
+  const [fields, setFields] = useState<Record<string, FieldState>>(() => seed(conflicts));
+
+  const setChoice = (field: string, choice: Choice) =>
+    setFields((prev) => {
+      const conflict = conflicts.find((c) => c.field === field);
+      if (!conflict) return prev;
+      // Switching sides re-seeds the editable value from the picked side.
+      const value = choice === 'mine' ? conflict.current : conflict.suggested;
+      return { ...prev, [field]: { choice, value } };
+    });
+
+  const setValue = (field: string, value: string) =>
+    setFields((prev) => ({
+      ...prev,
+      [field]: { choice: prev[field]?.choice ?? 'mine', value },
+    }));
+
+  const handleSave = async () => {
+    const base: ContactProfile = { ...(profile ?? {}) };
+    for (const c of conflicts) {
+      const value = (fields[c.field]?.value ?? c.current).trim();
+      if (STRING_FIELDS.includes(c.field as StringProfileField)) {
+        base[c.field as StringProfileField] = value || undefined;
+      } else if (c.field === 'location' && value) {
+        // Preserve any per-language overrides; only the default value changes.
+        // An emptied value means "keep current" — leave `location` untouched so
+        // an existing `byLang` and a real `default` survive.
+        base.location = { ...base.location, default: value };
+      }
+    }
+    try {
+      await save(base);
+      notify(t('settings.contactConflict.saved'), 'success');
+      onResolved?.();
+      onClose();
+    } catch {
+      notify(t('settings.contactConflict.saveFailed'), 'error');
+    }
+  };
+
+  const options = [
+    { value: 'mine' as const, label: t('settings.contactConflict.keepMine') },
+    { value: 'resume' as const, label: t('settings.contactConflict.useResume') },
+  ] as const;
+
+  return (
+    <ModalShell open={open} onClose={onClose} maxWidth="max-w-2xl">
+      <div className="flex max-h-[85vh] flex-col">
+        <div className="flex items-start gap-2 border-b border-white/[0.08] px-6 py-5">
+          <UserCheck size={16} className="mt-0.5 shrink-0 text-brand-soft" />
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-semibold text-foreground/85">
+              {t('settings.contactConflict.title')}
+            </span>
+            <p className="text-xs text-foreground/55">
+              {t('settings.contactConflict.description')}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-4 overflow-y-auto px-6 py-5">
+          {conflicts.map((c) => {
+            const state = fields[c.field] ?? { choice: 'mine' as Choice, value: c.current };
+            return (
+              <div
+                key={c.field}
+                className="flex flex-col gap-3 rounded-xl border border-white/[0.06] bg-white/[0.02] p-4"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-xs font-medium text-foreground/70">
+                    {t(labelKey(c.field))}
+                  </span>
+                  <SegmentedControl
+                    options={options}
+                    value={state.choice}
+                    onChange={(choice) => setChoice(c.field, choice)}
+                    ariaLabel={t('settings.contactConflict.choiceAria', {
+                      field: t(labelKey(c.field)),
+                    })}
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  <div className="flex flex-col gap-1">
+                    <span className="text-[10px] uppercase tracking-wider text-foreground/40">
+                      {t('settings.contactConflict.savedLabel')}
+                    </span>
+                    <span className="truncate text-xs text-foreground/60">
+                      {c.current || t('settings.contactConflict.emptyValue')}
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-[10px] uppercase tracking-wider text-foreground/40">
+                      {t('settings.contactConflict.resumeLabel')}
+                    </span>
+                    <span className="truncate text-xs text-foreground/60">
+                      {c.suggested || t('settings.contactConflict.emptyValue')}
+                    </span>
+                  </div>
+                </div>
+
+                <Input
+                  aria-label={t('settings.contactConflict.editAria', {
+                    field: t(labelKey(c.field)),
+                  })}
+                  value={state.value}
+                  onChange={(e) => setValue(c.field, e.target.value)}
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-white/[0.08] px-6 py-4">
+          <Button variant="ghost" onClick={onClose}>
+            {t('settings.contactConflict.dismiss')}
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={isPending}>
+            {t('settings.contactConflict.save')}
+          </Button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}

--- a/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/ResumeStep/index.tsx
@@ -2,9 +2,10 @@ import { ArrowLeft, ArrowRight, FileText, Loader2, Upload } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useRef, useState } from 'react';
 
-import type { DocumentRecord } from '@ajh/shared';
+import type { ContactFieldConflict, DocumentRecord } from '@ajh/shared';
 import { Button, cn, FloatingIcon, useNotification, withDelay } from '@ajh/ui';
 
+import { ContactConflictModal } from '@/components/contact/ContactConflictModal';
 import { ProfileUrlImport } from '@/features/resume/components/ProfileUrlImport';
 import { useImportWithOcr } from '@/hooks/use-import-with-ocr';
 import { useTranslation } from '@/lib/i18n';
@@ -32,15 +33,25 @@ export function ResumeStep({ onBack, onNext, direction, stepIndex, totalSteps }:
   const { importFile, isPending: uploading, isOcr } = useImportWithOcr();
   const setResume = usePreferencesStore((s) => s.setResume);
 
+  // Contact-mismatch follow-up — only fires if the user already saved contact
+  // fields (e.g. revisiting onboarding) that disagree with the imported résumé.
+  const [conflicts, setConflicts] = useState<ContactFieldConflict[]>([]);
+  // Bumped per import so the modal remounts and re-seeds its rows cleanly.
+  const [importKey, setImportKey] = useState(0);
+
   const hasResume = documents.length > 0;
 
   const handleFileUpload = async (file: File) => {
     try {
-      await importFile(file);
+      const result = await importFile(file);
       const first = (documentsRaw as (DocumentRecord & { _id?: string })[]).find(Boolean);
       const id = first?._id ?? first?.id;
       if (id) setResume({ defaultId: String(id), autoIndex: true, autoParse: true });
       notify(t('onboarding.resume.uploaded'), 'success');
+      if (result.contactConflicts?.length) {
+        setConflicts(result.contactConflicts);
+        setImportKey((k) => k + 1);
+      }
     } catch (err) {
       notify(err instanceof Error ? err.message : t('onboarding.resume.uploadFailed'), 'error');
     }
@@ -174,6 +185,13 @@ export function ResumeStep({ onBack, onNext, direction, stepIndex, totalSteps }:
           <ArrowRight size={14} />
         </Button>
       </motion.div>
+
+      <ContactConflictModal
+        key={importKey}
+        open={conflicts.length > 0}
+        conflicts={conflicts}
+        onClose={() => setConflicts([])}
+      />
     </OnboardingStepWrapper>
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/preferences/ResumePreferences/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/ResumePreferences/index.tsx
@@ -2,9 +2,10 @@ import { AlertCircle, Download, FileText, Loader2, Sparkles, Trash2, Upload } fr
 import { motion } from 'motion/react';
 import { useRef, useState } from 'react';
 
-import type { DocumentRecord } from '@ajh/shared';
+import type { ContactFieldConflict, DocumentRecord } from '@ajh/shared';
 import { Button, cn, GlassCard, transition, useNotification } from '@ajh/ui';
 
+import { ContactConflictModal } from '@/components/contact/ContactConflictModal';
 import { ProfileUrlImport } from '@/features/resume/components/ProfileUrlImport';
 import { useImportWithOcr } from '@/hooks/use-import-with-ocr';
 import { useTranslation } from '@/lib/i18n';
@@ -36,12 +37,22 @@ export function ResumePreferences() {
   const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Contact-mismatch follow-up: surfaced after a successful import when the
+  // résumé's contact fields disagree with the saved profile. Never gates import.
+  const [conflicts, setConflicts] = useState<ContactFieldConflict[]>([]);
+  // Bumped per import so the modal remounts and re-seeds its rows cleanly.
+  const [importKey, setImportKey] = useState(0);
+
   const handleFileUpload = async (file: File) => {
     if (!file) return;
     try {
-      await importFile(file);
+      const result = await importFile(file);
       if (fileInputRef.current) fileInputRef.current.value = '';
       notify(t('settings.resume.uploaded'), 'success');
+      if (result.contactConflicts?.length) {
+        setConflicts(result.contactConflicts);
+        setImportKey((k) => k + 1);
+      }
     } catch (err) {
       notify(err instanceof Error ? err.message : t('settings.resume.uploadFailed'), 'error');
     }
@@ -261,6 +272,13 @@ export function ResumePreferences() {
           })}
         </div>
       )}
+
+      <ContactConflictModal
+        key={importKey}
+        open={conflicts.length > 0}
+        conflicts={conflicts}
+        onClose={() => setConflicts([])}
+      />
     </GlassCard>
   );
 }

--- a/apps/tauri/src/renderer/hooks/use-import-with-ocr/use-import-with-ocr.ts
+++ b/apps/tauri/src/renderer/hooks/use-import-with-ocr/use-import-with-ocr.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import type { StructuredResume } from '@ajh/shared';
+import type { ContactFieldConflict, ContactProfile, StructuredResume } from '@ajh/shared';
 
 import i18n from '@/i18n';
 import { ocrFile } from '@/lib/ocr';
@@ -13,6 +13,8 @@ type ImportResult = {
   success?: boolean;
   error?: string;
   review?: StructuredResume;
+  contactConflicts?: ContactFieldConflict[];
+  suggestedContact?: ContactProfile;
 };
 
 /**

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -298,6 +298,21 @@
       "photoErrorSize": "Dieses Bild ist zu groß. Wählen Sie eines unter 10 MB.",
       "photoErrorDecode": "Dieses Bild konnte nicht gelesen werden. Versuchen Sie eine andere Datei."
     },
+    "contactConflict": {
+      "title": "Kontaktdaten aktualisieren?",
+      "description": "Ihr importierter Lebenslauf enthält Kontaktdaten, die von Ihrem gespeicherten Profil abweichen. Ihr Lebenslauf wurde unverändert importiert — wählen Sie unten für jedes Feld den gewünschten Wert. Beim Überspringen bleibt Ihr gespeichertes Profil unverändert.",
+      "keepMine": "Meine behalten",
+      "useResume": "Aus Lebenslauf",
+      "savedLabel": "Gespeichert",
+      "resumeLabel": "Lebenslauf",
+      "emptyValue": "—",
+      "choiceAria": "Wert für {{field}} wählen",
+      "editAria": "{{field}} bearbeiten",
+      "save": "Speichern",
+      "dismiss": "Kontaktdaten behalten",
+      "saved": "Kontaktprofil aktualisiert.",
+      "saveFailed": "Kontaktprofil konnte nicht aktualisiert werden."
+    },
     "developer": {
       "title": "Entwickler-Werkzeuge",
       "debugMode": "Debug-Modus",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -298,6 +298,21 @@
       "photoErrorSize": "That image is too large. Choose one under 10 MB.",
       "photoErrorDecode": "That image couldn't be read. Try a different file."
     },
+    "contactConflict": {
+      "title": "Update your contact details?",
+      "description": "Your imported résumé lists contact details that differ from your saved profile. Your résumé was imported as-is — choose which value to keep for each field below. Skipping leaves your saved profile unchanged.",
+      "keepMine": "Keep mine",
+      "useResume": "Use résumé's",
+      "savedLabel": "Saved",
+      "resumeLabel": "Résumé",
+      "emptyValue": "—",
+      "choiceAria": "Choose value for {{field}}",
+      "editAria": "Edit {{field}}",
+      "save": "Save",
+      "dismiss": "Keep my contact info",
+      "saved": "Contact profile updated.",
+      "saveFailed": "Couldn't update your contact profile."
+    },
     "developer": {
       "title": "Developer Tools",
       "debugMode": "Debug mode",

--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -29,6 +29,10 @@ L0 platform/net/error → L1 domain → L2 services/commands → L3 entrypoints.
 - **AI** — `commands/ai_provider/` (ollama/openai/anthropic/gemini + cli_agent), `commands/ai.rs`, `documents/` (embeddings), `ai_generations/`, `conversations/`, `extraction/`, `recommend/`.
 - **Platform/data** — `platform/` (`config.rs` `data_dir()`), `net/` (`http.rs` `shared()`), `error.rs`, `observability.rs` (`Span`), `db.rs`, `data_store.rs`, `credentials/`, `updater/`, `pipeline/`, `jobs/`, `postings/`, `job_preferences/`, `profile_import/`.
 
+## Shared renderer generation components
+
+`apps/tauri/src/renderer/components/generation/EditableOutput/` — app-level (not `@ajh/ui`) shared component used by AI Generate, saved `GenerationCard`, and the autopilot apply modal. Renders a Preview/Edit toggle for `resumeText` / `coverLetterText`; inline AI rewrite via `RewritePopover` calls `rewriteSelection` (in `renderer/lib/generate/generation/generation.ts`) which reuses `streamGenerate` with `buildRewritePrompt` (`packages/prompts/src/generate/rewrite.ts`) — no new IPC command. Edits persist through `useUpdateAiGeneration` (`services/use-ai-generations/`) → `aiGenerations.update` IPC → `update_texts` in `ai_generations/mod.rs`. See ADR-007 addendum for the optimistic-cache contract.
+
 ## Feature ownership (frontend ↔ domain ↔ agent)
 
 Renderer (`apps/tauri/src/renderer/`): ~14 features each owning a route + service hooks (`renderer/services/`, [TanStack Query][tanstack-query]), [Zustand][zustand] stores, state machines (`lib/machines/`). Map: jobs/search/monitoring → backend jobs/scraping; ai-generate/ai-workspace → AI + resume/export; resumes/resume → resume-export domain; autopilot/onboarding → automation; settings/privacy → platform/security.

--- a/docs/knowledge/decision-records/adr-007-ai-generations-application-aggregate.md
+++ b/docs/knowledge/decision-records/adr-007-ai-generations-application-aggregate.md
@@ -22,3 +22,7 @@ The `applied` status of a job (whether the user has generated documents for it) 
 - `applied` derivation eliminates dual-write risk; autopilot reads `applied_job_urls()` to skip already-applied jobs.
 - `merge_application` is a pure function, independently testable (`ai_generations/test.rs`).
 - New fields on the aggregate require an additive migration; the lockstep comment in `commands/data.rs::build_bundle` must be updated to include any new persistent fields in exports/backups.
+
+## Addendum — field-selective text edit (F1, v0.65)
+
+`AiGenerationsContract.update(req: AiGenerationUpdateRequest)` (`aiGenerations:update` channel) allows post-save editing of `resumeText` / `coverLetterText` without touching the rest of the aggregate. Rust: `update_texts` in `ai_generations/mod.rs` — must verify `rows_changed > 0` and error on 0 (silent Ok diverges the optimistic cache). Frontend optimistic path: `useUpdateAiGeneration` in `renderer/services/use-ai-generations/`; no re-sync `useEffect` — the optimistic cache owns truth, rollback handles failure. See `AiGenerationUpdateRequest` in `packages/shared/src/ipc/contracts/aiGenerations.ts`.

--- a/docs/knowledge/domain-model.md
+++ b/docs/knowledge/domain-model.md
@@ -8,7 +8,7 @@ Describes the **shape**; the source is authoritative for field-level detail. Use
 
 - **`DocumentModel`** — `apps/tauri/src-tauri/src/model/` (`document.rs`). The structured résumé: sections → blocks → rich text. The export pipeline and templates consume this; the renderer edits a serialized form via IPC.
 - **Sections / blocks / rich text** — section ordering, content hierarchy, and customization are owned by `resume-export-expert`; see `model/` + `docs/EXPORT_TEMPLATES.md`.
-- **Contact profile** — `contact_profile/` + `commands/contact_profile.rs` (header source of truth for links/contact).
+- **Contact profile** — `contact_profile/` + `commands/contact_profile.rs` (header source of truth for links/contact). Conflict detection on résumé import: `contact_profile/mod.rs: detect_contact_conflicts` (normalizers + per-field diffing); `documents.import` returns additive `contactConflicts` / `suggestedContact` fields (loose JSON, no schema change, import never gated). Renderer resolution: `components/generation/EditableOutput/` area → `ContactConflictModal` (keep-mine / use-résumé per field). Conflict resolution is **local-only** — no data leaves the device.
 
 ## Export contract
 

--- a/docs/knowledge/security-rules.md
+++ b/docs/knowledge/security-rules.md
@@ -26,6 +26,7 @@ For `tauri-security-reviewer` (cross-cutting authority). Security/data findings 
 ## Data / privacy (GDPR)
 
 - `commands/privacy.rs` + `db.rs`/`data_store.rs`: retention + deletion honored; temp/export files cleaned up; resume/PII protected at rest and in caches. A retention/cleanup regression is HIGH.
+- **Additive IPC PII fields** — when an IPC response gains a field carrying PII (e.g. `contactConflicts`/`suggestedContact` on `documents.import`): never `tracing`/log the values; render via JSX text nodes, not HTML/auto-anchors; the save path must re-read a validated IPC round-trip (not raw scraped data); allowlist the key before any dynamic property write (prototype-pollution guard); never `let _ =` a profile write. See `contact_profile/mod.rs: detect_contact_conflicts` as the reference implementation.
 - **Full reset** — `privacy_reset_app` wipes every persistent store via a `Resettable` registry: stores are wired with `manage_resettable` at their `.manage()` site (which registers their reset), and the command just iterates the registry — so a new store is covered automatically. Backups (`commands/data.rs::build_bundle`) remain a separate explicit list. See [ADR-009](decision-records/adr-009-resettable-reset-registry.md).
 
 ## Abuse / cost (DoS & spend)

--- a/packages/shared/src/ipc/contracts/documents.ts
+++ b/packages/shared/src/ipc/contracts/documents.ts
@@ -122,6 +122,21 @@ export interface StructuredResume {
   warnings: string[];
 }
 
+/**
+ * A single identity field where the imported résumé's contact value conflicts
+ * with the saved contact profile (both non-empty, normalized values differ).
+ * The import never blocks on these — it still silently fills empty fields — but
+ * they are returned so the renderer can let the user resolve each one per-field.
+ * `field` is a stable key: `email`, `phone`, `fullName`, `linkedin`, `github`,
+ * `website`, or `location`. `current`/`suggested` are the original (un-normalized)
+ * values for faithful display.
+ */
+export interface ContactFieldConflict {
+  field: string;
+  current: string;
+  suggested: string;
+}
+
 /** Signals the recommender reads — a subset of the generation metadata. */
 export interface TemplateRecommendSignals {
   jobTitle?: string;
@@ -146,9 +161,13 @@ export interface TemplateRecommendation {
 export interface DocumentsContract {
   list(): Promise<DocumentRecord[]>;
 
-  import(
-    req: DocumentImportRequest
-  ): Promise<{ id: string; success: boolean; review?: StructuredResume }>;
+  import(req: DocumentImportRequest): Promise<{
+    id: string;
+    success: boolean;
+    review?: StructuredResume;
+    contactConflicts?: ContactFieldConflict[];
+    suggestedContact?: ContactProfile;
+  }>;
 
   /** Suggest a template + locale from the generation metadata signals. */
   recommendTemplate(req: TemplateRecommendSignals): Promise<TemplateRecommendation>;

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -145,6 +145,7 @@ export { DATA_CHANNELS, type DataContract } from './data.js';
 export { DIALOG_CHANNELS, type DialogContract } from './dialog.js';
 export {
   type ConfidenceLevel,
+  type ContactFieldConflict,
   DOCUMENTS_CHANNELS,
   type DocumentsContract,
   type ResumeField,


### PR DESCRIPTION
## What

When a user uploads a new résumé and its extracted contact details **conflict** with what's already in their saved contact profile, the app now surfaces the difference and lets them resolve it per-field — instead of silently dropping the résumé's value (the old behavior never overwrote a set field, so a changed email/phone just vanished with no notice).

The import itself is unchanged and **never gated**: the résumé still imports, empty profile fields still autofill silently. The conflict resolution is a follow-up step.

## How

**Backend (`commands/documents.rs` + `contact_profile/mod.rs`)**
- `detect_contact_conflicts(current, suggested)` compares the single-valued identity fields — **email, phone, linkedin, github, website, location** (`.default`); `extra_links` excluded.
- A conflict requires **both sides non-empty AND normalized values differ**. Conservative normalizers mean we don't nag on cosmetic differences: email case, phone formatting (`+1 (555) 123-4567` ≡ `15551234567`), and URL `http`/`https` / `www.` / trailing-slash are all ignored. The reported values are the original un-normalized strings.
- `documents.import` returns the new `contactConflicts` + `suggestedContact` (additive, loose-JSON response — no schema/codegen change). A failed profile-write is now logged (`tracing::warn`, no PII) instead of silently discarded.

**Renderer**
- New `ContactConflictModal` (`ModalShell` + `SegmentedControl` + `Input`): per conflict, **keep mine / use résumé's** (default keep-mine) with an editable field. On save it reads the live profile, applies the chosen values (`location` sets `.default`, preserving `byLang`; an emptied value keeps the current), and persists via `useSaveContactProfile`.
- Wired into **both** the Settings résumé upload and the onboarding résumé step. (The mid-generation AI-Generate resume input deliberately does not pop this modal — out of scope.)

## Tests
- Rust (`detect_contact_conflicts` + normalizers): normalized-equal → no conflict (email case, phone formatting, URL scheme/www/slash); genuine diffs per field with original-string assertions; one-side-empty → no conflict; `location` `.default` vs `byLang`; `extra_links` excluded; multi-field; malformed/no-host URL edge.
- Renderer (`ContactConflictModal`): keep-mine (with a fixture that defeats a no-op impl), use-résumé, edited value, `location` byLang-preserve, cleared-location keeps current, dismiss = no save, `onClose` on success / not on rejection, independent multi-conflict resolution.

## Review
Agent pipeline: `rust-backend-architect` + `frontend-reviewer` + `tauri-security-reviewer` (all HIGH resolved — dead `suggestedContact` prop removed, dead `fullName` branch removed, render-phase `setState` replaced with key-remount, write-error logged); `test-author` → `testing-reviewer` (keep-mine tautology + coverage gaps resolved). Security: local-only, no new IPC command, PII never logged, prototype-pollution allowlist on the dynamic field write.

> Carries a small `docs:` commit (ADR-007 addendum + architecture pointer) — the close-out docs from #262, which were authored after that PR was pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)