### PR TITLE
docs: correct extension import mode, disclose native-messaging, note rate budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The only outbound calls are to the AI provider **you** configure (and an optiona
 
 - **Now on the Chrome Web Store and Firefox Add-ons** — <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Install for Chrome</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener noreferrer">Install for Firefox</a>.
 - MV3 extension for **Chrome & Firefox** — while browsing any job board, click the extension button to import the job into your saved applications.
-- **Two import modes:** **Import via URL** (extension sends the URL, app fetches + parses), or **Scan page** (extension captures the authenticated DOM, useful for login-walled boards).
+- **One-click import** — click **"Import this job"** on any board page; the extension automatically captures the rendered DOM when possible (bypassing bot-walls on logged-in boards like LinkedIn/Indeed) and falls back to URL-only on restricted pages.
 - Fully local — jobs are sent to the desktop app over a **loopback-only WebSocket**, paired with a secret token. Zero remote backend, zero analytics.
 - See <a href="apps/extension/README.md" target="_blank" rel="noopener noreferrer">apps/extension/README.md</a> for setup, dev pairing, and architecture. Try it locally — see the extension's <a href="apps/extension/README.md#local-development--testing" target="_blank" rel="noopener noreferrer">Local development & testing</a> guide.
 

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -13,7 +13,7 @@
 
 This is the browser half of the **AI Job Hunter** job-import feature. An MV3 extension available for **Chrome on the Web Store** ([install](https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll)) and **Firefox on AMO** ([install](https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/)). It captures the job posting on the current tab and sends it to the **desktop app** running on your machine, over a private loopback WebSocket. No account. No remote backend. It is inert unless the desktop app is running and you have paired it.
 
-**What it does:** while browsing a job board, click the extension button → choose **Import via URL** (extension sends the job URL, desktop fetches + parses it) or **Scan page** (extension captures the rendered DOM, desktop parses it) → the job appears in your **AI Job Hunter** saved applications, tagged **New**. Tick **"I already applied"** to mark it applied instead.
+**What it does:** while browsing a job board, click the extension button → click **Import this job** → the job appears in your **AI Job Hunter** saved applications, tagged **New**. The extension automatically captures the rendered DOM when possible (for login-walled boards like LinkedIn/Indeed that block headless fetching); on restricted pages it falls back to URL-only. Tick **"I already applied"** to mark it applied instead.
 
 The desktop half (bridge server, parser, Applications store) lives in `apps/tauri/src-tauri/src/extension_bridge/`. The wire protocol is shared: `packages/shared/src/ipc/extension-protocol.ts`.
 
@@ -28,10 +28,12 @@ The desktop half (bridge server, parser, Applications store) lives in `apps/taur
    ↓
 3. You copy the pairing token from app Settings → paste into extension
    ↓
-4. Open any job board → click extension button → pick import mode
+4. Open any job board → click extension button → click Import this job
    ↓
 5. Desktop receives frame → fetches/parses job → creates saved Application
 ```
+
+**Rate budget:** extension imports share the desktop's scrape rate budget (30 requests/min, 2 concurrent). This is the same budget as the in-app scrape commands; a rate-limited import returns an error in the popup rather than silently queuing. See `apps/tauri/src-tauri/src/limits/mod.rs` (`SCRAPE_RATE_MAX` / `SCRAPE_CONCURRENCY_MAX`) and the `handle_import` function in `apps/tauri/src-tauri/src/extension_bridge/mod.rs`.
 
 ---
 
@@ -51,8 +53,8 @@ To actually **use** it, pair with the desktop app:
 1. Open the desktop app → go to **Settings → Browser extension**
 2. Copy the pairing token
 3. Open the extension popup → paste the token
-4. You'll see **Import via URL** and **Scan page** buttons
-5. Open a job board and click one of them
+4. You'll see the **Import this job** button
+5. Open a job board posting and click **Import this job**
 
 For **local development**, see the section below — the unpacked extension gets a dev id that doesn't match the published allowlist, so you need to set an env var when starting the desktop app.
 
@@ -97,7 +99,7 @@ The one non-obvious step is **dev pairing**: a locally-loaded (unpacked) extensi
 
 5. **Import a job:**
 
-   Open any job posting → click the extension → **Import via URL** (sends the tab url; the app fetches + parses) or **Scan page** (sends the rendered DOM, for logged-in LinkedIn etc.); tick **"I already applied"** to land it as `applied` instead of `saved`. The job appears live in the app's **Applications** list (deduped by url).
+   Open any job posting → click the extension → click **Import this job**; the extension automatically captures the rendered DOM when possible (for logged-in boards like LinkedIn that block headless fetching) and falls back to URL-only on restricted pages; tick **"I already applied"** to land it as `applied` instead of `saved`. The job appears live in the app's **Applications** list (deduped by url).
 
 **Notes:** the app must be running first (the popup shows an "AI Job Hunter isn't running" state with a Retry button otherwise). **Firefox:** `about:debugging` → **Load Temporary Add-on** → `dist/firefox/manifest.json`; its origin is a per-profile `moz-extension://<uuid>` (find it in `about:debugging`), so set `AJH_EXTENSION_DEV_ORIGINS="moz-extension://<uuid>"`. **Multiple browsers at once:** comma-separate, e.g. `chrome-extension://<id>,moz-extension://<uuid>`.
 
@@ -146,8 +148,7 @@ both browsers; it grants **no** access to any public or LAN host.
   extension. There is no telemetry, no analytics, no external API.
 - The only stored value is the pairing token, kept in `chrome.storage.local`,
   used solely to authenticate to the local desktop app.
-- Scan mode captures the current page's DOM **only when the user clicks "Scan
-  page"**, and the captured HTML is sent only to the local app.
+- The extension captures the page's rendered DOM **only when the user clicks Import this job** — never in the background — and sends it only to the local app. On restricted pages (e.g. browser system pages) DOM capture is skipped and only the URL is sent.
 
 ### Threat model
 
@@ -185,8 +186,7 @@ is expected. A reviewer testing it standalone will see, by design:
   errors, no broken UI.
 - With the app **running but unpaired**: a **pairing screen** asking for the
   64-character token from the app's Settings.
-- With the app **running and paired**: the import view (two buttons + the
-  "I already applied" checkbox).
+- With the app **running and paired**: the import view (a single **Import this job** button + the "I already applied" checkbox).
 - **On Firefox with HTTPS-Only Mode enabled**: the extension connects via
   **native messaging** (the `app.aijobhunter.bridge` host spawned by the browser)
   instead of the loopback WebSocket; this avoids the silent `ws://` → `wss://`
@@ -194,8 +194,7 @@ is expected. A reviewer testing it standalone will see, by design:
 
 To exercise the full path, install the desktop app from the project release,
 open it, copy the token from **Settings → Browser extension**, paste it into the
-extension, then open any job posting and click **Import via URL** or
-**Scan page**.
+extension, then open any job posting and click **Import this job**.
 
 ---
 

--- a/docs/knowledge/extension-domain.md
+++ b/docs/knowledge/extension-domain.md
@@ -33,6 +33,10 @@ Native-messaging registry locations are OS- and sandboxing-aware. See `apps/taur
 
 A new message type or field MUST be added to the TS shared constants (`EXTENSION_MESSAGE_TYPES`) and the Rust `msg` constants in `extension_bridge/mod.rs` in the **same change**. The TS side is the wire spec; Rust must follow. A parity test in `extension_bridge/test.rs` pins the constants.
 
+## Import flow
+
+Single unified import: `background.ts::runImport` always tries DOM capture first (`scripting.executeScript` → `content.js`), falls back to URL-only if capture is blocked (restricted pages). No user-visible mode selection — one **Import this job** button. The bridge side (`extension_bridge/mod.rs::handle_import`) acquires the shared `"scrape_url"` rate-limiter slot (same key/constants as `scrape_url` IPC: 30 req/60 s, 2 concurrent — see `limits/mod.rs` `SCRAPE_RATE_MAX` / `SCRAPE_CONCURRENCY_MAX`).
+
 ## Store policy
 
 Chrome Web Store + Firefox AMO: MV3, no remote code, least-privilege permissions, single-purpose, honest metadata, privacy/data disclosure. Full pre-submission checklist in `.claude/skills/extension-standards/SKILL.md`.

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -158,18 +158,18 @@ h2 .anchor:focus-visible{border-radius:2px}
   <div class="card">
     <span class="label">What it sends — and where</span>
     <ul>
-      <li><b>Loopback only.</b> The extension opens a WebSocket to <code>ws://127.0.0.1:&lt;port&gt;</code> — your own desktop app, on your own machine. It has <b>no remote backend</b> and contacts <b>no third-party server</b>. Its only host permission is <code>127.0.0.1</code> (loopback); it grants no access to any public or LAN address.</li>
-      <li><b>Import via URL</b> sends just the current tab's job URL to the local app, which fetches and parses it.</li>
-      <li><b>Scan page</b> captures the current page's rendered DOM <b>only when you click "Scan page"</b>, and sends that HTML only to the local app (for logged-in pages a headless fetch can't reach). Nothing is captured in the background or on page load.</li>
+      <li><b>Loopback only.</b> The extension connects to your own desktop app over native messaging (preferred) or a loopback WebSocket at <code>ws://127.0.0.1:&lt;port&gt;</code> (fallback). It has <b>no remote backend</b> and contacts <b>no third-party server</b>. Its only host permission is <code>127.0.0.1</code> (loopback); it grants no access to any public or LAN address.</li>
+      <li><b>Import this job</b> sends the current tab's URL to the local app. The extension also captures the page's rendered DOM when possible (for logged-in boards that a headless server-side fetch cannot reach), and sends that HTML only to the local app. <b>Nothing is captured in the background or on page load.</b> Capture happens only when you click Import.</li>
     </ul>
   </div>
 
   <div class="card">
     <span class="label">Permissions, and why each is there</span>
     <ul>
-      <li><code>activeTab</code> — read the URL and (in Scan mode) the DOM of the tab you clicked, <b>only on that click</b>. No standing access to any site.</li>
+      <li><code>activeTab</code> — read the URL and the DOM of the tab you clicked, <b>only on that click</b>. No standing access to any site.</li>
       <li><code>storage</code> — store the pairing token locally so you only pair once.</li>
-      <li><code>scripting</code> — MV3 requires this to inject the Scan-mode capture on demand; its reach stays limited to the active tab.</li>
+      <li><code>scripting</code> — MV3 requires this to inject the DOM capture into the active tab on import click; its reach stays limited to the active tab.</li>
+      <li><code>nativeMessaging</code> — connect to the AI Job Hunter desktop host (<code>app.aijobhunter.bridge</code>) using the browser's native-messaging channel. This is the primary transport to the local app and is immune to Firefox HTTPS-Only Mode silently upgrading <code>ws://</code> connections. Falls back to the loopback WebSocket if the native host is not registered.</li>
     </ul>
     <p class="note">
       No broad host access (<code>&lt;all_urls&gt;</code>), no <code>tabs</code> permission, no <code>webRequest</code>,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated browser extension docs to describe a single **“Import this job”** flow instead of separate import modes.
  * Clarified that imports try to capture the page content when possible, and automatically fall back to **URL-only** on restricted pages.
  * Added guidance for the **“I already applied”** checkbox and updated setup, testing, and privacy notes to match the new experience.
  * Noted that rate-limited imports now show an error instead of waiting silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->