### PR TITLE
fix: correct multi-page resume export, modal blur, and release notes

### DIFF
--- a/apps/tauri/src-tauri/src/export/parser/mod.rs
+++ b/apps/tauri/src-tauri/src/export/parser/mod.rs
@@ -316,6 +316,20 @@ fn is_likely_company_or_role(text: &str) -> bool {
     words.iter().any(|word| COMPANY_KEYWORDS.contains(word))
 }
 
+/// A Markdown thematic break: 3+ identical `-`, `*`, or `_` markers (optionally
+/// separated by spaces) and nothing else — e.g. `---`, `***`, `___`, `- - -`.
+/// The model emits these as section separators, but every template already draws
+/// its own section rules, so a literal break renders as stray "---" text AND
+/// doubles the divider. Recognized here so it can be dropped as a blank line.
+fn is_thematic_break(line: &str) -> bool {
+    let marks: String = line.chars().filter(|c| !c.is_whitespace()).collect();
+    if marks.len() < 3 {
+        return false;
+    }
+    let first = marks.chars().next().unwrap();
+    matches!(first, '-' | '*' | '_') && marks.chars().all(|c| c == first)
+}
+
 /// Parse a single line
 fn parse_line(raw: &str, idx: usize, all_lines: &[&str]) -> ParsedLine {
     let trimmed = raw.trim();
@@ -325,6 +339,20 @@ fn parse_line(raw: &str, idx: usize, all_lines: &[&str]) -> ParsedLine {
 
     // Blank line
     if clean.is_empty() {
+        return ParsedLine {
+            kind: LineKind::Blank,
+            raw: String::new(),
+            text: String::new(),
+            segments: Vec::new(),
+            right_text: None,
+        };
+    }
+
+    // Markdown thematic break (`---`, `***`, `___`): a visual separator, never
+    // content. Dropped as Blank so it doesn't render as a stray "---" paragraph
+    // on top of the template's own section rule. Checked on `trimmed` (not
+    // `clean`, which collapses `***` → `*` via the `**` bold strip).
+    if is_thematic_break(trimmed) {
         return ParsedLine {
             kind: LineKind::Blank,
             raw: String::new(),

--- a/apps/tauri/src-tauri/src/export/parser/test.rs
+++ b/apps/tauri/src-tauri/src/export/parser/test.rs
@@ -99,7 +99,10 @@ fn thematic_breaks_are_dropped_as_blank() {
 #[test]
 fn em_dash_and_short_runs_are_not_thematic_breaks() {
     // A real em-dash (single glyph) and a 2-char run are content, not breaks.
-    assert!(!matches!(parse_line("\u{2014}", 3, &[]).kind, LineKind::Blank));
+    assert!(!matches!(
+        parse_line("\u{2014}", 3, &[]).kind,
+        LineKind::Blank
+    ));
     assert!(!matches!(parse_line("--", 3, &[]).kind, LineKind::Blank));
     // A dashed bullet keeps its text — only pure marker runs are breaks.
     assert!(!matches!(

--- a/apps/tauri/src-tauri/src/export/parser/test.rs
+++ b/apps/tauri/src-tauri/src/export/parser/test.rs
@@ -83,6 +83,32 @@ fn test_parse_resume() {
 }
 
 #[test]
+fn thematic_breaks_are_dropped_as_blank() {
+    // Each form the model emits as a section separator must be dropped so it
+    // never renders as stray "---" text doubling the template's own rule.
+    for sep in ["---", "***", "___", "----------", "- - -"] {
+        let line = parse_line(sep, 3, &[]);
+        assert!(
+            matches!(line.kind, LineKind::Blank),
+            "expected Blank for separator {sep:?}, got {:?}",
+            line.kind
+        );
+    }
+}
+
+#[test]
+fn em_dash_and_short_runs_are_not_thematic_breaks() {
+    // A real em-dash (single glyph) and a 2-char run are content, not breaks.
+    assert!(!matches!(parse_line("\u{2014}", 3, &[]).kind, LineKind::Blank));
+    assert!(!matches!(parse_line("--", 3, &[]).kind, LineKind::Blank));
+    // A dashed bullet keeps its text — only pure marker runs are breaks.
+    assert!(!matches!(
+        parse_line("- real bullet", 3, &[]).kind,
+        LineKind::Blank
+    ));
+}
+
+#[test]
 fn sanitize_markdown_strips_stray_emphasis_but_keeps_bold() {
     // The observed symptom: lone asterisks leaked by the model.
     assert_eq!(sanitize_markdown("*React and AWS*"), "React and AWS");

--- a/apps/tauri/src-tauri/src/export/typst_engine/templates/atelier.typ
+++ b/apps/tauri/src-tauri/src/export/typst_engine/templates/atelier.typ
@@ -311,13 +311,19 @@
         height: page_h,
         margin: (top: margin_v, bottom: margin_v, left: 0pt, right: margin_r),
         background: {
-          // (a) Full-height tinted band — the sidebar background.
+          // (a) Full-height tinted band — drawn on EVERY page for visual continuity.
           place(left + top,
             rect(width: sidebar_w, height: 100%, fill: c-sidebar-bg)
           )
-          // (b) Sidebar content placed over the band, repeating on every page.
-          //     dy = margin_v so it starts at the same top margin as the main text.
-          place(left + top, dx: gutter, dy: margin_v, sidebar-content-inner)
+          // (b) Sidebar content — rendered ONCE, on page 1 only. Drawing it in the
+          //     page background would otherwise repeat the whole sidebar on every
+          //     page of a multi-page résumé; gating on the page counter keeps it on
+          //     page 1 while the band continues, so the main column still clears it.
+          context {
+            if counter(page).get().first() == 1 {
+              place(left + top, dx: gutter, dy: margin_v, sidebar-content-inner)
+            }
+          }
         },
       )
 

--- a/apps/tauri/src-tauri/src/export/typst_engine/templates/portrait.typ
+++ b/apps/tauri/src-tauri/src/export/typst_engine/templates/portrait.typ
@@ -415,12 +415,18 @@
     height: page-h,
     margin: (top: margin-v, bottom: margin-v, left: 0pt, right: margin-r),
     background: {
-      // Full-height tinted sidebar band.
+      // Full-height tinted sidebar band — drawn on EVERY page for visual continuity.
       place(left + top,
         rect(width: sidebar-w, height: 100%, fill: c-sidebar-bg)
       )
-      // Sidebar content placed over the band, starting at the top margin.
-      place(left + top, dx: sb-pad-l, dy: margin-v, sidebar-inner)
+      // Sidebar content — rendered ONCE, on page 1 only. Drawing it in the page
+      // background would otherwise repeat the whole sidebar on every page of a
+      // multi-page résumé. The band continues; the main column already clears it.
+      context {
+        if counter(page).get().first() == 1 {
+          place(left + top, dx: sb-pad-l, dy: margin-v, sidebar-inner)
+        }
+      }
     },
   )
 

--- a/apps/tauri/src-tauri/src/export/typst_engine/test.rs
+++ b/apps/tauri/src-tauri/src/export/typst_engine/test.rs
@@ -752,17 +752,29 @@ fn portrait_multipage_sidebar_renders_once() {
     // page(background:) sidebar technique, so the page-1-only gate must hold here too.
     let model = model_from_resume_text(ATELIER_MULTIPAGE);
     let t = template_style(TemplateId::Portrait);
-    let bytes = render_pdf_with_photo(&model, TypstTemplate::Portrait, &opts_photo(false), Some(&t), None)
-        .expect("render_pdf_with_photo(portrait, multipage) should succeed");
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Portrait,
+        &opts_photo(false),
+        Some(&t),
+        None,
+    )
+    .expect("render_pdf_with_photo(portrait, multipage) should succeed");
     assert!(bytes.starts_with(b"%PDF"));
 
     let page_count = count_pdf_pages(&bytes);
-    assert!(page_count >= 2, "multi-page fixture must produce ≥2 pages; got {page_count}");
+    assert!(
+        page_count >= 2,
+        "multi-page fixture must produce ≥2 pages; got {page_count}"
+    );
 
     let extracted = pdf_extract::extract_text_from_mem(&bytes).expect("pdf-extract");
     let lower = extracted.to_lowercase();
     // Sidebar content present (on page 1) …
-    assert!(lower.contains("grafana"), "sidebar skill missing\n---\n{lower}");
+    assert!(
+        lower.contains("grafana"),
+        "sidebar skill missing\n---\n{lower}"
+    );
     // … and rendered exactly once, not repeated per page.
     assert_eq!(
         lower.matches("grafana").count(),

--- a/apps/tauri/src-tauri/src/export/typst_engine/test.rs
+++ b/apps/tauri/src-tauri/src/export/typst_engine/test.rs
@@ -669,7 +669,7 @@ fn atelier_ats_render_produces_valid_pdf() {
 // in the extracted text — this is the regression guard for F1/F4 (dense
 // sidebar overflow).  A clipped sidebar would cause these assertions to fail.
 #[test]
-fn atelier_multipage_sidebar_repeats() {
+fn atelier_multipage_sidebar_renders_once() {
     let model = model_from_resume_text(ATELIER_MULTIPAGE);
     let bytes = render_pdf(&model, TypstTemplate::Atelier, &opts_atelier(false), None)
         .expect("render_pdf(atelier, multipage) should succeed");
@@ -733,12 +733,41 @@ fn atelier_multipage_sidebar_repeats() {
         );
     }
 
-    // The known skill "Rust" must also appear ≥2 times (sidebar repeats per page).
-    let rust_count = lower.matches("rust").count();
-    assert!(
-        rust_count >= 2,
-        "sidebar skill 'Rust' should appear ≥2 times across pages (sidebar repeats); \
-         found {rust_count} time(s)\n---\n{lower}"
+    // The sidebar now renders ONCE (page 1 only), no longer repeated per page.
+    // A sidebar-only skill ("Grafana" — never appears in a main-column bullet)
+    // must therefore appear exactly once across the whole multi-page document.
+    let grafana_count = lower.matches("grafana").count();
+    assert_eq!(
+        grafana_count, 1,
+        "sidebar skill 'Grafana' must appear exactly once (sidebar renders once, \
+         not repeated per page); found {grafana_count}\n---\n{lower}"
+    );
+}
+
+#[test]
+fn portrait_multipage_sidebar_renders_once() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+
+    // Same multi-page fixture through Portrait (no photo). Portrait uses the same
+    // page(background:) sidebar technique, so the page-1-only gate must hold here too.
+    let model = model_from_resume_text(ATELIER_MULTIPAGE);
+    let t = template_style(TemplateId::Portrait);
+    let bytes = render_pdf_with_photo(&model, TypstTemplate::Portrait, &opts_photo(false), Some(&t), None)
+        .expect("render_pdf_with_photo(portrait, multipage) should succeed");
+    assert!(bytes.starts_with(b"%PDF"));
+
+    let page_count = count_pdf_pages(&bytes);
+    assert!(page_count >= 2, "multi-page fixture must produce ≥2 pages; got {page_count}");
+
+    let extracted = pdf_extract::extract_text_from_mem(&bytes).expect("pdf-extract");
+    let lower = extracted.to_lowercase();
+    // Sidebar content present (on page 1) …
+    assert!(lower.contains("grafana"), "sidebar skill missing\n---\n{lower}");
+    // … and rendered exactly once, not repeated per page.
+    assert_eq!(
+        lower.matches("grafana").count(),
+        1,
+        "Portrait sidebar must render once across pages\n---\n{lower}"
     );
 }
 

--- a/apps/tauri/src-tauri/src/model/adapter.rs
+++ b/apps/tauri/src-tauri/src/model/adapter.rs
@@ -25,6 +25,29 @@ use crate::export::types::{DocumentType, LineKind};
 use super::document::{Block, DocumentModel, EntryBlock, HeaderBlock, Section, SectionId};
 use super::rich::tokenize_rich;
 
+/// A short role/headline line (1–6 words, ≤60 chars, no terminal sentence
+/// punctuation) that sits directly after the name/contact and before any
+/// section — the candidate's professional title. Rejects summary prose (long or
+/// ends in punctuation), known section headings, and all-caps banners, so real
+/// content is never mistaken for the title.
+fn is_title_like(text: &str) -> bool {
+    let words = text.split_whitespace().count();
+    if !(1..=6).contains(&words) || text.chars().count() > 60 || text.ends_with(['.', '!', '?']) {
+        return false;
+    }
+    // Never promote a line that classifies as a known (non-Custom) section
+    // heading (e.g. "Skills", "Certifications") — that's section content, not a title.
+    if !matches!(SectionId::from_header(text), SectionId::Custom(_)) {
+        return false;
+    }
+    // Reject all-caps multi-word banners ("KEY HIGHLIGHTS"): a heading, not a title.
+    let alpha: String = text.chars().filter(|c| c.is_alphabetic()).collect();
+    if words >= 2 && !alpha.is_empty() && alpha == alpha.to_uppercase() {
+        return false;
+    }
+    true
+}
+
 /// Push a finished block into the active section, or into the preamble when no
 /// section has started yet (leading content under no heading).
 fn push_block(block: Block, current: &mut Option<Section>, preamble: &mut Vec<Block>) {
@@ -56,6 +79,7 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
     let parsed = parse_resume(text);
 
     let mut name: Option<String> = None;
+    let mut title: Option<String> = None;
     let mut contact_parts: Vec<String> = Vec::new();
     let mut seen_section = false;
 
@@ -150,12 +174,27 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
             },
 
             LineKind::Text => {
-                flush_entry(&mut entry, &mut current, &mut preamble);
-                push_block(
-                    Block::Paragraph(tokenize_rich(&line.raw)),
-                    &mut current,
-                    &mut preamble,
-                );
+                // Promote a short role line that sits directly after the
+                // name/contact (before any section, as the very first body line)
+                // into the header title slot — that's where every template
+                // renders it (italic, under the name), so it no longer floats as
+                // a redundant stray paragraph above the summary.
+                if !seen_section
+                    && title.is_none()
+                    && name.is_some()
+                    && entry.is_none()
+                    && preamble.is_empty()
+                    && is_title_like(&line.text)
+                {
+                    title = Some(line.text.clone());
+                } else {
+                    flush_entry(&mut entry, &mut current, &mut preamble);
+                    push_block(
+                        Block::Paragraph(tokenize_rich(&line.raw)),
+                        &mut current,
+                        &mut preamble,
+                    );
+                }
             }
         }
     }
@@ -188,7 +227,7 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
     let mut model = DocumentModel::new(DocumentType::Resume);
     model.header = HeaderBlock {
         name: name.unwrap_or_default(),
-        title: None,
+        title,
         contact,
     };
     model.sections = sections;
@@ -509,5 +548,71 @@ Principal Engineer | Meridian Systems | 2019 \u{2013} Present
             1,
             "bullet must attach to the entry"
         );
+    }
+
+    /// A short role line directly after the contact is promoted to the header
+    /// title (not a floating paragraph), and a Markdown thematic break between
+    /// the title and the first section is dropped — never rendered as "---".
+    #[test]
+    fn role_line_becomes_header_title_and_breaks_are_dropped() {
+        let resume = "\
+Jane Doe
+jane@example.com
+
+Front-End Engineer
+---
+
+PROFESSIONAL SUMMARY
+Senior Front-End Engineer with 6+ years of experience.
+";
+        let m = model_from_resume_text(resume);
+        assert_eq!(m.header.title.as_deref(), Some("Front-End Engineer"));
+
+        // No body paragraph is a literal thematic break or the bare role line.
+        for s in &m.sections {
+            for b in &s.blocks {
+                if let Block::Paragraph(rt) = b {
+                    let t = flat(rt);
+                    assert_ne!(t, "---", "literal thematic break leaked into body");
+                    assert_ne!(
+                        t, "Front-End Engineer",
+                        "role should be the header title, not a paragraph"
+                    );
+                }
+            }
+        }
+
+        // The real summary section survives; no invented untitled preamble.
+        let summary = m
+            .sections
+            .iter()
+            .find(|s| s.id == SectionId::Summary)
+            .expect("summary section");
+        assert_eq!(summary.heading, "PROFESSIONAL SUMMARY");
+    }
+
+    /// A long leading sentence is prose, not a title — it must NOT be promoted.
+    #[test]
+    fn long_leading_sentence_is_not_promoted_to_title() {
+        // SAMPLE's first preamble line is a full sentence (>6 words, trailing ".").
+        let m = model();
+        assert_eq!(m.header.title, None);
+    }
+
+    /// The hardened heuristic: real titles promote; known section names, all-caps
+    /// banners, and prose are rejected so real content never becomes the title.
+    #[test]
+    fn is_title_like_distinguishes_titles_from_sections_and_prose() {
+        assert!(is_title_like("Front-End Engineer"));
+        assert!(is_title_like("Senior Backend Developer"));
+        // Known section headings (any case) are content, not titles.
+        assert!(!is_title_like("Skills"));
+        assert!(!is_title_like("Certifications"));
+        assert!(!is_title_like("Education"));
+        // An all-caps multi-word banner is a heading, not a title.
+        assert!(!is_title_like("KEY HIGHLIGHTS"));
+        // Prose (terminal punctuation / too long) is never a title.
+        assert!(!is_title_like("A passionate engineer who ships."));
+        assert!(!is_title_like("Lots and lots and lots of words here now"));
     }
 }

--- a/apps/tauri/src-tauri/src/validate/mod.rs
+++ b/apps/tauri/src-tauri/src/validate/mod.rs
@@ -112,6 +112,18 @@ pub fn validate_and_fix(
     // re-exported single-column (linearized), then re-checked.
     let can_linearize = crate::theme::is_two_column(request.template_id) && !request.ats_mode;
     if has_critical(&issues) && can_linearize {
+        // A downgrade silently changes the user's chosen layout, so it must never
+        // be invisible (the lesson from the silent two-column→single-column bug).
+        let codes: Vec<&str> = issues
+            .iter()
+            .filter(|i| i.severity == Severity::Critical)
+            .map(|i| i.code.as_str())
+            .collect();
+        log::warn!(
+            "export: re-rendering two-column {:?} as single-column because critical issues survived validation: {:?}",
+            request.template_id,
+            codes,
+        );
         request.ats_mode = true;
         bytes = generate(&request)?;
         issues = run_validators(&request, &bytes);
@@ -463,10 +475,16 @@ fn evaluate(
             let out_of_order = positions.windows(2).any(|w| w[1] < w[0]);
             if out_of_order {
                 if two_column {
-                    issues.push(ExportIssue::critical(
+                    // A two-column layout extracting out of source order is inherent
+                    // to the design (the sidebar is a separate column), not a defect
+                    // — so this is advisory, NOT critical. Keeping it critical made
+                    // `validate_and_fix` silently re-render single-column, overriding
+                    // the user's explicit two-column + ATS-off choice. ATS mode is the
+                    // user's control for a guaranteed single-column reading order.
+                    issues.push(ExportIssue::warning(
                         "section_order",
-                        "The two-column layout's sections interleave when read top-to-bottom, \
-                         which ATS parsers misread.",
+                        "This two-column layout can read out of order in strict ATS parsers. \
+                         Enable ATS mode for a single-column, ATS-safe version.",
                     ));
                 } else {
                     issues.push(ExportIssue::warning(

--- a/apps/tauri/src-tauri/src/validate/tests.rs
+++ b/apps/tauri/src-tauri/src/validate/tests.rs
@@ -29,16 +29,24 @@ fn in_order_sections_are_clean() {
 }
 
 #[test]
-fn interleaved_two_column_is_critical() {
+fn interleaved_two_column_is_warning_not_blocking() {
     let e = expected(&["EXPERIENCE", "SKILLS", "EDUCATION"]);
-    // SKILLS (a sidebar section) surfaces before EXPERIENCE → reading order broken.
+    // SKILLS (a sidebar section) surfaces before EXPERIENCE in extraction order.
+    // That is inherent to a two-column layout (the sidebar is a separate column),
+    // not a defect — so it must be a non-blocking WARNING, never critical. A
+    // critical here made `validate_and_fix` silently re-render single-column,
+    // overriding the user's explicit two-column + ATS-off choice.
     let extracted = "Jane Doe jane@example.com SKILLS rust EXPERIENCE lots of work EDUCATION uni";
     let issues = evaluate(&e, extracted, true, DocumentType::Resume);
     assert!(
+        !has_critical(&issues),
+        "two-column reading order must not block: {issues:?}"
+    );
+    assert!(
         issues
             .iter()
-            .any(|i| i.code == "section_order" && i.severity == Severity::Critical),
-        "interleaved two-column must be critical: {issues:?}"
+            .any(|i| i.code == "section_order" && i.severity == Severity::Warning),
+        "interleaved two-column must surface as a warning: {issues:?}"
     );
 }
 

--- a/apps/tauri/src/renderer/features/settings/components/update-section/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/update-section/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 
+import { compareSemver } from '@ajh/shared';
 import { Button, cn, MarkdownMessage, RefreshButton, SettingsSection } from '@ajh/ui';
 
 import { useTranslation } from '@/lib/i18n';
@@ -39,8 +40,27 @@ export function UpdateSection() {
   const { status, check, download, install } = useUpdater();
   const openExternal = useOpenExternal();
   const [showChangelog, setShowChangelog] = useState(false);
-  const changelog = useChangelog(showChangelog);
   const currentVersion = String(versionRaw).replace(/^v/, '');
+
+  // An update is in flight (available, downloading, or staged). While it is, we
+  // surface the *accumulated* notes — not just the latest tag — so a user several
+  // versions behind sees everything they're about to get.
+  const updateInProgress =
+    status.state === 'available' || status.state === 'downloading' || status.state === 'downloaded';
+
+  // Fetch the release history as soon as an update is in flight (not only when the
+  // user expands "View changelog") so the "What's new" box can aggregate it.
+  const changelog = useChangelog(showChangelog || updateInProgress);
+
+  // Every stable release strictly newer than the installed version — i.e. the set
+  // of changes this update actually delivers. `releases` is newest-first; the
+  // newest is the available version, so a `> currentVersion` filter is the range.
+  const pendingReleases =
+    updateInProgress && currentVersion
+      ? (changelog.data?.releases ?? []).filter(
+          (r) => !r.prerelease && r.body && compareSemver(r.version, currentVersion) > 0
+        )
+      : [];
 
   const noRelease = status.state === 'error' && isNoReleaseError(status.message);
   const GITHUB_RELEASES_URL =
@@ -114,22 +134,40 @@ export function UpdateSection() {
         </div>
       )}
 
-      {/* What's new in the available update */}
-      {(status.state === 'available' ||
-        status.state === 'downloading' ||
-        status.state === 'downloaded') &&
-        'releaseNotes' in status &&
-        status.releaseNotes && (
+      {/* What's new in the available update — every release since the installed
+          version, falling back to the latest tag's note when the history is
+          unavailable (offline / GitHub error / version unknown). */}
+      {updateInProgress &&
+        (pendingReleases.length > 0 || ('releaseNotes' in status && status.releaseNotes)) && (
           <div className="mt-4 space-y-1.5">
             <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-foreground/55">
-              {t('settings.update.whatsNew')} {'version' in status ? status.version : ''}
+              {pendingReleases.length > 0 && currentVersion
+                ? t('settings.update.changesSince', { version: currentVersion })
+                : `${t('settings.update.whatsNew')} ${'version' in status ? status.version : ''}`}
             </div>
-            <div className="max-h-36 overflow-y-auto rounded-lg border border-white/[0.05] bg-white/[0.02] p-3">
-              <MarkdownMessage
-                content={status.releaseNotes}
-                className="text-xs text-foreground/60"
-                onLinkClick={(url) => openExternal.mutate(url)}
-              />
+            <div className="max-h-60 overflow-y-auto rounded-lg border border-white/[0.05] bg-white/[0.02] p-3">
+              {pendingReleases.length > 0 ? (
+                <div className="space-y-3">
+                  {pendingReleases.map((release) => (
+                    <div key={release.version} className="space-y-1">
+                      <span className="font-mono text-xs text-foreground/80">
+                        v{release.version}
+                      </span>
+                      <MarkdownMessage
+                        content={release.body ?? ''}
+                        className="text-xs text-foreground/60"
+                        onLinkClick={(url) => openExternal.mutate(url)}
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <MarkdownMessage
+                  content={'releaseNotes' in status ? (status.releaseNotes ?? '') : ''}
+                  className="text-xs text-foreground/60"
+                  onLinkClick={(url) => openExternal.mutate(url)}
+                />
+              )}
             </div>
           </div>
         )}

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -483,6 +483,7 @@
       "install": "Neu starten & installieren",
       "error": "Prüfung fehlgeschlagen",
       "whatsNew": "Neu in",
+      "changesSince": "Änderungen seit v{{version}}",
       "downloadFromGitHub": "Von GitHub herunterladen",
       "viewChangelog": "Änderungsprotokoll anzeigen",
       "hideChangelog": "Änderungsprotokoll ausblenden",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -498,6 +498,7 @@
       "install": "Restart & install",
       "error": "Check failed",
       "whatsNew": "What's new in",
+      "changesSince": "Changes since v{{version}}",
       "downloadFromGitHub": "Download from GitHub",
       "viewChangelog": "View changelog",
       "hideChangelog": "Hide changelog",

--- a/apps/tauri/src/renderer/lib/generate/export/export.test.ts
+++ b/apps/tauri/src/renderer/lib/generate/export/export.test.ts
@@ -74,14 +74,17 @@ describe('exportDOCX / exportPDF', () => {
     expect(arg.text.startsWith('Dear Hiring Team')).toBe(true);
   });
 
-  it('falls back to the modern template for an unknown id', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('throws on an unknown template id instead of silently falling back', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     const exportAndSave = vi.fn().mockResolvedValue('/p');
     _registerClient(createMockClient({ documents: { exportAndSave } }));
 
-    await exportDOCX('Body', 'out.docx', 'resume', meta, 'does-not-exist' as never);
-    expect(warn).toHaveBeenCalled();
-    expect(exportAndSave).toHaveBeenCalledWith(expect.objectContaining({ templateId: 'modern' }));
+    // A wrong-template export is indistinguishable from a correct one, so the
+    // unknown id surfaces as an error rather than quietly swapping in "modern".
+    await expect(
+      exportDOCX('Body', 'out.docx', 'resume', meta, 'does-not-exist' as never)
+    ).rejects.toThrow(/Unknown export template/);
+    expect(exportAndSave).not.toHaveBeenCalled();
   });
 
   it('throws on empty content', async () => {

--- a/apps/tauri/src/renderer/lib/generate/export/export.ts
+++ b/apps/tauri/src/renderer/lib/generate/export/export.ts
@@ -81,8 +81,11 @@ export async function exportDOCX(
       throw new Error('Invalid filename provided.');
     }
     if (!TEMPLATES[templateId]) {
-      console.warn(`Template "${templateId}" not found, using "modern" instead.`);
-      templateId = 'modern';
+      // Surface the failure instead of silently swapping in "modern" — a
+      // wrong-template export is indistinguishable from a correct one and hides
+      // the real bug. The Rust deserializer keeps a graceful, logged Classic
+      // fallback as the proper degradation layer if an unknown id ever arrives.
+      throw new Error(`Unknown export template: "${templateId}".`);
     }
 
     const api = getClient();
@@ -135,8 +138,11 @@ export async function exportPDF(
       throw new Error('Invalid filename provided.');
     }
     if (!TEMPLATES[templateId]) {
-      console.warn(`Template "${templateId}" not found, using "modern" instead.`);
-      templateId = 'modern';
+      // Surface the failure instead of silently swapping in "modern" — a
+      // wrong-template export is indistinguishable from a correct one and hides
+      // the real bug. The Rust deserializer keeps a graceful, logged Classic
+      // fallback as the proper degradation layer if an unknown id ever arrives.
+      throw new Error(`Unknown export template: "${templateId}".`);
     }
 
     const api = getClient();

--- a/apps/tauri/src/renderer/styles/globals.css
+++ b/apps/tauri/src/renderer/styles/globals.css
@@ -53,11 +53,22 @@ html[data-color-scheme='light'][data-performance-mode='low-memory'] body {
 }
 
 /* ── Modal background blur ───────────────────────────────────────────────── */
-/* The blur + dim behind a modal comes from GlassOverlay's fixed-overlay
-   `backdrop-blur` + `bg-black/40` — which only composites the region behind the
-   overlay rect. We intentionally do NOT `filter: blur` the whole .app-content
-   subtree: that forces a full-subtree re-rasterization every frame of the
-   transition (and while open), which is far more expensive than the overlay. */
+/* The frosted glass behind a modal. GlassOverlay supplies the dim scrim, but
+   WebView2 does not reliably composite its `backdrop-filter` because the overlay
+   is portaled to <body> (outside #root) — in-flow glass surfaces frost fine, the
+   portaled overlay does not. So the blur is an in-flow `filter` on the app shell
+   (#root), the same mechanism that frosts the sidebar. The portal (overlay +
+   panel) lives outside #root and stays sharp. `ModalShell` ref-counts the class.
+   The filter is toggled, never animated, so it costs a single raster while open
+   rather than a per-frame re-rasterization. Skipped in low-memory and
+   reduce-transparency modes, consistent with the rest of the glass system. */
+body.modal-blur-active #root {
+  filter: blur(8px);
+}
+html[data-performance-mode='low-memory'] body.modal-blur-active #root,
+[data-reduce-transparency] body.modal-blur-active #root {
+  filter: none;
+}
 
 /* ── Onboarding glass modal ─────────────────────────────────────────────────── */
 .onboarding-glass-modal {

--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -230,6 +230,11 @@ describe('buildResumeSystemPrompt', () => {
     expect(prompt).toContain('NEVER BREAK THESE RULES');
     expect(prompt.length).toBeLessThan(buildResumeSystemPrompt('technical').length);
   });
+
+  it('forbids dropping work roles in every depth', () => {
+    expect(buildResumeSystemPrompt('ats')).toMatch(/NEVER drop, merge, or omit a work role/i);
+    expect(buildResumeSystemPrompt('ats', 'small')).toMatch(/NEVER omit a work role/i);
+  });
 });
 
 describe('buildResumePrompt', () => {
@@ -248,6 +253,16 @@ describe('buildResumePrompt', () => {
       'ats'
     );
     expect(prompt).toContain('Rewrite entirely');
+  });
+
+  it('keeps every role and drops the old culling instructions', () => {
+    const prompt = buildResumePrompt(RESUME_WITH_LINKS, 'Job ad', META, 'ats');
+    expect(prompt).toContain('Include EVERY role');
+    expect(prompt).toContain('Repeat the block above for EVERY role');
+    // The instructions that told the model to cull roles must be gone.
+    expect(prompt).not.toContain('remove bullets irrelevant');
+    expect(prompt).not.toContain('experience to minimize');
+    expect(prompt).not.toContain('experience items most relevant');
   });
 });
 

--- a/packages/prompts/src/generate/resume.ts
+++ b/packages/prompts/src/generate/resume.ts
@@ -25,6 +25,7 @@ NEVER BREAK THESE RULES:
 3. ONLY add keywords from the job ad when they embed naturally into EXISTING true statements
 4. Every bullet: Action Verb + What + Technology + Measurable Result (if number exists in original)
 5. Every skill, job title, company, date, and achievement MUST come from the original resume
+6. NEVER omit a work role — keep every employer/role from the original; only condense the bullets within each role
 
 REQUIRED SECTION HEADERS (exact spelling):
 Professional Summary · Work Experience · Education · Skills
@@ -53,6 +54,7 @@ HARD CONSTRAINTS (never violate):
 - Use only facts from the candidate's resume — never invent skills, employers, titles, dates, or numbers.
 - Only weave in job-ad keywords where they fit an EXISTING true statement.
 - Every bullet: action verb + what + technology + a measurable result that already exists in the source.
+- Keep every work role from the candidate's resume — never drop or merge roles; only tailor the bullets inside each role.
 
 ACCEPTANCE CHECKS — verify and revise until all pass:
 - Output is the rewritten resume only (no commentary), in the target language, using that market's standard section headers and one consistent date format.
@@ -77,6 +79,7 @@ CORE RULES — NEVER BREAK (violations = instant failure):
 4. Every bullet point must refer to work the candidate actually did
 5. NEVER fabricate numbers - only use metrics if they're in the original or can be reasonably inferred
 6. NEVER add technologies the candidate hasn't used
+7. NEVER drop, merge, or omit a work role — every employer/role in the original resume MUST appear in the output, with its real title and dates; you may only reorder and condense the bullets within each role
 
 ATS OPTIMIZATION RULES (CRITICAL - 40% of success):
 
@@ -252,9 +255,9 @@ Job ad requires: Python, Kubernetes, GCP
 Internally analyse before writing:
 1. Extract the 8–10 most important requirements from the job ad
 2. Map each requirement to the candidate's existing experience
-3. Identify the 2–3 experience items most relevant to this role
+3. For EACH role in <candidate_resume>, identify the bullets most relevant to this job
 4. Note which bullets lack quantification or strong action verbs
-5. List experience to minimize (irrelevant to this role)
+5. Decide a within-role bullet order for every role (most relevant first) — never decide which roles to keep, because every role is kept
 
 Rewriting rules:
 
@@ -265,11 +268,12 @@ Professional Summary (3 sentences max):
 - Include the job title from the ad naturally
 
 Work Experience (most recent first):
-- Reorder bullets: most relevant to this job first
+- Include EVERY role from <candidate_resume> — same employer, title, and dates. Never drop, merge, or summarise away a role, even if it seems less relevant to this job.
+- Within each role, reorder bullets so the most relevant to this job come first
 - Rewrite weak bullets to CAR format: Action Verb + What + Technology (bolded) + Result
 - Embed bolded keywords naturally into EXISTING true statements
-- Compress or remove bullets irrelevant to this role
-- Each role: 3–5 strong bullets max
+- Condense wording within a role, but keep at least one bullet for every role so no role is left empty
+- Aim for 3–5 strong bullets on the most relevant roles; older or less relevant roles may have fewer, but never zero
 
 Skills Section:
 - Order by relevance to this job ad (most relevant first)
@@ -303,6 +307,8 @@ ${conv.headers.experience.toUpperCase()}
 Role Title, Company Name (${conv.dateExample})
 • Bullet using CAR format with **bolded tech**
 • ...
+(blank line)
+Repeat the block above for EVERY role in <candidate_resume>, most recent first — one block per employer/role, none omitted.
 (blank line)
 ${conv.headers.skills.toUpperCase()}
 Category: Skill1, **Skill2**, Skill3

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   calculateDownloadSpeed,
   calculateTimeRemaining,
+  compareSemver,
   formatBytes,
   formatDownloadSpeed,
   formatTimeRemaining,
@@ -126,5 +127,44 @@ describe('calculateTimeRemaining', () => {
   it('returns 0 once fully downloaded', () => {
     expect(calculateTimeRemaining(1000, 1000, 100)).toBe(0);
     expect(calculateTimeRemaining(1000, 1200, 100)).toBe(0);
+  });
+});
+
+describe('compareSemver', () => {
+  it('orders by major, then minor, then patch', () => {
+    expect(compareSemver('1.0.0', '2.0.0')).toBeLessThan(0);
+    expect(compareSemver('0.69.0', '0.65.0')).toBeGreaterThan(0);
+    expect(compareSemver('0.65.2', '0.65.10')).toBeLessThan(0);
+  });
+
+  it('returns 0 for equal versions', () => {
+    expect(compareSemver('0.65.0', '0.65.0')).toBe(0);
+  });
+
+  it('tolerates a leading v on either side', () => {
+    expect(compareSemver('v0.69.0', '0.65.0')).toBeGreaterThan(0);
+    expect(compareSemver('0.65.0', 'v0.65.0')).toBe(0);
+  });
+
+  it('ignores prerelease and build suffixes for ordering', () => {
+    expect(compareSemver('0.69.0-beta.1', '0.69.0')).toBe(0);
+    expect(compareSemver('0.69.0+build5', '0.69.0')).toBe(0);
+  });
+
+  it('treats missing or malformed segments as zero', () => {
+    expect(compareSemver('1', '1.0.0')).toBe(0);
+    expect(compareSemver('1.2', '1.2.0')).toBe(0);
+    expect(compareSemver('', '0.0.0')).toBe(0);
+    expect(compareSemver('0.65.x', '0.65.0')).toBe(0);
+  });
+
+  it('sorts an array newest-first when negated', () => {
+    const versions = ['0.65.0', '0.69.0', '0.66.3', '0.66.0'];
+    expect([...versions].sort((a, b) => compareSemver(b, a))).toEqual([
+      '0.69.0',
+      '0.66.3',
+      '0.66.0',
+      '0.65.0',
+    ]);
   });
 });

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -97,3 +97,25 @@ export function calculateTimeRemaining(
   }
   return remainingBytes / bytesPerSecond;
 }
+
+/**
+ * Compare two semantic version strings (`MAJOR.MINOR.PATCH`).
+ *
+ * Tolerant of a leading `v` and of a `-prerelease`/`+build` suffix (ignored for
+ * ordering — release lines only ever surface stable tags). Missing or malformed
+ * numeric segments are treated as `0`. Returns a negative number when `a < b`,
+ * `0` when equal, and a positive number when `a > b`, so it slots straight into
+ * `Array.prototype.sort`.
+ */
+export function compareSemver(a: string, b: string): number {
+  const parse = (v: string): [number, number, number] => {
+    const core = v.trim().replace(/^v/i, '').split(/[-+]/, 1)[0] ?? '';
+    const [major = 0, minor = 0, patch = 0] = core
+      .split('.')
+      .map((n) => Number.parseInt(n, 10) || 0);
+    return [major, minor, patch];
+  };
+  const [aMajor, aMinor, aPatch] = parse(a);
+  const [bMajor, bMinor, bPatch] = parse(b);
+  return aMajor - bMajor || aMinor - bMinor || aPatch - bPatch;
+}

--- a/packages/ui/src/components/ModalShell/ModalShell.tsx
+++ b/packages/ui/src/components/ModalShell/ModalShell.tsx
@@ -7,6 +7,26 @@ import { cn } from '../../lib/cn';
 import { transition, variants } from '../../lib/motion';
 import { GlassOverlay } from '../GlassOverlay';
 
+/**
+ * Number of currently-open ModalShells. WebView2 does not reliably composite the
+ * portaled overlay's `backdrop-filter`, so the frosted-glass effect comes from
+ * blurring the in-flow app shell instead (see the `.modal-blur-active` rule in
+ * the app CSS). The class is ref-counted so stacked modals keep the blur until
+ * the last one closes. Toggling a body class keeps this primitive app-agnostic.
+ */
+let openModalCount = 0;
+
+function setModalBlur(active: boolean): void {
+  if (typeof document === 'undefined') return;
+  if (active) {
+    openModalCount += 1;
+    document.body.classList.add('modal-blur-active');
+  } else {
+    openModalCount = Math.max(0, openModalCount - 1);
+    if (openModalCount === 0) document.body.classList.remove('modal-blur-active');
+  }
+}
+
 export interface ModalShellProps {
   open: boolean;
   onClose: () => void;
@@ -50,9 +70,16 @@ export function ModalShell({
     return () => window.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
-  // The blur + dim behind the modal comes from GlassOverlay (fixed-overlay
-  // backdrop-blur), which only composites the area behind it — far cheaper than
-  // filtering the whole app subtree, so we no longer toggle a body attribute.
+  // Frost the app shell behind the modal. GlassOverlay supplies the dim scrim,
+  // but its `backdrop-filter` blur is unreliable across WebView2 portal stacking
+  // contexts, so the actual blur is an in-flow `filter` on the app shell driven
+  // by this body class (see `.modal-blur-active` in the app CSS). Ref-counted via
+  // `setModalBlur` so stacked modals don't clear it early.
+  useEffect(() => {
+    if (!open) return;
+    setModalBlur(true);
+    return () => setModalBlur(false);
+  }, [open]);
 
   return createPortal(
     <AnimatePresence>


### PR DESCRIPTION
## What & why

Bundles the export-correctness fixes found while testing longer resumes, plus a fix to the in-app updater so the **What's new** box shows every release since the user's installed version — not just the latest tag.

### Export
- **Keep every work role.** The tailoring prompt kept only the 2–3 "most relevant" experience items, so a 4-role / 2-page resume came back with 2 roles. The prompt now tailors bullets *within* every role and never drops, merges, or summarises one away. (`packages/prompts`)
- **Two-column sidebar renders once.** On multi-page resumes the atelier/portrait sidebar repeated its content on every page; now gated to page 1.
- **No spurious single-column downgrade.** The validate gate demoted a correct two-column layout on a section-order check (critical → warning).
- **Cleaner extraction.** `is_title_like` no longer promotes prose lines to section titles; literal `---` separators no longer leak into the rendered document.

### Modal glassmorphism
- App content behind modals stayed sharp, so the frosted panels never read as depth. `backdrop-filter` is unreliable across the modal's portal stacking contexts, so we blur the in-flow `#root` content via a ref-counted body class set by `ModalShell`.

### Release notes "since your version"
- `latest.json` `notes` is a single "see the release tag" link, so the updater's **What's new** box only ever showed the newest tag — a user several versions behind never saw the intervening changes. It now aggregates notes for every stable release newer than the installed version (reusing the existing `updater_changelog` query + a new `compareSemver` helper in `@ajh/shared`), falling back to the single-tag note when the history is unavailable (offline / GitHub error / version unknown).

## Tests
- `compareSemver` unit tests (`@ajh/shared`)
- generation role-preservation tests (`@ajh/prompts`)
- render-once sidebar tests (atelier + portrait)
- export test updated for throw-on-unknown-template
- Full suite green: shared / prompts / ui / renderer vitest + `cargo test` (crate)

## Verification
- `pnpm --dir apps/tauri typecheck` ✓ · eslint ✓ · vitest ✓ · `cargo test` ✓
- Manual: Settings → Updates shows **Changes since vX.Y.Z** listing each newer release when an update is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
