### PR TITLE
feat: make location broadening and guessed markets visible

### DIFF
--- a/apps/desktop/src-tauri/src/autopilot/test.rs
+++ b/apps/desktop/src-tauri/src/autopilot/test.rs
@@ -479,6 +479,7 @@ fn board_summary(
         error: error.map(String::from),
         skipped: skipped.map(String::from),
         truncated: truncated.map(String::from),
+        note: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
@@ -540,6 +540,7 @@ mod tests {
             error: error.map(String::from),
             skipped: skipped.map(String::from),
             truncated: truncated.map(String::from),
+            note: None,
         }
     }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -244,6 +244,13 @@ async fn primary_chain(
     // No working fallback fired. If we retained sparse guessed-market items, return
     // them rather than the diagnostic — a user with only Adzuna keys keeps their few
     // legit hits (better than nothing). The uncertainty was already logged above.
+    //
+    // NOTE (deliberately under-surfaced, PR D): this salvage path — and the sibling
+    // one at the `sparse_guessed_items.take()` above — return the sparse guessed
+    // hits WITHOUT a `BoardScrapeSummary.note`, because only `primary_chain` (not
+    // `AdzunaProvider`, which holds the note sink) knows the guess was salvaged
+    // rather than authoritative or replaced. Revisit when PR F threads location
+    // context through this path.
     if let Some(items) = sparse_guessed_items {
         return Ok(dedupe(items));
     }
@@ -525,9 +532,11 @@ impl Scraper for AggregatorScraper {
             .unwrap_or_else(|| "de".to_string());
 
         // Construct providers fresh per call so that key changes made in Settings
-        // take effect immediately without requiring an app restart.
+        // take effect immediately without requiring an app restart. Adzuna carries
+        // the location-policy note sink so its guessed-market / broadening decisions
+        // surface as `BoardScrapeSummary.note` (see `AdzunaProvider::report_note`).
         let providers: Vec<Box<dyn JobProvider>> = vec![
-            Box::new(AdzunaProvider::new()),
+            Box::new(AdzunaProvider::new().with_note_sink(ctx.on_note.clone())),
             Box::new(JSearchProvider::new()),
             // Additive, opt-in, paid: only runs when the toggle is ON and a token
             // is present (gated in `ApifyLinkedInProvider::is_configured`).

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
@@ -7,6 +7,8 @@
 /// descendants, including `test.rs`) rather than fully private, purely to
 /// preserve this behavior-preserving move — no API surface beyond `aggregator`
 /// is intended.
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -76,6 +78,28 @@ pub(super) fn adzuna_max_days_old(date_filter: Option<&str>) -> u32 {
 /// which keys off Adzuna returning empty.
 pub(super) fn should_broaden(country_guessed: bool, where_val: &str, count: usize) -> bool {
     !country_guessed && !where_val.is_empty() && count < super::ADZUNA_BROADEN_FLOOR
+}
+
+/// User-facing note token when a GUESSED market (no `country_code` was supplied)
+/// returned an AUTHORITATIVE result set — `count` at or above the broaden floor,
+/// so [`super::primary_chain`] returns it as-is instead of routing to the global
+/// (JSearch) fallback. Surfaces the otherwise-silent market guess so the user can
+/// set a country for deterministic results.
+///
+/// `None` for an explicit country, an empty location, or a sub-floor count (which
+/// `primary_chain` re-routes to the global fallback, so no guessed-market results
+/// are actually shown — flagging the guess there would mislead). Country code
+/// only — never the raw location (free-text PII).
+pub(super) fn guessed_market_note(
+    country_guessed: bool,
+    location: &str,
+    count: usize,
+    country: &str,
+) -> Option<String> {
+    // `.trim()` here is defensive for direct unit-test callers — the real call
+    // site (`AdzunaProvider::search`) already passes a caller-trimmed `location`.
+    (country_guessed && !location.trim().is_empty() && count >= super::ADZUNA_BROADEN_FLOOR)
+        .then(|| format!("guessed-market:{country}"))
 }
 
 /// Adzuna's `where` wants a place *inside* the market (the country is already the
@@ -207,6 +231,12 @@ pub(super) struct AdzunaResp {
 pub(crate) struct AdzunaProvider {
     pub(super) app_id: Option<String>,
     pub(super) app_key: Option<String>,
+    /// Optional side-channel for user-facing location-policy notes (guessed
+    /// market, sparse city → country-wide broadening). Injected by
+    /// `AggregatorScraper::search` from the `ScrapeContext`; `None` in unit tests
+    /// and credential-state probes. `Arc` (Send + Sync) so the provider stays
+    /// `Sync` while it holds the sink across `.await`.
+    pub(super) note_sink: Option<Arc<dyn Fn(String) + Send + Sync>>,
 }
 
 impl AdzunaProvider {
@@ -223,6 +253,23 @@ impl AdzunaProvider {
                     log::warn!("[aggregator] {ADZUNA_APP_KEY} keyring error: {e}");
                     None
                 }),
+            note_sink: None,
+        }
+    }
+
+    /// Attach a location-policy note sink (from the aggregator's `ScrapeContext`).
+    pub(super) fn with_note_sink(
+        mut self,
+        sink: Option<Arc<dyn Fn(String) + Send + Sync>>,
+    ) -> Self {
+        self.note_sink = sink;
+        self
+    }
+
+    /// Emit an informational location-policy note through the injected sink, if any.
+    fn report_note(&self, note: String) {
+        if let Some(ref sink) = self.note_sink {
+            sink(note);
         }
     }
 }
@@ -284,6 +331,15 @@ impl JobProvider for AdzunaProvider {
         )
         .await?;
 
+        // Surface the guessed-market policy when this guess produced the
+        // authoritative result (>= floor, so `primary_chain` keeps it). `broaden`
+        // never fires for a guessed market, so `postings.len()` here is final for
+        // that branch. Country code only — the raw location is never emitted.
+        if let Some(note) = guessed_market_note(country_guessed, location, postings.len(), country)
+        {
+            self.report_note(note);
+        }
+
         // Broaden on near-empty: even a hygienic `where` can over-narrow a sparse
         // market, so if a real Adzuna market returned under the floor, retry ONCE
         // country-wide (`where=""`) — same `what`, sort, and `max_days_old` — and
@@ -306,6 +362,9 @@ impl JobProvider for AdzunaProvider {
                         postings.len(),
                         broadened.len()
                     );
+                    // Surface the sparse-city → country-wide broadening. Country
+                    // code only — never the raw location (free-text PII).
+                    self.report_note(format!("broadened:{country}"));
                     return Ok(broadened);
                 }
                 Ok(_) => {}

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -277,6 +277,7 @@ fn adzuna_is_configured_requires_both_keys() {
     let unconfigured = AdzunaProvider {
         app_id: None,
         app_key: None,
+        note_sink: None,
     };
     assert!(!unconfigured.is_configured());
 
@@ -284,6 +285,7 @@ fn adzuna_is_configured_requires_both_keys() {
     let partial = AdzunaProvider {
         app_id: Some("id123".to_string()),
         app_key: None,
+        note_sink: None,
     };
     assert!(!partial.is_configured());
 
@@ -291,6 +293,7 @@ fn adzuna_is_configured_requires_both_keys() {
     let full = AdzunaProvider {
         app_id: Some("id123".to_string()),
         app_key: Some("key456".to_string()),
+        note_sink: None,
     };
     assert!(full.is_configured());
 }
@@ -585,6 +588,7 @@ async fn adzuna_unconfigured_returns_err_without_network() {
     let p = AdzunaProvider {
         app_id: None,
         app_key: None,
+        note_sink: None,
     };
     let result = p
         .search("engineer", "berlin", "de", false, None, None, make_token())
@@ -852,6 +856,7 @@ fn make_ctx() -> ScrapeContext {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     }
 }
 
@@ -1076,6 +1081,41 @@ fn should_broaden_only_for_explicit_sparse_market() {
 }
 
 #[test]
+fn guessed_market_note_only_for_authoritative_guess() {
+    // Guessed market + real location + an AUTHORITATIVE result (>= the floor of 3)
+    // → surface the otherwise-silent market guess, carrying the country code only.
+    assert_eq!(
+        guessed_market_note(true, "London", 3, "de").as_deref(),
+        Some("guessed-market:de")
+    );
+    assert_eq!(
+        guessed_market_note(true, "London", 12, "us").as_deref(),
+        Some("guessed-market:us"),
+        "the note carries the guessed market's country code, never the raw location"
+    );
+
+    // Guessed market but a SUB-floor result (0/1/2): primary_chain re-routes to the
+    // global fallback, so NO guessed-market results are actually shown — flagging
+    // the guess here would mislead. No note.
+    for count in [0usize, 1, 2] {
+        assert_eq!(
+            guessed_market_note(true, "London", count, "de"),
+            None,
+            "a sub-floor guessed result ({count}) routes to the fallback — no note"
+        );
+    }
+
+    // Explicit country (not guessed) → never a guessed-market note; the broaden
+    // path owns the sparse-city case for an explicitly-supplied market.
+    assert_eq!(guessed_market_note(false, "London", 10, "de"), None);
+
+    // Guessed market but EMPTY / whitespace-only location → guessing a default
+    // market for a location-less browse is expected, not worth surfacing.
+    assert_eq!(guessed_market_note(true, "", 10, "de"), None);
+    assert_eq!(guessed_market_note(true, "   ", 10, "de"), None);
+}
+
+#[test]
 fn jsearch_date_posted_maps_correctly() {
     // All sub-day windows floor at "3days" (JSearch has no sub-day token, and
     // "today" zeroed out autopilot "recent" filters on quiet days — regression guard).
@@ -1285,6 +1325,7 @@ async fn adzuna_empty_country_resolves_to_supported_de() {
     let p = AdzunaProvider {
         app_id: Some("fake-id".to_string()),
         app_key: Some("fake-key".to_string()),
+        note_sink: None,
     };
     // Empty country → production code resolves to "de" → passes allowlist → fails
     // downstream at the network/auth layer (no real keys), NOT at country validation.
@@ -1773,6 +1814,7 @@ async fn adzuna_provider_rejects_unsupported_country_before_network() {
     let p = AdzunaProvider {
         app_id: Some("fake-id".to_string()),
         app_key: Some("fake-key".to_string()),
+        note_sink: None,
     };
     // "xx" is not in the allowlist.
     let result = p
@@ -1800,6 +1842,7 @@ async fn adzuna_provider_accepts_supported_country_passes_allowlist() {
     let p = AdzunaProvider {
         app_id: Some("fake-id".to_string()),
         app_key: Some("fake-key".to_string()),
+        note_sink: None,
     };
     // "de" is in the allowlist; the error that comes back must NOT mention the
     // allowlist — it should be a network/auth error (or similar), not a country error.

--- a/apps/desktop/src-tauri/src/scraping/boards/arbeitnow/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/arbeitnow/test.rs
@@ -46,6 +46,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/arbeitsagentur/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/arbeitsagentur/test.rs
@@ -132,6 +132,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/ashby/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ashby/test.rs
@@ -133,6 +133,7 @@ async fn empty_companies_returns_empty_without_network() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let result = scraper.search(input, ctx).await;
     assert!(result.is_ok(), "empty companies must return Ok, not Err");
@@ -174,6 +175,7 @@ async fn cancelled_before_fetch_returns_ok_not_err() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     // Cancel before search runs so the per-company loop breaks on the first
     // iteration without attempting any network I/O.
@@ -223,6 +225,7 @@ async fn all_blank_companies_returns_ok_empty() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let result = scraper.search(input, ctx).await;
     assert!(result.is_ok());
@@ -257,6 +260,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/bamboohr/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/bamboohr/test.rs
@@ -32,6 +32,7 @@ fn make_ctx() -> ScrapeContext {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/berlinstartupjobs/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/berlinstartupjobs/test.rs
@@ -72,6 +72,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/breezy/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/breezy/test.rs
@@ -32,6 +32,7 @@ fn make_ctx() -> ScrapeContext {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/comeet/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/comeet/test.rs
@@ -35,6 +35,7 @@ fn make_ctx() -> ScrapeContext {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/test.rs
@@ -369,6 +369,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/greenhouse/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/greenhouse/test.rs
@@ -134,6 +134,7 @@ async fn empty_companies_returns_empty_without_network() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let result = scraper.search(input, ctx).await;
     assert!(result.is_ok(), "empty companies must return Ok, not Err");
@@ -175,6 +176,7 @@ async fn cancelled_before_fetch_returns_ok_not_err() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     // Cancel before search runs so the per-company loop breaks on the first
     // iteration without attempting any network I/O.
@@ -221,6 +223,7 @@ async fn all_blank_companies_returns_ok_empty() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let result = scraper.search(input, ctx).await;
     assert!(result.is_ok());
@@ -255,6 +258,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/lever/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/lever/test.rs
@@ -95,6 +95,7 @@ async fn empty_companies_returns_empty_without_network() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let result = scraper.search(input, ctx).await;
     assert!(result.is_ok(), "empty companies must return Ok, not Err");
@@ -132,6 +133,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/linkedin/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/linkedin/test.rs
@@ -54,6 +54,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/personio/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/personio/test.rs
@@ -62,6 +62,7 @@ async fn invalid_slug_skipped_without_network() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
 
     // IP:port — the primary SSRF vector.
@@ -304,6 +305,7 @@ async fn empty_companies_returns_empty_without_network() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let result = scraper.search(input, ctx).await;
     assert!(result.is_ok(), "empty companies must return Ok, not Err");
@@ -341,6 +343,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/pinpoint/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/pinpoint/test.rs
@@ -32,6 +32,7 @@ fn make_ctx() -> ScrapeContext {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/recruitee/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/recruitee/test.rs
@@ -32,6 +32,7 @@ fn make_ctx() -> ScrapeContext {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     }
 }
 
@@ -102,6 +103,7 @@ async fn mixed_list_invalid_slug_skipped_no_panic() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     // Cancel immediately so the valid slug's fetch attempt is aborted before
     // any I/O, keeping the test network-free.
@@ -282,6 +284,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/remoteok/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/remoteok/test.rs
@@ -113,6 +113,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/remotive/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/remotive/test.rs
@@ -46,6 +46,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/rippling/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/rippling/test.rs
@@ -32,6 +32,7 @@ fn make_ctx() -> ScrapeContext {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/smartrecruiters/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/smartrecruiters/test.rs
@@ -178,6 +178,7 @@ async fn empty_companies_returns_empty_without_network() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let result = scraper.search(input, ctx).await;
     assert!(result.is_ok(), "empty companies must return Ok, not Err");
@@ -221,6 +222,7 @@ async fn all_blank_companies_returns_ok_empty() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let result = scraper.search(input, ctx).await;
     assert!(result.is_ok());
@@ -255,6 +257,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/themuse/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/themuse/test.rs
@@ -32,6 +32,7 @@ fn make_ctx() -> ScrapeContext {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/workable/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/workable/test.rs
@@ -32,6 +32,7 @@ fn make_ctx() -> ScrapeContext {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/wwr/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/wwr/test.rs
@@ -79,6 +79,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/boards/ycombinator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ycombinator/test.rs
@@ -79,6 +79,7 @@ async fn live_search_returns_results() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     let results = tokio::time::timeout(
         std::time::Duration::from_secs(30),

--- a/apps/desktop/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/mod.rs
@@ -60,6 +60,18 @@ pub struct BoardScrapeSummary {
     /// Serde-optional so records persisted before this field deserialize as `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub truncated: Option<String>,
+    /// Set when a board applied a location policy the user did not explicitly
+    /// request (informational, NOT a failure — `count` is still authoritative):
+    /// - `"guessed-market:<cc>"` — no country was supplied, so the `<cc>` market
+    ///   was guessed and returned an authoritative result set; set a country for
+    ///   deterministic results.
+    /// - `"broadened:<cc>"` — a sparse city search was widened country-wide within
+    ///   the `<cc>` market.
+    ///
+    /// `<cc>` is an ISO country code; the note never carries the raw location
+    /// (free-text PII). Serde-optional so pre-existing records deserialize as `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
 }
 
 /// Maximum number of distinct boards processed per `scrape_boards` call.
@@ -132,6 +144,7 @@ impl ScraperEngine {
         on_progress: Option<Box<dyn Fn(f32) + Send>>,
         on_item: Option<Box<dyn Fn(JobPosting) + Send>>,
         on_truncation: Option<Box<dyn Fn(String) + Send>>,
+        on_note: Option<std::sync::Arc<dyn Fn(String) + Send + Sync>>,
     ) -> anyhow::Result<Vec<JobPosting>> {
         // Central item cap. The board loops stream items through `on_item` and
         // check `ctx.signal`; we count the stream here and cancel the token the
@@ -178,6 +191,7 @@ impl ScraperEngine {
             on_progress,
             on_item: wrapped,
             on_truncation,
+            on_note,
         };
 
         let span = crate::observability::Span::begin("scrape", format!("board={board}"));
@@ -224,6 +238,7 @@ impl ScraperEngine {
         on_progress: Option<Arc<dyn Fn(f32) + Send + Sync>>,
         on_item: Option<Arc<dyn Fn(JobPosting) + Send + Sync>>,
         on_truncation: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
+        on_note: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
         browser_sem: Arc<Semaphore>,
     ) -> Vec<(String, anyhow::Result<Vec<JobPosting>>)> {
         let total = resolved.len();
@@ -241,6 +256,7 @@ impl ScraperEngine {
                 let on_progress = on_progress.clone();
                 let on_item = on_item.clone();
                 let on_truncation = on_truncation.clone();
+                let on_note = on_note.clone();
                 let done = done.clone();
                 let browser_sem = browser_sem.clone();
 
@@ -285,6 +301,18 @@ impl ScraperEngine {
                                 boxed
                             });
 
+                        // Same per-board tagging for the informational location-policy
+                        // note channel; kept as an `Arc` (not a `Box`) because the
+                        // aggregator forwards it to a sub-provider held across `.await`.
+                        let per_board_on_note: Option<Arc<dyn Fn(String) + Send + Sync>> =
+                            on_note.as_ref().map(|arc| {
+                                let arc = arc.clone();
+                                let name = name.clone();
+                                let wrapped: Arc<dyn Fn(String) + Send + Sync> =
+                                    Arc::new(move |note: String| arc(name.clone(), note));
+                                wrapped
+                            });
+
                         let res = Self::run_one(
                             &name,
                             scraper,
@@ -293,6 +321,7 @@ impl ScraperEngine {
                             None,
                             per_board_on_item,
                             per_board_on_truncation,
+                            per_board_on_note,
                         )
                         .await;
 
@@ -461,6 +490,7 @@ impl ScraperEngine {
                     error: None,
                     skipped: Some(reason.into()),
                     truncated: None,
+                    note: None,
                 });
             } else {
                 name_to_idx.insert(id.clone(), idx);
@@ -483,6 +513,21 @@ impl ScraperEngine {
             })
         };
 
+        // Per-board informational location-policy notes (aggregator guessed-market /
+        // sparse city broadened country-wide). Same board-name-keyed collection as
+        // truncations; folded into `BoardScrapeSummary.note` below. Empty for a run
+        // where no board applied such a policy.
+        let notes: Arc<std::sync::Mutex<HashMap<String, String>>> =
+            Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let note_sink: Arc<dyn Fn(String, String) + Send + Sync> = {
+            let notes = notes.clone();
+            Arc::new(move |board, note| {
+                if let Ok(mut guard) = notes.lock() {
+                    guard.insert(board, note);
+                }
+            })
+        };
+
         let results = Self::run_boards(
             runnable,
             input,
@@ -490,6 +535,7 @@ impl ScraperEngine {
             on_progress,
             on_item,
             Some(truncation_sink),
+            Some(note_sink),
             self.browser_sem.clone(),
         )
         .await;
@@ -516,12 +562,14 @@ impl ScraperEngine {
                     // is surfaced here so it is not indistinguishable from a complete
                     // run; a board that completed its pages has no map entry.
                     let truncated = truncations.lock().ok().and_then(|mut m| m.remove(&board));
+                    let note = notes.lock().ok().and_then(|mut m| m.remove(&board));
                     slot_summaries[idx] = Some(BoardScrapeSummary {
                         board,
                         count: postings.len(),
                         error: None,
                         skipped: None,
                         truncated,
+                        note,
                     });
                     all_postings.extend(postings);
                 }
@@ -532,6 +580,7 @@ impl ScraperEngine {
                         error: Some(e.to_string()),
                         skipped: None,
                         truncated: None,
+                        note: None,
                     });
                 }
             }

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -366,6 +366,7 @@ async fn central_amount_cap_truncates_stream_and_return() {
         None,
         Some(on_item),
         None,
+        None,
     )
     .await
     .expect("capped scrape recovers as success");
@@ -421,6 +422,7 @@ async fn run_boards_collects_all_boards_up_to_amount() {
         None,
         Some(on_item),
         None,
+        None,
         test_browser_sem(),
     )
     .await;
@@ -454,6 +456,7 @@ async fn run_boards_one_error_does_not_kill_others() {
         resolved,
         fake_input(10),
         parent,
+        None,
         None,
         None,
         None,
@@ -497,6 +500,7 @@ async fn run_boards_parent_cancel_stops_all() {
         None,
         None,
         None,
+        None,
         test_browser_sem(),
     )
     .await;
@@ -524,6 +528,7 @@ async fn run_boards_child_cap_stops_only_its_board() {
         resolved,
         fake_input(3),
         parent.clone(),
+        None,
         None,
         None,
         None,
@@ -562,6 +567,7 @@ async fn run_boards_browser_board_collects_items() {
         resolved,
         fake_input(10),
         parent,
+        None,
         None,
         None,
         None,
@@ -654,6 +660,7 @@ async fn run_boards_browser_boards_serialized() {
         None,
         None,
         None,
+        None,
         test_browser_sem(),
     )
     .await;
@@ -703,6 +710,7 @@ async fn scrape_boards_dedupes_and_caps_large_input() {
         fake_refs,
         fake_input(1),
         parent,
+        None,
         None,
         None,
         None,
@@ -1211,6 +1219,176 @@ async fn scrape_boards_partial_pagination_surfaces_truncated_and_keeps_count() {
     assert_eq!(complete.count, 4, "complete board returns all its items");
 }
 
+/// PR D — a board that applied a silent location policy (the aggregator's guessed
+/// market / sparse-city broadening) reports it through `ctx.report_note`; the
+/// engine tags it with the board name and attributes it to THAT board's summary
+/// as `BoardScrapeSummary.note`, while a sibling that reports nothing stays
+/// `note: None`. Exercised through the engine seam (the aggregator hardcodes its
+/// providers) rather than a live network — same pattern as the truncation test.
+#[tokio::test]
+async fn scrape_boards_surfaces_location_note_on_the_right_summary() {
+    struct NotingScraper;
+
+    #[async_trait::async_trait]
+    impl Scraper for NotingScraper {
+        fn id(&self) -> &'static str {
+            "noting"
+        }
+        fn display_name(&self) -> &'static str {
+            "Noting"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            let job = JobPosting {
+                id: "noting:0".to_string(),
+                external_id: Some("0".to_string()),
+                title: "Job".to_string(),
+                company: "Note Co".to_string(),
+                location: None,
+                url: "https://note.example.com/0".to_string(),
+                source: "noting".to_string(),
+                description: None,
+                requirements: None,
+                posted_at: None,
+                captured_at: 0,
+                extra: std::collections::HashMap::new(),
+            };
+            if let Some(ref on_item) = ctx.on_item {
+                on_item(job.clone());
+            }
+            // A location policy was applied (e.g. no country supplied → market
+            // guessed) — surface it, country code only.
+            ctx.report_note("guessed-market:de".to_string());
+            Ok(vec![job])
+        }
+    }
+
+    static NOTING: std::sync::LazyLock<NotingScraper> = std::sync::LazyLock::new(|| NotingScraper);
+    // A sibling that applies no policy — must report note: None.
+    static PLAIN: std::sync::LazyLock<FakeScraper> =
+        std::sync::LazyLock::new(|| FakeScraper::http(2));
+
+    let engine = ScraperEngine::new();
+    let boards = vec!["note-board".to_string(), "plain-board".to_string()];
+
+    let (_postings, summaries) = engine
+        .scrape_boards_with_resolver(
+            &boards,
+            fake_input(10),
+            "job-trust-d-note".to_string(),
+            None,
+            None,
+            std::path::Path::new("."),
+            |id| match id {
+                "note-board" => Ok(&*NOTING as &'static dyn Scraper),
+                "plain-board" => Ok(&*PLAIN as &'static dyn Scraper),
+                other => Err(anyhow::anyhow!("Unknown board: {other}")),
+            },
+        )
+        .await
+        .expect("a board that only reports a note still succeeds");
+
+    let noted = summaries
+        .iter()
+        .find(|s| s.board == "note-board")
+        .expect("note-board summary missing");
+    assert_eq!(
+        noted.note.as_deref(),
+        Some("guessed-market:de"),
+        "the location-policy note must survive into BoardScrapeSummary.note on the \
+         reporting board"
+    );
+    assert!(noted.error.is_none() && noted.skipped.is_none() && noted.truncated.is_none());
+
+    let plain = summaries
+        .iter()
+        .find(|s| s.board == "plain-board")
+        .expect("plain-board summary missing");
+    assert!(
+        plain.note.is_none(),
+        "a board that applied no location policy must not be tagged with a note; got {plain:?}"
+    );
+}
+
+/// PR D regression guard — a board that reports a note and THEN fails (returns
+/// `Err`) must end up `note: None` on its summary: the Err arm of
+/// `scrape_boards_with_resolver` intentionally does not read the notes map, so
+/// the note is dropped rather than misattributed to an error summary that also
+/// carries stale/irrelevant location-policy context. Pins the intended Err-arm
+/// behavior for any future note-emitting board.
+#[tokio::test]
+async fn scrape_boards_drops_note_when_board_then_errors() {
+    struct NotingThenFailingScraper;
+
+    #[async_trait::async_trait]
+    impl Scraper for NotingThenFailingScraper {
+        fn id(&self) -> &'static str {
+            "noting-failing"
+        }
+        fn display_name(&self) -> &'static str {
+            "NotingThenFailing"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            // Report a location-policy note, then fail — e.g. Adzuna guessed a
+            // market and reported it, but the subsequent network call errored.
+            ctx.report_note("guessed-market:de".to_string());
+            Err(anyhow::anyhow!("board error"))
+        }
+    }
+
+    static NOTING_FAILING: std::sync::LazyLock<NotingThenFailingScraper> =
+        std::sync::LazyLock::new(|| NotingThenFailingScraper);
+
+    let engine = ScraperEngine::new();
+    let boards = vec!["noting-failing-board".to_string()];
+
+    let (_postings, summaries) = engine
+        .scrape_boards_with_resolver(
+            &boards,
+            fake_input(10),
+            "job-trust-d-note-err".to_string(),
+            None,
+            None,
+            std::path::Path::new("."),
+            |id| match id {
+                "noting-failing-board" => Ok(&*NOTING_FAILING as &'static dyn Scraper),
+                other => Err(anyhow::anyhow!("Unknown board: {other}")),
+            },
+        )
+        .await
+        .expect(
+            "one board erroring with no items recovered is still an Ok run \
+                 (parent token was never cancelled)",
+        );
+
+    let summary = summaries
+        .iter()
+        .find(|s| s.board == "noting-failing-board")
+        .expect("noting-failing-board summary missing");
+    assert!(
+        summary.note.is_none(),
+        "a note reported before an Err must be dropped, not attached to the \
+         error summary; got {summary:?}"
+    );
+    assert!(
+        summary.error.is_some(),
+        "the board error itself must still surface"
+    );
+}
+
 // ── F1: empty boards guard ────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -1394,6 +1572,7 @@ async fn run_boards_preserves_input_order() {
         resolved,
         fake_input(5),
         parent,
+        None,
         None,
         None,
         None,

--- a/apps/desktop/src-tauri/src/scraping/types/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/types/mod.rs
@@ -72,6 +72,15 @@ pub struct ScrapeContext {
     /// is distinguishable from a complete one. `None` for every other board and
     /// whenever no sink is wired (e.g. a board's own unit tests).
     pub on_truncation: Option<Box<dyn Fn(String) + Send>>,
+    /// Per-board **informational** side-channel for a location policy the board
+    /// applied that the user didn't explicitly ask for — currently the aggregator's
+    /// guessed market (no `country_code` supplied) or a sparse city search widened
+    /// country-wide. The engine surfaces it as `BoardScrapeSummary.note`. Unlike
+    /// [`Self::on_truncation`] this is an `Arc`, not a `Box`: the aggregator hands
+    /// it to a sub-provider (`AdzunaProvider`) that holds it across `.await`, so it
+    /// must be `Send + Sync`. `None` when the board reports no policy note and
+    /// whenever no sink is wired (e.g. a board's own unit tests).
+    pub on_note: Option<std::sync::Arc<dyn Fn(String) + Send + Sync>>,
 }
 
 impl ScrapeContext {
@@ -80,6 +89,14 @@ impl ScrapeContext {
     pub fn report_truncation(&self, reason: String) {
         if let Some(ref cb) = self.on_truncation {
             cb(reason);
+        }
+    }
+
+    /// Report an informational location-policy note (see [`ScrapeContext::on_note`]).
+    /// No-op when no sink is wired, so a board can report unconditionally.
+    pub fn report_note(&self, note: String) {
+        if let Some(ref cb) = self.on_note {
+            cb(note);
         }
     }
 }

--- a/apps/desktop/src-tauri/src/scraping/types/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/types/test.rs
@@ -144,6 +144,7 @@ fn test_scrape_context_creation() {
         on_progress: None,
         on_item: None,
         on_truncation: None,
+        on_note: None,
     };
     assert!(!ctx.signal.is_cancelled());
 }
@@ -155,6 +156,7 @@ fn test_scrape_context_with_callbacks() {
         on_progress: Some(Box::new(|_| {})),
         on_item: Some(Box::new(|_| {})),
         on_truncation: None,
+        on_note: None,
     };
     assert!(ctx.on_progress.is_some());
     assert!(ctx.on_item.is_some());

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.test.tsx
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.test.tsx
@@ -30,6 +30,9 @@ vi.mock('@ajh/translations', () => ({
       if (opts && 'defaultValue' in opts) return `label(${String(opts.defaultValue)})`;
       return k;
     },
+    // `note` chips resolve the country name via i18n.language + the real
+    // regionName helper (not mocked), so the hook must expose i18n here.
+    i18n: { language: 'en' },
   }),
 }));
 
@@ -210,6 +213,93 @@ describe('BoardSummaryChips — variants', () => {
     );
     expect(chips()[0]?.textContent).toContain('jobs.boardSummary.skip.other');
     expect(chips()[0]?.textContent).not.toContain('mystery');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Location note chips (PR D) — broadened / guessed-market tokens
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('BoardSummaryChips — location note chips', () => {
+  it('maps a "broadened:<cc>" note to the informational (processing) broadened label', () => {
+    render(
+      <BoardSummaryChips summaries={[{ board: 'aggregator', count: 3, note: 'broadened:de' }]} />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('processing');
+    expect(chip?.textContent).toContain('jobs.boardSummary.note.broadened');
+    // The raw machine token must never leak into the UI.
+    expect(chip?.textContent).not.toContain('broadened:de');
+  });
+
+  it('maps a "guessed-market:<cc>" note to the guessed-market label', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[{ board: 'aggregator', count: 2, note: 'guessed-market:gb' }]}
+      />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('processing');
+    expect(chip?.textContent).toContain('jobs.boardSummary.note.guessed');
+    expect(chip?.textContent).not.toContain('guessed-market:gb');
+  });
+
+  it('tolerates an unknown/future note token — falls through to the plain success chip', () => {
+    render(
+      <BoardSummaryChips summaries={[{ board: 'aggregator', count: 4, note: 'future-token:de' }]} />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('success');
+    expect(chip?.textContent).toContain('jobs.boardSummary.count:4');
+    expect(chip?.textContent).not.toContain('future-token');
+  });
+
+  it('ignores a malformed (colon-less) note token', () => {
+    render(<BoardSummaryChips summaries={[{ board: 'aggregator', count: 4, note: 'mystery' }]} />);
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('success');
+    expect(chip?.textContent).not.toContain('mystery');
+  });
+
+  it('ignores a malformed multi-colon token instead of rendering the trailing garbage as a country', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[{ board: 'aggregator', count: 4, note: 'broadened:de:extra' }]}
+      />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('success');
+    expect(chip?.textContent).not.toContain('DE:EXTRA');
+    expect(chip?.textContent).not.toContain('extra');
+  });
+
+  it('precedence: error wins over a co-present note', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[{ board: 'aggregator', count: 0, error: 'boom', note: 'broadened:de' }]}
+      />
+    );
+    expect(chips()[0]?.getAttribute('data-color')).toBe('error');
+  });
+
+  it('precedence: truncated wins over a co-present note', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[
+          { board: 'aggregator', count: 5, truncated: 'page 2 failed', note: 'broadened:de' },
+        ]}
+      />
+    );
+    expect(chips()[0]?.getAttribute('data-color')).toBe('warning');
+  });
+
+  it('precedence: a valid note wins over the plain success count', () => {
+    render(
+      <BoardSummaryChips summaries={[{ board: 'aggregator', count: 6, note: 'broadened:de' }]} />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('processing');
+    expect(chip?.textContent).not.toContain('jobs.boardSummary.count');
   });
 });
 

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.test.tsx
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.test.tsx
@@ -375,6 +375,19 @@ describe('BoardSummaryChips — all-ok collapse', () => {
     );
     expect(chips()).toHaveLength(2);
   });
+
+  it('does NOT collapse when a sibling board carries an informational note (note ≠ success)', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[
+          { board: 'a', count: 4 },
+          { board: 'b', count: 2, note: 'broadened:de' },
+        ]}
+      />
+    );
+    expect(chips()).toHaveLength(2);
+    expect(chips()[1]?.getAttribute('data-color')).toBe('processing');
+  });
 });
 
 describe('BoardSummaryChips — chip detail cap + wrap classes', () => {

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
@@ -2,6 +2,8 @@ import type { BoardScrapeSummary } from '@ajh/shared';
 import { type TFunction, useTranslation } from '@ajh/translations';
 import { cn, Tag } from '@ajh/ui';
 
+import { regionName } from '@/lib/region-name';
+
 /**
  * Compact per-board diagnostics strip. Renders a `BoardScrapeSummary[]` as one
  * chip per board — `board · count | reason` — so a zero / partial / failed run is
@@ -10,10 +12,11 @@ import { cn, Tag } from '@ajh/ui';
  * it lives outside both feature dirs (no cross-feature import).
  *
  * Variants: success (green count), error (red, sanitized reason), skipped
- * (neutral "config" tone, mapped reason), truncated (amber "partial"). When
- * EVERY board succeeded, the whole strip collapses to one compact "N boards ·
- * all ok" chip instead of one green chip per board (noise reduction — a clean
- * run doesn't need a per-board breakdown).
+ * (neutral "config" tone, mapped reason), truncated (amber "partial"), note
+ * (blue "informational" — a benign location policy the board applied, e.g. a
+ * broadened / guessed market). When EVERY board succeeded, the whole strip
+ * collapses to one compact "N boards · all ok" chip instead of one green chip
+ * per board (noise reduction — a clean run doesn't need a per-board breakdown).
  */
 
 /** Max length of a sanitized reason — a hint, not a full error dump. */
@@ -108,14 +111,17 @@ function redactToken(token: string): string {
   return placeholder ? token.replace(trimmed, placeholder) : token;
 }
 
-type ChipTone = 'success' | 'error' | 'skipped' | 'truncated';
+type ChipTone = 'success' | 'error' | 'skipped' | 'truncated' | 'note';
 
-/** Tone → `Tag` colour. Skipped is the neutral "needs configuration" tone. */
-const TONE_COLOR: Record<ChipTone, 'success' | 'error' | 'default' | 'warning'> = {
+/** Tone → `Tag` colour. Skipped is the neutral "needs configuration" tone;
+ *  `note` uses the informational (blue) `processing` tone — distinct from the
+ *  error/skip/partial tones — for a benign "how the search was adjusted" hint. */
+const TONE_COLOR: Record<ChipTone, 'success' | 'error' | 'default' | 'warning' | 'processing'> = {
   success: 'success',
   error: 'error',
   skipped: 'default',
   truncated: 'warning',
+  note: 'processing',
 };
 
 interface Chip {
@@ -142,13 +148,39 @@ function skipDetail(skipped: string, t: TFunction): string {
 }
 
 /**
+ * Map a controlled location `note` token to a localized label — or `null` for an
+ * unknown/future token so a legacy or newer backend can never leak a raw machine
+ * token into the UI (tolerant, like the `skipped` fallback). Shape is
+ * `kind:<countryCode>` (lowercase cc); the country name is resolved natively.
+ */
+function noteDetail(note: string, t: TFunction, locale: string): string | null {
+  const sep = note.indexOf(':');
+  if (sep < 0) return null;
+  const kind = note.slice(0, sep);
+  const cc = note.slice(sep + 1).trim();
+  // Alpha-2 only — a malformed multi-colon token (e.g. "broadened:de:extra")
+  // must not render its trailing garbage as a "country".
+  if (cc.length !== 2) return null;
+  const country = regionName(cc, locale);
+  switch (kind) {
+    case 'broadened':
+      return t('jobs.boardSummary.note.broadened', { country });
+    case 'guessed-market':
+      return t('jobs.boardSummary.note.guessed', { country });
+    default:
+      return null;
+  }
+}
+
+/**
  * Normalize + classify each summary defensively — the array crosses IPC and may
  * be a legacy/tampered persisted record, so unknown shapes are tolerated (a
  * non-object entry, a missing board id, a non-numeric count) rather than trusted.
- * Per-board precedence mirrors Rust `scrape_diagnostics`: error > skipped >
- * truncated > success.
+ * Per-board precedence mirrors Rust `scrape_diagnostics`, with the informational
+ * location note slotting below the failure/partial tones: error > skipped >
+ * truncated > note > success.
  */
-function toChips(summaries: readonly BoardScrapeSummary[], t: TFunction): Chip[] {
+function toChips(summaries: readonly BoardScrapeSummary[], t: TFunction, locale: string): Chip[] {
   if (!Array.isArray(summaries)) return [];
   const chips: Chip[] = [];
   summaries.forEach((raw, i) => {
@@ -160,6 +192,8 @@ function toChips(summaries: readonly BoardScrapeSummary[], t: TFunction): Chip[]
     const error = typeof s.error === 'string' && s.error.trim() ? s.error : null;
     const skipped = typeof s.skipped === 'string' && s.skipped.trim() ? s.skipped : null;
     const truncated = typeof s.truncated === 'string' && s.truncated.trim() ? s.truncated : null;
+    const noteRaw = typeof s.note === 'string' && s.note.trim() ? s.note : null;
+    const note = noteRaw ? noteDetail(noteRaw, t, locale) : null;
     const count = typeof s.count === 'number' && Number.isFinite(s.count) ? s.count : 0;
 
     let tone: ChipTone;
@@ -173,6 +207,9 @@ function toChips(summaries: readonly BoardScrapeSummary[], t: TFunction): Chip[]
     } else if (truncated) {
       tone = 'truncated';
       detail = t('jobs.boardSummary.partial');
+    } else if (note) {
+      tone = 'note';
+      detail = note;
     } else {
       tone = 'success';
       detail = t('jobs.boardSummary.count', { count });
@@ -188,8 +225,8 @@ export interface BoardSummaryChipsProps {
 }
 
 export function BoardSummaryChips({ summaries, className }: BoardSummaryChipsProps) {
-  const { t } = useTranslation();
-  const boardChips = toChips(summaries, t);
+  const { t, i18n } = useTranslation();
+  const boardChips = toChips(summaries, t, i18n.language);
   if (boardChips.length === 0) return null;
 
   // Noise reduction: a fully clean run (every board succeeded) collapses to one

--- a/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/StepTarget.test.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/StepTarget.test.tsx
@@ -31,30 +31,45 @@ import { StepTarget } from './index';
 // ── Module stubs ──────────────────────────────────────────────────────────────
 
 vi.mock('@ajh/translations', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
 }));
 
 // Replace LocationInput with a test double backed by a vi.fn() so individual
 // tests can override the emitted suggestion via mockImplementation.
 // All other @ajh/ui exports pass through so the component renders normally.
 type LocationInputStubProps = {
+  onChange?: (v: string) => void;
   onSelectSuggestion?: (s: { display: string; countryCode?: string | null }) => void;
 };
 
-function defaultLocationInputImpl({ onSelectSuggestion }: LocationInputStubProps) {
-  const handler = () => onSelectSuggestion?.({ display: 'London, UK', countryCode: 'gb' });
+function defaultLocationInputImpl({ onChange, onSelectSuggestion }: LocationInputStubProps) {
+  const pick = () => onSelectSuggestion?.({ display: 'London, UK', countryCode: 'gb' });
+  const editManually = () => onChange?.('Lon');
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      data-testid="location-input-stub"
-      onClick={handler}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') handler();
-      }}
-    >
-      pick-location
-    </div>
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        data-testid="location-input-stub"
+        onClick={pick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') pick();
+        }}
+      >
+        pick-location
+      </div>
+      <div
+        role="button"
+        tabIndex={0}
+        data-testid="location-input-manual-edit"
+        onClick={editManually}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') editManually();
+        }}
+      >
+        edit-location
+      </div>
+    </>
   );
 }
 
@@ -176,6 +191,21 @@ describe('StepTarget — countryCode wiring (Fix A)', () => {
     await user.click(screen.getByTestId('location-input-stub'));
 
     expect(readProbe().countryCode).toBe('gb');
+  });
+
+  it('shows the derived "Country" line after a suggestion pick, and hides it again on manual edit', async () => {
+    const user = userEvent.setup();
+    renderStep({ countryCode: undefined });
+
+    expect(screen.queryByText('autopilot.wizard.target.countryResolved')).toBeNull();
+
+    await user.click(screen.getByTestId('location-input-stub'));
+    expect(screen.getByText('autopilot.wizard.target.countryResolved')).toBeInTheDocument();
+
+    // Manually editing the location clears countryCode (index.tsx's onChange
+    // handler) — the derived-country line must disappear with it.
+    await user.click(screen.getByTestId('location-input-manual-edit'));
+    expect(screen.queryByText('autopilot.wizard.target.countryResolved')).toBeNull();
   });
 
   it('renders a warning Alert for the aggregator key hint when aggregator is selected and keys are absent', () => {

--- a/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
@@ -1,3 +1,4 @@
+import { Globe } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 
@@ -7,6 +8,7 @@ import { Alert, Button, cn, Dropdown, Input, LocationInput, NumberField } from '
 
 import type { Prefilled, WizardState } from '@/features/autopilot/types';
 import { makeMultiSelectKeyHandler } from '@/hooks/use-roving-tabindex';
+import { regionName } from '@/lib/region-name';
 import { useAppClient } from '@/providers/AppClientProvider';
 import { useHasProviderKey } from '@/services/use-ai-provider';
 import { useBoardsCatalog } from '@/services/use-boards';
@@ -22,12 +24,16 @@ interface StepTargetProps {
 }
 
 export function StepTarget({ prefilled }: StepTargetProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const api = useAppClient();
   const { control, setValue } = useFormContext<WizardState>();
   // Disabled "coming soon" control — display the current value without binding.
   const workType = useWatch({ control, name: 'workType' });
   const boards = useWatch({ control, name: 'boards' });
+  // Country derived from the picked location suggestion — surfaced inline so the
+  // user SEES which market the autopilot will search (vs. the silent save-time
+  // backfill, now only a legacy fallback). Cleared by editing the location.
+  const countryCode = useWatch({ control, name: 'countryCode' });
 
   const boardRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const focusedBoardIdx = useRef<number>(0);
@@ -199,6 +205,14 @@ export function StepTarget({ prefilled }: StepTargetProps) {
                   placeholder={t('autopilot.wizard.target.locationPlaceholder')}
                   onFetchSuggestions={(q) => api.geocode.suggest(q)}
                 />
+                {countryCode && (
+                  <p className="flex items-center gap-1 text-[10px] text-foreground/45">
+                    <Globe size={10} aria-hidden />
+                    {t('autopilot.wizard.target.countryResolved', {
+                      country: regionName(countryCode, i18n.language),
+                    })}
+                  </p>
+                )}
                 {prefilled.location && (
                   <PrefilledBadge field={t('autopilot.wizard.target.fromLocationSettings')} />
                 )}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsResults/JobsResults.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsResults/JobsResults.test.tsx
@@ -20,7 +20,7 @@ import { TEST_IDS } from '@ajh/test-ids';
 // ── i18n stub ─────────────────────────────────────────────────────────────────
 
 vi.mock('@ajh/translations', () => ({
-  useTranslation: () => ({ t: (k: string) => k }),
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
 }));
 
 // ── router stub ───────────────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
@@ -117,6 +117,27 @@ describe('useScraping — geo fields in the replace-vs-append signature', () => 
     expect(result.current.replacePendingRef.current).toBe(true);
   });
 
+  it('replaces (not appends) when only the search radius differs', async () => {
+    mutateAsync.mockClear();
+    const { result, rerender } = renderHookWithClient(
+      ({ form }: { form: ScrapeFormState }) => useScraping(noopNotify, form),
+      { initialProps: { form: makeForm({ radiusKm: 0 }) } }
+    );
+
+    await act(async () => {
+      await result.current.startScrape();
+    });
+
+    // Same city, wider radius → a different search area must REPLACE. This
+    // fails if radiusKm is missing from the signature.
+    rerender({ form: makeForm({ radiusKm: 25 }) });
+    await act(async () => {
+      await result.current.startScrape();
+    });
+
+    expect(result.current.replacePendingRef.current).toBe(true);
+  });
+
   it('appends (does not replace) when the search is byte-for-byte identical', async () => {
     mutateAsync.mockClear();
     const { result, rerender } = renderHookWithClient(

--- a/apps/desktop/src/renderer/lib/region-name.test.ts
+++ b/apps/desktop/src/renderer/lib/region-name.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { regionName } from './region-name';
+
+describe('regionName', () => {
+  it('resolves a lowercase ISO alpha-2 code to a localized country name', () => {
+    expect(regionName('de', 'en')).toBe('Germany');
+    expect(regionName('us', 'en')).toBe('United States');
+  });
+
+  it('localizes the name by locale', () => {
+    expect(regionName('de', 'de')).toBe('Deutschland');
+  });
+
+  it('accepts an already-uppercase code', () => {
+    expect(regionName('GB', 'en')).toBe('United Kingdom');
+  });
+
+  it('falls back to the uppercased code for a structurally-invalid input', () => {
+    // length !== 2 short-circuits before DisplayNames (which would throw).
+    expect(regionName('x', 'en')).toBe('X');
+    expect(regionName('', 'en')).toBe('');
+  });
+
+  it('falls back to the uppercased code when DisplayNames rejects a length-2 non-region', () => {
+    // 'A1' is length-2 yet not a valid region subtag → DisplayNames throws → caught.
+    expect(regionName('a1', 'en')).toBe('A1');
+  });
+});

--- a/apps/desktop/src/renderer/lib/region-name.ts
+++ b/apps/desktop/src/renderer/lib/region-name.ts
@@ -1,0 +1,22 @@
+/**
+ * Localized country name for an ISO 3166-1 alpha-2 code via the native
+ * `Intl.DisplayNames` (zero-dep). Two call sites need it: the autopilot wizard's
+ * derived-country line and the per-board "note" chips.
+ *
+ * Note tokens carry a LOWERCASE code (e.g. `"de"`) while `DisplayNames` wants an
+ * uppercase region code, so we normalize. An unknown/unsupported code, a
+ * malformed input, or a runtime without full-ICU `DisplayNames` all degrade to
+ * the uppercased code rather than throwing — the caller always gets a printable
+ * string.
+ */
+export function regionName(code: string, locale: string): string {
+  const cc = code.trim().toUpperCase();
+  // Alpha-2 only (our tokens/geocode codes) — guards the empty/short inputs that
+  // would otherwise throw a RangeError inside DisplayNames.
+  if (cc.length !== 2) return cc;
+  try {
+    return new Intl.DisplayNames([locale], { type: 'region' }).of(cc) ?? cc;
+  } catch {
+    return cc;
+  }
+}

--- a/docs/knowledge/scraping-domain.md
+++ b/docs/knowledge/scraping-domain.md
@@ -101,7 +101,7 @@ Location input policy is now visible via per-board summary notes. When a search 
 - **Note tokens:** `BoardScrapeSummary.note: Option<String>` records the location policy decision as a machine token:
   - `broadened:<cc>` — Adzuna results exist but sparse (`< 3`); broadened from city to country-level (e.g., "few local results in Berlin — showing Germany-wide").
   - `guessed-market:<cc>` — No explicit country provided; market was guessed and Adzuna returned >= 3 results (authoritative guess). Never emitted for sub-floor guesses that fall through to JSearch global fallback.
-  - Only one note per run; guessed and broadened are mutually exclusive (guessed when `country_guessed=false`, broadened when `country_guessed=false`).
+  - Only one note per run; guessed and broadened are mutually exclusive (guessed when `country_guessed=true`, broadened when `country_guessed=false`).
 - **Frontend rendering:** Chips mapped via `BoardSummaryChips.tsx` `ChipTone 'note'` (informational blue); locale-keyed labels `jobs.boardSummary.note.{broadened, guessed}` with country name via `Intl.DisplayNames({type:'region'})` for user-friendly labels (en + de).
 - **Wizard visibility:** Autopilot wizard shows inline "Country: <Name>" when `countryCode` is set, cleared on manual location edit (user may re-pick via the location-input autocompleter).
 - **Source:** `scraping/types/mod.rs` (`on_note` side-channel + `report_note()`), `scraping/engine/mod.rs` (`BoardScrapeSummary.note` wiring), `boards/aggregator/mod.rs` (inject), `boards/aggregator/providers.rs` (Adzuna emit sites + `guessed_market_note` helper).

--- a/docs/knowledge/scraping-domain.md
+++ b/docs/knowledge/scraping-domain.md
@@ -93,6 +93,19 @@ Adzuna's API is country-scoped with a fixed market allowlist; see `ADZUNA_SUPPOR
 - **Empty results:** Legitimate (do NOT trigger fallback to next provider; only errors do).
 - **Cancellation:** Pre-fallback cancel signal skips the paid provider entirely.
 
+**Aggregator location determinism (PR D, 2026-07-10):**
+
+Location input policy is now visible via per-board summary notes. When a search input lacks explicit country but specifies a city/region, the aggregator may broaden to country-level results or guess a market (fallback when Adzuna is sparse).
+
+- **Floor guard:** `ADZUNA_BROADEN_FLOOR = 3` at `aggregator/mod.rs:44`. Broaden is triggered only when Adzuna returns fewer than 3 results for a location query AND `!country_guessed` (i.e. the user didn't supply a country). Guessed-market fallback to JSearch happens only when guessed Adzuna also returns `< 3` results.
+- **Note tokens:** `BoardScrapeSummary.note: Option<String>` records the location policy decision as a machine token:
+  - `broadened:<cc>` — Adzuna results exist but sparse (`< 3`); broadened from city to country-level (e.g., "few local results in Berlin — showing Germany-wide").
+  - `guessed-market:<cc>` — No explicit country provided; market was guessed and Adzuna returned >= 3 results (authoritative guess). Never emitted for sub-floor guesses that fall through to JSearch global fallback.
+  - Only one note per run; guessed and broadened are mutually exclusive (guessed when `country_guessed=false`, broadened when `country_guessed=false`).
+- **Frontend rendering:** Chips mapped via `BoardSummaryChips.tsx` `ChipTone 'note'` (informational blue); locale-keyed labels `jobs.boardSummary.note.{broadened, guessed}` with country name via `Intl.DisplayNames({type:'region'})` for user-friendly labels (en + de).
+- **Wizard visibility:** Autopilot wizard shows inline "Country: <Name>" when `countryCode` is set, cleared on manual location edit (user may re-pick via the location-input autocompleter).
+- **Source:** `scraping/types/mod.rs` (`on_note` side-channel + `report_note()`), `scraping/engine/mod.rs` (`BoardScrapeSummary.note` wiring), `boards/aggregator/mod.rs` (inject), `boards/aggregator/providers.rs` (Adzuna emit sites + `guessed_market_note` helper).
+
 ## Trust assessment (PR 3, 2026-07-01)
 
 Every finalized `JobPosting` carries a **ghost-job / trust signal** — a pure,
@@ -177,8 +190,8 @@ Per-board scrape outcomes are now visible via a shared `BoardSummaryChips` compo
 - **Header strip** (Jobs page) — persistent chip strip rendered in the pinned header when results are present, survives the auto-closing scrape form. Gated on `!scraping && filteredJobs.length > 0`. Cleared on new scrape start, `job.failed`, or clear-postings.
 - **Empty state** (Jobs page) — same strip rendered below the zero-results message to explain per-board why nothing was found. Only owner of the zero-results explanation surface; header strip is never shown alongside it (mutual exclusivity).
 - **Autopilot card** — renders persisted `lastRunSummaries` as chips when run is finished (`!running`). Needs-configuration variant (when `runStatus==='failed'` AND every summary skipped with none errored) renders a neutral `autopilot.badge.needsConfig` badge + HoverPopover hint, not a red failure state.
-- **Chip rendering** — `BoardSummaryChips.tsx` (component + pure `sanitizeReason` sanitizer). Sanitizer redacts UNC paths, IPv4/IPv6, URLs, emails, credential patterns; caps input @1000 chars, output @200 chars. Chip detail display is further capped @60 chars (wraps with `whitespace-normal break-words`). Chip order by severity: error (red) > skipped (neutral) > truncated (amber) > success (green). All-success all-green collapse when multiple boards and all succeeded. Source: `apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx`.
-- **I18n keys** — `jobs.boardSummary.{label, count_one, count_other, partial, allOk_one, allOk_other, skip.{needsLogin, needsCompany, needsKeys, other}}` + `autopilot.badge.{needsConfig, needsConfigHint, completedWithErrorsHint}` (en + de).
+- **Chip rendering** — `BoardSummaryChips.tsx` (component + pure `sanitizeReason` sanitizer). Sanitizer redacts UNC paths, IPv4/IPv6, URLs, emails, credential patterns; caps input @1000 chars, output @200 chars. Chip detail display is further capped @60 chars (wraps with `whitespace-normal break-words`). Chip order by severity: error (red) > skipped (neutral) > truncated (amber) > note (blue, informational) > success (green). All-success all-green collapse when multiple boards and all succeeded. **Location notes** (`broadened:<cc>` / `guessed-market:<cc>`, added in PR D) are rendered with tone 'note' and i18n labels mapping the machine token to a user-friendly country-aware message. Source: `apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx`.
+- **I18n keys** — `jobs.boardSummary.{label, count_one, count_other, partial, allOk_one, allOk_other, skip.{needsLogin, needsCompany, needsKeys, other}, note.{broadened, guessed}}` + `autopilot.badge.{needsConfig, needsConfigHint, completedWithErrorsHint}` + `autopilot.wizard.target.countryResolved` (en + de).
 - **Whole-scrape failures** — persisted as `lastFailureNote` (sanitized, same redactor) on `JobsPage`; rendered as a small `role="status"` line in header + forwarded to `JobsResults` empty state (never triple-explained when `missingAdzunaKeys` is the root cause).
 - **Skip-toast folding** — the three sticky notification warnings (needs-login / needs-company / needs-keys) were removed; their signal is now persistent in the chip strip (still actionable via `BoardConnectChip` in the scrape form for login boards).
 

--- a/packages/shared/src/ipc/contracts/boards.ts
+++ b/packages/shared/src/ipc/contracts/boards.ts
@@ -55,6 +55,14 @@ export interface BoardsContract {
  * - `truncated` — a paginated board kept a partial harvest after a mid-run page
  *   failure (e.g. `"page 3 of 5 failed: HTTP 429"`); `count` is a partial tally,
  *   not the full result set. Absent when the harvest ran to completion.
+ * - `note` — an INFORMATIONAL location policy the board applied that the user did
+ *   not explicitly request (not a failure; `count` is still authoritative). One of:
+ *   - `"guessed-market:<cc>"` — no country was supplied, so the `<cc>` market was
+ *     guessed and returned an authoritative result set; set a country for
+ *     deterministic results.
+ *   - `"broadened:<cc>"` — a sparse city search was widened country-wide within
+ *     the `<cc>` market.
+ *   `<cc>` is an ISO country code; the field never carries the raw location text.
  */
 export interface BoardScrapeSummary {
   board: string;
@@ -62,6 +70,7 @@ export interface BoardScrapeSummary {
   error?: string;
   skipped?: 'needs-login' | 'needs-company' | 'needs-keys';
   truncated?: string;
+  note?: string;
 }
 
 export const BOARDS_CHANNELS = {

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1530,6 +1530,7 @@
         "locationOptional": "(optional)",
         "locationPlaceholder": "z.B. Berlin, remote",
         "fromLocationSettings": "aus Standortseinstellungen",
+        "countryResolved": "Land: {{country}}",
         "workType": "Arbeitsart",
         "items": "Zu scrapende Einträge",
         "postedWithin": "Veröffentlicht innerhalb",
@@ -1845,6 +1846,10 @@
         "needsCompany": "Firma nötig",
         "needsKeys": "API-Schlüssel nötig",
         "other": "übersprungen"
+      },
+      "note": {
+        "broadened": "wenige lokale Treffer — landesweit in {{country}} gesucht",
+        "guessed": "kein Land gesetzt — {{country}} durchsucht"
       }
     },
     "viewList": "Liste",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1526,6 +1526,7 @@
         "locationOptional": "(optional)",
         "locationPlaceholder": "e.g. Berlin, remote",
         "fromLocationSettings": "from location settings",
+        "countryResolved": "Country: {{country}}",
         "workType": "Work type",
         "items": "Items to scrape",
         "postedWithin": "Posted within",
@@ -1841,6 +1842,10 @@
         "needsCompany": "needs company",
         "needsKeys": "needs keys",
         "other": "skipped"
+      },
+      "note": {
+        "broadened": "few local results — showing {{country}} wide",
+        "guessed": "no country set — searched {{country}}"
       }
     },
     "viewList": "List",


### PR DESCRIPTION
## Summary

PR D of the job-search trust program (audit 2026-07-10): identical location inputs used to flip invisibly between correct-market, wrong-market-sparse, and fallback outcomes — this PR makes the two silent location policies visible and closes the wizard's country blind spot. Builds on #597/#598/#599. (The audit's broaden-floor quick win was already shipped on main — `ADZUNA_BROADEN_FLOOR = 3` verified with its truth-table tests intact.)

## What changed

- **Location policy becomes visible:** new `ScrapeContext.on_note` side-channel (mirrors PR B's truncation pattern) → `BoardScrapeSummary.note`. The Adzuna provider emits machine tokens — `broadened:<cc>` when city→country broadening is adopted, `guessed-market:<cc>` when a guessed market's result is authoritative (≥ floor). Tokens carry only allowlist-validated country codes, never the raw location. The sparse-salvage corner is deliberately un-noted (never misleading; commented for PR F).
- **Chips render the notes:** `BoardSummaryChips` gains an informational tone — "few local results — showing Germany wide" / "no country set — searched Germany" via native `Intl.DisplayNames` (new `lib/region-name.ts`, guarded fallbacks). Malformed/future tokens fall through silently; a note blocks the all-green collapse so it can't hide.
- **Wizard country visibility:** the autopilot wizard already persisted `countryCode` from the location picker — now it SHOWS the resolved country inline ("Country: Germany") and the line disappears on manual edit, making the silent save-time backfill a legacy fallback only.
- **Replace-vs-append:** geo fields (country/lat/lon/radius) were already in the search signature; the missing radius-change test now pins it.

## Review trail (internal fleet)

- scraping-applier-expert: APPROVE (note semantics traced: emit iff adopted/authoritative, mutual exclusivity structural; advisory Err-arm test + deferral comments applied)
- frontend-reviewer: APPROVE-WITH-FIXES → wizard-line test, malformed-token guard, precedence test applied
- tauri-security-reviewer: PASS (tokens provably allowlist-only; sink spoof-proof; text-node rendering)
- pr-reviewer ×2 (opus PASS zero findings — all cross-stage seams traced; sonnet PASS 1🟡 → collapse-guard regression test added)

## Test plan

- CI runs the Rust suite (host fault blocks local cargo test; fmt/check/clippy clean). Desktop vitest 2135+/green locally, whole-graph typecheck clean, gen:ipc:check clean.
- Manual: scrape a city with sparse results → blue chip explains the broadening; save an autopilot with a picked location → country line appears under the field.

Part 4/8 of the trust program — next: PR E (cross-source dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)