### PR TITLE
feat: default the company-search toggle on when the model supports web search

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -163,6 +163,30 @@ pub async fn ai_list_provider_models(
     json!(provider_client.list_models(&app).await)
 }
 
+/// Static, network-free capability probe for a provider/model — currently only
+/// whether it can attempt a web-grounded `research*` search. Reads the resolved
+/// [`ModelCapabilities`] matrix (the SAME value consumed server-side by
+/// `ai_research_*`), so the renderer never mirrors the per-provider booleans: a
+/// NEW provider is exposed with zero TypeScript change. Drives the
+/// capability-driven default of the tailoring "search company" toggle. An
+/// unknown/unresolvable provider degrades to `supportsWebSearch: false`,
+/// matching the caller's safe default-off fallback.
+#[tauri::command]
+pub fn ai_model_capabilities(
+    provider: String,
+    model: Option<String>,
+    base_url: Option<String>,
+) -> Value {
+    let supports_web_search = resolve_by_name(&provider, base_url)
+        .map(|client| {
+            client
+                .capabilities(&model.unwrap_or_default())
+                .supports_web_search
+        })
+        .unwrap_or(false);
+    json!({ "supportsWebSearch": supports_web_search })
+}
+
 /// Local (Ollama) model list — powers the model picker's "Ollama (Local)"
 /// section. Cloud models come from `ai_list_provider_models`.
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
@@ -802,6 +802,35 @@ mod tests {
     }
 
     #[test]
+    fn web_search_support_is_capability_driven_per_provider() {
+        // Exercises the exact path `ai_model_capabilities` takes
+        // (`resolve_by_name(..).capabilities(..).supports_web_search`) so the
+        // renderer's capability-driven "search company" default stays a read of
+        // the Rust matrix, never a TS mirror. Native OpenAI can web-search; a
+        // generic OpenAI-compatible gateway cannot — every other provider can.
+        let cases = [
+            ("anthropic", true),
+            ("gemini", true),
+            ("ollama", true),
+            ("ollama-cloud", true),
+            ("openai", true),
+            ("openai-compatible", false),
+            ("claude-code", true),
+            ("codex", true),
+            ("gemini-cli", true),
+        ];
+        for (name, expected) in cases {
+            let client = resolve_by_name(name, None).unwrap();
+            assert_eq!(
+                client.capabilities("").supports_web_search,
+                expected,
+                "{name} web-search support"
+            );
+        }
+        assert!(resolve_by_name("nope", None).is_err());
+    }
+
+    #[test]
     fn provider_id_round_trips() {
         for id in [
             ProviderId::Ollama,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -777,6 +777,7 @@ pub fn run() {
             // ai
             commands::ai::ai_generate,
             commands::ai::ai_list_models,
+            commands::ai::ai_model_capabilities,
             commands::ai::ai_inspect_model,
             commands::ai::ai_research_company,
             commands::ai::ai_research_answer,

--- a/apps/desktop/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
+++ b/apps/desktop/src/renderer/features/ai-generate/components/AIGeneratePage/index.tsx
@@ -16,6 +16,7 @@ import { OutputPanelIdle } from '@/features/ai-generate/components/OutputPanelId
 import { useFileUpload } from '@/features/ai-generate/hooks/useFileUpload';
 import { useGeneration } from '@/features/ai-generate/hooks/useGeneration';
 import { useStageRotation } from '@/features/ai-generate/hooks/useStageRotation';
+import { useResearchCompanyDefault } from '@/hooks/use-research-company-default';
 import {
   buildFilename,
   type EmphasisId,
@@ -82,8 +83,10 @@ export function AIGeneratePage() {
   const [genStep, setGenStep] = useState<{ current: number; total: number; label: string } | null>(
     null
   );
-  // Opt-in company research for the cover letter — default off (no extra web/LLM call).
-  const [researchCompany, setResearchCompany] = useState(false);
+  // Company research for the cover letter — the initial default is capability-
+  // driven (ON when the active model can web-search, OFF otherwise); a user
+  // toggle always wins from then on.
+  const [researchCompany, setResearchCompany] = useResearchCompanyDefault();
   // In-flight flag, decoupled from `stage`: with progressive reveal (#23) the
   // stage is already `done` (résumé shown) while the cover letter still streams.
   const [isGenerating, setIsGenerating] = useState(false);

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
@@ -71,12 +71,23 @@ const resolveJobUrlState = {
 // Tracks the last `shouldFetch` arg received by useResolveJobUrl.
 let lastResolveJobUrlShouldFetch: boolean | undefined = undefined;
 
+// Mutable container so tests can flip the active model's web-search capability,
+// which drives the capability-driven default of the "search company" toggle.
+const modelCapsState = {
+  data: { supportsWebSearch: false } as { supportsWebSearch: boolean } | undefined,
+  isSuccess: true,
+};
+
 vi.mock('@/services', () => ({
   useResolveJobUrl: (_url: string, shouldFetch: boolean) => {
     lastResolveJobUrlShouldFetch = shouldFetch;
     return { data: resolveJobUrlState.data, isLoading: resolveJobUrlState.isLoading };
   },
   useExtractText: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useActiveModelCapabilities: () => ({
+    data: modelCapsState.data,
+    isSuccess: modelCapsState.isSuccess,
+  }),
 }));
 
 // ── useTailorGeneration — controlled mock ─────────────────────────────────────
@@ -179,14 +190,23 @@ vi.mock('./TailorWizard', () => ({
     onGenerate,
     jobDesc,
     onJobDescChange,
+    methods,
   }: {
     step: number;
     setStep: (n: number) => void;
     onGenerate: (v: { resume: string; outputType: 'resume'; researchCompany: boolean }) => void;
     jobDesc?: string;
     onJobDescChange?: (v: string) => void;
+    // The RHF form — the stub reads the research toggle so the capability-driven
+    // default is observable via a data attribute.
+    methods: { watch: (name: 'researchCompany') => boolean };
   }) => (
-    <div data-testid={TEST_IDS.documents.tailorWizard} data-step={step} data-jobdesc={jobDesc}>
+    <div
+      data-testid={TEST_IDS.documents.tailorWizard}
+      data-step={step}
+      data-jobdesc={jobDesc}
+      data-research={String(methods.watch('researchCompany'))}
+    >
       <div
         role="button"
         tabIndex={0}
@@ -397,6 +417,9 @@ beforeEach(() => {
   resolveJobUrlState.data = undefined;
   resolveJobUrlState.isLoading = false;
   lastResolveJobUrlShouldFetch = undefined;
+  // Reset model-capability state (default: cannot web-search → toggle off).
+  modelCapsState.data = { supportsWebSearch: false };
+  modelCapsState.isSuccess = true;
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -565,6 +588,43 @@ describe('TailorFlow — persistence injection', () => {
 
     expect(persistence.setAtsMode).toHaveBeenCalledTimes(1);
     expect(persistence.setAtsMode).toHaveBeenCalledWith(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2b. Capability-driven "search company" default
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('TailorFlow — capability-driven research default', () => {
+  it('defaults the research toggle ON for a web-search-capable model (fresh form)', () => {
+    modelCapsState.data = { supportsWebSearch: true };
+    renderFlow({ persistence: makePersistence({ wizardForm: null }) });
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-research',
+      'true'
+    );
+  });
+
+  it('defaults the research toggle OFF for a model without web search (fresh form)', () => {
+    modelCapsState.data = { supportsWebSearch: false };
+    renderFlow({ persistence: makePersistence({ wizardForm: null }) });
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-research',
+      'false'
+    );
+  });
+
+  it('does NOT override a restored form — the saved choice wins over the capability default', () => {
+    // Capability says ON, but the persisted form saved OFF → the restore wins.
+    modelCapsState.data = { supportsWebSearch: true };
+    const persistence = makePersistence({
+      wizardForm: { resume: 'Seeded', outputType: 'both', researchCompany: false },
+    });
+    renderFlow({ persistence });
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-research',
+      'false'
+    );
   });
 });
 

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
@@ -626,6 +626,35 @@ describe('TailorFlow — capability-driven research default', () => {
       'false'
     );
   });
+
+  it('re-seeds the toggle when the model changes mid-session (fresh form, untouched)', () => {
+    modelCapsState.data = { supportsWebSearch: false };
+    const persistence = makePersistence({ wizardForm: null });
+    // A fresh element per render so React reconciles (identical element refs bail).
+    const el = () => (
+      <TailorFlow
+        job={JOB}
+        resumeText="My resume"
+        board="linkedin"
+        contextId="autopilot:https://acme.com/jobs/1"
+        jobUrl="https://acme.com/jobs/1"
+        persistence={persistence}
+      />
+    );
+    const { rerender } = render(el());
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-research',
+      'false'
+    );
+
+    // User switches to a web-search-capable model without touching the toggle.
+    modelCapsState.data = { supportsWebSearch: true };
+    rerender(el());
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-research',
+      'true'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/index.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/index.tsx
@@ -9,7 +9,7 @@ import { transition } from '@ajh/ui';
 import { useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
 import { useInterviewQuestions } from '@/hooks/use-interview-questions';
 import type { TemplateId } from '@/lib/generate';
-import { useResolveJobUrl } from '@/services';
+import { useActiveModelCapabilities, useResolveJobUrl } from '@/services';
 
 import { ApplicationQuestionsModal } from './ApplicationQuestionsModal';
 import { GeneratingPanel } from './GeneratingPanel';
@@ -129,10 +129,18 @@ export function TailorFlow({
   const setTemplateId = persistence.setTemplateId;
   const setAtsMode = persistence.setAtsMode;
 
+  // Capability-driven default for the "search company" toggle: default ON when
+  // the active model can web-search. Read from the Rust capability matrix (never
+  // a TS mirror), so a new provider needs no change here.
+  const caps = useActiveModelCapabilities();
+
   // RHF owns the live editing layer; `persistence.wizardForm` is a one-shot seed.
   // Seed `defaultValues` ONCE — written back on step-advance and on generate.
+  // Only a FRESH (unpersisted) form takes the capability-driven research default;
+  // a restored form keeps the user's saved choice.
+  const startedFresh = useRef(persistence.wizardForm == null);
   const initialForm = useRef<TailorWizardState>(
-    persistence.wizardForm ?? buildTailorDefaults(resumeText)
+    persistence.wizardForm ?? buildTailorDefaults(resumeText, caps.data?.supportsWebSearch ?? false)
   );
   const methods = useForm<TailorWizardState>({
     defaultValues: initialForm.current,
@@ -142,6 +150,22 @@ export function TailorFlow({
 
   // The research toggle is an RHF field; the hook needs its live value.
   const researchCompany = useWatch({ control: methods.control, name: 'researchCompany' });
+
+  // When the capability resolves AFTER the form was seeded (cold cache), apply
+  // the ON/OFF default once — only for a fresh form and only until the user
+  // touches the toggle (RHF's dirty flag guards the override, so it's never
+  // clobbered on a late resolve).
+  const seededResearch = useRef(false);
+  const researchDirty = !!methods.formState.dirtyFields.researchCompany;
+  useEffect(() => {
+    if (seededResearch.current || !startedFresh.current || !caps.isSuccess) return;
+    seededResearch.current = true;
+    if (!researchDirty) {
+      methods.setValue('researchCompany', caps.data?.supportsWebSearch ?? false, {
+        shouldDirty: false,
+      });
+    }
+  }, [caps.isSuccess, caps.data, researchDirty, methods]);
 
   const [referralOpen, setReferralOpen] = useState(false);
   const [questionsOpen, setQuestionsOpen] = useState(false);

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/index.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/index.tsx
@@ -9,6 +9,7 @@ import { transition } from '@ajh/ui';
 import { useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
 import { useInterviewQuestions } from '@/hooks/use-interview-questions';
 import type { TemplateId } from '@/lib/generate';
+import { shouldSeedResearchDefault } from '@/lib/research-company-default';
 import { useActiveModelCapabilities, useResolveJobUrl } from '@/services';
 
 import { ApplicationQuestionsModal } from './ApplicationQuestionsModal';
@@ -133,17 +134,19 @@ export function TailorFlow({
   // the active model can web-search. Read from the Rust capability matrix (never
   // a TS mirror), so a new provider needs no change here.
   const caps = useActiveModelCapabilities();
+  const supportsWebSearch = caps.data?.supportsWebSearch ?? false;
 
   // RHF owns the live editing layer; `persistence.wizardForm` is a one-shot seed.
   // Seed `defaultValues` ONCE — written back on step-advance and on generate.
   // Only a FRESH (unpersisted) form takes the capability-driven research default;
-  // a restored form keeps the user's saved choice.
+  // a restored form keeps the user's saved choice. Lazy `useState` initializer so
+  // `buildTailorDefaults` runs once, not on every render.
   const startedFresh = useRef(persistence.wizardForm == null);
-  const initialForm = useRef<TailorWizardState>(
-    persistence.wizardForm ?? buildTailorDefaults(resumeText, caps.data?.supportsWebSearch ?? false)
+  const [initialForm] = useState<TailorWizardState>(
+    () => persistence.wizardForm ?? buildTailorDefaults(resumeText, supportsWebSearch)
   );
   const methods = useForm<TailorWizardState>({
-    defaultValues: initialForm.current,
+    defaultValues: initialForm,
     resolver: zodResolver(tailorWizardSchema),
     mode: 'onChange',
   });
@@ -151,21 +154,30 @@ export function TailorFlow({
   // The research toggle is an RHF field; the hook needs its live value.
   const researchCompany = useWatch({ control: methods.control, name: 'researchCompany' });
 
-  // When the capability resolves AFTER the form was seeded (cold cache), apply
-  // the ON/OFF default once — only for a fresh form and only until the user
-  // touches the toggle (RHF's dirty flag guards the override, so it's never
-  // clobbered on a late resolve).
-  const seededResearch = useRef(false);
+  // Keep the "search company" default in sync with the active model's capability:
+  // seed it when the capability resolves after a cold-cache seed, and RE-seed it
+  // on a mid-session model switch that flips the capability — but only for a fresh
+  // form and only until the user touches the toggle (RHF's dirty flag guards the
+  // override, so an explicit choice is never clobbered). The DECISION is the shared
+  // `shouldSeedResearchDefault` helper; RHF owns the state. `lastSeededResearch`
+  // tracks the last-seeded capability (seeded from the fresh form's construction
+  // value) so a no-change resolve is a no-op.
   const researchDirty = !!methods.formState.dirtyFields.researchCompany;
+  const lastSeededResearch = useRef<boolean | null>(
+    startedFresh.current ? (caps.isSuccess ? supportsWebSearch : null) : null
+  );
   useEffect(() => {
-    if (seededResearch.current || !startedFresh.current || !caps.isSuccess) return;
-    seededResearch.current = true;
-    if (!researchDirty) {
-      methods.setValue('researchCompany', caps.data?.supportsWebSearch ?? false, {
-        shouldDirty: false,
-      });
-    }
-  }, [caps.isSuccess, caps.data, researchDirty, methods]);
+    if (!startedFresh.current) return;
+    const { seed, value } = shouldSeedResearchDefault({
+      capabilityResolved: caps.isSuccess,
+      supportsWebSearch,
+      userTouched: researchDirty,
+      lastSeededValue: lastSeededResearch.current,
+    });
+    if (!seed) return;
+    lastSeededResearch.current = value;
+    methods.setValue('researchCompany', value, { shouldDirty: false });
+  }, [caps.isSuccess, supportsWebSearch, researchDirty, methods]);
 
   const [referralOpen, setReferralOpen] = useState(false);
   const [questionsOpen, setQuestionsOpen] = useState(false);

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/lib/tailor-state.test.ts
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/lib/tailor-state.test.ts
@@ -9,9 +9,17 @@ describe('buildTailorDefaults', () => {
     expect(buildTailorDefaults(undefined).outputType).toBe('both');
   });
 
-  it('returns researchCompany false by default', () => {
+  it('returns researchCompany false by default (safe fallback)', () => {
     expect(buildTailorDefaults('text').researchCompany).toBe(false);
     expect(buildTailorDefaults().researchCompany).toBe(false);
+  });
+
+  it('honors the capability-driven researchCompany argument', () => {
+    // The caller passes the active model's `supportsWebSearch` so the toggle
+    // defaults ON for a web-search-capable model and OFF otherwise.
+    expect(buildTailorDefaults('text', true).researchCompany).toBe(true);
+    expect(buildTailorDefaults('text', false).researchCompany).toBe(false);
+    expect(buildTailorDefaults(undefined, true).researchCompany).toBe(true);
   });
 
   it('seeds resume from resumeText when provided', () => {

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/lib/tailor-state.ts
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/lib/tailor-state.ts
@@ -10,7 +10,17 @@ export interface TailorWizardState {
   researchCompany: boolean;
 }
 
-/** Seed defaults for a fresh job — resume pre-filled from the autopilot's base. */
-export function buildTailorDefaults(resumeText?: string): TailorWizardState {
-  return { resume: resumeText ?? '', outputType: 'both', researchCompany: false };
+/**
+ * Seed defaults for a fresh job — resume pre-filled from the autopilot's base.
+ *
+ * `researchCompany` is capability-driven: the caller passes the active model's
+ * `supportsWebSearch` so the "search company" toggle defaults ON for a model
+ * that can web-search and OFF otherwise. Defaults to `false` (the safe fallback
+ * used while the capability is still resolving, or when it can't).
+ */
+export function buildTailorDefaults(
+  resumeText?: string,
+  researchCompany = false
+): TailorWizardState {
+  return { resume: resumeText ?? '', outputType: 'both', researchCompany };
 }

--- a/apps/desktop/src/renderer/hooks/use-research-company-default.test.ts
+++ b/apps/desktop/src/renderer/hooks/use-research-company-default.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+
+import { createMockClient, renderHookWithClient } from '@/test-support';
+
+import { useResearchCompanyDefault } from './use-research-company-default';
+
+function clientWithWebSearch(supportsWebSearch: boolean) {
+  return createMockClient({
+    'ai.modelCapabilities': vi.fn().mockResolvedValue({ supportsWebSearch }),
+  });
+}
+
+/** Let the capability query resolve and its effect apply (macrotask settle). */
+async function settle() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+describe('useResearchCompanyDefault', () => {
+  it('defaults ON once a web-search-capable model resolves', async () => {
+    const { result } = renderHookWithClient(() => useResearchCompanyDefault(), {
+      client: clientWithWebSearch(true),
+    });
+    // Safe fallback while the capability is still resolving.
+    expect(result.current[0]).toBe(false);
+    await waitFor(() => expect(result.current[0]).toBe(true));
+  });
+
+  it('stays OFF for a model that cannot web-search', async () => {
+    const { result } = renderHookWithClient(() => useResearchCompanyDefault(), {
+      client: clientWithWebSearch(false),
+    });
+    await settle();
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('never clobbers an explicit user override on a late resolve', async () => {
+    const { result } = renderHookWithClient(() => useResearchCompanyDefault(), {
+      client: clientWithWebSearch(true),
+    });
+    // User turns it OFF before the capability resolves.
+    act(() => result.current[1](false));
+    // Capability then resolves to ON — but the user's choice must win.
+    await settle();
+    expect(result.current[0]).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/hooks/use-research-company-default.test.ts
+++ b/apps/desktop/src/renderer/hooks/use-research-company-default.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, waitFor } from '@testing-library/react';
 
+import { usePreferencesStore } from '@/store/preferences-store';
 import { createMockClient, renderHookWithClient } from '@/test-support';
 
 import { useResearchCompanyDefault } from './use-research-company-default';
@@ -11,12 +12,41 @@ function clientWithWebSearch(supportsWebSearch: boolean) {
   });
 }
 
+/**
+ * A client whose capability answer depends on the requested model — lets a test
+ * drive a mid-session model switch (via the preferences store) and observe the
+ * default follow it. Only `searcher` can web-search.
+ */
+function clientByModel() {
+  return createMockClient({
+    'ai.modelCapabilities': vi.fn(({ model }: { model: string }) =>
+      Promise.resolve({ supportsWebSearch: model === 'searcher' })
+    ),
+  });
+}
+
+/** Point the active provider/model at `model` (drives the capability query key). */
+function useModel(model: string) {
+  act(() =>
+    usePreferencesStore.getState().setAiProviderConfig({
+      activeProvider: 'ollama',
+      providers: { ollama: { model } },
+    })
+  );
+}
+
 /** Let the capability query resolve and its effect apply (macrotask settle). */
 async function settle() {
   await act(async () => {
     await new Promise((r) => setTimeout(r, 0));
   });
 }
+
+// The preferences store is a persisted singleton — reset the model config so each
+// test starts from a known active provider/model.
+beforeEach(() => {
+  usePreferencesStore.setState({ aiProviderConfig: undefined });
+});
 
 describe('useResearchCompanyDefault', () => {
   it('defaults ON once a web-search-capable model resolves', async () => {
@@ -43,6 +73,40 @@ describe('useResearchCompanyDefault', () => {
     // User turns it OFF before the capability resolves.
     act(() => result.current[1](false));
     // Capability then resolves to ON — but the user's choice must win.
+    await settle();
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('re-seeds when the model changes mid-session while still untouched', async () => {
+    useModel('plain');
+    const { result } = renderHookWithClient(() => useResearchCompanyDefault(), {
+      client: clientByModel(),
+    });
+    await settle();
+    expect(result.current[0]).toBe(false);
+
+    // Switch to a web-search-capable model — the untouched default follows it.
+    useModel('searcher');
+    await waitFor(() => expect(result.current[0]).toBe(true));
+
+    // Switch back to a plain model — the default follows again.
+    useModel('plain');
+    await waitFor(() => expect(result.current[0]).toBe(false));
+  });
+
+  it('keeps the user override across a mid-session model change', async () => {
+    useModel('searcher');
+    const { result } = renderHookWithClient(() => useResearchCompanyDefault(), {
+      client: clientByModel(),
+    });
+    await waitFor(() => expect(result.current[0]).toBe(true));
+
+    // User turns it OFF — an explicit choice.
+    act(() => result.current[1](false));
+    expect(result.current[0]).toBe(false);
+
+    // A later model switch must NOT resurrect the capability default.
+    useModel('plain');
     await settle();
     expect(result.current[0]).toBe(false);
   });

--- a/apps/desktop/src/renderer/hooks/use-research-company-default.ts
+++ b/apps/desktop/src/renderer/hooks/use-research-company-default.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { useActiveModelCapabilities } from '@/services';
+
+/**
+ * Local "search company" toggle whose INITIAL default is capability-driven: ON
+ * when the active model can web-search, OFF otherwise. Drop-in for `useState`,
+ * returning `[value, setValue]`.
+ *
+ * Starts `false` (the safe fallback while the capability is still resolving),
+ * then flips to the model's `supportsWebSearch` exactly once — and never after
+ * the user has toggled it (tracked via a ref) — so an explicit override is never
+ * clobbered on re-render or a late resolve. Only the initial default is
+ * capability-driven.
+ */
+export function useResearchCompanyDefault(): readonly [boolean, (v: boolean) => void] {
+  const { data, isSuccess } = useActiveModelCapabilities();
+  const [value, setValueState] = useState(false);
+  const userTouched = useRef(false);
+  const applied = useRef(false);
+
+  useEffect(() => {
+    if (userTouched.current || applied.current || !isSuccess) return;
+    applied.current = true;
+    setValueState(data?.supportsWebSearch ?? false);
+  }, [isSuccess, data]);
+
+  const setValue = (v: boolean) => {
+    userTouched.current = true;
+    setValueState(v);
+  };
+
+  return [value, setValue] as const;
+}

--- a/apps/desktop/src/renderer/hooks/use-research-company-default.ts
+++ b/apps/desktop/src/renderer/hooks/use-research-company-default.ts
@@ -1,29 +1,44 @@
 import { useEffect, useRef, useState } from 'react';
 
+import { shouldSeedResearchDefault } from '@/lib/research-company-default';
 import { useActiveModelCapabilities } from '@/services';
 
 /**
- * Local "search company" toggle whose INITIAL default is capability-driven: ON
- * when the active model can web-search, OFF otherwise. Drop-in for `useState`,
- * returning `[value, setValue]`.
+ * Local "search company" toggle whose default is capability-driven: ON when the
+ * active model can web-search, OFF otherwise. Drop-in for `useState`, returning
+ * `[value, setValue]`.
  *
- * Starts `false` (the safe fallback while the capability is still resolving),
- * then flips to the model's `supportsWebSearch` exactly once — and never after
- * the user has toggled it (tracked via a ref) — so an explicit override is never
- * clobbered on re-render or a late resolve. Only the initial default is
- * capability-driven.
+ * The default FOLLOWS the active model: it seeds on the first capability resolve
+ * and re-seeds when a mid-session model switch flips the capability — as long as
+ * the user hasn't manually toggled it (an explicit choice is sticky and never
+ * clobbered). The seed DECISION is the shared {@link shouldSeedResearchDefault}
+ * helper; this hook only owns the `useState` + ref plumbing.
+ *
+ * Flash: `useState` is lazily initialized from the capability query, which uses a
+ * long staleTime — so on any load AFTER the first-ever one the value is already
+ * cached and there is no ON-flash. The first-EVER (uncached) load starts `false`
+ * and flips once the async query resolves; that single frame is inherent to async
+ * resolution and not worth heavier machinery to shave.
  */
 export function useResearchCompanyDefault(): readonly [boolean, (v: boolean) => void] {
   const { data, isSuccess } = useActiveModelCapabilities();
-  const [value, setValueState] = useState(false);
+  const supportsWebSearch = data?.supportsWebSearch ?? false;
+
+  const [value, setValueState] = useState(() => (isSuccess ? supportsWebSearch : false));
   const userTouched = useRef(false);
-  const applied = useRef(false);
+  const lastSeeded = useRef<boolean | null>(isSuccess ? supportsWebSearch : null);
 
   useEffect(() => {
-    if (userTouched.current || applied.current || !isSuccess) return;
-    applied.current = true;
-    setValueState(data?.supportsWebSearch ?? false);
-  }, [isSuccess, data]);
+    const { seed, value: next } = shouldSeedResearchDefault({
+      capabilityResolved: isSuccess,
+      supportsWebSearch,
+      userTouched: userTouched.current,
+      lastSeededValue: lastSeeded.current,
+    });
+    if (!seed) return;
+    lastSeeded.current = next;
+    setValueState(next);
+  }, [isSuccess, supportsWebSearch]);
 
   const setValue = (v: boolean) => {
     userTouched.current = true;

--- a/apps/desktop/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/desktop/src/renderer/lib/mock-client/mock-client.ts
@@ -100,6 +100,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       hasProviderKey: async () => ({ has: false }),
       testProviderKey: async () => ({ success: true }),
       listProviderModels: emptyList,
+      modelCapabilities: async () => ({ supportsWebSearch: false }),
       embeddingStatus: async () => ({
         active: { provider: 'ollama', model: 'nomic-embed-text' },
         spaces: [],

--- a/apps/desktop/src/renderer/lib/research-company-default.test.ts
+++ b/apps/desktop/src/renderer/lib/research-company-default.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldSeedResearchDefault } from './research-company-default';
+
+describe('shouldSeedResearchDefault', () => {
+  it('does not seed until the capability resolves', () => {
+    expect(
+      shouldSeedResearchDefault({
+        capabilityResolved: false,
+        supportsWebSearch: true,
+        userTouched: false,
+        lastSeededValue: null,
+      })
+    ).toEqual({ seed: false, value: true });
+  });
+
+  it('seeds the resolved capability on the first resolve (never seeded yet)', () => {
+    expect(
+      shouldSeedResearchDefault({
+        capabilityResolved: true,
+        supportsWebSearch: true,
+        userTouched: false,
+        lastSeededValue: null,
+      })
+    ).toEqual({ seed: true, value: true });
+
+    expect(
+      shouldSeedResearchDefault({
+        capabilityResolved: true,
+        supportsWebSearch: false,
+        userTouched: false,
+        lastSeededValue: null,
+      })
+    ).toEqual({ seed: true, value: false });
+  });
+
+  it('does not re-seed a value already applied', () => {
+    expect(
+      shouldSeedResearchDefault({
+        capabilityResolved: true,
+        supportsWebSearch: true,
+        userTouched: false,
+        lastSeededValue: true,
+      }).seed
+    ).toBe(false);
+  });
+
+  it('re-seeds when a mid-session model switch flips the capability (still untouched)', () => {
+    // Was seeded ON for a searcher, model switched to a non-searcher.
+    expect(
+      shouldSeedResearchDefault({
+        capabilityResolved: true,
+        supportsWebSearch: false,
+        userTouched: false,
+        lastSeededValue: true,
+      })
+    ).toEqual({ seed: true, value: false });
+
+    // Was seeded OFF, model switched to a web-search-capable one.
+    expect(
+      shouldSeedResearchDefault({
+        capabilityResolved: true,
+        supportsWebSearch: true,
+        userTouched: false,
+        lastSeededValue: false,
+      })
+    ).toEqual({ seed: true, value: true });
+  });
+
+  it('never seeds once the user has toggled it — the explicit choice is sticky', () => {
+    // Capability flips ON but the user turned it OFF: no clobber.
+    expect(
+      shouldSeedResearchDefault({
+        capabilityResolved: true,
+        supportsWebSearch: true,
+        userTouched: true,
+        lastSeededValue: false,
+      }).seed
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/lib/research-company-default.ts
+++ b/apps/desktop/src/renderer/lib/research-company-default.ts
@@ -1,0 +1,45 @@
+/**
+ * The core decision for the capability-driven "search company" toggle default,
+ * shared by every consumer so the little state machine can't drift between them.
+ * Pure (no React) → unit-testable in isolation. Each consumer still owns its own
+ * state plumbing (`useState` vs react-hook-form); only the DECISION lives here.
+ */
+export interface SeedResearchDefaultInput {
+  /** The active-model capability query has resolved (success). */
+  capabilityResolved: boolean;
+  /** The active model can web-search — the value the toggle should default to. */
+  supportsWebSearch: boolean;
+  /** The user has manually toggled the control; their explicit choice is sticky. */
+  userTouched: boolean;
+  /**
+   * The capability value written by the last seed, or `null` if never seeded. A
+   * tracked value (not a one-shot flag) so a mid-session model switch that FLIPS
+   * the capability re-seeds, while a resolve that doesn't change it is a no-op.
+   */
+  lastSeededValue: boolean | null;
+}
+
+export interface SeedResearchDefaultDecision {
+  /** Apply `value` to the toggle. */
+  seed: boolean;
+  /** The value to write when `seed` is true. */
+  value: boolean;
+}
+
+/**
+ * Decide whether to (re)seed the "search company" toggle from the active model's
+ * web-search capability:
+ * - an explicit user choice always wins (never clobbered),
+ * - nothing seeds until the capability resolves,
+ * - it seeds on the first resolve AND re-seeds whenever a mid-session model
+ *   switch flips the capability — but never re-writes a value already applied.
+ */
+export function shouldSeedResearchDefault({
+  capabilityResolved,
+  supportsWebSearch,
+  userTouched,
+  lastSeededValue,
+}: SeedResearchDefaultInput): SeedResearchDefaultDecision {
+  if (userTouched || !capabilityResolved) return { seed: false, value: supportsWebSearch };
+  return { seed: lastSeededValue !== supportsWebSearch, value: supportsWebSearch };
+}

--- a/apps/desktop/src/renderer/services/query-client/query-client.ts
+++ b/apps/desktop/src/renderer/services/query-client/query-client.ts
@@ -70,6 +70,7 @@ export const keys = {
   jobs: { all: ['jobs'] as const, detail: (id: string) => ['jobs', id] as const },
   ai: {
     models: ['ai', 'models'] as const,
+    capabilities: ['ai', 'capabilities'] as const,
     embeddingStatus: ['ai', 'embeddingStatus'] as const,
   },
   documents: {

--- a/apps/desktop/src/renderer/services/use-ai-provider/use-ai-provider.ts
+++ b/apps/desktop/src/renderer/services/use-ai-provider/use-ai-provider.ts
@@ -126,3 +126,28 @@ export const useGenerateConfig = () => {
     effort: settings?.effort,
   };
 };
+
+/**
+ * Static capabilities of a provider/model (currently just web-search support),
+ * read straight from the Rust `ModelCapabilities` matrix — never a TS mirror, so
+ * a new provider is picked up with zero renderer change. Cheap + rarely-changing,
+ * so cached for a long while.
+ */
+export const useModelCapabilities = (provider: string, model: string, baseUrl?: string) => {
+  const api = useAppClient();
+  return useQuery({
+    queryKey: [...keys.ai.capabilities, provider, model, baseUrl ?? ''],
+    queryFn: () => api.ai.modelCapabilities({ provider, model, baseUrl }),
+    staleTime: QUERY_TIMES.VERY_LONG,
+  });
+};
+
+/**
+ * Capabilities for the ACTIVE provider/model — the single source both tailoring
+ * wizards read to default the "search company" toggle ON when the selected model
+ * can web-search, OFF otherwise.
+ */
+export const useActiveModelCapabilities = () => {
+  const { provider, model, baseUrl } = useGenerateConfig();
+  return useModelCapabilities(provider, model, baseUrl);
+};

--- a/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
+++ b/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
@@ -84,6 +84,15 @@ export const ai = {
     invoke('ai_test_provider_key', { provider, baseUrl }),
   listProviderModels: ({ provider, baseUrl }: { provider: string; baseUrl?: string }) =>
     invoke('ai_list_provider_models', { provider, baseUrl }),
+  modelCapabilities: ({
+    provider,
+    model,
+    baseUrl,
+  }: {
+    provider: string;
+    model?: string;
+    baseUrl?: string;
+  }) => invoke('ai_model_capabilities', { provider, model, baseUrl }),
   embeddingStatus: () => invoke('ai_embedding_status'),
   setEmbeddingConfig: ({
     provider,

--- a/packages/shared/src/ipc/contracts/ai.ts
+++ b/packages/shared/src/ipc/contracts/ai.ts
@@ -118,6 +118,22 @@ export interface AiContract {
    */
   listProviderModels(req: { provider: string; baseUrl?: string }): Promise<Array<{ name: string }>>;
 
+  /**
+   * Static, network-free capability probe for a provider/model — currently just
+   * whether it can attempt a web-grounded company/role search. Reads the Rust
+   * `ModelCapabilities` matrix (the same value the backend gates `research*` on),
+   * so the renderer never mirrors the per-provider booleans and a new provider
+   * needs zero TS change. Drives the capability-driven default of the tailoring
+   * "search company" toggle. Unknown/unresolvable providers degrade to
+   * `{ supportsWebSearch: false }`. `baseUrl` is forwarded for OpenAI-compatible
+   * servers.
+   */
+  modelCapabilities(req: {
+    provider: string;
+    model?: string;
+    baseUrl?: string;
+  }): Promise<{ supportsWebSearch: boolean }>;
+
   /** Active embedding space, per-space vector counts, and document index coverage. */
   embeddingStatus(): Promise<EmbeddingStatus>;
 


### PR DESCRIPTION
Post-audit issue #1 — make the "search company" (web-grounded research) default in the tailoring wizards **capability-driven** instead of hardcoded off.

## What
- New network-free `ai_model_capabilities(provider, model?, baseUrl?) → { supportsWebSearch }` command that exposes the existing Rust `ModelCapabilities.supports_web_search` to the renderer. **Read straight from Rust** — no per-provider list mirrored in TS, so a new provider needs zero renderer change.
- `useResearchCompanyDefault` hook; both wizards (AI Generate + TailorFlow) now default the "search company" toggle **ON iff the selected model supports web search** (Anthropic/Gemini/Ollama/native OpenAI/CLI = yes; openai-compatible gateway = no).
- A user override or a restored/persisted form always wins over the capability seed (only the initial default is capability-driven).

## Notes
- Plain-arg command (no Zod DTO), so `gen:ipc:check` is unaffected.
- Tests: Rust capability-per-provider, the hook (ON flips / OFF stays / late-resolve doesn't clobber an override), TailorFlow fresh-vs-restored defaults.

## Verification
`gen:ipc:check`, `turbo run typecheck --force` (0 errors), `lint:strict`, cargo fmt/check/clippy, and the JS/shared suites (1976 + 147) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability-based detection for AI model web-search support.
  * The “research company” toggle now defaults based on the active model’s capabilities, while still allowing users to override it.

* **Bug Fixes**
  * Restored saved form selections now take precedence over automatic defaults.
  * Late-loading capability results no longer overwrite a user’s chosen setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->