### PR TITLE
feat: collapse cross-source duplicate jobs behind one canonical key

### DIFF
--- a/apps/desktop/src-tauri/src/autopilot/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot/mod.rs
@@ -816,31 +816,17 @@ fn u32_field_in_range(v: &serde_json::Value, key: &str, max: u32) -> Option<u32>
         .filter(|&n| n <= max)
 }
 
-/// Canonical dedup key for a found job.
-///
-/// Uses the app-wide [`crate::applications::normalize_job_url`] (lowercased host,
-/// `www.`/fragment/tracking-param stripped) so tracking-param/hash variants of the
-/// SAME URL collapse to a single row — this is same-host URL-variant dedup, not
-/// cross-provider identity: an aggregator's `redirect_url` (e.g. Adzuna's `FoundJob.url`,
-/// hosted on an adzuna domain) normalizes to a different key than a board's direct
-/// posting URL, so the same job surfaced by both sources is NOT collapsed here (that
-/// needs redirect-chain canonicalization, deferred to trust-program PR E). Falls back
-/// to a normalized `title \u{1} company` when the URL is missing/unusable, so URL-less
-/// postings still dedupe sanely (the control-char separator can't be reproduced by a
-/// title that merely contains the company name) — known limitation: two distinct
-/// URL-less postings that happen to share title+company will also merge; rare, and
-/// only affects the discovery surface, so it's an accepted trade-off.
+/// Canonical dedup key for a [`FoundJob`] — a thin `FoundJob` adapter over the
+/// app-wide [`canonical_job_key`](crate::scraping::boards::common::canonical_job_key),
+/// the single source of truth for "is this the same job?" shared with the scrape
+/// engine's cross-source pass and (mirrored in TS) the renderer's `mergePostings`.
+/// Forwarding the posting's `url`/`title`/`company` keeps autopilot's merge keyed
+/// byte-for-byte identically to those, so a job surfaced by two sources collapses to
+/// one row and fires one notification — and persisted found-jobs keyed under the old
+/// inlined copy recompute to the same key (the algorithm is unchanged, only DRYed).
+/// The aggregator-redirect-vs-direct-URL limitation is documented on that fn.
 fn merge_key(j: &FoundJob) -> String {
-    let normalized = crate::applications::normalize_job_url(&j.url);
-    if !normalized.is_empty() {
-        normalized
-    } else {
-        format!(
-            "{}\u{1}{}",
-            j.title.trim().to_lowercase(),
-            j.company.trim().to_lowercase()
-        )
-    }
+    crate::scraping::boards::common::canonical_job_key(&j.url, &j.title, &j.company)
 }
 
 /// Byte length of a job's description (0 when absent) — used to keep the richer of
@@ -870,6 +856,11 @@ fn merge_found_jobs(existing: &[FoundJob], incoming: Vec<FoundJob>) -> Vec<Found
     // 1) Collapse duplicates WITHIN the incoming batch by canonical key. First
     //    occurrence keeps its position; a later duplicate carrying a longer
     //    description upgrades that one field (richer text for the tailor flow).
+    //    (The engine's dedup_cross_source runs upstream and — like this pass —
+    //    keeps the incumbent's identity and only upgrades description/extra
+    //    field-by-field, never a whole-posting replace; cross-source dupes are
+    //    already collapsed before they reach here, so this pass only ever sees
+    //    same-source within-batch repeats.)
     let mut order: Vec<String> = Vec::new();
     let mut by_key: HashMap<String, FoundJob> = HashMap::new();
     for job in incoming {

--- a/apps/desktop/src-tauri/src/autopilot/test.rs
+++ b/apps/desktop/src-tauri/src/autopilot/test.rs
@@ -1060,6 +1060,38 @@ fn merge_dedups_same_job_across_two_url_variants() {
 }
 
 #[test]
+fn merge_collapses_persisted_row_against_a_new_url_variant() {
+    // Back-compat: a found-job persisted under one raw URL must merge with an
+    // incoming batch item that is a *variant* of the same URL (tracking params
+    // vs. hash fragment) — they share one canonical key, so the re-surfaced job
+    // updates the existing row instead of adding a duplicate, and only the truly
+    // new job is flagged. Guards the merge_key → canonical_job_key delegation:
+    // the algorithm is unchanged, so old-scheme keys still recompute identically.
+    let persisted = found_job("https://boards.example.com/jobs/42?utm_source=x", 100);
+    let variant = found_job("https://boards.example.com/jobs/42#apply", 999);
+    let fresh = found_job("https://boards.example.com/jobs/99", 200);
+
+    let merged = merge_found_jobs(&[persisted], vec![variant, fresh]);
+
+    assert_eq!(
+        merged.len(),
+        2,
+        "the variant merges into the persisted row; only the fresh job is added"
+    );
+    let resurfaced = merged
+        .iter()
+        .find(|j| j.url.contains("/jobs/42"))
+        .expect("the persisted job's row survives");
+    assert_eq!(resurfaced.found_at, 100, "first-seen time preserved");
+    assert!(!resurfaced.is_new, "a re-surfaced URL variant is not new");
+    let brand_new = merged
+        .iter()
+        .find(|j| j.url.contains("/jobs/99"))
+        .expect("the fresh job is present");
+    assert!(brand_new.is_new, "the never-seen job is flagged new");
+}
+
+#[test]
 fn merge_dedups_internal_batch_duplicate() {
     // The same job surfaced by two sources (aggregator + a named board) in ONE run.
     let from_aggregator = found_job("https://jobs.example.com/eng-42", 1);

--- a/apps/desktop/src-tauri/src/scraping/boards/common.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common.rs
@@ -122,5 +122,58 @@ pub(crate) fn should_propagate_page_error(collected_so_far: usize) -> bool {
     collected_so_far == 0
 }
 
+/// App-wide canonical dedup key for a job posting — the single source of truth
+/// for "is this the same job?" across every source (the scrape engine's
+/// cross-board pass, autopilot's `merge_found_jobs`, and — mirrored in TS at
+/// `apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.ts` — the
+/// renderer's `mergePostings`). Keeping all three keyed identically is the whole
+/// point of trust-program PR E: a job surfaced by two boards collapses to one row
+/// and fires one notification, not two or three.
+///
+/// **Exact algorithm (mirror this precisely in any other language):**
+/// 1. `n = normalize_job_url(url)` — the app-wide URL identity
+///    ([`crate::applications::normalize_job_url`]): rejects any non-`http(s)`
+///    scheme to `""`; lowercases the whole URL; strips a leading `www.` on the
+///    host; drops the `#fragment`; drops the query string **except** per-host
+///    identifying params (currently only `indeed.com`'s `jk`, emitted in a fixed
+///    order); strips a trailing `/` on the path. Empty/blank input → `""`.
+/// 2. If `n` is non-empty, the key **is** `n` (URL identity).
+/// 3. Otherwise (missing/unusable/non-http URL) fall back to
+///    `"{title}\u{1}{company}"` with each side `.trim().to_lowercase()`. The
+///    `U+0001` (SOH) separator can't occur in real text, so a title that merely
+///    contains the company name can't forge a colliding key — and near-miss
+///    titles stay distinct (`"senior rust engineer\u{1}acme"` ≠
+///    `"rust engineer\u{1}acme"`).
+///
+/// Chosen over the aggregator's narrower private `canonical_url` (which only
+/// strips LinkedIn query params and is a within-aggregator provider-merge
+/// concern): `normalize_job_url` is the genuinely app-wide, well-tested URL
+/// identity that autopilot's merge already keys on, so building on it keeps the
+/// stages in lockstep instead of diverging on two different URL notions.
+///
+/// Known limitation (out of scope for stage 1): an aggregator *redirect* URL and
+/// the board's *direct* posting URL normalize to different keys, so the same job
+/// reached via a redirect is not collapsed here — that needs redirect-chain
+/// canonicalization, tracked separately.
+///
+/// The title+company fallback assumes each board already validated/populated
+/// `title` (every registered `Scraper` does); it is not itself a title
+/// validator, so postings with all-empty titles/companies collapse to the
+/// single `"\u{1}"` key.
+///
+/// Pure — no I/O — so the key is directly unit-testable.
+pub(crate) fn canonical_job_key(url: &str, title: &str, company: &str) -> String {
+    let normalized = crate::applications::normalize_job_url(url);
+    if !normalized.is_empty() {
+        normalized
+    } else {
+        format!(
+            "{}\u{1}{}",
+            title.trim().to_lowercase(),
+            company.trim().to_lowercase()
+        )
+    }
+}
+
 #[cfg(test)]
 mod test;

--- a/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
@@ -92,3 +92,75 @@ fn partial_harvest_is_kept_not_propagated() {
         "a page failure after many items were already collected must keep the partial harvest"
     );
 }
+
+// ── canonical_job_key (trust PR E, stage 1) ──────────────────────────────────
+//
+// The app-wide cross-source dedup key. Stage 2 (autopilot merge) and stage 3
+// (renderer `mergePostings`, mirrored in TS) key on the EXACT same algorithm, so
+// these assertions pin the contract all three stages must agree on.
+
+#[test]
+fn canonical_key_same_url_across_boards_collapses() {
+    // www/tracking variants of the same URL from different boards → same key
+    // (URL identity via normalize_job_url); differing titles don't matter once a
+    // usable URL exists (the URL is the identity).
+    let a = canonical_job_key(
+        "https://www.acme.example/jobs/42?utm_source=x",
+        "Senior Engineer",
+        "Acme",
+    );
+    let b = canonical_job_key("https://acme.example/jobs/42", "Sr. Engineer", "Acme Inc");
+    assert_eq!(
+        a, b,
+        "same canonical URL must key identically regardless of board/title"
+    );
+    assert_eq!(a, "https://acme.example/jobs/42");
+}
+
+#[test]
+fn canonical_key_urlless_matches_on_title_and_company() {
+    // No usable URL → normalized `title\u{1}company` key; case- and
+    // whitespace(edge)-insensitive via trim + lowercase.
+    let a = canonical_job_key("", " Senior Rust Engineer ", "Acme");
+    let b = canonical_job_key("", "senior rust engineer", "  ACME ");
+    assert_eq!(
+        a, b,
+        "same title+company must key identically when no URL exists"
+    );
+    assert_eq!(a, "senior rust engineer\u{1}acme");
+}
+
+#[test]
+fn canonical_key_near_miss_titles_stay_distinct() {
+    // Precision requirement: a broader/narrower title at the same company must
+    // NOT merge.
+    let senior = canonical_job_key("", "Senior Rust Engineer", "Acme");
+    let plain = canonical_job_key("", "Rust Engineer", "Acme");
+    assert_ne!(senior, plain, "near-miss titles must stay distinct");
+}
+
+#[test]
+fn canonical_key_separator_cannot_be_forged_by_title() {
+    // The U+0001 (SOH) separator means a title that merely CONTAINS the company
+    // name can't collide with a genuine title+company split.
+    let forged = canonical_job_key("", "Engineer Acme", "");
+    let genuine = canonical_job_key("", "Engineer", "Acme");
+    assert_ne!(
+        forged, genuine,
+        "the SOH separator must prevent a title-contains-company collision"
+    );
+}
+
+#[test]
+fn canonical_key_empty_or_non_http_url_falls_back_to_title_company() {
+    // Empty, whitespace-only, and dangerous non-http(s) schemes all normalize to
+    // "" (no openable link) → fall back to the title+company key.
+    let expected = "t\u{1}co";
+    assert_eq!(canonical_job_key("", "T", "Co"), expected);
+    assert_eq!(canonical_job_key("   ", "T", "Co"), expected);
+    assert_eq!(
+        canonical_job_key("javascript:alert(1)", "T", "Co"),
+        expected
+    );
+    assert_eq!(canonical_job_key("file:///etc/passwd", "T", "Co"), expected);
+}

--- a/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
@@ -130,6 +130,16 @@ fn canonical_key_urlless_matches_on_title_and_company() {
     assert_eq!(a, "senior rust engineer\u{1}acme");
 }
 
+/// Cross-language drift fixture — the TS mirror
+/// (`features/jobs/lib/canonical-job-key.ts`) asserts against this EXACT same
+/// title/company pair, so a divergence in either language's lowercasing rules
+/// is caught by comparing the two expected strings side by side.
+#[test]
+fn canonical_key_urlless_non_ascii_lowercases_correctly() {
+    let key = canonical_job_key("", "Développeur Sénior", "Müller GmbH");
+    assert_eq!(key, "développeur sénior\u{1}müller gmbh");
+}
+
 #[test]
 fn canonical_key_near_miss_titles_stay_distinct() {
     // Precision requirement: a broader/narrower title at the same company must

--- a/apps/desktop/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/mod.rs
@@ -713,6 +713,11 @@ fn desc_len(p: &JobPosting) -> usize {
 /// JSON `null` or `""`) is left untouched; a key the incumbent lacks, or holds
 /// null/empty for, is filled from the challenger. Never removes an incumbent
 /// key the challenger doesn't have.
+///
+/// Unions arbitrary extra keys; the TS mirror
+/// (`features/jobs/lib/merge-postings.ts` `collapseDuplicate`) fills a FIXED
+/// field list instead — any NEW key a board writes into `JobPosting.extra`
+/// must be added to that TS fill-list too (lockstep pair).
 fn merge_extra(
     incumbent: &mut HashMap<String, serde_json::Value>,
     challenger: HashMap<String, serde_json::Value>,

--- a/apps/desktop/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/mod.rs
@@ -596,6 +596,21 @@ impl ScraperEngine {
             return Err(anyhow::anyhow!("scrape cancelled"));
         }
 
+        // Cross-source dedup (trust PR E, stage 1): the same job surfaced by two
+        // boards was concatenated above as separate rows — collapse to one, upgrading
+        // the incumbent's description/extra from the richer duplicate in first-seen
+        // order (see `dedup_cross_source`). Per-board `summaries[i].count` stay
+        // as-fetched (they describe each board's raw return), so the removed count is
+        // the cross-source overlap, surfaced as a log line only (no summary field / no
+        // renderer change). Not board-attributed here: `summaries.len()` would also
+        // count skipped/errored boards that contributed nothing to collapse.
+        let before = all_postings.len();
+        let all_postings = dedup_cross_source(all_postings);
+        let removed = before - all_postings.len();
+        if removed > 0 {
+            log::info!("[scrape] collapsed {removed} cross-source duplicate(s)");
+        }
+
         Ok((all_postings, summaries))
     }
 
@@ -628,6 +643,88 @@ impl ScraperEngine {
 impl Default for ScraperEngine {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Collapse cross-source duplicate postings into one, keyed by the app-wide
+/// [`canonical_job_key`](super::boards::common::canonical_job_key). Boards run
+/// independently, so a job surfaced by two of them lands in the concatenated
+/// result as separate rows; this is the single cross-board dedup pass
+/// (trust-program PR E, stage 1).
+///
+/// **Survivor policy — field-level upgrade, incumbent identity kept.** The
+/// FIRST-seen posting for a key is the incumbent and stays in its original slot
+/// (order-preserving, stable) — its `id`/`url`/`source` (board attribution) are
+/// NEVER overwritten by a later duplicate, only two things are merged in from
+/// each challenger:
+///   - `description` — upgraded when the challenger's is longer (a fuller
+///     description scores and reads better, and aggregator snippets are often
+///     truncated — trust-audit root cause 6 — so a board returning full text
+///     should win the description regardless of which came first);
+///   - `extra` — unioned key-by-key: a non-empty (non-null, non-`""`) incumbent
+///     value is kept as-is; only a key the incumbent lacks (or holds
+///     null/empty for) is filled from the challenger.
+///
+/// This mirrors the within-batch upgrade step in `autopilot::merge_found_jobs`
+/// and is deliberately NOT a whole-struct replace: a full swap would silently
+/// discard every field only the incumbent had — concretely, Adzuna rows carry
+/// `extra["salaryMin"/"salaryMax"/"salaryCurrency"]` (consumed by
+/// usePostingActions/TailorFlow/ApplicationDetailPage) that most direct boards
+/// don't, so a direct board winning purely on description length must not
+/// delete the salary.
+///
+/// Per-board `BoardScrapeSummary.count`s are intentionally NOT adjusted here:
+/// each describes what that board returned (as-fetched), so after this pass the
+/// per-board counts may not sum to the deduped total — that difference IS the
+/// cross-source overlap, logged by the caller.
+///
+/// Pure (no I/O) so the survivor policy is directly unit-testable.
+fn dedup_cross_source(postings: Vec<JobPosting>) -> Vec<JobPosting> {
+    let mut index_of: HashMap<String, usize> = HashMap::new();
+    let mut out: Vec<JobPosting> = Vec::with_capacity(postings.len());
+    for p in postings {
+        let key = super::boards::common::canonical_job_key(&p.url, &p.title, &p.company);
+        match index_of.get(&key) {
+            Some(&i) => {
+                // Field-level upgrade only — incumbent id/url/source (board
+                // attribution) are left untouched.
+                if desc_len(&p) > desc_len(&out[i]) {
+                    out[i].description = p.description;
+                }
+                merge_extra(&mut out[i].extra, p.extra);
+            }
+            None => {
+                index_of.insert(key, out.len());
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
+/// Byte length of a posting's description (`None`/absent → 0). The description-
+/// upgrade tiebreak in [`dedup_cross_source`].
+fn desc_len(p: &JobPosting) -> usize {
+    p.description.as_deref().map(str::len).unwrap_or(0)
+}
+
+/// Union a challenger posting's `extra` map into the incumbent's, in place. A
+/// key the incumbent already holds a non-empty value for (anything but
+/// JSON `null` or `""`) is left untouched; a key the incumbent lacks, or holds
+/// null/empty for, is filled from the challenger. Never removes an incumbent
+/// key the challenger doesn't have.
+fn merge_extra(
+    incumbent: &mut HashMap<String, serde_json::Value>,
+    challenger: HashMap<String, serde_json::Value>,
+) {
+    for (k, v) in challenger {
+        let incumbent_is_empty = incumbent
+            .get(&k)
+            .map(|existing| existing.is_null() || existing.as_str() == Some(""))
+            .unwrap_or(true);
+        if incumbent_is_empty {
+            incumbent.insert(k, v);
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -2579,3 +2579,323 @@ async fn ats_per_company_transport_error_does_not_suppress_remaining_companies()
         "slug-1 errored and must produce no items"
     );
 }
+
+// ── TRUST PR E stage 1: cross-source dedup ────────────────────────────────────
+//
+// `dedup_cross_source` is the single cross-board pass. The pure tests pin the
+// survivor policy (field-level upgrade, incumbent identity NEVER swapped)
+// directly; the engine-seam test proves it is wired into
+// `scrape_boards_with_resolver` and that per-board summary counts stay
+// as-fetched (only the aggregated result set is deduped).
+
+/// Minimal `JobPosting` builder for the pure dedup tests — only the fields the
+/// canonical key + survivor policy read (url/title/company/description/extra).
+fn dedup_posting(
+    source: &str,
+    url: &str,
+    title: &str,
+    company: &str,
+    description: Option<&str>,
+) -> JobPosting {
+    dedup_posting_with_extra(source, url, title, company, description, &[])
+}
+
+/// Like [`dedup_posting`] but with an explicit `extra` map, for the union tests.
+fn dedup_posting_with_extra(
+    source: &str,
+    url: &str,
+    title: &str,
+    company: &str,
+    description: Option<&str>,
+    extra: &[(&str, serde_json::Value)],
+) -> JobPosting {
+    JobPosting {
+        id: format!("{source}:{title}"),
+        external_id: None,
+        title: title.to_string(),
+        company: company.to_string(),
+        location: None,
+        url: url.to_string(),
+        source: source.to_string(),
+        description: description.map(str::to_string),
+        requirements: None,
+        posted_at: None,
+        captured_at: 0,
+        extra: extra
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect(),
+    }
+}
+
+#[test]
+fn dedup_cross_source_upgrades_description_and_extra_but_keeps_incumbent_identity() {
+    // Same job, two boards: "aggregator" FIRST (incumbent) — truncated snippet,
+    // but carries the salary fields Adzuna scrapes into `extra`; "board" SECOND
+    // (challenger) — same canonical URL, full description, no salary, but a
+    // `remote` flag the aggregator lacks. This is the exact regression scenario
+    // a whole-struct replace would break: a direct board winning on description
+    // length must not delete the incumbent's salary.
+    let input = vec![
+        dedup_posting_with_extra(
+            "aggregator",
+            "https://www.acme.example/jobs/42?utm_source=x",
+            "Staff Engineer",
+            "Acme",
+            Some("snippet"),
+            &[
+                ("salaryMin", serde_json::json!(100_000)),
+                ("salaryMax", serde_json::json!(140_000)),
+                ("salaryCurrency", serde_json::json!("USD")),
+            ],
+        ),
+        dedup_posting_with_extra(
+            "board",
+            "https://acme.example/jobs/42",
+            "Staff Engineer",
+            "Acme",
+            Some("a much longer full description that beats the snippet"),
+            &[
+                // Overlapping key with a DIFFERENT value — the incumbent's
+                // non-empty value must win, not be overwritten.
+                ("salaryCurrency", serde_json::json!("EUR")),
+                ("remote", serde_json::json!(true)),
+            ],
+        ),
+    ];
+    let out = dedup_cross_source(input);
+    assert_eq!(
+        out.len(),
+        1,
+        "same canonical URL across boards collapses to one"
+    );
+
+    // Incumbent identity (board attribution / url / id) is NEVER swapped, even
+    // though the challenger's description wins.
+    assert_eq!(
+        out[0].source, "aggregator",
+        "incumbent board attribution must be kept, not overwritten by the challenger"
+    );
+    assert_eq!(
+        out[0].id, "aggregator:Staff Engineer",
+        "incumbent id must be kept"
+    );
+    assert_eq!(
+        out[0].url, "https://www.acme.example/jobs/42?utm_source=x",
+        "incumbent url must be kept"
+    );
+
+    // Description IS upgraded — the challenger's is longer.
+    assert_eq!(
+        out[0].description.as_deref(),
+        Some("a much longer full description that beats the snippet"),
+        "description must upgrade to the challenger's longer text"
+    );
+
+    // Extra is UNIONED, never wholesale replaced: the incumbent's salary fields
+    // (which only it had) survive; the incumbent's non-empty overlapping key
+    // wins over the challenger's; a challenger-only key is added.
+    assert_eq!(
+        out[0].extra.get("salaryMin"),
+        Some(&serde_json::json!(100_000)),
+        "incumbent-only salaryMin must be retained, not deleted by the challenger winning \
+         the description"
+    );
+    assert_eq!(
+        out[0].extra.get("salaryMax"),
+        Some(&serde_json::json!(140_000)),
+        "incumbent-only salaryMax must be retained"
+    );
+    assert_eq!(
+        out[0].extra.get("salaryCurrency"),
+        Some(&serde_json::json!("USD")),
+        "incumbent's non-empty salaryCurrency must win over the challenger's differing value"
+    );
+    assert_eq!(
+        out[0].extra.get("remote"),
+        Some(&serde_json::json!(true)),
+        "a challenger-only key must be unioned in"
+    );
+}
+
+#[test]
+fn dedup_cross_source_equal_description_length_keeps_incumbent_unchanged() {
+    // Equal-length descriptions (both None here) → no description upgrade; and
+    // incumbent identity (source/url/id) is NEVER swapped by dedup regardless of
+    // whether an upgrade happens.
+    let input = vec![
+        dedup_posting("first", "https://acme.example/jobs/42", "Eng", "Acme", None),
+        dedup_posting(
+            "second",
+            "https://www.acme.example/jobs/42?ref=y",
+            "Eng",
+            "Acme",
+            None,
+        ),
+    ];
+    let out = dedup_cross_source(input);
+    assert_eq!(out.len(), 1);
+    assert_eq!(
+        out[0].source, "first",
+        "incumbent identity (board/source) must never be swapped by dedup"
+    );
+    assert!(out[0].description.is_none(), "no description to upgrade to");
+}
+
+#[test]
+fn dedup_cross_source_keeps_distinct_jobs_and_order() {
+    // Distinct canonical keys must all survive, in first-seen order.
+    let input = vec![
+        dedup_posting("b", "https://acme.example/jobs/1", "A", "Acme", None),
+        dedup_posting("b", "https://acme.example/jobs/2", "B", "Acme", None),
+        dedup_posting("b", "https://acme.example/jobs/3", "C", "Acme", None),
+    ];
+    let urls: Vec<String> = dedup_cross_source(input)
+        .iter()
+        .map(|p| p.url.clone())
+        .collect();
+    assert_eq!(
+        urls,
+        vec![
+            "https://acme.example/jobs/1",
+            "https://acme.example/jobs/2",
+            "https://acme.example/jobs/3",
+        ],
+        "distinct jobs must all be kept in first-seen order"
+    );
+}
+
+#[test]
+fn dedup_cross_source_collapses_urlless_by_title_and_company() {
+    // URL-less postings fall back to title+company; same title+company (case/edge-
+    // whitespace insensitive) collapses; description upgrades to the richer one,
+    // but incumbent ("x") identity is kept.
+    let input = vec![
+        dedup_posting("x", "", " Staff Engineer ", "Acme", None),
+        dedup_posting("y", "   ", "staff engineer", "  ACME", Some("desc")),
+    ];
+    let out = dedup_cross_source(input);
+    assert_eq!(out.len(), 1, "same title+company with no URL must collapse");
+    assert_eq!(
+        out[0].source, "x",
+        "incumbent identity is kept even when the challenger's description wins"
+    );
+    assert_eq!(
+        out[0].description.as_deref(),
+        Some("desc"),
+        "description upgrades to the challenger's non-empty text"
+    );
+}
+
+/// Engine seam — two boards return the SAME job (same canonical URL up to
+/// www/tracking): the aggregated result collapses to ONE posting, keeping the
+/// FIRST board's identity (id/url/source) while upgrading its description to
+/// the richer, full-text one from its later duplicate — while each board's
+/// `BoardScrapeSummary.count` stays as-fetched (1 each) — per-board counts
+/// describe raw returns, not the deduped set.
+#[tokio::test]
+async fn scrape_boards_collapses_cross_source_duplicates_keeping_richer() {
+    struct OneJobScraper {
+        url: &'static str,
+        description: &'static str,
+        source: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl Scraper for OneJobScraper {
+        fn id(&self) -> &'static str {
+            "onejob"
+        }
+        fn display_name(&self) -> &'static str {
+            "OneJob"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            let job = JobPosting {
+                id: format!("{}:1", self.source),
+                external_id: Some("1".to_string()),
+                title: "Staff Engineer".to_string(),
+                company: "Acme".to_string(),
+                location: None,
+                url: self.url.to_string(),
+                source: self.source.to_string(),
+                description: Some(self.description.to_string()),
+                requirements: None,
+                posted_at: None,
+                captured_at: 0,
+                extra: std::collections::HashMap::new(),
+            };
+            if let Some(ref on_item) = ctx.on_item {
+                on_item(job.clone());
+            }
+            Ok(vec![job])
+        }
+    }
+
+    // "agg" first with a truncated snippet + tracking params; "board" second with
+    // the same canonical URL (www + no query) and the FULL description.
+    static AGG: std::sync::LazyLock<OneJobScraper> = std::sync::LazyLock::new(|| OneJobScraper {
+        url: "https://www.acme.example/jobs/42?utm_source=agg",
+        description: "short snippet",
+        source: "aggregator",
+    });
+    static BOARD: std::sync::LazyLock<OneJobScraper> = std::sync::LazyLock::new(|| OneJobScraper {
+        url: "https://acme.example/jobs/42",
+        description: "full description with many more characters than the snippet",
+        source: "board",
+    });
+
+    let engine = ScraperEngine::new();
+    let boards = vec!["agg-board".to_string(), "board-board".to_string()];
+    let (postings, summaries) = engine
+        .scrape_boards_with_resolver(
+            &boards,
+            fake_input(10),
+            "job-trust-e-dedup".to_string(),
+            None,
+            None,
+            std::path::Path::new("."),
+            |id| match id {
+                "agg-board" => Ok(&*AGG as &'static dyn Scraper),
+                "board-board" => Ok(&*BOARD as &'static dyn Scraper),
+                other => Err(anyhow::anyhow!("Unknown board: {other}")),
+            },
+        )
+        .await
+        .expect("cross-source dedup run must be Ok");
+
+    // Per-board counts stay as-fetched: each board returned exactly 1.
+    assert_eq!(summaries.len(), 2, "one summary per board");
+    for s in &summaries {
+        assert_eq!(
+            s.count, 1,
+            "per-board count must stay as-fetched (pre-dedup); got {s:?}"
+        );
+        assert!(s.error.is_none() && s.skipped.is_none());
+    }
+
+    // The aggregated result collapses the duplicate to ONE posting...
+    assert_eq!(
+        postings.len(),
+        1,
+        "the same job from two boards must collapse to one aggregated row"
+    );
+    // ...the FIRST board's identity is kept (never overwritten by a later
+    // duplicate)...
+    assert_eq!(
+        postings[0].source, "aggregator",
+        "incumbent (first-seen) board identity must be kept, not swapped for the challenger's"
+    );
+    // ...but its description is upgraded to the richer, full text.
+    assert_eq!(
+        postings[0].description.as_deref(),
+        Some("full description with many more characters than the snippet"),
+        "the surviving row's description must upgrade to the full text, not stay truncated"
+    );
+}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -210,10 +210,16 @@ export function JobsPage() {
     if (livePostings.length > 0) setShowScrapeForm(false);
   }, [livePostings.length]);
 
-  const allPostings = useMemo(
-    () => mergePostings(postings, livePostings),
-    [postings, livePostings]
-  );
+  // `absorbedInto` traces which live-stream ids collapsed into which survivor id
+  // (boards stream at different speeds and the persisted refetch can land under a
+  // DIFFERENT incumbent than the one currently selected) — JobsResults consumes it
+  // to re-point a stale `selectedId` at its survivor instead of silently falling
+  // back to the top of the list.
+  const { allPostings, absorbedInto } = useMemo(() => {
+    const absorbedInto = new Map<string, string>();
+    const allPostings = mergePostings(postings, livePostings, absorbedInto);
+    return { allPostings, absorbedInto };
+  }, [postings, livePostings]);
 
   const handleClearPostings = async () => {
     setConfirmClear(false);
@@ -394,6 +400,7 @@ export function JobsPage() {
             // empty state doesn't re-show a prior scrape's diagnostics when a
             // filter (not the scrape) is what emptied the visible list.
             totalCount={allPostings.length}
+            absorbedInto={absorbedInto}
             onShowMore={handleShowMore}
             onScrape={() => setShowScrapeForm(true)}
           />

--- a/apps/desktop/src/renderer/features/jobs/components/JobsResults/JobsResults.reconciliation.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsResults/JobsResults.reconciliation.test.tsx
@@ -128,7 +128,11 @@ function posting(id: string): Posting {
 const noop = () => {};
 const formatRelativeTime = () => '';
 
-function renderResults(filtered: Posting[], resumeId: string | null = null) {
+function renderResults(
+  filtered: Posting[],
+  resumeId: string | null = null,
+  absorbedInto?: Map<string, string>
+) {
   const wrapper = ({ children }: { children: ReactNode }) => (
     <MatchScoresProvider resumeId={resumeId}>{children}</MatchScoresProvider>
   );
@@ -137,6 +141,7 @@ function renderResults(filtered: Posting[], resumeId: string | null = null) {
       filtered={filtered}
       formatRelativeTime={formatRelativeTime}
       scraping={false}
+      absorbedInto={absorbedInto}
       onShowMore={noop}
       onScrape={noop}
     />,
@@ -223,5 +228,58 @@ describe('JobsResults — selectedId reconciliation', () => {
     });
 
     expect(mockSetJobs).not.toHaveBeenCalled();
+  });
+
+  // ── Regression: a selected id absorbed by mergePostings' cross-source collapse
+  // must re-point at the survivor, NOT silently fall back to display[0] ─────────
+  //
+  // Root-cause scenario: boards=[aggregator, board]. The fast `board` streams
+  // first, so its live-stream row (id `board-1`) is the only copy and gets
+  // selected by the user. `livePostings` is never cleared on job.completed. The
+  // persisted refetch holds the SAME job under `aggregator-1` (the engine's
+  // incumbent-selection order follows board input order, not display arrival
+  // order). mergePostings' pass 2 absorbs `board-1` into `aggregator-1` — before
+  // this fix, `selectedId` (`board-1`) vanished from `filtered` and the existing
+  // reconciliation effect silently swapped the detail pane to display[0], an
+  // UNRELATED job.
+  it('re-points selection at the survivor id when the selected live-id row was absorbed by a persisted incumbent (not display[0])', async () => {
+    STORE_STATE.jobs = { viewMode: 'split', selectedId: 'board-1' };
+    const absorbedInto = new Map([['board-1', 'aggregator-1']]);
+
+    await act(async () => {
+      // `board-1` no longer appears — mergePostings already collapsed it into
+      // `aggregator-1`, which is unrelated-job-shaped ('unrelated-job') to prove
+      // the fix isn't accidentally passing via display[0] coincidentally matching.
+      renderResults([posting('unrelated-job'), posting('aggregator-1')], null, absorbedInto);
+    });
+
+    expect(mockSetJobs).toHaveBeenCalledWith({ selectedId: 'aggregator-1' });
+    expect(mockSetJobs).not.toHaveBeenCalledWith({ selectedId: 'unrelated-job' });
+  });
+
+  it('falls back to display[0] when the selected id was absorbed but the survivor is somehow not in display', async () => {
+    // Defensive: absorbedInto claims a survivor that isn't actually in `filtered`
+    // (should not happen in practice — the survivor is always in the merged
+    // output — but the effect must not select a phantom id).
+    STORE_STATE.jobs = { viewMode: 'split', selectedId: 'board-1' };
+    const absorbedInto = new Map([['board-1', 'not-in-display']]);
+
+    await act(async () => {
+      renderResults([posting('job-present')], null, absorbedInto);
+    });
+
+    expect(mockSetJobs).toHaveBeenCalledWith({ selectedId: 'job-present' });
+  });
+
+  it('does NOT call setJobs when the selection is absorbed but the caller passes no absorbedInto map', async () => {
+    // absorbedInto omitted entirely (e.g. a caller that never merges duplicate
+    // sources) — must fall back to the existing topId behaviour, not throw.
+    STORE_STATE.jobs = { viewMode: 'split', selectedId: 'job-missing' };
+
+    await act(async () => {
+      renderResults([posting('job-present')]);
+    });
+
+    expect(mockSetJobs).toHaveBeenCalledWith({ selectedId: 'job-present' });
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/components/JobsResults/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsResults/index.tsx
@@ -36,6 +36,12 @@ interface JobsResultsProps {
    *  Optional — when omitted, `filtered` is treated as authoritative (matches
    *  every call site that doesn't apply a filter). */
   totalCount?: number;
+  /** Maps an absorbed cross-source-duplicate id to the survivor id it collapsed
+   *  into (`mergePostings`'s `absorbed` out-param) — lets the selection
+   *  reconciliation effect below re-point a stale `selectedId` at the SAME job
+   *  under its new id, instead of silently falling back to the top of the list.
+   *  Optional: callers that never merge duplicate sources (or tests) can omit it. */
+  absorbedInto?: Map<string, string>;
   onShowMore: () => void;
   onScrape: () => void;
 }
@@ -58,6 +64,7 @@ export function JobsResults({
   boardSummaries,
   failureNote,
   totalCount,
+  absorbedInto,
   onShowMore,
   onScrape,
 }: JobsResultsProps) {
@@ -101,16 +108,26 @@ export function JobsResults({
   const topId = filtered[0]?.id ?? null;
   const selectionInDisplay = selectedId !== null && filtered.some((p) => p.id === selectedId);
 
-  // Auto-select: pick topId only when there is NO valid selection in the display.
-  // This preserves the user's chosen job across re-scrapes, show-more, and live
-  // prepends — we only step in when the detail pane would otherwise be blank
-  // (fresh search with nothing selected, or selection was filtered out).
+  // If the selection isn't directly in `filtered`, it may have been absorbed by
+  // mergePostings' cross-source collapse (a live `board`-id row selected before
+  // the persisted refetch lands it under a DIFFERENT `aggregator`-id incumbent —
+  // boards stream at different speeds, so the engine's incumbent choice need not
+  // match the id the user already had open). Resolve to that survivor BEFORE
+  // falling back to topId — the survivor IS the same job, just a new id.
+  const survivorId = selectedId !== null ? (absorbedInto?.get(selectedId) ?? null) : null;
+  const survivorInDisplay = survivorId !== null && filtered.some((p) => p.id === survivorId);
+
+  // Auto-select: pick the survivor (if the selection collapsed into one) or
+  // topId, only when there is NO valid selection in the display. This preserves
+  // the user's chosen job across re-scrapes, show-more, and live prepends — we
+  // only step in when the detail pane would otherwise be blank/wrong (fresh
+  // search with nothing selected, selection was filtered out, or it collapsed
+  // into a differently-id'd survivor).
   useEffect(() => {
     if (viewMode !== 'split' || topId === null) return;
-    if (!selectionInDisplay) {
-      setJobs({ selectedId: topId });
-    }
-  }, [viewMode, topId, selectionInDisplay, setJobs]);
+    if (selectionInDisplay) return;
+    setJobs({ selectedId: survivorInDisplay && survivorId !== null ? survivorId : topId });
+  }, [viewMode, topId, selectionInDisplay, survivorInDisplay, survivorId, setJobs]);
 
   // Windowed list: only visible rows (+ overscan) mount. Keyed by posting id so
   // measurement survives live-prepended rows during a scrape.

--- a/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.test.ts
@@ -38,6 +38,14 @@ describe('canonicalJobKey — Rust truth-table parity (verbatim inputs)', () => 
     expect(a).toBe(`senior rust engineer${SEP}acme`);
   });
 
+  it('URL-less non-ASCII title+company normalizes to the exact expected key (Rust drift guard)', () => {
+    // Same case verbatim is pinned in the Rust truth table — a JS `.toLowerCase()`
+    // vs Rust `.to_lowercase()` divergence on accented Unicode would show up here
+    // as a mismatched exact string, not just an equality-between-variants check.
+    const key = canonicalJobKey('', 'Développeur Sénior', 'Müller GmbH');
+    expect(key).toBe(`développeur sénior${SEP}müller gmbh`);
+  });
+
   it('near-miss titles at the same company stay distinct', () => {
     const senior = canonicalJobKey('', 'Senior Rust Engineer', 'Acme');
     const plain = canonicalJobKey('', 'Rust Engineer', 'Acme');

--- a/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.test.ts
@@ -1,0 +1,115 @@
+/**
+ * canonicalJobKey — the TS half of the cross-source dedup key (trust PR E,
+ * stage 3). It is a LOCKSTEP mirror of the Rust `canonical_job_key`
+ * (`scraping/boards/common.rs`) built on `normalize_job_url`
+ * (`applications/mod.rs`).
+ *
+ * The first five cases copy the Rust truth-table inputs VERBATIM from
+ * `scraping/boards/common/test.rs` (fixtures can't be literally shared across
+ * languages, so duplicating the inputs is the drift guard: if either side
+ * changes the algorithm, one of these — or its Rust twin — fails). The rest
+ * pin TS-side URL-normalization details (Indeed `jk`, www/fragment/query/
+ * trailing-slash, whole-URL lowercasing) that the Rust `normalize_job_url`
+ * tests own on their side.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { canonicalJobKey } from './canonical-job-key';
+
+// U+0001 (SOH) fallback-key separator — matches KEY_SEP in the impl and Rust's `\u{1}`.
+const SEP = String.fromCharCode(1);
+
+describe('canonicalJobKey — Rust truth-table parity (verbatim inputs)', () => {
+  it('same URL across boards collapses (www/tracking variants, differing titles)', () => {
+    const a = canonicalJobKey(
+      'https://www.acme.example/jobs/42?utm_source=x',
+      'Senior Engineer',
+      'Acme'
+    );
+    const b = canonicalJobKey('https://acme.example/jobs/42', 'Sr. Engineer', 'Acme Inc');
+    expect(a).toBe(b);
+    expect(a).toBe('https://acme.example/jobs/42');
+  });
+
+  it('URL-less rows match on normalized title + company', () => {
+    const a = canonicalJobKey('', ' Senior Rust Engineer ', 'Acme');
+    const b = canonicalJobKey('', 'senior rust engineer', '  ACME ');
+    expect(a).toBe(b);
+    expect(a).toBe(`senior rust engineer${SEP}acme`);
+  });
+
+  it('near-miss titles at the same company stay distinct', () => {
+    const senior = canonicalJobKey('', 'Senior Rust Engineer', 'Acme');
+    const plain = canonicalJobKey('', 'Rust Engineer', 'Acme');
+    expect(senior).not.toBe(plain);
+  });
+
+  it('the SOH separator cannot be forged by a title containing the company', () => {
+    const forged = canonicalJobKey('', 'Engineer Acme', '');
+    const genuine = canonicalJobKey('', 'Engineer', 'Acme');
+    expect(forged).not.toBe(genuine);
+  });
+
+  it('empty / whitespace / non-http(s) schemes fall back to title+company', () => {
+    const expected = `t${SEP}co`;
+    expect(canonicalJobKey('', 'T', 'Co')).toBe(expected);
+    expect(canonicalJobKey('   ', 'T', 'Co')).toBe(expected);
+    expect(canonicalJobKey('javascript:alert(1)', 'T', 'Co')).toBe(expected);
+    expect(canonicalJobKey('file:///etc/passwd', 'T', 'Co')).toBe(expected);
+  });
+});
+
+describe('canonicalJobKey — URL normalization details (mirror normalize_job_url)', () => {
+  it('keeps Indeed jk, drops other query params, strips www', () => {
+    expect(
+      canonicalJobKey('https://www.indeed.com/viewjob?jk=abc123&utm_source=x', 'Engineer', 'Acme')
+    ).toBe('https://indeed.com/viewjob?jk=abc123');
+  });
+
+  it('keeps jk on Indeed subdomains and is param-order independent', () => {
+    const a = canonicalJobKey('https://de.indeed.com/viewjob?jk=abc123', 'Engineer', 'Acme');
+    const b = canonicalJobKey(
+      'https://de.indeed.com/viewjob?utm_source=x&jk=abc123',
+      'Engineer',
+      'Acme'
+    );
+    expect(a).toBe(b);
+    expect(a).toBe('https://de.indeed.com/viewjob?jk=abc123');
+  });
+
+  it('drops jk for non-Indeed hosts (jk is not identifying there)', () => {
+    expect(canonicalJobKey('https://acme.example/jobs?jk=x', 'Engineer', 'Acme')).toBe(
+      'https://acme.example/jobs'
+    );
+  });
+
+  it('drops the fragment and strips a trailing slash', () => {
+    expect(canonicalJobKey('https://www.acme.example/jobs/42/#apply', 'Engineer', 'Acme')).toBe(
+      'https://acme.example/jobs/42'
+    );
+  });
+
+  it('lowercases the WHOLE url including the path (byte-equivalent to Rust, unlike URL())', () => {
+    expect(canonicalJobKey('https://Acme.EXAMPLE/Jobs/ABC', 'Engineer', 'Acme')).toBe(
+      'https://acme.example/jobs/abc'
+    );
+  });
+
+  it('keys a scheme-less url by the url itself (not the title fallback)', () => {
+    expect(canonicalJobKey('acme.example/jobs/42', 'Engineer', 'Acme')).toBe(
+      'acme.example/jobs/42'
+    );
+  });
+
+  it('a malformed URL (empty authority) does not throw and returns deterministic output', () => {
+    // "https:///path" has a scheme but an empty host — no `URL`/regex parse step
+    // exists here to throw on it (raw string mirror, by design); this pins that
+    // the fn stays a pure no-crash string transform on odd input, same as Rust's
+    // `normalize_job_url` (no panics, no `Result`).
+    expect(() => canonicalJobKey('https:///path', 'Engineer', 'Acme')).not.toThrow();
+    const key = canonicalJobKey('https:///path', 'Engineer', 'Acme');
+    expect(typeof key).toBe('string');
+    // Same input twice must key identically (determinism, not just no-crash).
+    expect(canonicalJobKey('https:///path', 'Engineer', 'Acme')).toBe(key);
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.ts
@@ -1,0 +1,139 @@
+/**
+ * App-wide canonical dedup key for a job posting — the TS mirror of the Rust
+ * `canonical_job_key` (`apps/desktop/src-tauri/src/scraping/boards/common.rs`),
+ * which itself builds on `normalize_job_url`
+ * (`apps/desktop/src-tauri/src/applications/mod.rs`).
+ *
+ * **LOCKSTEP PAIR** — this file and `scraping/boards/common.rs::canonical_job_key`
+ * MUST stay byte-identical for the same inputs (like `sanitizeReason` ↔
+ * `redact_token`). The whole point of trust-program PR E is that the engine's
+ * cross-source dedup, autopilot's `merge_found_jobs`, and the renderer's
+ * `mergePostings` all key on ONE notion of "same job", so a posting surfaced by
+ * two boards collapses to one row and fires one notification. If the two sides
+ * drift, the deduped completion count no longer reconciles with the displayed
+ * rows. The truth-table test copies the Rust test inputs verbatim so any drift
+ * fails a test.
+ *
+ * Deliberately a raw-string mirror, NOT the WHATWG `URL` API: `normalize_job_url`
+ * lowercases the WHOLE url (path + query included), does no percent-decoding, and
+ * strips trailing slashes itself. `URL` lowercases only scheme+host, re-encodes
+ * components, and resolves `.`/`..` — any of which would diverge from the Rust
+ * key for real inputs, defeating the cross-boundary dedup this exists to enable.
+ */
+
+/**
+ * Extract an explicit URL scheme (`scheme:` per RFC 3986 §3.1), lowercased, if
+ * one is present before the first `/`, `?`, or `#`. Mirrors Rust
+ * `explicit_scheme`. Returns `null` for scheme-less input (a `:` inside a path or
+ * query is not a scheme).
+ */
+function explicitScheme(input: string): string | null {
+  // Only the head before the first path/query/fragment delimiter can carry a scheme.
+  const head = input.split(/[/?#]/, 1)[0] ?? input;
+  const colon = head.indexOf(':');
+  if (colon === -1) return null;
+  const candidate = head.slice(0, colon);
+  if (candidate === '') return null;
+  // First char ALPHA, rest ALPHA / DIGIT / "+" / "-" / ".".
+  if (!/^[A-Za-z][A-Za-z0-9+.-]*$/.test(candidate)) return null;
+  return candidate.toLowerCase();
+}
+
+/**
+ * Per-host allowlist of *identifying* query params that survive normalization
+ * (every other query param is dropped). Mirrors Rust `identifying_query_params`:
+ * currently only Indeed's `jk` (other boards put the id in the path).
+ */
+function identifyingQueryParams(host: string): readonly string[] {
+  if (host === 'indeed.com' || host.endsWith('.indeed.com')) return ['jk'];
+  return [];
+}
+
+/**
+ * Rebuild the query keeping only `identifyingQueryParams(host)`, emitted in the
+ * allowlist's fixed order (so input param ordering can't change the key). A param
+ * with an empty value is skipped. Mirrors Rust `retain_identifying_params`.
+ */
+function retainIdentifyingParams(host: string, query: string): string {
+  const allow = identifyingQueryParams(host);
+  if (allow.length === 0 || query === '') return '';
+  const parts: string[] = [];
+  for (const key of allow) {
+    for (const pair of query.split('&')) {
+      const eq = pair.indexOf('=');
+      const k = eq === -1 ? pair : pair.slice(0, eq);
+      const v = eq === -1 ? '' : pair.slice(eq + 1);
+      if (k === key && v !== '') {
+        parts.push(`${key}=${v}`);
+        break; // first match per key, like Rust's find_map
+      }
+    }
+  }
+  return parts.join('&');
+}
+
+/**
+ * Normalize a job URL into a stable identity string. Mirrors Rust
+ * `normalize_job_url`: rejects any non-`http(s)` explicit scheme to `""`;
+ * lowercases the whole URL; strips a leading `www.` on the host; drops the
+ * `#fragment`; drops the query except per-host identifying params; strips a
+ * trailing `/` on the path. Empty/blank input → `""`.
+ */
+function normalizeJobUrl(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed === '') return '';
+
+  // Reject dangerous explicit schemes at the single chokepoint: only http(s) round-trips.
+  const scheme = explicitScheme(trimmed);
+  if (scheme !== null && scheme !== 'http' && scheme !== 'https') return '';
+
+  const lower = trimmed.toLowerCase();
+  // split_once("://")
+  const sep = lower.indexOf('://');
+  const schemePart = sep === -1 ? null : lower.slice(0, sep);
+  const rest = sep === -1 ? lower : lower.slice(sep + 3);
+
+  // Drop the fragment, then split the query off the path.
+  const hash = rest.indexOf('#');
+  const noFrag = hash === -1 ? rest : rest.slice(0, hash);
+  const qmark = noFrag.indexOf('?');
+  const pathPart = qmark === -1 ? noFrag : noFrag.slice(0, qmark);
+  const query = qmark === -1 ? '' : noFrag.slice(qmark + 1);
+
+  // split_once('/') — host, then everything after the first slash (or none).
+  const slash = pathPart.indexOf('/');
+  const rawHost = slash === -1 ? pathPart : pathPart.slice(0, slash);
+  const path = slash === -1 ? null : pathPart.slice(slash + 1);
+
+  const host = rawHost.startsWith('www.') ? rawHost.slice(4) : rawHost;
+  const retainedQuery = retainIdentifyingParams(host, query);
+
+  let out = '';
+  if (schemePart !== null) out += `${schemePart}://`;
+  out += host;
+  if (path !== null) {
+    const trimmedPath = path.replace(/\/+$/, ''); // Rust trim_end_matches('/')
+    if (trimmedPath !== '') out += `/${trimmedPath}`;
+  }
+  if (retainedQuery !== '') out += `?${retainedQuery}`;
+  return out;
+}
+
+/**
+ * U+0001 (SOH) fallback-key separator, matching Rust's `\u{1}`. Cannot occur in
+ * real title/company text, so a title that merely contains the company name
+ * can't forge a colliding key, and near-miss titles stay distinct.
+ */
+const KEY_SEP = String.fromCharCode(1); // U+0001 (SOH); see doc above
+
+/**
+ * The canonical dedup key. Mirrors Rust `canonical_job_key`:
+ * 1. `n = normalizeJobUrl(url)`; if non-empty, the key IS `n` (URL identity).
+ * 2. Otherwise fall back to `"{title}<U+0001>{company}"`, each side
+ *    `.trim().toLowerCase()`.
+ */
+export function canonicalJobKey(url: string, title: string, company: string): string {
+  const normalized = normalizeJobUrl(url);
+  if (normalized !== '') return normalized;
+  return `${title.trim().toLowerCase()}${KEY_SEP}${company.trim().toLowerCase()}`;
+}

--- a/apps/desktop/src/renderer/features/jobs/lib/merge-postings.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/merge-postings.test.ts
@@ -1,0 +1,295 @@
+/**
+ * mergePostings — id-merge + cross-source canonical-key dedup (trust PR E, stage 3).
+ *
+ * Pass 1 (backend-wins-by-id) is also covered by the pure-function block in
+ * JobsPage.dedup-throttle.test.tsx; this file focuses on pass 2 — collapsing the
+ * same job surfaced under DIFFERENT ids by two sources, and the survivor policy
+ * (keep-incumbent identity, union interactions, byte-length description upgrade,
+ * fill-only-missing enrichment).
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { JobInteraction, JobTrustAssessment } from '@ajh/shared';
+
+import type { Posting } from '../types';
+import { mergePostings } from './merge-postings';
+
+function makePosting(overrides: Partial<Posting> & { id: string }): Posting {
+  return {
+    source: 'linkedin',
+    externalId: overrides.id,
+    url: `https://example.com/${overrides.id}`,
+    title: 'Engineer',
+    company: 'Acme',
+    description: '',
+    capturedAt: 0,
+    ...overrides,
+  };
+}
+
+describe('mergePostings — cross-source canonical-key dedup', () => {
+  it('two streamed rows for the same job (different ids) collapse to one, first-seen kept', () => {
+    // The live-stream window: the manual-scrape stream is NOT deduped by the
+    // engine, so two boards emit the same job under different ids until this pass.
+    const gh = makePosting({ id: 'gh-1', url: 'https://acme.example/jobs/42' });
+    const li = makePosting({ id: 'li-9', url: 'https://www.acme.example/jobs/42?utm_source=x' });
+    const result = mergePostings([], [gh, li]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('gh-1');
+  });
+
+  it('the richer (longest) description survives, incumbent id preserved', () => {
+    const incumbent = makePosting({
+      id: 'a',
+      url: 'https://acme.example/jobs/42',
+      description: 'short snippet',
+    });
+    const richer = makePosting({
+      id: 'b',
+      url: 'https://acme.example/jobs/42',
+      description: 'a much longer, full job description with the entire body text',
+    });
+    const result = mergePostings([], [incumbent, richer]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('a');
+    expect(result[0]?.description).toBe(richer.description);
+  });
+
+  it('a persisted row with user-state survives a streamed duplicate: id + interactions kept, description upgraded', () => {
+    const bookmark: JobInteraction = {
+      jobId: 'backend-1',
+      title: 'Engineer',
+      company: 'Acme',
+      url: 'https://acme.example/jobs/42',
+      source: 'linkedin',
+      interactionType: 'bookmarked',
+      timestamp: 1,
+    };
+    const backend = makePosting({
+      id: 'backend-1',
+      url: 'https://acme.example/jobs/42',
+      description: 'persisted text',
+      interactions: [bookmark],
+    });
+    const live = makePosting({
+      id: 'live-9',
+      url: 'https://www.acme.example/jobs/42#apply',
+      description: 'a much longer streamed description with the full body',
+    });
+    const result = mergePostings([backend], [live]);
+    expect(result).toHaveLength(1);
+    // Survivor keeps the incumbent's id (selection keys on id); `live` here has no
+    // interactions to union in, so the incumbent's bookmark alone survives.
+    expect(result[0]?.id).toBe('backend-1');
+    expect(result[0]?.interactions).toEqual([bookmark]);
+    // ...but upgrades to the fuller description.
+    expect(result[0]?.description).toBe(live.description);
+  });
+
+  it('interactions from both incumbent and challenger are UNIONED, not dropped', () => {
+    // Two already-persisted legacy duplicates (pre-dating the engine's dedup pass)
+    // can each carry distinct saved/applied state — collapsing must not silently
+    // drop the challenger's.
+    const saved: JobInteraction = {
+      jobId: 'a',
+      title: 'Engineer',
+      company: 'Acme',
+      url: 'https://acme.example/jobs/42',
+      source: 'linkedin',
+      interactionType: 'bookmarked',
+      timestamp: 1,
+    };
+    const applied: JobInteraction = {
+      jobId: 'b',
+      title: 'Engineer',
+      company: 'Acme',
+      url: 'https://acme.example/jobs/42',
+      source: 'indeed',
+      interactionType: 'applied',
+      timestamp: 2,
+    };
+    const incumbent = makePosting({
+      id: 'a',
+      url: 'https://acme.example/jobs/42',
+      interactions: [saved],
+    });
+    const challenger = makePosting({
+      id: 'b',
+      url: 'https://acme.example/jobs/42',
+      interactions: [applied],
+    });
+    const result = mergePostings([], [incumbent, challenger]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('a');
+    expect(result[0]?.interactions).toEqual([saved, applied]);
+  });
+
+  it('exact-duplicate interaction entries collapse to one on union', () => {
+    const dup: JobInteraction = {
+      jobId: 'a',
+      title: 'Engineer',
+      company: 'Acme',
+      url: 'https://acme.example/jobs/42',
+      source: 'linkedin',
+      interactionType: 'viewed',
+      timestamp: 5,
+    };
+    const incumbent = makePosting({
+      id: 'a',
+      url: 'https://acme.example/jobs/42',
+      interactions: [dup],
+    });
+    const challenger = makePosting({
+      id: 'b',
+      url: 'https://acme.example/jobs/42',
+      interactions: [{ ...dup }],
+    });
+    const result = mergePostings([], [incumbent, challenger]);
+    expect(result[0]?.interactions).toHaveLength(1);
+  });
+
+  it('url-less rows with the same title+company collapse via the fallback key', () => {
+    const a = makePosting({
+      id: 'a',
+      url: '',
+      title: 'Rust Engineer',
+      company: 'Acme',
+      description: 'x',
+    });
+    const b = makePosting({
+      id: 'b',
+      url: '   ',
+      title: 'rust engineer',
+      company: '  ACME ',
+      description: 'a longer description',
+    });
+    const result = mergePostings([], [a, b]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('a');
+    expect(result[0]?.description).toBe('a longer description');
+  });
+
+  it('description upgrade compares UTF-8 BYTE length, not UTF-16 code units (matches Rust str::len)', () => {
+    // Incumbent: 5 ASCII chars = 5 code units = 5 bytes.
+    // Challenger: 4 "€" (U+20AC) = 4 code units (fewer than incumbent) but 12 UTF-8
+    // bytes (more than incumbent) — a code-unit compare would WRONGLY keep the
+    // incumbent; the byte-length compare correctly upgrades to the challenger,
+    // matching what Rust's byte-based `desc_len`/comparison would pick.
+    const incumbent = makePosting({
+      id: 'a',
+      url: 'https://acme.example/jobs/42',
+      description: '12345',
+    });
+    const challenger = makePosting({
+      id: 'b',
+      url: 'https://acme.example/jobs/42',
+      description: '€€€€',
+    });
+    expect(challenger.description.length).toBeLessThan(incumbent.description.length);
+    const result = mergePostings([], [incumbent, challenger]);
+    expect(result[0]?.id).toBe('a');
+    expect(result[0]?.description).toBe('€€€€');
+  });
+
+  it('trust is filled from the challenger when the incumbent lacks it', () => {
+    const trust: JobTrustAssessment = { score: 80, level: 'high', flags: [] };
+    const incumbent = makePosting({ id: 'a', url: 'https://acme.example/jobs/42' });
+    const challenger = makePosting({ id: 'b', url: 'https://acme.example/jobs/42', trust });
+    const result = mergePostings([], [incumbent, challenger]);
+    expect(result[0]?.id).toBe('a');
+    expect(result[0]?.trust).toEqual(trust);
+  });
+
+  it("the incumbent's own trust is never overwritten by the challenger", () => {
+    const incumbentTrust: JobTrustAssessment = { score: 90, level: 'high', flags: [] };
+    const challengerTrust: JobTrustAssessment = {
+      score: 20,
+      level: 'low',
+      flags: ['suspiciousDomain'],
+    };
+    const incumbent = makePosting({
+      id: 'a',
+      url: 'https://acme.example/jobs/42',
+      trust: incumbentTrust,
+    });
+    const challenger = makePosting({
+      id: 'b',
+      url: 'https://acme.example/jobs/42',
+      trust: challengerTrust,
+    });
+    const result = mergePostings([], [incumbent, challenger]);
+    expect(result[0]?.trust).toEqual(incumbentTrust);
+  });
+
+  it('equal-length descriptions tie to the incumbent (no upgrade)', () => {
+    const a = makePosting({ id: 'a', url: 'https://acme.example/jobs/42', description: 'abcd' });
+    const b = makePosting({ id: 'b', url: 'https://acme.example/jobs/42', description: 'wxyz' });
+    const result = mergePostings([], [a, b]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('a');
+    expect(result[0]?.description).toBe('abcd');
+  });
+
+  it('salary the incumbent LACKS is filled from the challenger (no data dropped on collapse)', () => {
+    // The cited harm: a direct-board row (no salary, incumbent) must not erase the
+    // aggregator duplicate's salary just because it won on description length.
+    const directBoard = makePosting({
+      id: 'gh-1',
+      url: 'https://acme.example/jobs/42',
+      description: 'a full direct-board description',
+    });
+    const adzuna = makePosting({
+      id: 'adz-9',
+      url: 'https://www.acme.example/jobs/42',
+      description: 'short',
+      salaryMin: 90000,
+      salaryMax: 120000,
+      salaryCurrency: 'EUR',
+    });
+    const result = mergePostings([], [directBoard, adzuna]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('gh-1');
+    expect(result[0]?.description).toBe('a full direct-board description');
+    expect(result[0]?.salaryMin).toBe(90000);
+    expect(result[0]?.salaryMax).toBe(120000);
+    expect(result[0]?.salaryCurrency).toBe('EUR');
+  });
+
+  it("the incumbent's own salary is never overwritten by the challenger", () => {
+    const incumbent = makePosting({
+      id: 'a',
+      url: 'https://acme.example/jobs/42',
+      salaryMin: 100000,
+      salaryCurrency: 'USD',
+    });
+    const challenger = makePosting({
+      id: 'b',
+      url: 'https://acme.example/jobs/42',
+      description: 'a longer description that would win the description upgrade',
+      salaryMin: 50000,
+      salaryCurrency: 'EUR',
+    });
+    const result = mergePostings([], [incumbent, challenger]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.salaryMin).toBe(100000);
+    expect(result[0]?.salaryCurrency).toBe('USD');
+    // Description still upgrades even while salary is preserved.
+    expect(result[0]?.description).toBe(challenger.description);
+  });
+
+  it('distinct jobs are untouched and keep input order', () => {
+    const a = makePosting({ id: 'a', url: 'https://acme.example/jobs/1' });
+    const b = makePosting({ id: 'b', url: 'https://acme.example/jobs/2' });
+    const c = makePosting({ id: 'c', url: 'https://acme.example/jobs/3' });
+    const result = mergePostings([a, b, c], []);
+    expect(result.map((p) => p.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('still merges by id (backend wins) before the canonical pass', () => {
+    const backend = makePosting({ id: 'shared', company: 'BackendCo', url: 'https://x/shared' });
+    const live = makePosting({ id: 'shared', company: 'LiveCo', url: 'https://x/shared' });
+    const result = mergePostings([backend], [live]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.company).toBe('BackendCo');
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/lib/merge-postings.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/merge-postings.test.ts
@@ -221,6 +221,35 @@ describe('mergePostings — cross-source canonical-key dedup', () => {
     expect(result[0]?.trust).toEqual(incumbentTrust);
   });
 
+  it('every enrichment field the challenger carries survives a collapse onto a bare incumbent (fill-list guard)', () => {
+    // Mechanical pin on collapseDuplicate's fill-list: builds a challenger with
+    // every enrichment key `JobPosting.extra` carries today (salaryMin/Max/
+    // Currency, remote, trust) set, and a bare incumbent with none of them, then
+    // asserts ALL of them survive the collapse. A future `extra` key added to the
+    // Rust side without a matching entry in collapseDuplicate's fill-list makes
+    // THIS test fail once the new field is added to the fixture below — when you
+    // add a key here, add the matching `?? ` line in collapseDuplicate too.
+    const trust: JobTrustAssessment = { score: 55, level: 'medium', flags: [] };
+    const incumbent = makePosting({ id: 'a', url: 'https://acme.example/jobs/42' });
+    const challenger = makePosting({
+      id: 'b',
+      url: 'https://acme.example/jobs/42',
+      remote: true,
+      salaryMin: 80000,
+      salaryMax: 100000,
+      salaryCurrency: 'GBP',
+      trust,
+    });
+    const result = mergePostings([], [incumbent, challenger]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('a'); // incumbent identity kept
+    expect(result[0]?.remote).toBe(true);
+    expect(result[0]?.salaryMin).toBe(80000);
+    expect(result[0]?.salaryMax).toBe(100000);
+    expect(result[0]?.salaryCurrency).toBe('GBP');
+    expect(result[0]?.trust).toEqual(trust);
+  });
+
   it('equal-length descriptions tie to the incumbent (no upgrade)', () => {
     const a = makePosting({ id: 'a', url: 'https://acme.example/jobs/42', description: 'abcd' });
     const b = makePosting({ id: 'b', url: 'https://acme.example/jobs/42', description: 'wxyz' });

--- a/apps/desktop/src/renderer/features/jobs/lib/merge-postings.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/merge-postings.test.ts
@@ -293,3 +293,55 @@ describe('mergePostings — cross-source canonical-key dedup', () => {
     expect(result[0]?.company).toBe('BackendCo');
   });
 });
+
+describe('mergePostings — absorbed out-param (selection traceability)', () => {
+  it('records the exact root-cause scenario: a selected board-id live row absorbed into the aggregator-id persisted incumbent', () => {
+    // boards=[aggregator, board]. `board` streams first (only live copy), the
+    // user selects it. The persisted refetch (postings, arriving after
+    // job.completed) holds the SAME job under the aggregator's id — the engine's
+    // incumbent-selection order follows board input order, not display arrival
+    // order — so `aggregator-1` is first-seen (incumbent) and `board-1` is the
+    // absorbed challenger.
+    const aggregatorPersisted = makePosting({
+      id: 'aggregator-1',
+      source: 'aggregator',
+      url: 'https://acme.example/jobs/42',
+    });
+    const boardLive = makePosting({
+      id: 'board-1',
+      source: 'board',
+      url: 'https://www.acme.example/jobs/42?utm_source=x',
+    });
+    const absorbed = new Map<string, string>();
+    const result = mergePostings([aggregatorPersisted], [boardLive], absorbed);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('aggregator-1');
+    expect(absorbed.get('board-1')).toBe('aggregator-1');
+    expect(absorbed.size).toBe(1);
+  });
+
+  it('does not record an entry when no collapse happens (distinct jobs)', () => {
+    const a = makePosting({ id: 'a', url: 'https://acme.example/jobs/1' });
+    const b = makePosting({ id: 'b', url: 'https://acme.example/jobs/2' });
+    const absorbed = new Map<string, string>();
+    mergePostings([a], [b], absorbed);
+    expect(absorbed.size).toBe(0);
+  });
+
+  it('does not record an entry when the id-merge (pass 1) already unified the row (same id both sides)', () => {
+    // Pass 1 drops the live copy before pass 2 ever runs — same id, not a
+    // cross-source absorb, so nothing should be recorded as "absorbed".
+    const backend = makePosting({ id: 'shared', url: 'https://acme.example/jobs/42' });
+    const live = makePosting({ id: 'shared', url: 'https://acme.example/jobs/42' });
+    const absorbed = new Map<string, string>();
+    mergePostings([backend], [live], absorbed);
+    expect(absorbed.size).toBe(0);
+  });
+
+  it('is a no-op (does not throw) when the caller omits the out-param', () => {
+    const a = makePosting({ id: 'a', url: 'https://acme.example/jobs/42' });
+    const b = makePosting({ id: 'b', url: 'https://acme.example/jobs/42' });
+    expect(() => mergePostings([], [a, b])).not.toThrow();
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/lib/merge-postings.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/merge-postings.ts
@@ -1,15 +1,117 @@
 import type { Posting } from '../types';
+import { canonicalJobKey } from './canonical-job-key';
+
+/** UTF-8 byte length, matching Rust's `str::len()` (bytes, not UTF-16 code
+ * units) — required so the description tie-break can never flip vs the Rust
+ * side's pick for a multi-byte string. */
+function byteLength(s: string): number {
+  return new TextEncoder().encode(s).length;
+}
+
+/**
+ * Union two postings' `interactions`, deduping exact-duplicate entries.
+ * `JobInteraction` is a flat record (no nested objects/arrays), so a
+ * `JSON.stringify` identity is a trivial, correct dedupe key here.
+ */
+function mergeInteractions(
+  incumbent: Posting['interactions'],
+  challenger: Posting['interactions']
+): Posting['interactions'] | undefined {
+  const all = [...(incumbent ?? []), ...(challenger ?? [])];
+  if (all.length === 0) return incumbent; // preserve undefined vs [] as-is
+  const seen = new Set<string>();
+  const deduped = all.filter((i) => {
+    const key = JSON.stringify(i);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  return deduped;
+}
+
+/**
+ * Collapse a later duplicate (`challenger`) into the first-seen `incumbent` for
+ * the same canonical key. Mirrors the corrected trust-PR-E survivor policy
+ * (`autopilot::merge_found_jobs` + the engine's `dedup_cross_source`):
+ *
+ * - **Incumbent identity is never swapped.** `id`/`url`/`source` (and every other
+ *   field the incumbent already holds) are kept — user-state (viewed/saved/applied
+ *   flags and the detail-pane selection) is keyed by `id`, so the survivor must
+ *   keep the id the user may have already acted on.
+ * - **`interactions` are UNIONED, not kept-incumbent-only** — two already-persisted
+ *   legacy duplicates (pre-dating the engine's dedup pass) can each carry distinct
+ *   saved/applied state; keeping only the incumbent's would silently drop the
+ *   challenger's. Exact-duplicate entries collapse via `mergeInteractions`.
+ * - **Longer description wins** (aggregator snippets are truncated), compared by
+ *   UTF-8 byte length so the pick can never flip vs Rust's byte-`len()` pick for a
+ *   multi-byte description; ties keep the incumbent.
+ * - **Enrichment the incumbent LACKS is filled from the challenger**, never the
+ *   reverse — a non-empty incumbent value always wins. This is the renderer analog
+ *   of the Rust `extra`-map union: a whole-row replace would silently DROP the
+ *   incumbent's salary (Adzuna's `salaryMin/Max/Currency`, consumed by
+ *   usePostingActions / TailorFlow / ApplicationDetailPage) when a direct-board
+ *   duplicate with no salary beat it on description length. `trust` (the ghost-job
+ *   signal) is filled the same way so a collapse never regresses a row from "has a
+ *   trust read" to "none".
+ */
+function collapseDuplicate(incumbent: Posting, challenger: Posting): Posting {
+  return {
+    ...incumbent,
+    description:
+      byteLength(challenger.description) > byteLength(incumbent.description)
+        ? challenger.description
+        : incumbent.description,
+    interactions: mergeInteractions(incumbent.interactions, challenger.interactions),
+    // Fill only where the incumbent has nothing; `??` keeps a present incumbent value.
+    remote: incumbent.remote ?? challenger.remote,
+    salaryMin: incumbent.salaryMin ?? challenger.salaryMin,
+    salaryMax: incumbent.salaryMax ?? challenger.salaryMax,
+    salaryCurrency: incumbent.salaryCurrency ?? challenger.salaryCurrency,
+    trust: incumbent.trust ?? challenger.trust,
+  };
+}
 
 /**
  * Merge live (streamed) and persisted postings into a single deduplicated list.
  *
- * Backend `postings` win on duplicate ids — they carry interactions and the
- * persisted full description. Streamed `livePostings` are only added when
- * they have no backend counterpart yet (mid-scrape, not yet persisted).
+ * Two passes:
+ *
+ * 1. **By id** — backend `postings` win on duplicate ids: they carry interactions
+ *    and the persisted full description. Streamed `livePostings` are added only
+ *    when they have no backend counterpart yet (mid-scrape, not yet persisted).
+ *
+ * 2. **By canonical key** — the same job surfaced by two sources gets DIFFERENT
+ *    board-prefixed ids, so pass 1 alone can't collapse it. The engine already
+ *    dedupes the persisted vec, but the manual-scrape live stream is NOT deduped
+ *    (it streams raw per-board items), so two boards emitting the same job leave
+ *    two live rows until this pass reconciles them — closing the live-stream
+ *    window and any cross-append duplicate. Keyed by `canonicalJobKey`, the exact
+ *    TS mirror of the Rust `canonical_job_key` that the engine + autopilot use, so
+ *    the displayed row count matches the deduped completion count. Because pass 1
+ *    puts backend `postings` before `livePostings`, a persisted row (which carries
+ *    the user's interactions) is the incumbent over a streamed duplicate. See
+ *    {@link collapseDuplicate} for the survivor policy.
  */
 export function mergePostings(postings: Posting[], livePostings: Posting[]): Posting[] {
+  // Pass 1 — merge by id (backend wins).
   const byId = new Map<string, Posting>();
   for (const p of postings) byId.set(p.id, p);
   for (const p of livePostings) if (!byId.has(p.id)) byId.set(p.id, p);
-  return [...byId.values()];
+
+  // Pass 2 — collapse cross-source duplicates by canonical key. `survivors`
+  // preserves first-seen order; `indexByKey` maps a canonical key to its slot.
+  const survivors: Posting[] = [];
+  const indexByKey = new Map<string, number>();
+  for (const p of byId.values()) {
+    const key = canonicalJobKey(p.url, p.title, p.company);
+    const idx = indexByKey.get(key);
+    if (idx === undefined) {
+      indexByKey.set(key, survivors.length);
+      survivors.push(p);
+      continue;
+    }
+    const incumbent = survivors[idx];
+    if (incumbent) survivors[idx] = collapseDuplicate(incumbent, p);
+  }
+  return survivors;
 }

--- a/apps/desktop/src/renderer/features/jobs/lib/merge-postings.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/merge-postings.ts
@@ -52,7 +52,8 @@ function mergeInteractions(
  *   usePostingActions / TailorFlow / ApplicationDetailPage) when a direct-board
  *   duplicate with no salary beat it on description length. `trust` (the ghost-job
  *   signal) is filled the same way so a collapse never regresses a row from "has a
- *   trust read" to "none".
+ *   trust read" to "none". This fill-list must track every key any board writes
+ *   into `JobPosting.extra` — lockstep with Rust `merge_extra`.
  */
 function collapseDuplicate(incumbent: Posting, challenger: Posting): Posting {
   return {
@@ -91,8 +92,26 @@ function collapseDuplicate(incumbent: Posting, challenger: Posting): Posting {
  *    puts backend `postings` before `livePostings`, a persisted row (which carries
  *    the user's interactions) is the incumbent over a streamed duplicate. See
  *    {@link collapseDuplicate} for the survivor policy.
+ *
+ * @param absorbed Optional out-param: when a challenger id collapses into a
+ *   survivor, `absorbed.set(challengerId, survivorId)` is recorded. Traceability
+ *   for callers that hold external state keyed by posting id (concretely:
+ *   `JobsResults`' `selectedId`) — a `board`-id row can be selected while it's
+ *   the only live copy, then later absorbed into an `aggregator`-id incumbent
+ *   once the persisted list refetches (boards stream at different speeds; the
+ *   engine's incumbent-selection order need not match display arrival order).
+ *   Without this, the id the caller has selected silently vanishes from the
+ *   merged list and any "selection missing → fall back to top" reconciliation
+ *   swaps the open detail pane to an unrelated job. An out-param (not a return-
+ *   shape change) was chosen to keep every existing `mergePostings(...)` call
+ *   site — which uses the return value as a plain `Posting[]` — unchanged; only
+ *   `JobsPage` (which owns `selectedId`) needs to pass one.
  */
-export function mergePostings(postings: Posting[], livePostings: Posting[]): Posting[] {
+export function mergePostings(
+  postings: Posting[],
+  livePostings: Posting[],
+  absorbed?: Map<string, string>
+): Posting[] {
   // Pass 1 — merge by id (backend wins).
   const byId = new Map<string, Posting>();
   for (const p of postings) byId.set(p.id, p);
@@ -111,7 +130,10 @@ export function mergePostings(postings: Posting[], livePostings: Posting[]): Pos
       continue;
     }
     const incumbent = survivors[idx];
-    if (incumbent) survivors[idx] = collapseDuplicate(incumbent, p);
+    if (incumbent) {
+      survivors[idx] = collapseDuplicate(incumbent, p);
+      if (p.id !== incumbent.id) absorbed?.set(p.id, incumbent.id);
+    }
   }
   return survivors;
 }

--- a/docs/knowledge/scraping-domain.md
+++ b/docs/knowledge/scraping-domain.md
@@ -183,6 +183,46 @@ Results now persist across navigation thanks to React Query + backend cache:
 - **Frontend:** Throttled `invalidatePostings()` on `job.stream` event (~1 ms throttle; eager on first item of new search)
 - **Hydration:** React Query re-fetches cache on component remount → results reappear
 
+## Cross-source dedup (PR E, 2026-07-10)
+
+When a job posting appears across multiple boards (e.g., a job scraped both from the Aggregator and a direct ATS board), the engine performs a single cross-source dedup pass to eliminate duplicates before the UI renders them.
+
+**Canonical job key:**
+
+Every job is keyed by its `canonical_job_key(url, title, company)` — defined in `apps/desktop/src-tauri/src/scraping/boards/common.rs`, mirrored in `apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.ts` for renderer-side dedup. The key normalizes URLs (lowercase whole URL, strip `www.`, drop fragments, keep only board-identifying query params like `indeed.com`'s `jk`) or falls back to `{title.trim().lowercase()}\u{0001}{company.trim().lowercase()}` (U+0001 separator prevents title/company forgery). The Rust function `normalize_job_url` is the shared app-wide URL identity (also used by autopilot's merge and extension import); the TS mirror must maintain byte-equivalence to the Rust implementation to ensure the same duplicate pairs are identified both sides.
+
+**Engine dedup pass:**
+
+`scraping/engine/mod.rs`: `dedup_cross_source()` runs once per manual scrape after all boards are concatenated, before results are returned to the UI. Duplicates sharing a canonical key are collapsed down to one survivor; the survivor is the incumbent (first-seen job for that key), but its fields are field-level-upgraded (not wholesale replaced):
+
+- `id`, `url`, `source`, `interactions` — never overwritten (incumbent identity kept; user-state is tied to `id`)
+- `description` — upgraded when the challenger's is strictly longer (measured in UTF-8 bytes)
+- `extra` (salary/remote/etc.) — unioned key-by-key, non-empty incumbent values win, keys the incumbent lacks are filled from the challenger
+
+This policy prevents silent data loss (e.g., Adzuna's salary fields wouldn't be dropped if a direct board with no salary won purely on description length).
+
+**Autopilot merge:**
+
+`autopilot/mod.rs`: `merge_found_jobs()` dedupes the incoming batch intra-batch using the same canonical key before merging against existing persisted rows. The engine's cross-source pass runs upstream (the Autopilot path consumes the already-deduped vec directly), so this is defensive; intra-batch dedup follows the same field-level-upgrade pattern. Notification count reflects post-dedup genuinely-new jobs only.
+
+**Renderer dedup pass:**
+
+`features/jobs/lib/merge-postings.ts`: `mergePostings(display, livePostings, absorbed?)` now runs a second pass (after pass 1's same-id merge) keyed by `canonicalJobKey`. The survivor is the incumbent (first-seen row, persisted rows over streamed duplicates), field-level-upgraded (description byte-length, extra union), and has its user-state preserved. An optional `absorbed` out-param records which row ids were collapsed so the selection-reconciliation effect can re-point a stale `selectedId` to the survivor instead of falling back to `display[0]`.
+
+This renderer pass reconciles manual-scrape live streams (which are not engine-deduped) with the completion count — visible rows now match the deduped unique total.
+
+**Shared fixtures:**
+
+The 5 Rust truth-table test cases (same URL across boards, url-less title+company, near-miss distinct, U+0001-unforgeable, empty/whitespace/dangerous-scheme fallback) are copied verbatim into the TS test as a drift guard — if either side's algorithm diverges, one of these tests fails.
+
+**Source pointers:**
+
+- Canonical key (Rust): `apps/desktop/src-tauri/src/scraping/boards/common.rs:canonical_job_key`
+- Engine dedup: `apps/desktop/src-tauri/src/scraping/engine/mod.rs:dedup_cross_source`
+- Autopilot merge: `apps/desktop/src-tauri/src/autopilot/mod.rs:merge_found_jobs` (delegates `merge_key` to the shared canonical key)
+- Canonical key (TS mirror): `apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.ts`
+- Renderer dedup: `apps/desktop/src/renderer/features/jobs/lib/merge-postings.ts:mergePostings`
+
 ## Jobs-page diagnostics surface (PR C, 2026-07-10)
 
 Per-board scrape outcomes are now visible via a shared `BoardSummaryChips` component, surfacing the sanitized failure reasons, skip reasons, partial-harvest signals, and success counts:


### PR DESCRIPTION
## Summary

PR E of the job-search trust program (audit 2026-07-10): the same job used to appear 2-3× (engine concatenated, renderer merged by board-prefixed id, autopilot by raw URL) and re-fired "N new jobs" notifications — duplicates read as "the agent is confused". Builds on #597-#600.

## What changed

- **One canonical job key:** `canonical_job_key(url, title, company)` in `scraping/boards/common.rs` — the app-wide `normalize_job_url` identity (already used by autopilot and extension import) when a usable URL exists, else normalized `title`+U+0001+`company`. TS lockstep mirror `features/jobs/lib/canonical-job-key.ts` (byte-equivalent raw-string port — WHATWG URL parsing deliberately avoided; 5 Rust fixture cases copied verbatim as the drift guard).
- **Engine pass:** `dedup_cross_source` collapses cross-board duplicates with a field-level merge — incumbent identity (id/url/board) never swapped, longer description (byte length) adopted, `extra` (salary etc.) unioned so an aggregator row's salary survives a direct board's fuller text winning.
- **Autopilot:** `merge_key` now delegates to the shared fn (byte-identity verified — persisted found-jobs unaffected); intra-batch dedupe + honest post-dedup new-count were already in place and are now aligned with the engine policy.
- **Renderer:** `mergePostings` pass 2 collapses same-key rows in the display (closes the live-stream vs completion-count divergence), unions interactions, fills salary/trust/remote, and reports absorbed ids so the selection reconciler re-points the open detail pane at the surviving row instead of jumping to the top.

## Review trail (internal fleet)

- scraping-applier-expert: REQUEST-CHANGES → full-struct survivor swap (silent salary loss) fixed to field-level merge → resolved
- rust-backend-architect scope: stage 2 was pre-hardened; DRY delegation only (audit premise stale)
- frontend-reviewer: APPROVE-WITH-FIXES → interactions union, byte-length tie-break, trust fill applied
- tauri-security-reviewer: PASS-WITH-ADVISORIES (no Apply-URL hijack possible — incumbent identity immutable; U+0001 forgery structurally impossible)
- pr-reviewer ×2: opus PASS (Rust↔TS parity traced line-by-line); sonnet 1🟠 → selection-follows-survivor implemented + regression tests

## Test plan

- CI runs the Rust suite (host fault blocks local cargo test; fmt/check/clippy clean). Desktop vitest 2169 green locally; typecheck + gen:ipc:check clean.
- Manual: scrape with aggregator + a direct board overlapping → one row per job, salary retained, completion count == visible rows; open a job mid-stream that later collapses → detail pane stays on that job.

Part 5/8 of the trust program — next: PR F (canonical location model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)