### PR TITLE
feat: apply pending extension updates immediately

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -169,8 +169,11 @@ browser.runtime.onUpdateAvailable.addListener(() => {
 // starts sooner. requestUpdateCheck is absent in Firefox, so feature-detect.
 // ponytail: single startup nudge only — the browser already polls periodically.
 if (typeof browser.runtime.requestUpdateCheck === 'function') {
-  void browser.runtime.requestUpdateCheck().catch(() => {
-    // Ignore — non-fatal; update checks may be rate-limited or unavailable.
+  void browser.runtime.requestUpdateCheck().catch((err: unknown) => {
+    // Non-fatal — update checks may be rate-limited or unavailable. Surface a
+    // sanitized warning to the SW console (no telemetry leaves the device) so a
+    // persistent updater regression stays observable instead of fully silent.
+    console.warn('[ajh] update check failed:', err instanceof Error ? err.name : 'unknown');
   });
 }
 

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -157,5 +157,22 @@ browser.runtime.onInstalled.addListener(() => {
 // Kick an initial probe when the worker first loads.
 void getClient().ensureConnected();
 
+// Apply a pending update immediately once the browser has already downloaded it,
+// instead of waiting for the next natural SW restart.
+// ponytail: onUpdateAvailable only fires when an update is already staged — we
+// are not pulling the update, just collapsing the apply delay.
+browser.runtime.onUpdateAvailable.addListener(() => {
+  browser.runtime.reload();
+});
+
+// Chrome-only: nudge the browser to check for an update now so the download
+// starts sooner. requestUpdateCheck is absent in Firefox, so feature-detect.
+// ponytail: single startup nudge only — the browser already polls periodically.
+if (typeof browser.runtime.requestUpdateCheck === 'function') {
+  void browser.runtime.requestUpdateCheck().catch(() => {
+    // Ignore — non-fatal; update checks may be rate-limited or unavailable.
+  });
+}
+
 // Ensure this file is treated as an ES module (Chrome SW `type: module`).
 export {};


### PR DESCRIPTION
Chrome and Firefox already auto-update store-installed extensions natively — we can't pull a version the store hasn't rolled out. This just **applies a staged update sooner**: `onUpdateAvailable → runtime.reload()` applies an already-downloaded update immediately instead of waiting for the next service-worker restart, plus a **Firefox-guarded** Chrome `requestUpdateCheck` nudge on startup. No new manifest permission; the browser still controls rollout. Builds clean for both targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extension updates now apply immediately when available, rather than waiting for the next service worker restart
  * Added an automatic, one-time update check on startup to ensure the latest version is deployed promptly
  * Update check failures are handled gracefully to avoid disruptive errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->