### PR TITLE
build: sync origin/main into the branch before pushing

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -21,6 +21,35 @@ fi
 GIT_ROOT=$(git rev-parse --show-toplevel)
 cd "$GIT_ROOT" || exit 1
 
+# ── Sync with origin/main before pushing ───────────────────────────────────────
+# Never push a branch built on a stale base — that is what lets a PR look clean
+# locally yet surface merge conflicts on GitHub. Fetch origin/main and, when the
+# branch is behind, fold it in first. A pre-push hook can't add the merge commit
+# to the in-flight push (git already fixed the payload), so on a clean merge we
+# stop and ask for a re-push; on conflicts we abort and let the dev resolve.
+# Skipped on main itself, in detached HEAD, when offline, or with PREPUSH_NO_SYNC=1.
+if [ -z "${PREPUSH_NO_SYNC:-}" ]; then
+  branch=$(git symbolic-ref --short -q HEAD || true)
+  if [ -n "$branch" ] && [ "$branch" != "main" ]; then
+    if git fetch -q origin main 2>/dev/null; then
+      if [ -n "$(git rev-list -n1 FETCH_HEAD --not "$branch" 2>/dev/null)" ]; then
+        echo "↻ origin/main has new commits — merging into $branch before push..."
+        if git merge --no-edit FETCH_HEAD; then
+          echo "✓ Merged latest origin/main into $branch."
+          echo "✗ Re-run your push so the merge commit is included."
+          exit 1
+        else
+          git merge --abort 2>/dev/null || true
+          echo "✗ Could not cleanly merge origin/main — resolve it, commit, then push again."
+          exit 1
+        fi
+      fi
+    else
+      echo "⚠ Could not fetch origin/main (offline?) — pushing without a fresh main sync."
+    fi
+  fi
+fi
+
 # Never use the turbo cache on push: a cached PASS can hide a real failure that
 # only surfaces on a clean run. Force every turbo task to execute.
 export TURBO_FORCE=1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -33,6 +33,13 @@ if [ -z "${PREPUSH_NO_SYNC:-}" ]; then
   if [ -n "$branch" ] && [ "$branch" != "main" ]; then
     if git fetch -q origin main 2>/dev/null; then
       if [ -n "$(git rev-list -n1 FETCH_HEAD --not "$branch" 2>/dev/null)" ]; then
+        # A dirty tree makes `git merge` refuse before it even starts, so handle
+        # it explicitly — otherwise the abort no-ops and the conflict message
+        # below would misleadingly blame a content conflict.
+        if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+          echo "✗ origin/main has new commits but your working tree is dirty — commit or stash, then push again."
+          exit 1
+        fi
         echo "↻ origin/main has new commits — merging into $branch before push..."
         if git merge --no-edit FETCH_HEAD; then
           echo "✓ Merged latest origin/main into $branch."
@@ -40,7 +47,7 @@ if [ -z "${PREPUSH_NO_SYNC:-}" ]; then
           exit 1
         else
           git merge --abort 2>/dev/null || true
-          echo "✗ Could not cleanly merge origin/main — resolve it, commit, then push again."
+          echo "✗ Could not cleanly merge origin/main — resolve the conflicts, commit, then push again."
           exit 1
         fi
       fi


### PR DESCRIPTION
## Summary
The pre-push gate validated each branch in isolation, so a branch built on a stale base passed locally yet surfaced merge conflicts on the PR (as just happened on #424). The hook now fetches `origin/main` and, when the branch is behind, folds it in **before** the gate runs.

A pre-push hook can't add the merge commit to the in-flight push (git already fixed the payload), so:
- **clean auto-merge** → stop with a "re-run your push" prompt so the merge commit is included next time
- **conflicts** → `git merge --abort` and ask the dev to resolve manually

Skipped on `main` itself, in detached HEAD, when offline (fetch fails → warn + continue), or with `PREPUSH_NO_SYNC=1`.

## Verification
- `sh -n .husky/pre-push` passes.
- Ran live on this branch's own push: up-to-date with main → sync block was a clean no-op, gate skipped (no gated paths). Confirms it doesn't disrupt normal pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pre-push validation now automatically syncs with the latest upstream main branch changes before running checks. If synchronization fails (e.g., due to network issues), the process continues with a warning to maintain workflow flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->