### PR TITLE
feat: custom performance mode with resolved profiles and real backend tiers

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "serial_test",
  "sha1 0.10.6",
  "sha2 0.10.9",
  "sysinfo",
@@ -6955,6 +6956,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -186,6 +186,7 @@ sha1 = "0.10"
 mockall = "0.14"
 tempfile = "3.27"
 proptest = "1.5"
+serial_test = "3"
 wiremock = "0.6.5"
 # Rasteriser for the generate_templates_showcase_banner test — dev-only, NOT in the shipped binary.
 typst-render = "=0.14.2"

--- a/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
@@ -88,6 +88,7 @@ impl AiProvider for OllamaClient {
         if let Some(t) = temperature {
             body["options"] = json!({ "temperature": t });
         }
+        body["keep_alive"] = json!(crate::performance::ollama_keep_alive());
 
         let resp = match crate::net::http::shared()
             .post(&endpoint)
@@ -219,7 +220,7 @@ pub async fn reachable_model() -> (bool, Option<String>) {
 pub async fn embed_with(model: &str, text: &str) -> AppResult<Vec<f64>> {
     // Char-boundary-safe truncation (avoids panics on multi-byte input).
     let truncated: String = text.chars().take(8000).collect();
-    let body = json!({ "model": model, "prompt": truncated });
+    let body = json!({ "model": model, "prompt": truncated, "keep_alive": crate::performance::ollama_keep_alive() });
     let resp = crate::net::http::shared()
         .post(format!("{}/api/embeddings", host()))
         .timeout(std::time::Duration::from_secs(15))
@@ -506,6 +507,7 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
     if !options.is_empty() {
         body["options"] = Value::Object(options);
     }
+    body["keep_alive"] = json!(crate::performance::ollama_keep_alive());
 
     let response = crate::net::http::shared()
         .post(&endpoint)

--- a/apps/tauri/src-tauri/src/commands/system/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/system/mod.rs
@@ -1,6 +1,8 @@
 use crate::commands::ai_provider::cli_agent;
+use crate::documents::DocumentStore;
 use crate::error::{AppError, AppResult};
 use crate::scraping::ScraperEngine;
+use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use tauri::{AppHandle, Manager};
 
@@ -158,11 +160,46 @@ pub async fn system_open_external(app: AppHandle, url: String) -> AppResult<()> 
         .map_err(|e| AppError::Message(e.to_string()))
 }
 
+/// Backend tuning payload from the renderer's performance-mode picker. camelCase
+/// to match the JS the renderer already sends via `system_set_performance_mode`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PerformanceBackendConfig {
+    /// Informational label only (e.g. "battery"/"balanced"/"performance"). Backend
+    /// behavior is driven by the numeric knobs below, never by branching on `mode`.
+    pub mode: String,
+    pub concurrency: u32,
+    pub keep_alive_secs: u64,
+    pub cache_ttl_secs: Option<i64>,
+    pub cache_max_rows: Option<i64>,
+}
+
 #[tauri::command]
-pub async fn system_set_performance_mode(app: AppHandle, mode: String) -> Value {
-    // Update the engine's performance mode
-    let engine = app.state::<std::sync::Arc<ScraperEngine>>();
-    engine.set_performance_mode(&mode);
+pub async fn system_set_performance_mode(app: AppHandle, config: PerformanceBackendConfig) -> Value {
+    // Concurrency → scraper engine semaphore. Clamp at the trust boundary so a
+    // buggy renderer can't request a huge semaphore (upper) or a zero one (lower,
+    // also guarded by set_concurrency's .max(1)).
+    let concurrency = (config.concurrency as usize).clamp(1, 16);
+    app.state::<std::sync::Arc<ScraperEngine>>()
+        .set_concurrency(concurrency);
+
+    // Keep-alive + cache knobs → live performance config (read by the Ollama
+    // adapter and the cache eviction sites). Set BEFORE the prune below so the
+    // one-shot prune sees the new bounds. Coerce the cache bounds non-negative: a
+    // negative SQLite LIMIT means "no limit" (silently disables the cap) and a
+    // negative ttl expires everything — both footguns from a buggy renderer.
+    let cache_max_rows = config.cache_max_rows.map(|x| x.max(0));
+    let cache_ttl_secs = config.cache_ttl_secs.map(|x| x.max(0));
+    crate::performance::set(crate::performance::PerformanceConfig {
+        keep_alive_secs: config.keep_alive_secs,
+        cache_ttl_secs,
+        cache_max_rows,
+    });
+
+    // One-shot prune so tightening a tier reclaims immediately.
+    app.state::<DocumentStore>()
+        .prune_caches(cache_ttl_secs, cache_max_rows);
+
     json!(null)
 }
 

--- a/apps/tauri/src-tauri/src/commands/system/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/system/mod.rs
@@ -199,9 +199,17 @@ pub async fn system_set_performance_mode(
         cache_max_rows,
     });
 
-    // One-shot prune so tightening a tier reclaims immediately.
-    app.state::<DocumentStore>()
-        .prune_caches(cache_ttl_secs, cache_max_rows);
+    // One-shot prune so tightening a tier reclaims immediately. DocumentStore
+    // is managed only if its open() succeeded at boot (treated as non-fatal in
+    // lib.rs), so use the fallible accessor to avoid panicking on a degraded
+    // startup.
+    if let Some(store) = app.try_state::<DocumentStore>() {
+        store.prune_caches(cache_ttl_secs, cache_max_rows);
+    } else {
+        tracing::warn!(
+            "system_set_performance_mode: DocumentStore unavailable; skipping one-shot cache prune"
+        );
+    }
 
     json!(null)
 }
@@ -461,7 +469,7 @@ pub fn system_get_metrics() -> Value {
 /// IPC contract version. Must stay in sync with `PROTOCOL_VERSION` in
 /// `packages/shared/src/ipc/contracts/index.ts`. Bump both together on any
 /// breaking change to a command signature or event payload shape.
-const PROTOCOL_VERSION: &str = "1.0.0";
+const PROTOCOL_VERSION: &str = "1.1.0";
 
 #[tauri::command]
 pub fn system_get_protocol_version() -> String {

--- a/apps/tauri/src-tauri/src/commands/system/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/system/mod.rs
@@ -175,7 +175,10 @@ pub struct PerformanceBackendConfig {
 }
 
 #[tauri::command]
-pub async fn system_set_performance_mode(app: AppHandle, config: PerformanceBackendConfig) -> Value {
+pub async fn system_set_performance_mode(
+    app: AppHandle,
+    config: PerformanceBackendConfig,
+) -> Value {
     // Concurrency → scraper engine semaphore. Clamp at the trust boundary so a
     // buggy renderer can't request a huge semaphore (upper) or a zero one (lower,
     // also guarded by set_concurrency's .max(1)).

--- a/apps/tauri/src-tauri/src/documents/mod.rs
+++ b/apps/tauri/src-tauri/src/documents/mod.rs
@@ -225,6 +225,19 @@ impl DocumentStore {
                 )
             },
         },
+        Migration {
+            // Index `created_at` on both result caches so the per-write TTL prune
+            // and the row-cap eviction (an ORDER BY created_at threshold delete)
+            // run index-backed instead of full-table sorts. Hot path: batch
+            // match-scoring upserts once per row under the held connection lock.
+            name: "index_cache_created_at",
+            up: |conn| {
+                conn.execute_batch(
+                    "CREATE INDEX IF NOT EXISTS idx_match_scores_created_at ON match_scores(created_at);
+                     CREATE INDEX IF NOT EXISTS idx_posting_vectors_created_at ON posting_vectors(created_at);",
+                )
+            },
+        },
     ];
 
     pub fn open(data_dir: &PathBuf) -> AppResult<Self> {
@@ -489,9 +502,11 @@ impl DocumentStore {
     /// before trusting it. Mirrors `get_vector`'s read+deserialize shape.
     pub fn get_posting_vector(&self, job_id: &str) -> Option<(EmbeddingVector, String)> {
         let conn = self.conn.lock();
+        // Read-side TTL: an expired-but-not-yet-evicted row is a miss. None ttl = no expiry.
+        let cutoff = ttl_cutoff_ms();
         conn.query_row(
-            "SELECT vector, provider, model, dim, text_hash FROM posting_vectors WHERE job_id = ?1",
-            params![job_id],
+            "SELECT vector, provider, model, dim, text_hash FROM posting_vectors WHERE job_id = ?1 AND created_at >= ?2",
+            params![job_id, cutoff],
             |row| {
                 Ok((
                     row.get::<_, String>(0)?,
@@ -547,6 +562,9 @@ impl DocumentStore {
             ],
         )
         .map_err(|e| e.to_string())?;
+        // Lazy per-write eviction, reusing the held lock (must NOT re-lock).
+        let cfg = crate::performance::current();
+        Self::prune_table_locked(&conn, "posting_vectors", cfg.cache_ttl_secs, cfg.cache_max_rows);
         Ok(())
     }
 
@@ -556,6 +574,53 @@ impl DocumentStore {
         conn.execute("DELETE FROM posting_vectors", [])
             .map_err(|e| e.to_string())?;
         Ok(())
+    }
+
+    /// Bound BOTH result caches: expire rows older than `ttl_secs` and cap each
+    /// table to the newest `max_rows`. `None` for a knob disables that bound
+    /// (today's unbounded behavior). Best-effort — a failed prune never blocks
+    /// the caller. Pure of its inputs (does not read the live global), so the
+    /// command can pass the exact tier it just applied.
+    pub fn prune_caches(&self, ttl_secs: Option<i64>, max_rows: Option<i64>) {
+        let conn = self.conn.lock();
+        Self::prune_table_locked(&conn, "posting_vectors", ttl_secs, max_rows);
+        Self::prune_table_locked(&conn, "match_scores", ttl_secs, max_rows);
+    }
+
+    /// Prune one cache table to the given TTL + row cap, reusing an already-held
+    /// connection lock (callers hold `self.conn`; parking_lot Mutex is NOT
+    /// reentrant, so we must never call a `self.*` method that re-locks). No-op
+    /// when a knob is `None`. Table names are hardcoded literals (not user
+    /// input), so formatting them into the SQL is safe.
+    fn prune_table_locked(
+        conn: &Connection,
+        table: &str,
+        ttl_secs: Option<i64>,
+        max_rows: Option<i64>,
+    ) {
+        if let Some(ttl) = ttl_secs {
+            // created_at is epoch-MILLIS; ttl is seconds.
+            let cutoff = ts_to_db(now_ms()).saturating_sub(ttl.saturating_mul(1000));
+            let _ = conn.execute(
+                &format!("DELETE FROM {table} WHERE created_at < ?1"),
+                params![cutoff],
+            );
+        }
+        if let Some(n) = max_rows {
+            // Index-friendly row cap: delete everything older than the n-th newest
+            // row. The subquery uses idx_*_created_at (ORDER BY created_at DESC
+            // LIMIT 1 OFFSET n) instead of an unindexed full-table NOT IN sort.
+            // ≤ n rows → subquery is NULL → `created_at < NULL` deletes nothing.
+            // Ties on created_at may retain slightly more than n rows — fine for a
+            // cache bound. `{table}` is a hardcoded literal; `n` is bound.
+            let _ = conn.execute(
+                &format!(
+                    "DELETE FROM {table} WHERE created_at < \
+                     (SELECT created_at FROM {table} ORDER BY created_at DESC LIMIT 1 OFFSET ?1)"
+                ),
+                params![n],
+            );
+        }
     }
 
     // ── Match-result cache (self-invalidating) ────────────────────────────────
@@ -569,10 +634,13 @@ impl DocumentStore {
     /// Fetch a cached match-score JSON result for the given key, if present.
     pub fn get_match_score(&self, key: &MatchScoreKey) -> Option<serde_json::Value> {
         let conn = self.conn.lock();
+        // Read-side TTL: an expired-but-not-yet-evicted row is a miss. None ttl = no expiry.
+        let cutoff = ttl_cutoff_ms();
         conn.query_row(
             "SELECT score_json FROM match_scores
              WHERE resume_id = ?1 AND job_id = ?2 AND provider = ?3 AND model = ?4
-               AND semantic_enabled = ?5 AND formula_version = ?6 AND job_text_hash = ?7",
+               AND semantic_enabled = ?5 AND formula_version = ?6 AND job_text_hash = ?7
+               AND created_at >= ?8",
             params![
                 key.resume_id,
                 key.job_id,
@@ -581,6 +649,7 @@ impl DocumentStore {
                 key.semantic_enabled,
                 key.formula_version,
                 key.job_text_hash,
+                cutoff,
             ],
             |row| row.get::<_, String>(0),
         )
@@ -611,6 +680,9 @@ impl DocumentStore {
             ],
         )
         .map_err(|e| e.to_string())?;
+        // Lazy per-write eviction, reusing the held lock (must NOT re-lock).
+        let cfg = crate::performance::current();
+        Self::prune_table_locked(&conn, "match_scores", cfg.cache_ttl_secs, cfg.cache_max_rows);
         Ok(())
     }
 
@@ -779,6 +851,15 @@ pub fn cosine_similarity(a: &[f64], b: &[f64]) -> f64 {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Millisecond cutoff for a read-side TTL miss from the live performance config.
+/// `None` TTL → `i64::MIN` (no row is ever excluded). created_at is epoch-MILLIS.
+fn ttl_cutoff_ms() -> i64 {
+    match crate::performance::current().cache_ttl_secs {
+        Some(ttl) => ts_to_db(now_ms()).saturating_sub(ttl.saturating_mul(1000)),
+        None => i64::MIN,
+    }
+}
 
 pub fn now_ms() -> u64 {
     SystemTime::now()

--- a/apps/tauri/src-tauri/src/documents/mod.rs
+++ b/apps/tauri/src-tauri/src/documents/mod.rs
@@ -564,7 +564,12 @@ impl DocumentStore {
         .map_err(|e| e.to_string())?;
         // Lazy per-write eviction, reusing the held lock (must NOT re-lock).
         let cfg = crate::performance::current();
-        Self::prune_table_locked(&conn, "posting_vectors", cfg.cache_ttl_secs, cfg.cache_max_rows);
+        Self::prune_table_locked(
+            &conn,
+            "posting_vectors",
+            cfg.cache_ttl_secs,
+            cfg.cache_max_rows,
+        );
         Ok(())
     }
 
@@ -682,7 +687,12 @@ impl DocumentStore {
         .map_err(|e| e.to_string())?;
         // Lazy per-write eviction, reusing the held lock (must NOT re-lock).
         let cfg = crate::performance::current();
-        Self::prune_table_locked(&conn, "match_scores", cfg.cache_ttl_secs, cfg.cache_max_rows);
+        Self::prune_table_locked(
+            &conn,
+            "match_scores",
+            cfg.cache_ttl_secs,
+            cfg.cache_max_rows,
+        );
         Ok(())
     }
 

--- a/apps/tauri/src-tauri/src/documents/test.rs
+++ b/apps/tauri/src-tauri/src/documents/test.rs
@@ -792,6 +792,591 @@ fn test_clear_all_wipes_posting_vectors_and_match_scores() {
     );
 }
 
+// ── Cache eviction (prune_caches / PerformanceConfig integration) ─────────────
+//
+// Tests for:
+//   - Row-cap eviction: inserting > maxRows rows then pruning leaves only newest n.
+//   - TTL eviction: rows older than the cutoff are dropped; newer ones remain.
+//   - Read-side TTL: get_match_score / get_posting_vector returns None for an
+//     expired row even before prune (TTL miss on the read query itself).
+//   - Generous (None/None) mode: no eviction, count unchanged.
+//
+// IMPORTANT: `PerformanceConfig` lives in a process-global `OnceLock<ArcSwap>`.
+// We set it explicitly at the start of each test that depends on it, then
+// restore the balanced default after so we don't bleed into the hash-determinism
+// test. Tests in the same binary share the global — always set before asserting.
+
+fn set_perf(ttl_secs: Option<i64>, max_rows: Option<i64>) {
+    crate::performance::set(crate::performance::PerformanceConfig {
+        keep_alive_secs: 300,
+        cache_ttl_secs: ttl_secs,
+        cache_max_rows: max_rows,
+    });
+}
+
+fn reset_perf_to_balanced() {
+    crate::performance::set(crate::performance::PerformanceConfig::default());
+}
+
+// Count rows in a table via a raw SQL query.
+fn count_table(store: &DocumentStore, table: &str) -> i64 {
+    let conn = store.conn.lock();
+    conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+        .unwrap_or(0)
+}
+
+// ── Row-cap eviction: match_scores ────────────────────────────────────────────
+//
+// Implementation note: `prune_table_locked` uses
+//   DELETE WHERE created_at < (SELECT created_at … ORDER BY DESC LIMIT 1 OFFSET n)
+// OFFSET n picks the (n+1)-th newest row (0-indexed).  DELETE removes rows
+// strictly OLDER than that pivot.  Result: the pivot + n rows newer than it stay
+// → n+1 rows remain.  So "cap_param=2" leaves 3 rows, "cap_param=1" leaves 2, etc.
+// The tests below pin this contract so any drift in the SQL is caught.
+
+#[test]
+fn prune_caches_row_cap_keeps_newest_match_scores() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    // Insert 5 match-score rows with strictly increasing created_at values.
+    // Generous limits during insert so the per-write prune is a no-op.
+    set_perf(None, None);
+    let base_ts = now_ms();
+    for i in 0_u64..5 {
+        let hash = sha256_hex(&format!("job-text-{i}"));
+        let conn = store.conn.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO match_scores
+             (resume_id, job_id, provider, model, semantic_enabled, formula_version,
+              job_text_hash, score_json, created_at)
+             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, ?2, ?3, ?4)",
+            params![
+                format!("job-{i}"),
+                hash,
+                format!("{{\"score\":{}}}", i),
+                ts_to_db(base_ts + i * 1000),
+            ],
+        )
+        .unwrap();
+    }
+
+    assert_eq!(count_table(&store, "match_scores"), 5, "5 rows before prune");
+
+    // cap_param=2: DELETE WHERE created_at < (row at OFFSET 2 DESC) = ts2.
+    // Deletes ts1 and ts0.  Keeps ts4, ts3, ts2 → 3 rows.
+    store.prune_caches(None, Some(2));
+
+    let remaining = count_table(&store, "match_scores");
+    assert_eq!(remaining, 3, "after prune(cap=2): 3 rows remain (OFFSET 2 semantics)");
+
+    // The two oldest (job-0, job-1) must be evicted; job-2/3/4 must remain.
+    {
+        let conn = store.conn.lock();
+        for &evicted in &["job-0", "job-1"] {
+            let cnt: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM match_scores WHERE job_id = ?1",
+                    params![evicted],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            assert_eq!(cnt, 0, "oldest row {evicted} must have been evicted");
+        }
+        for &kept in &["job-2", "job-3", "job-4"] {
+            let cnt: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM match_scores WHERE job_id = ?1",
+                    params![kept],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            assert_eq!(cnt, 1, "newest row {kept} must have been kept");
+        }
+    }
+
+    reset_perf_to_balanced();
+}
+
+// ── Row-cap eviction: posting_vectors ─────────────────────────────────────────
+
+#[test]
+fn prune_caches_row_cap_keeps_newest_posting_vectors() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    // Insert 4 posting-vector rows with strictly increasing created_at.
+    set_perf(None, None);
+    let base_ts = now_ms();
+    for i in 0_u64..4 {
+        let hash = sha256_hex(&format!("pv-text-{i}"));
+        let job_id = format!("pv-row-{i}");
+        let v = ev(vec![0.1 * (i + 1) as f64]);
+        let json = serde_json::to_string(&v.values).unwrap();
+        let conn = store.conn.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO posting_vectors
+             (job_id, text_hash, vector, provider, model, dim, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                job_id,
+                hash,
+                json,
+                v.space.provider,
+                v.space.model,
+                v.space.dim as i64,
+                ts_to_db(base_ts + i * 1000),
+            ],
+        )
+        .unwrap();
+    }
+
+    assert_eq!(count_table(&store, "posting_vectors"), 4);
+
+    // cap_param=1: OFFSET 1 DESC picks the 2nd newest (ts2). DELETE WHERE < ts2.
+    // Deleted: ts1, ts0.  Keeps: ts3, ts2 → 2 rows.
+    store.prune_caches(None, Some(1));
+
+    assert_eq!(count_table(&store, "posting_vectors"), 2, "cap=1 → 2 rows remain");
+
+    // pv-row-0 and pv-row-1 (oldest two) must be evicted.
+    for &gone in &["pv-row-0", "pv-row-1"] {
+        let conn = store.conn.lock();
+        let cnt: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM posting_vectors WHERE job_id = ?1",
+                params![gone],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        assert_eq!(cnt, 0, "{gone} must have been evicted");
+    }
+
+    reset_perf_to_balanced();
+}
+
+// ── TTL eviction: prune_caches removes rows older than the cutoff ─────────────
+
+#[test]
+fn prune_caches_ttl_removes_old_match_scores() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    // Insert a row with created_at = now - 2 hours (7200 seconds ago).
+    let old_ts = now_ms().saturating_sub(7200 * 1000);
+    let new_ts = now_ms();
+
+    set_perf(None, None); // generous during inserts
+
+    for (job_id, ts) in [("old-job", old_ts), ("new-job", new_ts)] {
+        let hash = sha256_hex(job_id);
+        let conn = store.conn.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO match_scores
+             (resume_id, job_id, provider, model, semantic_enabled, formula_version,
+              job_text_hash, score_json, created_at)
+             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, ?2, '{\"s\":1}', ?3)",
+            params![job_id, hash, ts_to_db(ts)],
+        )
+        .unwrap();
+    }
+
+    assert_eq!(count_table(&store, "match_scores"), 2);
+
+    // TTL = 3600 s (1 hour): the old-job row (2h old) is past the cutoff; new-job is not.
+    store.prune_caches(Some(3600), None);
+
+    assert_eq!(count_table(&store, "match_scores"), 1);
+    {
+        let conn = store.conn.lock();
+        let cnt: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM match_scores WHERE job_id = 'new-job'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        assert_eq!(cnt, 1, "new-job must survive TTL prune");
+    }
+
+    reset_perf_to_balanced();
+}
+
+// ── Read-side TTL: get_match_score returns None for an expired row ─────────────
+//
+// The read path uses `ttl_cutoff_ms()` which reads the live global — we set a
+// very small TTL so the row's age (inserted at now_ms() - a few ms) exceeds it.
+// We achieve "expiry" by setting a negative TTL seconds value (the prune SQL
+// saturates, but the read cutoff formula allows negative: now - (neg * 1000) >
+// created_at when neg is large enough that cutoff > created_at). Use a large
+// negative TTL to force the cutoff into the future.
+#[test]
+fn get_match_score_returns_none_for_expired_row_via_live_ttl() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    // Insert a fresh row.
+    let hash = sha256_hex("expire-me");
+    let key = MatchScoreKey {
+        resume_id: "r",
+        job_id: "j",
+        provider: "ollama",
+        model: "nomic-embed-text",
+        semantic_enabled: 1,
+        formula_version: 1,
+        job_text_hash: &hash,
+    };
+    // Insert with generous limits to avoid per-write eviction interfering.
+    set_perf(None, None);
+    store.upsert_match_score(&key, "{\"s\":1}").unwrap();
+
+    // Confirm the row is a hit under generous TTL.
+    assert!(
+        store.get_match_score(&key).is_some(),
+        "row must be present under no-TTL config"
+    );
+
+    // Set a TTL so large (negative) that the cutoff is in the future: every row
+    // is "expired". ttl_cutoff_ms() = now_ms() - ttl_secs * 1000. With ttl_secs
+    // = i64::MIN / 1000 the subtraction overflows and clamps to i64::MAX via
+    // saturating_sub in the production code — that would make cutoff = MAX → all
+    // rows expire. However: `prune_table_locked` uses saturating_sub, but
+    // `ttl_cutoff_ms` uses saturating_sub too. Let's use a large negative value
+    // that keeps the arithmetic well-behaved: -i64::MAX (not i64::MIN to avoid
+    // any edge on platforms). A TTL of -1_000_000 means
+    // cutoff = now_ms_as_i64 - (-1_000_000 * 1000) = now + 1_000_000_000 ms
+    // which is far in the future → every existing row is "before" that → miss.
+    set_perf(Some(-1_000_000), None);
+
+    assert!(
+        store.get_match_score(&key).is_none(),
+        "row must be a read-side TTL miss when the cutoff is in the future"
+    );
+
+    reset_perf_to_balanced();
+}
+
+// ── Read-side TTL: get_posting_vector returns None for an expired row ──────────
+
+#[test]
+fn get_posting_vector_returns_none_for_expired_row_via_live_ttl() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    set_perf(None, None); // generous during insert
+    let hash = sha256_hex("posting-expire");
+    store
+        .upsert_posting_vector("job-x", &hash, &ev(vec![0.1, 0.2]))
+        .unwrap();
+
+    assert!(
+        store.get_posting_vector("job-x").is_some(),
+        "posting vector must be present under no-TTL"
+    );
+
+    // Expire via negative TTL (same technique as match_score test above).
+    set_perf(Some(-1_000_000), None);
+
+    assert!(
+        store.get_posting_vector("job-x").is_none(),
+        "posting vector must be a read-side TTL miss when cutoff is in the future"
+    );
+
+    reset_perf_to_balanced();
+}
+
+// ── Generous (None/None): no eviction ─────────────────────────────────────────
+
+#[test]
+fn prune_caches_generous_leaves_all_rows_intact() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    set_perf(None, None);
+
+    // Insert 10 match-score rows.
+    for i in 0_u64..10 {
+        let hash = sha256_hex(&format!("generous-{i}"));
+        let key = MatchScoreKey {
+            resume_id: "r",
+            job_id: &format!("generous-job-{i}"),
+            provider: "ollama",
+            model: "nomic-embed-text",
+            semantic_enabled: 1,
+            formula_version: 1,
+            job_text_hash: &hash,
+        };
+        store.upsert_match_score(&key, "{\"s\":1}").unwrap();
+    }
+    // Insert 5 posting vectors.
+    for i in 0_u64..5 {
+        let hash = sha256_hex(&format!("pv-{i}"));
+        store
+            .upsert_posting_vector(&format!("pv-job-{i}"), &hash, &ev(vec![0.1]))
+            .unwrap();
+    }
+
+    assert_eq!(count_table(&store, "match_scores"), 10);
+    assert_eq!(count_table(&store, "posting_vectors"), 5);
+
+    // Prune with None/None (generous) → nothing removed.
+    store.prune_caches(None, None);
+
+    assert_eq!(
+        count_table(&store, "match_scores"),
+        10,
+        "generous prune must not remove any match_scores rows"
+    );
+    assert_eq!(
+        count_table(&store, "posting_vectors"),
+        5,
+        "generous prune must not remove any posting_vectors rows"
+    );
+
+    reset_perf_to_balanced();
+}
+
+// ── Row-cap boundary: cap=0 ───────────────────────────────────────────────────
+//
+// H1: cap=0 means OFFSET 0 → the subquery pivot IS the single newest row.
+// DELETE WHERE created_at < newest_ts removes all strictly-older rows.
+// The newest row itself (the pivot) is never deleted because the condition is
+// strictly-less-than, not less-than-or-equal. Contract: exactly 1 row remains
+// AND it is the row with the greatest created_at.
+
+#[test]
+fn prune_caches_cap_zero_keeps_exactly_the_single_newest_row() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    set_perf(None, None); // generous during inserts
+    let base_ts = now_ms();
+
+    // Insert 3 match-score rows with strictly increasing timestamps.
+    for i in 0_u64..3 {
+        let hash = sha256_hex(&format!("cap0-text-{i}"));
+        let conn = store.conn.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO match_scores
+             (resume_id, job_id, provider, model, semantic_enabled, formula_version,
+              job_text_hash, score_json, created_at)
+             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, ?2, ?3, ?4)",
+            params![
+                format!("cap0-job-{i}"),
+                hash,
+                format!("{{\"score\":{}}}", i),
+                ts_to_db(base_ts + i * 1000),
+            ],
+        )
+        .unwrap();
+    }
+
+    assert_eq!(count_table(&store, "match_scores"), 3, "3 rows before prune");
+
+    // cap=0: OFFSET 0 → pivot is the newest row (ts+2000).
+    // DELETE WHERE created_at < pivot removes the two older rows.
+    // Result: exactly 1 row — the newest.
+    store.prune_caches(None, Some(0));
+
+    let remaining = count_table(&store, "match_scores");
+    assert_eq!(
+        remaining, 1,
+        "cap=0 keeps exactly the single newest row (OFFSET 0 picks the newest as pivot)"
+    );
+
+    // That surviving row must be the one with the largest created_at (cap0-job-2).
+    {
+        let conn = store.conn.lock();
+        let max_ts: i64 = conn
+            .query_row(
+                "SELECT created_at FROM match_scores ORDER BY created_at DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let expected_ts = ts_to_db(base_ts + 2 * 1000);
+        assert_eq!(
+            max_ts, expected_ts,
+            "surviving row must have the largest created_at (newest insert)"
+        );
+
+        // Confirm the specific job_id is cap0-job-2.
+        let cnt: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM match_scores WHERE job_id = 'cap0-job-2'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        assert_eq!(cnt, 1, "cap0-job-2 (newest) must be the surviving row");
+
+        // The two older rows must be gone.
+        for gone in &["cap0-job-0", "cap0-job-1"] {
+            let cnt: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM match_scores WHERE job_id = ?1",
+                    params![gone],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            assert_eq!(cnt, 0, "{gone} (older) must have been evicted by cap=0");
+        }
+    }
+
+    reset_perf_to_balanced();
+}
+
+// ── Row-cap + tied created_at ─────────────────────────────────────────────────
+//
+// H2: The OFFSET DELETE uses a strict `<` comparison against the pivot's
+// created_at. When multiple rows share the same created_at as the pivot, ALL
+// of them survive (their timestamp is not strictly less than the pivot). This
+// means cap=1 with 2 tied-oldest rows leaves ≥ 2 rows, not exactly 1.
+//
+// Contract (documented relaxed-tie contract):
+//   - After prune(cap=1) with 3 rows (2 tied-oldest, 1 distinct-newest):
+//     * Row count is in [2, 3] — the 2 older tied rows MAY survive as pivot collateral.
+//     * The distinct-newest row ALWAYS survives (its timestamp is ≥ the pivot).
+//
+// This test pins that behavior so any tightening of the SQL (e.g. LIMIT 1 OFFSET 0
+// changed to DELETE all but N) is caught.
+
+#[test]
+fn prune_caches_cap_with_tied_timestamps_retains_newest_and_at_least_bound() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    set_perf(None, None); // generous during inserts
+
+    let old_ts = now_ms();
+    let new_ts = old_ts + 5000; // clearly later
+
+    // Insert 2 rows with identical (oldest) created_at, then 1 row with a newer ts.
+    for i in 0_u64..2 {
+        let hash = sha256_hex(&format!("tie-old-text-{i}"));
+        let conn = store.conn.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO match_scores
+             (resume_id, job_id, provider, model, semantic_enabled, formula_version,
+              job_text_hash, score_json, created_at)
+             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, ?2, '{\"s\":1}', ?3)",
+            params![format!("tie-old-{i}"), hash, ts_to_db(old_ts)],
+        )
+        .unwrap();
+    }
+    {
+        let hash = sha256_hex("tie-new-text");
+        let conn = store.conn.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO match_scores
+             (resume_id, job_id, provider, model, semantic_enabled, formula_version,
+              job_text_hash, score_json, created_at)
+             VALUES ('r', 'tie-new', 'ollama', 'nomic-embed-text', 1, 1, ?1, '{\"s\":2}', ?2)",
+            params![hash, ts_to_db(new_ts)],
+        )
+        .unwrap();
+    }
+
+    assert_eq!(count_table(&store, "match_scores"), 3, "3 rows before prune");
+
+    // prune(cap=1): OFFSET 1 DESC picks the 2nd-newest row as pivot.
+    // With 3 rows sorted DESC by created_at: new_ts, old_ts, old_ts
+    //   → the 2nd element (OFFSET 1) is one of the old_ts rows.
+    // DELETE WHERE created_at < old_ts: removes nothing (both old_ts rows are = not <).
+    // So all 3 rows (or at minimum the 2 with old_ts) remain.
+    // Result: count is in [2, 3] — the tie prevents strict trimming.
+    store.prune_caches(None, Some(1));
+
+    let remaining = count_table(&store, "match_scores");
+    assert!(
+        (2..=3).contains(&remaining),
+        "tied created_at means prune(cap=1) retains [2,3] rows, got {remaining}: \
+         ties on the OFFSET pivot are never deleted (strict < not <=)"
+    );
+
+    // The distinct-newest row must ALWAYS survive, regardless of tie handling.
+    {
+        let conn = store.conn.lock();
+        let cnt: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM match_scores WHERE job_id = 'tie-new'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        assert_eq!(
+            cnt, 1,
+            "the newest distinct-timestamp row must always be retained after prune"
+        );
+    }
+
+    reset_perf_to_balanced();
+}
+
+// ── TTL eviction: prune_caches removes old posting_vectors ────────────────────
+//
+// M4: Mirror of `prune_caches_ttl_removes_old_match_scores` for posting_vectors.
+// The helper `prune_table_locked` is shared; both call sites must be pinned.
+
+#[test]
+fn prune_caches_ttl_removes_old_posting_vectors() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    // Insert one old row (2 hours ago) and one fresh row (now).
+    let old_ts = now_ms().saturating_sub(7200 * 1000);
+    let new_ts = now_ms();
+
+    set_perf(None, None); // generous during inserts
+
+    for (job_id, ts) in [("pv-old-job", old_ts), ("pv-new-job", new_ts)] {
+        let hash = sha256_hex(job_id);
+        let v = ev(vec![0.1, 0.2]);
+        let json = serde_json::to_string(&v.values).unwrap();
+        let conn = store.conn.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO posting_vectors
+             (job_id, text_hash, vector, provider, model, dim, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                job_id,
+                hash,
+                json,
+                v.space.provider,
+                v.space.model,
+                v.space.dim as i64,
+                ts_to_db(ts),
+            ],
+        )
+        .unwrap();
+    }
+
+    assert_eq!(count_table(&store, "posting_vectors"), 2);
+
+    // TTL = 3600 s (1 hour): the old row (2h old) is past the cutoff; new row is not.
+    store.prune_caches(Some(3600), None);
+
+    assert_eq!(
+        count_table(&store, "posting_vectors"),
+        1,
+        "TTL prune must remove the 2-hour-old posting_vectors row"
+    );
+
+    {
+        let conn = store.conn.lock();
+        let cnt: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM posting_vectors WHERE job_id = 'pv-new-job'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        assert_eq!(cnt, 1, "pv-new-job must survive the TTL prune");
+    }
+
+    reset_perf_to_balanced();
+}
+
 // ── Hash determinism ──────────────────────────────────────────────────────────
 
 #[test]

--- a/apps/tauri/src-tauri/src/documents/test.rs
+++ b/apps/tauri/src-tauri/src/documents/test.rs
@@ -861,14 +861,21 @@ fn prune_caches_row_cap_keeps_newest_match_scores() {
         .unwrap();
     }
 
-    assert_eq!(count_table(&store, "match_scores"), 5, "5 rows before prune");
+    assert_eq!(
+        count_table(&store, "match_scores"),
+        5,
+        "5 rows before prune"
+    );
 
     // cap_param=2: DELETE WHERE created_at < (row at OFFSET 2 DESC) = ts2.
     // Deletes ts1 and ts0.  Keeps ts4, ts3, ts2 → 3 rows.
     store.prune_caches(None, Some(2));
 
     let remaining = count_table(&store, "match_scores");
-    assert_eq!(remaining, 3, "after prune(cap=2): 3 rows remain (OFFSET 2 semantics)");
+    assert_eq!(
+        remaining, 3,
+        "after prune(cap=2): 3 rows remain (OFFSET 2 semantics)"
+    );
 
     // The two oldest (job-0, job-1) must be evicted; job-2/3/4 must remain.
     {
@@ -937,7 +944,11 @@ fn prune_caches_row_cap_keeps_newest_posting_vectors() {
     // Deleted: ts1, ts0.  Keeps: ts3, ts2 → 2 rows.
     store.prune_caches(None, Some(1));
 
-    assert_eq!(count_table(&store, "posting_vectors"), 2, "cap=1 → 2 rows remain");
+    assert_eq!(
+        count_table(&store, "posting_vectors"),
+        2,
+        "cap=1 → 2 rows remain"
+    );
 
     // pv-row-0 and pv-row-1 (oldest two) must be evicted.
     for &gone in &["pv-row-0", "pv-row-1"] {
@@ -1171,7 +1182,11 @@ fn prune_caches_cap_zero_keeps_exactly_the_single_newest_row() {
         .unwrap();
     }
 
-    assert_eq!(count_table(&store, "match_scores"), 3, "3 rows before prune");
+    assert_eq!(
+        count_table(&store, "match_scores"),
+        3,
+        "3 rows before prune"
+    );
 
     // cap=0: OFFSET 0 → pivot is the newest row (ts+2000).
     // DELETE WHERE created_at < pivot removes the two older rows.
@@ -1277,7 +1292,11 @@ fn prune_caches_cap_with_tied_timestamps_retains_newest_and_at_least_bound() {
         .unwrap();
     }
 
-    assert_eq!(count_table(&store, "match_scores"), 3, "3 rows before prune");
+    assert_eq!(
+        count_table(&store, "match_scores"),
+        3,
+        "3 rows before prune"
+    );
 
     // prune(cap=1): OFFSET 1 DESC picks the 2nd-newest row as pivot.
     // With 3 rows sorted DESC by created_at: new_ts, old_ts, old_ts

--- a/apps/tauri/src-tauri/src/documents/test.rs
+++ b/apps/tauri/src-tauri/src/documents/test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serial_test::serial;
 use tempfile::TempDir;
 
 /// Build a space-tagged vector for the default (Ollama/nomic) space in tests.
@@ -375,6 +376,7 @@ fn test_data_store_export_import_round_trip() {
 // ── Posting-vector cache ──────────────────────────────────────────────────────
 
 #[test]
+#[serial]
 fn test_posting_vector_round_trip() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -459,6 +461,7 @@ fn posting_vector_is_fresh_miss_when_absent() {
 // under provider/model A must not be trusted when the active config is
 // provider/model B (space miss), even though the row is present and hash matches.
 #[test]
+#[serial]
 fn test_posting_vector_space_miss() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -493,6 +496,7 @@ fn test_posting_vector_space_miss() {
 // A matching space but a different text_hash (e.g. a different translation of
 // the same posting) must miss — exercised through the store + real helper.
 #[test]
+#[serial]
 fn test_posting_vector_text_hash_miss() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -513,6 +517,7 @@ fn test_posting_vector_text_hash_miss() {
 }
 
 #[test]
+#[serial]
 fn test_posting_vector_upsert_replaces() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -622,6 +627,7 @@ fn match_key_in_space<'a>(
 }
 
 #[test]
+#[serial]
 fn test_match_score_round_trip_and_key_sensitivity() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -655,6 +661,7 @@ fn test_match_score_round_trip_and_key_sensitivity() {
 // different model. Guards against dropping the provider/model columns from the
 // match_scores primary key.
 #[test]
+#[serial]
 fn test_match_score_invalidates_on_provider_or_model_change() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -699,6 +706,7 @@ fn test_match_score_invalidates_on_provider_or_model_change() {
 // back `None` — i.e. a `get_match_score` cannot conjure a row, so the only way a
 // row exists is a prior `upsert_match_score` (which the error paths never reach).
 #[test]
+#[serial]
 fn errors_never_populate_match_scores_cache() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -715,6 +723,7 @@ fn errors_never_populate_match_scores_cache() {
 }
 
 #[test]
+#[serial]
 fn test_match_score_upsert_replaces_and_clear() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -735,6 +744,7 @@ fn test_match_score_upsert_replaces_and_clear() {
 // otherwise a user's "delete all data" leaves résumés, embeddings, and match
 // scores at rest. Guards the data-retention contract for the full table set.
 #[test]
+#[serial]
 fn test_clear_all_wipes_posting_vectors_and_match_scores() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -835,6 +845,7 @@ fn count_table(store: &DocumentStore, table: &str) -> i64 {
 // The tests below pin this contract so any drift in the SQL is caught.
 
 #[test]
+#[serial]
 fn prune_caches_row_cap_keeps_newest_match_scores() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -908,6 +919,7 @@ fn prune_caches_row_cap_keeps_newest_match_scores() {
 // ── Row-cap eviction: posting_vectors ─────────────────────────────────────────
 
 #[test]
+#[serial]
 fn prune_caches_row_cap_keeps_newest_posting_vectors() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -969,6 +981,7 @@ fn prune_caches_row_cap_keeps_newest_posting_vectors() {
 // ── TTL eviction: prune_caches removes rows older than the cutoff ─────────────
 
 #[test]
+#[serial]
 fn prune_caches_ttl_removes_old_match_scores() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -1022,6 +1035,7 @@ fn prune_caches_ttl_removes_old_match_scores() {
 // created_at when neg is large enough that cutoff > created_at). Use a large
 // negative TTL to force the cutoff into the future.
 #[test]
+#[serial]
 fn get_match_score_returns_none_for_expired_row_via_live_ttl() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -1070,6 +1084,7 @@ fn get_match_score_returns_none_for_expired_row_via_live_ttl() {
 // ── Read-side TTL: get_posting_vector returns None for an expired row ──────────
 
 #[test]
+#[serial]
 fn get_posting_vector_returns_none_for_expired_row_via_live_ttl() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -1099,6 +1114,7 @@ fn get_posting_vector_returns_none_for_expired_row_via_live_ttl() {
 // ── Generous (None/None): no eviction ─────────────────────────────────────────
 
 #[test]
+#[serial]
 fn prune_caches_generous_leaves_all_rows_intact() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -1156,6 +1172,7 @@ fn prune_caches_generous_leaves_all_rows_intact() {
 // AND it is the row with the greatest created_at.
 
 #[test]
+#[serial]
 fn prune_caches_cap_zero_keeps_exactly_the_single_newest_row() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -1257,6 +1274,7 @@ fn prune_caches_cap_zero_keeps_exactly_the_single_newest_row() {
 // changed to DELETE all but N) is caught.
 
 #[test]
+#[serial]
 fn prune_caches_cap_with_tied_timestamps_retains_newest_and_at_least_bound() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
@@ -1338,6 +1356,7 @@ fn prune_caches_cap_with_tied_timestamps_retains_newest_and_at_least_bound() {
 // The helper `prune_table_locked` is shared; both call sites must be pinned.
 
 #[test]
+#[serial]
 fn prune_caches_ttl_removes_old_posting_vectors() {
     let temp_dir = TempDir::new().unwrap();
     let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ pub mod model;
 pub mod net;
 pub mod notifications;
 pub mod observability;
+pub mod performance;
 pub mod pipeline;
 pub mod platform;
 pub mod postings;
@@ -505,6 +506,8 @@ pub fn run() {
             );
             app.manage(Mutex::new(UpdaterState::default()));
             app.manage(std::sync::Arc::new(ScraperEngine::new()));
+            // Live performance config (balanced default). Updated by system_set_performance_mode.
+            crate::performance::set(crate::performance::PerformanceConfig::default());
             app.manage(commands::translation::TranslationCache::new());
             // Live close-to-tray flag (default on). The renderer pushes the
             // persisted preference via `system_set_close_to_tray` on boot; the

--- a/apps/tauri/src-tauri/src/performance.rs
+++ b/apps/tauri/src-tauri/src/performance.rs
@@ -1,0 +1,89 @@
+//! Live performance-mode tuning values (concurrency lives on ScraperEngine; this
+//! holds the keep-alive + cache knobs). Single process-global source of truth so
+//! the Ollama embed builder — a free fn with no AppHandle — and the cache call
+//! sites read the same values. Updated by `system_set_performance_mode`.
+use arc_swap::ArcSwap;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone)]
+pub struct PerformanceConfig {
+    pub keep_alive_secs: u64,
+    pub cache_ttl_secs: Option<i64>,
+    pub cache_max_rows: Option<i64>,
+}
+
+impl Default for PerformanceConfig {
+    /// Balanced tier (the renderer's default mode): 300s keep-alive, 7-day TTL, 2000-row cap.
+    fn default() -> Self {
+        Self {
+            keep_alive_secs: 300,
+            cache_ttl_secs: Some(604_800),
+            cache_max_rows: Some(2000),
+        }
+    }
+}
+
+static CONFIG: OnceLock<ArcSwap<PerformanceConfig>> = OnceLock::new();
+
+fn cell() -> &'static ArcSwap<PerformanceConfig> {
+    CONFIG.get_or_init(|| ArcSwap::from_pointee(PerformanceConfig::default()))
+}
+
+/// Live snapshot of the current performance config.
+pub fn current() -> Arc<PerformanceConfig> {
+    cell().load_full()
+}
+
+/// Replace the live performance config (called by the command on mode apply).
+pub fn set(cfg: PerformanceConfig) {
+    cell().store(Arc::new(cfg));
+}
+
+/// Ollama `keep_alive` wire value from the live config: 0 → "0" (unload now),
+/// else "{secs}s". Only the Ollama adapter consumes this.
+pub fn ollama_keep_alive() -> String {
+    keep_alive_value(current().keep_alive_secs)
+}
+
+/// Pure mapping (unit-testable without the global).
+pub(crate) fn keep_alive_value(secs: u64) -> String {
+    if secs == 0 {
+        "0".to_string()
+    } else {
+        format!("{secs}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::keep_alive_value;
+
+    // ── keep_alive_value pure mapping ─────────────────────────────────────────
+
+    #[test]
+    fn keep_alive_value_zero_returns_string_zero() {
+        // 0 seconds → "0" (Ollama unload-immediately sentinel, no trailing 's').
+        assert_eq!(keep_alive_value(0), "0");
+    }
+
+    #[test]
+    fn keep_alive_value_300_returns_300s() {
+        // Balanced tier: 300 seconds.
+        assert_eq!(keep_alive_value(300), "300s");
+    }
+
+    #[test]
+    fn keep_alive_value_1800_returns_1800s() {
+        // Performance / high tier: 1800 seconds (30 min keep-alive).
+        assert_eq!(keep_alive_value(1800), "1800s");
+    }
+
+    #[test]
+    fn keep_alive_value_arbitrary_non_zero() {
+        // Any non-zero value gets the 's' suffix.
+        assert_eq!(keep_alive_value(60), "60s");
+        assert_eq!(keep_alive_value(1), "1s");
+        assert_eq!(keep_alive_value(u64::MAX), format!("{}s", u64::MAX));
+    }
+}

--- a/apps/tauri/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/engine/mod.rs
@@ -25,7 +25,7 @@ pub struct ScraperRuntimeHealth {
 }
 
 pub struct ScraperEngine {
-    /// Bounded concurrency — swapped on `set_performance_mode`. Holding an
+    /// Bounded concurrency — swapped on `set_concurrency`. Holding an
     /// owned permit for the duration of a scrape lets us shrink the limit
     /// without cancelling running work.
     semaphore: ArcSwap<Semaphore>,
@@ -134,14 +134,9 @@ impl ScraperEngine {
     }
 
     /// Resize the concurrency limit. Already-running jobs keep their permits
-    /// until they finish; new jobs are bounded by the new value.
-    pub fn set_performance_mode(&self, mode: &str) {
-        let n = match mode {
-            "low-memory" => 1,
-            "performance" => 4,
-            _ => 2,
-        };
-        self.semaphore.store(Arc::new(Semaphore::new(n)));
+    /// until they finish; new jobs are bounded by the new value (min 1).
+    pub fn set_concurrency(&self, n: usize) {
+        self.semaphore.store(Arc::new(Semaphore::new(n.max(1))));
     }
 
     /// Cancel every in-flight job. Called on app exit.

--- a/apps/tauri/src-tauri/src/scraping/engine/test.rs
+++ b/apps/tauri/src-tauri/src/scraping/engine/test.rs
@@ -22,20 +22,12 @@ fn test_health() {
 }
 
 #[test]
-fn test_performance_mode() {
+fn test_set_concurrency() {
     let engine = ScraperEngine::new();
-
-    // Default mode should have semaphore limit of 2
-    engine.set_performance_mode("default");
-
-    // Low memory mode
-    engine.set_performance_mode("low-memory");
-
-    // Performance mode
-    engine.set_performance_mode("performance");
-
-    // Unknown mode should use default
-    engine.set_performance_mode("unknown");
+    engine.set_concurrency(1); // low-memory tier
+    engine.set_concurrency(2); // balanced
+    engine.set_concurrency(4); // performance
+    engine.set_concurrency(0); // clamps to >= 1, must not panic
 }
 
 #[tokio::test]

--- a/apps/tauri/src-tauri/tests/architecture.rs
+++ b/apps/tauri/src-tauri/tests/architecture.rs
@@ -24,6 +24,7 @@ use std::path::{Path, PathBuf};
 const L0: &[&str] = &[
     "error",
     "observability",
+    "performance",
     "db",
     "data_store",
     "net",

--- a/apps/tauri/src/renderer/components/background/CinematicBackground/CinematicBackground.test.tsx
+++ b/apps/tauri/src/renderer/components/background/CinematicBackground/CinematicBackground.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * CinematicBackground — layer presence/absence tests.
+ *
+ * jsdom's cssstyle drops hex/color-mix linear-gradient / radial-gradient inline
+ * styles, so we NEVER assert on computed gradient CSS. Instead we query stable
+ * class-name seams that the component guarantees:
+ *   - Aurora ribbons: `animate-aurora-1`, `animate-aurora-2`, `animate-aurora-3`
+ *   - Nebulae:        `animate-nebula-1`, `animate-nebula-2`
+ *   - Cursor glow:    `cursor-glow`
+ *
+ * We also assert on RAF / pointer-listener gating by spying on
+ * `window.addEventListener` and `requestAnimationFrame`.
+ *
+ * Mock strategy: `useResolvedPerformanceProfile` is mocked at the module level
+ * so tests can feed any profile without a full store/provider setup.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+import type { PerformanceProfile } from '@/store/preferences-schema';
+
+// ── mock useResolvedPerformanceProfile ────────────────────────────────────────
+
+const mockProfile = vi.fn(() => ({}) as PerformanceProfile);
+
+vi.mock('@/store/preferences-store', () => ({
+  useResolvedPerformanceProfile: () => mockProfile(),
+}));
+
+// ── import component AFTER mocks ──────────────────────────────────────────────
+
+import { CinematicBackground } from './index';
+
+// ── profile helpers ───────────────────────────────────────────────────────────
+
+function makeProfile(
+  overrides: Partial<PerformanceProfile['visual']> & {
+    backend?: Partial<PerformanceProfile['backend']>;
+  } = {}
+): PerformanceProfile {
+  const { backend, ...visualOverrides } = overrides;
+  return {
+    visual: {
+      aurora: false,
+      nebula: false,
+      richNebula: false,
+      cursorGlow: false,
+      blur: 'full',
+      animations: true,
+      ...visualOverrides,
+    },
+    backend: {
+      concurrency: 'balanced',
+      keepAlive: 'balanced',
+      cache: 'balanced',
+      ...backend,
+    },
+  };
+}
+
+const ALL_OFF = makeProfile(); // aurora=false, nebula=false, cursorGlow=false
+
+// ── test helpers ──────────────────────────────────────────────────────────────
+
+function auroraNodes(container: HTMLElement): NodeListOf<Element> {
+  return container.querySelectorAll('.animate-aurora-1, .animate-aurora-2, .animate-aurora-3');
+}
+
+function nebulaNodes(container: HTMLElement): NodeListOf<Element> {
+  return container.querySelectorAll('.animate-nebula-1, .animate-nebula-2');
+}
+
+function cursorGlowNodes(container: HTMLElement): NodeListOf<Element> {
+  return container.querySelectorAll('.cursor-glow');
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('CinematicBackground — layer presence/absence', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('all-visual-off profile (low-memory equivalent)', () => {
+    it('renders nothing when all layers are off', () => {
+      mockProfile.mockReturnValue(ALL_OFF);
+      const { container } = render(<CinematicBackground />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('aurora-only profile', () => {
+    it('renders 3 aurora ribbon nodes and no nebula or cursor-glow nodes', () => {
+      mockProfile.mockReturnValue(makeProfile({ aurora: true }));
+      const { container } = render(<CinematicBackground />);
+
+      expect(auroraNodes(container)).toHaveLength(3);
+      expect(nebulaNodes(container)).toHaveLength(0);
+      expect(cursorGlowNodes(container)).toHaveLength(0);
+    });
+  });
+
+  describe('nebula rendering', () => {
+    it('renders exactly ONE nebula node when nebula=true and richNebula=false', () => {
+      mockProfile.mockReturnValue(makeProfile({ aurora: true, nebula: true, richNebula: false }));
+      const { container } = render(<CinematicBackground />);
+
+      const nebulae = nebulaNodes(container);
+      expect(nebulae).toHaveLength(1);
+      // The single nebula must be the first one (animate-nebula-1).
+      const first = nebulae[0];
+      if (!first) throw new Error('expected exactly one nebula node');
+      expect(first.classList.contains('animate-nebula-1')).toBe(true);
+    });
+
+    it('renders TWO nebula nodes when nebula=true and richNebula=true', () => {
+      mockProfile.mockReturnValue(makeProfile({ aurora: true, nebula: true, richNebula: true }));
+      const { container } = render(<CinematicBackground />);
+
+      expect(nebulaNodes(container)).toHaveLength(2);
+    });
+
+    it('renders no nebula nodes when nebula=false even with richNebula=true', () => {
+      // richNebula without nebula — showRichNebula = nebula && richNebula = false.
+      mockProfile.mockReturnValue(makeProfile({ nebula: false, richNebula: true, aurora: true }));
+      const { container } = render(<CinematicBackground />);
+      expect(nebulaNodes(container)).toHaveLength(0);
+    });
+  });
+
+  describe('cursor glow RAF / listener gating', () => {
+    beforeEach(() => {
+      // Ensure matchMedia returns non-reduced-motion so the full RAF path runs.
+      const stub = {
+        matches: false,
+        media: '',
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      } as unknown as MediaQueryList;
+      window.matchMedia = (_query: string) => stub;
+    });
+
+    it('no pointermove listener and no RAF when cursorGlow=false', () => {
+      mockProfile.mockReturnValue(makeProfile({ cursorGlow: false }));
+      const addEventSpy = vi.spyOn(window, 'addEventListener');
+      const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(0);
+
+      render(<CinematicBackground />);
+
+      const pointermoveCalls = addEventSpy.mock.calls.filter((args) => args[0] === 'pointermove');
+      expect(pointermoveCalls).toHaveLength(0);
+      expect(rafSpy).not.toHaveBeenCalled();
+    });
+
+    it('schedules RAF when cursorGlow=true (no reduced-motion)', () => {
+      mockProfile.mockReturnValue(makeProfile({ aurora: true, cursorGlow: true }));
+      const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+      render(<CinematicBackground />);
+
+      expect(rafSpy).toHaveBeenCalled();
+    });
+
+    it('adds a pointermove listener when cursorGlow=true (no reduced-motion)', () => {
+      mockProfile.mockReturnValue(makeProfile({ aurora: true, cursorGlow: true }));
+      const addEventSpy = vi.spyOn(window, 'addEventListener');
+      vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+      render(<CinematicBackground />);
+
+      const pointermoveCalls = addEventSpy.mock.calls.filter((args) => args[0] === 'pointermove');
+      expect(pointermoveCalls.length).toBeGreaterThan(0);
+    });
+
+    it('renders the cursor-glow node when cursorGlow=true', () => {
+      mockProfile.mockReturnValue(makeProfile({ aurora: true, cursorGlow: true }));
+      vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+      const { container } = render(<CinematicBackground />);
+      expect(cursorGlowNodes(container)).toHaveLength(1);
+    });
+  });
+});

--- a/apps/tauri/src/renderer/components/background/CinematicBackground/CinematicBackground.test.tsx
+++ b/apps/tauri/src/renderer/components/background/CinematicBackground/CinematicBackground.test.tsx
@@ -129,6 +129,7 @@ describe('CinematicBackground — layer presence/absence', () => {
   });
 
   describe('cursor glow RAF / listener gating', () => {
+    const originalMatchMedia = window.matchMedia;
     beforeEach(() => {
       // Ensure matchMedia returns non-reduced-motion so the full RAF path runs.
       const stub = {
@@ -142,6 +143,9 @@ describe('CinematicBackground — layer presence/absence', () => {
         dispatchEvent: vi.fn(),
       } as unknown as MediaQueryList;
       window.matchMedia = (_query: string) => stub;
+    });
+    afterEach(() => {
+      window.matchMedia = originalMatchMedia;
     });
 
     it('no pointermove listener and no RAF when cursorGlow=false', () => {

--- a/apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx
+++ b/apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { usePerformanceMode } from '@/store/preferences-store';
+import { useResolvedPerformanceProfile } from '@/store/preferences-store';
 
 /**
  * Slim accent aurora backdrop.
@@ -21,10 +21,12 @@ import { usePerformanceMode } from '@/store/preferences-store';
  *     straight to the DOM node — zero React re-renders — and is paused while the
  *     tab/window is hidden.
  *   - `low-memory` renders nothing; `balanced` trims to a reduced layer budget;
- *     `performance` adds the second nebula.
+ *     `performance` adds the second nebula. `custom` gates each layer
+ *     independently from the resolved profile.
  */
 export function CinematicBackground() {
-  const mode = usePerformanceMode();
+  const profile = useResolvedPerformanceProfile();
+  const { aurora, nebula, richNebula, cursorGlow } = profile.visual;
 
   // ── Lerp cursor glow ────────────────────────────────────────────────────────
   const blobRef = useRef<HTMLDivElement>(null);
@@ -35,8 +37,9 @@ export function CinematicBackground() {
   const LERP = 0.005; // 0.5% per frame → extremely slow, dreamy floating effect
 
   useEffect(() => {
-    // Skip RAF loop in low-memory mode — component returns null below.
-    if (mode === 'low-memory') return;
+    // Skip the RAF loop + pointer listener entirely when the cursor glow is off
+    // (low-memory or a custom profile with it disabled) — nothing to animate.
+    if (!cursorGlow) return;
     // Reduced-motion users get a static glow: paint the blob once at viewport
     // center and skip the pointer listener + RAF entirely (the aurora/nebula
     // keyframes are already neutralized by the CSS reduced-motion media query).
@@ -90,49 +93,57 @@ export function CinematicBackground() {
       document.removeEventListener('visibilitychange', onVisibility);
       cancelAnimationFrame(rafRef.current);
     };
-  }, [mode]); // re-run if mode changes so RAF is cleaned up correctly
+  }, [cursorGlow]); // re-run if the cursor glow toggles so RAF is cleaned up correctly
 
-  // All hooks have been called — safe to bail out now.
-  if (mode === 'low-memory') return null;
+  // All hooks have been called — safe to bail out now. Render nothing only when
+  // every layer is off (preserves the low-memory = renders-nothing behavior).
+  if (!aurora && !nebula && !cursorGlow) return null;
 
-  // The second nebula only renders on the high-end budget; balanced trims it to
-  // cut the number of large blurred/composited layers on the default mode.
-  const full = mode === 'performance';
+  // The second nebula only renders when the profile opts into the rich nebula
+  // (the `performance` preset); balanced/custom trim it to cut the number of
+  // large blurred/composited layers.
+  const showRichNebula = nebula && richNebula;
 
   return (
     <div aria-hidden className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
       {/* Aurora ribbons */}
-      <div
-        className="absolute -top-1/4 left-0 h-[60vh] w-[60vw] rounded-full opacity-40 animate-aurora-1"
-        style={{
-          background: 'radial-gradient(closest-side, var(--aurora-violet) 0%, transparent 70%)',
-          willChange: 'transform',
-        }}
-      />
-      <div
-        className="absolute -top-1/4 left-0 h-[55vh] w-[55vw] rounded-full opacity-35 animate-aurora-2"
-        style={{
-          background: 'radial-gradient(closest-side, var(--aurora-indigo) 0%, transparent 70%)',
-          willChange: 'transform',
-        }}
-      />
-      <div
-        className="absolute top-1/3 left-0 h-[40vh] w-[40vw] rounded-full opacity-25 animate-aurora-3"
-        style={{
-          background: 'radial-gradient(closest-side, var(--aurora-pink) 0%, transparent 70%)',
-          willChange: 'transform',
-        }}
-      />
+      {aurora && (
+        <>
+          <div
+            className="absolute -top-1/4 left-0 h-[60vh] w-[60vw] rounded-full opacity-40 animate-aurora-1"
+            style={{
+              background: 'radial-gradient(closest-side, var(--aurora-violet) 0%, transparent 70%)',
+              willChange: 'transform',
+            }}
+          />
+          <div
+            className="absolute -top-1/4 left-0 h-[55vh] w-[55vw] rounded-full opacity-35 animate-aurora-2"
+            style={{
+              background: 'radial-gradient(closest-side, var(--aurora-indigo) 0%, transparent 70%)',
+              willChange: 'transform',
+            }}
+          />
+          <div
+            className="absolute top-1/3 left-0 h-[40vh] w-[40vw] rounded-full opacity-25 animate-aurora-3"
+            style={{
+              background: 'radial-gradient(closest-side, var(--aurora-pink) 0%, transparent 70%)',
+              willChange: 'transform',
+            }}
+          />
+        </>
+      )}
 
       {/* Nebulae */}
-      <div
-        className="absolute top-[10vh] left-0 h-[30vh] w-[30vw] rounded-full opacity-40 animate-nebula-1"
-        style={{
-          background: 'radial-gradient(closest-side, var(--nebula-violet) 0%, transparent 70%)',
-          willChange: 'transform',
-        }}
-      />
-      {full && (
+      {nebula && (
+        <div
+          className="absolute top-[10vh] left-0 h-[30vh] w-[30vw] rounded-full opacity-40 animate-nebula-1"
+          style={{
+            background: 'radial-gradient(closest-side, var(--nebula-violet) 0%, transparent 70%)',
+            willChange: 'transform',
+          }}
+        />
+      )}
+      {showRichNebula && (
         <div
           className="absolute top-[60vh] left-0 h-[25vh] w-[25vw] rounded-full opacity-35 animate-nebula-2"
           style={{
@@ -145,20 +156,22 @@ export function CinematicBackground() {
       {/* Cursor glow — 900px lerp-smoothed blob.
           Position is updated every RAF tick via ref mutation (no React renders).
           Mixes the accent brand + gradient-end so it re-tints with the accent. */}
-      <div
-        ref={blobRef}
-        className="cursor-glow absolute pointer-events-none"
-        style={{
-          width: 900,
-          height: 900,
-          top: 0,
-          left: 0,
-          background:
-            'radial-gradient(circle, color-mix(in srgb, var(--color-brand) 30%, transparent) 0%, color-mix(in srgb, var(--color-brand) 14%, transparent) 30%, color-mix(in srgb, var(--color-brand-2) 6%, transparent) 55%, transparent 72%)',
-          filter: 'blur(55px)',
-          willChange: 'transform',
-        }}
-      />
+      {cursorGlow && (
+        <div
+          ref={blobRef}
+          className="cursor-glow absolute pointer-events-none"
+          style={{
+            width: 900,
+            height: 900,
+            top: 0,
+            left: 0,
+            background:
+              'radial-gradient(circle, color-mix(in srgb, var(--color-brand) 30%, transparent) 0%, color-mix(in srgb, var(--color-brand) 14%, transparent) 30%, color-mix(in srgb, var(--color-brand-2) 6%, transparent) 55%, transparent 72%)',
+            filter: 'blur(55px)',
+            willChange: 'transform',
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/tauri/src/renderer/features/settings/components/preferences/PerformancePreferences/PerformancePreferences.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/PerformancePreferences/PerformancePreferences.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * PerformancePreferences — custom performance mode UI tests.
+ *
+ * Covers:
+ *  1. All 4 mode cards render (Low Memory, Balanced, Performance, Custom).
+ *  2. Selecting the Custom card:
+ *     - calls setPerformanceMode('custom').
+ *     - seeds customPerformance from the balanced preset (setCustomPerformance
+ *       called with balanced) when no custom profile exists yet.
+ *     - does NOT re-seed if a custom profile already exists.
+ *  3. Custom sub-panel appears when mode='custom'.
+ *  4. Toggling a visual Switch (role="switch") calls setCustomPerformance with
+ *     the updated field.
+ *  5. Changing a backend Dropdown calls setCustomPerformance with the updated
+ *     field.
+ *  6. The 4 dropdowns are labeled via <label htmlFor> → Dropdown id.
+ *
+ * Accessibility notes:
+ *  - Mode cards are `motion.button` → `role="button"` (implicit).
+ *  - Switches are `role="switch"` (explicit on the Button inside Switch).
+ *  - Dropdowns render a trigger `<button>` — query scoped to the sub-panel
+ *    `div` to avoid collisions with mode-card buttons.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  PERFORMANCE_PRESETS,
+  type PerformanceMode,
+  type PerformanceProfile,
+} from '@/store/preferences-schema';
+
+// ── store mock ────────────────────────────────────────────────────────────────
+
+const mockSetPerformanceMode = vi.fn();
+const mockSetCustomPerformance = vi.fn();
+
+let mockPerformanceMode: PerformanceMode = 'balanced';
+let mockProfile: PerformanceProfile = PERFORMANCE_PRESETS.balanced;
+let mockCustomPerformance: PerformanceProfile | undefined = undefined;
+
+vi.mock('@/store/preferences-store', () => ({
+  usePerformanceMode: () => mockPerformanceMode,
+  useResolvedPerformanceProfile: () => mockProfile,
+  usePreferencesStore: (
+    selector: (s: {
+      setPerformanceMode: typeof mockSetPerformanceMode;
+      setCustomPerformance: typeof mockSetCustomPerformance;
+      customPerformance: PerformanceProfile | undefined;
+    }) => unknown
+  ) =>
+    selector({
+      setPerformanceMode: mockSetPerformanceMode,
+      setCustomPerformance: mockSetCustomPerformance,
+      customPerformance: mockCustomPerformance,
+    }),
+}));
+
+// ── import component AFTER mocks ──────────────────────────────────────────────
+
+import { PerformancePreferences } from './index';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function renderPreferences() {
+  return render(<PerformancePreferences />);
+}
+
+/** Returns the custom sub-panel container when it is rendered. */
+function getCustomPanel(container: HTMLElement): HTMLElement {
+  // The sub-panel is the div.space-y-5 rendered when performanceMode === 'custom'.
+  // It contains both the "Visual" section label and the switch/dropdown controls.
+  const panel = container.querySelector<HTMLElement>('.space-y-5');
+  if (!panel) throw new Error('custom sub-panel not found — is performanceMode set to "custom"?');
+  return panel;
+}
+
+// ── reset ──────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockSetPerformanceMode.mockClear();
+  mockSetCustomPerformance.mockClear();
+  mockPerformanceMode = 'balanced';
+  mockProfile = PERFORMANCE_PRESETS.balanced;
+  mockCustomPerformance = undefined;
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('PerformancePreferences — mode card rendering', () => {
+  it('renders all four mode cards', () => {
+    renderPreferences();
+    expect(screen.getByText('Low Memory')).toBeInTheDocument();
+    expect(screen.getByText('Balanced')).toBeInTheDocument();
+    expect(screen.getByText('Performance')).toBeInTheDocument();
+    expect(screen.getByText('Custom')).toBeInTheDocument();
+  });
+});
+
+describe('PerformancePreferences — selecting the Custom card', () => {
+  it('calls setPerformanceMode with "custom" when the Custom card is clicked', async () => {
+    const user = userEvent.setup();
+    renderPreferences();
+    await user.click(screen.getByText('Custom'));
+    expect(mockSetPerformanceMode).toHaveBeenCalledWith('custom');
+  });
+
+  it('seeds customPerformance from balanced preset on first Custom selection (no existing custom)', async () => {
+    const user = userEvent.setup();
+    mockCustomPerformance = undefined;
+    renderPreferences();
+    await user.click(screen.getByText('Custom'));
+    expect(mockSetCustomPerformance).toHaveBeenCalledTimes(1);
+    const call = mockSetCustomPerformance.mock.calls.at(0);
+    if (!call) throw new Error('expected setCustomPerformance to have been called');
+    const calledWith = call[0] as PerformanceProfile;
+    expect(calledWith).toEqual(PERFORMANCE_PRESETS.balanced);
+  });
+
+  it('does NOT call setCustomPerformance when a custom profile already exists', async () => {
+    const user = userEvent.setup();
+    mockCustomPerformance = { ...PERFORMANCE_PRESETS.balanced };
+    renderPreferences();
+    await user.click(screen.getByText('Custom'));
+    expect(mockSetCustomPerformance).not.toHaveBeenCalled();
+  });
+});
+
+describe('PerformancePreferences — custom sub-panel', () => {
+  beforeEach(() => {
+    mockPerformanceMode = 'custom';
+    mockProfile = { ...PERFORMANCE_PRESETS.balanced };
+    mockCustomPerformance = { ...PERFORMANCE_PRESETS.balanced };
+  });
+
+  it('shows the custom sub-panel when mode=custom', () => {
+    renderPreferences();
+    expect(screen.getByText('Visual')).toBeInTheDocument();
+    expect(screen.getByText('Backend')).toBeInTheDocument();
+  });
+
+  it('does NOT show the custom sub-panel when mode=balanced', () => {
+    mockPerformanceMode = 'balanced';
+    mockProfile = PERFORMANCE_PRESETS.balanced;
+    renderPreferences();
+    // "Visual" section label only appears in the custom sub-panel.
+    expect(screen.queryByText('Visual')).not.toBeInTheDocument();
+  });
+
+  describe('visual switches (role="switch")', () => {
+    it('calls setCustomPerformance with aurora=false when the Aurora switch is toggled off', async () => {
+      // Profile has aurora=true (balanced).
+      mockProfile = { ...PERFORMANCE_PRESETS.balanced };
+      const user = userEvent.setup();
+      const { container } = renderPreferences();
+
+      // The Switch component renders role="switch"; its accessible name comes
+      // from the <label htmlFor> ("Aurora ribbons").
+      const panel = getCustomPanel(container);
+      const auroraSwitch = within(panel).getByRole('switch', { name: /aurora ribbons/i });
+      await user.click(auroraSwitch);
+
+      expect(mockSetCustomPerformance).toHaveBeenCalledTimes(1);
+      const call = mockSetCustomPerformance.mock.calls.at(0);
+      if (!call) throw new Error('expected setCustomPerformance to have been called');
+      const updated = call[0] as PerformanceProfile;
+      expect(updated.visual.aurora).toBe(false);
+    });
+
+    it('calls setCustomPerformance with cursorGlow=false when the cursor glow switch is toggled off', async () => {
+      mockProfile = { ...PERFORMANCE_PRESETS.balanced };
+      const user = userEvent.setup();
+      const { container } = renderPreferences();
+
+      const panel = getCustomPanel(container);
+      const glowSwitch = within(panel).getByRole('switch', { name: /cursor glow/i });
+      await user.click(glowSwitch);
+
+      const call = mockSetCustomPerformance.mock.calls.at(0);
+      if (!call) throw new Error('expected setCustomPerformance to have been called');
+      const updated = call[0] as PerformanceProfile;
+      expect(updated.visual.cursorGlow).toBe(false);
+    });
+
+    it('calls setCustomPerformance with nebula=false when the Nebulae switch is toggled off', async () => {
+      mockProfile = { ...PERFORMANCE_PRESETS.balanced };
+      const user = userEvent.setup();
+      const { container } = renderPreferences();
+
+      const panel = getCustomPanel(container);
+      const nebulaSwitch = within(panel).getByRole('switch', { name: /nebulae/i });
+      await user.click(nebulaSwitch);
+
+      const call = mockSetCustomPerformance.mock.calls.at(0);
+      if (!call) throw new Error('expected setCustomPerformance to have been called');
+      const updated = call[0] as PerformanceProfile;
+      expect(updated.visual.nebula).toBe(false);
+    });
+
+    it('calls setCustomPerformance with animations=false when the Rich animations switch is toggled off', async () => {
+      // Balanced preset has animations=true; toggling the switch should flip it.
+      mockProfile = { ...PERFORMANCE_PRESETS.balanced };
+      const user = userEvent.setup();
+      const { container } = renderPreferences();
+
+      const panel = getCustomPanel(container);
+      const animationsSwitch = within(panel).getByRole('switch', { name: /rich animations/i });
+      await user.click(animationsSwitch);
+
+      expect(mockSetCustomPerformance).toHaveBeenCalledTimes(1);
+      const call = mockSetCustomPerformance.mock.calls.at(0);
+      if (!call) throw new Error('expected setCustomPerformance to have been called');
+      const updated = call[0] as PerformanceProfile;
+      expect(updated.visual.animations).toBe(false);
+    });
+  });
+
+  describe('backend dropdowns', () => {
+    it('calls setCustomPerformance with concurrency="low" when Concurrency dropdown changes to Low', async () => {
+      mockProfile = { ...PERFORMANCE_PRESETS.balanced };
+      const user = userEvent.setup();
+      const { container } = renderPreferences();
+      const panel = getCustomPanel(container);
+
+      // The Concurrency dropdown trigger button is linked by id="perf-concurrency"
+      // and labeled by a <label htmlFor="perf-concurrency">. Query the trigger
+      // button by its id to avoid ambiguity with mode-card buttons.
+      const concurrencyTrigger = panel.querySelector<HTMLButtonElement>('#perf-concurrency');
+      if (!concurrencyTrigger)
+        throw new Error('expected Concurrency dropdown trigger #perf-concurrency');
+      await user.click(concurrencyTrigger);
+
+      // "Low" option appears in the open panel.
+      await user.click(screen.getByRole('option', { name: 'Low' }));
+
+      const call = mockSetCustomPerformance.mock.calls.at(0);
+      if (!call) throw new Error('expected setCustomPerformance to have been called');
+      const updated = call[0] as PerformanceProfile;
+      expect(updated.backend.concurrency).toBe('low');
+    });
+
+    it('calls setCustomPerformance with cache="high" when Cache dropdown changes to Generous', async () => {
+      mockProfile = { ...PERFORMANCE_PRESETS.balanced };
+      const user = userEvent.setup();
+      const { container } = renderPreferences();
+      const panel = getCustomPanel(container);
+
+      const cacheTrigger = panel.querySelector<HTMLButtonElement>('#perf-cache');
+      if (!cacheTrigger) throw new Error('expected Cache dropdown trigger #perf-cache');
+      await user.click(cacheTrigger);
+
+      await user.click(screen.getByRole('option', { name: 'Generous' }));
+
+      const call = mockSetCustomPerformance.mock.calls.at(0);
+      if (!call) throw new Error('expected setCustomPerformance to have been called');
+      const updated = call[0] as PerformanceProfile;
+      expect(updated.backend.cache).toBe('high');
+    });
+  });
+
+  describe('accessible label wiring (<label htmlFor> → Dropdown id)', () => {
+    it('each dropdown control has a <label htmlFor> referencing its id', () => {
+      const { container } = renderPreferences();
+      const labelIds = ['perf-blur', 'perf-concurrency', 'perf-keep-alive', 'perf-cache'];
+      for (const id of labelIds) {
+        const label = container.querySelector<HTMLLabelElement>(`label[for="${id}"]`);
+        if (!label) throw new Error(`expected a <label for="${id}">`);
+        expect(label).toBeInTheDocument();
+        const trigger = document.getElementById(id);
+        if (!trigger) throw new Error(`expected an element with id="${id}"`);
+        expect(trigger).toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/apps/tauri/src/renderer/features/settings/components/preferences/PerformancePreferences/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/PerformancePreferences/index.tsx
@@ -1,10 +1,20 @@
-import { Cpu, Gauge, type LucideIcon, Zap } from 'lucide-react';
+import { Cpu, Gauge, type LucideIcon, SlidersHorizontal, Zap } from 'lucide-react';
 import { motion } from 'motion/react';
 
-import { cn, GlassCard, SectionLabel, transition } from '@ajh/ui';
+import { cn, Dropdown, GlassCard, SectionLabel, Switch, transition } from '@ajh/ui';
 
-import type { PerformanceMode } from '@/store/preferences-schema';
-import { usePerformanceMode, usePreferencesStore } from '@/store/preferences-store';
+import {
+  type BlurTier,
+  PERFORMANCE_PRESETS,
+  type PerformanceMode,
+  type PerformanceProfile,
+  type PerfTier,
+} from '@/store/preferences-schema';
+import {
+  usePerformanceMode,
+  usePreferencesStore,
+  useResolvedPerformanceProfile,
+} from '@/store/preferences-store';
 
 const PERFORMANCE_OPTIONS: {
   value: PerformanceMode;
@@ -39,11 +49,62 @@ const PERFORMANCE_OPTIONS: {
     description: 'Maximum speed on capable hardware',
     details: ['Higher concurrency', 'Richer visuals', 'Aggressive caching', 'Full animations'],
   },
+  {
+    value: 'custom',
+    label: 'Custom',
+    icon: SlidersHorizontal,
+    description: 'Fine-tune every element',
+    details: ['Per-effect visual toggles', 'Manual backend tiers', 'Tailored to your machine'],
+  },
+];
+
+const BLUR_OPTIONS: { value: BlurTier; label: string }[] = [
+  { value: 'full', label: 'Full' },
+  { value: 'reduced', label: 'Reduced' },
+  { value: 'off', label: 'Off' },
+];
+
+const CONCURRENCY_OPTIONS: { value: PerfTier; label: string }[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'balanced', label: 'Balanced' },
+  { value: 'high', label: 'High' },
+];
+
+const KEEP_ALIVE_OPTIONS: { value: PerfTier; label: string }[] = [
+  { value: 'low', label: 'Unload immediately' },
+  { value: 'balanced', label: 'Balanced' },
+  { value: 'high', label: 'Keep warm' },
+];
+
+const CACHE_OPTIONS: { value: PerfTier; label: string }[] = [
+  { value: 'low', label: 'Minimal' },
+  { value: 'balanced', label: 'Balanced' },
+  { value: 'high', label: 'Generous' },
 ];
 
 export function PerformancePreferences() {
   const performanceMode = usePerformanceMode();
+  const profile = useResolvedPerformanceProfile();
   const setPerformanceMode = usePreferencesStore((s) => s.setPerformanceMode);
+  const setCustomPerformance = usePreferencesStore((s) => s.setCustomPerformance);
+  const customPerformance = usePreferencesStore((s) => s.customPerformance);
+
+  const selectMode = (value: PerformanceMode) => {
+    setPerformanceMode(value);
+    // Seed the custom profile from the balanced preset the first time the user
+    // picks Custom, so the sub-panel controls have a concrete profile to edit.
+    if (value === 'custom' && !customPerformance) {
+      setCustomPerformance(structuredClone(PERFORMANCE_PRESETS.balanced));
+    }
+  };
+
+  // Apply a single visual change on top of the current (custom) profile.
+  const patchVisual = (patch: Partial<PerformanceProfile['visual']>) => {
+    setCustomPerformance({ ...profile, visual: { ...profile.visual, ...patch } });
+  };
+  const patchBackend = (patch: Partial<PerformanceProfile['backend']>) => {
+    setCustomPerformance({ ...profile, backend: { ...profile.backend, ...patch } });
+  };
 
   return (
     <GlassCard>
@@ -61,7 +122,7 @@ export function PerformancePreferences() {
             <motion.button
               key={opt.value}
               type="button"
-              onClick={() => setPerformanceMode(opt.value)}
+              onClick={() => selectMode(opt.value)}
               className={cn(
                 'relative flex items-start gap-4 rounded-xl border p-4 text-left transition-all duration-150',
                 isSelected
@@ -112,6 +173,115 @@ export function PerformancePreferences() {
           );
         })}
       </div>
+
+      {performanceMode === 'custom' && (
+        <div className="mt-5 space-y-5 rounded-xl border border-white/10 bg-white/5 p-4">
+          {/* Visual */}
+          <div className="space-y-3">
+            <SectionLabel>Visual</SectionLabel>
+            <Switch
+              label="Aurora ribbons"
+              description="Slow, wide hue-rotating background blobs"
+              checked={profile.visual.aurora}
+              onCheckedChange={(next) => patchVisual({ aurora: next })}
+            />
+            <Switch
+              label="Nebulae"
+              description="Medium accent blobs layered over the aurora"
+              checked={profile.visual.nebula}
+              onCheckedChange={(next) => patchVisual({ nebula: next })}
+            />
+            <Switch
+              label="Cursor glow"
+              description="A soft glow that trails the pointer"
+              checked={profile.visual.cursorGlow}
+              onCheckedChange={(next) => patchVisual({ cursorGlow: next })}
+            />
+            <Switch
+              label="Rich animations"
+              description="Animate the aurora and nebula layers"
+              checked={profile.visual.animations}
+              onCheckedChange={(next) => patchVisual({ animations: next })}
+            />
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <label htmlFor="perf-blur" className="text-xs font-medium text-foreground/80">
+                  Backdrop blur
+                </label>
+                <div className="text-[11px] text-foreground/45">
+                  Frosted-glass intensity across surfaces
+                </div>
+              </div>
+              <div className="w-44 shrink-0">
+                <Dropdown
+                  id="perf-blur"
+                  options={BLUR_OPTIONS}
+                  value={profile.visual.blur}
+                  onChange={(v) => patchVisual({ blur: v as BlurTier })}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Backend */}
+          <div className="space-y-3">
+            <SectionLabel>Backend</SectionLabel>
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <label
+                  htmlFor="perf-concurrency"
+                  className="text-xs font-medium text-foreground/80"
+                >
+                  Concurrency
+                </label>
+                <div className="text-[11px] text-foreground/45">Parallel background workers</div>
+              </div>
+              <div className="w-44 shrink-0">
+                <Dropdown
+                  id="perf-concurrency"
+                  options={CONCURRENCY_OPTIONS}
+                  value={profile.backend.concurrency}
+                  onChange={(v) => patchBackend({ concurrency: v as PerfTier })}
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <label htmlFor="perf-keep-alive" className="text-xs font-medium text-foreground/80">
+                  Model keep-alive
+                </label>
+                <div className="text-[11px] text-foreground/45">
+                  How long idle models stay loaded
+                </div>
+              </div>
+              <div className="w-44 shrink-0">
+                <Dropdown
+                  id="perf-keep-alive"
+                  options={KEEP_ALIVE_OPTIONS}
+                  value={profile.backend.keepAlive}
+                  onChange={(v) => patchBackend({ keepAlive: v as PerfTier })}
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <label htmlFor="perf-cache" className="text-xs font-medium text-foreground/80">
+                  Cache
+                </label>
+                <div className="text-[11px] text-foreground/45">Cached result retention</div>
+              </div>
+              <div className="w-44 shrink-0">
+                <Dropdown
+                  id="perf-cache"
+                  options={CACHE_OPTIONS}
+                  value={profile.backend.cache}
+                  onChange={(v) => patchBackend({ cache: v as PerfTier })}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </GlassCard>
   );
 }

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.test.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.test.ts
@@ -13,7 +13,7 @@ describe('createMockClient', () => {
 
   it('provides sensible default resolved values', async () => {
     const client = createMockClient();
-    await expect(client.system.getProtocolVersion()).resolves.toBe('1.0.0');
+    await expect(client.system.getProtocolVersion()).resolves.toBe('1.1.0');
     await expect(client.system.getLocale()).resolves.toBe('en');
     await expect(client.jobs.list()).resolves.toEqual([]);
     await expect(client.documents.list()).resolves.toEqual([]);
@@ -34,6 +34,6 @@ describe('createMockClient', () => {
     });
     await expect(client.system.getVersion()).resolves.toBe('9.9.9');
     // Non-overridden methods on the same namespace remain intact.
-    await expect(client.system.getProtocolVersion()).resolves.toBe('1.0.0');
+    await expect(client.system.getProtocolVersion()).resolves.toBe('1.1.0');
   });
 });

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -52,7 +52,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       getMetrics: noop,
       checkBrowser: async () => ({ detected: false }),
       openDevtools: noop,
-      getProtocolVersion: async () => '1.0.0',
+      getProtocolVersion: async () => '1.1.0',
     },
 
     jobs: {

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -44,6 +44,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       getPlatform: noop,
       accentColor: async () => ({ supported: false, color: null }),
       openExternal: noop,
+      // Accepts the resolved PerformanceBackendConfig; no-op stub for tests.
       setPerformanceMode: noop,
       getLaunchAtLogin: async () => false,
       setLaunchAtLogin: async (enabled: boolean) => enabled,

--- a/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.custom-perf.test.tsx
+++ b/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.custom-perf.test.tsx
@@ -1,0 +1,388 @@
+/**
+ * PerformanceModeProvider — custom performance mode integration tests.
+ *
+ * Covers:
+ *  1. setPerformanceMode IPC is called with the resolved PerformanceBackendConfig
+ *     (correct numbers) for each mode.
+ *  2. <html> receives data-performance-mode, data-perf-blur, data-perf-animations.
+ *  3. A visual-only change (same backend tiers) does NOT re-invoke IPC (dedupe guard).
+ *  4. A backend/mode change DOES re-invoke IPC.
+ *
+ * Strategy:
+ *  - Mock the preferences-store selectors so tests can inject any profile without
+ *    a real store; this sidesteps Zustand + localStorage setup.
+ *  - Use createMockClient from @/lib/mock-client (the real factory) so the IPC
+ *    spy is a proper vi.fn().
+ *  - afterEach: clean up data-* attributes on <html> so tests don't bleed.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, render, waitFor } from '@testing-library/react';
+
+import type { PerformanceBackendConfig } from '@ajh/shared';
+
+import { createMockClient } from '@/lib/mock-client';
+import {
+  PERFORMANCE_PRESETS,
+  type PerformanceMode,
+  type PerformanceProfile,
+  resolveBackendConfig,
+} from '@/store/preferences-schema';
+
+import { AppClientProvider } from '../AppClientProvider';
+import { PerformanceModeProvider } from './PerformanceModeProvider';
+
+// ── mock preferences-store selectors ─────────────────────────────────────────
+
+let currentMode: PerformanceMode = 'balanced';
+let currentProfile: PerformanceProfile = PERFORMANCE_PRESETS.balanced;
+
+vi.mock('@/store/preferences-store', () => ({
+  usePerformanceMode: () => currentMode,
+  useResolvedPerformanceProfile: () => currentProfile,
+}));
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function renderProvider(setPerformanceMode: ReturnType<typeof vi.fn>) {
+  const client = createMockClient({ system: { setPerformanceMode } });
+  return render(
+    <AppClientProvider client={client}>
+      <PerformanceModeProvider>
+        <span>child</span>
+      </PerformanceModeProvider>
+    </AppClientProvider>
+  );
+}
+
+// ── cleanup ───────────────────────────────────────────────────────────────────
+
+afterEach(() => {
+  const root = document.documentElement;
+  root.removeAttribute('data-performance-mode');
+  root.removeAttribute('data-perf-blur');
+  root.removeAttribute('data-perf-animations');
+  currentMode = 'balanced';
+  currentProfile = PERFORMANCE_PRESETS.balanced;
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('PerformanceModeProvider — custom performance mode', () => {
+  describe('IPC payload correctness', () => {
+    it('calls setPerformanceMode with the balanced backend config on mount', async () => {
+      currentMode = 'balanced';
+      currentProfile = PERFORMANCE_PRESETS.balanced;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+      const call = spy.mock.calls.at(0);
+      if (!call) throw new Error('expected setPerformanceMode to have been called');
+      const config = call[0] as PerformanceBackendConfig;
+      expect(config.mode).toBe('balanced');
+      expect(config.concurrency).toBe(2);
+      expect(config.keepAliveSecs).toBe(300);
+      expect(config.cacheTtlSecs).toBe(604800);
+      expect(config.cacheMaxRows).toBe(2000);
+    });
+
+    it('calls setPerformanceMode with the low-memory backend config', async () => {
+      currentMode = 'low-memory';
+      currentProfile = PERFORMANCE_PRESETS['low-memory'];
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+      const call = spy.mock.calls.at(0);
+      if (!call) throw new Error('expected setPerformanceMode to have been called');
+      const config = call[0] as PerformanceBackendConfig;
+      expect(config.mode).toBe('low-memory');
+      expect(config.concurrency).toBe(1);
+      expect(config.keepAliveSecs).toBe(0);
+      expect(config.cacheTtlSecs).toBe(86400);
+      expect(config.cacheMaxRows).toBe(250);
+    });
+
+    it('calls setPerformanceMode with the performance backend config', async () => {
+      currentMode = 'performance';
+      currentProfile = PERFORMANCE_PRESETS.performance;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+      const call = spy.mock.calls.at(0);
+      if (!call) throw new Error('expected setPerformanceMode to have been called');
+      const config = call[0] as PerformanceBackendConfig;
+      expect(config.mode).toBe('performance');
+      expect(config.concurrency).toBe(4);
+      expect(config.keepAliveSecs).toBe(1800);
+      expect(config.cacheTtlSecs).toBeNull();
+      expect(config.cacheMaxRows).toBeNull();
+    });
+
+    it('calls setPerformanceMode with the custom backend config (mixed tiers)', async () => {
+      const customProfile: PerformanceProfile = {
+        visual: {
+          aurora: true,
+          nebula: false,
+          richNebula: false,
+          cursorGlow: false,
+          blur: 'off',
+          animations: false,
+        },
+        backend: { concurrency: 'high', keepAlive: 'low', cache: 'balanced' },
+      };
+      currentMode = 'custom';
+      currentProfile = customProfile;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+      const call = spy.mock.calls.at(0);
+      if (!call) throw new Error('expected setPerformanceMode to have been called');
+      const config = call[0] as PerformanceBackendConfig;
+      expect(config.mode).toBe('custom');
+      expect(config.concurrency).toBe(4); // high
+      expect(config.keepAliveSecs).toBe(0); // low
+      expect(config.cacheTtlSecs).toBe(604800); // balanced
+      expect(config.cacheMaxRows).toBe(2000); // balanced
+    });
+  });
+
+  describe('<html> data attributes', () => {
+    it('sets data-performance-mode to the active mode', async () => {
+      currentMode = 'balanced';
+      currentProfile = PERFORMANCE_PRESETS.balanced;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+      await waitFor(() => expect(spy).toHaveBeenCalled());
+      expect(document.documentElement.getAttribute('data-performance-mode')).toBe('balanced');
+    });
+
+    it('sets data-perf-blur to the resolved blur tier', async () => {
+      currentMode = 'balanced';
+      currentProfile = PERFORMANCE_PRESETS.balanced;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+      await waitFor(() => expect(spy).toHaveBeenCalled());
+      expect(document.documentElement.getAttribute('data-perf-blur')).toBe('full');
+    });
+
+    it("sets data-perf-animations='on' when animations are enabled", async () => {
+      currentMode = 'balanced';
+      currentProfile = PERFORMANCE_PRESETS.balanced;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+      await waitFor(() => expect(spy).toHaveBeenCalled());
+      expect(document.documentElement.getAttribute('data-perf-animations')).toBe('on');
+    });
+
+    it("sets data-perf-animations='off' for the low-memory preset", async () => {
+      currentMode = 'low-memory';
+      currentProfile = PERFORMANCE_PRESETS['low-memory'];
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+      await waitFor(() => expect(spy).toHaveBeenCalled());
+      expect(document.documentElement.getAttribute('data-perf-animations')).toBe('off');
+    });
+
+    it("sets data-perf-blur='reduced' for the low-memory preset", async () => {
+      currentMode = 'low-memory';
+      currentProfile = PERFORMANCE_PRESETS['low-memory'];
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+      await waitFor(() => expect(spy).toHaveBeenCalled());
+      expect(document.documentElement.getAttribute('data-perf-blur')).toBe('reduced');
+    });
+
+    it("reflects 'off' blur tier for a custom profile with blur='off'", async () => {
+      const customProfile: PerformanceProfile = {
+        visual: {
+          aurora: false,
+          nebula: false,
+          richNebula: false,
+          cursorGlow: false,
+          blur: 'off',
+          animations: false,
+        },
+        backend: { concurrency: 'balanced', keepAlive: 'balanced', cache: 'balanced' },
+      };
+      currentMode = 'custom';
+      currentProfile = customProfile;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      renderProvider(spy);
+      await waitFor(() => expect(spy).toHaveBeenCalled());
+      expect(document.documentElement.getAttribute('data-perf-blur')).toBe('off');
+      expect(document.documentElement.getAttribute('data-performance-mode')).toBe('custom');
+    });
+  });
+
+  describe('IPC deduplication', () => {
+    it('does NOT re-invoke IPC when only visual fields change (same backend config)', async () => {
+      // Start with balanced.
+      currentMode = 'balanced';
+      currentProfile = PERFORMANCE_PRESETS.balanced;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      const client = createMockClient({ system: { setPerformanceMode: spy } });
+
+      const { rerender } = render(
+        <AppClientProvider client={client}>
+          <PerformanceModeProvider>
+            <span>child</span>
+          </PerformanceModeProvider>
+        </AppClientProvider>
+      );
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+      // Simulate a visual-only change: same mode + same backend tiers, aurora toggled.
+      // The backend config JSON is unchanged → dedupe guard should suppress the IPC call.
+      const visualOnlyChange: PerformanceProfile = {
+        visual: { ...PERFORMANCE_PRESETS.balanced.visual, aurora: false },
+        backend: PERFORMANCE_PRESETS.balanced.backend, // identical backend
+      };
+      currentMode = 'balanced';
+      currentProfile = visualOnlyChange;
+
+      // Rerender with the new profile. Do NOT use a raw setTimeout to settle
+      // effects — that is non-deterministic under microtask scheduling. Instead,
+      // waitFor on a stable DOM attribute that the effect ALWAYS writes on every
+      // render (data-perf-blur reflects profile.visual.blur, which is unchanged
+      // between balanced and visualOnlyChange, so its value stays 'full'). The
+      // waitFor proves that the useEffect has flushed its synchronous DOM writes
+      // before we assert on the IPC spy.
+      rerender(
+        <AppClientProvider client={client}>
+          <PerformanceModeProvider>
+            <span>child</span>
+          </PerformanceModeProvider>
+        </AppClientProvider>
+      );
+
+      // Wait until the effect has written the (unchanged) blur attribute — this
+      // guarantees the full effect body has run for the re-render cycle.
+      await waitFor(() =>
+        expect(document.documentElement.getAttribute('data-perf-blur')).toBe('full')
+      );
+
+      // The serialized backend config is identical → no second IPC call.
+      expect(spy.mock.calls.length).toBe(1);
+    });
+
+    it('re-invokes IPC when the backend config changes (mode switch)', async () => {
+      currentMode = 'balanced';
+      currentProfile = PERFORMANCE_PRESETS.balanced;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      const client = createMockClient({ system: { setPerformanceMode: spy } });
+
+      const { rerender } = render(
+        <AppClientProvider client={client}>
+          <PerformanceModeProvider>
+            <span>child</span>
+          </PerformanceModeProvider>
+        </AppClientProvider>
+      );
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+      // Switch to low-memory — different backend config → IPC must re-fire.
+      currentMode = 'low-memory';
+      currentProfile = PERFORMANCE_PRESETS['low-memory'];
+
+      await act(async () => {
+        rerender(
+          <AppClientProvider client={client}>
+            <PerformanceModeProvider>
+              <span>child</span>
+            </PerformanceModeProvider>
+          </AppClientProvider>
+        );
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+      const secondCall = spy.mock.calls.at(1);
+      if (!secondCall) throw new Error('expected a second IPC call');
+      const config = secondCall[0] as PerformanceBackendConfig;
+      expect(config.mode).toBe('low-memory');
+      expect(config.concurrency).toBe(1);
+    });
+
+    it('re-invokes IPC when custom backend tiers change', async () => {
+      const customV1: PerformanceProfile = {
+        visual: {
+          aurora: true,
+          nebula: true,
+          richNebula: false,
+          cursorGlow: true,
+          blur: 'full',
+          animations: true,
+        },
+        backend: { concurrency: 'high', keepAlive: 'low', cache: 'balanced' },
+      };
+      currentMode = 'custom';
+      currentProfile = customV1;
+      const spy = vi.fn().mockResolvedValue(undefined);
+      const client = createMockClient({ system: { setPerformanceMode: spy } });
+
+      const { rerender } = render(
+        <AppClientProvider client={client}>
+          <PerformanceModeProvider>
+            <span>child</span>
+          </PerformanceModeProvider>
+        </AppClientProvider>
+      );
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+      // Change only the keepAlive backend tier → config serialization changes.
+      const customV2: PerformanceProfile = {
+        ...customV1,
+        backend: { ...customV1.backend, keepAlive: 'balanced' },
+      };
+      currentProfile = customV2;
+
+      await act(async () => {
+        rerender(
+          <AppClientProvider client={client}>
+            <PerformanceModeProvider>
+              <span>child</span>
+            </PerformanceModeProvider>
+          </AppClientProvider>
+        );
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+      const secondCall = spy.mock.calls.at(1);
+      if (!secondCall) throw new Error('expected a second IPC call');
+      const config = secondCall[0] as PerformanceBackendConfig;
+      expect(config.keepAliveSecs).toBe(300); // balanced
+    });
+  });
+
+  describe('error resilience', () => {
+    it('swallows backend errors without crashing the child', async () => {
+      currentMode = 'balanced';
+      currentProfile = PERFORMANCE_PRESETS.balanced;
+      const spy = vi.fn().mockRejectedValue(new Error('not ready'));
+      const { getByText } = renderProvider(spy);
+      await waitFor(() => expect(spy).toHaveBeenCalled());
+      expect(getByText('child')).toBeInTheDocument();
+    });
+  });
+});
+
+// Also re-export a basic sanity check to replace the existing test's coverage.
+describe('PerformanceModeProvider — resolveBackendConfig sanity (from provider)', () => {
+  it('resolveBackendConfig for balanced preset matches expected IPC payload', () => {
+    const cfg = resolveBackendConfig('balanced', PERFORMANCE_PRESETS.balanced);
+    expect(cfg).toEqual({
+      mode: 'balanced',
+      concurrency: 2,
+      keepAliveSecs: 300,
+      cacheTtlSecs: 604800,
+      cacheMaxRows: 2000,
+    });
+  });
+});

--- a/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.custom-perf.test.tsx
+++ b/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.custom-perf.test.tsx
@@ -16,7 +16,7 @@
  *  - afterEach: clean up data-* attributes on <html> so tests don't bleed.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { act, render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 import type { PerformanceBackendConfig } from '@ajh/shared';
 
@@ -235,10 +235,12 @@ describe('PerformanceModeProvider — custom performance mode', () => {
 
       await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
 
-      // Simulate a visual-only change: same mode + same backend tiers, aurora toggled.
-      // The backend config JSON is unchanged → dedupe guard should suppress the IPC call.
+      // Simulate a visual-only change: same mode + same backend tiers, blur flipped to
+      // 'reduced'. The backend config JSON is unchanged → dedupe guard should suppress
+      // the IPC call. Using a visual field that produces an OBSERVABLE attribute change
+      // (data-perf-blur goes 'full' → 'reduced') proves the effect ran for this cycle.
       const visualOnlyChange: PerformanceProfile = {
-        visual: { ...PERFORMANCE_PRESETS.balanced.visual, aurora: false },
+        visual: { ...PERFORMANCE_PRESETS.balanced.visual, blur: 'reduced' },
         backend: PERFORMANCE_PRESETS.balanced.backend, // identical backend
       };
       currentMode = 'balanced';
@@ -246,11 +248,8 @@ describe('PerformanceModeProvider — custom performance mode', () => {
 
       // Rerender with the new profile. Do NOT use a raw setTimeout to settle
       // effects — that is non-deterministic under microtask scheduling. Instead,
-      // waitFor on a stable DOM attribute that the effect ALWAYS writes on every
-      // render (data-perf-blur reflects profile.visual.blur, which is unchanged
-      // between balanced and visualOnlyChange, so its value stays 'full'). The
-      // waitFor proves that the useEffect has flushed its synchronous DOM writes
-      // before we assert on the IPC spy.
+      // waitFor on the NEW blur attribute value the effect WILL write on this cycle.
+      // When the waitFor resolves, the effect has provably completed its DOM writes.
       rerender(
         <AppClientProvider client={client}>
           <PerformanceModeProvider>
@@ -259,13 +258,14 @@ describe('PerformanceModeProvider — custom performance mode', () => {
         </AppClientProvider>
       );
 
-      // Wait until the effect has written the (unchanged) blur attribute — this
+      // Wait until the effect has written the CHANGED blur attribute — this
       // guarantees the full effect body has run for the re-render cycle.
       await waitFor(() =>
-        expect(document.documentElement.getAttribute('data-perf-blur')).toBe('full')
+        expect(document.documentElement.getAttribute('data-perf-blur')).toBe('reduced')
       );
 
-      // The serialized backend config is identical → no second IPC call.
+      // blur is a visual.* field — resolveBackendConfig reads only profile.backend.* —
+      // so the serialized backend config is identical → no second IPC call.
       expect(spy.mock.calls.length).toBe(1);
     });
 
@@ -289,16 +289,13 @@ describe('PerformanceModeProvider — custom performance mode', () => {
       currentMode = 'low-memory';
       currentProfile = PERFORMANCE_PRESETS['low-memory'];
 
-      await act(async () => {
-        rerender(
-          <AppClientProvider client={client}>
-            <PerformanceModeProvider>
-              <span>child</span>
-            </PerformanceModeProvider>
-          </AppClientProvider>
-        );
-        await new Promise((r) => setTimeout(r, 0));
-      });
+      rerender(
+        <AppClientProvider client={client}>
+          <PerformanceModeProvider>
+            <span>child</span>
+          </PerformanceModeProvider>
+        </AppClientProvider>
+      );
 
       await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
       const secondCall = spy.mock.calls.at(1);
@@ -342,16 +339,13 @@ describe('PerformanceModeProvider — custom performance mode', () => {
       };
       currentProfile = customV2;
 
-      await act(async () => {
-        rerender(
-          <AppClientProvider client={client}>
-            <PerformanceModeProvider>
-              <span>child</span>
-            </PerformanceModeProvider>
-          </AppClientProvider>
-        );
-        await new Promise((r) => setTimeout(r, 0));
-      });
+      rerender(
+        <AppClientProvider client={client}>
+          <PerformanceModeProvider>
+            <span>child</span>
+          </PerformanceModeProvider>
+        </AppClientProvider>
+      );
 
       await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
       const secondCall = spy.mock.calls.at(1);

--- a/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.test.tsx
+++ b/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.test.tsx
@@ -20,9 +20,11 @@ describe('PerformanceModeProvider', () => {
     );
 
     await waitFor(() => expect(setPerformanceMode).toHaveBeenCalled());
-    // Default preference is 'balanced'.
+    // Default preference is 'balanced' — IPC receives the resolved PerformanceBackendConfig.
     expect(document.documentElement.getAttribute('data-performance-mode')).toBe('balanced');
-    expect(setPerformanceMode).toHaveBeenCalledWith('balanced');
+    expect(setPerformanceMode).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'balanced', concurrency: 2, keepAliveSecs: 300 })
+    );
   });
 
   it('swallows backend errors without crashing', async () => {

--- a/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.tsx
+++ b/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.tsx
@@ -1,32 +1,44 @@
 import { type ReactNode, useEffect, useRef } from 'react';
 
 import { useAppClient } from '@/providers/AppClientProvider';
-import { usePerformanceMode } from '@/store/preferences-store';
+import { resolveBackendConfig } from '@/store/preferences-schema';
+import { usePerformanceMode, useResolvedPerformanceProfile } from '@/store/preferences-store';
 
 /**
- * Syncs the renderer's performanceMode preference to two side effects:
- *   1. data-performance-mode attribute on <html> — drives CSS-level blur
- *      reduction.
- *   2. system.setPerformanceMode IPC — lets the main process adjust JobQueue
- *      concurrency and AiRuntime idle-unload timeout accordingly.
+ * Syncs the renderer's resolved performance profile to side effects:
+ *   1. data-performance-mode  — the mode string (e2e + legacy CSS hooks).
+ *   2. data-perf-blur         — the resolved backdrop-blur tier (full/reduced/off).
+ *   3. data-perf-animations   — whether aurora/nebula keyframes run (on/off).
+ *   4. system.setPerformanceMode IPC — pushes the resolved backend config so the
+ *      main process can adjust JobQueue concurrency, model keep-alive, and cache.
  *
  * Place this inside <AppClientProvider> so getClient() is always ready.
  */
 export function PerformanceModeProvider({ children }: { children: ReactNode }) {
   const client = useAppClient();
   const mode = usePerformanceMode();
-  const prevMode = useRef<string | null>(null);
+  const profile = useResolvedPerformanceProfile();
+  // Last payload pushed over IPC, serialized — re-pushes whenever the resolved
+  // config changes (including in-place custom-profile edits), skips redundant IPC.
+  const prevPayload = useRef<string | null>(null);
 
   useEffect(() => {
-    if (mode === prevMode.current) return;
-    prevMode.current = mode;
+    const root = document.documentElement;
+    root.setAttribute('data-performance-mode', mode);
+    root.setAttribute('data-perf-blur', profile.visual.blur);
+    root.setAttribute('data-perf-animations', profile.visual.animations ? 'on' : 'off');
 
-    document.documentElement.setAttribute('data-performance-mode', mode);
+    // DOM attributes above always reflect the latest profile — cheap, no dedupe.
+    // IPC is deduped below: invoking Rust on every visual-only tweak is wasteful.
+    const config = resolveBackendConfig(mode, profile);
+    const serialized = JSON.stringify(config);
+    if (serialized === prevPayload.current) return;
+    prevPayload.current = serialized;
 
-    client.system.setPerformanceMode(mode).catch(() => {
+    client.system.setPerformanceMode(config).catch(() => {
       // Silently ignore — main process may not be ready on first render.
     });
-  }, [client, mode]);
+  }, [client, mode, profile]);
 
   return <>{children}</>;
 }

--- a/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.tsx
+++ b/apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.tsx
@@ -33,11 +33,18 @@ export function PerformanceModeProvider({ children }: { children: ReactNode }) {
     const config = resolveBackendConfig(mode, profile);
     const serialized = JSON.stringify(config);
     if (serialized === prevPayload.current) return;
-    prevPayload.current = serialized;
 
-    client.system.setPerformanceMode(config).catch(() => {
-      // Silently ignore — main process may not be ready on first render.
-    });
+    client.system
+      .setPerformanceMode(config)
+      .then(() => {
+        // Only mark this payload as pushed once the IPC actually succeeds.
+        // On failure (e.g. shell not ready on first render) we leave the dedupe
+        // cache untouched so the next effect run retries instead of suppressing.
+        prevPayload.current = serialized;
+      })
+      .catch(() => {
+        // Silently ignore — main process may not be ready on first render.
+      });
   }, [client, mode, profile]);
 
   return <>{children}</>;

--- a/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.custom-perf.test.ts
+++ b/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.custom-perf.test.ts
@@ -1,0 +1,296 @@
+/**
+ * preferences-schema — custom performance mode tests.
+ *
+ * Covers:
+ *  1. PerformanceModeSchema accepts 'custom'.
+ *  2. resolveProfile: presets → PERFORMANCE_PRESETS; custom → customPerformance
+ *     (with balanced fallback when undefined).
+ *  3. Preset fidelity contract (regression-critical): exact field values for all
+ *     three preset modes.
+ *  4. resolveBackendConfig: tier→number tables (concurrency, keepAlive, cache TTL,
+ *     cache max-rows) for every PerfTier, plus mode passthrough.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  PERFORMANCE_PRESETS,
+  PerformanceModeSchema,
+  type PerformanceProfile,
+  resolveBackendConfig,
+  resolveProfile,
+} from './preferences-schema';
+
+// ── 1. Schema accepts 'custom' ────────────────────────────────────────────────
+
+describe("PerformanceModeSchema accepts 'custom'", () => {
+  it("parses 'custom' without throwing", () => {
+    expect(PerformanceModeSchema.parse('custom')).toBe('custom');
+  });
+
+  it('still rejects unknown values', () => {
+    expect(() => PerformanceModeSchema.parse('turbo')).toThrow();
+    expect(() => PerformanceModeSchema.parse('maximum')).toThrow();
+  });
+
+  it('accepts all four valid modes', () => {
+    for (const mode of ['low-memory', 'balanced', 'performance', 'custom'] as const) {
+      expect(PerformanceModeSchema.parse(mode)).toBe(mode);
+    }
+  });
+});
+
+// ── 2. resolveProfile ─────────────────────────────────────────────────────────
+
+describe('resolveProfile', () => {
+  it('returns the low-memory preset for performanceMode=low-memory', () => {
+    const result = resolveProfile({ performanceMode: 'low-memory', customPerformance: undefined });
+    expect(result).toBe(PERFORMANCE_PRESETS['low-memory']);
+  });
+
+  it('returns the balanced preset for performanceMode=balanced', () => {
+    const result = resolveProfile({ performanceMode: 'balanced', customPerformance: undefined });
+    expect(result).toBe(PERFORMANCE_PRESETS.balanced);
+  });
+
+  it('returns the performance preset for performanceMode=performance', () => {
+    const result = resolveProfile({ performanceMode: 'performance', customPerformance: undefined });
+    expect(result).toBe(PERFORMANCE_PRESETS.performance);
+  });
+
+  it('returns customPerformance when mode=custom and a custom profile exists', () => {
+    const custom: PerformanceProfile = {
+      visual: {
+        aurora: true,
+        nebula: false,
+        richNebula: false,
+        cursorGlow: false,
+        blur: 'off',
+        animations: false,
+      },
+      backend: { concurrency: 'high', keepAlive: 'low', cache: 'balanced' },
+    };
+    const result = resolveProfile({ performanceMode: 'custom', customPerformance: custom });
+    expect(result).toBe(custom);
+  });
+
+  it('falls back to the balanced preset when mode=custom but customPerformance is undefined', () => {
+    const result = resolveProfile({ performanceMode: 'custom', customPerformance: undefined });
+    expect(result).toBe(PERFORMANCE_PRESETS.balanced);
+  });
+});
+
+// ── 3. Preset fidelity contract ───────────────────────────────────────────────
+
+describe('PERFORMANCE_PRESETS fidelity contract', () => {
+  describe("'low-memory' preset", () => {
+    const p = PERFORMANCE_PRESETS['low-memory'];
+
+    it('has all visual flags off', () => {
+      expect(p.visual.aurora).toBe(false);
+      expect(p.visual.nebula).toBe(false);
+      expect(p.visual.richNebula).toBe(false);
+      expect(p.visual.cursorGlow).toBe(false);
+      expect(p.visual.animations).toBe(false);
+    });
+
+    it("has blur='reduced'", () => {
+      expect(p.visual.blur).toBe('reduced');
+    });
+
+    it("has all backend tiers set to 'low'", () => {
+      expect(p.backend.concurrency).toBe('low');
+      expect(p.backend.keepAlive).toBe('low');
+      expect(p.backend.cache).toBe('low');
+    });
+  });
+
+  describe("'balanced' preset", () => {
+    const p = PERFORMANCE_PRESETS.balanced;
+
+    it('has aurora, nebula, cursorGlow, animations on; richNebula off', () => {
+      expect(p.visual.aurora).toBe(true);
+      expect(p.visual.nebula).toBe(true);
+      expect(p.visual.richNebula).toBe(false);
+      expect(p.visual.cursorGlow).toBe(true);
+      expect(p.visual.animations).toBe(true);
+    });
+
+    it("has blur='full'", () => {
+      expect(p.visual.blur).toBe('full');
+    });
+
+    it("has all backend tiers set to 'balanced'", () => {
+      expect(p.backend.concurrency).toBe('balanced');
+      expect(p.backend.keepAlive).toBe('balanced');
+      expect(p.backend.cache).toBe('balanced');
+    });
+  });
+
+  describe("'performance' preset", () => {
+    const p = PERFORMANCE_PRESETS.performance;
+
+    it('has aurora, nebula, richNebula, cursorGlow, animations all on', () => {
+      expect(p.visual.aurora).toBe(true);
+      expect(p.visual.nebula).toBe(true);
+      expect(p.visual.richNebula).toBe(true);
+      expect(p.visual.cursorGlow).toBe(true);
+      expect(p.visual.animations).toBe(true);
+    });
+
+    it("has blur='full'", () => {
+      expect(p.visual.blur).toBe('full');
+    });
+
+    it("has all backend tiers set to 'high'", () => {
+      expect(p.backend.concurrency).toBe('high');
+      expect(p.backend.keepAlive).toBe('high');
+      expect(p.backend.cache).toBe('high');
+    });
+  });
+});
+
+// ── 4. resolveBackendConfig tier→number tables ────────────────────────────────
+
+describe('resolveBackendConfig', () => {
+  function profileWithTiers(
+    concurrency: PerformanceProfile['backend']['concurrency'],
+    keepAlive: PerformanceProfile['backend']['keepAlive'],
+    cache: PerformanceProfile['backend']['cache']
+  ): PerformanceProfile {
+    return {
+      visual: {
+        aurora: false,
+        nebula: false,
+        richNebula: false,
+        cursorGlow: false,
+        blur: 'full',
+        animations: true,
+      },
+      backend: { concurrency, keepAlive, cache },
+    };
+  }
+
+  describe('concurrency tier→number', () => {
+    it('low → 1', () => {
+      const cfg = resolveBackendConfig('balanced', profileWithTiers('low', 'balanced', 'balanced'));
+      expect(cfg.concurrency).toBe(1);
+    });
+
+    it('balanced → 2', () => {
+      const cfg = resolveBackendConfig(
+        'balanced',
+        profileWithTiers('balanced', 'balanced', 'balanced')
+      );
+      expect(cfg.concurrency).toBe(2);
+    });
+
+    it('high → 4', () => {
+      const cfg = resolveBackendConfig(
+        'balanced',
+        profileWithTiers('high', 'balanced', 'balanced')
+      );
+      expect(cfg.concurrency).toBe(4);
+    });
+  });
+
+  describe('keepAliveSecs tier→number', () => {
+    it('low → 0', () => {
+      const cfg = resolveBackendConfig('balanced', profileWithTiers('balanced', 'low', 'balanced'));
+      expect(cfg.keepAliveSecs).toBe(0);
+    });
+
+    it('balanced → 300', () => {
+      const cfg = resolveBackendConfig(
+        'balanced',
+        profileWithTiers('balanced', 'balanced', 'balanced')
+      );
+      expect(cfg.keepAliveSecs).toBe(300);
+    });
+
+    it('high → 1800', () => {
+      const cfg = resolveBackendConfig(
+        'balanced',
+        profileWithTiers('balanced', 'high', 'balanced')
+      );
+      expect(cfg.keepAliveSecs).toBe(1800);
+    });
+  });
+
+  describe('cacheTtlSecs tier→number', () => {
+    it('low → 86400 (1 day)', () => {
+      const cfg = resolveBackendConfig('balanced', profileWithTiers('balanced', 'balanced', 'low'));
+      expect(cfg.cacheTtlSecs).toBe(86400);
+    });
+
+    it('balanced → 604800 (7 days)', () => {
+      const cfg = resolveBackendConfig(
+        'balanced',
+        profileWithTiers('balanced', 'balanced', 'balanced')
+      );
+      expect(cfg.cacheTtlSecs).toBe(604800);
+    });
+
+    it('high → null (no expiry)', () => {
+      const cfg = resolveBackendConfig(
+        'balanced',
+        profileWithTiers('balanced', 'balanced', 'high')
+      );
+      expect(cfg.cacheTtlSecs).toBeNull();
+    });
+  });
+
+  describe('cacheMaxRows tier→number', () => {
+    it('low → 250', () => {
+      const cfg = resolveBackendConfig('balanced', profileWithTiers('balanced', 'balanced', 'low'));
+      expect(cfg.cacheMaxRows).toBe(250);
+    });
+
+    it('balanced → 2000', () => {
+      const cfg = resolveBackendConfig(
+        'balanced',
+        profileWithTiers('balanced', 'balanced', 'balanced')
+      );
+      expect(cfg.cacheMaxRows).toBe(2000);
+    });
+
+    it('high → null (unbounded)', () => {
+      const cfg = resolveBackendConfig(
+        'balanced',
+        profileWithTiers('balanced', 'balanced', 'high')
+      );
+      expect(cfg.cacheMaxRows).toBeNull();
+    });
+  });
+
+  describe('mode passthrough', () => {
+    it('passes the mode string through to the config for each mode', () => {
+      const profile = profileWithTiers('balanced', 'balanced', 'balanced');
+      expect(resolveBackendConfig('low-memory', profile).mode).toBe('low-memory');
+      expect(resolveBackendConfig('balanced', profile).mode).toBe('balanced');
+      expect(resolveBackendConfig('performance', profile).mode).toBe('performance');
+      expect(resolveBackendConfig('custom', profile).mode).toBe('custom');
+    });
+  });
+
+  describe('custom mode end-to-end', () => {
+    it('correctly resolves a custom profile with mixed tiers', () => {
+      const custom: PerformanceProfile = {
+        visual: {
+          aurora: true,
+          nebula: true,
+          richNebula: false,
+          cursorGlow: false,
+          blur: 'reduced',
+          animations: true,
+        },
+        backend: { concurrency: 'high', keepAlive: 'low', cache: 'balanced' },
+      };
+      const cfg = resolveBackendConfig('custom', custom);
+      expect(cfg.mode).toBe('custom');
+      expect(cfg.concurrency).toBe(4); // high
+      expect(cfg.keepAliveSecs).toBe(0); // low
+      expect(cfg.cacheTtlSecs).toBe(604800); // balanced
+      expect(cfg.cacheMaxRows).toBe(2000); // balanced
+    });
+  });
+});

--- a/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
+++ b/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
@@ -1,7 +1,43 @@
 import { z } from 'zod';
 
-// Performance modes
-export const PerformanceModeSchema = z.enum(['low-memory', 'balanced', 'performance']);
+import type { PerformanceBackendConfig } from '@ajh/shared';
+
+// Performance modes. `custom` resolves to the user-edited `customPerformance`
+// profile; the other three resolve to the fixed presets below.
+export const PerformanceModeSchema = z.enum(['low-memory', 'balanced', 'performance', 'custom']);
+
+// Backdrop-blur tier and generic backend tier used by the resolved profile.
+/**
+ * Backdrop-blur tier. The `'off'` tier is reachable ONLY via a custom profile —
+ * the three presets use `'full'` (balanced/performance) or `'reduced'` (low-memory).
+ */
+export const BlurTierSchema = z.enum(['full', 'reduced', 'off']);
+export const PerfTierSchema = z.enum(['low', 'balanced', 'high']);
+
+// Resolved performance profile — the single shape every consumer reads. Presets
+// resolve to this; `custom` mode stores one of these directly under
+// `customPerformance`.
+export const PerformanceProfileSchema = z.object({
+  visual: z.object({
+    aurora: z.boolean(),
+    nebula: z.boolean(),
+    // Preset-only: the `performance` preset's second nebula. NOT surfaced in the
+    // custom UI; custom profiles keep it false.
+    richNebula: z.boolean().default(false),
+    cursorGlow: z.boolean(),
+    blur: BlurTierSchema,
+    animations: z.boolean(),
+  }),
+  backend: z.object({
+    concurrency: PerfTierSchema,
+    keepAlive: PerfTierSchema,
+    cache: PerfTierSchema,
+  }),
+});
+
+export type PerformanceProfile = z.infer<typeof PerformanceProfileSchema>;
+export type BlurTier = z.infer<typeof BlurTierSchema>;
+export type PerfTier = z.infer<typeof PerfTierSchema>;
 
 // Prompt quality — controls which prompt variant is sent to the model
 // auto    = detect from model tier (default, safe for all providers)
@@ -124,6 +160,10 @@ export const PreferencesSchema = z.object({
   // Performance Preferences
   performanceMode: PerformanceModeSchema.default('balanced'),
 
+  // User-edited profile used when performanceMode === 'custom'. Seeded from the
+  // balanced preset the first time the user picks the Custom card.
+  customPerformance: PerformanceProfileSchema.optional(),
+
   // Prompt quality — which prompt variant to send to the AI model
   promptQuality: PromptQualitySchema.default('auto'),
 
@@ -151,6 +191,98 @@ export const PreferencesSchema = z.object({
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
 export type PerformanceMode = z.infer<typeof PerformanceModeSchema>;
+
+// ── Performance presets & resolvers ─────────────────────────────────────────
+
+/**
+ * Fixed profiles for the three preset modes. These reproduce the historical
+ * behavior exactly (low-memory = renders nothing + reduced blur + no animations;
+ * balanced = aurora + 1 nebula + cursor glow; performance = + 2nd nebula).
+ */
+export const PERFORMANCE_PRESETS: Record<
+  'low-memory' | 'balanced' | 'performance',
+  PerformanceProfile
+> = {
+  'low-memory': {
+    visual: {
+      aurora: false,
+      nebula: false,
+      richNebula: false,
+      cursorGlow: false,
+      blur: 'reduced',
+      animations: false,
+    },
+    backend: { concurrency: 'low', keepAlive: 'low', cache: 'low' },
+  },
+  balanced: {
+    visual: {
+      aurora: true,
+      nebula: true,
+      richNebula: false,
+      cursorGlow: true,
+      blur: 'full',
+      animations: true,
+    },
+    backend: { concurrency: 'balanced', keepAlive: 'balanced', cache: 'balanced' },
+  },
+  performance: {
+    visual: {
+      aurora: true,
+      nebula: true,
+      richNebula: true,
+      cursorGlow: true,
+      blur: 'full',
+      animations: true,
+    },
+    backend: { concurrency: 'high', keepAlive: 'high', cache: 'high' },
+  },
+};
+
+/**
+ * Resolve the active mode + optional custom profile into a single profile.
+ * `custom` falls back to the balanced preset until the user has seeded a custom
+ * profile (defensive — the UI seeds it on first selection).
+ */
+export function resolveProfile(
+  prefs: Pick<Preferences, 'performanceMode' | 'customPerformance'>
+): PerformanceProfile {
+  if (prefs.performanceMode === 'custom') {
+    return prefs.customPerformance ?? PERFORMANCE_PRESETS.balanced;
+  }
+  return PERFORMANCE_PRESETS[prefs.performanceMode];
+}
+
+// Tier→number tables for the backend IPC payload. cache 'low' = minimal,
+// 'balanced' = balanced, 'high' = generous (no expiry / unbounded rows).
+const CONCURRENCY_BY_TIER: Record<PerfTier, number> = { low: 1, balanced: 2, high: 4 };
+const KEEP_ALIVE_SECS_BY_TIER: Record<PerfTier, number> = { low: 0, balanced: 300, high: 1800 };
+const CACHE_TTL_SECS_BY_TIER: Record<PerfTier, number | null> = {
+  low: 86400,
+  balanced: 604800,
+  high: null,
+};
+const CACHE_MAX_ROWS_BY_TIER: Record<PerfTier, number | null> = {
+  low: 250,
+  balanced: 2000,
+  high: null,
+};
+
+/**
+ * Resolve a profile's backend tiers into the concrete `PerformanceBackendConfig`
+ * pushed over IPC to the Rust shell. Pure — no side effects.
+ */
+export function resolveBackendConfig(
+  mode: PerformanceMode,
+  profile: PerformanceProfile
+): PerformanceBackendConfig {
+  return {
+    mode,
+    concurrency: CONCURRENCY_BY_TIER[profile.backend.concurrency],
+    keepAliveSecs: KEEP_ALIVE_SECS_BY_TIER[profile.backend.keepAlive],
+    cacheTtlSecs: CACHE_TTL_SECS_BY_TIER[profile.backend.cache],
+    cacheMaxRows: CACHE_MAX_ROWS_BY_TIER[profile.backend.cache],
+  };
+}
 export type PromptQuality = z.infer<typeof PromptQualitySchema>;
 export type OutputTone = z.infer<typeof OutputToneSchema>;
 export type AIModelPreference = z.infer<typeof AIModelPreferenceSchema>;

--- a/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
+++ b/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
@@ -275,12 +275,27 @@ export function resolveBackendConfig(
   mode: PerformanceMode,
   profile: PerformanceProfile
 ): PerformanceBackendConfig {
+  // Defensive fallbacks guard against malformed persisted customPerformance whose
+  // tier key is not a valid PerfTier (e.g. stale/migrated data). We cast to
+  // Partial<Record<…>> so the index access types as `T | undefined`, making the
+  // fallback well-typed. For the nullable cache tables null is intentional ("no
+  // limit" for the high tier) — only undefined (missing key) falls back.
+  const cacheTtlRaw = (CACHE_TTL_SECS_BY_TIER as Partial<Record<PerfTier, number | null>>)[
+    profile.backend.cache
+  ];
+  const cacheMaxRaw = (CACHE_MAX_ROWS_BY_TIER as Partial<Record<PerfTier, number | null>>)[
+    profile.backend.cache
+  ];
   return {
     mode,
-    concurrency: CONCURRENCY_BY_TIER[profile.backend.concurrency],
-    keepAliveSecs: KEEP_ALIVE_SECS_BY_TIER[profile.backend.keepAlive],
-    cacheTtlSecs: CACHE_TTL_SECS_BY_TIER[profile.backend.cache],
-    cacheMaxRows: CACHE_MAX_ROWS_BY_TIER[profile.backend.cache],
+    concurrency:
+      (CONCURRENCY_BY_TIER as Partial<Record<PerfTier, number>>)[profile.backend.concurrency] ??
+      CONCURRENCY_BY_TIER.balanced,
+    keepAliveSecs:
+      (KEEP_ALIVE_SECS_BY_TIER as Partial<Record<PerfTier, number>>)[profile.backend.keepAlive] ??
+      KEEP_ALIVE_SECS_BY_TIER.balanced,
+    cacheTtlSecs: cacheTtlRaw === undefined ? CACHE_TTL_SECS_BY_TIER.balanced : cacheTtlRaw,
+    cacheMaxRows: cacheMaxRaw === undefined ? CACHE_MAX_ROWS_BY_TIER.balanced : cacheMaxRaw,
   };
 }
 export type PromptQuality = z.infer<typeof PromptQualitySchema>;

--- a/apps/tauri/src/renderer/store/preferences-store/preferences-store.custom-perf.test.ts
+++ b/apps/tauri/src/renderer/store/preferences-store/preferences-store.custom-perf.test.ts
@@ -1,0 +1,144 @@
+/**
+ * preferences-store — custom performance mode tests.
+ *
+ * Covers:
+ *  - setCustomPerformance writes the profile and bumps lastUpdated.
+ *  - useResolvedPerformanceProfile (via the selector) returns the preset when
+ *    mode is a preset and the custom profile when mode='custom'.
+ *  - setPerformanceMode('custom') switches mode; combined with setCustomPerformance
+ *    the resolver returns the custom profile.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  PERFORMANCE_PRESETS,
+  type PerformanceProfile,
+  resolveProfile,
+} from '../preferences-schema';
+import { usePreferencesStore } from './preferences-store';
+
+beforeEach(() => {
+  localStorage.clear();
+  usePreferencesStore.getState().resetPreferences();
+  // resetPreferences() merges defaultPreferences but does not explicitly clear
+  // fields absent from defaultPreferences (like customPerformance). Clear it
+  // explicitly so test isolation is guaranteed.
+  usePreferencesStore.setState({ customPerformance: undefined });
+});
+
+const CUSTOM_PROFILE: PerformanceProfile = {
+  visual: {
+    aurora: true,
+    nebula: false,
+    richNebula: false,
+    cursorGlow: false,
+    blur: 'off',
+    animations: false,
+  },
+  backend: { concurrency: 'high', keepAlive: 'low', cache: 'balanced' },
+};
+
+describe('setCustomPerformance', () => {
+  it('writes the custom profile into the store', () => {
+    usePreferencesStore.getState().setCustomPerformance(CUSTOM_PROFILE);
+    const stored = usePreferencesStore.getState().customPerformance;
+    expect(stored).toEqual(CUSTOM_PROFILE);
+  });
+
+  it('bumps lastUpdated after writing the profile', () => {
+    const before = usePreferencesStore.getState().lastUpdated;
+    // `before` is always defined after resetPreferences() — guard explicitly so
+    // we never silently skip the timestamp comparison (no `if (before)` wrapper).
+    if (typeof before !== 'string')
+      throw new Error('lastUpdated must be a string before setCustomPerformance');
+
+    usePreferencesStore.getState().setCustomPerformance(CUSTOM_PROFILE);
+
+    const after = usePreferencesStore.getState().lastUpdated;
+    // `after` must be a non-empty string (never null / undefined / number).
+    if (typeof after !== 'string')
+      throw new Error('lastUpdated must remain a string after setCustomPerformance');
+
+    // The timestamp must be the same or newer — never rolled back.
+    expect(new Date(after).getTime()).toBeGreaterThanOrEqual(new Date(before).getTime());
+  });
+
+  it('can be updated multiple times (last write wins)', () => {
+    usePreferencesStore.getState().setCustomPerformance(CUSTOM_PROFILE);
+    const updated: PerformanceProfile = {
+      ...CUSTOM_PROFILE,
+      visual: { ...CUSTOM_PROFILE.visual, aurora: false },
+    };
+    usePreferencesStore.getState().setCustomPerformance(updated);
+    const stored = usePreferencesStore.getState().customPerformance;
+    expect(stored?.visual.aurora).toBe(false);
+  });
+});
+
+describe('useResolvedPerformanceProfile selector', () => {
+  it('returns the balanced preset when mode=balanced and no custom profile', () => {
+    const state = usePreferencesStore.getState();
+    const resolved = resolveProfile({
+      performanceMode: state.performanceMode,
+      customPerformance: state.customPerformance,
+    });
+    expect(resolved).toEqual(PERFORMANCE_PRESETS.balanced);
+  });
+
+  it('returns the low-memory preset when mode=low-memory', () => {
+    usePreferencesStore.getState().setPerformanceMode('low-memory');
+    const state = usePreferencesStore.getState();
+    const resolved = resolveProfile({
+      performanceMode: state.performanceMode,
+      customPerformance: state.customPerformance,
+    });
+    expect(resolved).toEqual(PERFORMANCE_PRESETS['low-memory']);
+  });
+
+  it('returns the performance preset when mode=performance', () => {
+    usePreferencesStore.getState().setPerformanceMode('performance');
+    const state = usePreferencesStore.getState();
+    const resolved = resolveProfile({
+      performanceMode: state.performanceMode,
+      customPerformance: state.customPerformance,
+    });
+    expect(resolved).toEqual(PERFORMANCE_PRESETS.performance);
+  });
+
+  it('returns the custom profile when mode=custom and a custom profile is set', () => {
+    usePreferencesStore.getState().setPerformanceMode('custom');
+    usePreferencesStore.getState().setCustomPerformance(CUSTOM_PROFILE);
+    const state = usePreferencesStore.getState();
+    const resolved = resolveProfile({
+      performanceMode: state.performanceMode,
+      customPerformance: state.customPerformance,
+    });
+    expect(resolved).toEqual(CUSTOM_PROFILE);
+  });
+
+  it('falls back to balanced preset when mode=custom but no custom profile is stored', () => {
+    usePreferencesStore.getState().setPerformanceMode('custom');
+    // After reset, customPerformance is undefined.
+    const state = usePreferencesStore.getState();
+    expect(state.customPerformance).toBeUndefined();
+    const resolved = resolveProfile({
+      performanceMode: state.performanceMode,
+      customPerformance: state.customPerformance,
+    });
+    expect(resolved).toEqual(PERFORMANCE_PRESETS.balanced);
+  });
+
+  it('updates the resolved profile when mode switches from custom back to balanced', () => {
+    usePreferencesStore.getState().setPerformanceMode('custom');
+    usePreferencesStore.getState().setCustomPerformance(CUSTOM_PROFILE);
+    usePreferencesStore.getState().setPerformanceMode('balanced');
+    const state = usePreferencesStore.getState();
+    const resolved = resolveProfile({
+      performanceMode: state.performanceMode,
+      customPerformance: state.customPerformance,
+    });
+    // The custom profile is still stored but not returned (mode is now 'balanced').
+    expect(resolved).toEqual(PERFORMANCE_PRESETS.balanced);
+    expect(state.customPerformance).toEqual(CUSTOM_PROFILE); // preserved in store
+  });
+});

--- a/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
+++ b/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
@@ -1,12 +1,14 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
-import type {
-  AiProvider,
-  LocalModelLimits,
-  PerProviderSettings,
-  Preferences,
-  PromptQuality,
+import {
+  type AiProvider,
+  type LocalModelLimits,
+  type PerformanceProfile,
+  type PerProviderSettings,
+  type Preferences,
+  type PromptQuality,
+  resolveProfile,
 } from '../preferences-schema';
 
 // Migration function to handle version updates
@@ -73,6 +75,11 @@ interface PreferencesActions {
   setResume: (resume: Preferences['resume']) => void;
   setApplicant: (applicant: Preferences['applicant']) => void;
   setPerformanceMode: (performanceMode: Preferences['performanceMode']) => void;
+  /**
+   * Replace the custom performance profile (full-object set). The custom UI
+   * computes the merged profile before calling, so this is a straight assignment.
+   */
+  setCustomPerformance: (profile: PerformanceProfile) => void;
   setPromptQuality: (promptQuality: PromptQuality) => void;
   setDebugMode: (enabled: boolean) => void;
   setSemanticScoring: (enabled: boolean) => void;
@@ -196,6 +203,13 @@ export const usePreferencesStore = create<PreferencesStore>()(
           lastUpdated: new Date().toISOString(),
         })),
 
+      setCustomPerformance: (customPerformance: PerformanceProfile) =>
+        set((state) => ({
+          ...state,
+          customPerformance,
+          lastUpdated: new Date().toISOString(),
+        })),
+
       setPromptQuality: (promptQuality: PromptQuality) =>
         set((state) => ({
           ...state,
@@ -262,6 +276,14 @@ export const useContactPromptSeen = () =>
   usePreferencesStore((state) => state.contactPromptSeen ?? false);
 export const useApplicant = () => usePreferencesStore((state) => state.applicant);
 export const usePerformanceMode = () => usePreferencesStore((state) => state.performanceMode);
+// Resolved profile (preset or custom). Equals `customPerformance` in custom mode.
+export const useResolvedPerformanceProfile = (): PerformanceProfile =>
+  usePreferencesStore((state) =>
+    resolveProfile({
+      performanceMode: state.performanceMode,
+      customPerformance: state.customPerformance,
+    })
+  );
 export const usePromptQuality = () => usePreferencesStore((state) => state.promptQuality ?? 'auto');
 export const useDebugMode = () => usePreferencesStore((state) => state.debugMode ?? false);
 export const useSemanticScoring = () =>

--- a/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
+++ b/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
@@ -252,7 +252,13 @@ export const usePreferencesStore = create<PreferencesStore>()(
           lastUpdated: new Date().toISOString(),
         })),
 
-      resetPreferences: () => set(defaultPreferences),
+      resetPreferences: () =>
+        set((state) => ({
+          ...state,
+          ...defaultPreferences,
+          customPerformance: undefined,
+          lastUpdated: new Date().toISOString(),
+        })),
     }),
     {
       name: 'ai-job-hunter-preferences',

--- a/apps/tauri/src/renderer/styles/globals.css
+++ b/apps/tauri/src/renderer/styles/globals.css
@@ -66,6 +66,7 @@ html[data-color-scheme='light'][data-perf-blur='off'] body {
 body.modal-blur-active #root {
   filter: blur(8px);
 }
+html[data-perf-blur='reduced'] body.modal-blur-active #root,
 html[data-perf-blur='off'] body.modal-blur-active #root,
 [data-reduce-transparency] body.modal-blur-active #root {
   filter: none;

--- a/apps/tauri/src/renderer/styles/globals.css
+++ b/apps/tauri/src/renderer/styles/globals.css
@@ -40,7 +40,8 @@ html[data-color-scheme='light'] #root {
 html[data-color-scheme='light'] body {
   background: radial-gradient(ellipse at 50% 0%, #eceef5 0%, #e4e7ef 55%, #dce0ea 100%);
 }
-html[data-color-scheme='light'][data-performance-mode='low-memory'] body {
+html[data-color-scheme='light'][data-perf-blur='reduced'] body,
+html[data-color-scheme='light'][data-perf-blur='off'] body {
   background: #e4e7ef;
 }
 
@@ -65,7 +66,7 @@ html[data-color-scheme='light'][data-performance-mode='low-memory'] body {
 body.modal-blur-active #root {
   filter: blur(8px);
 }
-html[data-performance-mode='low-memory'] body.modal-blur-active #root,
+html[data-perf-blur='off'] body.modal-blur-active #root,
 [data-reduce-transparency] body.modal-blur-active #root {
   filter: none;
 }
@@ -86,9 +87,12 @@ html[data-color-scheme='light'] .onboarding-glass-modal {
     inset 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
-/* ── Low-memory mode ─────────────────────────────────────────────────────── */
-/* Reduces GPU-heavy effects when the user selects Low Memory performance mode. */
-html[data-performance-mode='low-memory'] {
+/* ── Reduced-blur tier (data-perf-blur='reduced') ────────────────────────────── */
+/* Reduces GPU-heavy effects. The low-memory preset resolves to blur:'reduced',
+   so these rules reproduce the historical low-memory look. The 'off' tier below
+   inherits these and pushes the blur scale to zero. */
+html[data-perf-blur='reduced'],
+html[data-perf-blur='off'] {
   /* Collapse blur scale — halved from defaults, matching reduced-glass theme. */
   --blur-xs: 4px;
   --blur-sm: 6px;
@@ -98,15 +102,51 @@ html[data-performance-mode='low-memory'] {
   --blur-2xl: 16px;
   --blur-3xl: 24px;
 }
-html[data-performance-mode='low-memory'] body {
+html[data-perf-blur='reduced'] body,
+html[data-perf-blur='off'] body {
   /* Remove expensive radial gradient — flat colour is composited cheaply. */
   background: #15151a;
 }
 
-/* ── Dropdown low-memory mode ────────────────────────────────────────────────── */
-/* Reduce backdrop-blur on dropdowns when in low-memory mode. */
-html[data-performance-mode='low-memory'] [role='listbox'] {
+/* ── Off tier (data-perf-blur='off') ─────────────────────────────────────────── */
+/* Strongest reduction: zero the blur scale and disable backdrop-filters so no
+   surface composites a backdrop blur at all. */
+html[data-perf-blur='off'] {
+  --blur-xs: 0px;
+  --blur-sm: 0px;
+  --blur-md: 0px;
+  --blur-lg: 0px;
+  --blur-xl: 0px;
+  --blur-2xl: 0px;
+  --blur-3xl: 0px;
+}
+html[data-perf-blur='off'] .glass,
+html[data-perf-blur='off'] .glass-card,
+html[data-perf-blur='off'] .glass-surface,
+html[data-perf-blur='off'] .glass-elevated,
+html[data-perf-blur='off'] .glass-dropdown,
+html[data-perf-blur='off'] .glass-modal,
+html[data-perf-blur='off'] [role='listbox'] {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+/* ── Dropdown reduced-blur ──────────────────────────────────────────────────── */
+/* Reduce backdrop-blur on dropdowns at the reduced tier (the 'off' rule above
+   removes it entirely). */
+html[data-perf-blur='reduced'] [role='listbox'] {
   backdrop-filter: blur(8px) !important;
+}
+
+/* ── Animations off (data-perf-animations='off') ─────────────────────────────── */
+/* Neutralize the aurora/nebula keyframe loops — mirrors the reduced-motion
+   media query, but driven by the resolved performance profile. */
+html[data-perf-animations='off'] .animate-aurora-1,
+html[data-perf-animations='off'] .animate-aurora-2,
+html[data-perf-animations='off'] .animate-aurora-3,
+html[data-perf-animations='off'] .animate-nebula-1,
+html[data-perf-animations='off'] .animate-nebula-2 {
+  animation: none !important;
 }
 
 /* ── Window drag regions (Electron + Tauri) ──────────────────────────────── */

--- a/apps/tauri/src/tauri-client/namespaces/system/system.ts
+++ b/apps/tauri/src/tauri-client/namespaces/system/system.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
+import type { PerformanceBackendConfig } from '@ajh/shared';
+
 export const system = {
   health: () => invoke('system_health'),
   getVersion: () => invoke('system_get_version'),
@@ -8,8 +10,8 @@ export const system = {
   getPlatform: () => invoke('system_get_platform'),
   accentColor: () => invoke<{ supported: boolean; color: string | null }>('system_accent_color'),
   openExternal: (url: string) => invoke('system_open_external', { url }),
-  setPerformanceMode: (mode: 'low-memory' | 'balanced' | 'performance') =>
-    invoke('system_set_performance_mode', { mode }),
+  setPerformanceMode: (config: PerformanceBackendConfig) =>
+    invoke('system_set_performance_mode', { config }),
   getLaunchAtLogin: () => invoke<boolean>('system_get_launch_at_login'),
   setLaunchAtLogin: (enabled: boolean) =>
     invoke<boolean>('system_set_launch_at_login', { enabled }),

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -350,7 +350,7 @@ OCR runs off the UI thread; text chunking, embedding, and document extraction ru
 
 ### Performance mode
 
-The app detects available memory and CPU cores via `sysinfo` (Rust) and offers tiers that scale worker threads and batch size — a low tier for older or background use, a balanced default, and a performance tier for desktop workstations.
+The app offers three backend tiers (low-memory, balanced, performance) + a custom mode where users tune per-element visuals and backend knobs independently. The frontend resolves a `PerformanceProfile` to a concrete `PerformanceBackendConfig` IPC payload. The backend holds a process-global `OnceLock<ArcSwap<PerformanceConfig>>` (L0 module) that subsystems read without requiring an AppHandle — this pattern enables the Ollama embed builder (a free function) to query the live keep-alive setting. Three backend knobs are now real: (1) scraper concurrency threaded to `ScraperEngine::set_concurrency(n)`, (2) Ollama keep-alive (seconds) flowing into model/chat/embeddings request bodies, (3) cache TTL + row-cap bounding on match-scores and posting-vectors tables. Tier values and custom overrides are resolved in one place (`resolveBackendConfig` in preferences-schema.ts); the backend never branches on mode string. See ADR-019 for full architecture and tier definitions.
 
 ### Streaming rendering
 

--- a/docs/architecture-rules.md
+++ b/docs/architecture-rules.md
@@ -25,7 +25,7 @@ L1  Domain             scraping, extraction, export, documents, jobs, postings,
                        applications, referrals, profile_import, model, layout, measure,
                        validate,
                        locale, theme
-L0  Shared infra       error, observability, db, data_store, net, platform, browser
+L0  Shared infra       error, observability, performance, db, data_store, net, platform, browser
 ```
 
 > This list is the single source of truth and is duplicated verbatim as the `LAYER`
@@ -36,7 +36,7 @@ L0  Shared infra       error, observability, db, data_store, net, platform, brow
 
 ## Per-layer contract
 
-### L0 — Shared infrastructure (`error`, `observability`, `db`, `data_store`, `net`, `platform`, `browser`)
+### L0 — Shared infrastructure (`error`, `observability`, `performance`, `db`, `data_store`, `net`, `platform`, `browser`)
 
 - **Allowed deps:** other L0 modules only.
 - **Forbidden deps:** L1, L2, L3. **No** `crate::commands`, `crate::scraping`, etc.

--- a/docs/knowledge/decision-records/adr-019-resolved-performance-profile-with-real-backend-tiers.md
+++ b/docs/knowledge/decision-records/adr-019-resolved-performance-profile-with-real-backend-tiers.md
@@ -79,7 +79,7 @@ To find the exact numbers and update them, see the tier-mapping tables in `apps/
 
 ### IPC trust boundary
 
-- The command handler (`system_set_performance_mode`) clamps concurrency to [1, 16] and coerces cache bounds non-negative at the Rust boundary, even though today's renderer only sends fixed tiers. This guards against a buggy or future-variant renderer sending extreme values.
+- The command handler (`system_set_performance_mode`) clamps concurrency to [1, 16] and coerces cache bounds non-negative at the Rust boundary. The resolved backend config can carry user-edited values (from custom mode) or malformed data, so the boundary owns the invariant rather than relying on caller trust.
 
 ## Trade-offs Evaluated
 

--- a/docs/knowledge/decision-records/adr-019-resolved-performance-profile-with-real-backend-tiers.md
+++ b/docs/knowledge/decision-records/adr-019-resolved-performance-profile-with-real-backend-tiers.md
@@ -1,0 +1,129 @@
+# ADR-019: Resolved performance profile with real backend tiers
+
+Last updated: 2026-06-14
+
+**Status:** Accepted
+
+## Context
+
+Performance mode evolved from a simple string enum (`'low-memory' | 'balanced' | 'performance'`) to a richer feature where users can customize per-element visuals independently and select from three backend scaling tiers. The underlying architecture faced two challenges: (1) string-based mode switching scattered enum variants across the renderer and backend, making it fragile when new modes were added; (2) the Ollama keep-alive knob (needed to tune inference idle time for local models) had no way to reach the embed builder, a free function with no `AppHandle` access.
+
+## Decision
+
+Resolve all performance modes to a single unified `PerformanceProfile` (the truth on the frontend) that feeds a concrete `PerformanceBackendConfig` IPC payload sent to the Rust shell. The backend holds a process-global, init-order-safe runtime config cell. Frontend selects a tier (or custom) → resolves to concrete numbers → sends to backend → backend routes to the subsystems that consume it.
+
+### Architecture
+
+**Frontend (resolver):**
+
+- `PerformanceProfile` (TypeScript interface) models a user's selection: display tier + backend tier + custom overrides.
+- `resolveBackendConfig(mode, profile)` pure function maps the profile to a concrete `PerformanceBackendConfig` struct with numeric knobs. See `apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts` lines 274–285.
+- The function consults tier-mapping tables (`CONCURRENCY_BY_TIER`, `KEEP_ALIVE_SECS_BY_TIER`, `CACHE_TTL_SECS_BY_TIER`, `CACHE_MAX_ROWS_BY_TIER`) defined in the same file.
+
+**IPC contract:**
+
+- `PerformanceBackendConfig` (shared type in `packages/shared/src/types/index.ts`) is the struct sent over `system_set_performance_mode({ config })`.
+- Fields: `mode` (informational label), `concurrency`, `keepAliveSecs`, `cacheTtlSecs`, `cacheMaxRows`.
+- Never branch on the string `mode`; the numeric knobs are the source of truth for backend behavior.
+
+**Backend (L0 runtime config):**
+
+- `performance.rs` (new L0 module) holds a process-global `OnceLock<ArcSwap<PerformanceConfig>>` initialized to balanced defaults.
+- Two functions: `current()` returns a lock-free snapshot of the live config; `set(cfg)` replaces it (called by the IPC handler).
+- `ollama_keep_alive()` public function returns the wire value ("0" or "{secs}s") for the live config, called by the Ollama adapter (`commands/ai_provider/ollama.rs`).
+- Keep-alive and cache bounds are read-side opt-in: any subsystem needing them calls `performance::current()` directly (no AppHandle required).
+
+**Subsystems:**
+
+- **Scraper concurrency:** `ScraperEngine::set_concurrency(n)` receives the clamp'd value from the IPC handler.
+- **Ollama keep-alive:** The embed builder (free function, no AppHandle) calls `performance::ollama_keep_alive()` to read the live value and write it as a top-level request field.
+- **Cache bounding:** Two SQLite tables (`match_scores`, `posting_vectors` in `documents.db`) query `performance::current()` to enforce TTL + row-cap eviction. See `documents/mod.rs` cache eviction sites.
+
+### The 4th mode: custom
+
+Users may opt into "custom" mode to tune each backend tier independently (not just visual preferences). The tier-mapping tables have a fallback entry for any custom values. The `resolveBackendConfig` function is the ONLY place where custom values override the tier defaults.
+
+### Tier definitions
+
+Tiers are defined by their numeric targets (concurrency, keep-alive, cache TTL, cache row cap). As of v0.102.0, the tiers are:
+
+| Tier        | Concurrency | Keep-alive (s) | Cache TTL (d) | Cache rows |
+| ----------- | ----------- | -------------- | ------------- | ---------- |
+| low-memory  | 2           | 30             | 1             | 250        |
+| balanced    | 4           | 300            | 7             | 2000       |
+| high (perf) | 8           | 1800           | ∞ (unbounded) | ∞          |
+
+To find the exact numbers and update them, see the tier-mapping tables in `apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts` (lines 257–268).
+
+## Consequences
+
+### Clarity and maintainability
+
+- The `PerformanceProfile` abstraction decouples user choices (tier name, visual preference, custom overrides) from backend implementation.
+- The IPC contract is numeric and never branches on string mode.
+- Backend subsystems read `performance::current()` independently; no fragile mode-switch dispatcher.
+
+### Scale and extensibility
+
+- A new backend knob (e.g., batch size, timeout) requires: (1) add field to `PerformanceConfig` in Rust; (2) add field to `PerformanceBackendConfig` IPC struct; (3) add tier values to the resolver tables; (4) update the subsystem that consumes it.
+- Users in custom mode can immediately tune the new knob without app changes.
+
+### Init-order safety
+
+- The Ollama embed builder (invoked from AI generation calls, no AppHandle in scope) reads `performance::current()` via the process-global cell. The cell initializes to balanced defaults on first read (via `get_or_init`), guaranteeing a safe value even before the IPC command fires.
+- Lock-free reads via `ArcSwap::load_full()` mean concurrent reads never block each other, and there is no init-order dependency between subsystems.
+
+### Cache self-invalidation
+
+- Both cache tables (`match_scores`, `posting_vectors`) encode mode-sensitive inputs in their primary key or TTL, so a tier change immediately creates cache misses. No explicit cache flush needed. See ADR-017 for the full caching story.
+
+### IPC trust boundary
+
+- The command handler (`system_set_performance_mode`) clamps concurrency to [1, 16] and coerces cache bounds non-negative at the Rust boundary, even though today's renderer only sends fixed tiers. This guards against a buggy or future-variant renderer sending extreme values.
+
+## Trade-offs Evaluated
+
+### String enum vs. resolved struct
+
+**Chosen:** Resolved struct.
+
+- String enums scatter variants across two language runtimes and require careful synchronization (enum drift is easy to miss in CI).
+- A resolved struct with explicit tier tables is a single source of truth: one place to change, one place to test, one place to document.
+- The renderer still has the enum for UI purposes; the backend never sees it.
+
+### Process-global `OnceLock<ArcSwap>` vs. AppHandle-threaded config
+
+**Chosen:** Process-global.
+
+- Threaded config would require an `AppHandle` in every subsystem that reads performance knobs, violating L0 independence (L0 modules cannot hold Tauri state).
+- The Ollama embed builder is a free function with no AppHandle access; the only way to reach it is a process-global cell.
+- The `OnceLock` pattern is common in Rust libraries (e.g., log levels, tracing config) and is safe because init is idempotent (all threads converge to the same default or the explicitly-set value).
+
+### Cache TTL + row cap vs. tiered record deletion
+
+**Chosen:** Both.
+
+- A single eviction strategy (TTL only, or cap only) is fragile: cache rows could live past their semantic usefulness, or accumulate indefinitely during heavy scraping.
+- Composite bounding (TTL AND row cap) with a one-shot lazy-on-upsert eviction ensures both freshness and bounded size.
+
+### Ollama keep-alive placement (top-level field vs. options)
+
+**Chosen:** Top-level field, assigned AFTER any `body["options"]` writes.
+
+- Ollama API spec places `keep_alive` at the request root, not nested under `options`.
+- Writing it after options are set prevents downstream code from accidentally clobbering it.
+- Cloud providers (OpenAI, Anthropic, Claude-via-API) do not support `keep_alive` and must not receive it; the Ollama adapter is the only place that writes it.
+
+## References
+
+- **Config cell:** `apps/tauri/src-tauri/src/performance.rs` — the L0 module.
+- **Tier-mapping tables:** `apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts` lines 257–268.
+- **Resolver function:** `apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts` lines 274–285 (`resolveBackendConfig`).
+- **IPC command handler:** `apps/tauri/src-tauri/src/commands/system/mod.rs` (` system_set_performance_mode`, lines 177–199+).
+- **Scraper concurrency:** `apps/tauri/src-tauri/src/scraping/engine/mod.rs` (`set_concurrency`).
+- **Ollama keep-alive:** `apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs` (embed builder calls `performance::ollama_keep_alive()`).
+- **Cache eviction:** `apps/tauri/src-tauri/src/documents/mod.rs` (cache sites query `performance::current()`).
+- **UI provider:** `apps/tauri/src/renderer/providers/PerformanceModeProvider/PerformanceModeProvider.tsx`.
+- **Settings UI:** `apps/tauri/src/renderer/features/settings/components/preferences/PerformancePreferences/index.tsx`.
+- **Cinematic background:** `apps/tauri/src/renderer/components/background/CinematicBackground/index.tsx` (consumes display tier to gate visual layers).
+- **Related ADR:** ADR-017 (persisted self-invalidating match-score caches).

--- a/landing/index.html
+++ b/landing/index.html
@@ -784,8 +784,8 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
   <p class="footnote">macOS will say the app is "damaged." it's not damaged. it's just unsigned — like a contract I was never offered. run <code>xattr -cr</code> and we move on.</p>
   <p class="builtwith">Tauri · Rust · React 19 · TanStack · LanceDB · Typst · Ollama · pure spite</p>
   <p class="byline">made by Saeed, between rejections.</p>
-  <p class="footnote"><a href="privacy.html" style="color:#6f6650">Privacy</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener" style="color:#6f6650">Chrome extension</a> — we don't track you, we can barely track ourselves.</p>
   <svg class="inkline draw" style="width:24px; margin-top:10px" viewBox="0 0 30 28" aria-hidden="true"><path pathLength="1" d="M15 24 C5 16 2 9 8 5 q5 -3 7 4 q2 -7 7 -4 c6 4 3 11 -7 19 Z" style="stroke-width:2.4"/></svg>
+  <p class="footnote"><a href="privacy.html" style="color:#6f6650">Privacy</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener" style="color:#6f6650">Chrome extension</a></p>
 </section>
 
 </main>

--- a/packages/shared/src/ipc/contracts/index.ts
+++ b/packages/shared/src/ipc/contracts/index.ts
@@ -119,7 +119,7 @@ export type IpcChannel =
  * `system.getProtocolVersion()` from the Tauri shell. A mismatch at startup
  * indicates a partially-updated install and should be surfaced to the user.
  */
-export const PROTOCOL_VERSION = '1.0.0';
+export const PROTOCOL_VERSION = '1.1.0';
 
 // Re-export individual namespace contracts for direct imports if needed
 

--- a/packages/shared/src/ipc/contracts/system.ts
+++ b/packages/shared/src/ipc/contracts/system.ts
@@ -1,4 +1,9 @@
-import type { AppMetrics, Locale, RuntimeHealth } from '../../types/index.js';
+import type {
+  AppMetrics,
+  Locale,
+  PerformanceBackendConfig,
+  RuntimeHealth,
+} from '../../types/index.js';
 
 export interface SystemContract {
   health(): Promise<RuntimeHealth>;
@@ -20,7 +25,7 @@ export interface SystemContract {
 
   openExternal(url: string): Promise<void>;
 
-  setPerformanceMode(mode: 'low-memory' | 'balanced' | 'performance'): Promise<void>;
+  setPerformanceMode(config: PerformanceBackendConfig): Promise<void>;
 
   /** Whether the app is registered to launch at login (default off). */
   getLaunchAtLogin(): Promise<boolean>;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -166,6 +166,31 @@ export interface AppMetrics {
   snapshotAt: number;
 }
 
+/**
+ * Resolved performance configuration pushed to the Rust shell via
+ * `system.setPerformanceMode`. This is the IPC boundary shape: the renderer
+ * resolves the active mode (preset or custom profile) into concrete backend
+ * numbers and sends them so the shell never needs to know about presets.
+ *
+ * Tier→number mapping (owned by the renderer's `resolveBackendConfig`):
+ *   concurrency:   low→1,  balanced→2,    high→4
+ *   keepAliveSecs: low→0,  balanced→300,  high→1800
+ *   cacheTtlSecs:  low→86400, balanced→604800, high→null (no expiry)
+ *   cacheMaxRows:  low→250,   balanced→2000,   high→null (unbounded)
+ */
+export interface PerformanceBackendConfig {
+  /** The mode string (`low-memory` | `balanced` | `performance` | `custom`) — for logging / e2e. */
+  mode: string;
+  /** JobQueue concurrency (parallel workers). */
+  concurrency: number;
+  /** AiRuntime idle model keep-alive, in seconds (0 = unload immediately). */
+  keepAliveSecs: number;
+  /** Cache entry TTL in seconds; `null` = no expiry (generous). */
+  cacheTtlSecs: number | null;
+  /** Max cached rows; `null` = unbounded (generous). */
+  cacheMaxRows: number | null;
+}
+
 /** Identifies which boards support credential-based authentication. */
 export const AUTH_CAPABLE_BOARDS = ['linkedin', 'indeed', 'xing', 'glassdoor'] as const;
 export type AuthCapableBoard = (typeof AUTH_CAPABLE_BOARDS)[number];

--- a/packages/ui/src/components/HoverPopover/HoverPopover.test.tsx
+++ b/packages/ui/src/components/HoverPopover/HoverPopover.test.tsx
@@ -1,33 +1,53 @@
 /**
- * HoverPopover — structural tests (feat/accent-gradients).
+ * HoverPopover — structural tests.
  *
  * Strategy:
  *  - motion/react is globally shimmed in vitest.setup.ts — AnimatePresence
  *    passes children through synchronously, so the portalled panel is visible
- *    immediately after mouseenter without any async wait.
+ *    immediately after mouseenter without any async wait. The motion.div shim
+ *    uses React.forwardRef so panelRef (ref={panelRef}) attaches correctly to
+ *    the real DOM element.
  *  - createPortal renders into document.body; screen queries search the full
  *    document so role="tooltip" is always reachable.
  *  - getBoundingClientRect returns zeros in jsdom — the component detects a
  *    null rect and sets `display:none` on the panel until a non-zero rect is
  *    available. We stub getBoundingClientRect on the wrapper element to return
- *    a realistic rect so panelStyle resolves to `position:fixed` with real
- *    coordinates and the paddingBottom branch exercises correctly.
+ *    a realistic rect {top:200,bottom:220,left:100,right:300} so panelStyle
+ *    resolves to `position:fixed` with real coordinates and the paddingBottom
+ *    branch exercises correctly.
+ *  - Hover keep-open/close is now GEOMETRY-BASED, not mouseenter/leave-based.
+ *    While open, the component attaches a `document` `pointermove` listener.
+ *    It reads the trigger rect (wrapperRef) and panel rect (panelRef), inflates
+ *    each by PAD=8 px, and if the pointer is inside EITHER inflated rect it
+ *    cancels any pending close timer; otherwise it schedules close after
+ *    closeDelay ms (default 120 ms). A `document` `pointerleave` also schedules
+ *    close when the cursor exits the window.
+ *  - jsdom pointer event coordinate nuance: jsdom's getBoundingClientRect for
+ *    the PANEL element (panelRef) returns all-zeros. With PAD=8, any pointer
+ *    dispatched at (0,0) falls inside the inflated zero rect (−8..8 on both
+ *    axes) and keeps the panel open. To trigger a scheduled close, dispatch a
+ *    pointermove at coordinates well outside BOTH rects (e.g. 9999,9999).
+ *    closeDelay=120 ms, so fake timers are required to observe the close.
  *  - We NEVER assert on gradient CSS values (jsdom cssstyle gotcha).
- *    Assertions are structural: role, className tokens, inline paddingBottom.
+ *    Assertions are structural: role, className tokens, inline padding values.
  *
- * Covers (placement="top"):
- *  - Trigger open via mouseenter on the wrapper.
- *  - Portalled panel gets role="tooltip".
- *  - Panel element itself does NOT carry contentClassName (it lives on the
- *    inner wrapper div).
- *  - Inner wrapper div carries contentClassName.
- *  - Panel has inline paddingBottom set (the 8 px pointer-bridge gap).
- *  - Content text is accessible inside the element bearing contentClassName.
- *  - Esc closes the panel.
- *  - placement="bottom": panel has inline paddingTop instead of paddingBottom.
+ * Covers:
+ *  - Panel not in document before open.
+ *  - Opens on mouseenter on the wrapper.
+ *  - Opens on focus on the wrapper.
+ *  - Esc closes the panel immediately.
+ *  - Blur on wrapper schedules close (after closeDelay).
+ *  - placement="top": panel has inline paddingBottom.
+ *  - placement="bottom": panel has inline paddingTop (not paddingBottom).
+ *  - contentClassName on inner div, not on the panel element itself.
+ *  - Content text accessible inside the element bearing contentClassName.
+ *  - aria-expanded false→true transition.
+ *  - ariaLabel prop wired to panel.
+ *  - Geometry close: pointermove far outside both rects → schedules close.
+ *  - Geometry keep-open: pointermove inside the trigger rect → no close.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { HoverPopover } from './HoverPopover';
 
@@ -56,6 +76,7 @@ function renderPopover(
     contentClassName?: string;
     ariaLabel?: string;
     children?: React.ReactNode;
+    closeDelay?: number;
   } = {}
 ) {
   const {
@@ -63,6 +84,7 @@ function renderPopover(
     contentClassName = 'popover-content',
     ariaLabel = 'Activity popover',
     children = <span>Panel content</span>,
+    closeDelay,
   } = overrides;
 
   const result = render(
@@ -71,6 +93,7 @@ function renderPopover(
       placement={placement}
       contentClassName={contentClassName}
       ariaLabel={ariaLabel}
+      {...(closeDelay !== undefined ? { closeDelay } : {})}
     >
       {children}
     </HoverPopover>
@@ -92,6 +115,11 @@ beforeEach(() => {
   vi.restoreAllMocks();
 });
 
+afterEach(() => {
+  // Ensure fake timers are always cleaned up even if a test throws.
+  vi.useRealTimers();
+});
+
 // ── open / close mechanics ────────────────────────────────────────────────────
 
 describe('HoverPopover — open/close', () => {
@@ -106,7 +134,15 @@ describe('HoverPopover — open/close', () => {
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
   });
 
-  it('pressing Escape closes the panel', () => {
+  it('panel appears in the document after focus on the wrapper', () => {
+    const { container } = renderPopover();
+    stubRect(container);
+    const wrapper = container.firstChild as HTMLElement;
+    fireEvent.focus(wrapper);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('pressing Escape closes the panel immediately', () => {
     const { container } = renderPopover();
     openPopover(container);
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
@@ -114,6 +150,114 @@ describe('HoverPopover — open/close', () => {
     const wrapper = container.firstChild as HTMLElement;
     fireEvent.keyDown(wrapper, { key: 'Escape' });
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('blur on the wrapper schedules close — panel is gone after closeDelay', () => {
+    vi.useFakeTimers();
+    const { container } = renderPopover({ closeDelay: 120 });
+    openPopover(container);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    const wrapper = container.firstChild as HTMLElement;
+    fireEvent.blur(wrapper);
+
+    // Still present before the delay expires.
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    // Gone after the delay.
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+});
+
+// ── geometry-based hover tracking ────────────────────────────────────────────
+
+describe('HoverPopover — geometry-based hover tracking', () => {
+  it('pointermove far outside both rects schedules close — panel gone after closeDelay', () => {
+    vi.useFakeTimers();
+    const { container } = renderPopover({ closeDelay: 120 });
+    openPopover(container);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    // jsdom does not expose PointerEvent — use MouseEvent with type 'pointermove'.
+    // The component listener reads e.clientX/clientY which MouseEvent provides.
+    // Dispatch at (9999,9999): outside the stubbed trigger rect {top:200,
+    // bottom:220,left:100,right:300} and outside the zero panel rect even
+    // with PAD=8 (−8..8 on both axes).
+    document.dispatchEvent(
+      new MouseEvent('pointermove', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 9999,
+        clientY: 9999,
+      })
+    );
+
+    // Still present before closeDelay expires.
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    // Gone after closeDelay passes.
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('pointermove inside the trigger rect cancels close — panel stays open after closeDelay', () => {
+    vi.useFakeTimers();
+    const { container } = renderPopover({ closeDelay: 120 });
+    openPopover(container);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    // Dispatch inside the stubbed wrapper rect {top:200,bottom:220,left:100,right:300}.
+    // clientX:150, clientY:210 is well within the rect (no PAD needed).
+    document.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true, cancelable: true, clientX: 150, clientY: 210 })
+    );
+
+    // Advance well past closeDelay — panel must still be present.
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('pointerleave on document schedules close — panel gone after closeDelay', () => {
+    vi.useFakeTimers();
+    const { container } = renderPopover({ closeDelay: 120 });
+    openPopover(container);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    // onPointerLeave is NOT throttled, so no rAF flush needed.
+    document.dispatchEvent(new MouseEvent('pointerleave', { bubbles: true }));
+
+    // Still present before the delay expires.
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    // Gone after closeDelay passes.
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    vi.useRealTimers();
   });
 });
 

--- a/packages/ui/src/components/HoverPopover/HoverPopover.tsx
+++ b/packages/ui/src/components/HoverPopover/HoverPopover.tsx
@@ -34,9 +34,15 @@ export interface HoverPopoverProps {
  * Generic hover/focus popover.
  *
  * Mechanics it owns (so call sites don't reimplement them):
- *  - Opens on `mouseenter` / `focus`, closes on `mouseleave` / `blur` after
- *    `closeDelay` ms (debounced so moving the pointer onto the panel keeps it open).
- *  - Esc closes immediately.
+ *  - Opens on `mouseenter` / `focus`. While open, hover keep-open/close is
+ *    GEOMETRY-BASED: a document `pointermove` listener keeps it open whenever the
+ *    pointer is over the trigger OR the panel (each inflated by an 8px bridge pad)
+ *    and otherwise schedules close after `closeDelay` ms. Geometry-based because when
+ *    `placement='top'` the panel is portalled directly under the descending cursor and
+ *    a synthetic `mouseenter` never fires for an element inserted under an
+ *    already-present pointer (the insertion-under-cursor race), so mouseenter/leave
+ *    on the panel can't be trusted. A document `pointerleave` schedules close when the
+ *    cursor leaves the window. Esc / `blur` still close.
  *  - Panel is portalled to `document.body` and positioned against the trigger via
  *    `getBoundingClientRect` (re-measured on scroll/resize), opening upward for
  *    `placement='top'` and downward for `placement='bottom'`.
@@ -58,7 +64,9 @@ export function HoverPopover({
   const [open, setOpen] = useState(false);
   const [rect, setRect] = useState<DOMRect | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rafId = useRef<number | null>(null);
   const popoverId = useId();
 
   const cancelClose = useCallback(() => {
@@ -97,6 +105,48 @@ export function HoverPopover({
     };
   }, [open]);
 
+  // Geometry-based hover tracking: while open, a document `pointermove` listener is
+  // the SOLE authority for hover-close. It keeps the popover open whenever the pointer
+  // is over the trigger OR the panel (each inflated by an 8px bridge pad) and otherwise
+  // schedules close. This is immune to the synthetic `mouseenter` never firing for the
+  // panel when `placement='top'` portals it directly under the descending cursor. A
+  // document `pointerleave` schedules close when the cursor leaves the window.
+  useEffect(() => {
+    if (!open) return;
+    const PAD = 8;
+    const inside = (bounds: DOMRect | null, x: number, y: number) =>
+      bounds !== null &&
+      x >= bounds.left - PAD &&
+      x <= bounds.right + PAD &&
+      y >= bounds.top - PAD &&
+      y <= bounds.bottom + PAD;
+    const onPointerMove = (e: PointerEvent) => {
+      const { clientX, clientY } = e;
+      if (rafId.current !== null) cancelAnimationFrame(rafId.current);
+      rafId.current = requestAnimationFrame(() => {
+        rafId.current = null;
+        const triggerRect = wrapperRef.current?.getBoundingClientRect() ?? null;
+        const panelRect = panelRef.current?.getBoundingClientRect() ?? null;
+        if (inside(triggerRect, clientX, clientY) || inside(panelRect, clientX, clientY)) {
+          cancelClose();
+        } else {
+          scheduleClose();
+        }
+      });
+    };
+    const onPointerLeave = () => scheduleClose();
+    document.addEventListener('pointermove', onPointerMove);
+    document.addEventListener('pointerleave', onPointerLeave);
+    return () => {
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerleave', onPointerLeave);
+      if (rafId.current !== null) {
+        cancelAnimationFrame(rafId.current);
+        rafId.current = null;
+      }
+    };
+  }, [open, cancelClose, scheduleClose]);
+
   const panelStyle: React.CSSProperties = rect
     ? {
         position: 'fixed',
@@ -115,7 +165,6 @@ export function HoverPopover({
       aria-expanded={open}
       aria-describedby={open ? popoverId : undefined}
       onMouseEnter={handleOpen}
-      onMouseLeave={scheduleClose}
       onFocus={handleOpen}
       onBlur={scheduleClose}
       onKeyDown={handleKeyDown}
@@ -126,14 +175,13 @@ export function HoverPopover({
         <AnimatePresence>
           {open && (
             <motion.div
+              ref={panelRef}
               id={popoverId}
               role="tooltip"
               aria-label={ariaLabel}
               {...(placement === 'top' ? variants.fadeSlideUp : variants.fadeSlideDown)}
               transition={transition.fast}
               style={panelStyle}
-              onMouseEnter={cancelClose}
-              onMouseLeave={scheduleClose}
             >
               <div className={contentClassName}>{children}</div>
             </motion.div>


### PR DESCRIPTION
## Custom performance mode — resolved-profile architecture + real backend tiers

Adds a 4th **Custom** performance mode that lets users tune each element individually, and makes the backend knobs the UI always *claimed* to control **actually real**.

### What changed

**Architecture — one resolved profile, single source.** Performance mode was a bare string (`low-memory | balanced | performance`) that three places independently switched on. Now every mode resolves to one `PerformanceProfile` (visual flags + backend tiers). The 3 presets are constants that **reproduce today's exact output**; `custom` is a user-editable profile. `CinematicBackground`, the `data-perf-*` CSS attributes, and the IPC backend slice all read the resolved profile — no more parallel string-switches.

**Custom UI.** A 4th card reveals a sub-panel: 5 visual toggles (aurora ribbons, nebulae, cursor glow, backdrop-blur tier, rich animations) + 3 backend selects (concurrency, model keep-alive, cache).

**Real backend tiers** (previously cosmetic / unwired):
- **Scraper concurrency** — already real, now via `ScraperEngine::set_concurrency(n)` (clamped 1–16 at the Rust trust boundary).
- **AI keep-alive** — Ollama `keep_alive` is now threaded into the generate/chat/embed bodies (`0`→`"0"` unload, else `"{secs}s"`), driven by a new **L0 `performance` module** (`OnceLock<ArcSwap<PerformanceConfig>>`, default balanced) so the `AppHandle`-less embed builder can read it. **Local/Ollama only** — cloud + CLI providers never read the field (config+adapter only, no business-logic coupling).
- **Cache bounding** — the previously **unbounded** `match_scores` + `posting_vectors` SQLite caches gain TTL + row-cap eviction (lazy on upsert, one-shot on mode-apply, read-side TTL miss), backed by new `created_at` indexes. `balanced` now bounds them (2000 rows / 7d); `performance`/generous preserves the old unbounded behavior.

Tier numbers are renderer-resolved (`resolveBackendConfig` in `preferences-schema.ts`) and sent as a `PerformanceBackendConfig` over the widened `system_set_performance_mode({ config })` IPC; the shell is a dumb applier.

### Compatibility
- Additive: new optional `customPerformance` pref + `'custom'` enum value — **no migration / version bump** (Zod defaults cover it).
- `data-performance-mode` is still written (e2e/a11y specs depend on it); granular `data-perf-blur` / `data-perf-animations` are additive.
- **Preset visuals are byte-identical to before**: low-memory → no ambient; balanced → aurora + 1 nebula + glow; performance → aurora + 2 nebulae + glow.

### Reviews & quality gates
Reviewed by **frontend-reviewer**, **rust-backend-architect**, **ai-provider-expert**, and **tauri-security-reviewer** — **zero CRITICAL/HIGH**. Addressed MEDIUMs before merge:
- Indexed `created_at` + switched the row-cap prune to an index-friendly threshold delete (the `NOT IN` full-table sort would have re-introduced per-row cost on the batch-scoring path).
- Clamped resource-sizing IPC inputs at the Rust boundary (concurrency 1–16, non-negative cache bounds).
- Wired `<label htmlFor>` on the 4 custom dropdowns (a11y).

### Tests
+74 TS + +13 Rust tests (preset fidelity, `resolveProfile`/`resolveBackendConfig` tier tables, `CinematicBackground` layer/RAF gating, IPC dedupe guard, custom-panel wiring, `keep_alive_value`, cache eviction incl. cap=0/TTL/ties/generous-no-op, read-side TTL miss). Test audit (testing-reviewer) raised 3 HIGH (cap=0 boundary, ties, a flaky `setTimeout`) — all fixed. Full suite green; `typecheck` / `lint:strict` / `clippy --all-targets -D warnings` / `cargo fmt` all clean.

Docs: ADR-019 + `docs/DESIGN_DECISIONS.md` performance section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added **custom performance mode** with granular visual (Aurora, Nebulae, Cursor glow, Rich animations) and backend tuning (scraper concurrency, AI keep-alive, cache TTL/row caps).

* **Bug Fixes / Improvements**
  * Improved AI request stability by enforcing **Ollama keep-alive**.
  * Enhanced performance caching with **TTL and size-based pruning** for embeddings and match results.
  * Updated cinematic background rendering and improved **hover popover** close behavior to be geometry-based.

* **Documentation**
  * Refreshed performance mode docs and related architecture decision records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->