### PR TITLE
feat: render the real exported pdf as the ai-generate live preview

### DIFF
--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
     ],
     "macOSPrivateApi": false,
     "security": {
-      "csp": "default-src 'self' tauri: asset: https://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: https://asset.localhost; font-src 'self' data: asset: https://asset.localhost; connect-src 'self' http://127.0.0.1:11434 http://127.0.0.1:* ws://127.0.0.1:* tauri: ipc: http://ipc.localhost"
+      "csp": "default-src 'self' tauri: asset: https://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: https://asset.localhost; font-src 'self' data: asset: https://asset.localhost; frame-src 'self' blob:; connect-src 'self' http://127.0.0.1:11434 http://127.0.0.1:* ws://127.0.0.1:* tauri: ipc: http://ipc.localhost"
     }
   },
   "bundle": {

--- a/apps/tauri/src/renderer/components/generation/EditableOutput/EditableOutput.test.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/EditableOutput.test.tsx
@@ -328,3 +328,25 @@ describe('EditableOutput — F4 inline rewrite splice', () => {
     });
   });
 });
+
+describe('EditableOutput — preview surface (#24)', () => {
+  it('renders the prettified-markdown preview by default (no previewSlot)', () => {
+    render(<EditableOutput value="Led **payments** work." onChange={vi.fn()} docType="resume" />);
+    // **markers** render as bold — the markdown fallback is active.
+    expect(screen.getByText('payments').tagName).toBe('STRONG');
+  });
+
+  it('renders a custom previewSlot instead of markdown when provided', () => {
+    render(
+      <EditableOutput
+        value="Led **payments** work."
+        onChange={vi.fn()}
+        docType="resume"
+        previewSlot={<div data-testid="custom-preview">PDF</div>}
+      />
+    );
+    expect(screen.getByTestId('custom-preview')).toBeInTheDocument();
+    // The markdown fallback must NOT also render when a slot is supplied.
+    expect(screen.queryByText('payments')).toBeNull();
+  });
+});

--- a/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
@@ -25,6 +25,13 @@ interface EditableOutputProps {
   className?: string;
   textAreaClassName?: string;
   placeholder?: string;
+  /**
+   * Optional custom Preview surface (#24). When provided, the Preview tab renders
+   * this instead of the prettified-markdown view — e.g. the real-PDF `PdfPreview`.
+   * The caller owns its lifecycle (it reads the same canonical text). Edit mode is
+   * unchanged. Consumers that omit it keep the markdown preview.
+   */
+  previewSlot?: React.ReactNode;
 }
 
 /** The frozen selection range + text snapshot captured when a rewrite starts. */
@@ -63,6 +70,7 @@ export function EditableOutput({
   className,
   textAreaClassName,
   placeholder,
+  previewSlot,
 }: EditableOutputProps) {
   const { t } = useTranslation();
   const selectedModel = useSelectedModel();
@@ -205,6 +213,9 @@ export function EditableOutput({
             )}
           </AnimatePresence>
         </div>
+      ) : previewSlot ? (
+        // #24 — caller-supplied Preview (e.g. the real-PDF view) replaces markdown.
+        <div className="h-full w-full overflow-hidden rounded-lg">{previewSlot}</div>
       ) : (
         <div className="h-full w-full overflow-y-auto rounded-lg">
           {value ? (

--- a/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
@@ -311,6 +311,8 @@ export function AIGeneratePage() {
                 meta={meta}
                 mode={mode}
                 templateId={templateId}
+                atsMode={atsMode}
+                locale={locale}
                 onActiveOutChange={setActiveOut}
                 onCopy={() => void copyOutput()}
                 onExport={doExport}

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
@@ -3,6 +3,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { OutputPanelDone } from './index';
 
+// Stub the real-PDF preview (#24) — it renders the export via IPC, out of scope
+// for this panel's preview/edit wiring test (covered in PdfPreview's own suite).
+vi.mock('../PdfPreview', () => ({
+  PdfPreview: () => <div data-testid="pdf-preview">PDF</div>,
+}));
+
 const RAW = 'Led **payments** migration at scale.';
 
 function renderPanel(overrides: Partial<React.ComponentProps<typeof OutputPanelDone>> = {}) {
@@ -17,6 +23,7 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof OutputPanelD
       meta={null}
       mode="ats"
       templateId="classic"
+      atsMode={false}
       onActiveOutChange={vi.fn()}
       onCopy={onCopy}
       onExport={onExport}
@@ -30,10 +37,10 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof OutputPanelD
 }
 
 describe('OutputPanelDone — preview/edit', () => {
-  it('renders prettified markdown by default, hiding the raw ** emphasis markers', () => {
+  it('shows the real-PDF preview by default (#24), not markdown or a textarea', () => {
     renderPanel();
-    // The **keyword** marker renders as bold, not as literal asterisks.
-    expect(screen.getByText('payments').tagName).toBe('STRONG');
+    // The default Preview tab renders the real-PDF view, not the markdown fallback.
+    expect(screen.getByTestId('pdf-preview')).toBeInTheDocument();
     expect(screen.queryByText(/\*\*payments\*\*/)).toBeNull();
     // No editable textarea while previewing.
     expect(screen.queryByRole('textbox')).toBeNull();

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
@@ -9,12 +9,14 @@ import {
   buildFilename,
   type GenerationMeta,
   MODES,
+  resolveMarket,
   type TemplateId,
   TEMPLATES,
 } from '@/lib/generate';
 import { useTranslation } from '@/lib/i18n';
 
 import { ExportModal } from '../ExportModal';
+import { PdfPreview } from '../PdfPreview';
 
 interface OutputPanelDoneProps {
   resumeOut: string;
@@ -23,6 +25,10 @@ interface OutputPanelDoneProps {
   meta: GenerationMeta | null;
   mode: string;
   templateId: TemplateId;
+  /** ATS single-column override — must match the export so the preview is faithful. */
+  atsMode: boolean;
+  /** Export market/locale — drives the cover-letter preview layout (#24). */
+  locale?: string;
   onActiveOutChange: (out: 'resume' | 'cover') => void;
   onCopy: () => void;
   onExport: (fmt: 'pdf' | 'docx' | 'txt') => Promise<void>;
@@ -41,6 +47,8 @@ export function OutputPanelDone({
   meta,
   mode,
   templateId,
+  atsMode,
+  locale,
   onActiveOutChange,
   onCopy,
   onExport,
@@ -52,6 +60,18 @@ export function OutputPanelDone({
 }: OutputPanelDoneProps) {
   const { t } = useTranslation();
   const [exportOpen, setExportOpen] = useState(false);
+
+  const docType = activeOut === 'resume' ? 'resume' : 'cover-letter';
+  // The cover letter's preview layout follows the resolved market (job country →
+  // language → override), exactly like the real export; résumé keeps the locale.
+  const previewLocale =
+    docType === 'cover-letter'
+      ? resolveMarket({
+          jobCountry: meta?.jobCountry,
+          targetLanguage: meta?.targetLanguage,
+          override: locale,
+        })
+      : locale;
 
   // If the active tab has no content but the other does, switch automatically
   useEffect(() => {
@@ -152,9 +172,21 @@ export function OutputPanelDone({
           value={currentOutput}
           onChange={onOutputChange}
           disabled={isGenerating}
-          docType={activeOut === 'resume' ? 'resume' : 'cover-letter'}
+          docType={docType}
           meta={meta}
           className="flex h-full w-full flex-col overflow-hidden"
+          previewSlot={
+            <PdfPreview
+              text={currentOutput}
+              docType={docType}
+              meta={meta}
+              templateId={templateId}
+              atsMode={atsMode}
+              locale={previewLocale}
+              paused={isGenerating}
+              className="h-full w-full"
+            />
+          }
         />
       </div>
 

--- a/apps/tauri/src/renderer/features/ai-generate/components/PdfPreview/PdfPreview.test.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/PdfPreview/PdfPreview.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+
+import type * as Generate from '@/lib/generate';
+
+import { PdfPreview } from './index';
+
+// Control the real-PDF render (the only side-effect) and keep the rest of the
+// generate barrel intact (types, etc.).
+const mockRender = vi.fn();
+vi.mock('@/lib/generate', async (importOriginal) => {
+  const actual = await importOriginal<typeof Generate>();
+  return { ...actual, renderPdfPreview: (...args: unknown[]) => mockRender(...args) };
+});
+
+vi.mock('@/lib/i18n', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const PROPS = { docType: 'resume' as const, templateId: 'classic' as const };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockRender.mockReset();
+  // jsdom does not implement these — provide spies the component can call.
+  URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('PdfPreview (#24)', () => {
+  it('renders the real PDF in an iframe after the debounce settles', async () => {
+    mockRender.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    render(<PdfPreview text="A real resume body" {...PROPS} />);
+
+    // Before the debounce elapses nothing is rendered yet.
+    expect(mockRender).not.toHaveBeenCalled();
+    expect(screen.queryByTitle('aiGenerate.pdfPreview.title')).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(mockRender).toHaveBeenCalledTimes(1);
+    const iframe = screen.getByTitle('aiGenerate.pdfPreview.title');
+    expect(iframe).toHaveAttribute('src', 'blob:mock-url');
+  });
+
+  it('does not render while paused (still generating)', async () => {
+    render(<PdfPreview text="A real resume body" paused {...PROPS} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    expect(mockRender).not.toHaveBeenCalled();
+    expect(screen.getByText('aiGenerate.pdfPreview.empty')).toBeInTheDocument();
+  });
+
+  it('does not render for empty/whitespace text', async () => {
+    render(<PdfPreview text="   " {...PROPS} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('shows an error state when the render fails', async () => {
+    mockRender.mockRejectedValue(new Error('render boom'));
+    render(<PdfPreview text="A real resume body" {...PROPS} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    expect(screen.getByText('aiGenerate.pdfPreview.failed')).toBeInTheDocument();
+    expect(screen.queryByTitle('aiGenerate.pdfPreview.title')).toBeNull();
+  });
+
+  it('debounces rapid edits into a single render of the latest text', async () => {
+    mockRender.mockResolvedValue(new Uint8Array([1]));
+    const { rerender } = render(<PdfPreview text="v1" {...PROPS} />);
+    rerender(<PdfPreview text="v2" {...PROPS} />);
+    rerender(<PdfPreview text="v3" {...PROPS} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(mockRender).toHaveBeenCalledTimes(1);
+    expect(mockRender).toHaveBeenCalledWith('v3', 'resume', undefined, 'classic', false, undefined);
+  });
+});

--- a/apps/tauri/src/renderer/features/ai-generate/components/PdfPreview/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/PdfPreview/index.tsx
@@ -1,0 +1,143 @@
+import { FileWarning, Loader2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { cn } from '@ajh/ui';
+
+import { type GenerationMeta, renderPdfPreview, type TemplateId } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+
+interface PdfPreviewProps {
+  /** Canonical document text (the same raw string copy/export read). */
+  text: string;
+  docType: 'resume' | 'cover-letter';
+  meta?: GenerationMeta | null;
+  templateId: TemplateId;
+  atsMode?: boolean;
+  /** Export market/locale (resolved by the caller, mirroring the real export). */
+  locale?: string;
+  /** Skip rendering — e.g. while the document is still generating. */
+  paused?: boolean;
+  className?: string;
+}
+
+/** How long after the last edit to re-render the real PDF (#24). */
+const DEBOUNCE_MS = 500;
+
+type Status = 'idle' | 'rendering' | 'ready' | 'error';
+
+/**
+ * Live preview that renders the **real exported PDF** (not an approximation):
+ * it calls the same Rust renderer the export uses (`renderPdfPreview`), wraps the
+ * returned bytes in a `blob:` URL, and shows them in an `<iframe>` (the webview's
+ * native PDF viewer). Re-renders ~{@link DEBOUNCE_MS}ms after edits settle, so
+ * typing stays instant while the preview catches up. The last good PDF stays on
+ * screen during a re-render (overlay spinner) and after a transient failure.
+ *
+ * This is the authoritative output before download — see ADR-012. The `blob:`
+ * frame source requires `frame-src blob:` in the CSP (tauri.conf.json).
+ */
+export function PdfPreview({
+  text,
+  docType,
+  meta,
+  templateId,
+  atsMode = false,
+  locale,
+  paused = false,
+  className,
+}: PdfPreviewProps) {
+  const { t } = useTranslation();
+  const [url, setUrl] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>('idle');
+  // Monotonic token so a slow render that resolves after a newer edit is ignored.
+  const renderToken = useRef(0);
+  const urlRef = useRef<string | null>(null);
+
+  // Revoke the last object URL on unmount.
+  useEffect(
+    () => () => {
+      if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (paused || !text.trim()) {
+      setStatus('idle');
+      return;
+    }
+    const token = ++renderToken.current;
+    setStatus('rendering');
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const bytes = await renderPdfPreview(
+            text,
+            docType,
+            meta ?? undefined,
+            templateId,
+            atsMode,
+            locale
+          );
+          if (token !== renderToken.current) return; // superseded by a newer edit
+          // Swap the blob only when the new one is ready, revoking the previous.
+          const next = URL.createObjectURL(new Blob([bytes], { type: 'application/pdf' }));
+          if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+          urlRef.current = next;
+          setUrl(next);
+          setStatus('ready');
+        } catch {
+          if (token !== renderToken.current) return;
+          setStatus('error');
+        }
+      })();
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [text, docType, meta, templateId, atsMode, locale, paused]);
+
+  return (
+    <div
+      className={cn(
+        'relative h-full w-full overflow-hidden rounded-lg border border-white/[0.06] bg-white/[0.02]',
+        className
+      )}
+    >
+      {url ? (
+        <iframe
+          src={url}
+          title={t('aiGenerate.pdfPreview.title')}
+          className="h-full w-full border-0 bg-white"
+        />
+      ) : status === 'error' ? (
+        <div className="flex h-full flex-col items-center justify-center gap-2 text-foreground/40">
+          <FileWarning size={20} />
+          <p className="text-[12px]">{t('aiGenerate.pdfPreview.failed')}</p>
+        </div>
+      ) : status === 'rendering' ? (
+        <div className="flex h-full flex-col items-center justify-center gap-2 text-foreground/40">
+          <Loader2 size={18} className="animate-spin text-brand-soft" />
+          <p className="text-[12px]">{t('aiGenerate.pdfPreview.rendering')}</p>
+        </div>
+      ) : (
+        <div className="flex h-full items-center justify-center text-[12px] text-foreground/25">
+          {t('aiGenerate.pdfPreview.empty')}
+        </div>
+      )}
+
+      {/* Keep the last good PDF visible during a re-render / after a transient
+          failure, with a corner indicator instead of blanking the pane. */}
+      {url && status === 'rendering' && (
+        <div className="absolute right-2 top-2 flex items-center gap-1.5 rounded-lg bg-black/55 px-2 py-1 text-[10px] text-white/85 backdrop-blur-sm">
+          <Loader2 size={10} className="animate-spin" />
+          {t('aiGenerate.pdfPreview.rendering')}
+        </div>
+      )}
+      {url && status === 'error' && (
+        <div className="absolute right-2 top-2 flex items-center gap-1.5 rounded-lg bg-red-500/70 px-2 py-1 text-[10px] text-white/90 backdrop-blur-sm">
+          <FileWarning size={10} />
+          {t('aiGenerate.pdfPreview.failed')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -570,6 +570,12 @@
     "edit": "Bearbeiten",
     "viewMode": "Ansichtsmodus",
     "placeholder": "Generierte Ausgabe erscheint hier…",
+    "pdfPreview": {
+      "title": "Dokumentvorschau",
+      "rendering": "Wird gerendert…",
+      "failed": "Vorschau nicht verfügbar",
+      "empty": "Generieren Sie ein Dokument, um es hier in der Vorschau zu sehen."
+    },
     "rewrite": {
       "trigger": "Mit KI umschreiben",
       "title": "Auswahl umschreiben",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -585,6 +585,12 @@
     "edit": "Edit",
     "viewMode": "View mode",
     "placeholder": "Generated output will appear here…",
+    "pdfPreview": {
+      "title": "Document preview",
+      "rendering": "Rendering…",
+      "failed": "Preview unavailable",
+      "empty": "Generate a document to preview it here."
+    },
     "rewrite": {
       "trigger": "Rewrite with AI",
       "title": "Rewrite selection",

--- a/apps/tauri/src/renderer/lib/generate/export/export.test.ts
+++ b/apps/tauri/src/renderer/lib/generate/export/export.test.ts
@@ -4,7 +4,7 @@ import type { GenerationMeta } from '@ajh/prompts/generate';
 
 import { _registerClient } from '../../app-client';
 import { createMockClient } from '../../mock-client';
-import { buildFilename, exportDOCX, exportPDF, exportTXT } from './export';
+import { buildFilename, exportDOCX, exportPDF, exportTXT, renderPdfPreview } from './export';
 
 const meta: GenerationMeta = {
   resumeLanguage: 'en',
@@ -90,5 +90,41 @@ describe('exportDOCX / exportPDF', () => {
   it('throws on empty content', async () => {
     _registerClient(createMockClient());
     await expect(exportDOCX('', 'out.docx')).rejects.toThrow(/empty document/);
+  });
+});
+
+describe('renderPdfPreview (#24)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('renders via exportDocument (no save) and returns the PDF bytes', async () => {
+    const exportDocument = vi
+      .fn()
+      .mockResolvedValue({ data: [1, 2, 3], mimeType: 'application/pdf' });
+    _registerClient(createMockClient({ documents: { exportDocument } }));
+
+    const bytes = await renderPdfPreview('Resume body', 'resume', meta, 'modern');
+    expect(exportDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ format: 'pdf', documentType: 'resume', templateId: 'modern' })
+    );
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+  });
+
+  it('extracts the cover-letter section before rendering', async () => {
+    const exportDocument = vi.fn().mockResolvedValue({ data: [], mimeType: 'application/pdf' });
+    _registerClient(createMockClient({ documents: { exportDocument } }));
+
+    const raw = 'Resume context\n### COMPLETE COVER LETTER ###\nDear Hiring Team, ...';
+    await renderPdfPreview(raw, 'cover-letter', meta, 'classic');
+    const arg = exportDocument.mock.calls[0]?.[0] as { text: string };
+    expect(arg.text.startsWith('Dear Hiring Team')).toBe(true);
+  });
+
+  it('throws on empty text and on an unknown template', async () => {
+    _registerClient(createMockClient());
+    await expect(renderPdfPreview('   ', 'resume', meta, 'modern')).rejects.toThrow(/empty/);
+    await expect(renderPdfPreview('Body', 'resume', meta, 'nope' as never)).rejects.toThrow(
+      /Unknown export template/
+    );
   });
 });

--- a/apps/tauri/src/renderer/lib/generate/export/export.ts
+++ b/apps/tauri/src/renderer/lib/generate/export/export.ts
@@ -175,6 +175,61 @@ export async function exportPDF(
   }
 }
 
+/** Raw export result over IPC: `Vec<u8>` serializes to a number[] (camelCase). */
+interface ExportPreviewResult {
+  data: number[];
+  mimeType: string;
+}
+
+/**
+ * Render the document to its real PDF bytes WITHOUT saving (#24) — the same Rust
+ * renderer the export uses (`documents.exportDocument`), so the in-app preview is
+ * the authoritative output, not an approximation (see ADR-012). Returns the PDF
+ * bytes for the caller to wrap in a `blob:` URL. Throws on empty text, unknown
+ * template, or a backend validation block, exactly like {@link exportPDF}.
+ */
+export async function renderPdfPreview(
+  text: string,
+  type: 'resume' | 'cover-letter' = 'resume',
+  meta?: GenerationMeta,
+  templateId: TemplateId = 'modern',
+  atsMode = false,
+  locale?: string
+  // ArrayBuffer-backed (not the default `Uint8Array<ArrayBufferLike>`) so the
+  // bytes are a valid `BlobPart` at the call site under TS's strict DOM lib.
+): Promise<Uint8Array<ArrayBuffer>> {
+  if (!text || text.trim().length === 0) {
+    throw new Error('Cannot preview an empty document.');
+  }
+  if (!TEMPLATES[templateId]) {
+    throw new Error(`Unknown export template: "${templateId}".`);
+  }
+
+  const api = getClient();
+  const exportText = type === 'cover-letter' ? extractCoverLetterText(text) : text;
+  // Same header source of truth as the real export (see exportPDF/exportDOCX).
+  const contact = await api.contactProfile.get().catch(() => undefined);
+  const result = (await api.documents.exportDocument({
+    text: exportText,
+    format: 'pdf',
+    documentType: type,
+    templateId,
+    atsMode,
+    locale,
+    contact,
+    meta: meta
+      ? {
+          candidateName: meta.candidateName,
+          jobTitle: meta.jobTitle,
+          companyName: meta.companyName,
+          targetLanguage: meta.targetLanguage,
+        }
+      : undefined,
+  })) as ExportPreviewResult;
+
+  return new Uint8Array(result.data);
+}
+
 export function exportTXT(text: string, filename: string): void {
   try {
     // Validation

--- a/apps/tauri/src/renderer/lib/generate/index.ts
+++ b/apps/tauri/src/renderer/lib/generate/index.ts
@@ -1,4 +1,4 @@
-export { buildFilename, exportDOCX, exportPDF, exportTXT } from './export';
+export { buildFilename, exportDOCX, exportPDF, exportTXT, renderPdfPreview } from './export';
 export {
   extractMetadata,
   generateApplicationAnswer,

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -43,7 +43,7 @@ Read the minimum; **stop at ~90% confidence**.
 | [ADR-009](decision-records/adr-009-resettable-reset-registry.md)             | Full factory reset via a `Resettable` registry                              |
 | [ADR-010](decision-records/adr-010-untrusted-input-fencing.md)               | Untrusted-input fencing for web-sourced company research                    |
 | [ADR-011](decision-records/adr-011-referral-helper-manual-only.md)           | Referral helper is manual-only; no LinkedIn profile scraping                |
-| [ADR-012](decision-records/adr-012-html-preview-approximate.md)              | AI-Generate live preview is an approximate HTML mirror                      |
+| [ADR-012](decision-records/adr-012-html-preview-approximate.md)              | AI-Generate live preview renders the real exported PDF                      |
 
 ## Canonical docs (do not duplicate — link)
 

--- a/docs/knowledge/decision-records/adr-012-html-preview-approximate.md
+++ b/docs/knowledge/decision-records/adr-012-html-preview-approximate.md
@@ -1,8 +1,8 @@
-# ADR-012: AI-Generate live preview is an approximate HTML mirror; PDF/DOCX remain the source of truth
+# ADR-012: AI-Generate live preview renders the real exported PDF; templates stay single-source
 
 Last updated: 2026-06-09
 
-**Status:** Accepted
+**Status:** Accepted (revised during implementation)
 
 ## Context
 
@@ -13,37 +13,46 @@ shows the generated résumé/cover letter as prettified markdown text (`OutputPa
 UX item #24 asks the preview to render the real template and let the user edit in that
 template. The 9 templates render in Rust: PDF via printpdf and DOCX via the model_docx
 backend. ADR-002 (dual PDF/DOCX backends, golden parity) keeps those two outputs
-byte-for-byte aligned via golden snapshots. There is no HTML render path today.
+byte-for-byte aligned via golden snapshots.
 
-A live, edit-as-you-type preview requires a render path that updates instantly in the
-renderer process.
+During implementation we discovered that the Rust export command `documents_export_document`
+(exposed in the renderer as `documents.exportDocument`) already returns the rendered PDF
+bytes (`ExportResult { data: Uint8Array, mimeType, ... }`) without saving to disk. This
+makes a **real-PDF live preview cheap and perfectly faithful** — zero drift, because it
+IS the export pipeline.
 
 ## Decision
 
-Build a live HTML/CSS **mirror** of the templates for the in-app editing preview.
+The AI-Generate live preview renders the **real exported PDF** from the Rust renderer
+(the same pipeline as the final export), re-rendering ~500ms after edits settle
+(debounced). The raw textarea remains the edit surface; the preview pane shows a
+`<iframe>` with the live PDF.
 
-The HTML mirror is explicitly **approximate** — a preview aid for the editing flow only.
-The Rust PDF/DOCX renderers remain the **single source of truth** for exported
-documents; ADR-002 parity is untouched.
+**This supersedes the original ADR-012 decision** (approximate HTML/CSS mirror). Reasoning:
 
-The user keeps a way to see the **real exported PDF** before download (the authoritative
-output).
+- The real-PDF preview is perfectly faithful (zero drift — it IS the export).
+- No second render path or duplicated template specs.
+- Far less code than a 9-template HTML mirror + a text→sections parser.
+- ADR-002 (dual PDF/DOCX parity) is untouched; the preview reuses the existing renderer.
 
-This is a deliberately accepted **third render path**, chosen for editing UX. It is NOT a
-replacement of the export pipeline.
+**Rejected alternative (original):** Build an approximate HTML/CSS mirror of the 9 templates.
+Rejected during implementation because the real-PDF approach is cheaper, more faithful,
+and eliminates the drift risk entirely.
 
-**Rejected alternative:** Make HTML the source of truth and generate PDF/DOCX from it
-(HTML→PDF), retiring the Rust renderers. Rejected as a massive export-pipeline rewrite
-that would reject ADR-002 and its golden-parity guarantees.
+**Rejected alternative (long-term escape hatch):** Make HTML the source of truth and
+generate PDF/DOCX from it (HTML→PDF). Out of scope; ADR-002 golden-parity guarantees
+are unchanged.
 
 ## Consequences
 
-- A third render path to maintain → genuine drift risk between the HTML preview and the
-  actual PDF/DOCX export. Mitigated by (a) labelling the preview approximate and
-  (b) keeping the real-PDF view available before download.
-- Template visual specs now live in two places (the Rust renderer and the HTML mirror);
-  template changes must update both, or accept that the preview diverges from the export.
-- Export renderers (printpdf / model_docx) are unchanged; no impact on existing golden
-  snapshots or ADR-002.
-- Revisit if drift becomes a recurring user-facing problem — a future move to an
-  HTML-source-of-truth pipeline (HTML→PDF) is the escape hatch, but is out of scope here.
+- The live preview is the **actual export output**, debounced per keystroke. Cost:
+  each refresh is a Rust round-trip (acceptable for a preview; not per-keystroke).
+- No HTML render path to maintain → zero drift between preview and export.
+  Template changes update the Rust renderer once; the preview automatically reflects them.
+- **CSP allowance:** `frame-src 'self' blob:` added to `apps/tauri/src-tauri/tauri.conf.json`
+  so the PDF `blob:` URL can load in an `<iframe>`. Blob URLs are same-origin and app-generated
+  (low risk); `tauri-security-reviewer` owns the CSP surface.
+- Export renderers (printpdf / model_docx) are unchanged; ADR-002 golden snapshots untouched.
+- Implementation pointers: `renderPdfPreview()` in `apps/tauri/src/renderer/lib/generate/export/export.ts`;
+  `PdfPreview` component in `apps/tauri/src/renderer/features/ai-generate/components/PdfPreview/`;
+  `EditableOutput` gained optional `previewSlot`; `OutputPanelDone` supplies it.


### PR DESCRIPTION
## What

**#24 — the AI-Generate live preview now renders the REAL exported PDF** (not prettified markdown), updating live as you edit. Renderer + one CSP line + an ADR revision — **no Rust code**.

### The decision changed during implementation (ADR-012 revised)

#24 was planned as an approximate HTML/CSS mirror of the 9 templates (ADR-012). While implementing, I found the Rust command `documents_export_document` (wired as `documents.exportDocument`) **already returns the rendered PDF bytes without saving**. That makes an in-app **real-PDF preview** cheap *and* perfectly faithful (zero drift), so — after grilling the trade-off with the maintainer — we ship that instead. The HTML mirror is now the rejected alternative (it would have duplicated 9 template specs in a second render path). **ADR-002 golden parity is untouched** — the preview reuses the existing renderer; no new render path. ADR-012 was revised by project-steward to record the change.

### How it works

- **`renderPdfPreview()`** (`lib/generate/export/export.ts`) — calls `exportDocument` (no save) and returns the PDF bytes (`Uint8Array`), reusing the same request-building (cover-letter extraction, contact-profile header) as the real export.
- **`PdfPreview`** component — debounces ~500ms after edits, wraps the bytes in a `blob:` URL, and shows them in an `<iframe>` (the webview's native PDF viewer). Keeps the last good PDF on screen during a re-render (corner spinner) and after a transient failure; a monotonic token discards superseded renders; object URLs are revoked on swap/unmount; loading/error/empty states.
- **`EditableOutput`** gains an optional `previewSlot` — the Preview tab renders it instead of the markdown view. The markdown preview stays the default for every other consumer; the **edit surface is unchanged** (raw textarea + F4 rewrite).
- **`OutputPanelDone`** supplies the `PdfPreview` slot (new `atsMode`/`locale` props; cover-letter preview locale resolved via `resolveMarket`, mirroring export); `AIGeneratePage` passes them.

### Security

Adds **`frame-src 'self' blob:`** to the CSP in `apps/tauri/src-tauri/tauri.conf.json` so the `blob:` PDF can load in the `<iframe>`. `blob:` is same-origin, app-generated bytes (the document we just rendered) — it cannot load remote content. Flagging for `tauri-security-reviewer` as the CSP owner.

## Verification

- 10 new tests: `PdfPreview` (debounce, paused, empty, error, latest-edit-wins), `EditableOutput` (slot vs markdown fallback), `renderPdfPreview` (request shape, cover extraction, guards).
- `pnpm lint:strict` 0 · real `tsc --noEmit` clean · `pnpm test` 901 passing (156 files) · prettier clean.
- No Rust code changed (CSP config only). Pre-push full gate (incl. cargo) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
