### PR TITLE
fix: notification-center coderabbit follow-ups (tray, permission, route, modal, docs)

### DIFF
--- a/apps/tauri/src-tauri/src/commands/notifications.rs
+++ b/apps/tauri/src-tauri/src/commands/notifications.rs
@@ -57,18 +57,23 @@ pub enum OsBanner {
 }
 
 /// The single permission-gated OS-notification path. Sends only when permission
-/// is granted, requesting once on first use and skipping silently on deny. Used
-/// by [`push_and_notify`]; the tray's autopilot banner routes through here too,
-/// so there is exactly ONE gated `.show()` call site in the app.
+/// is granted; when the state is already `Denied` it skips silently WITHOUT
+/// re-requesting (a denied permission is terminal). Any other state (`Prompt` /
+/// `PromptWithRationale`, or a read error) triggers a one-time request and shows
+/// only if that returns `Granted`. Used by [`push_and_notify`]; the tray's
+/// autopilot banner routes through here too, so there is exactly ONE gated
+/// `.show()` call site in the app.
 pub fn show_os_notification(app: &AppHandle, title: &str, body: &str) {
-    // Permission gate: send only if granted; request once when not, skip on deny.
-    let granted = matches!(
-        app.notification().permission_state(),
-        Ok(PermissionState::Granted)
-    ) || matches!(
-        app.notification().request_permission(),
-        Ok(PermissionState::Granted)
-    );
+    // Permission gate: send when granted; skip silently (no re-request) when
+    // already denied; otherwise request once and show only if that grants.
+    let granted = match app.notification().permission_state() {
+        Ok(PermissionState::Granted) => true,
+        Ok(PermissionState::Denied) => false,
+        _ => matches!(
+            app.notification().request_permission(),
+            Ok(PermissionState::Granted)
+        ),
+    };
     if !granted {
         return;
     }

--- a/apps/tauri/src-tauri/src/notifications/mod.rs
+++ b/apps/tauri/src-tauri/src/notifications/mod.rs
@@ -4,8 +4,9 @@
 //! persisted to `<dataDir>/notifications.json`. It mirrors the persistence
 //! pattern of [`crate::autopilot::AutopilotStore`] /
 //! [`crate::postings::InteractionStore`]: a `data_file` path plus an in-memory
-//! cache guarded by a `parking_lot::Mutex`, with IO swallowed via `.ok()` so the
-//! mutators stay infallible.
+//! cache guarded by a `parking_lot::Mutex`. The mutators stay infallible: read
+//! IO is swallowed via `.ok()`, and a failed save (serialize or write) is logged
+//! via `log::warn!` rather than propagated.
 //!
 //! ## Layering
 //! Pure **data + disk** — deliberately `AppHandle`-free (no Tauri imports beyond
@@ -196,8 +197,17 @@ impl NotificationStore {
     }
 
     fn save(&self, notifications: Vec<AppNotification>) {
-        if let Ok(json) = serde_json::to_string_pretty(&notifications) {
-            std::fs::write(&self.data_file, json).ok();
+        // Infallible (mirrors every sibling store), but a failed serialize or
+        // write is logged rather than silently dropped so disk-persistence
+        // problems are diagnosable. The in-memory cache is still updated so the
+        // running session stays consistent even if the disk write failed.
+        match serde_json::to_string_pretty(&notifications) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&self.data_file, &json) {
+                    log::warn!("failed to persist notifications to disk: {e}");
+                }
+            }
+            Err(e) => log::warn!("failed to serialize notifications: {e}"),
         }
         *self.cache.lock() = Some(notifications);
     }

--- a/apps/tauri/src-tauri/src/tray/mod.rs
+++ b/apps/tauri/src-tauri/src/tray/mod.rs
@@ -225,6 +225,7 @@ pub fn on_new_jobs(app: &AppHandle, autopilot_id: &str, autopilot_name: &str, ne
             g.total
         };
         let _ = state.new_jobs_item.set_text(format!("New jobs: {total}"));
+        let _ = state.new_jobs_item.set_enabled(total > 0);
     }
 }
 
@@ -263,6 +264,7 @@ pub fn handle_notification_click(app: &AppHandle) {
         t
     };
     let _ = state.new_jobs_item.set_text("New jobs: 0");
+    let _ = state.new_jobs_item.set_enabled(false);
     if let Some(id) = target {
         emit_focus(app, &id);
     }

--- a/apps/tauri/src/renderer/components/layout/Titlebar/NotificationBell/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/Titlebar/NotificationBell/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from '@ajh/translations';
 import { Button, EmptyState, transition } from '@ajh/ui';
 
+import { resolveNotificationRoute } from '@/lib/notification-route';
 import { timeAgo } from '@/lib/time';
 import {
   useClearAllNotifications,
@@ -119,10 +120,11 @@ export function NotificationBell() {
                     markRead.mutate(n.id);
                     setOpen(false);
                     if (n.route) {
-                      // `route.to` is a dynamic string from the backend, but
-                      // TanStack's `navigate` is typed for static routes — a
-                      // minimal cast is required for the runtime-driven target.
-                      void router.navigate({ to: n.route.to, search: n.route.search } as never);
+                      const validatedTo = resolveNotificationRoute(n.route.to);
+                      void router.navigate({
+                        to: validatedTo,
+                        search: validatedTo === n.route.to ? n.route.search : undefined,
+                      });
                     }
                   };
                   return (

--- a/apps/tauri/src/renderer/features/applications/components/TrackJobModal/index.tsx
+++ b/apps/tauri/src/renderer/features/applications/components/TrackJobModal/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 
 import type { ApplicationTrackRequest } from '@ajh/shared';
@@ -21,19 +22,28 @@ export function TrackJobModal({ open, onClose }: TrackJobModalProps) {
     defaultValues: { jobUrl: '', company: '', title: '', candidate: '' },
   });
 
+  // Guard stale in-flight mutations from closing/resetting a freshly reopened modal.
+  // Each time `open` transitions to true a new session token is issued; only the
+  // submit that captured the CURRENT token may call handleClose.
+  const sessionRef = useRef(0);
+  useEffect(() => {
+    if (open) sessionRef.current += 1;
+  }, [open]);
+
   const handleClose = () => {
     reset();
     onClose();
   };
 
   const onSubmit = handleSubmit(async (values) => {
+    const session = sessionRef.current;
     const req: ApplicationTrackRequest = {};
     if (values.jobUrl.trim()) req.jobUrl = values.jobUrl.trim();
     if (values.company.trim()) req.company = values.company.trim();
     if (values.title.trim()) req.title = values.title.trim();
     if (values.candidate.trim()) req.candidate = values.candidate.trim();
     await trackMutation.mutateAsync(req);
-    handleClose();
+    if (sessionRef.current === session) handleClose();
   });
 
   const titleId = 'track-job-modal-title';

--- a/apps/tauri/src/renderer/lib/notification-route.test.ts
+++ b/apps/tauri/src/renderer/lib/notification-route.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  isKnownRoute,
+  KNOWN_ROUTE_PATHS,
+  resolveNotificationRoute,
+  ROUTE_FALLBACK,
+} from './notification-route';
+
+// ── isKnownRoute (pure core) ──────────────────────────────────────────────────
+
+describe('isKnownRoute', () => {
+  const known = new Set(['/jobs', '/settings', '/']);
+
+  it('returns true for a path in the set', () => {
+    expect(isKnownRoute(known, '/jobs')).toBe(true);
+  });
+
+  it('returns true for root path', () => {
+    expect(isKnownRoute(known, '/')).toBe(true);
+  });
+
+  it('returns false for an unknown path', () => {
+    expect(isKnownRoute(known, '/nonexistent')).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isKnownRoute(known, '')).toBe(false);
+  });
+
+  it('returns false for a partial match (prefix only)', () => {
+    expect(isKnownRoute(known, '/job')).toBe(false);
+  });
+});
+
+// ── resolveNotificationRoute ──────────────────────────────────────────────────
+
+describe('resolveNotificationRoute', () => {
+  it('passes through every known route unchanged', () => {
+    for (const path of KNOWN_ROUTE_PATHS) {
+      expect(resolveNotificationRoute(path)).toBe(path);
+    }
+  });
+
+  it('returns ROUTE_FALLBACK for an unknown destination', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(resolveNotificationRoute('/unknown-backend-route')).toBe(ROUTE_FALLBACK);
+    warnSpy.mockRestore();
+  });
+
+  it('logs a console.warn for an unknown destination including the offending path', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    resolveNotificationRoute('/bogus');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('/bogus'));
+    warnSpy.mockRestore();
+  });
+
+  it('does NOT warn for a known route', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    resolveNotificationRoute('/jobs');
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('ROUTE_FALLBACK is "/"', () => {
+    expect(ROUTE_FALLBACK).toBe('/');
+  });
+});

--- a/apps/tauri/src/renderer/lib/notification-route.ts
+++ b/apps/tauri/src/renderer/lib/notification-route.ts
@@ -1,0 +1,77 @@
+/**
+ * notification-route — validate backend-supplied route destinations.
+ *
+ * The Rust backend emits notification `route.to` strings at runtime.
+ * TanStack Router's `navigate` is typed against a static union of known
+ * paths; this helper validates the candidate string against that union
+ * before navigation so an unknown destination falls back to '/' instead
+ * of silently breaking.
+ *
+ * `KnownRoutePath` is sourced directly from `FileRouteTypes['to']` in
+ * routeTree.gen.ts (the TanStack Router generated file). The exhaustive
+ * `KNOWN_ROUTE_TABLE` below is keyed by that union, so adding or removing
+ * a route in routeTree.gen.ts causes a typecheck failure here until the
+ * table is updated — the runtime `KNOWN_ROUTE_PATHS` Set can never
+ * silently drift from the router.
+ */
+
+import type { FileRouteTypes } from '@/routeTree.gen';
+
+/** Union of the router's known `to` paths — sourced from routeTree.gen.ts. */
+export type KnownRoutePath = FileRouteTypes['to'];
+
+/** Fallback destination used for unknown routes. */
+export const ROUTE_FALLBACK: KnownRoutePath = '/';
+
+// Exhaustive over KnownRoutePath: a new/removed route in routeTree.gen
+// fails typecheck here until this table matches. The runtime Set is derived
+// from it, so KNOWN_ROUTE_PATHS can never silently drift from the router.
+const KNOWN_ROUTE_TABLE: Record<KnownRoutePath, true> = {
+  '/': true,
+  '/ai-generate': true,
+  '/analyze': true,
+  '/applications': true,
+  '/autopilot': true,
+  '/build': true,
+  '/jobs': true,
+  '/monitoring': true,
+  '/resumes': true,
+  '/search': true,
+  '/settings': true,
+  '/support': true,
+};
+
+/**
+ * Build the known-paths Set from the exhaustive route table.
+ * Kept as a `const` so callers can cache it across renders if desired.
+ */
+export const KNOWN_ROUTE_PATHS: Set<KnownRoutePath> = new Set(
+  Object.keys(KNOWN_ROUTE_TABLE) as KnownRoutePath[]
+);
+
+/**
+ * Pure core — accepts the set of known paths and a candidate string.
+ * Returns `true` when the candidate is a member of the set.
+ *
+ * Accepts any `Set<string>` so unit tests can drive it directly
+ * without importing the router.
+ */
+export function isKnownRoute(knownPaths: Set<string>, candidate: string): boolean {
+  return knownPaths.has(candidate);
+}
+
+/**
+ * Validate `candidate` against the known router paths.
+ *
+ * - Known path   → returns it typed as `KnownRoutePath`.
+ * - Unknown path → logs a warning and returns `ROUTE_FALLBACK`.
+ */
+export function resolveNotificationRoute(candidate: string): KnownRoutePath {
+  if (isKnownRoute(KNOWN_ROUTE_PATHS, candidate)) {
+    return candidate as KnownRoutePath;
+  }
+  console.warn(
+    `[notification-route] Unknown route destination "${candidate}" from backend notification. Falling back to "${ROUTE_FALLBACK}".`
+  );
+  return ROUTE_FALLBACK;
+}

--- a/docs/knowledge/notification-center.md
+++ b/docs/knowledge/notification-center.md
@@ -5,15 +5,15 @@
 - Store: `apps/tauri/src-tauri/src/notifications/mod.rs` — `NotificationStore`, `AppNotification`, `NewNotification`, `NotificationRoute`
 - Commands: `apps/tauri/src-tauri/src/commands/notifications.rs` — `notifications_list`, `notifications_mark_read`, `notifications_mark_all_read`, `notifications_remove`, `notifications_clear_all`, `notifications_clicked`, `push_and_notify`, `OsBanner`
 - IPC contract: `packages/shared/src/ipc/contracts/notifications.ts` — request/response schemas
-- Renderer service: `apps/tauri/src/renderer/services/use-notifications.ts` — query hook `useNotificationsList`, `useNotificationsEvents`, mutation hooks `useMarkRead`, `useMarkAllRead`, `useRemove`, `useClearAll`, `useNotificationClicked`
-- UI: `apps/tauri/src/renderer/components/layout/Titlebar/NotificationBell.tsx` — bell icon + unread badge + dropdown inbox; `apps/tauri/src/renderer/routes/__root.tsx` — `NotificationToastBridge` for toast rendering; app routes (`/autopilot`, `/applications`) consume `focus` / `highlight` query params
+- Renderer service: `apps/tauri/src/renderer/services/use-notifications/use-notifications.ts` — query hook `useNotifications`, subscription hook `useNotificationEvents`, mutation hooks `useMarkNotificationRead`, `useMarkAllNotificationsRead`, `useRemoveNotification`, `useClearAllNotifications`
+- UI: `apps/tauri/src/renderer/components/layout/Titlebar/NotificationBell/index.tsx` — bell icon + unread badge + dropdown inbox; `apps/tauri/src/renderer/routes/__root.tsx` — `NotificationToastBridge` for toast rendering; app routes (`/autopilot`, `/applications`) consume `focus` / `highlight` query params
 - Sources: autopilot `apps/tauri/src-tauri/src/autopilot/mod.rs` (`tray::on_new_jobs`, pushes with `OsBanner::Always`); browser extension `apps/tauri/src-tauri/src/extension_bridge/mod.rs` (success branch, pushes with `OsBanner::WhenUnfocused`)
 
 **Decision:** ADR-016 (centralized, Rust-owned, persisted store; open-typed kind + route for extensibility; English-only content Phase 1; desktop onAction identity-free routing to inbox)
 
 **Setup:**
 
-- Tauri `main.rs` registers via `manage_resettable(app, &mut reset_reg, "notifications", NotificationStore::new(data_dir))`
+- Tauri `lib.rs` registers via `notifications::manage(app, &mut reset_registry, &data_dir)` (line ~499)
 - Capabilities: `notification:allow-notify`, `notification:allow-show`, `notification:allow-request-permission`, `notification:allow-check-permissions`, `notification:allow-is-permission-granted`, `notification:allow-permission-state`
 
 **Integration:** sources call `push_and_notify(app, NewNotification { kind, title, body, route }, OsBanner)` to create and broadcast; renderer refetches inbox on `notifications:changed` event; toast appears on `notifications:toast` event when focused; OS banner appears per policy; deep-link from banner/tray goes to `notifications_clicked` → inbox open


### PR DESCRIPTION
Applies the valid CodeRabbit review findings raised on #364 (already merged) on a fresh branch.

## Fixes

### Rust
- **#1 tray** — the "New jobs: N" tray item was built `.enabled(false)` and only ever had its text updated, so it never became clickable. Now `set_enabled(total > 0)` in `on_new_jobs` and `set_enabled(false)` on reset in `handle_notification_click`.
- **#3 notifications** — `show_os_notification` now treats a denied notification permission as terminal: `Granted` → show; `Denied` → skip (no re-request); `Prompt`/`PromptWithRationale`/`Err` → request once, show only on `Granted`.
- **#2 notifications store** — `save()` now `log::warn!`s on serialize/write failure instead of swallowing it silently. The store stays infallible (signature unchanged).

### Renderer
- **#4 NotificationBell** — validates a backend-supplied notification `route.to` against the router's known paths before navigating, drops the unsafe `as never` cast, and falls back to `/` with a warning on an unknown destination. The known-route union is sourced from `routeTree.gen` via an exhaustive `Record<KnownRoutePath, true>` so it cannot silently drift (a new/removed route fails typecheck). New pure helper `lib/notification-route.ts` + unit tests.
- **#5 TrackJobModal** — captures an open-session token on submit and only closes/resets after the awaited mutation if the session is unchanged, so a stale in-flight mutation can no longer reset a reopened modal.

### Docs
- **#7** — corrected `docs/knowledge/notification-center.md`: real hook names (`useNotifications`, `useNotificationEvents`, `useMarkNotificationRead`, `useMarkAllNotificationsRead`, `useRemoveNotification`, `useClearAllNotifications`, `api.notifications.clicked()`), service path (`services/use-notifications/use-notifications.ts`), bell path (`Titlebar/NotificationBell/index.tsx`), and registration location (`lib.rs`, not `main.rs`). Kept `NotificationToastBridge` (it exists in `routes/__root.tsx` — CodeRabbit was wrong there).

## Skipped (intentional)
- **#6** `use-autopilot.ts` "unused `useEffect`" — false positive; it is used by the `onStep`/`onFocus` effects and `lint:strict --max-warnings 0` passes.
- **#2 core** making `save()` fallible — intentional infallible-store pattern matching every sibling store (security-reviewed LOW). Only the warn-logs were added.

## Verification
- `cargo build` + `cargo clippy --all-targets --all-features -- -D warnings` + `cargo test --all-features`: green (1020 passed, incl. `--test architecture`).
- Renderer `typecheck` (10/10), `vitest` (1553 passed), `lint:strict` (0 errors / 0 warnings).
- Reviewed by `rust-backend-architect` + `frontend-reviewer`: no HIGH/CRITICAL findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OS notification permission handling to distinguish denied states.
  * Fixed stale submission handling in job tracking modal.
  * Enhanced notification route validation and fallback logic.

* **Improvements**
  * "New jobs" menu item now dynamically enables/disables based on unread jobs.
  * Added warning logging for notification persistence failures.

* **Tests**
  * Added tests for notification route validation helpers.

* **Documentation**
  * Updated notification center integration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->