### PR TITLE
ci: add harden-runner egress audit to linux ci jobs

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -48,6 +48,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -66,6 +71,11 @@ jobs:
       cache-key: ${{ steps.cache-key.outputs.value }}
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -116,6 +126,11 @@ jobs:
     needs: dependencies
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -218,6 +233,11 @@ jobs:
     needs: dependencies
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -304,6 +324,11 @@ jobs:
     needs: dependencies
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -517,6 +542,11 @@ jobs:
     needs: dependencies
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -633,6 +663,11 @@ jobs:
     timeout-minutes: 25
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,6 +54,11 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,11 @@ jobs:
         language: [javascript-typescript]
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,11 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -45,6 +45,11 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -101,6 +106,11 @@ jobs:
     timeout-minutes: 25
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,6 +31,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -75,6 +80,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -30,6 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -48,6 +53,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
       - name: 📥 Checkout Repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
**Phase 1d** — completes Phase 1 (CI foundations + supply-chain hardening).

## What
Adds `step-security/harden-runner` (audit mode, SHA-pinned) as the first step of **every job in the 7 Linux core workflows** (16 jobs: ci-pipeline ×7, e2e, security ×2, pr-review ×2, codeql, claude-review, workflow-lint ×2). It monitors CI network egress to catch supply-chain anomalies (a compromised dependency/action phoning home or exfiltrating secrets).

## Scope & notes
- **Linux-only:** harden-runner fully supports `ubuntu-latest` only, so the `release.yml` macOS/Windows build matrix is intentionally excluded.
- **Audit mode:** non-blocking — records egress, no allowlist enforcement (can switch to `block` later once the egress baseline is known).
- ⚠️ **External dependency:** harden-runner reports to StepSecurity's service — accepted deliberately (you confirmed); the one exception to the otherwise self-contained program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
