### PR TITLE
feat: résumé builder — draft a résumé from interview answers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,7 @@ target/llvm-cov/
 .mcp.json
 graphify-out/
 .codegraph/
+.obsidian/
 
 post-checkout
 post-commit

--- a/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   Briefcase,
   Cpu,
+  FilePlus2,
   FileText,
   Gauge,
   HelpCircle,
@@ -42,6 +43,7 @@ const NAV_SECTIONS: { labelKey: string; items: readonly NavItem[] }[] = [
       { to: ROUTES.JOBS, label: 'nav.jobs', icon: Briefcase, tourId: 'jobs' },
       { to: ROUTES.ANALYZE, label: 'nav.analyze', icon: Gauge, tourId: 'analyze' },
       { to: ROUTES.GENERATE, label: 'nav.generate', icon: Wand2, tourId: 'generate' },
+      { to: ROUTES.BUILD, label: 'nav.build', icon: FilePlus2, tourId: 'build' },
       // Labelled "Documents" (résumés + cover letters + activity); the route
       // stays /resumes and the tour anchor is 'documents'.
       { to: ROUTES.RESUMES, label: 'nav.documents', icon: FileText, tourId: 'documents' },

--- a/apps/tauri/src/renderer/constants/routes/routes.ts
+++ b/apps/tauri/src/renderer/constants/routes/routes.ts
@@ -2,6 +2,7 @@ export const ROUTES = {
   DASHBOARD: '/',
   ANALYZE: '/analyze',
   GENERATE: '/ai-generate',
+  BUILD: '/build',
   JOBS: '/jobs',
   AUTOPILOT: '/autopilot',
   RESUMES: '/resumes',

--- a/apps/tauri/src/renderer/features/resume-builder/components/BuilderWizard/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/BuilderWizard/index.tsx
@@ -1,0 +1,148 @@
+import { ChevronLeft, ChevronRight, Sparkles } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+
+import { Button, StepDots, transition } from '@ajh/ui';
+
+import type { InterviewAnswers, TemplateId } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+import { useSessionStore } from '@/store/session-store';
+
+import { StepContact } from '../wizard-steps/StepContact';
+import { StepEducation } from '../wizard-steps/StepEducation';
+import { StepExperience } from '../wizard-steps/StepExperience';
+import { StepExtras } from '../wizard-steps/StepExtras';
+import { StepReview } from '../wizard-steps/StepReview';
+import { StepSkills } from '../wizard-steps/StepSkills';
+import { StepSummary } from '../wizard-steps/StepSummary';
+
+const TOTAL_STEPS = 7;
+
+interface BuilderWizardProps {
+  language: string;
+  templateId: TemplateId;
+  atsMode: boolean;
+  isComplete: boolean;
+  canGenerate: boolean;
+  isGenerating: boolean;
+  onLanguageChange: (language: string) => void;
+  onTemplateChange: (id: TemplateId) => void;
+  onAtsModeChange: (enabled: boolean) => void;
+  onGenerate: () => void;
+}
+
+export function BuilderWizard({
+  language,
+  templateId,
+  atsMode,
+  isComplete,
+  canGenerate,
+  isGenerating,
+  onLanguageChange,
+  onTemplateChange,
+  onAtsModeChange,
+  onGenerate,
+}: BuilderWizardProps) {
+  const { t } = useTranslation();
+  const resumeBuilder = useSessionStore((s) => s.resumeBuilder);
+  const setResumeBuilder = useSessionStore((s) => s.setResumeBuilder);
+
+  const { answers, wizardStep: step } = resumeBuilder;
+  const setStep = (v: number) =>
+    setResumeBuilder({ wizardStep: Math.max(0, Math.min(TOTAL_STEPS - 1, v)) });
+  const update = (patch: Partial<InterviewAnswers>) =>
+    setResumeBuilder({ answers: { ...answers, ...patch } });
+
+  const isLast = step === TOTAL_STEPS - 1;
+
+  return (
+    <motion.div
+      key="builder-wizard"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 8 }}
+      transition={transition.relaxed}
+      className="flex flex-1 flex-col overflow-hidden"
+    >
+      {/* Top navigation + non-clickable procedure indicator (mirrors GenerateWizard). */}
+      <div className="shrink-0 flex items-center justify-between gap-3 px-8 pt-7 pb-2">
+        <Button
+          onClick={() => setStep(step - 1)}
+          disabled={step === 0}
+          variant="ghost"
+          size="sm"
+          className="gap-1.5 text-foreground/50 hover:text-foreground/80 disabled:opacity-0"
+        >
+          <ChevronLeft size={14} />
+          {t('build.wizard.back')}
+        </Button>
+
+        <div className="flex flex-col items-center gap-1.5">
+          <StepDots currentStep={step} totalSteps={TOTAL_STEPS} className="flex gap-1.5" />
+          <span className="text-[10px] uppercase tracking-[0.16em] text-foreground/40">
+            {t('build.wizard.stepCounter', { current: step + 1, total: TOTAL_STEPS })}
+          </span>
+        </div>
+
+        {isLast ? (
+          <Button
+            onClick={onGenerate}
+            disabled={!canGenerate || isGenerating}
+            loading={isGenerating}
+            variant="glass"
+            size="sm"
+            className="gap-1.5 transition-all duration-150 ease-out"
+          >
+            {!isGenerating && <Sparkles size={13} />}
+            {isGenerating ? t('build.wizard.generating') : t('build.wizard.generate')}
+          </Button>
+        ) : (
+          <Button
+            onClick={() => setStep(step + 1)}
+            variant="glass"
+            size="sm"
+            className="gap-1.5 transition-all duration-150 ease-out"
+          >
+            {t('build.wizard.next')}
+            <ChevronRight size={14} />
+          </Button>
+        )}
+      </div>
+
+      {/* Step content */}
+      <div className="flex-1 overflow-y-auto px-8 pb-6 pt-2" aria-live="polite">
+        <div className="mb-4">
+          <h2 className="text-sm font-semibold text-foreground/85">{t(`build.steps.${step}`)}</h2>
+          <p className="mt-0.5 text-xs text-foreground/40">{t(`build.descriptions.${step}`)}</p>
+        </div>
+
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={step}
+            initial={{ opacity: 0, x: 16 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -16 }}
+            transition={transition.normal}
+          >
+            {step === 0 && <StepContact answers={answers} update={update} />}
+            {step === 1 && <StepSummary answers={answers} update={update} />}
+            {step === 2 && <StepExperience answers={answers} update={update} />}
+            {step === 3 && <StepEducation answers={answers} update={update} />}
+            {step === 4 && <StepSkills answers={answers} update={update} />}
+            {step === 5 && <StepExtras answers={answers} update={update} />}
+            {step === 6 && (
+              <StepReview
+                language={language}
+                templateId={templateId}
+                atsMode={atsMode}
+                isComplete={isComplete}
+                onLanguageChange={onLanguageChange}
+                onTemplateChange={onTemplateChange}
+                onAtsModeChange={onAtsModeChange}
+              />
+            )}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/RepeatableList/RepeatableList.test.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/RepeatableList/RepeatableList.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Input } from '@ajh/ui';
+
+import { RepeatableList } from './index';
+
+interface Item {
+  value: string;
+}
+
+function setup(items: Item[]) {
+  const onChange = vi.fn();
+  render(
+    <RepeatableList<Item>
+      items={items}
+      onChange={onChange}
+      blank={() => ({ value: '' })}
+      addLabel="Add item"
+      removeLabel="Remove item"
+      emptyLabel="Nothing yet"
+      render={(item, set) => (
+        <Input
+          aria-label="value"
+          value={item.value}
+          onChange={(e) => set({ value: e.target.value })}
+        />
+      )}
+    />
+  );
+  return { onChange };
+}
+
+describe('RepeatableList', () => {
+  it('shows the empty label when there are no items', () => {
+    setup([]);
+    expect(screen.getByText('Nothing yet')).toBeInTheDocument();
+  });
+
+  it('appends a blank entry on add', async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup([{ value: 'a' }]);
+    await user.click(screen.getByRole('button', { name: 'Add item' }));
+    expect(onChange).toHaveBeenCalledWith([{ value: 'a' }, { value: '' }]);
+  });
+
+  it('removes the targeted entry', async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup([{ value: 'a' }, { value: 'b' }]);
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove item' });
+    await user.click(removeButtons[1]!);
+    expect(onChange).toHaveBeenCalledWith([{ value: 'a' }]);
+  });
+
+  it('patches a single entry immutably on edit', async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup([{ value: '' }]);
+    await user.type(screen.getByLabelText('value'), 'x');
+    expect(onChange).toHaveBeenLastCalledWith([{ value: 'x' }]);
+  });
+});

--- a/apps/tauri/src/renderer/features/resume-builder/components/RepeatableList/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/RepeatableList/index.tsx
@@ -1,0 +1,70 @@
+import { Plus, Trash2 } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { Button, GlassCard } from '@ajh/ui';
+
+interface RepeatableListProps<T> {
+  items: T[];
+  onChange: (items: T[]) => void;
+  /** Factory for a new blank entry. */
+  blank: () => T;
+  addLabel: string;
+  removeLabel: string;
+  /** Shown when there are no entries yet. */
+  emptyLabel: string;
+  /** Render one entry's fields. `update` patches just this entry; `remove` drops it. */
+  render: (item: T, update: (patch: Partial<T>) => void, index: number) => ReactNode;
+}
+
+/**
+ * Generic add/remove/update list for the repeatable Resume Builder sections
+ * (experience, education, projects, …). Treats `items` immutably so the session
+ * slice's shared defaults are never mutated in place.
+ */
+export function RepeatableList<T>({
+  items,
+  onChange,
+  blank,
+  addLabel,
+  removeLabel,
+  emptyLabel,
+  render,
+}: RepeatableListProps<T>) {
+  const add = () => onChange([...items, blank()]);
+  const update = (index: number, patch: Partial<T>) =>
+    onChange(items.map((item, i) => (i === index ? { ...item, ...patch } : item)));
+  const remove = (index: number) => onChange(items.filter((_, i) => i !== index));
+
+  return (
+    <div className="space-y-3">
+      {items.length === 0 && (
+        <p className="rounded-lg border border-dashed border-white/10 px-4 py-6 text-center text-xs text-foreground/35">
+          {emptyLabel}
+        </p>
+      )}
+
+      {items.map((item, index) => (
+        // Index key is stable enough here: entries are only ever appended or
+        // removed wholesale, never reordered.
+        <GlassCard key={index} className="relative space-y-2.5 p-4">
+          <Button
+            type="button"
+            onClick={() => remove(index)}
+            variant="ghost"
+            size="sm"
+            aria-label={removeLabel}
+            className="absolute right-2 top-2 text-foreground/40 hover:text-action-delete"
+          >
+            <Trash2 size={14} />
+          </Button>
+          {render(item, (patch) => update(index, patch), index)}
+        </GlassCard>
+      ))}
+
+      <Button type="button" onClick={add} variant="ghost" size="sm" className="gap-1.5">
+        <Plus size={14} />
+        {addLabel}
+      </Button>
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/ResumeBuilderPage/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/ResumeBuilderPage/index.tsx
@@ -1,0 +1,171 @@
+import { ArrowRight, RotateCcw } from 'lucide-react';
+import { AnimatePresence } from 'motion/react';
+import { useState } from 'react';
+
+import { Button, ErrorState } from '@ajh/ui';
+
+import { PageTransition } from '@/components/layout/PageTransition';
+import { AiSetupHint } from '@/components/ui/AiSetupHint';
+import { ModelSelector } from '@/components/ui/ModelSelector';
+import { OutputPanelDone } from '@/features/ai-generate/components/OutputPanelDone';
+import { OutputPanelGenerating } from '@/features/ai-generate/components/OutputPanelGenerating';
+import {
+  buildFilename,
+  exportDOCX,
+  exportPDF,
+  exportTXT,
+  isTwoColumnTemplate,
+  type TemplateId,
+} from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+
+import { useResumeBuilder } from '../../hooks/useResumeBuilder';
+import { BuilderWizard } from '../BuilderWizard';
+
+export function ResumeBuilderPage() {
+  const { t } = useTranslation();
+  const {
+    language,
+    locale,
+    templateId,
+    atsMode,
+    stage,
+    output,
+    setResumeBuilder,
+    meta,
+    canGenerate,
+    canUseAI,
+    aiReason,
+    isComplete,
+    isGenerating,
+    streamBuffer,
+    thinkingBuffer,
+    modelLoading,
+    tokenCount,
+    tokenStartMs,
+    error,
+    synthesize,
+    tailorToJob,
+    reset,
+  } = useResumeBuilder();
+
+  const [copied, setCopied] = useState(false);
+
+  const onLanguageChange = (lng: string) =>
+    setResumeBuilder({ language: lng, locale: lng === 'de' ? 'de' : 'en' });
+  const onTemplateChange = (id: TemplateId) =>
+    setResumeBuilder(
+      isTwoColumnTemplate(id) ? { templateId: id } : { templateId: id, atsMode: false }
+    );
+  const onAtsModeChange = (enabled: boolean) => setResumeBuilder({ atsMode: enabled });
+
+  const copyOutput = async () => {
+    if (isGenerating || !output) return;
+    await navigator.clipboard.writeText(output);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
+  };
+
+  const doExport = async (fmt: 'pdf' | 'docx' | 'txt') => {
+    if (isGenerating || !output) return;
+    const name = buildFilename(meta, 'resume', fmt);
+    if (fmt === 'pdf') await exportPDF(output, name, 'resume', meta, templateId, atsMode, locale);
+    if (fmt === 'docx') await exportDOCX(output, name, 'resume', meta, templateId, atsMode, locale);
+    if (fmt === 'txt') exportTXT(output, name);
+  };
+
+  return (
+    <PageTransition className="h-full overflow-hidden">
+      <div className="flex h-full flex-col">
+        {/* Header: title + model picker */}
+        <div className="shrink-0 flex items-center justify-between gap-4 border-b border-white/8 px-8 py-4">
+          <div>
+            <h1 className="text-sm font-semibold text-foreground/90">{t('build.title')}</h1>
+            <p className="text-xs text-foreground/40">{t('build.subtitle')}</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <AiSetupHint show={!canUseAI} reason={aiReason} />
+            <ModelSelector />
+          </div>
+        </div>
+
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <AnimatePresence mode="wait">
+            {stage === 'interview' && (
+              <BuilderWizard
+                key="wizard"
+                language={language}
+                templateId={templateId}
+                atsMode={atsMode}
+                isComplete={isComplete}
+                canGenerate={canGenerate}
+                isGenerating={isGenerating}
+                onLanguageChange={onLanguageChange}
+                onTemplateChange={onTemplateChange}
+                onAtsModeChange={onAtsModeChange}
+                onGenerate={() => void synthesize()}
+              />
+            )}
+
+            {stage === 'generating' && (
+              <OutputPanelGenerating
+                key="generating"
+                stageLabel={t('build.wizard.generating')}
+                streamBuffer={streamBuffer}
+                activeOut="resume"
+                thinkingBuffer={thinkingBuffer}
+                modelLoading={modelLoading}
+                tokenCount={tokenCount}
+                tokenStartMs={tokenStartMs}
+              />
+            )}
+
+            {stage === 'done' && (
+              <div key="done" className="flex flex-1 flex-col overflow-hidden">
+                <OutputPanelDone
+                  resumeOut={output}
+                  coverOut=""
+                  activeOut="resume"
+                  meta={meta}
+                  mode="ats"
+                  templateId={templateId}
+                  atsMode={atsMode}
+                  locale={locale}
+                  onActiveOutChange={() => {}}
+                  onCopy={() => void copyOutput()}
+                  onExport={doExport}
+                  onOutputChange={(value) => setResumeBuilder({ output: value })}
+                  onRegenerate={() => void synthesize()}
+                  copied={copied}
+                  isGenerating={isGenerating}
+                  generatingDoc={null}
+                />
+                <div className="shrink-0 flex items-center justify-end gap-2 border-t border-white/8 px-8 py-3">
+                  <Button onClick={reset} variant="ghost" size="sm" className="gap-1.5">
+                    <RotateCcw size={14} />
+                    {t('build.output.startOver')}
+                  </Button>
+                  <Button onClick={tailorToJob} variant="glass" size="sm" className="gap-1.5">
+                    {t('build.output.tailor')}
+                    <ArrowRight size={14} />
+                  </Button>
+                </div>
+              </div>
+            )}
+          </AnimatePresence>
+
+          {error && (
+            <div className="shrink-0 mx-6 mb-4">
+              <ErrorState
+                title={t('build.toast.failed')}
+                description={error}
+                onRetry={() => void synthesize()}
+                className="rounded-xl border border-red-400/20 bg-red-400/5 py-6"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/WizardField/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/WizardField/index.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+interface WizardFieldProps {
+  label: string;
+  hint?: string;
+  /** Associates the label with a control by id (for inputs that aren't nested children). */
+  htmlFor?: string;
+  children: ReactNode;
+}
+
+/** Labeled field wrapper for Resume Builder wizard steps. */
+export function WizardField({ label, hint, htmlFor, children }: WizardFieldProps) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <label htmlFor={htmlFor} className="text-xs font-medium text-foreground/60">
+          {label}
+        </label>
+        {hint && <span className="text-[10px] text-foreground/30">{hint}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepContact/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepContact/index.tsx
@@ -1,0 +1,35 @@
+import { Input } from '@ajh/ui';
+
+import { ContactProfileForm } from '@/components/contact/ContactProfileForm';
+import { useTranslation } from '@/lib/i18n';
+
+import type { BuilderStepProps } from '../../../types';
+import { WizardField } from '../../WizardField';
+
+/**
+ * Contact + headline. Reuses the authoritative {@link ContactProfileForm} (it
+ * saves to the contact profile, which becomes the exported header automatically),
+ * and captures an optional headline that informs the synthesized summary.
+ */
+export function StepContact({ answers, update }: BuilderStepProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-5">
+      <ContactProfileForm />
+
+      <WizardField
+        label={t('build.contact.headlineLabel')}
+        hint={t('build.contact.headlineHint')}
+        htmlFor="build-headline"
+      >
+        <Input
+          id="build-headline"
+          value={answers.headline ?? ''}
+          onChange={(e) => update({ headline: e.target.value })}
+          placeholder={t('build.contact.headlinePlaceholder')}
+        />
+      </WizardField>
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepEducation/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepEducation/index.tsx
@@ -1,0 +1,77 @@
+import { Input, TextArea } from '@ajh/ui';
+
+import type { InterviewEducation } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+
+import type { BuilderStepProps } from '../../../types';
+import { RepeatableList } from '../../RepeatableList';
+import { WizardField } from '../../WizardField';
+
+const blank = (): InterviewEducation => ({
+  degree: '',
+  institution: '',
+  location: '',
+  startDate: '',
+  endDate: '',
+  details: '',
+});
+
+/** Repeatable education entries (core section). */
+export function StepEducation({ answers, update }: BuilderStepProps) {
+  const { t } = useTranslation();
+
+  return (
+    <RepeatableList<InterviewEducation>
+      items={answers.education ?? []}
+      onChange={(education) => update({ education })}
+      blank={blank}
+      addLabel={t('build.education.add')}
+      removeLabel={t('build.remove')}
+      emptyLabel={t('build.education.empty')}
+      render={(item, set) => (
+        <div className="space-y-2.5">
+          <div className="grid grid-cols-2 gap-2.5">
+            <WizardField label={t('build.education.degree')}>
+              <Input value={item.degree} onChange={(e) => set({ degree: e.target.value })} />
+            </WizardField>
+            <WizardField label={t('build.education.institution')}>
+              <Input
+                value={item.institution}
+                onChange={(e) => set({ institution: e.target.value })}
+              />
+            </WizardField>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2.5">
+            <WizardField label={t('build.education.location')}>
+              <Input
+                value={item.location ?? ''}
+                onChange={(e) => set({ location: e.target.value })}
+              />
+            </WizardField>
+            <WizardField label={t('build.education.start')}>
+              <Input
+                value={item.startDate ?? ''}
+                onChange={(e) => set({ startDate: e.target.value })}
+              />
+            </WizardField>
+            <WizardField label={t('build.education.end')}>
+              <Input
+                value={item.endDate ?? ''}
+                onChange={(e) => set({ endDate: e.target.value })}
+              />
+            </WizardField>
+          </div>
+
+          <WizardField label={t('build.education.details')} hint={t('build.education.detailsHint')}>
+            <TextArea
+              value={item.details ?? ''}
+              onChange={(e) => set({ details: e.target.value })}
+              rows={2}
+            />
+          </WizardField>
+        </div>
+      )}
+    />
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepExperience/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepExperience/index.tsx
@@ -1,0 +1,88 @@
+import { Input, TextArea } from '@ajh/ui';
+
+import type { InterviewExperience } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+
+import type { BuilderStepProps } from '../../../types';
+import { RepeatableList } from '../../RepeatableList';
+import { WizardField } from '../../WizardField';
+
+const blank = (): InterviewExperience => ({
+  title: '',
+  company: '',
+  location: '',
+  startDate: '',
+  endDate: '',
+  current: false,
+  bullets: [],
+});
+
+/** Repeatable work-experience entries (core section). */
+export function StepExperience({ answers, update }: BuilderStepProps) {
+  const { t } = useTranslation();
+
+  return (
+    <RepeatableList<InterviewExperience>
+      items={answers.experience ?? []}
+      onChange={(experience) => update({ experience })}
+      blank={blank}
+      addLabel={t('build.experience.add')}
+      removeLabel={t('build.remove')}
+      emptyLabel={t('build.experience.empty')}
+      render={(item, set) => (
+        <div className="space-y-2.5">
+          <div className="grid grid-cols-2 gap-2.5">
+            <WizardField label={t('build.experience.title')}>
+              <Input value={item.title} onChange={(e) => set({ title: e.target.value })} />
+            </WizardField>
+            <WizardField label={t('build.experience.company')}>
+              <Input value={item.company} onChange={(e) => set({ company: e.target.value })} />
+            </WizardField>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2.5">
+            <WizardField label={t('build.experience.location')}>
+              <Input
+                value={item.location ?? ''}
+                onChange={(e) => set({ location: e.target.value })}
+              />
+            </WizardField>
+            <WizardField label={t('build.experience.start')}>
+              <Input value={item.startDate} onChange={(e) => set({ startDate: e.target.value })} />
+            </WizardField>
+            <WizardField label={t('build.experience.end')}>
+              <Input
+                value={item.endDate}
+                onChange={(e) => set({ endDate: e.target.value })}
+                disabled={item.current}
+                placeholder={item.current ? t('build.experience.present') : ''}
+              />
+            </WizardField>
+          </div>
+
+          <label className="flex items-center gap-2 text-xs text-foreground/60">
+            <input
+              type="checkbox"
+              checked={item.current ?? false}
+              onChange={(e) => set({ current: e.target.checked })}
+              className="accent-brand"
+            />
+            {t('build.experience.current')}
+          </label>
+
+          <WizardField
+            label={t('build.experience.bullets')}
+            hint={t('build.experience.bulletsHint')}
+          >
+            <TextArea
+              value={(item.bullets ?? []).join('\n')}
+              onChange={(e) => set({ bullets: e.target.value.split('\n') })}
+              rows={4}
+              placeholder={t('build.experience.bulletsPlaceholder')}
+            />
+          </WizardField>
+        </div>
+      )}
+    />
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepExtras/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepExtras/index.tsx
@@ -1,0 +1,180 @@
+import { ChevronRight } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { Input, TextArea } from '@ajh/ui';
+
+import type { InterviewEntry, InterviewProject, InterviewPublication } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+
+import type { BuilderStepProps } from '../../../types';
+import { RepeatableList } from '../../RepeatableList';
+import { WizardField } from '../../WizardField';
+
+/** A collapsible optional sub-section. Native <details> keeps the step compact. */
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <details className="group rounded-lg border border-white/8 bg-white/[0.02] px-3.5 py-2.5 [&_summary::-webkit-details-marker]:hidden">
+      <summary className="flex cursor-pointer list-none items-center gap-1.5 text-xs font-medium text-foreground/70">
+        <ChevronRight
+          size={13}
+          className="text-foreground/40 transition-transform group-open:rotate-90"
+        />
+        {title}
+      </summary>
+      <div className="pt-3">{children}</div>
+    </details>
+  );
+}
+
+const blankEntry = (): InterviewEntry => ({ title: '', detail: '', year: '' });
+
+/** Optional extra sections (projects, publications, awards, volunteering, languages, certs). */
+export function StepExtras({ answers, update }: BuilderStepProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-2.5">
+      <Section title={t('build.extras.projects.title')}>
+        <RepeatableList<InterviewProject>
+          items={answers.projects ?? []}
+          onChange={(projects) => update({ projects })}
+          blank={() => ({ name: '', description: '', link: '' })}
+          addLabel={t('build.extras.projects.add')}
+          removeLabel={t('build.remove')}
+          emptyLabel={t('build.extras.projects.empty')}
+          render={(item, set) => (
+            <div className="space-y-2.5">
+              <WizardField label={t('build.extras.projects.name')}>
+                <Input value={item.name} onChange={(e) => set({ name: e.target.value })} />
+              </WizardField>
+              <WizardField label={t('build.extras.projects.description')}>
+                <TextArea
+                  value={item.description ?? ''}
+                  onChange={(e) => set({ description: e.target.value })}
+                  rows={2}
+                />
+              </WizardField>
+              <WizardField label={t('build.extras.link')} hint={t('build.extras.linkHint')}>
+                <Input value={item.link ?? ''} onChange={(e) => set({ link: e.target.value })} />
+              </WizardField>
+            </div>
+          )}
+        />
+      </Section>
+
+      <Section title={t('build.extras.publications.title')}>
+        <RepeatableList<InterviewPublication>
+          items={answers.publications ?? []}
+          onChange={(publications) => update({ publications })}
+          blank={() => ({ title: '', venue: '', year: '', link: '' })}
+          addLabel={t('build.extras.publications.add')}
+          removeLabel={t('build.remove')}
+          emptyLabel={t('build.extras.publications.empty')}
+          render={(item, set) => (
+            <div className="space-y-2.5">
+              <WizardField label={t('build.extras.publications.titleField')}>
+                <Input value={item.title} onChange={(e) => set({ title: e.target.value })} />
+              </WizardField>
+              <div className="grid grid-cols-2 gap-2.5">
+                <WizardField label={t('build.extras.publications.venue')}>
+                  <Input
+                    value={item.venue ?? ''}
+                    onChange={(e) => set({ venue: e.target.value })}
+                  />
+                </WizardField>
+                <WizardField label={t('build.extras.publications.year')}>
+                  <Input value={item.year ?? ''} onChange={(e) => set({ year: e.target.value })} />
+                </WizardField>
+              </div>
+              <WizardField label={t('build.extras.link')} hint={t('build.extras.linkHint')}>
+                <Input value={item.link ?? ''} onChange={(e) => set({ link: e.target.value })} />
+              </WizardField>
+            </div>
+          )}
+        />
+      </Section>
+
+      <Section title={t('build.extras.awards.title')}>
+        <RepeatableList<InterviewEntry>
+          items={answers.awards ?? []}
+          onChange={(awards) => update({ awards })}
+          blank={blankEntry}
+          addLabel={t('build.extras.awards.add')}
+          removeLabel={t('build.remove')}
+          emptyLabel={t('build.extras.awards.empty')}
+          render={(item, set) => (
+            <div className="grid grid-cols-[1fr_1fr_5rem] gap-2.5">
+              <WizardField label={t('build.extras.entryTitle')}>
+                <Input value={item.title} onChange={(e) => set({ title: e.target.value })} />
+              </WizardField>
+              <WizardField label={t('build.extras.entryDetail')}>
+                <Input
+                  value={item.detail ?? ''}
+                  onChange={(e) => set({ detail: e.target.value })}
+                />
+              </WizardField>
+              <WizardField label={t('build.extras.entryYear')}>
+                <Input value={item.year ?? ''} onChange={(e) => set({ year: e.target.value })} />
+              </WizardField>
+            </div>
+          )}
+        />
+      </Section>
+
+      <Section title={t('build.extras.volunteer.title')}>
+        <RepeatableList<InterviewEntry>
+          items={answers.volunteer ?? []}
+          onChange={(volunteer) => update({ volunteer })}
+          blank={blankEntry}
+          addLabel={t('build.extras.volunteer.add')}
+          removeLabel={t('build.remove')}
+          emptyLabel={t('build.extras.volunteer.empty')}
+          render={(item, set) => (
+            <div className="grid grid-cols-[1fr_1fr_5rem] gap-2.5">
+              <WizardField label={t('build.extras.entryTitle')}>
+                <Input value={item.title} onChange={(e) => set({ title: e.target.value })} />
+              </WizardField>
+              <WizardField label={t('build.extras.entryDetail')}>
+                <Input
+                  value={item.detail ?? ''}
+                  onChange={(e) => set({ detail: e.target.value })}
+                />
+              </WizardField>
+              <WizardField label={t('build.extras.entryYear')}>
+                <Input value={item.year ?? ''} onChange={(e) => set({ year: e.target.value })} />
+              </WizardField>
+            </div>
+          )}
+        />
+      </Section>
+
+      <Section title={t('build.extras.languages.title')}>
+        <WizardField
+          label={t('build.extras.languages.label')}
+          hint={t('build.extras.languages.hint')}
+        >
+          <TextArea
+            value={(answers.languages ?? []).join('\n')}
+            onChange={(e) => update({ languages: e.target.value.split('\n') })}
+            rows={3}
+            placeholder={t('build.extras.languages.placeholder')}
+          />
+        </WizardField>
+      </Section>
+
+      <Section title={t('build.extras.certifications.title')}>
+        <WizardField
+          label={t('build.extras.certifications.label')}
+          hint={t('build.extras.certifications.hint')}
+        >
+          <TextArea
+            value={(answers.certifications ?? []).join('\n')}
+            onChange={(e) => update({ certifications: e.target.value.split('\n') })}
+            rows={3}
+            placeholder={t('build.extras.certifications.placeholder')}
+          />
+        </WizardField>
+      </Section>
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepReview/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepReview/index.tsx
@@ -1,0 +1,66 @@
+import { Info } from 'lucide-react';
+
+import { SegmentedControl } from '@ajh/ui';
+
+import { StepTemplate } from '@/features/ai-generate/components/wizard-steps/StepTemplate';
+import type { TemplateId } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+
+import { WizardField } from '../../WizardField';
+
+interface StepReviewProps {
+  language: string;
+  templateId: TemplateId;
+  atsMode: boolean;
+  isComplete: boolean;
+  onLanguageChange: (language: string) => void;
+  onTemplateChange: (id: TemplateId) => void;
+  onAtsModeChange: (enabled: boolean) => void;
+}
+
+/**
+ * Final step: output language + template/ATS choice. The Generate button lives in
+ * the wizard's top bar; this surfaces a hint when required sections are missing.
+ */
+export function StepReview({
+  language,
+  templateId,
+  atsMode,
+  isComplete,
+  onLanguageChange,
+  onTemplateChange,
+  onAtsModeChange,
+}: StepReviewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-5">
+      {!isComplete && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-400/20 bg-amber-400/5 px-3.5 py-2.5 text-xs text-amber-200/80">
+          <Info size={14} className="mt-0.5 shrink-0" />
+          <span>{t('build.review.incomplete')}</span>
+        </div>
+      )}
+
+      <WizardField label={t('build.review.language')}>
+        <SegmentedControl<string>
+          variant="grid"
+          ariaLabel={t('build.review.language')}
+          value={language}
+          onChange={onLanguageChange}
+          options={[
+            { value: 'en', label: t('build.review.languageEn') },
+            { value: 'de', label: t('build.review.languageDe') },
+          ]}
+        />
+      </WizardField>
+
+      <StepTemplate
+        templateId={templateId}
+        atsMode={atsMode}
+        onTemplateChange={onTemplateChange}
+        onAtsModeChange={onAtsModeChange}
+      />
+    </div>
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepSkills/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepSkills/index.tsx
@@ -1,0 +1,27 @@
+import { TextArea } from '@ajh/ui';
+
+import { useTranslation } from '@/lib/i18n';
+
+import type { BuilderStepProps } from '../../../types';
+import { WizardField } from '../../WizardField';
+
+/** Skills (core section) — one per line; the synthesis groups them ATS-style. */
+export function StepSkills({ answers, update }: BuilderStepProps) {
+  const { t } = useTranslation();
+
+  return (
+    <WizardField
+      label={t('build.skills.label')}
+      hint={t('build.skills.hint')}
+      htmlFor="build-skills"
+    >
+      <TextArea
+        id="build-skills"
+        value={(answers.skills ?? []).join('\n')}
+        onChange={(e) => update({ skills: e.target.value.split('\n') })}
+        rows={6}
+        placeholder={t('build.skills.placeholder')}
+      />
+    </WizardField>
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepSummary/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/wizard-steps/StepSummary/index.tsx
@@ -1,0 +1,30 @@
+import { TextArea } from '@ajh/ui';
+
+import { useTranslation } from '@/lib/i18n';
+
+import type { BuilderStepProps } from '../../../types';
+import { WizardField } from '../../WizardField';
+
+/**
+ * Optional professional summary. If left blank, the synthesis derives one
+ * strictly from the other answers; if filled, its substance is kept verbatim.
+ */
+export function StepSummary({ answers, update }: BuilderStepProps) {
+  const { t } = useTranslation();
+
+  return (
+    <WizardField
+      label={t('build.summary.label')}
+      hint={t('build.summary.hint')}
+      htmlFor="build-summary"
+    >
+      <TextArea
+        id="build-summary"
+        value={answers.summary ?? ''}
+        onChange={(e) => update({ summary: e.target.value })}
+        placeholder={t('build.summary.placeholder')}
+        rows={5}
+      />
+    </WizardField>
+  );
+}

--- a/apps/tauri/src/renderer/features/resume-builder/hooks/useResumeBuilder.ts
+++ b/apps/tauri/src/renderer/features/resume-builder/hooks/useResumeBuilder.ts
@@ -1,0 +1,183 @@
+import { useRef, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+
+import { useToast } from '@ajh/ui';
+
+import { useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
+import { ROUTES } from '@/constants/routes';
+import { type GenerationMeta, synthesizeResume } from '@/lib/generate';
+import { useTranslation } from '@/lib/i18n';
+import { useSaveAiGeneration } from '@/services/use-ai-generations';
+import { useContactProfile } from '@/services/use-contact-profile';
+import { useSessionStore } from '@/store/session-store';
+
+/**
+ * Resume Builder orchestration (#1 / B9): builds the synthesis `GenerationMeta`
+ * from the interview answers + saved contact profile, runs the single streamed
+ * synthesis pass, persists the result to Documents (saveAiGeneration), and
+ * provides the in-memory "tailor to a job" handoff into AI-Generate. State lives
+ * in the `resumeBuilder` session slice; transient streaming state is local.
+ */
+export function useResumeBuilder() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const notify = useToast();
+  const selectedModel = useSelectedModel();
+  const { canUse: canUseAI, reason: aiReason } = useCanUseAI();
+  const { data: contact } = useContactProfile();
+  const saveAiGeneration = useSaveAiGeneration();
+
+  const resumeBuilder = useSessionStore((s) => s.resumeBuilder);
+  const setResumeBuilder = useSessionStore((s) => s.setResumeBuilder);
+  const resetResumeBuilder = useSessionStore((s) => s.resetResumeBuilder);
+  const setAIGenerate = useSessionStore((s) => s.setAIGenerate);
+  const resetAIGenerate = useSessionStore((s) => s.resetAIGenerate);
+
+  const { answers, language, locale, templateId, atsMode, stage, output } = resumeBuilder;
+
+  const [streamBuffer, setStreamBuffer] = useState('');
+  const [thinkingBuffer, setThinkingBuffer] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [modelLoading, setModelLoading] = useState(false);
+  const [tokenCount, setTokenCount] = useState(0);
+  const tokenStartRef = useRef<number | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Name comes from the authoritative contact profile (the export header source);
+  // fall back to anything captured directly in the answers.
+  const fullName = contact?.fullName?.trim() || answers.fullName?.trim() || '';
+
+  const meta: GenerationMeta = {
+    resumeLanguage: language,
+    jobAdLanguage: language,
+    mismatch: false,
+    candidateName: fullName,
+    jobTitle: answers.headline?.trim() || '',
+    companyName: '',
+    targetLanguage: language,
+    topRequirements: [],
+  };
+
+  // Completeness gate: a real résumé needs a name, some history, and some skills.
+  const hasName = fullName.length > 0;
+  const hasHistory =
+    (answers.experience?.some((e) => e.title?.trim() || e.company?.trim()) ?? false) ||
+    (answers.education?.some((e) => e.degree?.trim() || e.institution?.trim()) ?? false);
+  const hasSkills = answers.skills?.some((s) => s.trim()) ?? false;
+  const isComplete = hasName && hasHistory && hasSkills;
+  const canGenerate = isComplete && canUseAI;
+
+  const synthesize = async () => {
+    if (isGenerating) return;
+    setError(null);
+    setStreamBuffer('');
+    setThinkingBuffer('');
+    setTokenCount(0);
+    setModelLoading(true);
+    tokenStartRef.current = null;
+    setIsGenerating(true);
+    setResumeBuilder({ stage: 'generating' });
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const result = await synthesizeResume(
+        { ...answers, fullName },
+        meta,
+        selectedModel,
+        (tok) => {
+          if (!tokenStartRef.current) tokenStartRef.current = Date.now();
+          setModelLoading(false);
+          setTokenCount((c) => c + 1);
+          setStreamBuffer((p) => (p + tok).slice(-600));
+        },
+        language,
+        controller.signal,
+        (tok) => {
+          setModelLoading(false);
+          setThinkingBuffer((p) => p + tok);
+        }
+      );
+
+      setResumeBuilder({ output: result, stage: 'done' });
+      // Persist as a generation so it appears in Documents (no jobUrl → a fresh
+      // row, never a per-job merge). No new IPC.
+      saveAiGeneration.mutate({
+        candidateName: meta.candidateName,
+        jobTitle: meta.jobTitle,
+        companyName: '',
+        resumeLanguage: language,
+        jobAdLanguage: language,
+        targetLanguage: language,
+        mismatch: false,
+        topRequirements: [],
+        mode: 'ats',
+        resumeText: result,
+        coverLetterText: '',
+        jobAd: '',
+      });
+      notify(t('build.toast.done'), 'success');
+    } catch (err) {
+      // A user-cancelled run is silent (Start over / unmount aborts in-flight).
+      if (!controller.signal.aborted) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        setResumeBuilder({ stage: 'interview' });
+        notify(t('build.toast.failed'), 'error');
+      }
+    } finally {
+      setIsGenerating(false);
+      abortRef.current = null;
+    }
+  };
+
+  /**
+   * "Tailor to a job" handoff (#1 grill Q5): seed the built résumé straight into
+   * AI-Generate's input in-memory and navigate there. The base-résumé picker only
+   * lists imported DocumentRecords, so this avoids a text-save IPC.
+   */
+  const tailorToJob = () => {
+    if (!output.trim()) return;
+    resetAIGenerate();
+    setAIGenerate({ resume: output });
+    void navigate({ to: ROUTES.GENERATE });
+  };
+
+  const reset = () => {
+    if (abortRef.current && isGenerating) abortRef.current.abort();
+    setError(null);
+    setStreamBuffer('');
+    setThinkingBuffer('');
+    resetResumeBuilder();
+  };
+
+  return {
+    answers,
+    language,
+    locale,
+    templateId,
+    atsMode,
+    stage,
+    output,
+    setResumeBuilder,
+    meta,
+    fullName,
+    canGenerate,
+    canUseAI,
+    aiReason: aiReason ?? '',
+    isComplete,
+    isGenerating,
+    streamBuffer,
+    thinkingBuffer,
+    modelLoading,
+    tokenCount,
+    tokenStartMs: tokenStartRef.current,
+    error,
+    setError,
+    synthesize,
+    tailorToJob,
+    reset,
+  };
+}

--- a/apps/tauri/src/renderer/features/resume-builder/types.ts
+++ b/apps/tauri/src/renderer/features/resume-builder/types.ts
@@ -1,0 +1,8 @@
+import type { InterviewAnswers } from '@/lib/generate';
+
+/** Common props every Resume Builder wizard step receives. */
+export interface BuilderStepProps {
+  answers: InterviewAnswers;
+  /** Shallow-merge a patch into the interview answers (immutable update). */
+  update: (patch: Partial<InterviewAnswers>) => void;
+}

--- a/apps/tauri/src/renderer/i18n/locales/de/translation.json
+++ b/apps/tauri/src/renderer/i18n/locales/de/translation.json
@@ -11,6 +11,7 @@
     "dashboard": "Übersicht",
     "analyze": "Lebenslauf-Analyse",
     "generate": "KI-Generator",
+    "build": "Lebenslauf-Builder",
     "jobs": "Jobs",
     "autopilot": "Autopilot",
     "documents": "Dokumente",
@@ -19,6 +20,134 @@
     "monitoring": "Monitoring",
     "support": "Hilfe & Support",
     "settings": "Einstellungen"
+  },
+  "build": {
+    "title": "Lebenslauf-Builder",
+    "subtitle": "Beantworte ein paar Fragen und wir erstellen daraus einen Lebenslauf.",
+    "remove": "Entfernen",
+    "wizard": {
+      "back": "Zurück",
+      "next": "Weiter",
+      "generate": "Lebenslauf erstellen",
+      "generating": "Dein Lebenslauf wird erstellt…",
+      "stepCounter": "Schritt {{current}} von {{total}}"
+    },
+    "steps": {
+      "0": "Deine Angaben",
+      "1": "Profil-Zusammenfassung",
+      "2": "Berufserfahrung",
+      "3": "Ausbildung",
+      "4": "Kenntnisse",
+      "5": "Weitere Abschnitte",
+      "6": "Prüfen & erstellen"
+    },
+    "descriptions": {
+      "0": "Deine Kontaktdaten werden zum Lebenslauf-Kopf. Optional eine Zielrolle ergänzen.",
+      "1": "Optional — leer lassen, dann schreiben wir sie aus deinen Angaben.",
+      "2": "Jede Position hinzufügen, neueste zuerst. Echte Erfolge als Stichpunkte.",
+      "3": "Füge deine Abschlüsse und Qualifikationen hinzu.",
+      "4": "Liste deine Kenntnisse auf — eine pro Zeile. Wir gruppieren sie.",
+      "5": "Optionale Extras: Projekte, Publikationen, Auszeichnungen, Ehrenamt, Sprachen, Zertifikate.",
+      "6": "Ausgabesprache und Vorlage wählen, dann erstellen."
+    },
+    "contact": {
+      "headlineLabel": "Zielrolle / Schlagzeile",
+      "headlinePlaceholder": "z. B. Senior Backend Engineer",
+      "headlineHint": "optional"
+    },
+    "summary": {
+      "label": "Profil-Zusammenfassung",
+      "placeholder": "Ein kurzer Absatz darüber, wer du bist und was du machst. Leer lassen zum automatischen Erstellen.",
+      "hint": "optional"
+    },
+    "experience": {
+      "add": "Position hinzufügen",
+      "empty": "Noch keine Positionen — füge deinen Werdegang hinzu.",
+      "title": "Position",
+      "company": "Unternehmen",
+      "location": "Ort",
+      "start": "Beginn",
+      "end": "Ende",
+      "present": "Heute",
+      "current": "Ich arbeite aktuell hier",
+      "bullets": "Erfolge",
+      "bulletsHint": "eine pro Zeile",
+      "bulletsPlaceholder": "X aufgebaut, das Y bewirkte und Z um 40 % verbesserte"
+    },
+    "education": {
+      "add": "Ausbildung hinzufügen",
+      "empty": "Noch keine Ausbildung.",
+      "degree": "Abschluss / Qualifikation",
+      "institution": "Einrichtung",
+      "location": "Ort",
+      "start": "Beginn",
+      "end": "Ende",
+      "details": "Details",
+      "detailsHint": "Auszeichnungen, Thesis, Schwerpunkte"
+    },
+    "skills": {
+      "label": "Kenntnisse",
+      "hint": "eine pro Zeile",
+      "placeholder": "Python\nPostgreSQL\nAWS"
+    },
+    "extras": {
+      "link": "Link",
+      "linkHint": "optional",
+      "entryTitle": "Titel",
+      "entryDetail": "Detail",
+      "entryYear": "Jahr",
+      "projects": {
+        "title": "Projekte",
+        "add": "Projekt hinzufügen",
+        "empty": "Noch keine Projekte.",
+        "name": "Name",
+        "description": "Beschreibung"
+      },
+      "publications": {
+        "title": "Publikationen",
+        "add": "Publikation hinzufügen",
+        "empty": "Noch keine Publikationen.",
+        "titleField": "Titel",
+        "venue": "Medium",
+        "year": "Jahr"
+      },
+      "awards": {
+        "title": "Auszeichnungen",
+        "add": "Auszeichnung hinzufügen",
+        "empty": "Noch keine Auszeichnungen."
+      },
+      "volunteer": {
+        "title": "Ehrenamt",
+        "add": "Ehrenamt hinzufügen",
+        "empty": "Noch kein Ehrenamt."
+      },
+      "languages": {
+        "title": "Sprachen",
+        "label": "Sprachen",
+        "hint": "eine pro Zeile",
+        "placeholder": "Englisch (Muttersprache)\nDeutsch (B2)"
+      },
+      "certifications": {
+        "title": "Zertifikate",
+        "label": "Zertifikate",
+        "hint": "eine pro Zeile",
+        "placeholder": "AWS Solutions Architect"
+      }
+    },
+    "review": {
+      "language": "Ausgabesprache",
+      "languageEn": "Englisch",
+      "languageDe": "Deutsch",
+      "incomplete": "Füge deinen Namen, mindestens eine Position oder Ausbildung und einige Kenntnisse hinzu."
+    },
+    "output": {
+      "tailor": "An Stelle anpassen",
+      "startOver": "Neu beginnen"
+    },
+    "toast": {
+      "done": "Lebenslauf erstellt — in Dokumenten gespeichert.",
+      "failed": "Lebenslauf konnte nicht erstellt werden. Bitte erneut versuchen."
+    }
   },
   "models": {
     "tier": {

--- a/apps/tauri/src/renderer/i18n/locales/en/translation.json
+++ b/apps/tauri/src/renderer/i18n/locales/en/translation.json
@@ -11,6 +11,7 @@
     "dashboard": "Dashboard",
     "analyze": "Resume Analyzer",
     "generate": "AI Generate",
+    "build": "Resume Builder",
     "jobs": "Jobs",
     "autopilot": "Autopilot",
     "documents": "Documents",
@@ -19,6 +20,134 @@
     "monitoring": "Monitoring",
     "support": "Help & Support",
     "settings": "Settings"
+  },
+  "build": {
+    "title": "Resume Builder",
+    "subtitle": "Answer a few questions and we'll build a résumé from your answers.",
+    "remove": "Remove",
+    "wizard": {
+      "back": "Back",
+      "next": "Next",
+      "generate": "Build résumé",
+      "generating": "Building your résumé…",
+      "stepCounter": "Step {{current}} of {{total}}"
+    },
+    "steps": {
+      "0": "Your details",
+      "1": "Professional summary",
+      "2": "Work experience",
+      "3": "Education",
+      "4": "Skills",
+      "5": "More sections",
+      "6": "Review & build"
+    },
+    "descriptions": {
+      "0": "Your contact details become the résumé header. Add an optional target role.",
+      "1": "Optional — leave blank and we'll write one from your answers.",
+      "2": "Add each role, most recent first. List real achievements as bullets.",
+      "3": "Add your degrees and qualifications.",
+      "4": "List your skills — one per line. We'll group them.",
+      "5": "Optional extras: projects, publications, awards, volunteering, languages, certifications.",
+      "6": "Pick the output language and template, then build."
+    },
+    "contact": {
+      "headlineLabel": "Target role / headline",
+      "headlinePlaceholder": "e.g. Senior Backend Engineer",
+      "headlineHint": "optional"
+    },
+    "summary": {
+      "label": "Professional summary",
+      "placeholder": "A short paragraph about who you are and what you do. Leave blank to auto-generate.",
+      "hint": "optional"
+    },
+    "experience": {
+      "add": "Add a role",
+      "empty": "No roles yet — add your work history.",
+      "title": "Job title",
+      "company": "Company",
+      "location": "Location",
+      "start": "Start",
+      "end": "End",
+      "present": "Present",
+      "current": "I currently work here",
+      "bullets": "Achievements",
+      "bulletsHint": "one per line",
+      "bulletsPlaceholder": "Built X that did Y, improving Z by 40%"
+    },
+    "education": {
+      "add": "Add education",
+      "empty": "No education yet.",
+      "degree": "Degree / qualification",
+      "institution": "Institution",
+      "location": "Location",
+      "start": "Start",
+      "end": "End",
+      "details": "Details",
+      "detailsHint": "honors, thesis, coursework"
+    },
+    "skills": {
+      "label": "Skills",
+      "hint": "one per line",
+      "placeholder": "Python\nPostgreSQL\nAWS"
+    },
+    "extras": {
+      "link": "Link",
+      "linkHint": "optional",
+      "entryTitle": "Title",
+      "entryDetail": "Detail",
+      "entryYear": "Year",
+      "projects": {
+        "title": "Projects",
+        "add": "Add a project",
+        "empty": "No projects yet.",
+        "name": "Name",
+        "description": "Description"
+      },
+      "publications": {
+        "title": "Publications",
+        "add": "Add a publication",
+        "empty": "No publications yet.",
+        "titleField": "Title",
+        "venue": "Venue",
+        "year": "Year"
+      },
+      "awards": {
+        "title": "Awards",
+        "add": "Add an award",
+        "empty": "No awards yet."
+      },
+      "volunteer": {
+        "title": "Volunteering",
+        "add": "Add volunteering",
+        "empty": "No volunteering yet."
+      },
+      "languages": {
+        "title": "Languages",
+        "label": "Languages",
+        "hint": "one per line",
+        "placeholder": "English (native)\nGerman (B2)"
+      },
+      "certifications": {
+        "title": "Certifications",
+        "label": "Certifications",
+        "hint": "one per line",
+        "placeholder": "AWS Solutions Architect"
+      }
+    },
+    "review": {
+      "language": "Output language",
+      "languageEn": "English",
+      "languageDe": "German",
+      "incomplete": "Add your name, at least one role or education entry, and some skills to build."
+    },
+    "output": {
+      "tailor": "Tailor to a job",
+      "startOver": "Start over"
+    },
+    "toast": {
+      "done": "Résumé built — saved to Documents.",
+      "failed": "Couldn't build the résumé. Please try again."
+    }
   },
   "models": {
     "tier": {

--- a/apps/tauri/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/tauri/src/renderer/lib/generate/generation/generation.ts
@@ -9,6 +9,11 @@
  * which streams `ai:stream` deltas under the returned jobId. Export lives in `./export`.
  */
 
+import {
+  buildBuilderSystemPrompt,
+  buildInterviewResumePrompt,
+  type InterviewAnswers,
+} from '@ajh/prompts/builder';
 import { getModelTier } from '@ajh/prompts/context-manager';
 import {
   buildApplicationAnswerPrompt,
@@ -276,6 +281,35 @@ export async function generateResume(
     getLinkMap(resume),
     getBodyLinkMap(resume)
   );
+}
+
+/**
+ * Resume Builder synthesis (#1 / B9): build a from-scratch résumé from structured
+ * interview answers in a SINGLE streamed pass. Mirrors {@link generateResume} —
+ * same provider config, effective tier, and streaming pipeline (so it works for
+ * every provider with zero per-provider code and adds NO new IPC) — but uses the
+ * builder prompts grounded on `<interview_answers>` instead of a base résumé + job
+ * ad. Provided links are kept inline by the prompt, so no link-map injection is
+ * needed (there is no source résumé to parse). Returns plain text.
+ */
+export async function synthesizeResume(
+  answers: InterviewAnswers,
+  meta: GenerationMeta,
+  model: string,
+  onToken: (tok: string) => void,
+  locale = 'en',
+  signal?: AbortSignal,
+  onThinking?: (tok: string) => void
+): Promise<string> {
+  const providerConfig = usePreferencesStore.getState().aiProviderConfig;
+  const activeProvider = providerConfig?.activeProvider ?? 'ollama';
+  const activeModel = providerConfig?.providers?.[activeProvider]?.model || model;
+  const tier = effectiveTier(activeModel, activeProvider);
+
+  const system = buildBuilderSystemPrompt(tier);
+  const user = buildInterviewResumePrompt(answers, meta);
+  const raw = await streamGenerate(model, system, user, onToken, 0.25, locale, signal, onThinking);
+  return extractPlainText(raw);
 }
 
 /**

--- a/apps/tauri/src/renderer/lib/generate/index.ts
+++ b/apps/tauri/src/renderer/lib/generate/index.ts
@@ -10,8 +10,17 @@ export {
   MODES,
   researchCompany,
   rewriteSelection,
+  synthesizeResume,
 } from './generation';
 export { isTwoColumnTemplate, TEMPLATE_IDS, type TemplateId, TEMPLATES } from './templates';
+export type {
+  InterviewAnswers,
+  InterviewEducation,
+  InterviewEntry,
+  InterviewExperience,
+  InterviewProject,
+  InterviewPublication,
+} from '@ajh/prompts/builder';
 
 /**
  * Debounce window (ms) for persisting an in-progress inline edit to a saved

--- a/apps/tauri/src/renderer/routes/build.tsx
+++ b/apps/tauri/src/renderer/routes/build.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { ResumeBuilderPage } from '@/features/resume-builder/components/ResumeBuilderPage';
+
+export const Route = createFileRoute('/build')({ component: ResumeBuilderPage });

--- a/apps/tauri/src/renderer/store/session-store/session-store.test.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.test.ts
@@ -27,6 +27,33 @@ describe('useSessionStore', () => {
     expect(useSessionStore.getState().analyze.stage).toBe('idle');
   });
 
+  it('patches and resets the Resume Builder slice (#1 / B9)', () => {
+    const { setResumeBuilder, resetResumeBuilder } = useSessionStore.getState();
+    setResumeBuilder({
+      wizardStep: 2,
+      stage: 'done',
+      output: '# Jane',
+      answers: {
+        ...useSessionStore.getState().resumeBuilder.answers,
+        fullName: 'Jane Doe',
+        skills: ['Python'],
+      },
+    });
+    let rb = useSessionStore.getState().resumeBuilder;
+    expect(rb.wizardStep).toBe(2);
+    expect(rb.stage).toBe('done');
+    expect(rb.answers.fullName).toBe('Jane Doe');
+    expect(rb.answers.skills).toEqual(['Python']);
+
+    resetResumeBuilder();
+    rb = useSessionStore.getState().resumeBuilder;
+    expect(rb.wizardStep).toBe(0);
+    expect(rb.stage).toBe('interview');
+    expect(rb.output).toBe('');
+    expect(rb.answers.fullName).toBe('');
+    expect(rb.answers.experience).toEqual([]);
+  });
+
   it('patches jobs, resumes and settings slices', () => {
     useSessionStore.getState().setJobs({ filter: 'react', sortBy: 'company' });
     expect(useSessionStore.getState().jobs).toEqual({ filter: 'react', sortBy: 'company' });

--- a/apps/tauri/src/renderer/store/session-store/session-store.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 
+import type { InterviewAnswers } from '@ajh/prompts/builder';
 import type { AutopilotFoundJob } from '@ajh/shared';
 
 import type { WizardState } from '@/features/autopilot/types';
@@ -40,6 +41,25 @@ interface AnalyzeSlice {
   result: AnalysisResult | null;
   /** Evaluate as a corporate résumé (default) or an academic CV (#54). */
   analysisMode: AnalysisMode;
+}
+
+/** Resume Builder (#1 / B9) — interview answers + wizard/synthesis state. */
+type ResumeBuilderStage = 'interview' | 'generating' | 'done';
+
+export interface ResumeBuilderSlice {
+  /** Structured interview answers — the grounding source for synthesis. */
+  answers: InterviewAnswers;
+  /** Current wizard step index (0-based). */
+  wizardStep: number;
+  stage: ResumeBuilderStage;
+  /** Synthesized résumé markdown (populated when stage === 'done'). */
+  output: string;
+  /** Output language for synthesis (e.g. `en`, `de`) — drives section headers. */
+  language: string;
+  /** Export market id (`us`, `de`, …) — drives page size; defaults from language. */
+  locale: string;
+  templateId: TemplateId;
+  atsMode: boolean;
 }
 
 interface JobsSlice {
@@ -119,11 +139,36 @@ const ANALYZE_DEFAULTS: AnalyzeSlice = {
   analysisMode: 'work',
 };
 
+const RESUME_BUILDER_DEFAULTS: ResumeBuilderSlice = {
+  answers: {
+    fullName: '',
+    headline: '',
+    summary: '',
+    experience: [],
+    education: [],
+    skills: [],
+    projects: [],
+    publications: [],
+    awards: [],
+    volunteer: [],
+    languages: [],
+    certifications: [],
+  },
+  wizardStep: 0,
+  stage: 'interview',
+  output: '',
+  language: 'en',
+  locale: 'en',
+  templateId: 'modern',
+  atsMode: false,
+};
+
 // ─── Store ────────────────────────────────────────────────────────────────────
 
 interface SessionState {
   aiGenerate: AIGenerateSlice;
   analyze: AnalyzeSlice;
+  resumeBuilder: ResumeBuilderSlice;
   jobs: JobsSlice;
   resumes: ResumesSlice;
   settings: SettingsSlice;
@@ -134,6 +179,9 @@ interface SessionState {
 
   setAnalyze: (patch: Partial<AnalyzeSlice>) => void;
   resetAnalyze: () => void;
+
+  setResumeBuilder: (patch: Partial<ResumeBuilderSlice>) => void;
+  resetResumeBuilder: () => void;
 
   setJobs: (patch: Partial<JobsSlice>) => void;
 
@@ -148,6 +196,7 @@ interface SessionState {
 export const useSessionStore = create<SessionState>((set) => ({
   aiGenerate: { ...AI_GENERATE_DEFAULTS },
   analyze: { ...ANALYZE_DEFAULTS },
+  resumeBuilder: { ...RESUME_BUILDER_DEFAULTS },
   jobs: { filter: '', sortBy: 'newest' },
   resumes: { tab: 'resumes', filter: '' },
   settings: { activeSection: 'general' },
@@ -165,6 +214,9 @@ export const useSessionStore = create<SessionState>((set) => ({
 
   setAnalyze: (patch) => set((s) => ({ analyze: { ...s.analyze, ...patch } })),
   resetAnalyze: () => set({ analyze: { ...ANALYZE_DEFAULTS } }),
+
+  setResumeBuilder: (patch) => set((s) => ({ resumeBuilder: { ...s.resumeBuilder, ...patch } })),
+  resetResumeBuilder: () => set({ resumeBuilder: { ...RESUME_BUILDER_DEFAULTS } }),
 
   setJobs: (patch) => set((s) => ({ jobs: { ...s.jobs, ...patch } })),
 

--- a/apps/tauri/vitest.config.ts
+++ b/apps/tauri/vitest.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
       { find: '@ajh/shared', replacement: resolve(sharedSrc, 'index.ts') },
       { find: '@ajh/prompts/generate', replacement: resolve(promptsSrc, 'generate/index.ts') },
       { find: '@ajh/prompts/analyze', replacement: resolve(promptsSrc, 'analyze/index.ts') },
+      { find: '@ajh/prompts/builder', replacement: resolve(promptsSrc, 'builder/index.ts') },
       {
         find: '@ajh/prompts/context-manager',
         replacement: resolve(promptsSrc, 'context-manager/index.ts'),

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -18,6 +18,10 @@
       "types": "./src/analyze/index.ts",
       "default": "./dist/analyze/index.js"
     },
+    "./builder": {
+      "types": "./src/builder/index.ts",
+      "default": "./dist/builder/index.js"
+    },
     "./context-manager": {
       "types": "./src/context-manager/index.ts",
       "default": "./dist/context-manager/index.js"

--- a/packages/prompts/src/builder/builder-prompt.ts
+++ b/packages/prompts/src/builder/builder-prompt.ts
@@ -1,0 +1,238 @@
+/**
+ * Resume Builder synthesis prompt (#1 / phase B9).
+ *
+ * The builder has NO base résumé and NO job ad — the candidate's structured
+ * interview answers ARE the grounding source. So this is a from-scratch writer
+ * with the same hard no-fabrication contract as the tailoring path, but the
+ * grounding tag is `<interview_answers>` rather than `<candidate_resume>`. The
+ * output uses the same markdown grammar and localized section headers as
+ * `generate/resume.ts`, so the existing export / preview / link handling apply
+ * unchanged.
+ */
+
+import { buildEmphasisDirectivesBlock } from '../generate/emphasis.js';
+import type { GenerationMeta } from '../generate/modes.js';
+import { resumeConventions } from '../locale/index.js';
+import { type PromptTarget, resolveProfile } from '../provider/index.js';
+import type {
+  InterviewAnswers,
+  InterviewEducation,
+  InterviewEntry,
+  InterviewExperience,
+  InterviewProject,
+  InterviewPublication,
+} from './types.js';
+
+const HARD_RULES = `NEVER BREAK THESE RULES:
+1. Use ONLY facts the candidate provided in <interview_answers>. NEVER invent employers, job titles, dates, metrics, skills, schools, degrees, or achievements.
+2. NEVER add a technology, tool, or number the candidate did not state. If a bullet has no number, keep it qualitative — do NOT fabricate one.
+3. You MAY reword, reorder, group, and reframe the provided facts for impact and ATS — but every claim must trace to an answer.
+4. Keep EVERY work role and education entry the candidate gave — reorder/condense the bullets within a role, never drop a role or entry.
+5. Keep every link the candidate provided inline on its item as [label](url) — never drop a link.`;
+
+const SUMMARY_RULE = `PROFESSIONAL SUMMARY:
+- If the candidate wrote a summary, keep its substance and claims (you may lightly polish grammar and flow) — do NOT replace it with a generic one.
+- If they wrote none, write a 2–3 sentence summary derived strictly from the answers (seniority and domain inferred from their roles) — invent no years, metrics, or claims.`;
+
+function buildBuilderSystemFull(): string {
+  return `You are an expert résumé writer with deep knowledge of ATS systems, recruiter behavior, and modern hiring practices. Build a complete, ATS-ready résumé from the candidate's interview answers.
+
+${HARD_RULES}
+
+${SUMMARY_RULE}
+
+SECTION HEADERS: use the target market's standard headers exactly as the task provides them, consistently. Never invent creative section names — ATS parsers rely on standard headers. Include optional sections (Projects, Publications, Certifications, etc.) only when the answers contain them.
+
+DATE FORMAT: one consistent format throughout (the task gives an example). Use an en-dash (–) for ranges and the target language's word for "Present" for current roles.
+
+BULLET POINTS:
+- Start each with a strong action verb (Architected, Led, Optimized, Delivered…).
+- Action + What + Technology/Tool + Measurable result WHEN the candidate supplied a number.
+- Max ~2 lines per bullet. Wrap genuine job-relevant keywords in **double asterisks** (max 2–3 per bullet).
+
+SKILLS: group ATS-style (e.g. Languages / Frameworks / Tools / Platforms) when the entries support it; otherwise a single clean line.
+
+OUTPUT: plain text only. Start with the candidate's name, then a contact line (these are replaced by the saved contact profile on export). Standard localized section headers, "•" for bullets, **double asterisks** for emphasis, no other markdown, no commentary, no XML tags. Output ONLY the résumé.`;
+}
+
+function buildBuilderSystemBrief(): string {
+  return `You are an expert résumé writer. Build a complete, ATS-ready résumé from the candidate's interview answers.
+
+${HARD_RULES}
+
+${SUMMARY_RULE}
+
+REQUIRED SECTION HEADERS: use the localized headers the task provides, consistently. Add optional sections (Projects, Publications, Certifications) only when the answers include them.
+
+DATE FORMAT: one consistent format (the task gives an example); en-dash for ranges; the target language's word for "Present" for current roles.
+
+Every bullet: strong action verb + what + technology + a measurable result only if the candidate gave one. Wrap key terms in **double asterisks** (max 2–3 per bullet).
+
+OUTPUT: plain text. Start with the name + a contact line (replaced by the saved profile on export). Standard headers, "•" bullets, only **bold** markdown. Output ONLY the résumé.`;
+}
+
+function buildBuilderSystemTask(): string {
+  return `You are a résumé-writing agent working a TASK. You may plan, draft, self-review, and revise before finalizing.
+
+GOAL: build a complete, ATS-ready résumé from the candidate's interview answers, in the target language, ready to pass ATS and impress a recruiter.
+
+${HARD_RULES}
+
+${SUMMARY_RULE}
+
+ACCEPTANCE CHECKS — verify and revise until all pass:
+- Output is the finished résumé only (no commentary), in the target language, using that market's standard section headers and one consistent date format.
+- No skill, employer, date, or number appears that the candidate did not provide.
+- Every provided link is preserved inline on its item.
+- Optional sections appear only when the answers contain them.
+
+OUTPUT: the finished résumé (plain text; name + contact line first — replaced by the saved profile on export; "•" bullets; only **bold** markdown).`;
+}
+
+export function buildBuilderSystemPrompt(target: PromptTarget = 'large'): string {
+  const { depth } = resolveProfile(target);
+  if (depth === 'task') return buildBuilderSystemTask();
+  if (depth === 'brief') return buildBuilderSystemBrief();
+  return buildBuilderSystemFull();
+}
+
+// ─── Answer rendering ────────────────────────────────────────────────────────
+
+function linkSuffix(label: string | undefined, link: string | undefined): string {
+  if (!link?.trim()) return '';
+  return ` [${(label || 'link').trim()}](${link.trim()})`;
+}
+
+function renderExperience(items: InterviewExperience[]): string {
+  return items
+    .filter((e) => e.title?.trim() || e.company?.trim())
+    .map((e) => {
+      const loc = e.location?.trim() ? ` (${e.location.trim()})` : '';
+      const end = e.current ? 'Present' : e.endDate?.trim() || 'Present';
+      const dates = e.startDate?.trim() ? ` | ${e.startDate.trim()} – ${end}` : '';
+      const head = `- ${e.title?.trim() || 'Role'} @ ${e.company?.trim() || 'Company'}${loc}${dates}`;
+      const bullets = (e.bullets ?? [])
+        .map((b) => b.trim())
+        .filter(Boolean)
+        .map((b) => `  • ${b}`)
+        .join('\n');
+      return bullets ? `${head}\n${bullets}` : head;
+    })
+    .join('\n');
+}
+
+function renderEducation(items: InterviewEducation[]): string {
+  return items
+    .filter((e) => e.degree?.trim() || e.institution?.trim())
+    .map((e) => {
+      const loc = e.location?.trim() ? `, ${e.location.trim()}` : '';
+      const range = [e.startDate?.trim(), e.endDate?.trim()].filter(Boolean).join(' – ');
+      const dates = range ? ` (${range})` : '';
+      const head = `- ${e.degree?.trim() || 'Degree'} — ${e.institution?.trim() || 'Institution'}${loc}${dates}`;
+      const details = e.details?.trim() ? `\n  ${e.details.trim()}` : '';
+      return `${head}${details}`;
+    })
+    .join('\n');
+}
+
+function renderProjects(items: InterviewProject[]): string {
+  return items
+    .filter((p) => p.name?.trim())
+    .map((p) => {
+      const desc = p.description?.trim() ? ` — ${p.description.trim()}` : '';
+      return `- ${p.name.trim()}${desc}${linkSuffix(p.name, p.link)}`;
+    })
+    .join('\n');
+}
+
+function renderPublications(items: InterviewPublication[]): string {
+  return items
+    .filter((p) => p.title?.trim())
+    .map((p) => {
+      const venue = p.venue?.trim() ? `, ${p.venue.trim()}` : '';
+      const year = p.year?.trim() ? ` (${p.year.trim()})` : '';
+      return `- ${p.title.trim()}${venue}${year}${linkSuffix(p.title, p.link)}`;
+    })
+    .join('\n');
+}
+
+function renderEntries(items: InterviewEntry[]): string {
+  return items
+    .filter((e) => e.title?.trim())
+    .map((e) => {
+      const detail = e.detail?.trim() ? ` — ${e.detail.trim()}` : '';
+      const year = e.year?.trim() ? ` (${e.year.trim()})` : '';
+      return `- ${e.title.trim()}${detail}${year}`;
+    })
+    .join('\n');
+}
+
+/** Render the answers into the `<interview_answers>` body. Empty sections are omitted. */
+export function renderInterviewAnswers(answers: InterviewAnswers): string {
+  const parts: string[] = [];
+  if (answers.fullName?.trim()) parts.push(`NAME: ${answers.fullName.trim()}`);
+  if (answers.headline?.trim()) parts.push(`HEADLINE: ${answers.headline.trim()}`);
+  if (answers.summary?.trim())
+    parts.push(`SUMMARY (candidate-written — keep its substance):\n${answers.summary.trim()}`);
+
+  const exp = renderExperience(answers.experience ?? []);
+  if (exp) parts.push(`EXPERIENCE:\n${exp}`);
+
+  const edu = renderEducation(answers.education ?? []);
+  if (edu) parts.push(`EDUCATION:\n${edu}`);
+
+  const skills = (answers.skills ?? []).map((s) => s.trim()).filter(Boolean);
+  if (skills.length) parts.push(`SKILLS: ${skills.join(', ')}`);
+
+  const projects = renderProjects(answers.projects ?? []);
+  if (projects) parts.push(`PROJECTS:\n${projects}`);
+
+  const pubs = renderPublications(answers.publications ?? []);
+  if (pubs) parts.push(`PUBLICATIONS:\n${pubs}`);
+
+  const awards = renderEntries(answers.awards ?? []);
+  if (awards) parts.push(`AWARDS:\n${awards}`);
+
+  const volunteer = renderEntries(answers.volunteer ?? []);
+  if (volunteer) parts.push(`VOLUNTEERING:\n${volunteer}`);
+
+  const langs = (answers.languages ?? []).map((s) => s.trim()).filter(Boolean);
+  if (langs.length) parts.push(`LANGUAGES: ${langs.join(', ')}`);
+
+  const certs = (answers.certifications ?? []).map((s) => s.trim()).filter(Boolean);
+  if (certs.length) parts.push(`CERTIFICATIONS: ${certs.join(', ')}`);
+
+  return parts.join('\n\n');
+}
+
+export function buildInterviewResumePrompt(
+  answers: InterviewAnswers,
+  meta: GenerationMeta
+): string {
+  // Section headers + date format follow the target market's conventions.
+  const conv = resumeConventions(meta.targetLanguage);
+  const conventionsNote = `CONVENTIONS (target market: ${meta.targetLanguage}): use these section headers — ${conv.headers.summary} / ${conv.headers.experience} / ${conv.headers.education} / ${conv.headers.skills}; and one consistent date format like ${conv.dateExample}.`;
+  const directivesBlock = buildEmphasisDirectivesBlock(meta.emphasis);
+  const hasSummary = Boolean(answers.summary?.trim());
+
+  return `<interview_answers>
+${renderInterviewAnswers(answers)}
+</interview_answers>
+
+Every employer, title, date, skill, achievement, and link in your output MUST come from <interview_answers>. Add nothing the candidate did not state.
+
+### CONTEXT ###
+Candidate: ${meta.candidateName || answers.fullName || 'Unknown'}
+${answers.headline?.trim() ? `Target role / headline: ${answers.headline.trim()}` : ''}
+Write in ${meta.targetLanguage}.
+${conventionsNote}
+${directivesBlock ? `${directivesBlock}\n` : ''}
+### TASK ###
+Build a complete, single-column, ATS-ready résumé from the answers above.
+- Lead with a ${hasSummary ? 'Professional Summary based on the candidate-written summary (keep its substance)' : 'Professional Summary of 2–3 sentences derived strictly from the answers'}.
+- Then Work Experience (every role, most relevant bullets first within each role), Education, and Skills.
+- Add Projects / Publications / Certifications / Awards / Volunteering / Languages sections ONLY when the answers include them, using the market's standard header names.
+- Keep every provided link inline on its item as [label](url).
+
+Output ONLY the résumé as plain text — name + contact line first (replaced by the saved contact profile on export), standard localized section headers, "•" bullets, **double asterisks** for emphasis only.`;
+}

--- a/packages/prompts/src/builder/builder.test.ts
+++ b/packages/prompts/src/builder/builder.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GenerationMeta } from '../generate/modes.js';
+import {
+  buildBuilderSystemPrompt,
+  buildInterviewResumePrompt,
+  type InterviewAnswers,
+  renderInterviewAnswers,
+} from './index.js';
+
+const META: GenerationMeta = {
+  resumeLanguage: 'en',
+  jobAdLanguage: 'en',
+  mismatch: false,
+  candidateName: 'Jane Doe',
+  jobTitle: '',
+  companyName: '',
+  targetLanguage: 'en',
+  topRequirements: [],
+};
+
+const ANSWERS: InterviewAnswers = {
+  fullName: 'Jane Doe',
+  headline: 'Senior Backend Engineer',
+  experience: [
+    {
+      title: 'Senior Engineer',
+      company: 'Acme',
+      location: 'Berlin',
+      startDate: 'Jan 2021',
+      endDate: '',
+      current: true,
+      bullets: ['Built a payments service handling 200k requests/day'],
+    },
+  ],
+  education: [{ degree: 'MSc Computer Science', institution: 'TU Munich', endDate: '2018' }],
+  skills: ['Python', 'PostgreSQL', 'AWS'],
+};
+
+describe('renderInterviewAnswers', () => {
+  it('renders core sections and omits empty optional ones', () => {
+    const out = renderInterviewAnswers(ANSWERS);
+    expect(out).toContain('NAME: Jane Doe');
+    expect(out).toContain('HEADLINE: Senior Backend Engineer');
+    expect(out).toContain('EXPERIENCE:');
+    expect(out).toContain('Senior Engineer @ Acme (Berlin)');
+    expect(out).toContain('EDUCATION:');
+    expect(out).toContain('SKILLS: Python, PostgreSQL, AWS');
+    // No optional sections were provided.
+    expect(out).not.toContain('PROJECTS:');
+    expect(out).not.toContain('PUBLICATIONS:');
+    expect(out).not.toContain('LANGUAGES:');
+  });
+
+  it('renders a current role as "Present"', () => {
+    expect(renderInterviewAnswers(ANSWERS)).toContain('Jan 2021 – Present');
+  });
+
+  it('keeps a candidate-written summary verbatim', () => {
+    const out = renderInterviewAnswers({ ...ANSWERS, summary: 'A hands-on platform engineer.' });
+    expect(out).toContain('SUMMARY (candidate-written — keep its substance):');
+    expect(out).toContain('A hands-on platform engineer.');
+  });
+
+  it('keeps project and publication links inline (#18)', () => {
+    const out = renderInterviewAnswers({
+      ...ANSWERS,
+      projects: [{ name: 'OSS Tool', description: 'A CLI', link: 'https://github.com/x/y' }],
+      publications: [
+        { title: 'On Caches', venue: 'JACM', year: '2022', link: 'https://doi.org/10.1/abc' },
+      ],
+    });
+    expect(out).toContain('PROJECTS:');
+    expect(out).toContain('[OSS Tool](https://github.com/x/y)');
+    expect(out).toContain('PUBLICATIONS:');
+    expect(out).toContain('[On Caches](https://doi.org/10.1/abc)');
+  });
+
+  it('renders awards, volunteering, languages, and certifications when present', () => {
+    const out = renderInterviewAnswers({
+      ...ANSWERS,
+      awards: [{ title: 'Hackathon winner', year: '2020' }],
+      volunteer: [{ title: 'Mentor', detail: 'CoderDojo' }],
+      languages: ['English (native)', 'German (B2)'],
+      certifications: ['AWS Solutions Architect'],
+    });
+    expect(out).toContain('AWARDS:');
+    expect(out).toContain('VOLUNTEERING:');
+    expect(out).toContain('LANGUAGES: English (native), German (B2)');
+    expect(out).toContain('CERTIFICATIONS: AWS Solutions Architect');
+  });
+});
+
+describe('buildBuilderSystemPrompt', () => {
+  it('enforces no-fabrication grounded in <interview_answers> across tiers', () => {
+    for (const tier of ['large', 'medium', 'small'] as const) {
+      const sys = buildBuilderSystemPrompt(tier);
+      expect(sys).toMatch(/interview_answers/);
+      expect(sys.toLowerCase()).toContain('never invent');
+      // The contact line is delegated to the export's saved profile.
+      expect(sys.toLowerCase()).toContain('contact');
+    }
+  });
+});
+
+describe('buildInterviewResumePrompt', () => {
+  it('grounds on the answers and asks to derive a summary when none given', () => {
+    const user = buildInterviewResumePrompt(ANSWERS, META);
+    expect(user).toContain('<interview_answers>');
+    expect(user).toContain('Senior Engineer @ Acme');
+    expect(user).toMatch(/derived strictly from the answers/);
+    expect(user).toContain('Write in en');
+  });
+
+  it('respects a candidate-written summary instead of deriving one', () => {
+    const user = buildInterviewResumePrompt({ ...ANSWERS, summary: 'A pragmatic engineer.' }, META);
+    expect(user).toMatch(/keep its substance/);
+  });
+
+  it('uses the target market section headers (de)', () => {
+    const user = buildInterviewResumePrompt(ANSWERS, { ...META, targetLanguage: 'de' });
+    expect(user).toContain('Berufserfahrung');
+    expect(user).toContain('Write in de');
+  });
+
+  it('folds in emphasis directives only when set (#15 future-proofing)', () => {
+    const plain = buildInterviewResumePrompt(ANSWERS, META);
+    expect(plain).not.toContain('user-selected biases');
+    const biased = buildInterviewResumePrompt(ANSWERS, { ...META, emphasis: ['quantify'] });
+    expect(biased).toContain('user-selected biases');
+  });
+});

--- a/packages/prompts/src/builder/index.ts
+++ b/packages/prompts/src/builder/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Resume Builder prompts (#1 / phase B9) — synthesize a from-scratch résumé from
+ * structured interview answers. The `@ajh/prompts/builder` entry point.
+ */
+
+export {
+  buildBuilderSystemPrompt,
+  buildInterviewResumePrompt,
+  renderInterviewAnswers,
+} from './builder-prompt.js';
+export * from './types.js';

--- a/packages/prompts/src/builder/types.ts
+++ b/packages/prompts/src/builder/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Structured interview answers — the grounding source for the Resume Builder
+ * (#1 / phase B9). The builder is a deterministic, offline questionnaire: the
+ * user fills these fields, then a SINGLE AI pass synthesizes a complete résumé
+ * from them (see `builder-prompt.ts`). No per-question LLM call.
+ *
+ * Contact identity (email / phone / location / profile links) is NOT here — it
+ * lives in the authoritative contact profile and is applied to the export header
+ * automatically (see the contact-profile docs). These answers carry only the
+ * résumé BODY content plus the candidate's name/headline for prompt context.
+ */
+
+/** One work-experience entry (repeatable). */
+export interface InterviewExperience {
+  title: string;
+  company: string;
+  /** City / country, optional. */
+  location?: string;
+  /** Free-text start, e.g. "Jan 2021" — the synthesis normalizes the format. */
+  startDate: string;
+  /** Free-text end; empty (or `current`) renders as the localized "Present". */
+  endDate: string;
+  /** Current role — renders the target language's word for "Present". */
+  current?: boolean;
+  /** Achievement bullets (the candidate's own facts). */
+  bullets: string[];
+}
+
+/** One education entry (repeatable). */
+export interface InterviewEducation {
+  /** Degree / qualification, e.g. "MSc Computer Science". */
+  degree: string;
+  institution: string;
+  location?: string;
+  startDate?: string;
+  endDate?: string;
+  /** Optional extras — honors, thesis, GPA, relevant coursework. */
+  details?: string;
+}
+
+/** One project (optional, repeatable). The link survives inline (#18). */
+export interface InterviewProject {
+  name: string;
+  description?: string;
+  /** Repo / live / case-study URL — kept inline as `[name](link)`. */
+  link?: string;
+}
+
+/** One publication (optional, repeatable) — academic résumés. DOI/url is a body link (#18). */
+export interface InterviewPublication {
+  title: string;
+  /** Journal / conference / venue. */
+  venue?: string;
+  year?: string;
+  /** DOI or article URL — kept inline. */
+  link?: string;
+}
+
+/** A generic dated line — used for awards and volunteering (optional). */
+export interface InterviewEntry {
+  title: string;
+  detail?: string;
+  year?: string;
+}
+
+/**
+ * The complete set of interview answers. Only `experience`, `education`, and
+ * `skills` are core; everything else is optional and rendered only when present.
+ * This shape is the single source shared by the prompt layer and the renderer's
+ * `resumeBuilder` session slice.
+ */
+export interface InterviewAnswers {
+  /** Candidate full name (also passed as `meta.candidateName`). */
+  fullName: string;
+  /** Optional target role / professional headline, informs the summary. */
+  headline?: string;
+  /**
+   * Candidate-written professional summary. Kept (lightly polished) when set;
+   * derived from the other answers when empty. Never replaced with a generic one.
+   */
+  summary?: string;
+  experience: InterviewExperience[];
+  education: InterviewEducation[];
+  /** Skills as discrete entries — grouped ATS-style by the synthesis. */
+  skills: string[];
+  projects?: InterviewProject[];
+  publications?: InterviewPublication[];
+  awards?: InterviewEntry[];
+  volunteer?: InterviewEntry[];
+  /** Spoken languages, e.g. "English (native)", "German (B2)". */
+  languages?: string[];
+  certifications?: string[];
+}

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1,4 +1,5 @@
 export * from './analyze/index.js';
+export * from './builder/index.js';
 export * from './context-manager/index.js';
 export * from './generate/index.js';
 export * from './locale/index.js';


### PR DESCRIPTION
## What

**B9 — Resume Builder (#1).** A new `/build` route + "Resume Builder" nav entry that interviews the user with a deterministic, offline questionnaire, then synthesizes a complete résumé from the answers in **one streamed AI pass**. No per-question model call.

**Frontend + prompts only — no Rust, no IPC, no new data surface, no security review.**

## How (7 decisions, grilled 2026-06-09)

1. **Engine** — fixed structured wizard (fully i18n/offline, zero AI cost to *ask*) + ONE AI synthesis pass. Rejected: AI-adaptive interview.
2. **IA** — its own `/build` route + workspace nav entry; own wizard reusing primitives (`StepDots`, top Back/Next bar, `OptionTile`/`StepTemplate`). Not a 4th `StepTarget` (that axis is output-type, not source).
3. **Synthesis prompt** — new `packages/prompts/builder` module (`buildBuilderSystemPrompt` + `buildInterviewResumePrompt`) grounded on `<interview_answers>` with a recast no-fabrication clause; emits the **same markdown grammar + localized headers** (`resumeConventions`) as the tailoring path, so export / live preview / link handling apply unchanged.
4. **Scope** — **job-agnostic base résumé**; tailoring stays in AI-Generate via a "Tailor to a job" handoff.
5. **Output + save** — reuses the existing `OutputPanelDone` (edit + real preview + export); persists via the existing `saveAiGeneration` (→ Documents; empty job link → a fresh row, never a per-job merge); "Tailor to a job" seeds the markdown into AI-Generate **in-memory** (the base-résumé picker only lists imported `DocumentRecord`s, and `documents.import` takes file bytes, not raw text — so no text-save IPC, no GDPR surface).
6. **Sections (Rich set)** — Contact (reuses the authoritative `ContactProfileForm` → becomes the exported header) · Summary (user-written kept verbatim, else AI-derived) · Experience\* · Education\* · Skills\* · optional Projects / Publications / Awards / Volunteering / Languages / Certifications, grouped under collapsible sub-sections.
7. **State** — new `resumeBuilder` session slice (survives navigation, not persisted to disk).

**Completeness gate:** Build enabled once there's a name + at least one role or education entry + some skills.

## Files

- `packages/prompts/src/builder/` — `types.ts` (`InterviewAnswers`), `builder-prompt.ts` (system/brief/task + `renderInterviewAnswers` + `buildInterviewResumePrompt`), barrel, `builder.test.ts`. New `@ajh/prompts/builder` subpath export.
- `lib/generate/generation.ts` — `synthesizeResume()` (mirrors `generateResume`, builder prompts, single streamed pass); barrel re-exports the synth + interview types.
- `store/session-store` — `resumeBuilder` slice (+ test).
- `features/resume-builder/**` — `ResumeBuilderPage`, `BuilderWizard`, 7 steps, `RepeatableList` (+ test), `WizardField`, `useResumeBuilder`.
- `routes/build.tsx` + `ROUTES.BUILD` + Sidebar entry; en/de `build.*` + `nav.build`; `vitest.config.ts` alias for the new subpath.
- `chore`: ignore the local `.obsidian/` editor directory.

## Verification

- `pnpm lint:strict` 0 · real `tsc --noEmit` clean · `vite build` clean (route tree regenerated, `@ajh/prompts/builder` resolves) · `pnpm test` green (+RepeatableList, builder prompt, slice tests) · prettier clean.
- Pre-push full gate (incl. cargo) passed.
- en/de parity verified for the new `build.*` block (90 keys, 0 drift).

## Reviewer notes

- Reuses `OutputPanelDone` / `OutputPanelGenerating` / `StepTemplate` from `ai-generate` — consistent with the existing `analyze`/`autopilot` cross-feature reuse of that feature's shared output components.
- No emphasis toggles in v1 (bias belongs to the tailor step); template/ATS chosen on the final step, changeable in the done panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
