### PR TITLE
docs: responsive layout conventions + ModalShell slot API

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -418,13 +418,46 @@ notify.destroy(); // dismiss all
 | `key`          | `string`                                                            | auto-generated | Stable ID; opening with same key updates that item |
 | `onClose`      | `() => void`                                                        | undefined      | Callback when dismissed                            |
 
-#### `Modal` / `ModalShell`
+#### `ModalShell`
+
+The canonical dialog container — overlay + glass panel + focus trap + Escape key. All other modals (`ConfirmModal`, etc.) compose from `ModalShell` rather than rebuilding.
 
 ```typescript
-<ModalShell open={open} onClose={() => setOpen(false)} title="Export Document">
-  {/* modal body */}
+<ModalShell
+  open={open}
+  onClose={() => setOpen(false)}
+  header={<h2>Export Document</h2>}
+  footer={<Button onClick={handleExport}>Export</Button>}
+>
+  {/* scrollable body content */}
 </ModalShell>
 ```
+
+**Props:**
+
+| Prop             | Type         | Default      | Notes                                                                                                                                          |
+| ---------------- | ------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `open`           | boolean      | required     | Controls visibility and animation                                                                                                              |
+| `onClose`        | `() => void` | required     | Called on Escape or backdrop click                                                                                                             |
+| `children`       | ReactNode    | required     | Body content — scrolled when tall, pinned header/footer stay visible                                                                           |
+| `header`         | ReactNode    | `undefined`  | Optional pinned header region (title, close button) — does not scroll; use `ariaLabelledby` to wire a title to the dialog's accessibility name |
+| `footer`         | ReactNode    | `undefined`  | Optional pinned footer region (action buttons) — does not scroll; keeps CTAs visible on short windows                                          |
+| `maxWidth`       | string       | `'max-w-md'` | Tailwind class capping dialog width (e.g. `max-w-lg`)                                                                                          |
+| `className`      | string       | `undefined`  | Extra classes on the panel element                                                                                                             |
+| `zIndex`         | number       | `600`        | z-layer (CSS `--z-modal`)                                                                                                                      |
+| `borderClass`    | string       | `undefined`  | Border color (e.g. `border-red-500/30`); defaults to white hairline                                                                            |
+| `ariaLabelledby` | string       | `undefined`  | `id` of the element labelling the dialog (e.g. title); wired to `aria-labelledby`                                                              |
+| `ariaLabel`      | string       | `undefined`  | Accessible name when no visible title element exists to reference                                                                              |
+
+**Anatomy:** The panel wraps a pinned `header` (shrink-0) → scrollable `body` (overflow-y-auto, @container, min-h-0 flex-1) → pinned `footer` (shrink-0). This ensures tall/multi-section modals stay usable on a 600px window and keeps buttons pinned while content scrolls.
+
+**Guidance:**
+
+- Multi-section modals and forms taller than viewport → **use slots**: put title/close in `header`, action buttons in `footer` so they stay pinned.
+- Simple single-body modals (confirm dialogs, quick forms) → **may pass everything as `children`** — the panel's height cap and scroll still protects them.
+- Set `ariaLabel` or `ariaLabelledby` so assistive tech announces the dialog. Icon-only close buttons must have an `aria-label`.
+
+Source: `packages/ui/src/components/ModalShell/ModalShell.tsx`.
 
 #### `ConfirmModal`
 

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -435,21 +435,21 @@ The canonical dialog container — overlay + glass panel + focus trap + Escape k
 
 **Props:**
 
-| Prop             | Type         | Default      | Notes                                                                                                                                          |
-| ---------------- | ------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `open`           | boolean      | required     | Controls visibility and animation                                                                                                              |
-| `onClose`        | `() => void` | required     | Called on Escape or backdrop click                                                                                                             |
-| `children`       | ReactNode    | required     | Body content — scrolled when tall, pinned header/footer stay visible                                                                           |
-| `header`         | ReactNode    | `undefined`  | Optional pinned header region (title, close button) — does not scroll; use `ariaLabelledby` to wire a title to the dialog's accessibility name |
-| `footer`         | ReactNode    | `undefined`  | Optional pinned footer region (action buttons) — does not scroll; keeps CTAs visible on short windows                                          |
-| `maxWidth`       | string       | `'max-w-md'` | Tailwind class capping dialog width (e.g. `max-w-lg`)                                                                                          |
-| `className`      | string       | `undefined`  | Extra classes on the panel element                                                                                                             |
-| `zIndex`         | number       | `600`        | z-layer (CSS `--z-modal`)                                                                                                                      |
-| `borderClass`    | string       | `undefined`  | Border color (e.g. `border-red-500/30`); defaults to white hairline                                                                            |
-| `ariaLabelledby` | string       | `undefined`  | `id` of the element labelling the dialog (e.g. title); wired to `aria-labelledby`                                                              |
-| `ariaLabel`      | string       | `undefined`  | Accessible name when no visible title element exists to reference                                                                              |
+| Prop             | Type         | Default                     | Notes                                                                                                                                          |
+| ---------------- | ------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `open`           | boolean      | required                    | Controls visibility and animation                                                                                                              |
+| `onClose`        | `() => void` | required                    | Called on Escape or backdrop click                                                                                                             |
+| `children`       | ReactNode    | required                    | Body content — scrolled when tall, pinned header/footer stay visible                                                                           |
+| `header`         | ReactNode    | `undefined`                 | Optional pinned header region (title, close button) — does not scroll; use `ariaLabelledby` to wire a title to the dialog's accessibility name |
+| `footer`         | ReactNode    | `undefined`                 | Optional pinned footer region (action buttons) — does not scroll; keeps CTAs visible on short windows                                          |
+| `maxWidth`       | string       | optional; component default | Tailwind class capping dialog width (e.g. `max-w-lg`) — see `ModalShell.tsx`                                                                   |
+| `className`      | string       | `undefined`                 | Extra classes on the panel element                                                                                                             |
+| `zIndex`         | number       | optional; component default | z-layer — see `ModalShell.tsx`                                                                                                                 |
+| `borderClass`    | string       | optional; component default | Border color (e.g. `border-red-500/30`) — see `ModalShell.tsx`                                                                                 |
+| `ariaLabelledby` | string       | `undefined`                 | `id` of the element labelling the dialog (e.g. title); wired to `aria-labelledby`                                                              |
+| `ariaLabel`      | string       | `undefined`                 | Accessible name when no visible title element exists to reference                                                                              |
 
-**Anatomy:** The panel wraps a pinned `header` (shrink-0) → scrollable `body` (overflow-y-auto, @container, min-h-0 flex-1) → pinned `footer` (shrink-0). This ensures tall/multi-section modals stay usable on a 600px window and keeps buttons pinned while content scrolls.
+**Anatomy:** The panel follows a three-zone pattern: a pinned header (title, close button), a scrollable body (content — scrolls when tall), and a pinned footer (action buttons). The overall panel height is capped so tall modals stay usable on short windows, and the header/footer remain visible while the body scrolls. See `packages/ui/src/components/ModalShell/ModalShell.tsx` for the implementation.
 
 **Guidance:**
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -652,19 +652,7 @@ The panel itself caps height: `max-h-[calc(100vh-2rem)] flex flex-col`. This ens
 
 ### Scroll-to-Top on Navigation
 
-Clicking a sidebar nav item smooth-scrolls the active page's scroll region to the top:
-
-```typescript
-// apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
-function scrollPageToTop() {
-  document
-    .querySelector('main.app-main')
-    ?.querySelectorAll('.overflow-y-auto')
-    .forEach((el) => el.scrollTo({ top: 0, behavior: 'smooth' }));
-}
-```
-
-This queries by the scroll class (not a ref registry) — one nav action doesn't need a registry. Same-route clicks (no page remount) now reset scroll position. Settings pages scroll from the section click handler, not an effect, so clicking an already-active section still scrolls.
+Clicking a sidebar nav item smooth-scrolls the active page's scroll region to the top. The settings page does the same on section click, so re-clicking an already-active section also scrolls. See `apps/tauri/src/renderer/components/layout/Sidebar/index.tsx` and `apps/tauri/src/renderer/features/settings/components/SettingsPage/index.tsx` for the implementation.
 
 ---
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -565,6 +565,109 @@ See ADR-022 for the full rationale.
 
 ---
 
+## 15. Responsive Layout Conventions (Window Resize)
+
+The app is a resizable desktop window with a hard floor of **900px × 600px** and no mobile breakpoints. The Tailwind breakpoints `sm` (640px) and `md` (768px) are always active, so **only `lg` (1024px), `xl` (1280px), and `2xl` (1536px)** plus **container queries** actually toggle layout on resize.
+
+### Window Envelope
+
+Set in `apps/tauri/src-tauri/tauri.conf.json`:
+
+```json
+{
+  "app": {
+    "windows": [
+      {
+        "width": 1280,
+        "height": 800,
+        "minWidth": 900,
+        "minHeight": 600,
+        "resizable": true
+      }
+    ]
+  }
+}
+```
+
+Default 1280×800, user-resizable from 900×600 floor to maximized. Sub-900px / phone layouts are out of scope.
+
+### Container Queries vs. Viewport Breakpoints
+
+**Two complementary tools:**
+
+1. **Container queries** (`@container`) — used by **width-varying panels** (e.g. two-pane layouts, narrow sidebar + wide content, modal bodies). Mark the panel `@container` and use `@sm:` / `@lg:` / `@4xl:` (Tailwind v4 built-in sizes: `@3xs…@7xl`, driven by the container's computed width) to respond to the panel's own width, not the viewport.
+
+2. **Viewport breakpoints** (`sm:` / `lg:` / `xl:` / `2xl:`) — used by **top-level, viewport-spanning grids** (e.g. monitoring dashboard page, full-width metric tiles). These have no `@container` ancestor, so container-query variants silently no-op; must use viewport breakpoints.
+
+**Key gotcha:** A container-query `@`-variant without a `@container` ancestor silently never fires. Always check:
+
+- Is this panel width-varying? → `@container` + `@`-variants.
+- Is this viewport-spanning? → ordinary viewport `md:`/`lg:` breakpoints.
+
+### Two-Panel Responsive Pattern
+
+Two-column pages (ai-generate, analyze, jobs detail) shrink side-by-side rather than stacking:
+
+```tsx
+// Parent: flex row on medium+, col on small
+<div className="flex h-full flex-col md:flex-row">
+  {/* Fixed-width panel: shrinks with viewport */}
+  <LeftPanel className="w-full md:w-[320px] lg:w-[380px] xl:w-[420px]" />
+
+  {/* Fluid content: gets min-w-0 so flex doesn't overflow it */}
+  <div className="min-w-0 flex-1 overflow-y-auto">{/* wide content takes available space */}</div>
+</div>
+```
+
+The `min-w-0` on the flex child is **critical**: it overrides flex's default `min-width: auto` (which prevents shrinking below content width), letting the sibling compress without crushing the content.
+
+### Container-Query Grid Example
+
+Multi-section modal or panel content:
+
+```tsx
+<ModalShell open={open} onClose={onClose} header={<h2>Title</h2>}>
+  {/* Modal body: marked @container, children respond to its width */}
+  <div className="@container space-y-4">
+    <section className="@sm:flex @sm:gap-4">
+      {/* Single column under 28rem; two columns @ ≥28rem */}
+      <div className="flex-1">Column 1</div>
+      <div className="flex-1">Column 2</div>
+    </section>
+  </div>
+</ModalShell>
+```
+
+On a 600px window with a 400px wide modal, the `@sm:` breakpoint (28rem ≈ 448px) doesn't fire, so the layout stays single-column. On a 900px window with the same modal, it fires and layout becomes two-column. This is **container-aware**, not viewport-aware.
+
+### ModalShell Scroll Behavior
+
+The `ModalShell` component (see DESIGN_SYSTEM.md) wraps header/body/footer with:
+
+- **Header** (pinned, `shrink-0`) — title, close button
+- **Body** (`overflow-y-auto`, `@container`, `min-h-0 flex-1`) — scrollable content
+- **Footer** (pinned, `shrink-0`) — action buttons
+
+The panel itself caps height: `max-h-[calc(100vh-2rem)] flex flex-col`. This ensures modals stay usable on a 600px window; tall forms scroll with buttons pinned.
+
+### Scroll-to-Top on Navigation
+
+Clicking a sidebar nav item smooth-scrolls the active page's scroll region to the top:
+
+```typescript
+// apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
+function scrollPageToTop() {
+  document
+    .querySelector('main.app-main')
+    ?.querySelectorAll('.overflow-y-auto')
+    .forEach((el) => el.scrollTo({ top: 0, behavior: 'smooth' }));
+}
+```
+
+This queries by the scroll class (not a ref registry) — one nav action doesn't need a registry. Same-route clicks (no page remount) now reset scroll position. Settings pages scroll from the section click handler, not an effect, so clicking an already-active section still scrolls.
+
+---
+
 ## Anti-Patterns to Avoid
 
 | Anti-Pattern                                      | Correct Approach                                                                                                                             |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the ModalShell design documentation into a full canonical dialog container guide, including composition model, props reference, anatomy (pinned header/body/footer with capped scroll height), and usage examples.
  * Added a responsive layout conventions section covering desktop window sizing constraints, when to use container queries vs viewport breakpoints, responsive two-panel examples, and expected sidebar navigation scroll-to-top behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->