### PR TITLE
feat: pick a run time for scheduled autopilots

### DIFF
--- a/apps/tauri/src-tauri/src/autopilot/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot/mod.rs
@@ -110,6 +110,16 @@ pub struct Autopilot {
     pub target: AutopilotTarget,
     pub filter: AutopilotFilter,
     pub schedule: String,
+    /// Local clock hour (0–23) a recurring schedule fires at. Used by
+    /// daily/twice_daily; ignored by hourly. `None` falls back to 09:00 in the
+    /// scheduler. Defaulted so older persisted records load.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule_hour: Option<u32>,
+    /// Local clock minute (0–59) a recurring schedule fires at. Used by
+    /// daily/twice_daily and as the "minute past the hour" for hourly. `None`
+    /// falls back to minute 0 in the scheduler. Defaulted so older records load.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule_minute: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resume_text: Option<String>,
     /// Optional base cover letter reused as the starting point when tailoring a
@@ -185,6 +195,8 @@ impl AutopilotStore {
                 }
             }),
             schedule: str_field(&input, "schedule"),
+            schedule_hour: u32_field_in_range(&input, "scheduleHour", 23),
+            schedule_minute: u32_field_in_range(&input, "scheduleMinute", 59),
             resume_text: input["resumeText"].as_str().map(String::from),
             cover_letter: input["coverLetter"].as_str().map(String::from),
             total_found: 0,
@@ -223,6 +235,12 @@ impl AutopilotStore {
         }
         if let Some(v) = patch.get("schedule").and_then(|v| v.as_str()) {
             ap.schedule = v.to_string();
+        }
+        if patch.get("scheduleHour").is_some() {
+            ap.schedule_hour = u32_field_in_range(&patch, "scheduleHour", 23);
+        }
+        if patch.get("scheduleMinute").is_some() {
+            ap.schedule_minute = u32_field_in_range(&patch, "scheduleMinute", 59);
         }
         if let Some(v) = patch.get("resumeText").and_then(|v| v.as_str()) {
             ap.resume_text = Some(v.to_string());
@@ -383,6 +401,19 @@ fn str_field(v: &serde_json::Value, key: &str) -> String {
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string()
+}
+
+/// Read an optional non-negative integer field as `u32`, accepting it only when
+/// it is in `0..=max`. Absent, non-numeric, or out-of-range → `None`, so a
+/// missing or poisoned schedule time falls back to the scheduler defaults
+/// rather than persisting a value that makes the occurrence permanently `None`
+/// (silently dead autopilot). Guards the storage boundary against a client that
+/// bypassed the Zod range check (e.g. `scheduleHour: 25`).
+fn u32_field_in_range(v: &serde_json::Value, key: &str, max: u32) -> Option<u32> {
+    v.get(key)
+        .and_then(|v| v.as_u64())
+        .map(|n| n as u32)
+        .filter(|&n| n <= max)
 }
 
 /// Merge a fresh run's postings into the cumulative found-jobs list, idempotently:

--- a/apps/tauri/src-tauri/src/autopilot/test.rs
+++ b/apps/tauri/src-tauri/src/autopilot/test.rs
@@ -103,6 +103,94 @@ fn legacy_auto_apply_records_load_and_strip_dead_keys_on_save() {
 }
 
 #[test]
+fn test_u32_field_in_range_rejects_out_of_range_and_non_numeric() {
+    let v = serde_json::json!({
+        "good": 23,
+        "tooBig": 25,
+        "minOk": 59,
+        "minBad": 60,
+        "negative": -1,
+        "text": "9",
+    });
+    // In-range values pass through.
+    assert_eq!(u32_field_in_range(&v, "good", 23), Some(23));
+    assert_eq!(u32_field_in_range(&v, "minOk", 59), Some(59));
+    // Out-of-range / non-numeric / absent → None (falls back to scheduler default).
+    assert_eq!(u32_field_in_range(&v, "tooBig", 23), None);
+    assert_eq!(u32_field_in_range(&v, "minBad", 59), None);
+    assert_eq!(u32_field_in_range(&v, "negative", 23), None);
+    assert_eq!(u32_field_in_range(&v, "text", 23), None);
+    assert_eq!(u32_field_in_range(&v, "missing", 23), None);
+}
+
+#[test]
+fn create_drops_out_of_range_schedule_time_so_scheduler_falls_back() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+
+    // A client that bypassed the Zod range check sends scheduleHour: 25 /
+    // scheduleMinute: 60. Persisting those verbatim would make `local_at`
+    // return None forever → the autopilot is silently never due. Instead the
+    // storage boundary stores None, so the scheduler uses its safe default.
+    let ap = store.create(serde_json::json!({
+        "name": "Out of range",
+        "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+        "filter": { "minMatchScore": 50.0 },
+        "schedule": "daily",
+        "scheduleHour": 25,
+        "scheduleMinute": 60,
+    }));
+    assert_eq!(ap.schedule_hour, None, "out-of-range hour is not persisted");
+    assert_eq!(
+        ap.schedule_minute, None,
+        "out-of-range minute is not persisted"
+    );
+
+    // A valid time is kept as-is.
+    let ok = store.create(serde_json::json!({
+        "name": "Valid",
+        "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+        "filter": { "minMatchScore": 50.0 },
+        "schedule": "daily",
+        "scheduleHour": 18,
+        "scheduleMinute": 30,
+    }));
+    assert_eq!(ok.schedule_hour, Some(18));
+    assert_eq!(ok.schedule_minute, Some(30));
+}
+
+#[test]
+fn update_rejects_out_of_range_time_while_keeping_null_clear() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+    let ap = store.create(serde_json::json!({
+        "name": "AP",
+        "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+        "filter": { "minMatchScore": 50.0 },
+        "schedule": "daily",
+        "scheduleHour": 10,
+        "scheduleMinute": 15,
+    }));
+
+    // Patching with an out-of-range hour clears it to None rather than poisoning.
+    let patched = store
+        .update(&ap.id, serde_json::json!({ "scheduleHour": 99 }))
+        .unwrap();
+    assert_eq!(patched.schedule_hour, None, "out-of-range patch → None");
+    assert_eq!(patched.schedule_minute, Some(15), "untouched field kept");
+
+    // Explicit null still clears (existing behavior preserved).
+    let cleared = store
+        .update(&ap.id, serde_json::json!({ "scheduleMinute": null }))
+        .unwrap();
+    assert_eq!(cleared.schedule_minute, None, "explicit null clears");
+}
+
+#[test]
 fn test_clear_all_removes_every_autopilot() {
     use tempfile::TempDir;
 

--- a/apps/tauri/src-tauri/src/autopilot_scheduler.rs
+++ b/apps/tauri/src-tauri/src/autopilot_scheduler.rs
@@ -6,14 +6,24 @@ use parking_lot::Mutex;
 /// `lastRunAt` in the store. Respects the `status` field — paused/archived
 /// autopilots are never triggered.
 ///
-/// Schedule intervals:
+/// Schedules are **clock-anchored** in DEVICE-LOCAL time: a recurring schedule
+/// fires at a chosen wall-clock time, not on a rolling interval.
 ///   manual      — never triggered automatically
-///   hourly      — run if last_run_at is > 60 min ago (or never ran)
-///   twice_daily — run if last_run_at is > 12 h ago (or never ran)
-///   daily       — run if last_run_at is > 24 h ago (or never ran)
+///   hourly      — every hour at `:scheduleMinute` (minute past the hour;
+///                 `scheduleHour` ignored; defaults to minute 0)
+///   daily       — once a day at `scheduleHour:scheduleMinute` (defaults 09:00)
+///   twice_daily — at `scheduleHour:scheduleMinute` AND 12 h later
+///
+/// Due-ness is decided against the **most recent scheduled occurrence at-or-
+/// before now** (see [`last_occurrence_ms`]): an autopilot is due iff its
+/// `lastRunAt` predates that occurrence. This gives catch-up for free — a
+/// missed occurrence (app was closed) runs once shortly after the next launch
+/// — while never double-running, because once `lastRunAt` is stamped at/after
+/// the occurrence it is no longer due until the next one rolls around.
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::{DateTime, Datelike, Local, TimeZone, Timelike};
 use tauri::{AppHandle, Manager};
 
 use crate::autopilot::{Autopilot, AutopilotStatus, AutopilotStore};
@@ -24,35 +34,106 @@ const TICK_INTERVAL_SECS: u64 = 60;
 /// startup (window, stores, plugins) before any autopilot scrape kicks off.
 const STARTUP_CATCHUP_DELAY_SECS: u64 = 5;
 
-/// Seconds between auto-runs for each schedule variant.
-fn interval_secs(schedule: &str) -> Option<u64> {
+/// Default local clock time for daily/twice_daily when no time is set, so
+/// records created before the run-time picker keep firing in the morning.
+const DEFAULT_HOUR: u32 = 9;
+const DEFAULT_MINUTE: u32 = 0;
+
+/// Build a local `DateTime` for `date` (taken from `anchor`) at `h:m:00`.
+/// Returns `None` only for the rare non-existent local wall-clock times (DST
+/// spring-forward gaps), in which case the caller treats the occurrence as
+/// absent for that day rather than guessing.
+fn local_at(anchor: &DateTime<Local>, h: u32, m: u32) -> Option<DateTime<Local>> {
+    Local
+        .with_ymd_and_hms(anchor.year(), anchor.month(), anchor.day(), h, m, 0)
+        .single()
+}
+
+/// Most recent scheduled occurrence at-or-before `now` (local), as epoch ms.
+///
+/// `None` for manual/unknown schedules. For recurring schedules this is always
+/// `Some` under normal clocks (it walks back to the previous hour/day when the
+/// time has not yet been reached today).
+///
+/// Hour/minute are defensively clamped to valid ranges before use: a legacy or
+/// imported record carrying an out-of-range value (e.g. `hour = 25`) falls back
+/// to the safe default instead of producing a permanently-`None` occurrence
+/// (silently-dead autopilot). Belt-and-suspenders with the storage-side range
+/// guard in [`crate::autopilot`].
+fn last_occurrence_ms(
+    schedule: &str,
+    hour: Option<u32>,
+    minute: Option<u32>,
+    now: DateTime<Local>,
+) -> Option<i64> {
+    // Clamp out-of-range times to the safe default rather than trusting the
+    // stored value — `local_at` would otherwise return `None` forever.
+    let hour = hour.filter(|&h| h <= 23);
+    let minute = minute.filter(|&m| m <= 59);
     match schedule {
-        "hourly" => Some(60 * 60),
-        "twice_daily" => Some(12 * 60 * 60),
-        "daily" => Some(24 * 60 * 60),
+        "hourly" => {
+            // Every hour at `:m`. This hour's `:m` if already past it, else the
+            // previous hour's `:m`.
+            let m = minute.unwrap_or(DEFAULT_MINUTE);
+            let this_hour = local_at(&now, now.hour(), m)?;
+            let occ = if this_hour <= now {
+                this_hour
+            } else {
+                this_hour - chrono::Duration::hours(1)
+            };
+            Some(occ.timestamp_millis())
+        }
+        "daily" => {
+            // Today at `h:m` if already past it, else yesterday's `h:m`.
+            let h = hour.unwrap_or(DEFAULT_HOUR);
+            let m = minute.unwrap_or(DEFAULT_MINUTE);
+            let today = local_at(&now, h, m)?;
+            let occ = if today <= now {
+                today
+            } else {
+                today - chrono::Duration::days(1)
+            };
+            Some(occ.timestamp_millis())
+        }
+        "twice_daily" => {
+            // Two daily occurrences {`h:m`, `h:m`+12h}. The latest of the four
+            // candidates (today + yesterday, both offsets) that is `<= now`.
+            let h = hour.unwrap_or(DEFAULT_HOUR);
+            let m = minute.unwrap_or(DEFAULT_MINUTE);
+            let base = local_at(&now, h, m)?;
+            let twelve = chrono::Duration::hours(12);
+            let day = chrono::Duration::days(1);
+            [base, base + twelve, base - day, base + twelve - day]
+                .into_iter()
+                .filter(|occ| *occ <= now)
+                .max()
+                .map(|occ| occ.timestamp_millis())
+        }
         _ => None, // manual or unknown — never auto-run
     }
 }
 
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
-}
-
 fn is_due(ap: &Autopilot) -> bool {
-    let Some(interval) = interval_secs(&ap.schedule) else {
-        return false;
-    };
     if ap.status != AutopilotStatus::Active {
         return false;
     }
-    let elapsed_ms = match ap.last_run_at {
-        Some(last) => now_ms().saturating_sub(last),
-        None => u64::MAX, // never ran → always due
+    let Some(occurrence_ms) = last_occurrence_ms(
+        &ap.schedule,
+        ap.schedule_hour,
+        ap.schedule_minute,
+        Local::now(),
+    ) else {
+        return false; // manual/unknown — never auto-run
     };
-    elapsed_ms >= interval * 1_000
+    match ap.last_run_at {
+        // Never ran → run once soon after creation (preserves today's
+        // first-run-immediately behaviour).
+        None => true,
+        // Due iff the last run predates the most recent occurrence: a missed or
+        // just-reached occurrence is due; a run at/after it is not (no
+        // double-run until the next occurrence).
+        Some(last) => (last as i64) < occurrence_ms,
+    }
 }
 
 pub fn start(app: AppHandle) {
@@ -102,10 +183,18 @@ async fn tick(app: &AppHandle, store: &Arc<Mutex<AutopilotStore>>) {
 
 #[cfg(test)]
 mod test {
+    use chrono::Offset;
+
     use super::*;
     use crate::autopilot::{AutopilotFilter, AutopilotTarget};
 
-    fn ap(schedule: &str, status: AutopilotStatus, last_run_at: Option<u64>) -> Autopilot {
+    fn ap(
+        schedule: &str,
+        status: AutopilotStatus,
+        last_run_at: Option<u64>,
+        schedule_hour: Option<u32>,
+        schedule_minute: Option<u32>,
+    ) -> Autopilot {
         Autopilot {
             id: "id".into(),
             name: "name".into(),
@@ -125,6 +214,8 @@ mod test {
                 exclude_keywords: None,
             },
             schedule: schedule.into(),
+            schedule_hour,
+            schedule_minute,
             resume_text: None,
             cover_letter: None,
             total_found: 0,
@@ -137,45 +228,219 @@ mod test {
         }
     }
 
+    /// A fixed *local* wall-clock instant on 2026-06-04 at `h:m:00`, built
+    /// timezone-portably.
+    ///
+    /// We can't construct it via `Local.with_ymd_and_hms(...)` — on a CI runner
+    /// whose local tz makes that wall time non-existent or ambiguous (a DST
+    /// gap/overlap), `.single()` is `None` and `.unwrap()` panics. Instead we
+    /// derive the UTC offset for that calendar day from a stable epoch instant
+    /// and subtract it, so we land on a real instant whose *local* H:M is what
+    /// we asked for, on every runner regardless of timezone.
+    fn local_on_2026_06_04(h: u32, m: u32) -> DateTime<Local> {
+        // Stable anchor: 2026-06-04 00:00:00 UTC, expressed in local time.
+        // 1_780_531_200_000 ms = 2026-06-04T00:00:00Z.
+        let local_midnight_utc = DateTime::from_timestamp_millis(1_780_531_200_000)
+            .unwrap()
+            .with_timezone(&Local);
+        // Offset that Local applies on that day; subtracting it makes the
+        // resulting instant read as `h:m` on the local wall clock.
+        let offset_secs = local_midnight_utc.offset().fix().local_minus_utc() as i64;
+        let target_utc_ms =
+            1_780_531_200_000 + (h as i64 * 3_600 + m as i64 * 60 - offset_secs) * 1_000;
+        DateTime::from_timestamp_millis(target_utc_ms)
+            .unwrap()
+            .with_timezone(&Local)
+    }
+
+    /// Fixed reference instant on 2026-06-04 at `h:m` local. All occurrence math
+    /// is deterministic against it (independent of the wall clock) and the
+    /// construction never panics on any runner's timezone.
+    fn now_at(h: u32, m: u32) -> DateTime<Local> {
+        local_on_2026_06_04(h, m)
+    }
+
+    /// Same calendar instant one day earlier (2026-06-03) at `h:m` local —
+    /// used by the "yesterday's occurrence" assertions.
+    fn yesterday_at(h: u32, m: u32) -> DateTime<Local> {
+        now_at(h, m) - chrono::Duration::days(1)
+    }
+
+    // ── last_occurrence_ms ─────────────────────────────────────────────────
+
     #[test]
-    fn interval_secs_maps_known_schedules() {
-        assert_eq!(interval_secs("hourly"), Some(60 * 60));
-        assert_eq!(interval_secs("twice_daily"), Some(12 * 60 * 60));
-        assert_eq!(interval_secs("daily"), Some(24 * 60 * 60));
-        assert_eq!(interval_secs("manual"), None);
-        assert_eq!(interval_secs("weekly"), None); // unknown → never auto-run
+    fn manual_and_unknown_have_no_occurrence() {
+        let now = now_at(14, 30);
+        assert_eq!(last_occurrence_ms("manual", None, None, now), None);
+        assert_eq!(last_occurrence_ms("weekly", None, None, now), None);
     }
 
     #[test]
+    fn hourly_uses_this_hour_when_past_the_minute_else_previous_hour() {
+        // minute 15, now 14:30 → this hour's 14:15.
+        let now = now_at(14, 30);
+        assert_eq!(
+            last_occurrence_ms("hourly", None, Some(15), now),
+            Some(now_at(14, 15).timestamp_millis())
+        );
+        // minute 45, now 14:30 (not yet reached) → previous hour's 13:45.
+        assert_eq!(
+            last_occurrence_ms("hourly", None, Some(45), now),
+            Some(now_at(13, 45).timestamp_millis())
+        );
+        // scheduleHour is ignored for hourly; default minute is 0.
+        assert_eq!(
+            last_occurrence_ms("hourly", Some(7), None, now),
+            Some(now_at(14, 0).timestamp_millis())
+        );
+    }
+
+    #[test]
+    fn daily_uses_today_when_past_else_yesterday() {
+        // 09:00 default, now 14:30 → today 09:00.
+        let now = now_at(14, 30);
+        assert_eq!(
+            last_occurrence_ms("daily", None, None, now),
+            Some(now_at(9, 0).timestamp_millis())
+        );
+        // Scheduled 18:30, now 14:30 (not yet) → yesterday 18:30.
+        assert_eq!(
+            last_occurrence_ms("daily", Some(18), Some(30), now),
+            Some(yesterday_at(18, 30).timestamp_millis())
+        );
+    }
+
+    #[test]
+    fn twice_daily_picks_the_later_reached_occurrence() {
+        // Base 09:00 (+12h = 21:00). now 14:30 → the 09:00 slot (21:00 not reached).
+        let now = now_at(14, 30);
+        assert_eq!(
+            last_occurrence_ms("twice_daily", Some(9), Some(0), now),
+            Some(now_at(9, 0).timestamp_millis())
+        );
+        // now 22:00 → the 21:00 slot is now the latest reached today.
+        let now_late = now_at(22, 0);
+        assert_eq!(
+            last_occurrence_ms("twice_daily", Some(9), Some(0), now_late),
+            Some(now_at(21, 0).timestamp_millis())
+        );
+        // Before both of today's slots (now 06:00) → yesterday's later slot 21:00.
+        let now_early = now_at(6, 0);
+        assert_eq!(
+            last_occurrence_ms("twice_daily", Some(9), Some(0), now_early),
+            Some(yesterday_at(21, 0).timestamp_millis())
+        );
+    }
+
+    // ── is_due (live clock; clock-stable invariants) ───────────────────────
+
+    #[test]
     fn manual_is_never_due_even_if_never_run() {
-        assert!(!is_due(&ap("manual", AutopilotStatus::Active, None)));
+        assert!(!is_due(&ap(
+            "manual",
+            AutopilotStatus::Active,
+            None,
+            None,
+            None
+        )));
     }
 
     #[test]
     fn paused_or_archived_is_never_due() {
-        assert!(!is_due(&ap("hourly", AutopilotStatus::Paused, None)));
-        assert!(!is_due(&ap("hourly", AutopilotStatus::Archived, None)));
+        assert!(!is_due(&ap(
+            "hourly",
+            AutopilotStatus::Paused,
+            None,
+            None,
+            None
+        )));
+        assert!(!is_due(&ap(
+            "hourly",
+            AutopilotStatus::Archived,
+            None,
+            None,
+            None
+        )));
+        // Even with a long-overdue last run, a non-active record never fires.
+        let long_ago = 0;
+        assert!(!is_due(&ap(
+            "daily",
+            AutopilotStatus::Paused,
+            Some(long_ago),
+            None,
+            None
+        )));
     }
 
     #[test]
     fn active_scheduled_is_due_when_never_run() {
-        assert!(is_due(&ap("hourly", AutopilotStatus::Active, None)));
-    }
-
-    #[test]
-    fn due_only_after_the_interval_elapses() {
-        let thirty_min_ago = now_ms() - 30 * 60 * 1000;
-        assert!(!is_due(&ap(
-            "hourly",
-            AutopilotStatus::Active,
-            Some(thirty_min_ago)
-        )));
-
-        let two_hours_ago = now_ms() - 2 * 60 * 60 * 1000;
+        // Never ran → runs once soon after creation (first-run-immediately).
         assert!(is_due(&ap(
             "hourly",
             AutopilotStatus::Active,
-            Some(two_hours_ago)
+            None,
+            None,
+            None
+        )));
+        assert!(is_due(&ap(
+            "daily",
+            AutopilotStatus::Active,
+            None,
+            None,
+            None
+        )));
+    }
+
+    #[test]
+    fn ran_at_or_after_the_latest_occurrence_is_not_due() {
+        // The no-double-run invariant, expressed deterministically: a run stamped
+        // at-or-after the most recent occurrence means not-due (the `is_due`
+        // predicate is `last < occurrence`). We pin `now` to a fixed instant and
+        // compute the occurrence against it — no live clock, so no minute-boundary
+        // race. `is_due` itself reads `Local::now()`, which is exactly the source
+        // of the flake we're avoiding here.
+        let now = now_at(14, 30);
+        // Mirrors `is_due`'s decision for a record that already ran: due iff
+        // `last_run_at < occurrence`. Asserting the negative for runs at/after
+        // the occurrence is the no-double-run guarantee.
+        let due_after_run = |occ: i64, last_run: i64| last_run < occ;
+        for (schedule, hour, minute) in [
+            ("hourly", None, None),
+            ("daily", None, None),
+            ("twice_daily", Some(9), Some(0)),
+        ] {
+            let occ = last_occurrence_ms(schedule, hour, minute, now)
+                .expect("recurring schedule has an occurrence");
+            // last_run exactly at the occurrence → not due (boundary is `<`).
+            assert!(
+                !due_after_run(occ, occ),
+                "{schedule}: run at the occurrence is not due"
+            );
+            // last_run after the occurrence → not due, until the next one rolls.
+            assert!(
+                !due_after_run(occ, occ + 1),
+                "{schedule}: run after the occurrence is not due"
+            );
+        }
+    }
+
+    #[test]
+    fn missed_occurrence_while_closed_is_caught_up_once() {
+        // Last ran far in the past (epoch 0) — well before the most recent
+        // occurrence — so the missed run is caught up exactly once on next tick.
+        assert!(is_due(&ap(
+            "daily",
+            AutopilotStatus::Active,
+            Some(0),
+            None,
+            None
+        )));
+        assert!(is_due(&ap(
+            "twice_daily",
+            AutopilotStatus::Active,
+            Some(0),
+            Some(9),
+            Some(0)
         )));
     }
 }

--- a/apps/tauri/src-tauri/src/ipc_contracts/autopilot.rs
+++ b/apps/tauri/src-tauri/src/ipc_contracts/autopilot.rs
@@ -11,6 +11,8 @@ pub struct AutopilotCreateRequest {
     pub target: AutopilotCreateRequestTarget,
     pub filter: AutopilotCreateRequestFilter,
     pub schedule: String,
+    pub schedule_hour: Option<u32>,
+    pub schedule_minute: Option<u32>,
     pub resume_text: Option<String>,
     pub cover_letter: Option<String>,
 }
@@ -46,6 +48,8 @@ pub struct AutopilotUpdateRequest {
     pub target: Option<AutopilotUpdateRequestTarget>,
     pub filter: Option<AutopilotUpdateRequestFilter>,
     pub schedule: Option<String>,
+    pub schedule_hour: Option<u32>,
+    pub schedule_minute: Option<u32>,
     pub resume_text: Option<String>,
     pub cover_letter: Option<String>,
     pub status: Option<String>,

--- a/apps/tauri/src/renderer/features/autopilot/components/CreationWizard/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/CreationWizard/index.tsx
@@ -95,6 +95,9 @@ export function CreationWizard({ onDone, onCancel }: CreationWizardProps) {
       resumeText: form.resumeText || undefined,
       coverLetter: form.coverLetter || undefined,
       schedule: form.schedule,
+      // Time-of-day only applies to recurring schedules; manual runs have no time.
+      scheduleHour: form.schedule === 'manual' ? undefined : form.scheduleHour,
+      scheduleMinute: form.schedule === 'manual' ? undefined : form.scheduleMinute,
     };
     try {
       const ap =

--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepSchedule/StepSchedule.test.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepSchedule/StepSchedule.test.tsx
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { SetFn, WizardState } from '@/features/autopilot/types';
+
+import { StepSchedule } from './index';
+
+// ── Module stubs ──────────────────────────────────────────────────────────────
+
+// Return every translation key verbatim — no i18next setup needed in jsdom.
+vi.mock('@/lib/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (!params) return key;
+      // Substitute {{placeholder}} values for tests that inspect interpolated strings.
+      return Object.entries(params).reduce(
+        (acc, [k, v]) => acc.replace(new RegExp(`\\{\\{${k}\\}\\}`, 'g'), String(v)),
+        key
+      );
+    },
+  }),
+}));
+
+// ── Fixture helpers ───────────────────────────────────────────────────────────
+
+function makeForm(overrides: Partial<WizardState> = {}): WizardState {
+  return {
+    name: 'Test run',
+    board: 'linkedin',
+    query: 'react developer',
+    location: 'Berlin',
+    workType: 'remote',
+    pages: 2,
+    dateFilter: '24h',
+    minMatchScore: 50,
+    keywords: '',
+    excludeKeywords: '',
+    resumeText: '',
+    coverLetter: '',
+    schedule: 'daily',
+    scheduleHour: 9,
+    scheduleMinute: 0,
+    ...overrides,
+  };
+}
+
+/** Open the SelectDropdown identified by its trigger button id attribute and pick an option. */
+async function pickOptionById(
+  user: ReturnType<typeof userEvent.setup>,
+  triggerId: string,
+  optionLabel: string
+) {
+  // SelectDropdown forwards an `id` onto its trigger button.
+  const trigger = document.getElementById(triggerId);
+  if (!trigger) throw new Error(`No element with id="${triggerId}"`);
+  await user.click(trigger);
+  expect(screen.getByRole('listbox')).toBeInTheDocument();
+  await user.click(screen.getByRole('option', { name: optionLabel }));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('StepSchedule', () => {
+  let set: Mock<SetFn>;
+
+  beforeEach(() => {
+    set = vi.fn<SetFn>();
+  });
+
+  // ── Gating: control visibility per schedule ─────────────────────────────────
+
+  describe('gating — daily', () => {
+    it('renders both hour and minute controls', () => {
+      render(<StepSchedule form={makeForm({ schedule: 'daily' })} set={set} />);
+      expect(document.getElementById('schedule-hour')).toBeInTheDocument();
+      expect(document.getElementById('schedule-minute')).toBeInTheDocument();
+    });
+
+    it('does not render the minutes-past-hour control', () => {
+      render(<StepSchedule form={makeForm({ schedule: 'daily' })} set={set} />);
+      expect(document.getElementById('schedule-minutes-past-hour')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('gating — twice_daily', () => {
+    it('renders both hour and minute controls', () => {
+      render(<StepSchedule form={makeForm({ schedule: 'twice_daily' })} set={set} />);
+      expect(document.getElementById('schedule-hour')).toBeInTheDocument();
+      expect(document.getElementById('schedule-minute')).toBeInTheDocument();
+    });
+
+    it('shows a "+12h" hint containing the second run time (hour 9 → 21:00)', () => {
+      render(
+        <StepSchedule
+          form={makeForm({ schedule: 'twice_daily', scheduleHour: 9, scheduleMinute: 0 })}
+          set={set}
+        />
+      );
+      // The hint text contains "21:00" — the first run at 09:00 plus 12h.
+      expect(screen.getByText(/21:00/)).toBeInTheDocument();
+    });
+
+    it('computes the second run time correctly for hour 13 → 01:00 (wraps at midnight)', () => {
+      render(
+        <StepSchedule
+          form={makeForm({ schedule: 'twice_daily', scheduleHour: 13, scheduleMinute: 15 })}
+          set={set}
+        />
+      );
+      // (13 + 12) % 24 = 1 → "01:15"
+      expect(screen.getByText(/01:15/)).toBeInTheDocument();
+    });
+
+    it('scheduleHour=0 boundary: "+12h" hint contains "12:00" and hour trigger shows "00" not the placeholder', async () => {
+      const user = userEvent.setup();
+      render(
+        <StepSchedule
+          form={makeForm({ schedule: 'twice_daily', scheduleHour: 0, scheduleMinute: 0 })}
+          set={set}
+        />
+      );
+
+      // (a) The "+12h" hint must contain "12:00" — (0+12)%24 = 12, minute 0.
+      // The hint is rendered by the alsoRunsAt i18n key which interpolates first/second.
+      // Because our mock substitutes {{second}} → "12:00" the text "12:00" appears in the DOM.
+      expect(screen.getByText(/12:00/)).toBeInTheDocument();
+
+      // (b) The hour trigger's displayed label must be "00", not the placeholder "Select…".
+      // SelectDropdown looks up `options.find(o => o.value === value)` and renders
+      // `selectedOption.label`. For scheduleHour=0, value prop = String(0) = "0" which
+      // matches HOUR_OPTIONS[0].value ("0") → label "00". A naive falsy guard on value
+      // would fall through to the placeholder instead.
+      const hourTrigger = document.getElementById('schedule-hour');
+      if (!hourTrigger) throw new Error('schedule-hour trigger not found');
+
+      // Open the dropdown and confirm the "00" option is marked as selected (aria-selected).
+      await user.click(hourTrigger);
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      const zeroOption = screen.getByRole('option', { name: '00' });
+      expect(zeroOption).toHaveAttribute('aria-selected', 'true');
+
+      // Also confirm the trigger itself displays "00" and not the placeholder text.
+      // The trigger <button> wraps a <span> whose text is selectedOption.label.
+      expect(hourTrigger).toHaveTextContent('00');
+      expect(hourTrigger).not.toHaveTextContent('Select…');
+    });
+  });
+
+  describe('gating — hourly', () => {
+    it('renders the minutes-past-hour control', () => {
+      render(<StepSchedule form={makeForm({ schedule: 'hourly' })} set={set} />);
+      expect(document.getElementById('schedule-minutes-past-hour')).toBeInTheDocument();
+    });
+
+    it('does not render the hour control', () => {
+      render(<StepSchedule form={makeForm({ schedule: 'hourly' })} set={set} />);
+      expect(document.getElementById('schedule-hour')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('gating — manual', () => {
+    it('renders no time controls at all', () => {
+      render(<StepSchedule form={makeForm({ schedule: 'manual' })} set={set} />);
+      expect(document.getElementById('schedule-hour')).not.toBeInTheDocument();
+      expect(document.getElementById('schedule-minute')).not.toBeInTheDocument();
+      expect(document.getElementById('schedule-minutes-past-hour')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Wiring: set() called with correct type ──────────────────────────────────
+
+  describe('wiring — hour control', () => {
+    it('calls set("scheduleHour", <number>) when a new hour is selected', async () => {
+      const user = userEvent.setup();
+      render(<StepSchedule form={makeForm({ schedule: 'daily', scheduleHour: 9 })} set={set} />);
+      await pickOptionById(user, 'schedule-hour', '08');
+      expect(set).toHaveBeenCalledWith('scheduleHour', 8);
+      // Guard: value must be a number, not a string.
+      const [, value] = set.mock.calls.find(([k]) => k === 'scheduleHour') ?? [];
+      expect(typeof value).toBe('number');
+    });
+  });
+
+  describe('wiring — minute control (daily)', () => {
+    it('calls set("scheduleMinute", <number>) when a new minute is selected', async () => {
+      const user = userEvent.setup();
+      render(<StepSchedule form={makeForm({ schedule: 'daily', scheduleMinute: 0 })} set={set} />);
+      await pickOptionById(user, 'schedule-minute', '15');
+      expect(set).toHaveBeenCalledWith('scheduleMinute', 15);
+      const [, value] = set.mock.calls.find(([k]) => k === 'scheduleMinute') ?? [];
+      expect(typeof value).toBe('number');
+    });
+  });
+
+  describe('wiring — minute control (hourly)', () => {
+    it('calls set("scheduleMinute", <number>) for the minutes-past-hour control', async () => {
+      const user = userEvent.setup();
+      render(<StepSchedule form={makeForm({ schedule: 'hourly', scheduleMinute: 0 })} set={set} />);
+      await pickOptionById(user, 'schedule-minutes-past-hour', '30');
+      expect(set).toHaveBeenCalledWith('scheduleMinute', 30);
+      const [, value] = set.mock.calls.find(([k]) => k === 'scheduleMinute') ?? [];
+      expect(typeof value).toBe('number');
+    });
+  });
+
+  describe('wiring — schedule selector buttons', () => {
+    it('calls set("schedule", "hourly") when the hourly button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<StepSchedule form={makeForm({ schedule: 'daily' })} set={set} />);
+      await user.click(
+        screen.getByRole('button', { name: /autopilot\.wizard\.schedule\.hourly/i })
+      );
+      expect(set).toHaveBeenCalledWith('schedule', 'hourly');
+    });
+
+    it('calls set("schedule", "manual") when the manual button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<StepSchedule form={makeForm({ schedule: 'daily' })} set={set} />);
+      await user.click(
+        screen.getByRole('button', { name: /autopilot\.wizard\.schedule\.manual/i })
+      );
+      expect(set).toHaveBeenCalledWith('schedule', 'manual');
+    });
+  });
+
+  // ── Summary section ─────────────────────────────────────────────────────────
+
+  describe('summary line', () => {
+    it('daily: shows "HH:MM" formatted time (09:00 for hour 9 minute 0)', () => {
+      render(
+        <StepSchedule
+          form={makeForm({ schedule: 'daily', scheduleHour: 9, scheduleMinute: 0 })}
+          set={set}
+        />
+      );
+      // The summary value cell renders the scheduleSummary string which includes "09:00".
+      expect(screen.getByText(/09:00/)).toBeInTheDocument();
+    });
+
+    it('twice_daily: shows both times in the summary', () => {
+      render(
+        <StepSchedule
+          form={makeForm({ schedule: 'twice_daily', scheduleHour: 9, scheduleMinute: 0 })}
+          set={set}
+        />
+      );
+      // Summary contains "09:00 & 21:00".
+      expect(screen.getByText(/09:00.*21:00/s)).toBeInTheDocument();
+    });
+
+    it('hourly: shows ":MM" format (":00" for minute 0)', () => {
+      render(<StepSchedule form={makeForm({ schedule: 'hourly', scheduleMinute: 0 })} set={set} />);
+      expect(screen.getByText(/:00/)).toBeInTheDocument();
+    });
+
+    it('manual: shows the manual i18n key (no time component)', () => {
+      render(<StepSchedule form={makeForm({ schedule: 'manual' })} set={set} />);
+      // The summary value cell is a <span> rendered next to the "summarySchedule" label.
+      // The same key also appears on the schedule selector button; getAllByText handles both.
+      const matches = screen.getAllByText('autopilot.wizard.schedule.manual');
+      // At least one match must exist (summary value); button label is the other.
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      // The summary value renders as a <span> (the schedule button renders as a <div>).
+      const summarySpan = matches.find((el) => el.tagName.toLowerCase() === 'span');
+      expect(summarySpan).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepSchedule/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepSchedule/index.tsx
@@ -1,15 +1,34 @@
 import { Check, Clock } from 'lucide-react';
 
 import type { AutopilotSchedule } from '@ajh/shared';
-import { Button, cn } from '@ajh/ui';
+import { Button, cn, SelectDropdown } from '@ajh/ui';
 
 import type { SetFn, WizardState } from '@/features/autopilot/types';
 import { useTranslation } from '@/lib/i18n';
+
+import { WizardField } from '../WizardField';
 
 interface StepScheduleProps {
   form: WizardState;
   set: SetFn;
 }
+
+/** Zero-padded two-digit string (e.g. 9 → "09"). */
+const pad2 = (n: number) => String(n).padStart(2, '0');
+
+/** "HH:MM" for an hour/minute pair. */
+const formatTime = (hour: number, minute: number) => `${pad2(hour)}:${pad2(minute)}`;
+
+const HOUR_OPTIONS = Array.from({ length: 24 }, (_, h) => ({
+  value: String(h),
+  label: pad2(h),
+}));
+
+// Minute granularity for the dropdown — every 5 minutes (00, 05, … 55).
+const MINUTE_OPTIONS = Array.from({ length: 12 }, (_, i) => ({
+  value: String(i * 5),
+  label: pad2(i * 5),
+}));
 
 export function StepSchedule({ form, set }: StepScheduleProps) {
   const { t } = useTranslation();
@@ -35,6 +54,24 @@ export function StepSchedule({ form, set }: StepScheduleProps) {
       desc: t('autopilot.wizard.schedule.twiceDailyDesc'),
     },
   ];
+
+  const showHourMinute = form.schedule === 'daily' || form.schedule === 'twice_daily';
+  const showMinuteOnly = form.schedule === 'hourly';
+  const secondTime = formatTime((form.scheduleHour + 12) % 24, form.scheduleMinute);
+
+  // Schedule label + time, formatted for the summary line.
+  const scheduleSummary = (() => {
+    switch (form.schedule) {
+      case 'daily':
+        return `${t('autopilot.wizard.schedule.daily')} · ${formatTime(form.scheduleHour, form.scheduleMinute)}`;
+      case 'twice_daily':
+        return `${t('autopilot.wizard.schedule.twiceDaily')} · ${formatTime(form.scheduleHour, form.scheduleMinute)} & ${secondTime}`;
+      case 'hourly':
+        return `${t('autopilot.wizard.schedule.hourly')} · :${pad2(form.scheduleMinute)}`;
+      default:
+        return t('autopilot.wizard.schedule.manual');
+    }
+  })();
 
   return (
     <div className="space-y-4">
@@ -72,6 +109,59 @@ export function StepSchedule({ form, set }: StepScheduleProps) {
         ))}
       </div>
 
+      {/* Time control — gated by the selected schedule. */}
+      {showHourMinute && (
+        <WizardField label={t('autopilot.wizard.schedule.runAt')}>
+          <div className="flex items-end gap-2">
+            <div className="flex-1 space-y-1">
+              <label htmlFor="schedule-hour" className="text-[10px] text-foreground/35">
+                {t('autopilot.wizard.schedule.hourLabel')}
+              </label>
+              <SelectDropdown
+                id="schedule-hour"
+                options={HOUR_OPTIONS}
+                value={String(form.scheduleHour)}
+                onChange={(v) => set('scheduleHour', Number(v))}
+              />
+            </div>
+            <span className="pb-2 text-sm font-medium text-foreground/40">:</span>
+            <div className="flex-1 space-y-1">
+              <label htmlFor="schedule-minute" className="text-[10px] text-foreground/35">
+                {t('autopilot.wizard.schedule.minuteLabel')}
+              </label>
+              <SelectDropdown
+                id="schedule-minute"
+                options={MINUTE_OPTIONS}
+                value={String(form.scheduleMinute)}
+                onChange={(v) => set('scheduleMinute', Number(v))}
+              />
+            </div>
+          </div>
+          {form.schedule === 'twice_daily' && (
+            <p className="text-[10px] text-foreground/40">
+              {t('autopilot.wizard.schedule.alsoRunsAt', {
+                first: formatTime(form.scheduleHour, form.scheduleMinute),
+                second: secondTime,
+              })}
+            </p>
+          )}
+        </WizardField>
+      )}
+
+      {showMinuteOnly && (
+        <WizardField
+          label={t('autopilot.wizard.schedule.minutesPastHour')}
+          htmlFor="schedule-minutes-past-hour"
+        >
+          <SelectDropdown
+            id="schedule-minutes-past-hour"
+            options={MINUTE_OPTIONS}
+            value={String(form.scheduleMinute)}
+            onChange={(v) => set('scheduleMinute', Number(v))}
+          />
+        </WizardField>
+      )}
+
       {/* Summary */}
       <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3 space-y-1.5">
         <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-foreground/55">
@@ -81,7 +171,7 @@ export function StepSchedule({ form, set }: StepScheduleProps) {
           [t('autopilot.wizard.schedule.summaryName'), form.name || '—'],
           [t('autopilot.wizard.schedule.summaryBoard'), form.board],
           [t('autopilot.wizard.schedule.summaryQuery'), form.query || '—'],
-          [t('autopilot.wizard.schedule.summarySchedule'), form.schedule.replace('_', ' ')],
+          [t('autopilot.wizard.schedule.summarySchedule'), scheduleSummary],
           [t('autopilot.wizard.schedule.summaryMinScore'), `${form.minMatchScore}%`],
         ].map(([k, v]) => (
           <div key={k} className="flex items-center justify-between">

--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/WizardField/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/WizardField/index.tsx
@@ -5,14 +5,18 @@ interface WizardFieldProps {
   hint?: string;
   /** Optional inline element rendered next to the label (e.g. a status badge). */
   badge?: ReactNode;
+  /** Associates the label with a control by id (for inputs that aren't nested children). */
+  htmlFor?: string;
   children: ReactNode;
 }
 
-export function WizardField({ label, hint, badge, children }: WizardFieldProps) {
+export function WizardField({ label, hint, badge, htmlFor, children }: WizardFieldProps) {
   return (
     <div className="space-y-1.5">
       <div className="flex items-center gap-1.5">
-        <label className="text-xs font-medium text-foreground/60">{label}</label>
+        <label htmlFor={htmlFor} className="text-xs font-medium text-foreground/60">
+          {label}
+        </label>
         {badge}
         {hint && <span className="text-[10px] text-foreground/30">{hint}</span>}
       </div>

--- a/apps/tauri/src/renderer/features/autopilot/lib/wizard-state.test.ts
+++ b/apps/tauri/src/renderer/features/autopilot/lib/wizard-state.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Autopilot } from '@ajh/shared';
+
+import { autopilotToWizardState, buildDefaults } from './wizard-state';
+
+// ── Minimal valid Autopilot fixture ──────────────────────────────────────────
+
+const BASE_AUTOPILOT: Autopilot = {
+  _id: 'ap-1',
+  name: 'My autopilot',
+  status: 'active',
+  target: {
+    board: 'linkedin',
+    query: 'react developer',
+    location: 'Berlin',
+    workType: 'remote',
+    pages: 2,
+    dateFilter: '24h',
+  },
+  filter: {
+    minMatchScore: 60,
+    keywords: ['react', 'typescript'],
+    excludeKeywords: ['senior'],
+  },
+  schedule: 'daily',
+  scheduleHour: 7,
+  scheduleMinute: 30,
+  resumeText: 'My resume text',
+  coverLetter: 'My cover letter',
+  totalFound: 5,
+  totalApplied: 1,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_001_000,
+};
+
+// ── buildDefaults ─────────────────────────────────────────────────────────────
+
+describe('buildDefaults()', () => {
+  it('seeds scheduleHour: 9 and scheduleMinute: 0 with no prefs', () => {
+    const state = buildDefaults();
+    expect(state.scheduleHour).toBe(9);
+    expect(state.scheduleMinute).toBe(0);
+  });
+
+  it('seeds scheduleHour: 9 and scheduleMinute: 0 when prefs are provided', () => {
+    const state = buildDefaults({ location: 'Berlin', remote: 'hybrid' });
+    expect(state.scheduleHour).toBe(9);
+    expect(state.scheduleMinute).toBe(0);
+  });
+
+  it('sets default schedule to daily', () => {
+    const state = buildDefaults();
+    expect(state.schedule).toBe('daily');
+  });
+
+  it('pre-fills location from job preferences', () => {
+    const state = buildDefaults({ location: 'Munich' });
+    expect(state.location).toBe('Munich');
+  });
+
+  it('falls back to empty location when prefs are absent', () => {
+    const state = buildDefaults();
+    expect(state.location).toBe('');
+  });
+});
+
+// ── autopilotToWizardState ────────────────────────────────────────────────────
+
+describe('autopilotToWizardState()', () => {
+  it('round-trips scheduleHour and scheduleMinute from an Autopilot', () => {
+    const state = autopilotToWizardState(BASE_AUTOPILOT);
+    expect(state.scheduleHour).toBe(7);
+    expect(state.scheduleMinute).toBe(30);
+  });
+
+  it('falls back to scheduleHour 9 when the field is absent on the Autopilot', () => {
+    const ap: Autopilot = { ...BASE_AUTOPILOT, scheduleHour: undefined };
+    const state = autopilotToWizardState(ap);
+    expect(state.scheduleHour).toBe(9);
+  });
+
+  it('falls back to scheduleMinute 0 when the field is absent on the Autopilot', () => {
+    const ap: Autopilot = { ...BASE_AUTOPILOT, scheduleMinute: undefined };
+    const state = autopilotToWizardState(ap);
+    expect(state.scheduleMinute).toBe(0);
+  });
+
+  it('maps both fields to 0 when the Autopilot explicitly stores 0', () => {
+    const ap: Autopilot = { ...BASE_AUTOPILOT, scheduleHour: 0, scheduleMinute: 0 };
+    const state = autopilotToWizardState(ap);
+    expect(state.scheduleHour).toBe(0);
+    expect(state.scheduleMinute).toBe(0);
+  });
+
+  it('round-trips all other top-level fields correctly', () => {
+    const state = autopilotToWizardState(BASE_AUTOPILOT);
+    expect(state.name).toBe('My autopilot');
+    expect(state.board).toBe('linkedin');
+    expect(state.query).toBe('react developer');
+    expect(state.schedule).toBe('daily');
+    expect(state.minMatchScore).toBe(60);
+    expect(state.resumeText).toBe('My resume text');
+    expect(state.coverLetter).toBe('My cover letter');
+  });
+
+  it('joins keywords array to a comma-separated string', () => {
+    const state = autopilotToWizardState(BASE_AUTOPILOT);
+    expect(state.keywords).toBe('react, typescript');
+  });
+
+  it('produces empty keywords string when keywords are absent', () => {
+    const ap: Autopilot = {
+      ...BASE_AUTOPILOT,
+      filter: { ...BASE_AUTOPILOT.filter, keywords: undefined },
+    };
+    const state = autopilotToWizardState(ap);
+    expect(state.keywords).toBe('');
+  });
+});

--- a/apps/tauri/src/renderer/features/autopilot/lib/wizard-state.ts
+++ b/apps/tauri/src/renderer/features/autopilot/lib/wizard-state.ts
@@ -21,6 +21,8 @@ export function buildDefaults(jobPrefs?: JobPreferences): WizardState {
     resumeText: '',
     coverLetter: '',
     schedule: 'daily',
+    scheduleHour: 9,
+    scheduleMinute: 0,
   };
 }
 
@@ -40,5 +42,7 @@ export function autopilotToWizardState(ap: Autopilot): WizardState {
     resumeText: ap.resumeText ?? '',
     coverLetter: ap.coverLetter ?? '',
     schedule: ap.schedule,
+    scheduleHour: ap.scheduleHour ?? 9,
+    scheduleMinute: ap.scheduleMinute ?? 0,
   };
 }

--- a/apps/tauri/src/renderer/features/autopilot/types.ts
+++ b/apps/tauri/src/renderer/features/autopilot/types.ts
@@ -18,6 +18,10 @@ export interface WizardState {
   coverLetter: string;
   // Step 4 — Schedule
   schedule: AutopilotSchedule;
+  /** Local clock hour (0–23) recurring schedules fire at. Used by daily/twice_daily. */
+  scheduleHour: number;
+  /** Local clock minute (0–59). Used by daily/twice_daily and as "minute past the hour" for hourly. */
+  scheduleMinute: number;
 }
 
 export type SetFn = <K extends keyof WizardState>(k: K, v: WizardState[K]) => void;

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -808,7 +808,12 @@
         "summaryBoard": "Board",
         "summaryQuery": "Abfrage",
         "summarySchedule": "Zeitplan",
-        "summaryMinScore": "Min. Bewertung"
+        "summaryMinScore": "Min. Bewertung",
+        "runAt": "Ausführen um",
+        "hourLabel": "Stunde",
+        "minuteLabel": "Minute",
+        "minutesPastHour": "Minuten nach der vollen Stunde",
+        "alsoRunsAt": "Läuft um {{first}} und {{second}}"
       },
       "runFailed": "Ausführung fehlgeschlagen",
       "createFailed": "Autopilot konnte nicht erstellt werden",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -823,7 +823,12 @@
         "summaryBoard": "Board",
         "summaryQuery": "Query",
         "summarySchedule": "Schedule",
-        "summaryMinScore": "Min score"
+        "summaryMinScore": "Min score",
+        "runAt": "Run at",
+        "hourLabel": "Hour",
+        "minuteLabel": "Minute",
+        "minutesPastHour": "Minutes past the hour",
+        "alsoRunsAt": "Runs at {{first}} and {{second}}"
       },
       "runFailed": "Run failed",
       "createFailed": "Failed to create autopilot",

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -185,6 +185,8 @@ import { Button, Input, GlassCard, Modal } from '@ajh/ui';
 />
 ```
 
+Accepts an optional `id` prop forwarded to the trigger button, enabling a `<label htmlFor>` to associate correctly with the control (label-click activates the dropdown; required for a11y when used inside a field wrapper such as `WizardField`).
+
 #### `LocationInput`
 
 Async geocode lookup with debounce:

--- a/docs/knowledge/automation-domain.md
+++ b/docs/knowledge/automation-domain.md
@@ -1,6 +1,6 @@
 # Automation domain (scraping + apply assistant + AI provider)
 
-Last updated: 2026-06-03
+Last updated: 2026-06-04
 
 Merged knowledge for `scraping-applier-expert` and `ai-provider-expert`. Source is authoritative for board/provider counts.
 
@@ -15,6 +15,7 @@ Merged knowledge for `scraping-applier-expert` and `ai-provider-expert`. Source 
 
 - **Decision (2026-06, PR #7 of the UX backlog):** the browser-automation apply engine (`applying/` — board appliers, `captcha_handler`, `form_filler`, the `APPLIERS` registry — plus `commands/apply`, `apply_helpers/`, and the apply IPC contract) was **removed**. The app is an **apply assistant**, not an auto-applier: selector drift, captcha, and per-board form logic made an auto-submit engine too costly to maintain, and it was never user-facing ("Coming Soon"). `chromiumoxide` stays — scraping uses it.
 - **What the assistant does** — from a found or scraped job the user tailors a résumé + cover letter (`renderer/features/autopilot/.../ApplyJobModal`, `renderer/store/generation-store/`), gets résumé-grounded application answers, opens the posting in the browser, and submits it themselves. Autopilot (`autopilot/`, `autopilot_scheduler`) **finds → ranks → notifies**; it never submits. Found-jobs PostingRow "Tailor" seeds the AI Generate workspace for any board.
+- **Autopilot scheduling** — **clock-anchored** (PR #266; was interval-based). `autopilot_scheduler.rs` computes the most-recent scheduled occurrence in local time (`chrono::Local`) via `last_occurrence_ms` / `is_due`; on launch it catches up to any missed run (single catch-up, no double-fire). Frequency modes: `daily` = HH:MM; `twice_daily` = HH:MM + 12 h; `hourly` = :MM; `manual` = no scheduling. Fields `scheduleHour` (0–23) and `scheduleMinute` (0–59) on the autopilot model — Zod-validated client-side, range-guarded in the store. Legacy records default to 09:00.
 - **"Applied" tracking** — derived, never auto-set: a found job is "applied" when a saved generation's `jobUrl` matches it (`commands/autopilot.rs: enrich_applied`). Each autopilot keeps an optional **base cover letter** (`coverLetter`) the assistant tailors per job.
 - **Security** — never log credentials/cookies; board session handling for **scraping** is co-reviewed by `tauri-security-reviewer`.
 

--- a/packages/shared/src/schemas/index.test.ts
+++ b/packages/shared/src/schemas/index.test.ts
@@ -101,6 +101,50 @@ describe('AutopilotCreateSchema', () => {
       ).not.toThrow();
     }
   });
+
+  it('accepts scheduleHour boundary values 0 and 23', () => {
+    expect(AutopilotCreateSchema.safeParse({ ...valid, scheduleHour: 0 }).success).toBe(true);
+    expect(AutopilotCreateSchema.safeParse({ ...valid, scheduleHour: 23 }).success).toBe(true);
+  });
+
+  it('accepts scheduleMinute boundary values 0 and 59', () => {
+    expect(AutopilotCreateSchema.safeParse({ ...valid, scheduleMinute: 0 }).success).toBe(true);
+    expect(AutopilotCreateSchema.safeParse({ ...valid, scheduleMinute: 59 }).success).toBe(true);
+  });
+
+  it('accepts a record omitting scheduleHour and scheduleMinute (both optional)', () => {
+    const {
+      scheduleHour: _h,
+      scheduleMinute: _m,
+      ...withoutTime
+    } = {
+      ...valid,
+      scheduleHour: 9,
+      scheduleMinute: 0,
+    };
+    expect(AutopilotCreateSchema.safeParse(withoutTime).success).toBe(true);
+  });
+
+  it('rejects scheduleHour: 24 (out of range)', () => {
+    expect(AutopilotCreateSchema.safeParse({ ...valid, scheduleHour: 24 }).success).toBe(false);
+  });
+
+  it('rejects scheduleHour: -1 (below zero)', () => {
+    expect(AutopilotCreateSchema.safeParse({ ...valid, scheduleHour: -1 }).success).toBe(false);
+  });
+
+  it('rejects scheduleMinute: 60 (out of range)', () => {
+    expect(AutopilotCreateSchema.safeParse({ ...valid, scheduleMinute: 60 }).success).toBe(false);
+  });
+
+  it('rejects scheduleHour: 9.5 (enforces .int())', () => {
+    // A schema that drops .int() would accept 9.5 — this confirms the constraint is present.
+    expect(AutopilotCreateSchema.safeParse({ ...valid, scheduleHour: 9.5 }).success).toBe(false);
+  });
+
+  it('rejects scheduleMinute: -1 (below zero)', () => {
+    expect(AutopilotCreateSchema.safeParse({ ...valid, scheduleMinute: -1 }).success).toBe(false);
+  });
 });
 
 describe('ScrapeBoardRequestSchema', () => {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -258,6 +258,12 @@ export const AutopilotCreateSchema = z.object({
   target: AutopilotTargetSchema,
   filter: AutopilotFilterSchema,
   schedule: z.enum(['manual', 'hourly', 'daily', 'twice_daily']),
+  // Local clock time a recurring schedule fires at. `scheduleHour` drives
+  // daily/twice_daily (ignored by hourly); `scheduleMinute` drives both those
+  // and the "minute past the hour" for hourly. Defaults applied in Rust when
+  // absent (09:00 for daily/twice_daily, minute 0 for hourly).
+  scheduleHour: z.number().int().min(0).max(23).optional(),
+  scheduleMinute: z.number().int().min(0).max(59).optional(),
   resumeText: z.string().optional(),
   // Optional base cover letter — reused as the starting point when tailoring a
   // found job in the apply assistant. (Auto-apply was removed; this field is a

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -209,6 +209,13 @@ export interface Autopilot {
     excludeKeywords?: string[];
   };
   schedule: 'manual' | 'hourly' | 'daily' | 'twice_daily';
+  /** Local clock hour (0–23) a recurring schedule fires at. Used by
+   *  daily/twice_daily; ignored by hourly. Defaults to 9 (09:00) when absent. */
+  scheduleHour?: number;
+  /** Local clock minute (0–59) a recurring schedule fires at. Used by
+   *  daily/twice_daily and as the "minute past the hour" for hourly. Defaults
+   *  to 0 when absent. */
+  scheduleMinute?: number;
   resumeText?: string;
   /** Optional base cover letter — the reusable starting point the apply
    *  assistant tailors per found job. */

--- a/packages/ui/src/components/SelectDropdown/SelectDropdown.tsx
+++ b/packages/ui/src/components/SelectDropdown/SelectDropdown.tsx
@@ -23,6 +23,8 @@ interface SelectDropdownProps {
   placeholder?: string;
   disabled?: boolean;
   icon?: React.ReactNode;
+  /** Forwarded to the trigger button so an external `<label htmlFor>` can name the control. */
+  id?: string;
 }
 
 export function SelectDropdown({
@@ -32,8 +34,10 @@ export function SelectDropdown({
   placeholder = 'Select…',
   disabled,
   icon,
+  id: idProp,
 }: SelectDropdownProps) {
-  const id = useId();
+  const generatedId = useId();
+  const id = idProp ?? generatedId;
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [highlighted, setHighlighted] = useState<number>(-1);


### PR DESCRIPTION
## What

Fixes the gap where choosing any schedule other than **Run manually** gave you no way to set *when* it runs. Autopilot scheduling was interval-based ("≥24h since the last run"), so there was no clock time to pick. It's now **clock-anchored**:

- **Daily** → runs at a chosen local time (e.g. 09:00).
- **Twice-daily** → runs at that time **and 12h later** (09:00 & 21:00).
- **Hourly** → runs at a chosen **minute past the hour** (e.g. :30).
- **Manual** → unchanged.

## How

- **Model:** adds `scheduleHour` (0–23) + `scheduleMinute` (0–59) to the autopilot, validated **client-side (Zod) and server-side** (range-guarded at the store + a defensive clamp in the scheduler so a bad value can never silently disable a run). Existing records default to **09:00** (back-compatible via `serde(default)`).
- **Scheduler** ([autopilot_scheduler.rs](apps/tauri/src-tauri/src/autopilot_scheduler.rs)): replaced the interval check with a **most-recent-occurrence** rule in device-local time (`chrono::Local`, DST-safe via `.single()`). This gives **catch-up for free** — a run missed while the app was closed fires once shortly after the next launch — and **never double-runs** (after a run, `last_run_at ≥ occurrence`). First run on creation still happens immediately.
- **Wizard:** the schedule step now shows hour/minute pickers gated per mode (hour+minute for daily/twice-daily, minute-only for hourly, nothing for manual), a twice-daily "+12h" hint, and a time-aware summary. Built from `@ajh/ui` `SelectDropdown` (no raw `<input type="time">`); `SelectDropdown` gained an optional `id` so the field labels associate for screen readers.

## Tests
- Rust scheduler: `last_occurrence_ms` per variant (incl. midnight/12h wrap), `is_due` (never-ran, paused/archived, catch-up, no-double-run), and out-of-range→default guards — all with a timezone-portable, non-flaky fixed-clock fixture.
- Schema: `scheduleHour`/`scheduleMinute` bounds (0/23/59 accepted, 24/-1/60 and non-int rejected).
- Renderer: `StepSchedule` gating, number-typed wiring, twice-daily hint incl. the `00:00 → 12:00` boundary (the `value="0"` dropdown hazard), summary; `wizard-state` defaults + edit round-trip incl. explicit-`0`.

## Review
Agent pipeline: `rust-backend-architect` + `frontend-reviewer` (all HIGH resolved — server-side range guard for out-of-range times, test de-flaking, a11y label association); `test-author` → `testing-reviewer` (the `scheduleHour: 0` boundary + schema edge cases closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)