### PR TITLE
feat: canonical location model with honest per-board location handling

### DIFF
--- a/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
@@ -40,6 +40,14 @@ pub async fn autopilot_scrape(
         actively_hiring: None,
         verified: None,
         sort_by: None,
+        // Location forwarding (trust PR F): the persisted `AutopilotTarget` carries
+        // only `location` (free text) + `country_code` — verified: it has no
+        // lat/lon/radius fields to forward (the wizard never captures them). Both
+        // are forwarded here, so `input.location_spec()` yields a spec with a city
+        // + country, which drives the engine's central location post-filter for
+        // non-supporting boards AND the aggregator's market routing on autopilot
+        // runs. Wiring lat/lon/radius needs the wizard + `AutopilotTargetSchema` to
+        // capture + persist them first (stage-2 / follow-up).
         country_code: target.country_code.clone(),
         latitude: None,
         longitude: None,

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -502,6 +502,12 @@ impl Scraper for AggregatorScraper {
         aggregator_store_error().is_none() && !aggregator_has_configured_provider()
     }
 
+    fn supports_location(&self) -> bool {
+        // Adzuna/JSearch consume the location server-side: `country_code` routes the
+        // market directly and the free-text `location` is the `where`/query param.
+        true
+    }
+
     async fn search(
         &self,
         input: BoardSearchInput,

--- a/apps/desktop/src-tauri/src/scraping/boards/arbeitsagentur/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/arbeitsagentur/mod.rs
@@ -97,6 +97,11 @@ impl Scraper for ArbeitsagenturScraper {
         ScraperMode::Http
     }
 
+    fn supports_location(&self) -> bool {
+        // The free-text location is sent server-side as the `wo` (where) param.
+        true
+    }
+
     async fn search(
         &self,
         input: BoardSearchInput,

--- a/apps/desktop/src-tauri/src/scraping/boards/linkedin/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/linkedin/mod.rs
@@ -53,6 +53,12 @@ impl Scraper for LinkedInScraper {
         crate::scraping::types::AuthRequirement::Optional
     }
 
+    fn supports_location(&self) -> bool {
+        // LinkedIn narrows server-side: it resolves the free-text location to a
+        // geoId typeahead and passes `distance` (radius) to the jobs search.
+        true
+    }
+
     async fn search(&self, input: BoardSearchInput, ctx: ScrapeContext) -> Result<Vec<JobPosting>> {
         // Try to load session data from disk
         let session_data = self.load_session_data().await;

--- a/apps/desktop/src-tauri/src/scraping/engine/location_filter.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/location_filter.rs
@@ -1,0 +1,425 @@
+//! Central, conservative location post-filter (trust PR F).
+//!
+//! Boards that do NOT consume the requested location server-side
+//! ([`Scraper::supports_location`](crate::scraping::types::Scraper::supports_location)
+//! `== false`) can return postings from anywhere. When the user requested a
+//! location, the engine drops the postings whose OWN location CLEARLY mismatches
+//! — but conservatively: it never drops a posting with an empty/unknown location
+//! or a remote marker, because keeping a wrong-city row is the old lie and
+//! dropping a remote job would be a new one. The requested location is matched by
+//! significant place-name tokens (case-insensitive substring); a bare country
+//! code with no place text leaves the filter inert.
+
+use crate::scraping::types::{JobPosting, LocationSpec};
+
+/// Location-text substrings that mark a posting as location-agnostic (remote).
+/// Matched case-insensitively against the posting's location; a hit means
+/// "never drop". Covers what the remote boards actually emit
+/// (Remotive/RemoteOK/WWR set `extra.remote=true` AND strings like
+/// "Worldwide"/"Anywhere"; German feeds emit "Homeoffice").
+const REMOTE_MARKERS: &[&str] = &[
+    "remote",
+    "anywhere",
+    "worldwide",
+    "world wide",
+    "home office",
+    "home-office",
+    "homeoffice",
+    "work from home",
+    "work-from-home",
+    "wfh",
+    "distributed",
+];
+
+/// Minimum length of a requested place-name token used for matching. Two-letter
+/// tokens (a bare country code, "UK") are too noisy to match on, so the filter
+/// stays inert unless a real place name is present.
+const MIN_TOKEN_LEN: usize = 3;
+
+/// A tiny, curated table of English⇄German exonym pairs for the handful of
+/// major DACH cities this project's German-market boards
+/// (arbeitsagentur/germantechjobs/berlinstartupjobs) actually surface.
+///
+/// **This is deliberately NOT a general place-name/geocoding database.**
+/// [`fold_variants`] fixes SAME-NAME diacritic spelling variants (native
+/// "Köln" vs transliterated "Koeln" vs bare "Koln" — one word, three
+/// spellings). It can NEVER bridge an exonym pair like Munich/München:
+/// those are two different WORDS for the same city, not a spelling variant
+/// of one — folding "münchen" and "munich" never produces the same string.
+/// The entries below are a bounded, explicit lookup for that separate
+/// problem. Any exonym pair NOT in this table is a known, documented gap:
+/// an unmatched city name still falls through to the filter's existing
+/// (conservative) drop path.
+const EXONYM_PAIRS: &[(&str, &str)] = &[
+    ("munich", "münchen"),
+    ("cologne", "köln"),
+    ("nuremberg", "nürnberg"),
+];
+
+/// Base-letter and DIN-5007-2-transliteration folds of `s`, lowercased.
+/// Real postings and typed requests spell German diaeresis characters
+/// interchangeably — native ("München"), transliterated ("Muenchen"), or
+/// bare ("Munchen") — so both folds are returned; matching against either
+/// bridges all three spellings of the SAME name. Pure.
+fn fold_variants(s: &str) -> (String, String) {
+    let lower = s.to_lowercase();
+    let mut base = String::with_capacity(lower.len());
+    let mut translit = String::with_capacity(lower.len() + 4);
+    for c in lower.chars() {
+        match c {
+            'ä' => {
+                base.push('a');
+                translit.push_str("ae");
+            }
+            'ö' => {
+                base.push('o');
+                translit.push_str("oe");
+            }
+            'ü' => {
+                base.push('u');
+                translit.push_str("ue");
+            }
+            'ß' => {
+                base.push_str("ss");
+                translit.push_str("ss");
+            }
+            other => {
+                base.push(other);
+                translit.push(other);
+            }
+        }
+    }
+    (base, translit)
+}
+
+/// True when `a` and `b` denote the same word once diaeresis spelling is
+/// normalised (either fold convention, either side) — e.g. "Köln" == "Koeln"
+/// == "Koln". Word-level equality (not substring) so this is precise enough
+/// to drive the exonym-table lookup. Pure.
+fn folds_equal(a: &str, b: &str) -> bool {
+    let (a_base, a_ue) = fold_variants(a);
+    let (b_base, b_ue) = fold_variants(b);
+    a_base == b_base || a_base == b_ue || a_ue == b_base || a_ue == b_ue
+}
+
+/// True when `needle`'s folded form (either convention) appears as a
+/// substring of `haystack`'s folded form (either convention) — the
+/// diaeresis-spelling-aware version of `haystack.contains(needle)`. Pure.
+fn contains_folded(haystack: &str, needle: &str) -> bool {
+    let (h_base, h_ue) = fold_variants(haystack);
+    let (n_base, n_ue) = fold_variants(needle);
+    h_base.contains(&n_base)
+        || h_base.contains(&n_ue)
+        || h_ue.contains(&n_base)
+        || h_ue.contains(&n_ue)
+}
+
+/// Expand `needles` in place with the curated [`EXONYM_PAIRS`] table: when a
+/// requested token names one side of a known pair, add the OTHER side too —
+/// e.g. a "Munich" request also accepts a "München" posting. See
+/// [`EXONYM_PAIRS`] for the documented scope limitation. Pure.
+fn expand_exonyms(needles: &mut Vec<String>) {
+    let originals = needles.clone();
+    for tok in &originals {
+        for (en, de) in EXONYM_PAIRS {
+            if folds_equal(tok, en) && !needles.iter().any(|n| folds_equal(n, de)) {
+                needles.push((*de).to_string());
+            } else if folds_equal(tok, de) && !needles.iter().any(|n| folds_equal(n, en)) {
+                needles.push((*en).to_string());
+            }
+        }
+    }
+}
+
+/// Significant lowercase place-name tokens from the requested location (its city
+/// and region text), expanded with any known exonym counterpart (see
+/// [`expand_exonyms`]). Empty when nothing usable was requested (e.g. only a
+/// country code), which makes the filter inert.
+fn requested_needles(requested: &LocationSpec) -> Vec<String> {
+    let mut needles: Vec<String> = Vec::new();
+    for field in [requested.city.as_deref(), requested.region.as_deref()] {
+        let Some(text) = field else { continue };
+        for tok in text.split(|c: char| !c.is_alphanumeric()) {
+            let tok = tok.trim().to_lowercase();
+            if tok.chars().count() >= MIN_TOKEN_LEN && !needles.contains(&tok) {
+                needles.push(tok);
+            }
+        }
+    }
+    expand_exonyms(&mut needles);
+    needles
+}
+
+/// True when `posting` should be DROPPED for a search that requested `requested`
+/// from a board that does not filter location server-side. Conservative:
+/// - remote (via the `extra.remote` flag OR a remote marker in the location text) → keep
+/// - empty / unknown location → keep
+/// - no usable requested place tokens (e.g. country-code-only) → keep
+/// - a diaeresis-spelling variant of the same name, or a curated exonym (see
+///   [`EXONYM_PAIRS`]) → keep (never a false drop on München/Munich, Köln/Cologne)
+/// - otherwise drop only when NO requested token (fold-aware) appears in the
+///   posting location.
+///
+/// Pure — the truth table is unit-tested below.
+pub(crate) fn location_mismatch(posting: &JobPosting, requested: &LocationSpec) -> bool {
+    // Never drop a posting a board flagged remote.
+    if posting
+        .extra
+        .get("remote")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    // Empty / unknown location → keep.
+    let loc = match posting.location.as_deref().map(str::trim) {
+        Some(l) if !l.is_empty() => l.to_lowercase(),
+        _ => return false,
+    };
+    // Remote marker in the location text → keep.
+    if REMOTE_MARKERS.iter().any(|m| loc.contains(m)) {
+        return false;
+    }
+    let needles = requested_needles(requested);
+    if needles.is_empty() {
+        return false; // nothing concrete to match → keep
+    }
+    // Keep when any requested token (diaeresis/exonym-aware) appears in the
+    // posting location; drop otherwise.
+    !needles.iter().any(|n| contains_folded(&loc, n))
+}
+
+/// Drop postings whose location clearly mismatches `requested`, returning the
+/// kept postings (in input order) and the number dropped. Pure — see
+/// [`location_mismatch`].
+pub(crate) fn filter_postings(
+    postings: Vec<JobPosting>,
+    requested: &LocationSpec,
+) -> (Vec<JobPosting>, usize) {
+    let before = postings.len();
+    let kept: Vec<JobPosting> = postings
+        .into_iter()
+        .filter(|p| !location_mismatch(p, requested))
+        .collect();
+    let dropped = before - kept.len();
+    (kept, dropped)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn posting(location: Option<&str>, remote: bool) -> JobPosting {
+        let mut extra = HashMap::new();
+        if remote {
+            extra.insert("remote".to_string(), serde_json::json!(true));
+        }
+        JobPosting {
+            id: "b:1".into(),
+            external_id: None,
+            title: "Engineer".into(),
+            company: "Acme".into(),
+            location: location.map(str::to_string),
+            url: "https://acme.example/1".into(),
+            source: "b".into(),
+            description: None,
+            requirements: None,
+            posted_at: None,
+            captured_at: 0,
+            extra,
+        }
+    }
+
+    fn requested(city: &str) -> LocationSpec {
+        LocationSpec {
+            city: Some(city.into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn keeps_matching_city() {
+        let req = requested("Berlin");
+        assert!(!location_mismatch(
+            &posting(Some("Berlin, Germany"), false),
+            &req
+        ));
+        assert!(!location_mismatch(
+            &posting(Some("Greater Berlin Area"), false),
+            &req
+        ));
+    }
+
+    #[test]
+    fn drops_clear_city_mismatch() {
+        let req = requested("Berlin");
+        assert!(location_mismatch(&posting(Some("London, UK"), false), &req));
+        assert!(location_mismatch(&posting(Some("Munich"), false), &req));
+    }
+
+    #[test]
+    fn keeps_empty_or_unknown_location() {
+        let req = requested("Berlin");
+        assert!(!location_mismatch(&posting(None, false), &req));
+        assert!(!location_mismatch(&posting(Some("   "), false), &req));
+    }
+
+    #[test]
+    fn keeps_remote_by_flag_or_text() {
+        let req = requested("Berlin");
+        // Remote flag (Remotive/RemoteOK/WWR) even with a concrete, non-matching
+        // location string — never drop a remote job.
+        assert!(!location_mismatch(&posting(Some("USA Only"), true), &req));
+        // Remote marker in the text, no flag.
+        assert!(!location_mismatch(
+            &posting(Some("Remote (US)"), false),
+            &req
+        ));
+        assert!(!location_mismatch(&posting(Some("Anywhere"), false), &req));
+        assert!(!location_mismatch(
+            &posting(Some("Homeoffice, Köln"), false),
+            &req
+        ));
+    }
+
+    #[test]
+    fn inert_when_no_usable_place_token() {
+        // Country-code-only request (no city text) → no needles → keep everything.
+        let cc_only = LocationSpec {
+            country_code: Some("de".into()),
+            ..Default::default()
+        };
+        assert!(!location_mismatch(
+            &posting(Some("London, UK"), false),
+            &cc_only
+        ));
+        // Too-short city token (< 3 chars) → inert.
+        let short = requested("NY");
+        assert!(!location_mismatch(&posting(Some("London"), false), &short));
+    }
+
+    #[test]
+    fn case_insensitive_match() {
+        let req = requested("BERLIN");
+        assert!(!location_mismatch(&posting(Some("berlin"), false), &req));
+    }
+
+    #[test]
+    fn conservative_keeps_partial_token_overlap() {
+        // Shared token ("san") → kept, erring toward keeping (conservative).
+        let req = requested("San Francisco");
+        assert!(!location_mismatch(
+            &posting(Some("San Diego, CA"), false),
+            &req
+        ));
+    }
+
+    #[test]
+    fn filter_postings_counts_drops_and_keeps_order() {
+        let req = requested("Berlin");
+        let postings = vec![
+            posting(Some("Berlin"), false), // keep
+            posting(Some("London"), false), // drop
+            posting(None, false),           // keep (unknown)
+            posting(Some("Remote"), false), // keep (remote text)
+            posting(Some("Paris"), false),  // drop
+        ];
+        let (kept, dropped) = filter_postings(postings, &req);
+        assert_eq!(dropped, 2);
+        assert_eq!(kept.len(), 3);
+        assert_eq!(kept[0].location.as_deref(), Some("Berlin"));
+        assert_eq!(kept[1].location, None);
+        assert_eq!(kept[2].location.as_deref(), Some("Remote"));
+    }
+
+    #[test]
+    fn no_drops_returns_zero() {
+        let req = requested("Berlin");
+        let postings = vec![posting(Some("Berlin"), false), posting(None, false)];
+        let (kept, dropped) = filter_postings(postings, &req);
+        assert_eq!(dropped, 0);
+        assert_eq!(kept.len(), 2);
+    }
+
+    // ── HIGH-2: diaeresis spelling variants (folding) ──────────────────────────
+
+    #[test]
+    fn diaeresis_spelling_variants_of_the_same_name_are_never_dropped() {
+        // Same word, three spellings — native, DIN-5007-2 transliteration, and
+        // bare (diaeresis stripped). Any request spelling must match any posting
+        // spelling.
+        for (req_city, posting_loc) in [
+            ("Köln", "Koeln, Deutschland"),
+            ("Koeln", "Köln, Deutschland"),
+            ("Koln", "Köln, Deutschland"),
+            ("München", "Muenchen"),
+            ("Muenchen", "München"),
+        ] {
+            let req = requested(req_city);
+            assert!(
+                !location_mismatch(&posting(Some(posting_loc), false), &req),
+                "{req_city:?} must match posting {posting_loc:?} (diaeresis spelling variant)"
+            );
+        }
+    }
+
+    // ── HIGH-2: curated exonym pairs ────────────────────────────────────────────
+
+    #[test]
+    fn curated_exonym_pairs_are_never_dropped() {
+        // The exact false-drop the critic reported: München/Munich, Köln/Cologne,
+        // Nürnberg/Nuremberg — bridged only via the curated EXONYM_PAIRS table,
+        // NOT by folding (folding cannot turn "munich" into "munchen").
+        for (req_city, posting_loc) in [
+            ("Munich", "München, Bayern"),
+            ("München", "Munich, Germany"),
+            ("Cologne", "Köln"),
+            ("Köln", "Cologne, Germany"),
+            ("Nuremberg", "Nürnberg"),
+        ] {
+            let req = requested(req_city);
+            assert!(
+                !location_mismatch(&posting(Some(posting_loc), false), &req),
+                "curated exonym: {req_city:?} must not drop posting {posting_loc:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn exonym_table_is_folding_aware_on_the_german_side() {
+        // A "Munich" request must also accept a transliterated/bare posting
+        // spelling of München (Muenchen/Munchen), not just the native form —
+        // the exonym expansion and the diaeresis fold compose.
+        let req = requested("Munich");
+        assert!(!location_mismatch(&posting(Some("Muenchen"), false), &req));
+    }
+
+    #[test]
+    fn exonym_gap_outside_the_curated_table_is_documented_and_still_drops() {
+        // HONESTY CHECK (HIGH-2): the curated table is intentionally bounded to
+        // three DACH pairs. An exonym pair NOT in the table (English "The Hague"
+        // vs Dutch "Den Haag") is NOT bridged — this pins the documented
+        // limitation rather than silently pretending it's fixed. A real, more
+        // complete exonym/geocoding table would need to grow this table, not
+        // change the matching mechanics.
+        let req = requested("Hague");
+        assert!(
+            location_mismatch(&posting(Some("Den Haag, Netherlands"), false), &req),
+            "an exonym pair outside EXONYM_PAIRS is a known, documented gap — must still drop"
+        );
+    }
+
+    #[test]
+    fn folding_alone_does_not_bridge_an_exonym_without_the_table() {
+        // Direct proof that folding is NOT what makes München/Munich match —
+        // the fold of "munich" and the fold of "münchen" are simply different
+        // strings, confirming the exonym table (not folding) does the bridging.
+        let (m_base, m_ue) = fold_variants("münchen");
+        let (n_base, n_ue) = fold_variants("munich");
+        assert_ne!(m_base, n_base);
+        assert_ne!(m_base, n_ue);
+        assert_ne!(m_ue, n_base);
+        assert_ne!(m_ue, n_ue);
+    }
+}

--- a/apps/desktop/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/mod.rs
@@ -14,6 +14,27 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, Semaphore};
 use tokio_util::sync::CancellationToken;
 
+mod location_filter;
+
+/// Per-item keep predicate for a single board (already bound to that board's
+/// name where relevant) — `true` = keep. Trust PR F's central location filter;
+/// `None` when no location filter applies to this run.
+///
+/// **Cap/filter ordering invariant (canonical explanation — HIGH-1):** `run_one`
+/// checks this predicate BEFORE its item cap counts/cancels, so a filtered item
+/// never increments the cap and never triggers cap-cancel — a board keeps
+/// paginating until `amount` MATCHING items are found, not `amount` raw ones.
+/// When active, `run_one` also returns the tracked kept set (not a raw-Vec
+/// truncate) as the final result, since raw order can otherwise keep an early
+/// mismatch while dropping a later real match. See `run_one`/`run_boards` for
+/// the wiring; every other mention below just points back here.
+type KeepItemFn = dyn Fn(&JobPosting) -> bool + Send;
+
+/// Board-name-aware keep predicate shared across every board in a
+/// `run_boards` fan-out; `run_boards` binds it to each board's name into a
+/// [`KeepItemFn`] before passing it to `run_one`.
+type KeepItemByBoardFn = dyn Fn(&str, &JobPosting) -> bool + Send + Sync;
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ScraperCatalogEntry {
     pub id: String,
@@ -29,6 +50,12 @@ pub struct ScraperCatalogEntry {
     /// when `input.companies` is empty, reporting `skipped: "needs-company"`.
     #[serde(rename = "requiresCompany")]
     pub requires_company: bool,
+    /// Whether the board narrows results by the requested location server-side.
+    /// When `false`, the engine conservatively post-filters this board's results
+    /// against the requested location (drops only clear city mismatches; never
+    /// remote/unknown-location rows). Drives the picker's per-board indicator.
+    #[serde(rename = "supportsLocation")]
+    pub supports_location: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -118,6 +145,7 @@ impl ScraperEngine {
                 auth: s.auth(),
                 listed: s.listed(),
                 requires_company: s.requires_company(),
+                supports_location: s.supports_location(),
             })
             .collect()
     }
@@ -136,6 +164,13 @@ impl ScraperEngine {
     ///
     /// `scraper` is the resolved board (or an error for an unknown board);
     /// tests inject a fake scraper through this seam.
+    ///
+    /// One parameter per independent callback/seam (progress, item, truncation,
+    /// note, keep-filter) — each is optional and semantically distinct, so
+    /// bundling them into a struct would obscure the call sites more than it
+    /// clarifies; matches the `#[allow(...)]` precedent used elsewhere in this
+    /// codebase for similar low-level fan-out functions.
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_one(
         board: &str,
         scraper: anyhow::Result<&dyn Scraper>,
@@ -145,6 +180,8 @@ impl ScraperEngine {
         on_item: Option<Box<dyn Fn(JobPosting) + Send>>,
         on_truncation: Option<Box<dyn Fn(String) + Send>>,
         on_note: Option<std::sync::Arc<dyn Fn(String) + Send + Sync>>,
+        // See `KeepItemFn` for the cap/filter ordering invariant this implements.
+        keep_item: Option<Box<KeepItemFn>>,
     ) -> anyhow::Result<Vec<JobPosting>> {
         // Central item cap. The board loops stream items through `on_item` and
         // check `ctx.signal`; we count the stream here and cancel the token the
@@ -156,6 +193,10 @@ impl ScraperEngine {
         let kept: Arc<std::sync::Mutex<Vec<JobPosting>>> =
             Arc::new(std::sync::Mutex::new(Vec::new()));
 
+        // Only exercised when a live on_item sink is ALSO wired (the gate lives
+        // inside its wrapper below). See `KeepItemFn`.
+        let has_active_filter = keep_item.is_some() && on_item.is_some();
+
         // Wrap the caller's `on_item` so each streamed posting is counted, kept,
         // and forwarded only while under the cap; the cap-reaching item flips
         // `reached` and cancels the token so each board's pagination stops early.
@@ -165,6 +206,12 @@ impl ScraperEngine {
             let kept = kept.clone();
             let token_for_wrapper = token.clone();
             let boxed: Box<dyn Fn(JobPosting) + Send> = Box::new(move |mut item: JobPosting| {
+                // Gate first — see `KeepItemFn`.
+                if let Some(ref keep) = keep_item {
+                    if !keep(&item) {
+                        return;
+                    }
+                }
                 let n = streamed.fetch_add(1, Ordering::SeqCst);
                 if n < amount {
                     // Trust assessment is attached here — the single funnel every
@@ -202,9 +249,17 @@ impl ScraperEngine {
 
         match result {
             Ok(mut items) => {
-                items.truncate(amount);
-                span.end_with(&format!("count={}", items.len()), true);
-                Ok(items)
+                let out = if has_active_filter {
+                    // `kept`, not a raw truncate — see `KeepItemFn`.
+                    kept.lock()
+                        .map(|mut g| std::mem::take(&mut *g))
+                        .unwrap_or_default()
+                } else {
+                    items.truncate(amount);
+                    items
+                };
+                span.end_with(&format!("count={}", out.len()), true);
+                Ok(out)
             }
             Err(e) => {
                 // Our own target-reached cancellation: the kept items were already
@@ -231,6 +286,9 @@ impl ScraperEngine {
     /// browser boards are serialized via the process-wide `browser_sem`) and
     /// collect per-board results in **input order**. Tests inject fake scrapers
     /// through this seam.
+    ///
+    /// See `run_one`'s doc note on the per-callback parameter shape.
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_boards<'s>(
         resolved: Vec<(String, anyhow::Result<&'s dyn Scraper>)>,
         input: BoardSearchInput,
@@ -239,6 +297,8 @@ impl ScraperEngine {
         on_item: Option<Arc<dyn Fn(JobPosting) + Send + Sync>>,
         on_truncation: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
         on_note: Option<Arc<dyn Fn(String, String) + Send + Sync>>,
+        // `None` when no location filter applies to this run. See `KeepItemFn`.
+        keep_item: Option<Arc<KeepItemByBoardFn>>,
         browser_sem: Arc<Semaphore>,
     ) -> Vec<(String, anyhow::Result<Vec<JobPosting>>)> {
         let total = resolved.len();
@@ -257,6 +317,7 @@ impl ScraperEngine {
                 let on_item = on_item.clone();
                 let on_truncation = on_truncation.clone();
                 let on_note = on_note.clone();
+                let keep_item = keep_item.clone();
                 let done = done.clone();
                 let browser_sem = browser_sem.clone();
 
@@ -313,6 +374,16 @@ impl ScraperEngine {
                                 wrapped
                             });
 
+                        // Bind to this board's name — see `KeepItemFn`.
+                        let per_board_keep_item: Option<Box<KeepItemFn>> =
+                            keep_item.as_ref().map(|arc| {
+                                let arc = arc.clone();
+                                let name = name.clone();
+                                let boxed: Box<KeepItemFn> =
+                                    Box::new(move |item: &JobPosting| arc(&name, item));
+                                boxed
+                            });
+
                         let res = Self::run_one(
                             &name,
                             scraper,
@@ -322,6 +393,7 @@ impl ScraperEngine {
                             per_board_on_item,
                             per_board_on_truncation,
                             per_board_on_note,
+                            per_board_keep_item,
                         )
                         .await;
 
@@ -454,6 +526,28 @@ impl ScraperEngine {
         // as an empty list.  Check once here so the per-board skip stays O(1).
         let has_usable_company = input.companies.iter().any(|c| !c.trim().is_empty());
 
+        // Central location post-filter (trust PR F): when a location was requested,
+        // boards that do NOT consume it server-side (`supports_location() == false`)
+        // get their results conservatively filtered so a wrong-city row can't pass
+        // as a hit. Computed once here; the set is empty (filter inert) when no
+        // location was requested, keeping location-agnostic searches byte-identical.
+        let requested_location = input.location_spec();
+        let non_location_boards: std::collections::HashSet<String> = if requested_location.is_some()
+        {
+            resolved
+                .iter()
+                .filter(|(_, scraper)| {
+                    scraper
+                        .as_ref()
+                        .map(|s| !s.supports_location())
+                        .unwrap_or(false)
+                })
+                .map(|(id, _)| id.clone())
+                .collect()
+        } else {
+            std::collections::HashSet::new()
+        };
+
         for (idx, (id, scraper)) in resolved.into_iter().enumerate() {
             // Determine skip reason (if any) from the resolved scraper.
             // Unknown-board Err values always pass through (no skip) so they
@@ -528,6 +622,30 @@ impl ScraperEngine {
             })
         };
 
+        // Per-board LIVE drop counts (see `KeepItemFn`) — the only place a
+        // live-filtered item's count is observable; merged with the post-hoc
+        // pass below (the no-live-streaming path, e.g. tests) into the note.
+        let location_drops: Arc<std::sync::Mutex<HashMap<String, usize>>> =
+            Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let keep_item: Option<Arc<KeepItemByBoardFn>> = requested_location.clone().map(|req| {
+            let non_loc = non_location_boards.clone();
+            let drops = location_drops.clone();
+            let f: Arc<KeepItemByBoardFn> = Arc::new(move |board: &str, item: &JobPosting| {
+                if !non_loc.contains(board) {
+                    return true; // board supports location — never filtered here
+                }
+                if location_filter::location_mismatch(item, &req) {
+                    if let Ok(mut guard) = drops.lock() {
+                        *guard.entry(board.to_string()).or_insert(0) += 1;
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+            f
+        });
+
         let results = Self::run_boards(
             runnable,
             input,
@@ -536,6 +654,7 @@ impl ScraperEngine {
             on_item,
             Some(truncation_sink),
             Some(note_sink),
+            keep_item,
             self.browser_sem.clone(),
         )
         .await;
@@ -555,6 +674,16 @@ impl ScraperEngine {
             let idx = name_to_idx[&board];
             match res {
                 Ok(postings) => {
+                    // Central location post-filter (trust PR F, see `location_filter`)
+                    // — a SAFETY NET here, not the primary filter: a no-op when the
+                    // live gate already ran (see `KeepItemFn`), the only filtering
+                    // pass otherwise (callers with no live on_item, e.g. tests).
+                    let (postings, post_hoc_dropped) = match &requested_location {
+                        Some(req) if non_location_boards.contains(&board) => {
+                            location_filter::filter_postings(postings, req)
+                        }
+                        _ => (postings, 0),
+                    };
                     if !postings.is_empty() {
                         any_recovered_items = true;
                     }
@@ -562,7 +691,36 @@ impl ScraperEngine {
                     // is surfaced here so it is not indistinguishable from a complete
                     // run; a board that completed its pages has no map entry.
                     let truncated = truncations.lock().ok().and_then(|mut m| m.remove(&board));
-                    let note = notes.lock().ok().and_then(|mut m| m.remove(&board));
+                    let mut note = notes.lock().ok().and_then(|mut m| m.remove(&board));
+                    // Combine the live gate's drop count with this pass's.
+                    let live_dropped = location_drops
+                        .lock()
+                        .ok()
+                        .and_then(|mut m| m.remove(&board))
+                        .unwrap_or(0);
+                    let dropped = live_dropped + post_hoc_dropped;
+                    // UNCONDITIONAL (incl. dropped==0): a location was requested and
+                    // this board doesn't honor it server-side, so its results were
+                    // never authoritative for that location regardless of whether any
+                    // row actually got dropped this run — the picker/chips must say so
+                    // every time, not just when there happened to be a drop. Emitting
+                    // only on dropped>0 let a non-supporting board with 0 drops read as
+                    // indistinguishable from a supporting one ("all ok"), half-telling
+                    // the 17/23-boards-ignore-location story. Deliberate consequence:
+                    // any run touching a non-supporting board with a location set no
+                    // longer collapses to a clean chip — that's intended honesty, not
+                    // a bug (stage-2 renders n=0 as a plain "location filtered
+                    // locally" marker, n>0 as the count).
+                    if non_location_boards.contains(&board) && requested_location.is_some() {
+                        // Surface via the existing note side-channel using the PR D
+                        // `kind:value` grammar (cf. `broadened:<cc>`). Count only —
+                        // never the raw location text (free-text PII). A non-location
+                        // board never emits its own note today, so this can't clobber
+                        // one — LOW: if a future non-supporting board ever also wires
+                        // `on_note`, this unconditional overwrite would silently drop
+                        // its message; join with "; " instead when that day comes.
+                        note = Some(format!("location-filtered:{dropped}"));
+                    }
                     slot_summaries[idx] = Some(BoardScrapeSummary {
                         board,
                         count: postings.len(),

--- a/apps/desktop/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/mod.rs
@@ -251,9 +251,19 @@ impl ScraperEngine {
             Ok(mut items) => {
                 let out = if has_active_filter {
                     // `kept`, not a raw truncate — see `KeepItemFn`.
-                    kept.lock()
-                        .map(|mut g| std::mem::take(&mut *g))
-                        .unwrap_or_default()
+                    match kept.lock() {
+                        Ok(mut g) => std::mem::take(&mut *g),
+                        Err(_) => {
+                            // A poisoned mutex here silently drops this board's
+                            // WHOLE result (empty Vec) — that must be visible, not
+                            // a quiet zero indistinguishable from a clean run.
+                            log::warn!(
+                                "[scrape] board '{board}' kept-items mutex poisoned; \
+                                 returning empty result"
+                            );
+                            Vec::new()
+                        }
+                    }
                 } else {
                     items.truncate(amount);
                     items
@@ -267,10 +277,19 @@ impl ScraperEngine {
                 // A real user cancel leaves `reached == false`, so it propagates the
                 // error exactly as before.
                 if reached.load(Ordering::SeqCst) {
-                    let mut kept_items = kept
-                        .lock()
-                        .map(|mut g| std::mem::take(&mut *g))
-                        .unwrap_or_default();
+                    let mut kept_items = match kept.lock() {
+                        Ok(mut g) => std::mem::take(&mut *g),
+                        Err(_) => {
+                            // Same visibility concern as the Ok(items) arm above:
+                            // a poisoned mutex must not silently present as "0
+                            // items recovered" with no trace.
+                            log::warn!(
+                                "[scrape] board '{board}' kept-items mutex poisoned on \
+                                 cap-recovery; returning empty result"
+                            );
+                            Vec::new()
+                        }
+                    };
                     kept_items.truncate(amount);
                     span.end_with(&format!("count={}", kept_items.len()), true);
                     Ok(kept_items)

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -30,6 +30,54 @@ fn test_catalog() {
 }
 
 #[test]
+fn test_catalog_supports_location_flags() {
+    // Verified catalog (trust PR F): only boards that consume the requested
+    // location SERVER-SIDE claim support. Everything else falls back to the
+    // conservative central post-filter, so it must report false.
+    let engine = ScraperEngine::new();
+    let catalog = engine.catalog();
+    let entry = |id: &str| {
+        catalog
+            .iter()
+            .find(|e| e.id == id)
+            .unwrap_or_else(|| panic!("missing board: {id}"))
+    };
+
+    // Server-side location consumers (verified by reading each `search()`).
+    assert!(
+        entry("aggregator").supports_location,
+        "aggregator routes market + `where`"
+    );
+    assert!(
+        entry("linkedin").supports_location,
+        "linkedin resolves geoId + distance"
+    );
+    assert!(
+        entry("arbeitsagentur").supports_location,
+        "arbeitsagentur sends `wo`"
+    );
+
+    // Boards that ignore location or only filter it client-side must be false.
+    for id in [
+        "remotive",
+        "remoteok",
+        "wwr",
+        "themuse",
+        "germantechjobs",
+        "arbeitnow",
+        "ycombinator",
+        "greenhouse",
+        "lever",
+        "comeet",
+    ] {
+        assert!(
+            !entry(id).supports_location,
+            "{id} must not claim server-side location support"
+        );
+    }
+}
+
+#[test]
 fn test_catalog_auth_tiers() {
     use crate::scraping::types::AuthRequirement;
 
@@ -367,6 +415,7 @@ async fn central_amount_cap_truncates_stream_and_return() {
         Some(on_item),
         None,
         None,
+        None,
     )
     .await
     .expect("capped scrape recovers as success");
@@ -423,6 +472,7 @@ async fn run_boards_collects_all_boards_up_to_amount() {
         Some(on_item),
         None,
         None,
+        None,
         test_browser_sem(),
     )
     .await;
@@ -456,6 +506,7 @@ async fn run_boards_one_error_does_not_kill_others() {
         resolved,
         fake_input(10),
         parent,
+        None,
         None,
         None,
         None,
@@ -501,6 +552,7 @@ async fn run_boards_parent_cancel_stops_all() {
         None,
         None,
         None,
+        None,
         test_browser_sem(),
     )
     .await;
@@ -528,6 +580,7 @@ async fn run_boards_child_cap_stops_only_its_board() {
         resolved,
         fake_input(3),
         parent.clone(),
+        None,
         None,
         None,
         None,
@@ -567,6 +620,7 @@ async fn run_boards_browser_board_collects_items() {
         resolved,
         fake_input(10),
         parent,
+        None,
         None,
         None,
         None,
@@ -661,6 +715,7 @@ async fn run_boards_browser_boards_serialized() {
         None,
         None,
         None,
+        None,
         test_browser_sem(),
     )
     .await;
@@ -710,6 +765,7 @@ async fn scrape_boards_dedupes_and_caps_large_input() {
         fake_refs,
         fake_input(1),
         parent,
+        None,
         None,
         None,
         None,
@@ -1572,6 +1628,7 @@ async fn run_boards_preserves_input_order() {
         resolved,
         fake_input(5),
         parent,
+        None,
         None,
         None,
         None,
@@ -2897,5 +2954,631 @@ async fn scrape_boards_collapses_cross_source_duplicates_keeping_richer() {
         postings[0].description.as_deref(),
         Some("full description with many more characters than the snippet"),
         "the surviving row's description must upgrade to the full text, not stay truncated"
+    );
+}
+
+// ── TRUST PR F: central conservative location post-filter ─────────────────────
+
+/// TRUST PR F — for a board WITHOUT server-side location support
+/// (`supports_location() == false`), the engine drops postings whose OWN location
+/// clearly mismatches the requested one, but conservatively keeps remote and
+/// unknown-location rows. The drop count surfaces as a `location-filtered:<n>`
+/// note (PR D grammar). A board that DOES consume location server-side is left
+/// untouched — re-filtering it could drop a legitimate in-radius match its server
+/// correctly included. Exercised through the engine seam (boards hardcode hosts).
+#[tokio::test]
+async fn scrape_boards_central_location_filter_drops_only_clear_mismatches() {
+    // Ignores location (supports_location defaults false). Returns a mix: matching
+    // city, clear mismatch, remote-flagged, and unknown-location.
+    struct LocationFake;
+    #[async_trait::async_trait]
+    impl Scraper for LocationFake {
+        fn id(&self) -> &'static str {
+            "locfake"
+        }
+        fn display_name(&self) -> &'static str {
+            "LocFake"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            let rows: [(&str, Option<&str>, bool); 4] = [
+                ("keep-berlin", Some("Berlin, Germany"), false),
+                ("drop-london", Some("London, UK"), false),
+                ("keep-remote", Some("USA Only"), true), // remote flag → keep
+                ("keep-unknown", None, false),           // unknown → keep
+            ];
+            let mut out = Vec::new();
+            for (slug, loc, remote) in rows {
+                let mut extra = std::collections::HashMap::new();
+                if remote {
+                    extra.insert("remote".to_string(), serde_json::json!(true));
+                }
+                let job = JobPosting {
+                    id: format!("locfake:{slug}"),
+                    external_id: Some(slug.to_string()),
+                    title: "Job".to_string(),
+                    company: "LF".to_string(),
+                    location: loc.map(str::to_string),
+                    url: format!("https://lf.example/{slug}"),
+                    source: "locfake".to_string(),
+                    description: None,
+                    requirements: None,
+                    posted_at: None,
+                    captured_at: 0,
+                    extra,
+                };
+                if let Some(ref on_item) = ctx.on_item {
+                    on_item(job.clone());
+                }
+                out.push(job);
+            }
+            Ok(out)
+        }
+    }
+
+    // A board that DOES consume location server-side — the central filter must
+    // leave it alone even though it returns a row for a different city name.
+    struct LocationAwareFake;
+    #[async_trait::async_trait]
+    impl Scraper for LocationAwareFake {
+        fn id(&self) -> &'static str {
+            "locaware"
+        }
+        fn display_name(&self) -> &'static str {
+            "LocAware"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        fn supports_location(&self) -> bool {
+            true
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            // An in-radius suburb the server correctly included — must survive.
+            let job = JobPosting {
+                id: "locaware:0".to_string(),
+                external_id: Some("0".to_string()),
+                title: "Job".to_string(),
+                company: "LA".to_string(),
+                location: Some("Potsdam".to_string()),
+                url: "https://la.example/0".to_string(),
+                source: "locaware".to_string(),
+                description: None,
+                requirements: None,
+                posted_at: None,
+                captured_at: 0,
+                extra: std::collections::HashMap::new(),
+            };
+            if let Some(ref on_item) = ctx.on_item {
+                on_item(job.clone());
+            }
+            Ok(vec![job])
+        }
+    }
+
+    static LOCFAKE: std::sync::LazyLock<LocationFake> = std::sync::LazyLock::new(|| LocationFake);
+    static LOCAWARE: std::sync::LazyLock<LocationAwareFake> =
+        std::sync::LazyLock::new(|| LocationAwareFake);
+
+    let engine = ScraperEngine::new();
+    let input = BoardSearchInput {
+        query: "q".to_string(),
+        location: Some("Berlin".to_string()),
+        amount: 100,
+        pages: 10,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: Vec::new(),
+    };
+
+    let (postings, summaries) = engine
+        .scrape_boards_with_resolver(
+            &["locfake".to_string(), "locaware".to_string()],
+            input,
+            "job-trust-f-locfilter".to_string(),
+            None,
+            None,
+            std::path::Path::new("."),
+            |id| match id {
+                "locfake" => Ok(&*LOCFAKE as &'static dyn Scraper),
+                "locaware" => Ok(&*LOCAWARE as &'static dyn Scraper),
+                other => Err(anyhow::anyhow!("Unknown board: {other}")),
+            },
+        )
+        .await
+        .expect("a filtered run is still Ok");
+
+    // Non-supporting board: London dropped; Berlin + remote + unknown kept (3).
+    let locfake = summaries
+        .iter()
+        .find(|s| s.board == "locfake")
+        .expect("locfake summary missing");
+    assert_eq!(
+        locfake.count, 3,
+        "only the clear London mismatch is dropped; got {locfake:?}"
+    );
+    assert_eq!(
+        locfake.note.as_deref(),
+        Some("location-filtered:1"),
+        "the single drop must surface as a location-filtered note; got {locfake:?}"
+    );
+    assert!(
+        !postings
+            .iter()
+            .any(|p| p.location.as_deref() == Some("London, UK")),
+        "the wrong-city row must not appear in the aggregated result"
+    );
+    assert!(
+        postings
+            .iter()
+            .any(|p| p.location.as_deref() == Some("Berlin, Germany")),
+        "the matching-city row must survive"
+    );
+    assert!(
+        postings
+            .iter()
+            .any(|p| p.source == "locfake" && p.location.is_none()),
+        "the unknown-location row must survive (never dropped)"
+    );
+
+    // Location-aware board: NOT filtered — its differently-named-city row survives
+    // and it carries no location-filtered note.
+    let locaware = summaries
+        .iter()
+        .find(|s| s.board == "locaware")
+        .expect("locaware summary missing");
+    assert_eq!(
+        locaware.count, 1,
+        "a server-side location board is not re-filtered; got {locaware:?}"
+    );
+    assert!(
+        locaware.note.is_none(),
+        "a supporting board must not get a location-filtered note; got {locaware:?}"
+    );
+    assert!(
+        postings
+            .iter()
+            .any(|p| p.location.as_deref() == Some("Potsdam")),
+        "the location-aware board's in-radius row must survive the central filter"
+    );
+}
+
+/// TRUST PR F back-compat — with NO location requested, a non-supporting board's
+/// results pass through byte-identically (the central filter is inert).
+#[tokio::test]
+async fn scrape_boards_no_location_requested_is_inert() {
+    struct AnywhereFake;
+    #[async_trait::async_trait]
+    impl Scraper for AnywhereFake {
+        fn id(&self) -> &'static str {
+            "anywherefake"
+        }
+        fn display_name(&self) -> &'static str {
+            "AnywhereFake"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            let mut out = Vec::new();
+            for (i, loc) in ["London, UK", "Tokyo", "Paris"].into_iter().enumerate() {
+                let job = JobPosting {
+                    id: format!("anywherefake:{i}"),
+                    external_id: Some(i.to_string()),
+                    title: "Job".to_string(),
+                    company: "AF".to_string(),
+                    location: Some(loc.to_string()),
+                    url: format!("https://af.example/{i}"),
+                    source: "anywherefake".to_string(),
+                    description: None,
+                    requirements: None,
+                    posted_at: None,
+                    captured_at: 0,
+                    extra: std::collections::HashMap::new(),
+                };
+                if let Some(ref on_item) = ctx.on_item {
+                    on_item(job.clone());
+                }
+                out.push(job);
+            }
+            Ok(out)
+        }
+    }
+    static ANYWHERE: std::sync::LazyLock<AnywhereFake> = std::sync::LazyLock::new(|| AnywhereFake);
+
+    let engine = ScraperEngine::new();
+    // `fake_input` has `location: None` → no location requested → filter inert.
+    let (postings, summaries) = engine
+        .scrape_boards_with_resolver(
+            &["anywherefake".to_string()],
+            fake_input(100),
+            "job-trust-f-inert".to_string(),
+            None,
+            None,
+            std::path::Path::new("."),
+            |id| {
+                if id == "anywherefake" {
+                    Ok(&*ANYWHERE as &'static dyn Scraper)
+                } else {
+                    Err(anyhow::anyhow!("Unknown board: {id}"))
+                }
+            },
+        )
+        .await
+        .expect("ok");
+
+    assert_eq!(
+        postings.len(),
+        3,
+        "no location requested → nothing dropped; got {postings:?}"
+    );
+    let s = summaries
+        .iter()
+        .find(|s| s.board == "anywherefake")
+        .expect("anywherefake summary missing");
+    assert_eq!(s.count, 3, "all rows kept when no location was requested");
+    assert!(
+        s.note.is_none(),
+        "no location requested → no location-filtered note; got {s:?}"
+    );
+}
+
+/// A fake board that streams 4 rows (2 clear location mismatches interleaved
+/// with 2 matches) via `ctx.on_item`, in the SAME row order it returns them —
+/// mirrors the real board loop pattern (`on_item` then `out.push`, no gap).
+struct CapFilterFake;
+
+#[async_trait::async_trait]
+impl Scraper for CapFilterFake {
+    fn id(&self) -> &'static str {
+        "capfilter"
+    }
+    fn display_name(&self) -> &'static str {
+        "CapFilter"
+    }
+    fn mode(&self) -> ScraperMode {
+        ScraperMode::Http
+    }
+    async fn search(
+        &self,
+        _input: BoardSearchInput,
+        ctx: ScrapeContext,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        // Rows 1 and 3 clearly mismatch a "Berlin" request; rows 2 and 4 match.
+        let rows: [(&str, &str); 4] = [
+            ("row1-mismatch", "London, UK"),
+            ("row2-match", "Berlin, Germany"),
+            ("row3-mismatch", "Paris, France"),
+            ("row4-match", "Berlin, Mitte"),
+        ];
+        let mut out = Vec::new();
+        for (slug, loc) in rows {
+            if ctx.signal.is_cancelled() {
+                break;
+            }
+            let job = JobPosting {
+                id: format!("capfilter:{slug}"),
+                external_id: Some(slug.to_string()),
+                title: "Job".to_string(),
+                company: "CF".to_string(),
+                location: Some(loc.to_string()),
+                url: format!("https://cf.example/{slug}"),
+                source: "capfilter".to_string(),
+                description: None,
+                requirements: None,
+                posted_at: None,
+                captured_at: 0,
+                extra: std::collections::HashMap::new(),
+            };
+            if let Some(ref on_item) = ctx.on_item {
+                on_item(job.clone());
+            }
+            out.push(job);
+        }
+        Ok(out)
+    }
+}
+
+/// HIGH-1 — cap/filter ordering: the item cap must count only MATCHING items,
+/// never raw pre-filter items, and the final result must be the true matching
+/// set (not a naive truncate of the raw board return, which can keep an early
+/// mismatch while dropping a later real match — see `run_one`'s `has_active_filter`
+/// branch). `amount=2`, 4 rows where rows 1 and 3 mismatch → both matches (rows
+/// 2 and 4) must be delivered, `count == 2`, and NEITHER mismatch survives.
+#[tokio::test]
+async fn scrape_boards_cap_and_location_filter_combined_delivers_only_matches() {
+    static CAPFILTER: std::sync::LazyLock<CapFilterFake> =
+        std::sync::LazyLock::new(|| CapFilterFake);
+
+    let streamed: Arc<std::sync::Mutex<Vec<JobPosting>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let streamed_cb = streamed.clone();
+    let on_item: Arc<dyn Fn(JobPosting) + Send + Sync> = Arc::new(move |item: JobPosting| {
+        if let Ok(mut g) = streamed_cb.lock() {
+            g.push(item);
+        }
+    });
+
+    let engine = ScraperEngine::new();
+    let mut input = fake_input(2); // amount=2 — the cap under test
+    input.location = Some("Berlin".to_string());
+
+    let (postings, summaries) = engine
+        .scrape_boards_with_resolver(
+            &["capfilter".to_string()],
+            input,
+            "job-trust-f-cap-and-filter".to_string(),
+            None,
+            Some(on_item),
+            std::path::Path::new("."),
+            |id| {
+                if id == "capfilter" {
+                    Ok(&*CAPFILTER as &'static dyn Scraper)
+                } else {
+                    Err(anyhow::anyhow!("Unknown board: {id}"))
+                }
+            },
+        )
+        .await
+        .expect("ok");
+
+    let s = summaries
+        .iter()
+        .find(|s| s.board == "capfilter")
+        .expect("capfilter summary missing");
+    assert_eq!(
+        s.count, 2,
+        "both real matches must be delivered despite amount=2 and 2 raw \
+         mismatches ahead of/interleaved with them; got {s:?}"
+    );
+    assert_eq!(
+        s.note.as_deref(),
+        Some("location-filtered:2"),
+        "both mismatches must be counted as dropped; got {s:?}"
+    );
+
+    let ids: std::collections::HashSet<&str> = postings.iter().map(|p| p.id.as_str()).collect();
+    assert!(
+        ids.contains("capfilter:row2-match") && ids.contains("capfilter:row4-match"),
+        "both real matches must survive, including the LATER one (row4) that a naive \
+         raw truncate(2) would have discarded in favor of the earlier mismatch (row1); \
+         got {postings:?}"
+    );
+    assert!(
+        !ids.contains("capfilter:row1-mismatch") && !ids.contains("capfilter:row3-mismatch"),
+        "neither mismatch may survive; got {postings:?}"
+    );
+}
+
+/// MEDIUM — the live stream gate and the final returned Vec must drop the
+/// IDENTICAL set: every item forwarded to the caller's `on_item` during the
+/// run must also be present in the final result, and vice versa (no item
+/// streamed-then-dropped, and no item present-in-result-but-never-streamed).
+#[tokio::test]
+async fn scrape_boards_stream_and_final_result_agree_under_location_filter() {
+    static CAPFILTER2: std::sync::LazyLock<CapFilterFake> =
+        std::sync::LazyLock::new(|| CapFilterFake);
+
+    let streamed: Arc<std::sync::Mutex<Vec<JobPosting>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let streamed_cb = streamed.clone();
+    let on_item: Arc<dyn Fn(JobPosting) + Send + Sync> = Arc::new(move |item: JobPosting| {
+        if let Ok(mut g) = streamed_cb.lock() {
+            g.push(item);
+        }
+    });
+
+    let engine = ScraperEngine::new();
+    let mut input = fake_input(100); // no cap interaction — isolates this invariant
+    input.location = Some("Berlin".to_string());
+
+    let (postings, _summaries) = engine
+        .scrape_boards_with_resolver(
+            &["capfilter2".to_string()],
+            input,
+            "job-trust-f-stream-agree".to_string(),
+            None,
+            Some(on_item),
+            std::path::Path::new("."),
+            |id| {
+                if id == "capfilter2" {
+                    Ok(&*CAPFILTER2 as &'static dyn Scraper)
+                } else {
+                    Err(anyhow::anyhow!("Unknown board: {id}"))
+                }
+            },
+        )
+        .await
+        .expect("ok");
+
+    let streamed_ids: std::collections::HashSet<String> = streamed
+        .lock()
+        .expect("lock")
+        .iter()
+        .map(|p| p.id.clone())
+        .collect();
+    let final_ids: std::collections::HashSet<String> =
+        postings.iter().map(|p| p.id.clone()).collect();
+
+    assert_eq!(
+        streamed_ids, final_ids,
+        "the live-streamed kept set must exactly equal the final returned set"
+    );
+    // Sanity: the agreeing set is exactly the 2 real matches, not e.g. empty sets
+    // trivially "agreeing".
+    assert_eq!(
+        streamed_ids.len(),
+        2,
+        "2 real matches expected in both sets"
+    );
+}
+
+/// Trust-story completeness (frontend-reviewer follow-up): the
+/// `location-filtered:<n>` note must be UNCONDITIONAL for a non-supporting
+/// board when a location was requested — including `n=0`. Emitting it only on
+/// `dropped>0` let a non-supporting board that happened to have zero mismatches
+/// this run read as indistinguishable from a genuinely location-aware one (a
+/// clean chip, "all ok"), half-telling the 17/23-boards-ignore-location story.
+/// Covers all three cases: non-supporting+location+0 drops → note "…:0";
+/// supporting board+location → no note; (no-location case is already covered
+/// by `scrape_boards_no_location_requested_is_inert`).
+#[tokio::test]
+async fn scrape_boards_zero_drops_still_emits_unconditional_note_for_non_supporting_board() {
+    // Non-supporting board whose rows ALL match the request — 0 drops, but the
+    // note must still fire since this board never honored location server-side.
+    struct AllMatchNonSupporting;
+    #[async_trait::async_trait]
+    impl Scraper for AllMatchNonSupporting {
+        fn id(&self) -> &'static str {
+            "allmatch"
+        }
+        fn display_name(&self) -> &'static str {
+            "AllMatch"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            let job = JobPosting {
+                id: "allmatch:0".to_string(),
+                external_id: Some("0".to_string()),
+                title: "Job".to_string(),
+                company: "AM".to_string(),
+                location: Some("Berlin, Germany".to_string()),
+                url: "https://am.example/0".to_string(),
+                source: "allmatch".to_string(),
+                description: None,
+                requirements: None,
+                posted_at: None,
+                captured_at: 0,
+                extra: std::collections::HashMap::new(),
+            };
+            if let Some(ref on_item) = ctx.on_item {
+                on_item(job.clone());
+            }
+            Ok(vec![job])
+        }
+    }
+
+    // Supporting board — must NEVER get a location-filtered note, regardless of
+    // its own location text (the central filter never touches it).
+    struct SupportingBoard;
+    #[async_trait::async_trait]
+    impl Scraper for SupportingBoard {
+        fn id(&self) -> &'static str {
+            "supporting"
+        }
+        fn display_name(&self) -> &'static str {
+            "Supporting"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        fn supports_location(&self) -> bool {
+            true
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            ctx: ScrapeContext,
+        ) -> anyhow::Result<Vec<JobPosting>> {
+            let job = JobPosting {
+                id: "supporting:0".to_string(),
+                external_id: Some("0".to_string()),
+                title: "Job".to_string(),
+                company: "SB".to_string(),
+                location: Some("Munich".to_string()), // doesn't matter — never filtered
+                url: "https://sb.example/0".to_string(),
+                source: "supporting".to_string(),
+                description: None,
+                requirements: None,
+                posted_at: None,
+                captured_at: 0,
+                extra: std::collections::HashMap::new(),
+            };
+            if let Some(ref on_item) = ctx.on_item {
+                on_item(job.clone());
+            }
+            Ok(vec![job])
+        }
+    }
+
+    static ALLMATCH: std::sync::LazyLock<AllMatchNonSupporting> =
+        std::sync::LazyLock::new(|| AllMatchNonSupporting);
+    static SUPPORTING: std::sync::LazyLock<SupportingBoard> =
+        std::sync::LazyLock::new(|| SupportingBoard);
+
+    let engine = ScraperEngine::new();
+    let mut input = fake_input(10);
+    input.location = Some("Berlin".to_string());
+
+    let (_postings, summaries) = engine
+        .scrape_boards_with_resolver(
+            &["allmatch".to_string(), "supporting".to_string()],
+            input,
+            "job-trust-f-zero-drop-note".to_string(),
+            None,
+            None, // no live on_item — exercises the post-hoc path
+            std::path::Path::new("."),
+            |id| match id {
+                "allmatch" => Ok(&*ALLMATCH as &'static dyn Scraper),
+                "supporting" => Ok(&*SUPPORTING as &'static dyn Scraper),
+                other => Err(anyhow::anyhow!("Unknown board: {other}")),
+            },
+        )
+        .await
+        .expect("ok");
+
+    let allmatch = summaries
+        .iter()
+        .find(|s| s.board == "allmatch")
+        .expect("allmatch summary missing");
+    assert_eq!(
+        allmatch.count, 1,
+        "the matching row is kept; got {allmatch:?}"
+    );
+    assert_eq!(
+        allmatch.note.as_deref(),
+        Some("location-filtered:0"),
+        "a non-supporting board must emit the note even with ZERO drops when a \
+         location was requested; got {allmatch:?}"
+    );
+
+    let supporting = summaries
+        .iter()
+        .find(|s| s.board == "supporting")
+        .expect("supporting summary missing");
+    assert!(
+        supporting.note.is_none(),
+        "a server-side location board must never carry a location-filtered note; \
+         got {supporting:?}"
     );
 }

--- a/apps/desktop/src-tauri/src/scraping/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/mod.rs
@@ -9,4 +9,4 @@ pub mod trust;
 pub mod types;
 
 pub use engine::{BoardScrapeSummary, ScraperEngine};
-pub use types::{BoardSearchInput, JobPosting};
+pub use types::{BoardSearchInput, JobPosting, LocationSpec};

--- a/apps/desktop/src-tauri/src/scraping/types/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/types/mod.rs
@@ -60,6 +60,75 @@ pub struct BoardSearchInput {
     pub companies: Vec<String>,
 }
 
+/// Canonical structured location for a search — the single model the engine's
+/// central location post-filter (and location-aware boards) reason over,
+/// assembled once from the free-text `location` plus the structured geo fields a
+/// picked geocode suggestion carries. All fields are optional so a partial or
+/// absent location degrades gracefully; a `None` spec (see
+/// [`BoardSearchInput::location_spec`]) means "no location was requested", which
+/// keeps location-agnostic searches byte-identical. Serde so it can ride IPC /
+/// be persisted; `#[serde(default)]` on every field so a sparse or older payload
+/// deserializes cleanly.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationSpec {
+    /// City / place name. Today sourced from the free-text `location`; a
+    /// structured geocode city can populate it later.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub city: Option<String>,
+    /// Region / state, when a structured pick provides one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// ISO 3166-1 alpha-2 country code — routes the aggregator's market directly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub country_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latitude: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub longitude: Option<f64>,
+    /// Search radius in km — consumed by LinkedIn's `distance` param.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub radius_km: Option<u32>,
+}
+
+impl LocationSpec {
+    /// True when the spec carries no location signal at all.
+    pub fn is_empty(&self) -> bool {
+        self.city.is_none()
+            && self.region.is_none()
+            && self.country_code.is_none()
+            && self.latitude.is_none()
+            && self.longitude.is_none()
+            && self.radius_km.is_none()
+    }
+}
+
+impl BoardSearchInput {
+    /// The canonical structured location for this search, assembled from the
+    /// free-text `location` (as the city) plus the structured geo fields. Returns
+    /// `None` when no location signal was supplied, so location-agnostic searches
+    /// stay byte-identical (the engine's central location post-filter is inert for
+    /// a `None` spec). The free-text `location` field is preserved alongside for
+    /// boards that only understand text.
+    pub fn location_spec(&self) -> Option<LocationSpec> {
+        let city = self
+            .location
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let spec = LocationSpec {
+            city,
+            region: None,
+            country_code: self.country_code.clone(),
+            latitude: self.latitude,
+            longitude: self.longitude,
+            radius_km: self.radius_km,
+        };
+        (!spec.is_empty()).then_some(spec)
+    }
+}
+
 pub struct ScrapeContext {
     pub signal: tokio_util::sync::CancellationToken,
     pub on_progress: Option<Box<dyn Fn(f32) + Send>>,
@@ -167,6 +236,25 @@ pub trait Scraper: Send + Sync {
     ///
     /// Defaults to `false` so only key-backed boards override it.
     fn needs_keys(&self) -> bool {
+        false
+    }
+
+    /// Whether this board narrows results by the requested location SERVER-SIDE
+    /// (the query itself is scoped to the place before results return), as opposed
+    /// to ignoring location or only filtering it client-side.
+    ///
+    /// When this is `false` and a location was requested, the engine applies a
+    /// conservative central post-filter to this board's results (drops only
+    /// postings whose OWN location clearly mismatches; never remote or
+    /// unknown-location rows). Verified per board by reading each `search()`:
+    /// - aggregator: Adzuna/JSearch `where` param + country market routing → `true`
+    /// - linkedin: geoId typeahead + `distance`/radius params → `true`
+    /// - arbeitsagentur: `wo` (where) param → `true`
+    ///
+    /// Every other board — remote-only feeds, regional feeds, company-slug ATS,
+    /// and boards that only filter location client-side — returns the default
+    /// `false`.
+    fn supports_location(&self) -> bool {
         false
     }
 

--- a/apps/desktop/src-tauri/src/scraping/types/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/types/mod.rs
@@ -132,6 +132,8 @@ impl BoardSearchInput {
 pub struct ScrapeContext {
     pub signal: tokio_util::sync::CancellationToken,
     pub on_progress: Option<Box<dyn Fn(f32) + Send>>,
+    /// Streamed per-posting sink. See [`Scraper::search`]'s doc contract: the
+    /// set streamed here must equal the `search` return value's set.
     pub on_item: Option<Box<dyn Fn(JobPosting) + Send>>,
     /// Reports that a paginated board stopped early after a mid-run page failure
     /// and kept its partial harvest (e.g. `"page 3 of 5 failed: HTTP 429"`). Only
@@ -258,6 +260,12 @@ pub trait Scraper: Send + Sync {
         false
     }
 
+    /// **Contract:** every posting streamed via `ctx.on_item` must also appear in
+    /// the returned `Vec` (and vice versa) — the same set, not a subset/superset.
+    /// The engine relies on this identity: under a live location filter it
+    /// returns the streamed/kept set as the board's authoritative result, so a
+    /// board that streams a different set than it returns would silently lose or
+    /// fabricate results for that board.
     async fn search(
         &self,
         input: BoardSearchInput,

--- a/apps/desktop/src-tauri/src/scraping/types/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/types/test.rs
@@ -117,6 +117,93 @@ fn test_board_search_input_defaults() {
 }
 
 #[test]
+fn location_spec_assembles_from_fields() {
+    let input = BoardSearchInput {
+        query: "dev".into(),
+        location: Some("  Berlin  ".into()),
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: Some("DE".into()),
+        latitude: Some(52.52),
+        longitude: Some(13.405),
+        radius_km: Some(25),
+        companies: Vec::new(),
+    };
+    let spec = input.location_spec().expect("a location was requested");
+    assert_eq!(spec.city.as_deref(), Some("Berlin")); // trimmed from free text
+    assert_eq!(spec.country_code.as_deref(), Some("DE"));
+    assert_eq!(spec.latitude, Some(52.52));
+    assert_eq!(spec.radius_km, Some(25));
+}
+
+#[test]
+fn location_spec_none_when_no_location_signal() {
+    // Back-compat: no location signal → None spec, so the central filter stays
+    // inert and location-agnostic searches behave byte-identically.
+    let input = BoardSearchInput {
+        query: "dev".into(),
+        location: None,
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: Vec::new(),
+    };
+    assert!(input.location_spec().is_none());
+    // A whitespace-only location is not a signal either.
+    let ws = BoardSearchInput {
+        location: Some("   ".into()),
+        ..input
+    };
+    assert!(ws.location_spec().is_none());
+}
+
+#[test]
+fn supports_location_defaults_false() {
+    // A minimal scraper that only implements the required methods must inherit the
+    // conservative default (a board opts IN to server-side location handling).
+    struct Bare;
+    #[async_trait::async_trait]
+    impl Scraper for Bare {
+        fn id(&self) -> &'static str {
+            "bare"
+        }
+        fn display_name(&self) -> &'static str {
+            "Bare"
+        }
+        fn mode(&self) -> ScraperMode {
+            ScraperMode::Http
+        }
+        async fn search(
+            &self,
+            _input: BoardSearchInput,
+            _ctx: ScrapeContext,
+        ) -> Result<Vec<JobPosting>, anyhow::Error> {
+            Ok(vec![])
+        }
+    }
+    assert!(!Bare.supports_location());
+}
+
+#[test]
 fn test_scraper_mode_http() {
     let mode = ScraperMode::Http;
     assert_eq!(mode, ScraperMode::Http);

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.test.tsx
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.test.tsx
@@ -304,6 +304,78 @@ describe('BoardSummaryChips — location note chips', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// location-filtered:<n> note chips (PR F) — off-location rows hidden locally
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('BoardSummaryChips — location-filtered note chips', () => {
+  it('maps "location-filtered:<n>" to the pluralized informational (processing) label', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[{ board: 'greenhouse', count: 6, note: 'location-filtered:5' }]}
+      />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('processing');
+    // The identity mock echoes `${key}:${count}` so the count is threaded through.
+    expect(chip?.textContent).toContain('jobs.boardSummary.note.locationFiltered:5');
+    // The raw machine token must never leak into the UI.
+    expect(chip?.textContent).not.toContain('location-filtered:5');
+  });
+
+  it('tolerates a non-numeric n — falls through to the plain success chip', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[{ board: 'greenhouse', count: 6, note: 'location-filtered:abc' }]}
+      />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('success');
+    expect(chip?.textContent).toContain('jobs.boardSummary.count:6');
+    expect(chip?.textContent).not.toContain('location-filtered');
+  });
+
+  it('maps "location-filtered:0" to the plain marker label (engine now emits n=0 too)', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[{ board: 'greenhouse', count: 6, note: 'location-filtered:0' }]}
+      />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('processing');
+    expect(chip?.textContent).toContain('jobs.boardSummary.note.locationFilteredNone');
+    // The pluralized hidden-count key must NOT be used for the zero case.
+    expect(chip?.textContent).not.toContain('jobs.boardSummary.note.locationFiltered:');
+  });
+
+  it('tolerates an empty n (bare "location-filtered:") — falls through to success', () => {
+    render(
+      <BoardSummaryChips summaries={[{ board: 'lever', count: 3, note: 'location-filtered:' }]} />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('success');
+    expect(chip?.textContent).not.toContain('locationFiltered');
+  });
+
+  it('tolerates a fractional / negative n (no chip)', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[{ board: 'greenhouse', count: 6, note: 'location-filtered:2.5' }]}
+      />
+    );
+    expect(chips()[0]?.getAttribute('data-color')).toBe('success');
+  });
+
+  it('precedence: an error still wins over a co-present location-filtered note', () => {
+    render(
+      <BoardSummaryChips
+        summaries={[{ board: 'greenhouse', count: 0, error: 'boom', note: 'location-filtered:4' }]}
+      />
+    );
+    expect(chips()[0]?.getAttribute('data-color')).toBe('error');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Robustness
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
@@ -150,18 +150,38 @@ function skipDetail(skipped: string, t: TFunction): string {
 /**
  * Map a controlled location `note` token to a localized label — or `null` for an
  * unknown/future token so a legacy or newer backend can never leak a raw machine
- * token into the UI (tolerant, like the `skipped` fallback). Shape is
- * `kind:<countryCode>` (lowercase cc); the country name is resolved natively.
+ * token into the UI (tolerant, like the `skipped` fallback). Two shapes:
+ *   - `kind:<countryCode>` (lowercase alpha-2) — `broadened` / `guessed-market`;
+ *     the country name is resolved natively.
+ *   - `location-filtered:<n>` (PR F) — the engine emits this unconditionally for
+ *     a board without server-side location support (even n=0, "checked, nothing
+ *     hidden"); n=0 gets a plain marker label, n>0 the pluralized hidden-count.
  */
 function noteDetail(note: string, t: TFunction, locale: string): string | null {
   const sep = note.indexOf(':');
   if (sep < 0) return null;
   const kind = note.slice(0, sep);
-  const cc = note.slice(sep + 1).trim();
-  // Alpha-2 only — a malformed multi-colon token (e.g. "broadened:de:extra")
-  // must not render its trailing garbage as a "country".
-  if (cc.length !== 2) return null;
-  const country = regionName(cc, locale);
+  const value = note.slice(sep + 1).trim();
+
+  // `location-filtered:<n>` — count of results dropped by the local location
+  // filter (0 = the board was checked and nothing was hidden). A malformed /
+  // negative / non-integer `n` is tolerated (no chip), like an unknown token,
+  // so a legacy or garbled payload never renders junk.
+  if (kind === 'location-filtered') {
+    // `Number('')` coerces to `0` in JS — reject empty explicitly so a bare
+    // "location-filtered:" (no digits at all) stays malformed, not a false 0.
+    if (!value) return null;
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 0) return null;
+    return n === 0
+      ? t('jobs.boardSummary.note.locationFilteredNone')
+      : t('jobs.boardSummary.note.locationFiltered', { count: n });
+  }
+
+  // `kind:<cc>` — alpha-2 only; a malformed multi-colon token (e.g.
+  // "broadened:de:extra") must not render its trailing garbage as a "country".
+  if (value.length !== 2) return null;
+  const country = regionName(value, locale);
   switch (kind) {
     case 'broadened':
       return t('jobs.boardSummary.note.broadened', { country });

--- a/apps/desktop/src/renderer/components/scrape/LocationFilterNote.i18n.test.ts
+++ b/apps/desktop/src/renderer/components/scrape/LocationFilterNote.i18n.test.ts
@@ -1,0 +1,41 @@
+/**
+ * en/de parity for the PR F location keys. Uses the REAL @ajh/translations
+ * instance (not the identity mock the component/chip tests use) so a key added
+ * to one locale but not the other — which resolves to the raw key string in the
+ * missing locale — fails here instead of silently shipping an untranslated UI.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import i18n from '@ajh/translations';
+
+const LOCALES = ['en', 'de'] as const;
+
+describe('PR F location i18n — en/de parity', () => {
+  it.each(LOCALES)('%s resolves the picker hint label', (lng) => {
+    const t = i18n.getFixedT(lng);
+    const out = t('jobs.locationFilterHint');
+    expect(out).not.toBe('jobs.locationFilterHint');
+    expect(out.trim().length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['en', 1],
+    ['en', 7],
+    ['de', 1],
+    ['de', 7],
+  ] as const)('%s resolves the pluralized location-filtered chip (count=%i)', (lng, count) => {
+    const t = i18n.getFixedT(lng);
+    const out = t('jobs.boardSummary.note.locationFiltered', { count });
+    // Resolved (not the raw key) and the count was interpolated.
+    expect(out).not.toBe('jobs.boardSummary.note.locationFiltered');
+    expect(out).toContain(String(count));
+  });
+
+  it.each(LOCALES)('%s resolves the n=0 plain marker label', (lng) => {
+    const t = i18n.getFixedT(lng);
+    const out = t('jobs.boardSummary.note.locationFilteredNone');
+    expect(out).not.toBe('jobs.boardSummary.note.locationFilteredNone');
+    expect(out.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/renderer/components/scrape/LocationFilterNote.test.tsx
+++ b/apps/desktop/src/renderer/components/scrape/LocationFilterNote.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * LocationFilterNote — honest picker hint (PR F, job-search trust program).
+ *
+ * Covers:
+ *  - Gate on a location being set: absent without one, present with one.
+ *  - Names ONLY the selected boards that don't filter by location server-side
+ *    (`supportsLocation` falsy); location-supporting boards are never listed.
+ *  - An absent flag reads as "does not support location" (contract semantics).
+ *
+ * @ajh/translations is a readable identity mock so the localized label + each
+ * board key are assertable without a real i18n instance (parity is covered
+ * separately in LocationFilterNote.i18n.test.ts).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import type { BoardCatalogEntry } from '@ajh/shared';
+
+import { LocationFilterNote } from './LocationFilterNote';
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+function board(id: string, supportsLocation?: boolean): BoardCatalogEntry {
+  return {
+    id,
+    displayName: id,
+    mode: 'api',
+    auth: 'guest',
+    listed: true,
+    requiresCompany: false,
+    supportsLocation,
+  };
+}
+
+describe('LocationFilterNote', () => {
+  it('renders nothing when no location is set', () => {
+    render(<LocationFilterNote boards={[board('greenhouse', false)]} hasLocation={false} />);
+    expect(screen.queryByRole('note')).toBeNull();
+  });
+
+  it('renders nothing when every selected board supports location server-side', () => {
+    render(
+      <LocationFilterNote
+        boards={[board('aggregator', true), board('linkedin', true)]}
+        hasLocation
+      />
+    );
+    expect(screen.queryByRole('note')).toBeNull();
+  });
+
+  it('renders nothing for an empty selection', () => {
+    render(<LocationFilterNote boards={[]} hasLocation />);
+    expect(screen.queryByRole('note')).toBeNull();
+  });
+
+  it('names ONLY the non-supporting boards when a location is set', () => {
+    render(
+      <LocationFilterNote
+        boards={[board('aggregator', true), board('greenhouse', false), board('lever', false)]}
+        hasLocation
+      />
+    );
+    const note = screen.getByRole('note');
+    expect(note.textContent).toContain('jobs.locationFilterHint');
+    expect(note.textContent).toContain('jobs.boards.greenhouse');
+    expect(note.textContent).toContain('jobs.boards.lever');
+    // A board that DOES filter by location server-side must never be named.
+    expect(note.textContent).not.toContain('jobs.boards.aggregator');
+  });
+
+  it('treats an absent supportsLocation flag as "does not support location"', () => {
+    render(<LocationFilterNote boards={[board('greenhouse', undefined)]} hasLocation />);
+    expect(screen.getByRole('note').textContent).toContain('jobs.boards.greenhouse');
+  });
+});

--- a/apps/desktop/src/renderer/components/scrape/LocationFilterNote.tsx
+++ b/apps/desktop/src/renderer/components/scrape/LocationFilterNote.tsx
@@ -1,0 +1,50 @@
+import { Info } from 'lucide-react';
+
+import type { BoardCatalogEntry } from '@ajh/shared';
+import { useTranslation } from '@ajh/translations';
+
+interface LocationFilterNoteProps {
+  /** The currently-selected listed boards (as catalog entries). */
+  boards: readonly BoardCatalogEntry[];
+  /** True once the user has entered a location — the hint is meaningless otherwise. */
+  hasLocation: boolean;
+}
+
+/**
+ * Honest per-board picker hint (PR F, job-search trust program). When a location
+ * is entered, it names the SELECTED boards that do NOT narrow results by location
+ * on their side (`supportsLocation` falsy). The scrape engine post-filters those
+ * boards' results to the requested location on-device (dropping only clear
+ * mismatches), so this tells the user upfront which boards "ignore" the location
+ * upstream — informational and muted, never a warning.
+ *
+ * Shared by the jobs manual picker and the autopilot wizard, so it lives outside
+ * both feature dirs (no cross-feature import), mirroring `BoardSummaryChips`.
+ */
+export function LocationFilterNote({ boards, hasLocation }: LocationFilterNoteProps) {
+  const { t } = useTranslation();
+  if (!hasLocation) return null;
+
+  // Optional flag: an absent / older payload reads as "does not support location"
+  // — matching the contract semantics and the engine's conservative post-filter.
+  const affected = boards.filter((b) => !b.supportsLocation);
+  if (affected.length === 0) return null;
+
+  return (
+    <div
+      role="note"
+      className="mb-3 flex flex-wrap items-center gap-1.5 text-[10px] text-foreground/70"
+    >
+      <Info size={11} aria-hidden="true" className="shrink-0" />
+      <span>{t('jobs.locationFilterHint')}</span>
+      {affected.map((e) => (
+        <span
+          key={e.id}
+          className="rounded-full bg-muted px-1.5 py-0.5 font-medium text-foreground/70"
+        >
+          {t(`jobs.boards.${e.id}`, { defaultValue: e.id })}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/StepTarget.test.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/StepTarget.test.tsx
@@ -249,3 +249,21 @@ describe('StepTarget — countryCode wiring (Fix A)', () => {
     expect(readProbe().countryCode).toBeUndefined();
   });
 });
+
+// ── LocationFilterNote integration (PR F) ───────────────────────────────────
+// Real component, not stubbed here, so a wrong prop name at the StepTarget
+// call site would fail this render instead of silently compiling and passing
+// every other test in the file.
+
+describe('StepTarget — location filter note (PR F integration)', () => {
+  it('shows the note when a location is set and the selected board does not support it', () => {
+    // catalog stub: aggregator, listed, no `supportsLocation` — falsy, non-supporting.
+    renderStep({ boards: ['aggregator'], location: 'Berlin' });
+    expect(screen.getByRole('note')).toBeInTheDocument();
+  });
+
+  it('hides the note when no location is set (default empty location)', () => {
+    renderStep({ boards: ['aggregator'], location: '' });
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
@@ -6,6 +6,7 @@ import { AGGREGATOR_BOARD_ID, type BoardCatalogEntry, PROVIDER_SLOTS } from '@aj
 import { useTranslation } from '@ajh/translations';
 import { Alert, Button, cn, Dropdown, Input, LocationInput, NumberField } from '@ajh/ui';
 
+import { LocationFilterNote } from '@/components/scrape/LocationFilterNote';
 import type { Prefilled, WizardState } from '@/features/autopilot/types';
 import { makeMultiSelectKeyHandler } from '@/hooks/use-roving-tabindex';
 import { regionName } from '@/lib/region-name';
@@ -34,12 +35,18 @@ export function StepTarget({ prefilled }: StepTargetProps) {
   // user SEES which market the autopilot will search (vs. the silent save-time
   // backfill, now only a legacy fallback). Cleared by editing the location.
   const countryCode = useWatch({ control, name: 'countryCode' });
+  // Location text — drives the honest "location filtered locally" board hint.
+  const location = useWatch({ control, name: 'location' });
 
   const boardRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const focusedBoardIdx = useRef<number>(0);
 
   const { data: catalogRaw, isLoading: catalogLoading } = useBoardsCatalog();
   const listedBoards: BoardCatalogEntry[] = (catalogRaw ?? []).filter((e) => e.listed);
+
+  // Selected boards + whether a location is set — feeds the location hint below.
+  const selectedListedBoards = listedBoards.filter((e) => boards.includes(e.id));
+  const hasLocation = (location ?? '').trim().length > 0;
 
   // Normalize: ensure every persisted board id still exists in the catalog.
   // Mirror ScrapeForm normalization guard — prevents an infinite re-render loop
@@ -155,6 +162,11 @@ export function StepTarget({ prefilled }: StepTargetProps) {
                   <Alert type="warning" showIcon message={t('jobs.aggregatorKeyHint')} />
                 </div>
               )}
+
+              {/* Honest location hint — mirrors ScrapeForm */}
+              <div className="mt-2 empty:mt-0">
+                <LocationFilterNote boards={selectedListedBoards} hasLocation={hasLocation} />
+              </div>
             </WizardField>
           );
         }}

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.test.tsx
@@ -128,7 +128,13 @@ const DEFAULT_FORM = {
 
 const NOOP = () => {};
 
-function renderForm(overrides: { catalogLoading?: boolean; catalog?: BoardCatalogEntry[] } = {}) {
+function renderForm(
+  overrides: {
+    catalogLoading?: boolean;
+    catalog?: BoardCatalogEntry[];
+    form?: typeof DEFAULT_FORM;
+  } = {}
+) {
   stubCatalog = overrides.catalog ?? LISTED_CATALOG;
   stubLoading = overrides.catalogLoading ?? false;
 
@@ -140,7 +146,7 @@ function renderForm(overrides: { catalogLoading?: boolean; catalog?: BoardCatalo
   return render(
     <ScrapeForm
       show={true}
-      form={DEFAULT_FORM}
+      form={overrides.form ?? DEFAULT_FORM}
       scraping={false}
       scrapeOutcome={null}
       onToggle={NOOP}
@@ -256,5 +262,24 @@ describe('ScrapeForm — hidden when show=false', () => {
     );
     // AnimatePresence renders nothing when show=false
     expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LocationFilterNote integration (PR F) — real component, not stubbed here,
+// so a wrong prop name at the ScrapeForm call site would fail this render
+// instead of silently compiling and passing every other test in the file.
+// ---------------------------------------------------------------------------
+
+describe('ScrapeForm — location filter note (PR F integration)', () => {
+  it('shows the note when a location is set and the selected board does not support it', () => {
+    // greenhouse (LISTED_CATALOG) has no `supportsLocation` — falsy, non-supporting.
+    renderForm({ form: { ...DEFAULT_FORM, boards: ['greenhouse'], location: 'Berlin' } });
+    expect(screen.getByRole('note')).toBeInTheDocument();
+  });
+
+  it('hides the note when no location is set (default form)', () => {
+    renderForm({ form: { ...DEFAULT_FORM, boards: ['greenhouse'], location: '' } });
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/index.tsx
@@ -8,6 +8,7 @@ import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
 import { Button, CardSkeleton, cn, GlassCard, Input, transition } from '@ajh/ui';
 
+import { LocationFilterNote } from '@/components/scrape/LocationFilterNote';
 import { AUTH_BENEFITS } from '@/features/jobs/constants';
 import { makeMultiSelectKeyHandler } from '@/hooks/use-roving-tabindex';
 import { useHasProviderKey } from '@/services/use-ai-provider';
@@ -85,6 +86,11 @@ export function ScrapeForm({
   const needsLoginBoards = listedBoards.filter(
     (e) => selectedSet.has(e.id) && (e.auth === 'optional' || e.auth === 'required')
   );
+
+  // Selected boards + whether a location is set — drives the honest "location
+  // filtered locally" picker hint for boards without server-side location support.
+  const selectedListedBoards = listedBoards.filter((e) => selectedSet.has(e.id));
+  const hasLocation = form.location.trim().length > 0;
 
   // True when any currently-selected board requires a company slug (ATS boards).
   // Derived entirely from catalog metadata — no hardcoded board list.
@@ -313,6 +319,10 @@ export function ScrapeForm({
                 ))}
               </div>
             )}
+
+            {/* Honest location hint — names selected boards that don't filter by
+                location server-side (results are matched on-device instead). */}
+            <LocationFilterNote boards={selectedListedBoards} hasLocation={hasLocation} />
 
             {/* Aggregator key hint — shown when aggregator selected but Adzuna keys absent */}
             {showAggregatorKeyHint && (

--- a/docs/knowledge/scraping-domain.md
+++ b/docs/knowledge/scraping-domain.md
@@ -106,6 +106,48 @@ Location input policy is now visible via per-board summary notes. When a search 
 - **Wizard visibility:** Autopilot wizard shows inline "Country: <Name>" when `countryCode` is set, cleared on manual location edit (user may re-pick via the location-input autocompleter).
 - **Source:** `scraping/types/mod.rs` (`on_note` side-channel + `report_note()`), `scraping/engine/mod.rs` (`BoardScrapeSummary.note` wiring), `boards/aggregator/mod.rs` (inject), `boards/aggregator/providers.rs` (Adzuna emit sites + `guessed_market_note` helper).
 
+## Canonical location model & central filter (PR F, 2026-07-11)
+
+Location input is now canonical: resolved once from user-supplied city/region/country/lat/lon/radius at search time; boards declare server-side support via `supports_location()`; the engine centrally filters results for boards that cannot honor location constraints.
+
+**LocationSpec canonical model:**
+
+- **Type:** `apps/desktop/src-tauri/src/scraping/types/mod.rs` — struct with optional fields: `city`, `region`, `country_code`, `lat`, `lon`, `radius_km` (all present per Nominatim pick, but none required).
+- **Accessor:** `BoardSearchInput::location_spec()` (not a stored field) — assembles the spec from existing input fields (`location` string + loose geo fields). Zero literal churn; back-compat automatic (None spec ⇒ filter inert).
+
+**Board supports_location() flag:**
+
+- **Trait method:** `Scraper::supports_location()` — returns true ONLY for boards with server-side location consumption.
+- **Truthful catalog:** Only **3 boards** read location server-side:
+  - **Aggregator** (Adzuna `where` param + country-scoped market routing; JSearch fallback)
+  - **LinkedIn** (`geoId` typeahead + `distance` radius)
+  - **Arbeitsagentur** (`wo` param)
+- **20 non-supporting boards:** Remote feeds (remotive/remoteok/wwr), regional feeds (berlinstartupjobs/germantechjobs), ycombinator/arbeitnow, themuse+comeet, all 10 company-slug ATS (greenhouse/lever/ashby/smartrecruiters/personio/recruitee/pinpoint/rippling/breezy/bamboohr/workable).
+- **IPC contract:** `BoardCatalogEntry.supportsLocation?` boolean flag in `packages/shared/src/ipc/contracts/boards.ts` (flows to renderer picker).
+
+**Central conservative filter:**
+
+- **Module:** `apps/desktop/src-tauri/src/scraping/engine/location_filter.rs` — pure function `location_mismatch(posting, &LocationSpec) -> bool`.
+- **Policy:** DROP a posting iff it has a concrete, non-remote location whose diacritic-folded form (ü/ö/ä→u/o/a variants) shares NO substring token (len≥3) with any folded-expanded requested needle (raw city/region tokens + curated exonym pairs like Munich/München). KEEP always: `extra.remote==true`; remote text marker (remote/wfh/etc.); empty/unknown location; no usable requested token (country-code-only is inert); diacritic spelling variant; curated exonym pair. **Known limitation:** exonym pairs outside the small curated table (`EXONYM_PAIRS`: Munich/München, Cologne/Köln, Nuremberg/Nürnberg) still drop — this is documented and tested, not silently "fixed" by folding alone.
+- **Wiring:** Applied ONLY to `supports_location()==false` boards ONLY when a location was requested. Threaded into the per-item streaming cap counting (not downstream, so cap counts POST-filter matches) + applied once post-hoc to final Vec for consistency across manual-cache, autopilot-found-jobs, and per-board `count` signals.
+- **Drop tracking:** `location-filtered:<n>` note token records the count (never raw location text — PII). Emitted UNCONDITIONALLY on every `supports_location()==false` board when location requested, even if n=0 (preserves honesty that location was NOT honored, whether or not anything was dropped this run).
+
+**Frontend picker surface:**
+
+- **LocationFilterNote component:** `apps/desktop/src/renderer/components/scrape/LocationFilterNote.tsx` — renders when selected boards include non-supporting ones + location is set. Lists by name the non-supporting boards in the selection (absent flag reads as unsupported per contract). Scoped to SELECTED boards (not all 20, to avoid noise).
+- **Chip rendering:** `BoardSummaryChips.tsx` extends note token mapping with `location-filtered:<n>` handling — `n>0` shows pluralized "N off-location result(s) hidden", `n===0` shows plain "location filtered locally" marker.
+- **I18n keys:** `jobs.locationFilterHint` (label row), `jobs.boardSummary.note.locationFiltered_one` / `_other` (count/marker), en+de parity verified by real `@ajh/translations` import test.
+
+**Source pointers:**
+
+- **LocationSpec + accessor:** `apps/desktop/src-tauri/src/scraping/types/mod.rs` + `BoardSearchInput::location_spec()` (call path)
+- **Filter policy + tests:** `apps/desktop/src-tauri/src/scraping/engine/location_filter.rs`
+- **Trait flag + catalog:** `apps/desktop/src-tauri/src/scraping/boards/mod.rs` (`Scraper::supports_location()`, `SCRAPERS` overrides)
+- **Filter wiring + note emission:** `apps/desktop/src-tauri/src/scraping/engine/mod.rs` (stream gate + post-hoc filter + note unconditional gate)
+- **Frontend picker + chip mapping:** `apps/desktop/src/renderer/components/scrape/LocationFilterNote.tsx` + `BoardSummaryChips.tsx` `noteDetail()`
+- **Autopilot forwarding (scope):** `apps/desktop/src-tauri/src/autopilot_helpers/mod.rs` (comment documents that lat/lon/radius are NOT persisted on AutopilotTarget; location+country_code are forwarded, future follow-up needed for radius expansion)
+- **IPC contract:** `packages/shared/src/ipc/contracts/boards.ts` (BoardCatalogEntry.supportsLocation)
+
 ## Trust assessment (PR 3, 2026-07-01)
 
 Every finalized `JobPosting` carries a **ghost-job / trust signal** — a pure,

--- a/packages/shared/src/ipc/contracts/boards.ts
+++ b/packages/shared/src/ipc/contracts/boards.ts
@@ -25,6 +25,14 @@ export interface BoardCatalogEntry {
    * if no companies are supplied.
    */
   requiresCompany: boolean;
+  /**
+   * Whether the board narrows results by the requested location server-side.
+   * When `false`, the engine conservatively post-filters this board's results
+   * against the requested location (dropping only clear city mismatches; never
+   * remote/unknown-location rows), so the picker can indicate which boards will
+   * genuinely honor a location. Optional so older/absent payloads read as `false`.
+   */
+  supportsLocation?: boolean;
 }
 
 export interface BoardsContract {
@@ -62,6 +70,10 @@ export interface BoardsContract {
  *     deterministic results.
  *   - `"broadened:<cc>"` — a sparse city search was widened country-wide within
  *     the `<cc>` market.
+ *   - `"location-filtered:<n>"` — this board doesn't honor location server-side
+ *     (`supportsLocation: false`), so the engine conservatively dropped `<n>`
+ *     of its results whose own location clearly mismatched the request; never
+ *     drops remote/unknown-location rows.
  *   `<cc>` is an ISO country code; the field never carries the raw location text.
  */
 export interface BoardScrapeSummary {

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1827,6 +1827,7 @@
       "loginToEnable": "Anmelden zum Aktivieren",
       "loginToEnableHint": "{{board}} erfordert eine Anmeldung — verbinde dein Konto, damit die Suche Ergebnisse liefert."
     },
+    "locationFilterHint": "Ort lokal gefiltert:",
     "companies": {
       "label": "Unternehmen",
       "placeholder": "z. B. stripe, airbnb",
@@ -1849,7 +1850,10 @@
       },
       "note": {
         "broadened": "wenige lokale Treffer — landesweit in {{country}} gesucht",
-        "guessed": "kein Land gesetzt — {{country}} durchsucht"
+        "guessed": "kein Land gesetzt — {{country}} durchsucht",
+        "locationFilteredNone": "Ort lokal gefiltert",
+        "locationFiltered_one": "{{count}} Treffer am falschen Ort ausgeblendet",
+        "locationFiltered_other": "{{count}} Treffer am falschen Ort ausgeblendet"
       }
     },
     "viewList": "Liste",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1823,6 +1823,7 @@
       "loginToEnable": "Sign in to enable",
       "loginToEnableHint": "{{board}} requires a login — connect your account so scraping returns results."
     },
+    "locationFilterHint": "Location filtered locally:",
     "companies": {
       "label": "Companies",
       "placeholder": "e.g. stripe, airbnb",
@@ -1845,7 +1846,10 @@
       },
       "note": {
         "broadened": "few local results — showing {{country}} wide",
-        "guessed": "no country set — searched {{country}}"
+        "guessed": "no country set — searched {{country}}",
+        "locationFilteredNone": "location filtered locally",
+        "locationFiltered_one": "{{count}} off-location result hidden",
+        "locationFiltered_other": "{{count}} off-location results hidden"
       }
     },
     "viewList": "List",


### PR DESCRIPTION
## Summary

PR F of the job-search trust program (audit 2026-07-10) — the one refactor the audit sanctioned: location was a free-text string that 23 boards freelanced over, with 17+ silently ignoring it. Now the app knows which boards honor location, approximates honestly for the rest, and says so. Builds on #597-#601.

## What changed

- **`LocationSpec`** (city/region/country/lat/lon/radius) derives once via an accessor from the geo fields the renderer already sends — zero churn on 54 construction sites, automatic back-compat (no location → everything byte-identical).
- **`Scraper::supports_location()`** — author-verified catalog: only the aggregator (`where` + market routing), LinkedIn (geoId/radius), and Arbeitsagentur (`wo`) consume location server-side; the other 20 boards are honestly flagged `false`, exposed to the renderer as `supportsLocation` on the board catalog.
- **Central conservative filter** (`scraping/engine/location_filter.rs`): for non-supporting boards, drops a posting only on a clear place mismatch — diacritic folding (base + DIN-5007-2) so Muenchen/München/Munchen always match, a curated exonym table (Munich/München, Cologne/Köln, Nuremberg/Nürnberg) with the boundary documented and tested, remote/unknown-location rows always kept. Filtered items are excluded from the item cap (`KeepItemFn` runs before the counter), so boards keep paginating until enough *matching* rows arrive — no silent under-delivery.
- **Nothing reads clean by accident:** every non-supporting board notes `location-filtered:<n>` — including n=0 — whenever a location was requested, rendered as chips ("N off-location results hidden" / "location filtered locally"); the board picker warns up front (`LocationFilterNote` in both the scrape form and the autopilot wizard). A run with location + non-supporting boards deliberately no longer collapses to "all ok".

## Review trail (internal fleet)

- scraping-applier-expert: REQUEST-CHANGES → 2 HIGH fixed (cap/filter ordering — boundary-pinned test; diacritic false-drops — folding + exonym table) → APPROVE
- frontend-reviewer: APPROVE-WITH-FIXES → contrast floor, defaultValue fallback, and the trust-story gap (unconditional n=0 notes) closed
- tauri-security-reviewer: PASS (linear matching — no ReDoS; count-only notes — no PII; zero new IPC/dep surface)
- pr-reviewer ×2: opus PASS (verified all 23 boards stream==return, so the kept-set path can't zero out results); sonnet PASS 1🟡 → integration render tests added

## Test plan

- CI runs the Rust suite (host fault blocks local cargo test; fmt/check/clippy clean incl. all test targets). Desktop vitest 2194/2194 locally; typecheck + gen:ipc:check clean.
- Manual: scrape "München" with a mixed board set → non-supporting boards show the location chip; a Munich-titled posting from a DE feed survives; picker shows the local-filter hint before scraping.

Part 6/8 of the trust program — next: PR G (board hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)