### PR TITLE
feat(scraping): add adzuna and jsearch aggregator with key settings

### DIFF
--- a/apps/tauri/src-tauri/src/credentials/mod.rs
+++ b/apps/tauri/src-tauri/src/credentials/mod.rs
@@ -171,5 +171,21 @@ impl CredentialStore {
     }
 }
 
+/// Read a single credential directly from the OS keychain by its full `slot`
+/// name (e.g. `"ai:adzuna-app-key"`), without needing an `AppHandle` or the
+/// metadata cache. Returns `None` when the entry is absent or the keychain is
+/// unavailable.
+///
+/// Workers (scrapers, autopilot tasks) that have no `AppHandle` use this
+/// instead of `get_provider_key`; it reuses the same keyring backend
+/// initialized at startup by [`init_keyring`].
+pub fn read_credential(slot: &str) -> Option<String> {
+    Entry::new(SERVICE, slot)
+        .ok()?
+        .get_password()
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
 #[cfg(test)]
 mod test;

--- a/apps/tauri/src-tauri/src/credentials/mod.rs
+++ b/apps/tauri/src-tauri/src/credentials/mod.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use crate::db::now_ms;
 use crate::error::{AppError, AppResult};
 
-const SERVICE: &str = "com.ajh.tauri";
+pub(crate) const SERVICE: &str = "com.ajh.tauri";
 
 /// Initialise the OS-native keyring backend. Must be called once before any
 /// `Entry` operations. Returns [`AppError::Storage`] if the platform secret
@@ -173,18 +173,55 @@ impl CredentialStore {
 
 /// Read a single credential directly from the OS keychain by its full `slot`
 /// name (e.g. `"ai:adzuna-app-key"`), without needing an `AppHandle` or the
-/// metadata cache. Returns `None` when the entry is absent or the keychain is
-/// unavailable.
+/// metadata cache.
+///
+/// Returns:
+/// - `Ok(Some(value))` — credential found and non-empty.
+/// - `Ok(None)` — credential not set or stored empty (`NoEntry`).
+/// - `Err(AppError::Storage)` — OS keyring is unavailable (locked store,
+///   permission denied, etc.); this is a genuine fault, NOT "key absent".
+///
+/// Caller policy for the `Err` case:
+/// - **Critical keys** (a credential the operation cannot proceed without)
+///   should surface the `Err` so the user learns the keyring is broken, rather
+///   than silently behaving as if the key were unset.
+/// - **Optional keys** (e.g. the aggregator's third-party Adzuna / JSearch API
+///   keys) may degrade gracefully: log the error and treat the key as absent
+///   (`None`). Never crash a user-triggered action over a missing or unreadable
+///   optional key — the board simply yields keyless-empty results.
 ///
 /// Workers (scrapers, autopilot tasks) that have no `AppHandle` use this
 /// instead of `get_provider_key`; it reuses the same keyring backend
 /// initialized at startup by [`init_keyring`].
-pub fn read_credential(slot: &str) -> Option<String> {
-    Entry::new(SERVICE, slot)
-        .ok()?
-        .get_password()
-        .ok()
-        .filter(|s| !s.is_empty())
+pub fn read_credential(slot: &str) -> AppResult<Option<String>> {
+    let entry = Entry::new(SERVICE, slot)
+        .map_err(|e| AppError::Storage(format!("keyring entry error for {slot}: {e}")))?;
+    match entry.get_password() {
+        Ok(pw) => Ok(if pw.is_empty() { None } else { Some(pw) }),
+        Err(keyring_core::Error::NoEntry) => Ok(None),
+        Err(e) => Err(AppError::Storage(format!(
+            "keyring read error for {slot}: {e}"
+        ))),
+    }
+}
+
+/// Test-only keyring harness shared across the workspace's unit tests.
+///
+/// `keyring_core::set_default_store` installs a PROCESS-GLOBAL store, and Cargo
+/// runs the lib test binary multi-threaded. To avoid one test replacing the
+/// store out from under another (which would orphan already-created mock
+/// `Cred`s), every test that needs the keyring goes through this single `Once`,
+/// installing keyring-core's in-memory `mock::Store` exactly once for the whole
+/// binary. Tests then isolate themselves by using unique slot names rather than
+/// by swapping stores. Lives here (not in `test.rs`) so sibling modules like the
+/// aggregator can share the same install path.
+#[cfg(test)]
+pub(crate) fn install_mock_keyring() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        keyring_core::set_default_store(keyring_core::mock::Store::new().unwrap());
+    });
 }
 
 #[cfg(test)]

--- a/apps/tauri/src-tauri/src/credentials/test.rs
+++ b/apps/tauri/src-tauri/src/credentials/test.rs
@@ -3,6 +3,25 @@ use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 
+// ── Keyring mock harness ──────────────────────────────────────────────────────
+//
+// keyring-core v1 ships an in-memory `mock::Store` (platform-independent, no
+// persistence) that lets us exercise the real `Entry` path — including the
+// non-`NoEntry` error branch of `read_credential` — without touching the OS
+// keychain. (The earlier "no mock backend" note above predated this; the C4
+// metadata tests still stand on their own.)
+//
+// The store is process-global, so installation funnels through the shared
+// `install_mock_keyring` (see `mod.rs`). Tests then use UUID-unique slot names so
+// their `Cred`s never collide, keeping them race-safe under Cargo's multi-thread
+// test runner.
+
+/// A slot name guaranteed unique to this test invocation, so its mock `Cred`
+/// is never shared with another (possibly concurrent) test.
+fn unique_slot(prefix: &str) -> String {
+    format!("{prefix}-{}", uuid::Uuid::new_v4())
+}
+
 #[test]
 fn test_is_available() {
     let temp_dir = TempDir::new().unwrap();
@@ -60,16 +79,15 @@ fn test_now_ms() {
 
 // ── C4 — Credential metadata persistence layer ───────────────────────────────
 //
-// keyring-core v1 uses platform-specific stores (DPAPI / Keychain / libsecret)
-// and does NOT expose a mock/in-memory credential builder in this version.
-// Full round-trip tests (set → get_decrypted) would hit the real OS keychain,
-// which is unsuitable for automated tests (CI agents may have no keychain,
-// Windows DPAPI is user-scoped and can fail in sandboxes).
+// The production keychain uses platform-specific stores (DPAPI / Keychain /
+// libsecret) that are unsuitable for automated tests (CI agents may have no
+// keychain; Windows DPAPI is user-scoped and can fail in sandboxes). These C4
+// tests therefore exercise the METADATA layer (credential-meta.json) in
+// isolation, driving `save_meta`/`load_meta` through the public API.
 //
-// We therefore test the METADATA layer (credential-meta.json) in isolation:
-// the `save_meta`/`load_meta` path is exercised indirectly through the public
-// API. The keychain operations (Entry::new / set_password / get_password) are
-// noted as untestable at unit level without a mock backend.
+// Where we DO need to drive the keyring `Entry` path (see the `read_credential`
+// tests below), we install keyring-core's in-memory `mock::Store` instead of
+// the OS keychain.
 
 /// Write a metadata file directly (bypassing `set`, which needs the keychain)
 /// and return a CredentialStore that reads from that file via `list()`.
@@ -230,5 +248,84 @@ fn get_decrypted_returns_none_when_no_metadata_entry() {
     assert!(
         result.is_none(),
         "get_decrypted must return None for an unregistered board_id"
+    );
+}
+
+// ── read_credential — keyring-backed branches (via the in-memory mock store) ──
+
+#[test]
+fn read_credential_missing_slot_returns_ok_none() {
+    // NoEntry branch: a slot that was never set must map to Ok(None) so OPTIONAL
+    // callers (e.g. the aggregator) degrade gracefully instead of erroring.
+    install_mock_keyring();
+    let slot = unique_slot("ai:nonexistent");
+
+    let result = read_credential(&slot);
+    assert!(
+        matches!(result, Ok(None)),
+        "missing slot must read as Ok(None); got {result:?}"
+    );
+}
+
+#[test]
+fn read_credential_present_slot_returns_value() {
+    // Happy path: a stored non-empty value reads back as Ok(Some(value)).
+    install_mock_keyring();
+    let slot = unique_slot("ai:present");
+    keyring_core::Entry::new(SERVICE, &slot)
+        .unwrap()
+        .set_password("super-secret-key")
+        .unwrap();
+
+    let result = read_credential(&slot);
+    assert!(
+        matches!(
+            result.as_ref().map(Option::as_deref),
+            Ok(Some("super-secret-key"))
+        ),
+        "present slot must read as Ok(Some(value)); got {result:?}"
+    );
+}
+
+#[test]
+fn read_credential_empty_value_returns_ok_none() {
+    // An empty stored value is treated as "absent" (Ok(None)) — the same
+    // degradation path as NoEntry, so an empty key never reads as configured.
+    install_mock_keyring();
+    let slot = unique_slot("ai:empty");
+    keyring_core::Entry::new(SERVICE, &slot)
+        .unwrap()
+        .set_password("")
+        .unwrap();
+
+    let result = read_credential(&slot);
+    assert!(
+        matches!(result, Ok(None)),
+        "empty stored value must read as Ok(None); got {result:?}"
+    );
+}
+
+#[test]
+fn read_credential_non_no_entry_error_returns_storage_err() {
+    // The "other keyring error" branch: any keyring failure that is NOT NoEntry
+    // (locked store, permission denied, …) must surface as AppError::Storage so
+    // CRITICAL callers can decide to surface it rather than silently degrade.
+    //
+    // The mock store lets us arm a specific error on a Cred; the next Entry call
+    // returns it (and then clears it). We arm a non-NoEntry error and assert the
+    // mapping. UUID-unique slot keeps this Cred isolated from concurrent tests.
+    install_mock_keyring();
+    let slot = unique_slot("ai:errslot");
+    let entry = keyring_core::Entry::new(SERVICE, &slot).unwrap();
+    let mock: &keyring_core::mock::Cred = entry.as_any().downcast_ref().unwrap();
+    mock.set_error(keyring_core::Error::Invalid(
+        "induced".to_string(),
+        "non-NoEntry keyring failure".to_string(),
+    ));
+
+    let result = read_credential(&slot);
+    assert!(
+        matches!(result, Err(AppError::Storage(_))),
+        "non-NoEntry keyring error must map to AppError::Storage; got {result:?}"
     );
 }

--- a/apps/tauri/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -82,8 +82,14 @@ pub(crate) struct AdzunaProvider {
 impl AdzunaProvider {
     fn new() -> Self {
         Self {
-            app_id: crate::credentials::read_credential("ai:adzuna-app-id"),
-            app_key: crate::credentials::read_credential("ai:adzuna-app-key"),
+            app_id: crate::credentials::read_credential("ai:adzuna-app-id").unwrap_or_else(|e| {
+                log::warn!("[aggregator] adzuna-app-id keyring error: {e}");
+                None
+            }),
+            app_key: crate::credentials::read_credential("ai:adzuna-app-key").unwrap_or_else(|e| {
+                log::warn!("[aggregator] adzuna-app-key keyring error: {e}");
+                None
+            }),
         }
     }
 }
@@ -114,13 +120,15 @@ impl JobProvider for AdzunaProvider {
 
         let country = if country.is_empty() { "de" } else { country };
         let country_enc = urlencoding::encode(country);
+        let app_id_enc = urlencoding::encode(app_id);
+        let app_key_enc = urlencoding::encode(app_key);
         let q_enc = urlencoding::encode(query);
         let loc_enc = urlencoding::encode(location);
 
         let url = format!(
             "https://api.adzuna.com/v1/api/jobs/{}/search/1\
              ?app_id={}&app_key={}&what={}&where={}&results_per_page=50&content-type=application/json",
-            country_enc, app_id, app_key, q_enc, loc_enc
+            country_enc, app_id_enc, app_key_enc, q_enc, loc_enc
         );
 
         let result = fetch_json::<AdzunaResp>(&url, FetchOptions::default(), signal).await?;
@@ -197,7 +205,10 @@ pub(crate) struct JSearchProvider {
 impl JSearchProvider {
     fn new() -> Self {
         Self {
-            api_key: crate::credentials::read_credential("ai:jsearch-key"),
+            api_key: crate::credentials::read_credential("ai:jsearch-key").unwrap_or_else(|e| {
+                log::warn!("[aggregator] jsearch-key keyring error: {e}");
+                None
+            }),
         }
     }
 }
@@ -376,23 +387,7 @@ fn dedupe(items: Vec<JobPosting>) -> Vec<JobPosting> {
 
 // ── Scraper impl ──────────────────────────────────────────────────────────────
 
-/// Credentials are process-stable (read from keyring at startup, not rotated
-/// at runtime without a restart).  Cache the constructed providers so we don't
-/// hit the OS keyring on every search call.
-static PROVIDERS: std::sync::OnceLock<Vec<Box<dyn JobProvider>>> = std::sync::OnceLock::new();
-
 pub struct AggregatorScraper;
-
-impl AggregatorScraper {
-    fn providers() -> &'static [Box<dyn JobProvider>] {
-        PROVIDERS.get_or_init(|| {
-            vec![
-                Box::new(AdzunaProvider::new()),
-                Box::new(JSearchProvider::new()),
-            ]
-        })
-    }
-}
 
 #[async_trait]
 impl Scraper for AggregatorScraper {
@@ -430,9 +425,15 @@ impl Scraper for AggregatorScraper {
             .map(str::to_lowercase)
             .unwrap_or_else(|| "de".to_string());
 
-        let providers = Self::providers();
+        // Construct providers fresh per call so that key changes made in Settings
+        // take effect immediately without requiring an app restart.
+        let providers: Vec<Box<dyn JobProvider>> = vec![
+            Box::new(AdzunaProvider::new()),
+            Box::new(JSearchProvider::new()),
+        ];
         let items =
-            search_with_providers(providers, query, location, &country, ctx.signal.clone()).await?;
+            search_with_providers(&providers, query, location, &country, ctx.signal.clone())
+                .await?;
 
         let amount = input.amount as usize;
         let mut out = Vec::new();

--- a/apps/tauri/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -1,0 +1,459 @@
+/// Aggregator board — Adzuna (primary) with JSearch (paid fallback).
+///
+/// Design:
+/// * One `Scraper` in the registry (id = `"aggregator"`).
+/// * Internally holds an ordered `JobProvider` registry: Adzuna → JSearch.
+/// * Fallback semantics (enforced in `search_with_providers`):
+///   - Adzuna configured + `Ok(items)` (even empty) → use those, do NOT call JSearch.
+///   - Adzuna configured + `Err(_)` → log, try JSearch if configured.
+///   - Adzuna not configured → try JSearch if configured.
+///   - Neither configured → `Ok(vec![])` (keyless-empty, never an error).
+/// * Keys are optional: absent = keyless-empty.  Never hardcoded, never logged.
+/// * Keys are read from the OS keychain via `credentials::read_credential`:
+///   - `ai:adzuna-app-id`   — Adzuna application ID
+///   - `ai:adzuna-app-key`  — Adzuna application key
+///   - `ai:jsearch-key`     — RapidAPI key for JSearch
+///
+/// Rate-limiting and cancellation are honoured: every network call flows
+/// through `scraping::http::fetch_json` (which checks `ctx.signal` and calls
+/// the per-host `rate_limiter`).
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::scraping::http::{fetch_json, strip_html, FetchOptions};
+use crate::scraping::types::{
+    AuthRequirement, BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode,
+};
+
+// ── Provider trait ────────────────────────────────────────────────────────────
+
+/// A single search-API backend.  Object-safe so the scraper can hold a
+/// `Vec<Box<dyn JobProvider>>` without generics leaking into the `Scraper` trait.
+#[async_trait]
+pub(crate) trait JobProvider: Send + Sync {
+    fn provider_id(&self) -> &'static str;
+    /// True when the necessary API keys are present in the credential store.
+    fn is_configured(&self) -> bool;
+    /// Run a search.  Non-2xx or network errors are returned as `Err`.
+    async fn search(
+        &self,
+        query: &str,
+        location: &str,
+        country: &str,
+        signal: tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<Vec<JobPosting>>;
+}
+
+// ── Adzuna provider ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct AdzunaCompany {
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdzunaLocation {
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdzunaJob {
+    id: String,
+    title: String,
+    company: Option<AdzunaCompany>,
+    location: Option<AdzunaLocation>,
+    redirect_url: String,
+    description: Option<String>,
+    created: Option<String>,
+    salary_min: Option<f64>,
+    salary_max: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdzunaResp {
+    results: Vec<AdzunaJob>,
+}
+
+pub(crate) struct AdzunaProvider {
+    app_id: Option<String>,
+    app_key: Option<String>,
+}
+
+impl AdzunaProvider {
+    fn new() -> Self {
+        Self {
+            app_id: crate::credentials::read_credential("ai:adzuna-app-id"),
+            app_key: crate::credentials::read_credential("ai:adzuna-app-key"),
+        }
+    }
+}
+
+#[async_trait]
+impl JobProvider for AdzunaProvider {
+    fn provider_id(&self) -> &'static str {
+        "adzuna"
+    }
+
+    fn is_configured(&self) -> bool {
+        self.app_id.is_some() && self.app_key.is_some()
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        location: &str,
+        country: &str,
+        signal: tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        if !self.is_configured() {
+            return Err(anyhow::anyhow!("adzuna: not configured"));
+        }
+
+        let app_id = self.app_id.as_deref().unwrap_or("");
+        let app_key = self.app_key.as_deref().unwrap_or("");
+
+        let country = if country.is_empty() { "de" } else { country };
+        let country_enc = urlencoding::encode(country);
+        let q_enc = urlencoding::encode(query);
+        let loc_enc = urlencoding::encode(location);
+
+        let url = format!(
+            "https://api.adzuna.com/v1/api/jobs/{}/search/1\
+             ?app_id={}&app_key={}&what={}&where={}&results_per_page=50&content-type=application/json",
+            country_enc, app_id, app_key, q_enc, loc_enc
+        );
+
+        let result = fetch_json::<AdzunaResp>(&url, FetchOptions::default(), signal).await?;
+        let resp = match result {
+            Some(r) => r,
+            None => {
+                return Err(anyhow::anyhow!(
+                    "adzuna: non-2xx response or unparseable body"
+                ))
+            }
+        };
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let postings = resp
+            .results
+            .into_iter()
+            .map(|j| {
+                let mut extra = std::collections::HashMap::new();
+                if let Some(min) = j.salary_min {
+                    extra.insert("salaryMin".to_string(), serde_json::json!(min));
+                }
+                if let Some(max) = j.salary_max {
+                    extra.insert("salaryMax".to_string(), serde_json::json!(max));
+                }
+                JobPosting {
+                    id: format!("aggregator:adzuna-{}", j.id),
+                    external_id: Some(format!("adzuna-{}", j.id)),
+                    title: j.title,
+                    company: j.company.and_then(|c| c.display_name).unwrap_or_default(),
+                    location: j.location.and_then(|l| l.display_name),
+                    url: j.redirect_url,
+                    source: "aggregator".to_string(),
+                    description: j.description.map(|d| strip_html(&d)),
+                    requirements: None,
+                    posted_at: j
+                        .created
+                        .as_deref()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .map(|dt| dt.timestamp_millis()),
+                    captured_at: now,
+                    extra,
+                }
+            })
+            .collect();
+
+        Ok(postings)
+    }
+}
+
+// ── JSearch provider ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct JSearchJob {
+    job_id: String,
+    job_title: String,
+    employer_name: Option<String>,
+    job_city: Option<String>,
+    job_country: Option<String>,
+    job_apply_link: Option<String>,
+    job_google_link: Option<String>,
+    job_description: Option<String>,
+    job_posted_at_datetime_utc: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JSearchResp {
+    data: Vec<JSearchJob>,
+}
+
+pub(crate) struct JSearchProvider {
+    api_key: Option<String>,
+}
+
+impl JSearchProvider {
+    fn new() -> Self {
+        Self {
+            api_key: crate::credentials::read_credential("ai:jsearch-key"),
+        }
+    }
+}
+
+#[async_trait]
+impl JobProvider for JSearchProvider {
+    fn provider_id(&self) -> &'static str {
+        "jsearch"
+    }
+
+    fn is_configured(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        location: &str,
+        _country: &str,
+        signal: tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        if !self.is_configured() {
+            return Err(anyhow::anyhow!("jsearch: not configured"));
+        }
+
+        let api_key = self.api_key.as_deref().unwrap_or("");
+
+        // JSearch takes a single free-text query field; combine query + location.
+        let combined = if location.is_empty() {
+            query.to_string()
+        } else {
+            format!("{query} in {location}")
+        };
+        let q_enc = urlencoding::encode(&combined);
+        let url = format!(
+            "https://jsearch.p.rapidapi.com/search?query={}&page=1&num_pages=1",
+            q_enc
+        );
+
+        let result = fetch_json::<JSearchResp>(
+            &url,
+            FetchOptions {
+                headers: Some(vec![
+                    ("X-RapidAPI-Key".to_string(), api_key.to_string()),
+                    (
+                        "X-RapidAPI-Host".to_string(),
+                        "jsearch.p.rapidapi.com".to_string(),
+                    ),
+                ]),
+                ..FetchOptions::default()
+            },
+            signal,
+        )
+        .await?;
+
+        let resp = match result {
+            Some(r) => r,
+            None => {
+                return Err(anyhow::anyhow!(
+                    "jsearch: non-2xx response or unparseable body"
+                ))
+            }
+        };
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let postings = resp
+            .data
+            .into_iter()
+            .filter_map(|j| {
+                let url = j
+                    .job_apply_link
+                    .clone()
+                    .or_else(|| j.job_google_link.clone())?;
+                let location = match (j.job_city.as_deref(), j.job_country.as_deref()) {
+                    (Some(c), Some(co)) if !c.is_empty() && !co.is_empty() => {
+                        Some(format!("{c}, {co}"))
+                    }
+                    (Some(c), _) if !c.is_empty() => Some(c.to_string()),
+                    (_, Some(co)) if !co.is_empty() => Some(co.to_string()),
+                    _ => None,
+                };
+                Some(JobPosting {
+                    id: format!("aggregator:jsearch-{}", j.job_id),
+                    external_id: Some(format!("jsearch-{}", j.job_id)),
+                    title: j.job_title,
+                    company: j.employer_name.unwrap_or_default(),
+                    location,
+                    url,
+                    source: "aggregator".to_string(),
+                    description: j.job_description.map(|d| strip_html(&d)),
+                    requirements: None,
+                    posted_at: j
+                        .job_posted_at_datetime_utc
+                        .as_deref()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .map(|dt| dt.timestamp_millis()),
+                    captured_at: now,
+                    extra: std::collections::HashMap::new(),
+                })
+            })
+            .collect();
+
+        Ok(postings)
+    }
+}
+
+// ── Fallback logic ────────────────────────────────────────────────────────────
+
+/// Run the provider chain: Adzuna primary, JSearch fallback.
+///
+/// Fallback rule (spec):
+/// - Adzuna configured, `Ok(items)` (even empty) → return those; skip JSearch.
+/// - Adzuna configured, `Err(_)`                 → log; try JSearch if configured.
+/// - Adzuna not configured                        → try JSearch if configured.
+/// - Neither configured                           → `Ok(vec![])` (keyless-empty).
+///
+/// Items from each provider are keyed by their `external_id` to deduplicate.
+async fn search_with_providers(
+    providers: &[Box<dyn JobProvider>],
+    query: &str,
+    location: &str,
+    country: &str,
+    signal: tokio_util::sync::CancellationToken,
+) -> anyhow::Result<Vec<JobPosting>> {
+    if signal.is_cancelled() {
+        return Ok(vec![]);
+    }
+
+    // Locate primary (Adzuna) and fallback (JSearch) by id.
+    let primary = providers.iter().find(|p| p.provider_id() == "adzuna");
+    let fallback = providers.iter().find(|p| p.provider_id() == "jsearch");
+
+    // Run primary if configured.
+    if let Some(p) = primary {
+        if p.is_configured() {
+            match p.search(query, location, country, signal.clone()).await {
+                Ok(items) => {
+                    // Even empty → use result as-is; do NOT fall through to JSearch.
+                    return Ok(dedupe(items));
+                }
+                Err(e) => {
+                    log::warn!("[aggregator] adzuna error, attempting jsearch fallback: {e}");
+                    // Fall through to JSearch below.
+                }
+            }
+        }
+    }
+
+    // Guard: don't fire a paid JSearch call after cancellation.
+    if signal.is_cancelled() {
+        return Ok(vec![]);
+    }
+
+    // Try fallback.
+    if let Some(f) = fallback {
+        if f.is_configured() {
+            return f.search(query, location, country, signal).await.map(dedupe);
+        }
+    }
+
+    // Neither configured.
+    Ok(vec![])
+}
+
+/// Deduplicate by `external_id`, preserving first-seen order.
+fn dedupe(items: Vec<JobPosting>) -> Vec<JobPosting> {
+    let mut seen = std::collections::HashSet::new();
+    items
+        .into_iter()
+        .filter(|p| {
+            let key = p.external_id.clone().unwrap_or_else(|| p.url.clone());
+            seen.insert(key)
+        })
+        .collect()
+}
+
+// ── Scraper impl ──────────────────────────────────────────────────────────────
+
+/// Credentials are process-stable (read from keyring at startup, not rotated
+/// at runtime without a restart).  Cache the constructed providers so we don't
+/// hit the OS keyring on every search call.
+static PROVIDERS: std::sync::OnceLock<Vec<Box<dyn JobProvider>>> = std::sync::OnceLock::new();
+
+pub struct AggregatorScraper;
+
+impl AggregatorScraper {
+    fn providers() -> &'static [Box<dyn JobProvider>] {
+        PROVIDERS.get_or_init(|| {
+            vec![
+                Box::new(AdzunaProvider::new()),
+                Box::new(JSearchProvider::new()),
+            ]
+        })
+    }
+}
+
+#[async_trait]
+impl Scraper for AggregatorScraper {
+    fn id(&self) -> &'static str {
+        "aggregator"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Aggregated Jobs"
+    }
+
+    fn mode(&self) -> ScraperMode {
+        ScraperMode::Http
+    }
+
+    fn auth(&self) -> AuthRequirement {
+        // Keys are optional config, not a login requirement.
+        AuthRequirement::Guest
+    }
+
+    fn requires_company(&self) -> bool {
+        false
+    }
+
+    async fn search(
+        &self,
+        input: BoardSearchInput,
+        ctx: ScrapeContext,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        let query = input.query.trim();
+        let location = input.location.as_deref().unwrap_or("").trim();
+        let country = input
+            .country_code
+            .as_deref()
+            .map(str::to_lowercase)
+            .unwrap_or_else(|| "de".to_string());
+
+        let providers = Self::providers();
+        let items =
+            search_with_providers(providers, query, location, &country, ctx.signal.clone()).await?;
+
+        let amount = input.amount as usize;
+        let mut out = Vec::new();
+
+        for posting in items.into_iter().take(amount) {
+            if ctx.signal.is_cancelled() {
+                break;
+            }
+            if let Some(ref on_item) = ctx.on_item {
+                on_item(posting.clone());
+            }
+            out.push(posting);
+        }
+
+        if let Some(ref on_progress) = ctx.on_progress {
+            on_progress(1.0);
+        }
+
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/apps/tauri/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -1,0 +1,537 @@
+use super::*;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_token() -> tokio_util::sync::CancellationToken {
+    tokio_util::sync::CancellationToken::new()
+}
+
+fn sample_posting(id: &str, provider: &str) -> JobPosting {
+    JobPosting {
+        id: format!("aggregator:{provider}-{id}"),
+        external_id: Some(format!("{provider}-{id}")),
+        title: format!("Engineer {id}"),
+        company: "Acme".to_string(),
+        location: Some("Berlin, DE".to_string()),
+        url: format!("https://{provider}.example.com/job/{id}"),
+        source: "aggregator".to_string(),
+        description: None,
+        requirements: None,
+        posted_at: None,
+        captured_at: 0,
+        extra: std::collections::HashMap::new(),
+    }
+}
+
+// ── Fake providers ────────────────────────────────────────────────────────────
+
+struct FakeProvider {
+    id: &'static str,
+    configured: bool,
+    result: Result<Vec<JobPosting>, &'static str>,
+}
+
+impl FakeProvider {
+    fn ok(id: &'static str, items: Vec<JobPosting>) -> Self {
+        Self {
+            id,
+            configured: true,
+            result: Ok(items),
+        }
+    }
+
+    fn err(id: &'static str, msg: &'static str) -> Self {
+        Self {
+            id,
+            configured: true,
+            result: Err(msg),
+        }
+    }
+
+    fn unconfigured(id: &'static str) -> Self {
+        Self {
+            id,
+            configured: false,
+            result: Ok(vec![]),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl JobProvider for FakeProvider {
+    fn provider_id(&self) -> &'static str {
+        self.id
+    }
+
+    fn is_configured(&self) -> bool {
+        self.configured
+    }
+
+    async fn search(
+        &self,
+        _query: &str,
+        _location: &str,
+        _country: &str,
+        _signal: tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        match &self.result {
+            Ok(v) => Ok(v.clone()),
+            Err(msg) => Err(anyhow::anyhow!(*msg)),
+        }
+    }
+}
+
+// ── Fallback logic tests ──────────────────────────────────────────────────────
+
+/// Adzuna Ok(items) → those items returned, JSearch not called (fake JSearch
+/// always errors to prove it wasn't reached).
+#[tokio::test]
+async fn adzuna_ok_returns_items_no_jsearch() {
+    let posting = sample_posting("1", "adzuna");
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::ok("adzuna", vec![posting.clone()])),
+        Box::new(FakeProvider::err("jsearch", "should not be called")),
+    ];
+
+    let result = search_with_providers(&providers, "engineer", "berlin", "de", make_token())
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].external_id, posting.external_id);
+}
+
+/// Adzuna Ok(empty) → empty returned, JSearch NOT called.
+#[tokio::test]
+async fn adzuna_ok_empty_does_not_call_jsearch() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::ok("adzuna", vec![])),
+        // JSearch is configured and would return items — but must not be called.
+        Box::new(FakeProvider::ok(
+            "jsearch",
+            vec![sample_posting("1", "jsearch")],
+        )),
+    ];
+
+    let result = search_with_providers(&providers, "engineer", "berlin", "de", make_token())
+        .await
+        .unwrap();
+
+    // Adzuna returned empty → result is empty (JSearch was bypassed).
+    assert_eq!(
+        result.len(),
+        0,
+        "JSearch must not be called when Adzuna returns Ok(empty)"
+    );
+}
+
+/// Adzuna Err → JSearch called and its results returned.
+#[tokio::test]
+async fn adzuna_err_falls_back_to_jsearch() {
+    let jsearch_posting = sample_posting("42", "jsearch");
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::err("adzuna", "api error")),
+        Box::new(FakeProvider::ok("jsearch", vec![jsearch_posting.clone()])),
+    ];
+
+    let result = search_with_providers(&providers, "engineer", "berlin", "de", make_token())
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].external_id, jsearch_posting.external_id);
+}
+
+/// Neither configured → Ok(empty), never an error.
+#[tokio::test]
+async fn neither_configured_returns_empty() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::unconfigured("adzuna")),
+        Box::new(FakeProvider::unconfigured("jsearch")),
+    ];
+
+    let result = search_with_providers(&providers, "engineer", "berlin", "de", make_token())
+        .await
+        .unwrap();
+
+    assert!(result.is_empty());
+}
+
+/// Only JSearch configured (Adzuna absent) → JSearch used.
+#[tokio::test]
+async fn only_jsearch_configured_uses_jsearch() {
+    let jsearch_posting = sample_posting("7", "jsearch");
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::unconfigured("adzuna")),
+        Box::new(FakeProvider::ok("jsearch", vec![jsearch_posting.clone()])),
+    ];
+
+    let result = search_with_providers(&providers, "engineer", "berlin", "de", make_token())
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].external_id, jsearch_posting.external_id);
+}
+
+/// Adzuna Err and JSearch not configured → Ok(empty), never an error.
+#[tokio::test]
+async fn adzuna_err_and_no_jsearch_returns_empty() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::err("adzuna", "timeout")),
+        Box::new(FakeProvider::unconfigured("jsearch")),
+    ];
+
+    let result = search_with_providers(&providers, "engineer", "berlin", "de", make_token())
+        .await
+        .unwrap();
+
+    assert!(result.is_empty());
+}
+
+/// Deduplication: two items with the same external_id → only first kept.
+#[tokio::test]
+async fn deduplication_by_external_id() {
+    let dup = sample_posting("99", "adzuna");
+    let items = vec![dup.clone(), dup.clone()];
+    let deduped = dedupe(items);
+    assert_eq!(deduped.len(), 1);
+}
+
+// ── is_configured reflects key presence ──────────────────────────────────────
+
+#[test]
+fn adzuna_is_configured_requires_both_keys() {
+    // Neither key → not configured.
+    let unconfigured = AdzunaProvider {
+        app_id: None,
+        app_key: None,
+    };
+    assert!(!unconfigured.is_configured());
+
+    // Only one key → not configured.
+    let partial = AdzunaProvider {
+        app_id: Some("id123".to_string()),
+        app_key: None,
+    };
+    assert!(!partial.is_configured());
+
+    // Both keys → configured.
+    let full = AdzunaProvider {
+        app_id: Some("id123".to_string()),
+        app_key: Some("key456".to_string()),
+    };
+    assert!(full.is_configured());
+}
+
+#[test]
+fn jsearch_is_configured_reflects_key_presence() {
+    let no_key = JSearchProvider { api_key: None };
+    assert!(!no_key.is_configured());
+
+    let with_key = JSearchProvider {
+        api_key: Some("rapidapikey".to_string()),
+    };
+    assert!(with_key.is_configured());
+}
+
+// ── URL / query building ──────────────────────────────────────────────────────
+
+#[test]
+fn adzuna_url_encodes_query_and_location() {
+    // Verify that special characters in query/location don't break the URL.
+    // (We test the encoding indirectly via urlencoding::encode behavior.)
+    let q = "Rust & C++";
+    let loc = "München, Bayern";
+    let q_enc = urlencoding::encode(q).to_string();
+    let loc_enc = urlencoding::encode(loc).to_string();
+
+    assert!(q_enc.contains("%26"), "& must be percent-encoded");
+    assert!(!q_enc.contains(' '), "spaces must be encoded");
+    assert!(loc_enc.contains("%C3%BC"), "ü must be percent-encoded");
+}
+
+#[test]
+fn jsearch_combines_query_and_location() {
+    let query = "software engineer";
+    let location = "Berlin";
+    let combined = format!("{query} in {location}");
+    assert_eq!(combined, "software engineer in Berlin");
+}
+
+#[test]
+fn jsearch_query_only_when_location_empty() {
+    let query = "software engineer";
+    let location = "";
+    let combined = if location.is_empty() {
+        query.to_string()
+    } else {
+        format!("{query} in {location}")
+    };
+    assert_eq!(combined, "software engineer");
+}
+
+#[test]
+fn adzuna_defaults_country_to_de() {
+    let country = "";
+    let resolved = if country.is_empty() { "de" } else { country };
+    assert_eq!(resolved, "de");
+}
+
+// ── Adzuna response → JobPosting mapping ─────────────────────────────────────
+
+#[test]
+fn adzuna_response_maps_to_job_posting() {
+    // Parse a fixture that mirrors the real Adzuna JSON shape.
+    let json = serde_json::json!({
+        "count": 1,
+        "results": [{
+            "id": "abc123",
+            "title": "Senior Rust Engineer",
+            "company": { "display_name": "RustCorp" },
+            "location": { "display_name": "Berlin, Germany", "area": ["Germany", "Berlin"] },
+            "redirect_url": "https://api.adzuna.com/v1/api/jobs/de/redirects/abc123",
+            "description": "<p>Job description here</p>",
+            "created": "2026-06-01T09:00:00Z",
+            "salary_min": 70000.0,
+            "salary_max": 90000.0
+        }]
+    });
+
+    let resp: AdzunaResp = serde_json::from_value(json).unwrap();
+    let j = &resp.results[0];
+
+    assert_eq!(j.id, "abc123");
+    assert_eq!(j.title, "Senior Rust Engineer");
+    assert_eq!(
+        j.company.as_ref().and_then(|c| c.display_name.as_deref()),
+        Some("RustCorp")
+    );
+    assert_eq!(
+        j.location.as_ref().and_then(|l| l.display_name.as_deref()),
+        Some("Berlin, Germany")
+    );
+    assert_eq!(
+        j.redirect_url,
+        "https://api.adzuna.com/v1/api/jobs/de/redirects/abc123"
+    );
+    assert!(j
+        .description
+        .as_deref()
+        .unwrap_or("")
+        .contains("Job description"));
+    // posted_at: 2026-06-01T09:00:00Z → positive ms timestamp
+    let ts = chrono::DateTime::parse_from_rfc3339(j.created.as_deref().unwrap())
+        .unwrap()
+        .timestamp_millis();
+    assert!(ts > 0);
+    assert_eq!(j.salary_min, Some(70000.0));
+    assert_eq!(j.salary_max, Some(90000.0));
+}
+
+// ── JSearch response → JobPosting mapping ────────────────────────────────────
+
+#[test]
+fn jsearch_response_maps_to_job_posting() {
+    let json = serde_json::json!({
+        "status": "OK",
+        "data": [{
+            "job_id": "xyz789",
+            "job_title": "Backend Developer",
+            "employer_name": "StartupAG",
+            "job_city": "Munich",
+            "job_country": "DE",
+            "job_apply_link": "https://startupag.example.com/jobs/xyz789",
+            "job_description": "<ul><li>Write Rust</li></ul>",
+            "job_posted_at_datetime_utc": "2026-05-15T12:00:00Z"
+        }]
+    });
+
+    let resp: JSearchResp = serde_json::from_value(json).unwrap();
+    let j = &resp.data[0];
+
+    assert_eq!(j.job_id, "xyz789");
+    assert_eq!(j.job_title, "Backend Developer");
+    assert_eq!(j.employer_name.as_deref(), Some("StartupAG"));
+    assert_eq!(j.job_city.as_deref(), Some("Munich"));
+    assert_eq!(j.job_country.as_deref(), Some("DE"));
+    assert_eq!(
+        j.job_apply_link.as_deref(),
+        Some("https://startupag.example.com/jobs/xyz789")
+    );
+    assert!(j
+        .job_description
+        .as_deref()
+        .unwrap_or("")
+        .contains("Write Rust"));
+    let ts = chrono::DateTime::parse_from_rfc3339(j.job_posted_at_datetime_utc.as_deref().unwrap())
+        .unwrap()
+        .timestamp_millis();
+    assert!(ts > 0);
+}
+
+/// JSearch: `job_google_link` is used as fallback when `job_apply_link` is null.
+#[test]
+fn jsearch_uses_google_link_when_apply_link_null() {
+    let json = serde_json::json!({
+        "status": "OK",
+        "data": [{
+            "job_id": "b",
+            "job_title": "Has google link only",
+            "employer_name": "Co",
+            "job_city": null,
+            "job_country": null,
+            "job_apply_link": null,
+            "job_google_link": "https://google.com/jobs/b",
+            "job_description": null,
+            "job_posted_at_datetime_utc": null
+        }]
+    });
+
+    let resp: JSearchResp = serde_json::from_value(json).unwrap();
+    let j = &resp.data[0];
+    // The fallback logic: apply_link.or_else(|| google_link) must yield the google link.
+    let url = j
+        .job_apply_link
+        .clone()
+        .or_else(|| j.job_google_link.clone());
+    assert_eq!(
+        url.as_deref(),
+        Some("https://google.com/jobs/b"),
+        "job_google_link must be used when job_apply_link is null"
+    );
+}
+
+/// JSearch: jobs with neither `job_apply_link` nor `job_google_link` are dropped.
+#[test]
+fn jsearch_drops_jobs_without_any_link() {
+    let json = serde_json::json!({
+        "status": "OK",
+        "data": [
+            {
+                "job_id": "a",
+                "job_title": "Has apply link",
+                "employer_name": "Co",
+                "job_city": null,
+                "job_country": null,
+                "job_apply_link": "https://example.com/a",
+                "job_google_link": null,
+                "job_description": null,
+                "job_posted_at_datetime_utc": null
+            },
+            {
+                "job_id": "b",
+                "job_title": "No link at all",
+                "employer_name": "Co",
+                "job_city": null,
+                "job_country": null,
+                "job_apply_link": null,
+                "job_google_link": null,
+                "job_description": null,
+                "job_posted_at_datetime_utc": null
+            }
+        ]
+    });
+
+    let resp: JSearchResp = serde_json::from_value(json).unwrap();
+    // Simulate the filter_map fallback: apply_link.or_else(|| google_link).
+    let count = resp
+        .data
+        .into_iter()
+        .filter(|j| j.job_apply_link.is_some() || j.job_google_link.is_some())
+        .count();
+    assert_eq!(count, 1, "job without either link must be dropped");
+}
+
+// ── Scraper trait basics ──────────────────────────────────────────────────────
+
+#[test]
+fn aggregator_scraper_id_and_display_name() {
+    let s = AggregatorScraper;
+    assert_eq!(s.id(), "aggregator");
+    assert_eq!(s.display_name(), "Aggregated Jobs");
+    assert_eq!(s.mode(), ScraperMode::Http);
+    assert_eq!(s.auth(), AuthRequirement::Guest);
+    assert!(!s.requires_company());
+}
+
+// ── is_configured() guard: unconfigured providers must return Err without a network call ──
+
+#[tokio::test]
+async fn adzuna_unconfigured_returns_err_without_network() {
+    let p = AdzunaProvider {
+        app_id: None,
+        app_key: None,
+    };
+    let result = p.search("engineer", "berlin", "de", make_token()).await;
+    assert!(result.is_err(), "unconfigured Adzuna must return Err");
+    assert!(
+        result.unwrap_err().to_string().contains("not configured"),
+        "error must say 'not configured'"
+    );
+}
+
+#[tokio::test]
+async fn jsearch_unconfigured_returns_err_without_network() {
+    let p = JSearchProvider { api_key: None };
+    let result = p.search("engineer", "berlin", "de", make_token()).await;
+    assert!(result.is_err(), "unconfigured JSearch must return Err");
+    assert!(
+        result.unwrap_err().to_string().contains("not configured"),
+        "error must say 'not configured'"
+    );
+}
+
+// ── Cancellation before fallback: cancelled signal must not fire JSearch ──────
+
+/// Cancellation set before `search_with_providers` is called →
+/// returns Ok(empty) immediately without touching any provider.
+#[tokio::test]
+async fn cancelled_before_search_returns_empty_no_provider_call() {
+    let signal = make_token();
+    signal.cancel();
+
+    // JSearch is configured and would return items — must NOT be called.
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::err("adzuna", "should not be called")),
+        Box::new(FakeProvider::ok(
+            "jsearch",
+            vec![sample_posting("1", "jsearch")],
+        )),
+    ];
+
+    let result = search_with_providers(&providers, "engineer", "berlin", "de", signal)
+        .await
+        .unwrap();
+    assert!(
+        result.is_empty(),
+        "cancelled signal must prevent any provider call"
+    );
+}
+
+/// Cancellation set after Adzuna fails (simulated by the signal already being
+/// cancelled when the fallback guard runs) → JSearch must not be called.
+#[tokio::test]
+async fn cancelled_after_adzuna_err_skips_jsearch() {
+    // We cancel the token before the call so the guard at the top of
+    // search_with_providers catches it immediately — same observable effect as
+    // a cancel that races between Adzuna-error and JSearch dispatch.
+    let signal = make_token();
+    signal.cancel();
+
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::err("adzuna", "network timeout")),
+        Box::new(FakeProvider::ok(
+            "jsearch",
+            vec![sample_posting("9", "jsearch")],
+        )),
+    ];
+
+    let result = search_with_providers(&providers, "engineer", "berlin", "de", signal)
+        .await
+        .unwrap();
+    assert!(
+        result.is_empty(),
+        "JSearch must not be called after cancellation"
+    );
+}

--- a/apps/tauri/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -509,18 +509,47 @@ async fn cancelled_before_search_returns_empty_no_provider_call() {
     );
 }
 
-/// Cancellation set after Adzuna fails (simulated by the signal already being
-/// cancelled when the fallback guard runs) → JSearch must not be called.
+/// A provider that returns an error AND cancels the supplied token during its
+/// `search()` call, simulating a cancel that arrives between Adzuna's failure
+/// and the JSearch fallback dispatch.
+struct CancelOnSearchProvider {
+    token: tokio_util::sync::CancellationToken,
+}
+
+#[async_trait::async_trait]
+impl JobProvider for CancelOnSearchProvider {
+    fn provider_id(&self) -> &'static str {
+        "adzuna"
+    }
+
+    fn is_configured(&self) -> bool {
+        true
+    }
+
+    async fn search(
+        &self,
+        _query: &str,
+        _location: &str,
+        _country: &str,
+        _signal: tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        // Fail AND cancel so the fallback guard (not the top-of-function guard)
+        // catches the cancellation before JSearch is called.
+        self.token.cancel();
+        Err(anyhow::anyhow!("adzuna: network timeout"))
+    }
+}
+
+/// Adzuna errors and the token is cancelled during that call → the pre-fallback
+/// cancel guard must prevent the paid JSearch call.
 #[tokio::test]
 async fn cancelled_after_adzuna_err_skips_jsearch() {
-    // We cancel the token before the call so the guard at the top of
-    // search_with_providers catches it immediately — same observable effect as
-    // a cancel that races between Adzuna-error and JSearch dispatch.
     let signal = make_token();
-    signal.cancel();
 
     let providers: Vec<Box<dyn JobProvider>> = vec![
-        Box::new(FakeProvider::err("adzuna", "network timeout")),
+        Box::new(CancelOnSearchProvider {
+            token: signal.clone(),
+        }),
         Box::new(FakeProvider::ok(
             "jsearch",
             vec![sample_posting("9", "jsearch")],
@@ -532,6 +561,98 @@ async fn cancelled_after_adzuna_err_skips_jsearch() {
         .unwrap();
     assert!(
         result.is_empty(),
-        "JSearch must not be called after cancellation"
+        "JSearch must not be called when token is cancelled after Adzuna error"
     );
+}
+
+// ── Credential-read degradation: keyring failure / absence → None, never panic ──
+//
+// `AdzunaProvider::new()` / `JSearchProvider::new()` read OPTIONAL third-party API
+// keys via `credentials::read_credential` and collapse BOTH `Err(_)` and
+// `Ok(None)` to `None` (graceful degradation: log + treat as absent — never crash
+// a user-triggered search over a missing optional key). These tests pin that
+// construction-time degradation using keyring-core's in-memory mock store.
+//
+// The providers read FIXED slot names (`ai:adzuna-app-id`, …), unlike the
+// UUID-isolated credentials tests, so these two tests serialize on a shared mutex
+// and clean up after themselves to stay race-safe within the multi-thread test
+// binary. The mock store install is the same process-wide `Once` the credentials
+// tests use, so it is never swapped mid-run.
+
+use std::sync::Mutex;
+static AGG_KEYRING_LOCK: Mutex<()> = Mutex::new(());
+
+const ADZUNA_SLOTS: [&str; 2] = ["ai:adzuna-app-id", "ai:adzuna-app-key"];
+const JSEARCH_SLOT: &str = "ai:jsearch-key";
+
+/// Delete the aggregator's fixed keyring slots so a test starts from a known
+/// "absent" baseline regardless of what a previous serialized test left behind.
+fn clear_aggregator_slots() {
+    for slot in ADZUNA_SLOTS.iter().chain(std::iter::once(&JSEARCH_SLOT)) {
+        if let Ok(entry) = keyring_core::Entry::new(crate::credentials::SERVICE, slot) {
+            // NoEntry on a clean slot is fine; we only care it ends up absent.
+            let _ = entry.delete_credential();
+        }
+    }
+}
+
+/// Absent keys (NoEntry → Ok(None) → None): both providers must construct with
+/// `None` credentials and report `is_configured() == false`, so the aggregator
+/// degrades to keyless-empty instead of panicking.
+#[test]
+fn providers_degrade_to_unconfigured_when_keys_absent() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    let adzuna = AdzunaProvider::new();
+    assert!(adzuna.app_id.is_none(), "absent adzuna app-id must be None");
+    assert!(
+        adzuna.app_key.is_none(),
+        "absent adzuna app-key must be None"
+    );
+    assert!(
+        !adzuna.is_configured(),
+        "Adzuna must be unconfigured when both keys are absent"
+    );
+
+    let jsearch = JSearchProvider::new();
+    assert!(jsearch.api_key.is_none(), "absent jsearch key must be None");
+    assert!(
+        !jsearch.is_configured(),
+        "JSearch must be unconfigured when the key is absent"
+    );
+}
+
+/// Keyring read FAILURE (non-NoEntry → Err) must ALSO degrade to None at
+/// construction (the provider's `.unwrap_or_else(|_| None)`), not propagate or
+/// panic. We arm a non-NoEntry error on one Adzuna slot's mock `Cred`; the next
+/// read of that slot returns it, exercising the `Err → None` branch.
+#[test]
+fn providers_degrade_to_unconfigured_on_keyring_error() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    // Arm a non-NoEntry failure on the app-id slot. `read_credential` maps it to
+    // Err(AppError::Storage), which the provider collapses to None.
+    let entry = keyring_core::Entry::new(crate::credentials::SERVICE, ADZUNA_SLOTS[0]).unwrap();
+    let mock: &keyring_core::mock::Cred = entry.as_any().downcast_ref().unwrap();
+    mock.set_error(keyring_core::Error::Invalid(
+        "induced".to_string(),
+        "non-NoEntry keyring failure".to_string(),
+    ));
+
+    // Must NOT panic; the errored slot collapses to None → not configured.
+    let adzuna = AdzunaProvider::new();
+    assert!(
+        adzuna.app_id.is_none(),
+        "keyring error on app-id must degrade to None, not crash"
+    );
+    assert!(
+        !adzuna.is_configured(),
+        "Adzuna must be unconfigured when a key read errors"
+    );
+
+    clear_aggregator_slots();
 }

--- a/apps/tauri/src-tauri/src/scraping/boards/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/boards/mod.rs
@@ -1,3 +1,4 @@
+pub mod aggregator;
 pub mod arbeitnow;
 pub mod arbeitsagentur;
 pub mod ashby;
@@ -19,6 +20,7 @@ pub mod wwr;
 pub mod xing;
 pub mod ycombinator;
 
+pub use aggregator::AggregatorScraper;
 pub use arbeitnow::ArbeitnowScraper;
 pub use arbeitsagentur::ArbeitsagenturScraper;
 pub use ashby::AshbyScraper;
@@ -47,6 +49,7 @@ use super::types::Scraper;
 /// derive from this list via the `Scraper` trait, so adding a board is one
 /// implementation module + one line here (no parallel match or hardcoded array).
 static SCRAPERS: &[&dyn Scraper] = &[
+    &AggregatorScraper,
     &LinkedInScraper,
     &GlassdoorScraper,
     &XingScraper,

--- a/apps/tauri/src-tauri/src/scraping/engine/test.rs
+++ b/apps/tauri/src-tauri/src/scraping/engine/test.rs
@@ -9,12 +9,13 @@ fn test_browser_sem() -> Arc<TokioSemaphore> {
 fn test_catalog() {
     let engine = ScraperEngine::new();
     let catalog = engine.catalog();
-    assert_eq!(catalog.len(), 20);
+    assert_eq!(catalog.len(), 21);
 
     // Check specific scrapers
     assert!(catalog.iter().any(|s| s.id == "linkedin"));
     assert!(catalog.iter().any(|s| s.id == "indeed"));
     assert!(catalog.iter().any(|s| s.id == "ycombinator"));
+    assert!(catalog.iter().any(|s| s.id == "aggregator"));
 }
 
 #[test]
@@ -139,9 +140,9 @@ fn test_catalog_listed_flags() {
     assert!(entry("linkedin").listed, "linkedin must be listed");
     assert!(entry("indeed").listed, "indeed must be listed");
 
-    // All 20 boards are listed
+    // All 21 boards are listed
     let listed_count = catalog.iter().filter(|e| e.listed).count();
-    assert_eq!(listed_count, 20, "all 20 boards should be listed");
+    assert_eq!(listed_count, 21, "all 21 boards should be listed");
 }
 
 #[test]
@@ -150,7 +151,7 @@ fn test_health() {
     let health = engine.health();
     assert_eq!(health.mode, "in-process");
     assert!(health.ready);
-    assert_eq!(health.scrapers.len(), 20);
+    assert_eq!(health.scrapers.len(), 21);
 }
 
 #[test]

--- a/apps/tauri/src-tauri/src/scraping/http/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/http/mod.rs
@@ -285,12 +285,17 @@ pub async fn fetch_json<T: for<'de> serde::Deserialize<'de>>(
     match serde_json::from_str::<T>(&res.text) {
         Ok(value) => Ok(Some(value)),
         Err(e) => {
-            // Log host+path only — the query string may contain API secrets (e.g.
-            // Adzuna app_id/app_key).  Never log the full URL or the response body.
+            // Log scheme+host+port+path only — never query (may contain API
+            // secrets like Adzuna app_key) or userinfo/fragment.
             let safe_url = reqwest::Url::parse(url)
-                .map(|mut u| {
-                    u.set_query(None);
-                    u.to_string()
+                .map(|u| {
+                    let port = u.port().map(|p| format!(":{p}")).unwrap_or_default();
+                    match u.host_str() {
+                        Some(host) => {
+                            format!("{}://{}{}{}", u.scheme(), host, port, u.path())
+                        }
+                        None => format!("{}:{}", u.scheme(), u.path()),
+                    }
                 })
                 .unwrap_or_else(|_| "<unparseable-url>".to_string());
             log::debug!(

--- a/apps/tauri/src-tauri/src/scraping/http/mod.rs
+++ b/apps/tauri/src-tauri/src/scraping/http/mod.rs
@@ -285,9 +285,16 @@ pub async fn fetch_json<T: for<'de> serde::Deserialize<'de>>(
     match serde_json::from_str::<T>(&res.text) {
         Ok(value) => Ok(Some(value)),
         Err(e) => {
-            // Log metadata only; never the raw response body (third-party data).
+            // Log host+path only — the query string may contain API secrets (e.g.
+            // Adzuna app_id/app_key).  Never log the full URL or the response body.
+            let safe_url = reqwest::Url::parse(url)
+                .map(|mut u| {
+                    u.set_query(None);
+                    u.to_string()
+                })
+                .unwrap_or_else(|_| "<unparseable-url>".to_string());
             log::debug!(
-                "[scraping::http] fetch_json parse failure for {url} ({e}); body_len={}",
+                "[scraping::http] fetch_json parse failure for {safe_url} ({e}); body_len={}",
                 res.text.len()
             );
             Ok(None)

--- a/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.tsx
@@ -9,6 +9,7 @@ import { AISettingsTab } from '@/features/settings/components/ai-settings/AISett
 import { ContactProfileTab } from '@/features/settings/components/contact/ContactProfileTab';
 import { GeneralSection } from '@/features/settings/components/general-section';
 import { AppearanceCard } from '@/features/settings/components/general-section/AppearanceCard';
+import { AggregatorKeysSettings } from '@/features/settings/components/preferences/AggregatorKeysSettings';
 import { DeveloperPreferences } from '@/features/settings/components/preferences/DeveloperPreferences';
 import { JobLocationPreferences } from '@/features/settings/components/preferences/JobLocationPreferences';
 import { OutputTonePreferences } from '@/features/settings/components/preferences/OutputTonePreferences';
@@ -79,6 +80,7 @@ export function SettingsContent({
               <>
                 <JobLocationPreferences />
                 <TechStackPreferences />
+                <AggregatorKeysSettings />
               </>
             )}
             {activeSection === 'resume' && <ResumePreferences />}

--- a/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/AggregatorKeysSettings.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/AggregatorKeysSettings.test.tsx
@@ -7,15 +7,17 @@
  *  - not connected: toggling show/hide changes input type.
  *  - not connected: Save calls setProviderKey after typing a value.
  *  - not connected: Save is a no-op (disabled) when input is blank.
+ *  - not connected: Save does NOT call mutateAsync when setProviderKey.isPending (re-entrancy guard).
  *  - connected: stored-key badge shown; Remove button present.
  *  - connected: clicking Remove opens the confirm modal.
  *  - connected: confirming Remove calls removeProviderKey.
+ *  - connected: Remove does NOT call mutateAsync when removeProviderKey.isPending (re-entrancy guard).
  *
  * Service hooks are stubbed at the boundary; the real @ajh/ui tree is used
  * (only useNotification is overridden to avoid a Notification provider).
  */
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type * as AjhUi from '@ajh/ui';
@@ -23,6 +25,19 @@ import type * as AjhUi from '@ajh/ui';
 // ── mutable key-state so tests can flip connected/disconnected per slot ────
 
 const keyState: Record<string, boolean> = {};
+
+// ── per-test pending-state overrides ──────────────────────────────────────
+// Default: not pending. Tests that probe the re-entrancy guard flip these.
+
+let setIsPending = false;
+let removeIsPending = false;
+
+afterEach(() => {
+  for (const k of Object.keys(keyState)) delete keyState[k];
+  setIsPending = false;
+  removeIsPending = false;
+  vi.clearAllMocks();
+});
 
 // ── i18n stub ──────────────────────────────────────────────────────────────
 
@@ -56,8 +71,8 @@ const mockRemoveMutateAsync = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/services', () => ({
   useHasProviderKey: (slot: string) => ({ data: { has: keyState[slot] ?? false } }),
-  useSetProviderKey: () => ({ mutateAsync: mockSetMutateAsync, isPending: false }),
-  useRemoveProviderKey: () => ({ mutateAsync: mockRemoveMutateAsync, isPending: false }),
+  useSetProviderKey: () => ({ mutateAsync: mockSetMutateAsync, isPending: setIsPending }),
+  useRemoveProviderKey: () => ({ mutateAsync: mockRemoveMutateAsync, isPending: removeIsPending }),
   useOpenExternal: () => ({ mutateAsync: vi.fn() }),
 }));
 
@@ -144,6 +159,32 @@ describe('AggregatorKeysSettings — not connected', () => {
     expect(mockSetMutateAsync).not.toHaveBeenCalled();
   });
 
+  it('does NOT call setProviderKey.mutateAsync when isPending (save re-entrancy guard)', async () => {
+    // Simulate a mutation already in-flight so handleSave's early-return fires.
+    setIsPending = true;
+    mockSetMutateAsync.mockClear();
+    const user = userEvent.setup();
+    const { container } = render(<AggregatorKeysSettings />);
+
+    const inputs = getPasswordInputs(container);
+    const firstInput = inputs[0];
+    if (!firstInput) throw new Error('No password input found');
+    // Type a value so the blank-input guard doesn't fire instead.
+    await user.type(firstInput, 'pending-key');
+
+    // Trigger via Enter key (the other branch of the save path).
+    await user.keyboard('{Enter}');
+
+    // The Save button click path:
+    const saveButtons = screen.getAllByRole('button', { name: /settings\.aggregatorKeys\.save/i });
+    const firstSave = saveButtons[0];
+    if (!firstSave) throw new Error('No Save button found');
+    await user.click(firstSave);
+
+    // Neither trigger should have reached mutateAsync.
+    expect(mockSetMutateAsync).not.toHaveBeenCalled();
+  });
+
   it('shows the generic saveError i18n message (not raw error) when save mutation rejects', async () => {
     mockSetMutateAsync.mockRejectedValueOnce(
       new Error('keyring: /home/user/.local/share/keyrings/secret')
@@ -179,8 +220,6 @@ describe('AggregatorKeysSettings — connected state', () => {
     render(<AggregatorKeysSettings />);
 
     expect(screen.getByText('settings.aggregatorKeys.adzunaAppId.connected')).toBeInTheDocument();
-
-    delete keyState['adzuna-app-id'];
   });
 
   it('shows a Remove button when a slot has a key', () => {
@@ -191,8 +230,6 @@ describe('AggregatorKeysSettings — connected state', () => {
     expect(
       screen.getAllByRole('button', { name: /settings\.aggregatorKeys\.remove/i }).length
     ).toBeGreaterThanOrEqual(1);
-
-    delete keyState['adzuna-app-id'];
   });
 
   it('clicking Remove opens the confirm modal', async () => {
@@ -209,13 +246,10 @@ describe('AggregatorKeysSettings — connected state', () => {
     await user.click(firstRemove);
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-
-    delete keyState['adzuna-app-id'];
   });
 
   it('calls removeProviderKey with the correct slot on modal confirm', async () => {
     keyState['adzuna-app-id'] = true;
-    mockRemoveMutateAsync.mockClear();
     const user = userEvent.setup();
 
     render(<AggregatorKeysSettings />);
@@ -238,14 +272,44 @@ describe('AggregatorKeysSettings — connected state', () => {
     await waitFor(() =>
       expect(mockRemoveMutateAsync).toHaveBeenCalledWith({ provider: 'adzuna-app-id' })
     );
+  });
 
-    delete keyState['adzuna-app-id'];
+  it('does NOT call removeProviderKey.mutateAsync when isPending (remove re-entrancy guard)', async () => {
+    // Put a slot in connected state so the Remove button renders.
+    keyState['adzuna-app-id'] = true;
+    // Simulate a removal already in-flight so handleRemove's early-return fires.
+    removeIsPending = true;
+    mockRemoveMutateAsync.mockClear();
+    const user = userEvent.setup();
+
+    render(<AggregatorKeysSettings />);
+
+    // Open the confirm modal via the Remove trigger button.
+    const removeButtons = screen.getAllByRole('button', {
+      name: /settings\.aggregatorKeys\.remove/i,
+    });
+    const firstRemove = removeButtons[0];
+    if (!firstRemove) throw new Error('No Remove button found');
+    await user.click(firstRemove);
+
+    // Confirm modal is open. The confirm button is disabled (isConfirming=true),
+    // so userEvent ignores it. Use fireEvent to bypass the disabled attribute and
+    // directly invoke the onClick handler — this is the scenario the re-entrancy
+    // guard defends against (programmatic / rapid double-submit while in-flight).
+    const dialog = screen.getByRole('dialog');
+    const confirmBtn = Array.from(dialog.querySelectorAll('button')).find((b) =>
+      /settings\.aggregatorKeys\.remove/i.test(b.textContent ?? '')
+    );
+    if (!confirmBtn) throw new Error('Confirm button not found in modal');
+    fireEvent.click(confirmBtn);
+
+    // handleRemove returned early at the isPending guard — mutateAsync must not fire.
+    expect(mockRemoveMutateAsync).not.toHaveBeenCalled();
   });
 
   it('shows the removeError i18n message (not raw error) when remove mutation rejects', async () => {
     keyState['adzuna-app-id'] = true;
     mockRemoveMutateAsync.mockRejectedValueOnce(new Error('keyring: permission denied'));
-    mockNotify.error.mockClear();
     const user = userEvent.setup();
 
     render(<AggregatorKeysSettings />);
@@ -269,7 +333,5 @@ describe('AggregatorKeysSettings — connected state', () => {
     expect(call?.[0]).toEqual({ message: 'settings.aggregatorKeys.removeError' });
     // raw error text must never reach the notification
     expect(call?.[0]).not.toMatchObject({ message: expect.stringContaining('keyring') });
-
-    delete keyState['adzuna-app-id'];
   });
 });

--- a/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/AggregatorKeysSettings.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/AggregatorKeysSettings.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * AggregatorKeysSettings — focused behaviour tests.
+ *
+ * Covers:
+ *  - not connected: password inputs rendered; Save buttons disabled when empty.
+ *  - not connected: eye-toggle buttons have accessible names (a11y guard).
+ *  - not connected: toggling show/hide changes input type.
+ *  - not connected: Save calls setProviderKey after typing a value.
+ *  - not connected: Save is a no-op (disabled) when input is blank.
+ *  - connected: stored-key badge shown; Remove button present.
+ *  - connected: clicking Remove opens the confirm modal.
+ *  - connected: confirming Remove calls removeProviderKey.
+ *
+ * Service hooks are stubbed at the boundary; the real @ajh/ui tree is used
+ * (only useNotification is overridden to avoid a Notification provider).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type * as AjhUi from '@ajh/ui';
+
+// ── mutable key-state so tests can flip connected/disconnected per slot ────
+
+const keyState: Record<string, boolean> = {};
+
+// ── i18n stub ──────────────────────────────────────────────────────────────
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+// ── @ajh/ui — use the real library, override only useNotification ──────────
+
+const mockNotify = {
+  open: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  destroy: vi.fn(),
+};
+
+vi.mock('@ajh/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof AjhUi>();
+  return {
+    ...actual,
+    useNotification: () => mockNotify,
+  };
+});
+
+// ── service stubs ──────────────────────────────────────────────────────────
+
+const mockSetMutateAsync = vi.fn().mockResolvedValue(undefined);
+const mockRemoveMutateAsync = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/services', () => ({
+  useHasProviderKey: (slot: string) => ({ data: { has: keyState[slot] ?? false } }),
+  useSetProviderKey: () => ({ mutateAsync: mockSetMutateAsync, isPending: false }),
+  useRemoveProviderKey: () => ({ mutateAsync: mockRemoveMutateAsync, isPending: false }),
+  useOpenExternal: () => ({ mutateAsync: vi.fn() }),
+}));
+
+// ── component under test ───────────────────────────────────────────────────
+
+import { AggregatorKeysSettings } from './index';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function getPasswordInputs(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('input[type="password"]'));
+}
+
+// ── tests — not connected (default keyState = all false) ──────────────────
+
+describe('AggregatorKeysSettings — not connected', () => {
+  it('renders password inputs for all three key fields', () => {
+    const { container } = render(<AggregatorKeysSettings />);
+    expect(getPasswordInputs(container).length).toBe(3);
+  });
+
+  it('Save buttons are disabled when inputs are empty', () => {
+    render(<AggregatorKeysSettings />);
+    const saveButtons = screen.getAllByRole('button', { name: /settings\.aggregatorKeys\.save/i });
+    saveButtons.forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it('eye-toggle buttons have accessible names for all three fields', () => {
+    render(<AggregatorKeysSettings />);
+    const eyeToggles = screen.getAllByRole('button', {
+      name: 'settings.aiProvider.showKey',
+    });
+    expect(eyeToggles.length).toBe(3);
+  });
+
+  it('toggling the first eye-button switches that field from password to text', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<AggregatorKeysSettings />);
+
+    expect(getPasswordInputs(container).length).toBe(3);
+
+    const toggles = screen.getAllByRole('button', { name: 'settings.aiProvider.showKey' });
+    const firstToggle = toggles[0];
+    if (!firstToggle) throw new Error('No eye-toggle found');
+    await user.click(firstToggle);
+
+    expect(getPasswordInputs(container).length).toBe(2);
+    expect(Array.from(container.querySelectorAll('input[type="text"]')).length).toBe(1);
+  });
+
+  it('calls setProviderKey with the correct slot and value on Save', async () => {
+    mockSetMutateAsync.mockClear();
+    const user = userEvent.setup();
+    const { container } = render(<AggregatorKeysSettings />);
+
+    const inputs = getPasswordInputs(container);
+    const firstInput = inputs[0];
+    if (!firstInput) throw new Error('No password input found');
+    await user.type(firstInput, 'my-app-id');
+
+    const saveButtons = screen.getAllByRole('button', { name: /settings\.aggregatorKeys\.save/i });
+    const firstSave = saveButtons[0];
+    if (!firstSave) throw new Error('No Save button found');
+    await user.click(firstSave);
+
+    await waitFor(() =>
+      expect(mockSetMutateAsync).toHaveBeenCalledWith({
+        provider: 'adzuna-app-id',
+        apiKey: 'my-app-id',
+      })
+    );
+  });
+
+  it('does NOT call setProviderKey when Save is disabled (empty input)', async () => {
+    mockSetMutateAsync.mockClear();
+    const user = userEvent.setup();
+    render(<AggregatorKeysSettings />);
+
+    const saveButtons = screen.getAllByRole('button', { name: /settings\.aggregatorKeys\.save/i });
+    const firstSave = saveButtons[0];
+    if (!firstSave) throw new Error('No Save button found');
+    await user.click(firstSave);
+
+    expect(mockSetMutateAsync).not.toHaveBeenCalled();
+  });
+});
+
+// ── tests — connected state ────────────────────────────────────────────────
+
+describe('AggregatorKeysSettings — connected state', () => {
+  it('shows the stored-key badge when a slot has a key', () => {
+    keyState['adzuna-app-id'] = true;
+
+    render(<AggregatorKeysSettings />);
+
+    expect(screen.getByText('settings.aggregatorKeys.adzunaAppId.connected')).toBeInTheDocument();
+
+    delete keyState['adzuna-app-id'];
+  });
+
+  it('shows a Remove button when a slot has a key', () => {
+    keyState['adzuna-app-id'] = true;
+
+    render(<AggregatorKeysSettings />);
+
+    expect(
+      screen.getAllByRole('button', { name: /settings\.aggregatorKeys\.remove/i }).length
+    ).toBeGreaterThanOrEqual(1);
+
+    delete keyState['adzuna-app-id'];
+  });
+
+  it('clicking Remove opens the confirm modal', async () => {
+    keyState['adzuna-app-id'] = true;
+    const user = userEvent.setup();
+
+    render(<AggregatorKeysSettings />);
+
+    const removeButtons = screen.getAllByRole('button', {
+      name: /settings\.aggregatorKeys\.remove/i,
+    });
+    const firstRemove = removeButtons[0];
+    if (!firstRemove) throw new Error('No Remove button found');
+    await user.click(firstRemove);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    delete keyState['adzuna-app-id'];
+  });
+
+  it('calls removeProviderKey with the correct slot on modal confirm', async () => {
+    keyState['adzuna-app-id'] = true;
+    mockRemoveMutateAsync.mockClear();
+    const user = userEvent.setup();
+
+    render(<AggregatorKeysSettings />);
+
+    const removeButtons = screen.getAllByRole('button', {
+      name: /settings\.aggregatorKeys\.remove/i,
+    });
+    const firstRemove = removeButtons[0];
+    if (!firstRemove) throw new Error('No Remove button found');
+    await user.click(firstRemove);
+
+    // ConfirmModal is open — find its confirm button inside the dialog
+    const dialog = screen.getByRole('dialog');
+    const confirmBtn = Array.from(dialog.querySelectorAll('button')).find((b) =>
+      /settings\.aggregatorKeys\.remove/i.test(b.textContent ?? '')
+    );
+    if (!confirmBtn) throw new Error('Confirm button not found in modal');
+    await user.click(confirmBtn);
+
+    await waitFor(() =>
+      expect(mockRemoveMutateAsync).toHaveBeenCalledWith({ provider: 'adzuna-app-id' })
+    );
+
+    delete keyState['adzuna-app-id'];
+  });
+});

--- a/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/AggregatorKeysSettings.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/AggregatorKeysSettings.test.tsx
@@ -143,6 +143,31 @@ describe('AggregatorKeysSettings — not connected', () => {
 
     expect(mockSetMutateAsync).not.toHaveBeenCalled();
   });
+
+  it('shows the generic saveError i18n message (not raw error) when save mutation rejects', async () => {
+    mockSetMutateAsync.mockRejectedValueOnce(
+      new Error('keyring: /home/user/.local/share/keyrings/secret')
+    );
+    mockNotify.error.mockClear();
+    const user = userEvent.setup();
+    const { container } = render(<AggregatorKeysSettings />);
+
+    const inputs = getPasswordInputs(container);
+    const firstInput = inputs[0];
+    if (!firstInput) throw new Error('No password input found');
+    await user.type(firstInput, 'bad-key');
+
+    const saveButtons = screen.getAllByRole('button', { name: /settings\.aggregatorKeys\.save/i });
+    const firstSave = saveButtons[0];
+    if (!firstSave) throw new Error('No Save button found');
+    await user.click(firstSave);
+
+    await waitFor(() => expect(mockNotify.error).toHaveBeenCalledOnce());
+    const [call] = mockNotify.error.mock.calls;
+    expect(call?.[0]).toEqual({ message: 'settings.aggregatorKeys.saveError' });
+    // raw error text must never reach the notification
+    expect(call?.[0]).not.toMatchObject({ message: expect.stringContaining('keyring') });
+  });
 });
 
 // ── tests — connected state ────────────────────────────────────────────────
@@ -213,6 +238,37 @@ describe('AggregatorKeysSettings — connected state', () => {
     await waitFor(() =>
       expect(mockRemoveMutateAsync).toHaveBeenCalledWith({ provider: 'adzuna-app-id' })
     );
+
+    delete keyState['adzuna-app-id'];
+  });
+
+  it('shows the removeError i18n message (not raw error) when remove mutation rejects', async () => {
+    keyState['adzuna-app-id'] = true;
+    mockRemoveMutateAsync.mockRejectedValueOnce(new Error('keyring: permission denied'));
+    mockNotify.error.mockClear();
+    const user = userEvent.setup();
+
+    render(<AggregatorKeysSettings />);
+
+    const removeButtons = screen.getAllByRole('button', {
+      name: /settings\.aggregatorKeys\.remove/i,
+    });
+    const firstRemove = removeButtons[0];
+    if (!firstRemove) throw new Error('No Remove button found');
+    await user.click(firstRemove);
+
+    const dialog = screen.getByRole('dialog');
+    const confirmBtn = Array.from(dialog.querySelectorAll('button')).find((b) =>
+      /settings\.aggregatorKeys\.remove/i.test(b.textContent ?? '')
+    );
+    if (!confirmBtn) throw new Error('Confirm button not found in modal');
+    await user.click(confirmBtn);
+
+    await waitFor(() => expect(mockNotify.error).toHaveBeenCalledOnce());
+    const [call] = mockNotify.error.mock.calls;
+    expect(call?.[0]).toEqual({ message: 'settings.aggregatorKeys.removeError' });
+    // raw error text must never reach the notification
+    expect(call?.[0]).not.toMatchObject({ message: expect.stringContaining('keyring') });
 
     delete keyState['adzuna-app-id'];
   });

--- a/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/index.tsx
@@ -43,7 +43,7 @@ function AggregatorKeyField({
   const [confirmRemove, setConfirmRemove] = useState(false);
 
   const handleSave = async () => {
-    if (!apiKey.trim()) return;
+    if (saving || setProviderKey.isPending || !apiKey.trim()) return;
     setSaving(true);
     try {
       await setProviderKey.mutateAsync({ provider: slot, apiKey: apiKey.trim() });
@@ -57,6 +57,7 @@ function AggregatorKeyField({
   };
 
   const handleRemove = async () => {
+    if (removeProviderKey.isPending) return;
     setConfirmRemove(false);
     try {
       await removeProviderKey.mutateAsync({ provider: slot });

--- a/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/index.tsx
@@ -1,0 +1,195 @@
+import { Check, Eye, EyeOff, Key, Loader2, Search, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+import { useTranslation } from '@ajh/translations';
+import { Button, ConfirmModal, Input, SettingsSection, useNotification } from '@ajh/ui';
+
+import {
+  useHasProviderKey,
+  useOpenExternal,
+  useRemoveProviderKey,
+  useSetProviderKey,
+} from '@/services';
+
+const ADZUNA_DOCS_URL = 'https://developer.adzuna.com';
+
+interface KeyFieldProps {
+  slot: string;
+  labelKey: string;
+  placeholderKey: string;
+  connectedKey: string;
+  removeConfirmTitleKey: string;
+  removeConfirmDescKey: string;
+}
+
+function AggregatorKeyField({
+  slot,
+  labelKey,
+  placeholderKey,
+  connectedKey,
+  removeConfirmTitleKey,
+  removeConfirmDescKey,
+}: KeyFieldProps) {
+  const { t } = useTranslation();
+  const notify = useNotification();
+  const setProviderKey = useSetProviderKey();
+  const removeProviderKey = useRemoveProviderKey();
+  const { data: keyData } = useHasProviderKey(slot);
+  const connected = keyData?.has ?? false;
+
+  const [apiKey, setApiKey] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(false);
+
+  const handleSave = async () => {
+    if (!apiKey.trim()) return;
+    setSaving(true);
+    try {
+      await setProviderKey.mutateAsync({ provider: slot, apiKey: apiKey.trim() });
+      setApiKey('');
+      notify.success({ message: t('settings.aggregatorKeys.saved') });
+    } catch (err) {
+      notify.error({
+        message: err instanceof Error ? err.message : t('settings.aggregatorKeys.saveError'),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    setConfirmRemove(false);
+    try {
+      await removeProviderKey.mutateAsync({ provider: slot });
+      notify.success({ message: t('settings.aggregatorKeys.removed') });
+    } catch (err) {
+      notify.error({
+        message: err instanceof Error ? err.message : t('settings.aggregatorKeys.saveError'),
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <div className="text-xs font-semibold uppercase tracking-[0.12em] text-foreground/55">
+        {t(labelKey)}
+      </div>
+
+      {connected ? (
+        <div className="flex items-center justify-between rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-3 py-2">
+          <div className="flex items-center gap-2 text-sm text-emerald-300/80">
+            <Key size={12} /> {t(connectedKey)}
+          </div>
+          <Button
+            variant="ghost"
+            className="text-xs text-red-400/60 hover:text-red-400"
+            onClick={() => setConfirmRemove(true)}
+          >
+            <Trash2 size={11} /> {t('settings.aggregatorKeys.remove')}
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="relative">
+            <Input
+              type={showKey ? 'text' : 'password'}
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && void handleSave()}
+              placeholder={t(placeholderKey)}
+              className="w-full pr-9 text-sm"
+            />
+            <Button
+              variant="unstyled"
+              aria-label={t(
+                showKey ? 'settings.aiProvider.hideKey' : 'settings.aiProvider.showKey'
+              )}
+              onClick={() => setShowKey((v) => !v)}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
+            >
+              {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+            </Button>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              variant="glass"
+              disabled={!apiKey.trim() || saving}
+              onClick={() => void handleSave()}
+              className={apiKey.trim() && !saving ? 'ring-1 ring-brand/20' : ''}
+            >
+              {saving ? (
+                <Loader2 size={13} className="animate-spin" />
+              ) : (
+                <>
+                  <Check size={12} /> {t('settings.aggregatorKeys.save')}
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <ConfirmModal
+        open={confirmRemove}
+        onClose={() => setConfirmRemove(false)}
+        onConfirm={() => void handleRemove()}
+        title={t(removeConfirmTitleKey)}
+        description={t(removeConfirmDescKey)}
+        confirmText={t('settings.aggregatorKeys.remove')}
+        variant="danger"
+        isConfirming={removeProviderKey.isPending}
+      />
+    </div>
+  );
+}
+
+export function AggregatorKeysSettings() {
+  const { t } = useTranslation();
+  const openExternal = useOpenExternal();
+
+  return (
+    <SettingsSection icon={Search} label={t('settings.aggregatorKeys.title')}>
+      <p className="mb-3 text-xs leading-relaxed text-foreground/50">
+        {t('settings.aggregatorKeys.description')}{' '}
+        <Button
+          variant="unstyled"
+          onClick={() => void openExternal.mutateAsync(ADZUNA_DOCS_URL)}
+          className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
+        >
+          developer.adzuna.com
+        </Button>{' '}
+        {t('settings.aggregatorKeys.descriptionSuffix')}
+      </p>
+
+      <div className="space-y-4">
+        <AggregatorKeyField
+          slot="adzuna-app-id"
+          labelKey="settings.aggregatorKeys.adzunaAppId.label"
+          placeholderKey="settings.aggregatorKeys.adzunaAppId.placeholder"
+          connectedKey="settings.aggregatorKeys.adzunaAppId.connected"
+          removeConfirmTitleKey="settings.aggregatorKeys.adzunaAppId.removeConfirmTitle"
+          removeConfirmDescKey="settings.aggregatorKeys.adzunaAppId.removeConfirmDesc"
+        />
+
+        <AggregatorKeyField
+          slot="adzuna-app-key"
+          labelKey="settings.aggregatorKeys.adzunaAppKey.label"
+          placeholderKey="settings.aggregatorKeys.adzunaAppKey.placeholder"
+          connectedKey="settings.aggregatorKeys.adzunaAppKey.connected"
+          removeConfirmTitleKey="settings.aggregatorKeys.adzunaAppKey.removeConfirmTitle"
+          removeConfirmDescKey="settings.aggregatorKeys.adzunaAppKey.removeConfirmDesc"
+        />
+
+        <AggregatorKeyField
+          slot="jsearch-key"
+          labelKey="settings.aggregatorKeys.jsearchKey.label"
+          placeholderKey="settings.aggregatorKeys.jsearchKey.placeholder"
+          connectedKey="settings.aggregatorKeys.jsearchKey.connected"
+          removeConfirmTitleKey="settings.aggregatorKeys.jsearchKey.removeConfirmTitle"
+          removeConfirmDescKey="settings.aggregatorKeys.jsearchKey.removeConfirmDesc"
+        />
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/index.tsx
@@ -49,10 +49,8 @@ function AggregatorKeyField({
       await setProviderKey.mutateAsync({ provider: slot, apiKey: apiKey.trim() });
       setApiKey('');
       notify.success({ message: t('settings.aggregatorKeys.saved') });
-    } catch (err) {
-      notify.error({
-        message: err instanceof Error ? err.message : t('settings.aggregatorKeys.saveError'),
-      });
+    } catch {
+      notify.error({ message: t('settings.aggregatorKeys.saveError') });
     } finally {
       setSaving(false);
     }
@@ -63,10 +61,8 @@ function AggregatorKeyField({
     try {
       await removeProviderKey.mutateAsync({ provider: slot });
       notify.success({ message: t('settings.aggregatorKeys.removed') });
-    } catch (err) {
-      notify.error({
-        message: err instanceof Error ? err.message : t('settings.aggregatorKeys.saveError'),
-      });
+    } catch {
+      notify.error({ message: t('settings.aggregatorKeys.removeError') });
     }
   };
 

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -654,6 +654,7 @@
       "removed": "Schlüssel entfernt.",
       "remove": "Entfernen",
       "saveError": "Schlüssel konnte nicht gespeichert werden.",
+      "removeError": "Schlüssel konnte nicht entfernt werden.",
       "adzunaAppId": {
         "label": "Adzuna App-ID",
         "placeholder": "Adzuna App-ID einfügen…",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -645,6 +645,37 @@
       "removeConfirmDesc": "Dadurch wird Ihr gespeicherter Ollama-Schlüssel gelöscht. Die Unternehmensrecherche pausiert, bis Sie wieder einen Schlüssel hinzufügen.",
       "saveError": "Schlüssel konnte nicht gespeichert werden."
     },
+    "aggregatorKeys": {
+      "title": "Jobsuche-Anbieter",
+      "description": "Adzuna ist der kostenlose primäre Aggregator — App-ID und App-Key erhalten Sie unter",
+      "descriptionSuffix": "JSearch (RapidAPI) ist ein optionaler kostenpflichtiger Fallback.",
+      "save": "Speichern",
+      "saved": "Schlüssel gespeichert.",
+      "removed": "Schlüssel entfernt.",
+      "remove": "Entfernen",
+      "saveError": "Schlüssel konnte nicht gespeichert werden.",
+      "adzunaAppId": {
+        "label": "Adzuna App-ID",
+        "placeholder": "Adzuna App-ID einfügen…",
+        "connected": "Adzuna App-ID sicher gespeichert",
+        "removeConfirmTitle": "Adzuna App-ID entfernen?",
+        "removeConfirmDesc": "Dadurch wird die gespeicherte Adzuna App-ID gelöscht. Die aggregierte Jobsuche liefert keine Ergebnisse mehr, bis Sie sie erneut hinzufügen."
+      },
+      "adzunaAppKey": {
+        "label": "Adzuna App-Key",
+        "placeholder": "Adzuna App-Key einfügen…",
+        "connected": "Adzuna App-Key sicher gespeichert",
+        "removeConfirmTitle": "Adzuna App-Key entfernen?",
+        "removeConfirmDesc": "Dadurch wird der gespeicherte Adzuna App-Key gelöscht. Die aggregierte Jobsuche liefert keine Ergebnisse mehr, bis Sie ihn erneut hinzufügen."
+      },
+      "jsearchKey": {
+        "label": "JSearch-Schlüssel (RapidAPI) — optional",
+        "placeholder": "RapidAPI JSearch-Schlüssel einfügen…",
+        "connected": "JSearch-Schlüssel sicher gespeichert",
+        "removeConfirmTitle": "JSearch-Schlüssel entfernen?",
+        "removeConfirmDesc": "Dadurch wird der gespeicherte JSearch-Schlüssel gelöscht. Der JSearch-Fallback wird deaktiviert, bis Sie ihn erneut hinzufügen."
+      }
+    },
     "accounts": {
       "boardsTitle": "Jobbörsen-Konten",
       "credentialsWarning": "Anmeldedaten werden lokal verschlüsselt auf Ihrem Gerät gespeichert. Sie werden niemals an einen Server gesendet.",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -654,6 +654,7 @@
       "removed": "Key removed.",
       "remove": "Remove",
       "saveError": "Couldn't save the key.",
+      "removeError": "Couldn't remove the key.",
       "adzunaAppId": {
         "label": "Adzuna App ID",
         "placeholder": "Paste your Adzuna App ID…",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -645,6 +645,37 @@
       "removeConfirmDesc": "This deletes your saved Ollama account key. Company research stops until you add a key again.",
       "saveError": "Couldn't save the key."
     },
+    "aggregatorKeys": {
+      "title": "Job search providers",
+      "description": "Adzuna is the free primary aggregator — get your App ID and App Key at",
+      "descriptionSuffix": "JSearch (RapidAPI) is an optional paid fallback.",
+      "save": "Save",
+      "saved": "Key saved.",
+      "removed": "Key removed.",
+      "remove": "Remove",
+      "saveError": "Couldn't save the key.",
+      "adzunaAppId": {
+        "label": "Adzuna App ID",
+        "placeholder": "Paste your Adzuna App ID…",
+        "connected": "Adzuna App ID stored securely",
+        "removeConfirmTitle": "Remove Adzuna App ID?",
+        "removeConfirmDesc": "This deletes the saved Adzuna App ID. Aggregated job search will stop returning results until you add it again."
+      },
+      "adzunaAppKey": {
+        "label": "Adzuna App Key",
+        "placeholder": "Paste your Adzuna App Key…",
+        "connected": "Adzuna App Key stored securely",
+        "removeConfirmTitle": "Remove Adzuna App Key?",
+        "removeConfirmDesc": "This deletes the saved Adzuna App Key. Aggregated job search will stop returning results until you add it again."
+      },
+      "jsearchKey": {
+        "label": "JSearch Key (RapidAPI) — optional",
+        "placeholder": "Paste your RapidAPI JSearch key…",
+        "connected": "JSearch key stored securely",
+        "removeConfirmTitle": "Remove JSearch key?",
+        "removeConfirmDesc": "This deletes the saved JSearch key. The JSearch fallback will be disabled until you add it again."
+      }
+    },
     "accounts": {
       "boardsTitle": "Job board accounts",
       "credentialsWarning": "Credentials are stored locally and encrypted on your device. They are never sent to any server.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an **aggregator** job board that combines results from Adzuna and JSearch, automatically falling back when the primary provider is unavailable/unconfigured, and deduplicating overlapping posts.
  * Added a **settings section** to connect and manage API credentials for **Adzuna** (App ID + App Key) and **JSearch** (RapidAPI key).

* **Improvements**
  * Enhanced job search reliability for the aggregator flow, including safer cancellation handling.
  * Improved request failure logging to avoid exposing full request URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->