### PR TITLE
ci: pin third-party actions to commit hashes + zizmor policy

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: 📦 Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
       with:
         version: 11.1.3
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -18,13 +18,13 @@ runs:
     # NOTE: this third-party action internally pins actions/cache/restore@v4
     # (Node 20), so it emits a deprecation warning we can't fix from here.
     - name: 🐧 Install Linux Dependencies
-      uses: awalsh128/cache-apt-pkgs-action@latest
+      uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
       with:
         packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
         version: latest
 
     - name: 💾 Restore Rust Cache
-      uses: swatinem/rust-cache@v2
+      uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         workspaces: apps/tauri/src-tauri
         cache-on-failure: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: 🤖 Run Claude review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # NO `prompt` on purpose: a prompt forces "automation mode", where the

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
 
       - name: 🐶 Setup reviewdog
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1
         with:
           reviewdog_version: latest
 
@@ -112,7 +112,7 @@ jobs:
           components: clippy
 
       - name: 💬 Clippy → reviewdog
-        uses: giraffate/clippy-action@v1
+        uses: giraffate/clippy-action@13b9d32482f25d29ead141b79e7e04e7900281e0 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 11.1.3
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: 🏷️ Run Semantic Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@16ca923e6ccbb50770c415a0ccd43709a8c5f7a4 # v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -144,7 +144,7 @@ jobs:
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: � Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 11.1.3
 
@@ -263,7 +263,7 @@ jobs:
           fetch-depth: 1
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 11.1.3
 
@@ -286,13 +286,13 @@ jobs:
 
       - name: 🐧 Install Linux Dependencies
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # latest
         with:
           packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
           version: latest
 
       - name: 💾 Restore Rust Cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: apps/tauri/src-tauri
           cache-on-failure: true
@@ -414,7 +414,7 @@ jobs:
 
       - name: Upload Release Assets
         if: success()
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: v${{ steps.resolve.outputs.version }}
           # Tauri only emits .sig files for NSIS, AppImage, and macOS .app.tar.gz
@@ -504,7 +504,7 @@ jobs:
           fetch-depth: 1
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 11.1.3
 
@@ -602,7 +602,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📤 Upload latest.json to Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: v${{ needs.build.outputs.version }}
           files: latest.json

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 1
 
       - name: 🔍 actionlint (reviewdog)
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
         with:
           reporter: github-pr-review
           filter_mode: added
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 1
 
       - name: 🐍 Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       # Advisory: prints findings (incl. unpinned actions, injection risks) but
       # never fails the build yet. SHA-pinning lands in a follow-up PR.

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,19 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+#
+# unpinned-uses policy: require a commit-SHA pin for third-party actions
+# (supply-chain hardening), but allow tag/branch refs for:
+#   - actions/* and github/*    → GitHub-owned, trusted
+#   - dtolnay/rust-toolchain    → the ref name (@stable) selects the toolchain;
+#                                 a SHA pin would break that unless an explicit
+#                                 `toolchain:` input is added
+#   - taiki-e/install-action    → uses a tool-name ref (@cargo-audit) to select
+#                                 what it installs
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        'actions/*': ref-pin
+        'github/*': ref-pin
+        'dtolnay/rust-toolchain': ref-pin
+        'taiki-e/install-action': ref-pin
+        '*': hash-pin


### PR DESCRIPTION
**Phase 1c** — supply-chain hardening (self-contained; no external service).

## What
- **Hash-pin all third-party actions** to commit SHAs (with `# vX` comments): `anthropics/claude-code-action`, `reviewdog/action-setup`, `reviewdog/action-actionlint`, `giraffate/clippy-action`, `astral-sh/setup-uv`, `awalsh128/cache-apt-pkgs-action`, `swatinem/rust-cache`, `pnpm/action-setup`, `cycjimmy/semantic-release-action`, `softprops/action-gh-release`. Dependabot (`github-actions`, already configured) maintains them.
- **`.github/zizmor.yml`** policy: require hash-pin for third-party; allow ref-pin for `actions/*` + `github/*` (GitHub-owned) and for `dtolnay/rust-toolchain` + `taiki-e/install-action` (ref name selects the toolchain/tool, so SHA-pinning would break them without extra inputs).

## Why
Removes the 'compromised mutable tag' attack vector for third-party actions and clears the bulk of the zizmor unpinned-uses findings from #290.

## Notes
- Touches `release.yml` (signing pipeline); pinning is behavior-preserving (same versions, locked by SHA).
- Harden-Runner is a separate follow-up (external StepSecurity dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)