### PR TITLE
feat: fix gemini/codex cli providers on windows and add antigravity

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -52,6 +52,12 @@
           "cmd": "npm",
           "args": ["install", "-g", "@google/gemini-cli"],
           "sidecar": false
+        },
+        {
+          "name": "install-antigravity",
+          "cmd": "npm",
+          "args": ["install", "-g", "@google/antigravity"],
+          "sidecar": false
         }
       ]
     }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/antigravity.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/antigravity.rs
@@ -1,0 +1,220 @@
+//! Antigravity CLI backend — Google's `agy` CLI run headless with the prompt on stdin.
+//!
+//! **UNVERIFIED — implemented to the documented contract, not runtime-tested.**
+//! `agy` is not installed on the build/dev machine, so this backend has never been
+//! exercised end-to-end. Everything below follows Antigravity's published CLI docs
+//! plus community reports; the parsing is deliberately defensive and the specifics
+//! (flags, models, npm package) are provisional until a real `agy` install confirms
+//! them. Mirrors [`super::gemini_cli`] because the contract is the same shape.
+//!
+//! **Security posture (fail-closed):** the prompt inlines untrusted, scraped
+//! job-description text, so it is delivered on **stdin** ([`PromptDelivery::Stdin`]),
+//! never as an argv element — nothing prompt-derived reaches the command line (or,
+//! on Windows, `cmd.exe`; see the CVE-2024-24576 note on [`PromptDelivery`]). We pass
+//! **no flags at all**: no `-p` (the prompt is piped), and deliberately **no `--yes`**.
+//! `--yes` would auto-approve any tool action `agy` decides to take with no sandbox,
+//! so a prompt-injection in the untrusted JD could trigger auto-approved side effects
+//! (the reviewer's HIGH). We do not auto-approve. If `agy` blocks waiting for approval
+//! without `--yes`, that surfaces as empty output at verify time — fail-closed, which
+//! is acceptable for an unverified backend; RCE-by-argv and silent auto-approval are not.
+//!
+//! **Before this backend can be trusted**, a real `agy` install must confirm it
+//! (a) consumes a piped-stdin prompt in non-interactive mode, and (b) exposes a
+//! read-only / no-tools headless mode — only then is auto-approving anything safe to
+//! reconsider. Until then it stays UNVERIFIED and flag-free.
+//!
+//! Documented contract:
+//!  * Binary `agy`. Non-interactive: prompt piped on stdin (historically also
+//!    accepted `agy -p "<prompt>"` / `--prompt` / `--print`, which we no longer use).
+//!  * Output is **plain text on stdout** — there is no working JSON mode yet
+//!    (`--output-format json` currently errors "flags provided but not defined"),
+//!    so we parse plain-text stdout line-by-line like Gemini CLI, NOT JSONL like
+//!    Codex. The shared plain-text hygiene ([`super::is_cli_stdout_noise`]) strips
+//!    credential/telemetry noise so it never lands in the generated letter.
+//!  * Auth: `agy`'s own keyring / Google sign-in — keyless here, exactly like the
+//!    other CLI agents. `detect()` only checks the binary exists; no key is injected.
+//!
+//! KNOWN CAVEAT (upstream): under a non-TTY — which is how we always spawn it —
+//! `agy` can DROP the final response line on stdout. We capture stdout fully (a
+//! buffered line stream for `chat_stream`, `wait_with_output` for `complete`), which
+//! is the most a caller can do from outside the tool; a dropped tail is an upstream
+//! bug, not a parse bug here. Re-verify once `agy` is installed.
+//!
+//! Also UNVERIFIED and to confirm against a real install: a model-selection flag
+//! is intentionally NOT passed (an unknown flag makes `agy` hard-error, which would
+//! break every call), so `agy` currently runs its own configured/default model and
+//! the [`models`](CliAgentBackend::models) list is informational for the UI only.
+
+use async_trait::async_trait;
+
+use crate::commands::ai_provider::ProviderId;
+use crate::error::{AppError, AppResult};
+
+use super::{CliAgentBackend, CliEvent, CliInvocation, PromptDelivery};
+
+/// UNVERIFIED model aliases (Antigravity is Gemini-based). Informational for the
+/// UI dropdown — the selection is not forwarded on the command line yet (see the
+/// module docs), so `agy` uses its own configured/default model regardless.
+const MODELS: &[&str] = &["gemini-3-pro", "gemini-2.5-pro"];
+
+pub struct AntigravityAgent;
+
+#[async_trait]
+impl CliAgentBackend for AntigravityAgent {
+    fn id(&self) -> ProviderId {
+        ProviderId::Antigravity
+    }
+
+    fn default_binary(&self) -> &'static str {
+        "agy"
+    }
+
+    fn env_override(&self) -> &'static str {
+        "ANTIGRAVITY_BIN"
+    }
+
+    fn models(&self) -> &'static [&'static str] {
+        MODELS
+    }
+
+    // UNVERIFIED npm package name — the one-click install runs `npm install -g` on
+    // this and it must match the shell-capability allowlist entry. Correct it once
+    // `agy`'s real distribution channel is confirmed (it may not be an npm package
+    // at all, in which case the guide/docs path is the real install route).
+    fn install_package(&self) -> &'static str {
+        "@google/antigravity"
+    }
+
+    fn docs_url(&self) -> &'static str {
+        "https://antigravity.google/docs"
+    }
+
+    // No system-prompt flag (like Gemini CLI) — the harness inlines the system
+    // prompt onto the user prompt.
+    fn inline_system(&self) -> bool {
+        true
+    }
+
+    // Antigravity has no headless reasoning-effort flag — `effort` is ignored.
+    fn stream_invocation(
+        &self,
+        _model: &str,
+        _system: &str,
+        _effort: Option<&str>,
+    ) -> CliInvocation {
+        CliInvocation {
+            args: headless_args(),
+            // Prompt on stdin, not argv — see the security posture in the module
+            // docs. No flags (no `-p`, no `--yes`); the prompt is piped.
+            prompt: PromptDelivery::Stdin,
+        }
+    }
+
+    fn complete_invocation(
+        &self,
+        _model: &str,
+        _system: &str,
+        _effort: Option<&str>,
+    ) -> CliInvocation {
+        CliInvocation {
+            args: headless_args(),
+            prompt: PromptDelivery::Stdin,
+        }
+    }
+
+    fn parse_stream_line(&self, line: &str) -> Option<CliEvent> {
+        // Plain-text output: emit each stdout line, preserving line breaks so
+        // paragraphs survive; the harness marks completion on EOF. Drop the same
+        // credential/telemetry noise Gemini emits (agy shares the Google auth stack).
+        if super::is_cli_stdout_noise(line) {
+            return None;
+        }
+        Some(CliEvent::Delta(format!("{line}\n")))
+    }
+
+    fn parse_complete(&self, stdout: &str) -> AppResult<String> {
+        // Strip operational noise, rejoin (keeps the answer's paragraph breaks),
+        // then trim. Captures stdout fully — see the non-TTY caveat in the module docs.
+        let text = stdout
+            .lines()
+            .filter(|l| !super::is_cli_stdout_noise(l))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let text = text.trim();
+        if text.is_empty() {
+            return Err(AppError::Provider(
+                "Antigravity: empty response".to_string(),
+            ));
+        }
+        Ok(text.to_string())
+    }
+}
+
+/// `agy` — no flags. The prompt is piped on stdin (not `-p`), and we deliberately do
+/// NOT pass `--yes`: auto-approving tool actions on an untrusted, JD-derived prompt
+/// with no sandbox is the HIGH the reviewer flagged. No model flag either (see the
+/// module docs). Kept as a named helper so both invocations stay in lockstep and the
+/// "no `--yes`, no `-p`" invariant has one place to assert against.
+fn headless_args() -> Vec<String> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn streams_plain_text_and_filters_noise() {
+        assert_eq!(
+            AntigravityAgent.parse_stream_line("Hello"),
+            Some(CliEvent::Delta("Hello\n".to_string()))
+        );
+        // Blank lines survive as paragraph breaks…
+        assert_eq!(
+            AntigravityAgent.parse_stream_line(""),
+            Some(CliEvent::Delta("\n".to_string()))
+        );
+        // …credential noise does not.
+        assert_eq!(
+            AntigravityAgent.parse_stream_line("Loaded cached credentials."),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_complete_strips_noise_and_trims() {
+        let out = "Loaded cached credentials.\nDear Team,\n\nRegards.\n";
+        assert_eq!(
+            AntigravityAgent.parse_complete(out).unwrap(),
+            "Dear Team,\n\nRegards."
+        );
+        assert!(AntigravityAgent.parse_complete("   ").is_err());
+    }
+
+    #[test]
+    fn argv_is_empty_prompt_on_stdin_and_never_auto_approves() {
+        let inv = AntigravityAgent.stream_invocation("gemini-3-pro", "system text", None);
+        // Prompt delivered on stdin — no untrusted JD text in argv / `cmd.exe`
+        // (CVE-2024-24576).
+        assert_eq!(inv.prompt, PromptDelivery::Stdin);
+        // No prompt value flag…
+        assert!(!inv.args.iter().any(|a| a == "-p"));
+        // …and crucially NO `--yes`: never auto-approve tool actions on an untrusted
+        // prompt (the HIGH finding). argv is empty — nothing but the piped prompt.
+        assert!(!inv.args.iter().any(|a| a == "--yes"));
+        assert!(inv.args.is_empty());
+    }
+
+    #[test]
+    fn complete_invocation_also_never_auto_approves() {
+        let inv = AntigravityAgent.complete_invocation("gemini-3-pro", "system text", None);
+        assert_eq!(inv.prompt, PromptDelivery::Stdin);
+        assert!(!inv.args.iter().any(|a| a == "--yes"));
+        assert!(inv.args.is_empty());
+    }
+
+    #[test]
+    fn inlines_system_prompt() {
+        assert!(AntigravityAgent.inline_system());
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/codex.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/codex.rs
@@ -6,6 +6,12 @@
 //! ([`CliAgentBackend::inline_system`]). Authenticates with the user's ChatGPT
 //! login (or `OPENAI_API_KEY`). Output is surfaced at message granularity — robust
 //! across Codex versions whether or not token deltas are emitted.
+//!
+//! The (untrusted, JD-bearing) prompt is delivered on **stdin**
+//! ([`PromptDelivery::Stdin`]): `codex exec` reads the prompt from stdin when no
+//! positional prompt argument is given, so nothing prompt-derived ever reaches
+//! argv (and, on Windows, `cmd.exe` — see the CVE-2024-24576 note on
+//! [`PromptDelivery`]). argv holds only the fixed exec flags below.
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -52,7 +58,9 @@ impl CliAgentBackend for CodexAgent {
     fn stream_invocation(&self, model: &str, _system: &str, effort: Option<&str>) -> CliInvocation {
         CliInvocation {
             args: exec_args(model, effort),
-            prompt: PromptDelivery::Arg,
+            // Prompt on stdin, not argv — `codex exec` reads stdin when given no
+            // positional prompt. Keeps untrusted JD text off the command line.
+            prompt: PromptDelivery::Stdin,
         }
     }
 
@@ -64,7 +72,7 @@ impl CliAgentBackend for CodexAgent {
     ) -> CliInvocation {
         CliInvocation {
             args: exec_args(model, effort),
-            prompt: PromptDelivery::Arg,
+            prompt: PromptDelivery::Stdin,
         }
     }
 
@@ -129,6 +137,10 @@ fn exec_args(model: &str, effort: Option<&str>) -> Vec<String> {
         "--json".to_string(),
         "--sandbox".to_string(),
         "read-only".to_string(),
+        // The harness runs in a neutral temp cwd, which is not a git repo; without
+        // this, `codex exec` refuses to run ("Not inside a trusted directory…") or
+        // blocks on an approval prompt. Read-only sandbox already bars side effects.
+        "--skip-git-repo-check".to_string(),
     ];
     if !model.trim().is_empty() {
         args.push("--model".to_string());
@@ -211,7 +223,9 @@ mod tests {
     #[test]
     fn exec_args_include_sandbox_and_model() {
         let inv = CodexAgent.stream_invocation("o4-mini", "", None);
-        assert_eq!(inv.prompt, PromptDelivery::Arg);
+        // Prompt is delivered on stdin, never as a positional argv element — so no
+        // untrusted JD text can reach `cmd.exe` on Windows (CVE-2024-24576).
+        assert_eq!(inv.prompt, PromptDelivery::Stdin);
         assert!(inv
             .args
             .windows(2)
@@ -225,6 +239,30 @@ mod tests {
             .args
             .iter()
             .any(|a| a.starts_with("model_reasoning_effort=")));
+        // Runs outside a git repo (temp cwd) — the check must be skipped.
+        assert!(inv.args.iter().any(|a| a == "--skip-git-repo-check"));
+    }
+
+    #[test]
+    fn argv_is_only_static_flags_never_the_prompt() {
+        // The full argv is a fixed, trusted set of exec flags (+ resolved model) —
+        // it never contains prompt/JD-derived text. That is the property that clears
+        // the command-injection CRITICAL: with `Stdin` delivery the harness pipes the
+        // prompt to the child, so nothing untrusted ever reaches argv / `cmd.exe`.
+        let inv = CodexAgent.stream_invocation("o4-mini", "system text here", None);
+        assert_eq!(
+            inv.args,
+            vec![
+                "exec",
+                "--json",
+                "--sandbox",
+                "read-only",
+                "--skip-git-repo-check",
+                "--model",
+                "o4-mini",
+            ]
+        );
+        assert_eq!(inv.prompt, PromptDelivery::Stdin);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/codex.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/codex.rs
@@ -142,12 +142,15 @@ fn exec_args(model: &str, effort: Option<&str>) -> Vec<String> {
         // blocks on an approval prompt. Read-only sandbox already bars side effects.
         "--skip-git-repo-check".to_string(),
     ];
-    if !model.trim().is_empty() {
+    // `arg_token` upholds the CVE-2024-24576 argv invariant defensively: model/effort
+    // are user settings (not scraped), but still ride argv through `cmd.exe` on
+    // Windows, so reject anything that isn't a plain identifier (drops the flag).
+    if let Some(model) = super::arg_token(model) {
         args.push("--model".to_string());
         args.push(model.to_string());
     }
     // Reasoning effort via a config override (low/medium/high). Omitted → Codex default.
-    if let Some(effort) = effort.map(str::trim).filter(|e| !e.is_empty()) {
+    if let Some(effort) = effort.and_then(super::arg_token) {
         args.push("-c".to_string());
         args.push(format!("model_reasoning_effort={effort}"));
     }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/gemini_cli.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/gemini_cli.rs
@@ -1,10 +1,16 @@
-//! Gemini CLI backend — Google's `gemini` CLI run headless (`gemini -p`).
+//! Gemini CLI backend — Google's `gemini` CLI run headless with the prompt on stdin.
 //!
 //! Note: distinct from the cloud Gemini API provider ([`super::super::gemini`]) —
 //! this id is `gemini-cli` and shells out to the locally-installed tool, which
 //! authenticates with the user's own Google / Gemini login. Output is plain text
 //! on stdout (no structured event stream and no system-prompt flag), so the
 //! harness inlines the system prompt and streams stdout line by line.
+//!
+//! The (untrusted, JD-bearing) prompt is delivered on **stdin**
+//! ([`PromptDelivery::Stdin`]): with a piped, non-TTY stdin `gemini` runs
+//! non-interactively and treats the piped text as the prompt — so we pass NO `-p`
+//! and nothing prompt-derived ever reaches argv (or, on Windows, `cmd.exe` — see the
+//! CVE-2024-24576 note on [`PromptDelivery`]). argv holds only the optional model flag.
 
 use async_trait::async_trait;
 
@@ -55,8 +61,10 @@ impl CliAgentBackend for GeminiCliAgent {
         _effort: Option<&str>,
     ) -> CliInvocation {
         CliInvocation {
-            args: prompt_args(model),
-            prompt: PromptDelivery::Arg,
+            args: model_args(model),
+            // Prompt on stdin, not argv — piped stdin is read as the prompt in
+            // non-interactive mode. Keeps untrusted JD text off the command line.
+            prompt: PromptDelivery::Stdin,
         }
     }
 
@@ -67,19 +75,32 @@ impl CliAgentBackend for GeminiCliAgent {
         _effort: Option<&str>,
     ) -> CliInvocation {
         CliInvocation {
-            args: prompt_args(model),
-            prompt: PromptDelivery::Arg,
+            args: model_args(model),
+            prompt: PromptDelivery::Stdin,
         }
     }
 
     fn parse_stream_line(&self, line: &str) -> Option<CliEvent> {
         // Plain-text output: emit each stdout line, preserving line breaks (blank
-        // lines included, so paragraphs survive). The harness marks completion on EOF.
+        // lines included, so paragraphs survive). The harness marks completion on
+        // EOF. Gemini prints credential/telemetry notices ("Loaded cached
+        // credentials.", …) to stdout around the answer — drop them so they don't
+        // get folded into the generated letter.
+        if super::is_cli_stdout_noise(line) {
+            return None;
+        }
         Some(CliEvent::Delta(format!("{line}\n")))
     }
 
     fn parse_complete(&self, stdout: &str) -> AppResult<String> {
-        let text = stdout.trim();
+        // Same hygiene as the streaming path: strip the operational noise lines,
+        // then trim. Rejoining with `\n` keeps the answer's own paragraph breaks.
+        let text = stdout
+            .lines()
+            .filter(|l| !super::is_cli_stdout_noise(l))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let text = text.trim();
         if text.is_empty() {
             return Err(AppError::Provider("Gemini CLI: empty response".to_string()));
         }
@@ -87,15 +108,14 @@ impl CliAgentBackend for GeminiCliAgent {
     }
 }
 
-/// `gemini [-m <model>] -p` — the harness appends the prompt as the final arg, so
-/// it lands as the value of `-p`.
-fn prompt_args(model: &str) -> Vec<String> {
+/// `gemini [-m <model>]` — the prompt is piped on stdin (non-interactive mode), so
+/// there is no `-p` value flag: argv is only the optional, trusted model selector.
+fn model_args(model: &str) -> Vec<String> {
     let mut args = Vec::new();
     if !model.trim().is_empty() {
         args.push("-m".to_string());
         args.push(model.to_string());
     }
-    args.push("-p".to_string());
     args
 }
 
@@ -126,13 +146,40 @@ mod tests {
     }
 
     #[test]
-    fn prompt_args_place_p_last_for_appended_prompt() {
-        let inv = GeminiCliAgent.stream_invocation("gemini-2.5-flash", "", None);
-        assert_eq!(inv.prompt, PromptDelivery::Arg);
-        assert_eq!(inv.args.last().unwrap(), "-p");
-        assert!(inv
-            .args
-            .windows(2)
-            .any(|w| w[0] == "-m" && w[1] == "gemini-2.5-flash"));
+    fn credential_noise_is_filtered_from_both_paths() {
+        // The streaming path drops the notice line but keeps the answer line.
+        assert_eq!(
+            GeminiCliAgent.parse_stream_line("Loaded cached credentials."),
+            None
+        );
+        assert_eq!(
+            GeminiCliAgent.parse_stream_line("Dear Team,"),
+            Some(CliEvent::Delta("Dear Team,\n".to_string()))
+        );
+        // The one-shot path strips the notice and returns only the answer body.
+        let out = "Loaded cached credentials.\nDear Team,\n\nThanks.\n";
+        assert_eq!(
+            GeminiCliAgent.parse_complete(out).unwrap(),
+            "Dear Team,\n\nThanks."
+        );
+    }
+
+    #[test]
+    fn argv_has_model_only_no_prompt_flag_prompt_on_stdin() {
+        let inv = GeminiCliAgent.stream_invocation("gemini-2.5-flash", "system text", None);
+        // Prompt delivered on stdin — the CVE-2024-24576 fix: no untrusted JD text
+        // in argv / `cmd.exe`.
+        assert_eq!(inv.prompt, PromptDelivery::Stdin);
+        // The `-p` value flag is gone; argv is exactly the trusted model selector.
+        assert!(!inv.args.iter().any(|a| a == "-p"));
+        assert_eq!(inv.args, vec!["-m", "gemini-2.5-flash"]);
+    }
+
+    #[test]
+    fn argv_is_empty_when_no_model() {
+        // No model → no flags at all; the entire prompt still goes on stdin.
+        let inv = GeminiCliAgent.stream_invocation("", "", None);
+        assert!(inv.args.is_empty());
+        assert_eq!(inv.prompt, PromptDelivery::Stdin);
     }
 }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/gemini_cli.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/gemini_cli.rs
@@ -112,7 +112,10 @@ impl CliAgentBackend for GeminiCliAgent {
 /// there is no `-p` value flag: argv is only the optional, trusted model selector.
 fn model_args(model: &str) -> Vec<String> {
     let mut args = Vec::new();
-    if !model.trim().is_empty() {
+    // `arg_token` upholds the CVE-2024-24576 argv invariant defensively: `model` is a
+    // user setting (not scraped), but still rides argv through `cmd.exe` on Windows,
+    // so reject anything that isn't a plain identifier (drops the flag → CLI default).
+    if let Some(model) = super::arg_token(model) {
         args.push("-m".to_string());
         args.push(model.to_string());
     }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
@@ -496,14 +496,12 @@ async fn run_stream(
         }
     };
 
-    if matches!(inv.prompt, PromptDelivery::Stdin) {
-        if let Some(mut stdin) = child.stdin.take() {
-            let _ = stdin.write_all(prompt.as_bytes()).await;
-            // `stdin` drops here → EOF, so the agent stops waiting for input.
-        }
-    } else {
-        drop(child.stdin.take());
-    }
+    // Feed stdin on a detached task so the stdout loop below drains concurrently.
+    // Awaiting the whole write first can DEADLOCK on a prompt larger than the OS
+    // pipe buffer (~64 KB) if the child interleaves stdout while still reading stdin
+    // (see `write_prompt_stdin`) — realistic for cover-letter prompts that inline
+    // the full JD + résumé + research brief.
+    let stdin_writer = write_prompt_stdin(inv.prompt, child.stdin.take(), prompt, label);
 
     // Drain stderr concurrently so a chatty agent can't deadlock on a full pipe.
     let stderr = child.stderr.take();
@@ -524,6 +522,9 @@ async fn run_stream(
     let deadline = tokio::time::Instant::now() + TIMEOUT;
     let mut emitted_done = false;
     let mut any_delta = false;
+    // Whether a non-blank content delta has streamed yet — gates leading-blank
+    // suppression so plain-text agents don't emit a stray newline before the answer.
+    let mut seen_content = false;
 
     loop {
         // Race the next line read against a cancel poll so a cancellation mid-line
@@ -581,6 +582,18 @@ async fn run_stream(
         match backend.parse_stream_line(&line) {
             Some(CliEvent::Delta(text)) if !text.is_empty() => {
                 any_delta = true;
+                // Suppress leading blank/whitespace-only lines so streamed output
+                // starts at the first real content line — matching the trimmed
+                // one-shot (`parse_complete`) output. A blank line left after a
+                // stripped credential notice (Gemini/Antigravity) would otherwise
+                // stream a stray leading newline. `any_delta` is set above regardless,
+                // so the success heuristic is unchanged.
+                if !seen_content {
+                    if text.trim().is_empty() {
+                        continue;
+                    }
+                    seen_content = true;
+                }
                 emit_event(
                     app,
                     AI_STREAM,
@@ -622,6 +635,9 @@ async fn run_stream(
     let status = child.wait().await.ok();
     let success = status.map(|s| s.success()).unwrap_or(false);
     let stderr_text = stderr_handle.await.unwrap_or_default();
+    // Reap the stdin writer — the child has exited, so it has completed; any write
+    // error was already logged inside the task and is never fatal.
+    let _ = stdin_writer.await;
 
     // No explicit terminal event (e.g. plain-text agents): a clean exit or any
     // streamed text means success; otherwise surface the failure.
@@ -665,13 +681,10 @@ async fn run_complete(
         }
     };
 
-    if matches!(inv.prompt, PromptDelivery::Stdin) {
-        if let Some(mut stdin) = child.stdin.take() {
-            let _ = stdin.write_all(prompt.as_bytes()).await;
-        }
-    } else {
-        drop(child.stdin.take());
-    }
+    // Feed stdin on a detached task so `wait_with_output` (which drains stdout/stderr)
+    // runs concurrently — awaiting the full write first can DEADLOCK on a prompt
+    // larger than the OS pipe buffer (~64 KB); see `write_prompt_stdin`.
+    let stdin_writer = write_prompt_stdin(inv.prompt, child.stdin.take(), prompt, label);
 
     let output = match tokio::time::timeout(TIMEOUT, child.wait_with_output()).await {
         Ok(Ok(o)) => o,
@@ -686,6 +699,8 @@ async fn run_complete(
             )));
         }
     };
+    // Reap the stdin writer — the child has exited, so it has completed.
+    let _ = stdin_writer.await;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -723,6 +738,64 @@ fn spawn(
         .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
+}
+
+/// Feed the prompt to the child's stdin on a **detached task** so the caller can
+/// drain stdout concurrently. Awaiting the full write *before* reading stdout can
+/// DEADLOCK when the prompt exceeds the OS pipe buffer (~64 KB) and the child
+/// interleaves stdout while still reading stdin: both pipes fill and neither side
+/// progresses — surfacing only as the 5-minute timeout. This is realistic for
+/// cover-letter prompts that inline the full scraped JD + résumé + research brief.
+///
+/// The task drops `stdin` when done so the child sees EOF (unchanged from before);
+/// a write error (e.g. a CLI that closed stdin early) is logged at `debug`, never
+/// fatal — success is still decided by the stdout/exit path. Only
+/// [`PromptDelivery::Stdin`] pipes the prompt; for the unused
+/// [`PromptDelivery::Arg`] the prompt already rode argv, so stdin is just closed.
+fn write_prompt_stdin(
+    delivery: PromptDelivery,
+    stdin: Option<tokio::process::ChildStdin>,
+    prompt: String,
+    label: &str,
+) -> tokio::task::JoinHandle<()> {
+    let label = label.to_string();
+    tokio::spawn(async move {
+        // No piped stdin (already taken) → nothing to do.
+        let Some(mut stdin) = stdin else { return };
+        // `Arg` (unused) already carried the prompt on argv; drop `stdin` to close it
+        // (EOF) without writing — matches the old `drop(child.stdin.take())`.
+        if delivery != PromptDelivery::Stdin {
+            return;
+        }
+        if let Err(e) = stdin.write_all(prompt.as_bytes()).await {
+            tracing::debug!("[cli_agent] {label}: stdin write ended early: {e}");
+        }
+        // `stdin` drops here → EOF, so the agent stops waiting for input.
+    })
+}
+
+/// Defense-in-depth for the CVE-2024-24576 invariant (argv carries only fixed,
+/// trusted flags). `model`/`effort` come from the user's OWN settings — never
+/// scraped/untrusted content — but on Windows they still ride argv through the
+/// `cmd.exe /C` wrapper, where Rust's batch-escaping does not engage. So before a
+/// backend turns one into an arg, require it to be a plain identifier
+/// (`[A-Za-z0-9._:-]+`, trimmed): anything with a shell metacharacter, whitespace,
+/// or control char is dropped (the flag is simply omitted, so the CLI falls back to
+/// its default) and a warning is logged. Every real model id / effort level passes
+/// unchanged.
+fn arg_token(value: &str) -> Option<&str> {
+    let v = value.trim();
+    if v.is_empty() {
+        return None;
+    }
+    if v.bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b':' | b'-'))
+    {
+        Some(v)
+    } else {
+        tracing::warn!("[cli_agent] dropping non-identifier CLI arg value: {v:?}");
+        None
+    }
 }
 
 fn spawn_error(agent: &str, binary: &str, e: std::io::Error) -> AppError {
@@ -875,6 +948,25 @@ mod tests {
             "I loaded cached credentials into the pipeline as described."
         ));
         assert!(!is_cli_stdout_noise(""));
+    }
+
+    #[test]
+    fn arg_token_accepts_ids_and_rejects_shell_metacharacters() {
+        // Real model ids / effort levels pass unchanged (trimmed).
+        assert_eq!(arg_token("gpt-5-codex"), Some("gpt-5-codex"));
+        assert_eq!(arg_token("gemini-2.5-pro"), Some("gemini-2.5-pro"));
+        assert_eq!(arg_token("o4-mini"), Some("o4-mini"));
+        assert_eq!(arg_token("high"), Some("high"));
+        assert_eq!(arg_token("  gemini-2.5-flash  "), Some("gemini-2.5-flash"));
+        // Shell metacharacters / whitespace-splitting / empties are rejected, so the
+        // flag is omitted rather than smuggling text through `cmd.exe` on Windows
+        // (the CVE-2024-24576 argv invariant, defended in depth).
+        for bad in [
+            "", "   ", "a b", "m&calc", "a|b", "a>b", "a<b", "a^b", "%PATH%", "a\"b", "a(b)",
+            "a\r\nb", "$(x)", "`x`", "a;b", "a/b",
+        ] {
+            assert_eq!(arg_token(bad), None, "{bad:?} must be rejected");
+        }
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
@@ -35,10 +35,12 @@ use super::{
     AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, RequestTrace, TokenParam,
 };
 
+mod antigravity;
 mod claude_code;
 mod codex;
 mod gemini_cli;
 
+use antigravity::AntigravityAgent;
 use claude_code::ClaudeCodeAgent;
 use codex::CodexAgent;
 use gemini_cli::GeminiCliAgent;
@@ -69,13 +71,28 @@ pub enum CliEvent {
 }
 
 /// How the prompt reaches the child process.
+///
+/// **Security — CVE-2024-24576 (Windows `.cmd`/"BatBadBut"):** the prompt inlines
+/// untrusted, scraped job-description text. On Windows an npm-global CLI
+/// (`codex`/`gemini`/`agy`) installs as a `.cmd` shim that must be launched through
+/// `cmd.exe /C` ([`cli_command`]). Rust's batch-argument escaping (the CVE fix) only
+/// engages when the spawned program is the `.cmd` itself — here the program is
+/// `cmd.exe`, not the `.cmd`, so it does NOT engage. A prompt containing `" & <cmd>`
+/// would then break out of `cmd.exe`'s parser and execute. The structural fix:
+/// **untrusted text must never transit argv.** Every backend uses
+/// [`Stdin`](Self::Stdin), so the command line carries only fixed, trusted flags and
+/// the harness pipes the prompt to `child.stdin`. Fail-closed — a CLI that ignores
+/// stdin yields empty output, never RCE.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptDelivery {
-    /// Pipe the prompt to stdin (avoids arg-length / escaping limits). Preferred.
+    /// Pipe the prompt to stdin (avoids arg-length / escaping limits, and keeps
+    /// untrusted prompt bytes off the command line — see the type-level security
+    /// note). The only variant any backend uses.
     Stdin,
-    /// Append the prompt as the **final** argument (place a value-flag like `-p`
-    /// last if the agent expects the prompt as that flag's value). Constructed by
-    /// the Codex / Gemini CLI backends (follow-up).
+    /// Append the prompt as the **final** argv element. **Unused** — retained only
+    /// as harness plumbing. Do NOT adopt it for any backend whose binary can be a
+    /// Windows `.cmd` shim: it would route untrusted prompt text through `cmd.exe`
+    /// (CVE-2024-24576, see above). Prefer [`Stdin`](Self::Stdin).
     #[allow(dead_code)]
     Arg,
 }
@@ -153,6 +170,7 @@ pub fn all() -> Vec<Box<dyn CliAgentBackend>> {
         Box::new(ClaudeCodeAgent),
         Box::new(CodexAgent),
         Box::new(GeminiCliAgent),
+        Box::new(AntigravityAgent),
     ]
 }
 
@@ -349,11 +367,44 @@ fn detect_cache() -> &'static Mutex<HashMap<String, Detected>> {
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Base command for a CLI agent: console window hidden on Windows, and an augmented
-/// `PATH` so a GUI-launched macOS/Linux app can find the binary (Finder/Dock apps
-/// inherit only a minimal `PATH`, missing npm/nvm/Homebrew/native installs).
-fn cli_command(binary: &str) -> Command {
+/// Base command for a CLI agent, with `args` applied: console window hidden on
+/// Windows, and an augmented `PATH` so a GUI-launched macOS/Linux app can find the
+/// binary (Finder/Dock apps inherit only a minimal `PATH`, missing
+/// npm/nvm/Homebrew/native installs).
+///
+/// On **Windows** it first resolves the binary on `PATH` × `PATHEXT`
+/// ([`crate::platform::resolve_cli_binary`]): a `.cmd`/`.bat` shim (how npm-global
+/// CLIs like `gemini`/`codex`/`agy` install — there is no `.exe`) is launched
+/// through `cmd.exe /C`, since `CreateProcess` cannot execute a batch file
+/// directly. Each element of `args` is passed as a **separate argv entry** — never
+/// concatenated into a shell string — so `cmd.exe` performs no word-splitting. If
+/// resolution fails we fall through to a bare spawn so the OS still surfaces
+/// `NotFound`.
+///
+/// **CVE-2024-24576 invariant:** because the program spawned is `cmd.exe` (not the
+/// `.cmd`), Rust's batch-argument escaping does NOT engage — so `args` here MUST
+/// carry only fixed, trusted flags (model/sandbox flags, `--version`), never
+/// untrusted prompt/JD text. That text goes on stdin via [`PromptDelivery::Stdin`];
+/// [`spawn`] only appends to argv for the unused [`PromptDelivery::Arg`], which no
+/// backend constructs. See the [`PromptDelivery`] type docs.
+fn cli_command(binary: &str, args: &[String]) -> Command {
+    #[cfg(windows)]
+    if let Some(resolved) = crate::platform::resolve_cli_binary(binary) {
+        let mut cmd = if resolved.needs_cmd_wrapper {
+            let mut c = Command::new("cmd");
+            c.arg("/C").arg(&resolved.path).args(args);
+            c
+        } else {
+            let mut c = Command::new(&resolved.path);
+            c.args(args);
+            c
+        };
+        cmd.no_window();
+        return cmd;
+    }
+
     let mut cmd = Command::new(binary);
+    cmd.args(args);
     cmd.no_window();
     if let Some(path) = crate::platform::cli_path() {
         cmd.env("PATH", path);
@@ -364,7 +415,7 @@ fn cli_command(binary: &str) -> Command {
 /// Whether the binary is installed (`<binary> --version` succeeds), plus its
 /// reported version. Mirrors `ollama::reachable_model()` as the health signal.
 pub async fn detect(binary: &str) -> (bool, Option<String>) {
-    let fut = cli_command(binary).arg("--version").output();
+    let fut = cli_command(binary, &["--version".to_string()]).output();
     match tokio::time::timeout(Duration::from_secs(5), fut).await {
         Ok(Ok(out)) if out.status.success() => {
             let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
@@ -656,11 +707,14 @@ fn spawn(
     prompt: &str,
 ) -> std::io::Result<tokio::process::Child> {
     let mut args = inv.args.clone();
+    // Untrusted prompt text enters argv ONLY for `PromptDelivery::Arg`, which no
+    // backend constructs — every agent uses `Stdin` (see `PromptDelivery` docs for
+    // the CVE-2024-24576 rationale). So in practice `args` is fixed trusted flags,
+    // and the prompt reaches the child via `child.stdin` in the callers below.
     if matches!(inv.prompt, PromptDelivery::Arg) {
         args.push(prompt.to_string());
     }
-    cli_command(binary)
-        .args(&args)
+    cli_command(binary, &args)
         // Neutral cwd: we only want text generation, never side effects in the
         // user's project (backends also disable tools where the CLI supports it).
         .current_dir(std::env::temp_dir())
@@ -757,6 +811,28 @@ fn user_prompt(req: &AiGenerateRequest) -> String {
         .join("\n\n")
 }
 
+/// Plain-text CLI agents (Gemini CLI, Antigravity) interleave the model's answer
+/// on stdout with a few operational lines — cached-credential notices, telemetry
+/// banners, dotenv/deprecation logs. Left in, they get folded into the generated
+/// letter. This recognizes those specific, exact-ish markers so a backend can drop
+/// them. Deliberately conservative — it matches only known operational lines (full
+/// exact matches or unmistakable log prefixes), never anything that could be real
+/// answer text, and treats blank lines as paragraph breaks (kept).
+fn is_cli_stdout_noise(line: &str) -> bool {
+    let t = line.trim();
+    if t.is_empty() {
+        return false; // paragraph break — never noise
+    }
+    // Full-line operational notices these CLIs print before/around the answer.
+    const EXACT: &[&str] = &["Loaded cached credentials.", "Data collection is disabled."];
+    if EXACT.contains(&t) {
+        return true;
+    }
+    // Unmistakable log/tooling prefixes (dotenv injector banner, Node warnings that
+    // some builds route to stdout). Prefix-anchored so ordinary prose can't match.
+    t.starts_with("[dotenv@") || t.starts_with("DeprecationWarning:") || t.starts_with("(node:")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -767,6 +843,7 @@ mod tests {
             ProviderId::ClaudeCode,
             ProviderId::Codex,
             ProviderId::GeminiCli,
+            ProviderId::Antigravity,
         ] {
             assert!(
                 backend_for(id).is_some(),
@@ -780,6 +857,24 @@ mod tests {
     #[test]
     fn non_cli_provider_has_no_backend() {
         assert!(backend_for(ProviderId::Anthropic).is_none());
+    }
+
+    #[test]
+    fn stdout_noise_filter_drops_only_operational_lines() {
+        // Known operational noise is dropped…
+        assert!(is_cli_stdout_noise("Loaded cached credentials."));
+        assert!(is_cli_stdout_noise("  Data collection is disabled.  "));
+        assert!(is_cli_stdout_noise(
+            "[dotenv@17.0.0] injecting env (2) from .env"
+        ));
+        assert!(is_cli_stdout_noise("(node:12345) Warning: something"));
+        // …while real answer text (even mentioning credentials) is kept, and blank
+        // lines survive as paragraph breaks.
+        assert!(!is_cli_stdout_noise("Dear Hiring Manager,"));
+        assert!(!is_cli_stdout_noise(
+            "I loaded cached credentials into the pipeline as described."
+        ));
+        assert!(!is_cli_stdout_noise(""));
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
@@ -62,6 +62,10 @@ pub enum ProviderId {
     /// Google Gemini CLI run headless (a [`cli_agent`] backend) — distinct from the
     /// cloud [`Gemini`](Self::Gemini) API. Keyless: uses the user's Google login.
     GeminiCli,
+    /// Google Antigravity CLI (`agy`) run headless (a [`cli_agent`] backend).
+    /// Keyless: uses `agy`'s own Google sign-in. **UNVERIFIED** — implemented to
+    /// the documented CLI contract but not runtime-tested (see `cli_agent::antigravity`).
+    Antigravity,
 }
 
 impl ProviderId {
@@ -77,6 +81,7 @@ impl ProviderId {
             "claude-code" => Ok(Self::ClaudeCode),
             "codex" => Ok(Self::Codex),
             "gemini-cli" => Ok(Self::GeminiCli),
+            "antigravity" => Ok(Self::Antigravity),
             other => Err(AppError::Config(format!(
                 "Unknown AI provider '{other}'. Select a configured provider in Settings → AI."
             ))),
@@ -94,6 +99,7 @@ impl ProviderId {
             Self::ClaudeCode => "claude-code",
             Self::Codex => "codex",
             Self::GeminiCli => "gemini-cli",
+            Self::Antigravity => "antigravity",
         }
     }
 
@@ -525,7 +531,10 @@ pub fn resolve(id: ProviderId, base_url: Option<String>) -> Box<dyn AiProvider> 
         ProviderId::Gemini => Box::new(GeminiClient),
         // Routed by the registry above; listed only to keep this match exhaustive
         // (so a new *non*-CLI provider still fails to compile until handled here).
-        ProviderId::ClaudeCode | ProviderId::Codex | ProviderId::GeminiCli => {
+        ProviderId::ClaudeCode
+        | ProviderId::Codex
+        | ProviderId::GeminiCli
+        | ProviderId::Antigravity => {
             unreachable!("CLI agents are resolved via cli_agent::backend_for")
         }
     }
@@ -842,6 +851,7 @@ mod tests {
             ProviderId::ClaudeCode,
             ProviderId::Codex,
             ProviderId::GeminiCli,
+            ProviderId::Antigravity,
         ] {
             assert_eq!(ProviderId::parse(id.as_str()).unwrap(), id);
         }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
@@ -827,6 +827,7 @@ mod tests {
             ("claude-code", true),
             ("codex", true),
             ("gemini-cli", true),
+            ("antigravity", true),
         ];
         for (name, expected) in cases {
             let client = resolve_by_name(name, None).unwrap();

--- a/apps/desktop/src-tauri/src/commands/cli_agents.rs
+++ b/apps/desktop/src-tauri/src/commands/cli_agents.rs
@@ -138,7 +138,7 @@ mod tests {
     async fn status_lists_every_registered_agent_with_install_metadata() {
         let status = build_status().await;
         let ids: Vec<&str> = status.agents.iter().map(|a| a.id.as_str()).collect();
-        for expected in ["claude-code", "codex", "gemini-cli"] {
+        for expected in ["claude-code", "codex", "gemini-cli", "antigravity"] {
             assert!(ids.contains(&expected), "{expected} missing from status");
         }
         for agent in &status.agents {

--- a/apps/desktop/src-tauri/src/platform/mod.rs
+++ b/apps/desktop/src-tauri/src/platform/mod.rs
@@ -8,3 +8,5 @@ pub use chrome::{
     detect_chromium_user_data_roots, detect_system_chrome, BrowserLaunch, ChromiumBrowser,
 };
 pub use process::{cli_path, NoWindow};
+#[cfg(windows)]
+pub use process::{resolve_cli_binary, ResolvedCli};

--- a/apps/desktop/src-tauri/src/platform/process.rs
+++ b/apps/desktop/src-tauri/src/platform/process.rs
@@ -148,3 +148,144 @@ fn login_shell_path() -> Option<String> {
         _ => None,
     }
 }
+
+// ── Windows binary resolution (PATH × PATHEXT, `.cmd`/`.bat` shims) ────────────────
+//
+// npm-global CLIs (`gemini`, `codex`, `agy`, …) install on Windows as **`.cmd`
+// shims** (e.g. `…\npm\gemini.cmd`) with no `.exe`. `CreateProcess` — and thus a
+// bare `Command::new("gemini")` — only launches `.com`/`.exe`; it does not consult
+// `PATHEXT`, so the shim is reported "not found" for both detection and spawn.
+// This resolver reproduces the shell's own lookup (search each `PATH` dir for the
+// name plus each `PATHEXT` extension) and reports whether the hit is a batch shim
+// that must be run through `cmd.exe`. It lives here so the "env access only in
+// `platform/**`" rule holds (PATH/PATHEXT are the only env reads).
+
+/// A CLI binary resolved on Windows: the concrete path found on `PATH`, and
+/// whether it is a `.cmd`/`.bat` shim that must be launched through `cmd.exe`.
+#[cfg(windows)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedCli {
+    /// Concrete resolved path, e.g. `…\npm\gemini.cmd` or `…\claude.exe`.
+    pub path: std::path::PathBuf,
+    /// `true` for a `.cmd`/`.bat` shim → launch via `cmd.exe /C <path> <args…>`.
+    pub needs_cmd_wrapper: bool,
+}
+
+/// The Windows default when `PATHEXT` is unset.
+#[cfg(windows)]
+const DEFAULT_PATHEXT: &str = ".COM;.EXE;.BAT;.CMD;.VBS;.JS;.WSF";
+
+/// Resolve `binary` to a concrete path on Windows, searching `PATH` × `PATHEXT`
+/// the way the shell does. `None` when nothing matches, so callers fall back to a
+/// bare spawn and let the OS surface `NotFound`.
+#[cfg(windows)]
+pub fn resolve_cli_binary(binary: &str) -> Option<ResolvedCli> {
+    let path_var = std::env::var_os("PATH").unwrap_or_default();
+    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| DEFAULT_PATHEXT.to_string());
+    resolve_cli_binary_in(binary, path_var.as_os_str(), &pathext)
+}
+
+/// Pure core of [`resolve_cli_binary`] — `PATH`/`PATHEXT` are injected so it is
+/// unit-testable with a fake directory and no process-env mutation.
+#[cfg(windows)]
+fn resolve_cli_binary_in(
+    binary: &str,
+    path_var: &std::ffi::OsStr,
+    pathext: &str,
+) -> Option<ResolvedCli> {
+    use std::path::Path;
+
+    // An already-qualified path (a `<AGENT>_BIN` override like `C:\tools\gemini.cmd`,
+    // or anything containing a separator) is honoured directly if it exists.
+    let raw = Path::new(binary);
+    if raw.is_absolute() || raw.components().count() > 1 {
+        return raw.is_file().then(|| resolved(raw.to_path_buf()));
+    }
+
+    // Try the bare name first (covers a name that already carries an extension),
+    // then the name + each `PATHEXT` entry.
+    let exts = std::iter::once(String::new()).chain(
+        pathext
+            .split(';')
+            .map(str::trim)
+            .filter(|e| !e.is_empty())
+            .map(str::to_string),
+    );
+    let exts: Vec<String> = exts.collect();
+
+    for dir in std::env::split_paths(path_var) {
+        for ext in &exts {
+            let candidate = dir.join(format!("{binary}{ext}"));
+            if candidate.is_file() {
+                return Some(resolved(candidate));
+            }
+        }
+    }
+    None
+}
+
+/// Tag a resolved path with whether it is a batch shim (`.cmd`/`.bat`).
+#[cfg(windows)]
+fn resolved(path: std::path::PathBuf) -> ResolvedCli {
+    let needs_cmd_wrapper = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("cmd") || e.eq_ignore_ascii_case("bat"))
+        .unwrap_or(false);
+    ResolvedCli {
+        path,
+        needs_cmd_wrapper,
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_resolver_tests {
+    use super::*;
+    use std::fs;
+
+    // Hermetic: a fake PATH dir + injected PATHEXT, so no process-env mutation and
+    // no assumption about which binaries exist on the runner.
+
+    #[test]
+    fn resolves_cmd_shim_and_flags_the_wrapper() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("foo.cmd"), "@echo off\r\n").unwrap();
+        let path_var = std::ffi::OsString::from(dir.path());
+
+        let r = resolve_cli_binary_in("foo", &path_var, ".COM;.EXE;.BAT;.CMD").unwrap();
+        assert!(r.needs_cmd_wrapper, ".cmd shim must be flagged for cmd.exe");
+        assert_eq!(
+            r.path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_ascii_lowercase(),
+            "foo.cmd"
+        );
+    }
+
+    #[test]
+    fn resolves_exe_directly_without_wrapper() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("bar.exe"), b"MZ").unwrap();
+        let path_var = std::ffi::OsString::from(dir.path());
+
+        let r = resolve_cli_binary_in("bar", &path_var, ".COM;.EXE;.BAT;.CMD").unwrap();
+        assert!(!r.needs_cmd_wrapper, ".exe is launched directly");
+        assert_eq!(
+            r.path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_ascii_lowercase(),
+            "bar.exe"
+        );
+    }
+
+    #[test]
+    fn missing_binary_resolves_to_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path_var = std::ffi::OsString::from(dir.path());
+        assert!(resolve_cli_binary_in("nope", &path_var, ".COM;.EXE;.BAT;.CMD").is_none());
+    }
+}

--- a/apps/desktop/src/renderer/lib/ai-providers/provider-meta.ts
+++ b/apps/desktop/src/renderer/lib/ai-providers/provider-meta.ts
@@ -96,6 +96,18 @@ export const PROVIDERS: Record<AiProvider, ProviderMeta> = {
     color: 'text-blue-400',
     models: ['gemini-2.5-pro', 'gemini-2.5-flash'],
   },
+  // UNVERIFIED backend (documented `agy` contract, not runtime-tested) — see
+  // src-tauri cli_agent/antigravity.rs. Models are informational (the CLI runs its
+  // own default model until a model-selection flag is confirmed).
+  antigravity: {
+    kind: 'cli-agent',
+    label: 'Antigravity',
+    description:
+      'Use your installed Antigravity CLI (agy) — your existing Google login, no API key.',
+    docsUrl: 'https://antigravity.google/docs',
+    color: 'text-blue-400',
+    models: ['gemini-3-pro', 'gemini-2.5-pro'],
+  },
 };
 
 export const PROVIDER_ORDER: AiProvider[] = [
@@ -108,6 +120,7 @@ export const PROVIDER_ORDER: AiProvider[] = [
   'claude-code',
   'codex',
   'gemini-cli',
+  'antigravity',
 ];
 
 /**

--- a/apps/desktop/src/renderer/lib/generate/provider-context.ts
+++ b/apps/desktop/src/renderer/lib/generate/provider-context.ts
@@ -25,7 +25,7 @@ import { usePreferencesStore } from '@/store/preferences-store';
 // ─── Provider kind mapping ────────────────────────────────────────────────────
 
 /** CLI agents: locally-installed headless tools (no API key). */
-const CLI_PROVIDERS = new Set<AiProvider>(['claude-code', 'codex', 'gemini-cli']);
+const CLI_PROVIDERS = new Set<AiProvider>(['claude-code', 'codex', 'gemini-cli', 'antigravity']);
 
 /** Cloud API providers (no local inference). */
 const CLOUD_PROVIDERS = new Set<AiProvider>([

--- a/apps/desktop/src/renderer/store/preferences-schema/preferences-schema.ts
+++ b/apps/desktop/src/renderer/store/preferences-schema/preferences-schema.ts
@@ -69,6 +69,9 @@ const AiProviderSchema = z.enum([
   'claude-code',
   'codex',
   'gemini-cli',
+  // Antigravity (`agy`) — UNVERIFIED CLI-agent backend (documented contract, not
+  // runtime-tested); see src-tauri cli_agent/antigravity.rs.
+  'antigravity',
 ]);
 
 // Per-local-model generation limits (Ollama only). Keyed by model name so each


### PR DESCRIPTION
Post-audit issue #4 — the CLI-agent AI providers gemini/codex didn't work (only Claude Code did), and antigravity wasn't supported.

## Windows fix (gemini + codex)
Root cause: gemini/codex install as npm-global **`.cmd` shims** (no `.exe`), which `CreateProcess` won't launch, so they were detected "not installed" and failed to spawn (Claude Code works — native `claude.exe`). Adds a **PATH × PATHEXT resolver** (`platform/process.rs`); resolved `.cmd`/`.bat` shims run via `cmd.exe /C` with **separate argv** (never a concatenated shell string). Also: codex gets `--skip-git-repo-check` (it runs in a temp cwd), and gemini's credential/telemetry stdout noise is filtered out of the generated text.

## New antigravity backend (`agy`) — ⚠️ UNVERIFIED
A new CLI backend mirroring the plain-text gemini path. **`agy` isn't installed on this machine**, so it's flagged UNVERIFIED throughout — its exact flags, stdin behavior, model-selection flag, npm package name, and the known non-TTY stdout-drop all need confirming against a real install before it's trusted end-to-end.

## 🔒 Security (reviewed — CRITICAL fixed)
A `tauri-security-reviewer` pass caught a **CVE-2024-24576 / "BatBadBut" command-injection (RCE)**: passing the untrusted prompt (which inlines **scraped job-description text**) as an argv element through `cmd.exe /C` let a malicious posting break out (`" & <cmd>`) or leak `%VAR%` — Rust's batch-arg escaping doesn't engage when the program is `cmd.exe`. **Fix:** deliver the prompt over **stdin** for codex/gemini/antigravity (like the `claude` backend), so argv carries only static trusted flags. Antigravity ships **without `--yes`** (no auto-approving tool actions on an untrusted prompt). Re-reviewed: **security gate PASS, no HIGH/CRITICAL remaining.**

## Verification
cargo fmt/check/clippy, `gen:ipc:check`, `turbo run typecheck --force` (0 errors), `lint:strict`, and the renderer suite (1984) all pass. New tests: PATH×PATHEXT resolver, stdin delivery + no `-p`/`--yes`, gemini noise filter, codex flags, CLI-agent parity. `cargo test` is env-blocked locally (Windows loader) — CI runs it.

**Known caveats (non-blocking, domain-owned):** stdin-prompt consumption for codex/gemini/`agy` needs a real-install check (worst case is empty output — fail-closed, not RCE); the `@google/antigravity` npm package name is a guess to confirm before enabling in-app install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)