### PR TITLE
ci: install linux tauri deps via apt-get, not the cache-apt-pkgs action

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -15,13 +15,26 @@ runs:
       with:
         components: ${{ inputs.components }}
 
-    # NOTE: this third-party action internally pins actions/cache/restore@v4
-    # (Node 20), so it emits a deprecation warning we can't fix from here.
+    # NOTE: cache-apt-pkgs-action does not actually install dev packages to the
+    # system location pkg-config searches (reports "Clean installing" but
+    # gdk-3.0.pc etc. are missing afterward) — use apt-get directly instead.
     - name: 🐧 Install Linux Dependencies
-      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
-      with:
-        packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-        version: latest
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libwebkit2gtk-4.1-dev \
+          libgtk-3-dev \
+          libayatana-appindicator3-dev \
+          librsvg2-dev \
+          libsoup-3.0-dev \
+          libjavascriptcoregtk-4.1-dev \
+          libxdo-dev \
+          libssl-dev \
+          patchelf \
+          build-essential \
+          curl wget file
 
     - name: 💾 Restore Rust Cache
       uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,10 +244,20 @@ jobs:
 
       - name: 🐧 Install Linux Dependencies
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
-        with:
-          packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev
-          version: latest
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libxdo-dev \
+            libssl-dev \
+            patchelf \
+            build-essential \
+            curl wget file
 
       - name: 💾 Restore Rust Cache
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1


### PR DESCRIPTION
## What

Replaces `awalsh128/cache-apt-pkgs-action` with a native `sudo apt-get install` for the Linux Tauri system dependencies, in **two** places: the `release.yml` installer build and the shared `.github/actions/setup-rust` composite action.

## Why — follow-up to #553, which was insufficient

#553 added `libgtk-3-dev` (+ soup/jscore) to the action's package list, but the Linux release build **still** fails:

```
Package gdk-3.0 was not found in the pkg-config search path
```

The CI log proves the **action** is the problem, not the package list: it was a cache **miss**, the action reported **"Clean installing 12 packages" including `libgtk-3-dev=3.24.33`**, yet `gdk-3.0.pc` was absent from the pkg-config path afterward. `awalsh128/cache-apt-pkgs-action@v1.6.x` does not reliably install `-dev` libraries to the system location on its clean-install path — so adding more package names can't fix it.

Native `apt-get install` installs to the system with the full transitive dependency closure and puts `.pc` files where pkg-config looks (the approach the official Tauri CI docs use).

## Scope — also defuses a latent failure

`.github/actions/setup-rust` (consumed by `ci-pipeline.yml` build-verification + tests, `quality.yml` clippy/cargo-hack/cargo-mutants/benchmark, and `security.yml` cargo-audit) used the **same** broken action pinned to an even older `v1.6.0` **and was missing `libgtk-3-dev`/`libsoup-3.0-dev`/`libjavascriptcoregtk-4.1-dev` entirely**. Those jobs pass today only because they hit a warm apt cache; the next cache miss would reproduce the identical `gdk-3.0 not found` failure. Converted to the same `apt-get` install.

All `setup-rust` consumers run on `ubuntu-latest`, and both apt steps are additionally guarded with `if: runner.os == 'Linux'` (defensive — matches the release.yml step).

## Trade-off

Drops apt-layer caching (a few seconds per Linux job) in exchange for a build that actually works.

## Verification

The real proof is a green `🚀 Release` run (manual `workflow_dispatch`) after merge. On this PR, the jobs that use `setup-rust` (Tests, Build Verification, Feature combinations, Mutation testing) exercise the new apt path directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
