### PR TITLE
ci: extract composite setup actions + add workflow lint

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,27 @@
+name: Setup Node + pnpm
+description: Install pnpm + Node 22 with the pnpm store cache, and optionally run a frozen install.
+
+inputs:
+  install:
+    description: Run `pnpm install --frozen-lockfile`.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: 📦 Setup pnpm
+      uses: pnpm/action-setup@v6
+      with:
+        version: 11.1.3
+
+    - name: 🟢 Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: pnpm
+
+    - name: 📥 Install Dependencies
+      if: inputs.install == 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,30 @@
+name: Setup Rust (Tauri)
+description: Install the Rust toolchain, the Linux Tauri system deps, and the shared Rust cache.
+
+inputs:
+  components:
+    description: Comma-separated rustup components (e.g. "clippy, rustfmt").
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: 🦀 Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: ${{ inputs.components }}
+
+    # NOTE: this third-party action internally pins actions/cache/restore@v4
+    # (Node 20), so it emits a deprecation warning we can't fix from here.
+    - name: 🐧 Install Linux Dependencies
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+        version: latest
+
+    - name: 💾 Restore Rust Cache
+      uses: swatinem/rust-cache@v2
+      with:
+        workspaces: apps/tauri/src-tauri
+        cache-on-failure: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,22 +29,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.1.3
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: 📥 Install Dependencies
-        run: |
-          echo "::group::Installing dependencies"
-          pnpm install --frozen-lockfile
-          echo "::endgroup::"
+      - name: 📦 Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: 🔨 Build Shared Packages
         run: |

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -50,19 +50,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.1.3
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: 📥 Install Dependencies
-        run: pnpm install --frozen-lockfile
+      - name: 📦 Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: 🐶 Setup reviewdog
         uses: reviewdog/action-setup@v1
@@ -117,22 +106,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 🦀 Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: 🦀 Setup Rust (Tauri)
+        uses: ./.github/actions/setup-rust
         with:
           components: clippy
-
-      - name: 🐧 Install Linux Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-          version: latest
-
-      - name: 💾 Restore Rust Cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: apps/tauri/src-tauri
-          cache-on-failure: true
 
       - name: 💬 Clippy → reviewdog
         uses: giraffate/clippy-action@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,22 +36,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.1.3
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: 📥 Install Dependencies
-        run: |
-          echo "::group::Installing dependencies"
-          pnpm install --frozen-lockfile
-          echo "::endgroup::"
+      - name: 📦 Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: 🔍 Run npm Audit
         id: npm-audit

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -41,7 +41,7 @@ jobs:
           reporter: github-pr-review
           filter_mode: added
           level: warning
-          fail_on_error: false
+          fail_level: none # advisory; was the deprecated `fail_on_error: false`
 
   zizmor:
     name: 🛡️ zizmor

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,62 @@
+name: 🧹 Workflow Lint
+
+# ──────────────────────────────────────────────────────────────────────
+# Lints + security-audits the GitHub Actions workflows & composite actions.
+# Runs only when CI config changes. Advisory (never blocks) until tuned —
+# actionlint posts inline; zizmor's findings (e.g. unpinned actions) print
+# to the log and are addressed in the SHA-pinning PR.
+# ──────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write # actionlint inline comments via reviewdog
+
+concurrency:
+  group: workflow-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: 🔍 actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: 🔍 actionlint (reviewdog)
+        uses: reviewdog/action-actionlint@v1
+        with:
+          reporter: github-pr-review
+          filter_mode: added
+          level: warning
+          fail_on_error: false
+
+  zizmor:
+    name: 🛡️ zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      # Advisory: prints findings (incl. unpinned actions, injection risks) but
+      # never fails the build yet. SHA-pinning lands in a follow-up PR.
+      - name: 🛡️ Run zizmor
+        run: uvx zizmor .github/workflows .github/actions || true


### PR DESCRIPTION
**Phase 1a** of the CI quality/workflow tooling program (fully Actions-native).

## What
- New composite actions: `.github/actions/setup-node-pnpm` (pnpm + Node 22 + cache + optional frozen install) and `.github/actions/setup-rust` (toolchain + Tauri apt deps + rust-cache).
- Refactored **e2e.yml**, **security.yml**, **pr-review.yml** to use them — removes the duplicated pnpm/node and Rust setup blocks (net −51 lines in those files).
- New **workflow-lint.yml** (advisory): `actionlint` (inline via reviewdog) + `zizmor` (security audit), runs only when `.github/**` changes.

## Not in this PR (sequenced next)
- **ci-pipeline.yml** refactor → Phase 1b (isolated because of its intricate caching).
- SHA-pinning + Harden-Runner → follow-up (zizmor flags unpinned actions as **advisory** here, so it won't block).

## Notes
- Self-contained: no accounts, no tokens, no external services.
- All new checks are advisory.
- This PR touches `.github/**`, so workflow-lint self-validates on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)