### PR TITLE
fix(scraping): preserve caller headers and stream-cap http responses

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "criterion",
  "dbus-secret-service-keyring-store",
  "docx-rs",
+ "encoding_rs",
  "feed-rs",
  "flate2",
  "futures",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -112,6 +112,9 @@ tokio-tungstenite = { version = "0.28", default-features = false, features = ["h
 chromiumoxide = { version = "0.9", features = ["fetcher", "zip8"] }
 
 futures = "0.3"
+# Charset decoding for the streamed fetch_text body (mirrors reqwest's internal .text() path).
+# Already a transitive dep via reqwest; declared explicitly so we can name it in scraping/http.
+encoding_rs = "0.8"
 regex = "1"
 anyhow = "1"
 thiserror = "2"

--- a/apps/tauri/src-tauri/src/scraping/boards/arbeitsagentur/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/arbeitsagentur/mod.rs
@@ -6,10 +6,7 @@
 /// detail fetch succeeds. This degrades gracefully — list data has title/company/
 /// location/url which is sufficient for search results.
 ///
-/// fetch_json note: we call fetch_text directly + deserialize manually because
-/// fetch_json overwrites the caller's `headers` with only `accept: application/json`,
-/// dropping the required `X-API-Key` header (follow-up: fix fetch_json to merge headers).
-use super::super::http::{fetch_text, strip_html};
+use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -136,12 +133,11 @@ impl Scraper for ArbeitsagenturScraper {
                 .collect::<Vec<_>>()
                 .join("&");
 
-            let list_res = match fetch_text(
+            let list_resp = match fetch_json::<ListResp>(
                 &format!("{}/jobs?{}", API_BASE, query_string),
                 super::super::http::FetchOptions {
                     headers: Some(vec![
                         ("X-API-Key".to_string(), API_KEY.to_string()),
-                        ("accept".to_string(), "application/json".to_string()),
                         ("accept-language".to_string(), "de-DE,de;q=0.9".to_string()),
                     ]),
                     ..Default::default()
@@ -160,13 +156,10 @@ impl Scraper for ArbeitsagenturScraper {
                     break;
                 }
             };
-            let list = if list_res.status_code >= 200 && list_res.status_code < 300 {
-                serde_json::from_str::<ListResp>(&list_res.text).ok()
-            } else {
-                None
-            };
 
-            let items = list.and_then(|l| l.stellenangebote).unwrap_or_default();
+            let items = list_resp
+                .and_then(|l| l.stellenangebote)
+                .unwrap_or_default();
 
             if items.is_empty() {
                 break;
@@ -190,21 +183,17 @@ impl Scraper for ArbeitsagenturScraper {
                     .clone()
                     .unwrap_or_else(|| self.to_base64_url(&j.refnr));
 
-                let detail = fetch_text(
+                let detail = fetch_json::<DetailResp>(
                     &format!("{}/jobdetails/{}", API_BASE, urlencoding::encode(&hash)),
                     super::super::http::FetchOptions {
-                        headers: Some(vec![
-                            ("X-API-Key".to_string(), API_KEY.to_string()),
-                            ("accept".to_string(), "application/json".to_string()),
-                        ]),
+                        headers: Some(vec![("X-API-Key".to_string(), API_KEY.to_string())]),
                         ..Default::default()
                     },
                     ctx.signal.clone(),
                 )
                 .await
                 .ok()
-                .filter(|r| r.status_code >= 200 && r.status_code < 300)
-                .and_then(|r| serde_json::from_str::<DetailResp>(&r.text).ok());
+                .flatten();
 
                 let description = detail.as_ref().and_then(|d| {
                     let desc = vec![

--- a/apps/tauri/src-tauri/src/scraping/http/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/http/mod.rs
@@ -6,6 +6,8 @@
 /// - opt-in JSON / HTML helpers with size caps
 use std::time::Duration;
 
+use futures::StreamExt as _;
+
 use crate::error::{AppError, AppResult};
 use crate::net::http::DEFAULT_UA;
 
@@ -96,10 +98,22 @@ pub async fn fetch_text(
         };
 
         request = request.header("user-agent", DEFAULT_UA);
-        request = request.header(
-            "accept",
-            "text/html,application/xhtml+xml,application/xml,application/json;q=0.9,*/*;q=0.8",
-        );
+
+        // Only add the broad HTML accept when the caller hasn't already set one.
+        // This prevents a double `accept` header when fetch_json (which prepends
+        // `accept: application/json` into opts.headers) calls fetch_text.
+        let caller_has_accept = opts
+            .headers
+            .as_deref()
+            .unwrap_or(&[])
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("accept"));
+        if !caller_has_accept {
+            request = request.header(
+                "accept",
+                "text/html,application/xhtml+xml,application/xml,application/json;q=0.9,*/*;q=0.8",
+            );
+        }
         request = request.header("accept-language", "en-US,en;q=0.9,de;q=0.8");
 
         if let Some(headers) = &opts.headers {
@@ -117,18 +131,46 @@ pub async fn fetch_text(
                 let status_code = response.status().as_u16();
                 let headers = response.headers().clone();
 
-                // Check content length if available
+                // Cheap pre-check: honest servers that declare content-length
+                // let us abort before reading a single byte.
                 if let Some(content_length) = response.content_length() {
                     if content_length > cap as u64 {
                         return Err(AppError::Validation("Response too large".to_string()));
                     }
                 }
 
-                let text = response.text().await?;
+                // Determine charset from Content-Type (mirrors what reqwest::Response::text()
+                // does internally) so German umlauts / € decode correctly regardless of cap.
+                let encoding = headers
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|ct| ct.to_str().ok())
+                    .and_then(|ct| {
+                        // Extract charset=... from e.g. "text/html; charset=iso-8859-1"
+                        ct.split(';').find_map(|part| {
+                            let p = part.trim();
+                            p.strip_prefix("charset=")
+                                .map(|cs| cs.trim().to_ascii_lowercase())
+                        })
+                    })
+                    .and_then(|cs| encoding_rs::Encoding::for_label(cs.as_bytes()))
+                    .unwrap_or(encoding_rs::UTF_8);
 
-                if text.len() > cap {
-                    return Err(AppError::Validation("Response too large".to_string()));
+                // Stream the body, accumulating bytes and aborting as soon as the
+                // running total exceeds the effective cap — prevents OOM from a
+                // server that lies about or omits Content-Length.
+                let mut stream = response.bytes_stream();
+                let mut buf: Vec<u8> = Vec::new();
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk.map_err(|e| AppError::Network(e.to_string()))?;
+                    buf.extend_from_slice(&chunk);
+                    if buf.len() > cap {
+                        return Err(AppError::Validation("Response too large".to_string()));
+                    }
                 }
+
+                // Decode using the charset we extracted above.
+                let (cow, _enc, _had_errors) = encoding.decode(&buf);
+                let text = cow.into_owned();
 
                 return Ok(FetchResult {
                     status_code,
@@ -156,10 +198,23 @@ pub async fn fetch_json<T: for<'de> serde::Deserialize<'de>>(
     opts: FetchOptions,
     signal: tokio_util::sync::CancellationToken,
 ) -> AppResult<Option<T>> {
+    // Merge `accept: application/json` into caller headers.
+    // Caller-supplied headers win — if the caller already set an `accept` header we
+    // leave it as-is; otherwise we prepend the JSON accept so fetch_text's broader
+    // HTML accept doesn't take precedence. This preserves auth headers like X-API-Key.
+    // Clone headers so we can use `..opts` below — avoids silently dropping any
+    // future FetchOptions field that would otherwise be missed by field-by-field copy.
+    let mut merged_headers = opts.headers.clone().unwrap_or_default();
+    let has_accept = merged_headers
+        .iter()
+        .any(|(k, _)| k.eq_ignore_ascii_case("accept"));
+    if !has_accept {
+        merged_headers.insert(0, ("accept".to_string(), "application/json".to_string()));
+    }
     let res = fetch_text(
         url,
         FetchOptions {
-            headers: Some(vec![("accept".to_string(), "application/json".to_string())]),
+            headers: Some(merged_headers),
             ..opts
         },
         signal,

--- a/apps/tauri/src-tauri/src/scraping/http/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/http/mod.rs
@@ -145,11 +145,16 @@ pub async fn fetch_text(
                     .get(reqwest::header::CONTENT_TYPE)
                     .and_then(|ct| ct.to_str().ok())
                     .and_then(|ct| {
-                        // Extract charset=... from e.g. "text/html; charset=iso-8859-1"
+                        // Extract charset=... from e.g. "text/html; Charset="ISO-8859-1""
+                        // Key match is case-insensitive; strip surrounding quotes from value.
                         ct.split(';').find_map(|part| {
                             let p = part.trim();
-                            p.strip_prefix("charset=")
-                                .map(|cs| cs.trim().to_ascii_lowercase())
+                            let eq = p.find('=')?;
+                            if !p[..eq].trim().eq_ignore_ascii_case("charset") {
+                                return None;
+                            }
+                            let cs = p[eq + 1..].trim().trim_matches(|c| c == '"' || c == '\'');
+                            Some(cs.to_ascii_lowercase())
                         })
                     })
                     .and_then(|cs| encoding_rs::Encoding::for_label(cs.as_bytes()))
@@ -162,10 +167,10 @@ pub async fn fetch_text(
                 let mut buf: Vec<u8> = Vec::new();
                 while let Some(chunk) = stream.next().await {
                     let chunk = chunk.map_err(|e| AppError::Network(e.to_string()))?;
-                    buf.extend_from_slice(&chunk);
-                    if buf.len() > cap {
+                    if buf.len().saturating_add(chunk.len()) > cap {
                         return Err(AppError::Validation("Response too large".to_string()));
                     }
+                    buf.extend_from_slice(&chunk);
                 }
 
                 // Decode using the charset we extracted above.

--- a/apps/tauri/src-tauri/src/scraping/http/test.rs
+++ b/apps/tauri/src-tauri/src/scraping/http/test.rs
@@ -181,6 +181,160 @@ async fn test_fetch_json_invalid() {
     assert!(result.unwrap().is_none());
 }
 
+/// fetch_json must forward caller-supplied headers (e.g. X-API-Key) intact.
+/// Previously it overwrote opts.headers entirely with just accept:application/json.
+#[tokio::test]
+async fn test_fetch_json_preserves_caller_headers() {
+    use serde::Deserialize;
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[derive(Deserialize)]
+    struct Resp {
+        ok: bool,
+    }
+
+    let mock_server = MockServer::start().await;
+    let signal = tokio_util::sync::CancellationToken::new();
+
+    // Only respond when the custom auth header is present — proves the header was forwarded.
+    Mock::given(method("GET"))
+        .and(header("x-api-key", "secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+        .mount(&mock_server)
+        .await;
+
+    let result = fetch_json::<Resp>(
+        &mock_server.uri(),
+        FetchOptions {
+            headers: Some(vec![("x-api-key".to_string(), "secret".to_string())]),
+            ..Default::default()
+        },
+        signal,
+    )
+    .await;
+
+    let parsed = result
+        .expect("fetch_json should succeed")
+        .expect("response should be deserialized");
+    assert!(parsed.ok, "expected ok:true — X-API-Key header was dropped");
+}
+
+/// fetch_text must abort the stream before fully buffering when the body exceeds
+/// the cap, even when no Content-Length is declared by the server.
+#[tokio::test]
+async fn test_fetch_text_stream_cap_no_content_length() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let signal = tokio_util::sync::CancellationToken::new();
+
+    // 100 bytes body, cap set to 50 — no Content-Length header from wiremock by default.
+    let body = "x".repeat(100);
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .mount(&mock_server)
+        .await;
+
+    let result = fetch_text(
+        &mock_server.uri(),
+        FetchOptions {
+            max_bytes: Some(50),
+            ..Default::default()
+        },
+        signal,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "should have returned an error for oversized body"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("too large"),
+        "expected 'too large' error, got: {err}"
+    );
+}
+
+/// fetch_text must correctly decode non-ASCII bytes (UTF-8: German umlauts, €).
+#[tokio::test]
+async fn test_fetch_text_utf8_decode() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let signal = tokio_util::sync::CancellationToken::new();
+
+    let body = "Softwareentwickler (m/w/d) – Gehalt: 80.000 € · München";
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/plain; charset=utf-8")
+                .set_body_string(body),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let result = fetch_text(&mock_server.uri(), FetchOptions::default(), signal).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().text, body);
+}
+
+/// A response whose Content-Type declares charset=iso-8859-1 and whose body
+/// contains raw ISO-8859-1 bytes must decode to the correct Unicode string.
+/// 0xFC is ü in ISO-8859-1.
+#[tokio::test]
+async fn test_fetch_text_iso8859_decode() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let signal = tokio_util::sync::CancellationToken::new();
+
+    // Raw ISO-8859-1: "Schl" + 0xFC + "ssel" = "Schlüssel"
+    let body_bytes: Vec<u8> = b"Schl\xFCssel".to_vec();
+
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html; charset=iso-8859-1")
+                .set_body_bytes(body_bytes),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let result = fetch_text(&mock_server.uri(), FetchOptions::default(), signal).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().text, "Schlüssel");
+}
+
+/// When Content-Type has no charset, fetch_text falls back to UTF-8.
+#[tokio::test]
+async fn test_fetch_text_no_charset_fallback_utf8() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let signal = tokio_util::sync::CancellationToken::new();
+
+    let body = "hello wörld";
+    Mock::given(method("GET"))
+        .respond_with(
+            // Content-Type with no charset= parameter.
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html")
+                .set_body_string(body),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let result = fetch_text(&mock_server.uri(), FetchOptions::default(), signal).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().text, body);
+}
+
 #[tokio::test]
 async fn test_fetch_text_cancelled() {
     use wiremock::matchers::method;

--- a/apps/tauri/src-tauri/src/scraping/http/test.rs
+++ b/apps/tauri/src-tauri/src/scraping/http/test.rs
@@ -310,6 +310,37 @@ async fn test_fetch_text_iso8859_decode() {
     assert_eq!(result.unwrap().text, "Schlüssel");
 }
 
+/// Content-Type with a capital-C "Charset" key and a quoted value must still
+/// resolve to the correct encoding — not silently fall back to UTF-8.
+/// 0xFC is ü in ISO-8859-1; if the charset is missed it would decode as garbage.
+#[tokio::test]
+async fn test_fetch_text_iso8859_uppercase_quoted_charset() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let signal = tokio_util::sync::CancellationToken::new();
+
+    let body_bytes: Vec<u8> = b"Schl\xFCssel".to_vec();
+
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html; Charset=\"iso-8859-1\"")
+                .set_body_bytes(body_bytes),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let result = fetch_text(&mock_server.uri(), FetchOptions::default(), signal).await;
+    assert!(result.is_ok());
+    assert_eq!(
+        result.unwrap().text,
+        "Schlüssel",
+        "capital-C Charset with quoted value must decode ISO-8859-1, not fall back to UTF-8"
+    );
+}
+
 /// When Content-Type has no charset, fetch_text falls back to UTF-8.
 #[tokio::test]
 async fn test_fetch_text_no_charset_fallback_utf8() {


### PR DESCRIPTION
Two hardening fixes to the shared scraper HTTP helper (`scraping/http/mod.rs`), both surfaced during the board verification sweep (#450).

## 1. `fetch_json` dropped caller headers (real bug)

It built request headers by replacing `opts.headers` with only `accept: application/json`, silently dropping caller headers — including arbeitsagentur's `X-API-Key`. That's what made the arbeitsagentur auth failure show up as **"empty results"** instead of a 401. Now it **merges**: caller headers are preserved and the JSON `accept` is added only if the caller didn't set one (single `accept`, no duplicate). `arbeitsagentur` moves back to `fetch_json` (its `fetch_text`-and-manual-deserialize workaround is removed).

## 2. Size cap enforced only after full buffering

`fetch_text` read the entire body via `Response::text()` **before** checking the cap, so a response that omits or lies about `Content-Length` could OOM — the guard was effectively useless. It now streams via `bytes_stream()` and aborts the moment the buffer exceeds the cap (peak ≈ cap + one chunk), keeping the cheap `content-length` pre-check as the first line. Charset is decoded with `encoding_rs` (already a transitive reqwest dep — zero new supply-chain surface), honoring the `Content-Type` charset with a UTF-8 fallback, so German/legacy encodings round-trip with no mojibake.

## Reviews & tests

- scraping-applier-expert + tauri-security-reviewer: **approved**, no HIGH/CRITICAL. Cap genuinely bounds memory; `encoding_rs` is the same crate reqwest uses internally.
- New tests: header forwarding (wiremock), stream-cap with no Content-Length, and charset decode for **utf-8 / iso-8859-1 / missing-charset**. `cargo test scraping::` green (23 in the http module); live boards (germantechjobs, arbeitsagentur, greenhouse) verified — correct decode + X-API-Key now flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP fetching with streamed response buffering, stricter max-size enforcement, and automatic charset-based decoding.
  * Prevented duplicate `accept` headers by respecting caller-supplied values.
  * Updated scraping to use typed JSON fetching for both list and detail endpoints.
* **Tests**
  * Added async unit tests covering JSON header forwarding, oversized response handling, and charset decoding (UTF-8 and ISO-8859-1).
* **Chores**
  * Added an explicit charset decoding dependency for improved response body decoding accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->