### PR TITLE
feat: cadence and regent single-column templates (templates pr 3/6)

### DIFF
--- a/apps/desktop/src-tauri/src/export/pdf/test.rs
+++ b/apps/desktop/src-tauri/src/export/pdf/test.rs
@@ -559,6 +559,8 @@ LANGUAGES
         TemplateId::Throughline,
         TemplateId::Portrait,
         TemplateId::Lebenslauf,
+        TemplateId::Cadence,
+        TemplateId::Regent,
     ];
 
     let out = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/sample_pdfs");

--- a/apps/desktop/src-tauri/src/export/templates/mod.rs
+++ b/apps/desktop/src-tauri/src/export/templates/mod.rs
@@ -120,10 +120,27 @@ pub struct Template {
     // New style options
     pub fonts: TemplateFonts,
     pub job_title_italic: bool,
-    /// When true: uppercase section header text + render at 0.85 × section_pt.
+    /// When true: wrap section heading text in Typst `smallcaps(…)` (small-caps
+    /// glyph variant; the PDF text layer keeps its original case — extraction-
+    /// safe) and render at 0.85 × section_pt. Read into `JsonStyle.section_small_caps`;
+    /// see `single_column.typ`'s `render-section` for the actual wrap.
     pub section_small_caps: bool,
-    /// Section rule thickness in pt (0.0 = no rule).
+    /// Section-rule stroke thickness in pt, read by the `single_column.typ`
+    /// ruled-bottom branch as `stroke: (rule_thickness * 1pt) + c-rule`.
+    /// `single_column.typ` falls back to the house `0.5pt` when this is `0.0` or
+    /// the style is absent — every pre-PR3 ruled template ships `0.5`, so this is
+    /// byte-identical for them; only Cadence sets a real `0.75` override.
     pub rule_thickness: f32,
+    /// Extra letter-spacing (tracking) applied to section headings, in em units.
+    /// `0.0` (the default for every pre-PR3 template) leaves headings untracked —
+    /// `single_column.typ` only emits `text(tracking: …)` when this is non-zero, so
+    /// existing output is byte-identical. Read into `JsonStyle.heading_tracking`.
+    pub heading_tracking: f32,
+    /// When true, wrap hyperlinked runs in `underline(…)` in the single-column
+    /// renderer. `false` (the default for every pre-PR3 template) leaves links
+    /// un-underlined, byte-identical to prior output. Read into
+    /// `JsonStyle.link_underline`.
+    pub link_underline: bool,
 
     // Two-column layout (None = single column)
     pub two_column: Option<TwoColumnConfig>,
@@ -159,6 +176,8 @@ impl Template {
             TemplateId::Throughline => Self::throughline(),
             TemplateId::Portrait => Self::portrait(),
             TemplateId::Lebenslauf => Self::lebenslauf(),
+            TemplateId::Cadence => Self::cadence(),
+            TemplateId::Regent => Self::regent(),
         }
     }
 
@@ -179,7 +198,7 @@ impl Template {
         self
     }
 
-    // ─── Eight live templates ─────────────────────────────────────────────────
+    // ─── Ten live templates ───────────────────────────────────────────────────
 
     /// ATS Classic — maximum compatibility, no color, safe for all ATS parsers.
     ///
@@ -213,6 +232,8 @@ impl Template {
             job_title_italic: true,
             section_small_caps: false,
             rule_thickness: 0.5,
+            heading_tracking: 0.0,
+            link_underline: false,
             two_column: None,
             cover_letter: CoverLetterLayout::default(),
         }
@@ -248,6 +269,8 @@ impl Template {
             job_title_italic: false,
             section_small_caps: false,
             rule_thickness: 0.0,
+            heading_tracking: 0.0,
+            link_underline: false,
             two_column: None,
             cover_letter: CoverLetterLayout {
                 paragraph_indent: ParagraphIndent::BlockNoIndent,
@@ -286,6 +309,8 @@ impl Template {
             job_title_italic: true,
             section_small_caps: false,
             rule_thickness: 0.5,
+            heading_tracking: 0.0,
+            link_underline: false,
             two_column: None,
             cover_letter: CoverLetterLayout {
                 paragraph_indent: ParagraphIndent::FirstLine,
@@ -334,6 +359,8 @@ impl Template {
             job_title_italic: true,
             section_small_caps: false,
             rule_thickness: 0.5,
+            heading_tracking: 0.0,
+            link_underline: false,
             two_column: Some(TwoColumnConfig {
                 sidebar_width_ratio: 0.30,
                 // Very light warm-grey tint that pairs with the slate-indigo accent.
@@ -386,6 +413,8 @@ impl Template {
             job_title_italic: true,
             section_small_caps: false,
             rule_thickness: 0.5,
+            heading_tracking: 0.0,
+            link_underline: false,
             two_column: None,
             cover_letter: CoverLetterLayout {
                 paragraph_indent: ParagraphIndent::BlockNoIndent,
@@ -431,6 +460,8 @@ impl Template {
             job_title_italic: true,
             section_small_caps: false,
             rule_thickness: 0.5,
+            heading_tracking: 0.0,
+            link_underline: false,
             two_column: None,
             cover_letter: CoverLetterLayout {
                 paragraph_indent: ParagraphIndent::BlockNoIndent,
@@ -478,6 +509,8 @@ impl Template {
             job_title_italic: true,
             section_small_caps: false,
             rule_thickness: 0.5,
+            heading_tracking: 0.0,
+            link_underline: false,
             // Two-column: sidebar holds contact, skills, education, languages,
             // certifications — same set as Atelier.
             two_column: Some(TwoColumnConfig {
@@ -529,12 +562,109 @@ impl Template {
             job_title_italic: false, // DIN style: no italic job titles
             section_small_caps: false,
             rule_thickness: 0.5,
+            heading_tracking: 0.0,
+            link_underline: false,
             // Single-column — DIN tabular layout manages its own columns.
             two_column: None,
             // Cover letter mirrors modern layout (appropriate for DIN letters).
             cover_letter: CoverLetterLayout {
                 paragraph_indent: ParagraphIndent::BlockNoIndent,
                 paragraph_spacing_pt: 8.0,
+            },
+        }
+    }
+
+    // ─── PR3 single-column ATS templates ──────────────────────────────────────
+
+    /// Cadence — Claude-PDF-style ATS single-column.
+    ///
+    /// Design: Inter throughout, large 28pt name, blue-grey accent (#4A6785),
+    /// letter-spaced (`heading_tracking 0.08`) all-caps ruled section headings,
+    /// underlined hyperlinks (`link_underline true`). Renders through the
+    /// parametric `single_column.typ` — no bespoke `.typ`. Tier: ATS.
+    pub(super) fn cadence() -> Self {
+        Self {
+            id: TemplateId::Cadence,
+            name: "Cadence",
+            tier: TemplateTier::Ats,
+            // Near-black ink with a restrained blue-grey accent.
+            name_color: (26, 26, 26),
+            section_color: (26, 26, 26),
+            accent_color: (74, 103, 133), // #4A6785 blue-grey
+            body_color: (43, 43, 43),
+            date_color: (107, 107, 107),
+            emphasis_color: (74, 103, 133),
+            rule_color: (74, 103, 133),
+            name_pt: 28.0,
+            section_pt: 10.5,
+            body_pt: 10.0,
+            margin_in: 0.8,
+            line_spacing: 1.15,
+            section_spacing_before: 12.0,
+            name_centered: false,
+            section_all_caps: true,
+            section_style: SectionStyle::RuledBottom,
+            fonts: TemplateFonts {
+                name_family: FontFamily::Inter,
+                heading_family: FontFamily::Inter,
+                body_family: FontFamily::Inter,
+            },
+            job_title_italic: false,
+            section_small_caps: false,
+            rule_thickness: 0.75,
+            heading_tracking: 0.08,
+            link_underline: true,
+            two_column: None,
+            cover_letter: CoverLetterLayout {
+                paragraph_indent: ParagraphIndent::BlockNoIndent,
+                paragraph_spacing_pt: 8.0,
+            },
+        }
+    }
+
+    /// Regent — executive serif ATS single-column.
+    ///
+    /// Design: Source Serif 4 throughout, 26pt name, burgundy (#6E1E2B) small-caps
+    /// section headings with a rose rule (#C9A9AE), lightly tracked
+    /// (`heading_tracking 0.04`), italic job titles, first-line-indent cover
+    /// letter (executive serif pairing, like Academic). Renders through the
+    /// parametric `single_column.typ` — no bespoke `.typ`. Tier: ATS.
+    pub(super) fn regent() -> Self {
+        Self {
+            id: TemplateId::Regent,
+            name: "Regent",
+            tier: TemplateTier::Ats,
+            // Charcoal ink, burgundy accent, muted rose rule.
+            name_color: (42, 42, 46),
+            section_color: (110, 30, 43), // #6E1E2B burgundy
+            accent_color: (110, 30, 43),
+            body_color: (38, 38, 42),
+            date_color: (122, 106, 110),
+            emphasis_color: (110, 30, 43),
+            rule_color: (201, 169, 174), // #C9A9AE rose
+            name_pt: 26.0,
+            section_pt: 11.0,
+            body_pt: 10.5,
+            margin_in: 0.9,
+            line_spacing: 1.2,
+            section_spacing_before: 14.0,
+            name_centered: false,
+            section_all_caps: false,
+            section_style: SectionStyle::RuledBottom,
+            fonts: TemplateFonts {
+                name_family: FontFamily::SourceSerif4,
+                heading_family: FontFamily::SourceSerif4,
+                body_family: FontFamily::SourceSerif4,
+            },
+            job_title_italic: true,
+            section_small_caps: true,
+            rule_thickness: 0.5,
+            heading_tracking: 0.04,
+            link_underline: false,
+            two_column: None,
+            cover_letter: CoverLetterLayout {
+                paragraph_indent: ParagraphIndent::FirstLine,
+                paragraph_spacing_pt: 0.0,
             },
         }
     }

--- a/apps/desktop/src-tauri/src/export/templates/mod.rs
+++ b/apps/desktop/src-tauri/src/export/templates/mod.rs
@@ -130,6 +130,9 @@ pub struct Template {
     /// `single_column.typ` falls back to the house `0.5pt` when this is `0.0` or
     /// the style is absent — every pre-PR3 ruled template ships `0.5`, so this is
     /// byte-identical for them; only Cadence sets a real `0.75` override.
+    /// NOTE: `0.0` means "default thickness", NOT "no rule" — rule *presence*
+    /// is owned by `section_style` (`BoldOnly` = no rule). Don't set `0.0` on a
+    /// `RuledBottom` template expecting suppression.
     pub rule_thickness: f32,
     /// Extra letter-spacing (tracking) applied to section headings, in em units.
     /// `0.0` (the default for every pre-PR3 template) leaves headings untracked —

--- a/apps/desktop/src-tauri/src/export/templates/test.rs
+++ b/apps/desktop/src-tauri/src/export/templates/test.rs
@@ -135,6 +135,8 @@ fn template_tiers_are_pinned() {
         (TemplateId::Atelier, Design),
         (TemplateId::Portrait, Design),
         (TemplateId::Lebenslauf, Design),
+        (TemplateId::Cadence, Ats),
+        (TemplateId::Regent, Ats),
     ];
     for (id, tier) in expected {
         assert_eq!(
@@ -143,4 +145,85 @@ fn template_tiers_are_pinned() {
             "template {id:?} has the wrong tier"
         );
     }
+}
+
+// ─── PR3: heading_tracking / link_underline knobs ──────────────────────────────
+
+/// Every pre-PR3 template must keep the two new knobs at their neutral default
+/// (0.0 / false) — `single_column.typ` only emits `tracking:`/`underline(…)` when
+/// non-zero/true, so this is what keeps existing output byte-identical.
+#[test]
+fn heading_tracking_and_link_underline_default_to_neutral_for_pre_pr3_templates() {
+    for id in [
+        TemplateId::Classic,
+        TemplateId::SwissMinimal,
+        TemplateId::Academic,
+        TemplateId::Atelier,
+        TemplateId::Meridian,
+        TemplateId::Throughline,
+        TemplateId::Portrait,
+        TemplateId::Lebenslauf,
+    ] {
+        let t = Template::get(id);
+        assert_eq!(
+            t.heading_tracking, 0.0,
+            "{id:?}: heading_tracking must default to 0.0"
+        );
+        assert!(
+            !t.link_underline,
+            "{id:?}: link_underline must default to false"
+        );
+    }
+}
+
+// ─── Cadence / Regent spec pins ─────────────────────────────────────────────────
+
+#[test]
+fn cadence_matches_spec() {
+    let t = Template::get(TemplateId::Cadence);
+    assert_eq!(t.tier, TemplateTier::Ats);
+    assert_eq!(t.name_pt, 28.0);
+    assert_eq!(t.section_pt, 10.5);
+    assert_eq!(t.body_pt, 10.0);
+    assert_eq!(t.margin_in, 0.8);
+    assert_eq!(t.line_spacing, 1.15);
+    assert_eq!(t.section_spacing_before, 12.0);
+    assert_eq!(t.accent_color, (74, 103, 133));
+    assert!(t.section_all_caps);
+    assert_eq!(t.section_style, SectionStyle::RuledBottom);
+    assert_eq!(t.rule_thickness, 0.75);
+    assert!(!t.job_title_italic);
+    assert!(!t.section_small_caps);
+    assert_eq!(t.heading_tracking, 0.08);
+    assert!(t.link_underline);
+    assert!(t.two_column.is_none());
+    assert_eq!(
+        t.cover_letter.paragraph_indent,
+        ParagraphIndent::BlockNoIndent
+    );
+    assert_eq!(t.cover_letter.paragraph_spacing_pt, 8.0);
+}
+
+#[test]
+fn regent_matches_spec() {
+    let t = Template::get(TemplateId::Regent);
+    assert_eq!(t.tier, TemplateTier::Ats);
+    assert_eq!(t.name_pt, 26.0);
+    assert_eq!(t.section_pt, 11.0);
+    assert_eq!(t.body_pt, 10.5);
+    assert_eq!(t.margin_in, 0.9);
+    assert_eq!(t.line_spacing, 1.2);
+    assert_eq!(t.section_spacing_before, 14.0);
+    assert_eq!(t.accent_color, (110, 30, 43));
+    assert_eq!(t.rule_color, (201, 169, 174));
+    assert!(!t.section_all_caps);
+    assert!(t.section_small_caps);
+    assert_eq!(t.section_style, SectionStyle::RuledBottom);
+    assert_eq!(t.rule_thickness, 0.5);
+    assert!(t.job_title_italic);
+    assert_eq!(t.heading_tracking, 0.04);
+    assert!(!t.link_underline);
+    assert!(t.two_column.is_none());
+    assert_eq!(t.cover_letter.paragraph_indent, ParagraphIndent::FirstLine);
+    assert_eq!(t.cover_letter.paragraph_spacing_pt, 0.0);
 }

--- a/apps/desktop/src-tauri/src/export/types.rs
+++ b/apps/desktop/src-tauri/src/export/types.rs
@@ -35,6 +35,14 @@ pub enum TemplateId {
     /// Phase 3b-i: DACH DIN-style tabular CV — photo top-right, formal A4,
     /// left-label / right-value rows, restrained accent.
     Lebenslauf,
+    /// PR3: Cadence — Claude-PDF-style ATS single-column (Inter, blue-grey accent,
+    /// letter-spaced all-caps ruled headings, underlined links). Renders through
+    /// the parametric `single_column.typ`.
+    Cadence,
+    /// PR3: Regent — executive serif ATS single-column (Source Serif 4, burgundy
+    /// small-caps headings, rose rule, first-line-indent letter). Renders through
+    /// the parametric `single_column.typ`.
+    Regent,
 }
 
 impl<'de> serde::Deserialize<'de> for TemplateId {
@@ -52,6 +60,8 @@ impl<'de> serde::Deserialize<'de> for TemplateId {
             "throughline" => TemplateId::Throughline,
             "portrait" => TemplateId::Portrait,
             "lebenslauf" => TemplateId::Lebenslauf,
+            "cadence" => TemplateId::Cadence,
+            "regent" => TemplateId::Regent,
             // Any unknown / removed id (e.g. "two-column", "refined-executive",
             // "executive", "editorial-serif", "mono-technical", "bogus") falls
             // back to Classic so a stale frontend never breaks export.
@@ -258,6 +268,8 @@ mod tests {
             (TemplateId::Throughline, "\"throughline\""),
             (TemplateId::Portrait, "\"portrait\""),
             (TemplateId::Lebenslauf, "\"lebenslauf\""),
+            (TemplateId::Cadence, "\"cadence\""),
+            (TemplateId::Regent, "\"regent\""),
         ];
         for (id, expected_json) in cases {
             let serialized = serde_json::to_string(&id).expect("serialize");

--- a/apps/desktop/src-tauri/src/export/typst_engine/engine.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/engine.rs
@@ -49,7 +49,7 @@ const SCALE_TYP: &str = include_str!("templates/_scale.typ");
 const ATELIER_TYP: &str = include_str!("templates/atelier.typ");
 
 /// Parametric single-column template driven by `data.style`.
-/// Serves Classic, SwissMinimal, and Academic.
+/// Serves Classic, SwissMinimal, Academic, Cadence, and Regent.
 const SINGLE_COLUMN_TYP: &str = include_str!("templates/single_column.typ");
 
 /// Meridian — header-band premium single-column template (Phase 3a).
@@ -92,7 +92,7 @@ pub enum TypstTemplate {
     /// Phase 1b — two-column premium sidebar template.
     Atelier,
     /// Phase 2 — parametric single-column driven by `data.style`.
-    /// Serves Classic, SwissMinimal, and Academic.
+    /// Serves Classic, SwissMinimal, Academic, Cadence, and Regent.
     SingleColumn,
     /// Phase 3a — header-band premium single-column template.
     Meridian,
@@ -130,16 +130,20 @@ impl TypstTemplate {
     }
 
     /// Derive the Typst template from an existing [`Template`] configuration.
-    /// All eight live template IDs are handled exhaustively; no fallback needed.
+    /// All ten live template IDs are handled exhaustively; no fallback needed.
     pub fn from_template(t: &Template) -> Self {
         match t.id {
             TemplateId::Atelier => TypstTemplate::Atelier,
-            // Classic, SwissMinimal, Academic → parametric SingleColumn renderer.
-            // (Classic migrated off its bespoke `classic.typ` onto the shared
-            // parametric template, styled from its registry palette via data.style.)
-            TemplateId::Classic | TemplateId::SwissMinimal | TemplateId::Academic => {
-                TypstTemplate::SingleColumn
-            }
+            // Classic, SwissMinimal, Academic, Cadence, Regent → parametric
+            // SingleColumn renderer. (Classic migrated off its bespoke
+            // `classic.typ` onto the shared parametric template; Cadence and Regent
+            // are pure-config single-column variants — no bespoke `.typ`. All are
+            // styled from their registry palette via data.style.)
+            TemplateId::Classic
+            | TemplateId::SwissMinimal
+            | TemplateId::Academic
+            | TemplateId::Cadence
+            | TemplateId::Regent => TypstTemplate::SingleColumn,
             // Phase 3a: two premium single-column templates.
             TemplateId::Meridian => TypstTemplate::Meridian,
             TemplateId::Throughline => TypstTemplate::Throughline,

--- a/apps/desktop/src-tauri/src/export/typst_engine/render.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/render.rs
@@ -177,6 +177,18 @@ pub(super) struct JsonStyle {
     /// When `false` (the default), education entry titles are rendered at normal weight
     /// to de-emphasize them.  Only the academic template sets this to `true`.
     pub emphasize_education: bool,
+    /// Extra section-heading letter-spacing (tracking) in em units. `0.0` (every
+    /// pre-PR3 template) means no tracking; `single_column.typ` only emits
+    /// `text(tracking: …)` when non-zero, so defaults are byte-identical.
+    pub heading_tracking: f32,
+    /// When `true`, hyperlinked runs are wrapped in `underline(…)`. `false` (every
+    /// pre-PR3 template) leaves links un-underlined, byte-identical to prior output.
+    pub link_underline: bool,
+    /// Section-rule stroke thickness in pt. `single_column.typ` falls back to the
+    /// house `0.5pt` when this is absent or `0.0`, so every pre-PR3 ruled template
+    /// (all of which are `0.5`) renders byte-identical; only Cadence (`0.75`) sets
+    /// a non-default value.
+    pub rule_thickness: f32,
 }
 
 #[derive(Serialize)]
@@ -253,6 +265,9 @@ pub(crate) fn style_from_template(t: &Template) -> JsonStyle {
         section_pt: t.section_pt,
         body_pt: t.body_pt,
         emphasize_education,
+        heading_tracking: t.heading_tracking,
+        link_underline: t.link_underline,
+        rule_thickness: t.rule_thickness,
     }
 }
 

--- a/apps/desktop/src-tauri/src/export/typst_engine/templates/single_column.typ
+++ b/apps/desktop/src-tauri/src/export/typst_engine/templates/single_column.typ
@@ -12,8 +12,14 @@
 //   data.style.section_style — "ruled-bottom" | "underline" | "bold-only"
 //   data.style.name_centered — bool: centre the name block
 //   data.style.section_all_caps — bool: uppercase section headings
-//   data.style.section_small_caps — bool (advisory; Typst renders upper+small when true)
+//   data.style.section_small_caps — bool: wrap heading text in Typst smallcaps(…)
+//             (small-caps glyph variant; the text layer keeps its original case)
+//             at 0.85 × section_pt
 //   data.style.job_title_italic — bool: italic job title under entry
+//   data.style.heading_tracking — number: extra heading letter-spacing in em (0 = none)
+//   data.style.link_underline — bool: underline hyperlinked runs when true
+//   data.style.rule_thickness — number: ruled-bottom stroke thickness in pt
+//             (0 or absent falls back to the house 0.5pt)
 //   data.style.name_pt / section_pt / body_pt — font sizes in pt
 //   data.opts.page_width_mm / page_height_mm — page geometry
 //   data.opts.accent — optional override (#RRGGBB or "")
@@ -61,6 +67,17 @@
 #let small-caps-flag = if "section_small_caps" in st { st.section_small_caps } else { false }
 #let title-italic    = if "job_title_italic" in st { st.job_title_italic } else { true }
 
+// PR3 knobs. Defaults are neutral: heading-tracking 0 emits no `tracking:` arg
+// and link-underline false emits no `underline(…)` wrapper, so pre-PR3 templates
+// render byte-identically.
+#let heading-tracking = if "heading_tracking" in st { st.heading_tracking } else { 0.0 }
+#let link-underline   = if "link_underline"   in st { st.link_underline   } else { false }
+
+// Rule-stroke thickness: fall back to the house 0.5pt when absent OR 0.0 (every
+// pre-PR3 ruled template already ships 0.5, so this is byte-identical for them;
+// only Cadence sets a real 0.75 override).
+#let rule-thickness = if "rule_thickness" in st and st.rule_thickness != 0.0 { st.rule_thickness } else { 0.5 }
+
 #let name-pt    = if "name_pt"    in st { st.name_pt    * 1pt } else { 20pt }
 #let section-pt = if "section_pt" in st { st.section_pt * 1pt } else { 11pt }
 #let body-pt    = if "body_pt"    in st { st.body_pt    * 1pt } else { 10.5pt }
@@ -101,7 +118,8 @@
       r.text
     }
     if "link" in r and r.link != none {
-      link(r.link, text(fill: c-accent, t))
+      let styled = text(fill: c-accent, t)
+      link(r.link, if link-underline { underline(styled) } else { styled })
     } else {
       t
     }
@@ -202,46 +220,57 @@
 
 // ── Section renderer ──────────────────────────────────────────────────────────
 
+// Render a section heading. `tracking:` is only passed when heading-tracking is
+// non-zero, so templates that leave it at the 0 default (every pre-PR3 template)
+// produce byte-identical markup to before the knob was added.
+#let heading-run(content, size) = {
+  if heading-tracking != 0.0 {
+    text(
+      size: size,
+      weight: "bold",
+      fill: c-section,
+      font: (font-heading, "Carlito", "Inter"),
+      tracking: heading-tracking * 1em,
+      content,
+    )
+  } else {
+    text(
+      size: size,
+      weight: "bold",
+      fill: c-section,
+      font: (font-heading, "Carlito", "Inter"),
+      content,
+    )
+  }
+}
+
 #let render-section(section) = {
-  let heading-text = if all-caps { upper(section.heading) } else { section.heading }
+  let heading-text = {
+    let base = if all-caps { upper(section.heading) } else { section.heading }
+    // smallcaps(…) applies the small-caps glyph variant while keeping the
+    // underlying text-layer characters in their original case (extraction-safe).
+    if small-caps-flag { smallcaps(base) } else { base }
+  }
   let heading-size = if small-caps-flag { section-pt * 0.85 } else { section-pt }
   let bold-title = entry-bold-for-section(section)
 
   if section-style == "ruled-bottom" {
     block(above: sp-section-above, below: sp-rule-below, {
-      text(
-        size: heading-size,
-        weight: "bold",
-        fill: c-section,
-        font: (font-heading, "Carlito", "Inter"),
-        heading-text,
-      )
+      heading-run(heading-text, heading-size)
     })
-    line(length: 100%, stroke: 0.5pt + c-rule)
+    line(length: 100%, stroke: (rule-thickness * 1pt) + c-rule)
     block(above: sp-after-rule, {
       for b in section.blocks { render-block(b, bold-title) }
     })
   } else if section-style == "underline" {
     block(above: sp-section-above, below: sp-after-rule, {
-      text(
-        size: heading-size,
-        weight: "bold",
-        fill: c-section,
-        font: (font-heading, "Carlito", "Inter"),
-        underline(heading-text),
-      )
+      heading-run(underline(heading-text), heading-size)
     })
     for b in section.blocks { render-block(b, bold-title) }
   } else {
     // bold-only
     block(above: sp-section-above, below: sp-after-rule, {
-      text(
-        size: heading-size,
-        weight: "bold",
-        fill: c-section,
-        font: (font-heading, "Carlito", "Inter"),
-        heading-text,
-      )
+      heading-run(heading-text, heading-size)
     })
     for b in section.blocks { render-block(b, bold-title) }
   }

--- a/apps/desktop/src-tauri/src/export/typst_engine/test.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/test.rs
@@ -361,8 +361,10 @@ fn every_template_renders_a_valid_pdf() {
         TemplateId::Throughline,
         TemplateId::Portrait,
         TemplateId::Lebenslauf,
+        TemplateId::Cadence,
+        TemplateId::Regent,
     ];
-    assert_eq!(ids.len(), 8, "expected the eight canonical templates");
+    assert_eq!(ids.len(), 10, "expected the ten canonical templates");
 
     let model = model_from_resume_text(FIXTURE_RESUME);
     for id in ids {
@@ -2404,6 +2406,8 @@ const STRAY_TOKENS: &[&str] = &[
     "#let",
     "pad(left",
     "place(",
+    "tracking:",
+    "smallcaps(",
 ];
 
 /// Render `bytes` through pdf-extract and assert no stray Typst tokens appear.
@@ -2560,11 +2564,248 @@ fn stray_typst_code_guard_letter() {
     assert_no_stray_tokens("letter", &bytes);
 }
 
+// ── PR3: heading_tracking / link_underline / rule_thickness knobs ──────────────
+// (backward-compat proof)
+//
+// Every pre-PR3 template ships heading_tracking: 0.0, link_underline: false, and
+// (for the ones whose rule is actually drawn) rule_thickness: 0.5 — the house
+// default. By construction:
+//   - `heading-run(...)` only emits `tracking: …` when `heading-tracking != 0.0`;
+//     at 0.0 it falls through to the exact `text(size:, weight:, fill:, font:,
+//     content)` call that existed before the knob (byte-for-byte, verified by
+//     reading the branch).
+//   - `render-runs(...)` only wraps a link in `underline(…)` when `link-underline`
+//     is true; at `false` the branch reduces to the bare `styled` value — the
+//     same `link(r.link, text(fill: c-accent, t))` call as before.
+//   - the rule stroke resolves `(rule-thickness * 1pt) + c-rule`, and every
+//     pre-PR3 ruled template ships `rule_thickness: 0.5` — `0.5 * 1pt == 0.5pt`,
+//     the same literal stroke as before. (SwissMinimal ships `0.0`, but its
+//     `section_style` is `BoldOnly`, so the ruled-bottom `line(...)` call — the
+//     only reader of `rule-thickness` — never executes for it either way.)
+//
+// Rather than re-deriving that proof at test time by rendering the same code
+// path twice and diffing the bytes (tautological — it would always pass), this
+// renders ONCE per template and checks two INDEPENDENT anchors decoded from the
+// compiled PDF: (a) no stray Typst source token leaked into the extracted text
+// (`assert_no_stray_tokens`, which also now guards the new `tracking:` /
+// `smallcaps(` syntax), and (b) the known section headings still appear intact,
+// in the expected reading order.
+
+#[test]
+fn pr3_knob_defaults_leave_pre_pr3_headings_and_content_intact() {
+    let model = model_from_resume_text(FIXTURE_RESUME);
+    for id in [
+        TemplateId::Classic,
+        TemplateId::SwissMinimal,
+        TemplateId::Academic,
+    ] {
+        let t = Template::get(id);
+        assert_eq!(
+            t.heading_tracking, 0.0,
+            "{id:?}: heading_tracking must be 0.0"
+        );
+        assert!(!t.link_underline, "{id:?}: link_underline must be false");
+
+        let bytes = render_pdf(&model, TypstTemplate::SingleColumn, &opts_sc(), Some(&t))
+            .unwrap_or_else(|e| panic!("{id:?}: render failed: {e:?}"));
+        assert_no_stray_tokens(&format!("{id:?}-knob-defaults"), &bytes);
+
+        let extracted = pdf_extract::extract_text_from_mem(&bytes)
+            .unwrap_or_else(|e| panic!("{id:?}: pdf-extract failed: {e}"));
+        let normalised: String = extracted.split_whitespace().collect::<Vec<_>>().join(" ");
+        let lower = normalised.to_lowercase();
+
+        assert!(
+            lower.contains("jane doe"),
+            "{id:?}: candidate name missing after knob threading\n---\n{lower}"
+        );
+        let order = ["summary", "experience", "education", "skills"];
+        let mut last = 0usize;
+        for h in &order {
+            let pos = lower.find(h).unwrap_or_else(|| {
+                panic!("{id:?}: heading '{h}' missing after knob threading\n---\n{lower}")
+            });
+            assert!(
+                pos >= last,
+                "{id:?}: '{h}' ({pos}) appeared before previous heading ({last})\n---\n{lower}"
+            );
+            last = pos;
+        }
+    }
+}
+
+// ── Cadence ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn cadence_render_produces_valid_pdf() {
+    let model = model_from_resume_text(FIXTURE_RESUME);
+    let t = template_style(TemplateId::Cadence);
+    let bytes = render_pdf(&model, TypstTemplate::SingleColumn, &opts_sc(), Some(&t))
+        .expect("render_pdf(cadence) should succeed");
+    assert!(!bytes.is_empty(), "Cadence PDF must not be empty");
+    assert!(
+        bytes.starts_with(b"%PDF"),
+        "Cadence output must start with %PDF"
+    );
+}
+
+#[test]
+fn cadence_accent_override_applies() {
+    let base = Template::get(TemplateId::Cadence);
+    let overridden = Template::get(TemplateId::Cadence).with_accent_override(Some("#00AA33"));
+    assert_ne!(base.accent_color, overridden.accent_color);
+    assert_eq!(overridden.accent_color, (0, 170, 51));
+    assert_eq!(overridden.emphasis_color, (0, 170, 51));
+}
+
+#[test]
+fn cadence_tracking_and_underline_change_the_rendered_svg() {
+    // Cadence sets heading_tracking 0.08 and link_underline true — prove the
+    // knobs actually perturb the rendered SVG (not just config plumbing) by
+    // diffing against a neutral (0.0 / false) variant of the same template.
+    let model = model_from_resume_text(FIXTURE_RESUME);
+    let cadence = Template::get(TemplateId::Cadence);
+    assert_eq!(cadence.heading_tracking, 0.08);
+    assert!(cadence.link_underline);
+
+    let neutral = Template {
+        heading_tracking: 0.0,
+        link_underline: false,
+        ..Template::get(TemplateId::Cadence)
+    };
+
+    let with_knobs = render_resume_svg_pages(
+        &model,
+        TypstTemplate::SingleColumn,
+        &opts_sc(),
+        Some(&cadence),
+    )
+    .expect("cadence render should succeed");
+    let without_knobs = render_resume_svg_pages(
+        &model,
+        TypstTemplate::SingleColumn,
+        &opts_sc(),
+        Some(&neutral),
+    )
+    .expect("cadence-neutral render should succeed");
+
+    assert_ne!(
+        with_knobs, without_knobs,
+        "heading_tracking/link_underline must visibly change the rendered SVG"
+    );
+}
+
+#[test]
+fn cadence_rule_thickness_changes_the_rendered_stroke() {
+    // Cadence specs a 0.75pt section rule (vs the house 0.5pt default) — prove
+    // `rule_thickness` is actually threaded into the rendered stroke width, not
+    // just pinned config (the finding this test exists to close: the field was
+    // previously dead in every renderer). Isolate it from the other PR3 knobs by
+    // holding heading_tracking/link_underline fixed and varying only the stroke.
+    let model = model_from_resume_text(FIXTURE_RESUME);
+    let cadence = Template::get(TemplateId::Cadence);
+    assert_eq!(cadence.rule_thickness, 0.75);
+
+    let half_pt_rule = Template {
+        rule_thickness: 0.5,
+        ..Template::get(TemplateId::Cadence)
+    };
+
+    let with_075 = render_resume_svg_pages(
+        &model,
+        TypstTemplate::SingleColumn,
+        &opts_sc(),
+        Some(&cadence),
+    )
+    .expect("cadence (0.75pt rule) render should succeed");
+    let with_05 = render_resume_svg_pages(
+        &model,
+        TypstTemplate::SingleColumn,
+        &opts_sc(),
+        Some(&half_pt_rule),
+    )
+    .expect("cadence (0.5pt rule) render should succeed");
+
+    assert_ne!(
+        with_075, with_05,
+        "rule_thickness must visibly change the rendered SVG stroke"
+    );
+}
+
+// ── Regent ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn regent_render_produces_valid_pdf() {
+    let model = model_from_resume_text(FIXTURE_RESUME);
+    let t = template_style(TemplateId::Regent);
+    let bytes = render_pdf(&model, TypstTemplate::SingleColumn, &opts_sc(), Some(&t))
+        .expect("render_pdf(regent) should succeed");
+    assert!(!bytes.is_empty(), "Regent PDF must not be empty");
+    assert!(
+        bytes.starts_with(b"%PDF"),
+        "Regent output must start with %PDF"
+    );
+}
+
+#[test]
+fn regent_accent_override_applies() {
+    let base = Template::get(TemplateId::Regent);
+    let overridden = Template::get(TemplateId::Regent).with_accent_override(Some("#123456"));
+    assert_ne!(base.accent_color, overridden.accent_color);
+    assert_eq!(overridden.accent_color, (18, 52, 86));
+    assert_eq!(overridden.emphasis_color, (18, 52, 86));
+}
+
+#[test]
+fn regent_maps_to_serif_small_caps_burgundy_style() {
+    use super::render::style_from_template;
+
+    let regent = Template::get(TemplateId::Regent);
+    let style = style_from_template(&regent);
+
+    // Source Serif 4 throughout, burgundy accent, small-caps (not all-caps)
+    // headings, light heading tracking, no link underline.
+    assert_eq!(style.font_heading, "Source Serif 4");
+    assert_eq!(style.font_name, "Source Serif 4");
+    assert_eq!(style.font_body, "Source Serif 4");
+    assert!(
+        style.section_small_caps,
+        "Regent headings must be small-caps"
+    );
+    assert!(
+        !style.section_all_caps,
+        "Regent headings must not be all-caps"
+    );
+    assert_eq!(style.c_accent, "#6E1E2B");
+    assert!((style.heading_tracking - 0.04).abs() < f32::EPSILON);
+    assert!(!style.link_underline);
+    assert_eq!(style.rule_thickness, 0.5);
+
+    // Exercise the actual render path too (not just the JsonStyle mapping) and
+    // guard the new `smallcaps(…)` call site — the bundled Source Serif 4 TTF
+    // has neither `smcp` nor `c2sc`, and Typst 0.15's `smallcaps` does not yet
+    // synthesize small caps for fonts lacking those features, so this renders
+    // headings at 0.85× size in their original case rather than visually
+    // distinct small-caps glyphs today; `smallcaps(…)` still keeps the PDF text
+    // layer's characters unmodified (extraction-safe) and is forward-compatible
+    // with a future smcp-capable font swap.
+    let model = model_from_resume_text(FIXTURE_RESUME);
+    let bytes = render_pdf(
+        &model,
+        TypstTemplate::SingleColumn,
+        &opts_sc(),
+        Some(&regent),
+    )
+    .expect("regent render_pdf should succeed");
+    assert!(bytes.starts_with(b"%PDF"));
+    assert_no_stray_tokens("regent-small-caps", &bytes);
+}
+
 // ── README showcase banner generator ─────────────────────────────────────────
 //
-// Renders all eight templates, rasterises the first page of each at 2× DPI
+// Renders all ten templates, rasterises the first page of each at 2× DPI
 // (144 px/pt), thumbnails each to 300 px wide, and composes a single wide
-// row (1×8) — a banner-proportioned strip like the project hero — on a
+// row (1×10) — a banner-proportioned strip like the project hero — on a
 // #F4F4F5 background with 20 px border-padding and 14 px gaps, writing the
 // result to docs/assets/templates-showcase.png.
 //
@@ -2656,8 +2897,11 @@ fn generate_templates_showcase_banner() {
     /// from the original A4 aspect ratio.
     const CELL_W: u32 = 300;
 
-    /// Layout: a single wide row — 9 columns × 1 row (banner proportions).
-    const COLS: u32 = 9;
+    /// Layout: a single wide row — 10 columns × 1 row (banner proportions).
+    /// Must be >= the template count: `ROWS` is hardcoded to 1, so any template
+    /// landing at row-index >= 1 would write pixels beyond `canvas_h` (an
+    /// out-of-bounds `put_pixel` panic below).
+    const COLS: u32 = 10;
     const ROWS: u32 = 1;
 
     /// Outer border padding (px) and gap between cells (px).
@@ -2687,7 +2931,7 @@ fn generate_templates_showcase_banner() {
         ats: false,
     };
 
-    // ── Template list (must be exactly 8, matching the canonical TemplateId set) ──
+    // ── Template list (must be exactly 10, matching the canonical TemplateId set) ──
 
     // (TemplateId, human label, kebab slug). The slug MUST match the renderer's
     // `TemplateId` wire ids so the per-template preview files line up with the UI.
@@ -2700,11 +2944,13 @@ fn generate_templates_showcase_banner() {
         (TemplateId::Throughline, "Throughline", "throughline"),
         (TemplateId::Portrait, "Portrait", "portrait"),
         (TemplateId::Lebenslauf, "Lebenslauf", "lebenslauf"),
+        (TemplateId::Cadence, "Cadence", "cadence"),
+        (TemplateId::Regent, "Regent", "regent"),
     ];
     assert_eq!(
         templates.len(),
-        8,
-        "showcase must cover exactly eight templates"
+        10,
+        "showcase must cover exactly ten templates"
     );
 
     // ── Helper: compile a World to a PagedDocument ────────────────────────────
@@ -2753,7 +2999,7 @@ fn generate_templates_showcase_banner() {
     std::fs::create_dir_all(&preview_dir)
         .unwrap_or_else(|e| panic!("showcase: create_dir_all template-previews: {e}"));
 
-    let mut thumbnails: Vec<RgbaImage> = Vec::with_capacity(8);
+    let mut thumbnails: Vec<RgbaImage> = Vec::with_capacity(10);
 
     for (id, label, slug) in templates {
         eprintln!("showcase: rendering {label}...");
@@ -2818,9 +3064,9 @@ fn generate_templates_showcase_banner() {
         eprintln!("  → thumbnail {tw_cur}×{th_cur}");
     }
 
-    assert_eq!(thumbnails.len(), 8, "must have exactly 8 thumbnails");
+    assert_eq!(thumbnails.len(), 10, "must have exactly 10 thumbnails");
 
-    // ── Compose single wide row (1×8) ─────────────────────────────────────────
+    // ── Compose single wide row (1×10) ────────────────────────────────────────
 
     // Use the actual thumbnail dimensions (thumbnail() preserves aspect, so
     // width should be CELL_W and height close to cell_h).
@@ -2917,7 +3163,7 @@ fn generate_templates_showcase_banner() {
     );
     eprintln!("  path: {}", out_path.display());
 
-    // ── Verify: all eight per-template previews exist and are non-trivial ─────
+    // ── Verify: all ten per-template previews exist and are non-trivial ───────
 
     for (_, label, slug) in templates {
         let p = preview_dir.join(format!("{slug}.svg"));
@@ -2930,7 +3176,7 @@ fn generate_templates_showcase_banner() {
         );
     }
     eprintln!(
-        "template previews written: 8 SVG → {}",
+        "template previews written: 10 SVG → {}",
         preview_dir.display()
     );
 }
@@ -2944,12 +3190,12 @@ fn generate_templates_showcase_banner() {
 /// ```
 ///
 /// This is the cover-letter analog of `generate_templates_showcase_banner`'s
-/// per-template previews. For each of the same eight résumé templates it builds
+/// per-template previews. For each of the same ten résumé templates it builds
 /// the exact cover-letter Typst world that [`super::engine::render_letter_pdf`]
 /// produces — `letter_style_from_template` derives the palette + fonts from the
 /// résumé [`Template`], so the rendered letter *inherits that template's visual
 /// style* — compiles page 1, and exports it to **SVG** (vector, no rasteriser,
-/// no `image` crate, no thumbnailing). The eight `.svg` files feed the
+/// no `image` crate, no thumbnailing). The ten `.svg` files feed the
 /// AI-Generate cover-letter template picker (fetched lazily by the UI via a Vite
 /// glob, mirroring the résumé `template-previews/` PNGs).
 ///
@@ -2967,7 +3213,7 @@ fn generate_cover_template_previews() {
     use super::letter::{parse_cover_letter, style_from_template as letter_style_from_template};
     use super::world::ResumeWorld;
 
-    // Same eight templates as the showcase generator. Slugs MUST match the
+    // Same ten templates as the showcase generator. Slugs MUST match the
     // renderer's `TemplateId` wire ids so the preview files line up with the UI.
     let templates: &[(TemplateId, &str, &str)] = &[
         (TemplateId::Classic, "Classic", "classic"),
@@ -2978,11 +3224,13 @@ fn generate_cover_template_previews() {
         (TemplateId::Throughline, "Throughline", "throughline"),
         (TemplateId::Portrait, "Portrait", "portrait"),
         (TemplateId::Lebenslauf, "Lebenslauf", "lebenslauf"),
+        (TemplateId::Cadence, "Cadence", "cadence"),
+        (TemplateId::Regent, "Regent", "regent"),
     ];
     assert_eq!(
         templates.len(),
-        8,
-        "cover previews must cover exactly eight templates"
+        10,
+        "cover previews must cover exactly ten templates"
     );
 
     // Embedded letter Typst sources (scale preamble + letter template), reused
@@ -3060,11 +3308,11 @@ fn generate_cover_template_previews() {
     }
 
     assert_eq!(
-        written, 8,
-        "cover previews: expected exactly 8 SVG files written"
+        written, 10,
+        "cover previews: expected exactly 10 SVG files written"
     );
 
-    // Verify all eight exist and are non-trivial.
+    // Verify all ten exist and are non-trivial.
     for (_, label, slug) in templates {
         let p = preview_dir.join(format!("{slug}.svg"));
         let meta = std::fs::metadata(&p)
@@ -3075,7 +3323,7 @@ fn generate_cover_template_previews() {
         );
     }
     eprintln!(
-        "cover-letter template previews written: 8 → {}",
+        "cover-letter template previews written: 10 → {}",
         preview_dir.display()
     );
 }

--- a/apps/desktop/src-tauri/src/recommend/tests.rs
+++ b/apps/desktop/src-tauri/src/recommend/tests.rs
@@ -11,9 +11,9 @@ fn signals(title: &str, seniority: &str, reqs: &[&str]) -> RecommendSignals {
     }
 }
 
-/// The eight live template IDs — the recommender must never return anything outside
+/// The ten live template IDs — the recommender must never return anything outside
 /// this set.
-const LIVE_TEMPLATES: [TemplateId; 8] = [
+const LIVE_TEMPLATES: [TemplateId; 10] = [
     TemplateId::Classic,
     TemplateId::SwissMinimal,
     TemplateId::Academic,
@@ -22,12 +22,14 @@ const LIVE_TEMPLATES: [TemplateId; 8] = [
     TemplateId::Throughline,
     TemplateId::Portrait,
     TemplateId::Lebenslauf,
+    TemplateId::Cadence,
+    TemplateId::Regent,
 ];
 
 #[test]
 fn recommender_never_returns_a_deleted_id() {
     // Exhaustive sweep over representative job signals.  Every result must be a
-    // member of the eight live templates — no deleted id (Modern et al.) may slip through.
+    // member of the ten live templates — no deleted id (Modern et al.) may slip through.
     let cases: &[(&str, &str, &[&str])] = &[
         ("Frontend Engineer", "mid", &["React", "TypeScript"]),
         ("Embedded Software Engineer", "mid", &["C++", "firmware"]),

--- a/apps/desktop/src-tauri/src/validate/tests.rs
+++ b/apps/desktop/src-tauri/src/validate/tests.rs
@@ -328,6 +328,8 @@ fn typst_single_column_pdf_passes_validation() {
         TemplateId::Meridian,
         TemplateId::Throughline,
         TemplateId::Lebenslauf,
+        TemplateId::Cadence,
+        TemplateId::Regent,
     ] {
         let (bytes, report) = typst_validate(id);
         assert!(!bytes.is_empty(), "{id:?}: empty PDF");

--- a/apps/desktop/src/renderer/features/ai-generate/components/wizard-steps/StepTemplate/StepTemplate.test.tsx
+++ b/apps/desktop/src/renderer/features/ai-generate/components/wizard-steps/StepTemplate/StepTemplate.test.tsx
@@ -337,9 +337,9 @@ describe('StepTemplate', () => {
     expect(screen.getByText('aiGenerate.tier.design')).toBeInTheDocument();
   });
 
-  it('shows a tier badge on every card (5 ATS + 3 design)', () => {
+  it('shows a tier badge on every card (7 ATS + 3 design)', () => {
     renderStep();
-    expect(screen.getAllByText('aiGenerate.tier.atsBadge')).toHaveLength(5);
+    expect(screen.getAllByText('aiGenerate.tier.atsBadge')).toHaveLength(7);
     expect(screen.getAllByText('aiGenerate.tier.designBadge')).toHaveLength(3);
   });
 
@@ -353,13 +353,18 @@ describe('StepTemplate', () => {
     }
   );
 
-  it.each(['classic', 'swiss-minimal', 'academic', 'meridian', 'throughline'] as const)(
-    'hides the ATS toggle for the ATS-tier template %s',
-    (id) => {
-      renderStep({ templateId: id });
-      expect(screen.queryByRole('switch')).not.toBeInTheDocument();
-    }
-  );
+  it.each([
+    'classic',
+    'swiss-minimal',
+    'academic',
+    'meridian',
+    'throughline',
+    'cadence',
+    'regent',
+  ] as const)('hides the ATS toggle for the ATS-tier template %s', (id) => {
+    renderStep({ templateId: id });
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+  });
 
   it('uses the two-column hint for a two-column template but the photo hint for Lebenslauf', () => {
     const { unmount } = renderStep({ templateId: 'atelier' });

--- a/apps/desktop/src/renderer/features/ai-generate/samples/cover-template-previews.test.ts
+++ b/apps/desktop/src/renderer/features/ai-generate/samples/cover-template-previews.test.ts
@@ -7,7 +7,7 @@ import { TEMPLATE_IDS } from '@/lib/generate';
 // module and supply a stub that mirrors what Vite would produce: one entry per
 // SVG file, keyed by a path whose basename (minus extension) is the template id.
 vi.mock('./cover-template-previews', () => {
-  // Simulate the 9 committed SVG assets.
+  // Simulate the committed SVG assets — one per canonical TemplateId.
   const ids = [
     'classic',
     'swiss-minimal',
@@ -17,6 +17,8 @@ vi.mock('./cover-template-previews', () => {
     'throughline',
     'portrait',
     'lebenslauf',
+    'cadence',
+    'regent',
   ] as const;
 
   const COVER_TEMPLATE_PREVIEWS = Object.fromEntries(

--- a/apps/desktop/src/renderer/features/ai-generate/samples/samples.ts
+++ b/apps/desktop/src/renderer/features/ai-generate/samples/samples.ts
@@ -25,4 +25,6 @@ export const TEMPLATE_CAPTIONS: Record<TemplateId, string> = {
   throughline: 'Vertical timeline spine. Engineering & product careers with a clear arc.',
   portrait: 'Photo header, two columns. European market and personal-brand résumés.',
   lebenslauf: 'DIN-style tabular CV with photo. German-speaking (DACH) market standard.',
+  cadence: 'Letter-spaced modern headings, restrained blue-grey. Premium and parser-safe.',
+  regent: 'Executive serif with small-caps headings and a deep burgundy accent. Leadership roles.',
 };

--- a/apps/desktop/src/renderer/lib/generate/templates/templates.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/templates/templates.test.ts
@@ -5,8 +5,8 @@ import { isDesignTier, TEMPLATES } from './templates';
 describe('TEMPLATES', () => {
   const ids = Object.keys(TEMPLATES);
 
-  it('exposes the eight document templates keyed by id', () => {
-    expect(ids).toHaveLength(8);
+  it('exposes the ten document templates keyed by id', () => {
+    expect(ids).toHaveLength(10);
     for (const id of ids) {
       expect(TEMPLATES[id as keyof typeof TEMPLATES].id).toBe(id);
     }
@@ -15,14 +15,16 @@ describe('TEMPLATES', () => {
   // Sync guard: this id set MUST equal the Rust `TemplateId` enum (export/types.rs,
   // kebab-case) and the shared contract union (packages/shared/.../documents.ts).
   // The Rust round-trip test pins the other side; if either drifts, a guard fails.
-  it('matches the canonical 8-template id set', () => {
+  it('matches the canonical 10-template id set', () => {
     expect([...ids].sort()).toEqual([
       'academic',
       'atelier',
+      'cadence',
       'classic',
       'lebenslauf',
       'meridian',
       'portrait',
+      'regent',
       'swiss-minimal',
       'throughline',
     ]);
@@ -60,8 +62,10 @@ describe('TEMPLATES', () => {
         .sort();
     expect(idsByTier('ats')).toEqual([
       'academic',
+      'cadence',
       'classic',
       'meridian',
+      'regent',
       'swiss-minimal',
       'throughline',
     ]);

--- a/apps/desktop/src/renderer/lib/generate/templates/templates.ts
+++ b/apps/desktop/src/renderer/lib/generate/templates/templates.ts
@@ -14,7 +14,9 @@ export type TemplateId =
   | 'meridian'
   | 'throughline'
   | 'portrait'
-  | 'lebenslauf';
+  | 'lebenslauf'
+  | 'cadence'
+  | 'regent';
 
 interface DocTemplate {
   id: TemplateId;
@@ -227,6 +229,52 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
     marginIn: 0.9,
     lineSpacingDocx: 264,
     sectionSpacingBefore: 240,
+    nameCentered: false,
+    sectionAllCaps: false,
+    sectionStyle: 'ruled-bottom',
+  },
+
+  /** Cadence — Inter, large 28pt name, blue-grey accent, letter-spaced all-caps ruled headings, underlined links */
+  cadence: {
+    id: 'cadence',
+    name: 'Cadence',
+    tier: 'ats',
+    nameColor: '1A1A1A',
+    sectionColor: '1A1A1A',
+    accentColor: '4A6785',
+    bodyColor: '2B2B2B',
+    dateColor: '6B6B6B',
+    emphasisColor: '4A6785',
+    ruleColor: '4A6785',
+    namePt: 28,
+    sectionPt: 10.5,
+    bodyPt: 10,
+    marginIn: 0.8,
+    lineSpacingDocx: 264,
+    sectionSpacingBefore: 240,
+    nameCentered: false,
+    sectionAllCaps: true,
+    sectionStyle: 'ruled-bottom',
+  },
+
+  /** Regent — Source Serif 4, deep burgundy accent + rose rule, serif small-caps headings, executive */
+  regent: {
+    id: 'regent',
+    name: 'Regent',
+    tier: 'ats',
+    nameColor: '2A2A2E',
+    sectionColor: '6E1E2B',
+    accentColor: '6E1E2B',
+    bodyColor: '26262A',
+    dateColor: '7A6A6E',
+    emphasisColor: '6E1E2B',
+    ruleColor: 'C9A9AE',
+    namePt: 26,
+    sectionPt: 11,
+    bodyPt: 10.5,
+    marginIn: 0.9,
+    lineSpacingDocx: 276,
+    sectionSpacingBefore: 280,
     nameCentered: false,
     sectionAllCaps: false,
     sectionStyle: 'ruled-bottom',

--- a/packages/shared/src/ipc/contracts/documents.ts
+++ b/packages/shared/src/ipc/contracts/documents.ts
@@ -10,7 +10,9 @@ export type TemplateId =
   | 'meridian'
   | 'throughline'
   | 'portrait'
-  | 'lebenslauf';
+  | 'lebenslauf'
+  | 'cadence'
+  | 'regent';
 
 interface ExportMeta {
   candidateName?: string;


### PR DESCRIPTION
## Summary

PR 3 of the template-overhaul series (after #590/#591): two new **ATS-tier single-column templates** on the parametric renderer — no new `.typ` files.

- **Cadence** — Inter throughout, 28pt name, muted blue-grey accent (#4A6785), letter-spaced all-caps ruled headings, underlined links. Modeled on the restrained-premium single-column style (2026 "premium = typographic discipline" direction).
- **Regent** — Source Serif 4 throughout, 26pt name, deep burgundy accent (#6E1E2B) with rose rules, small-caps serif headings, executive first-line-indent letter pairing.
- **Two backward-compatible style knobs** on the shared renderer: `heading_tracking` (Typst `text(tracking:)` — real advance-width, no injected characters, extraction-safe) and `link_underline`. Defaults preserve existing templates' output byte-for-byte (guarded branches + independent-anchor regression test).
- **`rule_thickness` was dead config in every renderer** — now actually threaded (only Cadence uses a non-default value; verified no existing template's output changes).
- Latent bug fixed: the showcase-banner generator's hardcoded 9-column grid would panic at the 10th template.

## Known caveat (documented, follow-up queued)

Regent uses real Typst `smallcaps()` (extraction-safe, text layer keeps original case) — but the **bundled Source Serif 4 lacks the `smcp`/`c2sc` OpenType features and Typst 0.15 does not synthesize small-caps**, so the effect is visually inert until a fuller font asset ships. DOCX approximates with uppercase + letter spacing (minor cross-format divergence until the font swap).

Preview SVGs for both templates + showcase banner regen are **pending CI** (host cannot execute cargo tests); the gallery renders its icon fallback meanwhile.

## Review status (pre-PR agent gates)

`resume-export-expert` — passed (no HIGH/CRITICAL); all three MEDIUMs fixed in-diff: dead `rule_thickness` threaded with rendered-output assertion, real `smallcaps()` with the font caveat above, tautological byte-identity test replaced with independent anchors (stray-token guard + pdf-extract content checks). ATS extraction safety of tracking/small-caps verified by construction and text-layer analysis.

## Tests

Count pins 8→10 across Rust + TS; per-template render/accent/knob tests (incl. rendered-stroke and tracking/underline SVG-diff assertions); tier pins gain 2 ATS entries; full frontend suite 3,267 green, typecheck + lint clean.

⚠️ Local `cargo test` cannot execute on the dev host — Rust tests compile clean under `cargo check --all-targets` + clippy; **CI is authoritative for Rust test execution.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
