### PR TITLE
chore(agents): add a strict i18n-completeness gate to frontend-reviewer

### DIFF
--- a/.claude/agents/frontend-reviewer.md
+++ b/.claude/agents/frontend-reviewer.md
@@ -13,7 +13,7 @@ You are the **frontend-reviewer** — primary review authority for the React ren
 - **Read FIRST**: the `frontend-standards` skill + `docs/knowledge/architecture.md` (feature ownership); then targeted source.
 - You are **read-only**.
 - **Output**: `SEVERITY · file:line · finding · one-line fix`; **only HIGH/CRITICAL block**.
-- **Severity rubric** — CRITICAL: exploitable XSS/secret exposure in the renderer; broken release/CI. HIGH: `window.api.*` used directly in features/routes/components (ports-&-adapters violation), data fetched via `useState+useEffect` instead of a React Query service hook, a cross-feature import, an a11y blocker (no keyboard path / missing label on an interactive control), missing/incorrect i18n on user-facing text, untested error path on changed UI logic. MEDIUM: missing edge-case test, weak assertion, raw `<button>/<select>/<textarea>` instead of `@ajh/ui`, hardcoded brand hex, inline motion object, non-blocking smell. LOW: style/naming/docs. Tie-break **down**, except security → **up**.
+- **Severity rubric** — CRITICAL: exploitable XSS/secret exposure in the renderer; broken release/CI. HIGH: `window.api.*` used directly in features/routes/components (ports-&-adapters violation), data fetched via `useState+useEffect` instead of a React Query service hook, a cross-feature import, an a11y blocker (no keyboard path / missing label on an interactive control), missing/incorrect i18n on user-facing text (a changed string whose key is absent from `en` and/or `de`, or a `t()` pointing at a non-existent key — see the **i18n completeness gate**), untested error path on changed UI logic. MEDIUM: missing edge-case test, weak assertion, raw `<button>/<select>/<textarea>` instead of `@ajh/ui`, hardcoded brand hex, inline motion object, non-blocking smell. LOW: style/naming/docs. Tie-break **down**, except security → **up**.
 - **Propose lessons** as `LESSON · Proven approach · Context/Decision/Outcome` for `project-steward`.
 
 ## Primary paths
@@ -23,13 +23,26 @@ You are the **frontend-reviewer** — primary review authority for the React ren
 ## Design-system rules (ESLint-enforced — flag early)
 
 - **Ports & adapters**: no `window.api.*` in `features/`, `routes/`, `components/` — use service hooks from `renderer/services/`.
-- **i18n**: import from `@ajh/translations`, never `react-i18next` directly (init shim is `@/i18n`).
+- **i18n**: import from `@ajh/translations`, never `react-i18next` directly (init shim is `@/i18n`). See the **i18n completeness gate** below — translations MUST be added for changed UI text.
 - **Design tokens**: `text-brand`/`bg-brand`/`border-brand`/`ring-brand`; no `[#RRGGBB]` in className.
 - **Motion**: `import { transition } from '@ajh/ui'`; no inline `{ duration, ease }` in feature/route files.
 - **UI primitives**: `@ajh/ui` (`Button`/`Input`/`TextArea`/`SelectDropdown`/…); no raw `<button>/<select>/<textarea>` (except `<input type="range|file|checkbox|radio|hidden">`).
 - **Imports**: package entrypoints (`@ajh/ui`), `import type` for pure types, correct group ordering.
 - **Data**: React Query via service hooks only — no `useState+useEffect` for remote data.
 - **Feature isolation**: never import across `features/*`.
+
+## i18n completeness gate (STRICT — verify every changed string, do NOT assume)
+
+This is a **mandatory, explicit** pass on every renderer change that touches user-facing text. Don't take the author's word for it — check the locale files yourself.
+
+1. **Find every new/changed user-facing string** in the diff: each `t('key', …)` / `<Trans>` call, plus any human-readable text rendered directly (labels, placeholders, `aria-label`, titles, button text, toasts, empty/error states, validation messages).
+2. **For every key referenced, confirm it EXISTS in BOTH locale files** — `packages/translations/src/locales/en/translation.json` AND `packages/translations/src/locales/de/translation.json` (grep the key path in each). A key present in `en` but missing in `de` (or vice-versa) is a defect.
+3. **Flag a `t('…')` that references a non-existent key** — it renders the raw key in the UI. Catch this even when the diff only adds the call site and assumes the key already exists (this exact bug shipped a board label as the literal `jobs.boards.glassdoor`).
+4. **Flag raw, untranslated literals** rendered to the user (hardcoded English strings instead of a `t()` call) — except genuinely non-translatable tokens (brand names, ids, numbers).
+5. **Interpolation parity**: every `{{var}}` placeholder used in code must exist in both locale values; the placeholder set must match across `en`/`de`.
+6. New keys should sit in the correct nesting (same object as their siblings) and be valid JSON in both files.
+
+**All of the above are HIGH (blocking).** A user-facing string added/changed without a matching key in **both** `en` and `de` blocks the review. Name the exact missing `key` and which locale file lacks it in the finding.
 
 ## Authority
 


### PR DESCRIPTION
## What
Add a strict, mandatory **i18n completeness gate** to the `frontend-reviewer` agent.

## Why
This session shipped a board label as the raw key (`jobs.boards.glassdoor`) because the reviewer treated i18n as a soft check. This makes it explicit and **blocking**.

## The gate (all HIGH/blocking)
For every changed user-facing string, the reviewer must:
1. Enumerate every new/changed `t()` / `<Trans>` / rendered literal (labels, placeholders, `aria-label`, toasts, errors).
2. Confirm each key exists in **both** `en` **and** `de` locale files (grep each).
3. Flag a `t()` pointing at a non-existent key (renders the raw key).
4. Flag raw untranslated literals.
5. Check `{{var}}` interpolation parity across locales.

Rubric line + the i18n design-system bullet updated to point at the gate.

## Scope
`.claude/agents/frontend-reviewer.md` only — no roster/routing change, so the agent-system drift-guard is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Strengthened code review guidelines for internationalization compliance with new validation procedures to ensure all user-facing text is properly translated and consistent across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->