### PR TITLE
fix: live-verified board hygiene with honest failure reasons

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/bamboohr/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/bamboohr/mod.rs
@@ -5,9 +5,12 @@
 //! board with `"needs-company"` when `input.companies` is empty.
 //!
 //! Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/bamboohr.mjs`.
+//! Live-verified 2026-07-11 against slug `fivetran` (4 jobs): response is
+//! `{meta, result[{id (string), jobOpeningName, location{city, state (string)},
+//! isRemote}]}` — shape confirmed, no drift.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{ats_all_fetches_failed, is_valid_dns_label_slug, normalize_companies};
+use super::common::{ats_board_failure, is_valid_dns_label_slug, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -162,6 +165,7 @@ impl Scraper for BambooHrScraper {
         let total = companies.len();
 
         let mut successful_fetches = 0usize;
+        let mut rejected_slugs = 0usize;
         let mut first_fetch_error: Option<String> = None;
 
         for (i, raw_company) in companies.iter().enumerate() {
@@ -175,6 +179,7 @@ impl Scraper for BambooHrScraper {
             // A slug like `127.0.0.1:8443/foo` would change the URL authority
             // and redirect the fetch away from BambooHR (SSRF).
             if !is_valid_dns_label_slug(&company) {
+                rejected_slugs += 1;
                 log::warn!("[bamboohr] skipping invalid company slug '{}'", company);
                 if let Some(ref on_progress) = ctx.on_progress {
                     on_progress((i + 1) as f32 / total as f32);
@@ -220,10 +225,21 @@ impl Scraper for BambooHrScraper {
             }
         }
 
-        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
-        if let Some(message) =
-            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
-        {
+        // A cancel that fired after an invalid slug was rejected (but before a
+        // later valid slug was reached) must not be misattributed as "all slugs
+        // invalid" — the run was interrupted, not misconfigured.
+        if ctx.signal.is_cancelled() {
+            return Ok(out);
+        }
+
+        // Err when every attempt failed OR every slug was rejected pre-fetch —
+        // see `ats_board_failure`.
+        if let Some(message) = ats_board_failure(
+            self.id(),
+            successful_fetches,
+            rejected_slugs,
+            &first_fetch_error,
+        ) {
             return Err(anyhow::anyhow!(message));
         }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/bamboohr/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/bamboohr/mod.rs
@@ -10,7 +10,7 @@
 //! isRemote}]}` — shape confirmed, no drift.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{ats_board_failure, is_valid_dns_label_slug, normalize_companies};
+use super::common::{ats_finish_search, is_valid_dns_label_slug, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -225,25 +225,16 @@ impl Scraper for BambooHrScraper {
             }
         }
 
-        // A cancel that fired after an invalid slug was rejected (but before a
-        // later valid slug was reached) must not be misattributed as "all slugs
-        // invalid" — the run was interrupted, not misconfigured.
-        if ctx.signal.is_cancelled() {
-            return Ok(out);
-        }
-
-        // Err when every attempt failed OR every slug was rejected pre-fetch —
-        // see `ats_board_failure`.
-        if let Some(message) = ats_board_failure(
+        // See `ats_finish_search`: cancellation wins over a synthesized
+        // all-fetches-failed/all-slugs-invalid board error.
+        ats_finish_search(
+            &ctx.signal,
+            out,
             self.id(),
             successful_fetches,
             rejected_slugs,
             &first_fetch_error,
-        ) {
-            return Err(anyhow::anyhow!(message));
-        }
-
-        Ok(out)
+        )
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/bamboohr/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/bamboohr/test.rs
@@ -230,19 +230,19 @@ async fn empty_companies_returns_empty_without_network() {
     );
 }
 
+/// An all-invalid-slug run rejects every slug pre-fetch (no network — the SSRF
+/// guard) and now surfaces a distinct board error instead of a silent zero
+/// (claude review #597).
 #[tokio::test]
-async fn invalid_slug_skipped_without_network() {
+async fn all_invalid_slugs_error_without_network() {
     let scraper = BambooHrScraper;
     let result = scraper
         .search(make_input(vec!["dotted.host".to_string()]), make_ctx())
         .await;
+    let err = result.expect_err("an all-invalid-slug run must be a board error, not a silent zero");
     assert!(
-        result.is_ok(),
-        "search must return Ok even for invalid slug"
-    );
-    assert!(
-        result.unwrap().is_empty(),
-        "invalid slug must produce empty result (skipped, no network)"
+        err.to_string().contains("slug(s) invalid"),
+        "error must name the invalid-slug reason, got: {err}"
     );
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/breezy/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/breezy/mod.rs
@@ -16,7 +16,7 @@
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
 use super::common::{
-    ats_board_failure, is_https_url, is_valid_dns_label_slug, normalize_companies,
+    ats_finish_search, is_https_url, is_valid_dns_label_slug, normalize_companies,
 };
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -274,10 +274,28 @@ impl Scraper for BreezyScraper {
                 }
             };
 
-            // A non-2xx / schema-drift response is now an `Err` above (which records
-            // `first_fetch_error`), so reaching here means a real success — count it.
-            successful_fetches += 1;
+            // A non-2xx response is now an `Err` above (which records
+            // `first_fetch_error`). A 200 where EVERY row fails to deserialize is
+            // schema drift too — the exact failure class the `location.state`
+            // object drift caused before `rows_to_jobs` existed — so treat that
+            // as a fetch failure rather than a silent success-with-zero-jobs
+            // (round-2 review finding).
+            let raw_row_count = data.len();
             let postings = rows_to_jobs(data);
+            if raw_row_count > 0 && postings.is_empty() {
+                log::warn!(
+                    "[breezy] all {raw_row_count} rows failed to parse for '{}'; treating as a fetch failure",
+                    company
+                );
+                first_fetch_error.get_or_insert_with(|| {
+                    format!("all {raw_row_count} rows failed to parse — response shape may have changed")
+                });
+                if let Some(ref on_progress) = ctx.on_progress {
+                    on_progress((i + 1) as f32 / total as f32);
+                }
+                continue;
+            }
+            successful_fetches += 1;
 
             for posting in parse_breezy_response(postings, &company, now) {
                 if let Some(ref on_item) = ctx.on_item {
@@ -291,25 +309,16 @@ impl Scraper for BreezyScraper {
             }
         }
 
-        // A cancel that fired after an invalid slug was rejected (but before a
-        // later valid slug was reached) must not be misattributed as "all slugs
-        // invalid" — the run was interrupted, not misconfigured.
-        if ctx.signal.is_cancelled() {
-            return Ok(out);
-        }
-
-        // Err when every attempt failed OR every slug was rejected pre-fetch —
-        // see `ats_board_failure`.
-        if let Some(message) = ats_board_failure(
+        // See `ats_finish_search`: cancellation wins over a synthesized
+        // all-fetches-failed/all-slugs-invalid board error.
+        ats_finish_search(
+            &ctx.signal,
+            out,
             self.id(),
             successful_fetches,
             rejected_slugs,
             &first_fetch_error,
-        ) {
-            return Err(anyhow::anyhow!(message));
-        }
-
-        Ok(out)
+        )
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/breezy/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/breezy/mod.rs
@@ -5,10 +5,18 @@
 //! board with `"needs-company"` when `input.companies` is empty.
 //!
 //! Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/breezy.mjs`.
+//! Live-verified 2026-07-11 against slug `breezy` (3 jobs). DRIFT FOUND + FIXED:
+//! `location.state` is an OBJECT (`{id, name}`) on the live API, not the bare
+//! string the career-ops port assumed — the old atomic `Vec<BzPosting>`
+//! deserialize failed every real tenant's whole payload (silent zero). Now
+//! `BzStateField` tolerates both shapes and rows deserialize per-row via
+//! `rows_to_jobs` (mirrors Rippling/Workable), so one drifted row can't zero the
+//! board. Confirmed present: `name`, `url`, `published_date` (RFC3339),
+//! `location{name, city, state{name}, country{name}, is_remote}`.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
 use super::common::{
-    ats_all_fetches_failed, is_https_url, is_valid_dns_label_slug, normalize_companies,
+    ats_board_failure, is_https_url, is_valid_dns_label_slug, normalize_companies,
 };
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -36,11 +44,32 @@ struct BzCountry {
     name: Option<String>,
 }
 
+/// Breezy's `location.state` is an OBJECT (`{id, name}`) on the live API
+/// (verified 2026-07-11) but a bare string on some tenants/fixtures — accept
+/// both so one shape doesn't fail the row. `Text` (a JSON string) and the object
+/// form are unambiguous under serde's untagged matching (a string can only be
+/// `Text`; an object can only be `Named`).
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum BzStateField {
+    Text(String),
+    Named { name: Option<String> },
+}
+
+impl BzStateField {
+    fn into_name(self) -> Option<String> {
+        match self {
+            BzStateField::Text(s) => Some(s),
+            BzStateField::Named { name } => name,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct BzLocation {
     name: Option<String>,
     city: Option<String>,
-    state: Option<String>,
+    state: Option<BzStateField>,
     country: Option<BzCountry>,
     #[serde(rename = "is_remote")]
     is_remote: Option<bool>,
@@ -53,6 +82,31 @@ pub(crate) struct BzPosting {
     #[serde(rename = "published_date")]
     published_date: Option<String>,
     location: Option<BzLocation>,
+}
+
+/// Deserialize each posting row independently, dropping (with a debug log) any
+/// row that fails to type-check — e.g. a future field-shape drift on one row.
+/// Without this, an atomic `Vec<BzPosting>` deserialize would fail the WHOLE
+/// company on a single malformed row (silent zero-jobs) — which is exactly how
+/// the live `location.state`-as-object shape broke every real tenant before this
+/// PR. Mirrors Rippling's/Workable's `rows_to_jobs`.
+pub(crate) fn rows_to_jobs(values: Vec<serde_json::Value>) -> Vec<BzPosting> {
+    let total = values.len();
+    let jobs: Vec<BzPosting> = values
+        .into_iter()
+        .filter_map(|v| match serde_json::from_value::<BzPosting>(v) {
+            Ok(job) => Some(job),
+            Err(e) => {
+                log::debug!("[breezy] skipping malformed row: {e}");
+                None
+            }
+        })
+        .collect();
+    let skipped = total - jobs.len();
+    if skipped > 0 {
+        log::warn!("[breezy] skipped {skipped}/{total} malformed rows");
+    }
+    jobs
 }
 
 /// Map a parsed Breezy response into postings for one company. Standalone
@@ -89,12 +143,16 @@ pub(crate) fn parse_breezy_response(
             let mut base = match l.name.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
                 Some(name) => name.to_string(),
                 None => {
-                    let parts: Vec<String> = [l.city, l.state, l.country.and_then(|c| c.name)]
-                        .into_iter()
-                        .flatten()
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect();
+                    let parts: Vec<String> = [
+                        l.city,
+                        l.state.and_then(BzStateField::into_name),
+                        l.country.and_then(|c| c.name),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
                     parts.join(", ")
                 }
             };
@@ -166,6 +224,7 @@ impl Scraper for BreezyScraper {
         let total = companies.len();
 
         let mut successful_fetches = 0usize;
+        let mut rejected_slugs = 0usize;
         let mut first_fetch_error: Option<String> = None;
 
         for (i, raw_company) in companies.iter().enumerate() {
@@ -179,6 +238,7 @@ impl Scraper for BreezyScraper {
             // A slug like `127.0.0.1:8443/foo` would change the URL authority
             // and redirect the fetch away from Breezy (SSRF).
             if !is_valid_dns_label_slug(&company) {
+                rejected_slugs += 1;
                 log::warn!("[breezy] skipping invalid company slug '{}'", company);
                 if let Some(ref on_progress) = ctx.on_progress {
                     on_progress((i + 1) as f32 / total as f32);
@@ -188,30 +248,36 @@ impl Scraper for BreezyScraper {
 
             let url = format!("https://{company}.breezy.hr/json");
 
-            let data =
-                match fetch_json::<Vec<BzPosting>>(&url, Default::default(), ctx.signal.clone())
-                    .await
-                {
-                    Ok(d) => d,
-                    Err(e) => {
-                        // Check cancellation first: a fetch that failed because
-                        // the run was cancelled is not a real board-level error.
-                        if ctx.signal.is_cancelled() {
-                            break;
-                        }
-                        log::warn!("[breezy] fetch failed for '{}': {e}", company);
-                        first_fetch_error.get_or_insert_with(|| e.to_string());
-                        if let Some(ref on_progress) = ctx.on_progress {
-                            on_progress((i + 1) as f32 / total as f32);
-                        }
-                        continue;
+            // Fetch as raw rows so `rows_to_jobs` can drop a single drifted row
+            // instead of failing the whole company (see the module doc: the live
+            // `location.state` object shape used to zero every tenant here).
+            let data = match fetch_json::<Vec<serde_json::Value>>(
+                &url,
+                Default::default(),
+                ctx.signal.clone(),
+            )
+            .await
+            {
+                Ok(d) => d,
+                Err(e) => {
+                    // Check cancellation first: a fetch that failed because
+                    // the run was cancelled is not a real board-level error.
+                    if ctx.signal.is_cancelled() {
+                        break;
                     }
-                };
+                    log::warn!("[breezy] fetch failed for '{}': {e}", company);
+                    first_fetch_error.get_or_insert_with(|| e.to_string());
+                    if let Some(ref on_progress) = ctx.on_progress {
+                        on_progress((i + 1) as f32 / total as f32);
+                    }
+                    continue;
+                }
+            };
 
             // A non-2xx / schema-drift response is now an `Err` above (which records
             // `first_fetch_error`), so reaching here means a real success — count it.
             successful_fetches += 1;
-            let postings = data;
+            let postings = rows_to_jobs(data);
 
             for posting in parse_breezy_response(postings, &company, now) {
                 if let Some(ref on_item) = ctx.on_item {
@@ -225,10 +291,21 @@ impl Scraper for BreezyScraper {
             }
         }
 
-        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
-        if let Some(message) =
-            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
-        {
+        // A cancel that fired after an invalid slug was rejected (but before a
+        // later valid slug was reached) must not be misattributed as "all slugs
+        // invalid" — the run was interrupted, not misconfigured.
+        if ctx.signal.is_cancelled() {
+            return Ok(out);
+        }
+
+        // Err when every attempt failed OR every slug was rejected pre-fetch —
+        // see `ats_board_failure`.
+        if let Some(message) = ats_board_failure(
+            self.id(),
+            successful_fetches,
+            rejected_slugs,
+            &first_fetch_error,
+        ) {
             return Err(anyhow::anyhow!(message));
         }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/breezy/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/breezy/test.rs
@@ -238,19 +238,19 @@ async fn empty_companies_returns_empty_without_network() {
     );
 }
 
+/// An all-invalid-slug run rejects every slug pre-fetch (no network — the SSRF
+/// guard) and now surfaces a distinct board error instead of a silent zero
+/// (claude review #597).
 #[tokio::test]
-async fn invalid_slug_skipped_without_network() {
+async fn all_invalid_slugs_error_without_network() {
     let scraper = BreezyScraper;
     let result = scraper
         .search(make_input(vec!["dotted.host".to_string()]), make_ctx())
         .await;
+    let err = result.expect_err("an all-invalid-slug run must be a board error, not a silent zero");
     assert!(
-        result.is_ok(),
-        "search must return Ok even for invalid slug"
-    );
-    assert!(
-        result.unwrap().is_empty(),
-        "invalid slug must produce empty result (skipped, no network)"
+        err.to_string().contains("slug(s) invalid"),
+        "error must name the invalid-slug reason, got: {err}"
     );
 }
 
@@ -267,6 +267,40 @@ async fn cancelled_before_fetch_returns_ok_not_err() {
     assert!(
         result.is_ok(),
         "cancelled run must return Ok, not Err — cancellation must not be recorded as first_fetch_error"
+    );
+}
+
+/// Pins the exact scenario a HIGH-severity review finding raised: a cancel
+/// firing AFTER an invalid slug is rejected but BEFORE a later valid slug is
+/// reached must not be misattributed as "all slugs invalid" (a benign
+/// cancellation, blamed on the user's company-name config). Uses the
+/// `on_progress` callback the reject branch already calls as the timing seam —
+/// the closure cancels the token the instant the first (invalid) slug is
+/// rejected; the second (valid-shaped) slug is never reached because the
+/// loop's top-of-iteration cancellation check breaks first.
+#[tokio::test]
+async fn cancel_after_reject_before_next_slug_returns_ok_not_all_invalid_error() {
+    let scraper = BreezyScraper;
+    let signal = tokio_util::sync::CancellationToken::new();
+    let cancel_on_progress = signal.clone();
+    let ctx = ScrapeContext {
+        signal: signal.clone(),
+        on_progress: Some(Box::new(move |_p: f32| cancel_on_progress.cancel())),
+        on_item: None,
+        on_truncation: None,
+        on_note: None,
+    };
+    let result = scraper
+        .search(
+            make_input(vec!["dotted.host".to_string(), "acme".to_string()]),
+            ctx,
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "a cancel firing right after a reject must return Ok (interrupted), not the \
+         all-slugs-invalid error — got {:?}",
+        result.err()
     );
 }
 
@@ -302,6 +336,73 @@ fn parse_breezy_response_happy_path_with_posted_at() {
         .unwrap()
         .timestamp_millis();
     assert_eq!(p.posted_at, Some(expected_posted_at));
+}
+
+/// Live drift (verified 2026-07-11): `location.state` and `location.country`
+/// arrive as OBJECTS (`{id, name}`), not bare strings. `BzStateField` +
+/// `BzCountry` must accept the object shape so the row deserializes AND the
+/// state/country names still contribute to the composed location string.
+#[test]
+fn parse_breezy_response_accepts_object_state_and_country() {
+    let json = r#"[
+        {
+            "name": "Backend Engineer",
+            "url": "https://acme.breezy.hr/p/obj-state",
+            "published_date": "2024-02-15T14:37:22.684Z",
+            "location": {
+                "name": null,
+                "city": "Sandy Hook",
+                "state": {"id": "CT", "name": "Connecticut"},
+                "country": {"name": "United States", "id": "US"},
+                "is_remote": false
+            }
+        }
+    ]"#;
+    let postings_in: Vec<BzPosting> =
+        serde_json::from_str(json).expect("object-shaped state/country must deserialize");
+    let postings = parse_breezy_response(postings_in, "acme", 0);
+    assert_eq!(postings.len(), 1);
+    assert_eq!(
+        postings[0].location,
+        Some("Sandy Hook, Connecticut, United States".to_string()),
+        "object state/country names must still compose into the location"
+    );
+}
+
+/// A bare-string `state` (older/other tenants) must still deserialize — the
+/// untagged `BzStateField` accepts both shapes.
+#[test]
+fn parse_breezy_response_accepts_string_state() {
+    let json = r#"[
+        {"name": "X", "url": "https://acme.breezy.hr/p/str-state", "published_date": null,
+         "location": {"name": null, "city": "Austin", "state": "TX", "country": null, "is_remote": false}}
+    ]"#;
+    let postings_in: Vec<BzPosting> = serde_json::from_str(json).unwrap();
+    let postings = parse_breezy_response(postings_in, "acme", 0);
+    assert_eq!(postings[0].location, Some("Austin, TX".to_string()));
+}
+
+/// `rows_to_jobs` drops a row that can't deserialize (e.g. a bare string where
+/// an object is required) and keeps the valid rows — one drifted row no longer
+/// zeros the whole company (the exact failure the live object-`state` shape
+/// caused under the old atomic `Vec<BzPosting>` deserialize).
+#[test]
+fn rows_to_jobs_drops_undeserializable_rows_keeps_valid() {
+    let values: Vec<serde_json::Value> = serde_json::from_str(
+        r#"[
+        {"name": "Valid", "url": "https://acme.breezy.hr/p/valid", "published_date": null, "location": null},
+        "not-an-object",
+        {"name": "Object State", "url": "https://acme.breezy.hr/p/obj", "published_date": null,
+         "location": {"state": {"id": "CT", "name": "Connecticut"}}}
+    ]"#,
+    )
+    .unwrap();
+    let jobs = rows_to_jobs(values);
+    assert_eq!(
+        jobs.len(),
+        2,
+        "the bare-string row is dropped; both object rows (incl. object-state) survive"
+    );
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/scraping/boards/breezy/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/breezy/test.rs
@@ -405,6 +405,25 @@ fn rows_to_jobs_drops_undeserializable_rows_keeps_valid() {
     );
 }
 
+/// Round-2 review finding: when EVERY row in a batch fails to deserialize
+/// (not just a stray one), `rows_to_jobs` must still return an empty `Vec` —
+/// this is the exact signal `search()` uses (`raw_row_count > 0 &&
+/// rows_to_jobs(..).is_empty()`) to treat the company as a FETCH FAILURE
+/// (recorded into `first_fetch_error`) instead of a silent success-with-zero
+/// — the same failure class the `location.state` object drift caused before
+/// `rows_to_jobs` existed, but now for a retype `rows_to_jobs` also can't
+/// parse at all.
+#[test]
+fn rows_to_jobs_all_rows_undeserializable_returns_empty() {
+    let values: Vec<serde_json::Value> =
+        serde_json::from_str(r#"["not-an-object", 42, null, ["also", "not", "valid"]]"#).unwrap();
+    let jobs = rows_to_jobs(values);
+    assert!(
+        jobs.is_empty(),
+        "every row failing to deserialize must yield an empty Vec (the all-drift signal)"
+    );
+}
+
 #[test]
 fn parse_breezy_response_accepts_bare_date_published_date() {
     let json = r#"[

--- a/apps/desktop/src-tauri/src/scraping/boards/comeet/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/comeet/mod.rs
@@ -15,6 +15,13 @@
 //! live-verification with a real company UID + token via the Settings UI
 //! (Pass 3). `CmPosition::company_name` below is a further speculative guess
 //! not in that field spec at all — see its own doc comment.
+//!
+//! Trust PR G (2026-07-11): because the shape is still unverified and the live
+//! endpoint 400s without credentials, Comeet is HIDDEN from the user-facing jobs
+//! picker/catalog via `listed() → false` — it stays registered and dispatchable
+//! (so a saved Comeet target still runs and a future live-verification just flips
+//! the flag back), but the app no longer PROMISES a board that can currently only
+//! return a silent zero. Do NOT delete the code.
 use super::super::http::fetch_json;
 use super::super::types::{
     AuthRequirement, BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode,
@@ -182,6 +189,15 @@ impl Scraper for ComeetScraper {
 
     fn mode(&self) -> ScraperMode {
         ScraperMode::Http
+    }
+
+    // Hidden from the manual jobs picker + autopilot board catalog until the
+    // response shape is live-verified (see the module doc). The board stays in
+    // the SCRAPERS registry so it remains dispatchable — a saved Comeet target
+    // still runs — but the picker no longer offers a board that can only return
+    // a silent zero today.
+    fn listed(&self) -> bool {
+        false
     }
 
     // Explicit override (matches the trait default) — mirrors the Aggregator

--- a/apps/desktop/src-tauri/src/scraping/boards/common.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common.rs
@@ -109,6 +109,48 @@ pub(crate) fn ats_all_fetches_failed(
         .map(|error| format!("all {board_id} company fetches failed: {error}"))
 }
 
+/// The distinct board-error message for a run whose every company slug was
+/// rejected by a pre-fetch validator (e.g. [`is_valid_dns_label_slug`]) before
+/// any network call ran. Shared so every ATS board words it identically.
+pub(crate) fn ats_all_slugs_invalid_message(board_id: &str, rejected_slugs: usize) -> String {
+    format!(
+        "all {rejected_slugs} company slug(s) invalid for {board_id} — check the company names in Settings"
+    )
+}
+
+/// Extends [`ats_all_fetches_failed`] to also surface company slugs that a
+/// pre-fetch validation guard rejected before any fetch ran. Those rejects were
+/// previously invisible: a run whose every slug was malformed recorded no
+/// `successful_fetches` AND no `first_fetch_error`, so `ats_all_fetches_failed`
+/// returned `None` and the board reported a silent zero (claude review #597).
+/// Used by the ATS boards that validate slugs up front (BambooHR, Breezy,
+/// Pinpoint, Rippling, Workable).
+///
+/// Decision table (given `successful_fetches`, `rejected_slugs`, `first_fetch_error`):
+/// - `successful_fetches > 0` → `None` (partial success kept — a rejected or
+///   errored remainder is a per-board log concern, not a whole-board failure);
+/// - else a real fetch error was recorded → the same
+///   `"all {board} company fetches failed: {error}"` message as
+///   [`ats_all_fetches_failed`] (a mix of rejects + fetch errors reports the
+///   fetch error, the more actionable signal);
+/// - else `rejected_slugs > 0` → the distinct
+///   [`ats_all_slugs_invalid_message`] ("all N company slug(s) invalid …");
+/// - else (nothing attempted, nothing rejected) → `None`.
+///
+/// Pure — directly unit-testable without a mock server.
+pub(crate) fn ats_board_failure(
+    board_id: &str,
+    successful_fetches: usize,
+    rejected_slugs: usize,
+    first_fetch_error: &Option<String>,
+) -> Option<String> {
+    if let Some(msg) = ats_all_fetches_failed(board_id, successful_fetches, first_fetch_error) {
+        return Some(msg);
+    }
+    (successful_fetches == 0 && rejected_slugs > 0)
+        .then(|| ats_all_slugs_invalid_message(board_id, rejected_slugs))
+}
+
 /// Decide the pagination-failure policy for a page fetch: a page reached with
 /// nothing collected yet (typically page 0) propagates the fetch failure as a
 /// board error; a later page that fails after some items were already

--- a/apps/desktop/src-tauri/src/scraping/boards/common.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common.rs
@@ -114,7 +114,7 @@ pub(crate) fn ats_all_fetches_failed(
 /// any network call ran. Shared so every ATS board words it identically.
 pub(crate) fn ats_all_slugs_invalid_message(board_id: &str, rejected_slugs: usize) -> String {
     format!(
-        "all {rejected_slugs} company slug(s) invalid for {board_id} — check the company names in Settings"
+        "all {rejected_slugs} company slug(s) invalid for {board_id} — check the company names in the jobs search form"
     )
 }
 
@@ -149,6 +149,43 @@ pub(crate) fn ats_board_failure(
     }
     (successful_fetches == 0 && rejected_slugs > 0)
         .then(|| ats_all_slugs_invalid_message(board_id, rejected_slugs))
+}
+
+/// Finalize an ATS multi-company board's `search()`: cancellation ALWAYS wins
+/// over a synthesized board error. A cancel that fires right after an invalid
+/// slug is rejected — but before a later valid slug is reached — must not be
+/// misattributed as "all slugs invalid" (a benign interruption reported as
+/// user misconfiguration). This priority is easy to get right per board and
+/// easy to silently drop in a copy-paste (it was — see the round-1 review
+/// finding this fixed), so it is centralized here: every board that shares
+/// this finish step gets the priority for free instead of re-deriving it, and
+/// the ONE test on this function pins it for all of them at once.
+///
+/// Shared by every ATS board using the full `ats_board_failure` shape
+/// (BambooHR, Breezy, Pinpoint, Recruitee, Rippling, Workable). Personio
+/// tracks a narrower `(attempted, rejected_slugs)` pair (no
+/// `successful_fetches`/`first_fetch_error` — a tracked follow-up) so it
+/// checks cancellation inline rather than sharing this exact shape.
+pub(crate) fn ats_finish_search(
+    signal: &tokio_util::sync::CancellationToken,
+    out: Vec<crate::scraping::types::JobPosting>,
+    board_id: &str,
+    successful_fetches: usize,
+    rejected_slugs: usize,
+    first_fetch_error: &Option<String>,
+) -> anyhow::Result<Vec<crate::scraping::types::JobPosting>> {
+    if signal.is_cancelled() {
+        return Ok(out);
+    }
+    if let Some(message) = ats_board_failure(
+        board_id,
+        successful_fetches,
+        rejected_slugs,
+        first_fetch_error,
+    ) {
+        return Err(anyhow::anyhow!(message));
+    }
+    Ok(out)
 }
 
 /// Decide the pagination-failure policy for a page fetch: a page reached with

--- a/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
@@ -64,6 +64,46 @@ fn zero_companies_edge_no_error_recorded_returns_none() {
     );
 }
 
+// ── ats_board_failure (rejected-slug surfacing, claude review #597) ───────────
+
+/// Partial success suppresses every failure signal — a rejected or errored
+/// remainder alongside ≥1 success is kept, not turned into a board error.
+#[test]
+fn board_failure_partial_success_returns_none() {
+    assert!(ats_board_failure("breezy", 1, 3, &Some("HTTP 404".into())).is_none());
+    assert!(ats_board_failure("breezy", 2, 0, &None).is_none());
+}
+
+/// Zero successes + a recorded fetch error → the SAME all-fetches-failed message
+/// (the fetch error is the more actionable signal even when slugs were also
+/// rejected).
+#[test]
+fn board_failure_fetch_error_beats_rejects() {
+    assert_eq!(
+        ats_board_failure("pinpoint", 0, 2, &Some("HTTP 403".into())).as_deref(),
+        Some("all pinpoint company fetches failed: HTTP 403"),
+    );
+}
+
+/// Zero successes, NO fetch error, but every slug was rejected pre-fetch → the
+/// distinct all-slugs-invalid error (this is the #597 silent-zero fix).
+#[test]
+fn board_failure_all_slugs_rejected_returns_distinct_error() {
+    let msg = ats_board_failure("rippling", 0, 3, &None).expect("all-rejected must error");
+    assert_eq!(
+        msg,
+        "all 3 company slug(s) invalid for rippling — check the company names in Settings",
+    );
+    assert_eq!(msg, ats_all_slugs_invalid_message("rippling", 3));
+}
+
+/// Nothing attempted and nothing rejected (e.g. the incoming list was empty
+/// after normalisation) → not a board failure.
+#[test]
+fn board_failure_nothing_attempted_returns_none() {
+    assert!(ats_board_failure("bamboohr", 0, 0, &None).is_none());
+}
+
 // ── should_propagate_page_error ──────────────────────────────────────────────
 
 #[test]

--- a/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
@@ -92,9 +92,62 @@ fn board_failure_all_slugs_rejected_returns_distinct_error() {
     let msg = ats_board_failure("rippling", 0, 3, &None).expect("all-rejected must error");
     assert_eq!(
         msg,
-        "all 3 company slug(s) invalid for rippling — check the company names in Settings",
+        "all 3 company slug(s) invalid for rippling — check the company names in the jobs search form",
     );
     assert_eq!(msg, ats_all_slugs_invalid_message("rippling", 3));
+}
+
+// ── ats_finish_search (cancellation-priority fix, round-2 review) ────────────
+//
+// The shared finish step for the 6 boards using the full `ats_board_failure`
+// shape. Pinned here ONCE so every board that calls it inherits the same
+// cancellation-wins-over-synthesized-error priority instead of a per-board
+// copy that can silently drop the guard (as happened in round 1).
+
+#[test]
+fn finish_search_cancelled_returns_ok_even_when_all_slugs_rejected() {
+    // The exact round-1 regression: a cancel that fired after every slug was
+    // rejected (no successes, no fetch error) must return the collected `out`
+    // as-is, NOT the all-slugs-invalid error — a benign interruption is not a
+    // board misconfiguration.
+    let signal = tokio_util::sync::CancellationToken::new();
+    signal.cancel();
+    let result = ats_finish_search(&signal, vec![], "breezy", 0, 3, &None);
+    assert!(
+        result.is_ok(),
+        "cancellation must win over the all-slugs-invalid synthesis, got {result:?}"
+    );
+    assert!(result.unwrap().is_empty());
+}
+
+#[test]
+fn finish_search_cancelled_returns_ok_even_when_all_fetches_failed() {
+    // Same priority for the other `ats_board_failure` branch: a cancel must
+    // suppress the all-fetches-failed error too.
+    let signal = tokio_util::sync::CancellationToken::new();
+    signal.cancel();
+    let result = ats_finish_search(
+        &signal,
+        vec![],
+        "rippling",
+        0,
+        0,
+        &Some("HTTP 403".to_string()),
+    );
+    assert!(result.is_ok(), "cancellation must win, got {result:?}");
+}
+
+#[test]
+fn finish_search_not_cancelled_surfaces_ats_board_failure_as_before() {
+    // Without cancellation, behavior is unchanged: delegates straight to
+    // `ats_board_failure`.
+    let signal = tokio_util::sync::CancellationToken::new();
+    let err = ats_finish_search(&signal, vec![], "pinpoint", 0, 2, &None)
+        .expect_err("uncancelled all-rejected run must still error");
+    assert!(err.to_string().contains("slug(s) invalid"));
+
+    let ok = ats_finish_search(&signal, vec![], "pinpoint", 1, 0, &None);
+    assert!(ok.is_ok(), "a successful fetch must still keep Ok");
 }
 
 /// Nothing attempted and nothing rejected (e.g. the incoming list was empty

--- a/apps/desktop/src-tauri/src/scraping/boards/linkedin/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/linkedin/mod.rs
@@ -4,14 +4,108 @@ use crate::scraping::types::BoardSearchInput;
 use crate::scraping::types::{JobPosting, ScrapeContext, Scraper};
 use anyhow::Result;
 use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 
 pub struct LinkedInScraper;
 
-/// Best-effort LinkedIn geoId lookup via the public jobs-guest typeahead.
+/// In-process cache of resolved geoIds, keyed by `(lowercased location query,
+/// lowercased country code)`. LinkedIn geoIds are stable, so caching successful
+/// resolutions avoids re-hitting the typeahead endpoint for repeated searches in
+/// the same session (e.g. every autopilot run for the same target). Only
+/// successful resolutions are cached — a transient network failure is left
+/// uncached so the next search retries. Bounded in practice by the small number
+/// of distinct (location, country) pairs a user searches.
+static GEO_ID_CACHE: LazyLock<Mutex<HashMap<(String, String), String>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// English country-name aliases used to bias typeahead selection toward the
+/// requested ISO alpha-2 country. LinkedIn's typeahead `displayName` ends with
+/// the English country name (e.g. "Berlin, Germany" vs "Berlin, Connecticut,
+/// United States"), and blindly taking the first hit leaks the search into the
+/// wrong country (#49). Covers the markets the app searches; an unlisted code
+/// returns `None`, so selection falls back to the first hit (no regression).
+fn country_aliases(cc: &str) -> Option<&'static [&'static str]> {
+    Some(match cc {
+        "de" => &["germany"],
+        "at" => &["austria"],
+        "ch" => &["switzerland"],
+        "be" => &["belgium"],
+        "gb" | "uk" => &["united kingdom"],
+        "ie" => &["ireland"],
+        "us" => &["united states"],
+        "ca" => &["canada"],
+        "fr" => &["france"],
+        "nl" => &["netherlands"],
+        "es" => &["spain"],
+        "it" => &["italy"],
+        "pl" => &["poland"],
+        "pt" => &["portugal"],
+        "se" => &["sweden"],
+        "au" => &["australia"],
+        "nz" => &["new zealand"],
+        "in" => &["india"],
+        "sg" => &["singapore"],
+        "br" => &["brazil"],
+        "mx" => &["mexico"],
+        "za" => &["south africa"],
+        _ => return None,
+    })
+}
+
+/// Extract a geoId string from one typeahead hit's `id` (number or string).
+fn hit_geo_id(hit: &serde_json::Value) -> Option<String> {
+    match hit.get("id")? {
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::String(s) => (!s.is_empty()).then(|| s.clone()),
+        _ => None,
+    }
+}
+
+/// Pick a geoId from the typeahead hits, biased toward `country_code` when set.
+/// When a country_code maps to known name aliases AND some hit's `displayName`
+/// matches that country, the FIRST such hit wins; otherwise (no country_code, an
+/// unlisted code, or no hit matches) fall back to the first usable hit — the
+/// prior behaviour, so this never regresses a resolvable location. Pure +
+/// unit-testable (no network).
+fn select_geo_id(hits: &[serde_json::Value], country_code: Option<&str>) -> Option<String> {
+    if let Some(aliases) = country_code
+        .map(str::to_lowercase)
+        .filter(|s| !s.is_empty())
+        .and_then(|cc| country_aliases(&cc))
+    {
+        let biased = hits.iter().find(|h| {
+            hit_geo_id(h).is_some()
+                && h.get("displayName")
+                    .and_then(|v| v.as_str())
+                    .map(|dn| {
+                        let dn = dn.to_lowercase();
+                        aliases.iter().any(|a| dn.contains(a))
+                    })
+                    .unwrap_or(false)
+        });
+        if let Some(hit) = biased {
+            return hit_geo_id(hit);
+        }
+    }
+    hits.iter().find_map(hit_geo_id)
+}
+
+/// Best-effort LinkedIn geoId lookup via the public jobs-guest typeahead,
+/// biased toward `country_code` and cached in-process (see `GEO_ID_CACHE`).
 /// Returns `None` on any failure so callers fall back to the free-text location
 /// filter (no regression). The endpoint is unofficial — verify behaviour with a
-/// real scrape after changing this.
-async fn resolve_geo_id(location: &str) -> Option<String> {
+/// real scrape after changing this (live-verified 2026-07-11: returns a
+/// `text/plain` JSON array of `{id, displayName, …}`, several hits per query).
+async fn resolve_geo_id(location: &str, country_code: Option<&str>) -> Option<String> {
+    let key = (
+        location.trim().to_lowercase(),
+        country_code.unwrap_or_default().to_lowercase(),
+    );
+    if let Some(cached) = GEO_ID_CACHE.lock().ok().and_then(|c| c.get(&key).cloned()) {
+        return Some(cached);
+    }
+
     let url = format!(
         "https://www.linkedin.com/jobs-guest/api/typeaheadHits?typeaheadType=GEO&query={}",
         urlencoding::encode(location)
@@ -27,12 +121,12 @@ async fn resolve_geo_id(location: &str) -> Option<String> {
         .await
         .ok()?;
     let hits: Vec<serde_json::Value> = resp.json().await.ok()?;
-    let geo = match hits.first()?.get("id")? {
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::String(s) => s.clone(),
-        _ => return None,
-    };
-    (!geo.is_empty()).then_some(geo)
+    let geo = select_geo_id(&hits, country_code)?;
+
+    if let Ok(mut cache) = GEO_ID_CACHE.lock() {
+        cache.insert(key, geo.clone());
+    }
+    Some(geo)
 }
 
 #[async_trait]
@@ -74,10 +168,13 @@ impl Scraper for LinkedInScraper {
         let http_client = LinkedInHttpClient::new(session_data)?;
         let api_client = LinkedInJobsApiClient::new(http_client);
 
-        // Resolve a precise geoId for the location (best-effort). On failure we
-        // fall back to the free-text `location` filter below (no regression, #49).
+        // Resolve a precise geoId for the location (best-effort, country-biased,
+        // cached). On failure we fall back to the free-text `location` filter
+        // below (no regression, #49).
         let geo_id = match input.location.as_deref() {
-            Some(loc) if !loc.trim().is_empty() => resolve_geo_id(loc).await,
+            Some(loc) if !loc.trim().is_empty() => {
+                resolve_geo_id(loc, input.country_code.as_deref()).await
+            }
             _ => None,
         };
 

--- a/apps/desktop/src-tauri/src/scraping/boards/linkedin/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/linkedin/mod.rs
@@ -79,8 +79,13 @@ fn select_geo_id(hits: &[serde_json::Value], country_code: Option<&str>) -> Opti
                 && h.get("displayName")
                     .and_then(|v| v.as_str())
                     .map(|dn| {
-                        let dn = dn.to_lowercase();
-                        aliases.iter().any(|a| dn.contains(a))
+                        // Anchor to the TRAILING segment, not a substring anywhere —
+                        // `displayName` ends with the English country name, so
+                        // `contains` false-positived on "India" matching "Indiana,
+                        // United States" and "Ireland" matching "Northern Ireland,
+                        // United Kingdom".
+                        let dn = dn.trim().to_lowercase();
+                        aliases.iter().any(|a| dn.ends_with(a))
                     })
                     .unwrap_or(false)
         });

--- a/apps/desktop/src-tauri/src/scraping/boards/linkedin/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/linkedin/test.rs
@@ -73,6 +73,40 @@ fn select_geo_id_biases_to_requested_country() {
     );
 }
 
+/// PR #603 review: matching must anchor to the TRAILING country segment
+/// (`ends_with`), not a substring anywhere (`contains`) — "india" is a
+/// substring of "Indiana, United States" and "ireland" is a substring of
+/// "Northern Ireland, United Kingdom", so a naive `contains` false-positives
+/// an `in`/`ie` search onto the wrong hit.
+#[test]
+fn select_geo_id_does_not_substring_match_country_name_inside_a_place_name() {
+    let hits: Vec<serde_json::Value> = serde_json::from_str(
+        r#"[
+        {"id": "1", "displayName": "Indianapolis, Indiana, United States"},
+        {"id": "2", "displayName": "Mumbai, India"}
+    ]"#,
+    )
+    .unwrap();
+    assert_eq!(
+        select_geo_id(&hits, Some("in")).as_deref(),
+        Some("2"),
+        "'in' must pick the real India hit, not fall for 'Indiana' containing 'india'"
+    );
+
+    let hits: Vec<serde_json::Value> = serde_json::from_str(
+        r#"[
+        {"id": "3", "displayName": "Belfast, Northern Ireland, United Kingdom"},
+        {"id": "4", "displayName": "Dublin, Ireland"}
+    ]"#,
+    )
+    .unwrap();
+    assert_eq!(
+        select_geo_id(&hits, Some("ie")).as_deref(),
+        Some("4"),
+        "'ie' must pick the real Ireland hit, not fall for 'Northern Ireland' containing 'ireland'"
+    );
+}
+
 /// No country, an unlisted code, or no matching displayName all fall back to the
 /// first usable hit — the prior behaviour, so a resolvable location never regresses.
 #[test]

--- a/apps/desktop/src-tauri/src/scraping/boards/linkedin/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/linkedin/test.rs
@@ -26,6 +26,85 @@ fn test_linkedin_scraper_mode_partial_eq() {
     assert_ne!(mode, crate::scraping::types::ScraperMode::Browser);
 }
 
+// ── country-biased geoId selection (trust PR G, #49) ─────────────────────────
+
+#[test]
+fn country_aliases_known_and_unknown() {
+    assert!(country_aliases("de").is_some());
+    assert!(
+        country_aliases("uk").is_some(),
+        "uk must alias united kingdom"
+    );
+    assert!(
+        country_aliases("gb").is_some(),
+        "gb must alias united kingdom"
+    );
+    assert!(
+        country_aliases("be").is_some(),
+        "be must alias belgium (Adzuna allowlist parity)"
+    );
+    assert!(
+        country_aliases("za").is_some(),
+        "za must alias south africa (Adzuna allowlist parity)"
+    );
+    assert!(country_aliases("zz").is_none(), "unknown code → no bias");
+    assert!(country_aliases("").is_none(), "empty code → no bias");
+}
+
+/// The whole point of #49: "Berlin" typeaheads to Germany first AND a US
+/// "Berlin"; a `us` search must pick the US hit, a `de` search the German one —
+/// not blindly the first hit.
+#[test]
+fn select_geo_id_biases_to_requested_country() {
+    let hits: Vec<serde_json::Value> = serde_json::from_str(
+        r#"[
+        {"id": "103035651", "displayName": "Berlin, Germany"},
+        {"id": "105506608", "displayName": "Berlin, Connecticut, United States"}
+    ]"#,
+    )
+    .unwrap();
+    assert_eq!(
+        select_geo_id(&hits, Some("us")).as_deref(),
+        Some("105506608")
+    );
+    assert_eq!(
+        select_geo_id(&hits, Some("de")).as_deref(),
+        Some("103035651")
+    );
+}
+
+/// No country, an unlisted code, or no matching displayName all fall back to the
+/// first usable hit — the prior behaviour, so a resolvable location never regresses.
+#[test]
+fn select_geo_id_falls_back_to_first_hit() {
+    let hits: Vec<serde_json::Value> = serde_json::from_str(
+        r#"[
+        {"id": "111", "displayName": "Somewhere, Nowhereland"},
+        {"id": "222", "displayName": "Elsewhere, Germany"}
+    ]"#,
+    )
+    .unwrap();
+    assert_eq!(select_geo_id(&hits, None).as_deref(), Some("111"));
+    assert_eq!(
+        select_geo_id(&hits, Some("fr")).as_deref(),
+        Some("111"),
+        "a country with no matching hit falls back to the first hit"
+    );
+    assert_eq!(select_geo_id(&hits, Some("")).as_deref(), Some("111"));
+}
+
+/// A numeric `id` (LinkedIn returns both) must resolve; empty hits → None.
+#[test]
+fn select_geo_id_numeric_id_and_empty() {
+    let hits: Vec<serde_json::Value> =
+        serde_json::from_str(r#"[{"id": 103035651, "displayName": "Berlin, Germany"}]"#).unwrap();
+    assert_eq!(
+        select_geo_id(&hits, Some("de")).as_deref(),
+        Some("103035651")
+    );
+    assert!(select_geo_id(&[], Some("de")).is_none());
+}
+
 #[tokio::test]
 #[ignore = "live network"]
 async fn live_search_returns_results() {

--- a/apps/desktop/src-tauri/src/scraping/boards/personio/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/personio/mod.rs
@@ -5,6 +5,7 @@
 /// board with `"needs-company"` when `input.companies` is empty.
 use super::super::http::{fetch_text, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
+use super::common::ats_all_slugs_invalid_message;
 use async_trait::async_trait;
 
 const HOSTS: &[&str] = &["jobs.personio.de", "jobs.personio.com"];
@@ -148,6 +149,11 @@ impl Scraper for PersonioScraper {
         let now = chrono::Utc::now().timestamp_millis();
         let mut out = vec![];
         let total = input.companies.len();
+        // #597: count slugs rejected by the SSRF guard vs. those that reached a
+        // fetch, so an all-invalid-slug run surfaces a distinct board error
+        // instead of a silent zero (see the all-rejected check after the loop).
+        let mut rejected_slugs = 0usize;
+        let mut attempted = 0usize;
 
         for (i, raw_company) in input.companies.iter().enumerate() {
             if ctx.signal.is_cancelled() {
@@ -163,12 +169,14 @@ impl Scraper for PersonioScraper {
             // A slug like `127.0.0.1:8443/foo` would change the URL authority and
             // redirect the fetch away from Personio (SSRF).
             if !is_valid_personio_slug(&company) {
+                rejected_slugs += 1;
                 log::warn!("[personio] skipping invalid company slug '{}'", company);
                 if let Some(ref on_progress) = ctx.on_progress {
                     on_progress((i + 1) as f32 / total as f32);
                 }
                 continue;
             }
+            attempted += 1;
 
             let mut xml_and_host: Option<(String, String)> = None;
             for &host in HOSTS {
@@ -253,6 +261,24 @@ impl Scraper for PersonioScraper {
             if let Some(ref on_progress) = ctx.on_progress {
                 on_progress((i + 1) as f32 / total as f32);
             }
+        }
+
+        // A cancel that fired after an invalid slug was rejected (but before a
+        // later valid slug was reached) must not be misattributed as "all slugs
+        // invalid" — the run was interrupted, not misconfigured.
+        if ctx.signal.is_cancelled() {
+            return Ok(out);
+        }
+
+        // #597: every non-blank slug was rejected pre-fetch (no fetch ran) — a
+        // silent zero otherwise. A run where at least one slug WAS fetched keeps
+        // its (possibly empty) result: a well-formed but wrong slug is not a
+        // validation error. Mirrors the ATS boards' `ats_board_failure` reject branch.
+        if attempted == 0 && rejected_slugs > 0 {
+            return Err(anyhow::anyhow!(ats_all_slugs_invalid_message(
+                self.id(),
+                rejected_slugs
+            )));
         }
 
         Ok(out)

--- a/apps/desktop/src-tauri/src/scraping/boards/personio/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/personio/test.rs
@@ -80,6 +80,52 @@ async fn all_invalid_slugs_error_without_network() {
     }
 }
 
+/// Personio keeps its own inline cancellation guard (narrower `(attempted,
+/// rejected_slugs)` shape than the shared `ats_finish_search` the other 6 ATS
+/// boards use — see the common.rs doc). Pins the same round-1 regression for
+/// this board specifically: a cancel firing right after an invalid slug is
+/// rejected (via the `on_progress` callback the reject branch already calls)
+/// must return `Ok`, not the all-slugs-invalid error.
+#[tokio::test]
+async fn cancel_after_reject_before_next_slug_returns_ok_not_all_invalid_error() {
+    let scraper = PersonioScraper;
+    let signal = tokio_util::sync::CancellationToken::new();
+    let cancel_on_progress = signal.clone();
+    let ctx = ScrapeContext {
+        signal: signal.clone(),
+        on_progress: Some(Box::new(move |_p: f32| cancel_on_progress.cancel())),
+        on_item: None,
+        on_truncation: None,
+        on_note: None,
+    };
+    let input = BoardSearchInput {
+        query: String::new(),
+        location: None,
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: vec!["dotted.host".to_string(), "clark".to_string()],
+    };
+    let result = scraper.search(input, ctx).await;
+    assert!(
+        result.is_ok(),
+        "a cancel firing right after a reject must return Ok (interrupted), not the \
+         all-slugs-invalid error — got {:?}",
+        result.err()
+    );
+}
+
 // ── ID namespacing — cross-tenant collision prevention ────────────────────────
 
 /// Two companies returning the same raw position ID must produce distinct

--- a/apps/desktop/src-tauri/src/scraping/boards/personio/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/personio/test.rs
@@ -32,10 +32,11 @@ fn slug_validation_rejects_ssrf_slugs() {
     assert!(!is_valid_personio_slug(&"a".repeat(64)));
 }
 
-/// An invalid slug must be skipped without any network request — the search
-/// returns Ok([]) immediately.
+/// An invalid slug must be rejected without any network request (SSRF guard).
+/// A run where EVERY slug is rejected now surfaces a distinct board error
+/// instead of a silent zero (claude review #597).
 #[tokio::test]
-async fn invalid_slug_skipped_without_network() {
+async fn all_invalid_slugs_error_without_network() {
     let scraper = PersonioScraper;
 
     let make_input = |companies: Vec<String>| BoardSearchInput {
@@ -65,32 +66,18 @@ async fn invalid_slug_skipped_without_network() {
         on_note: None,
     };
 
-    // IP:port — the primary SSRF vector.
-    let result = scraper
-        .search(make_input(vec!["127.0.0.1:8443".to_string()]), make_ctx())
-        .await;
-    assert!(result.is_ok(), "invalid slug must return Ok");
-    assert!(
-        result.unwrap().is_empty(),
-        "SSRF slug must produce empty result (skipped, no network)"
-    );
-
-    // Dotted host.
-    let result = scraper
-        .search(make_input(vec!["dotted.host".to_string()]), make_ctx())
-        .await;
-    assert!(result.is_ok());
-    assert!(result.unwrap().is_empty(), "dotted slug must be skipped");
-
-    // Path injection.
-    let result = scraper
-        .search(make_input(vec!["127.0.0.1/foo".to_string()]), make_ctx())
-        .await;
-    assert!(result.is_ok());
-    assert!(
-        result.unwrap().is_empty(),
-        "path-injection slug must be skipped"
-    );
+    // Each all-invalid-slug run rejects pre-fetch (no network) AND now returns a
+    // distinct board error rather than a silent empty result.
+    for slug in ["127.0.0.1:8443", "dotted.host", "127.0.0.1/foo"] {
+        let err = scraper
+            .search(make_input(vec![slug.to_string()]), make_ctx())
+            .await
+            .expect_err("an all-invalid-slug run must be a board error, not a silent zero");
+        assert!(
+            err.to_string().contains("slug(s) invalid"),
+            "error for '{slug}' must name the invalid-slug reason, got: {err}"
+        );
+    }
 }
 
 // ── ID namespacing — cross-tenant collision prevention ────────────────────────

--- a/apps/desktop/src-tauri/src/scraping/boards/pinpoint/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/pinpoint/mod.rs
@@ -5,10 +5,17 @@
 //! board with `"needs-company"` when `input.companies` is empty.
 //!
 //! Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/pinpoint.mjs`.
+//! Live-verification attempted 2026-07-11: every probed slug returned HTTP 404
+//! (no public customer slug found — Pinpoint tenants use bespoke subdomains), so
+//! the response shape stays reconnaissance-ported, NOT live-confirmed. This is
+//! low-risk: a wrong slug 404s (surfaced as a board fetch error via PR A), an
+//! all-invalid-slug run surfaces the `ats_board_failure` all-slugs-invalid error,
+//! and a drifted-but-200 shape fails `fetch_json`'s parse (also a board error) —
+//! no silent zero in any case.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
 use super::common::{
-    ats_all_fetches_failed, is_https_url, is_valid_dns_label_slug, normalize_companies,
+    ats_board_failure, is_https_url, is_valid_dns_label_slug, normalize_companies,
 };
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -137,6 +144,7 @@ impl Scraper for PinpointScraper {
         let total = companies.len();
 
         let mut successful_fetches = 0usize;
+        let mut rejected_slugs = 0usize;
         let mut first_fetch_error: Option<String> = None;
 
         for (i, raw_company) in companies.iter().enumerate() {
@@ -150,6 +158,7 @@ impl Scraper for PinpointScraper {
             // A slug like `127.0.0.1:8443/foo` would change the URL authority
             // and redirect the fetch away from Pinpoint (SSRF).
             if !is_valid_dns_label_slug(&company) {
+                rejected_slugs += 1;
                 log::warn!("[pinpoint] skipping invalid company slug '{}'", company);
                 if let Some(ref on_progress) = ctx.on_progress {
                     on_progress((i + 1) as f32 / total as f32);
@@ -195,10 +204,21 @@ impl Scraper for PinpointScraper {
             }
         }
 
-        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
-        if let Some(message) =
-            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
-        {
+        // A cancel that fired after an invalid slug was rejected (but before a
+        // later valid slug was reached) must not be misattributed as "all slugs
+        // invalid" — the run was interrupted, not misconfigured.
+        if ctx.signal.is_cancelled() {
+            return Ok(out);
+        }
+
+        // Err when every attempt failed OR every slug was rejected pre-fetch —
+        // see `ats_board_failure`.
+        if let Some(message) = ats_board_failure(
+            self.id(),
+            successful_fetches,
+            rejected_slugs,
+            &first_fetch_error,
+        ) {
             return Err(anyhow::anyhow!(message));
         }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/pinpoint/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/pinpoint/mod.rs
@@ -15,7 +15,7 @@
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
 use super::common::{
-    ats_board_failure, is_https_url, is_valid_dns_label_slug, normalize_companies,
+    ats_finish_search, is_https_url, is_valid_dns_label_slug, normalize_companies,
 };
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -204,25 +204,16 @@ impl Scraper for PinpointScraper {
             }
         }
 
-        // A cancel that fired after an invalid slug was rejected (but before a
-        // later valid slug was reached) must not be misattributed as "all slugs
-        // invalid" — the run was interrupted, not misconfigured.
-        if ctx.signal.is_cancelled() {
-            return Ok(out);
-        }
-
-        // Err when every attempt failed OR every slug was rejected pre-fetch —
-        // see `ats_board_failure`.
-        if let Some(message) = ats_board_failure(
+        // See `ats_finish_search`: cancellation wins over a synthesized
+        // all-fetches-failed/all-slugs-invalid board error.
+        ats_finish_search(
+            &ctx.signal,
+            out,
             self.id(),
             successful_fetches,
             rejected_slugs,
             &first_fetch_error,
-        ) {
-            return Err(anyhow::anyhow!(message));
-        }
-
-        Ok(out)
+        )
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/pinpoint/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/pinpoint/test.rs
@@ -221,19 +221,19 @@ async fn empty_companies_returns_empty_without_network() {
     );
 }
 
+/// An all-invalid-slug run rejects every slug pre-fetch (no network — the SSRF
+/// guard) and now surfaces a distinct board error instead of a silent zero
+/// (claude review #597).
 #[tokio::test]
-async fn invalid_slug_skipped_without_network() {
+async fn all_invalid_slugs_error_without_network() {
     let scraper = PinpointScraper;
     let result = scraper
         .search(make_input(vec!["dotted.host".to_string()]), make_ctx())
         .await;
+    let err = result.expect_err("an all-invalid-slug run must be a board error, not a silent zero");
     assert!(
-        result.is_ok(),
-        "search must return Ok even for invalid slug"
-    );
-    assert!(
-        result.unwrap().is_empty(),
-        "invalid slug must produce empty result (skipped, no network)"
+        err.to_string().contains("slug(s) invalid"),
+        "error must name the invalid-slug reason, got: {err}"
     );
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/recruitee/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/recruitee/mod.rs
@@ -5,7 +5,7 @@
 /// board with `"needs-company"` when `input.companies` is empty.
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::ats_board_failure;
+use super::common::ats_finish_search;
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -186,25 +186,16 @@ impl Scraper for RecruiteeScraper {
             }
         }
 
-        // A cancel that fired after an invalid slug was rejected (but before a
-        // later valid slug was reached) must not be misattributed as "all slugs
-        // invalid" — the run was interrupted, not misconfigured.
-        if ctx.signal.is_cancelled() {
-            return Ok(out);
-        }
-
-        // Distinguishes an all-slug 403/parse-drift run OR an all-slug-rejected
-        // run from a genuine zero result; see `ats_board_failure` for the decision.
-        if let Some(message) = ats_board_failure(
+        // See `ats_finish_search`: cancellation wins over a synthesized
+        // all-fetches-failed/all-slugs-invalid board error.
+        ats_finish_search(
+            &ctx.signal,
+            out,
             self.id(),
             successful_fetches,
             rejected_slugs,
             &first_fetch_error,
-        ) {
-            return Err(anyhow::anyhow!(message));
-        }
-
-        Ok(out)
+        )
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/recruitee/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/recruitee/mod.rs
@@ -5,7 +5,7 @@
 /// board with `"needs-company"` when `input.companies` is empty.
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::ats_all_fetches_failed;
+use super::common::ats_board_failure;
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -81,6 +81,7 @@ impl Scraper for RecruiteeScraper {
         let total = input.companies.len();
 
         let mut successful_fetches = 0usize;
+        let mut rejected_slugs = 0usize;
         let mut first_fetch_error: Option<String> = None;
 
         for (i, company) in input.companies.iter().enumerate() {
@@ -97,6 +98,7 @@ impl Scraper for RecruiteeScraper {
             // percent-encode dots and produce a malformed host. Accept only
             // labels that are valid hostname components (alphanumeric + hyphen).
             if !is_valid_recruitee_slug(company) {
+                rejected_slugs += 1;
                 log::warn!("[recruitee] skipping invalid hostname slug '{}'", company);
                 continue;
             }
@@ -184,11 +186,21 @@ impl Scraper for RecruiteeScraper {
             }
         }
 
-        // Distinguishes an all-slug 403/parse-drift run from a genuine zero result;
-        // see `ats_all_fetches_failed` for the decision.
-        if let Some(message) =
-            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
-        {
+        // A cancel that fired after an invalid slug was rejected (but before a
+        // later valid slug was reached) must not be misattributed as "all slugs
+        // invalid" — the run was interrupted, not misconfigured.
+        if ctx.signal.is_cancelled() {
+            return Ok(out);
+        }
+
+        // Distinguishes an all-slug 403/parse-drift run OR an all-slug-rejected
+        // run from a genuine zero result; see `ats_board_failure` for the decision.
+        if let Some(message) = ats_board_failure(
+            self.id(),
+            successful_fetches,
+            rejected_slugs,
+            &first_fetch_error,
+        ) {
             return Err(anyhow::anyhow!(message));
         }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/recruitee/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/recruitee/test.rs
@@ -40,54 +40,26 @@ fn make_ctx() -> ScrapeContext {
 // Hostname-slug validation guard
 // ---------------------------------------------------------------------------
 
-/// Slugs with characters outside [a-zA-Z0-9-] must be skipped without any
-/// network request (the guard rejects them before the first fetch).
+/// Slugs with characters outside [a-zA-Z0-9-] must be rejected without any
+/// network request (the guard rejects them before the first fetch). A run where
+/// EVERY slug is rejected now surfaces a distinct board error instead of a
+/// silent zero (claude review #597).
 #[tokio::test]
-async fn invalid_slug_skipped_without_network() {
+async fn all_invalid_slugs_error_without_network() {
     let scraper = RecruiteeScraper;
 
-    // `@` is not a valid hostname label character
-    let result = scraper
-        .search(make_input(vec!["bad@host".to_string()]), make_ctx())
-        .await;
-    assert!(
-        result.is_ok(),
-        "search must return Ok even for invalid slug"
-    );
-    assert!(
-        result.unwrap().is_empty(),
-        "invalid slug 'bad@host' must produce empty result (skipped, no network)"
-    );
-
-    // space is not a valid hostname label character
-    let result = scraper
-        .search(make_input(vec!["has space".to_string()]), make_ctx())
-        .await;
-    assert!(result.is_ok());
-    assert!(
-        result.unwrap().is_empty(),
-        "invalid slug 'has space' must produce empty result (skipped, no network)"
-    );
-
-    // dot is not a valid hostname label character (would split the subdomain)
-    let result = scraper
-        .search(make_input(vec!["dotted.host".to_string()]), make_ctx())
-        .await;
-    assert!(result.is_ok());
-    assert!(
-        result.unwrap().is_empty(),
-        "invalid slug 'dotted.host' must produce empty result (skipped, no network)"
-    );
-
-    // percent-encoded character is not a valid hostname label character
-    let result = scraper
-        .search(make_input(vec!["bad%20slug".to_string()]), make_ctx())
-        .await;
-    assert!(result.is_ok());
-    assert!(
-        result.unwrap().is_empty(),
-        "invalid slug 'bad%20slug' must produce empty result (skipped, no network)"
-    );
+    // `@`, space, dot, and percent-encoding are each invalid hostname-label
+    // characters — every one is rejected pre-fetch, so each run is a board error.
+    for slug in ["bad@host", "has space", "dotted.host", "bad%20slug"] {
+        let err = scraper
+            .search(make_input(vec![slug.to_string()]), make_ctx())
+            .await
+            .expect_err("an all-invalid-slug run must be a board error, not a silent zero");
+        assert!(
+            err.to_string().contains("slug(s) invalid"),
+            "error for '{slug}' must name the invalid-slug reason, got: {err}"
+        );
+    }
 }
 
 /// A mixed list with one invalid slug followed by one valid-shaped slug must

--- a/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
@@ -12,7 +12,7 @@
 //! string fallback).
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{ats_board_failure, normalize_companies};
+use super::common::{ats_finish_search, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -248,25 +248,16 @@ impl Scraper for RipplingScraper {
             }
         }
 
-        // A cancel that fired after an invalid slug was rejected (but before a
-        // later valid slug was reached) must not be misattributed as "all slugs
-        // invalid" — the run was interrupted, not misconfigured.
-        if ctx.signal.is_cancelled() {
-            return Ok(out);
-        }
-
-        // Err when every attempt failed OR every slug was rejected pre-fetch —
-        // see `ats_board_failure`.
-        if let Some(message) = ats_board_failure(
+        // See `ats_finish_search`: cancellation wins over a synthesized
+        // all-fetches-failed/all-slugs-invalid board error.
+        ats_finish_search(
+            &ctx.signal,
+            out,
             self.id(),
             successful_fetches,
             rejected_slugs,
             &first_fetch_error,
-        ) {
-            return Err(anyhow::anyhow!(message));
-        }
-
-        Ok(out)
+        )
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/rippling/mod.rs
@@ -5,9 +5,14 @@
 //! board with `"needs-company"` when `input.companies` is empty.
 //!
 //! Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/rippling.mjs`.
+//! Live-verified 2026-07-11 against slug `rippling` (780 jobs): response is a
+//! `[{uuid, name, department, url (https://ats.rippling.com/…), workLocation{id,
+//! label}}]` array — shape confirmed, no drift; every row's `workLocation` was an
+//! object (`rows_to_jobs` + the untagged `RpWorkLocation` already tolerate a
+//! string fallback).
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{ats_all_fetches_failed, normalize_companies};
+use super::common::{ats_board_failure, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -181,6 +186,7 @@ impl Scraper for RipplingScraper {
         let total = companies.len();
 
         let mut successful_fetches = 0usize;
+        let mut rejected_slugs = 0usize;
         let mut first_fetch_error: Option<String> = None;
 
         for (i, company) in companies.iter().enumerate() {
@@ -189,6 +195,7 @@ impl Scraper for RipplingScraper {
             }
 
             if !is_valid_rippling_slug(company) {
+                rejected_slugs += 1;
                 log::warn!("[rippling] skipping invalid company slug '{}'", company);
                 if let Some(ref on_progress) = ctx.on_progress {
                     on_progress((i + 1) as f32 / total as f32);
@@ -241,10 +248,21 @@ impl Scraper for RipplingScraper {
             }
         }
 
-        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
-        if let Some(message) =
-            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
-        {
+        // A cancel that fired after an invalid slug was rejected (but before a
+        // later valid slug was reached) must not be misattributed as "all slugs
+        // invalid" — the run was interrupted, not misconfigured.
+        if ctx.signal.is_cancelled() {
+            return Ok(out);
+        }
+
+        // Err when every attempt failed OR every slug was rejected pre-fetch —
+        // see `ats_board_failure`.
+        if let Some(message) = ats_board_failure(
+            self.id(),
+            successful_fetches,
+            rejected_slugs,
+            &first_fetch_error,
+        ) {
             return Err(anyhow::anyhow!(message));
         }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/rippling/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/rippling/test.rs
@@ -224,19 +224,19 @@ async fn empty_companies_returns_empty_without_network() {
     );
 }
 
+/// An all-invalid-slug run rejects every slug pre-fetch (no network — the SSRF
+/// guard) and now surfaces a distinct board error instead of a silent zero
+/// (claude review #597).
 #[tokio::test]
-async fn invalid_slug_skipped_without_network() {
+async fn all_invalid_slugs_error_without_network() {
     let scraper = RipplingScraper;
     let result = scraper
         .search(make_input(vec!["dotted.host".to_string()]), make_ctx())
         .await;
+    let err = result.expect_err("an all-invalid-slug run must be a board error, not a silent zero");
     assert!(
-        result.is_ok(),
-        "search must return Ok even for invalid slug"
-    );
-    assert!(
-        result.unwrap().is_empty(),
-        "invalid slug must produce empty result (skipped, no network)"
+        err.to_string().contains("slug(s) invalid"),
+        "error must name the invalid-slug reason, got: {err}"
     );
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/themuse/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/themuse/mod.rs
@@ -6,6 +6,10 @@
 /// that have no server-side search either.
 ///
 /// Endpoint reconnaissance ported from santifer/career-ops (MIT), `providers/themuse.mjs`.
+/// Live-verified 2026-07-11 (page 0): response is `{page, page_count, total,
+/// items_per_page: 20, results[{name, refs{landing_page}, company{name},
+/// locations[{name}]}]}` — every parsed field present, `page_count` in the tens
+/// of thousands. Shape confirmed, no drift.
 use super::super::http::fetch_json;
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
 use super::common::{matches_filters, should_propagate_page_error};
@@ -20,9 +24,9 @@ const BASE_URL: &str = "https://www.themuse.com/api/public/jobs";
 /// 100-page fetch (this is a UI-triggered search, not a bulk crawl).
 const MAX_PAGES: u32 = 5;
 
-/// The Muse's actual per-page result count is unconfirmed (unverified
-/// endpoint). Used only to flag likely response-shape drift on page 0: a
-/// truly single-page feed rarely holds this many jobs, so `page_count == 0`
+/// The Muse's per-page result count is 20 (confirmed live 2026-07-11). This
+/// floor stays well under that. Used only to flag likely response-shape drift
+/// on page 0: a truly single-page feed rarely holds this many jobs, so `page_count == 0`
 /// alongside a page this full is far more likely a renamed/dropped field
 /// than a legitimate one-page result set.
 const LIKELY_FULL_PAGE_LEN: usize = 10;

--- a/apps/desktop/src-tauri/src/scraping/boards/workable/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/workable/mod.rs
@@ -11,7 +11,7 @@
 //! doc/blog — so it isn't marked "unverified" like those.
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{ats_all_fetches_failed, normalize_companies};
+use super::common::{ats_board_failure, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -257,6 +257,7 @@ impl Scraper for WorkableScraper {
         let total = companies.len();
 
         let mut successful_fetches = 0usize;
+        let mut rejected_slugs = 0usize;
         let mut first_fetch_error: Option<String> = None;
 
         for (i, slug) in companies.iter().enumerate() {
@@ -267,6 +268,7 @@ impl Scraper for WorkableScraper {
             // Guard: reject slugs that could redirect the request via path
             // traversal or an injected query string.
             if !is_valid_workable_slug(slug) {
+                rejected_slugs += 1;
                 log::warn!("[workable] skipping invalid company slug '{}'", slug);
                 if let Some(ref on_progress) = ctx.on_progress {
                     on_progress((i + 1) as f32 / total as f32);
@@ -323,10 +325,21 @@ impl Scraper for WorkableScraper {
             }
         }
 
-        // Return Err only when every attempt failed — see `ats_all_fetches_failed`.
-        if let Some(message) =
-            ats_all_fetches_failed(self.id(), successful_fetches, &first_fetch_error)
-        {
+        // A cancel that fired after an invalid slug was rejected (but before a
+        // later valid slug was reached) must not be misattributed as "all slugs
+        // invalid" — the run was interrupted, not misconfigured.
+        if ctx.signal.is_cancelled() {
+            return Ok(out);
+        }
+
+        // Err when every attempt failed OR every slug was rejected pre-fetch —
+        // see `ats_board_failure`.
+        if let Some(message) = ats_board_failure(
+            self.id(),
+            successful_fetches,
+            rejected_slugs,
+            &first_fetch_error,
+        ) {
             return Err(anyhow::anyhow!(message));
         }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/workable/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/workable/mod.rs
@@ -11,7 +11,7 @@
 //! doc/blog — so it isn't marked "unverified" like those.
 use super::super::http::{fetch_json, strip_html};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{ats_board_failure, normalize_companies};
+use super::common::{ats_finish_search, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -325,25 +325,16 @@ impl Scraper for WorkableScraper {
             }
         }
 
-        // A cancel that fired after an invalid slug was rejected (but before a
-        // later valid slug was reached) must not be misattributed as "all slugs
-        // invalid" — the run was interrupted, not misconfigured.
-        if ctx.signal.is_cancelled() {
-            return Ok(out);
-        }
-
-        // Err when every attempt failed OR every slug was rejected pre-fetch —
-        // see `ats_board_failure`.
-        if let Some(message) = ats_board_failure(
+        // See `ats_finish_search`: cancellation wins over a synthesized
+        // all-fetches-failed/all-slugs-invalid board error.
+        ats_finish_search(
+            &ctx.signal,
+            out,
             self.id(),
             successful_fetches,
             rejected_slugs,
             &first_fetch_error,
-        ) {
-            return Err(anyhow::anyhow!(message));
-        }
-
-        Ok(out)
+        )
     }
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/workable/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/workable/test.rs
@@ -343,18 +343,18 @@ async fn empty_companies_returns_empty_without_network() {
     assert!(result.unwrap().is_empty());
 }
 
+/// An all-invalid-slug run rejects every slug pre-fetch (no network — the path-
+/// traversal guard) and now surfaces a distinct board error instead of a silent
+/// zero (claude review #597).
 #[tokio::test]
-async fn invalid_slug_skipped_without_network() {
+async fn all_invalid_slugs_error_without_network() {
     let result = WorkableScraper
         .search(make_input(vec!["../escape".to_string()]), make_ctx())
         .await;
+    let err = result.expect_err("an all-invalid-slug run must be a board error, not a silent zero");
     assert!(
-        result.is_ok(),
-        "search must return Ok even for an invalid slug"
-    );
-    assert!(
-        result.unwrap().is_empty(),
-        "invalid slug must be skipped, no network"
+        err.to_string().contains("slug(s) invalid"),
+        "error must name the invalid-slug reason, got: {err}"
     );
 }
 

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -191,9 +191,29 @@ fn test_catalog_listed_flags() {
         "arbeitsagentur must be listed"
     );
 
-    // All 23 active boards are listed
+    // Comeet is registered (dispatchable) but HIDDEN from the picker until its
+    // response shape is live-verified (trust PR G) — it must still be present in
+    // the catalog, just with `listed = false`.
+    assert!(
+        catalog.iter().any(|e| e.id == "comeet"),
+        "comeet must stay registered (dispatchable)"
+    );
+    assert!(
+        !entry("comeet").listed,
+        "comeet must be hidden from the picker until live-verified"
+    );
+
+    // Every board except the hidden Comeet is listed (23 registered, 1 hidden).
     let listed_count = catalog.iter().filter(|e| e.listed).count();
-    assert_eq!(listed_count, 23, "all 23 boards should be listed");
+    assert_eq!(
+        listed_count,
+        catalog.len() - 1,
+        "all boards except the hidden Comeet should be listed"
+    );
+    assert_eq!(
+        listed_count, 22,
+        "22 of the 23 registered boards are listed"
+    );
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/scraping/linkedin/api_client/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/linkedin/api_client/mod.rs
@@ -92,6 +92,24 @@ pub(crate) async fn cancellable_sleep(
     }
 }
 
+/// Structural discriminator for LinkedIn's guest `seeMoreJobPostings/search`
+/// endpoint: whether a **page-0** 200 response that parsed to `card_count` job
+/// cards indicates a soft-block rather than a genuine empty result.
+///
+/// Verified live 2026-07-11: the guest endpoint pads ANY real page-0 query with
+/// talent-pool / "spontaneous application" cards (a real, non-block query never
+/// returns an empty card list on page 0), and paging past the end returns HTTP
+/// 400 (already surfaced as an error upstream). So a 200 page-0 body that yields
+/// **zero** job cards is never "0 jobs found" — it is an anti-bot soft-block, a
+/// login-wall interstitial, or a card-markup change. Surfacing it as a board
+/// error (not the previous silent `Ok(vec![])`) is what makes LinkedIn honest.
+///
+/// Only page 0 is treated this way: a later page legitimately returns zero once
+/// the harvest is exhausted, and by then real cards were already collected.
+fn page0_is_soft_block(card_count: usize) -> bool {
+    card_count == 0
+}
+
 #[derive(Debug, Clone)]
 pub struct JobsSearchParams {
     pub keywords: String,
@@ -371,6 +389,21 @@ impl LinkedInJobsApiClient {
                     Ok(jobs) => jobs,
                     Err(e) => return Err(e),
                 };
+            }
+
+            // Honest block detection: a page-0 200 that yields zero job cards is a
+            // soft-block / login-wall / markup drift, NOT a genuine empty result
+            // (see `page0_is_soft_block`). Surface it as a board error instead of
+            // the previous silent `Ok(vec![])`. Guarded on cancellation so a cancel
+            // firing between fetch and here isn't mislabelled as a block.
+            if page == 0
+                && page0_is_soft_block(jobs.len())
+                && !signal.is_some_and(|s| s.is_cancelled())
+            {
+                return Err(anyhow::anyhow!(
+                    "LinkedIn returned no job cards — it may be rate-limiting guest traffic, \
+                     require login, or have changed its page layout; results unavailable"
+                ));
             }
 
             for job in &jobs {

--- a/apps/desktop/src-tauri/src/scraping/linkedin/api_client/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/linkedin/api_client/test.rs
@@ -247,3 +247,19 @@ async fn test_cancellable_sleep_elapses_normally() {
         "sleep must actually elapse the full duration"
     );
 }
+
+// ── page-0 soft-block discriminator (trust PR G) ─────────────────────────────
+//
+// Verified live 2026-07-11: the guest endpoint pads any real page-0 query with
+// talent-pool cards and 400s past the end, so a 200 page-0 body that parsed to
+// ZERO cards is a soft-block / login-wall / markup drift, never "0 jobs found".
+
+#[test]
+fn page0_soft_block_only_on_zero_cards() {
+    assert!(
+        page0_is_soft_block(0),
+        "zero page-0 cards is the soft-block signal (never a genuine empty result)"
+    );
+    assert!(!page0_is_soft_block(1), "one card is a real result");
+    assert!(!page0_is_soft_block(10), "a full page is a real result");
+}

--- a/docs/knowledge/scraping-domain.md
+++ b/docs/knowledge/scraping-domain.md
@@ -328,6 +328,34 @@ Board fetch errors are now representable end-to-end, distinguishing between "boa
 - **Rust commands:** `apps/desktop/src-tauri/src/commands/scrape.rs` (`scrape_resolve_url`, `scrape_update_description`)
 - **PostingsCache mutation:** `apps/desktop/src-tauri/src/postings/mod.rs: update_description(job_id, text)` — in-place cache mutation; text-hash-keyed result/embedding caches auto-invalidate on changed job text
 
+## Board hygiene (PR G, 2026-07-11)
+
+Live verification of never-verified recon-ported boards and hardening against silent zeros.
+
+**Live verification (curl, single polite requests, 2026-07-11):**
+
+- **Themuse** — `GET /api/public/jobs?page=0` shape confirmed; `items_per_page=20` documented.
+- **Breezy HR** — drift FIXED: `location.state` is object `{id,name}`, not string. Parser switched to per-row `rows_to_jobs` (matching rippling/workable idiom) so a single drifted row can't zero the board. Added recovery from `all rows failed to parse` state (`raw_row_count > 0 && postings.empty()` → records `first_fetch_error`, skips `successful_fetches` increment, treated as fetch failure not genuine zero).
+- **BambooHR** — response shape confirmed; `state` IS a plain string (unlike breezy). No changes needed.
+- **Rippling** — response shape confirmed; `workLocation` tolerant of per-row objects. No changes needed.
+- **Pinpoint** — unverifiable: no public slug found (bespoke subdomains). Parser kept as reconnaissance; drift/wrong-slug covered by existing error plumbing.
+- **Comeet** — hidden from picker via `listed()→false`; code kept, dispatchable via API. Credentials remain configurable in Settings (no removal to avoid orphaning user data).
+
+**LinkedIn soft-block detection:**
+
+A 200 page-0 response with zero job cards is never genuine empty (verified: nonsense-keyword query still returns 10 padded cards). Chosen discriminator: `page0_is_soft_block(card_count)==card_count==0`. Returns board Err (`"LinkedIn returned no job cards — may be rate-limiting/require login/changed layout; results unavailable"`). Also: added country-biased cached `select_geo_id` (in-process cache keyed `(query, country)`, successes only) + `country_aliases` map for ambiguous names (e.g. `"be"→"Belgium"`).
+
+**Rejected-slug surfacing (ATS boards):**
+
+New `ats_finish_search(signal, out, board_id, successful_fetches, rejected_slugs, first_fetch_error)` in `boards/common.rs` centralizes "cancellation wins, else delegate to `ats_board_failure`"; wired into 7 ATS boards (bamboohr, breezy, pinpoint, rippling, workable, recruitee, personio). All-rejected → distinct error: `"all N company slug(s) invalid for {board} — check the company names in the jobs search form"`. Partial-reject (some fetched, some invalid) → log-only (chip mapping deferred).
+
+**Source pointers:**
+
+- Breezy row-drift recovery: `apps/desktop/src-tauri/src/scraping/boards/breezy/mod.rs` (capture `raw_row_count`, check emptiness post-`rows_to_jobs`)
+- LinkedIn soft-block + geoId cache: `apps/desktop/src-tauri/src/scraping/boards/linkedin/mod.rs` (`page0_is_soft_block`, `GEO_ID_CACHE`, `select_geo_id`, `country_aliases`)
+- Rejected-slug finalization: `apps/desktop/src-tauri/src/scraping/boards/common.rs` (`ats_finish_search`, `ats_all_slugs_invalid_message`)
+- Tests: breezy `rows_to_jobs_all_rows_undeserializable_returns_empty` · linkedin `page0_is_soft_block`, `select_geo_id` · common `finish_search_*` truth table + personio inline cancel-after-reject seam
+
 ## See also
 
 - `docs/SCRAPING_ENDPOINTS.md` — verified external endpoint reconnaissance (23 active boards, `aggregator` counted once among them; retired boards noted)


### PR DESCRIPTION
## Summary

PR G of the job-search trust program (audit 2026-07-10): the never-verified recon boards got a live-shape verification pass, the one board that could only ever silently return zero is no longer promised to users, and LinkedIn's silent soft-block is detected. Builds on #597-#602.

## What changed

- **Live verification (curl, one-shot, 2026-07-11):** themuse (runs on every keyword search), bamboohr, and rippling shapes confirmed field-by-field with dated module notes. **Breezy was functionally dead** — `location.state` drifted from string to object, atomically failing every tenant's deserialize — fixed with a tolerant untagged parse + per-row handling, PLUS a total-drift guard: a response whose rows ALL fail to parse records a fetch failure, never a silent empty success. Pinpoint has no findable public slug — documented unverifiable; PR A's error plumbing covers every failure mode.
- **Comeet hidden** (`listed() → false`): its response shape was speculative and the live endpoint 400s — the code stays registered (saved targets still dispatch), only the user-facing promise is removed.
- **LinkedIn soft-block detection:** empirically established that page 0 always pads with talent-pool cards (even nonsense keywords) and paging past the end returns 400 — so a 200 page-0 with zero cards is never a genuine empty. It now errs honestly ("may be rate-limiting / require login / changed layout"), after the geoId-strip retry, cancellation-guarded. Plus country-biased geoId selection (alias table incl. Adzuna-allowlist parity) and an in-process geoId cache.
- **All-slugs-invalid becomes a distinct error** ("all N company slug(s) invalid — check the company names in the jobs search form") across the 7 slug-validating boards, via a shared `ats_finish_search` that encodes cancellation-wins in one tested place — a mid-list cancel can never be misreported as user misconfiguration.

## Review trail (internal fleet)

- scraping-applier-expert: REQUEST-CHANGES → cancellation-guard HIGH fixed across all 7 boards + country aliases → resolved
- tauri-security-reviewer: PASS-WITH-ADVISORIES (no slug values in error strings; geoId cache in-memory only; serde untagged bounded by response caps)
- pr-reviewer ×2 (opus + sonnet independently converged): total-row-drift silent zero → fetch-failure guard added; wrong-screen copy → reworded; cancel-guard consolidated into ats_finish_search with shared tests

## Test plan

- CI runs the Rust suite (host fault blocks local cargo test; fmt/check/clippy clean). Live shapes captured as fixtures; standalone example verified the breezy untagged parse + geoId bias.
- Manual: scrape with a breezy company (e.g. a real tenant) → jobs return; enter an invalid company name for an ATS board → distinct "slugs invalid" chip, not silent zero.

Part 7/8 of the trust program — next: PR H (scheduler retry + robustness tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)