### PR TITLE
fix: deliver macos menu-bar nav intents via a focused poll backstop

### DIFF
--- a/apps/tauri/src/renderer/services/use-menu/use-menu.test.ts
+++ b/apps/tauri/src/renderer/services/use-menu/use-menu.test.ts
@@ -1,0 +1,357 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import type { MenuActionEvent, MenuNavigateEvent, PendingMenuIntent } from '@ajh/shared';
+
+import { createMockClient, withProviders } from '@/test-support';
+
+import { useMenuIntents } from './use-menu';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const NAV_INTENT: PendingMenuIntent = {
+  event: 'menu.navigate',
+  payload: { route: '/jobs', section: null } satisfies MenuNavigateEvent,
+};
+
+const ACTION_INTENT: PendingMenuIntent = {
+  event: 'menu.action',
+  payload: { action: 'check-updates' } satisfies MenuActionEvent,
+};
+
+/**
+ * Render the hook with a mock client whose `menu.takePending` is controlled by
+ * the caller. `onNavigate` and `onAction` are passed through so assertions can
+ * be made on them.
+ *
+ * The `onNavigate` / `onAction` event-listener registrars (`menu.onNavigate`,
+ * `menu.onAction`) default to no-op unsub stubs matching the `createMockClient`
+ * default for `on*` methods — they return `() => {}`.
+ */
+function setup(takePending: () => Promise<PendingMenuIntent | null>) {
+  const onNavigate = vi.fn();
+  const onAction = vi.fn();
+  const client = createMockClient({ 'menu.takePending': takePending });
+  const utils = renderHook(() => useMenuIntents(onNavigate, onAction), {
+    wrapper: withProviders(client),
+  });
+  return { ...utils, onNavigate, onAction, takePending };
+}
+
+// ── visibilityState descriptor management ────────────────────────────────────
+
+let originalVisibilityDescriptor: PropertyDescriptor | undefined;
+
+function setVisibilityState(value: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+function restoreVisibilityState() {
+  if (originalVisibilityDescriptor) {
+    Object.defineProperty(document, 'visibilityState', originalVisibilityDescriptor);
+  }
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // Capture the original visibilityState descriptor before any test overrides it.
+  originalVisibilityDescriptor = Object.getOwnPropertyDescriptor(document, 'visibilityState');
+  // Fake timers control setInterval / clearInterval used by the poll backstop.
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  // Restore visibilityState — Object.defineProperty overrides are NOT undone by
+  // vi.restoreAllMocks(), so we must restore manually.
+  restoreVisibilityState();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useMenuIntents — poll backstop', () => {
+  it('drains a buffered navigate intent via poll when no focus/visibility events fire', async () => {
+    // mount → null so mount-drain is a no-op, first poll tick → intent, rest → null.
+    const takePending = vi
+      .fn<() => Promise<PendingMenuIntent | null>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(NAV_INTENT)
+      .mockResolvedValue(null);
+
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setVisibilityState('visible');
+
+    const { onNavigate } = setup(takePending);
+
+    // Let mount-drain microtasks settle (async timer advance drains microtask
+    // queue between callbacks — zero advance just flushes pending microtasks).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    // Advance past the 250 ms poll interval — the poll fires, drains the intent.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(260);
+    });
+
+    expect(onNavigate).toHaveBeenCalledExactlyOnceWith(NAV_INTENT.payload);
+  });
+
+  it('does not re-fire onNavigate on subsequent poll ticks after buffer is empty', async () => {
+    // mount → null, first poll tick → intent, all later ticks → null.
+    const takePending = vi
+      .fn<() => Promise<PendingMenuIntent | null>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(NAV_INTENT)
+      .mockResolvedValue(null);
+
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setVisibilityState('visible');
+
+    const { onNavigate } = setup(takePending);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // First tick delivers the intent.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(260);
+    });
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+
+    // Several more ticks — buffer is empty, onNavigate must not be called again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250 * 5);
+    });
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke takePending via poll when document is not focused', async () => {
+    // Poll gate: `visibilityState === 'visible' && hasFocus()`.
+    // hasFocus=false → poll body skipped entirely.
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    setVisibilityState('visible');
+
+    const takePending = vi
+      .fn<() => Promise<PendingMenuIntent | null>>()
+      .mockResolvedValueOnce(null) // mount drain → empty
+      .mockResolvedValue(NAV_INTENT); // all poll ticks → intent (must never reach)
+
+    const { onNavigate } = setup(takePending);
+
+    // Allow mount-drain to settle.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const callsAfterMount = takePending.mock.calls.length;
+
+    // Advance several poll intervals — poll gate (hasFocus=false) must suppress all.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250 * 4);
+    });
+
+    expect(takePending).toHaveBeenCalledTimes(callsAfterMount);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke takePending via poll when document is not visible', async () => {
+    // Same as above but gate fails on visibilityState rather than hasFocus.
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setVisibilityState('hidden');
+
+    const takePending = vi
+      .fn<() => Promise<PendingMenuIntent | null>>()
+      .mockResolvedValueOnce(null) // mount drain → empty
+      .mockResolvedValue(NAV_INTENT); // all poll ticks → intent (must never reach)
+
+    const { onNavigate } = setup(takePending);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const callsAfterMount = takePending.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250 * 4);
+    });
+
+    expect(takePending).toHaveBeenCalledTimes(callsAfterMount);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('drains on the next poll tick after focus is restored', async () => {
+    let focused = false;
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => focused);
+    setVisibilityState('visible');
+
+    const takePending = vi
+      .fn<() => Promise<PendingMenuIntent | null>>()
+      .mockResolvedValueOnce(null) // mount drain
+      .mockResolvedValueOnce(NAV_INTENT) // first focused poll tick
+      .mockResolvedValue(null);
+
+    const { onNavigate } = setup(takePending);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Poll while unfocused — must stay silent.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    // Restore focus — next poll tick must drain.
+    focused = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(260);
+    });
+
+    expect(onNavigate).toHaveBeenCalledExactlyOnceWith(NAV_INTENT.payload);
+  });
+
+  it('stops polling after unmount and does not call onNavigate or takePending again', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setVisibilityState('visible');
+
+    // Spy on setInterval to capture the handle returned for the 250 ms poll.
+    // We wrap the real (fake-timer) implementation so advanceTimersByTimeAsync
+    // still drives ticks normally in this and every other test.
+    const realSetInterval = window.setInterval.bind(window);
+    let pollHandle: number | undefined;
+    const setIntervalSpy = vi
+      .spyOn(window, 'setInterval')
+      .mockImplementation((handler: TimerHandler, delay?: number, ...args: unknown[]) => {
+        const id = realSetInterval(handler, delay, ...args);
+        // Capture only the 250 ms poll registered by the hook.
+        if (delay === 250) pollHandle = id;
+        return id;
+      });
+
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+
+    const takePending = vi.fn<() => Promise<PendingMenuIntent | null>>().mockResolvedValue(null);
+    const { onNavigate, unmount } = setup(takePending);
+
+    // Let mount-drain settle.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Confirm the interval is running — advance one tick.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(260);
+    });
+
+    const callsBeforeUnmount = takePending.mock.calls.length;
+
+    // Unmount triggers cleanup: clearInterval(poll) + cancelled = true.
+    unmount();
+
+    // Assert clearInterval was called with the exact handle the hook registered,
+    // not just any clearInterval call React/jsdom may emit during teardown.
+    expect(pollHandle).toBeDefined();
+    expect(clearIntervalSpy).toHaveBeenCalledWith(pollHandle);
+
+    setIntervalSpy.mockRestore();
+
+    // Advance several more ticks — interval must be gone.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250 * 5);
+    });
+
+    expect(takePending).toHaveBeenCalledTimes(callsBeforeUnmount);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('routes a buffered menu.action intent to onAction, not onNavigate', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setVisibilityState('visible');
+
+    const takePending = vi
+      .fn<() => Promise<PendingMenuIntent | null>>()
+      .mockResolvedValueOnce(null) // mount drain
+      .mockResolvedValueOnce(ACTION_INTENT) // first poll tick
+      .mockResolvedValue(null);
+
+    const { onNavigate, onAction } = setup(takePending);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(260);
+    });
+
+    expect(onAction).toHaveBeenCalledExactlyOnceWith(ACTION_INTENT.payload);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('swallows IPC rejection, keeps polling, and delivers on recovery', async () => {
+    // HIGH 2: takePending rejects on the first poll tick (simulating a transient
+    // IPC failure). The try/catch in drain() must swallow it — no unhandled
+    // rejection, no throw. The interval must survive and deliver on the next tick.
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setVisibilityState('visible');
+
+    const takePending = vi
+      .fn<() => Promise<PendingMenuIntent | null>>()
+      .mockResolvedValueOnce(null) // mount drain → empty
+      .mockRejectedValueOnce(new Error('ipc failed')) // first poll tick → rejects
+      .mockRejectedValueOnce(new Error('ipc failed again')) // second poll tick → rejects
+      .mockResolvedValueOnce(NAV_INTENT) // third poll tick → recovers
+      .mockResolvedValue(null);
+
+    const { onNavigate, onAction } = setup(takePending);
+
+    // Mount-drain settles.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(onAction).not.toHaveBeenCalled();
+
+    // First poll tick — rejects; try/catch swallows; no callbacks fired.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(260);
+    });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(onAction).not.toHaveBeenCalled();
+
+    // Second poll tick — rejects again; still no callbacks.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(260);
+    });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    // Third poll tick — resolves with NAV_INTENT; intent delivered.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(260);
+    });
+
+    expect(onNavigate).toHaveBeenCalledExactlyOnceWith(NAV_INTENT.payload);
+    expect(onAction).not.toHaveBeenCalled();
+
+    // Confirm takePending was called on all ticks (poll survived the rejections).
+    // mount drain (1) + tick1 reject (1) + tick2 reject (1) + tick3 resolve (1) = 4.
+    expect(takePending).toHaveBeenCalledTimes(4);
+  });
+});

--- a/apps/tauri/src/renderer/services/use-menu/use-menu.ts
+++ b/apps/tauri/src/renderer/services/use-menu/use-menu.ts
@@ -21,7 +21,11 @@ import { useAppClient } from '@/providers/AppClientProvider';
  *    where the window never loses focus (so no focus/visibility change fires);
  *  - window `focus` + visibility-restore — cover the tray case (clicking the menu
  *    stole then returned focus) and the hidden → shown restore;
- *  - mount — anything buffered before the listeners attached.
+ *  - mount — anything buffered before the listeners attached;
+ *  - focused poll (250 ms) — backstop for the macOS menu-bar nav case where the
+ *    main window keeps key focus throughout (no focus/visibility event fires and
+ *    the shell emit is timing-fragile across NSMenu tracking); drains only while
+ *    the document is visible and focused, so there is zero background cost.
  *
  * `takePending` takes-and-clears atomically, so no matter how many triggers fire,
  * the intent is delivered exactly once and never re-fires on a later unrelated
@@ -35,10 +39,17 @@ export const useMenuIntents = (
   useEffect(() => {
     let cancelled = false;
     const drain = async () => {
-      const intent = await api.menu.takePending();
-      if (cancelled || !intent) return;
-      if (intent.event === 'menu.navigate') onNavigate?.(intent.payload);
-      else if (intent.event === 'menu.action') onAction?.(intent.payload);
+      try {
+        const intent = await api.menu.takePending();
+        if (cancelled || !intent) return;
+        if (intent.event === 'menu.navigate') onNavigate?.(intent.payload);
+        else if (intent.event === 'menu.action') onAction?.(intent.payload);
+      } catch {
+        // A transient IPC pull failure must not surface as an unhandled rejection
+        // (the 250ms poll would otherwise spam them). The shell buffer is retained
+        // on the shell side when the pull never returned, so a later trigger/poll
+        // re-drains; nothing is permanently lost.
+      }
     };
     const trigger = () => void drain();
     const onVisibility = () => {
@@ -52,9 +63,17 @@ export const useMenuIntents = (
     // payload and always drain the buffer so delivery is exactly-once.
     const offNavigate = api.menu.onNavigate(trigger);
     const offAction = api.menu.onAction(trigger);
+    // Backstop: the macOS menu-bar nav case fires NO focus/visibility/emit the
+    // renderer can trust (window keeps key focus; the shell emit is dropped across
+    // menu tracking). Poll the buffer while focused so the buffered intent always
+    // lands. `takePending` is a cheap take-and-clear; an empty pull is a no-op.
+    const poll: number = window.setInterval(() => {
+      if (document.visibilityState === 'visible' && document.hasFocus()) void drain();
+    }, 250);
 
     return () => {
       cancelled = true;
+      window.clearInterval(poll);
       window.removeEventListener('focus', trigger);
       document.removeEventListener('visibilitychange', onVisibility);
       offNavigate?.();


### PR DESCRIPTION
## Problem

On macOS, clicking native menu items that navigate the renderer — **Settings** (under the
app/About menu) and the **View**-menu route items — did nothing. The navigation only fired
later, after an *unrelated* window event (e.g. open **About**, close it → the queued Settings
nav suddenly happened).

## Root cause

The shell buffers each menu intent in `tray::PendingMenu` and the renderer **pulls** it via
`menu_take_pending`; every other mechanism (Rust `emit`, window `focus`, `visibilitychange`,
mount) is only a **trigger** to drain that buffer.

In the menu-bar nav case the main window never loses/regains *key* status (the system menu
bar belongs to the same app), so **no** JS `focus`/`visibilitychange`/show event fires, and
the Rust→JS `emit` is timing-fragile across NSMenu tracking — even the 120ms deferred re-emit
does not reliably reach the webview. Closing **About** works only because it's a separate
`NSWindow` that resigns→reclaims key, firing a real JS `blur`→`focus` that drains the buffer.

## Fix (renderer-only)

Add a **focused-only polling backstop** to `useMenuIntents`:

- `setInterval(250ms)` gated on `document.visibilityState === 'visible' && document.hasFocus()`
  that drains the existing exactly-once shell buffer. Pull is reliable where push is not; the
  buffer is take-and-clear, so an extra drain is a harmless no-op. Gated → zero cost when the
  app is backgrounded/hidden (the menu-bar case is always focused).
- Wrap `drain()` in `try/catch` so a poll-driven IPC rejection can't spam unhandled rejections.
- All existing emit/focus/visibility/mount triggers stay as the low-latency happy path → no
  Windows/tray regression. **No Rust / IPC / contract change.**

## Tests

New `use-menu.test.ts` (8 cases): poll-drain with no events, exactly-once across ticks,
gated-off when unfocused/hidden, focus-restore recovery, `clearInterval(pollId)` on unmount,
IPC-rejection survival + recovery, and `menu.action` routing. Uses `vi.advanceTimersByTimeAsync`
so the tests are sensitive to the poll actually firing.

## Verification

- `use-menu` suite: 8/8 green · eslint `--max-warnings 0` clean · `tsc --noEmit` clean.
- Manual (macOS) to confirm post-merge: App menu → Settings (no About first) navigates within
  ~250ms; View-menu route items navigate; repeat rapidly → last click wins; tray Settings /
  Check-for-Updates still work.

## Follow-up (out of scope, advisory)

`onAction`/`onNavigate` in `use-menu-navigation.ts` may be identity-unstable if
`useNotification`/`useUpdater` return fresh refs per render, churning the effect/interval
(idempotent, harmless now). Worth a future stabilization pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
