### PR TITLE
test: fix non-null assertion lint on main from b9

### DIFF
--- a/apps/tauri/src/renderer/features/resume-builder/components/RepeatableList/RepeatableList.test.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/RepeatableList/RepeatableList.test.tsx
@@ -49,7 +49,9 @@ describe('RepeatableList', () => {
     const user = userEvent.setup();
     const { onChange } = setup([{ value: 'a' }, { value: 'b' }]);
     const removeButtons = screen.getAllByRole('button', { name: 'Remove item' });
-    await user.click(removeButtons[1]!);
+    const second = removeButtons[1];
+    expect(second).toBeDefined();
+    if (second) await user.click(second);
     expect(onChange).toHaveBeenCalledWith([{ value: 'a' }]);
   });
 


### PR DESCRIPTION
## What

Fix a `@typescript-eslint/no-non-null-assertion` violation that landed on `main` with the B9 résumé builder (#326): `RepeatableList.test.tsx` used `removeButtons[1]!`, which fails `lint:strict --max-warnings 0`.

## Why it slipped through

The fix was written during B9 but never entered the merged commit — a `git reset --soft` left the corrected file unstaged, and the **pre-push hook lints the working tree, not the index**, so the gate passed locally while the commit kept the assertion. Replaced with a defined-guard (`const second = removeButtons[1]; expect(second).toBeDefined(); if (second) ...`).

Test-only; no behavior change. `test:` type → no release.

## Verification

- `eslint RepeatableList.test.tsx --max-warnings 0` clean.
- RepeatableList tests pass.
- Pre-push full gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
