### PR TITLE
fix: prevent prep-this-application runs from getting stuck at pending

### DIFF
--- a/apps/desktop/src-tauri/src/agent/controller.rs
+++ b/apps/desktop/src-tauri/src/agent/controller.rs
@@ -33,6 +33,19 @@ pub const MAX_AGENT_STEPS: usize = 8;
 /// completions per run — stops a loop that keeps calling tools without converging.
 pub const MAX_AGENT_TOKENS: usize = 60_000;
 
+/// Wall-clock ceiling on ONE provider turn or ONE read-tool call (a text-drafting
+/// tool makes its own provider request). Before this fix, the `tokio::select!`
+/// races below raced ONLY against `cancel` — a hung or misconfigured
+/// OpenAI-compatible `base_url` blocked the whole run for minutes with no
+/// terminal event, so `agent_run`'s spawn never emitted a terminal `jobs:event`
+/// and the run looked stuck at pending forever.
+// ponytail: set comfortably above the longest single-call HTTP timeout we ship
+// (`commands::ai_provider::timeouts::OLLAMA_COMPLETION` = 300s), so that
+// timeout's own specific network error surfaces first in the common case; this
+// is the backstop for whatever slips past it (e.g. a custom base_url whose
+// connect/read hangs outside the per-request client timeout).
+pub(super) const AGENT_STEP_TIMEOUT: Duration = Duration::from_secs(360);
+
 /// The fixed, trusted system prompt. NEVER interpolate scraped/user/tool text here.
 /// `pub(super)` so `agent::gate`'s test harness can reuse the exact same prompt
 /// instead of duplicating the literal.
@@ -63,6 +76,11 @@ pub enum StoppedReason {
     /// (`AppError::RateLimited`) mid-run — stop gracefully and keep whatever
     /// `steps`/`final_text` were already accumulated instead of discarding them.
     Budgeted,
+    /// A single provider turn or read-tool call exceeded [`AGENT_STEP_TIMEOUT`] —
+    /// a hung/misconfigured endpoint must not block the run forever with no
+    /// terminal event. Maps to a job FAILURE in `agent_run` (never a silent
+    /// success — see its spawn's match arm).
+    Timeout,
 }
 
 /// The result of an agent run.
@@ -186,6 +204,16 @@ fn tool_result_fence(name: &str, body: &str) -> String {
     format!("[tool_result:{name}]\n{body}")
 }
 
+/// The `final_text` stamped on a [`StoppedReason::Timeout`] outcome — surfaced
+/// verbatim as the job's failure message by `agent_run`'s spawn.
+fn step_timeout_message() -> String {
+    format!(
+        "The AI provider did not respond within {}s, so the run was stopped instead \
+         of hanging indefinitely. Check the model/endpoint in Settings → AI and try again.",
+        AGENT_STEP_TIMEOUT.as_secs()
+    )
+}
+
 /// The budgeted, cancellable tool-calling loop. Pure control flow over
 /// [`AgentEnv`] — no `AppHandle`, so it is unit-testable with a scripted fake.
 ///
@@ -274,19 +302,29 @@ pub async fn run_agent_with_system(
                     stopped_reason: StoppedReason::Cancelled,
                 });
             }
-            result = env.turn(&messages) => match result {
-                Ok(t) => t,
+            result = tokio::time::timeout(AGENT_STEP_TIMEOUT, env.turn(&messages)) => match result {
+                Ok(Ok(t)) => t,
                 // `LiveAgentEnv::turn` charges the per-provider daily ceiling before
                 // each request; hitting it on turn 3+ of an otherwise-successful run
                 // must not discard the `steps`/`final_text` accumulated so far.
-                Err(AppError::RateLimited(_)) => {
+                Ok(Err(AppError::RateLimited(_))) => {
                     return Ok(AgentOutcome {
                         final_text,
                         steps,
                         stopped_reason: StoppedReason::Budgeted,
                     });
                 }
-                Err(e) => return Err(e),
+                Ok(Err(e)) => return Err(e),
+                // Wall-clock backstop: the provider never responded within
+                // `AGENT_STEP_TIMEOUT` — stop instead of hanging forever with no
+                // terminal event.
+                Err(_elapsed) => {
+                    return Ok(AgentOutcome {
+                        final_text: step_timeout_message(),
+                        steps,
+                        stopped_reason: StoppedReason::Timeout,
+                    });
+                }
             },
         };
         steps += 1;
@@ -361,9 +399,22 @@ pub async fn run_agent_with_system(
                                 stopped_reason: StoppedReason::Cancelled,
                             });
                         }
-                        result = env.run_read_tool(&call.name, call.args.clone()) => match result {
-                            Ok(v) => v.to_string(),
-                            Err(e) => format!("error: {e}"),
+                        result = tokio::time::timeout(
+                            AGENT_STEP_TIMEOUT,
+                            env.run_read_tool(&call.name, call.args.clone()),
+                        ) => match result {
+                            Ok(Ok(v)) => v.to_string(),
+                            Ok(Err(e)) => format!("error: {e}"),
+                            // Wall-clock backstop: this read tool (which may itself
+                            // make a provider call, e.g. a drafting tool) never
+                            // returned within `AGENT_STEP_TIMEOUT`.
+                            Err(_elapsed) => {
+                                return Ok(AgentOutcome {
+                                    final_text: step_timeout_message(),
+                                    steps,
+                                    stopped_reason: StoppedReason::Timeout,
+                                });
+                            }
                         },
                     }
                 }
@@ -846,6 +897,77 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.stopped_reason, StoppedReason::Cancelled);
+        assert_eq!(
+            out.steps, 1,
+            "the turn that requested the hanging tool call already counted"
+        );
+    }
+
+    /// The controller's wall-clock backstop: a provider turn that never resolves
+    /// (no cancellation involved) must still stop the run, not hang forever with
+    /// no terminal event. `start_paused` lets the sleep past `AGENT_STEP_TIMEOUT`
+    /// resolve the instant the loop's own timeout timer fires, instead of
+    /// blocking the test for 360 real seconds (mirrors
+    /// `salary_research`'s `enrich_returns_none_...timeout` test).
+    #[tokio::test(start_paused = true)]
+    async fn provider_turn_exceeding_the_step_timeout_stops_the_loop() {
+        struct SlowTurnEnv;
+        #[async_trait]
+        impl AgentEnv for SlowTurnEnv {
+            async fn turn(&self, _messages: &[ChatMsg]) -> AppResult<AgentTurn> {
+                tokio::time::sleep(AGENT_STEP_TIMEOUT + Duration::from_secs(5)).await;
+                Ok(final_turn("too slow to matter"))
+            }
+            async fn run_read_tool(&self, _name: &str, _args: Value) -> AppResult<Value> {
+                unreachable!("no tool call is reached in this test")
+            }
+            fn on_step(&self, _step: &AgentStep) {}
+        }
+
+        let out = run_agent(
+            &SlowTurnEnv,
+            &whitelist(),
+            "help".into(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::Timeout);
+        assert_eq!(out.steps, 0, "the hung turn never actually resolved");
+        assert!(
+            out.final_text.contains("did not respond"),
+            "the timeout must leave a clear final message, got: {:?}",
+            out.final_text
+        );
+    }
+
+    /// Same backstop for an in-flight READ tool call (e.g. a text-drafting tool
+    /// making its own provider request) — the turn that requested it resolves
+    /// immediately, so this exercises the second `tokio::time::timeout` site.
+    #[tokio::test(start_paused = true)]
+    async fn read_tool_call_exceeding_the_step_timeout_stops_the_loop() {
+        struct SlowToolEnv;
+        #[async_trait]
+        impl AgentEnv for SlowToolEnv {
+            async fn turn(&self, _messages: &[ChatMsg]) -> AppResult<AgentTurn> {
+                Ok(read_call("reader"))
+            }
+            async fn run_read_tool(&self, _name: &str, _args: Value) -> AppResult<Value> {
+                tokio::time::sleep(AGENT_STEP_TIMEOUT + Duration::from_secs(5)).await;
+                Ok(json!({ "ran": "too late" }))
+            }
+            fn on_step(&self, _step: &AgentStep) {}
+        }
+
+        let out = run_agent(
+            &SlowToolEnv,
+            &whitelist(),
+            "help".into(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.stopped_reason, StoppedReason::Timeout);
         assert_eq!(
             out.steps, 1,
             "the turn that requested the hanging tool call already counted"

--- a/apps/desktop/src-tauri/src/commands/agent.rs
+++ b/apps/desktop/src-tauri/src/commands/agent.rs
@@ -31,27 +31,40 @@ use crate::ipc_contracts::agent::{AgentConfirmRequest, AgentRunRequest};
 use crate::pipeline::Completer;
 use crate::scraping::ScraperEngine;
 
+/// Fail the run: mark the job Failed and release its cancel-token registration.
+/// Shared by every validation step that now runs INSIDE the spawned task (see
+/// `agent_run`'s fix note) so each one doesn't hand-roll the same two calls.
+async fn fail_run(app: &AppHandle, engine: &ScraperEngine, job_id: &str, msg: String) {
+    crate::commands::jobs::job_fail(app, job_id, msg);
+    engine.unregister_token(job_id).await;
+}
+
 /// Prepare one job application via the agentic loop. Returns `{ jobId }`
 /// immediately; the run streams `agent:step` events and finishes the job async.
 ///
-/// Modeled on [`crate::commands::ai::ai_generate`]: acquire the anti-abuse limiter
-/// (held for the whole run), validate the provider/model, start a `JobTracker`
-/// entry, then spawn the loop. All validation failures fail the job with a clear
-/// message and still return `{ jobId }` so the renderer can surface it.
+/// Modeled on [`crate::commands::ai::ai_generate`]: acquire the anti-abuse limiter,
+/// register the cancel token, then spawn the loop. EVERY fail-able step — provider/
+/// model validation, `Completer::resolve`, the tool-capability check, and loading
+/// the résumé + cached job posting — now runs INSIDE the spawned task, alongside
+/// the loop itself, so no terminal `jobs:event` can ever fire before this function
+/// returns `{ jobId }`. That return is the renderer's ONLY source of the job id; it
+/// starts filtering `jobs:event`/`agent:step` by that id only afterwards, so a
+/// terminal event emitted synchronously (as validation failures used to, via a
+/// `fail` closure called before the `json!` return) was silently dropped and the
+/// run looked stuck at pending forever. The one exception is the limiter's
+/// rate/concurrency rejection: it still fails synchronously (before the cancel
+/// token even exists to register), which the renderer separately reconciles.
 #[tauri::command]
 pub async fn agent_run(app: AppHandle, req: AgentRunRequest) -> Value {
     let job_id = new_job_id();
     crate::commands::jobs::job_start(&app, &job_id, "agent.run");
 
-    let fail = |app: &AppHandle, job_id: &str, msg: String| -> Value {
-        crate::commands::jobs::job_fail(app, job_id, msg);
-        json!({ "jobId": job_id })
-    };
-
     // 0. Anti-abuse: rate + concurrency cap. Held for the run's lifetime (moved into
     // the spawned task), so the in-flight slot frees exactly when the run ends. One
     // run fans out into several provider calls (each turn/tool is separately charged
     // against the per-provider daily ceiling), so admit fewer than an `ai_generate`.
+    // This is the one remaining SYNCHRONOUS fail path (see the fn doc above): it
+    // runs before the cancel token exists, so there is nothing to unregister.
     let limiter = app.state::<Arc<crate::limits::Limiter>>().inner().clone();
     let guard = match limiter.acquire(
         "agent_run",
@@ -59,67 +72,11 @@ pub async fn agent_run(app: AppHandle, req: AgentRunRequest) -> Value {
         crate::limits::AGENT_RUN_CONCURRENCY_MAX,
     ) {
         Ok(g) => g,
-        Err(e) => return fail(&app, &job_id, e.to_string()),
+        Err(e) => {
+            crate::commands::jobs::job_fail(&app, &job_id, e.to_string());
+            return json!({ "jobId": job_id });
+        }
     };
-
-    // 1-2. Provider must be present, known, and own the model — the same
-    // required-and-validated rule as `ai_generate` (no silent fallback).
-    let provider_id = match ProviderId::parse(req.provider.trim()) {
-        Ok(id) => id,
-        Err(e) => return fail(&app, &job_id, e.to_string()),
-    };
-    if let Err(e) = provider_id.validate_model(&req.model) {
-        return fail(&app, &job_id, e.to_string());
-    }
-
-    // Resolve the active provider into a Completer for the agent's own turns.
-    let completer = match Completer::resolve(
-        &app,
-        Some(&req.provider),
-        Some(&req.model),
-        req.base_url.clone(),
-    ) {
-        Ok(c) => c,
-        Err(e) => return fail(&app, &job_id, e.to_string()),
-    };
-
-    // HIGH-2 defense-in-depth: a non-tool model degrades `chat_with_tools` to a
-    // single-shot answer (see the trait default), which could present a fabricated
-    // match score or invented company research as if the tools actually ran. Reject
-    // early with a clear message — the renderer separately disables the entry point
-    // for non-tool models; this is the server-side guard.
-    if let Err(e) = require_tool_capable(completer.capabilities(), &req.model) {
-        return fail(&app, &job_id, e.to_string());
-    }
-
-    // Load the résumé + cached job posting to build the (untrusted, fenced) user
-    // message. Both must exist — fail early with a clear message otherwise.
-    let Some(resume) = app.state::<DocumentStore>().get(&req.resume_id) else {
-        return fail(
-            &app,
-            &job_id,
-            format!("resume not found: {}", req.resume_id),
-        );
-    };
-    let Some(job_text) = crate::commands::match_resume::job_text_for(&app, &req.job_id) else {
-        return fail(
-            &app,
-            &job_id,
-            format!("job not found in cache: {}", req.job_id),
-        );
-    };
-
-    // Trusted routing context threaded into the tools — provider/model/base_url/
-    // job_id all come from the VALIDATED request, NEVER from model-supplied tool
-    // args (job_id lets `research_company` load THIS run's own posting server-side
-    // — see the LOW-1 fix in `agent::tools`).
-    let ctx = ToolContext {
-        provider: req.provider.clone(),
-        model: req.model.clone(),
-        base_url: req.base_url.clone(),
-        job_id: req.job_id.clone(),
-    };
-    let user = build_user_message(&req.resume_id, &req.job_id, &resume.text, &job_text);
 
     // HIGH-1(a): register the cancel token BEFORE spawning (mirrors
     // `commands::scrape::scrape_boards`) so a fast `jobs_cancel` call arriving
@@ -137,6 +94,82 @@ pub async fn agent_run(app: AppHandle, req: AgentRunRequest) -> Value {
     let engine_task = engine.clone();
     tauri::async_runtime::spawn(async move {
         let _guard = guard; // release the concurrency slot when the run ends
+
+        // 1-2. Provider must be present, known, and own the model — the same
+        // required-and-validated rule as `ai_generate` (no silent fallback).
+        let provider_id = match ProviderId::parse(req.provider.trim()) {
+            Ok(id) => id,
+            Err(e) => {
+                fail_run(&app_task, &engine_task, &job_id_task, e.to_string()).await;
+                return;
+            }
+        };
+        if let Err(e) = provider_id.validate_model(&req.model) {
+            fail_run(&app_task, &engine_task, &job_id_task, e.to_string()).await;
+            return;
+        }
+
+        // Resolve the active provider into a Completer for the agent's own turns.
+        let completer = match Completer::resolve(
+            &app_task,
+            Some(&req.provider),
+            Some(&req.model),
+            req.base_url.clone(),
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                fail_run(&app_task, &engine_task, &job_id_task, e.to_string()).await;
+                return;
+            }
+        };
+
+        // HIGH-2 defense-in-depth: a non-tool model degrades `chat_with_tools` to a
+        // single-shot answer (see the trait default), which could present a
+        // fabricated match score or invented company research as if the tools
+        // actually ran. Reject early with a clear message — the renderer separately
+        // disables the entry point for non-tool models; this is the server-side
+        // guard.
+        if let Err(e) = require_tool_capable(completer.capabilities(), &req.model) {
+            fail_run(&app_task, &engine_task, &job_id_task, e.to_string()).await;
+            return;
+        }
+
+        // Load the résumé + cached job posting to build the (untrusted, fenced)
+        // user message. Both must exist — fail early with a clear message otherwise.
+        let Some(resume) = app_task.state::<DocumentStore>().get(&req.resume_id) else {
+            fail_run(
+                &app_task,
+                &engine_task,
+                &job_id_task,
+                format!("resume not found: {}", req.resume_id),
+            )
+            .await;
+            return;
+        };
+        let Some(job_text) = crate::commands::match_resume::job_text_for(&app_task, &req.job_id)
+        else {
+            fail_run(
+                &app_task,
+                &engine_task,
+                &job_id_task,
+                format!("job not found in cache: {}", req.job_id),
+            )
+            .await;
+            return;
+        };
+
+        // Trusted routing context threaded into the tools — provider/model/base_url/
+        // job_id all come from the VALIDATED request, NEVER from model-supplied
+        // tool args (job_id lets `research_company` load THIS run's own posting
+        // server-side — see the LOW-1 fix in `agent::tools`).
+        let ctx = ToolContext {
+            provider: req.provider.clone(),
+            model: req.model.clone(),
+            base_url: req.base_url.clone(),
+            job_id: req.job_id.clone(),
+        };
+        let user = build_user_message(&req.resume_id, &req.job_id, &resume.text, &job_text);
+
         let tools = prep_application_tools();
         let outcome = run_agent_live(
             &app_task,
@@ -157,6 +190,14 @@ pub async fn agent_run(app: AppHandle, req: AgentRunRequest) -> Value {
             // deliberately-aborted run is misleading, not a finished suggestion.
             Ok(o) if o.stopped_reason == StoppedReason::Cancelled => {
                 crate::commands::jobs::job_cancel(&app_task, &job_id_task);
+            }
+            // A hung/misconfigured provider or tool call: the controller's own
+            // step timeout stopped the loop (see `agent::controller::
+            // AGENT_STEP_TIMEOUT`). This is a FAILURE, never a silent success —
+            // the renderer must show an error, not a completed proposal built on
+            // a run that never actually finished.
+            Ok(o) if o.stopped_reason == StoppedReason::Timeout => {
+                crate::commands::jobs::job_fail(&app_task, &job_id_task, o.final_text);
             }
             Ok(o) => {
                 // Terminal PROPOSAL step: the agent's final summary of what it

--- a/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
@@ -275,7 +275,7 @@ describe('PrepApplicationPanel — run failure', () => {
   });
 });
 
-describe('PrepApplicationPanel — fast-fail reconciliation (no stuck spinner)', () => {
+describe('PrepApplicationPanel — useJob reconciliation fallback (no stuck spinner)', () => {
   it('reaches `error` via useJob reconciliation when the job already failed before any jobs:event arrived', async () => {
     // Simulates the race: a fast backend validation failure emits its
     // terminal `jobs:event` before `agent.run`'s IPC round-trip resolves, so
@@ -300,6 +300,57 @@ describe('PrepApplicationPanel — fast-fail reconciliation (no stuck spinner)',
     expect(screen.getByText('jobs.prep.runFailed')).toBeInTheDocument();
     expect(screen.getByText('Provider does not support tool calls.')).toBeInTheDocument();
     // Would still show the busy spinner if the machine were stuck in `planning`.
+    expect(screen.queryByText('jobs.prep.starting')).not.toBeInTheDocument();
+  });
+
+  it('reaches `done` via useJob reconciliation and renders the proposal when job.completed never arrived (agent:step already streamed it)', async () => {
+    openModal();
+    await clickStart();
+
+    // The `agent:step` channel is unaffected by the `jobs:event` race — the
+    // proposal narration already streamed in. `job.result` (read here) is a
+    // DIFFERENT field than the live event path's `event.data` — this is the
+    // regression check for that mapping.
+    stubbedJobRecord = {
+      id: 'job-1',
+      kind: 'ai.generate',
+      status: 'completed',
+      progress: 100,
+      payload: {},
+      result: { finalText: 'Proposal draft text.', steps: 5, stoppedReason: 'done' },
+      retries: 0,
+      maxRetries: 0,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    act(() => {
+      stepHandler?.(
+        turnStep({ step: 5, text: 'Proposal draft text.', tools: [], kind: 'proposal' })
+      );
+    });
+
+    expect(screen.getByText('jobs.prep.proposalTitle')).toBeInTheDocument();
+    expect(screen.getByText('Proposal draft text.')).toBeInTheDocument();
+    expect(screen.getByText('jobs.prep.stopped.done')).toBeInTheDocument();
+    expect(screen.queryByText('jobs.prep.starting')).not.toBeInTheDocument();
+  });
+
+  it('reaches `cancelled` via useJob reconciliation when the job was already cancelled before any jobs:event arrived', async () => {
+    stubbedJobRecord = {
+      id: 'job-1',
+      kind: 'ai.generate',
+      status: 'cancelled',
+      progress: 0,
+      payload: {},
+      retries: 0,
+      maxRetries: 0,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    openModal();
+    await clickStart();
+
+    expect(screen.getByText('jobs.prep.stopped.cancelled')).toBeInTheDocument();
     expect(screen.queryByText('jobs.prep.starting')).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
@@ -25,7 +25,7 @@ import type React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
-import type { AgentStepEvent, JobEvent } from '@ajh/shared';
+import type { AgentStepEvent, JobEvent, JobRecord } from '@ajh/shared';
 import type * as AjhUi from '@ajh/ui';
 
 import type { Posting } from '@/features/jobs/types';
@@ -74,6 +74,9 @@ vi.mock('@/hooks/useDefaultResumeId', () => ({
 
 let stepHandler: ((event: AgentStepEvent) => void) | undefined;
 let jobEventHandler: ((event: JobEvent) => void) | undefined;
+// Drives the `useJob` reconciliation fallback — undefined unless a test
+// stubs it to simulate a fast-fail job the event path never delivered.
+let stubbedJobRecord: JobRecord | undefined;
 const mockRunMutateAsync = vi.fn().mockResolvedValue({ jobId: 'job-1' });
 const mockCancelMutateAsync = vi.fn().mockResolvedValue(undefined);
 const mockConfirmMutateAsync = vi.fn().mockResolvedValue({ ok: true });
@@ -86,6 +89,7 @@ vi.mock('@/services', () => ({
   },
   useCancelJob: () => ({ mutateAsync: mockCancelMutateAsync }),
   useGenerateConfig: () => ({ provider: 'ollama', model: 'llama3', baseUrl: undefined }),
+  useJob: () => ({ data: stubbedJobRecord }),
   useJobEvents: (cb: (event: JobEvent) => void) => {
     jobEventHandler = cb;
   },
@@ -142,6 +146,7 @@ beforeEach(() => {
   mockConfirmMutateAsync.mockResolvedValue({ ok: true });
   stepHandler = undefined;
   jobEventHandler = undefined;
+  stubbedJobRecord = undefined;
 });
 
 function openModal() {
@@ -267,6 +272,35 @@ describe('PrepApplicationPanel — run failure', () => {
     });
 
     expect(screen.queryByText('jobs.prep.runFailed')).not.toBeInTheDocument();
+  });
+});
+
+describe('PrepApplicationPanel — fast-fail reconciliation (no stuck spinner)', () => {
+  it('reaches `error` via useJob reconciliation when the job already failed before any jobs:event arrived', async () => {
+    // Simulates the race: a fast backend validation failure emits its
+    // terminal `jobs:event` before `agent.run`'s IPC round-trip resolves, so
+    // `handleJobEvent`'s `runJobId` guard never sees it. `jobEventHandler` is
+    // intentionally never invoked here — the fallback must reconcile solely
+    // from the job's already-failed status once `runJobId` is known.
+    stubbedJobRecord = {
+      id: 'job-1',
+      kind: 'ai.generate',
+      status: 'failed',
+      progress: 0,
+      payload: {},
+      error: 'Provider does not support tool calls.',
+      retries: 0,
+      maxRetries: 0,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    openModal();
+    await clickStart();
+
+    expect(screen.getByText('jobs.prep.runFailed')).toBeInTheDocument();
+    expect(screen.getByText('Provider does not support tool calls.')).toBeInTheDocument();
+    // Would still show the busy spinner if the machine were stuck in `planning`.
+    expect(screen.queryByText('jobs.prep.starting')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/index.tsx
@@ -15,6 +15,7 @@ import {
   useAgentStepEvents,
   useCancelJob,
   useGenerateConfig,
+  useJob,
   useJobEvents,
 } from '@/services';
 
@@ -117,6 +118,9 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
   // `start()` an instant (pre-render) "is a run already active" read so a
   // fast double-click can't spawn two concurrent runs.
   const activeRef = useRef(false);
+  // Guards the `useJob` reconciliation fallback below so it fires at most
+  // once per run — reset alongside the rest of the run state in `start()`.
+  const reconciledRef = useRef(false);
   const prevStatusRef = useRef<Partial<Record<ChecklistKey, string>>>({});
   // A stable in-modal focus target: `AgentConfirm` (and its own heading) fully
   // unmounts once a confirm resolves, so focus needs somewhere durable to land
@@ -168,31 +172,65 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
   );
   useAgentStepEvents(handleStep);
 
-  const handleJobEvent = useCallback(
-    (event: JobEvent) => {
-      if (!activeRef.current || event.jobId !== runJobId) return;
-      if (event.type === 'job.completed') {
-        activeRef.current = false;
-        setPendingConfirm(null);
-        setResult(event.data as AgentRunResult);
+  /**
+   * Shared terminal handling for both the live `jobs:event` path
+   * (`handleJobEvent`) and the `useJob` reconciliation fallback below — same
+   * side effects regardless of which one observes the terminal status first.
+   */
+  const finishRun = useCallback(
+    (outcome: 'completed' | 'failed' | 'cancelled', data?: unknown) => {
+      activeRef.current = false;
+      setPendingConfirm(null);
+      if (outcome === 'completed') {
+        setResult(data as AgentRunResult);
         send('COMPLETE');
-      } else if (event.type === 'job.failed') {
-        activeRef.current = false;
-        setPendingConfirm(null);
-        setError(typeof event.data === 'string' ? event.data : t('jobs.prep.runFailed'));
+      } else if (outcome === 'failed') {
+        setError(typeof data === 'string' ? data : t('jobs.prep.runFailed'));
         send('ERROR');
-      } else if (event.type === 'job.cancelled') {
+      } else {
         // A deliberate Stop is not a failure — its own state/copy, not ERROR.
         // Cancelling a suspended run resolves its pending confirm server-side
         // too (see `AgentGate::remove`) — nothing left here to act on.
-        activeRef.current = false;
-        setPendingConfirm(null);
         send('CANCEL');
       }
     },
-    [runJobId, send, t]
+    [send, t]
+  );
+
+  const handleJobEvent = useCallback(
+    (event: JobEvent) => {
+      if (!activeRef.current || event.jobId !== runJobId) return;
+      if (event.type === 'job.completed') finishRun('completed', event.data);
+      else if (event.type === 'job.failed') finishRun('failed', event.data);
+      else if (event.type === 'job.cancelled') finishRun('cancelled');
+    },
+    [runJobId, finishRun]
   );
   useJobEvents(handleJobEvent);
+
+  // Fallback for a fast fail: the backend can emit a terminal `jobs:event`
+  // BEFORE `agent.run`'s IPC round-trip resolves (before `runJobId`/the
+  // `activeRef`/`event.jobId` guard above is even listening), so that event
+  // is silently dropped and the machine would otherwise sit in its busy state
+  // forever. Once `runJobId` is known, reconcile against the job's actual
+  // status — idempotent (fires at most once via `reconciledRef`, and only
+  // while the machine is still busy, so it never overrides a run that already
+  // terminated through the normal event path).
+  const jobQuery = useJob(runJobId ?? '');
+  useEffect(() => {
+    if (!runJobId || reconciledRef.current || !isBusy) return;
+    const job = jobQuery.data;
+    if (
+      !job ||
+      (job.status !== 'completed' && job.status !== 'failed' && job.status !== 'cancelled')
+    ) {
+      return;
+    }
+    reconciledRef.current = true;
+    if (job.status === 'completed') finishRun('completed', job.result);
+    else if (job.status === 'failed') finishRun('failed', job.error);
+    else finishRun('cancelled');
+  }, [runJobId, jobQuery.data, isBusy, finishRun]);
 
   /** `<AgentConfirm>` only calls this once the resolve actually took effect
    *  (`{ ok: true }`) — an `{ ok: false }` stays on-screen showing its own
@@ -223,6 +261,7 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
     setPendingConfirm(null);
     prevStatusRef.current = {};
     activeRef.current = true;
+    reconciledRef.current = false;
     send('START');
     try {
       const { jobId } = await runAgent.mutateAsync({


### PR DESCRIPTION
## What

Fixes the user-reported bug that **"Prep this application" gets stuck at some pending jobs** — the agentic run hangs on a spinner and never completes. Two independent causes, both fixed.

## Root causes & fixes

**1. Renderer race — the permanent hang.** `agent_run` minted the job id, `job_start`ed it, then ran provider/model/résumé/job validation **synchronously** — each failure emitted the terminal `job.failed` `jobs:event` *before* the `{ jobId }` return. The panel only learns the job id (and only then filters events on it) from that return, so a fast validation failure's terminal event was dropped and the state machine sat in `planning` forever.
- **Backend:** move every fail-able validation into the spawned task, so all terminal events (success *or* failure) fire asynchronously — exactly like the happy path. `job_start` + cancel-token registration stay synchronous before the spawn (a fast `jobs_cancel` must never be a no-op); the limiter rejection is the sole remaining synchronous fail (it runs before the token exists), which the renderer reconciles. New `fail_run` helper (`job_fail` + `unregister_token`) at each site.
- **Renderer:** `PrepApplicationPanel` now reconciles against the job's *actual* status via `useJob(runJobId)` once the id is known — if the job is already terminal while the machine is still busy, it drives `COMPLETE`/`ERROR`/`CANCEL` (shared `finishRun`, fires at most once, never overrides a terminated machine).

**2. No per-step wall-clock timeout — long stalls.** The controller raced each provider turn / read-tool call only against `cancel`; a hung or misconfigured OpenAI-compatible `base_url` could block for minutes with no terminal event.
- Add `AGENT_STEP_TIMEOUT` (360s, above the 300s Ollama HTTP timeout) wrapping both step selects, plus `StoppedReason::Timeout` mapped to `job_fail` (never a silent success), so the loop always terminates and always emits a terminal `jobs:event`. The confirm-gate suspension keeps its own `CONFIRM_TIMEOUT`.

## Review

Reviewed by **rust-backend-architect** (token lifecycle, timeout/cancel composition — cancellation still wins the biased select; HIGH-1(a)/(b) invariants intact) and **frontend-reviewer** (byte-exact payload parity between the reconciliation and live-event paths; idempotent both directions). No HIGH/CRITICAL. `cargo fmt` + `clippy -D warnings` + build clean; `cargo test --test architecture` 11 passed; two new `FakeEnv` step-timeout tests; typecheck + `PrepApplicationPanel` suite (19) green. Rust tests run in CI.

## Verify

Trigger prep with a bad/absent provider or a missing résumé → the panel shows an **error**, never a permanent spinner; a slow provider now hits the step timeout and terminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
