### PR TITLE
ci: bump claude review to opus 4.8 and make coderabbit on-demand

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,11 +1,14 @@
 # yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
 #
-# CodeRabbit — always-on AI PR review for this public repo (free OSS plan).
-# It complements (never replaces) the deterministic merge gate in
+# CodeRabbit — ON-DEMAND AI PR review for this public repo (free OSS plan).
+# Auto-review is OFF (reviews.auto_review.enabled: false): CodeRabbit stays
+# silent on open/push and reviews ONLY when the owner comments "@coderabbitai
+# review" on a PR — mirroring the on-demand "@claude review" workflow
+# (.github/workflows/claude-review.yml). This keeps review spend/noise under
+# explicit control; the deterministic merge gate in
 # .github/workflows/ci-pipeline.yml and the SARIF security jobs (codeql/semgrep/
-# scorecard/security). Advisory only: it must NOT approve or block merge — only
-# "✅ CI OK" gates. The on-demand "@claude review" (.github/workflows/claude-review.yml)
-# stays for agent-routed deep dives.
+# scorecard/security) are what actually gate merge. Advisory only: CodeRabbit
+# must NOT approve or block merge — only "✅ CI OK" gates.
 #
 # Conventions mirror CLAUDE.md + .github/copilot-instructions.md; ownership mirrors
 # .claude/review-routes.json; labels mirror the former .github/labeler.yml.
@@ -25,8 +28,10 @@ reviews:
   review_status: true
   poem: false
   collapse_walkthrough: false
+  # On-demand only: no automatic review on open/push. Trigger a review by
+  # commenting "@coderabbitai review" on the PR (see header note).
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     base_branches:
       - main

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -65,7 +65,7 @@ jobs:
           fetch-depth: 0
 
       - name: 🤖 Run Claude review
-        uses: anthropics/claude-code-action@74eedf1a1892082d619c3edb66b9402da6520e7f # v1.0.156
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1.0.162
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # NO `prompt` on purpose: a prompt forces "automation mode", where the
@@ -78,5 +78,5 @@ jobs:
           # to automation mode, so the review still uses our agent routing + the
           # token-efficiency contract while being able to post.
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-opus-4-8
             --append-system-prompt "Review this pull request. Map the changed files to their owner in .claude/review-routes.json (first matching primary glob wins), apply that .claude/agents checklist plus the .claude/skills/token-efficiency contract, and review only the changed files. Severity: only HIGH or CRITICAL are blocking (architecture violations; untested error or security paths; credential, IPC, or updater exploits; data loss); treat the rest as advisory. Post findings as inline comments on the changed lines. Be advisory only and do not approve or block the PR."


### PR DESCRIPTION
## What

Two review-tooling changes, both making PR review **on-demand + higher quality**:

1. **Claude review → Opus 4.8** — bump `anthropics/claude-code-action` v1.0.156 → v1.0.162 (SHA-pinned) and switch the on-demand `@claude review` model `claude-sonnet-4-6` → `claude-opus-4-8`.
2. **CodeRabbit → on-demand only** — set `reviews.auto_review.enabled: false` so CodeRabbit no longer reviews on open/push; it reviews only when the owner comments `@coderabbitai review`, mirroring the `@claude review` flow.

## Why land this first

Both take effect from the **default branch**: `@claude review` is an `issue_comment` trigger (GitHub runs the workflow from `main`, not the PR branch), and CodeRabbit reads `.coderabbit.yaml` from the base. So this must merge to `main` before it affects any later PR's review.

## Cost / control

Both reviewers are now owner-gated + on-demand — quota and comment noise spend only when the owner explicitly asks. Merge gating stays with the deterministic CI checks (`✅ CI OK`) + SARIF security jobs, never the AI reviewers (both remain advisory-only). Claude workflow security (least-privilege perms, `cancel-in-progress: false`, OAuth-subscription auth) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
