### PR TITLE
refactor: centralize timeouts/durations and use section/stage registries

### DIFF
--- a/apps/tauri/src-tauri/src/commands/ai_provider/anthropic.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/anthropic.rs
@@ -11,6 +11,7 @@ use crate::error::{AppError, AppResult};
 use super::research;
 use super::retry::send_with_retry;
 use super::stream::{stream_response, StreamPiece};
+use super::timeouts;
 use super::{
     friendly_api_error, AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, RequestTrace,
     TokenParam,
@@ -198,7 +199,7 @@ impl AiProvider for AnthropicClient {
 
         let response = crate::net::http::shared()
             .post(&endpoint)
-            .timeout(std::time::Duration::from_secs(300))
+            .timeout(timeouts::STREAM)
             .header("x-api-key", &api_key)
             .header("anthropic-version", VERSION)
             .json(&body)
@@ -259,7 +260,7 @@ impl AiProvider for AnthropicClient {
         let resp = send_with_retry(|| {
             crate::net::http::shared()
                 .post(&endpoint)
-                .timeout(std::time::Duration::from_secs(120))
+                .timeout(timeouts::COMPLETION)
                 .header("x-api-key", &api_key)
                 .header("anthropic-version", VERSION)
                 .json(&body)
@@ -327,7 +328,7 @@ impl AiProvider for AnthropicClient {
 
         let resp = crate::net::http::shared()
             .post(&endpoint)
-            .timeout(std::time::Duration::from_secs(25))
+            .timeout(timeouts::WEB_SEARCH)
             .header("x-api-key", &api_key)
             .header("anthropic-version", VERSION)
             .json(&body)
@@ -380,7 +381,7 @@ impl AiProvider for AnthropicClient {
             .get(format!("{BASE}/models"))
             .header("x-api-key", &api_key)
             .header("anthropic-version", VERSION)
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(timeouts::LIST_MODELS)
             .send()
             .await;
         if let Ok(r) = resp {
@@ -410,7 +411,7 @@ impl AiProvider for AnthropicClient {
             .get(format!("{BASE}/models"))
             .header("x-api-key", &api_key)
             .header("anthropic-version", VERSION)
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(timeouts::LIST_MODELS)
             .send()
             .await
             .map_err(|e| format!("Request failed: {e}"))?;

--- a/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/gemini.rs
@@ -11,6 +11,7 @@ use crate::error::{AppError, AppResult};
 use super::research;
 use super::retry::send_with_retry;
 use super::stream::{stream_response, StreamPiece};
+use super::timeouts;
 use super::{
     friendly_api_error, AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, RequestTrace,
     TokenParam,
@@ -251,7 +252,7 @@ impl AiProvider for GeminiClient {
         let url = format!("{BASE}{endpoint_label}");
         let response = crate::net::http::shared()
             .post(&url)
-            .timeout(std::time::Duration::from_secs(300))
+            .timeout(timeouts::STREAM)
             .header("x-goog-api-key", &api_key)
             .json(&body)
             .send()
@@ -309,7 +310,7 @@ impl AiProvider for GeminiClient {
         let resp = send_with_retry(|| {
             crate::net::http::shared()
                 .post(&url)
-                .timeout(std::time::Duration::from_secs(120))
+                .timeout(timeouts::COMPLETION)
                 .header("x-goog-api-key", &api_key)
                 .json(&body)
         })
@@ -369,7 +370,7 @@ impl AiProvider for GeminiClient {
         let url = format!("{BASE}{endpoint_label}");
         let resp = crate::net::http::shared()
             .post(&url)
-            .timeout(std::time::Duration::from_secs(25))
+            .timeout(timeouts::WEB_SEARCH)
             .header("x-goog-api-key", &api_key)
             .json(&body)
             .send()
@@ -413,7 +414,7 @@ impl AiProvider for GeminiClient {
         let resp = send_with_retry(|| {
             crate::net::http::shared()
                 .post(&url)
-                .timeout(std::time::Duration::from_secs(30))
+                .timeout(timeouts::EMBED)
                 .header("x-goog-api-key", &api_key)
                 .json(&body)
         })
@@ -457,7 +458,7 @@ impl AiProvider for GeminiClient {
         let resp = client
             .get(format!("{BASE}/v1/models"))
             .header("x-goog-api-key", &api_key)
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(timeouts::LIST_MODELS)
             .send()
             .await;
         if let Ok(r) = resp {
@@ -481,7 +482,7 @@ impl AiProvider for GeminiClient {
         let resp = client
             .get(format!("{BASE}/v1/models"))
             .header("x-goog-api-key", &api_key)
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(timeouts::LIST_MODELS)
             .send()
             .await
             .map_err(|e| format!("Request failed: {e}"))?;

--- a/apps/tauri/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/mod.rs
@@ -27,6 +27,7 @@ mod openai;
 mod research; // shared company-research prompt spec + helpers used by every `research()`
 mod retry; // bounded exponential backoff for the non-streaming complete/embed paths
 mod stream; // shared streaming loop (cancel-check + chunk read + emit + complete) for cloud adapters
+mod timeouts; // semantically-named per-request HTTP timeouts (pure extraction of the magic-number literals)
 
 use anthropic::AnthropicClient;
 use cli_agent::CliAgentClient;

--- a/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/ollama.rs
@@ -15,6 +15,7 @@ use crate::events::{emit_event, JobEvent, JOBS_EVENT};
 
 use super::research::{self, SearchResult};
 use super::stream::{stream_response, StreamPiece};
+use super::timeouts;
 use super::{
     AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, RequestTrace, TokenParam,
 };
@@ -92,7 +93,7 @@ impl AiProvider for OllamaClient {
         let resp = match super::retry::send_with_retry(|| {
             crate::net::http::shared()
                 .post(&endpoint)
-                .timeout(std::time::Duration::from_secs(300))
+                .timeout(timeouts::OLLAMA_COMPLETION)
                 .json(&body)
         })
         .await
@@ -150,7 +151,7 @@ impl AiProvider for OllamaClient {
         let client = crate::net::http::shared();
         match client
             .get(format!("{}/api/tags", host()))
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(timeouts::LIST_MODELS)
             .send()
             .await
         {
@@ -170,7 +171,7 @@ impl AiProvider for OllamaClient {
 pub async fn list_tag_models() -> Vec<Value> {
     let resp = match crate::net::http::shared()
         .get(format!("{}/api/tags", host()))
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(timeouts::LIST_MODELS)
         .send()
         .await
     {
@@ -196,7 +197,7 @@ pub async fn list_tag_models() -> Vec<Value> {
 pub async fn reachable_model() -> (bool, Option<String>) {
     match crate::net::http::shared()
         .get(format!("{}/api/tags", host()))
-        .timeout(std::time::Duration::from_secs(3))
+        .timeout(timeouts::HEALTH)
         .send()
         .await
     {
@@ -227,7 +228,7 @@ pub async fn embed_with(model: &str, text: &str) -> AppResult<Vec<f64>> {
     let resp = super::retry::send_with_retry(|| {
         crate::net::http::shared()
             .post(&endpoint)
-            .timeout(std::time::Duration::from_secs(15))
+            .timeout(timeouts::OLLAMA_EMBED)
             .json(&body)
     })
     .await
@@ -261,7 +262,7 @@ pub async fn ollama_web_search(
 ) -> AppResult<Vec<SearchResult>> {
     let resp = crate::net::http::shared()
         .post(WEB_SEARCH_URL)
-        .timeout(std::time::Duration::from_secs(15))
+        .timeout(timeouts::OLLAMA_WEB_SEARCH)
         .bearer_auth(key)
         .json(&json!({ "query": query, "max_results": limit.min(10) }))
         .send()
@@ -361,7 +362,7 @@ pub async fn show_model(model: &str) -> Value {
     let body = json!({ "model": model });
     let resp = match crate::net::http::shared()
         .post(format!("{}/api/show", host()))
-        .timeout(std::time::Duration::from_secs(15))
+        .timeout(timeouts::OLLAMA_SHOW)
         .json(&body)
         .send()
         .await
@@ -427,7 +428,7 @@ fn normalize_show(data: &Value) -> Value {
 pub async fn pull(app: &AppHandle, job_id: &str, model: &str) -> AppResult<()> {
     let mut response = crate::net::http::shared()
         .post(format!("{}/api/pull", host()))
-        .timeout(std::time::Duration::from_secs(3600))
+        .timeout(timeouts::MODEL_PULL)
         .json(&json!({ "model": model, "stream": true }))
         .send()
         .await
@@ -573,7 +574,7 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
 
     let response = crate::net::http::shared()
         .post(&endpoint)
-        .timeout(std::time::Duration::from_secs(300))
+        .timeout(timeouts::STREAM)
         .json(&body)
         .send()
         .await;

--- a/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/openai.rs
@@ -13,6 +13,7 @@ use crate::error::{AppError, AppResult};
 use super::research;
 use super::retry::send_with_retry;
 use super::stream::{stream_response, StreamPiece};
+use super::timeouts;
 use super::{
     friendly_api_error, AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, RequestTrace,
     TokenParam,
@@ -209,7 +210,7 @@ impl AiProvider for OpenAiClient {
 
         let response = crate::net::http::shared()
             .post(&endpoint)
-            .timeout(std::time::Duration::from_secs(300))
+            .timeout(timeouts::STREAM)
             .bearer_auth(&api_key)
             .json(&body)
             .send()
@@ -274,7 +275,7 @@ impl AiProvider for OpenAiClient {
         let resp = send_with_retry(|| {
             crate::net::http::shared()
                 .post(&endpoint)
-                .timeout(std::time::Duration::from_secs(120))
+                .timeout(timeouts::COMPLETION)
                 .bearer_auth(&api_key)
                 .json(&body)
         })
@@ -342,7 +343,7 @@ impl AiProvider for OpenAiClient {
         });
         let resp = crate::net::http::shared()
             .post(&endpoint)
-            .timeout(std::time::Duration::from_secs(25))
+            .timeout(timeouts::WEB_SEARCH)
             .bearer_auth(&api_key)
             .json(&body)
             .send()
@@ -381,7 +382,7 @@ impl AiProvider for OpenAiClient {
         let resp = send_with_retry(|| {
             crate::net::http::shared()
                 .post(&endpoint)
-                .timeout(std::time::Duration::from_secs(30))
+                .timeout(timeouts::EMBED)
                 .bearer_auth(&api_key)
                 .json(&body)
         })
@@ -432,7 +433,7 @@ impl AiProvider for OpenAiClient {
         let resp = client
             .get(format!("{}/models", self.base_url))
             .bearer_auth(&api_key)
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(timeouts::LIST_MODELS)
             .send()
             .await;
         if let Ok(r) = resp {
@@ -460,7 +461,7 @@ impl AiProvider for OpenAiClient {
         let resp = client
             .get(format!("{}/models", self.base_url))
             .bearer_auth(&api_key)
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(timeouts::LIST_MODELS)
             .send()
             .await
             .map_err(|e| format!("Request failed: {e}"))?;

--- a/apps/tauri/src-tauri/src/commands/ai_provider/timeouts.rs
+++ b/apps/tauri/src-tauri/src/commands/ai_provider/timeouts.rs
@@ -1,0 +1,66 @@
+//! Per-request HTTP timeouts for the AI provider adapters.
+//!
+//! Each constant is named by the *operation* it bounds, not by its raw value, so
+//! a call site reads as `.timeout(timeouts::STREAM)` instead of a bare magic
+//! number. Two sites share a constant only when they bound the **same operation**
+//! at the **same duration**; same duration + different operation gets its own
+//! constant so the values can drift independently later.
+//!
+//! Values are intentionally identical to the literals they replaced — this module
+//! is a pure extraction with no behavior change.
+
+use std::time::Duration;
+
+// ── Chat generation ─────────────────────────────────────────────────────────────
+
+/// Streaming chat completion (`chat_stream`): the long-running SSE/JSON stream a
+/// cloud provider or the local Ollama daemon emits while generating.
+pub const STREAM: Duration = Duration::from_secs(300);
+
+/// Non-streaming cloud completion (`complete`): a single full-response call to a
+/// cloud provider (OpenAI / Anthropic / Gemini).
+pub const COMPLETION: Duration = Duration::from_secs(120);
+
+/// Non-streaming **local** Ollama completion (`complete`): the local daemon can
+/// be far slower than a cloud API on first token, so it gets the longer
+/// stream-class budget rather than the cloud [`COMPLETION`] bound.
+pub const OLLAMA_COMPLETION: Duration = Duration::from_secs(300);
+
+// ── Embeddings ──────────────────────────────────────────────────────────────────
+
+/// Cloud embeddings (`embed`): a single-vector embeddings request to OpenAI or
+/// Gemini.
+pub const EMBED: Duration = Duration::from_secs(30);
+
+/// Local Ollama embeddings (`/api/embeddings`): the local daemon's embeddings
+/// endpoint, bounded tighter than cloud embeddings.
+pub const OLLAMA_EMBED: Duration = Duration::from_secs(15);
+
+// ── Company research (provider-native web search) ───────────────────────────────
+
+/// Cloud native web-search research (`research`): the provider's own server-side
+/// web-search tool call (OpenAI `web_search`, Anthropic `web_search_20250305`,
+/// Gemini `google_search`).
+pub const WEB_SEARCH: Duration = Duration::from_secs(25);
+
+/// Ollama Web Search API (`/api/web_search` on ollama.com): the hosted search
+/// call that backs the Ollama-family research path.
+pub const OLLAMA_WEB_SEARCH: Duration = Duration::from_secs(15);
+
+// ── Model discovery & health ────────────────────────────────────────────────────
+
+/// Listing models / validating a key (`list_models`, `test_key`): a quick GET to
+/// the provider's model catalog or tags endpoint.
+pub const LIST_MODELS: Duration = Duration::from_secs(10);
+
+/// Local Ollama reachability probe (`reachable_model`): the fast health check
+/// behind the system-health panel, kept short so an unreachable daemon fails fast.
+pub const HEALTH: Duration = Duration::from_secs(3);
+
+/// Inspecting a local Ollama model (`/api/show`): fetch a model's trained context
+/// length and size labels.
+pub const OLLAMA_SHOW: Duration = Duration::from_secs(15);
+
+/// Pulling (downloading) a local Ollama model (`/api/pull`): a large multi-GB
+/// download streamed with progress, hence the hour-long ceiling.
+pub const MODEL_PULL: Duration = Duration::from_secs(3600);

--- a/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
+++ b/apps/tauri/src/renderer/components/layout/Sidebar/index.tsx
@@ -23,6 +23,7 @@ import { Button, cn, Image, NavPill, transition, variants } from '@ajh/ui';
 
 import { ROUTES } from '@/constants/routes';
 import { getTimeGreeting } from '@/lib/greeting';
+import { TOOLTIP_HIDE_MS } from '@/lib/timings';
 import { useContactProfile } from '@/services';
 import { useAppVersion } from '@/services/use-system';
 import { useToggleSidebar, useUserName } from '@/store/preferences-store';
@@ -93,7 +94,7 @@ export function Sidebar() {
   const showVersion = () => {
     setVersionTooltip(true);
     if (tooltipTimer.current) clearTimeout(tooltipTimer.current);
-    tooltipTimer.current = setTimeout(() => setVersionTooltip(false), 2000);
+    tooltipTimer.current = setTimeout(() => setVersionTooltip(false), TOOLTIP_HIDE_MS);
   };
 
   const renderNavItem = ({ to, label, icon: Icon, tourId }: NavItem) => {

--- a/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
@@ -26,6 +26,7 @@ import {
   resolveMarket,
   type TemplateId,
 } from '@/lib/generate';
+import { COPY_FEEDBACK_LONG_MS } from '@/lib/timings';
 import { useExtractText } from '@/services';
 import { useSaveAiGeneration } from '@/services/use-ai-generations';
 import { useContactPromptSeen, usePreferencesStore } from '@/store/preferences-store';
@@ -179,7 +180,7 @@ export function AIGeneratePage() {
     const text = activeOut === 'resume' ? resumeOut : coverOut;
     await navigator.clipboard.writeText(text);
     setCopied(true);
-    setTimeout(() => setCopied(false), 1800);
+    setTimeout(() => setCopied(false), COPY_FEEDBACK_LONG_MS);
   };
 
   const currentOutput = activeOut === 'resume' ? resumeOut : coverOut;

--- a/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
+++ b/apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx
@@ -1,6 +1,6 @@
 import { ScanSearch } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import type { DocumentRecord } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
@@ -11,7 +11,7 @@ import { useCanUseAI, useSelectedModel, useSelectedProvider } from '@/components
 import { AnalysisProgress } from '@/features/analyze/components/AnalysisProgress';
 import { AnalysisResults } from '@/features/analyze/components/AnalysisResults';
 import { AnalyzeLeftPanel } from '@/features/analyze/components/AnalyzeLeftPanel';
-import { ACCEPTED_EXTS, MAX_BYTES } from '@/features/analyze/constants';
+import { ACCEPTED_EXTS, MAX_BYTES, type Stage } from '@/features/analyze/constants';
 import { useAnalysisRun } from '@/features/analyze/hooks/useAnalysisRun';
 import { useAnalyzeState } from '@/features/analyze/hooks/useAnalyzeState';
 import { PROVIDERS } from '@/lib/ai-providers/provider-meta';
@@ -125,6 +125,74 @@ function AnalyzePage() {
     extractTextMutation.reset();
   };
 
+  const stageRegistry: Record<Stage, () => ReactNode> = {
+    idle: () => (
+      <motion.div
+        key="idle"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="flex flex-1 flex-col items-center justify-center gap-6 px-10"
+      >
+        <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-brand/10 ring-1 ring-brand/20">
+          <ScanSearch size={36} className="text-brand-soft/60" />
+        </div>
+        <div className="text-center">
+          <div className="text-lg font-semibold text-foreground/50">{t('analyze.idleTitle')}</div>
+          <div className="mt-1 text-sm text-foreground/30">{t('analyze.idleSubtitle')}</div>
+        </div>
+        <div className="flex flex-col gap-2 text-center">
+          {[
+            t('analyze.features.ats'),
+            t('analyze.features.keywords'),
+            t('analyze.features.feedback'),
+            t('analyze.features.verdict'),
+          ].map((f, i) => (
+            <div key={i} className="flex items-center gap-2 text-xs text-foreground/35">
+              <span className="h-1 w-1 rounded-full bg-brand/40" /> {f}
+            </div>
+          ))}
+        </div>
+      </motion.div>
+    ),
+    running: () => (
+      <motion.div
+        key="running"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="flex flex-1 flex-col overflow-hidden"
+      >
+        <div className="select-text flex-1 overflow-y-auto px-8 py-8">
+          <AnalysisProgress
+            running
+            stream={stream}
+            thinking={thinkingBuffer}
+            modelLoading={modelLoading}
+            tokenCount={tokenCount}
+            tokenStartMs={tokenStartRef.current}
+            estimatedMs={analysisEstimateMs}
+            slow={slowProvider}
+            t={t}
+          />
+        </div>
+      </motion.div>
+    ),
+    done: () =>
+      result ? (
+        <motion.div
+          key={`done-${runId}`}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="flex flex-1 flex-col overflow-hidden"
+        >
+          <div className="@container select-text flex-1 overflow-y-auto px-8 py-8 space-y-4">
+            <AnalysisResults result={result} t={t} />
+          </div>
+        </motion.div>
+      ) : null,
+  };
+
   return (
     <PageTransition className="h-full overflow-hidden">
       <div className="flex h-full flex-col md:flex-row">
@@ -149,76 +217,7 @@ function AnalyzePage() {
         />
 
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <AnimatePresence mode="wait">
-            {stage === 'idle' && (
-              <motion.div
-                key="idle"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="flex flex-1 flex-col items-center justify-center gap-6 px-10"
-              >
-                <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-brand/10 ring-1 ring-brand/20">
-                  <ScanSearch size={36} className="text-brand-soft/60" />
-                </div>
-                <div className="text-center">
-                  <div className="text-lg font-semibold text-foreground/50">
-                    {t('analyze.idleTitle')}
-                  </div>
-                  <div className="mt-1 text-sm text-foreground/30">{t('analyze.idleSubtitle')}</div>
-                </div>
-                <div className="flex flex-col gap-2 text-center">
-                  {[
-                    t('analyze.features.ats'),
-                    t('analyze.features.keywords'),
-                    t('analyze.features.feedback'),
-                    t('analyze.features.verdict'),
-                  ].map((f, i) => (
-                    <div key={i} className="flex items-center gap-2 text-xs text-foreground/35">
-                      <span className="h-1 w-1 rounded-full bg-brand/40" /> {f}
-                    </div>
-                  ))}
-                </div>
-              </motion.div>
-            )}
-
-            {stage === 'running' && (
-              <motion.div
-                key="running"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="flex flex-1 flex-col overflow-hidden"
-              >
-                <div className="select-text flex-1 overflow-y-auto px-8 py-8">
-                  <AnalysisProgress
-                    running
-                    stream={stream}
-                    thinking={thinkingBuffer}
-                    modelLoading={modelLoading}
-                    tokenCount={tokenCount}
-                    tokenStartMs={tokenStartRef.current}
-                    estimatedMs={analysisEstimateMs}
-                    slow={slowProvider}
-                    t={t}
-                  />
-                </div>
-              </motion.div>
-            )}
-
-            {stage === 'done' && result && (
-              <motion.div
-                key={`done-${runId}`}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                className="flex flex-1 flex-col overflow-hidden"
-              >
-                <div className="@container select-text flex-1 overflow-y-auto px-8 py-8 space-y-4">
-                  <AnalysisResults result={result} t={t} />
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
+          <AnimatePresence mode="wait">{stageRegistry[stage]()}</AnimatePresence>
 
           {error && (
             <div className="shrink-0 mx-6 mb-4">

--- a/apps/tauri/src/renderer/features/documents/components/GenerationCard/index.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/GenerationCard/index.tsx
@@ -45,6 +45,7 @@ import {
   type TemplateId,
   TEMPLATES,
 } from '@/lib/generate';
+import { COPY_FEEDBACK_LONG_MS } from '@/lib/timings';
 import { useOpenExternal } from '@/services';
 import { useRemoveAiGeneration, useUpdateAiGeneration } from '@/services/use-ai-generations';
 import { useReferrals, useUpsertReferral } from '@/services/use-referrals/use-referrals';
@@ -140,7 +141,10 @@ export function GenerationCard({ gen, selected = false, onToggleSelect }: Genera
     await navigator.clipboard.writeText(draft);
     setCopiedReferral(contact.id);
     notify.success({ message: t('resumes.generated.referralCopied') });
-    setTimeout(() => setCopiedReferral((id) => (id === contact.id ? null : id)), 1800);
+    setTimeout(
+      () => setCopiedReferral((id) => (id === contact.id ? null : id)),
+      COPY_FEEDBACK_LONG_MS
+    );
   };
 
   // Mark a referral as sent. The backend upsert overwrites the whole row by id

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.tsx
@@ -5,6 +5,8 @@ import { APPLICATION_QUESTIONS } from '@ajh/prompts/generate';
 import { useTranslation } from '@ajh/translations';
 import { Button, Input, ModalShell } from '@ajh/ui';
 
+import { COPY_FEEDBACK_MS } from '@/lib/timings';
+
 import { MAX_CUSTOM_QUESTION_LEN } from './useApplicationAnswers';
 
 interface Props {
@@ -48,7 +50,7 @@ export function ApplicationQuestionsModal({
   const copy = async (id: string, text: string) => {
     await navigator.clipboard.writeText(text);
     setCopiedId(id);
-    setTimeout(() => setCopiedId(null), 1500);
+    setTimeout(() => setCopiedId(null), COPY_FEEDBACK_MS);
   };
 
   const submitCustom = () => {

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/index.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/index.tsx
@@ -8,6 +8,7 @@ import { Button, Input, ModalShell, SegmentedControl, StreamingText, TextArea } 
 
 import { ModelSelector, useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
 import { CONNECTION_NOTE_LIMIT } from '@/lib/generate';
+import { COPY_FEEDBACK_MS, TOOLTIP_HIDE_MS } from '@/lib/timings';
 import { useReferrals, useUpsertReferral } from '@/services';
 
 import { WizardField } from '../WizardField';
@@ -70,7 +71,7 @@ export function ReferralModal({ job, resume, onClose }: Props) {
     if (!gen.draft || overLimit) return;
     await navigator.clipboard.writeText(gen.draft);
     setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
   };
 
   const save = () => {
@@ -108,7 +109,7 @@ export function ReferralModal({ job, resume, onClose }: Props) {
       {
         onSuccess: () => {
           setSaved(true);
-          setTimeout(() => setSaved(false), 2000);
+          setTimeout(() => setSaved(false), TOOLTIP_HIDE_MS);
           // Add-another: clear the form + draft so the next person can be entered.
           setPersonName('');
           setPersonRole('');

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/index.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/index.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -275,6 +275,62 @@ export function TailorFlow({
     });
   }, [stage, questionsCount, interviewQuestionsCount, onController]);
 
+  const stageRegistry: Record<TailorFlowStage, () => ReactNode> = {
+    configuring: () => (
+      <TailorWizard
+        methods={methods}
+        step={step}
+        setStep={handleStep}
+        jobDesc={jobDesc}
+        onJobDescChange={setJobDescOverride}
+        hasDesc={hasDesc}
+        fetchingDesc={fetchingDesc}
+        jobUrl={job.url}
+        canUse={canUse}
+        reason={reason}
+        onGenerate={startGeneration}
+        jobAdSummary={jobAdSummary}
+      />
+    ),
+    generating: () => (
+      <GeneratingPanel
+        target={generatedTarget}
+        phase={gen.phase}
+        phaseLabel={gen.phaseLabel}
+        thinking={gen.thinking}
+        output={gen.output}
+        onCancel={() => gen.abort()}
+      />
+    ),
+    done: () => (
+      <ResultsPanel
+        target={generatedTarget}
+        jobDesc={jobDesc}
+        onJobDescChange={setJobDescOverride}
+        hasDesc={hasDesc}
+        fetchingDesc={fetchingDesc}
+        jobUrl={job.url}
+        jobAdSummary={jobAdSummary}
+        activeOut={gen.activeOut}
+        setActiveOut={gen.setActiveOut}
+        templateId={persistence.templateId}
+        atsMode={persistence.atsMode}
+        onTemplateChange={setTemplateId}
+        onAtsModeChange={setAtsMode}
+        output={gen.output}
+        onEdit={gen.editActiveOutput}
+        meta={gen.meta}
+        copied={gen.copied}
+        onCopy={() => void gen.copy()}
+        exportOpen={gen.exportOpen}
+        setExportOpen={gen.setExportOpen}
+        onExport={(fmt) => void gen.exportAs(fmt)}
+        onRegenerate={() => startGeneration(methods.getValues())}
+        onEditSettings={() => setForceConfiguring(true)}
+      />
+    ),
+  };
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       {/* Stage body */}
@@ -288,61 +344,7 @@ export function TailorFlow({
             transition={transition.fast}
             className="h-full"
           >
-            {stage === 'configuring' && (
-              <TailorWizard
-                methods={methods}
-                step={step}
-                setStep={handleStep}
-                jobDesc={jobDesc}
-                onJobDescChange={setJobDescOverride}
-                hasDesc={hasDesc}
-                fetchingDesc={fetchingDesc}
-                jobUrl={job.url}
-                canUse={canUse}
-                reason={reason}
-                onGenerate={startGeneration}
-                jobAdSummary={jobAdSummary}
-              />
-            )}
-
-            {stage === 'generating' && (
-              <GeneratingPanel
-                target={generatedTarget}
-                phase={gen.phase}
-                phaseLabel={gen.phaseLabel}
-                thinking={gen.thinking}
-                output={gen.output}
-                onCancel={() => gen.abort()}
-              />
-            )}
-
-            {stage === 'done' && (
-              <ResultsPanel
-                target={generatedTarget}
-                jobDesc={jobDesc}
-                onJobDescChange={setJobDescOverride}
-                hasDesc={hasDesc}
-                fetchingDesc={fetchingDesc}
-                jobUrl={job.url}
-                jobAdSummary={jobAdSummary}
-                activeOut={gen.activeOut}
-                setActiveOut={gen.setActiveOut}
-                templateId={persistence.templateId}
-                atsMode={persistence.atsMode}
-                onTemplateChange={setTemplateId}
-                onAtsModeChange={setAtsMode}
-                output={gen.output}
-                onEdit={gen.editActiveOutput}
-                meta={gen.meta}
-                copied={gen.copied}
-                onCopy={() => void gen.copy()}
-                exportOpen={gen.exportOpen}
-                setExportOpen={gen.setExportOpen}
-                onExport={(fmt) => void gen.exportAs(fmt)}
-                onRegenerate={() => startGeneration(methods.getValues())}
-                onEditSettings={() => setForceConfiguring(true)}
-              />
-            )}
+            {stageRegistry[stage]()}
           </motion.div>
         </AnimatePresence>
       </div>

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/useTailorGeneration.ts
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/useTailorGeneration.ts
@@ -13,6 +13,7 @@ import {
   PERSIST_DEBOUNCE_MS,
   type TemplateId,
 } from '@/lib/generate';
+import { COPY_FEEDBACK_MS } from '@/lib/timings';
 import { useAppClient } from '@/providers/AppClientProvider';
 import { keys } from '@/services/query-client';
 import { useUpdateAiGeneration } from '@/services/use-ai-generations';
@@ -203,7 +204,7 @@ export function useTailorGeneration({
     if (!output) return;
     await navigator.clipboard.writeText(output);
     setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
   };
 
   const exportAs = async (fmt: 'pdf' | 'docx' | 'txt') => {

--- a/apps/tauri/src/renderer/features/resume-builder/components/ResumeBuilderPage/index.tsx
+++ b/apps/tauri/src/renderer/features/resume-builder/components/ResumeBuilderPage/index.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight, RotateCcw } from 'lucide-react';
 import { AnimatePresence } from 'motion/react';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 
 import { useTranslation } from '@ajh/translations';
 import { Button, ErrorState } from '@ajh/ui';
@@ -18,6 +18,8 @@ import {
   isTwoColumnTemplate,
   type TemplateId,
 } from '@/lib/generate';
+import { COPY_FEEDBACK_LONG_MS } from '@/lib/timings';
+import type { ResumeBuilderStage } from '@/store/session-store';
 
 import { useResumeBuilder } from '../../hooks/useResumeBuilder';
 import { BuilderWizard } from '../BuilderWizard';
@@ -61,7 +63,7 @@ export function ResumeBuilderPage() {
     if (isGenerating || !output) return;
     await navigator.clipboard.writeText(output);
     setCopied(true);
-    setTimeout(() => setCopied(false), 1800);
+    setTimeout(() => setCopied(false), COPY_FEEDBACK_LONG_MS);
   };
 
   const doExport = async (fmt: 'pdf' | 'docx' | 'txt') => {
@@ -70,6 +72,68 @@ export function ResumeBuilderPage() {
     if (fmt === 'pdf') await exportPDF(output, name, 'resume', meta, templateId, atsMode, locale);
     if (fmt === 'docx') await exportDOCX(output, name, 'resume', meta, templateId, atsMode, locale);
     if (fmt === 'txt') exportTXT(output, name);
+  };
+
+  const stageRegistry: Record<ResumeBuilderStage, () => ReactNode> = {
+    interview: () => (
+      <BuilderWizard
+        key="wizard"
+        language={language}
+        templateId={templateId}
+        atsMode={atsMode}
+        isComplete={isComplete}
+        canUseAI={canUseAI}
+        isGenerating={isGenerating}
+        onLanguageChange={onLanguageChange}
+        onTemplateChange={onTemplateChange}
+        onAtsModeChange={onAtsModeChange}
+        onGenerate={() => void synthesize()}
+      />
+    ),
+    generating: () => (
+      <OutputPanelGenerating
+        key="generating"
+        stageLabel={t('build.wizard.generating')}
+        streamBuffer={streamBuffer}
+        activeOut="resume"
+        thinkingBuffer={thinkingBuffer}
+        modelLoading={modelLoading}
+        tokenCount={tokenCount}
+        tokenStartMs={tokenStartMs}
+      />
+    ),
+    done: () => (
+      <div key="done" className="flex flex-1 flex-col overflow-hidden">
+        <OutputPanelDone
+          resumeOut={output}
+          coverOut=""
+          activeOut="resume"
+          meta={meta}
+          mode="ats"
+          templateId={templateId}
+          atsMode={atsMode}
+          locale={locale}
+          onActiveOutChange={() => {}}
+          onCopy={() => void copyOutput()}
+          onExport={doExport}
+          onOutputChange={(value) => setResumeBuilder({ output: value })}
+          onRegenerate={() => void synthesize()}
+          copied={copied}
+          isGenerating={isGenerating}
+          generatingDoc={null}
+        />
+        <div className="shrink-0 flex items-center justify-end gap-2 border-t border-[var(--border-soft)] px-8 py-3">
+          <Button onClick={reset} variant="ghost" className="gap-1.5">
+            <RotateCcw size={14} />
+            {t('build.output.startOver')}
+          </Button>
+          <Button onClick={tailorToJob} variant="glass" className="gap-1.5">
+            {t('build.output.tailor')}
+            <ArrowRight size={14} />
+          </Button>
+        </div>
+      </div>
+    ),
   };
 
   return (
@@ -88,69 +152,7 @@ export function ResumeBuilderPage() {
         </div>
 
         <div className="flex flex-1 flex-col overflow-hidden">
-          <AnimatePresence mode="wait">
-            {stage === 'interview' && (
-              <BuilderWizard
-                key="wizard"
-                language={language}
-                templateId={templateId}
-                atsMode={atsMode}
-                isComplete={isComplete}
-                canUseAI={canUseAI}
-                isGenerating={isGenerating}
-                onLanguageChange={onLanguageChange}
-                onTemplateChange={onTemplateChange}
-                onAtsModeChange={onAtsModeChange}
-                onGenerate={() => void synthesize()}
-              />
-            )}
-
-            {stage === 'generating' && (
-              <OutputPanelGenerating
-                key="generating"
-                stageLabel={t('build.wizard.generating')}
-                streamBuffer={streamBuffer}
-                activeOut="resume"
-                thinkingBuffer={thinkingBuffer}
-                modelLoading={modelLoading}
-                tokenCount={tokenCount}
-                tokenStartMs={tokenStartMs}
-              />
-            )}
-
-            {stage === 'done' && (
-              <div key="done" className="flex flex-1 flex-col overflow-hidden">
-                <OutputPanelDone
-                  resumeOut={output}
-                  coverOut=""
-                  activeOut="resume"
-                  meta={meta}
-                  mode="ats"
-                  templateId={templateId}
-                  atsMode={atsMode}
-                  locale={locale}
-                  onActiveOutChange={() => {}}
-                  onCopy={() => void copyOutput()}
-                  onExport={doExport}
-                  onOutputChange={(value) => setResumeBuilder({ output: value })}
-                  onRegenerate={() => void synthesize()}
-                  copied={copied}
-                  isGenerating={isGenerating}
-                  generatingDoc={null}
-                />
-                <div className="shrink-0 flex items-center justify-end gap-2 border-t border-[var(--border-soft)] px-8 py-3">
-                  <Button onClick={reset} variant="ghost" className="gap-1.5">
-                    <RotateCcw size={14} />
-                    {t('build.output.startOver')}
-                  </Button>
-                  <Button onClick={tailorToJob} variant="glass" className="gap-1.5">
-                    {t('build.output.tailor')}
-                    <ArrowRight size={14} />
-                  </Button>
-                </div>
-              </div>
-            )}
-          </AnimatePresence>
+          <AnimatePresence mode="wait">{stageRegistry[stage]()}</AnimatePresence>
 
           {error && (
             <div className="shrink-0 mx-6 mb-4">

--- a/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.tsx
+++ b/apps/tauri/src/renderer/features/settings/components/SettingsContent/index.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'motion/react';
-import { type RefObject, useEffect } from 'react';
+import { type ReactNode, type RefObject, useEffect } from 'react';
 
 import { IconBadge, transition, variants } from '@ajh/ui';
 
@@ -50,6 +50,63 @@ export function SettingsContent({
   userName,
   onAnchorConsumed,
 }: Props) {
+  const sectionRegistry: Record<SectionId, () => ReactNode> = {
+    general: () => (
+      <GeneralSection
+        localName={localName}
+        setLocalName={setLocalName}
+        setUserName={setUserName}
+        userName={userName}
+      />
+    ),
+    appearance: () => <AppearanceCard />,
+    contact: () => <ContactProfileTab />,
+    ai: () => (
+      <>
+        <div data-settings-anchor="ai-provider">
+          <AISettingsTab />
+        </div>
+        <div data-settings-anchor="ai-tone">
+          <OutputTonePreferences />
+        </div>
+      </>
+    ),
+    job: () => (
+      <>
+        <div data-settings-anchor="job-location">
+          <JobLocationPreferences />
+        </div>
+        <div data-settings-anchor="job-techstack">
+          <TechStackPreferences />
+        </div>
+        <div data-settings-anchor="job-aggregator">
+          <AggregatorKeysSettings />
+        </div>
+      </>
+    ),
+    resume: () => (
+      <div data-settings-anchor="resume-manage">
+        <ResumePreferences />
+      </div>
+    ),
+    accounts: () => <AccountsSettingsTab />,
+    privacy: () => <PrivacySettingsTab />,
+    performance: () => (
+      <div data-settings-anchor="performance-mode">
+        <PerformancePreferences />
+      </div>
+    ),
+    developer: () => (
+      <div data-settings-anchor="developer-tools">
+        <DeveloperPreferences />
+      </div>
+    ),
+    about: () => (
+      <div data-settings-anchor="about-info">
+        <AboutTab />
+      </div>
+    ),
+  };
   /**
    * Scroll to + briefly ring-highlight an anchored element after the section
    * mounts. Keyed on both activeSection and pendingAnchor so it re-fires when
@@ -122,61 +179,7 @@ export function SettingsContent({
             transition={transition.normal}
             className="max-w-2xl space-y-4"
           >
-            {activeSection === 'general' && (
-              <GeneralSection
-                localName={localName}
-                setLocalName={setLocalName}
-                setUserName={setUserName}
-                userName={userName}
-              />
-            )}
-            {activeSection === 'appearance' && <AppearanceCard />}
-            {activeSection === 'contact' && <ContactProfileTab />}
-            {activeSection === 'ai' && (
-              <>
-                <div data-settings-anchor="ai-provider">
-                  <AISettingsTab />
-                </div>
-                <div data-settings-anchor="ai-tone">
-                  <OutputTonePreferences />
-                </div>
-              </>
-            )}
-            {activeSection === 'job' && (
-              <>
-                <div data-settings-anchor="job-location">
-                  <JobLocationPreferences />
-                </div>
-                <div data-settings-anchor="job-techstack">
-                  <TechStackPreferences />
-                </div>
-                <div data-settings-anchor="job-aggregator">
-                  <AggregatorKeysSettings />
-                </div>
-              </>
-            )}
-            {activeSection === 'resume' && (
-              <div data-settings-anchor="resume-manage">
-                <ResumePreferences />
-              </div>
-            )}
-            {activeSection === 'accounts' && <AccountsSettingsTab />}
-            {activeSection === 'privacy' && <PrivacySettingsTab />}
-            {activeSection === 'performance' && (
-              <div data-settings-anchor="performance-mode">
-                <PerformancePreferences />
-              </div>
-            )}
-            {activeSection === 'developer' && (
-              <div data-settings-anchor="developer-tools">
-                <DeveloperPreferences />
-              </div>
-            )}
-            {activeSection === 'about' && (
-              <div data-settings-anchor="about-info">
-                <AboutTab />
-              </div>
-            )}
+            {sectionRegistry[activeSection]()}
           </motion.div>
         </AnimatePresence>
       </div>

--- a/apps/tauri/src/renderer/lib/timings.ts
+++ b/apps/tauri/src/renderer/lib/timings.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared UI timing constants (milliseconds).
+ *
+ * Only values used in two or more places (or representing a clear shared UX
+ * pattern) are defined here. Genuinely one-off delays stay inline at the call
+ * site (see "left as one-offs" below).
+ *
+ *   COPY_FEEDBACK_MS      1 500 ms — clipboard copy icon reset (short copy actions)
+ *   COPY_FEEDBACK_LONG_MS 1 800 ms — clipboard copy icon reset (long-form content)
+ *   TOOLTIP_HIDE_MS       2 000 ms — tooltip / success-flash auto-dismiss
+ *
+ * Left as one-offs:
+ *   1 400 ms  ExtensionBridgeSection highlight-fade   — single use, semantically specific
+ *   3 500 ms  ApplicationsPage row highlight flash    — single use
+ *   1 200 ms  AISelectionStep skip transition delay   — single use
+ *   1 000 ms  JobsPage stream-invalidate throttle     — single use, internal throttle
+ *   350 ms    BuilderWizard RHF→Zustand sync debounce — single use, internal
+ */
+export const COPY_FEEDBACK_MS = 1_500;
+export const COPY_FEEDBACK_LONG_MS = 1_800;
+export const TOOLTIP_HIDE_MS = 2_000;

--- a/apps/tauri/src/renderer/services/query-client/query-client.ts
+++ b/apps/tauri/src/renderer/services/query-client/query-client.ts
@@ -1,6 +1,27 @@
 import { QueryClient } from '@tanstack/react-query';
 
 /**
+ * Named duration constants for React Query staleTime / gcTime / refetchInterval.
+ * All values are in milliseconds. Co-locate here so every service hook references
+ * the same semantic constant rather than a bare magic number.
+ *
+ *   SHORT         10 s  — fast-moving data (embedding status)
+ *   POLLING_STALE 20 s  — paired with 30 s refetchInterval (health / metrics)
+ *   MEDIUM        30 s  — default; board/bridge polling; provider key check
+ *   LONG          60 s  — AI model list (changes rarely mid-session)
+ *   VERY_LONG      5 min — gc default; provider models; resolved job URL
+ *   TEN_MIN       10 min — match scores; changelog (expensive, rarely stale)
+ */
+export const QUERY_TIMES = {
+  SHORT: 10_000,
+  POLLING_STALE: 20_000,
+  MEDIUM: 30_000,
+  LONG: 60_000,
+  VERY_LONG: 300_000,
+  TEN_MIN: 600_000,
+} as const;
+
+/**
  * Shared QueryClient for the renderer.
  *
  * Tuned for a local-first desktop app (applies equally to Electron, Tauri, or a
@@ -20,8 +41,8 @@ import { QueryClient } from '@tanstack/react-query';
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30_000,
-      gcTime: 5 * 60_000,
+      staleTime: QUERY_TIMES.MEDIUM,
+      gcTime: QUERY_TIMES.VERY_LONG,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       retry: 1,

--- a/apps/tauri/src/renderer/services/use-ai-provider/use-ai-provider.ts
+++ b/apps/tauri/src/renderer/services/use-ai-provider/use-ai-provider.ts
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAppClient } from '@/providers/AppClientProvider';
 import { useAiProviderConfig } from '@/store/preferences-store';
 
-import { keys } from '../query-client';
+import { keys, QUERY_TIMES } from '../query-client';
 
 export const useHasProviderKey = (provider: string, enabled = true) => {
   const api = useAppClient();
@@ -11,7 +11,7 @@ export const useHasProviderKey = (provider: string, enabled = true) => {
     queryKey: [...keys.ai.models, 'provider-key', provider],
     queryFn: () => api.ai.hasProviderKey({ provider }),
     enabled: enabled && provider !== 'ollama',
-    staleTime: 30_000,
+    staleTime: QUERY_TIMES.MEDIUM,
   });
 };
 
@@ -45,7 +45,7 @@ export const useListProviderModels = (provider: string, enabled = true, baseUrl?
     queryKey: [...keys.ai.models, 'provider-models', provider, baseUrl ?? ''],
     queryFn: () => api.ai.listProviderModels({ provider, baseUrl }),
     enabled: enabled && provider !== 'ollama',
-    staleTime: 300_000,
+    staleTime: QUERY_TIMES.VERY_LONG,
   });
 };
 
@@ -91,7 +91,7 @@ export const useEmbeddingStatus = () => {
   return useQuery({
     queryKey: keys.ai.embeddingStatus,
     queryFn: () => api.ai.embeddingStatus(),
-    staleTime: 10_000,
+    staleTime: QUERY_TIMES.SHORT,
   });
 };
 

--- a/apps/tauri/src/renderer/services/use-ai/use-ai.ts
+++ b/apps/tauri/src/renderer/services/use-ai/use-ai.ts
@@ -5,14 +5,14 @@ import type { AiGenerateRequest, AiStreamChunk } from '@ajh/shared';
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
-import { keys } from '../query-client';
+import { keys, QUERY_TIMES } from '../query-client';
 
 export const useAIModels = () => {
   const api = useAppClient();
   return useQuery({
     queryKey: keys.ai.models,
     queryFn: () => api.ai.listModels(),
-    staleTime: 60_000,
+    staleTime: QUERY_TIMES.LONG,
   });
 };
 

--- a/apps/tauri/src/renderer/services/use-boards/use-boards.ts
+++ b/apps/tauri/src/renderer/services/use-boards/use-boards.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/rea
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
-import { keys } from '../query-client';
+import { keys, QUERY_TIMES } from '../query-client';
 import { useCheckBrowser } from '../use-system';
 
 const KEYS = {
@@ -17,7 +17,7 @@ export const useLinkedInStatus = () => {
   return useQuery({
     queryKey: KEYS.linkedinStatus,
     queryFn: () => api.linkedin.getStatus(),
-    refetchInterval: 30_000,
+    refetchInterval: QUERY_TIMES.MEDIUM,
   });
 };
 
@@ -67,7 +67,7 @@ export const useBoardStatus = (boardId: string) => {
   return useQuery({
     queryKey: KEYS.boardStatus(boardId),
     queryFn: () => api.boards.getStatus({ boardId }),
-    refetchInterval: 30_000,
+    refetchInterval: QUERY_TIMES.MEDIUM,
     enabled: !!boardId,
   });
 };
@@ -129,12 +129,12 @@ export const useBoardStatuses = (boardIds: string[] = []) => {
         ? {
             queryKey: KEYS.linkedinStatus,
             queryFn: () => api.linkedin.getStatus(),
-            refetchInterval: 30_000,
+            refetchInterval: QUERY_TIMES.MEDIUM,
           }
         : {
             queryKey: KEYS.boardStatus(id),
             queryFn: () => api.boards.getStatus({ boardId: id }),
-            refetchInterval: 30_000,
+            refetchInterval: QUERY_TIMES.MEDIUM,
             enabled: !!id,
           }
     ),

--- a/apps/tauri/src/renderer/services/use-extension-bridge/use-extension-bridge.ts
+++ b/apps/tauri/src/renderer/services/use-extension-bridge/use-extension-bridge.ts
@@ -4,7 +4,7 @@ import type { ExtensionBridgeStatus, ExtensionBridgeTokenResult } from '@ajh/sha
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
-import { keys } from '../query-client';
+import { keys, QUERY_TIMES } from '../query-client';
 
 /**
  * Live view of the local extension-bridge status (bound port, whether a browser
@@ -22,7 +22,7 @@ export const useExtensionBridgeStatus = () => {
   return useQuery<ExtensionBridgeStatus>({
     queryKey: keys.extensionBridge.status,
     queryFn: () => api.extensionBridge.status(),
-    refetchInterval: 30_000,
+    refetchInterval: QUERY_TIMES.MEDIUM,
   });
 };
 

--- a/apps/tauri/src/renderer/services/use-match/use-match.ts
+++ b/apps/tauri/src/renderer/services/use-match/use-match.ts
@@ -6,7 +6,7 @@ import type { MatchResumeRequest, MatchScore } from '@ajh/shared';
 import { useAppClient } from '@/providers/AppClientProvider';
 import { useSemanticScoring } from '@/store/preferences-store';
 
-import { keys } from '../query-client';
+import { keys, QUERY_TIMES } from '../query-client';
 
 /**
  * Score a resume against a job posting on demand. The result is expensive to
@@ -39,7 +39,7 @@ export const useJobMatchScore = (resumeId: string | null, jobId: string, enabled
         semanticScoringEnabled: semanticScoring,
       }),
     enabled: enabled && !!resumeId && !!jobId,
-    staleTime: 10 * 60 * 1000,
+    staleTime: QUERY_TIMES.TEN_MIN,
   });
 };
 
@@ -63,7 +63,7 @@ export const useJobMatchScores = (resumeId: string | null, jobIds: string[]) => 
         semanticScoringEnabled: semanticScoring,
       }),
     enabled: !!resumeId && ids.length > 0,
-    staleTime: 10 * 60 * 1000,
+    staleTime: QUERY_TIMES.TEN_MIN,
     placeholderData: keepPreviousData,
   });
   const scoresById = useMemo(() => {

--- a/apps/tauri/src/renderer/services/use-postings/use-postings.ts
+++ b/apps/tauri/src/renderer/services/use-postings/use-postings.ts
@@ -5,7 +5,7 @@ import type { ScrapeBoardsRequest, ScrapeUrlRequest } from '@ajh/shared';
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
-import { keys } from '../query-client';
+import { keys, QUERY_TIMES } from '../query-client';
 
 export const usePostings = () => {
   const api = useAppClient();
@@ -46,7 +46,7 @@ export const useResolveJobUrl = (url: string, enabled = true) => {
     queryKey: keys.postings.resolve(url),
     queryFn: () => api.scrape.resolveUrl({ url }),
     enabled: enabled && !!url,
-    staleTime: 5 * 60_000,
+    staleTime: QUERY_TIMES.VERY_LONG,
   });
 };
 

--- a/apps/tauri/src/renderer/services/use-system/use-system.ts
+++ b/apps/tauri/src/renderer/services/use-system/use-system.ts
@@ -7,15 +7,15 @@ import { getResolvedScheme, reapplySystemAccent } from '@ajh/ui';
 import { useAppClient } from '@/providers/AppClientProvider';
 import { usePreferencesStore } from '@/store/preferences-store';
 
-import { keys, queryClient } from '../query-client';
+import { keys, QUERY_TIMES, queryClient } from '../query-client';
 
 export const useSystemHealth = () => {
   const api = useAppClient();
   return useQuery({
     queryKey: keys.system.health,
     queryFn: () => api.system.health(),
-    refetchInterval: 30_000,
-    staleTime: 20_000,
+    refetchInterval: QUERY_TIMES.MEDIUM,
+    staleTime: QUERY_TIMES.POLLING_STALE,
   });
 };
 
@@ -147,8 +147,8 @@ export const useSystemMetrics = () => {
   return useQuery({
     queryKey: keys.system.metrics,
     queryFn: () => api.system.getMetrics(),
-    refetchInterval: 30_000,
-    staleTime: 20_000,
+    refetchInterval: QUERY_TIMES.MEDIUM,
+    staleTime: QUERY_TIMES.POLLING_STALE,
   });
 };
 

--- a/apps/tauri/src/renderer/services/use-updater/use-updater.ts
+++ b/apps/tauri/src/renderer/services/use-updater/use-updater.ts
@@ -11,7 +11,7 @@ import {
 
 import { useAppClient } from '@/providers/AppClientProvider';
 
-import { keys } from '../query-client';
+import { keys, QUERY_TIMES } from '../query-client';
 
 export type UpdateStatus =
   | { state: 'idle' }
@@ -124,6 +124,6 @@ export function useChangelog(enabled: boolean) {
     queryKey: keys.updater.changelog,
     queryFn: () => api.updater.changelog(),
     enabled,
-    staleTime: 10 * 60_000,
+    staleTime: QUERY_TIMES.TEN_MIN,
   });
 }

--- a/apps/tauri/src/renderer/store/session-store/session-store.ts
+++ b/apps/tauri/src/renderer/store/session-store/session-store.ts
@@ -39,7 +39,7 @@ interface AnalyzeSlice {
   analysisMode: AnalysisMode;
 }
 
-type ResumeBuilderStage = 'interview' | 'generating' | 'done';
+export type ResumeBuilderStage = 'interview' | 'generating' | 'done';
 
 export interface ResumeBuilderSlice {
   answers: InterviewAnswers;

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -656,27 +656,65 @@ Clicking a sidebar nav item smooth-scrolls the active page's scroll region to th
 
 ---
 
+## 16. Render Registries (Section/Stage Dispatch)
+
+For 3+ way conditional rendering based on a discriminated union (section IDs, page stages, workflow steps), use a typed **render registry** — a `Record<Union, () => ReactNode>` object with lazy-evaluated thunks — instead of a chain of `x === 'literal' && <Component />` conditionals.
+
+### Why
+
+- **Compile-time exhaustiveness**: TypeScript enforces all union variants are keyed.
+- **Single source of truth**: variant definitions (from constants) stay decoupled from render logic.
+- **Testability**: registries are easily mockable; conditionals buried in JSX are not.
+
+### Pattern
+
+```typescript
+import type { SectionId } from '@/features/settings/constants';
+
+// Inside the component:
+const sectionRegistry: Record<SectionId, () => ReactNode> = {
+  general: () => <GeneralSection {...props} />,
+  appearance: () => <AppearanceCard />,
+  contact: () => <ContactProfileTab />,
+  // ... all other SectionId variants
+};
+
+// Render:
+<div>{sectionRegistry[activeSection]()}</div>
+```
+
+Thunks are evaluated only on render; they can capture props/state via closure. Register anchors or data attributes in the thunk to co-locate layout hints with the rendered content.
+
+### References
+
+- `apps/tauri/src/renderer/features/settings/components/SettingsContent/index.tsx` (SectionId registry)
+- `apps/tauri/src/renderer/features/documents/components/TailorFlow/index.tsx` (stage registry)
+- `apps/tauri/src/renderer/features/analyze/components/AnalyzePage/index.tsx` (stage registry)
+
+---
+
 ## Anti-Patterns to Avoid
 
-| Anti-Pattern                                                    | Correct Approach                                                                                                                             |
-| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `useState + useEffect` for IPC data                             | React Query service hook                                                                                                                     |
-| `window.__TAURI_INVOKE__` directly                              | `useAppClient()` service hook                                                                                                                |
-| `import { useTranslation } from "react-i18next"`                | `import { useTranslation } from "@ajh/translations"`                                                                                         |
-| Cross-feature imports                                           | Only import from `@ajh/ui`, `services/`, `lib/`                                                                                              |
-| `// eslint-disable` comment                                     | Fix the underlying issue or add a scoped `eslint.config.mjs` override                                                                        |
-| Inline `{ duration: 0.2, ease: "easeOut" }`                     | `transition.fast` from `@ajh/ui`                                                                                                             |
-| Hardcoded colors in className                                   | `text-brand`, `bg-brand`, etc.                                                                                                               |
-| Storing credentials in SQLite                                   | OS keychain (AI keys via `credentials` module; board sessions via `boards.*`/`linkedin.*`)                                                   |
-| Reading `AJH_DATA_DIR` / rebuilding `~/.ajh`                    | `platform::config::data_dir()`                                                                                                               |
-| Per-page `?` that aborts a partial scrape                       | First-page error propagates as `Err`; a later page logs + `break`s, keeping the partial (P10)                                                |
-| `reqwest::Client::new()` / `::builder()`                        | `net::http::shared()` or `net::http::build_client()`                                                                                         |
-| `Result<_, String>` for fallible internals                      | `AppResult<_>` / `AppError` from `crate::error`                                                                                              |
-| Folding web-fetched content directly into prompts               | Wrap in an untrusted-content fence (see `packages/prompts/src/emphasis.ts`); label the block so the model treats it as untrusted input       |
-| Per-provider `thinking` handling in the renderer                | Normalize at the adapter boundary; consume the unified `chunk.thinking` field everywhere                                                     |
-| Raw `<a target="_blank">` or `window.open`                      | `<ExternalLink href={url}>` for hyperlinks; `useOpenExternal()` directly for button/actions with side effects (`components/ui/ExternalLink`) |
-| `import { os } from "@tauri-apps/plugin-os"` in features/routes | `useWindowControls()` service hook; exports OS platform checks (e.g. `isMacos`) alongside window actions                                     |
-| `import { Store } from "@tauri-apps/plugin-store"` in features  | Dedicated store wrapper that allowlists keys via module-level constants (example: `renderer/lib/onboarding-mirror.ts`); never user input     |
+| Anti-Pattern                                                     | Correct Approach                                                                                                                             |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useState + useEffect` for IPC data                              | React Query service hook                                                                                                                     |
+| `window.__TAURI_INVOKE__` directly                               | `useAppClient()` service hook                                                                                                                |
+| `import { useTranslation } from "react-i18next"`                 | `import { useTranslation } from "@ajh/translations"`                                                                                         |
+| Cross-feature imports                                            | Only import from `@ajh/ui`, `services/`, `lib/`                                                                                              |
+| `// eslint-disable` comment                                      | Fix the underlying issue or add a scoped `eslint.config.mjs` override                                                                        |
+| Inline `{ duration: 0.2, ease: "easeOut" }`                      | `transition.fast` from `@ajh/ui`                                                                                                             |
+| Hardcoded colors in className                                    | `text-brand`, `bg-brand`, etc.                                                                                                               |
+| Storing credentials in SQLite                                    | OS keychain (AI keys via `credentials` module; board sessions via `boards.*`/`linkedin.*`)                                                   |
+| Reading `AJH_DATA_DIR` / rebuilding `~/.ajh`                     | `platform::config::data_dir()`                                                                                                               |
+| Per-page `?` that aborts a partial scrape                        | First-page error propagates as `Err`; a later page logs + `break`s, keeping the partial (P10)                                                |
+| `reqwest::Client::new()` / `::builder()`                         | `net::http::shared()` or `net::http::build_client()`                                                                                         |
+| `Result<_, String>` for fallible internals                       | `AppResult<_>` / `AppError` from `crate::error`                                                                                              |
+| Folding web-fetched content directly into prompts                | Wrap in an untrusted-content fence (see `packages/prompts/src/emphasis.ts`); label the block so the model treats it as untrusted input       |
+| Per-provider `thinking` handling in the renderer                 | Normalize at the adapter boundary; consume the unified `chunk.thinking` field everywhere                                                     |
+| Raw `<a target="_blank">` or `window.open`                       | `<ExternalLink href={url}>` for hyperlinks; `useOpenExternal()` directly for button/actions with side effects (`components/ui/ExternalLink`) |
+| `import { os } from "@tauri-apps/plugin-os"` in features/routes  | `useWindowControls()` service hook; exports OS platform checks (e.g. `isMacos`) alongside window actions                                     |
+| `import { Store } from "@tauri-apps/plugin-store"` in features   | Dedicated store wrapper that allowlists keys via module-level constants (example: `renderer/lib/onboarding-mirror.ts`); never user input     |
+| `section === 'foo' && <Foo /> \|\| section === 'bar' && <Bar />` | Render registry: `Record<SectionId, () => ReactNode>` with lazy thunks (§16)                                                                 |
 
 [tauri]: https://tauri.app
 [tanstack-query]: https://tanstack.com/query

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -668,22 +668,18 @@ For 3+ way conditional rendering based on a discriminated union (section IDs, pa
 
 ### Pattern
 
+Define a `Record<Union, () => ReactNode>` keyed by the discriminated-union variants, where each value is a thunk that returns the section/stage content for that variant. Thunks are evaluated only on render; they can capture props/state via closure. Register anchors or data attributes in the thunk to co-locate layout hints with the rendered content.
+
 ```typescript
-import type { SectionId } from '@/features/settings/constants';
+// Type shape (not a concrete implementation):
+// Record<SectionId, () => ReactNode>
+//
+// Where SectionId is the discriminated union (e.g., 'general' | 'appearance' | 'contact' | …),
+// and each thunk returns the ReactNode for that variant.
 
-// Inside the component:
-const sectionRegistry: Record<SectionId, () => ReactNode> = {
-  general: () => <GeneralSection {...props} />,
-  appearance: () => <AppearanceCard />,
-  contact: () => <ContactProfileTab />,
-  // ... all other SectionId variants
-};
-
-// Render:
+// Usage:
 <div>{sectionRegistry[activeSection]()}</div>
 ```
-
-Thunks are evaluated only on render; they can capture props/state via closure. Register anchors or data attributes in the thunk to co-locate layout hints with the rendered content.
 
 ### References
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Unified HTTP request timeouts across AI providers to improve responsiveness and reliability.
  * Standardized UI timing for “copied” feedback and tooltip auto-hide across multiple screens.
  * Centralized background data refresh/cache timings to keep content updating consistently.
  * Refreshed internal stage/section rendering to use registry-based lookups (no intended user-visible change).

* **Documentation**
  * Added developer guidance on implementing typed render registries and updated pattern anti-examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->