### PR TITLE
feat: sponsorship, agent-system redesign, landing perf, i18n parity

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: [saeedkolivand]
+ko_fi: saeedkolivand
+custom: ['https://paypal.me/saeedkolivand']

--- a/README.md
+++ b/README.md
@@ -487,24 +487,35 @@ See <a href="CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBU
 
 ## Documentation
 
-| Document                                                                                                                            | Description                                                          |
-| ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| <a href="apps/tauri/README.md" target="_blank" rel="noopener noreferrer">apps/tauri/README.md</a>                                   | Desktop app architecture, directory map, Rust/React setup            |
-| <a href="apps/extension/README.md" target="_blank" rel="noopener noreferrer">apps/extension/README.md</a>                           | Browser extension (MV3) — job import, local dev pairing, permissions |
-| <a href="docs/ARCHITECTURE.md" target="_blank" rel="noopener noreferrer">docs/ARCHITECTURE.md</a>                                   | System design, data flow, diagrams                                   |
-| <a href="docs/PATTERNS.md" target="_blank" rel="noopener noreferrer">docs/PATTERNS.md</a>                                           | IPC, state machines, AI streaming, search patterns                   |
-| <a href="docs/API.md" target="_blank" rel="noopener noreferrer">docs/API.md</a>                                                     | IPC namespaces + commands                                            |
-| <a href="docs/EXPORT_TEMPLATES.md" target="_blank" rel="noopener noreferrer">docs/EXPORT_TEMPLATES.md</a>                           | Templates, theming, PDF/DOCX export                                  |
-| <a href="docs/DESIGN_SYSTEM.md" target="_blank" rel="noopener noreferrer">docs/DESIGN_SYSTEM.md</a>                                 | Tokens, components, motion, theming                                  |
-| <a href="docs/DEVELOPMENT.md" target="_blank" rel="noopener noreferrer">docs/DEVELOPMENT.md</a>                                     | Local dev environment setup                                          |
-| <a href="docs/DEPLOYMENT.md" target="_blank" rel="noopener noreferrer">docs/DEPLOYMENT.md</a>                                       | Building and releasing installers                                    |
-| <a href="docs/ARCHITECTURE_STATUS.md" target="_blank" rel="noopener noreferrer">docs/ARCHITECTURE_STATUS.md</a>                     | Implementation status tracker                                        |
-| <a href="docs/knowledge/" target="_blank" rel="noopener noreferrer">docs/knowledge/</a>                                             | Knowledge base + architecture decision records (ADRs)                |
-| <a href="SECURITY.md" target="_blank" rel="noopener noreferrer">SECURITY.md</a>                                                     | Security policy &amp; vulnerability reporting                        |
-| <a href="CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a>                                             | Code style, branching, PR process                                    |
-| <a target="_blank" rel="noopener noreferrer" href="https://aijobhunter.app/how-it-works.html">landing/how-it-works.html</a>         | How the AI Job Hunter works end-to-end (interactive walkthrough)     |
-| <a target="_blank" rel="noopener noreferrer" href="https://aijobhunter.app/architecture-map.html">landing/architecture-map.html</a> | Interactive architecture map of the AI Job Hunter                    |
-| <a target="_blank" rel="noopener noreferrer" href="https://aijobhunter.app/creature.html">landing/creature.html</a>                 | THE CREATURE — a hand-drawn doodle about the recruiter you summon    |
+| Document                                                                                                                            | Description                                                                                                        |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| <a href="apps/tauri/README.md" target="_blank" rel="noopener noreferrer">apps/tauri/README.md</a>                                   | Desktop app architecture, directory map, Rust/React setup                                                          |
+| <a href="apps/extension/README.md" target="_blank" rel="noopener noreferrer">apps/extension/README.md</a>                           | Browser extension (MV3) — job import, local dev pairing, permissions                                               |
+| <a href="docs/ARCHITECTURE.md" target="_blank" rel="noopener noreferrer">docs/ARCHITECTURE.md</a>                                   | System design, data flow, diagrams                                                                                 |
+| <a href="docs/PATTERNS.md" target="_blank" rel="noopener noreferrer">docs/PATTERNS.md</a>                                           | IPC, state machines, AI streaming, search patterns                                                                 |
+| <a href="docs/API.md" target="_blank" rel="noopener noreferrer">docs/API.md</a>                                                     | IPC namespaces + commands                                                                                          |
+| <a href="docs/EXPORT_TEMPLATES.md" target="_blank" rel="noopener noreferrer">docs/EXPORT_TEMPLATES.md</a>                           | Templates, theming, PDF/DOCX export                                                                                |
+| <a href="docs/DESIGN_SYSTEM.md" target="_blank" rel="noopener noreferrer">docs/DESIGN_SYSTEM.md</a>                                 | Tokens, components, motion, theming                                                                                |
+| <a href="docs/DEVELOPMENT.md" target="_blank" rel="noopener noreferrer">docs/DEVELOPMENT.md</a>                                     | Local dev environment setup                                                                                        |
+| <a href="docs/DEPLOYMENT.md" target="_blank" rel="noopener noreferrer">docs/DEPLOYMENT.md</a>                                       | Building and releasing installers                                                                                  |
+| <a href="docs/ARCHITECTURE_STATUS.md" target="_blank" rel="noopener noreferrer">docs/ARCHITECTURE_STATUS.md</a>                     | Implementation status tracker                                                                                      |
+| <a href="docs/knowledge/" target="_blank" rel="noopener noreferrer">docs/knowledge/</a>                                             | Knowledge base + architecture decision records (ADRs)                                                              |
+| <a href="SECURITY.md" target="_blank" rel="noopener noreferrer">SECURITY.md</a>                                                     | Security policy &amp; vulnerability reporting                                                                      |
+| <a href="CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a>                                             | Code style, branching, PR process                                                                                  |
+| <a target="_blank" rel="noopener noreferrer" href="https://aijobhunter.app/how-it-works.html">landing/how-it-works.html</a>         | How the AI Job Hunter works end-to-end (interactive walkthrough)                                                   |
+| <a target="_blank" rel="noopener noreferrer" href="https://aijobhunter.app/architecture-map.html">landing/architecture-map.html</a> | Interactive architecture map of the AI Job Hunter                                                                  |
+| <a target="_blank" rel="noopener noreferrer" href="https://aijobhunter.app/agent-system.html">landing/agent-system.html</a>         | Interactive agent-fleet walkthrough — 21 paired author+critic agents, intake→delegation routing, per-task pipeline |
+| <a target="_blank" rel="noopener noreferrer" href="https://aijobhunter.app/creature.html">landing/creature.html</a>                 | THE CREATURE — a hand-drawn doodle about the recruiter you summon                                                  |
+
+---
+
+## 💛 Fund the job hunt
+
+This project is built by a guy who is, himself, still unemployed — a cry for help, made between rejections. If it's saving you time or sanity, consider a voluntary gift:
+
+<a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener noreferrer">GitHub Sponsors</a> · <a href="https://ko-fi.com/saeedkolivand" target="_blank" rel="noopener noreferrer">Ko-fi</a> · <a href="https://paypal.me/saeedkolivand" target="_blank" rel="noopener noreferrer">PayPal</a>
+
+Donations don't conflict with the PolyForm Noncommercial license — the license restricts commercial repackaging and resale by others; voluntary gifts to the maintainer are not commercial use.
 
 ---
 

--- a/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.tsx
@@ -3,6 +3,7 @@ import type { RefObject } from 'react';
 
 import { IconBadge, transition, variants } from '@ajh/ui';
 
+import { AboutTab } from '@/features/settings/components/about/AboutTab';
 import { AccountsSettingsTab } from '@/features/settings/components/accounts/AccountsSettingsTab';
 import { AISettingsTab } from '@/features/settings/components/ai-settings/AISettingsTab';
 import { ContactProfileTab } from '@/features/settings/components/contact/ContactProfileTab';
@@ -85,6 +86,7 @@ export function SettingsContent({
             {activeSection === 'privacy' && <PrivacySettingsTab />}
             {activeSection === 'performance' && <PerformancePreferences />}
             {activeSection === 'developer' && <DeveloperPreferences />}
+            {activeSection === 'about' && <AboutTab />}
           </motion.div>
         </AnimatePresence>
       </div>

--- a/apps/tauri/src/renderer/features/settings/components/about/AboutTab.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/about/AboutTab.tsx
@@ -1,4 +1,4 @@
-import { Github, Heart } from 'lucide-react';
+import { Gift, Heart, Wallet } from 'lucide-react';
 
 import { useTranslation } from '@ajh/translations';
 import { Button, GlassCard, SectionLabel } from '@ajh/ui';
@@ -9,7 +9,7 @@ const DONATE_LINKS = [
   {
     key: 'github' as const,
     href: 'https://github.com/sponsors/saeedkolivand',
-    icon: Github,
+    icon: Gift,
     labelKey: 'settings.about.githubSponsors',
   },
   {
@@ -21,7 +21,7 @@ const DONATE_LINKS = [
   {
     key: 'paypal' as const,
     href: 'https://paypal.me/saeedkolivand',
-    icon: Heart,
+    icon: Wallet,
     labelKey: 'settings.about.paypal',
   },
 ];

--- a/apps/tauri/src/renderer/features/settings/components/about/AboutTab.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/about/AboutTab.tsx
@@ -1,0 +1,67 @@
+import { Github, Heart } from 'lucide-react';
+
+import { useTranslation } from '@ajh/translations';
+import { Button, GlassCard, SectionLabel } from '@ajh/ui';
+
+import { useAppVersion, useOpenExternal } from '@/services';
+
+const DONATE_LINKS = [
+  {
+    key: 'github' as const,
+    href: 'https://github.com/sponsors/saeedkolivand',
+    icon: Github,
+    labelKey: 'settings.about.githubSponsors',
+  },
+  {
+    key: 'kofi' as const,
+    href: 'https://ko-fi.com/saeedkolivand',
+    icon: Heart,
+    labelKey: 'settings.about.kofi',
+  },
+  {
+    key: 'paypal' as const,
+    href: 'https://paypal.me/saeedkolivand',
+    icon: Heart,
+    labelKey: 'settings.about.paypal',
+  },
+];
+
+export function AboutTab() {
+  const { t } = useTranslation();
+  const { data: versionRaw = '' } = useAppVersion();
+  const version = versionRaw
+    ? String(versionRaw).startsWith('v')
+      ? String(versionRaw)
+      : `v${versionRaw}`
+    : '';
+  const openExternal = useOpenExternal();
+
+  return (
+    <GlassCard>
+      <div className="mb-4 flex items-center gap-2">
+        <Heart size={15} className="text-brand-soft" aria-hidden="true" />
+        <SectionLabel>{t('settings.about.title')}</SectionLabel>
+      </div>
+
+      <div className="space-y-4">
+        {version && <p className="font-mono text-xs text-foreground/40">{version}</p>}
+
+        <p className="text-sm text-foreground/60">{t('settings.about.pitch')}</p>
+
+        <div className="space-y-2 pt-1">
+          {DONATE_LINKS.map(({ key, href, icon: Icon, labelKey }) => (
+            <Button
+              key={key}
+              variant="glass"
+              className="w-full justify-start gap-2 text-xs"
+              onClick={() => openExternal.mutate(href)}
+            >
+              <Icon size={13} />
+              {t(labelKey)}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </GlassCard>
+  );
+}

--- a/apps/tauri/src/renderer/features/settings/constants.ts
+++ b/apps/tauri/src/renderer/features/settings/constants.ts
@@ -4,6 +4,7 @@ import {
   Cpu,
   FileText,
   Gauge,
+  Heart,
   Languages,
   Lock,
   Palette,
@@ -21,7 +22,8 @@ export type SectionId =
   | 'accounts'
   | 'privacy'
   | 'performance'
-  | 'developer';
+  | 'developer'
+  | 'about';
 
 export interface NavItem {
   id: SectionId;
@@ -103,6 +105,17 @@ export const NAV_GROUPS: NavGroup[] = [
         label: 'settings.sections.developer.label',
         icon: Terminal,
         description: 'settings.sections.developer.description',
+      },
+    ],
+  },
+  {
+    label: 'settings.groups.about',
+    items: [
+      {
+        id: 'about',
+        label: 'settings.sections.about.label',
+        icon: Heart,
+        description: 'settings.sections.about.description',
       },
     ],
   },

--- a/apps/tauri/src/renderer/hooks/use-menu-navigation.ts
+++ b/apps/tauri/src/renderer/hooks/use-menu-navigation.ts
@@ -24,6 +24,7 @@ const SETTINGS_SECTIONS: readonly SettingsSection[] = [
   'privacy',
   'performance',
   'developer',
+  'about',
 ];
 
 /**

--- a/apps/tauri/src/renderer/store/session-store/session-store.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.ts
@@ -74,7 +74,8 @@ export type SettingsSection =
   | 'accounts'
   | 'privacy'
   | 'performance'
-  | 'developer';
+  | 'developer'
+  | 'about';
 
 interface SettingsSlice {
   activeSection: SettingsSection;

--- a/landing/agent-system.html
+++ b/landing/agent-system.html
@@ -7,7 +7,7 @@
 <meta name="description" content="How the AI Job Hunter repo's .claude/ agent system works: 21 specialized agents, paired author + critic per domain, routed by area, reviewed independently, closed out by a steward.">
 <meta name="robots" content="index,follow">
 <link rel="canonical" href="https://aijobhunter.app/agent-system">
-<meta name="theme-color" content="#f4ecdc">
+<meta name="theme-color" content="#0d0f14">
 <meta property="og:title" content="AI Job Hunter — The Agent Fleet">
 <meta property="og:description" content="21 agents, paired author + critic per domain. The .claude/ system that builds and reviews this repo, explained.">
 <meta property="og:url" content="https://aijobhunter.app/agent-system">
@@ -18,189 +18,243 @@
 <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Anton&family=Gloria+Hallelujah&family=Patrick+Hand&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
 <style>
 :root{
-  --scrawl:'Gloria Hallelujah', cursive;
-  --hand:'Patrick Hand', cursive;
-  --impact:'Anton', Impact, sans-serif;
+  --head:'Space Grotesk', system-ui, sans-serif;
+  --body:system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --mono:'Space Mono', monospace;
-  --paper:#f4ecdc;
-  --ink:#1c1812;
-  --red:#e24b4a;
-  --muted:#5a5340;
+
+  --bg:#0d0f14;
+  --surface:#161922;
+  --surface-2:#1d2230;
+  --border:rgba(255,255,255,.10);
+  --text:#e6e9ef;
+  --muted:#9aa3b2;
+  --accent:#e24b4a;
+  --accent-soft:rgba(226,75,74,.14);
+
+  --author:#34d399;
+  --author-tint:rgba(52,211,153,.12);
+  --critic:#f472b6;
+  --critic-tint:rgba(244,114,182,.12);
+
+  --r:14px;
+  --pill:999px;
+  --elev:0 10px 30px -18px rgba(0,0,0,.7);
+  --hair:inset 0 1px 0 rgba(255,255,255,.04);
 }
 *{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%; text-size-adjust:100%}
 body{
-  margin:0; background:var(--paper); color:var(--ink);
-  font-family:var(--hand); font-size:18px; line-height:1.7;
+  margin:0; background:var(--bg); color:var(--text);
+  font-family:var(--body); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
 }
-a{color:var(--red); text-decoration:none; border-bottom:1.5px solid rgba(226,75,74,.4)}
-a:hover{border-bottom-color:var(--red)}
-code{font-family:var(--mono); font-size:.8em; background:#e6dcc4; padding:1px 6px; border-radius:4px}
+a{color:var(--accent); text-decoration:none; border-bottom:1px solid var(--accent-soft); transition:border-color .2s}
+a:hover{border-bottom-color:var(--accent)}
+code{font-family:var(--mono); font-size:.82em; background:var(--surface-2); padding:1px 6px; border-radius:6px; color:var(--text)}
 
-/* click-to-copy command chip (matches download.html) */
-.copy-cmd{cursor:pointer; display:inline-block; margin:3px 0; transition:background .15s, color .15s}
-.copy-cmd:hover{background:#dccdaa}
-.copy-cmd:focus-visible{outline:2px solid var(--ink); outline-offset:2px}
-.copy-cmd.copied{background:#cfe6cf; color:#2f5d2f}
-.copy-cmd.copied::after{content:" ✓"; font-weight:700}
+/* click-to-copy command chip */
+.copy-cmd{cursor:pointer; display:inline-block; margin:3px 0; border-radius:8px; transition:background .18s, color .18s, transform .18s}
+.copy-cmd:hover{background:var(--surface-2)}
+.copy-cmd:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
+.copy-cmd.copied{background:var(--author-tint); color:var(--text)}
+.copy-cmd.copied::after{content:" ✓"; font-weight:700; color:var(--author)}
 
-.wrap{max-width:900px; margin:0 auto; padding:56px 22px 90px}
+.wrap{max-width:920px; margin:0 auto; padding:56px 22px 90px}
 
-.top-back{display:inline-block; font-family:var(--mono); font-size:13px; color:var(--muted); border:none; margin-bottom:30px}
-.top-back:hover{color:var(--ink)}
+.top-back{display:inline-block; font-family:var(--mono); font-size:13px; color:var(--muted); border:none; margin-bottom:30px; transition:color .2s, transform .2s}
+.top-back:hover{color:var(--text); transform:translateX(-3px)}
 
-h1{font-family:var(--impact); text-transform:uppercase; font-size:clamp(40px,10vw,76px); line-height:.92; margin:0 0 10px; letter-spacing:1px}
-.lede{font-family:var(--mono); font-size:14px; line-height:1.85; color:#2c271c; margin:18px 0 0}
-.lede b{color:var(--ink)}
-.tag{font-family:var(--scrawl); font-size:clamp(16px,3.4vw,21px); color:var(--red); margin:14px 0 0}
-.count{font-family:var(--mono); font-size:13px; color:var(--muted); margin:6px 0 0}
-.count b{color:var(--ink)}
+h1{font-family:var(--head); font-weight:700; font-size:clamp(40px,9vw,72px); line-height:1.02; margin:0 0 10px; letter-spacing:-.02em}
+.lede{font-size:17px; line-height:1.65; color:var(--text); margin:18px 0 0; max-width:68ch}
+.lede b{color:var(--text); font-weight:600}
+.tag{font-family:var(--head); font-weight:500; font-size:clamp(17px,3.2vw,22px); color:var(--accent); margin:14px 0 0; line-height:1.4}
+.count{font-family:var(--mono); font-size:13px; color:var(--muted); margin:8px 0 0}
+.count b{color:var(--text)}
+.count .num{display:inline-block; min-width:2ch}
 
-h2.section{font-family:var(--impact); text-transform:uppercase; font-size:clamp(24px,5.4vw,38px); letter-spacing:.5px; margin:0 0 4px; line-height:1}
-.section-sub{font-family:var(--scrawl); font-size:clamp(15px,3vw,18px); color:var(--muted); margin:0 0 22px}
+h2.section{font-family:var(--head); font-weight:700; font-size:clamp(26px,5vw,40px); letter-spacing:-.02em; margin:0 0 4px; line-height:1.05}
+.section-sub{font-size:clamp(15px,2.6vw,17px); color:var(--muted); margin:0 0 22px}
 
-hr.scrawl{border:none; height:14px; margin:54px auto; width:200px;
-  background:no-repeat center/contain url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 14'><path d='M4 8 q12 -8 24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0' fill='none' stroke='%231c1812' stroke-width='2.6' stroke-linecap='round'/></svg>")}
+/* thin centered gradient divider (replaces the scrawl hr) */
+hr.scrawl{border:none; height:1px; margin:54px auto; width:min(560px,90%);
+  background:linear-gradient(90deg, transparent, var(--border) 18%, var(--border) 82%, transparent)}
 
-/* generic wobbly card */
+/* generic card */
 .card{
-  background:#fffef8; border:2.6px solid var(--ink);
-  border-radius:16px 11px 18px 9px/9px 17px 11px 16px; box-shadow:4px 5px 0 rgba(0,0,0,.14);
-  padding:18px 20px;
+  background:var(--surface); border:1px solid var(--border);
+  border-radius:var(--r); box-shadow:var(--elev), var(--hair);
+  padding:20px 22px;
 }
 
 /* ---------- intake → delegation ---------- */
 .intake{display:grid; grid-template-columns:minmax(0,1fr) minmax(0,1.1fr); gap:20px; align-items:start}
 .issue-list{display:flex; flex-direction:column; gap:10px}
 .issue{
-  font-family:var(--hand); font-size:16px; text-align:left; width:100%; cursor:pointer;
-  background:#ece2cf; border:2.4px solid var(--ink); color:var(--ink);
-  border-radius:13px 9px 14px 10px; box-shadow:3px 4px 0 rgba(0,0,0,.14);
-  padding:11px 14px; transition:transform .14s, background .14s;
+  font-family:var(--body); font-size:15px; text-align:left; width:100%; cursor:pointer;
+  background:var(--surface); border:1px solid var(--border); color:var(--text);
+  border-radius:var(--r); box-shadow:var(--hair);
+  padding:12px 15px; transition:transform .18s, background .18s, border-color .18s;
 }
-.issue:nth-child(odd){transform:rotate(-.3deg)} .issue:nth-child(even){transform:rotate(.3deg)}
-.issue:hover{background:#e3d6ba; transform:translateY(-2px)}
-.issue[aria-pressed="true"]{background:var(--ink); color:var(--paper); box-shadow:2px 3px 0 rgba(0,0,0,.3)}
+.issue:hover{background:var(--surface-2); border-color:rgba(255,255,255,.18); transform:translateY(-3px)}
+.issue:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
+.issue[aria-pressed="true"]{background:var(--accent-soft); border-color:var(--accent); color:var(--text)}
 .issue .ico{margin-right:8px}
 .route{
-  background:#fffef8; border:2.6px solid var(--ink); transform:rotate(.25deg);
-  border-radius:16px 11px 18px 9px/9px 17px 11px 16px; box-shadow:4px 5px 0 rgba(0,0,0,.14);
-  padding:18px 20px; min-height:220px;
+  background:var(--surface); border:1px solid var(--border);
+  border-radius:var(--r); box-shadow:var(--elev), var(--hair);
+  padding:20px 22px; min-height:220px;
 }
-.route .placeholder{font-family:var(--scrawl); color:var(--muted)}
-.route h3{font-family:var(--impact); text-transform:uppercase; letter-spacing:.5px; font-size:18px; margin:0 0 2px}
+.route .placeholder{color:var(--muted)}
+.route h3{font-family:var(--head); font-weight:700; letter-spacing:-.01em; font-size:19px; margin:0 0 2px; color:var(--text)}
 .route .area{font-family:var(--mono); font-size:13px; color:var(--muted); margin:0 0 14px}
 .flow{list-style:none; margin:0; padding:0}
-.flow li{display:flex; gap:10px; align-items:baseline; margin:0 0 9px; line-height:1.4}
-.flow .lbl{font-family:var(--mono); font-size:12.5px; color:var(--muted); min-width:78px; flex:0 0 78px; text-transform:uppercase; padding-top:2px}
-.flow .who{font-family:var(--hand); font-size:16px}
-.flow .who b{font-family:var(--mono); font-size:13px; background:#e6dcc4; padding:1px 6px; border-radius:4px; color:var(--ink)}
-.flow .who .crit{background:#f3d9d4}
-.flow .who .sec{background:#dfe9d8}
-.flow .why{font-family:var(--hand); font-size:14px; color:var(--muted)}
+.flow li{display:flex; gap:10px; align-items:baseline; margin:0 0 10px; line-height:1.45}
+.flow .lbl{font-family:var(--mono); font-size:12px; color:var(--muted); min-width:78px; flex:0 0 78px; text-transform:uppercase; letter-spacing:.04em; padding-top:1px}
+.flow .who{font-size:15px}
+.flow .who b{font-family:var(--mono); font-weight:400; font-size:13px; background:var(--surface-2); padding:2px 7px; border-radius:6px; color:var(--text); border:1px solid var(--border)}
+.flow .who .crit{background:var(--critic-tint); border-color:rgba(244,114,182,.4); color:var(--text)}
+.flow .who .sec{background:var(--author-tint); border-color:rgba(52,211,153,.4); color:var(--text)}
+.flow .why{font-size:14px; color:var(--muted)}
+
+/* route panel re-trigger animation */
+@media (prefers-reduced-motion: no-preference){
+  .route .placeholder, .route h3, .route .area, .route .flow li{opacity:1}
+  .route.swap h3, .route.swap .area, .route.swap .flow li{
+    animation:route-in .42s cubic-bezier(.22,.61,.36,1) backwards;
+  }
+  .route.swap .area{animation-delay:.05s}
+  .route.swap .flow li{animation-delay:.1s}
+  .route.swap .flow li:nth-child(2){animation-delay:.15s}
+  .route.swap .flow li:nth-child(3){animation-delay:.2s}
+  .route.swap .flow li:nth-child(4){animation-delay:.25s}
+  @keyframes route-in{from{opacity:0; transform:translateY(10px)} to{opacity:1; transform:none}}
+}
 
 /* ---------- fleet map ---------- */
 .map-shell{overflow-x:auto; -webkit-overflow-scrolling:touch}
 .fleet-svg{display:block; width:100%; height:auto; min-width:680px; font-family:var(--mono)}
-.fleet-svg text{fill:var(--ink); font-size:12px}
-.fleet-svg .domain-lbl{font-family:var(--scrawl); font-size:15px; fill:var(--muted)}
+.fleet-svg text{fill:var(--text); font-size:12px}
+.fleet-svg .domain-lbl{font-family:var(--head); font-weight:500; font-size:14px; fill:var(--muted)}
 .fleet-svg .node{cursor:pointer}
-.fleet-svg .node rect{fill:#fffef8; stroke:var(--ink); stroke-width:2.4; transition:fill .15s}
-.fleet-svg .node.author rect{fill:#eef3e9}
-.fleet-svg .node.critic rect{fill:#fbeae7}
-.fleet-svg .node:hover rect, .fleet-svg .node.active rect{fill:#ffe9a8}
-.fleet-svg .node:focus-visible rect{stroke:var(--red); stroke-width:3.5}
-.fleet-svg .link{fill:none; stroke:var(--ink); stroke-width:2.2; stroke-linecap:round; opacity:.32; transition:opacity .15s, stroke .15s}
-.fleet-svg .link.risk{stroke:var(--red)}
-.fleet-svg .link.lit{opacity:1; stroke-width:3}
+.fleet-svg .node rect{fill:var(--surface); stroke:var(--border); stroke-width:1.4; transition:fill .2s, stroke .2s}
+.fleet-svg .node.author rect{fill:var(--author-tint); stroke:var(--author)}
+.fleet-svg .node.critic rect{fill:var(--critic-tint); stroke:var(--critic)}
+.fleet-svg .node:hover rect, .fleet-svg .node.active rect{fill:var(--accent); stroke:var(--accent)}
+.fleet-svg .node:hover text, .fleet-svg .node.active text{fill:#fff}
+.fleet-svg .node:focus-visible rect{stroke:var(--accent); stroke-width:2.4}
+.fleet-svg .link{fill:none; stroke:rgba(255,255,255,.22); stroke-width:1.6; stroke-linecap:round; opacity:.6; transition:opacity .2s, stroke .2s, stroke-width .2s}
+.fleet-svg .link.risk{stroke:var(--accent); opacity:.55}
+.fleet-svg .link.lit{opacity:1; stroke-width:2.6; stroke:var(--text)}
+.fleet-svg .link.risk.lit{stroke:var(--accent)}
 .map-hint{font-family:var(--mono); font-size:13px; color:var(--muted); margin:10px 0 0; text-align:center}
 .legend{display:flex; flex-wrap:wrap; gap:8px 18px; justify-content:center; font-family:var(--mono); font-size:12px; color:var(--muted); margin:14px 0 0}
 .legend span{display:inline-flex; align-items:center; gap:6px}
-.sw{width:18px; height:0; border-top:3px solid var(--ink); display:inline-block}
-.sw.risk{border-color:var(--red)}
-.sw.box{width:14px; height:14px; border:2px solid var(--ink); border-radius:3px}
-.sw.box.author{background:#eef3e9} .sw.box.critic{background:#fbeae7}
+.sw{width:18px; height:0; border-top:2px solid rgba(255,255,255,.3); display:inline-block}
+.sw.risk{border-color:var(--accent)}
+.sw.box{width:14px; height:14px; border:1px solid var(--border); border-radius:4px}
+.sw.box.author{background:var(--author-tint); border-color:var(--author)}
+.sw.box.critic{background:var(--critic-tint); border-color:var(--critic)}
 
-/* draw-on animation, gated below by prefers-reduced-motion */
+/* draw-on + risk flow, gated below by prefers-reduced-motion */
 @media (prefers-reduced-motion: no-preference){
-  /* stagger via inline animation-delay on each .link (two .domain-lbl <text> precede them, so :nth-child was mis-targeted) */
-  .fleet-svg .link{stroke-dasharray:520; stroke-dashoffset:520; animation:draw 1.5s ease forwards}
+  .fleet-svg .link{stroke-dasharray:520; stroke-dashoffset:520; animation:draw 1.4s ease forwards}
   @keyframes draw{to{stroke-dashoffset:0}}
+  /* slow subtle dashed flow on the red risk links (after they finish drawing) */
+  .fleet-svg .link.risk{stroke-dasharray:8 8; animation:draw 1.4s ease forwards, riskflow 2.6s linear 1.4s infinite}
+  @keyframes riskflow{to{stroke-dashoffset:-16}}
 }
 @media (prefers-reduced-motion: reduce){
   *{ transition:none !important; animation:none !important }
 }
 
+/* ---------- scroll reveal (transform/opacity only) ---------- */
+@media (prefers-reduced-motion: no-preference){
+  .reveal{opacity:0; transform:translateY(16px); transition:opacity .55s ease, transform .55s ease}
+  .reveal.in{opacity:1; transform:none}
+}
+
 /* ---------- agent cards ---------- */
-.domain-band{font-family:var(--scrawl); font-size:clamp(15px,3vw,19px); color:var(--ink); margin:30px 0 12px; display:flex; align-items:center; gap:10px}
-.domain-band::after{content:""; flex:1; height:3px; background:var(--ink); opacity:.18; border-radius:3px}
+.domain-band{font-family:var(--head); font-weight:500; font-size:clamp(15px,3vw,18px); color:var(--text); margin:32px 0 14px; display:flex; align-items:center; gap:12px}
+.domain-band::after{content:""; flex:1; height:1px; background:linear-gradient(90deg, var(--border), transparent)}
 .agent-grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:18px}
 .agent{
-  background:#fffef8; border:2.6px solid var(--ink);
-  border-radius:16px 11px 18px 9px/9px 17px 11px 16px; box-shadow:4px 5px 0 rgba(0,0,0,.14);
-  padding:16px 18px; display:flex; flex-direction:column; gap:8px;
+  background:var(--surface); border:1px solid var(--border);
+  border-radius:var(--r); box-shadow:var(--elev), var(--hair);
+  padding:18px 18px; display:flex; flex-direction:column; gap:9px;
+  transition:transform .2s ease, border-color .2s ease;
 }
-.agent:nth-child(odd){transform:rotate(-.3deg)} .agent:nth-child(even){transform:rotate(.3deg)}
-.agent .name{font-family:var(--mono); font-weight:700; font-size:14px; color:var(--ink); word-break:break-word}
-.agent .role-pill{font-family:var(--mono); font-size:11px; text-transform:uppercase; letter-spacing:.5px; padding:1px 7px; border-radius:6px; align-self:flex-start; border:2px solid var(--ink)}
-.role-author{background:#eef3e9} .role-critic{background:#fbeae7} .role-cross{background:#e6dcc4}
-.agent .role{font-family:var(--hand); font-size:15px; line-height:1.35}
+.agent:hover{transform:translateY(-3px); border-color:rgba(255,255,255,.18)}
+.agent .name{font-family:var(--mono); font-weight:700; font-size:14px; color:var(--text); word-break:break-word}
+.agent .role-pill{font-family:var(--mono); font-size:11px; text-transform:uppercase; letter-spacing:.05em; padding:2px 9px; border-radius:var(--pill); align-self:flex-start; border:1px solid var(--border)}
+.role-author{background:var(--author-tint); border-color:rgba(52,211,153,.4); color:var(--author)}
+.role-critic{background:var(--critic-tint); border-color:rgba(244,114,182,.4); color:var(--critic)}
+.role-cross{background:var(--surface-2); color:var(--muted)}
+.agent .role{font-size:15px; line-height:1.45; color:var(--text)}
 .agent .pair{font-family:var(--mono); font-size:12px; color:var(--muted); line-height:1.5}
-.agent .pair b{color:var(--ink)}
+.agent .pair b{color:var(--text); font-weight:400}
 .agent .paths{font-family:var(--mono); font-size:12px; color:var(--muted); line-height:1.5; word-break:break-word}
-.agent .copy-cmd{margin-top:auto; font-family:var(--mono); font-size:13px; line-height:1.5; background:#e6dcc4; border-radius:8px; padding:7px 9px; border:2px dashed rgba(28,24,18,.35)}
+.agent .copy-cmd{margin-top:auto; font-family:var(--mono); font-size:12.5px; line-height:1.5; background:var(--surface-2); border-radius:10px; padding:9px 11px; border:1px solid var(--border)}
+.agent .copy-cmd:hover{border-color:rgba(255,255,255,.2)}
 
 /* ---------- pipeline walkthrough ---------- */
 .pipeline{display:flex; flex-direction:column; gap:0}
-.step{display:flex; gap:14px; align-items:flex-start; position:relative; padding:0 0 18px}
-.step:not(:last-child)::before{content:""; position:absolute; left:17px; top:34px; bottom:-2px; width:3px; background:repeating-linear-gradient(var(--ink) 0 6px, transparent 6px 11px); opacity:.4}
-.step .num{flex:0 0 36px; width:36px; height:36px; display:flex; align-items:center; justify-content:center; font-family:var(--impact); font-size:18px; background:var(--ink); color:var(--paper); border-radius:50% 48% 52% 50%; z-index:1}
-.step .body{flex:1 1 auto; padding-top:3px}
-.step h3{font-family:var(--mono); font-weight:700; font-size:14px; margin:0 0 3px}
+.step{display:flex; gap:14px; align-items:flex-start; position:relative; padding:0 0 20px}
+.step .connector{position:absolute; left:17px; top:34px; bottom:-2px; width:2px; background:var(--border); transform-origin:top; transform:scaleY(0); transition:transform .5s ease}
+.step.in .connector{transform:scaleY(1)}
+.step .num{flex:0 0 36px; width:36px; height:36px; display:flex; align-items:center; justify-content:center; font-family:var(--head); font-weight:700; font-size:16px; background:var(--surface-2); color:var(--text); border:1px solid var(--border); border-radius:50%; z-index:1; transition:transform .35s cubic-bezier(.34,1.56,.64,1)}
+.step .body{flex:1 1 auto; padding-top:4px}
+.step h3{font-family:var(--mono); font-weight:700; font-size:14px; margin:0 0 4px; color:var(--text)}
 .step h3 .tag{font-family:var(--mono); font-size:12px; color:var(--muted); font-weight:400; margin-left:2px; background:none}
-.step p{margin:0; font-size:16px; line-height:1.45}
-.step p .a{font-family:var(--mono); font-size:12px; background:#e6dcc4; padding:1px 5px; border-radius:4px}
+.step p{margin:0; font-size:15.5px; line-height:1.55}
+.step p .a{font-family:var(--mono); font-size:12px; background:var(--surface-2); padding:1px 6px; border-radius:6px; border:1px solid var(--border)}
+@media (prefers-reduced-motion: no-preference){
+  .pipeline.armed .step .num{transform:scale(.6); opacity:0}
+  .pipeline.armed .step.in .num{transform:scale(1); opacity:1}
+}
 
 /* ---------- big work-together prompt ---------- */
 .big-prompt{
-  background:#fffef8; border:2.6px solid var(--ink); transform:rotate(-.25deg);
-  border-radius:18px 12px 20px 10px/10px 19px 12px 18px; box-shadow:5px 6px 0 rgba(0,0,0,.16);
-  padding:22px 24px;
+  background:var(--surface); border:1px solid var(--border);
+  border-radius:var(--r); box-shadow:var(--elev), var(--hair);
+  padding:24px 26px;
 }
-.big-prompt .copy-cmd{display:block; font-family:var(--mono); font-size:14px; line-height:1.6; background:var(--ink); color:var(--paper); border-radius:10px; padding:14px 16px; margin:0 0 16px}
-.big-prompt .copy-cmd:hover{background:#2a241a}
-.big-prompt .copy-cmd:focus-visible{outline-color:var(--paper)}
-.big-prompt .copy-cmd.copied{background:#2f5d2f; color:#eaf6ea}
+.big-prompt .copy-cmd{display:block; font-family:var(--mono); font-size:14px; line-height:1.6; background:var(--surface-2); color:var(--text); border:1px solid var(--border); border-radius:12px; padding:15px 17px; margin:0 0 18px}
+.big-prompt .copy-cmd:hover{background:var(--bg); border-color:var(--accent)}
+.big-prompt .copy-cmd:focus-visible{outline-color:var(--accent)}
+.big-prompt .copy-cmd.copied{background:var(--author-tint); color:var(--text)}
 .teams{display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; margin:0}
-.team{background:#ece2cf; border:2.4px solid var(--ink); border-radius:13px 9px 14px 10px; padding:13px 15px}
-.team h4{font-family:var(--scrawl); font-size:15px; margin:0 0 7px}
-.team ul{margin:0; padding-left:18px; font-size:14.5px; line-height:1.5}
-.team code{font-size:.78em}
+.team{background:var(--surface-2); border:1px solid var(--border); border-radius:var(--r); padding:15px 16px; transition:transform .2s ease, border-color .2s ease}
+.team:hover{transform:translateY(-3px); border-color:rgba(255,255,255,.18)}
+.team h4{font-family:var(--head); font-weight:500; font-size:15px; margin:0 0 8px; color:var(--text)}
+.team ul{margin:0; padding-left:18px; font-size:14.5px; line-height:1.55; color:var(--text)}
+.team code{font-size:.8em}
 
 /* ---------- with vs without ---------- */
 .versus{display:grid; grid-template-columns:1fr 1fr; gap:18px}
 .vcol{
-  border:2.6px solid var(--ink); border-radius:16px 11px 18px 9px/9px 17px 11px 16px;
-  box-shadow:4px 5px 0 rgba(0,0,0,.14); padding:16px 18px;
+  border:1px solid var(--border); border-radius:var(--r);
+  box-shadow:var(--elev), var(--hair); padding:18px 20px;
+  transition:transform .2s ease, border-color .2s ease;
 }
-.vcol.without{background:#f1e3d0; transform:rotate(-.3deg)}
-.vcol.with{background:#fffef8; transform:rotate(.3deg)}
-.vcol h3{font-family:var(--impact); text-transform:uppercase; letter-spacing:.5px; font-size:19px; margin:0 0 12px}
-.dim{margin:0 0 13px}
-.dim .k{font-family:var(--mono); font-size:12px; text-transform:uppercase; letter-spacing:.5px; color:var(--muted); display:block; margin:0 0 1px}
-.dim .v{font-family:var(--hand); font-size:16px; line-height:1.35}
-.dim .v b{font-family:var(--mono); font-size:13px}
-.illustrative{font-family:var(--mono); font-size:12px; color:var(--muted); margin:14px 0 0; line-height:1.7; border-top:2px dashed rgba(28,24,18,.25); padding-top:12px}
-.illustrative b{color:var(--ink)}
+.vcol:hover{transform:translateY(-3px)}
+.vcol.without{background:var(--surface-2)}
+.vcol.with{background:var(--surface); border-color:rgba(52,211,153,.3)}
+.vcol h3{font-family:var(--head); font-weight:700; letter-spacing:-.01em; font-size:20px; margin:0 0 14px; color:var(--text)}
+.dim{margin:0 0 14px}
+.dim .k{font-family:var(--mono); font-size:12px; text-transform:uppercase; letter-spacing:.04em; color:var(--muted); display:block; margin:0 0 2px}
+.dim .v{font-size:15px; line-height:1.45; color:var(--text)}
+.dim .v b{font-family:var(--mono); font-size:13px; font-weight:700}
+.illustrative{font-family:var(--mono); font-size:12px; color:var(--muted); margin:16px 0 0; line-height:1.7; border-top:1px solid var(--border); padding-top:14px}
+.illustrative b{color:var(--text)}
 
 footer{margin-top:64px; text-align:center}
-.byline{font-family:var(--scrawl); font-size:15px; color:var(--muted)}
+.byline{font-family:var(--head); font-weight:500; font-size:16px; color:var(--muted)}
 .foot-links{font-family:var(--mono); font-size:13px; color:var(--muted); margin-top:10px}
-.foot-links a{color:var(--muted); border:none}
-.foot-links a:hover{color:var(--ink)}
+.foot-links a{color:var(--muted); border:none; transition:color .2s}
+.foot-links a:hover{color:var(--text)}
 
 @media (max-width:680px){
   .intake{grid-template-columns:1fr}
@@ -216,7 +270,7 @@ footer{margin-top:64px; text-align:center}
   <!-- ============ 1 · HERO ============ -->
   <h1>The Agent Fleet</h1>
   <p class="tag">a swarm of tiny specialists builds this repo, and a second swarm tears their work apart.</p>
-  <p class="count"><b>21 agents</b>, paired author + critic per domain.</p>
+  <p class="count"><b><span class="num" id="agent-count" data-to="21">21</span> agents</b>, paired author + critic per domain.</p>
   <p class="lede">
     Every task and code change in this repo routes through a <b>.claude/</b> agent system. You name no agent —
     the system reads the files you touched, picks the <b>author</b> that owns that area, runs an <b>independent critic</b>
@@ -251,7 +305,7 @@ footer{margin-top:64px; text-align:center}
   <p class="section-sub">authors (left, green) write. critics (right, pink) audit. hover a node to light its pairing.</p>
 
   <div class="map-shell">
-    <svg class="fleet-svg" viewBox="0 0 680 470" role="img" aria-label="Map of the agent fleet: each author paired to its independent critic, with security and performance secondaries connecting in red.">
+    <svg class="fleet-svg" viewBox="0 0 680 510" role="img" aria-label="Map of the agent fleet: each author paired to its independent critic, with security and performance secondaries connecting in red.">
       <!-- column headers -->
       <text class="domain-lbl" x="70" y="20">AUTHORS · write</text>
       <text class="domain-lbl" x="400" y="20">CRITICS · audit</text>
@@ -267,11 +321,11 @@ footer{margin-top:64px; text-align:center}
       <path class="link" data-pair="test"   style="animation-delay:.35s"  d="M220 375 C 300 375, 300 375, 400 375" />
       <path class="link" data-pair="cq"     style="animation-delay:.4s"   d="M220 420 C 300 420, 300 420, 400 420" />
       <!-- risk secondaries — security + performance reach across to many authors (red) -->
-      <path class="link risk" data-pair="sec"  style="animation-delay:.45s" d="M470 425 C 360 200, 300 80, 215 62" />
-      <path class="link risk" data-pair="sec"  style="animation-delay:.5s"  d="M470 425 C 380 320, 320 250, 215 240" />
-      <path class="link risk" data-pair="sec"  style="animation-delay:.55s" d="M470 425 C 360 360, 320 300, 215 285" />
-      <path class="link risk" data-pair="perf" style="animation-delay:.6s"  d="M610 425 C 480 360, 360 335, 215 330" />
-      <path class="link risk" data-pair="perf" style="animation-delay:.65s" d="M610 425 C 520 360, 360 295, 215 285" />
+      <path class="link risk" data-pair="sec"  style="animation-delay:.45s" d="M254 470 C 360 200, 300 80, 215 62" />
+      <path class="link risk" data-pair="sec"  style="animation-delay:.5s"  d="M254 470 C 380 320, 320 250, 215 240" />
+      <path class="link risk" data-pair="sec"  style="animation-delay:.55s" d="M254 470 C 360 360, 320 300, 215 285" />
+      <path class="link risk" data-pair="perf" style="animation-delay:.6s"  d="M446 470 C 480 360, 360 335, 215 330" />
+      <path class="link risk" data-pair="perf" style="animation-delay:.65s" d="M446 470 C 520 360, 360 295, 215 285" />
 
       <!-- AUTHOR nodes -->
       <g class="node author" data-pair="rust"   tabindex="0" role="button" aria-label="rust-backend-author (author)"><rect x="30"  y="46"  width="190" height="28" rx="6"/><text x="40" y="64">rust-backend-author</text></g>
@@ -294,9 +348,9 @@ footer{margin-top:64px; text-align:center}
       <g class="node critic" data-pair="test"   tabindex="0" role="button" aria-label="testing-reviewer (critic)"><rect x="400" y="361" width="200" height="28" rx="6"/><text x="410" y="379">testing-reviewer</text></g>
       <g class="node critic" data-pair="cq"     tabindex="0" role="button" aria-label="code-quality-reviewer (critic)"><rect x="400" y="406" width="200" height="28" rx="6"/><text x="410" y="424">code-quality-reviewer</text></g>
 
-      <!-- risk-lens nodes (bottom, red-linked) -->
-      <g class="node critic" data-pair="sec"  tabindex="0" role="button" aria-label="tauri-security-reviewer (critic)"><rect x="370" y="438" width="200" height="28" rx="6"/><text x="380" y="456">tauri-security-reviewer</text></g>
-      <g class="node critic" data-pair="perf" tabindex="0" role="button" aria-label="performance-profiler (critic)"><rect x="510" y="438" width="160" height="28" rx="6"/><text x="520" y="456">performance-profiler</text></g>
+      <!-- risk-lens nodes (bottom, red-linked) — centered, side-by-side, 12px gap -->
+      <g class="node critic" data-pair="sec"  tabindex="0" role="button" aria-label="tauri-security-reviewer (critic)"><rect x="154" y="470" width="200" height="28" rx="6"/><text x="164" y="488">tauri-security-reviewer</text></g>
+      <g class="node critic" data-pair="perf" tabindex="0" role="button" aria-label="performance-profiler (critic)"><rect x="366" y="470" width="160" height="28" rx="6"/><text x="376" y="488">performance-profiler</text></g>
     </svg>
   </div>
   <div class="legend">
@@ -324,6 +378,7 @@ footer{margin-top:64px; text-align:center}
 
   <div class="card pipeline">
     <div class="step">
+      <div class="connector" aria-hidden="true"></div>
       <div class="num">1</div>
       <div class="body">
         <h3>Intake &amp; triage <span class="tag">main session</span></h3>
@@ -331,6 +386,7 @@ footer{margin-top:64px; text-align:center}
       </div>
     </div>
     <div class="step">
+      <div class="connector" aria-hidden="true"></div>
       <div class="num">2</div>
       <div class="body">
         <h3>Pre-harvest handoff <span class="tag">context, once</span></h3>
@@ -338,6 +394,7 @@ footer{margin-top:64px; text-align:center}
       </div>
     </div>
     <div class="step">
+      <div class="connector" aria-hidden="true"></div>
       <div class="num">3</div>
       <div class="body">
         <h3>Author implements <span class="tag">write access</span></h3>
@@ -345,6 +402,7 @@ footer{margin-top:64px; text-align:center}
       </div>
     </div>
     <div class="step">
+      <div class="connector" aria-hidden="true"></div>
       <div class="num">4</div>
       <div class="body">
         <h3>Independent critic audits <span class="tag">read-only</span></h3>
@@ -352,6 +410,7 @@ footer{margin-top:64px; text-align:center}
       </div>
     </div>
     <div class="step">
+      <div class="connector" aria-hidden="true"></div>
       <div class="num">5</div>
       <div class="body">
         <h3>test-author writes tests <span class="tag">if testable</span></h3>
@@ -359,6 +418,7 @@ footer{margin-top:64px; text-align:center}
       </div>
     </div>
     <div class="step">
+      <div class="connector" aria-hidden="true"></div>
       <div class="num">6</div>
       <div class="body">
         <h3>testing-reviewer audits the tests <span class="tag">read-only</span></h3>
@@ -366,6 +426,7 @@ footer{margin-top:64px; text-align:center}
       </div>
     </div>
     <div class="step">
+      <div class="connector" aria-hidden="true"></div>
       <div class="num">7</div>
       <div class="body">
         <h3>cleanup sweeps dead code <span class="tag">report-first</span></h3>
@@ -470,7 +531,7 @@ footer{margin-top:64px; text-align:center}
   <footer>
     <p class="byline">21 specialists, zero of them with a real job either.</p>
     <p class="foot-links">
-      <a href="index.html">home</a> · <a href="download.html">download</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a>
+      <a href="index.html">home</a> · <a href="download.html">download</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener">♥ sponsor</a>
     </p>
   </footer>
 
@@ -585,7 +646,12 @@ footer{margin-top:64px; text-align:center}
       issues.forEach(function(b){ b.setAttribute('aria-pressed','false'); });
       btn.setAttribute('aria-pressed','true');
       var r = ROUTES[btn.getAttribute('data-issue')];
-      if(r) routeEl.innerHTML = routeHTML(r);
+      if(!r) return;
+      // re-trigger the fade/slide-in by toggling the swap class before re-rendering
+      routeEl.classList.remove('swap');
+      void routeEl.offsetWidth; // reflow so the animation restarts
+      routeEl.innerHTML = routeHTML(r);
+      routeEl.classList.add('swap');
     });
   });
 
@@ -624,6 +690,75 @@ footer{margin-top:64px; text-align:center}
     });
   }
   document.querySelectorAll('.copy-cmd').forEach(wireCopy);
+
+  // ---- scroll reveals + count-up + pipeline arming (all transform/opacity, reduced-motion off) ----
+  (function(){
+    var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var countEl = document.getElementById('agent-count');
+
+    function countUp(el){
+      var to = parseInt(el.getAttribute('data-to'), 10) || 0;
+      if(reduce){ el.textContent = String(to); return; }
+      var dur = 900, start = null;
+      function frame(t){
+        if(start === null) start = t;
+        var p = Math.min(1, (t - start) / dur);
+        var eased = 1 - Math.pow(1 - p, 3); // easeOutCubic
+        el.textContent = String(Math.round(eased * to));
+        if(p < 1) requestAnimationFrame(frame);
+        else el.textContent = String(to);
+      }
+      el.textContent = '0';
+      requestAnimationFrame(frame);
+    }
+
+    if(reduce || !('IntersectionObserver' in window)){
+      if(countEl) countEl.textContent = countEl.getAttribute('data-to') || countEl.textContent;
+      return; // CSS leaves everything visible; nothing to animate
+    }
+
+    // mark elements to reveal, with a per-sibling stagger inside each group
+    var groups = [
+      ['h1, .tag, .count, .lede', 0],
+      ['h2.section, .section-sub', 0],
+      ['.intake > *', 70],
+      ['.map-shell, .legend, .map-hint', 60],
+      ['.domain-band', 0],
+      ['.agent', 55],
+      ['.pipeline', 0],
+      ['.big-prompt', 0],
+      ['.team', 70],
+      ['.vcol, .illustrative', 80],
+      ['footer > *', 0]
+    ];
+    groups.forEach(function(g){
+      var sel = g[0], step = g[1], i = 0;
+      document.querySelectorAll(sel).forEach(function(el){
+        el.classList.add('reveal');
+        if(step) el.style.transitionDelay = (i++ * step) + 'ms';
+      });
+    });
+
+    // arm the pipeline so its step numbers pop in on reveal
+    var pipeline = document.querySelector('.pipeline');
+    if(pipeline){
+      pipeline.classList.add('armed');
+      pipeline.querySelectorAll('.step').forEach(function(s){ s.classList.add('reveal'); });
+    }
+
+    var io = new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(!e.isIntersecting) return;
+        var el = e.target;
+        el.classList.add('in');
+        if(el === countEl) countUp(el);
+        io.unobserve(el);
+      });
+    }, { threshold: 0.16, rootMargin: '0px 0px -8% 0px' });
+
+    document.querySelectorAll('.reveal').forEach(function(el){ io.observe(el); });
+    if(countEl) io.observe(countEl);
+  })();
 </script>
 </body>
 </html>

--- a/landing/architecture-map.html
+++ b/landing/architecture-map.html
@@ -4028,5 +4028,11 @@
         console.log('%c(a drift checker fails CI if this diagram ever lies. it has caught me twice.)', soft);
       } catch (e) {} })();
     </script>
+    <p style="position:fixed;bottom:0;left:0;right:0;z-index:9999;margin:0;padding:5px 14px;background:var(--panel);border-top:1px solid var(--border);font-size:11px;color:var(--muted);text-align:center;pointer-events:auto">
+      <a href="/" style="color:var(--muted)">home</a> ·
+      <a href="/download" style="color:var(--muted)">download</a> ·
+      <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener" style="color:var(--muted)">GitHub</a> ·
+      <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener" style="color:var(--muted)">♥ sponsor</a>
+    </p>
   </body>
 </html>

--- a/landing/ci-dashboard.html
+++ b/landing/ci-dashboard.html
@@ -962,6 +962,8 @@
         >workflow catalog</a>
       ·
       <a href="./benchmarks/">benchmarks</a>
+      ·
+      <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener">♥ sponsor</a>
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/landing/creature.html
+++ b/landing/creature.html
@@ -210,6 +210,7 @@ body::after{content:'';position:fixed;inset:0;z-index:0;pointer-events:none;opac
     <a class="back" href="/">← back to the notebook</a>
   </div>
 </div>
+<p style="position:relative;z-index:10;text-align:center;font-family:var(--mono);font-size:12px;color:#6f6650;margin:12px 0 0;padding-bottom:14px"><a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener" style="color:#6f6650">♥ sponsor</a> · <a href="/" style="color:#6f6650">home</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener" style="color:#6f6650">GitHub</a></p>
 
 <script>
 'use strict';

--- a/landing/download.html
+++ b/landing/download.html
@@ -198,7 +198,7 @@ footer{margin-top:60px; text-align:center}
   <footer>
     <p class="byline">made by Saeed, between rejections.</p>
     <p class="foot-links">
-      <a href="/">home</a> · <a href="/privacy">privacy</a> · <a href="/creature">▶ the short film</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener">Firefox extension</a>
+      <a href="/">home</a> · <a href="/privacy">privacy</a> · <a href="/creature">▶ the short film</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener">Firefox extension</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener">♥ sponsor</a>
     </p>
   </footer>
 

--- a/landing/how-it-works.html
+++ b/landing/how-it-works.html
@@ -944,6 +944,12 @@
         </p>
       </section>
     </main>
+    <footer style="text-align:center;padding:24px 16px 28px;font-size:12px;color:var(--muted)">
+      <a href="/" style="color:var(--muted)">home</a> ·
+      <a href="/download" style="color:var(--muted)">download</a> ·
+      <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener" style="color:var(--muted)">GitHub</a> ·
+      <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener" style="color:var(--muted)">♥ sponsor</a>
+    </footer>
 
     <script>
       /* ============================ NAV ============================ */

--- a/landing/index.html
+++ b/landing/index.html
@@ -49,7 +49,6 @@ img,svg{display:block}
 body::after{
   content:""; position:fixed; top:0; right:0; bottom:0; left:0; z-index:60; pointer-events:none; opacity:.06;
   background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='120' height='120' filter='url(%23n)'/></svg>");
-  mix-blend-mode:overlay;
 }
 
 /* ---------- doodle ink ---------- */
@@ -104,10 +103,10 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
    section's content column, and each drawing tip is an arrowhead that finally
    lands pointing at the CTA from its own side. Scrubbed by overall scroll
    progress, both directions. */
-#journey{position:absolute; top:0; left:0; width:100%; z-index:40; pointer-events:none}
+#journey{position:absolute; top:0; left:0; width:100%; z-index:40; pointer-events:none; contain:paint; transform:translateZ(0)}
 #journey svg{display:block; width:100%; height:100%; overflow:visible}
 #journey path{fill:none; stroke:var(--red); stroke-width:3.4; stroke-linecap:round; stroke-linejoin:round}
-#journey #journey-path,#journey #journey-path-2{opacity:.85; filter:drop-shadow(0 1px 0 rgba(0,0,0,.25))}
+#journey #journey-path,#journey #journey-path-2{opacity:.85}
 /* narrow viewports get an edge-hugging route from the JS builder instead of
    the gutter snake — keep the ink lighter there so it reads as margin doodle */
 @media (max-width:700px){ #journey path{stroke-width:2.6} }
@@ -194,12 +193,10 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
   /* backgrounds drift slower than the scroll → depth */
   .stage .photo{
     transform:translate3d(0,calc((var(--p,.5) - .5) * 10vh),0) scale(1.2);
-    will-change:transform;
   }
   /* content gently sinks as a section leaves centre (scrubbed, reversible) */
   .stage > .inner{
     transform:translate3d(0,calc((1 - var(--c,1)) * 24px),0);
-    will-change:transform;
   }
   /* hero content lifts away + dims as you scroll past it */
   .hero > .inner{
@@ -296,7 +293,7 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
 .ats{display:flex; align-items:center; gap:10px}
 .ats svg{width:64px; flex:none}
 .feed{
-  width:230px; height:84px; overflow:hidden; border:2px solid rgba(255,255,255,.12); border-radius:10px; background:#120d1c; position:relative;
+  width:230px; height:84px; overflow:hidden; border:2px solid rgba(255,255,255,.12); border-radius:10px; background:#120d1c; position:relative; content-visibility:auto;
 }
 .feed .scroller{position:absolute; left:0; top:0; width:100%; animation:feed 7s linear infinite}
 @keyframes feed{0%{transform:translateY(0)}100%{transform:translateY(-50%)}}
@@ -319,7 +316,7 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
   radial-gradient(72% 72% at 50% 42%, #eec46c 0%, #d98e26 36%, #ad5b0d 70%, #6f2f05 100%);
   filter:saturate(1.35) contrast(1.1) brightness(.9);
 }
-.beat3 .grade{background:radial-gradient(70% 60% at 50% 42%,rgba(255,255,255,.14),rgba(255,255,255,0) 55%); mix-blend-mode:screen}
+.beat3 .grade{background:radial-gradient(70% 60% at 50% 42%,rgba(255,255,255,.2),rgba(255,255,255,0) 55%)}
 .beat3{color:#0b0b0b}
 .beat3-dood{width:clamp(200px,38vw,300px); margin:0 auto 6px; filter:drop-shadow(0 0 10px #ff00d4) drop-shadow(0 0 4px #00fff0)}
 .fried{
@@ -797,11 +794,12 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
   <a class="cta" id="cta" href="/download">ok fine, take the app →</a>
   <a class="src-link" href="https://github.com/saeedkolivand/ai-job-hunter-app">view the source — it's PolyForm Noncommercial: read it, fork it, learn from it. just don't sell my misery back to me.</a>
   <a class="src-link" href="/creature">▶ THE CREATURE — a hand-drawn doodle about the tiny recruiter you accidentally summon. it grows. (2:40)</a>
+  <p class="src-link" style="margin-top:24px; font-size:14px; color:#6a614b">or fund a man's job hunt → <a href="https://ko-fi.com/saeedkolivand" target="_blank" rel="noopener" style="color:#4a4233">buy me a coffee</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener" style="color:#4a4233">sponsor</a> · <a href="https://paypal.me/saeedkolivand" target="_blank" rel="noopener" style="color:#4a4233">PayPal</a></p>
   <p class="footnote">macOS will say the app is "damaged." it's not damaged. it's just unsigned — like a contract I was never offered. run <code>xattr -cr</code> and we move on.</p>
   <p class="builtwith">Tauri · Rust · React 19 · TanStack · LanceDB · Typst · Ollama · pure spite</p>
   <p class="byline">made by Saeed, between rejections.</p>
   <svg class="inkline draw" style="width:24px; margin-top:10px" viewBox="0 0 30 28" aria-hidden="true"><path pathLength="1" d="M15 24 C5 16 2 9 8 5 q5 -3 7 4 q2 -7 7 -4 c6 4 3 11 -7 19 Z" style="stroke-width:2.4"/></svg>
-  <p class="footnote"><a href="/privacy" style="color:#6f6650">Privacy</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener" style="color:#6f6650">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener" style="color:#6f6650">Firefox extension</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener" style="color:#6f6650">GitHub</a></p>
+  <p class="footnote"><a href="/privacy" style="color:#6f6650">Privacy</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener" style="color:#6f6650">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener" style="color:#6f6650">Firefox extension</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener" style="color:#6f6650">GitHub</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener" style="color:#6f6650">♥ sponsor</a></p>
 </section>
 
 </main>
@@ -925,37 +923,57 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
   /* .testi/.finale aren't .stage but carry draw-on scribbles — observe them too */
   document.querySelectorAll('.stage, .testi, .finale').forEach(function(s){ io.observe(s); });
 
-  /* ---- progress bar + odometer ---- */
+  /* ---- shared cached document height (avoids forced layout every frame) ---- */
+  var docMax = 0;
+  function measureDoc(){
+    docMax = document.documentElement.scrollHeight - (innerHeight || document.documentElement.clientHeight);
+    if(docMax < 0) docMax = 0;
+  }
+  addEventListener('load', measureDoc);
+  addEventListener('resize', measureDoc);
+  measureDoc();
+
+  /* ---- progress bar + odometer (rAF-throttled, uses cached docMax) ---- */
   var bar=document.getElementById('progress'), plabel=document.getElementById('progress-label'), odo=document.getElementById('odometer');
-  function onScroll(){
-    var h=document.documentElement.scrollHeight-innerHeight;
-    var f=h>0?scrollY/h:0; var pct=Math.round(f*100);
+  var progTick=false;
+  function paintProgress(){
+    var f=docMax>0?scrollY/docMax:0; var pct=Math.round(f*100);
     bar.style.width=pct+'%';
     plabel.textContent='job search: '+pct+'% complete · est. time remaining: ∞';
     odo.textContent='rejections survived: '+(1247+Math.floor(f*312)).toLocaleString('en-US');
+    progTick=false;
   }
-  addEventListener('scroll', onScroll, {passive:true}); onScroll();
+  function onScroll(){ if(!progTick){ progTick=true; requestAnimationFrame(paintProgress); } }
+  addEventListener('scroll', onScroll, {passive:true}); paintProgress();
 
   /* ---- scroll scenes: per-section --p (0→1 through the viewport) and --c
-         (1 when centred) drive the parallax/scrub CSS above. rAF-throttled. ---- */
-  var scenes = document.querySelectorAll('.stage, .testi, .finale'), sceneTick=false;
+         (1 when centred) drive the parallax/scrub CSS above. rAF-throttled.
+         READ pass (all getBoundingClientRect calls) happens before any WRITE,
+         and writes are skipped when the rounded value hasn't changed. ---- */
+  var scenes = document.querySelectorAll('.stage, .finale'), sceneTick=false;
   function paintScenes(){
+    var sy = scrollY;
     var vh = innerHeight || document.documentElement.clientHeight;
-    var maxS = document.documentElement.scrollHeight - vh;
+    var maxS = docMax;
+    /* READ pass: collect all rects first, no style writes */
+    var rects = [];
+    for(var i=0;i<scenes.length;i++) rects.push(scenes[i].getBoundingClientRect());
+    /* WRITE pass: compute and conditionally apply --p / --c */
     for(var i=0;i<scenes.length;i++){
-      var s=scenes[i], r=s.getBoundingClientRect();
+      var s=scenes[i], r=rects[i];
       var p=(vh - r.top)/(vh + r.height);
       /* sections near the document end can never travel fully past the
          viewport, so raw --p tops out below 1 and their scroll-scrubbed
          strokes would stay half-drawn — rescale by the progress this
          section can actually reach at full scroll */
-      var pm=(vh - (r.top + scrollY - maxS))/(vh + r.height);
+      var pm=(vh - (r.top + sy - maxS))/(vh + r.height);
       if(pm>0 && pm<1) p/=pm;
       p = p<0?0:(p>1?1:p);
       var mid=r.top + r.height/2;
       var c=1 - Math.min(1, Math.abs(mid - vh/2)/(vh/2 + r.height/2));
-      s.style.setProperty('--p', p.toFixed(4));
-      s.style.setProperty('--c', c.toFixed(4));
+      var pf=p.toFixed(4), cf=c.toFixed(4);
+      if(pf !== s.__p){ s.style.setProperty('--p', pf); s.__p=pf; }
+      if(cf !== s.__c){ s.style.setProperty('--c', cf); s.__c=cf; }
     }
     sceneTick=false;
   }
@@ -1100,8 +1118,7 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
 
     function paintJourney(){
       if(!built) return;
-      var max=document.documentElement.scrollHeight-innerHeight;
-      var p=max>0?Math.min(1,Math.max(0,scrollY/max)):0;
+      var p=docMax>0?Math.min(1,Math.max(0,scrollY/docMax)):0;
       drawOne(line, tip, tbl, len, p);
       drawOne(line2, tip2, tbl2, len2, p);
     }
@@ -1109,9 +1126,13 @@ svg.inkline{display:block; margin:0 auto; pointer-events:none; overflow:visible;
     var jt=false;
     addEventListener('scroll', function(){ if(!jt){ jt=true; requestAnimationFrame(function(){ jt=false; paintJourney(); }); } }, {passive:true});
     var rt; addEventListener('resize', function(){ clearTimeout(rt); rt=setTimeout(build, 180); });
-    addEventListener('load', build);
-    setTimeout(build, 1800);   /* re-measure after webfonts settle layout */
-    build();
+    addEventListener('load', function(){ build(); measureDoc(); });
+    if(document.fonts && document.fonts.ready){            /* re-measure after webfonts settle layout */
+      document.fonts.ready.then(function(){ build(); measureDoc(); });
+    } else {
+      setTimeout(function(){ build(); measureDoc(); }, 1800);
+    }
+    build(); measureDoc();
   })();
 
   /* ---- poke a doodle: it mumbles in-character (voice per mood) ---- */

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -248,7 +248,7 @@ footer{margin-top:60px; text-align:center}
   <footer>
     <p class="byline">made by Saeed, between rejections.</p>
     <p class="foot-links">
-      <a href="/">home</a> · <a href="/creature">▶ the short film</a> · privacy
+      <a href="/">home</a> · <a href="/creature">▶ the short film</a> · privacy · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener">♥ sponsor</a>
     </p>
   </footer>
 

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -410,12 +410,17 @@
   "settings": {
     "groups": {
       "preferences": "Einstellungen",
-      "system": "System"
+      "system": "System",
+      "about": "Über"
     },
     "sections": {
       "general": {
         "label": "Allgemein",
-        "description": "Name, Sprache, Aussehen"
+        "description": "Name, Sprache & Startverhalten"
+      },
+      "appearance": {
+        "label": "Aussehen",
+        "description": "Design, Akzentfarbe & Textgröße"
       },
       "contact": {
         "label": "Kontaktprofil",
@@ -448,6 +453,10 @@
       "developer": {
         "label": "Entwickler",
         "description": "Debug-Werkzeuge & Diagnose"
+      },
+      "about": {
+        "label": "Die Suche unterstützen",
+        "description": "App-Info & Unterstützungsmöglichkeiten"
       }
     },
     "applicant": {
@@ -517,6 +526,13 @@
       "debugModeHint": "Ausführliche Protokollierung und Diagnose-Overlays aktivieren",
       "openDevtools": "DevTools-Konsole öffnen"
     },
+    "about": {
+      "title": "Die Suche unterstützen",
+      "pitch": "Wenn diese App dir einige Nächte erspart hat, kannst du etwas zurückgeben — jeder Beitrag hilft.",
+      "githubSponsors": "Auf GitHub sponsern",
+      "kofi": "Einen Kaffee auf Ko-fi spendieren",
+      "paypal": "Trinkgeld via PayPal senden"
+    },
     "profile": {
       "title": "Profil",
       "displayName": "Anzeigename",
@@ -525,6 +541,32 @@
     },
     "language": {
       "title": "Sprache"
+    },
+    "appearance": {
+      "title": "Aussehen",
+      "scheme": "Design",
+      "light": "Hell",
+      "dark": "Dunkel",
+      "system": "System",
+      "textSize": "Textgröße",
+      "textSmall": "Klein",
+      "textDefault": "Standard",
+      "textLarge": "Groß",
+      "reduceTransparency": "Transparenz reduzieren",
+      "reduceTransparencyHint": "Undurchsichtige Flächen statt Milchglas verwenden.",
+      "increaseContrast": "Kontrast erhöhen",
+      "increaseContrastHint": "Stärkere Rahmen und Trennlinien.",
+      "accent": "Akzentfarbe",
+      "accentHint": "Färbt Schaltflächen, Links und Hervorhebungen in der gesamten App.",
+      "accentDefault": "Standard",
+      "accentViolet": "Violett",
+      "accentBlue": "Blau",
+      "accentGreen": "Grün",
+      "accentOrange": "Orange",
+      "accentPink": "Rosa",
+      "accentRed": "Rot",
+      "accentYellow": "Gelb",
+      "accentGraphite": "Graphit"
     },
     "onboarding": {
       "title": "Einführungsassistent",
@@ -1805,6 +1847,10 @@
           "label": "Allgemein",
           "description": "Name, Sprache, Aussehen"
         },
+        "appearance": {
+          "label": "Aussehen",
+          "description": "Design, Akzentfarbe & Textgröße"
+        },
         "contact": {
           "label": "Kontaktprofil",
           "description": "Kopfzeilen-Angaben & Profillinks"
@@ -2237,6 +2283,16 @@
     "notFound": "Diese Stellenanzeige konnte nicht gelesen werden — Beschreibung manuell einfügen.",
     "failed": "Import fehlgeschlagen. URL prüfen und erneut versuchen.",
     "imported": "Importiert"
+  },
+  "updater": {
+    "available": "v{{version}} ist verfügbar",
+    "downloading": "Update wird heruntergeladen… {{percent}}%",
+    "downloaded": "v{{version}} ist bereit zur Installation",
+    "downloadButton": "Herunterladen",
+    "installButton": "Neu starten & installieren",
+    "checking": "Suche nach Updates…",
+    "upToDate": "Du verwendest die neueste Version.",
+    "checkFailed": "Update-Prüfung fehlgeschlagen."
   },
   "resumeReview": {
     "title": "Extrahierten Lebenslauf prüfen",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -410,7 +410,8 @@
   "settings": {
     "groups": {
       "preferences": "Preferences",
-      "system": "System"
+      "system": "System",
+      "about": "About"
     },
     "sections": {
       "general": {
@@ -452,6 +453,10 @@
       "developer": {
         "label": "Developer",
         "description": "Debug tools & diagnostics"
+      },
+      "about": {
+        "label": "Fund the hunt",
+        "description": "App info & ways to chip in"
       }
     },
     "applicant": {
@@ -520,6 +525,13 @@
       "debugMode": "Debug mode",
       "debugModeHint": "Enable verbose logging and diagnostic overlays",
       "openDevtools": "Open DevTools Console"
+    },
+    "about": {
+      "title": "Fund the hunt",
+      "pitch": "If this app saved you some 3am despair, you can chip in — any amount helps keep it going.",
+      "githubSponsors": "Sponsor on GitHub",
+      "kofi": "Buy a coffee on Ko-fi",
+      "paypal": "Send a tip via PayPal"
     },
     "profile": {
       "title": "Profile",


### PR DESCRIPTION
## What

Landing-site polish + a new sponsorship/donations setup, plus an i18n parity fix. All code changes were implemented by the repo's domain agents and reviewed.

### 💛 Sponsorship / donations
- `.github/FUNDING.yml` → repo Sponsor button (GitHub Sponsors + Ko-fi + PayPal custom URL).
- README "Fund the job hunt" section, with a note that donations don't conflict with the PolyForm Noncommercial license.
- Landing finale donate CTA + a "♥ sponsor" footer link across 8 landing pages.
- In-app **Settings → About** tab (`AboutTab`) — app version + 3 external donate links, reusing `useOpenExternal` / `useAppVersion`, en+de strings, `@ajh/ui` primitives.

### 🎨 Landing: `agent-system.html` redesign
- Replaced the hard-to-read hand-drawn doodle aesthetic with a clean, readable dark UI (Space Grotesk + system sans).
- Added scroll-reveal, hover, count-up, route-swap and pipeline animations — all transform/opacity, `prefers-reduced-motion` gated.
- Fixed the overlapping/clipped fleet-map risk nodes (`tauri-security-reviewer` / `performance-profiler`).

### ⚡ Landing: `index.html` scroll performance
Three rounds of jank removal, all visual behavior preserved:
- Removed the `mix-blend-mode` grain overlay + a second blend layer; dropped the journey drop-shadow.
- Split `paintScenes` into read-pass / write-pass to kill layout thrashing; skip unchanged `--p`/`--c` writes.
- Cached `scrollHeight` (`docMax`); rAF-throttled the progress bar; removed redundant `will-change`.
- Layer-isolated the journey SVG (`contain:paint` + `translateZ(0)`); `content-visibility` on the off-screen feed; rebuild on `document.fonts.ready`.

### 📚 Docs + i18n
- Added the agent-system page to the README documentation table.
- Synced DE locale with the EN source: filled 34 missing keys (`settings.appearance.*`, `updater.*`, support sections) → EN/DE now at full parity (1936 / 1936); fixed a stale `general.description`.

## Notes
- GitHub Sponsors + Ko-fi links resolve once those accounts are enrolled/created; PayPal is live.
- The in-app About tab reaches users with the next release.
- Pre-push typecheck (cache-bypassed) caught a removed lucide brand icon + a `SettingsSection` type drift — both fixed in this branch.

## Test plan
- `pnpm typecheck` green (pre-push, cache-bypassed).
- lint-staged (eslint + prettier) clean on commit; `lint:strict` green in the frontend review.
- EN/DE key parity verified deterministically (0 missing, 0 extra).
- Manual: reload landing pages (smooth scroll, dark agent-system), open Settings → About.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "About" section in settings featuring funding and donation options.
  * Introduced appearance customization settings including theme scheme, text sizing, transparency/contrast toggles, and accent color palette.
  * Added updater translations for application update management.

* **Documentation**
  * Expanded README documentation table with additional interactive walkthrough resources.

* **Chores**
  * Configured repository funding links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->