### PR TITLE
feat: add which-model-for-what guidance to the model picker

### DIFF
--- a/apps/tauri/src/renderer/components/ui/ModelSelector/index.tsx
+++ b/apps/tauri/src/renderer/components/ui/ModelSelector/index.tsx
@@ -3,7 +3,9 @@ import { useQueries } from '@tanstack/react-query';
 
 import { Dropdown } from '@ajh/ui';
 
+import { getModelGuidance } from '@/lib/ai-providers/model-guidance';
 import { PROVIDER_ORDER, PROVIDERS } from '@/lib/ai-providers/provider-meta';
+import { useTranslation } from '@/lib/i18n';
 import { useAppClient } from '@/providers/AppClientProvider';
 import { useAIModels, useHasProviderKey, useSystemHealth } from '@/services';
 import { keys } from '@/services/query-client';
@@ -24,6 +26,7 @@ interface ModelSelectorProps {
  * curated aliases when their binary is detected.
  */
 export function ModelSelector({ className }: ModelSelectorProps) {
+  const { t } = useTranslation();
   const api = useAppClient();
   const { data: modelList = [] } = useAIModels();
   const ollamaModels = modelList as Model[];
@@ -89,6 +92,13 @@ export function ModelSelector({ className }: ModelSelectorProps) {
         ? `${activeProvider}||${activeProviderModel}`
         : '';
 
+  // "Which model for what" hint (#6) for the current selection — derived from the
+  // model name + provider kind, so new models are covered with no code change.
+  const selectedModelName = selectedValue ? (selectedValue.split('||')[1] ?? '') : '';
+  const guidance = selectedModelName
+    ? getModelGuidance(selectedModelName, PROVIDERS[activeProvider]?.kind ?? 'local-server')
+    : null;
+
   const handleModelChange = (value: string) => {
     const [provider, model] = value.split('||');
     if (!provider || !model) return;
@@ -113,6 +123,15 @@ export function ModelSelector({ className }: ModelSelectorProps) {
           />
         </div>
       </div>
+      {guidance && (
+        <p className="mt-1.5 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px] leading-relaxed text-foreground/40">
+          <span className="rounded bg-white/[0.06] px-1.5 py-0.5 font-medium text-foreground/55">
+            {t(`models.tier.${guidance.tier}`)}
+          </span>
+          <span className="text-foreground/55">{t(`models.guidance.task.${guidance.task}`)}</span>
+          <span className="text-foreground/30">· {t(`models.guidance.kind.${guidance.kind}`)}</span>
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/tauri/src/renderer/i18n/locales/de.json
+++ b/apps/tauri/src/renderer/i18n/locales/de.json
@@ -20,6 +20,26 @@
     "support": "Hilfe & Support",
     "settings": "Einstellungen"
   },
+  "models": {
+    "tier": {
+      "large": "Groß",
+      "medium": "Mittel",
+      "small": "Klein"
+    },
+    "guidance": {
+      "task": {
+        "strong": "Stärkste Reasoning-Leistung — ideal für Analyse und nuancierte Umformulierungen.",
+        "balanced": "Ausgewogen — solide für die Generierung; Analyse ist brauchbar.",
+        "basic": "Leichtgewichtig — gut für schnelle Entwürfe; für tiefe Analyse ein größeres Modell wählen.",
+        "light": "Schnell & sparsam — super für Generierung und schnelle Durchläufe; tiefe Analyse kann Nuancen verfehlen."
+      },
+      "kind": {
+        "cloud": "Cloud · schnell, nutzt Ihren API-Schlüssel.",
+        "local": "Lokal · privat; Geschwindigkeit hängt von Ihrer Hardware ab.",
+        "cli": "CLI · nutzt Ihren bestehenden Login, kein API-Schlüssel."
+      }
+    }
+  },
   "shortcuts": {
     "title": "Tastenkürzel",
     "navigate": "Navigieren",

--- a/apps/tauri/src/renderer/i18n/locales/en.json
+++ b/apps/tauri/src/renderer/i18n/locales/en.json
@@ -20,6 +20,26 @@
     "support": "Help & Support",
     "settings": "Settings"
   },
+  "models": {
+    "tier": {
+      "large": "Large",
+      "medium": "Medium",
+      "small": "Small"
+    },
+    "guidance": {
+      "task": {
+        "strong": "Strongest reasoning — best for analysis and nuanced rewrites.",
+        "balanced": "Balanced — solid for generation; analysis is decent.",
+        "basic": "Lightweight — fine for quick drafts; pick a larger model for deep analysis.",
+        "light": "Fast & economical — great for generation and quick passes; deep analysis may miss nuance."
+      },
+      "kind": {
+        "cloud": "Cloud · fast, uses your API key.",
+        "local": "Local · private; speed depends on your hardware.",
+        "cli": "CLI · uses your existing login, no API key."
+      }
+    }
+  },
   "shortcuts": {
     "title": "Keyboard shortcuts",
     "navigate": "Navigate",

--- a/apps/tauri/src/renderer/lib/ai-providers/model-guidance.test.ts
+++ b/apps/tauri/src/renderer/lib/ai-providers/model-guidance.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { getModelGuidance } from './model-guidance';
+
+describe('getModelGuidance (#6)', () => {
+  it('flags a strong large cloud model for analysis', () => {
+    expect(getModelGuidance('claude-opus-4-7', 'cloud')).toEqual({
+      tier: 'large',
+      light: false,
+      task: 'strong',
+      kind: 'cloud',
+    });
+  });
+
+  it('calls out a hosted "mini" as a fast/light variant despite the large tier', () => {
+    const g = getModelGuidance('gpt-4o-mini', 'cloud');
+    expect(g.tier).toBe('large');
+    expect(g.light).toBe(true);
+    expect(g.task).toBe('light');
+  });
+
+  it('treats haiku / flash as light variants', () => {
+    expect(getModelGuidance('claude-haiku-4-5-20251001', 'cloud').task).toBe('light');
+    expect(getModelGuidance('gemini-2.5-flash', 'cloud').task).toBe('light');
+  });
+
+  it('maps local model sizes: small → light, medium → balanced', () => {
+    expect(getModelGuidance('llama3.2:1b', 'local-server')).toMatchObject({
+      tier: 'small',
+      task: 'light',
+      kind: 'local',
+    });
+    expect(getModelGuidance('llama3:8b', 'local-server')).toMatchObject({
+      tier: 'medium',
+      light: false,
+      task: 'balanced',
+      kind: 'local',
+    });
+  });
+
+  it('maps provider kind to the right note (cli login, no key)', () => {
+    expect(getModelGuidance('opus', 'cli-agent')).toMatchObject({ task: 'strong', kind: 'cli' });
+  });
+});

--- a/apps/tauri/src/renderer/lib/ai-providers/model-guidance.ts
+++ b/apps/tauri/src/renderer/lib/ai-providers/model-guidance.ts
@@ -1,0 +1,50 @@
+import { getModelTier } from '@ajh/prompts/context-manager';
+
+import type { ProviderKind } from './provider-meta';
+
+/**
+ * "Which model for what" guidance (#6) — derived entirely from the model name +
+ * provider kind, so a NEW model gets sensible guidance with zero code changes
+ * (registry/inference-driven, never a per-model-name table).
+ *
+ * Two signals:
+ * - **tier** (`getModelTier`): cloud / CLI models and >14B locals → `large`;
+ *   4–14B → `medium`; <4B / unknown local → `small`.
+ * - **light**: a name that advertises a fast/economical variant (mini, flash,
+ *   haiku, lite, nano, or a sub-4B local) — capable but trades depth for speed.
+ *
+ * The UI maps `task`/`kind` to i18n strings; this stays pure + testable.
+ */
+export interface ModelGuidance {
+  tier: 'large' | 'medium' | 'small';
+  light: boolean;
+  /** i18n key suffix for the task-fit hint. */
+  task: 'strong' | 'balanced' | 'basic' | 'light';
+  /** i18n key suffix for the provider-kind note. */
+  kind: 'cloud' | 'local' | 'cli';
+}
+
+const LIGHT_VARIANT_RE = /\b(mini|flash|lite|nano|small)\b|haiku/i;
+
+function kindKey(kind: ProviderKind): ModelGuidance['kind'] {
+  if (kind === 'cloud') return 'cloud';
+  if (kind === 'cli-agent') return 'cli';
+  return 'local';
+}
+
+export function getModelGuidance(modelName: string, kind: ProviderKind): ModelGuidance {
+  const tier = getModelTier(modelName);
+  const light = LIGHT_VARIANT_RE.test(modelName) || tier === 'small';
+
+  // A light/fast variant is called out as such regardless of its nominal tier
+  // (e.g. a hosted "mini" classifies as `large` but behaves like a fast variant).
+  const task: ModelGuidance['task'] = light
+    ? 'light'
+    : tier === 'large'
+      ? 'strong'
+      : tier === 'medium'
+        ? 'balanced'
+        : 'basic';
+
+  return { tier, light, task, kind: kindKey(kind) };
+}


### PR DESCRIPTION
## What

**B7 — "which model for what" guidance (#6).** Frontend only, registry-driven. Adds an in-app hint under the model picker so users understand the selected model's fit and its provider trade-offs.

- New `lib/ai-providers/model-guidance.ts` → `getModelGuidance(modelName, providerKind)`. Everything is **inferred** — the tier (via `getModelTier`) plus a light-variant check (`mini` / `flash` / `haiku` / `lite` / `nano` / sub-4B local) and the provider kind — returning a task-fit bucket (`strong` / `balanced` / `basic` / `light`) and a kind note (`cloud` / `local` / `cli`). **No per-model table**, so a new model is covered with zero code (stays registry-driven, per the project's future-proof rule).
- `ModelSelector` renders the hint for the current selection: a **tier badge** + a one-line **task-fit** hint + a muted **kind note**. It appears wherever the picker is used (generate + analyze panels), i.e. exactly at point-of-choice.
- en/de strings for `models.tier.*` and `models.guidance.{task,kind}.*`.

Examples: `claude-opus` → "Large · Strongest reasoning — best for analysis"; `gpt-4o-mini` / `claude-haiku` / `gemini-flash` → "Fast & economical…"; a 1B local → "Lightweight…"; CLI agents → "uses your existing login, no API key."

## Verification

- 5 helper unit tests (strong large cloud, hosted "mini" as light, haiku/flash light, local small→light / medium→balanced, CLI kind).
- `pnpm lint:strict` 0 · real `tsc --noEmit` clean · `pnpm test` 913 passing (157 files) · prettier clean.
- No Rust. Pre-push full gate passed.

> Scoped to the point-of-pick hint (the highest-value, most discoverable form of #6). A separate settings "models intro" panel could follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
