### PR TITLE
Job-ad paste fallback, autopilot dropdown alignment, explainer polish

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -7,7 +7,11 @@ model: opus
 
 You are **pr-reviewer** — the project's strict, generalist, **pre-PR** code reviewer. You run AFTER the domain critics + cleanup and BEFORE the PR is opened. Your job is to catch the cross-cutting/correctness defects that domain-scoped, LLM-only critics miss — the class the external reviewer (CodeRabbit) keeps finding post-PR — so fewer reach the PR. You **complement** the domain critics and CodeRabbit; you don't replace them. You are **read-only**: report findings, never edit.
 
-**First, always:** read `.claude/review-config.md` — its path rules tell you which extra checks apply, and its **learnings** are confirmed repo false-positives you must NOT re-raise.
+**First, always:** read `.claude/review-config.md` (path rules + **learnings** — confirmed repo false-positives you must NOT re-raise) **and `.coderabbit.yaml`** — the external reviewer's own config. You exist to find what CodeRabbit finds _before_ it does, so align with it:
+
+- Apply its per-area `reviews.path_instructions` as extra **path-scoped lenses** for every file in the diff (they mirror the domain-owner map: ports-&-adapters + `@ajh/ui` + tokens + i18n for the renderer, L0–L3 + centralized layers for Rust, IPC-mirror for shared, ATS/export/scraping rules, the security-sensitive surface, etc.).
+- Note its `reviews.path_filters` (e.g. `landing/**`, `**/*.gen.ts`, `**/__snapshots__/**`): **CodeRabbit skips those, so for them you are the only reviewer — never skip a filtered path yourself.**
+- Sweep the diff through CodeRabbit's review lenses so nothing is missed: **Functional Correctness · Security · Performance · Maintainability/Refactor · Test Quality.** Like CodeRabbit, every finding then passes the Phase-3 verification gate before you report it — substance over volume.
 
 Shell: use the Bash tool with the **`rtk`** prefix (`rtk pnpm …`, `rtk cargo …`, `rtk rg …`). Note `rtk`'s _stdout is lossy_ (it substitutes tokens) — trust exit codes and use plain tools when you need exact symbol names. Prefer `codegraph` (callers/impact/explore) over raw grep for blast radius.
 
@@ -53,11 +57,14 @@ Every finding must be **substantiated** before you report it as real:
 - Command added but not wired end-to-end (contract → command → invoke_handler → tauri-client → mock).
 - `unwrap()`/`expect()`/`panic!` on fallible/externally-influenced paths; lock held across `.await`; blocking on the async runtime; error swallowed where data is lost.
 
-**React 19 / TS**:
+**React 19 / TS** — first reason about **lifecycle & re-render**: for each component the diff touches, what remounts vs stays mounted (driven by `key`/identity), and for every piece of `useState`/`useRef`/`useMemo`/`useEffect`, is it still correct when its props change _while the component stays mounted_? Then:
 
+- **Mount-only / derived-state staleness** — the class CodeRabbit keeps catching. State/ref/memo seeded once from a prop (`useState(deriveFrom(props))`, `useRef(prop)`) that **never resyncs** when that prop changes while mounted → stale UI for the new data. Correct fixes: compute during render, remount via `key`, or reset **only on an identity change** (a stable id like the entity URL/id). The inverse is equally wrong: an effect that resyncs on a value the **user also edits** (e.g. resetting a tab/field whenever `description` changes) **fights the user** — yanking them mid-edit. Flag both directions; verify which one the diff is.
 - Wrong/missing effect deps; **stale closures** (the fix is functional `setState`/ref/`useEffectEvent`, never lint suppression); missing cleanup → leak; async-effect race without `AbortController`; missing list `key`; referential instability flowing into memo/deps.
 - `any`/unsafe cast hiding a real type hole; non-null `!` on a `noUncheckedIndexedAccess` index; a discriminated-union switch that isn't exhaustive.
-- Design-system/i18n (per `review-config.md` path rules): raw `<button>/<select>/<textarea>`, `[#hex]`, missing en+de keys, `react-i18next` imported directly.
+- Design-system/i18n (per `review-config.md` + `.coderabbit.yaml` path rules): raw `<button>/<select>/<textarea>`, `[#hex]`, missing en+de keys, `react-i18next` imported directly. **Dead i18n keys** a diff orphans (a removed call site leaving a now-unreferenced key) are a 🟡 cleanup.
+
+**Test quality** (review the diff's _changed test files_ + coverage of changed source, per `.coderabbit.yaml`'s test path rule): weak/tautological assertions, over-mocking that hides the real path, flakiness, and **mount-only coverage** — a stateful component changed without a prop-change/`rerender` test, or a changed edge/error/security path with no test. Missing coverage of a normal path is 🟡; an untested error/security path the diff introduced is 🟠.
 
 ## Severity & verdict
 

--- a/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
+++ b/apps/tauri/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
@@ -16,8 +16,9 @@ import { ComingSoonBadge } from '../ComingSoonBadge';
 import { PrefilledBadge } from '../PrefilledBadge';
 import { WizardField } from '../WizardField';
 
-// Matches the @ajh/ui Dropdown / LocationInput trigger (h-9, same border &
-// bg) so text inputs sit flush with the dropdowns beside them on the same row.
+// Matches @ajh/ui LocationInput trigger (h-9, same border & bg) so text inputs
+// sit flush with sibling controls on the same row. The Dropdown uses tone="field"
+// for matching border/bg, plus className="h-9 shadow-none" for height alignment.
 const inputCls =
   'w-full h-9 rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 text-xs text-foreground/80 placeholder:text-foreground/25 outline-none focus:border-brand/40 transition-colors';
 
@@ -261,6 +262,8 @@ export function StepTarget({ prefilled }: StepTargetProps) {
                 value={field.value}
                 onChange={field.onChange}
                 placeholder={t('autopilot.wizard.target.anyTime')}
+                tone="field"
+                className="h-9 shadow-none"
               />
             </WizardField>
           )}

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
@@ -15,6 +15,20 @@ vi.mock('@ajh/translations', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+// ExternalLink uses useAppClient (requires AppClientProvider) — stub it with a
+// plain anchor so tests that reach the Job-ad source tab don't need a provider.
+vi.mock('@/components/ui/ExternalLink', () => ({
+  ExternalLink: ({
+    href,
+    children,
+    ...rest
+  }: { href: string; children: React.ReactNode } & React.HTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
 // EditableOutput mock — exposes onChange/onBlur/isPending + renders previewSlot.
 // Uses divs (not raw <textarea>/<button>) to stay clear of the @ajh/ui ESLint rule.
 // The mock is intentionally richer than the original so edit/debounce/preview tests

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/JobAdView.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/JobAdView.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * JobAdView — unit tests for the truncation/paste UX fix + a11y wiring.
+ *
+ * Covers:
+ *   1. Default tab selection — source when no description or truncated; summary otherwise.
+ *   2. TextArea always present on the source tab (even with empty/failed/no-description states).
+ *   3. onJobDescChange fires when the textarea value changes.
+ *   4. Truncation hint visible iff description ends with ellipsis.
+ *   5. ExternalLink "view job" rendered only when jobUrl is provided.
+ *   6. TextArea a11y: short aria-label (tab key, NOT editHelper sentence) + aria-describedby wiring.
+ *
+ * Strategy:
+ *  - `@ajh/translations` returns keys as-is (deterministic assertions).
+ *  - `@ajh/ui` primitives that this component uses render their child content /
+ *    pass through props we assert on; we do NOT stub them — real primitives
+ *    catch future API changes early.
+ *  - `@/components/ui/ExternalLink` and `@/lib/generate` are real imports
+ *    (no network, pure).
+ *  - noUncheckedIndexedAccess: all array index accesses are guarded.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TEST_IDS } from '@ajh/test-ids';
+
+// ── i18n ──────────────────────────────────────────────────────────────────────
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// ── ExternalLink — thin anchor wrapper, no special provider needed ─────────────
+
+vi.mock('@/components/ui/ExternalLink', () => ({
+  ExternalLink: ({
+    href,
+    children,
+    ...rest
+  }: { href: string; children: React.ReactNode } & React.HTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// ── OUTPUT_LANGUAGES — only the shape matters; stub to a minimal list ──────────
+
+vi.mock('@/lib/generate', () => ({
+  OUTPUT_LANGUAGES: [{ code: 'en', endonym: 'English' }],
+}));
+
+// ── Import component AFTER all mocks ─────────────────────────────────────────
+
+import { JobAdView } from './JobAdView';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeProps(overrides: Partial<Parameters<typeof JobAdView>[0]> = {}) {
+  return {
+    jobDesc: 'Full job description with enough text.',
+    onJobDescChange: vi.fn(),
+    summary: '',
+    generating: false,
+    error: null,
+    onGenerateSummary: vi.fn(),
+    language: 'en',
+    onLanguageChange: vi.fn(),
+    hasDesc: true,
+    fetchingDesc: false,
+    jobUrl: undefined,
+    ...overrides,
+  };
+}
+
+// ── 1. Default tab selection ──────────────────────────────────────────────────
+
+describe('JobAdView — default tab selection', () => {
+  it('defaults to summary tab when description is present and not truncated', () => {
+    render(<JobAdView {...makeProps()} />);
+    // Summary content area is visible (no jobAdViewTextarea at initial render)
+    // because we start on the summary tab. The textarea is behind the source tab.
+    expect(screen.queryByTestId(TEST_IDS.documents.jobAdViewTextarea)).not.toBeInTheDocument();
+    // The "Generate summary" button is rendered (summary tab empty state).
+    expect(screen.getByText('autopilot.apply.jobAdView.generateSummary')).toBeInTheDocument();
+  });
+
+  it('defaults to source tab when hasDesc is false', () => {
+    render(<JobAdView {...makeProps({ hasDesc: false, jobDesc: '' })} />);
+    expect(screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea)).toBeInTheDocument();
+  });
+
+  it('defaults to source tab when jobDesc ends with "…" (unicode ellipsis)', () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Some partial description…', hasDesc: true })} />);
+    expect(screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea)).toBeInTheDocument();
+  });
+
+  it('defaults to source tab when jobDesc ends with "..." (three dots)', () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Partial...', hasDesc: true })} />);
+    expect(screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea)).toBeInTheDocument();
+  });
+
+  it('defaults to summary tab when jobDesc ends with a normal character (not truncated)', () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Normal full description.', hasDesc: true })} />);
+    expect(screen.queryByTestId(TEST_IDS.documents.jobAdViewTextarea)).not.toBeInTheDocument();
+  });
+});
+
+// ── 2. TextArea always present on source tab ──────────────────────────────────
+
+describe('JobAdView — TextArea always present on source tab', () => {
+  async function switchToSource() {
+    // Click the "Job ad" segmented control option (key passed through as-is by mock).
+    await userEvent.click(screen.getByText('autopilot.apply.tabs.jobAd'));
+  }
+
+  it('shows an editable TextArea even when jobDesc is empty and hasDesc is false', async () => {
+    render(<JobAdView {...makeProps({ hasDesc: false, jobDesc: '' })} />);
+    // Already on source tab (default for no-desc).
+    const textarea = screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea);
+    expect(textarea).toBeInTheDocument();
+  });
+
+  it('shows the paste placeholder when jobDesc is empty', () => {
+    render(<JobAdView {...makeProps({ hasDesc: false, jobDesc: '' })} />);
+    const textarea = screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea);
+    // Placeholder is set via the `placeholder` prop on TextArea → rendered on the underlying element.
+    expect(textarea).toHaveAttribute('placeholder', 'autopilot.apply.jobAdView.pasteHint');
+  });
+
+  it('shows an editable TextArea on source tab even when starting on summary (normal desc)', async () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Normal full description.', hasDesc: true })} />);
+    // Starts on summary — switch to source.
+    await switchToSource();
+    expect(screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea)).toBeInTheDocument();
+  });
+
+  it('does NOT show the TextArea while fetchingDesc is true (loading state takes precedence)', async () => {
+    render(<JobAdView {...makeProps({ hasDesc: false, jobDesc: '', fetchingDesc: true })} />);
+    // The spinner/loading state replaces the textarea while fetching.
+    expect(screen.queryByTestId(TEST_IDS.documents.jobAdViewTextarea)).not.toBeInTheDocument();
+    expect(screen.getByText('autopilot.apply.fetchingDescription')).toBeInTheDocument();
+  });
+});
+
+// ── 3. onJobDescChange fires on edit ─────────────────────────────────────────
+
+describe('JobAdView — onJobDescChange callback', () => {
+  it('calls onJobDescChange once per keystroke when the user types in the textarea', async () => {
+    const onJobDescChange = vi.fn();
+    render(<JobAdView {...makeProps({ hasDesc: false, jobDesc: '', onJobDescChange })} />);
+    const textarea = screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea);
+    await userEvent.type(textarea, 'hello');
+    // Controlled component fires one change event per character.
+    expect(onJobDescChange).toHaveBeenCalledTimes(5);
+    // Each call receives the current target value (a single char since the prop
+    // doesn't update between renders in this controlled-stub setup).
+    expect(onJobDescChange).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('calls onJobDescChange when the user clears and re-types in the textarea', async () => {
+    const onJobDescChange = vi.fn();
+    render(<JobAdView {...makeProps({ hasDesc: true, jobDesc: 'Partial…', onJobDescChange })} />);
+    // Truncated desc — already on source tab.
+    const textarea = screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea);
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, 'New text');
+    expect(onJobDescChange).toHaveBeenCalled();
+  });
+});
+
+// ── 4. Truncation hint ────────────────────────────────────────────────────────
+
+describe('JobAdView — truncation hint', () => {
+  it('shows the truncation hint when jobDesc ends with unicode ellipsis', () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Short snippet…', hasDesc: true })} />);
+    expect(screen.getByText('autopilot.apply.jobAdView.truncatedHint')).toBeInTheDocument();
+  });
+
+  it('shows the truncation hint when jobDesc ends with three dots', () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Short snippet...', hasDesc: true })} />);
+    expect(screen.getByText('autopilot.apply.jobAdView.truncatedHint')).toBeInTheDocument();
+  });
+
+  it('does NOT show the truncation hint for a normal (non-truncated) description', async () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Normal full description.', hasDesc: true })} />);
+    // Switch to source tab to inspect.
+    await userEvent.click(screen.getByText('autopilot.apply.tabs.jobAd'));
+    expect(screen.queryByText('autopilot.apply.jobAdView.truncatedHint')).not.toBeInTheDocument();
+  });
+
+  it('does NOT show the truncation hint when jobDesc is empty (no text to hint about)', () => {
+    render(<JobAdView {...makeProps({ hasDesc: false, jobDesc: '' })} />);
+    expect(screen.queryByText('autopilot.apply.jobAdView.truncatedHint')).not.toBeInTheDocument();
+  });
+});
+
+// ── 5. ExternalLink / viewJob ─────────────────────────────────────────────────
+
+describe('JobAdView — view job link', () => {
+  it('renders the "view job" link on source tab when jobUrl is provided', async () => {
+    render(
+      <JobAdView
+        {...makeProps({ hasDesc: false, jobDesc: '', jobUrl: 'https://example.com/job' })}
+      />
+    );
+    // Already on source tab (no desc).
+    const link = screen.getByText('autopilot.viewJob').closest('a');
+    expect(link).toHaveAttribute('href', 'https://example.com/job');
+  });
+
+  it('does NOT render the "view job" link when jobUrl is undefined', () => {
+    render(<JobAdView {...makeProps({ hasDesc: false, jobDesc: '', jobUrl: undefined })} />);
+    expect(screen.queryByText('autopilot.viewJob')).not.toBeInTheDocument();
+  });
+
+  it('renders the "view job" link even on the source tab when description is present', async () => {
+    render(
+      <JobAdView
+        {...makeProps({
+          jobDesc: 'Normal full description.',
+          hasDesc: true,
+          jobUrl: 'https://example.com/job',
+        })}
+      />
+    );
+    // Switch to source tab.
+    await userEvent.click(screen.getByText('autopilot.apply.tabs.jobAd'));
+    const link = screen.getByText('autopilot.viewJob').closest('a');
+    expect(link).toHaveAttribute('href', 'https://example.com/job');
+  });
+});
+
+// ── 6. TextArea a11y — aria-label + aria-describedby ─────────────────────────
+
+describe('JobAdView — TextArea a11y wiring', () => {
+  it('uses the short tab-label key as aria-label (NOT the full editHelper sentence)', () => {
+    render(<JobAdView {...makeProps({ hasDesc: false, jobDesc: '' })} />);
+    const textarea = screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea);
+    // aria-label must be the tab key (short name), not the full editHelper description
+    expect(textarea).toHaveAttribute('aria-label', 'autopilot.apply.tabs.jobAd');
+    expect(textarea).not.toHaveAttribute('aria-label', 'autopilot.apply.jobAdView.editHelper');
+  });
+
+  it('references the helper paragraph id via aria-describedby (non-truncated)', async () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Normal full description.', hasDesc: true })} />);
+    await userEvent.click(screen.getByText('autopilot.apply.tabs.jobAd'));
+    const textarea = screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea);
+    expect(textarea).toHaveAttribute('aria-describedby', 'job-ad-edit-helper');
+    // The helper paragraph itself must carry the stable id
+    const helperPara = document.getElementById('job-ad-edit-helper');
+    expect(helperPara).toBeInTheDocument();
+    expect(helperPara).toHaveTextContent('autopilot.apply.jobAdView.editHelper');
+  });
+
+  it('includes the truncation-hint id in aria-describedby when a truncated description is shown', () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Short snippet…', hasDesc: true })} />);
+    // Truncated → starts on source tab automatically
+    const textarea = screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea);
+    expect(textarea).toHaveAttribute(
+      'aria-describedby',
+      'job-ad-edit-helper job-ad-truncated-hint'
+    );
+    // Both paragraphs must carry their stable ids
+    expect(document.getElementById('job-ad-edit-helper')).toBeInTheDocument();
+    expect(document.getElementById('job-ad-truncated-hint')).toBeInTheDocument();
+  });
+
+  it('does NOT include truncation-hint id when description is not truncated', async () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Normal full description.', hasDesc: true })} />);
+    await userEvent.click(screen.getByText('autopilot.apply.tabs.jobAd'));
+    const textarea = screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea);
+    // Only helper id, no truncation-hint id
+    expect(textarea).toHaveAttribute('aria-describedby', 'job-ad-edit-helper');
+    expect(textarea).not.toHaveAttribute(
+      'aria-describedby',
+      expect.stringContaining('job-ad-truncated-hint')
+    );
+  });
+});

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/JobAdView.test.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/JobAdView.test.tsx
@@ -280,3 +280,85 @@ describe('JobAdView — TextArea a11y wiring', () => {
     );
   });
 });
+
+// ── 7. Tab resync on posting change ──────────────────────────────────────────
+
+describe('JobAdView — tab resync on posting change', () => {
+  it('does NOT switch tab when jobDesc changes but jobUrl stays the same (no-yank guard)', () => {
+    // Start on source tab (truncated posting).
+    const { rerender } = render(
+      <JobAdView
+        {...makeProps({ jobUrl: 'https://example.com/job/1', jobDesc: 'Partial…', hasDesc: true })}
+      />
+    );
+    // Confirm we started on source.
+    expect(screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea)).toBeInTheDocument();
+
+    // Simulate the user pasting a full description — jobDesc changes, jobUrl stays the same.
+    rerender(
+      <JobAdView
+        {...makeProps({
+          jobUrl: 'https://example.com/job/1',
+          jobDesc: 'Full description that is no longer truncated.',
+          hasDesc: true,
+        })}
+      />
+    );
+
+    // Tab must NOT flip to summary — the user is still editing in the textarea.
+    expect(screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea)).toBeInTheDocument();
+  });
+
+  it('re-derives to summary when a new jobUrl arrives with a full description', () => {
+    // Posting #1 — truncated, starts on source.
+    const { rerender } = render(
+      <JobAdView
+        {...makeProps({ jobUrl: 'https://example.com/job/1', jobDesc: 'Partial…', hasDesc: true })}
+      />
+    );
+    expect(screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea)).toBeInTheDocument();
+
+    // Navigate to posting #2 — full description, different URL.
+    rerender(
+      <JobAdView
+        {...makeProps({
+          jobUrl: 'https://example.com/job/2',
+          jobDesc: 'Full description with plenty of content.',
+          hasDesc: true,
+        })}
+      />
+    );
+
+    // Tab should re-derive to summary (full desc, not truncated).
+    expect(screen.queryByTestId(TEST_IDS.documents.jobAdViewTextarea)).not.toBeInTheDocument();
+    expect(screen.getByText('autopilot.apply.jobAdView.generateSummary')).toBeInTheDocument();
+  });
+
+  it('re-derives to source when a new jobUrl arrives with no description (hasDesc false)', () => {
+    // Posting #1 — full description, starts on summary.
+    const { rerender } = render(
+      <JobAdView
+        {...makeProps({
+          jobUrl: 'https://example.com/job/1',
+          jobDesc: 'Full description with plenty of content.',
+          hasDesc: true,
+        })}
+      />
+    );
+    expect(screen.queryByTestId(TEST_IDS.documents.jobAdViewTextarea)).not.toBeInTheDocument();
+
+    // Navigate to posting #2 — no description.
+    rerender(
+      <JobAdView
+        {...makeProps({
+          jobUrl: 'https://example.com/job/2',
+          jobDesc: '',
+          hasDesc: false,
+        })}
+      />
+    );
+
+    // Tab should re-derive to source (no desc).
+    expect(screen.getByTestId(TEST_IDS.documents.jobAdViewTextarea)).toBeInTheDocument();
+  });
+});

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink as ExternalLinkIcon, Loader2, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 
+import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
 import {
   Button,
@@ -28,11 +29,20 @@ interface Props {
   jobUrl?: string;
 }
 
+/** Returns true when the text ends with the ellipsis character or three dots. */
+function looksPartial(text: string) {
+  const t = text.trimEnd();
+  return t.endsWith('…') || t.endsWith('...');
+}
+
 /**
  * Shared two-tab job-ad surface (Summary | Job Ad) used by both the wizard's
  * first step and the results panel's job-ad tab. The Summary sub-tab lazily
  * streams an AI summary on an explicit click; the Job Ad sub-tab shows the raw
  * posting as an EDITABLE textarea so a bad scrape can be fixed before tailoring.
+ *
+ * Default tab is `source` when the description is missing or looks truncated so
+ * paste is immediately discoverable; otherwise `summary`.
  */
 export function JobAdView({
   jobDesc,
@@ -48,7 +58,13 @@ export function JobAdView({
   jobUrl,
 }: Props) {
   const { t } = useTranslation();
-  const [tab, setTab] = useState<'summary' | 'source'>('summary');
+
+  // Start on `source` when there's nothing to show or the snippet is truncated —
+  // that's when paste is the most useful action. `summary` otherwise (normal case).
+  const truncated = looksPartial(jobDesc);
+  const [tab, setTab] = useState<'summary' | 'source'>(
+    !hasDesc || truncated ? 'source' : 'summary'
+  );
 
   // Sourced from OUTPUT_LANGUAGES (the single locale source of truth) so each value
   // is a locale CODE the generation pipeline's safeLocale accepts — display names
@@ -133,33 +149,41 @@ export function JobAdView({
             <Loader2 size={12} className="animate-spin" />
             {t('autopilot.apply.fetchingDescription')}
           </div>
-        ) : hasDesc || jobDesc ? (
+        ) : (
+          // Source tab — always editable. Empty when scrape failed / no description captured.
           <div className="flex min-h-0 flex-1 flex-col gap-1">
+            {truncated && (
+              <p
+                id="job-ad-truncated-hint"
+                className="shrink-0 rounded-md border border-amber-400/20 bg-amber-400/5 px-2 py-1 text-[10px] text-amber-200/80"
+              >
+                {t('autopilot.apply.jobAdView.truncatedHint')}
+              </p>
+            )}
             <TextArea
               variant="glass"
               value={jobDesc}
               onChange={(e) => onJobDescChange(e.target.value)}
+              placeholder={t('autopilot.apply.jobAdView.pasteHint')}
               className="h-full flex-1 resize-none text-[11px] leading-relaxed"
-              aria-label={t('autopilot.apply.jobAdView.editHelper')}
+              aria-label={t('autopilot.apply.tabs.jobAd')}
+              aria-describedby={
+                truncated ? 'job-ad-edit-helper job-ad-truncated-hint' : 'job-ad-edit-helper'
+              }
+              data-testid={TEST_IDS.documents.jobAdViewTextarea}
             />
-            <p className="shrink-0 text-[10px] text-foreground/35">
+            <p id="job-ad-edit-helper" className="shrink-0 text-[10px] text-foreground/35">
               {t('autopilot.apply.jobAdView.editHelper')}
             </p>
-          </div>
-        ) : jobUrl ? (
-          <div className="rounded-lg border border-amber-400/20 bg-amber-400/5 px-3 py-2 text-[11px] text-amber-200/80">
-            {t('autopilot.apply.loadFailed')}{' '}
-            <ExternalLink
-              href={jobUrl}
-              className="inline-flex items-center gap-0.5 font-medium text-brand-soft hover:underline"
-            >
-              {t('autopilot.viewJob')}
-              <ExternalLinkIcon size={10} />
-            </ExternalLink>
-          </div>
-        ) : (
-          <div className="rounded-lg border border-amber-400/20 bg-amber-400/5 px-3 py-2 text-[11px] text-amber-200/80">
-            {t('autopilot.apply.noDescription')}
+            {jobUrl && (
+              <ExternalLink
+                href={jobUrl}
+                className="shrink-0 inline-flex items-center gap-0.5 self-start text-[10px] font-medium text-brand-soft hover:underline"
+              >
+                {t('autopilot.viewJob')}
+                <ExternalLinkIcon size={10} />
+              </ExternalLink>
+            )}
           </div>
         )}
       </div>

--- a/apps/tauri/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
+++ b/apps/tauri/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink as ExternalLinkIcon, Loader2, Sparkles } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
@@ -65,6 +65,16 @@ export function JobAdView({
   const [tab, setTab] = useState<'summary' | 'source'>(
     !hasDesc || truncated ? 'source' : 'summary'
   );
+
+  // Re-pick the default sub-tab only when the POSTING changes (new jobUrl), not on
+  // every jobDesc edit — pasting into the source textarea changes `truncated`, and
+  // resyncing on that would yank the user out of the textarea they're editing.
+  const prevJobUrl = useRef(jobUrl);
+  useEffect(() => {
+    if (prevJobUrl.current === jobUrl) return;
+    prevJobUrl.current = jobUrl;
+    setTab(!hasDesc || looksPartial(jobDesc) ? 'source' : 'summary');
+  }, [jobUrl, hasDesc, jobDesc]);
 
   // Sourced from OUTPUT_LANGUAGES (the single locale source of truth) so each value
   // is a locale CODE the generation pipeline's safeLocale accepts — display names

--- a/landing/agent-system.html
+++ b/landing/agent-system.html
@@ -111,13 +111,16 @@ hr.scrawl{border:none; height:1px; margin:54px auto; width:min(560px,90%);
 .route h3{font-family:var(--head); font-weight:700; letter-spacing:-.01em; font-size:19px; margin:0 0 2px; color:var(--text)}
 .route .area{font-family:var(--mono); font-size:13px; color:var(--muted); margin:0 0 14px}
 .flow{list-style:none; margin:0; padding:0}
-.flow li{display:flex; gap:10px; align-items:baseline; margin:0 0 10px; line-height:1.45}
+.flow li{display:flex; flex-wrap:wrap; gap:4px 10px; align-items:baseline; margin:0 0 10px; line-height:1.45}
 .flow .lbl{font-family:var(--mono); font-size:12px; color:var(--muted); min-width:78px; flex:0 0 78px; text-transform:uppercase; letter-spacing:.04em; padding-top:1px}
 .flow .who{font-size:15px}
 .flow .who b{font-family:var(--mono); font-weight:400; font-size:13px; background:var(--surface-2); padding:2px 7px; border-radius:6px; color:var(--text); border:1px solid var(--border)}
 .flow .who .crit{background:var(--critic-tint); border-color:rgba(244,114,182,.4); color:var(--text)}
 .flow .who .sec{background:var(--author-tint); border-color:rgba(52,211,153,.4); color:var(--text)}
-.flow .why{font-size:14px; color:var(--muted)}
+.flow .who .gate{background:rgba(251,191,36,.12); border-color:rgba(251,191,36,.4); color:var(--text)}
+.flow .why{font-size:14px; color:var(--muted); flex-basis:100%; margin-left:88px}
+.flow li.area{flex-wrap:nowrap}
+.flow li.area .why{flex-basis:auto; margin-left:0}
 
 /* route panel re-trigger animation */
 @media (prefers-reduced-motion: no-preference){
@@ -130,6 +133,7 @@ hr.scrawl{border:none; height:1px; margin:54px auto; width:min(560px,90%);
   .route.swap .flow li:nth-child(2){animation-delay:.15s}
   .route.swap .flow li:nth-child(3){animation-delay:.2s}
   .route.swap .flow li:nth-child(4){animation-delay:.25s}
+  .route.swap .flow li:nth-child(5){animation-delay:.3s}
   @keyframes route-in{from{opacity:0; transform:translateY(10px)} to{opacity:1; transform:none}}
 }
 
@@ -438,10 +442,18 @@ footer{margin-top:64px; text-align:center}
       </div>
     </div>
     <div class="step">
+      <div class="connector" aria-hidden="true"></div>
       <div class="num">8</div>
       <div class="body">
         <h3>project-steward closes <span class="tag">sole doc writer</span></h3>
         <p><span class="a">project-steward</span> syncs <span class="a">docs/</span> + <span class="a">docs/knowledge</span>, persists any lesson, and runs <span class="a">graphify update .</span> + <span class="a">codegraph sync</span> so the graphs match reality again.</p>
+      </div>
+    </div>
+    <div class="step">
+      <div class="num">9</div>
+      <div class="body">
+        <h3>pr-reviewer gate <span class="tag">before the PR</span></h3>
+        <p>The final internal pass before <span class="a">git push</span>. <span class="a">pr-reviewer</span> runs the repo's real tools (typecheck, lint, clippy, tests) + cross-file blast-radius + a verification gate so CodeRabbit finds less. 🔴+🟠 findings block the PR. Invoke with <span class="a">/review</span>.</p>
       </div>
     </div>
   </div>
@@ -608,35 +620,44 @@ footer{margin-top:64px; text-align:center}
         ['detected','UI / renderer code — a focus-ring is a renderer + a11y concern.'],
         ['author','frontend-author','author','adds the focus style on the @ajh/ui primitive'],
         ['critic','frontend-reviewer','crit','checks ports-&-adapters + design tokens'],
-        ['critic','ui-ux-expert','crit','the a11y / visual taste lens — is the ring actually visible?'] ] },
+        ['critic','ui-ux-expert','crit','the a11y / visual taste lens — is the ring actually visible?'],
+        ['gate','pr-reviewer','gate','final pre-PR gate — runs the real tools + blast-radius before the PR (/review)'] ] },
     ats:    { title:'ATS score seems wrong', area:'commands/match_resume.rs, validate/, recommend/ → ATS scoring',
       rows:[
         ['detected','Scoring / matching logic — owned by the job-match domain, not export formatting.'],
         ['author','job-match-author','author','fixes the scoring kernel / keyword extraction'],
-        ['critic','job-match-expert','crit','audits match quality + recommendation correctness'] ] },
+        ['critic','job-match-expert','crit','audits match quality + recommendation correctness'],
+        ['gate','pr-reviewer','gate','final pre-PR gate — runs the real tools + blast-radius before the PR (/review)'] ] },
     ipc:    { title:'Add an IPC command for X', area:'commands/**, commands/mod.rs, packages/shared/** → backend + IPC',
       rows:[
         ['detected','New IPC surface — Rust backend, and a new attack surface.'],
         ['author','rust-backend-author','author','implements the command + wires the contract'],
         ['critic','rust-backend-architect','crit','reviews boundaries, errors, data integrity'],
-        ['secondary','tauri-security-reviewer','sec','default risk Secondary — every new command is IPC attack surface'] ] },
+        ['secondary','tauri-security-reviewer','sec','default risk Secondary — every new command is IPC attack surface'],
+        ['gate','pr-reviewer','gate','final pre-PR gate — runs the real tools + blast-radius before the PR (/review)'] ] },
     pdf:    { title:'PDF export overflows a page', area:'export/**, layout/**, measure/** → resume/export',
       rows:[
         ['detected','Export rendering + pagination — the resume/export domain (perf-sensitive).'],
         ['author','pdf-docx-generator','author','fixes layout / pagination in the renderer'],
         ['critic','resume-export-expert','crit','audits ATS-safe structure + template correctness'],
-        ['secondary','performance-profiler','sec','export is a hot path — perf lens rides along'] ] },
+        ['secondary','performance-profiler','sec','export is a hot path — perf lens rides along'],
+        ['gate','pr-reviewer','gate','final pre-PR gate — runs the real tools + blast-radius before the PR (/review)'] ] },
     scrape: { title:'Scraper stopped matching LinkedIn', area:'scraping/**, browser/**, SCRAPERS registry → scraping',
       rows:[
         ['detected','Selector resilience + browser automation — the scraping domain.'],
         ['author','scraping-applier-author','author','repairs the LinkedIn selectors in the registry'],
-        ['critic','scraping-applier-expert','crit','audits selector resilience + workflow reliability'] ] },
+        ['critic','scraping-applier-expert','crit','audits selector resilience + workflow reliability'],
+        ['gate','pr-reviewer','gate','final pre-PR gate — runs the real tools + blast-radius before the PR (/review)'] ] },
   };
 
   function routeHTML(r){
     var rows = r.rows.map(function(row){
       if(row[0]==='detected'){
-        return '<li><span class="lbl">area</span><span class="why">'+esc(row[1])+'</span></li>';
+        return '<li class="area"><span class="lbl">area</span><span class="why">'+esc(row[1])+'</span></li>';
+      }
+      if(row[0]==='gate'){
+        return '<li><span class="lbl">gate</span><span class="who"><b class="gate">'+esc(row[1])+'</b></span>'+
+               '<span class="why">— '+esc(row[3])+'</span></li>';
       }
       var lbl = row[0]==='author' ? 'author' : row[0]==='secondary' ? 'secondary' : 'critic';
       var cls = row[2]==='author' ? '' : row[2]==='sec' ? 'sec' : 'crit';

--- a/packages/test-ids/src/test-ids.ts
+++ b/packages/test-ids/src/test-ids.ts
@@ -94,6 +94,7 @@ export const TEST_IDS = {
     pdfPreview: 'pdf-preview',
     thinkingBubble: 'thinking-bubble',
     stepDots: 'step-dots',
+    jobAdViewTextarea: 'job-ad-view-textarea',
   },
 
   /** Resume shared components (ResumeInputCard) */

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1252,8 +1252,6 @@
       "back": "Zurück zum Autopilot",
       "match": "Übereinstimmung",
       "jobDescription": "Stellenbeschreibung",
-      "noDescription": "Für diesen Job wurde keine Beschreibung erfasst.",
-      "loadFailed": "Diese Anzeige konnte nicht geladen werden — sie ist möglicherweise geschlossen oder erfordert eine Anmeldung.",
       "fetchingDescription": "Stellenbeschreibung wird abgerufen…",
       "generate": "Generieren",
       "generating": "Generiere…",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1299,7 +1299,9 @@
         "summaryHint": "Erhalte eine KI-Zusammenfassung dieser Anzeige — wichtigste Aufgaben, Anforderungen und Signale.",
         "generating": "Stellenanzeige wird zusammengefasst…",
         "editHelper": "Änderungen hier werden für die Generierung verwendet — korrigiere einen fehlerhaften Scrape vor dem Anpassen.",
-        "summaryLanguage": "Zusammenfassungssprache"
+        "summaryLanguage": "Zusammenfassungssprache",
+        "pasteHint": "Vollständige Stellenanzeige hier einfügen…",
+        "truncatedHint": "Dies sieht wie ein unvollständiges Inserat aus — füge die vollständige Anzeige ein, um das beste Ergebnis zu erzielen."
       },
       "tryAgain": "Erneut versuchen",
       "hintNoResume": "Fügen Sie Ihren Lebenslauf hinzu, um zu generieren",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1295,7 +1295,9 @@
         "summaryHint": "Get an AI summary of this posting — key responsibilities, requirements, and signals.",
         "generating": "Summarizing the job ad…",
         "editHelper": "Edits here are used for generation — fix a bad scrape before tailoring.",
-        "summaryLanguage": "Summary language"
+        "summaryLanguage": "Summary language",
+        "pasteHint": "Paste the full job ad here…",
+        "truncatedHint": "This looks like a partial listing — paste the full ad for the best result."
       },
       "tryAgain": "Try again",
       "hintNoResume": "Add your resume to generate",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1248,8 +1248,6 @@
       "back": "Back to autopilot",
       "match": "match",
       "jobDescription": "Job description",
-      "noDescription": "No description was captured for this job.",
-      "loadFailed": "Couldn't load this posting — it may be closed or require sign-in.",
       "fetchingDescription": "Fetching job description…",
       "generate": "Generate",
       "generating": "Generating…",

--- a/packages/ui/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.test.tsx
@@ -224,6 +224,56 @@ describe('Dropdown', () => {
     });
   });
 
+  describe('className passthrough', () => {
+    it('merges className onto the trigger button, overriding the default height', () => {
+      render(
+        <Dropdown options={LANG_OPTIONS} value="" onChange={() => {}} className="h-9 shadow-none" />
+      );
+      const trigger = screen.getByRole('button');
+      // className is appended last inside cn() so twMerge resolves h-9 over the default h-8
+      expect(trigger.className).toContain('h-9');
+      expect(trigger.className).not.toMatch(/\bh-8\b/);
+    });
+  });
+
+  describe('tone="field"', () => {
+    it('keeps a brand border when open and does not retain the rest border-white class', async () => {
+      render(<Dropdown options={LANG_OPTIONS} value="" onChange={() => {}} tone="field" />);
+      const trigger = screen.getByRole('button');
+      // Open the dropdown
+      await userEvent.click(trigger);
+      await screen.findByRole('listbox');
+      // Must have brand border in open state
+      expect(trigger.className).toMatch(/border-brand/);
+      // Must NOT retain the rest-state white border class once open
+      expect(trigger.className).not.toMatch(/border-white/);
+    });
+
+    it('applies text-foreground/40 to the chevron (matching form-field icon opacity)', () => {
+      render(<Dropdown options={LANG_OPTIONS} value="" onChange={() => {}} tone="field" />);
+      // The ChevronDown svg is the last svg inside the trigger (SVGAnimatedString — use getAttribute)
+      const trigger = screen.getByRole('button');
+      const chevron = trigger.querySelector('svg:last-of-type');
+      expect(chevron).not.toBeNull();
+      if (!chevron) return;
+      const cls = chevron.getAttribute('class') ?? '';
+      // text-foreground/40 must be on the chevron, not the dimmer /30 (default) or brand (primary)
+      expect(cls).toContain('text-foreground/40');
+      expect(cls).not.toContain('text-foreground/30');
+    });
+
+    it('keeps the default chevron at text-foreground/30 when tone is default', () => {
+      render(<Dropdown options={LANG_OPTIONS} value="" onChange={() => {}} tone="default" />);
+      const trigger = screen.getByRole('button');
+      const chevron = trigger.querySelector('svg:last-of-type');
+      expect(chevron).not.toBeNull();
+      if (!chevron) return;
+      const cls = chevron.getAttribute('class') ?? '';
+      expect(cls).toContain('text-foreground/30');
+      expect(cls).not.toContain('text-foreground/40');
+    });
+  });
+
   describe('listClassName override', () => {
     it('applies the custom class to the list container', async () => {
       render(

--- a/packages/ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.tsx
@@ -37,11 +37,16 @@ export interface DropdownProps {
   /** Trigger height — 'sm' matches Button size="sm" (h-7); 'md' is the default, matches Button md (h-8). */
   size?: 'sm' | 'md';
   /**
-   * Trigger accent. `default` is the neutral glass trigger; `primary` tints the
-   * trigger with the brand colour (e.g. an application-status selector). Opt-in
-   * per call site — other dropdowns stay neutral.
+   * Trigger accent.
+   * - `default` — neutral glass trigger (border-clear / bg-field).
+   * - `primary` — brand-tinted trigger (e.g. application-status selector).
+   * - `field`   — form-field appearance matching Input/NumberField controls:
+   *               border-white/[0.06], bg-white/[0.03], text-foreground/80 at
+   *               rest; brand border preserved when open (no twMerge regression).
    */
-  tone?: 'default' | 'primary';
+  tone?: 'default' | 'primary' | 'field';
+  /** Extra classes merged onto the trigger button — appended last so they reliably override height/bg/border defaults. */
+  className?: string;
 }
 
 export function Dropdown({
@@ -56,6 +61,7 @@ export function Dropdown({
   listClassName,
   size = 'md',
   tone = 'default',
+  className,
 }: DropdownProps) {
   const generatedId = useId();
   const id = idProp ?? generatedId;
@@ -184,12 +190,20 @@ export function Dropdown({
                 'border border-brand/30 bg-brand/10 text-brand-soft',
                 open ? 'border-brand/55 bg-brand/15' : 'hover:border-brand/45 hover:bg-brand/15'
               )
-            : cn(
-                'border border-[var(--border-clear)] bg-field',
-                open
-                  ? 'border-brand/45 bg-muted text-foreground/90'
-                  : 'text-foreground/75 hover:border-[var(--border-clear)] hover:bg-muted hover:text-foreground/90'
-              )
+            : tone === 'field'
+              ? cn(
+                  'border border-white/[0.06] bg-white/[0.03] text-foreground/80',
+                  open
+                    ? 'border-brand/45 bg-white/[0.05] text-foreground/90'
+                    : 'hover:border-white/10 hover:bg-white/[0.04] hover:text-foreground/90'
+                )
+              : cn(
+                  'border border-[var(--border-clear)] bg-field',
+                  open
+                    ? 'border-brand/45 bg-muted text-foreground/90'
+                    : 'text-foreground/75 hover:border-[var(--border-clear)] hover:bg-muted hover:text-foreground/90'
+                ),
+          className
         )}
       >
         <span className="flex min-w-0 items-center gap-2">
@@ -202,7 +216,11 @@ export function Dropdown({
           size={12}
           className={cn(
             'shrink-0 transition-transform duration-150',
-            tone === 'primary' ? 'text-brand-soft/70' : 'text-foreground/30',
+            tone === 'primary'
+              ? 'text-brand-soft/70'
+              : tone === 'field'
+                ? 'text-foreground/40'
+                : 'text-foreground/30',
             open && 'rotate-180'
           )}
         />


### PR DESCRIPTION
## What & why

Three independent fixes from one debugging session, plus an import/export audit (no code changes needed there).

### 1. `feat` — paste the full job ad when scraping is blocked or partial
Aggregators like **Adzuna** return a *truncated* description (ends with `…`) and **429-block anonymous server-side fetches** — verified by fetching `adzuna.de/details/{id}` from both a datacenter and a residential IP (both got `HTTP 429`). The renderer already tries to re-resolve full text under an 800-char floor (`useResolveJobUrl`), but it can't get past the 429, so the Tailor view falls back to the teaser.

Since the full text isn't obtainable by scraping, the robust fix is a **manual paste fallback**: the editable job-ad textarea (which already existed, buried behind a sub-tab) is now always available on the **Job Ad** sub-tab — including when a scrape fully fails — defaults open when the description is missing or looks truncated, and shows a hint prompting the user to paste the full ad. Accessible name/description wired correctly (`aria-label` + `aria-describedby`).

### 2. `ui` — align the autopilot "Posted within" dropdown
It rendered shorter (`h-8`) with a solid fill and a heavier border than the sibling inputs (`h-9`, translucent glass). Added a `tone="field"` variant to the shared `@ajh/ui` Dropdown that matches the form-field tokens **and preserves the brand border when open**; the call site uses `tone="field"` + `h-9`. Chevron tint matched to the sibling field icons.

### 3. `docs` — agent-system explainer polish
In the routing cards, each author/critic description now sits **below** its badge (the area row stays inline). The `pr-reviewer` gate — previously mentioned once — is now a final pipeline step and a gate row in every routing example, matching the documented pre-PR flow.

## Import/export audit (answer, no changes)
Document export (PDF/DOCX/TXT), résumé import (parser-based + OCR fallback), job import (extension/URL/board), whole-app backup/restore (`data_export`/`data_import`, secrets correctly excluded), and GDPR factory-reset all work. Soft spots (advisory, out of scope): LinkedIn profile import is fragile to page changes; restore has no cross-SQLite transaction; localStorage UI prefs aren't in the backup.

## Test plan
- `pnpm -w typecheck` ✅ 12/12
- `pnpm lint:strict` ✅ clean
- `@ajh/ui` Dropdown ✅ 37/37 (incl. open-state brand-border regression lock)
- `@ajh/tauri` JobAdView / GenerationOutput / TailorFlow / StepTarget ✅ 194 tests
- No Rust changed (a backend enrichment approach was explored and reverted — the renderer already owns resolution and Adzuna 429s anonymous fetches).
- Internal `pr-reviewer` gate: **CLEAR** (0 🔴 / 0 🟠).

## Follow-up (advisory)
`autopilot.apply.loadFailed` / `noDescription` i18n keys are now unreferenced — safe to drop in a docs/cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job ad view now detects partial/truncated pasted descriptions and shows guidance to paste the full posting.
  * Dropdown component adds a new `field` styling tone (with customizable trigger classes).

* **Improvements**
  * Job ad view defaults to the most appropriate tab based on whether a description exists or appears truncated, and prevents tab switching from interrupting edits.
  * Source tab now consistently provides an editable description textarea, with truncation hinting and improved accessibility text.
  * Autopilot wizard input alignment/styling refined for a more consistent layout.

* **Tests**
  * Added coverage for Job ad view interactions and Dropdown styling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->