### PR TITLE
feat: progressive reveal for ai-generate + adr-012 html preview

### DIFF
--- a/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence } from 'motion/react';
 import { useRef, useState } from 'react';
 
-import { ErrorState } from '@ajh/ui';
+import { ErrorState, useToast } from '@ajh/ui';
 
 import { ContactPromptModal } from '@/components/contact/ContactPromptModal';
 import { PageTransition } from '@/components/layout/PageTransition';
@@ -80,7 +80,11 @@ export function AIGeneratePage() {
   );
   // Opt-in company research for the cover letter — default off (no extra web/LLM call).
   const [researchCompany, setResearchCompany] = useState(false);
+  // In-flight flag, decoupled from `stage`: with progressive reveal (#23) the
+  // stage is already `done` (résumé shown) while the cover letter still streams.
+  const [isGenerating, setIsGenerating] = useState(false);
 
+  const notify = useToast();
   const selectedModel = useSelectedModel();
   const { canUse: canUseAI, reason: aiReason } = useCanUseAI();
   const extractTextMutation = useExtractText();
@@ -125,6 +129,8 @@ export function AIGeneratePage() {
     saveAiGeneration,
     t,
     setStageLabel,
+    setIsGenerating,
+    notify,
     researchCompany,
     locale
   );
@@ -216,7 +222,14 @@ export function AIGeneratePage() {
     }
   };
 
-  const isGenerating = stage === 'generating';
+  // Which document is still streaming (only meaningful in the progressive-reveal
+  // window: stage `done`, résumé shown, cover still generating). Drives the cover
+  // tab's "generating…" indicator in OutputPanelDone (#23).
+  const generatingDoc: 'resume' | 'cover' | null = isGenerating
+    ? genStep?.label === 'Cover Letter'
+      ? 'cover'
+      : 'resume'
+    : null;
 
   return (
     <PageTransition className="h-full overflow-hidden">
@@ -302,6 +315,7 @@ export function AIGeneratePage() {
                 onRegenerate={() => void handleGenerate()}
                 copied={copied}
                 isGenerating={isGenerating}
+                generatingDoc={generatingDoc}
               />
             )}
           </AnimatePresence>

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, Download, FileText, LayoutTemplate, RotateCcw } from 'lucide-react';
+import { Check, Copy, Download, FileText, LayoutTemplate, Loader2, RotateCcw } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useEffect, useState } from 'react';
 
@@ -30,6 +30,8 @@ interface OutputPanelDoneProps {
   onRegenerate: () => void;
   copied: boolean;
   isGenerating?: boolean;
+  /** Which document is still streaming during progressive reveal (#23), or null. */
+  generatingDoc?: 'resume' | 'cover' | null;
 }
 
 export function OutputPanelDone({
@@ -46,6 +48,7 @@ export function OutputPanelDone({
   onRegenerate,
   copied,
   isGenerating = false,
+  generatingDoc = null,
 }: OutputPanelDoneProps) {
   const { t } = useTranslation();
   const [exportOpen, setExportOpen] = useState(false);
@@ -71,21 +74,29 @@ export function OutputPanelDone({
         <div className="flex items-center gap-1">
           {(
             [
-              ...(resumeOut ? [{ id: 'resume' as const, label: t('aiGenerate.resume') }] : []),
-              ...(coverOut ? [{ id: 'cover' as const, label: t('aiGenerate.coverLetter') }] : []),
+              ...(resumeOut || generatingDoc === 'resume'
+                ? [{ id: 'resume' as const, label: t('aiGenerate.resume') }]
+                : []),
+              ...(coverOut || generatingDoc === 'cover'
+                ? [{ id: 'cover' as const, label: t('aiGenerate.coverLetter') }]
+                : []),
             ] as { id: 'resume' | 'cover'; label: string }[]
           ).map(({ id, label }) => (
             <Button
               key={id}
               onClick={() => onActiveOutChange(id)}
               className={cn(
-                'rounded-lg px-3 py-1.5 text-xs font-medium transition-all h-auto',
+                'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all h-auto',
                 activeOut === id
                   ? 'bg-brand/15 text-brand-soft'
                   : 'text-foreground/45 hover:text-foreground/70'
               )}
             >
               {label}
+              {/* #23 — the document still streaming in the background gets a spinner. */}
+              {generatingDoc === id && (
+                <Loader2 size={10} className="animate-spin text-brand-soft" />
+              )}
             </Button>
           ))}
         </div>

--- a/apps/tauri/src/renderer/features/ai-generate/hooks/useGeneration.test.ts
+++ b/apps/tauri/src/renderer/features/ai-generate/hooks/useGeneration.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { generateCoverLetter, generateResume, type GenerationMeta } from '@/lib/generate';
+
+import { useGeneration } from './useGeneration';
+
+// Stub the generation pipeline. extractMetadata resolves a minimal meta; the
+// résumé/cover generators emit one token and return a fixed string by default.
+vi.mock('@/lib/generate', () => ({
+  extractMetadata: vi.fn().mockResolvedValue({
+    candidateName: 'A',
+    jobTitle: 'Dev',
+    companyName: 'Co',
+    resumeLanguage: 'en',
+    jobAdLanguage: 'en',
+    mismatch: false,
+    targetLanguage: 'en',
+    topRequirements: [],
+  }),
+  generateResume: vi.fn(async (..._a: unknown[]) => 'RESUME'),
+  generateCoverLetter: vi.fn(async (..._a: unknown[]) => 'COVER'),
+}));
+
+const META: GenerationMeta = {
+  candidateName: 'A',
+  jobTitle: 'Dev',
+  companyName: 'Co',
+  resumeLanguage: 'en',
+  jobAdLanguage: 'en',
+  mismatch: false,
+  targetLanguage: 'en',
+  topRequirements: [],
+};
+
+type Target = 'resume' | 'cover' | 'both';
+
+/**
+ * Build the (large, positional) useGeneration arg list with vi.fn() setters.
+ * `useGeneration` is a plain factory (no React hooks inside), but it is named
+ * like a hook, so it is invoked via `renderHook` to satisfy rules-of-hooks.
+ */
+function setup(target: Target) {
+  const m = {
+    setStage: vi.fn(),
+    setMeta: vi.fn(),
+    setResumeOut: vi.fn(),
+    setCoverOut: vi.fn(),
+    setActiveOut: vi.fn(),
+    setStreamBuffer: vi.fn(),
+    setThinkingBuffer: vi.fn(),
+    setModelLoading: vi.fn(),
+    setTokenCount: vi.fn(),
+    setGenStep: vi.fn(),
+    setError: vi.fn(),
+    startStageRotation: vi.fn(),
+    stopStageRotation: vi.fn(),
+    saveAiGeneration: { mutate: vi.fn() },
+    setStageLabel: vi.fn(),
+    setIsGenerating: vi.fn(),
+    notify: vi.fn(),
+  };
+  const tokenStartRef = { current: null as number | null };
+  const abortControllerRef = { current: null as AbortController | null };
+
+  const { result } = renderHook(() =>
+    useGeneration(
+      'resume text',
+      'job ad',
+      META,
+      'ats',
+      target,
+      'llama',
+      m.setStage,
+      m.setMeta,
+      m.setResumeOut,
+      m.setCoverOut,
+      m.setActiveOut,
+      m.setStreamBuffer,
+      m.setThinkingBuffer,
+      m.setModelLoading,
+      m.setTokenCount,
+      m.setGenStep,
+      m.setError,
+      tokenStartRef,
+      m.startStageRotation,
+      m.stopStageRotation,
+      abortControllerRef,
+      m.saveAiGeneration,
+      (k: string) => k,
+      m.setStageLabel,
+      m.setIsGenerating,
+      m.notify
+    )
+  );
+  return { handleGenerate: result.current.handleGenerate, m };
+}
+
+const stageCalls = (m: ReturnType<typeof setup>['m']) =>
+  m.setStage.mock.calls.map((c) => c[0] as string);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(generateResume).mockResolvedValue('RESUME');
+  vi.mocked(generateCoverLetter).mockResolvedValue('COVER');
+});
+
+describe('useGeneration — progressive reveal (#23)', () => {
+  it('reveals the résumé (stage done) and finishes both, with a success toast', async () => {
+    const { handleGenerate, m } = setup('both');
+    await handleGenerate();
+
+    const stages = stageCalls(m);
+    expect(stages[0]).toBe('generating');
+    // 'done' is set twice: once right after the résumé (progressive reveal) and
+    // again at the end — the double-flip is the reveal signature.
+    expect(stages.filter((s) => s === 'done').length).toBeGreaterThanOrEqual(2);
+    expect(stages.at(-1)).toBe('done');
+
+    expect(m.setIsGenerating).toHaveBeenCalledWith(true);
+    expect(m.setIsGenerating).toHaveBeenLastCalledWith(false);
+    expect(m.notify).toHaveBeenCalledWith('aiGenerate.toast.bothReady', 'success');
+    expect(m.saveAiGeneration.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ resumeText: 'RESUME', coverLetterText: 'COVER' })
+    );
+    expect(m.setError).not.toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('keeps the finished résumé when the cover letter fails, and flags it', async () => {
+    vi.mocked(generateCoverLetter).mockRejectedValueOnce(new Error('cover boom'));
+    const { handleGenerate, m } = setup('both');
+    await handleGenerate();
+
+    // The résumé is salvaged: we end on 'done', never bouncing back to configuring.
+    expect(stageCalls(m).at(-1)).toBe('done');
+    expect(stageCalls(m)).not.toContain('configuring');
+    expect(m.notify).toHaveBeenCalledWith('aiGenerate.toast.coverFailed', 'error');
+    // Persisted résumé-only (no cover text), and no hard error surfaced.
+    expect(m.saveAiGeneration.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ resumeText: 'RESUME', coverLetterText: '' })
+    );
+    expect(m.setError).not.toHaveBeenCalledWith(expect.any(String));
+    expect(m.setIsGenerating).toHaveBeenLastCalledWith(false);
+  });
+
+  it('surfaces a hard error and returns to configuring when the résumé fails', async () => {
+    vi.mocked(generateResume).mockRejectedValueOnce(new Error('resume boom'));
+    const { handleGenerate, m } = setup('both');
+    await handleGenerate();
+
+    expect(stageCalls(m).at(-1)).toBe('configuring');
+    expect(m.setError).toHaveBeenCalledWith('resume boom');
+    expect(m.notify).toHaveBeenCalledWith('aiGenerate.toast.failed', 'error');
+    expect(m.saveAiGeneration.mutate).not.toHaveBeenCalled();
+    expect(m.setIsGenerating).toHaveBeenLastCalledWith(false);
+  });
+});
+
+describe('useGeneration — single target', () => {
+  it('cover-only stays in the streaming view until done, then notifies', async () => {
+    const { handleGenerate, m } = setup('cover');
+    await handleGenerate();
+
+    const stages = stageCalls(m);
+    // No early progressive 'done' for a single document — only the final one.
+    expect(stages).toEqual(['generating', 'done']);
+    expect(generateResume).not.toHaveBeenCalled();
+    expect(m.notify).toHaveBeenCalledWith('aiGenerate.toast.coverReady', 'success');
+    expect(m.saveAiGeneration.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ resumeText: '', coverLetterText: 'COVER' })
+    );
+  });
+
+  it('resume-only generates just the résumé and notifies', async () => {
+    const { handleGenerate, m } = setup('resume');
+    await handleGenerate();
+
+    expect(stageCalls(m)).toEqual(['generating', 'done']);
+    expect(generateCoverLetter).not.toHaveBeenCalled();
+    expect(m.notify).toHaveBeenCalledWith('aiGenerate.toast.resumeReady', 'success');
+  });
+});

--- a/apps/tauri/src/renderer/features/ai-generate/hooks/useGeneration.ts
+++ b/apps/tauri/src/renderer/features/ai-generate/hooks/useGeneration.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/generate';
 
 type AIGenerateStage = 'idle' | 'extracting' | 'configuring' | 'generating' | 'done';
+type NotifyVariant = 'success' | 'error' | 'info' | 'warning';
 
 export function useGeneration(
   resume: string,
@@ -35,6 +36,12 @@ export function useGeneration(
   saveAiGeneration: { mutate: (data: AiGenerationSaveRequest) => void },
   t: (key: string) => string,
   setStageLabel: (label: string) => void,
+  /** Tracks an in-flight generation independently of `stage` — once the résumé is
+   *  revealed (#23 progressive reveal) the stage is already `done` while the cover
+   *  is still streaming, so "is generating" can't be derived from the stage. */
+  setIsGenerating: (v: boolean) => void,
+  /** Toast sink for success/failure notices (#23). */
+  notify: (message: string, variant?: NotifyVariant) => void,
   /** Opt-in company research folded into the cover-letter prompt. */
   researchCompany = false,
   /**
@@ -70,6 +77,7 @@ export function useGeneration(
     tokenStartRef.current = null;
     const total = target === 'both' ? 2 : 1;
     setGenStep({ current: 1, total, label: target === 'cover' ? 'Cover Letter' : 'Resume' });
+    setIsGenerating(true);
     setStage('generating');
     startStageRotation();
 
@@ -78,6 +86,24 @@ export function useGeneration(
 
     let finalResume = '';
     let finalCover = '';
+
+    // Persist a finished generation (résumé and/or cover). Reused by the success
+    // path and the "cover failed but the résumé is done" salvage path (#23).
+    const persist = (resumeText: string, coverLetterText: string) =>
+      saveAiGeneration.mutate({
+        candidateName: meta.candidateName,
+        jobTitle: meta.jobTitle,
+        companyName: meta.companyName,
+        resumeLanguage: meta.resumeLanguage,
+        jobAdLanguage: meta.jobAdLanguage,
+        targetLanguage: meta.targetLanguage,
+        mismatch: meta.mismatch,
+        topRequirements: meta.topRequirements,
+        mode,
+        resumeText,
+        coverLetterText,
+        jobAd,
+      });
 
     const onTok =
       (setter: (fn: (p: string) => string) => void, accumulate: (t: string) => void) =>
@@ -113,16 +139,26 @@ export function useGeneration(
           onThink
         );
         setResumeOut(finalResume);
+        // #23 progressive reveal: in a "both" run, surface the finished résumé
+        // immediately and let the cover letter keep streaming in the background.
+        if (target === 'both') {
+          stopStageRotation();
+          setStreamBuffer('');
+          setActiveOut('resume');
+          setStage('done');
+        }
       }
 
       if (target === 'cover' || target === 'both') {
-        setActiveOut('cover');
+        // Cover-only keeps the streaming panel; in "both" the résumé is already
+        // revealed and the cover streams into its tab in the done view.
+        if (target === 'cover') setActiveOut('cover');
         setStreamBuffer('');
         setThinkingBuffer('');
         setModelLoading(true);
         tokenStartRef.current = null;
         setTokenCount(0);
-        setGenStep({ current: 2, total: 2, label: 'Cover Letter' });
+        setGenStep({ current: total, total, label: 'Cover Letter' });
         finalCover = await generateCoverLetter(
           resume,
           jobAd,
@@ -142,30 +178,40 @@ export function useGeneration(
 
       stopStageRotation();
       setStreamBuffer('');
+      setGenStep(null);
       setStage('done');
-      const doneActiveOut =
-        target === 'cover' ? 'cover' : finalResume ? 'resume' : finalCover ? 'cover' : 'resume';
-      setActiveOut(doneActiveOut);
+      setActiveOut(target === 'cover' ? 'cover' : finalResume ? 'resume' : 'cover');
 
-      void saveAiGeneration.mutate({
-        candidateName: meta.candidateName,
-        jobTitle: meta.jobTitle,
-        companyName: meta.companyName,
-        resumeLanguage: meta.resumeLanguage,
-        jobAdLanguage: meta.jobAdLanguage,
-        targetLanguage: meta.targetLanguage,
-        mismatch: meta.mismatch,
-        topRequirements: meta.topRequirements,
-        mode,
-        resumeText: finalResume,
-        coverLetterText: finalCover,
-        jobAd,
-      });
+      persist(finalResume, finalCover);
+      notify(
+        target === 'both'
+          ? t('aiGenerate.toast.bothReady')
+          : target === 'cover'
+            ? t('aiGenerate.toast.coverReady')
+            : t('aiGenerate.toast.resumeReady'),
+        'success'
+      );
     } catch (err) {
       stopStageRotation();
-      setError(err instanceof Error ? err.message : t('aiGenerate.errors.generationFailed'));
-      setStage('configuring');
+      setStreamBuffer('');
+      setGenStep(null);
+      if (controller.signal.aborted) {
+        // User cancelled — keep any finished document on screen, no error toast.
+        setStage(finalResume || finalCover ? 'done' : 'configuring');
+      } else if (target === 'both' && finalResume && !finalCover) {
+        // The résumé finished but the cover letter failed — keep the résumé
+        // visible (#23: never discard a finished document) and flag the cover.
+        setStage('done');
+        setActiveOut('resume');
+        persist(finalResume, '');
+        notify(t('aiGenerate.toast.coverFailed'), 'error');
+      } else {
+        setError(err instanceof Error ? err.message : t('aiGenerate.errors.generationFailed'));
+        setStage('configuring');
+        notify(t('aiGenerate.toast.failed'), 'error');
+      }
     } finally {
+      setIsGenerating(false);
       abortControllerRef.current = null;
     }
   };

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -531,6 +531,13 @@
     "coverLetter": "Anschreiben",
     "both": "Beides",
     "generating": "Generierung…",
+    "toast": {
+      "resumeReady": "Lebenslauf fertig",
+      "coverReady": "Anschreiben fertig",
+      "bothReady": "Lebenslauf und Anschreiben fertig",
+      "coverFailed": "Lebenslauf ist fertig — das Anschreiben ist fehlgeschlagen",
+      "failed": "Generierung fehlgeschlagen"
+    },
     "selectModel": "Wählen Sie zuerst ein Modell",
     "addApiKey": "API-Schlüssel in Einstellungen hinzufügen",
     "installCli": "CLI-Agent installieren",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -546,6 +546,13 @@
     "coverLetter": "Cover Letter",
     "both": "Both",
     "generating": "Generating…",
+    "toast": {
+      "resumeReady": "Resume ready",
+      "coverReady": "Cover letter ready",
+      "bothReady": "Resume and cover letter ready",
+      "coverFailed": "Resume is ready — the cover letter failed",
+      "failed": "Generation failed"
+    },
     "selectModel": "Select a model first",
     "addApiKey": "Add API key in Settings",
     "installCli": "Install the CLI agent",

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -42,6 +42,8 @@ Read the minimum; **stop at ~90% confidence**.
 | [ADR-008](decision-records/adr-008-pdf-glyph-subsetting.md)                  | PDF glyph subsetting at export time via `parse_font`                        |
 | [ADR-009](decision-records/adr-009-resettable-reset-registry.md)             | Full factory reset via a `Resettable` registry                              |
 | [ADR-010](decision-records/adr-010-untrusted-input-fencing.md)               | Untrusted-input fencing for web-sourced company research                    |
+| [ADR-011](decision-records/adr-011-referral-helper-manual-only.md)           | Referral helper is manual-only; no LinkedIn profile scraping                |
+| [ADR-012](decision-records/adr-012-html-preview-approximate.md)              | AI-Generate live preview is an approximate HTML mirror                      |
 
 ## Canonical docs (do not duplicate — link)
 

--- a/docs/knowledge/decision-records/adr-012-html-preview-approximate.md
+++ b/docs/knowledge/decision-records/adr-012-html-preview-approximate.md
@@ -1,0 +1,49 @@
+# ADR-012: AI-Generate live preview is an approximate HTML mirror; PDF/DOCX remain the source of truth
+
+Last updated: 2026-06-09
+
+**Status:** Accepted
+
+## Context
+
+The AI-Generate wizard (`apps/tauri/src/renderer/features/ai-generate/`) currently
+shows the generated résumé/cover letter as prettified markdown text (`OutputPanelDone` →
+`EditableOutput`), NOT the actual exported layout.
+
+UX item #24 asks the preview to render the real template and let the user edit in that
+template. The 9 templates render in Rust: PDF via printpdf and DOCX via the model_docx
+backend. ADR-002 (dual PDF/DOCX backends, golden parity) keeps those two outputs
+byte-for-byte aligned via golden snapshots. There is no HTML render path today.
+
+A live, edit-as-you-type preview requires a render path that updates instantly in the
+renderer process.
+
+## Decision
+
+Build a live HTML/CSS **mirror** of the templates for the in-app editing preview.
+
+The HTML mirror is explicitly **approximate** — a preview aid for the editing flow only.
+The Rust PDF/DOCX renderers remain the **single source of truth** for exported
+documents; ADR-002 parity is untouched.
+
+The user keeps a way to see the **real exported PDF** before download (the authoritative
+output).
+
+This is a deliberately accepted **third render path**, chosen for editing UX. It is NOT a
+replacement of the export pipeline.
+
+**Rejected alternative:** Make HTML the source of truth and generate PDF/DOCX from it
+(HTML→PDF), retiring the Rust renderers. Rejected as a massive export-pipeline rewrite
+that would reject ADR-002 and its golden-parity guarantees.
+
+## Consequences
+
+- A third render path to maintain → genuine drift risk between the HTML preview and the
+  actual PDF/DOCX export. Mitigated by (a) labelling the preview approximate and
+  (b) keeping the real-PDF view available before download.
+- Template visual specs now live in two places (the Rust renderer and the HTML mirror);
+  template changes must update both, or accept that the preview diverges from the export.
+- Export renderers (printpdf / model_docx) are unchanged; no impact on existing golden
+  snapshots or ADR-002.
+- Revisit if drift becomes a recurring user-facing problem — a future move to an
+  HTML-source-of-truth pipeline (HTML→PDF) is the escape hatch, but is out of scope here.


### PR DESCRIPTION
## What

**#23 — progressive reveal for AI-Generate** + a forward-looking ADR for #24. Frontend + docs only (no Rust, no contract changes).

### #23 — progressive reveal (`feat:`)
The "Both" generation no longer leaves the user on a blank streaming screen until *everything* finishes.

- **Progressive reveal**: the résumé is shown the moment it's done while the cover letter keeps streaming into its tab in the background (the tab shows a spinner). This needs an in-flight flag decoupled from `stage`, since the stage is already `done` while the cover is still generating.
- **Cover-failure salvage**: if the cover letter fails after the résumé succeeded, the finished résumé stays on screen and is persisted (résumé-only); the failure is flagged with a toast instead of discarding the whole run.
- **Success / failure toasts** via the existing notification system; user-cancel (abort) keeps any finished document and shows no error toast.
- New `useGeneration` unit test: progressive reveal, cover-failure salvage, hard failure, and single-target (résumé-only / cover-only) runs.

Files: `useGeneration.ts` (flow), `AIGeneratePage` (decoupled `isGenerating`, `useToast`, `generatingDoc`), `OutputPanelDone` (per-tab generating spinner), `en/de` toast strings, `useGeneration.test.ts`.

### docs — ADR-012 (`docs:`)
Pre-records the decision (grilled with the user) for the upcoming UX item **#24**: the AI-Generate live preview will be an **approximate HTML mirror** of the templates for editing responsiveness, while the **Rust PDF/DOCX renderers stay the single source of truth** (ADR-002 golden parity untouched). Backfills the decision-records index in `docs/knowledge/README.md`.

## Verification
- `pnpm lint:strict` 0 · `pnpm typecheck --force` 7/7 · `pnpm test` 875 passing (155 files) · prettier clean.
- No Rust touched. Pre-push full gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
