### PR TITLE
feat: collapsible sidebar with persisted state

### DIFF
--- a/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
@@ -8,6 +8,7 @@ import {
   HelpCircle,
   LayoutDashboard,
   type LucideIcon,
+  PanelLeftClose,
   Settings,
   User,
   Wand2,
@@ -24,7 +25,7 @@ import { ROUTES } from '@/constants/routes';
 import { getTimeGreeting } from '@/lib/greeting';
 import { useContactProfile } from '@/services';
 import { useAppVersion } from '@/services/use-system';
-import { useUserName } from '@/store/preferences-store';
+import { useToggleSidebar, useUserName } from '@/store/preferences-store';
 
 interface NavItem {
   to: string;
@@ -84,6 +85,8 @@ export function Sidebar() {
   const { data: version = 'v0.1.0' } = useAppVersion();
   const appVersion = version.startsWith('v') ? version : `v${version}`;
 
+  const toggleSidebar = useToggleSidebar();
+
   const [versionTooltip, setVersionTooltip] = useState(false);
   const tooltipTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -127,6 +130,16 @@ export function Sidebar() {
 
   return (
     <aside className="app-sidebar glass-surface m-3 mr-0 flex w-60 flex-col rounded-2xl p-3">
+      <div className="flex justify-end pb-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={toggleSidebar}
+          aria-label={t('nav.collapseSidebar')}
+        >
+          <PanelLeftClose size={16} />
+        </Button>
+      </div>
       <nav className="flex flex-col gap-4">
         {NAV_SECTIONS.map((section) => (
           <div key={section.labelKey}>

--- a/apps/tauri/src/renderer/routes/__root.tsx
+++ b/apps/tauri/src/renderer/routes/__root.tsx
@@ -1,3 +1,5 @@
+import { PanelLeft } from 'lucide-react';
+import { motion } from 'motion/react';
 import { useEffect, useRef } from 'react';
 import {
   createRootRoute,
@@ -9,7 +11,7 @@ import {
 
 import type { NotificationToast } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
-import { Button, NotificationProvider, useNotification } from '@ajh/ui';
+import { Button, NotificationProvider, transition, useNotification } from '@ajh/ui';
 
 import { CinematicBackground } from '@/components/background/CinematicBackground';
 import { ProtocolVersionGate } from '@/components/layout/ProtocolVersionGate';
@@ -30,6 +32,7 @@ import {
   useNotificationEvents,
   useSyncCloseToTray,
 } from '@/services';
+import { useSidebarCollapsed, useToggleSidebar } from '@/store/preferences-store';
 
 /** Drives the native-menu navigation/actions. Rendered INSIDE
  *  `NotificationProvider` so its check-for-updates feedback can raise toasts. */
@@ -107,6 +110,9 @@ function NotificationToastBridge() {
 
 function RootLayout() {
   const router = useRouter();
+  const { t } = useTranslation();
+  const isCollapsed = useSidebarCollapsed();
+  const toggleSidebar = useToggleSidebar();
 
   // Route to an autopilot's found-jobs when the tray/deep-link asks (app-global).
   useAutopilotFocusNavigation();
@@ -182,10 +188,31 @@ function RootLayout() {
             <CinematicBackground />
             <Titlebar />
             <div className="flex flex-1 overflow-hidden">
-              <Sidebar />
-              <main className="app-main glass-surface m-3 flex-1 overflow-hidden rounded-2xl">
-                <Outlet />
-              </main>
+              <motion.div
+                animate={{ width: isCollapsed ? 0 : 'auto', opacity: isCollapsed ? 0 : 1 }}
+                transition={transition.normal}
+                className="overflow-hidden"
+                style={{ flexShrink: 0 }}
+              >
+                <Sidebar />
+              </motion.div>
+              <div className="relative flex flex-1 overflow-hidden">
+                {isCollapsed && (
+                  <div className="absolute left-0 top-0 z-10 p-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={toggleSidebar}
+                      aria-label={t('nav.expandSidebar')}
+                    >
+                      <PanelLeft size={16} />
+                    </Button>
+                  </div>
+                )}
+                <main className="app-main glass-surface m-3 flex-1 overflow-hidden rounded-2xl">
+                  <Outlet />
+                </main>
+              </div>
             </div>
             <StatusBar />
             <OnboardingWizard />

--- a/apps/tauri/src/renderer/routes/__root.tsx
+++ b/apps/tauri/src/renderer/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { PanelLeft } from 'lucide-react';
-import { motion } from 'motion/react';
+import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef } from 'react';
 import {
   createRootRoute,
@@ -188,14 +188,23 @@ function RootLayout() {
             <CinematicBackground />
             <Titlebar />
             <div className="flex flex-1 overflow-hidden">
-              <motion.div
-                animate={{ width: isCollapsed ? 0 : 'auto', opacity: isCollapsed ? 0 : 1 }}
-                transition={transition.normal}
-                className="overflow-hidden"
-                style={{ flexShrink: 0 }}
-              >
-                <Sidebar />
-              </motion.div>
+              {/* Unmount (not just shrink) the sidebar when collapsed so its links
+                  leave the tab order and stay out of reach of keyboard/SR users. */}
+              <AnimatePresence initial={false}>
+                {!isCollapsed && (
+                  <motion.div
+                    key="sidebar"
+                    initial={{ width: 0, opacity: 0 }}
+                    animate={{ width: 'auto', opacity: 1 }}
+                    exit={{ width: 0, opacity: 0 }}
+                    transition={transition.normal}
+                    className="overflow-hidden"
+                    style={{ flexShrink: 0 }}
+                  >
+                    <Sidebar />
+                  </motion.div>
+                )}
+              </AnimatePresence>
               <div className="relative flex flex-1 overflow-hidden">
                 {isCollapsed && (
                   <div className="absolute left-0 top-0 z-10 p-2">

--- a/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
+++ b/apps/tauri/src/renderer/store/preferences-schema/preferences-schema.ts
@@ -189,6 +189,9 @@ export const PreferencesSchema = z.object({
   // résumé / cover-letter generation.
   contactPromptSeen: z.boolean().default(false),
 
+  // Sidebar
+  sidebarCollapsed: z.boolean().default(false).optional(),
+
   // Metadata
   lastUpdated: z.string().optional(),
 });

--- a/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
+++ b/apps/tauri/src/renderer/store/preferences-store/preferences-store.ts
@@ -64,6 +64,7 @@ const defaultPreferences: Preferences = {
   recentLocations: [],
   onboardingCompleted: false,
   contactPromptSeen: false,
+  sidebarCollapsed: false,
   lastUpdated: new Date().toISOString(),
 };
 
@@ -95,6 +96,8 @@ interface PreferencesActions {
   /** Re-arm the onboarding wizard so it replays on next launch. */
   resetOnboarding: () => void;
   setContactPromptSeen: () => void;
+  toggleSidebar: () => void;
+  setSidebarCollapsed: (collapsed: boolean) => void;
   resetPreferences: () => void;
 }
 
@@ -281,6 +284,20 @@ export const usePreferencesStore = create<PreferencesStore>()(
           lastUpdated: new Date().toISOString(),
         })),
 
+      toggleSidebar: () =>
+        set((state) => ({
+          ...state,
+          sidebarCollapsed: !state.sidebarCollapsed,
+          lastUpdated: new Date().toISOString(),
+        })),
+
+      setSidebarCollapsed: (sidebarCollapsed: boolean) =>
+        set((state) => ({
+          ...state,
+          sidebarCollapsed,
+          lastUpdated: new Date().toISOString(),
+        })),
+
       resetPreferences: () =>
         set((state) => ({
           ...state,
@@ -325,3 +342,6 @@ export const useSemanticScoring = () =>
   usePreferencesStore((state) => state.semanticScoring ?? false);
 export const useCloseToTray = () => usePreferencesStore((state) => state.closeToTray ?? true);
 export const useRecentLocations = () => usePreferencesStore((state) => state.recentLocations ?? []);
+export const useSidebarCollapsed = () =>
+  usePreferencesStore((state) => state.sidebarCollapsed ?? false);
+export const useToggleSidebar = () => usePreferencesStore((state) => state.toggleSidebar);

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -19,7 +19,9 @@
     "monitoring": "Monitoring",
     "support": "Hilfe & Support",
     "settings": "Einstellungen",
-    "applications": "Bewerbungen"
+    "applications": "Bewerbungen",
+    "collapseSidebar": "Seitenleiste einklappen",
+    "expandSidebar": "Seitenleiste ausklappen"
   },
   "build": {
     "title": "Lebenslauf-Builder",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -19,7 +19,9 @@
     "monitoring": "Monitoring",
     "support": "Help & Support",
     "settings": "Settings",
-    "applications": "Applications"
+    "applications": "Applications",
+    "collapseSidebar": "Collapse sidebar",
+    "expandSidebar": "Expand sidebar"
   },
   "build": {
     "title": "Resume Builder",


### PR DESCRIPTION
Adds a ChatGPT-style collapse/expand for the sidebar:
- A collapse button at the top of the sidebar hides it; the main content reflows to full width.
- A floating expand button at the top-left of the main area brings it back.
- The collapsed flag **persists** in the existing preferences store (localStorage); the width/opacity transition uses the shared motion token.
- The **Titlebar is deliberately untouched** to avoid conflicting with the global-back-button PR (#421).

i18n (en/de) for both control aria-labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible navigation sidebar with a header control to minimize and expand it.
  * Sidebar collapsed state is now persisted and restored across sessions.
  * Smooth animated transitions enhance the expand/collapse experience.
* **Documentation**
  * Updated English and German accessibility labels for the sidebar collapse/expand controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->