### PR TITLE
fix: let manual benchmark dispatch commit the dashboard

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,12 +93,13 @@ jobs:
           alert-comment-cc-users: '@saeedkolivand'
 
       # Commit the refreshed dashboard back to main, exactly like the release
-      # cask/version-sync jobs (SSH deploy key + [skip ci]). Push-only — PRs just
-      # compare. [skip ci] keeps this commit from re-triggering any workflow,
-      # so the Pages deploy is kicked explicitly in the next step.
+      # cask/version-sync jobs (SSH deploy key + [skip ci]). Runs on push AND
+      # manual workflow_dispatch (so "Run workflow" can seed/refresh the baseline)
+      # but NOT on PRs, which stay compare-only. [skip ci] keeps this commit from
+      # re-triggering any workflow, so Pages is kicked explicitly in the next step.
       - name: 📤 Commit benchmark data
         id: commit
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
@
## Problem

On the [workflow_dispatch run](https://github.com/saeedkolivand/ai-job-hunter-assistant-app/actions/runs/27321032297), the bench ran green but **📤 Commit benchmark data** and **🌐 Trigger Pages deploy** were **skipped** — they were gated `if: github.event_name == 'push'`, and a manual "Run workflow" is `workflow_dispatch`, not `push`. So a deliberate manual run still left `landing/benchmarks` empty.

## Fix

Relax the gate to `if: github.event_name != 'pull_request'`. Now **push** and **workflow_dispatch** both commit + deploy; **PRs** stay compare-only (no push). This makes the Actions-tab "Run workflow" button usable to seed/refresh the baseline on demand.

Follow-up to #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@