### PR TITLE
fix: limit location search to city- and country-level results

### DIFF
--- a/apps/tauri/src-tauri/src/commands/geocoding.rs
+++ b/apps/tauri/src-tauri/src/commands/geocoding.rs
@@ -1,4 +1,72 @@
+use std::collections::HashSet;
+
 use serde_json::{json, Value};
+
+#[cfg(test)]
+mod test;
+
+/// Reduce a Nominatim result to a city- or country-level suggestion.
+/// Returns None for anything more detailed (road/house/postcode/POI) or a
+/// region/state-level match, so the UI only ever shows "City, Country".
+fn to_city_country(item: &Value) -> Option<Value> {
+    let address = item.get("address");
+
+    // First present, non-empty city-equivalent field.
+    let city = address.and_then(|a| {
+        ["city", "town", "village", "municipality", "hamlet"]
+            .iter()
+            .find_map(|key| {
+                a.get(*key)
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+            })
+    });
+
+    let country = address
+        .and_then(|a| a.get("country"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    let country_code = address
+        .and_then(|a| a.get("country_code"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_uppercase());
+
+    let lat = item
+        .get("lat")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<f64>().ok());
+    let lon = item
+        .get("lon")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<f64>().ok());
+
+    let addresstype = item.get("addresstype").and_then(|v| v.as_str());
+    let is_country_level = addresstype == Some("country");
+
+    // Keep only city-level matches, or explicit country-level matches.
+    if city.is_none() && !is_country_level {
+        return None;
+    }
+
+    let display = match (&city, &country) {
+        (Some(city), Some(country)) => format!("{city}, {country}"),
+        (Some(city), None) => city.clone(),
+        // Country-level result (no city): label is the country name, falling
+        // back to country_code if the country name is somehow absent.
+        (None, Some(country)) => country.clone(),
+        (None, None) => country_code.clone()?,
+    };
+
+    Some(json!({
+        "display": display,
+        "lat": lat,
+        "lon": lon,
+        "countryCode": country_code,
+    }))
+}
 
 #[tauri::command]
 pub async fn geocode_suggest(query: String) -> Value {
@@ -7,7 +75,7 @@ pub async fn geocode_suggest(query: String) -> Value {
     }
 
     let url = format!(
-        "https://nominatim.openstreetmap.org/search?format=json&q={}&limit=5&addressdetails=1",
+        "https://nominatim.openstreetmap.org/search?format=json&q={}&limit=10&addressdetails=1",
         urlencoding::encode(&query)
     );
 
@@ -22,40 +90,26 @@ pub async fn geocode_suggest(query: String) -> Value {
         Err(_) => return json!([]),
     };
 
-    let results = match response.json::<Vec<serde_json::Value>>().await {
+    let results = match response.json::<Vec<Value>>().await {
         Ok(r) => r,
         Err(_) => return json!([]),
     };
 
-    // Surface the structured fields Nominatim already returns (addressdetails=1):
-    // ISO country code + coordinates. They let the scrape pass a precise location
-    // (country filter / radius) instead of a fuzzy free-text string, which is what
-    // caused results to leak across countries (#49). `display` stays primary so
-    // existing consumers that read only `.display` keep working.
+    // Reduce every Nominatim hit to a city- or country-level suggestion
+    // (`to_city_country`), drop everything more detailed, dedupe by the visible
+    // label, preserve order, and cap at 5. `countryCode`/`lat`/`lon` survive so
+    // ScrapeForm keeps its country + radius filtering (#49/#40).
+    let mut seen: HashSet<String> = HashSet::new();
     let suggestions: Vec<Value> = results
-        .into_iter()
-        .filter_map(|item| {
-            let display = item.get("display_name")?.as_str()?.to_string();
-            let lat = item
-                .get("lat")
-                .and_then(|v| v.as_str())
-                .and_then(|s| s.parse::<f64>().ok());
-            let lon = item
-                .get("lon")
-                .and_then(|v| v.as_str())
-                .and_then(|s| s.parse::<f64>().ok());
-            let country_code = item
-                .get("address")
-                .and_then(|a| a.get("country_code"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_uppercase());
-            Some(json!({
-                "display": display,
-                "lat": lat,
-                "lon": lon,
-                "countryCode": country_code,
-            }))
+        .iter()
+        .filter_map(to_city_country)
+        .filter(|s| {
+            s.get("display")
+                .and_then(|d| d.as_str())
+                .map(|d| seen.insert(d.to_string()))
+                .unwrap_or(false)
         })
+        .take(5)
         .collect();
 
     json!(suggestions)

--- a/apps/tauri/src-tauri/src/commands/geocoding/test.rs
+++ b/apps/tauri/src-tauri/src/commands/geocoding/test.rs
@@ -1,0 +1,502 @@
+//! Unit tests for `to_city_country`.
+//!
+//! This child module can reach the private parent helper via
+//! `super::to_city_country`. Tests are authored by the test-author stage.
+
+use serde_json::json;
+
+use super::to_city_country;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn display(v: &serde_json::Value) -> &str {
+    v.get("display")
+        .and_then(|d| d.as_str())
+        .expect("display field missing")
+}
+
+fn country_code(v: &serde_json::Value) -> Option<&str> {
+    v.get("countryCode").and_then(|c| c.as_str())
+}
+
+fn lat(v: &serde_json::Value) -> Option<f64> {
+    v.get("lat").and_then(|l| l.as_f64())
+}
+
+fn lon(v: &serde_json::Value) -> Option<f64> {
+    v.get("lon").and_then(|l| l.as_f64())
+}
+
+// ---------------------------------------------------------------------------
+// 1. City result (addresstype == "city")
+// ---------------------------------------------------------------------------
+
+#[test]
+fn city_result_full_fields() {
+    let item = json!({
+        "addresstype": "city",
+        "lat": "52.5",
+        "lon": "13.4",
+        "address": {
+            "city": "Berlin",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some for city result");
+
+    assert_eq!(display(&result), "Berlin, Germany");
+    assert_eq!(country_code(&result), Some("DE"));
+    assert_eq!(lat(&result), Some(52.5));
+    assert_eq!(lon(&result), Some(13.4));
+}
+
+// ---------------------------------------------------------------------------
+// 2. town / village / municipality / hamlet fallbacks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn town_fallback() {
+    let item = json!({
+        "addresstype": "town",
+        "lat": "51.5",
+        "lon": "-0.1",
+        "address": {
+            "town": "Reading",
+            "country": "United Kingdom",
+            "country_code": "gb"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some for town");
+
+    assert_eq!(display(&result), "Reading, United Kingdom");
+    assert_eq!(country_code(&result), Some("GB"));
+    assert_eq!(lat(&result), Some(51.5));
+    assert_eq!(lon(&result), Some(-0.1));
+}
+
+#[test]
+fn village_fallback() {
+    let item = json!({
+        "addresstype": "village",
+        "lat": "48.1",
+        "lon": "11.6",
+        "address": {
+            "village": "Grünwald",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some for village");
+
+    assert_eq!(display(&result), "Grünwald, Germany");
+    assert_eq!(country_code(&result), Some("DE"));
+}
+
+#[test]
+fn municipality_fallback() {
+    let item = json!({
+        "addresstype": "municipality",
+        "lat": "60.0",
+        "lon": "25.0",
+        "address": {
+            "municipality": "Espoo",
+            "country": "Finland",
+            "country_code": "fi"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some for municipality");
+
+    assert_eq!(display(&result), "Espoo, Finland");
+    assert_eq!(country_code(&result), Some("FI"));
+}
+
+#[test]
+fn hamlet_fallback() {
+    let item = json!({
+        "addresstype": "hamlet",
+        "lat": "55.0",
+        "lon": "10.0",
+        "address": {
+            "hamlet": "Stengade",
+            "country": "Denmark",
+            "country_code": "dk"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some for hamlet");
+
+    assert_eq!(display(&result), "Stengade, Denmark");
+    assert_eq!(country_code(&result), Some("DK"));
+}
+
+// city takes priority over town when both present
+#[test]
+fn city_takes_priority_over_town() {
+    let item = json!({
+        "addresstype": "city",
+        "lat": "52.5",
+        "lon": "13.4",
+        "address": {
+            "city": "Berlin",
+            "town": "Wannsee",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some");
+    assert_eq!(display(&result), "Berlin, Germany");
+}
+
+// ---------------------------------------------------------------------------
+// 3. Country-level result (no city field)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn country_level_result() {
+    let item = json!({
+        "addresstype": "country",
+        "address": {
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some for country-level");
+
+    assert_eq!(display(&result), "Germany");
+    assert_eq!(country_code(&result), Some("DE"));
+    // lat/lon absent → null
+    assert!(result.get("lat").and_then(|v| v.as_f64()).is_none());
+    assert!(result.get("lon").and_then(|v| v.as_f64()).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// 4. Rejected types — road / house / postcode / POI / state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn road_rejected() {
+    let item = json!({
+        "addresstype": "road",
+        "lat": "52.5",
+        "lon": "13.4",
+        "address": {
+            "road": "Main St",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    assert!(to_city_country(&item).is_none(), "road should be rejected");
+}
+
+#[test]
+fn postcode_rejected() {
+    let item = json!({
+        "addresstype": "postcode",
+        "lat": "52.5",
+        "lon": "13.4",
+        "address": {
+            "postcode": "10115",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    assert!(
+        to_city_country(&item).is_none(),
+        "postcode should be rejected"
+    );
+}
+
+#[test]
+fn house_number_rejected() {
+    let item = json!({
+        "addresstype": "house",
+        "lat": "52.5",
+        "lon": "13.4",
+        "address": {
+            "house_number": "42",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    assert!(to_city_country(&item).is_none(), "house should be rejected");
+}
+
+#[test]
+fn poi_rejected() {
+    let item = json!({
+        "addresstype": "amenity",
+        "lat": "52.5",
+        "lon": "13.4",
+        "address": {
+            "amenity": "Brandenburg Gate",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    assert!(
+        to_city_country(&item).is_none(),
+        "POI/amenity should be rejected"
+    );
+}
+
+#[test]
+fn state_level_rejected() {
+    let item = json!({
+        "addresstype": "state",
+        "lat": "52.0",
+        "lon": "12.0",
+        "address": {
+            "state": "Brandenburg",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    assert!(
+        to_city_country(&item).is_none(),
+        "state/region should be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. No country — city present, country absent
+// ---------------------------------------------------------------------------
+
+#[test]
+fn city_without_country() {
+    let item = json!({
+        "addresstype": "city",
+        "lat": "34.0",
+        "lon": "36.0",
+        "address": {
+            "city": "Homs"
+            // no country, no country_code
+        }
+    });
+    let result =
+        to_city_country(&item).expect("should return Some when city present without country");
+
+    assert_eq!(
+        display(&result),
+        "Homs",
+        "no trailing comma when country absent"
+    );
+    assert!(
+        result
+            .get("countryCode")
+            .map(|v| v.is_null())
+            .unwrap_or(true),
+        "countryCode should be null/absent"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Missing or non-numeric lat/lon → null, suggestion still returned
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_lat_lon_still_returns_suggestion() {
+    let item = json!({
+        "addresstype": "city",
+        "address": {
+            "city": "Oslo",
+            "country": "Norway",
+            "country_code": "no"
+        }
+        // lat / lon keys absent
+    });
+    let result = to_city_country(&item).expect("should return Some even without lat/lon");
+
+    assert_eq!(display(&result), "Oslo, Norway");
+    assert!(lat(&result).is_none(), "lat should be null when absent");
+    assert!(lon(&result).is_none(), "lon should be null when absent");
+}
+
+#[test]
+fn non_numeric_lat_lon_returns_null_fields() {
+    let item = json!({
+        "addresstype": "city",
+        "lat": "not-a-number",
+        "lon": "also-bad",
+        "address": {
+            "city": "Atlantis",
+            "country": "Mythica",
+            "country_code": "my"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some with non-numeric lat/lon");
+
+    assert_eq!(display(&result), "Atlantis, Mythica");
+    assert!(lat(&result).is_none(), "non-numeric lat should be null");
+    assert!(lon(&result).is_none(), "non-numeric lon should be null");
+}
+
+// ---------------------------------------------------------------------------
+// 7. country_code casing — always upper-cased
+// ---------------------------------------------------------------------------
+
+#[test]
+fn country_code_uppercased_from_lowercase() {
+    let item = json!({
+        "addresstype": "city",
+        "lat": "51.5",
+        "lon": "-0.1",
+        "address": {
+            "city": "London",
+            "country": "United Kingdom",
+            "country_code": "gb"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some");
+
+    assert_eq!(
+        country_code(&result),
+        Some("GB"),
+        "country_code must be upper-cased"
+    );
+}
+
+#[test]
+fn country_code_already_upper_stays_upper() {
+    let item = json!({
+        "addresstype": "city",
+        "lat": "48.9",
+        "lon": "2.3",
+        "address": {
+            "city": "Paris",
+            "country": "France",
+            "country_code": "FR"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some");
+
+    assert_eq!(country_code(&result), Some("FR"));
+}
+
+// ---------------------------------------------------------------------------
+// 8. Empty string city fields are treated as absent (use next fallback)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_city_falls_through_to_town() {
+    let item = json!({
+        "addresstype": "town",
+        "lat": "53.0",
+        "lon": "9.0",
+        "address": {
+            "city": "",
+            "town": "Buxtehude",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    let result = to_city_country(&item).expect("should return Some using town fallback");
+
+    assert_eq!(display(&result), "Buxtehude, Germany");
+}
+
+// ---------------------------------------------------------------------------
+// 9. Country-level with only country_code (no country name)
+//    Branch: (None, None) => country_code.clone()?  →  yields raw uppercased code.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn country_level_code_only_no_country_name() {
+    let item = json!({
+        "addresstype": "country",
+        "address": {
+            "country_code": "de"
+            // "country" name intentionally absent
+        }
+    });
+    let result = to_city_country(&item)
+        .expect("should return Some: country_code fallback covers the (None,None) branch");
+
+    assert_eq!(
+        display(&result),
+        "DE",
+        "display must be the raw uppercased country_code when country name is absent"
+    );
+    assert_eq!(
+        country_code(&result),
+        Some("DE"),
+        "countryCode must also be the uppercased code"
+    );
+    // lat/lon absent from the input → the JSON value must be explicitly null,
+    // not merely a missing key — assert directly on the Value variant.
+    assert!(
+        result.get("lat").map(|v| v.is_null()).unwrap_or(false),
+        "lat must be an explicit JSON null (not a missing key)"
+    );
+    assert!(
+        result.get("lon").map(|v| v.is_null()).unwrap_or(false),
+        "lon must be an explicit JSON null (not a missing key)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 10. Country addresstype with empty address → returns None
+//     The `?` on `country_code.clone()?` in the (None, None) branch propagates
+//     None out of the helper when both country name and country_code are absent.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn country_level_empty_address_returns_none() {
+    let item = json!({
+        "addresstype": "country",
+        "address": {}
+        // no country, no country_code, no city
+    });
+    assert!(
+        to_city_country(&item).is_none(),
+        "country addresstype with an empty address must return None: \
+         the ? on country_code propagates None out of the helper"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 11. Road result that carries a parent `city` field (Nominatim contextual address)
+//
+//     Nominatim sometimes returns `addresstype:"road"` but includes a `city`
+//     field in the address object because it encodes the administrative context
+//     of the road.  The keep-rule in `to_city_country` is:
+//       "city present OR is_country_level" → accept.
+//     Because `city` is present the road hit is accepted, and `display` is built
+//     from the city (not the road name).  This is intentional: a road match
+//     collapses to its containing city so the UI shows "Berlin, Germany" rather
+//     than a street name.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn road_with_parent_city_collapses_to_city() {
+    let item = json!({
+        "addresstype": "road",
+        "lat": "52.5",
+        "lon": "13.4",
+        "address": {
+            "road": "Unter den Linden",
+            "city": "Berlin",
+            "country": "Germany",
+            "country_code": "de"
+        }
+    });
+    // Road hits are normally rejected, but this one carries a `city` field in
+    // the address context, so the keep-rule (`city.is_some()`) accepts it and
+    // the display collapses to the city — never the road name.
+    let result = to_city_country(&item)
+        .expect("road with a parent city field must be accepted and collapsed to its city");
+
+    assert_eq!(
+        display(&result),
+        "Berlin, Germany",
+        "display must be the city, not the road name"
+    );
+    assert_eq!(
+        country_code(&result),
+        Some("DE"),
+        "countryCode must be uppercased"
+    );
+    assert_eq!(lat(&result), Some(52.5), "lat must be preserved");
+    assert_eq!(lon(&result), Some(13.4), "lon must be preserved");
+}

--- a/apps/tauri/src/tauri-client/namespaces/geocode/geocode.ts
+++ b/apps/tauri/src/tauri-client/namespaces/geocode/geocode.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
+import type { GeocodeSuggestion } from '@ajh/shared';
+
 export const geocode = {
-  suggest: (query: string) =>
-    invoke('geocode_suggest', { query }) as Promise<Array<{ display: string }>>,
+  suggest: (query: string) => invoke('geocode_suggest', { query }) as Promise<GeocodeSuggestion[]>,
 };

--- a/docs/API.md
+++ b/docs/API.md
@@ -444,6 +444,19 @@ type TemplateId =
 
 Location lookup and reverse geocoding.
 
+#### `geocode.suggest(query: string): Promise<GeocodeSuggestion[]>`
+
+Autocomplete suggestions filtered to city-level and country-level results only (via `to_city_country` filter in Rust backend). Returned display strings are formatted as `"City, Country"` for cities or bare country name for country-level matches.
+
+```typescript
+interface GeocodeSuggestion {
+  display: string;
+  lat?: number | null;
+  lon?: number | null;
+  countryCode?: string | null;
+}
+```
+
 #### `geocode.lookup(query: string): Promise<GeocodeResult[]>`
 
 ```typescript

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -171,7 +171,7 @@ export {
   type TemplateRecommendation,
   type TemplateRecommendSignals,
 } from './documents.js';
-export { GEOCODE_CHANNELS, type GeocodeContract } from './geocode.js';
+export { GEOCODE_CHANNELS, type GeocodeContract, type GeocodeSuggestion } from './geocode.js';
 export { JOB_PREFERENCES_CHANNELS, type JobPreferencesContract } from './jobPreferences.js';
 export { JOBS_CHANNELS, type JobsContract } from './jobs.js';
 export { LINKEDIN_CHANNELS, type LinkedinContract } from './linkedin.js';

--- a/packages/ui/src/hooks/useGeocoding.test.ts
+++ b/packages/ui/src/hooks/useGeocoding.test.ts
@@ -39,6 +39,8 @@ describe('useGeocoding', () => {
         json: async () => [
           { address: { city: 'Paris', state: 'Île-de-France', country: 'France' } },
           { address: { town: 'Lyon', country: 'France' } },
+          { addresstype: 'country', address: { country: 'France' } },
+          { addresstype: 'road', address: { road: 'Rue de Rivoli', country: 'France' } }, // skipped — no city/town/village, not a country
           { address: {} }, // skipped — no city/town/village
         ],
       })
@@ -51,8 +53,9 @@ describe('useGeocoding', () => {
       await vi.advanceTimersByTimeAsync(350);
     });
     expect(result.current.suggestions).toEqual([
-      { display: 'Paris, Île-de-France, France' },
+      { display: 'Paris, France' },
       { display: 'Lyon, France' },
+      { display: 'France' },
     ]);
   });
 
@@ -66,5 +69,89 @@ describe('useGeocoding', () => {
       await vi.advanceTimersByTimeAsync(350);
     });
     expect(result.current.suggestions).toEqual([]);
+  });
+
+  it('resolves city from municipality when city/town/village absent', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [{ address: { municipality: 'Espoo', country: 'Finland' } }],
+      })
+    );
+    const { result, rerender } = renderHook(({ q }) => useGeocoding(q), {
+      initialProps: { q: '' },
+    });
+    rerender({ q: 'Espoo' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+    expect(result.current.suggestions).toEqual([{ display: 'Espoo, Finland' }]);
+  });
+
+  it('resolves city from hamlet when city/town/village/municipality absent', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [{ address: { hamlet: 'Little Snoring', country: 'United Kingdom' } }],
+      })
+    );
+    const { result, rerender } = renderHook(({ q }) => useGeocoding(q), {
+      initialProps: { q: '' },
+    });
+    rerender({ q: 'Little Snoring' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+    expect(result.current.suggestions).toEqual([{ display: 'Little Snoring, United Kingdom' }]);
+  });
+
+  it('deduplicates country-level results — two identical country entries produce one suggestion', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { addresstype: 'country', address: { country: 'France' } },
+          { addresstype: 'country', address: { country: 'France' } },
+        ],
+      })
+    );
+    const { result, rerender } = renderHook(({ q }) => useGeocoding(q), {
+      initialProps: { q: '' },
+    });
+    rerender({ q: 'France' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+    expect(result.current.suggestions).toHaveLength(1);
+    expect(result.current.suggestions).toEqual([{ display: 'France' }]);
+  });
+
+  it('skips road/POI results and does not include road names in any suggestion display', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { address: { city: 'Paris', country: 'France' } },
+          { addresstype: 'road', address: { road: 'Rue de Rivoli', country: 'France' } },
+          { address: {} },
+        ],
+      })
+    );
+    const { result, rerender } = renderHook(({ q }) => useGeocoding(q), {
+      initialProps: { q: '' },
+    });
+    rerender({ q: 'Rivoli' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+    expect(result.current.suggestions).toHaveLength(1);
+    expect(result.current.suggestions).toEqual([{ display: 'Paris, France' }]);
+    for (const s of result.current.suggestions) {
+      expect(s.display).not.toContain('Rue de Rivoli');
+    }
   });
 });

--- a/packages/ui/src/hooks/useGeocoding.ts
+++ b/packages/ui/src/hooks/useGeocoding.ts
@@ -11,15 +11,18 @@ async function defaultFetch(query: string): Promise<Suggestion[]> {
   const url =
     `https://nominatim.openstreetmap.org/search` +
     `?q=${encodeURIComponent(query)}` +
-    `&format=json&addressdetails=1&limit=6&featuretype=city`;
+    `&format=json&addressdetails=1&limit=6`;
   try {
     const res = await fetch(url, { headers: { 'Accept-Language': 'en' } });
     if (!res.ok) return [];
     const data = (await res.json()) as Array<{
+      addresstype?: string;
       address?: {
         city?: string;
         town?: string;
         village?: string;
+        municipality?: string;
+        hamlet?: string;
         state?: string;
         country?: string;
       };
@@ -27,10 +30,17 @@ async function defaultFetch(query: string): Promise<Suggestion[]> {
     const seen = new Set<string>();
     return data.flatMap((item) => {
       const addr = item.address ?? {};
-      const city = addr.city ?? addr.town ?? addr.village ?? '';
-      if (!city) return [];
-      const parts = [city, addr.state, addr.country].filter(Boolean);
-      const display = parts.join(', ');
+      const city = addr.city ?? addr.town ?? addr.village ?? addr.municipality ?? addr.hamlet ?? '';
+      // City-level: "City, Country". Country-level: just the country.
+      // Anything else (road/POI/region) is dropped.
+      let display: string;
+      if (city) {
+        display = [city, addr.country].filter(Boolean).join(', ');
+      } else if (item.addresstype === 'country' && addr.country) {
+        display = addr.country;
+      } else {
+        return [];
+      }
       if (seen.has(display)) return [];
       seen.add(display);
       return [{ display }];


### PR DESCRIPTION
## Summary
Location autocomplete now returns **only city- and country-level** results — labelled `"City, Country"` (e.g. `Berlin, Germany`) — instead of Nominatim's raw `display_name`, which leaked street/house/postcode/neighborhood/POI detail.

## What changed
- **`geocode_suggest`** (`commands/geocoding.rs`): new pure helper `to_city_country` keeps a result only when a city-equivalent field (`city/town/village/municipality/hamlet`) is present **or** `addresstype == "country"`; builds `"City, Country"` (or bare country for country-level); dedupes by `display`; `limit` 5→10; **keeps `display`/`lat`/`lon`/`countryCode`** so ScrapeForm's country + radius filter (#49/#40) is unaffected. A road/POI hit with a parent `city` field collapses *up* to its city — desired.
- **`@ajh/ui` `useGeocoding`**: the fallback `defaultFetch` aligned to the same city-fallback chain + `"City, Country"` label, and allows country-level. (The 6 live consumers use the Rust path; this is the network fallback only.)
- **tauri-client** geocode return type corrected to `GeocodeSuggestion[]`.

## Decisions
- Format **"City, Country"** (region/state dropped); **country-level results allowed** (typing `Germany` → `Germany`) — so filtering is by `address`/`addresstype`, not `featuretype=city`.

## Tests & review
- 21 Rust unit tests for `to_city_country` (city-field fallbacks, country-level, `(None,None)→code`, road/POI/postcode/state rejection, lat/lon null, casing) + extended `useGeocoding` TS tests (incl. municipality/hamlet parity, dedupe).
- Reviews: rust **APPROVE**, security **clean**, frontend ok; testing-reviewer's 2 HIGH resolved (TS dropped `municipality`/`hamlet` — fixed for Rust↔TS parity; untested `(None,None)` branch — covered).
- Follow-up recorded (out of scope): `api.geocode.suggest` is called inline in component props; should move to a `useGeocodeSuggest` service hook (ports & adapters).

## Verification
`cargo test` (21), `@ajh/ui` vitest (8), `cargo clippy`/`fmt`, `pnpm typecheck`, `pnpm lint:strict` — all green. Manual: street/postcode → no over-detailed suggestion; `Berlin` → `Berlin, Germany`; `Germany` → `Germany`; ScrapeForm still captures `countryCode`/`lat`/`lon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
