### PR TITLE
chore(pages): pin custom domain with landing/CNAME

### DIFF
--- a/landing/CNAME
+++ b/landing/CNAME
@@ -1,0 +1,1 @@
+aijobhunter.app


### PR DESCRIPTION
## What

Adds `landing/CNAME` containing `aijobhunter.app`.

## Why

`pages.yml` deploys the `landing/` folder directly as the Pages artifact. There is currently **no CNAME file** in that folder — the custom domain is held only by the repo's Pages settings. With the GitHub Actions deploy method, if the published artifact lacks a CNAME file, a redeploy can drop the custom domain and GitHub has to re-assert it.

Committing `landing/CNAME` makes `aijobhunter.app` stick on every deploy, and is also a prerequisite if the domain is ever switched from Cloudflare-proxied (edge HTTPS) to DNS-only (GitHub-managed cert + Enforce HTTPS).

No behavior change to the site; it just re-asserts the domain already in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)