### PR TITLE
perf(db): run sqlite off the async runtime and speed up store hot paths

### DIFF
--- a/apps/tauri/src-tauri/src/autopilot/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot/mod.rs
@@ -373,7 +373,17 @@ impl AutopilotStore {
             v
         };
         if let Ok(json) = serde_json::to_string_pretty(&list) {
-            std::fs::write(&self.data_file, json).ok();
+            // No-op-write skip: many mutations (set_run_status, stamp_last_run, …)
+            // re-serialize identical state. Skip the disk write when the bytes
+            // match what's already persisted — a pure dirty check, NOT debouncing,
+            // so state is still flushed synchronously the instant it changes (no
+            // crash-loss window). A missing/unreadable file never matches → write.
+            let unchanged = std::fs::read_to_string(&self.data_file)
+                .map(|existing| existing == json)
+                .unwrap_or(false);
+            if !unchanged {
+                std::fs::write(&self.data_file, json).ok();
+            }
         }
         *self.cache.lock() = Some(map);
     }

--- a/apps/tauri/src-tauri/src/autopilot/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot/mod.rs
@@ -4,6 +4,7 @@ use parking_lot::Mutex;
 /// Records are persisted to <dataDir>/autopilots.json as a flat JSON array.
 /// All field names are serialised in camelCase to match the TypeScript schema
 /// (`#[serde(rename_all = "camelCase")]`).
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -162,11 +163,7 @@ impl AutopilotStore {
     pub fn list(&self) -> Vec<Autopilot> {
         let map = self.load();
         let mut items: Vec<Autopilot> = map.into_values().collect();
-        items.sort_by(|a, b| {
-            b.created_at
-                .cmp(&a.created_at)
-                .then_with(|| a.id.cmp(&b.id))
-        });
+        items.sort_by(cmp_autopilot_newest_first);
         items
     }
 
@@ -373,11 +370,7 @@ impl AutopilotStore {
     fn save(&self, map: HashMap<String, Autopilot>) {
         let list: Vec<&Autopilot> = {
             let mut v: Vec<&Autopilot> = map.values().collect();
-            v.sort_by(|a, b| {
-                b.created_at
-                    .cmp(&a.created_at)
-                    .then_with(|| a.id.cmp(&b.id))
-            });
+            v.sort_by(|a, b| cmp_autopilot_newest_first(a, b));
             v
         };
         if let Ok(json) = serde_json::to_string_pretty(&list) {
@@ -412,6 +405,15 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+/// Sort autopilots newest-first by `created_at`, breaking ties by `id` so the
+/// order is stable across runs despite the unordered map. Single source of truth
+/// for both the read order (`list`) and the on-disk order (`save`).
+fn cmp_autopilot_newest_first(a: &Autopilot, b: &Autopilot) -> Ordering {
+    b.created_at
+        .cmp(&a.created_at)
+        .then_with(|| a.id.cmp(&b.id))
 }
 
 fn str_field(v: &serde_json::Value, key: &str) -> String {

--- a/apps/tauri/src-tauri/src/autopilot/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot/mod.rs
@@ -162,7 +162,11 @@ impl AutopilotStore {
     pub fn list(&self) -> Vec<Autopilot> {
         let map = self.load();
         let mut items: Vec<Autopilot> = map.into_values().collect();
-        items.sort_by_key(|a| std::cmp::Reverse(a.created_at));
+        items.sort_by(|a, b| {
+            b.created_at
+                .cmp(&a.created_at)
+                .then_with(|| a.id.cmp(&b.id))
+        });
         items
     }
 
@@ -369,7 +373,11 @@ impl AutopilotStore {
     fn save(&self, map: HashMap<String, Autopilot>) {
         let list: Vec<&Autopilot> = {
             let mut v: Vec<&Autopilot> = map.values().collect();
-            v.sort_by_key(|a| std::cmp::Reverse(a.created_at));
+            v.sort_by(|a, b| {
+                b.created_at
+                    .cmp(&a.created_at)
+                    .then_with(|| a.id.cmp(&b.id))
+            });
             v
         };
         if let Ok(json) = serde_json::to_string_pretty(&list) {

--- a/apps/tauri/src-tauri/src/autopilot/test.rs
+++ b/apps/tauri/src-tauri/src/autopilot/test.rs
@@ -291,6 +291,98 @@ fn test_data_store_export_import_preserves_id() {
     assert_eq!(list[0].name, "Test AP");
 }
 
+#[test]
+fn save_skips_disk_write_when_serialized_state_is_unchanged() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+    store.create(serde_json::json!({
+        "name": "AP",
+        "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+        "filter": { "minMatchScore": 50.0 },
+        "schedule": "manual",
+    }));
+
+    // After `create`, disk already holds exactly the serialized JSON, so the
+    // dirty check compares equal and must skip the write. Probe with mtime: a
+    // skipped write never touches the file (mtime frozen); a real rewrite would
+    // bump it. Re-save the identical, unchanged map and assert mtime is stable.
+    let file = temp.path().join("autopilots.json");
+    let before = std::fs::metadata(&file).unwrap().modified().unwrap();
+
+    let map = store.load();
+    store.save(map);
+
+    let after = std::fs::metadata(&file).unwrap().modified().unwrap();
+    assert_eq!(
+        before, after,
+        "identical serialized state must skip the write (mtime unchanged)"
+    );
+    // And the state is preserved, not blanked.
+    assert!(std::fs::read_to_string(&file).unwrap().contains("\"_id\""));
+}
+
+#[test]
+fn save_writes_when_serialized_state_differs() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+    store.create(serde_json::json!({
+        "name": "AP",
+        "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+        "filter": { "minMatchScore": 50.0 },
+        "schedule": "manual",
+    }));
+
+    // Overwrite the file with content that does NOT match the serialized map,
+    // then save the (unchanged) map: the bytes differ, so the write must proceed
+    // and replace the sentinel content with the real serialized JSON.
+    let file = temp.path().join("autopilots.json");
+    std::fs::write(&file, "// stale sentinel content").unwrap();
+
+    let map = store.load();
+    store.save(map);
+
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        !after.contains("stale sentinel"),
+        "differing on-disk content must trigger a write"
+    );
+    assert!(
+        after.contains("\"_id\""),
+        "real serialized state was written"
+    );
+}
+
+#[test]
+fn save_writes_when_file_is_missing() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+    store.create(serde_json::json!({
+        "name": "AP",
+        "target": { "board": "linkedin", "query": "rust", "pages": 1 },
+        "filter": { "minMatchScore": 50.0 },
+        "schedule": "manual",
+    }));
+
+    // A missing/unreadable file never matches the serialized bytes → the write
+    // must proceed so state isn't lost on the first persist after deletion.
+    let file = temp.path().join("autopilots.json");
+    std::fs::remove_file(&file).unwrap();
+    assert!(!file.exists());
+
+    let map = store.load();
+    store.save(map);
+
+    assert!(file.exists(), "missing file is (re)written, not skipped");
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert!(after.contains("\"_id\""), "serialized state was written");
+}
+
 fn found_job(url: &str, found_at: u64) -> FoundJob {
     FoundJob {
         title: "Engineer".into(),

--- a/apps/tauri/src-tauri/src/commands/match_resume.rs
+++ b/apps/tauri/src-tauri/src/commands/match_resume.rs
@@ -106,18 +106,18 @@ async fn score_one(
         formula_version: MATCH_FORMULA_VERSION,
         job_text_hash: &job_text_hash,
     };
-    if let Some(cached) = store.get_match_score(&cache_key) {
+    if let Some(cached) = store.get_match_score_async(cache_key.to_owned_key()).await {
         return cached;
     }
     let (resume_vec, job_vec) = if skip_semantic {
         (None, None)
     } else {
-        let rv = match store.get_vector(&resume.id) {
+        let rv = match store.get_vector_async(&resume.id).await {
             Some(v) if active.matches(&v.space) => Some(v),
             _ => {
                 let v = embed(app, &resume.text).await;
                 if let Some(ref ev) = v {
-                    let _ = store.upsert_vector(&resume.id, ev);
+                    let _ = store.upsert_vector_async(&resume.id, ev).await;
                 }
                 v
             }
@@ -181,7 +181,10 @@ async fn score_one(
         "explanation": explanation,
     });
     if let Ok(s) = serde_json::to_string(&result) {
-        store.upsert_match_score(&cache_key, &s).ok();
+        store
+            .upsert_match_score_async(cache_key.to_owned_key(), s)
+            .await
+            .ok();
     }
     result
 }

--- a/apps/tauri/src-tauri/src/documents/mod.rs
+++ b/apps/tauri/src-tauri/src/documents/mod.rs
@@ -8,6 +8,7 @@ use parking_lot::Mutex;
 /// Ollama is called for embeddings via reqwest; gracefully degrades when
 /// Ollama is not running.
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{params, Connection};
@@ -90,6 +91,52 @@ pub struct MatchScoreKey<'a> {
     pub job_text_hash: &'a str,
 }
 
+impl MatchScoreKey<'_> {
+    /// Copy the borrowed key into an owned form that can cross into a
+    /// `spawn_blocking` (`'static`) closure for the async store methods.
+    pub fn to_owned_key(&self) -> OwnedMatchScoreKey {
+        OwnedMatchScoreKey {
+            resume_id: self.resume_id.to_string(),
+            job_id: self.job_id.to_string(),
+            provider: self.provider.to_string(),
+            model: self.model.to_string(),
+            semantic_enabled: self.semantic_enabled,
+            formula_version: self.formula_version,
+            job_text_hash: self.job_text_hash.to_string(),
+        }
+    }
+}
+
+/// Owned twin of [`MatchScoreKey`]. The borrowed key keeps the hot call site
+/// allocation-free, but a `spawn_blocking` closure must be `Send + 'static`, so
+/// the async store methods take this owned form and borrow it back inside the
+/// closure via [`OwnedMatchScoreKey::as_ref`].
+pub struct OwnedMatchScoreKey {
+    pub resume_id: String,
+    pub job_id: String,
+    pub provider: String,
+    pub model: String,
+    pub semantic_enabled: i64,
+    pub formula_version: i64,
+    pub job_text_hash: String,
+}
+
+impl OwnedMatchScoreKey {
+    /// Borrow back into a [`MatchScoreKey`] so the shared SQL helper takes one
+    /// key type for both the sync and async paths.
+    pub fn as_ref(&self) -> MatchScoreKey<'_> {
+        MatchScoreKey {
+            resume_id: &self.resume_id,
+            job_id: &self.job_id,
+            provider: &self.provider,
+            model: &self.model,
+            semantic_enabled: self.semantic_enabled,
+            formula_version: self.formula_version,
+            job_text_hash: &self.job_text_hash,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DocumentRecord {
     #[serde(rename = "_id")]
@@ -115,7 +162,11 @@ pub struct DocumentRecord {
 // ── DocumentStore ─────────────────────────────────────────────────────────────
 
 pub struct DocumentStore {
-    conn: Mutex<Connection>,
+    /// Shared so a clone can move into a `spawn_blocking` closure on the hot
+    /// match path (the closure must be `Send + 'static`). `parking_lot::Mutex`
+    /// is not reentrant — never re-lock while a guard is held, and never hold a
+    /// guard across an `.await`.
+    conn: Arc<Mutex<Connection>>,
     /// Monotonic count of `upsert_posting_vector` writes, used to amortize the
     /// posting-vector cache prune onto a cheap cadence (every
     /// [`Self::POSTING_PRUNE_EVERY`] writes) instead of running two DELETEs under
@@ -291,7 +342,7 @@ impl DocumentStore {
         // every `open()`.
         run_migrations(&mut conn, Self::MIGRATIONS)?;
         Ok(Self {
-            conn: Mutex::new(conn),
+            conn: Arc::new(Mutex::new(conn)),
             posting_writes: std::sync::atomic::AtomicU64::new(0),
         })
     }
@@ -425,52 +476,43 @@ impl DocumentStore {
     /// Store a space-tagged vector. The space (`provider`/`model`/`dim`) travels
     /// with the values so comparisons can reject incompatible vectors.
     pub fn upsert_vector(&self, doc_id: &str, v: &EmbeddingVector) -> AppResult<()> {
-        let json = serde_json::to_string(&v.values).map_err(|e| e.to_string())?;
         let conn = self.conn.lock();
-        conn.execute(
-            "INSERT INTO vectors (doc_id, vector, provider, model, dim, version)
-             VALUES (?1, ?2, ?3, ?4, ?5, 1)
-             ON CONFLICT(doc_id) DO UPDATE SET
-                vector = excluded.vector, provider = excluded.provider,
-                model = excluded.model, dim = excluded.dim, version = excluded.version",
-            params![
-                doc_id,
-                json,
-                v.space.provider,
-                v.space.model,
-                v.space.dim as i64
-            ],
-        )
-        .map_err(|e| e.to_string())?;
-        Ok(())
+        upsert_vector_with_conn(&conn, doc_id, v)
+    }
+
+    /// Async variant of [`upsert_vector`] that runs the blocking lock + write on
+    /// a `spawn_blocking` thread, keeping the Tokio worker free on the hot match
+    /// path (`score_one` may call this up to once per job in a 1000-job batch).
+    /// Same write, same return type — callers in async contexts use this.
+    pub async fn upsert_vector_async(&self, doc_id: &str, v: &EmbeddingVector) -> AppResult<()> {
+        let conn = Arc::clone(&self.conn);
+        let doc_id = doc_id.to_string();
+        let v = v.clone();
+        spawn_blocking_db(move || {
+            let conn = conn.lock();
+            upsert_vector_with_conn(&conn, &doc_id, &v)
+        })
+        .await
     }
 
     pub fn get_vector(&self, doc_id: &str) -> Option<EmbeddingVector> {
         let conn = self.conn.lock();
-        conn.query_row(
-            "SELECT vector, provider, model, dim FROM vectors WHERE doc_id = ?1",
-            params![doc_id],
-            |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, i64>(3)?,
-                ))
-            },
-        )
-        .ok()
-        .and_then(|(json, provider, model, dim)| {
-            let values: Vec<f64> = serde_json::from_str(&json).ok()?;
-            Some(EmbeddingVector {
-                values,
-                space: EmbeddingSpace {
-                    provider,
-                    model,
-                    dim: dim as usize,
-                },
-            })
+        get_vector_with_conn(&conn, doc_id)
+    }
+
+    /// Async variant of [`get_vector`] — runs the blocking lock + read off the
+    /// async worker via `spawn_blocking`. A `JoinError` (closure panicked)
+    /// degrades to `None`, matching the sync read's "row missing → None" shape.
+    pub async fn get_vector_async(&self, doc_id: &str) -> Option<EmbeddingVector> {
+        let conn = Arc::clone(&self.conn);
+        let doc_id = doc_id.to_string();
+        tauri::async_runtime::spawn_blocking(move || {
+            let conn = conn.lock();
+            get_vector_with_conn(&conn, &doc_id)
         })
+        .await
+        .ok()
+        .flatten()
     }
 
     // ── Posting-vector cache (translation-aware job embeddings) ───────────────
@@ -634,61 +676,49 @@ impl DocumentStore {
     /// Fetch a cached match-score JSON result for the given key, if present.
     pub fn get_match_score(&self, key: &MatchScoreKey) -> Option<serde_json::Value> {
         let conn = self.conn.lock();
-        // Read-side TTL: an expired-but-not-yet-evicted row is a miss. None ttl = no expiry.
-        let cutoff = ttl_cutoff_ms();
-        conn.query_row(
-            "SELECT score_json FROM match_scores
-             WHERE resume_id = ?1 AND job_id = ?2 AND provider = ?3 AND model = ?4
-               AND semantic_enabled = ?5 AND formula_version = ?6 AND job_text_hash = ?7
-               AND created_at >= ?8",
-            params![
-                key.resume_id,
-                key.job_id,
-                key.provider,
-                key.model,
-                key.semantic_enabled,
-                key.formula_version,
-                key.job_text_hash,
-                cutoff,
-            ],
-            |row| row.get::<_, String>(0),
-        )
+        get_match_score_with_conn(&conn, key)
+    }
+
+    /// Async variant of [`get_match_score`] — runs the blocking lock + read off
+    /// the async worker. Takes an owned [`OwnedMatchScoreKey`] because the
+    /// borrowed [`MatchScoreKey`] can't cross into a `'static` closure. A
+    /// `JoinError` degrades to `None` (a cache miss), so a panicking blocking
+    /// task never poisons the result — `score_one` recomputes the score.
+    pub async fn get_match_score_async(
+        &self,
+        key: OwnedMatchScoreKey,
+    ) -> Option<serde_json::Value> {
+        let conn = Arc::clone(&self.conn);
+        tauri::async_runtime::spawn_blocking(move || {
+            let conn = conn.lock();
+            get_match_score_with_conn(&conn, &key.as_ref())
+        })
+        .await
         .ok()
-        .and_then(|json| serde_json::from_str(&json).ok())
+        .flatten()
     }
 
     /// Store (or replace) the cached match-score JSON result for the given key.
     pub fn upsert_match_score(&self, key: &MatchScoreKey, score_json: &str) -> AppResult<()> {
         let conn = self.conn.lock();
-        conn.execute(
-            "INSERT INTO match_scores
-                (resume_id, job_id, provider, model, semantic_enabled, formula_version,
-                 job_text_hash, score_json, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-             ON CONFLICT(resume_id, job_id, provider, model, semantic_enabled, formula_version, job_text_hash)
-             DO UPDATE SET score_json = excluded.score_json, created_at = excluded.created_at",
-            params![
-                key.resume_id,
-                key.job_id,
-                key.provider,
-                key.model,
-                key.semantic_enabled,
-                key.formula_version,
-                key.job_text_hash,
-                score_json,
-                ts_to_db(now_ms()),
-            ],
-        )
-        .map_err(|e| e.to_string())?;
-        // Lazy per-write eviction, reusing the held lock (must NOT re-lock).
-        let cfg = crate::performance::current();
-        Self::prune_table_locked(
-            &conn,
-            "match_scores",
-            cfg.cache_ttl_secs,
-            cfg.cache_max_rows,
-        );
-        Ok(())
+        upsert_match_score_with_conn(&conn, key, score_json)
+    }
+
+    /// Async variant of [`upsert_match_score`] — runs the blocking write + lazy
+    /// eviction off the async worker. Takes owned key + json so the closure is
+    /// `'static`. The TTL/row-cap prune reads `performance::current()` *inside*
+    /// the closure, reusing the held lock (never re-locks → no deadlock).
+    pub async fn upsert_match_score_async(
+        &self,
+        key: OwnedMatchScoreKey,
+        score_json: String,
+    ) -> AppResult<()> {
+        let conn = Arc::clone(&self.conn);
+        spawn_blocking_db(move || {
+            let conn = conn.lock();
+            upsert_match_score_with_conn(&conn, &key.as_ref(), &score_json)
+        })
+        .await
     }
 
     /// Drop the entire match-result cache (e.g. on embedding-config change).
@@ -860,6 +890,131 @@ pub async fn posting_vector_or_embed(
         .upsert_posting_vector(job_id, &hash, &v)
         .ok();
     Some(v)
+}
+
+// ── Connection-bound SQL helpers ───────────────────────────────────────────────
+//
+// The hot match-path methods (`*_vector` / `*_match_score`) have both a sync
+// form (used by the synchronous `DataStore` trait + tests) and an async form
+// that offloads the blocking lock + query onto `spawn_blocking`. Both share the
+// SQL through these `&Connection`-bound free functions so the query lives in
+// exactly one place. They take `&Connection` (the caller already holds the
+// lock), so they never re-lock — `parking_lot::Mutex` is not reentrant.
+
+fn upsert_vector_with_conn(conn: &Connection, doc_id: &str, v: &EmbeddingVector) -> AppResult<()> {
+    let json = serde_json::to_string(&v.values).map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT INTO vectors (doc_id, vector, provider, model, dim, version)
+         VALUES (?1, ?2, ?3, ?4, ?5, 1)
+         ON CONFLICT(doc_id) DO UPDATE SET
+            vector = excluded.vector, provider = excluded.provider,
+            model = excluded.model, dim = excluded.dim, version = excluded.version",
+        params![
+            doc_id,
+            json,
+            v.space.provider,
+            v.space.model,
+            v.space.dim as i64
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn get_vector_with_conn(conn: &Connection, doc_id: &str) -> Option<EmbeddingVector> {
+    conn.query_row(
+        "SELECT vector, provider, model, dim FROM vectors WHERE doc_id = ?1",
+        params![doc_id],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        },
+    )
+    .ok()
+    .and_then(|(json, provider, model, dim)| {
+        let values: Vec<f64> = serde_json::from_str(&json).ok()?;
+        Some(EmbeddingVector {
+            values,
+            space: EmbeddingSpace {
+                provider,
+                model,
+                dim: dim as usize,
+            },
+        })
+    })
+}
+
+fn get_match_score_with_conn(conn: &Connection, key: &MatchScoreKey) -> Option<serde_json::Value> {
+    // Read-side TTL: an expired-but-not-yet-evicted row is a miss. None ttl = no expiry.
+    let cutoff = ttl_cutoff_ms();
+    conn.query_row(
+        "SELECT score_json FROM match_scores
+         WHERE resume_id = ?1 AND job_id = ?2 AND provider = ?3 AND model = ?4
+           AND semantic_enabled = ?5 AND formula_version = ?6 AND job_text_hash = ?7
+           AND created_at >= ?8",
+        params![
+            key.resume_id,
+            key.job_id,
+            key.provider,
+            key.model,
+            key.semantic_enabled,
+            key.formula_version,
+            key.job_text_hash,
+            cutoff,
+        ],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+    .and_then(|json| serde_json::from_str(&json).ok())
+}
+
+fn upsert_match_score_with_conn(
+    conn: &Connection,
+    key: &MatchScoreKey,
+    score_json: &str,
+) -> AppResult<()> {
+    conn.execute(
+        "INSERT INTO match_scores
+            (resume_id, job_id, provider, model, semantic_enabled, formula_version,
+             job_text_hash, score_json, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(resume_id, job_id, provider, model, semantic_enabled, formula_version, job_text_hash)
+         DO UPDATE SET score_json = excluded.score_json, created_at = excluded.created_at",
+        params![
+            key.resume_id,
+            key.job_id,
+            key.provider,
+            key.model,
+            key.semantic_enabled,
+            key.formula_version,
+            key.job_text_hash,
+            score_json,
+            ts_to_db(now_ms()),
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    // Lazy per-write eviction, reusing the held lock (must NOT re-lock).
+    let cfg = crate::performance::current();
+    DocumentStore::prune_table_locked(conn, "match_scores", cfg.cache_ttl_secs, cfg.cache_max_rows);
+    Ok(())
+}
+
+/// Run a fallible blocking DB closure on the `spawn_blocking` pool and flatten
+/// the `JoinError` into the typed [`AppError`] hierarchy. A panic in the closure
+/// (or pool shutdown) surfaces as an `AppError::Storage`, matching how every
+/// other rusqlite failure on this store is categorized. Used by the write-side
+/// async methods, where the `?`-propagated result must distinguish failure.
+async fn spawn_blocking_db<F>(f: F) -> AppResult<()>
+where
+    F: FnOnce() -> AppResult<()> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(f)
+        .await
+        .map_err(|e| crate::error::AppError::Storage(format!("documents db task failed: {e}")))?
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/apps/tauri/src-tauri/src/documents/mod.rs
+++ b/apps/tauri/src-tauri/src/documents/mod.rs
@@ -902,7 +902,7 @@ pub async fn posting_vector_or_embed(
 // lock), so they never re-lock — `parking_lot::Mutex` is not reentrant.
 
 fn upsert_vector_with_conn(conn: &Connection, doc_id: &str, v: &EmbeddingVector) -> AppResult<()> {
-    let json = serde_json::to_string(&v.values).map_err(|e| e.to_string())?;
+    let json = serde_json::to_string(&v.values)?;
     conn.execute(
         "INSERT INTO vectors (doc_id, vector, provider, model, dim, version)
          VALUES (?1, ?2, ?3, ?4, ?5, 1)
@@ -916,8 +916,7 @@ fn upsert_vector_with_conn(conn: &Connection, doc_id: &str, v: &EmbeddingVector)
             v.space.model,
             v.space.dim as i64
         ],
-    )
-    .map_err(|e| e.to_string())?;
+    )?;
     Ok(())
 }
 

--- a/apps/tauri/src-tauri/src/postings/mod.rs
+++ b/apps/tauri/src-tauri/src/postings/mod.rs
@@ -83,6 +83,12 @@ pub struct InteractionStore {
     /// old `Option<Vec<_>>` cache that forced an O(n) linear scan + a clone of the
     /// whole vector on every interaction event.
     cache: Option<HashMap<InteractionKey, InteractionRecord>>,
+    /// Set true only when a corrupt `interactions.json` was detected but the
+    /// backup rename FAILED (file locked / cross-device / permissions). While it
+    /// is set, `save` refuses to write — overwriting the path would clobber the
+    /// un-backed-up corrupt original and lose the user's recoverable data. A
+    /// successful backup leaves this false so `save` writes fresh data normally.
+    block_save: bool,
 }
 
 impl InteractionStore {
@@ -91,6 +97,7 @@ impl InteractionStore {
         Self {
             data_file: data_dir.join("interactions.json"),
             cache: None,
+            block_save: false,
         }
     }
 
@@ -143,12 +150,28 @@ impl InteractionStore {
     }
 
     /// Borrow the in-memory map, hydrating it from disk on first access.
+    ///
+    /// A *missing* file hydrates an empty map (first run). A file that *exists*
+    /// but fails to parse is NOT silently treated as empty — that would let the
+    /// next `save` overwrite it with an empty array, destroying every recorded
+    /// interaction. Instead the corrupt file is backed up (see
+    /// [`Self::back_up_corrupt_file`]) before we start with an empty map, so the
+    /// data is recoverable and the next `save` can't clobber the original.
     fn map_mut(&mut self) -> &mut HashMap<InteractionKey, InteractionRecord> {
         if self.cache.is_none() {
-            let loaded: Vec<InteractionRecord> = std::fs::read_to_string(&self.data_file)
-                .ok()
-                .and_then(|s| serde_json::from_str(&s).ok())
-                .unwrap_or_default();
+            let loaded: Vec<InteractionRecord> = match std::fs::read_to_string(&self.data_file) {
+                // No file yet — first run, an empty map is correct.
+                Err(_) => Vec::new(),
+                Ok(contents) => match serde_json::from_str(&contents) {
+                    Ok(records) => records,
+                    // The file exists but is malformed. Preserve it before the
+                    // store can overwrite it with an empty map on the next save.
+                    Err(err) => {
+                        self.back_up_corrupt_file(&err);
+                        Vec::new()
+                    }
+                },
+            };
             self.cache = Some(
                 loaded
                     .into_iter()
@@ -157,6 +180,29 @@ impl InteractionStore {
             );
         }
         self.cache.as_mut().expect("cache just initialized")
+    }
+
+    /// Move a malformed `interactions.json` aside to `interactions.json.corrupt`
+    /// so a parse failure never silently discards the user's data. A fixed
+    /// suffix (no timestamp/random source here) is enough: it survives the
+    /// next `save`, which writes back to the original path. The error is logged
+    /// via the shared tracing layer for diagnostics.
+    ///
+    /// If the rename FAILS (file locked / cross-device / permissions) the corrupt
+    /// original still sits at `data_file`, so we set `block_save` to stop the next
+    /// `save` from overwriting it with an empty map. A successful rename frees the
+    /// path and leaves `block_save` false so `save` proceeds normally.
+    fn back_up_corrupt_file(&mut self, err: &serde_json::Error) {
+        let backup = self.data_file.with_extension("json.corrupt");
+        let renamed = std::fs::rename(&self.data_file, &backup).is_ok();
+        if !renamed {
+            self.block_save = true;
+        }
+        log::error!(
+            "[postings] interactions.json failed to parse ({err}); \
+             backed_up={renamed} backup={}",
+            backup.display()
+        );
     }
 
     /// Snapshot the records in a deterministic order (newest first, then by
@@ -177,6 +223,18 @@ impl InteractionStore {
     /// (unchanged shape). Serializes the deterministic snapshot so the file is
     /// stable between writes.
     fn save(&mut self) {
+        // A corrupt original is still sitting at `data_file` because its backup
+        // rename failed. Writing now would clobber the only copy of the user's
+        // recoverable data, so skip the write. The new interaction stays in
+        // memory (lost on restart) — preserving the on-disk original wins.
+        if self.block_save {
+            log::error!(
+                "[postings] save skipped: corrupt interactions.json could not be \
+                 backed up; refusing to overwrite the un-backed-up original at {}",
+                self.data_file.display()
+            );
+            return;
+        }
         let records = self.records();
         if let Ok(json) = serde_json::to_string_pretty(&records) {
             std::fs::write(&self.data_file, json).ok();

--- a/apps/tauri/src-tauri/src/postings/mod.rs
+++ b/apps/tauri/src-tauri/src/postings/mod.rs
@@ -71,9 +71,18 @@ pub struct InteractionRecord {
     pub location: String,
 }
 
+/// Key into the in-memory interaction map: a record is unique per
+/// (`job_id`, `interaction_type`) — the same identity the old linear scan used.
+type InteractionKey = (String, String);
+
 pub struct InteractionStore {
     data_file: PathBuf,
-    cache: Option<Vec<InteractionRecord>>,
+    /// In-memory map keyed by (job_id, interaction_type) for O(1) upsert. Lazily
+    /// hydrated from disk on first access; the flat JSON array on disk is the
+    /// source of truth and is rebuilt from this map on every `save`. Replaces the
+    /// old `Option<Vec<_>>` cache that forced an O(n) linear scan + a clone of the
+    /// whole vector on every interaction event.
+    cache: Option<HashMap<InteractionKey, InteractionRecord>>,
 }
 
 impl InteractionStore {
@@ -86,7 +95,7 @@ impl InteractionStore {
     }
 
     pub fn list(&mut self, filter_type: Option<&str>) -> Vec<InteractionRecord> {
-        let all = self.load();
+        let all = self.records();
         match filter_type {
             Some(t) => all
                 .into_iter()
@@ -97,68 +106,81 @@ impl InteractionStore {
     }
 
     pub fn upsert(&mut self, record: InteractionRecord) {
-        let mut all = self.load();
-        if let Some(existing) = all
-            .iter_mut()
-            .find(|r| r.job_id == record.job_id && r.interaction_type == record.interaction_type)
-        {
-            *existing = record;
-        } else {
-            all.push(record);
-        }
-        self.save(all);
+        let map = self.map_mut();
+        // O(1): a re-interaction with the same (job_id, type) overwrites in place;
+        // a new pair inserts. No full-vector clone, no linear scan.
+        map.insert(
+            (record.job_id.clone(), record.interaction_type.clone()),
+            record,
+        );
+        self.save();
     }
 
     pub fn clear_all(&mut self) {
-        self.save(vec![]);
+        self.cache = Some(HashMap::new());
+        self.save();
     }
 
     /// Export all interactions for the data export feature.
     pub fn export_all(&mut self) -> Vec<InteractionRecord> {
-        self.load()
+        self.records()
     }
 
-    /// Import from an exported bundle, upserting each record.
+    /// Import from an exported bundle, upserting each record. Returns the count
+    /// of records that were newly inserted (not overwrites), matching the old
+    /// behavior exactly.
     pub fn import_bundle(&mut self, records: Vec<InteractionRecord>) -> usize {
-        let mut all = self.load();
+        let map = self.map_mut();
         let mut imported = 0;
-        let mut index: HashMap<(String, String), usize> = all
-            .iter()
-            .enumerate()
-            .map(|(i, r)| ((r.job_id.clone(), r.interaction_type.clone()), i))
-            .collect();
-
         for record in records {
             let key = (record.job_id.clone(), record.interaction_type.clone());
-            if let Some(&idx) = index.get(&key) {
-                all[idx] = record;
-            } else {
-                index.insert(key, all.len());
-                all.push(record);
+            if map.insert(key, record).is_none() {
                 imported += 1;
             }
         }
-        self.save(all);
+        self.save();
         imported
     }
 
-    fn load(&mut self) -> Vec<InteractionRecord> {
-        if let Some(ref c) = self.cache {
-            return c.clone();
+    /// Borrow the in-memory map, hydrating it from disk on first access.
+    fn map_mut(&mut self) -> &mut HashMap<InteractionKey, InteractionRecord> {
+        if self.cache.is_none() {
+            let loaded: Vec<InteractionRecord> = std::fs::read_to_string(&self.data_file)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_default();
+            self.cache = Some(
+                loaded
+                    .into_iter()
+                    .map(|r| ((r.job_id.clone(), r.interaction_type.clone()), r))
+                    .collect(),
+            );
         }
-        let loaded: Vec<InteractionRecord> = std::fs::read_to_string(&self.data_file)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default();
-        self.cache = Some(loaded.clone());
-        loaded
+        self.cache.as_mut().expect("cache just initialized")
     }
 
-    fn save(&mut self, records: Vec<InteractionRecord>) {
+    /// Snapshot the records in a deterministic order (newest first, then by
+    /// id/type) so both `list`/`export_all` and the on-disk file are stable
+    /// across runs despite the unordered map.
+    fn records(&mut self) -> Vec<InteractionRecord> {
+        let mut all: Vec<InteractionRecord> = self.map_mut().values().cloned().collect();
+        all.sort_by(|a, b| {
+            b.timestamp
+                .cmp(&a.timestamp)
+                .then_with(|| a.job_id.cmp(&b.job_id))
+                .then_with(|| a.interaction_type.cmp(&b.interaction_type))
+        });
+        all
+    }
+
+    /// Persist the current map as the flat JSON array the on-disk format expects
+    /// (unchanged shape). Serializes the deterministic snapshot so the file is
+    /// stable between writes.
+    fn save(&mut self) {
+        let records = self.records();
         if let Ok(json) = serde_json::to_string_pretty(&records) {
             std::fs::write(&self.data_file, json).ok();
         }
-        self.cache = Some(records);
     }
 }
 

--- a/apps/tauri/src-tauri/src/postings/test.rs
+++ b/apps/tauri/src-tauri/src/postings/test.rs
@@ -167,6 +167,135 @@ fn test_interaction_store_export_all() {
 }
 
 #[test]
+fn corrupt_interactions_file_is_preserved_not_overwritten() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().to_path_buf();
+    let data_file = data_dir.join("interactions.json");
+
+    // Simulate a file that exists on disk but is malformed (truncated write,
+    // disk corruption, manual edit). The old loader swallowed the parse error
+    // and started from an empty map, so the next save wiped every interaction.
+    std::fs::write(&data_file, b"{ this is not valid json ]").unwrap();
+
+    let mut store = InteractionStore::new(&data_dir);
+    // First access hydrates the cache; the corrupt file is moved aside.
+    let records = store.list(None);
+    assert!(records.is_empty(), "corrupt file loads as empty in-memory");
+
+    // The original bytes are preserved in the backup, NOT silently discarded.
+    let backup = data_dir.join("interactions.json.corrupt");
+    assert!(backup.exists(), "corrupt file is backed up");
+    assert_eq!(
+        std::fs::read_to_string(&backup).unwrap(),
+        "{ this is not valid json ]",
+        "backup keeps the original corrupt bytes"
+    );
+
+    // A subsequent mutation rewrites the primary file (now valid), but the
+    // backup still holds the recoverable original.
+    store.upsert(InteractionRecord {
+        job_id: "job-1".to_string(),
+        interaction_type: "viewed".to_string(),
+        timestamp: 1,
+        title: "Test".to_string(),
+        company: "Test".to_string(),
+        url: "https://example.com".to_string(),
+        source: "test".to_string(),
+        location: "Remote".to_string(),
+    });
+    assert!(backup.exists(), "backup survives the next save");
+}
+
+#[test]
+fn corrupt_file_with_failed_backup_blocks_save_keeping_original() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().to_path_buf();
+    let data_file = data_dir.join("interactions.json");
+    let backup = data_dir.join("interactions.json.corrupt");
+
+    // Corrupt primary file on disk.
+    let original = b"{ this is not valid json ]";
+    std::fs::write(&data_file, original).unwrap();
+
+    // Force the backup rename to FAIL cross-platform: the backup target already
+    // exists as a NON-EMPTY directory, so renaming a file onto it errors on every
+    // OS. This simulates the rename failing (file locked / cross-device / perms).
+    std::fs::create_dir(&backup).unwrap();
+    std::fs::write(backup.join("sentinel"), b"x").unwrap();
+
+    let mut store = InteractionStore::new(&data_dir);
+    // Hydrating sees the corrupt file, attempts the backup, and the rename fails.
+    let records = store.list(None);
+    assert!(records.is_empty(), "corrupt file loads as empty in-memory");
+    assert!(store.block_save, "failed backup arms the save guard");
+
+    // A mutation would normally rewrite the primary file. With the guard armed,
+    // save MUST skip the write so the un-backed-up corrupt original is preserved.
+    store.upsert(InteractionRecord {
+        job_id: "job-1".to_string(),
+        interaction_type: "viewed".to_string(),
+        timestamp: 1,
+        title: "Test".to_string(),
+        company: "Test".to_string(),
+        url: "https://example.com".to_string(),
+        source: "test".to_string(),
+        location: "Remote".to_string(),
+    });
+
+    assert_eq!(
+        std::fs::read(&data_file).unwrap(),
+        original,
+        "save did not overwrite the un-backed-up corrupt original"
+    );
+}
+
+#[test]
+fn successful_backup_leaves_save_unblocked() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().to_path_buf();
+    let data_file = data_dir.join("interactions.json");
+
+    // Corrupt primary file, no obstruction at the backup path → rename succeeds.
+    std::fs::write(&data_file, b"{ not json ]").unwrap();
+
+    let mut store = InteractionStore::new(&data_dir);
+    store.list(None);
+    assert!(
+        !store.block_save,
+        "a successful backup must NOT arm the save guard"
+    );
+
+    // save proceeds: the now-free primary path is rewritten with valid JSON.
+    store.upsert(InteractionRecord {
+        job_id: "job-1".to_string(),
+        interaction_type: "viewed".to_string(),
+        timestamp: 1,
+        title: "Test".to_string(),
+        company: "Test".to_string(),
+        url: "https://example.com".to_string(),
+        source: "test".to_string(),
+        location: "Remote".to_string(),
+    });
+    let written = std::fs::read_to_string(&data_file).unwrap();
+    let parsed: Vec<InteractionRecord> = serde_json::from_str(&written).unwrap();
+    assert_eq!(parsed.len(), 1, "save wrote fresh data to the freed path");
+}
+
+#[test]
+fn missing_interactions_file_loads_empty_without_backup() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().to_path_buf();
+    // No interactions.json written — first run.
+    let mut store = InteractionStore::new(&data_dir);
+    assert!(store.list(None).is_empty());
+    // A missing file is normal, not corruption: no .corrupt backup is created.
+    assert!(
+        !data_dir.join("interactions.json.corrupt").exists(),
+        "missing file must not be treated as corrupt"
+    );
+}
+
+#[test]
 fn test_interaction_store_import_bundle() {
     let dir = TempDir::new().unwrap();
     let data_dir = dir.path().to_path_buf();


### PR DESCRIPTION
## What

Three fleet-audit performance findings:

- **[HIGH]** `DocumentStore` SQLite ran **on the Tokio async runtime** — `score_one` did up to 1000 per-batch blocking lock+query calls, starving the runtime.
- **[MED]** `InteractionStore::upsert` did an O(n) scan + full-file rewrite on every interaction event.
- **[LOW]** `AutopilotStore::save` wrote on every mutation even when state was unchanged.

## Changes

- **`documents/mod.rs` + `commands/match_resume.rs`** — `conn` → `Arc<Mutex<Connection>>`; SQL extracted into shared `*_with_conn(&Connection, …)` free functions (single source of truth); new `*_async` variants `Arc::clone` before `spawn_blocking`, lock+query **inside** the blocking closure. `score_one` now calls the async variants. Sync methods retained for the synchronous `DataStore` import/export trait + tests. `OwnedMatchScoreKey` lets the borrowed key cross into the `'static` closure. JoinError → `AppError::Storage` on writes (not swallowed); reads degrade JoinError → `None` (cache-miss → recompute).
- **`postings/mod.rs`** — InteractionStore re-keyed to `HashMap<(job_id, interaction_type), Record>` → O(1) upsert. On-disk JSON array shape unchanged; `records()` returns a deterministic newest-first snapshot.
- **`autopilot/mod.rs`** — `save` skips `fs::write` when serialized bytes are byte-identical (pure dirty check, **no** debounce/delay → no crash-loss window).

JobTracker conversion deferred (verifier graded it MEDIUM-in-practice; bare owned `Connection`, sprawling).

## Validation

`cargo fmt --check` ✅ · `cargo check` ✅ · `cargo clippy -D warnings` ✅ · `cargo test` documents/postings/autopilot/match_resume/architecture all green
**Reviewed by `performance-profiler` + `rust-backend-architect`: no HIGH/CRITICAL.** HIGH confirmed resolved (no blocking call remains on the async worker in `score_one`); concurrency sound (no guard across `.await`, non-reentrant mutex never re-locked); sync↔async SQL parity byte-verified; key round-trip + InteractionStore dedup/count semantics preserved.

## Notes

- Touches `documents/mod.rs` — may need a trivial rebase against the upcoming `refactor(rust): centralize now_ms` PR.
- Follow-up (out of scope): `commands/ai.rs:429` has a pre-existing sync `upsert_vector` chained with `set_indexed` on the async runtime in the reindex path — needs a `set_indexed` async twin to convert.

_Part of a multi-PR fleet-audit cleanup._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated autopilot listing to show newest items first (with stable ordering for ties).
  * Reduced unnecessary saves for autopilot configurations by avoiding rewrites when data hasn’t changed.
  * Improved resume matching responsiveness by moving key caching/vector steps to async operations.
* **Bug Fixes**
  * Made interaction caching more reliable with faster direct updates, deterministic exports, and safer handling of corrupted `interactions.json` (with automatic backup and protection against overwriting).
* **Tests**
  * Added coverage for autopilot save behavior and interaction-file corruption scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->