### PR TITLE
fix(security): restrict system_open_external to http and https schemes

### DIFF
--- a/apps/tauri/src-tauri/src/commands/system/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/system/mod.rs
@@ -155,8 +155,20 @@ pub fn system_open_devtools(app: AppHandle) {
 #[tauri::command]
 pub async fn system_open_external(app: AppHandle, url: String) -> AppResult<()> {
     use tauri_plugin_opener::OpenerExt;
+
+    // Allowlist web schemes only. The renderer passes this URL through to the OS
+    // opener, so without a scheme check a `file:`/custom-scheme URL would launch
+    // an arbitrary handler. Case-insensitive: URL schemes are not case-sensitive.
+    let trimmed = url.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if !(lower.starts_with("http://") || lower.starts_with("https://")) {
+        return Err(AppError::Message(
+            "system_open_external: only http(s) URLs are allowed".to_string(),
+        ));
+    }
+
     app.opener()
-        .open_url(&url, None::<&str>)
+        .open_url(trimmed, None::<&str>)
         .map_err(|e| AppError::Message(e.to_string()))
 }
 

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
     ],
     "macOSPrivateApi": false,
     "security": {
-      "csp": "default-src 'self' tauri: asset: https://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: https://asset.localhost; font-src 'self' data: asset: https://asset.localhost; connect-src 'self' http://127.0.0.1:11434 http://127.0.0.1:* ws://127.0.0.1:* tauri: ipc: http://ipc.localhost"
+      "csp": "default-src 'self' tauri: asset: https://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: https://asset.localhost; font-src 'self' data: asset: https://asset.localhost; connect-src 'self' http://127.0.0.1:11434 ws://127.0.0.1:47615 ws://127.0.0.1:47616 ws://127.0.0.1:47617 ws://127.0.0.1:47618 ws://127.0.0.1:47619 ws://127.0.0.1:47620 tauri: ipc: http://ipc.localhost"
     }
   },
   "bundle": {


### PR DESCRIPTION
## What

Two fleet-audit security findings:

- **[HIGH]** `system_open_external` handed the renderer-supplied URL straight to the OS opener with **no scheme check** — `file:`/`javascript:`/custom-scheme passthrough.
- **[LOW]** CSP `connect-src` carried wildcard loopback (`http://127.0.0.1:*`, `ws://127.0.0.1:*`), drifting from the documented Ollama-only decision.

## Changes

- **`commands/system/mod.rs`** — allowlist `http`/`https` only. Case-insensitive, trimmed `starts_with` check (`url` is not a dependency); rejects with a typed `AppError`. The **trimmed** value is what's opened (no TOCTOU). Valid http(s) behavior preserved.
- **`tauri.conf.json`** — narrow `connect-src` loopback to exact ports: Ollama `127.0.0.1:11434` + the extension-bridge WS range `ws://127.0.0.1:47615..47620` (confirmed against `extension_bridge/mod.rs` `PORT_RANGE`).

## Validation

`cargo fmt --check` ✅ · `cargo check` ✅ · `cargo clippy -D warnings` ✅ · `prettier --check` ✅
**`tauri-security-reviewer`: no HIGH/CRITICAL.** Verified: every non-http(s) scheme is rejected (no bypass via case/whitespace/scheme-relative/`http:`-no-`//`); no renderer caller passes `mailto:`/`tel:`/`file:` (no functional regression); provider HTTPS + updater egress go through the Rust `net/http.rs` client, not the webview, so the loopback-only narrowing breaks nothing.

## Out of scope (routed to docs/steward)

- Dev CSP in `vite.config.ts:51` still has loopback wildcards.
- `docs/knowledge/security-rules.md` could note the now-pinned bridge WS range.

_Part of a multi-PR fleet-audit cleanup._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by restricting external URL opening to HTTP and HTTPS protocols only, blocking other URL schemes.
  * Strengthened Content Security Policy by restricting WebSocket connections to explicitly defined ports instead of allowing broad wildcards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->