### PR TITLE
feat: add a global back button to the titlebar

### DIFF
--- a/apps/tauri/src/renderer/components/layout/Titlebar/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/Titlebar/index.tsx
@@ -1,8 +1,11 @@
-import { Sparkles } from 'lucide-react';
+import { ChevronLeft, Sparkles } from 'lucide-react';
 import { type ComponentType, useEffect, useState } from 'react';
+import { useNavigate, useRouterState } from '@tanstack/react-router';
 
 import { useTranslation } from '@ajh/translations';
+import { Button } from '@ajh/ui';
 
+import { parentRoute } from '@/lib/parent-route';
 import { onWindowControlsRegistered } from '@/lib/window-controls-registry';
 import { useOnboardingCompleted } from '@/store/preferences-store';
 
@@ -14,6 +17,10 @@ export function Titlebar() {
   const [WindowControls, setWindowControls] = useState<ComponentType | null>(null);
   const [isMac, setIsMac] = useState(false);
 
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const navigate = useNavigate();
+  const parent = parentRoute(pathname);
+
   useEffect(() => {
     onWindowControlsRegistered((c) => setWindowControls(() => c));
     setIsMac(navigator.userAgent.includes('Mac'));
@@ -24,15 +31,25 @@ export function Titlebar() {
       className="app-drag relative z-[300] flex h-10 select-none items-center justify-between"
       data-tauri-drag-region
     >
-      {/* Left spacer — mirrors the window-controls width so the right cluster has
-          something to balance against. Mac: 80px traffic lights · Windows/Linux:
-          3 × 44px control buttons = 132px */}
-      {isMac ? <div className="w-20" /> : <div className="w-[132px]" />}
+      {/* Left cluster: fixed-width spacer (mirrors window-controls on the right) with
+          optional back button on detail routes. `app-no-drag` keeps it clickable. */}
+      <div className={`app-no-drag flex items-center ${isMac ? 'w-20' : 'w-[132px]'}`}>
+        {parent !== null && (
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={t('nav.back')}
+            onClick={() => void navigate({ to: parent })}
+            className="ml-1 flex h-7 items-center gap-1 px-2 text-foreground/50 hover:text-foreground/80"
+          >
+            <ChevronLeft size={15} />
+          </Button>
+        )}
+      </div>
 
       {/* Title is an absolutely-centered overlay so it stays centered on the whole
-          bar regardless of how wide the left/right clusters are (the bell widens
-          the right side). `pointer-events-none` lets the drag region pass through
-          — the title isn't interactive, so nothing is lost. */}
+          bar regardless of how wide the left/right clusters are. `pointer-events-none`
+          lets the drag region pass through — the title isn't interactive. */}
       {onboardingCompleted && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
           <div className="flex items-center gap-2 text-xs font-medium text-foreground/70">

--- a/apps/tauri/src/renderer/lib/parent-route.test.ts
+++ b/apps/tauri/src/renderer/lib/parent-route.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { ROUTES } from '@/constants/routes';
+
+import { parentRoute } from './parent-route';
+
+describe('parentRoute', () => {
+  it('maps application detail to ROUTES.APPLICATIONS', () => {
+    expect(parentRoute('/applications/abc')).toBe(ROUTES.APPLICATIONS);
+  });
+
+  it('handles long ids', () => {
+    expect(parentRoute('/applications/some-uuid-1234')).toBe(ROUTES.APPLICATIONS);
+  });
+
+  it('returns null for /applications (top-level)', () => {
+    expect(parentRoute('/applications')).toBeNull();
+  });
+
+  it('returns null for /jobs', () => {
+    expect(parentRoute('/jobs')).toBeNull();
+  });
+
+  it('returns null for root /', () => {
+    expect(parentRoute('/')).toBeNull();
+  });
+
+  it('returns null for /settings', () => {
+    expect(parentRoute('/settings')).toBeNull();
+  });
+});

--- a/apps/tauri/src/renderer/lib/parent-route.ts
+++ b/apps/tauri/src/renderer/lib/parent-route.ts
@@ -1,0 +1,11 @@
+import { ROUTES } from '@/constants/routes';
+
+/**
+ * Maps a resolved pathname to its logical parent route for the global back button.
+ * Returns null on top-level routes (no back button should render).
+ * ponytail: single source of truth — add one line per new detail route.
+ */
+export function parentRoute(pathname: string): string | null {
+  if (/^\/applications\/[^/]+$/.test(pathname)) return ROUTES.APPLICATIONS;
+  return null;
+}

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -19,7 +19,8 @@
     "monitoring": "Monitoring",
     "support": "Hilfe & Support",
     "settings": "Einstellungen",
-    "applications": "Bewerbungen"
+    "applications": "Bewerbungen",
+    "back": "Zurück"
   },
   "build": {
     "title": "Lebenslauf-Builder",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -19,7 +19,8 @@
     "monitoring": "Monitoring",
     "support": "Help & Support",
     "settings": "Settings",
-    "applications": "Applications"
+    "applications": "Applications",
+    "back": "Back"
   },
   "build": {
     "title": "Resume Builder",


### PR DESCRIPTION
A context-aware **"up"** control in the Titlebar (left), shown only on sub/detail routes via a centralized `parentRoute()` resolver (single source of truth, one line per future detail route). The app blocks history back/forward, so it navigates to the mapped parent explicitly.

Today it surfaces on the Application detail route (→ `/applications`) and coexists with that page's richer `from`-aware in-page back; it auto-covers future detail routes. Adds `parentRoute` unit tests + `nav.back` (en/de).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an intelligent back button to the title bar that appears on applicable detail pages and returns users to the corresponding parent section.
* **Tests**
  * Added test coverage for the back-navigation route mapping across supported and non-supported paths.
* **Localization**
  * Updated navigation labels to include a dedicated “Back” text in English and German.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->