### PR TITLE
ci: bump codeql-action to v4 (v3 deprecated dec 2026)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,12 +48,12 @@ jobs:
           fetch-depth: 1
 
       - name: 🧰 Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: 🔬 Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
Bumps `github/codeql-action` init + analyze from v3 to v4 in [codeql.yml](.github/workflows/codeql.yml). CodeQL Action v3 is deprecated in December 2026 (see the [changelog](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/)); v4 is the current major. No behavior change — same languages, same build-mode.

Follow-up to #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)