### PR TITLE
refactor: centralize data-testid literals into @ajh/test-ids package

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -21,11 +21,12 @@ Local-first **Tauri** desktop app. **Tauri is the shell** — Rust core does the
 `rtk rg` not `grep` · `rtk fd` not `find` · `rtk bat` not `cat`. Always Bash, never PowerShell.
 Never `find -exec`. Git Bash paths: `/c/Users/...`.
 
-## Monorepo packages (exactly four workspace packages)
+## Monorepo packages (five workspace packages)
 - `packages/shared` (`@ajh/shared`) — IPC contracts + Zod schemas + types. No React, no Node APIs.
 - `packages/ui` (`@ajh/ui`) — React component library + design system. No app logic (no Zustand, no IPC).
 - `packages/prompts` (`@ajh/prompts`) — AI prompt templates. Pure TypeScript, zero deps. No UI, no `window`.
 - `packages/translations` (`@ajh/translations`) — i18next config + en/de resources. No app/IPC/renderer imports.
+- `packages/test-ids` (`@ajh/test-ids`) — Central data-testid constants shared by components and tests.
 
 The Rust core lives in `apps/tauri/src-tauri/`; the React renderer in `apps/tauri/src/renderer/`.
 

--- a/.cursor/rules/packages.mdc
+++ b/.cursor/rules/packages.mdc
@@ -8,8 +8,8 @@ alwaysApply: true
 
 > Canonical rules: see `CLAUDE.md` + `.claude/skills/*` — this file is a pointer + the load-bearing subset; CLAUDE.md wins on any conflict.
 
-There are exactly four workspace packages: `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`, `@ajh/translations`.
-There are no separate backend TS packages — backend logic lives in the Rust core under
+There are exactly five workspace packages: `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`, `@ajh/translations`,
+`@ajh/test-ids`. There are no separate backend TS packages — backend logic lives in the Rust core under
 `apps/tauri/src-tauri/`, reached only via the IPC contract.
 
 ## Path Privacy
@@ -36,9 +36,14 @@ There are no separate backend TS packages — backend logic lives in the Rust co
 - i18next config + UI translation resources (en/de) → consumed as `@ajh/translations`
 - No app / IPC / renderer imports (the locale→main listener stays in the renderer's `@/i18n` shim)
 
+## @ajh/test-ids (packages/test-ids)
+- Central nested feature-namespaced `TEST_IDS` constant map
+- Shared by production components (for `data-testid`) and tests
+- No app logic, zero deps
+
 ## Dependency direction
 ```
-renderer → @ajh/ui, @ajh/shared, @ajh/prompts, @ajh/translations
+renderer → @ajh/ui, @ajh/shared, @ajh/prompts, @ajh/translations, @ajh/test-ids
 Rust core (apps/tauri/src-tauri) ← reached only via IPC (packages/shared contract)
 ```
 Lower packages never import from upper packages.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -53,8 +53,8 @@ Exception: `<input type="range|file|checkbox|radio|hidden">`.
 
 **9. Data fetching** — React Query via service hooks only. No `useState + useEffect` for remote data.
 
-**10. Package boundaries** — workspace packages are exactly `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`,
-`@ajh/translations`. The renderer never reaches into the Rust core directly — it goes through IPC service hooks.
+**10. Package boundaries** — workspace packages are exactly five: `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`,
+`@ajh/translations`, `@ajh/test-ids`. The renderer never reaches into the Rust core directly — it goes through IPC service hooks.
 
 **11. No ESLint bypass** — no `// eslint-disable`, no `@ts-ignore`. `eslint.config.mjs` scoped overrides only.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@ Exception: `<input type="range|file|checkbox|radio|hidden">`.
 
 **9. Data fetching** — React Query via service hooks only. No `useState + useEffect` for remote data.
 
-**10. Package boundaries** — workspace packages are exactly `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`, `@ajh/translations`. The renderer reaches the Rust core only via IPC service hooks.
+**10. Package boundaries** — workspace packages are five: `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`, `@ajh/translations`, `@ajh/test-ids`. The renderer reaches the Rust core only via IPC service hooks.
 
 **11. No ESLint bypass** — no `// eslint-disable`, no `@ts-ignore`. `eslint.config.mjs` scoped overrides only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ IPC contract: `packages/shared/src/ipc/contracts.ts`.
 
 **10. Data fetching** — React Query via service hooks only. No `useState + useEffect` for remote data.
 
-**11. Package boundaries** — renderer imports only `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`.
+**11. Package boundaries** — renderer imports only `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`, `@ajh/translations`, `@ajh/test-ids`.
 
 **12. State machines** — 3+ state flows use `useMachine` + machines in `lib/machines/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ packages/shared       ← IPC contracts, Zod schemas, shared types (no UI, no No
 packages/ui           ← React component library + design system (no app logic)
 packages/prompts      ← AI prompt templates — provider-aware + locale-driven (pure TS, zero deps)
 packages/translations ← i18next config + UI translation resources (en/de) → @ajh/translations (no app/IPC deps)
+packages/test-ids     ← Central nested TEST_IDS map shared by components + tests (drift-proof data-testid constants) → @ajh/test-ids
 apps/tauri            ← Tauri app: Rust core (scraping, login, documents, AI) + React renderer
 ```
 

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@ajh/prompts": "workspace:*",
     "@ajh/shared": "workspace:*",
+    "@ajh/test-ids": "workspace:*",
     "@ajh/translations": "workspace:*",
     "@ajh/ui": "workspace:*",
     "@hookform/resolvers": "^5.4.0",

--- a/apps/tauri/src/renderer/__tests__/route-outlet-nesting.test.tsx
+++ b/apps/tauri/src/renderer/__tests__/route-outlet-nesting.test.tsx
@@ -52,6 +52,7 @@ import {
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import type { Application } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 
 import { installUnknownPathRedirect } from '@/lib/router-guard';
 import { useSessionStore } from '@/store/session-store';
@@ -92,7 +93,7 @@ vi.mock('@/components/layout/PageShell', () => ({
     title?: string;
     subtitle?: string;
   }) => (
-    <div data-testid="page-shell">
+    <div data-testid={TEST_IDS.layout.pageShell}>
       {actions}
       {children}
     </div>
@@ -103,28 +104,28 @@ vi.mock('@/components/layout/PageShell', () => ({
 
 vi.mock('@/components/layout/PageTransition', () => ({
   PageTransition: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="page-transition">{children}</div>
+    <div data-testid={TEST_IDS.layout.pageTransition}>{children}</div>
   ),
 }));
 
 // ── GenerationCard stub ───────────────────────────────────────────────────────
 
 vi.mock('@/features/documents/components/GenerationCard', () => ({
-  GenerationCard: () => <div data-testid="generation-card" />,
+  GenerationCard: () => <div data-testid={TEST_IDS.documents.generationCard} />,
 }));
 
 // ── AutopilotPage leaf stubs ───────────────────────────────────────────────────
 
 vi.mock('@/features/autopilot/components/AutopilotCard', () => ({
-  AutopilotCard: () => <div data-testid="autopilot-card" />,
+  AutopilotCard: () => <div data-testid={TEST_IDS.autopilot.card} />,
 }));
 
 vi.mock('@/features/autopilot/components/CreationWizard', () => ({
-  CreationWizard: () => <div data-testid="creation-wizard" />,
+  CreationWizard: () => <div data-testid={TEST_IDS.autopilot.creationWizard} />,
 }));
 
 vi.mock('@/features/autopilot/components/EmptyState', () => ({
-  EmptyState: () => <div data-testid="autopilot-empty-state" />,
+  EmptyState: () => <div data-testid={TEST_IDS.autopilot.emptyState} />,
 }));
 
 vi.mock('@/features/autopilot/hooks/useAutopilotRun', () => ({
@@ -212,7 +213,7 @@ vi.mock('@/services/use-ai-generations', () => ({
 // not TailorFlow internals, so stubbing the leaf is the correct approach.
 
 vi.mock('@/features/documents/components/TailorFlow', () => ({
-  TailorFlow: () => <div data-testid="tailor-flow-stub" />,
+  TailorFlow: () => <div data-testid={TEST_IDS.documents.tailorFlowStub} />,
 }));
 
 // ── Import real page components (after all mocks) ─────────────────────────────
@@ -348,7 +349,7 @@ describe('Route Outlet nesting — regression guard', () => {
 
     // Critically: ApplicationsPage's "application-row" testid must NOT be present
     // — confirms the list page did NOT mount (layout Outlet served the child).
-    expect(screen.queryByTestId('application-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.applications.row)).not.toBeInTheDocument();
   });
 
   /**
@@ -413,7 +414,7 @@ describe('Route Outlet nesting — regression guard', () => {
     expect(defaultTab).toHaveAttribute('aria-selected', 'true');
 
     // Sanity: the list page must not have rendered.
-    expect(screen.queryByTestId('application-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.applications.row)).not.toBeInTheDocument();
   });
 
   /**
@@ -442,12 +443,12 @@ describe('Route Outlet nesting — regression guard', () => {
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: () => <div data-testid="dashboard">dashboard</div>,
+      component: () => <div data-testid={TEST_IDS.layout.dashboard}>dashboard</div>,
     });
     const jobsRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/jobs',
-      component: () => <div data-testid="jobs-list">jobs</div>,
+      component: () => <div data-testid={TEST_IDS.jobs.jobsList}>jobs</div>,
     });
     const applicationsLayout = createRoute({
       getParentRoute: () => rootRoute,
@@ -490,7 +491,7 @@ describe('Route Outlet nesting — regression guard', () => {
       expect(router.state.location.pathname).toBe('/jobs');
     });
     expect(router.state.location.pathname).toBe('/jobs');
-    expect(screen.queryByTestId('dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.layout.dashboard)).not.toBeInTheDocument();
   });
 
   /**
@@ -515,7 +516,7 @@ describe('Route Outlet nesting — regression guard', () => {
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: () => <div data-testid="dashboard">dashboard</div>,
+      component: () => <div data-testid={TEST_IDS.layout.dashboard}>dashboard</div>,
     });
     const applicationsLayout = createRoute({
       getParentRoute: () => rootRoute,
@@ -557,6 +558,6 @@ describe('Route Outlet nesting — regression guard', () => {
       expect(router.state.location.pathname).toBe('/applications');
     });
     expect(router.state.location.pathname).toBe('/applications');
-    expect(screen.queryByTestId('dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.layout.dashboard)).not.toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/renderer/__tests__/tailor-back-nav.test.tsx
+++ b/apps/tauri/src/renderer/__tests__/tailor-back-nav.test.tsx
@@ -38,6 +38,7 @@ import {
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import type { Application } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 
 import { installUnknownPathRedirect } from '@/lib/router-guard';
 import { createMockClient, withProviders } from '@/test-support';
@@ -59,7 +60,7 @@ vi.mock('@/features/jobs/hooks/useDefaultResumeId', () => ({
 }));
 
 vi.mock('@/features/documents/components/TailorFlow', () => ({
-  TailorFlow: () => <div data-testid="tailor-flow-stub" />,
+  TailorFlow: () => <div data-testid={TEST_IDS.documents.tailorFlowStub} />,
 }));
 
 const APPLICATION_FIXTURE: Application = {
@@ -128,17 +129,17 @@ function buildRouter(initial: string) {
 
   const rootRoute = createRootRoute({
     component: () => <Outlet />,
-    notFoundComponent: () => <div data-testid="notfound">Page not found</div>,
+    notFoundComponent: () => <div data-testid={TEST_IDS.layout.notFound}>Page not found</div>,
   });
   const indexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/',
-    component: () => <div data-testid="dashboard">dashboard</div>,
+    component: () => <div data-testid={TEST_IDS.layout.dashboard}>dashboard</div>,
   });
   const jobsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/jobs',
-    component: () => <div data-testid="jobs-list">jobs</div>,
+    component: () => <div data-testid={TEST_IDS.jobs.jobsList}>jobs</div>,
   });
   const applicationsLayout = createRoute({
     getParentRoute: () => rootRoute,
@@ -148,7 +149,7 @@ function buildRouter(initial: string) {
   const applicationsIndex = createRoute({
     getParentRoute: () => applicationsLayout,
     path: '/',
-    component: () => <div data-testid="applications-list">list</div>,
+    component: () => <div data-testid={TEST_IDS.applications.list}>list</div>,
   });
   const applicationsDetail = createRoute({
     getParentRoute: () => applicationsLayout,
@@ -184,7 +185,7 @@ describe('Tailor → documents-tab → Back regression', () => {
       expect(router.state.isLoading).toBe(false);
     });
     expect(router.state.location.pathname).toBe('/jobs');
-    expect(screen.queryByTestId('dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.layout.dashboard)).not.toBeInTheDocument();
   });
 
   it('Back from a deep-link (no `from`) defaults to /applications, not the dashboard, with the guard active', async () => {
@@ -199,6 +200,6 @@ describe('Tailor → documents-tab → Back regression', () => {
       expect(router.state.isLoading).toBe(false);
     });
     expect(router.state.location.pathname).toBe('/applications');
-    expect(screen.queryByTestId('dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.layout.dashboard)).not.toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/renderer/components/generation/EditableOutput/EditableOutput.test.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/EditableOutput.test.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useImperativeHandle } from 'react';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { TEST_IDS } from '@ajh/test-ids';
 import type * as AjhUi from '@ajh/ui';
 import type { RichTextEditorHandle, RichTextEditorProps } from '@ajh/ui';
 
@@ -50,13 +51,16 @@ vi.mock('@ajh/ui', async (importOriginal) => {
       );
 
       return (
-        <div data-testid="rich-text-editor">
-          <span data-testid="rte-value">{value}</span>
-          <actual.Button data-testid="rte-select-trigger" onClick={() => onSelectionChange?.(true)}>
+        <div data-testid={TEST_IDS.generation.richTextEditor}>
+          <span data-testid={TEST_IDS.generation.rteValue}>{value}</span>
+          <actual.Button
+            data-testid={TEST_IDS.generation.rteSelectTrigger}
+            onClick={() => onSelectionChange?.(true)}
+          >
             simulate selection
           </actual.Button>
           <actual.Button
-            data-testid="rte-deselect-trigger"
+            data-testid={TEST_IDS.generation.rteDeselectTrigger}
             onClick={() => onSelectionChange?.(false)}
           >
             deselect
@@ -380,7 +384,7 @@ describe('EditableOutput — tab wiring', () => {
 
     switchToWysiwygEdit();
 
-    expect(screen.getByTestId('rich-text-editor')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.generation.richTextEditor)).toBeInTheDocument();
     // No raw <textarea> in WYSIWYG Edit view.
     expect(screen.queryByRole('textbox')).toBeNull();
   });
@@ -392,7 +396,7 @@ describe('EditableOutput — tab wiring', () => {
 
     expect(screen.getByRole('textbox')).toBeInTheDocument();
     expect(screen.getByRole<HTMLTextAreaElement>('textbox').tagName).toBe('TEXTAREA');
-    expect(screen.queryByTestId('rich-text-editor')).toBeNull();
+    expect(screen.queryByTestId(TEST_IDS.generation.richTextEditor)).toBeNull();
   });
 });
 
@@ -434,7 +438,7 @@ describe('EditableOutput — F4 inline rewrite splice (Editor/WYSIWYG path)', ()
     switchToWysiwygEdit();
 
     // Simulate the user making a selection inside the editor.
-    fireEvent.click(screen.getByTestId('rte-select-trigger'));
+    fireEvent.click(screen.getByTestId(TEST_IDS.generation.rteSelectTrigger));
 
     // Rewrite trigger should now be visible.
     openRewritePopover();
@@ -464,7 +468,7 @@ describe('EditableOutput — F4 inline rewrite splice (Editor/WYSIWYG path)', ()
     render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
 
     switchToWysiwygEdit();
-    fireEvent.click(screen.getByTestId('rte-select-trigger'));
+    fireEvent.click(screen.getByTestId(TEST_IDS.generation.rteSelectTrigger));
     openRewritePopover();
 
     // Cancel without starting a rewrite.
@@ -488,7 +492,7 @@ describe('EditableOutput — F4 inline rewrite splice (Editor/WYSIWYG path)', ()
     render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
 
     switchToWysiwygEdit();
-    fireEvent.click(screen.getByTestId('rte-select-trigger'));
+    fireEvent.click(screen.getByTestId(TEST_IDS.generation.rteSelectTrigger));
     openRewritePopover();
 
     // getSelectionContext must have been invoked when the popover opened.
@@ -511,7 +515,7 @@ describe('EditableOutput — F4 inline rewrite splice (Editor/WYSIWYG path)', ()
     render(<EditableOutput value={FULL_TEXT} onChange={onChange} docType="resume" />);
 
     switchToWysiwygEdit();
-    fireEvent.click(screen.getByTestId('rte-select-trigger'));
+    fireEvent.click(screen.getByTestId(TEST_IDS.generation.rteSelectTrigger));
     openRewritePopover();
 
     await act(async () => {
@@ -544,10 +548,10 @@ describe('EditableOutput — preview surface (#24)', () => {
         value="Led **payments** work."
         onChange={vi.fn()}
         docType="resume"
-        previewSlot={<div data-testid="custom-preview">PDF</div>}
+        previewSlot={<div data-testid={TEST_IDS.generation.customPreview}>PDF</div>}
       />
     );
-    expect(screen.getByTestId('custom-preview')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.generation.customPreview)).toBeInTheDocument();
     // The markdown fallback must NOT also render when a slot is supplied.
     expect(screen.queryByText('payments')).toBeNull();
   });

--- a/apps/tauri/src/renderer/components/resume/ResumeInputCard/ResumeInputCard.test.tsx
+++ b/apps/tauri/src/renderer/components/resume/ResumeInputCard/ResumeInputCard.test.tsx
@@ -10,6 +10,8 @@ import type React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import { TEST_IDS } from '@ajh/test-ids';
+
 // ── i18n stub ─────────────────────────────────────────────────────────────────
 
 vi.mock('@ajh/translations', () => ({
@@ -20,10 +22,12 @@ vi.mock('@ajh/translations', () => ({
 
 vi.mock('../ProfileUrlInput', () => ({ ProfileUrlInput: () => null }));
 vi.mock('../ResumeReviewPanel', () => ({
-  ResumeReviewPanel: () => <div data-testid="review" />,
+  ResumeReviewPanel: () => <div data-testid={TEST_IDS.resume.review} />,
 }));
 vi.mock('../SavedResumeMenu', () => ({ SavedResumeMenu: () => null }));
-vi.mock('../UploadZone', () => ({ UploadZone: () => <div data-testid="upload-zone" /> }));
+vi.mock('../UploadZone', () => ({
+  UploadZone: () => <div data-testid={TEST_IDS.resume.uploadZone} />,
+}));
 
 // ── useResumeInput stub ───────────────────────────────────────────────────────
 // Module-level mutable object: set BEFORE each render, never after.
@@ -128,7 +132,7 @@ describe('ResumeInputCard — resting / expanded flow', () => {
 
     expect(screen.getByText('My CV')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /resumeInput\.change/i })).toBeInTheDocument();
-    expect(screen.queryByTestId('upload-zone')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.resume.uploadZone)).not.toBeInTheDocument();
   });
 
   it('clicking Change expands the card (setExpanded(true))', () => {
@@ -149,16 +153,16 @@ describe('ResumeInputCard — resting / expanded flow', () => {
     stubbedHook = { ...baseHook, expanded: true };
     render(<ResumeInputCard {...defaultProps} />);
 
-    expect(screen.getByTestId('upload-zone')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.resume.uploadZone)).toBeInTheDocument();
   });
 
   it('renders the review panel only when review is present', () => {
     stubbedHook = { ...baseHook, expanded: true, review: undefined };
     const { rerender } = render(<ResumeInputCard {...defaultProps} />);
-    expect(screen.queryByTestId('review')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.resume.review)).not.toBeInTheDocument();
 
     stubbedHook = { ...baseHook, expanded: true, review: { reviewRequired: true } };
     rerender(<ResumeInputCard {...defaultProps} value="x" />);
-    expect(screen.getByTestId('review')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.resume.review)).toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import { TEST_IDS } from '@ajh/test-ids';
+
 import { OutputPanelDone } from './index';
 
 // Stub the real-PDF preview (#24) — it renders the export via IPC, out of scope
 // for this panel's preview/edit wiring test (covered in PdfPreview's own suite).
 vi.mock('@/components/generation/PdfPreview', () => ({
-  PdfPreview: () => <div data-testid="pdf-preview">PDF</div>,
+  PdfPreview: () => <div data-testid={TEST_IDS.documents.pdfPreview}>PDF</div>,
 }));
 
 // EditableOutput (rendered inside OutputPanelDone) calls useContactProfile() which
@@ -46,7 +48,7 @@ describe('OutputPanelDone — preview/edit', () => {
   it('shows the real-PDF preview by default (#24), not markdown or a textarea', () => {
     renderPanel();
     // The default Preview tab renders the real-PDF view, not the markdown fallback.
-    expect(screen.getByTestId('pdf-preview')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toBeInTheDocument();
     expect(screen.queryByText(/\*\*payments\*\*/)).toBeNull();
     // No editable textarea while previewing.
     expect(screen.queryByRole('textbox')).toBeNull();

--- a/apps/tauri/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
+++ b/apps/tauri/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
@@ -30,6 +30,7 @@ import userEvent from '@testing-library/user-event';
 
 import type { Application } from '@ajh/shared';
 import type { AiGenerationRecord } from '@ajh/shared/ipc';
+import { TEST_IDS } from '@ajh/test-ids';
 
 import type { TailorWizardState } from '@/features/documents/components/TailorFlow/lib/tailor-state';
 import type { TemplateId } from '@/lib/generate';
@@ -106,7 +107,7 @@ vi.mock('@/features/documents/components/TailorFlow', () => ({
   // Surface the injected seedGeneration id so we can assert DocumentsTab wires the
   // latest matching record (cold-entry hydration source).
   TailorFlow: ({ seedGeneration }: { seedGeneration?: { id: string } }) => (
-    <div data-testid="tailor-flow" data-seedgenid={seedGeneration?.id ?? ''} />
+    <div data-testid={TEST_IDS.documents.tailorFlow} data-seedgenid={seedGeneration?.id ?? ''} />
   ),
 }));
 
@@ -114,7 +115,7 @@ vi.mock('@/features/documents/components/TailorFlow', () => ({
 
 vi.mock('@/features/documents/components/GenerationCard', () => ({
   GenerationCard: ({ gen }: { gen: AiGenerationRecord }) => (
-    <div data-testid="generation-card" data-genid={gen.id} />
+    <div data-testid={TEST_IDS.documents.generationCard} data-genid={gen.id} />
   ),
 }));
 
@@ -255,8 +256,8 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
 
     // The Documents tab is now a full-height host for TailorFlow (mirrors the
     // autopilot apply flow); the previously-saved generations list was removed.
-    expect(screen.queryByTestId('generation-card')).not.toBeInTheDocument();
-    expect(screen.getByTestId('tailor-flow')).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.generationCard)).not.toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toBeInTheDocument();
   });
 
   it('shows no saved GenerationCard when no generation matches', () => {
@@ -274,9 +275,9 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
 
     render(<ApplicationDetailPage />);
 
-    expect(screen.queryByTestId('generation-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.generationCard)).not.toBeInTheDocument();
     // TailorFlow still mounts so the user can generate inline.
-    expect(screen.getByTestId('tailor-flow')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toBeInTheDocument();
   });
 
   it('passes the matching generation to TailorFlow as the seedGeneration (cold-entry source)', () => {
@@ -298,7 +299,10 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
     render(<ApplicationDetailPage />);
 
     // Only gen-1 matches the application's jobUrl → it seeds the flow.
-    expect(screen.getByTestId('tailor-flow')).toHaveAttribute('data-seedgenid', 'gen-1');
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toHaveAttribute(
+      'data-seedgenid',
+      'gen-1'
+    );
   });
 
   it('passes no seedGeneration to TailorFlow when nothing matches', () => {
@@ -316,7 +320,7 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
 
     render(<ApplicationDetailPage />);
 
-    expect(screen.getByTestId('tailor-flow')).toHaveAttribute('data-seedgenid', '');
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toHaveAttribute('data-seedgenid', '');
   });
 
   it('does NOT match generations when the application jobUrl is empty', () => {
@@ -335,7 +339,7 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
 
     render(<ApplicationDetailPage />);
 
-    expect(screen.queryByTestId('generation-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.generationCard)).not.toBeInTheDocument();
   });
 });
 
@@ -579,7 +583,7 @@ describe('ApplicationDetailPage — not-found / error state', () => {
     render(<ApplicationDetailPage />);
 
     expect(screen.getByText('applications.detail.notFound')).toBeInTheDocument();
-    expect(screen.queryByTestId('generation-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.generationCard)).not.toBeInTheDocument();
   });
 
   it('shows the not-found error state when isError=true', () => {
@@ -608,7 +612,7 @@ describe('ApplicationDetailPage — loading state', () => {
     const { container } = render(<ApplicationDetailPage />);
 
     // No GenerationCard and no not-found text while loading.
-    expect(screen.queryByTestId('generation-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.generationCard)).not.toBeInTheDocument();
     expect(screen.queryByText('applications.detail.notFound')).not.toBeInTheDocument();
 
     // RowSkeleton / CardSkeleton render real elements with animate-skeleton class.
@@ -912,7 +916,7 @@ describe('ApplicationDetailPage — Documents tab toolbar', () => {
   it('renders the TailorFlow stub on the Documents tab', () => {
     mockTab = 'documents';
     renderLoaded();
-    expect(screen.getByTestId('tailor-flow')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toBeInTheDocument();
   });
 
   it('does NOT render the Questions button when controller stage is not "done"', () => {

--- a/apps/tauri/src/renderer/features/applications/components/ApplicationsPage/ApplicationsPage.highlight.test.tsx
+++ b/apps/tauri/src/renderer/features/applications/components/ApplicationsPage/ApplicationsPage.highlight.test.tsx
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
 
 import type { Application } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 
 import { useSessionStore } from '@/store/session-store';
 
@@ -64,7 +65,7 @@ vi.mock('@/features/applications/components/ApplicationRow', () => ({
     highlighted?: boolean;
   }) => (
     <div
-      data-testid="application-row"
+      data-testid={TEST_IDS.applications.row}
       data-appid={application.id}
       data-status={application.status}
       data-highlighted={highlighted ? 'true' : 'false'}
@@ -77,12 +78,12 @@ vi.mock('@/features/applications/components/ApplicationRow', () => ({
 // ── Stubs for page dependencies ───────────────────────────────────────────────
 
 vi.mock('@/features/applications/components/TrackJobModal', () => ({
-  TrackJobModal: () => <div data-testid="track-job-modal" />,
+  TrackJobModal: () => <div data-testid={TEST_IDS.applications.trackJobModal} />,
 }));
 
 vi.mock('@/components/layout/PageShell', () => ({
   PageShell: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="page-shell">{children}</div>
+    <div data-testid={TEST_IDS.layout.pageShell}>{children}</div>
   ),
 }));
 
@@ -148,7 +149,7 @@ describe('ApplicationsPage — ?highlight consumption', () => {
     });
 
     const targetRow = screen
-      .getAllByTestId('application-row')
+      .getAllByTestId(TEST_IDS.applications.row)
       .find((el) => el.getAttribute('data-appid') === TARGET_ID);
     expect(targetRow).toBeDefined();
     expect(targetRow?.getAttribute('data-highlighted')).toBe('true');
@@ -163,7 +164,7 @@ describe('ApplicationsPage — ?highlight consumption', () => {
     });
 
     const otherRow = screen
-      .getAllByTestId('application-row')
+      .getAllByTestId(TEST_IDS.applications.row)
       .find((el) => el.getAttribute('data-appid') === OTHER_ID);
     expect(otherRow).toBeDefined();
     expect(otherRow?.getAttribute('data-highlighted')).toBe('false');
@@ -202,7 +203,7 @@ describe('ApplicationsPage — ?highlight consumption', () => {
     // This confirms the section was actually un-collapsed in the rendered output,
     // not just in store state.
     const targetRow = screen
-      .getAllByTestId('application-row')
+      .getAllByTestId(TEST_IDS.applications.row)
       .find((el) => el.getAttribute('data-appid') === TARGET_ID);
     expect(targetRow).toBeDefined();
     expect(targetRow).toBeInTheDocument();
@@ -218,7 +219,7 @@ describe('ApplicationsPage — ?highlight consumption', () => {
 
     // Flash active right after mount.
     let targetRow = screen
-      .getAllByTestId('application-row')
+      .getAllByTestId(TEST_IDS.applications.row)
       .find((el) => el.getAttribute('data-appid') === TARGET_ID);
     expect(targetRow?.getAttribute('data-highlighted')).toBe('true');
 
@@ -228,7 +229,7 @@ describe('ApplicationsPage — ?highlight consumption', () => {
     });
 
     targetRow = screen
-      .getAllByTestId('application-row')
+      .getAllByTestId(TEST_IDS.applications.row)
       .find((el) => el.getAttribute('data-appid') === TARGET_ID);
     expect(targetRow?.getAttribute('data-highlighted')).toBe('false');
   });
@@ -242,7 +243,7 @@ describe('ApplicationsPage — ?highlight consumption', () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
-    const rows = screen.getAllByTestId('application-row');
+    const rows = screen.getAllByTestId(TEST_IDS.applications.row);
     rows.forEach((row) => {
       expect(row.getAttribute('data-highlighted')).toBe('false');
     });
@@ -264,7 +265,7 @@ describe('ApplicationsPage — ?highlight consumption', () => {
     );
 
     // No row is highlighted — the unknown id matches nothing.
-    const rows = screen.getAllByTestId('application-row');
+    const rows = screen.getAllByTestId(TEST_IDS.applications.row);
     rows.forEach((row) => {
       expect(row.getAttribute('data-highlighted')).toBe('false');
     });

--- a/apps/tauri/src/renderer/features/applications/components/ApplicationsPage/ApplicationsPage.test.tsx
+++ b/apps/tauri/src/renderer/features/applications/components/ApplicationsPage/ApplicationsPage.test.tsx
@@ -22,6 +22,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 import type { Application } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 
 import { useSessionStore } from '@/store/session-store';
 
@@ -73,7 +74,11 @@ vi.mock('@/services/use-applications', () => ({
 
 vi.mock('@/features/applications/components/ApplicationRow', () => ({
   ApplicationRow: ({ application }: { application: Application }) => (
-    <div data-testid="application-row" data-appid={application.id} data-status={application.status}>
+    <div
+      data-testid={TEST_IDS.applications.row}
+      data-appid={application.id}
+      data-status={application.status}
+    >
       {application.title}
     </div>
   ),
@@ -82,14 +87,14 @@ vi.mock('@/features/applications/components/ApplicationRow', () => ({
 // ── TrackJobModal stub ────────────────────────────────────────────────────────
 
 vi.mock('@/features/applications/components/TrackJobModal', () => ({
-  TrackJobModal: () => <div data-testid="track-job-modal" />,
+  TrackJobModal: () => <div data-testid={TEST_IDS.applications.trackJobModal} />,
 }));
 
 // ── PageShell stub — render children directly ─────────────────────────────────
 
 vi.mock('@/components/layout/PageShell', () => ({
   PageShell: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="page-shell">{children}</div>
+    <div data-testid={TEST_IDS.layout.pageShell}>{children}</div>
   ),
 }));
 
@@ -183,19 +188,19 @@ describe('ApplicationsPage — grouped rendering', () => {
 
     // Two ApplicationRow stubs for 'applied'.
     const appliedRows = screen
-      .getAllByTestId('application-row')
+      .getAllByTestId(TEST_IDS.applications.row)
       .filter((el) => el.getAttribute('data-status') === 'applied');
     expect(appliedRows).toHaveLength(2);
 
     // One row for 'interviewing'.
     const interviewingRows = screen
-      .getAllByTestId('application-row')
+      .getAllByTestId(TEST_IDS.applications.row)
       .filter((el) => el.getAttribute('data-status') === 'interviewing');
     expect(interviewingRows).toHaveLength(1);
 
     // One row for 'saved'.
     const savedRows = screen
-      .getAllByTestId('application-row')
+      .getAllByTestId(TEST_IDS.applications.row)
       .filter((el) => el.getAttribute('data-status') === 'saved');
     expect(savedRows).toHaveLength(1);
   });
@@ -212,7 +217,7 @@ describe('ApplicationsPage — grouped rendering', () => {
     // The empty-list EmptyState uses the 'applications.empty' key as its title.
     expect(screen.getByText('applications.empty')).toBeInTheDocument();
     // No section headers rendered.
-    expect(screen.queryByTestId('application-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.applications.row)).not.toBeInTheDocument();
   });
 
   it('does not render empty-stage sections (stages with zero apps are hidden)', () => {
@@ -244,7 +249,7 @@ describe('ApplicationsPage — grouped rendering', () => {
     const { container } = render(<ApplicationsPage />);
 
     // Negative: no app rows and no empty-state.
-    expect(screen.queryByTestId('application-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.applications.row)).not.toBeInTheDocument();
     expect(screen.queryByText('applications.empty')).not.toBeInTheDocument();
 
     // Positive: RowSkeleton renders elements with the animate-skeleton class.
@@ -264,7 +269,7 @@ describe('ApplicationsPage — grouped rendering', () => {
     render(<ApplicationsPage />);
 
     expect(screen.getByText('applications.errorTitle')).toBeInTheDocument();
-    expect(screen.queryByTestId('application-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.applications.row)).not.toBeInTheDocument();
   });
 
   // Gap 7 (MEDIUM): filter — only matching rows render when session-store filter is set.
@@ -282,7 +287,7 @@ describe('ApplicationsPage — grouped rendering', () => {
 
     render(<ApplicationsPage />);
 
-    const rows = screen.getAllByTestId('application-row');
+    const rows = screen.getAllByTestId(TEST_IDS.applications.row);
     // APPS_MULTI_STAGE has company 'Alpha' (a1) and 'AlphaB' (a2) — both match 'alpha'.
     // 'Beta' (a3) and 'Gamma' (a4) must NOT appear.
     expect(rows).toHaveLength(2);
@@ -308,6 +313,6 @@ describe('ApplicationsPage — grouped rendering', () => {
 
     // noResults empty state is shown when allApps has rows but sections is empty.
     expect(screen.getByText('applications.noResults')).toBeInTheDocument();
-    expect(screen.queryByTestId('application-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.applications.row)).not.toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/renderer/features/autopilot/components/AutopilotPage/AutopilotPage.focus.test.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/AutopilotPage/AutopilotPage.focus.test.tsx
@@ -15,6 +15,8 @@ import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render } from '@testing-library/react';
 
+import { TEST_IDS } from '@ajh/test-ids';
+
 import { useSessionStore } from '@/store/session-store';
 
 import { AutopilotPage } from './index';
@@ -55,15 +57,15 @@ vi.mock('@/services', async (importOriginal) => {
 // ── Heavy sub-component stubs ─────────────────────────────────────────────────
 
 vi.mock('@/features/autopilot/components/AutopilotCard', () => ({
-  AutopilotCard: () => <div data-testid="autopilot-card" />,
+  AutopilotCard: () => <div data-testid={TEST_IDS.autopilot.card} />,
 }));
 
 vi.mock('@/features/autopilot/components/CreationWizard', () => ({
-  CreationWizard: () => <div data-testid="creation-wizard" />,
+  CreationWizard: () => <div data-testid={TEST_IDS.autopilot.creationWizard} />,
 }));
 
 vi.mock('@/features/autopilot/components/EmptyState', () => ({
-  EmptyState: () => <div data-testid="autopilot-empty-state" />,
+  EmptyState: () => <div data-testid={TEST_IDS.autopilot.emptyState} />,
 }));
 
 vi.mock('@/features/autopilot/hooks/useAutopilotRun', () => ({
@@ -80,7 +82,7 @@ vi.mock('@/features/autopilot/hooks/useAutopilotRun', () => ({
 
 vi.mock('@/components/layout/PageTransition', () => ({
   PageTransition: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="page-transition">{children}</div>
+    <div data-testid={TEST_IDS.layout.pageTransition}>{children}</div>
   ),
 }));
 

--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepSchedule/StepSchedule.test.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepSchedule/StepSchedule.test.tsx
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { TEST_IDS } from '@ajh/test-ids';
+
 import type { WizardState } from '@/features/autopilot/types';
 
 import { StepSchedule } from './index';
@@ -50,7 +52,7 @@ function Probe() {
   const { watch } = useFormContext<WizardState>();
   const v = watch();
   return (
-    <output data-testid="probe">
+    <output data-testid={TEST_IDS.autopilot.probe}>
       {JSON.stringify({
         schedule: v.schedule,
         scheduleHour: v.scheduleHour,
@@ -75,7 +77,7 @@ function renderStep(overrides: Partial<WizardState> = {}) {
 }
 
 function readProbe(): Pick<WizardState, 'schedule' | 'scheduleHour' | 'scheduleMinute'> {
-  return JSON.parse(screen.getByTestId('probe').textContent ?? '{}');
+  return JSON.parse(screen.getByTestId(TEST_IDS.autopilot.probe).textContent ?? '{}');
 }
 
 /** Open the Dropdown identified by its trigger button id attribute and pick an option. */

--- a/apps/tauri/src/renderer/features/documents/components/DocumentsPage/DocumentsPage.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/DocumentsPage/DocumentsPage.test.tsx
@@ -29,6 +29,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import type { AiGenerationRecord } from '@ajh/shared/ipc';
+import { TEST_IDS } from '@ajh/test-ids';
 
 import { useSessionStore } from '@/store/session-store';
 
@@ -84,7 +85,7 @@ vi.mock('@/features/documents/components/GenerationCard', () => ({
     onToggleSelect?: (id: string) => void;
   }) => (
     <div
-      data-testid="generation-card"
+      data-testid={TEST_IDS.documents.generationCard}
       data-genid={gen.id}
       data-selected={selected ? '1' : '0'}
       // The whole point of the change: the card is only "selectable" (renders its
@@ -99,7 +100,7 @@ vi.mock('@/features/documents/components/GenerationCard', () => ({
 // ── InteractionRow stub (Résumés tab never renders it; import must resolve) ────
 
 vi.mock('@/features/documents/components/InteractionRow', () => ({
-  InteractionRow: () => <div data-testid="interaction-row" />,
+  InteractionRow: () => <div data-testid={TEST_IDS.documents.interactionRow} />,
 }));
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -163,7 +164,7 @@ describe('DocumentsPage — selection mode', () => {
     expect(screen.queryByRole('button', { name: SELECT_DONE })).not.toBeInTheDocument();
 
     // Cards render but are NOT selectable (no onToggleSelect → no checkbox).
-    const cards = screen.getAllByTestId('generation-card');
+    const cards = screen.getAllByTestId(TEST_IDS.documents.generationCard);
     expect(cards).toHaveLength(2);
     cards.forEach((c) => expect(c).toHaveAttribute('data-selectable', '0'));
   });
@@ -180,7 +181,7 @@ describe('DocumentsPage — selection mode', () => {
 
     // Every card is now selectable (received onToggleSelect).
     screen
-      .getAllByTestId('generation-card')
+      .getAllByTestId(TEST_IDS.documents.generationCard)
       .forEach((c) => expect(c).toHaveAttribute('data-selectable', '1'));
   });
 
@@ -196,7 +197,7 @@ describe('DocumentsPage — selection mode', () => {
     expect(screen.queryByLabelText(SELECT_ALL)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: SELECT_START })).toBeInTheDocument();
     screen
-      .getAllByTestId('generation-card')
+      .getAllByTestId(TEST_IDS.documents.generationCard)
       .forEach((c) => expect(c).toHaveAttribute('data-selectable', '0'));
   });
 
@@ -207,7 +208,7 @@ describe('DocumentsPage — selection mode', () => {
 
     expect(screen.queryByRole('button', { name: SELECT_START })).not.toBeInTheDocument();
     expect(screen.queryByLabelText(SELECT_ALL)).not.toBeInTheDocument();
-    expect(screen.queryByTestId('generation-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.generationCard)).not.toBeInTheDocument();
   });
 
   it('keeps the Select button when a search filter matches no documents', () => {
@@ -223,7 +224,7 @@ describe('DocumentsPage — selection mode', () => {
     expect(screen.getByRole('button', { name: SELECT_START })).toBeInTheDocument();
 
     // No cards survive the filter, and the no-results empty state is shown.
-    expect(screen.queryByTestId('generation-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.generationCard)).not.toBeInTheDocument();
     expect(screen.getByText('resumes.noResults')).toBeInTheDocument();
   });
 
@@ -234,14 +235,14 @@ describe('DocumentsPage — selection mode', () => {
 
     // Before Select-all: no card is selected.
     screen
-      .getAllByTestId('generation-card')
+      .getAllByTestId(TEST_IDS.documents.generationCard)
       .forEach((c) => expect(c).toHaveAttribute('data-selected', '0'));
 
     fireEvent.click(screen.getByLabelText(SELECT_ALL));
 
     // After Select-all: every card is selected.
     screen
-      .getAllByTestId('generation-card')
+      .getAllByTestId(TEST_IDS.documents.generationCard)
       .forEach((c) => expect(c).toHaveAttribute('data-selected', '1'));
   });
 });

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/GeneratingPanel.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/GeneratingPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
+import { TEST_IDS } from '@ajh/test-ids';
 import type * as AjhUi from '@ajh/ui';
 
 import { GeneratingPanel } from './GeneratingPanel';
@@ -15,7 +16,7 @@ vi.mock('@ajh/translations', () => ({
 // without the real streaming infrastructure.
 vi.mock('@/components/generation/ThinkingBubble', () => ({
   ThinkingBubble: ({ thinking }: { thinking: string }) => (
-    <div data-testid="thinking-bubble">{thinking}</div>
+    <div data-testid={TEST_IDS.documents.thinkingBubble}>{thinking}</div>
   ),
 }));
 
@@ -27,7 +28,7 @@ vi.mock('@ajh/ui', async (importOriginal) => {
     ...actual,
     StepDots: ({ currentStep, totalSteps }: { currentStep: number; totalSteps: number }) => (
       <div
-        data-testid="step-dots"
+        data-testid={TEST_IDS.documents.stepDots}
         data-current={String(currentStep)}
         data-total={String(totalSteps)}
       />
@@ -54,7 +55,7 @@ function makeProps(overrides: Partial<Parameters<typeof GeneratingPanel>[0]> = {
 // ── Helper to read StepDots props ─────────────────────────────────────────────
 
 function stepDotsProps(): { current: number; total: number } {
-  const el = screen.getByTestId('step-dots');
+  const el = screen.getByTestId(TEST_IDS.documents.stepDots);
   return {
     current: Number(el.getAttribute('data-current')),
     total: Number(el.getAttribute('data-total')),

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { TEST_IDS } from '@ajh/test-ids';
 import type * as AjhUi from '@ajh/ui';
 
 import { GenerationOutput } from './GenerationOutput';
@@ -32,21 +33,26 @@ vi.mock('@/components/generation/EditableOutput', () => ({
     canSave?: boolean;
     previewSlot?: React.ReactNode;
   }) => (
-    <div data-testid="editable-output">
+    <div data-testid={TEST_IDS.documents.editableOutput}>
       {value}
       <div
         role="textbox"
-        data-testid="editable-input"
+        data-testid={TEST_IDS.documents.editableInput}
         contentEditable
         suppressContentEditableWarning
         onInput={(e) => onChange?.((e.target as HTMLElement).textContent ?? '')}
       />
       {onSave && (
-        <div role="button" data-testid="save-btn" data-can-save={String(canSave)} onClick={onSave}>
+        <div
+          role="button"
+          data-testid={TEST_IDS.documents.saveBtn}
+          data-can-save={String(canSave)}
+          onClick={onSave}
+        >
           save
         </div>
       )}
-      {previewSlot && <div data-testid="preview-slot">{previewSlot}</div>}
+      {previewSlot && <div data-testid={TEST_IDS.documents.previewSlot}>{previewSlot}</div>}
     </div>
   ),
 }));
@@ -54,7 +60,9 @@ vi.mock('@/components/generation/EditableOutput', () => ({
 // PdfPreview mock — renders its `text` prop into a testid so tests can inspect
 // the committed text without launching the real Typst/PDF pipeline.
 vi.mock('@/components/generation/PdfPreview', () => ({
-  PdfPreview: ({ text }: { text: string }) => <div data-testid="pdf-preview">{text}</div>,
+  PdfPreview: ({ text }: { text: string }) => (
+    <div data-testid={TEST_IDS.documents.pdfPreview}>{text}</div>
+  ),
 }));
 
 // Dropdown mock — preserves all other @ajh/ui exports unchanged via
@@ -179,7 +187,7 @@ describe('GenerationOutput', () => {
       expect(screen.getByDisplayValue('Full job description text')).toBeInTheDocument();
 
       // The doc EditableOutput must NOT be mounted while the Job ad tab is active.
-      expect(screen.queryByTestId('editable-output')).not.toBeInTheDocument();
+      expect(screen.queryByTestId(TEST_IDS.documents.editableOutput)).not.toBeInTheDocument();
     });
 
     it('shows the summary empty-state Generate button and calls generate on click', async () => {
@@ -250,12 +258,12 @@ describe('GenerationOutput', () => {
       render(<GenerationOutput {...makeProps()} />);
 
       // EditableOutput is present initially (doc view).
-      expect(screen.getByTestId('editable-output')).toBeInTheDocument();
+      expect(screen.getByTestId(TEST_IDS.documents.editableOutput)).toBeInTheDocument();
 
       await clickJobAdTab(user);
 
       // EditableOutput must be gone after switching to job-ad view.
-      expect(screen.queryByTestId('editable-output')).not.toBeInTheDocument();
+      expect(screen.queryByTestId(TEST_IDS.documents.editableOutput)).not.toBeInTheDocument();
     });
   });
 
@@ -412,12 +420,12 @@ describe('GenerationOutput', () => {
   describe('Template picker', () => {
     it('renders the template picker on the resume tab (doc view)', () => {
       render(<GenerationOutput {...makeProps({ activeOut: 'resume' })} />);
-      expect(screen.getByTestId('template-picker')).toBeInTheDocument();
+      expect(screen.getByTestId(TEST_IDS.documents.templatePicker)).toBeInTheDocument();
     });
 
     it('renders the template picker on the cover tab (doc view)', () => {
       render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'cover' })} />);
-      expect(screen.getByTestId('template-picker')).toBeInTheDocument();
+      expect(screen.getByTestId(TEST_IDS.documents.templatePicker)).toBeInTheDocument();
     });
 
     it('is absent after switching to the job-ad view', async () => {
@@ -426,7 +434,7 @@ describe('GenerationOutput', () => {
 
       await clickJobAdTab(user);
 
-      expect(screen.queryByTestId('template-picker')).not.toBeInTheDocument();
+      expect(screen.queryByTestId(TEST_IDS.documents.templatePicker)).not.toBeInTheDocument();
     });
 
     it('calls onTemplateChange with the selected id when a two-column template is picked', async () => {
@@ -495,7 +503,7 @@ describe('GenerationOutput', () => {
           {...makeProps({ target: 'both', activeOut: 'cover', templateId: 'atelier' })}
         />
       );
-      expect(screen.getByTestId('template-picker')).toBeInTheDocument();
+      expect(screen.getByTestId(TEST_IDS.documents.templatePicker)).toBeInTheDocument();
       expect(screen.queryByRole('switch')).not.toBeInTheDocument();
     });
 
@@ -580,7 +588,9 @@ describe('GenerationOutput', () => {
           {...makeProps({ activeOut: 'resume', output: 'Initial content', editable: true })}
         />
       );
-      expect(screen.getByTestId('pdf-preview')).toHaveTextContent('Initial content');
+      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent(
+        'Initial content'
+      );
     });
 
     it('a parent-driven output change (no local edit) refreshes the preview immediately', () => {
@@ -590,7 +600,7 @@ describe('GenerationOutput', () => {
       // No local edit has happened — the effect must update committed when output changes.
       rerender(<GenerationOutput {...props} output="Version 2" />);
 
-      expect(screen.getByTestId('pdf-preview')).toHaveTextContent('Version 2');
+      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Version 2');
     });
 
     it('after a local edit the preview still shows the last committed (pre-save) text', async () => {
@@ -602,15 +612,15 @@ describe('GenerationOutput', () => {
       );
 
       // Verify preview shows initial committed text before any edit.
-      expect(screen.getByTestId('pdf-preview')).toHaveTextContent('Committed text');
+      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Committed text');
 
       // Simulate a local edit: type into the contentEditable box.
-      const editBox = screen.getByTestId('editable-input');
+      const editBox = screen.getByTestId(TEST_IDS.documents.editableInput);
       await user.click(editBox);
       await user.type(editBox, 'Edited text');
 
       // Preview must still show the old committed text — Save not clicked yet.
-      expect(screen.getByTestId('pdf-preview')).toHaveTextContent('Committed text');
+      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Committed text');
     });
 
     it('canSave becomes true after a local edit', async () => {
@@ -621,14 +631,17 @@ describe('GenerationOutput', () => {
         />
       );
 
-      const saveBtn = screen.getByTestId('save-btn');
+      const saveBtn = screen.getByTestId(TEST_IDS.documents.saveBtn);
       expect(saveBtn).toHaveAttribute('data-can-save', 'false');
 
-      const editBox = screen.getByTestId('editable-input');
+      const editBox = screen.getByTestId(TEST_IDS.documents.editableInput);
       await user.click(editBox);
       await user.type(editBox, 'Changed');
 
-      expect(screen.getByTestId('save-btn')).toHaveAttribute('data-can-save', 'true');
+      expect(screen.getByTestId(TEST_IDS.documents.saveBtn)).toHaveAttribute(
+        'data-can-save',
+        'true'
+      );
     });
 
     it('clicking save commits the current output to the preview and canSave goes false', async () => {
@@ -640,20 +653,23 @@ describe('GenerationOutput', () => {
       );
 
       // Edit to diverge committed from output.
-      const editBox = screen.getByTestId('editable-input');
+      const editBox = screen.getByTestId(TEST_IDS.documents.editableInput);
       await user.click(editBox);
       await user.type(editBox, 'After save');
 
       // Preview still shows old text before Save.
-      expect(screen.getByTestId('pdf-preview')).toHaveTextContent('Before save');
+      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Before save');
 
       // Click Save.
-      await user.click(screen.getByTestId('save-btn'));
+      await user.click(screen.getByTestId(TEST_IDS.documents.saveBtn));
 
       // After save the preview must reflect the new committed text.
       // The component sets committed[activeOut] = output (which the wrapper
       // already updated to include the typed text).
-      expect(screen.getByTestId('save-btn')).toHaveAttribute('data-can-save', 'false');
+      expect(screen.getByTestId(TEST_IDS.documents.saveBtn)).toHaveAttribute(
+        'data-can-save',
+        'false'
+      );
     });
   });
 

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/ReferralModal.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/ReferralModal.test.tsx
@@ -17,6 +17,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import type { AutopilotFoundJob } from '@ajh/shared';
 import type { ReferralContact, ReferralUpsertRequest } from '@ajh/shared/ipc';
+import { TEST_IDS } from '@ajh/test-ids';
 import type * as AjhUi from '@ajh/ui';
 
 // ── service mocks ─────────────────────────────────────────────────────────────
@@ -87,7 +88,7 @@ vi.mock('@ajh/ui', async (importOriginal) => {
   return {
     ...actual,
     ModalShell: ({ children }: { children: React.ReactNode }) => (
-      <div data-testid="modal-shell">{children}</div>
+      <div data-testid={TEST_IDS.documents.modalShell}>{children}</div>
     ),
   };
 });

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
@@ -27,6 +27,8 @@ import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { TEST_IDS } from '@ajh/test-ids';
+
 // ── i18n ──────────────────────────────────────────────────────────────────────
 
 vi.mock('@ajh/translations', () => ({
@@ -182,14 +184,19 @@ vi.mock('./TailorWizard', () => ({
     onGenerate: (v: { resume: string; outputType: 'resume'; researchCompany: boolean }) => void;
     jobDesc?: string;
   }) => (
-    <div data-testid="tailor-wizard" data-step={step} data-jobdesc={jobDesc}>
-      <div role="button" tabIndex={0} data-testid="wizard-next" onClick={() => setStep(step + 1)}>
+    <div data-testid={TEST_IDS.documents.tailorWizard} data-step={step} data-jobdesc={jobDesc}>
+      <div
+        role="button"
+        tabIndex={0}
+        data-testid={TEST_IDS.documents.wizardNext}
+        onClick={() => setStep(step + 1)}
+      >
         next-step
       </div>
       <div
         role="button"
         tabIndex={0}
-        data-testid="wizard-generate"
+        data-testid={TEST_IDS.documents.wizardGenerate}
         onClick={() =>
           onGenerate({ resume: 'my-resume', outputType: 'resume', researchCompany: false })
         }
@@ -201,7 +208,7 @@ vi.mock('./TailorWizard', () => ({
 }));
 
 vi.mock('./GeneratingPanel', () => ({
-  GeneratingPanel: () => <div data-testid="generating-panel" />,
+  GeneratingPanel: () => <div data-testid={TEST_IDS.documents.generatingPanel} />,
 }));
 
 vi.mock('./ResultsPanel', () => ({
@@ -220,7 +227,11 @@ vi.mock('./ResultsPanel', () => ({
     templateId?: string;
     atsMode?: boolean;
   }) => (
-    <div data-testid="results-panel" data-templateid={templateId} data-atsmode={String(atsMode)}>
+    <div
+      data-testid={TEST_IDS.documents.resultsPanel}
+      data-templateid={templateId}
+      data-atsmode={String(atsMode)}
+    >
       <div role="button" tabIndex={0} onClick={onEditSettings}>
         edit-settings
       </div>
@@ -236,7 +247,7 @@ vi.mock('./ResultsPanel', () => ({
 
 vi.mock('./ApplicationQuestionsModal', () => ({
   ApplicationQuestionsModal: ({ onClose }: { onClose: () => void }) => (
-    <div data-testid="questions-modal">
+    <div data-testid={TEST_IDS.documents.questionsModal}>
       <div role="button" tabIndex={0} onClick={onClose}>
         close-questions
       </div>
@@ -246,7 +257,7 @@ vi.mock('./ApplicationQuestionsModal', () => ({
 
 vi.mock('./InterviewQuestionsModal', () => ({
   InterviewQuestionsModal: ({ onClose }: { onClose: () => void }) => (
-    <div data-testid="interview-modal">
+    <div data-testid={TEST_IDS.documents.interviewModal}>
       <div role="button" tabIndex={0} onClick={onClose}>
         close-interview
       </div>
@@ -256,7 +267,7 @@ vi.mock('./InterviewQuestionsModal', () => ({
 
 vi.mock('./ReferralModal', () => ({
   ReferralModal: ({ onClose }: { onClose: () => void }) => (
-    <div data-testid="referral-modal">
+    <div data-testid={TEST_IDS.documents.referralModal}>
       <div role="button" tabIndex={0} onClick={onClose}>
         close-referral
       </div>
@@ -383,33 +394,33 @@ beforeEach(() => {
 describe('TailorFlow — stage derivation', () => {
   it('renders the wizard (configuring) when not generating and no output', () => {
     renderFlow({});
-    expect(screen.getByTestId('tailor-wizard')).toBeInTheDocument();
-    expect(screen.queryByTestId('generating-panel')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('results-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.generatingPanel)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.resultsPanel)).not.toBeInTheDocument();
   });
 
   it('renders the generating panel when generating=true (no output)', () => {
     genMock.generating = true;
     renderFlow({});
-    expect(screen.getByTestId('generating-panel')).toBeInTheDocument();
-    expect(screen.queryByTestId('tailor-wizard')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('results-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.generatingPanel)).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.tailorWizard)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.resultsPanel)).not.toBeInTheDocument();
   });
 
   it('renders the results panel when resumeOut is set and not generating', () => {
     genMock.resumeOut = 'Generated resume text';
     genMock.output = 'Generated resume text';
     renderFlow({});
-    expect(screen.getByTestId('results-panel')).toBeInTheDocument();
-    expect(screen.queryByTestId('tailor-wizard')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('generating-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.resultsPanel)).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.tailorWizard)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.generatingPanel)).not.toBeInTheDocument();
   });
 
   it('renders the results panel when only coverOut is set', () => {
     genMock.coverOut = 'Generated cover letter';
     genMock.output = 'Generated cover letter';
     renderFlow({});
-    expect(screen.getByTestId('results-panel')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.resultsPanel)).toBeInTheDocument();
   });
 
   it('generating=true WINS over existing output (generating stage takes priority)', () => {
@@ -417,8 +428,8 @@ describe('TailorFlow — stage derivation', () => {
     genMock.resumeOut = 'Previous output';
     genMock.output = 'Previous output';
     renderFlow({});
-    expect(screen.getByTestId('generating-panel')).toBeInTheDocument();
-    expect(screen.queryByTestId('results-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.generatingPanel)).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.resultsPanel)).not.toBeInTheDocument();
   });
 
   it('clicking "edit-settings" from done stage reverts to the wizard (forceConfiguring)', async () => {
@@ -428,14 +439,14 @@ describe('TailorFlow — stage derivation', () => {
     renderFlow({});
 
     // We are in done stage — results panel visible.
-    expect(screen.getByTestId('results-panel')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.resultsPanel)).toBeInTheDocument();
 
     // The stubbed ResultsPanel exposes an edit-settings button that calls onEditSettings.
     await user.click(screen.getByRole('button', { name: 'edit-settings' }));
 
     // After clicking, TailorFlow sets forceConfiguring → wizard shown.
-    expect(screen.getByTestId('tailor-wizard')).toBeInTheDocument();
-    expect(screen.queryByTestId('results-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.resultsPanel)).not.toBeInTheDocument();
 
     // Output is preserved under forceConfiguring — gen mock still has output.
     expect(genMock.resumeOut).toBe('Generated resume');
@@ -451,7 +462,7 @@ describe('TailorFlow — persistence injection', () => {
     // The stub renders `data-step={step}` so we can assert the value was forwarded.
     const persistence = makePersistence({ wizardStep: 2 });
     renderFlow({ persistence });
-    expect(screen.getByTestId('tailor-wizard')).toHaveAttribute('data-step', '2');
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute('data-step', '2');
   });
 
   it('reads wizardForm from persistence to seed the RHF defaultValues (non-null form)', () => {
@@ -462,7 +473,7 @@ describe('TailorFlow — persistence injection', () => {
       wizardForm: { resume: 'Seeded resume', outputType: 'resume', researchCompany: false },
     });
     renderFlow({ persistence });
-    expect(screen.getByTestId('tailor-wizard')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toBeInTheDocument();
   });
 
   it('calls persistence.setWizardForm AND persistence.setWizardStep when advancing a step', async () => {
@@ -474,7 +485,7 @@ describe('TailorFlow — persistence injection', () => {
     const persistence = makePersistence({ wizardStep: 0 });
     renderFlow({ persistence });
 
-    await user.click(screen.getByTestId('wizard-next'));
+    await user.click(screen.getByTestId(TEST_IDS.documents.wizardNext));
 
     // setWizardForm is called with the current RHF values (persistForm snapshot).
     expect(persistence.setWizardForm).toHaveBeenCalledTimes(1);
@@ -490,7 +501,7 @@ describe('TailorFlow — persistence injection', () => {
     const persistence = makePersistence();
     renderFlow({ persistence });
 
-    await user.click(screen.getByTestId('wizard-generate'));
+    await user.click(screen.getByTestId(TEST_IDS.documents.wizardGenerate));
 
     // persistForm is always called before generation starts.
     expect(persistence.setWizardForm).toHaveBeenCalledTimes(1);
@@ -509,7 +520,7 @@ describe('TailorFlow — persistence injection', () => {
     const persistence = makePersistence({ templateId: 'classic', atsMode: true });
     renderFlow({ persistence });
 
-    const panel = screen.getByTestId('results-panel');
+    const panel = screen.getByTestId(TEST_IDS.documents.resultsPanel);
     expect(panel).toHaveAttribute('data-templateid', 'classic');
     expect(panel).toHaveAttribute('data-atsmode', 'true');
   });
@@ -620,14 +631,14 @@ describe('TailorFlow — controller seam', () => {
       },
     });
 
-    expect(screen.queryByTestId('questions-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.questionsModal)).not.toBeInTheDocument();
 
     // Wrap the imperative state-update in act() so React flushes synchronously.
     act(() => {
       capturedController?.openQuestions();
     });
 
-    expect(await screen.findByTestId('questions-modal')).toBeInTheDocument();
+    expect(await screen.findByTestId(TEST_IDS.documents.questionsModal)).toBeInTheDocument();
   });
 
   it('calling openReferral() opens the ReferralModal', async () => {
@@ -638,13 +649,13 @@ describe('TailorFlow — controller seam', () => {
       },
     });
 
-    expect(screen.queryByTestId('referral-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.referralModal)).not.toBeInTheDocument();
 
     act(() => {
       capturedController?.openReferral();
     });
 
-    expect(await screen.findByTestId('referral-modal')).toBeInTheDocument();
+    expect(await screen.findByTestId(TEST_IDS.documents.referralModal)).toBeInTheDocument();
   });
 
   it('closing the questions modal removes it from the DOM', async () => {
@@ -659,10 +670,10 @@ describe('TailorFlow — controller seam', () => {
     act(() => {
       capturedController?.openQuestions();
     });
-    expect(await screen.findByTestId('questions-modal')).toBeInTheDocument();
+    expect(await screen.findByTestId(TEST_IDS.documents.questionsModal)).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'close-questions' }));
-    expect(screen.queryByTestId('questions-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.questionsModal)).not.toBeInTheDocument();
   });
 
   it('closing the referral modal removes it from the DOM', async () => {
@@ -677,16 +688,16 @@ describe('TailorFlow — controller seam', () => {
     act(() => {
       capturedController?.openReferral();
     });
-    expect(await screen.findByTestId('referral-modal')).toBeInTheDocument();
+    expect(await screen.findByTestId(TEST_IDS.documents.referralModal)).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'close-referral' }));
-    expect(screen.queryByTestId('referral-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.documents.referralModal)).not.toBeInTheDocument();
   });
 
   it('onController is not required — component renders without it', () => {
     // Verify no crash when onController prop is omitted.
     expect(() => renderFlow({})).not.toThrow();
-    expect(screen.getByTestId('tailor-wizard')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toBeInTheDocument();
   });
 });
 
@@ -749,7 +760,10 @@ describe('TailorFlow — prefer-longer / useResolveJobUrl branch', () => {
     });
 
     // jobDesc flowed into TailorWizard as the jobDesc prop → exposed as data-jobdesc.
-    expect(screen.getByTestId('tailor-wizard')).toHaveAttribute('data-jobdesc', longFetched);
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-jobdesc',
+      longFetched
+    );
   });
 
   it('(b) long initialDesc (≥800) → useResolveJobUrl called with shouldFetch=false', () => {
@@ -775,6 +789,9 @@ describe('TailorFlow — prefer-longer / useResolveJobUrl branch', () => {
     });
 
     // jobDesc must equal the carried initialDesc, not the fetched one.
-    expect(screen.getByTestId('tailor-wizard')).toHaveAttribute('data-jobdesc', carried);
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-jobdesc',
+      carried
+    );
   });
 });

--- a/apps/tauri/src/renderer/features/jobs/components/JobsPage/JobsPage.dedup-throttle.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/JobsPage/JobsPage.dedup-throttle.test.tsx
@@ -27,6 +27,8 @@ import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, waitFor } from '@testing-library/react';
 
+import { TEST_IDS } from '@ajh/test-ids';
+
 import type { Posting } from '@/features/jobs/types';
 
 // ---------------------------------------------------------------------------
@@ -104,7 +106,9 @@ vi.mock('@/hooks/use-format-relative-time', () => ({
 }));
 
 vi.mock('@/components/layout/PageHeader', () => ({
-  PageHeader: ({ title }: { title: string }) => <div data-testid="page-header">{title}</div>,
+  PageHeader: ({ title }: { title: string }) => (
+    <div data-testid={TEST_IDS.layout.pageHeader}>{title}</div>
+  ),
 }));
 
 vi.mock('@/components/layout/PageTransition', () => ({
@@ -121,9 +125,9 @@ vi.mock('@/features/jobs/components/JobsResults', () => ({
   JobsResults: ({ filtered }: { filtered: Posting[] }) => {
     lastFiltered.value = filtered;
     return (
-      <ul data-testid="jobs-results">
+      <ul data-testid={TEST_IDS.jobs.jobsResults}>
         {filtered.map((p) => (
-          <li key={p.id} data-testid="posting-row" data-id={p.id}>
+          <li key={p.id} data-testid={TEST_IDS.jobs.postingRow} data-id={p.id}>
             {p.title}
           </li>
         ))}
@@ -133,7 +137,7 @@ vi.mock('@/features/jobs/components/JobsResults', () => ({
 }));
 
 vi.mock('@/features/jobs/components/ScrapeForm', () => ({
-  ScrapeForm: () => <div data-testid="scrape-form" />,
+  ScrapeForm: () => <div data-testid={TEST_IDS.jobs.scrapeForm} />,
 }));
 
 vi.mock('@ajh/translations', () => ({
@@ -194,7 +198,7 @@ function fireStreamEvent(item: Posting, jobId = 'job-abc') {
  * noUncheckedIndexedAccess-safe: getAttribute returns string | null.
  */
 function renderedIds(): string[] {
-  return Array.from(document.querySelectorAll('[data-testid="posting-row"]')).map(
+  return Array.from(document.querySelectorAll(`[data-testid="${TEST_IDS.jobs.postingRow}"]`)).map(
     (el) => el.getAttribute('data-id') ?? ''
   );
 }

--- a/apps/tauri/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
@@ -17,6 +17,8 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, waitFor } from '@testing-library/react';
 
+import { TEST_IDS } from '@ajh/test-ids';
+
 // ---------------------------------------------------------------------------
 // Shared containers — these are objects so vi.mock factories can mutate their
 // properties even though factories run in an isolated scope.
@@ -86,7 +88,9 @@ vi.mock('@/hooks/use-format-relative-time', () => ({
 }));
 
 vi.mock('@/components/layout/PageHeader', () => ({
-  PageHeader: ({ title }: { title: string }) => <div data-testid="page-header">{title}</div>,
+  PageHeader: ({ title }: { title: string }) => (
+    <div data-testid={TEST_IDS.layout.pageHeader}>{title}</div>
+  ),
 }));
 
 vi.mock('@/components/layout/PageTransition', () => ({
@@ -94,11 +98,11 @@ vi.mock('@/components/layout/PageTransition', () => ({
 }));
 
 vi.mock('@/features/jobs/components/JobsResults', () => ({
-  JobsResults: () => <div data-testid="jobs-results" />,
+  JobsResults: () => <div data-testid={TEST_IDS.jobs.jobsResults} />,
 }));
 
 vi.mock('@/features/jobs/components/ScrapeForm', () => ({
-  ScrapeForm: () => <div data-testid="scrape-form" />,
+  ScrapeForm: () => <div data-testid={TEST_IDS.jobs.scrapeForm} />,
 }));
 
 vi.mock('@/features/jobs/providers', () => ({

--- a/apps/tauri/src/renderer/features/jobs/components/JobsResults/JobsResults.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/JobsResults/JobsResults.test.tsx
@@ -17,6 +17,7 @@ import { screen } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 
 import type { MatchScore } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 
 // ── i18n stub — identity t() so we assert on keys ─────────────────────────────
 
@@ -40,7 +41,7 @@ vi.mock('@/services', () => ({
 
 vi.mock('@/features/jobs/components/PostingRow', () => ({
   PostingRow: ({ posting }: { posting: { id: string; title: string } }) => (
-    <div data-testid="posting-row" data-id={posting.id}>
+    <div data-testid={TEST_IDS.jobs.postingRow} data-id={posting.id}>
       {posting.title}
     </div>
   ),
@@ -131,7 +132,7 @@ function renderResults(opts: {
 }
 
 function rowOrder(): string[] {
-  return Array.from(document.querySelectorAll('[data-testid="posting-row"]')).map(
+  return Array.from(document.querySelectorAll(`[data-testid="${TEST_IDS.jobs.postingRow}"]`)).map(
     (el) => el.getAttribute('data-id') ?? ''
   );
 }
@@ -147,7 +148,7 @@ describe('JobsResults — gating', () => {
     renderResults({ filtered: [posting('a', 'A'), posting('b', 'B')], scraping: true });
 
     expect(screen.getByText('jobs.searching')).toBeInTheDocument();
-    expect(screen.queryByTestId('posting-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.jobs.postingRow)).not.toBeInTheDocument();
     // "Show more" is hidden while waiting.
     expect(screen.queryByText('jobs.showMore')).not.toBeInTheDocument();
   });
@@ -159,7 +160,7 @@ describe('JobsResults — gating', () => {
     });
 
     expect(screen.getByText('jobs.scoring')).toBeInTheDocument();
-    expect(screen.queryByTestId('posting-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.jobs.postingRow)).not.toBeInTheDocument();
   });
 
   it('reveals results (escape hatch) when scoring errors even while the batch is still pending', () => {
@@ -219,6 +220,6 @@ describe('JobsResults — no résumé', () => {
     expect(screen.getByText('jobs.empty')).toBeInTheDocument();
     expect(screen.queryByText('jobs.scoring')).not.toBeInTheDocument();
     expect(screen.queryByText('jobs.searching')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('posting-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.jobs.postingRow)).not.toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.aggregator-hint.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.aggregator-hint.test.tsx
@@ -16,6 +16,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 import type { BoardCatalogEntry } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 
 // ---------------------------------------------------------------------------
 // Stubs — boards catalog
@@ -53,7 +54,7 @@ vi.mock('@/services/use-ai-provider', () => ({
 // ---------------------------------------------------------------------------
 
 vi.mock('./ScrapeFilters', () => ({
-  ScrapeFilters: () => <div data-testid="scrape-filters" />,
+  ScrapeFilters: () => <div data-testid={TEST_IDS.jobs.scrapeFilters} />,
 }));
 
 vi.mock('./BoardConnectChip', () => ({
@@ -153,7 +154,7 @@ describe('ScrapeForm — aggregator key hint', () => {
     stubKeyHas = false;
     renderForm(['aggregator']);
 
-    expect(screen.getByTestId('aggregator-key-hint')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.jobs.aggregatorKeyHint)).toBeInTheDocument();
     expect(screen.getByText('jobs.aggregatorKeyHint')).toBeInTheDocument();
   });
 
@@ -162,7 +163,7 @@ describe('ScrapeForm — aggregator key hint', () => {
     stubKeyHas = true;
     renderForm(['aggregator']);
 
-    expect(screen.queryByTestId('aggregator-key-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.jobs.aggregatorKeyHint)).not.toBeInTheDocument();
   });
 
   it('shows the hint when aggregator is selected and only App ID is absent (App Key present)', () => {
@@ -171,7 +172,7 @@ describe('ScrapeForm — aggregator key hint', () => {
     renderForm(['aggregator']);
 
     // Both keys must be present to suppress the hint
-    expect(screen.getByTestId('aggregator-key-hint')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.jobs.aggregatorKeyHint)).toBeInTheDocument();
   });
 
   it('shows the hint when aggregator is selected and only App Key is absent (App ID present)', () => {
@@ -179,7 +180,7 @@ describe('ScrapeForm — aggregator key hint', () => {
     stubKeyHas = false;
     renderForm(['aggregator']);
 
-    expect(screen.getByTestId('aggregator-key-hint')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.jobs.aggregatorKeyHint)).toBeInTheDocument();
   });
 
   it('hides the hint when aggregator is NOT selected (even with keys absent)', () => {
@@ -187,7 +188,7 @@ describe('ScrapeForm — aggregator key hint', () => {
     stubKeyHas = false;
     renderForm(['greenhouse']); // no aggregator board selected
 
-    expect(screen.queryByTestId('aggregator-key-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.jobs.aggregatorKeyHint)).not.toBeInTheDocument();
   });
 
   it('hides the hint when aggregator is deselected (multiple boards, aggregator removed)', () => {
@@ -195,6 +196,6 @@ describe('ScrapeForm — aggregator key hint', () => {
     stubKeyHas = false;
     renderForm(['greenhouse']); // aggregator not in selection
 
-    expect(screen.queryByTestId('aggregator-key-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.jobs.aggregatorKeyHint)).not.toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.company-input.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.company-input.test.tsx
@@ -28,6 +28,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import type { BoardCatalogEntry } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 
 // ---------------------------------------------------------------------------
 // Module-level stubs — reset before each test to prevent state leaks.
@@ -56,7 +57,7 @@ vi.mock('@/services/use-ai-provider', () => ({
 }));
 
 vi.mock('./ScrapeFilters', () => ({
-  ScrapeFilters: () => <div data-testid="scrape-filters" />,
+  ScrapeFilters: () => <div data-testid={TEST_IDS.jobs.scrapeFilters} />,
 }));
 
 vi.mock('./BoardConnectChip', () => ({

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.interaction.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.interaction.test.tsx
@@ -19,6 +19,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { BoardCatalogEntry } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 
 // ---------------------------------------------------------------------------
 // Module-level stubs
@@ -48,7 +49,7 @@ vi.mock('@/services/use-ai-provider', () => ({
 }));
 
 vi.mock('./ScrapeFilters', () => ({
-  ScrapeFilters: () => <div data-testid="scrape-filters" />,
+  ScrapeFilters: () => <div data-testid={TEST_IDS.jobs.scrapeFilters} />,
 }));
 
 vi.mock('./BoardConnectChip', () => ({
@@ -352,7 +353,7 @@ function renderFormWithQuery(
 
 /** Returns the primary Start/Scrape button (variant=primary, no aria-pressed). */
 function getStartButton(): HTMLElement {
-  return screen.getByTestId('scrape-start-button');
+  return screen.getByTestId(TEST_IDS.jobs.scrapeStartButton);
 }
 
 describe('ScrapeForm — required-board login gate', () => {

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.test.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.test.tsx
@@ -19,6 +19,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 import type { BoardCatalogEntry } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 
 // ---------------------------------------------------------------------------
 // Module-level stub for useBoardsCatalog — set before each test via the ref
@@ -43,7 +44,7 @@ vi.mock('@/services/use-ai-provider', () => ({
 
 // Stub ScrapeFilters — deep component; not under test here
 vi.mock('./ScrapeFilters', () => ({
-  ScrapeFilters: () => <div data-testid="scrape-filters" />,
+  ScrapeFilters: () => <div data-testid={TEST_IDS.jobs.scrapeFilters} />,
 }));
 
 // Stub BoardConnectChip — not under test here

--- a/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/index.tsx
+++ b/apps/tauri/src/renderer/features/jobs/components/ScrapeForm/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 
 import type { BoardCatalogEntry } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
 import { Button, CardSkeleton, cn, GlassCard, Input, transition } from '@ajh/ui';
 
@@ -311,7 +312,7 @@ export function ScrapeForm({
             {/* Aggregator key hint — shown when aggregator selected but Adzuna keys absent */}
             {showAggregatorKeyHint && (
               <p
-                data-testid="aggregator-key-hint"
+                data-testid={TEST_IDS.jobs.aggregatorKeyHint}
                 className="mb-3 flex items-center gap-1.5 text-[11px] text-amber-400/70"
               >
                 <Info size={11} aria-hidden="true" />
@@ -430,7 +431,7 @@ export function ScrapeForm({
                 aria-describedby={
                   !scraping && blockedByRequiredLogin ? 'scrape-blocked-hint' : undefined
                 }
-                data-testid="scrape-start-button"
+                data-testid={TEST_IDS.jobs.scrapeStartButton}
                 className="transition-all duration-150 ease-out"
               >
                 {!scraping && <Search size={12} />}

--- a/apps/tauri/src/renderer/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/tauri/src/renderer/features/onboarding/OnboardingWizard/index.test.tsx
@@ -22,6 +22,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { TEST_IDS } from '@ajh/test-ids';
 import { Button } from '@ajh/ui';
 
 import { usePreferencesStore } from '@/store/preferences-store';
@@ -51,7 +52,11 @@ vi.mock('../steps/WelcomeStep', () => ({
     stepIndex: number;
     totalSteps: number;
   }) => (
-    <div data-testid="step-welcome" data-step-index={stepIndex} data-total-steps={totalSteps}>
+    <div
+      data-testid={TEST_IDS.onboarding.stepWelcome}
+      data-step-index={stepIndex}
+      data-total-steps={totalSteps}
+    >
       <Button onClick={onNext}>next</Button>
       {onBack && <Button onClick={onBack}>back</Button>}
     </div>
@@ -70,7 +75,11 @@ vi.mock('../steps/ResumeStep', () => ({
     stepIndex: number;
     totalSteps: number;
   }) => (
-    <div data-testid="step-resume" data-step-index={stepIndex} data-total-steps={totalSteps}>
+    <div
+      data-testid={TEST_IDS.onboarding.stepResume}
+      data-step-index={stepIndex}
+      data-total-steps={totalSteps}
+    >
       <Button onClick={onNext}>next</Button>
       {onBack && <Button onClick={onBack}>back</Button>}
     </div>
@@ -89,7 +98,11 @@ vi.mock('../steps/AISelectionStep', () => ({
     stepIndex: number;
     totalSteps: number;
   }) => (
-    <div data-testid="step-ai" data-step-index={stepIndex} data-total-steps={totalSteps}>
+    <div
+      data-testid={TEST_IDS.onboarding.stepAi}
+      data-step-index={stepIndex}
+      data-total-steps={totalSteps}
+    >
       <Button onClick={onNext}>next</Button>
       {onBack && <Button onClick={onBack}>back</Button>}
     </div>
@@ -108,7 +121,11 @@ vi.mock('../steps/ResearchStep', () => ({
     stepIndex: number;
     totalSteps: number;
   }) => (
-    <div data-testid="step-research" data-step-index={stepIndex} data-total-steps={totalSteps}>
+    <div
+      data-testid={TEST_IDS.onboarding.stepResearch}
+      data-step-index={stepIndex}
+      data-total-steps={totalSteps}
+    >
       <Button onClick={onNext}>next</Button>
       {onBack && <Button onClick={onBack}>back</Button>}
     </div>
@@ -127,7 +144,11 @@ vi.mock('../steps/BrowserStep', () => ({
     stepIndex: number;
     totalSteps: number;
   }) => (
-    <div data-testid="step-browser" data-step-index={stepIndex} data-total-steps={totalSteps}>
+    <div
+      data-testid={TEST_IDS.onboarding.stepBrowser}
+      data-step-index={stepIndex}
+      data-total-steps={totalSteps}
+    >
       <Button onClick={onNext}>next</Button>
       {onBack && <Button onClick={onBack}>back</Button>}
     </div>
@@ -146,7 +167,11 @@ vi.mock('../steps/AdzunaKeyStep', () => ({
     stepIndex: number;
     totalSteps: number;
   }) => (
-    <div data-testid="step-adzunaKey" data-step-index={stepIndex} data-total-steps={totalSteps}>
+    <div
+      data-testid={TEST_IDS.onboarding.stepAdzunaKey}
+      data-step-index={stepIndex}
+      data-total-steps={totalSteps}
+    >
       <Button onClick={onNext}>next</Button>
       {onBack && <Button onClick={onBack}>back</Button>}
     </div>
@@ -165,7 +190,11 @@ vi.mock('../steps/ExtensionStep', () => ({
     stepIndex: number;
     totalSteps: number;
   }) => (
-    <div data-testid="step-extension" data-step-index={stepIndex} data-total-steps={totalSteps}>
+    <div
+      data-testid={TEST_IDS.onboarding.stepExtension}
+      data-step-index={stepIndex}
+      data-total-steps={totalSteps}
+    >
       <Button onClick={onNext}>next</Button>
       {onBack && <Button onClick={onBack}>back</Button>}
     </div>
@@ -184,7 +213,11 @@ vi.mock('../steps/AppearanceStep', () => ({
     stepIndex: number;
     totalSteps: number;
   }) => (
-    <div data-testid="step-appearance" data-step-index={stepIndex} data-total-steps={totalSteps}>
+    <div
+      data-testid={TEST_IDS.onboarding.stepAppearance}
+      data-step-index={stepIndex}
+      data-total-steps={totalSteps}
+    >
       <Button onClick={onNext}>next</Button>
       {onBack && <Button onClick={onBack}>back</Button>}
     </div>
@@ -195,7 +228,7 @@ vi.mock('../steps/AppearanceStep', () => ({
 
 vi.mock('../SpotlightTour', () => ({
   SpotlightTour: ({ onFinish }: { onFinish: () => void }) => (
-    <div data-testid="tour">
+    <div data-testid={TEST_IDS.onboarding.tour}>
       <Button onClick={onFinish}>finish-tour</Button>
     </div>
   ),
@@ -251,7 +284,7 @@ describe('OnboardingWizard — step filter', () => {
     });
     renderWizard();
 
-    const welcome = screen.getByTestId('step-welcome');
+    const welcome = screen.getByTestId(TEST_IDS.onboarding.stepWelcome);
     expect(totalStepsOf(welcome)).toBe(8);
   });
 
@@ -261,7 +294,7 @@ describe('OnboardingWizard — step filter', () => {
     });
     renderWizard();
 
-    const welcome = screen.getByTestId('step-welcome');
+    const welcome = screen.getByTestId(TEST_IDS.onboarding.stepWelcome);
     expect(totalStepsOf(welcome)).toBe(7);
   });
 
@@ -269,7 +302,7 @@ describe('OnboardingWizard — step filter', () => {
     usePreferencesStore.setState({ aiProviderConfig: undefined });
     renderWizard();
 
-    const welcome = screen.getByTestId('step-welcome');
+    const welcome = screen.getByTestId(TEST_IDS.onboarding.stepWelcome);
     expect(totalStepsOf(welcome)).toBe(7);
   });
 
@@ -281,11 +314,11 @@ describe('OnboardingWizard — step filter', () => {
     renderWizard();
 
     // welcome → resume → ai → research (index 3)
-    await clickNext(user, screen.getByTestId('step-welcome'));
-    await clickNext(user, screen.getByTestId('step-resume'));
-    await clickNext(user, screen.getByTestId('step-ai'));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
 
-    expect(screen.getByTestId('step-research')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepResearch)).toBeInTheDocument();
   });
 
   it('research stub never appears when activeProvider is openai', async () => {
@@ -296,12 +329,12 @@ describe('OnboardingWizard — step filter', () => {
     renderWizard();
 
     // welcome → resume → ai → browser (research skipped)
-    await clickNext(user, screen.getByTestId('step-welcome'));
-    await clickNext(user, screen.getByTestId('step-resume'));
-    await clickNext(user, screen.getByTestId('step-ai'));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
 
-    expect(screen.queryByTestId('step-research')).not.toBeInTheDocument();
-    expect(screen.getByTestId('step-browser')).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.onboarding.stepResearch)).not.toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepBrowser)).toBeInTheDocument();
   });
 });
 
@@ -310,25 +343,25 @@ describe('OnboardingWizard — navigation', () => {
     const user = userEvent.setup();
     renderWizard();
 
-    expect(screen.getByTestId('step-welcome')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepWelcome)).toBeInTheDocument();
 
-    await clickNext(user, screen.getByTestId('step-welcome'));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
 
-    expect(screen.queryByTestId('step-welcome')).not.toBeInTheDocument();
-    expect(screen.getByTestId('step-resume')).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.onboarding.stepWelcome)).not.toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepResume)).toBeInTheDocument();
   });
 
   it('stepIndex prop increments correctly on each onNext', async () => {
     const user = userEvent.setup();
     renderWizard();
 
-    expect(stepIndexOf(screen.getByTestId('step-welcome'))).toBe(0);
+    expect(stepIndexOf(screen.getByTestId(TEST_IDS.onboarding.stepWelcome))).toBe(0);
 
-    await clickNext(user, screen.getByTestId('step-welcome'));
-    expect(stepIndexOf(screen.getByTestId('step-resume'))).toBe(1);
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    expect(stepIndexOf(screen.getByTestId(TEST_IDS.onboarding.stepResume))).toBe(1);
 
-    await clickNext(user, screen.getByTestId('step-resume'));
-    expect(stepIndexOf(screen.getByTestId('step-ai'))).toBe(2);
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
+    expect(stepIndexOf(screen.getByTestId(TEST_IDS.onboarding.stepAi))).toBe(2);
   });
 
   it('renders SpotlightTour after onNext on the last step', async () => {
@@ -339,16 +372,16 @@ describe('OnboardingWizard — navigation', () => {
     renderWizard();
 
     // 7-step sequence (openai): welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4) → extension(5) → appearance(6)
-    await clickNext(user, screen.getByTestId('step-welcome'));
-    await clickNext(user, screen.getByTestId('step-resume'));
-    await clickNext(user, screen.getByTestId('step-ai'));
-    await clickNext(user, screen.getByTestId('step-browser'));
-    await clickNext(user, screen.getByTestId('step-adzunaKey'));
-    await clickNext(user, screen.getByTestId('step-extension'));
-    await clickNext(user, screen.getByTestId('step-appearance'));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAppearance));
 
-    expect(screen.getByTestId('tour')).toBeInTheDocument();
-    expect(screen.queryByTestId('step-appearance')).not.toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.onboarding.tour)).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.onboarding.stepAppearance)).not.toBeInTheDocument();
   });
 
   it('calling onFinish on the tour marks onboarding complete (renders null)', async () => {
@@ -359,13 +392,13 @@ describe('OnboardingWizard — navigation', () => {
     const { container } = renderWizard();
 
     // Advance through all 7 steps to reach the tour
-    await clickNext(user, screen.getByTestId('step-welcome'));
-    await clickNext(user, screen.getByTestId('step-resume'));
-    await clickNext(user, screen.getByTestId('step-ai'));
-    await clickNext(user, screen.getByTestId('step-browser'));
-    await clickNext(user, screen.getByTestId('step-adzunaKey'));
-    await clickNext(user, screen.getByTestId('step-extension'));
-    await clickNext(user, screen.getByTestId('step-appearance'));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAppearance));
 
     // Tour is visible; click finish
     await user.click(screen.getByRole('button', { name: 'finish-tour' }));
@@ -381,19 +414,19 @@ describe('OnboardingWizard — goBack floor', () => {
     renderWizard();
 
     // Advance to step 1, then go back to step 0
-    await clickNext(user, screen.getByTestId('step-welcome'));
-    expect(screen.getByTestId('step-resume')).toBeInTheDocument();
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepResume)).toBeInTheDocument();
 
     // Go back to welcome
-    await clickBack(user, screen.getByTestId('step-resume'));
+    await clickBack(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
 
-    expect(screen.getByTestId('step-welcome')).toBeInTheDocument();
-    expect(stepIndexOf(screen.getByTestId('step-welcome'))).toBe(0);
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepWelcome)).toBeInTheDocument();
+    expect(stepIndexOf(screen.getByTestId(TEST_IDS.onboarding.stepWelcome))).toBe(0);
 
     // Clicking the (non-existent / inert) back at index 0 must not crash.
     // The WelcomeStep stub only shows a back button when onBack is provided.
     // The wizard passes goBack unconditionally; verify the step renders fine.
-    expect(screen.getByTestId('step-welcome')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepWelcome)).toBeInTheDocument();
   });
 
   it('stepIndex stays at 0 when goBack is triggered at first step', async () => {
@@ -401,14 +434,14 @@ describe('OnboardingWizard — goBack floor', () => {
     renderWizard();
 
     // Navigate forward then back to index 0
-    await clickNext(user, screen.getByTestId('step-welcome'));
-    await clickBack(user, screen.getByTestId('step-resume'));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    await clickBack(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
 
     // Now at index 0. The WelcomeStep stub only renders a back button when
     // onBack is provided; the wizard always passes goBack so the button IS
     // present. Assert it exists (non-vacuous), click it, and confirm the
     // wizard stays at index 0 — goBack is a floor-clamped no-op at step 0.
-    const welcomeEl = screen.getByTestId('step-welcome');
+    const welcomeEl = screen.getByTestId(TEST_IDS.onboarding.stepWelcome);
     expect(stepIndexOf(welcomeEl)).toBe(0);
 
     const welcomeBackBtn = within(welcomeEl).queryByRole('button', { name: 'back' });
@@ -416,8 +449,8 @@ describe('OnboardingWizard — goBack floor', () => {
     if (welcomeBackBtn) await user.click(welcomeBackBtn);
 
     // Identity of the visible step must not change
-    expect(screen.getByTestId('step-welcome')).toBeInTheDocument();
-    expect(stepIndexOf(screen.getByTestId('step-welcome'))).toBe(0);
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepWelcome)).toBeInTheDocument();
+    expect(stepIndexOf(screen.getByTestId(TEST_IDS.onboarding.stepWelcome))).toBe(0);
   });
 });
 
@@ -430,18 +463,18 @@ describe('OnboardingWizard — clamp on provider flip', () => {
     renderWizard();
 
     // Advance to the last step of the 8-step ollama sequence (index 7 = appearance)
-    await clickNext(user, screen.getByTestId('step-welcome'));
-    await clickNext(user, screen.getByTestId('step-resume'));
-    await clickNext(user, screen.getByTestId('step-ai'));
-    await clickNext(user, screen.getByTestId('step-research'));
-    await clickNext(user, screen.getByTestId('step-browser'));
-    await clickNext(user, screen.getByTestId('step-adzunaKey'));
-    await clickNext(user, screen.getByTestId('step-extension'));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResearch));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
 
     // At index 7 (appearance), totalSteps 8
-    expect(screen.getByTestId('step-appearance')).toBeInTheDocument();
-    expect(stepIndexOf(screen.getByTestId('step-appearance'))).toBe(7);
-    expect(totalStepsOf(screen.getByTestId('step-appearance'))).toBe(8);
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepAppearance)).toBeInTheDocument();
+    expect(stepIndexOf(screen.getByTestId(TEST_IDS.onboarding.stepAppearance))).toBe(7);
+    expect(totalStepsOf(screen.getByTestId(TEST_IDS.onboarding.stepAppearance))).toBe(8);
 
     // Flip provider to openai — array shrinks to 7 steps (max valid index = 6).
     // The clamp effect must land the wizard on step 6 = appearance.
@@ -474,6 +507,6 @@ describe('OnboardingWizard — completion gate', () => {
   it('renders the wizard when onboardingCompleted is false', () => {
     usePreferencesStore.setState({ onboardingCompleted: false });
     renderWizard();
-    expect(screen.getByTestId('step-welcome')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.onboarding.stepWelcome)).toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.test.tsx
@@ -22,6 +22,8 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
+import { TEST_IDS } from '@ajh/test-ids';
+
 // ── matchMedia leak guard ─────────────────────────────────────────────────────
 // Several describe blocks override window.matchMedia in their beforeEach to
 // simulate prefers-reduced-motion.  Save the original once here and restore it
@@ -37,46 +39,46 @@ vi.mock('@ajh/translations', () => ({
 // ── Stub every section component so SettingsContent renders without IPC ───────
 
 vi.mock('@/features/settings/components/general-section', () => ({
-  GeneralSection: () => <div data-testid="general-section" />,
+  GeneralSection: () => <div data-testid={TEST_IDS.settings.generalSection} />,
 }));
 vi.mock('@/features/settings/components/general-section/AppearanceCard', () => ({
-  AppearanceCard: () => <div data-testid="appearance-card" />,
+  AppearanceCard: () => <div data-testid={TEST_IDS.settings.appearanceCard} />,
 }));
 vi.mock('@/features/settings/components/contact/ContactProfileTab', () => ({
-  ContactProfileTab: () => <div data-testid="contact-tab" />,
+  ContactProfileTab: () => <div data-testid={TEST_IDS.settings.contactTab} />,
 }));
 vi.mock('@/features/settings/components/ai-settings/AISettingsTab', () => ({
-  AISettingsTab: () => <div data-testid="ai-tab" />,
+  AISettingsTab: () => <div data-testid={TEST_IDS.settings.aiTab} />,
 }));
 vi.mock('@/features/settings/components/preferences/OutputTonePreferences', () => ({
-  OutputTonePreferences: () => <div data-testid="tone-prefs" />,
+  OutputTonePreferences: () => <div data-testid={TEST_IDS.settings.tonePrefs} />,
 }));
 vi.mock('@/features/settings/components/preferences/JobLocationPreferences', () => ({
-  JobLocationPreferences: () => <div data-testid="job-location" />,
+  JobLocationPreferences: () => <div data-testid={TEST_IDS.settings.jobLocation} />,
 }));
 vi.mock('@/features/settings/components/preferences/TechStackPreferences', () => ({
-  TechStackPreferences: () => <div data-testid="tech-stack" />,
+  TechStackPreferences: () => <div data-testid={TEST_IDS.settings.techStack} />,
 }));
 vi.mock('@/features/settings/components/preferences/AggregatorKeysSettings', () => ({
-  AggregatorKeysSettings: () => <div data-testid="aggregator" />,
+  AggregatorKeysSettings: () => <div data-testid={TEST_IDS.settings.aggregator} />,
 }));
 vi.mock('@/features/settings/components/preferences/ResumePreferences', () => ({
-  ResumePreferences: () => <div data-testid="resume-prefs" />,
+  ResumePreferences: () => <div data-testid={TEST_IDS.settings.resumePrefs} />,
 }));
 vi.mock('@/features/settings/components/accounts/AccountsSettingsTab', () => ({
-  AccountsSettingsTab: () => <div data-testid="accounts-tab" />,
+  AccountsSettingsTab: () => <div data-testid={TEST_IDS.settings.accountsTab} />,
 }));
 vi.mock('@/features/settings/components/privacy/PrivacySettingsTab', () => ({
-  PrivacySettingsTab: () => <div data-testid="privacy-tab" />,
+  PrivacySettingsTab: () => <div data-testid={TEST_IDS.settings.privacyTab} />,
 }));
 vi.mock('@/features/settings/components/preferences/PerformancePreferences', () => ({
-  PerformancePreferences: () => <div data-testid="perf-prefs" />,
+  PerformancePreferences: () => <div data-testid={TEST_IDS.settings.perfPrefs} />,
 }));
 vi.mock('@/features/settings/components/preferences/DeveloperPreferences', () => ({
-  DeveloperPreferences: () => <div data-testid="dev-prefs" />,
+  DeveloperPreferences: () => <div data-testid={TEST_IDS.settings.devPrefs} />,
 }));
 vi.mock('@/features/settings/components/about/AboutTab', () => ({
-  AboutTab: () => <div data-testid="about-tab" />,
+  AboutTab: () => <div data-testid={TEST_IDS.settings.aboutTab} />,
 }));
 
 // ── component under test ──────────────────────────────────────────────────────

--- a/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.test.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.test.tsx
@@ -35,6 +35,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { TEST_IDS } from '@ajh/test-ids';
 import type { ThemePrefs } from '@ajh/ui';
 
 // ── i18n stub ─────────────────────────────────────────────────────────────────
@@ -119,7 +120,9 @@ describe('AppearanceCard — preset accent swatches', () => {
     const { container } = render(<AppearanceCard />);
     // The Default chip contains a <span> tagged with a stable test id; locating it
     // by `data-testid` keeps element detection CSS-independent (no style matching).
-    const dot = container.querySelector<HTMLElement>('[data-testid="default-accent-dot"]');
+    const dot = container.querySelector<HTMLElement>(
+      `[data-testid="${TEST_IDS.settings.defaultAccentDot}"]`
+    );
     if (!dot) throw new Error('expected default chip dot with CSS-var gradient background');
     const dotStyle = dot.getAttribute('style') ?? '';
     expect(dotStyle).toContain('var(--color-brand-base)');

--- a/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/general-section/AppearanceCard.tsx
@@ -1,6 +1,7 @@
 import { Monitor, Palette, Type } from 'lucide-react';
 import { useRef, useState } from 'react';
 
+import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
 import {
   applyThemeAnimated,
@@ -150,7 +151,7 @@ export function AppearanceCard() {
               )}
             >
               <span
-                data-testid="default-accent-dot"
+                data-testid={TEST_IDS.settings.defaultAccentDot}
                 className="h-3 w-3 rounded-full"
                 style={{
                   // BASE brand tokens (never overridden by the runtime accent

--- a/apps/tauri/vite.config.ts
+++ b/apps/tauri/vite.config.ts
@@ -25,6 +25,12 @@ export default defineConfig({
         find: /^@ajh\/translations$/,
         replacement: path.resolve(__dirname, '../../packages/translations/src/index.ts'),
       },
+      // Resolve test-id constants to SOURCE — production components import this
+      // package so Vite must know the path in both dev and build modes.
+      {
+        find: /^@ajh\/test-ids$/,
+        replacement: path.resolve(__dirname, '../../packages/test-ids/src/index.ts'),
+      },
       { find: '@', replacement: path.resolve(__dirname, 'src/renderer') },
     ],
   },

--- a/apps/tauri/vitest.config.ts
+++ b/apps/tauri/vitest.config.ts
@@ -17,6 +17,7 @@ const sharedSrc = resolve(here, '../../packages/shared/src');
 const promptsSrc = resolve(here, '../../packages/prompts/src');
 const uiSrc = resolve(here, '../../packages/ui/src');
 const translationsSrc = resolve(here, '../../packages/translations/src');
+const testIdsSrc = resolve(here, '../../packages/test-ids/src');
 
 export default defineConfig({
   plugins: [react()],
@@ -52,6 +53,7 @@ export default defineConfig({
       { find: '@ajh/prompts', replacement: resolve(promptsSrc, 'index.ts') },
       { find: '@ajh/ui', replacement: resolve(uiSrc, 'index.ts') },
       { find: '@ajh/translations', replacement: resolve(translationsSrc, 'index.ts') },
+      { find: '@ajh/test-ids', replacement: resolve(testIdsSrc, 'index.ts') },
       { find: '@', replacement: resolve(here, 'src/renderer') },
     ],
   },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,6 +178,10 @@ It is **provider-aware** and **locale-driven**:
 - **Modular folders** — every concern (`analyze/`, `generate/`, `context-manager/`, `provider/`, `locale/`, `workspace/`) is a folder with an `index.ts` barrel (the `@ajh/prompts/<name>` subpath entry) plus focused submodules and a colocated test. `context-manager/model-size.ts` parses a model's parameter size generically from its tag and defaults unknown local models to the smaller/safer prompt; CLI-agent / hosted model names (sonnet/opus/haiku/codex/gpt/claude/gemini) are treated as capable.
 - **Validators** (`validateAndRepair`, `validateMetadata`) remain the universal fallback for every provider.
 
+### `packages/test-ids` — Test-ID Constants (`@ajh/test-ids`)
+
+Centralized, feature-namespaced `TEST_IDS` constant map mirroring translation-key structure: `TEST_IDS.<feature>.<name>` ↔ `t('<feature>.<name>')`. Consumed as a production dependency by both components (for `data-testid` attributes) and tests (for queries), ensuring test IDs cannot drift between a component's implementation and its test suite. See `packages/test-ids/src/test-ids.ts`.
+
 > The heavy work (scraping, document extraction, AI generation, embeddings) runs natively in the Rust core under `apps/tauri/src-tauri/` — see the Component Breakdown above. Earlier Node packages (`@ajh/core`, `@ajh/ai`, `@ajh/data`, `@ajh/workers`) implemented this for a now-removed sidecar and have been deleted.
 
 ---
@@ -447,17 +451,21 @@ graph TD
     UI["packages/ui"]
     Prompts["packages/prompts"]
     Translations["packages/translations"]
+    TestIds["packages/test-ids"]
 
     Renderer --> Shared
     Renderer --> UI
     Renderer --> Prompts
     Renderer --> Translations
+    Renderer --> TestIds
     UI --> Shared
+    UI --> TestIds
 
     style Renderer fill:#4f46e5,color:#fff
     style UI fill:#7c3aed,color:#fff
     style Shared fill:#0f766e,color:#fff
     style Translations fill:#7c3aed,color:#fff
+    style TestIds fill:#b91c1c,color:#fff
 ```
 
 **Hard rules:**
@@ -466,7 +474,8 @@ graph TD
 - `packages/ui` — no [Zustand][zustand], no IPC, no routing
 - `packages/prompts` — no UI, no `window`
 - `packages/translations` — i18next singleton + adapters; no app-specific or IPC imports
-- The renderer imports only `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`, `@ajh/translations`
+- `packages/test-ids` — pure string constants only; no React, no Node, no test-framework imports
+- The renderer imports only `@ajh/shared`, `@ajh/ui`, `@ajh/prompts`, `@ajh/translations`, `@ajh/test-ids`
 
 [tauri]: https://tauri.app
 [react]: https://react.dev

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -135,6 +135,7 @@ packages/
   shared/               ← IPC contracts + Zod schemas + shared types
   ui/                   ← @ajh/ui component library
   prompts/              ← AI prompt templates
+  test-ids/             ← @ajh/test-ids — centralized test-id constants (drift-proof data-testid)
 ```
 
 ---

--- a/packages/test-ids/package.json
+++ b/packages/test-ids/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@ajh/test-ids",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/test-ids/src/index.ts
+++ b/packages/test-ids/src/index.ts
@@ -1,0 +1,1 @@
+export * from './test-ids';

--- a/packages/test-ids/src/test-ids.test.ts
+++ b/packages/test-ids/src/test-ids.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { TEST_IDS } from './test-ids';
+
+/** Recursively collect all leaf string values from the nested TEST_IDS tree. */
+function collectLeaves(
+  node: Record<string, unknown>,
+  path = ''
+): Array<{ path: string; value: string }> {
+  const results: Array<{ path: string; value: string }> = [];
+  for (const [key, val] of Object.entries(node)) {
+    const fullPath = path ? `${path}.${key}` : key;
+    if (typeof val === 'string') {
+      results.push({ path: fullPath, value: val });
+    } else if (val !== null && typeof val === 'object') {
+      results.push(...collectLeaves(val as Record<string, unknown>, fullPath));
+    }
+  }
+  return results;
+}
+
+describe('TEST_IDS', () => {
+  it('all leaf values are globally unique (no silent string collisions)', () => {
+    const leaves = collectLeaves(TEST_IDS as unknown as Record<string, unknown>);
+    const seen = new Map<string, string>();
+    const duplicates: string[] = [];
+
+    for (const { path, value } of leaves) {
+      if (seen.has(value)) {
+        duplicates.push(`"${value}" appears at both "${seen.get(value)}" and "${path}"`);
+      } else {
+        seen.set(value, path);
+      }
+    }
+
+    expect(duplicates, `Duplicate test-id values found:\n${duplicates.join('\n')}`).toHaveLength(0);
+  });
+
+  it('all leaf values are non-empty strings', () => {
+    const leaves = collectLeaves(TEST_IDS as unknown as Record<string, unknown>);
+    const empty = leaves.filter(({ value }) => !value || value.trim() === '');
+    expect(empty, 'Found empty test-id values').toHaveLength(0);
+  });
+
+  it('has expected top-level namespaces', () => {
+    const keys = Object.keys(TEST_IDS);
+    expect(keys).toContain('layout');
+    expect(keys).toContain('jobs');
+    expect(keys).toContain('settings');
+    expect(keys).toContain('autopilot');
+    expect(keys).toContain('applications');
+    expect(keys).toContain('documents');
+    expect(keys).toContain('resume');
+    expect(keys).toContain('generation');
+    expect(keys).toContain('onboarding');
+  });
+});

--- a/packages/test-ids/src/test-ids.ts
+++ b/packages/test-ids/src/test-ids.ts
@@ -1,0 +1,126 @@
+/**
+ * Centralized, feature-namespaced test-id constants.
+ *
+ * Shape mirrors the translation-key namespace tree:
+ *   TEST_IDS.<feature>.<name>  ←→  t('<feature>.<name>')
+ *
+ * String VALUES are byte-identical to the original inline strings — only the
+ * reference site changes from a literal to a constant.
+ *
+ * Rule: pure string constants only — no React, no Node, no test-framework imports.
+ */
+export const TEST_IDS = {
+  /** Chrome / cross-route layout stubs */
+  layout: {
+    pageShell: 'page-shell',
+    pageHeader: 'page-header',
+    pageTransition: 'page-transition',
+    notFound: 'notfound',
+    dashboard: 'dashboard',
+  },
+
+  /** Jobs feature — scraping, results, form */
+  jobs: {
+    scrapeForm: 'scrape-form',
+    /** stub-only: no matching attribute on the real component */
+    scrapeFilters: 'scrape-filters',
+    aggregatorKeyHint: 'aggregator-key-hint',
+    scrapeStartButton: 'scrape-start-button',
+    jobsResults: 'jobs-results',
+    jobsList: 'jobs-list',
+    postingRow: 'posting-row',
+  },
+
+  /** Settings feature */
+  settings: {
+    defaultAccentDot: 'default-accent-dot',
+    generalSection: 'general-section',
+    appearanceCard: 'appearance-card',
+    contactTab: 'contact-tab',
+    aiTab: 'ai-tab',
+    tonePrefs: 'tone-prefs',
+    jobLocation: 'job-location',
+    techStack: 'tech-stack',
+    aggregator: 'aggregator',
+    resumePrefs: 'resume-prefs',
+    accountsTab: 'accounts-tab',
+    privacyTab: 'privacy-tab',
+    perfPrefs: 'perf-prefs',
+    devPrefs: 'dev-prefs',
+    aboutTab: 'about-tab',
+  },
+
+  /** Autopilot feature */
+  autopilot: {
+    card: 'autopilot-card',
+    creationWizard: 'creation-wizard',
+    emptyState: 'autopilot-empty-state',
+    /** StepSchedule probe — used in wizard step test */
+    probe: 'probe',
+  },
+
+  /** Applications (tracker) feature */
+  applications: {
+    list: 'applications-list',
+    row: 'application-row',
+    trackJobModal: 'track-job-modal',
+  },
+
+  /**
+   * Documents feature — TailorFlow, DocumentsPage, GenerationOutput,
+   * GeneratingPanel, ReferralModal, ai-generate OutputPanelDone.
+   */
+  documents: {
+    generationCard: 'generation-card',
+    interactionRow: 'interaction-row',
+    /** stub-only: no matching attribute on the real component */
+    tailorFlowStub: 'tailor-flow-stub',
+    /** stub-only: no matching attribute on the real component — used in ApplicationDetailPage tests */
+    tailorFlow: 'tailor-flow',
+    tailorWizard: 'tailor-wizard',
+    wizardNext: 'wizard-next',
+    wizardGenerate: 'wizard-generate',
+    generatingPanel: 'generating-panel',
+    resultsPanel: 'results-panel',
+    questionsModal: 'questions-modal',
+    interviewModal: 'interview-modal',
+    referralModal: 'referral-modal',
+    modalShell: 'modal-shell',
+    editableOutput: 'editable-output',
+    editableInput: 'editable-input',
+    saveBtn: 'save-btn',
+    previewSlot: 'preview-slot',
+    templatePicker: 'template-picker',
+    pdfPreview: 'pdf-preview',
+    thinkingBubble: 'thinking-bubble',
+    stepDots: 'step-dots',
+  },
+
+  /** Resume shared components (ResumeInputCard) */
+  resume: {
+    review: 'review',
+    uploadZone: 'upload-zone',
+  },
+
+  /** Shared generation component (EditableOutput) */
+  generation: {
+    richTextEditor: 'rich-text-editor',
+    rteSelectTrigger: 'rte-select-trigger',
+    rteValue: 'rte-value',
+    rteDeselectTrigger: 'rte-deselect-trigger',
+    customPreview: 'custom-preview',
+  },
+
+  /** Onboarding wizard */
+  onboarding: {
+    stepWelcome: 'step-welcome',
+    stepResume: 'step-resume',
+    stepAi: 'step-ai',
+    stepResearch: 'step-research',
+    stepBrowser: 'step-browser',
+    stepAdzunaKey: 'step-adzuna-key',
+    stepExtension: 'step-extension',
+    stepAppearance: 'step-appearance',
+    tour: 'tour',
+  },
+} as const;

--- a/packages/test-ids/tsconfig.json
+++ b/packages/test-ids/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/test-ids/vitest.config.ts
+++ b/packages/test-ids/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts'],
+    reporters: ['verbose'],
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@ajh/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@ajh/test-ids':
+        specifier: workspace:*
+        version: link:../../packages/test-ids
       '@ajh/translations':
         specifier: workspace:*
         version: link:../../packages/translations
@@ -269,6 +272,15 @@ importers:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/test-ids:
+    devDependencies:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     projects: [
       'packages/shared',
       'packages/prompts',
+      'packages/test-ids',
       'packages/ui',
       // Storybook browser-test project (headless Chromium via Playwright). Runs
       // every story as a test; selectable on its own with `--project storybook`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized DOM querying across 40+ UI/regression tests by switching `data-testid` selectors and component stubs to centralized `TEST_IDS` constants.

* **Chores**
  * Added a new `@ajh/test-ids` package providing feature-namespaced `TEST_IDS` string constants.
  * Updated app build/test tooling to recognize and use the new package during development and test runs.

* **Documentation**
  * Updated architecture and development docs (and monorepo rule sets) to describe the new test-id infrastructure and package boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->