### PR TITLE
fix(ui): keep modal open when a text-selection drag ends on the backdrop

### DIFF
--- a/packages/ui/src/components/ModalShell/ModalShell.test.tsx
+++ b/packages/ui/src/components/ModalShell/ModalShell.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ModalShell } from './ModalShell';
@@ -69,6 +69,60 @@ describe('ModalShell', () => {
     );
     await userEvent.keyboard('{Escape}');
     expect(onClose).toHaveBeenCalled();
+  });
+
+  // --- text-selection drag regression ---
+
+  it('closes when mousedown AND click both land on the backdrop', () => {
+    const onClose = vi.fn();
+    render(
+      <ModalShell open onClose={onClose}>
+        <p>body</p>
+      </ModalShell>
+    );
+    const dialog = screen.getByRole('dialog');
+    const backdrop = dialog.parentElement!;
+
+    fireEvent.mouseDown(backdrop, { target: backdrop });
+    fireEvent.click(backdrop, { target: backdrop });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT close when mousedown starts inside the panel but click reaches the backdrop (selection drag)', () => {
+    const onClose = vi.fn();
+    render(
+      <ModalShell open onClose={onClose}>
+        <p>inner content</p>
+      </ModalShell>
+    );
+    const dialog = screen.getByRole('dialog');
+    const backdrop = dialog.parentElement!;
+    const innerPara = screen.getByText('inner content');
+
+    // Simulate: press starts on a child inside the panel (mousedown on innerPara, which
+    // bubbles up to backdrop — so e.target !== e.currentTarget on the backdrop handler).
+    fireEvent.mouseDown(innerPara);
+    // Release / click lands on the backdrop itself
+    fireEvent.click(backdrop, { target: backdrop });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does NOT close on backdrop mousedown+click when closeOnBackdrop={false}', () => {
+    const onClose = vi.fn();
+    render(
+      <ModalShell open onClose={onClose} closeOnBackdrop={false}>
+        <p>body</p>
+      </ModalShell>
+    );
+    const dialog = screen.getByRole('dialog');
+    const backdrop = dialog.parentElement!;
+
+    fireEvent.mouseDown(backdrop, { target: backdrop });
+    fireEvent.click(backdrop, { target: backdrop });
+
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   // --- responsive-window-resize contract (header / footer / className) ---

--- a/packages/ui/src/components/ModalShell/ModalShell.tsx
+++ b/packages/ui/src/components/ModalShell/ModalShell.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'motion/react';
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useFocusTrap } from '../../hooks/use-focus-trap';
@@ -70,6 +70,7 @@ export function ModalShell({
   closeOnBackdrop = true,
 }: ModalShellProps) {
   const trapRef = useFocusTrap(open);
+  const pointerDownOnBackdrop = useRef(false);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -101,7 +102,18 @@ export function ModalShell({
           <motion.div
             className="fixed inset-0 flex items-center justify-center p-4"
             style={{ zIndex }}
-            onClick={closeOnBackdrop ? onClose : undefined}
+            onMouseDown={(e) => {
+              pointerDownOnBackdrop.current = e.target === e.currentTarget;
+            }}
+            onClick={(e) => {
+              if (
+                closeOnBackdrop &&
+                pointerDownOnBackdrop.current &&
+                e.target === e.currentTarget
+              ) {
+                onClose();
+              }
+            }}
             {...variants.overlay}
             transition={transition.overlay}
           >
@@ -119,7 +131,6 @@ export function ModalShell({
               )}
               {...variants.scale}
               transition={transition.modal}
-              onClick={(e) => e.stopPropagation()}
             >
               {header && <div className="shrink-0">{header}</div>}
               <div className="@container min-h-0 flex-1 overflow-y-auto">{children}</div>


### PR DESCRIPTION
## The bug

In the Autopilot creation modal (and every other modal), typing in an input then **selecting that text by dragging** closes the modal the moment the drag ends outside the panel.

## Root cause

`ModalShell` closed on any `click` on the backdrop container, with the panel relying on `onClick` `stopPropagation`. A text-selection drag starts with `mousedown` on an input (inside the panel) and ends with `mouseup` on the backdrop, so the browser dispatches the `click` on the **common ancestor (the backdrop)** — the panel's `stopPropagation` never runs and `onClose()` fires.

## Fix

Close only when the press both **starts and ends** on the backdrop: track the mousedown origin via a ref (`e.target === e.currentTarget`) and gate `onClose` on it plus the same target check on click. A drag that begins inside the panel no longer closes the modal. Escape + explicit controls unchanged; `closeOnBackdrop={false}` still respected. The now-redundant panel `stopPropagation` was removed. Fixes all modals, not just Autopilot.

## Tests

Three regression tests in `ModalShell.test.tsx`: genuine backdrop click still closes; press-inside → click-on-backdrop does NOT close (the bug); `closeOnBackdrop={false}` never closes. 431/431 `@ajh/ui` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal dismissal behavior to correctly handle backdrop interactions, preventing unwanted closures during text selection or drag operations while maintaining the intended close-on-backdrop functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->