### PR TITLE
fix: job-search trust quick wins (silent failures, location determinism, dedupe)

### DIFF
--- a/apps/desktop/src-tauri/src/autopilot/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot/mod.rs
@@ -712,36 +712,101 @@ fn u32_field_in_range(v: &serde_json::Value, key: &str, max: u32) -> Option<u32>
         .filter(|&n| n <= max)
 }
 
+/// Canonical dedup key for a found job.
+///
+/// Uses the app-wide [`crate::applications::normalize_job_url`] (lowercased host,
+/// `www.`/fragment/tracking-param stripped) so tracking-param/hash variants of the
+/// SAME URL collapse to a single row — this is same-host URL-variant dedup, not
+/// cross-provider identity: an aggregator's `redirect_url` (e.g. Adzuna's `FoundJob.url`,
+/// hosted on an adzuna domain) normalizes to a different key than a board's direct
+/// posting URL, so the same job surfaced by both sources is NOT collapsed here (that
+/// needs redirect-chain canonicalization, deferred to trust-program PR E). Falls back
+/// to a normalized `title \u{1} company` when the URL is missing/unusable, so URL-less
+/// postings still dedupe sanely (the control-char separator can't be reproduced by a
+/// title that merely contains the company name) — known limitation: two distinct
+/// URL-less postings that happen to share title+company will also merge; rare, and
+/// only affects the discovery surface, so it's an accepted trade-off.
+fn merge_key(j: &FoundJob) -> String {
+    let normalized = crate::applications::normalize_job_url(&j.url);
+    if !normalized.is_empty() {
+        normalized
+    } else {
+        format!(
+            "{}\u{1}{}",
+            j.title.trim().to_lowercase(),
+            j.company.trim().to_lowercase()
+        )
+    }
+}
+
+/// Byte length of a job's description (0 when absent) — used to keep the richer of
+/// two same-key postings when collapsing a within-batch duplicate.
+fn description_len(j: &FoundJob) -> usize {
+    j.description.as_deref().map(str::len).unwrap_or(0)
+}
+
 /// Merge a fresh run's postings into the cumulative found-jobs list, idempotently:
 ///
+/// - the incoming batch is first collapsed on [`merge_key`], so the SAME job
+///   surfaced twice in one batch, or via two tracking-param/hash URL variants,
+///   becomes ONE row — and counts once in the "N new jobs" notification (this
+///   does NOT collapse an aggregator's redirect URL against a board's direct
+///   URL for the same job; see [`merge_key`]),
 /// - existing rows are kept (preserving `found_at`/first-seen) and have `is_new`
-///   cleared; if the run re-surfaced them, volatile fields (title/company/
-///   description/score/location) are refreshed,
-/// - postings whose URL was never seen are placed first (on top) and flagged
+///   cleared; if the run re-surfaced them (matched by `merge_key`), volatile
+///   fields (title/company/description/score/location/salary/board/trust) refresh,
+/// - postings whose key was never seen are placed first (on top) and flagged
 ///   `is_new`, in the incoming (already score-sorted) order.
 ///
 /// Re-running with the same postings yields the same set — only `is_new` moves.
 /// `applied` is derived on read, so it is left at its default here.
 fn merge_found_jobs(existing: &[FoundJob], incoming: Vec<FoundJob>) -> Vec<FoundJob> {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
-    let incoming_by_url: HashMap<&str, &FoundJob> =
-        incoming.iter().map(|j| (j.url.as_str(), j)).collect();
+    // 1) Collapse duplicates WITHIN the incoming batch by canonical key. First
+    //    occurrence keeps its position; a later duplicate carrying a longer
+    //    description upgrades that one field (richer text for the tailor flow).
+    let mut order: Vec<String> = Vec::new();
+    let mut by_key: HashMap<String, FoundJob> = HashMap::new();
+    for job in incoming {
+        let key = merge_key(&job);
+        match by_key.get_mut(&key) {
+            Some(kept) => {
+                if description_len(&job) > description_len(kept) {
+                    kept.description = job.description;
+                }
+            }
+            None => {
+                order.push(key.clone());
+                by_key.insert(key, job);
+            }
+        }
+    }
+    let incoming: Vec<FoundJob> = order
+        .into_iter()
+        .map(|k| by_key.remove(&k).expect("key inserted above"))
+        .collect();
+
+    // 2) Merge the de-duplicated batch against existing rows, keyed the same way so
+    //    a re-surfaced posting matches regardless of which URL variant/source
+    //    persisted it.
+    let incoming_by_key: HashMap<String, &FoundJob> =
+        incoming.iter().map(|j| (merge_key(j), j)).collect();
 
     let refreshed_existing: Vec<FoundJob> = existing
         .iter()
         .map(|e| {
             let mut row = e.clone();
             row.is_new = false;
-            if let Some(inc) = incoming_by_url.get(e.url.as_str()) {
+            if let Some(inc) = incoming_by_key.get(&merge_key(e)) {
                 row.title = inc.title.clone();
                 row.company = inc.company.clone();
                 if inc.location.is_some() {
                     row.location = inc.location.clone();
                 }
                 // Carry the board over: existing rows persisted before `board` existed
-                // (`None`) pick it up when the same URL re-surfaces; the append branch
-                // (`..inc`) preserves it for never-seen URLs.
+                // (`None`) pick it up when the same job re-surfaces; the append branch
+                // (`..inc`) preserves it for never-seen jobs.
                 if inc.board.is_some() {
                     row.board = inc.board.clone();
                 }
@@ -765,7 +830,7 @@ fn merge_found_jobs(existing: &[FoundJob], incoming: Vec<FoundJob>) -> Vec<Found
                 }
                 // Same legacy-migration case as `board` above: an existing row
                 // persisted before `trust` existed (`None`) picks it up when the
-                // same URL re-surfaces on a later run.
+                // same job re-surfaces on a later run.
                 if inc.trust.is_some() {
                     row.trust = inc.trust.clone();
                 }
@@ -774,13 +839,12 @@ fn merge_found_jobs(existing: &[FoundJob], incoming: Vec<FoundJob>) -> Vec<Found
         })
         .collect();
 
-    let existing_urls: std::collections::HashSet<&str> =
-        existing.iter().map(|j| j.url.as_str()).collect();
+    let existing_keys: HashSet<String> = existing.iter().map(merge_key).collect();
     // New jobs go on top: the batch is already score-sorted desc upstream
     // (commands/autopilot.rs), so preserving incoming order here keeps that.
     let mut merged: Vec<FoundJob> = incoming
         .into_iter()
-        .filter(|inc| !existing_urls.contains(inc.url.as_str()))
+        .filter(|inc| !existing_keys.contains(&merge_key(inc)))
         .map(|inc| FoundJob {
             is_new: true,
             applied: false,

--- a/apps/desktop/src-tauri/src/autopilot/test.rs
+++ b/apps/desktop/src-tauri/src/autopilot/test.rs
@@ -680,6 +680,124 @@ fn merge_puts_newly_found_jobs_on_top() {
     assert_eq!(merged[1].url, "old", "prior finds fall below the new one");
 }
 
+// ── Cross-source / canonical-URL dedup ────────────────────────────────────────
+
+#[test]
+fn merge_dedups_same_job_across_two_url_variants() {
+    // Same job captured two ways: tracking query params vs. a hash fragment.
+    let a = found_job(
+        "https://boards.example.com/jobs/42?utm_source=aggregator",
+        1,
+    );
+    let b = found_job("https://boards.example.com/jobs/42#apply", 2);
+
+    let merged = merge_found_jobs(&[], vec![a, b]);
+
+    assert_eq!(
+        merged.len(),
+        1,
+        "tracking-param and hash variants of one job URL must merge to a single row"
+    );
+    assert!(merged[0].is_new, "the single merged row is newly surfaced");
+}
+
+#[test]
+fn merge_dedups_internal_batch_duplicate() {
+    // The same job surfaced by two sources (aggregator + a named board) in ONE run.
+    let from_aggregator = found_job("https://jobs.example.com/eng-42", 1);
+    let from_board = found_job("https://jobs.example.com/eng-42", 2);
+
+    let merged = merge_found_jobs(&[], vec![from_aggregator, from_board]);
+
+    assert_eq!(
+        merged.len(),
+        1,
+        "an internal batch duplicate must produce exactly one row"
+    );
+}
+
+#[test]
+fn merge_distinct_jobs_are_unaffected_by_dedup() {
+    let merged = merge_found_jobs(
+        &[],
+        vec![
+            found_job("https://a.example.com/1", 1),
+            found_job("https://b.example.com/2", 2),
+            found_job("https://c.example.com/3", 3),
+        ],
+    );
+
+    assert_eq!(
+        merged.len(),
+        3,
+        "three distinct jobs must remain three rows"
+    );
+    assert!(merged.iter().all(|j| j.is_new));
+}
+
+#[test]
+fn merge_within_batch_dup_keeps_longer_description() {
+    // First-seen carries a short description; the later duplicate a longer one.
+    let mut short = found_job("https://jobs.example.com/eng-42?ref=a", 1);
+    short.description = Some("short".into());
+    let mut long = found_job("https://jobs.example.com/eng-42?ref=b", 2);
+    long.description = Some("a much longer and more complete description".into());
+
+    let merged = merge_found_jobs(&[], vec![short, long]);
+
+    assert_eq!(merged.len(), 1, "the two variants merge to one row");
+    assert_eq!(
+        merged[0].description.as_deref(),
+        Some("a much longer and more complete description"),
+        "the longer description from the later duplicate must win"
+    );
+}
+
+#[test]
+fn merge_dedups_url_less_jobs_by_title_and_company() {
+    // No URL → fall back to a normalized title+company key. `found_job` sets
+    // title "Engineer", company "Acme".
+    let a = found_job("", 1); // url ""            → fallback key
+    let b = found_job("   ", 2); // whitespace url  → normalizes to "" → same key
+    let mut c = found_job("", 3);
+    c.company = "Globex".into(); // same title, different company → distinct key
+
+    let merged = merge_found_jobs(&[], vec![a, b, c]);
+
+    assert_eq!(
+        merged.len(),
+        2,
+        "URL-less jobs dedupe by normalized title+company: the two Acme rows merge, Globex stays"
+    );
+}
+
+#[test]
+fn record_run_new_count_reflects_deduped_batch() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let store = AutopilotStore::new(&temp.path().to_path_buf());
+    let ap = store.create(serde_json::json!({
+        "name": "AP",
+        "target": { "board": "aggregator", "query": "rust", "pages": 1 },
+        "filter": { "minMatchScore": 0.0 },
+        "schedule": "manual",
+    }));
+    let id = ap.id;
+
+    // One logical job surfaced by two sources + one genuinely distinct job.
+    let dup_a = found_job("https://jobs.example.com/eng-1?utm_source=x", 1);
+    let dup_b = found_job("https://jobs.example.com/eng-1#frag", 2);
+    let other = found_job("https://jobs.example.com/eng-2", 3);
+
+    let new_count = store.record_run(&id, 3, 0, vec![dup_a, dup_b, other]);
+
+    assert_eq!(
+        new_count, 2,
+        "the 'N new jobs' count must reflect the DEDUPED batch (2 unique), not the raw 3"
+    );
+}
+
 #[test]
 fn record_run_reports_only_newly_surfaced_jobs() {
     use tempfile::TempDir;

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -1083,23 +1083,32 @@ async fn primary_chain(
                 )
                 .await
             {
-                Ok(items) if items.is_empty() && country_guessed && !location.is_empty() => {
-                    // Guessed-market guard (see doc comment above): an empty result
-                    // from a GUESSED country with a real location is untrustworthy.
-                    // Treat it like an Adzuna error and fall through below instead
-                    // of returning early.
+                Ok(items)
+                    if items.len() < ADZUNA_BROADEN_FLOOR
+                        && country_guessed
+                        && !location.is_empty() =>
+                {
+                    // Guessed-market guard (see doc comment above): a SPARSE result —
+                    // fewer than the broaden floor — from a GUESSED country with a real
+                    // location is untrustworthy. "London" defaulting to "de" returns
+                    // either nothing or a handful of stray German hits; neither should
+                    // be trusted as authoritative. Treat it like an Adzuna error and
+                    // fall through below (to JSearch, which is global + free-text)
+                    // instead of returning those few results as the whole answer.
                     //
                     // PRIVACY: never log/persist the raw user-entered `location` —
                     // it's free-text PII, not something this repo puts in logs or
                     // diagnostics. `country` (the guessed market code) is fine.
                     log::warn!(
-                        "[aggregator] adzuna guessed market '{country}' returned no results \
-                         for the supplied location (no country_code supplied); \
-                         attempting jsearch fallback"
+                        "[aggregator] adzuna guessed market '{country}' returned too few \
+                         results ({}) for the supplied location (no country_code supplied); \
+                         attempting jsearch fallback",
+                        items.len()
                     );
                     adzuna_configured_failed = Some(anyhow::anyhow!(
-                        "adzuna: guessed market '{country}' returned no results for the \
-                         supplied location (no country was supplied)"
+                        "adzuna: guessed market '{country}' returned too few results ({}) for \
+                         the supplied location (no country was supplied)",
+                        items.len()
                     ));
                     // Fall through to JSearch/diagnostic below.
                 }
@@ -1314,6 +1323,39 @@ async fn search_with_providers(
     }
 }
 
+// ── Credential-state helpers (needs-keys skip vs. store-error) ──────────────────
+
+/// Whether at least one aggregator provider is fully configured. Constructs the
+/// providers fresh — the same keyring read the search path does — so a key added
+/// in Settings clears any `needs-keys` skip on the next run. Apify counts only
+/// when its opt-in toggle AND token are both present (its own `is_configured`).
+///
+/// Provider construction swallows a keyring READ FAILURE to an unconfigured
+/// state; that fault is classified separately by [`aggregator_store_error`] so it
+/// surfaces as a board error rather than a misleading `needs-keys` skip.
+fn aggregator_has_configured_provider() -> bool {
+    AdzunaProvider::new().is_configured()
+        || JSearchProvider::new().is_configured()
+        || ApifyLinkedInProvider::new().is_configured()
+}
+
+/// First keyring READ error across the aggregator's primary provider slots, if
+/// any. Distinguishes a credential-store FAULT (surfaced as a board error) from
+/// mere key absence (surfaced as a `needs-keys` skip). Returns `None` when every
+/// slot reads cleanly — whether the key is present or simply absent.
+///
+/// The error string is a keyring backend message + slot name only; it never
+/// carries a credential value (see `credentials::read_credential`).
+fn aggregator_store_error() -> Option<String> {
+    use crate::ipc_contracts::provider_slots::{ADZUNA_APP_ID, ADZUNA_APP_KEY, JSEARCH_KEY};
+    for slot in [ADZUNA_APP_ID, ADZUNA_APP_KEY, JSEARCH_KEY] {
+        if let Err(e) = crate::credentials::read_credential(&format!("ai:{slot}")) {
+            return Some(e.to_string());
+        }
+    }
+    None
+}
+
 // ── Scraper impl ──────────────────────────────────────────────────────────────
 
 pub struct AggregatorScraper;
@@ -1341,11 +1383,29 @@ impl Scraper for AggregatorScraper {
         false
     }
 
+    fn needs_keys(&self) -> bool {
+        // Skip with "needs-keys" only when the store reads cleanly but has no
+        // usable provider keys. A store READ FAILURE is NOT a skip — `search`
+        // surfaces it as a board error instead — so short-circuit on that case.
+        aggregator_store_error().is_none() && !aggregator_has_configured_provider()
+    }
+
     async fn search(
         &self,
         input: BoardSearchInput,
         ctx: ScrapeContext,
     ) -> anyhow::Result<Vec<JobPosting>> {
+        // Surface a credential-store FAILURE (keyring unavailable) as a real board
+        // error rather than the silent keyless-empty a missing key produces. Mere
+        // key absence is handled upstream by the engine's `needs-keys` skip, so by
+        // the time `search` runs the only credential fault left to report is a
+        // store read error.
+        if let Some(msg) = aggregator_store_error() {
+            return Err(anyhow::anyhow!(
+                "aggregator: credential store unavailable ({msg})"
+            ));
+        }
+
         let query = input.query.trim();
         let location = input.location.as_deref().unwrap_or("").trim();
         // Whether the caller supplied a real `country_code`, vs us GUESSING "de"

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -21,113 +21,27 @@
 /// Rate-limiting and cancellation are honoured: every network call flows
 /// through `scraping::http::fetch_json` (which checks `ctx.signal` and calls
 /// the per-host `rate_limiter`).
+///
+/// The three `JobProvider` impls (Adzuna/JSearch/Apify) live in `providers.rs`
+/// (split out to stay under the R8 module-size cap); this file holds the shared
+/// `JobProvider` trait, the fallback orchestration (`primary_chain` /
+/// `search_with_providers`), the credential-state helpers, and the `Scraper` impl.
 use async_trait::async_trait;
-use serde::Deserialize;
 
-use crate::scraping::http::{fetch_json, html_to_markdown, FetchOptions};
 use crate::scraping::types::{
     AuthRequirement, BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode,
 };
 
-// ── Serde helpers ─────────────────────────────────────────────────────────────
-
-/// Accept either a JSON string or a JSON integer for the Adzuna `id` field,
-/// normalizing both to `String`.  Adzuna documents the field as a string but
-/// the live API returns it as an integer (e.g. `331705081`).
-fn de_string_or_number<'de, D>(de: D) -> Result<String, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum StringOrNumber {
-        Str(String),
-        Num(i64),
-    }
-
-    match StringOrNumber::deserialize(de)? {
-        StringOrNumber::Str(s) => Ok(s),
-        StringOrNumber::Num(n) => Ok(n.to_string()),
-    }
-}
-
-/// Like [`de_string_or_number`] but for an OPTIONAL field, tolerating `null` /
-/// absent / string / number. Used for the Apify actor's loosely-typed `id` and
-/// `postedAt`, which vary by run (string id, numeric id, or omitted).
-fn de_opt_string_or_number<'de, D>(de: D) -> Result<Option<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = Option::<serde_json::Value>::deserialize(de)?;
-    Ok(value.and_then(|v| match v {
-        serde_json::Value::String(s) => Some(s),
-        serde_json::Value::Number(n) => Some(n.to_string()),
-        _ => None,
-    }))
-}
-
-// ── Date-filter helpers ────────────────────────────────────────────────────────
-
-/// Map a UI date-filter token to Adzuna's `max_days_old` integer (whole days).
-///
-// ponytail: Adzuna's recency granularity is whole days — it can't do sub-day. A
-// 1-day ceiling zeroed out autopilot "recent" filters on quiet days (a normal
-// query returns near-nothing in a single day), so sub-day windows FLOOR at 3 days
-// and rely on the query's `sort_by=date` for freshness instead of a hard clamp.
-// No filter / unrecognized token caps at 30 days so the aggregator never surfaces
-// postings older than a month. (Coarse mapping; 3-day floor / 30-day ceiling.)
-fn adzuna_max_days_old(date_filter: Option<&str>) -> u32 {
-    match date_filter {
-        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => 3,
-        Some("week") => 7,
-        _ => 30,
-    }
-}
+mod providers;
+use providers::*;
 
 /// Below this many results from a supported market, a non-empty `where` retries
-/// once country-wide (see `AdzunaProvider::search`). A city geocode can be sparse
-/// even when the country has plenty; broadening recovers the full market page.
+/// once country-wide (see `AdzunaProvider::search` in `providers.rs`). A city
+/// geocode can be sparse even when the country has plenty; broadening recovers
+/// the full market page. Also gates `primary_chain`'s guessed-market fallback
+/// below — shared between both, hence it stays at this level rather than moving
+/// into `providers.rs` with the provider implementations.
 const ADZUNA_BROADEN_FLOOR: usize = 3;
-
-/// Whether to broaden a sparse Adzuna result to a country-wide (`where=""`) retry.
-/// Only for an explicitly-supplied country (`!country_guessed`) — broadening a
-/// GUESSED market would defeat primary_chain's guessed-market → JSearch fallback,
-/// which keys off Adzuna returning empty.
-fn should_broaden(country_guessed: bool, where_val: &str, count: usize) -> bool {
-    !country_guessed && !where_val.is_empty() && count < ADZUNA_BROADEN_FLOOR
-}
-
-/// Adzuna's `where` wants a place *inside* the market (the country is already the
-/// URL path segment), so a trailing ", Germany"/", Deutschland" just over-narrows the
-/// geocode. Keep the first comma-segment (the city/region), trimmed.
-// ponytail: first-segment heuristic. A country-name-only location (e.g. "germany")
-// already returns Adzuna's full page, so no country-name table is needed.
-fn adzuna_where(location: &str) -> &str {
-    location.split(',').next().map(str::trim).unwrap_or("")
-}
-
-/// Map a UI date-filter token to JSearch's `date_posted` query token
-/// (`all|today|3days|week|month`). Sub-day windows floor at `3days` — like Adzuna,
-/// JSearch has no sub-day granularity, and a `today` ceiling zeroed out autopilot
-/// "recent" filters on quiet days. The freshest still surface first because the
-/// JSearch request pairs this window with `&sort_by=date` (JSearch defaults to
-/// relevance, not recency — the sort param is what makes the guarantee true).
-/// No filter / unrecognized token caps at `month`.
-///
-// ponytail: intentional cross-provider recency skew for sub-day tokens (e.g.
-// `"24h"`). The free/cheap providers can't do sub-day granularity, so Adzuna
-// (`adzuna_max_days_old` → 3) and JSearch (here → `3days`) both widen to 3 days,
-// while the paid Apify/LinkedIn path (`apify_f_tpr` → `r86400`) keeps a strict
-// ≤24h window. Merged results therefore mix recency windows for sub-day filters —
-// the deliberate tradeoff (surface *something* over nothing on quiet days); a
-// future reader shouldn't "fix" the skew back into a hard clamp.
-fn jsearch_date_posted(date_filter: Option<&str>) -> &'static str {
-    match date_filter {
-        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => "3days",
-        Some("week") => "week",
-        _ => "month",
-    }
-}
 
 // ── Provider trait ────────────────────────────────────────────────────────────
 
@@ -162,867 +76,6 @@ pub(crate) trait JobProvider: Send + Sync {
     ) -> anyhow::Result<Vec<JobPosting>>;
 }
 
-// ── Adzuna supported-country allowlist ───────────────────────────────────────
-
-/// ISO 3166-1 alpha-2 country codes hosted by Adzuna's job-search API.
-///
-/// Source: Adzuna API documentation at <https://api.adzuna.com/v1/doc>
-/// (path-parameter enumeration visible in the interactive endpoint reference).
-/// Verified against the known set as of 2026-06-23; update this list if
-/// Adzuna adds new markets (the path `/v1/api/jobs/{country}/search/1` returns
-/// a non-2xx error body for any code not in this set, which is indistinguishable
-/// from an auth failure without real keys — see code comment in `search`).
-const ADZUNA_SUPPORTED_COUNTRIES: &[&str] = &[
-    "at", // Austria
-    "au", // Australia
-    "be", // Belgium
-    "br", // Brazil
-    "ca", // Canada
-    "ch", // Switzerland
-    "de", // Germany
-    "es", // Spain
-    "fr", // France
-    "gb", // United Kingdom
-    "in", // India
-    "it", // Italy
-    "mx", // Mexico
-    "nl", // Netherlands
-    "nz", // New Zealand
-    "pl", // Poland
-    "sg", // Singapore
-    "us", // United States
-    "za", // South Africa
-];
-
-#[inline]
-fn adzuna_supports_country(country: &str) -> bool {
-    ADZUNA_SUPPORTED_COUNTRIES.contains(&country)
-}
-
-/// ISO-4217 currency for an Adzuna market. Adzuna's search API returns
-/// `salary_min`/`salary_max` as bare numbers with no currency field, so the
-/// currency has to be derived from the country the search targeted — one entry
-/// per code in [`ADZUNA_SUPPORTED_COUNTRIES`]. `None` for any country not in
-/// that list (the salary answer then falls back to a web lookup for currency
-/// instead of guessing).
-#[inline]
-fn adzuna_currency_for_country(country: &str) -> Option<&'static str> {
-    Some(match country {
-        "at" | "be" | "de" | "es" | "fr" | "it" | "nl" => "EUR",
-        "au" => "AUD",
-        "br" => "BRL",
-        "ca" => "CAD",
-        "ch" => "CHF",
-        "gb" => "GBP",
-        "in" => "INR",
-        "mx" => "MXN",
-        "nz" => "NZD",
-        "pl" => "PLN",
-        "sg" => "SGD",
-        "us" => "USD",
-        "za" => "ZAR",
-        _ => return None,
-    })
-}
-
-// ── Adzuna provider ───────────────────────────────────────────────────────────
-
-#[derive(Debug, Deserialize)]
-struct AdzunaCompany {
-    display_name: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AdzunaLocation {
-    display_name: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AdzunaJob {
-    #[serde(deserialize_with = "de_string_or_number")]
-    id: String,
-    title: String,
-    company: Option<AdzunaCompany>,
-    location: Option<AdzunaLocation>,
-    redirect_url: String,
-    description: Option<String>,
-    created: Option<String>,
-    salary_min: Option<f64>,
-    salary_max: Option<f64>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AdzunaResp {
-    results: Vec<AdzunaJob>,
-}
-
-pub(crate) struct AdzunaProvider {
-    app_id: Option<String>,
-    app_key: Option<String>,
-}
-
-impl AdzunaProvider {
-    fn new() -> Self {
-        use crate::ipc_contracts::provider_slots::{ADZUNA_APP_ID, ADZUNA_APP_KEY};
-        Self {
-            app_id: crate::credentials::read_credential(&format!("ai:{ADZUNA_APP_ID}"))
-                .unwrap_or_else(|e| {
-                    log::warn!("[aggregator] {ADZUNA_APP_ID} keyring error: {e}");
-                    None
-                }),
-            app_key: crate::credentials::read_credential(&format!("ai:{ADZUNA_APP_KEY}"))
-                .unwrap_or_else(|e| {
-                    log::warn!("[aggregator] {ADZUNA_APP_KEY} keyring error: {e}");
-                    None
-                }),
-        }
-    }
-}
-
-#[async_trait]
-impl JobProvider for AdzunaProvider {
-    fn provider_id(&self) -> &'static str {
-        "adzuna"
-    }
-
-    fn is_configured(&self) -> bool {
-        self.app_id.is_some() && self.app_key.is_some()
-    }
-
-    async fn search(
-        &self,
-        query: &str,
-        location: &str,
-        country: &str,
-        country_guessed: bool,
-        date_filter: Option<&str>,
-        _amount: Option<u32>,
-        signal: tokio_util::sync::CancellationToken,
-    ) -> anyhow::Result<Vec<JobPosting>> {
-        if !self.is_configured() {
-            return Err(anyhow::anyhow!("adzuna: not configured"));
-        }
-
-        // Reject unsupported countries before issuing any HTTP request.
-        // Adzuna only hosts a fixed set of markets; an unsupported country code
-        // would produce a non-2xx response (indistinguishable from an auth error
-        // at the HTTP level without real keys). Returning Err here lets the
-        // `search_with_providers` fallback chain transparently route to JSearch
-        // (which uses free-text location and is globally scoped).
-        let country = if country.is_empty() { "de" } else { country };
-        if !adzuna_supports_country(country) {
-            return Err(anyhow::anyhow!(
-                "adzuna: country '{country}' is not in Adzuna's supported market list \
-                 (supported: {}); configure a JSearch key for global coverage",
-                ADZUNA_SUPPORTED_COUNTRIES.join(", ")
-            ));
-        }
-
-        let app_id = self.app_id.as_deref().unwrap_or("");
-        let app_key = self.app_key.as_deref().unwrap_or("");
-
-        // Drop redundant country suffixes so a ", Germany"/", Deutschland" tail
-        // doesn't over-narrow the geocode (the country is already the URL path).
-        let where_hygienic = adzuna_where(location);
-
-        let postings = fetch_adzuna_page(
-            country,
-            app_id,
-            app_key,
-            query,
-            where_hygienic,
-            date_filter,
-            signal.clone(),
-        )
-        .await?;
-
-        // Broaden on near-empty: even a hygienic `where` can over-narrow a sparse
-        // market, so if a real Adzuna market returned under the floor, retry ONCE
-        // country-wide (`where=""`) — same `what`, sort, and `max_days_old` — and
-        // keep whichever set is larger. A transient error on the retry keeps the
-        // narrow result rather than discarding it.
-        //
-        // GUARD: never broaden a GUESSED market (`country_guessed`). Turning a
-        // guessed-market empty/near-empty into a non-empty country-wide result
-        // would defeat `primary_chain`'s guessed-market guard, which relies on
-        // an empty Adzuna result to fall through to JSearch (global, free-text
-        // location) when the guess is probably wrong (e.g. "London" defaulting
-        // to "de"). Only broaden for an explicitly-supplied country.
-        if should_broaden(country_guessed, where_hygienic, postings.len()) {
-            match fetch_adzuna_page(country, app_id, app_key, query, "", date_filter, signal).await
-            {
-                Ok(broadened) if broadened.len() > postings.len() => {
-                    // PRIVACY: never log the raw `where`/location — free-text PII.
-                    log::info!(
-                        "[aggregator] adzuna sparse result ({}), broadened country-wide ({})",
-                        postings.len(),
-                        broadened.len()
-                    );
-                    return Ok(broadened);
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    log::warn!(
-                        "[aggregator] adzuna broaden retry failed, keeping narrow result: {e}"
-                    )
-                }
-            }
-        }
-
-        Ok(postings)
-    }
-}
-
-/// Map one Adzuna result to a [`JobPosting`], deriving `extra.salaryCurrency`
-/// from `country` (Adzuna reports bare salary numbers with no currency field).
-/// Pulled out of `AdzunaProvider::search` so it's unit-testable without a
-/// network call.
-fn adzuna_job_to_posting(j: AdzunaJob, country: &str, now: i64) -> JobPosting {
-    let mut extra = std::collections::HashMap::new();
-    let has_salary = j.salary_min.is_some() || j.salary_max.is_some();
-    if let Some(min) = j.salary_min {
-        extra.insert("salaryMin".to_string(), serde_json::json!(min));
-    }
-    if let Some(max) = j.salary_max {
-        extra.insert("salaryMax".to_string(), serde_json::json!(max));
-    }
-    // Currency is only meaningful alongside an amount; an unmapped country
-    // omits it so the downstream salary answer falls back to a web lookup
-    // instead of showing a wrong/absent currency.
-    if has_salary {
-        if let Some(currency) = adzuna_currency_for_country(country) {
-            extra.insert("salaryCurrency".to_string(), serde_json::json!(currency));
-        }
-    }
-    JobPosting {
-        id: format!("aggregator:adzuna-{}", j.id),
-        external_id: Some(format!("adzuna-{}", j.id)),
-        title: j.title,
-        company: j.company.and_then(|c| c.display_name).unwrap_or_default(),
-        location: j.location.and_then(|l| l.display_name),
-        url: j.redirect_url,
-        source: "aggregator".to_string(),
-        description: j.description.map(|d| html_to_markdown(&d)),
-        requirements: None,
-        posted_at: j
-            .created
-            .as_deref()
-            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-            .map(|dt| dt.timestamp_millis()),
-        captured_at: now,
-        extra,
-    }
-}
-
-/// Build + fetch + parse ONE Adzuna page for a given `where` value.
-///
-/// Factored out of `AdzunaProvider::search` so the near-empty broaden retry can
-/// reissue the exact same request (same `what`, `sort_by=date`, `results_per_page`,
-/// and `max_days_old`) with only `where` changed. Called at most twice per search.
-async fn fetch_adzuna_page(
-    country: &str,
-    app_id: &str,
-    app_key: &str,
-    query: &str,
-    where_val: &str,
-    date_filter: Option<&str>,
-    signal: tokio_util::sync::CancellationToken,
-) -> anyhow::Result<Vec<JobPosting>> {
-    // Sort newest-first (Adzuna defaults to relevance, which floats stale postings
-    // up) and always bound the window with max_days_old so nothing older than the
-    // cap (30 days, or the user's tighter pick) is returned.
-    let url = format!(
-        "https://api.adzuna.com/v1/api/jobs/{}/search/1\
-         ?app_id={}&app_key={}&what={}&where={}&results_per_page=50&content-type=application/json\
-         &sort_by=date&sort_direction=down&max_days_old={}",
-        urlencoding::encode(country),
-        urlencoding::encode(app_id),
-        urlencoding::encode(app_key),
-        urlencoding::encode(query),
-        urlencoding::encode(where_val),
-        adzuna_max_days_old(date_filter),
-    );
-
-    let resp = match fetch_json::<AdzunaResp>(&url, FetchOptions::default(), signal).await? {
-        Some(r) => r,
-        None => {
-            return Err(anyhow::anyhow!(
-                "adzuna: non-2xx response or unparseable body"
-            ))
-        }
-    };
-
-    let now = chrono::Utc::now().timestamp_millis();
-    Ok(resp
-        .results
-        .into_iter()
-        .map(|j| adzuna_job_to_posting(j, country, now))
-        .collect())
-}
-
-// ── JSearch provider ──────────────────────────────────────────────────────────
-
-#[derive(Debug, Deserialize)]
-struct JSearchJob {
-    job_id: String,
-    job_title: String,
-    employer_name: Option<String>,
-    job_city: Option<String>,
-    job_country: Option<String>,
-    job_apply_link: Option<String>,
-    job_google_link: Option<String>,
-    job_description: Option<String>,
-    job_posted_at_datetime_utc: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct JSearchResp {
-    data: Vec<JSearchJob>,
-}
-
-pub(crate) struct JSearchProvider {
-    api_key: Option<String>,
-}
-
-impl JSearchProvider {
-    fn new() -> Self {
-        use crate::ipc_contracts::provider_slots::JSEARCH_KEY;
-        Self {
-            api_key: crate::credentials::read_credential(&format!("ai:{JSEARCH_KEY}"))
-                .unwrap_or_else(|e| {
-                    log::warn!("[aggregator] {JSEARCH_KEY} keyring error: {e}");
-                    None
-                }),
-        }
-    }
-}
-
-#[async_trait]
-impl JobProvider for JSearchProvider {
-    fn provider_id(&self) -> &'static str {
-        "jsearch"
-    }
-
-    fn is_configured(&self) -> bool {
-        self.api_key.is_some()
-    }
-
-    async fn search(
-        &self,
-        query: &str,
-        location: &str,
-        _country: &str,
-        _country_guessed: bool,
-        date_filter: Option<&str>,
-        _amount: Option<u32>,
-        signal: tokio_util::sync::CancellationToken,
-    ) -> anyhow::Result<Vec<JobPosting>> {
-        if !self.is_configured() {
-            return Err(anyhow::anyhow!("jsearch: not configured"));
-        }
-
-        let api_key = self.api_key.as_deref().unwrap_or("");
-
-        // JSearch takes a single free-text query field; combine query + location.
-        let combined = if location.is_empty() {
-            query.to_string()
-        } else {
-            format!("{query} in {location}")
-        };
-        let q_enc = urlencoding::encode(&combined);
-        let mut url = format!(
-            "https://jsearch.p.rapidapi.com/search?query={}&page=1&num_pages=1",
-            q_enc
-        );
-
-        // Sort newest-first (JSearch defaults to relevance, which does NOT put the
-        // freshest posting on top) so the widened `date_posted` window still surfaces
-        // the most-recent jobs first — matching Adzuna's `sort_by=date` and honouring
-        // the freshness guarantee documented on `jsearch_date_posted`.
-        url.push_str(&format!(
-            "&date_posted={}&sort_by=date",
-            jsearch_date_posted(date_filter)
-        ));
-
-        let result = fetch_json::<JSearchResp>(
-            &url,
-            FetchOptions {
-                headers: Some(vec![
-                    ("X-RapidAPI-Key".to_string(), api_key.to_string()),
-                    (
-                        "X-RapidAPI-Host".to_string(),
-                        "jsearch.p.rapidapi.com".to_string(),
-                    ),
-                ]),
-                ..FetchOptions::default()
-            },
-            signal,
-        )
-        .await?;
-
-        let resp = match result {
-            Some(r) => r,
-            None => {
-                return Err(anyhow::anyhow!(
-                    "jsearch: non-2xx response or unparseable body"
-                ))
-            }
-        };
-
-        let now = chrono::Utc::now().timestamp_millis();
-        let postings = resp
-            .data
-            .into_iter()
-            .filter_map(|j| {
-                let url = j
-                    .job_apply_link
-                    .clone()
-                    .or_else(|| j.job_google_link.clone())?;
-                let location = match (j.job_city.as_deref(), j.job_country.as_deref()) {
-                    (Some(c), Some(co)) if !c.is_empty() && !co.is_empty() => {
-                        Some(format!("{c}, {co}"))
-                    }
-                    (Some(c), _) if !c.is_empty() => Some(c.to_string()),
-                    (_, Some(co)) if !co.is_empty() => Some(co.to_string()),
-                    _ => None,
-                };
-                Some(JobPosting {
-                    id: format!("aggregator:jsearch-{}", j.job_id),
-                    external_id: Some(format!("jsearch-{}", j.job_id)),
-                    title: j.job_title,
-                    company: j.employer_name.unwrap_or_default(),
-                    location,
-                    url,
-                    source: "aggregator".to_string(),
-                    description: j.job_description.map(|d| html_to_markdown(&d)),
-                    requirements: None,
-                    posted_at: j
-                        .job_posted_at_datetime_utc
-                        .as_deref()
-                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                        .map(|dt| dt.timestamp_millis()),
-                    captured_at: now,
-                    extra: std::collections::HashMap::new(),
-                })
-            })
-            .collect();
-
-        Ok(postings)
-    }
-}
-
-// ── Non-secret aggregator settings (plugin-store JSON) ──────────────────────────
-//
-// The "Include LinkedIn (Apify)" opt-in toggle and the optional actor-id override
-// are NOT secrets, so they do not belong in the OS keychain. The renderer persists
-// them with `@tauri-apps/plugin-store` to `<app_data_dir>/scraping-settings.json`;
-// plugin-store resolves a relative store path against the app data dir — the SAME
-// directory `platform::config::data_dir()` resolves for AppHandle-less workers, so
-// the provider can read them here without an `AppHandle` (mirrors how API keys are
-// read AppHandle-free via `credentials::read_credential`).
-//
-// The file name + key strings are the cross-language contract in
-// `packages/shared/src/scraping-settings.ts`; the literals below are pinned to it
-// by `aggregator_settings_keys_match_shared_contract` in `test.rs`.
-const SCRAPING_SETTINGS_FILE: &str = "scraping-settings.json";
-const SETTING_APIFY_ENABLED: &str = "apifyLinkedinEnabled";
-const SETTING_APIFY_ACTOR_ID: &str = "apifyLinkedinActorId";
-
-#[derive(Debug, Default, Clone)]
-struct AggregatorSettings {
-    /// Master opt-in for the paid Apify LinkedIn provider. Default `false`.
-    apify_linkedin_enabled: bool,
-    /// Optional actor-id override; `None` → the built-in default actor.
-    apify_linkedin_actor_id: Option<String>,
-}
-
-/// Read the non-secret aggregator settings from the plugin-store JSON file.
-///
-/// Absent file, parse failure, or missing keys all degrade to defaults (toggle
-/// OFF) — never an error. A missing/garbled settings file must never crash a
-/// user-triggered search; it simply means the opt-in provider stays disabled.
-fn read_aggregator_settings() -> AggregatorSettings {
-    let path = crate::platform::config::data_dir().join(SCRAPING_SETTINGS_FILE);
-    let json: serde_json::Value = std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or(serde_json::Value::Null);
-
-    let apify_linkedin_enabled = json
-        .get(SETTING_APIFY_ENABLED)
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
-    let apify_linkedin_actor_id = json
-        .get(SETTING_APIFY_ACTOR_ID)
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-
-    AggregatorSettings {
-        apify_linkedin_enabled,
-        apify_linkedin_actor_id,
-    }
-}
-
-// ── Apify LinkedIn provider (additive, paid) ────────────────────────────────────
-
-/// Default Apify actor: scrapes public LinkedIn jobs with no LinkedIn login,
-/// billed pay-per-event (~$1.00 / 1000 results). Overridable via the non-secret
-/// `apifyLinkedinActorId` setting.
-const APIFY_DEFAULT_ACTOR: &str = "curious_coder~linkedin-jobs-scraper";
-
-// ponytail: HARD cost ceiling. Apify bills per dataset result, so every run is
-// bounded by `count = APIFY_MAX_ITEMS`; we NEVER issue an unbounded fetch. The
-// opt-in toggle (gated in `is_configured`) is the second, mandatory cost gate —
-// a stored token ALONE never triggers a paid run.
-const APIFY_MAX_ITEMS: u32 = 50;
-
-/// `run-sync-get-dataset-items` is capped at 300s server-side (returns 408 on
-/// timeout); give the client a matching wall-clock ceiling so a stalled actor
-/// run can't hang the scrape.
-const APIFY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
-
-/// Server-side USD ceiling for pay-per-event actor overrides. Belt-and-suspenders
-/// on top of `maxItems`: a user who overrides the actor to a pay-per-event model
-/// is still bounded by this hard Apify platform limit.
-const APIFY_MAX_CHARGE_USD: &str = "1.00";
-
-/// INVARIANT: retries=0 for every Apify `run-sync-get-dataset-items` call.
-/// The endpoint is NON-IDEMPOTENT and billed per result — a retry on 429/503/network
-/// would start ANOTHER charged actor run (up to 3× cost with the default retries=2).
-/// Shared by production code and tests so a change to either breaks the invariant check.
-const APIFY_RETRIES: u32 = 0;
-
-/// Validate an Apify actor id against the platform grammar `user~actor`.
-///
-/// Both parts must be non-empty and consist solely of `[A-Za-z0-9_.-]`.
-/// A malformed id injected via `apifyLinkedinActorId` could otherwise reach
-/// the API URL (even though the host is fixed, a path-traversal like
-/// `../../v1/…` is still a concern). An invalid id falls back silently to
-/// `APIFY_DEFAULT_ACTOR` — the provider logs a warning and continues.
-fn is_valid_apify_actor_id(id: &str) -> bool {
-    let valid_part = |s: &str| {
-        !s.is_empty()
-            && s.chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-')
-    };
-    match id.split_once('~') {
-        Some((user, actor)) => valid_part(user) && valid_part(actor),
-        None => false,
-    }
-}
-
-/// Build the Apify `run-sync-get-dataset-items` endpoint URL for a given actor.
-///
-/// `max_items` is the server-side platform cap for this request; callers compute
-/// it as `min(APIFY_MAX_ITEMS, amount - primary.len())` so we never fetch more
-/// than actually needed.  The Bearer token is NEVER included here — it goes in
-/// the `Authorization` header only, keeping it out of request-URL logging.
-///
-/// This is the single source of truth consumed by both the production call in
-/// [`ApifyLinkedInProvider::search`] and the invariant test in `test.rs`. A future
-/// refactor that removes either cap would break the test that calls this function.
-fn build_apify_endpoint(actor_id: &str, max_items: u32) -> String {
-    format!(
-        "https://api.apify.com/v2/acts/{}/run-sync-get-dataset-items\
-         ?maxItems={}&maxTotalChargeUsd={}",
-        actor_id, max_items, APIFY_MAX_CHARGE_USD
-    )
-}
-
-/// Map a UI date-filter token to LinkedIn's `f_TPR` recency parameter. Sub-day
-/// windows collapse to the past 24h (`r86400`); `week` → `r604800`; everything
-/// else (month / no filter / unknown) caps at the past month (`r2592000`),
-/// mirroring the 30-day ceiling the other providers enforce.
-fn apify_f_tpr(date_filter: Option<&str>) -> &'static str {
-    match date_filter {
-        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => "r86400",
-        Some("week") => "r604800",
-        _ => "r2592000",
-    }
-}
-
-/// Build the public LinkedIn jobs-search URL the actor expects as input (it
-/// scrapes pre-built search URLs, not a raw keyword string). Query + location are
-/// percent-encoded; recency comes from [`apify_f_tpr`].
-fn build_linkedin_search_url(query: &str, location: &str, date_filter: Option<&str>) -> String {
-    let q = urlencoding::encode(query);
-    let loc = urlencoding::encode(location);
-    let f_tpr = apify_f_tpr(date_filter);
-    format!("https://www.linkedin.com/jobs/search/?keywords={q}&location={loc}&f_TPR={f_tpr}")
-}
-
-/// Try to parse the actor's `postedAt` into epoch millis: RFC-3339 first, then a
-/// bare epoch (seconds scaled to millis, or millis as-is). A relative string
-/// ("2 weeks ago") yields `None` — an absent posted date is acceptable.
-fn parse_apify_posted_at(s: &str) -> Option<i64> {
-    let s = s.trim();
-    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
-        return Some(dt.timestamp_millis());
-    }
-    if let Ok(n) = s.parse::<i64>() {
-        // < 10^12 ≈ seconds (any plausible ms epoch is far larger).
-        return Some(if n < 1_000_000_000_000 { n * 1000 } else { n });
-    }
-    None
-}
-
-/// One dataset item from the Apify actor. Every field is optional + defensively
-/// aliased: the actor's output shape drifts between runs/versions, so we accept
-/// the documented field names plus sensible fallbacks and skip anything unusable.
-#[derive(Debug, Clone, Deserialize)]
-struct ApifyItem {
-    #[serde(default, alias = "jobTitle")]
-    title: Option<String>,
-    #[serde(default, rename = "companyName")]
-    company_name: Option<String>,
-    #[serde(default)]
-    location: Option<String>,
-    #[serde(default, rename = "jobUrl")]
-    job_url: Option<String>,
-    #[serde(default, deserialize_with = "de_opt_string_or_number")]
-    id: Option<String>,
-    #[serde(
-        default,
-        rename = "postedAt",
-        deserialize_with = "de_opt_string_or_number"
-    )]
-    posted_at: Option<String>,
-    #[serde(default, rename = "descriptionText")]
-    description_text: Option<String>,
-    #[serde(default, rename = "jobDescription")]
-    job_description: Option<String>,
-    #[serde(default, rename = "descriptionHtml")]
-    description_html: Option<String>,
-}
-
-/// Validate that a URL from the Apify actor is HTTPS on a `linkedin.com` host.
-///
-/// A drifting or user-overridden actor could inject arbitrary URLs into
-/// `JobPosting.url`.  We constrain the output to the only expected domain
-/// (`linkedin.com` / `*.linkedin.com`) and scheme (`https`).  Items whose URL
-/// fails validation are dropped — same as items missing title/url.
-fn is_valid_apify_linkedin_url(url: &str) -> bool {
-    if let Ok(parsed) = reqwest::Url::parse(url) {
-        // host_str() is already lowercase after Url::parse (URL standard).
-        return parsed.scheme() == "https"
-            && parsed
-                .host_str()
-                .is_some_and(|h| h == "linkedin.com" || h.ends_with(".linkedin.com"));
-    }
-    false
-}
-
-/// Build the `FetchOptions` for the Apify `run-sync-get-dataset-items` call.
-///
-/// The Bearer token goes in the Authorization header only — never the URL.
-/// `retries` is hardwired to `APIFY_RETRIES` (0): the endpoint is NON-IDEMPOTENT
-/// and billed per result; a retry would start another charged run.
-///
-/// This is the single source of truth consumed by [`ApifyLinkedInProvider::search`]
-/// and by the invariant test in `test.rs`.  Removing the `retries` override here
-/// breaks the test.
-fn apify_fetch_options(body: String, token: &str) -> FetchOptions {
-    FetchOptions {
-        method: Some(reqwest::Method::POST),
-        body: Some(body),
-        headers: Some(vec![
-            ("authorization".to_string(), format!("Bearer {token}")),
-            ("content-type".to_string(), "application/json".to_string()),
-        ]),
-        timeout: Some(APIFY_TIMEOUT),
-        retries: APIFY_RETRIES, // NON-IDEMPOTENT: each run is billed — never retry
-        ..FetchOptions::default()
-    }
-}
-
-/// Defensively map an [`ApifyItem`] to a [`JobPosting`]. Returns `None` when the
-/// item lacks BOTH a usable title and a usable URL (no `jobUrl` and no `id` to
-/// construct one) — such an item can't be opened, so it's dropped.
-fn map_apify_item(item: ApifyItem, now: i64) -> Option<JobPosting> {
-    let title = item
-        .title
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())?;
-
-    let id = item
-        .id
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-
-    // URL: explicit jobUrl wins; for the id-constructed fallback, require a
-    // digits-only id so we never interpolate an arbitrary string into a path.
-    let url = item
-        .job_url
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .or_else(|| {
-            id.as_deref()
-                .filter(|s| s.chars().all(|c| c.is_ascii_digit()))
-                .map(|id| format!("https://www.linkedin.com/jobs/view/{id}"))
-        })?;
-
-    // Security: drop items whose URL is not HTTPS on a linkedin.com host.
-    // A drifting actor can inject non-LinkedIn or non-HTTPS URLs; we reject those.
-    if !is_valid_apify_linkedin_url(&url) {
-        return None;
-    }
-
-    let description = item
-        .description_text
-        .or(item.job_description)
-        .or(item.description_html)
-        .map(|d| html_to_markdown(&d));
-
-    let posted_at = item.posted_at.as_deref().and_then(parse_apify_posted_at);
-
-    // Stable external id for dedupe: the LinkedIn job id when present, else the URL.
-    let external_id = id
-        .map(|id| format!("linkedin-{id}"))
-        .unwrap_or_else(|| format!("linkedin-{url}"));
-
-    Some(JobPosting {
-        id: format!("aggregator:{external_id}"),
-        external_id: Some(external_id),
-        title,
-        company: item
-            .company_name
-            .map(|s| s.trim().to_string())
-            .unwrap_or_default(),
-        location: item
-            .location
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty()),
-        url,
-        source: "aggregator".to_string(),
-        description,
-        requirements: None,
-        posted_at,
-        captured_at: now,
-        extra: std::collections::HashMap::new(),
-    })
-}
-
-pub(crate) struct ApifyLinkedInProvider {
-    token: Option<String>,
-    /// The opt-in toggle. `is_configured()` requires this AND a token.
-    enabled: bool,
-    actor_id: String,
-}
-
-impl ApifyLinkedInProvider {
-    fn new() -> Self {
-        use crate::ipc_contracts::provider_slots::APIFY_TOKEN;
-        let token = crate::credentials::read_credential(&format!("ai:{APIFY_TOKEN}"))
-            .unwrap_or_else(|e| {
-                log::warn!("[aggregator] {APIFY_TOKEN} keyring error: {e}");
-                None
-            });
-        let settings = read_aggregator_settings();
-        // Validate the user-supplied actor id before interpolating it into the
-        // API path. Falls back to the default actor on mismatch; never panics.
-        let actor_id = settings
-            .apify_linkedin_actor_id
-            .filter(|id| {
-                if is_valid_apify_actor_id(id) {
-                    true
-                } else {
-                    log::warn!(
-                        "[aggregator] apifyLinkedinActorId is not a valid Apify actor id \
-                         (expected user~actor grammar); falling back to the default actor"
-                    );
-                    false
-                }
-            })
-            .unwrap_or_else(|| APIFY_DEFAULT_ACTOR.to_string());
-        Self {
-            token,
-            enabled: settings.apify_linkedin_enabled,
-            actor_id,
-        }
-    }
-}
-
-#[async_trait]
-impl JobProvider for ApifyLinkedInProvider {
-    fn provider_id(&self) -> &'static str {
-        "apify_linkedin"
-    }
-
-    fn is_configured(&self) -> bool {
-        // BOTH gates are mandatory: an Apify token present AND the user opted in.
-        // Never run a paid scrape just because a token happens to be stored.
-        self.token.is_some() && self.enabled
-    }
-
-    async fn search(
-        &self,
-        query: &str,
-        location: &str,
-        _country: &str,
-        _country_guessed: bool,
-        date_filter: Option<&str>,
-        amount: Option<u32>,
-        signal: tokio_util::sync::CancellationToken,
-    ) -> anyhow::Result<Vec<JobPosting>> {
-        if !self.is_configured() {
-            return Err(anyhow::anyhow!("apify_linkedin: not configured"));
-        }
-
-        let token = self.token.as_deref().unwrap_or("");
-        let search_url = build_linkedin_search_url(query, location, date_filter);
-
-        // Dynamic cost cap: honour the caller's remaining budget (amount - primary.len())
-        // passed in by `search_with_providers`, capped at the absolute maximum.
-        // `maxItems` is the Apify platform-enforced server-side cap; `count` in the
-        // actor body is the actor-input budget (a user-overridden actor might ignore
-        // `count`, so both must agree). Bearer token stays in the Authorization header
-        // only — never the URL or query string.
-        let max_items = amount.unwrap_or(APIFY_MAX_ITEMS).min(APIFY_MAX_ITEMS);
-        let endpoint = build_apify_endpoint(&self.actor_id, max_items);
-
-        let body = serde_json::json!({
-            "urls": [search_url],
-            "count": max_items,
-        })
-        .to_string();
-
-        // POST via the shared scraping client.
-        //
-        // INVARIANT: retries=0 (via `apify_fetch_options`).  The endpoint is
-        // NON-IDEMPOTENT and billed per result — a retry would start ANOTHER charged
-        // actor run (up to 3× cost with the default retries=2). Never retry.
-        //
-        // `tokio::select!` races the paid fetch against the cancellation signal so
-        // a user cancel mid-flight is honoured within one poll cycle.
-        let raw = tokio::select! {
-            _ = signal.cancelled() => {
-                return Err(anyhow::anyhow!("apify_linkedin: cancelled"));
-            }
-            result = fetch_json::<Vec<ApifyItem>>(
-                &endpoint,
-                apify_fetch_options(body, token),
-                signal.clone(),
-            ) => result?
-        };
-        let items = raw.ok_or_else(|| {
-            anyhow::anyhow!(
-                "apify_linkedin: non-2xx response, timeout (408), or unparseable dataset body"
-            )
-        })?;
-
-        let now = chrono::Utc::now().timestamp_millis();
-        Ok(items
-            .into_iter()
-            .filter_map(|it| map_apify_item(it, now))
-            .collect())
-    }
-}
-
 // ── Fallback logic ────────────────────────────────────────────────────────────
 
 /// Run the provider chain: Adzuna primary, JSearch fallback.
@@ -1040,11 +93,19 @@ impl JobProvider for ApifyLinkedInProvider {
 /// as a GUESS, not a real target — a common autopilot shape (a prefilled/typed
 /// location with no geocode pick). If that guess comes back `Ok(empty)` for a
 /// real (non-empty) `location`, the location is very likely NOT in Germany, so
-/// trusting the empty guess would silently zero out an otherwise-findable
-/// search (the autopilot aggregator zero-jobs bug). Treat it like an Adzuna
-/// error instead: fall through to JSearch (global, free-text location) or
-/// surface the diagnostic. A guessed country with NO location (the keyless/
-/// no-location default) is unaffected — `Ok(empty)` there returns as before.
+/// trusting the sparse guess would silently zero out (or under-fill) an otherwise-
+/// findable search (the autopilot aggregator zero-jobs bug). Treat it like an
+/// Adzuna error instead: fall through to JSearch (global, free-text location).
+///
+/// - When a fallback IS configured it wins (the sparse Adzuna hits are dropped).
+/// - When NO fallback is configured (or it also fails), any real (non-empty)
+///   sparse hits are RETURNED as a last resort — a user with only Adzuna keys
+///   keeps their few legit results instead of losing them to a diagnostic error;
+///   an EMPTY guessed-market result still surfaces the diagnostic (nothing to
+///   salvage, and a silent zero is the bug we guard).
+///
+/// A guessed country with NO location (the keyless/no-location default) is
+/// unaffected — `Ok(empty)` there returns as before.
 ///
 /// Items from each provider are keyed by their `external_id` to deduplicate.
 async fn primary_chain(
@@ -1067,6 +128,14 @@ async fn primary_chain(
     // Track whether Adzuna was configured-but-failed so we can distinguish
     // "keys present, request failed" from "no keys at all" at the end.
     let mut adzuna_configured_failed: Option<anyhow::Error> = None;
+
+    // Real (non-empty) but SPARSE items from a GUESSED market. We distrust them
+    // enough to prefer a fallback, but if there is no working fallback they beat
+    // discarding legit hits for a zero-results error — so we retain and return them
+    // as a last resort. An EMPTY guessed-market result is NOT salvaged here (there
+    // is nothing to return, and a silent zero is the exact autopilot bug the
+    // diagnostic guards) — it keeps the diagnostic-Err path via `adzuna_configured_failed`.
+    let mut sparse_guessed_items: Option<Vec<JobPosting>> = None;
 
     // Run primary if configured.
     if let Some(p) = primary {
@@ -1110,6 +179,13 @@ async fn primary_chain(
                          the supplied location (no country was supplied)",
                         items.len()
                     ));
+                    // Retain the sparse-but-real hits so that, absent a working
+                    // fallback, we return them rather than discarding legit results
+                    // for a zero-results error. Empty stays unsalvaged (see the
+                    // `sparse_guessed_items` doc) and keeps the diagnostic-Err path.
+                    if !items.is_empty() {
+                        sparse_guessed_items = Some(items);
+                    }
                     // Fall through to JSearch/diagnostic below.
                 }
                 Ok(items) => {
@@ -1134,7 +210,7 @@ async fn primary_chain(
     // Try fallback.
     if let Some(f) = fallback {
         if f.is_configured() {
-            return f
+            match f
                 .search(
                     query,
                     location,
@@ -1145,11 +221,34 @@ async fn primary_chain(
                     signal,
                 )
                 .await
-                .map(dedupe);
+            {
+                Ok(items) => return Ok(dedupe(items)),
+                Err(e) => {
+                    // Fallback itself failed. If we retained sparse-but-real Adzuna
+                    // items from a guessed market, return those (better than nothing)
+                    // rather than surfacing the fallback error and losing legit hits.
+                    if let Some(items) = sparse_guessed_items.take() {
+                        log::warn!(
+                            "[aggregator] jsearch fallback failed ({e}); returning {} \
+                             sparse guessed-market adzuna result(s) instead",
+                            items.len()
+                        );
+                        return Ok(dedupe(items));
+                    }
+                    return Err(e);
+                }
+            }
         }
     }
 
-    // Adzuna had keys but failed (e.g. unsupported country, or an empty guessed
+    // No working fallback fired. If we retained sparse guessed-market items, return
+    // them rather than the diagnostic — a user with only Adzuna keys keeps their few
+    // legit hits (better than nothing). The uncertainty was already logged above.
+    if let Some(items) = sparse_guessed_items {
+        return Ok(dedupe(items));
+    }
+
+    // Adzuna had keys but failed (e.g. unsupported country, or an EMPTY guessed
     // market) AND JSearch is not configured → surface a diagnostic error instead
     // of a silent empty result. The engine records this in BoardScrapeSummary.error,
     // which the Jobs page renders as a partial-failure warning and autopilot logs
@@ -1339,16 +438,22 @@ fn aggregator_has_configured_provider() -> bool {
         || ApifyLinkedInProvider::new().is_configured()
 }
 
-/// First keyring READ error across the aggregator's primary provider slots, if
-/// any. Distinguishes a credential-store FAULT (surfaced as a board error) from
-/// mere key absence (surfaced as a `needs-keys` skip). Returns `None` when every
-/// slot reads cleanly — whether the key is present or simply absent.
+/// First keyring READ error across the aggregator's provider credential slots
+/// (Adzuna id/key, JSearch key, and the Apify token), if any. Probes the SAME slot
+/// set [`aggregator_has_configured_provider`] counts — including the Apify token —
+/// so a faulting Apify slot (with Adzuna/JSearch merely absent) is classified as a
+/// store error rather than a misleading `needs-keys` skip. Distinguishes a
+/// credential-store FAULT (surfaced as a board error) from mere key absence
+/// (surfaced as a `needs-keys` skip). Returns `None` when every slot reads
+/// cleanly — whether the key is present or simply absent.
 ///
 /// The error string is a keyring backend message + slot name only; it never
 /// carries a credential value (see `credentials::read_credential`).
 fn aggregator_store_error() -> Option<String> {
-    use crate::ipc_contracts::provider_slots::{ADZUNA_APP_ID, ADZUNA_APP_KEY, JSEARCH_KEY};
-    for slot in [ADZUNA_APP_ID, ADZUNA_APP_KEY, JSEARCH_KEY] {
+    use crate::ipc_contracts::provider_slots::{
+        ADZUNA_APP_ID, ADZUNA_APP_KEY, APIFY_TOKEN, JSEARCH_KEY,
+    };
+    for slot in [ADZUNA_APP_ID, ADZUNA_APP_KEY, JSEARCH_KEY, APIFY_TOKEN] {
         if let Err(e) = crate::credentials::read_credential(&format!("ai:{slot}")) {
             return Some(e.to_string());
         }

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
@@ -1,0 +1,976 @@
+/// The three `JobProvider` implementations backing the aggregator board: Adzuna
+/// (primary), JSearch (paid fallback), and Apify LinkedIn (additive, opt-in,
+/// paid). Split out of `mod.rs` (R8 module-size guard) — fallback orchestration
+/// (`primary_chain`/`search_with_providers`) and the `Scraper` impl stay there.
+///
+/// Visibility: items here are `pub(super)` (visible to `aggregator` and its
+/// descendants, including `test.rs`) rather than fully private, purely to
+/// preserve this behavior-preserving move — no API surface beyond `aggregator`
+/// is intended.
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::scraping::http::{fetch_json, html_to_markdown, FetchOptions};
+use crate::scraping::types::JobPosting;
+
+use super::JobProvider;
+
+// ── Serde helpers ─────────────────────────────────────────────────────────────
+
+/// Accept either a JSON string or a JSON integer for the Adzuna `id` field,
+/// normalizing both to `String`.  Adzuna documents the field as a string but
+/// the live API returns it as an integer (e.g. `331705081`).
+fn de_string_or_number<'de, D>(de: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrNumber {
+        Str(String),
+        Num(i64),
+    }
+
+    match StringOrNumber::deserialize(de)? {
+        StringOrNumber::Str(s) => Ok(s),
+        StringOrNumber::Num(n) => Ok(n.to_string()),
+    }
+}
+
+/// Like [`de_string_or_number`] but for an OPTIONAL field, tolerating `null` /
+/// absent / string / number. Used for the Apify actor's loosely-typed `id` and
+/// `postedAt`, which vary by run (string id, numeric id, or omitted).
+fn de_opt_string_or_number<'de, D>(de: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(de)?;
+    Ok(value.and_then(|v| match v {
+        serde_json::Value::String(s) => Some(s),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }))
+}
+
+// ── Date-filter helpers ────────────────────────────────────────────────────────
+
+/// Map a UI date-filter token to Adzuna's `max_days_old` integer (whole days).
+///
+// ponytail: Adzuna's recency granularity is whole days — it can't do sub-day. A
+// 1-day ceiling zeroed out autopilot "recent" filters on quiet days (a normal
+// query returns near-nothing in a single day), so sub-day windows FLOOR at 3 days
+// and rely on the query's `sort_by=date` for freshness instead of a hard clamp.
+// No filter / unrecognized token caps at 30 days so the aggregator never surfaces
+// postings older than a month. (Coarse mapping; 3-day floor / 30-day ceiling.)
+pub(super) fn adzuna_max_days_old(date_filter: Option<&str>) -> u32 {
+    match date_filter {
+        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => 3,
+        Some("week") => 7,
+        _ => 30,
+    }
+}
+
+/// Whether to broaden a sparse Adzuna result to a country-wide (`where=""`) retry.
+/// Only for an explicitly-supplied country (`!country_guessed`) — broadening a
+/// GUESSED market would defeat primary_chain's guessed-market → JSearch fallback,
+/// which keys off Adzuna returning empty.
+pub(super) fn should_broaden(country_guessed: bool, where_val: &str, count: usize) -> bool {
+    !country_guessed && !where_val.is_empty() && count < super::ADZUNA_BROADEN_FLOOR
+}
+
+/// Adzuna's `where` wants a place *inside* the market (the country is already the
+/// URL path segment), so a trailing ", Germany"/", Deutschland" just over-narrows the
+/// geocode. Keep the first comma-segment (the city/region), trimmed.
+// ponytail: first-segment heuristic. A country-name-only location (e.g. "germany")
+// already returns Adzuna's full page, so no country-name table is needed.
+pub(super) fn adzuna_where(location: &str) -> &str {
+    location.split(',').next().map(str::trim).unwrap_or("")
+}
+
+/// Map a UI date-filter token to JSearch's `date_posted` query token
+/// (`all|today|3days|week|month`). Sub-day windows floor at `3days` — like Adzuna,
+/// JSearch has no sub-day granularity, and a `today` ceiling zeroed out autopilot
+/// "recent" filters on quiet days. The freshest still surface first because the
+/// JSearch request pairs this window with `&sort_by=date` (JSearch defaults to
+/// relevance, not recency — the sort param is what makes the guarantee true).
+/// No filter / unrecognized token caps at `month`.
+///
+// ponytail: intentional cross-provider recency skew for sub-day tokens (e.g.
+// `"24h"`). The free/cheap providers can't do sub-day granularity, so Adzuna
+// (`adzuna_max_days_old` → 3) and JSearch (here → `3days`) both widen to 3 days,
+// while the paid Apify/LinkedIn path (`apify_f_tpr` → `r86400`) keeps a strict
+// ≤24h window. Merged results therefore mix recency windows for sub-day filters —
+// the deliberate tradeoff (surface *something* over nothing on quiet days); a
+// future reader shouldn't "fix" the skew back into a hard clamp.
+pub(super) fn jsearch_date_posted(date_filter: Option<&str>) -> &'static str {
+    match date_filter {
+        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => "3days",
+        Some("week") => "week",
+        _ => "month",
+    }
+}
+
+// ── Adzuna supported-country allowlist ───────────────────────────────────────
+
+/// ISO 3166-1 alpha-2 country codes hosted by Adzuna's job-search API.
+///
+/// Source: Adzuna API documentation at <https://api.adzuna.com/v1/doc>
+/// (path-parameter enumeration visible in the interactive endpoint reference).
+/// Verified against the known set as of 2026-06-23; update this list if
+/// Adzuna adds new markets (the path `/v1/api/jobs/{country}/search/1` returns
+/// a non-2xx error body for any code not in this set, which is indistinguishable
+/// from an auth failure without real keys — see code comment in `search`).
+pub(super) const ADZUNA_SUPPORTED_COUNTRIES: &[&str] = &[
+    "at", // Austria
+    "au", // Australia
+    "be", // Belgium
+    "br", // Brazil
+    "ca", // Canada
+    "ch", // Switzerland
+    "de", // Germany
+    "es", // Spain
+    "fr", // France
+    "gb", // United Kingdom
+    "in", // India
+    "it", // Italy
+    "mx", // Mexico
+    "nl", // Netherlands
+    "nz", // New Zealand
+    "pl", // Poland
+    "sg", // Singapore
+    "us", // United States
+    "za", // South Africa
+];
+
+#[inline]
+pub(super) fn adzuna_supports_country(country: &str) -> bool {
+    ADZUNA_SUPPORTED_COUNTRIES.contains(&country)
+}
+
+/// ISO-4217 currency for an Adzuna market. Adzuna's search API returns
+/// `salary_min`/`salary_max` as bare numbers with no currency field, so the
+/// currency has to be derived from the country the search targeted — one entry
+/// per code in [`ADZUNA_SUPPORTED_COUNTRIES`]. `None` for any country not in
+/// that list (the salary answer then falls back to a web lookup for currency
+/// instead of guessing).
+#[inline]
+pub(super) fn adzuna_currency_for_country(country: &str) -> Option<&'static str> {
+    Some(match country {
+        "at" | "be" | "de" | "es" | "fr" | "it" | "nl" => "EUR",
+        "au" => "AUD",
+        "br" => "BRL",
+        "ca" => "CAD",
+        "ch" => "CHF",
+        "gb" => "GBP",
+        "in" => "INR",
+        "mx" => "MXN",
+        "nz" => "NZD",
+        "pl" => "PLN",
+        "sg" => "SGD",
+        "us" => "USD",
+        "za" => "ZAR",
+        _ => return None,
+    })
+}
+
+// ── Adzuna provider ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub(super) struct AdzunaCompany {
+    pub(super) display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct AdzunaLocation {
+    pub(super) display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct AdzunaJob {
+    #[serde(deserialize_with = "de_string_or_number")]
+    pub(super) id: String,
+    pub(super) title: String,
+    pub(super) company: Option<AdzunaCompany>,
+    pub(super) location: Option<AdzunaLocation>,
+    pub(super) redirect_url: String,
+    pub(super) description: Option<String>,
+    pub(super) created: Option<String>,
+    pub(super) salary_min: Option<f64>,
+    pub(super) salary_max: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct AdzunaResp {
+    pub(super) results: Vec<AdzunaJob>,
+}
+
+pub(crate) struct AdzunaProvider {
+    pub(super) app_id: Option<String>,
+    pub(super) app_key: Option<String>,
+}
+
+impl AdzunaProvider {
+    pub(super) fn new() -> Self {
+        use crate::ipc_contracts::provider_slots::{ADZUNA_APP_ID, ADZUNA_APP_KEY};
+        Self {
+            app_id: crate::credentials::read_credential(&format!("ai:{ADZUNA_APP_ID}"))
+                .unwrap_or_else(|e| {
+                    log::warn!("[aggregator] {ADZUNA_APP_ID} keyring error: {e}");
+                    None
+                }),
+            app_key: crate::credentials::read_credential(&format!("ai:{ADZUNA_APP_KEY}"))
+                .unwrap_or_else(|e| {
+                    log::warn!("[aggregator] {ADZUNA_APP_KEY} keyring error: {e}");
+                    None
+                }),
+        }
+    }
+}
+
+#[async_trait]
+impl JobProvider for AdzunaProvider {
+    fn provider_id(&self) -> &'static str {
+        "adzuna"
+    }
+
+    fn is_configured(&self) -> bool {
+        self.app_id.is_some() && self.app_key.is_some()
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        location: &str,
+        country: &str,
+        country_guessed: bool,
+        date_filter: Option<&str>,
+        _amount: Option<u32>,
+        signal: tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        if !self.is_configured() {
+            return Err(anyhow::anyhow!("adzuna: not configured"));
+        }
+
+        // Reject unsupported countries before issuing any HTTP request.
+        // Adzuna only hosts a fixed set of markets; an unsupported country code
+        // would produce a non-2xx response (indistinguishable from an auth error
+        // at the HTTP level without real keys). Returning Err here lets the
+        // `search_with_providers` fallback chain transparently route to JSearch
+        // (which uses free-text location and is globally scoped).
+        let country = if country.is_empty() { "de" } else { country };
+        if !adzuna_supports_country(country) {
+            return Err(anyhow::anyhow!(
+                "adzuna: country '{country}' is not in Adzuna's supported market list \
+                 (supported: {}); configure a JSearch key for global coverage",
+                ADZUNA_SUPPORTED_COUNTRIES.join(", ")
+            ));
+        }
+
+        let app_id = self.app_id.as_deref().unwrap_or("");
+        let app_key = self.app_key.as_deref().unwrap_or("");
+
+        // Drop redundant country suffixes so a ", Germany"/", Deutschland" tail
+        // doesn't over-narrow the geocode (the country is already the URL path).
+        let where_hygienic = adzuna_where(location);
+
+        let postings = fetch_adzuna_page(
+            country,
+            app_id,
+            app_key,
+            query,
+            where_hygienic,
+            date_filter,
+            signal.clone(),
+        )
+        .await?;
+
+        // Broaden on near-empty: even a hygienic `where` can over-narrow a sparse
+        // market, so if a real Adzuna market returned under the floor, retry ONCE
+        // country-wide (`where=""`) — same `what`, sort, and `max_days_old` — and
+        // keep whichever set is larger. A transient error on the retry keeps the
+        // narrow result rather than discarding it.
+        //
+        // GUARD: never broaden a GUESSED market (`country_guessed`). Turning a
+        // guessed-market empty/near-empty into a non-empty country-wide result
+        // would defeat `primary_chain`'s guessed-market guard, which relies on
+        // an empty Adzuna result to fall through to JSearch (global, free-text
+        // location) when the guess is probably wrong (e.g. "London" defaulting
+        // to "de"). Only broaden for an explicitly-supplied country.
+        if should_broaden(country_guessed, where_hygienic, postings.len()) {
+            match fetch_adzuna_page(country, app_id, app_key, query, "", date_filter, signal).await
+            {
+                Ok(broadened) if broadened.len() > postings.len() => {
+                    // PRIVACY: never log the raw `where`/location — free-text PII.
+                    log::info!(
+                        "[aggregator] adzuna sparse result ({}), broadened country-wide ({})",
+                        postings.len(),
+                        broadened.len()
+                    );
+                    return Ok(broadened);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::warn!(
+                        "[aggregator] adzuna broaden retry failed, keeping narrow result: {e}"
+                    )
+                }
+            }
+        }
+
+        Ok(postings)
+    }
+}
+
+/// Map one Adzuna result to a [`JobPosting`], deriving `extra.salaryCurrency`
+/// from `country` (Adzuna reports bare salary numbers with no currency field).
+/// Pulled out of `AdzunaProvider::search` so it's unit-testable without a
+/// network call.
+pub(super) fn adzuna_job_to_posting(j: AdzunaJob, country: &str, now: i64) -> JobPosting {
+    let mut extra = std::collections::HashMap::new();
+    let has_salary = j.salary_min.is_some() || j.salary_max.is_some();
+    if let Some(min) = j.salary_min {
+        extra.insert("salaryMin".to_string(), serde_json::json!(min));
+    }
+    if let Some(max) = j.salary_max {
+        extra.insert("salaryMax".to_string(), serde_json::json!(max));
+    }
+    // Currency is only meaningful alongside an amount; an unmapped country
+    // omits it so the downstream salary answer falls back to a web lookup
+    // instead of showing a wrong/absent currency.
+    if has_salary {
+        if let Some(currency) = adzuna_currency_for_country(country) {
+            extra.insert("salaryCurrency".to_string(), serde_json::json!(currency));
+        }
+    }
+    JobPosting {
+        id: format!("aggregator:adzuna-{}", j.id),
+        external_id: Some(format!("adzuna-{}", j.id)),
+        title: j.title,
+        company: j.company.and_then(|c| c.display_name).unwrap_or_default(),
+        location: j.location.and_then(|l| l.display_name),
+        url: j.redirect_url,
+        source: "aggregator".to_string(),
+        description: j.description.map(|d| html_to_markdown(&d)),
+        requirements: None,
+        posted_at: j
+            .created
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.timestamp_millis()),
+        captured_at: now,
+        extra,
+    }
+}
+
+/// Build + fetch + parse ONE Adzuna page for a given `where` value.
+///
+/// Factored out of `AdzunaProvider::search` so the near-empty broaden retry can
+/// reissue the exact same request (same `what`, `sort_by=date`, `results_per_page`,
+/// and `max_days_old`) with only `where` changed. Called at most twice per search.
+async fn fetch_adzuna_page(
+    country: &str,
+    app_id: &str,
+    app_key: &str,
+    query: &str,
+    where_val: &str,
+    date_filter: Option<&str>,
+    signal: tokio_util::sync::CancellationToken,
+) -> anyhow::Result<Vec<JobPosting>> {
+    // Sort newest-first (Adzuna defaults to relevance, which floats stale postings
+    // up) and always bound the window with max_days_old so nothing older than the
+    // cap (30 days, or the user's tighter pick) is returned.
+    let url = format!(
+        "https://api.adzuna.com/v1/api/jobs/{}/search/1\
+         ?app_id={}&app_key={}&what={}&where={}&results_per_page=50&content-type=application/json\
+         &sort_by=date&sort_direction=down&max_days_old={}",
+        urlencoding::encode(country),
+        urlencoding::encode(app_id),
+        urlencoding::encode(app_key),
+        urlencoding::encode(query),
+        urlencoding::encode(where_val),
+        adzuna_max_days_old(date_filter),
+    );
+
+    let resp = match fetch_json::<AdzunaResp>(&url, FetchOptions::default(), signal).await? {
+        Some(r) => r,
+        None => {
+            return Err(anyhow::anyhow!(
+                "adzuna: non-2xx response or unparseable body"
+            ))
+        }
+    };
+
+    let now = chrono::Utc::now().timestamp_millis();
+    Ok(resp
+        .results
+        .into_iter()
+        .map(|j| adzuna_job_to_posting(j, country, now))
+        .collect())
+}
+
+// ── JSearch provider ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub(super) struct JSearchJob {
+    pub(super) job_id: String,
+    pub(super) job_title: String,
+    pub(super) employer_name: Option<String>,
+    pub(super) job_city: Option<String>,
+    pub(super) job_country: Option<String>,
+    pub(super) job_apply_link: Option<String>,
+    pub(super) job_google_link: Option<String>,
+    pub(super) job_description: Option<String>,
+    pub(super) job_posted_at_datetime_utc: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct JSearchResp {
+    pub(super) data: Vec<JSearchJob>,
+}
+
+pub(crate) struct JSearchProvider {
+    pub(super) api_key: Option<String>,
+}
+
+impl JSearchProvider {
+    pub(super) fn new() -> Self {
+        use crate::ipc_contracts::provider_slots::JSEARCH_KEY;
+        Self {
+            api_key: crate::credentials::read_credential(&format!("ai:{JSEARCH_KEY}"))
+                .unwrap_or_else(|e| {
+                    log::warn!("[aggregator] {JSEARCH_KEY} keyring error: {e}");
+                    None
+                }),
+        }
+    }
+}
+
+#[async_trait]
+impl JobProvider for JSearchProvider {
+    fn provider_id(&self) -> &'static str {
+        "jsearch"
+    }
+
+    fn is_configured(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        location: &str,
+        _country: &str,
+        _country_guessed: bool,
+        date_filter: Option<&str>,
+        _amount: Option<u32>,
+        signal: tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        if !self.is_configured() {
+            return Err(anyhow::anyhow!("jsearch: not configured"));
+        }
+
+        let api_key = self.api_key.as_deref().unwrap_or("");
+
+        // JSearch takes a single free-text query field; combine query + location.
+        let combined = if location.is_empty() {
+            query.to_string()
+        } else {
+            format!("{query} in {location}")
+        };
+        let q_enc = urlencoding::encode(&combined);
+        let mut url = format!(
+            "https://jsearch.p.rapidapi.com/search?query={}&page=1&num_pages=1",
+            q_enc
+        );
+
+        // Sort newest-first (JSearch defaults to relevance, which does NOT put the
+        // freshest posting on top) so the widened `date_posted` window still surfaces
+        // the most-recent jobs first — matching Adzuna's `sort_by=date` and honouring
+        // the freshness guarantee documented on `jsearch_date_posted`.
+        url.push_str(&format!(
+            "&date_posted={}&sort_by=date",
+            jsearch_date_posted(date_filter)
+        ));
+
+        let result = fetch_json::<JSearchResp>(
+            &url,
+            FetchOptions {
+                headers: Some(vec![
+                    ("X-RapidAPI-Key".to_string(), api_key.to_string()),
+                    (
+                        "X-RapidAPI-Host".to_string(),
+                        "jsearch.p.rapidapi.com".to_string(),
+                    ),
+                ]),
+                ..FetchOptions::default()
+            },
+            signal,
+        )
+        .await?;
+
+        let resp = match result {
+            Some(r) => r,
+            None => {
+                return Err(anyhow::anyhow!(
+                    "jsearch: non-2xx response or unparseable body"
+                ))
+            }
+        };
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let postings = resp
+            .data
+            .into_iter()
+            .filter_map(|j| {
+                let url = j
+                    .job_apply_link
+                    .clone()
+                    .or_else(|| j.job_google_link.clone())?;
+                let location = match (j.job_city.as_deref(), j.job_country.as_deref()) {
+                    (Some(c), Some(co)) if !c.is_empty() && !co.is_empty() => {
+                        Some(format!("{c}, {co}"))
+                    }
+                    (Some(c), _) if !c.is_empty() => Some(c.to_string()),
+                    (_, Some(co)) if !co.is_empty() => Some(co.to_string()),
+                    _ => None,
+                };
+                Some(JobPosting {
+                    id: format!("aggregator:jsearch-{}", j.job_id),
+                    external_id: Some(format!("jsearch-{}", j.job_id)),
+                    title: j.job_title,
+                    company: j.employer_name.unwrap_or_default(),
+                    location,
+                    url,
+                    source: "aggregator".to_string(),
+                    description: j.job_description.map(|d| html_to_markdown(&d)),
+                    requirements: None,
+                    posted_at: j
+                        .job_posted_at_datetime_utc
+                        .as_deref()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .map(|dt| dt.timestamp_millis()),
+                    captured_at: now,
+                    extra: std::collections::HashMap::new(),
+                })
+            })
+            .collect();
+
+        Ok(postings)
+    }
+}
+
+// ── Non-secret aggregator settings (plugin-store JSON) ──────────────────────────
+//
+// The "Include LinkedIn (Apify)" opt-in toggle and the optional actor-id override
+// are NOT secrets, so they do not belong in the OS keychain. The renderer persists
+// them with `@tauri-apps/plugin-store` to `<app_data_dir>/scraping-settings.json`;
+// plugin-store resolves a relative store path against the app data dir — the SAME
+// directory `platform::config::data_dir()` resolves for AppHandle-less workers, so
+// the provider can read them here without an `AppHandle` (mirrors how API keys are
+// read AppHandle-free via `credentials::read_credential`).
+//
+// The file name + key strings are the cross-language contract in
+// `packages/shared/src/scraping-settings.ts`; the literals below are pinned to it
+// by `aggregator_settings_keys_match_shared_contract` in `test.rs`.
+pub(super) const SCRAPING_SETTINGS_FILE: &str = "scraping-settings.json";
+pub(super) const SETTING_APIFY_ENABLED: &str = "apifyLinkedinEnabled";
+pub(super) const SETTING_APIFY_ACTOR_ID: &str = "apifyLinkedinActorId";
+
+#[derive(Debug, Default, Clone)]
+struct AggregatorSettings {
+    /// Master opt-in for the paid Apify LinkedIn provider. Default `false`.
+    apify_linkedin_enabled: bool,
+    /// Optional actor-id override; `None` → the built-in default actor.
+    apify_linkedin_actor_id: Option<String>,
+}
+
+/// Read the non-secret aggregator settings from the plugin-store JSON file.
+///
+/// Absent file, parse failure, or missing keys all degrade to defaults (toggle
+/// OFF) — never an error. A missing/garbled settings file must never crash a
+/// user-triggered search; it simply means the opt-in provider stays disabled.
+fn read_aggregator_settings() -> AggregatorSettings {
+    let path = crate::platform::config::data_dir().join(SCRAPING_SETTINGS_FILE);
+    let json: serde_json::Value = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or(serde_json::Value::Null);
+
+    let apify_linkedin_enabled = json
+        .get(SETTING_APIFY_ENABLED)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let apify_linkedin_actor_id = json
+        .get(SETTING_APIFY_ACTOR_ID)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    AggregatorSettings {
+        apify_linkedin_enabled,
+        apify_linkedin_actor_id,
+    }
+}
+
+// ── Apify LinkedIn provider (additive, paid) ────────────────────────────────────
+
+/// Default Apify actor: scrapes public LinkedIn jobs with no LinkedIn login,
+/// billed pay-per-event (~$1.00 / 1000 results). Overridable via the non-secret
+/// `apifyLinkedinActorId` setting.
+pub(super) const APIFY_DEFAULT_ACTOR: &str = "curious_coder~linkedin-jobs-scraper";
+
+// ponytail: HARD cost ceiling. Apify bills per dataset result, so every run is
+// bounded by `count = APIFY_MAX_ITEMS`; we NEVER issue an unbounded fetch. The
+// opt-in toggle (gated in `is_configured`) is the second, mandatory cost gate —
+// a stored token ALONE never triggers a paid run.
+pub(super) const APIFY_MAX_ITEMS: u32 = 50;
+
+/// `run-sync-get-dataset-items` is capped at 300s server-side (returns 408 on
+/// timeout); give the client a matching wall-clock ceiling so a stalled actor
+/// run can't hang the scrape.
+const APIFY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Server-side USD ceiling for pay-per-event actor overrides. Belt-and-suspenders
+/// on top of `maxItems`: a user who overrides the actor to a pay-per-event model
+/// is still bounded by this hard Apify platform limit.
+pub(super) const APIFY_MAX_CHARGE_USD: &str = "1.00";
+
+/// INVARIANT: retries=0 for every Apify `run-sync-get-dataset-items` call.
+/// The endpoint is NON-IDEMPOTENT and billed per result — a retry on 429/503/network
+/// would start ANOTHER charged actor run (up to 3× cost with the default retries=2).
+/// Shared by production code and tests so a change to either breaks the invariant check.
+pub(super) const APIFY_RETRIES: u32 = 0;
+
+/// Validate an Apify actor id against the platform grammar `user~actor`.
+///
+/// Both parts must be non-empty and consist solely of `[A-Za-z0-9_.-]`.
+/// A malformed id injected via `apifyLinkedinActorId` could otherwise reach
+/// the API URL (even though the host is fixed, a path-traversal like
+/// `../../v1/…` is still a concern). An invalid id falls back silently to
+/// `APIFY_DEFAULT_ACTOR` — the provider logs a warning and continues.
+pub(super) fn is_valid_apify_actor_id(id: &str) -> bool {
+    let valid_part = |s: &str| {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-')
+    };
+    match id.split_once('~') {
+        Some((user, actor)) => valid_part(user) && valid_part(actor),
+        None => false,
+    }
+}
+
+/// Build the Apify `run-sync-get-dataset-items` endpoint URL for a given actor.
+///
+/// `max_items` is the server-side platform cap for this request; callers compute
+/// it as `min(APIFY_MAX_ITEMS, amount - primary.len())` so we never fetch more
+/// than actually needed.  The Bearer token is NEVER included here — it goes in
+/// the `Authorization` header only, keeping it out of request-URL logging.
+///
+/// This is the single source of truth consumed by both the production call in
+/// [`ApifyLinkedInProvider::search`] and the invariant test in `test.rs`. A future
+/// refactor that removes either cap would break the test that calls this function.
+pub(super) fn build_apify_endpoint(actor_id: &str, max_items: u32) -> String {
+    format!(
+        "https://api.apify.com/v2/acts/{}/run-sync-get-dataset-items\
+         ?maxItems={}&maxTotalChargeUsd={}",
+        actor_id, max_items, APIFY_MAX_CHARGE_USD
+    )
+}
+
+/// Map a UI date-filter token to LinkedIn's `f_TPR` recency parameter. Sub-day
+/// windows collapse to the past 24h (`r86400`); `week` → `r604800`; everything
+/// else (month / no filter / unknown) caps at the past month (`r2592000`),
+/// mirroring the 30-day ceiling the other providers enforce.
+pub(super) fn apify_f_tpr(date_filter: Option<&str>) -> &'static str {
+    match date_filter {
+        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => "r86400",
+        Some("week") => "r604800",
+        _ => "r2592000",
+    }
+}
+
+/// Build the public LinkedIn jobs-search URL the actor expects as input (it
+/// scrapes pre-built search URLs, not a raw keyword string). Query + location are
+/// percent-encoded; recency comes from [`apify_f_tpr`].
+pub(super) fn build_linkedin_search_url(
+    query: &str,
+    location: &str,
+    date_filter: Option<&str>,
+) -> String {
+    let q = urlencoding::encode(query);
+    let loc = urlencoding::encode(location);
+    let f_tpr = apify_f_tpr(date_filter);
+    format!("https://www.linkedin.com/jobs/search/?keywords={q}&location={loc}&f_TPR={f_tpr}")
+}
+
+/// Try to parse the actor's `postedAt` into epoch millis: RFC-3339 first, then a
+/// bare epoch (seconds scaled to millis, or millis as-is). A relative string
+/// ("2 weeks ago") yields `None` — an absent posted date is acceptable.
+fn parse_apify_posted_at(s: &str) -> Option<i64> {
+    let s = s.trim();
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.timestamp_millis());
+    }
+    if let Ok(n) = s.parse::<i64>() {
+        // < 10^12 ≈ seconds (any plausible ms epoch is far larger).
+        return Some(if n < 1_000_000_000_000 { n * 1000 } else { n });
+    }
+    None
+}
+
+/// One dataset item from the Apify actor. Every field is optional + defensively
+/// aliased: the actor's output shape drifts between runs/versions, so we accept
+/// the documented field names plus sensible fallbacks and skip anything unusable.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ApifyItem {
+    #[serde(default, alias = "jobTitle")]
+    pub(super) title: Option<String>,
+    #[serde(default, rename = "companyName")]
+    pub(super) company_name: Option<String>,
+    #[serde(default)]
+    pub(super) location: Option<String>,
+    #[serde(default, rename = "jobUrl")]
+    pub(super) job_url: Option<String>,
+    #[serde(default, deserialize_with = "de_opt_string_or_number")]
+    pub(super) id: Option<String>,
+    #[serde(
+        default,
+        rename = "postedAt",
+        deserialize_with = "de_opt_string_or_number"
+    )]
+    pub(super) posted_at: Option<String>,
+    #[serde(default, rename = "descriptionText")]
+    pub(super) description_text: Option<String>,
+    #[serde(default, rename = "jobDescription")]
+    pub(super) job_description: Option<String>,
+    #[serde(default, rename = "descriptionHtml")]
+    pub(super) description_html: Option<String>,
+}
+
+/// Validate that a URL from the Apify actor is HTTPS on a `linkedin.com` host.
+///
+/// A drifting or user-overridden actor could inject arbitrary URLs into
+/// `JobPosting.url`.  We constrain the output to the only expected domain
+/// (`linkedin.com` / `*.linkedin.com`) and scheme (`https`).  Items whose URL
+/// fails validation are dropped — same as items missing title/url.
+fn is_valid_apify_linkedin_url(url: &str) -> bool {
+    if let Ok(parsed) = reqwest::Url::parse(url) {
+        // host_str() is already lowercase after Url::parse (URL standard).
+        return parsed.scheme() == "https"
+            && parsed
+                .host_str()
+                .is_some_and(|h| h == "linkedin.com" || h.ends_with(".linkedin.com"));
+    }
+    false
+}
+
+/// Build the `FetchOptions` for the Apify `run-sync-get-dataset-items` call.
+///
+/// The Bearer token goes in the Authorization header only — never the URL.
+/// `retries` is hardwired to `APIFY_RETRIES` (0): the endpoint is NON-IDEMPOTENT
+/// and billed per result; a retry would start another charged run.
+///
+/// This is the single source of truth consumed by [`ApifyLinkedInProvider::search`]
+/// and by the invariant test in `test.rs`.  Removing the `retries` override here
+/// breaks the test.
+pub(super) fn apify_fetch_options(body: String, token: &str) -> FetchOptions {
+    FetchOptions {
+        method: Some(reqwest::Method::POST),
+        body: Some(body),
+        headers: Some(vec![
+            ("authorization".to_string(), format!("Bearer {token}")),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]),
+        timeout: Some(APIFY_TIMEOUT),
+        retries: APIFY_RETRIES, // NON-IDEMPOTENT: each run is billed — never retry
+        ..FetchOptions::default()
+    }
+}
+
+/// Defensively map an [`ApifyItem`] to a [`JobPosting`]. Returns `None` when the
+/// item lacks BOTH a usable title and a usable URL (no `jobUrl` and no `id` to
+/// construct one) — such an item can't be opened, so it's dropped.
+pub(super) fn map_apify_item(item: ApifyItem, now: i64) -> Option<JobPosting> {
+    let title = item
+        .title
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+
+    let id = item
+        .id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    // URL: explicit jobUrl wins; for the id-constructed fallback, require a
+    // digits-only id so we never interpolate an arbitrary string into a path.
+    let url = item
+        .job_url
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            id.as_deref()
+                .filter(|s| s.chars().all(|c| c.is_ascii_digit()))
+                .map(|id| format!("https://www.linkedin.com/jobs/view/{id}"))
+        })?;
+
+    // Security: drop items whose URL is not HTTPS on a linkedin.com host.
+    // A drifting actor can inject non-LinkedIn or non-HTTPS URLs; we reject those.
+    if !is_valid_apify_linkedin_url(&url) {
+        return None;
+    }
+
+    let description = item
+        .description_text
+        .or(item.job_description)
+        .or(item.description_html)
+        .map(|d| html_to_markdown(&d));
+
+    let posted_at = item.posted_at.as_deref().and_then(parse_apify_posted_at);
+
+    // Stable external id for dedupe: the LinkedIn job id when present, else the URL.
+    let external_id = id
+        .map(|id| format!("linkedin-{id}"))
+        .unwrap_or_else(|| format!("linkedin-{url}"));
+
+    Some(JobPosting {
+        id: format!("aggregator:{external_id}"),
+        external_id: Some(external_id),
+        title,
+        company: item
+            .company_name
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default(),
+        location: item
+            .location
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
+        url,
+        source: "aggregator".to_string(),
+        description,
+        requirements: None,
+        posted_at,
+        captured_at: now,
+        extra: std::collections::HashMap::new(),
+    })
+}
+
+pub(crate) struct ApifyLinkedInProvider {
+    pub(super) token: Option<String>,
+    /// The opt-in toggle. `is_configured()` requires this AND a token.
+    pub(super) enabled: bool,
+    pub(super) actor_id: String,
+}
+
+impl ApifyLinkedInProvider {
+    pub(super) fn new() -> Self {
+        use crate::ipc_contracts::provider_slots::APIFY_TOKEN;
+        let token = crate::credentials::read_credential(&format!("ai:{APIFY_TOKEN}"))
+            .unwrap_or_else(|e| {
+                log::warn!("[aggregator] {APIFY_TOKEN} keyring error: {e}");
+                None
+            });
+        let settings = read_aggregator_settings();
+        // Validate the user-supplied actor id before interpolating it into the
+        // API path. Falls back to the default actor on mismatch; never panics.
+        let actor_id = settings
+            .apify_linkedin_actor_id
+            .filter(|id| {
+                if is_valid_apify_actor_id(id) {
+                    true
+                } else {
+                    log::warn!(
+                        "[aggregator] apifyLinkedinActorId is not a valid Apify actor id \
+                         (expected user~actor grammar); falling back to the default actor"
+                    );
+                    false
+                }
+            })
+            .unwrap_or_else(|| APIFY_DEFAULT_ACTOR.to_string());
+        Self {
+            token,
+            enabled: settings.apify_linkedin_enabled,
+            actor_id,
+        }
+    }
+}
+
+#[async_trait]
+impl JobProvider for ApifyLinkedInProvider {
+    fn provider_id(&self) -> &'static str {
+        "apify_linkedin"
+    }
+
+    fn is_configured(&self) -> bool {
+        // BOTH gates are mandatory: an Apify token present AND the user opted in.
+        // Never run a paid scrape just because a token happens to be stored.
+        self.token.is_some() && self.enabled
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        location: &str,
+        _country: &str,
+        _country_guessed: bool,
+        date_filter: Option<&str>,
+        amount: Option<u32>,
+        signal: tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        if !self.is_configured() {
+            return Err(anyhow::anyhow!("apify_linkedin: not configured"));
+        }
+
+        let token = self.token.as_deref().unwrap_or("");
+        let search_url = build_linkedin_search_url(query, location, date_filter);
+
+        // Dynamic cost cap: honour the caller's remaining budget (amount - primary.len())
+        // passed in by `search_with_providers`, capped at the absolute maximum.
+        // `maxItems` is the Apify platform-enforced server-side cap; `count` in the
+        // actor body is the actor-input budget (a user-overridden actor might ignore
+        // `count`, so both must agree). Bearer token stays in the Authorization header
+        // only — never the URL or query string.
+        let max_items = amount.unwrap_or(APIFY_MAX_ITEMS).min(APIFY_MAX_ITEMS);
+        let endpoint = build_apify_endpoint(&self.actor_id, max_items);
+
+        let body = serde_json::json!({
+            "urls": [search_url],
+            "count": max_items,
+        })
+        .to_string();
+
+        // POST via the shared scraping client.
+        //
+        // INVARIANT: retries=0 (via `apify_fetch_options`).  The endpoint is
+        // NON-IDEMPOTENT and billed per result — a retry would start ANOTHER charged
+        // actor run (up to 3× cost with the default retries=2). Never retry.
+        //
+        // `tokio::select!` races the paid fetch against the cancellation signal so
+        // a user cancel mid-flight is honoured within one poll cycle.
+        let raw = tokio::select! {
+            _ = signal.cancelled() => {
+                return Err(anyhow::anyhow!("apify_linkedin: cancelled"));
+            }
+            result = fetch_json::<Vec<ApifyItem>>(
+                &endpoint,
+                apify_fetch_options(body, token),
+                signal.clone(),
+            ) => result?
+        };
+        let items = raw.ok_or_else(|| {
+            anyhow::anyhow!(
+                "apify_linkedin: non-2xx response, timeout (408), or unparseable dataset body"
+            )
+        })?;
+
+        let now = chrono::Utc::now().timestamp_millis();
+        Ok(items
+            .into_iter()
+            .filter_map(|it| map_apify_item(it, now))
+            .collect())
+    }
+}

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::scraping::http::FetchOptions;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -718,7 +719,9 @@ async fn cancelled_after_adzuna_err_skips_jsearch() {
 
 use std::sync::Mutex;
 
-use crate::ipc_contracts::provider_slots::{ADZUNA_APP_ID, ADZUNA_APP_KEY, JSEARCH_KEY};
+use crate::ipc_contracts::provider_slots::{
+    ADZUNA_APP_ID, ADZUNA_APP_KEY, APIFY_TOKEN, JSEARCH_KEY,
+};
 
 static AGG_KEYRING_LOCK: Mutex<()> = Mutex::new(());
 
@@ -736,12 +739,21 @@ fn jsearch_slot() -> String {
     format!("ai:{JSEARCH_KEY}")
 }
 
+fn apify_slot() -> String {
+    format!("ai:{APIFY_TOKEN}")
+}
+
 /// Delete the aggregator's fixed keyring slots so a test starts from a known
 /// "absent" baseline regardless of what a previous serialized test left behind.
 fn clear_aggregator_slots() {
     let adzuna = adzuna_slots();
     let jsearch = jsearch_slot();
-    for slot in adzuna.iter().chain(std::iter::once(&jsearch)) {
+    let apify = apify_slot();
+    for slot in adzuna
+        .iter()
+        .chain(std::iter::once(&jsearch))
+        .chain(std::iter::once(&apify))
+    {
         if let Ok(entry) = keyring_core::Entry::new(crate::credentials::SERVICE, slot) {
             // NoEntry on a clean slot is fine; we only care it ends up absent.
             let _ = entry.delete_credential();
@@ -934,6 +946,46 @@ fn aggregator_search_surfaces_store_read_failure_as_error() {
     assert!(
         result.is_err(),
         "a credential-store read failure must surface as a board error, not Ok(empty)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("credential store unavailable"),
+        "the diagnostic must name the store as unavailable; got: {msg}"
+    );
+
+    clear_aggregator_slots();
+}
+
+/// Consistency guard: `aggregator_has_configured_provider` counts the Apify
+/// provider, so `aggregator_store_error` must probe the Apify token slot too. A
+/// keyring READ FAILURE on the APIFY token slot ALONE (Adzuna + JSearch merely
+/// absent) must classify as a store error — `needs_keys()` false and `search`
+/// surfaces the fault as a board error — NOT a misleading `needs-keys` skip.
+#[test]
+fn aggregator_apify_slot_read_failure_is_a_store_error_not_needs_keys() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    // Arm a non-NoEntry failure on the APIFY token slot only. Adzuna + JSearch stay
+    // absent (NoEntry → Ok(None)), so without probing the Apify slot this would look
+    // like a plain "no keys" needs-keys skip.
+    let entry = keyring_core::Entry::new(crate::credentials::SERVICE, &apify_slot()).unwrap();
+    let mock: &keyring_core::mock::Cred = entry.as_any().downcast_ref().unwrap();
+    mock.set_error(keyring_core::Error::Invalid(
+        "induced".to_string(),
+        "keyring backend unavailable".to_string(),
+    ));
+
+    assert!(
+        !AggregatorScraper.needs_keys(),
+        "an Apify-slot store fault (others absent) must NOT be a needs-keys skip"
+    );
+
+    let result = block_on(AggregatorScraper.search(make_input(), make_ctx()));
+    assert!(
+        result.is_err(),
+        "an Apify-slot store fault must surface as a board error, not Ok(empty)"
     );
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -1593,6 +1645,97 @@ async fn explicit_country_sparse_does_not_fall_back() {
         result.len(),
         2,
         "explicit-country sparse results are authoritative; the floor guard is guessed-market only"
+    );
+}
+
+/// Guessed market + non-empty location + a SPARSE Adzuna result (2 < floor) +
+/// JSearch NOT configured → the sparse hits are the best available answer, so they
+/// are RETURNED (a user with only Adzuna keys keeps their 2 legit results) rather
+/// than discarded for a zero-results diagnostic Err. The uncertainty is logged.
+#[tokio::test]
+async fn guessed_market_sparse_no_fallback_returns_sparse_items() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::ok(
+            "adzuna",
+            vec![
+                sample_posting("s1", "adzuna"),
+                sample_posting("s2", "adzuna"),
+            ],
+        )),
+        // No configured fallback.
+        Box::new(FakeProvider::unconfigured("jsearch")),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "London",
+        "de",
+        true, // country_guessed
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .expect("sparse guessed-market items must be returned, not an Err, with no fallback");
+
+    assert_eq!(
+        result.len(),
+        2,
+        "sparse guessed-market Adzuna items must be returned when there is no JSearch fallback"
+    );
+    assert!(
+        result.iter().all(|p| p
+            .external_id
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("adzuna-")),
+        "the returned items must be the sparse Adzuna hits"
+    );
+}
+
+/// Guessed market + non-empty location + a SPARSE Adzuna result + JSearch
+/// configured but ERRORING → the fallback failed, so the sparse Adzuna hits are
+/// returned (better than nothing) rather than surfacing the JSearch error.
+#[tokio::test]
+async fn guessed_market_sparse_fallback_errors_returns_sparse_items() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::ok(
+            "adzuna",
+            vec![
+                sample_posting("s1", "adzuna"),
+                sample_posting("s2", "adzuna"),
+            ],
+        )),
+        // Fallback is configured but fails on this call.
+        Box::new(FakeProvider::err("jsearch", "jsearch upstream 500")),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "London",
+        "de",
+        true, // country_guessed
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .expect("a failing fallback must not sink the sparse Adzuna items");
+
+    assert_eq!(
+        result.len(),
+        2,
+        "sparse guessed-market Adzuna items must survive a failing JSearch fallback"
+    );
+    assert!(
+        result.iter().all(|p| p
+            .external_id
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("adzuna-")),
+        "the returned items must be the sparse Adzuna hits, not JSearch's"
     );
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -810,6 +810,140 @@ fn providers_degrade_to_unconfigured_on_keyring_error() {
     clear_aggregator_slots();
 }
 
+// ── needs-keys skip classification (aggregator) ───────────────────────────────
+
+fn make_input() -> BoardSearchInput {
+    BoardSearchInput {
+        query: "engineer".into(),
+        location: Some("berlin".into()),
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: Some("de".into()),
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: vec![],
+    }
+}
+
+fn make_ctx() -> ScrapeContext {
+    ScrapeContext {
+        signal: make_token(),
+        on_progress: None,
+        on_item: None,
+    }
+}
+
+/// Drive an async board `search` from a sync (`#[test]`) body so the keyring lock
+/// guard is never held across an `.await` suspend point clippy can observe
+/// (`await_holding_lock`) — same harness the comeet board uses.
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+/// Unconfigured aggregator (store readable, no keys) → `needs_keys() == true`, so
+/// the engine skips it with "needs-keys" instead of a silent keyless-empty.
+#[test]
+fn aggregator_needs_keys_when_unconfigured() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    assert!(
+        AggregatorScraper.needs_keys(),
+        "an aggregator with no configured provider keys must report needs_keys()==true"
+    );
+}
+
+/// A configured aggregator (Adzuna keys present) → `needs_keys() == false`, so the
+/// board runs normally and is NOT skipped.
+#[test]
+fn aggregator_does_not_need_keys_when_configured() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    for slot in adzuna_slots() {
+        keyring_core::Entry::new(crate::credentials::SERVICE, &slot)
+            .unwrap()
+            .set_password("configured")
+            .unwrap();
+    }
+
+    assert!(
+        !AggregatorScraper.needs_keys(),
+        "a configured aggregator (both Adzuna keys present) must report needs_keys()==false"
+    );
+
+    clear_aggregator_slots();
+}
+
+/// A keyring READ FAILURE must NOT be classified as `needs-keys`: `needs_keys()`
+/// returns false so the board still runs, and `search` surfaces the fault as a
+/// board error (credential store unavailable) rather than a silent empty.
+#[test]
+fn aggregator_store_read_failure_is_not_a_needs_keys_skip() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    let entry = keyring_core::Entry::new(crate::credentials::SERVICE, &adzuna_slots()[0]).unwrap();
+    let mock: &keyring_core::mock::Cred = entry.as_any().downcast_ref().unwrap();
+    mock.set_error(keyring_core::Error::Invalid(
+        "induced".to_string(),
+        "keyring backend unavailable".to_string(),
+    ));
+
+    assert!(
+        !AggregatorScraper.needs_keys(),
+        "a store read failure must not be treated as a needs-keys skip"
+    );
+
+    clear_aggregator_slots();
+}
+
+/// Companion to the classification test: a store read failure makes `search`
+/// return a board error naming the store as unavailable — no silent empty, no
+/// network call (the guard short-circuits before any provider is built).
+#[test]
+fn aggregator_search_surfaces_store_read_failure_as_error() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    let entry = keyring_core::Entry::new(crate::credentials::SERVICE, &adzuna_slots()[0]).unwrap();
+    let mock: &keyring_core::mock::Cred = entry.as_any().downcast_ref().unwrap();
+    mock.set_error(keyring_core::Error::Invalid(
+        "induced".to_string(),
+        "keyring backend unavailable".to_string(),
+    ));
+
+    let result = block_on(AggregatorScraper.search(make_input(), make_ctx()));
+    assert!(
+        result.is_err(),
+        "a credential-store read failure must surface as a board error, not Ok(empty)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("credential store unavailable"),
+        "the diagnostic must name the store as unavailable; got: {msg}"
+    );
+
+    clear_aggregator_slots();
+}
+
 // ── Date-filter mapping helpers ───────────────────────────────────────────────
 
 #[test]
@@ -1332,6 +1466,133 @@ async fn guessed_market_empty_with_no_location_is_not_treated_as_untrustworthy()
         result.is_empty(),
         "a guessed market with NO location must keep the legacy Ok(empty) \
          behavior — JSearch must not be called"
+    );
+}
+
+/// Guessed market + non-empty location + a SPARSE Adzuna result (2 < the broaden
+/// floor of 3) + JSearch configured → the sparse hits are not trusted; JSearch is
+/// consulted and its results win. This is the "London → stray German hits" case.
+#[tokio::test]
+async fn guessed_market_sparse_with_location_falls_back_to_jsearch() {
+    let jsearch_posting = sample_posting("g-sparse", "jsearch");
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        // Two stray hits (< ADZUNA_BROADEN_FLOOR) from the GUESSED "de" market.
+        Box::new(FakeProvider::ok(
+            "adzuna",
+            vec![
+                sample_posting("s1", "adzuna"),
+                sample_posting("s2", "adzuna"),
+            ],
+        )),
+        Box::new(FakeProvider::ok("jsearch", vec![jsearch_posting.clone()])),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "London",
+        "de",
+        true, // country_guessed
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        result.len(),
+        1,
+        "a sparse (< floor) result from a GUESSED market must fall through to \
+         JSearch, not be trusted as authoritative"
+    );
+    assert_eq!(result[0].external_id, jsearch_posting.external_id);
+}
+
+/// Guessed market + a result AT the broaden floor (3 == ADZUNA_BROADEN_FLOOR) →
+/// authoritative; JSearch must NOT be consulted (the fake JSearch errors so any
+/// call would surface as an Err and fail `.unwrap()`).
+#[tokio::test]
+async fn guessed_market_at_floor_does_not_fall_back() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::ok(
+            "adzuna",
+            vec![
+                sample_posting("f1", "adzuna"),
+                sample_posting("f2", "adzuna"),
+                sample_posting("f3", "adzuna"),
+            ],
+        )),
+        Box::new(FakeProvider::err(
+            "jsearch",
+            "must not be called at/above the broaden floor",
+        )),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "London",
+        "de",
+        true, // country_guessed
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        result.len(),
+        3,
+        "a result at the broaden floor from a guessed market is authoritative — no fallback"
+    );
+    assert!(
+        result.iter().all(|p| p
+            .external_id
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("adzuna-")),
+        "the at-floor result must be Adzuna's, not JSearch's"
+    );
+}
+
+/// Explicit country (`country_guessed == false`) + a sparse Adzuna result →
+/// unchanged behavior: the sparse hits are authoritative and JSearch is NOT
+/// consulted. The floor guard is guessed-market only.
+#[tokio::test]
+async fn explicit_country_sparse_does_not_fall_back() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::ok(
+            "adzuna",
+            vec![
+                sample_posting("e1", "adzuna"),
+                sample_posting("e2", "adzuna"),
+            ],
+        )),
+        Box::new(FakeProvider::err(
+            "jsearch",
+            "must not be called for an explicit country",
+        )),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "London",
+        "gb",
+        false, // explicit country — not guessed
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        result.len(),
+        2,
+        "explicit-country sparse results are authoritative; the floor guard is guessed-market only"
     );
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -956,31 +956,56 @@ fn aggregator_search_surfaces_store_read_failure_as_error() {
     clear_aggregator_slots();
 }
 
-/// Consistency guard: `aggregator_has_configured_provider` counts the Apify
-/// provider, so `aggregator_store_error` must probe the Apify token slot too. A
-/// keyring READ FAILURE on the APIFY token slot ALONE (Adzuna + JSearch merely
-/// absent) must classify as a store error — `needs_keys()` false and `search`
-/// surfaces the fault as a board error — NOT a misleading `needs-keys` skip.
-#[test]
-fn aggregator_apify_slot_read_failure_is_a_store_error_not_needs_keys() {
-    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
-    crate::credentials::install_mock_keyring();
-    clear_aggregator_slots();
-
-    // Arm a non-NoEntry failure on the APIFY token slot only. Adzuna + JSearch stay
-    // absent (NoEntry → Ok(None)), so without probing the Apify slot this would look
-    // like a plain "no keys" needs-keys skip.
+/// Arm a non-NoEntry failure on the APIFY token slot only (Adzuna + JSearch stay
+/// absent — `NoEntry` → `Ok(None)`). `keyring_core::mock::Cred::set_error` is a
+/// ONE-SHOT: the induced error is returned and cleared on the very next entry
+/// method call, then the mock reads cleanly again — so callers must arm it
+/// immediately before the single probe they intend to exercise, never reuse one
+/// arm across two reads (a prior version of this test armed once and then called
+/// both `needs_keys()` and `search()` against it, so the second call silently saw
+/// a clean read and the test asserted the wrong thing without failing to compile).
+fn arm_apify_slot_fault() {
     let entry = keyring_core::Entry::new(crate::credentials::SERVICE, &apify_slot()).unwrap();
     let mock: &keyring_core::mock::Cred = entry.as_any().downcast_ref().unwrap();
     mock.set_error(keyring_core::Error::Invalid(
         "induced".to_string(),
         "keyring backend unavailable".to_string(),
     ));
+}
+
+/// Consistency guard: `aggregator_has_configured_provider` counts the Apify
+/// provider, so `aggregator_store_error` must probe the Apify token slot too. A
+/// keyring READ FAILURE on the APIFY token slot ALONE (Adzuna + JSearch merely
+/// absent) must classify as a store error — `needs_keys()` false — NOT a
+/// misleading `needs-keys` skip.
+#[test]
+fn aggregator_apify_slot_read_failure_is_not_a_needs_keys_skip() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    arm_apify_slot_fault();
 
     assert!(
         !AggregatorScraper.needs_keys(),
         "an Apify-slot store fault (others absent) must NOT be a needs-keys skip"
     );
+
+    clear_aggregator_slots();
+}
+
+/// Companion to the classification test above: an APIFY-slot-only store fault
+/// (Adzuna + JSearch merely absent) makes `search` return a board error naming
+/// the store as unavailable — NOT a silent `Ok(empty)`. Arms its own fresh fault
+/// (see [`arm_apify_slot_fault`] doc — the mock error is one-shot, so this must
+/// NOT share an arm with the `needs_keys()` probe above).
+#[test]
+fn aggregator_apify_slot_read_failure_surfaces_as_search_error() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    arm_apify_slot_fault();
 
     let result = block_on(AggregatorScraper.search(make_input(), make_ctx()));
     assert!(

--- a/apps/desktop/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/mod.rs
@@ -411,6 +411,12 @@ impl ScraperEngine {
                 if s.requires_company() && !has_usable_company {
                     return Some("needs-company");
                 }
+                // Skip 3: key-backed board (e.g. the aggregator) with no API keys
+                // configured. Surfaces "needs-keys" so the UI can prompt the user
+                // to add keys instead of showing a silent, unexplained zero.
+                if s.needs_keys() {
+                    return Some("needs-keys");
+                }
                 None
             });
 

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -1253,6 +1253,80 @@ async fn required_board_without_session_is_skipped() {
     );
 }
 
+/// A board that declares `needs_keys() == true` (a key-backed board with no API
+/// keys configured) must be skipped with `skipped=Some("needs-keys")`, count=0,
+/// no error — its `search` must never run. A sibling guest board runs normally.
+#[tokio::test]
+async fn needs_keys_board_without_keys_is_skipped() {
+    struct NeedsKeysPanicker;
+
+    #[async_trait::async_trait]
+    impl Scraper for NeedsKeysPanicker {
+        fn id(&self) -> &'static str {
+            "needs-keys-panicker"
+        }
+        fn display_name(&self) -> &'static str {
+            "NeedsKeysPanicker"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        fn needs_keys(&self) -> bool {
+            true
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            _ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            panic!("needs_keys board must never be searched when unconfigured");
+        }
+    }
+
+    static NK: std::sync::LazyLock<NeedsKeysPanicker> =
+        std::sync::LazyLock::new(|| NeedsKeysPanicker);
+    static FAKE_GUEST: std::sync::LazyLock<FakeScraper> =
+        std::sync::LazyLock::new(|| FakeScraper::http(1));
+
+    let engine = ScraperEngine::new();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (_postings, summaries) = engine
+        .scrape_boards_with_resolver(
+            &["nk-board".to_string(), "guest-board".to_string()],
+            fake_input(5),
+            "job-needs-keys".to_string(),
+            None,
+            None,
+            tmp.path(),
+            |id| match id {
+                "nk-board" => Ok(&*NK as &'static dyn Scraper),
+                "guest-board" => Ok(&*FAKE_GUEST as &'static dyn Scraper),
+                other => Err(anyhow::anyhow!("unknown: {other}")),
+            },
+        )
+        .await
+        .expect("skip run must return Ok");
+
+    let nk = summaries
+        .iter()
+        .find(|s| s.board == "nk-board")
+        .expect("nk-board summary missing");
+    assert_eq!(
+        nk.skipped.as_deref(),
+        Some("needs-keys"),
+        "an unconfigured key-backed board must be skipped with 'needs-keys'"
+    );
+    assert_eq!(nk.count, 0, "skipped board must report count=0");
+    assert!(nk.error.is_none(), "skipped board must not carry an error");
+
+    let guest = summaries
+        .iter()
+        .find(|s| s.board == "guest-board")
+        .expect("guest-board summary missing");
+    assert!(guest.skipped.is_none(), "guest board must not be skipped");
+    assert_eq!(guest.count, 1, "guest board must run and report count=1");
+}
+
 /// Input order is preserved across a mixed run/skip/run scenario:
 /// [required-no-session (skip), guest (run), required-no-session-2 (skip)]
 /// Summaries must come back in that same order, not skips-last.

--- a/apps/desktop/src-tauri/src/scraping/types/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/types/mod.rs
@@ -119,6 +119,22 @@ pub trait Scraper: Send + Sync {
         false
     }
 
+    /// Whether this board needs API keys/credentials that are currently absent.
+    ///
+    /// Some boards (the aggregator, backed by Adzuna/JSearch/Apify) return
+    /// nothing without configured API keys. Rather than run and yield a silent
+    /// empty result, the engine skips such a board with reason `"needs-keys"`
+    /// when this returns `true`, so the UI/diagnostics can prompt the user to
+    /// configure their keys instead of showing an unexplained zero.
+    ///
+    /// This is evaluated per scrape (it may read the credential store), so a key
+    /// added in Settings clears the skip on the next run without a restart.
+    ///
+    /// Defaults to `false` so only key-backed boards override it.
+    fn needs_keys(&self) -> bool {
+        false
+    }
+
     async fn search(
         &self,
         input: BoardSearchInput,

--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
@@ -1,0 +1,67 @@
+/**
+ * useAutopilotRun — resolved `{ error }` payload handling.
+ *
+ * The backend `autopilot_run` command RESOLVES (does not reject) with an
+ * `{ error }` payload on a scrape failure or unknown id. This exercises the
+ * real hook to verify that such a resolution routes to the error state — the
+ * SAME state the reject path uses — rather than being treated as 'done'.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { act } from '@testing-library/react';
+
+import { renderHookWithClient } from '@/test-support';
+
+// ---------------------------------------------------------------------------
+// Stubs — declared before the module under test is imported.
+// ---------------------------------------------------------------------------
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}));
+
+const runMutateAsync = vi.fn();
+
+vi.mock('@/services', async (importActual) => {
+  const actual = await importActual<Record<string, unknown>>();
+  return {
+    ...actual,
+    useRunAutopilot: () => ({ mutateAsync: runMutateAsync }),
+    usePauseAutopilot: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+    useResumeAutopilot: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+    useRemoveAutopilot: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+    useAutopilotStepEvents: () => {},
+  };
+});
+
+// Import under test AFTER mocks.
+import { useAutopilotRun } from './useAutopilotRun';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAutopilotRun — handleRun error-payload handling', () => {
+  it('routes a resolved { error } payload to the error state, not done', async () => {
+    runMutateAsync.mockResolvedValueOnce({ error: 'scrape failed: 429', jobId: 'j1' });
+    const { result } = renderHookWithClient(() => useAutopilotRun());
+
+    await act(async () => {
+      await result.current.handleRun('ap1');
+    });
+
+    expect(result.current.runStates.ap1).toBe('error');
+    expect(result.current.error).toBe('scrape failed: 429');
+  });
+
+  it('routes a resolved success payload to the done state', async () => {
+    runMutateAsync.mockResolvedValueOnce({ jobId: 'j2', found: 3, applied: 0 });
+    const { result } = renderHookWithClient(() => useAutopilotRun());
+
+    await act(async () => {
+      await result.current.handleRun('ap2');
+    });
+
+    expect(result.current.runStates.ap2).toBe('done');
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
@@ -61,7 +61,16 @@ export function useAutopilotRun() {
     setRunStates({ [id]: 'scraping' });
     setStepLogs({ [id]: [] });
     try {
-      await runAutopilot.mutateAsync(id);
+      // `autopilot_run` RESOLVES (not rejects) with an `{ error }` payload when a
+      // scrape fails or the id is unknown, so a resolved value is not proof of
+      // success — inspect it and route to the SAME error state the reject path
+      // below uses instead of falsely reporting 'done'.
+      const result = await runAutopilot.mutateAsync(id);
+      if (result.error) {
+        setRunStates({ [id]: 'error' });
+        setError(result.error);
+        return;
+      }
       setRunStates({ [id]: 'done' });
     } catch (err) {
       setRunStates({ [id]: 'error' });

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -188,7 +188,7 @@ export function JobsPage() {
       const needsKeysBoards = boardSummaries.filter((b) => b.skipped === 'needs-keys');
       if (needsKeysBoards.length > 0) {
         notify.warning({
-          message: t('jobs.needsKeysSkippedNote'),
+          message: t('jobs.needsKeys.skippedNote'),
           // Sticky: diagnostic notification requires user action (add API keys).
           duration: 0,
         });

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -183,6 +183,16 @@ export function JobsPage() {
           duration: 0,
         });
       }
+      // Surface skipped-due-to-missing-API-keys boards (the aggregator) so the
+      // user knows to configure keys in Settings rather than see a silent zero.
+      const needsKeysBoards = boardSummaries.filter((b) => b.skipped === 'needs-keys');
+      if (needsKeysBoards.length > 0) {
+        notify.warning({
+          message: t('jobs.needsKeysSkippedNote'),
+          // Sticky: diagnostic notification requires user action (add API keys).
+          duration: 0,
+        });
+      }
     } else if (ev.type === 'job.failed') {
       noteScrapeFinished(ev.jobId, {
         ok: false,

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/index.tsx
@@ -365,21 +365,13 @@ export function ScrapeForm({
               onGeocode={onGeocode}
             />
 
-            {/* Progress bar */}
+            {/* Scraping status — an honest indeterminate signal only (the earlier
+                fake 85% progress bar fabricated progress and was removed). The real
+                per-board progress is the streamed-results count shown in JobsResults. */}
             {scraping && (
-              <div className="mb-4">
-                <div className="h-px w-full overflow-hidden rounded-full bg-white/[0.06]">
-                  <motion.div
-                    className="h-full rounded-full bg-gradient-to-r from-brand to-brand-soft"
-                    initial={{ width: '0%' }}
-                    animate={{ width: '85%' }}
-                    transition={transition.fakeProgress}
-                  />
-                </div>
-                <div className="mt-1.5 flex items-center gap-1.5 text-[11px] text-foreground/40">
-                  <Loader2 size={10} className="animate-spin" />
-                  {t('jobs.scraping')} {scrapingLabel}…
-                </div>
+              <div className="mb-4 flex items-center gap-1.5 text-[11px] text-foreground/40">
+                <Loader2 size={10} className="animate-spin" />
+                {t('jobs.scraping')} {scrapingLabel}…
               </div>
             )}
 

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
@@ -93,3 +93,47 @@ describe('useScraping — companies field in scrapeBoards payload', () => {
     expect(payload).toHaveProperty('companies', ['stripe', 'airbnb']);
   });
 });
+
+describe('useScraping — geo fields in the replace-vs-append signature', () => {
+  it('replaces (not appends) when only the countryCode differs', async () => {
+    mutateAsync.mockClear();
+    const { result, rerender } = renderHookWithClient(
+      ({ form }: { form: ScrapeFormState }) => useScraping(noopNotify, form),
+      { initialProps: { form: makeForm({ countryCode: 'US' }) } }
+    );
+
+    // First run seeds the last-search signature.
+    await act(async () => {
+      await result.current.startScrape();
+    });
+
+    // Same keywords, different country → a different market must REPLACE the
+    // stale results. This fails if countryCode is missing from the signature.
+    rerender({ form: makeForm({ countryCode: 'DE' }) });
+    await act(async () => {
+      await result.current.startScrape();
+    });
+
+    expect(result.current.replacePendingRef.current).toBe(true);
+  });
+
+  it('appends (does not replace) when the search is byte-for-byte identical', async () => {
+    mutateAsync.mockClear();
+    const { result, rerender } = renderHookWithClient(
+      ({ form }: { form: ScrapeFormState }) => useScraping(noopNotify, form),
+      { initialProps: { form: makeForm({ countryCode: 'US' }) } }
+    );
+
+    await act(async () => {
+      await result.current.startScrape();
+    });
+
+    // Identical form (including geo) → "show more" semantics: keep + append.
+    rerender({ form: makeForm({ countryCode: 'US' }) });
+    await act(async () => {
+      await result.current.startScrape();
+    });
+
+    expect(result.current.replacePendingRef.current).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
@@ -72,7 +72,7 @@ export function useScraping(
       scrapeForm.countryCode ?? '',
       scrapeForm.latitude ?? '',
       scrapeForm.longitude ?? '',
-      scrapeForm.radiusKm,
+      scrapeForm.radiusKm ?? '',
       scrapeForm.dateFilter ?? '',
       scrapeForm.companies.slice().sort().join(','),
     ].join('|');

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
@@ -66,6 +66,13 @@ export function useScraping(
       [...scrapeForm.boards].sort().join(','),
       scrapeForm.query.trim().toLowerCase(),
       scrapeForm.location.trim().toLowerCase(),
+      // Geo fields: a geo-different search (same keywords, different country /
+      // coordinates / radius) targets a different market, so it must REPLACE the
+      // stale results rather than append to them.
+      scrapeForm.countryCode ?? '',
+      scrapeForm.latitude ?? '',
+      scrapeForm.longitude ?? '',
+      scrapeForm.radiusKm,
       scrapeForm.dateFilter ?? '',
       scrapeForm.companies.slice().sort().join(','),
     ].join('|');

--- a/packages/shared/src/ipc/contracts/autopilot.ts
+++ b/packages/shared/src/ipc/contracts/autopilot.ts
@@ -12,7 +12,13 @@ export interface AutopilotContract {
 
   remove(req: { autopilotId: string }): Promise<void>;
 
-  run(req: { autopilotId: string }): Promise<{ jobId: string }>;
+  /**
+   * Run an autopilot now. The backend command *resolves* (does not reject) with
+   * an `{ error }` payload on a scrape failure or unknown id, so callers MUST
+   * inspect `error` — a resolved value is not proof of success. `jobId` is
+   * present on every non-error outcome (success / cancel).
+   */
+  run(req: { autopilotId: string }): Promise<{ jobId?: string; error?: string }>;
 
   pause(req: { autopilotId: string }): Promise<void>;
 

--- a/packages/shared/src/ipc/contracts/boards.ts
+++ b/packages/shared/src/ipc/contracts/boards.ts
@@ -50,12 +50,14 @@ export interface BoardsContract {
  * Per-board outcome from a completed scrape job.
  * - `skipped: "needs-login"` — board bypassed because no session exists.
  * - `skipped: "needs-company"` — ATS board bypassed because no company slug was supplied.
+ * - `skipped: "needs-keys"` — key-backed board (the aggregator) bypassed because its
+ *   API keys aren't configured; prompt the user to add them in Settings.
  */
 export interface BoardScrapeSummary {
   board: string;
   count: number;
   error?: string;
-  skipped?: 'needs-login' | 'needs-company';
+  skipped?: 'needs-login' | 'needs-company' | 'needs-keys';
 }
 
 export const BOARDS_CHANNELS = {

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1802,6 +1802,7 @@
       "skippedNote_one": "{{boards}} wurde übersprungen — füge einen Unternehmens-Slug hinzu, um dieses Board zu durchsuchen.",
       "skippedNote_other": "{{boards}} wurden übersprungen — füge einen Unternehmens-Slug hinzu, um diese Boards zu durchsuchen."
     },
+    "needsKeysSkippedNote": "Job-Aggregator übersprungen — keine API-Schlüssel konfiguriert. Schlüssel in den Einstellungen hinzufügen.",
     "companies": {
       "label": "Unternehmen",
       "placeholder": "z. B. stripe, airbnb",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1802,7 +1802,9 @@
       "skippedNote_one": "{{boards}} wurde übersprungen — füge einen Unternehmens-Slug hinzu, um dieses Board zu durchsuchen.",
       "skippedNote_other": "{{boards}} wurden übersprungen — füge einen Unternehmens-Slug hinzu, um diese Boards zu durchsuchen."
     },
-    "needsKeysSkippedNote": "Job-Aggregator übersprungen — keine API-Schlüssel konfiguriert. Schlüssel in den Einstellungen hinzufügen.",
+    "needsKeys": {
+      "skippedNote": "Job-Aggregator übersprungen — keine API-Schlüssel konfiguriert. Schlüssel in den Einstellungen hinzufügen."
+    },
     "companies": {
       "label": "Unternehmen",
       "placeholder": "z. B. stripe, airbnb",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1798,6 +1798,7 @@
       "skippedNote_one": "{{boards}} was skipped — add a company slug to scrape this board.",
       "skippedNote_other": "{{boards}} were skipped — add a company slug to scrape these boards."
     },
+    "needsKeysSkippedNote": "Job aggregator skipped — no API keys configured. Add keys in Settings.",
     "companies": {
       "label": "Companies",
       "placeholder": "e.g. stripe, airbnb",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1798,7 +1798,9 @@
       "skippedNote_one": "{{boards}} was skipped — add a company slug to scrape this board.",
       "skippedNote_other": "{{boards}} were skipped — add a company slug to scrape these boards."
     },
-    "needsKeysSkippedNote": "Job aggregator skipped — no API keys configured. Add keys in Settings.",
+    "needsKeys": {
+      "skippedNote": "Job aggregator skipped — no API keys configured. Add keys in Settings."
+    },
     "companies": {
       "label": "Companies",
       "placeholder": "e.g. stripe, airbnb",

--- a/packages/ui/src/lib/motion.ts
+++ b/packages/ui/src/lib/motion.ts
@@ -80,8 +80,6 @@ export const transition = {
   blob2: { duration: 0.8, ease: 'easeOut', delay: 0.08 },
   /** Atmospheric background blob — third layer */
   blob3: { duration: 0.9, ease: 'easeOut', delay: 0.12 },
-  /** Fake indeterminate progress for scraping / medium AI tasks */
-  fakeProgress: { duration: 12, ease: 'easeOut' },
   /** Fake indeterminate progress for longer AI generation tasks */
   fakeProgressSlow: { duration: 20, ease: 'easeOut' },
 } as const;


### PR DESCRIPTION
## Summary

Six trust quick wins from the 2026-07-10 job-search audit (23-agent adversarially-verified review of the autopilot/scraping/location stack; full report in `.claude/scratch/job-search-trust-audit.md`). The audit confirmed the engine sound and identified that failures were being converted into silent zero-result "success" — these are the ≤1-day fixes from its top-ranked list.

- **fix(scraping):** guessed-market results below the broaden floor (3) now fall through to the fallback provider instead of returning 1–2 wrong-market hits as authoritative; keyless aggregator surfaces as a `needs-keys` skip (mirrors `needs-login`/`needs-company`); credential-store read failures surface as board errors pre-network.
- **fix(autopilot):** `merge_found_jobs` dedupes by normalized URL within and across batches (notification counts now reflect distinct postings; cross-provider redirect-URL identity documented as deferred to trust-program PR E); a resolved `{error}` run payload now reaches the error banner instead of rendering as "done".
- **fix(jobs):** replace-vs-append scrape signature includes geo fields — changing location replaces stale results instead of appending.
- **ui(jobs):** fake 85% progress animation removed (honest indeterminate spinner + streamed count remain); `needs-keys` sticky warning with en+de copy.

## Review status

- `scraping-applier-expert` — passed, no blocking findings (3 advisory LOWs: keyring-read redundancy acceptable at once-per-scrape; dedup-reach comments softened in-diff; title+company fallback collision documented as known limitation).
- `frontend-reviewer` — passed, no blocking findings (2 cosmetic LOWs noted: flat `jobs.needsKeysSkippedNote` key vs nested sibling pattern; needs-keys note omits board interpolation — single-board reason, fine as-is).

## Tests

13 new Rust tests (guessed-market floor boundaries, needs-keys skip via panicking mock, store-failure-is-error, dedupe variants/fallback/notification count) + 3 renderer tests (resolved-error routing, geo replace, byte-identical append guard).

⚠️ Local `cargo test` cannot execute on the dev host (known STATUS_ENTRYPOINT_NOT_FOUND DLL fault) — Rust tests compile clean under `cargo check --all-targets` + clippy; **CI is authoritative for Rust test execution.** Frontend: full suite green (317 files / 3,228 tests), whole-graph typecheck + lint:strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
