### PR TITLE
feat: unify input field shadows and add clearable inputs

### DIFF
--- a/apps/tauri/src-tauri/src/model/rich.rs
+++ b/apps/tauri/src-tauri/src/model/rich.rs
@@ -17,6 +17,14 @@ use crate::export::parser::parse_inline_md;
 static FULL_URL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"https?://[^\s|·•,<>"']+"#).unwrap());
 
+/// A scheme-less URL written out in body text: a domain WITH a path
+/// (`github.com/user/repo`). Linked verbatim — the full text stays visible and an
+/// `https://` scheme is added only for the hyperlink target — so résumé project
+/// links render the same in the export as in the WYSIWYG editor. A bare domain
+/// with no path, or a short-TLD token like `CI/CD`, is intentionally not matched.
+static BARE_DOMAIN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)\b(?:[a-z0-9-]+\.)+[a-z]{2,}/[^\s|·•,<>"']+"#).unwrap());
+
 static EMAIL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}").unwrap());
 
@@ -151,6 +159,22 @@ pub fn split_urls(text: &str) -> Vec<Span> {
                 end: m.start() + url.len(),
                 label: url_label(url),
                 url: url.to_string(),
+            });
+        }
+    }
+
+    // Scheme-less project URLs (any domain): linked verbatim, scheme added only
+    // for the href. Runs after FULL_URL_RE so a scheme-full URL isn't matched twice.
+    for m in BARE_DOMAIN_RE.find_iter(text) {
+        let url = m.as_str().trim_end_matches(['.', ',', ')']);
+        let end = m.start() + url.len();
+        let overlaps = matches.iter().any(|u| m.start() < u.end && end > u.start);
+        if !overlaps {
+            matches.push(Match {
+                start: m.start(),
+                end,
+                label: url.to_string(),
+                url: format!("https://{url}"),
             });
         }
     }
@@ -356,6 +380,55 @@ mod tests {
                 Some("https://janedoe.dev".to_string())
             )]
         );
+    }
+
+    #[test]
+    fn split_urls_links_scheme_less_project_urls_for_any_domain() {
+        for (text, label, href) in [
+            (
+                "github.com/me/repo",
+                "github.com/me/repo",
+                "https://github.com/me/repo",
+            ),
+            (
+                "gitlab.com/me/proj",
+                "gitlab.com/me/proj",
+                "https://gitlab.com/me/proj",
+            ),
+            (
+                "behance.net/me/case",
+                "behance.net/me/case",
+                "https://behance.net/me/case",
+            ),
+            (
+                "my-site.dev/work/x",
+                "my-site.dev/work/x",
+                "https://my-site.dev/work/x",
+            ),
+        ] {
+            let spans = split_urls(text);
+            assert_eq!(spans.len(), 1, "expected one span for {text}");
+            match &spans[0] {
+                Span::Link { label: l, url: u } => {
+                    assert_eq!(l.as_str(), label, "label for {text}");
+                    assert_eq!(u.as_str(), href, "href for {text}");
+                }
+                _ => panic!("expected a link span for {text}"),
+            }
+        }
+    }
+
+    #[test]
+    fn split_urls_ignores_bare_domain_without_path_and_short_tld_tokens() {
+        // No path → not a project link; "CI/CD" has no domain dot → not a URL.
+        assert!(matches!(
+            split_urls("github.com").as_slice(),
+            [Span::Text(_)]
+        ));
+        assert!(matches!(
+            split_urls("Agile, CI/CD, TDD").as_slice(),
+            [Span::Text(_)]
+        ));
     }
 
     // ── Link helpers (moved here with their implementation from export::links) ──

--- a/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
@@ -346,6 +346,7 @@ export function EditableOutput({
             spellCheck
             labels={editorLabels}
             linkSuggestions={linkSuggestions}
+            linkResolutions={linkSuggestions}
             onSelectionChange={setHasSelection}
             placeholder={placeholder ?? t('aiGenerate.placeholder')}
             className="h-full w-full"

--- a/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from '@ajh/translations';
 import {
   Button,
+  cn,
   MarkdownMessage,
   RichTextEditor,
   type RichTextEditorHandle,
@@ -285,7 +286,7 @@ export function EditableOutput({
   );
 
   return (
-    <div className={className}>
+    <div className={cn('flex min-h-0 flex-col', className)}>
       <div className="mb-2 flex shrink-0 items-center justify-between gap-2">
         {/* Rewrite trigger — left, only in Edit/Source with a live selection. */}
         <div className="flex items-center">
@@ -333,7 +334,7 @@ export function EditableOutput({
       </div>
 
       {view === 'edit' ? (
-        <div className="relative h-full w-full">
+        <div className="relative flex-1 min-h-0 w-full">
           {/* WYSIWYG edit surface — same canonical `value`/`onChange` as Source.
               Lock with readOnly while a rewrite streams (mirrors the Source path). */}
           <RichTextEditor
@@ -353,7 +354,7 @@ export function EditableOutput({
           {rewriteOverlay}
         </div>
       ) : view === 'source' ? (
-        <div className="relative h-full w-full">
+        <div className="relative flex-1 min-h-0 w-full">
           {/* Source — raw markdown power-user / inspection view (hand-editable). */}
           <TextArea
             ref={textareaRef}
@@ -379,9 +380,9 @@ export function EditableOutput({
         </div>
       ) : previewSlot ? (
         // #24 — caller-supplied Preview (e.g. the real-PDF view) replaces markdown.
-        <div className="h-full w-full overflow-hidden rounded-lg">{previewSlot}</div>
+        <div className="min-h-0 w-full flex-1 overflow-hidden rounded-lg">{previewSlot}</div>
       ) : (
-        <div className="h-full w-full overflow-y-auto rounded-lg">
+        <div className="min-h-0 w-full flex-1 overflow-y-auto rounded-lg">
           {value ? (
             <MarkdownMessage content={value} className="text-[12px] text-foreground/80" />
           ) : (

--- a/apps/tauri/src/renderer/features/applications/components/ApplicationsPage/index.tsx
+++ b/apps/tauri/src/renderer/features/applications/components/ApplicationsPage/index.tsx
@@ -84,16 +84,16 @@ export function ApplicationsPage() {
 
   const actions = (
     <div className="flex items-center gap-2">
-      <div className="flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-1.5 transition-colors focus-within:border-brand/35">
-        <Search size={12} className="shrink-0 text-foreground/40" />
-        <Input
-          value={filter}
-          onChange={(e) => setApplications({ filter: e.target.value })}
-          placeholder={t('applications.filterPlaceholder')}
-          className="w-40 bg-transparent text-xs text-foreground outline-none placeholder:text-foreground/25 border-none p-0 rounded-none"
-          variant="default"
-        />
-      </div>
+      <Input
+        prefix={<Search size={12} />}
+        value={filter}
+        onChange={(e) => setApplications({ filter: e.target.value })}
+        placeholder={t('applications.filterPlaceholder')}
+        className="w-40 text-xs text-foreground/75 placeholder:text-foreground/30"
+        variant="default"
+        wrapperClassName="h-7"
+        allowClear
+      />
       <Button size="sm" variant="glass" onClick={() => setTrackOpen(true)}>
         <Plus size={12} />
         {t('applications.trackButton')}

--- a/apps/tauri/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -190,17 +190,18 @@ export function JobsPage() {
                     {t('jobs.clear')}
                   </Button>
                 )}
-                <div className="flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-1.5 transition-colors focus-within:border-brand/35">
-                  <ListFilter size={12} className="shrink-0 text-foreground/40" />
-                  <Input
-                    value={filter}
-                    onChange={(e) => setFilter(e.target.value)}
-                    placeholder={t('jobs.searchPlaceholder')}
-                    className="w-48 bg-transparent text-xs text-foreground outline-none placeholder:text-foreground/25 border-none p-0 rounded-none"
-                    variant="default"
-                  />
-                </div>
+                <Input
+                  prefix={<ListFilter size={12} />}
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value)}
+                  placeholder={t('jobs.searchPlaceholder')}
+                  className="w-48 text-xs text-foreground/75 placeholder:text-foreground/30"
+                  variant="default"
+                  wrapperClassName="h-7"
+                  allowClear
+                />
                 <Dropdown
+                  size="sm"
                   options={[
                     { value: 'newest', label: t('jobs.sortNewest') },
                     { value: 'oldest', label: t('jobs.sortOldest') },

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/index.tsx
@@ -86,6 +86,7 @@ export function ScrapeForm({
                 onChange={(e) => onFormChange({ query: e.target.value })}
                 placeholder={t('jobs.queryPlaceholder')}
                 disabled={scraping}
+                allowClear
                 className="w-full bg-white/[0.03] text-sm text-foreground placeholder:text-foreground/25 disabled:opacity-50"
               />
             </div>

--- a/apps/tauri/vite.config.ts
+++ b/apps/tauri/vite.config.ts
@@ -9,7 +9,17 @@ const TAURI_DEV_PORT = 5174;
 
 export default defineConfig({
   resolve: {
-    alias: { '@': path.resolve(__dirname, 'src/renderer') },
+    alias: [
+      // Resolve the design system to its SOURCE in dev so packages/ui edits
+      // hot-reload — otherwise the renderer loads the prebuilt dist (exports
+      // "." → ./dist/index.js) and src changes are invisible until a rebuild.
+      // Exact-match regex so `@ajh/ui/css` still resolves to the package.
+      {
+        find: /^@ajh\/ui$/,
+        replacement: path.resolve(__dirname, '../../packages/ui/src/index.ts'),
+      },
+      { find: '@', replacement: path.resolve(__dirname, 'src/renderer') },
+    ],
   },
   plugins: [
     TanStackRouterVite({

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -254,10 +254,12 @@ Props:
 
 Source: `packages/ui/src/components/RichTextEditor/`; exported from `@ajh/ui` at `packages/ui/src/index.ts`.
 
-#### `SelectDropdown`
+#### `Dropdown`
+
+The single canonical select — the former `SelectDropdown` and `Dropdown` were merged into one. Keyboard navigation, drop-up flip, a leading `icon`, auto-search at ≥8 options, and optional `options[].section` group headers + `options[].meta` right-aligned text.
 
 ```typescript
-<SelectDropdown
+<Dropdown
   options={[{ value: "en", label: "English" }, { value: "de", label: "Deutsch" }]}
   value={locale}
   onChange={setLocale}
@@ -635,7 +637,7 @@ These are enforced in CI (`pnpm lint:strict`) by [ESLint][eslint]:
 | ------------------------------------ | -------------------------------------------------------------------------------- |
 | No `[#RRGGBB]` in className          | Hardcoded hex colors                                                             |
 | No `<button>` raw element            | Missing Button primitive (use `variant="unstyled"` for custom surfaces)          |
-| No `<select>` raw element            | Missing SelectDropdown primitive                                                 |
+| No `<select>` raw element            | Missing Dropdown primitive                                                       |
 | No `<textarea>` raw element          | Missing TextArea primitive                                                       |
 | No `<input>` raw element             | Missing Input primitive — `type=range\|file\|checkbox\|radio\|hidden` are exempt |
 | No inline `{duration, ease}` objects | Missing motion token (use `transition.*`, `withDelay()`)                         |

--- a/docs/knowledge/builder-form-pattern.md
+++ b/docs/knowledge/builder-form-pattern.md
@@ -11,7 +11,7 @@ React Component (BuilderWizard)
     ↓
 useForm (RHF) → form state (live editing)
     ↓
-Controller → @ajh/ui primitives (Button, Input, SelectDropdown, etc.)
+Controller → @ajh/ui primitives (Button, Input, Dropdown, etc.)
     ↓
 useFieldArray (FieldArrayList) → repeatable sections
     ↓
@@ -72,9 +72,9 @@ const onBuild = async () => {
 ## RHF patterns
 
 - **useFieldArray** for repeatable sections (experience, education, extra links). Call `remove(index)` to delete; note the **stale-read hazard** (see lessons).
-- **Controller** wraps custom @ajh/ui controls (Input, SelectDropdown, etc.) since they don't accept `ref`.
+- **Controller** wraps custom @ajh/ui controls (Input, Dropdown, etc.) since they don't accept `ref`.
 - **@ajh/ui LocationInput** for experience/education location (custom control, Controller-bound).
-- **MonthYearField** — two SelectDropdown fields ("MMM", "YYYY") or "Present" checkbox; rendered as inline controls.
+- **MonthYearField** — two Dropdown fields ("MMM", "YYYY") or "Present" checkbox; rendered as inline controls.
 - **Form-level validation**: `formState.isValid` gates the Build button until all required fields pass schema validation.
 
 ## ContactProfileForm (isolated)

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -110,7 +110,7 @@ export function Alert({
         background: cfg.bg,
         border: `1px solid ${cfg.border}`,
         borderRadius: banner ? 0 : '10px',
-        color: 'rgba(255,255,255,0.88)',
+        color: 'color-mix(in srgb, var(--color-foreground) 80%, transparent)',
         fontSize: '13px',
         lineHeight: 1.45,
         ...style,
@@ -132,12 +132,21 @@ export function Alert({
 
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
-          style={{ fontWeight: description != null ? 600 : 500, color: 'rgba(255,255,255,0.92)' }}
+          style={{
+            fontWeight: description != null ? 600 : 500,
+            color: 'color-mix(in srgb, var(--color-foreground) 90%, transparent)',
+          }}
         >
           {message}
         </div>
         {description != null && (
-          <div style={{ marginTop: '3px', fontSize: '12px', color: 'rgba(255,255,255,0.62)' }}>
+          <div
+            style={{
+              marginTop: '3px',
+              fontSize: '12px',
+              color: 'color-mix(in srgb, var(--color-foreground) 60%, transparent)',
+            }}
+          >
             {description}
           </div>
         )}
@@ -159,11 +168,17 @@ export function Alert({
             background: 'none',
             border: 'none',
             cursor: 'pointer',
-            color: 'rgba(255,255,255,0.45)',
+            color: 'color-mix(in srgb, var(--color-foreground) 45%, transparent)',
             transition: 'color 150ms',
           }}
-          onMouseEnter={(e) => (e.currentTarget.style.color = 'rgba(255,255,255,0.85)')}
-          onMouseLeave={(e) => (e.currentTarget.style.color = 'rgba(255,255,255,0.45)')}
+          onMouseEnter={(e) =>
+            (e.currentTarget.style.color =
+              'color-mix(in srgb, var(--color-foreground) 85%, transparent)')
+          }
+          onMouseLeave={(e) =>
+            (e.currentTarget.style.color =
+              'color-mix(in srgb, var(--color-foreground) 45%, transparent)')
+          }
         >
           {closeIcon}
         </button>

--- a/packages/ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.tsx
@@ -34,6 +34,8 @@ export interface DropdownProps {
   searchable?: boolean;
   /** Tailwind max-height class applied to the options list. Defaults to 'max-h-56'. */
   listClassName?: string;
+  /** Trigger height — 'sm' matches Button size="sm" (h-7); 'md' is the default (h-9). */
+  size?: 'sm' | 'md';
 }
 
 export function Dropdown({
@@ -46,6 +48,7 @@ export function Dropdown({
   id: idProp,
   searchable,
   listClassName,
+  size = 'md',
 }: DropdownProps) {
   const generatedId = useId();
   const id = idProp ?? generatedId;
@@ -165,13 +168,14 @@ export function Dropdown({
         }}
         onKeyDown={handleKeyDown}
         className={cn(
-          'flex h-9 w-full items-center justify-between gap-2 rounded-lg px-3 text-xs transition-all duration-150',
-          'border border-white/[0.06] bg-white/[0.03]',
+          'flex w-full items-center justify-between gap-2 rounded-lg text-xs transition-all duration-150',
+          size === 'sm' ? 'h-7 px-2.5' : 'h-9 px-3',
+          'border border-[var(--border-soft)] bg-[rgb(var(--glass-rgb)/0.08)] shadow-sm',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent',
           'disabled:cursor-not-allowed disabled:opacity-40',
           open
-            ? 'border-brand/35 bg-white/[0.05] text-foreground/90'
-            : 'text-foreground/70 hover:border-white/10 hover:bg-white/[0.05] hover:text-foreground/90'
+            ? 'border-brand/35 bg-[rgb(var(--glass-rgb)/0.12)] text-foreground/90'
+            : 'text-foreground/75 hover:border-[var(--border-mid)] hover:bg-[rgb(var(--glass-rgb)/0.12)] hover:text-foreground/90'
         )}
       >
         <span className="flex min-w-0 items-center gap-2">

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -1,30 +1,149 @@
-import { forwardRef, type InputHTMLAttributes } from 'react';
+import { X } from 'lucide-react';
+import { forwardRef, type InputHTMLAttributes, type ReactNode, useRef } from 'react';
 
 import { cn } from '../../lib/cn';
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'prefix'> {
   variant?: 'default' | 'glass' | 'unstyled';
+  /**
+   * Icon/element rendered before the input text. When present, a wrapper div
+   * owns the border and focus ring — the inner input loses its own chrome.
+   */
+  prefix?: ReactNode;
+  /**
+   * Icon/element rendered after the input text. Same wrapper behaviour as prefix.
+   */
+  suffix?: ReactNode;
+  /**
+   * Show a clear (×) button while the field holds a value (antd `allowClear`).
+   * Clearing dispatches a native input event so the bound `onChange` fires with
+   * an empty string — assumes a controlled `value`.
+   */
+  allowClear?: boolean;
+  /** Extra className merged into the wrapper div (only active when prefix or suffix is set). */
+  wrapperClassName?: string;
+}
+
+function ClearButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-label="Clear"
+      tabIndex={-1}
+      // Keep focus on the input — blur-before-click would hide the button first.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className="flex shrink-0 items-center justify-center rounded-full p-0.5 text-foreground/30 transition-colors hover:text-foreground/70"
+    >
+      <X size={12} />
+    </button>
+  );
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, variant = 'glass', type = 'text', ...props }, ref) => {
-    // `unstyled` is an escape hatch for inline/embedded fields (e.g. a borderless
-    // input sitting inside a card row) that supply their own appearance via
-    // className. It still routes through this primitive for consistency.
+  (
+    {
+      className,
+      variant = 'glass',
+      type = 'text',
+      prefix,
+      suffix,
+      allowClear,
+      wrapperClassName,
+      ...props
+    },
+    ref
+  ) => {
     const unstyled = variant === 'unstyled';
-    return (
+    const innerRef = useRef<HTMLInputElement | null>(null);
+    const setRefs = (node: HTMLInputElement | null) => {
+      innerRef.current = node;
+      if (typeof ref === 'function') ref(node);
+      else if (ref) ref.current = node;
+    };
+
+    // Clear by setting the native value + dispatching `input`, so React's
+    // onChange runs and a controlled parent receives ''.
+    const clear = () => {
+      const el = innerRef.current;
+      if (!el) return;
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      setter?.call(el, '');
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.focus();
+    };
+
+    const showClear =
+      allowClear === true && !props.disabled && String(props.value ?? '').length > 0;
+
+    // Wrapped mode: prefix/suffix sit inside a styled container; the inner
+    // <input> strips its own border/outline so the ring belongs to the wrapper.
+    if (prefix !== undefined || suffix !== undefined) {
+      return (
+        <div
+          className={cn(
+            'flex items-center gap-2 rounded-lg px-2.5 transition-shadow duration-150',
+            !unstyled &&
+              variant !== 'glass' && [
+                'border border-[var(--border-soft)] bg-[rgb(var(--glass-rgb)/0.08)] shadow-sm',
+              ],
+            !unstyled && variant === 'glass' && 'glass shadow-sm',
+            // Focus ring on the wrapper, not the input.
+            'focus-within:outline-none focus-within:ring-2 focus-within:ring-brand/50 focus-within:ring-offset-1 focus-within:ring-offset-transparent',
+            wrapperClassName
+          )}
+        >
+          {prefix !== undefined && <span className="shrink-0 text-foreground/40">{prefix}</span>}
+          <input
+            ref={setRefs}
+            type={type}
+            className={cn(
+              'min-w-0 flex-1 bg-transparent text-sm text-foreground placeholder:text-foreground/30',
+              'border-none p-0 focus:outline-none',
+              className
+            )}
+            // Tailwind v4 unlayered :focus-visible beats layered focus: classes →
+            // inline style is the only reliable override for the default UA ring.
+            style={{ outline: 'none' }}
+            {...props}
+          />
+          {showClear && <ClearButton onClick={clear} />}
+          {suffix !== undefined && <span className="shrink-0 text-foreground/40">{suffix}</span>}
+        </div>
+      );
+    }
+
+    // Bare mode.
+    const input = (
       <input
-        ref={ref}
+        ref={setRefs}
         type={type}
         className={cn(
           !unstyled &&
-            'input-field rounded-lg px-3 py-2 text-sm text-foreground placeholder:text-foreground/30',
-          variant === 'default' && 'bg-white/5',
-          variant === 'glass' && 'glass-dropdown',
+            'input-field rounded-lg px-3 py-2 text-sm text-foreground placeholder:text-foreground/30 transition-shadow duration-150',
+          variant === 'default' && 'bg-white/5 shadow-sm',
+          variant === 'glass' && 'glass shadow-sm',
+          // Reserve room so long text doesn't slide under the clear button.
+          allowClear && 'pr-9',
           className
         )}
         {...props}
       />
+    );
+
+    if (!allowClear) return input;
+
+    // Overlay the clear button on the right so the input keeps its own chrome
+    // and padding (assumes a full-width input — the common case).
+    return (
+      <div className="relative w-full">
+        {input}
+        {showClear && (
+          <span className="absolute right-2.5 top-1/2 -translate-y-1/2">
+            <ClearButton onClick={clear} />
+          </span>
+        )}
+      </div>
     );
   }
 );

--- a/packages/ui/src/components/LocationInput/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput/LocationInput.tsx
@@ -113,10 +113,13 @@ export function LocationInput({
       <Button
         id={id}
         type="button"
+        variant="unstyled"
         disabled={disabled}
         onClick={() => !disabled && setOpen((o) => !o)}
         className={cn(
-          'glass-graphite glass-highlight flex h-9 w-full items-center justify-between gap-2 rounded-xl px-3 text-xs transition-all duration-150',
+          // `unstyled` so the field doesn't inherit the Button base `active:scale`
+          // press shrink — it looks like a text input, not a pressable button.
+          'glass shadow-sm flex h-9 w-full items-center justify-between gap-2 rounded-lg px-3 text-xs transition-shadow duration-150',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50',
           open ? 'border-brand/35' : 'hover:bg-white/[0.02]'
         )}

--- a/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
@@ -10,6 +10,7 @@ import {
 import { type Editor, EditorContent, useEditor } from '@tiptap/react';
 
 import { cn } from '../../lib/cn';
+import { type LinkResolution, setLinkResolutions } from './decorations';
 import { buildEditorExtensions } from './extensions';
 import { docToMarkdown, joinPreserved, markdownToDoc, splitPreserved } from './markdown';
 import { type LinkSuggestion, Toolbar, type ToolbarLabels } from './Toolbar';
@@ -54,6 +55,12 @@ export interface RichTextEditorProps {
    * filters them as the user types and still validates the picked URL on submit.
    */
   linkSuggestions?: LinkSuggestion[];
+  /**
+   * Label→url pairs the editor renders as display-only links (the same links the
+   * export attaches) — supplied by the renderer from the contact/body link maps +
+   * ContactProfile. Decorations only; the canonical markdown is never changed.
+   */
+  linkResolutions?: LinkResolution[];
 }
 
 const ONCHANGE_DEBOUNCE_MS = 200;
@@ -87,6 +94,7 @@ export const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorPro
       labels,
       onSelectionChange,
       linkSuggestions,
+      linkResolutions,
     },
     ref
   ) {
@@ -170,6 +178,14 @@ export const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorPro
     useEffect(() => {
       editor?.setEditable(editable);
     }, [editor, editable]);
+
+    // Push display-only link resolutions into the decoration plugin so plain
+    // contact/body labels + bare URLs render as links (the canonical markdown is
+    // never touched). Re-runs whenever the resolved links change.
+    useEffect(() => {
+      if (!editor) return;
+      setLinkResolutions(editor, linkResolutions ?? []);
+    }, [editor, linkResolutions]);
 
     // Flush any pending debounce on unmount so the last edit is never lost.
     useEffect(() => {

--- a/packages/ui/src/components/RichTextEditor/decorations.test.ts
+++ b/packages/ui/src/components/RichTextEditor/decorations.test.ts
@@ -40,6 +40,27 @@ describe('buildDecorations — links', () => {
   it('ignores labels shorter than two characters', () => {
     expect(decoratedTexts('a b a', [{ label: 'a', url: 'https://x.com' }])).toHaveLength(0);
   });
+
+  it('autolinks a scheme-less project url (domain + path)', () => {
+    expect(decoratedTexts('AI Job Hunter — github.com/me/ai-job-hunter')).toContain(
+      'github.com/me/ai-job-hunter'
+    );
+  });
+
+  it('does not match a bare token like CI/CD as a url', () => {
+    expect(decoratedTexts('Methodologies: Agile, Scrum, CI/CD, TDD')).toHaveLength(0);
+  });
+
+  it('links the project url, not the brand keyword, in a body section', () => {
+    // "GitHub" sits in a body bullet (after a heading), not on the contact line,
+    // so the brand label must NOT be linked — only the project URL is.
+    const texts = decoratedTexts('## PROJECTS\n- AI Job Hunter — github.com/me/repo', [
+      { label: 'GitHub', url: 'https://github.com/me' },
+    ]);
+    expect(texts).not.toContain('GitHub');
+    expect(texts).not.toContain('github');
+    expect(texts).toContain('github.com/me/repo');
+  });
 });
 
 describe('buildDecorations — header region', () => {

--- a/packages/ui/src/components/RichTextEditor/decorations.test.ts
+++ b/packages/ui/src/components/RichTextEditor/decorations.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDecorations, type LinkResolution } from './decorations';
+import { getEditorSchema, markdownToDoc } from './markdown';
+
+/** The text each decoration in the built set covers, for assertion convenience. */
+function decoratedTexts(md: string, resolutions: LinkResolution[] = []): string[] {
+  const schema = getEditorSchema();
+  const doc = markdownToDoc(md, schema);
+  const set = buildDecorations(doc, resolutions);
+  return set.find().map((d) => doc.textBetween(d.from, d.to, '\n', ''));
+}
+
+describe('buildDecorations — links', () => {
+  it('decorates a plain contact label that resolves to a url', () => {
+    const texts = decoratedTexts('Köln | me@x.com | LinkedIn', [
+      { label: 'LinkedIn', url: 'https://linkedin.com/in/x' },
+    ]);
+    expect(texts).toContain('LinkedIn');
+  });
+
+  it('does NOT decorate the label when there is no resolution for it', () => {
+    expect(decoratedTexts('Köln | me@x.com | LinkedIn')).not.toContain('LinkedIn');
+  });
+
+  it('autolinks a bare http(s) url in body text', () => {
+    const texts = decoratedTexts('Project — https://github.com/me/repo');
+    expect(texts).toContain('https://github.com/me/repo');
+  });
+
+  it('never double-links text already inside a real markdown link mark', () => {
+    // The label is already an inline [LinkedIn](url) link → its text carries a
+    // link mark, so the resolution must NOT add a second decoration over it.
+    const texts = decoratedTexts('Köln | [LinkedIn](https://linkedin.com/in/x)', [
+      { label: 'LinkedIn', url: 'https://linkedin.com/in/x' },
+    ]);
+    expect(texts).not.toContain('LinkedIn');
+  });
+
+  it('ignores labels shorter than two characters', () => {
+    expect(decoratedTexts('a b a', [{ label: 'a', url: 'https://x.com' }])).toHaveLength(0);
+  });
+});
+
+describe('buildDecorations — header region', () => {
+  it('tags the paragraphs before the first section heading as the header', () => {
+    const texts = decoratedTexts('Saeed Kolivand\nSenior Developer\n## EXPERIENCE\n- did things');
+    expect(texts.some((t) => t.includes('Saeed Kolivand'))).toBe(true);
+    expect(texts.some((t) => t.includes('Senior Developer'))).toBe(true);
+  });
+
+  it('adds no header decorations when there is no section heading (cover letter)', () => {
+    // No heading → degrade to plain flow (only link decorations, of which there
+    // are none here).
+    expect(decoratedTexts('Dear hiring manager,\n\nI am writing to apply…')).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/RichTextEditor/decorations.ts
+++ b/packages/ui/src/components/RichTextEditor/decorations.ts
@@ -1,0 +1,72 @@
+/**
+ * Display-only ProseMirror decorations for the résumé/cover-letter editor.
+ *
+ * These NEVER touch the document model — they only add CSS classes for the
+ * "document skin" (so the editing surface reads like a rendered résumé) and are
+ * recomputed on every doc change. Because they are decorations, the canonical
+ * markdown the editor serializes is completely unaffected (the byte-exact
+ * round-trip in `markdown.ts` is preserved).
+ *
+ * Header region: the contiguous run of non-empty top-level paragraphs BEFORE the
+ * first section heading is the résumé header (name / role / contact line). They
+ * get centered, and the first (the name) is enlarged. A document with no heading
+ * (e.g. a cover letter) gets no header styling — it degrades to plain paragraph
+ * flow, which is correct since a cover letter has no section structure to anchor.
+ */
+import type { Node as PMNode } from '@tiptap/pm/model';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+import { Extension } from '@tiptap/react';
+
+const decorationsKey = new PluginKey('rich-text-editor-decorations');
+
+/** Index of the first top-level heading node, or -1 when there is none. */
+function firstHeadingIndex(doc: PMNode): number {
+  let found = -1;
+  doc.forEach((node, _offset, index) => {
+    if (found === -1 && node.type.name === 'heading') found = index;
+  });
+  return found;
+}
+
+function buildDecorations(doc: PMNode): DecorationSet {
+  const headingAt = firstHeadingIndex(doc);
+  // No heading → no header region (cover letters degrade to plain flow).
+  if (headingAt <= 0) return DecorationSet.empty;
+
+  const decorations: Decoration[] = [];
+  let headerSeen = 0;
+  doc.forEach((node, offset, index) => {
+    if (index >= headingAt) return;
+    if (node.type.name !== 'paragraph' || node.textContent.trim() === '') return;
+    // First non-empty header paragraph is the candidate's name (enlarged).
+    const cls = headerSeen === 0 ? 'rt-header rt-name' : 'rt-header';
+    decorations.push(Decoration.node(offset, offset + node.nodeSize, { class: cls }));
+    headerSeen += 1;
+  });
+  return DecorationSet.create(doc, decorations);
+}
+
+/**
+ * Tiptap extension that adds the document-skin decorations. Stateless wrt the
+ * document model — pure presentation, recomputed only when the doc changes.
+ */
+export const EditorDecorations = Extension.create({
+  name: 'editorDecorations',
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: decorationsKey,
+        state: {
+          init: (_config, { doc }) => buildDecorations(doc),
+          apply: (tr, old) => (tr.docChanged ? buildDecorations(tr.doc) : old),
+        },
+        props: {
+          decorations(state) {
+            return decorationsKey.getState(state);
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/packages/ui/src/components/RichTextEditor/decorations.ts
+++ b/packages/ui/src/components/RichTextEditor/decorations.ts
@@ -1,24 +1,55 @@
 /**
  * Display-only ProseMirror decorations for the résumé/cover-letter editor.
  *
- * These NEVER touch the document model — they only add CSS classes for the
- * "document skin" (so the editing surface reads like a rendered résumé) and are
- * recomputed on every doc change. Because they are decorations, the canonical
- * markdown the editor serializes is completely unaffected (the byte-exact
- * round-trip in `markdown.ts` is preserved).
+ * These NEVER touch the document model — they only add CSS classes / inline
+ * `<a>` wrappers for presentation, and are recomputed as the doc (or the link
+ * data) changes. Because they are decorations, the canonical markdown the editor
+ * serializes is completely unaffected (the byte-exact round-trip in `markdown.ts`
+ * is preserved).
  *
- * Header region: the contiguous run of non-empty top-level paragraphs BEFORE the
- * first section heading is the résumé header (name / role / contact line). They
- * get centered, and the first (the name) is enlarged. A document with no heading
- * (e.g. a cover letter) gets no header styling — it degrades to plain paragraph
- * flow, which is correct since a cover letter has no section structure to anchor.
+ * Two kinds:
+ *  - **Header region** — the contiguous run of non-empty top-level paragraphs
+ *    BEFORE the first section heading is the résumé header (name / role / contact
+ *    line). They get centered, and the first (the name) is enlarged. A document
+ *    with no heading (e.g. a cover letter) gets no header styling — it degrades to
+ *    plain paragraph flow.
+ *  - **Links** — plain text that the export pipeline WOULD hyperlink (contact /
+ *    body labels resolved from the reference block + ContactProfile, supplied by
+ *    the renderer) plus bare `http(s)` URLs are rendered as links, so the editor
+ *    shows the same links the preview/export does. Text already inside a real
+ *    `[label](url)` mark is skipped (never double-linked).
  */
 import type { Node as PMNode } from '@tiptap/pm/model';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
-import { Extension } from '@tiptap/react';
+import { type Editor, Extension } from '@tiptap/react';
 
-const decorationsKey = new PluginKey('rich-text-editor-decorations');
+/** A label→url pair the editor should render as a (display-only) link. */
+export interface LinkResolution {
+  label: string;
+  url: string;
+}
+
+interface DecorationState {
+  resolutions: LinkResolution[];
+  set: DecorationSet;
+}
+
+const decorationsKey = new PluginKey<DecorationState>('rich-text-editor-decorations');
+
+/** Push the current link resolutions into the decoration plugin (display-only). */
+export function setLinkResolutions(editor: Editor, resolutions: LinkResolution[]): void {
+  const { view } = editor;
+  view.dispatch(view.state.tr.setMeta(decorationsKey, resolutions));
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const BARE_URL_RE = /\bhttps?:\/\/[^\s)]+/gi;
+
+// ── Header region ───────────────────────────────────────────────────────────
 
 /** Index of the first top-level heading node, or -1 when there is none. */
 function firstHeadingIndex(doc: PMNode): number {
@@ -29,41 +60,93 @@ function firstHeadingIndex(doc: PMNode): number {
   return found;
 }
 
-function buildDecorations(doc: PMNode): DecorationSet {
+function headerDecorations(doc: PMNode): Decoration[] {
   const headingAt = firstHeadingIndex(doc);
   // No heading → no header region (cover letters degrade to plain flow).
-  if (headingAt <= 0) return DecorationSet.empty;
+  if (headingAt <= 0) return [];
 
   const decorations: Decoration[] = [];
   let headerSeen = 0;
   doc.forEach((node, offset, index) => {
     if (index >= headingAt) return;
     if (node.type.name !== 'paragraph' || node.textContent.trim() === '') return;
-    // First non-empty header paragraph is the candidate's name (enlarged).
     const cls = headerSeen === 0 ? 'rt-header rt-name' : 'rt-header';
     decorations.push(Decoration.node(offset, offset + node.nodeSize, { class: cls }));
     headerSeen += 1;
   });
-  return DecorationSet.create(doc, decorations);
+  return decorations;
+}
+
+// ── Links ───────────────────────────────────────────────────────────────────
+
+function linkDecorations(doc: PMNode, resolutions: LinkResolution[]): Decoration[] {
+  // Whole-word, case-insensitive matchers for each resolved label. Labels under
+  // 2 chars are skipped to avoid decorating stray fragments.
+  const matchers = resolutions
+    .map((r) => ({ label: r.label.trim(), url: r.url.trim() }))
+    .filter((r) => r.label.length >= 2 && r.url.length > 0)
+    .map((r) => ({ url: r.url, re: new RegExp(`\\b${escapeRegExp(r.label)}\\b`, 'gi') }));
+
+  const decorations: Decoration[] = [];
+  const linkSpec = (url: string) => ({ nodeName: 'a', class: 'rt-link', 'data-href': url });
+
+  doc.descendants((node, pos) => {
+    if (!node.isText || !node.text) return;
+    // Skip text already carrying a real link mark — never double-link.
+    if (node.marks.some((m) => m.type.name === 'link')) return;
+    const text = node.text;
+
+    for (const { url, re } of matchers) {
+      re.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(text)) !== null) {
+        decorations.push(
+          Decoration.inline(pos + m.index, pos + m.index + m[0].length, linkSpec(url))
+        );
+      }
+    }
+
+    BARE_URL_RE.lastIndex = 0;
+    let u: RegExpExecArray | null;
+    while ((u = BARE_URL_RE.exec(text)) !== null) {
+      decorations.push(
+        Decoration.inline(pos + u.index, pos + u.index + u[0].length, linkSpec(u[0]))
+      );
+    }
+  });
+  return decorations;
+}
+
+/** Build the full decoration set (header + links) for a document. */
+export function buildDecorations(doc: PMNode, resolutions: LinkResolution[]): DecorationSet {
+  const decorations = [...headerDecorations(doc), ...linkDecorations(doc, resolutions)];
+  return decorations.length === 0 ? DecorationSet.empty : DecorationSet.create(doc, decorations);
 }
 
 /**
- * Tiptap extension that adds the document-skin decorations. Stateless wrt the
- * document model — pure presentation, recomputed only when the doc changes.
+ * Tiptap extension adding the document-skin + link decorations. Stateless wrt the
+ * document model — pure presentation. Link resolutions are pushed in by the React
+ * component via `setLinkResolutions` (a transaction meta), so they react to the
+ * current document without re-creating the editor.
  */
 export const EditorDecorations = Extension.create({
   name: 'editorDecorations',
   addProseMirrorPlugins() {
     return [
-      new Plugin({
+      new Plugin<DecorationState>({
         key: decorationsKey,
         state: {
-          init: (_config, { doc }) => buildDecorations(doc),
-          apply: (tr, old) => (tr.docChanged ? buildDecorations(tr.doc) : old),
+          init: (_config, { doc }) => ({ resolutions: [], set: buildDecorations(doc, []) }),
+          apply: (tr, prev) => {
+            const meta = tr.getMeta(decorationsKey) as LinkResolution[] | undefined;
+            if (meta === undefined && !tr.docChanged) return prev;
+            const resolutions = meta ?? prev.resolutions;
+            return { resolutions, set: buildDecorations(tr.doc, resolutions) };
+          },
         },
         props: {
           decorations(state) {
-            return decorationsKey.getState(state);
+            return decorationsKey.getState(state)?.set;
           },
         },
       }),

--- a/packages/ui/src/components/RichTextEditor/decorations.ts
+++ b/packages/ui/src/components/RichTextEditor/decorations.ts
@@ -47,7 +47,10 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-const BARE_URL_RE = /\bhttps?:\/\/[^\s)]+/gi;
+// A URL in body text: a scheme URL, OR a scheme-less domain WITH a path
+// (`github.com/user/repo`) — the form résumé project links usually take. A bare
+// domain with no path, or a token like `CI/CD`, is intentionally NOT matched.
+const URL_RE = /\bhttps?:\/\/[^\s)]+|\b(?:[a-z0-9-]+\.)+[a-z]{2,}\/[^\s)]+/gi;
 
 // ── Header region ───────────────────────────────────────────────────────────
 
@@ -58,6 +61,15 @@ function firstHeadingIndex(doc: PMNode): number {
     if (found === -1 && node.type.name === 'heading') found = index;
   });
   return found;
+}
+
+/** Document position where the first top-level heading starts, or -1 if none. */
+function firstHeadingPos(doc: PMNode): number {
+  let pos = -1;
+  doc.forEach((node, offset) => {
+    if (pos === -1 && node.type.name === 'heading') pos = offset;
+  });
+  return pos;
 }
 
 function headerDecorations(doc: PMNode): Decoration[] {
@@ -80,6 +92,14 @@ function headerDecorations(doc: PMNode): Decoration[] {
 // ── Links ───────────────────────────────────────────────────────────────────
 
 function linkDecorations(doc: PMNode, resolutions: LinkResolution[]): Decoration[] {
+  // Contact-brand labels (LinkedIn, GitHub, Website, …) are linked ONLY inside the
+  // header region — the contact line lives before the first section heading —
+  // mirroring the backend's contact-line gating. This stops a brand keyword from
+  // being linked where it merely appears in body text (e.g. "github" inside a
+  // project URL in a PROJECTS section). Project links are picked up as URLs below.
+  const headingPos = firstHeadingPos(doc);
+  const headerLimit = headingPos === -1 ? Number.POSITIVE_INFINITY : headingPos;
+
   // Whole-word, case-insensitive matchers for each resolved label. Labels under
   // 2 chars are skipped to avoid decorating stray fragments.
   const matchers = resolutions
@@ -96,19 +116,23 @@ function linkDecorations(doc: PMNode, resolutions: LinkResolution[]): Decoration
     if (node.marks.some((m) => m.type.name === 'link')) return;
     const text = node.text;
 
-    for (const { url, re } of matchers) {
-      re.lastIndex = 0;
-      let m: RegExpExecArray | null;
-      while ((m = re.exec(text)) !== null) {
-        decorations.push(
-          Decoration.inline(pos + m.index, pos + m.index + m[0].length, linkSpec(url))
-        );
+    // Brand labels: header region only (gated like the export's contact line).
+    if (pos < headerLimit) {
+      for (const { url, re } of matchers) {
+        re.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(text)) !== null) {
+          decorations.push(
+            Decoration.inline(pos + m.index, pos + m.index + m[0].length, linkSpec(url))
+          );
+        }
       }
     }
 
-    BARE_URL_RE.lastIndex = 0;
+    // URLs (including scheme-less project links): anywhere in the document.
+    URL_RE.lastIndex = 0;
     let u: RegExpExecArray | null;
-    while ((u = BARE_URL_RE.exec(text)) !== null) {
+    while ((u = URL_RE.exec(text)) !== null) {
       decorations.push(
         Decoration.inline(pos + u.index, pos + u.index + u[0].length, linkSpec(u[0]))
       );

--- a/packages/ui/src/components/RichTextEditor/extensions.ts
+++ b/packages/ui/src/components/RichTextEditor/extensions.ts
@@ -1,6 +1,8 @@
 import type { Extensions } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 
+import { EditorDecorations } from './decorations';
+
 /**
  * Allowed link protocols. The editor is export-safe by construction: the only
  * schemes a user (or a paste) can introduce are the three that survive to the
@@ -87,5 +89,8 @@ export function buildEditorExtensions(): Extensions {
         HTMLAttributes: { rel: 'noopener noreferrer nofollow' },
       },
     }),
+    // Display-only "document skin" decorations (header region). Adds no schema
+    // nodes/marks — pure presentation — so the markdown round-trip is unaffected.
+    EditorDecorations,
   ];
 }

--- a/packages/ui/src/components/SetupHint/SetupHint.tsx
+++ b/packages/ui/src/components/SetupHint/SetupHint.tsx
@@ -1,19 +1,12 @@
-import { Info, Loader2, type LucideIcon } from 'lucide-react';
+import { Loader2, type LucideIcon } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import type { ReactNode } from 'react';
 
-import { cn } from '../../lib/cn';
 import { transition } from '../../lib/motion';
+import { Alert } from '../Alert';
+import { Button } from '../Button';
 
 type Tone = 'info' | 'amber';
-
-const TONE: Record<Tone, { box: string; icon: string }> = {
-  info: { box: 'border-blue-400/15 bg-blue-400/5 text-blue-200/75', icon: 'text-blue-400/60' },
-  amber: {
-    box: 'border-amber-400/15 bg-amber-400/5 text-amber-200/80',
-    icon: 'text-amber-400/60',
-  },
-};
 
 export interface SetupHintProps {
   /** Collapses (with animation) when false. Default true. */
@@ -31,8 +24,7 @@ export interface SetupHintProps {
 
 /**
  * Inline "a prerequisite blocks this flow — here's the one-click fix" banner.
- * Generalized from the jobs ScrapeForm auth hint so every blocked flow (no AI
- * provider, disconnected board, …) gets the same nudge + action affordance.
+ * Renders via `Alert` so tone, layout, and accessibility are consistent.
  */
 export function SetupHint({
   show = true,
@@ -40,11 +32,26 @@ export function SetupHint({
   actionLabel,
   onAction,
   pending = false,
-  icon: Icon = Info,
+  icon: IconProp,
   tone = 'info',
   className,
 }: SetupHintProps) {
-  const c = TONE[tone];
+  const alertType = tone === 'amber' ? 'warning' : 'info';
+  const iconNode = IconProp ? <IconProp size={12} /> : undefined;
+
+  const action =
+    actionLabel && onAction ? (
+      <Button
+        type="button"
+        variant="unstyled"
+        disabled={pending}
+        onClick={onAction}
+        className="shrink-0 text-[11px] text-brand-soft underline-offset-2 hover:underline disabled:opacity-50"
+      >
+        {pending ? <Loader2 size={11} className="animate-spin" /> : actionLabel}
+      </Button>
+    ) : undefined;
+
   return (
     <AnimatePresence>
       {show && (
@@ -55,26 +62,15 @@ export function SetupHint({
           transition={transition.fast}
           className="overflow-hidden"
         >
-          <div
-            className={cn(
-              'flex items-center gap-2 rounded-lg border px-3 py-2 text-[11px]',
-              c.box,
-              className
-            )}
-          >
-            <Icon size={12} className={cn('shrink-0', c.icon)} />
-            <span>{message}</span>
-            {actionLabel && onAction && (
-              <button
-                type="button"
-                disabled={pending}
-                onClick={onAction}
-                className="ml-auto shrink-0 text-brand-soft underline-offset-2 hover:underline disabled:opacity-50"
-              >
-                {pending ? <Loader2 size={11} className="animate-spin" /> : actionLabel}
-              </button>
-            )}
-          </div>
+          <Alert
+            type={alertType}
+            message={message}
+            showIcon
+            icon={iconNode}
+            action={action}
+            className={className}
+            style={{ fontSize: '11px', padding: '6px 10px' }}
+          />
         </motion.div>
       )}
     </AnimatePresence>

--- a/packages/ui/src/css/rich-text-editor.css
+++ b/packages/ui/src/css/rich-text-editor.css
@@ -87,6 +87,40 @@
   color: var(--color-brand);
 }
 
+/* ── Document skin ────────────────────────────────────────────────────────────
+   Make the editing surface read like a rendered résumé instead of a raw text
+   blob: a centered readable column, section headings styled as résumé section
+   labels (uppercase + hairline rule), and a centered header block (name / role /
+   contact) tagged by `decorations.ts`. Pure presentation — the canonical markdown
+   the editor serializes is unaffected. */
+.rich-text-editor .ProseMirror {
+  max-width: 44rem;
+  margin-inline: auto;
+}
+.rich-text-editor .ProseMirror h2 {
+  margin-top: 1.25rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--border-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8125rem;
+  color: color-mix(in oklab, var(--color-foreground) 72%, transparent);
+}
+.rich-text-editor .ProseMirror h2:first-child {
+  margin-top: 0;
+}
+/* Header region (top-level blocks before the first section heading). */
+.rich-text-editor .ProseMirror .rt-header {
+  text-align: center;
+}
+.rich-text-editor .ProseMirror .rt-name {
+  margin-bottom: 0.1rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-foreground);
+}
+
 /* Placeholder: an overlay rendered by the component when the document is empty
    (no extra Tiptap extension needed). It sits over the editor and is removed
    from the a11y tree / pointer events so it never blocks typing. */

--- a/packages/ui/src/css/utilities.css
+++ b/packages/ui/src/css/utilities.css
@@ -739,11 +739,12 @@ html[data-text-scale='large'] {
   border-color: var(--border-soft);
 }
 
-/* Two-tone chrome (macOS System Settings): the sidebar sits on the gray canvas
-   tone (lightly translucent) while content cards stay near-opaque white. We
-   override only the sidebar here so the glass elevation ladder stays intact. */
+/* In light mode the sidebar shares the page's canvas tone. The previous two-tone
+   macOS gray read as a mismatched panel against the parchment canvas; using the
+   canvas color makes the sidebar match the rest of the page while its glass border
+   + shadow keep it reading as a panel. */
 [data-color-scheme='light'] .app-sidebar {
-  background: rgb(232 235 242 / 0.72);
+  background: var(--color-background);
 }
 
 /* The main content area is a near-opaque white panel in dark mode (intended),


### PR DESCRIPTION
## Summary
Makes the input/field layer visually consistent and adds an antd-style clearable input. All field primitives now share one subtle `shadow-sm` lift; the glass `Input` drops the heavier `glass-dropdown` `shadow-lg`.

## Changes
- **Unified field shadow** — `shadow-sm` across `Input` (default + glass), `Dropdown` trigger, glass `Button`, and `LocationInput`. Glass `Input` now uses `.glass` (so the `shadow-sm` utility applies) instead of `glass-dropdown`.
- **`allowClear`** on `Input` (antd parity) — shows a clear (×) while the field has a value, clearing via a native input-event dispatch so the bound `onChange` fires with `''`. Wired onto the jobs, applications, and scrape filter/query inputs.
- **Focus-outline transition** — `transition-shadow` so the ring fades in/out.
- **`LocationInput`** — `variant="unstyled"` to drop the `Button` base `active:scale` press-shrink on the field trigger; aligned to the shared field surface.
- **Applications filter** — replaced the hand-rolled wrapper with the `Input` `prefix` API.
- **Dev DX** — alias `@ajh/ui` → its source in the tauri dev `vite.config.ts` so `packages/ui` edits hot-reload instead of needing a `dist` rebuild.
- **Misc design-system** — `Alert` token-based foreground colors; `Dropdown` `size` prop + token shadow; `SetupHint` renders via `Alert`.

## Test plan
- Pre-push gate green: typecheck, lint:strict, 1594 JS tests, cargo check/clippy/tests.
- Manual: clear button appears/clears on filter + scrape inputs; focus ring fades; LocationInput no longer shrinks on click; fields share one shadow in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection and auto-linking of scheme-less project URLs (e.g., `github.com/user/repo`)
  * Introduced clear button functionality for search and input fields
  * Enhanced rich text editor with automatic link resolution and document styling

* **Improvements**
  * Refined search bar UI across pages with integrated icon elements
  * Added size variants to dropdown components
  * Improved color consistency and responsive layouts throughout the app

* **Documentation**
  * Updated design system documentation to reflect component improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->