### PR TITLE
fix(resume): preserve literal markdown chars and resolve region-suffixed locales

### DIFF
--- a/apps/tauri/src-tauri/src/export/model_docx.rs
+++ b/apps/tauri/src-tauri/src/export/model_docx.rs
@@ -88,7 +88,11 @@ pub(crate) fn generate_resume_docx_in(
 
     // ATS mode collapses to a single column and reorders sections for reading.
     // theme::is_two_column is the single source of truth for two-column gating.
-    let two_column = crate::theme::is_two_column(template.id) && !ats_mode;
+    // Belt-and-suspenders: also require two_column config to be present so a
+    // future template classified as two-column but missing the config falls back
+    // to single-column rather than reaching the expect() in add_two_column_body.
+    let two_column =
+        crate::theme::is_two_column(template.id) && template.two_column.is_some() && !ats_mode;
     if ats_mode {
         transform::linearize(&mut model);
     }

--- a/apps/tauri/src-tauri/src/export/model_docx.rs
+++ b/apps/tauri/src-tauri/src/export/model_docx.rs
@@ -87,7 +87,8 @@ pub(crate) fn generate_resume_docx_in(
     }
 
     // ATS mode collapses to a single column and reorders sections for reading.
-    let two_column = template.two_column.is_some() && !ats_mode;
+    // theme::is_two_column is the single source of truth for two-column gating.
+    let two_column = crate::theme::is_two_column(template.id) && !ats_mode;
     if ats_mode {
         transform::linearize(&mut model);
     }

--- a/apps/tauri/src-tauri/src/export/parser/mod.rs
+++ b/apps/tauri/src-tauri/src/export/parser/mod.rs
@@ -72,17 +72,40 @@ pub fn normalize_unicode(text: &str) -> String {
 
 /// Strip stray Markdown emphasis the model occasionally leaks (`*React`, `AWS*`,
 /// `AWS*-Services`) WITHOUT touching valid `**bold**` runs (the renderer turns those
-/// into real bold) or in-word punctuation like `snake_case`. Runs after
+/// into real bold), in-word punctuation like `snake_case`, or literal `*`/`` ` ``
+/// that sit between two word characters (e.g. `5*4`, `a*b`). Runs after
 /// [`normalize_unicode`], before any Markdown parsing.
 pub fn sanitize_markdown(text: &str) -> String {
-    // Protect valid bold pairs, drop every remaining lone '*' and stray backtick,
-    // then restore the bold markers.
+    // Strategy:
+    // 1. Protect bold pairs (**…**) with a sentinel so the single-* pass ignores them.
+    // 2. Walk the guarded string; keep a `*` or `` ` `` only when it is flanked by a
+    //    word character on BOTH sides (i.e. it is a literal mid-word character like
+    //    `5*4`). A marker at a word boundary (emphasis position) is dropped.
+    // 3. Restore bold markers.
     const BOLD: &str = "\u{0}B\u{0}";
-    text.replace("**", BOLD)
-        .chars()
-        .filter(|&c| c != '*' && c != '`')
-        .collect::<String>()
-        .replace(BOLD, "**")
+    let guarded = text.replace("**", BOLD);
+    let chars: Vec<char> = guarded.chars().collect();
+    let mut out = String::with_capacity(guarded.len());
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch == '*' || ch == '`' {
+            let prev_word = i > 0 && is_word_char(chars[i - 1]);
+            let next_word = i + 1 < chars.len() && is_word_char(chars[i + 1]);
+            if prev_word && next_word {
+                out.push(ch); // literal mid-word char — preserve
+            }
+            // else: emphasis-position marker — drop
+        } else {
+            out.push(ch);
+        }
+    }
+    out.replace(BOLD, "**")
+}
+
+/// Returns `true` when `c` is an ASCII word character (`[A-Za-z0-9_]`).
+/// Mirrors the `\w` class that the `regex` crate would use in ASCII mode.
+#[inline]
+fn is_word_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
 }
 
 /// Typography pass for dash usage. With en/em-dashes preserved by

--- a/apps/tauri/src-tauri/src/export/parser/mod.rs
+++ b/apps/tauri/src-tauri/src/export/parser/mod.rs
@@ -103,8 +103,9 @@ pub fn sanitize_markdown(text: &str) -> String {
 
 /// Returns `true` when `c` is an ASCII word character (`[A-Za-z0-9_]`).
 /// Mirrors the `\w` class that the `regex` crate would use in ASCII mode.
+/// `pub(crate)` so `validate` can import this instead of duplicating it.
 #[inline]
-fn is_word_char(c: char) -> bool {
+pub(crate) fn is_word_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '_'
 }
 

--- a/apps/tauri/src-tauri/src/export/typst_engine/photo.rs
+++ b/apps/tauri/src-tauri/src/export/typst_engine/photo.rs
@@ -104,16 +104,12 @@ fn decode_and_sanitise(raw: &[u8]) -> Option<Vec<u8>> {
         .with_guessed_format()
         .ok()?;
 
-    // Reject formats that are not ordinary raster images.
+    // Reject formats that are not the MIME-gated raster types (png/jpeg/webp/gif).
+    // BMP and TIFF are intentionally excluded: the upstream MIME gate in
+    // `decode_data_url` never admits them, so this branch is dead — keeping it
+    // here would be misleading and could create a gap if the MIME list diverges.
     match reader.format() {
-        Some(
-            ImageFormat::Png
-            | ImageFormat::Jpeg
-            | ImageFormat::WebP
-            | ImageFormat::Gif
-            | ImageFormat::Bmp
-            | ImageFormat::Tiff,
-        ) => {}
+        Some(ImageFormat::Png | ImageFormat::Jpeg | ImageFormat::WebP | ImageFormat::Gif) => {}
         _ => return None,
     }
 

--- a/apps/tauri/src-tauri/src/locale/mod.rs
+++ b/apps/tauri/src-tauri/src/locale/mod.rs
@@ -1,18 +1,14 @@
-//! Locale profiles — per-market document conventions: page size, date style,
-//! photo/PII policy, and default section order.
+//! Locale profiles — per-market document conventions: page size and photo policy.
 //!
-//! Page size + date style feed both backends; section order + photo/PII feed the
-//! AI prompt and model build. Phase 1 ships the `en` default (A4, photos Never,
-//! no personal details) plus the types; the full registry (US, UK, DE/AT/CH, FR,
-//! NL, generic-EU/INTL) is populated in Phase 7.
+//! Page size feeds both PDF and DOCX backends (A4 vs US Letter).  Photo policy
+//! and privacy rules (photo/PII) are surfaced to the AI prompt and UI.
+//! Phase 1 ships the `en` default (A4, photos Never) plus the types; the full
+//! registry (US, UK, DE/AT/CH, FR, NL, generic-EU/INTL) is populated in Phase 7.
 //!
-//! Privacy: photo / personal details are **user-supplied only** — never inferred
-//! or auto-added.
+//! Privacy: photo is **user-supplied only** — never inferred or auto-added.
 #![allow(dead_code)]
 
 pub mod letter;
-
-use crate::model::document::SectionId;
 
 /// Physical page size.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,17 +40,6 @@ impl PageSize {
     }
 }
 
-/// How date ranges are written in the target market.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DateStyle {
-    /// "January 2021 – March 2023"
-    MonthYear,
-    /// "01/2021 – 03/2023"
-    NumericSlash,
-    /// "2021-01 – 2023-03"
-    IsoMonth,
-}
-
 /// Whether a photo is customary on a CV in this market.
 /// User-supplied only — never inferred or auto-added.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,51 +55,8 @@ pub struct LocaleProfile {
     /// Market id ("en", "de", "us", …).
     pub id: &'static str,
     pub page_size: PageSize,
-    pub date_style: DateStyle,
     pub photo: PhotoPolicy,
-    /// Whether personal details (DOB, nationality, marital status) are customary
-    /// in this market. User-supplied only.
-    pub include_personal_details: bool,
-    /// Canonical section ordering for this market (consumed by
-    /// `transform::reorder_sections`).
-    pub default_section_order: &'static [SectionId],
 }
-
-/// Default single-column section order shared by the English/international profile.
-const DEFAULT_ORDER: &[SectionId] = &[
-    SectionId::Summary,
-    SectionId::Experience,
-    SectionId::Skills,
-    SectionId::Projects,
-    SectionId::Education,
-    SectionId::Certifications,
-    SectionId::Languages,
-    SectionId::Awards,
-];
-
-/// US résumés lead with experience and skills; education trails.
-const US_ORDER: &[SectionId] = &[
-    SectionId::Summary,
-    SectionId::Experience,
-    SectionId::Skills,
-    SectionId::Projects,
-    SectionId::Education,
-    SectionId::Certifications,
-    SectionId::Awards,
-    SectionId::Languages,
-];
-
-/// UK/EU CVs give education more prominence (right after experience).
-const EDUCATION_FORWARD_ORDER: &[SectionId] = &[
-    SectionId::Summary,
-    SectionId::Experience,
-    SectionId::Education,
-    SectionId::Skills,
-    SectionId::Languages,
-    SectionId::Certifications,
-    SectionId::Projects,
-    SectionId::Awards,
-];
 
 impl LocaleProfile {
     /// Page geometry for this profile.
@@ -127,12 +69,20 @@ impl LocaleProfile {
     /// international default, so a new/unsupported market always works.
     pub fn get(id: &str) -> LocaleProfile {
         let key = id.trim().to_lowercase();
-        // Match on the leading region/country token (`de-at` → `de`, `en_us` → `en`).
-        let region = key
-            .split(['-', '_'])
-            .next_back()
-            .filter(|s| s.len() == 2)
-            .unwrap_or(key.as_str());
+        // Try both the leading token and the trailing token — whichever matches a
+        // known region wins.  This handles both `en-US` (leading `en` → intl but
+        // trailing `us` → US Letter) and `de-AT` (leading `de` → DACH) correctly.
+        // Prefer the leading token when both match (family-first: `de-AT` → `de`).
+        let mut parts = key.split(['-', '_']).filter(|s| s.len() == 2);
+        let first = parts.next().unwrap_or(key.as_str());
+        let last = parts.next_back().unwrap_or(first);
+        let region = if Self::is_known_region(first) {
+            first
+        } else if Self::is_known_region(last) {
+            last
+        } else {
+            key.as_str()
+        };
         match region {
             "us" => Self::us(),
             "uk" | "gb" => Self::uk(),
@@ -142,6 +92,14 @@ impl LocaleProfile {
             "eu" => Self::eu(),
             _ => Self::intl(),
         }
+    }
+
+    /// Returns `true` when `token` is a supported region/market code.
+    fn is_known_region(token: &str) -> bool {
+        matches!(
+            token,
+            "us" | "uk" | "gb" | "de" | "at" | "ch" | "fr" | "nl" | "eu" | "dach"
+        )
     }
 
     /// Every supported market profile (for the recommender and UI pickers).
@@ -168,82 +126,61 @@ impl LocaleProfile {
         LocaleProfile {
             id: "en",
             page_size: PageSize::A4,
-            date_style: DateStyle::MonthYear,
             photo: PhotoPolicy::Never,
-            include_personal_details: false,
-            default_section_order: DEFAULT_ORDER,
         }
     }
 
-    /// United States — US Letter, no photo, no personal details.
+    /// United States — US Letter, no photo.
     pub fn us() -> LocaleProfile {
         LocaleProfile {
             id: "us",
             page_size: PageSize::Letter,
-            date_style: DateStyle::MonthYear,
             photo: PhotoPolicy::Never,
-            include_personal_details: false,
-            default_section_order: US_ORDER,
         }
     }
 
-    /// United Kingdom — A4, no photo, education-forward.
+    /// United Kingdom — A4, no photo.
     pub fn uk() -> LocaleProfile {
         LocaleProfile {
             id: "uk",
             page_size: PageSize::A4,
-            date_style: DateStyle::MonthYear,
             photo: PhotoPolicy::Never,
-            include_personal_details: false,
-            default_section_order: EDUCATION_FORWARD_ORDER,
         }
     }
 
-    /// DACH (DE/AT/CH) — A4, photo common, personal details customary.
+    /// DACH (DE/AT/CH) — A4, photo common.
     pub fn dach() -> LocaleProfile {
         LocaleProfile {
             id: "dach",
             page_size: PageSize::A4,
-            date_style: DateStyle::NumericSlash,
             photo: PhotoPolicy::Common,
-            include_personal_details: true,
-            default_section_order: EDUCATION_FORWARD_ORDER,
         }
     }
 
-    /// France — A4, photo optional, personal details customary.
+    /// France — A4, photo optional.
     pub fn fr() -> LocaleProfile {
         LocaleProfile {
             id: "fr",
             page_size: PageSize::A4,
-            date_style: DateStyle::NumericSlash,
             photo: PhotoPolicy::Optional,
-            include_personal_details: true,
-            default_section_order: EDUCATION_FORWARD_ORDER,
         }
     }
 
-    /// Netherlands — A4, photo optional, no personal details.
+    /// Netherlands — A4, photo optional.
     pub fn nl() -> LocaleProfile {
         LocaleProfile {
             id: "nl",
             page_size: PageSize::A4,
-            date_style: DateStyle::MonthYear,
             photo: PhotoPolicy::Optional,
-            include_personal_details: false,
-            default_section_order: EDUCATION_FORWARD_ORDER,
         }
     }
 
-    /// Generic EU — A4, photo optional, education-forward.
+    /// Generic EU — A4, photo optional.
     pub fn eu() -> LocaleProfile {
         LocaleProfile {
             id: "eu",
             page_size: PageSize::A4,
-            date_style: DateStyle::MonthYear,
             photo: PhotoPolicy::Optional,
-            include_personal_details: false,
-            default_section_order: EDUCATION_FORWARD_ORDER,
         }
     }
 }
@@ -283,7 +220,6 @@ mod tests {
         assert_eq!(p.id, "en");
         assert_eq!(p.page_size, PageSize::A4);
         assert_eq!(p.photo, PhotoPolicy::Never);
-        assert!(!p.include_personal_details);
         assert_eq!(
             p.page_geometry(),
             PageGeometry {
@@ -300,27 +236,18 @@ mod tests {
     }
 
     #[test]
-    fn default_order_starts_with_summary_then_experience() {
-        let order = LocaleProfile::en().default_section_order;
-        assert_eq!(order.first(), Some(&SectionId::Summary));
-        assert_eq!(order.get(1), Some(&SectionId::Experience));
-    }
-
-    #[test]
     fn us_is_letter_sized_without_photo() {
         let us = LocaleProfile::get("us");
         assert_eq!(us.page_size, PageSize::Letter);
         assert_eq!(us.photo, PhotoPolicy::Never);
-        assert!(!us.include_personal_details);
     }
 
     #[test]
-    fn dach_uses_photo_and_personal_details() {
+    fn dach_uses_photo_common() {
         let de = LocaleProfile::get("de");
         assert_eq!(de.id, "dach");
         assert_eq!(de.page_size, PageSize::A4);
         assert_eq!(de.photo, PhotoPolicy::Common);
-        assert!(de.include_personal_details);
         // AT and CH resolve to the same DACH profile.
         assert_eq!(LocaleProfile::get("at"), de);
         assert_eq!(LocaleProfile::get("ch"), de);
@@ -328,9 +255,20 @@ mod tests {
 
     #[test]
     fn region_is_parsed_from_locale_tags_case_insensitively() {
+        // Trailing region token (en-US → US → Letter).
         assert_eq!(LocaleProfile::get("en-US"), LocaleProfile::us());
+        // Leading language token (de_AT → de → DACH; at also matches but de comes first).
         assert_eq!(LocaleProfile::get("de_AT"), LocaleProfile::dach());
+        // Single 2-char code (GB → uk).
         assert_eq!(LocaleProfile::get("GB"), LocaleProfile::uk());
+    }
+
+    #[test]
+    fn leading_region_wins_when_trailing_is_unknown() {
+        // "fr-CA" — trailing "ca" is not a known region, leading "fr" is → France.
+        assert_eq!(LocaleProfile::get("fr-CA"), LocaleProfile::fr());
+        // "nl-BE" — trailing "be" is not a known region, leading "nl" is → Netherlands.
+        assert_eq!(LocaleProfile::get("nl-BE"), LocaleProfile::nl());
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/validate/mod.rs
+++ b/apps/tauri/src-tauri/src/validate/mod.rs
@@ -220,10 +220,53 @@ fn run_validators(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> {
     issues
 }
 
+/// Light URL canonicalization for the header-URL mismatch check.
+///
+/// Normalizes trivial differences that don't change the identity of a URL:
+/// - lowercase scheme and host (the authority is case-insensitive per RFC 3986)
+/// - strip a single trailing slash from the path
+/// - decode a percent-encoded space (`%20` → space), the most common encoding
+///   divergence between stored profile values and rendered PDF annotations
+///
+/// Intentionally conservative: the check's goal is to catch a genuinely wrong
+/// URL (a company link leaking into the header), not to canonicalize semantics.
+fn canonicalize_url(url: &str) -> String {
+    // Lowercase scheme+host only — path/query/fragment are case-sensitive.
+    let (prefix, rest) = if let Some(after_scheme) = url.find("://").map(|i| url.split_at(i + 3)) {
+        let (scheme_slashes, after) = after_scheme;
+        // Find end of authority (host[:port])
+        let auth_end = after.find('/').unwrap_or(after.len());
+        let (authority, path_and_rest) = after.split_at(auth_end);
+        (
+            format!(
+                "{}{}",
+                scheme_slashes.to_lowercase(),
+                authority.to_lowercase()
+            ),
+            path_and_rest.to_string(),
+        )
+    } else {
+        (String::new(), url.to_string())
+    };
+
+    // Strip a single trailing slash from the path portion.
+    let rest = rest.strip_suffix('/').unwrap_or(&rest).to_string();
+
+    // Decode a percent-encoded space — the most common trivial encoding mismatch.
+    let rest = rest.replace("%20", " ");
+
+    format!("{prefix}{rest}")
+}
+
 /// Reject stray Markdown emphasis (`*`, backtick) that survived sanitization into
 /// the rendered text — the leaked-asterisk symptom. Applies to PDF and DOCX.
+///
+/// Only flags `*` or `` ` `` that appear at emphasis-boundary positions (not
+/// flanked by an ASCII word character on both sides). A `*` between two word
+/// chars (e.g. `5*4`, `a*b`) is a literal value preserved by the sanitizer and
+/// must not be treated as a rendering defect.
 fn stray_markdown_issues(extracted: &str) -> Vec<ExportIssue> {
-    if extracted.contains('*') || extracted.contains('`') {
+    if has_stray_emphasis(extracted) {
         vec![ExportIssue::critical(
             "stray_markdown",
             "The exported document contains stray Markdown markers (* or `) that should \
@@ -232,6 +275,28 @@ fn stray_markdown_issues(extracted: &str) -> Vec<ExportIssue> {
     } else {
         Vec::new()
     }
+}
+
+/// Returns `true` when `text` contains a `*` or `` ` `` that is NOT flanked by
+/// ASCII word characters on both sides — the same rule the sanitizer uses to
+/// decide what to strip vs. preserve.
+fn has_stray_emphasis(text: &str) -> bool {
+    let chars: Vec<char> = text.chars().collect();
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch == '*' || ch == '`' {
+            let prev_word = i > 0 && is_ascii_word_char(chars[i - 1]);
+            let next_word = i + 1 < chars.len() && is_ascii_word_char(chars[i + 1]);
+            if !(prev_word && next_word) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[inline]
+fn is_ascii_word_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
 }
 
 /// A link annotation read back from the rendered PDF: its `/Rect` in PDF user
@@ -292,11 +357,18 @@ fn pdf_render_issues(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> 
             .filter(|l| l.page == 0 && l.rect[1].max(l.rect[3]) >= header_band_bottom)
             .collect();
 
+        // Canonicalise URLs before comparing so trivial differences (trailing slash,
+        // scheme/host case, a percent-encoded space) do not cause false positives.
+        // The check's intent — catching a wrong link in the header — is preserved;
+        // we only avoid blocking on byte-identical-but-semantically-equal URLs.
+        let allowed_canonical: std::collections::BTreeSet<String> =
+            allowed.iter().map(|u| canonicalize_url(u)).collect();
+
         // A header-band link that is NOT one of the profile's own fields means a
         // body/company link displaced a personal one (the URL-swap regression) —
         // the document shows a wrong link, so this stays blocking.
         for link in &header_links {
-            if !allowed.contains(&link.url) {
+            if !allowed_canonical.contains(&canonicalize_url(&link.url)) {
                 issues.push(ExportIssue::critical(
                     "header_url_mismatch",
                     format!(
@@ -312,7 +384,10 @@ fn pdf_render_issues(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> 
         // advisory — a missing/displaced contact link is a quality note, never a
         // reason to stop the user exporting an otherwise-valid, readable document.
         for url in &allowed {
-            if !header_links.iter().any(|l| &l.url == url) {
+            if !header_links
+                .iter()
+                .any(|l| canonicalize_url(&l.url) == canonicalize_url(url))
+            {
                 issues.push(ExportIssue::warning(
                     "header_url_missing",
                     format!("Contact profile link {url} is missing from the rendered header."),

--- a/apps/tauri/src-tauri/src/validate/mod.rs
+++ b/apps/tauri/src-tauri/src/validate/mod.rs
@@ -224,38 +224,47 @@ fn run_validators(request: &ExportRequest, bytes: &[u8]) -> Vec<ExportIssue> {
 ///
 /// Normalizes trivial differences that don't change the identity of a URL:
 /// - lowercase scheme and host (the authority is case-insensitive per RFC 3986)
-/// - strip a single trailing slash from the path
+/// - strip a single trailing slash from the path (never from the query/fragment)
 /// - decode a percent-encoded space (`%20` → space), the most common encoding
 ///   divergence between stored profile values and rendered PDF annotations
 ///
 /// Intentionally conservative: the check's goal is to catch a genuinely wrong
 /// URL (a company link leaking into the header), not to canonicalize semantics.
 fn canonicalize_url(url: &str) -> String {
-    // Lowercase scheme+host only — path/query/fragment are case-sensitive.
-    let (prefix, rest) = if let Some(after_scheme) = url.find("://").map(|i| url.split_at(i + 3)) {
-        let (scheme_slashes, after) = after_scheme;
-        // Find end of authority (host[:port])
-        let auth_end = after.find('/').unwrap_or(after.len());
-        let (authority, path_and_rest) = after.split_at(auth_end);
-        (
-            format!(
-                "{}{}",
-                scheme_slashes.to_lowercase(),
-                authority.to_lowercase()
-            ),
-            path_and_rest.to_string(),
-        )
-    } else {
-        (String::new(), url.to_string())
+    // Split off scheme+authority (both case-insensitive per RFC 3986).
+    // Authority ends at the first '/', '?', or '#' — NOT just the first '/'.
+    // Without this, `https://example.com?Token=ABC` wrongly treats `?Token=ABC`
+    // as part of the authority and lowercases the query string.
+    let (prefix, path_query_fragment) =
+        if let Some(after_scheme_start) = url.find("://").map(|i| i + 3) {
+            let after = &url[after_scheme_start..];
+            // End of authority = first of '/', '?', '#' (or end of string).
+            let auth_end = after.find(['/', '?', '#']).unwrap_or(after.len());
+            let scheme_and_auth = &url[..after_scheme_start + auth_end];
+            let rest = &url[after_scheme_start + auth_end..];
+            (scheme_and_auth.to_lowercase(), rest.to_string())
+        } else {
+            (String::new(), url.to_string())
+        };
+
+    // Separate the path from any query/fragment so we only strip a trailing
+    // slash from the path, never from inside the query or fragment.
+    let path_query_fragment = {
+        // Find where path ends (first '?' or '#').
+        let qf_start = path_query_fragment
+            .find(['?', '#'])
+            .unwrap_or(path_query_fragment.len());
+        let path = &path_query_fragment[..qf_start];
+        let query_fragment = &path_query_fragment[qf_start..];
+        // Strip at most one trailing slash from the path.
+        let path = path.strip_suffix('/').unwrap_or(path);
+        format!("{path}{query_fragment}")
     };
 
-    // Strip a single trailing slash from the path portion.
-    let rest = rest.strip_suffix('/').unwrap_or(&rest).to_string();
-
     // Decode a percent-encoded space — the most common trivial encoding mismatch.
-    let rest = rest.replace("%20", " ");
+    let path_query_fragment = path_query_fragment.replace("%20", " ");
 
-    format!("{prefix}{rest}")
+    format!("{prefix}{path_query_fragment}")
 }
 
 /// Reject stray Markdown emphasis (`*`, backtick) that survived sanitization into
@@ -284,19 +293,15 @@ fn has_stray_emphasis(text: &str) -> bool {
     let chars: Vec<char> = text.chars().collect();
     for (i, &ch) in chars.iter().enumerate() {
         if ch == '*' || ch == '`' {
-            let prev_word = i > 0 && is_ascii_word_char(chars[i - 1]);
-            let next_word = i + 1 < chars.len() && is_ascii_word_char(chars[i + 1]);
+            let prev_word = i > 0 && crate::export::parser::is_word_char(chars[i - 1]);
+            let next_word =
+                i + 1 < chars.len() && crate::export::parser::is_word_char(chars[i + 1]);
             if !(prev_word && next_word) {
                 return true;
             }
         }
     }
     false
-}
-
-#[inline]
-fn is_ascii_word_char(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '_'
 }
 
 /// A link annotation read back from the rendered PDF: its `/Rect` in PDF user

--- a/apps/tauri/src-tauri/src/validate/tests.rs
+++ b/apps/tauri/src-tauri/src/validate/tests.rs
@@ -388,3 +388,67 @@ fn typst_cover_letter_pdf_passes_validation() {
         report.issues
     );
 }
+
+// ─── canonicalize_url ─────────────────────────────────────────────────────────
+
+/// Query-string case (including values like `Token=ABC`) must be preserved.
+/// The old code found '/' at `after.len()` but still treated `?Token=ABC` as
+/// part of the authority — so `authority.to_lowercase()` clobbered the token.
+#[test]
+fn canonicalize_url_preserves_query_case() {
+    let url = "https://Example.COM/path?Token=ABC&foo=Bar";
+    let canon = canonicalize_url(url);
+    // Scheme + host lowercased; path + query case preserved.
+    assert_eq!(canon, "https://example.com/path?Token=ABC&foo=Bar");
+}
+
+/// A URL with no path separator before the query must not lowercase the query.
+#[test]
+fn canonicalize_url_query_without_path_slash() {
+    let url = "https://Example.COM?Token=ABC";
+    let canon = canonicalize_url(url);
+    assert_eq!(canon, "https://example.com?Token=ABC");
+}
+
+/// Fragment identifiers must not be lowercased or mangled.
+#[test]
+fn canonicalize_url_preserves_fragment() {
+    let url = "https://Example.COM/page#SectionTitle";
+    let canon = canonicalize_url(url);
+    assert_eq!(canon, "https://example.com/page#SectionTitle");
+}
+
+/// A trailing slash on the PATH (before any `?`) is stripped; the query is kept.
+#[test]
+fn canonicalize_url_strips_path_trailing_slash_before_query() {
+    let url = "https://example.com/profile/?Token=ABC";
+    let canon = canonicalize_url(url);
+    assert_eq!(canon, "https://example.com/profile?Token=ABC");
+}
+
+/// Two genuinely different URLs (different hosts / paths) must never compare equal.
+#[test]
+fn canonicalize_url_different_urls_are_not_equal() {
+    let a = canonicalize_url("https://linkedin.com/in/janedoe");
+    let b = canonicalize_url("https://github.com/janedoe");
+    assert_ne!(
+        a, b,
+        "different URLs must not collide after canonicalization"
+    );
+}
+
+/// Regression: a Google Drive URL with a query containing uppercase must not be
+/// lowercased — this is the exact URL shape that false-blocked exports.
+#[test]
+fn canonicalize_url_google_drive_link_is_stable() {
+    let url = "https://drive.google.com/file/d/abc123/view?usp=drive_link";
+    // Canonicalizing twice must yield the same string (idempotent).
+    let once = canonicalize_url(url);
+    let twice = canonicalize_url(&once);
+    assert_eq!(once, twice, "canonicalize_url must be idempotent");
+    // The query value must survive unchanged.
+    assert!(
+        once.contains("?usp=drive_link"),
+        "query must survive: {once}"
+    );
+}


### PR DESCRIPTION
## What

Fleet-audit resume/export fixes — 2 correctness bugs + 4 hygiene items.

## Changes

- **[MED] `sanitize_markdown` no longer corrupts literal content** (`export/parser/mod.rs`) — it used to delete **every** `*`/backtick after protecting `**bold**`, silently mangling content like `5*4`. Now a char-walk keeps a `*`/`` ` `` only when flanked by ASCII word chars on both sides (mid-word literals preserved; `*emphasis*`, lone markers, bullet `* `, `` `code` `` still stripped). The `stray_markdown_issues` **validator was updated with the identical rule** so the two can't diverge.
- **[MED] Locale region resolution** (`locale/mod.rs`) — `LocaleProfile::get` used only the trailing token; now tries leading + trailing 2-char tokens against the known-region set (prefer leading). Fixes `fr-CA`→fr, `nl-BE`→nl, `de-LI`→dach (were wrongly falling to the `en` default); `en-US`→us, `de-DE`→dach, `en-GB`→uk preserved. Added tests.
- **[LOW] Deleted dead locale convention fields** (`date_style`, `include_personal_details`, `default_section_order` + enums/consts) — unused, documented as deferred (resume-domain.md). `transform::reorder_sections` kept (used by `linearize`).
- **[LOW] Two-column gate** (`model_docx.rs`) → `crate::theme::is_two_column(template.id) && !ats_mode` (single source of truth; equivalent for all 9 templates).
- **[LOW] Photo decoder** — removed unreachable `Bmp`/`Tiff` branches from `decode_and_sanitise` (upstream MIME gate only admits png/jpeg/webp/gif).
- **[LOW] `header_url_mismatch`** — compares after light `canonicalize_url()` (lowercase scheme+host, strip one trailing slash, decode `%20`) to kill false positives on byte-different-but-equal URLs; still blocks genuinely different links.

## Validation

`cargo fmt --check` ✅ · `cargo check` ✅ · `cargo clippy -D warnings` ✅ · `cargo test` **1192 passed** ✅ · **no golden snapshots changed**
**Reviewed by `resume-export-expert`: no HIGH/CRITICAL.** Sanitizer verified across ~30 adversarial inputs (bold round-trips; sanitizer↔validator rules proven identical); locale precedence has **zero regressions**; two-column equivalence confirmed for all templates; URL canonicalization preserves the security intent.

_Part of a multi-PR fleet-audit cleanup._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown punctuation handling in document exports to preserve literal characters
  * More reliable DOCX two-column rendering based on template and layout configuration
  * Increased validation tolerance for URL formatting differences in PDF exports
  * Tightened supported image formats for DOCX rendering (PNG, JPEG, WebP, GIF)
* **Refactor**
  * Streamlined locale profile configuration to focus on page size and photo policy
* **Tests**
  * Added regression coverage for URL canonicalization behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->