### PR TITLE
feat: add job trust / ghost-job validator with badge

### DIFF
--- a/apps/desktop/src-tauri/src/autopilot/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot/mod.rs
@@ -150,6 +150,14 @@ pub struct FoundJob {
     /// always `false`; the read path fills it in.
     #[serde(default)]
     pub applied: bool,
+    /// Ghost-job trust signal, computed at find-time via
+    /// [`crate::scraping::trust::assess_trust`]. `Option` (not a plain
+    /// [`crate::scraping::trust::TrustAssessment`]) purely so a run recorded
+    /// before this field existed still deserializes — `#[serde(default)]` gives
+    /// `None` for a legacy record; every run recorded from here on always sets
+    /// `Some(..)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust: Option<crate::scraping::trust::TrustAssessment>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -677,6 +685,12 @@ fn merge_found_jobs(existing: &[FoundJob], incoming: Vec<FoundJob>) -> Vec<Found
                 }
                 if inc.score.is_some() {
                     row.score = inc.score;
+                }
+                // Same legacy-migration case as `board` above: an existing row
+                // persisted before `trust` existed (`None`) picks it up when the
+                // same URL re-surfaces on a later run.
+                if inc.trust.is_some() {
+                    row.trust = inc.trust.clone();
                 }
             }
             row

--- a/apps/desktop/src-tauri/src/autopilot/test.rs
+++ b/apps/desktop/src-tauri/src/autopilot/test.rs
@@ -510,6 +510,7 @@ fn found_job(url: &str, found_at: u64) -> FoundJob {
         found_at,
         is_new: false,
         applied: false,
+        trust: None,
     }
 }
 
@@ -645,6 +646,39 @@ fn merge_preserves_and_refreshes_board_across_resurface() {
         a2.board,
         Some("aggregator".to_string()),
         "appended new row keeps its board (via ..inc spread)"
+    );
+}
+
+#[test]
+fn merge_preserves_and_refreshes_trust_across_resurface() {
+    // Same legacy-migration case as the board test above: an existing row
+    // persisted before `trust` existed (None) must pick up the incoming trust
+    // when the same URL re-surfaces, and a never-seen URL keeps its trust.
+    let mut existing = found_job("https://a.com/1", 100);
+    existing.trust = None; // legacy row, no trust assessment yet
+
+    let resurfaced_trust =
+        crate::scraping::trust::assess_trust("https://linkedin.com/jobs/view/1", "Acme");
+    let mut resurfaced = found_job("https://a.com/1", 999);
+    resurfaced.trust = Some(resurfaced_trust.clone());
+    let fresh_trust =
+        crate::scraping::trust::assess_trust("https://boards.greenhouse.io/acme/jobs/2", "Acme");
+    let mut fresh = found_job("https://a.com/2", 200);
+    fresh.trust = Some(fresh_trust.clone());
+
+    let merged = merge_found_jobs(&[existing], vec![resurfaced, fresh]);
+
+    let a1 = merged.iter().find(|j| j.url == "https://a.com/1").unwrap();
+    assert_eq!(
+        a1.trust,
+        Some(resurfaced_trust),
+        "re-surfaced existing row picks up the incoming trust"
+    );
+    let a2 = merged.iter().find(|j| j.url == "https://a.com/2").unwrap();
+    assert_eq!(
+        a2.trust,
+        Some(fresh_trust),
+        "appended new row keeps its trust (via ..inc spread)"
     );
 }
 

--- a/apps/desktop/src-tauri/src/commands/autopilot.rs
+++ b/apps/desktop/src-tauri/src/commands/autopilot.rs
@@ -186,42 +186,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
     let found_at = now_ms();
     let mut found_jobs: Vec<FoundJob> = postings
         .iter()
-        .map(|p| {
-            // Keyword-coverage match %: share of the JD's keywords present in the
-            // résumé, scored over the SAME blob as `commands::match_resume`
-            // (title + description + requirements via `posting_text_blob`).
-            // Embedding-free.
-            let score = if resume.is_empty() {
-                None
-            } else {
-                crate::documents::keywords::posting_text_blob(
-                    &p.title,
-                    p.description.as_deref(),
-                    p.requirements.as_deref(),
-                )
-                .map(|blob| crate::documents::keywords::coverage_score(resume, &blob))
-            };
-            FoundJob {
-                title: p.title.clone(),
-                company: p.company.clone(),
-                url: p.url.clone(),
-                location: p.location.clone(),
-                board: {
-                    let s = p.source.trim();
-                    if s.is_empty() {
-                        None
-                    } else {
-                        Some(s.to_string())
-                    }
-                },
-                description: p.description.clone(),
-                score,
-                found_at,
-                // Set by the dedup merge in `record_run`; `applied` is derived on read.
-                is_new: false,
-                applied: false,
-            }
-        })
+        .map(|p| build_found_job(p, resume, found_at))
         .collect();
 
     // Highest keyword-coverage match first; unscored postings sort to the end.
@@ -332,6 +297,53 @@ pub fn autopilot_resume(app: AppHandle, autopilot_id: String) -> Value {
 }
 
 // Helper functions
+
+/// Pure `JobPosting → FoundJob` projection — the same one `autopilot_run`'s
+/// `postings.iter().map(..)` calls. Extracted so a unit test can exercise the
+/// REAL projection (every field, plus the `assess_trust(&p.url, &p.company)`
+/// call and its arg order) instead of a hand-retyped mirror that could
+/// silently drift from this one (e.g. a dropped field or swapped args).
+pub(crate) fn build_found_job(p: &JobPosting, resume: &str, found_at: u64) -> FoundJob {
+    // Keyword-coverage match %: share of the JD's keywords present in the
+    // résumé, scored over the SAME blob as `commands::match_resume`
+    // (title + description + requirements via `posting_text_blob`).
+    // Embedding-free.
+    let score = if resume.is_empty() {
+        None
+    } else {
+        crate::documents::keywords::posting_text_blob(
+            &p.title,
+            p.description.as_deref(),
+            p.requirements.as_deref(),
+        )
+        .map(|blob| crate::documents::keywords::coverage_score(resume, &blob))
+    };
+    FoundJob {
+        title: p.title.clone(),
+        company: p.company.clone(),
+        url: p.url.clone(),
+        location: p.location.clone(),
+        board: {
+            let s = p.source.trim();
+            if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            }
+        },
+        description: p.description.clone(),
+        score,
+        found_at,
+        // Set by the dedup merge in `record_run`; `applied` is derived on read.
+        is_new: false,
+        applied: false,
+        // `p` never went through the engine's streaming wrapper (this Vec is
+        // `scraper.search()`'s own separately-returned copy, not the
+        // on_item-streamed one `ScraperEngine::run_one` attaches trust to) —
+        // compute it directly here, same pure call.
+        trust: Some(crate::scraping::trust::assess_trust(&p.url, &p.company)),
+    }
+}
 
 /// Whether a posting passes the autopilot's keyword filters: it must contain
 /// **all** must-include keywords and **none** of the exclude keywords, matched
@@ -488,6 +500,7 @@ mod tests {
             found_at: 0,
             is_new: false,
             applied: false,
+            trust: None,
         }
     }
 

--- a/apps/desktop/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/mod.rs
@@ -139,9 +139,14 @@ impl ScraperEngine {
             let reached = reached.clone();
             let kept = kept.clone();
             let token_for_wrapper = token.clone();
-            let boxed: Box<dyn Fn(JobPosting) + Send> = Box::new(move |item: JobPosting| {
+            let boxed: Box<dyn Fn(JobPosting) + Send> = Box::new(move |mut item: JobPosting| {
                 let n = streamed.fetch_add(1, Ordering::SeqCst);
                 if n < amount {
+                    // Trust assessment is attached here — the single funnel every
+                    // board's streamed item passes through before it reaches the
+                    // caller's `on_item` (PostingsCache + `job.stream`/`SCRAPE_ITEM`
+                    // for both the manual scrape and Autopilot UIs).
+                    super::trust::attach(&mut item);
                     if let Ok(mut guard) = kept.lock() {
                         guard.push(item.clone());
                     }

--- a/apps/desktop/src-tauri/src/scraping/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/mod.rs
@@ -5,6 +5,7 @@ pub mod http;
 pub mod linkedin;
 pub mod rate_limiter;
 pub mod scrape_url;
+pub mod trust;
 pub mod types;
 
 pub use engine::{BoardScrapeSummary, ScraperEngine};

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
@@ -44,7 +44,19 @@ async fn try_named_boards(url: &str) -> Result<Option<JobPosting>> {
     Ok(None)
 }
 
+/// Resolve `url` to a [`JobPosting`], with a trust assessment always attached
+/// (see [`crate::scraping::trust::attach`]) — the single point every caller
+/// (the `scrape_url`/`scrape_resolve_url` commands and the extension-bridge
+/// import) shares, so none of them need to compute it themselves.
 pub async fn resolve(url: &str) -> Result<Option<JobPosting>> {
+    let posting = resolve_uncached(url).await?;
+    Ok(posting.map(|mut p| {
+        crate::scraping::trust::attach(&mut p);
+        p
+    }))
+}
+
+async fn resolve_uncached(url: &str) -> Result<Option<JobPosting>> {
     // Pass 1: try named boards on the original URL (fast path — no redirect
     // follow needed when the caller already holds a direct board URL).
     if let Some(posting) = try_named_boards(url).await? {

--- a/apps/desktop/src-tauri/src/scraping/trust/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/trust/mod.rs
@@ -1,0 +1,212 @@
+//! Job trust / ghost-job signal — a pure, non-blocking enrichment computed for
+//! every scraped posting so the renderer can badge suspicious listings.
+//!
+//! Ported from santifer/career-ops's `providers/_trust-validator.mjs`
+//! (MIT License) — <https://github.com/santifer/career-ops>.
+//!
+//! V1 is flag-only: **enrich, never drop**. A low score never removes a
+//! posting; it only lowers [`TrustAssessment::level`] for the UI badge (a
+//! separate frontend pass). No config/enabled toggle — always computed.
+
+use super::types::JobPosting;
+use serde::{Deserialize, Serialize};
+
+/// Result of [`assess_trust`] — attached to every finalized [`JobPosting`] via
+/// [`attach`], never left unset. Also stored (as `Option`) on Autopilot's
+/// persisted `FoundJob` record, so this derives `Deserialize` too — a
+/// pre-PR3 `FoundJob` on disk has no `trust` key and deserializes `None`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustAssessment {
+    pub score: u8,
+    pub level: TrustLevel,
+    pub flags: Vec<TrustFlag>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TrustLevel {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TrustFlag {
+    MissingApplyUrl,
+    InvalidUrl,
+    SuspiciousDomain,
+    CompanyDomainMismatch,
+}
+
+/// URL-shortener domains — they obscure the real destination, a classic
+/// ghost-job / phishing tell. Suffix-matched via [`matches_domain_list`].
+const SUSPICIOUS_DOMAINS: &[&str] = &[
+    "bit.ly",
+    "tinyurl.com",
+    "t.co",
+    "forms.gle",
+    "goo.gl",
+    "shorturl.at",
+    "rebrand.ly",
+    "cutt.ly",
+];
+
+/// Hosts a `CompanyDomainMismatch` is never raised against: real ATS
+/// platforms (career-ops's original list) plus the hosts our own 21
+/// `SCRAPERS` boards legitimately return as `JobPosting.url` where that host
+/// is the BOARD's own domain rather than the employer's — LinkedIn
+/// (`linkedin.com`, always `/jobs/view/<id>`), Berlin Startup Jobs
+/// (`berlinstartupjobs.com`, its own WordPress RSS permalink), and the Adzuna
+/// aggregator (`api.adzuna.com` — the country code is a *path* segment, e.g.
+/// `/v1/api/jobs/de/redirects/…`, not a subdomain, so this one host covers
+/// every market's `redirect_url`) — so those boards' results aren't
+/// systematically flagged. JSearch's `job_apply_link` is the real employer
+/// URL, so it's intentionally left off this list.
+const ATS_ALLOWLIST: &[&str] = &[
+    "greenhouse.io",
+    "boards.greenhouse.io",
+    "ashbyhq.com",
+    "lever.co",
+    "workday.com",
+    "myworkdayjobs.com",
+    "smartrecruiters.com",
+    "recruitee.com",
+    "workable.com",
+    "apply.workable.com",
+    "icims.com",
+    "taleo.net",
+    "applytojob.com",
+    "breezy.hr",
+    "bamboohr.com",
+    "pinpointhq.com",
+    "rippling.com",
+    "ats.rippling.com",
+    "personio.de",
+    "jobs.personio.de",
+    "teamtailor.com",
+    "themuse.com",
+    "remoteok.com",
+    "remotive.com",
+    "weworkremotely.com",
+    "arbeitnow.com",
+    "linkedin.com",
+    "berlinstartupjobs.com",
+    "api.adzuna.com",
+];
+
+/// Score/flag a posting from its apply `url` and `company` name. Pure, no I/O;
+/// never panics on untrusted input.
+pub fn assess_trust(url: &str, company: &str) -> TrustAssessment {
+    let mut flags = Vec::new();
+
+    if url.trim().is_empty() {
+        flags.push(TrustFlag::MissingApplyUrl);
+        return finish(100 - 40, flags);
+    }
+
+    let parsed = match reqwest::Url::parse(url) {
+        Ok(u) if u.scheme() == "http" || u.scheme() == "https" => u,
+        _ => {
+            flags.push(TrustFlag::InvalidUrl);
+            return finish(100 - 50, flags);
+        }
+    };
+
+    let host = parsed.host_str().unwrap_or_default().to_lowercase();
+    let mut score: i32 = 100;
+
+    if matches_domain_list(&host, SUSPICIOUS_DOMAINS) {
+        flags.push(TrustFlag::SuspiciousDomain);
+        score -= 25;
+    }
+
+    if !company.trim().is_empty()
+        && !matches_domain_list(&host, ATS_ALLOWLIST)
+        && !company_matches_host(company, &host)
+    {
+        flags.push(TrustFlag::CompanyDomainMismatch);
+        score -= 15;
+    }
+
+    finish(score, flags)
+}
+
+/// Compute [`assess_trust`] for `job` and attach it as `job.extra["trust"]` —
+/// the same board-specific-metadata channel `#[serde(flatten)]` already
+/// exposes for e.g. salary, so the shape reaches the renderer without a new
+/// dedicated struct field (which would force every board's `JobPosting`
+/// literal to populate it). A serialization failure is unreachable for this
+/// all-primitive struct, but is tolerated (posting still ships, just without
+/// `trust`) rather than risking a panic on the hot scrape path.
+pub fn attach(job: &mut JobPosting) {
+    let assessment = assess_trust(&job.url, &job.company);
+    if let Ok(value) = serde_json::to_value(&assessment) {
+        job.extra.insert("trust".to_string(), value);
+    }
+}
+
+fn finish(score: i32, flags: Vec<TrustFlag>) -> TrustAssessment {
+    let score = score.clamp(0, 100) as u8;
+    let level = if score >= 90 {
+        TrustLevel::High
+    } else if score >= 60 {
+        TrustLevel::Medium
+    } else {
+        TrustLevel::Low
+    };
+    TrustAssessment {
+        score,
+        level,
+        flags,
+    }
+}
+
+/// Does `host` equal or end with `.{d}` for any domain `d` in `list`?
+pub(crate) fn matches_domain_list(host: &str, list: &[&str]) -> bool {
+    list.iter()
+        .any(|d| host == *d || host.ends_with(&format!(".{d}")))
+}
+
+/// Best-effort "is this posting's host plausibly the company's own domain (or
+/// an ATS subdomain naming it)?" check. An unjudgeable (empty-after-normalize)
+/// company name returns `true` (no flag) rather than guessing.
+///
+/// Known heuristic limitation, both directions, from the unanchored
+/// `host.contains(..)` match: (a) it **misses** a brand-embedding phishing
+/// host — `"Amazon"` vs. `amazon-careers.xyz` matches and suppresses the
+/// flag, staying `High` — and (b) a short (≤2-char, post `len >= 3` filter
+/// mostly avoids this, but a 3-char word like `"AWS"`) or generic company
+/// word can over-match an unrelated host. Label-boundary anchoring (matching
+/// `company.tld` / `company.` / `.company.` rather than a bare substring)
+/// would close (a), but was deliberately **deferred for V1**: it trades that
+/// miss for false positives on legitimate brand+suffix domains (e.g.
+/// `datadoghq.com` vs. `Datadog`, `getbamboohr.com` vs. `BambooHR`). The
+/// resulting flag is advisory/non-gating — it only lowers a badge level, it
+/// never hides or drops a posting — so the false-negative is an accepted V1
+/// trade-off. Revisit this anchoring if any future flow ever gates behavior
+/// (e.g. auto-hide, auto-skip) on `TrustAssessment::level`.
+pub(crate) fn company_matches_host(company: &str, host: &str) -> bool {
+    let normalized: String = company
+        .to_lowercase()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == ' ')
+        .collect();
+    let normalized = normalized.trim();
+    if normalized.is_empty() {
+        return true;
+    }
+
+    let slug: String = normalized.chars().filter(|c| !c.is_whitespace()).collect();
+    if !slug.is_empty() && host.contains(&slug) {
+        return true;
+    }
+
+    normalized
+        .split_whitespace()
+        .any(|word| word.len() >= 3 && host.contains(word))
+}
+
+#[cfg(test)]
+mod test;

--- a/apps/desktop/src-tauri/src/scraping/trust/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/trust/test.rs
@@ -1,0 +1,320 @@
+use super::*;
+use crate::commands::autopilot::build_found_job;
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Minimal `JobPosting` fixture — mirrors the shape a board scraper returns.
+fn posting(url: &str, company: &str) -> JobPosting {
+    JobPosting {
+        id: "job-1".to_string(),
+        external_id: None,
+        title: "Backend Engineer".to_string(),
+        company: company.to_string(),
+        location: None,
+        url: url.to_string(),
+        source: "manual".to_string(),
+        description: None,
+        requirements: None,
+        posted_at: None,
+        captured_at: 0,
+        extra: HashMap::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// assess_trust — clean job
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clean_job_scores_100_high_no_flags() {
+    let a = assess_trust("https://stripe.com/jobs/1", "Stripe");
+    assert_eq!(a.score, 100);
+    assert_eq!(a.level, TrustLevel::High);
+    assert!(a.flags.is_empty(), "expected no flags, got {:?}", a.flags);
+}
+
+// ---------------------------------------------------------------------------
+// assess_trust — missing url (early return)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_url_flags_and_early_returns() {
+    for url in ["", "   ", "\t\n"] {
+        // Company deliberately set to something that would ALSO mismatch, to
+        // prove the empty-url branch early-returns before the mismatch check
+        // ever runs.
+        let a = assess_trust(url, "Suspicious Co");
+        assert_eq!(a.score, 60, "url={url:?}");
+        assert_eq!(a.level, TrustLevel::Medium, "url={url:?}");
+        assert_eq!(
+            a.flags,
+            vec![TrustFlag::MissingApplyUrl],
+            "url={url:?} — early return must produce exactly one flag"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// assess_trust — invalid url (early return)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn invalid_url_flags_and_early_returns() {
+    for url in [
+        "javascript:alert(1)",             // parseable, non-http(s) scheme
+        "data:text/plain;base64,aGVsbG8=", // parseable, non-http(s) scheme
+        "ftp://files.example.com/x",       // parseable, non-http(s) scheme
+        "not-a-url-at-all",                // non-parseable (no scheme)
+    ] {
+        let a = assess_trust(url, "Suspicious Co");
+        assert_eq!(a.score, 50, "url={url:?}");
+        assert_eq!(a.level, TrustLevel::Low, "url={url:?}");
+        assert_eq!(
+            a.flags,
+            vec![TrustFlag::InvalidUrl],
+            "url={url:?} — early return must produce exactly one flag"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// assess_trust — suspicious domain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn suspicious_domain_flagged_and_penalized() {
+    // Company left empty so only the suspicious-domain check is exercised.
+    let a = assess_trust("https://bit.ly/x", "");
+    assert_eq!(a.score, 75);
+    assert_eq!(a.level, TrustLevel::Medium);
+    assert_eq!(a.flags, vec![TrustFlag::SuspiciousDomain]);
+}
+
+#[test]
+fn suspicious_domain_subdomain_still_flagged() {
+    let a = assess_trust("https://sub.bit.ly/x", "");
+    assert_eq!(a.score, 75);
+    assert_eq!(a.level, TrustLevel::Medium);
+    assert_eq!(a.flags, vec![TrustFlag::SuspiciousDomain]);
+}
+
+// ---------------------------------------------------------------------------
+// assess_trust — company/domain mismatch
+// ---------------------------------------------------------------------------
+
+#[test]
+fn company_domain_mismatch_flagged_and_penalized() {
+    let a = assess_trust("https://randomhost.xyz/j", "Acme");
+    assert_eq!(a.score, 85);
+    assert_eq!(a.level, TrustLevel::Medium);
+    assert_eq!(a.flags, vec![TrustFlag::CompanyDomainMismatch]);
+}
+
+// ---------------------------------------------------------------------------
+// assess_trust — allowlist suppresses mismatch
+// ---------------------------------------------------------------------------
+
+#[test]
+fn allowlisted_ats_host_suppresses_mismatch() {
+    // Company is deliberately unrelated to the host so this would flag
+    // `CompanyDomainMismatch` if the host weren't allowlisted.
+    for url in [
+        "https://boards.greenhouse.io/other-corp/jobs/55",
+        "https://greenhouse.io/jobs/99",
+    ] {
+        let a = assess_trust(url, "Weyland-Yutani");
+        assert_eq!(a.score, 100, "url={url}");
+        assert_eq!(a.level, TrustLevel::High, "url={url}");
+        assert!(a.flags.is_empty(), "url={url} flags={:?}", a.flags);
+    }
+}
+
+/// The Adzuna aggregator host — the country code is a path segment (e.g.
+/// `/v1/api/jobs/de/redirects/…`), not a subdomain, so `api.adzuna.com` alone
+/// must cover every market's `redirect_url` without flagging every posting.
+#[test]
+fn adzuna_aggregator_host_suppresses_mismatch() {
+    let a = assess_trust(
+        "https://api.adzuna.com/v1/api/jobs/de/redirects/123",
+        "Weyland-Yutani",
+    );
+    assert_eq!(a.score, 100);
+    assert_eq!(a.level, TrustLevel::High);
+    assert!(a.flags.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// assess_trust — combined penalties
+// ---------------------------------------------------------------------------
+
+#[test]
+fn suspicious_and_mismatch_combine() {
+    let a = assess_trust("https://bit.ly/xyz", "Acme");
+    assert_eq!(a.score, 60);
+    assert_eq!(a.level, TrustLevel::Medium);
+    assert_eq!(
+        a.flags,
+        vec![
+            TrustFlag::SuspiciousDomain,
+            TrustFlag::CompanyDomainMismatch
+        ]
+    );
+}
+
+/// `assess_trust`'s two combinable penalties (-25, -15) can't drive a real
+/// call below 0, so this exercises the private `finish` clamp directly to
+/// prove the floor holds regardless of how many flags/penalties pile up.
+#[test]
+fn finish_clamps_score_to_zero_never_negative() {
+    let a = finish(
+        -1000,
+        vec![
+            TrustFlag::SuspiciousDomain,
+            TrustFlag::CompanyDomainMismatch,
+        ],
+    );
+    assert_eq!(a.score, 0);
+    assert_eq!(a.level, TrustLevel::Low);
+}
+
+// ---------------------------------------------------------------------------
+// finish — level thresholds
+// ---------------------------------------------------------------------------
+
+#[test]
+fn level_threshold_boundaries() {
+    assert_eq!(finish(90, vec![]).level, TrustLevel::High);
+    assert_eq!(finish(89, vec![]).level, TrustLevel::Medium);
+    assert_eq!(finish(60, vec![]).level, TrustLevel::Medium);
+    assert_eq!(finish(59, vec![]).level, TrustLevel::Low);
+}
+
+// ---------------------------------------------------------------------------
+// attach() — the JSON contract the renderer badge deserializes
+// ---------------------------------------------------------------------------
+
+/// `attach` is the production glue (called from the scrape engine + manual
+/// `scrape_url`) that writes `job.extra["trust"]` — this is the only test
+/// proving that channel round-trips to the exact camelCase shape the
+/// renderer badge expects, not just that `assess_trust` computes correctly.
+#[test]
+fn attach_writes_expected_json_shape() {
+    let mut job = posting("https://randomhost.xyz/j", "Acme");
+    attach(&mut job);
+
+    let value = job
+        .extra
+        .get("trust")
+        .expect("attach must insert job.extra[\"trust\"]");
+
+    assert_eq!(value["score"], serde_json::json!(85));
+    assert_eq!(value["level"], serde_json::json!("medium"));
+    assert_eq!(value["flags"], serde_json::json!(["companyDomainMismatch"]));
+
+    // Round-trip through the real type — proves the shape isn't just
+    // coincidentally matching field names, it actually deserializes.
+    let assessment: TrustAssessment = serde_json::from_value(value.clone())
+        .expect("job.extra[\"trust\"] must deserialize back to TrustAssessment");
+    assert_eq!(assessment.score, 85);
+    assert_eq!(assessment.level, TrustLevel::Medium);
+    assert_eq!(assessment.flags, vec![TrustFlag::CompanyDomainMismatch]);
+}
+
+// ---------------------------------------------------------------------------
+// matches_domain_list — anchoring (security regression)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn matches_domain_list_anchors_on_label_boundary() {
+    let list = ["greenhouse.io"];
+    assert!(
+        !matches_domain_list("evil-greenhouse.io", &list),
+        "hyphen-glued lookalike must NOT match — not a real subdomain"
+    );
+    assert!(
+        !matches_domain_list("greenhouse.io.evil.com", &list),
+        "the allowlisted domain used as a prefix of an attacker host must NOT match"
+    );
+    assert!(
+        matches_domain_list("sub.greenhouse.io", &list),
+        "a real subdomain must match"
+    );
+    assert!(
+        matches_domain_list("greenhouse.io", &list),
+        "an exact host must match"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// company_matches_host — current documented behavior
+// ---------------------------------------------------------------------------
+
+#[test]
+fn company_matches_host_documented_behavior() {
+    // Intentionally-deferred V1 limitation (see the doc comment on
+    // `company_matches_host`): the unanchored `host.contains(slug)` check
+    // matches a brand-embedding phishing host, suppressing the mismatch flag.
+    // This assertion documents the REAL current behavior, not the ideal one —
+    // label-boundary anchoring was deliberately deferred to avoid false
+    // positives on legit brand+suffix domains (e.g. datadoghq.com/Datadog).
+    assert!(
+        company_matches_host("Amazon", "amazon-careers.xyz"),
+        "known deferred limitation: unanchored substring match suppresses \
+         the flag for a brand-embedding phishing-style host"
+    );
+
+    // Direction (b), same doc comment: a short/generic (>=3 char) company
+    // word can over-match an unrelated host that merely happens to contain
+    // it. "Cloud" is generic enough to appear in a host with no real
+    // relation to "Bright Cloud Systems" — the word-level fallback (not the
+    // full-slug check, since "brightcloudsystems" isn't a substring of the
+    // host) suppresses the flag anyway. Documents the real current
+    // behavior, not the ideal one.
+    assert!(
+        company_matches_host("Bright Cloud Systems", "cloudhosting.io"),
+        "known deferred limitation: a generic company word (\"cloud\") \
+         over-matches an unrelated host that merely contains the word"
+    );
+
+    // An unjudgeable (empty-after-normalize) company never raises a flag.
+    assert!(company_matches_host("", "anything.example.com"));
+    assert!(company_matches_host("   ", "anything.example.com"));
+
+    // Exact brand host is the intended-to-work case.
+    assert!(company_matches_host("Stripe", "stripe.com"));
+}
+
+// ---------------------------------------------------------------------------
+// FoundJob wiring — exercises the REAL `build_found_job` projection (the
+// same one `autopilot_run`'s `postings.iter().map(..)` calls), not a
+// hand-retyped mirror that could silently drift (dropped field, swapped args).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn found_job_carries_trust_from_real_build_found_job() {
+    // Asymmetric on purpose: "Acme" shares no substring with "randomhost.xyz",
+    // so a swapped-arg regression (`assess_trust(company, url)` instead of
+    // `assess_trust(url, company)`) would try to parse "Acme" as a url —
+    // InvalidUrl/50/Low — instead of the real 85/Medium/[CompanyDomainMismatch]
+    // result below, and this test would fail.
+    let p = posting("https://randomhost.xyz/j", "Acme");
+
+    let found = build_found_job(&p, "", 0);
+    let expected = assess_trust(&p.url, &p.company);
+
+    let trust = found
+        .trust
+        .expect("build_found_job must always set Some(..)");
+    assert_eq!(trust.score, expected.score);
+    assert_eq!(trust.level, expected.level);
+    assert_eq!(trust.flags, expected.flags);
+
+    // Pin the concrete values too, not just equality against a second call
+    // to the same function.
+    assert_eq!(trust.score, 85);
+    assert_eq!(trust.level, TrustLevel::Medium);
+    assert_eq!(trust.flags, vec![TrustFlag::CompanyDomainMismatch]);
+}

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -30,6 +30,7 @@ import {
 import { type AutopilotRunState, RUN_STATE_LABEL } from '@/lib/machines/autopilot-run.machine';
 import { MatchBand } from '@/lib/match-band';
 import { timeAgo } from '@/lib/time';
+import { TrustBadge } from '@/lib/trust-badge';
 import { useInteractions, useOpenExternal, usePersistJob } from '@/services';
 
 interface StepLog {
@@ -362,6 +363,13 @@ export function AutopilotCard({
                               {t('jobs.viewed')}
                             </Tag>
                           )}
+                          {/* interactive=false: this whole row is already a <Button> (handleJobClick) —
+                              a nested focusable popover trigger would be invalid HTML (button-in-button). */}
+                          <TrustBadge
+                            trust={job.trust}
+                            className={STATUS_TAG}
+                            interactive={false}
+                          />
                         </div>
                         <div className="flex items-center gap-1.5 text-[10px] text-foreground/40">
                           <span className="truncate">{job.company}</span>

--- a/apps/desktop/src/renderer/features/jobs/components/JobDetailPane/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobDetailPane/index.tsx
@@ -32,6 +32,7 @@ import { RowMatchScore } from '@/features/jobs/components/RowMatchScore';
 import { usePostingActions } from '@/features/jobs/hooks/usePostingActions';
 import { useMatchScores } from '@/features/jobs/providers';
 import type { Posting } from '@/features/jobs/types';
+import { TrustBadge } from '@/lib/trust-badge';
 import { useResolveJobUrl, useUpdatePostingDescription } from '@/services';
 
 // ponytail: heuristic threshold — Adzuna search snippets are ~200–500 chars;
@@ -236,6 +237,7 @@ function DetailContent({
                   {t('jobs.saved')}
                 </Tag>
               )}
+              <TrustBadge trust={posting.trust} className={statusTagCls} />
             </div>
           </div>
 

--- a/apps/desktop/src/renderer/features/jobs/components/PostingListItem/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PostingListItem/index.tsx
@@ -6,6 +6,7 @@ import { cn, resolveTransition, transition } from '@ajh/ui';
 
 import { CompanyAvatar } from '@/features/jobs/components/CompanyAvatar';
 import type { Posting } from '@/features/jobs/types';
+import { TrustBadge } from '@/lib/trust-badge';
 
 interface PostingListItemProps {
   posting: Posting;
@@ -118,7 +119,12 @@ export function PostingListItem({
             {posting.postedAt && (
               <span className="shrink-0">· {formatRelativeTime(posting.postedAt)}</span>
             )}
-            {/* Status markers — decorative (aria-hidden); SR summary above */}
+            {/* Status markers — decorative (aria-hidden); SR summary above.
+                TrustBadge is `interactive={false}` here: rows are never real tab
+                stops (active-descendant pattern below) — a focusable popover
+                trigger would add an unexpected extra stop per row. `strong`
+                forces an opaque fill since the selected row's gradient pill can
+                undercut the default translucent tint's contrast. */}
             <span className="ml-auto flex shrink-0 items-center gap-1">
               {has('applied') && <CircleCheck size={12} aria-hidden="true" />}
               {/* "Viewed" text label replaces the eye icon — aria-hidden since SR uses the summary above */}
@@ -128,6 +134,12 @@ export function PostingListItem({
                 </span>
               )}
               {has('bookmarked') && <Bookmark size={12} aria-hidden="true" />}
+              <TrustBadge
+                trust={posting.trust}
+                className="px-1 py-0 text-[9px]"
+                strong={selected}
+                interactive={false}
+              />
             </span>
           </div>
         </div>

--- a/apps/desktop/src/renderer/features/jobs/components/PostingRow/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PostingRow/index.tsx
@@ -17,6 +17,7 @@ import { ActionMenu, Button, SourceBadge, Tag, transition } from '@ajh/ui';
 import { CompanyAvatar } from '@/features/jobs/components/CompanyAvatar';
 import { usePostingActions } from '@/features/jobs/hooks/usePostingActions';
 import type { Posting } from '@/features/jobs/types';
+import { TrustBadge } from '@/lib/trust-badge';
 
 interface PostingRowProps {
   posting: Posting;
@@ -62,6 +63,7 @@ export function PostingRow({ posting, formatRelativeTime }: PostingRowProps) {
               {t('jobs.saved')}
             </Tag>
           )}
+          <TrustBadge trust={posting.trust} className={STATUS_TAG} />
         </div>
         <div className="mt-1 flex items-center gap-4 text-fine-print">
           <span className="flex items-center gap-1.5 text-foreground/85">

--- a/apps/desktop/src/renderer/features/jobs/types.ts
+++ b/apps/desktop/src/renderer/features/jobs/types.ts
@@ -1,4 +1,4 @@
-import type { JobInteraction } from '@ajh/shared';
+import type { JobInteraction, JobTrustAssessment } from '@ajh/shared';
 
 export interface Posting {
   id: string;
@@ -13,6 +13,9 @@ export interface Posting {
   postedAt?: number;
   capturedAt: number;
   interactions?: JobInteraction[];
+  /** Ghost-job trust signal, computed at scrape-time. Absent on postings
+   *  captured before this field existed. */
+  trust?: JobTrustAssessment;
 }
 
 export interface JobEvent {

--- a/apps/desktop/src/renderer/lib/trust-badge.test.tsx
+++ b/apps/desktop/src/renderer/lib/trust-badge.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * TrustBadge — level gating, resolved i18n copy, and an i18n key-drift guard.
+ *
+ * Deliberately does NOT mock `@ajh/translations` (unlike most sibling tests —
+ * see e.g. `match-band.test.tsx`'s `t: (k) => k` raw-key stub). The whole
+ * point of the flag-label tests below is to catch a broken
+ * `t(`jobs.trust.flags.${flag}`)` template string (typo'd key, missing
+ * resource entry) — a raw-key stub would just echo the key back and could
+ * never fail this way, and TypeScript can't check a key built at runtime.
+ * `@ajh/translations` resolves to real source in vitest (see
+ * `vitest.config.ts`'s alias) and initializes with the real bundled en/de
+ * resources as an import side effect, so `t()` here returns real English
+ * copy — or, if a key is missing/mistyped, the raw key string, which the
+ * tests below assert does NOT appear.
+ *
+ * `@ajh/ui` (Button/Tag/HoverPopover) is also left unmocked — all three are
+ * simple, provider-free components here, so real rendering is cheap and
+ * avoids a stub silently drifting from the real trigger/DOM shape.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import type { JobTrustAssessment } from '@ajh/shared';
+
+import { TrustBadge } from './trust-badge';
+
+type TrustFlag = JobTrustAssessment['flags'][number];
+
+function assessment(
+  level: JobTrustAssessment['level'],
+  flags: TrustFlag[] = []
+): JobTrustAssessment {
+  return { score: 50, level, flags };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Level gating — no badge for a missing assessment or a trusted (high) one.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('TrustBadge — level gating', () => {
+  it('renders nothing when trust is undefined', () => {
+    const { container } = render(<TrustBadge trust={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for level "high" (no badge = trusted)', () => {
+    const { container } = render(<TrustBadge trust={assessment('high')} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Resolved level labels — must be real copy, not the raw i18n key.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('TrustBadge — resolved level labels', () => {
+  it('shows "Medium trust" (resolved copy, not the raw key) for level medium', () => {
+    const { container } = render(<TrustBadge trust={assessment('medium', ['suspiciousDomain'])} />);
+    expect(screen.getByText('Medium trust')).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(/jobs\.trust\.level\./);
+  });
+
+  it('shows "Low trust" (resolved copy, not the raw key) for level low', () => {
+    const { container } = render(<TrustBadge trust={assessment('low', ['invalidUrl'])} />);
+    expect(screen.getByText('Low trust')).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(/jobs\.trust\.level\./);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// i18n key-drift guard — the point of this file. Every `TrustFlag` must
+// resolve through `jobs.trust.flags.${flag}` to real copy; a broken template
+// string / missing resource entry would leave the raw key visible instead.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FLAG_LABEL: Record<TrustFlag, string> = {
+  missingApplyUrl: 'Missing apply link',
+  invalidUrl: 'Broken apply link',
+  suspiciousDomain: 'Suspicious domain',
+  companyDomainMismatch: "Domain doesn't match company",
+};
+
+const ALL_FLAGS = Object.keys(FLAG_LABEL) as TrustFlag[];
+
+describe('TrustBadge — i18n key-drift guard (every flag)', () => {
+  it.each(ALL_FLAGS)(
+    'flag "%s" resolves to real copy, no raw i18n key leaks into the DOM',
+    (flag) => {
+      const { container } = render(<TrustBadge trust={assessment('medium', [flag])} />);
+      expect(container.textContent).toContain(FLAG_LABEL[flag]);
+      expect(container.textContent).not.toMatch(/jobs\.trust\.flags\./);
+    }
+  );
+
+  it('joins multiple flag labels with ", " in the reasons text', () => {
+    const { container } = render(
+      <TrustBadge trust={assessment('low', ['missingApplyUrl', 'suspiciousDomain'])} />
+    );
+    expect(container.textContent).toContain('Missing apply link, Suspicious domain');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// interactive prop — false drops the focusable popover trigger; reasons stay
+// reachable via the always-present sr-only suffix either way.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('TrustBadge — interactive prop', () => {
+  it('interactive=false renders inline with no focusable trigger; reasons still present via sr-only text', () => {
+    const { container } = render(
+      <TrustBadge trust={assessment('medium', ['suspiciousDomain'])} interactive={false} />
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText('Medium trust')).toBeInTheDocument();
+    expect(container.textContent).toContain('Suspicious domain');
+  });
+
+  it('interactive=true (default) renders a focusable popover trigger button', () => {
+    render(<TrustBadge trust={assessment('medium', ['suspiciousDomain'])} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// strong prop — opaque solid-fill path; not asserting exact color classes,
+// just that both variants mount and still show the resolved label.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('TrustBadge — strong prop', () => {
+  it('mounts without error for both medium and low when strong', () => {
+    const { rerender } = render(
+      <TrustBadge trust={assessment('medium', ['suspiciousDomain'])} strong />
+    );
+    expect(screen.getByText('Medium trust')).toBeInTheDocument();
+
+    rerender(<TrustBadge trust={assessment('low', ['invalidUrl'])} strong />);
+    expect(screen.getByText('Low trust')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/lib/trust-badge.tsx
+++ b/apps/desktop/src/renderer/lib/trust-badge.tsx
@@ -1,0 +1,90 @@
+import { ShieldAlert } from 'lucide-react';
+
+import type { JobTrustAssessment } from '@ajh/shared';
+import { useTranslation } from '@ajh/translations';
+import { Button, cn, HoverPopover, Tag } from '@ajh/ui';
+
+/**
+ * Ghost-job trust badge — flag-only, V1: renders NOTHING for `level === 'high'`
+ * or a missing `trust` (no badge = trusted, keeps the common case noise-free).
+ * The visible label names the signal explicitly ("Low trust" / "Medium trust")
+ * so it can't be mistaken for a generic "unverified account" state and reads
+ * distinctly from the adjacent match-score Low/Medium/High tag. `low` gets the
+ * stronger (error) tint, `medium` the softer (warning) one — both stay advisory,
+ * never alarming.
+ *
+ * The "why" (which flags fired) is reachable by mouse AND keyboard via a
+ * `HoverPopover` (focus-triggerable, unlike a native `title`), plus an
+ * always-present sr-only suffix folded into the trigger's accessible name so
+ * screen readers get the detail without needing to open the popover.
+ */
+export function TrustBadge({
+  trust,
+  className,
+  strong,
+  interactive = true,
+}: {
+  trust?: JobTrustAssessment;
+  className?: string;
+  /** Force an opaque solid fill instead of the default translucent tint — use
+   *  when the badge sits over a tinted/gradient surface (e.g. a selected row
+   *  highlight) where the translucent tint's contrast against that surface
+   *  isn't guaranteed. */
+  strong?: boolean;
+  /** Set false on a surface where rows are deliberately never real tab stops
+   *  (an aria-activedescendant listbox) — a focusable popover trigger there
+   *  would add an unexpected extra stop per row. Renders the badge + an
+   *  sr-only reasons suffix instead, read as part of the row's own content
+   *  when it becomes the active descendant. Default true. */
+  interactive?: boolean;
+}) {
+  const { t } = useTranslation();
+  if (!trust || trust.level === 'high') return null;
+
+  const isLow = trust.level === 'low';
+  const levelLabel = t(`jobs.trust.level.${trust.level}`);
+  const reasons = trust.flags.map((flag) => t(`jobs.trust.flags.${flag}`)).join(', ');
+
+  const badge = (
+    <Tag
+      color={isLow ? 'error' : 'warning'}
+      icon={<ShieldAlert size={8} aria-hidden="true" />}
+      className={cn(
+        'rounded-full px-1.5 py-0.5 uppercase tracking-wider',
+        strong &&
+          (isLow
+            ? 'border-transparent bg-red-700 text-white'
+            : 'border-transparent bg-amber-700 text-white'),
+        className
+      )}
+    >
+      {levelLabel}
+    </Tag>
+  );
+
+  if (!interactive || !reasons) {
+    return (
+      <span className="inline-flex items-center gap-1">
+        {badge}
+        {reasons && <span className="sr-only">: {reasons}</span>}
+      </span>
+    );
+  }
+
+  return (
+    <HoverPopover
+      placement="top"
+      ariaLabel={reasons}
+      trigger={
+        <Button variant="unstyled" className="inline-flex items-center rounded-full">
+          {badge}
+          <span className="sr-only">: {reasons}</span>
+        </Button>
+      }
+    >
+      <p className="dropdown-surface max-w-[220px] px-3 py-2 text-fine-print leading-snug text-foreground/70">
+        {reasons}
+      </p>
+    </HoverPopover>
+  );
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -736,6 +736,14 @@ interface JobPosting {
   remote?: 'yes' | 'no' | 'hybrid';
   postedAt?: string;
   scrapedAt: string;
+  // Ghost-job trust signal, always populated by the backend (non-blocking —
+  // flag-only, never drops a posting). See docs/knowledge/scraping-domain.md
+  // § Trust assessment.
+  trust?: {
+    score: number; // 0–100
+    level: 'high' | 'medium' | 'low';
+    flags: Array<'missingApplyUrl' | 'invalidUrl' | 'suspiciousDomain' | 'companyDomainMismatch'>;
+  };
 }
 
 interface ScrapeResult {

--- a/docs/knowledge/scraping-domain.md
+++ b/docs/knowledge/scraping-domain.md
@@ -85,6 +85,75 @@ Adzuna's API is country-scoped with a fixed market allowlist; see `ADZUNA_SUPPOR
 - **Empty results:** Legitimate (do NOT trigger fallback to next provider; only errors do).
 - **Cancellation:** Pre-fallback cancel signal skips the paid provider entirely.
 
+## Trust assessment (PR 3, 2026-07-01)
+
+Every finalized `JobPosting` carries a **ghost-job / trust signal** — a pure,
+non-blocking enrichment ported from `santifer/career-ops`'s
+`providers/_trust-validator.mjs` (MIT). V1 is **flag-only: enrich, never
+drop** — a low score never removes a posting, it only lowers the level for a
+renderer badge (separate frontend pass). No config/enabled toggle; always
+computed.
+
+- **Module:** `apps/desktop/src-tauri/src/scraping/trust/mod.rs` —
+  `pub fn assess_trust(url: &str, company: &str) -> TrustAssessment` (pure,
+  no I/O, no new deps — `reqwest::Url`, i.e. the `url` crate reqwest
+  re-exports). All helpers `pub(crate)` for fixture testing.
+- **Shape:** `TrustAssessment { score: u8, level: TrustLevel, flags: Vec<TrustFlag> }`.
+  `score` starts at 100 and is only ever decreased, clamped `0..=100`.
+  `level`: `>=90 High`, `>=60 Medium`, else `Low`. The renderer `TrustBadge` only displays for `'medium'` or `'low'`; `'high'` renders no badge (no badge = trusted, noise-free).
+- **Flags** — four signals, each decrements `score` by a penalty amount (see
+  `SUSPICIOUS_DOMAINS`, `ATS_ALLOWLIST`, and `finish()` in
+  `apps/desktop/src-tauri/src/scraping/trust/mod.rs` for penalty magnitudes
+  and thresholds):
+  - `MissingApplyUrl` (early return) — `url` empty/whitespace.
+  - `InvalidUrl` (early return) — `url` doesn't parse or scheme isn't `http(s)`.
+  - `SuspiciousDomain` — host is a URL shortener (see `SUSPICIOUS_DOMAINS`
+    constant).
+  - `CompanyDomainMismatch` — `company` is non-empty, the host isn't on the
+    ATS allowlist, and the host doesn't plausibly name the company (normalized
+    slug or a ≥3-char word match).
+- **ATS allowlist** — never raises `CompanyDomainMismatch`. See `ATS_ALLOWLIST`
+  constant in `apps/desktop/src-tauri/src/scraping/trust/mod.rs`; includes the
+  standard ATS platforms (Greenhouse, Lever, etc.) plus our 21 `SCRAPERS` boards
+  where `JobPosting.url` is systematically the BOARD's own domain rather than the
+  employer's, plus the Adzuna aggregator (whose redirect host is a constant
+  `api.adzuna.com` — country code is a path segment, not a subdomain).
+- **`company_matches_host` is an unanchored substring heuristic**, not
+  label-boundary matching — see the doc comment in `trust/mod.rs` for the
+  known both-direction trade-off (misses a brand-embedding phishing host like
+  `amazon-careers.xyz`; a short/generic company word can over-match).
+  Deliberately deferred for V1 since the flag is advisory/non-gating; anchor
+  it if a future flow ever gates behavior on `level`.
+- **Wiring — three call sites** (every other `JobPosting`/`FoundJob`
+  construction site is untouched; `JobPosting.trust` is NOT a dedicated
+  struct field, to avoid touching all ~21 board literals — it's attached into
+  the existing `#[serde(flatten)] extra: HashMap<String, Value>` channel, the
+  same one salary/remote-status metadata already uses):
+  - `ScraperEngine::run_one`'s streaming wrapper
+    (`apps/desktop/src-tauri/src/scraping/engine/mod.rs`) — the funnel every
+    board's streamed item passes through before reaching either caller's
+    `on_item` (manual scrape → `PostingsCache` + `job.stream`; Autopilot's
+    _live_ scrape stream → `SCRAPE_ITEM`).
+  - `scrape_url::resolve()` (`apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs`)
+    — the single-URL resolver shared by the `scrape_url`/`scrape_resolve_url`
+    commands and the extension-bridge import (import doesn't persist `trust`
+    — it only ever writes an `ApplicationMeta`, not the postings/`JobPosting`
+    contract).
+  - `commands::autopilot::autopilot_run`'s `postings → FoundJob` `.map()`
+    (`apps/desktop/src-tauri/src/commands/autopilot.rs`) — the **persisted**
+    `AutopilotFoundJob` record the badge UI actually reads is built from the
+    board's separately-returned `Vec<JobPosting>`, not the streamed copy the
+    engine wrapper attaches to, so it calls `assess_trust` directly (a pure,
+    cheap call — no need to round-trip through `extra`). `FoundJob.trust` is
+    `Option<TrustAssessment>` (unlike `JobPosting`'s always-`Some`): a run
+    recorded before this field existed deserializes with `None`
+    (`#[serde(default)]`), every run recorded from here on sets `Some(..)`.
+- **Contract:** `packages/shared/src/types/index.ts` — `JobTrustAssessment`,
+  `JobPosting.trust?`, and `AutopilotFoundJob.trust?`. None are
+  Zod-schema-derived (like the rest of those two interfaces), so none are
+  `gen:ipc`-generated; kept hand-in-sync with the Rust serde shapes, same as
+  every other field on both interfaces.
+
 ## Scrape results persistence (PR #463)
 
 Results now persist across navigation thanks to React Query + backend cache:

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -65,6 +65,17 @@ export interface DocumentRecord {
   isDefault?: boolean;
 }
 
+/**
+ * Ghost-job / trust signal computed for every scraped posting (backend,
+ * always populated — never absent on a real posting). Flag-only: a low score
+ * never removes a posting, it only badges it in the renderer.
+ */
+export interface JobTrustAssessment {
+  score: number;
+  level: 'high' | 'medium' | 'low';
+  flags: Array<'missingApplyUrl' | 'invalidUrl' | 'suspiciousDomain' | 'companyDomainMismatch'>;
+}
+
 export interface JobPosting {
   id: string;
   externalId?: string;
@@ -77,6 +88,7 @@ export interface JobPosting {
   requirements?: string[];
   postedAt?: number;
   capturedAt: number;
+  trust?: JobTrustAssessment;
   /** Board-specific metadata (salary, remote status, etc.) */
   [key: string]: unknown;
 }
@@ -256,6 +268,9 @@ export interface AutopilotFoundJob {
   /** The user has generated an application for this job (derived from a saved
    *  generation whose `jobUrl` matches `url`). Drives the "Applied" badge. */
   applied?: boolean;
+  /** Ghost-job trust signal, computed at find-time. Absent only on a run
+   *  recorded before this field existed. */
+  trust?: JobTrustAssessment;
 }
 
 /** Result record for a single autopilot run. */

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1723,6 +1723,18 @@
       "High": "Hoch",
       "Medium": "Mittel",
       "Low": "Niedrig"
+    },
+    "trust": {
+      "level": {
+        "medium": "Fraglich",
+        "low": "Riskant"
+      },
+      "flags": {
+        "missingApplyUrl": "Kein Bewerbungslink",
+        "invalidUrl": "Bewerbungslink fehlerhaft",
+        "suspiciousDomain": "Verdächtige Domain",
+        "companyDomainMismatch": "Domain stimmt nicht mit Unternehmen überein"
+      }
     }
   },
   "resumes": {

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1719,6 +1719,18 @@
       "High": "High",
       "Medium": "Medium",
       "Low": "Low"
+    },
+    "trust": {
+      "level": {
+        "medium": "Medium trust",
+        "low": "Low trust"
+      },
+      "flags": {
+        "missingApplyUrl": "Missing apply link",
+        "invalidUrl": "Broken apply link",
+        "suspiciousDomain": "Suspicious domain",
+        "companyDomainMismatch": "Domain doesn't match company"
+      }
     }
   },
   "resumes": {


### PR DESCRIPTION
## What

Adds a **job trust / ghost-job validator** — scores every scraped job for scam/ghost-posting signals and surfaces a badge on low-trust listings. **PR 3 of 3** from the [santifer/career-ops](https://github.com/santifer/career-ops) (MIT) evaluation, after #513 (4 ATS boards) and #529 (The Muse). Ported from `_trust-validator.mjs`, attributed in the module header.

## How it works

Pure Rust validator (`scraping/trust/mod.rs`) — start at 100, subtract:
| Flag | Penalty |
|---|---|
| `missingApplyUrl` | −40 (early return) |
| `invalidUrl` (non-http scheme / unparseable) | −50 (early return) |
| `suspiciousDomain` (url-shortener host) | −25 |
| `companyDomainMismatch` (company name absent from host, host not on ATS/aggregator allowlist) | −15 |

Then classify **≥90 High / ≥60 Medium / else Low**. **Enrich, never drop.** (Exact penalties/lists live in the `trust` module consts — docs point at them rather than restating.)

- **Allowlist** includes our ATS board hosts + `api.adzuna.com` (the aggregator's constant redirect host) so our own primary results aren't systematically flagged.
- **Attached** at the pipeline stream funnel + url-resolve path + the Autopilot `build_found_job` projection, and carried across a re-surfaced job in `merge_found_jobs` — so every renderer surface has it. Exposed via a `trust` field on the shared `JobPosting`/`AutopilotFoundJob` contract (serde-flatten).

## Badge

`TrustBadge` (`renderer/lib/`, shared like `MatchBand`) renders **only for Medium/Low** (High = trusted → no badge). Reuses MatchBand's warning/error color language; a single soft flag can only reach Medium/warning (never Low/error), so legit aggregator jobs never get an alarming red badge. Flags are exposed via a **keyboard-reachable `HoverPopover`**; selected rows use an opaque fill to stay AA-contrast over the row gradient. Placed on the detail pane, both list views, and the Autopilot card.

## Known V1 limitation (documented, non-gating)

`company_matches_host` uses an unanchored substring match (faithful to the source). It can miss brand-embedding phishing hosts (`amazon-careers.xyz`) and short slugs over-match. We deliberately kept the faithful port for V1 rather than label-anchoring, which would trade that for false-positives on legit brand+suffix domains (`datadoghq.com`); the flag is advisory/non-gating. Revisit if any flow ever gates behavior on `level`.

## Tests

- **16 Rust** — scoring per flag + early returns + clamp + thresholds, allowlist suppression (incl. `api.adzuna.com`), `matches_domain_list` label-boundary anchoring (`evil-greenhouse.io` not matched), `attach()` camelCase JSON-shape round-trip, the real `build_found_job` projection with asymmetric args (catches swapped `assess_trust` args), and the `merge_found_jobs` resurface carry-over.
- **12 TrustBadge** — level gating, resolved i18n labels, an i18n key-drift guard (uses real translations), and the `interactive`/`strong` paths.

## Review trail (pre-CodeRabbit)

scraping-applier-expert + tauri-security-reviewer (backend — fixed 2 HIGH: Autopilot coverage, Adzuna allowlist; security confirmed panic-safe + allowlist correctly anchored, no IPC injection) · testing-reviewer (fixed 2 HIGH: `attach` test + real `build_found_job` guard) · frontend-reviewer + ui-ux-expert (badge — fixed keyboard a11y, button-in-button, selected-row AA contrast, placement, i18n terseness) · pr-reviewer (final — **PASS**; its one MEDIUM, the resurface carry-over, is fixed here). All gates green: `cargo test` (whole crate), `pnpm -F @ajh/desktop test` (1831), typecheck, lint:strict, gen:ipc:check, cargo fmt.
