### PR TITLE
fix(extension): remove "looking for the desktop app" searching placeholder

### DIFF
--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -104,12 +104,8 @@
            re-checks the connection, and "?" explains. No body content needed. -->
       <section id="view-offline" class="view" hidden></section>
 
-      <!-- Searching placeholder. -->
-      <section id="view-searching" class="view">
-        <div class="empty">
-          <p class="empty__body">Looking for the desktop app…</p>
-        </div>
-      </section>
+      <!-- Searching state: the "○ Connecting…" pill conveys it; no body needed. -->
+      <section id="view-searching" class="view"></section>
     </main>
 
     <script type="module" src="./popup/popup.ts"></script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the popup's searching view by removing unnecessary placeholder text during desktop app connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->