### PR TITLE
fix: keep popup views hidden, scroll small viewports, drop autopilot auto-apply copy

### DIFF
--- a/apps/extension/src/popup/popup.css
+++ b/apps/extension/src/popup/popup.css
@@ -56,6 +56,14 @@
   box-sizing: border-box;
 }
 
+/* The [hidden] attribute toggles views/controls. Author `display` rules (.view,
+ * .retry) outrank the UA `[hidden]{display:none}` by origin, so restore it
+ * explicitly — otherwise every view renders at once (e.g. "✓ Authorized" leaks
+ * into the not-paired state). */
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   width: 360px;

--- a/apps/tauri/src/renderer/routes/__root.tsx
+++ b/apps/tauri/src/renderer/routes/__root.tsx
@@ -178,19 +178,25 @@ function RootLayout() {
       <NotificationToastBridge />
       <ProtocolVersionGate>
         <CapabilityProvider>
-          <div className="app-content relative flex h-screen flex-col overflow-hidden pt-3">
-            <CinematicBackground />
-            <Titlebar />
-            <div className="flex flex-1 overflow-hidden">
-              <Sidebar />
-              <main className="app-main glass-surface m-3 flex-1 overflow-hidden rounded-2xl">
-                <Outlet />
-              </main>
+          {/* Outer scroll container: below the 900×600 window floor (a small
+              window, or custom OS display scaling that inflates CSS px) the whole
+              app scrolls instead of clipping. At/above the floor the shell is
+              exactly 100vh, so no scrollbar appears and the layout is unchanged. */}
+          <div className="h-screen overflow-y-auto">
+            <div className="app-content relative flex min-h-[max(100vh,600px)] flex-col overflow-hidden pt-3">
+              <CinematicBackground />
+              <Titlebar />
+              <div className="flex flex-1 overflow-hidden">
+                <Sidebar />
+                <main className="app-main glass-surface m-3 flex-1 overflow-hidden rounded-2xl">
+                  <Outlet />
+                </main>
+              </div>
+              <StatusBar />
+              <OnboardingWizard />
+              <UpdateBanner />
+              <ShortcutsOverlay />
             </div>
-            <StatusBar />
-            <OnboardingWizard />
-            <UpdateBanner />
-            <ShortcutsOverlay />
           </div>
         </CapabilityProvider>
       </ProtocolVersionGate>

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1259,10 +1259,10 @@
     "loading": "Laden…",
     "empty": {
       "title": "Noch keine Autopilots",
-      "description": "Richten Sie einen Autopilot ein, um automatisch Jobs zu suchen, anhand Ihres Lebenslaufs zu bewerten und sich zu bewerben.",
+      "description": "Richten Sie einen Autopilot ein, um automatisch Jobs zu suchen und anhand Ihres Lebenslaufs zu bewerten – die Bewerbung erledigen Sie selbst.",
       "step1": "Wählen Sie ein Board, ein Stichwort und einen Standort",
       "step2": "Legen Sie eine Mindestübereinstimmung fest, um schwache Ergebnisse zu filtern",
-      "step3": "Wählen Sie Speichern, Überprüfen oder Auto-Bewerbung",
+      "step3": "Wählen Sie Speichern oder Überprüfen jedes Treffers",
       "step4": "Planen Sie stündlich, täglich oder manuelle Ausführungen",
       "createFirst": "Erstellen Sie Ihren ersten Autopilot"
     },

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1262,7 +1262,7 @@
       "description": "Richten Sie einen Autopilot ein, um automatisch Jobs zu suchen und anhand Ihres Lebenslaufs zu bewerten – die Bewerbung erledigen Sie selbst.",
       "step1": "Wählen Sie ein Board, ein Stichwort und einen Standort",
       "step2": "Legen Sie eine Mindestübereinstimmung fest, um schwache Ergebnisse zu filtern",
-      "step3": "Wählen Sie Speichern oder Überprüfen jedes Treffers",
+      "step3": "Speichern oder überprüfen Sie jeden Treffer",
       "step4": "Planen Sie stündlich, täglich oder manuelle Ausführungen",
       "createFirst": "Erstellen Sie Ihren ersten Autopilot"
     },

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1285,7 +1285,7 @@
     "loading": "Loading…",
     "empty": {
       "title": "No autopilots yet",
-      "description": "Set up an autopilot to automatically search jobs and score them against your resume — you apply with the tailoring assistant.",
+      "description": "Set up an autopilot to automatically find and score matching jobs — you review and apply to each one yourself.",
       "step1": "Pick a board, keyword, and location",
       "step2": "Set a minimum match score to filter weak results",
       "step3": "Choose to save or review each match",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1285,10 +1285,10 @@
     "loading": "Loading…",
     "empty": {
       "title": "No autopilots yet",
-      "description": "Set up an autopilot to automatically search jobs, score them against your resume, and apply.",
+      "description": "Set up an autopilot to automatically search jobs and score them against your resume — you apply with the tailoring assistant.",
       "step1": "Pick a board, keyword, and location",
       "step2": "Set a minimum match score to filter weak results",
-      "step3": "Choose to save, review, or auto-apply",
+      "step3": "Choose to save or review each match",
       "step4": "Schedule it to run hourly, daily, or manually",
       "createFirst": "Create your first Autopilot"
     },


### PR DESCRIPTION
## What

Three UI bug fixes (extension popup + desktop renderer).

### 1. Extension popup rendered every view at once
The popup hides inactive sections with the `hidden` attribute, which only works because of the UA stylesheet's `[hidden] { display: none }`. But author rules `.view { display: flex }` / `.retry { display: inline-flex }` outrank the UA rule by **cascade origin**, so nothing was hidden — the import, pair, and offline views stacked, and the green "✓ Authorized" box (paired/connected view) leaked into the **not-paired** state. A user who fresh-installed and never paired saw "Authorized."

**Fix:** re-assert `[hidden] { display: none !important; }` after the reset in `popup.css`.

### 2. Content didn't scroll on small windows / OS display scaling
The app shell was `h-screen overflow-hidden` with no outer scroll, so when the effective viewport dropped below the 900×600 window floor (small window, or custom OS display scaling inflating CSS px), content was clipped with no way to reach it.

**Fix:** wrap the shell in a viewport-height `overflow-y-auto` container and floor it at `min-h-[max(100vh,600px)]`. At/above the floor the shell is exactly 100vh → no scrollbar, layout unchanged; below it the whole app scrolls. The `position: fixed` background is unaffected; modals already scroll via `ModalShell`.

### 3. Autopilot copy promised "auto-apply"
The autopilot empty state said it would "auto-apply" / "…and apply", contradicting the locked find-and-notify design ("Autopilot never applies for you"). Reworded the description and `step3` in **en + de** to say you apply yourself.

## Files
- `apps/extension/src/popup/popup.css`
- `apps/tauri/src/renderer/routes/__root.tsx`
- `packages/translations/src/locales/{en,de}/translation.json`

## Verify
- **Popup:** load the unpacked extension on a fresh profile (unpaired) → only the "Paste the pairing token / Save & pair" view shows; no "✓ Authorized".
- **Scroll:** set Windows display scaling to 150% (or resize the window short) → the desktop app scrolls instead of clipping; at normal size there's no extra scrollbar.
- **Copy:** open Autopilot with no autopilots → empty state no longer mentions auto-apply (en + de).

Note: the popup fix ships to users only with the next **extension** store release; the desktop fixes ship via the normal app release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display behavior for elements using the `hidden` attribute to ensure they don’t render unintentionally.

* **UI/UX Improvements**
  * Improved scroll handling in the main layout so content scrolls naturally below a fixed “floor,” while larger screens keep the intended fixed-height behavior.
  * Updated Autopilot onboarding text (English and German) to better explain that you review and choose “Save” or “Review” for each match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->