### PR TITLE
feat(jobs): prompt for adzuna key in onboarding and scrape form

### DIFF
--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.aggregator-hint.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.aggregator-hint.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * ScrapeForm — aggregator key hint tests.
+ *
+ * Covers:
+ *   - Hint shown when 'aggregator' board is selected and both Adzuna keys absent
+ *   - Hint hidden when 'aggregator' board is selected but both keys present
+ *   - Hint hidden when only App ID is present (both must be present to suppress hint)
+ *   - Hint hidden when 'aggregator' board is NOT selected (even with keys absent)
+ *
+ * motion/react is globally shimmed in vitest.setup.ts.
+ * Uses the same stub approach as ScrapeForm.test.tsx.
+ */
+
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import type { BoardCatalogEntry } from '@ajh/shared';
+
+// ---------------------------------------------------------------------------
+// Stubs — boards catalog
+// ---------------------------------------------------------------------------
+
+let stubCatalog: BoardCatalogEntry[] = [];
+let stubLoading = false;
+
+vi.mock('@/services/use-boards', () => ({
+  useBoardsCatalog: () => ({
+    data: stubCatalog,
+    isLoading: stubLoading,
+    isSuccess: !stubLoading && stubCatalog !== undefined,
+  }),
+  useBoardStatuses: () => ({ results: [], anyConnected: false }),
+}));
+
+// ---------------------------------------------------------------------------
+// Stubs — Adzuna key presence (configurable per test)
+// ---------------------------------------------------------------------------
+
+let stubIdHas = false;
+let stubKeyHas = false;
+
+vi.mock('@/services/use-ai-provider', () => ({
+  useHasProviderKey: (slot: string) => {
+    if (slot === 'adzuna-app-id') return { data: { has: stubIdHas } };
+    if (slot === 'adzuna-app-key') return { data: { has: stubKeyHas } };
+    return { data: { has: false } };
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Stubs — ScrapeFilters, BoardConnectChip, i18n, roving tabindex
+// ---------------------------------------------------------------------------
+
+vi.mock('./ScrapeFilters', () => ({
+  ScrapeFilters: () => <div data-testid="scrape-filters" />,
+}));
+
+vi.mock('./BoardConnectChip', () => ({
+  BoardConnectChip: ({ board }: { board: string }) => <span data-testid={`chip-${board}`} />,
+}));
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({
+    t: (k: string, p?: Record<string, string>) => {
+      if (!p) return k;
+      return Object.entries(p).reduce(
+        (acc, [k2, v]) => acc.replace(new RegExp(`\\{\\{${k2}\\}\\}`, 'g'), v),
+        k
+      );
+    },
+  }),
+}));
+
+vi.mock('@/hooks/use-roving-tabindex', () => ({
+  makeMultiSelectKeyHandler: () => () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (AFTER mocks)
+// ---------------------------------------------------------------------------
+
+import { ScrapeForm } from './index';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CATALOG_WITH_AGGREGATOR: BoardCatalogEntry[] = [
+  {
+    id: 'greenhouse',
+    displayName: 'Greenhouse',
+    mode: 'http',
+    auth: 'guest',
+    listed: true,
+    requiresCompany: false,
+  },
+  {
+    id: 'aggregator',
+    displayName: 'Aggregator',
+    mode: 'http',
+    auth: 'guest',
+    listed: true,
+    requiresCompany: false,
+  },
+];
+
+function buildForm(boards: string[]): Parameters<typeof ScrapeForm>[0]['form'] {
+  return {
+    boards,
+    query: '',
+    location: '',
+    radiusKm: 0,
+    amount: 25,
+    dateFilter: '' as const,
+    locale: 'en',
+    companies: [],
+  };
+}
+
+const NOOP = () => {};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}
+
+function renderForm(boards: string[]) {
+  stubCatalog = CATALOG_WITH_AGGREGATOR;
+  stubLoading = false;
+
+  return render(
+    <ScrapeForm
+      show={true}
+      form={buildForm(boards)}
+      scraping={false}
+      scrapeOutcome={null}
+      onToggle={NOOP}
+      onFormChange={NOOP}
+      onStart={NOOP}
+      onCancel={NOOP}
+      onGeocode={async () => []}
+    />,
+    { wrapper: Wrapper }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ScrapeForm — aggregator key hint', () => {
+  it('shows the hint when aggregator is selected and both Adzuna keys are absent', () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    renderForm(['aggregator']);
+
+    expect(screen.getByTestId('aggregator-key-hint')).toBeInTheDocument();
+    expect(screen.getByText('jobs.aggregatorKeyHint')).toBeInTheDocument();
+  });
+
+  it('hides the hint when aggregator is selected and both Adzuna keys are present', () => {
+    stubIdHas = true;
+    stubKeyHas = true;
+    renderForm(['aggregator']);
+
+    expect(screen.queryByTestId('aggregator-key-hint')).not.toBeInTheDocument();
+  });
+
+  it('shows the hint when aggregator is selected and only App ID is absent (App Key present)', () => {
+    stubIdHas = false;
+    stubKeyHas = true;
+    renderForm(['aggregator']);
+
+    // Both keys must be present to suppress the hint
+    expect(screen.getByTestId('aggregator-key-hint')).toBeInTheDocument();
+  });
+
+  it('shows the hint when aggregator is selected and only App Key is absent (App ID present)', () => {
+    stubIdHas = true;
+    stubKeyHas = false;
+    renderForm(['aggregator']);
+
+    expect(screen.getByTestId('aggregator-key-hint')).toBeInTheDocument();
+  });
+
+  it('hides the hint when aggregator is NOT selected (even with keys absent)', () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    renderForm(['greenhouse']); // no aggregator board selected
+
+    expect(screen.queryByTestId('aggregator-key-hint')).not.toBeInTheDocument();
+  });
+
+  it('hides the hint when aggregator is deselected (multiple boards, aggregator removed)', () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    renderForm(['greenhouse']); // aggregator not in selection
+
+    expect(screen.queryByTestId('aggregator-key-hint')).not.toBeInTheDocument();
+  });
+});

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.company-input.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.company-input.test.tsx
@@ -50,6 +50,11 @@ vi.mock('@/services/use-boards', () => ({
   useBoardStatuses: () => ({ results: [], anyConnected: false }),
 }));
 
+// Stub out Adzuna key presence — not under test in this file.
+vi.mock('@/services/use-ai-provider', () => ({
+  useHasProviderKey: () => ({ data: { has: false } }),
+}));
+
 vi.mock('./ScrapeFilters', () => ({
   ScrapeFilters: () => <div data-testid="scrape-filters" />,
 }));

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.interaction.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.interaction.test.tsx
@@ -42,6 +42,11 @@ vi.mock('@/services/use-boards', () => ({
   useBoardStatuses: () => stubStatuses,
 }));
 
+// Stub out Adzuna key presence — not under test in this file.
+vi.mock('@/services/use-ai-provider', () => ({
+  useHasProviderKey: () => ({ data: { has: false } }),
+}));
+
 vi.mock('./ScrapeFilters', () => ({
   ScrapeFilters: () => <div data-testid="scrape-filters" />,
 }));

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.test.tsx
@@ -36,6 +36,11 @@ vi.mock('@/services/use-boards', () => ({
   useBoardStatuses: () => ({ results: [], anyConnected: false }),
 }));
 
+// Stub out Adzuna key presence — not under test in this file.
+vi.mock('@/services/use-ai-provider', () => ({
+  useHasProviderKey: () => ({ data: { has: false } }),
+}));
+
 // Stub ScrapeFilters — deep component; not under test here
 vi.mock('./ScrapeFilters', () => ({
   ScrapeFilters: () => <div data-testid="scrape-filters" />,

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/index.tsx
@@ -114,8 +114,8 @@ export function ScrapeForm({
   // Adzuna keys aren't configured. Derived from service hooks; no hardcoded values
   // beyond the board's stable catalog id ('aggregator').
   const aggregatorSelected = selectedSet.has('aggregator');
-  const { data: adzunaIdData } = useHasProviderKey('adzuna-app-id');
-  const { data: adzunaKeyData } = useHasProviderKey('adzuna-app-key');
+  const { data: adzunaIdData } = useHasProviderKey('adzuna-app-id', aggregatorSelected);
+  const { data: adzunaKeyData } = useHasProviderKey('adzuna-app-key', aggregatorSelected);
   const showAggregatorKeyHint = aggregatorSelected && !(adzunaIdData?.has && adzunaKeyData?.has);
 
   const handleSelectAll = () => {

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/index.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Search, X } from 'lucide-react';
+import { Info, Loader2, Search, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
@@ -9,6 +9,7 @@ import { Button, CardSkeleton, cn, GlassCard, Input, transition } from '@ajh/ui'
 
 import { AUTH_BENEFITS } from '@/features/jobs/constants';
 import { makeMultiSelectKeyHandler } from '@/hooks/use-roving-tabindex';
+import { useHasProviderKey } from '@/services/use-ai-provider';
 import { useBoardsCatalog, useBoardStatuses } from '@/services/use-boards';
 
 import { BoardConnectChip } from './BoardConnectChip';
@@ -108,6 +109,14 @@ export function ScrapeForm({
       (requiredResults[i]?.data as { connected?: boolean } | undefined)?.connected !== true
   );
   const blockedByRequiredLogin = unconnectedRequired.length > 0;
+
+  // Aggregator key hint — shown when the aggregator board is selected but the
+  // Adzuna keys aren't configured. Derived from service hooks; no hardcoded values
+  // beyond the board's stable catalog id ('aggregator').
+  const aggregatorSelected = selectedSet.has('aggregator');
+  const { data: adzunaIdData } = useHasProviderKey('adzuna-app-id');
+  const { data: adzunaKeyData } = useHasProviderKey('adzuna-app-key');
+  const showAggregatorKeyHint = aggregatorSelected && !(adzunaIdData?.has && adzunaKeyData?.has);
 
   const handleSelectAll = () => {
     onFormChange({ boards: listedBoards.map((e) => e.id) });
@@ -293,6 +302,17 @@ export function ScrapeForm({
                   <BoardConnectChip key={e.id} board={e.id} required={e.auth === 'required'} />
                 ))}
               </div>
+            )}
+
+            {/* Aggregator key hint — shown when aggregator selected but Adzuna keys absent */}
+            {showAggregatorKeyHint && (
+              <p
+                data-testid="aggregator-key-hint"
+                className="mb-3 flex items-center gap-1.5 text-[11px] text-amber-400/70"
+              >
+                <Info size={11} aria-hidden="true" />
+                {t('jobs.aggregatorKeyHint')}
+              </p>
             )}
 
             {/* Companies input — only shown when an ATS board (requiresCompany) is selected */}

--- a/apps/tauri/src/renderer/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/OnboardingWizard/index.test.tsx
@@ -134,6 +134,25 @@ vi.mock('../steps/BrowserStep', () => ({
   ),
 }));
 
+vi.mock('../steps/AdzunaKeyStep', () => ({
+  AdzunaKeyStep: ({
+    onNext,
+    onBack,
+    stepIndex,
+    totalSteps,
+  }: {
+    onNext: () => void;
+    onBack?: () => void;
+    stepIndex: number;
+    totalSteps: number;
+  }) => (
+    <div data-testid="step-adzunaKey" data-step-index={stepIndex} data-total-steps={totalSteps}>
+      <Button onClick={onNext}>next</Button>
+      {onBack && <Button onClick={onBack}>back</Button>}
+    </div>
+  ),
+}));
+
 vi.mock('../steps/ExtensionStep', () => ({
   ExtensionStep: ({
     onNext,
@@ -226,9 +245,19 @@ beforeEach(() => {
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 describe('OnboardingWizard — step filter', () => {
-  it('includes research step (7 total) when activeProvider is ollama', () => {
+  it('includes research step (8 total) when activeProvider is ollama', () => {
     usePreferencesStore.setState({
       aiProviderConfig: { activeProvider: 'ollama', providers: {} },
+    });
+    renderWizard();
+
+    const welcome = screen.getByTestId('step-welcome');
+    expect(totalStepsOf(welcome)).toBe(8);
+  });
+
+  it('excludes research step (7 total) when activeProvider is openai', () => {
+    usePreferencesStore.setState({
+      aiProviderConfig: { activeProvider: 'openai', providers: {} },
     });
     renderWizard();
 
@@ -236,22 +265,12 @@ describe('OnboardingWizard — step filter', () => {
     expect(totalStepsOf(welcome)).toBe(7);
   });
 
-  it('excludes research step (6 total) when activeProvider is openai', () => {
-    usePreferencesStore.setState({
-      aiProviderConfig: { activeProvider: 'openai', providers: {} },
-    });
-    renderWizard();
-
-    const welcome = screen.getByTestId('step-welcome');
-    expect(totalStepsOf(welcome)).toBe(6);
-  });
-
-  it('excludes research step (6 total) when activeProvider is undefined', () => {
+  it('excludes research step (7 total) when activeProvider is undefined', () => {
     usePreferencesStore.setState({ aiProviderConfig: undefined });
     renderWizard();
 
     const welcome = screen.getByTestId('step-welcome');
-    expect(totalStepsOf(welcome)).toBe(6);
+    expect(totalStepsOf(welcome)).toBe(7);
   });
 
   it('research stub is present in the DOM when ollama is active after navigating to it', async () => {
@@ -319,11 +338,12 @@ describe('OnboardingWizard — navigation', () => {
     const user = userEvent.setup();
     renderWizard();
 
-    // 6-step sequence (openai): welcome(0) → resume(1) → ai(2) → browser(3) → extension(4) → appearance(5)
+    // 7-step sequence (openai): welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4) → extension(5) → appearance(6)
     await clickNext(user, screen.getByTestId('step-welcome'));
     await clickNext(user, screen.getByTestId('step-resume'));
     await clickNext(user, screen.getByTestId('step-ai'));
     await clickNext(user, screen.getByTestId('step-browser'));
+    await clickNext(user, screen.getByTestId('step-adzunaKey'));
     await clickNext(user, screen.getByTestId('step-extension'));
     await clickNext(user, screen.getByTestId('step-appearance'));
 
@@ -338,11 +358,12 @@ describe('OnboardingWizard — navigation', () => {
     const user = userEvent.setup();
     const { container } = renderWizard();
 
-    // Advance through all 6 steps to reach the tour
+    // Advance through all 7 steps to reach the tour
     await clickNext(user, screen.getByTestId('step-welcome'));
     await clickNext(user, screen.getByTestId('step-resume'));
     await clickNext(user, screen.getByTestId('step-ai'));
     await clickNext(user, screen.getByTestId('step-browser'));
+    await clickNext(user, screen.getByTestId('step-adzunaKey'));
     await clickNext(user, screen.getByTestId('step-extension'));
     await clickNext(user, screen.getByTestId('step-appearance'));
 
@@ -408,28 +429,29 @@ describe('OnboardingWizard — clamp on provider flip', () => {
     const user = userEvent.setup();
     renderWizard();
 
-    // Advance to the last step of the 7-step ollama sequence (index 6 = appearance)
+    // Advance to the last step of the 8-step ollama sequence (index 7 = appearance)
     await clickNext(user, screen.getByTestId('step-welcome'));
     await clickNext(user, screen.getByTestId('step-resume'));
     await clickNext(user, screen.getByTestId('step-ai'));
     await clickNext(user, screen.getByTestId('step-research'));
     await clickNext(user, screen.getByTestId('step-browser'));
+    await clickNext(user, screen.getByTestId('step-adzunaKey'));
     await clickNext(user, screen.getByTestId('step-extension'));
 
-    // At index 6 (appearance), totalSteps 7
+    // At index 7 (appearance), totalSteps 8
     expect(screen.getByTestId('step-appearance')).toBeInTheDocument();
-    expect(stepIndexOf(screen.getByTestId('step-appearance'))).toBe(6);
-    expect(totalStepsOf(screen.getByTestId('step-appearance'))).toBe(7);
+    expect(stepIndexOf(screen.getByTestId('step-appearance'))).toBe(7);
+    expect(totalStepsOf(screen.getByTestId('step-appearance'))).toBe(8);
 
-    // Flip provider to openai — array shrinks to 6 steps (max valid index = 5).
-    // The clamp effect must land the wizard on step 5 = appearance.
+    // Flip provider to openai — array shrinks to 7 steps (max valid index = 6).
+    // The clamp effect must land the wizard on step 6 = appearance.
     act(() => {
       usePreferencesStore.setState({
         aiProviderConfig: { activeProvider: 'openai', providers: {} },
       });
     });
 
-    // The clamped visible step must be exactly appearance at index 5 / totalSteps 6.
+    // The clamped visible step must be exactly appearance at index 6 / totalSteps 7.
     const visibleStep = document.querySelector('[data-total-steps]');
     if (!visibleStep) throw new Error('expected a visible step after provider flip');
     const visibleStepEl = visibleStep as HTMLElement;
@@ -437,8 +459,8 @@ describe('OnboardingWizard — clamp on provider flip', () => {
     // Identity: must be the appearance stub (not a fallback to welcome at index 0)
     expect(visibleStepEl.getAttribute('data-testid')).toBe('step-appearance');
     // Exact clamped index — not just "within range"
-    expect(stepIndexOf(visibleStepEl)).toBe(5);
-    expect(totalStepsOf(visibleStepEl)).toBe(6);
+    expect(stepIndexOf(visibleStepEl)).toBe(6);
+    expect(totalStepsOf(visibleStepEl)).toBe(7);
   });
 });
 

--- a/apps/tauri/src/renderer/features/onboarding/steps-config.ts
+++ b/apps/tauri/src/renderer/features/onboarding/steps-config.ts
@@ -1,3 +1,4 @@
+import { AdzunaKeyStep } from './steps/AdzunaKeyStep';
 import { AISelectionStep } from './steps/AISelectionStep';
 import { AppearanceStep } from './steps/AppearanceStep';
 import { BrowserStep } from './steps/BrowserStep';
@@ -12,6 +13,7 @@ export const ONBOARDING_STEPS = [
   { id: 'ai', component: AISelectionStep },
   { id: 'research', component: ResearchStep },
   { id: 'browser', component: BrowserStep },
+  { id: 'adzunaKey', component: AdzunaKeyStep },
   { id: 'extension', component: ExtensionStep },
   { id: 'appearance', component: AppearanceStep },
 ] as const;

--- a/apps/tauri/src/renderer/features/onboarding/steps/AdzunaKeyStep/index.test.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/AdzunaKeyStep/index.test.tsx
@@ -11,7 +11,7 @@
  * noUncheckedIndexedAccess: all array accesses are guarded.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -30,6 +30,14 @@ let stubKeyHas = false;
 const mutateAsyncSpy = vi.fn().mockResolvedValue(undefined);
 const notifySuccessSpy = vi.fn();
 const notifyErrorSpy = vi.fn();
+
+beforeEach(() => {
+  stubIdHas = false;
+  stubKeyHas = false;
+  mutateAsyncSpy.mockClear();
+  notifySuccessSpy.mockClear();
+  notifyErrorSpy.mockClear();
+});
 
 vi.mock('@/services', () => ({
   useHasProviderKey: (slot: string) => {

--- a/apps/tauri/src/renderer/features/onboarding/steps/AdzunaKeyStep/index.test.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/AdzunaKeyStep/index.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * AdzunaKeyStep — render, key-save, skip, and connected-state tests.
+ *
+ * Strategy:
+ *  - @ajh/translations → key-passthrough t() (mirrors ResearchStep pattern).
+ *  - @/services is mocked: useHasProviderKey returns configurable per-slot data;
+ *    useSetProviderKey returns a mutateAsync spy; useOpenExternal is a no-op.
+ *  - @ajh/ui is spread from the real module; useNotification is replaced with spies.
+ *  - withProviders + createMockClient supply React Query / AppClient context.
+ *
+ * noUncheckedIndexedAccess: all array accesses are guarded.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { createMockClient, withProviders } from '@/test-support';
+
+// ── i18n stub ─────────────────────────────────────────────────────────────────
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+// ── Service stubs ─────────────────────────────────────────────────────────────
+
+let stubIdHas = false;
+let stubKeyHas = false;
+const mutateAsyncSpy = vi.fn().mockResolvedValue(undefined);
+const notifySuccessSpy = vi.fn();
+const notifyErrorSpy = vi.fn();
+
+vi.mock('@/services', () => ({
+  useHasProviderKey: (slot: string) => {
+    if (slot === 'adzuna-app-id') return { data: { has: stubIdHas } };
+    if (slot === 'adzuna-app-key') return { data: { has: stubKeyHas } };
+    return { data: { has: false } };
+  },
+  useSetProviderKey: () => ({ mutateAsync: mutateAsyncSpy }),
+  useOpenExternal: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+// ── @ajh/ui: spread real module; stub useNotification ─────────────────────────
+
+vi.mock('@ajh/ui', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    useNotification: () => ({
+      success: notifySuccessSpy,
+      error: notifyErrorSpy,
+    }),
+  };
+});
+
+// ── component under test (imported AFTER mocks) ───────────────────────────────
+
+import { AdzunaKeyStep } from './index';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function renderStep(overrides: Partial<Parameters<typeof AdzunaKeyStep>[0]> = {}) {
+  const onNext = vi.fn();
+  const onBack = vi.fn();
+  const client = createMockClient();
+
+  const props = {
+    onNext,
+    onBack,
+    direction: 1 as const,
+    stepIndex: 4,
+    totalSteps: 7,
+    ...overrides,
+  };
+
+  const result = render(<AdzunaKeyStep {...props} />, { wrapper: withProviders(client) });
+  return { ...result, onNext, onBack };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('AdzunaKeyStep — render', () => {
+  it('renders the title key', () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    renderStep();
+    expect(screen.getByText('onboarding.adzunaKey.title')).toBeInTheDocument();
+  });
+
+  it('renders the subtitle key', () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    renderStep();
+    expect(screen.getByText('onboarding.adzunaKey.subtitle')).toBeInTheDocument();
+  });
+
+  it('renders App ID and App Key input fields when neither key is saved', () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    renderStep();
+    expect(screen.getByLabelText('onboarding.adzunaKey.appIdLabel')).toBeInTheDocument();
+    expect(screen.getByLabelText('onboarding.adzunaKey.appKeyLabel')).toBeInTheDocument();
+  });
+
+  it('renders the "skip" button label when neither key is saved', () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    renderStep();
+    // The next/skip button is the forward button; label is skip when not both saved
+    expect(
+      screen.getByRole('button', { name: /onboarding\.adzunaKey\.skip/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the skip hint text', () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    renderStep();
+    expect(screen.getByText('onboarding.adzunaKey.skipHint')).toBeInTheDocument();
+  });
+});
+
+describe('AdzunaKeyStep — connected state', () => {
+  it('shows the connected banner when both keys are saved', () => {
+    stubIdHas = true;
+    stubKeyHas = true;
+    renderStep();
+    expect(screen.getByText('onboarding.adzunaKey.connected')).toBeInTheDocument();
+  });
+
+  it('hides the input fields when both keys are saved', () => {
+    stubIdHas = true;
+    stubKeyHas = true;
+    renderStep();
+    expect(screen.queryByLabelText('onboarding.adzunaKey.appIdLabel')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('onboarding.adzunaKey.appKeyLabel')).not.toBeInTheDocument();
+  });
+
+  it('shows "next" label (not "skip") when both keys are saved', () => {
+    stubIdHas = true;
+    stubKeyHas = true;
+    renderStep();
+    expect(
+      screen.getByRole('button', { name: /onboarding\.adzunaKey\.next/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /onboarding\.adzunaKey\.skip/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows partial-saved hint when only App ID is saved', () => {
+    stubIdHas = true;
+    stubKeyHas = false;
+    renderStep();
+    expect(screen.getByText('onboarding.adzunaKey.partialSaved')).toBeInTheDocument();
+  });
+});
+
+describe('AdzunaKeyStep — key save', () => {
+  it('calls useSetProviderKey mutateAsync with adzuna-app-id slot when App ID is typed and saved', async () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    mutateAsyncSpy.mockClear();
+    const user = userEvent.setup();
+    renderStep();
+
+    const appIdInput = screen.getByLabelText('onboarding.adzunaKey.appIdLabel');
+    await user.type(appIdInput, 'my-app-id');
+
+    const saveBtn = screen.getByRole('button', { name: /onboarding\.adzunaKey\.save/i });
+    await user.click(saveBtn);
+
+    const calls = mutateAsyncSpy.mock.calls;
+    const idCall = calls.find(
+      (c) =>
+        (c[0] as { provider: string; apiKey: string } | undefined)?.provider === 'adzuna-app-id'
+    );
+    expect(idCall).toBeDefined();
+    const arg = idCall?.[0] as { provider: string; apiKey: string } | undefined;
+    expect(arg?.apiKey).toBe('my-app-id');
+  });
+
+  it('calls useSetProviderKey mutateAsync with adzuna-app-key slot when App Key is typed and saved', async () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    mutateAsyncSpy.mockClear();
+    const user = userEvent.setup();
+    renderStep();
+
+    const appKeyInput = screen.getByLabelText('onboarding.adzunaKey.appKeyLabel');
+    await user.type(appKeyInput, 'my-app-key');
+
+    const saveBtn = screen.getByRole('button', { name: /onboarding\.adzunaKey\.save/i });
+    await user.click(saveBtn);
+
+    const calls = mutateAsyncSpy.mock.calls;
+    const keyCall = calls.find(
+      (c) =>
+        (c[0] as { provider: string; apiKey: string } | undefined)?.provider === 'adzuna-app-key'
+    );
+    expect(keyCall).toBeDefined();
+    const arg = keyCall?.[0] as { provider: string; apiKey: string } | undefined;
+    expect(arg?.apiKey).toBe('my-app-key');
+  });
+
+  it('shows a success notification after saving', async () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    mutateAsyncSpy.mockClear();
+    notifySuccessSpy.mockClear();
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.type(screen.getByLabelText('onboarding.adzunaKey.appIdLabel'), 'id');
+    await user.click(screen.getByRole('button', { name: /onboarding\.adzunaKey\.save/i }));
+
+    expect(notifySuccessSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error notification when mutateAsync rejects', async () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    mutateAsyncSpy.mockRejectedValueOnce(new Error('network fail'));
+    notifyErrorSpy.mockClear();
+    const user = userEvent.setup();
+    renderStep();
+
+    await user.type(screen.getByLabelText('onboarding.adzunaKey.appIdLabel'), 'id');
+    await user.click(screen.getByRole('button', { name: /onboarding\.adzunaKey\.save/i }));
+
+    expect(notifyErrorSpy).toHaveBeenCalledTimes(1);
+    const call = notifyErrorSpy.mock.calls[0];
+    const arg = call?.[0] as { message: string } | undefined;
+    expect(arg?.message).toBe('network fail');
+  });
+});
+
+describe('AdzunaKeyStep — navigation', () => {
+  it('clicking skip/next calls onNext', async () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    const user = userEvent.setup();
+    const { onNext } = renderStep();
+
+    await user.click(screen.getByRole('button', { name: /onboarding\.adzunaKey\.skip/i }));
+
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking back calls onBack', async () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    const user = userEvent.setup();
+    const { onBack } = renderStep();
+
+    await user.click(screen.getByRole('button', { name: /onboarding\.adzunaKey\.back/i }));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('skip/next is always enabled (step is always skippable)', () => {
+    stubIdHas = false;
+    stubKeyHas = false;
+    renderStep();
+
+    const skipBtn = screen.getByRole('button', { name: /onboarding\.adzunaKey\.skip/i });
+    expect(skipBtn).not.toBeDisabled();
+  });
+});

--- a/apps/tauri/src/renderer/features/onboarding/steps/AdzunaKeyStep/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/AdzunaKeyStep/index.tsx
@@ -1,0 +1,245 @@
+import { ArrowLeft, ArrowRight, Check, Eye, EyeOff, Key, Loader2, Search } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useState } from 'react';
+
+import { useTranslation } from '@ajh/translations';
+import { Button, FloatingIcon, Input, useNotification, withDelay } from '@ajh/ui';
+
+import { useHasProviderKey, useOpenExternal, useSetProviderKey } from '@/services';
+
+import { OnboardingStepWrapper } from '../../components/OnboardingStepWrapper';
+
+const ADZUNA_DOCS_URL = 'https://developer.adzuna.com';
+
+interface Props {
+  onBack: () => void;
+  onNext: () => void;
+  direction: number;
+  stepIndex: number;
+  totalSteps: number;
+}
+
+/**
+ * Optional, skippable onboarding step: connect a free Adzuna API key so the
+ * aggregator board returns results. Both App ID and App Key are needed; the
+ * user can skip and add them later via Settings → AI → Job search providers.
+ */
+export function AdzunaKeyStep({ onBack, onNext, direction, stepIndex, totalSteps }: Props) {
+  const { t } = useTranslation();
+  const notify = useNotification();
+  const openExternal = useOpenExternal();
+  const setProviderKey = useSetProviderKey();
+
+  const { data: idData } = useHasProviderKey('adzuna-app-id');
+  const { data: keyData } = useHasProviderKey('adzuna-app-key');
+  const idSaved = idData?.has ?? false;
+  const keySaved = keyData?.has ?? false;
+  const bothSaved = idSaved && keySaved;
+
+  const [appId, setAppId] = useState('');
+  const [appKey, setAppKey] = useState('');
+  const [showId, setShowId] = useState(false);
+  const [showKey, setShowKey] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const canSave = (appId.trim().length > 0 || idSaved) && (appKey.trim().length > 0 || keySaved);
+
+  const handleSave = async () => {
+    if (!appId.trim() && !appKey.trim()) return;
+    setSaving(true);
+    try {
+      if (appId.trim()) {
+        await setProviderKey.mutateAsync({ provider: 'adzuna-app-id', apiKey: appId.trim() });
+        setAppId('');
+      }
+      if (appKey.trim()) {
+        await setProviderKey.mutateAsync({ provider: 'adzuna-app-key', apiKey: appKey.trim() });
+        setAppKey('');
+      }
+      notify.success({ message: t('onboarding.adzunaKey.saved') });
+    } catch (err) {
+      notify.error({
+        message: err instanceof Error ? err.message : t('onboarding.adzunaKey.saveError'),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <OnboardingStepWrapper
+      direction={direction}
+      stepIndex={stepIndex}
+      totalSteps={totalSteps}
+      onBack={onBack}
+      onNext={onNext}
+      canAdvance
+    >
+      <div className="mb-6 flex justify-center">
+        <FloatingIcon icon={Search} size={24} />
+      </div>
+
+      <motion.div
+        initial={{ y: 10, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={withDelay(0.1)}
+        className="mb-5 text-center"
+      >
+        <h1 className="mb-2 text-xl font-semibold text-foreground/95">
+          {t('onboarding.adzunaKey.title')}
+        </h1>
+        <p className="text-sm text-foreground/50">{t('onboarding.adzunaKey.subtitle')}</p>
+      </motion.div>
+
+      <motion.div
+        initial={{ y: 10, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={withDelay(0.15)}
+        className="mb-6"
+      >
+        {bothSaved ? (
+          <div className="flex items-center gap-2 rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-4 py-2.5 text-sm text-emerald-300/80">
+            <Key size={13} className="text-emerald-400" />
+            {t('onboarding.adzunaKey.connected')}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-xs text-foreground/40">
+              {t('onboarding.adzunaKey.getKeyAt')}{' '}
+              <Button
+                variant="unstyled"
+                onClick={() => void openExternal.mutateAsync(ADZUNA_DOCS_URL)}
+                className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
+              >
+                developer.adzuna.com
+              </Button>
+            </p>
+
+            {/* App ID field */}
+            <div>
+              {idSaved ? (
+                <div className="flex items-center gap-2 rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-3 py-2 text-xs text-emerald-300/80">
+                  <Key size={12} className="text-emerald-400" />
+                  {t('onboarding.adzunaKey.appIdLabel')} —{' '}
+                  {t('settings.aggregatorKeys.adzunaAppId.connected')}
+                </div>
+              ) : (
+                <div className="relative">
+                  <label
+                    htmlFor="onboarding-adzuna-app-id"
+                    className="mb-1 block text-xs font-medium text-foreground/55"
+                  >
+                    {t('onboarding.adzunaKey.appIdLabel')}
+                  </label>
+                  <div className="relative">
+                    <Input
+                      id="onboarding-adzuna-app-id"
+                      type={showId ? 'text' : 'password'}
+                      value={appId}
+                      onChange={(e) => setAppId(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && canSave && void handleSave()}
+                      placeholder={t('onboarding.adzunaKey.appIdPlaceholder')}
+                      className="w-full pr-9 text-sm"
+                    />
+                    <Button
+                      variant="unstyled"
+                      aria-label={t(
+                        showId ? 'settings.aiProvider.hideKey' : 'settings.aiProvider.showKey'
+                      )}
+                      onClick={() => setShowId((v) => !v)}
+                      className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
+                    >
+                      {showId ? <EyeOff size={13} /> : <Eye size={13} />}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* App Key field */}
+            <div>
+              {keySaved ? (
+                <div className="flex items-center gap-2 rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-3 py-2 text-xs text-emerald-300/80">
+                  <Key size={12} className="text-emerald-400" />
+                  {t('onboarding.adzunaKey.appKeyLabel')} —{' '}
+                  {t('settings.aggregatorKeys.adzunaAppKey.connected')}
+                </div>
+              ) : (
+                <div>
+                  <label
+                    htmlFor="onboarding-adzuna-app-key"
+                    className="mb-1 block text-xs font-medium text-foreground/55"
+                  >
+                    {t('onboarding.adzunaKey.appKeyLabel')}
+                  </label>
+                  <div className="relative">
+                    <Input
+                      id="onboarding-adzuna-app-key"
+                      type={showKey ? 'text' : 'password'}
+                      value={appKey}
+                      onChange={(e) => setAppKey(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && canSave && void handleSave()}
+                      placeholder={t('onboarding.adzunaKey.appKeyPlaceholder')}
+                      className="w-full pr-9 text-sm"
+                    />
+                    <Button
+                      variant="unstyled"
+                      aria-label={t(
+                        showKey ? 'settings.aiProvider.hideKey' : 'settings.aiProvider.showKey'
+                      )}
+                      onClick={() => setShowKey((v) => !v)}
+                      className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground/30 hover:text-foreground/60"
+                    >
+                      {showKey ? <EyeOff size={13} /> : <Eye size={13} />}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {(idSaved || keySaved) && !bothSaved && (
+              <p className="text-xs text-amber-400/70">{t('onboarding.adzunaKey.partialSaved')}</p>
+            )}
+
+            <div className="flex justify-end">
+              <Button
+                variant="primary"
+                disabled={(!appId.trim() && !appKey.trim()) || saving}
+                onClick={() => void handleSave()}
+              >
+                {saving ? (
+                  <Loader2 size={13} className="animate-spin" />
+                ) : (
+                  <>
+                    <Check size={12} /> {t('onboarding.adzunaKey.save')}
+                  </>
+                )}
+              </Button>
+            </div>
+
+            <p className="text-[10px] text-foreground/30">{t('onboarding.adzunaKey.skipHint')}</p>
+          </div>
+        )}
+      </motion.div>
+
+      <motion.div
+        initial={{ y: 10, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={withDelay(0.2)}
+        className="flex items-center gap-3"
+      >
+        <Button variant="ghost" onClick={onBack} className="flex items-center gap-1.5">
+          <ArrowLeft size={13} />
+          {t('onboarding.adzunaKey.back')}
+        </Button>
+
+        <div className="flex-1" />
+
+        <Button variant="primary" onClick={onNext} className="flex items-center gap-1.5">
+          {bothSaved ? t('onboarding.adzunaKey.next') : t('onboarding.adzunaKey.skip')}
+          <ArrowRight size={13} />
+        </Button>
+      </motion.div>
+    </OnboardingStepWrapper>
+  );
+}

--- a/apps/tauri/src/renderer/features/onboarding/steps/AdzunaKeyStep/index.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/steps/AdzunaKeyStep/index.tsx
@@ -22,7 +22,7 @@ interface Props {
 /**
  * Optional, skippable onboarding step: connect a free Adzuna API key so the
  * aggregator board returns results. Both App ID and App Key are needed; the
- * user can skip and add them later via Settings → AI → Job search providers.
+ * user can skip and add them later via Settings → Jobs.
  */
 export function AdzunaKeyStep({ onBack, onNext, direction, stepIndex, totalSteps }: Props) {
   const { t } = useTranslation();
@@ -42,7 +42,7 @@ export function AdzunaKeyStep({ onBack, onNext, direction, stepIndex, totalSteps
   const [showKey, setShowKey] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  const canSave = (appId.trim().length > 0 || idSaved) && (appKey.trim().length > 0 || keySaved);
+  const hasSomethingToSave = appId.trim().length > 0 || appKey.trim().length > 0;
 
   const handleSave = async () => {
     if (!appId.trim() && !appKey.trim()) return;
@@ -137,7 +137,9 @@ export function AdzunaKeyStep({ onBack, onNext, direction, stepIndex, totalSteps
                       type={showId ? 'text' : 'password'}
                       value={appId}
                       onChange={(e) => setAppId(e.target.value)}
-                      onKeyDown={(e) => e.key === 'Enter' && canSave && void handleSave()}
+                      onKeyDown={(e) =>
+                        e.key === 'Enter' && hasSomethingToSave && !saving && void handleSave()
+                      }
                       placeholder={t('onboarding.adzunaKey.appIdPlaceholder')}
                       className="w-full pr-9 text-sm"
                     />
@@ -178,7 +180,9 @@ export function AdzunaKeyStep({ onBack, onNext, direction, stepIndex, totalSteps
                       type={showKey ? 'text' : 'password'}
                       value={appKey}
                       onChange={(e) => setAppKey(e.target.value)}
-                      onKeyDown={(e) => e.key === 'Enter' && canSave && void handleSave()}
+                      onKeyDown={(e) =>
+                        e.key === 'Enter' && hasSomethingToSave && !saving && void handleSave()
+                      }
                       placeholder={t('onboarding.adzunaKey.appKeyPlaceholder')}
                       className="w-full pr-9 text-sm"
                     />
@@ -204,7 +208,7 @@ export function AdzunaKeyStep({ onBack, onNext, direction, stepIndex, totalSteps
             <div className="flex justify-end">
               <Button
                 variant="primary"
-                disabled={(!appId.trim() && !appKey.trim()) || saving}
+                disabled={!hasSomethingToSave || saving}
                 onClick={() => void handleSave()}
               >
                 {saving ? (

--- a/apps/tauri/src/renderer/services/use-ai-provider/use-ai-provider.ts
+++ b/apps/tauri/src/renderer/services/use-ai-provider/use-ai-provider.ts
@@ -5,12 +5,12 @@ import { useAiProviderConfig } from '@/store/preferences-store';
 
 import { keys } from '../query-client';
 
-export const useHasProviderKey = (provider: string) => {
+export const useHasProviderKey = (provider: string, enabled = true) => {
   const api = useAppClient();
   return useQuery({
     queryKey: [...keys.ai.models, 'provider-key', provider],
     queryFn: () => api.ai.hasProviderKey({ provider }),
-    enabled: provider !== 'ollama',
+    enabled: enabled && provider !== 'ollama',
     staleTime: 30_000,
   });
 };

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1604,8 +1604,10 @@
       "remotive": "Remotive",
       "arbeitnow": "Arbeit Now",
       "wwr": "WWR",
-      "ycombinator": "YC Jobs"
+      "ycombinator": "YC Jobs",
+      "aggregator": "Aggregator"
     },
+    "aggregatorKeyHint": "Fügen Sie Ihren kostenlosen Adzuna-Schlüssel in den Einstellungen hinzu, um die aggregierte Jobsuche zu aktivieren.",
     "regions": {
       "us": "🇺🇸 Vereinigte Staaten — indeed.com",
       "de": "🇩🇪 Deutschland — de.indeed.com",
@@ -2273,6 +2275,24 @@
       "back": "Zurück",
       "next": "Weiter",
       "skip": "Vorerst überspringen"
+    },
+    "adzunaKey": {
+      "title": "Aggregierte Jobsuche",
+      "subtitle": "Adzuna ist ein kostenloser Aggregator, der Millionen von Jobs durchsucht. Fügen Sie Ihre App-ID und Ihren App-Key ein, um ihn zu aktivieren — Sie können dies jederzeit später in den Einstellungen nachholen.",
+      "getKeyAt": "Ihre kostenlosen Schlüssel erhalten Sie unter",
+      "appIdLabel": "App-ID",
+      "appKeyLabel": "App-Key",
+      "appIdPlaceholder": "Adzuna App-ID einfügen…",
+      "appKeyPlaceholder": "Adzuna App-Key einfügen…",
+      "connected": "Beide Schlüssel gespeichert — die aggregierte Suche ist bereit.",
+      "partialSaved": "Ein Schlüssel gespeichert — fügen Sie beide hinzu, um die aggregierte Suche zu aktivieren.",
+      "save": "Speichern",
+      "saved": "Schlüssel gespeichert.",
+      "saveError": "Schlüssel konnte nicht gespeichert werden.",
+      "skip": "Vorerst überspringen",
+      "skipHint": "Sie können dies später unter Einstellungen → KI → Jobsuche-Anbieter hinzufügen.",
+      "next": "Weiter",
+      "back": "Zurück"
     },
     "browser": {
       "title": "Browser erforderlich",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2290,7 +2290,7 @@
       "saved": "Schlüssel gespeichert.",
       "saveError": "Schlüssel konnte nicht gespeichert werden.",
       "skip": "Vorerst überspringen",
-      "skipHint": "Sie können dies später unter Einstellungen → KI → Jobsuche-Anbieter hinzufügen.",
+      "skipHint": "Sie können dies später unter Einstellungen → Jobs hinzufügen.",
       "next": "Weiter",
       "back": "Zurück"
     },

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1600,8 +1600,10 @@
       "remotive": "Remotive",
       "arbeitnow": "Arbeit Now",
       "wwr": "WWR",
-      "ycombinator": "YC Jobs"
+      "ycombinator": "YC Jobs",
+      "aggregator": "Aggregator"
     },
+    "aggregatorKeyHint": "Add your free Adzuna key in Settings to enable aggregated search.",
     "regions": {
       "us": "🇺🇸 United States — indeed.com",
       "de": "🇩🇪 Germany — de.indeed.com",
@@ -2269,6 +2271,24 @@
       "back": "Back",
       "next": "Continue",
       "skip": "Skip for now"
+    },
+    "adzunaKey": {
+      "title": "Aggregated Job Search",
+      "subtitle": "Adzuna is a free aggregator that searches millions of jobs. Paste your App ID and App Key to enable it — you can always add these later in Settings.",
+      "getKeyAt": "Get your free keys at",
+      "appIdLabel": "App ID",
+      "appKeyLabel": "App Key",
+      "appIdPlaceholder": "Paste your Adzuna App ID…",
+      "appKeyPlaceholder": "Paste your Adzuna App Key…",
+      "connected": "Both keys saved — aggregated search is ready.",
+      "partialSaved": "One key saved — add both to enable aggregated search.",
+      "save": "Save",
+      "saved": "Key saved.",
+      "saveError": "Couldn't save the key.",
+      "skip": "Skip for now",
+      "skipHint": "You can add this later in Settings → AI → Job search providers.",
+      "next": "Continue",
+      "back": "Back"
     },
     "browser": {
       "title": "Browser Required",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2286,7 +2286,7 @@
       "saved": "Key saved.",
       "saveError": "Couldn't save the key.",
       "skip": "Skip for now",
-      "skipHint": "You can add this later in Settings → AI → Job search providers.",
+      "skipHint": "You can add this later in Settings → Jobs.",
       "next": "Continue",
       "back": "Back"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated onboarding step for Adzuna credentials configuration, enabling aggregated job search functionality
  * Added informational hint in the scrape form that prompts users to configure Adzuna keys when selecting the aggregator board
  * Enhanced support for managing Adzuna API credentials through the application settings flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->