### PR TITLE
ci: add semgrep sast and openssf scorecard (advisory)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+name: 🏅 OpenSSF Scorecard
+
+# ──────────────────────────────────────────────────────────────────────
+# Automated security-posture score (branch protection, pinned deps, token
+# permissions, etc.). Self-contained: publish_results=false keeps results out
+# of the public OpenSSF dashboard; findings post to the Security tab (SARIF).
+# ──────────────────────────────────────────────────────────────────────
+
+on:
+  branch_protection_rule:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 5 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: 🏅 Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write # upload SARIF to the Security tab
+      contents: read
+
+    steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: 🏅 Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Keep results self-contained — do not publish to the public OpenSSF API.
+          publish_results: false
+
+      - name: 📤 Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,62 @@
+name: 🔬 Semgrep
+
+# ──────────────────────────────────────────────────────────────────────
+# SAST via Semgrep OSS rulesets (no account, no cloud). Complements CodeQL.
+# Advisory: findings post to the Security tab (SARIF); the scan step never
+# fails the build. Runs on PRs, pushes to main, and weekly.
+# ──────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: 🔬 Semgrep SAST
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      # OSS rulesets pulled from the public registry (no login). Advisory: the
+      # scan never fails the job; results surface in the Security tab via SARIF.
+      - name: 🔬 Run Semgrep
+        run: |
+          uvx semgrep scan \
+            --config p/security-audit \
+            --config p/typescript \
+            --config p/react \
+            --sarif --output semgrep.sarif || true
+
+      - name: 📤 Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep


### PR DESCRIPTION
**Phase 5 (security scanning)** — two self-contained scanners; findings post to the **Security tab** (SARIF). Both advisory.

## What
- **Semgrep** (`semgrep.yml`) — SAST via OSS rulesets (`p/security-audit`, `p/typescript`, `p/react`), run with `uvx semgrep` (no account, no cloud). Complements CodeQL. The scan step never fails the job (`|| true`); SARIF uploads regardless. Runs on PRs, pushes to `main`, and weekly.
- **OpenSSF Scorecard** (`scorecard.yml`) — security-posture score (branch protection, pinned deps, token perms, …). `publish_results: false` keeps results off the public OpenSSF dashboard — fully self-contained, SARIF to the Security tab. Runs on push to `main`, weekly, and `branch_protection_rule`.

## Notes
- No accounts, no tokens, no external publish.
- Harden-Runner (audit) on both jobs; new `ossf/scorecard-action` SHA-pinned to latest (`v2.4.3`); `github/codeql-action/upload-sarif` stays on `@v3` (GitHub-owned, allowed by the zizmor policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
