### PR TITLE
feat: jobs collapse — unified record, appended migration, footer tracks every kind

### DIFF
--- a/apps/tauri/src-tauri/src/commands/ai.rs
+++ b/apps/tauri/src-tauri/src/commands/ai.rs
@@ -30,13 +30,11 @@ fn uuid_v4() -> String {
 #[tauri::command]
 pub async fn ai_generate(app: AppHandle, req: AiGenerateRequest) -> Value {
     let job_id = uuid_v4();
-    app.state::<Mutex<JobTracker>>()
-        .lock()
-        .start(&job_id, "ai.generate");
+    crate::commands::jobs::job_start(&app, &job_id, "ai.generate");
 
     let fail = |app: &AppHandle, job_id: &str, msg: String| -> Value {
         emit_stream_error(app, job_id, &msg);
-        app.state::<Mutex<JobTracker>>().lock().fail(job_id, msg);
+        crate::commands::jobs::job_fail(app, job_id, msg);
         json!({ "jobId": job_id })
     };
 
@@ -75,10 +73,7 @@ pub async fn ai_generate(app: AppHandle, req: AiGenerateRequest) -> Value {
         if let Err(e) = provider.chat_stream(&app_clone, &job_id_clone, &req).await {
             let msg = e.to_string();
             emit_stream_error(&app_clone, &job_id_clone, &msg);
-            app_clone
-                .state::<Mutex<JobTracker>>()
-                .lock()
-                .fail(&job_id_clone, msg);
+            crate::commands::jobs::job_fail(&app_clone, &job_id_clone, msg);
         }
     });
 
@@ -206,9 +201,7 @@ pub async fn ai_research_company(
 #[tauri::command]
 pub async fn ai_pull_model(app: AppHandle, model: String) -> Value {
     let job_id = uuid_v4();
-    app.state::<Mutex<JobTracker>>()
-        .lock()
-        .start(&job_id, "ai.pull_model");
+    crate::commands::jobs::job_start(&app, &job_id, "ai.pull_model");
 
     let job_id_clone = job_id.clone();
     let app_clone = app.clone();
@@ -216,16 +209,14 @@ pub async fn ai_pull_model(app: AppHandle, model: String) -> Value {
     tauri::async_runtime::spawn(async move {
         match ollama::pull(&app_clone, &job_id_clone, &model).await {
             Ok(()) => {
-                app_clone
-                    .state::<Mutex<JobTracker>>()
-                    .lock()
-                    .complete(&job_id_clone, json!({ "model": model, "done": true }));
+                crate::commands::jobs::job_complete(
+                    &app_clone,
+                    &job_id_clone,
+                    json!({ "model": model, "done": true }),
+                );
             }
             Err(e) => {
-                app_clone
-                    .state::<Mutex<JobTracker>>()
-                    .lock()
-                    .fail(&job_id_clone, e.to_string());
+                crate::commands::jobs::job_fail(&app_clone, &job_id_clone, e.to_string());
             }
         }
     });
@@ -348,9 +339,7 @@ pub async fn ai_set_embedding_config(
 #[tauri::command]
 pub async fn ai_reembed_all(app: AppHandle) -> Value {
     let job_id = uuid_v4();
-    app.state::<Mutex<JobTracker>>()
-        .lock()
-        .start(&job_id, "ai.reembed");
+    crate::commands::jobs::job_start(&app, &job_id, "ai.reembed");
 
     let job_id_clone = job_id.clone();
     let app_clone = app.clone();
@@ -400,19 +389,10 @@ pub async fn ai_reembed_all(app: AppHandle) -> Value {
             );
         }
 
-        app_clone.state::<Mutex<JobTracker>>().lock().complete(
+        crate::commands::jobs::job_complete(
+            &app_clone,
             &job_id_clone,
             json!({ "reembedded": done, "failed": failed, "total": total }),
-        );
-        emit_event(
-            &app_clone,
-            JOBS_EVENT,
-            JobEvent {
-                r#type: "job.completed".to_string(),
-                job_id: job_id_clone.clone(),
-                data: Some(json!({ "reembedded": done, "failed": failed, "total": total })),
-                ts: crate::documents::now_ms() as i64,
-            },
         );
     });
 

--- a/apps/tauri/src-tauri/src/commands/ai_provider/anthropic.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/anthropic.rs
@@ -176,9 +176,11 @@ impl AiProvider for AnthropicClient {
                                     thinking: None,
                                 },
                             );
-                            app.state::<Mutex<JobTracker>>()
-                                .lock()
-                                .complete(job_id, json!({ "done": true }));
+                            crate::commands::jobs::job_complete(
+                                app,
+                                job_id,
+                                json!({ "done": true }),
+                            );
                             trace.end(Some(status.as_u16()), true);
                             return Ok(());
                         }
@@ -253,9 +255,7 @@ impl AiProvider for AnthropicClient {
                 thinking: None,
             },
         );
-        app.state::<Mutex<JobTracker>>()
-            .lock()
-            .complete(job_id, json!({ "done": true }));
+        crate::commands::jobs::job_complete(app, job_id, json!({ "done": true }));
         trace.end(Some(status.as_u16()), true);
         Ok(())
     }

--- a/apps/tauri/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
@@ -625,9 +625,7 @@ fn emit_done(app: &AppHandle, job_id: &str) {
             thinking: None,
         },
     );
-    app.state::<Mutex<JobTracker>>()
-        .lock()
-        .complete(job_id, json!({ "done": true }));
+    crate::commands::jobs::job_complete(app, job_id, json!({ "done": true }));
 }
 
 /// All `system` message content, joined — passed to the agent as its system prompt.

--- a/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
@@ -246,9 +246,7 @@ impl AiProvider for GeminiClient {
                 thinking: None,
             },
         );
-        app.state::<Mutex<JobTracker>>()
-            .lock()
-            .complete(job_id, json!({ "done": true }));
+        crate::commands::jobs::job_complete(app, job_id, json!({ "done": true }));
         trace.end(Some(status.as_u16()), true);
         Ok(())
     }

--- a/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
@@ -593,9 +593,7 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
                         },
                     );
                     if done {
-                        app.state::<Mutex<JobTracker>>()
-                            .lock()
-                            .complete(job_id, json!({ "done": true }));
+                        crate::commands::jobs::job_complete(app, job_id, json!({ "done": true }));
                         trace.end(Some(status.as_u16()), true);
                         return Ok(());
                     }
@@ -620,9 +618,7 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
             thinking: None,
         },
     );
-    app.state::<Mutex<JobTracker>>()
-        .lock()
-        .complete(job_id, json!({ "done": true }));
+    crate::commands::jobs::job_complete(app, job_id, json!({ "done": true }));
     trace.end(Some(status.as_u16()), true);
     Ok(())
 }

--- a/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
@@ -226,9 +226,11 @@ impl AiProvider for OpenAiClient {
                                     thinking: None,
                                 },
                             );
-                            app.state::<Mutex<JobTracker>>()
-                                .lock()
-                                .complete(job_id, json!({ "done": true }));
+                            crate::commands::jobs::job_complete(
+                                app,
+                                job_id,
+                                json!({ "done": true }),
+                            );
                             trace.end(Some(status.as_u16()), true);
                             return Ok(());
                         }
@@ -284,9 +286,7 @@ impl AiProvider for OpenAiClient {
                 thinking: None,
             },
         );
-        app.state::<Mutex<JobTracker>>()
-            .lock()
-            .complete(job_id, json!({ "done": true }));
+        crate::commands::jobs::job_complete(app, job_id, json!({ "done": true }));
         trace.end(Some(status.as_u16()), true);
         Ok(())
     }

--- a/apps/tauri/src-tauri/src/commands/autopilot.rs
+++ b/apps/tauri/src-tauri/src/commands/autopilot.rs
@@ -121,9 +121,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
     );
 
     let job_id = uuid_v4();
-    app.state::<Mutex<crate::jobs::JobTracker>>()
-        .lock()
-        .start(&job_id, "autopilot.run");
+    crate::commands::jobs::job_start(&app, &job_id, "autopilot.run");
 
     // Mark the run live so the UI shows a "running" badge and a crash mid-run
     // is later reconciled to "interrupted" (see `mark_interrupted_runs`).
@@ -158,9 +156,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
             store(&app)
                 .lock()
                 .set_run_status(&autopilot_id, RunStatus::Failed);
-            app.state::<Mutex<crate::jobs::JobTracker>>()
-                .lock()
-                .fail(&job_id, e.to_string());
+            crate::commands::jobs::job_fail(&app, &job_id, e.to_string());
             span.end(false);
             return json!({ "error": e, "jobId": job_id });
         }
@@ -250,9 +246,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
         store(&app)
             .lock()
             .set_run_status(&autopilot_id, RunStatus::Completed);
-        app.state::<Mutex<crate::jobs::JobTracker>>()
-            .lock()
-            .cancel(&job_id);
+        crate::commands::jobs::job_cancel(&app, &job_id);
         span.end_with("cancelled before recording results", false);
         return json!({ "jobId": job_id, "cancelled": true });
     }
@@ -267,9 +261,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
 
     engine.unregister_token(&job_id).await;
 
-    app.state::<Mutex<crate::jobs::JobTracker>>()
-        .lock()
-        .complete(&job_id, json!({ "found": kept, "applied": 0 }));
+    crate::commands::jobs::job_complete(&app, &job_id, json!({ "found": kept, "applied": 0 }));
 
     emit_step(
         &app,

--- a/apps/tauri/src-tauri/src/commands/jobs.rs
+++ b/apps/tauri/src-tauri/src/commands/jobs.rs
@@ -1,8 +1,64 @@
+use crate::events::{emit_event, JobEvent, JOBS_EVENT};
 use crate::jobs::JobTracker;
 use crate::scraping::ScraperEngine;
 use parking_lot::Mutex;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
+
+// ── L3 emit wrapper ───────────────────────────────────────────────────────────
+//
+// The `JobTracker` (L1) is AppHandle-free and must not emit. These thin wrappers
+// are the single mutator boundary: they apply the in-memory/SQLite transition and
+// then emit the matching `jobs:event` so the footer activity monitor reflects
+// EVERY job of EVERY kind (ai.generate, autopilot.run, scrape.*, …), not just the
+// few that used to emit ad-hoc. Call these instead of `tracker.lock().<mutator>()`.
+
+fn emit_job_event(app: &AppHandle, kind: &str, job_id: &str, data: Option<Value>) {
+    emit_event(
+        app,
+        JOBS_EVENT,
+        JobEvent {
+            r#type: kind.to_string(),
+            job_id: job_id.to_string(),
+            data,
+            ts: crate::documents::now_ms() as i64,
+        },
+    );
+}
+
+/// Register a job as running and emit `job.started`.
+pub fn job_start(app: &AppHandle, id: &str, kind: &str) {
+    app.state::<Mutex<JobTracker>>().lock().start(id, kind);
+    emit_job_event(app, "job.started", id, None);
+}
+
+/// Update a job's progress (0.0–1.0) and emit `job.progress`.
+pub fn job_progress(app: &AppHandle, id: &str, p: f64) {
+    app.state::<Mutex<JobTracker>>().lock().update_progress(id, p);
+    emit_job_event(app, "job.progress", id, Some(json!({ "progress": p })));
+}
+
+/// Mark a job completed and emit `job.completed` (the result rides as `data`).
+pub fn job_complete(app: &AppHandle, id: &str, result: Value) {
+    app.state::<Mutex<JobTracker>>()
+        .lock()
+        .complete(id, result.clone());
+    emit_job_event(app, "job.completed", id, Some(result));
+}
+
+/// Mark a job failed and emit `job.failed` (the error string rides as `data`).
+pub fn job_fail(app: &AppHandle, id: &str, error: String) {
+    app.state::<Mutex<JobTracker>>()
+        .lock()
+        .fail(id, error.clone());
+    emit_job_event(app, "job.failed", id, Some(Value::String(error)));
+}
+
+/// Mark a job cancelled and emit `job.cancelled`.
+pub fn job_cancel(app: &AppHandle, id: &str) {
+    app.state::<Mutex<JobTracker>>().lock().cancel(id);
+    emit_job_event(app, "job.cancelled", id, None);
+}
 
 #[tauri::command]
 pub fn jobs_list(app: AppHandle) -> Value {
@@ -23,7 +79,7 @@ pub async fn jobs_cancel(app: AppHandle, job_id: String) -> Value {
     let engine = app.state::<std::sync::Arc<ScraperEngine>>();
     engine.cancel(&job_id).await;
 
-    app.state::<Mutex<JobTracker>>().lock().cancel(&job_id);
+    job_cancel(&app, &job_id);
     json!({ "success": true })
 }
 

--- a/apps/tauri/src-tauri/src/commands/jobs.rs
+++ b/apps/tauri/src-tauri/src/commands/jobs.rs
@@ -34,7 +34,9 @@ pub fn job_start(app: &AppHandle, id: &str, kind: &str) {
 
 /// Update a job's progress (0.0–1.0) and emit `job.progress`.
 pub fn job_progress(app: &AppHandle, id: &str, p: f64) {
-    app.state::<Mutex<JobTracker>>().lock().update_progress(id, p);
+    app.state::<Mutex<JobTracker>>()
+        .lock()
+        .update_progress(id, p);
     emit_job_event(app, "job.progress", id, Some(json!({ "progress": p })));
 }
 

--- a/apps/tauri/src-tauri/src/commands/pipeline.rs
+++ b/apps/tauri/src-tauri/src/commands/pipeline.rs
@@ -7,13 +7,11 @@
 //! (e.g. a resume validator) without a bespoke architecture.
 
 use async_trait::async_trait;
-use parking_lot::Mutex;
 use serde_json::{json, Value};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use crate::commands::ai_provider::{emit_stream_error, resolve, AiGenerateRequest, ProviderId};
 use crate::error::AppResult;
-use crate::jobs::JobTracker;
 use crate::pipeline::{Pipeline, Stage};
 
 fn new_job_id() -> String {
@@ -47,13 +45,11 @@ impl Stage<GenerationContext> for StreamGenerateStage {
 #[tauri::command]
 pub async fn generate_pipeline(app: AppHandle, req: AiGenerateRequest) -> Value {
     let job_id = new_job_id();
-    app.state::<Mutex<JobTracker>>()
-        .lock()
-        .start(&job_id, "pipeline.generate");
+    crate::commands::jobs::job_start(&app, &job_id, "pipeline.generate");
 
     let fail = |app: &AppHandle, job_id: &str, msg: String| -> Value {
         emit_stream_error(app, job_id, &msg);
-        app.state::<Mutex<JobTracker>>().lock().fail(job_id, msg);
+        crate::commands::jobs::job_fail(app, job_id, msg);
         json!({ "jobId": job_id })
     };
 
@@ -88,10 +84,7 @@ pub async fn generate_pipeline(app: AppHandle, req: AiGenerateRequest) -> Value 
         if let Err(e) = pipeline.run(&mut ctx).await {
             let msg = e.to_string();
             emit_stream_error(&app_clone, &job_id_clone, &msg);
-            app_clone
-                .state::<Mutex<JobTracker>>()
-                .lock()
-                .fail(&job_id_clone, msg);
+            crate::commands::jobs::job_fail(&app_clone, &job_id_clone, msg);
         }
     });
 

--- a/apps/tauri/src-tauri/src/commands/scrape.rs
+++ b/apps/tauri/src-tauri/src/commands/scrape.rs
@@ -55,9 +55,7 @@ fn uuid_v4() -> String {
 #[tauri::command]
 pub async fn scrape_board(app: AppHandle, req: ScrapeBoardRequest) -> Value {
     let job_id = uuid_v4();
-    app.state::<Mutex<crate::jobs::JobTracker>>()
-        .lock()
-        .start(&job_id, "scrape.board");
+    crate::commands::jobs::job_start(&app, &job_id, "scrape.board");
 
     let engine = app.state::<std::sync::Arc<ScraperEngine>>().inner().clone();
     let input = BoardSearchInput {
@@ -88,12 +86,7 @@ pub async fn scrape_board(app: AppHandle, req: ScrapeBoardRequest) -> Value {
             SCRAPE_PROGRESS,
             json!({ "jobId": job_id_progress, "progress": p }),
         );
-        if let Some(tracker) = app_progress.try_state::<Mutex<crate::jobs::JobTracker>>() {
-            {
-                let mut g = tracker.lock();
-                g.update_progress(&job_id_progress, p as f64);
-            }
-        }
+        crate::commands::jobs::job_progress(&app_progress, &job_id_progress, p as f64);
     });
 
     let app_item = app.clone();
@@ -133,39 +126,16 @@ pub async fn scrape_board(app: AppHandle, req: ScrapeBoardRequest) -> Value {
             )
             .await;
 
-        let tracker = app_clone.state::<Mutex<crate::jobs::JobTracker>>();
         match &result {
             Ok(results) => {
-                {
-                    let mut g = tracker.lock();
-                    g.complete(&job_id_clone, json!({ "count": results.len() }));
-                }
-                emit_event(
+                crate::commands::jobs::job_complete(
                     &app_clone,
-                    JOBS_EVENT,
-                    JobEvent {
-                        r#type: "job.completed".to_string(),
-                        job_id: job_id_clone.clone(),
-                        data: Some(json!({ "count": results.len() })),
-                        ts: now_ms() as i64,
-                    },
+                    &job_id_clone,
+                    json!({ "count": results.len() }),
                 );
             }
             Err(e) => {
-                {
-                    let mut g = tracker.lock();
-                    g.fail(&job_id_clone, e.to_string());
-                }
-                emit_event(
-                    &app_clone,
-                    JOBS_EVENT,
-                    JobEvent {
-                        r#type: "job.failed".to_string(),
-                        job_id: job_id_clone.clone(),
-                        data: Some(json!(e.to_string())),
-                        ts: now_ms() as i64,
-                    },
-                );
+                crate::commands::jobs::job_fail(&app_clone, &job_id_clone, e.to_string());
             }
         }
 
@@ -183,16 +153,13 @@ pub async fn scrape_url(app: AppHandle, req: ScrapeUrlRequest) -> Value {
     }
 
     let job_id = uuid_v4();
-    app.state::<Mutex<crate::jobs::JobTracker>>()
-        .lock()
-        .start(&job_id, "scrape.url");
+    crate::commands::jobs::job_start(&app, &job_id, "scrape.url");
 
     let app_clone = app.clone();
     let job_id_clone = job_id.clone();
     tokio::spawn(async move {
         let result = crate::scraping::scrape_url::resolve(&url).await;
 
-        let tracker = app_clone.state::<Mutex<crate::jobs::JobTracker>>();
         match result {
             Ok(Some(posting)) => {
                 if let Some(cache) = app_clone.try_state::<Mutex<PostingsCache>>() {
@@ -215,52 +182,21 @@ pub async fn scrape_url(app: AppHandle, req: ScrapeUrlRequest) -> Value {
                     },
                 );
 
-                {
-                    let mut g = tracker.lock();
-                    g.complete(&job_id_clone, json!({ "ok": true }));
-                }
-                emit_event(
+                crate::commands::jobs::job_complete(
                     &app_clone,
-                    JOBS_EVENT,
-                    JobEvent {
-                        r#type: "job.completed".to_string(),
-                        job_id: job_id_clone.clone(),
-                        data: Some(json!({ "count": 1 })),
-                        ts: now_ms() as i64,
-                    },
+                    &job_id_clone,
+                    json!({ "count": 1 }),
                 );
             }
             Ok(None) => {
-                {
-                    let mut g = tracker.lock();
-                    g.fail(&job_id_clone, "no scraper matched this URL".to_string());
-                }
-                emit_event(
+                crate::commands::jobs::job_fail(
                     &app_clone,
-                    JOBS_EVENT,
-                    JobEvent {
-                        r#type: "job.failed".to_string(),
-                        job_id: job_id_clone.clone(),
-                        data: Some(json!("no scraper matched this URL")),
-                        ts: now_ms() as i64,
-                    },
+                    &job_id_clone,
+                    "no scraper matched this URL".to_string(),
                 );
             }
             Err(e) => {
-                {
-                    let mut g = tracker.lock();
-                    g.fail(&job_id_clone, e.to_string());
-                }
-                emit_event(
-                    &app_clone,
-                    JOBS_EVENT,
-                    JobEvent {
-                        r#type: "job.failed".to_string(),
-                        job_id: job_id_clone.clone(),
-                        data: Some(json!(e.to_string())),
-                        ts: now_ms() as i64,
-                    },
-                );
+                crate::commands::jobs::job_fail(&app_clone, &job_id_clone, e.to_string());
             }
         }
     });

--- a/apps/tauri/src-tauri/src/jobs/mod.rs
+++ b/apps/tauri/src-tauri/src/jobs/mod.rs
@@ -3,6 +3,13 @@
 /// Records dispatched jobs and their status both in memory (for fast lookups)
 /// and in SQLite (for crash recovery). On startup, incomplete jobs from the
 /// last session are loaded and surfaced as `failed` so the UI can show them.
+///
+/// The record shape mirrors the shared `JobRecord` (packages/shared/src/types)
+/// 1:1 in camelCase: id, kind, status, progress, payload, result, error,
+/// retries, maxRetries, createdAt, updatedAt, startedAt, finishedAt. The tracker
+/// is L1 (pure data + disk, AppHandle-free); Tauri-event emission for each
+/// transition lives in the L3 wrapper (`commands::jobs`), so this module never
+/// reaches the shell.
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -17,30 +24,38 @@ use crate::db::{run_migrations, Migration};
 #[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
 pub enum JobStatus {
-    Pending,
+    Queued,
     Running,
+    Streaming,
     Completed,
     Failed,
     Cancelled,
+    Retrying,
 }
 
 impl JobStatus {
     fn as_str(&self) -> &'static str {
         match self {
-            JobStatus::Pending => "pending",
+            JobStatus::Queued => "queued",
             JobStatus::Running => "running",
+            JobStatus::Streaming => "streaming",
             JobStatus::Completed => "completed",
             JobStatus::Failed => "failed",
             JobStatus::Cancelled => "cancelled",
+            JobStatus::Retrying => "retrying",
         }
     }
 
     fn from_str(s: &str) -> Self {
         match s {
+            // `pending` is a legacy alias from before the status model expanded.
+            "queued" | "pending" => JobStatus::Queued,
+            "running" => JobStatus::Running,
+            "streaming" => JobStatus::Streaming,
             "completed" => JobStatus::Completed,
             "failed" => JobStatus::Failed,
             "cancelled" => JobStatus::Cancelled,
-            "pending" => JobStatus::Pending,
+            "retrying" => JobStatus::Retrying,
             _ => JobStatus::Failed, // treat unknown/interrupted as failed
         }
     }
@@ -54,9 +69,17 @@ pub struct JobRecord {
     pub status: JobStatus,
     /// 0.0 – 1.0
     pub progress: f64,
-    pub created_at: u64,
+    /// The original dispatch payload (kept for retry re-dispatch). `Null` when
+    /// the dispatcher didn't record one.
+    pub payload: Value,
     pub result: Option<Value>,
     pub error: Option<String>,
+    pub retries: u32,
+    pub max_retries: u32,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub started_at: Option<u64>,
+    pub finished_at: Option<u64>,
 }
 
 #[derive(Default)]
@@ -66,11 +89,12 @@ pub struct JobTracker {
 }
 
 impl JobTracker {
-    const MIGRATIONS: &'static [Migration] = &[Migration {
-        name: "create_jobs",
-        up: |conn| {
-            conn.execute_batch(
-                "CREATE TABLE IF NOT EXISTS jobs (
+    const MIGRATIONS: &'static [Migration] = &[
+        Migration {
+            name: "create_jobs",
+            up: |conn| {
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS jobs (
                         id         TEXT PRIMARY KEY,
                         kind       TEXT NOT NULL,
                         status     TEXT NOT NULL,
@@ -80,9 +104,26 @@ impl JobTracker {
                         error      TEXT
                     );
                     CREATE INDEX IF NOT EXISTS idx_jobs_created ON jobs(created_at DESC);",
-            )
+                )
+            },
         },
-    }];
+        // Appended for the unified 12-field JobRecord. SQLite ADD COLUMN can't
+        // re-run, but the user_version runner gates each migration to exactly
+        // once. `create_jobs` above is never edited.
+        Migration {
+            name: "jobs_add_lifecycle_fields",
+            up: |conn| {
+                conn.execute_batch(
+                    "ALTER TABLE jobs ADD COLUMN payload TEXT NOT NULL DEFAULT '{}';
+                     ALTER TABLE jobs ADD COLUMN retries INTEGER NOT NULL DEFAULT 0;
+                     ALTER TABLE jobs ADD COLUMN max_retries INTEGER NOT NULL DEFAULT 0;
+                     ALTER TABLE jobs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0;
+                     ALTER TABLE jobs ADD COLUMN started_at INTEGER;
+                     ALTER TABLE jobs ADD COLUMN finished_at INTEGER;",
+                )
+            },
+        },
+    ];
 
     /// Open a persistent job tracker backed by SQLite in `data_dir`.
     /// Incomplete jobs from the previous session are loaded as `failed`.
@@ -100,20 +141,30 @@ impl JobTracker {
             return Self::default();
         }
 
-        // Load recent jobs (last 24 h) and mark any interrupted running jobs as failed.
+        // Load recent jobs (last 24 h) and mark any interrupted in-flight jobs as
+        // failed (records the failure time too).
         let cutoff = now_ms().saturating_sub(24 * 60 * 60 * 1_000);
+        let now = now_ms();
         let _ = conn.execute(
-            "UPDATE jobs SET status = 'failed', error = 'Interrupted by app restart'
-             WHERE status IN ('running', 'pending') AND created_at > ?1",
-            params![cutoff as i64],
+            "UPDATE jobs SET status = 'failed', error = 'Interrupted by app restart',
+                 updated_at = ?1, finished_at = ?1
+             WHERE status IN ('running', 'pending', 'queued', 'streaming', 'retrying')
+               AND created_at > ?2",
+            params![now as i64, cutoff as i64],
         );
 
         let mut jobs = HashMap::new();
         if let Ok(mut stmt) = conn.prepare(
-            "SELECT id, kind, status, progress, created_at, result, error
+            "SELECT id, kind, status, progress, payload, result, error, retries,
+                    max_retries, created_at, updated_at, started_at, finished_at
              FROM jobs WHERE created_at > ?1 ORDER BY created_at DESC",
         ) {
             let rows = stmt.query_map(params![cutoff as i64], |row| {
+                let payload_str: Option<String> = row.get(4)?;
+                let payload = payload_str
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or(Value::Null);
                 let result_str: Option<String> = row.get(5)?;
                 let result = result_str
                     .as_deref()
@@ -123,9 +174,15 @@ impl JobTracker {
                     kind: row.get(1)?,
                     status: JobStatus::from_str(&row.get::<_, String>(2)?),
                     progress: row.get(3)?,
-                    created_at: row.get::<_, i64>(4)? as u64,
+                    payload,
                     result,
                     error: row.get(6)?,
+                    retries: row.get::<_, i64>(7)? as u32,
+                    max_retries: row.get::<_, i64>(8)? as u32,
+                    created_at: row.get::<_, i64>(9)? as u64,
+                    updated_at: row.get::<_, i64>(10)? as u64,
+                    started_at: row.get::<_, Option<i64>>(11)?.map(|v| v as u64),
+                    finished_at: row.get::<_, Option<i64>>(12)?.map(|v| v as u64),
                 })
             });
             if let Ok(rows) = rows {
@@ -144,14 +201,21 @@ impl JobTracker {
 
     /// Register a new job as running.
     pub fn start(&mut self, id: &str, kind: &str) {
+        let now = now_ms();
         let record = JobRecord {
             id: id.to_string(),
             kind: kind.to_string(),
             status: JobStatus::Running,
             progress: 0.0,
-            created_at: now_ms(),
+            payload: Value::Null,
             result: None,
             error: None,
+            retries: 0,
+            max_retries: 0,
+            created_at: now,
+            updated_at: now,
+            started_at: Some(now),
+            finished_at: None,
         };
         self.persist_upsert(&record);
         self.jobs.insert(id.to_string(), record);
@@ -167,55 +231,60 @@ impl JobTracker {
     }
 
     pub fn update_progress(&mut self, id: &str, p: f64) {
-        if let Some(job) = self.jobs.get_mut(id) {
-            job.progress = p;
-            if let Some(db) = &self.db {
-                let _ = db.execute(
-                    "UPDATE jobs SET progress = ?1 WHERE id = ?2",
-                    params![p, id],
-                );
+        let record = match self.jobs.get_mut(id) {
+            Some(job) => {
+                job.progress = p;
+                job.updated_at = now_ms();
+                job.clone()
             }
-        }
+            None => return,
+        };
+        self.persist_upsert(&record);
     }
 
     pub fn complete(&mut self, id: &str, result: Value) {
-        if let Some(job) = self.jobs.get_mut(id) {
-            job.status = JobStatus::Completed;
-            job.progress = 1.0;
-            job.result = Some(result.clone());
-            let result_str = serde_json::to_string(&result).ok();
-            if let Some(db) = &self.db {
-                let _ = db.execute(
-                    "UPDATE jobs SET status = 'completed', progress = 1.0, result = ?1 WHERE id = ?2",
-                    params![result_str, id],
-                );
+        let record = match self.jobs.get_mut(id) {
+            Some(job) => {
+                let now = now_ms();
+                job.status = JobStatus::Completed;
+                job.progress = 1.0;
+                job.result = Some(result);
+                job.updated_at = now;
+                job.finished_at = Some(now);
+                job.clone()
             }
-        }
+            None => return,
+        };
+        self.persist_upsert(&record);
     }
 
     pub fn fail(&mut self, id: &str, error: String) {
-        if let Some(job) = self.jobs.get_mut(id) {
-            job.status = JobStatus::Failed;
-            job.error = Some(error.clone());
-            if let Some(db) = &self.db {
-                let _ = db.execute(
-                    "UPDATE jobs SET status = 'failed', error = ?1 WHERE id = ?2",
-                    params![error, id],
-                );
+        let record = match self.jobs.get_mut(id) {
+            Some(job) => {
+                let now = now_ms();
+                job.status = JobStatus::Failed;
+                job.error = Some(error);
+                job.updated_at = now;
+                job.finished_at = Some(now);
+                job.clone()
             }
-        }
+            None => return,
+        };
+        self.persist_upsert(&record);
     }
 
     pub fn cancel(&mut self, id: &str) {
-        if let Some(job) = self.jobs.get_mut(id) {
-            job.status = JobStatus::Cancelled;
-            if let Some(db) = &self.db {
-                let _ = db.execute(
-                    "UPDATE jobs SET status = 'cancelled' WHERE id = ?1",
-                    params![id],
-                );
+        let record = match self.jobs.get_mut(id) {
+            Some(job) => {
+                let now = now_ms();
+                job.status = JobStatus::Cancelled;
+                job.updated_at = now;
+                job.finished_at = Some(now);
+                job.clone()
             }
-        }
+            None => return,
+        };
+        self.persist_upsert(&record);
     }
 
     pub fn list(&self) -> Vec<&JobRecord> {
@@ -230,21 +299,30 @@ impl JobTracker {
 
     fn persist_upsert(&self, record: &JobRecord) {
         if let Some(db) = &self.db {
+            let payload_str = serde_json::to_string(&record.payload).ok();
             let result_str = record
                 .result
                 .as_ref()
                 .and_then(|r| serde_json::to_string(r).ok());
             let _ = db.execute(
-                "INSERT OR REPLACE INTO jobs (id, kind, status, progress, created_at, result, error)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                "INSERT OR REPLACE INTO jobs
+                    (id, kind, status, progress, payload, result, error, retries,
+                     max_retries, created_at, updated_at, started_at, finished_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
                 params![
                     record.id,
                     record.kind,
                     record.status.as_str(),
                     record.progress,
-                    record.created_at as i64,
+                    payload_str,
                     result_str,
                     record.error,
+                    record.retries as i64,
+                    record.max_retries as i64,
+                    record.created_at as i64,
+                    record.updated_at as i64,
+                    record.started_at.map(|v| v as i64),
+                    record.finished_at.map(|v| v as i64),
                 ],
             );
         }

--- a/apps/tauri/src-tauri/src/jobs/test.rs
+++ b/apps/tauri/src-tauri/src/jobs/test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use serde_json::json;
+use serde_json::{json, Value};
 
 #[test]
 fn test_start_job() {
@@ -86,4 +86,56 @@ fn test_multiple_jobs() {
     assert_eq!(tracker.get("job-1").unwrap().status, JobStatus::Running);
     assert_eq!(tracker.get("job-2").unwrap().status, JobStatus::Completed);
     assert_eq!(tracker.get("job-3").unwrap().status, JobStatus::Failed);
+}
+
+#[test]
+fn test_lifecycle_timestamps() {
+    let mut tracker = JobTracker::default();
+    tracker.start("j", "ai.generate");
+    let j = tracker.get("j").unwrap();
+    assert!(j.started_at.is_some());
+    assert!(j.finished_at.is_none());
+    assert_eq!(j.retries, 0);
+    assert_eq!(j.payload, Value::Null);
+    let at_start = j.updated_at;
+
+    tracker.complete("j", json!({ "ok": true }));
+    let j = tracker.get("j").unwrap();
+    assert_eq!(j.status, JobStatus::Completed);
+    assert!(j.finished_at.is_some());
+    assert!(j.updated_at >= at_start);
+}
+
+#[test]
+fn test_persist_reload_migration_roundtrip() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    {
+        let mut tracker = JobTracker::open(dir.path());
+        tracker.start("j-1", "scrape.board");
+        tracker.complete("j-1", json!({ "count": 3 }));
+    }
+    // Reopen: the appended-migration columns (payload/retries/finished_at/…) must
+    // round-trip, and a completed job stays completed (not flagged interrupted).
+    let reopened = JobTracker::open(dir.path());
+    let j = reopened.get("j-1").expect("job survives reload");
+    assert_eq!(j.kind, "scrape.board");
+    assert_eq!(j.status, JobStatus::Completed);
+    assert_eq!(j.result, Some(json!({ "count": 3 })));
+    assert!(j.finished_at.is_some());
+    assert_eq!(j.retries, 0);
+}
+
+#[test]
+fn test_interrupted_running_job_marked_failed_on_reload() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    {
+        let mut tracker = JobTracker::open(dir.path());
+        tracker.start("j-run", "ai.generate"); // left running (simulated crash)
+    }
+    let reopened = JobTracker::open(dir.path());
+    let j = reopened.get("j-run").expect("job survives reload");
+    assert_eq!(j.status, JobStatus::Failed);
+    assert!(j.finished_at.is_some());
 }


### PR DESCRIPTION
## Jobs collapse — unified record, appended migration, footer tracks every job kind

The final phase of the event-system work. Unifies the job model and makes the footer activity monitor reflect **every** job of **every** kind.

### What changed

**1. Unified job model + SQLite migration** (`refactor:`)
- The Rust `JobRecord` now matches the shared `JobRecord` (packages/shared/src/types) field-for-field: adds `payload`, `retries`, `maxRetries`, `updatedAt`, `startedAt`, `finishedAt`. `JobStatus` expands to the shared 7 variants (`queued`/`running`/`streaming`/`completed`/`failed`/`cancelled`/`retrying`; `pending` kept as a legacy `from_str` alias). `jobs_list` / `jobs_get` now return the canonical record.
- An **appended** `jobs_add_lifecycle_fields` migration (the `user_version` runner applies it exactly once; `create_jobs` is never edited). `open()`/persist/load stay in sync with the new columns; crash recovery flags every in-flight status as failed.
- New **L3 emit wrapper** in `commands/jobs.rs` (`job_start`/`job_progress`/`job_complete`/`job_fail`/`job_cancel`): the single mutator boundary that runs the L1 transition then emits the matching typed `jobs:event`. The L1 `JobTracker` stays AppHandle-free (R2 holds).

**2. Every transition emits** (`feat:`)
- Repoint all ~31 `tracker.lock().{start,update_progress,complete,fail,cancel}` call sites (across `commands/{ai,pipeline,autopilot,scrape}` + the AI providers anthropic/openai/gemini/ollama/cli_agent) to the wrapper. So `jobs:event` now fires for **every** kind — `ai.generate`, `ai.pull_model`, `ai.reembed`, `pipeline.generate`, `autopilot.run`, `scrape.board`, `scrape.url` — and **`job.started`** fires on dispatch. Previously only a couple of paths emitted ad-hoc, so the footer was silent for `ai.generate` / `autopilot.run`.
- Removed the now-redundant ad-hoc `job.completed`/`job.failed` emits (data preserved byte-for-byte by the wrapper); the per-item `job.stream` data streams are kept. Scrape progress now also rides `jobs:event` via `job_progress`.

### Behavior change
The footer/StatusBar now populates for previously-silent kinds, and `job.started` is a new event. `jobs_list` gains the unified fields. The renderer needed **no changes** — its existing `useJobs`/StatusBar handle the richer record and the extra events (renderer suite stays green).

### Verification
- `cargo build` + `clippy --all-targets --all-features -- -D warnings` + `cargo test --all-features` — **1027 passed**, incl. `--test architecture` (`jobs` stays L1, `events` L3, R2 green) and new jobs tests: lifecycle timestamps, a **migration persist/reload round-trip**, crash-recovery.
- `pnpm gen:ipc:check` ✓ · `pnpm --filter @ajh/shared test` ✓ · renderer `typecheck` 10/10 · `vitest` **773 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Centralized job lifecycle event management ensures consistent tracking across all operations (AI generation, model pulling, autopilot, pipeline, scraping).
  * Enhanced job state tracking with expanded status types and comprehensive lifecycle timestamps.
  * Standardized progress reporting and job completion/failure handling with consistent event payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->