### PR TITLE
build: pin conventional-changelog-conventionalcommits to v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [0.119.0](https://github.com/saeedkolivand/ai-job-hunter-app/compare/v0.118.2...v0.119.0) (2026-06-30)
 
+### ✨ Features
+
+* add apify linkedin aggregator provider (opt-in) ([#510](https://github.com/saeedkolivand/ai-job-hunter-app/issues/510)) ([075e240](https://github.com/saeedkolivand/ai-job-hunter-app/commit/075e24010ea48ba2105a40e8c96c5022ed63c63e))
+* export a redacted diagnostics bundle for crash reports ([#509](https://github.com/saeedkolivand/ai-job-hunter-app/issues/509)) ([87f0b97](https://github.com/saeedkolivand/ai-job-hunter-app/commit/87f0b97c4860479723c8df4a6f31f34edd48b0cb))
+* apply by email — generate a tailored application email per job ([#508](https://github.com/saeedkolivand/ai-job-hunter-app/issues/508)) ([708c6fc](https://github.com/saeedkolivand/ai-job-hunter-app/commit/708c6fc852f688840db36083b579442ff7ac0d01))
+
+### 🐛 Bug Fixes
+
+* jobs-list scroll restore, clearer selection, rewrite ux ([#506](https://github.com/saeedkolivand/ai-job-hunter-app/issues/506)) ([8dee5d6](https://github.com/saeedkolivand/ai-job-hunter-app/commit/8dee5d672a25755d307147977546b8098b2e4ae3))
+* prevent cover-letter extractor panic on multibyte job ads ([#504](https://github.com/saeedkolivand/ai-job-hunter-app/issues/504)) ([f622c5c](https://github.com/saeedkolivand/ai-job-hunter-app/commit/f622c5c08421375dd11b5af79a5cac28122eb751))
+
+### 🎨 UI/UX
+
+* align landing fleet authors header with its cards ([6efea88](https://github.com/saeedkolivand/ai-job-hunter-app/commit/6efea88298e029dae55a105b467a09ac7bf8f5f8))
+
+### 📚 Documentation
+
+* bump privacy policy last-updated date ([e640c88](https://github.com/saeedkolivand/ai-job-hunter-app/commit/e640c886d226f978997ab2306fac58361f31ae9c))
+* correct extension import mode, disclose native-messaging, note rate budget ([#507](https://github.com/saeedkolivand/ai-job-hunter-app/issues/507)) ([951a480](https://github.com/saeedkolivand/ai-job-hunter-app/commit/951a480726dc850ae0c7c956ddab33d3c0950deb))
+
 ## [0.118.2](https://github.com/saeedkolivand/ai-job-hunter-app/compare/v0.118.1...v0.118.2) (2026-06-25)
 
 ### 🎨 UI/UX

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@semantic-release/github": "^12.0.8",
     "@types/node": "^26.0.1",
     "@vitest/coverage-v8": "^4.1.9",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "eslint": "^10.6.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       conventional-changelog-conventionalcommits:
-        specifier: ^10.2.0
-        version: 10.2.0
+        specifier: ^9.3.1
+        version: 9.3.1
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
@@ -613,10 +613,6 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
-
-  '@conventional-changelog/template@1.2.0':
-    resolution: {integrity: sha512-12qHxvlKjHmP0PQ+17EREgC7lWyLwbph1RKcZQZ7k7ZWGmrxfxC9gadHGfvzr0g0u8BhiBGg3tks93txodlyRQ==}
-    engines: {node: '>=22'}
 
   '@croct/json5-parser@0.2.2':
     resolution: {integrity: sha512-0NJMLrbeLbQ0eCVj3UoH/kG2QckUgOASfwmfDTjyW1xAYPyTNJXcWVT/dssJdTJd0pRchW+qF0VFWQHcxs1OVw==}
@@ -2928,10 +2924,6 @@ packages:
   conventional-changelog-angular@8.3.1:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
     engines: {node: '>=18'}
-
-  conventional-changelog-conventionalcommits@10.2.0:
-    resolution: {integrity: sha512-UtlM9GqolY7OmlQh5L/UEVoKsTUpTgUVy1PU8JN5gl5Ydaejb7WRklGliG1SKPxxj7hzA173eG3Kt5fYWE2pmg==}
-    engines: {node: '>=22'}
 
   conventional-changelog-conventionalcommits@9.3.1:
     resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
@@ -6185,8 +6177,6 @@ snapshots:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.4.0
 
-  '@conventional-changelog/template@1.2.0': {}
-
   '@croct/json5-parser@0.2.2':
     dependencies:
       '@croct/json': 2.1.0
@@ -8305,10 +8295,6 @@ snapshots:
   conventional-changelog-angular@8.3.1:
     dependencies:
       compare-func: 2.0.0
-
-  conventional-changelog-conventionalcommits@10.2.0:
-    dependencies:
-      '@conventional-changelog/template': 1.2.0
 
   conventional-changelog-conventionalcommits@9.3.1:
     dependencies:


### PR DESCRIPTION
## Root Cause

Commit 2071dd16 upgraded `conventional-changelog-conventionalcommits` from v9.3.1 to v10.2.0. However, `@semantic-release/release-notes-generator@14.1.1` (bundled in semantic-release 25) expects v9 with `conventional-changelog-writer@8.4.0`. The v10 writer is incompatible, causing `generateNotes()` to silently render empty notes.

The commit-analyzer (which only parses) still worked, so the version bumped to 0.119.0 correctly — but the changelog was dropped entirely, losing 3 features, 2 bug fixes, and 2 documentation entries.

## Fix

1. Pin `conventional-changelog-conventionalcommits` back to v9.3.1
2. Relock `pnpm-lock.yaml`
3. Backfill the 0.119.0 CHANGELOG entry with its complete content

## Verification

- package.json: conventional-changelog-conventionalcommits ✓ ^9.3.1
- pnpm-lock.yaml: only conventional-changelog-conventionalcommits tree changed (10.2.0 removed, 9.3.1 resolved)
- CHANGELOG.md: 0.119.0 now contains 3 features + 2 bug fixes + 1 UI/UX + 2 documentation entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)