### PR TITLE
chore: structured review gate with deterministic verdict and metrics

### DIFF
--- a/.claude/hooks/review-gate.mjs
+++ b/.claude/hooks/review-gate.mjs
@@ -13,8 +13,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
-import { spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import {
   SKIP_GLOBS,
   matchesAny,
@@ -115,8 +114,9 @@ try {
       segments.push(...splitByFile(git(args)));
     } catch {}
   };
-  if (mergeBase) collect(['diff', '-M', `${mergeBase}..HEAD`, '--unified=3', '--', ...nonSkipped]);
-  collect(['diff', '-M', 'HEAD', '--unified=3', '--', ...nonSkipped]);
+  // ONE diff from merge-base (or HEAD) to the WORKING TREE — committed + uncommitted
+  // captured in a single pass, so a file changed in both never yields two segments.
+  collect(['diff', '-M', mergeBase || 'HEAD', '--unified=3', '--', ...nonSkipped]);
   // `git diff HEAD` is blind to untracked files — diff each against /dev/null.
   // --no-index exits 1 on difference, so output is recovered from the thrown error.
   for (const f of untracked) {
@@ -129,7 +129,7 @@ try {
       if (e && typeof e.stdout === 'string') segments.push(...splitByFile(e.stdout));
     }
   }
-  const { diff } = assembleDiff(segments, MAX);
+  const { diff, omitted, deletedCount } = assembleDiff(segments, MAX);
   if (!diff.trim()) exit0();
 
   // trivial-change heuristic (comment/import/blank-only → skip)
@@ -141,7 +141,12 @@ try {
     if (/^(import |use |pub use |mod |from )/.test(b)) return false;
     return true;
   });
-  if (!meaningful.length) exit0();
+  if (!meaningful.length) {
+    // deletion-only / over-budget-only changes carry no +/- lines — the review is
+    // skipped as a degradation, but the metrics must not read as "clean".
+    if (deletedCount || omitted.length) logM({ outcome: 'degraded', blocked: false });
+    exit0();
+  }
 
   // 5. Tier 0 — architecture guards (deterministic findings, confidence 1.0).
   // ponytail: JS regex over changed .rs contents; PR 3 swaps this for ast-grep.
@@ -149,19 +154,48 @@ try {
     const i = content.split('\n').findIndex((l) => re.test(l));
     return i >= 0 ? i + 1 : 0;
   };
+  // added (+) lines per file — a violation only BLOCKS when the diff introduced it;
+  // a pre-existing hit in a touched file surfaces honestly as non-blocking
+  // (introduced_by_diff: false — CI architecture tests own pre-existing debt).
+  const addedByFile = new Map();
+  for (const s of segments) {
+    const added = s.text
+      .split('\n')
+      .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+      .map((l) => l.slice(1))
+      .join('\n');
+    addedByFile.set(s.file, (addedByFile.get(s.file) || '') + added + '\n');
+  }
   const tier0 = [];
-  const arch = (file, line, summary, fix) =>
+  const arch = (file, line, summary, fix, introduced) =>
     tier0.push({
       severity: 'HIGH',
       category: 'arch',
       file,
       line,
-      summary,
-      evidence: 'deterministic Tier-0 guard (docs/architecture-rules.md)',
+      summary: introduced ? summary : `${summary} (pre-existing)`,
+      evidence: introduced
+        ? 'deterministic Tier-0 guard (docs/architecture-rules.md)'
+        : 'pre-existing in a touched file — not introduced by this diff',
       fix,
       confidence: 1,
-      introduced_by_diff: true,
+      introduced_by_diff: introduced,
     });
+  const ARCH_RULES = [
+    [
+      /std::env::var\b/,
+      /\/platform\//,
+      'std::env::var outside platform/',
+      'move env access into platform/config.rs',
+    ],
+    [/reqwest::Client\b/, /\/net\//, 'reqwest::Client outside net/', 'use net/http.rs shared()'],
+    [
+      /Result<[^>]*,\s*String\s*>/,
+      /\/error(\.rs|\/)/,
+      'untyped Result<_, String> outside error/',
+      'use AppError/AppResult',
+    ],
+  ];
   for (const f of nonSkipped) {
     if (!f.endsWith('.rs')) continue;
     let content = '';
@@ -171,27 +205,14 @@ try {
       continue;
     }
     const p = '/' + f;
-    if (!/\/platform\//.test(p) && /std::env::var\b/.test(content))
-      arch(
-        f,
-        findLine(content, /std::env::var\b/),
-        'std::env::var outside platform/',
-        'move env access into platform/config.rs'
-      );
-    if (!/\/net\//.test(p) && /reqwest::Client\b/.test(content))
-      arch(
-        f,
-        findLine(content, /reqwest::Client\b/),
-        'reqwest::Client outside net/',
-        'use net/http.rs shared()'
-      );
-    if (!/\/error(\.rs|\/)/.test(p) && /Result<[^>]*,\s*String\s*>/.test(content))
-      arch(
-        f,
-        findLine(content, /Result<[^>]*,\s*String\s*>/),
-        'untyped Result<_, String> outside error/',
-        'use AppError/AppResult'
-      );
+    const added = addedByFile.get(f) || '';
+    // true = introduced by the diff, false = pre-existing, null = absent
+    const hit = (re) => (re.test(added) ? true : re.test(content) ? false : null);
+    for (const [re, exemptRe, summary, fix] of ARCH_RULES) {
+      if (exemptRe.test(p)) continue;
+      const h = hit(re);
+      if (h !== null) arch(f, findLine(content, re), summary, fix, h);
+    }
   }
 
   // 6. reviewed-hash cache (body-only hunk hashes; line-number agnostic)
@@ -201,7 +222,9 @@ try {
     cache = new Set(fs.readFileSync(cachePath, 'utf8').split('\n').filter(Boolean));
   } catch {}
   const hashes = hunkHashes(diff);
-  if (hashes.length && hashes.every((h) => cache.has(h)) && !tier0.length) {
+  // pre-existing (non-blocking) tier-0 hits must not defeat the cache forever
+  const tier0Blocking = tier0.some((t) => t.introduced_by_diff);
+  if (hashes.length && hashes.every((h) => cache.has(h)) && !tier0Blocking) {
     logM({ outcome: 'cache-skip', blocked: false });
     exit0();
   }
@@ -375,7 +398,7 @@ ${diff}
         .map(formatFinding)
         .join('\n')}` +
         (unverified.length
-          ? `\n\nUnverified (low-confidence, advisory):\n${unverified.map(formatFinding).join('\n')}`
+          ? `\n\nNon-blocking HIGH/CRITICAL (low confidence or pre-existing):\n${unverified.map(formatFinding).join('\n')}`
           : '') +
         (advisory.length ? `\n\nAdvisory:\n- ${advisory.join('\n- ')}` : '') +
         fallbackNote
@@ -404,7 +427,7 @@ ${diff}
   const advisoryOut = [];
   if (unverified.length)
     advisoryOut.push(
-      `Unverified findings (confidence < 0.6):\n${unverified.map(formatFinding).join('\n')}`
+      `Non-blocking HIGH/CRITICAL (low confidence or pre-existing):\n${unverified.map(formatFinding).join('\n')}`
     );
   if (lowmed.length)
     advisoryOut.push(`Advisory findings:\n${lowmed.map(formatFinding).join('\n')}`);

--- a/.claude/hooks/review-gate.mjs
+++ b/.claude/hooks/review-gate.mjs
@@ -2,15 +2,34 @@
 /**
  * review-gate.mjs — global Stop hook. Tiered, batched, token-efficient code review.
  * Generic by default; specialized per-project via <cwd>/.claude/review-routes.json + .claude/agents/*.md.
- * NEVER hard-fails the session: any error → exit 0 (don't block the user on a hook bug).
+ * NEVER hard-fails the session: any error → exit 0 (don't block the user on a hook bug),
+ * but every meaningful run — including failures — logs one line to .claude/.review-metrics.jsonl.
  *
  * Tiers: guards → skip-list → Tier 0 deterministic arch-guards → reviewed-hash cache →
- *        route to ≤3 owner checklists → ONE batched `claude -p` (model by risk) → block only on HIGH/CRITICAL.
+ *        route to ≤3 owner checklists → ONE batched `claude -p` (schema-1 JSON findings) →
+ *        deterministic verdict: block iff parsed HIGH/CRITICAL with confidence ≥ 0.6.
+ * Scope: the full branch range (merge-base with origin/main → HEAD) PLUS the working
+ *        tree and untracked files — committing no longer blinds the gate.
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import crypto from 'node:crypto';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import {
+  SKIP_GLOBS,
+  matchesAny,
+  globToRe,
+  splitByFile,
+  assembleDiff,
+  hunkHashes,
+  FINDING_CONTRACT,
+  blockingFindings,
+  formatFinding,
+  countBySeverity,
+  runClaudeReview,
+  appendMetrics,
+  readLearnings,
+} from './review-lib.mjs';
 
 const exit0 = (msg) => {
   if (msg) process.stdout.write(msg);
@@ -20,6 +39,12 @@ const block = (reason) => {
   process.stdout.write(JSON.stringify({ decision: 'block', reason }));
   process.exit(0);
 };
+
+const t0 = Date.now();
+const metric = { kind: 'stop-gate', branch: '', model: '', files: 0 };
+let metricsCwd = process.cwd();
+const logM = (extra) =>
+  appendMetrics(metricsCwd, { ...metric, duration_ms: Date.now() - t0, ...extra });
 
 try {
   // --- read Stop payload (stdin) ---
@@ -35,85 +60,77 @@ try {
   if (payload.stop_hook_active === true) exit0(); // one review→fix cycle per finish-chain (block-once)
 
   const cwd = payload.cwd || process.cwd();
+  metricsCwd = cwd;
   const git = (args) =>
     execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
 
-  // 2. git + changed files
+  // 2. git + scope: branch range (merge-base..HEAD) ∪ working tree ∪ untracked
   let inRepo = false;
   try {
     inRepo = git(['rev-parse', '--is-inside-work-tree']).trim() === 'true';
   } catch {}
   if (!inRepo) exit0();
-  let changed = [];
+
+  let branch = '';
   try {
-    changed = git(['diff', '--name-only', 'HEAD'])
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean);
+    branch = git(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
   } catch {}
-  let untracked = [];
-  try {
-    untracked = git(['ls-files', '--others', '--exclude-standard'])
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean);
-  } catch {}
-  changed = [...new Set(changed.concat(untracked))];
+  metric.branch = branch;
+
+  // committed-but-unmerged range — skipped on main/detached (PRs-only repo policy)
+  let mergeBase = '';
+  if (branch && branch !== 'main' && branch !== 'HEAD') {
+    try {
+      mergeBase = git(['merge-base', 'origin/main', 'HEAD']).trim();
+      if (mergeBase === git(['rev-parse', 'HEAD']).trim()) mergeBase = ''; // nothing committed
+    } catch {}
+  }
+
+  const names = (args) => {
+    try {
+      return git(args)
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  };
+  const committedNames = mergeBase ? names(['diff', '--name-only', `${mergeBase}..HEAD`]) : [];
+  const workingNames = names(['diff', '--name-only', 'HEAD']);
+  const untracked = names(['ls-files', '--others', '--exclude-standard']);
+  const changed = [...new Set([...committedNames, ...workingNames, ...untracked])];
   if (!changed.length) exit0();
 
-  // glob helpers (`**/` = optional dir prefix, so `**/package.json` also matches root files)
-  const globToRe = (g) =>
-    new RegExp(
-      '^' +
-        g
-          .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-          .replace(/\*\*\//g, '\u0001')
-          .replace(/\*\*/g, '\u0002')
-          .replace(/\*/g, '[^/]*')
-          .replace(/\u0001/g, '(?:.*/)?')
-          .replace(/\u0002/g, '.*') +
-        '$'
-    );
-  const matchesAny = (file, globs) => (globs || []).some((g) => globToRe(g).test(file));
-
   // 3. skip-list (no LLM)
-  const SKIP = [
-    'docs/knowledge/**',
-    '**/*.md',
-    '**/*.lock',
-    '**/pnpm-lock.yaml',
-    '**/package-lock.json',
-    '**/Cargo.lock',
-    '**/*.snap',
-    '**/snapshots/**',
-    '**/golden/**',
-    '**/*.gen.*',
-    '**/dist/**',
-    '**/build/**',
-    '**/target/**',
-    'graphify-out/**',
-  ];
-  const nonSkipped = changed.filter((f) => !matchesAny(f, SKIP));
+  const nonSkipped = changed.filter((f) => !matchesAny(f, SKIP_GLOBS));
   if (!nonSkipped.length) exit0();
+  metric.files = nonSkipped.length;
 
-  // diff (bounded)
+  // 4. per-file diff segments (rename-aware) → drop-order assembly, hunk-safe cuts
   const MAX = 60000;
-  let diff = '';
-  try {
-    diff = git(['diff', 'HEAD', '--unified=3', '--', ...nonSkipped]);
-  } catch {}
-  // `git diff HEAD` is blind to untracked files — diff each against /dev/null so
-  // new-file-only changes are still reviewed. --no-index exits 1 on difference,
-  // so the output is recovered from the thrown error.
-  for (const f of untracked) {
-    if (!nonSkipped.includes(f) || diff.length > MAX) continue;
+  const segments = [];
+  const collect = (args) => {
     try {
-      diff += git(['diff', '--no-index', '--unified=3', '--', '/dev/null', f]);
+      segments.push(...splitByFile(git(args)));
+    } catch {}
+  };
+  if (mergeBase) collect(['diff', '-M', `${mergeBase}..HEAD`, '--unified=3', '--', ...nonSkipped]);
+  collect(['diff', '-M', 'HEAD', '--unified=3', '--', ...nonSkipped]);
+  // `git diff HEAD` is blind to untracked files — diff each against /dev/null.
+  // --no-index exits 1 on difference, so output is recovered from the thrown error.
+  for (const f of untracked) {
+    if (!nonSkipped.includes(f)) continue;
+    try {
+      segments.push(
+        ...splitByFile(git(['diff', '--no-index', '--unified=3', '--', '/dev/null', f]))
+      );
     } catch (e) {
-      if (e && typeof e.stdout === 'string') diff += e.stdout;
+      if (e && typeof e.stdout === 'string') segments.push(...splitByFile(e.stdout));
     }
   }
-  if (diff.length > MAX) diff = diff.slice(0, MAX) + '\n...[diff truncated]...';
+  const { diff } = assembleDiff(segments, MAX);
+  if (!diff.trim()) exit0();
 
   // trivial-change heuristic (comment/import/blank-only → skip)
   const codeLines = diff.split('\n').filter((l) => /^[+-]/.test(l) && !/^[+-]{3}/.test(l));
@@ -126,8 +143,25 @@ try {
   });
   if (!meaningful.length) exit0();
 
-  // 4. Tier 0 — architecture guards (JS regex over changed .rs contents; cross-platform, no grep)
-  const archFindings = [];
+  // 5. Tier 0 — architecture guards (deterministic findings, confidence 1.0).
+  // ponytail: JS regex over changed .rs contents; PR 3 swaps this for ast-grep.
+  const findLine = (content, re) => {
+    const i = content.split('\n').findIndex((l) => re.test(l));
+    return i >= 0 ? i + 1 : 0;
+  };
+  const tier0 = [];
+  const arch = (file, line, summary, fix) =>
+    tier0.push({
+      severity: 'HIGH',
+      category: 'arch',
+      file,
+      line,
+      summary,
+      evidence: 'deterministic Tier-0 guard (docs/architecture-rules.md)',
+      fix,
+      confidence: 1,
+      introduced_by_diff: true,
+    });
   for (const f of nonSkipped) {
     if (!f.endsWith('.rs')) continue;
     let content = '';
@@ -138,37 +172,41 @@ try {
     }
     const p = '/' + f;
     if (!/\/platform\//.test(p) && /std::env::var\b/.test(content))
-      archFindings.push(
-        `HIGH · ${f} · std::env::var outside platform/ · move env access into platform/config.rs`
+      arch(
+        f,
+        findLine(content, /std::env::var\b/),
+        'std::env::var outside platform/',
+        'move env access into platform/config.rs'
       );
     if (!/\/net\//.test(p) && /reqwest::Client\b/.test(content))
-      archFindings.push(`HIGH · ${f} · reqwest::Client outside net/ · use net/http.rs shared()`);
+      arch(
+        f,
+        findLine(content, /reqwest::Client\b/),
+        'reqwest::Client outside net/',
+        'use net/http.rs shared()'
+      );
     if (!/\/error(\.rs|\/)/.test(p) && /Result<[^>]*,\s*String\s*>/.test(content))
-      archFindings.push(
-        `HIGH · ${f} · untyped Result<_, String> outside error/ · use AppError/AppResult`
+      arch(
+        f,
+        findLine(content, /Result<[^>]*,\s*String\s*>/),
+        'untyped Result<_, String> outside error/',
+        'use AppError/AppResult'
       );
   }
 
-  // 5. reviewed-hash cache (body-only hunk hashes; line-number agnostic)
+  // 6. reviewed-hash cache (body-only hunk hashes; line-number agnostic)
   const cachePath = path.join(cwd, '.claude', '.review-cache');
   let cache = new Set();
   try {
     cache = new Set(fs.readFileSync(cachePath, 'utf8').split('\n').filter(Boolean));
   } catch {}
-  const hunkBodies = diff
-    .split(/^@@.*$/m)
-    .slice(1)
-    .map((h) =>
-      h
-        .split('\n')
-        .filter((l) => /^[+-]/.test(l) && !/^[+-]{3}/.test(l))
-        .map((l) => l.slice(1).trim())
-        .join('\n')
-    );
-  const hunkHashes = hunkBodies.map((b) => crypto.createHash('sha1').update(b).digest('hex'));
-  if (hunkHashes.length && hunkHashes.every((h) => cache.has(h)) && !archFindings.length) exit0();
+  const hashes = hunkHashes(diff);
+  if (hashes.length && hashes.every((h) => cache.has(h)) && !tier0.length) {
+    logM({ outcome: 'cache-skip', blocked: false });
+    exit0();
+  }
 
-  // 6. route → ≤cap owners (+ secondaries on risk)
+  // 7. route → ≤cap owners (+ secondaries on risk)
   let routes = null;
   try {
     routes = JSON.parse(fs.readFileSync(path.join(cwd, '.claude', 'review-routes.json'), 'utf8'));
@@ -198,25 +236,36 @@ try {
   }
   if (!selected.length) selected = ['rust-backend-architect'];
 
-  // model by risk (from what MATCHED, not from what survived the cap)
-  const highRisk = securityMatched || owners.includes('job-match-expert');
-  const model = highRisk ? 'sonnet' : 'haiku';
+  // model by risk. sonnet across the board — haiku recall was the weakest link of
+  // the only auto-firing reviewer. Escalation switch for security diffs:
+  // const model = securityMatched ? 'opus' : 'sonnet';
+  const model = 'sonnet';
+  metric.model = model;
 
-  // owner checklists (strip frontmatter, bound size)
+  // owner checklists — 12K TOTAL budget; drop whole trailing owners, never truncate text
   const agentDir = path.join(cwd, '.claude', 'agents');
-  const checklists = selected
-    .map((name) => {
-      try {
-        const c = fs
-          .readFileSync(path.join(agentDir, name + '.md'), 'utf8')
-          .replace(/^---[\s\S]*?---/, '')
-          .trim();
-        return `### ${name}\n${c.slice(0, 5000)}`;
-      } catch {
-        return `### ${name}`;
-      }
-    })
-    .join('\n\n');
+  const CHECKLIST_BUDGET = 12000;
+  const consulted = [];
+  const notConsulted = [];
+  let checklists = '';
+  for (const name of selected) {
+    let body = '';
+    try {
+      body = fs
+        .readFileSync(path.join(agentDir, name + '.md'), 'utf8')
+        .replace(/^---[\s\S]*?---/, '')
+        .trim();
+    } catch {}
+    const entry = `### ${name}\n${body}\n\n`;
+    if (checklists.length + entry.length > CHECKLIST_BUDGET && consulted.length) {
+      notConsulted.push(name);
+      continue;
+    }
+    checklists += entry;
+    consulted.push(name);
+  }
+  if (notConsulted.length)
+    checklists += `(not consulted, over budget: ${notConsulted.join(', ')})\n`;
 
   // lessons retrieval by touched domain (proactive, folded into the same prompt)
   let lessons = '';
@@ -239,49 +288,66 @@ try {
     }
   } catch {}
 
-  // 7. Tier 1 — ONE batched claude -p
-  const prompt = `You are a STRICT but calibrated code reviewer. Review ONLY the diff below, applying the relevant reviewer checklists. Use the severity rubric EXACTLY. Output ONLY findings, one per line, as: \`SEVERITY · file:line · finding · one-line fix\` (SEVERITY ∈ LOW|MEDIUM|HIGH|CRITICAL). If there are no HIGH/CRITICAL issues, reply with exactly: APPROVED (optionally followed by LOW/MEDIUM advisory lines).
+  // learnings — known repo false positives (memory unification: the gate now reads
+  // the same store /review and pr-reviewer use)
+  const learnings = readLearnings(cwd, 4000);
+  const learningsBlock = learnings
+    ? `\n\n## Known repo false positives — do NOT re-raise any of these\n${learnings}`
+    : '';
+
+  // 8. Tier 1 — ONE batched claude -p, schema-1 JSON findings
+  const prompt = `You are a STRICT but calibrated code reviewer. Review ONLY the diff below, applying the relevant reviewer checklists.
 
 ## Severity rubric (STRICT — verify against the diff; do not assume coverage or key existence)
 - CRITICAL: exploitable security on a secret/credential/IPC/updater/network-egress path; data loss/corruption; breaks a release or CI gate.
 - HIGH: architecture-rule violation (std::env::var outside platform/, reqwest::Client outside net/, untyped Result<_,String> outside error/); changed non-trivial logic shipped WITHOUT a test, or a test whose assertion is weak/tautological/asserts the mock/doesn't exercise the change; untested error/edge/security path on changed code; provider-specific coupling in business logic; PII/temp-file-cleanup/retention regression; user-facing text whose i18n key is missing from en or de (or a t() referencing a non-existent key).
 - MEDIUM: unguarded hot-path perf regression, non-blocking correctness smell, a missing NON-critical edge-case test.
 - LOW: style/naming/comments/formatting/docs.
-STRICT tie-break: round UP for test-coverage, error/edge-path, i18n, security, and data findings; round down only for pure style/naming/docs. Only HIGH/CRITICAL are blocking.
+STRICT tie-break: round UP for test-coverage, error/edge-path, i18n, security, and data findings; round down only for pure style/naming/docs.
+
+${FINDING_CONTRACT}
 
 ## Reviewer checklists (apply only those whose area the diff touches)
-${checklists}${lessons}
+${checklists}${lessons}${learningsBlock}
 
 ## Diff
 \`\`\`diff
 ${diff}
 \`\`\`
 `;
-  let reviewOut = '';
-  try {
-    const r = spawnSync('claude', ['-p', '--model', model, '--output-format', 'text'], {
-      cwd,
-      input: prompt,
-      encoding: 'utf8',
-      shell: true,
-      env: { ...process.env, REVIEW_HOOK_ACTIVE: '1' },
-      timeout: 120000,
-      maxBuffer: 10 * 1024 * 1024,
-    });
-    reviewOut = (r.stdout || '').trim();
-  } catch {}
+  const r = runClaudeReview({ cwd, prompt, model });
+  metric.parse_retries = r.parseRetries;
 
-  // 8. aggregate + decide
-  const llmFindings =
-    reviewOut && !/^APPROVED/i.test(reviewOut)
-      ? reviewOut
-          .split('\n')
-          .map((s) => s.trim())
-          .filter(Boolean)
-      : [];
-  const all = [...archFindings, ...llmFindings];
-  const blocking = all.filter((l) => /\b(HIGH|CRITICAL)\b/.test(l));
-  const lowmed = llmFindings.filter((l) => !/\b(HIGH|CRITICAL)\b/.test(l) && !/^APPROVED/i.test(l));
+  // 9. deterministic verdict — from parsed findings, never from prose
+  let findings = [...tier0];
+  let fallbackNote = '';
+  if (r.findings) {
+    findings.push(...r.findings);
+  } else if (r.raw && r.parseFailed) {
+    // conservative fallback: unparseable output that talks about HIGH/CRITICAL blocks
+    if (/\b(HIGH|CRITICAL)\b/.test(r.raw) && !/^APPROVED/i.test(r.raw)) {
+      findings.push({
+        severity: 'HIGH',
+        category: 'correctness',
+        file: '(unparsed reviewer output)',
+        line: 0,
+        summary: 'reviewer flagged HIGH/CRITICAL but violated the output contract',
+        evidence: r.raw.slice(0, 1500),
+        fix: 'read the raw finding below and address it',
+        confidence: 1,
+        introduced_by_diff: true,
+      });
+      fallbackNote = `\n\nRaw reviewer output (contract violation):\n${r.raw.slice(0, 2000)}`;
+    }
+  }
+
+  const blocking = blockingFindings(findings, 0.6);
+  const unverified = findings.filter(
+    (f) => (f.severity === 'HIGH' || f.severity === 'CRITICAL') && !blocking.includes(f)
+  );
+  const lowmed = findings.filter((f) => f.severity === 'MEDIUM' || f.severity === 'LOW');
+  metric.findings = countBySeverity(findings);
+  if (r.parseFailed) metric.parse_failed = true;
 
   // advisories (non-blocking)
   const advisory = [];
@@ -303,32 +369,57 @@ ${diff}
   if (blocking.length) {
     // Do NOT cache blocking hunks. Unfixed HIGH/CRITICAL must be re-reviewed and
     // re-blocked on the next finish until it is actually fixed — no whitelist-on-block.
+    logM({ outcome: 'blocked', blocked: true });
     block(
-      `Review gate [${selected.join(', ')}] — blocking issues, address then finish:\n\n${blocking.join('\n')}` +
-        (advisory.length ? `\n\nAdvisory:\n- ${advisory.join('\n- ')}` : '')
+      `Review gate [${consulted.join(', ')}] — blocking issues, address then finish:\n\n${blocking
+        .map(formatFinding)
+        .join('\n')}` +
+        (unverified.length
+          ? `\n\nUnverified (low-confidence, advisory):\n${unverified.map(formatFinding).join('\n')}`
+          : '') +
+        (advisory.length ? `\n\nAdvisory:\n- ${advisory.join('\n- ')}` : '') +
+        fallbackNote
     );
   }
 
   // Fail-open, but visibly — and never cache hunks the model did not actually review.
-  if (!reviewOut) {
+  if (r.error === 'llm_unavailable') {
+    logM({ outcome: 'llm-unavailable', blocked: false, error: r.error });
     exit0('review-gate: LLM review skipped (reviewer unavailable) — diff NOT cached');
+  }
+  if (r.parseFailed) {
+    logM({ outcome: 'parse-failed', blocked: false });
+    exit0('review-gate: reviewer output unparseable (no HIGH/CRITICAL text) — diff NOT cached');
   }
 
   // No blocking findings → record reviewed hunks so a future finish skips this clean code.
   try {
     fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-    fs.appendFileSync(cachePath, hunkHashes.join('\n') + '\n');
+    fs.appendFileSync(cachePath, hashes.join('\n') + '\n');
     // bound growth: keep only the most recent ~2000 hashes
     const lines = fs.readFileSync(cachePath, 'utf8').split('\n').filter(Boolean);
     if (lines.length > 2000) fs.writeFileSync(cachePath, lines.slice(-2000).join('\n') + '\n');
   } catch {}
-  if (lowmed.length || advisory.length) {
-    let note = '✓ Review gate: no blocking issues.';
-    if (lowmed.length) note += `\nAdvisory findings:\n${lowmed.join('\n')}`;
-    if (advisory.length) note += `\nReminders:\n- ${advisory.join('\n- ')}`;
-    exit0(note);
-  }
+
+  const advisoryOut = [];
+  if (unverified.length)
+    advisoryOut.push(
+      `Unverified findings (confidence < 0.6):\n${unverified.map(formatFinding).join('\n')}`
+    );
+  if (lowmed.length)
+    advisoryOut.push(`Advisory findings:\n${lowmed.map(formatFinding).join('\n')}`);
+  if (advisory.length) advisoryOut.push(`Reminders:\n- ${advisory.join('\n- ')}`);
+  logM({ outcome: advisoryOut.length ? 'advisory' : 'clean', blocked: false });
+  if (advisoryOut.length) exit0(`✓ Review gate: no blocking issues.\n${advisoryOut.join('\n')}`);
   exit0();
-} catch {
+} catch (e) {
+  try {
+    logM({
+      outcome: 'error',
+      blocked: false,
+      error: 'gate_exception',
+      message: String(e && e.message).slice(0, 300),
+    });
+  } catch {}
   process.exit(0);
 }

--- a/.claude/hooks/review-gate.mjs
+++ b/.claude/hooks/review-gate.mjs
@@ -129,6 +129,9 @@ try {
       if (e && typeof e.stdout === 'string') segments.push(...splitByFile(e.stdout));
     }
   }
+  // count files that actually produced diff segments (a committed-then-reverted
+  // file is in nonSkipped but nets to zero) — metrics must reflect what was reviewed
+  metric.files = new Set(segments.map((s) => s.file)).size;
   const { diff, omitted, deletedCount } = assembleDiff(segments, MAX);
   if (!diff.trim()) exit0();
 
@@ -227,6 +230,21 @@ try {
   if (hashes.length && hashes.every((h) => cache.has(h)) && !tier0Blocking) {
     logM({ outcome: 'cache-skip', blocked: false });
     exit0();
+  }
+
+  // an INTRODUCED tier-0 hit is deterministic (confidence 1) — the verdict is
+  // already known, so don't spend an LLM review on it; the fixed code gets its
+  // full review on the next finish.
+  if (tier0Blocking) {
+    metric.model = 'none';
+    metric.findings = countBySeverity(tier0);
+    logM({ outcome: 'tier0-block', blocked: true });
+    block(
+      `Review gate [tier-0 arch guards] — blocking issues, address then finish:\n\n${tier0
+        .filter((t) => t.introduced_by_diff)
+        .map(formatFinding)
+        .join('\n')}`
+    );
   }
 
   // 7. route → ≤cap owners (+ secondaries on risk)

--- a/.claude/hooks/review-lib.mjs
+++ b/.claude/hooks/review-lib.mjs
@@ -94,8 +94,10 @@ export const assembleDiff = (segments, max = 60000) => {
   );
   let diff = '';
   const omitted = [];
+  let deletedCount = 0;
   for (const s of segs) {
     if (s.deleted) {
+      deletedCount += 1;
       diff += `# deleted: ${s.file} (-${s.dels} lines)\n`;
       continue;
     }
@@ -122,7 +124,7 @@ export const assembleDiff = (segments, max = 60000) => {
     omitted.push(`${s.file} (+${s.adds}/-${s.dels})`);
   }
   if (omitted.length) diff += `# omitted files (over budget): ${omitted.join(', ')}\n`;
-  return { diff, omitted };
+  return { diff, omitted, deletedCount };
 };
 
 // ─── hunk hashing (body-only, line-number agnostic) ──────────────────────────

--- a/.claude/hooks/review-lib.mjs
+++ b/.claude/hooks/review-lib.mjs
@@ -1,0 +1,317 @@
+/**
+ * review-lib.mjs — shared core for every AI-review surface (ADR-0008 program):
+ * the Stop gate (review-gate.mjs), the pre-push gate (scripts/pre-push-review.mjs)
+ * and the CI verdict script (scripts/ci-review-verdict.mjs).
+ *
+ * Owns the four contracts:
+ *  1. Finding schema v1 — the ONLY model output (one fenced ```json block).
+ *  2. Deterministic verdict — block/pass computed in JS from parsed findings,
+ *     never from model prose (`blockingFindings`).
+ *  3. Parse contract — last fenced json block → validate → ONE corrective retry
+ *     → conservative regex fallback (`runClaudeReview`).
+ *  4. Metrics — one JSONL line per meaningful run (`appendMetrics`).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+
+// ─── globs ───────────────────────────────────────────────────────────────────
+
+// Double-star prefix globs also match root files; u0001/u0002 are placeholders.
+export const globToRe = (g) =>
+  new RegExp(
+    '^' +
+      g
+        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+        .replace(/\*\*\//g, '')
+        .replace(/\*\*/g, '')
+        .replace(/\*/g, '[^/]*')
+        .replace(//g, '(?:.*/)?')
+        .replace(//g, '.*') +
+      '$'
+  );
+
+export const matchesAny = (file, globs) => (globs || []).some((g) => globToRe(g).test(file));
+
+/** Files no review surface should spend tokens on. */
+export const SKIP_GLOBS = [
+  'docs/knowledge/**',
+  '**/*.md',
+  '**/*.lock',
+  '**/pnpm-lock.yaml',
+  '**/package-lock.json',
+  '**/Cargo.lock',
+  '**/*.snap',
+  '**/snapshots/**',
+  '**/golden/**',
+  '**/*.gen.*',
+  '**/dist/**',
+  '**/build/**',
+  '**/target/**',
+  'graphify-out/**',
+];
+
+// ─── diff assembly (drop-order, never cut inside a hunk) ─────────────────────
+
+export const classifyFile = (f) => {
+  if (/\.(test|spec)\.|\/tests?\/|\/e2e\/|\/__tests__\//.test(f)) return 'test';
+  if (/\.(md|mdx|txt)$|^docs\//.test(f)) return 'docs';
+  return 'source';
+};
+
+/**
+ * Split one unified-diff blob into per-file segments.
+ * Returns [{ file, text, adds, dels, deleted }].
+ */
+export const splitByFile = (blob) => {
+  const segs = [];
+  if (!blob) return segs;
+  const parts = blob.split(/^(?=diff --git )/m).filter((p) => p.startsWith('diff --git '));
+  for (const text of parts) {
+    // `b/<path>` is authoritative (rename-aware); fall back to a/<path> for deletions.
+    const m = /^diff --git "?a\/([^"\n]+)"? "?b\/([^"\n]+)"?$/m.exec(text);
+    const file = m ? m[2] || m[1] : '';
+    if (!file) continue;
+    const adds = (text.match(/^\+(?!\+\+)/gm) || []).length;
+    const dels = (text.match(/^-(?!--)/gm) || []).length;
+    const deleted = /^deleted file mode /m.test(text);
+    segs.push({ file, text, adds, dels, deleted });
+  }
+  return segs;
+};
+
+/**
+ * Assemble per-file segments into one bounded diff, by priority: source → test →
+ * docs (PR-Agent drop-order). Deletions and over-budget files degrade to
+ * one-line notes; a single over-budget segment is cut at hunk boundaries only.
+ * Returns { diff, omitted } — omitted = ['file (+a/-b)'].
+ */
+export const assembleDiff = (segments, max = 60000) => {
+  const order = { source: 0, test: 1, docs: 2 };
+  const segs = [...segments].sort(
+    (a, b) => order[classifyFile(a.file)] - order[classifyFile(b.file)]
+  );
+  let diff = '';
+  const omitted = [];
+  for (const s of segs) {
+    if (s.deleted) {
+      diff += `# deleted: ${s.file} (-${s.dels} lines)\n`;
+      continue;
+    }
+    const room = max - diff.length;
+    if (s.text.length <= room) {
+      diff += s.text;
+      continue;
+    }
+    // Doesn't fit whole — keep the longest prefix of WHOLE hunks if there is
+    // real room left, otherwise degrade the file to a one-line note.
+    if (room > 4000) {
+      const starts = [...s.text.matchAll(/^@@.*$/gm)].map((h) => h.index);
+      let cut = 0; // cut BEFORE hunk i ⇒ keep hunks 0..i-1 fully
+      for (let i = 1; i < starts.length; i++) {
+        if (starts[i] <= room) cut = starts[i];
+        else break;
+      }
+      const keep = cut > 0 ? s.text.slice(0, cut) : '';
+      if (/^@@/m.test(keep)) {
+        diff += keep + `# …remaining hunks of ${s.file} omitted (+${s.adds}/-${s.dels} total)\n`;
+        continue;
+      }
+    }
+    omitted.push(`${s.file} (+${s.adds}/-${s.dels})`);
+  }
+  if (omitted.length) diff += `# omitted files (over budget): ${omitted.join(', ')}\n`;
+  return { diff, omitted };
+};
+
+// ─── hunk hashing (body-only, line-number agnostic) ──────────────────────────
+
+export const hunkBodies = (diff) =>
+  diff
+    .split(/^@@.*$/m)
+    .slice(1)
+    .map((h) =>
+      h
+        .split('\n')
+        .filter((l) => /^[+-]/.test(l) && !/^[+-]{3}/.test(l))
+        .map((l) => l.slice(1).trim())
+        .join('\n')
+    );
+
+export const hunkHashes = (diff) =>
+  hunkBodies(diff).map((b) => crypto.createHash('sha1').update(b).digest('hex'));
+
+// ─── finding schema v1 + deterministic verdict ───────────────────────────────
+
+export const SEVERITIES = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'];
+
+/** The output contract given verbatim to every review model. */
+export const FINDING_CONTRACT = `## Output contract (schema 1 — MANDATORY)
+Reply with EXACTLY ONE fenced \`\`\`json block and nothing else:
+\`\`\`json
+{ "schema": 1, "findings": [ {
+  "severity": "CRITICAL|HIGH|MEDIUM|LOW",
+  "category": "security|correctness|data-loss|arch|test-coverage|i18n|perf|style",
+  "file": "repo/relative/path", "line": 42,
+  "summary": "one sentence: the defect",
+  "evidence": "why it is real: traced path / quoted rule / constructed triggering input",
+  "fix": "one-line fix",
+  "confidence": 0.85,
+  "introduced_by_diff": true } ] }
+\`\`\`
+Rules: \`confidence\` is your calibrated probability (0-1) that the finding is real AND correctly
+severity-ranked — anything you cannot substantiate from the diff + checklists gets <= 0.5.
+\`introduced_by_diff\` is false ONLY for pre-existing defects in unchanged code. No findings ->
+\`{ "schema": 1, "findings": [] }\`. No prose outside the json block.`;
+
+/** Shape-validate + normalize a parsed candidate. Returns findings[] or null. */
+export const validateFindings = (obj) => {
+  if (!obj || typeof obj !== 'object' || !Array.isArray(obj.findings)) return null;
+  const out = [];
+  for (const f of obj.findings) {
+    if (!f || typeof f !== 'object') return null;
+    const severity = String(f.severity || '').toUpperCase();
+    if (!SEVERITIES.includes(severity)) return null;
+    if (typeof f.file !== 'string' || typeof f.summary !== 'string') return null;
+    out.push({
+      severity,
+      category: typeof f.category === 'string' ? f.category : 'correctness',
+      file: f.file,
+      line: Number.isFinite(Number(f.line)) ? Number(f.line) : 0,
+      summary: f.summary,
+      evidence: typeof f.evidence === 'string' ? f.evidence : '',
+      fix: typeof f.fix === 'string' ? f.fix : '',
+      confidence: Number.isFinite(Number(f.confidence))
+        ? Math.max(0, Math.min(1, Number(f.confidence)))
+        : 1,
+      introduced_by_diff: f.introduced_by_diff !== false,
+    });
+  }
+  return out;
+};
+
+/** Extract findings from model stdout: LAST fenced json block wins. */
+export const parseFindings = (stdout) => {
+  if (!stdout) return null;
+  const blocks = [...stdout.matchAll(/```json\s*([\s\S]*?)```/g)];
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    try {
+      const v = validateFindings(JSON.parse(blocks[i][1]));
+      if (v) return v;
+    } catch {}
+  }
+  // tolerate a bare JSON reply without fences
+  try {
+    const v = validateFindings(JSON.parse(stdout.trim()));
+    if (v) return v;
+  } catch {}
+  return null;
+};
+
+/**
+ * The deterministic gate. Never derived from model prose (a model saying
+ * "APPROVED" while listing a HIGH, or prose containing the word HIGH, must not
+ * decide anything).
+ */
+export const blockingFindings = (findings, minConfidence) =>
+  (findings || []).filter(
+    (f) =>
+      (f.severity === 'HIGH' || f.severity === 'CRITICAL') &&
+      (f.confidence ?? 1) >= minConfidence &&
+      f.introduced_by_diff !== false
+  );
+
+export const formatFinding = (f) =>
+  `${f.severity} · ${f.file}${f.line ? ':' + f.line : ''} · ${f.summary}${f.fix ? ' · ' + f.fix : ''}`;
+
+export const countBySeverity = (findings) => {
+  const c = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const f of findings || []) {
+    const k = f.severity.toLowerCase();
+    c[k] = (c[k] || 0) + 1;
+  }
+  return c;
+};
+
+// ─── claude -p driver (parse + one corrective retry) ─────────────────────────
+
+/**
+ * Run one non-interactive review. Returns
+ * { findings, raw, parseRetries, parseFailed, error } — findings === null means
+ * both parse attempts failed (caller decides the conservative fallback);
+ * error is set when the binary itself was unavailable / timed out.
+ */
+export const runClaudeReview = ({ cwd, prompt, model, timeoutMs = 120000 }) => {
+  const call = (p) => {
+    try {
+      const r = spawnSync('claude', ['-p', '--model', model, '--output-format', 'text'], {
+        cwd,
+        input: p,
+        encoding: 'utf8',
+        shell: true,
+        env: { ...process.env, REVIEW_HOOK_ACTIVE: '1' },
+        timeout: timeoutMs,
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return (r.stdout || '').trim();
+    } catch {
+      return '';
+    }
+  };
+  const first = call(prompt);
+  if (!first)
+    return {
+      findings: null,
+      raw: '',
+      parseRetries: 0,
+      parseFailed: false,
+      error: 'llm_unavailable',
+    };
+  let findings = parseFindings(first);
+  if (findings) return { findings, raw: first, parseRetries: 0, parseFailed: false, error: null };
+  const second = call(
+    prompt +
+      '\n\n## CONTRACT VIOLATION\nYour previous reply was not a single valid schema-1 json block. Re-emit ONLY the findings JSON — one fenced ```json block, no prose.'
+  );
+  findings = parseFindings(second);
+  return {
+    findings,
+    raw: second || first,
+    parseRetries: 1,
+    parseFailed: !findings,
+    error: null,
+  };
+};
+
+// ─── metrics ─────────────────────────────────────────────────────────────────
+
+const METRICS_MAX_LINES = 5000;
+
+/** Append one metrics record; never throws. */
+export const appendMetrics = (cwd, record) => {
+  try {
+    const p = path.join(cwd, '.claude', '.review-metrics.jsonl');
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.appendFileSync(p, JSON.stringify({ ts: new Date().toISOString(), ...record }) + '\n');
+    const lines = fs.readFileSync(p, 'utf8').split('\n').filter(Boolean);
+    if (lines.length > METRICS_MAX_LINES)
+      fs.writeFileSync(p, lines.slice(-METRICS_MAX_LINES).join('\n') + '\n');
+  } catch {}
+};
+
+// ─── learnings (review-config.md — the FP memory pr-reviewer already uses) ───
+
+/**
+ * Return the learnings sections of .claude/review-config.md (everything from the
+ * first learnings-ish heading to EOF), capped. '' when absent.
+ */
+export const readLearnings = (cwd, capChars = 4000) => {
+  try {
+    const txt = fs.readFileSync(path.join(cwd, '.claude', 'review-config.md'), 'utf8');
+    const m = /^## (Learnings|Hard exclusions)[\s\S]*$/m.exec(txt);
+    return m ? m[0].slice(0, capChars) : '';
+  } catch {
+    return '';
+  }
+};

--- a/.claude/review-routes.json
+++ b/.claude/review-routes.json
@@ -38,6 +38,7 @@
     { "glob": "apps/desktop/src/**", "owner": "frontend-reviewer" },
     { "glob": "apps/desktop/src-tauri/src/**", "owner": "rust-backend-architect" },
     { "glob": "packages/shared/**", "owner": "rust-backend-architect" },
+    { "glob": ".claude/**", "owner": "project-steward" },
     { "glob": "landing/**", "owner": "project-steward" },
     { "glob": "docs/**", "owner": "project-steward" },
     { "glob": "scripts/**", "owner": "project-steward" },

--- a/.claude/review-routes.json
+++ b/.claude/review-routes.json
@@ -38,6 +38,7 @@
     { "glob": "apps/desktop/src/**", "owner": "frontend-reviewer" },
     { "glob": "apps/desktop/src-tauri/src/**", "owner": "rust-backend-architect" },
     { "glob": "packages/shared/**", "owner": "rust-backend-architect" },
+    { "glob": ".claude/hooks/**", "owner": "code-quality-reviewer" },
     { "glob": ".claude/**", "owner": "project-steward" },
     { "glob": "landing/**", "owner": "project-steward" },
     { "glob": "docs/**", "owner": "project-steward" },

--- a/.gitignore
+++ b/.gitignore
@@ -207,6 +207,7 @@ temp/
 .claude/settings.local.json
 .claude/memory/
 .claude/.review-cache
+.claude/.review-metrics.jsonl
 .claude/*.bak-ruflo
 .claude-flow*
 # Per-task handoff files are transient; the template is committed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Cross-cutting critics (no author — fixes route to the owning domain author): `
 **Hard rules:**
 
 - **Main session never edits source directly** — delegate all code changes to a domain author via `Agent`. Exceptions: `CLAUDE.md`, `.claude/**` meta-config, plan files, single-char typo fixes.
-- **Trivial diffs skip the swarm** (docs/config/rename/one-liners) — the Stop review-gate (`.claude/hooks/review-gate.mjs`) reviews the real diff regardless; only HIGH/CRITICAL block, once per finish-chain, inert in plan mode.
+- **Trivial diffs skip the swarm** (docs/config/rename/one-liners) — the Stop review-gate (`.claude/hooks/review-gate.mjs`) reviews the full branch diff (committed + working tree) regardless; blocks on parsed HIGH/CRITICAL findings with confidence ≥ 0.6 (deterministic verdict, schema-1 JSON — never prose matching), once per finish-chain, inert in plan mode. Every run logs to `.claude/.review-metrics.jsonl`.
 - **Lessons** (`.claude/memory/lessons.jsonl`) — only `project-steward` writes; others propose via `LESSON · category · Context/Decision/Outcome`.
 - **Cross-session recall** — all agents may call `mcp__mcp-search` (claude-mem: `search`/`timeline`/`get_observations`/`memory_search`/`memory_context`) for prior-session context. Provided by the user-installed `thedotmack/claude-mem` plugin, not the repo — absent if the plugin isn't installed (the allowlist entry then just no-ops). Honor `docs/` path-privacy + `<private>` for PII.
 

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
@@ -295,10 +295,11 @@ export function BoardSummaryChips({ summaries, className }: BoardSummaryChipsPro
           className="max-w-[220px] whitespace-normal break-words text-[10px] font-normal"
         >
           {c.board ? (
-            <>
+            <span className="min-w-0">
               <span className="font-semibold">{c.board}</span>
-              <span>· {c.detail}</span>
-            </>
+              {' · '}
+              {c.detail}
+            </span>
           ) : (
             c.detail
           )}

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
@@ -295,7 +295,7 @@ export function BoardSummaryChips({ summaries, className }: BoardSummaryChipsPro
           className="max-w-[220px] whitespace-normal break-words text-[10px] font-normal"
         >
           {c.board ? (
-            <span className="min-w-0">
+            <span>
               <span className="font-semibold">{c.board}</span>
               {' · '}
               {c.detail}


### PR DESCRIPTION
PR 1 of 6 — review-system hardening program (ADR-0008, in progress). Keystone: every downstream PR (ensemble review, ast-grep tier-0, findings ledger, pre-push gate, CI required check) consumes the contracts introduced here.

## What

- **NEW \`.claude/hooks/review-lib.mjs\`** — shared core for all AI-review surfaces:
  - schema-1 finding contract (severity/category/file/line/summary/evidence/fix/confidence/introduced_by_diff) — the ONLY model output, one fenced json block
  - \`parseFindings\` (last fenced block wins) + \`runClaudeReview\` (ONE corrective retry, then conservative fallback)
  - \`blockingFindings(findings, minConfidence)\` — the deterministic verdict, computed in JS, never from model prose
  - drop-order diff assembly (source → tests → docs; never cuts inside a hunk; deletions/over-budget files degrade to one-line notes)
  - metrics appender + review-config learnings reader
- **\`.claude/hooks/review-gate.mjs\`** rewritten on the lib:
  - scope = full branch range (merge-base with origin/main → HEAD) ∪ working tree ∪ untracked — **committing no longer blinds the gate**
  - rename-aware (\`git diff -M\`); 60K budget applied at hunk boundaries instead of a mid-hunk slice
  - checklists: 12K total budget, drops whole trailing owners (named in prompt) instead of truncating text mid-rule
  - default model haiku → sonnet
  - verdict: parsed HIGH/CRITICAL findings with confidence ≥ 0.6 block; the \`/\b(HIGH|CRITICAL)\b/\` prose regex no longer decides anything (low-confidence highs surface as "unverified" advisories)
  - prompt now includes review-config learnings beside lessons (memory unification, half 1)
  - one metrics line per meaningful run → \`.claude/.review-metrics.jsonl\` (gitignored), including cache-skips, llm-unavailable, parse failures, and the fail-open exception path — fail-open stays, silence ends
- **\`ui:\` side-fix** (user-reported): long board-chip notes (aggregator broadened-location text) wrapped into a narrow flex column beside the label; chip content is now a single inline text run.

## Verification

15-case harness (isolated throwaway repo + stateful fake \`claude\` shim), all passing:
- tier-0 canary (\`std::env::var\` outside \`platform/\`) blocks deterministically, metrics \`blocked\`
- seeded HIGH at confidence 0.9 blocks; same finding at 0.3 passes and is listed as unverified (threshold is real)
- garbage output once → corrective retry parses (\`parse_retries: 1\`); garbage twice without HIGH text → fail-open, diff NOT cached, \`parse_failed\` metric; garbage twice WITH high/critical text → conservative fallback block
- clean run writes cache; identical second run makes zero claude calls (\`cache-skip\` metric)
- committed-then-clean-tree branch still reviewed and blocked (commit-blindness fix)
- \`pnpm check:agent-system\` green; chip fix: 50/50 vitest, typecheck, lint:strict all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)