### PR TITLE
chore: add context7 mcp server and prettier/lockfile claude code hooks

### DIFF
--- a/.claude/hooks/format-on-edit.mjs
+++ b/.claude/hooks/format-on-edit.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// PostToolUse(Edit|Write): prettier-format the file Claude just touched.
+// Mirrors the lint-staged prettier pass so edits land formatted instead of
+// waiting for commit. --ignore-unknown skips non-prettier files; .prettierignore
+// is honored automatically. Best-effort: a prettier hiccup never blocks the edit.
+import { execSync } from 'node:child_process';
+
+const raw = await new Promise((resolve) => {
+  let data = '';
+  process.stdin.on('data', (c) => (data += c));
+  process.stdin.on('end', () => resolve(data));
+});
+
+const file = JSON.parse(raw || '{}')?.tool_input?.file_path;
+if (file) {
+  // prettier globs its CLI args; on Windows the backslashes are read as glob escapes
+  // ("No files matching the pattern"). Forward slashes work and Windows accepts them.
+  const f = file.replace(/\\/g, '/');
+  try {
+    execSync(`pnpm exec prettier --ignore-unknown --write "${f}"`, { stdio: 'ignore' });
+  } catch {
+    // ponytail: best-effort format; swallow errors so a slow/failed prettier never breaks the session
+  }
+}

--- a/.claude/hooks/guard-protected-files.mjs
+++ b/.claude/hooks/guard-protected-files.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// PreToolUse(Edit|Write): block hand-edits to the lockfile. Dependency changes
+// must go through `pnpm add/remove` so the resolved graph never silently drifts.
+// Exit 2 rejects the tool call; stderr is shown to Claude. Add patterns as needed.
+const PROTECTED = [/(^|[\\/])pnpm-lock\.yaml$/];
+
+const raw = await new Promise((resolve) => {
+  let data = '';
+  process.stdin.on('data', (c) => (data += c));
+  process.stdin.on('end', () => resolve(data));
+});
+
+const file = JSON.parse(raw || '{}')?.tool_input?.file_path || '';
+if (PROTECTED.some((re) => re.test(file))) {
+  console.error(
+    `Blocked: "${file}" is protected. Change dependencies with "pnpm add/remove", not by editing the lockfile.`
+  );
+  process.exit(2);
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,28 @@
             "timeout": 5000
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/guard-protected-files.mjs",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/format-on-edit.mjs",
+            "timeout": 20000
+          }
+        ]
       }
     ],
     "Stop": [

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -8,6 +8,10 @@
       "type": "stdio",
       "command": "codegraph",
       "args": ["serve", "--mcp"]
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
     }
   }
 }


### PR DESCRIPTION
Wires in three Claude Code automations recommended by the `claude-code-setup` plugin.

## Changes
- **context7 MCP** (`.mcp.json` + tracked `.mcp.json.example`) — live library/API docs lookup (HTTP, keyless). `.mcp.json` is gitignored, so the team-facing copy lives in `.mcp.json.example`.
- **`format-on-edit.mjs`** (`PostToolUse: Edit|Write`) — prettier-writes each file Claude edits, mirroring the lint-staged pass so edits land formatted instead of waiting for commit. Honors `.prettierignore`/`.gitignore`; best-effort (never blocks an edit).
- **`guard-protected-files.mjs`** (`PreToolUse: Edit|Write`) — blocks hand-edits to `pnpm-lock.yaml` so the dependency graph can't silently drift; deps change via `pnpm add/remove`.

Both hooks wired in `.claude/settings.json`.

## Notes
- Two Windows gotchas handled in `format-on-edit.mjs`: prettier globs its CLI args (backslash paths fail, so `\` is normalized to `/`), and it respects `.gitignore`.
- Requires a Claude Code restart to load the new MCP server / hooks.

## Test
- Both JSON configs validated.
- Format hook verified end-to-end against a real backslash Windows path (formats correctly).
- Guard verified: blocks `pnpm-lock.yaml` (exit 2 + reason), allows normal source files (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic code formatting for edited files to maintain consistent style
  * Implemented protection against modifications to critical configuration files
  * Extended MCP server configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->