### PR TITLE
fix(landing): restore the creature film (curly-quote regression)

### DIFF
--- a/landing/creature.html
+++ b/landing/creature.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>THE CREATURE — a hand-drawn doodle short film</title>
+<link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
 <meta name="description" content="a doodle engineer accidentally summons a tiny recruiter creature. each application makes it bigger. a hand-drawn short film from the AI Job Hunter notebook. runtime ~2:40.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Anton&family=Caveat:wght@600;700&family=Gloria+Hallelujah&family=Patrick+Hand&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
@@ -218,14 +219,14 @@ a:focus-visible,button:focus-visible,[tabindex]:focus-visible,[role="button"]:fo
   <div class="tmono thint">sound on · space pause · 2× button · m mute · → skip · r replay</div>
 </div>
 
-<div id=”endcard” class=”overlay” hidden role=”dialog” aria-modal=”true” aria-labelledby=”endcard-title”>
-  <h2 id=”endcard-title”>THE END</h2>
-  <p class=”esub”>the creature is fine. it lives in the app now. it answers to “send”.</p>
-  <div class=”tnote”>no recruiters were harmed. several were automated.</div>
-  <div class=”tmono”>rejections survived: 1,247 · dignity: rebooting · you: press send</div>
-  <div class=”erow”>
-    <button id=”replay2” class=”hbtn”>↺ watch it again</button>
-    <a class=”back” href=”/”>← back to the notebook</a>
+<div id="endcard" class="overlay" hidden role="dialog" aria-modal="true" aria-labelledby="endcard-title">
+  <h2 id="endcard-title">THE END</h2>
+  <p class="esub">the creature is fine. it lives in the app now. it answers to “send”.</p>
+  <div class="tnote">no recruiters were harmed. several were automated.</div>
+  <div class="tmono">rejections survived: 1,247 · dignity: rebooting · you: press send</div>
+  <div class="erow">
+    <button id="replay2" class="hbtn">↺ watch it again</button>
+    <a class="back" href="/">← back to the notebook</a>
   </div>
 </div>
 <p id="sitefoot" style="position:fixed;bottom:0;left:0;right:0;z-index:6;text-align:center;font-family:var(--mono);font-size:12px;color:#4a4030;padding:4px 0 6px;background:rgba(244,236,220,.82);pointer-events:none"><a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener" style="color:#4a4030;pointer-events:auto">♥ sponsor</a> · <a href="/" style="color:#4a4030;pointer-events:auto">home</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener" style="color:#4a4030;pointer-events:auto">GitHub</a></p>


### PR DESCRIPTION
## Summary — urgent: the creature film stopped playing

The wave-2 (#490) `#endcard` dialog edit replaced straight quotes with **curly quotes** (`”`) across the block, so `id="endcard"`, `id="replay2"`, etc. didn't parse. `$('replay2')` became null → **`Cannot read properties of null (reading 'addEventListener')`** at the wiring step → the film script halted and the page showed only the paper background + text.

**Fix:** restored straight quotes on all `#endcard` attributes (kept the intentional typographic `“send”` in the prose). `$('endcard')`/`$('replay2')` resolve again → the film plays.

This PR is `landing/creature.html` only (its favicon, also missing, rides along since it's the same file) — split out from the cosmetic links/favicons PR so it can merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
