### PR TITLE
fix: buffer cold-start deep-link autopilot focus so it isn't lost

### DIFF
--- a/apps/tauri/src-tauri/src/commands/autopilot.rs
+++ b/apps/tauri/src-tauri/src/commands/autopilot.rs
@@ -271,6 +271,28 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
     json!({ "jobId": job_id, "found": kept, "applied": 0 })
 }
 
+/// Take + clear the buffered autopilot-focus id. Split from the command so it's
+/// unit-testable without a Tauri `State`. Atomic: the lock is held across the take.
+pub(crate) fn take_pending_focus(buf: &crate::tray::PendingFocus) -> Option<String> {
+    buf.0.lock().take()
+}
+
+/// Atomically take + clear the autopilot-focus intent buffered by
+/// `tray::dispatch_focus` (a cold-start `ajh://autopilot/<id>` deep link fires
+/// during Rust setup, before the renderer's `useAutopilotFocusNavigation`
+/// listener attaches, so the `autopilot:focus` emit is lost). The renderer PULLS
+/// this once its JS loop is provably live (on mount + on the emitted event). The
+/// atomic take means an intent is delivered exactly once and can't re-fire on a
+/// later unrelated focus. Returns `None` (the common case) when nothing is
+/// buffered. Returns the `autopilotId` string. Infallible — just a lock take — so
+/// no `AppResult`.
+#[tauri::command]
+pub fn autopilot_take_pending_focus(
+    state: tauri::State<'_, crate::tray::PendingFocus>,
+) -> Option<String> {
+    take_pending_focus(state.inner())
+}
+
 #[tauri::command]
 pub fn autopilot_pause(app: AppHandle, autopilot_id: String) -> Value {
     store(&app)
@@ -458,5 +480,20 @@ mod tests {
         // No resume / no description → no score → never filtered out by the gate.
         assert!(passes_min_score(&found(None), 50.0));
         assert!(passes_min_score(&found(None), 100.0));
+    }
+
+    #[test]
+    fn take_pending_focus_returns_buffered_id_then_clears() {
+        let buf = crate::tray::PendingFocus(Mutex::new(Some("autopilot-123".to_string())));
+        assert_eq!(take_pending_focus(&buf), Some("autopilot-123".to_string()));
+        // Atomic take cleared the slot — a second pull (e.g. a later focus) is empty,
+        // so a cold-start deep-link focus is delivered exactly once and can't re-fire.
+        assert_eq!(take_pending_focus(&buf), None);
+    }
+
+    #[test]
+    fn take_pending_focus_returns_none_when_empty() {
+        let buf = crate::tray::PendingFocus(Mutex::new(None));
+        assert_eq!(take_pending_focus(&buf), None);
     }
 }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -145,12 +145,14 @@ fn nav_route_for(id: &str) -> Option<&'static str> {
 /// Drive the renderer for a validated deep-link target. Shared by every delivery
 /// path (single-instance relaunch, `on_open_url`, cold first-instance launch) so
 /// they stay in lockstep. `None` (a hostile/unrecognized URL) navigates nowhere
-/// — the caller has already focused the window. Each arm picks the right
-/// renderer signal: autopilot uses the fire-and-forget focus emit; pairing uses
-/// the cold-start-robust buffered `menu:navigate` intent.
+/// — the caller has already focused the window. Both arms use a cold-start-robust
+/// buffered intent so the signal survives a renderer that hasn't attached its
+/// listeners yet (the cold first-instance launch fires during Rust setup):
+/// autopilot buffers in `PendingFocus` (`dispatch_focus`); pairing buffers the
+/// `menu:navigate` intent (`dispatch_extension_pairing`).
 fn handle_deep_link(app: &AppHandle, target: Option<deeplink::FocusTarget>) {
     match target {
-        Some(deeplink::FocusTarget::Autopilot(id)) => tray::emit_focus(app, &id),
+        Some(deeplink::FocusTarget::Autopilot(id)) => tray::dispatch_focus(app, &id),
         Some(deeplink::FocusTarget::ExtensionPairing) => tray::dispatch_extension_pairing(app),
         None => {}
     }
@@ -452,6 +454,14 @@ pub fn run() {
             }
 
             let handle = app.handle();
+
+            // Buffer for an autopilot-focus intent (cold-start `ajh://autopilot/<id>`)
+            // managed HERE, before the cold-start deep-link block below — that block
+            // runs during setup, well before `tray::build` (which manages the sibling
+            // `PendingMenu`). `dispatch_focus` writes the id into this buffer BEFORE
+            // emitting, so it must already be in state when the cold-start deep link
+            // is handled, or the write silently no-ops and the intent is lost.
+            app.manage(tray::PendingFocus(Mutex::new(None)));
 
             // `ajh://` deep links. The OS routes a cold/click-launched URL here
             // (macOS via `on_open_url`; Windows/Linux a second instance forwards
@@ -794,6 +804,7 @@ pub fn run() {
             commands::autopilot::autopilot_run,
             commands::autopilot::autopilot_pause,
             commands::autopilot::autopilot_resume,
+            commands::autopilot::autopilot_take_pending_focus,
             // ai generations
             commands::ai_generations::ai_generations_list,
             commands::ai_generations::ai_generations_save,

--- a/apps/tauri/src-tauri/src/tray/mod.rs
+++ b/apps/tauri/src-tauri/src/tray/mod.rs
@@ -45,6 +45,16 @@ struct NewJobs {
 /// `(event_name, payload)`; the renderer takes-and-clears it atomically.
 pub struct PendingMenu(pub Mutex<Option<(String, serde_json::Value)>>);
 
+/// The last autopilot-focus intent, buffered by `dispatch_focus` and pulled by
+/// the renderer (`autopilot_take_pending_focus`) so a cold-start
+/// `ajh://autopilot/<id>` deep link isn't lost to the fire-and-forget `emit`
+/// race — the deep link fires during Rust setup, before the renderer's
+/// `useAutopilotFocusNavigation` listener attaches. A dedicated buffer (autopilot
+/// focus is a distinct domain from the navigate/action menu intents). Single-slot
+/// (last delivery wins) holding the `autopilotId`; the renderer takes-and-clears
+/// it atomically.
+pub struct PendingFocus(pub Mutex<Option<String>>);
+
 /// Build the tray icon + menu and register `TrayState`. Called once from setup.
 pub fn build(app: &AppHandle) -> tauri::Result<()> {
     let show = MenuItemBuilder::with_id(SHOW_ID, "Show AI Job Hunter").build(app)?;
@@ -117,6 +127,9 @@ pub fn build(app: &AppHandle) -> tauri::Result<()> {
     });
     // Buffer for a menu intent missed by a backgrounded webview (see `dispatch_menu`).
     app.manage(PendingMenu(Mutex::new(None)));
+    // NOTE: the sibling `PendingFocus` buffer (autopilot-focus deep links) is
+    // managed earlier in `lib.rs` setup — BEFORE the cold-start deep-link block,
+    // which runs well before this `tray::build`. See the comment there.
     Ok(())
 }
 
@@ -242,9 +255,43 @@ pub fn dispatch_extension_pairing(app: &AppHandle) {
     );
 }
 
+/// Restore the window and deliver an autopilot-focus intent so the renderer jumps
+/// to a specific autopilot's found-jobs panel.
+///
+/// Mirrors [`dispatch_menu`] for the cold-start race: `emit` is fire-and-forget,
+/// so a focus fired during Rust setup (a cold-start `ajh://autopilot/<id>` deep
+/// link) lands BEFORE the renderer's `useAutopilotFocusNavigation` listener
+/// attaches and is lost. So we ALWAYS buffer the id in [`PendingFocus`] (written
+/// BEFORE `show_focus` so it's in place no matter how quickly the renderer pulls)
+/// and let the renderer PULL it (`autopilot_take_pending_focus`) once its JS loop
+/// is provably live. `autopilot_take_pending_focus` takes-and-clears atomically,
+/// so the intent is delivered exactly once and can't re-fire on a later unrelated
+/// focus. The immediate emit stays purely as a low-latency *trigger* for the
+/// already-running case where a live webview drains immediately, plus a deferred
+/// re-emit (same rationale as `dispatch_menu`).
+pub fn dispatch_focus(app: &AppHandle, autopilot_id: &str) {
+    // Buffer BEFORE showing so the renderer's pull (which may fire as soon as the
+    // window is shown / focused / mounted) always finds the intent.
+    if let Some(s) = app.try_state::<PendingFocus>() {
+        *s.0.lock() = Some(autopilot_id.to_string());
+    }
+    show_focus(app);
+    emit_focus(app, autopilot_id);
+    // Deferred re-trigger for the case where the immediate emit was dropped (the
+    // renderer drains `PendingFocus` exactly-once, so this duplicate is a no-op if
+    // the first emit already landed). Same rationale + timing as `dispatch_menu`.
+    let app_retry = app.clone();
+    let id_retry = autopilot_id.to_string();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(tokio::time::Duration::from_millis(120)).await;
+        emit_focus(&app_retry, &id_retry);
+    });
+}
+
 /// Emit a focus event so the renderer jumps to a specific autopilot's found-jobs
-/// panel (or, with an empty id, just refreshes the list). Shared by the tray and
-/// the single-instance deep-link guard.
+/// panel (or, with an empty id, just refreshes the list). The low-latency trigger
+/// used by the already-running tray path; the cold-start deep-link path goes
+/// through [`dispatch_focus`] which also buffers in [`PendingFocus`].
 pub fn emit_focus(app: &AppHandle, autopilot_id: &str) {
     emit_event(
         app,

--- a/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.test.ts
+++ b/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { createMockClient, withProviders } from '@/test-support';
+
+import { useAutopilotFocusNavigation } from './use-autopilot-focus-navigation';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const navigate = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigate,
+}));
+
+const setAutopilot = vi.fn();
+vi.mock('@/store/session-store', () => ({
+  useSessionStore: (selector: (s: { setAutopilot: typeof setAutopilot }) => unknown) =>
+    selector({ setAutopilot }),
+}));
+
+// Capture the live-event handler registered by useAutopilotFocusEvents so tests
+// can fire it directly (simulates the shell's autopilot:focus emit).
+let capturedFocusHandler: ((event: { autopilotId: string }) => void) | undefined;
+vi.mock('@/services', () => ({
+  keys: { autopilot: { all: ['autopilot'] } },
+  useAutopilotFocusEvents: (handler: (event: { autopilotId: string }) => void) => {
+    capturedFocusHandler = handler;
+  },
+}));
+
+// useQueryClient — return a stub with invalidateQueries as a spy.
+const invalidateQueries = vi.fn();
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries }),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Render the hook with a mock client whose `autopilot.takePendingFocus` resolves
+ * to `pending`. On mount the hook drains once; tests can also override for later
+ * drain triggers.
+ */
+function renderWithPending(
+  pending: string | null,
+  takePendingFocus = vi.fn().mockResolvedValue(pending)
+) {
+  const client = createMockClient({ 'autopilot.takePendingFocus': takePendingFocus });
+  const utils = renderHook(() => useAutopilotFocusNavigation(), {
+    wrapper: withProviders(client),
+  });
+  return { ...utils, takePendingFocus };
+}
+
+beforeEach(() => {
+  navigate.mockClear();
+  setAutopilot.mockClear();
+  invalidateQueries.mockClear();
+  capturedFocusHandler = undefined;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useAutopilotFocusNavigation — pull drain (buffered deep-link path)', () => {
+  it('navigates to /autopilot and sets focusedId when a buffered id is pulled on mount', async () => {
+    renderWithPending('ap-123');
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/autopilot' }));
+    expect(setAutopilot).toHaveBeenCalledExactlyOnceWith({ focusedId: 'ap-123' });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['autopilot'] });
+  });
+
+  it('does nothing when the pull returns null (common case — nothing buffered)', async () => {
+    const { takePendingFocus } = renderWithPending(null);
+
+    await waitFor(() => expect(takePendingFocus).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+    expect(setAutopilot).not.toHaveBeenCalled();
+  });
+
+  it('drains exactly once even if a later window-focus trigger sees a cleared buffer', async () => {
+    // First pull (mount) returns the id; subsequent pulls see null (cleared).
+    const takePendingFocus = vi.fn().mockResolvedValueOnce('ap-once').mockResolvedValue(null);
+    renderWithPending(null, takePendingFocus);
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+    });
+
+    // Still exactly one navigation — the buffer was cleared after the first pull.
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains on window focus (tray/close-to-tray restore path)', async () => {
+    // Mount drain returns null; a later buffer arrives.
+    const takePendingFocus = vi.fn().mockResolvedValue(null);
+    renderWithPending(null, takePendingFocus);
+
+    await waitFor(() => expect(takePendingFocus).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+
+    takePendingFocus.mockResolvedValueOnce('ap-focus');
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/autopilot' }));
+    expect(setAutopilot).toHaveBeenCalledWith({ focusedId: 'ap-focus' });
+  });
+
+  it('drains on visibilitychange to visible (hidden→shown restore path)', async () => {
+    const takePendingFocus = vi.fn().mockResolvedValue(null);
+    renderWithPending(null, takePendingFocus);
+
+    await waitFor(() => expect(takePendingFocus).toHaveBeenCalled());
+
+    takePendingFocus.mockResolvedValueOnce('ap-vis');
+    // jsdom defaults visibilityState to 'visible', so we simulate the transition.
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/autopilot' }));
+  });
+
+  it('silently swallows IPC errors (no unhandled rejection)', async () => {
+    const takePendingFocus = vi.fn().mockRejectedValue(new Error('IPC failure'));
+    // Should not throw — the hook catches transient failures.
+    expect(() => renderWithPending(null, takePendingFocus)).not.toThrow();
+    // Let the rejected promise settle.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAutopilotFocusNavigation — live event path', () => {
+  it('handles a live autopilot:focus event with an id', async () => {
+    renderWithPending(null);
+
+    await waitFor(() => expect(capturedFocusHandler).toBeDefined());
+
+    act(() => {
+      capturedFocusHandler?.({ autopilotId: 'ap-live' });
+    });
+
+    expect(navigate).toHaveBeenCalledWith({ to: '/autopilot' });
+    expect(setAutopilot).toHaveBeenCalledWith({ focusedId: 'ap-live' });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['autopilot'] });
+  });
+
+  it('only invalidates (no navigation) for a live event with an empty autopilotId', async () => {
+    renderWithPending(null);
+
+    await waitFor(() => expect(capturedFocusHandler).toBeDefined());
+
+    act(() => {
+      capturedFocusHandler?.({ autopilotId: '' });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    expect(setAutopilot).not.toHaveBeenCalled();
+  });
+});

--- a/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.test.ts
+++ b/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.test.ts
@@ -44,6 +44,11 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
  * Render the hook with a mock client whose `autopilot.takePendingFocus` resolves
  * to `pending`. On mount the hook drains once; tests can also override for later
  * drain triggers.
+ *
+ * Override shape: `createMockClient` from `@/test-support` accepts dotted-key
+ * overrides (`'namespace.method': fn`) via a Proxy — NOT nested objects. The
+ * Proxy `get` trap checks `overrides['autopilot.takePendingFocus']` directly so
+ * the override IS applied; call assertions below prove it each time.
  */
 function renderWithPending(
   pending: string | null,
@@ -71,8 +76,10 @@ afterEach(() => {
 
 describe('useAutopilotFocusNavigation — pull drain (buffered deep-link path)', () => {
   it('navigates to /autopilot and sets focusedId when a buffered id is pulled on mount', async () => {
-    renderWithPending('ap-123');
+    const { takePendingFocus } = renderWithPending('ap-123');
 
+    // Prove the override was actually called (not a default-null path passing by luck).
+    await waitFor(() => expect(takePendingFocus).toHaveBeenCalledOnce());
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/autopilot' }));
     expect(setAutopilot).toHaveBeenCalledExactlyOnceWith({ focusedId: 'ap-123' });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['autopilot'] });
@@ -91,7 +98,10 @@ describe('useAutopilotFocusNavigation — pull drain (buffered deep-link path)',
     const takePendingFocus = vi.fn().mockResolvedValueOnce('ap-once').mockResolvedValue(null);
     renderWithPending(null, takePendingFocus);
 
-    await waitFor(() => expect(navigate).toHaveBeenCalledTimes(1));
+    // Prove the override fn fired (not a default-null path) and produced navigation.
+    await waitFor(() => expect(takePendingFocus).toHaveBeenCalledOnce());
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/autopilot' }));
+    expect(setAutopilot).toHaveBeenCalledWith({ focusedId: 'ap-once' });
 
     await act(async () => {
       window.dispatchEvent(new Event('focus'));
@@ -108,7 +118,8 @@ describe('useAutopilotFocusNavigation — pull drain (buffered deep-link path)',
     const takePendingFocus = vi.fn().mockResolvedValue(null);
     renderWithPending(null, takePendingFocus);
 
-    await waitFor(() => expect(takePendingFocus).toHaveBeenCalled());
+    // Mount drain called the override (not the default) and correctly did nothing.
+    await waitFor(() => expect(takePendingFocus).toHaveBeenCalledOnce());
     expect(navigate).not.toHaveBeenCalled();
 
     takePendingFocus.mockResolvedValueOnce('ap-focus');
@@ -117,6 +128,8 @@ describe('useAutopilotFocusNavigation — pull drain (buffered deep-link path)',
       await Promise.resolve();
     });
 
+    // Override called a second time (window focus trigger) and produced navigation.
+    await waitFor(() => expect(takePendingFocus).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/autopilot' }));
     expect(setAutopilot).toHaveBeenCalledWith({ focusedId: 'ap-focus' });
   });
@@ -125,7 +138,9 @@ describe('useAutopilotFocusNavigation — pull drain (buffered deep-link path)',
     const takePendingFocus = vi.fn().mockResolvedValue(null);
     renderWithPending(null, takePendingFocus);
 
-    await waitFor(() => expect(takePendingFocus).toHaveBeenCalled());
+    // Mount drain: override called, nothing buffered.
+    await waitFor(() => expect(takePendingFocus).toHaveBeenCalledOnce());
+    expect(navigate).not.toHaveBeenCalled();
 
     takePendingFocus.mockResolvedValueOnce('ap-vis');
     // jsdom defaults visibilityState to 'visible', so we simulate the transition.
@@ -138,7 +153,10 @@ describe('useAutopilotFocusNavigation — pull drain (buffered deep-link path)',
       await Promise.resolve();
     });
 
+    // Override called a second time (visibility trigger) and drove navigation.
+    await waitFor(() => expect(takePendingFocus).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/autopilot' }));
+    expect(setAutopilot).toHaveBeenCalledWith({ focusedId: 'ap-vis' });
   });
 
   it('silently swallows IPC errors (no unhandled rejection)', async () => {

--- a/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.ts
+++ b/apps/tauri/src/renderer/hooks/use-autopilot-focus-navigation.ts
@@ -1,9 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 
 import type { AutopilotFocusEvent } from '@ajh/shared';
 
+import { useAppClient } from '@/providers/AppClientProvider';
 import { keys, useAutopilotFocusEvents } from '@/services';
 import { useSessionStore } from '@/store/session-store';
 
@@ -14,8 +15,16 @@ import { useSessionStore } from '@/store/session-store';
  * card to auto-expand (empty id = refresh only).
  *
  * Mounted once in the root layout so it fires regardless of the current route.
+ *
+ * Delivery model (mirrors use-menu):
+ *  - Live `autopilot:focus` event — low-latency for already-running windows.
+ *  - Pull via `autopilot.takePendingFocus()` on mount + window focus +
+ *    visibility-restore — covers cold-start deep links where the Rust setup emits
+ *    before JS listeners are attached. The shell buffers the id atomically so the
+ *    event + pull can't double-fire (take-and-clear).
  */
 export function useAutopilotFocusNavigation() {
+  const api = useAppClient();
   const navigate = useNavigate();
   const qc = useQueryClient();
   const setAutopilot = useSessionStore((s) => s.setAutopilot);
@@ -31,5 +40,36 @@ export function useAutopilotFocusNavigation() {
     [navigate, qc, setAutopilot]
   );
 
+  // Live event listener — already-running window path.
   useAutopilotFocusEvents(onFocus);
+
+  // Pull drain — cold-start deep-link path + tray-restore path.
+  // Mirrors use-menu's drain triggers: mount, window focus, visibility-restore.
+  useEffect(() => {
+    let cancelled = false;
+    const drain = async () => {
+      try {
+        const id = await api.autopilot.takePendingFocus();
+        if (cancelled || !id) return;
+        onFocus({ autopilotId: id });
+      } catch {
+        // Transient IPC failure — the buffer is retained on the shell side;
+        // a later trigger re-drains. Never surface as an unhandled rejection.
+      }
+    };
+    const trigger = () => void drain();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void drain();
+    };
+
+    void drain(); // mount: drain anything buffered before listeners attached
+    window.addEventListener('focus', trigger);
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('focus', trigger);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [api, onFocus]);
 }

--- a/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/tauri/src/renderer/lib/mock-client/mock-client.ts
@@ -272,6 +272,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       resume: noop,
       onStep: () => () => {},
       onFocus: () => () => {},
+      takePendingFocus: () => Promise.resolve(null),
     },
 
     menu: {

--- a/apps/tauri/src/tauri-client/namespaces/autopilot/autopilot.ts
+++ b/apps/tauri/src/tauri-client/namespaces/autopilot/autopilot.ts
@@ -24,4 +24,5 @@ export const autopilot = {
     asyncUnsub(() =>
       listen<AutopilotFocusEvent>(EVENT_CHANNELS.autopilot.focus, (e) => handler(e.payload))
     ),
+  takePendingFocus: () => invoke<string | null>('autopilot_take_pending_focus'),
 };

--- a/docs/API.md
+++ b/docs/API.md
@@ -207,6 +207,10 @@ matching jobs (the user tailors & applies with the assistant; there is no auto-a
 
 #### `autopilot.resume(id: string): Promise<void>`
 
+#### `autopilot.takePendingFocus(): Promise<string | null>`
+
+Atomically take and clear the autopilot-focus intent buffered by the shell while the app was starting (cold-start deep link `ajh://autopilot/<id>`). A deep-link deep-link emitted during Rust setup fires before the renderer's `onFocus` listener attaches, so the event is lost; the renderer pulls the buffered `autopilotId` once its JS loop is live (on mount and when focus is regained). Returns `null` when nothing is buffered (the common case—only set by a cold-start deep link). Mirrors `menu.takePending()`.
+
 ```typescript
 interface WorkflowDefinition {
   name: string;

--- a/docs/knowledge/event-system.md
+++ b/docs/knowledge/event-system.md
@@ -40,6 +40,18 @@ Centralized, one-way event channels — the complement to IPC request/response (
 
 **Convention:** Use `dispatch_menu` for local window broadcasts in `tray/mod.rs` (identity-free tray/window distinction); all other paths use centralized `emit_event`.
 
+## Cold-start deep-link buffering
+
+When a deep link (e.g. `ajh://autopilot/<id>`) or menu action fires during Tauri setup, before the renderer's JS event listeners attach, the emitted event is lost. Mitigate with a **buffer + pull pattern**:
+
+1. Shell-side: `app.manage(Buffer<T>)` at the earliest point in setup (before any write path runs)
+2. Write path: write intent to buffer BEFORE emit
+3. Renderer: on mount (and on window focus/visibility-restore), call `takePendingIntent()` to atomically take and clear
+
+Examples: `menu.takePending()` (menu + action intents), `autopilot.takePendingFocus()` (focus target id). Both use the same pattern.
+
+**Critical ordering:** The buffer must be app-managed at the point the EARLIEST write can occur, which may be well before the buffer is consumed. Placing `app.manage()` inside a late builder (e.g. `tray::build`) will silently no-op any write that fires before the builder runs.
+
 ## Renderer consumption
 
 **Tauri-client namespaces:** `apps/tauri/src/tauri-client/namespaces/**`

--- a/packages/shared/src/ipc/contracts/autopilot.ts
+++ b/packages/shared/src/ipc/contracts/autopilot.ts
@@ -24,6 +24,16 @@ export interface AutopilotContract {
    *  focus an autopilot's found-jobs panel. An empty `autopilotId` is a pure
    *  "refresh the list" signal (e.g. after a tray Pause-All) with no navigation. */
   onFocus(handler: (event: AutopilotFocusEvent) => void): () => void;
+
+  /** Atomically take + clear the autopilot-focus intent buffered by the shell.
+   *  A cold-start `ajh://autopilot/<id>` deep link fires the `autopilot:focus`
+   *  emit during Rust setup, before the renderer's `useAutopilotFocusNavigation`
+   *  listener attaches, so the event is lost; the shell buffers the id and the
+   *  renderer pulls it once its JS loop is live (on mount + on the emitted
+   *  event). The IPC response is reliable where the event was not. Resolves to
+   *  the buffered `autopilotId`, or `null` when nothing is buffered (the common
+   *  case — only set by a cold-start deep link). Mirrors `menu.takePending`. */
+  takePendingFocus(): Promise<string | null>;
 }
 
 export interface AutopilotStepEvent {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cold-start–safe autopilot focus delivery with buffered intent consumption, ensuring navigation isn’t missed during app startup or renderer readiness.
  * Introduced `autopilot.takePendingFocus()` to atomically pull the pending autopilot id (once) from the shell.
* **Tests**
  * Added a test suite covering buffered consumption, live `autopilot:focus` handling, and single-drain navigation/session behavior.
* **Documentation**
  * Documented the new IPC/API method and expanded the cold-start deep-link buffering guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->