### PR TITLE
fix: stop project links seeding the contact profile on import

### DIFF
--- a/apps/desktop/src-tauri/src/contact_profile/mod.rs
+++ b/apps/desktop/src-tauri/src/contact_profile/mod.rs
@@ -453,10 +453,90 @@ fn is_personal_linkedin(url: &str) -> bool {
     host_is(url, "linkedin.com") && url.to_lowercase().contains("/in/")
 }
 
-/// A personal GitHub profile/repo (any github.com URL that isn't an org settings
-/// page is acceptable as the candidate's GitHub).
+/// A github.com URL. Combined with `is_profile_shaped` at the call site so only
+/// `github.com/<user>` (not `/<user>/<repo>`) is promoted to the candidate's
+/// GitHub — a repo link is a project reference, not an identity.
 fn is_github(url: &str) -> bool {
     host_is(url, "github.com")
+}
+
+/// Known social/portfolio platform hosts whose profile page belongs on the
+/// contact line. Mirrors `PROFILE_DOMAINS` in
+/// `packages/prompts/src/generate/links/links.ts` — keep the two lists in sync.
+const PROFILE_HOSTS: &[&str] = &[
+    "linkedin.com",
+    "github.com",
+    "gitlab.com",
+    "twitter.com",
+    "x.com",
+    "behance.net",
+    "dribbble.com",
+    "medium.com",
+    "stackoverflow.com",
+    "dev.to",
+    "codepen.io",
+    "youtube.com",
+    "youtu.be",
+    "notion.so",
+    "figma.com",
+    "npmjs.com",
+    "crates.io",
+    "solo.to",
+    "bio.link",
+    "linktr.ee",
+    "bento.me",
+];
+
+fn is_profile_host(url: &str) -> bool {
+    PROFILE_HOSTS.iter().any(|d| host_is(url, d))
+}
+
+/// Non-empty path segments of `url` (host, query and fragment stripped).
+/// Mirrors `pathSegments()` in links.ts (only the *count* matters here, so
+/// unlike the TS version this does not percent-decode).
+fn path_segments(url: &str) -> Vec<&str> {
+    let trimmed = url.trim();
+    let no_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    let path = match no_scheme.find('/') {
+        Some(idx) => no_scheme[idx..].split(['?', '#']).next().unwrap_or(""),
+        None => "",
+    };
+    path.split('/').filter(|s| !s.is_empty()).collect()
+}
+
+/// A bare-root URL — host only, no meaningful path. The shape of a homepage.
+/// Mirrors `isBareRoot()` in links.ts.
+fn is_bare_root(url: &str) -> bool {
+    path_segments(url).is_empty()
+}
+
+/// Is this platform URL a *profile* (belongs on the contact line) rather than a
+/// deep link to a specific repo/article (a project reference, which belongs in
+/// the résumé body, not the header)? `github.com/<user>` is a profile;
+/// `github.com/<user>/<repo>` is a project. Mirrors `isProfileShaped()` in
+/// links.ts.
+fn is_profile_shaped(url: &str) -> bool {
+    if host_is(url, "github.com") || host_is(url, "gitlab.com") {
+        return path_segments(url).len() <= 1;
+    }
+    true
+}
+
+/// A link shaped like a contact-line entry: a profile-shaped platform profile,
+/// or a bare-root personal domain. LinkedIn keeps the stricter
+/// `is_personal_linkedin` (`/in/`) gate instead of the generic
+/// `is_profile_shaped` rule — a company/school page is otherwise
+/// indistinguishable by shape but must never seed the header. Canonical rule
+/// (keep in sync): `isProfileShaped`/`classifyLinks` in
+/// `packages/prompts/src/generate/links/links.ts`.
+fn is_contact_link(url: &str) -> bool {
+    if host_is(url, "linkedin.com") {
+        return is_personal_linkedin(url);
+    }
+    (is_profile_host(url) && is_profile_shaped(url)) || (!is_profile_host(url) && is_bare_root(url))
 }
 
 /// Personal-site / link-in-bio hosts that belong under "Website".
@@ -473,14 +553,17 @@ fn is_job_board(url: &str) -> bool {
     JOB_BOARD_HOSTS.iter().any(|d| host_is(url, d))
 }
 
-/// Classify extracted résumé links into a [`ContactProfile`] by NAME, not by
-/// position. Picks the first personal LinkedIn (`/in/`), the first GitHub, and a
-/// personal website (a known link-in-bio host, else the first non-job-board,
-/// non-platform `http(s)` link). Every remaining personal `http(s)` link (e.g.
-/// Dribbble, Behance, a portfolio) is kept as a labelled [`ContactLink`] in
-/// `extra_links`, so the header is seeded with the candidate's full link set —
-/// never a job-board / employer page. This is a suggestion to seed the editable
-/// profile, never the final header on its own.
+/// Classify extracted résumé links into a [`ContactProfile`] by NAME and SHAPE,
+/// not by position. Picks the first personal LinkedIn (`/in/`), the first
+/// profile-shaped GitHub (`github.com/<user>`, never `/<user>/<repo>`), and a
+/// personal website (a known link-in-bio host, else the first bare-root,
+/// non-platform `http(s)` link). Every remaining *contact-shaped* link — a
+/// profile-shaped platform profile (Dribbble, Behance, a second GitHub user) or
+/// a bare-root personal domain — is kept as a labelled [`ContactLink`] in
+/// `extra_links`; a deep-path project/demo/article/repo link never seeds the
+/// header. Canonical rule (keep in sync): `isProfileShaped`/`classifyLinks` in
+/// `packages/prompts/src/generate/links/links.ts`. This is a suggestion to seed
+/// the editable profile, never the final header on its own.
 pub fn classify_contact_links(links: &[Link]) -> ContactProfile {
     let mut profile = ContactProfile::default();
     for link in links {
@@ -499,7 +582,7 @@ pub fn classify_contact_links(links: &[Link]) -> ContactProfile {
             profile.linkedin = Some(url.to_string());
             continue;
         }
-        if profile.github.is_none() && is_github(url) {
+        if profile.github.is_none() && is_github(url) && is_profile_shaped(url) {
             profile.github = Some(url.to_string());
             continue;
         }
@@ -508,16 +591,17 @@ pub fn classify_contact_links(links: &[Link]) -> ContactProfile {
             continue;
         }
     }
-    // Website fallback: the first non-job-board, non-platform http(s) link, so a
-    // personal portfolio on an arbitrary domain is still surfaced — but an
-    // employer / company URL never is.
+    // Website fallback: the first non-job-board, non-platform, bare-root http(s)
+    // link, so a personal portfolio homepage is still surfaced — but an
+    // employer/company URL or a deep link (e.g. a project demo path) never is.
+    // `!is_profile_host` subsumes the old explicit linkedin/github checks.
     if profile.website.is_none() {
         for link in links {
             let url = link.url.trim();
             if (url.starts_with("http://") || url.starts_with("https://"))
                 && !is_job_board(url)
-                && !host_is(url, "linkedin.com")
-                && !is_github(url)
+                && !is_profile_host(url)
+                && is_bare_root(url)
             {
                 profile.website = Some(url.to_string());
                 break;
@@ -539,6 +623,7 @@ pub fn classify_contact_links(links: &[Link]) -> ContactProfile {
         let url = link.url.trim();
         if !(url.starts_with("http://") || url.starts_with("https://"))
             || is_job_board(url)
+            || !is_contact_link(url)
             || named.contains(url)
             || profile.extra_links.iter().any(|e| e.url == url)
         {

--- a/apps/desktop/src-tauri/src/contact_profile/test.rs
+++ b/apps/desktop/src-tauri/src/contact_profile/test.rs
@@ -146,6 +146,56 @@ fn classify_keeps_other_personal_links_as_labelled_extras() {
     );
 }
 
+/// Project/repo/demo links must never leak into the contact profile, even
+/// though they share a host with a genuine platform profile — only the
+/// profile-shaped form (bare user page) qualifies. Mirrors `isProfileShaped`/
+/// `classifyLinks` in `packages/prompts/src/generate/links/links.ts`.
+#[test]
+fn classify_excludes_deep_path_project_links_by_shape() {
+    let links = vec![
+        link("https://github.com/alice"),
+        link("https://github.com/alice/my-project"),
+        link("https://gitlab.com/alice"),
+        link("https://gitlab.com/alice/my-project"),
+        link("https://linkedin.com/in/alice"),
+        link("https://linkedin.com/company/acme"),
+        link("https://myapp.com/demo"),
+        link("https://alice.dev"),
+        link("https://dribbble.com/alice"),
+    ];
+    let p = classify_contact_links(&links);
+
+    assert_eq!(p.github.as_deref(), Some("https://github.com/alice"));
+    assert_eq!(p.linkedin.as_deref(), Some("https://linkedin.com/in/alice"));
+    assert_eq!(p.website.as_deref(), Some("https://alice.dev"));
+
+    let extra_urls: Vec<&str> = p.extra_links.iter().map(|e| e.url.as_str()).collect();
+    assert!(
+        extra_urls.contains(&"https://dribbble.com/alice"),
+        "a platform profile must still seed extras: {extra_urls:?}"
+    );
+    assert!(
+        extra_urls.contains(&"https://gitlab.com/alice"),
+        "a bare GitLab profile is profile-shaped and must seed extras: {extra_urls:?}"
+    );
+    assert!(
+        !extra_urls.contains(&"https://github.com/alice/my-project"),
+        "a repo URL is a project reference, not an identity — must not leak: {extra_urls:?}"
+    );
+    assert!(
+        !extra_urls.contains(&"https://gitlab.com/alice/my-project"),
+        "a GitLab repo URL is a project reference, not an identity — must not leak: {extra_urls:?}"
+    );
+    assert!(
+        !extra_urls.contains(&"https://linkedin.com/company/acme"),
+        "a company page must never seed the header: {extra_urls:?}"
+    );
+    assert!(
+        !extra_urls.contains(&"https://myapp.com/demo"),
+        "a deep-path demo link must never seed the header: {extra_urls:?}"
+    );
+}
+
 #[test]
 fn fill_empty_from_completes_sparse_profile_without_clobbering() {
     // The user edited only the website (their portfolio); an import suggests a full set.

--- a/apps/desktop/src-tauri/src/contact_profile/test.rs
+++ b/apps/desktop/src-tauri/src/contact_profile/test.rs
@@ -175,6 +175,10 @@ fn classify_excludes_deep_path_project_links_by_shape() {
         "a platform profile must still seed extras: {extra_urls:?}"
     );
     assert!(
+        !extra_urls.contains(&"https://github.com/alice"),
+        "a github profile promoted to the github field must not also appear in extras: {extra_urls:?}"
+    );
+    assert!(
         extra_urls.contains(&"https://gitlab.com/alice"),
         "a bare GitLab profile is profile-shaped and must seed extras: {extra_urls:?}"
     );


### PR DESCRIPTION
## Problem
On résumé import, the contact profile (header) is autofilled from the résumé's links — but **project links leaked in**: a GitHub *repo* URL became the candidate's `github`, a live-demo URL became `website`, and every remaining `http(s)` link was dumped into `extra_links`. Users then had to manually delete those in Contact Profile settings after every import.

## Root cause
`classify_contact_links` (`apps/desktop/src-tauri/src/contact_profile/mod.rs`) classified a **flat, section-blind** link pool using **host-only** rules — `is_github` matched any `github.com`, the website fallback took the first non-platform URL, and the extras loop kept *every* remaining link. The correct discrimination already existed on the TS generation side (`packages/prompts/src/generate/links/links.ts` — `isProfileShaped`/`classifyLinks`) but was never applied on the Rust import path.

## Fix
Gate seeding by URL **shape**, mirroring `links.ts`. New helpers (`PROFILE_HOSTS`, `is_profile_host`, `path_segments`, `is_bare_root`, `is_profile_shaped`, `is_contact_link`) close the three leak points:
- **GitHub** promotion now requires `is_profile_shaped` → `github.com/<user>` yes, `github.com/<user>/<repo>` no.
- **Website** fallback now requires `!is_profile_host && is_bare_root` → a deep demo path or a platform host is never taken as `website`.
- **extra_links** now requires `is_contact_link` → deep-path repo/demo/article/project URLs are dropped; genuine platform profiles (Dribbble, Behance, a second GitHub *user*) and bare-root personal sites are kept.

LinkedIn keeps its stricter `/in/` gate (company/school pages must never seed the header). Pure string parsing — **no regex** (no ReDoS surface). Doc-comments point to `links.ts` as the canonical rule so the two can't drift.

## Tests
`contact_profile/test.rs` — new `classify_excludes_deep_path_project_links_by_shape` asserting BOTH directions: GitHub/GitLab repo URLs, a LinkedIn company page, and a deep demo path are all excluded from the whole profile; `github.com/<user>`, `gitlab.com/<user>`, `linkedin.com/in/<user>`, `dribbble.com/<user>`, and a bare personal domain still seed correctly.
- `cargo test -p ajh-tauri --lib contact_profile` → 34 passed. `clippy -D warnings` clean. `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)