### PR TITLE
feat: auto-commit preview edits and add referral improve-with-ai

### DIFF
--- a/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
@@ -1,7 +1,8 @@
-import { Code, Eye, Pencil, Save, Sparkles } from 'lucide-react';
+import { Code, Eye, Loader2, Pencil, Sparkles } from 'lucide-react';
 import { AnimatePresence } from 'motion/react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
+import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
 import {
   Button,
@@ -43,14 +44,15 @@ interface EditableOutputProps {
    */
   previewSlot?: React.ReactNode;
   /**
-   * Optional explicit-save handler. When provided, a **Save** button appears in the
-   * edit-view toolbar; clicking it commits the current edits (e.g. so a heavy
-   * `previewSlot` recompiles only on Save instead of on every keystroke). When
-   * omitted, behavior is unchanged — editing flows straight through `onChange`.
+   * When true, a subtle "Updating preview…" indicator is shown — set while a
+   * debounced commit is pending or the PdfPreview is recompiling.
    */
-  onSave?: () => void;
-  /** Enables the Save button — true when there are unsaved edits. */
-  canSave?: boolean;
+  isPending?: boolean;
+  /**
+   * Called when focus leaves the editor. Callers use this to flush any pending
+   * debounced commit immediately (e.g. on blur or tab switch).
+   */
+  onBlur?: () => void;
   /**
    * The source résumé text (the uploaded/original), when available. Feeds the
    * link dialog's suggestion pick-list with the full extracted link map. Optional
@@ -119,8 +121,8 @@ export function EditableOutput({
   textAreaClassName,
   placeholder,
   previewSlot,
-  onSave,
-  canSave = false,
+  isPending = false,
+  onBlur,
   sourceResume,
 }: EditableOutputProps) {
   const { t } = useTranslation();
@@ -303,18 +305,19 @@ export function EditableOutput({
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
-          {/* Save — in Edit/Source when a save handler is supplied; commits the
-              current edits (e.g. so the preview recompiles on Save, not per keystroke). */}
-          {onSave && isEditing && (
-            <Button
-              type="button"
-              onClick={onSave}
-              disabled={disabled || !canSave}
-              className="flex h-auto items-center gap-1.5 rounded-lg bg-brand/15 px-2.5 py-1 text-[11px] font-medium text-brand-soft transition-colors hover:bg-brand/20 disabled:pointer-events-none disabled:opacity-30"
+          {/* "Updating preview…" — shown while a debounced commit is pending or
+              the PdfPreview is recompiling. Sits left of the view-mode control. */}
+          {isPending && (
+            <span
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              data-testid={TEST_IDS.generation.pendingCommit}
+              className="flex items-center gap-1 text-[10px] text-foreground/35"
             >
-              <Save size={11} />
-              {t('aiGenerate.save')}
-            </Button>
+              <Loader2 size={10} className="animate-spin" />
+              {t('aiGenerate.previewUpdating')}
+            </span>
           )}
 
           <SegmentedControl<'preview' | 'edit' | 'source'>
@@ -334,7 +337,7 @@ export function EditableOutput({
       </div>
 
       {view === 'edit' ? (
-        <div className="relative flex-1 min-h-0 w-full">
+        <div className="relative flex-1 min-h-0 w-full" onBlur={onBlur}>
           {/* WYSIWYG edit surface — same canonical `value`/`onChange` as Source.
               Lock with readOnly while a rewrite streams (mirrors the Source path). */}
           <RichTextEditor
@@ -361,6 +364,7 @@ export function EditableOutput({
             ref={textareaRef}
             value={value}
             onChange={(e) => onChange(e.target.value)}
+            onBlur={onBlur}
             onSelect={updateSelection}
             onMouseUp={updateSelection}
             onKeyUp={updateSelection}

--- a/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
+++ b/apps/tauri/src/renderer/components/generation/EditableOutput/index.tsx
@@ -337,7 +337,14 @@ export function EditableOutput({
       </div>
 
       {view === 'edit' ? (
-        <div className="relative flex-1 min-h-0 w-full" onBlur={onBlur}>
+        <div
+          className="relative flex-1 min-h-0 w-full"
+          onBlur={(e) => {
+            // Only fire when focus truly leaves the container (not between internal
+            // controls like toolbar buttons → editor body).
+            if (!e.currentTarget.contains(e.relatedTarget)) onBlur?.();
+          }}
+        >
           {/* WYSIWYG edit surface — same canonical `value`/`onChange` as Source.
               Lock with readOnly while a rewrite streams (mirrors the Source path). */}
           <RichTextEditor
@@ -358,13 +365,19 @@ export function EditableOutput({
           {rewriteOverlay}
         </div>
       ) : view === 'source' ? (
-        <div className="relative flex-1 min-h-0 w-full">
+        <div
+          className="relative flex-1 min-h-0 w-full"
+          onBlur={(e) => {
+            // Only fire when focus truly leaves the container (not to the rewrite
+            // overlay buttons or other internal elements).
+            if (!e.currentTarget.contains(e.relatedTarget)) onBlur?.();
+          }}
+        >
           {/* Source — raw markdown power-user / inspection view (hand-editable). */}
           <TextArea
             ref={textareaRef}
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            onBlur={onBlur}
             onSelect={updateSelection}
             onMouseUp={updateSelection}
             onKeyUp={updateSelection}

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
@@ -17,6 +17,16 @@ vi.mock('@/services/use-contact-profile', () => ({
   useContactProfile: () => ({ data: undefined }),
 }));
 
+// Stub useDebouncedCommit so tests don't depend on fake timers.
+// scheduleCommit immediately calls onCommit — simulates instant commit in tests.
+vi.mock('@/hooks/use-debounced-commit', () => ({
+  useDebouncedCommit: (onCommit: (v: string) => void) => ({
+    scheduleCommit: (v: string) => onCommit(v),
+    flush: (v: string) => onCommit(v),
+    cancel: () => undefined,
+  }),
+}));
+
 const RAW = 'Led **payments** migration at scale.';
 
 function renderPanel(overrides: Partial<React.ComponentProps<typeof OutputPanelDone>> = {}) {
@@ -66,5 +76,12 @@ describe('OutputPanelDone — preview/edit', () => {
     expect(textarea.value).toBe(RAW);
     // Switching views must not mutate the canonical output.
     expect(onOutputChange).not.toHaveBeenCalled();
+  });
+
+  it('no Save button is rendered (auto-debounce replaced manual save)', () => {
+    renderPanel();
+    // Switch to Source so the full edit toolbar is visible.
+    fireEvent.click(screen.getByRole('radio', { name: /source/i }));
+    expect(screen.queryByRole('button', { name: /save/i })).toBeNull();
   });
 });

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/OutputPanelDone.test.tsx
@@ -18,11 +18,13 @@ vi.mock('@/services/use-contact-profile', () => ({
 }));
 
 // Stub useDebouncedCommit so tests don't depend on fake timers.
-// scheduleCommit immediately calls onCommit — simulates instant commit in tests.
+// scheduleCommit immediately calls onCommit with the (out, value) pair —
+// simulates instant commit in tests. flush() with no argument is also a no-op
+// (the pair was just committed by scheduleCommit already).
 vi.mock('@/hooks/use-debounced-commit', () => ({
-  useDebouncedCommit: (onCommit: (v: string) => void) => ({
-    scheduleCommit: (v: string) => onCommit(v),
-    flush: (v: string) => onCommit(v),
+  useDebouncedCommit: (onCommit: (out: string, v: string) => void) => ({
+    scheduleCommit: (out: string, v: string) => onCommit(out, v),
+    flush: () => undefined,
     cancel: () => undefined,
   }),
 }));

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
@@ -92,20 +92,18 @@ export function OutputPanelDone({
     }
   }, []);
 
-  const { scheduleCommit, flush, cancel } = useDebouncedCommit(
-    useCallback((text: string) => setCommitted(activeOut, text), [activeOut, setCommitted])
-  );
+  const { scheduleCommit, flush, cancel } = useDebouncedCommit<'resume' | 'cover'>(setCommitted);
 
-  // Flush on doc/tab switch so a pending edit commits before the view changes.
+  // Flush on doc/tab switch so a pending edit commits to ITS OWN doc before the
+  // view changes. flush() uses the (out, value) pair captured at scheduleCommit
+  // time — never the current activeOut — so the edit always lands in the right doc.
   const prevActiveOutRef = useRef(activeOut);
   useEffect(() => {
     if (prevActiveOutRef.current !== activeOut) {
-      const prev = prevActiveOutRef.current;
-      const pendingText = prev === 'resume' ? resumeOut : coverOut;
-      flush(pendingText);
+      flush();
       prevActiveOutRef.current = activeOut;
     }
-  }, [activeOut, resumeOut, coverOut, flush]);
+  }, [activeOut, flush]);
 
   // Cancel on unmount.
   useEffect(() => cancel, [cancel]);
@@ -130,31 +128,23 @@ export function OutputPanelDone({
 
   // Record the emitted value as a local edit, schedule the debounced commit, and
   // propagate the canonical string (copy/export stay live without recompiling).
+  // Pass (activeOut, value) so the pair is captured now — tab switches can't
+  // misroute the commit to a different doc.
   const handleOutputChange = useCallback(
     (value: string) => {
       lastEditRef.current[activeOut] = value;
       if (activeOut === 'resume') setPendingResume(true);
       else setPendingCover(true);
-      scheduleCommit(value);
+      scheduleCommit(activeOut, value);
       onOutputChange(value);
     },
     [activeOut, scheduleCommit, onOutputChange]
   );
 
-  // Stable refs so handleBlur always reads the latest values.
-  const activeOutRef = useRef(activeOut);
-  activeOutRef.current = activeOut;
-  const resumeOutRef = useRef(resumeOut);
-  resumeOutRef.current = resumeOut;
-  const coverOutRef = useRef(coverOut);
-  coverOutRef.current = coverOut;
-
   const handleBlur = useCallback(() => {
-    const doc = activeOutRef.current;
-    // Prefer the last locally-typed value (may be ahead of the prop in the same render).
-    const latest =
-      lastEditRef.current[doc] ?? (doc === 'resume' ? resumeOutRef.current : coverOutRef.current);
-    flush(latest);
+    // flush() commits the (out, value) pair captured at scheduleCommit time —
+    // uses the typed value, never the prop, and always routes to the correct doc.
+    flush();
   }, [flush]);
 
   const docType = activeOut === 'resume' ? 'resume' : 'cover-letter';
@@ -268,7 +258,7 @@ export function OutputPanelDone({
       {generatingDoc === 'cover' && (
         <div className="shrink-0 flex items-center gap-2 border-b border-amber-400/20 bg-amber-400/5 px-6 py-2 text-[11px] text-amber-400/80">
           <Loader2 size={11} className="animate-spin shrink-0" />
-          Cover letter is still generating — editing locked until both documents are ready.
+          {t('aiGenerate.coverStillGenerating')}
         </div>
       )}
 

--- a/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
+++ b/apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx
@@ -7,6 +7,7 @@ import { Button, cn } from '@ajh/ui';
 
 import { EditableOutput } from '@/components/generation/EditableOutput';
 import { PdfPreview } from '@/components/generation/PdfPreview';
+import { useDebouncedCommit } from '@/hooks/use-debounced-commit';
 import {
   buildFilename,
   type GenerationMeta,
@@ -65,51 +66,96 @@ export function OutputPanelDone({
   const [exportOpen, setExportOpen] = useState(false);
 
   // ── Committed preview text (decoupled from the live edited string) ────────────
-  // The PdfPreview renders the COMMITTED text, which only changes on discrete
-  // events — initial generation, regeneration, or an explicit Save — never on raw
-  // keystrokes. Typing still updates the canonical string (resumeOut/coverOut) so
-  // copy/export stay live and correct, but the heavy Typst recompile is deferred.
+  // PdfPreview renders COMMITTED text. Local edits auto-commit after ~700 ms via
+  // useDebouncedCommit; generation/regeneration commits immediately.
   const [committedResume, setCommittedResume] = useState(resumeOut);
   const [committedCover, setCommittedCover] = useState(coverOut);
-  // The last value the editor emitted per doc — lets us tell a generation/regenerate
-  // (external change) apart from a local edit, so the former auto-refreshes the
-  // preview and the latter does not.
+  // Track whether there is a pending debounced commit (drives the "Updating…" hint).
+  const [pendingResume, setPendingResume] = useState(false);
+  const [pendingCover, setPendingCover] = useState(false);
+
+  // The last value the editor emitted per doc — distinguishes external changes
+  // (generation / regeneration) from local edits, so external changes bypass the
+  // debounce and refresh the preview immediately.
   const lastEditRef = useRef<{ resume: string | null; cover: string | null }>({
     resume: null,
     cover: null,
   });
 
-  // Auto-refresh the committed text when resumeOut/coverOut change for a reason
-  // OTHER than the local editor (generation, regeneration). If the incoming text
-  // matches what the editor last emitted for that doc, it's a local edit → leave
-  // the committed text alone (preview waits for Save).
+  const setCommitted = useCallback((out: 'resume' | 'cover', text: string) => {
+    if (out === 'resume') {
+      setCommittedResume(text);
+      setPendingResume(false);
+    } else {
+      setCommittedCover(text);
+      setPendingCover(false);
+    }
+  }, []);
+
+  const { scheduleCommit, flush, cancel } = useDebouncedCommit(
+    useCallback((text: string) => setCommitted(activeOut, text), [activeOut, setCommitted])
+  );
+
+  // Flush on doc/tab switch so a pending edit commits before the view changes.
+  const prevActiveOutRef = useRef(activeOut);
+  useEffect(() => {
+    if (prevActiveOutRef.current !== activeOut) {
+      const prev = prevActiveOutRef.current;
+      const pendingText = prev === 'resume' ? resumeOut : coverOut;
+      flush(pendingText);
+      prevActiveOutRef.current = activeOut;
+    }
+  }, [activeOut, resumeOut, coverOut, flush]);
+
+  // Cancel on unmount.
+  useEffect(() => cancel, [cancel]);
+
+  // Auto-refresh committed when resumeOut/coverOut change for a reason OTHER than
+  // a local edit (generation, regeneration). A local edit sets lastEditRef so the
+  // debounce handles it instead.
   useEffect(() => {
     if (resumeOut !== lastEditRef.current.resume) {
       setCommittedResume(resumeOut);
+      setPendingResume(false);
       lastEditRef.current.resume = null;
     }
   }, [resumeOut]);
   useEffect(() => {
     if (coverOut !== lastEditRef.current.cover) {
       setCommittedCover(coverOut);
+      setPendingCover(false);
       lastEditRef.current.cover = null;
     }
   }, [coverOut]);
 
-  const commit = useCallback((out: 'resume' | 'cover', text: string) => {
-    if (out === 'resume') setCommittedResume(text);
-    else setCommittedCover(text);
-  }, []);
-
-  // Record the emitted value as a local edit, then propagate it to the canonical
-  // string (which keeps copy/export live without recompiling the preview).
+  // Record the emitted value as a local edit, schedule the debounced commit, and
+  // propagate the canonical string (copy/export stay live without recompiling).
   const handleOutputChange = useCallback(
     (value: string) => {
       lastEditRef.current[activeOut] = value;
+      if (activeOut === 'resume') setPendingResume(true);
+      else setPendingCover(true);
+      scheduleCommit(value);
       onOutputChange(value);
     },
-    [activeOut, onOutputChange]
+    [activeOut, scheduleCommit, onOutputChange]
   );
+
+  // Stable refs so handleBlur always reads the latest values.
+  const activeOutRef = useRef(activeOut);
+  activeOutRef.current = activeOut;
+  const resumeOutRef = useRef(resumeOut);
+  resumeOutRef.current = resumeOut;
+  const coverOutRef = useRef(coverOut);
+  coverOutRef.current = coverOut;
+
+  const handleBlur = useCallback(() => {
+    const doc = activeOutRef.current;
+    // Prefer the last locally-typed value (may be ahead of the prop in the same render).
+    const latest =
+      lastEditRef.current[doc] ?? (doc === 'resume' ? resumeOutRef.current : coverOutRef.current);
+    flush(latest);
+  }, [flush]);
 
   const docType = activeOut === 'resume' ? 'resume' : 'cover-letter';
   // The cover letter's preview layout follows the resolved market (job country →
@@ -132,6 +178,7 @@ export function OutputPanelDone({
   const currentOutput = activeOut === 'resume' ? resumeOut : coverOut;
   // Committed text for the active doc — what PdfPreview actually renders.
   const committed = activeOut === 'resume' ? committedResume : committedCover;
+  const isPending = activeOut === 'resume' ? pendingResume : pendingCover;
   const currentMeta = meta;
 
   return (
@@ -231,8 +278,8 @@ export function OutputPanelDone({
         <EditableOutput
           value={currentOutput}
           onChange={handleOutputChange}
-          onSave={() => commit(activeOut, currentOutput)}
-          canSave={currentOutput !== committed}
+          onBlur={handleBlur}
+          isPending={isPending}
           disabled={isGenerating}
           docType={docType}
           meta={meta}

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { TEST_IDS } from '@ajh/test-ids';
@@ -15,22 +15,22 @@ vi.mock('@ajh/translations', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-// EditableOutput mock — exposes onChange/onSave/canSave + renders previewSlot.
+// EditableOutput mock — exposes onChange/onBlur/isPending + renders previewSlot.
 // Uses divs (not raw <textarea>/<button>) to stay clear of the @ajh/ui ESLint rule.
-// The mock is intentionally richer than the original so edit/save/preview tests
+// The mock is intentionally richer than the original so edit/debounce/preview tests
 // can drive the component's committed-text logic without the real editor tree.
 vi.mock('@/components/generation/EditableOutput', () => ({
   EditableOutput: ({
     value,
     onChange,
-    onSave,
-    canSave,
+    onBlur,
+    isPending,
     previewSlot,
   }: {
     value: string;
     onChange?: (v: string) => void;
-    onSave?: () => void;
-    canSave?: boolean;
+    onBlur?: () => void;
+    isPending?: boolean;
     previewSlot?: React.ReactNode;
   }) => (
     <div data-testid={TEST_IDS.documents.editableOutput}>
@@ -41,17 +41,9 @@ vi.mock('@/components/generation/EditableOutput', () => ({
         contentEditable
         suppressContentEditableWarning
         onInput={(e) => onChange?.((e.target as HTMLElement).textContent ?? '')}
+        onBlur={onBlur}
       />
-      {onSave && (
-        <div
-          role="button"
-          data-testid={TEST_IDS.documents.saveBtn}
-          data-can-save={String(canSave)}
-          onClick={onSave}
-        >
-          save
-        </div>
-      )}
+      {isPending && <div data-testid={TEST_IDS.generation.pendingCommit}>updating</div>}
       {previewSlot && <div data-testid={TEST_IDS.documents.previewSlot}>{previewSlot}</div>}
     </div>
   ),
@@ -578,10 +570,13 @@ describe('GenerationOutput', () => {
   // ── 8. Edit → save → preview committed-text logic ────────────────────────────
   // The component is controlled: onEdit informs the parent which passes the new
   // output back down. ControlledWrapper simulates that round-trip.
-  // PdfPreview (inside previewSlot) always renders the COMMITTED text, not the
-  // live keystroke value — it only updates when Save is clicked.
+  // PdfPreview (inside previewSlot) always renders the COMMITTED text, which now
+  // auto-commits via a ~700 ms debounce — no manual Save button.
 
-  describe('Edit → save → preview flow', () => {
+  describe('Edit → debounce → preview flow', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
     it('preview text matches the initial output on first render', () => {
       render(
         <ControlledWrapper
@@ -597,79 +592,84 @@ describe('GenerationOutput', () => {
       const props = makeProps({ activeOut: 'resume', output: 'Version 1', editable: true });
       const { rerender } = render(<GenerationOutput {...props} />);
 
-      // No local edit has happened — the effect must update committed when output changes.
+      // No local edit — external change must update committed immediately.
       rerender(<GenerationOutput {...props} output="Version 2" />);
 
       expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Version 2');
     });
 
-    it('after a local edit the preview still shows the last committed (pre-save) text', async () => {
-      const user = userEvent.setup();
+    it('before 700 ms the preview still shows the last committed text', () => {
       render(
         <ControlledWrapper
           {...makeProps({ activeOut: 'resume', output: 'Committed text', editable: true })}
         />
       );
 
-      // Verify preview shows initial committed text before any edit.
       expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Committed text');
 
-      // Simulate a local edit: type into the contentEditable box.
       const editBox = screen.getByTestId(TEST_IDS.documents.editableInput);
-      await user.click(editBox);
-      await user.type(editBox, 'Edited text');
+      void act(() => {
+        editBox.textContent = 'Edited text';
+        editBox.dispatchEvent(new Event('input', { bubbles: true }));
+      });
 
-      // Preview must still show the old committed text — Save not clicked yet.
+      void act(() => vi.advanceTimersByTime(699));
+
+      // Preview must still show old committed text — debounce not yet fired.
       expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Committed text');
     });
 
-    it('canSave becomes true after a local edit', async () => {
-      const user = userEvent.setup();
+    it('after 700 ms the debounce auto-commits and the preview updates', () => {
       render(
         <ControlledWrapper
-          {...makeProps({ activeOut: 'resume', output: 'Original', editable: true })}
+          {...makeProps({ activeOut: 'resume', output: 'Old text', editable: true })}
         />
       );
 
-      const saveBtn = screen.getByTestId(TEST_IDS.documents.saveBtn);
-      expect(saveBtn).toHaveAttribute('data-can-save', 'false');
-
       const editBox = screen.getByTestId(TEST_IDS.documents.editableInput);
-      await user.click(editBox);
-      await user.type(editBox, 'Changed');
+      void act(() => {
+        editBox.textContent = 'New text';
+        editBox.dispatchEvent(new Event('input', { bubbles: true }));
+      });
 
-      expect(screen.getByTestId(TEST_IDS.documents.saveBtn)).toHaveAttribute(
-        'data-can-save',
-        'true'
-      );
+      void act(() => vi.advanceTimersByTime(700));
+
+      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('New text');
     });
 
-    it('clicking save commits the current output to the preview and canSave goes false', async () => {
-      const user = userEvent.setup();
+    it('blur flushes the debounce immediately without waiting 700 ms', async () => {
+      // Switch to real timers for this test — the blur flush is synchronous and
+      // fake-timer + async-act interaction can hide the state update.
+      vi.useRealTimers();
+
       render(
         <ControlledWrapper
-          {...makeProps({ activeOut: 'resume', output: 'Before save', editable: true })}
+          {...makeProps({ activeOut: 'resume', output: 'Before blur', editable: true })}
         />
       );
 
-      // Edit to diverge committed from output.
       const editBox = screen.getByTestId(TEST_IDS.documents.editableInput);
-      await user.click(editBox);
-      await user.type(editBox, 'After save');
+      await act(async () => {
+        editBox.textContent = 'After blur';
+        editBox.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+      await act(async () => {
+        editBox.dispatchEvent(new Event('blur', { bubbles: true }));
+      });
 
-      // Preview still shows old text before Save.
-      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Before save');
+      // Blur flushes the commit synchronously; waitFor handles React's async render.
+      await waitFor(() => {
+        expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('After blur');
+      });
+    });
 
-      // Click Save.
-      await user.click(screen.getByTestId(TEST_IDS.documents.saveBtn));
-
-      // After save the preview must reflect the new committed text.
-      // The component sets committed[activeOut] = output (which the wrapper
-      // already updated to include the typed text).
-      expect(screen.getByTestId(TEST_IDS.documents.saveBtn)).toHaveAttribute(
-        'data-can-save',
-        'false'
+    it('no Save button is rendered', () => {
+      render(
+        <ControlledWrapper
+          {...makeProps({ activeOut: 'resume', output: 'Some text', editable: true })}
+        />
       );
+      expect(screen.queryByTestId(TEST_IDS.documents.saveBtn)).not.toBeInTheDocument();
     });
   });
 

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
@@ -671,6 +671,76 @@ describe('GenerationOutput', () => {
       );
       expect(screen.queryByTestId(TEST_IDS.documents.saveBtn)).not.toBeInTheDocument();
     });
+
+    // ── BUG 2 regression: tab-switch commit must route to the correct doc ─────────
+    // Uses the REAL useDebouncedCommit hook (not mocked) + fake timers.
+    // Scenario: type on resume tab → switch to cover before 700 ms → the flush
+    // triggered by the switch must commit the typed value to RESUME (not cover);
+    // cover's preview must remain unchanged.
+    it('edit resume → switch tab before 700 ms → resume commits typed value, cover is untouched', () => {
+      // Stateful wrapper that mirrors the real parent: each doc owns its own output
+      // string and the active doc's output is passed down. Switching tabs passes
+      // the COVER's content as output, so the external-change detection does not
+      // accidentally overwrite committed.cover with the resume text.
+      function TabSwitchWrapper() {
+        const [activeOut, setActiveOut] = React.useState<'resume' | 'cover'>('resume');
+        const [resumeText, setResumeText] = React.useState('Original resume');
+        const coverText = 'Cover content';
+        const output = activeOut === 'resume' ? resumeText : coverText;
+        const handleEdit = (text: string) => {
+          if (activeOut === 'resume') setResumeText(text);
+        };
+        return (
+          <GenerationOutput
+            {...makeProps({
+              target: 'both',
+              activeOut,
+              setActiveOut,
+              output,
+              onEdit: handleEdit,
+              editable: true,
+            })}
+          />
+        );
+      }
+
+      render(<TabSwitchWrapper />);
+
+      // 1. Type on the resume tab — scheduleCommit('resume', 'Typed resume') fires.
+      const editBox = screen.getByTestId(TEST_IDS.documents.editableInput);
+      void act(() => {
+        editBox.textContent = 'Typed resume';
+        editBox.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+
+      // 2. Advance only 300 ms — debounce has NOT fired yet.
+      void act(() => vi.advanceTimersByTime(300));
+
+      // Preview still shows old committed text (resume).
+      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent(
+        'Original resume'
+      );
+
+      // 3. Switch to cover tab before the 700 ms window — triggers flush().
+      //    flush() must commit ('resume', 'Typed resume') — not ('cover', anything).
+      void act(() => {
+        screen.getByRole('tab', { name: 'autopilot.apply.target.cover' }).click();
+      });
+
+      // 4. Advance past the original debounce window; the timer was cancelled by flush.
+      void act(() => vi.advanceTimersByTime(700));
+
+      // Cover tab is now active — its committed text comes from coverText ('Cover content').
+      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Cover content');
+
+      // 5. Switch BACK to resume to verify its committed value.
+      void act(() => {
+        screen.getByRole('tab', { name: 'autopilot.apply.target.resume' }).click();
+      });
+
+      // Resume must show the typed value — committed by the flush at tab-switch time.
+      expect(screen.getByTestId(TEST_IDS.documents.pdfPreview)).toHaveTextContent('Typed resume');
+    });
   });
 
   // ── 9. Tabpanel ARIA linkage ──────────────────────────────────────────────

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy, Download, FileText, LayoutTemplate } from 'lucide-react';
-import { useEffect, useId, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import { useTranslation } from '@ajh/translations';
 import { Button, cn, Dropdown, Switch } from '@ajh/ui';
@@ -7,6 +7,7 @@ import { Button, cn, Dropdown, Switch } from '@ajh/ui';
 import { EditableOutput } from '@/components/generation/EditableOutput';
 import { type ExportFormat, ExportPicker } from '@/components/generation/ExportPicker';
 import { PdfPreview } from '@/components/generation/PdfPreview';
+import { useDebouncedCommit } from '@/hooks/use-debounced-commit';
 import {
   buildFilename,
   type GenerationMeta,
@@ -84,33 +85,73 @@ export function GenerationOutput({
   const [exportFormat, setExportFormat] = useState<ExportFormat>('pdf');
   const atsSwitchId = useId();
 
-  // Committed text per doc — what PdfPreview renders (recompiles only on discrete
-  // events: generation/regenerate/tab-switch/Save, never per keystroke). This
-  // component only ever sees the ACTIVE doc's `output`, so we key by `activeOut`.
+  // Committed text per doc — what PdfPreview renders. Local edits auto-commit
+  // after ~700 ms via useDebouncedCommit; generation/regeneration commits immediately.
   const [committed, setCommitted] = useState<Record<'resume' | 'cover', string>>({
     resume: activeOut === 'resume' ? output : '',
     cover: activeOut === 'cover' ? output : '',
   });
+  const [pending, setPending] = useState(false);
+
   const lastEditRef = useRef<Record<'resume' | 'cover', string | null>>({
     resume: null,
     cover: null,
   });
+  // Always hold the latest output/activeOut so handleBlur doesn't close over stale values.
+  const outputRef = useRef(output);
+  outputRef.current = output;
+  const activeOutRef = useRef(activeOut);
+  activeOutRef.current = activeOut;
 
-  // Refresh committed for the active doc when `output` changes for a reason OTHER
-  // than a local edit (generation, regenerate, or a tab switch that swaps `output`
-  // to the other doc's canonical text). A local edit sets lastEditRef so it does
-  // NOT refresh — the preview waits for Save.
+  const commitToDoc = useCallback(
+    (text: string) => {
+      setCommitted((c) => ({ ...c, [activeOut]: text }));
+      setPending(false);
+    },
+    [activeOut]
+  );
+
+  const { scheduleCommit, flush, cancel } = useDebouncedCommit(commitToDoc);
+
+  // Flush on doc/tab switch so a pending edit commits before the view changes.
+  const prevActiveOutRef = useRef(activeOut);
+  useEffect(() => {
+    if (prevActiveOutRef.current !== activeOut) {
+      flush(output);
+      prevActiveOutRef.current = activeOut;
+    }
+  }, [activeOut, output, flush]);
+
+  // Cancel on unmount.
+  useEffect(() => cancel, [cancel]);
+
+  // Refresh committed when `output` changes for a reason OTHER than a local edit
+  // (generation, regenerate, or tab switch). A local edit sets lastEditRef so the
+  // debounce handles it instead.
   useEffect(() => {
     if (output !== lastEditRef.current[activeOut]) {
       setCommitted((c) => ({ ...c, [activeOut]: output }));
+      setPending(false);
       lastEditRef.current[activeOut] = null;
     }
   }, [output, activeOut]);
 
-  const handleEdit = (value: string) => {
-    lastEditRef.current[activeOut] = value;
-    onEdit(value);
-  };
+  const handleEdit = useCallback(
+    (value: string) => {
+      lastEditRef.current[activeOut] = value;
+      setPending(true);
+      scheduleCommit(value);
+      onEdit(value);
+    },
+    [activeOut, scheduleCommit, onEdit]
+  );
+
+  const handleBlur = useCallback(() => {
+    // Use the last-edited value if a local edit is in flight; else the current prop.
+    const activeKey = activeOutRef.current;
+    const latest = lastEditRef.current[activeKey] ?? outputRef.current;
+    flush(latest);
+  }, [flush]);
   const docType = activeOut === 'resume' ? 'resume' : 'cover-letter';
 
   // Template picker (mirrors GenerateWizard.handleTemplateChange): selecting a
@@ -293,8 +334,8 @@ export function GenerationOutput({
           <EditableOutput
             value={output}
             onChange={handleEdit}
-            onSave={() => setCommitted((c) => ({ ...c, [activeOut]: output }))}
-            canSave={output !== committed[activeOut]}
+            onBlur={handleBlur}
+            isPending={pending}
             disabled={!editable}
             docType={docType}
             meta={meta}

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
@@ -97,30 +97,24 @@ export function GenerationOutput({
     resume: null,
     cover: null,
   });
-  // Always hold the latest output/activeOut so handleBlur doesn't close over stale values.
-  const outputRef = useRef(output);
-  outputRef.current = output;
-  const activeOutRef = useRef(activeOut);
-  activeOutRef.current = activeOut;
 
-  const commitToDoc = useCallback(
-    (text: string) => {
-      setCommitted((c) => ({ ...c, [activeOut]: text }));
-      setPending(false);
-    },
-    [activeOut]
-  );
+  const commitToDoc = useCallback((out: 'resume' | 'cover', text: string) => {
+    setCommitted((c) => ({ ...c, [out]: text }));
+    setPending(false);
+  }, []);
 
-  const { scheduleCommit, flush, cancel } = useDebouncedCommit(commitToDoc);
+  const { scheduleCommit, flush, cancel } = useDebouncedCommit<'resume' | 'cover'>(commitToDoc);
 
-  // Flush on doc/tab switch so a pending edit commits before the view changes.
+  // Flush on doc/tab switch so a pending edit commits to ITS OWN doc before the
+  // view changes. flush() uses the (out, value) pair captured at scheduleCommit
+  // time — never the current activeOut — so the edit always lands in the right doc.
   const prevActiveOutRef = useRef(activeOut);
   useEffect(() => {
     if (prevActiveOutRef.current !== activeOut) {
-      flush(output);
+      flush();
       prevActiveOutRef.current = activeOut;
     }
-  }, [activeOut, output, flush]);
+  }, [activeOut, flush]);
 
   // Cancel on unmount.
   useEffect(() => cancel, [cancel]);
@@ -140,17 +134,17 @@ export function GenerationOutput({
     (value: string) => {
       lastEditRef.current[activeOut] = value;
       setPending(true);
-      scheduleCommit(value);
+      // Capture (activeOut, value) pair now — tab switches can't misroute the commit.
+      scheduleCommit(activeOut, value);
       onEdit(value);
     },
     [activeOut, scheduleCommit, onEdit]
   );
 
   const handleBlur = useCallback(() => {
-    // Use the last-edited value if a local edit is in flight; else the current prop.
-    const activeKey = activeOutRef.current;
-    const latest = lastEditRef.current[activeKey] ?? outputRef.current;
-    flush(latest);
+    // flush() commits the (out, value) pair captured at scheduleCommit time —
+    // uses the typed value, never the prop, and always routes to the correct doc.
+    flush();
   }, [flush]);
   const docType = activeOut === 'resume' ? 'resume' : 'cover-letter';
 

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/ReferralModal.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/ReferralModal.test.tsx
@@ -58,6 +58,7 @@ vi.mock('@/components/ui/ModelSelector', () => ({
 // it() can set its own value before rendering.
 let stubbedDraft = '';
 const mockGenerate = vi.fn<() => Promise<void>>(async () => {});
+const mockImprove = vi.fn<(instruction: string) => Promise<void>>(async () => {});
 
 vi.mock('./useReferralDraft', () => ({
   useReferralDraft: () => ({
@@ -65,6 +66,7 @@ vi.mock('./useReferralDraft', () => ({
     generating: false,
     error: null,
     generate: mockGenerate,
+    improve: mockImprove,
     abort: vi.fn(),
     canGenerate: true,
     // save()'s onSuccess now calls reset() (the add-another flow) — stub it so the
@@ -102,6 +104,7 @@ beforeEach(() => {
   stubbedContacts = [];
   mockUpsertMutate.mockClear();
   mockGenerate.mockClear();
+  mockImprove.mockClear();
 });
 
 afterEach(() => {
@@ -362,5 +365,87 @@ describe('ReferralModal — over-limit counter text', () => {
     switchChannel('connection_note');
 
     expect(screen.getByText(/autopilot\.referral\.overLimit/)).toBeInTheDocument();
+  });
+});
+
+describe('ReferralModal — Improve with AI affordance', () => {
+  it('is NOT rendered when draft is empty', () => {
+    // stubbedDraft = '' (reset in beforeEach)
+    renderModal();
+    fillPersonName('Bob Chen');
+
+    // The improve section is conditionally rendered only when gen.draft is non-empty.
+    expect(
+      screen.queryByRole('button', { name: /autopilot\.referral\.improvePresets\.warmer/i })
+    ).toBeNull();
+    expect(screen.queryByLabelText('autopilot.referral.improveInstruction')).toBeNull();
+  });
+
+  it('IS rendered when a draft exists and not generating', () => {
+    stubbedDraft = 'Hi Bob, I wanted to reach out.';
+    renderModal();
+    fillPersonName('Bob Chen');
+
+    // All four preset chips must be present.
+    expect(
+      screen.getByRole('button', { name: 'autopilot.referral.improvePresets.warmer' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'autopilot.referral.improvePresets.shorter' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'autopilot.referral.improvePresets.moreSpecific' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'autopilot.referral.improvePresets.fixGrammar' })
+    ).toBeInTheDocument();
+
+    // Free-text input and Apply button must be present.
+    expect(screen.getByLabelText('autopilot.referral.improveInstruction')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'autopilot.referral.improveApply' })
+    ).toBeInTheDocument();
+  });
+
+  it('clicking a preset chip calls gen.improve with the preset i18n label', () => {
+    stubbedDraft = 'Hi Bob, I wanted to reach out.';
+    renderModal();
+    fillPersonName('Bob Chen');
+
+    act(() => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'autopilot.referral.improvePresets.warmer' })
+      );
+    });
+
+    // The mock t() returns the key itself, so the instruction passed is the full key.
+    expect(mockImprove).toHaveBeenCalledTimes(1);
+    expect(mockImprove).toHaveBeenCalledWith('autopilot.referral.improvePresets.warmer');
+  });
+
+  it('submitting a custom instruction via Apply button calls gen.improve', () => {
+    stubbedDraft = 'Hi Bob, I wanted to reach out.';
+    renderModal();
+    fillPersonName('Bob Chen');
+
+    const instructionInput = screen.getByLabelText('autopilot.referral.improveInstruction');
+    fireEvent.change(instructionInput, { target: { value: 'mention the Kafka work' } });
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'autopilot.referral.improveApply' }));
+    });
+
+    expect(mockImprove).toHaveBeenCalledTimes(1);
+    expect(mockImprove).toHaveBeenCalledWith('mention the Kafka work');
+  });
+
+  it('Apply button is disabled when the instruction input is blank', () => {
+    stubbedDraft = 'Hi Bob, I wanted to reach out.';
+    renderModal();
+    fillPersonName('Bob Chen');
+
+    const applyBtn = screen.getByRole('button', { name: 'autopilot.referral.improveApply' });
+    // Instruction is empty (default state) → Apply must be disabled.
+    expect(applyBtn).toBeDisabled();
   });
 });

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/ReferralModal.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/ReferralModal.test.tsx
@@ -448,4 +448,38 @@ describe('ReferralModal — Improve with AI affordance', () => {
     // Instruction is empty (default state) → Apply must be disabled.
     expect(applyBtn).toBeDisabled();
   });
+
+  // ── Keyboard behaviour on the improve instruction input ───────────────────────
+
+  it('pressing Enter on the instruction input submits the instruction (calls improve)', () => {
+    stubbedDraft = 'Hi Bob, I wanted to reach out.';
+    renderModal();
+    fillPersonName('Bob Chen');
+
+    const instructionInput = screen.getByLabelText('autopilot.referral.improveInstruction');
+    fireEvent.change(instructionInput, { target: { value: 'be more concise' } });
+
+    act(() => {
+      fireEvent.keyDown(instructionInput, { key: 'Enter', code: 'Enter', shiftKey: false });
+    });
+
+    expect(mockImprove).toHaveBeenCalledTimes(1);
+    expect(mockImprove).toHaveBeenCalledWith('be more concise');
+  });
+
+  it('pressing Shift+Enter on the instruction input does NOT submit', () => {
+    stubbedDraft = 'Hi Bob, I wanted to reach out.';
+    renderModal();
+    fillPersonName('Bob Chen');
+
+    const instructionInput = screen.getByLabelText('autopilot.referral.improveInstruction');
+    fireEvent.change(instructionInput, { target: { value: 'be more concise' } });
+
+    act(() => {
+      // Shift+Enter must not trigger improve (allows line breaks in a future multi-line variant).
+      fireEvent.keyDown(instructionInput, { key: 'Enter', code: 'Enter', shiftKey: true });
+    });
+
+    expect(mockImprove).not.toHaveBeenCalled();
+  });
 });

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/index.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/index.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, Save, ShieldCheck, Sparkles, UserPlus, X } from 'lucide-react';
+import { Check, Copy, Save, ShieldCheck, Sparkles, UserPlus, Wand2, X } from 'lucide-react';
 import { useState } from 'react';
 
 import type { AutopilotFoundJob } from '@ajh/shared';
@@ -23,6 +23,10 @@ interface Props {
 }
 
 const CHANNELS: ReferralChannel[] = ['email', 'linkedin_message', 'connection_note'];
+
+/** Preset improve instructions — key matches i18n `improvePresets.*`. */
+const IMPROVE_PRESETS = ['warmer', 'shorter', 'moreSpecific', 'fixGrammar'] as const;
+type ImprovePreset = (typeof IMPROVE_PRESETS)[number];
 
 /** Map the chosen channel to the matching persisted draft field. */
 function draftField(channel: ReferralChannel): 'emailDraft' | 'messageDraft' | 'inviteNoteDraft' {
@@ -50,6 +54,7 @@ export function ReferralModal({ job, resume, onClose }: Props) {
   const [channel, setChannel] = useState<ReferralChannel>('linkedin_message');
   const [copied, setCopied] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [improveInstruction, setImproveInstruction] = useState('');
 
   const contacts = useReferrals(job.url);
   const upsert = useUpsertReferral();
@@ -119,6 +124,13 @@ export function ReferralModal({ job, resume, onClose }: Props) {
         },
       }
     );
+  };
+
+  const submitImprove = (instruction: string) => {
+    const trimmed = instruction.trim();
+    if (!trimmed) return;
+    void gen.improve(trimmed);
+    setImproveInstruction('');
   };
 
   const channelLabel = (c: ReferralChannel) => t(`autopilot.referral.channel.${c}`);
@@ -277,7 +289,7 @@ export function ReferralModal({ job, resume, onClose }: Props) {
           {gen.error && <p className="text-[11px] text-red-300/80">{gen.error}</p>}
         </div>
 
-        {/* Draft output — only the generated message and its actions. */}
+        {/* Draft output — generated message, Improve with AI affordance, and actions. */}
         {(gen.draft || gen.generating) && (
           <div className="space-y-1.5 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5">
             <StreamingText text={gen.draft} isStreaming={gen.generating} />
@@ -316,6 +328,61 @@ export function ReferralModal({ job, resume, onClose }: Props) {
                 </Button>
               </div>
             </div>
+
+            {/* Improve with AI — only visible when a draft exists and not streaming. */}
+            {gen.draft && !gen.generating && (
+              <div className="space-y-2 border-t border-white/[0.06] pt-2">
+                {/* Preset chips */}
+                <div
+                  className="flex flex-wrap gap-1.5"
+                  role="group"
+                  aria-label={t('autopilot.referral.improveLabel')}
+                >
+                  {IMPROVE_PRESETS.map((preset: ImprovePreset) => (
+                    <Button
+                      key={preset}
+                      variant="glass"
+                      disabled={!gen.canGenerate}
+                      onClick={() =>
+                        submitImprove(t(`autopilot.referral.improvePresets.${preset}`))
+                      }
+                      className="h-auto px-2 py-0.5 text-[10px]"
+                    >
+                      {t(`autopilot.referral.improvePresets.${preset}`)}
+                    </Button>
+                  ))}
+                </div>
+
+                {/* Free-text instruction */}
+                <div className="flex gap-1.5">
+                  <Input
+                    id="referral-improve-instruction"
+                    variant="default"
+                    className="min-w-0 flex-1 shadow-none"
+                    value={improveInstruction}
+                    onChange={(e) => setImproveInstruction(e.target.value)}
+                    placeholder={t('autopilot.referral.improveInstructionPlaceholder')}
+                    aria-label={t('autopilot.referral.improveInstruction')}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        submitImprove(improveInstruction);
+                      }
+                    }}
+                  />
+                  <Button
+                    variant="glass"
+                    disabled={!gen.canGenerate || !improveInstruction.trim()}
+                    onClick={() => submitImprove(improveInstruction)}
+                    aria-label={t('autopilot.referral.improveApply')}
+                    className="shrink-0"
+                  >
+                    <Wand2 size={12} />
+                    {t('autopilot.referral.improveApply')}
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         )}
 

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.test.ts
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.test.ts
@@ -451,6 +451,58 @@ describe('useReferralDraft — improve()', () => {
     expect(result.current.error).toBeNull();
     expect(result.current.generating).toBe(false);
   });
+
+  // ── BUG 3 regression guard: draft must survive failed / aborted improve ────────
+
+  it('draft is preserved (not cleared) when improve() fails with a network error', async () => {
+    mockGenerateReferralImprove.mockRejectedValueOnce(new Error('network failure'));
+
+    const { result } = render();
+
+    // Seed a draft.
+    await act(async () => {
+      await result.current.generate();
+    });
+    const originalDraft = result.current.draft;
+    expect(originalDraft).not.toBe('');
+
+    // improve() fails — draft must be restored to the pre-improve value.
+    await act(async () => {
+      await result.current.improve('make it shorter');
+    });
+
+    expect(result.current.draft).toBe(originalDraft);
+    expect(result.current.error).toBe('network failure');
+    expect(result.current.generating).toBe(false);
+  });
+
+  it('draft is preserved (not cleared) when improve() is aborted mid-stream', async () => {
+    mockGenerateReferralImprove.mockImplementationOnce(async (): Promise<string> => {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    });
+
+    const { result } = render();
+
+    // Seed a draft.
+    await act(async () => {
+      await result.current.generate();
+    });
+    const originalDraft = result.current.draft;
+    expect(originalDraft).not.toBe('');
+
+    // Start improve then abort — draft must survive.
+    act(() => {
+      void result.current.improve('make it shorter');
+    });
+
+    await act(async () => {
+      result.current.abort();
+    });
+
+    expect(result.current.draft).toBe(originalDraft);
+    expect(result.current.error).toBeNull();
+    expect(result.current.generating).toBe(false);
+  });
 });
 
 // ── channel-switch clears draft ───────────────────────────────────────────────

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.test.ts
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.test.ts
@@ -17,8 +17,9 @@ import type { ReferralChannel } from '@ajh/shared/ipc';
 import { useReferralDraft } from './useReferralDraft';
 
 // ── mock @/lib/generate ───────────────────────────────────────────────────────
-// generateReferral is mocked as a vi.fn that resolves with a deterministic string.
-// The mock is reset between tests so individual cases can override the return value.
+// generateReferral + generateReferralImprove are mocked as vi.fn that resolve with
+// a deterministic string. The mock is reset between tests so individual cases can
+// override the return value.
 
 const mockGenerateReferral =
   vi.fn<
@@ -37,9 +38,30 @@ const mockGenerateReferral =
     }) => Promise<string>
   >();
 
+const mockGenerateReferralImprove =
+  vi.fn<
+    (params: {
+      personName: string;
+      personRole?: string;
+      companyName: string;
+      jobTitle: string;
+      resume: string;
+      draft: string;
+      instruction: string;
+      format: ReferralChannel;
+      charLimit?: number;
+      model: string;
+      locale?: string;
+      onToken?: (tok: string) => void;
+      signal?: AbortSignal;
+    }) => Promise<string>
+  >();
+
 vi.mock('@/lib/generate', () => ({
   generateReferral: (...args: Parameters<typeof mockGenerateReferral>) =>
     mockGenerateReferral(...args),
+  generateReferralImprove: (...args: Parameters<typeof mockGenerateReferralImprove>) =>
+    mockGenerateReferralImprove(...args),
   // CONNECTION_NOTE_LIMIT is a re-export from @ajh/prompts — provide the real value.
   CONNECTION_NOTE_LIMIT: 300,
 }));
@@ -70,6 +92,9 @@ const render = (p: typeof BASE = BASE) => renderHook(() => useReferralDraft(p), 
 
 beforeEach(() => {
   mockGenerateReferral.mockResolvedValue('Hi Bob, I wanted to reach out about the role at Acme.');
+  mockGenerateReferralImprove.mockResolvedValue(
+    'Hi Bob! I really wanted to reach out about the role at Acme.'
+  );
 });
 
 afterEach(() => {
@@ -283,6 +308,146 @@ describe('useReferralDraft — aborted generation does not surface an error', ()
     });
 
     // The catch guard `!controller.signal.aborted` must suppress the error.
+    expect(result.current.error).toBeNull();
+    expect(result.current.generating).toBe(false);
+  });
+});
+
+// ── improve() ────────────────────────────────────────────────────────────────
+
+describe('useReferralDraft — improve()', () => {
+  it('calls generateReferralImprove with the current draft + instruction and sets the new draft', async () => {
+    const { result } = render();
+
+    // First generate a draft.
+    await act(async () => {
+      await result.current.generate();
+    });
+    expect(result.current.draft).toBe('Hi Bob, I wanted to reach out about the role at Acme.');
+
+    // Now improve it.
+    await act(async () => {
+      await result.current.improve('make it warmer');
+    });
+
+    expect(mockGenerateReferralImprove).toHaveBeenCalledTimes(1);
+    expect(mockGenerateReferralImprove).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draft: 'Hi Bob, I wanted to reach out about the role at Acme.',
+        instruction: 'make it warmer',
+        personName: 'Bob Chen',
+        companyName: 'Acme',
+        format: 'linkedin_message',
+        model: 'llama3',
+      })
+    );
+    expect(result.current.draft).toBe(
+      'Hi Bob! I really wanted to reach out about the role at Acme.'
+    );
+    expect(result.current.generating).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does nothing when canGenerate is false (no draft + canUse=false)', async () => {
+    const { result } = render({ ...BASE, canUse: false });
+
+    await act(async () => {
+      await result.current.improve('make it warmer');
+    });
+
+    expect(mockGenerateReferralImprove).not.toHaveBeenCalled();
+    expect(result.current.draft).toBe('');
+  });
+
+  it('does nothing when draft is empty even if canGenerate is true', async () => {
+    const { result } = render();
+    // draft starts empty — improve should early-return.
+
+    await act(async () => {
+      await result.current.improve('make it warmer');
+    });
+
+    expect(mockGenerateReferralImprove).not.toHaveBeenCalled();
+  });
+
+  it('replaces the draft with the improved text (streams replacement)', async () => {
+    mockGenerateReferralImprove.mockImplementationOnce(
+      async ({ onToken }: { onToken?: (tok: string) => void }): Promise<string> => {
+        onToken?.('Improved ');
+        onToken?.('text.');
+        return 'Improved text.';
+      }
+    );
+
+    const { result } = render();
+
+    // Seed a draft so improve() can act.
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    await act(async () => {
+      await result.current.improve('shorter');
+    });
+
+    expect(result.current.draft).toBe('Improved text.');
+  });
+
+  it('surfaces non-abort errors in error state', async () => {
+    mockGenerateReferralImprove.mockRejectedValueOnce(new Error('improve failure'));
+
+    const { result } = render();
+
+    // Seed a draft.
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    await act(async () => {
+      await result.current.improve('fix grammar');
+    });
+
+    expect(result.current.error).toBe('improve failure');
+    expect(result.current.generating).toBe(false);
+  });
+
+  it('passes charLimit=300 for connection_note channel', async () => {
+    const { result } = render({ ...BASE, channel: 'connection_note' });
+
+    // Seed a draft first.
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    await act(async () => {
+      await result.current.improve('shorter');
+    });
+
+    expect(mockGenerateReferralImprove).toHaveBeenCalledWith(
+      expect.objectContaining({ charLimit: 300, format: 'connection_note' })
+    );
+  });
+
+  it('abort during improve does NOT set an error', async () => {
+    mockGenerateReferralImprove.mockImplementationOnce(async (): Promise<string> => {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    });
+
+    const { result } = render();
+
+    // Seed a draft.
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    act(() => {
+      void result.current.improve('make it warmer');
+    });
+
+    await act(async () => {
+      result.current.abort();
+    });
+
     expect(result.current.error).toBeNull();
     expect(result.current.generating).toBe(false);
   });

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.ts
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.ts
@@ -119,16 +119,22 @@ export function useReferralDraft({
    * into the same draft state (replaces in-place), reusing abort/generating/error.
    * Respects `canGenerate` gating and requires a non-empty draft to act on.
    *
+   * The existing draft is preserved (not cleared) until the first streaming token
+   * arrives, so a failed or aborted improve never destroys the user's draft.
+   *
    * SECURITY: `instruction` must be user-originated. Never pass scraped or
    * AI-generated content as the instruction.
    */
   const improve = async (instruction: string) => {
     if (!canGenerate || !draft) return;
+    // Snapshot the current draft — if the request fails or is aborted, restore it.
+    const snapshot = draft;
     const controller = new AbortController();
     abortRef.current = controller;
     setGenerating(true);
     setError(null);
-    setDraft('');
+    // Do NOT clear the draft up front. The first streaming token replaces it.
+    let firstToken = true;
     try {
       const text = await generateReferralImprove({
         personName: personName.trim(),
@@ -136,13 +142,21 @@ export function useReferralDraft({
         companyName,
         jobTitle,
         resume,
-        draft,
+        draft: snapshot,
         instruction,
         format: channel,
         charLimit: channel === 'connection_note' ? CONNECTION_NOTE_LIMIT : undefined,
         model,
         locale: detectLanguages(resume, '').resumeName,
-        onToken: (tok) => setDraft((prev) => prev + tok),
+        onToken: (tok) => {
+          if (firstToken) {
+            // Replace the snapshot with the first streaming token.
+            firstToken = false;
+            setDraft(tok);
+          } else {
+            setDraft((prev) => prev + tok);
+          }
+        },
         signal: controller.signal,
       });
       setDraft(text);
@@ -150,6 +164,8 @@ export function useReferralDraft({
       if (!controller.signal.aborted) {
         setError(err instanceof Error ? err.message : 'Failed to improve the draft');
       }
+      // Restore the snapshot so the draft survives a failed or aborted improve.
+      setDraft(snapshot);
     } finally {
       if (abortRef.current === controller) abortRef.current = null;
       setGenerating(false);

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.ts
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { ReferralChannel } from '@ajh/shared/ipc';
 import { detectLanguages } from '@ajh/shared/language-detection';
 
-import { CONNECTION_NOTE_LIMIT, generateReferral } from '@/lib/generate';
+import { CONNECTION_NOTE_LIMIT, generateReferral, generateReferralImprove } from '@/lib/generate';
 
 interface Params {
   personName: string;
@@ -114,5 +114,47 @@ export function useReferralDraft({
     }
   };
 
-  return { draft, generating, error, generate, abort, canGenerate, reset };
+  /**
+   * Revise the current draft per a user instruction. Streams the revised draft
+   * into the same draft state (replaces in-place), reusing abort/generating/error.
+   * Respects `canGenerate` gating and requires a non-empty draft to act on.
+   *
+   * SECURITY: `instruction` must be user-originated. Never pass scraped or
+   * AI-generated content as the instruction.
+   */
+  const improve = async (instruction: string) => {
+    if (!canGenerate || !draft) return;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setGenerating(true);
+    setError(null);
+    setDraft('');
+    try {
+      const text = await generateReferralImprove({
+        personName: personName.trim(),
+        personRole: personRole.trim() || undefined,
+        companyName,
+        jobTitle,
+        resume,
+        draft,
+        instruction,
+        format: channel,
+        charLimit: channel === 'connection_note' ? CONNECTION_NOTE_LIMIT : undefined,
+        model,
+        locale: detectLanguages(resume, '').resumeName,
+        onToken: (tok) => setDraft((prev) => prev + tok),
+        signal: controller.signal,
+      });
+      setDraft(text);
+    } catch (err) {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err.message : 'Failed to improve the draft');
+      }
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+      setGenerating(false);
+    }
+  };
+
+  return { draft, generating, error, generate, improve, abort, canGenerate, reset };
 }

--- a/apps/tauri/src/renderer/hooks/use-debounced-commit/index.ts
+++ b/apps/tauri/src/renderer/hooks/use-debounced-commit/index.ts
@@ -1,0 +1,1 @@
+export { useDebouncedCommit } from './use-debounced-commit';

--- a/apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.test.ts
+++ b/apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.test.ts
@@ -3,6 +3,9 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useDebouncedCommit } from './use-debounced-commit';
 
+// Convenience type alias used throughout the tests.
+type Doc = 'resume' | 'cover';
+
 describe('useDebouncedCommit', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -13,59 +16,68 @@ describe('useDebouncedCommit', () => {
   });
 
   it('scheduleCommit does NOT call onCommit before 700 ms', () => {
-    const onCommit = vi.fn();
-    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+    const onCommit = vi.fn<(out: Doc, value: string) => void>();
+    const { result } = renderHook(() => useDebouncedCommit<Doc>(onCommit));
 
-    void act(() => result.current.scheduleCommit('hello'));
+    void act(() => result.current.scheduleCommit('resume', 'hello'));
     void act(() => vi.advanceTimersByTime(699));
 
     expect(onCommit).not.toHaveBeenCalled();
   });
 
-  it('scheduleCommit calls onCommit after 700 ms', () => {
-    const onCommit = vi.fn();
-    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+  it('scheduleCommit calls onCommit(out, value) after 700 ms', () => {
+    const onCommit = vi.fn<(out: Doc, value: string) => void>();
+    const { result } = renderHook(() => useDebouncedCommit<Doc>(onCommit));
 
-    void act(() => result.current.scheduleCommit('hello'));
+    void act(() => result.current.scheduleCommit('resume', 'hello'));
     void act(() => vi.advanceTimersByTime(700));
 
     expect(onCommit).toHaveBeenCalledTimes(1);
-    expect(onCommit).toHaveBeenCalledWith('hello');
+    expect(onCommit).toHaveBeenCalledWith('resume', 'hello');
   });
 
-  it('rapid scheduleCommit calls debounce — only the LAST value commits', () => {
-    const onCommit = vi.fn();
-    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+  it('rapid scheduleCommit calls debounce — only the LAST (out, value) pair commits', () => {
+    const onCommit = vi.fn<(out: Doc, value: string) => void>();
+    const { result } = renderHook(() => useDebouncedCommit<Doc>(onCommit));
 
     void act(() => {
-      result.current.scheduleCommit('a');
-      result.current.scheduleCommit('ab');
-      result.current.scheduleCommit('abc');
+      result.current.scheduleCommit('resume', 'a');
+      result.current.scheduleCommit('resume', 'ab');
+      result.current.scheduleCommit('resume', 'abc');
     });
     void act(() => vi.advanceTimersByTime(700));
 
     expect(onCommit).toHaveBeenCalledTimes(1);
-    expect(onCommit).toHaveBeenCalledWith('abc');
+    expect(onCommit).toHaveBeenCalledWith('resume', 'abc');
   });
 
-  it('flush fires immediately and cancels any pending debounce', () => {
-    const onCommit = vi.fn();
-    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+  it('flush fires immediately with the stored pair and cancels any pending debounce', () => {
+    const onCommit = vi.fn<(out: Doc, value: string) => void>();
+    const { result } = renderHook(() => useDebouncedCommit<Doc>(onCommit));
 
-    void act(() => result.current.scheduleCommit('local'));
-    void act(() => result.current.flush('local'));
+    void act(() => result.current.scheduleCommit('resume', 'local'));
+    void act(() => result.current.flush());
     void act(() => vi.advanceTimersByTime(700));
 
-    // flush fires once; no second call from the cancelled timer.
+    // flush fires once with the captured pair; no second call from the cancelled timer.
     expect(onCommit).toHaveBeenCalledTimes(1);
-    expect(onCommit).toHaveBeenCalledWith('local');
+    expect(onCommit).toHaveBeenCalledWith('resume', 'local');
+  });
+
+  it('flush is a no-op when there is no pending commit', () => {
+    const onCommit = vi.fn<(out: Doc, value: string) => void>();
+    const { result } = renderHook(() => useDebouncedCommit<Doc>(onCommit));
+
+    void act(() => result.current.flush());
+
+    expect(onCommit).not.toHaveBeenCalled();
   });
 
   it('cancel drops the pending debounce — onCommit never called', () => {
-    const onCommit = vi.fn();
-    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+    const onCommit = vi.fn<(out: Doc, value: string) => void>();
+    const { result } = renderHook(() => useDebouncedCommit<Doc>(onCommit));
 
-    void act(() => result.current.scheduleCommit('local'));
+    void act(() => result.current.scheduleCommit('cover', 'local'));
     void act(() => result.current.cancel());
     void act(() => vi.advanceTimersByTime(700));
 
@@ -73,10 +85,10 @@ describe('useDebouncedCommit', () => {
   });
 
   it('cancel on unmount prevents stale callback after 700 ms', () => {
-    const onCommit = vi.fn();
-    const { result, unmount } = renderHook(() => useDebouncedCommit(onCommit));
+    const onCommit = vi.fn<(out: Doc, value: string) => void>();
+    const { result, unmount } = renderHook(() => useDebouncedCommit<Doc>(onCommit));
 
-    void act(() => result.current.scheduleCommit('ghost'));
+    void act(() => result.current.scheduleCommit('resume', 'ghost'));
     unmount();
     void act(() => vi.advanceTimersByTime(700));
 
@@ -84,12 +96,12 @@ describe('useDebouncedCommit', () => {
   });
 
   it('onCommit identity change between schedule and fire uses the latest callback', () => {
-    const first = vi.fn();
-    const second = vi.fn();
+    const first = vi.fn<(out: Doc, value: string) => void>();
+    const second = vi.fn<(out: Doc, value: string) => void>();
     let cb = first;
-    const { result, rerender } = renderHook(() => useDebouncedCommit(cb));
+    const { result, rerender } = renderHook(() => useDebouncedCommit<Doc>(cb));
 
-    void act(() => result.current.scheduleCommit('value'));
+    void act(() => result.current.scheduleCommit('resume', 'value'));
 
     // Swap callback before the timer fires.
     cb = second;
@@ -98,6 +110,44 @@ describe('useDebouncedCommit', () => {
     void act(() => vi.advanceTimersByTime(700));
 
     expect(first).not.toHaveBeenCalled();
-    expect(second).toHaveBeenCalledWith('value');
+    expect(second).toHaveBeenCalledWith('resume', 'value');
+  });
+
+  // ── BUG 2 regression: tab-switch commit must route to the original doc ────────
+
+  it('tab-switch mid-edit: flush commits to the ORIGINAL doc, not the new activeOut', () => {
+    // Simulates the real caller: scheduleCommit captures ('resume', typedText),
+    // then the user switches tabs, then flush() is called.
+    // onCommit must receive ('resume', typedText) — not ('cover', anything).
+    const onCommit = vi.fn<(out: Doc, value: string) => void>();
+    const { result } = renderHook(() => useDebouncedCommit<Doc>(onCommit));
+
+    // 1. User types on the resume tab — pair captured as ('resume', 'typed text').
+    void act(() => result.current.scheduleCommit('resume', 'typed text'));
+
+    // 2. Before 700 ms, user switches to cover tab — caller calls flush().
+    void act(() => vi.advanceTimersByTime(300));
+    void act(() => result.current.flush());
+
+    // 3. After the switch, advance past the original debounce window.
+    void act(() => vi.advanceTimersByTime(700));
+
+    // flush must have committed ONCE to 'resume' with 'typed text'.
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('resume', 'typed text');
+  });
+
+  it('timer fires and commits the captured pair even when the caller has switched docs', () => {
+    // The timer always commits the pair set at scheduleCommit time.
+    const onCommit = vi.fn<(out: Doc, value: string) => void>();
+    const { result } = renderHook(() => useDebouncedCommit<Doc>(onCommit));
+
+    void act(() => result.current.scheduleCommit('cover', 'cover draft'));
+
+    // 700 ms later — no flush, no cancel; the timer fires with the captured pair.
+    void act(() => vi.advanceTimersByTime(700));
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('cover', 'cover draft');
   });
 });

--- a/apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.test.ts
+++ b/apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useDebouncedCommit } from './use-debounced-commit';
+
+describe('useDebouncedCommit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('scheduleCommit does NOT call onCommit before 700 ms', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+
+    void act(() => result.current.scheduleCommit('hello'));
+    void act(() => vi.advanceTimersByTime(699));
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('scheduleCommit calls onCommit after 700 ms', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+
+    void act(() => result.current.scheduleCommit('hello'));
+    void act(() => vi.advanceTimersByTime(700));
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('hello');
+  });
+
+  it('rapid scheduleCommit calls debounce — only the LAST value commits', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+
+    void act(() => {
+      result.current.scheduleCommit('a');
+      result.current.scheduleCommit('ab');
+      result.current.scheduleCommit('abc');
+    });
+    void act(() => vi.advanceTimersByTime(700));
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('abc');
+  });
+
+  it('flush fires immediately and cancels any pending debounce', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+
+    void act(() => result.current.scheduleCommit('local'));
+    void act(() => result.current.flush('local'));
+    void act(() => vi.advanceTimersByTime(700));
+
+    // flush fires once; no second call from the cancelled timer.
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith('local');
+  });
+
+  it('cancel drops the pending debounce — onCommit never called', () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useDebouncedCommit(onCommit));
+
+    void act(() => result.current.scheduleCommit('local'));
+    void act(() => result.current.cancel());
+    void act(() => vi.advanceTimersByTime(700));
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('cancel on unmount prevents stale callback after 700 ms', () => {
+    const onCommit = vi.fn();
+    const { result, unmount } = renderHook(() => useDebouncedCommit(onCommit));
+
+    void act(() => result.current.scheduleCommit('ghost'));
+    unmount();
+    void act(() => vi.advanceTimersByTime(700));
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('onCommit identity change between schedule and fire uses the latest callback', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    let cb = first;
+    const { result, rerender } = renderHook(() => useDebouncedCommit(cb));
+
+    void act(() => result.current.scheduleCommit('value'));
+
+    // Swap callback before the timer fires.
+    cb = second;
+    rerender();
+
+    void act(() => vi.advanceTimersByTime(700));
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith('value');
+  });
+});

--- a/apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.ts
+++ b/apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.ts
@@ -7,16 +7,19 @@ const DEBOUNCE_MS = 700;
  * letting EXTERNAL changes (generation / regeneration) skip the debounce entirely.
  *
  * Contract:
- * - Call `scheduleCommit(value)` on every local-edit onChange.
- * - `flush(value)` commits immediately and cancels any pending debounce — call on
- *   blur and on doc/tab switch.
+ * - Call `scheduleCommit(out, value)` on every local-edit onChange — the (out,
+ *   value) PAIR is captured at call time so a tab switch cannot misroute the edit.
+ * - `flush()` commits the captured pair immediately and cancels any pending
+ *   debounce — call on blur and on doc/tab switch.
  * - `cancel()` drops any pending debounce without committing — call on unmount or
  *   when the caller switches away and wants to discard the pending edit.
  *
  * The hook is stateless — it does not hold the committed value itself; the caller
  * owns state and passes `onCommit` to receive updates.
  */
-export function useDebouncedCommit(onCommit: (value: string) => void) {
+export function useDebouncedCommit<TOut extends string>(
+  onCommit: (out: TOut, value: string) => void
+) {
   // Keep a stable ref so the timeout closure always sees the latest callback
   // without re-creating the timer functions when onCommit changes identity.
   const onCommitRef = useRef(onCommit);
@@ -25,6 +28,10 @@ export function useDebouncedCommit(onCommit: (value: string) => void) {
   });
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // The pending (out, value) pair captured at scheduleCommit time — the timer and
+  // flush both commit THIS pair, never a later activeOut from the closure.
+  const pendingRef = useRef<{ out: TOut; value: string } | null>(null);
 
   const clearTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -35,28 +42,37 @@ export function useDebouncedCommit(onCommit: (value: string) => void) {
 
   /** Schedule a debounced commit for a LOCAL edit (user typing). */
   const scheduleCommit = useCallback(
-    (value: string) => {
+    (out: TOut, value: string) => {
       clearTimer();
+      // Capture the pair NOW — the timer closure reads pendingRef, not the
+      // closure-captured `out`/`value`, so rapid re-schedules always use the latest.
+      pendingRef.current = { out, value };
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
-        onCommitRef.current(value);
+        const pending = pendingRef.current;
+        if (pending) {
+          pendingRef.current = null;
+          onCommitRef.current(pending.out, pending.value);
+        }
       }, DEBOUNCE_MS);
     },
     [clearTimer]
   );
 
   /** Flush any pending debounce immediately (blur / tab switch). */
-  const flush = useCallback(
-    (value: string) => {
-      clearTimer();
-      onCommitRef.current(value);
-    },
-    [clearTimer]
-  );
+  const flush = useCallback(() => {
+    clearTimer();
+    const pending = pendingRef.current;
+    if (pending) {
+      pendingRef.current = null;
+      onCommitRef.current(pending.out, pending.value);
+    }
+  }, [clearTimer]);
 
   /** Cancel pending debounce without committing (unmount / discard). */
   const cancel = useCallback(() => {
     clearTimer();
+    pendingRef.current = null;
   }, [clearTimer]);
 
   // Cancel on unmount to avoid calling stale callbacks.

--- a/apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.ts
+++ b/apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const DEBOUNCE_MS = 700;
+
+/**
+ * Debounces LOCAL edits (user typing) ~700 ms before calling `onCommit`, while
+ * letting EXTERNAL changes (generation / regeneration) skip the debounce entirely.
+ *
+ * Contract:
+ * - Call `scheduleCommit(value)` on every local-edit onChange.
+ * - `flush(value)` commits immediately and cancels any pending debounce — call on
+ *   blur and on doc/tab switch.
+ * - `cancel()` drops any pending debounce without committing — call on unmount or
+ *   when the caller switches away and wants to discard the pending edit.
+ *
+ * The hook is stateless — it does not hold the committed value itself; the caller
+ * owns state and passes `onCommit` to receive updates.
+ */
+export function useDebouncedCommit(onCommit: (value: string) => void) {
+  // Keep a stable ref so the timeout closure always sees the latest callback
+  // without re-creating the timer functions when onCommit changes identity.
+  const onCommitRef = useRef(onCommit);
+  useEffect(() => {
+    onCommitRef.current = onCommit;
+  });
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  /** Schedule a debounced commit for a LOCAL edit (user typing). */
+  const scheduleCommit = useCallback(
+    (value: string) => {
+      clearTimer();
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        onCommitRef.current(value);
+      }, DEBOUNCE_MS);
+    },
+    [clearTimer]
+  );
+
+  /** Flush any pending debounce immediately (blur / tab switch). */
+  const flush = useCallback(
+    (value: string) => {
+      clearTimer();
+      onCommitRef.current(value);
+    },
+    [clearTimer]
+  );
+
+  /** Cancel pending debounce without committing (unmount / discard). */
+  const cancel = useCallback(() => {
+    clearTimer();
+  }, [clearTimer]);
+
+  // Cancel on unmount to avoid calling stale callbacks.
+  useEffect(() => cancel, [cancel]);
+
+  return { scheduleCommit, flush, cancel };
+}

--- a/apps/tauri/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/tauri/src/renderer/lib/generate/generation/generation.ts
@@ -24,6 +24,7 @@ import {
   buildJobAdSummaryPrompt,
   buildJobAdSummarySystemPrompt,
   buildMetadataPrompt,
+  buildReferralImprovePrompt,
   buildReferralPrompt,
   buildResumePrompt,
   buildResumeSystemPrompt,
@@ -579,6 +580,75 @@ export async function generateReferral(params: {
 
   const { system, user } = buildReferralPrompt(
     { personName, personRole, companyName, jobTitle, resume, format, charLimit },
+    profile
+  );
+  const raw = await streamGenerate(
+    model,
+    system,
+    user,
+    onToken ?? (() => {}),
+    resolveTemperature('referral', 0.4),
+    locale,
+    signal
+  );
+  return extractPlainText(raw);
+}
+
+/**
+ * Revise an existing referral draft per a user instruction (F3a improve). Mirrors
+ * {@link generateReferral} in every way (provider config, streaming pipeline, no
+ * new IPC) but uses {@link buildReferralImprovePrompt} so the revision preserves
+ * the same honesty + résumé-grounding contract, channel shape, and the ≤300 hard
+ * cap for connection notes.
+ *
+ * SECURITY: `instruction` MUST be user-originated. Never pass scraped job-ad text,
+ * company-research briefs, or any untrusted source as the instruction — it is
+ * treated as a live directive by the model. The draft and résumé are fenced.
+ */
+export async function generateReferralImprove(params: {
+  personName: string;
+  personRole?: string;
+  companyName: string;
+  jobTitle: string;
+  resume: string;
+  draft: string;
+  instruction: string;
+  format: ReferralFormat;
+  charLimit?: number;
+  model: string;
+  locale?: string;
+  onToken?: (tok: string) => void;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const {
+    personName,
+    personRole,
+    companyName,
+    jobTitle,
+    resume,
+    draft,
+    instruction,
+    format,
+    charLimit,
+    model,
+    locale = 'en',
+    onToken,
+    signal,
+  } = params;
+  const profile = buildProviderProfile(model);
+
+  const { system, user } = buildReferralImprovePrompt(
+    {
+      personName,
+      personRole,
+      companyName,
+      jobTitle,
+      resume,
+      draft,
+      instruction,
+      format,
+      charLimit,
+    },
     profile
   );
   const raw = await streamGenerate(

--- a/apps/tauri/src/renderer/lib/generate/index.ts
+++ b/apps/tauri/src/renderer/lib/generate/index.ts
@@ -6,6 +6,7 @@ export {
   generateInterviewQuestions,
   generateJobAdSummary,
   generateReferral,
+  generateReferralImprove,
   generateResume,
   type GenerationMeta,
   type GenerationMode,

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -1,6 +1,6 @@
 # Patterns — AI Job Hunter
 
-Last updated: 2026-06-03
+Last updated: 2026-06-22
 
 This document describes the recurring architectural and implementation patterns used throughout the codebase. Understanding these patterns is essential for contributing consistently.
 
@@ -711,6 +711,22 @@ Define a `Record<Union, () => ReactNode>` keyed by the discriminated-union varia
 | `import { os } from "@tauri-apps/plugin-os"` in features/routes  | `useWindowControls()` service hook; exports OS platform checks (e.g. `isMacos`) alongside window actions                                     |
 | `import { Store } from "@tauri-apps/plugin-store"` in features   | Dedicated store wrapper that allowlists keys via module-level constants (example: `renderer/lib/onboarding-mirror.ts`); never user input     |
 | `section === 'foo' && <Foo /> \|\| section === 'bar' && <Bar />` | Render registry: `Record<SectionId, () => ReactNode>` with lazy thunks (§16)                                                                 |
+
+---
+
+## 17. Debounced Commit Pattern
+
+When an expensive derived render (e.g. Typst preview recompile) must be refreshed on user edits, but per-keystroke updates are cost-prohibitive, use debounced commit to gate the expensive operation while keeping local edits live.
+
+**Characteristics:**
+
+- **Local edits are live** for copy/paste/export (the local state is unaffected).
+- **Expensive operation (e.g. Typst recompile) is gated** behind ~700ms debounce per keystroke.
+- **External changes (generation/regeneration) bypass debounce** and recompile immediately.
+- **Flush on blur/doc-switch** ensures edits are committed before navigation.
+- **Visual hint** (e.g. "Updating preview…") indicates a pending commit.
+
+**Reference:** `useDebouncedCommit()` hook in `apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.ts`; integrated in `OutputPanelDone` for resume/cover-letter preview rendering. On each keystroke, `setLocalEditorText` captures the live state (unaffected by debounce), while `scheduleCommit` gates the expensive Typst recompile. On blur or doc-switch, `flush()` commits any pending edits immediately; external content generation (e.g. AI regeneration) bypasses the timer via replacement semantics.
 
 [tauri]: https://tauri.app
 [tanstack-query]: https://tanstack.com/query

--- a/docs/knowledge/decision-records/adr-012-html-preview-approximate.md
+++ b/docs/knowledge/decision-records/adr-012-html-preview-approximate.md
@@ -1,6 +1,6 @@
 # ADR-012: Live preview renders the real exported document via SVG; templates stay single-source
 
-Last updated: 2026-06-09
+Last updated: 2026-06-22
 
 **Status:** Accepted (revised during implementation)
 
@@ -49,7 +49,11 @@ validation — but stop at vector SVG instead of PDF bytes.
 ## Consequences
 
 - **Preview is the authoritative output** — it IS the Typst render, not an approximation.
-- Each edit triggers a Rust round-trip (cost acceptable for ~500ms debounce; covers both resume and letter).
+- Each edit triggers a Rust round-trip (cost acceptable for ~700ms debounce; covers both resume and letter).
+  **Debounce amendment (2026-06-22):** The explicit Save button is no longer required. Local edits now
+  commit to the preview on a ~700ms debounce (`useDebouncedCommit` hook), while generation/regeneration
+  commits immediately. This preserves the intent of the earlier save-gating (no per-keystroke Typst
+  recompiles) while removing the manual step. An "Updating preview…" hint shows while a commit is pending.
 - No HTML render path → zero drift. Template changes in Typst automatically appear in the preview.
 - **SVG sanitization:** Typst leaves raw `&` in link hrefs. Before wrapping as `<img>`, escape them
   to `&amp;` so the XML parses. See `escapeSvgAmpersands()` in `export/export.ts`.
@@ -64,5 +68,7 @@ validation — but stop at vector SVG instead of PDF bytes.
 
 - `renderDocumentPreview()` – `apps/tauri/src/renderer/lib/generate/export/export.ts`
 - `PdfPreview` – `apps/tauri/src/renderer/features/ai-generate/components/PdfPreview/`
+- `useDebouncedCommit()` – `apps/tauri/src/renderer/hooks/use-debounced-commit/use-debounced-commit.ts` (debounced local-edit commit)
+- `OutputPanelDone` – `apps/tauri/src/renderer/features/ai-generate/components/OutputPanelDone/index.tsx` (integration point)
 - `documents_render_preview_images` – `apps/tauri/src-tauri/src/export/commands/mod.rs`
 - `render_resume_svg_pages` / `render_letter_svg_pages` – `apps/tauri/src-tauri/src/export/typst_engine/render.rs`

--- a/docs/knowledge/domain-model.md
+++ b/docs/knowledge/domain-model.md
@@ -1,6 +1,6 @@
 # Domain model (core types, traits, registries)
 
-Last updated: 2026-06-21
+Last updated: 2026-06-22
 
 Describes the **shape**; the source is authoritative for field-level detail. Use `graphify explain "<type>"` then read the owning file.
 
@@ -24,7 +24,7 @@ Describes the **shape**; the source is authoritative for field-level detail. Use
 
 - **`referrals` store** — `referrals/mod.rs` (L1 domain); full CRUD via `commands/referrals.rs`. Each record captures a contact (name, company, role, relationship) plus a generated or hand-edited referral note in up to three formats (email, LinkedIn message, cold-ask). Local-only — no data leaves the device.
 - **`ReferralModal`** — `apps/tauri/src/renderer/features/autopilot/components/ReferralModal` (or adjacent apply-flow component); surfaced in the autopilot apply flow.
-- **Prompt layer** — `buildReferralPrompt` / `generateReferral` in `packages/prompts`; produces connection-note (≤ 300 chars), email, and LinkedIn-message variants; reuses `streamGenerate`.
+- **Prompt layer** — `buildReferralPrompt` / `generateReferral` in `packages/prompts`; produces connection-note (≤ 300 chars), email, and LinkedIn-message variants; reuses `streamGenerate`. **Improve variant** — `buildReferralImprovePrompt` / `gen.improve()` accept a preset or free-text instruction (warmer/shorter/more specific/fix grammar) and stream a revised draft via the same streaming infra.
 - **Data lifecycle** — wired into `manage_resettable` (full reset) and `commands/data.rs::build_bundle` (export/import). See [ADR-011](decision-records/adr-011-referral-helper-manual-only.md) for the decision to keep entry manual and discard LinkedIn scraping.
 
 ## Automation traits + registries

--- a/packages/prompts/src/generate/referral/referral.test.ts
+++ b/packages/prompts/src/generate/referral/referral.test.ts
@@ -292,6 +292,27 @@ describe('buildReferralImprovePrompt — draft + instruction inclusion', () => {
     expect(m[1].length).toBeLessThanOrEqual(4000);
     expect(m[1].length).toBeGreaterThan(0);
   });
+
+  it('truncates an over-long instruction to the MAX_INSTRUCTION_CHARS cap', () => {
+    // A huge instruction (e.g. a pasted blob) must not be interpolated unbounded —
+    // it would blow provider context budgets / spike cost.
+    const huge = 'B'.repeat(10_000);
+    const { user } = buildReferralImprovePrompt({ ...IMPROVE_BASE, instruction: huge });
+    const m = /### INSTRUCTION ###\n([\s\S]*?)\n\nRevise <current_draft>/.exec(user);
+    if (!m?.[1]) throw new Error('INSTRUCTION block not found');
+    // Bounded well below the raw 10k input (the cap is 1000).
+    expect(m[1].length).toBeLessThanOrEqual(1000);
+    expect(m[1].length).toBeGreaterThan(0);
+  });
+
+  it('trims surrounding whitespace from the instruction before interpolating', () => {
+    const { user } = buildReferralImprovePrompt({
+      ...IMPROVE_BASE,
+      instruction: '   Make it shorter.   \n',
+    });
+    expect(user).toContain('### INSTRUCTION ###\nMake it shorter.\n');
+    expect(user).not.toContain('### INSTRUCTION ###\n   Make it shorter.');
+  });
 });
 
 describe('buildReferralImprovePrompt — preserves generate grounding', () => {

--- a/packages/prompts/src/generate/referral/referral.test.ts
+++ b/packages/prompts/src/generate/referral/referral.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildReferralPrompt, CONNECTION_NOTE_LIMIT, type ReferralFormat } from './referral.js';
+import {
+  buildReferralImprovePrompt,
+  buildReferralPrompt,
+  CONNECTION_NOTE_LIMIT,
+  type ReferralFormat,
+} from './referral.js';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -249,5 +254,121 @@ describe('buildReferralPrompt — custom charLimit override', () => {
 
     expect(system).not.toContain('300');
     expect(user).not.toContain('300');
+  });
+});
+
+// ─── buildReferralImprovePrompt — revise an existing draft ─────────────────────
+
+const DRAFT =
+  'Hi Bob, I noticed Globex is hiring a Senior Backend Engineer. ' +
+  'I led a billing-platform migration at Acme and would value a referral. Thanks!';
+
+const IMPROVE_BASE: Parameters<typeof buildReferralImprovePrompt>[0] = {
+  ...BASE,
+  draft: DRAFT,
+  instruction: 'Make it warmer and a bit shorter.',
+};
+
+describe('buildReferralImprovePrompt — draft + instruction inclusion', () => {
+  it('embeds the current draft inside a fenced <current_draft> block', () => {
+    const { user } = buildReferralImprovePrompt(IMPROVE_BASE);
+    expect(user).toContain('<current_draft>');
+    expect(user).toContain('</current_draft>');
+    expect(user).toContain('billing-platform migration at Acme');
+  });
+
+  it('includes the user instruction in an ### INSTRUCTION ### block', () => {
+    const { user } = buildReferralImprovePrompt(IMPROVE_BASE);
+    expect(user).toMatch(/### INSTRUCTION ###/);
+    expect(user).toContain('Make it warmer and a bit shorter.');
+  });
+
+  it('truncates an over-long draft to the MAX_DRAFT_CHARS cap', () => {
+    const huge = 'A'.repeat(10_000);
+    const { user } = buildReferralImprovePrompt({ ...IMPROVE_BASE, draft: huge });
+    const m = /<current_draft>\n([\s\S]*?)\n<\/current_draft>/.exec(user);
+    if (!m?.[1]) throw new Error('current_draft block not found');
+    // Bounded well below the raw 10k input (the cap is 4000).
+    expect(m[1].length).toBeLessThanOrEqual(4000);
+    expect(m[1].length).toBeGreaterThan(0);
+  });
+});
+
+describe('buildReferralImprovePrompt — preserves generate grounding', () => {
+  it('carries the fenced <candidate_resume> block', () => {
+    const { user } = buildReferralImprovePrompt(IMPROVE_BASE);
+    expect(user).toContain('<candidate_resume>');
+    expect(user).toContain('</candidate_resume>');
+  });
+
+  it('re-states the no-fabrication rule for instruction-driven additions', () => {
+    const { user } = buildReferralImprovePrompt(IMPROVE_BASE);
+    // The instruction must not become a license to fabricate.
+    expect(user).toMatch(/never invent/i);
+    expect(user).toMatch(/instruction asks for that the résumé does not support/i);
+  });
+
+  it('system prompt keeps the honesty contract (no invented shared history)', () => {
+    const { system } = buildReferralImprovePrompt(IMPROVE_BASE);
+    expect(system).toMatch(/never invent/i);
+    expect(system).toMatch(/shared history|already know each other/i);
+  });
+
+  it('system prompt tells the model to keep the rules over the instruction', () => {
+    const { system } = buildReferralImprovePrompt(IMPROVE_BASE);
+    expect(system).toMatch(/revise the existing draft/i);
+    expect(system).toMatch(/follow the rule/i);
+  });
+
+  it('includes recipient, company, and job title in the user prompt', () => {
+    const { user } = buildReferralImprovePrompt(IMPROVE_BASE);
+    expect(user).toContain('Bob Chen (Engineering Director)');
+    expect(user).toContain('Globex');
+    expect(user).toContain('Senior Backend Engineer');
+  });
+});
+
+describe('buildReferralImprovePrompt — channel + length cap', () => {
+  it('enforces the ≤300 hard cap in both prompts for connection_note', () => {
+    const { system, user } = buildReferralImprovePrompt({
+      ...IMPROVE_BASE,
+      format: 'connection_note',
+    });
+    expect(system).toMatch(/hard limit/i);
+    expect(system).toContain('300');
+    expect(user).toMatch(/hard constraint/i);
+    expect(user).toContain('300');
+  });
+
+  it('honors a custom charLimit override for connection_note', () => {
+    const { system, user } = buildReferralImprovePrompt({
+      ...IMPROVE_BASE,
+      format: 'connection_note',
+      charLimit: 180,
+    });
+    expect(system).toContain('180');
+    expect(user).toContain('180');
+    expect(system).not.toContain('300');
+    expect(user).not.toContain('300');
+  });
+
+  it('omits the hard-cap clause for email and linkedin_message', () => {
+    for (const format of ['email', 'linkedin_message'] as ReferralFormat[]) {
+      const { user } = buildReferralImprovePrompt({ ...IMPROVE_BASE, format });
+      expect(user).not.toMatch(/hard constraint/i);
+    }
+  });
+
+  it('large tier renders MORE résumé context than small tier', () => {
+    const longResume = 'Jane Doe\nSenior Engineer\n\nEXPERIENCE\n' + 'X'.repeat(20_000);
+    const params = { ...IMPROVE_BASE, resume: longResume };
+    const extract = (u: string): string => {
+      const m = /<candidate_resume>([\s\S]*?)<\/candidate_resume>/.exec(u);
+      if (!m?.[1]) throw new Error('candidate_resume block not found');
+      return m[1];
+    };
+    const { user: large } = buildReferralImprovePrompt(params, 'large');
+    const { user: small } = buildReferralImprovePrompt(params, 'small');
+    expect(extract(large).length).toBeGreaterThan(extract(small).length);
   });
 });

--- a/packages/prompts/src/generate/referral/referral.ts
+++ b/packages/prompts/src/generate/referral/referral.ts
@@ -171,6 +171,12 @@ export interface ReferralImproveParams extends ReferralPromptParams {
 // any realistic referral email/message.
 const MAX_DRAFT_CHARS = 4000;
 
+// Hard cap on the user instruction, which is interpolated verbatim into the prompt.
+// Instructions are short directives ("make it warmer", "fix grammar"), so a tight
+// bound keeps an over-long (or pasted) instruction from blowing provider context
+// budgets / spiking cost. Trim first, then truncate.
+const MAX_INSTRUCTION_CHARS = 1000;
+
 /** The connection-note hard-cap clause, shared by generate + improve user prompts. */
 function hardCapClause(limit?: number): string {
   return `\n\nHARD CONSTRAINT: the entire note MUST be ${limit} characters or fewer. Count characters and stay under the limit. A note over ${limit} characters will be rejected.`;
@@ -204,6 +210,7 @@ export function buildReferralImprovePrompt(
   const role = personRole?.trim();
   const recipient = role ? `${personName} (${role})` : personName;
   const draftBody = draft.slice(0, MAX_DRAFT_CHARS);
+  const instructionBody = instruction.trim().slice(0, MAX_INSTRUCTION_CHARS);
 
   // brief = compact/imperative framing for small local models; full/task get the
   // fuller guidance. The contract + format rule are identical across depths so the
@@ -239,7 +246,7 @@ Company: ${companyName}
 Role the candidate is applying for: ${jobTitle}
 
 ### INSTRUCTION ###
-${instruction}
+${instructionBody}
 
 Revise <current_draft> to apply the instruction, producing an improved version of ${FORMAT_LABELS[format]} from the candidate to ${personName} (the low-pressure ask to refer the candidate for the ${jobTitle} role at ${companyName}). Ground every claim in the résumé.${
     format === 'connection_note' ? hardCapClause(limit) : ''

--- a/packages/prompts/src/generate/referral/referral.ts
+++ b/packages/prompts/src/generate/referral/referral.ts
@@ -19,6 +19,10 @@
  * a bare tier or a full provider profile, so it adapts across ollama / cloud /
  * cli with zero per-provider code: the resolved profile sizes how much of the
  * résumé context the prompt carries and how verbose the framing is.
+ *
+ * {@link buildReferralImprovePrompt} is the revise counterpart: given an existing
+ * draft plus a user instruction, it rewrites that draft under the SAME honesty +
+ * résumé-grounding contract, channel shape, and hard cap as the generate builder.
  */
 
 import { truncateResume } from '../../context-manager/index.js';
@@ -132,11 +136,115 @@ Company: ${companyName}
 Role the candidate is applying for: ${jobTitle}
 
 Write ${FORMAT_LABELS[format]} from the candidate to ${personName}, asking, politely and low-pressure, whether they'd be open to referring the candidate for the ${jobTitle} role at ${companyName}. Ground every claim in the résumé.${
-    format === 'connection_note'
-      ? `\n\nHARD CONSTRAINT: the entire note MUST be ${limit} characters or fewer. Count characters and stay under the limit. A note over ${limit} characters will be rejected.`
-      : ''
+    format === 'connection_note' ? hardCapClause(limit) : ''
   }
 Output ONLY the message:`;
+
+  return { system, user };
+}
+
+/**
+ * Parameters for {@link buildReferralImprovePrompt}. Mirrors
+ * {@link ReferralPromptParams} (same recipient + job + résumé grounding and the
+ * same per-format constraints) but revises an EXISTING draft per a user
+ * instruction instead of writing one from scratch.
+ */
+export interface ReferralImproveParams extends ReferralPromptParams {
+  /** The current referral draft the user wants revised — the text to improve. */
+  draft: string;
+  /**
+   * The user's revision instruction — free text (e.g. "make it warmer, mention
+   * the Kafka work") and/or a preset's instruction (e.g. "shorter", "more
+   * specific", "fix grammar").
+   *
+   * SECURITY: this MUST be user-originated — it is deliberately treated as an
+   * instruction the model obeys. Never build it from scraped job-ad text,
+   * company-research briefs, the recipient's profile, or any untrusted source;
+   * doing so would turn a prompt-injection payload into a live instruction. The
+   * grounded résumé and the current draft are fenced; the instruction is not.
+   */
+  instruction: string;
+}
+
+// Hard cap on the echoed draft itself so a huge paste can't blow a small model's
+// context (the draft is reproduced verbatim into the prompt). Generous enough for
+// any realistic referral email/message.
+const MAX_DRAFT_CHARS = 4000;
+
+/** The connection-note hard-cap clause, shared by generate + improve user prompts. */
+function hardCapClause(limit?: number): string {
+  return `\n\nHARD CONSTRAINT: the entire note MUST be ${limit} characters or fewer. Count characters and stay under the limit. A note over ${limit} characters will be rejected.`;
+}
+
+/**
+ * Build the referral IMPROVE system + user prompt. Revises an existing referral
+ * draft per a user instruction while keeping the SAME guarantees as the generate
+ * builder: only résumé-grounded claims (no fabrication, no invented shared
+ * history), the channel's shape, and the hard ≤300 cap for a connection note.
+ * Mirrors {@link buildReferralPrompt}'s provider abstraction via
+ * {@link resolveProfile}, so it adapts across ollama / cloud / cli with zero
+ * per-provider code.
+ */
+export function buildReferralImprovePrompt(
+  params: ReferralImproveParams,
+  target: PromptTarget = 'large'
+): { system: string; user: string } {
+  const { personRole, resume, format, draft, instruction } = params;
+  const personName = params.personName.trim();
+  const companyName = params.companyName.trim();
+  const jobTitle = params.jobTitle.trim();
+
+  const { depth, truncation } = resolveProfile(target);
+  const resumeBody = truncateResume(stripLinkBlock(resume), truncation);
+
+  const limit =
+    format === 'connection_note' ? (params.charLimit ?? CONNECTION_NOTE_LIMIT) : params.charLimit;
+
+  const formatRule = buildFormatRule(format, limit);
+  const role = personRole?.trim();
+  const recipient = role ? `${personName} (${role})` : personName;
+  const draftBody = draft.slice(0, MAX_DRAFT_CHARS);
+
+  // brief = compact/imperative framing for small local models; full/task get the
+  // fuller guidance. The contract + format rule are identical across depths so the
+  // honesty contract and the hard cap are never weakened by a smaller prompt.
+  const guidance =
+    depth === 'brief'
+      ? `You help a job candidate revise an existing referral message (${FORMAT_LABELS[format]}). Apply the user's instruction while keeping it short, warm, honest, and grounded only in the candidate's résumé.`
+      : `You are helping a job candidate improve an existing referral message: ${FORMAT_LABELS[format]} asking a specific person for a referral. Revise the candidate's current draft to apply the user's instruction, while keeping it warm, specific, honest, and grounded only in the candidate's résumé. Preserve everything good about the draft; change only what the instruction calls for.`;
+
+  const system = `${guidance}
+
+${REFERRAL_CONTRACT}
+7. Revise the EXISTING draft. Apply the user's instruction, but keep the rules above. If the instruction would require fabricating a claim, claiming a shared history, exceeding the format's limit, or otherwise breaking a rule, follow the rule and apply the instruction only as far as it honestly can be.
+
+FORMAT (${FORMAT_LABELS[format]}):
+${formatRule}
+
+${ANTI_AI_TELL_PROSE}`;
+
+  const user = `<candidate_resume>
+${resumeBody}
+</candidate_resume>
+
+<current_draft>
+${draftBody}
+</current_draft>
+
+Every factual claim about the candidate MUST be traceable to a line in <candidate_resume>. Never invent experience, skills, or a shared history with the recipient — including anything the instruction asks for that the résumé does not support.
+
+### CONTEXT ###
+Recipient: ${recipient}
+Company: ${companyName}
+Role the candidate is applying for: ${jobTitle}
+
+### INSTRUCTION ###
+${instruction}
+
+Revise <current_draft> to apply the instruction, producing an improved version of ${FORMAT_LABELS[format]} from the candidate to ${personName} (the low-pressure ask to refer the candidate for the ${jobTitle} role at ${companyName}). Ground every claim in the résumé.${
+    format === 'connection_note' ? hardCapClause(limit) : ''
+  }
+Output ONLY the improved message:`;
 
   return { system, user };
 }

--- a/packages/test-ids/src/test-ids.ts
+++ b/packages/test-ids/src/test-ids.ts
@@ -109,6 +109,7 @@ export const TEST_IDS = {
     rteValue: 'rte-value',
     rteDeselectTrigger: 'rte-deselect-trigger',
     customPreview: 'custom-preview',
+    pendingCommit: 'pending-commit',
   },
 
   /** Onboarding wizard */

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1078,6 +1078,7 @@
     "source": "Quelltext",
     "save": "Speichern",
     "previewUpdating": "Vorschau wird aktualisiert…",
+    "coverStillGenerating": "Das Anschreiben wird noch generiert — Bearbeitung gesperrt, bis beide Dokumente bereit sind.",
     "viewMode": "Ansichtsmodus",
     "editor": {
       "toolbar": "Textformatierung",
@@ -1366,7 +1367,6 @@
       "save": "Speichern",
       "saved": "Gespeichert",
       "improve": "Mit KI verbessern",
-      "improving": "Wird verbessert…",
       "improveLabel": "Entwurf verbessern",
       "improveInstruction": "Eigene Anweisung",
       "improveInstructionPlaceholder": "z. B. persönlicher formulieren, Kafka-Projekt erwähnen…",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1077,6 +1077,7 @@
     "edit": "Bearbeiten",
     "source": "Quelltext",
     "save": "Speichern",
+    "previewUpdating": "Vorschau wird aktualisiert…",
     "viewMode": "Ansichtsmodus",
     "editor": {
       "toolbar": "Textformatierung",
@@ -1364,6 +1365,18 @@
       "copied": "Kopiert",
       "save": "Speichern",
       "saved": "Gespeichert",
+      "improve": "Mit KI verbessern",
+      "improving": "Wird verbessert…",
+      "improveLabel": "Entwurf verbessern",
+      "improveInstruction": "Eigene Anweisung",
+      "improveInstructionPlaceholder": "z. B. persönlicher formulieren, Kafka-Projekt erwähnen…",
+      "improveApply": "Anwenden",
+      "improvePresets": {
+        "warmer": "Wärmer",
+        "shorter": "Kürzer",
+        "moreSpecific": "Spezifischer",
+        "fixGrammar": "Grammatik korrigieren"
+      },
       "overLimit": "Über dem 300-Zeichen-Limit — vor dem Speichern kürzen",
       "delete": "Kontakt löschen",
       "status": {

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1073,6 +1073,7 @@
     "edit": "Edit",
     "source": "Source",
     "save": "Save",
+    "previewUpdating": "Updating preview…",
     "viewMode": "View mode",
     "editor": {
       "toolbar": "Text formatting",
@@ -1360,6 +1361,18 @@
       "copied": "Copied",
       "save": "Save",
       "saved": "Saved",
+      "improve": "Improve with AI",
+      "improving": "Improving…",
+      "improveLabel": "Improve the draft",
+      "improveInstruction": "Custom instruction",
+      "improveInstructionPlaceholder": "e.g. make it more specific, mention the Kafka work…",
+      "improveApply": "Apply",
+      "improvePresets": {
+        "warmer": "Warmer",
+        "shorter": "Shorter",
+        "moreSpecific": "More specific",
+        "fixGrammar": "Fix grammar"
+      },
       "overLimit": "Over the 300-character limit — trim before saving",
       "delete": "Delete contact",
       "status": {

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1074,6 +1074,7 @@
     "source": "Source",
     "save": "Save",
     "previewUpdating": "Updating preview…",
+    "coverStillGenerating": "Cover letter is still generating — editing locked until both documents are ready.",
     "viewMode": "View mode",
     "editor": {
       "toolbar": "Text formatting",
@@ -1362,7 +1363,6 @@
       "save": "Save",
       "saved": "Saved",
       "improve": "Improve with AI",
-      "improving": "Improving…",
       "improveLabel": "Improve the draft",
       "improveInstruction": "Custom instruction",
       "improveInstructionPlaceholder": "e.g. make it more specific, mention the Kafka work…",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an “Improve with AI” option for referral drafts with preset suggestions (warmer, shorter, more specific, fix grammar) and custom instructions.

* **Changes**
  * Document edits now use a debounce-based workflow: the preview updates automatically after you pause typing, and commits are flushed when focus leaves.
  * Removed the explicit Save button—updates are reflected via a new “Updating preview…” pending indicator during processing.
  * Added new UI status/lock messages for AI preview updates and when the cover is still generating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->