### PR TITLE
build: add cross-platform extension zip packaging script

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -8,6 +8,7 @@
     "build": "pnpm build:chrome && pnpm build:firefox",
     "build:chrome": "cross-env BROWSER=chrome vite build",
     "build:firefox": "cross-env BROWSER=firefox vite build",
+    "package": "pnpm build && node scripts/package.mjs",
     "dev": "cross-env BROWSER=chrome vite build --watch --mode development",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/extension/scripts/package.mjs
+++ b/apps/extension/scripts/package.mjs
@@ -1,0 +1,69 @@
+// Store-ready zip packager for the AI Job Hunter browser extension.
+//
+// Zips the built dist/chrome and dist/firefox folders into upload-ready archives
+// with manifest.json at the ZIP ROOT (Chrome Web Store / AMO require this — no
+// nested <target>/ folder) using forward-slash separators.
+//
+// Zero-dependency, cross-platform: prefers the `zip` binary (CI/macOS/Linux),
+// and falls back to PowerShell `Compress-Archive` on Windows when `zip` is
+// missing (preferring pwsh 7, which writes forward-slash separators).
+//
+// Run: pnpm -F @ajh/extension package   (builds first, then zips)
+//      node apps/extension/scripts/package.mjs   (zips an existing build)
+
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { existsSync, rmSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EXT_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(EXT_ROOT, '..', '..');
+const DIST = path.join(EXT_ROOT, 'dist');
+
+const { version } = createRequire(import.meta.url)('../package.json');
+const TARGETS = ['chrome', 'firefox'];
+
+// `zip` present? (CI/macOS/Linux). Detect via a cheap version probe.
+const HAS_ZIP = spawnSync('zip', ['-v'], { stdio: 'ignore' }).status === 0;
+const rel = (p) => path.relative(REPO_ROOT, p).split(path.sep).join('/');
+
+function zipTarget(target) {
+  const srcDir = path.join(DIST, target);
+  if (!existsSync(path.join(srcDir, 'manifest.json'))) {
+    console.error(
+      `error: ${rel(srcDir)}/manifest.json not found — build first: pnpm -F @ajh/extension build`
+    );
+    process.exit(1);
+  }
+  const out = path.join(DIST, `ai-job-hunter-extension-${target}-${version}.zip`);
+  rmSync(out, { force: true }); // avoid `zip` appending stale entries
+
+  let res;
+  if (HAS_ZIP) {
+    // Run from inside the source dir so entries are root-relative (`.`).
+    res = spawnSync('zip', ['-qr', out, '.'], { cwd: srcDir, stdio: 'inherit' });
+  } else if (process.platform === 'win32') {
+    // `<src>/*` makes entries root-relative; -Force overwrites. pwsh 7 writes
+    // forward slashes; powershell 5.1 is the fallback.
+    const cmd = `Compress-Archive -Path '${srcDir}/*' -DestinationPath '${out}' -Force`;
+    const shell =
+      spawnSync('pwsh', ['-v'], { stdio: 'ignore' }).status === 0 ? 'pwsh' : 'powershell';
+    res = spawnSync(shell, ['-NoProfile', '-NonInteractive', '-Command', cmd], {
+      stdio: 'inherit',
+    });
+  } else {
+    console.error('error: `zip` binary is required to package on this platform');
+    process.exit(1);
+  }
+
+  if (res.status !== 0) {
+    console.error(`error: packaging ${target} failed (exit ${res.status})`);
+    process.exit(res.status ?? 1);
+  }
+  const bytes = statSync(out).size;
+  console.log(`packaged ${rel(out)}  ${bytes} bytes (${(bytes / 1024).toFixed(1)} kB)`);
+}
+
+for (const target of TARGETS) zipTarget(target);

--- a/apps/extension/scripts/package.mjs
+++ b/apps/extension/scripts/package.mjs
@@ -45,9 +45,12 @@ function zipTarget(target) {
     // Run from inside the source dir so entries are root-relative (`.`).
     res = spawnSync('zip', ['-qr', out, '.'], { cwd: srcDir, stdio: 'inherit' });
   } else if (process.platform === 'win32') {
-    // `<src>/*` makes entries root-relative; -Force overwrites. pwsh 7 writes
-    // forward slashes; powershell 5.1 is the fallback.
-    const cmd = `Compress-Archive -Path '${srcDir}/*' -DestinationPath '${out}' -Force`;
+    // PowerShell escapes a literal single quote inside a single-quoted string by
+    // doubling it; escape both paths so a directory containing a quote can't
+    // break the command. `<src>/*` makes entries root-relative; -Force overwrites.
+    // pwsh 7 writes forward slashes; powershell 5.1 is the fallback.
+    const psQuote = (p) => p.replace(/'/g, "''");
+    const cmd = `Compress-Archive -Path '${psQuote(srcDir)}/*' -DestinationPath '${psQuote(out)}' -Force`;
     const shell =
       spawnSync('pwsh', ['-v'], { stdio: 'ignore' }).status === 0 ? 'pwsh' : 'powershell';
     res = spawnSync(shell, ['-NoProfile', '-NonInteractive', '-Command', cmd], {


### PR DESCRIPTION
Adds a reusable `pnpm -F @ajh/extension package` command to produce **store-ready** extension zips locally (and anywhere), filling the gap where `zip` isn't installed (e.g. Git Bash on Windows).

## What it does
- `apps/extension/scripts/package.mjs` zips `dist/chrome` and `dist/firefox` into `ai-job-hunter-extension-{chrome,firefox}-<version>.zip` (output to gitignored `dist/`).
- **Store-ready layout:** `manifest.json` at the zip **root** (no nested `chrome/`/`firefox/` folder), forward-slash separators — the format Chrome Web Store / Firefox AMO expect for upload.
- **Zero-dependency, cross-platform:** uses the `zip` binary when present (CI/macOS/Linux); falls back to PowerShell `Compress-Archive` on Windows when `zip` is missing (prefers `pwsh` 7 for forward slashes). No new npm dependency (avoids the supply-chain release-age gate).
- `"package": "pnpm build && node scripts/package.mjs"` builds first, then zips.

## Verified
Ran `pnpm -F @ajh/extension package` on Windows (no `zip` → PowerShell fallback exercised): both zips produced, `manifest.json` confirmed at the zip root with forward-slash subpaths (`icons/…`, `chunks/…`). Prettier + ESLint clean.

Note: this differs from the release workflow's GitHub-release artifact, which zips the *folder* (`chrome/…`, load-unpacked layout). This script targets store upload. A follow-up could converge the release workflow onto this script if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the release process by automating extension packaging for both Chrome and Firefox distribution. The implementation generates version-managed release archives with built-in validation to verify all required components are included, reducing manual packaging steps and improving consistency across browser platform releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->