### PR TITLE
fix: detect native-host launch by host name not exact manifest filename

### DIFF
--- a/apps/tauri/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/tauri/src-tauri/src/extension_bridge/mod.rs
@@ -64,6 +64,10 @@ mod test;
 pub const NATIVE_HOST_NAME: &str = "app.aijobhunter.bridge";
 
 /// On-disk host-manifest filename the browser reads to find + spawn the host.
+/// Only the non-Windows host-manifest paths use this exact filename; on Windows
+/// the files carry a `.firefox`/`.chrome` infix (see [`register`]), so launch
+/// detection matches [`NATIVE_HOST_NAME`] anywhere in the path instead.
+#[cfg(not(windows))]
 pub const NATIVE_HOST_MANIFEST: &str = "app.aijobhunter.bridge.json";
 
 /// Wire `type` strings — the Rust mirror of the shared `EXTENSION_MESSAGE_TYPES`

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -313,9 +313,10 @@ fn open_external(app: &AppHandle, url: &str) {
 ///
 /// The BROWSER controls argv, so we detect by what browsers actually pass:
 /// - Firefox: `[exe, <manifest_path>, <extension_id>]` — an arg is the
-///   host-manifest path, which *contains* the host name. On Windows that path
-///   carries a `.firefox`/`.chrome` infix before `.json`, so we match on the
-///   host name being present rather than the filename ending exactly.
+///   host-manifest path. Its final component starts with the host name and ends
+///   with `.json`; on Windows that filename carries a `.firefox`/`.chrome` infix
+///   (`app.aijobhunter.bridge.firefox.json`), so we match the filename shape
+///   rather than an exact `…bridge.json` suffix (see [`is_host_manifest_arg`]).
 /// - Chrome: `[exe, chrome-extension://<id>/, (--parent-window=<hwnd> on Win)]` —
 ///   an arg starts with `chrome-extension://`.
 ///
@@ -332,16 +333,24 @@ pub fn run_native_host_if_invoked() -> bool {
 /// True iff `args` (the process args AFTER argv[0]) look like a browser
 /// native-messaging launch of our stdio host. Browsers pass:
 /// - Chrome: `chrome-extension://<id>/` (+ `--parent-window=<hwnd>` on Windows).
-/// - Firefox: `<manifest_path> <gecko_id>` — the manifest path contains the host
-///   name ([`extension_bridge::NATIVE_HOST_NAME`]), and on Windows carries a
-///   `.firefox`/`.chrome` infix before `.json`.
+/// - Firefox: `<manifest_path> <gecko_id>` — an arg is the host-manifest path,
+///   matched by [`is_host_manifest_arg`] (final path component starts with the
+///   host name and ends with `.json`).
 ///
 /// Pure over its iterator so the exact failure modes can be unit-tested without
 /// touching the real `std::env::args`.
 fn is_native_host_invocation<'a>(mut args: impl Iterator<Item = &'a str>) -> bool {
-    args.any(|arg| {
-        arg.starts_with("chrome-extension://") || arg.contains(extension_bridge::NATIVE_HOST_NAME)
-    })
+    args.any(|arg| arg.starts_with("chrome-extension://") || is_host_manifest_arg(arg))
+}
+
+/// True iff `arg` is a path whose final component is one of our native-messaging
+/// host manifests (`app.aijobhunter.bridge*.json`) — tighter than a bare
+/// substring match so a crafted flag like `--foo=app.aijobhunter.bridge` is not
+/// misdetected. Covers the unix `…bridge.json` and Windows
+/// `…bridge.firefox.json` / `…bridge.chrome.json` names alike.
+fn is_host_manifest_arg(arg: &str) -> bool {
+    let file = arg.rsplit(['/', '\\']).next().unwrap_or(arg);
+    file.starts_with(extension_bridge::NATIVE_HOST_NAME) && file.ends_with(".json")
 }
 
 /// Build and run the Tauri application. Called by the binary shim in `main.rs`.
@@ -845,5 +854,24 @@ mod run_native_host_tests {
     fn ignores_deep_link_launch() {
         // The `ajh://` deep-link path must NOT be misdetected as a host launch.
         assert!(!detect(&["ajh://settings/extension"]));
+    }
+
+    #[test]
+    fn ignores_crafted_flag_containing_host_name() {
+        // A bare substring match (the prior `contains`) would have misfired on a
+        // flag value; the manifest-filename shape check rejects it.
+        assert!(!detect(&["--foo=app.aijobhunter.bridge"]));
+    }
+
+    #[test]
+    fn ignores_bare_host_name() {
+        // The host name alone is not a `.json` manifest path.
+        assert!(!detect(&["app.aijobhunter.bridge"]));
+    }
+
+    #[test]
+    fn ignores_non_json_lookalike() {
+        // Right stem, wrong extension — not a host manifest.
+        assert!(!detect(&["/etc/app.aijobhunter.bridge.json.bak"]));
     }
 }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -312,21 +312,36 @@ fn open_external(app: &AppHandle, url: &str) {
 /// the stdio Port).
 ///
 /// The BROWSER controls argv, so we detect by what browsers actually pass:
-/// - Firefox: `[exe, <manifest_path>, <extension_id>]` — an arg ends with the
-///   host-manifest filename.
+/// - Firefox: `[exe, <manifest_path>, <extension_id>]` — an arg is the
+///   host-manifest path, which *contains* the host name. On Windows that path
+///   carries a `.firefox`/`.chrome` infix before `.json`, so we match on the
+///   host name being present rather than the filename ending exactly.
 /// - Chrome: `[exe, chrome-extension://<id>/, (--parent-window=<hwnd> on Win)]` —
 ///   an arg starts with `chrome-extension://`.
 ///
 /// Our deep links use the `ajh://` scheme, so there is no collision with these.
 pub fn run_native_host_if_invoked() -> bool {
-    let is_native_host = std::env::args().skip(1).any(|arg| {
-        arg.starts_with("chrome-extension://")
-            || arg.ends_with(extension_bridge::NATIVE_HOST_MANIFEST)
-    });
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let is_native_host = is_native_host_invocation(args.iter().map(String::as_str));
     if is_native_host {
         extension_bridge::native_host::run();
     }
     is_native_host
+}
+
+/// True iff `args` (the process args AFTER argv[0]) look like a browser
+/// native-messaging launch of our stdio host. Browsers pass:
+/// - Chrome: `chrome-extension://<id>/` (+ `--parent-window=<hwnd>` on Windows).
+/// - Firefox: `<manifest_path> <gecko_id>` — the manifest path contains the host
+///   name ([`extension_bridge::NATIVE_HOST_NAME`]), and on Windows carries a
+///   `.firefox`/`.chrome` infix before `.json`.
+///
+/// Pure over its iterator so the exact failure modes can be unit-tested without
+/// touching the real `std::env::args`.
+fn is_native_host_invocation<'a>(mut args: impl Iterator<Item = &'a str>) -> bool {
+    args.any(|arg| {
+        arg.starts_with("chrome-extension://") || arg.contains(extension_bridge::NATIVE_HOST_NAME)
+    })
 }
 
 /// Build and run the Tauri application. Called by the binary shim in `main.rs`.
@@ -785,4 +800,50 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri application");
+}
+
+#[cfg(test)]
+mod run_native_host_tests {
+    use super::is_native_host_invocation;
+
+    fn detect(args: &[&str]) -> bool {
+        is_native_host_invocation(args.iter().copied())
+    }
+
+    #[test]
+    fn detects_firefox_windows_infixed_manifest_path() {
+        // Regression: Windows host-manifest carries a `.firefox` infix before
+        // `.json`, so the old `ends_with("...bridge.json")` check missed it.
+        assert!(detect(&[
+            "C:\\Users\\x\\AppData\\Roaming\\com.aijobhunter\\native-messaging\\app.aijobhunter.bridge.firefox.json",
+            "job-importer@aijobhunter.app",
+        ]));
+    }
+
+    #[test]
+    fn detects_firefox_unix_manifest_path() {
+        assert!(detect(&[
+            "/home/x/.mozilla/native-messaging-hosts/app.aijobhunter.bridge.json",
+            "job-importer@aijobhunter.app",
+        ]));
+    }
+
+    #[test]
+    fn detects_chrome_extension_origin() {
+        assert!(detect(&[
+            "chrome-extension://oaoekkgkhmgdfnpmfkpphgiikliaicll/",
+            "--parent-window=12345",
+        ]));
+    }
+
+    #[test]
+    fn ignores_normal_launch() {
+        assert!(!detect(&[]));
+    }
+
+    #[test]
+    fn ignores_deep_link_launch() {
+        // The `ajh://` deep-link path must NOT be misdetected as a host launch.
+        assert!(!detect(&["ajh://settings/extension"]));
+    }
 }


### PR DESCRIPTION
## Bug

After 0.105.0 (native-messaging transport), on **Firefox + Windows** the app window kept popping to the foreground — even when minimized — and the extension never connected ("app not connected").

## Root cause

Filename mismatch between registration and launch detection:

- `extension_bridge/register.rs` writes the Windows host manifests with a per-browser infix: `app.aijobhunter.bridge.firefox.json` / `.chrome.json`, and points the HKCU registry at the `.firefox.json` one.
- `lib.rs::run_native_host_if_invoked` detected a host launch via `arg.ends_with("app.aijobhunter.bridge.json")` (`NATIVE_HOST_MANIFEST`).
- Firefox spawns the host with the manifest path as argv, e.g. `…\native-messaging\app.aijobhunter.bridge.firefox.json`. `"…bridge.firefox.json".ends_with("…bridge.json")` is **false** → detection fails → the exe falls through to `ajh_tauri::run()` → single-instance focuses the running app and the secondary exits → the extension's reconnect backoff re-spawns it → the window keeps popping up and native messaging never connects.

(Chrome was unaffected — Chrome passes `chrome-extension://<id>/` as argv, not the manifest path.)

## Fix

Detect by the **host name stem** `arg.contains("app.aijobhunter.bridge")` (`NATIVE_HOST_NAME`) instead of the exact `.json` filename — that matches the manifest path on every platform and filename variant (`.json`, `.firefox.json`, `.chrome.json`). The `chrome-extension://` check stays for Chrome.

Extracted the predicate into a pure `is_native_host_invocation()` helper with unit tests pinning the failure modes — including the exact Firefox-Windows `.firefox.json` path that regressed. `NATIVE_HOST_MANIFEST` is now `#[cfg(not(windows))]`-gated (its only remaining user is `register.rs`'s non-Windows branch).

## Scope

Desktop-app (Rust) only — the published browser extension is unchanged and needs **no repack**. After users update the app, registration re-points at the new exe and detection works.

## Verification

- `cargo clippy --all-targets -D warnings` clean.
- `cargo test run_native_host` → **5 passed** (Firefox-Windows infixed path, Firefox-unix path, Chrome origin, empty launch, `ajh://` deep-link not misdetected).
- `cargo test extension_bridge::` → **50 passed**.
- Manual E2E (can't run native messaging in CI): build + run the app, load the Firefox build with **HTTPS-Only Mode ON**, pair, Import → expect **● Connected**, no window pop, no `wss://` attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native-host invocation detection across Windows and Unix-like environments, using browser-argv heuristics rather than exact manifest suffix matching.
  * Updated manifest-path handling to account for platform-specific filename infixes and reduced false-positive matches from near-miss arguments.
* **Tests**
  * Added unit tests covering Firefox and Chrome invocation patterns, deep-link non-detection, empty launches, and multiple crafted argv cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->