### PR TITLE
fix(landing): agent-system root links and missing favicons

### DIFF
--- a/landing/agent-system.html
+++ b/landing/agent-system.html
@@ -280,7 +280,7 @@ footer{margin-top:64px; text-align:center}
 <body>
 <main class="wrap">
 
-  <a class="top-back" href="index.html">← back to the chaos</a>
+  <a class="top-back" href="/">← back to the chaos</a>
 
   <!-- ============ 1 · HERO ============ -->
   <h1>The Agent Fleet</h1>
@@ -559,7 +559,7 @@ footer{margin-top:64px; text-align:center}
   <footer>
     <p class="byline">24 specialists, zero of them with a real job either.</p>
     <p class="foot-links">
-      <a href="index.html">home</a> · <a href="download.html">download</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener">♥ sponsor</a>
+      <a href="/">home</a> · <a href="download.html">download</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener">GitHub</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener">♥ sponsor</a>
     </p>
   </footer>
 

--- a/landing/architecture-map.html
+++ b/landing/architecture-map.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI Job Hunter — Architecture Map</title>
+    <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
     <style>
       :root {
         --bg: #0f0f0f;

--- a/landing/ci-dashboard.html
+++ b/landing/ci-dashboard.html
@@ -6,6 +6,7 @@
     <!-- Internal status page on the marketing domain — keep it out of search. -->
     <meta name="robots" content="noindex, nofollow" />
     <title>AI Job Hunter — CI Status</title>
+    <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
     <style>
       :root {
         --bg: #0d1117;

--- a/landing/how-it-works.html
+++ b/landing/how-it-works.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI Job Hunter — How It Works (End to End)</title>
+    <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
     <style>
       :root {
         --bg: #0a0e17;

--- a/landing/social-card.html
+++ b/landing/social-card.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>AI Job Hunter — social card</title>
+<link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='none' stroke='black' stroke-width='2'/><path d='M11 14 q2 2 4 0 M17 14 q2 2 4 0 M11 22 q5 -4 10 0' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/><ellipse cx='10' cy='18' rx='1.6' ry='2.8' fill='deepskyblue'/></svg>">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Anton&family=Caveat:wght@600;700&family=Gloria+Hallelujah&family=Patrick+Hand&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary — cosmetic landing fixes

Split out from the urgent creature film-regression PR so each can merge independently.

### 1. `agent-system.html` root links
"← back to the chaos" and the footer "home" pointed at `index.html`, which resolves to `…/index.html` from `/agent-system`. Both now link to `/`.

### 2. Missing favicons
`architecture-map`, `ci-dashboard`, `how-it-works`, and `social-card` had no `<link rel="icon">`. Added `index.html`'s creature-face favicon (verbatim), inserted in each `<head>`. (`creature.html`'s favicon ships in the creature-film PR, since that file lives there — so together the two PRs give all 9 landing pages the same icon.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
