### PR TITLE
fix: firefox-on-windows extension connectivity (native-host launch detection)

### DIFF
--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -66,6 +66,12 @@
 
       <!-- Import view: shown when paired + connected. -->
       <section id="view-import" class="view" hidden>
+        <!-- Persistent "authorized" cue: this section only renders when phase ===
+             'connected', which requires a stored pairing token — so the button is
+             correctly visible only when authorized (no JS toggle needed). It is
+             always disabled (a pure status indicator, not actionable). The "✓"
+             glyph carries the meaning beyond color (deuteranopia-safe). -->
+        <button id="authorized-indicator" class="btn btn--authorized" type="button" disabled aria-label="Already authorized">✓ Authorized</button>
         <p class="hint">Import the job on this page into your desktop app.</p>
         <div class="actions">
           <button id="btn-url" class="btn btn--primary" type="button">Import via URL</button>
@@ -101,8 +107,12 @@
       </section>
 
       <!-- App-not-running state: the pill reads "✕ App not running", the header Retry
-           re-checks the connection, and "?" explains. No body content needed. -->
-      <section id="view-offline" class="view" hidden></section>
+           re-checks the connection, and "?" explains. Offers the download page for
+           users who don't have the desktop app yet. -->
+      <section id="view-offline" class="view" hidden>
+        <p class="hint">Don’t have the desktop app yet?</p>
+        <button id="btn-get-app" class="btn btn--primary" type="button">Get the app</button>
+      </section>
 
       <!-- Searching state: the "○ Connecting…" pill conveys it; no body needed. -->
       <section id="view-searching" class="view"></section>

--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -71,7 +71,15 @@
              correctly visible only when authorized (no JS toggle needed). It is
              always disabled (a pure status indicator, not actionable). The "✓"
              glyph carries the meaning beyond color (deuteranopia-safe). -->
-        <button id="authorized-indicator" class="btn btn--authorized" type="button" disabled aria-label="Already authorized">✓ Authorized</button>
+        <button
+          id="authorized-indicator"
+          class="btn btn--authorized"
+          type="button"
+          disabled
+          aria-label="Already authorized"
+        >
+          ✓ Authorized
+        </button>
         <p class="hint">Import the job on this page into your desktop app.</p>
         <div class="actions">
           <button id="btn-url" class="btn btn--primary" type="button">Import via URL</button>

--- a/apps/extension/src/popup/popup.css
+++ b/apps/extension/src/popup/popup.css
@@ -296,6 +296,20 @@ body {
   background: var(--primary-hover);
 }
 
+/* Persistent "✓ Authorized" status button in the import view. Always disabled
+ * (not actionable), so it overrides the default .btn:disabled dimming to read
+ * as a positive "connected" state — same success tone as .pill--connected.
+ * .btn.btn--authorized:disabled beats both .btn:disabled and .btn--authorized
+ * on specificity, so the dimming/not-allowed cursor never wins. */
+.btn--authorized,
+.btn.btn--authorized:disabled {
+  opacity: 1;
+  cursor: default;
+  color: var(--pill-connected-fg);
+  background: var(--pill-connected-bg);
+  border-color: var(--pill-connected-border);
+}
+
 .check {
   display: flex;
   align-items: center;

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -25,6 +25,7 @@ vi.mock('@wxt-dev/browser', () => ({
       sendMessage: vi.fn(),
       onMessage: { addListener: vi.fn() },
     },
+    tabs: { create: vi.fn() },
   },
 }));
 
@@ -236,6 +237,23 @@ describe('savePairing (#btn-save-token)', () => {
     expect(btn.disabled).toBe(false);
     expect(btn.textContent).toBe('Save & pair');
     expect(byId<HTMLParagraphElement>('pair-msg').textContent).toMatch(/failed/i);
+  });
+});
+
+describe('get the app (#btn-get-app)', () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+  const tabsCreateMock = vi.mocked(browser.tabs.create);
+
+  beforeEach(() => {
+    tabsCreateMock.mockReset();
+  });
+
+  it('opens the public download page in a new tab when clicked', async () => {
+    byId<HTMLButtonElement>('btn-get-app').click();
+    await flush();
+
+    expect(tabsCreateMock).toHaveBeenCalledTimes(1);
+    expect(tabsCreateMock).toHaveBeenCalledWith({ url: 'https://aijobhunter.app/download' });
   });
 });
 

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -54,6 +54,7 @@ function buildPopupDom(): void {
     <button id="btn-open-settings"></button>
     <button id="btn-help"></button>
     <p id="help-popover" hidden></p>
+    <button id="btn-get-app"></button>
   `;
 }
 

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -80,6 +80,7 @@ const els = {
   btnOpenSettings: byId<HTMLButtonElement>('btn-open-settings'),
   btnHelp: byId<HTMLButtonElement>('btn-help'),
   helpPopover: byId<HTMLParagraphElement>('help-popover'),
+  btnGetApp: byId<HTMLButtonElement>('btn-get-app'),
 };
 
 /** Actionable label for the pairing button; restored after a failed/cleared pair. */
@@ -109,6 +110,10 @@ const STATUS_TIMEOUT_MS = 3_000;
  *  with the pairing token highlighted. The click is the required user gesture;
  *  the browser may show its own "Open AI Job Hunter?" confirmation (expected). */
 const PAIRING_DEEP_LINK = 'ajh://settings/extension';
+
+/** Public download page, offered in the offline view for users who don't yet
+ *  have the desktop app installed. */
+const GET_APP_URL = 'https://aijobhunter.app/download';
 
 /**
  * Last-known token state, cached so a transient `!ok` status reply (asleep or
@@ -296,6 +301,16 @@ async function openAppPairing(): Promise<void> {
   }
 }
 
+/** Open the public download page in a new tab so a user without the desktop
+ *  app can install it. Best-effort; failures are swallowed. */
+async function getApp(): Promise<void> {
+  try {
+    await browser.tabs.create({ url: GET_APP_URL });
+  } catch {
+    // No-op: best-effort.
+  }
+}
+
 function wire(): void {
   els.btnUrl.addEventListener('click', () => void doImport('url'));
   els.btnScan.addEventListener('click', () => void doImport('scan'));
@@ -306,6 +321,7 @@ function wire(): void {
   els.btnUnpair.addEventListener('click', () => void unpair());
   els.btnRetry.addEventListener('click', () => void retry());
   els.btnOpenSettings.addEventListener('click', () => void openAppPairing());
+  els.btnGetApp.addEventListener('click', () => void getApp());
   els.btnHelp.addEventListener('click', toggleHelp);
 
   // Live status pushes from the background while the popup is open.

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -319,14 +319,24 @@ fn open_external(app: &AppHandle, url: &str) {
 ///
 /// Our deep links use the `ajh://` scheme, so there is no collision with these.
 pub fn run_native_host_if_invoked() -> bool {
-    let is_native_host = std::env::args().skip(1).any(|arg| {
-        arg.starts_with("chrome-extension://")
-            || arg.ends_with(extension_bridge::NATIVE_HOST_MANIFEST)
-    });
+    let is_native_host = is_native_host_launch(std::env::args().skip(1));
     if is_native_host {
         extension_bridge::native_host::run();
     }
     is_native_host
+}
+
+/// True if these argv-tail args look like a browser native-messaging launch:
+/// Chrome passes the extension origin (`chrome-extension://…`); Firefox passes the
+/// full path to our host manifest, whose filename contains `NATIVE_HOST_NAME` on
+/// every OS (mac/linux: `…bridge.json`; Windows: `…bridge.firefox.json` / `.chrome.json`).
+/// Extracted from `run_native_host_if_invoked` so the per-OS filename matching is
+/// unit-testable (argv is process-global and can't be set in a test).
+fn is_native_host_launch<I: IntoIterator<Item = String>>(args: I) -> bool {
+    args.into_iter().any(|arg| {
+        arg.starts_with("chrome-extension://")
+            || (arg.ends_with(".json") && arg.contains(extension_bridge::NATIVE_HOST_NAME))
+    })
 }
 
 /// Build and run the Tauri application. Called by the binary shim in `main.rs`.
@@ -785,4 +795,63 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_native_host_launch;
+
+    /// Build the argv tail a browser would pass (owned `String`s, as
+    /// `std::env::args` yields).
+    fn args(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn windows_firefox_manifest_path_is_native_host() {
+        // The regression: the `.firefox` infix broke the old `ends_with` match.
+        assert!(is_native_host_launch(args(&[
+            r"C:\Users\me\AppData\...\app.aijobhunter.bridge.firefox.json",
+            "job-importer@aijobhunter.app",
+        ])));
+    }
+
+    #[test]
+    fn windows_chrome_manifest_path_is_native_host() {
+        assert!(is_native_host_launch(args(&[
+            r"C:\Users\me\...\app.aijobhunter.bridge.chrome.json",
+        ])));
+    }
+
+    #[test]
+    fn unix_manifest_path_is_native_host() {
+        assert!(is_native_host_launch(args(&[
+            "/home/me/.mozilla/native-messaging-hosts/app.aijobhunter.bridge.json",
+        ])));
+    }
+
+    #[test]
+    fn chrome_extension_origin_is_native_host() {
+        assert!(is_native_host_launch(args(&[
+            "chrome-extension://oaoekkgkhmgdfnpmfkpphgiikliaicll/",
+        ])));
+    }
+
+    #[test]
+    fn deep_link_launch_is_not_native_host() {
+        assert!(!is_native_host_launch(args(&["ajh://settings/extension"])));
+    }
+
+    #[test]
+    fn empty_launch_is_not_native_host() {
+        assert!(!is_native_host_launch(args(&[])));
+    }
+
+    #[test]
+    fn unrelated_json_arg_is_not_native_host() {
+        // A `.json` arg that does NOT contain the host name must not match.
+        assert!(!is_native_host_launch(args(&[
+            "/tmp/some-other-config.json"
+        ])));
+    }
 }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -328,14 +328,25 @@ pub fn run_native_host_if_invoked() -> bool {
 
 /// True if these argv-tail args look like a browser native-messaging launch:
 /// Chrome passes the extension origin (`chrome-extension://…`); Firefox passes the
-/// full path to our host manifest, whose filename contains `NATIVE_HOST_NAME` on
+/// full path to our host manifest, whose filename starts with `NATIVE_HOST_NAME` on
 /// every OS (mac/linux: `…bridge.json`; Windows: `…bridge.firefox.json` / `.chrome.json`).
+/// The host name is matched on the manifest FILENAME (basename) only — not anywhere
+/// in the path — so a directory that merely contains the host name can't false-positive.
 /// Extracted from `run_native_host_if_invoked` so the per-OS filename matching is
 /// unit-testable (argv is process-global and can't be set in a test).
 fn is_native_host_launch<I: IntoIterator<Item = String>>(args: I) -> bool {
     args.into_iter().any(|arg| {
-        arg.starts_with("chrome-extension://")
-            || (arg.ends_with(".json") && arg.contains(extension_bridge::NATIVE_HOST_NAME))
+        if arg.starts_with("chrome-extension://") {
+            return true;
+        }
+        // Match the host manifest by FILENAME (basename), not anywhere in the
+        // path, so a directory that merely contains the host name can't trigger
+        // a false native-host launch. Every browser/OS manifest filename starts
+        // with NATIVE_HOST_NAME and ends with `.json` (…bridge.json /
+        // …bridge.firefox.json / …bridge.chrome.json). Split on both separators
+        // so a Windows backslash path is handled too.
+        let basename = arg.rsplit(['/', '\\']).next().unwrap_or(arg.as_str());
+        basename.starts_with(extension_bridge::NATIVE_HOST_NAME) && basename.ends_with(".json")
     })
 }
 
@@ -852,6 +863,15 @@ mod tests {
         // A `.json` arg that does NOT contain the host name must not match.
         assert!(!is_native_host_launch(args(&[
             "/tmp/some-other-config.json"
+        ])));
+    }
+
+    #[test]
+    fn host_name_in_directory_is_not_native_host() {
+        // The host name in a DIRECTORY component (not the filename) must NOT match —
+        // only the manifest basename counts.
+        assert!(!is_native_host_launch(args(&[
+            "/opt/app.aijobhunter.bridge/other.json"
         ])));
     }
 }

--- a/landing/creature.html
+++ b/landing/creature.html
@@ -207,7 +207,7 @@ body::after{content:'';position:fixed;inset:0;z-index:0;pointer-events:none;opac
   <div class="tmono">rejections survived: 1,247 · dignity: rebooting · you: press send</div>
   <div class="erow">
     <button id="replay2" class="hbtn">↺ watch it again</button>
-    <a class="back" href="index.html">← back to the notebook</a>
+    <a class="back" href="/">← back to the notebook</a>
   </div>
 </div>
 

--- a/landing/download.html
+++ b/landing/download.html
@@ -6,11 +6,11 @@
 <title>AI Job Hunter — Download</title>
 <meta name="description" content="Download the AI Job Hunter desktop app for macOS, Windows, and Linux. A local-first, AI-native job-hunting assistant. Free, open source, unsigned, and unemployed.">
 <meta name="robots" content="index,follow">
-<link rel="canonical" href="https://aijobhunter.app/download.html">
+<link rel="canonical" href="https://aijobhunter.app/download">
 <meta name="theme-color" content="#f4ecdc">
 <meta property="og:title" content="AI Job Hunter — Download">
 <meta property="og:description" content="Get the desktop app for macOS, Windows, and Linux. Plus the browser extension. Local-first. No accounts. Still unemployed.">
-<meta property="og:url" content="https://aijobhunter.app/download.html">
+<meta property="og:url" content="https://aijobhunter.app/download">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="AI Job Hunter — Download">
@@ -117,7 +117,7 @@ footer{margin-top:60px; text-align:center}
 <body>
 <main class="wrap">
 
-  <a class="top-back" href="index.html">← back to the chaos</a>
+  <a class="top-back" href="/">← back to the chaos</a>
 
   <h1>Take the app</h1>
 
@@ -196,7 +196,7 @@ footer{margin-top:60px; text-align:center}
   <footer>
     <p class="byline">made by Saeed, between rejections.</p>
     <p class="foot-links">
-      <a href="index.html">home</a> · <a href="privacy.html">privacy</a> · <a href="creature.html">▶ the short film</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener">Firefox extension</a>
+      <a href="/">home</a> · <a href="/privacy">privacy</a> · <a href="/creature">▶ the short film</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener">Firefox extension</a>
     </p>
   </footer>
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -521,8 +521,8 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
     <h1 class="reveal">Job hunting broke me.<br>So I built a <span class="ul">robot<svg class="draw" viewBox="0 0 120 14" aria-hidden="true"><path pathLength="1" d="M4 8 Q34 3 62 6 T116 6"/><path pathLength="1" d="M14 12 Q52 8 104 10"/></svg></span> to do it.</h1>
     <p class="sub reveal">AI Job Hunter scrapes 19 job boards, writes your cover letters, and drafts your applications while you dissociate — you just press send. Runs fully offline. <b>Built by a guy who is, himself, still unemployed.</b></p>
     <div class="scrollhint reveal">scroll to watch a man fall apart<span class="arr">↓</span></div>
-    <a class="filmhint reveal" href="creature.html">▶ or don't scroll — watch THE CREATURE. he summons a tiny recruiter. it grows. (2:40)</a>
-    <a class="filmhint reveal" href="download.html">already sold? → just take the app</a>
+    <a class="filmhint reveal" href="/creature">▶ or don't scroll — watch THE CREATURE. he summons a tiny recruiter. it grows. (2:40)</a>
+    <a class="filmhint reveal" href="/download">already sold? → just take the app</a>
   </div>
 </section>
 
@@ -793,14 +793,14 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
     </svg>
   </div>
   <p class="honest">yes, this app is real. yes, it actually scrapes LinkedIn, Indeed, StepStone, Xing, and 15 others. yes, it's built with Tauri + Rust + React 19 + a vector database + a pure-Rust Typst engine that renders every PDF — because I had a lot of free time, on account of the unemployment. no, it does not auto-apply — it finds the jobs and writes the whole application; hitting submit is the one job left to you. no, I still don't have a job. the autopilot is doing its best.</p>
-  <a class="cta" id="cta" href="download.html">ok fine, take the app →</a>
+  <a class="cta" id="cta" href="/download">ok fine, take the app →</a>
   <a class="src-link" href="https://github.com/saeedkolivand/ai-job-hunter-app">view the source — it's PolyForm Noncommercial: read it, fork it, learn from it. just don't sell my misery back to me.</a>
-  <a class="src-link" href="creature.html">▶ THE CREATURE — a hand-drawn doodle about the tiny recruiter you accidentally summon. it grows. (2:40)</a>
+  <a class="src-link" href="/creature">▶ THE CREATURE — a hand-drawn doodle about the tiny recruiter you accidentally summon. it grows. (2:40)</a>
   <p class="footnote">macOS will say the app is "damaged." it's not damaged. it's just unsigned — like a contract I was never offered. run <code>xattr -cr</code> and we move on.</p>
   <p class="builtwith">Tauri · Rust · React 19 · TanStack · LanceDB · Typst · Ollama · pure spite</p>
   <p class="byline">made by Saeed, between rejections.</p>
   <svg class="inkline draw" style="width:24px; margin-top:10px" viewBox="0 0 30 28" aria-hidden="true"><path pathLength="1" d="M15 24 C5 16 2 9 8 5 q5 -3 7 4 q2 -7 7 -4 c6 4 3 11 -7 19 Z" style="stroke-width:2.4"/></svg>
-  <p class="footnote"><a href="privacy.html" style="color:#6f6650">Privacy</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener" style="color:#6f6650">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener" style="color:#6f6650">Firefox extension</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener" style="color:#6f6650">GitHub</a></p>
+  <p class="footnote"><a href="/privacy" style="color:#6f6650">Privacy</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener" style="color:#6f6650">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener" style="color:#6f6650">Firefox extension</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener" style="color:#6f6650">GitHub</a></p>
 </section>
 
 </main>

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -6,11 +6,11 @@
 <title>AI Job Hunter — Privacy Policy</title>
 <meta name="description" content="How the AI Job Hunter desktop app and browser extension handle your data. No accounts, no analytics, no telemetry. Local-first.">
 <meta name="robots" content="index,follow">
-<link rel="canonical" href="https://aijobhunter.app/privacy.html">
+<link rel="canonical" href="https://aijobhunter.app/privacy">
 <meta name="theme-color" content="#f4ecdc">
 <meta property="og:title" content="AI Job Hunter — Privacy Policy">
 <meta property="og:description" content="How the AI Job Hunter desktop app and browser extension handle your data. No accounts, no analytics, no telemetry. Local-first.">
-<meta property="og:url" content="https://aijobhunter.app/privacy.html">
+<meta property="og:url" content="https://aijobhunter.app/privacy">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="AI Job Hunter — Privacy Policy">
@@ -86,7 +86,7 @@ footer{margin-top:60px; text-align:center}
 <body>
 <main class="wrap">
 
-  <a class="top-back" href="index.html">← back to the chaos</a>
+  <a class="top-back" href="/">← back to the chaos</a>
 
   <h1>Privacy Policy</h1>
   <p class="updated">Last updated: 13 June 2026</p>
@@ -248,7 +248,7 @@ footer{margin-top:60px; text-align:center}
   <footer>
     <p class="byline">made by Saeed, between rejections.</p>
     <p class="foot-links">
-      <a href="index.html">home</a> · <a href="creature.html">▶ the short film</a> · privacy
+      <a href="/">home</a> · <a href="/creature">▶ the short film</a> · privacy
     </p>
   </footer>
 


### PR DESCRIPTION
## Problem

With the browser extension installed in **Firefox on Windows**, the desktop app was opened/focused repeatedly and the extension **never reached "Connected"** (the popup's Network tab showed `ws://127.0.0.1:47615..47620` probes all failing). macOS and Chrome were unaffected.

## Root cause

`main()` decides "run the silent stdio relay vs boot the GUI" by sniffing argv in `run_native_host_if_invoked`. Firefox launches a native-messaging host as `[exe, <full path to host manifest>, <add-on id>]`. The host-manifest filename differs per OS (`extension_bridge/register.rs`):

- macOS/Linux → `app.aijobhunter.bridge.json` → matched the old `ends_with("…bridge.json")` ✅
- **Windows → `app.aijobhunter.bridge.firefox.json`** → the `.firefox` infix broke `ends_with` ❌

So on Windows + Firefox the spawned exe wasn't recognized as a native host → it booted the **full GUI** (the repeated app-opening) instead of the relay → native messaging never connected → it fell back to Firefox's loopback `ws://`, which Firefox handles unreliably (the documented reason native messaging is the *primary* Firefox transport). Chrome worked because its argv arg is `chrome-extension://…`; macOS worked because its manifest filename matched.

## Changes

- **fix (core):** `run_native_host_if_invoked` now matches the host-manifest path by the `NATIVE_HOST_NAME` substring on **every** OS (covers `…bridge.firefox.json` / `.chrome.json` on Windows), keeping the Chrome `chrome-extension://` prefix match. Extracted a pure `is_native_host_launch` predicate + unit tests for the per-OS argv shapes (the regression case included). Once detection is fixed, Windows Firefox uses the silent relay like macOS already does, so the unreliable ws fallback is no longer hit.
- **feat (popup UX):** when already paired, the popup shows a disabled **"✓ Authorized"** button at the top of the import view (the token already persists across restarts — this is just a clear confirmation). Unpairing returns to the enabled "Save & pair" screen as before.
- **feat (popup UX):** the previously-empty **"App not running"** view now offers a **"Get the app"** button → `https://aijobhunter.app/download` (new tab), for users without the desktop app. Shown only in that state.

## Not changed

- Firefox's loopback `ws://` fallback failing is expected and untouched — native messaging is the intended Firefox transport, and this PR makes Windows Firefox use it.
- Token persistence is already correct (`browser.storage.local`) — confirmed working; no change.

## Verification

- `cargo test -p ajh-tauri native_host` — green (10/10, incl. the 7 new detector tests).
- `cargo clippy -p ajh-tauri --lib` / `cargo fmt --check` — clean.
- `pnpm -F @ajh/extension typecheck | test | lint | build` — all green (48/48 tests; popup emits to dist/chrome + dist/firefox).
- Manual (to do on a Windows machine): run the fixed app once (re-registers the host), open Firefox + extension → app no longer opens repeatedly, popup reaches Connected via the relay, no GUI flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR — landing-site clean URLs (`chore`)

Per follow-up request, internal `landing/` links now use clean URLs:
- nav links are root-relative and extensionless: `index.html`→`/`, `download.html`→`/download`, `privacy.html`→`/privacy`, `creature.html`→`/creature`.
- absolute `canonical`/`og:url` on download & privacy drop `.html` (e.g. `https://aijobhunter.app/download`), matching the extension's new "Get the app" link.
- External links (GitHub, release binaries, Chrome/Firefox stores, mailto) and the root canonical are untouched.

**Deploy note:** these clean nav URLs assume the host serves extensionless paths (`/download` → `download.html`, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extension popup now displays a persistent "✓ Authorized" indicator in the connected view to confirm active authorization status.
  * Added user-friendly guidance and a "Get the app" button in the offline view to help users download and install the desktop app.

* **Improvements**
  * Enhanced detection of native app launches for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->