### PR TITLE
fix: represent board fetch failures instead of silent zero results

### DIFF
--- a/apps/desktop/src-tauri/src/profile_import/github.rs
+++ b/apps/desktop/src-tauri/src/profile_import/github.rs
@@ -111,8 +111,12 @@ fn map_status(code: u16) -> Option<AppError> {
 /// The GET goes through the hardened [`fetch_text`] helper, which gives the 8 MB
 /// streaming body cap, the per-host rate limiter, and cancellation for free; we
 /// add an explicit [`REQUEST_TIMEOUT`] since the shared client has no global one.
-/// We keep the status code so the 404 / 403,429 mapping survives (which
-/// `fetch_json` would collapse into a single `None`).
+/// We use `fetch_text` (not `fetch_json`) specifically to keep `res.status_code`
+/// as a plain number we can branch on in [`map_status`] for GitHub's own
+/// 404-vs-403/429-vs-other semantics — `fetch_json` now turns every non-2xx into
+/// one `Err(AppError::Provider("HTTP <status>"))`, which is the right contract
+/// for the scraping boards but loses the structured code this 404/403/429
+/// distinction needs.
 pub async fn fetch_repos(input: &str) -> AppResult<Vec<GitHubRepo>> {
     let username = parse_username(input)?;
     let url = api_url(&username);

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
@@ -391,14 +391,14 @@ async fn fetch_adzuna_page(
         adzuna_max_days_old(date_filter),
     );
 
-    let resp = match fetch_json::<AdzunaResp>(&url, FetchOptions::default(), signal).await? {
-        Some(r) => r,
-        None => {
-            return Err(anyhow::anyhow!(
-                "adzuna: non-2xx response or unparseable body"
-            ))
-        }
-    };
+    // A non-2xx or schema-drift response propagates as `Err` from `fetch_json`
+    // (carrying the HTTP status); `?` surfaces it as a provider failure. The
+    // "adzuna:" prefix is required — the aggregator board fronts three
+    // providers, so an unattributed "HTTP 403" in BoardScrapeSummary.error
+    // wouldn't say which one failed.
+    let resp = fetch_json::<AdzunaResp>(&url, FetchOptions::default(), signal)
+        .await
+        .map_err(|e| anyhow::anyhow!("adzuna: {e}"))?;
 
     let now = chrono::Utc::now().timestamp_millis();
     Ok(resp
@@ -492,7 +492,12 @@ impl JobProvider for JSearchProvider {
             jsearch_date_posted(date_filter)
         ));
 
-        let result = fetch_json::<JSearchResp>(
+        // A non-2xx or schema-drift response propagates as `Err` from `fetch_json`
+        // (carrying the HTTP status); `?` surfaces it as a provider failure. The
+        // "jsearch:" prefix is required — the aggregator board fronts three
+        // providers, so an unattributed "HTTP 403" in BoardScrapeSummary.error
+        // wouldn't say which one failed.
+        let resp = fetch_json::<JSearchResp>(
             &url,
             FetchOptions {
                 headers: Some(vec![
@@ -506,16 +511,8 @@ impl JobProvider for JSearchProvider {
             },
             signal,
         )
-        .await?;
-
-        let resp = match result {
-            Some(r) => r,
-            None => {
-                return Err(anyhow::anyhow!(
-                    "jsearch: non-2xx response or unparseable body"
-                ))
-            }
-        };
+        .await
+        .map_err(|e| anyhow::anyhow!("jsearch: {e}"))?;
 
         let now = chrono::Utc::now().timestamp_millis();
         let postings = resp
@@ -951,7 +948,10 @@ impl JobProvider for ApifyLinkedInProvider {
         //
         // `tokio::select!` races the paid fetch against the cancellation signal so
         // a user cancel mid-flight is honoured within one poll cycle.
-        let raw = tokio::select! {
+        // A non-2xx / timeout / schema-drift response propagates as `Err` from
+        // `fetch_json` (carrying the HTTP status); `?` surfaces it as a provider
+        // failure instead of a silent empty dataset.
+        let items = tokio::select! {
             _ = signal.cancelled() => {
                 return Err(anyhow::anyhow!("apify_linkedin: cancelled"));
             }
@@ -961,11 +961,6 @@ impl JobProvider for ApifyLinkedInProvider {
                 signal.clone(),
             ) => result?
         };
-        let items = raw.ok_or_else(|| {
-            anyhow::anyhow!(
-                "apify_linkedin: non-2xx response, timeout (408), or unparseable dataset body"
-            )
-        })?;
 
         let now = chrono::Utc::now().timestamp_millis();
         Ok(items

--- a/apps/desktop/src-tauri/src/scraping/boards/arbeitnow/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/arbeitnow/mod.rs
@@ -1,6 +1,7 @@
 /// Arbeitnow — public JSON API
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
+use super::common::should_propagate_page_error;
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -69,7 +70,7 @@ impl Scraper for ArbeitnowScraper {
             .await
             {
                 Ok(d) => d,
-                Err(e) if out.is_empty() => return Err(e.into()),
+                Err(e) if should_propagate_page_error(out.len()) => return Err(e.into()),
                 Err(e) => {
                     log::warn!(
                         "[arbeitnow] page {page} failed: {e}; returning {} collected",
@@ -79,10 +80,8 @@ impl Scraper for ArbeitnowScraper {
                 }
             };
 
-            let (jobs, has_next) = match data {
-                Some(d) => (d.data, d.links.and_then(|l| l.next).is_some()),
-                None => break,
-            };
+            let jobs = data.data;
+            let has_next = data.links.and_then(|l| l.next).is_some();
 
             if jobs.is_empty() {
                 break;

--- a/apps/desktop/src-tauri/src/scraping/boards/arbeitnow/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/arbeitnow/mod.rs
@@ -2,6 +2,7 @@
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
 use super::common::should_propagate_page_error;
+use crate::error::AppError;
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -70,6 +71,10 @@ impl Scraper for ArbeitnowScraper {
             .await
             {
                 Ok(d) => d,
+                // A cancel firing mid-fetch is a clean stop, not a failure —
+                // even on page 0 with nothing collected yet, this must return
+                // `Ok(out)` (empty), not bubble as an error.
+                Err(AppError::Cancelled) => break,
                 Err(e) if should_propagate_page_error(out.len()) => return Err(e.into()),
                 Err(e) => {
                     log::warn!(

--- a/apps/desktop/src-tauri/src/scraping/boards/arbeitsagentur/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/arbeitsagentur/mod.rs
@@ -8,6 +8,7 @@
 ///
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
+use super::common::should_propagate_page_error;
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -147,7 +148,7 @@ impl Scraper for ArbeitsagenturScraper {
             .await
             {
                 Ok(r) => r,
-                Err(e) if out.is_empty() => return Err(e.into()),
+                Err(e) if should_propagate_page_error(out.len()) => return Err(e.into()),
                 Err(e) => {
                     log::warn!(
                         "[arbeitsagentur] page {page} failed: {e}; returning {} collected",
@@ -157,9 +158,7 @@ impl Scraper for ArbeitsagenturScraper {
                 }
             };
 
-            let items = list_resp
-                .and_then(|l| l.stellenangebote)
-                .unwrap_or_default();
+            let items = list_resp.stellenangebote.unwrap_or_default();
 
             if items.is_empty() {
                 break;
@@ -183,6 +182,9 @@ impl Scraper for ArbeitsagenturScraper {
                     .clone()
                     .unwrap_or_else(|| self.to_base64_url(&j.refnr));
 
+                // Detail is opportunistic — 404s are common from non-browser clients
+                // (bot filter). On any failure we still emit the job from list data,
+                // so a failed detail fetch collapses to `None`, not a board error.
                 let detail = fetch_json::<DetailResp>(
                     &format!("{}/jobdetails/{}", API_BASE, urlencoding::encode(&hash)),
                     super::super::http::FetchOptions {
@@ -192,8 +194,7 @@ impl Scraper for ArbeitsagenturScraper {
                     ctx.signal.clone(),
                 )
                 .await
-                .ok()
-                .flatten();
+                .ok();
 
                 let description = detail.as_ref().and_then(|d| {
                     let desc = vec![

--- a/apps/desktop/src-tauri/src/scraping/boards/arbeitsagentur/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/arbeitsagentur/mod.rs
@@ -9,6 +9,7 @@
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
 use super::common::should_propagate_page_error;
+use crate::error::AppError;
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -148,6 +149,10 @@ impl Scraper for ArbeitsagenturScraper {
             .await
             {
                 Ok(r) => r,
+                // A cancel firing mid-fetch is a clean stop, not a failure —
+                // even on page 0 with nothing collected yet, this must return
+                // `Ok(out)` (empty), not bubble as an error.
+                Err(AppError::Cancelled) => break,
                 Err(e) if should_propagate_page_error(out.len()) => return Err(e.into()),
                 Err(e) => {
                     log::warn!(

--- a/apps/desktop/src-tauri/src/scraping/boards/ashby/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ashby/mod.rs
@@ -5,7 +5,7 @@
 //! board with `"needs-company"` when `input.companies` is empty.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::normalize_companies;
+use super::common::{ats_all_fetches_failed, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -114,18 +114,10 @@ impl Scraper for AshbyScraper {
                     }
                 };
 
-            let jobs = match data {
-                Some(d) => {
-                    successful_fetches += 1;
-                    d.jobs
-                }
-                None => {
-                    if let Some(ref on_progress) = ctx.on_progress {
-                        on_progress((i + 1) as f32 / total as f32);
-                    }
-                    continue;
-                }
-            };
+            // A non-2xx / schema-drift response is now an `Err` above (which records
+            // `first_fetch_error`), so reaching here means a real success — count it.
+            successful_fetches += 1;
+            let jobs = data.jobs;
 
             for j in jobs {
                 let posted_at = j
@@ -166,11 +158,11 @@ impl Scraper for AshbyScraper {
             }
         }
 
-        // Return Err only when every attempt failed — partial success is kept.
-        if successful_fetches == 0 {
-            if let Some(error) = first_fetch_error {
-                return Err(anyhow::anyhow!("all ashby company fetches failed: {error}"));
-            }
+        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/bamboohr/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/bamboohr/mod.rs
@@ -7,7 +7,7 @@
 //! Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/bamboohr.mjs`.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{is_valid_dns_label_slug, normalize_companies};
+use super::common::{ats_all_fetches_failed, is_valid_dns_label_slug, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -203,18 +203,10 @@ impl Scraper for BambooHrScraper {
                 }
             };
 
-            let resp = match data {
-                Some(d) => {
-                    successful_fetches += 1;
-                    d
-                }
-                None => {
-                    if let Some(ref on_progress) = ctx.on_progress {
-                        on_progress((i + 1) as f32 / total as f32);
-                    }
-                    continue;
-                }
-            };
+            // A non-2xx / schema-drift response is now an `Err` above (which records
+            // `first_fetch_error`), so reaching here means a real success — count it.
+            successful_fetches += 1;
+            let resp = data;
 
             for posting in parse_bamboohr_response(resp, &company, now) {
                 if let Some(ref on_item) = ctx.on_item {
@@ -228,13 +220,11 @@ impl Scraper for BambooHrScraper {
             }
         }
 
-        // Return Err only when every attempt failed — partial success is kept.
-        if successful_fetches == 0 {
-            if let Some(error) = first_fetch_error {
-                return Err(anyhow::anyhow!(
-                    "all bamboohr company fetches failed: {error}"
-                ));
-            }
+        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/berlinstartupjobs/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/berlinstartupjobs/mod.rs
@@ -38,7 +38,9 @@ impl Scraper for BerlinStartupJobsScraper {
         .await?;
 
         if res.status_code != 200 {
-            return Ok(vec![]);
+            // Representable failure: a non-2xx feed response is a failed board, not
+            // a silent zero — surface the status into `BoardScrapeSummary.error`.
+            return Err(anyhow::anyhow!("HTTP {}", res.status_code));
         }
 
         let now = chrono::Utc::now().timestamp_millis();

--- a/apps/desktop/src-tauri/src/scraping/boards/breezy/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/breezy/mod.rs
@@ -7,7 +7,9 @@
 //! Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/breezy.mjs`.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{is_https_url, is_valid_dns_label_slug, normalize_companies};
+use super::common::{
+    ats_all_fetches_failed, is_https_url, is_valid_dns_label_slug, normalize_companies,
+};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -206,18 +208,10 @@ impl Scraper for BreezyScraper {
                     }
                 };
 
-            let postings = match data {
-                Some(d) => {
-                    successful_fetches += 1;
-                    d
-                }
-                None => {
-                    if let Some(ref on_progress) = ctx.on_progress {
-                        on_progress((i + 1) as f32 / total as f32);
-                    }
-                    continue;
-                }
-            };
+            // A non-2xx / schema-drift response is now an `Err` above (which records
+            // `first_fetch_error`), so reaching here means a real success — count it.
+            successful_fetches += 1;
+            let postings = data;
 
             for posting in parse_breezy_response(postings, &company, now) {
                 if let Some(ref on_item) = ctx.on_item {
@@ -231,13 +225,11 @@ impl Scraper for BreezyScraper {
             }
         }
 
-        // Return Err only when every attempt failed — partial success is kept.
-        if successful_fetches == 0 {
-            if let Some(error) = first_fetch_error {
-                return Err(anyhow::anyhow!(
-                    "all breezy company fetches failed: {error}"
-                ));
-            }
+        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/comeet/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/comeet/mod.rs
@@ -229,7 +229,7 @@ impl Scraper for ComeetScraper {
             urlencoding::encode(token.trim())
         );
 
-        let data = match fetch_json::<Vec<serde_json::Value>>(
+        let raw = match fetch_json::<Vec<serde_json::Value>>(
             &url,
             Default::default(),
             ctx.signal.clone(),
@@ -239,11 +239,9 @@ impl Scraper for ComeetScraper {
             Ok(d) => d,
             // A cancel firing mid-fetch is a clean stop, not a board error.
             Err(_) if ctx.signal.is_cancelled() => return Ok(vec![]),
+            // A non-2xx / schema-drift response now surfaces as a board error
+            // instead of a silent empty result.
             Err(e) => return Err(e.into()),
-        };
-        let raw = match data {
-            Some(d) => d,
-            None => return Ok(vec![]),
         };
 
         let now = chrono::Utc::now().timestamp_millis();

--- a/apps/desktop/src-tauri/src/scraping/boards/common.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common.rs
@@ -81,3 +81,46 @@ pub(crate) fn matches_filters(
 
     true
 }
+
+/// Decide whether an ATS multi-company board's fetch loop should fail the
+/// whole board. Returns `Some(message)` — ready to wrap in
+/// `anyhow::anyhow!` — only when every attempted per-company fetch failed
+/// (`successful_fetches == 0` AND at least one real fetch error was
+/// recorded). Returns `None` when at least one company succeeded (partial
+/// success is kept) OR when no company ever reached a fetch (e.g. every slug
+/// was rejected by a pre-fetch validation guard, or the input list was
+/// empty) — that is a "nothing to fetch" outcome, not a board failure.
+///
+/// Pure — no I/O, no board host — so it is directly unit-testable without a
+/// mock server. Shared by every ATS board that tracks
+/// `successful_fetches`/`first_fetch_error` (Ashby, BambooHR, Breezy,
+/// Greenhouse, Lever, Pinpoint, Recruitee, Rippling, SmartRecruiters,
+/// Workable).
+pub(crate) fn ats_all_fetches_failed(
+    board_id: &str,
+    successful_fetches: usize,
+    first_fetch_error: &Option<String>,
+) -> Option<String> {
+    if successful_fetches > 0 {
+        return None;
+    }
+    first_fetch_error
+        .as_ref()
+        .map(|error| format!("all {board_id} company fetches failed: {error}"))
+}
+
+/// Decide the pagination-failure policy for a page fetch: a page reached with
+/// nothing collected yet (typically page 0) propagates the fetch failure as a
+/// board error; a later page that fails after some items were already
+/// streamed instead stops pagination and keeps the partial result.
+///
+/// Pure — takes only the already-known collected count, no I/O — so it is
+/// directly unit-testable without a mock server. Shared by every paginated
+/// board that fails closed on an empty-so-far collection (The Muse,
+/// Arbeitnow, Arbeitsagentur).
+pub(crate) fn should_propagate_page_error(collected_so_far: usize) -> bool {
+    collected_so_far == 0
+}
+
+#[cfg(test)]
+mod test;

--- a/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+// ── ats_all_fetches_failed ───────────────────────────────────────────────────
+//
+// `common.rs` (not a board's own `mod.rs`) is the natural home for these
+// tests: `ats_all_fetches_failed` is shared by 10 ATS boards (lever, recruitee,
+// smartrecruiters, greenhouse, ashby, breezy, bamboohr, pinpoint, rippling,
+// workable) and `should_propagate_page_error` by 3 paginated boards (themuse,
+// arbeitnow, arbeitsagentur) — unlike `normalize_companies`/`is_https_url`
+// (2-3 users each, tested by per-board copy in each user's `test.rs`),
+// duplicating one test suite across 10+ board files would be pure repetition
+// of the exact same assertions against the exact same pure fn.
+
+#[test]
+fn all_fail_returns_error_naming_board_and_first_error() {
+    // successful_fetches == 0 AND a real error was recorded → Some(message)
+    // that names the board id and carries the first recorded error verbatim
+    // (this is what lands in `BoardScrapeSummary.error` — must be attributable
+    // to a specific board, not a bare "HTTP 403").
+    let result = ats_all_fetches_failed("lever", 0, &Some("HTTP 403".to_string()));
+    assert_eq!(
+        result.as_deref(),
+        Some("all lever company fetches failed: HTTP 403"),
+        "all-fail message must name the board id and carry the first error verbatim"
+    );
+}
+
+#[test]
+fn partial_success_returns_none_even_with_a_recorded_error() {
+    // At least one company succeeded → None, regardless of whether an earlier
+    // slug also recorded a fetch error. Partial success must be kept, not
+    // treated as a board failure (this is the case the audit called out —
+    // one bad slug in a multi-company batch must not zero out the good ones).
+    let result = ats_all_fetches_failed("smartrecruiters", 1, &Some("HTTP 404".to_string()));
+    assert!(
+        result.is_none(),
+        "at least one successful fetch must suppress the all-fail error, got {result:?}"
+    );
+
+    // Also true with more than one success and no recorded error at all.
+    let clean = ats_all_fetches_failed("smartrecruiters", 3, &None);
+    assert!(clean.is_none());
+}
+
+/// Zero-companies / nothing-attempted edge: `successful_fetches == 0` AND no
+/// error was ever recorded (every slug rejected by a pre-fetch validation
+/// guard, e.g. `is_valid_dns_label_slug`, before any fetch ran — or the
+/// company list was empty). This is the exact state every ATS board reaches
+/// when its per-company loop never records a fetch attempt.
+///
+/// Must be `None` — "nothing to fetch" is not a board failure. Confirmed
+/// behavior-preserving against the pre-extraction inline shape (still visible
+/// in `smartrecruiters/mod.rs`: `if successful_fetches == 0 { if let
+/// Some(error) = first_fetch_error { return Err(...) } }`, falling through to
+/// `Ok(out)` when `first_fetch_error` is `None`) — the extraction did not
+/// change this edge's outcome.
+#[test]
+fn zero_companies_edge_no_error_recorded_returns_none() {
+    let result = ats_all_fetches_failed("bamboohr", 0, &None);
+    assert!(
+        result.is_none(),
+        "no companies ever attempted (0 successes, no recorded error) must not synthesize a \
+         board error — got {result:?}"
+    );
+}
+
+// ── should_propagate_page_error ──────────────────────────────────────────────
+
+#[test]
+fn zero_collected_propagates_page_failure() {
+    // Page 0 (or any page reached with nothing collected yet) failing must
+    // propagate as a board error — this is what fixed themuse's page-0 silent
+    // zero (a blocked/rotted feed on the very first page must not look like a
+    // genuine empty result).
+    assert!(
+        should_propagate_page_error(0),
+        "a page failure with nothing collected yet must propagate"
+    );
+}
+
+#[test]
+fn partial_harvest_is_kept_not_propagated() {
+    // A later page failing after some items were already streamed must stop
+    // pagination and keep the partial result, not discard everything already
+    // collected by turning it into a board error.
+    assert!(
+        !should_propagate_page_error(1),
+        "a page failure after 1 item was already collected must keep the partial harvest"
+    );
+    assert!(
+        !should_propagate_page_error(50),
+        "a page failure after many items were already collected must keep the partial harvest"
+    );
+}

--- a/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/mod.rs
@@ -259,7 +259,10 @@ impl Scraper for GermanTechJobsScraper {
 
         if res.status_code != 200 {
             log::warn!("[germantechjobs] feed fetch returned {}", res.status_code);
-            return Ok(vec![]);
+            // Representable failure: a non-2xx feed response (e.g. the historic
+            // /rss 403) is a failed board, not a silent zero — surface the status
+            // so it lands in `BoardScrapeSummary.error`.
+            return Err(anyhow::anyhow!("HTTP {}", res.status_code));
         }
 
         let now = chrono::Utc::now().timestamp_millis();

--- a/apps/desktop/src-tauri/src/scraping/boards/greenhouse/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/greenhouse/mod.rs
@@ -5,7 +5,7 @@
 //! board with `"needs-company"` when `input.companies` is empty.
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::normalize_companies;
+use super::common::{ats_all_fetches_failed, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -116,18 +116,10 @@ impl Scraper for GreenhouseScraper {
                     }
                 };
 
-            let jobs = match data {
-                Some(d) => {
-                    successful_fetches += 1;
-                    d.jobs
-                }
-                None => {
-                    if let Some(ref on_progress) = ctx.on_progress {
-                        on_progress((i + 1) as f32 / total as f32);
-                    }
-                    continue;
-                }
-            };
+            // A non-2xx / schema-drift response is now an `Err` above (which records
+            // `first_fetch_error`), so reaching here means a real success — count it.
+            successful_fetches += 1;
+            let jobs = data.jobs;
 
             for j in jobs {
                 let description = j.content.map(|c| strip_html(&c));
@@ -163,13 +155,11 @@ impl Scraper for GreenhouseScraper {
             }
         }
 
-        // Return Err only when every attempt failed — partial success is kept.
-        if successful_fetches == 0 {
-            if let Some(error) = first_fetch_error {
-                return Err(anyhow::anyhow!(
-                    "all greenhouse company fetches failed: {error}"
-                ));
-            }
+        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/lever/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/lever/mod.rs
@@ -5,6 +5,7 @@
 /// board with `"needs-company"` when `input.companies` is empty.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
+use super::common::ats_all_fetches_failed;
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -72,6 +73,9 @@ impl Scraper for LeverScraper {
         let mut out = vec![];
         let total = input.companies.len();
 
+        let mut successful_fetches = 0usize;
+        let mut first_fetch_error: Option<String> = None;
+
         for (i, company) in input.companies.iter().enumerate() {
             if ctx.signal.is_cancelled() {
                 break;
@@ -87,24 +91,23 @@ impl Scraper for LeverScraper {
                 urlencoding::encode(company)
             );
 
-            let data =
+            let postings =
                 match fetch_json::<Vec<LeverPosting>>(&url, Default::default(), ctx.signal.clone())
                     .await
                 {
                     Ok(d) => d,
                     Err(e) => {
-                        log::warn!("[lever] fetch failed for '{}': {e}", company);
+                        // A fetch that failed because the run was cancelled is not
+                        // a real board-level error.
                         if ctx.signal.is_cancelled() {
                             break;
                         }
+                        log::warn!("[lever] fetch failed for '{}': {e}", company);
+                        first_fetch_error.get_or_insert_with(|| e.to_string());
                         continue;
                     }
                 };
-
-            let postings = match data {
-                Some(d) => d,
-                None => continue,
-            };
+            successful_fetches += 1;
 
             for p in postings {
                 let posting = JobPosting {
@@ -132,6 +135,14 @@ impl Scraper for LeverScraper {
             if let Some(ref on_progress) = ctx.on_progress {
                 on_progress((i + 1) as f32 / total as f32);
             }
+        }
+
+        // Distinguishes an all-slug 403/parse-drift run from a genuine zero result;
+        // see `ats_all_fetches_failed` for the decision.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/pinpoint/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/pinpoint/mod.rs
@@ -7,7 +7,9 @@
 //! Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/pinpoint.mjs`.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{is_https_url, is_valid_dns_label_slug, normalize_companies};
+use super::common::{
+    ats_all_fetches_failed, is_https_url, is_valid_dns_label_slug, normalize_companies,
+};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -176,18 +178,10 @@ impl Scraper for PinpointScraper {
                 }
             };
 
-            let resp = match data {
-                Some(d) => {
-                    successful_fetches += 1;
-                    d
-                }
-                None => {
-                    if let Some(ref on_progress) = ctx.on_progress {
-                        on_progress((i + 1) as f32 / total as f32);
-                    }
-                    continue;
-                }
-            };
+            // A non-2xx / schema-drift response is now an `Err` above (which records
+            // `first_fetch_error`), so reaching here means a real success — count it.
+            successful_fetches += 1;
+            let resp = data;
 
             for posting in parse_pinpoint_response(resp, &company, now) {
                 if let Some(ref on_item) = ctx.on_item {
@@ -201,13 +195,11 @@ impl Scraper for PinpointScraper {
             }
         }
 
-        // Return Err only when every attempt failed — partial success is kept.
-        if successful_fetches == 0 {
-            if let Some(error) = first_fetch_error {
-                return Err(anyhow::anyhow!(
-                    "all pinpoint company fetches failed: {error}"
-                ));
-            }
+        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/recruitee/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/recruitee/mod.rs
@@ -5,6 +5,7 @@
 /// board with `"needs-company"` when `input.companies` is empty.
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
+use super::common::ats_all_fetches_failed;
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -79,6 +80,9 @@ impl Scraper for RecruiteeScraper {
         let mut out = vec![];
         let total = input.companies.len();
 
+        let mut successful_fetches = 0usize;
+        let mut first_fetch_error: Option<String> = None;
+
         for (i, company) in input.companies.iter().enumerate() {
             if ctx.signal.is_cancelled() {
                 break;
@@ -103,18 +107,18 @@ impl Scraper for RecruiteeScraper {
             {
                 Ok(d) => d,
                 Err(e) => {
-                    log::warn!("[recruitee] fetch failed for '{}': {e}", company);
+                    // A fetch that failed because the run was cancelled is not
+                    // a real board-level error.
                     if ctx.signal.is_cancelled() {
                         break;
                     }
+                    log::warn!("[recruitee] fetch failed for '{}': {e}", company);
+                    first_fetch_error.get_or_insert_with(|| e.to_string());
                     continue;
                 }
             };
-
-            let offers = match data {
-                Some(d) => d.offers,
-                None => continue,
-            };
+            successful_fetches += 1;
+            let offers = data.offers;
 
             for o in offers {
                 let description = vec![
@@ -178,6 +182,14 @@ impl Scraper for RecruiteeScraper {
             if let Some(ref on_progress) = ctx.on_progress {
                 on_progress((i + 1) as f32 / total as f32);
             }
+        }
+
+        // Distinguishes an all-slug 403/parse-drift run from a genuine zero result;
+        // see `ats_all_fetches_failed` for the decision.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/remoteok/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/remoteok/mod.rs
@@ -54,17 +54,14 @@ impl Scraper for RemoteOkScraper {
         ctx: ScrapeContext,
     ) -> anyhow::Result<Vec<JobPosting>> {
         let q = input.query.trim().to_lowercase();
+        // A non-2xx or schema-drift response now propagates as `Err` (surfaced in
+        // `BoardScrapeSummary.error`) instead of a silent empty result.
         let items = fetch_json::<Vec<RemoteOkItem>>(
             "https://remoteok.com/api",
             Default::default(),
             ctx.signal,
         )
         .await?;
-
-        let items = match items {
-            Some(i) => i,
-            None => return Ok(vec![]),
-        };
 
         let now = chrono::Utc::now().timestamp_millis();
         let mut out = vec![];

--- a/apps/desktop/src-tauri/src/scraping/boards/remotive/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/remotive/mod.rs
@@ -55,12 +55,11 @@ impl Scraper for RemotiveScraper {
             )
         };
 
-        let data = fetch_json::<Resp>(&url, Default::default(), ctx.signal).await?;
-
-        let jobs = match data {
-            Some(d) => d.jobs,
-            None => return Ok(vec![]),
-        };
+        // A non-2xx or schema-drift response now propagates as `Err` (surfaced in
+        // `BoardScrapeSummary.error`) instead of a silent empty result.
+        let jobs = fetch_json::<Resp>(&url, Default::default(), ctx.signal)
+            .await?
+            .jobs;
 
         let now = chrono::Utc::now().timestamp_millis();
         let mut out = vec![];

--- a/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
@@ -7,7 +7,7 @@
 //! Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/rippling.mjs`.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::normalize_companies;
+use super::common::{ats_all_fetches_failed, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -224,18 +224,10 @@ impl Scraper for RipplingScraper {
                 }
             };
 
-            let jobs = match data {
-                Some(d) => {
-                    successful_fetches += 1;
-                    rows_to_jobs(d)
-                }
-                None => {
-                    if let Some(ref on_progress) = ctx.on_progress {
-                        on_progress((i + 1) as f32 / total as f32);
-                    }
-                    continue;
-                }
-            };
+            // A non-2xx / schema-drift response is now an `Err` above (which records
+            // `first_fetch_error`), so reaching here means a real success — count it.
+            successful_fetches += 1;
+            let jobs = rows_to_jobs(data);
 
             for posting in parse_rippling_response(jobs, company, now) {
                 if let Some(ref on_item) = ctx.on_item {
@@ -249,13 +241,11 @@ impl Scraper for RipplingScraper {
             }
         }
 
-        // Return Err only when every attempt failed — partial success is kept.
-        if successful_fetches == 0 {
-            if let Some(error) = first_fetch_error {
-                return Err(anyhow::anyhow!(
-                    "all rippling company fetches failed: {error}"
-                ));
-            }
+        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/smartrecruiters/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/smartrecruiters/mod.rs
@@ -6,7 +6,7 @@
 //! this board with `"needs-company"` when `input.companies` is empty.
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::normalize_companies;
+use super::common::{ats_all_fetches_failed, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -100,6 +100,9 @@ impl Scraper for SmartRecruitersScraper {
         let companies = normalize_companies(&input.companies, MAX_COMPANIES);
         let company_count = companies.len();
 
+        let mut successful_fetches = 0usize;
+        let mut first_fetch_error: Option<String> = None;
+
         for (ci, company) in companies.iter().enumerate() {
             if ctx.signal.is_cancelled() {
                 break;
@@ -128,23 +131,24 @@ impl Scraper for SmartRecruitersScraper {
                 {
                     Ok(l) => l,
                     Err(e) => {
-                        log::warn!("[smartrecruiters] list fetch failed for '{}': {e}", company);
+                        // A fetch that failed because the run was cancelled is not
+                        // a real board-level error.
                         if ctx.signal.is_cancelled() {
                             break;
+                        }
+                        // A non-2xx / schema-drift list response now records the
+                        // failure so an all-slug 403 run returns Err (not a silent
+                        // zero) via the all-fail check below.
+                        log::warn!("[smartrecruiters] list fetch failed for '{}': {e}", company);
+                        first_fetch_error.get_or_insert_with(|| e.to_string());
+                        if let Some(ref on_progress) = ctx.on_progress {
+                            on_progress((ci + 1) as f32 / company_count as f32);
                         }
                         continue;
                     }
                 };
-
-            let postings = match list {
-                Some(l) => l.content,
-                None => {
-                    if let Some(ref on_progress) = ctx.on_progress {
-                        on_progress((ci + 1) as f32 / company_count as f32);
-                    }
-                    continue;
-                }
-            };
+            successful_fetches += 1;
+            let postings = list.content;
 
             let posting_count = postings.len();
 
@@ -159,10 +163,10 @@ impl Scraper for SmartRecruitersScraper {
                     p.id
                 );
 
-                // On a detail-fetch error yield `None` (not `continue`) so the
-                // progress emission + politeness sleep below still run every
-                // iteration; otherwise repeated detail errors would stop
-                // rate-limiting requests and stall progress.
+                // Detail is best-effort: a failed detail fetch (404 / non-2xx /
+                // schema drift) skips only this posting, never the whole board — the
+                // list fetch already counted as a success. The progress emission +
+                // politeness sleep still run so pacing and rate-limiting hold.
                 let detail = match fetch_json::<DetailResp>(
                     &detail_url,
                     Default::default(),
@@ -174,19 +178,6 @@ impl Scraper for SmartRecruitersScraper {
                     Err(e) => {
                         log::warn!(
                             "[smartrecruiters] detail fetch failed for posting {} ({detail_url}): {e}; skipping",
-                            p.id
-                        );
-                        None
-                    }
-                };
-
-                let detail = match detail {
-                    Some(d) => d,
-                    None => {
-                        // Detail unavailable (404 / parse failure): skip this posting
-                        // but still run the progress + sleep so pacing holds.
-                        log::debug!(
-                            "[smartrecruiters] detail returned None for posting {} — skipping",
                             p.id
                         );
                         if let Some(ref on_progress) = ctx.on_progress {
@@ -295,6 +286,15 @@ impl Scraper for SmartRecruitersScraper {
             if let Some(ref on_progress) = ctx.on_progress {
                 on_progress((ci + 1) as f32 / company_count as f32);
             }
+        }
+
+        // Distinguishes an all-slug 403 run from a genuine zero result (detail-only
+        // failures don't count — the list fetch already counted as a success); see
+        // `ats_all_fetches_failed` for the decision.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/themuse/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/themuse/mod.rs
@@ -8,7 +8,7 @@
 /// Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/themuse.mjs`.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::matches_filters;
+use super::common::{matches_filters, should_propagate_page_error};
 use crate::error::AppError;
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -167,43 +167,28 @@ impl Scraper for TheMuseScraper {
                 break;
             }
 
-            let data = match fetch_json::<TmResponse>(
+            // A non-2xx or schema-drift response now propagates as `Err`. On page 0
+            // (nothing collected yet) that surfaces as a board error instead of a
+            // silent empty result; on a later page it stops pagination and keeps
+            // what was already streamed (partial success).
+            let resp = match fetch_json::<TmResponse>(
                 &format!("{BASE_URL}?page={page}"),
                 Default::default(),
                 ctx.signal.clone(),
             )
             .await
             {
-                Ok(d) => d,
+                Ok(r) => r,
                 // A cancel firing mid-fetch is a clean stop, not a failure —
                 // even on page 0 with nothing collected yet, this must return
                 // `Ok(out)` (empty), not bubble as an error.
                 Err(AppError::Cancelled) => break,
-                Err(e) if out.is_empty() => return Err(e.into()),
+                Err(e) if should_propagate_page_error(out.len()) => return Err(e.into()),
                 Err(e) => {
                     log::warn!(
                         "[themuse] page {page} failed: {e}; returning {} collected",
                         out.len()
                     );
-                    break;
-                }
-            };
-
-            // A non-2xx response or a body that doesn't match the expected
-            // shape comes back as `None` from `fetch_json` — treat that page
-            // as empty/stop rather than erroring out the whole scrape. Page 0
-            // going `None` already surfaces as an empty `out` to the caller;
-            // a later page going `None` is silent truncation otherwise, so
-            // log it.
-            let resp = match data {
-                Some(r) => r,
-                None => {
-                    if page > 0 {
-                        log::warn!(
-                            "[themuse] page {page} returned None (non-2xx or shape mismatch); stopping with {} collected",
-                            out.len()
-                        );
-                    }
                     break;
                 }
             };

--- a/apps/desktop/src-tauri/src/scraping/boards/workable/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/workable/mod.rs
@@ -11,7 +11,7 @@
 //! doc/blog — so it isn't marked "unverified" like those.
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::normalize_companies;
+use super::common::{ats_all_fetches_failed, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -297,18 +297,10 @@ impl Scraper for WorkableScraper {
                     }
                 };
 
-            let resp = match data {
-                Some(d) => {
-                    successful_fetches += 1;
-                    d
-                }
-                None => {
-                    if let Some(ref on_progress) = ctx.on_progress {
-                        on_progress((i + 1) as f32 / total as f32);
-                    }
-                    continue;
-                }
-            };
+            // A non-2xx / schema-drift response is now an `Err` above (which records
+            // `first_fetch_error`), so reaching here means a real success — count it.
+            successful_fetches += 1;
+            let resp = data;
 
             let company = resp
                 .name
@@ -331,13 +323,11 @@ impl Scraper for WorkableScraper {
             }
         }
 
-        // Return Err only when every attempt failed — partial success is kept.
-        if successful_fetches == 0 {
-            if let Some(error) = first_fetch_error {
-                return Err(anyhow::anyhow!(
-                    "all workable company fetches failed: {error}"
-                ));
-            }
+        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
+        if let Some(message) =
+            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
+        {
+            return Err(anyhow::anyhow!(message));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/wwr/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/wwr/mod.rs
@@ -33,7 +33,9 @@ impl Scraper for WeWorkRemotelyScraper {
         .await?;
 
         if res.status_code != 200 {
-            return Ok(vec![]);
+            // Representable failure: a non-2xx feed response is a failed board, not
+            // a silent zero — surface the status into `BoardScrapeSummary.error`.
+            return Err(anyhow::anyhow!("HTTP {}", res.status_code));
         }
 
         let now = chrono::Utc::now().timestamp_millis();

--- a/apps/desktop/src-tauri/src/scraping/boards/ycombinator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ycombinator/mod.rs
@@ -65,14 +65,15 @@ impl Scraper for YCombinatorScraper {
     ) -> anyhow::Result<Vec<JobPosting>> {
         let q = input.query.trim().to_lowercase();
 
-        // Step 1: fetch the list of job story IDs
+        // Step 1: fetch the list of job story IDs. A non-2xx or schema-drift
+        // response propagates as `Err` (surfaced in `BoardScrapeSummary.error`)
+        // rather than a silent empty result; a genuine empty list is `Ok([])`.
         let ids = fetch_json::<Vec<i64>>(
             &format!("{}/jobstories.json", HN_BASE),
             Default::default(),
             ctx.signal.clone(),
         )
-        .await?
-        .unwrap_or_default();
+        .await?;
 
         if ids.is_empty() {
             return Ok(vec![]);
@@ -92,6 +93,8 @@ impl Scraper for YCombinatorScraper {
                 break;
             }
 
+            // Per-item fetch is best-effort: a single failed/absent item (404,
+            // deleted `null` body, or drift) skips that item, never the whole run.
             let item = match fetch_json::<HnItem>(
                 &format!("{}/item/{}.json", HN_BASE, id),
                 Default::default(),
@@ -99,8 +102,7 @@ impl Scraper for YCombinatorScraper {
             )
             .await
             {
-                Ok(Some(i)) => i,
-                Ok(None) => continue,
+                Ok(i) => i,
                 Err(e) => {
                     log::warn!("[ycombinator] item {id} failed: {e}; skipping");
                     continue;

--- a/apps/desktop/src-tauri/src/scraping/boards/ycombinator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ycombinator/mod.rs
@@ -104,7 +104,9 @@ impl Scraper for YCombinatorScraper {
             {
                 Ok(i) => i,
                 Err(e) => {
-                    log::warn!("[ycombinator] item {id} failed: {e}; skipping");
+                    // debug, not warn: a deleted HN item (null body → Parse err) is a
+                    // routine, expected condition, not a board-level problem.
+                    log::debug!("[ycombinator] item {id} failed: {e}; skipping");
                     continue;
                 }
             };

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -921,6 +921,158 @@ async fn scrape_boards_partial_success_under_cancel_returns_ok() {
     );
 }
 
+// ── TRUST PR A: honest-failure containment ────────────────────────────────────
+
+/// TRUST PR A — a board that fails all its fetches surfaces its failure without
+/// killing the batch, and a genuine empty result stays distinguishable from a
+/// failure.
+///
+/// This pins the sink end of the "representable fetch failures" contract. After
+/// PR A a board that hits a non-2xx / schema-drift / all-slug-fail returns `Err`
+/// (carrying the HTTP status) instead of a silent `Ok([])`. The engine must:
+///   - contain that `Err` into the board's `BoardScrapeSummary.error` (carrying
+///     the status), not bubble it up — `scrape_boards` itself stays `Ok`;
+///   - keep a sibling board's jobs, with its own `error: None`;
+///   - leave a genuinely empty board as `count=0, error=None` (a real zero is
+///     NOT a failure — that distinction is the whole point of the PR).
+///
+/// It complements `scraping/http/test.rs`'s source-end coverage
+/// (`test_fetch_json_non_2xx_carries_status` → `Err(Provider("HTTP 403"))`,
+/// `test_fetch_json_invalid` → `Err(Parse)`): those prove the fetch layer
+/// produces the `Err`; this proves the engine surfaces it honestly. Board
+/// `search()` methods hardcode their production hosts (no base-URL injection
+/// seam), so their per-board `?`/all-fail propagation can only be exercised
+/// through this engine seam without a live network — see the log note.
+#[tokio::test]
+async fn scrape_boards_failed_board_surfaces_error_and_keeps_siblings() {
+    // Mimics a board that propagated a fetch failure — germantechjobs' non-200
+    // `Err(anyhow!("HTTP {status}"))`, or an ATS all-slug-fail
+    // `Err("all lever company fetches failed: HTTP 403")`. The "403" substring
+    // is what must survive `e.to_string()` into the summary so a blocked/rotted
+    // board is distinguishable from a genuine zero.
+    struct HttpBlockedScraper;
+
+    #[async_trait::async_trait]
+    impl Scraper for HttpBlockedScraper {
+        fn id(&self) -> &'static str {
+            "blocked"
+        }
+        fn display_name(&self) -> &'static str {
+            "Blocked"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            _ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            Err(anyhow::anyhow!("HTTP 403"))
+        }
+    }
+
+    static BLOCKED: std::sync::LazyLock<HttpBlockedScraper> =
+        std::sync::LazyLock::new(|| HttpBlockedScraper);
+    // Sibling that succeeds with 3 items — must survive its failing peer.
+    static GOOD: std::sync::LazyLock<FakeScraper> =
+        std::sync::LazyLock::new(|| FakeScraper::http(3));
+    // A genuine empty result — Ok([]), which must NOT be reported as an error.
+    static EMPTY: std::sync::LazyLock<FakeScraper> =
+        std::sync::LazyLock::new(|| FakeScraper::http(0));
+
+    let engine = ScraperEngine::new();
+    // No cancellation: the failing board must be contained into its summary, not
+    // bubble up as a batch-level `Err` (that gate requires a cancelled token).
+    let boards = vec![
+        "blocked-board".to_string(),
+        "good-board".to_string(),
+        "empty-board".to_string(),
+    ];
+
+    let (postings, summaries) = engine
+        .scrape_boards_with_resolver(
+            &boards,
+            fake_input(10),
+            "job-trust-a-containment".to_string(),
+            None,
+            None,
+            // All three fakes are Guest / !requires_company / !needs_keys, so no
+            // skip fires regardless of data_dir — `.` matches the partial-cancel test.
+            std::path::Path::new("."),
+            |id| match id {
+                "blocked-board" => Ok(&*BLOCKED as &'static dyn Scraper),
+                "good-board" => Ok(&*GOOD as &'static dyn Scraper),
+                "empty-board" => Ok(&*EMPTY as &'static dyn Scraper),
+                other => Err(anyhow::anyhow!("Unknown board: {other}")),
+            },
+        )
+        .await
+        .expect("one failing board must not fail the whole batch — scrape_boards must be Ok");
+
+    assert_eq!(
+        summaries.len(),
+        3,
+        "one summary per board; got {summaries:?}"
+    );
+
+    // Failing board: error set + carries the HTTP status, count 0, not skipped.
+    let blocked = summaries
+        .iter()
+        .find(|s| s.board == "blocked-board")
+        .expect("blocked-board summary missing");
+    let err = blocked
+        .error
+        .as_deref()
+        .expect("a failed board must carry an error, not a silent Ok([]) (count=0, error=None)");
+    assert!(
+        err.contains("403"),
+        "the HTTP status must survive into BoardScrapeSummary.error so a blocked board is \
+         distinguishable from a genuine zero; got {err:?}"
+    );
+    assert_eq!(blocked.count, 0, "failed board reports count=0");
+    assert!(
+        blocked.skipped.is_none(),
+        "a fetch failure is an error, not a skip"
+    );
+
+    // Genuine empty board: the trust distinction — a real zero is Ok, not an error.
+    let empty = summaries
+        .iter()
+        .find(|s| s.board == "empty-board")
+        .expect("empty-board summary missing");
+    assert!(
+        empty.error.is_none(),
+        "a genuine empty result must NOT be reported as an error; got {empty:?}"
+    );
+    assert!(empty.skipped.is_none(), "an empty result is not a skip");
+    assert_eq!(empty.count, 0, "empty board reports count=0 with no error");
+
+    // Sibling success board: succeeds, no error, its items are kept.
+    let good = summaries
+        .iter()
+        .find(|s| s.board == "good-board")
+        .expect("good-board summary missing");
+    assert!(
+        good.error.is_none(),
+        "the succeeding board must not inherit its failing peer's error; got {good:?}"
+    );
+    assert!(good.skipped.is_none(), "good board must not be skipped");
+    assert_eq!(good.count, 3, "good board returns its 3 items");
+
+    // Only the good board's 3 postings are aggregated — the failed and empty
+    // boards each contribute none.
+    assert_eq!(
+        postings.len(),
+        3,
+        "only the good board's items are aggregated; got {postings:?}"
+    );
+    assert!(
+        postings.iter().all(|p| p.source == "fake"),
+        "all recovered postings must come from the good (fake) board"
+    );
+}
+
 // ── F1: empty boards guard ────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/apps/desktop/src-tauri/src/scraping/http/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/http/mod.rs
@@ -281,11 +281,23 @@ fn retry_after_ms(headers: &reqwest::header::HeaderMap) -> Option<u64> {
     Some(secs.saturating_mul(1_000).min(30_000))
 }
 
+/// Fetch a URL and deserialize a 2xx JSON body into `T`.
+///
+/// Failures are **representable** — a caller can tell these three apart:
+/// - **(a) HTTP failure** — a non-2xx response returns `Err(AppError::Provider("HTTP <status>"))`,
+///   carrying the status code.
+/// - **(b) schema drift** — a 2xx body that does not deserialize into `T` returns
+///   `Err(AppError::Parse(_))` (serde detail is logged, not returned, so no body value crosses IPC).
+/// - **(c) success (incl. empty)** — a 2xx body that deserializes returns `Ok(T)`; a genuinely empty
+///   payload (e.g. `[]`/`{}`) is `Ok(empty)`, never conflated with a failure.
+///
+/// Transport/cancellation faults from [`fetch_text`] (`AppError::Cancelled`/`Network`/`Validation`)
+/// propagate unchanged via `?`.
 pub async fn fetch_json<T: for<'de> serde::Deserialize<'de>>(
     url: &str,
     opts: FetchOptions,
     signal: tokio_util::sync::CancellationToken,
-) -> AppResult<Option<T>> {
+) -> AppResult<T> {
     // Merge `accept: application/json` into caller headers.
     // Caller-supplied headers win — if the caller already set an `accept` header we
     // leave it as-is; otherwise we prepend the JSON accept so fetch_text's broader
@@ -326,19 +338,20 @@ pub async fn fetch_json<T: for<'de> serde::Deserialize<'de>>(
             "[scraping::http] non-2xx HTTP {} for {safe_url}",
             res.status_code
         );
-        return Ok(None);
+        // (a) Upstream non-2xx — carry the status code so a blocked/rotted/mistyped
+        // board is distinguishable from a genuine empty result, not a silent `Ok`.
+        return Err(AppError::Provider(format!("HTTP {}", res.status_code)));
     }
 
-    match serde_json::from_str::<T>(&res.text) {
-        Ok(value) => Ok(Some(value)),
-        Err(e) => {
-            log::warn!(
-                "[scraping::http] fetch_json parse failure for {safe_url} ({e}); body_len={}",
-                res.text.len()
-            );
-            Ok(None)
-        }
-    }
+    serde_json::from_str::<T>(&res.text).map_err(|e| {
+        log::warn!(
+            "[scraping::http] fetch_json parse failure for {safe_url} ({e}); body_len={}",
+            res.text.len()
+        );
+        // (b) Schema drift. The serde detail is logged above but kept out of the
+        // returned message so no body value can cross IPC → renderer.
+        AppError::Parse("response body did not match the expected schema".to_string())
+    })
 }
 
 pub fn strip_html(html: &str) -> String {

--- a/apps/desktop/src-tauri/src/scraping/http/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/http/test.rs
@@ -185,14 +185,15 @@ async fn test_fetch_json_success() {
         .mount(&mock_server)
         .await;
 
-    let result =
-        fetch_json::<TestResponse>(&mock_server.uri(), FetchOptions::default(), signal).await;
-    let parsed = result
-        .expect("fetch_json should succeed")
-        .expect("fetch_json should deserialize the response");
+    let parsed = fetch_json::<TestResponse>(&mock_server.uri(), FetchOptions::default(), signal)
+        .await
+        .expect("fetch_json should succeed and deserialize the response");
     assert_eq!(parsed.message, "test");
 }
 
+/// (b) A 2xx body that doesn't deserialize into the target type is a
+/// representable schema-drift failure (`AppError::Parse`), not a silent empty
+/// success — so a board sees the failure and can surface it.
 #[tokio::test]
 async fn test_fetch_json_invalid() {
     use wiremock::matchers::method;
@@ -206,10 +207,56 @@ async fn test_fetch_json_invalid() {
         .mount(&mock_server)
         .await;
 
-    let result: crate::error::AppResult<Option<serde_json::Value>> =
+    let result: crate::error::AppResult<serde_json::Value> =
         fetch_json(&mock_server.uri(), FetchOptions::default(), signal).await;
-    assert!(result.is_ok());
-    assert!(result.unwrap().is_none());
+    match result {
+        Err(crate::error::AppError::Parse(msg)) => {
+            // Pin the exact static message — the serde detail (which would
+            // quote fragments of the body) is logged separately and must
+            // never reach the returned error, since that error crosses IPC
+            // into `BoardScrapeSummary.error` → renderer.
+            assert_eq!(
+                msg, "response body did not match the expected schema",
+                "Parse message must be the static no-leak string, not serde detail"
+            );
+            assert!(
+                !msg.contains("invalid json"),
+                "Parse message must not contain the mock response body: {msg:?}"
+            );
+        }
+        other => panic!("expected a Parse error on schema drift, got {other:?}"),
+    }
+}
+
+/// (a) A non-2xx response is a representable HTTP failure that carries the
+/// status code (`AppError::Provider("HTTP <status>")`), never a silent empty
+/// success — this is what makes a blocked/rotted board distinguishable from
+/// "no jobs".
+#[tokio::test]
+async fn test_fetch_json_non_2xx_carries_status() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let signal = tokio_util::sync::CancellationToken::new();
+
+    // 403 is not 429/503, so the retry loop returns it immediately.
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(403).set_body_string(r#"{"message":"blocked"}"#))
+        .mount(&mock_server)
+        .await;
+
+    let result: crate::error::AppResult<serde_json::Value> =
+        fetch_json(&mock_server.uri(), FetchOptions::default(), signal).await;
+    match result {
+        Err(crate::error::AppError::Provider(msg)) => {
+            assert!(
+                msg.contains("403"),
+                "status code should be carried, got {msg:?}"
+            );
+        }
+        other => panic!("expected a Provider error carrying the status, got {other:?}"),
+    }
 }
 
 /// fetch_json must forward caller-supplied headers (e.g. X-API-Key) intact.
@@ -245,9 +292,7 @@ async fn test_fetch_json_preserves_caller_headers() {
     )
     .await;
 
-    let parsed = result
-        .expect("fetch_json should succeed")
-        .expect("response should be deserialized");
+    let parsed = result.expect("fetch_json should succeed and deserialize the response");
     assert!(parsed.ok, "expected ok:true — X-API-Key header was dropped");
 }
 

--- a/docs/knowledge/scraping-domain.md
+++ b/docs/knowledge/scraping-domain.md
@@ -1,6 +1,6 @@
 # Scraping domain (boards, company-scoped, aggregator)
 
-Last updated: 2026-07-02
+Last updated: 2026-07-10
 
 Describes the job-scraping subsystem: board registry (23 active scrapers), company-scoped ATS boards, and the Adzuna/JSearch aggregator. **Shape only** — refer to source for implementation detail. See `docs/SCRAPING_ENDPOINTS.md` for verified endpoint snapshots (external reconnaissance) and `docs/knowledge/decision-records/adr-026-retire-anti-bot-boards.md` for the retirement rationale.
 
@@ -202,8 +202,16 @@ Results now persist across navigation thanks to React Query + backend cache:
   - The Muse: `apps/desktop/src-tauri/src/scraping/boards/themuse/mod.rs`
 - **Aggregator:**
   - Registry: `apps/desktop/src-tauri/src/scraping/boards/aggregator/`
-  - Adzuna provider: `apps/desktop/src-tauri/src/scraping/boards/aggregator/adzuna.rs`
-  - JSearch provider: `apps/desktop/src-tauri/src/scraping/boards/aggregator/jsearch.rs`
+  - Providers (Adzuna, JSearch, Apify): `apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs` (JobProvider trait + implementations)
+
+## Error representability (PR A, 2026-07-10)
+
+Board fetch errors are now representable end-to-end, distinguishing between "board is blocked/rotted/misconfigured" and "no jobs found".
+
+- **`fetch_json` signature** — `apps/desktop/src-tauri/src/scraping/http/mod.rs`. Returns `AppResult<T>` (was `AppResult<Option<T>>`). Non-2xx responses → `Err(AppError::Provider("HTTP <status>"))` (preserves status code). Serde drift → `Err(AppError::Parse("response body did not match the expected schema"))` (serde details logged, never returned). 2xx-valid → `Ok(T)`. Empty payloads return `Ok(empty)` not `Ok(None)`.
+- **`fetch_text` boards** — germantechjobs, wwr, berlinstartupjobs now propagate non-200 as errors instead of silent-empty.
+- **Board error outcome** — All boards propagate fetch errors via `search()` → `Err`, which surfaces in `BoardScrapeSummary.error: Option<String>` (engine records it). Boards with multi-company fanout (lever, recruitee, smartrecruiters, etc.) track `successful_fetches` and `first_fetch_error`; when `successful_fetches == 0`, the error propagates (all-fail → board error, not `Ok(empty)`). Pagination boards (themuse, arbeitnow, arbeitsagentur) distinguish page-0 failure (error) from later-page failure (keep partial harvest).
+- **Shared decision functions** — `apps/desktop/src-tauri/src/scraping/boards/common.rs` exports two pure fns: `ats_all_fetches_failed(board_id, successful_fetches, first_fetch_error) -> Option<String>` (returns error message only when all companies failed) and `should_propagate_page_error(collected_so_far: usize) -> bool` (propagate if nothing collected yet, else keep partial harvest). Wired into 10 ATS boards + 3 paginated boards; no production URL embedded (testable without wiremock).
 - **Frontend:** Service hook `apps/desktop/src/renderer/services/boards.ts` (scrape mutations)
 - **Settings UI:** `apps/desktop/src/renderer/features/settings/routes/JobsSettings.tsx`
 - **Detail pane:**


### PR DESCRIPTION
## Summary

PR A of the job-search trust program (audit 2026-07-10, `.claude/scratch/job-search-trust-audit.md`): the scrape fleet's #1 trust killer was `fetch_json` collapsing every non-2xx response and schema-drift parse failure into `Ok(None)`, which nearly every board rendered as a successful zero-result run — a blocked, rotted, or mistyped-slug board was indistinguishable from "no jobs".

## What changed

- `scraping/http/mod.rs` — `fetch_json` returns `AppResult<T>` (was `AppResult<Option<T>>`): non-2xx → `Err(Provider("HTTP <status>"))`, schema drift → `Err(Parse(static message))` with serde detail kept log-side only. The `Option` removal compile-forces every call site to handle failure honestly.
- All ~20 `fetch_json` board call sites propagate errors into `BoardScrapeSummary.error` instead of mapping to empty success; `germantechjobs`/`wwr`/`berlinstartupjobs` (`fetch_text`) err on non-200 (fixes the documented germantechjobs `/rss` 403 silent zero).
- ATS boards: shared `ats_all_fetches_failed` gate in `scraping/boards/common.rs` wired into all 10 ATS boards — an all-companies-failed run now returns `Err` (closes the wrong-company-slug silent zero); lever/recruitee/smartrecruiters gained the `successful_fetches`/`first_fetch_error` tracking they lacked.
- Paginated boards (themuse/arbeitnow/arbeitsagentur): shared `should_propagate_page_error` — page-0 failure propagates, later-page failure keeps the partial harvest; user-cancel breaks cleanly instead of surfacing as a board error.
- Adzuna/JSearch raw HTTP failures carry their provider prefix so aggregator errors stay attributable.
- Tests: `fetch_json` contract tests (403 carries status, Parse message pinned static + no-body-leak guard), truth-table tests for both shared fns, engine containment test (failing board's error lands in its summary, siblings' jobs survive, genuine-empty stays distinct).
- Docs: `docs/knowledge/scraping-domain.md` synced (error contract + stale aggregator file refs).

## Review trail (internal fleet)

- scraping-applier-expert: APPROVE-WITH-FIXES → provider-prefix fix applied
- testing-reviewer: REQUEST-CHANGES → pure-fn extraction + truth-table tests → APPROVE
- tauri-security-reviewer: PASS-WITH-ADVISORIES (no HIGH/CRITICAL; error strings verified URL/body/secret-free)
- pr-reviewer ×2 (opus+sonnet): PASS → cancelled-break guards + log-level + doc fixes applied

## Test plan

- CI runs the full Rust suite (local `cargo test` blocked by the known host entrypoint fault; `cargo check --tests` + `clippy --tests` + `fmt --check` clean locally).
- Manual: a board returning 403/404 now shows in its `BoardScrapeSummary.error` instead of "0 jobs".

Part 1/8 of the trust program — next: PR B (honest autopilot run status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)