### PR TITLE
feat: aria and saffron photo templates with per-template placement (templates pr 4/6)

### DIFF
--- a/apps/desktop/src-tauri/src/export/model_docx.rs
+++ b/apps/desktop/src-tauri/src/export/model_docx.rs
@@ -223,7 +223,7 @@ fn add_two_column_body(
         right_align_date: true,
     };
     for section in &model.sections {
-        match theme::placement_for(&section.id) {
+        match theme::placement_for(template.id, &section.id) {
             Placement::Sidebar => sidebar_paras.extend(section_paragraphs(section, &sidebar_ctx)),
             Placement::Main => main_paras.extend(section_paragraphs(section, &main_ctx)),
         }

--- a/apps/desktop/src-tauri/src/export/pdf/mod.rs
+++ b/apps/desktop/src-tauri/src/export/pdf/mod.rs
@@ -5,7 +5,7 @@ use super::{
     types::{DocumentType, ExportRequest},
 };
 
-// Typst engine — used by the live export path for all eight templates.
+// Typst engine — used by the live export path for all twelve templates.
 use super::typst_engine::{
     render_letter_pdf, render_letter_svg_pages, render_pdf, render_pdf_with_photo,
     render_resume_svg_pages, render_resume_svg_pages_with_photo, resolve_photo, RenderOpts,
@@ -101,7 +101,8 @@ fn prepare_resume_render(request: &ExportRequest) -> ResumeRenderInputs {
         ats: request.ats_mode,
     };
 
-    // Resolve photo bytes (for photo-capable templates; None for others).
+    // Resolved whenever a contact photo is present; only photo-capable templates
+    // consume it.
     let contact_has_photo = request
         .contact
         .as_ref()

--- a/apps/desktop/src-tauri/src/export/pdf/test.rs
+++ b/apps/desktop/src-tauri/src/export/pdf/test.rs
@@ -561,6 +561,8 @@ LANGUAGES
         TemplateId::Lebenslauf,
         TemplateId::Cadence,
         TemplateId::Regent,
+        TemplateId::Aria,
+        TemplateId::Saffron,
     ];
 
     let out = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/sample_pdfs");

--- a/apps/desktop/src-tauri/src/export/templates/mod.rs
+++ b/apps/desktop/src-tauri/src/export/templates/mod.rs
@@ -181,6 +181,8 @@ impl Template {
             TemplateId::Lebenslauf => Self::lebenslauf(),
             TemplateId::Cadence => Self::cadence(),
             TemplateId::Regent => Self::regent(),
+            TemplateId::Aria => Self::aria(),
+            TemplateId::Saffron => Self::saffron(),
         }
     }
 
@@ -201,7 +203,7 @@ impl Template {
         self
     }
 
-    // ─── Ten live templates ───────────────────────────────────────────────────
+    // ─── Twelve live templates ────────────────────────────────────────────────
 
     /// ATS Classic — maximum compatibility, no color, safe for all ATS parsers.
     ///
@@ -668,6 +670,115 @@ impl Template {
             cover_letter: CoverLetterLayout {
                 paragraph_indent: ParagraphIndent::FirstLine,
                 paragraph_spacing_pt: 0.0,
+            },
+        }
+    }
+
+    // ─── PR4 photo / two-column design templates ──────────────────────────────
+
+    /// Aria — minimalist design two-column (Ava-Amelia reference).
+    ///
+    /// Design: an untinted RIGHT sidebar carries the rectangular top-right photo,
+    /// contact, and Skills/Languages/Certifications; the main column (left) opens
+    /// with a 30pt Manrope name and carries Summary/Experience/Projects **and
+    /// Education** (per the `theme::placement_for` override). Slate accent
+    /// (#46505C), letter-spaced (`heading_tracking 0.06`) all-caps hairline-ruled
+    /// headings, Inter body, generous whitespace. No-photo fallback is a name-only
+    /// header (no monogram). Renders through the bespoke `aria.typ`. Tier: Design.
+    pub(super) fn aria() -> Self {
+        Self {
+            id: TemplateId::Aria,
+            name: "Aria",
+            tier: TemplateTier::Design,
+            // Slate palette on near-black ink.
+            name_color: (17, 17, 17),
+            section_color: (26, 26, 26),
+            accent_color: (70, 80, 92), // #46505C slate
+            body_color: (42, 42, 42),
+            date_color: (122, 122, 122),
+            emphasis_color: (70, 80, 92),
+            rule_color: (214, 217, 221), // #D6D9DD hairline
+            name_pt: 30.0,
+            section_pt: 10.5,
+            body_pt: 10.0,
+            margin_in: 0.6,
+            line_spacing: 1.25,
+            section_spacing_before: 16.0,
+            name_centered: false,
+            section_all_caps: true,
+            section_style: SectionStyle::RuledBottom,
+            fonts: TemplateFonts {
+                name_family: FontFamily::Manrope,
+                heading_family: FontFamily::Manrope,
+                body_family: FontFamily::Inter,
+            },
+            job_title_italic: false,
+            section_small_caps: false,
+            rule_thickness: 0.5,
+            heading_tracking: 0.06,
+            link_underline: false,
+            two_column: Some(TwoColumnConfig {
+                sidebar_width_ratio: 0.32,
+                // Untinted (white) — aria.typ skips the sidebar band fill.
+                sidebar_bg_color: (255, 255, 255),
+            }),
+            cover_letter: CoverLetterLayout {
+                paragraph_indent: ParagraphIndent::BlockNoIndent,
+                paragraph_spacing_pt: 8.0,
+            },
+        }
+    }
+
+    /// Saffron — warm design two-column (warm reference).
+    ///
+    /// Design: a tinted LEFT sidebar (#F5E7DA) carries a circular photo with a
+    /// 1.5pt accent ring (the differentiator vs Portrait's ringless circle),
+    /// contact, and Skills/Education/Languages; the main column carries
+    /// Summary/Experience/Projects **and Certifications** (per the
+    /// `theme::placement_for` override). Source Serif 4 small-caps headings, Inter
+    /// body, terracotta accent (#A85A3E), warm dark name. No-photo fallback is a
+    /// warm accent monogram circle. Renders through the bespoke `saffron.typ`.
+    /// Tier: Design.
+    pub(super) fn saffron() -> Self {
+        Self {
+            id: TemplateId::Saffron,
+            name: "Saffron",
+            tier: TemplateTier::Design,
+            // Terracotta accent on a warm dark ink.
+            name_color: (58, 46, 40),
+            section_color: (168, 90, 62), // #A85A3E terracotta
+            accent_color: (168, 90, 62),
+            body_color: (48, 42, 38),
+            date_color: (138, 122, 110),
+            emphasis_color: (168, 90, 62),
+            rule_color: (226, 201, 180),
+            name_pt: 24.0,
+            section_pt: 11.0,
+            body_pt: 10.5,
+            margin_in: 0.55,
+            line_spacing: 1.2,
+            section_spacing_before: 12.0,
+            name_centered: false,
+            section_all_caps: false,
+            section_style: SectionStyle::RuledBottom,
+            fonts: TemplateFonts {
+                name_family: FontFamily::SourceSerif4,
+                heading_family: FontFamily::SourceSerif4,
+                body_family: FontFamily::Inter,
+            },
+            job_title_italic: true,
+            section_small_caps: true,
+            rule_thickness: 0.5,
+            heading_tracking: 0.0,
+            link_underline: false,
+            two_column: Some(TwoColumnConfig {
+                sidebar_width_ratio: 0.34,
+                // Warm peach tint.
+                sidebar_bg_color: (245, 231, 218),
+            }),
+            cover_letter: CoverLetterLayout {
+                paragraph_indent: ParagraphIndent::BlockNoIndent,
+                paragraph_spacing_pt: 8.0,
             },
         }
     }

--- a/apps/desktop/src-tauri/src/export/templates/test.rs
+++ b/apps/desktop/src-tauri/src/export/templates/test.rs
@@ -137,6 +137,8 @@ fn template_tiers_are_pinned() {
         (TemplateId::Lebenslauf, Design),
         (TemplateId::Cadence, Ats),
         (TemplateId::Regent, Ats),
+        (TemplateId::Aria, Design),
+        (TemplateId::Saffron, Design),
     ];
     for (id, tier) in expected {
         assert_eq!(
@@ -226,4 +228,70 @@ fn regent_matches_spec() {
     assert!(t.two_column.is_none());
     assert_eq!(t.cover_letter.paragraph_indent, ParagraphIndent::FirstLine);
     assert_eq!(t.cover_letter.paragraph_spacing_pt, 0.0);
+}
+
+// ─── PR4: Aria / Saffron spec pins ──────────────────────────────────────────────
+
+#[test]
+fn aria_matches_spec() {
+    let t = Template::get(TemplateId::Aria);
+    assert_eq!(t.tier, TemplateTier::Design);
+    assert_eq!(t.name_pt, 30.0);
+    assert_eq!(t.section_pt, 10.5);
+    assert_eq!(t.body_pt, 10.0);
+    assert_eq!(t.margin_in, 0.6);
+    assert_eq!(t.line_spacing, 1.25);
+    assert_eq!(t.section_spacing_before, 16.0);
+    assert_eq!(t.name_color, (17, 17, 17));
+    assert_eq!(t.section_color, (26, 26, 26));
+    assert_eq!(t.accent_color, (70, 80, 92));
+    assert_eq!(t.body_color, (42, 42, 42));
+    assert_eq!(t.date_color, (122, 122, 122));
+    assert_eq!(t.emphasis_color, (70, 80, 92));
+    assert_eq!(t.rule_color, (214, 217, 221));
+    assert!(t.section_all_caps);
+    assert!(!t.section_small_caps);
+    assert!(!t.job_title_italic);
+    assert_eq!(t.heading_tracking, 0.06);
+    assert!(!t.link_underline);
+    let tc = t.two_column.as_ref().expect("Aria is two-column");
+    assert_eq!(tc.sidebar_width_ratio, 0.32);
+    assert_eq!(tc.sidebar_bg_color, (255, 255, 255));
+    assert_eq!(
+        t.cover_letter.paragraph_indent,
+        ParagraphIndent::BlockNoIndent
+    );
+    assert_eq!(t.cover_letter.paragraph_spacing_pt, 8.0);
+}
+
+#[test]
+fn saffron_matches_spec() {
+    let t = Template::get(TemplateId::Saffron);
+    assert_eq!(t.tier, TemplateTier::Design);
+    assert_eq!(t.name_pt, 24.0);
+    assert_eq!(t.section_pt, 11.0);
+    assert_eq!(t.body_pt, 10.5);
+    assert_eq!(t.margin_in, 0.55);
+    assert_eq!(t.line_spacing, 1.2);
+    assert_eq!(t.section_spacing_before, 12.0);
+    assert_eq!(t.name_color, (58, 46, 40));
+    assert_eq!(t.section_color, (168, 90, 62));
+    assert_eq!(t.accent_color, (168, 90, 62));
+    assert_eq!(t.body_color, (48, 42, 38));
+    assert_eq!(t.date_color, (138, 122, 110));
+    assert_eq!(t.emphasis_color, (168, 90, 62));
+    assert_eq!(t.rule_color, (226, 201, 180));
+    assert!(!t.section_all_caps);
+    assert!(t.section_small_caps);
+    assert!(t.job_title_italic);
+    assert_eq!(t.heading_tracking, 0.0);
+    assert!(!t.link_underline);
+    let tc = t.two_column.as_ref().expect("Saffron is two-column");
+    assert_eq!(tc.sidebar_width_ratio, 0.34);
+    assert_eq!(tc.sidebar_bg_color, (245, 231, 218));
+    assert_eq!(
+        t.cover_letter.paragraph_indent,
+        ParagraphIndent::BlockNoIndent
+    );
+    assert_eq!(t.cover_letter.paragraph_spacing_pt, 8.0);
 }

--- a/apps/desktop/src-tauri/src/export/types.rs
+++ b/apps/desktop/src-tauri/src/export/types.rs
@@ -43,6 +43,16 @@ pub enum TemplateId {
     /// small-caps headings, rose rule, first-line-indent letter). Renders through
     /// the parametric `single_column.typ`.
     Regent,
+    /// PR4: Aria — minimalist design two-column with an untinted RIGHT sidebar and
+    /// a rectangular top-right photo (Manrope name, Inter body, slate accent,
+    /// letter-spaced caps headings). Education reads in the main column. Renders
+    /// through the bespoke `aria.typ`.
+    Aria,
+    /// PR4: Saffron — warm design two-column with a tinted LEFT sidebar and a
+    /// circular ringed photo (Source Serif 4 small-caps headings, Inter body,
+    /// terracotta accent). Certifications read in the main column. Renders through
+    /// the bespoke `saffron.typ`.
+    Saffron,
 }
 
 impl<'de> serde::Deserialize<'de> for TemplateId {
@@ -62,6 +72,8 @@ impl<'de> serde::Deserialize<'de> for TemplateId {
             "lebenslauf" => TemplateId::Lebenslauf,
             "cadence" => TemplateId::Cadence,
             "regent" => TemplateId::Regent,
+            "aria" => TemplateId::Aria,
+            "saffron" => TemplateId::Saffron,
             // Any unknown / removed id (e.g. "two-column", "refined-executive",
             // "executive", "editorial-serif", "mono-technical", "bogus") falls
             // back to Classic so a stale frontend never breaks export.
@@ -270,6 +282,8 @@ mod tests {
             (TemplateId::Lebenslauf, "\"lebenslauf\""),
             (TemplateId::Cadence, "\"cadence\""),
             (TemplateId::Regent, "\"regent\""),
+            (TemplateId::Aria, "\"aria\""),
+            (TemplateId::Saffron, "\"saffron\""),
         ];
         for (id, expected_json) in cases {
             let serialized = serde_json::to_string(&id).expect("serialize");

--- a/apps/desktop/src-tauri/src/export/typst_engine/engine.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/engine.rs
@@ -64,6 +64,13 @@ const PORTRAIT_TYP: &str = include_str!("templates/portrait.typ");
 /// Lebenslauf — DACH DIN-style tabular CV with photo top-right.
 const LEBENSLAUF_TYP: &str = include_str!("templates/lebenslauf.typ");
 
+/// Aria — minimalist design two-column, untinted RIGHT sidebar, rectangular
+/// top-right photo (PR4).
+const ARIA_TYP: &str = include_str!("templates/aria.typ");
+
+/// Saffron — warm design two-column, tinted LEFT sidebar, circular ringed photo (PR4).
+const SAFFRON_TYP: &str = include_str!("templates/saffron.typ");
+
 /// Parametric cover-letter template driven by `data.opts` + `data.style`.
 /// A4 or Letter; themed from the chosen resume template's accent + fonts.
 const LETTER_TYP: &str = include_str!("templates/letter.typ");
@@ -102,6 +109,11 @@ pub enum TypstTemplate {
     Portrait,
     /// Phase 3b-i — DACH DIN-style tabular CV, photo top-right.
     Lebenslauf,
+    /// PR4 — minimalist design two-column, untinted RIGHT sidebar, rectangular
+    /// top-right photo.
+    Aria,
+    /// PR4 — warm design two-column, tinted LEFT sidebar, circular ringed photo.
+    Saffron,
 }
 
 impl TypstTemplate {
@@ -115,6 +127,8 @@ impl TypstTemplate {
             TypstTemplate::Throughline => THROUGHLINE_TYP,
             TypstTemplate::Portrait => PORTRAIT_TYP,
             TypstTemplate::Lebenslauf => LEBENSLAUF_TYP,
+            TypstTemplate::Aria => ARIA_TYP,
+            TypstTemplate::Saffron => SAFFRON_TYP,
         }
     }
 
@@ -130,7 +144,7 @@ impl TypstTemplate {
     }
 
     /// Derive the Typst template from an existing [`Template`] configuration.
-    /// All ten live template IDs are handled exhaustively; no fallback needed.
+    /// All twelve live template IDs are handled exhaustively; no fallback needed.
     pub fn from_template(t: &Template) -> Self {
         match t.id {
             TemplateId::Atelier => TypstTemplate::Atelier,
@@ -150,6 +164,9 @@ impl TypstTemplate {
             // Phase 3b-i: two photo templates.
             TemplateId::Portrait => TypstTemplate::Portrait,
             TemplateId::Lebenslauf => TypstTemplate::Lebenslauf,
+            // PR4: two design photo / two-column templates.
+            TemplateId::Aria => TypstTemplate::Aria,
+            TemplateId::Saffron => TypstTemplate::Saffron,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/export/typst_engine/render.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/render.rs
@@ -375,6 +375,11 @@ pub(super) fn prepare_with_photo(
 ) -> crate::error::AppResult<PreparedRender> {
     let accent_str = normalise_accent(opts.accent.as_deref()).unwrap_or_default();
 
+    // Section placement is per-template (Aria/Saffron override the default table).
+    // Fall back to the default table (Classic) when no styling template is passed
+    // — only the two-column photo templates ever carry an override anyway.
+    let template_id = style_template.map(|t| t.id).unwrap_or_default();
+
     let json_data = JsonData {
         opts: JsonOpts {
             page_width_mm: opts.page.width_mm,
@@ -393,7 +398,7 @@ pub(super) fn prepare_with_photo(
             .sections
             .iter()
             .map(|s| {
-                let p = crate::theme::placement_for(&s.id);
+                let p = crate::theme::placement_for(template_id, &s.id);
                 JsonSection {
                     heading: s.heading.clone(),
                     blocks: s.blocks.iter().map(convert_block).collect(),

--- a/apps/desktop/src-tauri/src/export/typst_engine/templates/aria.typ
+++ b/apps/desktop/src-tauri/src/export/typst_engine/templates/aria.typ
@@ -1,0 +1,419 @@
+// Aria — minimalist two-column premium template with an untinted RIGHT sidebar.
+//
+// Design contract:
+//   Two-column layout: an UNTINTED sidebar (32 % width) on the RIGHT carries a
+//   rectangular top-right photo, contact details, and the placement-sidebar
+//   sections (Skills / Languages / Certifications — NOT Education, which reads in
+//   the main column per theme::placement_for's Aria override).  The main column
+//   (left) opens with a large 30pt name then Summary, Experience, Projects,
+//   Education, and any remaining non-sidebar sections.  The split is entirely
+//   data-driven via each section's `placement` field.
+//
+//   No sidebar tint: the sidebar is separated by whitespace only (the registry
+//   ships a white sidebar_bg, so no band rect is drawn).  Sidebar content is
+//   placed via page(background: ...) so it can align with the main-column top
+//   margin and repeat cleanly; it is rendered ONCE (page 1 only).  The main
+//   column reserves the right margin (main-right) so its text clears the sidebar.
+//
+//   Photo zone (top of the right sidebar):
+//     - has_photo == true : a rectangular /photo.png with subtle rounding.
+//     - has_photo == false: NOTHING (minimalist name-only fallback — no monogram).
+//       The candidate name always lives in the main-column header regardless.
+//
+//   ATS mode (data.opts.ats == true):
+//     - No sidebar, no photo. All sections linear in document order — mirrors
+//       portrait.typ's is-ats branch.
+//
+// Design: original.  Accent: slate (#46505C).  Name/headings: Manrope; body: Inter.
+// Headings are letter-spaced (heading_tracking) all-caps with hairline rules.
+// ORIGINALITY: designed from generic layout conventions only.
+//
+// Data contract (mirrors portrait.typ, plus data.style.heading_tracking):
+//   data.style.c_name / c_section / c_accent / c_body / c_date / c_rule
+//   data.style.font_name / font_heading / font_body
+//   data.style.section_all_caps / job_title_italic — bool
+//   data.style.heading_tracking — number: heading letter-spacing in em (0 = none)
+//   data.style.name_pt / section_pt / body_pt
+//   data.opts.page_width_mm / page_height_mm / accent / ats / has_photo / lang
+//   data.header.name / title / contact[]
+//   data.sections[].heading / blocks[] / placement / kind
+//
+// Guard: every optional dict key is checked before access.
+// Spacing scale constants come from _scale.typ (prepended by engine.rs).
+
+// ── Style resolution ──────────────────────────────────────────────────────────
+
+#let st = if "style" in data { data.style } else { (:) }
+
+#let c-name    = rgb(if "c_name"    in st { st.c_name    } else { "#111111" })
+#let c-section = rgb(if "c_section" in st { st.c_section } else { "#1A1A1A" })
+#let c-body    = rgb(if "c_body"    in st { st.c_body    } else { "#2A2A2A" })
+#let c-date    = rgb(if "c_date"    in st { st.c_date    } else { "#7A7A7A" })
+#let c-rule    = rgb(if "c_rule"    in st { st.c_rule    } else { "#D6D9DD" })
+
+#let c-accent = {
+  if "accent" in data.opts and data.opts.accent != "" {
+    rgb(data.opts.accent)
+  } else if "c_accent" in st {
+    rgb(st.c_accent)
+  } else {
+    rgb("#46505C")
+  }
+}
+
+#let font-name    = if "font_name"    in st { st.font_name    } else { "Manrope" }
+#let font-heading = if "font_heading" in st { st.font_heading } else { "Manrope" }
+#let font-body    = if "font_body"    in st { st.font_body    } else { "Inter" }
+
+#let all-caps     = if "section_all_caps"  in st { st.section_all_caps  } else { true }
+#let title-italic = if "job_title_italic"  in st { st.job_title_italic  } else { false }
+
+// Heading letter-spacing (tracking) in em. 0 → no tracking argument emitted.
+#let heading-tracking = if "heading_tracking" in st { st.heading_tracking } else { 0.0 }
+
+#let name-pt    = if "name_pt"    in st { st.name_pt    * 1pt } else { 30pt }
+#let section-pt = if "section_pt" in st { st.section_pt * 1pt } else { 10.5pt }
+#let body-pt    = if "body_pt"    in st { st.body_pt    * 1pt } else { 10pt }
+
+#let emphasize-edu = if "emphasize_education" in st { st.emphasize_education } else { false }
+
+// ── Layout constants ──────────────────────────────────────────────────────────
+
+#let page-w = data.opts.page_width_mm  * 1mm
+#let page-h = data.opts.page_height_mm * 1mm
+
+#let sidebar-frac = 0.32
+#let sidebar-w    = sidebar-frac * page-w
+#let gutter       = 10mm           // gap between main text and the sidebar
+#let margin-v     = 16mm           // generous top/bottom margin
+#let margin-l     = 16mm           // left margin (main column)
+
+// Main content reserves this much on the RIGHT so it clears the sidebar zone.
+#let main-right   = sidebar-w + gutter
+
+// ATS-mode side margins — comfortable single-column.
+#let ats-x        = 20mm
+
+// Sidebar internal padding.
+#let sb-pad-l = 6pt
+#let sb-pad-r = 8pt
+
+// Rectangular photo: fills the sidebar content width; portrait-ish aspect.
+#let photo-w = sidebar-w - sb-pad-l - sb-pad-r
+#let photo-h = photo-w * 1.15
+
+// ── Flags ─────────────────────────────────────────────────────────────────────
+
+#let is-ats    = if "ats"       in data.opts { data.opts.ats       } else { false }
+#let has-photo = if "has_photo" in data.opts { data.opts.has_photo } else { false }
+
+// ── Text / paragraph defaults ─────────────────────────────────────────────────
+
+#set text(
+  font: (font-body, "Inter", "Carlito", "Noto Sans"),
+  size: body-pt,
+  fill: c-body,
+  lang: data.opts.lang,
+)
+
+#set par(leading: lead, spacing: sp-para)
+
+// ── Heading helpers (all-caps + optional tracking) ─────────────────────────────
+
+#let heading-display(h) = if all-caps { upper(h) } else { h }
+
+#let heading-run(content, size, fill) = {
+  if heading-tracking != 0.0 {
+    text(
+      size: size,
+      weight: "bold",
+      fill: fill,
+      font: (font-heading, "Manrope", "Inter", "Carlito"),
+      tracking: heading-tracking * 1em,
+      content,
+    )
+  } else {
+    text(
+      size: size,
+      weight: "bold",
+      fill: fill,
+      font: (font-heading, "Manrope", "Inter", "Carlito"),
+      content,
+    )
+  }
+}
+
+// ── Rich-text helpers ─────────────────────────────────────────────────────────
+
+#let render-runs(runs) = {
+  for r in runs {
+    let t = if r.bold and r.italic {
+      text(weight: "bold", style: "italic", r.text)
+    } else if r.bold {
+      text(weight: "bold", r.text)
+    } else if r.italic {
+      text(style: "italic", r.text)
+    } else {
+      r.text
+    }
+    if "link" in r and r.link != none {
+      link(r.link, text(fill: c-accent, t))
+    } else {
+      t
+    }
+  }
+}
+
+// ── Entry renderer (main column) ───────────────────────────────────────────────
+
+#let render-entry(blk, bold-title) = {
+  let title-content = if "title" in blk { render-runs(blk.title) } else { "" }
+  let date-str = if "date" in blk and blk.date != none { blk.date } else { "" }
+  let title-weight = if bold-title { "bold" } else { "regular" }
+
+  block(breakable: false, width: 100%, {
+    grid(
+      columns: (1fr, auto),
+      gutter: 4pt,
+      text(weight: title-weight, fill: c-body, title-content),
+      text(weight: title-weight, fill: c-date, size: body-pt - 1pt, date-str),
+    )
+
+    if "subtitle" in blk and blk.subtitle != none and blk.subtitle.len() > 0 {
+      block(above: sp-subtitle-gap, below: sp-subtitle-below,
+        text(style: if title-italic { "italic" } else { "normal" }, fill: c-body, render-runs(blk.subtitle))
+      )
+    }
+
+    if "bullets" in blk and blk.bullets.len() > 0 {
+      block(above: sp-bullet-above, below: 0pt, {
+        set list(spacing: sp-bullet-gap)
+        for bullet in blk.bullets {
+          list.item(render-runs(bullet))
+        }
+      })
+    }
+  })
+}
+
+#let entry-bold-for-section(section) = {
+  let kind = if "kind" in section { section.kind } else { "" }
+  if kind == "education" { emphasize-edu } else { true }
+}
+
+#let render-block(b, bold-title) = {
+  if b.kind == "paragraph" {
+    if "runs" in b { block(below: 4pt, render-runs(b.runs)) }
+  } else if b.kind == "bullet" {
+    if "runs" in b { list.item(render-runs(b.runs)) }
+  } else if b.kind == "entry" {
+    block(below: sp-entry, render-entry(b, bold-title))
+  }
+}
+
+// ── Sidebar block renderer (compact) ───────────────────────────────────────────
+
+#let render-block-sb(b, bold-title) = {
+  if b.kind == "paragraph" {
+    if "runs" in b {
+      block(below: sp-sb-item, text(size: body-pt - 0.5pt, render-runs(b.runs)))
+    }
+  } else if b.kind == "bullet" {
+    if "runs" in b {
+      list.item(text(size: body-pt - 0.5pt, render-runs(b.runs)))
+    }
+  } else if b.kind == "entry" {
+    let blk = b
+    let title-content = if "title" in blk { render-runs(blk.title) } else { "" }
+    let date-str = if "date" in blk and blk.date != none { blk.date } else { "" }
+    let bold-t = if bold-title { "bold" } else { "regular" }
+    block(below: sp-sb-item, {
+      text(weight: bold-t, size: body-pt - 0.5pt, title-content)
+      if date-str != "" {
+        text(size: body-pt - 1.5pt, fill: c-date, " · " + date-str)
+      }
+      if "subtitle" in blk and blk.subtitle != none and blk.subtitle.len() > 0 {
+        block(above: 1pt,
+          text(style: "italic", size: body-pt - 1pt, render-runs(blk.subtitle))
+        )
+      }
+    })
+  }
+}
+
+// ── Section renderers ──────────────────────────────────────────────────────────
+
+#let render-section-main(section) = {
+  let bold-title = entry-bold-for-section(section)
+
+  block(above: sp-section-above, below: sp-rule-below, {
+    heading-run(heading-display(section.heading), section-pt, c-section)
+  })
+  line(length: 100%, stroke: 0.5pt + c-rule)
+  block(above: sp-after-rule, {
+    for b in section.blocks { render-block(b, bold-title) }
+  })
+}
+
+#let render-section-sb(section) = {
+  let bold-title = entry-bold-for-section(section)
+
+  block(above: sp-sb-section-above, below: sp-sb-rule-below, {
+    heading-run(heading-display(section.heading), section-pt - 0.5pt, c-accent)
+  })
+  line(length: 100%, stroke: 0.5pt + c-rule)
+  block(above: sp-sb-after-rule, {
+    for b in section.blocks { render-block-sb(b, bold-title) }
+  })
+}
+
+// ── Section partitioning (data-driven) ─────────────────────────────────────────
+
+#let section-placement(s) = {
+  if "placement" in s { s.placement } else { "main" }
+}
+
+#let sidebar-sections = data.sections.filter(s => section-placement(s) == "sidebar")
+#let main-sections    = data.sections.filter(s => section-placement(s) == "main")
+
+// ── Photo zone (rectangular, subtle rounding) — omitted entirely when no photo ─
+
+#let name-str = if "name" in data.header { data.header.name } else { "" }
+
+// ── Sidebar inner content (rendered once, placed in page background) ───────────
+
+#let sidebar-inner = box(
+  width: sidebar-w - sb-pad-l - sb-pad-r,
+  {
+    // Photo zone — rectangular with subtle rounding. No monogram fallback:
+    // when there is no photo the sidebar simply opens with the contact block.
+    if has-photo {
+      block(below: 12pt, width: 100%, {
+        box(
+          width: photo-w,
+          height: photo-h,
+          clip: true,
+          radius: 3pt,
+          image("photo.png", width: photo-w, height: photo-h, fit: "cover"),
+        )
+      })
+    }
+
+    // Contact line.
+    if "contact" in data.header and data.header.contact.len() > 0 {
+      block(below: 10pt, width: 100%, {
+        text(
+          size: body-pt - 1pt,
+          fill: c-body,
+          font: (font-body, "Inter", "Carlito"),
+          render-runs(data.header.contact),
+        )
+      })
+    }
+
+    // Sidebar sections.
+    for s in sidebar-sections {
+      render-section-sb(s)
+    }
+  }
+)
+
+// ── Main column header (page 1 only) ───────────────────────────────────────────
+
+#let main-header-content = {
+  block(below: sp-name-below, {
+    text(
+      size: name-pt,
+      weight: "bold",
+      fill: c-name,
+      font: (font-name, "Manrope", "Inter", "Carlito"),
+      name-str,
+    )
+  })
+
+  if "title" in data.header and data.header.title != none {
+    block(below: sp-header-title-below,
+      text(
+        size: section-pt,
+        style: if title-italic { "italic" } else { "normal" },
+        fill: c-accent,
+        data.header.title,
+      )
+    )
+  }
+
+  // Thin accent keyline anchoring the header.
+  block(above: 6pt, below: 12pt,
+    line(length: 100%, stroke: 1pt + c-accent)
+  )
+}
+
+// ── Render ──────────────────────────────────────────────────────────────────────
+
+#if is-ats {
+  // ATS: single-column, no sidebar, no photo (mirrors portrait.typ).
+  set page(
+    width:  page-w,
+    height: page-h,
+    margin: (top: margin-v, bottom: margin-v, left: ats-x, right: ats-x),
+  )
+
+  block(below: sp-name-below, {
+    text(
+      size: name-pt,
+      weight: "bold",
+      fill: c-name,
+      font: (font-name, "Manrope", "Inter", "Carlito"),
+      name-str,
+    )
+  })
+
+  if "title" in data.header and data.header.title != none {
+    block(below: sp-header-title-below,
+      text(
+        size: section-pt,
+        style: if title-italic { "italic" } else { "normal" },
+        fill: c-accent,
+        data.header.title,
+      )
+    )
+  }
+
+  if "contact" in data.header {
+    block(below: sp-header-contact,
+      text(size: body-pt, fill: c-body, render-runs(data.header.contact))
+    )
+  }
+
+  // All sections in document order (main + sidebar interleaved).
+  for section in data.sections {
+    render-section-main(section)
+  }
+} else {
+  // Two-column layout with the sidebar on the RIGHT. The band carries NO tint
+  // (Aria is separated by whitespace only); sidebar content is placed on page 1.
+  set page(
+    width:  page-w,
+    height: page-h,
+    margin: (top: margin-v, bottom: margin-v, left: margin-l, right: 0pt),
+    background: {
+      // No background rect — the sidebar is untinted by design.
+      // Sidebar content — rendered ONCE, on page 1 only, right-aligned.
+      context {
+        if counter(page).get().first() == 1 {
+          place(right + top, dx: -sb-pad-r, dy: margin-v, sidebar-inner)
+        }
+      }
+    },
+  )
+
+  // Main column header (reserve the right margin so it clears the sidebar).
+  pad(right: main-right, main-header-content)
+
+  // Main column sections.
+  pad(right: main-right, {
+    for section in main-sections {
+      render-section-main(section)
+    }
+  })
+}

--- a/apps/desktop/src-tauri/src/export/typst_engine/templates/portrait.typ
+++ b/apps/desktop/src-tauri/src/export/typst_engine/templates/portrait.typ
@@ -269,13 +269,23 @@
 
 // ── Candidate initials (no-photo fallback) ────────────────────────────────────
 
+// `.slice(0, 1)` is a BYTE offset and panics whenever the first character is
+// multi-byte in UTF-8 (Ü, É, Ł, …) — plausible in DACH/EU candidate names. Use
+// `.clusters()` (grapheme-cluster split) and take the first cluster instead, so
+// a name like "Über Ödegaard" renders safely instead of aborting the export.
+#let first-cluster(s) = {
+  let cl = s.clusters()
+  if cl.len() > 0 { cl.first() } else { "" }
+}
+
 #let name-str = if "name" in data.header { data.header.name } else { "" }
 #let initials = {
   let parts = name-str.split(" ").filter(p => p.len() > 0)
   if parts.len() >= 2 {
-    upper(parts.at(0).slice(0, 1)) + upper(parts.at(1).slice(0, 1))
+    upper(first-cluster(parts.at(0))) + upper(first-cluster(parts.at(1)))
   } else if parts.len() == 1 {
-    upper(parts.at(0).slice(0, 1))
+    let c = first-cluster(parts.at(0))
+    if c != "" { upper(c) } else { "?" }
   } else {
     "?"
   }

--- a/apps/desktop/src-tauri/src/export/typst_engine/templates/saffron.typ
+++ b/apps/desktop/src-tauri/src/export/typst_engine/templates/saffron.typ
@@ -1,0 +1,461 @@
+// Saffron — warm two-column premium template with a tinted LEFT sidebar.
+//
+// Design contract:
+//   Two-column layout: a warm-peach tinted sidebar (34 % width) on the LEFT
+//   carries a circular RINGED photo, contact details, and the placement-sidebar
+//   sections (Skills / Education / Languages).  The main column (right) carries
+//   the name/title header then Summary, Experience, Projects, Certifications, and
+//   any remaining non-sidebar sections.  Certifications read in the main column
+//   (per theme::placement_for's Saffron override) — the split is entirely data-
+//   driven via each section's `placement` field.
+//
+//   The sidebar band is drawn via page(background: ...) — same technique as
+//   Portrait/Atelier — so it repeats on every page without clipping.  Sidebar
+//   content is placed in the background too (page 1 only), with dy = margin_v so
+//   it aligns with the main-column top margin.
+//
+//   Photo zone (top of sidebar background):
+//     - has_photo == true : circular clip of /photo.png with a 1.5pt accent ring
+//       (the differentiator vs Portrait's ringless circle).
+//     - has_photo == false: a warm accent monogram circle (white initials).
+//
+//   ATS mode (data.opts.ats == true):
+//     - No sidebar background, no photo. All sections linear in document order.
+//
+// Design: original.  Accent: terracotta (#A85A3E).  Headings: Source Serif 4
+// small-caps; body: Inter.
+// ORIGINALITY: designed from generic layout conventions only.
+//
+// Data contract (mirrors portrait.typ):
+//   data.style.c_name / c_section / c_accent / c_body / c_date / c_rule
+//   data.style.font_name / font_heading / font_body
+//   data.style.section_all_caps / section_small_caps / job_title_italic — bool
+//   data.style.name_pt / section_pt / body_pt
+//   data.opts.page_width_mm / page_height_mm / accent / ats / has_photo / lang
+//   data.header.name / title / contact[]
+//   data.sections[].heading / blocks[] / placement / kind
+//
+// Guard: every optional dict key is checked before access.
+// Spacing scale constants come from _scale.typ (prepended by engine.rs).
+
+// ── Style resolution ──────────────────────────────────────────────────────────
+
+#let st = if "style" in data { data.style } else { (:) }
+
+#let c-name    = rgb(if "c_name"    in st { st.c_name    } else { "#3A2E28" })
+#let c-section = rgb(if "c_section" in st { st.c_section } else { "#A85A3E" })
+#let c-body    = rgb(if "c_body"    in st { st.c_body    } else { "#302A26" })
+#let c-date    = rgb(if "c_date"    in st { st.c_date    } else { "#8A7A6E" })
+#let c-rule    = rgb(if "c_rule"    in st { st.c_rule    } else { "#E2C9B4" })
+
+#let c-accent = {
+  if "accent" in data.opts and data.opts.accent != "" {
+    rgb(data.opts.accent)
+  } else if "c_accent" in st {
+    rgb(st.c_accent)
+  } else {
+    rgb("#A85A3E")
+  }
+}
+
+// Sidebar background — warm peach tint.
+#let c-sidebar-bg = rgb("#F5E7DA")
+
+#let font-name    = if "font_name"    in st { st.font_name    } else { "Source Serif 4" }
+#let font-heading = if "font_heading" in st { st.font_heading } else { "Source Serif 4" }
+#let font-body    = if "font_body"    in st { st.font_body    } else { "Inter" }
+
+#let all-caps     = if "section_all_caps"   in st { st.section_all_caps   } else { false }
+#let small-caps   = if "section_small_caps" in st { st.section_small_caps } else { true }
+#let title-italic = if "job_title_italic"   in st { st.job_title_italic   } else { true }
+
+#let name-pt    = if "name_pt"    in st { st.name_pt    * 1pt } else { 24pt }
+#let section-pt = if "section_pt" in st { st.section_pt * 1pt } else { 11pt }
+#let body-pt    = if "body_pt"    in st { st.body_pt    * 1pt } else { 10.5pt }
+
+#let emphasize-edu = if "emphasize_education" in st { st.emphasize_education } else { false }
+
+// ── Layout constants ──────────────────────────────────────────────────────────
+
+#let page-w = data.opts.page_width_mm  * 1mm
+#let page-h = data.opts.page_height_mm * 1mm
+
+#let sidebar-frac = 0.34
+#let sidebar-w    = sidebar-frac * page-w
+#let gutter       = 9mm            // gap between sidebar band edge and main text
+#let margin-v     = 14mm           // top/bottom margin
+#let margin-r     = 14mm           // right margin
+
+// Main content left margin = sidebar band width + gutter.
+#let main-left    = sidebar-w + gutter
+
+// ATS-mode left margin — comfortable single-column.
+#let ats-left     = 20mm
+
+// Photo circle diameter: fills ~72 % of the sidebar width.
+#let photo-d = 46mm
+// Ring stroke thickness (the Saffron differentiator vs Portrait's ringless circle).
+#let ring-w  = 1.5pt
+
+// Sidebar internal padding.
+#let sb-pad-l = 8pt
+#let sb-pad-r = 6pt
+
+// ── Flags ─────────────────────────────────────────────────────────────────────
+
+#let is-ats    = if "ats"       in data.opts { data.opts.ats       } else { false }
+#let has-photo = if "has_photo" in data.opts { data.opts.has_photo } else { false }
+
+// ── Text / paragraph defaults ─────────────────────────────────────────────────
+
+#set text(
+  font: (font-body, "Inter", "Carlito", "Noto Sans"),
+  size: body-pt,
+  fill: c-body,
+  lang: data.opts.lang,
+)
+
+#set par(leading: lead, spacing: sp-para)
+
+// ── Heading display (small-caps / all-caps aware) ──────────────────────────────
+
+#let heading-display(h) = {
+  let base = if all-caps { upper(h) } else { h }
+  if small-caps { smallcaps(base) } else { base }
+}
+
+// ── Rich-text helpers ─────────────────────────────────────────────────────────
+
+#let render-runs(runs) = {
+  for r in runs {
+    let t = if r.bold and r.italic {
+      text(weight: "bold", style: "italic", r.text)
+    } else if r.bold {
+      text(weight: "bold", r.text)
+    } else if r.italic {
+      text(style: "italic", r.text)
+    } else {
+      r.text
+    }
+    if "link" in r and r.link != none {
+      link(r.link, text(fill: c-accent, t))
+    } else {
+      t
+    }
+  }
+}
+
+// ── Entry renderer (main column) ───────────────────────────────────────────────
+
+#let render-entry(blk, bold-title) = {
+  let title-content = if "title" in blk { render-runs(blk.title) } else { "" }
+  let date-str = if "date" in blk and blk.date != none { blk.date } else { "" }
+  let title-weight = if bold-title { "bold" } else { "regular" }
+
+  block(breakable: false, width: 100%, {
+    grid(
+      columns: (1fr, auto),
+      gutter: 4pt,
+      text(weight: title-weight, fill: c-body, title-content),
+      text(weight: title-weight, fill: c-date, size: body-pt - 1pt, date-str),
+    )
+
+    if "subtitle" in blk and blk.subtitle != none and blk.subtitle.len() > 0 {
+      block(above: sp-subtitle-gap, below: sp-subtitle-below,
+        text(style: if title-italic { "italic" } else { "normal" }, fill: c-body, render-runs(blk.subtitle))
+      )
+    }
+
+    if "bullets" in blk and blk.bullets.len() > 0 {
+      block(above: sp-bullet-above, below: 0pt, {
+        set list(spacing: sp-bullet-gap)
+        for bullet in blk.bullets {
+          list.item(render-runs(bullet))
+        }
+      })
+    }
+  })
+}
+
+#let entry-bold-for-section(section) = {
+  let kind = if "kind" in section { section.kind } else { "" }
+  if kind == "education" { emphasize-edu } else { true }
+}
+
+#let render-block(b, bold-title) = {
+  if b.kind == "paragraph" {
+    if "runs" in b { block(below: 4pt, render-runs(b.runs)) }
+  } else if b.kind == "bullet" {
+    if "runs" in b { list.item(render-runs(b.runs)) }
+  } else if b.kind == "entry" {
+    block(below: sp-entry, render-entry(b, bold-title))
+  }
+}
+
+// ── Sidebar block renderer (compact) ───────────────────────────────────────────
+
+#let render-block-sb(b, bold-title) = {
+  if b.kind == "paragraph" {
+    if "runs" in b {
+      block(below: sp-sb-item, text(size: body-pt - 0.5pt, render-runs(b.runs)))
+    }
+  } else if b.kind == "bullet" {
+    if "runs" in b {
+      list.item(text(size: body-pt - 0.5pt, render-runs(b.runs)))
+    }
+  } else if b.kind == "entry" {
+    let blk = b
+    let title-content = if "title" in blk { render-runs(blk.title) } else { "" }
+    let date-str = if "date" in blk and blk.date != none { blk.date } else { "" }
+    let bold-t = if bold-title { "bold" } else { "regular" }
+    block(below: sp-sb-item, {
+      text(weight: bold-t, size: body-pt - 0.5pt, title-content)
+      if date-str != "" {
+        text(size: body-pt - 1.5pt, fill: c-date, " · " + date-str)
+      }
+      if "subtitle" in blk and blk.subtitle != none and blk.subtitle.len() > 0 {
+        block(above: 1pt,
+          text(style: "italic", size: body-pt - 1pt, render-runs(blk.subtitle))
+        )
+      }
+    })
+  }
+}
+
+// ── Section renderers ──────────────────────────────────────────────────────────
+
+#let render-section-main(section) = {
+  let bold-title = entry-bold-for-section(section)
+
+  block(above: sp-section-above, below: sp-rule-below, {
+    text(
+      size: section-pt,
+      weight: "bold",
+      fill: c-section,
+      font: (font-heading, "Source Serif 4", "Carlito"),
+      heading-display(section.heading),
+    )
+  })
+  line(length: 100%, stroke: 0.5pt + c-rule)
+  block(above: sp-after-rule, {
+    for b in section.blocks { render-block(b, bold-title) }
+  })
+}
+
+#let render-section-sb(section) = {
+  let bold-title = entry-bold-for-section(section)
+
+  block(above: sp-sb-section-above, below: sp-sb-rule-below, {
+    text(
+      size: section-pt - 0.5pt,
+      weight: "bold",
+      fill: c-accent,
+      font: (font-heading, "Source Serif 4", "Carlito"),
+      heading-display(section.heading),
+    )
+  })
+  line(length: 100%, stroke: 0.5pt + c-rule)
+  block(above: sp-sb-after-rule, {
+    for b in section.blocks { render-block-sb(b, bold-title) }
+  })
+}
+
+// ── Section partitioning (data-driven) ─────────────────────────────────────────
+
+#let section-placement(s) = {
+  if "placement" in s { s.placement } else { "main" }
+}
+
+#let sidebar-sections = data.sections.filter(s => section-placement(s) == "sidebar")
+#let main-sections    = data.sections.filter(s => section-placement(s) == "main")
+
+// ── Candidate initials (no-photo fallback) ─────────────────────────────────────
+
+#let name-str = if "name" in data.header { data.header.name } else { "" }
+#let initials = {
+  let parts = name-str.split(" ").filter(p => p.len() > 0)
+  if parts.len() >= 2 {
+    upper(parts.at(0).slice(0, 1)) + upper(parts.at(1).slice(0, 1))
+  } else if parts.len() == 1 {
+    upper(parts.at(0).slice(0, 1))
+  } else {
+    "?"
+  }
+}
+
+// ── Photo zone (circular, ringed) ──────────────────────────────────────────────
+//
+// The 1.5pt accent ring is drawn as its OWN stroked circle (fill: none),
+// stacked via `place` over the clipped photo — NOT as the `stroke` of the
+// clipped photo box itself. A clipped box's own stroke can be half-clipped at
+// the content edge (Typst clips at the box's inner bound before the stroke is
+// fully painted), which would render the ring at roughly half its 1.5pt weight.
+// Stacking a separate, unclipped circle guarantees the full ring is visible —
+// the Saffron differentiator vs Portrait's ringless circle.
+//
+// Geometry: the ring circle has radius `photo-d/2 - ring-w/2` so its stroke's
+// outer edge lands exactly at `photo-d/2` (flush with the outer box, no
+// overflow); the inner photo/monogram circle is sized to `inner-d` so its edge
+// meets the ring's inner edge with no gap and no overlap.
+
+#let inner-d = photo-d - 2 * ring-w
+
+#let photo-zone = box(width: photo-d, height: photo-d, {
+  place(center + horizon,
+    circle(radius: photo-d / 2 - ring-w / 2, stroke: ring-w + c-accent, fill: none)
+  )
+  place(center + horizon,
+    if has-photo {
+      box(
+        width: inner-d,
+        height: inner-d,
+        clip: true,
+        radius: inner-d / 2,
+        image("photo.png", width: inner-d, height: inner-d, fit: "cover"),
+      )
+    } else {
+      circle(
+        radius: inner-d / 2,
+        fill: c-accent,
+        stroke: none,
+        text(
+          size: name-pt * 0.75,
+          weight: "bold",
+          fill: white,
+          font: (font-name, "Source Serif 4", "Carlito"),
+          initials,
+        ),
+      )
+    }
+  )
+})
+
+// ── Sidebar inner content (rendered once, placed in page background) ───────────
+
+#let sidebar-inner = box(
+  width: sidebar-w - sb-pad-l - sb-pad-r,
+  {
+    // Photo zone.
+    block(below: 12pt, width: 100%, align(center, photo-zone))
+
+    // Contact line.
+    if "contact" in data.header and data.header.contact.len() > 0 {
+      block(below: 10pt, width: 100%, {
+        text(
+          size: body-pt - 1pt,
+          fill: c-body,
+          font: (font-body, "Inter", "Carlito"),
+          render-runs(data.header.contact),
+        )
+      })
+    }
+
+    // Sidebar sections.
+    for s in sidebar-sections {
+      render-section-sb(s)
+    }
+  }
+)
+
+// ── Main column header (page 1 only) ───────────────────────────────────────────
+
+#let main-header-content = {
+  block(below: sp-name-below, {
+    text(
+      size: name-pt,
+      weight: "bold",
+      fill: c-name,
+      font: (font-name, "Source Serif 4", "Carlito"),
+      name-str,
+    )
+  })
+
+  if "title" in data.header and data.header.title != none {
+    block(below: sp-header-title-below,
+      text(
+        size: section-pt,
+        style: if title-italic { "italic" } else { "normal" },
+        fill: c-body,
+        data.header.title,
+      )
+    )
+  }
+
+  // Thin accent keyline.
+  block(above: 6pt, below: 10pt,
+    line(length: 100%, stroke: 1.5pt + c-accent)
+  )
+}
+
+// ── Render ──────────────────────────────────────────────────────────────────────
+
+#if is-ats {
+  // ATS: single-column, no sidebar, no photo.
+  set page(
+    width:  page-w,
+    height: page-h,
+    margin: (top: margin-v, bottom: margin-v, left: ats-left, right: margin-r),
+  )
+
+  block(below: sp-name-below, {
+    text(
+      size: name-pt,
+      weight: "bold",
+      fill: c-name,
+      font: (font-name, "Source Serif 4", "Carlito"),
+      name-str,
+    )
+  })
+
+  if "title" in data.header and data.header.title != none {
+    block(below: sp-header-title-below,
+      text(
+        size: section-pt,
+        style: if title-italic { "italic" } else { "normal" },
+        fill: c-body,
+        data.header.title,
+      )
+    )
+  }
+
+  if "contact" in data.header {
+    block(below: sp-header-contact,
+      text(size: body-pt, fill: c-body, render-runs(data.header.contact))
+    )
+  }
+
+  // All sections in document order (main + sidebar interleaved).
+  for section in data.sections {
+    render-section-main(section)
+  }
+} else {
+  // Two-column layout using page(background: ...) to carry the LEFT sidebar band
+  // + sidebar content — same technique as Portrait.
+  set page(
+    width:  page-w,
+    height: page-h,
+    margin: (top: margin-v, bottom: margin-v, left: 0pt, right: margin-r),
+    background: {
+      // Full-height tinted sidebar band — drawn on EVERY page for continuity.
+      place(left + top,
+        rect(width: sidebar-w, height: 100%, fill: c-sidebar-bg)
+      )
+      // Sidebar content — rendered ONCE, on page 1 only.
+      context {
+        if counter(page).get().first() == 1 {
+          place(left + top, dx: sb-pad-l, dy: margin-v, sidebar-inner)
+        }
+      }
+    },
+  )
+
+  // Main column header (inset by main-left so it clears the sidebar band).
+  pad(left: main-left, main-header-content)
+
+  // Main column sections.
+  pad(left: main-left, {
+    for section in main-sections {
+      render-section-main(section)
+    }
+  })
+}

--- a/apps/desktop/src-tauri/src/export/typst_engine/templates/saffron.typ
+++ b/apps/desktop/src-tauri/src/export/typst_engine/templates/saffron.typ
@@ -271,13 +271,23 @@
 
 // ── Candidate initials (no-photo fallback) ─────────────────────────────────────
 
+// `.slice(0, 1)` is a BYTE offset and panics whenever the first character is
+// multi-byte in UTF-8 (Ü, É, Ł, …) — plausible in DACH/EU candidate names. Use
+// `.clusters()` (grapheme-cluster split) and take the first cluster instead, so
+// a name like "Über Ödegaard" renders safely instead of aborting the export.
+#let first-cluster(s) = {
+  let cl = s.clusters()
+  if cl.len() > 0 { cl.first() } else { "" }
+}
+
 #let name-str = if "name" in data.header { data.header.name } else { "" }
 #let initials = {
   let parts = name-str.split(" ").filter(p => p.len() > 0)
   if parts.len() >= 2 {
-    upper(parts.at(0).slice(0, 1)) + upper(parts.at(1).slice(0, 1))
+    upper(first-cluster(parts.at(0))) + upper(first-cluster(parts.at(1)))
   } else if parts.len() == 1 {
-    upper(parts.at(0).slice(0, 1))
+    let c = first-cluster(parts.at(0))
+    if c != "" { upper(c) } else { "?" }
   } else {
     "?"
   }

--- a/apps/desktop/src-tauri/src/export/typst_engine/test.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/test.rs
@@ -2014,6 +2014,28 @@ fn portrait_render_no_photo_produces_valid_pdf() {
     assert!(bytes.starts_with(b"%PDF"));
 }
 
+// (1b-multibyte) Portrait's no-photo monogram fallback slices the candidate's
+// first name to build initials. A byte-offset `.slice(0, 1)` panics Typst
+// whenever the first character is multi-byte in UTF-8 (plausible DACH/EU
+// names) — this pins the grapheme-safe fix (`.clusters().first()`).
+#[test]
+fn portrait_no_photo_monogram_is_grapheme_safe_for_multibyte_names() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+
+    let text = "Über Ödegaard\nuber@example.com\n\nSUMMARY\nEngineer.\n";
+    let model = model_from_resume_text(text);
+    let t = template_style(TemplateId::Portrait);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Portrait,
+        &opts_photo(false),
+        Some(&t),
+        None,
+    )
+    .expect("portrait no-photo render with a multi-byte first character must not panic");
+    assert!(bytes.starts_with(b"%PDF"));
+}
+
 // (1c) Portrait ATS mode → valid PDF with linear reading order.
 #[test]
 fn portrait_ats_harness() {
@@ -2488,13 +2510,23 @@ fn aria_ats_mode_linearizes_reading_order() {
         .collect::<Vec<_>>()
         .join(" ")
         .to_lowercase();
-    // Experience before Education before Skills in the linear reading order.
+    // ATS linearization (`model::transform::linearize`) reorders `data.sections`
+    // to the fixed canonical ATS reading order (Summary, Experience, Skills,
+    // Projects, Education, Certifications, Languages, Awards, Publications) — it
+    // ignores column `placement` entirely, which only shapes the two-column
+    // VISUAL layout and never applies in ATS mode. So the Aria placement override
+    // (Education → main column) has no bearing here: the expected order is the
+    // canonical ATS order, not the placement-projected one.
     let exp = lower.find("experience").expect("experience present");
-    let edu = lower.find("education").expect("education present");
     let skl = lower.find("skills").expect("skills present");
+    let edu = lower.find("education").expect("education present");
+    let cert = lower
+        .find("certifications")
+        .expect("certifications present");
     assert!(
-        exp < edu && edu < skl,
-        "aria ATS reading order wrong: {lower}"
+        exp < skl && skl < edu && edu < cert,
+        "aria ATS reading order wrong (expected canonical ATS order: \
+         experience < skills < education < certifications): {lower}"
     );
 }
 
@@ -2628,6 +2660,27 @@ fn saffron_render_no_photo_produces_valid_pdf() {
     );
 }
 
+// Saffron's no-photo monogram fallback shares Portrait's slicing logic (copied
+// pattern) — same grapheme-safety pin as
+// `portrait_no_photo_monogram_is_grapheme_safe_for_multibyte_names`.
+#[test]
+fn saffron_no_photo_monogram_is_grapheme_safe_for_multibyte_names() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+
+    let text = "Über Ödegaard\nuber@example.com\n\nSUMMARY\nEngineer.\n";
+    let model = model_from_resume_text(text);
+    let t = template_style(TemplateId::Saffron);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Saffron,
+        &opts_photo(false),
+        Some(&t),
+        None,
+    )
+    .expect("saffron no-photo render with a multi-byte first character must not panic");
+    assert!(bytes.starts_with(b"%PDF"));
+}
+
 #[test]
 fn saffron_ats_mode_drops_photo() {
     use crate::export::typst_engine::render_resume_svg_pages_with_photo;
@@ -2683,14 +2736,22 @@ fn saffron_ats_mode_linearizes_reading_order() {
         .collect::<Vec<_>>()
         .join(" ")
         .to_lowercase();
+    // Same semantics as `aria_ats_mode_linearizes_reading_order`: ATS mode uses
+    // the canonical ATS order (Summary, Experience, Skills, Projects, Education,
+    // Certifications, …) regardless of Saffron's placement override
+    // (Certifications → main column), which is visual-only and never applies in
+    // ATS mode. Include `education` so the expected order isn't coincidentally
+    // satisfied by only checking two of the four sections.
     let exp = lower.find("experience").expect("experience present");
     let skl = lower.find("skills").expect("skills present");
+    let edu = lower.find("education").expect("education present");
     let cert = lower
         .find("certifications")
         .expect("certifications present");
     assert!(
-        exp < skl && skl < cert,
-        "saffron ATS reading order wrong: {lower}"
+        exp < skl && skl < edu && edu < cert,
+        "saffron ATS reading order wrong (expected canonical ATS order: \
+         experience < skills < education < certifications): {lower}"
     );
 }
 

--- a/apps/desktop/src-tauri/src/export/typst_engine/test.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/test.rs
@@ -363,8 +363,10 @@ fn every_template_renders_a_valid_pdf() {
         TemplateId::Lebenslauf,
         TemplateId::Cadence,
         TemplateId::Regent,
+        TemplateId::Aria,
+        TemplateId::Saffron,
     ];
-    assert_eq!(ids.len(), 10, "expected the ten canonical templates");
+    assert_eq!(ids.len(), 12, "expected the twelve canonical templates");
 
     let model = model_from_resume_text(FIXTURE_RESUME);
     for id in ids {
@@ -2331,6 +2333,465 @@ fn lebenslauf_write_sample_pdfs_for_review() {
     assert!(bytes_with.starts_with(b"%PDF"));
 }
 
+// ── Aria / Saffron (PR4 design two-column photo templates) ────────────────────
+//
+// Both are photo-capable two-column templates rendered through bespoke `.typ`
+// sources.  Per template we assert: valid PDF with + without a photo (fallback
+// path), ATS mode drops the photo (SVG `<image>` assert like Lebenslauf), the
+// document-accent override changes the output, `is_two_column` is true, a 2-page
+// fixture keeps the sidebar band to page 1, and the per-template placement
+// override lands the moved section in the main column.
+
+/// Fixture with distinct EDUCATION + CERTIFICATIONS + SKILLS sections so the
+/// per-template placement override can be asserted at the serialized-JSON level.
+const PLACEMENT_FIXTURE: &str = "\
+Jane Doe
+jane@example.com | https://linkedin.com/in/janedoe
+
+EXPERIENCE
+Acme Corp  2020 - Present
+Senior Engineer
+- Built a distributed task scheduler
+
+EDUCATION
+State University  2013 - 2017
+BSc Computer Science
+
+SKILLS
+- Rust, Go, TypeScript
+
+CERTIFICATIONS
+- AWS Certified Solutions Architect
+";
+
+/// Serialized column placement (`"main"` / `"sidebar"`) for the section with the
+/// given canonical `kind`, as produced by `prepare` for `template_id`. This is
+/// the single substrate that both the PDF and DOCX two-column splits consume.
+fn placement_of(template_id: TemplateId, kind: &str) -> String {
+    use super::render::{prepare, PreparedRender};
+    let model = model_from_resume_text(PLACEMENT_FIXTURE);
+    let t = Template::get(template_id);
+    let source = TypstTemplate::from_template(&t).source_with_scale();
+    let PreparedRender { data_json, .. } =
+        prepare(&model, &source, &opts_a4(), Some(&t)).expect("prepare should succeed");
+    let v: serde_json::Value =
+        serde_json::from_slice(&data_json).expect("data.json must be valid JSON");
+    let sections = v["sections"].as_array().expect("sections array");
+    let sec = sections
+        .iter()
+        .find(|s| s["kind"] == kind)
+        .unwrap_or_else(|| panic!("section kind {kind:?} not found in {sections:?}"));
+    sec["placement"]
+        .as_str()
+        .expect("placement string")
+        .to_string()
+}
+
+// ── Aria ────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn aria_render_with_photo_produces_valid_pdf() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+    let photo_png = resolve_photo(&fixture_photo_data_url());
+    assert!(photo_png.is_some(), "fixture photo must resolve");
+    let model = model_from_resume_text(ATELIER_FIXTURE);
+    let t = template_style(TemplateId::Aria);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Aria,
+        &opts_photo(false),
+        Some(&t),
+        photo_png,
+    )
+    .expect("render_pdf_with_photo(aria) should succeed");
+    assert!(!bytes.is_empty(), "Aria PDF must not be empty");
+    assert!(
+        bytes.starts_with(b"%PDF"),
+        "Aria output must start with %PDF"
+    );
+}
+
+#[test]
+fn aria_render_no_photo_produces_valid_pdf() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+    let model = model_from_resume_text(ATELIER_FIXTURE);
+    let t = template_style(TemplateId::Aria);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Aria,
+        &opts_photo(false),
+        Some(&t),
+        None,
+    )
+    .expect("render_pdf_with_photo(aria, no-photo) should succeed");
+    assert!(
+        bytes.starts_with(b"%PDF"),
+        "Aria no-photo must start with %PDF"
+    );
+}
+
+#[test]
+fn aria_ats_mode_drops_photo() {
+    use crate::export::typst_engine::render_resume_svg_pages_with_photo;
+    let model = model_from_resume_text(ATELIER_FIXTURE);
+    let t = template_style(TemplateId::Aria);
+    let photo_png = resolve_photo(&fixture_photo_data_url());
+    assert!(photo_png.is_some(), "fixture photo must resolve");
+
+    // Non-ATS + photo → embedded as an SVG <image>.
+    let shown = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Aria,
+        &opts_photo(false),
+        Some(&t),
+        photo_png.clone(),
+    )
+    .expect("aria non-ats svg");
+    assert!(
+        shown.join("").contains("<image"),
+        "non-ATS Aria with a photo must embed it as an <image> element"
+    );
+
+    // ATS + same photo → linear, no image.
+    let ats = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Aria,
+        &opts_photo(true),
+        Some(&t),
+        photo_png,
+    )
+    .expect("aria ats svg");
+    assert!(
+        !ats.join("").contains("<image"),
+        "ATS-mode Aria must drop the photo (no <image> element)"
+    );
+}
+
+#[test]
+fn aria_ats_mode_linearizes_reading_order() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+    let mut model = model_from_resume_text(PLACEMENT_FIXTURE);
+    // Export path linearizes for ATS; replicate it here for the reading-order check.
+    crate::model::transform::linearize(&mut model);
+    let t = template_style(TemplateId::Aria);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Aria,
+        &opts_photo(true),
+        Some(&t),
+        None,
+    )
+    .expect("aria ats pdf");
+    let extracted = pdf_extract::extract_text_from_mem(&bytes).expect("pdf-extract");
+    let lower: String = extracted
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+    // Experience before Education before Skills in the linear reading order.
+    let exp = lower.find("experience").expect("experience present");
+    let edu = lower.find("education").expect("education present");
+    let skl = lower.find("skills").expect("skills present");
+    assert!(
+        exp < edu && edu < skl,
+        "aria ATS reading order wrong: {lower}"
+    );
+}
+
+#[test]
+fn aria_accent_override_changes_output() {
+    use crate::export::typst_engine::render_resume_svg_pages_with_photo;
+    let model = model_from_resume_text(ATELIER_FIXTURE);
+    let t = template_style(TemplateId::Aria);
+
+    let base = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Aria,
+        &opts_photo(false),
+        Some(&t),
+        None,
+    )
+    .expect("aria base svg")
+    .join("");
+
+    let mut accented_opts = opts_photo(false);
+    accented_opts.accent = Some("#FF00AA".to_string());
+    let accented = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Aria,
+        &accented_opts,
+        Some(&t),
+        None,
+    )
+    .expect("aria accent svg")
+    .join("");
+
+    assert_ne!(
+        base, accented,
+        "a document-accent override must change Aria's rendered output"
+    );
+    assert!(
+        accented.to_lowercase().contains("ff00aa"),
+        "the accent hex should appear in Aria's SVG fills"
+    );
+}
+
+#[test]
+fn aria_is_two_column() {
+    assert!(crate::theme::is_two_column(TemplateId::Aria));
+}
+
+#[test]
+fn aria_multipage_sidebar_renders_once() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+    let model = model_from_resume_text(ATELIER_MULTIPAGE);
+    let t = template_style(TemplateId::Aria);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Aria,
+        &opts_photo(false),
+        Some(&t),
+        None,
+    )
+    .expect("render_pdf_with_photo(aria, multipage) should succeed");
+    assert!(bytes.starts_with(b"%PDF"));
+    assert!(
+        count_pdf_pages(&bytes) >= 2,
+        "multi-page fixture must produce ≥2 pages"
+    );
+    let lower = pdf_extract::extract_text_from_mem(&bytes)
+        .expect("pdf-extract")
+        .to_lowercase();
+    assert!(
+        lower.contains("grafana"),
+        "sidebar skill missing\n---\n{lower}"
+    );
+    assert_eq!(
+        lower.matches("grafana").count(),
+        1,
+        "Aria sidebar must render once across pages\n---\n{lower}"
+    );
+}
+
+#[test]
+fn aria_moves_education_to_main_column() {
+    assert_eq!(
+        placement_of(TemplateId::Aria, "education"),
+        "main",
+        "Aria: Education must be placed in the main column"
+    );
+    // The rest of the sidebar set is unchanged for Aria.
+    assert_eq!(placement_of(TemplateId::Aria, "skills"), "sidebar");
+    assert_eq!(placement_of(TemplateId::Aria, "certifications"), "sidebar");
+}
+
+// ── Saffron ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn saffron_render_with_photo_produces_valid_pdf() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+    let photo_png = resolve_photo(&fixture_photo_data_url());
+    assert!(photo_png.is_some(), "fixture photo must resolve");
+    let model = model_from_resume_text(ATELIER_FIXTURE);
+    let t = template_style(TemplateId::Saffron);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Saffron,
+        &opts_photo(false),
+        Some(&t),
+        photo_png,
+    )
+    .expect("render_pdf_with_photo(saffron) should succeed");
+    assert!(!bytes.is_empty(), "Saffron PDF must not be empty");
+    assert!(
+        bytes.starts_with(b"%PDF"),
+        "Saffron output must start with %PDF"
+    );
+}
+
+#[test]
+fn saffron_render_no_photo_produces_valid_pdf() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+    let model = model_from_resume_text(ATELIER_FIXTURE);
+    let t = template_style(TemplateId::Saffron);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Saffron,
+        &opts_photo(false),
+        Some(&t),
+        None,
+    )
+    .expect("render_pdf_with_photo(saffron, no-photo) should succeed");
+    assert!(
+        bytes.starts_with(b"%PDF"),
+        "Saffron no-photo must start with %PDF"
+    );
+}
+
+#[test]
+fn saffron_ats_mode_drops_photo() {
+    use crate::export::typst_engine::render_resume_svg_pages_with_photo;
+    let model = model_from_resume_text(ATELIER_FIXTURE);
+    let t = template_style(TemplateId::Saffron);
+    let photo_png = resolve_photo(&fixture_photo_data_url());
+    assert!(photo_png.is_some(), "fixture photo must resolve");
+
+    let shown = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Saffron,
+        &opts_photo(false),
+        Some(&t),
+        photo_png.clone(),
+    )
+    .expect("saffron non-ats svg");
+    assert!(
+        shown.join("").contains("<image"),
+        "non-ATS Saffron with a photo must embed it as an <image> element"
+    );
+
+    let ats = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Saffron,
+        &opts_photo(true),
+        Some(&t),
+        photo_png,
+    )
+    .expect("saffron ats svg");
+    assert!(
+        !ats.join("").contains("<image"),
+        "ATS-mode Saffron must drop the photo (no <image> element)"
+    );
+}
+
+#[test]
+fn saffron_ats_mode_linearizes_reading_order() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+    let mut model = model_from_resume_text(PLACEMENT_FIXTURE);
+    crate::model::transform::linearize(&mut model);
+    let t = template_style(TemplateId::Saffron);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Saffron,
+        &opts_photo(true),
+        Some(&t),
+        None,
+    )
+    .expect("saffron ats pdf");
+    let extracted = pdf_extract::extract_text_from_mem(&bytes).expect("pdf-extract");
+    let lower: String = extracted
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+    let exp = lower.find("experience").expect("experience present");
+    let skl = lower.find("skills").expect("skills present");
+    let cert = lower
+        .find("certifications")
+        .expect("certifications present");
+    assert!(
+        exp < skl && skl < cert,
+        "saffron ATS reading order wrong: {lower}"
+    );
+}
+
+#[test]
+fn saffron_accent_override_changes_output() {
+    use crate::export::typst_engine::render_resume_svg_pages_with_photo;
+    let model = model_from_resume_text(ATELIER_FIXTURE);
+    let t = template_style(TemplateId::Saffron);
+
+    let base = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Saffron,
+        &opts_photo(false),
+        Some(&t),
+        None,
+    )
+    .expect("saffron base svg")
+    .join("");
+
+    let mut accented_opts = opts_photo(false);
+    accented_opts.accent = Some("#FF00AA".to_string());
+    let accented = render_resume_svg_pages_with_photo(
+        &model,
+        TypstTemplate::Saffron,
+        &accented_opts,
+        Some(&t),
+        None,
+    )
+    .expect("saffron accent svg")
+    .join("");
+
+    assert_ne!(
+        base, accented,
+        "a document-accent override must change Saffron's rendered output"
+    );
+    assert!(
+        accented.to_lowercase().contains("ff00aa"),
+        "the accent hex should appear in Saffron's SVG fills"
+    );
+}
+
+#[test]
+fn saffron_is_two_column() {
+    assert!(crate::theme::is_two_column(TemplateId::Saffron));
+}
+
+#[test]
+fn saffron_multipage_sidebar_renders_once() {
+    use crate::export::typst_engine::render_pdf_with_photo;
+    let model = model_from_resume_text(ATELIER_MULTIPAGE);
+    let t = template_style(TemplateId::Saffron);
+    let bytes = render_pdf_with_photo(
+        &model,
+        TypstTemplate::Saffron,
+        &opts_photo(false),
+        Some(&t),
+        None,
+    )
+    .expect("render_pdf_with_photo(saffron, multipage) should succeed");
+    assert!(bytes.starts_with(b"%PDF"));
+    assert!(
+        count_pdf_pages(&bytes) >= 2,
+        "multi-page fixture must produce ≥2 pages"
+    );
+    let lower = pdf_extract::extract_text_from_mem(&bytes)
+        .expect("pdf-extract")
+        .to_lowercase();
+    assert!(
+        lower.contains("grafana"),
+        "sidebar skill missing\n---\n{lower}"
+    );
+    assert_eq!(
+        lower.matches("grafana").count(),
+        1,
+        "Saffron sidebar must render once across pages\n---\n{lower}"
+    );
+}
+
+#[test]
+fn saffron_moves_certifications_to_main_column() {
+    assert_eq!(
+        placement_of(TemplateId::Saffron, "certifications"),
+        "main",
+        "Saffron: Certifications must be placed in the main column"
+    );
+    // Education stays in the sidebar for Saffron (unlike Aria).
+    assert_eq!(placement_of(TemplateId::Saffron, "education"), "sidebar");
+    assert_eq!(placement_of(TemplateId::Saffron, "skills"), "sidebar");
+}
+
+#[test]
+fn portrait_placement_is_unchanged_by_the_refactor() {
+    // Control: the default table (Portrait) keeps Education + Certifications in
+    // the sidebar — the per-template id parameter must not shift it.
+    assert_eq!(placement_of(TemplateId::Portrait, "education"), "sidebar");
+    assert_eq!(
+        placement_of(TemplateId::Portrait, "certifications"),
+        "sidebar"
+    );
+}
+
 // ── resolve_photo unit tests (already in photo.rs; re-exercised here for ──────
 //    integration-layer confidence that the export module re-exports correctly)
 
@@ -2803,9 +3264,9 @@ fn regent_maps_to_serif_small_caps_burgundy_style() {
 
 // ── README showcase banner generator ─────────────────────────────────────────
 //
-// Renders all ten templates, rasterises the first page of each at 2× DPI
+// Renders all twelve templates, rasterises the first page of each at 2× DPI
 // (144 px/pt), thumbnails each to 300 px wide, and composes a single wide
-// row (1×10) — a banner-proportioned strip like the project hero — on a
+// row (1×12) — a banner-proportioned strip like the project hero — on a
 // #F4F4F5 background with 20 px border-padding and 14 px gaps, writing the
 // result to docs/assets/templates-showcase.png.
 //
@@ -2897,11 +3358,12 @@ fn generate_templates_showcase_banner() {
     /// from the original A4 aspect ratio.
     const CELL_W: u32 = 300;
 
-    /// Layout: a single wide row — 10 columns × 1 row (banner proportions).
+    /// Layout: a single wide row — 12 columns × 1 row (banner proportions).
     /// Must be >= the template count: `ROWS` is hardcoded to 1, so any template
     /// landing at row-index >= 1 would write pixels beyond `canvas_h` (an
-    /// out-of-bounds `put_pixel` panic below).
-    const COLS: u32 = 10;
+    /// out-of-bounds `put_pixel` panic below). One row keeps the grid math trivial
+    /// (`col = idx % COLS`, `row = idx / COLS = 0`) for all twelve templates.
+    const COLS: u32 = 12;
     const ROWS: u32 = 1;
 
     /// Outer border padding (px) and gap between cells (px).
@@ -2931,7 +3393,7 @@ fn generate_templates_showcase_banner() {
         ats: false,
     };
 
-    // ── Template list (must be exactly 10, matching the canonical TemplateId set) ──
+    // ── Template list (must be exactly 12, matching the canonical TemplateId set) ──
 
     // (TemplateId, human label, kebab slug). The slug MUST match the renderer's
     // `TemplateId` wire ids so the per-template preview files line up with the UI.
@@ -2946,11 +3408,13 @@ fn generate_templates_showcase_banner() {
         (TemplateId::Lebenslauf, "Lebenslauf", "lebenslauf"),
         (TemplateId::Cadence, "Cadence", "cadence"),
         (TemplateId::Regent, "Regent", "regent"),
+        (TemplateId::Aria, "Aria", "aria"),
+        (TemplateId::Saffron, "Saffron", "saffron"),
     ];
     assert_eq!(
         templates.len(),
-        10,
-        "showcase must cover exactly ten templates"
+        12,
+        "showcase must cover exactly twelve templates"
     );
 
     // ── Helper: compile a World to a PagedDocument ────────────────────────────
@@ -2999,7 +3463,7 @@ fn generate_templates_showcase_banner() {
     std::fs::create_dir_all(&preview_dir)
         .unwrap_or_else(|e| panic!("showcase: create_dir_all template-previews: {e}"));
 
-    let mut thumbnails: Vec<RgbaImage> = Vec::with_capacity(10);
+    let mut thumbnails: Vec<RgbaImage> = Vec::with_capacity(12);
 
     for (id, label, slug) in templates {
         eprintln!("showcase: rendering {label}...");
@@ -3008,9 +3472,13 @@ fn generate_templates_showcase_banner() {
         let typst_tmpl = TypstTemplate::from_template(&t);
         let source = typst_tmpl.source_with_scale();
 
-        // Photo templates (Portrait, Lebenslauf) rendered without a photo
-        // so the showcase generator has no binary dependency.
-        let has_photo = matches!(id, TemplateId::Portrait | TemplateId::Lebenslauf);
+        // Photo templates (Portrait, Lebenslauf, Aria, Saffron) take the photo-
+        // capable prepare path but render their no-photo fallback so the showcase
+        // generator has no binary dependency.
+        let has_photo = matches!(
+            id,
+            TemplateId::Portrait | TemplateId::Lebenslauf | TemplateId::Aria | TemplateId::Saffron
+        );
 
         let PreparedRender {
             source: compiled_source,
@@ -3064,7 +3532,7 @@ fn generate_templates_showcase_banner() {
         eprintln!("  → thumbnail {tw_cur}×{th_cur}");
     }
 
-    assert_eq!(thumbnails.len(), 10, "must have exactly 10 thumbnails");
+    assert_eq!(thumbnails.len(), 12, "must have exactly 12 thumbnails");
 
     // ── Compose single wide row (1×10) ────────────────────────────────────────
 
@@ -3176,7 +3644,7 @@ fn generate_templates_showcase_banner() {
         );
     }
     eprintln!(
-        "template previews written: 10 SVG → {}",
+        "template previews written: 12 SVG → {}",
         preview_dir.display()
     );
 }
@@ -3213,7 +3681,7 @@ fn generate_cover_template_previews() {
     use super::letter::{parse_cover_letter, style_from_template as letter_style_from_template};
     use super::world::ResumeWorld;
 
-    // Same ten templates as the showcase generator. Slugs MUST match the
+    // Same twelve templates as the showcase generator. Slugs MUST match the
     // renderer's `TemplateId` wire ids so the preview files line up with the UI.
     let templates: &[(TemplateId, &str, &str)] = &[
         (TemplateId::Classic, "Classic", "classic"),
@@ -3226,11 +3694,13 @@ fn generate_cover_template_previews() {
         (TemplateId::Lebenslauf, "Lebenslauf", "lebenslauf"),
         (TemplateId::Cadence, "Cadence", "cadence"),
         (TemplateId::Regent, "Regent", "regent"),
+        (TemplateId::Aria, "Aria", "aria"),
+        (TemplateId::Saffron, "Saffron", "saffron"),
     ];
     assert_eq!(
         templates.len(),
-        10,
-        "cover previews must cover exactly ten templates"
+        12,
+        "cover previews must cover exactly twelve templates"
     );
 
     // Embedded letter Typst sources (scale preamble + letter template), reused

--- a/apps/desktop/src-tauri/src/recommend/tests.rs
+++ b/apps/desktop/src-tauri/src/recommend/tests.rs
@@ -11,9 +11,9 @@ fn signals(title: &str, seniority: &str, reqs: &[&str]) -> RecommendSignals {
     }
 }
 
-/// The ten live template IDs — the recommender must never return anything outside
-/// this set.
-const LIVE_TEMPLATES: [TemplateId; 10] = [
+/// The twelve live template IDs — the recommender must never return anything
+/// outside this set.
+const LIVE_TEMPLATES: [TemplateId; 12] = [
     TemplateId::Classic,
     TemplateId::SwissMinimal,
     TemplateId::Academic,
@@ -24,6 +24,8 @@ const LIVE_TEMPLATES: [TemplateId; 10] = [
     TemplateId::Lebenslauf,
     TemplateId::Cadence,
     TemplateId::Regent,
+    TemplateId::Aria,
+    TemplateId::Saffron,
 ];
 
 #[test]

--- a/apps/desktop/src-tauri/src/theme/mod.rs
+++ b/apps/desktop/src-tauri/src/theme/mod.rs
@@ -25,26 +25,42 @@ pub fn template(id: TemplateId) -> Template {
 /// truth for sidebar classification (the per-template `sidebar_sections` list and
 /// its legacy printpdf renderer are gone).
 ///
-/// Sidebar-leaning sections (skills / education / languages / certifications) go
-/// to the sidebar; everything else flows in the main column. Contact details
-/// live in the document header (handled by the layout engine), so they are not a
-/// [`SectionId`] here.
-pub fn placement_for(id: &SectionId) -> Placement {
-    match id {
-        SectionId::Skills
-        | SectionId::Education
-        | SectionId::Languages
-        | SectionId::Certifications => Placement::Sidebar,
+/// Default: sidebar-leaning sections (skills / education / languages /
+/// certifications) go to the sidebar; everything else flows in the main column.
+/// Contact details live in the document header (handled by the layout engine), so
+/// they are not a [`SectionId`] here.
+///
+/// Per-template overrides pull a specific section back into the main column:
+/// **Aria** keeps Education in the main column; **Saffron** keeps Certifications
+/// in the main column. Atelier / Portrait use the default table unchanged.
+pub fn placement_for(template_id: TemplateId, id: &SectionId) -> Placement {
+    match (template_id, id) {
+        // Aria: Education reads in the main column (design choice).
+        (TemplateId::Aria, SectionId::Education) => Placement::Main,
+        // Saffron: Certifications read in the main column.
+        (TemplateId::Saffron, SectionId::Certifications) => Placement::Main,
+        // Default sidebar-leaning set for every other (template, section) pair.
+        (
+            _,
+            SectionId::Skills
+            | SectionId::Education
+            | SectionId::Languages
+            | SectionId::Certifications,
+        ) => Placement::Sidebar,
         _ => Placement::Main,
     }
 }
 
 /// Returns `true` when a template uses a two-column layout.
 ///
-/// `Atelier` (Phase 1b) and `Portrait` (Phase 3b-i) are the two live two-column
-/// templates.  In ATS mode they collapse to a single linear column.
+/// `Atelier` (Phase 1b), `Portrait` (Phase 3b-i), and `Aria` / `Saffron` (PR4)
+/// are the live two-column templates.  In ATS mode they collapse to a single
+/// linear column.
 pub fn is_two_column(id: TemplateId) -> bool {
-    matches!(id, TemplateId::Atelier | TemplateId::Portrait)
+    matches!(
+        id,
+        TemplateId::Atelier | TemplateId::Portrait | TemplateId::Aria | TemplateId::Saffron
+    )
 }
 
 /// How hyperlinks render for a template.
@@ -84,17 +100,20 @@ mod tests {
 
     #[test]
     fn sidebar_sections_go_to_the_sidebar() {
-        for id in [
-            SectionId::Skills,
-            SectionId::Education,
-            SectionId::Languages,
-            SectionId::Certifications,
-        ] {
-            assert_eq!(
-                placement_for(&id),
-                Placement::Sidebar,
-                "{id:?} should be sidebar"
-            );
+        // Default table (Atelier / Portrait keep the full sidebar set).
+        for tid in [TemplateId::Atelier, TemplateId::Portrait] {
+            for id in [
+                SectionId::Skills,
+                SectionId::Education,
+                SectionId::Languages,
+                SectionId::Certifications,
+            ] {
+                assert_eq!(
+                    placement_for(tid, &id),
+                    Placement::Sidebar,
+                    "{tid:?}/{id:?} should be sidebar"
+                );
+            }
         }
     }
 
@@ -105,21 +124,94 @@ mod tests {
             SectionId::Experience,
             SectionId::Projects,
         ] {
-            assert_eq!(placement_for(&id), Placement::Main, "{id:?} should be main");
+            assert_eq!(
+                placement_for(TemplateId::Portrait, &id),
+                Placement::Main,
+                "{id:?} should be main"
+            );
         }
         assert_eq!(
-            placement_for(&SectionId::Custom("Patents".into())),
+            placement_for(TemplateId::Portrait, &SectionId::Custom("Patents".into())),
             Placement::Main
         );
     }
 
     #[test]
-    fn two_column_only_for_two_column_templates() {
-        assert!(is_two_column(TemplateId::Atelier), "Atelier is two-column");
-        assert!(
-            is_two_column(TemplateId::Portrait),
-            "Portrait is two-column"
+    fn aria_keeps_education_in_the_main_column() {
+        // Aria pulls Education into the main column; the rest of the sidebar set
+        // is unchanged.
+        assert_eq!(
+            placement_for(TemplateId::Aria, &SectionId::Education),
+            Placement::Main,
+            "Aria: Education should read in the main column"
         );
+        for id in [
+            SectionId::Skills,
+            SectionId::Languages,
+            SectionId::Certifications,
+        ] {
+            assert_eq!(
+                placement_for(TemplateId::Aria, &id),
+                Placement::Sidebar,
+                "Aria/{id:?} should stay in the sidebar"
+            );
+        }
+    }
+
+    #[test]
+    fn saffron_keeps_certifications_in_the_main_column() {
+        // Saffron pulls Certifications into the main column; Education stays in
+        // the sidebar (unlike Aria).
+        assert_eq!(
+            placement_for(TemplateId::Saffron, &SectionId::Certifications),
+            Placement::Main,
+            "Saffron: Certifications should read in the main column"
+        );
+        for id in [
+            SectionId::Skills,
+            SectionId::Education,
+            SectionId::Languages,
+        ] {
+            assert_eq!(
+                placement_for(TemplateId::Saffron, &id),
+                Placement::Sidebar,
+                "Saffron/{id:?} should stay in the sidebar"
+            );
+        }
+    }
+
+    #[test]
+    fn default_templates_placement_is_byte_identical() {
+        // Guard: adding the id parameter must NOT shift Atelier/Portrait placement.
+        for tid in [TemplateId::Atelier, TemplateId::Portrait] {
+            assert_eq!(
+                placement_for(tid, &SectionId::Education),
+                Placement::Sidebar
+            );
+            assert_eq!(
+                placement_for(tid, &SectionId::Certifications),
+                Placement::Sidebar
+            );
+            assert_eq!(placement_for(tid, &SectionId::Skills), Placement::Sidebar);
+            assert_eq!(
+                placement_for(tid, &SectionId::Languages),
+                Placement::Sidebar
+            );
+            assert_eq!(placement_for(tid, &SectionId::Summary), Placement::Main);
+            assert_eq!(placement_for(tid, &SectionId::Experience), Placement::Main);
+        }
+    }
+
+    #[test]
+    fn two_column_only_for_two_column_templates() {
+        for id in [
+            TemplateId::Atelier,
+            TemplateId::Portrait,
+            TemplateId::Aria,
+            TemplateId::Saffron,
+        ] {
+            assert!(is_two_column(id), "{id:?} is two-column");
+        }
         assert!(!is_two_column(TemplateId::Classic));
         assert!(!is_two_column(TemplateId::SwissMinimal));
         assert!(

--- a/apps/desktop/src-tauri/src/validate/tests.rs
+++ b/apps/desktop/src-tauri/src/validate/tests.rs
@@ -319,6 +319,14 @@ fn typst_validate(template_id: TemplateId) -> (Vec<u8>, ExportReport) {
     .expect("typst pdf export")
 }
 
+fn typst_validate_ats(template_id: TemplateId) -> (Vec<u8>, ExportReport) {
+    validate_and_fix(
+        req(ExportFormat::Pdf, template_id, true),
+        crate::export::pdf::generate_pdf,
+    )
+    .expect("typst pdf export (ats)")
+}
+
 #[test]
 fn typst_single_column_pdf_passes_validation() {
     for id in [
@@ -351,7 +359,12 @@ fn typst_single_column_pdf_passes_validation() {
 
 #[test]
 fn typst_two_column_atelier_pdf_passes_validation() {
-    for id in [TemplateId::Atelier, TemplateId::Portrait] {
+    for id in [
+        TemplateId::Atelier,
+        TemplateId::Portrait,
+        TemplateId::Aria,
+        TemplateId::Saffron,
+    ] {
         let (bytes, report) = typst_validate(id);
         assert!(!bytes.is_empty(), "{id:?}: empty PDF");
         assert!(
@@ -365,6 +378,31 @@ fn typst_two_column_atelier_pdf_passes_validation() {
                 .iter()
                 .any(|i| i.severity == Severity::Critical),
             "{id:?}: no critical issues expected on a valid Typst PDF, got: {:?}",
+            report.issues
+        );
+    }
+}
+
+/// Aria/Saffron (PR4 design two-column templates) must also round-trip the
+/// validator in ATS mode — same pattern as `typst_single_column_pdf_passes_validation`,
+/// just with `ats_mode: true` so the linearized, photo-dropped render is what's
+/// checked (the non-ATS assertion above only covers the two-column render).
+#[test]
+fn typst_two_column_ats_mode_pdf_passes_validation() {
+    for id in [TemplateId::Aria, TemplateId::Saffron] {
+        let (bytes, report) = typst_validate_ats(id);
+        assert!(!bytes.is_empty(), "{id:?}: empty ATS-mode PDF");
+        assert!(
+            report.ok,
+            "{id:?}: Typst ATS-mode PDF must pass validate_and_fix — issues: {:?}",
+            report.issues
+        );
+        assert!(
+            !report
+                .issues
+                .iter()
+                .any(|i| i.severity == Severity::Critical),
+            "{id:?}: no critical issues expected on a valid ATS-mode Typst PDF, got: {:?}",
             report.issues
         );
     }

--- a/apps/desktop/src/renderer/features/ai-generate/components/wizard-steps/StepTemplate/StepTemplate.test.tsx
+++ b/apps/desktop/src/renderer/features/ai-generate/components/wizard-steps/StepTemplate/StepTemplate.test.tsx
@@ -337,15 +337,15 @@ describe('StepTemplate', () => {
     expect(screen.getByText('aiGenerate.tier.design')).toBeInTheDocument();
   });
 
-  it('shows a tier badge on every card (7 ATS + 3 design)', () => {
+  it('shows a tier badge on every card (7 ATS + 5 design)', () => {
     renderStep();
     expect(screen.getAllByText('aiGenerate.tier.atsBadge')).toHaveLength(7);
-    expect(screen.getAllByText('aiGenerate.tier.designBadge')).toHaveLength(3);
+    expect(screen.getAllByText('aiGenerate.tier.designBadge')).toHaveLength(5);
   });
 
   // ── ATS toggle gate is tier-aware (the Lebenslauf photo fix) ─────────────────
 
-  it.each(['atelier', 'portrait', 'lebenslauf'] as const)(
+  it.each(['atelier', 'portrait', 'lebenslauf', 'aria', 'saffron'] as const)(
     'shows the ATS toggle for the design-tier template %s',
     (id) => {
       renderStep({ templateId: id });

--- a/apps/desktop/src/renderer/features/ai-generate/samples/cover-template-previews.test.ts
+++ b/apps/desktop/src/renderer/features/ai-generate/samples/cover-template-previews.test.ts
@@ -19,6 +19,8 @@ vi.mock('./cover-template-previews', () => {
     'lebenslauf',
     'cadence',
     'regent',
+    'aria',
+    'saffron',
   ] as const;
 
   const COVER_TEMPLATE_PREVIEWS = Object.fromEntries(

--- a/apps/desktop/src/renderer/features/ai-generate/samples/samples.ts
+++ b/apps/desktop/src/renderer/features/ai-generate/samples/samples.ts
@@ -27,4 +27,6 @@ export const TEMPLATE_CAPTIONS: Record<TemplateId, string> = {
   lebenslauf: 'DIN-style tabular CV with photo. German-speaking (DACH) market standard.',
   cadence: 'Letter-spaced modern headings, restrained blue-grey. Premium and parser-safe.',
   regent: 'Executive serif with small-caps headings and a deep burgundy accent. Leadership roles.',
+  aria: 'Minimalist two-column with an airy untinted sidebar and photo. Collapses to single column for ATS.',
+  saffron: 'Warm serif with a tinted sidebar and ringed photo. Collapses to single column for ATS.',
 };

--- a/apps/desktop/src/renderer/lib/generate/templates/templates.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/templates/templates.test.ts
@@ -5,8 +5,8 @@ import { isDesignTier, TEMPLATES } from './templates';
 describe('TEMPLATES', () => {
   const ids = Object.keys(TEMPLATES);
 
-  it('exposes the ten document templates keyed by id', () => {
-    expect(ids).toHaveLength(10);
+  it('exposes the twelve document templates keyed by id', () => {
+    expect(ids).toHaveLength(12);
     for (const id of ids) {
       expect(TEMPLATES[id as keyof typeof TEMPLATES].id).toBe(id);
     }
@@ -15,9 +15,10 @@ describe('TEMPLATES', () => {
   // Sync guard: this id set MUST equal the Rust `TemplateId` enum (export/types.rs,
   // kebab-case) and the shared contract union (packages/shared/.../documents.ts).
   // The Rust round-trip test pins the other side; if either drifts, a guard fails.
-  it('matches the canonical 10-template id set', () => {
+  it('matches the canonical 12-template id set', () => {
     expect([...ids].sort()).toEqual([
       'academic',
+      'aria',
       'atelier',
       'cadence',
       'classic',
@@ -25,6 +26,7 @@ describe('TEMPLATES', () => {
       'meridian',
       'portrait',
       'regent',
+      'saffron',
       'swiss-minimal',
       'throughline',
     ]);
@@ -69,7 +71,7 @@ describe('TEMPLATES', () => {
       'swiss-minimal',
       'throughline',
     ]);
-    expect(idsByTier('design')).toEqual(['atelier', 'lebenslauf', 'portrait']);
+    expect(idsByTier('design')).toEqual(['aria', 'atelier', 'lebenslauf', 'portrait', 'saffron']);
   });
 
   it('isDesignTier is true exactly for design-tier templates', () => {

--- a/apps/desktop/src/renderer/lib/generate/templates/templates.ts
+++ b/apps/desktop/src/renderer/lib/generate/templates/templates.ts
@@ -16,7 +16,9 @@ export type TemplateId =
   | 'portrait'
   | 'lebenslauf'
   | 'cadence'
-  | 'regent';
+  | 'regent'
+  | 'aria'
+  | 'saffron';
 
 interface DocTemplate {
   id: TemplateId;
@@ -279,6 +281,52 @@ export const TEMPLATES: Record<TemplateId, DocTemplate> = {
     sectionAllCaps: false,
     sectionStyle: 'ruled-bottom',
   },
+
+  /** Aria — minimalist design two-column, untinted right sidebar, photo top-right, slate accent, 30pt Manrope name */
+  aria: {
+    id: 'aria',
+    name: 'Aria',
+    tier: 'design',
+    nameColor: '111111',
+    sectionColor: '1A1A1A',
+    accentColor: '46505C',
+    bodyColor: '2A2A2A',
+    dateColor: '7A7A7A',
+    emphasisColor: '46505C',
+    ruleColor: 'D6D9DD',
+    namePt: 30,
+    sectionPt: 10.5,
+    bodyPt: 10,
+    marginIn: 0.6,
+    lineSpacingDocx: 288,
+    sectionSpacingBefore: 320,
+    nameCentered: false,
+    sectionAllCaps: true,
+    sectionStyle: 'ruled-bottom',
+  },
+
+  /** Saffron — warm design two-column, tinted left sidebar, ringed circular photo, terracotta accent, Source Serif 4 small-caps */
+  saffron: {
+    id: 'saffron',
+    name: 'Saffron',
+    tier: 'design',
+    nameColor: '3A2E28',
+    sectionColor: 'A85A3E',
+    accentColor: 'A85A3E',
+    bodyColor: '302A26',
+    dateColor: '8A7A6E',
+    emphasisColor: 'A85A3E',
+    ruleColor: 'E2C9B4',
+    namePt: 24,
+    sectionPt: 11,
+    bodyPt: 10.5,
+    marginIn: 0.55,
+    lineSpacingDocx: 276,
+    sectionSpacingBefore: 240,
+    nameCentered: false,
+    sectionAllCaps: false,
+    sectionStyle: 'ruled-bottom',
+  },
 };
 
 /** Stable list of all template ids (kebab-case on the wire). */
@@ -289,7 +337,7 @@ export const TEMPLATE_IDS = Object.keys(TEMPLATES) as TemplateId[];
  * ATS mode — mirrors the backend `theme::is_two_column`. The ATS toggle + the
  * recommendation auto-apply key off this rather than a hardcoded id.
  */
-const TWO_COLUMN_TEMPLATE_IDS = new Set<TemplateId>(['atelier', 'portrait']);
+const TWO_COLUMN_TEMPLATE_IDS = new Set<TemplateId>(['atelier', 'portrait', 'aria', 'saffron']);
 
 export function isTwoColumnTemplate(id: TemplateId): boolean {
   return TWO_COLUMN_TEMPLATE_IDS.has(id);

--- a/packages/shared/src/ipc/contracts/documents.ts
+++ b/packages/shared/src/ipc/contracts/documents.ts
@@ -12,7 +12,9 @@ export type TemplateId =
   | 'portrait'
   | 'lebenslauf'
   | 'cadence'
-  | 'regent';
+  | 'regent'
+  | 'aria'
+  | 'saffron';
 
 interface ExportMeta {
   candidateName?: string;


### PR DESCRIPTION
## Summary

PR 4 of the template-overhaul series (after #590–#592): two **design-tier photo/two-column templates** + **per-template section placement**.

- **Aria** — minimalist two-column: RIGHT *untinted* sidebar, rectangular photo top-right, 30pt Manrope name, slate accent (#46505C), letter-spaced hairline headings, Inter body, generous whitespace. No-photo fallback: clean name-only header (deliberately no monogram). Modeled on the "Ava Amelia" reference.
- **Saffron** — warm serif two-column: LEFT tinted sidebar (#F5E7DA), circular photo with a 1.5pt terracotta ring, Source Serif 4 small-caps headings + Inter body, terracotta accent (#A85A3E). No-photo fallback: warm monogram circle. Modeled on the "Jacqueline Thompson" reference.
- **Per-template placement** — `placement_for` is now template-aware: Aria keeps *Education* in the main column and Saffron keeps *Certifications* there (matching the reference designs); existing templates' placement is byte-identical (regression-controlled), and **PDF + DOCX key off the same template id** — no cross-format divergence.
- Both templates fully support ATS mode (linearize to single column, drop photo — reading-order and image-drop proven by tests) and the Document accent override.

## Design notes (documented decisions)

- **Saffron vs Portrait**: the critic's honest verdict — structurally close ("Portrait in warm serif"); distinct via serif small-caps identity, warm palette, ringed photo, and the Certifications placement. Shipped per the planning decision that the warm reference earns its slot; flagged for the gallery's long-term curation.
- **Aria page 2+**: the untinted right sidebar reserves its column width on later pages (airy by design; no band to fill it). Documented as intended.
- Preview SVGs + showcase banner regen remain **pending CI** (host cannot execute cargo tests); gallery falls back to icons. The ring geometry was verified against a real rendered SVG via an out-of-band example binary (full 1.5pt stroke, no clip).

## Review status (pre-PR agent gates)

`resume-export-expert` — **no blocking findings**; all advisories fixed in-diff: ring drawn as an overlay circle (clip-proof, render-verified), ATS-mode validator round-trip added for both ids, photo-resolution comment reworded. Placement refactor verified equivalent-by-construction for existing templates; injection-safe data flow confirmed.

## Tests

Per template: valid PDF with/without photo, ATS drops photo (SVG assert) + linear reading order (pdf-extract), accent override, two-column flag, multi-page sidebar-renders-once, placement overrides at the serialized-JSON level, Portrait-placement regression control, ATS validator round-trip. Count pins 10→12 across Rust + TS. Frontend suite 3,269 green; typecheck + lint clean.

⚠️ Local `cargo test` cannot execute on the dev host — Rust tests compile clean under `cargo check --all-targets` + clippy; **CI is authoritative for Rust test execution.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
