### PR TITLE
feat: add academic-vs-work mode to the resume analyzer

### DIFF
--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzeLeftPanel/index.tsx
@@ -1,4 +1,13 @@
-import { AlertCircle, AlertTriangle, RefreshCw, ScanSearch, Sparkles, Zap } from 'lucide-react';
+import {
+  AlertCircle,
+  AlertTriangle,
+  Briefcase,
+  GraduationCap,
+  RefreshCw,
+  ScanSearch,
+  Sparkles,
+  Zap,
+} from 'lucide-react';
 
 import { Button, cn, SegmentedControl } from '@ajh/ui';
 
@@ -8,6 +17,7 @@ import { AiSetupHint } from '@/components/ui/AiSetupHint';
 import { ModelSelector } from '@/components/ui/ModelSelector';
 import type { Stage } from '@/features/analyze/constants';
 import { useTranslation } from '@/lib/i18n';
+import type { AnalysisMode } from '@/lib/resume-ai';
 import type { PromptQuality } from '@/store/preferences-schema';
 
 interface Props {
@@ -20,12 +30,14 @@ interface Props {
   canUseAI: boolean;
   aiReason: string;
   promptQuality: PromptQuality;
+  analysisMode: AnalysisMode;
   onUpload: (target: 'resume' | 'jobAd', file: File) => Promise<void>;
   onReset: () => void;
   onRun: () => void;
   setResume: (v: string) => void;
   setJobAd: (v: string) => void;
   setPromptQuality: (v: PromptQuality) => void;
+  setAnalysisMode: (v: AnalysisMode) => void;
 }
 
 export function AnalyzeLeftPanel({
@@ -38,12 +50,14 @@ export function AnalyzeLeftPanel({
   canUseAI,
   aiReason,
   promptQuality,
+  analysisMode,
   onUpload,
   onReset,
   onRun,
   setResume,
   setJobAd,
   setPromptQuality,
+  setAnalysisMode,
 }: Props) {
   const { t } = useTranslation();
 
@@ -84,6 +98,26 @@ export function AnalyzeLeftPanel({
       {/* One-click AI setup when no provider is ready */}
       <div className="px-6">
         <AiSetupHint show={!canUseAI} reason={aiReason} />
+      </div>
+
+      {/* Document type — academic CV vs work résumé (#54). Drives the ATS criteria. */}
+      <div className="px-6 pb-4">
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/55">
+          {t('analyze.mode.label')}
+        </div>
+        <SegmentedControl<AnalysisMode>
+          variant="grid"
+          ariaLabel={t('analyze.mode.label')}
+          value={analysisMode}
+          onChange={setAnalysisMode}
+          options={[
+            { value: 'work', label: t('analyze.mode.work'), icon: Briefcase },
+            { value: 'academic', label: t('analyze.mode.academic'), icon: GraduationCap },
+          ]}
+        />
+        <p className="mt-1.5 text-[10px] leading-relaxed text-foreground/35">
+          {t(analysisMode === 'academic' ? 'analyze.mode.academicHint' : 'analyze.mode.workHint')}
+        </p>
       </div>
 
       {/* Prompt quality selector */}

--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
@@ -22,8 +22,18 @@ import { usePreferencesStore, usePromptQuality } from '@/store/preferences-store
 function AnalyzePage() {
   const { t, i18n } = useTranslation();
 
-  const { resume, jobAd, stage, result, setResume, setJobAd, setStage, setResult } =
-    useAnalyzeState();
+  const {
+    resume,
+    jobAd,
+    stage,
+    result,
+    analysisMode,
+    setResume,
+    setJobAd,
+    setStage,
+    setResult,
+    setAnalysisMode,
+  } = useAnalyzeState();
 
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [uploading, setUploading] = useState<'resume' | 'jobAd' | null>(null);
@@ -93,7 +103,17 @@ function AnalyzePage() {
     tokenStartRef,
     run,
     reset,
-  } = useAnalysisRun(resume, jobAd, selectedModel, canUseAI, i18n, setStage, setResult, t);
+  } = useAnalysisRun(
+    resume,
+    jobAd,
+    selectedModel,
+    canUseAI,
+    i18n,
+    setStage,
+    setResult,
+    t,
+    analysisMode
+  );
 
   const handleReset = async () => {
     await reset();
@@ -118,12 +138,14 @@ function AnalyzePage() {
           canUseAI={canUseAI}
           aiReason={aiReason ?? ''}
           promptQuality={promptQuality}
+          analysisMode={analysisMode}
           onUpload={handleUpload}
           onReset={handleReset}
           onRun={run}
           setResume={setResume}
           setJobAd={setJobAd}
           setPromptQuality={setPromptQuality}
+          setAnalysisMode={setAnalysisMode}
         />
 
         <div className="flex flex-1 flex-col overflow-hidden">

--- a/apps/tauri/src/renderer/features/analyze/hooks/useAnalysisRun.ts
+++ b/apps/tauri/src/renderer/features/analyze/hooks/useAnalysisRun.ts
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 
 import type { Stage } from '@/features/analyze/constants';
-import { type AnalysisResult, runAnalysis } from '@/lib/resume-ai';
+import { type AnalysisMode, type AnalysisResult, runAnalysis } from '@/lib/resume-ai';
 import { useOutputTone, usePromptQuality } from '@/store/preferences-store';
 
 export function useAnalysisRun(
@@ -12,7 +12,9 @@ export function useAnalysisRun(
   i18n: { language: string },
   setStage: (v: Stage) => void,
   setResult: (v: AnalysisResult | null) => void,
-  t: (key: string) => string
+  t: (key: string) => string,
+  /** Evaluate as a corporate résumé (default) or an academic CV (#54). */
+  analysisMode: AnalysisMode = 'work'
 ) {
   const [error, setError] = useState<string | null>(null);
   const [stream, setStream] = useState('');
@@ -47,7 +49,11 @@ export function useAnalysisRun(
         jobAd,
         model: selectedModel,
         locale: i18n.language,
-        meta: { targetLocale: i18n.language, outputTone: outputTone ?? 'professional' },
+        meta: {
+          targetLocale: i18n.language,
+          outputTone: outputTone ?? 'professional',
+          analysisMode,
+        },
         onToken: (tok) => {
           if (!tokenStartRef.current) {
             tokenStartRef.current = Date.now();

--- a/apps/tauri/src/renderer/features/analyze/hooks/useAnalyzeState.ts
+++ b/apps/tauri/src/renderer/features/analyze/hooks/useAnalyzeState.ts
@@ -1,25 +1,28 @@
 import { useCallback } from 'react';
 
 import type { Stage } from '@/features/analyze/constants';
-import type { AnalysisResult } from '@/lib/resume-ai';
+import type { AnalysisMode, AnalysisResult } from '@/lib/resume-ai';
 import { useSessionStore } from '@/store/session-store';
 
 export function useAnalyzeState() {
   const { analyze, setAnalyze } = useSessionStore();
-  const { resume, jobAd, stage, result } = analyze;
+  const { resume, jobAd, stage, result, analysisMode } = analyze;
   const setResume = useCallback((v: string) => setAnalyze({ resume: v }), [setAnalyze]);
   const setJobAd = (v: string) => setAnalyze({ jobAd: v });
   const setStage = (v: Stage) => setAnalyze({ stage: v });
   const setResult = (v: AnalysisResult | null) => setAnalyze({ result: v });
+  const setAnalysisMode = (v: AnalysisMode) => setAnalyze({ analysisMode: v });
 
   return {
     resume,
     jobAd,
     stage,
     result,
+    analysisMode,
     setResume,
     setJobAd,
     setStage,
     setResult,
+    setAnalysisMode,
   };
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -112,6 +112,13 @@
     },
     "verdict": "Endurteil",
     "recruiterView": "Sichtweise des Personalers —",
+    "mode": {
+      "label": "Dokumenttyp",
+      "work": "Lebenslauf (Beruf)",
+      "academic": "Akademischer CV",
+      "workHint": "Bewertet nach ATS- und Recruiter-Konventionen für Unternehmen.",
+      "academicHint": "Bewertet nach Normen für akademische CVs — Publikationen, Forschung und Länge werden geschätzt, nicht abgewertet."
+    },
     "groups": {
       "strengthsSkills": "Stärken & Fähigkeiten",
       "recommendations": "Empfehlungen & Umformulierungen",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -112,6 +112,13 @@
     },
     "verdict": "Final Verdict",
     "recruiterView": "Recruiter's view —",
+    "mode": {
+      "label": "Document type",
+      "work": "Work résumé",
+      "academic": "Academic CV",
+      "workHint": "Scored against corporate ATS and recruiter conventions.",
+      "academicHint": "Scored against academic-CV norms — publications, research, and length are valued, not penalized."
+    },
     "groups": {
       "strengthsSkills": "Strengths & skills",
       "recommendations": "Recommendations & rewrites",

--- a/apps/tauri/src/renderer/lib/resume-ai/resume-ai.ts
+++ b/apps/tauri/src/renderer/lib/resume-ai/resume-ai.ts
@@ -11,6 +11,7 @@
  */
 
 import {
+  type AnalysisMode,
   type AnalysisResult,
   buildAnalysisPrompt,
   buildSystemPrompt,
@@ -37,7 +38,7 @@ function effectiveTier(model: string): ModelTier {
   return getModelTier(model);
 }
 
-export type { AnalysisResult };
+export type { AnalysisMode, AnalysisResult };
 
 interface RunAnalysisOptions {
   resume: string;

--- a/apps/tauri/src/renderer/store/session-store/session-store.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.ts
@@ -4,7 +4,7 @@ import type { AutopilotFoundJob } from '@ajh/shared';
 
 import type { WizardState } from '@/features/autopilot/types';
 import type { EmphasisId, GenerationMeta, GenerationMode, TemplateId } from '@/lib/generate';
-import type { AnalysisResult } from '@/lib/resume-ai';
+import type { AnalysisMode, AnalysisResult } from '@/lib/resume-ai';
 
 // ─── Per-route state shapes ───────────────────────────────────────────────────
 
@@ -38,6 +38,8 @@ interface AnalyzeSlice {
   jobAd: string;
   stage: AnalyzeStage;
   result: AnalysisResult | null;
+  /** Evaluate as a corporate résumé (default) or an academic CV (#54). */
+  analysisMode: AnalysisMode;
 }
 
 interface JobsSlice {
@@ -114,6 +116,7 @@ const ANALYZE_DEFAULTS: AnalyzeSlice = {
   jobAd: '',
   stage: 'idle',
   result: null,
+  analysisMode: 'work',
 };
 
 // ─── Store ────────────────────────────────────────────────────────────────────

--- a/packages/prompts/src/analyze/analysis-prompt.ts
+++ b/packages/prompts/src/analyze/analysis-prompt.ts
@@ -5,12 +5,36 @@ import { resumeConventions } from '../locale/index.js';
 import { type PromptTarget, resolveProfile } from '../provider/index.js';
 import { SCHEMA, SCHEMA_COMPACT } from './schema.js';
 
+/** Which hiring convention to evaluate the résumé against (#54). */
+export type AnalysisMode = 'work' | 'academic';
+
 export interface PromptMeta {
   resumeLanguage?: string;
   jobAdLanguage?: string;
   targetLocale?: string;
   outputTone?: string;
   modelName?: string; // For model-aware context management
+  /** Evaluate as a corporate résumé (default) or an academic CV (#54). */
+  analysisMode?: AnalysisMode;
+}
+
+/**
+ * Academic-CV evaluation note (#54). When the candidate selects "academic", the
+ * analyzer must judge the document against academic-hiring conventions instead of
+ * corporate-résumé rules — otherwise it wrongly penalizes the things that make an
+ * academic CV strong (length, a Publications section, scholarly detail). Empty for
+ * the default "work" mode, which the existing corporate-oriented prompt covers.
+ */
+function buildModeNote(mode?: AnalysisMode): string {
+  if (mode !== 'academic') return '';
+  return `
+### DOCUMENT TYPE: ACADEMIC CV (evaluate against academic-hiring norms, NOT a corporate résumé)
+- Length: multi-page is normal and expected — do NOT penalize length or recommend cutting to one page.
+- Core content: publications, citations, conference talks, research projects, grants/funding, teaching, advising, peer review, and academic service are CORE experience, not extras — weight them accordingly.
+- Sections: Publications, Research, Teaching, Grants, Presentations, and References are standard, ATS-appropriate academic sections — do NOT flag them as non-standard or as ATS risks.
+- Scoring: judge ATS, job match, and readability by academic conventions (research/teaching fit, publication record, methods rigor), NOT corporate keyword density or one-line CAR-bullet brevity.
+- Recommendations & rewrites: keep the scholarly register; never recommend deleting publications or compressing the CV into a corporate one-pager.
+Apply every honesty / no-fabrication rule exactly as in the base instructions.`;
 }
 
 export function buildAnalysisPrompt(
@@ -43,6 +67,8 @@ export function buildAnalysisPrompt(
 Use these pre-detected languages for your analysis. DO NOT perform your own language detection.`
       : '';
 
+  const modeNote = buildModeNote(meta.analysisMode);
+
   // Section headers + date conventions follow the JOB-AD locale, not a fixed market.
   const conv = resumeConventions(meta.jobAdLanguage ?? meta.targetLocale);
   const marketNote = `
@@ -65,6 +91,7 @@ ${j}
 </job_ad>
 ${langDetectionNote}
 ${marketNote}
+${modeNote}
 
 ${toneNote}
 ${langNote}
@@ -97,6 +124,7 @@ ${j}
 </job_ad>
 ${langDetectionNote}
 ${marketNote}
+${modeNote}
 
 ${toneNote}
 ${langNote}
@@ -116,6 +144,7 @@ ${r}
 ${j}
 ${langDetectionNote}
 ${marketNote}
+${modeNote}
 
 ### ANALYSIS STEPS ###
 

--- a/packages/prompts/src/analyze/analyze.test.ts
+++ b/packages/prompts/src/analyze/analyze.test.ts
@@ -61,6 +61,27 @@ describe('buildAnalysisPrompt', () => {
     const small = buildAnalysisPrompt(resume, jobAd, { modelName: 'phi-3' });
     expect(large.length).toBeGreaterThan(small.length);
   });
+
+  it('injects the academic-CV criteria only when analysisMode is academic (#54)', () => {
+    const work = buildAnalysisPrompt(resume, jobAd, { analysisMode: 'work' }, 'large');
+    const academic = buildAnalysisPrompt(resume, jobAd, { analysisMode: 'academic' }, 'large');
+    expect(work).not.toContain('ACADEMIC CV');
+    expect(academic).toContain('ACADEMIC CV');
+    // The academic note must reverse the corporate length penalty and protect a
+    // Publications section.
+    expect(academic).toContain('do NOT penalize length');
+    expect(academic).toContain('Publications');
+  });
+
+  it('applies the academic note across tiers (compact + task prompts too)', () => {
+    const small = buildAnalysisPrompt(resume, jobAd, { analysisMode: 'academic' }, 'small');
+    expect(small).toContain('ACADEMIC CV');
+  });
+
+  it('defaults to work mode (no academic note) when analysisMode is omitted', () => {
+    const prompt = buildAnalysisPrompt(resume, jobAd, {}, 'large');
+    expect(prompt).not.toContain('ACADEMIC CV');
+  });
 });
 
 describe('validateAndRepair', () => {


### PR DESCRIPTION
## What

**B5b — academic-vs-work analyzer mode (#54).** Completes B5. Adds a document-type toggle so the analyzer judges against the right hiring convention.

The analyzer judged everything by corporate-résumé rules, which penalizes an academic CV for exactly what makes it strong (multi-page length, a publications section). Now the analyzer has a **Work résumé / Academic CV** toggle:

- **Academic mode** injects a criteria note (in all three prompt tiers) telling the model to evaluate against academic-hiring norms: multi-page is expected (no length penalty); publications, research, grants, and teaching are **core** experience; Publications/Research/Teaching sections are ATS-appropriate, not risks; score by academic conventions, not corporate keyword density.
- **Work mode** is the default and keeps the existing corporate-oriented prompt unchanged.

## How

- `AnalysisMode = 'work' | 'academic'` + `buildModeNote()` in `packages/prompts/src/analyze/analysis-prompt.ts`; injected via `PromptMeta.analysisMode` into the brief/task/full prompts.
- Threaded renderer-side: `runAnalysis` meta → `useAnalysisRun(…, analysisMode)`; held in the session `analyze.analysisMode` slice (default `work`) via `useAnalyzeState`; a `SegmentedControl` (Briefcase / GraduationCap) in `AnalyzeLeftPanel` with a mode hint; en/de strings.

## Verification

- 4 new prompt tests: academic note present only in academic mode, applied across tiers (compact + full), absent by default (work). 
- `pnpm lint:strict` 0 · real `tsc --noEmit` clean · `pnpm test` 909 passing (157 files) · prettier clean.
- No Rust. Pre-push full gate passed.

> Criteria authored from academic-CV conventions; worth a real academic-CV spot check (alongside the #18 links verify) once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
