### PR TITLE
fix: loosen cover-letter paragraph spacing and tune resume rhythm

### DIFF
--- a/apps/tauri/src-tauri/src/export/typst_engine/templates/_scale.typ
+++ b/apps/tauri/src-tauri/src/export/typst_engine/templates/_scale.typ
@@ -6,18 +6,25 @@
 // only, never inside individual template files.
 //
 // Main-column constants
-#let lead             = 0.72em   // paragraph line-spacing (leading)
-#let sp-para          = 0.95em   // space between paragraphs / summary lines
-#let sp-section-above = 17pt     // space above a section heading
+// Rhythm principle (#25): more air BETWEEN groups (sections, entries), slightly
+// tighter WITHIN a group (bullets) — stronger visual hierarchy / scannability.
+#let lead             = 0.78em   // paragraph line-spacing (leading)
+#let sp-para          = 1.0em    // space between paragraphs / summary lines
+#let sp-section-above = 20pt     // space above a section heading
 #let sp-rule-below    = 4pt      // space between heading text and the rule
-#let sp-after-rule    = 7pt      // space after the rule before first block
-#let sp-entry         = 12pt     // space below each entry block
+#let sp-after-rule    = 8pt      // space after the rule before first block
+#let sp-entry         = 15pt     // space below each entry block
 #let sp-bullet-above  = 7pt      // space above the bullet list inside an entry
-#let sp-bullet-gap    = 6pt      // space BETWEEN bullet items within an entry
+#let sp-bullet-gap    = 5pt      // space BETWEEN bullet items within an entry
 #let sp-subtitle-gap  = 1pt      // space above subtitle row
 #let sp-subtitle-below = 2pt     // space below subtitle row
-#let sp-header-contact = 12pt    // space below contact line before first section
+#let sp-header-contact = 14pt    // space below contact line before first section
 #let sp-name-below    = 9pt      // space below candidate name block (before contact)
+
+// Cover-letter paragraph spacing (#26) — letters read better with a clearer gap
+// between paragraphs than résumé summary lines, so the letter uses its own
+// constant instead of reusing sp-para. Used only by letter.typ.
+#let sp-letter-para   = 1.4em    // space between cover-letter body paragraphs
 
 // Sidebar-specific constants (used by Atelier and any future two-column template)
 #let sp-sb-section-above = 17pt  // space above a sidebar section heading

--- a/apps/tauri/src-tauri/src/export/typst_engine/templates/letter.typ
+++ b/apps/tauri/src-tauri/src/export/typst_engine/templates/letter.typ
@@ -67,7 +67,7 @@
   lang: lang,
 )
 
-#set par(leading: lead, spacing: sp-para, justify: true)
+#set par(leading: lead, spacing: sp-letter-para, justify: true)
 
 // ── Rich-text renderer ────────────────────────────────────────────────────────
 // Mirrors the single_column.typ render-runs helper exactly so font rendering
@@ -215,7 +215,7 @@
 
 #if "body" in data {
   for para in data.body {
-    block(above: 0pt, below: sp-para, breakable: true,
+    block(above: 0pt, below: sp-letter-para, breakable: true,
       render-runs(para)
     )
   }


### PR DESCRIPTION
## What

**B6 — export/PDF polish: #26 cover-letter paragraph spacing + #25 résumé vertical-rhythm tune.** Two Typst template assets only (no Rust code, no TS).

> Note: PDF rendering is **Typst** for both résumé and cover letter (`export/typst_engine/templates/*.typ`) — the spacing constants live in the shared `_scale.typ`, prepended to every template, so changes apply uniformly.

### #26 — cover-letter paragraph spacing

The cover letter reused the résumé's `sp-para` (0.95em) for gaps between body paragraphs — cramped for a letter. It now has its **own** `sp-letter-para` constant set to **1.4em**, so paragraphs read like a real business letter. Résumé spacing is untouched.

### #25 — global rhythm tune (user-approved)

Stronger visual hierarchy across all 9 templates — more air **between** groups, slightly tighter **within** — centralised in `_scale.typ`:

| constant | before | after |
| --- | --- | --- |
| `lead` (line leading) | 0.72em | 0.78em |
| `sp-para` | 0.95em | 1.0em |
| `sp-section-above` | 17pt | 20pt |
| `sp-after-rule` | 7pt | 8pt |
| `sp-entry` (between roles) | 12pt | 15pt |
| `sp-bullet-gap` (within entry) | 6pt | 5pt |
| `sp-header-contact` | 12pt | 14pt |

## Verification

- Typst render tests pass: **typst_engine 93 · pdf 23 · templates 15** (1 ignored). Assertions are content + page-count (`>=`) based — no pixel goldens — so the spacing shift is safe; the multi-page fixtures still force ≥2 pages.
- No `.rs`/`.ts` changed (Typst assets only). Pre-push full gate (cargo check/test/clippy/fmt + pnpm) passed.

Best viewed live via the new #24 PDF preview — open any generated résumé/cover letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
