### PR TITLE
fix: harden rippling scraper against a single malformed row

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
@@ -78,9 +78,12 @@ pub(crate) struct RpJob {
 /// Deserialize each row independently, dropping (with a debug log) any row
 /// that fails — e.g. a missing `uuid` or a non-object/non-string
 /// `workLocation`. Without this, `Vec<RpJob>`'s atomic deserialize would fail
-/// the whole company on a single malformed row (silent zero-jobs).
+/// the whole company on a single malformed row (silent zero-jobs). If every
+/// row in the batch fails (schema drift), a `warn!` still fires so a
+/// whole-batch zero-jobs isn't silently counted as a successful fetch.
 pub(crate) fn rows_to_jobs(values: Vec<serde_json::Value>) -> Vec<RpJob> {
-    values
+    let total = values.len();
+    let jobs: Vec<RpJob> = values
         .into_iter()
         .filter_map(|v| match serde_json::from_value::<RpJob>(v) {
             Ok(job) => Some(job),
@@ -89,7 +92,12 @@ pub(crate) fn rows_to_jobs(values: Vec<serde_json::Value>) -> Vec<RpJob> {
                 None
             }
         })
-        .collect()
+        .collect();
+    let skipped = total - jobs.len();
+    if skipped > 0 {
+        log::warn!("[rippling] skipped {skipped}/{total} malformed rows");
+    }
+    jobs
 }
 
 /// Map a parsed Rippling response into postings for one company. Standalone

--- a/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
@@ -75,6 +75,23 @@ pub(crate) struct RpJob {
     work_location: Option<RpWorkLocation>,
 }
 
+/// Deserialize each row independently, dropping (with a debug log) any row
+/// that fails — e.g. a missing `uuid` or a non-object/non-string
+/// `workLocation`. Without this, `Vec<RpJob>`'s atomic deserialize would fail
+/// the whole company on a single malformed row (silent zero-jobs).
+pub(crate) fn rows_to_jobs(values: Vec<serde_json::Value>) -> Vec<RpJob> {
+    values
+        .into_iter()
+        .filter_map(|v| match serde_json::from_value::<RpJob>(v) {
+            Ok(job) => Some(job),
+            Err(e) => {
+                log::debug!("[rippling] skipping malformed row: {e}");
+                None
+            }
+        })
+        .collect()
+}
+
 /// Map a parsed Rippling response into postings for one company. Standalone
 /// (no `&self`) so it is unit-testable against a JSON fixture.
 pub(crate) fn parse_rippling_response(
@@ -187,8 +204,12 @@ impl Scraper for RipplingScraper {
                 urlencoding::encode(company)
             );
 
-            let data = match fetch_json::<Vec<RpJob>>(&url, Default::default(), ctx.signal.clone())
-                .await
+            let data = match fetch_json::<Vec<serde_json::Value>>(
+                &url,
+                Default::default(),
+                ctx.signal.clone(),
+            )
+            .await
             {
                 Ok(d) => d,
                 Err(e) => {
@@ -209,7 +230,7 @@ impl Scraper for RipplingScraper {
             let jobs = match data {
                 Some(d) => {
                     successful_fetches += 1;
-                    d
+                    rows_to_jobs(d)
                 }
                 None => {
                     if let Some(ref on_progress) = ctx.on_progress {

--- a/apps/desktop/src-tauri/src/scraping/boards/rippling/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/rippling/test.rs
@@ -255,6 +255,63 @@ async fn cancelled_before_fetch_returns_ok_not_err() {
 }
 
 // ---------------------------------------------------------------------------
+// rows_to_jobs — per-row resilience (regression guard for silent-batch-loss)
+// ---------------------------------------------------------------------------
+
+/// Core regression guard: one malformed row (missing required `uuid`) must
+/// not fail the whole batch — the other, well-formed rows must still come
+/// through. Before this fix, `fetch_json::<Vec<RpJob>>` deserialized the
+/// array atomically, so a single bad row silently yielded zero jobs.
+#[test]
+fn rows_to_jobs_skips_row_missing_uuid_keeps_good_rows() {
+    let values: Vec<serde_json::Value> = serde_json::from_str(
+        r#"[
+            {"uuid": "good-1", "name": "Engineer One", "url": "https://ats.rippling.com/acme/jobs/good-1", "workLocation": null},
+            {"name": "No UUID Row", "url": "https://ats.rippling.com/acme/jobs/x", "workLocation": null},
+            {"uuid": "good-2", "name": "Engineer Two", "url": "https://ats.rippling.com/acme/jobs/good-2", "workLocation": null}
+        ]"#,
+    )
+    .unwrap();
+
+    let jobs = rows_to_jobs(values);
+    let uuids: Vec<&str> = jobs.iter().map(|j| j.uuid.as_str()).collect();
+    assert_eq!(
+        uuids,
+        vec!["good-1", "good-2"],
+        "the missing-uuid row must be dropped, both good rows kept: {uuids:?}"
+    );
+}
+
+/// A non-object `workLocation` (e.g. a bare number, which the untagged enum
+/// can't match as either `Object` or `Text`) fails per-row deserialize and
+/// must be skipped without taking down sibling rows.
+#[test]
+fn rows_to_jobs_skips_row_with_non_object_work_location() {
+    let values: Vec<serde_json::Value> = serde_json::from_str(
+        r#"[
+            {"uuid": "good-1", "name": "Engineer One", "url": "https://ats.rippling.com/acme/jobs/good-1", "workLocation": null},
+            {"uuid": "bad-location", "name": "Bad Location", "url": "https://ats.rippling.com/acme/jobs/bad-location", "workLocation": 42},
+            {"uuid": "good-2", "name": "Engineer Two", "url": "https://ats.rippling.com/acme/jobs/good-2", "workLocation": null}
+        ]"#,
+    )
+    .unwrap();
+
+    let jobs = rows_to_jobs(values);
+    let uuids: Vec<&str> = jobs.iter().map(|j| j.uuid.as_str()).collect();
+    assert_eq!(
+        uuids,
+        vec!["good-1", "good-2"],
+        "the non-object workLocation row must be dropped, both good rows kept: {uuids:?}"
+    );
+}
+
+#[test]
+fn rows_to_jobs_empty_array_returns_empty_vec() {
+    let values: Vec<serde_json::Value> = serde_json::from_str("[]").unwrap();
+    assert!(rows_to_jobs(values).is_empty());
+}
+
+// ---------------------------------------------------------------------------
 // parse_rippling_response — fixture-based parsing
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Hardens the **Rippling** board scraper so a single malformed row in the API response no longer silently zeroes an entire company's job list. Follow-up to the career-ops program (#513 / #529 / #530): the "verify 5 boards live" pass surfaced this as the one real code gap.

## The bug

Rippling deserialized its response as an **atomic** `Vec<RpJob>`, and `RpJob.uuid` is a **required** `String` (`workLocation` is an untagged enum). So one row missing `uuid` — or with an oddly-typed `workLocation` — failed the *whole* deserialize, and that company returned **zero** jobs, logged only as a generic fetch error. Rippling is the only one of the five new boards with a required per-row field; pinpoint/breezy/bamboohr are all-`Option` and already tolerate bad rows, so the fix is scoped to Rippling alone.

## Fix

Fetch the array as `Vec<serde_json::Value>` and deserialize **per row** via a new `rows_to_jobs()` — `filter_map` over `serde_json::from_value::<RpJob>`, `log::debug!`-and-drop on `Err`. `parse_rippling_response` is unchanged; the `uuid` requirement and the `ats.rippling.com` URL host-lock still run, so a surviving row passes the exact same guards as before. ~24 lines, no new deps, robustness-only (all-good-row output is byte-identical).

## Live verification (2026-07-01)

All 5 recently-added boards probed against real tenants — **zero endpoint/shape drift**:

| Board | Tenant | Result |
|---|---|---|
| The Muse | *(public API)* | ✅ `name`/`company.name`/`refs.landing_page`/`locations[0].name` |
| Pinpoint | `safetywing` | ✅ `{data:[]}`, `title`/abs `url`/`location.name` |
| Rippling | `consensus` | ✅ array, `name`/host-locked `url`/`workLocation.label` |
| Breezy | `urrly` (44 roles) | ✅ `name`/abs `url`/ISO `published_date`/`location.name` |
| BambooHR | `lucid` (5 roles) | ✅ `{result:[]}`, `id`/`jobOpeningName`/`location.{city,state}`/`isRemote` |

Nothing shipped dead — every parser matches its live JSON. This PR is the only code change the verification produced.

## Tests

3 new tests on `rows_to_jobs` (25 rippling tests pass total):
- `rows_to_jobs_skips_row_missing_uuid_keeps_good_rows` — `[good, {no uuid}, good]` → exactly the 2 good rows (the core regression guard).
- `rows_to_jobs_skips_row_with_non_object_work_location` — `workLocation: 42` dropped, siblings survive.
- `rows_to_jobs_empty_array_returns_empty_vec`.

## Review trail (pre-CodeRabbit)

`scraping-applier-author` implemented → `scraping-applier-expert` (per-row isolation sound; top-level-not-array behavior unchanged via `fetch_json` → `Ok(None)`; host-lock/uuid guards intact; rippling-only scope correct) + `testing-reviewer` (strong count+identity+order assertions, realistic fixtures) — **both PASS, no HIGH/CRITICAL**. Gates: `cargo test` (rippling green), `cargo clippy` (clean), `cargo fmt --check` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job search resilience so partially malformed listings no longer block results from loading.
  * If some job rows can’t be read, the rest still appear instead of failing the entire search.
  * Added coverage for missing fields, unexpected data types, and empty results to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->