### PR TITLE
fix(data): surface partial restore failures instead of reporting success

### DIFF
--- a/apps/tauri/src-tauri/src/ai_generations/mod.rs
+++ b/apps/tauri/src-tauri/src/ai_generations/mod.rs
@@ -337,8 +337,7 @@ impl AiGenerationStore {
 
     pub fn remove(&self, id: &str) -> AppResult<()> {
         let conn = self.conn.lock();
-        conn.execute("DELETE FROM ai_generations WHERE id = ?1", params![id])
-            .map_err(|e| e.to_string())?;
+        conn.execute("DELETE FROM ai_generations WHERE id = ?1", params![id])?;
         Ok(())
     }
 
@@ -353,9 +352,7 @@ impl AiGenerationStore {
         let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         let sql = format!("DELETE FROM ai_generations WHERE id IN ({placeholders})");
         let conn = self.conn.lock();
-        let deleted = conn
-            .execute(&sql, rusqlite::params_from_iter(ids.iter()))
-            .map_err(|e| e.to_string())?;
+        let deleted = conn.execute(&sql, rusqlite::params_from_iter(ids.iter()))?;
         Ok(deleted)
     }
 
@@ -364,12 +361,10 @@ impl AiGenerationStore {
     /// everything". Idempotent: an Application with no documents deletes 0 rows.
     pub fn remove_for_application(&self, application_id: &str) -> AppResult<usize> {
         let conn = self.conn.lock();
-        let deleted = conn
-            .execute(
-                "DELETE FROM ai_generations WHERE application_id = ?1",
-                params![application_id],
-            )
-            .map_err(|e| e.to_string())?;
+        let deleted = conn.execute(
+            "DELETE FROM ai_generations WHERE application_id = ?1",
+            params![application_id],
+        )?;
         Ok(deleted)
     }
 
@@ -379,12 +374,10 @@ impl AiGenerationStore {
     /// tracking only (keep documents)".
     pub fn detach_application(&self, application_id: &str) -> AppResult<usize> {
         let conn = self.conn.lock();
-        let updated = conn
-            .execute(
-                "UPDATE ai_generations SET application_id = NULL WHERE application_id = ?1",
-                params![application_id],
-            )
-            .map_err(|e| e.to_string())?;
+        let updated = conn.execute(
+            "UPDATE ai_generations SET application_id = NULL WHERE application_id = ?1",
+            params![application_id],
+        )?;
         Ok(updated)
     }
 
@@ -402,24 +395,18 @@ impl AiGenerationStore {
     ) -> AppResult<()> {
         let conn = self.conn.lock();
         let changed = match (resume_text, cover_letter_text) {
-            (Some(resume), Some(cover)) => conn
-                .execute(
-                    "UPDATE ai_generations SET resume_text = ?2, cover_letter_text = ?3 WHERE id = ?1",
-                    params![id, resume, cover],
-                )
-                .map_err(|e| e.to_string())?,
-            (Some(resume), None) => conn
-                .execute(
-                    "UPDATE ai_generations SET resume_text = ?2 WHERE id = ?1",
-                    params![id, resume],
-                )
-                .map_err(|e| e.to_string())?,
-            (None, Some(cover)) => conn
-                .execute(
-                    "UPDATE ai_generations SET cover_letter_text = ?2 WHERE id = ?1",
-                    params![id, cover],
-                )
-                .map_err(|e| e.to_string())?,
+            (Some(resume), Some(cover)) => conn.execute(
+                "UPDATE ai_generations SET resume_text = ?2, cover_letter_text = ?3 WHERE id = ?1",
+                params![id, resume, cover],
+            )?,
+            (Some(resume), None) => conn.execute(
+                "UPDATE ai_generations SET resume_text = ?2 WHERE id = ?1",
+                params![id, resume],
+            )?,
+            (None, Some(cover)) => conn.execute(
+                "UPDATE ai_generations SET cover_letter_text = ?2 WHERE id = ?1",
+                params![id, cover],
+            )?,
             // Both fields absent: no UPDATE is issued, so there is no
             // rows-changed count to check — an explicit no-op success.
             (None, None) => return Ok(()),

--- a/apps/tauri/src-tauri/src/commands/data.rs
+++ b/apps/tauri/src-tauri/src/commands/data.rs
@@ -214,6 +214,7 @@ pub async fn data_import(app: AppHandle) -> Value {
     }
 
     let mut imported = serde_json::Map::new();
+    let mut had_error = false;
     let mut import_into = |key: &str, store: &dyn DataStore| {
         if let Some(data) = stores.get(key) {
             match store.import(data) {
@@ -221,6 +222,7 @@ pub async fn data_import(app: AppHandle) -> Value {
                     imported.insert(key.to_string(), json!(n));
                 }
                 Err(e) => {
+                    had_error = true;
                     imported.insert(key.to_string(), json!({ "error": e }));
                 }
             }
@@ -251,12 +253,25 @@ pub async fn data_import(app: AppHandle) -> Value {
     }
     if let Some(s) = app.try_state::<Mutex<InteractionStore>>() {
         if let Some(data) = stores.get("interactions") {
-            let records: Vec<InteractionRecord> =
-                serde_json::from_value(data.clone()).unwrap_or_default();
-            let n = s.lock().import_bundle(records);
-            imported.insert("interactions".to_string(), json!(n));
+            match serde_json::from_value::<Vec<InteractionRecord>>(data.clone()) {
+                Ok(records) => {
+                    let n = s.lock().import_bundle(records);
+                    imported.insert("interactions".to_string(), json!(n));
+                }
+                Err(e) => {
+                    had_error = true;
+                    imported.insert(
+                        "interactions".to_string(),
+                        json!({ "error": e.to_string() }),
+                    );
+                }
+            }
         }
     }
 
-    json!({ "success": true, "imported": Value::Object(imported) })
+    json!({
+        "success": !had_error,
+        "partial": had_error,
+        "imported": Value::Object(imported),
+    })
 }

--- a/apps/tauri/src/renderer/features/settings/components/privacy/PrivacySettingsTab/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/privacy/PrivacySettingsTab/index.tsx
@@ -90,6 +90,8 @@ export function PrivacySettingsTab() {
         notify.success({
           message: t('settings.privacy.importSuccess', { count, plural: count === 1 ? '' : 's' }),
         });
+      } else if (res.partial) {
+        notify.error({ message: t('settings.privacy.importPartial') });
       } else if (res.error) notify.error({ message: t('settings.privacy.somethingWentWrong') });
     } catch {
       notify.error({ message: t('settings.privacy.somethingWentWrong') });

--- a/packages/shared/src/ipc/contracts/data.ts
+++ b/packages/shared/src/ipc/contracts/data.ts
@@ -6,6 +6,8 @@ export interface DataContract {
   /** Restore all user data from a user-chosen backup file (replace semantics). */
   import(): Promise<{
     success: boolean;
+    /** True when one or more stores failed to restore (others may have succeeded). */
+    partial?: boolean;
     imported?: Record<string, number | { error: string }>;
     error?: string;
   }>;

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -697,7 +697,8 @@
       "signedOutSuccess": "Von allen Konten abgemeldet. Neuverbindung über Einstellungen → Konten.",
       "historyClearedSuccess": "Interaktionsverlauf gelöscht.",
       "exportSuccess": "Daten erfolgreich exportiert.",
-      "importSuccess": "{{count}} Datensatz{{plural}} importiert."
+      "importSuccess": "{{count}} Datensatz{{plural}} importiert.",
+      "importPartial": "Einige Elemente konnten nicht wiederhergestellt werden. Ihre Daten sind möglicherweise unvollständig."
     },
     "location": {
       "title": "Bevorzugter Standort",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -697,7 +697,8 @@
       "signedOutSuccess": "Signed out of all accounts. Reconnect via Settings → Accounts.",
       "historyClearedSuccess": "Interaction history cleared.",
       "exportSuccess": "Data exported successfully.",
-      "importSuccess": "Imported {{count}} record{{plural}}."
+      "importSuccess": "Imported {{count}} record{{plural}}.",
+      "importPartial": "Some items could not be restored. Your data may be incomplete."
     },
     "location": {
       "title": "Preferred Location",


### PR DESCRIPTION
## What

Fleet-audit **HIGH** (data integrity): `data_import` (Settings → Privacy → restore) returned `success: true` even when an individual store's import failed — the user saw an "imported N items" success toast after a partial/failed restore. The interactions section also silently restored 0 records on malformed input via `unwrap_or_default()`.

## Changes

- **`commands/data.rs`** — track `had_error` across all 7 store imports + the interactions deserialize; return `{ success: !had_error, partial: had_error, imported }`. Replaced the interactions `unwrap_or_default()` silent-swallow with an explicit error captured into the result map.
- **`contracts/data.ts`** — add `partial?: boolean` to the `data:import` return type.
- **`PrivacySettingsTab`** — branch on `res.partial` → error toast; no false success toast on a partial restore.
- **`translations` en + de** — new `settings.privacy.importPartial` key (no hardcoded English).
- **`ai_generations/mod.rs`** (LOW, same domain) — drop `.map_err(|e| e.to_string())` on 5 methods' rusqlite calls so failures keep the typed `AppError::Storage` category instead of being stringified.

## Validation

`cargo check` ✅ · full `tsc` ✅ · eslint ✅ · translation JSON valid ✅
Reviewed by `rust-backend-architect`: **no HIGH/CRITICAL** — correctness (every failure path sets the flag), borrow-checker soundness, and contract/renderer lockstep all confirmed.

## Notes

- Cross-store restore remains non-atomic (separate SQLite files — pre-existing); this PR *surfaces* the partial state rather than hiding it.
- May need a trivial rebase against the upcoming `refactor(rust): centralize now_ms` PR, which also touches `data.rs` / `ai_generations`.

_Part of a multi-PR fleet-audit cleanup (per-domain PRs for independent review)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data import error handling to better track failures and provide clearer feedback when some items restore successfully while others encounter issues.
  * Enhanced import notifications to distinguish between complete and partial success scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->