### PR TITLE
fix: dedup indeed imports by job id and link generation docs via fk

### DIFF
--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -950,8 +950,10 @@ fn explicit_scheme(input: &str) -> Option<String> {
 }
 
 /// Normalize a job URL into a stable dedup key: lowercase host, strip a leading
-/// `www.`, drop the query (`?…`) and fragment (`#…`), and trim a trailing `/`.
-/// The scheme is preserved (lowercased). Empty input returns empty.
+/// `www.`, drop the fragment (`#…`), retain only per-host *identifying* query
+/// params (e.g. Indeed `jk`) while dropping every other query param (utm_*, ref,
+/// tracking), and trim a trailing `/`. The scheme is preserved (lowercased). Empty
+/// input returns empty.
 ///
 /// Security chokepoint: an input carrying an explicit scheme other than
 /// `http`/`https` (e.g. `javascript:`, `data:`, `file:`, `vbscript:`, `blob:`) is
@@ -979,12 +981,21 @@ pub fn normalize_job_url(url: &str) -> String {
         Some((s, r)) => (Some(s.to_string()), r.to_string()),
         None => (None, lower.clone()),
     };
-    let no_qf = rest.split(['?', '#']).next().unwrap_or(&rest).to_string();
-    let (host, path) = match no_qf.split_once('/') {
+    // Drop the fragment (`#…`) unconditionally, then split the query off the path so
+    // per-host identifying params can be selectively retained below.
+    let no_frag = rest.split('#').next().unwrap_or(&rest);
+    let (path_part, query) = match no_frag.split_once('?') {
+        Some((p, q)) => (p, q),
+        None => (no_frag, ""),
+    };
+    let (host, path) = match path_part.split_once('/') {
         Some((h, p)) => (h.to_string(), Some(p.to_string())),
-        None => (no_qf.clone(), None),
+        None => (path_part.to_string(), None),
     };
     let host = host.strip_prefix("www.").unwrap_or(&host).to_string();
+    // Keep ONLY the host's identifying query params (utm_*, ref, … are dropped);
+    // hosts with no allowlist entry drop the whole query, exactly as before.
+    let retained_query = retain_identifying_params(&host, query);
     let mut out = String::new();
     if let Some(s) = scheme {
         out.push_str(&s);
@@ -998,7 +1009,46 @@ pub fn normalize_job_url(url: &str) -> String {
             out.push_str(p);
         }
     }
+    if !retained_query.is_empty() {
+        out.push('?');
+        out.push_str(&retained_query);
+    }
     out
+}
+
+/// Per-host allowlist of *identifying* query params that must survive normalization
+/// (every other query param — utm_*, ref, tracking — is dropped, and hosts absent
+/// here drop the entire query). Keep in sync with the canonical URL builders in
+/// `scraping::scrape_url` that place a job id in the query string: currently only
+/// Indeed (`/viewjob?jk=<id>`). LinkedIn et al. put the id in the PATH, so they need
+/// no entry here and normalize exactly as before.
+fn identifying_query_params(host: &str) -> &'static [&'static str] {
+    if host == "indeed.com" || host.ends_with(".indeed.com") {
+        &["jk"]
+    } else {
+        &[]
+    }
+}
+
+/// Rebuild the query string keeping only `identifying_query_params(host)`, emitted
+/// in the allowlist's own fixed order so the input param ordering can never change
+/// the dedup key. A param with an empty value is skipped. Returns "" when nothing is
+/// retained (the common, path-based case).
+fn retain_identifying_params(host: &str, query: &str) -> String {
+    let allow = identifying_query_params(host);
+    if allow.is_empty() || query.is_empty() {
+        return String::new();
+    }
+    allow
+        .iter()
+        .filter_map(|key| {
+            query.split('&').find_map(|pair| {
+                let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+                (k == *key && !v.is_empty()).then(|| format!("{key}={v}"))
+            })
+        })
+        .collect::<Vec<_>>()
+        .join("&")
 }
 
 /// Truncate `s` to at most `max_bytes`, never splitting a UTF-8 char.

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -142,6 +142,48 @@ fn scheme_less_input_with_colon_in_path_is_not_misclassified() {
 }
 
 #[test]
+fn retains_per_host_identifying_query_params_for_dedup() {
+    // Indeed carries the job id in the query (`?jk=<id>`). Two DISTINCT ids must
+    // yield two DISTINCT keys — the collision bug was that every Indeed job
+    // normalized to a single `/viewjob` key and merged onto one Application.
+    assert_ne!(
+        normalize_job_url("https://indeed.com/viewjob?jk=aaa"),
+        normalize_job_url("https://indeed.com/viewjob?jk=bbb")
+    );
+    // The identifying param survives verbatim (lowercased with the rest of the url).
+    assert_eq!(
+        normalize_job_url("https://www.indeed.com/viewjob?jk=abc123"),
+        "https://indeed.com/viewjob?jk=abc123"
+    );
+    // Country TLD (de.indeed.com) is covered by the `.indeed.com` suffix match.
+    assert_eq!(
+        normalize_job_url("https://de.indeed.com/viewjob?jk=xyz"),
+        "https://de.indeed.com/viewjob?jk=xyz"
+    );
+    // Same job, tracking-only query differences → SAME key (jk retained, the rest
+    // dropped). Param ORDER must not matter — allowlist order is authoritative.
+    assert_eq!(
+        normalize_job_url("https://indeed.com/viewjob?jk=abc&from=serp&utm_source=x"),
+        normalize_job_url("https://indeed.com/viewjob?utm_campaign=y&jk=abc")
+    );
+    assert_eq!(
+        normalize_job_url("https://indeed.com/viewjob?jk=abc&from=serp&utm_source=x"),
+        "https://indeed.com/viewjob?jk=abc"
+    );
+    // Path-based URL on a non-allowlisted host is UNCHANGED: the whole query is still
+    // dropped (LinkedIn puts the id in the path, so it is unaffected by this fix).
+    assert_eq!(
+        normalize_job_url("https://www.linkedin.com/jobs/view/12345?trk=abc&refId=z"),
+        "https://linkedin.com/jobs/view/12345"
+    );
+    // A non-Indeed host never retains a query param, even a `jk` lookalike.
+    assert_eq!(
+        normalize_job_url("https://acme.example/viewjob?jk=abc"),
+        "https://acme.example/viewjob"
+    );
+}
+
+#[test]
 fn status_from_id_is_relaxed_and_round_trips() {
     for &s in ApplicationStatus::ALL {
         assert_eq!(ApplicationStatus::from_id(s.as_id()), s);

--- a/apps/desktop/src-tauri/src/commands/ai_generations.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_generations.rs
@@ -13,7 +13,7 @@ pub async fn ai_generations_list(app: AppHandle) -> Value {
 pub async fn ai_generations_save(app: AppHandle, req: AiGenerationSaveRequest) -> Value {
     let store = app.state::<crate::ai_generations::AiGenerationStore>();
 
-    let rec = crate::ai_generations::AiGenerationRecord {
+    let mut rec = crate::ai_generations::AiGenerationRecord {
         id: crate::ai_generations::make_generation_id(),
         created_at: crate::db::now_ms(),
         candidate_name: req.candidate_name,
@@ -73,17 +73,22 @@ pub async fn ai_generations_save(app: AppHandle, req: AiGenerationSaveRequest) -
         salary_currency: None,
     };
     if let Some(apps) = app.try_state::<crate::applications::ApplicationStore>() {
-        if let Err(e) = apps.upsert_for_origin(
+        match apps.upsert_for_origin(
             &job_url,
             &board,
             &meta,
             crate::applications::ApplicationOrigin::Generate,
             None,
         ) {
-            // Non-fatal: a failed Application upsert must not lose the generation
-            // the user just produced. The generation save below is the user-visible
-            // action; the aggregate can be re-derived.
-            log::warn!("[ai_generations] application upsert failed (non-fatal): {e}");
+            // Link the generation to its parent Application via the FK so the detail
+            // page can join docs by `application_id` instead of a raw-vs-normalized
+            // url string compare (which never matches for query-id boards like Indeed:
+            // the Application stores the normalized url, the generation the raw one).
+            Ok(app_id) => rec.application_id = Some(app_id),
+            // Non-fatal: a failed Application upsert must not lose the generation the
+            // user just produced. The generation save below is the user-visible action;
+            // the aggregate (and the FK, via boot-time backfill) can be re-derived.
+            Err(e) => log::warn!("[ai_generations] application upsert failed (non-fatal): {e}"),
         }
     }
 

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
@@ -210,14 +210,19 @@ function makeApp(overrides: Partial<Application> = {}): Application {
 }
 
 /**
- * Minimal generation fixture. Only `id` and `jobUrl` are read by the
- * component's filter; `GenerationCard` itself is stubbed, so the rest
- * of the AiGenerationRecord fields are cast placeholders.
+ * Minimal generation fixture. The component now joins docs by the `applicationId`
+ * FK (not `jobUrl`); `GenerationCard` itself is stubbed, so the rest of the
+ * AiGenerationRecord fields are cast placeholders.
  */
-function makeGen(overrides: { id: string; jobUrl: string }): AiGenerationRecord {
+function makeGen(overrides: {
+  id: string;
+  jobUrl: string;
+  applicationId?: string;
+}): AiGenerationRecord {
   return {
     id: overrides.id,
     jobUrl: overrides.jobUrl,
+    applicationId: overrides.applicationId,
     createdAt: 0,
     candidateName: '',
     jobTitle: '',
@@ -272,8 +277,8 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
     });
     mockUseAiGenerations.mockReturnValue({
       data: [
-        makeGen({ id: 'gen-1', jobUrl: 'https://acme.com/job/1' }),
-        makeGen({ id: 'gen-2', jobUrl: 'https://other.com/x' }),
+        makeGen({ id: 'gen-1', jobUrl: 'https://acme.com/job/1', applicationId: 'app-1' }),
+        makeGen({ id: 'gen-2', jobUrl: 'https://other.com/x', applicationId: 'app-2' }),
       ],
     });
 
@@ -295,7 +300,13 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
       isError: false,
     });
     mockUseAiGenerations.mockReturnValue({
-      data: [makeGen({ id: 'gen-x', jobUrl: 'https://different.com/job/99' })],
+      data: [
+        makeGen({
+          id: 'gen-x',
+          jobUrl: 'https://different.com/job/99',
+          applicationId: 'app-other',
+        }),
+      ],
     });
 
     render(<ApplicationDetailPage />);
@@ -316,14 +327,14 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
     });
     mockUseAiGenerations.mockReturnValue({
       data: [
-        makeGen({ id: 'gen-1', jobUrl: 'https://acme.com/job/1' }),
-        makeGen({ id: 'gen-2', jobUrl: 'https://other.com/x' }),
+        makeGen({ id: 'gen-1', jobUrl: 'https://acme.com/job/1', applicationId: 'app-1' }),
+        makeGen({ id: 'gen-2', jobUrl: 'https://other.com/x', applicationId: 'app-2' }),
       ],
     });
 
     render(<ApplicationDetailPage />);
 
-    // Only gen-1 matches the application's jobUrl → it seeds the flow.
+    // Only gen-1 carries this application's FK → it seeds the flow.
     expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toHaveAttribute(
       'data-seedgenid',
       'gen-1'
@@ -340,7 +351,13 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
       isError: false,
     });
     mockUseAiGenerations.mockReturnValue({
-      data: [makeGen({ id: 'gen-x', jobUrl: 'https://different.com/job/99' })],
+      data: [
+        makeGen({
+          id: 'gen-x',
+          jobUrl: 'https://different.com/job/99',
+          applicationId: 'app-other',
+        }),
+      ],
     });
 
     render(<ApplicationDetailPage />);
@@ -348,10 +365,12 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
     expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toHaveAttribute('data-seedgenid', '');
   });
 
-  it('does NOT match generations when the application jobUrl is empty', () => {
-    // The component's guard: `appUrl !== '' && g.jobUrl.trim() === appUrl`
+  it('does NOT match a generation whose applicationId differs from this application', () => {
+    // Docs join by the `applicationId` FK, not by url — a generation linked to a
+    // DIFFERENT Application (or unlinked) must not surface here, even if its url
+    // happens to match.
     mockTab = 'documents';
-    const app = makeApp({ jobUrl: '' });
+    const app = makeApp({ id: 'app-1' });
 
     mockUseApplication.mockReturnValue({
       data: { application: app, events: [] },
@@ -359,7 +378,9 @@ describe('ApplicationDetailPage — generation matching (Documents tab)', () => 
       isError: false,
     });
     mockUseAiGenerations.mockReturnValue({
-      data: [makeGen({ id: 'gen-z', jobUrl: '' })],
+      data: [
+        makeGen({ id: 'gen-z', jobUrl: 'https://acme.com/job/1', applicationId: 'app-other' }),
+      ],
     });
 
     render(<ApplicationDetailPage />);

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
@@ -287,11 +287,13 @@ function ApplicationDetailLoaded({ application, events, onBack, backLabel }: Loa
     void setStatus.mutateAsync({ id: application.id, status });
   };
 
-  // Documents are display-joined to this application by `jobUrl`. v1 uses a
-  // trim-only comparison; normalization parity (case/scheme/query) is a follow-up.
-  const appUrl = application.jobUrl.trim();
+  // Documents are display-joined to this application by the `applicationId` FK
+  // (set on the generation at save time; legacy rows are backfilled at boot). A
+  // raw-vs-normalized `jobUrl` string compare never matches for query-id boards
+  // like Indeed — the Application stores the normalized url, the generation the raw
+  // one — so the FK is the robust link.
   const matchingGenerations = (aiGenerations.data ?? []).filter(
-    (g) => appUrl !== '' && g.jobUrl.trim() === appUrl
+    (g) => g.applicationId === application.id
   );
 
   const orderedEvents = [...events].sort((a, b) => b.at - a.at);

--- a/apps/desktop/src/renderer/services/use-applications/use-applications.ts
+++ b/apps/desktop/src/renderer/services/use-applications/use-applications.ts
@@ -106,6 +106,14 @@ export const useApplicationEvents = (onChanged?: (event: ApplicationChangedEvent
   useEffect(() => {
     const off = api.applications.onChanged((event) => {
       void qc.invalidateQueries({ queryKey: keys.applications.all });
+      // An open detail page for the imported application must refresh too — its
+      // status/docs can change on import (e.g. an Indeed import that now lands on the
+      // right row). Invalidate the exact detail key explicitly so it refetches.
+      if (event.applicationId) {
+        void qc.invalidateQueries({
+          queryKey: keys.applications.detail(event.applicationId),
+        });
+      }
       // A new application created from a posting flips that posting's "applied" badge,
       // so the postings list must refresh too.
       void qc.invalidateQueries({ queryKey: keys.postings.all });

--- a/packages/shared/src/ipc/contracts/aiGenerations.ts
+++ b/packages/shared/src/ipc/contracts/aiGenerations.ts
@@ -25,6 +25,13 @@ export interface AiGenerationRecord {
   companyBrief: string;
   /** AI-suggested questions the candidate can ASK the interviewer, if any. */
   interviewQuestions: InterviewQuestion[];
+  /**
+   * Parent Application FK — set at save time (and backfilled at boot for legacy
+   * rows). The Application detail page joins this generation's docs by this id, not
+   * by url, because the Application stores the NORMALIZED url and the generation the
+   * RAW one (they never match for query-id boards like Indeed). Absent when unlinked.
+   */
+  applicationId?: string;
 }
 
 export interface AiGenerationSaveRequest {


### PR DESCRIPTION
Post-audit issue #3 — importing an **Indeed** job (esp. with the Applications page open) went straight to `applied` instead of `saved`, and the Application detail page hid existing generated docs. Two root causes (not a status branch):

## (a) URL-normalization collision
`normalize_job_url` dropped the whole query string, but Indeed's job id lives in the query (`viewjob?jk=<id>`) — so **every** Indeed job collapsed to one dedup key and imports merged onto the first Application there (often a Generate-origin `applied` row). LinkedIn puts the id in the path, which is why this was Indeed-specific.

**Fix:** make `normalize_job_url` **additive** — retain a per-host allowlist of identifying query params (Indeed `jk`) while still dropping tracking params (`utm_*`, `ref`, param reorder). Path-based hosts normalize byte-for-byte as before. Distinct Indeed jobs now get distinct keys → correct `saved` dedup, and the stored URL is a valid openable link again.

## (b) Docs joined by raw URL
The detail page matched generations to the Application by raw `jobUrl` equality, but the Application stores the *normalized* URL and the generation stores the *raw* one → never matched for Indeed.

**Fix:** stamp `application_id` on the generation at **save** time (from the origin upsert that already runs first) and join the detail page on that **FK** instead of the URL. Boot-time backfill still covers legacy rows. Also invalidate the detail query on import so an open page refreshes.

## Verification
`gen:ipc:check`, `turbo run typecheck --force` (0 errors), `lint:strict`, cargo fmt/check/clippy, and the JS/shared suites (1969 + 147) pass. New Rust tests (jk retained, tracking dropped, LinkedIn unchanged) + updated detail-page FK-join tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)