### PR TITLE
feat: add multi-select emphasis toggles to the generate wizard

### DIFF
--- a/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
@@ -17,6 +17,7 @@ import { useGeneration } from '@/features/ai-generate/hooks/useGeneration';
 import { useStageRotation } from '@/features/ai-generate/hooks/useStageRotation';
 import {
   buildFilename,
+  type EmphasisId,
   exportDOCX,
   exportPDF,
   exportTXT,
@@ -40,6 +41,7 @@ export function AIGeneratePage() {
     stage,
     meta,
     mode,
+    emphasis,
     target,
     templateId,
     atsMode,
@@ -55,6 +57,7 @@ export function AIGeneratePage() {
     setAIGenerate(v === 'configuring' ? { stage: v, wizardStep: 0 } : { stage: v });
   const setMeta = (v: typeof meta) => setAIGenerate({ meta: v });
   const setMode = (v: GenerationMode) => setAIGenerate({ mode: v });
+  const setEmphasis = (v: EmphasisId[]) => setAIGenerate({ emphasis: v });
   const setTarget = (v: 'resume' | 'cover' | 'both') => setAIGenerate({ target: v });
   const setTemplateId = (v: TemplateId) => setAIGenerate({ templateId: v });
   const setAtsMode = (v: boolean) => setAIGenerate({ atsMode: v });
@@ -132,7 +135,8 @@ export function AIGeneratePage() {
     setIsGenerating,
     notify,
     researchCompany,
-    locale
+    locale,
+    emphasis
   );
 
   const canProceed = resume.trim().length > 50 && jobAd.trim().length > 50;
@@ -264,6 +268,7 @@ export function AIGeneratePage() {
               <GenerateWizard
                 key="wizard"
                 mode={mode}
+                emphasis={emphasis}
                 target={target}
                 templateId={templateId}
                 atsMode={atsMode}
@@ -271,6 +276,7 @@ export function AIGeneratePage() {
                 researchCompany={researchCompany}
                 isGenerating={isGenerating}
                 onModeChange={setMode}
+                onEmphasisChange={setEmphasis}
                 onTargetChange={setTarget}
                 onTemplateChange={(id) => {
                   setTemplateId(id);

--- a/apps/tauri/src/renderer/features/ai-generate/components/GenerateWizard/GenerateWizard.test.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/GenerateWizard/GenerateWizard.test.tsx
@@ -65,6 +65,7 @@ vi.mock('@/store/session-store', () => ({
 function makeProps(overrides: Partial<Parameters<typeof GenerateWizard>[0]> = {}) {
   return {
     mode: 'ats' as const,
+    emphasis: [],
     target: 'both' as const,
     templateId: 'modern' as const,
     atsMode: false,
@@ -72,6 +73,7 @@ function makeProps(overrides: Partial<Parameters<typeof GenerateWizard>[0]> = {}
     researchCompany: false,
     isGenerating: false,
     onModeChange: vi.fn(),
+    onEmphasisChange: vi.fn(),
     onTargetChange: vi.fn(),
     onTemplateChange: vi.fn(),
     onAtsModeChange: vi.fn(),

--- a/apps/tauri/src/renderer/features/ai-generate/components/GenerateWizard/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/GenerateWizard/index.tsx
@@ -3,7 +3,12 @@ import { AnimatePresence, motion } from 'motion/react';
 
 import { Button, StepDots, transition } from '@ajh/ui';
 
-import { type GenerationMode, isTwoColumnTemplate, type TemplateId } from '@/lib/generate';
+import {
+  type EmphasisId,
+  type GenerationMode,
+  isTwoColumnTemplate,
+  type TemplateId,
+} from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
 import { useSessionStore } from '@/store/session-store';
 
@@ -15,6 +20,7 @@ const TOTAL_STEPS = 3;
 
 interface GenerateWizardProps {
   mode: GenerationMode;
+  emphasis: EmphasisId[];
   target: 'resume' | 'cover' | 'both';
   templateId: TemplateId;
   atsMode: boolean;
@@ -22,6 +28,7 @@ interface GenerateWizardProps {
   researchCompany: boolean;
   isGenerating: boolean;
   onModeChange: (mode: GenerationMode) => void;
+  onEmphasisChange: (ids: EmphasisId[]) => void;
   onTargetChange: (t: 'resume' | 'cover' | 'both') => void;
   onTemplateChange: (id: TemplateId) => void;
   onAtsModeChange: (enabled: boolean) => void;
@@ -32,6 +39,7 @@ interface GenerateWizardProps {
 
 export function GenerateWizard({
   mode,
+  emphasis,
   target,
   templateId,
   atsMode,
@@ -39,6 +47,7 @@ export function GenerateWizard({
   researchCompany,
   isGenerating,
   onModeChange,
+  onEmphasisChange,
   onTargetChange,
   onTemplateChange,
   onAtsModeChange,
@@ -158,10 +167,12 @@ export function GenerateWizard({
             {step === 2 && (
               <StepFineTune
                 mode={mode}
+                emphasis={emphasis}
                 target={target}
                 locale={locale}
                 researchCompany={researchCompany}
                 onModeChange={onModeChange}
+                onEmphasisChange={onEmphasisChange}
                 onLocaleChange={onLocaleChange}
                 onResearchCompanyChange={onResearchCompanyChange}
               />

--- a/apps/tauri/src/renderer/features/ai-generate/components/wizard-steps/StepFineTune/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/wizard-steps/StepFineTune/index.tsx
@@ -1,9 +1,16 @@
-import { AlertTriangle, Gauge, type LucideIcon, SlidersHorizontal, Zap } from 'lucide-react';
+import { AlertTriangle, Check, Gauge, type LucideIcon, SlidersHorizontal, Zap } from 'lucide-react';
 
 import { Button, cn, SelectDropdown } from '@ajh/ui';
 
 import { isOllamaFamily } from '@/lib/ai-providers/provider-meta';
-import { type GenerationMode, LETTER_MARKET_IDS, letterConventions, MODES } from '@/lib/generate';
+import {
+  EMPHASIS_OPTIONS,
+  type EmphasisId,
+  type GenerationMode,
+  LETTER_MARKET_IDS,
+  letterConventions,
+  MODES,
+} from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
 import { useHasProviderKey } from '@/services';
 import type { PromptQuality } from '@/store/preferences-schema';
@@ -15,10 +22,12 @@ import {
 
 interface StepFineTuneProps {
   mode: GenerationMode;
+  emphasis: EmphasisId[];
   target: 'resume' | 'cover' | 'both';
   locale: string;
   researchCompany: boolean;
   onModeChange: (mode: GenerationMode) => void;
+  onEmphasisChange: (ids: EmphasisId[]) => void;
   onLocaleChange: (locale: string) => void;
   onResearchCompanyChange: (v: boolean) => void;
 }
@@ -51,14 +60,20 @@ const QUALITY_OPTIONS: {
 
 export function StepFineTune({
   mode,
+  emphasis,
   target,
   locale,
   researchCompany,
   onModeChange,
+  onEmphasisChange,
   onLocaleChange,
   onResearchCompanyChange,
 }: StepFineTuneProps) {
   const { t } = useTranslation();
+
+  // #15 — emphasis directives are multi-select (toggle in/out of the set).
+  const toggleEmphasis = (id: EmphasisId) =>
+    onEmphasisChange(emphasis.includes(id) ? emphasis.filter((e) => e !== id) : [...emphasis, id]);
   const promptQuality = usePromptQuality();
   const setPromptQuality = usePreferencesStore((s) => s.setPromptQuality);
 
@@ -106,6 +121,48 @@ export function StepFineTune({
               </Button>
             )
           )}
+        </div>
+      </div>
+
+      {/* Emphasis directives (#15) — multi-select, fact-safe rewrite biases */}
+      <div>
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/55">
+          {t('aiGenerate.wizard.emphasis.label')}
+        </div>
+        <div className="grid grid-cols-2 gap-1.5">
+          {EMPHASIS_OPTIONS.map(({ id }) => {
+            const active = emphasis.includes(id);
+            return (
+              <Button
+                key={id}
+                onClick={() => toggleEmphasis(id)}
+                aria-pressed={active}
+                className={cn(
+                  'flex items-center gap-2 rounded-xl border px-3 py-2 text-left transition-all h-auto',
+                  active
+                    ? 'border-brand/35 bg-brand/8 text-foreground/90'
+                    : 'border-white/[0.05] bg-transparent text-foreground/50 hover:border-white/[0.08] hover:text-foreground/75'
+                )}
+              >
+                <span
+                  className={cn(
+                    'flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border',
+                    active ? 'border-brand bg-brand text-white' : 'border-white/15'
+                  )}
+                >
+                  {active && <Check size={10} />}
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-[11px] font-medium">
+                    {t(`aiGenerate.wizard.emphasis.${id}.label`)}
+                  </span>
+                  <span className="block text-[10px] text-foreground/35">
+                    {t(`aiGenerate.wizard.emphasis.${id}.desc`)}
+                  </span>
+                </span>
+              </Button>
+            );
+          })}
         </div>
       </div>
 

--- a/apps/tauri/src/renderer/features/ai-generate/hooks/useGeneration.ts
+++ b/apps/tauri/src/renderer/features/ai-generate/hooks/useGeneration.ts
@@ -1,6 +1,7 @@
 import type { AiGenerationSaveRequest } from '@ajh/shared/ipc';
 
 import {
+  type EmphasisId,
   extractMetadata,
   generateCoverLetter,
   generateResume,
@@ -49,7 +50,9 @@ export function useGeneration(
    * to the cover-letter prompt so the generated text matches the export layout,
    * which resolves the same market from this value + the detected job country.
    */
-  marketOverride = ''
+  marketOverride = '',
+  /** User-selected emphasis directives (#15), merged into meta at generate-time. */
+  emphasis: EmphasisId[] = []
 ) {
   const handleAnalyze = async () => {
     setError(null);
@@ -67,6 +70,9 @@ export function useGeneration(
 
   const handleGenerate = async () => {
     if (!meta || !selectedModel) return;
+    // Fold the user's emphasis directives (#15) into the meta the prompt builders
+    // read. Kept separate from the stored `meta` (extracted) so the wizard owns it.
+    const genMeta: GenerationMeta = emphasis.length ? { ...meta, emphasis } : meta;
     setError(null);
     setResumeOut('');
     setCoverOut('');
@@ -128,7 +134,7 @@ export function useGeneration(
         finalResume = await generateResume(
           resume,
           jobAd,
-          meta,
+          genMeta,
           mode,
           selectedModel,
           onTok(setStreamBuffer, (t) => {
@@ -162,7 +168,7 @@ export function useGeneration(
         finalCover = await generateCoverLetter(
           resume,
           jobAd,
-          meta,
+          genMeta,
           mode,
           selectedModel,
           onTok(setStreamBuffer, (t) => {

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -635,6 +635,29 @@
       "back": "Zurück",
       "next": "Weiter",
       "generate": "Generieren",
+      "emphasis": {
+        "label": "Schwerpunkt",
+        "quantify": {
+          "label": "Wirkung quantifizieren",
+          "desc": "Vorhandene Kennzahlen hervorheben."
+        },
+        "leadership": {
+          "label": "Führungsfokus",
+          "desc": "Verantwortung und Einfluss betonen."
+        },
+        "concise": {
+          "label": "Prägnanter",
+          "desc": "Knappere Punkte, keine Füllwörter."
+        },
+        "senior": {
+          "label": "Senior-Ton",
+          "desc": "Nach Umfang und Ergebnis rahmen."
+        },
+        "technical": {
+          "label": "Technische Tiefe",
+          "desc": "Konkrete Technik und Systeme nennen."
+        }
+      },
       "quality": {
         "label": "Prompt-Qualität",
         "full": "Vollständig",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -650,6 +650,29 @@
       "back": "Back",
       "next": "Next",
       "generate": "Generate",
+      "emphasis": {
+        "label": "Emphasis",
+        "quantify": {
+          "label": "Quantify impact",
+          "desc": "Surface metrics already in your résumé."
+        },
+        "leadership": {
+          "label": "Leadership focus",
+          "desc": "Foreground ownership and influence."
+        },
+        "concise": {
+          "label": "More concise",
+          "desc": "Tighter bullets, no filler."
+        },
+        "senior": {
+          "label": "Senior tone",
+          "desc": "Frame by scope and outcome."
+        },
+        "technical": {
+          "label": "Technical depth",
+          "desc": "Name specific tech and systems."
+        }
+      },
       "quality": {
         "label": "Prompt quality",
         "full": "Full",

--- a/apps/tauri/src/renderer/lib/generate/index.ts
+++ b/apps/tauri/src/renderer/lib/generate/index.ts
@@ -19,9 +19,10 @@ export { isTwoColumnTemplate, TEMPLATE_IDS, type TemplateId, TEMPLATES } from '.
  * useTailorGeneration) stay in lockstep.
  */
 export const PERSIST_DEBOUNCE_MS = 800;
-export type { RewriteDocType } from '@ajh/prompts/generate';
+export type { EmphasisId, RewriteDocType } from '@ajh/prompts/generate';
 export {
   CONNECTION_NOTE_LIMIT,
+  EMPHASIS_OPTIONS,
   LETTER_MARKET_IDS,
   letterConventions,
   resolveMarket,

--- a/apps/tauri/src/renderer/store/session-store/session-store.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand';
 import type { AutopilotFoundJob } from '@ajh/shared';
 
 import type { WizardState } from '@/features/autopilot/types';
-import type { GenerationMeta, GenerationMode, TemplateId } from '@/lib/generate';
+import type { EmphasisId, GenerationMeta, GenerationMode, TemplateId } from '@/lib/generate';
 import type { AnalysisResult } from '@/lib/resume-ai';
 
 // ─── Per-route state shapes ───────────────────────────────────────────────────
@@ -17,6 +17,8 @@ interface AIGenerateSlice {
   stage: AIGenerateStage;
   meta: GenerationMeta | null;
   mode: GenerationMode;
+  /** User-selected emphasis directives (#15) — fact-safe rewrite biases. */
+  emphasis: EmphasisId[];
   target: AIGenerateTarget;
   templateId: TemplateId;
   atsMode: boolean;
@@ -96,6 +98,7 @@ const AI_GENERATE_DEFAULTS: AIGenerateSlice = {
   stage: 'idle',
   meta: null,
   mode: 'ats',
+  emphasis: [],
   target: 'both',
   templateId: 'modern',
   atsMode: false,

--- a/packages/prompts/src/generate/cover-letter.ts
+++ b/packages/prompts/src/generate/cover-letter.ts
@@ -7,6 +7,7 @@ import {
   type ApplicantPreferences,
   buildApplicantDetailsBlock,
   buildCompanyResearchBlock,
+  buildEmphasisDirectivesBlock,
   buildGroundingBlock,
   buildLetterEmphasisBlock,
 } from './emphasis.js';
@@ -255,6 +256,7 @@ export function buildCoverLetterPrompt(
   const resumeBody = truncateResume(stripLinkBlock(resume), truncation);
 
   const emphasisBlock = buildLetterEmphasisBlock(meta.topRequirements ?? []);
+  const directivesBlock = buildEmphasisDirectivesBlock(meta.emphasis);
   const groundingBlock = buildGroundingBlock(resumeBody, meta.topRequirements ?? []);
 
   return `${linksBlock ? `${linksBlock}\n\n` : ''}<candidate_resume>
@@ -284,7 +286,7 @@ Candidate: ${meta.candidateName || 'Unknown'}
 Role: ${meta.jobTitle || 'this role'} at ${meta.companyName || 'this company'}
 Today: ${today}
 ${langNote}
-${emphasisBlock}
+${directivesBlock ? `${directivesBlock}\n` : ''}${emphasisBlock}
 ${groundingBlock ? `\n${groundingBlock}\n` : ''}
 ### WRITING NOTES (internal — do NOT output any of this) ###
 

--- a/packages/prompts/src/generate/emphasis.ts
+++ b/packages/prompts/src/generate/emphasis.ts
@@ -132,6 +132,62 @@ These are the applicant's OWN stated preferences. State them only where the ques
 }
 
 /**
+ * User-selectable emphasis directives (#15) — multi-select rewrite biases applied
+ * on top of the chosen mode. Every directive is **fact-safe**: it changes framing
+ * or focus only and must never invent facts the résumé doesn't contain.
+ */
+export type EmphasisId = 'quantify' | 'leadership' | 'concise' | 'senior' | 'technical';
+
+/**
+ * Single source of truth for the emphasis directives — id + the exact instruction
+ * folded into the prompt. The wizard renders localized labels keyed by `id`; the
+ * prompt layer consumes the instruction. Adding a directive here surfaces it in
+ * both places (add the matching i18n label keys). Order here is the render +
+ * prompt order.
+ */
+export const EMPHASIS_OPTIONS: { id: EmphasisId; instruction: string }[] = [
+  {
+    id: 'quantify',
+    instruction:
+      'Quantify impact: surface the numbers, scale, and measurable outcomes already in the résumé (metrics, %, volume, team size). NEVER invent or estimate figures that are not present.',
+  },
+  {
+    id: 'leadership',
+    instruction:
+      'Leadership focus: foreground ownership, mentoring, and cross-functional influence the résumé already demonstrates. Do NOT claim leadership the résumé does not show.',
+  },
+  {
+    id: 'concise',
+    instruction:
+      'More concise: tighter bullets, fewer words, no filler. Preserve every role, fact, and metric — cut only redundancy, never content.',
+  },
+  {
+    id: 'senior',
+    instruction:
+      'Senior tone: frame contributions in terms of scope, judgment, and outcome rather than tasks. Do NOT inflate the candidate’s actual level, title, or responsibilities.',
+  },
+  {
+    id: 'technical',
+    instruction:
+      'Technical depth: name the specific technologies, systems, and engineering decisions the résumé already contains. Do NOT add technologies the candidate never used.',
+  },
+];
+
+/**
+ * Build the emphasis-directives block from the user's multi-selected toggles (#15).
+ * Filters to known ids (in registry order), de-dupes, and prefixes a hard
+ * no-fabrication reminder so the biases can never license invented facts. Returns
+ * '' when nothing is selected, so prompts that don't use it pay nothing.
+ */
+export function buildEmphasisDirectivesBlock(ids: EmphasisId[] | undefined): string {
+  if (!ids?.length) return '';
+  const selected = new Set(ids);
+  const lines = EMPHASIS_OPTIONS.filter((o) => selected.has(o.id)).map((o) => `- ${o.instruction}`);
+  if (!lines.length) return '';
+  return `EMPHASIS — apply these user-selected biases WITHOUT inventing facts (every statement must still be traceable to the résumé):\n${lines.join('\n')}`;
+}
+
+/**
  * Build the bold emphasis instruction block for prompts.
  * The AI uses **keyword** notation; the renderer converts to real bold.
  */

--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -9,10 +9,13 @@ import {
   buildBodyLinksBlock,
   buildCoverLetterPrompt,
   buildCoverLetterSystemPrompt,
+  buildEmphasisDirectivesBlock,
   buildGroundingBlock,
   buildMetadataPrompt,
   buildResumePrompt,
   buildResumeSystemPrompt,
+  EMPHASIS_OPTIONS,
+  type EmphasisId,
   extractPlainText,
   type GenerationMeta,
   getBodyLinkMap,
@@ -345,6 +348,36 @@ describe('buildResumeSystemPrompt', () => {
   });
 });
 
+describe('buildEmphasisDirectivesBlock (#15)', () => {
+  it('returns empty for no/empty selection', () => {
+    expect(buildEmphasisDirectivesBlock(undefined)).toBe('');
+    expect(buildEmphasisDirectivesBlock([])).toBe('');
+  });
+
+  it('emits one instruction per selected directive, in registry order, with a no-fabrication guard', () => {
+    const block = buildEmphasisDirectivesBlock(['technical', 'quantify']);
+    expect(block).toContain('WITHOUT inventing facts');
+    // Registry order (quantify before technical) regardless of input order.
+    expect(block.indexOf('Quantify impact')).toBeLessThan(block.indexOf('Technical depth'));
+    // Exactly two directive lines.
+    expect(block.split('\n').filter((l) => l.startsWith('- ')).length).toBe(2);
+  });
+
+  it('ignores unknown ids and de-dupes repeats', () => {
+    // Cast simulates a stale/unknown id leaking from persisted state.
+    const ids = ['quantify', 'quantify', 'bogus'] as EmphasisId[];
+    const block = buildEmphasisDirectivesBlock(ids);
+    expect(block.split('\n').filter((l) => l.startsWith('- ')).length).toBe(1);
+  });
+
+  it('every registry option carries a fact-safe instruction', () => {
+    expect(EMPHASIS_OPTIONS.length).toBeGreaterThanOrEqual(5);
+    for (const o of EMPHASIS_OPTIONS) {
+      expect(o.instruction.length).toBeGreaterThan(20);
+    }
+  });
+});
+
 describe('buildResumePrompt', () => {
   it('includes candidate context and a language note', () => {
     const prompt = buildResumePrompt(RESUME_WITH_LINKS, 'Job ad', META, 'ats');
@@ -371,6 +404,21 @@ describe('buildResumePrompt', () => {
     expect(prompt).not.toContain('remove bullets irrelevant');
     expect(prompt).not.toContain('experience to minimize');
     expect(prompt).not.toContain('experience items most relevant');
+  });
+
+  it('folds in emphasis directives only when selected (#15)', () => {
+    const base = buildResumePrompt(RESUME_WITH_LINKS, 'Job ad', META, 'ats');
+    expect(base).not.toContain('EMPHASIS — apply these user-selected biases');
+
+    const withEmphasis = buildResumePrompt(
+      RESUME_WITH_LINKS,
+      'Job ad',
+      { ...META, emphasis: ['quantify', 'concise'] },
+      'ats'
+    );
+    expect(withEmphasis).toContain('EMPHASIS — apply these user-selected biases');
+    expect(withEmphasis).toContain('Quantify impact');
+    expect(withEmphasis).toContain('More concise');
   });
 
   it('surfaces body project/publication links so they survive generation (#18)', () => {
@@ -515,6 +563,17 @@ describe('buildCoverLetterPrompt', () => {
   it('omits the company-research block when no brief is provided', () => {
     const prompt = buildCoverLetterPrompt(RESUME_WITH_LINKS, 'Job ad', META, 'recruiter');
     expect(prompt).not.toContain('<company_research>');
+  });
+
+  it('folds in emphasis directives when selected (#15)', () => {
+    const prompt = buildCoverLetterPrompt(
+      RESUME_WITH_LINKS,
+      'Job ad',
+      { ...META, emphasis: ['leadership'] },
+      'recruiter'
+    );
+    expect(prompt).toContain('EMPHASIS — apply these user-selected biases');
+    expect(prompt).toContain('Leadership focus');
   });
 
   it('injects German market conventions (Betreff + salary/start-date) while keeping the letter language', () => {

--- a/packages/prompts/src/generate/modes.ts
+++ b/packages/prompts/src/generate/modes.ts
@@ -1,5 +1,7 @@
 /** Generation modes + metadata shape. */
 
+import type { EmphasisId } from './emphasis.js';
+
 export type GenerationMode =
   | 'ats' // Conservative ATS Optimization
   | 'recruiter' // Recruiter-Friendly Rewrite
@@ -31,6 +33,13 @@ export interface GenerationMeta {
    * when unknown — resolution then falls back to the research brief / language.
    */
   jobCountry?: string;
+  /**
+   * User-selected emphasis directives (#15) — fact-safe rewrite biases applied on
+   * top of the mode (e.g. quantify impact, more concise). Optional so existing
+   * `GenerationMeta` literals stay valid; the wizard merges the chosen set into
+   * meta just before generation.
+   */
+  emphasis?: EmphasisId[];
 }
 
 export const MODES: Record<

--- a/packages/prompts/src/generate/resume.ts
+++ b/packages/prompts/src/generate/resume.ts
@@ -3,7 +3,11 @@
 import { truncateResume } from '../context-manager/index.js';
 import { resumeConventions } from '../locale/index.js';
 import { type PromptTarget, resolveProfile } from '../provider/index.js';
-import { buildEmphasisBlock, buildGroundingBlock } from './emphasis.js';
+import {
+  buildEmphasisBlock,
+  buildEmphasisDirectivesBlock,
+  buildGroundingBlock,
+} from './emphasis.js';
 import { buildBodyLinksBlock, parseLinksFromResume, stripLinkBlock } from './links.js';
 import { type GenerationMeta, type GenerationMode, MODES } from './modes.js';
 
@@ -225,6 +229,7 @@ export function buildResumePrompt(
   const resumeBody = truncateResume(stripLinkBlock(resume), truncation);
 
   const emphasisBlock = buildEmphasisBlock(meta.topRequirements ?? []);
+  const directivesBlock = buildEmphasisDirectivesBlock(meta.emphasis);
   const groundingBlock = buildGroundingBlock(resumeBody, meta.topRequirements ?? []);
 
   return `${linksBlock ? `${linksBlock}\n\n` : ''}${bodyLinksBlock ? `${bodyLinksBlock}\n\n` : ''}<candidate_resume>
@@ -243,7 +248,7 @@ Target Role: ${meta.jobTitle || 'Unknown'}
 Company: ${meta.companyName || 'Unknown'}
 ${langNote}
 ${conventionsNote}
-${emphasisBlock}
+${directivesBlock ? `${directivesBlock}\n` : ''}${emphasisBlock}
 ${groundingBlock ? `\n${groundingBlock}\n` : ''}
 EXAMPLE — MISSING SKILLS (follow this exactly):
 


### PR DESCRIPTION
## What

**#15 — multi-select emphasis toggles** for the AI-Generate wizard. Prompts + renderer only (no Rust, no contract changes).

A new **Emphasis** control in the wizard's fine-tune step lets the user bias a rewrite *on top of* the chosen mode, multi-select:

- **Quantify impact** — surface metrics already in the résumé
- **Leadership focus** — foreground ownership & influence the résumé shows
- **More concise** — tighter bullets, no filler (no content cut)
- **Senior tone** — frame by scope/judgment/outcome (no level inflation)
- **Technical depth** — name the specific tech the résumé already contains

Every directive is **fact-safe**: it changes framing/focus only and can never license inventing facts. The directives block is prefixed with a hard "WITHOUT inventing facts — every statement must still be traceable to the résumé" guard.

## How

- **`packages/prompts/src/generate/emphasis.ts`** — `EmphasisId` + `EMPHASIS_OPTIONS` (single source of truth: id + exact prompt instruction) + `buildEmphasisDirectivesBlock(ids)` (filters to known ids in registry order, de-dupes, no-fabrication guard). Distinct from the existing keyword-bolding `buildEmphasisBlock`.
- **Threading via `GenerationMeta.emphasis?`** — zero signature churn: both `buildResumePrompt` and `buildCoverLetterPrompt` already read `meta`, so they just consume `meta.emphasis`. `useGeneration` merges the wizard's selected set into meta at generate-time (`genMeta`), keeping the session field separate like `mode` (not stored on the extracted meta).
- **State** — `aiGenerate.emphasis: EmphasisId[]` in the session store (default `[]`), threaded `AIGeneratePage → GenerateWizard → StepFineTune`.
- **UI** — `StepFineTune` renders a 2-column multi-select (Check toggle, `aria-pressed`) between Style and Prompt quality; the list is driven by `EMPHASIS_OPTIONS`, so adding a directive surfaces it in the UI automatically (add the i18n keys).
- **i18n** — en + de label and 5 option label/desc strings.

## Verification

- 6 new prompt unit tests: directive ordering, de-dupe, unknown-id filtering, registry sanity, and the *only-when-selected* fold-in for both résumé and cover letter. `GenerateWizard` test props updated.
- `pnpm lint:strict` 0 · `pnpm typecheck --force` clean · `pnpm test` 891 passing (155 files) · prettier clean.
- No Rust touched. Pre-push full gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
