### PR TITLE
test: cover the get-app error-swallow path in the extension popup

### DIFF
--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -255,6 +255,18 @@ describe('get the app (#btn-get-app)', () => {
     expect(tabsCreateMock).toHaveBeenCalledTimes(1);
     expect(tabsCreateMock).toHaveBeenCalledWith({ url: 'https://aijobhunter.app/download' });
   });
+
+  it('swallows a tabs.create rejection without propagating an unhandled error', async () => {
+    tabsCreateMock.mockRejectedValueOnce(new Error('tabs unavailable'));
+
+    byId<HTMLButtonElement>('btn-get-app').click();
+    await flush();
+
+    // getApp() wraps tabs.create in try/catch; the rejection is swallowed
+    // inside getApp, so reaching this point without an unhandled rejection is
+    // the assertion. The call still fired exactly once.
+    expect(tabsCreateMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('header Retry visibility', () => {


### PR DESCRIPTION
Small follow-up to #412.

CodeRabbit asked for a test covering the error path of the popup's "Get the app" action — `getApp()` wraps `browser.tabs.create` in try/catch and swallows failures. This adds that test: a rejected `tabs.create` must not propagate an unhandled error and must still fire exactly once.

It was meant to ship in #412 but its original commit was rejected by commitlint (capitalized subject) and the failure was missed, so it never landed. Landing it now.

- Extension suite: 50/50 passing.
- Test-only; no release impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for error handling scenarios in app initialization, ensuring proper management of rejection cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->