### PR TITLE
perf: reduce aurora background blur on retina displays

### DIFF
--- a/packages/ui/src/css/utilities.css
+++ b/packages/ui/src/css/utilities.css
@@ -512,6 +512,28 @@
   animation: nebula-2 75s ease-in-out infinite;
   animation-delay: -50s;
 }
+/* Retina/high-DPR (esp. macOS WKWebView): a 120px blur on a 60vw layer has a
+   DPR²-scaled backing texture that saturates the compositor and drops frames
+   app-wide. Halve the blur radius where DPR makes it expensive — the radial
+   gradients already feather the edges, so the visual stays soft. 1× displays
+   keep the full blur (free there). */
+@media (min-resolution: 2dppx) {
+  .animate-aurora-1 {
+    filter: blur(60px);
+  }
+  .animate-aurora-2 {
+    filter: blur(72px);
+  }
+  .animate-aurora-3 {
+    filter: blur(60px);
+  }
+  .animate-nebula-1 {
+    filter: blur(48px);
+  }
+  .animate-nebula-2 {
+    filter: blur(48px);
+  }
+}
 .animate-streak-1 {
   animation: streak-1 8s ease-in-out infinite;
   animation-delay: -2s;


### PR DESCRIPTION
**Bug:** on macOS the app animations lag; turning off the aurora ribbons (Settings → Performance → custom) makes it smooth.

**Cause:** the aurora/nebula blobs animate transform-only (already optimized), but each carries a large *static* `filter: blur(120–140px)` on a 40–60vw layer. On **Retina (2–3× DPR)** the blurred composited layer's backing texture scales with DPR² + blur radius, saturating the WKWebView/Metal compositor and dropping frames **app-wide**. Windows/Linux at 1× absorb it fine — which is why only macOS showed it.

**Fix:** halve the aurora/nebula blur radius under `@media (min-resolution: 2dppx)` only. The radial-gradients already feather the edges so it stays soft; 1× displays keep the full blur (free there). CSS-only, no JS, base values untouched.

_Needs a Retina Mac to confirm; if frames still drop the next lever is trimming ribbon count on high-DPR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized animated background effects to render with improved visual clarity on high-resolution displays, ensuring proper appearance across devices with higher pixel densities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->