### PR TITLE
ci: post js coverage as a pr comment

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -369,6 +369,9 @@ jobs:
     timeout-minutes: 25
     needs: [changes, dependencies]
     if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.rust == 'true'
+    permissions:
+      contents: read
+      pull-requests: write # post the JS coverage PR comment
 
     steps:
       - name: 🛡️ Harden Runner
@@ -473,6 +476,14 @@ jobs:
               echo "_Coverage report not generated._"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Post the JS coverage as a PR comment (per-file + totals), replacing what
+      # Codecov would have shown — fully in-Actions. Advisory: fork PRs get a
+      # read-only token so the comment can't post (that's fine).
+      - name: 📊 JS Coverage PR Comment
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
 
       # cargo-llvm-cov collects coverage; cargo-nextest is the test runner
       # (parallel, flaky-retry, faster, clearer output). `cargo llvm-cov nextest`

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'text-summary', 'json', 'html'],
+      reporter: ['text', 'text-summary', 'json', 'json-summary', 'html'],
       reportsDirectory: './coverage',
       include: [
         'packages/shared/src/**/*.ts',


### PR DESCRIPTION
**Native coverage on PRs** — the in-Actions replacement for Codecov (no external service).

## What
- Add the `json-summary` reporter to `vitest.config.ts`.
- New step in the ci-pipeline **Tests** job posts a **JS coverage PR comment** (per-file + totals) via `davelosert/vitest-coverage-report-action` (SHA-pinned to v2.12.0). Tests job gets `pull-requests: write`.

## Notes
- **Advisory + PR-only**, `continue-on-error` — fork PRs get a read-only token so the comment can't post (expected, harmless).
- **Rust coverage** stays in the existing job-summary table (no single action covers both; the JS surface is what most PRs touch).
- Trade-off vs Codecov: no long-term **trend dashboard** (that was Codecov's external-only feature); per-PR coverage is now visible in-Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
