### PR TITLE
feat: import selected job from board list views + reset/pairing fixes

### DIFF
--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -191,10 +191,18 @@ async function refreshStatusWithTimeout(): Promise<void> {
  */
 async function refreshUntilSettled(attempts = 5, gapMs = 600): Promise<void> {
   for (let i = 0; i < attempts; i += 1) {
-    const res = await send({ kind: 'getStatus' });
-    const status = resolveStatusResponse(res, lastKnownHasToken);
-    render(status);
-    if (status.phase !== 'searching') return;
+    try {
+      const res = await send({ kind: 'getStatus' });
+      const status = resolveStatusResponse(res, lastKnownHasToken);
+      render(status);
+      if (status.phase !== 'searching') return;
+    } catch {
+      // A transient MV3 message-channel rejection here must NOT bubble into the
+      // savePairing catch (a false "Pairing failed" after a successful pair). The
+      // live status push / next popup open recovers; show offline and stop.
+      renderOffline();
+      return;
+    }
     if (i < attempts - 1) await delay(gapMs);
   }
 }

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -182,6 +182,23 @@ async function refreshStatusWithTimeout(): Promise<void> {
   }
 }
 
+/**
+ * Poll `getStatus` until the phase leaves `searching` (the bridge connection has
+ * settled to connected / not_paired / app_not_running) or the attempts run out.
+ * Renders each result. A safety net so the popup never strands on the "searching"
+ * spinner when the background's live status push is missed (MV3 race / just-woken
+ * worker). The live `onMessage` push still updates the view independently.
+ */
+async function refreshUntilSettled(attempts = 5, gapMs = 600): Promise<void> {
+  for (let i = 0; i < attempts; i += 1) {
+    const res = await send({ kind: 'getStatus' });
+    const status = resolveStatusResponse(res, lastKnownHasToken);
+    render(status);
+    if (status.phase !== 'searching') return;
+    if (i < attempts - 1) await delay(gapMs);
+  }
+}
+
 async function doImport(mode: ImportMode): Promise<void> {
   els.btnUrl.disabled = true;
   els.btnScan.disabled = true;
@@ -217,7 +234,7 @@ async function savePairing(): Promise<void> {
     els.btnSaveToken.textContent = '✓ Authorized';
     setMsg(els.pairMsg, 'Paired.', 'ok');
     await delay(AUTHORIZED_CONFIRM_MS);
-    await refreshStatus();
+    await refreshUntilSettled();
     if (!els.views.import.hidden) {
       // Connected view is now shown; move focus off the (hidden) token input.
       els.btnUrl.focus();

--- a/apps/tauri/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/tauri/src-tauri/src/extension_bridge/mod.rs
@@ -540,25 +540,36 @@ async fn handle_import(app: &AppHandle, payload: Value) -> AppResult<ImportOk> {
         return Err(AppError::Validation("url is required".to_string()));
     }
 
-    // URL / SSRF safety: normalize (http(s) only — empty means rejected) then
-    // guard the host against loopback/private/link-local/`*.local`.
-    let normalized = normalize_job_url(&url);
+    // Centralized SPA/list-view normalization: if the user imported from a board's
+    // search/SPA view (selected job id in a query param), rewrite to the canonical
+    // single-job URL so BOTH import modes resolve the SELECTED job, not the list
+    // shell. `None` → already a direct page / unknown host (use the URL as-is).
+    let canonical = crate::scraping::scrape_url::canonical_job_url(&url);
+    let effective_url = canonical.as_deref().unwrap_or(url.as_str());
+
+    // URL / SSRF safety on whatever we will actually fetch + store (the canonical
+    // link when rewritten, else the original). Normalize (http(s) only) then guard
+    // the host against loopback/private/link-local/`*.local`.
+    let normalized = normalize_job_url(effective_url);
     if normalized.is_empty() {
         return Err(AppError::Validation(
             "url is not a valid http(s) URL".to_string(),
         ));
     }
-    if !auth::is_safe_import_url(&url) {
+    if !auth::is_safe_import_url(effective_url) {
         return Err(AppError::Validation(
             "url host is not allowed (private/loopback)".to_string(),
         ));
     }
 
-    // Parse the posting. Scan mode reuses the fetch-free parser on the supplied
-    // (authenticated) DOM; URL mode runs the full resolver.
-    let posting = match html {
-        Some(html) => crate::scraping::scrape_url::parse_from_html(&url, &html),
-        None => crate::scraping::scrape_url::resolve(&url).await?,
+    // Parse the posting. A canonicalized (list/SPA) import re-resolves the
+    // canonical link for BOTH modes — the captured list DOM can't be trusted to be
+    // the selected job. A direct page keeps existing behavior: Scan mode reuses the
+    // supplied authenticated DOM; URL mode runs the resolver.
+    let posting = match (&canonical, html) {
+        (Some(c), _) => crate::scraping::scrape_url::resolve(c).await?,
+        (None, Some(html)) => crate::scraping::scrape_url::parse_from_html(&url, &html),
+        (None, None) => crate::scraping::scrape_url::resolve(&url).await?,
     };
     let posting = match posting {
         Some(p) => p,

--- a/apps/tauri/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/scrape_url/mod.rs
@@ -36,6 +36,53 @@ pub async fn resolve(url: &str) -> Result<Option<JobPosting>> {
     generic_html(url).await
 }
 
+/// Map a board's search / SPA "list + detail pane" view URL (where the SELECTED
+/// job's id lives in a query param) to the canonical single-job URL. Returns
+/// `None` when the URL is already a direct job page or the host is unrecognized —
+/// the caller then uses the URL as-is. This is the single, centralized place that
+/// knows "which job is selected in this SPA view"; every board plugs in via one
+/// match arm. Ids are validated before being interpolated into a URL we will
+/// later fetch (defense-in-depth alongside the import path's SSRF guard).
+pub fn canonical_job_url(url: &str) -> Option<String> {
+    let u = reqwest::Url::parse(url).ok()?;
+    let host = u.host_str()?.to_ascii_lowercase();
+    let query = |key: &str| {
+        u.query_pairs()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.into_owned())
+    };
+
+    // LinkedIn: /jobs/search|collections/...?currentJobId=<id> → /jobs/view/<id>.
+    // Numeric id only. Skip when already a direct /jobs/view/ page.
+    if host == "linkedin.com" || host == "www.linkedin.com" || host.ends_with(".linkedin.com") {
+        if !u.path().contains("/jobs/view/") {
+            if let Some(id) = query("currentJobId") {
+                if !id.is_empty() && id.bytes().all(|b| b.is_ascii_digit()) {
+                    return Some(format!("https://www.linkedin.com/jobs/view/{id}"));
+                }
+            }
+        }
+        return None;
+    }
+
+    // Indeed (incl. country TLDs like de.indeed.com): ?vjk=<id> → /viewjob?jk=<id>.
+    // Alphanumeric id only. Skip when already a /viewjob page.
+    if host == "indeed.com" || host.ends_with(".indeed.com") {
+        if !u.path().contains("/viewjob") {
+            if let Some(id) = query("vjk") {
+                if !id.is_empty() && id.bytes().all(|b| b.is_ascii_alphanumeric()) {
+                    return Some(format!("https://{host}/viewjob?jk={id}"));
+                }
+            }
+        }
+        return None;
+    }
+
+    // TODO(import): Glassdoor (jobListingId/jl), Xing, StepStone — need a real
+    // captured URL to pin the param + canonical template. Tracked as a follow-up.
+    None
+}
+
 /// LinkedIn (and similar pages) render "Show more" / "Show less" toggle buttons
 /// right after the description markup; strip those trailing labels.
 static SHOW_MORE_RE: std::sync::LazyLock<regex::Regex> =

--- a/apps/tauri/src-tauri/src/scraping/scrape_url/test.rs
+++ b/apps/tauri/src-tauri/src/scraping/scrape_url/test.rs
@@ -469,3 +469,79 @@ async fn try_personio_rejects_bare_personio_substring_host() {
         .expect("suffix evasion returns Ok(None) at the gate, no network")
         .is_none());
 }
+
+// ── canonical_job_url: SPA/list-view → canonical single-job URL ───────────────
+
+#[test]
+fn canonical_linkedin_search_with_current_job_id() {
+    assert_eq!(
+        super::canonical_job_url("https://www.linkedin.com/jobs/search/?currentJobId=4185657072"),
+        Some("https://www.linkedin.com/jobs/view/4185657072".to_string())
+    );
+}
+
+#[test]
+fn canonical_linkedin_collections_with_current_job_id() {
+    assert_eq!(
+        super::canonical_job_url(
+            "https://www.linkedin.com/jobs/collections/recommended/?currentJobId=123"
+        ),
+        Some("https://www.linkedin.com/jobs/view/123".to_string())
+    );
+}
+
+#[test]
+fn canonical_linkedin_direct_view_page_is_none() {
+    assert_eq!(
+        super::canonical_job_url("https://www.linkedin.com/jobs/view/123/"),
+        None
+    );
+}
+
+#[test]
+fn canonical_linkedin_non_numeric_id_is_none() {
+    assert_eq!(
+        super::canonical_job_url("https://www.linkedin.com/jobs/search/?currentJobId=abc123"),
+        None
+    );
+}
+
+#[test]
+fn canonical_linkedin_no_current_job_id_is_none() {
+    assert_eq!(
+        super::canonical_job_url("https://www.linkedin.com/jobs/search/?keywords=rust"),
+        None
+    );
+}
+
+#[test]
+fn canonical_indeed_search_with_vjk() {
+    assert_eq!(
+        super::canonical_job_url("https://www.indeed.com/jobs?q=x&vjk=9b6647ed6c731326"),
+        Some("https://www.indeed.com/viewjob?jk=9b6647ed6c731326".to_string())
+    );
+}
+
+#[test]
+fn canonical_indeed_country_tld_host_preserved() {
+    assert_eq!(
+        super::canonical_job_url("https://de.indeed.com/jobs?q=x&vjk=abc123"),
+        Some("https://de.indeed.com/viewjob?jk=abc123".to_string())
+    );
+}
+
+#[test]
+fn canonical_indeed_direct_viewjob_is_none() {
+    assert_eq!(
+        super::canonical_job_url("https://www.indeed.com/viewjob?jk=9b6647ed6c731326"),
+        None
+    );
+}
+
+#[test]
+fn canonical_unknown_host_is_none() {
+    assert_eq!(
+        super::canonical_job_url("https://example.com/jobs?vjk=123&currentJobId=456"),
+        None
+    );
+}

--- a/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
+++ b/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
@@ -52,6 +52,7 @@ const migratePreferences = (state: Record<string, unknown>, version: number): Pr
 
 // Default preferences
 const defaultPreferences: Preferences = {
+  userName: '',
   version: 1,
   language: 'en',
   outputTone: 'professional',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the connection status indicator could remain stuck showing “searching” if the expected live status update was missed.

* **New Features**
  * Job imports from LinkedIn and Indeed search views are now automatically converted to canonical single-job URLs for consistency.
  * Added a new username preference field (defaulting to an empty string).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->