### PR TITLE
feat: two-tone accent gradients, aurora revival, and chrome-extension publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 <p align="center">
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/releases"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey"></a>
   <a href="https://aijobhunter.app"><img alt="Live site" src="https://img.shields.io/badge/Live-site-e24b4a"></a>
+  <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll"><img alt="Chrome Web Store" src="https://img.shields.io/badge/Chrome%20Web%20Store-available-e24b4a?logo=googlechrome&logoColor=white"></a>
   <a href="SECURITY.md"><img alt="Security policy" src="https://img.shields.io/badge/security-policy-2ea44f"></a>
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/saeedkolivand/ai-job-hunter-app?style=flat&color=f5b301"></a>
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/pulls"><img alt="PRs Welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
@@ -129,6 +130,7 @@ The only outbound calls are to the AI provider **you** configure (and an optiona
 <details>
 <summary><strong>🌐 Browser extension (save jobs one-click)</strong></summary>
 
+- **Now on the Chrome Web Store** — <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Install for Chrome</a>. Firefox (AMO) coming soon.
 - MV3 extension for **Chrome & Firefox** — while browsing any job board, click the extension button to import the job into your saved applications.
 - **Two import modes:** **Import via URL** (extension sends the URL, app fetches + parses), or **Scan page** (extension captures the authenticated DOM, useful for login-walled boards).
 - Fully local — jobs are sent to the desktop app over a **loopback-only WebSocket**, paired with a secret token. Zero remote backend, zero analytics.

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -7,10 +7,11 @@
 <p align="center">
   <a href="https://img.shields.io/badge/MV3-Chrome%20%7C%20Firefox-24C8DB"><img alt="MV3" src="https://img.shields.io/badge/MV3-Chrome%20%7C%20Firefox-24C8DB"></a>
   <a href="https://img.shields.io/badge/loopback-only-2ea44f"><img alt="Loopback only" src="https://img.shields.io/badge/loopback-only-2ea44f"></a>
-  <a href="https://img.shields.io/badge/unpublished-dev-orange"><img alt="Unpublished" src="https://img.shields.io/badge/unpublished-dev-orange"></a>
+  <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll"><img alt="Chrome published" src="https://img.shields.io/badge/Chrome-published-2ea44f?logo=googlechrome&logoColor=white"></a>
+  <a href="https://img.shields.io/badge/Firefox-AMO%20pending-orange?logo=firefox&logoColor=white"><img alt="Firefox AMO pending" src="https://img.shields.io/badge/Firefox-AMO%20pending-orange?logo=firefox&logoColor=white"></a>
 </p>
 
-This is the browser half of the **AI Job Hunter** job-import feature. An MV3 extension (Chrome + Firefox) that captures the job posting on the current tab and sends it to the **desktop app** running on your machine, over a private loopback WebSocket. No account. No remote backend. It is inert unless the desktop app is running and you have paired it.
+This is the browser half of the **AI Job Hunter** job-import feature. An MV3 extension available for **Chrome on the Web Store** ([install](https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll)) and Firefox/AMO (pending). It captures the job posting on the current tab and sends it to the **desktop app** running on your machine, over a private loopback WebSocket. No account. No remote backend. It is inert unless the desktop app is running and you have paired it.
 
 **What it does:** while browsing a job board, click the extension button → choose **Import via URL** (extension sends the job URL, desktop fetches + parses it) or **Scan page** (extension captures the rendered DOM, desktop parses it) → the job appears in your **AI Job Hunter** saved applications, tagged **New**. Tick **"I already applied"** to mark it applied instead.
 
@@ -59,7 +60,7 @@ For **local development**, see the section below — the unpacked extension gets
 
 ## Local Development & Testing
 
-The one non-obvious step is **dev pairing**: a locally-loaded (unpacked) extension gets a random dev id that is NOT in the desktop app's origin allowlist (which only holds publish-time placeholders), so the app refuses to pair with it unless you trust that dev origin via the `AJH_EXTENSION_DEV_ORIGINS` env var. Chrome is the easiest target.
+The one non-obvious step is **dev pairing**: a locally-loaded (unpacked) extension gets a random dev id that is NOT in the desktop app's origin allowlist (which holds the published Chrome id), so the app refuses to pair with it unless you trust that dev origin via the `AJH_EXTENSION_DEV_ORIGINS` env var. Chrome is the easiest target.
 
 1. **Build the extension** (repo root):
 
@@ -236,7 +237,7 @@ On release, the **Release workflow** includes a manual `package-extension` job (
 - Packages them as zips with source-build reproducibility info
 - Uploads artifacts for store submission (when the extension is published)
 
-Release frequency: the extension version tracks the app version via `pnpm sync:version` (currently unpublished, so no store cadence).
+Release frequency: the extension version tracks the app version via `pnpm sync:version` (Chrome is published to the Web Store; Firefox/AMO is pending).
 
 ---
 
@@ -264,7 +265,7 @@ emitted JS stays readable for review.
 The desktop bridge validates `moz-extension://` and `chrome-extension://` origins in the WS handshake (`apps/tauri/src-tauri/src/extension_bridge/auth.rs::is_allowed_origin`). **The origin is not the auth boundary** — the per-frame 256-bit pairing token is; the origin is defense-in-depth.
 
 - **Firefox:** origins are random per-install internal UUIDs (anti-fingerprinting), not the AMO gecko id. The bridge accepts any well-formed UUID shape (8-4-4-4-12 lowercase hex) via `is_extension_uuid`. The gecko id (`job-importer@aijobhunter.app`) never appears in a real `moz-extension://` origin and is intentionally absent from the allowlist.
-- **Chrome:** the bridge holds the stable Chrome Web Store id in `ALLOWED_EXTENSION_IDS[0]` (still a placeholder `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`). The real CWS id is assigned at publish and cannot be forced from the manifest — it must be set in `auth.rs` once published. Until then, a locally-loaded Chrome build is admitted only via the desktop dev-origin override (`AJH_EXTENSION_DEV_ORIGINS`).
+- **Chrome:** the bridge pins the published Chrome Web Store id `oaoekkgkhmgdfnpmfkpphgiikliaicll` in `ALLOWED_EXTENSION_IDS` (in `apps/tauri/src-tauri/src/extension_bridge/auth.rs`). A locally-loaded Chrome build is still admitted only via the dev-origin override (`AJH_EXTENSION_DEV_ORIGINS`).
 
 ---
 

--- a/apps/tauri/src-tauri/src/extension_bridge/auth.rs
+++ b/apps/tauri/src-tauri/src/extension_bridge/auth.rs
@@ -17,14 +17,15 @@
 /// (`job-importer@aijobhunter.app`, in `apps/extension/src/manifest.ts`) never
 /// appears as an origin and is intentionally absent from this list.
 ///
-/// **TODO(bridge): the Chrome Web Store id is still a placeholder** — it is
-/// assigned at publish time, so until the extension is published no Chrome
-/// production origin matches and only the dev override
-/// (`platform::config::extension_dev_origins`) admits a local Chrome extension.
+/// The published Chrome Web Store id is now pinned below. The Chrome
+/// `chrome-extension://` host IS the stable Web Store id, so the production
+/// origin matches by exact id; the dev override
+/// (`platform::config::extension_dev_origins`) still admits a local Chrome
+/// extension during development.
 /// Each id is matched as `chrome-extension://<id>` (Chrome only).
 pub const ALLOWED_EXTENSION_IDS: &[&str] = &[
-    // Chrome Web Store id (32 lowercase a–p chars) — PLACEHOLDER (set at publish).
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    // Published Chrome Web Store id (32 lowercase a–p chars).
+    "oaoekkgkhmgdfnpmfkpphgiikliaicll",
 ];
 
 /// Whether a handshake `Origin` is an allowed extension origin.
@@ -134,8 +135,9 @@ mod tests {
 
     #[test]
     fn allows_known_chrome_id() {
-        let origin = format!("chrome-extension://{}", ALLOWED_EXTENSION_IDS[0]);
-        assert!(is_allowed_origin(&origin, &[]));
+        // The published Chrome Web Store id must be an allowed origin.
+        let origin = "chrome-extension://oaoekkgkhmgdfnpmfkpphgiikliaicll";
+        assert!(is_allowed_origin(origin, &[]));
     }
 
     #[test]

--- a/apps/tauri/src/TauriWindowControls.tsx
+++ b/apps/tauri/src/TauriWindowControls.tsx
@@ -75,7 +75,7 @@ export function TauriWindowControls() {
       {/* Close */}
       <button
         onClick={() => win.close()}
-        className="flex h-10 w-11 items-center justify-center text-foreground/50 transition-colors hover:bg-red-500 hover:text-white"
+        className="group flex h-10 w-11 items-center justify-center text-foreground/50 transition-colors hover:bg-red-500 hover:text-white"
         aria-label="Close"
       >
         <svg
@@ -85,6 +85,7 @@ export function TauriWindowControls() {
           fill="none"
           stroke="currentColor"
           strokeWidth="1.2"
+          className="group-hover:stroke-white"
         >
           <line x1="1" y1="1" x2="9" y2="9" />
           <line x1="9" y1="1" x2="1" y2="9" />

--- a/apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx
+++ b/apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx
@@ -1,14 +1,149 @@
+import { useEffect, useRef } from 'react';
+
+import { usePerformanceMode } from '@/store/preferences-store';
+
 /**
- * Ambient backdrop — Apple "restraint" pass (A1).
+ * Slim accent aurora backdrop.
  *
- * The previous cinematic system (aurora ribbons, nebulae, soft streaks, a
- * 900px lerp-smoothed cursor blob, parallax glow orbs, grid texture, film grain
- * and vignette) was removed: the Apple design language forbids decorative
- * gradients and glows, and elevation now comes from surface-color steps +
- * hairlines, not ambient light. The canvas is simply the calm, flat themed
- * `--color-background`, rendered as one static, non-interactive layer (no RAF
- * loop, no pointer listeners, no re-renders — also a performance win).
+ * Layers (back → front):
+ *   1. Aurora ribbons — three slow, wide, hue-rotating CSS blobs.
+ *   2. Nebulae        — one (balanced) / two (performance) medium blobs.
+ *   3. Cursor glow    — a 900px lerp-smoothed blob that trails the pointer.
+ *
+ * All colors derive from the accent: the aurora/nebula vars in tokens.css map
+ * to the brand family, and the cursor glow mixes --color-brand / --color-brand-2,
+ * so the whole layer re-tints with the chosen accent. Reduced motion is handled
+ * in CSS (the animation keyframes are disabled under prefers-reduced-motion).
+ *
+ * Performance:
+ *   - The cursor glow uses a JavaScript lerp loop (not a CSS transition) applied
+ *     straight to the DOM node — zero React re-renders — and is paused while the
+ *     tab/window is hidden.
+ *   - `low-memory` renders nothing; `balanced` trims to a reduced layer budget;
+ *     `performance` adds the second nebula.
  */
 export function CinematicBackground() {
-  return <div aria-hidden className="pointer-events-none fixed inset-0 -z-10 bg-background" />;
+  const mode = usePerformanceMode();
+
+  // ── Lerp cursor glow ────────────────────────────────────────────────────────
+  const blobRef = useRef<HTMLDivElement>(null);
+  const targetRef = useRef({ x: 0, y: 0 }); // where the cursor IS
+  const posRef = useRef({ x: 0, y: 0 }); // where the blob IS (lerped)
+  const rafRef = useRef(0);
+  const HALF = 450; // half of 900px blob
+  const LERP = 0.005; // 0.5% per frame → extremely slow, dreamy floating effect
+
+  useEffect(() => {
+    // Skip RAF loop in low-memory mode — component returns null below.
+    if (mode === 'low-memory') return;
+    // Seed starting position to viewport center so blob doesn't slide in from (0,0)
+    if (typeof window !== 'undefined') {
+      const cx = window.innerWidth / 2;
+      const cy = window.innerHeight / 2;
+      targetRef.current = { x: cx, y: cy };
+      posRef.current = { x: cx, y: cy };
+    }
+
+    const onMove = (e: PointerEvent) => {
+      targetRef.current = { x: e.clientX, y: e.clientY };
+    };
+
+    const tick = () => {
+      posRef.current.x += (targetRef.current.x - posRef.current.x) * LERP;
+      posRef.current.y += (targetRef.current.y - posRef.current.y) * LERP;
+
+      if (blobRef.current) {
+        blobRef.current.style.transform = `translate(${posRef.current.x - HALF}px, ${posRef.current.y - HALF}px)`;
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    // Pause the loop while hidden (background tab / minimized window) so we don't
+    // burn frames animating something nobody can see; resume on return.
+    const onVisibility = () => {
+      cancelAnimationFrame(rafRef.current);
+      if (!document.hidden) rafRef.current = requestAnimationFrame(tick);
+    };
+
+    window.addEventListener('pointermove', onMove, { passive: true });
+    document.addEventListener('visibilitychange', onVisibility);
+    if (!document.hidden) rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      document.removeEventListener('visibilitychange', onVisibility);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [mode]); // re-run if mode changes so RAF is cleaned up correctly
+
+  // All hooks have been called — safe to bail out now.
+  if (mode === 'low-memory') return null;
+
+  // The second nebula only renders on the high-end budget; balanced trims it to
+  // cut the number of large blurred/composited layers on the default mode.
+  const full = mode === 'performance';
+
+  return (
+    <div aria-hidden className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+      {/* Aurora ribbons */}
+      <div
+        className="absolute -top-1/4 left-0 h-[60vh] w-[60vw] rounded-full opacity-40 animate-aurora-1"
+        style={{
+          background: 'radial-gradient(closest-side, var(--aurora-violet) 0%, transparent 70%)',
+          willChange: 'transform',
+        }}
+      />
+      <div
+        className="absolute -top-1/4 left-0 h-[55vh] w-[55vw] rounded-full opacity-35 animate-aurora-2"
+        style={{
+          background: 'radial-gradient(closest-side, var(--aurora-indigo) 0%, transparent 70%)',
+          willChange: 'transform',
+        }}
+      />
+      <div
+        className="absolute top-1/3 left-0 h-[40vh] w-[40vw] rounded-full opacity-25 animate-aurora-3"
+        style={{
+          background: 'radial-gradient(closest-side, var(--aurora-pink) 0%, transparent 70%)',
+          willChange: 'transform',
+        }}
+      />
+
+      {/* Nebulae */}
+      <div
+        className="absolute top-[10vh] left-0 h-[30vh] w-[30vw] rounded-full opacity-40 animate-nebula-1"
+        style={{
+          background: 'radial-gradient(closest-side, var(--nebula-violet) 0%, transparent 70%)',
+          willChange: 'transform',
+        }}
+      />
+      {full && (
+        <div
+          className="absolute top-[60vh] left-0 h-[25vh] w-[25vw] rounded-full opacity-35 animate-nebula-2"
+          style={{
+            background: 'radial-gradient(closest-side, var(--nebula-indigo) 0%, transparent 70%)',
+            willChange: 'transform',
+          }}
+        />
+      )}
+
+      {/* Cursor glow — 900px lerp-smoothed blob.
+          Position is updated every RAF tick via ref mutation (no React renders).
+          Mixes the accent brand + gradient-end so it re-tints with the accent. */}
+      <div
+        ref={blobRef}
+        className="cursor-glow absolute pointer-events-none"
+        style={{
+          width: 900,
+          height: 900,
+          top: 0,
+          left: 0,
+          background:
+            'radial-gradient(circle, color-mix(in srgb, var(--color-brand) 30%, transparent) 0%, color-mix(in srgb, var(--color-brand) 14%, transparent) 30%, color-mix(in srgb, var(--color-brand-2) 6%, transparent) 55%, transparent 72%)',
+          filter: 'blur(55px)',
+          willChange: 'transform',
+        }}
+      />
+    </div>
+  );
 }

--- a/apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx
+++ b/apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx
@@ -12,8 +12,9 @@ import { usePerformanceMode } from '@/store/preferences-store';
  *
  * All colors derive from the accent: the aurora/nebula vars in tokens.css map
  * to the brand family, and the cursor glow mixes --color-brand / --color-brand-2,
- * so the whole layer re-tints with the chosen accent. Reduced motion is handled
- * in CSS (the animation keyframes are disabled under prefers-reduced-motion).
+ * so the whole layer re-tints with the chosen accent. Reduced motion disables
+ * the aurora/nebula keyframes in CSS, and the cursor-glow RAF loop is also
+ * skipped in JS (the glow is painted once, static, at viewport center).
  *
  * Performance:
  *   - The cursor glow uses a JavaScript lerp loop (not a CSS transition) applied
@@ -36,6 +37,20 @@ export function CinematicBackground() {
   useEffect(() => {
     // Skip RAF loop in low-memory mode — component returns null below.
     if (mode === 'low-memory') return;
+    // Reduced-motion users get a static glow: paint the blob once at viewport
+    // center and skip the pointer listener + RAF entirely (the aurora/nebula
+    // keyframes are already neutralized by the CSS reduced-motion media query).
+    const reduceMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduceMotion) {
+      const cx = window.innerWidth / 2;
+      const cy = window.innerHeight / 2;
+      if (blobRef.current) {
+        blobRef.current.style.transform = `translate(${cx - HALF}px, ${cy - HALF}px)`;
+      }
+      return;
+    }
     // Seed starting position to viewport center so blob doesn't slide in from (0,0)
     if (typeof window !== 'undefined') {
       const cx = window.innerWidth / 2;

--- a/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
@@ -2,7 +2,6 @@ import {
   Activity,
   Briefcase,
   ClipboardList,
-  Cpu,
   FilePlus2,
   FileText,
   Gauge,
@@ -23,9 +22,8 @@ import { Button, cn, NavPill, transition, variants } from '@ajh/ui';
 
 import { ROUTES } from '@/constants/routes';
 import { getTimeGreeting } from '@/lib/greeting';
-import { useAICapability } from '@/providers/CapabilityProvider';
 import { useAppVersion } from '@/services/use-system';
-import { useAIModel, useAiProviderConfig, useUserName } from '@/store/preferences-store';
+import { useUserName } from '@/store/preferences-store';
 
 interface NavItem {
   to: string;
@@ -69,22 +67,11 @@ export function Sidebar() {
   const { t } = useTranslation();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const userName = useUserName();
-  const aiModel = useAIModel();
-  const providerConfig = useAiProviderConfig();
-  const ai = useAICapability();
   const { data: version = 'v0.1.0' } = useAppVersion();
   const appVersion = version.startsWith('v') ? version : `v${version}`;
 
   const [versionTooltip, setVersionTooltip] = useState(false);
   const tooltipTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const aiStatus = !ai ? 'checking' : ai.ready ? 'ready' : 'offline';
-
-  const activeProvider = providerConfig?.activeProvider ?? 'ollama';
-  const currentModel =
-    activeProvider === 'ollama'
-      ? aiModel?.defaultModel
-      : providerConfig?.providers?.[activeProvider]?.model;
 
   const showVersion = () => {
     setVersionTooltip(true);
@@ -156,44 +143,6 @@ export function Sidebar() {
             </Link>
           </div>
         )}
-        <div className="flex items-center gap-2 rounded-lg border border-foreground/[0.06] bg-foreground/[0.03] px-2 py-1.5">
-          <Cpu
-            size={11}
-            className={cn(
-              'shrink-0',
-              aiStatus === 'ready'
-                ? 'text-emerald-400/70'
-                : aiStatus === 'offline'
-                  ? 'text-red-400/60'
-                  : 'text-foreground/25'
-            )}
-          />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-1.5">
-              <span
-                className={cn(
-                  'h-1.5 w-1.5 shrink-0 rounded-full',
-                  aiStatus === 'ready'
-                    ? 'bg-emerald-400 shadow-[0_0_4px_rgba(52,211,153,0.6)]'
-                    : aiStatus === 'offline'
-                      ? 'bg-red-400/70'
-                      : 'animate-pulse bg-foreground/20'
-                )}
-              />
-              <span className="truncate text-xs text-foreground/55">
-                {aiStatus === 'ready'
-                  ? currentModel
-                    ? currentModel.length > 30
-                      ? `${currentModel.slice(0, 28)}…`
-                      : currentModel
-                    : 'AI ready'
-                  : aiStatus === 'offline'
-                    ? 'AI offline'
-                    : 'Checking…'}
-              </span>
-            </div>
-          </div>
-        </div>
         <div className="relative flex justify-center">
           <Button
             variant="unstyled"

--- a/apps/tauri/src/renderer/components/layout/StatusBar/index.test.tsx
+++ b/apps/tauri/src/renderer/components/layout/StatusBar/index.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * StatusBar — structural tests (feat/accent-gradients).
+ *
+ * Strategy:
+ *  - All hooks that reach IPC / QueryClient / Zustand persistence are stubbed
+ *    at the module level (same pattern as NotificationBell.test.tsx and
+ *    ModelSelector.test.tsx).
+ *  - @tanstack/react-router useRouter is mocked with a controllable navigate spy.
+ *  - @/store/session-store useSessionStore is mocked; setSettings is a vi.fn()
+ *    spy so we can assert it receives { activeSection: 'ai' }.
+ *  - @/providers/CapabilityProvider useCapabilities returns a canned value.
+ *  - @/services useWorkerActivity returns idle state.
+ *  - @/store/preferences-store useAIModel / useAiProviderConfig return minimal stubs.
+ *  - @/hooks/use-kind-label-map useKindLabelMap returns an empty map.
+ *  - motion/react is globally shimmed — AnimatePresence renders children synchronously.
+ *  - HoverPopover internally calls createPortal; portalled content is reachable
+ *    via screen queries that search the full document.
+ *
+ * Covers (feat/accent-gradients):
+ *  - Clicking the AI-settings button calls setSettings({ activeSection: 'ai' }).
+ *  - Clicking the AI-settings button navigates to ROUTES.SETTINGS.
+ *  - The AI-settings button is identifiable via aria-label="AI settings".
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// ── i18n ──────────────────────────────────────────────────────────────────────
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({ navigate: mockNavigate }),
+}));
+
+// ── session-store — spy on setSettings ────────────────────────────────────────
+
+const mockSetSettings = vi.fn();
+
+vi.mock('@/store/session-store', () => ({
+  useSessionStore: (selector: (s: { setSettings: typeof mockSetSettings }) => unknown) =>
+    selector({ setSettings: mockSetSettings }),
+}));
+
+// ── CapabilityProvider ────────────────────────────────────────────────────────
+
+vi.mock('@/providers/CapabilityProvider', () => ({
+  useCapabilities: () => ({
+    ai: { ready: true, model: 'llama3.2' },
+    data: { ready: true, sqlite: true, vector: true },
+    initialized: true,
+  }),
+}));
+
+// ── Worker activity ───────────────────────────────────────────────────────────
+
+vi.mock('@/services', async (importOriginal) => {
+  const orig = await importOriginal<Record<string, unknown>>();
+  return {
+    ...(orig as object),
+    useWorkerActivity: () => ({
+      isActive: false,
+      active: 0,
+      queued: 0,
+      running: [],
+      queuedJobs: [],
+    }),
+  };
+});
+
+// ── Preferences store ─────────────────────────────────────────────────────────
+
+vi.mock('@/store/preferences-store', () => ({
+  useAIModel: () => ({ defaultModel: 'llama3.2' }),
+  useAiProviderConfig: () => ({
+    activeProvider: 'ollama',
+    providers: { ollama: { model: '' } },
+  }),
+}));
+
+// ── Kind label map ────────────────────────────────────────────────────────────
+
+vi.mock('@/hooks/use-kind-label-map', () => ({
+  useKindLabelMap: () => ({}),
+}));
+
+// ── component under test ──────────────────────────────────────────────────────
+
+import { ROUTES } from '@/constants/routes';
+
+import { StatusBar } from './index';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function renderStatusBar() {
+  return render(<StatusBar />);
+}
+
+// ── reset ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockNavigate.mockReset();
+  mockSetSettings.mockReset();
+});
+
+// ── AI-settings button (feat/accent-gradients) ────────────────────────────────
+
+describe('StatusBar — AI-settings button', () => {
+  it('renders a button with aria-label="AI settings"', () => {
+    renderStatusBar();
+    expect(screen.getByRole('button', { name: 'AI settings' })).toBeInTheDocument();
+  });
+
+  it('clicking "AI settings" calls setSettings with { activeSection: "ai" }', () => {
+    renderStatusBar();
+    fireEvent.click(screen.getByRole('button', { name: 'AI settings' }));
+    expect(mockSetSettings).toHaveBeenCalledOnce();
+    expect(mockSetSettings).toHaveBeenCalledWith({ activeSection: 'ai' });
+  });
+
+  it('clicking "AI settings" navigates to ROUTES.SETTINGS', () => {
+    renderStatusBar();
+    fireEvent.click(screen.getByRole('button', { name: 'AI settings' }));
+    expect(mockNavigate).toHaveBeenCalledOnce();
+    expect(mockNavigate).toHaveBeenCalledWith(expect.objectContaining({ to: ROUTES.SETTINGS }));
+  });
+});
+
+// ── static content smoke checks ───────────────────────────────────────────────
+
+describe('StatusBar — static content', () => {
+  it('renders the db-status text "SQLite · LanceDB" when both are ready', () => {
+    renderStatusBar();
+    expect(screen.getByText('SQLite · LanceDB')).toBeInTheDocument();
+  });
+
+  it('renders the offline-capable tagline', () => {
+    renderStatusBar();
+    expect(screen.getByText('local-first · offline-capable')).toBeInTheDocument();
+  });
+});

--- a/apps/tauri/src/renderer/components/layout/StatusBar/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/StatusBar/index.tsx
@@ -9,6 +9,7 @@ import { useKindLabelMap } from '@/hooks/use-kind-label-map';
 import { useCapabilities } from '@/providers/CapabilityProvider';
 import { useWorkerActivity } from '@/services';
 import { useAIModel, useAiProviderConfig } from '@/store/preferences-store';
+import { useSessionStore } from '@/store/session-store';
 
 export function StatusBar() {
   const { t } = useTranslation();
@@ -18,6 +19,7 @@ export function StatusBar() {
   const activity = useWorkerActivity(kindLabelMap);
   const aiModel = useAIModel();
   const providerConfig = useAiProviderConfig();
+  const setSettings = useSessionStore((s) => s.setSettings);
 
   // Get current model name from active provider
   const activeProvider = providerConfig?.activeProvider ?? 'ollama';
@@ -58,10 +60,18 @@ export function StatusBar() {
   return (
     <div className="glass-surface mx-3 mb-3 mt-2 flex items-center justify-between rounded-xl px-4 py-1.5 text-[11px] text-foreground/60">
       <div className="flex items-center gap-4">
-        <span className="flex items-center gap-1.5">
+        <Button
+          variant="unstyled"
+          aria-label="AI settings"
+          className="flex items-center gap-1.5 rounded hover:text-foreground/80 transition-colors"
+          onClick={() => {
+            setSettings({ activeSection: 'ai' });
+            void router.navigate({ to: ROUTES.SETTINGS });
+          }}
+        >
           <Sparkles size={12} className={statusColor()} />
           {statusText()}
-        </span>
+        </Button>
         <span className="flex items-center gap-1.5">
           <Database size={12} className={data.ready ? 'text-emerald-400' : 'text-foreground/40'} />
           {dbStatus()}

--- a/apps/tauri/src/renderer/components/ui/UpdateBanner/index.tsx
+++ b/apps/tauri/src/renderer/components/ui/UpdateBanner/index.tsx
@@ -41,7 +41,7 @@ export function UpdateBanner() {
             className="flex items-center gap-3 rounded-xl border border-brand/30 px-4 py-2.5 shadow-2xl shadow-black/40"
             style={{
               background:
-                'linear-gradient(135deg, rgba(168,85,247,0.15) 0%, rgba(99,102,241,0.10) 100%)',
+                'linear-gradient(135deg, color-mix(in srgb, var(--color-brand) 15%, transparent) 0%, color-mix(in srgb, var(--color-brand-2) 10%, transparent) 100%)',
               backdropFilter: 'blur(16px)',
             }}
           >

--- a/apps/tauri/src/renderer/features/monitoring/components/Sparkline/index.tsx
+++ b/apps/tauri/src/renderer/features/monitoring/components/Sparkline/index.tsx
@@ -11,12 +11,21 @@ export function Sparkline({ data }: Props) {
       <svg viewBox="0 0 480 64" preserveAspectRatio="none" className="h-20 w-full">
         <defs>
           <linearGradient id="bar-fill" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="rgba(168,85,247,0.6)" />
-            <stop offset="100%" stopColor="rgba(168,85,247,0.1)" />
+            <stop offset="0%" stopColor="color-mix(in srgb, var(--color-brand) 60%, transparent)" />
+            <stop
+              offset="100%"
+              stopColor="color-mix(in srgb, var(--color-brand) 10%, transparent)"
+            />
           </linearGradient>
           <linearGradient id="bar-fill-now" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="rgba(99,102,241,0.9)" />
-            <stop offset="100%" stopColor="rgba(99,102,241,0.2)" />
+            <stop
+              offset="0%"
+              stopColor="color-mix(in srgb, var(--color-brand-2) 90%, transparent)"
+            />
+            <stop
+              offset="100%"
+              stopColor="color-mix(in srgb, var(--color-brand-2) 20%, transparent)"
+            />
           </linearGradient>
         </defs>
         {data.map((v, i) => {

--- a/apps/tauri/src/renderer/features/onboarding/steps/PrefsStep/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/PrefsStep/index.tsx
@@ -70,7 +70,7 @@ export function PrefsStep({ onBack, onNext, direction }: Props) {
         style={{
           background: 'linear-gradient(145deg, rgba(20,14,36,0.97) 0%, rgba(12,10,24,0.97) 100%)',
           boxShadow:
-            '0 32px 80px rgba(0,0,0,0.6), 0 0 0 1px rgba(168,85,247,0.08), inset 0 1px 0 rgba(255,255,255,0.04)',
+            '0 32px 80px rgba(0,0,0,0.6), 0 0 0 1px color-mix(in srgb, var(--color-brand) 8%, transparent), inset 0 1px 0 rgba(255,255,255,0.04)',
         }}
       >
         {/* Heading */}

--- a/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserNotDetectedState/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/browser/BrowserNotDetectedState/index.tsx
@@ -44,9 +44,9 @@ export function BrowserNotDetectedState({ onBack, onNext }: BrowserNotDetectedSt
             className="relative flex h-16 w-16 items-center justify-center rounded-2xl"
             style={{
               background:
-                'linear-gradient(135deg, rgba(168,85,247,0.25) 0%, rgba(99,102,241,0.15) 100%)',
-              border: '1px solid rgba(168,85,247,0.3)',
-              boxShadow: '0 0 32px rgba(168,85,247,0.2)',
+                'linear-gradient(135deg, color-mix(in srgb, var(--color-brand) 25%, transparent) 0%, color-mix(in srgb, var(--color-brand-2) 15%, transparent) 100%)',
+              border: '1px solid color-mix(in srgb, var(--color-brand) 30%, transparent)',
+              boxShadow: '0 0 32px color-mix(in srgb, var(--color-brand) 20%, transparent)',
             }}
           >
             <Globe size={28} className="text-brand-soft" />

--- a/apps/tauri/src/renderer/features/settings/components/SettingsSidebar/index.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SettingsSidebar/index.test.tsx
@@ -94,12 +94,14 @@ describe('SettingsSidebar — active row chevron (feat/accent-gradients)', () =>
   it('chevron element carries the text-brand-soft class', () => {
     const { container } = renderSidebar('general');
     const [chevron] = findChevrons(container);
+    if (!chevron) throw new Error('Expected one chevron element but found none');
     expect(chevron.className).toContain('text-brand-soft');
   });
 
   it('chevron element contains a ChevronRight svg icon', () => {
     const { container } = renderSidebar('general');
     const [chevron] = findChevrons(container);
+    if (!chevron) throw new Error('Expected one chevron element but found none');
     // lucide icons render as <svg> elements
     const svg = chevron.querySelector('svg');
     expect(svg).not.toBeNull();
@@ -113,7 +115,9 @@ describe('SettingsSidebar — active row chevron (feat/accent-gradients)', () =>
     expect(chevrons).toHaveLength(1);
     // Verify the single chevron is inside the General row, not the AI row
     const aiButton = screen.getByRole('button', { name: /AI/i });
-    expect(aiButton.contains(chevrons[0])).toBe(false);
+    const activeChevron = chevrons[0];
+    if (!activeChevron) throw new Error('Expected one chevron element but found none');
+    expect(aiButton.contains(activeChevron)).toBe(false);
   });
 
   it('switching active section moves the chevron to the new active row', () => {
@@ -126,7 +130,9 @@ describe('SettingsSidebar — active row chevron (feat/accent-gradients)', () =>
     );
     expect(findChevrons(container)).toHaveLength(1);
     const generalButton = screen.getByRole('button', { name: /General/i });
-    expect(generalButton.contains(findChevrons(container)[0])).toBe(true);
+    const generalChevron = findChevrons(container)[0];
+    if (!generalChevron) throw new Error('Expected chevron in General row but found none');
+    expect(generalButton.contains(generalChevron)).toBe(true);
 
     rerender(
       <SettingsSidebar
@@ -137,7 +143,9 @@ describe('SettingsSidebar — active row chevron (feat/accent-gradients)', () =>
     );
     expect(findChevrons(container)).toHaveLength(1);
     const aiButton = screen.getByRole('button', { name: /AI/i });
-    expect(aiButton.contains(findChevrons(container)[0])).toBe(true);
+    const aiChevron = findChevrons(container)[0];
+    if (!aiChevron) throw new Error('Expected chevron in AI row but found none');
+    expect(aiButton.contains(aiChevron)).toBe(true);
   });
 });
 

--- a/apps/tauri/src/renderer/features/settings/components/SettingsSidebar/index.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SettingsSidebar/index.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * SettingsSidebar — structural tests (feat/accent-gradients).
+ *
+ * Strategy:
+ *  - motion/react is globally shimmed in vitest.setup.ts: motion.span renders
+ *    as a plain <span> and forwards all non-motion props, so layoutId becomes
+ *    an HTML attribute we can query via getAttribute('layoutId').
+ *  - @ajh/ui is NOT mocked; we render the real NavPill / Button to exercise
+ *    the actual component tree.
+ *  - No IPC / QueryClient needed: SettingsSidebar is pure presentational.
+ *
+ * Covers (feat/accent-gradients):
+ *  - Active row renders a motion.span (shimmed to <span>) carrying text-brand-soft
+ *    that wraps the ChevronRight svg icon.
+ *  - The chevron span is the sole text-brand-soft element that contains a child svg.
+ *  - Inactive rows do NOT render a chevron span.
+ *  - onSectionChange fires with the correct id on row click.
+ *  - Active row has aria-current="page"; inactive rows have none.
+ */
+// ── fixtures ──────────────────────────────────────────────────────────────────
+// Minimal nav groups: one group with two items so we can test active vs inactive.
+import { Cpu, Languages } from 'lucide-react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import type { NavGroup, SectionId } from '@/features/settings/constants';
+
+import { SettingsSidebar } from './index';
+
+const NAV_GROUPS_FIXTURE: NavGroup[] = [
+  {
+    label: 'Preferences',
+    items: [
+      {
+        id: 'general',
+        label: 'General',
+        icon: Languages,
+        description: 'General settings',
+      },
+      {
+        id: 'ai',
+        label: 'AI',
+        icon: Cpu,
+        description: 'AI settings',
+      },
+    ],
+  },
+];
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function renderSidebar(activeSection: SectionId, onSectionChange = vi.fn()) {
+  return render(
+    <SettingsSidebar
+      navGroups={NAV_GROUPS_FIXTURE}
+      activeSection={activeSection}
+      onSectionChange={onSectionChange}
+    />
+  );
+}
+
+/**
+ * Find all chevron spans in the sidebar.
+ *
+ * The motion shim strips layoutId (it is in MOTION_PROPS) before passing props
+ * to the underlying DOM element, so we cannot query by [layoutid=…].
+ * Instead we rely on the stable className "text-brand-soft" that SettingsSidebar
+ * unconditionally places on the motion.span that wraps ChevronRight. That class
+ * is unique to the chevron element inside the sidebar — no other element in the
+ * tree carries it — so it is a reliable structural hook.
+ */
+function findChevrons(container: HTMLElement): HTMLElement[] {
+  // The motion.span renders as a plain <span>; its className contains text-brand-soft.
+  // We match any element (span or otherwise) carrying that class so the test is
+  // resilient to the tag name the shim chooses.
+  return Array.from(container.querySelectorAll<HTMLElement>('.text-brand-soft')).filter(
+    (el) => el.querySelector('svg') !== null
+  );
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('SettingsSidebar — active row chevron (feat/accent-gradients)', () => {
+  it('active row renders exactly one chevron span (text-brand-soft + child svg)', () => {
+    const { container } = renderSidebar('general');
+    const chevrons = findChevrons(container);
+    expect(chevrons).toHaveLength(1);
+  });
+
+  it('chevron element carries the text-brand-soft class', () => {
+    const { container } = renderSidebar('general');
+    const [chevron] = findChevrons(container);
+    expect(chevron.className).toContain('text-brand-soft');
+  });
+
+  it('chevron element contains a ChevronRight svg icon', () => {
+    const { container } = renderSidebar('general');
+    const [chevron] = findChevrons(container);
+    // lucide icons render as <svg> elements
+    const svg = chevron.querySelector('svg');
+    expect(svg).not.toBeNull();
+  });
+
+  it('chevron is absent for all inactive rows', () => {
+    // 'general' is active → 'ai' row is inactive and must have no chevron
+    const { container } = renderSidebar('general');
+    const chevrons = findChevrons(container);
+    // Only the active row gets a chevron
+    expect(chevrons).toHaveLength(1);
+    // Verify the single chevron is inside the General row, not the AI row
+    const aiButton = screen.getByRole('button', { name: /AI/i });
+    expect(aiButton.contains(chevrons[0])).toBe(false);
+  });
+
+  it('switching active section moves the chevron to the new active row', () => {
+    const { container, rerender } = render(
+      <SettingsSidebar
+        navGroups={NAV_GROUPS_FIXTURE}
+        activeSection="general"
+        onSectionChange={vi.fn()}
+      />
+    );
+    expect(findChevrons(container)).toHaveLength(1);
+    const generalButton = screen.getByRole('button', { name: /General/i });
+    expect(generalButton.contains(findChevrons(container)[0])).toBe(true);
+
+    rerender(
+      <SettingsSidebar
+        navGroups={NAV_GROUPS_FIXTURE}
+        activeSection="ai"
+        onSectionChange={vi.fn()}
+      />
+    );
+    expect(findChevrons(container)).toHaveLength(1);
+    const aiButton = screen.getByRole('button', { name: /AI/i });
+    expect(aiButton.contains(findChevrons(container)[0])).toBe(true);
+  });
+});
+
+describe('SettingsSidebar — aria-current', () => {
+  it('active row button has aria-current="page"', () => {
+    renderSidebar('general');
+    expect(screen.getByRole('button', { name: /General/i })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('inactive row button has no aria-current attribute', () => {
+    renderSidebar('general');
+    expect(screen.getByRole('button', { name: /AI/i })).not.toHaveAttribute('aria-current');
+  });
+});
+
+describe('SettingsSidebar — interaction', () => {
+  it('clicking an inactive row calls onSectionChange with its id', () => {
+    const onChange = vi.fn();
+    renderSidebar('general', onChange);
+    fireEvent.click(screen.getByRole('button', { name: /AI/i }));
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith('ai');
+  });
+
+  it('clicking the active row still fires onSectionChange', () => {
+    const onChange = vi.fn();
+    renderSidebar('general', onChange);
+    fireEvent.click(screen.getByRole('button', { name: /General/i }));
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith('general');
+  });
+});

--- a/apps/tauri/src/renderer/features/settings/components/SettingsSidebar/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SettingsSidebar/index.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight } from 'lucide-react';
+import { motion } from 'motion/react';
 
-import { Button, cn, NavPill } from '@ajh/ui';
+import { Button, cn, NavPill, transition } from '@ajh/ui';
 
 import type { NavGroup, SectionId } from '@/features/settings/constants';
 
@@ -46,7 +47,15 @@ export function SettingsSidebar({ navGroups, activeSection, onSectionChange }: P
                       )}
                     />
                     <span className="flex-1 font-medium">{label}</span>
-                    {active && <ChevronRight size={12} className="text-foreground/30" />}
+                    {active && (
+                      <motion.span
+                        layoutId="settings-chevron"
+                        transition={transition.spring}
+                        className="text-brand-soft"
+                      >
+                        <ChevronRight size={12} />
+                      </motion.span>
+                    )}
                   </Button>
                 </div>
               );

--- a/apps/tauri/src/renderer/features/settings/components/accounts/BoardSessionRow/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/accounts/BoardSessionRow/index.tsx
@@ -27,7 +27,11 @@ const BOARD_STYLE: Record<string, { iconBg: string; glowColor: string; abbr: str
   glassdoor: { iconBg: '#0CAA41', glowColor: 'rgba(12,170,65,0.2)', abbr: 'gd' },
 };
 
-const FALLBACK = { iconBg: 'var(--color-brand)', glowColor: 'rgba(168,85,247,0.2)', abbr: '?' };
+const FALLBACK = {
+  iconBg: 'var(--color-brand)',
+  glowColor: 'color-mix(in srgb, var(--color-brand) 20%, transparent)',
+  abbr: '?',
+};
 
 export function BoardSessionRow({ board }: { board: Board }) {
   const [confirmOpen, setConfirmOpen] = useState(false);

--- a/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * AppearanceCard — two-tone gradient accent swatch tests.
+ *
+ * Covers:
+ *  - Every preset accent swatch button renders with an inline `background` style
+ *    containing `linear-gradient(` — NOT a flat solid color.
+ *  - The Default chip's colour dot uses the CSS-var gradient pair
+ *    (var(--color-brand) … var(--color-brand-2)).
+ *  - Clicking a preset swatch calls applyThemeAnimated with both accentColor and
+ *    accentColor2 so the two-tone gradient is wired end-to-end.
+ *
+ * Mock strategy mirrors EmbeddingsSettings.test.tsx (the nearest sibling):
+ *  - @ajh/translations → key-passthrough t()
+ *  - @/services → useSystemAccent returns { data: { supported: false } } to hide
+ *    the System chip (simplifies assertions; chip count is deterministic)
+ *  - @ajh/ui → spread actual, override useNotification (avoids provider tree)
+ *  - applyThemeAnimated is spied on via vi.mock so we can assert its args without
+ *    touching real DOM / localStorage side-effects in these tests.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { ThemePrefs } from '@ajh/ui';
+
+// ── i18n stub ─────────────────────────────────────────────────────────────────
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+// ── Service stubs ─────────────────────────────────────────────────────────────
+
+vi.mock('@/services', () => ({
+  useSystemAccent: () => ({ data: { supported: false } }),
+}));
+
+// ── @ajh/ui — spread actual, spy on applyThemeAnimated, stub notification ────
+// applyThemeAnimatedSpy must NOT be referenced before initialisation inside a
+// vi.mock factory (hoisting rule). Declare it with vi.fn() inside the factory
+// and expose it on the module object; then grab it via vi.mocked() after import.
+
+vi.mock('@ajh/ui', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    // Replace the side-effectful theme applier with a spy so tests never touch
+    // localStorage or document.documentElement.style.
+    applyThemeAnimated: vi.fn(),
+    useNotification: () => ({
+      open: vi.fn(),
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warning: vi.fn(),
+      destroy: vi.fn(),
+    }),
+  };
+});
+
+// ── component under test (import AFTER mocks) ─────────────────────────────────
+
+import * as AjhUiModule from '@ajh/ui';
+
+import { AppearanceCard } from './AppearanceCard';
+
+// Grab the spy reference after the mock is established.
+const applyThemeAnimatedSpy = vi.mocked(AjhUiModule.applyThemeAnimated);
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * All preset accent swatch buttons: the ones rendered by the ACCENTS array in
+ * AppearanceCard. They are round (h-7 w-7) and carry an inline `background`
+ * style with a linear-gradient. We identify them by their inline style
+ * containing "linear-gradient" AND having an aria-label that matches one of the
+ * known accent i18n keys — distinct from the Default and System chips which
+ * are text-bearing buttons.
+ */
+function getSwatchButtons(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('button')).filter((btn) => {
+    const bg = btn.style.background ?? btn.style.backgroundColor ?? '';
+    return bg.includes('linear-gradient');
+  });
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('AppearanceCard — preset accent swatches', () => {
+  it('renders 8 preset swatch buttons (one per ACCENTS entry)', () => {
+    render(<AppearanceCard />);
+    // ACCENTS has 8 entries (violet, blue, green, orange, pink, red, yellow, graphite).
+    expect(getSwatchButtons()).toHaveLength(8);
+  });
+
+  it('every preset swatch carries a linear-gradient background, not a flat color', () => {
+    render(<AppearanceCard />);
+    const swatches = getSwatchButtons();
+    expect(swatches.length).toBeGreaterThan(0);
+    for (const btn of swatches) {
+      expect(btn.style.background).toContain('linear-gradient(');
+    }
+  });
+
+  it('the Default chip colour dot uses the CSS-var gradient (var(--color-brand) … var(--color-brand-2))', () => {
+    render(<AppearanceCard />);
+    // The Default chip contains a <span> whose background is the CSS-var gradient.
+    const dots = Array.from(document.querySelectorAll<HTMLElement>('span')).filter((el) =>
+      (el.style.background ?? '').includes('var(--color-brand)')
+    );
+    expect(dots.length).toBeGreaterThanOrEqual(1);
+    const dot = dots[0];
+    if (!dot) throw new Error('expected default chip dot with CSS-var gradient background');
+    expect(dot.style.background).toContain('var(--color-brand)');
+    expect(dot.style.background).toContain('var(--color-brand-2)');
+    expect(dot.style.background).toContain('linear-gradient(');
+  });
+
+  it('clicking a preset swatch calls applyThemeAnimated with both accentColor and accentColor2', async () => {
+    applyThemeAnimatedSpy.mockClear();
+    const user = userEvent.setup();
+    render(<AppearanceCard />);
+
+    const swatches = getSwatchButtons();
+    expect(swatches.length).toBeGreaterThan(0);
+
+    // Click the first swatch (violet: color '#a855f7', color2 '#6366f1').
+    const firstSwatch = swatches[0];
+    if (!firstSwatch) throw new Error('expected at least one preset swatch button');
+    await user.click(firstSwatch);
+
+    expect(applyThemeAnimatedSpy).toHaveBeenCalledTimes(1);
+    const call = applyThemeAnimatedSpy.mock.calls.at(-1);
+    if (!call) throw new Error('expected applyThemeAnimated to have been called');
+    const calledWith: ThemePrefs = call[0];
+    expect(calledWith.accentSource).toBe('custom');
+    // Both gradient stops must be forwarded — never undefined.
+    expect(typeof calledWith.accentColor).toBe('string');
+    expect(calledWith.accentColor?.length).toBeGreaterThan(0);
+    expect(typeof calledWith.accentColor2).toBe('string');
+    expect(calledWith.accentColor2?.length).toBeGreaterThan(0);
+    // The two gradient stops must differ (it's a two-tone, not a self-referential pair).
+    expect(calledWith.accentColor).not.toBe(calledWith.accentColor2);
+  });
+
+  it('each swatch gradient uses two distinct hex stops (start ≠ end)', () => {
+    render(<AppearanceCard />);
+    const swatches = getSwatchButtons();
+    for (const btn of swatches) {
+      // Extract the two hex values from  `linear-gradient(135deg, #xxxxxx, #yyyyyy)`.
+      const matches = btn.style.background.match(/#[0-9a-fA-F]{6}/g);
+      expect(matches).not.toBeNull();
+      if (!matches) throw new Error(`Expected hex matches in gradient: ${btn.style.background}`);
+      expect(matches.length).toBe(2);
+      // The two stops must differ — the gradient is genuinely two-tone.
+      const stop1 = matches[0];
+      const stop2 = matches[1];
+      if (!stop1 || !stop2)
+        throw new Error(`Expected two hex stops in gradient: ${btn.style.background}`);
+      expect(stop1.toLowerCase()).not.toBe(stop2.toLowerCase());
+    }
+  });
+});

--- a/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.test.tsx
@@ -16,6 +16,16 @@
  *  - @ajh/ui → spread actual, override useNotification (avoids provider tree)
  *  - applyThemeAnimated is spied on via vi.mock so we can assert its args without
  *    touching real DOM / localStorage side-effects in these tests.
+ *
+ * Robustness notes:
+ *  - All DOM queries are scoped to the `container` returned by `render()` to
+ *    prevent interaction with parallel tests that share the global `document`.
+ *  - Raw `getAttribute('style')` is used instead of `.style.background` everywhere
+ *    so that jsdom CSSOM re-serialization (which can normalise hex → rgb or drop
+ *    the value depending on parse order) never affects our assertions.
+ *  - `getSwatchButtons` filters to buttons whose raw style attribute contains BOTH
+ *    `linear-gradient(` AND a `#` hex stop, which excludes the Default chip's
+ *    `<span>` (CSS-var gradient, no `#`) and any other non-hex-gradient elements.
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -71,17 +81,20 @@ const applyThemeAnimatedSpy = vi.mocked(AjhUiModule.applyThemeAnimated);
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 /**
- * All preset accent swatch buttons: the ones rendered by the ACCENTS array in
- * AppearanceCard. They are round (h-7 w-7) and carry an inline `background`
- * style with a linear-gradient. We identify them by their inline style
- * containing "linear-gradient" AND having an aria-label that matches one of the
- * known accent i18n keys — distinct from the Default and System chips which
- * are text-bearing buttons.
+ * All preset accent swatch buttons within `root`: the ones rendered by the
+ * ACCENTS array in AppearanceCard. Identified by their raw inline style
+ * attribute containing BOTH `linear-gradient(` AND a `#` hex stop — this
+ * reliably excludes the Default chip's `<span>` (which uses CSS vars, no `#`)
+ * and any buttons without a gradient style at all.
+ *
+ * Using `getAttribute('style')` instead of `.style.background` avoids jsdom
+ * CSSOM re-serialization, which can normalize hex stops to `rgb(...)` or drop
+ * the value entirely depending on parse/run order across the full test suite.
  */
-function getSwatchButtons(): HTMLElement[] {
-  return Array.from(document.querySelectorAll<HTMLElement>('button')).filter((btn) => {
-    const bg = btn.style.background ?? btn.style.backgroundColor ?? '';
-    return bg.includes('linear-gradient');
+function getSwatchButtons(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('button')).filter((btn) => {
+    const rawStyle = btn.getAttribute('style') ?? '';
+    return rawStyle.includes('linear-gradient(') && rawStyle.includes('#');
   });
 }
 
@@ -89,40 +102,41 @@ function getSwatchButtons(): HTMLElement[] {
 
 describe('AppearanceCard — preset accent swatches', () => {
   it('renders 8 preset swatch buttons (one per ACCENTS entry)', () => {
-    render(<AppearanceCard />);
+    const { container } = render(<AppearanceCard />);
     // ACCENTS has 8 entries (violet, blue, green, orange, pink, red, yellow, graphite).
-    expect(getSwatchButtons()).toHaveLength(8);
+    expect(getSwatchButtons(container)).toHaveLength(8);
   });
 
   it('every preset swatch carries a linear-gradient background, not a flat color', () => {
-    render(<AppearanceCard />);
-    const swatches = getSwatchButtons();
+    const { container } = render(<AppearanceCard />);
+    const swatches = getSwatchButtons(container);
     expect(swatches.length).toBeGreaterThan(0);
     for (const btn of swatches) {
-      expect(btn.style.background).toContain('linear-gradient(');
+      expect(btn.getAttribute('style') ?? '').toContain('linear-gradient(');
     }
   });
 
   it('the Default chip colour dot uses the CSS-var gradient (var(--color-brand) … var(--color-brand-2))', () => {
-    render(<AppearanceCard />);
+    const { container } = render(<AppearanceCard />);
     // The Default chip contains a <span> whose background is the CSS-var gradient.
-    const dots = Array.from(document.querySelectorAll<HTMLElement>('span')).filter((el) =>
-      (el.style.background ?? '').includes('var(--color-brand)')
+    const dots = Array.from(container.querySelectorAll<HTMLElement>('span')).filter((el) =>
+      (el.getAttribute('style') ?? '').includes('var(--color-brand)')
     );
     expect(dots.length).toBeGreaterThanOrEqual(1);
     const dot = dots[0];
     if (!dot) throw new Error('expected default chip dot with CSS-var gradient background');
-    expect(dot.style.background).toContain('var(--color-brand)');
-    expect(dot.style.background).toContain('var(--color-brand-2)');
-    expect(dot.style.background).toContain('linear-gradient(');
+    const dotStyle = dot.getAttribute('style') ?? '';
+    expect(dotStyle).toContain('var(--color-brand)');
+    expect(dotStyle).toContain('var(--color-brand-2)');
+    expect(dotStyle).toContain('linear-gradient(');
   });
 
   it('clicking a preset swatch calls applyThemeAnimated with both accentColor and accentColor2', async () => {
     applyThemeAnimatedSpy.mockClear();
     const user = userEvent.setup();
-    render(<AppearanceCard />);
+    const { container } = render(<AppearanceCard />);
 
-    const swatches = getSwatchButtons();
+    const swatches = getSwatchButtons(container);
     expect(swatches.length).toBeGreaterThan(0);
 
     // Click the first swatch (violet: color '#a855f7', color2 '#6366f1').
@@ -145,19 +159,21 @@ describe('AppearanceCard — preset accent swatches', () => {
   });
 
   it('each swatch gradient uses two distinct hex stops (start ≠ end)', () => {
-    render(<AppearanceCard />);
-    const swatches = getSwatchButtons();
+    const { container } = render(<AppearanceCard />);
+    const swatches = getSwatchButtons(container);
     for (const btn of swatches) {
-      // Extract the two hex values from  `linear-gradient(135deg, #xxxxxx, #yyyyyy)`.
-      const matches = btn.style.background.match(/#[0-9a-fA-F]{6}/g);
+      // Read the raw style attribute — not the CSSOM — to avoid jsdom re-serialization
+      // converting hex stops to rgb() or dropping the value under parallel test runs.
+      const rawStyle = btn.getAttribute('style') ?? '';
+      // Extract the two hex values from `linear-gradient(135deg, #xxxxxx, #yyyyyy)`.
+      const matches = rawStyle.match(/#[0-9a-fA-F]{6}/g);
       expect(matches).not.toBeNull();
-      if (!matches) throw new Error(`Expected hex matches in gradient: ${btn.style.background}`);
+      if (!matches) throw new Error(`Expected hex matches in gradient: ${rawStyle}`);
       expect(matches.length).toBe(2);
       // The two stops must differ — the gradient is genuinely two-tone.
       const stop1 = matches[0];
       const stop2 = matches[1];
-      if (!stop1 || !stop2)
-        throw new Error(`Expected two hex stops in gradient: ${btn.style.background}`);
+      if (!stop1 || !stop2) throw new Error(`Expected two hex stops in gradient: ${rawStyle}`);
       expect(stop1.toLowerCase()).not.toBe(stop2.toLowerCase());
     }
   });

--- a/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.test.tsx
@@ -20,12 +20,14 @@
  * Robustness notes:
  *  - All DOM queries are scoped to the `container` returned by `render()` to
  *    prevent interaction with parallel tests that share the global `document`.
- *  - Raw `getAttribute('style')` is used instead of `.style.background` everywhere
- *    so that jsdom CSSOM re-serialization (which can normalise hex → rgb or drop
- *    the value depending on parse order) never affects our assertions.
- *  - `getSwatchButtons` filters to buttons whose raw style attribute contains BOTH
- *    `linear-gradient(` AND a `#` hex stop, which excludes the Default chip's
- *    `<span>` (CSS-var gradient, no `#`) and any other non-hex-gradient elements.
+ *  - Swatch detection uses the `data-accent-color` attribute (CSS-independent),
+ *    so it is immune to jsdom CSSOM rejecting/normalising hex gradient values.
+ *    The two accent hex stops are read from `data-accent-color` /
+ *    `data-accent-color2` rather than parsing the inline `style` string.
+ *  - The Default chip's colour dot is located via `data-testid="default-accent-dot"`,
+ *    so finding it no longer depends on matching its style content. Its CSS-var
+ *    gradient style is then asserted directly (these `getAttribute('style')`
+ *    checks still work in jsdom).
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -82,20 +84,15 @@ const applyThemeAnimatedSpy = vi.mocked(AjhUiModule.applyThemeAnimated);
 
 /**
  * All preset accent swatch buttons within `root`: the ones rendered by the
- * ACCENTS array in AppearanceCard. Identified by their raw inline style
- * attribute containing BOTH `linear-gradient(` AND a `#` hex stop — this
- * reliably excludes the Default chip's `<span>` (which uses CSS vars, no `#`)
- * and any buttons without a gradient style at all.
+ * ACCENTS array in AppearanceCard. The preset swatch buttons carry a stable
+ * `data-accent-color` attribute, so we select them by that attribute alone.
  *
- * Using `getAttribute('style')` instead of `.style.background` avoids jsdom
- * CSSOM re-serialization, which can normalize hex stops to `rgb(...)` or drop
- * the value entirely depending on parse/run order across the full test suite.
+ * The Default-dot `<span>` and the System chip have no `data-accent-color`,
+ * so this query is robust and CSS-independent — it does not depend on jsdom
+ * CSSOM parsing the inline gradient style.
  */
 function getSwatchButtons(root: HTMLElement): HTMLElement[] {
-  return Array.from(root.querySelectorAll<HTMLElement>('button')).filter((btn) => {
-    const rawStyle = btn.getAttribute('style') ?? '';
-    return rawStyle.includes('linear-gradient(') && rawStyle.includes('#');
-  });
+  return Array.from(root.querySelectorAll<HTMLElement>('button[data-accent-color]'));
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -107,23 +104,21 @@ describe('AppearanceCard — preset accent swatches', () => {
     expect(getSwatchButtons(container)).toHaveLength(8);
   });
 
-  it('every preset swatch carries a linear-gradient background, not a flat color', () => {
+  it('every preset swatch exposes two distinct hex accent colors (a real two-tone, not a flat color)', () => {
     const { container } = render(<AppearanceCard />);
     const swatches = getSwatchButtons(container);
     expect(swatches.length).toBeGreaterThan(0);
     for (const btn of swatches) {
-      expect(btn.getAttribute('style') ?? '').toContain('linear-gradient(');
+      expect(btn.getAttribute('data-accent-color')).toMatch(/^#[0-9a-fA-F]{6}$/);
+      expect(btn.getAttribute('data-accent-color2')).toMatch(/^#[0-9a-fA-F]{6}$/);
     }
   });
 
   it('the Default chip colour dot uses the CSS-var gradient (var(--color-brand) … var(--color-brand-2))', () => {
     const { container } = render(<AppearanceCard />);
-    // The Default chip contains a <span> whose background is the CSS-var gradient.
-    const dots = Array.from(container.querySelectorAll<HTMLElement>('span')).filter((el) =>
-      (el.getAttribute('style') ?? '').includes('var(--color-brand)')
-    );
-    expect(dots.length).toBeGreaterThanOrEqual(1);
-    const dot = dots[0];
+    // The Default chip contains a <span> tagged with a stable test id; locating it
+    // by `data-testid` keeps element detection CSS-independent (no style matching).
+    const dot = container.querySelector<HTMLElement>('[data-testid="default-accent-dot"]');
     if (!dot) throw new Error('expected default chip dot with CSS-var gradient background');
     const dotStyle = dot.getAttribute('style') ?? '';
     expect(dotStyle).toContain('var(--color-brand)');
@@ -162,19 +157,17 @@ describe('AppearanceCard — preset accent swatches', () => {
     const { container } = render(<AppearanceCard />);
     const swatches = getSwatchButtons(container);
     for (const btn of swatches) {
-      // Read the raw style attribute — not the CSSOM — to avoid jsdom re-serialization
-      // converting hex stops to rgb() or dropping the value under parallel test runs.
-      const rawStyle = btn.getAttribute('style') ?? '';
-      // Extract the two hex values from `linear-gradient(135deg, #xxxxxx, #yyyyyy)`.
-      const matches = rawStyle.match(/#[0-9a-fA-F]{6}/g);
-      expect(matches).not.toBeNull();
-      if (!matches) throw new Error(`Expected hex matches in gradient: ${rawStyle}`);
-      expect(matches.length).toBe(2);
+      // Read the two stops from the stable data attributes — CSS-independent, so
+      // jsdom CSSOM rejecting/normalising the inline gradient never affects this.
+      const color = btn.getAttribute('data-accent-color');
+      const color2 = btn.getAttribute('data-accent-color2');
+      if (!color || !color2) {
+        throw new Error('expected both data-accent-color and data-accent-color2 on swatch');
+      }
+      expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+      expect(color2).toMatch(/^#[0-9a-fA-F]{6}$/);
       // The two stops must differ — the gradient is genuinely two-tone.
-      const stop1 = matches[0];
-      const stop2 = matches[1];
-      if (!stop1 || !stop2) throw new Error(`Expected two hex stops in gradient: ${rawStyle}`);
-      expect(stop1.toLowerCase()).not.toBe(stop2.toLowerCase());
+      expect(color.toLowerCase()).not.toBe(color2.toLowerCase());
     }
   });
 });

--- a/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx
@@ -135,6 +135,7 @@ export function AppearanceCard() {
               )}
             >
               <span
+                data-testid="default-accent-dot"
                 className="h-3 w-3 rounded-full"
                 style={{
                   background: 'linear-gradient(135deg, var(--color-brand), var(--color-brand-2))',
@@ -182,6 +183,8 @@ export function AppearanceCard() {
                     'h-7 w-7 rounded-full border-2 transition-transform focus-visible:ring-2 focus-visible:ring-brand/50',
                     active ? 'scale-110 border-foreground/70' : 'border-transparent hover:scale-105'
                   )}
+                  data-accent-color={color}
+                  data-accent-color2={color2}
                   style={{ background: `linear-gradient(135deg, ${color}, ${color2})` }}
                 />
               );

--- a/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx
@@ -32,15 +32,35 @@ const SCALES: { id: TextScale; labelKey: string; size: string }[] = [
 // macOS-style preset accents the user can pick manually. 'default' (handled
 // separately) keeps the shipped, per-scheme-tuned violet; each preset here is a
 // fixed hex applied to both schemes via the theme engine's accent applier.
-const ACCENTS: { id: string; color: string; labelKey: string }[] = [
-  { id: 'violet', color: '#a855f7', labelKey: 'settings.appearance.accentViolet' },
-  { id: 'blue', color: '#007aff', labelKey: 'settings.appearance.accentBlue' },
-  { id: 'green', color: '#34c759', labelKey: 'settings.appearance.accentGreen' },
-  { id: 'orange', color: '#ff9500', labelKey: 'settings.appearance.accentOrange' },
-  { id: 'pink', color: '#ff2d55', labelKey: 'settings.appearance.accentPink' },
-  { id: 'red', color: '#ff3b30', labelKey: 'settings.appearance.accentRed' },
-  { id: 'yellow', color: '#ffcc00', labelKey: 'settings.appearance.accentYellow' },
-  { id: 'graphite', color: '#8e8e93', labelKey: 'settings.appearance.accentGraphite' },
+const ACCENTS: { id: string; color: string; color2: string; labelKey: string }[] = [
+  {
+    id: 'violet',
+    color: '#a855f7',
+    color2: '#6366f1',
+    labelKey: 'settings.appearance.accentViolet',
+  },
+  { id: 'blue', color: '#007aff', color2: '#22d3ee', labelKey: 'settings.appearance.accentBlue' },
+  { id: 'green', color: '#34c759', color2: '#06b6a4', labelKey: 'settings.appearance.accentGreen' },
+  {
+    id: 'orange',
+    color: '#ff9500',
+    color2: '#ffb340',
+    labelKey: 'settings.appearance.accentOrange',
+  },
+  { id: 'pink', color: '#ff2d55', color2: '#ff5e9c', labelKey: 'settings.appearance.accentPink' },
+  { id: 'red', color: '#ff3b30', color2: '#ff2d7a', labelKey: 'settings.appearance.accentRed' },
+  {
+    id: 'yellow',
+    color: '#ffcc00',
+    color2: '#ff9500',
+    labelKey: 'settings.appearance.accentYellow',
+  },
+  {
+    id: 'graphite',
+    color: '#8e8e93',
+    color2: '#6e7280',
+    labelKey: 'settings.appearance.accentGraphite',
+  },
 ];
 
 export function AppearanceCard() {
@@ -114,7 +134,12 @@ export function AppearanceCard() {
                   : 'border-foreground/10 text-foreground/55 hover:text-foreground/80'
               )}
             >
-              <span className="h-3 w-3 rounded-full bg-brand" />
+              <span
+                className="h-3 w-3 rounded-full"
+                style={{
+                  background: 'linear-gradient(135deg, var(--color-brand), var(--color-brand-2))',
+                }}
+              />
               {t('settings.appearance.accentDefault')}
             </Button>
             {sysAccent?.supported && (
@@ -138,7 +163,7 @@ export function AppearanceCard() {
                 {t('settings.appearance.system')}
               </Button>
             )}
-            {ACCENTS.map(({ id, color, labelKey }) => {
+            {ACCENTS.map(({ id, color, color2, labelKey }) => {
               const active =
                 prefs.accentSource === 'custom' &&
                 prefs.accentColor?.toLowerCase() === color.toLowerCase();
@@ -150,12 +175,14 @@ export function AppearanceCard() {
                   aria-checked={active}
                   aria-label={t(labelKey)}
                   title={t(labelKey)}
-                  onClick={() => update({ accentSource: 'custom', accentColor: color })}
+                  onClick={() =>
+                    update({ accentSource: 'custom', accentColor: color, accentColor2: color2 })
+                  }
                   className={cn(
                     'h-7 w-7 rounded-full border-2 transition-transform focus-visible:ring-2 focus-visible:ring-brand/50',
                     active ? 'scale-110 border-foreground/70' : 'border-transparent hover:scale-105'
                   )}
-                  style={{ backgroundColor: color }}
+                  style={{ background: `linear-gradient(135deg, ${color}, ${color2})` }}
                 />
               );
             })}

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -9,7 +9,7 @@ The design system lives in `packages/ui` and is published as the `@ajh/ui` inter
 > 1. **Accent stays violet** (`--color-brand`), not Apple's Action Blue.
 > 2. **Colorful action buttons** are allowed (Apple mandates a single accent). They are _semantic_ (run/edit/delete), token-driven (`--color-action-*`), and never decorative.
 >
-> "Hybrid" depth: content surfaces are flat (`.surface-card`); frosted **glass is reserved for hero surfaces only** — modals, the dashboard hero, and chrome (sidebar/titlebar/sticky bars). Decorative gradients, glows, and the aurora background were removed from content.
+> "Hybrid" depth: content surfaces are flat (`.surface-card`); frosted **glass is reserved for hero surfaces only** — modals, the dashboard hero, and chrome (sidebar/titlebar/sticky bars). Decorative gradients and glows live in content. A **slim, accent-tinted aurora** (ribbons, nebulae, and cursor glow, gated by performance mode) sits as the ambient backdrop behind all surfaces; it is always present when performance allows.
 
 ---
 
@@ -23,6 +23,8 @@ All tokens are CSS custom properties defined in `packages/ui/src/css/tokens.css`
 /* Brand palette */
 --color-brand          /* Primary interactive color (violet — the accent) */
 --color-brand-soft     /* Muted/secondary brand variant */
+--color-brand-2        /* Gradient-end hue (hand-tuned per preset, rotateHueHex(-30°) for system/custom) */
+--color-brand-2-soft   /* Lighter step of brand-2 (for secondary text/icons) */
 --color-brand-dim      /* Darker accent tone (derived via CSS color-mix from brand) */
 
 /* Colorful action tokens (semantic; the deliberate divergence — tokens only,
@@ -170,18 +172,20 @@ A **single-source, user-customizable accent** system colllapses brand-color frag
 **Single point of derivation** — `--color-brand` in `packages/ui/src/css/tokens.css` is the sole accent. All derived colors compute from it at paint time:
 
 - **`--color-brand-soft`** — a lighter step for secondary accent text/icons (28% whiter on dark schemes, 16% on light to account for canvas contrast).
+- **`--color-brand-2` / `--color-brand-2-soft`** — gradient-end hue and its lighter variant, derived at runtime by `applyAccent()` in `packages/ui/src/lib/theme.ts`. Hand-tuned per preset (e.g. blue #007aff→#22d3ee), or auto-rotated via `rotateHueHex(color, -30)` for system/custom accents. Static default values (violet→indigo) are shipped in tokens.css and cleared for `accentSource:'default'`. The `ThemePrefs.accentColor2` optional field allows preset overrides.
 - **`--color-brand-dim`** — a darker tone for disabled/subtle states (derived via CSS `color-mix(–10%)`).
 - **`--color-action-primary`** — alias for brand (the signature CTA color); semantic, never diverges.
 - **`ring-brand`** — the focus ring (2px brand outline on focus-visible buttons/inputs).
-- **Brand glows and gradients** — all derive via `color-mix` in `utilities.css`, so they auto-adjust with the accent.
+- **Brand glows and gradients** (`.text-gradient`, `.gradient-border`, `.glass-violet`, `.glass-indigo`, aurora ribbons/nebulae) — all derive via `color-mix` in `utilities.css` or inline CSS, referencing `var(--color-brand)` / `var(--color-brand-2)`, so they auto-adjust with the accent.
 
 **Auto-contrast for legibility** — `--color-action-foreground` is computed at runtime by `applyAccent()` in `packages/ui/src/lib/theme.ts` using `readableForeground()` from `packages/ui/src/lib/color.ts`. The function applies WCAG luminance (`> 0.55 → dark label; ≤ 0.55 → white label`) so filled primary CTAs remain readable on any accent (pale lavender accents get `#1d1d1f` labels; deep indigo accents get `#ffffff`).
 
-**Runtime applier** — `applyAccent(root, prefs, scheme)` writes the three accent vars (`--color-brand`, `--color-brand-soft`, `--color-action-foreground`) to `<html>.style` before paint, or clears them for `'default'`. The applier is idempotent and re-runs on scheme changes (light/dark swap) to recalculate the soft-step lightness per-canvas. Applied via `restoreTheme()` on init and `applyThemeAnimated()` on user change.
+**Runtime applier** — `applyAccent(root, prefs, scheme)` writes the five accent vars (`--color-brand`, `--color-brand-soft`, `--color-brand-2`, `--color-brand-2-soft`, `--color-action-foreground`) to `<html>.style` before paint, or clears them for `'default'`. The applier derives `color2` via `prefs.accentColor2 ?? rotateHueHex(color, -30)` (with helper `rotateHueHex()` from `packages/ui/src/lib/color.ts` performing HSL hue rotation), recalculates both soft steps per-canvas, and auto-contrasts the foreground label color. The applier is idempotent and re-runs on scheme changes (light/dark swap). Applied via `restoreTheme()` on init and `applyThemeAnimated()` on user change.
 
 **User picker** — Settings → Appearance card (`apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx`) offers:
 
-- Default chip + 8 preset macOS-style swatches + System chip (hidden when `supported:false`).
+- Default chip + 8 preset macOS-style swatches (each with hand-tuned `color2`) + System chip (hidden when `supported:false`).
+- Swatches preview the two-tone gradient (brand → brand-2), so users see the full accent effect before apply.
 - Persisted to `localStorage` as part of `ThemePrefs`.
 
 **One primary CTA per view** — to avoid visual noise and let the accent shine, each view has at most one `variant="primary"` button (the main action). Secondary actions use `variant="default"` (neutral, no accent).

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -172,15 +172,15 @@ A **single-source, user-customizable accent** system colllapses brand-color frag
 **Single point of derivation** — `--color-brand` in `packages/ui/src/css/tokens.css` is the sole accent. All derived colors compute from it at paint time:
 
 - **`--color-brand-soft`** — a lighter step for secondary accent text/icons (28% whiter on dark schemes, 16% on light to account for canvas contrast).
-- **`--color-brand-2` / `--color-brand-2-soft`** — gradient-end hue and its lighter variant, derived at runtime by `applyAccent()` in `packages/ui/src/lib/theme.ts`. Hand-tuned per preset (e.g. blue #007aff→#22d3ee), or auto-rotated via `rotateHueHex(color, -30)` for system/custom accents. Static default values (violet→indigo) are shipped in tokens.css and cleared for `accentSource:'default'`. The `ThemePrefs.accentColor2` optional field allows preset overrides.
-- **`--color-brand-dim`** — a darker tone for disabled/subtle states (derived via CSS `color-mix(–10%)`).
+- **`--color-brand-2` / `--color-brand-2-soft`** — gradient-end hue and its lighter variant. Hand-tuned per preset (e.g. blue #007aff→#22d3ee) or auto-derived via `rotateHueHex()` in `packages/ui/src/lib/color.ts` for system/custom accents. Derived at runtime by `applyAccent()` in `packages/ui/src/lib/theme.ts`; see `ThemePrefs.accentColor2` for preset overrides.
+- **`--color-brand-dim`** — a darker tone for disabled/subtle states.
 - **`--color-action-primary`** — alias for brand (the signature CTA color); semantic, never diverges.
 - **`ring-brand`** — the focus ring (2px brand outline on focus-visible buttons/inputs).
-- **Brand glows and gradients** (`.text-gradient`, `.gradient-border`, `.glass-violet`, `.glass-indigo`, aurora ribbons/nebulae) — all derive via `color-mix` in `utilities.css` or inline CSS, referencing `var(--color-brand)` / `var(--color-brand-2)`, so they auto-adjust with the accent.
+- **Brand glows and gradients** (`.text-gradient`, `.gradient-border`, `.glass-violet`, `.glass-indigo`, aurora ribbons/nebulae) — all reference `var(--color-brand)` / `var(--color-brand-2)` via `color-mix` in `utilities.css` or inline CSS, so they auto-adjust with the accent.
 
-**Auto-contrast for legibility** — `--color-action-foreground` is computed at runtime by `applyAccent()` in `packages/ui/src/lib/theme.ts` using `readableForeground()` from `packages/ui/src/lib/color.ts`. The function applies WCAG luminance (`> 0.55 → dark label; ≤ 0.55 → white label`) so filled primary CTAs remain readable on any accent (pale lavender accents get `#1d1d1f` labels; deep indigo accents get `#ffffff`).
+**Auto-contrast for legibility** — `--color-action-foreground` is computed by `readableForeground()` from `packages/ui/src/lib/color.ts`, applied at runtime by `applyAccent()` in `packages/ui/src/lib/theme.ts`. So filled primary CTAs remain readable on any accent.
 
-**Runtime applier** — `applyAccent(root, prefs, scheme)` writes the five accent vars (`--color-brand`, `--color-brand-soft`, `--color-brand-2`, `--color-brand-2-soft`, `--color-action-foreground`) to `<html>.style` before paint, or clears them for `'default'`. The applier derives `color2` via `prefs.accentColor2 ?? rotateHueHex(color, -30)` (with helper `rotateHueHex()` from `packages/ui/src/lib/color.ts` performing HSL hue rotation), recalculates both soft steps per-canvas, and auto-contrasts the foreground label color. The applier is idempotent and re-runs on scheme changes (light/dark swap). Applied via `restoreTheme()` on init and `applyThemeAnimated()` on user change.
+**Runtime applier** — `applyAccent()` in `packages/ui/src/lib/theme.ts` writes the five accent vars to `<html>.style` before paint, or clears them for `'default'`. It is idempotent and re-runs on scheme changes (light/dark swap). See `ACCENT_VARS` in theme.ts for the full list.
 
 **User picker** — Settings → Appearance card (`apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx`) offers:
 

--- a/docs/knowledge/decision-records/adr-018-revive-accent-tinted-aurora-ambient-background.md
+++ b/docs/knowledge/decision-records/adr-018-revive-accent-tinted-aurora-ambient-background.md
@@ -26,15 +26,15 @@ All layers reference `--color-brand` / `--color-brand-2` via `color-mix` in CSS 
 
 ### Performance mode gating
 
-- **`low-memory`** — renders nothing; the aurora component returns null.
-- **`balanced`** — one nebula, cursor glow only; no parallax or streaming animations.
-- **`performance`** — adds a second nebula; cursor glow applies transform-only keyframes (no JavaScript loop).
+- **`low-memory`** — renders nothing; the component returns null.
+- **`balanced`** — renders one nebula + cursor glow RAF loop; no second nebula.
+- **`performance`** — adds a second nebula; cursor glow RAF loop is active in both modes.
 
-The cursor glow's RAF loop is paused when the tab is hidden (`visibilitychange` listener) to avoid frame burn on background tabs.
+All aurora/nebula animation uses transform-only CSS keyframes (no layout thrashing). The cursor glow's RAF loop is paused when the tab is hidden (`visibilitychange` listener) to avoid frame burn on background tabs.
 
 ### Accessibility
 
-- All animation is disabled under `prefers-reduced-motion` CSS media query.
+- Under `prefers-reduced-motion`, the CSS aurora/nebula keyframes are disabled via `@media (prefers-reduced-motion: reduce)` in `utilities.css`, and the cursor-glow RAF loop is skipped in JS (the glow is painted once, static, at viewport center).
 - Cursor glow position is seeded to viewport center on init, so blob doesn't slide in from (0,0) on first paint.
 
 ### Implementation

--- a/docs/knowledge/decision-records/adr-018-revive-accent-tinted-aurora-ambient-background.md
+++ b/docs/knowledge/decision-records/adr-018-revive-accent-tinted-aurora-ambient-background.md
@@ -1,0 +1,90 @@
+# ADR-018: Revive accent-tinted aurora ambient background
+
+Last updated: 2026-06-14
+
+**Status:** Accepted
+
+## Context
+
+The aurora/cinematic backdrop was removed in commit `8688eb91` ("apple design system + UX overhaul") as part of restraint-driven design and performance optimization. At that time, `CinematicBackground` became a flat fill, shedding parallax orbs, streaks, grid, film-grain, and the animated aurora ribbons + nebulae.
+
+The two-tone accent-gradient work (brand → brand-2 hue pair) introduced a visual opportunity: a living accent-tinted surface for the gradient to inhabit. The flat backdrop had become inert with respect to the customizable accent, making it visually disconnected from user personalization choices.
+
+## Decision
+
+Revive a **slim aurora** as the ambient backdrop, constrained to performance and a11y guardrails:
+
+### Layer stack (back → front)
+
+1. **Aurora ribbons** — three slow, wide, hue-rotating CSS keyframe blobs, deriving color from `--color-brand` + `--color-brand-2`.
+2. **Nebulae** — one (balanced mode) or two (performance mode) medium blobs, same color family.
+3. **Cursor glow** — a 900px lerp-smoothed JavaScript blob that trails the pointer, mixing `--color-brand` / `--color-brand-2` inline.
+
+### Color derivation
+
+All layers reference `--color-brand` / `--color-brand-2` via `color-mix` in CSS or inline application, so the entire aurora re-tints whenever the user changes the accent (via Settings → Appearance). The static defaults (violet → indigo, `#a855f7` → `#6366f1`) are shipped in `packages/ui/src/css/tokens.css` and override to match the runtime accent (via `applyAccent()` in `packages/ui/src/lib/theme.ts`).
+
+### Performance mode gating
+
+- **`low-memory`** — renders nothing; the aurora component returns null.
+- **`balanced`** — one nebula, cursor glow only; no parallax or streaming animations.
+- **`performance`** — adds a second nebula; cursor glow applies transform-only keyframes (no JavaScript loop).
+
+The cursor glow's RAF loop is paused when the tab is hidden (`visibilitychange` listener) to avoid frame burn on background tabs.
+
+### Accessibility
+
+- All animation is disabled under `prefers-reduced-motion` CSS media query.
+- Cursor glow position is seeded to viewport center on init, so blob doesn't slide in from (0,0) on first paint.
+
+### Implementation
+
+- **React component:** `apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx`.
+- **Styles:** CSS keyframes + tokens in `packages/ui/src/css/tokens.css` (`--aurora-*`, `--nebula-*` vars) and `utilities.css` (`.aurora-ribbon`, `.nebula`, `.cursor-glow` classes).
+- **Theme integration:** `applyAccent()` and `restoreTheme()` already handle the brand/brand-2 tokens; the aurora consumes them via CSS variable reference, requiring no new IPC or store updates.
+
+## Consequences
+
+- **Brand vitality** returns as a living, interactive accent-driven backdrop. Users immediately see the visual effect of accent changes in Settings.
+- **Accent visibility** — the two-tone gradient now has a clear, persistent surface to inhabit (aurora ribbons + nebulae), reinforcing personalization.
+- **Performance trade-off** — a re-added (but bounded) animated layer set. Mitigations:
+  - Slim layer count (3 blobs + cursor glow; no parallax/streaks/grid/film-grain/vignette from the original).
+  - Transform-only keyframes (no layout thrashing).
+  - RAF loop on cursor glow uses 0.5% lerp per frame (extremely slow, no jank).
+  - Gated by existing Performance Mode — users on low-memory see zero overhead.
+  - Reduced-motion users see static blobs (no animation).
+- **Reversibility** — the aurora can be disabled by removing the `CinematicBackground` component call or returning null unconditionally; no cascading refactors needed.
+
+## Trade-offs Evaluated
+
+### Revive aurora vs. keep flat fill
+
+**Chosen:** Revive (slim, constrained).
+
+- Flat fill is inert w.r.t. accent customization; the new gradient work goes unseen at the UI boundary.
+- Full revived aurora (parallax, streaks, grid, grain, vignette) was removed for good reasons (performance, restraint); selective revival of 3 blobs + cursor glow splits the difference.
+- Layer count and RAF loop are measurably less costly than the original (no `Math.random()` per frame, no SVG filters, no parallax matrix math).
+
+### Animating aurora via CSS vs. RAF
+
+**Chosen:** CSS keyframes (aurora/nebulae), RAF for cursor glow only.
+
+- CSS animation on static blobs scales to any device; RAF loop on pointer-tracking is per-device latency-aware (0.5% lerp doesn't block main thread).
+- Decoupling allows low-memory mode to drop the entire component (no RAF setup) without disabling static blobs.
+
+### Cursor glow lerp factor (0.5% per frame)
+
+**Chosen:** 0.5% (0.005 multiplier).
+
+- 0.005 is ~60fps-responsive (at 200 lerp frames, blob reaches ~63% of target distance). Slower than typical UI feedback.
+- Faster (e.g. 0.02) feels snappy but cancels the "dreamy" effect; slower (e.g. 0.001) feels laggy on rapid pointer movement.
+- No tuning in settings (fixed); breakpoints (low-memory) disable it entirely rather than expose a slider.
+
+## References
+
+- **Revived component:** `apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx`.
+- **Token definitions:** `packages/ui/src/css/tokens.css` (aurora/nebula color vars) + `packages/ui/src/css/utilities.css` (aurora/nebula/cursor-glow classes).
+- **Accent derivation:** `packages/ui/src/lib/theme.ts` (`applyAccent()`) + `packages/ui/src/lib/color.ts` (`rotateHueHex()` hue rotation helper).
+- **Commit that introduced two-tone accents:** feat: derive two-tone accent gradients and revive accent-tinted aurora.
+- **Commit that originally removed aurora:** `8688eb91` (apple design system + UX overhaul).
+- **Related ADR:** ADR-017 (persisted caches); ADR-004 (ports and adapters / theming concerns).

--- a/landing/index.html
+++ b/landing/index.html
@@ -784,7 +784,7 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
   <p class="footnote">macOS will say the app is "damaged." it's not damaged. it's just unsigned — like a contract I was never offered. run <code>xattr -cr</code> and we move on.</p>
   <p class="builtwith">Tauri · Rust · React 19 · TanStack · LanceDB · Typst · Ollama · pure spite</p>
   <p class="byline">made by Saeed, between rejections.</p>
-  <p class="footnote"><a href="privacy.html" style="color:#6f6650">Privacy</a> — we don't track you, we can barely track ourselves.</p>
+  <p class="footnote"><a href="privacy.html" style="color:#6f6650">Privacy</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener" style="color:#6f6650">Chrome extension</a> — we don't track you, we can barely track ourselves.</p>
   <svg class="inkline draw" style="width:24px; margin-top:10px" viewBox="0 0 30 28" aria-hidden="true"><path pathLength="1" d="M15 24 C5 16 2 9 8 5 q5 -3 7 4 q2 -7 7 -4 c6 4 3 11 -7 19 Z" style="stroke-width:2.4"/></svg>
 </section>
 

--- a/packages/ui/src/components/Button/Button.test.tsx
+++ b/packages/ui/src/components/Button/Button.test.tsx
@@ -44,6 +44,23 @@ describe('Button', () => {
     expect(btn.className).toContain('h-10');
   });
 
+  // ── accent-gradient assertions (feat/accent-gradients) ──────────────────────
+
+  it('variant="primary" carries bg-brand-gradient and text-action-foreground (NOT bg-action-primary)', () => {
+    render(<Button variant="primary">CTA</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('bg-brand-gradient');
+    expect(btn.className).toContain('text-action-foreground');
+    expect(btn.className).not.toContain('bg-action-primary');
+  });
+
+  it('variant="run" still carries its solid bg-action-run token (unchanged by accent-gradient sweep)', () => {
+    render(<Button variant="run">Run</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('bg-action-run');
+    expect(btn.className).toContain('text-action-foreground');
+  });
+
   it('injects no chrome for the unstyled variant but keeps a11y essentials', () => {
     render(
       <Button variant="unstyled" className="custom-surface">

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import { cn } from '../../lib/cn';
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * Apple-grammar variants:
-   * - `primary` — the signature solid violet CTA (action-primary token, rounded utility radius).
+   * - `primary` — the signature two-tone accent CTA (action-primary token, rounded utility radius).
    * - `run` / `edit` / `delete` — solid colorful action pills (semantic colour,
    *   the deliberate divergence from Apple's single-accent rule; tokens only).
    * - `default` / `glass` / `ghost` — neutral utility buttons (rounded, not pill).
@@ -59,7 +59,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
           // Filled Apple actions — solid colour + white label (tokens only, no hex)
           variant === 'primary' && [
-            'bg-action-primary text-action-foreground',
+            'bg-brand-gradient text-action-foreground',
             'hover:brightness-110',
           ],
           variant === 'run' && ['bg-action-run text-action-foreground', 'hover:brightness-110'],

--- a/packages/ui/src/components/FloatingIcon/FloatingIcon.tsx
+++ b/packages/ui/src/components/FloatingIcon/FloatingIcon.tsx
@@ -22,9 +22,9 @@ export function FloatingIcon({ icon: Icon, size = 24, children }: FloatingIconPr
         className="relative flex h-14 w-14 items-center justify-center rounded-2xl"
         style={{
           background:
-            'linear-gradient(135deg, rgba(168,85,247,0.25) 0%, rgba(99,102,241,0.15) 100%)',
-          border: '1px solid rgba(168,85,247,0.3)',
-          boxShadow: '0 0 32px rgba(168,85,247,0.2)',
+            'linear-gradient(135deg, color-mix(in srgb, var(--color-brand) 25%, transparent) 0%, color-mix(in srgb, var(--color-brand-2) 15%, transparent) 100%)',
+          border: '1px solid color-mix(in srgb, var(--color-brand) 30%, transparent)',
+          boxShadow: '0 0 32px color-mix(in srgb, var(--color-brand) 20%, transparent)',
         }}
       >
         {children || <Icon size={size} className="text-brand-soft" />}

--- a/packages/ui/src/components/HoverPopover/HoverPopover.test.tsx
+++ b/packages/ui/src/components/HoverPopover/HoverPopover.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * HoverPopover — structural tests (feat/accent-gradients).
+ *
+ * Strategy:
+ *  - motion/react is globally shimmed in vitest.setup.ts — AnimatePresence
+ *    passes children through synchronously, so the portalled panel is visible
+ *    immediately after mouseenter without any async wait.
+ *  - createPortal renders into document.body; screen queries search the full
+ *    document so role="tooltip" is always reachable.
+ *  - getBoundingClientRect returns zeros in jsdom — the component detects a
+ *    null rect and sets `display:none` on the panel until a non-zero rect is
+ *    available. We stub getBoundingClientRect on the wrapper element to return
+ *    a realistic rect so panelStyle resolves to `position:fixed` with real
+ *    coordinates and the paddingBottom branch exercises correctly.
+ *  - We NEVER assert on gradient CSS values (jsdom cssstyle gotcha).
+ *    Assertions are structural: role, className tokens, inline paddingBottom.
+ *
+ * Covers (placement="top"):
+ *  - Trigger open via mouseenter on the wrapper.
+ *  - Portalled panel gets role="tooltip".
+ *  - Panel element itself does NOT carry contentClassName (it lives on the
+ *    inner wrapper div).
+ *  - Inner wrapper div carries contentClassName.
+ *  - Panel has inline paddingBottom set (the 8 px pointer-bridge gap).
+ *  - Content text is accessible inside the element bearing contentClassName.
+ *  - Esc closes the panel.
+ *  - placement="bottom": panel has inline paddingTop instead of paddingBottom.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { HoverPopover } from './HoverPopover';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/** Stub getBoundingClientRect on whatever element is returned by wrapperRef. */
+function stubRect(container: HTMLElement, rect: Partial<DOMRect> = {}) {
+  const defaultRect: DOMRect = {
+    top: 200,
+    bottom: 220,
+    left: 100,
+    right: 300,
+    width: 200,
+    height: 20,
+    x: 100,
+    y: 200,
+    toJSON: () => ({}),
+  };
+  const el = container.firstChild as HTMLElement;
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({ ...defaultRect, ...rect });
+}
+
+function renderPopover(
+  overrides: {
+    placement?: 'top' | 'bottom';
+    contentClassName?: string;
+    ariaLabel?: string;
+    children?: React.ReactNode;
+  } = {}
+) {
+  const {
+    placement = 'top',
+    contentClassName = 'popover-content',
+    ariaLabel = 'Activity popover',
+    children = <span>Panel content</span>,
+  } = overrides;
+
+  const result = render(
+    <HoverPopover
+      trigger={<button type="button">Trigger</button>}
+      placement={placement}
+      contentClassName={contentClassName}
+      ariaLabel={ariaLabel}
+    >
+      {children}
+    </HoverPopover>
+  );
+
+  return result;
+}
+
+/** Open the popover by firing mouseenter on the outermost wrapper div. */
+function openPopover(container: HTMLElement) {
+  stubRect(container);
+  const wrapper = container.firstChild as HTMLElement;
+  fireEvent.mouseEnter(wrapper);
+}
+
+// ── reset ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── open / close mechanics ────────────────────────────────────────────────────
+
+describe('HoverPopover — open/close', () => {
+  it('panel is not in the document before mouseenter', () => {
+    renderPopover();
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('panel appears in the document after mouseenter on the wrapper', () => {
+    const { container } = renderPopover();
+    openPopover(container);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('pressing Escape closes the panel', () => {
+    const { container } = renderPopover();
+    openPopover(container);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    const wrapper = container.firstChild as HTMLElement;
+    fireEvent.keyDown(wrapper, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+});
+
+// ── placement="top" structural assertions ─────────────────────────────────────
+
+describe('HoverPopover — placement="top" structure', () => {
+  it('panel has inline paddingBottom (the 8px pointer-bridge gap)', () => {
+    const { container } = renderPopover({ placement: 'top' });
+    openPopover(container);
+
+    const panel = screen.getByRole('tooltip');
+    // paddingBottom is set as a numeric px value via React inline style.
+    expect(panel).toHaveStyle({ paddingBottom: '8px' });
+  });
+
+  it('panel element itself does NOT carry contentClassName', () => {
+    const { container } = renderPopover({ placement: 'top', contentClassName: 'my-content' });
+    openPopover(container);
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel.className).not.toContain('my-content');
+  });
+
+  it('inner wrapper div carries contentClassName', () => {
+    const { container } = renderPopover({ placement: 'top', contentClassName: 'my-content' });
+    openPopover(container);
+
+    // The inner <div> is the direct child of role="tooltip".
+    const panel = screen.getByRole('tooltip');
+    const inner = panel.firstElementChild as HTMLElement;
+    expect(inner).not.toBeNull();
+    expect(inner.className).toContain('my-content');
+  });
+
+  it('content text is accessible inside the element with contentClassName', () => {
+    const { container } = renderPopover({
+      placement: 'top',
+      contentClassName: 'my-content',
+      children: <span>Hello world</span>,
+    });
+    openPopover(container);
+
+    const inner = screen.getByRole('tooltip').firstElementChild as HTMLElement;
+    expect(inner).toHaveTextContent('Hello world');
+  });
+});
+
+// ── placement="bottom" structure ──────────────────────────────────────────────
+
+describe('HoverPopover — placement="bottom" structure', () => {
+  it('panel has inline paddingTop (not paddingBottom) for bottom placement', () => {
+    const { container } = renderPopover({ placement: 'bottom' });
+    openPopover(container);
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel).toHaveStyle({ paddingTop: '8px' });
+    // paddingBottom must NOT be set for bottom placement
+    const styleAttr = panel.getAttribute('style') ?? '';
+    expect(styleAttr).not.toMatch(/padding-bottom\s*:\s*8/);
+  });
+
+  it('panel element itself does NOT carry contentClassName for bottom placement', () => {
+    const { container } = renderPopover({
+      placement: 'bottom',
+      contentClassName: 'bottom-content',
+    });
+    openPopover(container);
+
+    const panel = screen.getByRole('tooltip');
+    expect(panel.className).not.toContain('bottom-content');
+  });
+});
+
+// ── aria wiring ───────────────────────────────────────────────────────────────
+
+describe('HoverPopover — aria wiring', () => {
+  it('wrapper has aria-expanded=false before open', () => {
+    const { container } = renderPopover();
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('wrapper has aria-expanded=true while panel is open', () => {
+    const { container } = renderPopover();
+    openPopover(container);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('panel carries the ariaLabel supplied via prop', () => {
+    const { container } = renderPopover({ ariaLabel: 'Worker activity' });
+    openPopover(container);
+    expect(screen.getByRole('tooltip', { name: 'Worker activity' })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/HoverPopover/HoverPopover.tsx
+++ b/packages/ui/src/components/HoverPopover/HoverPopover.tsx
@@ -103,8 +103,8 @@ export function HoverPopover({
         left: rect.left,
         zIndex: 9999,
         ...(placement === 'top'
-          ? { bottom: window.innerHeight - rect.top + 8 }
-          : { top: rect.bottom + 8 }),
+          ? { bottom: window.innerHeight - rect.top, paddingBottom: 8 }
+          : { top: rect.bottom, paddingTop: 8 }),
       }
     : { display: 'none' };
 
@@ -134,9 +134,8 @@ export function HoverPopover({
               style={panelStyle}
               onMouseEnter={cancelClose}
               onMouseLeave={scheduleClose}
-              className={contentClassName}
             >
-              {children}
+              <div className={contentClassName}>{children}</div>
             </motion.div>
           )}
         </AnimatePresence>,

--- a/packages/ui/src/components/NavPill/NavPill.test.tsx
+++ b/packages/ui/src/components/NavPill/NavPill.test.tsx
@@ -21,3 +21,37 @@ describe('NavPill', () => {
     expect((container.firstChild as HTMLElement).className).toContain('rounded-full');
   });
 });
+
+// ── accent-gradient token assertions (feat/accent-gradients) ──────────────────
+//
+// jsdom's cssstyle drops/normalises linear-gradient and color-mix values, so
+// reading el.style.background is unreliable across the full-suite run.
+// Instead we read the raw `style` attribute string, which preserves the
+// authored text exactly as React serialises it to the DOM attribute.
+
+describe('NavPill — accent-gradient tokens', () => {
+  it('inline style references var(--color-brand) for background/border/boxShadow', () => {
+    const { container } = render(<NavPill layoutId="accent-test" />);
+    const pill = container.firstChild as HTMLElement;
+    const styleAttr = pill.getAttribute('style') ?? '';
+
+    // All three CSS properties must use the design-token CSS variable, not raw RGB.
+    expect(styleAttr).toContain('--color-brand');
+  });
+
+  it('inline style does NOT contain the old hardcoded RGB values (168, 85, 247)', () => {
+    const { container } = render(<NavPill layoutId="accent-test-no-hex" />);
+    const styleAttr = (container.firstChild as HTMLElement).getAttribute('style') ?? '';
+
+    // Neither space-separated nor comma-only form of the old purple RGB literal.
+    expect(styleAttr).not.toContain('168, 85, 247');
+    expect(styleAttr).not.toContain('168,85,247');
+  });
+
+  it('inline background references var(--color-brand-2) for the gradient end-stop', () => {
+    const { container } = render(<NavPill layoutId="accent-brand2-test" />);
+    const styleAttr = (container.firstChild as HTMLElement).getAttribute('style') ?? '';
+
+    expect(styleAttr).toContain('--color-brand-2');
+  });
+});

--- a/packages/ui/src/components/NavPill/NavPill.tsx
+++ b/packages/ui/src/components/NavPill/NavPill.tsx
@@ -17,7 +17,7 @@ export interface NavPillProps {
  * Animated active-row indicator for vertical nav lists (app sidebar, settings
  * sidebar). Render it conditionally — only for the active row — as the first
  * child of a `relative` wrapper, with the clickable row as its sibling above.
- * The violet glass pill slides between rows via motion's shared-layout
+ * The accent glass pill slides between rows via motion's shared-layout
  * animation keyed on {@link NavPillProps.layoutId}. Decorative: the active
  * state is conveyed to assistive tech by `aria-current` on the row itself.
  */
@@ -28,9 +28,10 @@ export function NavPill({ layoutId, className }: NavPillProps) {
       layoutId={layoutId}
       className={cn('pointer-events-none absolute inset-0 rounded-xl', className)}
       style={{
-        background: 'linear-gradient(135deg, rgba(168,85,247,0.18) 0%, rgba(99,102,241,0.10) 100%)',
-        border: '1px solid rgba(168,85,247,0.25)',
-        boxShadow: '0 0 16px rgba(168,85,247,0.12)',
+        background:
+          'linear-gradient(135deg, color-mix(in srgb, var(--color-brand) 18%, transparent) 0%, color-mix(in srgb, var(--color-brand-2) 10%, transparent) 100%)',
+        border: '1px solid color-mix(in srgb, var(--color-brand) 25%, transparent)',
+        boxShadow: '0 0 16px color-mix(in srgb, var(--color-brand) 12%, transparent)',
       }}
       transition={transition.spring}
     />

--- a/packages/ui/src/css/tokens.css
+++ b/packages/ui/src/css/tokens.css
@@ -44,6 +44,10 @@
      re-tints. Semantic action (run/edit/delete) + status colors are NOT accent. */
   --color-brand: #a855f7;
   --color-brand-soft: #c084fc;
+  /* Gradient-end + its soft step (shipped indigo) — the static `default` accent
+     the runtime applier overrides for custom/system accents. */
+  --color-brand-2: #6366f1;
+  --color-brand-2-soft: #818cf8;
   --color-brand-dim: color-mix(in srgb, var(--color-brand) 15%, transparent);
 
   /* Native macOS font (San Francisco) where it exists — it can't be bundled, so
@@ -236,13 +240,15 @@
   /* Top-edge specular highlight — the bright hairline that reads as real glass. */
   --glass-specular: inset 0 1px 0 rgba(255, 255, 255, 0.22);
 
-  /* ── Aurora / nebula palette (for CinematicBackground) ───────────────── */
-  --aurora-violet: #a855f7;
-  --aurora-indigo: #6366f1;
-  --aurora-pink: #ec4899;
-  --aurora-cyan: #22d3ee;
-  --nebula-violet: #c084fc;
-  --nebula-indigo: #818cf8;
+  /* ── Aurora / nebula palette (for CinematicBackground) — re-tints with the
+     accent: every hue derives from the brand family so non-violet accents stay
+     coherent (no off-accent pink/cyan). ─────────────────────────────────── */
+  --aurora-violet: var(--color-brand);
+  --aurora-indigo: var(--color-brand-2);
+  --aurora-pink: var(--color-brand-soft);
+  --aurora-cyan: var(--color-brand-2-soft);
+  --nebula-violet: var(--color-brand-soft);
+  --nebula-indigo: var(--color-brand-2-soft);
   /* ── RGB aliases for brand colors (used in gradients) */
   --rgb-brand: 168 85 247;
   --rgb-aurora-indigo: 99 102 241;
@@ -299,6 +305,9 @@
      to ~#7C3AED (still the same violet family, just legible on white). */
   --color-brand: #7c3aed;
   --color-brand-soft: #8b5cf6;
+  /* Gradient-end deepened for light (legible on white, matching the brand step). */
+  --color-brand-2: #4f46e5;
+  --color-brand-2-soft: #6366f1;
   --color-brand-dim: color-mix(in srgb, var(--color-brand) 12%, transparent);
   --color-primary: oklch(50% 58% 285);
   --color-primary-foreground: oklch(99% 0.15% 270);
@@ -401,11 +410,12 @@
   --glow-brand-md: 0 0 36px rgba(124, 58, 237, 0.14);
   --glow-blue-md: 0 0 36px rgba(79, 70, 229, 0.14);
 
-  /* Pastel the cinematic aurora so the light canvas stays calm and readable. */
-  --aurora-violet: #c9b1f7;
-  --aurora-indigo: #adb6f7;
-  --aurora-pink: #f3bcd8;
-  --aurora-cyan: #aee5ef;
-  --nebula-violet: #dcccfb;
-  --nebula-indigo: #c1c8f7;
+  /* Pastel the cinematic aurora so the light canvas stays calm and readable —
+     each hue is the matching brand var softened toward white so it re-tints. */
+  --aurora-violet: color-mix(in srgb, var(--color-brand) 55%, white);
+  --aurora-indigo: color-mix(in srgb, var(--color-brand-2) 55%, white);
+  --aurora-pink: color-mix(in srgb, var(--color-brand-soft) 55%, white);
+  --aurora-cyan: color-mix(in srgb, var(--color-brand-2-soft) 55%, white);
+  --nebula-violet: color-mix(in srgb, var(--color-brand-soft) 45%, white);
+  --nebula-indigo: color-mix(in srgb, var(--color-brand-2-soft) 45%, white);
 }

--- a/packages/ui/src/css/utilities.css
+++ b/packages/ui/src/css/utilities.css
@@ -41,7 +41,7 @@
 
 /* ── Cinematic gradient text ─────────────────────────────────────────────── */
 .text-gradient {
-  background: linear-gradient(135deg, #fff 0%, #a855f7 50%, #6366f1 100%);
+  background: linear-gradient(135deg, #fff 0%, var(--color-brand) 50%, var(--color-brand-2) 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -121,18 +121,26 @@
 
 /* ── Tonal glass variants ────────────────────────────────────────────────── */
 .glass-violet {
-  background: linear-gradient(135deg, rgba(168, 139, 250, 0.08) 0%, rgba(99, 102, 241, 0.04) 100%);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-brand) 8%, transparent) 0%,
+    color-mix(in srgb, var(--color-brand-2) 4%, transparent) 100%
+  );
   backdrop-filter: blur(var(--blur-md)) saturate(var(--sat-high));
   -webkit-backdrop-filter: blur(var(--blur-md)) saturate(var(--sat-high));
-  border: 1px solid rgba(196, 181, 253, 0.1);
+  border: 1px solid color-mix(in srgb, var(--color-brand-soft) 10%, transparent);
   border-radius: var(--radius);
   box-shadow: var(--shadow-2xl), var(--glow-brand-md);
 }
 .glass-indigo {
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.08) 0%, rgba(59, 130, 246, 0.04) 100%);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-brand-2) 8%, transparent) 0%,
+    color-mix(in srgb, var(--color-brand-2-soft) 4%, transparent) 100%
+  );
   backdrop-filter: blur(var(--blur-md)) saturate(var(--sat-high));
   -webkit-backdrop-filter: blur(var(--blur-md)) saturate(var(--sat-high));
-  border: 1px solid rgba(165, 180, 252, 0.1);
+  border: 1px solid color-mix(in srgb, var(--color-brand-2-soft) 10%, transparent);
   border-radius: var(--radius);
   box-shadow: var(--shadow-2xl), var(--glow-blue-md);
 }
@@ -190,7 +198,7 @@
   position: absolute;
   inset: 0;
   border-radius: var(--radius);
-  background: linear-gradient(45deg, #a855f7, #6366f1, #a855f7);
+  background: linear-gradient(45deg, var(--color-brand), var(--color-brand-2), var(--color-brand));
   z-index: -1;
   animation: gradient-rotate 3s linear infinite;
 }
@@ -701,7 +709,12 @@ html[data-text-scale='large'] {
   background: linear-gradient(to right, transparent, rgba(255, 255, 255, 0.85), transparent);
 }
 [data-color-scheme='light'] .text-gradient {
-  background: linear-gradient(135deg, #1e1b2e 0%, #7c3aed 50%, #4f46e5 100%);
+  background: linear-gradient(
+    135deg,
+    #1e1b2e 0%,
+    var(--color-brand) 50%,
+    var(--color-brand-2) 100%
+  );
   -webkit-background-clip: text;
   background-clip: text;
 }

--- a/packages/ui/src/css/utilities.css
+++ b/packages/ui/src/css/utilities.css
@@ -46,6 +46,9 @@
   background-clip: text;
   color: transparent;
 }
+.bg-brand-gradient {
+  background-image: linear-gradient(135deg, var(--color-brand), var(--color-brand-2));
+}
 
 /* ── Glass elevation scale ───────────────────────────────────────────────── */
 /*
@@ -752,11 +755,14 @@ html[data-text-scale='large'] {
   border-color: var(--border-soft);
 }
 
-/* In light mode the sidebar is a white panel (the card tone) floating on the
-   gray canvas — its glass border + shadow lift it off the page, matching the
-   white content cards rather than blending into the gray backdrop. */
 [data-color-scheme='light'] .app-sidebar {
+  /* Same flat surface as the content cards (.surface-card): one source —
+     --color-card fill + --border-soft hairline, no shadow/blur. */
   background: var(--color-card);
+  border-color: var(--border-soft);
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 /* The main content area is a near-opaque white panel in dark mode (intended),

--- a/packages/ui/src/lib/color.test.ts
+++ b/packages/ui/src/lib/color.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { lighten, lightenHex, luminance, parseHex, readableForeground, toHex } from './color';
+import {
+  lighten,
+  lightenHex,
+  luminance,
+  parseHex,
+  readableForeground,
+  rotateHueHex,
+  toHex,
+} from './color';
 
 describe('parseHex', () => {
   it('parses #rrggbb', () => {
@@ -63,5 +71,102 @@ describe('readableForeground', () => {
   });
   it('returns null on invalid input', () => {
     expect(readableForeground('nope')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotateHueHex
+// ---------------------------------------------------------------------------
+
+/** Derive hue in degrees [0, 360) from a #rrggbb string. Returns -1 when invalid. */
+function hueFromHex(hex: string): number {
+  const rgb = parseHex(hex);
+  if (!rgb) return -1;
+  const r = rgb.r / 255;
+  const g = rgb.g / 255;
+  const b = rgb.b / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  if (d === 0) return 0; // achromatic
+  let h: number;
+  if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  return (h * 60 + 360) % 360;
+}
+
+describe('rotateHueHex', () => {
+  it('violet #a855f7 rotated -30° lands in the indigo/blue family (~240°)', () => {
+    const result = rotateHueHex('#a855f7', -30);
+    expect(result).not.toBeNull();
+    // Result must be a valid #rrggbb and different from the input.
+    expect(result).toMatch(/^#[0-9a-f]{6}$/);
+    expect(result).not.toBe('#a855f7');
+    // Hue must be near 240° (±6° tolerance to absorb rounding).
+    const hue = hueFromHex(result ?? '');
+    expect(Math.abs(hue - 240)).toBeLessThanOrEqual(6);
+  });
+
+  it('a 0° rotation returns the same color within rounding', () => {
+    const input = '#a855f7';
+    const result = rotateHueHex(input, 0);
+    expect(result).not.toBeNull();
+    // Round-trip: parse both and compare channels within ±1 (integer rounding).
+    const orig = parseHex(input);
+    if (!orig) throw new Error(`parseHex failed for known-valid input: ${input}`);
+    const got = parseHex(result ?? '');
+    if (!got) throw new Error(`parseHex failed for rotateHueHex result: ${result}`);
+    expect(Math.abs(got.r - orig.r)).toBeLessThanOrEqual(1);
+    expect(Math.abs(got.g - orig.g)).toBeLessThanOrEqual(1);
+    expect(Math.abs(got.b - orig.b)).toBeLessThanOrEqual(1);
+  });
+
+  it('a 360° rotation returns the same color within rounding', () => {
+    const input = '#34c759';
+    const result = rotateHueHex(input, 360);
+    expect(result).not.toBeNull();
+    const orig = parseHex(input);
+    if (!orig) throw new Error(`parseHex failed for known-valid input: ${input}`);
+    const got = parseHex(result ?? '');
+    if (!got) throw new Error(`parseHex failed for rotateHueHex result: ${result}`);
+    expect(Math.abs(got.r - orig.r)).toBeLessThanOrEqual(1);
+    expect(Math.abs(got.g - orig.g)).toBeLessThanOrEqual(1);
+    expect(Math.abs(got.b - orig.b)).toBeLessThanOrEqual(1);
+  });
+
+  it('hue wrap-around: near-red #ff3b30 rotated -30° gives a valid hex shifted toward magenta', () => {
+    // #ff3b30 is a red (hue ~3°). Rotating -30° wraps to ~333°, the magenta/pink
+    // range where blue > red channel gap is smaller (blue grows, hue shifts left).
+    const result = rotateHueHex('#ff3b30', -30);
+    expect(result).not.toBeNull();
+    expect(result).toMatch(/^#[0-9a-f]{6}$/);
+    // After rotating toward magenta the blue channel must have grown vs the input.
+    const orig = parseHex('#ff3b30');
+    if (!orig) throw new Error('parseHex failed for known-valid input: #ff3b30');
+    const got = parseHex(result ?? '');
+    if (!got) throw new Error(`parseHex failed for rotateHueHex result: ${result}`);
+    expect(got.b).toBeGreaterThan(orig.b);
+    // Result must still be a valid hex — no NaN / clamped-to-black artefact.
+    expect(got.r + got.g + got.b).toBeGreaterThan(0);
+  });
+
+  it('invalid inputs return null', () => {
+    expect(rotateHueHex('nope', -30)).toBeNull();
+    expect(rotateHueHex('#12', 10)).toBeNull();
+    expect(rotateHueHex('', 0)).toBeNull();
+  });
+
+  it('achromatic input (#808080) returns a valid hex that is still achromatic', () => {
+    // Saturation is 0 for pure grays, so rotating the hue is a mathematical
+    // no-op: S=0 means all channels must remain equal after the round-trip.
+    const result = rotateHueHex('#808080', -30);
+    expect(result).not.toBeNull();
+    expect(result).toMatch(/^#[0-9a-f]{6}$/);
+    const got = parseHex(result ?? '');
+    if (!got) throw new Error(`parseHex failed for rotateHueHex result: ${result}`);
+    // All channels equal within ±1 (rounding only).
+    expect(Math.abs(got.r - got.g)).toBeLessThanOrEqual(1);
+    expect(Math.abs(got.g - got.b)).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/ui/src/lib/color.ts
+++ b/packages/ui/src/lib/color.ts
@@ -67,3 +67,58 @@ export function readableForeground(hex: string): string | null {
   if (!rgb) return null;
   return luminance(rgb) > 0.55 ? '#1d1d1f' : '#ffffff';
 }
+
+/**
+ * Accent gradient math
+ * ─────────────────────────────────────────────────────────────────────────
+ * Hue rotation lets a single accent hex spawn a coherent two-tone gradient
+ * end: rotate the hue, keep saturation + lightness, and the pair reads as the
+ * same family. Used by the theme engine to auto-derive --color-brand-2 when a
+ * preset/custom accent ships no hand-tuned second hex.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+/** RGB → HSL. h in degrees 0..360, s/l in 0..1. */
+function rgbToHsl(c: Rgb): { h: number; s: number; l: number } {
+  const r = c.r / 255;
+  const g = c.g / 255;
+  const b = c.b / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d === 0) return { h: 0, s: 0, l };
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  return { h: h * 60, s, l };
+}
+
+/** HSL → RGB. h in degrees, s/l in 0..1. */
+function hslToRgb(h: number, s: number, l: number): Rgb {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  // hp ∈ [0, 6) after normalization, so the sextant chain is exhaustive.
+  const sextant = (): [number, number, number] => {
+    if (hp < 1) return [c, x, 0];
+    if (hp < 2) return [x, c, 0];
+    if (hp < 3) return [0, c, x];
+    if (hp < 4) return [0, x, c];
+    if (hp < 5) return [x, 0, c];
+    return [c, 0, x];
+  };
+  const [r1, g1, b1] = sextant();
+  const m = l - c / 2;
+  return { r: (r1 + m) * 255, g: (g1 + m) * 255, b: (b1 + m) * 255 };
+}
+
+/** Rotate a hex's hue by `deg` (keeps S + L); null on invalid input. */
+export function rotateHueHex(hex: string, deg: number): string | null {
+  const rgb = parseHex(hex);
+  if (!rgb) return null;
+  const { h, s, l } = rgbToHsl(rgb);
+  return toHex(hslToRgb(h + deg, s, l));
+}

--- a/packages/ui/src/lib/color.ts
+++ b/packages/ui/src/lib/color.ts
@@ -115,10 +115,15 @@ function hslToRgb(h: number, s: number, l: number): Rgb {
   return { r: (r1 + m) * 255, g: (g1 + m) * 255, b: (b1 + m) * 255 };
 }
 
-/** Rotate a hex's hue by `deg` (keeps S + L); null on invalid input. */
+/**
+ * Rotate a hex's hue by `deg` (keeps S + L); null on invalid input. A non-finite
+ * `deg` (NaN/±Infinity) is a no-op that returns the normalized original rather
+ * than producing NaN channel garbage.
+ */
 export function rotateHueHex(hex: string, deg: number): string | null {
   const rgb = parseHex(hex);
   if (!rgb) return null;
+  if (!Number.isFinite(deg)) return toHex(rgb);
   const { h, s, l } = rgbToHsl(rgb);
   return toHex(hslToRgb(h + deg, s, l));
 }

--- a/packages/ui/src/lib/theme.test.ts
+++ b/packages/ui/src/lib/theme.test.ts
@@ -201,3 +201,93 @@ describe('theme engine — accent', () => {
     expect(darkSoft).not.toBe(lightSoft);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Gradient — two-tone accent vars (--color-brand-2 / --color-brand-2-soft)
+// ---------------------------------------------------------------------------
+
+describe('theme engine — accent gradient (brand-2)', () => {
+  const base: ThemePrefs = {
+    scheme: 'dark',
+    reduceTransparency: false,
+    contrast: 'normal',
+    textScale: 'default',
+    accentSource: 'default',
+  };
+  const cssVar = (name: string) => document.documentElement.style.getPropertyValue(name);
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.style.cssText = '';
+    stubMatchMedia({});
+  });
+  afterEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the hand-tuned accentColor2 verbatim when provided (custom with color2)', () => {
+    applyTheme({
+      ...base,
+      accentSource: 'custom',
+      accentColor: '#007aff',
+      accentColor2: '#22d3ee',
+    });
+    expect(cssVar('--color-brand')).toBe('#007aff');
+    expect(cssVar('--color-brand-2')).toBe('#22d3ee');
+  });
+
+  it('auto-rotates to a distinct brand-2 when accentColor2 is absent (custom without color2)', () => {
+    applyTheme({
+      ...base,
+      accentSource: 'custom',
+      accentColor: '#007aff',
+      // accentColor2 intentionally omitted
+    });
+    const brand2 = cssVar('--color-brand-2');
+    // Must be set, valid hex, and different from the primary.
+    expect(brand2).toMatch(/^#[0-9a-f]{6}$/);
+    expect(brand2).not.toBe('');
+    expect(brand2).not.toBe('#007aff');
+  });
+
+  it("'default' source clears --color-brand-2 and --color-brand-2-soft", () => {
+    // First set a custom accent with brand-2.
+    applyTheme({
+      ...base,
+      accentSource: 'custom',
+      accentColor: '#a855f7',
+      accentColor2: '#6366f1',
+    });
+    expect(cssVar('--color-brand-2')).toBe('#6366f1');
+
+    // Switch to default — both gradient vars must be removed.
+    applyTheme({ ...base, accentSource: 'default' });
+    expect(cssVar('--color-brand-2')).toBe('');
+    expect(cssVar('--color-brand-2-soft')).toBe('');
+  });
+
+  it('sets --color-brand-2-soft to a non-empty valid hex whenever brand-2 is set', () => {
+    applyTheme({
+      ...base,
+      accentSource: 'custom',
+      accentColor: '#34c759',
+      accentColor2: '#06b6a4',
+    });
+    const brand2Soft = cssVar('--color-brand-2-soft');
+    expect(brand2Soft).toMatch(/^#[0-9a-f]{6}$/);
+    expect(brand2Soft).not.toBe('');
+  });
+
+  it('--color-brand-2-soft is also set when brand-2 is auto-derived (no color2 supplied)', () => {
+    applyTheme({
+      ...base,
+      accentSource: 'custom',
+      accentColor: '#ff9500',
+      // no accentColor2
+    });
+    const brand2Soft = cssVar('--color-brand-2-soft');
+    expect(brand2Soft).toMatch(/^#[0-9a-f]{6}$/);
+    expect(brand2Soft).not.toBe('');
+  });
+});

--- a/packages/ui/src/lib/theme.test.ts
+++ b/packages/ui/src/lib/theme.test.ts
@@ -290,4 +290,28 @@ describe('theme engine — accent gradient (brand-2)', () => {
     expect(brand2Soft).toMatch(/^#[0-9a-f]{6}$/);
     expect(brand2Soft).not.toBe('');
   });
+
+  it("'system' source derives brand-2 by rotation, ignoring a stale accentColor2", () => {
+    applyTheme({
+      ...base,
+      accentSource: 'system',
+      accentColor: '#1e9e5a',
+      // Leftover from a prior preset — must NOT be reused for the system accent.
+      accentColor2: '#6366f1',
+    });
+    const brand2 = cssVar('--color-brand-2');
+    // Derived via rotation of the system color, not the stale persisted pair.
+    expect(brand2).toMatch(/^#[0-9a-f]{6}$/);
+    expect(brand2).not.toBe('#6366f1');
+  });
+
+  it("'custom' source still honors the hand-tuned accentColor2 verbatim", () => {
+    applyTheme({
+      ...base,
+      accentSource: 'custom',
+      accentColor: '#1e9e5a',
+      accentColor2: '#22d3ee',
+    });
+    expect(cssVar('--color-brand-2')).toBe('#22d3ee');
+  });
 });

--- a/packages/ui/src/lib/theme.ts
+++ b/packages/ui/src/lib/theme.ts
@@ -15,7 +15,7 @@
  * ─────────────────────────────────────────────────────────────────────────
  */
 
-import { lightenHex, readableForeground } from './color';
+import { lightenHex, readableForeground, rotateHueHex } from './color';
 
 export type ColorScheme = 'light' | 'dark' | 'system';
 export type ContrastPref = 'normal' | 'more';
@@ -41,6 +41,8 @@ export interface ThemePrefs {
   accentSource: AccentSource;
   /** Resolved hex accent for 'system'/'custom' (e.g. '#a855f7'). */
   accentColor?: string;
+  /** Optional hand-tuned gradient-end hex for presets; absent for system/custom (then auto-rotated). */
+  accentColor2?: string;
 }
 
 const STORAGE_KEY = 'ajh-theme';
@@ -54,7 +56,13 @@ export const DEFAULT_THEME_PREFS: ThemePrefs = {
 };
 
 /** Accent-derived CSS vars the applier owns on :root (cleared for 'default'). */
-const ACCENT_VARS = ['--color-brand', '--color-brand-soft', '--color-action-foreground'] as const;
+const ACCENT_VARS = [
+  '--color-brand',
+  '--color-brand-soft',
+  '--color-brand-2',
+  '--color-brand-2-soft',
+  '--color-action-foreground',
+] as const;
 
 /**
  * Write (or clear) the runtime accent override on :root. brand-dim, the focus
@@ -68,6 +76,10 @@ function applyAccent(root: HTMLElement, prefs: ThemePrefs, scheme: 'light' | 'da
   const softAmount = scheme === 'dark' ? 0.28 : 0.16;
   const soft = color ? lightenHex(color, softAmount) : null;
   const foreground = color ? readableForeground(color) : null;
+  // Gradient-end: a hand-tuned second hex when the preset ships one, else the
+  // accent hue rotated -30° so every accent gets a coherent two-tone pair.
+  const color2 = color ? (prefs.accentColor2 ?? rotateHueHex(color, -30) ?? undefined) : undefined;
+  const brand2Soft = color2 ? lightenHex(color2, softAmount) : null;
 
   if (!color || !soft || !foreground) {
     for (const v of ACCENT_VARS) root.style.removeProperty(v);
@@ -76,6 +88,12 @@ function applyAccent(root: HTMLElement, prefs: ThemePrefs, scheme: 'light' | 'da
   root.style.setProperty('--color-brand', color);
   root.style.setProperty('--color-brand-soft', soft);
   root.style.setProperty('--color-action-foreground', foreground);
+  // brand-2 is best-effort: a valid accent still applies even when the second
+  // hue can't be derived — just skip the two gradient-end props.
+  if (color2 && brand2Soft) {
+    root.style.setProperty('--color-brand-2', color2);
+    root.style.setProperty('--color-brand-2-soft', brand2Soft);
+  }
 }
 
 const mq = (query: string): MediaQueryList | null =>

--- a/packages/ui/src/lib/theme.ts
+++ b/packages/ui/src/lib/theme.ts
@@ -76,9 +76,14 @@ function applyAccent(root: HTMLElement, prefs: ThemePrefs, scheme: 'light' | 'da
   const softAmount = scheme === 'dark' ? 0.28 : 0.16;
   const soft = color ? lightenHex(color, softAmount) : null;
   const foreground = color ? readableForeground(color) : null;
-  // Gradient-end: a hand-tuned second hex when the preset ships one, else the
-  // accent hue rotated -30° so every accent gets a coherent two-tone pair.
-  const color2 = color ? (prefs.accentColor2 ?? rotateHueHex(color, -30) ?? undefined) : undefined;
+  // Gradient-end: a hand-tuned second hex only when the source is 'custom' (a
+  // preset's hand-tuned pair); 'system' always derives via hue rotation so a
+  // stale persisted accentColor2 never leaks onto a freshly picked system hue.
+  const color2 = color
+    ? ((prefs.accentSource === 'custom' ? prefs.accentColor2 : undefined) ??
+      rotateHueHex(color, -30) ??
+      undefined)
+    : undefined;
   const brand2Soft = color2 ? lightenHex(color2, softAmount) : null;
 
   if (!color || !soft || !foreground) {


### PR DESCRIPTION
Bundles the Chrome-extension publish work + the accent-gradient feature (one branch, per request). Perf-mode customization is **deferred to its own branch/PR** (plan saved).

## ✨ Accent gradients + aurora (feat)
Every accent — preset, system, or custom hex — now produces a coherent **two-tone gradient** instead of the hard-coded violet→indigo.
- New `--color-brand-2` (+`-soft`) gradient-end token: hand-tuned per preset, `rotateHueHex(−30°)` fallback for system/custom, static for `default` (so the shipped look is **pixel-identical**).
- `.text-gradient`, `.gradient-border`, `.glass-violet`/`.glass-indigo` + the aurora tokens now ride `--color-brand`/`--color-brand-2`.
- **Revived a slim, accent-tinted aurora** backdrop (ribbons + nebulae + RAF cursor glow), perf-mode gated + reduced-motion safe — see **ADR-018**. Parallax/streaks/grain were not revived.
- Appearance swatches preview the two-tone gradient.

## 🔗 Chrome extension published (fix + docs)
- `fix:` pin the real Chrome Web Store id `oaoekkgkhmgdfnpmfkpphgiikliaicll` in the extension-bridge origin allowlist (`auth.rs`) so the published extension can handshake the desktop app.
- `docs:` announce Chrome availability (CWS badge + install links) across the root README + extension README, flip the "unpublished" notes (Firefox/AMO still pending), and add a Chrome-extension link to the landing footer.

## 🧪 Tests
- New unit coverage: `rotateHueHex`, `applyAccent` brand-2 derivation/clear, AppearanceCard swatches.
- Hardened the swatch tests against jsdom's `cssstyle` rejecting hex-stop `linear-gradient` (data-attribute seam instead of CSS parsing).

## Docs
- `docs/DESIGN_SYSTEM.md` corrected (gradients now token-derived; aurora revived) + **ADR-018** added.

## Verify
`pnpm -w typecheck` · `pnpm lint:strict` · `pnpm test` (1647 green) · `cargo test` (extension-bridge auth). In-app: Settings → Appearance → pick any accent → headings/glass/aurora re-tint; Default unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a layered cinematic background with cursor-glow, reduced-motion handling, and low-memory/performance mode behavior.
  * Introduced two-tone accent gradients across the accent picker and UI elements (using a secondary “gradient-end” accent color).
* **Documentation**
  * Updated design system guidance/token documentation and added an ADR for the accent-tinted ambient background.
* **Chores**
  * Updated store badges and extension published/pending availability information.
* **Tests**
  * Added/extended automated tests for two-tone accent behavior and related UI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->