### PR TITLE
fix: repair feature tour on collapsed sidebar, answer text selection, and rewrite popover stacking

### DIFF
--- a/apps/desktop/src/renderer/components/generation/EditableOutput/RewritePopover.test.tsx
+++ b/apps/desktop/src/renderer/components/generation/EditableOutput/RewritePopover.test.tsx
@@ -85,6 +85,7 @@ vi.mock('@ajh/ui', () => ({
   transition: { fast: {} },
   // useFocusTrap returns a ref object — the mock div accepts it as a plain prop.
   useFocusTrap: () => ({ current: null }),
+  cn: (...classes: unknown[]) => classes.filter(Boolean).join(' '),
 }));
 
 // ── component under test (import AFTER mocks so hoisting picks up the stubs) ──
@@ -173,5 +174,113 @@ describe('RewritePopover — timeout', () => {
     expect(screen.queryByText('aiGenerate.rewrite.failed')).toBeNull();
     // The rewrite result is displayed.
     expect(screen.getByText('rewritten text')).toBeTruthy();
+  });
+});
+
+describe('RewritePopover — anchored portal (anchorEl)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders inline (inside its own container) when anchorEl is not set', () => {
+    const { container } = renderPopover();
+    expect(container.contains(screen.getByRole('dialog'))).toBe(true);
+  });
+
+  it('portals to document.body, fixed-positions off the trigger rect, and lifts z-toast', () => {
+    const anchorEl = document.createElement('button');
+    anchorEl.getBoundingClientRect = () =>
+      ({ top: 100, bottom: 120, left: 200, right: 300, width: 100, height: 20 }) as DOMRect;
+    document.body.appendChild(anchorEl);
+
+    const { container } = render(
+      <RewritePopover
+        target={{ selection: 'some selected text', before: '', after: '' }}
+        docType="resume"
+        model="test-model"
+        onAccept={vi.fn()}
+        onClose={vi.fn()}
+        anchorEl={anchorEl}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    // Portaled OUT of the render container (a document.body sibling), not inline.
+    expect(container.contains(dialog)).toBe(false);
+    expect(dialog.className).toContain('z-toast');
+    expect(dialog.style.position).toBe('fixed');
+    expect(dialog.style.top).toBe('124px'); // rect.bottom (120) + 4px gap
+    expect(dialog.style.left).toBe('8px'); // clamped — rect.right (300) - panel width would go negative
+
+    document.body.removeChild(anchorEl);
+  });
+
+  it('flips the popover upward when it would not fit below the trigger', () => {
+    // jsdom performs no layout, so every element's real getBoundingClientRect()
+    // reads as zeros. Stub it globally to a realistic popover panel height
+    // (~380px, matching header + selection echo + presets + input + footer);
+    // the trigger below overrides its own instance method (takes precedence
+    // over this prototype stub) to report its own, separately-controlled rect.
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = () =>
+      ({ top: 0, left: 0, right: 352, bottom: 380, width: 352, height: 380 }) as DOMRect;
+
+    const anchorEl = document.createElement('button');
+    // Trigger sits near the bottom of jsdom's default 768px-tall viewport —
+    // opening below (720 + 380 + 4 = 1104) would push the footer far offscreen.
+    anchorEl.getBoundingClientRect = () =>
+      ({ top: 700, bottom: 720, left: 200, right: 300, width: 100, height: 20 }) as DOMRect;
+    document.body.appendChild(anchorEl);
+
+    render(
+      <RewritePopover
+        target={{ selection: 'some selected text', before: '', after: '' }}
+        docType="resume"
+        model="test-model"
+        onAccept={vi.fn()}
+        onClose={vi.fn()}
+        anchorEl={anchorEl}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    // Flipped above: anchorRect.top (700) - panelHeight (380) - 4px gap = 316.
+    expect(dialog.style.top).toBe('316px');
+    expect(Number(dialog.style.top.replace('px', ''))).toBeGreaterThanOrEqual(8);
+
+    document.body.removeChild(anchorEl);
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  it('clamps the flipped-upward position to never go above the 8px viewport margin', () => {
+    // A trigger near the very TOP of the viewport with a panel taller than the
+    // whole viewport: it doesn't fit below (forcing a flip), and flipping
+    // naively (anchorRect.top - panelHeight - 4) would go negative — must
+    // clamp to 8px instead of running off the top edge.
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = () =>
+      ({ top: 0, left: 0, right: 352, bottom: 750, width: 352, height: 750 }) as DOMRect;
+
+    const anchorEl = document.createElement('button');
+    anchorEl.getBoundingClientRect = () =>
+      ({ top: 20, bottom: 40, left: 200, right: 300, width: 100, height: 20 }) as DOMRect;
+    document.body.appendChild(anchorEl);
+
+    render(
+      <RewritePopover
+        target={{ selection: 'some selected text', before: '', after: '' }}
+        docType="resume"
+        model="test-model"
+        onAccept={vi.fn()}
+        onClose={vi.fn()}
+        anchorEl={anchorEl}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.style.top).toBe('8px');
+
+    document.body.removeChild(anchorEl);
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   });
 });

--- a/apps/desktop/src/renderer/components/generation/EditableOutput/RewritePopover.tsx
+++ b/apps/desktop/src/renderer/components/generation/EditableOutput/RewritePopover.tsx
@@ -36,7 +36,8 @@ interface RewritePopoverProps {
   locale?: string;
   /** Called with the accepted replacement text for the frozen range. */
   onAccept: (replacement: string) => void;
-  /** Called to dismiss the popover (Cancel / Escape / backdrop). */
+  /** Called to dismiss the popover (Cancel / Escape) — there is no backdrop in
+   *  either anchored-portal or inline mode, so outside-click doesn't dismiss. */
   onClose: () => void;
   /**
    * When set, the popover portals to `document.body` and fixed-positions itself

--- a/apps/desktop/src/renderer/components/generation/EditableOutput/RewritePopover.tsx
+++ b/apps/desktop/src/renderer/components/generation/EditableOutput/RewritePopover.tsx
@@ -1,9 +1,10 @@
 import { Check, Loader2, Sparkles, X } from 'lucide-react';
 import { motion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useTranslation } from '@ajh/translations';
-import { Button, Input, Tag, transition, useFocusTrap } from '@ajh/ui';
+import { Button, cn, Input, Tag, transition, useFocusTrap } from '@ajh/ui';
 
 import { type RewriteDocType, rewriteSelection } from '@/lib/generate';
 
@@ -12,6 +13,9 @@ const PRESETS = ['shorten', 'expand', 'rephrase', 'impact', 'grammar'] as const;
 
 /** Abort a stalled rewrite after this many ms so the popover never wedges. */
 const REWRITE_TIMEOUT_MS = 60_000;
+/** Matches the panel's `w-[22rem]` — clamps left-edge overflow when the trigger
+ *  sits near a viewport edge (anchored-portal mode only). */
+const POPOVER_WIDTH_PX = 352;
 type Preset = (typeof PRESETS)[number];
 
 export interface RewriteTarget {
@@ -34,6 +38,13 @@ interface RewritePopoverProps {
   onAccept: (replacement: string) => void;
   /** Called to dismiss the popover (Cancel / Escape / backdrop). */
   onClose: () => void;
+  /**
+   * When set, the popover portals to `document.body` and fixed-positions itself
+   * below-right of this trigger element instead of rendering inline. Use when the
+   * inline placement would be clipped by an `overflow-hidden`/`overflow-y-auto`
+   * ancestor (e.g. inside a `ModalShell`) or needs to sit above a modal's z-index.
+   */
+  anchorEl?: HTMLElement | null;
 }
 
 /**
@@ -54,6 +65,7 @@ export function RewritePopover({
   locale = 'en',
   onAccept,
   onClose,
+  anchorEl,
 }: RewritePopoverProps) {
   const { t } = useTranslation();
   const [instruction, setInstruction] = useState('');
@@ -66,6 +78,42 @@ export function RewritePopover({
   // into the page behind it. `useFocusTrap` also auto-focuses the first focusable
   // element; we still explicitly focus the instruction field below.
   const trapRef = useFocusTrap(true);
+  // A dedicated, locally-owned ref to the panel element (separate from
+  // `trapRef`) so measuring its height doesn't depend on `useFocusTrap`'s
+  // returned ref identity — merged onto the same node via the callback ref below.
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+  // The popover's own rendered height — it varies with content (streaming
+  // result, error text, …), so it can't be assumed static. Used to decide
+  // whether the panel fits below the trigger or must flip above it.
+  const [panelHeight, setPanelHeight] = useState<number | null>(null);
+
+  // Anchored-portal mode only: measure the trigger on open, and re-measure on
+  // scroll/resize — the caller's scrollable ancestor (e.g. a modal body) can move
+  // the trigger while this fixed-positioned popover stays put otherwise. Also
+  // track the panel's own height via ResizeObserver so a later content change
+  // (e.g. the streaming result appearing) can re-trigger the fit check below.
+  useLayoutEffect(() => {
+    if (!anchorEl) return;
+    const measureAnchor = () => setAnchorRect(anchorEl.getBoundingClientRect());
+    measureAnchor();
+    window.addEventListener('scroll', measureAnchor, true);
+    window.addEventListener('resize', measureAnchor);
+
+    const panel = panelRef.current;
+    let observer: ResizeObserver | undefined;
+    if (panel) {
+      setPanelHeight(panel.getBoundingClientRect().height);
+      observer = new ResizeObserver(() => setPanelHeight(panel.getBoundingClientRect().height));
+      observer.observe(panel);
+    }
+
+    return () => {
+      window.removeEventListener('scroll', measureAnchor, true);
+      window.removeEventListener('resize', measureAnchor);
+      observer?.disconnect();
+    };
+  }, [anchorEl]);
 
   // The instruction that produced the current result — lets Regenerate re-run the
   // same instruction without the user retyping it.
@@ -154,9 +202,36 @@ export function RewritePopover({
 
   const canAccept = !streaming && !!result.trim() && !error;
 
-  return (
+  // Anchored-portal mode: fixed-position below-right of the trigger, clamped so
+  // the (fixed-width) panel never runs off the left edge, and flipped ABOVE the
+  // trigger when it wouldn't fit below (e.g. Rewrite opened on a question near
+  // the bottom of a scrollable, height-capped modal) — clamped so it also never
+  // runs off the top edge. `visibility: hidden` (not `display: none`) until the
+  // first measurement lands keeps the panel laid out (so its real height can be
+  // read) without a visible flash — it's gone by paint since `useLayoutEffect`
+  // flushes `setAnchorRect`/`setPanelHeight` before the browser paints.
+  const anchoredStyle: React.CSSProperties | undefined = anchorEl
+    ? anchorRect
+      ? {
+          position: 'fixed',
+          top:
+            panelHeight !== null && anchorRect.bottom + panelHeight + 4 > window.innerHeight - 8
+              ? Math.max(8, anchorRect.top - panelHeight - 4)
+              : anchorRect.bottom + 4,
+          left: Math.min(
+            Math.max(8, anchorRect.right - POPOVER_WIDTH_PX),
+            window.innerWidth - POPOVER_WIDTH_PX - 8
+          ),
+        }
+      : { position: 'fixed', top: 0, left: 0, visibility: 'hidden' }
+    : undefined;
+
+  const popover = (
     <motion.div
-      ref={trapRef as React.RefObject<HTMLDivElement>}
+      ref={(node: HTMLDivElement | null) => {
+        trapRef.current = node;
+        panelRef.current = node;
+      }}
       role="dialog"
       aria-modal="true"
       aria-label={t('aiGenerate.rewrite.title')}
@@ -164,7 +239,11 @@ export function RewritePopover({
       animate={{ opacity: 1, y: 0, scale: 1 }}
       exit={{ opacity: 0, y: 6, scale: 0.98 }}
       transition={transition.fast}
-      className="w-[22rem] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-[var(--border-clear)] bg-secondary shadow-2xl"
+      style={anchoredStyle}
+      className={cn(
+        'w-[22rem] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-[var(--border-clear)] bg-secondary shadow-2xl',
+        anchorEl && 'z-toast'
+      )}
     >
       <div className="flex items-center justify-between border-b border-[var(--border-clear)] px-3 py-2">
         <span className="flex items-center gap-1.5 text-[11px] font-medium text-foreground/70">
@@ -286,4 +365,6 @@ export function RewritePopover({
       </div>
     </motion.div>
   );
+
+  return anchorEl ? createPortal(popover, document.body) : popover;
 }

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.test.tsx
@@ -132,7 +132,22 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  // Selections persist on the jsdom `window` across tests in the same file.
+  window.getSelection()?.removeAllRanges();
 });
+
+/** Selects `substring` (must occur exactly once in `text`) inside `el`'s text
+ *  node, mirroring a user drag-selecting part of the rendered answer. */
+function selectSubstring(el: HTMLElement, text: string, substring: string) {
+  const textNode = el.firstChild as Text;
+  const start = text.indexOf(substring);
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, start + substring.length);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+}
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
@@ -164,6 +179,36 @@ describe('ApplicationQuestionsModal — Rewrite with AI', () => {
     expect(popover).toBeTruthy();
     expect(popover.getAttribute('data-doc-type')).toBe('application-answer');
     expect(popover.getAttribute('data-selection')).toBe(ANSWER_TEXT);
+  });
+
+  it('selecting part of the answer targets only that substring for rewrite', () => {
+    render(<ApplicationQuestionsModal {...buildProps()} />);
+    selectSubstring(screen.getByText(ANSWER_TEXT), ANSWER_TEXT, 'led a payments migration');
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'autopilot.apply.questions.rewriteAriaLabel' })
+    );
+
+    expect(screen.getByTestId('rewrite-popover').getAttribute('data-selection')).toBe(
+      'led a payments migration'
+    );
+  });
+
+  it('accepting a rewrite of a selected substring splices it back into the full answer', async () => {
+    const updateAnswer = vi
+      .fn<(id: string, text: string) => Promise<void>>()
+      .mockResolvedValue(undefined);
+    render(<ApplicationQuestionsModal {...buildProps({ updateAnswer })} />);
+    selectSubstring(screen.getByText(ANSWER_TEXT), ANSWER_TEXT, 'led a payments migration');
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'autopilot.apply.questions.rewriteAriaLabel' })
+    );
+    fireEvent.click(screen.getByTestId('popover-accept')); // stub emits 'Rewritten answer text'
+
+    await waitFor(() => {
+      expect(updateAnswer).toHaveBeenCalledWith(QUESTION_ID, 'Because I Rewritten answer text.');
+    });
   });
 
   it('passes model and locale to the popover', () => {

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.test.tsx
@@ -362,7 +362,7 @@ describe('ApplicationQuestionsModal — Rewrite with AI', () => {
     expect(popover.getAttribute('data-selection')).toBe(secondAnswer);
   });
 
-  it('stale revert guard: if a second acceptRewrite supersedes A before A save fails, revertAnswer is NOT called for A', async () => {
+  it('stale revert guard: if a second acceptRewrite supersedes A before A save fails, revertAnswer and the error toast are NOT triggered for A', async () => {
     // The shared stub always emits the SAME text, so A and B would be
     // indistinguishable. Override the stub for this test to emit different
     // text on successive accepts — this is the only way to prove the sentinel
@@ -434,11 +434,47 @@ describe('ApplicationQuestionsModal — Rewrite with AI', () => {
 
     // revertAnswer must NOT have been called — B superseded A.
     expect(revertAnswer).not.toHaveBeenCalled();
-    // Error toast is still shown for A's failure.
+    // Nor should the error toast fire — B is the current, already-saved
+    // answer; surfacing "save failed" for A's superseded rejection would be a
+    // stale, misleading toast for text the user no longer sees.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0)); // flush the reject→catch microtask chain
+    });
+    expect(mockNotifyError).not.toHaveBeenCalled();
+  });
+
+  it('still-current save failure DOES toast even with a stale pendingRewriteRef entry from an earlier accept', async () => {
+    // First accept succeeds and is cleared from pendingRewriteRef (fix 2); a
+    // second, still-current accept then fails and must still surface a toast.
+    const updateAnswer = vi
+      .fn<(id: string, text: string) => Promise<void>>()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('IPC save failed'));
+    const revertAnswer = vi.fn<(id: string, prev: string) => void>();
+    render(<ApplicationQuestionsModal {...buildProps({ updateAnswer, revertAnswer })} />);
+
+    // First accept — succeeds, clearing the sentinel.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'autopilot.apply.questions.rewriteAriaLabel' })
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('popover-accept'));
+    });
+    expect(mockNotifyError).not.toHaveBeenCalled();
+
+    // Second accept — this save fails and is still the current one.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'autopilot.apply.questions.rewriteAriaLabel' })
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('popover-accept'));
+    });
+
     await waitFor(() => {
       expect(mockNotifyError).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'autopilot.apply.questions.rewriteSaveError' })
       );
     });
+    expect(revertAnswer).toHaveBeenCalledWith(QUESTION_ID, ANSWER_TEXT);
   });
 });

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.tsx
@@ -154,10 +154,21 @@ export function ApplicationQuestionsModal({
     const next = snapshot.slice(0, start) + replacement + snapshot.slice(end);
     setFrozen(null);
     pendingRewriteRef.current[id] = next; // synchronous — latest-wins sentinel
-    updateAnswer(id, next).catch(() => {
-      if (pendingRewriteRef.current[id] === next) revertAnswer(id, prev);
-      notify.error({ message: t('autopilot.apply.questions.rewriteSaveError') });
-    });
+    updateAnswer(id, next)
+      .then(() => {
+        // Still current — clear the sentinel so it doesn't linger forever.
+        if (pendingRewriteRef.current[id] === next) delete pendingRewriteRef.current[id];
+      })
+      .catch(() => {
+        // Only revert/toast if this save is still the current one — a
+        // superseded rewrite (a later accept already overwrote the sentinel)
+        // failing shouldn't surface a stale "save failed" toast or clobber
+        // the newer, already-displayed answer.
+        if (pendingRewriteRef.current[id] === next) {
+          revertAnswer(id, prev);
+          notify.error({ message: t('autopilot.apply.questions.rewriteSaveError') });
+        }
+      });
   };
 
   // Shared answer + Copy + Rewrite block — reused by predefined and custom rows.

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/ApplicationQuestionsModal.tsx
@@ -6,10 +6,43 @@ import { APPLICATION_QUESTIONS } from '@ajh/prompts/generate';
 import { useTranslation } from '@ajh/translations';
 import { Button, Input, ModalShell, useNotification } from '@ajh/ui';
 
-import { RewritePopover } from '@/components/generation/EditableOutput/RewritePopover';
+import {
+  RewritePopover,
+  type RewriteTarget,
+} from '@/components/generation/EditableOutput/RewritePopover';
 import { COPY_FEEDBACK_MS } from '@/lib/timings';
 
 import { MAX_CUSTOM_QUESTION_LEN } from './useApplicationAnswers';
+
+/** Selection offsets relative to `container`'s text, or null when nothing inside
+ *  it is selected. Mirrors the textarea-offset capture in EditableOutput's
+ *  `openSourceRewrite`, but for a plain (non-input) selectable element. */
+function getSelectionOffsets(container: HTMLElement): { start: number; end: number } | null {
+  const sel = window.getSelection();
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null;
+  const range = sel.getRangeAt(0);
+  if (!container.contains(range.commonAncestorContainer)) return null;
+  const pre = document.createRange();
+  pre.selectNodeContents(container);
+  pre.setEnd(range.startContainer, range.startOffset);
+  const start = pre.toString().length;
+  return { start, end: start + range.toString().length };
+}
+
+/** A rewrite frozen at trigger time — the splice range + snapshot answer it
+ *  should be spliced back into on Accept (mirrors EditableOutput's FrozenRange). */
+interface FrozenAnswer {
+  id: string;
+  start: number;
+  end: number;
+  /** The answer string at freeze time — accept splices against this, not the
+   *  live `answers[id]`, so a stray write in-between can't shift the offsets. */
+  snapshot: string;
+  target: RewriteTarget;
+  /** The Rewrite button that opened this popover — anchors the portaled popover
+   *  and reclaims focus when it closes. */
+  anchorEl: HTMLElement;
+}
 
 interface Props {
   selected: Set<string>;
@@ -61,8 +94,10 @@ export function ApplicationQuestionsModal({
   const notify = useNotification();
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [draft, setDraft] = useState('');
-  // Which answer id currently has the rewrite popover open (one at a time).
-  const [rewritingId, setRewritingId] = useState<string | null>(null);
+  // The frozen rewrite (one at a time) — null when no popover is open.
+  const [frozen, setFrozen] = useState<FrozenAnswer | null>(null);
+  // Answer <p> elements keyed by question id — read to compute selection offsets.
+  const answerRefs = useRef<Record<string, HTMLParagraphElement | null>>({});
   // Tracks the latest optimistically-written value per answer id. Set
   // SYNCHRONOUSLY in acceptRewrite (before the async save) so the .catch
   // guard never races against a React render cycle.
@@ -80,19 +115,47 @@ export function ApplicationQuestionsModal({
     setDraft('');
   };
 
-  const openRewrite = (id: string) => setRewritingId(id);
-  const closeRewrite = () => setRewritingId(null);
+  // Capture the live selection inside the answer's <p> (if any) and freeze it —
+  // splice range + surrounding context — so the rewrite targets just the
+  // selected span. Falls back to the whole answer when nothing is selected.
+  const openRewrite = (id: string, trigger: HTMLElement) => {
+    const answer = answers[id] ?? '';
+    const container = answerRefs.current[id];
+    const offsets = container ? getSelectionOffsets(container) : null;
+    const start = offsets?.start ?? 0;
+    const end = offsets?.end ?? answer.length;
+    setFrozen({
+      id,
+      start,
+      end,
+      snapshot: answer,
+      anchorEl: trigger,
+      target: {
+        selection: answer.slice(start, end),
+        before: answer.slice(0, start),
+        after: answer.slice(end),
+      },
+    });
+  };
+  const closeRewrite = () => {
+    const trigger = frozen?.anchorEl;
+    setFrozen(null);
+    trigger?.focus();
+  };
   // Close the popover immediately (never leave the user stuck), then fire the
   // persist. On failure: only revert if the answer hasn't been superseded by
   // a second rewrite that was accepted while this save was in-flight.
   // pendingRewriteRef is set SYNCHRONOUSLY here, so the guard is safe even if
   // the rejection arrives before React flushes the optimistic re-render.
-  const acceptRewrite = (id: string, text: string) => {
+  const acceptRewrite = (replacement: string) => {
+    if (!frozen) return;
+    const { id, start, end, snapshot } = frozen;
     const prev = answers[id] ?? '';
-    setRewritingId(null);
-    pendingRewriteRef.current[id] = text; // synchronous — latest-wins sentinel
-    updateAnswer(id, text).catch(() => {
-      if (pendingRewriteRef.current[id] === text) revertAnswer(id, prev);
+    const next = snapshot.slice(0, start) + replacement + snapshot.slice(end);
+    setFrozen(null);
+    pendingRewriteRef.current[id] = next; // synchronous — latest-wins sentinel
+    updateAnswer(id, next).catch(() => {
+      if (pendingRewriteRef.current[id] === next) revertAnswer(id, prev);
       notify.error({ message: t('autopilot.apply.questions.rewriteSaveError') });
     });
   };
@@ -101,7 +164,12 @@ export function ApplicationQuestionsModal({
   const answerBlock = (id: string, answer: string) => (
     <div className="px-2 pb-2 pl-7">
       <div className="relative rounded-md border border-[var(--border-clear)] bg-card px-2.5 py-2">
-        <p className="whitespace-pre-wrap text-[11px] leading-relaxed text-foreground/70">
+        <p
+          ref={(el) => {
+            answerRefs.current[id] = el;
+          }}
+          className="select-text whitespace-pre-wrap text-[11px] leading-relaxed text-foreground/70"
+        >
           {answer}
         </p>
         {/* Action row — Rewrite (primary affordance with label) + Copy */}
@@ -109,7 +177,10 @@ export function ApplicationQuestionsModal({
           <Button
             variant="ghost"
             type="button"
-            onClick={() => openRewrite(id)}
+            // Keep the live text selection alive through the click — a bare click
+            // would let the browser collapse it before onClick reads it.
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => openRewrite(id, e.currentTarget)}
             title={t('autopilot.apply.questions.rewrite')}
             aria-label={t('autopilot.apply.questions.rewriteAriaLabel')}
             className="h-auto gap-1 px-1.5 py-0.5 text-[11px] text-brand-soft"
@@ -129,19 +200,21 @@ export function ApplicationQuestionsModal({
           </Button>
         </div>
 
-        {/* Rewrite popover — rendered inline, anchored below the answer card */}
+        {/* Rewrite popover — portals to document.body and fixed-anchors off the
+            trigger (see RewritePopover's `anchorEl`), so it escapes this card's
+            clipping ancestors (ModalShell's overflow-hidden panel / overflow-y-auto
+            body) instead of rendering — and clipping — inline. */}
         <AnimatePresence>
-          {rewritingId === id && (
-            <div className="absolute right-0 top-full z-[700] mt-1">
-              <RewritePopover
-                target={{ selection: answer, before: '', after: '' }}
-                docType="application-answer"
-                model={model}
-                locale={locale}
-                onAccept={(text) => void acceptRewrite(id, text)}
-                onClose={closeRewrite}
-              />
-            </div>
+          {frozen?.id === id && (
+            <RewritePopover
+              target={frozen.target}
+              docType="application-answer"
+              model={model}
+              locale={locale}
+              anchorEl={frozen.anchorEl}
+              onAccept={acceptRewrite}
+              onClose={closeRewrite}
+            />
           )}
         </AnimatePresence>
       </div>

--- a/apps/desktop/src/renderer/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/OnboardingWizard/index.test.tsx
@@ -408,6 +408,99 @@ describe('OnboardingWizard — navigation', () => {
   });
 });
 
+describe('OnboardingWizard — sidebar force-open on tour start', () => {
+  it('sets sidebarCollapsed to false only once the last step submits into the tour', async () => {
+    usePreferencesStore.setState({
+      aiProviderConfig: { activeProvider: 'openai', providers: {} },
+      sidebarCollapsed: true,
+    });
+    const user = userEvent.setup();
+    renderWizard();
+
+    // 7-step sequence (openai): welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4) → extension(5) → appearance(6)
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+
+    // Still on a regular step — sidebar must be untouched.
+    expect(usePreferencesStore.getState().sidebarCollapsed).toBe(true);
+
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAppearance));
+
+    // Tour now visible and the sidebar has been forced open so its
+    // [data-tour-id] anchors exist for SpotlightTour to measure.
+    expect(screen.getByTestId(TEST_IDS.onboarding.tour)).toBeInTheDocument();
+    expect(usePreferencesStore.getState().sidebarCollapsed).toBe(false);
+  });
+
+  it('leaves sidebarCollapsed untouched while navigating earlier steps', async () => {
+    usePreferencesStore.setState({ sidebarCollapsed: true });
+    const user = userEvent.setup();
+    renderWizard();
+
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+
+    expect(usePreferencesStore.getState().sidebarCollapsed).toBe(true);
+  });
+
+  it('restores sidebarCollapsed to true once the tour finishes (was collapsed before onboarding)', async () => {
+    usePreferencesStore.setState({
+      aiProviderConfig: { activeProvider: 'openai', providers: {} },
+      sidebarCollapsed: true,
+    });
+    const user = userEvent.setup();
+    renderWizard();
+
+    // 7-step sequence (openai): welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4) → extension(5) → appearance(6)
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAppearance));
+
+    // Tour forced the sidebar open (see the test above).
+    expect(screen.getByTestId(TEST_IDS.onboarding.tour)).toBeInTheDocument();
+    expect(usePreferencesStore.getState().sidebarCollapsed).toBe(false);
+
+    // Finishing (or skipping) the tour must restore the user's original
+    // collapsed preference instead of leaving it silently forced open.
+    await user.click(screen.getByRole('button', { name: 'finish-tour' }));
+
+    expect(usePreferencesStore.getState().sidebarCollapsed).toBe(true);
+  });
+
+  it('leaves sidebarCollapsed false after the tour finishes for a first-run user (no-op restore)', async () => {
+    usePreferencesStore.setState({
+      aiProviderConfig: { activeProvider: 'openai', providers: {} },
+      sidebarCollapsed: false,
+    });
+    const user = userEvent.setup();
+    renderWizard();
+
+    // 7-step sequence (openai): welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4) → extension(5) → appearance(6)
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAppearance));
+
+    expect(screen.getByTestId(TEST_IDS.onboarding.tour)).toBeInTheDocument();
+    expect(usePreferencesStore.getState().sidebarCollapsed).toBe(false);
+
+    await user.click(screen.getByRole('button', { name: 'finish-tour' }));
+
+    // Default (never collapsed) — restoring is a no-op, stays false.
+    expect(usePreferencesStore.getState().sidebarCollapsed).toBe(false);
+  });
+});
+
 describe('OnboardingWizard — goBack floor', () => {
   it('does not crash when goBack is called at stepIndex 0', async () => {
     const user = userEvent.setup();

--- a/apps/desktop/src/renderer/features/onboarding/OnboardingWizard/index.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/OnboardingWizard/index.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { transition } from '@ajh/ui';
 
@@ -11,10 +11,14 @@ import { ONBOARDING_STEPS } from '../steps-config';
 export function OnboardingWizard() {
   const onboardingCompleted = useOnboardingCompleted();
   const setOnboardingComplete = usePreferencesStore((s) => s.setOnboardingComplete);
+  const setSidebarCollapsed = usePreferencesStore((s) => s.setSidebarCollapsed);
   const activeProvider = usePreferencesStore((s) => s.aiProviderConfig?.activeProvider);
   const [stepIndex, setStepIndex] = useState(0);
   const [direction, setDirection] = useState(1);
   const [showTour, setShowTour] = useState(false);
+  // Snapshot the user's sidebar preference from right before the tour forces
+  // it open, so it can be restored on finish instead of silently overwritten.
+  const sidebarWasCollapsedRef = useRef(false);
 
   // Research is only relevant for local Ollama (other providers search with
   // their own key). `extension`/`appearance` are unconditional.
@@ -41,8 +45,21 @@ export function OnboardingWizard() {
       setStepIndex((prev) => prev + 1);
     } else {
       setDirection(1);
+      // The tour spotlights sidebar nav items — a collapsed sidebar unmounts
+      // them, so force it open before the tour measures its anchors. Snapshot
+      // the prior value first so it can be restored once the tour ends.
+      sidebarWasCollapsedRef.current = usePreferencesStore.getState().sidebarCollapsed ?? false;
+      setSidebarCollapsed(false);
       setShowTour(true);
     }
+  };
+
+  // Restore the user's original sidebar preference (if it was collapsed) once
+  // the tour ends, then mark onboarding complete — runs on both "finish" and
+  // "skip" since SpotlightTour's onFinish covers both.
+  const finishTour = () => {
+    if (sidebarWasCollapsedRef.current) setSidebarCollapsed(true);
+    setOnboardingComplete();
   };
 
   const goBack = () => {
@@ -85,7 +102,7 @@ export function OnboardingWizard() {
             onBack={goBack}
           />
         )}
-        {showTour && <SpotlightTour key="tour" onFinish={setOnboardingComplete} />}
+        {showTour && <SpotlightTour key="tour" onFinish={finishTour} />}
       </AnimatePresence>
     </div>
   );

--- a/apps/desktop/src/renderer/features/onboarding/SpotlightTour/index.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/SpotlightTour/index.tsx
@@ -94,17 +94,37 @@ export function SpotlightTour({ onFinish }: Props) {
   const current = TOUR_ITEMS[stepIdx] as TourItem;
   const isLast = stepIdx === TOUR_ITEMS.length - 1;
 
-  const measureTarget = useCallback((id: string) => {
-    const el = document.querySelector(`[data-tour-id="${id}"]`);
-    if (el) {
+  // The sidebar is forced open right before the tour starts, so its anchors
+  // mount and animate width 0 -> auto in the same commit. A single measure
+  // can land mid-animation (zero/partial rect that's never re-checked), so
+  // retry until the anchor has a real size, then keep tracking it via
+  // ResizeObserver until the expand animation settles.
+  useLayoutEffect(() => {
+    let rafId: number | undefined;
+    let observer: ResizeObserver | undefined;
+
+    const update = (el: Element) => {
       const r = el.getBoundingClientRect();
       setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
-    }
-  }, []);
+    };
 
-  useLayoutEffect(() => {
-    measureTarget(current.tourId);
-  }, [current.tourId, measureTarget]);
+    const tryMeasure = () => {
+      const el = document.querySelector(`[data-tour-id="${current.tourId}"]`);
+      if (el && el.getBoundingClientRect().width > 0) {
+        update(el);
+        observer = new ResizeObserver(() => update(el));
+        observer.observe(el);
+      } else {
+        rafId = requestAnimationFrame(tryMeasure);
+      }
+    };
+    tryMeasure();
+
+    return () => {
+      if (rafId !== undefined) cancelAnimationFrame(rafId);
+      observer?.disconnect();
+    };
+  }, [current.tourId]);
 
   const next = useCallback(() => {
     if (isLast) {

--- a/apps/desktop/src/renderer/features/onboarding/SpotlightTour/index.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/SpotlightTour/index.tsx
@@ -86,6 +86,10 @@ interface Props {
   onFinish: () => void;
 }
 
+// Cap the rAF measure-retry below so a renamed/removed `data-tour-id` anchor
+// fails loud+cheap instead of busy-looping for the tour's lifetime.
+const MAX_MEASURE_ATTEMPTS = 60; // ~1s at 60fps — the anchor mounts well before this
+
 export function SpotlightTour({ onFinish }: Props) {
   const { t } = useTranslation();
   const [stepIdx, setStepIdx] = useState(0);
@@ -102,6 +106,7 @@ export function SpotlightTour({ onFinish }: Props) {
   useLayoutEffect(() => {
     let rafId: number | undefined;
     let observer: ResizeObserver | undefined;
+    let attempts = 0;
 
     const update = (el: Element) => {
       const r = el.getBoundingClientRect();
@@ -114,8 +119,14 @@ export function SpotlightTour({ onFinish }: Props) {
         update(el);
         observer = new ResizeObserver(() => update(el));
         observer.observe(el);
-      } else {
+      } else if (attempts < MAX_MEASURE_ATTEMPTS) {
+        attempts += 1;
         rafId = requestAnimationFrame(tryMeasure);
+      } else {
+        console.warn(
+          `SpotlightTour: anchor [data-tour-id="${current.tourId}"] never measured a real size — stopping retries`
+        );
+        if (el) update(el); // best-effort — likely zero-size, still better than the last step's rect
       }
     };
     tryMeasure();


### PR DESCRIPTION
## What

Three user-reported renderer bugs (bugs #1, #5, #6 of the batch).

**1 — Feature tour breaks when the sidebar is collapsed.** A collapsed sidebar is *unmounted*, so the tour's `[data-tour-id]` anchors don't exist and the spotlight measures null (broken tour after "Replay wizard"). `OnboardingWizard` now forces the sidebar open before the tour starts **and restores the user's prior collapsed preference** when the tour finishes/skips; `SpotlightTour` re-measures the anchor via `requestAnimationFrame` + `ResizeObserver` so the spotlight lands correctly after the sidebar's `width 0→auto` expand settles.

**2 — Can't select part of a generated answer.** The global `body{user-select:none}` allowlist excluded the answer `<p>`; it now carries `select-text`. "Rewrite" captures the real DOM substring selection (`{selection, before, after}`) and splices the result back at the selected offsets (mirrors `EditableOutput`), falling back to the whole answer when nothing is selected.

**3 — "Rewrite selection" popover renders clipped under the modal.** It was inline inside the modal's `overflow-hidden` panel + transformed stacking context. It now portals to `document.body` (`position: fixed`, anchored off the trigger rect, `z-toast`=700 above the modal's 650), measures its own height, and **flips upward when it wouldn't fit below** (clamped to the viewport) so its Cancel/Accept never render off-screen.

## Review

Orchestrated via a workflow (two parallel authors → frontend-reviewer + ui-ux-expert). ui-ux caught a **HIGH** — the portaled popover had no vertical flip, so on a question near the viewport bottom its actions rendered permanently off-screen — now fixed (measured-height flip-above) and re-verified by ui-ux. A **MEDIUM** (sidebar preference not restored after the tour) was also fixed. One remaining advisory — an unanimated mid-stream re-flip if a streaming result grows the panel past the fits-below threshold — is deferred as non-blocking polish. typecheck + eslint clean; **59 tests** across the 5 affected suites pass.

## Verify

Collapse the sidebar → Settings → Replay wizard → the tour runs with the sidebar expanded and correctly anchored, then the sidebar returns to collapsed. Highlight a substring of a generated answer and rewrite just it. Open Rewrite on a question near the bottom of the list — the popover flips above and stays fully on-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
