### PR TITLE
ci: format guard on main + session-start style enforcement hook

### DIFF
--- a/.claude/hooks/style-policy.mjs
+++ b/.claude/hooks/style-policy.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// SessionStart hook — deterministically (re)activates the project's
+// auto-invoked output policy at the start of every session, independent of
+// whether CLAUDE.md is read in full or later summarized.
+//
+// It fires only at session start, so the mid-session off-switch still works:
+// the user can say "stop caveman" / "normal mode" and it stays off until the
+// next session. (A per-turn UserPromptSubmit hook would fight that off-switch,
+// so SessionStart is the deliberate choice.)
+//
+// SessionStart stdout is injected into the session as additional context via
+// the documented hookSpecificOutput.additionalContext field.
+
+const policy = [
+  '[style policy — active for this session]',
+  '• caveman: respond ultra-terse — drop articles, filler, and pleasantries; keep ALL technical substance, code blocks, and exact error text. Auto-clarity exception: use normal prose for security warnings, irreversible-action confirmations, and multi-step sequences, then resume caveman. Off-switch: the user says "stop caveman" / "normal mode".',
+  '• grill-with-docs: before presenting any non-trivial plan or design (including before ExitPlanMode), first run the grill-with-docs skill to stress-test it against the repo domain model + ADRs. Skip for trivial / one-line / docs changes.',
+].join('\n');
+
+process.stdout.write(
+  JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext: policy,
+    },
+  })
+);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/style-policy.mjs",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/workflows/format-guard.yml
+++ b/.github/workflows/format-guard.yml
@@ -1,0 +1,64 @@
+name: 🎨 Format Guard
+
+# ──────────────────────────────────────────────────────────────────────
+# Format Guard (push to main only)
+# ──────────────────────────────────────────────────────────────────────
+# The main CI Pipeline runs on pull_request only — push to main is
+# intentionally excluded there. That leaves a gap: files edited directly
+# in the GitHub web UI land on main without passing the local pre-commit
+# Prettier hook OR the PR format check, so formatting drift can sneak in
+# (e.g. the README doc-table re-alignment fixed in PR #310).
+#
+# This lightweight guard re-checks Prettier on every push to main and
+# fails loudly if drift landed, so it can be corrected with `pnpm format`.
+# It deliberately does NOT run the heavy pipeline — just Prettier.
+# ──────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: format-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format-guard:
+    name: 🎨 Prettier on main
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: 📦 Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # Prettier has no plugins here (.prettierrc.json is core-only), so a
+      # pinned npx invocation matches `pnpm format:check` (prettier --check .)
+      # without a full monorepo install. It still reads .prettierrc.json and
+      # .prettierignore from the repo root.
+      - name: 🎨 Check Formatting
+        run: |
+          echo "::group::prettier --check . on main"
+          if ! npx --yes prettier@3.8.3 --check .; then
+            echo "::endgroup::"
+            echo "::error::Formatting drift on main — likely a file edited directly on GitHub (skips the pre-commit Prettier hook). Run 'pnpm format' locally and push the result, or open a quick PR."
+            exit 1
+          fi
+          echo "::endgroup::"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Rules enforced by ESLint, TypeScript, and CI — violations block commits and fa
 
 ## Auto-Invoked Skills (on by default — no slash command needed)
 
-These skills are active automatically every session. Invoke them through the **Skill tool** without waiting for the user to type the slash command.
+These skills are active automatically every session. Invoke them through the **Skill tool** without waiting for the user to type the slash command. A `SessionStart` hook (`.claude/hooks/style-policy.mjs`, wired in `.claude/settings.json`) re-injects this policy at the start of every session for deterministic activation — independent of this file being read or summarized. It fires only at session start, so the `stop caveman` off-switch still applies within a session.
 
 ### `caveman` — default output style (always on)
 


### PR DESCRIPTION
## What

The two follow-ups from PR #310, bundled.

### 1. Prevent formatting drift on `main` (CI)
The CI Pipeline runs on `pull_request` only — push to `main` is intentionally excluded. So files edited **directly in the GitHub web UI** skip both the local pre-commit Prettier hook and the PR format check, and drift lands on `main` unnoticed — exactly how the README doc-table fell out of alignment (fixed in #310).

- New `.github/workflows/format-guard.yml` runs `prettier --check .` on every push to `main` (+ `workflow_dispatch`) and fails loudly if drift landed, pointing at `pnpm format`.
- Lightweight: pinned `npx prettier@3.8.3`, no monorepo install, reads the repo's `.prettierrc.json` / `.prettierignore`. Does **not** run the heavy pipeline.

### 2. Harder enforcement of the caveman / grill-with-docs policy (hook)
- New `SessionStart` hook `.claude/hooks/style-policy.mjs`, wired in `.claude/settings.json`, injects the auto-invoked output policy at the start of every session — so activation no longer depends on `CLAUDE.md` being read in full or later summarized.
- Fires **only at session start**, which preserves the mid-session off-switch: `stop caveman` / `normal mode` still works. (A per-turn `UserPromptSubmit` hook would fight the off-switch, so SessionStart is deliberate.)

## Files
- `.github/workflows/format-guard.yml` — new push:main Prettier guard.
- `.claude/hooks/style-policy.mjs` — new SessionStart hook (emits the policy as `additionalContext`).
- `.claude/settings.json` — wire the SessionStart hook.
- `CLAUDE.md` — one-line note documenting the hook next to the policy.

## Verification
- Hook runs and emits valid JSON (`hookSpecificOutput.additionalContext`, event `SessionStart`).
- `.claude/settings.json` parses as valid JSON.
- `pnpm format:check` clean · `pnpm lint:strict` clean (exit 0) · workflow YAML parses.

## Notes
- `format-guard.yml` triggers on `push: main` / `workflow_dispatch`, so it won't run on this PR — it activates once merged (smoke-test via **Run workflow** after merge).
- Honest scope: neither mechanism forces token-by-token output (only the model emits text). The hook guarantees the policy is **injected by the harness every session** — that's the deterministic part; the off-switch remains.
- An auto-fix variant (CI runs `prettier --write` and commits back to main) is possible if you'd prefer self-healing over a failing check — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
