### PR TITLE
fix(i18n): add the glassdoor board label

### DIFF
--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1557,6 +1557,7 @@
       "indeed": "Indeed",
       "stepstone": "StepStone",
       "xing": "XING",
+      "glassdoor": "Glassdoor",
       "arbeitsagentur": "Arbeitsagentur",
       "berlinstartupjobs": "Berlin Startup",
       "germantechjobs": "German Tech",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1553,6 +1553,7 @@
       "indeed": "Indeed",
       "stepstone": "StepStone",
       "xing": "XING",
+      "glassdoor": "Glassdoor",
       "arbeitsagentur": "Arbeitsagentur",
       "berlinstartupjobs": "Berlin Startup",
       "germantechjobs": "German Tech",


### PR DESCRIPTION
## What
Add the missing `jobs.boards.glassdoor` label to the en + de translations.

## Why
Glassdoor became visible in the jobs board picker in #456, but `jobs.boards` had no `glassdoor` entry, so `t('jobs.boards.glassdoor')` rendered the raw key in the UI.

## Changes
- `en/translation.json` + `de/translation.json`: add `"glassdoor": "Glassdoor"` to `jobs.boards` (brand name, untranslated).

## Test plan
- `pnpm --filter @ajh/translations build` — passes (JSON valid). No board-label completeness test exists; the one `jobs.boards.glassdoor` spot-check (`ScrapeForm.test.tsx`) uses a mock catalog and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Glassdoor as a supported job board option in German and English languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->