### PR TITLE
chore: ast-grep tier-0 rule pack and gitleaks secret scan

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -34,7 +34,7 @@ pasted their outputs into your prompt, use those — do NOT re-run them.** Other
 - **Cross-OS / `#[cfg]` blind spot:** full doctrine in `.claude/review-checklists/rust.md` — a same-host cargo run silently excludes other-OS `#[cfg]` code; treat touched OS-gated code as **UNVERIFIED** (require a cross-target `cargo check --target …` or hand-review the gated bodies). Never report 🟢/PASS on cfg-gated code a same-host build can't compile.
 - If `packages/shared/**` IPC contracts/schemas changed: `rtk pnpm gen:ipc:check` (must be clean) and confirm `mock-client.ts` mirrors any new method.
 - **Targeted tests**: run the test files covering the touched code (not the full suite) — `rtk pnpm --filter @ajh/desktop test <paths>` / the owning package filter.
-- **Secret scan**: grep the diff for hardcoded secrets/keys/tokens (API keys, `adzuna` app_id/app_key literals, private keys, `Authorization:` bearer literals). Any committed secret is 🔴.
+- **Secret scan**: prefer `gitleaks` when on PATH — `gitleaks detect --no-banner --log-opts "<base>..HEAD"` for committed changes plus `gitleaks protect --staged --no-banner` for staged ones (install: `winget install gitleaks` / `scoop install gitleaks`). If absent, fall back to grepping the diff for hardcoded secrets/keys/tokens (API keys, `adzuna` app_id/app_key literals, private keys, `Authorization:` bearer literals) and say the scan was grep-only. Any committed secret is 🔴.
 
 A tool failure the diff caused is a finding. Quote the tool's own output.
 

--- a/.claude/hooks/review-gate.mjs
+++ b/.claude/hooks/review-gate.mjs
@@ -151,8 +151,10 @@ try {
     exit0();
   }
 
-  // 5. Tier 0 — architecture guards (deterministic findings, confidence 1.0).
-  // ponytail: JS regex over changed .rs contents; PR 3 swaps this for ast-grep.
+  // 5. Tier 0 — deterministic guards (confidence 1.0). Primary: the ast-grep pack
+  // (.claude/review-rules/*.yml, discovered via repo-root sgconfig.yml — never pass
+  // -c, it silently breaks the rules' files: globs). Fallback: legacy JS regexes
+  // when the binary is unavailable.
   const findLine = (content, re) => {
     const i = content.split('\n').findIndex((l) => re.test(l));
     return i >= 0 ? i + 1 : 0;
@@ -169,52 +171,94 @@ try {
       .join('\n');
     addedByFile.set(s.file, (addedByFile.get(s.file) || '') + added + '\n');
   }
+  const introducedIn = (file, snippet) => {
+    const probe = (snippet || '').split('\n')[0].trim();
+    return probe ? (addedByFile.get(file) || '').includes(probe) : false;
+  };
   const tier0 = [];
-  const arch = (file, line, summary, fix, introduced) =>
-    tier0.push({
-      severity: 'HIGH',
-      category: 'arch',
-      file,
-      line,
-      summary: introduced ? summary : `${summary} (pre-existing)`,
-      evidence: introduced
-        ? 'deterministic Tier-0 guard (docs/architecture-rules.md)'
-        : 'pre-existing in a touched file — not introduced by this diff',
-      fix,
-      confidence: 1,
-      introduced_by_diff: introduced,
-    });
-  const ARCH_RULES = [
-    [
-      /std::env::var\b/,
-      /\/platform\//,
-      'std::env::var outside platform/',
-      'move env access into platform/config.rs',
-    ],
-    [/reqwest::Client\b/, /\/net\//, 'reqwest::Client outside net/', 'use net/http.rs shared()'],
-    [
-      /Result<[^>]*,\s*String\s*>/,
-      /\/error(\.rs|\/)/,
-      'untyped Result<_, String> outside error/',
-      'use AppError/AppResult',
-    ],
-  ];
-  for (const f of nonSkipped) {
-    if (!f.endsWith('.rs')) continue;
-    let content = '';
-    try {
-      content = fs.readFileSync(path.join(cwd, f), 'utf8');
-    } catch {
-      continue;
+  let sgRan = false;
+  try {
+    // ast-grep exits 1 when error findings exist — that is a result, not a failure;
+    // forward-slash repo-relative paths only (backslashes break files: globs).
+    const r = spawnSync(
+      'pnpm',
+      ['exec', 'ast-grep', 'scan', '--json=compact', '--', ...nonSkipped],
+      { cwd, encoding: 'utf8', shell: true, timeout: 60000, maxBuffer: 20 * 1024 * 1024 }
+    );
+    const matches = JSON.parse(r.stdout || '');
+    sgRan = true;
+    for (const m of matches) {
+      const file = String(m.file || '').replace(/\\/g, '/');
+      const introduced = introducedIn(file, m.text);
+      tier0.push({
+        severity: m.severity === 'error' ? 'HIGH' : 'MEDIUM',
+        category: 'arch',
+        file,
+        line: (m.range && m.range.start && m.range.start.line + 1) || 0,
+        summary: (m.message || m.ruleId) + (introduced ? '' : ' (pre-existing)'),
+        evidence: introduced
+          ? `ast-grep rule ${m.ruleId}`
+          : `ast-grep rule ${m.ruleId} — pre-existing in a touched file, not introduced by this diff`,
+        fix: m.note || '',
+        confidence: 1,
+        introduced_by_diff: introduced,
+      });
     }
-    const p = '/' + f;
-    const added = addedByFile.get(f) || '';
-    // true = introduced by the diff, false = pre-existing, null = absent
-    const hit = (re) => (re.test(added) ? true : re.test(content) ? false : null);
-    for (const [re, exemptRe, summary, fix] of ARCH_RULES) {
-      if (exemptRe.test(p)) continue;
-      const h = hit(re);
-      if (h !== null) arch(f, findLine(content, re), summary, fix, h);
+  } catch {}
+  if (!sgRan) {
+    metric.sg_fallback = true;
+    const arch = (file, line, summary, fix, introduced) =>
+      tier0.push({
+        severity: 'HIGH',
+        category: 'arch',
+        file,
+        line,
+        summary: introduced ? summary : `${summary} (pre-existing)`,
+        evidence: introduced
+          ? 'deterministic Tier-0 guard (docs/architecture-rules.md)'
+          : 'pre-existing in a touched file — not introduced by this diff',
+        fix,
+        confidence: 1,
+        introduced_by_diff: introduced,
+      });
+    const ARCH_RULES = [
+      [
+        /std::env::var(_os)?\b/,
+        /\/platform\//,
+        'std::env::var outside platform/',
+        'move env access into platform/config.rs',
+      ],
+      [
+        // R5 is about CONSTRUCTION — using the reqwest::Client type elsewhere is fine
+        /reqwest::Client::(new|builder)\(|reqwest::ClientBuilder::new\(/,
+        /\/net\//,
+        'reqwest client constructed outside net/',
+        'use net/http.rs shared()/build_client()',
+      ],
+      [
+        /Result<[^>]*,\s*String\s*>/,
+        /\/error(\.rs|\/)/,
+        'untyped Result<_, String> outside error/',
+        'use AppError/AppResult',
+      ],
+    ];
+    for (const f of nonSkipped) {
+      if (!f.endsWith('.rs')) continue;
+      let content = '';
+      try {
+        content = fs.readFileSync(path.join(cwd, f), 'utf8');
+      } catch {
+        continue;
+      }
+      const p = '/' + f;
+      const added = addedByFile.get(f) || '';
+      // true = introduced by the diff, false = pre-existing, null = absent
+      const hit = (re) => (re.test(added) ? true : re.test(content) ? false : null);
+      for (const [re, exemptRe, summary, fix] of ARCH_RULES) {
+        if (exemptRe.test(p)) continue;
+        const h = hit(re);
+        if (h !== null) arch(f, findLine(content, re), summary, fix, h);
+      }
     }
   }
 
@@ -225,8 +269,8 @@ try {
     cache = new Set(fs.readFileSync(cachePath, 'utf8').split('\n').filter(Boolean));
   } catch {}
   const hashes = hunkHashes(diff);
-  // pre-existing (non-blocking) tier-0 hits must not defeat the cache forever
-  const tier0Blocking = tier0.some((t) => t.introduced_by_diff);
+  // pre-existing / warning-severity tier-0 hits must not defeat the cache forever
+  const tier0Blocking = tier0.some((t) => t.introduced_by_diff && t.severity === 'HIGH');
   if (hashes.length && hashes.every((h) => cache.has(h)) && !tier0Blocking) {
     logM({ outcome: 'cache-skip', blocked: false });
     exit0();
@@ -241,7 +285,7 @@ try {
     logM({ outcome: 'tier0-block', blocked: true });
     block(
       `Review gate [tier-0 arch guards] — blocking issues, address then finish:\n\n${tier0
-        .filter((t) => t.introduced_by_diff)
+        .filter((t) => t.introduced_by_diff && t.severity === 'HIGH')
         .map(formatFinding)
         .join('\n')}`
     );

--- a/.claude/hooks/review-gate.mjs
+++ b/.claude/hooks/review-gate.mjs
@@ -180,12 +180,17 @@ try {
   try {
     // ast-grep exits 1 when error findings exist — that is a result, not a failure;
     // forward-slash repo-relative paths only (backslashes break files: globs).
+    // shell:true is required on Windows (pnpm is a .cmd) — quote every path so
+    // spaces/metacharacters in a filename can't break or be interpreted by the shell.
     const r = spawnSync(
       'pnpm',
-      ['exec', 'ast-grep', 'scan', '--json=compact', '--', ...nonSkipped],
+      ['exec', 'ast-grep', 'scan', '--json=compact', '--', ...nonSkipped.map((f) => `"${f}"`)],
       { cwd, encoding: 'utf8', shell: true, timeout: 60000, maxBuffer: 20 * 1024 * 1024 }
     );
-    const matches = JSON.parse(r.stdout || '');
+    const out = (r.stdout || '').trim();
+    // distinguish "ran clean, empty output" from "binary missing/errored" — only the
+    // latter may fall back to the legacy regexes
+    const matches = !r.error && r.status === 0 && !out ? [] : JSON.parse(out);
     sgRan = true;
     for (const m of matches) {
       const file = String(m.file || '').replace(/\\/g, '/');
@@ -229,10 +234,11 @@ try {
         'move env access into platform/config.rs',
       ],
       [
-        // R5 is about CONSTRUCTION — using the reqwest::Client type elsewhere is fine
+        // R5 is about CONSTRUCTION — using the reqwest::Client type elsewhere is fine.
+        // exempt only net/http.rs, matching the ast-grep rule's ignores exactly
         /reqwest::Client::(new|builder)\(|reqwest::ClientBuilder::new\(/,
-        /\/net\//,
-        'reqwest client constructed outside net/',
+        /\/net\/http\.rs$/,
+        'reqwest client constructed outside net/http.rs',
         'use net/http.rs shared()/build_client()',
       ],
       [

--- a/.claude/review-rules/rust-env-var-outside-platform.yml
+++ b/.claude/review-rules/rust-env-var-outside-platform.yml
@@ -1,0 +1,13 @@
+id: rust-env-var-outside-platform
+language: rust
+severity: error
+message: std::env::var outside platform/ — move env access into platform/config.rs
+note: docs/architecture-rules.md — env access is centralized in the platform layer (CI-enforced by cargo test --test architecture)
+files:
+  - apps/desktop/src-tauri/src/**
+ignores:
+  - '**/platform/**'
+rule:
+  any:
+    - pattern: std::env::var($$$A)
+    - pattern: std::env::var_os($$$A)

--- a/.claude/review-rules/rust-reqwest-construct-outside-net.yml
+++ b/.claude/review-rules/rust-reqwest-construct-outside-net.yml
@@ -1,0 +1,14 @@
+id: rust-reqwest-construct-outside-net
+language: rust
+severity: error
+message: reqwest client CONSTRUCTED outside net/http.rs — use net::http shared()/build_client()
+note: docs/architecture-rules.md R5 — construction only; using the reqwest::Client type elsewhere is fine
+files:
+  - apps/desktop/src-tauri/src/**
+ignores:
+  - '**/net/http.rs'
+rule:
+  any:
+    - pattern: reqwest::Client::new($$$A)
+    - pattern: reqwest::Client::builder($$$A)
+    - pattern: reqwest::ClientBuilder::new($$$A)

--- a/.claude/review-rules/rust-result-string-outside-error.yml
+++ b/.claude/review-rules/rust-result-string-outside-error.yml
@@ -1,0 +1,13 @@
+id: rust-result-string-outside-error
+language: rust
+severity: error
+message: untyped Result<_, String> outside error/ — use AppError/AppResult
+note: docs/architecture-rules.md — error types are centralized in the error layer
+files:
+  - apps/desktop/src-tauri/src/**
+ignores:
+  - '**/error/**'
+  - '**/error.rs'
+rule:
+  kind: generic_type
+  regex: 'Result<[^>]*,\s*String\s*>'

--- a/.claude/review-rules/ts-gctime-infinity.yml
+++ b/.claude/review-rules/ts-gctime-infinity.yml
@@ -1,0 +1,15 @@
+id: ts-gctime-infinity
+language: typescript
+severity: warning
+message: "gcTime: Infinity pins every distinct query key's payload for the app lifetime — keep gcTime finite on dynamic keys (staleTime: Infinity is fine for immutable data)"
+note: pr-reviewer frontend checklist — React Query cache hygiene
+files:
+  - apps/desktop/src/renderer/**
+rule:
+  pattern:
+    context: 'const q = { gcTime: Infinity }'
+    selector: pair
+ignores:
+  - '**/*.test.*'
+  - '**/*.spec.*'
+  - '**/test-support*'

--- a/.claude/review-rules/tsx-gctime-infinity.yml
+++ b/.claude/review-rules/tsx-gctime-infinity.yml
@@ -1,0 +1,15 @@
+id: tsx-gctime-infinity
+language: tsx
+severity: warning
+message: "gcTime: Infinity pins every distinct query key's payload for the app lifetime — keep gcTime finite on dynamic keys (staleTime: Infinity is fine for immutable data)"
+note: pr-reviewer frontend checklist — React Query cache hygiene
+files:
+  - apps/desktop/src/renderer/**
+rule:
+  pattern:
+    context: 'const q = { gcTime: Infinity }'
+    selector: pair
+ignores:
+  - '**/*.test.*'
+  - '**/*.spec.*'
+  - '**/test-support*'

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -264,6 +264,28 @@ If a commit is rejected, check the terminal output for the specific lint error. 
 
 ---
 
+## Deterministic Review Tooling
+
+The Stop review-gate runs **Tier-0 structural linters** to catch regressions before human review:
+
+```bash
+pnpm scan:rules              # ast-grep structural rules from .claude/review-rules/*.yml
+```
+
+These rules are zero-false-positive and **mandatory** — the repo must always scan clean. A rule that fires on `main` is either a real regression (fix the code) or a bad rule (disable/refine in `sgconfig.yml`). Rules check for unsafe patterns (environment variables outside platform modules, Result-to-string conversions, GC infinity bugs in queries, etc.) — see `.claude/review-rules/*.yml` for the full catalog.
+
+For **secret scanning** during local review (before push), install [gitleaks](https://github.com/gitleaks/gitleaks):
+
+```bash
+winget install gitleaks              # Windows
+brew install gitleaks                # macOS
+scoop install gitleaks               # Windows (alternative)
+```
+
+Then run `gitleaks detect --source . -v` in the repo root to catch hardcoded credentials, API keys, etc. The reviewer falls back to a grep-based scan if gitleaks is absent.
+
+---
+
 ## Optional: Knowledge-Graph MCP (graphify)
 
 [graphify](https://pypi.org/project/graphifyy/) builds a queryable knowledge graph of the codebase under `graphify-out/`. It can also run as a local [MCP](https://modelcontextprotocol.io) server, exposing `query` / `explain` / `path` retrieval to AI dev tools (Claude Code, etc.) — usually far cheaper than grepping raw files.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -272,13 +272,14 @@ The Stop review-gate runs **Tier-0 structural linters** to catch regressions bef
 pnpm scan:rules              # ast-grep structural rules from .claude/review-rules/*.yml
 ```
 
-These rules are zero-false-positive and **mandatory** — the repo must always scan clean. A rule that fires on `main` is either a real regression (fix the code) or a bad rule (disable/refine in `sgconfig.yml`). Rules check for unsafe patterns (environment variables outside platform modules, Result-to-string conversions, GC infinity bugs in queries, etc.) — see `.claude/review-rules/*.yml` for the full catalog.
+These rules are zero-false-positive and **mandatory** — the repo must always scan clean. A rule that fires on `main` is either a real regression (fix the code) or a bad rule (disable/refine in the rule's YAML under `.claude/review-rules/*.yml`). Rules check for unsafe patterns (environment variables outside platform modules, Result-to-string conversions, GC infinity bugs in queries, etc.) — see `.claude/review-rules/*.yml` for the full catalog.
 
 For **secret scanning** during local review (before push), install [gitleaks](https://github.com/gitleaks/gitleaks):
 
 ```bash
 winget install gitleaks              # Windows
 brew install gitleaks                # macOS
+apt install gitleaks                 # Linux (Debian/Ubuntu)
 scoop install gitleaks               # Windows (alternative)
 ```
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gen:ipc:check": "pnpm --filter @ajh/shared gen:ipc:check",
     "gen:workflows": "node scripts/gen-workflow-catalog.mjs && prettier --write .github/workflows/README.md README.md",
     "gen:workflows:check": "node scripts/gen-workflow-catalog.mjs && prettier --write .github/workflows/README.md README.md && git diff --exit-code -- .github/workflows/README.md README.md",
+    "scan:rules": "ast-grep scan",
     "check:landing-drift": "node scripts/check-landing-drift.mjs",
     "check:agent-system": "node scripts/check-agent-system.mjs",
     "clean": "pnpm -r exec rimraf dist out .turbo node_modules/.cache",
@@ -39,6 +40,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@ast-grep/cli": "^0.44.1",
     "@axe-core/playwright": "^4.12.1",
     "@commitlint/cli": "^21.2.0",
     "@commitlint/config-conventional": "^21.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      '@ast-grep/cli':
+        specifier: ^0.44.1
+        version: 0.44.1
       '@axe-core/playwright':
         specifier: ^4.12.1
         version: 4.12.1(playwright-core@1.61.1)
@@ -441,6 +444,55 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@ast-grep/cli-darwin-arm64@0.44.1':
+    resolution: {integrity: sha512-wOzb+IqFy4Pdhvs+PeaHdQJ1VemsI1SgoOGJf+x0J0KBSJ+s/hUg2n1fVJwfsrw/XDIbz9m7PGKTGCLxsgYa1g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/cli-darwin-x64@0.44.1':
+    resolution: {integrity: sha512-X3OzzsnO9Q3ISQ4qO3jasWk8EZhJA03xfmJHhuS9rGJZZCbNEuqjicrwrDMKK8EgEGJ7MG4oL0BE5qUcn3twLw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/cli-linux-arm64-gnu@0.44.1':
+    resolution: {integrity: sha512-2F1YBRd9tQnfrGX+4BlkfXWLb2jqNgTmjp0ETLNRLMmSDinR905QsZn2A55qcAZxhQDU982mEzzgT4NduPXIGg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-linux-x64-gnu@0.44.1':
+    resolution: {integrity: sha512-d5UNoDLT2i6xV4GGqcPnrAR6CB3H078+v3BiqjKxZdZMHFnDe46+i+DxfH1IK6yvJqViqv2F611+wiAAn/s7qw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-win32-arm64-msvc@0.44.1':
+    resolution: {integrity: sha512-r6K49Z14BLOeJdBSmaoK+TdgtPRqJfJ562F0n0KvRi0qH3o8is8N2dXtEMYKynYm/tdOd65i69Mc1WKSuIeWyA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/cli-win32-ia32-msvc@0.44.1':
+    resolution: {integrity: sha512-AusXTP5SfUQEL/EkF0fhHoA4H30M7hsVgvsVEZ7PeZrxB69trzUcqKnHC8pBDYTmgIsJsr9dtXjTPDcBauaPiA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/cli-win32-x64-msvc@0.44.1':
+    resolution: {integrity: sha512-gDMHT17Edmp/tXTDdMSQHd9vJki2Y2WSXq9ycrvjziHwpmnsnc6xlCQ7SEOGA1987vepSpkOkqBCPliP2TVW0w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/cli@0.44.1':
+    resolution: {integrity: sha512-wSjtu0/9xSYzzo/EW31w5pf1qB33tejYKmKXb2nBAlZ5PpYtOqwFmk9H1nywhjzO913beugsKAZYxrwciqW9AQ==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
 
   '@axe-core/playwright@4.12.1':
     resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
@@ -6015,6 +6067,39 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@ast-grep/cli-darwin-arm64@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-darwin-x64@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-linux-arm64-gnu@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-linux-x64-gnu@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-win32-arm64-msvc@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-win32-ia32-msvc@0.44.1':
+    optional: true
+
+  '@ast-grep/cli-win32-x64-msvc@0.44.1':
+    optional: true
+
+  '@ast-grep/cli@0.44.1':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@ast-grep/cli-darwin-arm64': 0.44.1
+      '@ast-grep/cli-darwin-x64': 0.44.1
+      '@ast-grep/cli-linux-arm64-gnu': 0.44.1
+      '@ast-grep/cli-linux-x64-gnu': 0.44.1
+      '@ast-grep/cli-win32-arm64-msvc': 0.44.1
+      '@ast-grep/cli-win32-ia32-msvc': 0.44.1
+      '@ast-grep/cli-win32-x64-msvc': 0.44.1
 
   '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 overrides:
   esbuild: '>=0.28.1 <0.29'
 allowBuilds:
+  '@ast-grep/cli': true
   '@swc/core': true
   better-sqlite3: true
   core-js: false

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,2 @@
+ruleDirs:
+  - .claude/review-rules


### PR DESCRIPTION
PR 3 of 6 — review-system hardening program. Deterministic invariants move out of prose/regex into versioned, testable structural rules.

## What

- **NEW \`.claude/review-rules/*.yml\`** — five ast-grep rules, every one validated against the real repo before landing:
  - \`rust-env-var-outside-platform\` (error, also matches \`var_os\`) — 0 repo hits
  - \`rust-reqwest-construct-outside-net\` (error) — **construction-only** (\`Client::new/builder\`, \`ClientBuilder::new\`), aligned to \`tests/architecture.rs\` R5. The naive "type mention" form had 2 false positives in \`scraping/\` — which also exposed that the gate's legacy regex had the same latent false-block; fixed here too.
  - \`rust-result-string-outside-error\` (error) — 0 repo hits
  - \`ts-gctime-infinity\` + \`tsx-gctime-infinity\` (warning; one rule per language — a tsx rule never matches .ts files) — ignore test files (3 test QueryClients legitimately pin gcTime)
- **Deliberately dropped** two planned rules after the repo scan: unwrap-in-LazyLock-init (72 pre-existing hits — known-good literal regexes in statics are house style; "fallible/externally-influenced" is reviewer judgment) and \`json!(ident)\` in commands (40 hits — struct-vs-contract-shaped-local isn't mechanically decidable). Both stay prose-only in the review checklists. Zero-false-positive is the acceptance bar for blocking rules.
- **Stop gate Tier 0**: primary = \`pnpm exec ast-grep scan --json=compact\` over the changed files (repo-root \`sgconfig.yml\` auto-discovery — \`-c\` from elsewhere silently breaks \`files:\` globs; forward-slash paths required). error→HIGH conf 1.0, warning→MEDIUM advisory; PR 1's added-lines gating still applies (pre-existing hits in touched files stay non-blocking). Introduced HIGH hits short-circuit to a **zero-LLM deterministic block**. Legacy regexes remain only as fallback when the binary is missing (logged as \`sg_fallback\`).
- **pr-reviewer secret scan**: prefers \`gitleaks\` (\`detect --log-opts\` + \`protect --staged\`) when on PATH, grep fallback with an install hint otherwise (no downloader script — gitleaks has no npm package; CI enforcement comes in PR 6).
- Tooling: \`@ast-grep/cli\` devDependency (+ build approval in \`pnpm-workspace.yaml\`), \`scan:rules\` script, docs note in DEVELOPMENT.md.

## Verification

- \`pnpm scan:rules\` clean repo-wide (the FP audit).
- All five rules proven to FIRE on positive fixtures (a never-firing rule scans clean forever — worse than no rule).
- Live canary through the real gate: untracked \`std::env::var\` file → \`tier0-block\` via the sg rule in 1.4s, \`model: "none"\`, no \`sg_fallback\` in metrics — zero LLM spend.
- Gate harness 21/21 (test repos exercise the regex-fallback path); \`check:agent-system\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)