### PR TITLE
feat: preserve project and publication links in generated resumes

### DIFF
--- a/apps/tauri/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/tauri/src/renderer/lib/generate/generation/generation.ts
@@ -23,6 +23,7 @@ import {
   extractPlainText,
   type GenerationMeta,
   type GenerationMode,
+  getBodyLinkMap,
   getLinkMap,
   injectLinksIntoGeneratedText,
   type ReferralFormat,
@@ -268,7 +269,13 @@ export async function generateResume(
   const system = buildResumeSystemPrompt(mode, tier);
   const user = buildResumePrompt(resume, jobAd, meta, mode, tier);
   const raw = await streamGenerate(model, system, user, onToken, 0.25, locale, signal, onThinking);
-  return injectLinksIntoGeneratedText(extractPlainText(raw), getLinkMap(resume));
+  // Contact links go on the header line; body links (projects/publications, #18)
+  // are re-attached to their own items anywhere in the body.
+  return injectLinksIntoGeneratedText(
+    extractPlainText(raw),
+    getLinkMap(resume),
+    getBodyLinkMap(resume)
+  );
 }
 
 /**

--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -6,6 +6,7 @@ import {
   buildApplicantDetailsBlock,
   buildApplicationAnswerPrompt,
   buildApplicationAnswerSystemPrompt,
+  buildBodyLinksBlock,
   buildCoverLetterPrompt,
   buildCoverLetterSystemPrompt,
   buildGroundingBlock,
@@ -14,6 +15,7 @@ import {
   buildResumeSystemPrompt,
   extractPlainText,
   type GenerationMeta,
+  getBodyLinkMap,
   getLinkMap,
   injectLinksIntoGeneratedText,
   MODES,
@@ -68,7 +70,7 @@ describe('getLinkMap', () => {
     expect(map.Personal).toBeUndefined();
   });
 
-  it('admits exactly one Website link and drops later non-platform URLs', () => {
+  it('admits exactly one Website link; later non-platform URLs become body links (#18)', () => {
     const resume = [
       'Body',
       '---',
@@ -79,9 +81,11 @@ describe('getLinkMap', () => {
     ].join('\n');
     const map = getLinkMap(resume);
     expect(map.LinkedIn).toBe('https://linkedin.com/in/jane');
-    expect(map.Website).toBe('https://janedoe.dev'); // first non-platform wins
-    expect(Object.values(map)).not.toContain('https://janeblog.example'); // 2nd dropped
+    expect(map.Website).toBe('https://janedoe.dev'); // first bare-root non-platform wins
+    expect(Object.values(map)).not.toContain('https://janeblog.example'); // 2nd → body, not contact
     expect(Object.values(map)).not.toContain('mailto:jane@example.com'); // mailto dropped
+    // The second personal site is no longer dropped — it is preserved as a body link.
+    expect(getBodyLinkMap(resume).Blog).toBe('https://janeblog.example');
   });
 
   it('returns an empty map when there is no reference block', () => {
@@ -92,6 +96,49 @@ describe('getLinkMap', () => {
     const resume = `Body\n---\n- [https://github.com/jane](https://github.com/jane)`;
     const map = getLinkMap(resume);
     expect(map.GitHub).toBe('https://github.com/jane');
+  });
+
+  it('keeps a GitHub profile (one path segment) on the contact line', () => {
+    const map = getLinkMap('Body\n---\n- [GitHub](https://github.com/jane)');
+    expect(map.GitHub).toBe('https://github.com/jane');
+    expect(getBodyLinkMap('Body\n---\n- [GitHub](https://github.com/jane)')).toEqual({});
+  });
+});
+
+describe('getBodyLinkMap (#18 — body links)', () => {
+  it('classifies project / publication / repo links as body, not contact', () => {
+    const resume = [
+      'Body',
+      '---',
+      '- [LinkedIn](https://linkedin.com/in/jane)', // contact profile
+      '- [GitHub](https://github.com/jane)', // contact profile (1 segment)
+      '- [orbit-sim](https://github.com/jane/orbit-sim)', // deep repo → body
+      '- [Spin glasses in 2D](https://doi.org/10.1103/PhysRevB.1.234)', // publication → body
+      '- [Email](mailto:jane@example.com)',
+    ].join('\n');
+
+    const contact = getLinkMap(resume);
+    expect(contact.LinkedIn).toBe('https://linkedin.com/in/jane');
+    expect(contact.GitHub).toBe('https://github.com/jane');
+
+    const body = getBodyLinkMap(resume);
+    expect(body['orbit-sim']).toBe('https://github.com/jane/orbit-sim');
+    expect(body['Spin glasses in 2D']).toBe('https://doi.org/10.1103/PhysRevB.1.234');
+    // The repo did NOT pollute the contact map, and the profile is not a body link.
+    expect(contact['orbit-sim']).toBeUndefined();
+    expect(body.GitHub).toBeUndefined();
+  });
+
+  it('humanises a slug when a body link anchor is a raw URL (PDF case)', () => {
+    const resume =
+      'Body\n---\n- [https://example.org/my-research-paper](https://example.org/my-research-paper)';
+    expect(getBodyLinkMap(resume)['my research paper']).toBe(
+      'https://example.org/my-research-paper'
+    );
+  });
+
+  it('returns an empty map when there are no body links', () => {
+    expect(getBodyLinkMap(RESUME_WITH_LINKS)).toEqual({});
   });
 });
 
@@ -175,6 +222,45 @@ describe('injectLinksIntoGeneratedText', () => {
     const twice = injectLinksIntoGeneratedText(once, { LinkedIn: 'https://linkedin.com/in/n' });
     expect(twice).toBe(once);
   });
+
+  it('injects body links onto their items anywhere in the body, not just the contact line (#18)', () => {
+    const text = [
+      'Jane Dev',
+      'Researcher',
+      'Berlin | jane@example.com | GitHub',
+      '',
+      'PROJECTS',
+      '• orbit-sim — a relativistic orbit simulator',
+      '',
+      'PUBLICATIONS',
+      '• Spin glasses in 2D, Phys Rev B (2021)',
+    ].join('\n');
+    const out = injectLinksIntoGeneratedText(
+      text,
+      { GitHub: 'https://github.com/janedev' },
+      {
+        'orbit-sim': 'https://github.com/janedev/orbit-sim',
+        'Spin glasses in 2D': 'https://doi.org/10.1/x',
+      }
+    );
+    expect(out).toContain('[GitHub](https://github.com/janedev)'); // contact line
+    expect(out).toContain('[orbit-sim](https://github.com/janedev/orbit-sim)'); // project bullet
+    expect(out).toContain('[Spin glasses in 2D](https://doi.org/10.1/x)'); // publication bullet
+  });
+
+  it('body-link injection is idempotent and skips already-linked spans', () => {
+    const text = '• orbit-sim — a simulator';
+    const map = { 'orbit-sim': 'https://github.com/janedev/orbit-sim' };
+    const once = injectLinksIntoGeneratedText(text, {}, map);
+    const twice = injectLinksIntoGeneratedText(once, {}, map);
+    expect(once).toContain('[orbit-sim](https://github.com/janedev/orbit-sim)');
+    expect(twice).toBe(once);
+  });
+
+  it('does not inject body links when no bodyMap is passed (cover-letter path)', () => {
+    const text = '• orbit-sim — a simulator';
+    expect(injectLinksIntoGeneratedText(text, { GitHub: 'https://github.com/x' })).toBe(text);
+  });
 });
 
 describe('parseLinksFromResume', () => {
@@ -188,6 +274,28 @@ describe('parseLinksFromResume', () => {
 
   it('returns empty result when there is no reference block', () => {
     expect(parseLinksFromResume('No block here')).toEqual({ block: '', cleanEmail: '' });
+  });
+});
+
+describe('buildBodyLinksBlock (#18)', () => {
+  it('lists body link labels and instructs the model to keep them on their items', () => {
+    const resume = [
+      'Body',
+      '---',
+      '- [LinkedIn](https://linkedin.com/in/jane)',
+      '- [orbit-sim](https://github.com/jane/orbit-sim)',
+      '- [My thesis](https://doi.org/10.1/x)',
+    ].join('\n');
+    const block = buildBodyLinksBlock(resume);
+    expect(block).toContain('orbit-sim');
+    expect(block).toContain('My thesis');
+    expect(block).toContain('PROJECTS');
+    // Contact-line links must NOT appear in the body block.
+    expect(block).not.toContain('LinkedIn');
+  });
+
+  it('returns an empty string when there are no body links', () => {
+    expect(buildBodyLinksBlock(RESUME_WITH_LINKS)).toBe('');
   });
 });
 
@@ -263,6 +371,27 @@ describe('buildResumePrompt', () => {
     expect(prompt).not.toContain('remove bullets irrelevant');
     expect(prompt).not.toContain('experience to minimize');
     expect(prompt).not.toContain('experience items most relevant');
+  });
+
+  it('surfaces body project/publication links so they survive generation (#18)', () => {
+    const resume = [
+      'Jane Dev',
+      'Researcher',
+      'Berlin | jane@example.com',
+      '',
+      'PROJECTS',
+      'Built orbit-sim',
+      '',
+      '---',
+      '- [orbit-sim](https://github.com/jane/orbit-sim)',
+      '- [My thesis](https://doi.org/10.1/x)',
+    ].join('\n');
+    const prompt = buildResumePrompt(resume, 'Job ad', META, 'ats');
+    expect(prompt).toContain('CANDIDATE PROJECT / PUBLICATION LINKS');
+    expect(prompt).toContain('orbit-sim');
+    expect(prompt).toContain('My thesis');
+    // The raw reference block itself is still stripped from <candidate_resume>.
+    expect(prompt).not.toContain('](https://doi.org/10.1/x)');
   });
 });
 

--- a/packages/prompts/src/generate/links.ts
+++ b/packages/prompts/src/generate/links.ts
@@ -108,37 +108,131 @@ function parseLinkBlock(resume: string): LinkBlockEntry[] {
   return entries;
 }
 
+/** Decoded, empties-removed path segments of a URL; [] on parse failure. */
+function pathSegments(url: string): string[] {
+  try {
+    return new URL(url).pathname
+      .split('/')
+      .map((s) => {
+        try {
+          return decodeURIComponent(s);
+        } catch {
+          return s;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** A bare-root URL — host only, no meaningful path. The shape of a homepage. */
+function isBareRoot(url: string): boolean {
+  return pathSegments(url).length === 0;
+}
+
 /**
- * Resolve the reference block into ordered contact links for the header line.
- *
- * Every known platform link keeps its brand label. In addition, the FIRST
- * non-platform http(s) URL is admitted ONCE under a generic "Website" label —
- * this is the website/portfolio fix: previously such URLs were dropped wholesale
- * by the PROFILE_DOMAINS allowlist. Subsequent non-platform URLs are still
- * dropped, so a single header-scoped site is surfaced without letting arbitrary
- * inline body URLs leak in. `mailto:` is excluded here (handled separately as the
- * clean email).
- *
- * Both getLinkMap() (post-generation injection) and parseLinksFromResume()
- * (prompt instruction) build on this, so the label the AI is told to write and
- * the label injection later looks for can never drift.
+ * Is this platform URL a *profile* (belongs on the contact line) rather than a
+ * deep link to a specific repo/article (which belongs on its own body item)?
+ * `github.com/<user>` is a profile; `github.com/<user>/<repo>` is a project →
+ * body. Other platforms (LinkedIn, Twitter, Medium, …) are treated as profiles
+ * since people rarely deep-link them as résumé project references.
  */
-function resolveContactLinks(resume: string): { label: string; url: string }[] {
-  const out: { label: string; url: string }[] = [];
+function isProfileShaped(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.replace(/^www\./, '').toLowerCase();
+  } catch {
+    return false;
+  }
+  if (host === 'github.com' || host === 'gitlab.com') {
+    return pathSegments(url).length <= 1;
+  }
+  return true;
+}
+
+/** A readable, visible label for a body link, preferring the human anchor. */
+function bodyLabel(anchor: string, url: string): string {
+  const a = anchor.trim();
+  if (a && !/^https?:\/\//i.test(a) && !a.startsWith('mailto:')) return a;
+  // Anchor is a raw URL (common in PDFs) — derive a name from the URL: a repo /
+  // article slug (last meaningful path segment) reads better than the bare host.
+  const segs = pathSegments(url);
+  const last = segs[segs.length - 1];
+  if (last && !/^\d+$/.test(last)) {
+    const humanised = last
+      .replace(/\.[a-z0-9]+$/i, '')
+      .replace(/[-_]+/g, ' ')
+      .trim();
+    if (humanised) return humanised;
+  }
+  return urlToFriendlyLabel(url);
+}
+
+/** De-duplicate a body label so each injects to exactly one URL. */
+function uniqueBodyLabel(label: string, used: Set<string>): string {
+  let candidate = label;
+  let n = 2;
+  while (used.has(candidate.toLowerCase())) candidate = `${label} (${n++})`;
+  used.add(candidate.toLowerCase());
+  return candidate;
+}
+
+interface ClassifiedLinks {
+  /** Profile / homepage links that belong on the header contact line. */
+  contact: { label: string; url: string }[];
+  /** Project / publication / portfolio links that belong on their own item (#18). */
+  body: { label: string; url: string }[];
+}
+
+/**
+ * Split the reference block into contact-line links vs body links (#18).
+ *
+ * - **Contact**: known platform *profiles* (LinkedIn, GitHub user, …) keep their
+ *   brand label; the FIRST non-platform *bare-root* URL is admitted once under a
+ *   generic "Website" label (the homepage/portfolio fix).
+ * - **Body**: everything else — project repos (`github.com/u/repo`), article /
+ *   DOI / publication links, and any additional personal sites. Previously these
+ *   were dropped twice (by the PROFILE_DOMAINS allowlist + the "first non-platform
+ *   only" Website rule, then stripped from the body), so academic project /
+ *   publication URLs silently vanished. They are now preserved on their own items.
+ *
+ * `mailto:` is excluded here (handled separately as the clean email). Both the
+ * prompt instructions and the post-generation injectors build on this, so the
+ * label the AI is told to write and the label injection later looks for can never
+ * drift.
+ */
+function classifyLinks(resume: string): ClassifiedLinks {
+  const contact: { label: string; url: string }[] = [];
+  const body: { label: string; url: string }[] = [];
   let websiteAdmitted = false;
+  const usedBodyLabels = new Set<string>();
+
   for (const { anchor, url } of parseLinkBlock(resume)) {
     if (url.startsWith('mailto:')) continue;
-    if (isProfileUrl(url)) {
+    if (!/^https?:\/\//i.test(url)) continue;
+
+    if (isProfileUrl(url) && isProfileShaped(url)) {
       // PDFs often store the raw URL as the anchor; derive the friendly label
       // (e.g. "LinkedIn") so injection matches what the AI writes.
       const label = /^https?:\/\//i.test(anchor) ? urlToFriendlyLabel(anchor) : anchor;
-      out.push({ label, url });
-    } else if (!websiteAdmitted && /^https?:\/\//i.test(url)) {
-      out.push({ label: WEBSITE_LABEL, url });
+      contact.push({ label, url });
+    } else if (!isProfileUrl(url) && isBareRoot(url) && !websiteAdmitted) {
+      contact.push({ label: WEBSITE_LABEL, url });
       websiteAdmitted = true;
+    } else {
+      body.push({ label: uniqueBodyLabel(bodyLabel(anchor, url), usedBodyLabels), url });
     }
   }
-  return out;
+  return { contact, body };
+}
+
+function resolveContactLinks(resume: string): { label: string; url: string }[] {
+  return classifyLinks(resume).contact;
+}
+
+function resolveBodyLinks(resume: string): { label: string; url: string }[] {
+  return classifyLinks(resume).body;
 }
 
 /**
@@ -148,6 +242,19 @@ function resolveContactLinks(resume: string): { label: string; url: string }[] {
 export function getLinkMap(resume: string): Record<string, string> {
   const map: Record<string, string> = {};
   for (const { label, url } of resolveContactLinks(resume)) {
+    map[label] = url;
+  }
+  return map;
+}
+
+/**
+ * Build a label→url map for the BODY links (projects, publications, portfolio)
+ * extracted from the reference block (#18). Consumed only by the résumé injection
+ * path — cover letters never carry body links.
+ */
+export function getBodyLinkMap(resume: string): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const { label, url } of resolveBodyLinks(resume)) {
     map[label] = url;
   }
   return map;
@@ -179,20 +286,28 @@ const MD_LINK_SPAN_RE = /\[[^\]]+\]\([^)]+\)/g;
  * body prose that merely mentions a platform untouched. Falls back to the first
  * pipe line bearing a known label when no email line is present. Idempotent: the
  * `(?<!\[)` lookbehind skips labels already inside a `[…]` link.
+ *
+ * `bodyMap` (#18) carries project / publication / portfolio links that belong to
+ * specific résumé items, not the contact line — so they are injected ANYWHERE in
+ * the body (every line), not gated to the contact line. Pass `{}` (the default)
+ * for documents that carry no body links, e.g. cover letters.
  */
 export function injectLinksIntoGeneratedText(
   text: string,
-  linkMap: Record<string, string>
+  linkMap: Record<string, string>,
+  bodyMap: Record<string, string> = {}
 ): string {
-  const labels = Object.keys(linkMap);
-  if (!labels.length) return text;
+  const contactLabels = Object.keys(linkMap);
+  // Guard against over-matching short/common words against arbitrary prose.
+  const bodyLabels = Object.keys(bodyMap).filter((l) => l.trim().length >= 3);
+  if (!contactLabels.length && !bodyLabels.length) return text;
 
-  const injectPlain = (segment: string): string => {
+  const injectPlain = (segment: string, labels: string[], map: Record<string, string>): string => {
     let out = segment;
     for (const label of labels) {
       out = out.replace(
         new RegExp(`\\b${escapeRegExp(label)}\\b`, 'gi'),
-        `[${label}](${linkMap[label]})`
+        `[${label}](${map[label]})`
       );
     }
     return out;
@@ -200,34 +315,47 @@ export function injectLinksIntoGeneratedText(
   // Inject into the plain text only, stepping over any pre-existing `[label](url)`
   // spans — so a label that recurs inside an already-injected URL (linkedin.com)
   // is never re-wrapped and the pass is idempotent.
-  const inject = (line: string): string => {
+  const inject = (line: string, labels: string[], map: Record<string, string>): string => {
     let out = '';
     let last = 0;
     for (const m of line.matchAll(MD_LINK_SPAN_RE)) {
       const idx = m.index ?? 0;
-      out += injectPlain(line.slice(last, idx)) + m[0];
+      out += injectPlain(line.slice(last, idx), labels, map) + m[0];
       last = idx + m[0].length;
     }
-    return out + injectPlain(line.slice(last));
+    return out + injectPlain(line.slice(last), labels, map);
   };
   const hasLabel = (line: string): boolean =>
-    labels.some((l) => new RegExp(`(?<!\\[)\\b${escapeRegExp(l)}\\b`, 'i').test(line));
+    contactLabels.some((l) => new RegExp(`(?<!\\[)\\b${escapeRegExp(l)}\\b`, 'i').test(line));
   const isContactCandidate = (line: string): boolean =>
     line.includes('|') && !SECTION_HEADER_RE.test(line.trim());
 
   const lines = text.split('\n');
-  let injected = false;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
-    if (isContactCandidate(line) && CONTACT_EMAIL_RE.test(line)) {
-      lines[i] = inject(line);
-      injected = true;
+
+  // 1) Contact links — only the contact line (pipe-delimited, carries the email).
+  if (contactLabels.length) {
+    let injected = false;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? '';
+      if (isContactCandidate(line) && CONTACT_EMAIL_RE.test(line)) {
+        lines[i] = inject(line, contactLabels, linkMap);
+        injected = true;
+      }
+    }
+    if (!injected) {
+      const i = lines.findIndex((l) => isContactCandidate(l) && hasLabel(l));
+      if (i !== -1) lines[i] = inject(lines[i] ?? '', contactLabels, linkMap);
     }
   }
-  if (!injected) {
-    const i = lines.findIndex((l) => isContactCandidate(l) && hasLabel(l));
-    if (i !== -1) lines[i] = inject(lines[i] ?? '');
+
+  // 2) Body links (#18) — kept on their own items, so inject them anywhere in the
+  // body (idempotent; stepping over already-linked spans).
+  if (bodyLabels.length) {
+    for (let i = 0; i < lines.length; i++) {
+      lines[i] = inject(lines[i] ?? '', bodyLabels, bodyMap);
+    }
   }
+
   return lines.join('\n');
 }
 
@@ -263,6 +391,31 @@ export function parseLinksFromResume(resume: string): ParsedResumeLinks {
   }
 
   return { block: parts.join('\n\n'), cleanEmail };
+}
+
+/**
+ * Build a prompt instruction for the candidate's BODY links — project, article,
+ * publication and portfolio URLs that belong to specific résumé items rather than
+ * the contact line (#18). The block regime (PDF/RTF) strips these before the
+ * model ever sees them, so without re-surfacing them here they are silently
+ * dropped (the original academic-link bug). The model is told to keep each label
+ * on its matching item — adding a PROJECTS / PUBLICATIONS section if an item has
+ * no natural home — and to write ONLY the short label; the real hyperlink is
+ * injected post-generation by injectLinksIntoGeneratedText() via getBodyLinkMap().
+ * Returns '' when there are no body links.
+ */
+export function buildBodyLinksBlock(resume: string): string {
+  const body = resolveBodyLinks(resume);
+  if (!body.length) return '';
+  const labels = body.map((b) => `- ${b.label}`).join('\n');
+  return (
+    `CANDIDATE PROJECT / PUBLICATION LINKS — each of these belongs to a specific item in the ` +
+    `résumé (a project, publication, or portfolio piece), NOT the contact line. Keep every one ` +
+    `of these labels as visible text on its matching item; write ONLY the short label, never the ` +
+    `full URL (the link is attached automatically). If an item has no natural home in Experience ` +
+    `or Skills, add a PROJECTS or PUBLICATIONS section and list it there. Drop none of them:\n` +
+    labels
+  );
 }
 
 /**

--- a/packages/prompts/src/generate/resume.ts
+++ b/packages/prompts/src/generate/resume.ts
@@ -4,7 +4,7 @@ import { truncateResume } from '../context-manager/index.js';
 import { resumeConventions } from '../locale/index.js';
 import { type PromptTarget, resolveProfile } from '../provider/index.js';
 import { buildEmphasisBlock, buildGroundingBlock } from './emphasis.js';
-import { parseLinksFromResume, stripLinkBlock } from './links.js';
+import { buildBodyLinksBlock, parseLinksFromResume, stripLinkBlock } from './links.js';
 import { type GenerationMeta, type GenerationMode, MODES } from './modes.js';
 
 export function buildResumeSystemPrompt(
@@ -216,6 +216,9 @@ export function buildResumePrompt(
   const conventionsNote = `CONVENTIONS (target market: ${meta.targetLanguage}): use these section headers — ${conv.headers.summary} / ${conv.headers.experience} / ${conv.headers.education} / ${conv.headers.skills}; and one consistent date format like ${conv.dateExample}.`;
 
   const { block: linksBlock } = parseLinksFromResume(resume);
+  // Project / publication / portfolio links that belong on their own items (#18) —
+  // re-surfaced for the model since stripLinkBlock() removes the reference block.
+  const bodyLinksBlock = buildBodyLinksBlock(resume);
   // Section-aware truncation: keep the whole résumé when it fits the model's
   // token budget, otherwise preserve high-value sections (Experience, Skills)
   // instead of blindly cutting the tail.
@@ -224,7 +227,7 @@ export function buildResumePrompt(
   const emphasisBlock = buildEmphasisBlock(meta.topRequirements ?? []);
   const groundingBlock = buildGroundingBlock(resumeBody, meta.topRequirements ?? []);
 
-  return `${linksBlock ? `${linksBlock}\n\n` : ''}<candidate_resume>
+  return `${linksBlock ? `${linksBlock}\n\n` : ''}${bodyLinksBlock ? `${bodyLinksBlock}\n\n` : ''}<candidate_resume>
 ${resumeBody}
 </candidate_resume>
 
@@ -313,6 +316,10 @@ Repeat the block above for EVERY role in <candidate_resume>, most recent first �
 ${conv.headers.skills.toUpperCase()}
 Category: Skill1, **Skill2**, Skill3
 ...
+(blank line)
+(ONLY if CANDIDATE PROJECT / PUBLICATION LINKS were provided AND a link has no natural home in a role above — add a PROJECTS or PUBLICATIONS section here, one item per line as "Item title — Label", using the short labels. Otherwise omit this section entirely.)
+
+Preserve EVERY label from CANDIDATE PROJECT / PUBLICATION LINKS somewhere in the output — drop none. Keep any [label](url) markdown links already present in <candidate_resume> intact on their items.
 
 Start the resume now:`;
 }


### PR DESCRIPTION
## What

**#18 — preserve project & publication links in generated résumés.** Prompts + renderer only (no Rust, no contract changes).

### The bug

PDF/RTF résumés (the dominant upload format) put **every** hyperlink into a trailing `\n---\n` reference block with no inline position — the body text is plain. The generation pipeline then:

1. `stripLinkBlock` removed that whole block before sending the résumé to the model, and
2. `resolveContactLinks` kept only platform *profiles* + the **first** non-platform URL as a generic "Website".

So a candidate's **project repos, article / DOI / publication links** (very common on academic résumés) were dropped *twice* and never appeared in the generated document. (DOCX/HTML inline their links, so those already survived — this is a block-regime fix.)

### The fix (all in `packages/prompts/src/generate/links.ts` + `resume.ts` + renderer `generation.ts`)

- **Classify** — `classifyLinks` splits the block into **contact** vs **body** links:
  - *contact*: platform profiles (`github.com/<user>`/gitlab ≤1 path segment, LinkedIn, etc.) keep their brand label; the **first non-platform _bare-root_ URL** becomes "Website". Refining the Website rule to *bare-root* stops an academic DOI/article from stealing the contact slot.
  - *body*: deep repos (`github.com/u/repo`), DOI/article/publication links, and any extra personal sites.
- **Preserve** — `getBodyLinkMap` + `buildBodyLinksBlock` re-surface body links to the model with an instruction to keep each label on its matching item, add a **PROJECTS / PUBLICATIONS** section if an item has no natural home, and drop none. The résumé output structure gained that conditional section plus a "keep existing `[label](url)` intact" rule.
- **Re-inject** — `injectLinksIntoGeneratedText(text, contactMap, bodyMap?)` gains a 3rd `bodyMap` argument that injects body labels **anywhere in the body** (not just the contact line), idempotently, stepping over already-linked spans, with a ≥3-char guard against over-matching prose. **Cover letters pass no body map**, so they stay contact-only.

### Honest limitation

PDFs carry no inline annotation position, so a body link's "original item" is approximated by **anchor-text matching** plus the PROJECTS/PUBLICATIONS section fallback — the best available without pdfium-level splicing. **Needs real-academic-doc verification** (same status as the #49/#40 scrape items).

## Verification

- 10 new unit tests (classification incl. profile-vs-repo + DOI, body injection across the body, idempotency, raw-URL slug humanising, cover-letter path stays contact-only).
- `pnpm lint:strict` 0 · `pnpm typecheck --force` clean · `pnpm test` 885 passing (155 files) · prettier clean.
- No Rust touched. Pre-push full gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
