### PR TITLE
feat: template tiers with grouped gallery and lebenslauf ats toggle fix (templates pr 2/6)

### DIFF
--- a/apps/desktop/src-tauri/src/export/templates/mod.rs
+++ b/apps/desktop/src-tauri/src/export/templates/mod.rs
@@ -69,11 +69,27 @@ pub enum SectionStyle {
     BoldOnly,
 }
 
+/// ATS-safe vs. design tier — metadata only, no render behavior.
+///
+/// Drives the frontend gallery grouping (ATS-Safe / Design sections + badge) and
+/// which templates surface the ATS-mode toggle: design-tier layouts (photo /
+/// two-column) drop the photo and linearize when ATS mode is on. Not serialized
+/// to the renderer (`JsonStyle` is unchanged); the frontend registry mirrors it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TemplateTier {
+    /// Single-column, parser-safe layouts.
+    Ats,
+    /// Photo / two-column / visually rich layouts.
+    Design,
+}
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Template {
     pub id: TemplateId,
     pub name: &'static str,
+    /// ATS-safe vs. design tier (metadata; see [`TemplateTier`]).
+    pub tier: TemplateTier,
 
     // Colors (RGB tuples)
     pub name_color: (u8, u8, u8),
@@ -176,6 +192,7 @@ impl Template {
         Self {
             id: TemplateId::Classic,
             name: "ATS Classic",
+            tier: TemplateTier::Ats,
             name_color: (17, 17, 17),
             section_color: (17, 17, 17),
             accent_color: (34, 34, 34),
@@ -206,6 +223,7 @@ impl Template {
         Self {
             id: TemplateId::SwissMinimal,
             name: "Swiss Minimal",
+            tier: TemplateTier::Ats,
             name_color: (20, 20, 20),
             section_color: (20, 20, 20),
             accent_color: (230, 57, 70),
@@ -243,6 +261,7 @@ impl Template {
         Self {
             id: TemplateId::Academic,
             name: "Academic",
+            tier: TemplateTier::Ats,
             name_color: (20, 40, 30),
             section_color: (27, 67, 50),
             accent_color: (27, 67, 50),
@@ -288,6 +307,7 @@ impl Template {
         Self {
             id: TemplateId::Atelier,
             name: "Atelier",
+            tier: TemplateTier::Design,
             // Slate-indigo palette: a deep, sophisticated purple-grey.
             name_color: (22, 20, 54),
             section_color: (74, 69, 128),
@@ -340,6 +360,7 @@ impl Template {
         Self {
             id: TemplateId::Meridian,
             name: "Meridian",
+            tier: TemplateTier::Ats,
             // Warm copper-sienna palette — original, professional.
             name_color: (255, 255, 255),  // white on the dark band
             section_color: (160, 82, 45), // copper-sienna for section headings
@@ -384,6 +405,7 @@ impl Template {
         Self {
             id: TemplateId::Throughline,
             name: "Throughline",
+            tier: TemplateTier::Ats,
             // Deep forest-teal palette.
             name_color: (15, 50, 45),    // very dark teal name
             section_color: (26, 92, 82), // forest teal sections
@@ -430,6 +452,7 @@ impl Template {
         Self {
             id: TemplateId::Portrait,
             name: "Portrait",
+            tier: TemplateTier::Design,
             // Deep slate-teal palette — professional, original.
             name_color: (18, 40, 50),
             section_color: (42, 100, 120),
@@ -480,6 +503,7 @@ impl Template {
         Self {
             id: TemplateId::Lebenslauf,
             name: "Lebenslauf",
+            tier: TemplateTier::Design,
             // Warm slate palette — formal, DACH-appropriate.
             name_color: (20, 25, 35),
             section_color: (61, 79, 107),

--- a/apps/desktop/src-tauri/src/export/templates/test.rs
+++ b/apps/desktop/src-tauri/src/export/templates/test.rs
@@ -117,3 +117,30 @@ fn with_accent_override_is_a_noop_for_absent_or_malformed_input() {
         );
     }
 }
+
+// ─── Template tier metadata ───────────────────────────────────────────────────
+
+/// Pin every template's ATS/Design tier. ATS-safe = single-column, parser-safe;
+/// Design = photo / two-column layouts (which surface the ATS-mode toggle and
+/// drop the photo when it's on). Update deliberately when a template is added.
+#[test]
+fn template_tiers_are_pinned() {
+    use TemplateTier::{Ats, Design};
+    let expected = [
+        (TemplateId::Classic, Ats),
+        (TemplateId::SwissMinimal, Ats),
+        (TemplateId::Academic, Ats),
+        (TemplateId::Meridian, Ats),
+        (TemplateId::Throughline, Ats),
+        (TemplateId::Atelier, Design),
+        (TemplateId::Portrait, Design),
+        (TemplateId::Lebenslauf, Design),
+    ];
+    for (id, tier) in expected {
+        assert_eq!(
+            Template::get(id).tier,
+            tier,
+            "template {id:?} has the wrong tier"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/export/typst_engine/test.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/test.rs
@@ -2252,6 +2252,51 @@ fn lebenslauf_ats_harness() {
     }
 }
 
+// (2c-tier) ATS mode drops the Lebenslauf photo.
+//
+// Verifies `lebenslauf.typ`'s `#if not is-ats and has-photo` branch through the
+// render path: with a real photo supplied, the non-ATS render embeds it (Typst
+// emits the raster as an SVG `<image>` element) but the ATS render omits it. The
+// SVG emit shares the exact world/data as the PDF path, so this is the cheapest
+// reliable assertion — no PDF-internals parsing needed.
+#[test]
+fn lebenslauf_ats_mode_drops_photo() {
+    use crate::export::typst_engine::render_resume_svg_pages_with_photo;
+
+    let model = model_from_resume_text(LEBENSLAUF_FIXTURE);
+    let t = template_style(TemplateId::Lebenslauf);
+    let photo_png = resolve_photo(&fixture_photo_data_url());
+    assert!(photo_png.is_some(), "fixture photo must resolve");
+
+    // Non-ATS + photo → the raster photo is embedded as an SVG <image>.
+    let pages_shown = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Lebenslauf,
+        &opts_photo(false),
+        Some(&t),
+        photo_png.clone(),
+    )
+    .expect("render_resume_svg_pages_with_photo(lebenslauf, non-ats) should succeed");
+    assert!(
+        pages_shown.join("").contains("<image"),
+        "non-ATS Lebenslauf with a photo must embed it as an <image> element"
+    );
+
+    // ATS + the same photo → `#if not is-ats and has-photo` is false → no image.
+    let pages_ats = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Lebenslauf,
+        &opts_photo(true),
+        Some(&t),
+        photo_png,
+    )
+    .expect("render_resume_svg_pages_with_photo(lebenslauf, ats) should succeed");
+    assert!(
+        !pages_ats.join("").contains("<image"),
+        "ATS-mode Lebenslauf must drop the photo (no <image> element)"
+    );
+}
+
 // (2d) Write Lebenslauf sample PDFs to target/ for human review.
 #[test]
 fn lebenslauf_write_sample_pdfs_for_review() {

--- a/apps/desktop/src/renderer/features/ai-generate/components/GenerateWizard/GenerateWizard.test.tsx
+++ b/apps/desktop/src/renderer/features/ai-generate/components/GenerateWizard/GenerateWizard.test.tsx
@@ -36,6 +36,7 @@ vi.mock('../wizard-steps/StepTemplate', () => ({
   }) => (
     <div>
       <Button onClick={() => onTemplateChange('classic')}>select-classic</Button>
+      <Button onClick={() => onTemplateChange('lebenslauf')}>select-lebenslauf</Button>
       <Button onClick={() => onAtsModeChange(false)}>reset-ats</Button>
     </div>
   ),
@@ -197,5 +198,15 @@ describe('GenerateWizard — template selection side-effects', () => {
     // StepTemplate stub calls onAtsModeChange(false) via the "reset-ats" button
     await user.click(screen.getByRole('button', { name: 'reset-ats' }));
     expect(onAtsModeChange).toHaveBeenCalledWith(false);
+  });
+
+  it('selecting Lebenslauf (design tier) does NOT reset ATS mode', async () => {
+    const user = userEvent.setup();
+    const onAtsModeChange = vi.fn();
+    const onTemplateChange = vi.fn();
+    render(<GenerateWizard {...makeProps({ onTemplateChange, onAtsModeChange })} />);
+    await user.click(screen.getByRole('button', { name: 'select-lebenslauf' }));
+    expect(onTemplateChange).toHaveBeenCalledWith('lebenslauf');
+    expect(onAtsModeChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/features/ai-generate/components/GenerateWizard/index.tsx
+++ b/apps/desktop/src/renderer/features/ai-generate/components/GenerateWizard/index.tsx
@@ -7,7 +7,7 @@ import { Button, StepDots, transition } from '@ajh/ui';
 import {
   type EmphasisId,
   type GenerationMode,
-  isTwoColumnTemplate,
+  isDesignTier,
   type TemplateId,
 } from '@/lib/generate';
 import { useSessionStore } from '@/store/session-store';
@@ -67,8 +67,10 @@ export function GenerateWizard({
 
   const handleTemplateChange = (id: TemplateId) => {
     onTemplateChange(id);
+    // ATS-tier templates have no ATS toggle — clear any stale atsMode.
+    // Design-tier templates (two-column OR photo, incl. Lebenslauf) keep it.
     // Cover letters have no ATS toggle, so never touch atsMode there.
-    if (target !== 'cover' && !isTwoColumnTemplate(id)) {
+    if (target !== 'cover' && !isDesignTier(id)) {
       onAtsModeChange(false);
     }
   };

--- a/apps/desktop/src/renderer/features/ai-generate/components/LeftPanel/index.tsx
+++ b/apps/desktop/src/renderer/features/ai-generate/components/LeftPanel/index.tsx
@@ -9,7 +9,12 @@ import { AiSetupHint } from '@/components/ui/AiSetupHint';
 import { ModelSelector } from '@/components/ui/ModelSelector';
 import { GenerationMetadata } from '@/features/ai-generate/components/GenerationMetadata';
 import { TemplateRecommendation } from '@/features/ai-generate/components/TemplateRecommendation';
-import { type GenerationMeta, isTwoColumnTemplate, type TemplateId } from '@/lib/generate';
+import {
+  type GenerationMeta,
+  isDesignTier,
+  isTwoColumnTemplate,
+  type TemplateId,
+} from '@/lib/generate';
 
 interface Props {
   resume: string;
@@ -130,7 +135,9 @@ export function LeftPanel({
           setTemplateId(id);
           setLocale(recommendedLocale);
           if (atsSuggested && isTwoColumnTemplate(id)) setAtsMode(true);
-          else if (!isTwoColumnTemplate(id)) setAtsMode(false);
+          // Reset gates on design-tier semantics like the other four surfaces;
+          // the auto-suggest guard above deliberately stays two-column-only.
+          else if (!isDesignTier(id)) setAtsMode(false);
         }}
       />
 

--- a/apps/desktop/src/renderer/features/ai-generate/components/wizard-steps/StepTemplate/StepTemplate.test.tsx
+++ b/apps/desktop/src/renderer/features/ai-generate/components/wizard-steps/StepTemplate/StepTemplate.test.tsx
@@ -317,4 +317,86 @@ describe('StepTemplate', () => {
     await user.click(screen.getByTestId(`${TEST_IDS.generation.accentSwatch}-navy`));
     expect(onAccentChange).toHaveBeenCalledWith('#1B3A5C');
   });
+
+  // ── tier grouping + badges ──────────────────────────────────────────────────
+
+  const renderStep = (props: Partial<Parameters<typeof StepTemplate>[0]> = {}) =>
+    render(
+      <StepTemplate
+        templateId="classic"
+        atsMode={false}
+        onTemplateChange={onTemplateChange}
+        onAtsModeChange={onAtsModeChange}
+        {...props}
+      />
+    );
+
+  it('groups the gallery into labeled ATS-Safe and Design sections', () => {
+    renderStep();
+    expect(screen.getByText('aiGenerate.tier.atsSafe')).toBeInTheDocument();
+    expect(screen.getByText('aiGenerate.tier.design')).toBeInTheDocument();
+  });
+
+  it('shows a tier badge on every card (5 ATS + 3 design)', () => {
+    renderStep();
+    expect(screen.getAllByText('aiGenerate.tier.atsBadge')).toHaveLength(5);
+    expect(screen.getAllByText('aiGenerate.tier.designBadge')).toHaveLength(3);
+  });
+
+  // ── ATS toggle gate is tier-aware (the Lebenslauf photo fix) ─────────────────
+
+  it.each(['atelier', 'portrait', 'lebenslauf'] as const)(
+    'shows the ATS toggle for the design-tier template %s',
+    (id) => {
+      renderStep({ templateId: id });
+      expect(screen.getByRole('switch', { name: /aiGenerate\.atsMode/i })).toBeInTheDocument();
+    }
+  );
+
+  it.each(['classic', 'swiss-minimal', 'academic', 'meridian', 'throughline'] as const)(
+    'hides the ATS toggle for the ATS-tier template %s',
+    (id) => {
+      renderStep({ templateId: id });
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    }
+  );
+
+  it('uses the two-column hint for a two-column template but the photo hint for Lebenslauf', () => {
+    const { unmount } = renderStep({ templateId: 'atelier' });
+    expect(screen.getByText('aiGenerate.atsModeHintTwoColumn')).toBeInTheDocument();
+    expect(screen.queryByText('aiGenerate.atsModeHintPhoto')).not.toBeInTheDocument();
+    unmount();
+
+    renderStep({ templateId: 'lebenslauf' });
+    expect(screen.getByText('aiGenerate.atsModeHintPhoto')).toBeInTheDocument();
+    expect(screen.queryByText('aiGenerate.atsModeHintTwoColumn')).not.toBeInTheDocument();
+  });
+
+  // Portrait is two-column AND has a photo — it must get the (inclusive)
+  // two-column hint copy, which also covers photo removal, not the photo-only key.
+  it('uses the inclusive two-column hint for Portrait (two-column + photo)', () => {
+    renderStep({ templateId: 'portrait' });
+    expect(screen.getByText('aiGenerate.atsModeHintTwoColumn')).toBeInTheDocument();
+    expect(screen.queryByText('aiGenerate.atsModeHintPhoto')).not.toBeInTheDocument();
+  });
+
+  it('resets ATS mode when an ATS-tier template is selected from a design-tier one', async () => {
+    const user = userEvent.setup();
+    renderStep({ templateId: 'lebenslauf', atsMode: true });
+    const swissButton = screen.getByText('Swiss Minimal').closest('button');
+    if (!swissButton) throw new Error('Swiss Minimal button not found');
+    await user.click(swissButton);
+    expect(onTemplateChange).toHaveBeenCalledWith('swiss-minimal');
+    expect(onAtsModeChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does NOT reset ATS mode when Lebenslauf (design tier) is selected', async () => {
+    const user = userEvent.setup();
+    renderStep({ templateId: 'atelier', atsMode: true });
+    const lebenslaufButton = screen.getByText('Lebenslauf (DACH)').closest('button');
+    if (!lebenslaufButton) throw new Error('Lebenslauf button not found');
+    await user.click(lebenslaufButton);
+    expect(onTemplateChange).toHaveBeenCalledWith('lebenslauf');
+    expect(onAtsModeChange).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/renderer/features/ai-generate/components/wizard-steps/StepTemplate/index.tsx
+++ b/apps/desktop/src/renderer/features/ai-generate/components/wizard-steps/StepTemplate/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from '@ajh/translations';
 import { Button, cn, Image } from '@ajh/ui';
 
 import { AccentPicker } from '@/components/generation/AccentPicker';
-import { isTwoColumnTemplate, type TemplateId, TEMPLATES } from '@/lib/generate';
+import { isDesignTier, isTwoColumnTemplate, type TemplateId, TEMPLATES } from '@/lib/generate';
 
 import { COVER_TEMPLATE_PREVIEWS, TEMPLATE_CAPTIONS, TEMPLATE_PREVIEWS } from '../../../samples';
 
@@ -37,81 +37,104 @@ export function StepTemplate({
 
   const handleTemplateSelect = (id: TemplateId) => {
     onTemplateChange(id);
-    // Single-column templates must never have ATS mode on — reset it.
-    // Cover letters have no ATS toggle, so never touch atsMode there.
-    if (!isCover && !isTwoColumnTemplate(id)) {
+    // ATS-tier templates have no ATS toggle (they are already parser-safe), so
+    // clear any stale atsMode. Design-tier templates (two-column OR photo, incl.
+    // Lebenslauf) keep the toggle. Cover letters never touch atsMode.
+    if (!isCover && !isDesignTier(id)) {
       onAtsModeChange(false);
     }
   };
 
+  const renderCard = (tpl: (typeof TEMPLATES)[TemplateId]) => {
+    // 'both' (and 'resume') intentionally use the résumé thumbnails — the template is shared
+    // and the résumé is the primary document; only cover-only swaps to cover-letter style previews.
+    const image = isCover ? COVER_TEMPLATE_PREVIEWS[tpl.id] : TEMPLATE_PREVIEWS[tpl.id];
+    const caption = TEMPLATE_CAPTIONS[tpl.id];
+    const selected = templateId === tpl.id;
+
+    return (
+      <Button
+        key={tpl.id}
+        onClick={() => handleTemplateSelect(tpl.id)}
+        className={cn(
+          'flex flex-col items-start gap-1.5 rounded-xl border p-2 text-left transition-all h-auto',
+          selected
+            ? 'border-brand/50 bg-brand/10 ring-2 ring-brand/40'
+            : 'border-[var(--border-clear)] bg-card hover:bg-muted'
+        )}
+      >
+        {/* Thumbnail */}
+        <div className="relative w-full rounded-lg overflow-hidden bg-muted aspect-[3/4] flex items-center justify-center">
+          {image ? (
+            <Image
+              src={image}
+              alt={tpl.name}
+              preview={false}
+              rootClassName="w-full h-full"
+              className="w-full h-full object-cover rounded-lg"
+            />
+          ) : (
+            <FileText size={20} className="text-foreground/20" />
+          )}
+          {/* Tier badge — top-left, opposite the selected check. Static label. */}
+          <span className="absolute left-1.5 top-1.5 rounded-full border border-[var(--border-clear)] bg-card/90 px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-wide text-foreground/60">
+            {t(tpl.tier === 'design' ? 'aiGenerate.tier.designBadge' : 'aiGenerate.tier.atsBadge')}
+          </span>
+          {/* #13 — selected state reads clearly with a check badge. */}
+          {selected && (
+            <span className="absolute right-1.5 top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-brand text-white shadow-sm">
+              <Check size={12} strokeWidth={3} />
+            </span>
+          )}
+        </div>
+
+        {/* Template name */}
+        <span
+          className={cn(
+            'text-[10px] font-medium leading-tight w-full text-center',
+            selected ? 'text-foreground/90' : 'text-foreground/50'
+          )}
+        >
+          {tpl.name}
+        </span>
+
+        {caption && (
+          <span className="text-[9px] text-foreground/30 leading-tight w-full text-center line-clamp-1">
+            {caption}
+          </span>
+        )}
+      </Button>
+    );
+  };
+
+  const atsTemplates = Object.values(TEMPLATES).filter((tpl) => !isDesignTier(tpl.id));
+  const designTemplates = Object.values(TEMPLATES).filter((tpl) => isDesignTier(tpl.id));
+
   return (
     <div className="space-y-4">
-      {/* Template thumbnail gallery */}
-      <div className="grid grid-cols-1 gap-3 @xs:grid-cols-3">
-        {Object.values(TEMPLATES).map((tpl) => {
-          // 'both' (and 'resume') intentionally use the résumé thumbnails — the template is shared
-          // and the résumé is the primary document; only cover-only swaps to cover-letter style previews.
-          const image = isCover ? COVER_TEMPLATE_PREVIEWS[tpl.id] : TEMPLATE_PREVIEWS[tpl.id];
-          const caption = TEMPLATE_CAPTIONS[tpl.id];
-          const selected = templateId === tpl.id;
+      {/* Template thumbnail gallery, grouped by tier (ATS-Safe first, then Design). */}
+      <div className="space-y-1.5">
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.16em] text-foreground/45">
+          {t('aiGenerate.tier.atsSafe')}
+        </h3>
+        <div className="grid grid-cols-1 gap-3 @xs:grid-cols-3">{atsTemplates.map(renderCard)}</div>
+      </div>
 
-          return (
-            <Button
-              key={tpl.id}
-              onClick={() => handleTemplateSelect(tpl.id)}
-              className={cn(
-                'flex flex-col items-start gap-1.5 rounded-xl border p-2 text-left transition-all h-auto',
-                selected
-                  ? 'border-brand/50 bg-brand/10 ring-2 ring-brand/40'
-                  : 'border-[var(--border-clear)] bg-card hover:bg-muted'
-              )}
-            >
-              {/* Thumbnail */}
-              <div className="relative w-full rounded-lg overflow-hidden bg-muted aspect-[3/4] flex items-center justify-center">
-                {image ? (
-                  <Image
-                    src={image}
-                    alt={tpl.name}
-                    preview={false}
-                    rootClassName="w-full h-full"
-                    className="w-full h-full object-cover rounded-lg"
-                  />
-                ) : (
-                  <FileText size={20} className="text-foreground/20" />
-                )}
-                {/* #13 — selected state reads clearly with a check badge. */}
-                {selected && (
-                  <span className="absolute right-1.5 top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-brand text-white shadow-sm">
-                    <Check size={12} strokeWidth={3} />
-                  </span>
-                )}
-              </div>
-
-              {/* Template name */}
-              <span
-                className={cn(
-                  'text-[10px] font-medium leading-tight w-full text-center',
-                  selected ? 'text-foreground/90' : 'text-foreground/50'
-                )}
-              >
-                {tpl.name}
-              </span>
-
-              {caption && (
-                <span className="text-[9px] text-foreground/30 leading-tight w-full text-center line-clamp-1">
-                  {caption}
-                </span>
-              )}
-            </Button>
-          );
-        })}
+      <div className="space-y-1.5">
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.16em] text-foreground/45">
+          {t('aiGenerate.tier.design')}
+        </h3>
+        <div className="grid grid-cols-1 gap-3 @xs:grid-cols-3">
+          {designTemplates.map(renderCard)}
+        </div>
       </div>
 
       {/* Document accent — per-export colour override, threaded to preview + export. */}
       {onAccentChange && <AccentPicker value={accent} onChange={onAccentChange} />}
 
-      {/* ATS safe mode toggle — only relevant for two-column résumé templates */}
-      {!isCover && isTwoColumnTemplate(templateId) && (
+      {/* ATS safe mode toggle — shown for design-tier résumé templates (two-column
+          OR photo, incl. Lebenslauf); ATS-tier templates are already parser-safe. */}
+      {!isCover && isDesignTier(templateId) && (
         <Button
           variant="unstyled"
           type="button"
@@ -135,7 +158,11 @@ export function StepTemplate({
               {t('aiGenerate.atsMode')}
             </div>
             <div className="text-[10px] text-foreground/35 mt-0.5">
-              {t('aiGenerate.atsModeHint')}
+              {t(
+                isTwoColumnTemplate(templateId)
+                  ? 'aiGenerate.atsModeHintTwoColumn'
+                  : 'aiGenerate.atsModeHintPhoto'
+              )}
             </div>
           </div>
           <div

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
@@ -496,18 +496,52 @@ describe('GenerationOutput', () => {
       expect(onTemplateChange).toHaveBeenCalledWith('classic');
       expect(onAtsModeChange).toHaveBeenCalledWith(false);
     });
+
+    it('does NOT reset ATS mode when Lebenslauf (design tier) is picked', async () => {
+      const user = userEvent.setup();
+      const onTemplateChange = vi.fn();
+      const onAtsModeChange = vi.fn();
+      render(
+        <GenerationOutput
+          {...makeProps({
+            activeOut: 'resume',
+            templateId: 'atelier',
+            onTemplateChange,
+            onAtsModeChange,
+            atsMode: true,
+          })}
+        />
+      );
+
+      await pickTemplate(user, 'lebenslauf');
+
+      expect(onTemplateChange).toHaveBeenCalledWith('lebenslauf');
+      expect(onAtsModeChange).not.toHaveBeenCalled();
+    });
   });
 
   // ── 7. ATS toggle ─────────────────────────────────────────────────────────────
-  // The switch is rendered only on the résumé tab AND when
-  // isTwoColumnTemplate(templateId) is true — ATS single-column linearization is a
-  // résumé concept, so it never shows on the cover tab.
+  // The switch is rendered only on the résumé tab AND when isDesignTier(templateId)
+  // is true (two-column OR photo, incl. Lebenslauf) — ATS-safe mode is a résumé
+  // concept, so it never shows on the cover tab.
 
   describe('ATS toggle', () => {
     it('renders a switch when a two-column template is active on the resume tab', () => {
       // 'atelier' is a confirmed two-column template.
       render(<GenerationOutput {...makeProps({ activeOut: 'resume', templateId: 'atelier' })} />);
       expect(screen.getByRole('switch')).toBeInTheDocument();
+    });
+
+    it('renders a switch for Lebenslauf (design-tier, single-column-with-photo)', () => {
+      render(
+        <GenerationOutput {...makeProps({ activeOut: 'resume', templateId: 'lebenslauf' })} />
+      );
+      expect(screen.getByRole('switch')).toBeInTheDocument();
+    });
+
+    it('does NOT render a switch for an ATS-tier template (classic)', () => {
+      render(<GenerationOutput {...makeProps({ activeOut: 'resume', templateId: 'classic' })} />);
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument();
     });
 
     it('is absent on the cover tab even for a two-column template', () => {

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
@@ -13,6 +13,7 @@ import {
   buildFilename,
   type GenerationMeta,
   isDesignTier,
+  isTwoColumnTemplate,
   TEMPLATE_IDS,
   type TemplateId,
   TEMPLATES,
@@ -273,7 +274,11 @@ export function GenerationOutput({
                 StepTemplate's switch markup; reuses the aiGenerate.atsMode keys). */}
             {activeOut === 'resume' && isDesignTier(templateId) && (
               <div
-                title={t('aiGenerate.atsModeHint')}
+                title={t(
+                  isTwoColumnTemplate(templateId)
+                    ? 'aiGenerate.atsModeHintTwoColumn'
+                    : 'aiGenerate.atsModeHintPhoto'
+                )}
                 className={cn(
                   'flex h-auto items-center gap-1.5 rounded-lg border px-2 py-1 transition-all',
                   atsMode

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
@@ -12,7 +12,7 @@ import { useDebouncedCommit } from '@/hooks/use-debounced-commit';
 import {
   buildFilename,
   type GenerationMeta,
-  isTwoColumnTemplate,
+  isDesignTier,
   TEMPLATE_IDS,
   type TemplateId,
   TEMPLATES,
@@ -154,14 +154,15 @@ export function GenerationOutput({
   }, [flush]);
   const docType = activeOut === 'resume' ? 'resume' : 'cover-letter';
 
-  // Template picker (mirrors GenerateWizard.handleTemplateChange): selecting a
-  // single-column template forces ATS off, since ATS-safe mode only linearizes the
-  // two-column templates. One template id drives BOTH docs' preview + export.
+  // Template picker (mirrors GenerateWizard.handleTemplateChange): selecting an
+  // ATS-tier template forces ATS off, since ATS-safe mode only applies to
+  // design-tier layouts (two-column OR photo, incl. Lebenslauf). One template id
+  // drives BOTH docs' preview + export.
   const templateOptions = TEMPLATE_IDS.map((id) => ({ value: id, label: TEMPLATES[id].name }));
   const handleTemplateChange = (value: string) => {
     const id = value as TemplateId;
     onTemplateChange(id);
-    if (!isTwoColumnTemplate(id)) onAtsModeChange(false);
+    if (!isDesignTier(id)) onAtsModeChange(false);
   };
 
   // ARIA tabs contract: each tab owns a stable id and controls a panel id; the
@@ -267,10 +268,10 @@ export function GenerationOutput({
                 listClassName="max-h-48"
               />
             </div>
-            {/* ATS-safe toggle — résumé-only + only meaningful for two-column
-                templates (copies StepTemplate's switch markup; reuses the
-                aiGenerate.atsMode keys). */}
-            {activeOut === 'resume' && isTwoColumnTemplate(templateId) && (
+            {/* ATS-safe toggle — résumé-only + only meaningful for design-tier
+                templates (two-column OR photo, incl. Lebenslauf; copies
+                StepTemplate's switch markup; reuses the aiGenerate.atsMode keys). */}
+            {activeOut === 'resume' && isDesignTier(templateId) && (
               <div
                 title={t('aiGenerate.atsModeHint')}
                 className={cn(

--- a/apps/desktop/src/renderer/features/resume-builder/components/ResumeBuilderPage/ResumeBuilderPage.test.tsx
+++ b/apps/desktop/src/renderer/features/resume-builder/components/ResumeBuilderPage/ResumeBuilderPage.test.tsx
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Button } from '@ajh/ui';
+
+import { ResumeBuilderPage } from './index';
+
+// ── Module stubs ──────────────────────────────────────────────────────────────
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/components/ui/ModelSelector', () => ({
+  ModelSelector: () => <div data-testid="model-selector-stub" />,
+}));
+
+vi.mock('@/components/ui/AiSetupHint', () => ({
+  AiSetupHint: () => null,
+}));
+
+// BuilderWizard stub: exposes just enough to drive the reset-gate behavior
+// (mirrors the GenerateWizard test's StepTemplate stub pattern) without
+// mounting the real react-hook-form wizard.
+vi.mock('../BuilderWizard', () => ({
+  BuilderWizard: ({ onTemplateChange }: { onTemplateChange: (id: string) => void }) => (
+    <div>
+      <Button onClick={() => onTemplateChange('atelier')}>select-atelier</Button>
+      <Button onClick={() => onTemplateChange('lebenslauf')}>select-lebenslauf</Button>
+      <Button onClick={() => onTemplateChange('classic')}>select-classic</Button>
+    </div>
+  ),
+}));
+
+const mockSetResumeBuilder = vi.fn();
+
+vi.mock('../../hooks/useResumeBuilder', () => ({
+  useResumeBuilder: () => ({
+    language: 'en',
+    locale: 'en',
+    templateId: 'classic',
+    atsMode: false,
+    stage: 'interview',
+    output: '',
+    setResumeBuilder: mockSetResumeBuilder,
+    meta: {},
+    canUseAI: true,
+    aiReason: '',
+    isComplete: false,
+    isGenerating: false,
+    streamBuffer: '',
+    thinkingBuffer: '',
+    modelLoading: false,
+    tokenCount: 0,
+    tokenStartMs: null,
+    error: null,
+    synthesize: vi.fn(),
+    tailorToJob: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+describe('ResumeBuilderPage — template reset gate', () => {
+  beforeEach(() => {
+    mockSetResumeBuilder.mockClear();
+  });
+
+  it('resets atsMode when an ATS-tier template is selected', async () => {
+    const user = userEvent.setup();
+    render(<ResumeBuilderPage />);
+    await user.click(screen.getByRole('button', { name: 'select-classic' }));
+    expect(mockSetResumeBuilder).toHaveBeenCalledWith({ templateId: 'classic', atsMode: false });
+  });
+
+  it('does NOT reset atsMode when selecting Lebenslauf (design tier)', async () => {
+    const user = userEvent.setup();
+    render(<ResumeBuilderPage />);
+    await user.click(screen.getByRole('button', { name: 'select-lebenslauf' }));
+    expect(mockSetResumeBuilder).toHaveBeenCalledWith({ templateId: 'lebenslauf' });
+    expect(mockSetResumeBuilder).not.toHaveBeenCalledWith(
+      expect.objectContaining({ atsMode: false })
+    );
+  });
+
+  it('does NOT reset atsMode when selecting a two-column template (Atelier)', async () => {
+    const user = userEvent.setup();
+    render(<ResumeBuilderPage />);
+    await user.click(screen.getByRole('button', { name: 'select-atelier' }));
+    expect(mockSetResumeBuilder).toHaveBeenCalledWith({ templateId: 'atelier' });
+  });
+});

--- a/apps/desktop/src/renderer/features/resume-builder/components/ResumeBuilderPage/index.tsx
+++ b/apps/desktop/src/renderer/features/resume-builder/components/ResumeBuilderPage/index.tsx
@@ -15,7 +15,7 @@ import {
   exportDOCX,
   exportPDF,
   exportTXT,
-  isTwoColumnTemplate,
+  isDesignTier,
   type TemplateId,
 } from '@/lib/generate';
 import { COPY_FEEDBACK_LONG_MS } from '@/lib/timings';
@@ -54,9 +54,7 @@ export function ResumeBuilderPage() {
 
   const onLanguageChange = (lng: string) => setResumeBuilder({ language: lng, locale: lng });
   const onTemplateChange = (id: TemplateId) =>
-    setResumeBuilder(
-      isTwoColumnTemplate(id) ? { templateId: id } : { templateId: id, atsMode: false }
-    );
+    setResumeBuilder(isDesignTier(id) ? { templateId: id } : { templateId: id, atsMode: false });
   const onAtsModeChange = (enabled: boolean) => setResumeBuilder({ atsMode: enabled });
 
   const copyOutput = async () => {

--- a/apps/desktop/src/renderer/lib/generate/index.ts
+++ b/apps/desktop/src/renderer/lib/generate/index.ts
@@ -29,7 +29,13 @@ export {
   type SupportedLocale,
   VALID_LOCALES,
 } from './locales';
-export { isTwoColumnTemplate, TEMPLATE_IDS, type TemplateId, TEMPLATES } from './templates';
+export {
+  isDesignTier,
+  isTwoColumnTemplate,
+  TEMPLATE_IDS,
+  type TemplateId,
+  TEMPLATES,
+} from './templates';
 export type {
   InterviewAnswers,
   InterviewEducation,

--- a/apps/desktop/src/renderer/lib/generate/templates/templates.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/templates/templates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { TEMPLATES } from './templates';
+import { isDesignTier, TEMPLATES } from './templates';
 
 describe('TEMPLATES', () => {
   const ids = Object.keys(TEMPLATES);
@@ -42,5 +42,38 @@ describe('TEMPLATES', () => {
       expect(t.bodyPt).toBeGreaterThan(0);
       expect(['ruled-bottom', 'underline', 'bold-only']).toContain(t.sectionStyle);
     }
+  });
+
+  // ── tier metadata (mirrors the Rust `TemplateTier`) ─────────────────────────
+
+  it('assigns every template an ats or design tier', () => {
+    for (const t of Object.values(TEMPLATES)) {
+      expect(['ats', 'design']).toContain(t.tier);
+    }
+  });
+
+  it('mirrors the Rust TemplateTier split (ats: single-column · design: photo/two-column)', () => {
+    const idsByTier = (tier: 'ats' | 'design') =>
+      Object.values(TEMPLATES)
+        .filter((t) => t.tier === tier)
+        .map((t) => t.id)
+        .sort();
+    expect(idsByTier('ats')).toEqual([
+      'academic',
+      'classic',
+      'meridian',
+      'swiss-minimal',
+      'throughline',
+    ]);
+    expect(idsByTier('design')).toEqual(['atelier', 'lebenslauf', 'portrait']);
+  });
+
+  it('isDesignTier is true exactly for design-tier templates', () => {
+    for (const t of Object.values(TEMPLATES)) {
+      expect(isDesignTier(t.id)).toBe(t.tier === 'design');
+    }
+    // Lebenslauf is design tier despite being single-column — the toggle-gate fix.
+    expect(isDesignTier('lebenslauf')).toBe(true);
+    expect(isDesignTier('classic')).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/lib/generate/templates/templates.ts
+++ b/apps/desktop/src/renderer/lib/generate/templates/templates.ts
@@ -19,6 +19,12 @@ export type TemplateId =
 interface DocTemplate {
   id: TemplateId;
   name: string;
+  /**
+   * ATS-safe vs. design tier — mirrors the Rust `TemplateTier`. Drives the
+   * gallery grouping (ATS-Safe / Design sections + badge) and which templates
+   * surface the ATS-mode toggle (design layouts drop the photo / linearize).
+   */
+  tier: 'ats' | 'design';
   // Colors (hex, no #)
   nameColor: string;
   sectionColor: string;
@@ -46,6 +52,7 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
   classic: {
     id: 'classic',
     name: 'ATS Classic',
+    tier: 'ats',
     nameColor: '111111',
     sectionColor: '111111',
     accentColor: '222222',
@@ -68,6 +75,7 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
   'swiss-minimal': {
     id: 'swiss-minimal',
     name: 'Swiss Minimal',
+    tier: 'ats',
     nameColor: '141414',
     sectionColor: '141414',
     accentColor: 'E63946',
@@ -90,6 +98,7 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
   academic: {
     id: 'academic',
     name: 'Academic',
+    tier: 'ats',
     nameColor: '141E1E',
     sectionColor: '1B4332',
     accentColor: '1B4332',
@@ -112,6 +121,7 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
   atelier: {
     id: 'atelier',
     name: 'Atelier',
+    tier: 'design',
     nameColor: '16143A',
     sectionColor: '4A4580',
     accentColor: '4A4580',
@@ -134,6 +144,7 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
   meridian: {
     id: 'meridian',
     name: 'Meridian',
+    tier: 'ats',
     nameColor: '2A2A2A',
     sectionColor: 'A0522D',
     accentColor: 'A0522D',
@@ -156,6 +167,7 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
   throughline: {
     id: 'throughline',
     name: 'Throughline',
+    tier: 'ats',
     nameColor: '141E1E',
     sectionColor: '1A5C52',
     accentColor: '1A5C52',
@@ -178,6 +190,7 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
   portrait: {
     id: 'portrait',
     name: 'Portrait',
+    tier: 'design',
     nameColor: '16303A',
     sectionColor: '2A6478',
     accentColor: '2A6478',
@@ -200,6 +213,7 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
   lebenslauf: {
     id: 'lebenslauf',
     name: 'Lebenslauf (DACH)',
+    tier: 'design',
     nameColor: '1E1E28',
     sectionColor: '3D4F6B',
     accentColor: '3D4F6B',
@@ -231,4 +245,15 @@ const TWO_COLUMN_TEMPLATE_IDS = new Set<TemplateId>(['atelier', 'portrait']);
 
 export function isTwoColumnTemplate(id: TemplateId): boolean {
   return TWO_COLUMN_TEMPLATE_IDS.has(id);
+}
+
+/**
+ * Design-tier templates (photo / two-column / visually rich) — mirrors the Rust
+ * `TemplateTier::Design`. Drives the gallery's Design section and the ATS-mode
+ * toggle gate: design layouts drop the photo and/or linearize under ATS mode,
+ * so the toggle is surfaced for all of them (incl. single-column-with-photo
+ * templates like Lebenslauf that `isTwoColumnTemplate` deliberately excludes).
+ */
+export function isDesignTier(id: TemplateId): boolean {
+  return TEMPLATES[id].tier === 'design';
 }

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1219,6 +1219,14 @@
     "resumePlaceholder": "Lebenslauftext hier einfügen…",
     "atsMode": "ATS-sicherer Modus",
     "atsModeHint": "Empfohlen für ATS-Bewerbungen — linearisiert das zweispaltige Layout",
+    "atsModeHintTwoColumn": "Empfohlen für ATS-Bewerbungen — reduziert das Layout auf eine Spalte und entfernt ein etwaiges Foto für maximale Parserkompatibilität",
+    "atsModeHintPhoto": "Empfohlen für ATS-Bewerbungen — entfernt das Foto für ein lineares, parserfreundliches Layout",
+    "tier": {
+      "atsSafe": "ATS-sicher",
+      "design": "Design",
+      "atsBadge": "ATS",
+      "designBadge": "Design"
+    },
     "documentAccent": "Dokumentakzent",
     "documentAccentDefault": "Vorlagenstandard",
     "documentAccentCustom": "Eigene",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1215,6 +1215,14 @@
     "resumePlaceholder": "Paste your resume text here…",
     "atsMode": "ATS-safe mode",
     "atsModeHint": "Recommended for ATS submissions — linearizes the two-column layout",
+    "atsModeHintTwoColumn": "Recommended for ATS submissions — collapses the layout to a single column and removes any photo for maximum parser compatibility",
+    "atsModeHintPhoto": "Recommended for ATS submissions — removes the photo for a linear, parser-safe layout",
+    "tier": {
+      "atsSafe": "ATS-Safe",
+      "design": "Design",
+      "atsBadge": "ATS",
+      "designBadge": "Design"
+    },
     "documentAccent": "Document accent",
     "documentAccentDefault": "Template default",
     "documentAccentCustom": "Custom",


### PR DESCRIPTION
## Summary

PR 2 of the template-overhaul series (after #590): formal **template tier** metadata + honest gallery, and the **Lebenslauf ATS-toggle bug fix**.

- **`TemplateTier { Ats, Design }`** on the Rust template registry (render-neutral metadata; ats: classic, swiss minimal, academic, meridian, throughline · design: atelier, portrait, lebenslauf), mirrored in the frontend registry with drift-pinning tests on both sides.
- **Gallery grouped** into "ATS-Safe" / "Design" sections with tier badges (semantic headings, token classes, en+de).
- **Bug fix:** the ATS toggle was gated on `isTwoColumnTemplate`, so **Lebenslauf (single-column + photo) never got the toggle and its photo always exported**. The gate and all four reset call sites (StepTemplate, GenerateWizard, TailorFlow output, resume builder) now use design-tier semantics — the backend already honored `ats_mode` for Lebenslauf (`#if not is-ats and has-photo`); a new Rust render test proves the photo drops.
- **Hint copy** is tier-aware and inclusive: two-column templates state they collapse *and* remove any photo (correct for Portrait today, and for the photo two-column templates arriving in PR4).

## Review status (pre-PR agent gates)

`frontend-reviewer` — passed; both MEDIUMs fixed in-diff (fourth reset gate in the resume builder; inclusive two-column hint copy) with new regression tests. LOW "recommender never auto-suggests ATS for lebenslauf" kept deliberately (product heuristic, documented).

## Tests

New: tier pins (Rust + TS), lebenslauf ATS-drops-photo (real SVG render assert), toggle presence/absence parametrized over all 8 templates, reset-vs-preserve semantics across all four surfaces, ResumeBuilderPage suite (new file). Full frontend suite: 3,261 tests green; whole-graph typecheck + lint:strict clean.

⚠️ Local `cargo test` cannot execute on the dev host — Rust tests compile clean under `cargo check --all-targets` + clippy; **CI is authoritative for Rust test execution.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
