### PR TITLE
feat: native-messaging transport for firefox https-only mode

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -107,12 +107,13 @@ The loopback WebSocket (`ws://127.0.0.1:47615..47620`) discovers the desktop app
 
 ## Permissions — minimal & justified
 
-| Permission                                                 | Why it is required                                                                                                                                                          |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `activeTab`                                                | Read the URL and (Scan mode) the DOM of the tab the user clicked on — **only** on that click, with no standing access to any site.                                          |
-| `storage`                                                  | Persist the pairing token locally so the user pairs once.                                                                                                                   |
-| `scripting`                                                | MV3 requires `scripting` to dynamically inject the Scan-mode capture via `chrome.scripting.executeScript`. Host scope stays limited to the active tab by `activeTab`.       |
-| `host_permissions: ws://127.0.0.1/*`, `http://127.0.0.1/*` | **Loopback only.** The background worker opens `ws://127.0.0.1:<port>` to the desktop bridge. See the finding below — this is the narrowest entry that works cross-browser. |
+| Permission                                                 | Why it is required                                                                                                                                                                                        |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `activeTab`                                                | Read the URL and (Scan mode) the DOM of the tab the user clicked on — **only** on that click, with no standing access to any site.                                                                        |
+| `storage`                                                  | Persist the pairing token locally so the user pairs once.                                                                                                                                                 |
+| `scripting`                                                | MV3 requires `scripting` to dynamically inject the Scan-mode capture via `chrome.scripting.executeScript`. Host scope stays limited to the active tab by `activeTab`.                                     |
+| `nativeMessaging`                                          | Spawn and exchange messages with the AI Job Hunter desktop host (`app.aijobhunter.bridge`) — the HTTPS-Only-safe transport to the local app. Falls back to loopback WS if the native host is unavailable. |
+| `host_permissions: ws://127.0.0.1/*`, `http://127.0.0.1/*` | **Loopback only.** The background worker opens `ws://127.0.0.1:<port>` to the desktop bridge (native-messaging fallback). See the finding below — this is the narrowest entry that works cross-browser.   |
 
 We do **not** request broad host access (`<all_urls>`, `*://*/*`), no
 `tabs` permission, no `webRequest`, and we do **not** loosen
@@ -179,12 +180,17 @@ the pairing token to the **first loopback port that answers** (see the
 **The extension is non-functional without the AI Job Hunter desktop app** — this
 is expected. A reviewer testing it standalone will see, by design:
 
-- On open with the app **not running**: an _"AI Job Hunter isn't running"_
-  empty state with a **Retry** button. No errors, no broken UI.
+- On open with the app **not running**: an empty body with a header **Retry** icon
+  and a **"?"** help popover; the status pill reads **"✕ App not running"**. No
+  errors, no broken UI.
 - With the app **running but unpaired**: a **pairing screen** asking for the
   64-character token from the app's Settings.
 - With the app **running and paired**: the import view (two buttons + the
   "I already applied" checkbox).
+- **On Firefox with HTTPS-Only Mode enabled**: the extension connects via
+  **native messaging** (the `app.aijobhunter.bridge` host spawned by the browser)
+  instead of the loopback WebSocket; this avoids the silent `ws://` → `wss://`
+  upgrade that breaks the plain loopback path.
 
 To exercise the full path, install the desktop app from the project release,
 open it, copy the token from **Settings → Browser extension**, paste it into the
@@ -262,15 +268,23 @@ emitted JS stays readable for review.
 
 ## Extension origin validation (bridge side)
 
-The desktop bridge validates `moz-extension://` and `chrome-extension://` origins in the WS handshake (`apps/tauri/src-tauri/src/extension_bridge/auth.rs::is_allowed_origin`). **The origin is not the auth boundary** — the per-frame 256-bit pairing token is; the origin is defense-in-depth.
+The desktop bridge validates extension origins in the handshake (`apps/tauri/src-tauri/src/extension_bridge/auth.rs::is_allowed_origin`). **The origin is not the auth boundary** — the per-frame 256-bit pairing token is; the origin is defense-in-depth.
 
-- **Firefox:** origins are random per-install internal UUIDs (anti-fingerprinting), not the AMO gecko id. The bridge accepts any well-formed UUID shape (8-4-4-4-12 lowercase hex) via `is_extension_uuid`. The gecko id (`job-importer@aijobhunter.app`) never appears in a real `moz-extension://` origin and is intentionally absent from the allowlist.
+- **Firefox:** a background-script WebSocket sends `Origin: null` (Firefox deliberately strips the per-install UUID to prevent fingerprinting per Bugzilla 1607936/1257989). The bridge accepts `null`. The gecko id (`job-importer@aijobhunter.app`) never appears as an origin and is intentionally absent from the allowlist.
 - **Chrome:** the bridge pins the published Chrome Web Store id `oaoekkgkhmgdfnpmfkpphgiikliaicll` in `ALLOWED_EXTENSION_IDS` (in `apps/tauri/src-tauri/src/extension_bridge/auth.rs`). A locally-loaded Chrome build is still admitted only via the dev-origin override (`AJH_EXTENSION_DEV_ORIGINS`).
+- **Native-messaging host:** sends the sentinel `Origin: ajh-native-host` (see `NATIVE_HOST_ORIGIN` in `auth.rs`). Defense-in-depth only; the per-frame token + loopback binding remain the real boundary.
 
 ---
 
-## Native Messaging Fallback (Future)
+## Native Messaging Transport
 
-This v1 uses a loopback WebSocket. If a store policy or hardened OS network config blocks loopback WS from an extension, the **fallback is native messaging**: register a native messaging host with the desktop app and swap `BridgeClient`'s transport from `WebSocket` to `browser.runtime.connectNative` (via `@wxt-dev/browser`).
+The extension uses **native-messaging as the primary transport**, with **loopback WebSocket as a fallback**:
 
-The wire protocol envelope (`@ajh/shared`) and desktop handlers stay identical — **only the transport changes**. Native messaging is browser-approved, cannot be port-squatted, and works across permission policies. Tracked as a `TODO(bridge)` follow-up; not implemented in v1.
+1. **Native messaging (preferred):** The browser spawns the desktop app's own exe in `--native-host` mode, which runs a stdio ↔ `ws://127.0.0.1` relay (`apps/tauri/src-tauri/src/extension_bridge/native_host.rs`). This is the by-default fix for Firefox's HTTPS-Only Mode: Firefox silently upgrades the extension's `ws://127.0.0.1` to `wss://` in strict-mode profiles, breaking the plain loopback path. A native process spawned by the browser is immune to that upgrade.
+   - **Native host name:** `app.aijobhunter.bridge` (configured in `apps/extension/src/lib/bridge.ts` and registered on every app launch via `apps/tauri/src-tauri/src/extension_bridge/register.rs`).
+   - **Readiness frame:** the native host sends a transport-local `{"type":"bridge.ready","ok":true|false}` control frame (not part of the wire protocol) so the extension can distinguish "app reachable" from "app down".
+   - **Same wire envelope:** the bridge protocol (`@ajh/shared` extension-protocol) is unchanged; only the transport swaps from `WebSocket` to `browser.runtime.connectNative` (`@wxt-dev/browser`).
+
+2. **WebSocket fallback:** if the native host is not registered (old app / never installed), or native-messaging is unavailable, the extension probes `127.0.0.1:47615..47620` and falls back to the loopback WebSocket. Chrome and older desktop app versions keep working.
+
+All origins flow through unchanged (the per-frame 256-bit pairing token over the loopback-only listener remains the real boundary). Native messaging cannot be port-squatted and survives permission policies that block loopback WS.

--- a/apps/extension/src/lib/bridge.test.ts
+++ b/apps/extension/src/lib/bridge.test.ts
@@ -590,6 +590,7 @@ describe('BridgeClient – native messaging transport', () => {
     port.simulateMessage({ type: 'bridge.ready', ok: false });
     await connectPromise;
 
+    expect(port.disconnect).toHaveBeenCalled(); // ok:false closes the native port
     expect(client.status().phase).toBe('app_not_running');
     expect(createdSockets).toHaveLength(0); // app down ≠ fall back to ws
 
@@ -659,6 +660,7 @@ describe('BridgeClient – native messaging transport', () => {
     createdSockets[0]!.simulateOpen();
     await connectPromise;
 
+    expect(port.disconnect).toHaveBeenCalled(); // timeout closes the native port
     expect(client.status()).toMatchObject({ phase: 'connected', port: 47615 });
 
     client.dispose();

--- a/apps/extension/src/lib/bridge.test.ts
+++ b/apps/extension/src/lib/bridge.test.ts
@@ -14,10 +14,25 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { browser } from '@wxt-dev/browser';
 
 import { EXTENSION_MESSAGE_TYPES } from '@ajh/shared';
 
 import { BridgeClient } from './bridge';
+
+// Default `connectNative` THROWS so the existing ws describe-blocks (which never
+// mock it) go straight to the ws probe — native is treated as "host unavailable
+// → fall back to ws". The native describe-block overrides this per-test.
+vi.mock('@wxt-dev/browser', () => ({
+  browser: {
+    runtime: {
+      connectNative: vi.fn(() => {
+        throw new Error('connectNative not available');
+      }),
+      lastError: undefined,
+    },
+  },
+}));
 
 // ── WebSocket fake ────────────────────────────────────────────────────────────
 
@@ -477,5 +492,175 @@ describe('BridgeClient – reconnect/backoff on close', () => {
 
     // No new probes — dispose prevented the reconnect.
     expect(createdCount).toBe(countBefore);
+  });
+});
+
+// ── native messaging transport ─────────────────────────────────────────────────
+
+type PortListener = (msg: unknown, port?: unknown) => void;
+
+interface FakePort {
+  postMessage: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  onMessage: { addListener: (cb: PortListener) => void };
+  onDisconnect: { addListener: (cb: () => void) => void };
+  simulateMessage: (obj: unknown) => void;
+  simulateDisconnect: (lastError?: { message: string }) => void;
+}
+
+function buildFakePort(): FakePort {
+  const msgListeners: PortListener[] = [];
+  const discListeners: Array<() => void> = [];
+  return {
+    postMessage: vi.fn(),
+    disconnect: vi.fn(),
+    onMessage: { addListener: (cb: PortListener) => void msgListeners.push(cb) },
+    onDisconnect: { addListener: (cb: () => void) => void discListeners.push(cb) },
+    simulateMessage(obj: unknown) {
+      msgListeners.forEach((cb) => cb(obj));
+    },
+    simulateDisconnect(lastError?: { message: string }) {
+      (browser.runtime as { lastError?: unknown }).lastError = lastError;
+      discListeners.forEach((cb) => cb());
+    },
+  };
+}
+
+describe('BridgeClient – native messaging transport', () => {
+  const connectNativeMock = vi.mocked(browser.runtime.connectNative);
+  let createdSockets: FakeWebSocket[] = [];
+  let restoreWS: () => void;
+
+  beforeEach(() => {
+    createdSockets = [];
+    restoreWS = installFakeWS((ws) => createdSockets.push(ws));
+    (browser.runtime as { lastError?: unknown }).lastError = undefined;
+  });
+
+  afterEach(() => {
+    restoreWS();
+    connectNativeMock.mockReset();
+    // Restore the suite default (throw) for any later file.
+    connectNativeMock.mockImplementation(() => {
+      throw new Error('connectNative not available');
+    });
+    vi.useRealTimers();
+  });
+
+  it('connects native-first on bridge.ready{ok:true} and round-trips an import via the port', async () => {
+    const port = buildFakePort();
+    connectNativeMock.mockReturnValue(port as never);
+
+    const client = new BridgeClient(vi.fn());
+    const connectPromise = client.ensureConnected();
+    port.simulateMessage({ type: 'bridge.ready', ok: true });
+    await connectPromise;
+
+    expect(client.status().phase).toBe('connected');
+    expect(createdSockets).toHaveLength(0); // never touched ws
+
+    const importPromise = client.importJob(FAKE_TOKEN, makeImportRequest());
+    await vi.waitFor(() => {
+      expect(port.postMessage).toHaveBeenCalled();
+    });
+    const sent = port.postMessage.mock.calls[0]?.[0] as { reqId: string };
+    expect(sent.type).toBe(EXTENSION_MESSAGE_TYPES.importRequest);
+
+    // Reply arrives as a PARSED OBJECT (native auto-parses JSON), not a string.
+    port.simulateMessage({
+      type: EXTENSION_MESSAGE_TYPES.importResult,
+      token: FAKE_TOKEN,
+      reqId: sent.reqId,
+      payload: { applicationId: 'native-1', status: 'saved' },
+    });
+
+    const result = await importPromise;
+    expect(result).toEqual({ applicationId: 'native-1', status: 'saved' });
+
+    client.dispose();
+  });
+
+  it('enters app_not_running on bridge.ready{ok:false} with NO ws fallback', async () => {
+    vi.useFakeTimers();
+    const port = buildFakePort();
+    connectNativeMock.mockReturnValue(port as never);
+
+    const client = new BridgeClient(vi.fn());
+    const connectPromise = client.ensureConnected();
+    port.simulateMessage({ type: 'bridge.ready', ok: false });
+    await connectPromise;
+
+    expect(client.status().phase).toBe('app_not_running');
+    expect(createdSockets).toHaveLength(0); // app down ≠ fall back to ws
+
+    // Reconnect scheduled — advance past backoff[0]=500ms; it re-tries native.
+    const callsBefore = connectNativeMock.mock.calls.length;
+    vi.advanceTimersByTime(600);
+    expect(connectNativeMock.mock.calls.length).toBeGreaterThan(callsBefore);
+
+    client.dispose();
+  });
+
+  it('falls back to the ws probe when connectNative throws', async () => {
+    connectNativeMock.mockImplementation(() => {
+      throw new Error('host not registered');
+    });
+
+    const client = new BridgeClient(vi.fn());
+    const connectPromise = client.ensureConnected();
+
+    await vi.waitFor(() => {
+      expect(createdSockets.length).toBeGreaterThanOrEqual(1);
+    });
+    expect(createdSockets[0]!.url).toBe('ws://127.0.0.1:47615');
+    createdSockets[0]!.simulateOpen();
+    await connectPromise;
+
+    expect(client.status()).toMatchObject({ phase: 'connected', port: 47615 });
+
+    client.dispose();
+  });
+
+  it('falls back to ws when the port disconnects (lastError) before any bridge.ready', async () => {
+    const port = buildFakePort();
+    connectNativeMock.mockReturnValue(port as never);
+
+    const client = new BridgeClient(vi.fn());
+    const connectPromise = client.ensureConnected();
+
+    // Host not registered: onDisconnect fires with lastError, before any ready.
+    port.simulateDisconnect({ message: 'Native host has exited.' });
+
+    await vi.waitFor(() => {
+      expect(createdSockets.length).toBeGreaterThanOrEqual(1);
+    });
+    createdSockets[0]!.simulateOpen();
+    await connectPromise;
+
+    expect(client.status()).toMatchObject({ phase: 'connected', port: 47615 });
+
+    client.dispose();
+  });
+
+  it('falls back to ws when no bridge.ready arrives within the ready timeout', async () => {
+    vi.useFakeTimers();
+    const port = buildFakePort();
+    connectNativeMock.mockReturnValue(port as never);
+
+    const client = new BridgeClient(vi.fn());
+    const connectPromise = client.ensureConnected();
+
+    // No ready frame — advance past READY_TIMEOUT_MS (1500ms) → fall back.
+    await vi.advanceTimersByTimeAsync(1_600);
+
+    await vi.waitFor(() => {
+      expect(createdSockets.length).toBeGreaterThanOrEqual(1);
+    });
+    createdSockets[0]!.simulateOpen();
+    await connectPromise;
+
+    expect(client.status()).toMatchObject({ phase: 'connected', port: 47615 });
+
+    client.dispose();
   });
 });

--- a/apps/extension/src/lib/bridge.ts
+++ b/apps/extension/src/lib/bridge.ts
@@ -1,10 +1,19 @@
 /**
- * Loopback WebSocket client to the desktop bridge.
+ * Client to the desktop bridge, native-messaging first with a `ws` fallback.
  *
- * The desktop binds `127.0.0.1` on the first free port in the range below
- * (see `apps/tauri/src-tauri/src/extension_bridge/mod.rs::PORT_RANGE`). We probe
- * that exact range, hold a SINGLE socket, send `import.request` envelopes
- * (token on every frame), and correlate replies by `reqId`.
+ * Two transports behind one {@link BridgeTransport} seam:
+ *
+ * 1. **Native messaging** (preferred). The browser spawns the desktop exe as a
+ *    native host (`app.aijobhunter.bridge`) which relays stdio ↔ the running
+ *    app's loopback bridge. Survives Firefox HTTPS-Only Mode (which upgrades the
+ *    extension's `ws://127.0.0.1` to `wss://` and breaks the socket path).
+ * 2. **WebSocket** (fallback). The desktop binds `127.0.0.1` on the first free
+ *    port in the range below (see
+ *    `apps/tauri/src-tauri/src/extension_bridge/mod.rs::PORT_RANGE`). Used when
+ *    the native host isn't registered (old/never-installed app).
+ *
+ * Either way we hold a SINGLE transport, send `import.request` envelopes (token
+ * on every frame), and correlate replies by `reqId`.
  *
  * Lifecycle note (MV3): the background service worker can be evicted at any
  * time, tearing down this client. The background entry re-creates it on wake
@@ -12,6 +21,8 @@
  * keeps no cross-eviction state beyond the in-flight `reqId` map (which dies
  * with the worker — callers re-issue on the fresh instance).
  */
+
+import { type Browser, browser } from '@wxt-dev/browser';
 
 import {
   EXTENSION_MESSAGE_TYPES,
@@ -24,6 +35,9 @@ import {
 const PORT_START = 47615;
 const PORT_END = 47620;
 
+/** Native host name — MUST match the Rust `extension_bridge::mod::NATIVE_HOST_NAME`. */
+const HOST_NAME = 'app.aijobhunter.bridge';
+
 /** Per-request timeout (ms) — the desktop fetch+parse for URL mode can be slow. */
 const REQUEST_TIMEOUT_MS = 30_000;
 
@@ -32,6 +46,9 @@ const BACKOFF_MS = [500, 1_000, 2_000, 5_000, 10_000];
 
 /** WS handshake/open timeout per port probe. */
 const OPEN_TIMEOUT_MS = 1_500;
+
+/** How long to wait for the native host's `bridge.ready` before falling back to ws. */
+const READY_TIMEOUT_MS = 1_500;
 
 type PendingResolver = (result: ExtensionImportResult) => void;
 
@@ -68,8 +85,136 @@ function isExtensionImportResult(v: unknown): v is ExtensionImportResult {
   );
 }
 
+// ── transport seam ──────────────────────────────────────────────────────────
+
+/**
+ * One open connection to the desktop bridge. `onMessage` delivers a PARSED
+ * object — ws JSON.parses the string frame, native messaging already auto-parses
+ * the JSON for us.
+ */
+interface BridgeTransport {
+  send(envelope: ExtensionEnvelope): void;
+  onMessage(cb: (env: unknown) => void): void;
+  onClose(cb: () => void): void;
+  close(): void;
+}
+
+class WebSocketTransport implements BridgeTransport {
+  constructor(private readonly socket: WebSocket) {}
+
+  send(envelope: ExtensionEnvelope): void {
+    this.socket.send(JSON.stringify(envelope));
+  }
+
+  onMessage(cb: (env: unknown) => void): void {
+    this.socket.addEventListener('message', (ev: MessageEvent) => {
+      if (typeof ev.data !== 'string') return;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(ev.data);
+      } catch {
+        return;
+      }
+      cb(parsed);
+    });
+  }
+
+  onClose(cb: () => void): void {
+    this.socket.addEventListener('close', cb);
+    // `close` fires after `error`; cleanup happens there. No error handler needed.
+  }
+
+  close(): void {
+    this.socket.close();
+  }
+}
+
+/** Distinguishable native-connect failures (see {@link connectNative}). */
+const NATIVE_UNAVAILABLE = 'native_unavailable'; // host not registered → fall back to ws
+const NATIVE_APP_DOWN = 'native_app_down'; // host ran, app is down → app_not_running, no ws
+
+class NativeMessagingTransport implements BridgeTransport {
+  constructor(private readonly port: Browser.runtime.Port) {}
+
+  send(envelope: ExtensionEnvelope): void {
+    this.port.postMessage(envelope);
+  }
+
+  onMessage(cb: (env: unknown) => void): void {
+    this.port.onMessage.addListener((msg: unknown) => {
+      // `bridge.ready` is transport-local; never forward it to result correlation.
+      if (isBridgeReady(msg)) {
+        // ok:false after connect = the app's bridge went away → behave like close.
+        if (!msg.ok) this.close();
+        return;
+      }
+      cb(msg);
+    });
+  }
+
+  onClose(cb: () => void): void {
+    this.port.onDisconnect.addListener(cb);
+  }
+
+  close(): void {
+    this.port.disconnect();
+  }
+}
+
+interface BridgeReady {
+  type: 'bridge.ready';
+  ok: boolean;
+}
+
+function isBridgeReady(msg: unknown): msg is BridgeReady {
+  return (
+    typeof msg === 'object' &&
+    msg !== null &&
+    (msg as { type?: unknown }).type === 'bridge.ready' &&
+    typeof (msg as { ok?: unknown }).ok === 'boolean'
+  );
+}
+
+/**
+ * Connect via native messaging, resolving only after `bridge.ready{ok:true}`.
+ * Rejects with {@link NATIVE_APP_DOWN} on `ok:false` (host reachable, app down)
+ * or {@link NATIVE_UNAVAILABLE} on pre-ready disconnect / ready-timeout (host not
+ * registered → caller falls back to ws). THROWS SYNCHRONOUSLY if `connectNative`
+ * itself fails so the caller can start the ws probe in the same tick (the ws
+ * reconnect test asserts the probe fires synchronously after the timer).
+ */
+function connectNative(): Promise<NativeMessagingTransport> {
+  const port: Browser.runtime.Port = browser.runtime.connectNative(HOST_NAME);
+
+  return new Promise<NativeMessagingTransport>((resolve, reject) => {
+    let settled = false;
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+
+    const timer = setTimeout(
+      () => finish(() => reject(new Error(NATIVE_UNAVAILABLE))),
+      READY_TIMEOUT_MS
+    );
+
+    port.onMessage.addListener((msg: unknown) => {
+      if (!isBridgeReady(msg)) return; // ignore stray frames before ready
+      finish(() =>
+        msg.ok ? resolve(new NativeMessagingTransport(port)) : reject(new Error(NATIVE_APP_DOWN))
+      );
+    });
+    port.onDisconnect.addListener(() => {
+      // Disconnect before ready = host not registered (lastError set).
+      finish(() => reject(new Error(NATIVE_UNAVAILABLE)));
+    });
+  });
+}
+
 export class BridgeClient {
-  private socket: WebSocket | null = null;
+  private transport: BridgeTransport | null = null;
   private port: number | null = null;
   private phase: BridgePhase = 'searching';
   private readonly pending = new Map<string, PendingResolver>();
@@ -86,22 +231,52 @@ export class BridgeClient {
     return { phase: this.phase, port: this.port };
   }
 
-  /** Whether an authenticated socket is currently open. */
+  /** Whether a transport is currently live. */
   isOpen(): boolean {
-    return this.socket?.readyState === WebSocket.OPEN;
+    return this.transport !== null;
   }
 
   /**
-   * Ensure a connection: if already open, no-op; otherwise probe the range.
+   * Ensure a connection: if already open, no-op; otherwise try native then ws.
    * Safe to call repeatedly (popup-open wake, reconnect button).
    */
   async ensureConnected(): Promise<void> {
     if (this.disposed || this.isOpen() || this.connecting) return;
     this.connecting = true;
     try {
+      this.setPhase('searching');
+      // Native first. ponytail: serial single-in-flight is fine — the popup
+      // imports one job at a time, matching the Rust host's serial relay.
+      // `connectNative()` THROWS SYNCHRONOUSLY when the host isn't registered, so
+      // building the readiness promise is separated from awaiting it — that keeps
+      // the ws fallback probe firing in the SAME tick (no microtask hop) when
+      // native is unavailable, which the ws reconnect test relies on.
+      let readyPromise: Promise<NativeMessagingTransport> | null = null;
+      try {
+        readyPromise = connectNative();
+      } catch {
+        readyPromise = null; // host not registered → straight to ws, same tick.
+      }
+      if (readyPromise) {
+        try {
+          const native = await readyPromise;
+          this.port = null; // native has no port number; diagnostics only.
+          this.attach(native);
+          return;
+        } catch (err) {
+          if (err instanceof Error && err.message === NATIVE_APP_DOWN) {
+            // Host reachable, app down — do NOT fall back to ws.
+            this.setPhase('app_not_running');
+            this.scheduleReconnect();
+            return;
+          }
+          // NATIVE_UNAVAILABLE → fall through to the ws probe.
+        }
+      }
+
       const socket = await this.probeRange();
       if (socket) {
-        this.attach(socket);
+        this.attach(new WebSocketTransport(socket));
       } else {
         this.setPhase('app_not_running');
         this.scheduleReconnect();
@@ -111,15 +286,15 @@ export class BridgeClient {
     }
   }
 
-  /** Tear down the socket and cancel timers (worker shutdown / manual reset). */
+  /** Tear down the transport and cancel timers (worker shutdown / manual reset). */
   dispose(): void {
     this.disposed = true;
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     for (const t of this.timers.values()) clearTimeout(t);
     this.timers.clear();
     this.pending.clear();
-    this.socket?.close();
-    this.socket = null;
+    this.transport?.close();
+    this.transport = null;
   }
 
   /**
@@ -128,8 +303,8 @@ export class BridgeClient {
    */
   async importJob(token: string, payload: ExtensionImportRequest): Promise<ExtensionImportResult> {
     await this.ensureConnected();
-    const socket = this.socket;
-    if (!socket || socket.readyState !== WebSocket.OPEN) {
+    const transport = this.transport;
+    if (!transport) {
       throw new Error('Desktop app not reachable. Is AI Job Hunter running?');
     }
 
@@ -151,7 +326,7 @@ export class BridgeClient {
       this.pending.set(reqId, resolve);
 
       try {
-        socket.send(JSON.stringify(envelope));
+        transport.send(envelope);
       } catch (err) {
         clearTimeout(timer);
         this.timers.delete(reqId);
@@ -224,37 +399,25 @@ export class BridgeClient {
     });
   }
 
-  /** Wire an opened socket: register handlers and reset backoff. */
-  private attach(socket: WebSocket): void {
-    this.socket = socket;
+  /** Wire an opened transport: register handlers and reset backoff. */
+  private attach(transport: BridgeTransport): void {
+    this.transport = transport;
     this.backoffIndex = 0;
     this.setPhase('connected');
 
-    socket.addEventListener('message', (ev: MessageEvent) => {
-      this.onMessage(typeof ev.data === 'string' ? ev.data : '');
-    });
-    socket.addEventListener('close', () => {
-      this.socket = null;
+    transport.onMessage((env) => this.onMessage(env));
+    transport.onClose(() => {
+      this.transport = null;
       this.failAllPending('Connection to the desktop app closed.');
       if (!this.disposed) {
         this.setPhase('app_not_running');
         this.scheduleReconnect();
       }
     });
-    socket.addEventListener('error', () => {
-      // `close` fires after `error`; cleanup happens there.
-    });
   }
 
-  /** Parse a reply envelope, match `reqId`, validate payload, resolve caller. */
-  private onMessage(raw: string): void {
-    if (!raw) return;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      return;
-    }
+  /** Match a parsed reply envelope by `reqId`, validate payload, resolve caller. */
+  private onMessage(parsed: unknown): void {
     if (typeof parsed !== 'object' || parsed === null) return;
     const env = parsed as Partial<ExtensionEnvelope>;
     if (env.type !== EXTENSION_MESSAGE_TYPES.importResult) return;

--- a/apps/extension/src/lib/bridge.ts
+++ b/apps/extension/src/lib/bridge.ts
@@ -194,21 +194,32 @@ function connectNative(): Promise<NativeMessagingTransport> {
       clearTimeout(timer);
       fn();
     };
+    // Pre-attach failures must close the native Port; otherwise the browser keeps
+    // the spawned host process alive across reconnect-backoff attempts.
+    const rejectWith = (reason: string, disconnect: boolean): void => {
+      finish(() => {
+        if (disconnect) {
+          try {
+            port.disconnect();
+          } catch {
+            /* already closed */
+          }
+        }
+        reject(new Error(reason));
+      });
+    };
 
-    const timer = setTimeout(
-      () => finish(() => reject(new Error(NATIVE_UNAVAILABLE))),
-      READY_TIMEOUT_MS
-    );
+    const timer = setTimeout(() => rejectWith(NATIVE_UNAVAILABLE, true), READY_TIMEOUT_MS);
 
     port.onMessage.addListener((msg: unknown) => {
       if (!isBridgeReady(msg)) return; // ignore stray frames before ready
-      finish(() =>
-        msg.ok ? resolve(new NativeMessagingTransport(port)) : reject(new Error(NATIVE_APP_DOWN))
-      );
+      if (msg.ok) finish(() => resolve(new NativeMessagingTransport(port)));
+      else rejectWith(NATIVE_APP_DOWN, true);
     });
     port.onDisconnect.addListener(() => {
-      // Disconnect before ready = host not registered (lastError set).
-      finish(() => reject(new Error(NATIVE_UNAVAILABLE)));
+      // Disconnect before ready = host not registered (lastError set); the port
+      // already fired disconnect, so do NOT call disconnect() again here.
+      rejectWith(NATIVE_UNAVAILABLE, false);
     });
   });
 }

--- a/apps/extension/src/manifest.ts
+++ b/apps/extension/src/manifest.ts
@@ -53,8 +53,11 @@ function baseManifest(): ManifestRecord {
     // activeTab → read the clicked tab's DOM on user action without broad host
     // access. storage → persist the pairing token. scripting → MV3 dynamic
     // inject for Scan mode (chrome.scripting.executeScript); host scope still
-    // limited to the active tab by activeTab.
-    permissions: ['activeTab', 'storage', 'scripting'],
+    // limited to the active tab by activeTab. nativeMessaging → `runtime.connectNative`
+    // to the desktop host (`app.aijobhunter.bridge`), the HTTPS-Only-safe transport
+    // that survives Firefox upgrading `ws://` to `wss://`; the loopback
+    // `host_permissions` below stay for the `ws` fallback.
+    permissions: ['activeTab', 'storage', 'scripting', 'nativeMessaging'],
     host_permissions: LOOPBACK_HOSTS,
     action: {
       default_popup: 'popup.html',

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -159,7 +159,7 @@ wmi = "0.18"
 windows-native-keyring-store = "1"
 # DPAPI (CryptUnprotectData) to unwrap the Chromium os_crypt AES key on Windows;
 # UI_ViewManagement reads the system accent color via UISettings (Appearance).
-windows = { version = "0.62.2", features = ["Win32_Security_Cryptography", "Win32_Foundation", "UI_ViewManagement"] }
+windows = { version = "0.62.2", features = ["Win32_Security_Cryptography", "Win32_Foundation", "UI_ViewManagement", "Win32_System_Registry"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store = { version = "1", features = ["keychain"] }

--- a/apps/tauri/src-tauri/src/extension_bridge/auth.rs
+++ b/apps/tauri/src-tauri/src/extension_bridge/auth.rs
@@ -28,6 +28,16 @@ pub const ALLOWED_EXTENSION_IDS: &[&str] = &[
     "oaoekkgkhmgdfnpmfkpphgiikliaicll",
 ];
 
+/// Sentinel `Origin` the native-messaging host
+/// ([`super::native_host`]) sends when it relays the browser's frames to this
+/// loopback bridge. The host is our OWN native process (spawned by the browser,
+/// our exe in `--native-host` mode) bridging stdio → `ws://127.0.0.1`, so it has
+/// no `chrome-extension://`/`moz-extension://` origin of its own. Accepting this
+/// sentinel is defense-in-depth only: the real boundary stays the per-frame
+/// 256-bit pairing token over the loopback-only listener, which the host relays
+/// through unchanged.
+pub const NATIVE_HOST_ORIGIN: &str = "ajh-native-host";
+
 /// Whether a handshake `Origin` is an allowed extension origin.
 ///
 /// This check is **defense-in-depth, not the primary boundary**. The real
@@ -67,6 +77,12 @@ pub fn is_allowed_origin(origin: &str, dev_origins: &[String]) -> bool {
     // listener, which a null-origin page cannot satisfy without the token the
     // user copied from the app's Settings.
     if origin == "null" {
+        return true;
+    }
+    // Native-messaging host (our own native process relaying to the loopback
+    // bridge — see `NATIVE_HOST_ORIGIN`). Exact match only; the per-frame token +
+    // loopback binding remain the real boundary.
+    if origin == NATIVE_HOST_ORIGIN {
         return true;
     }
     // Chrome: scheme + known store id. An origin is just scheme + host, so a
@@ -177,6 +193,24 @@ mod tests {
         // happen to contain it.
         assert!(!is_allowed_origin("nullish", &[]));
         assert!(!is_allowed_origin("https://null.example.com", &[]));
+    }
+
+    #[test]
+    fn allows_native_host_sentinel_origin() {
+        // Our native-messaging host relays to the loopback bridge with this
+        // sentinel Origin (it has no extension origin of its own). Accepted
+        // (defense-in-depth); the per-frame token is the real boundary.
+        assert!(is_allowed_origin(NATIVE_HOST_ORIGIN, &[]));
+        assert!(is_allowed_origin("ajh-native-host", &[]));
+        // Leading/trailing whitespace is trimmed before the check.
+        assert!(is_allowed_origin("  ajh-native-host  ", &[]));
+    }
+
+    #[test]
+    fn rejects_origins_that_merely_contain_native_sentinel() {
+        // Only the exact sentinel is accepted — not strings that contain it.
+        assert!(!is_allowed_origin("ajh-native-host.evil.com", &[]));
+        assert!(!is_allowed_origin("xajh-native-host", &[]));
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/extension_bridge/auth.rs
+++ b/apps/tauri/src-tauri/src/extension_bridge/auth.rs
@@ -58,15 +58,27 @@ pub fn is_allowed_origin(origin: &str, dev_origins: &[String]) -> bool {
     if dev_origins.iter().any(|d| d == origin) {
         return true;
     }
+    // Firefox: a WebSocket/fetch initiated from an extension BACKGROUND script
+    // sends `Origin: null` — Firefox deliberately strips the `moz-extension://`
+    // UUID rather than leak it (Bugzilla 1607936 / 1257989). So the real Firefox
+    // bridge handshake arrives as `null`, NOT `moz-extension://<uuid>`. Accept
+    // it: the origin gate is defense-in-depth only — the actual boundary is the
+    // per-frame 256-bit pairing token over a loopback-only (`127.0.0.1`)
+    // listener, which a null-origin page cannot satisfy without the token the
+    // user copied from the app's Settings.
+    if origin == "null" {
+        return true;
+    }
     // Chrome: scheme + known store id. An origin is just scheme + host, so a
     // clean id has no slash (reject a trailing path / extra segment).
     if let Some(id) = origin.strip_prefix("chrome-extension://") {
         return !id.contains('/') && ALLOWED_EXTENSION_IDS.contains(&id);
     }
-    // Firefox: scheme + per-install internal UUID. The id is random per profile
-    // and unknowable in advance, so accept any well-formed UUID host (again, no
-    // trailing path). `is_extension_uuid` already rejects anything containing a
-    // slash, since a slash is not a hex/dash UUID char.
+    // Firefox, non-background contexts (e.g. a content/popup-initiated socket):
+    // `moz-extension://<uuid>`. The id is random per profile and unknowable in
+    // advance, so accept any well-formed UUID host (no trailing path —
+    // `is_extension_uuid` rejects a slash, which is not a hex/dash char). The
+    // common background path is handled by the `null` case above.
     if let Some(host) = origin.strip_prefix("moz-extension://") {
         return is_extension_uuid(host);
     }
@@ -144,6 +156,27 @@ mod tests {
     fn allows_well_formed_firefox_uuid() {
         let origin = format!("moz-extension://{FIREFOX_UUID}");
         assert!(is_allowed_origin(&origin, &[]));
+    }
+
+    #[test]
+    fn allows_firefox_null_origin() {
+        // Firefox sends `Origin: null` for a WebSocket initiated from an
+        // extension background script — it strips the moz-extension UUID rather
+        // than leak it (Bugzilla 1607936 / 1257989). This is the REAL Firefox
+        // bridge handshake (NOT `moz-extension://<uuid>`). The origin gate is
+        // defense-in-depth only; the per-frame 256-bit pairing token over a
+        // loopback-only listener is the actual boundary.
+        assert!(is_allowed_origin("null", &[]));
+        // Leading/trailing whitespace is trimmed before the check.
+        assert!(is_allowed_origin("  null  ", &[]));
+    }
+
+    #[test]
+    fn rejects_origins_that_merely_contain_null() {
+        // Only the exact `null` token is accepted — not arbitrary strings that
+        // happen to contain it.
+        assert!(!is_allowed_origin("nullish", &[]));
+        assert!(!is_allowed_origin("https://null.example.com", &[]));
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/tauri/src-tauri/src/extension_bridge/mod.rs
@@ -52,8 +52,19 @@ use crate::events::{emit_event, APPLICATIONS_CHANGED};
 pub mod auth;
 #[cfg(test)]
 mod import_tests;
+pub mod native_host;
+pub mod register;
 #[cfg(test)]
 mod test;
+
+/// Native-messaging host name — the registered identifier the browser uses to
+/// spawn our relay (our exe in `--native-host` mode). MUST match the extension
+/// side exactly (`apps/extension`). The host-manifest filename is this with a
+/// `.json` suffix.
+pub const NATIVE_HOST_NAME: &str = "app.aijobhunter.bridge";
+
+/// On-disk host-manifest filename the browser reads to find + spawn the host.
+pub const NATIVE_HOST_MANIFEST: &str = "app.aijobhunter.bridge.json";
 
 /// Wire `type` strings — the Rust mirror of the shared `EXTENSION_MESSAGE_TYPES`
 /// in `packages/shared/src/ipc/extension-protocol.ts`. A parity test

--- a/apps/tauri/src-tauri/src/extension_bridge/native_host.rs
+++ b/apps/tauri/src-tauri/src/extension_bridge/native_host.rs
@@ -1,0 +1,240 @@
+//! Native-messaging transport host — a near-dumb byte relay between a browser's
+//! native-messaging Port (stdio) and the running desktop app's existing loopback
+//! `ws://127.0.0.1` bridge ([`super`]).
+//!
+//! ## Why this exists
+//! Firefox's HTTPS-Only Mode silently upgrades a background script's
+//! `ws://127.0.0.1` → `wss://`, which the plain loopback bridge can't serve (no
+//! TLS on loopback). A native-messaging host is a real spawned process, immune to
+//! that upgrade: the browser launches our own exe (in `--native-host` mode), and
+//! this relay forwards frames over plain `ws://` to the bridge. Same wire
+//! envelope; only the transport changes.
+//!
+//! ```text
+//! Browser ⇄ (stdio: u32-len-prefix + JSON) ⇄ this host ⇄ (ws loopback) ⇄ app
+//! ```
+//!
+//! ## Not a protocol parser
+//! The host does NOT understand the bridge protocol. The per-frame pairing token
+//! flows through verbatim, so bridge auth ([`super::auth`]) + pairing UX are
+//! untouched. The ONE thing it speaks itself is a transport-local readiness
+//! control frame (`bridge.ready`) so the extension can tell "app reachable" from
+//! "app down" — that frame never reaches the bridge and is NOT part of the
+//! `@ajh/shared` bridge protocol.
+//!
+//! Invoked from `main()` BEFORE Tauri boots (see `lib::run_native_host_if_invoked`),
+//! so there is no ambient Tokio runtime — [`run`] builds its own.
+
+use futures::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio::io::{stdin, stdout, AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+use tokio_tungstenite::tungstenite::{ClientRequestBuilder, Message};
+
+use super::auth::NATIVE_HOST_ORIGIN;
+use super::{MAX_FRAME_BYTES, PORT_RANGE};
+
+/// `--native-host` entry point. Builds its own current-thread runtime (no Tauri
+/// reactor exists at this point in `main`) and blocks on the relay. Never panics
+/// out — a build failure just logs and returns so the process exits cleanly.
+pub fn run() {
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            log::warn!("[native_host] failed to build runtime: {e}");
+            return;
+        }
+    };
+    rt.block_on(relay());
+}
+
+/// Connect to the first live bridge port, announce readiness, then pump frames
+/// 1:1 between stdin and the ws until either side closes.
+async fn relay() {
+    let mut ws = match connect_bridge().await {
+        Some(ws) => ws,
+        None => {
+            // App not running / no bridge port answered. Tell the extension, then
+            // exit cleanly — the browser Port disconnects and the extension shows
+            // app_not_running (it will re-spawn us on the next attempt).
+            write_ready(false).await;
+            return;
+        }
+    };
+    write_ready(true).await;
+
+    let mut input = stdin();
+    let mut output = stdout();
+
+    // ponytail: serial single-in-flight relay — the popup imports one job at a
+    // time; add reqId multiplexing only if concurrent requests ever ship.
+    loop {
+        // 1. Read one stdin frame (browser → host). EOF = Port closed → exit.
+        let frame = match read_stdin_frame(&mut input).await {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => break, // clean EOF
+            Err(_) => break,   // malformed / over-cap length → exit
+        };
+
+        // 2. Forward it verbatim to the bridge as a Text frame.
+        let text = match String::from_utf8(frame) {
+            Ok(t) => t,
+            Err(_) => continue, // not UTF-8 JSON — drop, keep the Port alive
+        };
+        if ws.send(Message::text(text)).await.is_err() {
+            break;
+        }
+
+        // 3. Read ws frames until the next Text/Binary reply, then frame it back
+        //    to stdout. A ws close/error ends the session.
+        match next_ws_payload(&mut ws).await {
+            Some(reply) => {
+                if write_stdout_frame(&mut output, reply.as_bytes())
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            None => break, // ws closed/errored
+        }
+    }
+
+    // On any exit (stdin EOF or ws closed) flip the extension to app_not_running.
+    write_ready(false).await;
+}
+
+/// Probe [`PORT_RANGE`] in order; the first port whose TCP connect + ws handshake
+/// both succeed wins. The handshake sends `Origin: ajh-native-host` (accepted by
+/// [`super::auth::is_allowed_origin`]). Uses `client_async_with_config` over a
+/// plain `TcpStream` — the crate has no TLS/`connect` feature, only `handshake`.
+async fn connect_bridge() -> Option<WsStream> {
+    let config = WebSocketConfig::default()
+        .max_message_size(Some(MAX_FRAME_BYTES))
+        .max_frame_size(Some(MAX_FRAME_BYTES));
+
+    for port in PORT_RANGE {
+        let tcp = match TcpStream::connect(("127.0.0.1", port)).await {
+            Ok(tcp) => tcp,
+            Err(_) => continue,
+        };
+        let uri = match format!("ws://127.0.0.1:{port}/").parse() {
+            Ok(uri) => uri,
+            Err(_) => continue,
+        };
+        let request = ClientRequestBuilder::new(uri).with_header("Origin", NATIVE_HOST_ORIGIN);
+        match tokio_tungstenite::client_async_with_config(request, tcp, Some(config)).await {
+            Ok((ws, _resp)) => return Some(ws),
+            Err(_) => continue,
+        }
+    }
+    None
+}
+
+type WsStream = tokio_tungstenite::WebSocketStream<TcpStream>;
+
+/// Read ws frames until the next Text/Binary payload (skipping Ping/Pong, which
+/// tungstenite auto-answers); `None` on close/error. NOTE: the ws round-trip
+/// can't be unit-tested here — it needs a live bridge server.
+async fn next_ws_payload(ws: &mut WsStream) -> Option<String> {
+    while let Some(frame) = ws.next().await {
+        match frame {
+            Ok(Message::Text(t)) => return Some(t.to_string()),
+            Ok(Message::Binary(b)) => return String::from_utf8(b.to_vec()).ok(),
+            Ok(Message::Close(_)) | Err(_) => return None,
+            _ => continue, // ping/pong/other control — keep reading
+        }
+    }
+    None
+}
+
+/// Write the transport-local readiness control frame. Best-effort: a write
+/// failure (browser already gone) is ignored — we're exiting anyway.
+async fn write_ready(ok: bool) {
+    let frame = json!({ "type": "bridge.ready", "ok": ok }).to_string();
+    let _ = write_stdout_frame(&mut stdout(), frame.as_bytes()).await;
+}
+
+// ── Native-messaging stdio framing ─────────────────────────────────────────────
+// Each message = a 4-byte length prefix in NATIVE byte order, then that many
+// bytes of UTF-8 JSON. An inbound length over the cap is rejected without
+// allocating.
+
+/// Read one length-prefixed stdin frame. `Ok(None)` on clean EOF (Port closed);
+/// `Err` on a partial read or an over-cap length (caller exits).
+async fn read_stdin_frame<R: AsyncReadExt + Unpin>(r: &mut R) -> std::io::Result<Option<Vec<u8>>> {
+    let mut len_buf = [0u8; 4];
+    match r.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        // EOF at a frame boundary is the normal Port-closed shutdown.
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+    let len = u32::from_ne_bytes(len_buf) as usize;
+    if len > MAX_FRAME_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "native-messaging frame over size cap",
+        ));
+    }
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf).await?;
+    Ok(Some(buf))
+}
+
+/// Write one length-prefixed stdout frame (native-order u32 prefix + bytes) and
+/// flush. Over-cap payloads are an internal bug — refuse rather than emit a frame
+/// the browser will reject.
+async fn write_stdout_frame<W: AsyncWriteExt + Unpin>(
+    w: &mut W,
+    payload: &[u8],
+) -> std::io::Result<()> {
+    if payload.len() > MAX_FRAME_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "native-messaging frame over size cap",
+        ));
+    }
+    let len = payload.len() as u32;
+    w.write_all(&len.to_ne_bytes()).await?;
+    w.write_all(payload).await?;
+    w.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The ws round-trip can't be exercised here (it needs a live bridge server);
+    // this pins only the stdio framing — the one bit of non-trivial byte logic.
+    #[tokio::test]
+    async fn stdio_frame_round_trips() {
+        let value = json!({ "type": "import.request", "reqId": "1", "token": "abc" });
+        let json = value.to_string();
+
+        // Encode: native-order u32 length prefix + UTF-8 JSON.
+        let mut encoded = (json.len() as u32).to_ne_bytes().to_vec();
+        encoded.extend_from_slice(json.as_bytes());
+
+        // Decode it back through the reader the relay uses.
+        let mut cursor = std::io::Cursor::new(encoded);
+        let decoded = read_stdin_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(decoded, json.as_bytes());
+
+        // A second read at EOF is the clean Port-closed signal, not an error.
+        assert!(read_stdin_frame(&mut cursor).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn rejects_over_cap_length() {
+        // A length prefix above MAX_FRAME_BYTES is refused without allocating it.
+        let over = (MAX_FRAME_BYTES as u32 + 1).to_ne_bytes().to_vec();
+        let mut cursor = std::io::Cursor::new(over);
+        assert!(read_stdin_frame(&mut cursor).await.is_err());
+    }
+}

--- a/apps/tauri/src-tauri/src/extension_bridge/register.rs
+++ b/apps/tauri/src-tauri/src/extension_bridge/register.rs
@@ -118,11 +118,10 @@ pub fn register_native_host(data_dir: &Path) {
     #[cfg(not(windows))]
     {
         let _ = data_dir; // unused off Windows — browsers read fixed well-known dirs
-        let Some(home) = std::env::var_os("HOME") else {
+        let Some(home) = crate::platform::config::home_dir() else {
             log::warn!("[native_host] HOME unset — skipping host-manifest registration");
             return;
         };
-        let home = Path::new(&home);
 
         #[cfg(target_os = "macos")]
         {

--- a/apps/tauri/src-tauri/src/extension_bridge/register.rs
+++ b/apps/tauri/src-tauri/src/extension_bridge/register.rs
@@ -1,0 +1,237 @@
+//! Native-messaging host registration — writes the per-browser host manifests
+//! and (on Windows) the HKCU registry pointers so Firefox/Chrome can find and
+//! spawn our relay ([`super::native_host`]).
+//!
+//! Called best-effort from the Tauri `setup` on every launch ([`register_native_host`]):
+//! idempotent and overwriting, so `path` (= the current exe) tracks app moves and
+//! updates. NEVER panics or propagates to boot — every step logs a warning on
+//! failure and continues.
+//!
+//! ## What gets written
+//! A host manifest is a small JSON file naming the host, its `stdio` type, the
+//! absolute exe `path`, and the browser-specific allow-list:
+//! - **Firefox** uses `"allowed_extensions": ["<gecko-id>"]`.
+//! - **Chrome**  uses `"allowed_origins": ["chrome-extension://<id>/"]` (Chrome
+//!   requires the trailing slash).
+//!
+//! Placement is OS- + browser-specific (see [`register_native_host`]). On Windows
+//! the browser finds the manifest via an HKCU registry value; on macOS/Linux it
+//! reads a fixed well-known directory directly (no registry).
+
+use std::path::Path;
+
+use serde_json::json;
+
+use super::NATIVE_HOST_NAME;
+// Only the non-Windows branches read the manifest filename; on Windows the path
+// is derived from `NATIVE_HOST_NAME` instead (the registry value points at it).
+#[cfg(not(windows))]
+use super::NATIVE_HOST_MANIFEST;
+
+/// Firefox gecko id (AMO `allowed_extensions` entry). MUST match the extension's
+/// manifest `browser_specific_settings.gecko.id`.
+const FIREFOX_GECKO_ID: &str = "job-importer@aijobhunter.app";
+
+/// Chrome allow-listed extension origin. Chrome requires the trailing slash.
+const CHROME_ALLOWED_ORIGIN: &str = "chrome-extension://oaoekkgkhmgdfnpmfkpphgiikliaicll/";
+
+const DESCRIPTION: &str = "AI Job Hunter browser bridge";
+
+/// Build the JSON bytes for one host manifest. `serde_json` escapes Windows
+/// backslashes in the exe path correctly.
+fn manifest_json(exe: &Path, firefox: bool) -> Vec<u8> {
+    let path = exe.to_string_lossy();
+    let allow = if firefox {
+        json!({ "allowed_extensions": [FIREFOX_GECKO_ID] })
+    } else {
+        json!({ "allowed_origins": [CHROME_ALLOWED_ORIGIN] })
+    };
+    // Merge the common fields with the browser-specific allow-list.
+    let mut obj = json!({
+        "name": NATIVE_HOST_NAME,
+        "description": DESCRIPTION,
+        "path": path,
+        "type": "stdio",
+    });
+    if let (Some(map), Some(extra)) = (obj.as_object_mut(), allow.as_object()) {
+        for (k, v) in extra {
+            map.insert(k.clone(), v.clone());
+        }
+    }
+    serde_json::to_vec_pretty(&obj).unwrap_or_default()
+}
+
+/// Write `bytes` to `path`, creating parent dirs. Best-effort: logs + returns on
+/// any failure.
+fn write_manifest(path: &Path, bytes: &[u8]) {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            log::warn!(
+                "[native_host] mkdir {} failed (non-fatal): {e}",
+                parent.display()
+            );
+            return;
+        }
+    }
+    if let Err(e) = std::fs::write(path, bytes) {
+        log::warn!(
+            "[native_host] write {} failed (non-fatal): {e}",
+            path.display()
+        );
+    }
+}
+
+/// Register the native-messaging host for Firefox + Chrome. Best-effort and
+/// idempotent — safe to call on every launch.
+pub fn register_native_host(data_dir: &Path) {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("[native_host] current_exe() failed (non-fatal): {e}");
+            return;
+        }
+    };
+    let firefox_json = manifest_json(&exe, true);
+    let chrome_json = manifest_json(&exe, false);
+
+    #[cfg(windows)]
+    {
+        // Windows: the manifest location is arbitrary; the browser is pointed at
+        // it by an HKCU registry value. Keep both under the app data dir.
+        let dir = data_dir.join("native-messaging");
+        let firefox_path = dir.join(format!("{NATIVE_HOST_NAME}.firefox.json"));
+        let chrome_path = dir.join(format!("{NATIVE_HOST_NAME}.chrome.json"));
+        write_manifest(&firefox_path, &firefox_json);
+        write_manifest(&chrome_path, &chrome_json);
+
+        let firefox_key = format!("Software\\Mozilla\\NativeMessagingHosts\\{NATIVE_HOST_NAME}");
+        let chrome_key =
+            format!("Software\\Google\\Chrome\\NativeMessagingHosts\\{NATIVE_HOST_NAME}");
+        if let Err(e) = set_hkcu_default(&firefox_key, &firefox_path.to_string_lossy()) {
+            log::warn!("[native_host] HKCU firefox key failed (non-fatal): {e}");
+        }
+        if let Err(e) = set_hkcu_default(&chrome_key, &chrome_path.to_string_lossy()) {
+            log::warn!("[native_host] HKCU chrome key failed (non-fatal): {e}");
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = data_dir; // unused off Windows — browsers read fixed well-known dirs
+        let Some(home) = std::env::var_os("HOME") else {
+            log::warn!("[native_host] HOME unset — skipping host-manifest registration");
+            return;
+        };
+        let home = Path::new(&home);
+
+        #[cfg(target_os = "macos")]
+        {
+            let firefox_path = home
+                .join("Library/Application Support/Mozilla/NativeMessagingHosts")
+                .join(NATIVE_HOST_MANIFEST);
+            let chrome_path = home
+                .join("Library/Application Support/Google/Chrome/NativeMessagingHosts")
+                .join(NATIVE_HOST_MANIFEST);
+            write_manifest(&firefox_path, &firefox_json);
+            write_manifest(&chrome_path, &chrome_json);
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let firefox_path = home
+                .join(".mozilla/native-messaging-hosts")
+                .join(NATIVE_HOST_MANIFEST);
+            let chrome_path = home
+                .join(".config/google-chrome/NativeMessagingHosts")
+                .join(NATIVE_HOST_MANIFEST);
+            write_manifest(&firefox_path, &firefox_json);
+            write_manifest(&chrome_path, &chrome_json);
+        }
+    }
+}
+
+/// Set the default (`""`) value of an HKCU subkey to `value` (REG_SZ). Creates
+/// the key if absent. Encapsulates the raw Win32 FFI; the registry crate would
+/// be a new dependency, so this hand-rolls `RegCreateKeyExW` + `RegSetValueExW`
+/// against the already-present `windows` crate.
+#[cfg(windows)]
+fn set_hkcu_default(subkey: &str, value: &str) -> std::io::Result<()> {
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::ERROR_SUCCESS;
+    use windows::Win32::System::Registry::{
+        RegCloseKey, RegCreateKeyExW, RegSetValueExW, HKEY, HKEY_CURRENT_USER, KEY_WRITE,
+        REG_OPTION_NON_VOLATILE, REG_SZ,
+    };
+
+    // UTF-16, NUL-terminated, for the PCWSTR args.
+    let subkey_w: Vec<u16> = subkey.encode_utf16().chain(std::iter::once(0)).collect();
+    let value_w: Vec<u16> = value.encode_utf16().chain(std::iter::once(0)).collect();
+
+    // SAFETY: standard advapi32 registry FFI. `subkey_w` is a valid NUL-terminated
+    // UTF-16 buffer kept alive across the call; `hkey` is written by
+    // RegCreateKeyExW and closed unconditionally below. `value_w` (incl. its NUL)
+    // is written as REG_SZ with an explicit byte length.
+    unsafe {
+        let mut hkey = HKEY::default();
+        let status = RegCreateKeyExW(
+            HKEY_CURRENT_USER,
+            PCWSTR(subkey_w.as_ptr()),
+            None,
+            PCWSTR::null(),
+            REG_OPTION_NON_VOLATILE,
+            KEY_WRITE,
+            None,
+            &mut hkey,
+            None,
+        );
+        if status != ERROR_SUCCESS {
+            return Err(std::io::Error::from_raw_os_error(status.0 as i32));
+        }
+
+        // REG_SZ byte length includes the trailing NUL (2 bytes per u16).
+        let bytes = std::slice::from_raw_parts(
+            value_w.as_ptr() as *const u8,
+            std::mem::size_of_val(value_w.as_slice()),
+        );
+        let set = RegSetValueExW(hkey, PCWSTR::null(), None, REG_SZ, Some(bytes));
+        let _ = RegCloseKey(hkey);
+        if set != ERROR_SUCCESS {
+            return Err(std::io::Error::from_raw_os_error(set.0 as i32));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn firefox_manifest_has_allowed_extensions_and_stdio() {
+        let exe = PathBuf::from(if cfg!(windows) {
+            r"C:\Program Files\AI Job Hunter\app.exe"
+        } else {
+            "/opt/aijobhunter/app"
+        });
+        let bytes = manifest_json(&exe, true);
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["name"], NATIVE_HOST_NAME);
+        assert_eq!(v["type"], "stdio");
+        assert_eq!(v["allowed_extensions"][0], FIREFOX_GECKO_ID);
+        assert!(v.get("allowed_origins").is_none());
+        // The exe path round-trips (serde_json escaped any backslashes).
+        assert_eq!(v["path"], exe.to_string_lossy().as_ref());
+    }
+
+    #[test]
+    fn chrome_manifest_has_allowed_origins_with_trailing_slash() {
+        let exe = PathBuf::from("/opt/aijobhunter/app");
+        let bytes = manifest_json(&exe, false);
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "stdio");
+        assert_eq!(v["allowed_origins"][0], CHROME_ALLOWED_ORIGIN);
+        assert!(v["allowed_origins"][0].as_str().unwrap().ends_with('/'));
+        assert!(v.get("allowed_extensions").is_none());
+    }
+}

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -304,6 +304,32 @@ fn open_external(app: &AppHandle, url: &str) {
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
+/// Detect a browser native-messaging launch from argv and, if so, run the stdio
+/// relay host ([`extension_bridge::native_host`]) instead of booting Tauri,
+/// returning `true` once it has handled and run the relay. `main.rs` calls this
+/// first so a native-host launch never reaches the Tauri builder or the
+/// single-instance plugin (which would forward argv to the running app and kill
+/// the stdio Port).
+///
+/// The BROWSER controls argv, so we detect by what browsers actually pass:
+/// - Firefox: `[exe, <manifest_path>, <extension_id>]` — an arg ends with the
+///   host-manifest filename.
+/// - Chrome: `[exe, chrome-extension://<id>/, (--parent-window=<hwnd> on Win)]` —
+///   an arg starts with `chrome-extension://`.
+///
+/// Our deep links use the `ajh://` scheme, so there is no collision with these.
+pub fn run_native_host_if_invoked() -> bool {
+    let is_native_host = std::env::args().skip(1).any(|arg| {
+        arg.starts_with("chrome-extension://")
+            || arg.starts_with("moz-extension://")
+            || arg.ends_with(extension_bridge::NATIVE_HOST_MANIFEST)
+    });
+    if is_native_host {
+        extension_bridge::native_host::run();
+    }
+    is_native_host
+}
+
 /// Build and run the Tauri application. Called by the binary shim in `main.rs`.
 pub fn run() {
     // Initialise the OS keyring up front. A failure here is non-fatal: the app
@@ -599,6 +625,12 @@ pub fn run() {
             // forget on the tokio runtime; a bind failure logs + disables the
             // bridge and never blocks boot. `BridgeState` was managed above.
             extension_bridge::start(handle.clone());
+
+            // Keep the native-messaging host manifests + OS registration current
+            // (path tracks app moves/updates) so the browser can spawn our stdio
+            // relay — the Firefox HTTPS-Only transport that survives the ws→wss
+            // upgrade. Best-effort; never blocks boot.
+            extension_bridge::register::register_native_host(&data_dir);
 
             // Watch the OS accent color (Windows): on a personalization accent
             // change, emit `system:accentChanged` so the renderer re-pulls the

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -321,7 +321,6 @@ fn open_external(app: &AppHandle, url: &str) {
 pub fn run_native_host_if_invoked() -> bool {
     let is_native_host = std::env::args().skip(1).any(|arg| {
         arg.starts_with("chrome-extension://")
-            || arg.starts_with("moz-extension://")
             || arg.ends_with(extension_bridge::NATIVE_HOST_MANIFEST)
     });
     if is_native_host {

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -5,5 +5,12 @@
 // (`ajh_tauri`) so it is reachable from integration tests and `benches/`.
 // See `lib.rs::run`. This is the canonical Tauri 2 lib + bin split.
 fn main() {
+    // Native-messaging short-circuit: when the browser launches this exe to spawn
+    // the stdio relay host, run the relay and exit — Tauri + single-instance must
+    // never boot (single-instance would forward argv to the running app and kill
+    // the stdio Port). Detected purely from argv inside the library.
+    if ajh_tauri::run_native_host_if_invoked() {
+        return;
+    }
     ajh_tauri::run();
 }

--- a/apps/tauri/src-tauri/src/platform/config.rs
+++ b/apps/tauri/src-tauri/src/platform/config.rs
@@ -32,6 +32,14 @@ pub fn data_dir() -> PathBuf {
     PathBuf::from(home).join(FALLBACK_DIR_NAME)
 }
 
+/// The current user's home directory (`$HOME`), if set. Centralizes the raw
+/// env read for the few callers (e.g. the native-messaging host registration)
+/// that need OS-mandated well-known directories outside the app data dir, so
+/// the R4 "env access only in platform/**" rule holds.
+pub fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
 /// Setup-side resolver (has an `AppHandle`). Resolves the authoritative app data
 /// dir via Tauri and exports it as `AJH_DATA_DIR` so AppHandle-less workers
 /// resolve the same path. Returns the resolved directory.


### PR DESCRIPTION
## Why

The published Firefox extension always shows **"app not running"** even when the desktop app is up. Two root causes (confirmed from a captured request):

1. **`Origin: null`** — Firefox sends `Origin: null` for a WebSocket opened from an extension background script (it strips the `moz-extension://<uuid>`, Bugzilla 1607936/1257989). The bridge's `is_allowed_origin` rejected it → 403.
2. **`ws → wss` upgrade** — with **HTTPS-Only Mode** on, Firefox upgrades `ws://127.0.0.1` → `wss://`, which the plain loopback bridge can't serve. There is no server/extension API to opt a connection out of the upgrade.

A loopback WebSocket can't be made to work for HTTPS-Only users, so this adds a **native-messaging transport** — a browser-spawned stdio host, immune to the HTTPS-Only upgrade.

## What

- **`fix:` `Origin: null`** now accepted in `extension_bridge/auth.rs` (the real Firefox background handshake).
- **`feat:` native-messaging transport.** The browser spawns the desktop app's own exe in `--native-host` mode (`lib::run_native_host_if_invoked`, detected from argv before Tauri boots), running a near-dumb stdio ↔ `ws://127.0.0.1` relay (`extension_bridge/native_host.rs`) to the existing loopback bridge. A native process is immune to the `ws→wss` upgrade.
- **Registration** on every launch: per-browser host manifests + (Windows) HKCU registry pointers (`extension_bridge/register.rs`). Host name `app.aijobhunter.bridge`. No new crate — added the `Win32_System_Registry` feature to the existing `windows` dep.
- **Extension is native-first with a `ws` fallback** (`apps/extension/src/lib/bridge.ts`): tries `connectNative('app.aijobhunter.bridge')`, falls back to the loopback `ws` probe when the host isn't registered (old app / Chrome / native unavailable). Same `@ajh/shared` wire envelope on both transports; the per-frame 256-bit pairing token flows through unchanged.
- New extension permission **`nativeMessaging`** (both targets); loopback `host_permissions` stay for the fallback.
- Bridge auth accepts the native-host sentinel `Origin: ajh-native-host` — defense-in-depth only; the token + loopback binding remain the boundary.

## Outcome

Firefox works by default (HTTPS-Only on **or** off); Chrome keeps working.

## Verification

- `cargo test extension_bridge::` → **50 passed** (auth origin cases incl. `null` + native sentinel, stdio framing round-trip + over-cap, manifest shapes); `cargo clippy --all-targets -D warnings` clean; full crate builds (incl. the Windows registry cfg path).
- `pnpm -F @ajh/extension test` → **48 passed** (43 ws + 5 native: native-first, `ws` fallback on connectNative-throw / disconnect-before-ready / ready-timeout, `bridge.ready{ok:false}`→app_not_running); typecheck + eslint clean; build emits both Chrome + Firefox dist with `nativeMessaging`.
- **Manual E2E (the real proof — native messaging can't be exercised in CI):** build + run the desktop app (registers the host); load the unpacked Firefox build with **HTTPS-Only Mode ON**; pair; open a job posting → Import. Expect: pill **● Connected**, import succeeds, no `wss://` attempt. Repeat with HTTPS-Only OFF and on Chrome (native, falling back to ws when the host isn't registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented native messaging as the primary extension-to-app transport, with automatic WebSocket fallback for improved connection reliability.
  * Added native messaging host support and registration behavior so the desktop app can act as a stdio bridge when launched by the browser.
  * Extension now requires the `nativeMessaging` permission.

* **Documentation**
  * Updated the extension README: clarified required permissions, improved reviewer test-state guidance, and documented transport/origin validation behavior.

* **Tests**
  * Added/updated coverage for native-first flows, timeouts, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->