### PR TITLE
fix: keep the autopilot edit wizard open on backdrop click

### DIFF
--- a/apps/tauri/src/renderer/features/autopilot/components/CreationWizard/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/CreationWizard/index.tsx
@@ -111,6 +111,7 @@ export function CreationWizard({ onDone, onCancel }: CreationWizardProps) {
       onClose={onCancel}
       maxWidth="max-w-xl"
       ariaLabelledby="creation-wizard-title"
+      closeOnBackdrop={!editing}
       header={
         <>
           {/* Wizard header */}

--- a/packages/ui/src/components/ModalShell/ModalShell.test.tsx
+++ b/packages/ui/src/components/ModalShell/ModalShell.test.tsx
@@ -46,6 +46,31 @@ describe('ModalShell', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it('does NOT close on backdrop click when closeOnBackdrop={false}', async () => {
+    const onClose = vi.fn();
+    render(
+      <ModalShell open onClose={onClose} closeOnBackdrop={false}>
+        <p>body</p>
+      </ModalShell>
+    );
+    // Click the overlay container (the dialog's parent) directly
+    const dialog = screen.getByRole('dialog');
+    const overlay = dialog.parentElement ?? dialog;
+    await userEvent.click(overlay);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('still closes on Escape when closeOnBackdrop={false}', async () => {
+    const onClose = vi.fn();
+    render(
+      <ModalShell open onClose={onClose} closeOnBackdrop={false}>
+        <p>body</p>
+      </ModalShell>
+    );
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
   // --- responsive-window-resize contract (header / footer / className) ---
 
   it('renders nothing when open is false', () => {

--- a/packages/ui/src/components/ModalShell/ModalShell.tsx
+++ b/packages/ui/src/components/ModalShell/ModalShell.tsx
@@ -47,6 +47,8 @@ export interface ModalShellProps {
   ariaLabelledby?: string;
   /** Accessible name when there is no visible title element to reference. */
   ariaLabel?: string;
+  /** When false, clicking the backdrop does NOT close the modal (Escape + explicit controls still do). Default true. */
+  closeOnBackdrop?: boolean;
 }
 
 /**
@@ -65,6 +67,7 @@ export function ModalShell({
   borderClass,
   ariaLabelledby,
   ariaLabel,
+  closeOnBackdrop = true,
 }: ModalShellProps) {
   const trapRef = useFocusTrap(open);
 
@@ -93,12 +96,12 @@ export function ModalShell({
         <>
           {/* Visual backdrop — no click handler; the outer container handles dismissal */}
           <GlassOverlay zIndex={zIndex - 1} />
-          {/* Click on the backdrop area (outside the panel) closes the modal.
+          {/* Click on the backdrop area (outside the panel) closes the modal when closeOnBackdrop is true.
               Click on the panel calls stopPropagation so it never reaches here. */}
           <motion.div
             className="fixed inset-0 flex items-center justify-center p-4"
             style={{ zIndex }}
-            onClick={onClose}
+            onClick={closeOnBackdrop ? onClose : undefined}
             {...variants.overlay}
             transition={transition.overlay}
           >


### PR DESCRIPTION
Clicking the backdrop while **editing** an autopilot discarded the in-progress edit. ModalShell gains an additive `closeOnBackdrop` prop (default `true`, so every existing modal is unchanged); the autopilot CreationWizard passes `closeOnBackdrop={!editing}`. The X button, Cancel, and Escape still close. Adds ModalShell tests for the new prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When editing an existing autopilot in the creation wizard, the modal can no longer be dismissed by clicking the backdrop area, preventing accidental dismissal. The Escape key remains available for closing.

* **Tests**
  * Added test coverage for modal backdrop click behavior, including verification that Escape key functionality is preserved when backdrop clicks are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->