### PR TITLE
ci: refactor ci-pipeline onto the composite setup actions

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -71,16 +71,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
+      - name: 📦 Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          version: 11.1.3
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
+          install: false
 
       - name: 🔑 Generate Cache Key
         id: cache-key
@@ -127,16 +121,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
+      - name: 📦 Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          version: 11.1.3
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
+          install: false
 
       - name: 💾 Restore node_modules Cache
         id: restore-node-modules
@@ -235,16 +223,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
+      - name: 📦 Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          version: 11.1.3
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
+          install: false
 
       - name: 💾 Restore node_modules Cache
         id: restore-node-modules
@@ -327,16 +309,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
+      - name: 📦 Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          version: 11.1.3
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
+          install: false
 
       - name: 💾 Restore node_modules Cache
         id: restore-node-modules
@@ -360,25 +336,10 @@ jobs:
           path: .turbo
           key: ${{ needs.dependencies.outputs.cache-key }}
 
-      - name: 🦀 Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: 🦀 Setup Rust (Tauri)
+        uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
-
-      # NOTE: this third-party action internally pins actions/cache/restore@v4
-      # (Node 20), so it emits a deprecation warning we can't fix from here —
-      # left as-is until upstream updates; the warning is non-fatal.
-      - name: 🐧 Install Linux Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-          version: latest
-
-      - name: 💾 Restore Rust Cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: apps/tauri/src-tauri
-          cache-on-failure: true
 
       # The @storybook/addon-vitest "storybook" project
       # (packages/ui/vitest.storybook.config.ts) runs every story as a test in
@@ -561,16 +522,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
+      - name: 📦 Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
         with:
-          version: 11.1.3
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
+          install: false
 
       - name: 💾 Restore node_modules Cache
         id: restore-node-modules
@@ -594,23 +549,8 @@ jobs:
           path: .turbo
           key: ${{ needs.dependencies.outputs.cache-key }}
 
-      - name: 🦀 Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      # NOTE: this third-party action internally pins actions/cache/restore@v4
-      # (Node 20), so it emits a deprecation warning we can't fix from here —
-      # left as-is until upstream updates; the warning is non-fatal.
-      - name: 🐧 Install Linux Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-          version: latest
-
-      - name: 💾 Restore Rust Cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: apps/tauri/src-tauri
-          cache-on-failure: true
+      - name: 🦀 Setup Rust (Tauri)
+        uses: ./.github/actions/setup-rust
 
       - name: 🦀 Cargo Check
         id: cargo-check
@@ -698,25 +638,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 🦀 Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: 🦀 Setup Rust (Tauri)
+        uses: ./.github/actions/setup-rust
         with:
           components: clippy, rustfmt
-
-      # NOTE: this third-party action internally pins actions/cache/restore@v4
-      # (Node 20), so it emits a deprecation warning we can't fix from here —
-      # left as-is until upstream updates; the warning is non-fatal.
-      - name: 🐧 Install Linux Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-          version: latest
-
-      - name: 💾 Restore Rust Cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: apps/tauri/src-tauri
-          cache-on-failure: true
 
       - name: 🎨 Cargo Format Check
         working-directory: apps/tauri/src-tauri


### PR DESCRIPTION
**Phase 1b** — refactors the main pipeline onto the composites added in #290.

## What
- Replaces the **5 duplicated pnpm/Node setup blocks** with `./.github/actions/setup-node-pnpm` (`install: false` — each job keeps its own node_modules cache + fallback install).
- Replaces the **3 Rust toolchain+apt+rust-cache blocks** (tests / build-verification / quality-checks) with `./.github/actions/setup-rust` (`components` passed through: `llvm-tools-preview`, none, `clippy, rustfmt`).
- **Net −75 lines**; same jobs, same caching, behavior unchanged.

## Verify
All ci-pipeline jobs should run identically and stay green (Dependencies, Lint & Format, Type Check, Tests, Build Verification, Quality Checks). The composites were already proven on #290's e2e + pr-review + clippy runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)