### PR TITLE
feat: restructure analyzer results into a summary-first grouped view

### DIFF
--- a/apps/tauri/src/renderer/features/analyze/components/AnalysisResults/AnalysisResults.test.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalysisResults/AnalysisResults.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import type { AnalysisResult } from '@/lib/resume-ai';
+
+import { AnalysisResults } from './index';
+
+const t = (k: string) => k;
+
+function makeResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    detectedLanguages: { resume: 'en', jobAd: 'en', mismatch: false },
+    scores: { ats: 80, jobMatch: 75, languageAlignment: 90, readability: 70, keywordCoverage: 65 },
+    summary: {
+      strengths: ['Strong React experience'],
+      weaknesses: [],
+      overallAssessment: 'Solid.',
+    },
+    missingKeywords: [],
+    matchedSkills: ['React'],
+    missingSkills: ['Docker'],
+    recommendations: [{ priority: 'high', text: 'Add Terraform to skills', category: 'skill' }],
+    sectionAnalysis: {
+      summary: { score: 80, feedback: 'ok' },
+      experience: { score: 75, feedback: 'ok' },
+      skills: { score: 70, feedback: 'ok' },
+      education: { score: 85, feedback: 'ok' },
+      formatting: { score: 90, feedback: 'ok' },
+    },
+    rewrites: [],
+    languageRecommendations: [],
+    atsRisks: [],
+    recruiterPerspective: 'Would shortlist.',
+    finalVerdict: 'Good fit for this role',
+    ...overrides,
+  };
+}
+
+describe('AnalysisResults (#8/#9)', () => {
+  it('leads with the verdict summary, always visible (not behind an accordion)', () => {
+    render(<AnalysisResults result={makeResult()} t={t} />);
+    expect(screen.getByText('Good fit for this role')).toBeInTheDocument();
+  });
+
+  it('opens the strengths & skills group by default, revealing its content', () => {
+    render(<AnalysisResults result={makeResult()} t={t} />);
+    expect(screen.getByText('analyze.groups.strengthsSkills')).toBeInTheDocument();
+    // defaultOpen → the strength text is in the DOM without interaction.
+    expect(screen.getByText('Strong React experience')).toBeInTheDocument();
+  });
+
+  it('keeps non-default groups collapsed (content not rendered until expanded)', () => {
+    render(<AnalysisResults result={makeResult()} t={t} />);
+    // The recommendations group header shows, but its body is collapsed.
+    expect(screen.getByText('analyze.groups.recommendations')).toBeInTheDocument();
+    expect(screen.queryByText('Add Terraform to skills')).toBeNull();
+  });
+
+  it('omits a group entirely when it has no content', () => {
+    // No language mismatch and no language recommendations → no language group.
+    render(<AnalysisResults result={makeResult()} t={t} />);
+    expect(screen.queryByText('analyze.groups.language')).toBeNull();
+  });
+
+  it('shows the language group when there is a mismatch', () => {
+    render(
+      <AnalysisResults
+        result={makeResult({
+          detectedLanguages: { resume: 'en', jobAd: 'de', mismatch: true },
+          languageRecommendations: ['Translate to German'],
+        })}
+        t={t}
+      />
+    );
+    expect(screen.getByText('analyze.groups.language')).toBeInTheDocument();
+  });
+});

--- a/apps/tauri/src/renderer/features/analyze/components/AnalysisResults/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalysisResults/index.tsx
@@ -1,0 +1,95 @@
+import { Accordion } from '@ajh/ui';
+
+import { AnalysisATSRisks } from '@/features/analyze/components/AnalysisATSRisks';
+import { AnalysisLanguageMismatch } from '@/features/analyze/components/AnalysisLanguageMismatch';
+import { AnalysisLanguageRecommendations } from '@/features/analyze/components/AnalysisLanguageRecommendations';
+import { AnalysisMissingSkills } from '@/features/analyze/components/AnalysisMissingSkills';
+import { AnalysisRecommendations } from '@/features/analyze/components/AnalysisRecommendations';
+import { AnalysisRewrites } from '@/features/analyze/components/AnalysisRewrites';
+import { AnalysisScores } from '@/features/analyze/components/AnalysisScores';
+import { AnalysisSectionAnalysis } from '@/features/analyze/components/AnalysisSectionAnalysis';
+import { AnalysisSkills } from '@/features/analyze/components/AnalysisSkills';
+import { AnalysisStrengths } from '@/features/analyze/components/AnalysisStrengths';
+import { AnalysisVerdict } from '@/features/analyze/components/AnalysisVerdict';
+import type { AnalysisResult } from '@/lib/resume-ai';
+
+interface AnalysisResultsProps {
+  result: AnalysisResult;
+  t: (key: string) => string;
+}
+
+/**
+ * Summary-first, categorized analysis view (#8/#9). The headline verdict + score
+ * dimensions stay always-visible at the top (with a language-mismatch banner when
+ * present); the detail — previously an 11-card text-bomb stacked vertically — is
+ * grouped into collapsible sections so the page leads with the takeaway and the
+ * rest is progressive disclosure. Each group renders only when it has content;
+ * the first (strengths & skills) is open by default.
+ */
+export function AnalysisResults({ result, t }: AnalysisResultsProps) {
+  const hasStrengthsSkills =
+    result.summary.strengths.length > 0 ||
+    result.summary.weaknesses.length > 0 ||
+    result.matchedSkills.length > 0 ||
+    result.missingSkills.length > 0;
+  const hasRecommendations = result.recommendations.length > 0 || result.rewrites.length > 0;
+  const hasAts = result.atsRisks.length > 0 || result.sectionAnalysis != null;
+  const hasLanguage =
+    result.detectedLanguages.mismatch || result.languageRecommendations.length > 0;
+
+  return (
+    <>
+      {/* Summary first (#9) — banner (self-hides), headline verdict, then scores. */}
+      <AnalysisLanguageMismatch result={result} t={t} />
+      <AnalysisVerdict result={result} t={t} />
+      <AnalysisScores result={result} t={t} />
+
+      {/* Grouped detail (#8) — progressive disclosure, first group open. */}
+      {hasStrengthsSkills && (
+        <Accordion
+          title={t('analyze.groups.strengthsSkills')}
+          defaultOpen
+          content={
+            <div className="space-y-4">
+              <AnalysisStrengths result={result} t={t} />
+              <AnalysisSkills result={result} t={t} />
+              <AnalysisMissingSkills result={result} />
+            </div>
+          }
+        />
+      )}
+      {hasRecommendations && (
+        <Accordion
+          title={t('analyze.groups.recommendations')}
+          content={
+            <div className="space-y-4">
+              <AnalysisRecommendations result={result} t={t} />
+              <AnalysisRewrites result={result} />
+            </div>
+          }
+        />
+      )}
+      {hasAts && (
+        <Accordion
+          title={t('analyze.groups.ats')}
+          content={
+            <div className="space-y-4">
+              <AnalysisATSRisks result={result} t={t} />
+              <AnalysisSectionAnalysis result={result} t={t} />
+            </div>
+          }
+        />
+      )}
+      {hasLanguage && (
+        <Accordion
+          title={t('analyze.groups.language')}
+          content={
+            <div className="space-y-4">
+              <AnalysisLanguageRecommendations result={result} t={t} />
+            </div>
+          }
+        />
+      )}
+    </>
+  );
+}

--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
@@ -7,25 +7,14 @@ import { ErrorState } from '@ajh/ui';
 
 import { PageTransition } from '@/components/layout/PageTransition';
 import { useCanUseAI, useSelectedModel, useSelectedProvider } from '@/components/ui/ModelSelector';
-import { AnalysisATSRisks } from '@/features/analyze/components/AnalysisATSRisks';
-import { AnalysisLanguageMismatch } from '@/features/analyze/components/AnalysisLanguageMismatch';
-import { AnalysisLanguageRecommendations } from '@/features/analyze/components/AnalysisLanguageRecommendations';
-import { AnalysisMissingSkills } from '@/features/analyze/components/AnalysisMissingSkills';
 import { AnalysisProgress } from '@/features/analyze/components/AnalysisProgress';
-import { AnalysisRecommendations } from '@/features/analyze/components/AnalysisRecommendations';
-import { AnalysisRewrites } from '@/features/analyze/components/AnalysisRewrites';
-import { AnalysisScores } from '@/features/analyze/components/AnalysisScores';
-import { AnalysisSectionAnalysis } from '@/features/analyze/components/AnalysisSectionAnalysis';
-import { AnalysisSkills } from '@/features/analyze/components/AnalysisSkills';
-import { AnalysisStrengths } from '@/features/analyze/components/AnalysisStrengths';
-import { AnalysisVerdict } from '@/features/analyze/components/AnalysisVerdict';
+import { AnalysisResults } from '@/features/analyze/components/AnalysisResults';
 import { AnalyzeLeftPanel } from '@/features/analyze/components/AnalyzeLeftPanel';
 import { ACCEPTED_EXTS, MAX_BYTES } from '@/features/analyze/constants';
 import { useAnalysisRun } from '@/features/analyze/hooks/useAnalysisRun';
 import { useAnalyzeState } from '@/features/analyze/hooks/useAnalyzeState';
 import { PROVIDERS } from '@/lib/ai-providers/provider-meta';
 import { useTranslation } from '@/lib/i18n';
-import type { AnalysisResult } from '@/lib/resume-ai';
 import { useDocuments, useExtractText } from '@/services';
 import type { AiProvider } from '@/store/preferences-schema';
 import { usePreferencesStore, usePromptQuality } from '@/store/preferences-store';
@@ -222,24 +211,6 @@ function AnalyzePage() {
         </div>
       </div>
     </PageTransition>
-  );
-}
-
-function AnalysisResults({ result, t }: { result: AnalysisResult; t: (key: string) => string }) {
-  return (
-    <>
-      <AnalysisLanguageMismatch result={result} t={t} />
-      <AnalysisScores result={result} t={t} />
-      <AnalysisVerdict result={result} t={t} />
-      <AnalysisStrengths result={result} t={t} />
-      <AnalysisSkills result={result} t={t} />
-      <AnalysisRecommendations result={result} t={t} />
-      <AnalysisATSRisks result={result} t={t} />
-      <AnalysisSectionAnalysis result={result} t={t} />
-      <AnalysisRewrites result={result} />
-      <AnalysisLanguageRecommendations result={result} t={t} />
-      <AnalysisMissingSkills result={result} />
-    </>
   );
 }
 

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -112,6 +112,12 @@
     },
     "verdict": "Endurteil",
     "recruiterView": "Sichtweise des Personalers —",
+    "groups": {
+      "strengthsSkills": "Stärken & Fähigkeiten",
+      "recommendations": "Empfehlungen & Umformulierungen",
+      "ats": "ATS & Formatierung",
+      "language": "Sprache & Lokalisierung"
+    },
     "strengths": "Stärken",
     "noStrengths": "Keine bemerkenswerten Stärken identifiziert.",
     "weaknesses": "Schwächen",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -112,6 +112,12 @@
     },
     "verdict": "Final Verdict",
     "recruiterView": "Recruiter's view —",
+    "groups": {
+      "strengthsSkills": "Strengths & skills",
+      "recommendations": "Recommendations & rewrites",
+      "ats": "ATS & formatting",
+      "language": "Language & localization"
+    },
     "strengths": "Strengths",
     "noStrengths": "No notable strengths identified.",
     "weaknesses": "Weaknesses",


### PR DESCRIPTION
## What

**B5a — Resume Analyzer IA restructure (#8 + #9).** Frontend only. The analysis result was an 11-card text-bomb stacked vertically; now it leads with the takeaway and the detail is progressive disclosure.

- **Summary first (#9)** — always visible at the top: a self-hiding language-mismatch banner, the headline `AnalysisVerdict` (final verdict + recruiter view), then `AnalysisScores`.
- **Grouped detail (#8)** — the remaining cards move into four collapsible `Accordion` groups:
  1. **Strengths & skills** (open by default) — strengths/weaknesses, matched skills, missing skills
  2. **Recommendations & rewrites**
  3. **ATS & formatting** — ATS risks, section analysis
  4. **Language & localization**
- Each group renders **only when it has content**, so a clean result no longer shows empty cards.
- `AnalysisResults` extracted from the `AnalyzePage` route into its own feature component (testable in isolation, correct placement).

`#54` (academic-vs-work ATS mode) is the remaining B5 piece and ships separately as B5b.

## Verification

- New `AnalysisResults` test (5): summary always visible (not behind an accordion), default-open group reveals content, collapsed groups hide content, empty group omitted, language group appears on a mismatch.
- `pnpm lint:strict` 0 · real `tsc --noEmit` clean · `pnpm test` 906 passing (157 files) · prettier clean.
- en/de group strings added. No Rust. Pre-push full gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
