### PR TITLE
build: add extension store-zip pack script

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -210,7 +210,14 @@ pnpm -F @ajh/extension dev          # watch mode (Chrome)
 pnpm -F @ajh/extension typecheck    # TypeScript check
 pnpm -F @ajh/extension lint         # ESLint
 pnpm -F @ajh/extension test         # Vitest suite
+pnpm -F @ajh/extension zip          # build + pack store zips → dist/*.zip
+pnpm extension:zip                  # same, from the repo root
 ```
+
+`zip` builds both targets and writes three archives to `dist/` (gitignored):
+`…-chrome-<v>.zip` and `…-firefox-<v>.zip` (store uploads, `manifest.json` at the
+root) and `…-firefox-source-<v>.zip` (the AMO source archive — a `git archive` of
+the tracked monorepo at HEAD, reproducible with `pnpm install && pnpm -F @ajh/extension build`).
 
 ### Build Tooling
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -11,7 +11,8 @@
     "dev": "cross-env BROWSER=chrome vite build --watch --mode development",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "zip": "pnpm run build && node scripts/pack.mjs"
   },
   "dependencies": {
     "@ajh/shared": "workspace:*",

--- a/apps/extension/scripts/pack.mjs
+++ b/apps/extension/scripts/pack.mjs
@@ -1,0 +1,78 @@
+/**
+ * Pack the built extension into store-upload zips.
+ *
+ * Produces three archives in `dist/` (gitignored) for the current package
+ * version:
+ *   - <name>-chrome-<v>.zip   → Chrome Web Store    (manifest.json at the root)
+ *   - <name>-firefox-<v>.zip  → AMO (the add-on)    (manifest.json at the root)
+ *   - <name>-firefox-source-<v>.zip → AMO source code (AMO requires the source
+ *     for build-tool/minified submissions; a clean `git archive` of the tracked
+ *     monorepo at HEAD, so it reproduces with `pnpm install && pnpm -F
+ *     @ajh/extension build`).
+ *
+ * Run via `pnpm -F @ajh/extension pack` (which builds first). Assumes the build
+ * already populated `dist/chrome` and `dist/firefox`.
+ *
+ * ponytail: shells out to the OS zip tool (PowerShell Compress-Archive on
+ * Windows, `zip` elsewhere) + `git archive` instead of pulling an archiver
+ * dependency — Node has no built-in zip writer and these are always present on a
+ * dev box. Swap in a JS archiver only if this ever needs to run where neither is.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const NAME = 'ai-job-hunter-job-importer';
+
+const extRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const dist = join(extRoot, 'dist');
+const version = JSON.parse(readFileSync(join(extRoot, 'package.json'), 'utf8')).version;
+
+/** Zip the CONTENTS of `srcDir` (so manifest.json lands at the archive root). */
+function zipDirContents(srcDir, outZip) {
+  if (!existsSync(srcDir)) {
+    throw new Error(`missing build output: ${srcDir} — run \`pnpm -F @ajh/extension build\` first`);
+  }
+  if (process.platform === 'win32') {
+    execFileSync(
+      'powershell',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Compress-Archive -Path '${join(srcDir, '*')}' -DestinationPath '${outZip}' -Force`,
+      ],
+      { stdio: 'inherit' }
+    );
+  } else {
+    // `zip` archives relative to its cwd, so run it inside srcDir → files at root.
+    execFileSync('zip', ['-r', '-q', outZip, '.'], { cwd: srcDir, stdio: 'inherit' });
+  }
+}
+
+// Clean stale zips so a re-pack never leaves an old version behind.
+for (const f of readdirSync(dist)) {
+  if (f.endsWith('.zip')) rmSync(join(dist, f));
+}
+
+const outputs = {
+  chrome: join(dist, `${NAME}-chrome-${version}.zip`),
+  firefox: join(dist, `${NAME}-firefox-${version}.zip`),
+  source: join(dist, `${NAME}-firefox-source-${version}.zip`),
+};
+
+zipDirContents(join(dist, 'chrome'), outputs.chrome);
+zipDirContents(join(dist, 'firefox'), outputs.firefox);
+
+// Source archive: tracked files at HEAD (no node_modules/dist/secrets), from the
+// repo root so workspace deps are included and the build reproduces.
+const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel']).toString().trim();
+execFileSync('git', ['archive', '--format=zip', '-o', outputs.source, 'HEAD'], { cwd: repoRoot });
+
+console.log(`\nPacked @ajh/extension v${version} → apps/extension/dist:`);
+for (const [label, p] of Object.entries(outputs)) {
+  const kb = (statSync(p).size / 1024).toFixed(1);
+  console.log(`  ${label.padEnd(8)} ${p.split(/[/\\]/).pop()}  (${kb} KB)`);
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "turbo build",
     "build:packages": "turbo build --filter=!@ajh/tauri",
     "package": "pnpm build:packages && pnpm --filter @ajh/tauri package",
+    "extension:zip": "pnpm -F @ajh/extension zip",
     "typecheck": "turbo typecheck",
     "lint": "eslint .",
     "lint:strict": "eslint . --max-warnings 0",


### PR DESCRIPTION
## What

Adds a reusable script to pack the browser extension into store-upload zips, instead of hand-running the archive commands each release.

- **`apps/extension/scripts/pack.mjs`** — builds nothing itself; zips the existing `dist/` output.
- **`pnpm -F @ajh/extension zip`** — `pnpm run build` + `node scripts/pack.mjs`.
- **`pnpm extension:zip`** (root) — convenience passthrough.

Produces three archives in `dist/` (gitignored) for the current package version:
| Zip | For | Notes |
|---|---|---|
| `…-chrome-<v>.zip` | Chrome Web Store | `manifest.json` at the zip root |
| `…-firefox-<v>.zip` | AMO (the add-on) | `manifest.json` at the zip root |
| `…-firefox-source-<v>.zip` | AMO **source** (required for build-tool submissions) | `git archive` of the tracked monorepo at HEAD — reproduces with `pnpm install && pnpm -F @ajh/extension build` |

## Why this shape

- **No new dependency.** Node has no built-in zip writer, so the script shells out to the OS tool — PowerShell `Compress-Archive` on Windows, `zip` elsewhere — and uses `git archive` for the (cross-platform) source zip.
- **Named `zip`, not `pack`** — `pnpm pack` is a reserved built-in (it makes a package `.tgz` and would shadow the script).
- Stale `dist/*.zip` are cleaned before each run so a re-pack never leaves an old version behind.

## Verification

- `pnpm extension:zip` and `pnpm -F @ajh/extension zip` both build + emit all three archives (chrome/firefox 56 KB, source ~11 MB).
- Confirmed `manifest.json` is at the **root** of both store zips (12 entries each), and the source zip contains `package.json` / `pnpm-workspace.yaml` / `pnpm-lock.yaml` / `apps/extension/**`.
- `pnpm -F @ajh/extension lint` + `typecheck` clean (the new `.mjs` is covered by ESLint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to build and package extension archives ready for Chrome and Firefox store submissions
  * Automatic Firefox source archive generation for build reproducibility verification

* **Documentation**
  * Updated build and development documentation with details on new packaging commands and generated archive outputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->