### PR TITLE
fix(deps): migrate rustcrypto stack to cipher 0.5 and digest 0.11 (cbc, sha1)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -87,14 +87,14 @@ dependencies = [
 name = "ajh-tauri"
 version = "0.124.0"
 dependencies = [
- "aes 0.8.4",
+ "aes 0.9.1",
  "aes-gcm",
  "anyhow",
  "apple-native-keyring-store",
  "arc-swap",
  "async-trait",
  "base64 0.22.1",
- "cbc 0.1.2",
+ "cbc 0.2.1",
  "chromiumoxide",
  "chrono",
  "core-foundation-sys",
@@ -105,7 +105,7 @@ dependencies = [
  "feed-rs",
  "flate2",
  "futures",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "htmd",
  "image",
  "keyring-core",
@@ -113,7 +113,7 @@ dependencies = [
  "lopdf 0.43.0",
  "mockall",
  "parking_lot",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "pdf-extract",
  "proptest",
  "rand 0.10.1",
@@ -125,7 +125,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha1 0.10.6",
+ "sha1 0.11.0",
  "sha2 0.10.9",
  "sysinfo",
  "tauri",
@@ -5423,16 +5423,6 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
-]
 
 [[package]]
 name = "pbkdf2"
@@ -10968,7 +10958,7 @@ dependencies = [
  "indexmap 2.14.0",
  "lzma-rust2",
  "memchr",
- "pbkdf2 0.13.0",
+ "pbkdf2",
  "ppmd-rust",
  "sha1 0.11.0",
  "time",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -199,15 +199,16 @@ wait-timeout = "0.2"
 # password comes from macOS Keychain / Linux libsecret). The `hmac` feature
 # gates the bare `pbkdf2_hmac` fn; default features (password-hash) stay off.
 [target."cfg(unix)".dependencies]
-aes = "0.8"
-# `alloc` exposes `cipher`'s Vec-returning `decrypt_padded_vec_mut` (used by the
-# Chromium cookie CBC decrypt in scraping/board_login/import.rs). Without it the
-# method is gated out and the macOS/Linux release build fails to compile (the
-# path is `cfg(not(windows))`, so it never surfaces in a Windows dev build).
-cbc = { version = "0.1", features = ["alloc"] }
-hmac = "0.12"
-pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
-sha1 = "0.10"
+aes = "0.9"
+# `alloc` + `block-padding` expose `cipher` 0.5's Vec-returning
+# `decrypt_padded_vec` (used by the Chromium cookie CBC decrypt in
+# scraping/board_login/import.rs). Without them the method is gated out and the
+# macOS/Linux release build fails to compile (the path is `cfg(not(windows))`,
+# so it never surfaces in a Windows dev build).
+cbc = { version = "0.2", features = ["alloc", "block-padding"] }
+hmac = "0.13"
+pbkdf2 = { version = "0.13", default-features = false, features = ["hmac"] }
+sha1 = "0.11"
 
 [dev-dependencies]
 mockall = "0.15"

--- a/apps/desktop/src-tauri/src/scraping/board_login/import.rs
+++ b/apps/desktop/src-tauri/src/scraping/board_login/import.rs
@@ -524,7 +524,7 @@ fn legacy_dpapi_decrypt(_enc: &[u8]) -> Option<Vec<u8>> {
 /// store is unavailable.
 #[cfg(not(target_os = "windows"))]
 fn decrypt_v10_unix_cbc(enc: &[u8], _key: &[u8]) -> Option<Vec<u8>> {
-    use aes::cipher::{BlockDecryptMut, KeyIvInit};
+    use aes::cipher::{BlockModeDecrypt, KeyIvInit};
 
     type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
 
@@ -543,7 +543,7 @@ fn decrypt_v10_unix_cbc(enc: &[u8], _key: &[u8]) -> Option<Vec<u8>> {
 
     let cipher = Aes128CbcDec::new_from_slices(&derived, &IV).ok()?;
     cipher
-        .decrypt_padded_vec_mut::<aes::cipher::block_padding::Pkcs7>(&enc[3..])
+        .decrypt_padded_vec::<aes::cipher::block_padding::Pkcs7>(&enc[3..])
         .ok()
 }
 


### PR DESCRIPTION
## Migrate the RustCrypto stack (cipher 0.5 + digest 0.11)

Coordinated bump so two held Dependabot PRs become mergeable. **Supersedes #579 (cbc) and #577 (sha1)** — both are done here, since the digest-0.11 ecosystem is already satisfied (hmac 0.13 + pbkdf2 0.13 on digest 0.11 were already resolved in the lockfile via `zip`/`lopdf`).

### Version changes (`Cargo.toml`, `[target."cfg(unix)".dependencies]`)
- `aes` 0.8 → 0.9, `cbc` 0.1 → 0.2 (+`block-padding` feature)  — cipher 0.4 → 0.5
- `sha1` 0.10 → 0.11, `hmac` 0.12 → 0.13, `pbkdf2` 0.12 → 0.13  — digest 0.10 → 0.11

### Code migration (`import.rs`, `decrypt_v10_unix_cbc` — Chromium cookie AES-128-CBC decrypt, non-Windows)
- `BlockDecryptMut` → `BlockModeDecrypt` (cipher 0.5 renamed the block-mode decrypt trait)
- `.decrypt_padded_vec_mut::<Pkcs7>` → `.decrypt_padded_vec::<Pkcs7>` (one-shot helper renamed)
- Everything else unchanged: `cbc::Decryptor<aes::Aes128>`, `new_from_slices(&derived, &IV)`, `pbkdf2_hmac::<Sha1>` — same PKCS7 unpad, same key/IV/salt/iterations.

### Verification
The changed path is `cfg(not(windows))`, so a Windows `cargo check` skips it. Verified via a standalone crate pinning the exact new versions, reproducing the decrypt fn: **PBKDF2-HMAC-SHA1 byte-matches RFC 6070 vectors, AES-128-CBC/PKCS7 round-trips** for both the 1-iter (Linux) and 1003-iter (macOS) paths. `cargo fmt`/`clippy --lib` clean. Authoritative build runs on CI (Linux/macOS runners).

### Reviewer notes
- `decrypt_padded_vec` (0.5) vs `decrypt_padded_vec_mut` (0.4): same PKCS7 semantics, same `Result` on bad padding — confirm the rename is semantics-preserving.
- `hmac` is a redundant direct dep (pbkdf2's `hmac` feature pulls it); bumped for digest-0.11 consistency, could be dropped in a follow-up.
- Untouched on purpose: `aes-gcm 0.10` (Windows AES-256-GCM path, uses aes 0.8 internally) and direct `sha2 0.10` (match-cache hashing).
