### PR TITLE
fix(menu): gate the menu_take_pending poll to macos only

### DIFF
--- a/apps/tauri/src/renderer/hooks/use-menu-navigation.ts
+++ b/apps/tauri/src/renderer/hooks/use-menu-navigation.ts
@@ -7,6 +7,7 @@ import { useNotification } from '@ajh/ui';
 
 import { useMenuIntents } from '@/services';
 import { useUpdater } from '@/services/use-updater';
+import { useWindowControls } from '@/services/use-window-controls';
 import { type SettingsSection, useSessionStore } from '@/store/session-store';
 import { useUiStore } from '@/store/ui-store';
 
@@ -45,6 +46,7 @@ export function useMenuNavigation() {
   const { check } = useUpdater();
   const notify = useNotification();
   const { t } = useTranslation();
+  const { isMacos } = useWindowControls();
 
   const onNavigate = useCallback(
     ({ route, section, focus }: MenuNavigateEvent) => {
@@ -95,6 +97,7 @@ export function useMenuNavigation() {
   // Single reliable delivery path: the shell buffers the intent and we pull it
   // (on the emitted event, on window focus/visibility-restore, and on mount).
   // Works from the tray and the macOS menu bar, whether the window was visible
-  // or hidden — see `useMenuIntents`.
-  useMenuIntents(onNavigate, onAction);
+  // or hidden — see `useMenuIntents`. The 250 ms poll backstop is macOS-only
+  // (NSMenu tracking suppresses focus/visibility/emit on the main window).
+  useMenuIntents(onNavigate, onAction, isMacos);
 }

--- a/apps/tauri/src/renderer/services/use-menu/use-menu.test.ts
+++ b/apps/tauri/src/renderer/services/use-menu/use-menu.test.ts
@@ -27,12 +27,15 @@ const ACTION_INTENT: PendingMenuIntent = {
  * The `onNavigate` / `onAction` event-listener registrars (`menu.onNavigate`,
  * `menu.onAction`) default to no-op unsub stubs matching the `createMockClient`
  * default for `on*` methods — they return `() => {}`.
+ *
+ * Pass `enablePoll: true` to activate the 250 ms backstop (macOS behaviour).
+ * Defaults to `true` so existing poll-backstop tests remain unchanged.
  */
-function setup(takePending: () => Promise<PendingMenuIntent | null>) {
+function setup(takePending: () => Promise<PendingMenuIntent | null>, enablePoll = true) {
   const onNavigate = vi.fn();
   const onAction = vi.fn();
   const client = createMockClient({ 'menu.takePending': takePending });
-  const utils = renderHook(() => useMenuIntents(onNavigate, onAction), {
+  const utils = renderHook(() => useMenuIntents(onNavigate, onAction, enablePoll), {
     wrapper: withProviders(client),
   });
   return { ...utils, onNavigate, onAction, takePending };
@@ -353,5 +356,42 @@ describe('useMenuIntents — poll backstop', () => {
     // Confirm takePending was called on all ticks (poll survived the rejections).
     // mount drain (1) + tick1 reject (1) + tick2 reject (1) + tick3 resolve (1) = 4.
     expect(takePending).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not create the interval when enablePoll is false (Windows/Linux path)', async () => {
+    // With enablePoll=false the setInterval must never be called for the 250ms
+    // backstop. The only takePending call should be the mount-drain.
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setVisibilityState('visible');
+
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+
+    const takePending = vi
+      .fn<() => Promise<PendingMenuIntent | null>>()
+      .mockResolvedValueOnce(null) // mount drain → empty
+      .mockResolvedValue(NAV_INTENT); // would be delivered by poll — must not reach
+
+    const { onNavigate, onAction } = setup(takePending, false);
+
+    // Settle mount-drain.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const mountDrainCalls = takePending.mock.calls.length;
+
+    // Advance several poll intervals — no interval was created, so only the
+    // mount-drain call should have fired.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250 * 5);
+    });
+
+    expect(takePending).toHaveBeenCalledTimes(mountDrainCalls);
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(onAction).not.toHaveBeenCalled();
+    // Confirm the hook never registered a 250 ms interval.
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 250);
+
+    setIntervalSpy.mockRestore();
   });
 });

--- a/apps/tauri/src/renderer/services/use-menu/use-menu.ts
+++ b/apps/tauri/src/renderer/services/use-menu/use-menu.ts
@@ -33,7 +33,12 @@ import { useAppClient } from '@/providers/AppClientProvider';
  */
 export const useMenuIntents = (
   onNavigate?: (event: MenuNavigateEvent) => void,
-  onAction?: (event: MenuActionEvent) => void
+  onAction?: (event: MenuActionEvent) => void,
+  /** Gate the 250 ms poll backstop. Only macOS needs it — the native menu bar
+   *  suspends the shell's emit and fires no focus/visibility event. On
+   *  Windows/Linux the mount-drain, `focus`, `visibilitychange`, and the
+   *  `onNavigate`/`onAction` emit triggers fully cover delivery. */
+  enablePoll = false
 ) => {
   const api = useAppClient();
   useEffect(() => {
@@ -63,21 +68,25 @@ export const useMenuIntents = (
     // payload and always drain the buffer so delivery is exactly-once.
     const offNavigate = api.menu.onNavigate(trigger);
     const offAction = api.menu.onAction(trigger);
-    // Backstop: the macOS menu-bar nav case fires NO focus/visibility/emit the
-    // renderer can trust (window keeps key focus; the shell emit is dropped across
-    // menu tracking). Poll the buffer while focused so the buffered intent always
-    // lands. `takePending` is a cheap take-and-clear; an empty pull is a no-op.
-    const poll: number = window.setInterval(() => {
-      if (document.visibilityState === 'visible' && document.hasFocus()) void drain();
-    }, 250);
+    // macOS-only backstop (gated by caller): the macOS menu-bar nav case fires NO
+    // focus/visibility/emit the renderer can trust (window keeps key focus; the
+    // shell emit is dropped across NSMenu tracking). Poll the buffer while focused
+    // so the buffered intent always lands. On Windows/Linux the other triggers
+    // fully cover delivery, so the poll is omitted to avoid constant null-returning
+    // IPC spam. `takePending` is a cheap take-and-clear; an empty pull is a no-op.
+    const poll: number | undefined = enablePoll
+      ? window.setInterval(() => {
+          if (document.visibilityState === 'visible' && document.hasFocus()) void drain();
+        }, 250)
+      : undefined;
 
     return () => {
       cancelled = true;
-      window.clearInterval(poll);
+      if (poll !== undefined) window.clearInterval(poll);
       window.removeEventListener('focus', trigger);
       document.removeEventListener('visibilitychange', onVisibility);
       offNavigate?.();
       offAction?.();
     };
-  }, [api, onNavigate, onAction]);
+  }, [api, onNavigate, onAction, enablePoll]);
 };


### PR DESCRIPTION
## The bug

On Windows, opening the app fires `menu_take_pending` IPC ~4×/second forever (a steady stream of null-returning requests in the Network/IPC tab — as reported).

## Root cause

`useMenuIntents` ([use-menu.ts](apps/tauri/src/renderer/services/use-menu/use-menu.ts)) runs a 250 ms `setInterval` that pulls `menu_take_pending` while the window is visible+focused. Per its own comment, that poll is a **macOS-menu-bar backstop**: NSMenu tracking suspends the shell's Rust→JS emit and fires no focus/visibility change, so only a poll catches a menu-bar nav intent there. On **Windows/Linux** the other triggers already in the same effect — mount drain, `window` `focus`, `visibilitychange`, and the `onNavigate`/`onAction` emit triggers — deliver every menu intent (the native menu bar isn't even reachable on Windows: borderless custom titlebar; only the tray is, and tray clicks fire `focus`). So the poll is pure waste off macOS.

## Fix

Gate the poll to macOS. `useMenuIntents` gains an `enablePoll` flag (default `false`); the interval is created only when `true`. `useMenuNavigation` passes `isMacos` from `useWindowControls()` (synchronous `platform() === 'macos'`). All non-poll triggers stay on every platform, so delivery is unchanged everywhere — Windows/Linux just stop the periodic null pulls. **macOS behavior is identical.**

## Tests

Existing 18 poll-backstop tests still run (setup passes `enablePoll: true`); added one asserting the interval is never created when `enablePoll` is false (the Windows/Linux path). 19/19 pass; tsc + lint:strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-specific menu navigation behavior with optimized intent delivery for macOS.

* **Tests**
  * Added test coverage for Windows/Linux menu behavior without polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->