### PR TITLE
ci: add cargo-hack and cargo-mutants rust quality checks (advisory)

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -1,0 +1,104 @@
+name: 🦀 Rust Quality (advisory)
+
+# ──────────────────────────────────────────────────────────────────────
+# Advisory Rust test-quality checks (neither blocks merge):
+#   - cargo-hack    : type-check each feature in isolation (catches feature-gate
+#                     bugs that --all-features hides, e.g. the no-default
+#                     legacy-renderer path).
+#   - cargo-mutants : mutation testing on the PR diff only (--in-diff) — does the
+#                     test suite actually catch injected bugs? Slow, so scoped to
+#                     changed lines and skipped when a PR touches no Rust.
+# ──────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-hack:
+    name: 🦀 Feature combinations
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: 🦀 Setup Rust (Tauri)
+        uses: ./.github/actions/setup-rust
+
+      - name: 🧰 Install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: 🦀 Check each feature (advisory)
+        continue-on-error: true
+        working-directory: apps/tauri/src-tauri
+        run: cargo hack --each-feature check --all-targets
+
+  cargo-mutants:
+    name: 🦀 Mutation testing (PR diff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          # Full history so the merge-base diff for --in-diff resolves.
+          fetch-depth: 0
+
+      - name: 🦀 Setup Rust (Tauri)
+        uses: ./.github/actions/setup-rust
+
+      - name: 🧰 Install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: 🦀 Mutation testing on the diff (advisory)
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Manual run — full-crate mutation testing is slow; this job only runs --in-diff on PRs."
+            exit 0
+          fi
+          # Crate-relative diff (paths like src/foo.rs) so cargo-mutants matches.
+          git -C "$GITHUB_WORKSPACE/apps/tauri/src-tauri" diff --relative "$BASE_SHA...HEAD" > "$RUNNER_TEMP/mutants.diff" || true
+          if [ ! -s "$RUNNER_TEMP/mutants.diff" ]; then
+            echo "No Rust changes under apps/tauri/src-tauri in this PR — skipping mutation testing."
+            exit 0
+          fi
+          cd apps/tauri/src-tauri
+          cargo mutants --in-diff "$RUNNER_TEMP/mutants.diff" --timeout 180 || true
+
+      - name: 📊 Upload mutants report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutants-${{ github.run_id }}
+          path: apps/tauri/src-tauri/mutants.out/
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
**Phase 3 (Rust test-quality)** — two advisory jobs in `rust-quality.yml`; neither blocks merge.

## What
- **cargo-hack** — `cargo hack --each-feature check --all-targets` type-checks each feature in isolation. Valuable here because the crate has real feature gates (`layout_pdf`, `model_docx`); this catches breakage in the `--no-default-features` legacy-renderer path that `--all-features` CI hides.
- **cargo-mutants** — mutation testing on the **PR diff only** (`--in-diff`): injects bugs into changed Rust lines and checks the test suite catches them (test *quality*, beyond coverage %). Skipped when a PR touches no Rust under `apps/tauri/src-tauri`. Report uploaded as an artifact.

## Notes
- Both **advisory** (`continue-on-error`). cargo-mutants is the heavy one — scoped to the diff and timeout-bounded; it may need a follow-up tuning pass (in-diff path matching / runtime) which is safe since it can't block.
- Installed via `taiki-e/install-action`; Harden-Runner audit on both jobs.
- Rust-only — pairs with the JS-side `knip` from #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
