### PR TITLE
fix: floor aggregator sub-day date filters to 3 days

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -70,22 +70,28 @@ where
 
 /// Map a UI date-filter token to Adzuna's `max_days_old` integer (whole days).
 ///
-// ponytail: Adzuna's recency granularity is whole days, so all sub-day options
-// collapse to 1 day (API ceiling). No filter / unrecognized token caps at 30 days
-// so the aggregator never surfaces postings older than a month.
+// ponytail: Adzuna's recency granularity is whole days — it can't do sub-day. A
+// 1-day ceiling zeroed out autopilot "recent" filters on quiet days (a normal
+// query returns near-nothing in a single day), so sub-day windows FLOOR at 3 days
+// and rely on the query's `sort_by=date` for freshness instead of a hard clamp.
+// No filter / unrecognized token caps at 30 days so the aggregator never surfaces
+// postings older than a month. (Coarse mapping; 3-day floor / 30-day ceiling.)
 fn adzuna_max_days_old(date_filter: Option<&str>) -> u32 {
     match date_filter {
-        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => 1,
+        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => 3,
         Some("week") => 7,
         _ => 30,
     }
 }
 
-/// Map a UI date-filter token to JSearch's `date_posted` query token. No filter /
-/// unrecognized token caps at `month` (results no older than the past month).
+/// Map a UI date-filter token to JSearch's `date_posted` query token
+/// (`all|today|3days|week|month`). Sub-day windows floor at `3days` — like Adzuna,
+/// JSearch has no sub-day granularity, and a `today` ceiling zeroed out autopilot
+/// "recent" filters on quiet days (results are date-sorted, so the freshest still
+/// surface first). No filter / unrecognized token caps at `month`.
 fn jsearch_date_posted(date_filter: Option<&str>) -> &'static str {
     match date_filter {
-        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => "today",
+        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => "3days",
         Some("week") => "week",
         _ => "month",
     }

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -87,8 +87,18 @@ fn adzuna_max_days_old(date_filter: Option<&str>) -> u32 {
 /// Map a UI date-filter token to JSearch's `date_posted` query token
 /// (`all|today|3days|week|month`). Sub-day windows floor at `3days` — like Adzuna,
 /// JSearch has no sub-day granularity, and a `today` ceiling zeroed out autopilot
-/// "recent" filters on quiet days (results are date-sorted, so the freshest still
-/// surface first). No filter / unrecognized token caps at `month`.
+/// "recent" filters on quiet days. The freshest still surface first because the
+/// JSearch request pairs this window with `&sort_by=date` (JSearch defaults to
+/// relevance, not recency — the sort param is what makes the guarantee true).
+/// No filter / unrecognized token caps at `month`.
+///
+// ponytail: intentional cross-provider recency skew for sub-day tokens (e.g.
+// `"24h"`). The free/cheap providers can't do sub-day granularity, so Adzuna
+// (`adzuna_max_days_old` → 3) and JSearch (here → `3days`) both widen to 3 days,
+// while the paid Apify/LinkedIn path (`apify_f_tpr` → `r86400`) keeps a strict
+// ≤24h window. Merged results therefore mix recency windows for sub-day filters —
+// the deliberate tradeoff (surface *something* over nothing on quiet days); a
+// future reader shouldn't "fix" the skew back into a hard clamp.
 fn jsearch_date_posted(date_filter: Option<&str>) -> &'static str {
     match date_filter {
         Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => "3days",
@@ -435,8 +445,12 @@ impl JobProvider for JSearchProvider {
             q_enc
         );
 
+        // Sort newest-first (JSearch defaults to relevance, which does NOT put the
+        // freshest posting on top) so the widened `date_posted` window still surfaces
+        // the most-recent jobs first — matching Adzuna's `sort_by=date` and honouring
+        // the freshness guarantee documented on `jsearch_date_posted`.
         url.push_str(&format!(
-            "&date_posted={}",
+            "&date_posted={}&sort_by=date",
             jsearch_date_posted(date_filter)
         ));
 

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -802,14 +802,17 @@ fn providers_degrade_to_unconfigured_on_keyring_error() {
 
 #[test]
 fn adzuna_max_days_old_maps_correctly() {
-    // All sub-day windows collapse to 1 day (Adzuna's day granularity).
-    assert_eq!(adzuna_max_days_old(Some("24h")), 1);
-    assert_eq!(adzuna_max_days_old(Some("8h")), 1);
-    assert_eq!(adzuna_max_days_old(Some("4h")), 1);
-    assert_eq!(adzuna_max_days_old(Some("2h")), 1);
-    assert_eq!(adzuna_max_days_old(Some("1h")), 1);
-    assert_eq!(adzuna_max_days_old(Some("30m")), 1);
-    assert_eq!(adzuna_max_days_old(Some("15m")), 1);
+    // All sub-day windows FLOOR at 3 days: Adzuna has no sub-day granularity, and a
+    // 1-day ceiling zeroed out autopilot "recent" filters on quiet days (regression
+    // guard). Date-sort still surfaces the freshest jobs first within the window.
+    assert_eq!(adzuna_max_days_old(Some("24h")), 3);
+    assert_eq!(adzuna_max_days_old(Some("8h")), 3);
+    assert_eq!(adzuna_max_days_old(Some("4h")), 3);
+    assert_eq!(adzuna_max_days_old(Some("2h")), 3);
+    assert_eq!(adzuna_max_days_old(Some("1h")), 3);
+    assert_eq!(adzuna_max_days_old(Some("30m")), 3);
+    assert_eq!(adzuna_max_days_old(Some("15m")), 3);
+    // Coarser tiers are unchanged.
     assert_eq!(adzuna_max_days_old(Some("week")), 7);
     assert_eq!(adzuna_max_days_old(Some("month")), 30);
     // No filter or an unknown token caps at the past month (30 days).
@@ -819,14 +822,16 @@ fn adzuna_max_days_old_maps_correctly() {
 
 #[test]
 fn jsearch_date_posted_maps_correctly() {
-    // All sub-day windows collapse to "today" (JSearch's finest token).
-    assert_eq!(jsearch_date_posted(Some("24h")), "today");
-    assert_eq!(jsearch_date_posted(Some("8h")), "today");
-    assert_eq!(jsearch_date_posted(Some("4h")), "today");
-    assert_eq!(jsearch_date_posted(Some("2h")), "today");
-    assert_eq!(jsearch_date_posted(Some("1h")), "today");
-    assert_eq!(jsearch_date_posted(Some("30m")), "today");
-    assert_eq!(jsearch_date_posted(Some("15m")), "today");
+    // All sub-day windows floor at "3days" (JSearch has no sub-day token, and
+    // "today" zeroed out autopilot "recent" filters on quiet days — regression guard).
+    assert_eq!(jsearch_date_posted(Some("24h")), "3days");
+    assert_eq!(jsearch_date_posted(Some("8h")), "3days");
+    assert_eq!(jsearch_date_posted(Some("4h")), "3days");
+    assert_eq!(jsearch_date_posted(Some("2h")), "3days");
+    assert_eq!(jsearch_date_posted(Some("1h")), "3days");
+    assert_eq!(jsearch_date_posted(Some("30m")), "3days");
+    assert_eq!(jsearch_date_posted(Some("15m")), "3days");
+    // Coarser tiers are unchanged.
     assert_eq!(jsearch_date_posted(Some("week")), "week");
     assert_eq!(jsearch_date_posted(Some("month")), "month");
     // No filter or an unknown token caps at the past month.
@@ -852,7 +857,10 @@ fn jsearch_date_posted_maps_correctly() {
 /// is required to have a real, non-default mapping).
 fn expected_mapping(token: &str) -> Option<(u32, &'static str)> {
     match token {
-        "15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h" => Some((1, "today")),
+        // Sub-day windows floor at 3 days ("3days" for JSearch) — see the doc-comments
+        // on `adzuna_max_days_old` / `jsearch_date_posted`. A tighter clamp zeroed out
+        // autopilot "recent" filters; date-sort keeps the freshest jobs on top.
+        "15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h" => Some((3, "3days")),
         "week" => Some((7, "week")),
         "month" => Some((30, "month")),
         _ => None,


### PR DESCRIPTION
Post-audit issue #6 — an **Autopilot on the Aggregator board** with a "Last 24h" (or any sub-day) date filter returned **zero** results, while the same search on the Jobs page (which defaults to *no* date filter → a 30-day window) returned results.

## Root cause
Adzuna (`max_days_old`) and JSearch (`date_posted`) have only **whole-day** recency granularity. The aggregator mapped every sub-day UI token (`15m`…`24h`) to the tightest window — Adzuna `max_days_old=1` / JSearch `"today"` — which returns near-zero on a quiet day. (Country was *not* the cause — both paths resolve Germany to `de`.)

## Fix
Floor the sub-day tier to **3 days** (Adzuna `max_days_old=3`, JSearch `"3days"`) and rely on the query's existing freshest-first sort (`&sort_by=date&sort_direction=down`). Coarser tiers and the no-filter default (30 days) are unchanged.

The paid **LinkedIn (Apify)** path keeps its exact sub-day window (`f_TPR=r86400`) — LinkedIn has real seconds-level recency, so it's accurate there, not a clamp.

## Tradeoff
A "Last 24h" aggregator filter now surfaces up-to-3-day-old jobs, freshest first, instead of nothing — the aggregator has no true sub-day granularity, so a 3-day floor + date-sort is the closest honest approximation of "recent".

## Verification
cargo fmt/check/clippy and `gen:ipc:check` pass; mapping unit tests + the exhaustiveness guard updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)