### PR TITLE
fix: invalidate the interactions query prefix when clearing interactions

### DIFF
--- a/apps/tauri/src/renderer/services/use-privacy/use-privacy.test.ts
+++ b/apps/tauri/src/renderer/services/use-privacy/use-privacy.test.ts
@@ -164,15 +164,14 @@ describe('useClearInteractions — interactions prefix invalidation', () => {
     await waitFor(() => expect(result.current.interactions.isSuccess).toBe(true));
     const callCountBefore = listInteractions.mock.calls.length;
 
-    await act(async () => {
-      try {
-        await result.current.clear.mutateAsync();
-      } catch {
-        // expected rejection
-      }
-    });
+    // 1. The mutation must actually reject — proves the error path was exercised.
+    await expect(result.current.clear.mutateAsync()).rejects.toThrow('backend error');
 
-    // onSuccess must NOT have fired — call count unchanged.
+    // 2. clearInteractions was called — the mutation ran, it didn't silently no-op.
+    expect(clearInteractions).toHaveBeenCalledOnce();
+
+    // 3. onSuccess was skipped — listInteractions did not refetch.
+    await waitFor(() => expect(result.current.clear.isError).toBe(true));
     expect(listInteractions.mock.calls.length).toBe(callCountBefore);
   });
 });

--- a/apps/tauri/src/renderer/services/use-privacy/use-privacy.test.ts
+++ b/apps/tauri/src/renderer/services/use-privacy/use-privacy.test.ts
@@ -14,7 +14,9 @@ import { act, waitFor } from '@testing-library/react';
 
 import { createMockClient, exerciseServiceHooks, renderHookWithClient } from '@/test-support';
 
+import { useInteractions } from '../use-postings/use-postings';
 import * as mod from './use-privacy';
+import { useClearInteractions } from './use-privacy';
 
 // ── hoisted spies ─────────────────────────────────────────────────────────────
 
@@ -90,5 +92,87 @@ describe('useResetApp', () => {
 
     expect(mockClearOnboardingMirror).not.toHaveBeenCalled();
     expect(mockResetPreferences).not.toHaveBeenCalled();
+  });
+});
+
+// ── useClearInteractions — prefix invalidation refetches typed interactions ────
+
+describe('useClearInteractions — interactions prefix invalidation', () => {
+  /**
+   * Real-chain test: uses the REAL useClearInteractions + REAL useInteractions
+   * hooks with only the IPC client mocked. Verifies that after clearInteractions
+   * settles, the interactions query for a typed key ('viewed') refetches — i.e.
+   * the prefix ['postings','interactions'] hits ['postings','interactions','viewed'].
+   *
+   * This guards against the prior bug where invalidating the full key
+   * ['postings','interactions',undefined] did NOT match typed queries and stale
+   * "viewed/saved" badges lingered until reload.
+   */
+  it('refetches useInteractions("viewed") after clearInteractions mutates', async () => {
+    const listInteractions = vi.fn().mockResolvedValue([]);
+    const clearInteractions = vi.fn().mockResolvedValue(undefined);
+
+    const client = createMockClient({
+      'scrape.listInteractions': listInteractions,
+      'privacy.clearInteractions': clearInteractions,
+    });
+
+    const { result } = renderHookWithClient(
+      () => ({
+        interactions: useInteractions('viewed'),
+        clear: useClearInteractions(),
+      }),
+      { client }
+    );
+
+    // Wait for the initial interactions query to settle.
+    await waitFor(() => expect(result.current.interactions.isSuccess).toBe(true));
+    const callCountBefore = listInteractions.mock.calls.length;
+
+    // Trigger the mutation.
+    await act(async () => {
+      await result.current.clear.mutateAsync();
+    });
+
+    // The interactions query for 'viewed' must have re-fired (prefix invalidation).
+    await waitFor(() => {
+      expect(listInteractions.mock.calls.length).toBeGreaterThan(callCountBefore);
+    });
+
+    // The refetch must have been for the 'viewed' type.
+    const refetchCall = listInteractions.mock.calls[callCountBefore];
+    expect(refetchCall?.[0]).toMatchObject({ interactionType: 'viewed' });
+  });
+
+  it('does not refetch interactions when clearInteractions rejects', async () => {
+    const listInteractions = vi.fn().mockResolvedValue([]);
+    const clearInteractions = vi.fn().mockRejectedValue(new Error('backend error'));
+
+    const client = createMockClient({
+      'scrape.listInteractions': listInteractions,
+      'privacy.clearInteractions': clearInteractions,
+    });
+
+    const { result } = renderHookWithClient(
+      () => ({
+        interactions: useInteractions('viewed'),
+        clear: useClearInteractions(),
+      }),
+      { client }
+    );
+
+    await waitFor(() => expect(result.current.interactions.isSuccess).toBe(true));
+    const callCountBefore = listInteractions.mock.calls.length;
+
+    await act(async () => {
+      try {
+        await result.current.clear.mutateAsync();
+      } catch {
+        // expected rejection
+      }
+    });
+
+    // onSuccess must NOT have fired — call count unchanged.
+    expect(listInteractions.mock.calls.length).toBe(callCountBefore);
   });
 });

--- a/apps/tauri/src/renderer/services/use-privacy/use-privacy.ts
+++ b/apps/tauri/src/renderer/services/use-privacy/use-privacy.ts
@@ -23,7 +23,10 @@ export const useClearInteractions = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => api.privacy.clearInteractions(),
-    onSuccess: () => qc.invalidateQueries({ queryKey: keys.postings.interactions() }),
+    // Invalidate the PREFIX so every typed interactions query ('viewed', 'opened', …)
+    // refetches — keys.postings.interactions(type) = ['postings','interactions',type]
+    // and React Query matches on prefix, so omitting the type segment hits all of them.
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['postings', 'interactions'] }),
   });
 };
 


### PR DESCRIPTION
## Summary

Follow-up from #486. `useClearInteractions` (privacy → "clear interaction history") invalidated `keys.postings.interactions()`, which is `['postings','interactions', undefined]` — a 3-element key whose trailing `undefined` is a literal, so it never prefix-matches the typed `['postings','interactions','viewed'|'opened'|…]` queries that `useInteractions(type)` registers. Result: after clearing interactions, the viewed/saved/applied badges kept showing stale state until a reload.

Fix: invalidate the two-element prefix `['postings','interactions']` so React Query's prefix match hits every typed interactions query — the identical fix already shipped for `usePersistJob` in #486.

## Test

Real-chain coverage added to `use-privacy.test.ts`: renders the real `useClearInteractions` + a real `useInteractions('viewed')`, fires `mutateAsync()`, and asserts the interactions query refetches after it settles (and not on rejection).

## Notes

Pre-existing on `main` (predates #486); split out as its own small PR to keep #486 focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactions data refresh after clearing items by updating the cache using a broader query-key prefix, so lists match the correct interaction type after success.
  * Ensured refresh behavior is skipped when the clear action fails.

* **Tests**
  * Expanded coverage to exercise the real clearing-and-refetch flow together, verifying the correct refetch parameters on success and no refetch on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->