### PR TITLE
feat: add a download button to each saved resume in the uploader

### DIFF
--- a/apps/tauri/src/renderer/components/resume/ResumeInputCard/index.tsx
+++ b/apps/tauri/src/renderer/components/resume/ResumeInputCard/index.tsx
@@ -54,6 +54,7 @@ export function ResumeInputCard({ value, onChange, disabled, placeholder }: Prop
     handleSelectSaved,
     handleSetDefaultSaved,
     handleRemove,
+    handleDownload,
     handleFileChange,
     handleSavePaste,
     handleProfileUrlSubmit,
@@ -130,6 +131,7 @@ export function ResumeInputCard({ value, onChange, disabled, placeholder }: Prop
             onSelect={handleSelectSaved}
             onSetDefault={handleSetDefaultSaved}
             onRemove={handleRemove}
+            onDownload={handleDownload}
             menuRef={savedMenuRef}
           />
         </div>

--- a/apps/tauri/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
+++ b/apps/tauri/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
@@ -152,10 +152,10 @@ export function useResumeInput({ value, onChange }: Params) {
     try {
       exportTXT(text, `${doc.title.replace(/\.[^/.]+$/, '')}.txt`);
       notify.success({ message: t('resumeInput.downloaded') });
-    } catch (err) {
-      notify.error({
-        message: err instanceof Error ? err.message : t('resumeInput.downloadFailed'),
-      });
+    } catch {
+      // exportTXT throws English-only messages; show the localized key instead
+      // of leaking raw exception text into a non-English locale's toast.
+      notify.error({ message: t('resumeInput.downloadFailed') });
     }
   };
 

--- a/apps/tauri/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
+++ b/apps/tauri/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
@@ -6,6 +6,7 @@ import { useTranslation } from '@ajh/translations';
 import { useNotification } from '@ajh/ui';
 
 import { useImportWithOcr } from '@/hooks/use-import-with-ocr';
+import { exportTXT } from '@/lib/generate';
 import { useAppClient } from '@/providers/AppClientProvider';
 import {
   keys,
@@ -145,6 +146,19 @@ export function useResumeInput({ value, onChange }: Params) {
     }
   };
 
+  const handleDownload = (doc: DocumentRecord) => {
+    const raw = rawDocs.find((d) => d._id === doc.id);
+    const text = raw?.text?.trim() ?? '';
+    try {
+      exportTXT(text, `${doc.title.replace(/\.[^/.]+$/, '')}.txt`);
+      notify.success({ message: t('resumeInput.downloaded') });
+    } catch (err) {
+      notify.error({
+        message: err instanceof Error ? err.message : t('resumeInput.downloadFailed'),
+      });
+    }
+  };
+
   const handleFileChange = async (file: File) => {
     clearReview();
     if (file.size > MAX_BYTES) {
@@ -253,6 +267,7 @@ export function useResumeInput({ value, onChange }: Params) {
     handleSelectSaved,
     handleSetDefaultSaved,
     handleRemove,
+    handleDownload,
     handleFileChange,
     handleSavePaste,
     handleProfileUrlSubmit,

--- a/apps/tauri/src/renderer/components/resume/SavedResumeMenu/index.tsx
+++ b/apps/tauri/src/renderer/components/resume/SavedResumeMenu/index.tsx
@@ -1,4 +1,4 @@
-import { Check, FileText, Sparkles, Trash2 } from 'lucide-react';
+import { Check, Download, FileText, Sparkles, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -15,6 +15,7 @@ interface Props {
   onSelect: (doc: DocumentRecord) => void;
   onSetDefault: (doc: DocumentRecord) => void;
   onRemove: (doc: DocumentRecord) => void;
+  onDownload: (doc: DocumentRecord) => void;
   menuRef?: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -26,6 +27,7 @@ export function SavedResumeMenu({
   onSelect,
   onSetDefault,
   onRemove,
+  onDownload,
   menuRef,
 }: Props) {
   const { t } = useTranslation();
@@ -94,6 +96,16 @@ export function SavedResumeMenu({
                   <Sparkles size={11} />
                 </Button>
               )}
+
+              <Button
+                variant="ghost"
+                onClick={() => onDownload(doc)}
+                title={t('settings.resume.download')}
+                aria-label={t('settings.resume.download')}
+                className="h-6 w-6 shrink-0 p-0 text-foreground/25 hover:text-blue-400"
+              >
+                <Download size={11} />
+              </Button>
 
               {confirmId === doc.id ? (
                 <Button

--- a/apps/tauri/src/renderer/features/settings/components/preferences/ResumePreferences/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/ResumePreferences/index.tsx
@@ -259,6 +259,7 @@ export function ResumePreferences() {
                     variant="ghost"
                     onClick={() => handleDownload(doc)}
                     title={t('settings.resume.download')}
+                    aria-label={t('settings.resume.download')}
                     className="h-8 w-8 p-0 text-foreground/30 hover:text-blue-400"
                   >
                     <Download size={13} />

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2283,7 +2283,9 @@
     "modePaste": "Text einfügen",
     "dropOrClick": "Lebenslauf hier ablegen oder klicken",
     "extracting": "Text wird extrahiert…",
-    "uploadedClickToReplace": "Klicken zum Ersetzen"
+    "uploadedClickToReplace": "Klicken zum Ersetzen",
+    "downloaded": "Lebenslauf heruntergeladen",
+    "downloadFailed": "Lebenslauf konnte nicht heruntergeladen werden"
   },
   "resume": {
     "profileImport": {

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2323,7 +2323,9 @@
     "modePaste": "Paste text",
     "dropOrClick": "Drop your resume here or click to upload",
     "extracting": "Extracting text…",
-    "uploadedClickToReplace": "Click to replace"
+    "uploadedClickToReplace": "Click to replace",
+    "downloaded": "Resume downloaded",
+    "downloadFailed": "Failed to download resume"
   },
   "resume": {
     "profileImport": {


### PR DESCRIPTION
Each résumé row in the uploader's `SavedResumeMenu` now has a **Download** button (and the existing one in résumé preferences gained a missing aria-label). It reuses the existing `exportTXT` browser-side download of the parsed résumé text — the same mechanism résumé preferences already used — so there's **no new IPC**. Adds aria-labels and download/failed toasts (en/de).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to download saved resumes as `.txt` files from the saved resume menu, including localized success and failure notifications.
* **Accessibility**
  * Improved accessibility by adding `aria-label`/tooltip support for resume download controls.
* **Localization**
  * Added English and German translation strings for the new resume download success and failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->