### PR TITLE
fix: aggregator low-count filtering + resume experience translation

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -89,6 +89,14 @@ fn adzuna_max_days_old(date_filter: Option<&str>) -> u32 {
 /// even when the country has plenty; broadening recovers the full market page.
 const ADZUNA_BROADEN_FLOOR: usize = 3;
 
+/// Whether to broaden a sparse Adzuna result to a country-wide (`where=""`) retry.
+/// Only for an explicitly-supplied country (`!country_guessed`) — broadening a
+/// GUESSED market would defeat primary_chain's guessed-market → JSearch fallback,
+/// which keys off Adzuna returning empty.
+fn should_broaden(country_guessed: bool, where_val: &str, count: usize) -> bool {
+    !country_guessed && !where_val.is_empty() && count < ADZUNA_BROADEN_FLOOR
+}
+
 /// Adzuna's `where` wants a place *inside* the market (the country is already the
 /// URL path segment), so a trailing ", Germany"/", Deutschland" just over-narrows the
 /// geocode. Keep the first comma-segment (the city/region), trimmed.
@@ -340,7 +348,7 @@ impl JobProvider for AdzunaProvider {
         // an empty Adzuna result to fall through to JSearch (global, free-text
         // location) when the guess is probably wrong (e.g. "London" defaulting
         // to "de"). Only broaden for an explicitly-supplied country.
-        if !country_guessed && !where_hygienic.is_empty() && postings.len() < ADZUNA_BROADEN_FLOOR {
+        if should_broaden(country_guessed, where_hygienic, postings.len()) {
             match fetch_adzuna_page(country, app_id, app_key, query, "", date_filter, signal).await
             {
                 Ok(broadened) if broadened.len() > postings.len() => {

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -84,6 +84,20 @@ fn adzuna_max_days_old(date_filter: Option<&str>) -> u32 {
     }
 }
 
+/// Below this many results from a supported market, a non-empty `where` retries
+/// once country-wide (see `AdzunaProvider::search`). A city geocode can be sparse
+/// even when the country has plenty; broadening recovers the full market page.
+const ADZUNA_BROADEN_FLOOR: usize = 3;
+
+/// Adzuna's `where` wants a place *inside* the market (the country is already the
+/// URL path segment), so a trailing ", Germany"/", Deutschland" just over-narrows the
+/// geocode. Keep the first comma-segment (the city/region), trimmed.
+// ponytail: first-segment heuristic. A country-name-only location (e.g. "germany")
+// already returns Adzuna's full page, so no country-name table is needed.
+fn adzuna_where(location: &str) -> &str {
+    location.split(',').next().map(str::trim).unwrap_or("")
+}
+
 /// Map a UI date-filter token to JSearch's `date_posted` query token
 /// (`all|today|3days|week|month`). Sub-day windows floor at `3days` — like Adzuna,
 /// JSearch has no sub-day granularity, and a `today` ceiling zeroed out autopilot
@@ -121,11 +135,19 @@ pub(crate) trait JobProvider: Send + Sync {
     /// `amount` is a provider-specific result cap that callers may pass to
     /// cost-bounded providers (currently Apify only).  Providers that have no
     /// concept of a cap ignore it (`_amount`).
+    ///
+    /// `country_guessed` is true when the caller supplied no explicit
+    /// `country_code` (see `AggregatorScraper::search`). Providers that don't
+    /// need to distinguish a real target from a guessed default ignore it
+    /// (`_country_guessed`) — currently only `AdzunaProvider` reads it, to keep
+    /// its near-empty broaden retry from ever firing on a guessed market (that
+    /// would defeat the guessed-market → JSearch fallback in `primary_chain`).
     async fn search(
         &self,
         query: &str,
         location: &str,
         country: &str,
+        country_guessed: bool,
         date_filter: Option<&str>,
         amount: Option<u32>,
         signal: tokio_util::sync::CancellationToken,
@@ -264,6 +286,7 @@ impl JobProvider for AdzunaProvider {
         query: &str,
         location: &str,
         country: &str,
+        country_guessed: bool,
         date_filter: Option<&str>,
         _amount: Option<u32>,
         signal: tokio_util::sync::CancellationToken,
@@ -289,42 +312,52 @@ impl JobProvider for AdzunaProvider {
 
         let app_id = self.app_id.as_deref().unwrap_or("");
         let app_key = self.app_key.as_deref().unwrap_or("");
-        let country_enc = urlencoding::encode(country);
-        let app_id_enc = urlencoding::encode(app_id);
-        let app_key_enc = urlencoding::encode(app_key);
-        let q_enc = urlencoding::encode(query);
-        let loc_enc = urlencoding::encode(location);
 
-        let mut url = format!(
-            "https://api.adzuna.com/v1/api/jobs/{}/search/1\
-             ?app_id={}&app_key={}&what={}&where={}&results_per_page=50&content-type=application/json",
-            country_enc, app_id_enc, app_key_enc, q_enc, loc_enc
-        );
+        // Drop redundant country suffixes so a ", Germany"/", Deutschland" tail
+        // doesn't over-narrow the geocode (the country is already the URL path).
+        let where_hygienic = adzuna_where(location);
 
-        // Sort newest-first (Adzuna defaults to relevance, which floats stale
-        // postings up) and always bound the window with max_days_old so nothing
-        // older than the cap (30 days, or the user's tighter pick) is returned.
-        url.push_str(&format!(
-            "&sort_by=date&sort_direction=down&max_days_old={}",
-            adzuna_max_days_old(date_filter)
-        ));
+        let postings = fetch_adzuna_page(
+            country,
+            app_id,
+            app_key,
+            query,
+            where_hygienic,
+            date_filter,
+            signal.clone(),
+        )
+        .await?;
 
-        let result = fetch_json::<AdzunaResp>(&url, FetchOptions::default(), signal).await?;
-        let resp = match result {
-            Some(r) => r,
-            None => {
-                return Err(anyhow::anyhow!(
-                    "adzuna: non-2xx response or unparseable body"
-                ))
+        // Broaden on near-empty: even a hygienic `where` can over-narrow a sparse
+        // market, so if a real Adzuna market returned under the floor, retry ONCE
+        // country-wide (`where=""`) — same `what`, sort, and `max_days_old` — and
+        // keep whichever set is larger. A transient error on the retry keeps the
+        // narrow result rather than discarding it.
+        //
+        // GUARD: never broaden a GUESSED market (`country_guessed`). Turning a
+        // guessed-market empty/near-empty into a non-empty country-wide result
+        // would defeat `primary_chain`'s guessed-market guard, which relies on
+        // an empty Adzuna result to fall through to JSearch (global, free-text
+        // location) when the guess is probably wrong (e.g. "London" defaulting
+        // to "de"). Only broaden for an explicitly-supplied country.
+        if !country_guessed && !where_hygienic.is_empty() && postings.len() < ADZUNA_BROADEN_FLOOR
+        {
+            match fetch_adzuna_page(country, app_id, app_key, query, "", date_filter, signal).await {
+                Ok(broadened) if broadened.len() > postings.len() => {
+                    // PRIVACY: never log the raw `where`/location — free-text PII.
+                    log::info!(
+                        "[aggregator] adzuna sparse result ({}), broadened country-wide ({})",
+                        postings.len(),
+                        broadened.len()
+                    );
+                    return Ok(broadened);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::warn!("[aggregator] adzuna broaden retry failed, keeping narrow result: {e}")
+                }
             }
-        };
-
-        let now = chrono::Utc::now().timestamp_millis();
-        let postings = resp
-            .results
-            .into_iter()
-            .map(|j| adzuna_job_to_posting(j, country, now))
-            .collect();
+        }
 
         Ok(postings)
     }
@@ -369,6 +402,48 @@ fn adzuna_job_to_posting(j: AdzunaJob, country: &str, now: i64) -> JobPosting {
         captured_at: now,
         extra,
     }
+}
+
+/// Build + fetch + parse ONE Adzuna page for a given `where` value.
+///
+/// Factored out of `AdzunaProvider::search` so the near-empty broaden retry can
+/// reissue the exact same request (same `what`, `sort_by=date`, `results_per_page`,
+/// and `max_days_old`) with only `where` changed. Called at most twice per search.
+async fn fetch_adzuna_page(
+    country: &str,
+    app_id: &str,
+    app_key: &str,
+    query: &str,
+    where_val: &str,
+    date_filter: Option<&str>,
+    signal: tokio_util::sync::CancellationToken,
+) -> anyhow::Result<Vec<JobPosting>> {
+    // Sort newest-first (Adzuna defaults to relevance, which floats stale postings
+    // up) and always bound the window with max_days_old so nothing older than the
+    // cap (30 days, or the user's tighter pick) is returned.
+    let url = format!(
+        "https://api.adzuna.com/v1/api/jobs/{}/search/1\
+         ?app_id={}&app_key={}&what={}&where={}&results_per_page=50&content-type=application/json\
+         &sort_by=date&sort_direction=down&max_days_old={}",
+        urlencoding::encode(country),
+        urlencoding::encode(app_id),
+        urlencoding::encode(app_key),
+        urlencoding::encode(query),
+        urlencoding::encode(where_val),
+        adzuna_max_days_old(date_filter),
+    );
+
+    let resp = match fetch_json::<AdzunaResp>(&url, FetchOptions::default(), signal).await? {
+        Some(r) => r,
+        None => return Err(anyhow::anyhow!("adzuna: non-2xx response or unparseable body")),
+    };
+
+    let now = chrono::Utc::now().timestamp_millis();
+    Ok(resp
+        .results
+        .into_iter()
+        .map(|j| adzuna_job_to_posting(j, country, now))
+        .collect())
 }
 
 // ── JSearch provider ──────────────────────────────────────────────────────────
@@ -423,6 +498,7 @@ impl JobProvider for JSearchProvider {
         query: &str,
         location: &str,
         _country: &str,
+        _country_guessed: bool,
         date_filter: Option<&str>,
         _amount: Option<u32>,
         signal: tokio_util::sync::CancellationToken,
@@ -874,6 +950,7 @@ impl JobProvider for ApifyLinkedInProvider {
         query: &str,
         location: &str,
         _country: &str,
+        _country_guessed: bool,
         date_filter: Option<&str>,
         amount: Option<u32>,
         signal: tokio_util::sync::CancellationToken,
@@ -981,7 +1058,15 @@ async fn primary_chain(
     if let Some(p) = primary {
         if p.is_configured() {
             match p
-                .search(query, location, country, date_filter, None, signal.clone())
+                .search(
+                    query,
+                    location,
+                    country,
+                    country_guessed,
+                    date_filter,
+                    None,
+                    signal.clone(),
+                )
                 .await
             {
                 Ok(items) if items.is_empty() && country_guessed && !location.is_empty() => {
@@ -1027,7 +1112,15 @@ async fn primary_chain(
     if let Some(f) = fallback {
         if f.is_configured() {
             return f
-                .search(query, location, country, date_filter, None, signal)
+                .search(
+                    query,
+                    location,
+                    country,
+                    country_guessed,
+                    date_filter,
+                    None,
+                    signal,
+                )
                 .await
                 .map(dedupe);
         }
@@ -1173,6 +1266,7 @@ async fn search_with_providers(
                 query,
                 location,
                 country,
+                country_guessed,
                 date_filter,
                 Some(apify_cap),
                 signal,

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -340,9 +340,9 @@ impl JobProvider for AdzunaProvider {
         // an empty Adzuna result to fall through to JSearch (global, free-text
         // location) when the guess is probably wrong (e.g. "London" defaulting
         // to "de"). Only broaden for an explicitly-supplied country.
-        if !country_guessed && !where_hygienic.is_empty() && postings.len() < ADZUNA_BROADEN_FLOOR
-        {
-            match fetch_adzuna_page(country, app_id, app_key, query, "", date_filter, signal).await {
+        if !country_guessed && !where_hygienic.is_empty() && postings.len() < ADZUNA_BROADEN_FLOOR {
+            match fetch_adzuna_page(country, app_id, app_key, query, "", date_filter, signal).await
+            {
                 Ok(broadened) if broadened.len() > postings.len() => {
                     // PRIVACY: never log the raw `where`/location — free-text PII.
                     log::info!(
@@ -354,7 +354,9 @@ impl JobProvider for AdzunaProvider {
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    log::warn!("[aggregator] adzuna broaden retry failed, keeping narrow result: {e}")
+                    log::warn!(
+                        "[aggregator] adzuna broaden retry failed, keeping narrow result: {e}"
+                    )
                 }
             }
         }
@@ -435,7 +437,11 @@ async fn fetch_adzuna_page(
 
     let resp = match fetch_json::<AdzunaResp>(&url, FetchOptions::default(), signal).await? {
         Some(r) => r,
-        None => return Err(anyhow::anyhow!("adzuna: non-2xx response or unparseable body")),
+        None => {
+            return Err(anyhow::anyhow!(
+                "adzuna: non-2xx response or unparseable body"
+            ))
+        }
     };
 
     let now = chrono::Utc::now().timestamp_millis();

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -847,6 +847,23 @@ fn adzuna_where_keeps_first_segment_and_drops_country_suffix() {
 }
 
 #[test]
+fn should_broaden_only_for_explicit_sparse_market() {
+    // Explicit country + non-empty where + count under the floor (3) → broaden.
+    assert!(should_broaden(false, "Köln", 2));
+
+    // Regression guard: a GUESSED market must never broaden — it would defeat
+    // primary_chain's guessed-market → JSearch fallback, which relies on Adzuna
+    // returning empty for a probably-wrong guess.
+    assert!(!should_broaden(true, "Köln", 0));
+
+    // Empty `where` means "already country-wide" — nothing left to broaden to.
+    assert!(!should_broaden(false, "", 0));
+
+    // At/above the floor, the result isn't sparse — don't retry.
+    assert!(!should_broaden(false, "Köln", 3));
+}
+
+#[test]
 fn jsearch_date_posted_maps_correctly() {
     // All sub-day windows floor at "3days" (JSearch has no sub-day token, and
     // "today" zeroed out autopilot "recent" filters on quiet days — regression guard).

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -72,6 +72,7 @@ impl JobProvider for FakeProvider {
         _query: &str,
         _location: &str,
         _country: &str,
+        _country_guessed: bool,
         _date_filter: Option<&str>,
         _amount: Option<u32>,
         _signal: tokio_util::sync::CancellationToken,
@@ -585,7 +586,7 @@ async fn adzuna_unconfigured_returns_err_without_network() {
         app_key: None,
     };
     let result = p
-        .search("engineer", "berlin", "de", None, None, make_token())
+        .search("engineer", "berlin", "de", false, None, None, make_token())
         .await;
     assert!(result.is_err(), "unconfigured Adzuna must return Err");
     assert!(
@@ -598,7 +599,7 @@ async fn adzuna_unconfigured_returns_err_without_network() {
 async fn jsearch_unconfigured_returns_err_without_network() {
     let p = JSearchProvider { api_key: None };
     let result = p
-        .search("engineer", "berlin", "de", None, None, make_token())
+        .search("engineer", "berlin", "de", false, None, None, make_token())
         .await;
     assert!(result.is_err(), "unconfigured JSearch must return Err");
     assert!(
@@ -658,6 +659,7 @@ impl JobProvider for CancelOnSearchProvider {
         _query: &str,
         _location: &str,
         _country: &str,
+        _country_guessed: bool,
         _date_filter: Option<&str>,
         _amount: Option<u32>,
         _signal: tokio_util::sync::CancellationToken,
@@ -828,6 +830,20 @@ fn adzuna_max_days_old_maps_correctly() {
     // No filter or an unknown token caps at the past month (30 days).
     assert_eq!(adzuna_max_days_old(None), 30);
     assert_eq!(adzuna_max_days_old(Some("99y")), 30);
+}
+
+#[test]
+fn adzuna_where_keeps_first_segment_and_drops_country_suffix() {
+    // Redundant country suffix (either language) is dropped — the country is
+    // already the URL path segment, so keeping it over-narrows the geocode.
+    assert_eq!(adzuna_where("Köln, Deutschland"), "Köln");
+    assert_eq!(adzuna_where("Cologne, Germany"), "Cologne");
+    // A country-name-only location already returns Adzuna's full page: pass through.
+    assert_eq!(adzuna_where("germany"), "germany");
+    // Empty stays empty (caller treats "" as country-wide).
+    assert_eq!(adzuna_where(""), "");
+    // Surrounding + inner whitespace is trimmed off the kept segment.
+    assert_eq!(adzuna_where("  Berlin , Germany "), "Berlin");
 }
 
 #[test]
@@ -1044,7 +1060,7 @@ async fn adzuna_empty_country_resolves_to_supported_de() {
     // Empty country → production code resolves to "de" → passes allowlist → fails
     // downstream at the network/auth layer (no real keys), NOT at country validation.
     let result = p
-        .search("engineer", "Berlin", "", None, None, make_token())
+        .search("engineer", "Berlin", "", false, None, None, make_token())
         .await;
     let e = result.unwrap_err();
     let msg = e.to_string();
@@ -1313,7 +1329,7 @@ async fn adzuna_provider_rejects_unsupported_country_before_network() {
     };
     // "xx" is not in the allowlist.
     let result = p
-        .search("engineer", "Seoul", "xx", None, None, make_token())
+        .search("engineer", "Seoul", "xx", false, None, None, make_token())
         .await;
     assert!(
         result.is_err(),
@@ -1341,7 +1357,7 @@ async fn adzuna_provider_accepts_supported_country_passes_allowlist() {
     // "de" is in the allowlist; the error that comes back must NOT mention the
     // allowlist — it should be a network/auth error (or similar), not a country error.
     let result = p
-        .search("engineer", "Berlin", "de", None, None, make_token())
+        .search("engineer", "Berlin", "de", false, None, None, make_token())
         .await;
     // We expect an error (no real API key) — an unexpected Ok would mean the test
     // environment somehow hit the real API, which must not silently pass unnoticed.
@@ -1405,7 +1421,7 @@ fn apify_is_configured_requires_token_and_toggle() {
 async fn apify_unconfigured_returns_err_without_network() {
     let p = apify(Some("t"), false);
     let result = p
-        .search("engineer", "berlin", "de", None, None, make_token())
+        .search("engineer", "berlin", "de", false, None, None, make_token())
         .await;
     assert!(result.is_err(), "unconfigured Apify must return Err");
     assert!(
@@ -1708,7 +1724,9 @@ async fn apify_search_pre_cancelled_signal_returns_err() {
     let signal = make_token();
     signal.cancel(); // pre-cancel before calling search
 
-    let result = p.search("dev", "Berlin", "de", None, None, signal).await;
+    let result = p
+        .search("dev", "Berlin", "de", false, None, None, signal)
+        .await;
     assert!(
         result.is_err(),
         "a pre-cancelled signal must make ApifyLinkedInProvider::search return Err"
@@ -2021,6 +2039,7 @@ async fn apify_skipped_when_primary_fills_amount() {
             _: &str,
             _: &str,
             _: &str,
+            _: bool,
             _: Option<&str>,
             _: Option<u32>,
             _: tokio_util::sync::CancellationToken,

--- a/packages/prompts/src/generate/resume/resume.ts
+++ b/packages/prompts/src/generate/resume/resume.ts
@@ -123,6 +123,7 @@ CORE RULES — NEVER BREAK (violations = instant failure):
 5. NEVER fabricate numbers - only use metrics if they're in the original or can be reasonably inferred
 6. NEVER add technologies the candidate hasn't used
 7. NEVER drop, merge, or omit a work role — every employer/role in the original resume MUST appear in the output, with its real title and dates; you may only reorder and condense the bullets within each role
+8. Write ALL body content — the Professional Summary AND every Work Experience and Skills bullet — in the target output language; if the source resume is in another language, TRANSLATE it (never leave source-language text). Proper nouns like employer/company names stay as written.
 
 ATS OPTIMIZATION RULES (CRITICAL - 40% of success):
 
@@ -320,6 +321,7 @@ Professional Summary (3 sentences max):
 - Include the job title from the ad naturally
 
 Work Experience (most recent first):
+- Write every bullet in ${meta.targetLanguage}. If a source bullet is in another language, TRANSLATE it into ${meta.targetLanguage} — never leave source-language text. Keep employer, title, and dates factual (do not translate proper nouns like company names).
 - Include EVERY role from <candidate_resume> — same employer, title, and dates. Never drop, merge, or summarise away a role, even if it seems less relevant to this job.
 - Within each role, reorder bullets so the most relevant to this job come first
 - Rewrite weak bullets to CAR format: Action Verb + What + Technology (bolded) + Result


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job search results so guessed countries no longer trigger misleading broader-country fallbacks.
  * Refined location handling to clean up redundant country text in search queries, helping results stay more accurate.
  * Updated resume generation so full content is consistently written in the selected output language, including translated work experience bullets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->