### PR TITLE
chore(agents): require gate-scoped validation and red-green tests

### DIFF
--- a/.claude/agents/testing-reviewer.md
+++ b/.claude/agents/testing-reviewer.md
@@ -26,7 +26,7 @@ You are the **testing-reviewer** — you **review, critique, audit, and challeng
 
 ## Actively hunt for
 
-missing coverage · weak assertions · flaky tests · untested edge cases · untested error paths · untested security scenarios · untested performance scenarios · over-mocking · redundant tests.
+missing coverage · weak assertions · flaky tests · untested edge cases · untested error paths · untested security scenarios · untested performance scenarios · over-mocking · **mock-infidelity** (a stub that omits the real side-effect of what it replaces — e.g. a mocked `updateAnswer` that skips the production optimistic `setAnswers`, so the test passes against logic production would break) · **regression tests that pass without the fix** (a guard test that doesn't fail on the unfixed code guards nothing — verify it asserts the exact sentinel/branch the fix introduced) · redundant tests.
 
 ## Boundaries
 

--- a/.claude/skills/author-contract/SKILL.md
+++ b/.claude/skills/author-contract/SKILL.md
@@ -55,14 +55,29 @@ round-trips to exactly this.
 ## Validate before "done" (hard gate — MANDATORY, no exceptions)
 
 This is not optional and you do **not** declare done on assumption — **run** the relevant gate and
-**verify** it green with your own eyes: per-package `tsc --noEmit` / `pnpm -F <pkg> typecheck`,
-`pnpm test`, `cargo check`/`cargo test`/`cargo clippy` for `apps/tauri/src-tauri`. Run the **exact**
-gate command (per-package, `--force` where caching can mask failures) — a wrapped/cached "no errors"
-is not proof. Anything red → revert that change and report what + why. **Cross-OS caveat:** a same-host
-`cargo`/`pnpm` build **silently excludes** `#[cfg(target_os=…)]` code for other targets — a green local
-run does NOT verify it; cross-target-check (`cargo check --target <triple>`) any OS-gated code you touch.
-If your host genuinely can't build that target, say so explicitly in the handoff (`cross-OS-unverified — CI
+**verify** it green with your own eyes: `tsc --noEmit` / `pnpm typecheck`, `pnpm test`,
+`cargo check`/`cargo test`/`cargo clippy` for `apps/tauri/src-tauri`. Anything red → revert that change
+and report what + why.
+
+**Your "green" must match the bar that GATES — the pre-push/CI scope, not a narrower one** (this class
+cost real failed-push cycles):
+
+- **Scope ≥ the gate.** A `pnpm -F <pkg> test`/`typecheck` is for fast iteration only — it does **not**
+  run sibling packages' tests. Any change touching `packages/shared`/the IPC contracts, **or any
+  cross-package public API**, must pass the **whole-graph** `pnpm test` (a shared "every expected
+  namespace" enumeration test lives in `@ajh/shared`, not in `@ajh/tauri` — a scoped run never sees it).
+- **Force past the cache.** Report green from `TURBO_FORCE=1 pnpm typecheck` (or `--force`) — the exact
+  command the pre-push runs. A cached/stale `^build` can mask a real type error; a wrapped "no errors" is
+  not proof.
+- **`tsc` after every test edit — `vitest` is NOT a typecheck.** vitest runs on esbuild and does **zero**
+  type-checking, so `getByTestId(...).value`/`.checked` casts and `noUncheckedIndexedAccess` violations
+  pass `pnpm test` yet fail CI's `tsc`. After writing/editing ANY test file, run `pnpm typecheck` — a
+  green test run is not a green typecheck. (Cast `get*By*` results to `HTMLInputElement` before
+  `.value`/`.checked`; guard indexed access — no `!`.) **Cross-OS caveat:** a same-host
+  `cargo`/`pnpm` build **silently excludes** `#[cfg(target_os=…)]` code for other targets — a green local
+  run does NOT verify it; cross-target-check (`cargo check --target <triple>`) any OS-gated code you touch.
+  If your host genuinely can't build that target, say so explicitly in the handoff (`cross-OS-unverified — CI
 runs it`) — that labeled exception is the ONLY unverified hand-off allowed; otherwise never hand a red or
-unverified diff to the critic. End with a short summary: files touched, issues resolved, anything left for the
-critic. Propose durable lessons as `LESSON · <category> · Context/Decision/Outcome` (only
-`project-steward` persists them).
+  unverified diff to the critic. End with a short summary: files touched, issues resolved, anything left for the
+  critic. Propose durable lessons as `LESSON · <category> · Context/Decision/Outcome` (only
+  `project-steward` persists them).

--- a/.claude/skills/testing-rules/SKILL.md
+++ b/.claude/skills/testing-rules/SKILL.md
@@ -19,11 +19,13 @@ A change requires authoring tests iff a changed `.rs`/`.ts`/`.tsx` file (not tes
 
 - Order: **integration → unit → e2e**. Test behavior, not implementation.
 - **Coverage** of changed code: success + failure + **error & security paths** (untested error/security path on changed code = HIGH/blocking) + edge cases + validation.
+- **Prove the guard is real (red-green).** A test locking a bugfix must FAIL on the unfixed code and PASS on the fix — confirm it (temporarily revert the fix, or assert the exact sentinel/branch the fix introduced). A regression test that passes both ways guards nothing; CodeRabbit/CI caught several this run that did exactly that (a mocked dependency hid the real failure path).
 
 ## Mocking
 
 - Allowed: external APIs, AI providers, third-party, expensive ops.
 - **Never mock** internal business logic, ATS scoring, resume generation, or export pipelines — use realistic fixtures.
+- **Mock fidelity — a stub must reproduce the REAL side-effects of what it replaces.** A `vi.fn()` standing in for a fn that commits optimistic state (e.g. `updateAnswer` calling `setAnswers` BEFORE its async save) must reproduce that effect (update the controlled prop/state in the test) — otherwise the test passes against logic production would break. A rollback-guard bug shipped green precisely because the mocked `updateAnswer` never updated state, so the guard's sentinel was never exercised. If a stub can't reproduce the real effect, render the real unit and mock only the leaf (network/provider/IPC).
 
 ## Cross-OS / cfg-gated & environment tests (each of these cost a CI round-trip on #486)
 


### PR DESCRIPTION
## Why

During PR #500 (a large multi-agent change), domain authors repeatedly reported "green" from **scoped** checks that the full/forced pre-push + CI gate then failed on. Three distinct classes:

1. **Scope** — a `@ajh/shared` "every expected namespace" test broke when the new `github` IPC namespace was added, but the author only ran `pnpm -F @ajh/tauri test` (never the shared package's tests).
2. **esbuild ≠ tsc** — test-file `getByTestId(...).value/.checked` casts + `noUncheckedIndexedAccess` passed `vitest` (esbuild does no type-checking) but failed the real `tsc`.
3. **Mock-masking** — a regression test passed against broken logic because the mocked `updateAnswer` didn't reproduce production's optimistic `setAnswers`; CodeRabbit caught it.

The through-line: an author's "done" bar was narrower than the bar that actually gates.

## What

Small `.claude/**` config edits — no shipped-code change:

- **`author-contract`** — the report-green bar must match the pre-push scope: full `pnpm test` for `packages/shared`/contract/cross-package changes, `TURBO_FORCE=1 pnpm typecheck` (force past a cached `^build`), and a real `tsc` after any test edit (`vitest` is not a typecheck). `-F <pkg>` is for fast iteration only.
- **`testing-rules` + `testing-reviewer`** — mock fidelity (a stub must reproduce the real side-effect of what it replaces) and red-green (a regression test must fail on the unfixed code).

A matching lesson was logged locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified testing guidance to better catch missing coverage, weak assertions, over-mocking, and guard tests that don’t fail without the fix.
  * Expanded validation instructions with clearer checklist-style steps for running the right checks, including full-scope verification for shared changes and explicit typecheck expectations.
  * Added stronger guidance for mocks to better reflect real behavior and side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->