### PR TITLE
fix: ground salary-lookup currency in the job's country

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -253,13 +253,25 @@ pub async fn ai_research_company(
 /// search, the search yields nothing reliable, or times out — so the salary
 /// answer always falls back to grounding in the applicant's own stated
 /// expectation alone. Only validated integers + a sanitized currency code are
-/// ever returned; raw web text never crosses this boundary.
+/// ever returned; raw web text never crosses this boundary. `country`/
+/// `currency` (resolved client-side from the job's validated ISO country)
+/// ground the reported currency so a blank/weak `location` can't let the
+/// model default to USD or hallucinate a currency — see
+/// `crate::salary_research::SalaryResearch::enrich`.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn ai_lookup_salary(
     app: AppHandle,
     role: String,
     company: Option<String>,
     location: Option<String>,
+    // ISO-3166 alpha-2 job country, when known — grounds `currency` below.
+    country: Option<String>,
+    // Authoritative ISO-4217 currency for `country` (resolved client-side via
+    // `countryToCurrency`); `None` when the country is unknown, which
+    // preserves the unconstrained "local currency for that location"
+    // behavior.
+    currency: Option<String>,
     provider: Option<String>,
     model: Option<String>,
     base_url: Option<String>,
@@ -320,6 +332,8 @@ pub async fn ai_lookup_salary(
             &role,
             company.as_deref().unwrap_or(""),
             location.as_deref().unwrap_or(""),
+            country.as_deref().unwrap_or(""),
+            currency.as_deref().unwrap_or(""),
         )
         .await
 }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/anthropic.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/anthropic.rs
@@ -425,6 +425,7 @@ impl AiProvider for AnthropicClient {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn research_salary(
         &self,
         app: &AppHandle,
@@ -432,12 +433,14 @@ impl AiProvider for AnthropicClient {
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> AppResult<String> {
         self.web_search_complete(
             app,
             model,
-            research::SALARY_SYSTEM,
-            &research::salary_user(role, company, location),
+            &research::salary_system(currency),
+            &research::salary_user(role, company, location, country, currency),
         )
         .await
     }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
@@ -247,6 +247,7 @@ impl AiProvider for CliAgentClient {
         .unwrap_or_default())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn research_salary(
         &self,
         app: &AppHandle,
@@ -254,16 +255,18 @@ impl AiProvider for CliAgentClient {
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> AppResult<String> {
         // Same best-effort contract as `research`: the agent's own web tools
         // search, `run_complete` degrades any failure to "" so generation
         // always proceeds.
-        let user = research::salary_user(role, company, location);
+        let user = research::salary_user(role, company, location, country, currency);
         Ok(run_complete(
             app,
             self.backend.as_ref(),
             model,
-            research::SALARY_SYSTEM,
+            &research::salary_system(currency),
             &user,
         )
         .await

--- a/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
@@ -482,6 +482,7 @@ impl AiProvider for GeminiClient {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn research_salary(
         &self,
         app: &AppHandle,
@@ -489,12 +490,14 @@ impl AiProvider for GeminiClient {
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> AppResult<String> {
         self.web_search_complete(
             app,
             model,
-            research::SALARY_SYSTEM,
-            &research::salary_user(role, company, location),
+            &research::salary_system(currency),
+            &research::salary_user(role, company, location, country, currency),
         )
         .await
     }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
@@ -351,6 +351,12 @@ pub trait AiProvider: Send + Sync {
     /// strictly validates it before anything reaches a prompt, so raw web text
     /// never does. Returns `""` (never an error) when the provider can't search
     /// or isn't configured — exactly like `research`. Default: no research.
+    ///
+    /// `country`/`currency` ground the report in the job's actual currency
+    /// (resolved client-side from its validated ISO country) — both empty when
+    /// the country is unknown, which preserves the unconstrained "local
+    /// currency for that location" behavior.
+    #[allow(clippy::too_many_arguments)]
     async fn research_salary(
         &self,
         _app: &AppHandle,
@@ -358,6 +364,8 @@ pub trait AiProvider: Send + Sync {
         _role: &str,
         _company: &str,
         _location: &str,
+        _country: &str,
+        _currency: &str,
     ) -> AppResult<String> {
         Ok(String::new())
     }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
@@ -540,7 +540,7 @@ pub async fn ollama_research_salary(
     country: &str,
     currency: &str,
 ) -> AppResult<String> {
-    let query = research::salary_search_query(role, company, location, country);
+    let query = research::salary_search_query(role, company, location, country, currency);
     let results = ollama_search(app, model, &query).await;
     if results.is_empty() {
         return Ok(String::new());

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
@@ -207,6 +207,7 @@ impl AiProvider for OllamaClient {
         ollama_research(app, self, model, company, role).await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn research_salary(
         &self,
         app: &AppHandle,
@@ -214,8 +215,10 @@ impl AiProvider for OllamaClient {
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> AppResult<String> {
-        ollama_research_salary(app, self, model, role, company, location).await
+        ollama_research_salary(app, self, model, role, company, location, country, currency).await
     }
 
     async fn embed(&self, _app: &AppHandle, model: &str, text: &str) -> AppResult<Vec<f64>> {
@@ -522,8 +525,11 @@ pub async fn ollama_research(
 
 /// Salary-range sibling of [`ollama_research`]: same search-then-synthesize
 /// shape, but the salary query/prompts (compact JSON contract, see
-/// `research::SALARY_SYSTEM`). Returns `""` when the key is missing or the
-/// search yields nothing, so the lookup degrades gracefully.
+/// `research::salary_system`). Returns `""` when the key is missing or the
+/// search yields nothing, so the lookup degrades gracefully. `country`/
+/// `currency` ground the report in the job's actual currency — see
+/// `AiProvider::research_salary`.
+#[allow(clippy::too_many_arguments)]
 pub async fn ollama_research_salary(
     app: &AppHandle,
     provider: &dyn AiProvider,
@@ -531,15 +537,23 @@ pub async fn ollama_research_salary(
     role: &str,
     company: &str,
     location: &str,
+    country: &str,
+    currency: &str,
 ) -> AppResult<String> {
-    let query = research::salary_search_query(role, company, location);
+    let query = research::salary_search_query(role, company, location, country);
     let results = ollama_search(app, model, &query).await;
     if results.is_empty() {
         return Ok(String::new());
     }
-    let user = research::salary_synth_user(role, company, location, &results);
+    let user = research::salary_synth_user(role, company, location, country, currency, &results);
     provider
-        .complete(app, model, research::SALARY_SYSTEM, &user, Some(0.2))
+        .complete(
+            app,
+            model,
+            &research::salary_system(currency),
+            &user,
+            Some(0.2),
+        )
         .await
 }
 

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama_cloud.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama_cloud.rs
@@ -81,6 +81,7 @@ impl AiProvider for OllamaCloudClient {
         super::ollama::ollama_research(app, &self.inner, model, company, role).await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn research_salary(
         &self,
         app: &AppHandle,
@@ -88,9 +89,20 @@ impl AiProvider for OllamaCloudClient {
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> AppResult<String> {
-        super::ollama::ollama_research_salary(app, &self.inner, model, role, company, location)
-            .await
+        super::ollama::ollama_research_salary(
+            app,
+            &self.inner,
+            model,
+            role,
+            company,
+            location,
+            country,
+            currency,
+        )
+        .await
     }
 
     async fn embed(&self, app: &AppHandle, model: &str, text: &str) -> AppResult<Vec<f64>> {

--- a/apps/desktop/src-tauri/src/commands/ai_provider/openai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/openai.rs
@@ -475,6 +475,7 @@ impl AiProvider for OpenAiClient {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn research_salary(
         &self,
         app: &AppHandle,
@@ -482,12 +483,14 @@ impl AiProvider for OpenAiClient {
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> AppResult<String> {
         self.web_search_complete(
             app,
             model,
-            research::SALARY_SYSTEM,
-            &research::salary_user(role, company, location),
+            &research::salary_system(currency),
+            &research::salary_user(role, company, location, country, currency),
         )
         .await
     }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/research.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/research.rs
@@ -89,18 +89,36 @@ fn role_or_default(role: &str) -> &str {
 // model's own words never survive past that JSON boundary).
 
 /// System prompt for the salary-range **native** path: the model searches the
-/// web itself and must reply with JSON only — no prose to parse out.
-pub const SALARY_SYSTEM: &str = "You are a compensation research assistant with web search. \
-Search the web for the typical ANNUAL gross salary range for the specified role — at the \
-specified company when reliable company-specific data exists, otherwise for the broader market \
-in the specified location. Respond with ONLY a compact JSON object in the exact form \
-{\"min\":<integer>,\"max\":<integer>,\"currency\":\"<ISO-4217 code>\"}, using the local currency \
-for that location. If you cannot find reliable data, respond with {}. No prose, no markdown, no \
-code fences, no commentary — JSON only.";
+/// web itself and must reply with JSON only — no prose to parse out. Pins the
+/// report currency when the caller knows one (resolved client-side from the
+/// job's validated ISO country via `countryToCurrency`) — the primary defense
+/// against the model defaulting to USD/hallucinating a currency on a
+/// blank/weak location. Falls back to the original unconstrained "local
+/// currency for that location" wording when `currency` is empty (unknown
+/// country — today's behavior, unchanged).
+pub fn salary_system(currency: &str) -> String {
+    let currency_phrase = currency_phrase(currency);
+    format!(
+        "You are a compensation research assistant with web search. \
+         Search the web for the typical ANNUAL gross salary range for the specified role — at \
+         the specified company when reliable company-specific data exists, otherwise for the \
+         broader market in the specified location. Respond with ONLY a compact JSON object in \
+         the exact form {{\"min\":<integer>,\"max\":<integer>,\"currency\":\"<ISO-4217 code>\"}}, \
+         using {currency_phrase}. If you cannot find reliable data, respond with {{}}. No \
+         prose, no markdown, no code fences, no commentary — JSON only."
+    )
+}
 
 /// User prompt for the salary-range **native** path (the provider's model
-/// searches + writes the JSON itself).
-pub fn salary_user(role: &str, company: &str, location: &str) -> String {
+/// searches + writes the JSON itself). Appends an authoritative currency-pin
+/// clause when `currency` is known — see [`salary_system`].
+pub fn salary_user(
+    role: &str,
+    company: &str,
+    location: &str,
+    country: &str,
+    currency: &str,
+) -> String {
     let role = role_or_default(role);
     let mut where_clause = String::new();
     if !company.trim().is_empty() {
@@ -109,14 +127,18 @@ pub fn salary_user(role: &str, company: &str, location: &str) -> String {
     if !location.trim().is_empty() {
         where_clause.push_str(&format!(" in {}", location.trim()));
     }
+    let currency_clause = currency_pin_clause(country, currency);
     format!(
-        "Search the web for the typical annual gross salary range for a {role}{where_clause}. \
-         Respond with ONLY the JSON object described in your instructions — no prose."
+        "Search the web for the typical annual gross salary range for a {role}{where_clause}.\
+         {currency_clause} Respond with ONLY the JSON object described in your instructions — no prose."
     )
 }
 
-/// The web-search query for the salary explicit-query path (Ollama).
-pub fn salary_search_query(role: &str, company: &str, location: &str) -> String {
+/// The web-search query for the salary explicit-query path (Ollama). Includes
+/// `country` (when known) alongside `location` — a geo-targeting hint, since
+/// `location` can be vague ("Remote") while the job's country is still
+/// resolved.
+pub fn salary_search_query(role: &str, company: &str, location: &str, country: &str) -> String {
     let role = role_or_default(role);
     let mut q = format!("{role} salary range annual");
     if !company.trim().is_empty() {
@@ -125,15 +147,21 @@ pub fn salary_search_query(role: &str, company: &str, location: &str) -> String 
     if !location.trim().is_empty() {
         q.push_str(&format!(" {}", location.trim()));
     }
+    if !country.trim().is_empty() {
+        q.push_str(&format!(" {}", country.trim()));
+    }
     q
 }
 
 /// User prompt for the salary-range **synthesize** path (Ollama): turn search
-/// snippets into the same compact JSON contract as [`salary_user`].
+/// snippets into the same compact JSON contract as [`salary_user`]. Pins the
+/// currency the same way [`salary_system`] does.
 pub fn salary_synth_user(
     role: &str,
     company: &str,
     location: &str,
+    country: &str,
+    currency: &str,
     results: &[SearchResult],
 ) -> String {
     let role = role_or_default(role);
@@ -147,6 +175,12 @@ pub fn salary_synth_user(
     } else {
         location.trim()
     };
+    let country_line = if country.trim().is_empty() {
+        String::new()
+    } else {
+        format!("\nCountry: {}", country.trim())
+    };
+    let currency_phrase = currency_phrase(currency);
     let snippets = results
         .iter()
         .enumerate()
@@ -154,13 +188,47 @@ pub fn salary_synth_user(
         .collect::<Vec<_>>()
         .join("\n");
     format!(
-        "Role: {role}\nCompany: {company}\nLocation: {location}\n\n\
+        "Role: {role}\nCompany: {company}\nLocation: {location}{country_line}\n\n\
          Search result snippets:\n{snippets}\n\n\
-         From these snippets, estimate the typical ANNUAL gross salary range in the local \
-         currency for that location. Respond with ONLY a compact JSON object in the exact form \
+         From these snippets, estimate the typical ANNUAL gross salary range in {currency_phrase}. \
+         Respond with ONLY a compact JSON object in the exact form \
          {{\"min\":<integer>,\"max\":<integer>,\"currency\":\"<ISO-4217 code>\"}}. If the \
          snippets don't support a reliable estimate, respond with {{}}. No prose."
     )
+}
+
+/// Shared currency wording for [`salary_system`] and [`salary_synth_user`]:
+/// "the local currency for that location" (today's unconstrained default) or
+/// an authoritative pin naming the confirmed currency. Pure + unit-tested.
+fn currency_phrase(currency: &str) -> String {
+    let currency = currency.trim();
+    if currency.is_empty() {
+        "the local currency for that location".to_string()
+    } else {
+        format!(
+            "{currency} — the confirmed currency for this role's location; do not report any \
+             other currency"
+        )
+    }
+}
+
+/// Authoritative currency-pinning sentence appended to [`salary_user`] — empty
+/// (no-op) when `currency` is unknown, so a job with no resolvable country
+/// gets today's unconstrained prompt. Pure + unit-tested.
+fn currency_pin_clause(country: &str, currency: &str) -> String {
+    let currency = currency.trim();
+    if currency.is_empty() {
+        return String::new();
+    }
+    let country = country.trim();
+    if country.is_empty() {
+        format!(" Report the salary range in {currency} — do not use any other currency.")
+    } else {
+        format!(
+            " The role is based in {country}; report the salary range in {currency} — do not \
+             use any other currency."
+        )
+    }
 }
 
 #[cfg(test)]
@@ -205,7 +273,7 @@ mod tests {
 
     #[test]
     fn salary_user_names_role_company_and_location_and_demands_json() {
-        let p = salary_user("Backend Engineer", "Acme", "Berlin, Germany");
+        let p = salary_user("Backend Engineer", "Acme", "Berlin, Germany", "", "");
         assert!(p.contains("Backend Engineer"));
         assert!(p.contains("Acme"));
         assert!(p.contains("Berlin, Germany"));
@@ -214,7 +282,7 @@ mod tests {
 
     #[test]
     fn salary_user_omits_company_and_location_clauses_when_blank() {
-        let p = salary_user("Backend Engineer", "  ", "  ");
+        let p = salary_user("Backend Engineer", "  ", "  ", "", "");
         assert!(!p.contains(" at \""));
         // No where-clause inserted: the role is followed directly by the
         // instruction sentence, not by an " in <location>" clause.
@@ -224,12 +292,35 @@ mod tests {
     }
 
     #[test]
+    fn salary_user_pins_the_currency_when_country_and_currency_are_known() {
+        let p = salary_user("Backend Engineer", "Acme", "", "DE", "EUR");
+        assert!(p.contains("The role is based in DE"));
+        assert!(p.contains("report the salary range in EUR"));
+        assert!(p.contains("do not use any other currency"));
+    }
+
+    #[test]
+    fn salary_user_currency_clause_is_empty_when_currency_is_unknown() {
+        // Unknown-country guard: no clause at all, not even a bare country
+        // mention — today's unconstrained behavior.
+        let p = salary_user("Backend Engineer", "Acme", "", "", "");
+        assert!(!p.contains("report the salary range in"));
+        assert!(!p.contains("based in"));
+    }
+
+    #[test]
     fn salary_search_query_includes_role_company_and_location() {
-        let q = salary_search_query("Backend Engineer", "Acme", "Berlin");
+        let q = salary_search_query("Backend Engineer", "Acme", "Berlin", "");
         assert!(q.contains("Backend Engineer"));
         assert!(q.contains("Acme"));
         assert!(q.contains("Berlin"));
         assert!(q.to_lowercase().contains("salary"));
+    }
+
+    #[test]
+    fn salary_search_query_includes_country_when_known() {
+        let q = salary_search_query("Backend Engineer", "", "Remote", "DE");
+        assert!(q.contains("DE"));
     }
 
     #[test]
@@ -239,10 +330,41 @@ mod tests {
             snippet: "Backend Engineer $120k-$150k".into(),
             url: "https://example.com".into(),
         }];
-        let p = salary_synth_user("Backend Engineer", "  ", "  ", &results);
+        let p = salary_synth_user("Backend Engineer", "  ", "  ", "", "", &results);
         assert!(p.contains("[1] Levels.fyi — Backend Engineer $120k-$150k"));
         assert!(p.contains("Company: unspecified"));
         assert!(p.contains("Location: unspecified"));
         assert!(p.to_lowercase().contains("json"));
+        // Unknown-country guard preserves the original unconstrained wording.
+        assert!(p.contains("in the local currency for that location"));
+    }
+
+    #[test]
+    fn salary_synth_user_pins_the_currency_and_notes_the_country_when_known() {
+        let results = vec![SearchResult {
+            title: "Levels.fyi".into(),
+            snippet: "Backend Engineer €65k-€80k".into(),
+            url: "https://example.com".into(),
+        }];
+        let p = salary_synth_user("Backend Engineer", "Acme", "Berlin", "DE", "EUR", &results);
+        assert!(p.contains("Country: DE"));
+        assert!(p.contains("in EUR"));
+        assert!(p.contains("do not report any other currency"));
+        assert!(!p.contains("in the local currency for that location"));
+    }
+
+    #[test]
+    fn salary_system_states_the_json_contract_using_the_local_currency_by_default() {
+        let s = salary_system("");
+        assert!(s.to_lowercase().contains("json"));
+        assert!(s.contains("using the local currency for that location"));
+    }
+
+    #[test]
+    fn salary_system_pins_the_currency_when_known() {
+        let s = salary_system("EUR");
+        assert!(s.contains("EUR"));
+        assert!(s.contains("do not report any other currency"));
+        assert!(!s.contains("using the local currency for that location"));
     }
 }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/research.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/research.rs
@@ -135,10 +135,19 @@ pub fn salary_user(
 }
 
 /// The web-search query for the salary explicit-query path (Ollama). Includes
-/// `country` (when known) alongside `location` — a geo-targeting hint, since
-/// `location` can be vague ("Remote") while the job's country is still
-/// resolved.
-pub fn salary_search_query(role: &str, company: &str, location: &str, country: &str) -> String {
+/// `country` alongside `location` — a geo-targeting hint, since `location` can
+/// be vague ("Remote") while the job's country is still resolved — but only
+/// once `currency` is resolved too, mirroring [`currency_pin_clause`]'s
+/// gating on the native path: an unresolved currency means the country
+/// couldn't be trusted enough to pin a currency, so it shouldn't leak into
+/// the query ungated either.
+pub fn salary_search_query(
+    role: &str,
+    company: &str,
+    location: &str,
+    country: &str,
+    currency: &str,
+) -> String {
     let role = role_or_default(role);
     let mut q = format!("{role} salary range annual");
     if !company.trim().is_empty() {
@@ -147,7 +156,7 @@ pub fn salary_search_query(role: &str, company: &str, location: &str, country: &
     if !location.trim().is_empty() {
         q.push_str(&format!(" {}", location.trim()));
     }
-    if !country.trim().is_empty() {
+    if !currency.trim().is_empty() && !country.trim().is_empty() {
         q.push_str(&format!(" {}", country.trim()));
     }
     q
@@ -175,7 +184,11 @@ pub fn salary_synth_user(
     } else {
         location.trim()
     };
-    let country_line = if country.trim().is_empty() {
+    // Gated on a *resolved* currency (mirrors [`currency_pin_clause`]'s native-
+    // path condition), not merely a non-empty `country` — a country the
+    // caller couldn't resolve a currency for shouldn't be interpolated
+    // ungated into the prompt either.
+    let country_line = if currency.trim().is_empty() || country.trim().is_empty() {
         String::new()
     } else {
         format!("\nCountry: {}", country.trim())
@@ -310,7 +323,7 @@ mod tests {
 
     #[test]
     fn salary_search_query_includes_role_company_and_location() {
-        let q = salary_search_query("Backend Engineer", "Acme", "Berlin", "");
+        let q = salary_search_query("Backend Engineer", "Acme", "Berlin", "", "");
         assert!(q.contains("Backend Engineer"));
         assert!(q.contains("Acme"));
         assert!(q.contains("Berlin"));
@@ -318,9 +331,18 @@ mod tests {
     }
 
     #[test]
-    fn salary_search_query_includes_country_when_known() {
-        let q = salary_search_query("Backend Engineer", "", "Remote", "DE");
+    fn salary_search_query_includes_country_when_currency_is_resolved() {
+        let q = salary_search_query("Backend Engineer", "", "Remote", "DE", "EUR");
         assert!(q.contains("DE"));
+    }
+
+    #[test]
+    fn salary_search_query_omits_country_when_currency_is_unresolved() {
+        // Gated on a *resolved* currency (mirrors `currency_pin_clause` on the
+        // native path) — a known country with no resolved currency must not
+        // leak into the search query ungated.
+        let q = salary_search_query("Backend Engineer", "", "Remote", "DE", "");
+        assert!(!q.contains("DE"));
     }
 
     #[test]
@@ -351,6 +373,20 @@ mod tests {
         assert!(p.contains("in EUR"));
         assert!(p.contains("do not report any other currency"));
         assert!(!p.contains("in the local currency for that location"));
+    }
+
+    #[test]
+    fn salary_synth_user_omits_the_country_line_when_the_currency_is_unresolved() {
+        // Gated on a *resolved* currency (mirrors the native path) — a known
+        // country with no resolved currency must not leak into the prompt.
+        let results = vec![SearchResult {
+            title: "Levels.fyi".into(),
+            snippet: "Backend Engineer $120k-$150k".into(),
+            url: "https://example.com".into(),
+        }];
+        let p = salary_synth_user("Backend Engineer", "Acme", "Berlin", "DE", "", &results);
+        assert!(!p.contains("Country: DE"));
+        assert!(p.contains("in the local currency for that location"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/pipeline/mod.rs
+++ b/apps/desktop/src-tauri/src/pipeline/mod.rs
@@ -85,15 +85,26 @@ impl Completer {
     /// provider can't search — see
     /// [`AiProvider::research_salary`](crate::commands::ai_provider::AiProvider::research_salary).
     /// The caller ([`crate::salary_research::SalaryResearch`]) parses + strictly
-    /// validates it before anything reaches a prompt.
+    /// validates it before anything reaches a prompt. `country`/`currency`
+    /// ground the report in the job's actual currency; both empty when unknown.
     pub async fn research_salary(
         &self,
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> AppResult<String> {
         self.provider
-            .research_salary(&self.app, &self.model, role, company, location)
+            .research_salary(
+                &self.app,
+                &self.model,
+                role,
+                company,
+                location,
+                country,
+                currency,
+            )
             .await
     }
 

--- a/apps/desktop/src-tauri/src/salary_research/mod.rs
+++ b/apps/desktop/src-tauri/src/salary_research/mod.rs
@@ -143,11 +143,16 @@ impl SalaryResearch {
 
         // Case-folded so "Berlin"/"berlin" don't miss each other; the
         // case-preserved values above still go to the prompt/query/logging.
-        // Deliberately NOT keyed on country/currency — the reconciliation
-        // below re-checks every read regardless of what was cached, so an
-        // older (possibly wrong-currency) entry self-heals via a fresh fetch
-        // rather than fragmenting the cache.
-        let key = cache_key(&role, &company, &location);
+        // Keyed on `currency` (not the raw `country` string) — two jobs
+        // sharing role/company/location but resolving to different expected
+        // currencies (e.g. a DE and a US "Remote" posting) must never share a
+        // cache row, or an unknown-currency read could surface whatever
+        // currency a different, known-currency job last wrote there. The
+        // `reconcile_expected_currency` self-heal below still re-checks every
+        // read regardless, so a legacy (pre-fix) or otherwise wrong-currency
+        // cached entry self-heals via a fresh fetch rather than fragmenting
+        // the cache further.
+        let key = cache_key(&role, &company, &location, &currency);
 
         // Fast path: cached, validated range younger than the TTL.
         if let Some(cache) = cache {
@@ -239,16 +244,21 @@ fn role_is_missing(role: &str) -> bool {
     role.trim().is_empty()
 }
 
-/// Build the cache key for a (role, company, location) lookup — case-folded so
-/// "Berlin"/"berlin" (or "Acme"/"ACME") land on the same cache entry, cutting
-/// avoidable cache misses (and duplicate paid provider calls) on the only
-/// difference being capitalization. Pure + unit-tested.
-fn cache_key(role: &str, company: &str, location: &str) -> String {
+/// Build the cache key for a (role, company, location, expected currency)
+/// lookup — case-folded so "Berlin"/"berlin" (or "Acme"/"ACME") land on the
+/// same cache entry, cutting avoidable cache misses (and duplicate paid
+/// provider calls) on the only difference being capitalization. `currency` is
+/// part of the key (not just baked into `location`/`country`) so two postings
+/// that share role/company/location but resolve to different expected
+/// currencies — including an unknown-currency ("") job vs. a known-currency
+/// one — never collide on the same cache row. Pure + unit-tested.
+fn cache_key(role: &str, company: &str, location: &str, currency: &str) -> String {
     format!(
-        "{}|{}|{}",
+        "{}|{}|{}|{}",
         role.to_lowercase(),
         company.to_lowercase(),
-        location.to_lowercase()
+        location.to_lowercase(),
+        currency.to_lowercase()
     )
 }
 
@@ -374,17 +384,32 @@ mod tests {
     #[test]
     fn cache_key_case_folds_so_differently_cased_inputs_collide() {
         assert_eq!(
-            cache_key("Backend Engineer", "Acme", "Berlin"),
-            cache_key("backend engineer", "ACME", "berlin")
+            cache_key("Backend Engineer", "Acme", "Berlin", "EUR"),
+            cache_key("backend engineer", "ACME", "berlin", "eur")
         );
     }
 
     #[test]
     fn cache_key_preserves_the_pipe_delimited_shape() {
         assert_eq!(
-            cache_key("Backend Engineer", "Acme", "Berlin"),
-            "backend engineer|acme|berlin"
+            cache_key("Backend Engineer", "Acme", "Berlin", "EUR"),
+            "backend engineer|acme|berlin|eur"
         );
+    }
+
+    #[test]
+    fn cache_key_differs_by_currency_so_cross_country_postings_never_collide() {
+        // The bug this fixes: a DE (EUR) and a US (USD) "Remote" posting share
+        // role/company/location, so without currency in the key they'd land
+        // on the same cache row — and an unknown-currency ("") read could then
+        // surface whatever currency a different, known-currency job last
+        // wrote there.
+        let de = cache_key("Backend Engineer", "Acme", "Remote", "EUR");
+        let us = cache_key("Backend Engineer", "Acme", "Remote", "USD");
+        let unknown = cache_key("Backend Engineer", "Acme", "Remote", "");
+        assert_ne!(de, us);
+        assert_ne!(de, unknown);
+        assert_ne!(us, unknown);
     }
 
     #[test]
@@ -576,7 +601,7 @@ mod tests {
                 currency: "EUR".to_string()
             })
         );
-        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin", "");
         assert!(
             cache.get(CACHE_NS, &key, TTL_SECS).is_some(),
             "a successful lookup must write through the cache"
@@ -602,7 +627,7 @@ mod tests {
             .await;
 
         assert_eq!(result, None);
-        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin", "");
         assert_eq!(cache.get(CACHE_NS, &key, TTL_SECS), None);
     }
 
@@ -625,7 +650,7 @@ mod tests {
             .await;
 
         assert_eq!(result, None);
-        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin", "");
         assert_eq!(cache.get(CACHE_NS, &key, TTL_SECS), None);
     }
 
@@ -647,7 +672,7 @@ mod tests {
             .await;
 
         assert_eq!(result, None);
-        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin", "");
         assert_eq!(cache.get(CACHE_NS, &key, TTL_SECS), None);
     }
 
@@ -669,7 +694,7 @@ mod tests {
             .await;
 
         assert_eq!(result, None);
-        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin", "");
         assert_eq!(cache.get(CACHE_NS, &key, TTL_SECS), None);
     }
 
@@ -739,7 +764,7 @@ mod tests {
 
         assert_eq!(result, None);
         // A dropped (mismatched) range must never be cached.
-        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin", "EUR");
         assert_eq!(cache.get(CACHE_NS, &key, TTL_SECS), None);
     }
 
@@ -751,7 +776,7 @@ mod tests {
         // currency) overwrites the stale row.
         let dir = TempDir::new().expect("tempdir");
         let cache = KvCache::open(dir.path()).expect("open cache");
-        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin", "EUR");
         cache.set(
             CACHE_NS,
             &key,
@@ -789,7 +814,7 @@ mod tests {
         // returned, even when the fallback fresh fetch also comes up empty.
         let dir = TempDir::new().expect("tempdir");
         let cache = KvCache::open(dir.path()).expect("open cache");
-        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin", "EUR");
         cache.set(
             CACHE_NS,
             &key,

--- a/apps/desktop/src-tauri/src/salary_research/mod.rs
+++ b/apps/desktop/src-tauri/src/salary_research/mod.rs
@@ -69,6 +69,8 @@ pub trait SalarySearcher {
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> impl std::future::Future<Output = AppResult<String>> + Send;
 }
 
@@ -78,8 +80,10 @@ impl SalarySearcher for Completer {
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> AppResult<String> {
-        Completer::research_salary(self, role, company, location).await
+        Completer::research_salary(self, role, company, location, country, currency).await
     }
 }
 
@@ -94,11 +98,25 @@ impl SalaryResearch {
     /// `role` is empty, the searcher can't search, the search/synthesis fails,
     /// times out, or its output doesn't parse into a plausible range.
     ///
+    /// `country`/`currency` ground the report in the job's actual currency
+    /// (resolved client-side from its validated ISO country) — both empty when
+    /// unknown, which preserves the unconstrained "local currency for that
+    /// location" behavior. When known, `currency` is also the safety net
+    /// against a stray hallucinated currency slipping past the model's own
+    /// JSON: [`reconcile_expected_currency`] fails safe — a parsed currency
+    /// that doesn't match the expected one is untrustworthy and is **dropped**
+    /// (never relabeled, which would put the wrong numbers under the right
+    /// symbol) — applied on both the cache-hit and fresh-fetch paths below.
+    /// The model is still asked to *research* in that currency (see
+    /// `commands::ai_provider::research::salary_system`), this is only the
+    /// defense-in-depth backstop.
+    ///
     /// `cache` is injected (`None` when the caller has no `KvCache` managed
     /// state) rather than looked up here — the sole production caller
     /// (`commands::ai::ai_lookup_salary`) resolves it once via
     /// `app.try_state::<KvCache>()` and passes it through, which is what keeps
     /// this function testable without an `AppHandle`.
+    #[allow(clippy::too_many_arguments)]
     pub async fn enrich<S: SalarySearcher>(
         &self,
         searcher: &S,
@@ -106,6 +124,8 @@ impl SalaryResearch {
         role: &str,
         company: &str,
         location: &str,
+        country: &str,
+        currency: &str,
     ) -> Option<SalaryRange> {
         // The very first thing this does — before touching `searcher` at all —
         // so a whitespace-only role never reaches it. Factored to a pure
@@ -118,17 +138,36 @@ impl SalaryResearch {
         let role = truncate_input(role.trim());
         let company = truncate_input(company.trim());
         let location = truncate_input(location.trim());
+        let country = truncate_input(country.trim());
+        let currency = truncate_input(currency.trim());
 
         // Case-folded so "Berlin"/"berlin" don't miss each other; the
         // case-preserved values above still go to the prompt/query/logging.
+        // Deliberately NOT keyed on country/currency — the reconciliation
+        // below re-checks every read regardless of what was cached, so an
+        // older (possibly wrong-currency) entry self-heals via a fresh fetch
+        // rather than fragmenting the cache.
         let key = cache_key(&role, &company, &location);
 
         // Fast path: cached, validated range younger than the TTL.
         if let Some(cache) = cache {
             if let Some(json) = cache.get(CACHE_NS, &key, TTL_SECS) {
                 if let Some(range) = parse_and_validate(&json) {
-                    tracing::info!(role = %role, company = %company, source = "cache", "salary_research: range");
-                    return Some(range);
+                    match reconcile_expected_currency(range, &currency) {
+                        Some(range) => {
+                            tracing::info!(role = %role, company = %company, source = "cache", "salary_research: range");
+                            return Some(range);
+                        }
+                        None => {
+                            // A pre-fix (or otherwise stale) cache entry in the
+                            // wrong currency — untrustworthy, don't relabel it.
+                            // Fall through to a fresh fetch instead of a cache
+                            // miss's usual `None`; a successful fetch below
+                            // overwrites this row (`cache.set` is upsert), so
+                            // the entry self-heals without waiting out the TTL.
+                            tracing::debug!(role = %role, company = %company, "salary_research: cached range is in the wrong currency, dropping and re-fetching");
+                        }
+                    }
                 }
             }
         }
@@ -137,7 +176,7 @@ impl SalaryResearch {
         // failure/timeout yields no range.
         let raw = match tokio::time::timeout(
             Duration::from_secs(RESEARCH_TIMEOUT_SECS),
-            searcher.research_salary(&role, &company, &location),
+            searcher.research_salary(&role, &company, &location, &country, &currency),
         )
         .await
         {
@@ -156,6 +195,9 @@ impl SalaryResearch {
         // all fall through here — never cached, so a bad miss doesn't stick for
         // the 7-day TTL.
         let range = parse_and_validate(&raw)?;
+        // Fail-safe, not relabel: a fresh result in the wrong currency is
+        // dropped (`None`) rather than shown under the wrong symbol.
+        let range = reconcile_expected_currency(range, &currency)?;
 
         if let Some(cache) = cache {
             if let Ok(json) = serde_json::to_string(&range) {
@@ -166,6 +208,23 @@ impl SalaryResearch {
         tracing::info!(role = %role, company = %company, source = "provider", "salary_research: range");
         Some(range)
     }
+}
+
+/// Fail-safe backstop behind [`commands::ai_provider::research::salary_system`]'s
+/// prompt-level pin: even if the model's own JSON slips a stray/wrong currency
+/// code past [`parse_and_validate`]'s shape check, this catches it — but it
+/// **drops** the range rather than relabeling it, since relabeling would put
+/// the wrong-currency numbers under the right symbol (more misleading than an
+/// obviously-wrong one). Returns `Some(range)` unchanged when
+/// `expected_currency` is empty (unknown country — preserves today's
+/// unconstrained behavior) or already matches; returns `None` when a known
+/// expected currency doesn't match the parsed one. Pure + unit-tested.
+fn reconcile_expected_currency(range: SalaryRange, expected_currency: &str) -> Option<SalaryRange> {
+    let expected = expected_currency.trim();
+    if expected.is_empty() || expected.eq_ignore_ascii_case(&range.currency) {
+        return Some(range);
+    }
+    None
 }
 
 /// Cap `s` to [`MAX_INPUT_CHARS`] (char-boundary safe — never splits a
@@ -450,6 +509,8 @@ mod tests {
             _role: &str,
             _company: &str,
             _location: &str,
+            _country: &str,
+            _currency: &str,
         ) -> AppResult<String> {
             Ok(self.0.to_string())
         }
@@ -463,6 +524,8 @@ mod tests {
             _role: &str,
             _company: &str,
             _location: &str,
+            _country: &str,
+            _currency: &str,
         ) -> AppResult<String> {
             Err(AppError::Provider("search failed".to_string()))
         }
@@ -476,6 +539,8 @@ mod tests {
             _role: &str,
             _company: &str,
             _location: &str,
+            _country: &str,
+            _currency: &str,
         ) -> AppResult<String> {
             // Sleeps past RESEARCH_TIMEOUT_SECS; under `start_paused = true` this
             // resolves the moment `enrich`'s own timeout timer fires instead of
@@ -498,6 +563,8 @@ mod tests {
                 "Backend Engineer",
                 "Acme",
                 "Berlin",
+                "",
+                "",
             )
             .await;
 
@@ -529,6 +596,8 @@ mod tests {
                 "Backend Engineer",
                 "Acme",
                 "Berlin",
+                "",
+                "",
             )
             .await;
 
@@ -550,6 +619,8 @@ mod tests {
                 "Backend Engineer",
                 "Acme",
                 "Berlin",
+                "",
+                "",
             )
             .await;
 
@@ -570,6 +641,8 @@ mod tests {
                 "Backend Engineer",
                 "Acme",
                 "Berlin",
+                "",
+                "",
             )
             .await;
 
@@ -590,11 +663,181 @@ mod tests {
                 "Backend Engineer",
                 "Acme",
                 "Berlin",
+                "",
+                "",
             )
             .await;
 
         assert_eq!(result, None);
         let key = cache_key("Backend Engineer", "Acme", "Berlin");
         assert_eq!(cache.get(CACHE_NS, &key, TTL_SECS), None);
+    }
+
+    // ── currency grounding (the bug fix): reconcile_expected_currency + enrich ─
+    //
+    // Fail-safe, not relabel: a mismatched currency is dropped (`None`), never
+    // overridden onto the (wrong-currency) numbers.
+
+    #[test]
+    fn reconcile_expected_currency_drops_a_mismatched_range() {
+        let range = SalaryRange {
+            min: 1,
+            max: 2,
+            currency: "USD".to_string(),
+        };
+        assert_eq!(reconcile_expected_currency(range, "EUR"), None);
+    }
+
+    #[test]
+    fn reconcile_expected_currency_is_a_no_op_when_the_expected_currency_is_unknown() {
+        // Unknown-country guard: an empty expected currency must never drop or
+        // mutate the parsed range — today's unconstrained behavior.
+        let range = SalaryRange {
+            min: 1,
+            max: 2,
+            currency: "USD".to_string(),
+        };
+        assert_eq!(reconcile_expected_currency(range.clone(), ""), Some(range));
+    }
+
+    #[test]
+    fn reconcile_expected_currency_is_a_no_op_when_it_already_matches_case_insensitively() {
+        let range = SalaryRange {
+            min: 1,
+            max: 2,
+            currency: "eur".to_string(),
+        };
+        // Already-matching (modulo case) is kept exactly as parsed.
+        assert_eq!(
+            reconcile_expected_currency(range.clone(), "eur"),
+            Some(range)
+        );
+    }
+
+    #[tokio::test]
+    async fn enrich_drops_a_hallucinated_currency_when_the_expected_currency_is_known() {
+        // The bug this fixes: a German role with a weak location previously let
+        // the model report USD. A stray USD slipping past the prompt-level pin
+        // must never be relabeled EUR (wrong numbers under the right symbol) —
+        // it's dropped instead, degrading to the C1 fallback like any other
+        // failed lookup.
+        let dir = TempDir::new().expect("tempdir");
+        let cache = KvCache::open(dir.path()).expect("open cache");
+        let searcher = FakeSearcher(r#"{"min":65000,"max":80000,"currency":"USD"}"#);
+
+        let result = SalaryResearch
+            .enrich(
+                &searcher,
+                Some(&cache),
+                "Backend Engineer",
+                "Acme",
+                "Berlin",
+                "DE",
+                "EUR",
+            )
+            .await;
+
+        assert_eq!(result, None);
+        // A dropped (mismatched) range must never be cached.
+        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        assert_eq!(cache.get(CACHE_NS, &key, TTL_SECS), None);
+    }
+
+    #[tokio::test]
+    async fn enrich_self_heals_a_stale_mismatched_cache_entry_via_a_fresh_fetch() {
+        // Simulates a stale cache entry written before this fix shipped (wrong
+        // currency baked in). It must not be returned as-is — `enrich` falls
+        // through to a fresh fetch, which (once it succeeds in the right
+        // currency) overwrites the stale row.
+        let dir = TempDir::new().expect("tempdir");
+        let cache = KvCache::open(dir.path()).expect("open cache");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        cache.set(
+            CACHE_NS,
+            &key,
+            r#"{"min":65000,"max":80000,"currency":"USD"}"#,
+        );
+        let searcher = FakeSearcher(r#"{"min":70000,"max":90000,"currency":"EUR"}"#);
+
+        let result = SalaryResearch
+            .enrich(
+                &searcher,
+                Some(&cache),
+                "Backend Engineer",
+                "Acme",
+                "Berlin",
+                "DE",
+                "EUR",
+            )
+            .await;
+
+        assert_eq!(
+            result,
+            Some(SalaryRange {
+                min: 70000,
+                max: 90000,
+                currency: "EUR".to_string()
+            })
+        );
+        let cached = cache.get(CACHE_NS, &key, TTL_SECS).expect("cached");
+        assert_eq!(parse_and_validate(&cached).unwrap().currency, "EUR");
+    }
+
+    #[tokio::test]
+    async fn enrich_returns_none_when_a_stale_cache_entry_mismatches_and_the_fresh_fetch_fails() {
+        // Fail-safe end-to-end: a stale mismatched cache entry is never
+        // returned, even when the fallback fresh fetch also comes up empty.
+        let dir = TempDir::new().expect("tempdir");
+        let cache = KvCache::open(dir.path()).expect("open cache");
+        let key = cache_key("Backend Engineer", "Acme", "Berlin");
+        cache.set(
+            CACHE_NS,
+            &key,
+            r#"{"min":65000,"max":80000,"currency":"USD"}"#,
+        );
+
+        let result = SalaryResearch
+            .enrich(
+                &ErrSearcher,
+                Some(&cache),
+                "Backend Engineer",
+                "Acme",
+                "Berlin",
+                "DE",
+                "EUR",
+            )
+            .await;
+
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn enrich_leaves_the_currency_untouched_when_the_country_is_unknown() {
+        // Unknown-country guard end-to-end: empty country/currency must not
+        // change today's behavior at all.
+        let dir = TempDir::new().expect("tempdir");
+        let cache = KvCache::open(dir.path()).expect("open cache");
+        let searcher = FakeSearcher(r#"{"min":65000,"max":80000,"currency":"USD"}"#);
+
+        let result = SalaryResearch
+            .enrich(
+                &searcher,
+                Some(&cache),
+                "Backend Engineer",
+                "Acme",
+                "",
+                "",
+                "",
+            )
+            .await;
+
+        assert_eq!(
+            result,
+            Some(SalaryRange {
+                min: 65000,
+                max: 80000,
+                currency: "USD".to_string()
+            })
+        );
     }
 }

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/useApplicationAnswers.test.ts
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/useApplicationAnswers.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 
-import { generateApplicationAnswer, lookupSalaryRange } from '@/lib/generate';
+import { extractMetadata, generateApplicationAnswer, lookupSalaryRange } from '@/lib/generate';
 
 import { useApplicationAnswers } from './useApplicationAnswers';
 
@@ -283,12 +283,52 @@ describe('useApplicationAnswers', () => {
         await result.current.generate();
       });
 
-      expect(lookupSalaryRange).toHaveBeenCalledWith('Engineer', 'Acme', '', 'llama3');
+      // No jobCountry in the base mock → country/currency both undefined (today's
+      // unconstrained behavior — the unknown-country fallback).
+      expect(lookupSalaryRange).toHaveBeenCalledWith(
+        'Engineer',
+        'Acme',
+        '',
+        'llama3',
+        undefined,
+        undefined
+      );
       expect(generateApplicationAnswer).toHaveBeenCalledWith(
         expect.objectContaining({
           question: 'What are your salary expectations?',
           salaryRange: { min: 65000, max: 80000, currency: 'EUR' },
         })
+      );
+    });
+
+    it('grounds the lookup in the detected job country + its currency (currency-grounding fix)', async () => {
+      vi.mocked(extractMetadata).mockResolvedValueOnce({
+        candidateName: 'Jane',
+        jobTitle: 'Engineer',
+        companyName: 'Acme',
+        resumeLanguage: 'en',
+        jobAdLanguage: 'en',
+        mismatch: false,
+        targetLanguage: 'en',
+        topRequirements: [],
+        jobLocation: 'Berlin, Germany',
+        jobCountry: 'DE',
+      });
+      vi.mocked(lookupSalaryRange).mockResolvedValue({ min: 65000, max: 80000, currency: 'EUR' });
+      const { result } = render();
+      act(() => result.current.toggle('salary'));
+
+      await act(async () => {
+        await result.current.generate();
+      });
+
+      expect(lookupSalaryRange).toHaveBeenCalledWith(
+        'Engineer',
+        'Acme',
+        'Berlin, Germany',
+        'llama3',
+        'DE',
+        'EUR'
       );
     });
 

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/useApplicationAnswers.ts
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/useApplicationAnswers.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { APPLICATION_QUESTIONS } from '@ajh/prompts/generate';
+import { APPLICATION_QUESTIONS, countryToCurrency } from '@ajh/prompts/generate';
 import type { ApplicationAnswer } from '@ajh/shared';
 
 import {
@@ -199,7 +199,9 @@ export function useApplicationAnswers({
                 detected.jobTitle,
                 detected.companyName,
                 detected.jobLocation || detected.jobCountry || '',
-                model
+                model,
+                detected.jobCountry,
+                countryToCurrency(detected.jobCountry)
               );
             } catch {
               salaryRange = undefined;

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -288,7 +288,13 @@ export async function lookupSalaryRange(
   role: string,
   company: string,
   location: string,
-  model: string
+  model: string,
+  /** ISO-3166 alpha-2 job country, when known — grounds the researched currency. */
+  country?: string,
+  /** Authoritative ISO-4217 currency for `country` (resolve via `countryToCurrency`
+   *  from `@ajh/prompts/generate`); omitted falls back to today's unconstrained
+   *  "local currency for that location" behavior. */
+  currency?: string
 ): Promise<SalaryRange | undefined> {
   try {
     const { activeProvider, providerSettings } = resolveActiveProvider(model);
@@ -296,6 +302,8 @@ export async function lookupSalaryRange(
       role,
       company: company.trim() || undefined,
       location: location.trim() || undefined,
+      country: country?.trim() || undefined,
+      currency: currency?.trim() || undefined,
       provider: activeProvider,
       model: providerSettings?.model || model,
       baseUrl: providerSettings?.baseUrl,

--- a/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
+++ b/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
@@ -29,6 +29,8 @@ export const ai = {
     role,
     company,
     location,
+    country,
+    currency,
     provider,
     model,
     baseUrl,
@@ -36,10 +38,22 @@ export const ai = {
     role: string;
     company?: string;
     location?: string;
+    country?: string;
+    currency?: string;
     provider?: string;
     model?: string;
     baseUrl?: string;
-  }) => invoke('ai_lookup_salary', { role, company, location, provider, model, baseUrl }),
+  }) =>
+    invoke('ai_lookup_salary', {
+      role,
+      company,
+      location,
+      country,
+      currency,
+      provider,
+      model,
+      baseUrl,
+    }),
   pullModel: (model: string) => invoke('ai_pull_model', { model }),
   unloadModel: (model: string) => invoke('ai_unload_model', { model }),
   embed: (req: EmbedRequest) => invoke('ai_embed', { req }),

--- a/packages/prompts/src/generate/index.ts
+++ b/packages/prompts/src/generate/index.ts
@@ -24,6 +24,7 @@ export * from './text/index.js';
 // generation builders (cover letter + application answers), so it's re-exported
 // here for a single import source.
 export {
+  countryToCurrency,
   countryToMarket,
   hasLetterConventions,
   LETTER_MARKET_IDS,

--- a/packages/prompts/src/locale/index.ts
+++ b/packages/prompts/src/locale/index.ts
@@ -889,6 +889,11 @@ const COUNTRY_TO_CURRENCY: Record<string, string> = {
   NL: 'EUR',
   HR: 'EUR',
   BG: 'EUR',
+  HU: 'HUF',
+  RO: 'RON',
+  SM: 'EUR',
+  VA: 'EUR',
+  AD: 'EUR',
 };
 
 /** Map an ISO-3166 alpha-2 country code to its ISO-4217 currency (undefined when unknown). */

--- a/packages/prompts/src/locale/index.ts
+++ b/packages/prompts/src/locale/index.ts
@@ -826,6 +826,77 @@ export function countryToMarket(country?: string): string | undefined {
   return COUNTRY_TO_MARKET[country.trim().toUpperCase()];
 }
 
+/**
+ * ISO-3166 alpha-2 country → ISO-4217 currency code. Wider than
+ * {@link COUNTRY_TO_MARKET} (also covers Nordics/CEE/Eurozone countries with
+ * no distinct letter-conventions entry) — grounds the web-researched salary
+ * range (see `salary_research` on the Rust side) in the job's actual currency
+ * so a blank/weak location can't let the model default to USD or hallucinate
+ * one.
+ *
+ * ponytail: kept as its own map, not derived from {@link COUNTRY_TO_MARKET} —
+ * the two group countries differently (e.g. all Eurozone members share one
+ * currency but split across `de`/`fr`/`es`/`it` letter-convention markets), so
+ * a derived map would need an inverse lookup with no real gain.
+ */
+const COUNTRY_TO_CURRENCY: Record<string, string> = {
+  US: 'USD',
+  GB: 'GBP',
+  UK: 'GBP',
+  IE: 'EUR',
+  AU: 'AUD',
+  NZ: 'NZD',
+  CA: 'CAD',
+  IN: 'INR',
+  SG: 'SGD',
+  DE: 'EUR',
+  AT: 'EUR',
+  CH: 'CHF',
+  FR: 'EUR',
+  BE: 'EUR',
+  LU: 'EUR',
+  MC: 'EUR',
+  ES: 'EUR',
+  MX: 'MXN',
+  AR: 'ARS',
+  CL: 'CLP',
+  CO: 'COP',
+  PE: 'PEN',
+  IT: 'EUR',
+  PT: 'EUR',
+  BR: 'BRL',
+  TR: 'TRY',
+  RU: 'RUB',
+  CN: 'CNY',
+  TW: 'TWD',
+  HK: 'HKD',
+  JP: 'JPY',
+  KR: 'KRW',
+  SE: 'SEK',
+  NO: 'NOK',
+  DK: 'DKK',
+  PL: 'PLN',
+  CZ: 'CZK',
+  SK: 'EUR',
+  SI: 'EUR',
+  EE: 'EUR',
+  LV: 'EUR',
+  LT: 'EUR',
+  CY: 'EUR',
+  MT: 'EUR',
+  GR: 'EUR',
+  FI: 'EUR',
+  NL: 'EUR',
+  HR: 'EUR',
+  BG: 'EUR',
+};
+
+/** Map an ISO-3166 alpha-2 country code to its ISO-4217 currency (undefined when unknown). */
+export function countryToCurrency(country?: string): string | undefined {
+  if (!country) return undefined;
+  return COUNTRY_TO_CURRENCY[country.trim().toUpperCase()];
+}
+
 export interface ResolveMarketInput {
   /** ISO-3166 alpha-2 country extracted from the job ad. */
   jobCountry?: string;

--- a/packages/prompts/src/locale/locale.test.ts
+++ b/packages/prompts/src/locale/locale.test.ts
@@ -156,6 +156,9 @@ describe('countryToCurrency', () => {
     // Croatia joined the Eurozone 2023-01-01; Bulgaria joined 2026-01-01.
     expect(countryToCurrency('HR')).toBe('EUR');
     expect(countryToCurrency('BG')).toBe('EUR');
+    // EU members outside the Eurozone.
+    expect(countryToCurrency('HU')).toBe('HUF');
+    expect(countryToCurrency('RO')).toBe('RON');
     expect(countryToCurrency('ZZ')).toBeUndefined();
     expect(countryToCurrency(undefined)).toBeUndefined();
   });

--- a/packages/prompts/src/locale/locale.test.ts
+++ b/packages/prompts/src/locale/locale.test.ts
@@ -4,6 +4,7 @@ import { detectSections, estimateTokens } from '../context-manager';
 import letterConventionsFixture from '../fixtures/letter-conventions.json';
 import {
   charsPerToken,
+  countryToCurrency,
   countryToMarket,
   hasLetterConventions,
   LETTER_MARKET_CONVENTIONS,
@@ -143,5 +144,19 @@ describe('countryToMarket + resolveMarket', () => {
     expect(resolveMarket({})).toBe('intl');
     // An invalid override is ignored (falls through to the chain).
     expect(resolveMarket({ override: 'zz', jobCountry: 'US' })).toBe('us');
+  });
+});
+
+describe('countryToCurrency', () => {
+  it('grounds the salary-lookup currency in the job country, case-insensitively', () => {
+    expect(countryToCurrency('DE')).toBe('EUR');
+    expect(countryToCurrency('gb')).toBe('GBP');
+    expect(countryToCurrency('US')).toBe('USD');
+    expect(countryToCurrency('CA')).toBe('CAD');
+    // Croatia joined the Eurozone 2023-01-01; Bulgaria joined 2026-01-01.
+    expect(countryToCurrency('HR')).toBe('EUR');
+    expect(countryToCurrency('BG')).toBe('EUR');
+    expect(countryToCurrency('ZZ')).toBeUndefined();
+    expect(countryToCurrency(undefined)).toBeUndefined();
   });
 });

--- a/packages/shared/src/ipc/contracts/ai.ts
+++ b/packages/shared/src/ipc/contracts/ai.ts
@@ -53,6 +53,14 @@ export interface AiContract {
     role: string;
     company?: string;
     location?: string;
+    /** ISO-3166 alpha-2 job country, when known — grounds `currency` below. */
+    country?: string;
+    /** Authoritative ISO-4217 currency for `country` (resolve client-side via
+     *  `countryToCurrency`). Pins the researched/reported currency server-side
+     *  so a blank/weak `location` can't let the model default to USD or
+     *  hallucinate one; omitted when the country is unknown, which preserves
+     *  today's unconstrained "local currency for that location" behavior. */
+    currency?: string;
     provider?: string;
     model?: string;
     baseUrl?: string;


### PR DESCRIPTION
## What

Fixes the user-reported bug: **the salary range shows the wrong currency** — e.g. a job located in Germany rendered USD/CAD instead of EUR (bug #2 of the batch).

## Root cause

The web-lookup salary path let the model **freely choose** the currency: `SALARY_SYSTEM` said "use the local currency for that location", and the user prompt **dropped the location clause entirely when it was blank**. With a weak/empty job-location string the model defaulted to USD or hallucinated CAD. (The scraped-salary path from #551 was already grounded and is unaffected.)

## Fix — ground the currency in the job's ISO country (end-to-end)

- **`countryToCurrency(iso2)`** in `@ajh/prompts` (ISO-3166 alpha-2 → ISO-4217; Eurozone incl. HR/BG + the common markets), beside `countryToMarket`.
- Thread the job country + resolved expected currency from the answer call site → `lookupSalaryRange` → the `lookupSalary` IPC contract → `ai_lookup_salary` → `SalaryResearch::enrich` → the shared `research.rs` prompt builders, which now **pin the currency authoritatively** ("the role is based in {country}; report the range in {currency}") across all provider fan-out builders + the Ollama synth path. Unknown country → byte-for-byte fallback to the prior wording.
- **Defense-in-depth that fails safe:** `reconcile_expected_currency` **drops** a result whose currency still mismatches (returns `None` → graceful no-range) rather than relabeling numbers it can't convert — a wrong paste-ready figure would be *more* misleading than an obvious wrong symbol. A stale wrong-currency cache entry falls through to a fresh grounded fetch. Scraped-salary precedence preserved.

## Review

Orchestrated via a workflow (one author owns the interdependent contract→prompt thread → ai-provider-expert + job-match-expert). **No HIGH/CRITICAL.** job-match-expert verified all currency mappings correct; its MEDIUM — the backstop relabeling without converting — is fixed here (relabel → drop). `gen:ipc:check` clean; typecheck 12/12; **365 `@ajh/prompts` + 3111 renderer tests**; cargo fmt + clippy `-D warnings` + build + architecture (11) green. Rust unit tests run in CI.

## Verify

A German (DE) job's salary lookup now returns EUR; US → USD; an unknown country falls back to prior behavior (no regression). A model that defies the currency pin yields no range rather than a mislabeled one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
