### PR TITLE
fix(landing): creature film regression, root links, and missing favicons

### DIFF
--- a/landing/agent-system.html
+++ b/landing/agent-system.html
@@ -280,7 +280,7 @@ footer{margin-top:64px; text-align:center}
 <body>
 <main class="wrap">
 
-  <a class="top-back" href="index.html">← back to the chaos</a>
+  <a class="top-back" href="/">← back to the chaos</a>
 
   <!-- ============ 1 · HERO ============ -->
   <h1>The Agent Fleet</h1>
@@ -559,7 +559,7 @@ footer{margin-top:64px; text-align:center}
   <footer>
     <p class="byline">24 specialists, zero of them with a real job either.</p>
     <p class="foot-links">
-      <a href="index.html">home</a> · <a href="download.html">download</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener">♥ sponsor</a>
+      <a href="/">home</a> · <a href="download.html">download</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener">♥ sponsor</a>
     </p>
   </footer>
 

--- a/landing/architecture-map.html
+++ b/landing/architecture-map.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI Job Hunter — Architecture Map</title>
+    <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
     <style>
       :root {
         --bg: #0f0f0f;

--- a/landing/ci-dashboard.html
+++ b/landing/ci-dashboard.html
@@ -6,6 +6,7 @@
     <!-- Internal status page on the marketing domain — keep it out of search. -->
     <meta name="robots" content="noindex, nofollow" />
     <title>AI Job Hunter — CI Status</title>
+    <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
     <style>
       :root {
         --bg: #0d1117;

--- a/landing/creature.html
+++ b/landing/creature.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>THE CREATURE — a hand-drawn doodle short film</title>
+<link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
 <meta name="description" content="a doodle engineer accidentally summons a tiny recruiter creature. each application makes it bigger. a hand-drawn short film from the AI Job Hunter notebook. runtime ~2:40.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Anton&family=Caveat:wght@600;700&family=Gloria+Hallelujah&family=Patrick+Hand&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">

--- a/landing/creature.html
+++ b/landing/creature.html
@@ -218,14 +218,14 @@ a:focus-visible,button:focus-visible,[tabindex]:focus-visible,[role="button"]:fo
   <div class="tmono thint">sound on · space pause · 2× button · m mute · → skip · r replay</div>
 </div>
 
-<div id=”endcard” class=”overlay” hidden role=”dialog” aria-modal=”true” aria-labelledby=”endcard-title”>
-  <h2 id=”endcard-title”>THE END</h2>
-  <p class=”esub”>the creature is fine. it lives in the app now. it answers to “send”.</p>
-  <div class=”tnote”>no recruiters were harmed. several were automated.</div>
-  <div class=”tmono”>rejections survived: 1,247 · dignity: rebooting · you: press send</div>
-  <div class=”erow”>
-    <button id=”replay2” class=”hbtn”>↺ watch it again</button>
-    <a class=”back” href=”/”>← back to the notebook</a>
+<div id="endcard" class="overlay" hidden role="dialog" aria-modal="true" aria-labelledby="endcard-title">
+  <h2 id="endcard-title">THE END</h2>
+  <p class="esub">the creature is fine. it lives in the app now. it answers to “send”.</p>
+  <div class="tnote">no recruiters were harmed. several were automated.</div>
+  <div class="tmono">rejections survived: 1,247 · dignity: rebooting · you: press send</div>
+  <div class="erow">
+    <button id="replay2" class="hbtn">↺ watch it again</button>
+    <a class="back" href="/">← back to the notebook</a>
   </div>
 </div>
 <p id="sitefoot" style="position:fixed;bottom:0;left:0;right:0;z-index:6;text-align:center;font-family:var(--mono);font-size:12px;color:#4a4030;padding:4px 0 6px;background:rgba(244,236,220,.82);pointer-events:none"><a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener" style="color:#4a4030;pointer-events:auto">♥ sponsor</a> · <a href="/" style="color:#4a4030;pointer-events:auto">home</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener" style="color:#4a4030;pointer-events:auto">GitHub</a></p>

--- a/landing/how-it-works.html
+++ b/landing/how-it-works.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI Job Hunter — How It Works (End to End)</title>
+    <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
     <style>
       :root {
         --bg: #0a0e17;

--- a/landing/social-card.html
+++ b/landing/social-card.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>AI Job Hunter — social card</title>
+<link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Anton&family=Caveat:wght@600;700&family=Gloria+Hallelujah&family=Patrick+Hand&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary

Three small landing-page hotfixes after the a11y waves (#489/#490).

### 1. `creature.html` film regression (HIGH — the film stopped playing)
The wave-2 `#endcard` dialog edit replaced straight quotes with **curly quotes** (`”`) across the whole block, so `id="endcard"`, `id="replay2"`, etc. didn't parse. That made `$('replay2')` null → **`Cannot read properties of null (reading 'addEventListener')`** at the wiring step → the film script halted and the page showed only the paper background + text. Restored straight quotes on all the attributes; kept the intentional typographic `“send”` in the prose.

### 2. `agent-system.html` root links
"← back to the chaos" and the footer "home" pointed at `index.html`, which resolves to `…/index.html` from `/agent-system`. Both now link to `/`.

### 3. Missing favicons
`architecture-map`, `ci-dashboard`, `creature`, `how-it-works`, and `social-card` had no `<link rel="icon">`. Added `index.html`'s creature-face favicon (verbatim) so all 9 landing pages share the same icon.

### Verified
- creature: only the intentional `“send”` curly-quote remains; `$('endcard')`/`$('replay2')` resolve again → film plays.
- favicon byte-identical to index on all 9 pages (only `<head>` indentation differs per page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
