### PR TITLE
fix(autopilot): redact standalone credential tokens in scrape diagnostics

### DIFF
--- a/apps/tauri/src-tauri/src/autopilot/test.rs
+++ b/apps/tauri/src-tauri/src/autopilot/test.rs
@@ -770,6 +770,36 @@ fn relax_is_noop_on_already_relaxed_record() {
 }
 
 #[test]
+fn relax_keeps_keywords_when_not_legacy() {
+    // Pins the documented narrow gap (autopilot/mod.rs `was_legacy`): a record
+    // with prefilled keywords where the user ALSO changed BOTH the score (≠50.0)
+    // AND the date (≠"24h") reads as non-legacy, so its keywords are KEPT. This
+    // guards against a future change to the `was_legacy` predicate silently
+    // regressing the "err toward keeping user data" direction.
+    let mut ap = base_autopilot();
+    ap.filter.min_match_score = 30.0; // ≠ 50.0
+    ap.target.date_filter = Some("week".into()); // ≠ "24h"
+    ap.filter.keywords = Some(vec!["python".into()]);
+
+    relax_legacy_filters(&mut ap);
+
+    assert_eq!(
+        ap.filter.keywords.as_deref(),
+        Some(["python".to_string()].as_ref()),
+        "non-legacy record (score≠50 AND date≠24h) must keep its keywords"
+    );
+    assert_eq!(
+        ap.filter.min_match_score, 30.0,
+        "non-default score must be left untouched"
+    );
+    assert_eq!(
+        ap.target.date_filter.as_deref(),
+        Some("week"),
+        "non-default date_filter must be left untouched"
+    );
+}
+
+#[test]
 fn relax_clears_none_keywords_remains_none() {
     // keywords already None → still None (no-op, no panic).
     let mut ap = base_autopilot();

--- a/apps/tauri/src-tauri/src/autopilot_helpers/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot_helpers/mod.rs
@@ -166,6 +166,26 @@ fn redact_token(token: &str) -> String {
     let is_homeish_path =
         lower.contains("users\\") || lower.contains("users/") || lower.contains("home/");
 
+    // Standalone credential assignment (`app_key=…`, `token=…`, `secret=…`) emitted
+    // OUTSIDE a full `://` URL. The `marker=` shape (the `=` makes it an assignment)
+    // is what flags it — matching the bare word would over-redact `keyword` / a
+    // prose "token". The `://` branch below runs first, so a full
+    // `https://…?app_key=…` still collapses to `<url-redacted>`, not this.
+    let is_credential = [
+        "app_key=",
+        "app_id=",
+        "apikey=",
+        "api_key=",
+        "key=",
+        "secret=",
+        "token=",
+        "password=",
+        "pwd=",
+        "auth=",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker));
+
     // Bare IPv4 / host:port — leaks the user's network surroundings. Require an
     // embedded `.` AND either a trailing `:<digits>` port or an all-numeric dotted
     // IPv4, so `429:`, `12:34` timestamps, and plain integers stay untouched.
@@ -183,6 +203,8 @@ fn redact_token(token: &str) -> String {
 
     if is_url {
         token.replace(trimmed, "<url-redacted>")
+    } else if is_credential {
+        token.replace(trimmed, "<credential-redacted>")
     } else if is_windows_path || is_unix_path || is_homeish_path {
         token.replace(trimmed, "<path-redacted>")
     } else if is_host_port {
@@ -428,5 +450,51 @@ mod tests {
         // A dotted version with no port and a non-IPv4 shape (3 segments) is left
         // alone too — not a host:port and not a 4-octet IPv4.
         assert_eq!(sanitize_reason("v1.2.3"), "v1.2.3");
+    }
+
+    #[test]
+    fn redact_standalone_credential_assignments() {
+        // A bare `marker=value` credential token emitted OUTSIDE a `://` URL must
+        // be redacted — the secret value must not survive (defense-in-depth).
+        for raw in ["bad app_key=abc123 request", "auth token=deadbeef rejected"] {
+            let out = sanitize_reason(raw);
+            assert!(
+                out.contains("<credential-redacted>"),
+                "credential placeholder must appear for {raw:?}; got: {out}"
+            );
+            assert!(
+                !out.contains("abc123") && !out.contains("deadbeef"),
+                "secret value leaked from {raw:?}; got: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn full_url_with_credential_query_still_wins_url_branch() {
+        // A full `https://…?app_key=…` token contains `://`, so the URL branch must
+        // win and collapse the WHOLE token to <url-redacted> — not <credential-redacted>.
+        let out = sanitize_reason("GET https://api.adzuna.com/v1/jobs?app_key=secret failed");
+        assert!(
+            out.contains("<url-redacted>"),
+            "URL branch must win for a full URL; got: {out}"
+        );
+        assert!(
+            !out.contains("<credential-redacted>"),
+            "URL token must not fall through to the credential branch; got: {out}"
+        );
+        assert!(
+            !out.contains("secret") && !out.contains("api.adzuna.com"),
+            "url + embedded secret leaked; got: {out}"
+        );
+    }
+
+    #[test]
+    fn credential_marker_does_not_over_redact_benign_words() {
+        // The `marker=` shape (the `=`) is required: bare words like `keyword` or a
+        // prose `token` (no `=`) must survive verbatim — no false positives.
+        assert_eq!(
+            sanitize_reason("keyword token apikey missing"),
+            "keyword token apikey missing"
+        );
     }
 }

--- a/apps/tauri/src-tauri/src/autopilot_helpers/mod.rs
+++ b/apps/tauri/src-tauri/src/autopilot_helpers/mod.rs
@@ -172,11 +172,10 @@ fn redact_token(token: &str) -> String {
     // prose "token". The `://` branch below runs first, so a full
     // `https://…?app_key=…` still collapses to `<url-redacted>`, not this.
     let is_credential = [
-        "app_key=",
-        "app_id=",
-        "apikey=",
-        "api_key=",
+        // `key=` (substring match) subsumes the `*key=` variants — `app_key=`,
+        // `apikey=`, `api_key=` all CONTAIN it — so don't re-add those here.
         "key=",
+        "app_id=",
         "secret=",
         "token=",
         "password=",


### PR DESCRIPTION
## Why

Follow-up to two 🔵 Trivial CodeRabbit nitpicks left on #484 *after* it merged.

## Changes

**1. Credential-token redaction (defense-in-depth).** `redact_token` (in `autopilot_helpers/mod.rs`, feeding the renderer-visible `scrape_diag` step) now redacts standalone credential-assignment tokens — `app_key=`, `app_id=`, `api_key=`, `key=`, `secret=`, `token=`, `password=`, … → `<credential-redacted>`. Gated on the literal `=` so benign content (`keyword`, a bare `token`, `v1.2.3`) is untouched, and ordered **after** the `://` URL branch so a full `https://…?app_key=…` still collapses to `<url-redacted>` (the more complete redaction). No current provider emits a bare key into a board error (Adzuna's key only appears inside the full URL; JSearch's is an `X-RapidAPI-Key` header) — this is belt-and-suspenders for any future path. **tauri-security-reviewer: 🟢 clean** (ordering, marker coverage, no over-redaction, no regression all verified).

**2. Regression test for the documented `was_legacy` gap.** `relax_legacy_filters` keeps keywords when a record reads non-legacy (score ≠ 50 **and** date ≠ "24h"). Added `relax_keeps_keywords_when_not_legacy` so a future change to the `was_legacy` predicate can't silently regress the "keep user data" direction.

Deliberately **did not** take CodeRabbit's "redact bare hostnames with a dot" suggestion — it would over-redact version strings and break the existing over-redaction control test.

## Tests

`cargo test autopilot` — 83 pass (+4): credential redaction, URL-branch-wins, no-over-redaction control, and the `was_legacy` gap lock. clippy `-D warnings` / fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved credential redaction to mask standalone credential assignment tokens (e.g., `app_key=`, `token=`, `password=`) in logs and output.
  * Updated redaction behavior to consistently fully mask complete URLs (including credential-bearing query parameters) without partial credential exposure.
  * Added coverage ensuring legacy auto-pilot filter relaxation preserves provided keywords when non-legacy settings are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->