### PR TITLE
fix: restore autopilot list to the applied job on back-navigation

### DIFF
--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/AutopilotCard.test.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/AutopilotCard.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -27,18 +27,36 @@ vi.mock('@ajh/translations', () => ({
 
 // ── motion/react — render children synchronously, no animation ───────────────
 
+// jsdom has no real animation engine — fire `onAnimationComplete` once on
+// MOUNT (matching a real single enter-animation completing), not on every
+// prop-identity change (the real `onAnimationComplete`/`resolvePendingScroll`
+// callback is recreated every render). A "latest ref" holds the current
+// callback so the effect itself can stay mount-only ([] deps) without going
+// stale — this is what lets tests distinguish "enter animation ran" from
+// "already mounted, no animation" (the rAF-fallback path).
 vi.mock('motion/react', () => ({
   AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   motion: {
     div: React.forwardRef(
       (
-        { children, ...rest }: React.HTMLAttributes<HTMLDivElement>,
+        {
+          children,
+          onAnimationComplete,
+          ...rest
+        }: React.HTMLAttributes<HTMLDivElement> & { onAnimationComplete?: () => void },
         ref: React.Ref<HTMLDivElement>
-      ) => (
-        <div ref={ref} {...rest}>
-          {children}
-        </div>
-      )
+      ) => {
+        const onAnimationCompleteRef = React.useRef(onAnimationComplete);
+        onAnimationCompleteRef.current = onAnimationComplete;
+        React.useEffect(() => {
+          onAnimationCompleteRef.current?.();
+        }, []);
+        return (
+          <div ref={ref} {...rest}>
+            {children}
+          </div>
+        );
+      }
     ),
   },
 }));
@@ -459,5 +477,132 @@ describe('AutopilotCard — handleJobClick persistJob rejection', () => {
     // openExternal fires before the try/catch around persistJob.
     expect(mockOpenExternal).toHaveBeenCalledWith('https://example.com/job/persist-fail');
     // No unhandled rejection — test runner would fail if one escaped.
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// focusedJobUrl — scroll-to-row + transient highlight (Back-navigation fix)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AutopilotCard — focusedJobUrl scroll + highlight', () => {
+  let scrollSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    scrollSpy = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    scrollSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('scrolls the row matching focusedJobUrl into view, not the header', () => {
+    const jobUrl = 'https://example.com/job/42';
+    renderCard(makeAutopilot([makeJob(jobUrl)]), { focused: true, focusedJobUrl: jobUrl });
+
+    const row = document.querySelector(`[data-job-url="${jobUrl}"]`);
+    expect(row).not.toBeNull();
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    const instance = scrollSpy.mock.instances[0];
+    if (!instance) throw new Error('scrollIntoView was not called');
+    expect(instance).toBe(row);
+    expect(scrollSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: 'smooth', block: 'center' })
+    );
+  });
+
+  it('applies the transient highlight ring to the targeted row', () => {
+    const jobUrl = 'https://example.com/job/highlight';
+    renderCard(makeAutopilot([makeJob(jobUrl)]), { focused: true, focusedJobUrl: jobUrl });
+
+    const row = document.querySelector(`[data-job-url="${jobUrl}"]`);
+    expect(row).toHaveClass('ring-brand/60');
+  });
+
+  it('fades the highlight after ~1.5s', () => {
+    vi.useFakeTimers();
+    const jobUrl = 'https://example.com/job/fade';
+    renderCard(makeAutopilot([makeJob(jobUrl)]), { focused: true, focusedJobUrl: jobUrl });
+
+    const row = document.querySelector(`[data-job-url="${jobUrl}"]`);
+    expect(row).toHaveClass('ring-brand/60');
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(row).not.toHaveClass('ring-brand/60');
+  });
+
+  it('calls onFocusHandled once the row has been scrolled to', () => {
+    const jobUrl = 'https://example.com/job/handled';
+    const onFocusHandled = vi.fn();
+    renderCard(makeAutopilot([makeJob(jobUrl)]), {
+      focused: true,
+      focusedJobUrl: jobUrl,
+      onFocusHandled,
+    });
+
+    expect(onFocusHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to centering the header when focusedJobUrl is absent', () => {
+    const jobUrl = 'https://example.com/job/no-focus-url';
+    renderCard(makeAutopilot([makeJob(jobUrl)]), { focused: true, focusedJobUrl: null });
+
+    const header = document.querySelector('[aria-expanded]');
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    const instance = scrollSpy.mock.instances[0];
+    if (!instance) throw new Error('scrollIntoView was not called');
+    expect(instance).toBe(header);
+  });
+
+  it('scrolls via the rAF fallback when the panel is already expanded (no enter animation fires)', async () => {
+    // Sync rAF stub — jsdom's real rAF is timer-based; this makes the fallback
+    // resolve synchronously within the test's act() calls.
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+    const onFocusHandled = vi.fn();
+    const jobUrl = 'https://example.com/job/already-expanded';
+    const autopilot = makeAutopilot([makeJob(jobUrl)]);
+    const { rerender } = renderCard(autopilot, { focused: false });
+
+    // Manually expand via the header — NOT via `focused` — so the found-jobs
+    // panel's enter animation (and its onAnimationComplete) has already fired
+    // and settled before focus arrives.
+    const header = document.querySelector('[aria-expanded]') as HTMLElement;
+    await act(async () => {
+      header.click();
+    });
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    // Focus now arrives while already expanded: `setShowFound(true)` is a
+    // no-op, so onAnimationComplete never re-fires — only the rAF fallback
+    // can resolve the pending scroll.
+    await act(async () => {
+      rerender(
+        <AutopilotCard
+          autopilot={autopilot}
+          {...defaultProps}
+          focused
+          focusedJobUrl={jobUrl}
+          onFocusHandled={onFocusHandled}
+        />
+      );
+    });
+
+    const row = document.querySelector(`[data-job-url="${jobUrl}"]`);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    const instance = scrollSpy.mock.instances[0];
+    if (!instance) throw new Error('scrollIntoView was not called');
+    expect(instance).toBe(row);
+    expect(onFocusHandled).toHaveBeenCalledTimes(1);
+
+    rafSpy.mockRestore();
   });
 });

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -12,7 +12,7 @@ import {
   Wand2,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { Autopilot, AutopilotFoundJob } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
@@ -45,6 +45,10 @@ interface AutopilotCardProps {
   stepLogs: StepLog[];
   /** When true (tray/deep-link focus), auto-expand found-jobs + scroll into view. */
   focused?: boolean;
+  /** A specific found-job url to scroll+highlight once expanded (e.g. returning
+   *  from an Apply via Back). Only meaningful when `focused` is true — falls
+   *  back to centering the header when null. */
+  focusedJobUrl?: string | null;
   /** Called once the focus has been consumed, so the page can clear it. */
   onFocusHandled?: () => void;
   onRun(): void;
@@ -71,6 +75,7 @@ export function AutopilotCard({
   runState,
   stepLogs,
   focused,
+  focusedJobUrl,
   onFocusHandled,
   onRun,
   onTogglePause,
@@ -86,7 +91,23 @@ export function AutopilotCard({
   const [showFound, setShowFound] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const headerRef = useRef<HTMLDivElement>(null);
+  const listContainerRef = useRef<HTMLDivElement>(null);
   const foundJobs = ap.foundJobs ?? [];
+
+  // Scroll-to-row + transient highlight target for `focusedJobUrl` (returning
+  // from an Apply via Back). Kept in a ref (not state) since it isn't rendered;
+  // `resolvePendingScroll` below clears it first so it can never double-fire
+  // between the enter-animation and already-expanded-rAF paths.
+  const pendingScrollUrlRef = useRef<string | null>(null);
+  const pendingScrollRafRef = useRef<number | null>(null);
+  const [highlightedUrl, setHighlightedUrl] = useState<string | null>(null);
+  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (highlightTimeoutRef.current) clearTimeout(highlightTimeoutRef.current);
+      if (pendingScrollRafRef.current !== null) cancelAnimationFrame(pendingScrollRafRef.current);
+    };
+  }, []);
 
   // Build viewed-url sets from persisted interactions (viewed + opened).
   const { data: viewedData } = useInteractions('viewed');
@@ -100,14 +121,45 @@ export function AutopilotCard({
     [viewedData, openedData]
   );
 
+  // Idempotent: reads + clears `pendingScrollUrlRef` FIRST, so it's safe to
+  // call from both the enter-animation completion and the already-expanded
+  // rAF fallback below without double-scrolling or double-firing onFocusHandled.
+  const resolvePendingScroll = useCallback(() => {
+    const url = pendingScrollUrlRef.current;
+    if (!url) return;
+    pendingScrollUrlRef.current = null;
+    const el = listContainerRef.current?.querySelector(`[data-job-url="${CSS.escape(url)}"]`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setHighlightedUrl(url);
+    if (highlightTimeoutRef.current) clearTimeout(highlightTimeoutRef.current);
+    highlightTimeoutRef.current = setTimeout(() => setHighlightedUrl(null), 1500);
+    onFocusHandled?.();
+  }, [onFocusHandled]);
+
   // Tray "New jobs" / deep-link focus: open this card's found-jobs and scroll to
   // it, then tell the page to clear the focus so a later click re-triggers.
+  // When `focusedJobUrl` is set (returning from an Apply via Back), defer the
+  // scroll+highlight to that specific row: normally via the found-jobs panel's
+  // `onAnimationComplete` (below) once its expand animation finishes, or — if
+  // the panel was ALREADY expanded, so no enter animation fires — via a rAF
+  // fallback here so the focus can never wedge.
   useEffect(() => {
     if (!focused) return;
-    setShowFound(true);
-    headerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    onFocusHandled?.();
-  }, [focused, onFocusHandled]);
+    if (focusedJobUrl) {
+      pendingScrollUrlRef.current = focusedJobUrl;
+      // Functional update: reads the PRE-focus `showFound` without adding it as
+      // a dependency (adding it would re-run this effect — and re-force the
+      // panel open — on every manual toggle while still focused).
+      setShowFound((wasExpanded) => {
+        if (wasExpanded) pendingScrollRafRef.current = requestAnimationFrame(resolvePendingScroll);
+        return true;
+      });
+    } else {
+      setShowFound(true);
+      headerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      onFocusHandled?.();
+    }
+  }, [focused, focusedJobUrl, onFocusHandled, resolvePendingScroll]);
 
   // #45 — relative last-run ("3 min ago") instead of an absolute timestamp.
   const lastRun = ap.lastRunAt
@@ -313,6 +365,7 @@ export function AutopilotCard({
             exit={{ opacity: 0, height: 0 }}
             transition={transition.fast}
             className="overflow-hidden"
+            onAnimationComplete={resolvePendingScroll}
           >
             <div className="overflow-hidden rounded-lg border border-[var(--border-clear)] bg-card">
               <div className="flex items-center justify-between border-b border-[var(--border-clear)] px-3 py-2">
@@ -330,11 +383,18 @@ export function AutopilotCard({
                   <ChevronUp size={12} />
                 </Button>
               </div>
-              <div className="max-h-64 divide-y divide-[var(--border-clear)] overflow-y-auto">
+              <div
+                ref={listContainerRef}
+                className="max-h-64 divide-y divide-[var(--border-clear)] overflow-y-auto"
+              >
                 {foundJobs.map((job, i) => (
                   <div
                     key={`${job.url}-${i}`}
-                    className="flex items-center gap-2 px-3 py-2 transition-colors hover:bg-muted"
+                    data-job-url={job.url}
+                    className={cn(
+                      'flex items-center gap-2 px-3 py-2 transition-colors hover:bg-muted',
+                      highlightedUrl === job.url && 'ring-2 ring-inset ring-brand/60'
+                    )}
                   >
                     <Button
                       variant="unstyled"

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/AutopilotPage.focus.test.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/AutopilotPage.focus.test.tsx
@@ -63,10 +63,19 @@ vi.mock('@/services', async (importOriginal) => {
 
 // Captures the onApply callback so board-provenance tests can invoke handleApply directly.
 let capturedOnApply: ((job: AutopilotFoundJob) => void) | null = null;
+// Captures the focusedJobUrl prop so the Back-navigation flow can assert it's forwarded.
+let capturedFocusedJobUrl: string | null | undefined = null;
 
 vi.mock('@/features/autopilot/components/AutopilotCard', () => ({
-  AutopilotCard: ({ onApply }: { onApply: (job: AutopilotFoundJob) => void }) => {
+  AutopilotCard: ({
+    onApply,
+    focusedJobUrl,
+  }: {
+    onApply: (job: AutopilotFoundJob) => void;
+    focusedJobUrl?: string | null;
+  }) => {
     capturedOnApply = onApply;
+    capturedFocusedJobUrl = focusedJobUrl;
     return <div data-testid={TEST_IDS.autopilot.card} />;
   },
 }));
@@ -101,13 +110,21 @@ vi.mock('@/components/layout/PageTransition', () => ({
 
 beforeEach(() => {
   useSessionStore.setState((s) => ({
-    autopilot: { ...s.autopilot, focusedId: null, lastAppliedId: null, creating: false },
+    autopilot: {
+      ...s.autopilot,
+      focusedId: null,
+      focusedJobUrl: null,
+      lastAppliedId: null,
+      lastAppliedJobUrl: null,
+      creating: false,
+    },
   }));
   mockNavigate.mockReset();
   mockInvalidateAutopilots.mockReset();
   mockMutateAsync.mockReset();
   mockAutopilotList = [];
   capturedOnApply = null;
+  capturedFocusedJobUrl = null;
   currentSearch = {};
 });
 
@@ -178,6 +195,26 @@ describe('AutopilotPage — lastAppliedId (re-expand on Back)', () => {
     const { autopilot } = useSessionStore.getState();
     expect(autopilot.focusedId).toBe('ap-7');
     expect(autopilot.lastAppliedId).toBeNull();
+  });
+
+  it('promotes lastAppliedJobUrl to focusedJobUrl on mount and clears it', async () => {
+    // Same Back-navigation flow, but also carrying the specific job url so the
+    // card can scroll to that row instead of just the header.
+    useSessionStore.setState((s) => ({
+      autopilot: {
+        ...s.autopilot,
+        lastAppliedId: 'ap-7',
+        lastAppliedJobUrl: 'https://example.com/job/1',
+      },
+    }));
+
+    await act(async () => {
+      render(<AutopilotPage />);
+    });
+
+    const { autopilot } = useSessionStore.getState();
+    expect(autopilot.focusedJobUrl).toBe('https://example.com/job/1');
+    expect(autopilot.lastAppliedJobUrl).toBeNull();
   });
 });
 
@@ -250,5 +287,42 @@ describe('AutopilotPage — handleApply board provenance', () => {
     });
 
     expect(mockMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ board: 'aggregator' }));
+  });
+});
+
+describe('AutopilotPage — focusedJobUrl plumbing', () => {
+  it('forwards focusedJobUrl to the focused AutopilotCard', async () => {
+    mockAutopilotList = [makeAutopilot(['indeed'])]; // _id: 'ap-1'
+    useSessionStore.setState((s) => ({
+      autopilot: {
+        ...s.autopilot,
+        lastAppliedId: 'ap-1',
+        lastAppliedJobUrl: 'https://example.com/job/1',
+      },
+    }));
+
+    await act(async () => {
+      render(<AutopilotPage />);
+    });
+
+    expect(capturedFocusedJobUrl).toBe('https://example.com/job/1');
+  });
+
+  it('sets lastAppliedJobUrl alongside lastAppliedId on Apply', async () => {
+    mockAutopilotList = [makeAutopilot(['indeed'])];
+    mockMutateAsync.mockResolvedValue({ id: 'app-99' });
+
+    await act(async () => {
+      render(<AutopilotPage />);
+    });
+
+    if (!capturedOnApply) throw new Error('AutopilotCard onApply was not captured');
+    await act(async () => {
+      (capturedOnApply as (job: AutopilotFoundJob) => void)(makeFoundJob('linkedin'));
+    });
+
+    const { autopilot } = useSessionStore.getState();
+    expect(autopilot.lastAppliedId).toBe('ap-1');
+    expect(autopilot.lastAppliedJobUrl).toBe('https://example.com/job/1');
   });
 });

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
@@ -23,7 +23,7 @@ function AutopilotPage() {
   const { data: autopilotList = [], isLoading: loading } = useAutopilots();
   const autopilots = autopilotList;
   const { autopilot, setAutopilot, resetAutopilotWizard, setApplicationApply } = useSessionStore();
-  const { creating, focusedId } = autopilot;
+  const { creating, focusedId, focusedJobUrl } = autopilot;
   const setCreating = (v: boolean) => setAutopilot({ creating: v });
   const resetWizard = resetAutopilotWizard;
 
@@ -43,11 +43,21 @@ function AutopilotPage() {
 
   // Returning from an Apply (Back): the user deep-linked into an application from a
   // found job. Re-focus that autopilot on this mount so its found-jobs list stays
-  // expanded instead of collapsing. One-shot — promoted to `focusedId` (which the
-  // card consumes + scrolls to) and cleared, so it only fires the first mount back.
+  // expanded instead of collapsing, and carry the specific job url along so the
+  // card scrolls to that row instead of just the header. One-shot — promoted to
+  // `focusedId`/`focusedJobUrl` (which the card consumes) and cleared, so it only
+  // fires the first mount back.
   useEffect(() => {
-    const appliedId = useSessionStore.getState().autopilot.lastAppliedId;
-    if (appliedId) setAutopilot({ focusedId: appliedId, lastAppliedId: null });
+    const { lastAppliedId: appliedId, lastAppliedJobUrl: appliedJobUrl } =
+      useSessionStore.getState().autopilot;
+    if (appliedId) {
+      setAutopilot({
+        focusedId: appliedId,
+        focusedJobUrl: appliedJobUrl,
+        lastAppliedId: null,
+        lastAppliedJobUrl: null,
+      });
+    }
   }, [setAutopilot]);
 
   const { runStates, stepLogs, error, setError, handleRun, handleTogglePause, handleDelete } =
@@ -95,9 +105,10 @@ function AutopilotPage() {
         applyWizardStep: 0,
         applyWizardForm: null,
       });
-      // Remember which autopilot we applied from so Back re-expands it (consumed
-      // on the Autopilot page's next mount).
-      setAutopilot({ lastAppliedId: ap._id });
+      // Remember which autopilot (and specific job) we applied from so Back
+      // re-expands it and scrolls to that row (consumed on the Autopilot page's
+      // next mount).
+      setAutopilot({ lastAppliedId: ap._id, lastAppliedJobUrl: job.url });
       void navigate({
         to: '/applications/$id',
         params: { id: res.id },
@@ -163,7 +174,8 @@ function AutopilotPage() {
                     runState={runState}
                     stepLogs={stepLogs[ap._id] ?? []}
                     focused={focusedId === ap._id}
-                    onFocusHandled={() => setAutopilot({ focusedId: null })}
+                    focusedJobUrl={focusedId === ap._id ? focusedJobUrl : null}
+                    onFocusHandled={() => setAutopilot({ focusedId: null, focusedJobUrl: null })}
                     onRun={() => void handleRun(ap._id)}
                     onTogglePause={() => void handleTogglePause(ap)}
                     onEdit={() => handleEdit(ap)}

--- a/apps/desktop/src/renderer/store/session-store/session-store.ts
+++ b/apps/desktop/src/renderer/store/session-store/session-store.ts
@@ -91,12 +91,19 @@ interface AutopilotSlice {
   wizardStep: number;
   wizardForm: WizardState | null;
   focusedId: string | null;
+  /** The specific found-job url to scroll+highlight within the focused card
+   *  (promoted from `lastAppliedJobUrl`); null for tray/deep-link focus, which
+   *  only centers the card header. */
+  focusedJobUrl: string | null;
   /**
    * The autopilot the user last applied from (deep-linked into the application
    * detail). Consumed once when the Autopilot page next mounts — promoted to
    * `focusedId` so pressing Back re-expands that card instead of collapsing it.
    */
   lastAppliedId: string | null;
+  /** The found job's url the user applied from — promoted to `focusedJobUrl`
+   *  alongside `lastAppliedId` so Back scrolls to that specific row. */
+  lastAppliedJobUrl: string | null;
 }
 
 /**
@@ -250,7 +257,9 @@ export const useSessionStore = create<SessionState>((set) => ({
     wizardStep: 0,
     wizardForm: null,
     focusedId: null,
+    focusedJobUrl: null,
     lastAppliedId: null,
+    lastAppliedJobUrl: null,
   },
   applicationApply: { ...APPLICATION_APPLY_DEFAULTS },
   applications: { collapsedSections: [], filter: '' },


### PR DESCRIPTION
## Problem
From an autopilot's found-jobs list, pressing **Apply** on a job deep in the list opens `/applications/$id`. "Back to Autopilot" does a fresh `navigate({to:'/autopilot'})`, so `AutopilotPage` remounts and the inner `overflow-y-auto` found-jobs list resets to the **top** — the user loses their place. (The card was already re-expanded via `lastAppliedId -> focusedId`, but only the autopilot id was known, so the card *header* was centered, not the job.)

## Fix
Extend the existing focus channel to also carry the applied job's url:
- Session store gains `lastAppliedJobUrl` / `focusedJobUrl` (default `null`).
- `handleApply` records `lastAppliedJobUrl: job.url`; the return effect promotes it to `focusedJobUrl` and passes it to the focused card.
- `AutopilotCard` tags each row with `data-job-url` and, once the found-jobs panel finishes expanding (`onAnimationComplete`) — or immediately via `requestAnimationFrame` if the card is already expanded — scrolls that row into view (`block:'center'`) and briefly highlights it (`ring-brand`, design token, no hex).
- Scroll resolution is **idempotent** (a ref is cleared first), so the `onAnimationComplete` and rAF paths can never double-fire, and it always calls `onFocusHandled()` so `focusedJobUrl` can't wedge in the store. The tray/deep-link focus path is unchanged (still centers the header).

Reuses the existing focus mechanism rather than adding a parallel one; mirrors `ApplicationRow`'s just-imported highlight idiom.

## Tests
- `AutopilotPage.focus.test.tsx`: `lastAppliedJobUrl` is promoted to `focusedJobUrl`, forwarded to the focused card, and cleared.
- `AutopilotCard.test.tsx`: asserts the exact matching row (not the header) is the scroll target, the highlight applies/fades, `onFocusHandled` fires once, header fallback when `focusedJobUrl` is absent, and the already-expanded (rAF) path.
- `vitest AutopilotCard AutopilotPage.focus` -> 36 passed. `typecheck` clean. `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)