### PR TITLE
feat: add the recruiter cinematic short film to landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
   &nbsp;·&nbsp;
   <a href="https://saeedkolivand.github.io/ai-job-hunter-assistant-app/">🌐 Live site</a>
   &nbsp;·&nbsp;
+  <a href="https://saeedkolivand.github.io/ai-job-hunter-assistant-app/recruiter.html">🎬 Short film</a>
+  &nbsp;·&nbsp;
   <a href="#-installation">📦 Install</a>
   &nbsp;·&nbsp;
   <a href="#-features">✨ Features</a>

--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ See <a href="CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBU
 | <a href="CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a>                                                                                 | Code style, branching, PR process                                |
 | <a target="_blank" rel="noopener noreferrer" href="https://saeedkolivand.github.io/ai-job-hunter-assistant-app/how-it-works.html">landing/how-it-works.html</a>         | How the AI Job Hunter works end-to-end (interactive walkthrough) |
 | <a target="_blank" rel="noopener noreferrer" href="https://saeedkolivand.github.io/ai-job-hunter-assistant-app/architecture-map.html">landing/architecture-map.html</a> | Interactive architecture map of the AI Job Hunter                |
+| <a target="_blank" rel="noopener noreferrer" href="https://saeedkolivand.github.io/ai-job-hunter-assistant-app/recruiter.html">landing/recruiter.html</a>               | THE RECRUITER — a cinematic short film about the job hunt        |
 
 ---
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -769,6 +769,7 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
   <button class="cta" id="cta">ok fine, take the app →</button>
   <a class="src-link" href="https://github.com/saeedkolivand/ai-job-hunter-assistant-app">view the source — it's MIT, like my prospects: open and freely available.</a>
   <a class="src-link" href="film.html">▶ relive the breakdown as a short film — same despair, now with a soundtrack. your hands can rest.</a>
+  <a class="src-link" href="recruiter.html">▶ THE RECRUITER — a neon horror film about the thing that whispers “did you apply today?”</a>
   <p class="footnote">macOS will say the app is "damaged." it's not damaged. it's just unsigned — like a contract I was never offered. run <code>xattr -cr</code> and we move on.</p>
   <p class="builtwith">Tauri · Rust · React 19 · TanStack · LanceDB · Typst · Ollama · pure spite</p>
   <p class="byline">made by Saeed, between rejections.</p>

--- a/landing/recruiter.html
+++ b/landing/recruiter.html
@@ -1,0 +1,2573 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>THE RECRUITER — a neon short film</title>
+<meta name="description" content="A 4:24 cyberpunk dark comedy about the thing that whispers 'did you apply today?'. Fully procedural — every pixel and every note is synthesized in this one file.">
+<meta property="og:title" content="THE RECRUITER — a neon horror short about job hunting">
+<meta property="og:description" content="It starts as a whisper. It ends as a 195-item country dropdown with four United States. A film first, an ad last.">
+<meta property="og:type" content="video.other">
+<link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><path d='M16 3 C24 3 28 11 28 19 C28 27 23 30 16 30 C9 30 4 27 4 19 C4 11 8 3 16 3 Z' fill='%23090a12'/><path d='M9 6 L7 1 L12 4 Z M23 6 L25 1 L20 4 Z' fill='%23090a12'/><circle cx='16' cy='16' r='7' fill='%23ff2d96' opacity='.45'/><circle cx='16' cy='16' r='4.6' fill='%23ff2d96'/><circle cx='17.4' cy='14.8' r='1.7' fill='%23fff'/></svg>">
+<style>
+/* ============================================================
+   THE RECRUITER — a single-file cyberpunk short (4:24)
+   1920×1080 design frame scaled to the window. Three canvases
+   (bg parallax / world / fx), a DOM UI overlay, a CSS post
+   stack, and a Web Audio score. No network. No mercy.
+   ============================================================ */
+:root{
+  --display:'Arial Narrow','Helvetica Neue',Impact,'Segoe UI',Arial,sans-serif;
+  --ui:system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,'Cascadia Mono',Consolas,Menlo,monospace;
+  --mag:#ff2d96; --cyn:#23e6ff; --amb:#ffb14d; --ink:#0a0c14;
+}
+*{box-sizing:border-box; margin:0; padding:0}
+html,body{height:100%; overflow:hidden; background:#000}
+body{font-family:var(--ui); color:#dfe6f0; user-select:none; -webkit-user-select:none}
+a,button{cursor:pointer}
+button{font:inherit; color:inherit; background:none; border:0}
+
+/* ---------- the cinema frame ---------- */
+#frame{
+  position:absolute; left:50%; top:50%; width:1920px; height:1080px;
+  transform:translate(-50%,-50%) scale(var(--s,.5));
+  background:#000; overflow:hidden; --lb:132px;
+}
+#stage,#ui{position:absolute; inset:0}
+canvas{position:absolute; left:0; top:0; width:1920px; height:1080px}
+#ui{z-index:40; pointer-events:none}
+#ui a,#ui button{pointer-events:auto}
+
+/* ---------- post stack ---------- */
+#grade{position:absolute; inset:0; z-index:20; pointer-events:none; mix-blend-mode:soft-light}
+#desat{position:absolute; inset:0; z-index:21; pointer-events:none; background:#7e828c; mix-blend-mode:saturation; opacity:0}
+#vignette{position:absolute; inset:0; z-index:22; pointer-events:none;
+  background:radial-gradient(115% 95% at 50% 48%, transparent 58%, rgba(0,0,5,.52) 100%)}
+#grain{
+  position:absolute; inset:0; z-index:23; pointer-events:none; opacity:.085; mix-blend-mode:overlay;
+  background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='140' height='140' filter='url(%23n)'/></svg>");
+  animation:grain .42s steps(5) infinite;
+}
+@keyframes grain{
+  0%{background-position:0 0}20%{background-position:-38px 22px}40%{background-position:24px -44px}
+  60%{background-position:-50px -8px}80%{background-position:36px 38px}100%{background-position:0 0}
+}
+.lb{position:absolute; left:0; right:0; height:var(--lb); background:#000; z-index:50; pointer-events:none}
+#lbTop{top:0} #lbBot{bottom:0}
+
+/* ---------- neon type helpers ---------- */
+.neon{
+  font-family:var(--display); font-weight:900; text-transform:uppercase; color:#fff;
+  text-shadow:0 0 7px rgba(255,45,150,.95),0 0 26px rgba(255,45,150,.5),0 0 64px rgba(255,45,150,.35),
+    2.5px 0 0 rgba(255,45,150,.85),-2.5px 0 0 rgba(35,230,255,.85);
+}
+.neon-c{
+  font-family:var(--display); font-weight:900; text-transform:uppercase; color:#eafcff;
+  text-shadow:0 0 7px rgba(35,230,255,.9),0 0 28px rgba(35,230,255,.45),
+    2px 0 0 rgba(255,45,150,.7),-2px 0 0 rgba(35,230,255,.9);
+}
+
+/* ---------- title card ---------- */
+#title{position:absolute; left:0; right:0; top:34%; text-align:center; opacity:0}
+#title .t-kick{font-family:var(--mono); font-size:19px; letter-spacing:.55em; color:#6f7d92; text-transform:uppercase; margin-bottom:26px}
+#t-main{font-size:170px; line-height:.92; letter-spacing:.04em}
+#t-cred{font-family:var(--ui); font-style:italic; font-size:26px; color:#93a0b4; margin-top:30px; opacity:0}
+
+/* ---------- subtitles ---------- */
+#subs{
+  position:absolute; left:50%; bottom:calc(var(--lb) + 34px); transform:translateX(-50%);
+  max-width:1180px; text-align:center; z-index:52; padding:10px 26px; border-radius:10px;
+  background:rgba(2,4,10,.55); font-size:33px; line-height:1.35; color:#f2f5fa;
+  text-shadow:0 2px 4px rgba(0,0,0,.8); opacity:0; white-space:pre-line;
+}
+#subs.on{opacity:1}
+#subs.who-c{color:#ff9dcd; font-style:italic; letter-spacing:.06em;
+  text-shadow:0 0 14px rgba(255,45,150,.65),0 2px 4px rgba(0,0,0,.8)}
+#subs.who-s{font-family:var(--mono); font-size:28px; color:#a8f4ff;
+  text-shadow:0 0 12px rgba(35,230,255,.4),0 2px 4px rgba(0,0,0,.8)}
+#subs.who-b{font-family:var(--display); font-weight:900; font-size:42px; letter-spacing:.08em; color:#fff;
+  text-shadow:2px 0 0 rgba(255,45,150,.8),-2px 0 0 rgba(35,230,255,.8),0 2px 6px rgba(0,0,0,.9)}
+#subs.who-cap{font-style:italic; font-size:27px; color:#9aa7ba}
+#skysub{
+  position:absolute; left:0; right:0; top:26%; text-align:center; z-index:39; pointer-events:none;
+  font-family:var(--display); font-weight:900; font-size:108px; letter-spacing:.18em; color:#e8d7ff;
+  opacity:0; text-shadow:0 0 60px rgba(160,80,255,.5),3px 0 0 rgba(255,45,150,.35),-3px 0 0 rgba(35,230,255,.35);
+}
+
+/* ---------- popup pool (achievements / job cards / profiles / stamps) ---------- */
+.pop{position:absolute; opacity:0; will-change:transform,opacity; z-index:48}
+.pop .p-in{border-radius:12px; overflow:hidden}
+.pop.ach .p-in{
+  display:flex; align-items:center; gap:16px; padding:16px 26px 16px 18px;
+  background:linear-gradient(135deg, rgba(40,28,4,.92), rgba(24,16,2,.92));
+  border:1px solid rgba(255,200,90,.55); box-shadow:0 0 30px rgba(255,177,77,.25), inset 0 0 22px rgba(255,177,77,.08);
+}
+.pop.ach .a-cup{font-size:40px; filter:drop-shadow(0 0 10px rgba(255,200,90,.8))}
+.pop.ach .a-kick{font-family:var(--mono); font-size:13px; letter-spacing:.3em; color:#c8a96a; text-transform:uppercase}
+.pop.ach .a-name{font-family:var(--display); font-weight:900; font-size:30px; letter-spacing:.05em; color:#ffe9bd; text-transform:uppercase}
+.pop.job .p-in{
+  width:540px; padding:22px 26px;
+  background:linear-gradient(160deg, rgba(10,14,26,.94), rgba(16,8,24,.94));
+  border:1px solid rgba(35,230,255,.4); box-shadow:0 0 36px rgba(35,230,255,.18), inset 0 0 30px rgba(35,230,255,.05);
+}
+.pop.job .j-kick{font-family:var(--mono); font-size:14px; letter-spacing:.28em; color:#3fd9f2; text-transform:uppercase; margin-bottom:8px}
+.pop.job .j-title{font-family:var(--display); font-weight:900; font-size:33px; line-height:1.05; color:#fff; text-transform:uppercase; letter-spacing:.02em;
+  text-shadow:1.5px 0 0 rgba(255,45,150,.6),-1.5px 0 0 rgba(35,230,255,.6)}
+.pop.job .j-line{font-size:21px; color:#aeb9cc; margin-top:9px; font-family:var(--ui)}
+.pop.job .j-line b{color:#ff9dcd; font-weight:600}
+.pop.prof .p-in{
+  display:flex; align-items:center; gap:16px; width:520px; padding:16px 20px;
+  background:rgba(8,12,22,.93); border:1px solid rgba(120,150,200,.35); box-shadow:0 14px 40px rgba(0,0,0,.5);
+}
+.pop.prof .pr-av{width:64px; height:64px; border-radius:50%; background:#16202f; display:flex; align-items:center; justify-content:center; flex:none; border:2px solid rgba(35,230,255,.4)}
+.pop.prof .pr-av svg{width:42px; height:42px}
+.pop.prof .pr-name{font-size:24px; font-weight:700; color:#fff}
+.pop.prof .pr-name span{color:#3fd9f2; font-size:16px; font-family:var(--mono); margin-left:8px}
+.pop.prof .pr-line{font-size:18px; color:#9fb0c6; margin-top:3px}
+.pop.mini .p-in{width:330px; padding:10px 16px}
+.pop.mini .pr-av{width:40px; height:40px}.pop.mini .pr-av svg{width:26px;height:26px}
+.pop.mini .pr-name{font-size:18px}.pop.mini .pr-line{font-size:14px}
+.pop.err .p-in{
+  width:600px; padding:0; background:rgba(12,8,10,.95); border:1px solid rgba(255,80,90,.55);
+  box-shadow:0 0 36px rgba(255,60,80,.25);
+}
+.pop.err .e-bar{display:flex; align-items:center; gap:10px; padding:10px 16px; background:rgba(255,60,80,.14);
+  font-family:var(--mono); font-size:16px; color:#ff9aa6; letter-spacing:.12em; text-transform:uppercase}
+.pop.err .e-dot{width:11px; height:11px; border-radius:50%; background:#ff4456; box-shadow:0 0 10px #ff4456}
+.pop.err .e-body{padding:16px 20px; font-family:var(--mono); font-size:20px; line-height:1.55; color:#ffd9de}
+.pop.stamp{left:50%; top:46%}
+.pop.stamp .p-in{
+  border:6px solid #ff3b4e; border-radius:14px; padding:10px 38px; background:rgba(20,2,6,.25);
+  font-family:var(--display); font-weight:900; font-size:120px; letter-spacing:.1em; color:#ff3b4e; text-transform:uppercase;
+  text-shadow:0 0 34px rgba(255,59,78,.7); box-shadow:0 0 50px rgba(255,59,78,.35), inset 0 0 40px rgba(255,59,78,.15);
+}
+.pop.stampS .p-in{
+  border:4px solid #57e08b; border-radius:10px; padding:6px 22px; background:rgba(2,18,8,.4);
+  font-family:var(--display); font-weight:900; font-size:40px; letter-spacing:.1em; color:#57e08b; text-transform:uppercase;
+  text-shadow:0 0 18px rgba(87,224,139,.7);
+}
+.pop.auto .p-in{
+  padding:12px 22px; background:rgba(8,16,12,.92); border:1px solid rgba(87,224,139,.5);
+  font-family:var(--mono); font-size:22px; color:#9af0bd; box-shadow:0 0 22px rgba(87,224,139,.2);
+}
+
+/* ---------- fake OS window (act 2) ---------- */
+#oswin{position:absolute; left:50%; top:47%; width:640px; transform:translate(-50%,-50%); opacity:0; z-index:46;
+  background:rgba(14,18,30,.96); border:1px solid rgba(90,110,150,.45); border-radius:10px;
+  box-shadow:0 30px 80px rgba(0,0,0,.6), 0 0 40px rgba(35,230,255,.07); overflow:hidden}
+#oswin .ow-bar{display:flex; align-items:center; gap:8px; padding:10px 14px; background:rgba(28,34,52,.9);
+  font-family:var(--mono); font-size:15px; color:#8fa0bb}
+#oswin .ow-dot{width:11px; height:11px; border-radius:50%; background:#3a4458}
+#oswin .ow-dot.r{background:#ff5f57}#oswin .ow-dot.y{background:#febc2e}#oswin .ow-dot.g{background:#28c840}
+#oswin .ow-title{margin-left:8px; letter-spacing:.06em}
+#os-body{padding:18px 22px; min-height:150px}
+#os-body .ol{display:flex; align-items:flex-start; gap:12px; font-family:var(--mono); font-size:21px; line-height:1.5; color:#cfdaea; margin-bottom:10px}
+#os-body .ol .ic{flex:none; width:26px; text-align:center}
+#os-body .ol.bad{color:#ffb3bd}#os-body .ol.bad .ic{color:#ff4456}
+#os-body .ol.info .ic{color:#3fd9f2}
+#os-body .ol.cnt{color:#ffd9a3}#os-body .ol.cnt .ic{color:#ffb14d}
+#os-prog{height:8px; border-radius:4px; background:rgba(255,255,255,.08); overflow:hidden; margin-top:6px}
+#os-prog i{display:block; height:100%; width:0; background:linear-gradient(90deg,var(--cyn),var(--mag))}
+
+/* ---------- plain app window (act 6 — deliberately calm, zero neon) ---------- */
+#appwin{position:absolute; left:50%; top:46%; width:1010px; transform:translate(-50%,-50%); opacity:0; z-index:46;
+  background:#f4f6f9; color:#2a3242; border-radius:12px; overflow:hidden;
+  box-shadow:0 40px 90px rgba(0,0,0,.55); font-family:var(--ui)}
+#appwin .aw-bar{display:flex; align-items:center; gap:10px; padding:12px 18px; background:#e8ecf2; border-bottom:1px solid #d7dde6}
+#appwin .aw-dot{width:11px; height:11px; border-radius:50%; background:#c6cdd8}
+#appwin .aw-name{font-size:17px; font-weight:600; color:#3c4658; letter-spacing:.02em}
+#appwin .aw-sub{font-size:13px; color:#8a94a6; margin-left:auto; font-family:var(--mono)}
+#aw-grid{display:grid; grid-template-columns:1.15fr 1fr; gap:14px; padding:16px}
+.aw-pane{background:#fff; border:1px solid #e2e7ee; border-radius:9px; padding:12px 14px; min-height:170px}
+.aw-pane h3{font-size:13px; font-weight:700; letter-spacing:.14em; text-transform:uppercase; color:#7b8698; margin-bottom:10px}
+.aw-row{display:flex; align-items:center; gap:9px; padding:7px 9px; border-radius:6px; background:#f3f6fa; margin-bottom:7px; font-size:15px; color:#39445a; opacity:0}
+.aw-row .dot{width:8px; height:8px; border-radius:50%; background:#57b06f; flex:none}
+.aw-row .fade{color:#94a0b4; margin-left:auto; font-size:13px; font-family:var(--mono)}
+.aw-chip{display:inline-block; padding:5px 11px; border-radius:14px; background:#eef1f6; font-size:13px; color:#4a5670; margin:0 6px 7px 0; border:1px solid #e0e6ee; position:relative; transition:none}
+.aw-chip.done{background:#e2f4e8; border-color:#bfe5cc; color:#2f6e44}
+#aw-letter{font-size:14.5px; line-height:1.6; color:#4a5468; white-space:pre-wrap; font-family:var(--ui)}
+#aw-letter i{display:inline-block; width:9px; height:17px; background:#5a8ef0; vertical-align:-3px}
+.aw-field{display:flex; align-items:center; gap:8px; margin-bottom:8px; font-size:14px; color:#6c7790}
+.aw-field .lab{width:96px; flex:none; text-align:right; font-size:12.5px; color:#94a0b4}
+.aw-field .box{flex:1; height:26px; border:1px solid #dde3ec; border-radius:5px; background:#fbfcfe; padding:3px 8px; font-size:13.5px; color:#39445a; overflow:hidden; white-space:nowrap}
+
+/* ---------- evolution nameplate ---------- */
+#nameplate{position:absolute; left:96px; bottom:calc(var(--lb) + 110px); opacity:0; z-index:47}
+#nameplate .np-kick{font-family:var(--mono); font-size:17px; letter-spacing:.5em; color:#ff7ab8; text-transform:uppercase}
+#nameplate .np-name{font-family:var(--display); font-weight:900; font-size:96px; line-height:1; letter-spacing:.03em; color:#fff; text-transform:uppercase;
+  text-shadow:3px 0 0 rgba(255,45,150,.85),-3px 0 0 rgba(35,230,255,.85),0 0 40px rgba(255,45,150,.4)}
+#nameplate .np-sub{font-family:var(--ui); font-style:italic; font-size:24px; color:#a9b4c8; margin-top:10px}
+
+/* ---------- boss UI ---------- */
+#bossbar{position:absolute; left:50%; top:calc(var(--lb) + 30px); transform:translateX(-50%); width:880px; opacity:0; z-index:47}
+#bossbar .bb-row{display:flex; align-items:baseline; gap:14px; margin-bottom:8px}
+#bossbar .bb-tag{font-family:var(--display); font-weight:900; font-size:34px; letter-spacing:.22em; color:#fff; text-transform:uppercase;
+  text-shadow:2px 0 0 rgba(255,45,150,.8),-2px 0 0 rgba(35,230,255,.8)}
+#bossbar .bb-owner{font-family:var(--mono); font-size:18px; color:#ff9dcd; letter-spacing:.12em}
+#bossbar .bb-track{height:22px; border:2px solid rgba(255,255,255,.65); border-radius:11px; padding:3px; background:rgba(0,0,0,.5); box-shadow:0 0 26px rgba(255,45,150,.25)}
+#bb-fill{height:100%; width:100%; border-radius:6px; background:linear-gradient(90deg,#ffd166,#ff2d96); box-shadow:0 0 14px rgba(255,150,80,.6)}
+
+/* ---------- country dropdown of despair ---------- */
+#dd{position:absolute; right:170px; top:30%; width:470px; opacity:0; z-index:47;
+  background:rgba(10,13,24,.96); border:1px solid rgba(120,140,190,.5); border-radius:10px; overflow:hidden;
+  box-shadow:0 30px 70px rgba(0,0,0,.6)}
+#dd .dd-head{padding:12px 16px; font-family:var(--mono); font-size:17px; color:#9fb0c6; background:rgba(30,36,56,.9); letter-spacing:.08em}
+#dd .dd-head b{color:#ff4456}
+#dd .dd-clip{height:330px; overflow:hidden; position:relative}
+#dd ul{list-style:none}
+#dd li{padding:9px 18px; font-family:var(--ui); font-size:20px; color:#c4cfdf; border-bottom:1px solid rgba(255,255,255,.04)}
+#dd li.us{color:#ffd9a3}
+#dd .dd-fadeT,#dd .dd-fadeB{position:absolute; left:0; right:0; height:46px; pointer-events:none}
+#dd .dd-fadeT{top:0; background:linear-gradient(rgba(10,13,24,1),transparent)}
+#dd .dd-fadeB{bottom:0; background:linear-gradient(transparent,rgba(10,13,24,1))}
+
+/* ---------- act 7 text cards ---------- */
+.tcard{position:absolute; left:0; right:0; top:44%; text-align:center; opacity:0; z-index:48;
+  font-family:var(--display); font-weight:900; font-size:74px; letter-spacing:.04em; color:#fff; text-transform:uppercase;
+  text-shadow:0 2px 30px rgba(0,0,0,.6)}
+#tc3 a{
+  color:#fff; text-decoration:none; font-size:106px; letter-spacing:.05em;
+  text-shadow:0 0 10px rgba(255,177,77,.8),0 0 44px rgba(255,141,60,.45),2px 0 0 rgba(255,45,150,.5),-2px 0 0 rgba(35,230,255,.5);
+  border-bottom:3px solid rgba(255,177,77,.45); padding-bottom:6px;
+}
+#tc3 .tc-cap{font-family:var(--ui); font-weight:400; font-style:italic; text-transform:none; letter-spacing:0;
+  font-size:27px; color:#d7c6b2; margin-top:34px; opacity:0}
+
+/* ---------- HUD ---------- */
+#mute{position:absolute; top:20px; right:20px; z-index:80; width:46px; height:46px; display:flex; align-items:center; justify-content:center;
+  background:rgba(8,10,18,.65); border:1px solid rgba(255,255,255,.16); border-radius:10px; color:#cfd6e0; pointer-events:auto}
+#mute:hover{background:rgba(24,28,42,.85)}
+#mute svg{width:25px; height:25px}
+#mute .slash{display:none}
+#mute.muted{color:#7e8a9c}
+#mute.muted .waves{display:none}
+#mute.muted .slash{display:block}
+#timecode{position:absolute; left:22px; bottom:16px; z-index:80; font-family:var(--mono); font-size:17px; color:#7d8a9e;
+  background:rgba(5,7,12,.55); padding:5px 12px; border-radius:7px; letter-spacing:.06em}
+#pausedBadge{position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); z-index:81; display:none;
+  font-family:var(--mono); font-size:21px; letter-spacing:.3em; color:#cfe2ef; text-transform:uppercase;
+  background:rgba(5,7,12,.7); border:1px solid rgba(255,255,255,.18); padding:14px 26px 14px 32px; border-radius:12px}
+body.paused.started #pausedBadge{display:block}
+.hud{opacity:0; transition:opacity .5s}
+body.started .hud{opacity:1}
+
+/* ---------- poster (start gate) ---------- */
+#poster{position:fixed; inset:0; z-index:200; display:flex; flex-direction:column; align-items:center; justify-content:center;
+  gap:26px; background:radial-gradient(80% 90% at 50% 30%, #101426 0%, #05060c 55%, #000 100%); text-align:center;
+  transition:opacity .7s, visibility .7s; padding:24px}
+#poster.gone{opacity:0; visibility:hidden}
+#poster .pk{font-family:var(--mono); font-size:15px; letter-spacing:.5em; color:#66748c; text-transform:uppercase}
+#poster h1{font-size:clamp(54px, 11vw, 150px); line-height:.95; animation:posterflick 3.2s infinite}
+@keyframes posterflick{
+  0%,100%{opacity:1} 92%{opacity:1} 93%{opacity:.55} 94%{opacity:1} 96%{opacity:.7} 97%{opacity:1}
+}
+#poster .peye{width:72px; height:72px; border-radius:50%; position:relative;
+  background:radial-gradient(circle at 50% 50%, #fff 0%, #ff2d96 28%, rgba(255,45,150,.25) 62%, transparent 75%);
+  box-shadow:0 0 50px rgba(255,45,150,.6); animation:eyepulse 2.6s ease-in-out infinite}
+@keyframes eyepulse{0%,100%{transform:scale(1)}50%{transform:scale(.86)}}
+#poster .ps{font-size:clamp(15px,2.4vw,22px); color:#9aa7bb; font-style:italic; max-width:52ch}
+#play{
+  display:flex; align-items:center; gap:14px; padding:18px 44px; border-radius:999px;
+  border:2px solid rgba(35,230,255,.55); background:rgba(10,16,28,.6); color:#eafcff;
+  font-family:var(--display); font-weight:900; font-size:26px; letter-spacing:.3em; text-transform:uppercase;
+  box-shadow:0 0 34px rgba(35,230,255,.22), inset 0 0 22px rgba(35,230,255,.08); transition:transform .15s, box-shadow .15s;
+}
+#play:hover{transform:scale(1.05); box-shadow:0 0 50px rgba(35,230,255,.4), inset 0 0 30px rgba(35,230,255,.14)}
+#play .tri{width:0; height:0; border-left:20px solid #eafcff; border-top:12px solid transparent; border-bottom:12px solid transparent}
+#poster .pn{font-family:var(--mono); font-size:14px; color:#5d6a80; line-height:1.8; max-width:64ch}
+#poster .rotate{display:none; font-family:var(--mono); font-size:14px; color:#ffb14d}
+@media (max-aspect-ratio:9/10){ #poster .rotate{display:block} }
+
+/* ---------- end card ---------- */
+#endcard{position:fixed; inset:0; z-index:190; display:flex; flex-direction:column; align-items:center; justify-content:center;
+  gap:24px; background:rgba(2,3,7,.92); text-align:center; opacity:0; visibility:hidden; transition:opacity 1.2s, visibility 1.2s; padding:24px}
+#endcard.show{opacity:1; visibility:visible}
+#endcard .ek{font-family:var(--mono); font-size:14px; letter-spacing:.5em; color:#66748c; text-transform:uppercase}
+#endcard h2{font-size:clamp(40px,7vw,92px)}
+#replay{
+  padding:14px 36px; border-radius:999px; border:2px solid rgba(255,45,150,.5); background:rgba(28,10,22,.5);
+  color:#ffd7ea; font-family:var(--display); font-weight:900; font-size:20px; letter-spacing:.26em; text-transform:uppercase;
+}
+#replay:hover{box-shadow:0 0 30px rgba(255,45,150,.35)}
+#endcard .by{font-size:clamp(16px,2.4vw,21px); color:#9aa7bb}
+#endcard .by a{color:#ffcf9a; text-decoration:none; border-bottom:1px solid rgba(255,177,77,.5)}
+#endcard .by a:hover{color:#ffe5c4}
+#endcard .moral{font-style:italic; font-size:15px; color:#5d6a80; font-family:var(--mono)}
+
+/* ---------- reduced motion ---------- */
+@media (prefers-reduced-motion: reduce){
+  #grain{animation:none}
+  #poster h1{animation:none}
+  #poster .peye{animation:none}
+}
+</style>
+</head>
+<body>
+
+<div id="frame">
+  <div id="stage">
+    <canvas id="bg" width="960" height="540"></canvas>
+    <canvas id="world"></canvas>
+    <canvas id="fx"></canvas>
+    <div id="grade"></div>
+    <div id="desat"></div>
+    <div id="vignette"></div>
+    <div id="grain"></div>
+  </div>
+
+  <div id="ui">
+    <div id="skysub">DID YOU APPLY TODAY?</div>
+
+    <div id="title">
+      <div class="t-kick">AI Job Hunter presents</div>
+      <h1 id="t-main" class="neon">The Recruiter</h1>
+      <div id="t-cred">a film about checking your email</div>
+    </div>
+
+    <div id="oswin" aria-hidden="true">
+      <div class="ow-bar"><span class="ow-dot r"></span><span class="ow-dot y"></span><span class="ow-dot g"></span>
+        <span class="ow-title" id="os-title">careers portal — tab 47 of 47</span></div>
+      <div id="os-body"></div>
+    </div>
+
+    <div id="appwin" aria-hidden="true">
+      <div class="aw-bar"><span class="aw-dot"></span><span class="aw-dot"></span><span class="aw-dot"></span>
+        <span class="aw-name">AI Job Hunter</span><span class="aw-sub" id="aw-sub">local · quiet · yours</span></div>
+      <div id="aw-grid">
+        <div class="aw-pane"><h3 id="aw-h1">jobs found while you slept</h3><div id="aw-jobs"></div></div>
+        <div class="aw-pane"><h3>application tracker</h3><div id="aw-track"></div>
+          <h3 style="margin-top:12px">autofill</h3><div id="aw-fields"></div></div>
+        <div class="aw-pane" style="grid-column:1 / -1; min-height:120px"><h3>cover letter — draft 1</h3><div id="aw-letter"></div></div>
+      </div>
+    </div>
+
+    <div id="nameplate" aria-hidden="true">
+      <div class="np-kick">— it evolved —</div>
+      <div class="np-name" id="np-name"></div>
+      <div class="np-sub" id="np-sub"></div>
+    </div>
+
+    <div id="bossbar" aria-hidden="true">
+      <div class="bb-row"><span class="bb-tag">Patience</span><span class="bb-owner" id="bb-owner"></span></div>
+      <div class="bb-track"><div id="bb-fill"></div></div>
+    </div>
+
+    <div id="dd" aria-hidden="true">
+      <div class="dd-head">country / region <b>*</b> &nbsp;<span style="opacity:.6">(195 options)</span></div>
+      <div class="dd-clip"><ul id="dd-list"></ul><div class="dd-fadeT"></div><div class="dd-fadeB"></div></div>
+    </div>
+
+    <div class="tcard" id="tc1">The job market is still insane.</div>
+    <div class="tcard" id="tc2">You don't have to be.</div>
+    <div class="tcard" id="tc3"><a href="index.html">AI Job Hunter</a><div class="tc-cap">let the machine handle the repetitive part.</div></div>
+
+    <div id="pops"></div>
+    <div id="subs" role="status" aria-live="polite"></div>
+  </div>
+
+  <div class="lb" id="lbTop"></div>
+  <div class="lb" id="lbBot"></div>
+
+  <button id="mute" class="hud" aria-label="mute the film" aria-pressed="false" title="mute">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M11 5 6 9H3v6h3l5 4z" fill="currentColor" stroke="none"></path>
+      <path class="waves" d="M15.5 8.5a5 5 0 0 1 0 7"></path>
+      <path class="waves" d="M18 6a8.5 8.5 0 0 1 0 12"></path>
+      <line class="slash" x1="4" y1="4" x2="20" y2="20"></line>
+    </svg>
+  </button>
+  <div id="timecode" class="hud" aria-hidden="true">00:00 / 04:24</div>
+  <div id="pausedBadge">⏸ paused — click to resume</div>
+</div>
+
+<div id="poster">
+  <div class="pk">AI Job Hunter presents</div>
+  <h1 class="neon">The Recruiter</h1>
+  <div class="peye" aria-hidden="true"></div>
+  <p class="ps">a dark comedy about the thing that whispers “did you apply today?”</p>
+  <button id="play" aria-label="play the film"><span class="tri" aria-hidden="true"></span>Play</button>
+  <p class="pn">4 min 24 s · all sound synthesized in your browser · headphones recommended<br>
+    click to pause · ← → to skip · subtitles always on · soft flashes only (≤3/s)</p>
+  <p class="rotate">↻ rotate your phone — this is a widescreen film</p>
+</div>
+
+<div id="endcard">
+  <div class="ek">you made it to the credits</div>
+  <h2 class="neon">The Recruiter</h2>
+  <button id="replay">↻ watch it again</button>
+  <p class="by">presented by <a href="index.html">AI Job Hunter</a> — it finds, tracks, and drafts. you press send.</p>
+  <p class="moral">the monster was a dropdown all along.</p>
+</div>
+
+<script>
+/* devtools easter egg — the house always notices */
+(function(){
+  try{
+    var head='background:#0a0c14;color:#ff2d96;font:bold 14px/2.4 monospace;padding:4px 10px;border:1px solid #ff2d96';
+    var link='color:#23e6ff;font:13px/1.7 monospace';
+    var soft='color:#66748c;font:12px/1.7 monospace';
+    console.log('%c THE RECRUITER — IT KNOWS YOU OPENED THIS ', head);
+    console.log('%cyou opened devtools on a horror film. brave. the monster in here is a country dropdown with 195 options, four United States, and not yours. the exorcism kit is open source: https://github.com/saeedkolivand/ai-job-hunter-assistant-app', link);
+    console.log('%c(every pixel and every note in this file is procedural. no requests were made. unlike the 47 mandatory questions.)', soft);
+  }catch(e){}
+})();
+
+(function(){
+'use strict';
+
+/* ============================ CORE ============================ */
+var T=264;                                  /* runtime, seconds (4:24) */
+var W=1920, H=1080;                         /* design frame */
+var reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
+var small=Math.min(innerWidth,innerHeight)<700;
+var PFAC=(reduce?0.25:1)*(small?0.5:1);     /* particle budget factor */
+
+var $=function(s){return document.querySelector(s)};
+function clamp(v,a,b){return v<a?a:(v>b?b:v)}
+function lerp(a,b,k){return a+(b-a)*k}
+function sm(a,b,v){v=clamp((v-a)/(b-a),0,1); return v*v*(3-2*v)}  /* smoothstep window */
+function eo(k){return 1-Math.pow(1-clamp(k,0,1),3)}               /* easeOut cubic */
+function ei(k){k=clamp(k,0,1); return k*k*k}
+function eio(k){k=clamp(k,0,1); return k<.5?4*k*k*k:1-Math.pow(-2*k+2,3)/2}
+function hash(n){var s=Math.sin(n*127.1+311.7)*43758.5453; return s-Math.floor(s)}  /* deterministic 0..1 */
+function fmt(s){s=Math.max(0,Math.floor(s)); return (''+((s/60)|0)).padStart(2,'0')+':'+(''+(s%60)).padStart(2,'0')}
+
+var frame=$('#frame');
+var bgC=$('#bg'), worldC=$('#world'), fxC=$('#fx');
+var bg=bgC.getContext('2d'), wd=worldC.getContext('2d'), fx=fxC.getContext('2d');
+var BS=small?1:Math.min(devicePixelRatio||1,1.5);  /* world/fx backing scale */
+worldC.width=W*BS; worldC.height=H*BS;
+fxC.width=W*BS;    fxC.height=H*BS;
+
+function fit(){
+  var s=Math.min(innerWidth/W, innerHeight/H);
+  frame.style.setProperty('--s', s.toFixed(4));
+}
+addEventListener('resize', fit); fit();
+
+/* film clock */
+var tNow=0, playing=false, started=false, ended=false, lastSeek=-99;
+
+/* camera — scenes write into this every frame (fully derived from t) */
+var cam={x:W/2, y:H/2, z:1, lb:132, vx:0, vy:0, px:W/2, py:H/2};
+var shakes=[];                               /* {t0, amp, freq} impulses (cue-fired) */
+function shake(amp,freq){ if(!reduce) shakes.push({t0:tNow, amp:amp, freq:freq||23}) }
+function shakeOff(){
+  var sx=0, sy=0;
+  for(var i=shakes.length-1;i>=0;i--){
+    var s=shakes[i], a=tNow-s.t0;
+    if(a<0||a>0.9){ shakes.splice(i,1); continue; }
+    var d=s.amp*Math.exp(-a*6);
+    sx+=Math.sin(a*s.freq*7.1)*d; sy+=Math.cos(a*s.freq*5.3)*d;
+  }
+  return [sx,sy];
+}
+/* world-space view transform for the current camera */
+function view(ctx,par){
+  par=par||1;
+  var o=shakeOff();
+  var cx=lerp(W/2,cam.x,par), cy=lerp(H/2,cam.y,par);
+  ctx.setTransform(BS*cam.z,0,0,BS*cam.z, BS*(W/2-cam.z*cx+o[0]), BS*(H/2-cam.z*cy+o[1]));
+}
+function uiSpace(ctx){ ctx.setTransform(BS,0,0,BS,0,0) }
+
+/* ============================ AUDIO ============================ */
+/* master → compressor → out. buses: music / amb / sfx / voice.
+   space = cheap reverb (delay+feedback+LP) fed per-call.        */
+var A=(function(){
+  var ac=null, master=null, comp=null, music=null, amb=null, sfx=null, voice=null;
+  var spaceIn=null;
+  var noiseBuf=null, brownBuf=null;
+  var muted=false;
+  var rainSrc=null, rainLP=null, rainG=null, humG=null, fireG=null, droneG=null;
+  var pad=null, padG=null, padLP=null;
+  var seqH=null, stepIdx=0, nextStep=0;
+  var STEP=60/96/4;                          /* 96 BPM sixteenths */
+
+  function ctx(){ return ac }
+  function init(){
+    if(ac) return;
+    ac=new (window.AudioContext||window.webkitAudioContext)();
+    /* iOS unlock: one silent sample */
+    var b=ac.createBuffer(1,1,22050), s=ac.createBufferSource(); s.buffer=b; s.connect(ac.destination); s.start(0);
+    comp=ac.createDynamicsCompressor(); comp.threshold.value=-18; comp.ratio.value=6; comp.connect(ac.destination);
+    master=ac.createGain(); master.gain.value=muted?0.0001:1; master.connect(comp);
+    music=ac.createGain(); music.gain.value=0.0001; music.connect(master);
+    amb=ac.createGain();   amb.gain.value=0.0001;   amb.connect(master);
+    sfx=ac.createGain();   sfx.gain.value=0.9;      sfx.connect(master);
+    voice=ac.createGain(); voice.gain.value=1;      voice.connect(master);
+    /* space send */
+    spaceIn=ac.createGain(); spaceIn.gain.value=1;
+    var dly=ac.createDelay(1); dly.delayTime.value=0.16;
+    var fb=ac.createGain(); fb.gain.value=0.35;
+    var lp=ac.createBiquadFilter(); lp.type='lowpass'; lp.frequency.value=2000;
+    spaceIn.connect(dly); dly.connect(lp); lp.connect(fb); fb.connect(dly); lp.connect(master);
+    /* noise buffers */
+    var len=2*ac.sampleRate, i;
+    noiseBuf=ac.createBuffer(1,len,ac.sampleRate);
+    var d=noiseBuf.getChannelData(0);
+    for(i=0;i<len;i++) d[i]=Math.random()*2-1;
+    brownBuf=ac.createBuffer(1,len,ac.sampleRate);
+    var bd=brownBuf.getChannelData(0), v=0;
+    for(i=0;i<len;i++){ v=(v+(Math.random()*2-1)*0.02); v*=0.998; bd[i]=v*3.5; }
+    startBeds();
+  }
+  /* --- helpers --- */
+  function G(v,dest){ var x=ac.createGain(); x.gain.value=v; x.connect(dest||sfx); return x }
+  function osc(type,f){ var o=ac.createOscillator(); o.type=type; o.frequency.value=f; return o }
+  function noise(){ var s=ac.createBufferSource(); s.buffer=noiseBuf; s.loop=true; return s }
+  function bye(src,root){ src.onended=function(){ try{root.disconnect()}catch(e){} } }
+  function env(g,t0,a,peak,rel,end){
+    g.gain.setValueAtTime(0.0001,t0);
+    g.gain.linearRampToValueAtTime(peak,t0+a);
+    g.gain.exponentialRampToValueAtTime(0.0001,t0+a+rel);
+    if(end) g.gain.setValueAtTime(0.0001,end);
+  }
+  function hz(m){ return 440*Math.pow(2,(m-69)/12) }
+
+  /* --- continuous beds (created once, gain-automated) --- */
+  function startBeds(){
+    /* rain */
+    rainSrc=noise(); rainLP=ac.createBiquadFilter(); rainLP.type='lowpass'; rainLP.frequency.value=2600; rainLP.Q.value=0.4;
+    var rhp=ac.createBiquadFilter(); rhp.type='highpass'; rhp.frequency.value=500;
+    rainG=G(0.0001,amb); rainSrc.connect(rhp); rhp.connect(rainLP); rainLP.connect(rainG); rainSrc.start();
+    /* city hum */
+    var br=ac.createBufferSource(); br.buffer=brownBuf; br.loop=true;
+    var blp=ac.createBiquadFilter(); blp.type='lowpass'; blp.frequency.value=300;
+    humG=G(0.0001,amb); br.connect(blp); blp.connect(humG); br.start();
+    var fifty=osc('sine',50), fg=G(0.012,humG); fifty.connect(fg); fifty.start();
+    /* dragon fire crackle (act 3) */
+    var fn=noise(); var fbp=ac.createBiquadFilter(); fbp.type='bandpass'; fbp.frequency.value=900; fbp.Q.value=0.6;
+    fireG=G(0.0001,sfx); fn.connect(fbp); fbp.connect(fireG); fn.start();
+    /* boss drone (act 5): 3 detuned saws + sub + slow LP wobble */
+    droneG=G(0.0001,music);
+    var dlp=ac.createBiquadFilter(); dlp.type='lowpass'; dlp.frequency.value=600; dlp.Q.value=4;
+    var lfo=osc('sine',0.15), lg=G(280,dlp.frequency); lfo.connect(lg); lfo.start();
+    [-12,0,12].forEach(function(c){
+      var o=osc('sawtooth',hz(28)); o.detune.value=c; var og=G(0.16,dlp); o.connect(og); o.start();
+    });
+    var sub=osc('sine',hz(16)), sg=G(0.4,droneG); sub.connect(sg); sub.start();
+    dlp.connect(droneG);
+    /* score pad: 3 osc through LP into music */
+    padLP=ac.createBiquadFilter(); padLP.type='lowpass'; padLP.frequency.value=700; padLP.Q.value=0.3;
+    padG=G(0.24,music); padLP.connect(padG);
+    pad=[0,1,2].map(function(i){
+      var o=osc('triangle',hz([45,60,64][i])); o.detune.value=(i-1)*6;
+      var g=G(0.3,padLP); o.connect(g); o.start();
+      return o;
+    });
+  }
+
+  /* --- one-shots --- */
+  function ding(vol){
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sine',1318), o2=osc('sine',1976);
+    var g=G(0.0001,sfx); env(g,t,0.004,(vol||0.12),0.5);
+    o.connect(g); o2.connect(g); o.start(t); o2.start(t); o.stop(t+0.6); o2.stop(t+0.6); bye(o,g);
+  }
+  function error(){
+    if(!ac) return;
+    var t=ac.currentTime;
+    [622.25,440].forEach(function(f,i){
+      var o=osc('square',f), g=G(0.0001,sfx);
+      env(g,t+i*0.16,0.006,0.07,0.18);
+      var lp=ac.createBiquadFilter(); lp.type='lowpass'; lp.frequency.value=2200;
+      o.connect(lp); lp.connect(g); o.start(t+i*0.16); o.stop(t+i*0.16+0.25); bye(o,g);
+    });
+  }
+  function chirp(){               /* the creature grows a little */
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('triangle',520), g=G(0.0001,voice);
+    o.frequency.linearRampToValueAtTime(940,t+0.09);
+    env(g,t,0.008,0.07,0.12);
+    o.connect(g); g.connect(spaceIn); o.start(t); o.stop(t+0.16); bye(o,g);
+  }
+  function pop(){
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sine',330), g=G(0.0001,sfx);
+    o.frequency.exponentialRampToValueAtTime(80,t+0.07); env(g,t,0.004,0.16,0.09);
+    o.connect(g); o.start(t); o.stop(t+0.12); bye(o,g);
+  }
+  function buzz(dur){             /* neon sign struggling */
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sawtooth',100), am=osc('square',13);
+    var ag=G(0.5,null); ag.disconnect(); var g=G(0.0001,sfx);
+    var bp=ac.createBiquadFilter(); bp.type='bandpass'; bp.frequency.value=800; bp.Q.value=2;
+    am.connect(ag.gain); o.connect(ag); ag.connect(bp); bp.connect(g);
+    env(g,t,0.01,0.05,dur||0.4);
+    o.start(t); am.start(t); o.stop(t+(dur||0.4)+0.1); am.stop(t+(dur||0.4)+0.1); bye(o,g);
+  }
+  function zap(){
+    if(!ac) return;
+    var t=ac.currentTime;
+    for(var i=0;i<3;i++){
+      var o=osc('square',200), g=G(0.0001,sfx);
+      o.frequency.exponentialRampToValueAtTime(1800,t+i*0.07+0.05);
+      env(g,t+i*0.07,0.004,0.05,0.05);
+      o.connect(g); o.start(t+i*0.07); o.stop(t+i*0.07+0.09); bye(o,g);
+    }
+  }
+  function train(near){           /* detuned saws + hiss, doppler pan */
+    if(!ac) return;
+    var t=ac.currentTime, dur=near?2.2:3.4, vol=near?0.22:0.085;
+    var p=ac.createStereoPanner?ac.createStereoPanner():null;
+    var g=G(0.0001,sfx); var root=p||g;
+    if(p){ p.pan.setValueAtTime(-1,t); p.pan.linearRampToValueAtTime(1,t+dur); p.connect(g); }
+    [0,9].forEach(function(c){
+      var o=osc('sawtooth',near?110:160); o.detune.value=c*3;
+      o.frequency.setValueAtTime(near?110:160,t);
+      o.frequency.linearRampToValueAtTime((near?110:160)*0.85,t+dur);   /* doppler drop */
+      var og=G(0.5,root); o.connect(og); o.start(t); o.stop(t+dur); bye(o,og);
+    });
+    var n=noise(), nb=ac.createBiquadFilter(); nb.type='bandpass'; nb.frequency.value=near?900:1600; nb.Q.value=0.5;
+    var ng=G(0.6,root); n.connect(nb); nb.connect(ng); n.start(t); n.stop(t+dur);
+    g.gain.setValueAtTime(0.0001,t); g.gain.linearRampToValueAtTime(vol,t+dur*0.4);
+    g.gain.linearRampToValueAtTime(0.0001,t+dur);
+    g.connect(spaceIn);
+  }
+  function horn(){                /* distant train horn — act 7 callback */
+    if(!ac) return;
+    var t=ac.currentTime, g=G(0.0001,sfx);
+    [220,277.18].forEach(function(f){
+      var o=osc('sine',f), og=G(0.5,g); o.connect(og);
+      o.frequency.linearRampToValueAtTime(f*0.97,t+1.6);
+      o.start(t); o.stop(t+1.8); bye(o,og);
+    });
+    g.gain.linearRampToValueAtTime(0.05,t+0.5); g.gain.linearRampToValueAtTime(0.0001,t+1.7);
+    g.connect(spaceIn);
+  }
+  function whisper(opt){          /* noise shaped to syllables — never words */
+    if(!ac) return;
+    opt=opt||{};
+    var t=ac.currentTime, n=opt.syl||4, size=opt.size||0.1, vol=opt.vol||0.16;
+    var slow=opt.slow||1, send=0.12+0.6*size;
+    for(var i=0;i<n;i++){
+      var t0=t+i*(0.16*slow)+hash(i*7+1)*0.04;
+      var dur=(0.1+hash(i*3+2)*0.08)*slow;
+      var s=noise();
+      var b1=ac.createBiquadFilter(); b1.type='bandpass'; b1.Q.value=6;
+      b1.frequency.value=(760-360*size)*(0.85+hash(i)*0.4);
+      var b2=ac.createBiquadFilter(); b2.type='bandpass'; b2.Q.value=8;
+      b2.frequency.value=(2300-900*size)*(0.85+hash(i+9)*0.4);
+      if(opt.gargle){ var lf=osc('sine',11), lg=G(b1.frequency.value*0.4,b1.frequency); lf.connect(lg); lf.start(t0); lf.stop(t0+dur+0.05); }
+      var g=G(0.0001,voice); env(g,t0,0.02,vol,dur);
+      var sg=G(send,spaceIn);
+      s.connect(b1); s.connect(b2); b1.connect(g); b2.connect(g); g.connect(sg);
+      s.start(t0); s.stop(t0+dur+0.08); bye(s,g);
+    }
+  }
+  function bossVoice(n){          /* bitcrushed square bursts — the hydra asks */
+    if(!ac) return;
+    var t=ac.currentTime, sh=ac.createWaveShaper(), curve=new Float32Array(64);
+    for(var i=0;i<64;i++) curve[i]=Math.round(((i/63)*2-1)*4)/4;
+    sh.curve=curve;
+    var bp=ac.createBiquadFilter(); bp.type='bandpass'; bp.frequency.value=820; bp.Q.value=1.4;
+    var g=G(0.0001,voice); sh.connect(bp); bp.connect(g); g.connect(spaceIn);
+    for(var k=0;k<(n||6);k++){
+      var t0=t+k*0.11, o=osc('square',75+hash(k)*60);
+      env2(g,t0,0.008,0.12,0.07);
+      o.connect(sh); o.start(t0); o.stop(t0+0.09); bye(o,g);
+    }
+  }
+  function env2(g,t0,a,peak,rel){ /* additive re-trigger envelope */
+    g.gain.setValueAtTime(0.0001,t0); g.gain.linearRampToValueAtTime(peak,t0+a);
+    g.gain.exponentialRampToValueAtTime(0.0001,t0+a+rel);
+  }
+  function levelup(){
+    if(!ac) return;
+    var t=ac.currentTime;
+    var o=osc('sawtooth',110), g=G(0.0001,sfx);
+    o.frequency.exponentialRampToValueAtTime(440,t+0.5);
+    env(g,t,0.01,0.12,0.55);
+    var lp=ac.createBiquadFilter(); lp.type='lowpass'; lp.frequency.value=2400;
+    o.connect(lp); lp.connect(g); g.connect(spaceIn); o.start(t); o.stop(t+0.7); bye(o,g);
+    var n=noise(), nb=ac.createBiquadFilter(); nb.type='bandpass'; nb.Q.value=1; nb.frequency.setValueAtTime(300,t);
+    nb.frequency.exponentialRampToValueAtTime(4000,t+0.45);
+    var ng=G(0.0001,sfx); env(ng,t,0.02,0.1,0.5); n.connect(nb); nb.connect(ng); n.start(t); n.stop(t+0.6);
+    thump(0.4);
+  }
+  function thump(v){
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sine',95), g=G(0.0001,sfx);
+    o.frequency.exponentialRampToValueAtTime(38,t+0.22); env(g,t,0.005,v||0.3,0.3);
+    o.connect(g); o.start(t); o.stop(t+0.4); bye(o,g);
+  }
+  function achieve(){
+    if(!ac) return;
+    var t=ac.currentTime;
+    [523.25,659.25,783.99,1046.5].forEach(function(f,i){
+      var o=osc('triangle',f), g=G(0.0001,sfx);
+      env(g,t+i*0.085,0.006,0.09,0.4);
+      o.connect(g); g.connect(spaceIn); o.start(t+i*0.085); o.stop(t+i*0.085+0.5); bye(o,g);
+    });
+    var n=noise(), hp=ac.createBiquadFilter(); hp.type='highpass'; hp.frequency.value=8000;
+    var ng=G(0.0001,sfx); env(ng,t+0.3,0.01,0.04,0.35); n.connect(hp); hp.connect(ng); n.start(t+0.3); n.stop(t+0.8);
+  }
+  function printer(){
+    if(!ac) return;
+    var t=ac.currentTime;
+    var m=osc('square',55), mg=G(0.0001,sfx); env(mg,t,0.02,0.05,0.7); m.connect(mg); m.start(t); m.stop(t+0.8); bye(m,mg);
+    for(var i=0;i<14;i++){
+      var n=noise(), b=ac.createBiquadFilter(); b.type='bandpass'; b.frequency.value=1200+hash(i)*600; b.Q.value=3;
+      var g=G(0.0001,sfx); env(g,t+i*0.045,0.003,0.07,0.03);
+      n.connect(b); b.connect(g); n.start(t+i*0.045); n.stop(t+i*0.045+0.05);
+    }
+  }
+  function keytick(v){
+    if(!ac) return;
+    var t=ac.currentTime, n=noise(), b=ac.createBiquadFilter(); b.type='bandpass'; b.frequency.value=2600+Math.random()*900; b.Q.value=4;
+    var g=G(0.0001,sfx); env(g,t,0.002,v||0.05,0.025);
+    n.connect(b); b.connect(g); n.start(t); n.stop(t+0.04); bye(n,g);
+  }
+  function softtick(){
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sine',880), g=G(0.0001,sfx); env(g,t,0.004,0.05,0.12);
+    o.connect(g); o.start(t); o.stop(t+0.16); bye(o,g);
+  }
+  function alarm(){
+    if(!ac) return;
+    var t=ac.currentTime;
+    for(var i=0;i<5;i++){
+      var o=osc('square',i%2?660:880), g=G(0.0001,sfx);
+      env(g,t+i*0.14,0.004,0.09,0.1);
+      var lp=ac.createBiquadFilter(); lp.type='lowpass'; lp.frequency.value=3000;
+      o.connect(lp); lp.connect(g); o.start(t+i*0.14); o.stop(t+i*0.14+0.13); bye(o,g);
+    }
+  }
+  function stampSfx(){
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sine',90), g=G(0.0001,sfx);
+    o.frequency.exponentialRampToValueAtTime(42,t+0.12); env(g,t,0.004,0.5,0.22);
+    o.connect(g); o.start(t); o.stop(t+0.3); bye(o,g);
+    var n=noise(), lp=ac.createBiquadFilter(); lp.type='lowpass'; lp.frequency.value=1400;
+    var ng=G(0.0001,sfx); env(ng,t,0.002,0.2,0.07); n.connect(lp); lp.connect(ng); n.start(t); n.stop(t+0.1);
+  }
+  function whoosh(up){
+    if(!ac) return;
+    var t=ac.currentTime, n=noise(), b=ac.createBiquadFilter(); b.type='bandpass'; b.Q.value=0.8;
+    b.frequency.setValueAtTime(up?300:2400,t); b.frequency.exponentialRampToValueAtTime(up?2400:300,t+0.5);
+    var g=G(0.0001,sfx); env(g,t,0.06,0.14,0.45);
+    n.connect(b); b.connect(g); g.connect(spaceIn); n.start(t); n.stop(t+0.6); bye(n,g);
+  }
+  function swish(){
+    if(!ac) return;
+    var t=ac.currentTime, n=noise(), b=ac.createBiquadFilter(); b.type='highpass'; b.frequency.value=3000;
+    var g=G(0.0001,sfx); env(g,t,0.02,0.06,0.14);
+    n.connect(b); b.connect(g); n.start(t); n.stop(t+0.2); bye(n,g);
+  }
+  function tickSwarm(){
+    if(!ac) return;
+    var t=ac.currentTime;
+    for(var i=0;i<30;i++){
+      var o=osc('square',1800+hash(i)*1700), g=G(0.0001,sfx);
+      env(g,t+i*0.022,0.002,0.022,0.02);
+      o.connect(g); o.start(t+i*0.022); o.stop(t+i*0.022+0.03);
+    }
+  }
+  function slurp(){
+    if(!ac) return;
+    var t=ac.currentTime, n=noise(), b=ac.createBiquadFilter(); b.type='bandpass'; b.Q.value=3;
+    b.frequency.setValueAtTime(300,t); b.frequency.exponentialRampToValueAtTime(2600,t+0.65);
+    var g=G(0.0001,sfx); env(g,t,0.04,0.16,0.6); n.connect(b); b.connect(g); n.start(t); n.stop(t+0.75); bye(n,g);
+    var o=osc('sine',620), og=G(0.0001,sfx); o.frequency.exponentialRampToValueAtTime(140,t+0.6);
+    env(og,t,0.03,0.08,0.6); o.connect(og); o.start(t); o.stop(t+0.7); bye(o,og);
+  }
+  function squeak(){
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sine',1400), g=G(0.0001,voice);
+    o.frequency.exponentialRampToValueAtTime(380,t+0.3);
+    var vib=osc('sine',26), vg=G(60,o.frequency); vib.connect(vg); vib.start(t); vib.stop(t+0.35);
+    env(g,t,0.01,0.12,0.32); o.connect(g); g.connect(spaceIn); o.start(t); o.stop(t+0.4); bye(o,g);
+  }
+  function clapShut(){
+    if(!ac) return;
+    var t=ac.currentTime, n=noise(), hp=ac.createBiquadFilter(); hp.type='highpass'; hp.frequency.value=700;
+    var g=G(0.0001,sfx); env(g,t,0.002,0.35,0.06);
+    n.connect(hp); hp.connect(g); n.start(t); n.stop(t+0.1); bye(n,g);
+    thump(0.45);
+  }
+  function creak(){
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sawtooth',82), g=G(0.0001,sfx);
+    o.frequency.linearRampToValueAtTime(58,t+0.5);
+    var lp=ac.createBiquadFilter(); lp.type='lowpass'; lp.frequency.value=500;
+    env(g,t,0.08,0.04,0.5); o.connect(lp); lp.connect(g); o.start(t); o.stop(t+0.65); bye(o,g);
+  }
+  function drip(){
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sine',1900), g=G(0.0001,sfx);
+    o.frequency.exponentialRampToValueAtTime(680,t+0.05); env(g,t,0.003,0.05,0.18);
+    o.connect(g); g.connect(spaceIn); o.start(t); o.stop(t+0.25); bye(o,g);
+  }
+  function chime(){
+    if(!ac) return;
+    var t=ac.currentTime, o=osc('sine',hz(81)), o2=osc('sine',hz(88));
+    var g=G(0.0001,sfx); env(g,t,0.01,0.06,1.2);
+    o.connect(g); o2.connect(g); g.connect(spaceIn); o.start(t); o2.start(t); o.stop(t+1.4); o2.stop(t+1.4); bye(o,g);
+  }
+  function shimmer(){
+    if(!ac) return;
+    var t=ac.currentTime;
+    [72,76,79,84].forEach(function(m,i){
+      var o=osc('triangle',hz(m)), g=G(0.0001,sfx);
+      env(g,t+i*0.12,0.2,0.035,1.4);
+      o.connect(g); g.connect(spaceIn); o.start(t+i*0.12); o.stop(t+2); bye(o,g);
+    });
+  }
+  function snap(){
+    if(!ac) return;
+    var t=ac.currentTime, n=noise(), bp=ac.createBiquadFilter(); bp.type='bandpass'; bp.frequency.value=2200; bp.Q.value=2;
+    var g=G(0.0001,sfx); env(g,t,0.002,0.18,0.05); n.connect(bp); bp.connect(g); n.start(t); n.stop(t+0.08); bye(n,g);
+  }
+  function revSwell(){            /* reverse-cymbal feel: rising noise */
+    if(!ac) return;
+    var t=ac.currentTime, n=noise(), hp=ac.createBiquadFilter(); hp.type='highpass'; hp.frequency.value=2000;
+    var g=G(0.0001,sfx);
+    g.gain.setValueAtTime(0.0001,t); g.gain.exponentialRampToValueAtTime(0.12,t+2.2); g.gain.linearRampToValueAtTime(0.0001,t+2.45);
+    n.connect(hp); hp.connect(g); g.connect(spaceIn); n.start(t); n.stop(t+2.5); bye(n,g);
+  }
+  function musicKill(){           /* the hard cut — mid-note, no mercy */
+    if(!ac) return;
+    music.gain.cancelScheduledValues(ac.currentTime);
+    music.gain.setValueAtTime(0.0001,ac.currentTime);
+  }
+
+  /* --- the score: 96 BPM sequencer, sections keyed by film time --- */
+  function section(t){
+    if(t<40)    return {pad:[45,60,64], lvl:.4,  cut:700,  arp:0,                 kick:0, hat:0, bass:[33], bassEvery:32};
+    if(t<80)    return {pad:[45,60,64], lvl:.5,  cut:1000, arp:[69,72,76,72],     arpEvery:2, kick:0, hat:0, bass:[33], bassEvery:16};
+    if(t<130)   return {pad:[43,58,62], lvl:.62, cut:1900, arp:[67,70,74,70,67,70,75,70], arpEvery:2, kick:1, hat:1, bass:[31,31,34,31], bassEvery:4};
+    if(t<150)   return {pad:[42,57,60], lvl:.42, cut:900,  arp:0,                 kick:0, hat:0, bass:[30], bassEvery:16};
+    if(t<160)   return {pad:[42,57,60], lvl:lerp(.3,.08,(t-150)/10), cut:600, arp:0, kick:0, hat:0, bass:0};
+    if(t<183.5) return {pad:[40,58,64], lvl:.72, cut:2600, arp:[64,70,73,79],     arpEvery:1, kick:1, hat:1, bass:[28,28,34,28], bassEvery:2};
+    if(t<214)   return null;                                   /* act 6 — the silence is the point */
+    if(t<225){  var ch=[[41,57,60],[36,55,60],[43,59,62],[45,60,64]][((t-214)/2.6|0)%4];
+                return {pad:ch, lvl:.34, cut:lerp(500,1100,(t-214)/11), arp:0, kick:0, hat:0, bass:0}; }
+    var ch7=[[45,61,64],[38,57,66],[40,59,64],[45,61,64]][((t-225)/3.4|0)%4];
+    return {pad:ch7, lvl:.45, cut:lerp(400,2400,(t-225)/39), arp:[69,73,76,81], arpEvery:4, kick:0, hat:0, bass:0};
+  }
+  function kick(t0){
+    var o=osc('sine',120), g=G(0.0001,music);
+    o.frequency.setValueAtTime(120,t0); o.frequency.exponentialRampToValueAtTime(42,t0+0.1);
+    g.gain.setValueAtTime(0.0001,t0); g.gain.linearRampToValueAtTime(0.5,t0+0.005); g.gain.exponentialRampToValueAtTime(0.0001,t0+0.22);
+    o.connect(g); o.start(t0); o.stop(t0+0.26); bye(o,g);
+  }
+  function hat(t0){
+    var n=noise(), hp=ac.createBiquadFilter(); hp.type='highpass'; hp.frequency.value=7500;
+    var g=G(0.0001,music);
+    g.gain.setValueAtTime(0.0001,t0); g.gain.linearRampToValueAtTime(0.05,t0+0.003); g.gain.exponentialRampToValueAtTime(0.0001,t0+0.045);
+    n.connect(hp); hp.connect(g); n.start(t0); n.stop(t0+0.07); bye(n,g);
+  }
+  function bassN(t0,m){
+    var o=osc('sawtooth',hz(m)), lp=ac.createBiquadFilter(); lp.type='lowpass'; lp.frequency.value=420; lp.Q.value=2;
+    var g=G(0.0001,music);
+    g.gain.setValueAtTime(0.0001,t0); g.gain.linearRampToValueAtTime(0.2,t0+0.01); g.gain.exponentialRampToValueAtTime(0.0001,t0+0.3);
+    o.connect(lp); lp.connect(g); o.start(t0); o.stop(t0+0.34); bye(o,g);
+  }
+  function pluck(t0,m){
+    var o=osc('square',hz(m)), bp=ac.createBiquadFilter(); bp.type='bandpass'; bp.frequency.value=hz(m)*1.6; bp.Q.value=1.6;
+    var g=G(0.0001,music);
+    g.gain.setValueAtTime(0.0001,t0); g.gain.linearRampToValueAtTime(0.085,t0+0.008); g.gain.exponentialRampToValueAtTime(0.0001,t0+0.16);
+    o.connect(bp); bp.connect(g); o.start(t0); o.stop(t0+0.2); bye(o,g);
+    var sg=G(0.18,spaceIn); g.connect(sg);
+  }
+  function seqStart(){
+    if(seqH||!ac) return;                       /* single-handle guard */
+    nextStep=ac.currentTime+0.06;
+    seqH=setInterval(function(){
+      if(!playing||!ac) return;
+      while(nextStep<ac.currentTime+0.12){
+        var ft=tNow+(nextStep-ac.currentTime);
+        var s=section(ft);
+        if(s){
+          var i=stepIdx%16;
+          if(s.kick&&i%4===0) kick(nextStep);
+          if(s.hat&&i%2===1) hat(nextStep);
+          if(s.bass&&stepIdx%s.bassEvery===0) bassN(nextStep,s.bass[(stepIdx/s.bassEvery|0)%s.bass.length]);
+          if(s.arp&&stepIdx%s.arpEvery===0) pluck(nextStep,s.arp[(stepIdx/s.arpEvery|0)%s.arp.length]);
+        }
+        stepIdx++; nextStep+=STEP;
+      }
+    },25);
+  }
+  function seqStop(){ if(seqH){ clearInterval(seqH); seqH=null; } }
+
+  /* --- per-frame derived audio state (seek-safe by construction) --- */
+  var lastLvl=-1,lastCut=-1,lastPad='',lastRain=-1,lastHum=-1,lastFire=-1,lastDrone=-1;
+  function frameUpdate(t,env){
+    if(!ac) return;
+    var now=ac.currentTime;
+    var s=section(t);
+    var lvl=s?s.lvl:0.0001, cut=s?s.cut:600;
+    if(Math.abs(lvl-lastLvl)>0.01){ music.gain.setTargetAtTime(lvl,now,0.12); lastLvl=lvl; }
+    if(s&&Math.abs(cut-lastCut)>20){ padLP.frequency.setTargetAtTime(cut,now,0.4); lastCut=cut; }
+    if(s){
+      var key=s.pad.join(',');
+      if(key!==lastPad){ for(var i=0;i<3;i++) pad[i].frequency.setTargetAtTime(hz(s.pad[i]),now,0.35); lastPad=key; }
+    }
+    if(Math.abs(env.rain-lastRain)>0.02){ rainG.gain.setTargetAtTime(env.rain*0.12,now,0.4); rainLP.frequency.setTargetAtTime(1400+env.rain*2400,now,0.5); lastRain=env.rain; }
+    if(Math.abs(env.hum-lastHum)>0.02){ humG.gain.setTargetAtTime(env.hum*0.1,now,0.5); lastHum=env.hum; }
+    if(Math.abs(env.fire-lastFire)>0.02){ fireG.gain.setTargetAtTime(env.fire*0.16,now,0.3); lastFire=env.fire; }
+    if(Math.abs(env.drone-lastDrone)>0.02){ droneG.gain.setTargetAtTime(env.drone*0.5,now,0.6); lastDrone=env.drone; }
+  }
+
+  function setMuted(m){
+    muted=m;
+    if(ac) master.gain.setTargetAtTime(m?0.0001:1, ac.currentTime, 0.015);
+  }
+  function suspend(){ if(ac&&ac.state==='running') ac.suspend() }
+  function resume(){ if(ac&&ac.state==='suspended') ac.resume() }
+
+  return {
+    init:init, ctx:ctx, seqStart:seqStart, seqStop:seqStop, frameUpdate:frameUpdate,
+    setMuted:setMuted, suspend:suspend, resume:resume, musicKill:musicKill,
+    ding:ding, error:error, chirp:chirp, pop:pop, buzz:buzz, zap:zap, train:train, horn:horn,
+    whisper:whisper, bossVoice:bossVoice, levelup:levelup, thump:thump, achieve:achieve,
+    printer:printer, keytick:keytick, softtick:softtick, alarm:alarm, stampSfx:stampSfx,
+    whoosh:whoosh, swish:swish, tickSwarm:tickSwarm, slurp:slurp, squeak:squeak,
+    clapShut:clapShut, creak:creak, drip:drip, chime:chime, shimmer:shimmer, snap:snap, revSwell:revSwell
+  };
+})();
+
+/* ============================ SPRITES (pre-rendered once, behind the poster) ============================ */
+var SPR=(function(){
+  function cnv(w,h){ var c=document.createElement('canvas'); c.width=w; c.height=h; return c }
+
+  /* radial glow textures — the only "blur" in the film (no shadowBlur in any loop) */
+  var glows={};
+  function glow(color){
+    if(glows[color]) return glows[color];
+    var c=cnv(256,256), g=c.getContext('2d');
+    var r=g.createRadialGradient(128,128,0,128,128,128);
+    r.addColorStop(0,color); r.addColorStop(0.35,color.replace('1)','0.35)')); r.addColorStop(1,color.replace('1)','0)'));
+    g.fillStyle=r; g.fillRect(0,0,256,256);
+    glows[color]=c; return c;
+  }
+  var GLOW={
+    mag:glow('rgba(255,45,150,1)'), cyn:glow('rgba(35,230,255,1)'),
+    amb:glow('rgba(255,177,77,1)'), wht:glow('rgba(235,242,255,1)'),
+    vio:glow('rgba(150,80,255,1)'), grn:glow('rgba(87,224,139,1)')
+  };
+  function blitGlow(ctx,tex,x,y,size,alpha){
+    ctx.save(); ctx.globalCompositeOperation='lighter'; ctx.globalAlpha=alpha;
+    ctx.drawImage(tex,x-size/2,y-size/2,size,size); ctx.restore();
+  }
+
+  /* skyline strips: 2400×420 each, increasingly dark with distance */
+  function strip(seed,baseCol,winCol,winP,neon){
+    var c=cnv(2400,420), g=c.getContext('2d'), x=0, i=seed;
+    while(x<2400){
+      var bw=46+hash(i)*120, bh=90+hash(i+1)*300, bx=x, by=420-bh;
+      g.fillStyle=baseCol; g.fillRect(bx,by,bw,bh);
+      if(hash(i+2)>0.6){ g.fillRect(bx+bw*0.3,by-14-hash(i+3)*30,3,14+hash(i+3)*30); } /* antenna */
+      if(winP>0){
+        g.fillStyle=winCol;
+        for(var wy=by+10; wy<410; wy+=14)
+          for(var wx=bx+6; wx<bx+bw-8; wx+=11)
+            if(hash(wx*3.7+wy*1.3+seed)<winP) g.fillRect(wx,wy,5,7);
+      }
+      if(neon&&hash(i+5)>0.72){
+        g.fillStyle=hash(i+6)>0.5?'rgba(255,45,150,.8)':'rgba(35,230,255,.8)';
+        g.fillRect(bx+4,by+6,4,Math.min(bh*0.5,90));
+      }
+      x+=bw+2+hash(i+4)*26; i+=7;
+    }
+    return c;
+  }
+  var strips=[
+    strip(11,'#0d1020','rgba(110,140,190,.35)',0.10,false),
+    strip(53,'#0a0d1a','rgba(140,170,220,.5)',0.16,false),
+    strip(97,'#070912','rgba(180,210,255,.6)',0.22,true)
+  ];
+
+  /* fog band */
+  var fog=(function(){
+    var c=cnv(512,128), g=c.getContext('2d');
+    var r=g.createRadialGradient(256,64,10,256,64,250);
+    r.addColorStop(0,'rgba(120,140,200,.32)'); r.addColorStop(1,'rgba(120,140,200,0)');
+    g.save(); g.scale(1,0.32); g.translate(0,140); g.fillStyle=r;
+    g.beginPath(); g.arc(256,200,250,0,7); g.fill(); g.restore();
+    return c;
+  })();
+
+  /* resume sheet */
+  var paper=(function(){
+    var c=cnv(90,120), g=c.getContext('2d');
+    g.fillStyle='#e8ecf2'; g.fillRect(0,0,90,120);
+    g.fillStyle='#9aa6b8'; g.fillRect(10,12,46,7);
+    g.fillStyle='#c2cbd8';
+    for(var y=30;y<108;y+=12) g.fillRect(10,y,70-hash(y)*26,4);
+    return c;
+  })();
+
+  /* a motivational post tile (the LINKEDIN FORM is made of these) */
+  var post=(function(){
+    var c=cnv(170,120), g=c.getContext('2d');
+    g.fillStyle='#0e1626'; g.fillRect(0,0,170,120);
+    g.strokeStyle='rgba(80,160,230,.7)'; g.lineWidth=2; g.strokeRect(1,1,168,118);
+    g.fillStyle='rgba(80,160,230,.85)'; g.beginPath(); g.arc(20,20,9,0,7); g.fill();
+    g.fillStyle='rgba(170,200,235,.8)'; g.fillRect(36,14,80,5); g.fillRect(36,24,52,4);
+    g.fillStyle='rgba(120,150,190,.55)';
+    for(var y=44;y<96;y+=11) g.fillRect(12,y,146-hash(y*3)*60,4);
+    g.fillStyle='#3b82d6'; g.fillRect(12,102,26,10);
+    g.fillStyle='#fff'; g.font='bold 9px sans-serif'; g.fillText('+1',17,110);
+    return c;
+  })();
+
+  /* boss tiles: a form field panel and a captcha grid */
+  var formTile=(function(){
+    var c=cnv(170,100), g=c.getContext('2d');
+    g.fillStyle='#0c1322'; g.fillRect(0,0,170,100);
+    g.strokeStyle='rgba(120,140,190,.55)'; g.lineWidth=2; g.strokeRect(1,1,168,98);
+    g.fillStyle='rgba(150,170,210,.5)'; g.fillRect(12,12,70,5);
+    g.strokeStyle='rgba(150,170,210,.5)'; g.strokeRect(12,26,146,18);
+    g.fillStyle='rgba(150,170,210,.4)'; g.fillRect(12,56,50,5);
+    g.strokeRect(12,68,146,18);
+    g.fillStyle='#ff4456'; g.font='bold 12px sans-serif'; g.fillText('*',86,22);
+    return c;
+  })();
+  var captcha=(function(){
+    var c=cnv(120,120), g=c.getContext('2d');
+    g.fillStyle='#0c1322'; g.fillRect(0,0,120,120);
+    g.strokeStyle='rgba(120,140,190,.55)'; g.lineWidth=2; g.strokeRect(1,1,118,118);
+    for(var i=0;i<9;i++){
+      var gx=8+(i%3)*36, gy=8+((i/3)|0)*36;
+      g.fillStyle=hash(i+40)>0.5?'rgba(60,90,140,.8)':'rgba(40,60,100,.8)';
+      g.fillRect(gx,gy,32,32);
+      if(hash(i+13)>0.66){ g.strokeStyle='#57e08b'; g.strokeRect(gx+3,gy+3,26,26); }
+    }
+    return c;
+  })();
+
+  /* ----- the five evolution forms: dark silhouettes, one glowing eye motif ----- */
+  function silStyle(g){ g.fillStyle='#06070e'; g.strokeStyle='rgba(255,45,150,.55)'; g.lineWidth=5 }
+  function rr(g,x,y,w,h,r){ g.beginPath(); g.moveTo(x+r,y); g.arcTo(x+w,y,x+w,y+h,r); g.arcTo(x+w,y+h,x,y+h,r); g.arcTo(x,y+h,x,y,r); g.arcTo(x,y,x+w,y,r); g.closePath() }
+
+  function evoRecruiter(){
+    var c=cnv(760,760), g=c.getContext('2d'); silStyle(g);
+    /* suit shoulders */
+    g.beginPath(); g.moveTo(120,760); g.quadraticCurveTo(130,520,250,470);
+    g.lineTo(510,470); g.quadraticCurveTo(630,520,640,760); g.closePath(); g.fill(); g.stroke();
+    /* tie */
+    g.fillStyle='#13050d'; g.beginPath(); g.moveTo(380,478); g.lineTo(412,520); g.lineTo(384,640); g.lineTo(352,520); g.closePath(); g.fill();
+    /* huge head with corporate hair wedge */
+    silStyle(g); rr(g,240,120,290,330,56); g.fill(); g.stroke();
+    g.beginPath(); g.moveTo(238,200); g.quadraticCurveTo(260,86,420,92); g.quadraticCurveTo(548,96,536,210);
+    g.quadraticCurveTo(420,160,238,200); g.closePath(); g.fill();
+    /* mouth: a thin polite line that is also a paper-feed slot */
+    g.strokeStyle='rgba(35,230,255,.5)'; g.lineWidth=4; g.beginPath(); g.moveTo(316,392); g.lineTo(458,392); g.stroke();
+    return {c:c, eyes:[[386,290,50]], w:760, h:760};
+  }
+  function evoHydra(){
+    var c=cnv(760,760), g=c.getContext('2d'); silStyle(g);
+    g.beginPath(); g.moveTo(110,760); g.quadraticCurveTo(140,560,260,520); g.lineTo(500,520);
+    g.quadraticCurveTo(620,560,650,760); g.closePath(); g.fill(); g.stroke();
+    var necks=[[200,170,-46],[380,96,0],[560,170,46]];
+    necks.forEach(function(n,i){
+      g.beginPath(); g.moveTo(330+i*36,540);
+      g.quadraticCurveTo(n[0]+n[2],380,n[0],n[1]+140); g.lineTo(n[0]+56,n[1]+150);
+      g.quadraticCurveTo(n[0]+90+n[2],400,420+i*30,545); g.closePath(); g.fill(); g.stroke();
+      rr(g,n[0]-58,n[1],140,150,34); g.fill(); g.stroke();
+      /* little tie on every head — middle management */
+      g.fillStyle='#13050d'; g.beginPath(); g.moveTo(n[0]+10,n[1]+148); g.lineTo(n[0]+24,n[1]+170); g.lineTo(n[0]+10,n[1]+196); g.lineTo(n[0]-4,n[1]+170); g.closePath(); g.fill();
+      silStyle(g);
+    });
+    return {c:c, eyes:[[212,250,30],[392,176,30],[572,250,30]], w:760, h:760};
+  }
+  function evoLinkedin(){
+    var c=cnv(760,760), g=c.getContext('2d');
+    function tile(x,y,r,s){ g.save(); g.translate(x,y); g.rotate(r); g.scale(s,s); g.drawImage(post,-85,-60); g.restore() }
+    /* torso of posts */
+    tile(380,600,0.05,1.25); tile(300,500,-0.12,1.1); tile(470,500,0.1,1.15);
+    tile(380,400,-0.04,1.2); tile(290,310,0.14,0.95); tile(470,310,-0.1,1);
+    /* arms ending in thumbs-up */
+    tile(180,420,-0.5,0.8); tile(580,420,0.5,0.8);
+    function thumb(x,y,fl){
+      g.save(); g.translate(x,y); g.scale(fl,1);
+      g.fillStyle='#2f74c4'; rr(g,-20,-6,34,40,8); g.fill();
+      rr(g,-2,-44,18,44,9); g.fill();
+      g.restore();
+    }
+    thumb(130,470,1); thumb(630,470,-1);
+    /* head tile */
+    g.save(); g.translate(380,190); g.drawImage(post,-85,-60); g.restore();
+    g.strokeStyle='rgba(80,160,230,.8)'; g.lineWidth=5; g.strokeRect(295,130,170,120);
+    return {c:c, eyes:[[380,190,40]], w:760, h:760};
+  }
+  function evoDragon(){
+    var c=cnv(760,760), g=c.getContext('2d'); silStyle(g);
+    /* body + tail */
+    g.beginPath(); g.moveTo(80,760); g.quadraticCurveTo(140,560,330,540);
+    g.quadraticCurveTo(560,520,640,640); g.quadraticCurveTo(700,710,740,700);
+    g.lineTo(740,760); g.closePath(); g.fill(); g.stroke();
+    /* neck arching left, head with shredder jaw */
+    g.beginPath(); g.moveTo(300,560); g.quadraticCurveTo(150,460,170,300);
+    g.quadraticCurveTo(180,210,260,200); g.lineTo(300,260); g.quadraticCurveTo(250,420,390,540); g.closePath(); g.fill(); g.stroke();
+    g.beginPath(); g.moveTo(150,210); g.lineTo(330,180); g.lineTo(345,235); g.lineTo(165,280); g.closePath(); g.fill(); g.stroke();
+    /* shredder teeth */
+    g.fillStyle='rgba(35,230,255,.65)';
+    for(var i=0;i<7;i++) g.fillRect(180+i*22,242-i*4,7,22);
+    /* wing of file-folder tabs */
+    silStyle(g);
+    g.beginPath(); g.moveTo(420,540); g.lineTo(470,300); g.lineTo(520,330); g.lineTo(560,250);
+    g.lineTo(600,300); g.lineTo(650,230); g.lineTo(660,560); g.closePath(); g.fill(); g.stroke();
+    return {c:c, eyes:[[235,170,26]], w:760, h:760};
+  }
+  function evoTitan(){
+    var c=cnv(760,760), g=c.getContext('2d'); silStyle(g);
+    /* legs */
+    rr(g,170,420,140,340,18); g.fill(); g.stroke();
+    rr(g,450,420,140,340,18); g.fill(); g.stroke();
+    /* torso slab */
+    rr(g,120,150,520,300,26); g.fill(); g.stroke();
+    /* window-panel grid on the torso */
+    g.strokeStyle='rgba(120,140,190,.4)'; g.lineWidth=3;
+    for(var x=160;x<620;x+=76){ g.beginPath(); g.moveTo(x,170); g.lineTo(x,430); g.stroke(); }
+    for(var y=200;y<440;y+=58){ g.beginPath(); g.moveTo(140,y); g.lineTo(620,y); g.stroke(); }
+    /* tiny head box — barely fits the org chart */
+    silStyle(g); rr(g,320,50,120,90,14); g.fill(); g.stroke();
+    /* arms */
+    rr(g,40,180,80,330,18); g.fill(); g.stroke();
+    rr(g,640,180,80,330,18); g.fill(); g.stroke();
+    return {c:c, eyes:[[380,95,26]], w:760, h:760};
+  }
+  var EVOS=[
+    {t:86,  name:'RECRUITER FORM',  sub:'it has your name. it has everyone’s name.',            spr:evoRecruiter(), sc:1.0},
+    {t:96,  name:'RECRUITER HYDRA', sub:'three heads. zero feedback.',                          spr:evoHydra(),     sc:1.25},
+    {t:108, name:'LINKEDIN FORM',   sub:'100% motivated. agree? 👍',                            spr:evoLinkedin(),  sc:1.5},
+    {t:118, name:'ATS DRAGON',      sub:'parses 9,000 résumés a second. understands none.',     spr:evoDragon(),    sc:1.95},
+    {t:125, name:'WORKDAY TITAN',   sub:'you already have an account. the password is gone.',   spr:evoTitan(),     sc:3.1}
+  ];
+
+  return {GLOW:GLOW, blitGlow:blitGlow, strips:strips, fog:fog, paper:paper, post:post,
+          formTile:formTile, captcha:captcha, EVOS:EVOS};
+})();
+
+/* ============================ RIGS ============================ */
+/* the protagonist — a simple, expressive vector man in a long coat */
+function drawGuy(c,o){
+  var s=o.s||1, pose=o.pose||'stand', ph=o.ph||0, rim=o.rim||'rgba(35,230,255,.75)';
+  var co='#12141d', sk='#cdb8a6';
+  c.save(); c.translate(o.x,o.y); c.scale(s*(o.flip?-1:1),s);
+  var bob=pose==='walk'?Math.abs(Math.cos(ph))*4:0;
+  var crouch=pose==='sit'?44:(pose==='type'?16:0);
+  c.translate(0,-bob+crouch*0);
+  c.lineCap='round'; c.lineJoin='round';
+
+  /* legs */
+  c.strokeStyle=co; c.lineWidth=14;
+  function leg(hx,swing,bend){
+    var kx=hx+swing*0.55, ky=-46+bend, fxx=hx+swing, fy=0;
+    c.beginPath(); c.moveTo(hx,-84); c.quadraticCurveTo(kx,ky,fxx,fy); c.stroke();
+    c.lineWidth=7; c.beginPath(); c.moveTo(fxx,fy); c.lineTo(fxx+10,fy); c.stroke(); c.lineWidth=14;
+  }
+  if(pose==='walk'){ leg(-4,Math.sin(ph)*24,0); leg(4,Math.sin(ph+Math.PI)*24,0); }
+  else if(pose==='sit'){
+    c.beginPath(); c.moveTo(-4,-70); c.lineTo(26,-58); c.lineTo(30,-6); c.stroke();
+    c.beginPath(); c.moveTo(6,-70); c.lineTo(40,-54); c.lineTo(46,-4); c.stroke();
+  }
+  else { leg(-7,-2,0); leg(7,4,0); }
+
+  /* coat body */
+  var ty=pose==='sit'?-66:-84;
+  c.fillStyle=co;
+  c.beginPath();
+  c.moveTo(-22,ty-78); c.quadraticCurveTo(-30,ty-30,-24,ty+18);
+  c.lineTo(24,ty+18); c.quadraticCurveTo(32,ty-30,22,ty-78);
+  c.quadraticCurveTo(0,ty-88,-22,ty-78); c.closePath(); c.fill();
+  /* collar */
+  c.strokeStyle='#1b1f2c'; c.lineWidth=5;
+  c.beginPath(); c.moveTo(-16,ty-74); c.lineTo(0,ty-58); c.lineTo(16,ty-74); c.stroke();
+
+  /* head */
+  var hy=ty-104;
+  c.fillStyle=sk; c.beginPath(); c.arc(0,hy,17,0,7); c.fill();
+  c.fillStyle='#1a1410';
+  c.beginPath(); c.arc(0,hy-3,17.5,Math.PI*1.02,Math.PI*1.98); c.quadraticCurveTo(14,hy-16,4,hy-19); c.fill();
+  /* rim light — the city paints him */
+  c.strokeStyle=rim; c.lineWidth=2.5;
+  c.beginPath(); c.arc(0,hy,17,Math.PI*0.62,Math.PI*1.1); c.stroke();
+  c.beginPath(); c.moveTo(-23,ty-70); c.quadraticCurveTo(-29,ty-30,-24,ty+14); c.stroke();
+
+  /* arms */
+  c.strokeStyle=co; c.lineWidth=11;
+  function arm(sx,ex,ey,mx,my){ c.beginPath(); c.moveTo(sx,ty-62); c.quadraticCurveTo(mx,my,ex,ey); c.stroke() }
+  if(pose==='walk'){
+    arm(-12,-12+Math.sin(ph+Math.PI)*16,ty+6,-16,ty-26);
+    if(o.umbrella){
+      arm(12,30,ty-66,26,ty-58);
+      c.strokeStyle='#0d0f16'; c.lineWidth=5; c.beginPath(); c.moveTo(30,ty-66); c.lineTo(38,hy-78); c.stroke();
+      c.fillStyle='#0d0f16';
+      c.beginPath(); c.moveTo(-46,hy-66); c.quadraticCurveTo(38,hy-132,122,hy-66);
+      c.quadraticCurveTo(94,hy-76,66,hy-64); c.quadraticCurveTo(52,hy-74,38,hy-64);
+      c.quadraticCurveTo(10,hy-76,-4,hy-64); c.quadraticCurveTo(-22,hy-74,-46,hy-66); c.closePath(); c.fill();
+      c.strokeStyle='rgba(255,45,150,.5)'; c.lineWidth=2.5;
+      c.beginPath(); c.moveTo(-46,hy-66); c.quadraticCurveTo(38,hy-132,122,hy-66); c.stroke();
+    } else arm(12,12+Math.sin(ph)*16,ty+6,16,ty-26);
+  }
+  else if(pose==='type'){ arm(-12,18,ty-30,-2,ty-34); arm(12,30,ty-32,22,ty-40); }
+  else if(pose==='sit'){ arm(-12,18,ty-22,-4,ty-26); arm(12,26,ty-24,20,ty-32); }
+  else if(pose==='flick'){
+    arm(-12,-14,ty+2,-18,ty-28);
+    var fp=clamp(o.fp||0,0,1);                      /* 0 wind-up, 1 released */
+    arm(12,34+fp*10,ty-92+fp*10,30,ty-60);
+    c.strokeStyle=sk; c.lineWidth=4;
+    c.beginPath(); c.moveTo(34+fp*10,ty-92+fp*10); c.lineTo(40+fp*14,ty-98+fp*12); c.stroke();
+  }
+  else { arm(-12,-14,ty+4,-18,ty-26); arm(12,14,ty+4,18,ty-26); }
+  c.restore();
+}
+
+/* the creature — one parameterized rig; size 0..1 maps palm→building */
+function drawCreature(c,o){
+  var t=o.t||0, s=lerp(16,300,clamp(o.size,0,1));    /* base radius */
+  var sway=Math.sin(t*1.7+1)*0.06, breathe=1+Math.sin(t*2.3)*0.03;
+  c.save(); c.translate(o.x,o.y); c.scale(o.flip?-1:1,1); c.rotate(sway*(o.wob||1));
+  c.scale(s/100*breathe, s/100);
+  /* tail wisp */
+  c.strokeStyle='rgba(8,9,18,.92)'; c.lineWidth=14; c.lineCap='round';
+  c.beginPath(); c.moveTo(-58,-30);
+  c.quadraticCurveTo(-110,-50+Math.sin(t*2.6)*16,-128,-104+Math.cos(t*2.1)*12); c.stroke();
+  /* body blob */
+  c.fillStyle='#080912';
+  c.beginPath();
+  c.moveTo(0,-150); c.bezierCurveTo(78,-150,96,-86,92,-40);
+  c.bezierCurveTo(88,4,52,16,0,16); c.bezierCurveTo(-52,16,-88,4,-92,-40);
+  c.bezierCurveTo(-96,-86,-78,-150,0,-150); c.closePath(); c.fill();
+  /* horn nubs */
+  c.beginPath(); c.moveTo(-44,-136); c.quadraticCurveTo(-58,-176,-30,-186); c.quadraticCurveTo(-30,-156,-18,-144); c.closePath(); c.fill();
+  c.beginPath(); c.moveTo(44,-136); c.quadraticCurveTo(58,-176,30,-186); c.quadraticCurveTo(30,-156,18,-144); c.closePath(); c.fill();
+  /* stub feet */
+  c.beginPath(); c.ellipse(-34,16,18,10,0,0,7); c.fill();
+  c.beginPath(); c.ellipse(34,16,18,10,0,0,7); c.fill();
+  /* rim */
+  c.strokeStyle='rgba(255,45,150,'+(0.25+0.45*o.size)+')'; c.lineWidth=4;
+  c.beginPath(); c.moveTo(-80,-110); c.bezierCurveTo(-96,-70,-90,-20,-60,4); c.stroke();
+  /* the eye */
+  var ex=o.eyeX||10, ey=-86, er=30*(o.eye||1);
+  SPR.blitGlow(c,SPR.GLOW.mag,ex,ey,er*7,0.5+0.3*Math.sin(t*3.1));
+  c.fillStyle='#ff2d96'; c.beginPath(); c.arc(ex,ey,er,0,7); c.fill();
+  c.fillStyle='#ffd7ea'; c.beginPath(); c.arc(ex+er*0.25,ey-er*0.25,er*0.34,0,7); c.fill();
+  c.restore();
+}
+
+/* ============================ PARTICLE POOLS (fixed arrays, zero per-frame alloc) ============================ */
+function Pool(cap){
+  var arr=new Array(cap), n=0;
+  for(var i=0;i<cap;i++) arr[i]={x:0,y:0,vx:0,vy:0,a:0,b:0,life:0,max:1};
+  return {
+    arr:arr, cap:cap,
+    get n(){return n},
+    spawn:function(){ return n<cap?arr[n++]:null },
+    kill:function(i){ n--; var tmp=arr[i]; arr[i]=arr[n]; arr[n]=tmp },
+    clear:function(){ n=0 },
+    each:function(f){ for(var i=n-1;i>=0;i--) f(arr[i],i) }
+  };
+}
+var rainP=Pool(Math.max(60,600*PFAC|0)),
+    splashP=Pool(Math.max(20,200*PFAC|0)),
+    emberP=Pool(Math.max(30,220*PFAC|0)),
+    paperP=Pool(Math.max(12,80*PFAC|0)),
+    confP=Pool(Math.max(30,250*PFAC|0));
+
+var rainCfg={on:true, intensity:1, dir:1, ground:0, splash:false, slant:-0.18};
+function rainInit(){
+  for(var i=0;i<rainP.cap;i++){ var p=rainP.spawn(); p.x=Math.random()*(W+400)-200; p.y=Math.random()*H; p.a=320+Math.random()*340; p.b=14+Math.random()*16; }
+}
+function rainStep(dt){
+  if(!rainCfg.on) return;
+  var lim=rainP.cap*rainCfg.intensity;
+  rainP.each(function(p,i){
+    if(i>=lim) return;
+    p.y+=p.a*dt*rainCfg.dir*2.2; p.x+=p.a*dt*rainCfg.slant;
+    if(rainCfg.dir>0&&rainCfg.splash&&p.y>rainCfg.ground&&p.y-p.a*dt*2.2<=rainCfg.ground){
+      var s=splashP.spawn(); if(s){ s.x=p.x; s.y=rainCfg.ground; s.life=0; s.max=0.4; }
+    }
+    if(rainCfg.dir>0&&p.y>H+30){ p.y=-30-Math.random()*120; p.x=Math.random()*(W+400)-200; }
+    if(rainCfg.dir<0&&p.y<-30){ p.y=H+30+Math.random()*120; p.x=Math.random()*(W+400)-200; }
+  });
+  splashP.each(function(p,i){ p.life+=dt; if(p.life>p.max) splashP.kill(i); });
+}
+function rainDraw(){
+  if(!rainCfg.on||rainCfg.intensity<=0.01) return;
+  var ox=-(cam.x-W/2)*0.06, oy=-(cam.y-H/2)*0.06;
+  fx.save(); fx.setTransform(BS,0,0,BS,BS*ox,BS*oy);
+  fx.strokeStyle='rgba(170,200,235,.34)'; fx.lineWidth=1.6; fx.beginPath();
+  var lim=rainP.cap*rainCfg.intensity;
+  rainP.each(function(p,i){
+    if(i>=lim) return;
+    fx.moveTo(p.x,p.y); fx.lineTo(p.x+p.b*rainCfg.slant*3.4,p.y+p.b*rainCfg.dir*1.6);
+  });
+  fx.stroke();
+  if(rainCfg.splash){
+    fx.strokeStyle='rgba(170,200,235,.3)'; fx.lineWidth=1.4;
+    splashP.each(function(p){
+      var k=p.life/p.max;
+      fx.globalAlpha=1-k;
+      fx.beginPath(); fx.ellipse(p.x,p.y,4+k*16,1.4+k*4,0,0,7); fx.stroke();
+    });
+    fx.globalAlpha=1;
+  }
+  fx.restore();
+}
+function paperBurst(x,y,n){
+  for(var i=0;i<n;i++){
+    var p=paperP.spawn(); if(!p) break;
+    p.x=x; p.y=y; p.vx=(Math.random()-0.3)*420; p.vy=-260-Math.random()*340;
+    p.a=Math.random()*6; p.b=(Math.random()-0.5)*9; p.life=0; p.max=2.4+Math.random();
+  }
+}
+function paperStep(dt){
+  paperP.each(function(p,i){
+    p.life+=dt; if(p.life>p.max){ paperP.kill(i); return }
+    p.vy+=620*dt; p.vx*=0.985; p.x+=p.vx*dt+Math.sin(p.life*7+p.a)*1.6; p.y+=p.vy*dt; p.a+=p.b*dt;
+  });
+}
+function paperDraw(ctx,sc){
+  paperP.each(function(p){
+    ctx.save(); ctx.translate(p.x,p.y); ctx.rotate(p.a); ctx.globalAlpha=clamp(2-(p.life/p.max)*2,0,1);
+    ctx.drawImage(SPR.paper,-9*(sc||1),-12*(sc||1),18*(sc||1),24*(sc||1)); ctx.restore();
+  });
+}
+function confettiBurst(x,y,n){
+  for(var i=0;i<n;i++){
+    var p=confP.spawn(); if(!p) break;
+    p.x=x+(Math.random()-0.5)*120; p.y=y+(Math.random()-0.5)*60;
+    p.vx=(Math.random()-0.5)*500; p.vy=-200-Math.random()*420;
+    p.a=Math.random()*6; p.b=Math.random(); p.life=0; p.max=2.2+Math.random()*1.4;
+  }
+}
+function confStep(dt){
+  confP.each(function(p,i){
+    p.life+=dt; if(p.life>p.max){ confP.kill(i); return }
+    p.vy+=380*dt; p.vx*=0.99; p.x+=p.vx*dt; p.y+=p.vy*dt+Math.sin(p.life*9+p.a)*1.2; p.a+=dt*4;
+  });
+}
+function confDraw(ctx){
+  confP.each(function(p){
+    ctx.save(); ctx.translate(p.x,p.y); ctx.rotate(p.a); ctx.globalAlpha=clamp(2-(p.life/p.max)*2,0,1);
+    if(p.b>0.55){ ctx.fillStyle='#2f74c4'; ctx.fillRect(-8,-8,16,16); ctx.fillStyle='#fff'; ctx.font='bold 11px sans-serif'; ctx.fillText('+1',-7,4); }
+    else { ctx.fillStyle=p.b>0.28?'#23e6ff':'#ff2d96'; ctx.fillRect(-5,-7,10,14); }
+    ctx.restore();
+  });
+}
+function emberSpawn(x,y){
+  var p=emberP.spawn(); if(!p) return;
+  p.x=x; p.y=y; p.vx=(Math.random()-0.2)*180; p.vy=-60-Math.random()*200;
+  p.life=0; p.max=0.9+Math.random()*1.1; p.a=2+Math.random()*4;
+}
+function emberStep(dt){
+  emberP.each(function(p,i){
+    p.life+=dt; if(p.life>p.max){ emberP.kill(i); return }
+    p.vy-=120*dt; p.x+=p.vx*dt+Math.sin(p.life*11)*1.4; p.y+=p.vy*dt;
+  });
+}
+function emberDraw(ctx){
+  ctx.save(); ctx.globalCompositeOperation='lighter';
+  emberP.each(function(p){
+    var k=1-p.life/p.max;
+    ctx.globalAlpha=k*0.9; ctx.fillStyle=k>0.55?'#ffd166':'#ff5a36';
+    ctx.fillRect(p.x,p.y,p.a,p.a);
+  });
+  ctx.restore();
+}
+function clearPools(){ splashP.clear(); paperP.clear(); confP.clear(); emberP.clear(); }
+rainInit();
+
+/* ============================ FILM DATA (the script) ============================ */
+/* subtitles — declarative, painted from t every frame (the film works muted) */
+var SUBS=[
+  [26.0,29.0,'c',"did you apply today?"],
+  [30.6,33.2,'g',"nope. no. it’s fine. everything is fine."],
+  [49.0,51.5,'g',"i was here yesterday. you watched me make three accounts."],
+  [58.0,60.4,'g',"the résumé you just ate. that one."],
+  [72.2,75.0,'c',"(from the drain) did you apply today?"],
+  [96.9,98.4,'b',"WHERE DO YOU SEE YOURSELF IN FIVE YEARS?"],
+  [98.6,100.0,'b',"WHY DO YOU WANT TO WORK HERE?"],
+  [100.3,101.7,'b',"EMPLOYED?"],
+  [128.8,130.0,'g',"wait—"],
+  [166.8,169.2,'g',"why is the health bar mine."],
+  [179.3,181.0,'g',"four united states. and mine isn’t even—"],
+  [181.6,186.0,'s',"cause of death: “please verify you are not a robot.” he was not."],
+  [196.0,197.8,'g',"oh."],
+  [216.1,217.1,'c',"please re-en—"],
+  [217.5,219.2,'cap',"(sad balloon noise)"],
+  [228.0,230.4,'c',"did you apply tod—"],
+  [234.6,236.4,'c',"…truce."],
+  [239.2,241.4,'g',"we’re not friends."],
+  [241.8,243.8,'c',"best friends."]
+];
+
+/* popup html builders */
+function achHtml(s){ return '<div class="p-in"><div class="a-cup">🏆</div><div><div class="a-kick">achievement unlocked</div><div class="a-name">'+s+'</div></div></div>' }
+function jobHtml(k,t,lines){
+  var h='<div class="p-in"><div class="j-kick">'+k+'</div><div class="j-title">'+t+'</div>';
+  for(var i=0;i<lines.length;i++) h+='<div class="j-line">'+lines[i]+'</div>';
+  return h+'</div>';
+}
+function profHtml(svg,name,tag,line){
+  return '<div class="p-in"><div class="pr-av">'+svg+'</div><div><div class="pr-name">'+name+'<span>'+tag+'</span></div><div class="pr-line">'+line+'</div></div></div>';
+}
+var AV={
+  squirrel:'<svg viewBox="0 0 40 40"><path d="M26 30 q12 -2 10 -14 q-2 -10 -10 -10 q6 6 3 14" fill="#c98c4e"/><circle cx="16" cy="22" r="10" fill="#b87c3e"/><path d="M10 13 l3 -6 4 5" fill="#b87c3e"/><circle cx="13" cy="20" r="1.8" fill="#1a1208"/><circle cx="20" cy="26" r="3" fill="#e8c79e"/></svg>',
+  pigeon:'<svg viewBox="0 0 40 40"><ellipse cx="20" cy="24" rx="11" ry="9" fill="#8d97a8"/><circle cx="27" cy="14" r="6" fill="#6f7a8d"/><path d="M32 13 l6 2 -6 2" fill="#e8a23c"/><circle cx="28" cy="12.5" r="1.6" fill="#ffd24d"/><circle cx="28" cy="12.5" r=".8" fill="#111"/></svg>',
+  plant:'<svg viewBox="0 0 40 40"><path d="M20 22 q-9 -4 -8 -14 q9 2 9 13 q1 -11 9 -13 q2 10 -8 14" fill="#4f9e5c"/><path d="M12 24 h16 l-2.5 12 h-11 z" fill="#b8623c"/></svg>',
+  toaster:'<svg viewBox="0 0 40 40"><rect x="6" y="14" width="28" height="18" rx="6" fill="#aeb6c4"/><rect x="11" y="10" width="7" height="6" rx="2" fill="#7e8696"/><rect x="22" y="10" width="7" height="6" rx="2" fill="#7e8696"/><circle cx="30" cy="26" r="2" fill="#5a6272"/></svg>'
+};
+/* popups — declarative {t0,dur,cls,html,st} (sound cues are separate one-shots) */
+var POPUPS=[
+  {t0:86.6, dur:7,   cls:'job',  st:{left:'1160px',top:'250px'},
+    html:jobHtml('NEW MATCH · 99%','Entry-Level Senior Principal Architect',
+      ['<b>12+ years experience</b> required','technology age: <b>8 months</b>','salary: competitive <span style="opacity:.55">(with what?)</span>'])},
+  {t0:90,   dur:5.5, cls:'ach',  st:{left:'1230px',top:'152px'}, html:achHtml('Rejected Before Applying')},
+  {t0:108.6,dur:7,   cls:'job',  st:{left:'1160px',top:'250px'},
+    html:jobHtml('🚀 HIRING ROCKSTAR NINJAS','Thought Leadership Associate',
+      ['competitive salary: <b>€14</b>','unlimited PTO <span style="opacity:.55">(do not take PTO)</span>','we’re a family 👍'])},
+  {t0:100,  dur:5.5, cls:'ach',  st:{left:'1230px',top:'152px'}, html:achHtml('Ghosted By An Automated Email')},
+  {t0:112,  dur:5.5, cls:'ach',  st:{left:'1230px',top:'152px'}, html:achHtml('Rejected From A Company That Doesn’t Exist')},
+  {t0:121.5,dur:4,   cls:'stampS', st:{left:'1010px',top:'430px'}, html:'<div class="p-in">ADVANCE TO INTERVIEW 1 OF 17</div>'},
+  {t0:125.6,dur:4.5, cls:'job',  st:{left:'1160px',top:'250px'},
+    html:jobHtml('TRENDING','Fast-Moving Startup',
+      ['founded: <b>yesterday</b>','stage: series Ω','your role: everything'])},
+  {t0:128,  dur:5,   cls:'ach',  st:{left:'1230px',top:'152px'}, html:achHtml('Rejected By A Company You Already Work For')},
+  {t0:138,  dur:11.2,cls:'prof', st:{left:'1300px',top:'230px'}, html:profHtml(AV.squirrel,'Squirrel','· 3rd','VP of Engineering · ex-FAANG (the actual fang)')},
+  {t0:142,  dur:7.2, cls:'prof', st:{left:'1300px',top:'380px'}, html:profHtml(AV.pigeon,'Pigeon','· 2nd','Senior Product Manager · open to hybrid (sky / ledge)')},
+  {t0:146,  dur:3.2, cls:'prof', st:{left:'1300px',top:'530px'}, html:profHtml(AV.plant,'Houseplant','· 1st','Team Lead · servant leadership · 10k followers')},
+  {t0:148.3,dur:1.3, cls:'prof mini', st:{left:'1390px',top:'680px'}, html:profHtml(AV.toaster,'Toaster','','Open to Work')},
+  {t0:174,  dur:5.2, cls:'err',  st:{left:'660px',top:'330px'},
+    html:'<div class="p-in"><div class="e-bar"><span class="e-dot"></span>create a password</div><div class="e-body">must contain: one uppercase, one number,<br>one symbol, one hieroglyph,<br>and a tear of genuine despair.</div></div>'},
+  {t0:181.3,dur:4.6, cls:'stamp', st:{}, html:'<div class="p-in">DEFEATED</div>'},
+  {t0:216.8,dur:2.4, cls:'auto', st:{left:'1210px',top:'600px'}, html:'<div class="p-in">✓ field auto-filled</div>'}
+];
+
+/* glitch + strobe windows — derived, never stateful */
+var GLITCHW=[
+  {t:34.4,d:0.35,a:0.4},{t:79,d:0.3,a:0.5},
+  {t:86,d:0.55,a:1},{t:96,d:0.55,a:1},{t:108,d:0.55,a:1},{t:118,d:0.55,a:1},{t:125,d:0.7,a:1},
+  {t:160,d:0.8,a:0.9},{t:181.3,d:0.6,a:1},{t:216.8,d:0.25,a:0.35}
+];
+function glitchAmt(t){
+  var a=0;
+  for(var i=0;i<GLITCHW.length;i++){
+    var g=GLITCHW[i], k=(t-g.t)/g.d;
+    if(k>=0&&k<1) a=Math.max(a,g.a*(1-k));
+  }
+  return a;
+}
+var FLASHW=[86,96,108,118,125,160];
+function flashAmt(t){
+  for(var i=0;i<FLASHW.length;i++){
+    var k=t-FLASHW[i];
+    if(k>=0&&k<1){
+      var base=(1-k)*0.5;
+      if(reduce) return base*0.55;                       /* fade, no strobe */
+      return (Math.floor(k*6)%2===0)?base:base*0.12;     /* 3 flashes/sec, hard cap */
+    }
+  }
+  return 0;
+}
+
+/* audio cues — one-shots only; skipped silently on big seeks */
+var CUES=[
+  [2.2,function(){A.buzz(0.5)}], [4.7,function(){A.buzz(0.25)}],
+  [10.5,function(){A.train(false)}],
+  [26,function(){A.whisper({syl:5,size:0.08,vol:0.15})}],
+  [30.2,function(){A.pop()}], [31.1,function(){A.pop()}],
+  [34.5,function(){A.zap(); A.buzz(0.5)}],
+  [37.1,function(){A.train(true); shake(9)}],
+  [44,function(){A.ding()}],
+  [48,function(){A.error()}], [48.3,function(){A.chirp()}],
+  [52,function(){A.ding()}], [52.3,function(){A.chirp()}],
+  [55,function(){A.error()}], [55.3,function(){A.chirp()}],
+  [57,function(){A.printer(); paperBurst(1140,560,paperP.cap); shake(5)}],
+  [65,function(){A.ding()}], [65.3,function(){A.chirp()}],
+  [72,function(){A.whisper({syl:5,size:0.3,vol:0.16,gargle:true,slow:1.2})}],
+  [76,function(){A.shimmer()}],
+  [79,function(){A.alarm(); shake(10)}],
+  [80.6,function(){A.whisper({syl:4,size:0.6,vol:0.2,slow:1.5})}],
+  [86,function(){A.levelup(); shake(13)}],
+  [90,function(){A.achieve()}],
+  [96,function(){A.levelup(); shake(13)}],
+  [96.9,function(){A.bossVoice(8)}], [98.6,function(){A.bossVoice(7)}], [100.3,function(){A.bossVoice(3)}],
+  [100,function(){A.achieve()}],
+  [108,function(){A.levelup(); shake(13)}],
+  [108.7,function(){confettiBurst(960,420,confP.cap); A.ding(0.1); A.swish()}],
+  [112,function(){A.achieve()}],
+  [118,function(){A.levelup(); shake(14)}],
+  [121.5,function(){A.stampSfx()}],
+  [125,function(){A.levelup(); A.thump(0.5); shake(18)}],
+  [128,function(){A.achieve()}],
+  [128.9,function(){A.whisper({syl:2,size:0.8,vol:0.16,slow:1.3})}],
+  [130,function(){A.whoosh(true); shake(6)}],
+  [134,function(){A.whoosh(true); shake(5)}],
+  [138,function(){A.whoosh(true); shake(5)}],
+  [138.1,function(){A.swish()}], [142,function(){A.swish()}], [146,function(){A.swish()}], [148.3,function(){A.swish()}],
+  [152,function(){A.whisper({syl:5,size:1,vol:0.3,slow:2.2})}],
+  [160,function(){A.thump(0.55); A.whoosh(false); shake(11)}],
+  [164,function(){A.swish()}],
+  [166.5,function(){A.snap()}],
+  [167,function(){A.revSwell()}],
+  [174,function(){A.error()}],
+  [178,function(){A.zap()}], [178.2,function(){A.tickSwarm()}],
+  [180.5,function(){A.slurp()}],
+  [181.3,function(){A.stampSfx(); shake(16)}],
+  [183.5,function(){A.clapShut(); A.musicKill()}],
+  [192,function(){A.creak()}],
+  [216.8,function(){A.squeak(); A.pop()}],
+  [228.1,function(){A.whisper({syl:4,size:0.02,vol:0.09,slow:1.1})}],
+  [231.9,function(){A.whoosh(true)}],
+  [238,function(){A.horn()}],
+  [244,function(){A.chime()}], [248,function(){A.chime()}], [252,function(){A.chime()}], [255,function(){A.chime()}]
+];
+CUES.sort(function(a,b){return a[0]-b[0]});
+var cueIdx=0;
+function cueStep(t){
+  while(cueIdx<CUES.length&&CUES[cueIdx][0]<=t){
+    if(t-CUES[cueIdx][0]<=1.5&&playing) CUES[cueIdx][1]();
+    cueIdx++;
+  }
+}
+function cueSeek(t){
+  cueIdx=0;
+  while(cueIdx<CUES.length&&CUES[cueIdx][0]<=t) cueIdx++;
+}
+
+/* the country dropdown of despair: 195 options, four United States, no Germany */
+(function(){
+  var base=('Afghanistan Albania Algeria Andorra Angola Argentina Armenia Australia Austria Azerbaijan Bahamas Bahrain Bangladesh Barbados Belarus Belgium Belize Benin Bhutan Bolivia Botswana Brazil Brunei Bulgaria Cambodia Cameroon Canada Chad Chile China Colombia Croatia Cuba Cyprus Czechia Denmark Djibouti Dominica Ecuador Egypt Estonia Eswatini Ethiopia Fiji Finland France Gabon Gambia Georgia Ghana Greece Grenada Guatemala Guinea Guyana Haiti Honduras Hungary Iceland India Indonesia Iran Iraq Ireland Israel Italy Jamaica Japan Jordan Kazakhstan Kenya Kiribati Kuwait Laos Latvia Lebanon Lesotho Liberia Libya Liechtenstein Lithuania Luxembourg Madagascar Malawi Malaysia Maldives Mali Malta Mauritania Mauritius Mexico Moldova Monaco Mongolia Montenegro Morocco Mozambique Myanmar Namibia Nauru Nepal Netherlands Nicaragua Niger Nigeria Norway Oman Pakistan Palau Panama Paraguay Peru Philippines Poland Portugal Qatar Romania Rwanda Samoa Senegal Serbia Seychelles Singapore Slovakia Slovenia Somalia Spain Sudan Suriname Sweden Switzerland Syria Taiwan Tajikistan Tanzania Thailand Togo Tonga Tunisia Turkey Turkmenistan Tuvalu Uganda Ukraine Uruguay Uzbekistan Vanuatu Venezuela Vietnam Yemen Zambia Zimbabwe').split(' ');
+  [12,33,54,75].forEach(function(p,i){ base.splice(p+i,0,'United States') });
+  var i=0;
+  while(base.length<195){ base.push(base[(i*7)%140]+' (Territory)'); i++; }
+  var html='';
+  for(var k=0;k<base.length;k++) html+='<li'+(base[k]==='United States'?' class="us"':'')+'>'+base[k]+'</li>';
+  $('#dd-list').innerHTML=html;
+})();
+
+/* ============================ DOM UI PAINTERS (all derived from t) ============================ */
+var subsEl=$('#subs'), subCur=-1;
+function subsPaint(t){
+  var hit=-1;
+  for(var i=0;i<SUBS.length;i++) if(t>=SUBS[i][0]&&t<SUBS[i][1]){ hit=i; break }
+  if(hit===subCur) return;
+  subCur=hit;
+  if(hit<0){ subsEl.className=''; subsEl.textContent=''; return }
+  subsEl.textContent=SUBS[hit][3];
+  subsEl.className='on who-'+SUBS[hit][2];
+}
+
+var popPool=[], popsEl=$('#pops');
+for(var pi=0;pi<8;pi++){ var d=document.createElement('div'); popsEl.appendChild(d); popPool.push({el:d, owner:null}) }
+function popupsPaint(t){
+  for(var i=0;i<POPUPS.length;i++){
+    var p=POPUPS[i], on=t>=p.t0&&t<p.t0+p.dur;
+    if(on&&!p.slot){
+      for(var j=0;j<popPool.length;j++) if(!popPool[j].owner){
+        p.slot=popPool[j]; p.slot.owner=p;
+        var el=p.slot.el;
+        el.className='pop '+p.cls; el.innerHTML=p.html;
+        el.style.left=p.st.left||''; el.style.top=p.st.top||''; el.style.right=p.st.right||'';
+        break;
+      }
+    }
+    if(!on&&p.slot){ p.slot.el.className='pop'; p.slot.el.style.opacity=0; p.slot.owner=null; p.slot=null }
+    if(on&&p.slot){
+      var k=t-p.t0, kin=eo(k/0.35), kout=1-ei((k-(p.dur-0.4))/0.4);
+      var a=Math.min(kin,kout), e=p.slot.el;
+      e.style.opacity=clamp(a,0,1).toFixed(3);
+      if(p.cls==='stamp') e.style.transform='translate(-50%,-50%) rotate(-8deg) scale('+lerp(2.4,1,eo(k/0.22)).toFixed(3)+')';
+      else if(p.cls==='stampS') e.style.transform='rotate(-6deg) scale('+lerp(1.9,1,eo(k/0.2)).toFixed(3)+')';
+      else e.style.transform='translateY('+((1-kin)*26).toFixed(1)+'px)';
+    }
+  }
+}
+
+/* title card: deterministic neon flicker */
+var titleEl=$('#title'), tMain=$('#t-main'), tCred=$('#t-cred');
+function titlePaint(t){
+  if(t>9||t<0.8){ titleEl.style.opacity=0; return }
+  var fl=1;
+  if(t<4.6){ var h=hash(Math.floor(t*26)); fl=h>0.3?1:0.18+h*1.8 }
+  var a=sm(0.9,1.9,t)*(1-sm(7.9,8.7,t));
+  titleEl.style.opacity=(a).toFixed(3);
+  tMain.style.opacity=fl.toFixed(3);
+  tCred.style.opacity=(sm(4.8,5.8,t)*(1-sm(7.6,8.3,t))).toFixed(3);
+}
+
+/* fake OS window (acts 2): content schedule derived from t */
+var oswin=$('#oswin'), osBody=$('#os-body'), osTitle=$('#os-title'), osSig='';
+var OS1=[[44,'bad','✕','Please create an account.'],
+         [48,'bad','✕','Your session has expired.'],
+         [52,'info','↥','Please upload your résumé.'],
+         [55,'bad','⟳','Now please re-enter everything manually.']];
+function oswinPaint(t){
+  var on=(t>=43&&t<59.5)||(t>=64&&t<70.5);
+  oswin.style.opacity=on?clamp((t>=64?(t-64):(t-43))/0.5,0,1)*(t>=64?(1-sm(69.8,70.5,t)):(1-sm(58.8,59.5,t))):0;
+  if(!on){ osSig=''; return }
+  var sig,h='';
+  if(t<60){
+    osTitle.textContent='careers portal — tab 47 of 47';
+    var n=0; for(var i=0;i<OS1.length;i++) if(t>=OS1[i][0]) n=i+1;
+    sig='a'+n;
+    if(sig!==osSig){
+      for(var k=0;k<n;k++) h+='<div class="ol '+OS1[k][1]+'"><span class="ic">'+OS1[k][2]+'</span><span>'+OS1[k][3]+'</span></div>';
+      osBody.innerHTML=h; osSig=sig;
+    }
+  } else {
+    osTitle.textContent='application — step 1 of ∞';
+    var q=clamp(1+Math.floor((t-66)/0.55),1,47);
+    sig='b'+(t>=65?q:0);
+    if(sig!==osSig){
+      h='<div class="ol cnt"><span class="ic">!</span><span>Please answer 47 mandatory questions.</span></div>';
+      if(t>=65.8) h+='<div class="ol info"><span class="ic">?</span><span>question '+q+' of 47 — “explain your entire life (200 char max)”</span></div>'
+        +'<div id="os-prog"><i style="width:'+(q/47*100).toFixed(1)+'%"></i></div>';
+      osBody.innerHTML=h; osSig=sig;
+      if(q>1&&playing) A.keytick(0.05);
+    }
+  }
+}
+
+/* act 6: the calm app window — searching, tracking, drafting. never applying. */
+var appwin=$('#appwin'), awJobs=$('#aw-jobs'), awTrack=$('#aw-track'), awFields=$('#aw-fields'), awLetter=$('#aw-letter');
+var JOBS6=[['Frontend Engineer','Nordwind Labs','94%'],['UI Engineer','Kiezwerk','91%'],['Product Engineer','Lichtfeld','89%'],
+           ['Design Engineer','Morgenrot','87%'],['Web Engineer','Stadtpuls','85%'],['Creative Technologist','Funkhaus 7','83%']];
+var CHIPS6=['found 38','deduped','tracked','tailored','drafted'];
+var LETTER6='Dear Nordwind Labs,\nI build interfaces that stay out of people’s way — most recently a tool that watched 19 job boards so I could sleep.';
+var FIELDS6=[['name','Arden Voss'],['email','arden@—'],['phone','+49 •••'],['portfolio','arden.dev']];
+(function(){
+  var h='';
+  JOBS6.forEach(function(j){ h+='<div class="aw-row"><span class="dot"></span><span>'+j[0]+' · '+j[1]+'</span><span class="fade">'+j[2]+'</span></div>' });
+  awJobs.innerHTML=h;
+  h=''; CHIPS6.forEach(function(c){ h+='<span class="aw-chip">'+c+'</span>' });
+  awTrack.innerHTML=h;
+  h=''; FIELDS6.forEach(function(f){ h+='<div class="aw-field"><span class="lab">'+f[0]+'</span><span class="box"></span></div>' });
+  awFields.innerHTML=h;
+})();
+var awSig='';
+function appwinPaint(t){
+  var on=t>=193&&t<222;
+  appwin.style.opacity=on?(sm(193,194.5,t)*(1-sm(220.5,222,t))).toFixed(3):0;
+  if(!on){ awSig=''; return }
+  var rows=awJobs.children, nR=clamp(Math.floor((t-197)/1.5),0,6);
+  var chips=awTrack.children, nC=clamp(Math.floor((t-200)/2.2),0,5);
+  var len=Math.floor(LETTER6.length*sm(205,214,t));
+  var nF=clamp(Math.floor((t-198.5)/2.6),0,4);
+  var sig=nR+'.'+nC+'.'+(len/4|0)+'.'+nF;
+  if(sig===awSig) return;
+  var old=awSig.split('.'); awSig=sig;
+  for(var i=0;i<6;i++){ rows[i].style.opacity=i<nR?1:0; rows[i].style.transform=i<nR?'none':'translateY(8px)' }
+  for(i=0;i<5;i++) chips[i].className='aw-chip'+(i<nC?' done':'');
+  awLetter.innerHTML=LETTER6.slice(0,len).replace(/\n/g,'<br>')+(len>0&&len<LETTER6.length?'<i></i>':'');
+  var fields=awFields.querySelectorAll('.box');
+  for(i=0;i<4;i++) fields[i].textContent=i<nF?FIELDS6[i][1]:'';
+  if(playing){
+    if(+old[0]<nR||+old[3]<nF) A.softtick();
+    else if(+old[1]<nC) A.softtick();
+    else if(len>0&&len<LETTER6.length) A.keytick(0.018);
+  }
+}
+
+/* evolution nameplate */
+var npEl=$('#nameplate'), npName=$('#np-name'), npSub=$('#np-sub'), npCur='';
+function nameplatePaint(t){
+  var evo=null;
+  for(var i=SPR.EVOS.length-1;i>=0;i--) if(t>=SPR.EVOS[i].t&&t<SPR.EVOS[i].t+4.6){ evo=SPR.EVOS[i]; break }
+  if(t>=160.5&&t<166) evo={name:'ULTIMATE WORKDAY', sub:'v2.0.1 · scheduled maintenance Sunday', t:160.5};
+  if(!evo){ npEl.style.opacity=0; npCur=''; return }
+  if(npCur!==evo.name){ npName.textContent=evo.name; npSub.textContent=evo.sub; npCur=evo.name }
+  var k=t-evo.t;
+  npEl.style.opacity=(eo(k/0.3)*(1-ei((k-4.0)/0.6))).toFixed(3);
+  var j=k<0.4?(hash(Math.floor(t*40))-0.5)*14*(1-k/0.4):0;
+  npEl.style.transform='translateX('+j.toFixed(1)+'px)';
+}
+
+/* boss bar: full, his, gone */
+var bossbar=$('#bossbar'), bbFill=$('#bb-fill'), bbOwner=$('#bb-owner');
+function bossbarPaint(t){
+  var on=t>=164&&t<186.5;
+  bossbar.style.opacity=on?(sm(164,164.6,t)*(1-sm(185.5,186.5,t))).toFixed(3):0;
+  if(!on) return;
+  var m=sm(166.2,167.2,t);                              /* the bar walks over to him */
+  bossbar.style.top=lerp(162,640,m).toFixed(0)+'px';
+  bossbar.style.width=lerp(880,430,m).toFixed(0)+'px';
+  bbOwner.textContent=m>0.6?'(yours)':'';
+  var hp=t<180.5?1:1-eo((t-180.5)/0.7);
+  bbFill.style.width=(clamp(hp,0,1)*100).toFixed(1)+'%';
+}
+
+/* country dropdown */
+var dd=$('#dd'), ddList=$('#dd-list');
+function ddPaint(t){
+  var on=t>=177.4&&t<181.4;
+  dd.style.opacity=on?(sm(177.4,177.8,t)*(1-sm(181,181.4,t))).toFixed(3):0;
+  if(on) ddList.style.transform='translateY('+(-clamp((t-177.8)*1050,0,3400)).toFixed(0)+'px)';
+}
+
+/* act 7 cards */
+var tc1=$('#tc1'), tc2=$('#tc2'), tc3=$('#tc3'), tcCap=tc3.querySelector('.tc-cap');
+function cardsPaint(t){
+  tc1.style.opacity=(sm(244,245,t)*(1-sm(247,247.9,t))).toFixed(3);
+  tc2.style.opacity=(sm(248,249,t)*(1-sm(251,251.9,t))).toFixed(3);
+  tc3.style.opacity=(sm(252,253.2,t)*(1-sm(261,263,t))).toFixed(3);
+  tcCap.style.opacity=sm(255,256.2,t).toFixed(3);
+}
+
+/* huge faint sky subtitle (act 4 rock bottom) */
+var skysub=$('#skysub');
+function skysubPaint(t){
+  var a=sm(152,153.4,t)*(1-sm(156,157.6,t));
+  skysub.style.opacity=(a*0.8).toFixed(3);
+  if(a>0) skysub.style.transform='scale('+(1+(t-152)*0.01).toFixed(4)+')';
+}
+
+/* per-act grade + desaturation + letterbox */
+var gradeEl=$('#grade'), desatEl=$('#desat'), actCur=-1;
+var GRADES=[
+  'linear-gradient(180deg, rgba(40,90,160,.55), rgba(150,40,120,.4))',
+  'linear-gradient(180deg, rgba(60,60,150,.5), rgba(120,40,140,.35))',
+  'linear-gradient(160deg, rgba(255,45,150,.38), rgba(40,20,90,.5))',
+  'linear-gradient(180deg, rgba(90,30,150,.55), rgba(20,10,50,.45))',
+  'linear-gradient(120deg, rgba(255,40,70,.4), rgba(20,160,200,.4))',
+  'linear-gradient(180deg, rgba(90,110,140,.3), rgba(60,80,110,.3))',
+  'linear-gradient(180deg, rgba(255,150,60,.45), rgba(255,60,90,.3))'
+];
+function actOf(t){ return t<40?0:t<80?1:t<130?2:t<160?3:t<190?4:t<225?5:6 }
+function gradePaint(t){
+  var a=actOf(t);
+  if(a!==actCur){ gradeEl.style.background=GRADES[a]; actCur=a }
+  desatEl.style.opacity=(sm(184,196,t)*(1-sm(222,231,t))*0.6).toFixed(3);
+}
+function letterboxPaint(){
+  frame.style.setProperty('--lb', cam.lb.toFixed(1)+'px');
+}
+
+/* HUD */
+var tcEl=$('#timecode'), tcLast=-1;
+function hudPaint(t){
+  var s=t|0;
+  if(s!==tcLast){ tcEl.textContent=fmt(t)+' / 04:24'; tcLast=s }
+}
+
+/* ============================ SCENE PAINTERS ============================ */
+var SFXT={};                                   /* derived-sound trackers, reset on seek */
+function track(key,val,fn){ if(SFXT[key]!==val){ var had=key in SFXT; SFXT[key]=val; if(had&&playing) fn(); } }
+
+/* --- background helpers (960×540 canvas, half design scale) --- */
+function bgGrad(c0,c1,c2){
+  var g=bg.createLinearGradient(0,0,0,540);
+  g.addColorStop(0,c0); g.addColorStop(0.62,c1); g.addColorStop(1,c2);
+  bg.fillStyle=g; bg.fillRect(0,0,960,540);
+}
+function bgStars(t,n,alpha){
+  bg.fillStyle='#cfe2ff';
+  for(var i=0;i<n;i++){
+    var x=hash(i*3+1)*960, y=hash(i*5+2)*300;
+    bg.globalAlpha=alpha*(0.4+0.6*Math.abs(Math.sin(t*1.4+i)));
+    bg.fillRect(x,y,1.6,1.6);
+  }
+  bg.globalAlpha=1;
+}
+function bgStrips(t,ys,drift){
+  for(var i=0;i<3;i++){
+    var par=[0.25,0.55,1.0][i]*0.18, sc=[0.42,0.55,0.72][i];
+    var w=2400*sc, ox=-(((cam.x-W/2)*par+(drift||0)*(i+1)*t)%w);
+    if(ox>0) ox-=w;
+    bg.globalAlpha=[0.75,0.9,1][i];
+    for(var x=ox;x<960;x+=w) bg.drawImage(SPR.strips[i],x,ys[i],w,420*sc);
+  }
+  bg.globalAlpha=1;
+}
+function bgFog(t,y,alpha,n){
+  for(var i=0;i<(n||4);i++){
+    var w=460+hash(i)*340, x=((hash(i*9)*1400+t*(6+i*4))%(960+w))-w;
+    bg.globalAlpha=alpha*(0.5+0.5*hash(i+3));
+    bg.drawImage(SPR.fog,x,y+hash(i*7)*70-30,w,w*0.25);
+  }
+  bg.globalAlpha=1;
+}
+
+/* --- world helpers --- */
+function neonText(c,txt,x,y,size,color,glowTex,fl){
+  c.save();
+  c.font='900 '+size+'px "Arial Narrow",Impact,sans-serif';
+  c.textAlign='center';
+  var w=c.measureText(txt).width;
+  SPR.blitGlow(c,glowTex,x,y-size*0.32,Math.max(w*1.6,size*3),0.5*fl);
+  c.globalAlpha=fl;
+  c.fillStyle=color; c.fillText(txt,x,y);
+  c.globalAlpha=fl*0.5; c.fillStyle='#fff'; c.fillText(txt,x-1.5,y-1);
+  c.restore(); c.globalAlpha=1;
+}
+function storefronts(c,gy){
+  for(var i=0;i<6;i++){
+    var bx=i*340-40, bw=320, bh=420+hash(i*13)*220;
+    c.fillStyle=['#0c0f1c','#0a0d18','#0e1120'][i%3];
+    c.fillRect(bx,gy-bh,bw,bh);
+    c.fillStyle='rgba(140,170,220,.14)';
+    for(var wy=gy-bh+30;wy<gy-160;wy+=44)
+      for(var wx=bx+18;wx<bx+bw-30;wx+=52)
+        if(hash(wx+wy)>0.45) c.fillRect(wx,wy,26,30);
+    c.fillStyle='#070910'; c.fillRect(bx,gy-130,bw,130);              /* shopfront */
+    c.fillStyle='rgba(35,230,255,.07)'; c.fillRect(bx+16,gy-118,bw-50,86);
+  }
+}
+
+/* the train: a lit slab with windows, used far (act 1) and as a foreground wipe */
+function drawTrain(c,x,y,sc,glow){
+  c.save(); c.translate(x,y); c.scale(sc,sc);
+  if(glow) SPR.blitGlow(c,SPR.GLOW.cyn,0,0,1500,0.22);
+  c.fillStyle='#0b0e1a';
+  c.beginPath(); c.moveTo(-560,-26); c.quadraticCurveTo(-600,0,-560,26);
+  c.lineTo(540,26); c.quadraticCurveTo(600,12,600,0); c.quadraticCurveTo(600,-12,540,-26); c.closePath(); c.fill();
+  c.fillStyle='rgba(255,210,140,.85)';
+  for(var i=0;i<18;i++) c.fillRect(-520+i*60,-12,34,20);
+  c.fillStyle='rgba(35,230,255,.9)'; c.fillRect(560,-6,30,12);
+  c.restore();
+}
+
+/* per-frame ambient audio levels (derived) */
+function audioEnv(t){
+  var rain= t<16?0.6 : t<40?0.9 : t<62?0.3 : t<70?0.25 : t<76?0.2 : t<79?0 :
+            t<130?0.5 : t<150?0.3 : t<160?0.78 : t<183.5?0.85 :
+            t<190?lerp(0.85,0.18,(t-183.5)/6.5) : t<225?0.12 : Math.max(0,lerp(0.1,0,(t-225)/12));
+  var hum = t<40?0.6 : t<76?0.22 : t<79?0 : t<160?0.45 : t<190?0.35 : t<225?0.12 : 0.08;
+  var fire= (t>=118&&t<125.5)?1:0;
+  var drone=(t>=158&&t<183.5)?sm(158,162,t):0;
+  return {rain:rain, hum:hum, fire:fire, drone:drone};
+}
+
+/* ---------------- ACT 1 ---------------- */
+function scTitle(t){
+  cam.x=W/2; cam.y=H/2; cam.z=1; cam.lb=132;
+  rainCfg.on=false;
+  bgGrad('#020308','#04050c','#060812');
+  bgFog(t,380,0.1,3);
+}
+function scCity(t){
+  var k=(t-8)/8;
+  cam.x=W/2+k*120; cam.y=H/2-20; cam.z=1+k*0.07; cam.lb=132;
+  rainCfg.on=true; rainCfg.splash=false; rainCfg.dir=1; rainCfg.slant=-0.18;
+  bgGrad('#070a18','#101430','#251038');
+  bgStars(t,46,0.5);
+  bgStrips(t,[150,210,270],0);
+  bgFog(t,330,0.22,5);
+  view(wd,1);
+  /* near rooftop silhouettes */
+  wd.fillStyle='#05060d';
+  for(var i=0;i<7;i++){
+    var bx=i*300-100+((i*37)%80), bh=240+hash(i*3)*260;
+    wd.fillRect(bx,1080-bh,280,bh);
+    wd.fillStyle='rgba(160,200,255,.1)';
+    for(var wy=1080-bh+24;wy<1040;wy+=40)
+      for(var wx=bx+14;wx<bx+260;wx+=46) if(hash(wx*1.3+wy)>0.6) wd.fillRect(wx,wy,20,26);
+    wd.fillStyle='#05060d';
+  }
+  /* tower neon */
+  neonText(wd,'仕事','東'===''?0:430,360,64,'#ff5fae',SPR.GLOW.mag,0.85+0.15*Math.sin(t*9));
+  neonText(wd,'HIRE CITY',1430,300,54,'#5ff0ff',SPR.GLOW.cyn,hash(Math.floor(t*7))>0.12?1:0.4);
+  /* the flying train */
+  if(t>9.8&&t<13.6){
+    var k2=(t-9.8)/3.8, tx=lerp(-700,2600,k2);
+    drawTrain(wd,tx,430,0.9,true);
+  }
+}
+function scStreet(t){
+  var gx=t<30?lerp(560,1240,sm(16,30,t)):(t<33?1240:lerp(1240,1500,sm(33,37,t)));
+  cam.x=clamp(gx+80,800,1500); cam.y=620; cam.z=1.14; cam.lb=132;
+  rainCfg.on=true; rainCfg.splash=true; rainCfg.ground=880; rainCfg.dir=1;
+  bgGrad('#070a18','#131038','#2c1240');
+  bgStrips(t,[130,190,250],0);
+  bgFog(t,300,0.2,4);
+  view(wd,1);
+  var gy=900;
+  storefronts(wd,gy-20);
+  /* wet asphalt */
+  var rg=wd.createLinearGradient(0,gy-20,0,1080);
+  rg.addColorStop(0,'#0a0c16'); rg.addColorStop(1,'#04050a');
+  wd.fillStyle=rg; wd.fillRect(-200,gy-20,2600,220);
+  function dressing(refl){
+    /* neon signs */
+    neonText(wd,'NOODLE',330,560,58,'#ff5fae',SPR.GLOW.mag,0.9+0.1*Math.sin(t*11));
+    neonText(wd,'BAR',700,520,44,'#5ff0ff',SPR.GLOW.cyn,hash(Math.floor(t*9)+4)>0.15?1:0.3);
+    var open=t>=34.5;
+    var fl=hash(Math.floor(t*13))>0.2?1:0.35;
+    neonText(wd,open?'OPEN TO WORK':'OPEN',1560,540,46,open?'#ffd166':'#7dffb0',open?SPR.GLOW.amb:SPR.GLOW.grn,fl);
+    /* trash can the creature perches on */
+    wd.fillStyle='#0d101c'; wd.fillRect(1395,gy-86,64,66); wd.fillRect(1388,gy-94,78,10);
+    /* the guy */
+    drawGuy(wd,{x:gx,y:gy,s:1.06,pose:t<30?'walk':(t<33?'stand':'walk'),ph:gx*0.045,umbrella:true,
+      rim:refl?'rgba(35,230,255,.4)':'rgba(35,230,255,.8)'});
+    /* the creature: appears 26, vanishes 30.2, reappears closer 31.1 */
+    if(t>=26&&t<30.2) drawCreature(wd,{x:1430,y:gy-86,size:0.07,t:t,eye:1});
+    if(t>=31.1&&t<36) drawCreature(wd,{x:gx-180,y:gy-2,size:0.085,t:t,eye:1.1,flip:true});
+  }
+  dressing(false);
+  /* puddle reflection */
+  wd.save();
+  wd.beginPath(); wd.rect(-200,gy,2600,200); wd.clip();
+  wd.translate(0,2*gy); wd.scale(1,-1); wd.globalAlpha=0.2;
+  dressing(true);
+  wd.restore(); wd.globalAlpha=1;
+  /* ripple streaks */
+  wd.strokeStyle='rgba(180,210,255,.05)'; wd.lineWidth=2;
+  for(var i=0;i<9;i++){ var ry=gy+14+i*16; wd.beginPath(); wd.moveTo(200+hash(i)*300,ry); wd.lineTo(900+hash(i*3)*900,ry); wd.stroke(); }
+  /* vanish puffs */
+  function puff(x,y,t0){
+    var k=(t-t0)/0.5; if(k<0||k>1) return;
+    wd.globalAlpha=1-k;
+    SPR.blitGlow(wd,SPR.GLOW.mag,x,y,60+k*160,0.5*(1-k));
+    wd.globalAlpha=1;
+  }
+  puff(1430,gy-130,30.2); puff(gx-180,gy-50,31.1);
+  /* foreground train wipe */
+  if(t>=37&&t<40){
+    var k3=(t-37)/3, tx=lerp(2800,-3400,eio(k3));
+    drawTrain(wd,tx,640,3.4,true);
+  }
+}
+
+/* ---------------- ACT 2 ---------------- */
+function aptRoom(t,dawn){
+  bgGrad(dawn?'#10141f':'#06070f',dawn?'#161b29':'#090b16',dawn?'#1d2230':'#0c0e1a');
+  view(wd,1);
+  /* wall + floor */
+  wd.fillStyle=dawn?'#141823':'#0a0c15'; wd.fillRect(-200,-200,2400,1100);
+  wd.fillStyle=dawn?'#10131c':'#070910'; wd.fillRect(-200,820,2400,460);
+  /* window with the city */
+  var wx=1280,wy=170,ww=470,wh=470;
+  wd.fillStyle=dawn?'#2a3550':'#11142c'; wd.fillRect(wx-14,wy-14,ww+28,wh+28);
+  var sg=wd.createLinearGradient(0,wy,0,wy+wh);
+  if(dawn){ sg.addColorStop(0,'#24314e'); sg.addColorStop(1,'#3d4a66'); }
+  else { sg.addColorStop(0,'#0d1130'); sg.addColorStop(1,'#311744'); }
+  wd.fillStyle=sg; wd.fillRect(wx,wy,ww,wh);
+  /* mini skyline through glass */
+  wd.save(); wd.beginPath(); wd.rect(wx,wy,ww,wh); wd.clip();
+  wd.globalAlpha=0.9; wd.drawImage(SPR.strips[2],wx-160-(dawn?0:8),wy+wh-240,1400,245);
+  if(!dawn){
+    SPR.blitGlow(wd,SPR.GLOW.mag,wx+120,wy+260,200,0.25);
+    SPR.blitGlow(wd,SPR.GLOW.cyn,wx+360,wy+300,160,0.2);
+  }
+  /* rain on glass */
+  wd.strokeStyle='rgba(190,215,250,.13)'; wd.lineWidth=2;
+  for(var i=0;i<14;i++){
+    var rx=wx+hash(i*7)*ww, ry=((t*120*(0.5+hash(i))+hash(i*3)*wh)%wh);
+    wd.beginPath(); wd.moveTo(rx,wy+ry); wd.lineTo(rx-3,wy+ry+26); wd.stroke();
+  }
+  wd.restore(); wd.globalAlpha=1;
+  wd.strokeStyle=dawn?'#39455f':'#1d2240'; wd.lineWidth=8;
+  wd.beginPath(); wd.moveTo(wx+ww/2,wy); wd.lineTo(wx+ww/2,wy+wh); wd.moveTo(wx,wy+wh/2); wd.lineTo(wx+ww,wy+wh/2); wd.stroke();
+  /* desk */
+  wd.fillStyle=dawn?'#1c2231':'#12151f'; wd.fillRect(420,760,640,26);
+  wd.fillRect(470,786,30,140); wd.fillRect(980,786,30,140);
+  return {wx:wx,wy:wy,ww:ww,wh:wh};
+}
+function laptop(c,x,y,open,glow,dawn){
+  c.save(); c.translate(x,y);
+  c.fillStyle='#181c28'; c.fillRect(-90,-8,180,10);                  /* base */
+  c.save(); c.rotate(-open*1.62);
+  c.fillStyle='#141826'; c.fillRect(0,-6,150,8);                     /* lid */
+  c.restore();
+  if(open>0.8&&glow>0){
+    var sc=c.createLinearGradient(-80,-110,0,0);
+    sc.addColorStop(0,'rgba(120,180,255,'+0.13*glow+')'); sc.addColorStop(1,'rgba(120,180,255,0)');
+    c.fillStyle=sc;
+    c.beginPath(); c.moveTo(-2,-8); c.lineTo(-30,-150); c.lineTo(120,-150); c.lineTo(60,-8); c.closePath(); c.fill();
+  }
+  c.restore();
+}
+function scApt(t){
+  cam.x=W/2-40; cam.y=560; cam.z=1.06+0.05*sm(40,60,t); cam.lb=132;
+  rainCfg.on=false;
+  aptRoom(t,false);
+  var flick=0.8+0.2*hash(Math.floor(t*17));
+  laptop(wd,740,760,1,flick,false);
+  drawGuy(wd,{x:660,y:905,s:1.12,pose:'sit',rim:'rgba(120,180,255,.6)'});
+  /* shelf creature: grows with every ding */
+  var grow=0.1+(t>=48.3?0.05:0)+(t>=52.3?0.05:0)+(t>=55.3?0.05:0)+(t>=57.2?0.04:0);
+  wd.fillStyle='#10131e'; wd.fillRect(210,470,190,16); wd.fillRect(210,486,16,440);
+  drawCreature(wd,{x:305,y:470,size:grow,t:t,eye:1});
+  /* printer */
+  wd.fillStyle='#161a26'; wd.fillRect(1100,718,140,46);
+  wd.fillStyle='#0a0c14'; wd.fillRect(1116,712,108,8);
+  if(t>56.7&&t<57.5){ wd.save(); wd.translate(hash(Math.floor(t*60))*4-2,0); wd.fillStyle='#161a26'; wd.fillRect(1100,718,140,46); wd.restore(); }
+  paperStep(0); paperDraw(wd,2.2);
+  track('key2',Math.floor(t*6),function(){ if(t>42&&t<56) A.keytick(0.04) });
+}
+function scCoffee(t){
+  cam.x=W/2; cam.y=560; cam.z=1.05; cam.lb=132;
+  rainCfg.on=false;
+  bgGrad('#0b0a12','#120e18','#181020');
+  view(wd,1);
+  wd.fillStyle='#120f1a'; wd.fillRect(-200,-200,2400,1100);
+  wd.fillStyle='#0d0a13'; wd.fillRect(-200,830,2400,450);
+  /* hanging lamps */
+  for(var i=0;i<3;i++){
+    var lx=480+i*420;
+    wd.strokeStyle='#211a28'; wd.lineWidth=4; wd.beginPath(); wd.moveTo(lx,0); wd.lineTo(lx,210); wd.stroke();
+    wd.fillStyle='#241a20'; wd.beginPath(); wd.arc(lx,224,26,Math.PI,0); wd.fill();
+    SPR.blitGlow(wd,SPR.GLOW.amb,lx,250,180,0.4);
+  }
+  /* big window, the creature outside */
+  var wx=170,wy=260,ww=620,wh=520;
+  wd.fillStyle='#241c2c'; wd.fillRect(wx-16,wy-16,ww+32,wh+32);
+  var ng=wd.createLinearGradient(0,wy,0,wy+wh);
+  ng.addColorStop(0,'#0c1030'); ng.addColorStop(1,'#2c1340');
+  wd.fillStyle=ng; wd.fillRect(wx,wy,ww,wh);
+  wd.save(); wd.beginPath(); wd.rect(wx,wy,ww,wh); wd.clip();
+  wd.globalAlpha=0.85; wd.drawImage(SPR.strips[2],wx-100,wy+wh-200,1300,205); wd.globalAlpha=1;
+  /* pressed face: squished, eye huge, palms on glass */
+  wd.save(); wd.translate(0,8*Math.sin(t*1.1)); wd.scale(1.12,0.94);
+  drawCreature(wd,{x:(wx+ww/2)/1.12,y:(wy+wh-30)/0.94,size:0.42,t:t,eye:1.35,eyeX:4,wob:0.3});
+  wd.restore();
+  wd.fillStyle='rgba(8,9,18,.95)';
+  wd.beginPath(); wd.ellipse(wx+200,wy+300,34,46,-0.3,0,7); wd.fill();
+  wd.beginPath(); wd.ellipse(wx+440,wy+310,34,46,0.3,0,7); wd.fill();
+  wd.strokeStyle='rgba(220,235,255,.1)'; wd.lineWidth=10;
+  wd.beginPath(); wd.moveTo(wx+90,wy+90); wd.lineTo(wx+260,wy+260); wd.stroke();
+  wd.beginPath(); wd.moveTo(wx+380,wy+60); wd.lineTo(wx+560,wy+240); wd.stroke();
+  wd.restore();
+  /* table + guy */
+  wd.fillStyle='#1d1622'; wd.fillRect(1010,800,460,22); wd.fillRect(1200,822,36,120);
+  laptop(wd,1240,800,1,0.9,false);
+  drawGuy(wd,{x:1150,y:942,s:1.1,pose:'sit',rim:'rgba(255,177,77,.55)'});
+  wd.fillStyle='#241a20'; wd.fillRect(1390,776,30,24); /* the coffee he cannot afford */
+}
+function scBath(t){
+  cam.x=W/2; cam.y=540; cam.z=1.12; cam.lb=132;
+  rainCfg.on=false;
+  bgGrad('#0a0d12','#0e1118','#11141c');
+  view(wd,1);
+  var fl=hash(Math.floor(t*23))>0.12?1:0.45;            /* dying fluorescent */
+  wd.fillStyle='#10141c'; wd.fillRect(-200,-200,2400,1300);
+  wd.strokeStyle='rgba(160,190,220,.07)'; wd.lineWidth=2;
+  for(var x=0;x<1920;x+=120){ wd.beginPath(); wd.moveTo(x,0); wd.lineTo(x,1080); wd.stroke(); }
+  for(var y=80;y<1080;y+=120){ wd.beginPath(); wd.moveTo(0,y); wd.lineTo(1920,y); wd.stroke(); }
+  SPR.blitGlow(wd,SPR.GLOW.wht,960,80,700,0.25*fl);
+  /* sink */
+  wd.fillStyle='#1a2030'; wd.fillRect(800,760,320,40);
+  wd.fillStyle='#141a28'; wd.fillRect(860,800,200,140);
+  wd.strokeStyle='rgba(170,210,255,.5)'; wd.lineWidth=3.5;
+  wd.beginPath(); wd.moveTo(960,742); wd.lineTo(960,790+hash(Math.floor(t*40))*6); wd.stroke();
+  /* mirror — the only place it exists */
+  var mx=770,my=240,mw=380,mh=460;
+  wd.fillStyle='#202a3c'; wd.fillRect(mx-12,my-12,mw+24,mh+24);
+  var mg=wd.createLinearGradient(mx,my,mx+mw,my+mh);
+  mg.addColorStop(0,'#1b2536'); mg.addColorStop(1,'#0e1422');
+  wd.fillStyle=mg; wd.fillRect(mx,my,mw,mh);
+  wd.save(); wd.beginPath(); wd.rect(mx,my,mw,mh); wd.clip();
+  wd.globalAlpha=0.92*fl;
+  drawGuy(wd,{x:mx+mw/2,y:my+mh+150,s:1.5,pose:'stand',rim:'rgba(170,210,255,.4)'});
+  drawCreature(wd,{x:mx+mw/2+110,y:my+mh-10,size:0.3,t:t,eye:1.25,flip:true});
+  wd.restore(); wd.globalAlpha=1;
+  /* the guy himself — alone, allegedly */
+  drawGuy(wd,{x:960,y:1056,s:1.7,pose:'stand',rim:'rgba(170,210,255,.5)'});
+}
+function scDream(t){
+  cam.x=W/2; cam.y=H/2; cam.z=1; cam.lb=132;
+  rainCfg.on=false;
+  bgGrad('#070a1c','#0b0f2a','#101536');
+  view(wd,1);
+  var dy=(t-76)*26;
+  for(var i=0;i<80;i++){
+    var x=hash(i*3)*1920, y=(hash(i*5)*1080-dy)%1080; if(y<0)y+=1080;
+    var tw=0.35+0.65*Math.abs(Math.sin(t*2.4+i));
+    wd.globalAlpha=tw*0.8; wd.strokeStyle='#9fd2ff'; wd.lineWidth=2;
+    wd.strokeRect(x,y,12,12);
+    if(hash(i*7)>0.55){ wd.beginPath(); wd.moveTo(x+2,y+6); wd.lineTo(x+5,y+9); wd.lineTo(x+10,y+2); wd.stroke(); }
+  }
+  wd.globalAlpha=1;
+  /* the constellation: one giant required checkbox */
+  var cx=960, cy=470-dy*0.3, k=sm(76.4,78.4,t);
+  wd.strokeStyle='rgba(255,209,102,'+(0.7*k)+')'; wd.lineWidth=5;
+  wd.strokeRect(cx-130,cy-130,260,260);
+  wd.beginPath(); wd.moveTo(cx-70,cy+10); wd.lineTo(cx-12,cy+72); wd.lineTo(cx+96,cy-66);
+  wd.globalAlpha=k; wd.stroke(); wd.globalAlpha=1;
+  neonText(wd,'* REQUIRED',cx,cy+230,40,'#ffd166',SPR.GLOW.amb,k);
+}
+
+/* ---------------- ACT 3: the arena ---------------- */
+function curEvo(t){
+  var e=null;
+  for(var i=SPR.EVOS.length-1;i>=0;i--) if(t>=SPR.EVOS[i].t){ e=SPR.EVOS[i]; break }
+  return e;
+}
+function scArena(t){
+  var evo=curEvo(t);
+  var punch=0;
+  for(var i=0;i<SPR.EVOS.length;i++){ var k=t-SPR.EVOS[i].t; if(k>=0&&k<0.8) punch=Math.max(punch,(1-eo(k/0.8))*0.16) }
+  cam.x=lerp(960,1060,sm(80,128,t)); cam.y=lerp(540,470,sm(125,128.5,t)); cam.z=(1+0.1*sm(80,130,t))*(1+punch); cam.lb=132;
+  rainCfg.on=true; rainCfg.splash=false; rainCfg.dir=1;
+  bgGrad('#0a0716','#1c0c30','#33103e');
+  bgStars(t,30,0.3);
+  bgStrips(t,[150,205,260],0);
+  bgFog(t,300,0.24,5);
+  view(wd,1);
+  var gy=920;
+  /* city floor band */
+  wd.fillStyle='#05060d'; wd.fillRect(-400,gy,2800,300);
+  wd.fillStyle='#0a0d18';
+  for(var b=0;b<9;b++){ var bx=-300+b*300, bh=130+hash(b*11)*200; wd.fillRect(bx,gy-bh,260,bh);
+    wd.fillStyle='rgba(150,180,230,.12)';
+    for(var wy2=gy-bh+18;wy2<gy-20;wy2+=34) for(var wx2=bx+12;wx2<bx+240;wx2+=40) if(hash(wx2+wy2*3)>0.55) wd.fillRect(wx2,wy2,18,22);
+    wd.fillStyle='#0a0d18';
+  }
+  var mx=1240;                                          /* monster anchor */
+  if(!evo){
+    /* the eclipse: the un-evolved thing, building-sized, rising behind the skyline */
+    var rise=sm(79.4,84,t);
+    wd.save(); wd.translate(mx,gy-100+(1-rise)*500); wd.scale(3.4,3.4);
+    drawCreature(wd,{x:0,y:0,size:1,t:t,eye:1.1});
+    wd.restore();
+  } else {
+    var ek=t-evo.t, settle=1+0.22*(1-eo(clamp(ek/0.45,0,1)));
+    var sc=evo.sc*settle, sw=evo.spr.w*sc, sh2=evo.spr.h*sc;
+    wd.drawImage(evo.spr.c,mx-sw/2,gy-sh2+10,sw,sh2);
+    /* the eye(s) — drawn live so they pulse and watch */
+    for(var e2=0;e2<evo.spr.eyes.length;e2++){
+      var eye=evo.spr.eyes[e2];
+      var ex=mx-sw/2+eye[0]*sc, ey=gy-sh2+10+eye[1]*sc, er=eye[2]*sc;
+      var boost=1;
+      if(evo.name==='RECRUITER HYDRA'){
+        var qs=[[96.9,98.4],[98.6,100],[100.3,101.7]][e2];
+        if(qs&&t>=qs[0]&&t<qs[1]) boost=1.7;
+      }
+      SPR.blitGlow(wd,SPR.GLOW.mag,ex,ey,er*6*boost,0.5+0.25*Math.sin(t*3.7+e2));
+      wd.fillStyle='#ff2d96'; wd.beginPath(); wd.arc(ex,ey,er*0.62*boost,0,7); wd.fill();
+      wd.fillStyle='#ffd7ea'; wd.beginPath(); wd.arc(ex+er*0.15,ey-er*0.15,er*0.2*boost,0,7); wd.fill();
+    }
+    /* ATS DRAGON: résumés stream into the shredder jaw, embers out */
+    if(evo.name==='ATS DRAGON'){
+      var jawX=mx-sw/2+250*sc, jawY=gy-sh2+10+230*sc;
+      for(var p2=0;p2<9;p2++){
+        var fk=((t*0.42)+p2/9)%1;
+        var px=lerp(-150,jawX,fk), py=lerp(gy-60,jawY,fk)+Math.sin(fk*9+p2)*40;
+        wd.save(); wd.translate(px,py); wd.rotate(fk*5+p2);
+        wd.globalAlpha=fk<0.92?1:1-(fk-0.92)/0.08;
+        wd.drawImage(SPR.paper,-22,-30,44,60); wd.restore();
+      }
+      wd.globalAlpha=1;
+      if(playing&&t<125) for(var s2=0;s2<3;s2++) emberSpawn(jawX+hash(s2+t)*40,jawY);
+      /* the lone survivor, blessed and stamped */
+      if(t>=120.6&&t<125){
+        var fl2=Math.sin(t*2.2)*10;
+        SPR.blitGlow(wd,SPR.GLOW.grn,1010,430+fl2,260,0.45);
+        wd.save(); wd.translate(1010,430+fl2); wd.rotate(-0.05);
+        wd.drawImage(SPR.paper,-45,-60,90,120); wd.restore();
+      }
+    }
+  }
+  emberStep(0); emberDraw(wd);
+  confStep(0); confDraw(wd);
+  /* the guy, very small, reconsidering everything */
+  drawGuy(wd,{x:430,y:gy+88,s:1,pose:'stand',rim:'rgba(255,45,150,.7)'});
+}
+
+/* ---------------- ACT 4 ---------------- */
+function scPull(t){
+  /* one continuous pull-back; the city shrinks faster than the thing does */
+  var z=1;
+  z=lerp(1,0.52,eio(sm(130,131.6,t)));
+  z=lerp(z,0.24,eio(sm(134,135.6,t)));
+  z=lerp(z,0.105,eio(sm(138,139.6,t)));
+  cam.x=960; cam.y=540; cam.z=1; cam.lb=132;
+  rainCfg.on=true; rainCfg.splash=false; rainCfg.intensity=0.5;
+  bgGrad('#0a0718','#190d33','#2a1242');
+  bgStars(t,60,0.6);
+  view(wd,1);
+  wd.save(); wd.translate(960,760); wd.scale(z,z); wd.translate(-960,-760);
+  /* ground + city diorama */
+  wd.fillStyle='#04050c'; wd.fillRect(960-4200,760,8400,2600);
+  for(var rep=-2;rep<=2;rep++) wd.drawImage(SPR.strips[2],960-1200+rep*2400,760-560,2400,560);
+  for(rep=-3;rep<=3;rep++){ wd.globalAlpha=0.8; wd.drawImage(SPR.strips[1],960-1100+rep*2200,760-380,2200,385); }
+  wd.globalAlpha=1;
+  /* mountains appear as we leave the city */
+  if(z<0.6){
+    wd.fillStyle='#0b0d1e';
+    for(var m=0;m<6;m++){
+      var mw2=2400, mxx=960-6000+m*2200;
+      wd.beginPath(); wd.moveTo(mxx,760); wd.lineTo(mxx+mw2*0.5,760-1300-hash(m)*700); wd.lineTo(mxx+mw2,760); wd.closePath(); wd.fill();
+    }
+  }
+  wd.restore();
+  /* the thing — it scales against the zoom, so it only ever gets bigger */
+  var ap=Math.pow(z,0.32), tit=SPR.EVOS[4];
+  var sw=tit.spr.w*4.6*ap, sh3=tit.spr.h*4.6*ap;
+  wd.globalAlpha=0.92;
+  wd.drawImage(tit.spr.c,1210-sw/2,760*lerp(1,0.9,1-z)+(760-sh3)*0+760-sh3*0.96,sw,sh3);
+  wd.globalAlpha=1;
+  var ex=1210-sw/2+tit.spr.eyes[0][0]*4.6*ap, ey=760-sh3*0.96+tit.spr.eyes[0][1]*4.6*ap;
+  /* at full pull-back the eye reads as the moon */
+  var moonK=sm(138.5,140.5,t);
+  SPR.blitGlow(wd,SPR.GLOW.mag,ex,ey,tit.spr.eyes[0][2]*4.6*ap*7*(1+moonK*1.2),0.55+0.3*moonK);
+  wd.fillStyle='#ff2d96'; wd.beginPath(); wd.arc(ex,ey,tit.spr.eyes[0][2]*4.6*ap*0.62,0,7); wd.fill();
+  wd.fillStyle='#ffe2f1'; wd.beginPath(); wd.arc(ex,ey,tit.spr.eyes[0][2]*4.6*ap*0.26,0,7); wd.fill();
+  /* clouds slide past as we rise */
+  bgFog(t,120+260*z,0.3,5);
+}
+function scCurb(t){
+  cam.x=820; cam.y=640; cam.z=1.22; cam.lb=132;
+  rainCfg.on=true; rainCfg.splash=true; rainCfg.ground=900; rainCfg.dir=1; rainCfg.intensity=1;
+  bgGrad('#06060e','#0b0a1c','#140d24');
+  bgStrips(t,[150,205,260],0);
+  view(wd,1);
+  var gy=920;
+  storefronts(wd,gy-30);
+  wd.fillStyle='#04050a'; wd.fillRect(-200,gy-30,2600,230);
+  /* one broken sign, barely trying */
+  var fl=hash(Math.floor(t*5))>0.5?(hash(Math.floor(t*17))>0.3?0.55:0.1):0.06;
+  neonText(wd,'OPE N',600,520,52,'#ff5fae',SPR.GLOW.mag,fl);
+  /* the sky is mostly eye now */
+  SPR.blitGlow(wd,SPR.GLOW.vio,1500,160,900,0.1+0.04*Math.sin(t*0.7));
+  /* curb + the guy at the bottom of it */
+  wd.fillStyle='#0d101a'; wd.fillRect(560,gy-36,560,18);
+  drawGuy(wd,{x:800,y:gy+46,s:1.3,pose:'sit',rim:'rgba(150,120,255,.45)'});
+  /* puddle holding the broken sign */
+  wd.save(); wd.globalAlpha=0.16; wd.translate(0,2*(gy+30)); wd.scale(1,-1);
+  neonText(wd,'OPE N',600,520,52,'#ff5fae',SPR.GLOW.mag,fl);
+  wd.restore(); wd.globalAlpha=1;
+}
+
+/* ---------------- ACT 5: ULTIMATE WORKDAY ---------------- */
+function scBoss(t){
+  var tt=Math.min(t,181.3);                          /* the boss freezes on DEFEATED */
+  cam.x=960; cam.y=520; cam.z=1+0.04*Math.sin(tt*0.4); cam.lb=lerp(132,0,sm(160,162,t));
+  if(t>186) cam.lb=lerp(0,132,sm(188,190,t));
+  rainCfg.on=true; rainCfg.splash=false; rainCfg.intensity=t<183.5?1:Math.max(0.15,1-(t-183.5)/7);
+  rainCfg.dir=(t>=167&&t<180.5&&!reduce)?-1:1;
+  bgGrad('#060410','#120826','#1c0a30');
+  bgStars(t,24,0.25);
+  bgStrips(tt,[170,225,275],0);
+  view(wd,1);
+  var die=t<183.5?1:1-eo(clamp((t-183.5)/0.7,0,1)); /* implosion on lid close */
+  var gy=980;
+  /* perspective grid floor */
+  wd.strokeStyle='rgba(35,230,255,'+(0.14*die)+')'; wd.lineWidth=2;
+  for(var i2=0;i2<12;i2++){ var fy=gy-2+Math.pow(i2/12,2)*-300; wd.beginPath(); wd.moveTo(-400,gy+i2*14); wd.lineTo(2320,gy+i2*14); wd.stroke(); }
+  for(i2=-10;i2<=10;i2++){ wd.beginPath(); wd.moveTo(960+i2*90,gy); wd.lineTo(960+i2*340,1180); wd.stroke(); }
+  if(die>0.01){
+    wd.save(); wd.translate(960,470); wd.scale(die,die); wd.translate(-960,-470);
+    /* tentacle dropdown ribbons */
+    wd.lineCap='round';
+    for(var tn=0;tn<4;tn++){
+      var bx=700+tn*170, wig=Math.sin(tt*1.3+tn*2)*90;
+      wd.strokeStyle='#0a0f20'; wd.lineWidth=34;
+      wd.beginPath(); wd.moveTo(960,640); wd.quadraticCurveTo(bx+wig,800,bx-60+wig*0.4,gy); wd.stroke();
+      wd.strokeStyle='rgba(35,230,255,.4)'; wd.lineWidth=3;
+      wd.beginPath(); wd.moveTo(960,640); wd.quadraticCurveTo(bx+wig,800,bx-60+wig*0.4,gy); wd.stroke();
+    }
+    /* the central monolith of forms */
+    SPR.blitGlow(wd,SPR.GLOW.vio,960,400,1300,0.3);
+    wd.fillStyle='#070b18'; wd.fillRect(770,160,380,500);
+    wd.strokeStyle='rgba(120,140,200,.5)'; wd.lineWidth=4; wd.strokeRect(770,160,380,500);
+    for(var fy2=0;fy2<4;fy2++) for(var fx2=0;fx2<2;fx2++)
+      wd.drawImage(SPR.formTile,786+fx2*180,210+fy2*108,170,100);
+    /* THE eye */
+    var elook=Math.sin(tt*0.6)*10-14;
+    SPR.blitGlow(wd,SPR.GLOW.mag,960+elook,120,420,0.75+0.2*Math.sin(tt*2.3));
+    wd.fillStyle='#ff2d96'; wd.beginPath(); wd.arc(960+elook,120,44,0,7); wd.fill();
+    wd.fillStyle='#fff'; wd.beginPath(); wd.arc(960+elook-8,112,13,0,7); wd.fill();
+    /* orbiting paperwork */
+    for(var ob=0;ob<12;ob++){
+      var ang=tt*(0.35+hash(ob)*0.25)+ob*0.524, rad=420+hash(ob*3)*260;
+      var ox=960+Math.cos(ang)*rad, oy=430+Math.sin(ang)*rad*0.42;
+      var osc2=0.5+hash(ob*7)*0.7, tex=ob%4===3?SPR.captcha:SPR.formTile;
+      wd.save(); wd.translate(ox,oy); wd.rotate(Math.sin(ang)*0.2); wd.globalAlpha=0.85;
+      wd.drawImage(tex,-tex.width*osc2/2,-tex.height*osc2/2,tex.width*osc2,tex.height*osc2);
+      wd.restore();
+    }
+    wd.globalAlpha=1;
+    /* checkbox tick swarm */
+    wd.strokeStyle='rgba(35,230,255,.7)'; wd.lineWidth=2;
+    for(var cb=0;cb<24;cb++){
+      var ca=tt*(1.1+hash(cb)*0.8)+cb, cr=240+hash(cb*5)*420;
+      var cx2=960+Math.cos(ca)*cr, cy2=430+Math.sin(ca)*cr*0.4;
+      wd.strokeRect(cx2,cy2,10,10);
+      if(hash(cb*3)>0.5){ wd.beginPath(); wd.moveTo(cx2+2,cy2+5); wd.lineTo(cx2+4,cy2+8); wd.lineTo(cx2+9,cy2+2); wd.stroke(); }
+    }
+    wd.restore();
+  }
+  /* hero shot: the guy plants his feet, laptop out */
+  var heroS=1.06+0.1*sm(166,172,t);
+  drawGuy(wd,{x:430,y:gy+72,s:heroS,pose:t<183.2?'type':'stand',rim:'rgba(35,230,255,.9)'});
+  if(t<183.4) laptop(wd,500,gy+40,1,1,false);
+  else laptop(wd,500,gy+40,Math.max(0,1-(t-183.4)*4),0,false);
+  /* after the cut: he stands in the dark and breathes */
+  if(t>184&&t<190){
+    wd.fillStyle='rgba(0,0,5,'+(0.35*sm(184,186,t))+')'; wd.fillRect(-400,-200,2800,1500);
+  }
+}
+
+/* ---------------- ACT 6 ---------------- */
+function scHome(t){
+  cam.x=W/2-30; cam.y=560; cam.z=1.05; cam.lb=132;
+  rainCfg.on=false;
+  var win=aptRoom(t,true);
+  /* he walks back in, sits, opens the lid */
+  var wx2=lerp(1700,660,sm(190,192,t));
+  var sitting=t>=192;
+  var lid=sm(192.2,193.2,t);
+  laptop(wd,740,760,lid,sitting?0.7:0,true);
+  drawGuy(wd,{x:sitting?660:wx2,y:905,s:1.12,pose:sitting?'sit':'walk',ph:wx2*0.045,rim:'rgba(170,190,220,.5)'});
+  /* the creature lives in the window reflection now, and it is shrinking */
+  var rsize=lerp(0.5,0.1,sm(198,214,t));
+  wd.save(); wd.beginPath(); wd.rect(win.wx,win.wy,win.ww,win.wh); wd.clip();
+  wd.globalAlpha=0.4;
+  drawCreature(wd,{x:win.wx+win.ww-130,y:win.wy+win.wh-16,size:rsize,t:t,eye:1});
+  wd.restore(); wd.globalAlpha=1;
+  /* …until it has to come argue in person, cat-sized */
+  if(t>=215.4){
+    var deflate=1-0.45*sm(217,218.4,t);
+    wd.save(); wd.translate(1110,760); wd.scale(1,deflate); wd.translate(-1110,-760);
+    drawCreature(wd,{x:1110,y:760,size:0.16,t:t,eye:t<217?1.2:0.7,flip:true});
+    wd.restore();
+  }
+}
+
+/* ---------------- ACT 7 ---------------- */
+function scRoof(t){
+  var k=sm(225,252,t);
+  cam.x=960; cam.y=560; cam.z=1.06-0.06*sm(236,250,t); cam.lb=132;
+  rainCfg.on=t<232; rainCfg.splash=false; rainCfg.intensity=Math.max(0,0.25*(1-sm(225,232,t)));
+  /* sky: night → ember dawn */
+  function mix(a,b,m){
+    var pa=parseInt(a.slice(1),16), pb=parseInt(b.slice(1),16);
+    var r=lerp(pa>>16,pb>>16,m)|0, g2=lerp((pa>>8)&255,(pb>>8)&255,m)|0, b2=lerp(pa&255,pb&255,m)|0;
+    return 'rgb('+r+','+g2+','+b2+')';
+  }
+  bgGrad(mix('#0a0e1e','#27355c',k), mix('#10142c','#7a4d68',k), mix('#1a1030','#ff8a4d',k));
+  bgStars(t,40,0.5*(1-k));
+  /* the sun, finally */
+  var sunY=lerp(560,400,sm(240,260,t)), sunA=sm(238,248,t);
+  if(sunA>0){
+    bg.globalAlpha=sunA;
+    var sg2=bg.createRadialGradient(480,sunY,4,480,sunY,150);
+    sg2.addColorStop(0,'rgba(255,220,170,.95)'); sg2.addColorStop(0.25,'rgba(255,160,90,.6)'); sg2.addColorStop(1,'rgba(255,140,80,0)');
+    bg.fillStyle=sg2; bg.beginPath(); bg.arc(480,sunY,150,0,7); bg.fill();
+    bg.globalAlpha=1;
+  }
+  bgStrips(t,[210,260,310],0);
+  bgFog(t,330,0.16,4);
+  view(wd,1);
+  /* distant train — the callback, going somewhere better */
+  if(t>237.5&&t<241){ var tk=(t-237.5)/3.5; drawTrain(wd,lerp(-300,2200,tk),540,0.32,false); }
+  /* rooftop */
+  var gy=880;
+  wd.fillStyle='#0b0d16'; wd.fillRect(-200,gy,2400,400);
+  wd.fillStyle='#10131e'; wd.fillRect(-200,gy-90,2400,90);             /* parapet */
+  wd.fillStyle='#0d1019'; wd.fillRect(1450,gy-10,200,-120);
+  wd.fillStyle='#141827'; wd.fillRect(1450,gy-130,200,120);            /* AC unit */
+  wd.fillStyle='#0a0c14'; wd.beginPath(); wd.arc(1550,gy-70,40,0,7); wd.fill();
+  /* the guy, watching the light come back */
+  drawGuy(wd,{x:700,y:gy-90+88,s:1.18,pose:t>=231.3&&t<233?'flick':'stand',fp:sm(231.5,232.1,t),
+    rim:k>0.4?'rgba(255,177,77,.8)':'rgba(35,230,255,.7)'});
+  /* the creature: palm-sized, hoarse, about to be flicked */
+  var cx3,cy3,rot=0,wob=1;
+  if(t<232){ cx3=884; cy3=gy-92; }
+  else if(t<233.8){ var fk=(t-232)/1.8; cx3=lerp(884,1560,eo(fk)); cy3=gy-92-Math.sin(Math.PI*Math.min(fk*1.15,1))*300+fk*fk*180; rot=fk*12.57; }
+  else if(t<236.6){ var bk=eio((t-233.8)/2.8); cx3=lerp(1560,920,bk); cy3=lerp(gy+40,gy-92,bk)-Math.sin(Math.PI*bk)*120; rot=12.57+Math.sin(bk*6)*0.3-Math.PI*2*bk*0; wob=0.4; }
+  else { cx3=920; cy3=gy-92; wob=0.6; }
+  wd.save(); wd.translate(cx3,cy3); wd.rotate(rot);
+  drawCreature(wd,{x:0,y:0,size:0.045,t:t,eye:t<232?1:0.85,wob:wob});
+  wd.restore();
+  /* drips from last night's rain */
+  track('drip',Math.floor((t-225)/2.8),function(){ if(t<243) A.drip() });
+  /* dim the world a little while the cards speak */
+  var dim=0.38*sm(243.4,244.6,t)*(1-sm(258,260,t));
+  if(dim>0){ uiSpace(wd); wd.fillStyle='rgba(2,3,8,'+dim+')'; wd.fillRect(0,0,W,H); }
+}
+
+var SCENES=[
+  {s:0,   e:8,   draw:scTitle},
+  {s:8,   e:16,  draw:scCity},
+  {s:16,  e:40,  draw:scStreet},
+  {s:40,  e:62,  draw:scApt},
+  {s:62,  e:70,  draw:scCoffee},
+  {s:70,  e:76,  draw:scBath},
+  {s:76,  e:79,  draw:scDream},
+  {s:79,  e:130, draw:scArena},
+  {s:130, e:150, draw:scPull},
+  {s:150, e:160, draw:scCurb},
+  {s:160, e:190, draw:scBoss},
+  {s:190, e:225, draw:scHome},
+  {s:225, e:264.5, draw:scRoof}
+];
+var sceneCur=-1;
+function sceneOf(t){
+  for(var i=SCENES.length-1;i>=0;i--) if(t>=SCENES[i].s) return i;
+  return 0;
+}
+
+/* dip-to-black transitions + the final fade (derived) */
+function fadeAmt(t){
+  var a=0;
+  [[189.0,2.0],[224.3,1.6]].forEach(function(f){
+    var k=(t-f[0])/f[1];
+    if(k>=0&&k<1) a=Math.max(a,Math.sin(Math.PI*k));
+  });
+  a=Math.max(a,sm(259,263,t));
+  a=Math.max(a,1-sm(0.05,0.9,t));
+  return a;
+}
+
+/* ============================ DIRECTOR (the one rAF that runs the whole film) ============================ */
+var rafH=0, lastMs=0;
+
+/* motion-blur feel: 2 ghost copies of #world along the camera velocity (never under reduced motion) */
+function ghostPass(dt){
+  var dx=(cam.px-cam.x)*cam.z, dy=(cam.py-cam.y)*cam.z;
+  cam.vx=dt>0?dx/dt:0; cam.vy=dt>0?dy/dt:0;
+  cam.px=cam.x; cam.py=cam.y;
+  if(reduce||dt<=0) return;
+  var sp=Math.sqrt(dx*dx+dy*dy);
+  if(sp<7||sp>300) return;                            /* still, or a cut — no smear */
+  var k=Math.min(sp,40)/sp;
+  uiSpace(fx);
+  fx.globalAlpha=0.25; fx.drawImage(worldC,dx*0.5*k,dy*0.5*k,W,H);
+  fx.globalAlpha=0.12; fx.drawImage(worldC,dx*k,dy*k,W,H);
+  fx.globalAlpha=1;
+}
+
+/* glitch: slices of #world redrawn offset + channel-split tint bands (deterministic from t) */
+function glitchPass(t){
+  var a=glitchAmt(t);
+  if(a<=0.02) return;
+  uiSpace(fx);
+  if(reduce){                                          /* crossfade-ish shimmer, no displacement */
+    fx.globalAlpha=a*0.16; fx.fillStyle='#9fb3d8'; fx.fillRect(0,0,W,H); fx.globalAlpha=1;
+    return;
+  }
+  var seed=Math.floor(t*30), n=3+Math.floor(a*3);
+  for(var i=0;i<n;i++){
+    var sy=hash(seed*3+i*17)*(H-120), sh=24+hash(seed*7+i*29)*96;
+    var ox=(hash(seed*11+i*41)-0.5)*150*a;
+    fx.drawImage(worldC,0,sy*BS,worldC.width,sh*BS,ox,sy,W,sh);
+    fx.globalCompositeOperation='lighter'; fx.globalAlpha=0.14*a;
+    fx.fillStyle='#ff2d96'; fx.fillRect(ox+6,sy,W,sh*0.5);
+    fx.fillStyle='#23e6ff'; fx.fillRect(ox-6,sy+sh*0.5,W,sh*0.5);
+    fx.globalAlpha=1; fx.globalCompositeOperation='source-over';
+  }
+}
+
+function finish(){
+  tNow=T; playing=false; ended=true;
+  if(rafH){ cancelAnimationFrame(rafH); rafH=0; }
+  document.body.classList.remove('paused');
+  subsPaint(T); popupsPaint(T); hudPaint(T);
+  $('#endcard').classList.add('show');
+  A.suspend();
+}
+
+function director(ms){
+  rafH=requestAnimationFrame(director);
+  var dt=Math.min((ms-lastMs)/1000,1/20); lastMs=ms;
+  if(dt<0) dt=0;
+  if(!playing) dt=0;                                   /* paused: keep painting, freeze time */
+  if(playing){
+    tNow+=dt;
+    if(tNow>=T){ finish(); return }
+    cueStep(tNow);
+  }
+  /* scene edge — both directions (play + seek): transient pools and derived-sound trackers reset */
+  var si=sceneOf(tNow);
+  if(si!==sceneCur){ sceneCur=si; clearPools(); SFXT={}; }
+  /* particles advance here; the scene painters draw them */
+  rainStep(dt); paperStep(dt); confStep(dt); emberStep(dt);
+  /* world + bg: every painter starts with bgGrad, so bg needs no clear */
+  wd.setTransform(1,0,0,1,0,0); wd.clearRect(0,0,worldC.width,worldC.height);
+  bg.setTransform(1,0,0,1,0,0);
+  SCENES[si].draw(tNow);
+  /* fx stack: ghosts under rain under glitch under flash under the fade */
+  fx.setTransform(1,0,0,1,0,0); fx.clearRect(0,0,fxC.width,fxC.height);
+  ghostPass(dt);
+  rainDraw();
+  glitchPass(tNow);
+  uiSpace(fx);
+  var fl=flashAmt(tNow);
+  if(fl>0){ fx.globalAlpha=fl; fx.fillStyle='#eaf2ff'; fx.fillRect(0,0,W,H); fx.globalAlpha=1; }
+  var fa=fadeAmt(tNow);
+  if(fa>0.002){ fx.globalAlpha=clamp(fa,0,1); fx.fillStyle='#000'; fx.fillRect(0,0,W,H); fx.globalAlpha=1; }
+  /* DOM layer — all derived from t */
+  subsPaint(tNow); popupsPaint(tNow); titlePaint(tNow);
+  oswinPaint(tNow); appwinPaint(tNow); nameplatePaint(tNow);
+  bossbarPaint(tNow); ddPaint(tNow); cardsPaint(tNow); skysubPaint(tNow);
+  gradePaint(tNow); letterboxPaint(); hudPaint(tNow);
+  A.frameUpdate(tNow,audioEnv(tNow));
+}
+
+/* ============================ BOOT ============================ */
+var posterEl=$('#poster'), endEl=$('#endcard'), muteBtn=$('#mute'), muted=false;
+
+function seek(to){
+  tNow=clamp(to,0,T-0.04);
+  lastSeek=tNow;
+  cueSeek(tNow);                                       /* skipped cues pass silently */
+  clearPools(); SFXT={};
+  sceneCur=-1; subCur=-1; actCur=-1; osSig=''; awSig=''; npCur='';
+}
+
+function setPlaying(p){
+  if(!started||ended) return;
+  playing=p;
+  document.body.classList.toggle('paused',!p);
+  if(p){ A.resume(); lastMs=performance.now(); }
+  else A.suspend();
+}
+
+function startFilm(){
+  if(started) return;
+  started=true; document.body.classList.add('started');
+  A.init(); A.seqStart();                              /* inside the click — autoplay-safe */
+  posterEl.classList.add('gone');
+  var q=/[?&]t=([0-9:.]+)/.exec(location.search);      /* ?t=mm:ss or ?t=sss debug seek */
+  if(q){ var p=q[1].split(':'), tq=p.length>1?(+p[0])*60+(+p[1]||0):+p[0]; if(tq>0) seek(tq); }
+  playing=true;
+  lastMs=performance.now();
+  if(!rafH) rafH=requestAnimationFrame(director);
+}
+$('#play').addEventListener('click',startFilm);
+
+function replayFilm(){
+  endEl.classList.remove('show'); ended=false;
+  seek(0);
+  playing=true; document.body.classList.remove('paused');
+  A.resume(); A.seqStart();
+  lastMs=performance.now();
+  if(!rafH) rafH=requestAnimationFrame(director);
+}
+$('#replay').addEventListener('click',replayFilm);
+
+muteBtn.addEventListener('click',function(e){
+  e.stopPropagation();
+  muted=!muted; A.setMuted(muted);
+  muteBtn.classList.toggle('muted',muted);
+  muteBtn.setAttribute('aria-pressed',muted?'true':'false');
+  muteBtn.title=muted?'unmute':'mute';
+});
+
+/* click (or tap) anywhere on the frame = pause; links and buttons keep working */
+frame.addEventListener('click',function(e){
+  if(!started||ended) return;
+  if(e.target.closest&&e.target.closest('a,button')) return;
+  setPlaying(!playing);
+});
+
+addEventListener('keydown',function(e){
+  if(e.key===' '||e.code==='Space'){
+    e.preventDefault();
+    if(!started) startFilm();
+    else if(ended) replayFilm();
+    else setPlaying(!playing);
+  }
+  else if(e.key==='ArrowRight'&&started&&!ended){ e.preventDefault(); seek(tNow+10); }
+  else if(e.key==='ArrowLeft'&&started&&!ended){ e.preventDefault(); seek(tNow-10); }
+});
+
+/* tab away = pause. it never auto-resumes — the film waits, unlike recruiters. */
+document.addEventListener('visibilitychange',function(){
+  if(document.hidden&&playing) setPlaying(false);
+});
+
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

**THE RECRUITER** — a second, completely different short film for the landing site: a 4:24 single-file cyberpunk dark-comedy short (Spider-Verse / Arcane / LD&R energy) about job-search anxiety. It plays like a festival short and only reveals AI Job Hunter in act 6. The existing crayon film is untouched; both coexist.

## Files

- `landing/recruiter.html` (new, 126 KB) — the entire film: CSS post stack, 3-layer canvas (bg parallax / world / fx), Director rAF engine, camera (dolly/punch-in/shake/letterbox), pooled particles (rain/embers/paper/confetti/checkbox swarm), pre-rendered sprites, fully procedural Web Audio (bus graph, 96 BPM lookahead sequencer, noise-syllable whisper synth, achievement/error/boss recipes), subtitle system (aria-live, film fully legible muted), achievement popups, boss "PATIENCE" bar, fake OS windows, glitch + grain + grading, poster-gated audio unlock, pause/seek/mute/timecode, `?t=mm:ss` debug seek, reduced-motion path, endcard with subtle link back to the landing page.
- `landing/index.html` — one `src-link` line pointing at the film.

## Story (7 acts, jokes every ≤18 s except one deliberate 28 s hold)

whisper → growth → monster evolutions (RECRUITER FORM / HYDRA / LINKEDIN FORM / ATS DRAGON / WORKDAY TITAN) → apocalypse (squirrel VP of engineering) → ULTIMATE WORKDAY instant defeat → quiet discovery ("Oh.") → sunrise truce with a palm-sized recruiter.

## Verification

- `node --check` clean on the extracted script; no `{{` placeholders; balanced tags.
- Zero external requests (system font stacks only — no Google Fonts; everything procedural).
- Headless Edge playthrough: boot → seeks into every act → endcard at 04:24 → replay; zero console errors.
- Strobes capped ≤3 flashes/s (WCAG 2.3.1); `prefers-reduced-motion` zeroes shake, quarters particles, flattens glitch.
- Deploys automatically via the existing Pages workflow on merge (`landing/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)