### PR TITLE
ci: stop claude review cancelling itself via concurrency

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,9 +29,15 @@ permissions:
   pull-requests: write
   id-token: write
 
+# cancel-in-progress MUST stay false: while a review runs, claude[bot] posts a
+# "working…" comment, which is itself an issue_comment event that starts a second
+# run in this same group. With cancel-in-progress: true that second run cancels
+# the real review mid-flight (the owner-gate skips it only AFTER concurrency is
+# evaluated). false lets the real review finish; the bot-comment run just queues
+# and is then skipped by the gate.
 concurrency:
   group: claude-review-${{ github.event.issue.number || github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   claude-review:


### PR DESCRIPTION
The bot's `working…` comment is an `issue_comment` event that starts a second run in the same concurrency group; with `cancel-in-progress: true` it cancelled the real review mid-flight (owner-gate skips it only after concurrency). Set `cancel-in-progress: false`.

Last test (#287) confirmed tag mode now engages (claude[bot] posted 'working…') — it was just cancelled by this. Final fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)