### PR TITLE
ci: install libgtk-3-dev on linux release to fix gdk-sys build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+          packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev
           version: latest
 
       - name: 💾 Restore Rust Cache


### PR DESCRIPTION
## What

Adds `libgtk-3-dev`, `libsoup-3.0-dev`, and `libjavascriptcoregtk-4.1-dev` to the Linux system-dependency list in the release workflow (`.github/workflows/release.yml`).

## Why

The `ubuntu-22.04` Tauri build was failing:

```
error: failed to run custom build command for `gdk-sys v0.18.2`
Package gdk-3.0 was not found in the pkg-config search path
```

The "🐧 Install Linux Dependencies" step uses `awalsh128/cache-apt-pkgs-action`, which restores **only the explicitly-listed packages, not their transitive dependencies**. `libwebkit2gtk-4.1-dev` was listed but `libgtk-3-dev` (which ships `gdk-3.0.pc`) was not, so on a cache hit pkg-config couldn't find `gdk-3.0` and `gdk-sys`'s build script failed. `libsoup-3.0-dev` and `libjavascriptcoregtk-4.1-dev` are the same-class next dominoes for webkit2gtk-4.1.

Adding them to the list also invalidates the stale apt cache (the package set is part of the cache key). This is the standard Tauri v2 Ubuntu-22.04 dependency set.

## Scope

One line in `.github/workflows/release.yml`. Checked the other workflows — `release.yml` is the only one installing Linux Tauri system deps, so no other job needs the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
