### PR TITLE
fix: surface newly found autopilot jobs at the top of the list

### DIFF
--- a/apps/desktop/src-tauri/src/autopilot/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot/mod.rs
@@ -653,7 +653,8 @@ fn u32_field_in_range(v: &serde_json::Value, key: &str, max: u32) -> Option<u32>
 /// - existing rows are kept (preserving `found_at`/first-seen) and have `is_new`
 ///   cleared; if the run re-surfaced them, volatile fields (title/company/
 ///   description/score/location) are refreshed,
-/// - postings whose URL was never seen are appended and flagged `is_new`.
+/// - postings whose URL was never seen are placed first (on top) and flagged
+///   `is_new`, in the incoming (already score-sorted) order.
 ///
 /// Re-running with the same postings yields the same set — only `is_new` moves.
 /// `applied` is derived on read, so it is left at its default here.
@@ -663,7 +664,7 @@ fn merge_found_jobs(existing: &[FoundJob], incoming: Vec<FoundJob>) -> Vec<Found
     let incoming_by_url: HashMap<&str, &FoundJob> =
         incoming.iter().map(|j| (j.url.as_str(), j)).collect();
 
-    let mut merged: Vec<FoundJob> = existing
+    let refreshed_existing: Vec<FoundJob> = existing
         .iter()
         .map(|e| {
             let mut row = e.clone();
@@ -699,15 +700,18 @@ fn merge_found_jobs(existing: &[FoundJob], incoming: Vec<FoundJob>) -> Vec<Found
 
     let existing_urls: std::collections::HashSet<&str> =
         existing.iter().map(|j| j.url.as_str()).collect();
-    for inc in incoming {
-        if !existing_urls.contains(inc.url.as_str()) {
-            merged.push(FoundJob {
-                is_new: true,
-                applied: false,
-                ..inc
-            });
-        }
-    }
+    // New jobs go on top: the batch is already score-sorted desc upstream
+    // (commands/autopilot.rs), so preserving incoming order here keeps that.
+    let mut merged: Vec<FoundJob> = incoming
+        .into_iter()
+        .filter(|inc| !existing_urls.contains(inc.url.as_str()))
+        .map(|inc| FoundJob {
+            is_new: true,
+            applied: false,
+            ..inc
+        })
+        .collect();
+    merged.extend(refreshed_existing);
 
     merged
 }

--- a/apps/desktop/src-tauri/src/autopilot/test.rs
+++ b/apps/desktop/src-tauri/src/autopilot/test.rs
@@ -547,12 +547,19 @@ fn merge_is_idempotent_on_a_repeated_run() {
 fn merge_keeps_prior_jobs_not_in_the_new_run() {
     let existing = vec![found_job("old", 1)];
     let merged = merge_found_jobs(&existing, vec![found_job("fresh", 2)]);
-    assert_eq!(
-        merged.len(),
-        2,
-        "prior finds are retained, new ones appended"
-    );
+    assert_eq!(merged.len(), 2, "prior finds retained below the new one");
     assert!(merged.iter().any(|j| j.url == "old"));
+}
+
+#[test]
+fn merge_puts_newly_found_jobs_on_top() {
+    let merged = merge_found_jobs(&[found_job("old", 1)], vec![found_job("fresh", 2)]);
+    assert_eq!(
+        merged[0].url, "fresh",
+        "newly found job is first (top of list)"
+    );
+    assert!(merged[0].is_new);
+    assert_eq!(merged[1].url, "old", "prior finds fall below the new one");
 }
 
 #[test]


### PR DESCRIPTION
## Problem
When an autopilot run finds new jobs, they appeared at the **bottom** of the autopilot's found-jobs list. Users expect newly discovered jobs to surface first.

## Root cause
`merge_found_jobs` (`apps/desktop/src-tauri/src/autopilot/mod.rs`) **appended** never-before-seen URLs to the end of the cumulative found-jobs list, and `AutopilotCard` renders that `Vec` verbatim (no client-side sort). So new finds rendered last.

## Fix
Build the merged `Vec` **new-first**: genuinely-new URLs (kept in the already score-sorted incoming order) first, then the refreshed existing rows. Existing rows keep their prior order, their `found_at`/first-seen time, and their `is_new`-cleared state. This mirrors the file's own convention — `write_to_disk` already orders the autopilots themselves newest-first.

No frontend / schema / IPC / migration change — the renderer shows the `Vec` order directly, and the "New" badge is unaffected. No other consumer depends on the old order (`record_run` counts `is_new`, `enrich_applied` only sets `applied`, export dumps the list as-is, the tray uses a count).

## Tests
- Added `merge_puts_newly_found_jobs_on_top` locking the new positional order (previously untested — existing merge tests are order-agnostic).
- Fixed stale "appended" wording in `merge_keeps_prior_jobs_not_in_the_new_run`.
- `cargo test -p ajh-tauri --lib autopilot` -> 92 passed, 0 failed. `cargo clippy` / `check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly discovered job postings now appear at the top of the job history list.
  * Previously seen jobs are still retained, with their status updated correctly during a refresh.
  * New items are clearly marked as new, while older items keep their existing placement below them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->