### PR TITLE
fix: rate-limit the ai_research_company web-search command

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -199,6 +199,26 @@ pub async fn ai_research_company(
     use crate::cover_letter::research::CompanyResearch;
     use crate::pipeline::Completer;
 
+    // Anti-abuse: rate + concurrency cap, sharing the same "ai_research" bucket
+    // as `ai_lookup_salary` — this is a billable provider web search with no
+    // other ceiling, so a looping/compromised renderer varying job_ad/company
+    // must not drive unbounded paid-API spend.
+    let limiter = app
+        .state::<std::sync::Arc<crate::limits::Limiter>>()
+        .inner()
+        .clone();
+    let _guard = match limiter.acquire(
+        "ai_research",
+        crate::limits::AI_RESEARCH_RATE_MAX,
+        crate::limits::AI_RESEARCH_CONCURRENCY_MAX,
+    ) {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::debug!("research_company: rate limited: {e}");
+            return json!({ "company": "", "brief": "" });
+        }
+    };
+
     let completer = match Completer::resolve(&app, provider.as_deref(), model.as_deref(), base_url)
     {
         Ok(c) => c,
@@ -207,6 +227,16 @@ pub async fn ai_research_company(
             return json!({ "company": "", "brief": "" });
         }
     };
+
+    // Per-provider daily request ceiling — the same coarse runaway-cost
+    // backstop `ai_generate`/`ai_lookup_salary` charge.
+    if let Err(e) = limiter.charge_provider_daily(
+        completer.provider_id().as_str(),
+        crate::limits::PROVIDER_DAILY_MAX,
+    ) {
+        tracing::debug!("research_company: daily budget exceeded: {e}");
+        return json!({ "company": "", "brief": "" });
+    }
 
     // Prefer the accurate AI-extracted company name from the generation flow; the
     // enricher falls back to heuristic job-ad extraction only when it's absent.
@@ -241,8 +271,8 @@ pub async fn ai_lookup_salary(
     // exactly. This is a billable provider web search (Ollama fires two calls:
     // search + synthesis) with no other ceiling, so a looping/compromised
     // renderer varying inputs must not drive unbounded paid-API spend. The
-    // `"ai_research"` bucket is shared with any future research-family command
-    // (`ai_research_company` is a follow-up retrofit — out of scope here).
+    // `"ai_research"` bucket is shared with `ai_research_company`, which uses
+    // the same guard.
     let limiter = app
         .state::<std::sync::Arc<crate::limits::Limiter>>()
         .inner()

--- a/apps/desktop/src-tauri/src/limits/mod.rs
+++ b/apps/desktop/src-tauri/src/limits/mod.rs
@@ -1,7 +1,7 @@
 //! In-memory anti-abuse limiter for paid / expensive commands.
 //!
-//! Guards `ai_generate`, `ai_lookup_salary`, `scrape_board`, and `scrape_url`
-//! against a looping (or XSS'd) renderer driving unbounded paid-API spend or
+//! Guards `ai_generate`, `ai_lookup_salary`, `ai_research_company`, `scrape_board`,
+//! and `scrape_url` against a looping (or XSS'd) renderer driving unbounded paid-API spend or
 //! scrape abuse — today only autopilot is wall-clock bounded, so a direct IPC
 //! loop has no ceiling.
 //!
@@ -47,8 +47,7 @@ pub const AI_GENERATE_RATE_MAX: usize = 20;
 pub const AI_GENERATE_CONCURRENCY_MAX: usize = 3;
 
 /// The `"ai_research"` command bucket: shared by every web-research lookup
-/// (today `ai_lookup_salary`; `ai_research_company` is a follow-up retrofit —
-/// out of scope here, tracked as a known gap) so they share one rate +
+/// (`ai_lookup_salary` and `ai_research_company`) so they share one rate +
 /// concurrency ceiling instead of each needing its own tuning. At most this
 /// many starts per [`RATE_WINDOW`].
 pub const AI_RESEARCH_RATE_MAX: usize = 20;


### PR DESCRIPTION
## Problem
`ai_research_company` fires a billable provider web search (company-brief research) with **no rate-limit, concurrency, or daily-budget guard** — unlike its siblings `ai_lookup_salary` and `ai_generate`. A looping or compromised renderer varying `job_ad`/`company` could drive unbounded paid-API spend. This was flagged as the "half-wired `ai_research` bucket" follow-up from the C2 (#549) security review.

## Fix
Apply the exact guard `ai_lookup_salary` already uses, sharing the same `"ai_research"` limiter bucket (so the two research commands share one ceiling) plus the per-provider daily budget:
- `limiter.acquire("ai_research", AI_RESEARCH_RATE_MAX, AI_RESEARCH_CONCURRENCY_MAX)` (RAII guard held for the command body) before resolving the provider;
- `charge_provider_daily(provider_id, PROVIDER_DAILY_MAX)` after resolve.

Both throttle paths degrade to `ai_research_company`'s existing empty `{ "company": "", "brief": "" }` shape — the company brief is optional, so generation continues ungrounded rather than erroring. Also updated `ai_lookup_salary`'s comment (the bucket is no longer half-wired).

## Tests
No new test — the process-local limiter has no unit-test seam (same as `ai_lookup_salary`). `cargo test -p ajh-tauri --lib` → 1718 passed; `clippy -D warnings` / `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)