### PR TITLE
fix(renderer): surface match-score guidance disclaimer in jobs ui

### DIFF
--- a/apps/tauri/src/renderer/features/jobs/components/RowMatchScore/RowMatchScore.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/RowMatchScore/RowMatchScore.test.tsx
@@ -104,6 +104,19 @@ describe('RowMatchScore — score state', () => {
     expect(screen.getByText('High')).toBeInTheDocument();
     expect(container.querySelector('[aria-busy="true"]')).not.toBeInTheDocument();
   });
+
+  it('renders the always-visible estimate label adjacent to the band', () => {
+    renderRow({ score: { ...BASE_SCORE, combined: 82 }, pending: false, hasResume: true });
+    // The "est." micro-label is the persistent estimate framing — present without
+    // any interaction. The i18n stub returns the key, so we assert on the key itself.
+    expect(screen.getByText('jobs.scoreEst')).toBeInTheDocument();
+  });
+
+  it('renders a guidance info trigger with the scoreGuidanceLabel aria-label', () => {
+    renderRow({ score: { ...BASE_SCORE, combined: 82 }, pending: false, hasResume: true });
+    // aria-label is distinct from the panel content — no duplicate-announcement.
+    expect(screen.getByRole('button', { name: 'jobs.scoreGuidanceLabel' })).toBeInTheDocument();
+  });
 });
 
 describe('RowMatchScore — pending state', () => {

--- a/apps/tauri/src/renderer/features/jobs/components/RowMatchScore/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/RowMatchScore/index.tsx
@@ -1,4 +1,7 @@
+import { Info } from 'lucide-react';
+
 import { useTranslation } from '@ajh/translations';
+import { Button, HoverPopover } from '@ajh/ui';
 
 import { MatchBand } from '@/features/jobs/lib/score';
 import { useRowMatchScore } from '@/features/jobs/providers';
@@ -7,17 +10,47 @@ import { useRowMatchScore } from '@/features/jobs/providers';
  * Presentational per-row match score. The combined keyword/semantic score is
  * supplied by MatchScoresProvider (one batch call for all filtered postings),
  * so this component holds no scheduling or fetching logic.
+ *
+ * Estimate framing is AMBIENT: the always-visible "est." micro-label adjacent
+ * to the band makes the disclaimer present without interaction. The info trigger
+ * opens the full guidance sentence on hover/focus; touch users see the "est."
+ * label regardless (non-blocking touch gap per reviewer agreement).
  */
 export function RowMatchScore({ jobId }: { jobId: string }) {
   const { t } = useTranslation();
   const { score, pending, hasResume } = useRowMatchScore(jobId);
 
   if (!hasResume) return null;
-  if (score) return <MatchBand value={score.combined} />;
+  if (score) {
+    return (
+      <HoverPopover
+        placement="top"
+        ariaLabel={t('jobs.scoreGuidance')}
+        trigger={
+          <div className="flex items-center gap-1">
+            <MatchBand value={score.combined} />
+            {/* Always-visible estimate framing — present without interaction. */}
+            <span className="text-fine-print text-foreground/50">{t('jobs.scoreEst')}</span>
+            <Button
+              variant="unstyled"
+              className="flex h-6 w-6 items-center justify-center text-foreground/50 hover:text-foreground/70 focus-visible:text-foreground/70"
+              aria-label={t('jobs.scoreGuidanceLabel')}
+            >
+              <Info size={14} aria-hidden="true" />
+            </Button>
+          </div>
+        }
+      >
+        <p className="dropdown-surface max-w-[220px] px-3 py-2 text-fine-print leading-snug text-foreground/70">
+          {t('jobs.scoreGuidance')}
+        </p>
+      </HoverPopover>
+    );
+  }
   if (pending) {
     return (
       <span
-        className="text-[11px] text-foreground/30"
+        className="text-fine-print text-foreground/30"
         aria-label={t('jobs.scoreLoading')}
         aria-busy="true"
       >

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1476,6 +1476,8 @@
     "scoreHint": "Diesen Job mit deinem Standard-Lebenslauf bewerten",
     "scoreNoResume": "Speichere einen Lebenslauf zum Bewerten",
     "scoreGuidance": "Dieser Score ist eine Schätzung — keine Entscheidung des Arbeitgebers oder eines ATS-Systems.",
+    "scoreGuidanceLabel": "Über diese Bewertung",
+    "scoreEst": "ca.",
     "showMore": "Mehr anzeigen",
     "tailor": "Anpassen",
     "tailorHint": "Lebenslauf & Anschreiben für diesen Job anpassen",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1472,6 +1472,8 @@
     "scoreHint": "Score this job against your default résumé",
     "scoreNoResume": "Save a résumé to score",
     "scoreGuidance": "This score is a guidance estimate — not the employer's decision or any ATS system's score.",
+    "scoreGuidanceLabel": "About this score",
+    "scoreEst": "est.",
     "showMore": "Show more",
     "tailor": "Tailor",
     "tailorHint": "Tailor your résumé & cover letter for this job",


### PR DESCRIPTION
## What

Surfaces the match-score **guidance framing** ("this is an estimate, not the employer's verdict") in the Jobs UI. PR #442 added the `guidance` data + `jobs.scoreGuidance` i18n key but nothing rendered it — the renderer showed only the numeric band, so the legally-meaningful framing was invisible to users.

> ⚠️ **Stacked on #442** (`fix/job-match-evidence-and-framing`) — it depends on that PR's `MatchScore.guidance` field + i18n key. **Retarget this PR's base to `main` (or rebase) once #442 merges.**

## Changes (`RowMatchScore`)

- **Persistent, always-visible estimate qualifier** — a muted `est.` micro-label (`jobs.scoreEst`, en `"est."` / de `"ca."`) sits next to the `MatchBand` with zero added row height, so the framing is present in the normal reading flow (not hidden behind hover). *(Postings have no separate detail view, so the row is the canonical surface.)*
- **Full disclaimer on demand** — a keyboard-accessible `HoverPopover` (info icon) carries the complete `jobs.scoreGuidance` sentence as a supplement.
- **a11y:** distinct trigger label `jobs.scoreGuidanceLabel` ("About this score" / "Über diese Bewertung") so the screen reader doesn't double-announce the full sentence; `size={14}` icon at `/50` opacity in a **24×24px** hit target (WCAG 2.5.8).
- **Tokens:** popover panel uses the canonical `dropdown-surface` utility (the prior `bg-surface` was an undefined token → transparent panel); `text-fine-print` (12px floor) instead of `text-[11px]`.

## Validation

`build:packages` ✅ · `lint:strict` 0 warnings ✅ · `format:check` ✅ · `typecheck` ✅ · `pnpm test` ✅ (de-tautologized: asserts the `est.` label renders without interaction + the distinct trigger label)
**Reviewed by `frontend-reviewer` + `ui-ux-expert`: a first pass caught a CRITICAL (transparent panel) + the framing being hover-only — both reworked** (persistent qualifier + `dropdown-surface`) and verified.

_Part of a multi-PR fleet-audit cleanup._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
