### PR TITLE
chore: findings ledger with convergence and review-stats

### DIFF
--- a/.claude/commands/review-stats.md
+++ b/.claude/commands/review-stats.md
@@ -1,0 +1,33 @@
+---
+description: Review-system health report from .claude/.review-metrics.jsonl + .review-ledger.jsonl — findings/run, block/parse-fail/fallback rates, suppression, resolution, and best-effort CodeRabbit miss rate
+argument-hint: [days back, default 30]
+---
+
+Report the review system's own performance — the eval loop that tells us whether the hardening program is working. All data is local JSONL; compute with `node -e` one-liners (both files may be absent on a fresh clone — degrade gracefully, report "no data yet").
+
+## 1. Gate + pre-push metrics (`.claude/.review-metrics.jsonl`)
+
+Per `kind` (`stop-gate`, `pre-push`, …) over the window (`$ARGUMENTS` days, default 30):
+
+- runs, and outcome distribution (`clean` / `advisory` / `blocked` / `tier0-block` / `reemit-block` / `reemit-advisory` / `cache-skip` / `degraded` / `llm-unavailable` / `parse-failed` / `error`)
+- findings per run by severity (mean), block rate
+- **parse-failure rate** (`parse_failed`) — >5% means the schema-1 contract is drifting; consider `--output-format json` wrapper parsing
+- **sg_fallback rate** — nonzero means ast-grep is missing/broken locally
+- cache-skip + re-emit counts (`reemits`) — how much work the ledger/caches are saving
+- suppressed counts (`suppressed`) — convergence + category suppression volume
+- audited skips (`skipped: true`, pre-push `REVIEW_SKIP`) — a rising trend means the gate is becoming theater; investigate why
+- mean `duration_ms` per outcome
+
+## 2. Ledger analysis (`.claude/.review-ledger.jsonl`)
+
+- open vs resolved-changed vs suppressed, by category
+- **ignore streaks**: open entries with `reemits ≥ 2` — candidates approaching category auto-suppression (only style/perf/i18n can suppress; anything else with a streak is a real unresolved problem — surface it)
+- resolution rate: resolved-changed ÷ (open + resolved-changed) per category — low resolution in a category = findings devs don't act on = calibrate that category's rules/prompts
+
+## 3. CodeRabbit miss rate (best-effort, needs `gh` auth + network)
+
+For merged PRs in the window (`gh pr list --state merged`), fetch review comments authored by `coderabbitai` (`gh api repos/{owner}/{repo}/pulls/<n>/comments`). A CodeRabbit finding on a file for which our metrics/ledger recorded NO finding in that PR's branch = a **miss** — the number this whole program exists to drive down. Report: misses, total CodeRabbit findings, miss rate, and the missed findings themselves (file + first line of the comment) so they can become checklist rules or ast-grep rules. Note the coverage caveat: CodeRabbit is on-demand, so only PRs where it was triggered contribute.
+
+## 4. Verdict line
+
+End with one line: `review-stats: <runs> runs · <block-rate>% blocked · <parse-fail>% parse-fail · <skips> audited skips · miss-rate <n/m or n/a>` plus, if any threshold is breached (parse-fail >5%, ignore-rate >30% in a category, rising REVIEW_SKIP trend), a short "calibration needed" note naming the fix.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -7,8 +7,9 @@ Run the **strict internal pre-PR review** — the gate that runs BEFORE a PR is 
 
 ## 1. Context
 
-- Read `.claude/review-config.md` (path rules + learnings — do not re-raise the listed false positives).
+- Read `.claude/review-config.md` (path rules + Hard exclusions / Signal-quality criteria / Precedents — do not re-raise the listed false positives).
 - Query prior lessons for the touched domains: `node .claude/hooks/lessons.mjs query --domain <d> --limit 4` for each domain whose `lessons_domains` globs (`.claude/review-routes.json`) match the diff (≤3 domains).
+- Load the branch's finding ledger (`.claude/.review-ledger.jsonl`, entries for this branch, last-status-wins per finding): findings already `open` are CONFIRMED — re-emit them in the report without re-verifying; skip spawning verifiers for them.
 
 ## 2. Scope + risk tier (mechanical — compute, don't vibe)
 
@@ -43,6 +44,7 @@ Spawn the ensemble **in parallel** (one Agent call per pass, per the tier). Rese
 4. **Verdict — mechanical**: BLOCK iff any surviving finding has severity CRITICAL/HIGH (🔴/🟠) with `confidence ≥ 0.8` and `introduced_by_diff !== false`. 🟡/⚪ and low-confidence survivors are advisory. **🔴 + 🟠 must be resolved before the PR goes up.**
 5. Report: verdict line first, then surviving findings grouped by severity (`severity | file:line | defect | substantiation | fix`), then advisories. Append any `UNVERIFIED (cross-OS: …)` coverage caveats from the passes verbatim.
 
-## 6. Learnings
+## 6. Learnings + ledger
 
-When a finding turns out to be a false positive, append it to `.claude/review-config.md` learnings so it isn't re-raised — and tell the user which verifier/pass produced it (calibration data for `/review-stats`).
+- When a finding turns out to be a false positive, append it to the right `.claude/review-config.md` section (Hard exclusions / Signal-quality criteria / Precedents) so it isn't re-raised — and tell the user which verifier/pass produced it (calibration data for `/review-stats`).
+- Append each surviving finding to `.claude/.review-ledger.jsonl` as `{"branch": "<branch>", "status": "open", "source": "review", "finding": <schema-1 finding>, "fileHunks": []}` (one JSON line each) so `/review-stats` can track resolution (entries without a hunk baseline are stats-only — the Stop gate neither re-emits nor auto-resolves them).

--- a/.claude/hooks/review-gate.mjs
+++ b/.claude/hooks/review-gate.mjs
@@ -21,6 +21,7 @@ import {
   splitByFile,
   assembleDiff,
   hunkHashes,
+  keptHashes,
   fileHunkHashes,
   ledgerKey,
   loadLedger,
@@ -193,8 +194,11 @@ try {
 
   // files with verbatim re-emits don't go back to the model
   const modelSegments = segments.filter((s) => !reEmitFiles.has(s.file));
-  const { diff, omitted, deletedCount } = assembleDiff(modelSegments, MAX);
-  if (!diff.trim() && !reEmitted.length) exit0();
+  const { diff, omitted, deletedCount, kept } = assembleDiff(modelSegments, MAX);
+  if (!diff.trim() && !reEmitted.length) {
+    appendLedger(cwd, ledgerAppends); // record resolved-changed transitions
+    exit0();
+  }
 
   // trivial-change heuristic (comment/import/blank-only → skip)
   const codeLines = diff.split('\n').filter((l) => /^[+-]/.test(l) && !/^[+-]{3}/.test(l));
@@ -208,6 +212,7 @@ try {
   if (!meaningful.length && !reEmitted.length) {
     // deletion-only / over-budget-only changes carry no +/- lines — the review is
     // skipped as a degradation, but the metrics must not read as "clean".
+    appendLedger(cwd, ledgerAppends); // record resolved-changed transitions
     if (deletedCount || omitted.length) logM({ outcome: 'degraded', blocked: false });
     exit0();
   }
@@ -537,7 +542,12 @@ ${diff}
       return why;
     };
     if (round2) {
-      const dropped = parsed.filter((f) => f.severity === 'MEDIUM' || f.severity === 'LOW');
+      // symmetric with category-suppression: convergence also only silences the
+      // suppressible categories — a NEW medium correctness/security finding on a
+      // later commit still surfaces (as advisory; MEDIUM/LOW never block anyway)
+      const dropped = parsed.filter(
+        (f) => (f.severity === 'MEDIUM' || f.severity === 'LOW') && SUPPRESSIBLE.has(f.category)
+      );
       if (dropped.length) {
         parsed = parsed.filter((f) => !dropped.includes(f));
         dropped.forEach((f) => suppress(f));
@@ -638,10 +648,8 @@ ${diff}
     // fix-and-refinish cycle only re-reviews what actually changed.
     appendLedger(cwd, ledgerAppends);
     if (parsed) {
-      const blockedFiles = new Set(blocking.map((f) => f.file));
-      writeCache(
-        segments.filter((s) => !blockedFiles.has(s.file)).flatMap((s) => hunkHashes(s.text))
-      );
+      // only hunks the model ACTUALLY saw (assembleDiff's `kept`), minus blocked files
+      writeCache(keptHashes(kept, new Set(blocking.map((f) => f.file))));
     }
     logM({ outcome: 'blocked', blocked: true });
     block(
@@ -650,6 +658,9 @@ ${diff}
         .join('\n')}` +
         (unverified.length
           ? `\n\nNon-blocking HIGH/CRITICAL (low confidence or pre-existing):\n${unverified.map(fmt).join('\n')}`
+          : '') +
+        (lowmed.length
+          ? `\n\nAdvisory findings (non-blocking):\n${lowmed.map(fmt).join('\n')}`
           : '') +
         (advisory.length ? `\n\nAdvisory:\n- ${advisory.join('\n- ')}` : '') +
         (suppressedNotes.length ? `\n\n${suppressedNotes.join('\n')}` : '') +
@@ -671,9 +682,10 @@ ${diff}
   }
 
   // No blocking findings → record ledger state + reviewed hunks so a future finish
-  // skips this clean code.
+  // skips this clean code. Cache ONLY what the model actually saw (`kept`) — an
+  // omitted over-budget file or a cut hunk tail must never be marked reviewed-clean.
   appendLedger(cwd, ledgerAppends);
-  writeCache(hashes);
+  writeCache(keptHashes(kept));
 
   const advisoryOut = [];
   if (unverified.length)

--- a/.claude/hooks/review-gate.mjs
+++ b/.claude/hooks/review-gate.mjs
@@ -21,6 +21,11 @@ import {
   splitByFile,
   assembleDiff,
   hunkHashes,
+  fileHunkHashes,
+  ledgerKey,
+  loadLedger,
+  appendLedger,
+  hasPriorRun,
   FINDING_CONTRACT,
   blockingFindings,
   formatFinding,
@@ -132,8 +137,64 @@ try {
   // count files that actually produced diff segments (a committed-then-reverted
   // file is in nonSkipped but nets to zero) — metrics must reflect what was reviewed
   metric.files = new Set(segments.map((s) => s.file)).size;
-  const { diff, omitted, deletedCount } = assembleDiff(segments, MAX);
-  if (!diff.trim()) exit0();
+
+  // 4b. findings ledger — cross-run finding state for this branch.
+  // OPEN findings whose file diff is byte-identical re-emit VERBATIM and their files
+  // skip the LLM entirely; a changed file auto-resolves its old findings. Categories
+  // the user has ignored 3+ consecutive times auto-suppress — but ONLY style/perf/i18n,
+  // never security/correctness/data-loss/arch/test-coverage.
+  const fileHunks = fileHunkHashes(segments);
+  const ledger = loadLedger(cwd, branch);
+  const round2 = hasPriorRun(cwd, branch);
+  const sameHunks = (a, b) => a.length === b.length && a.every((h, i) => h === b[i]);
+  const SUPPRESSIBLE = new Set(['style', 'perf', 'i18n']);
+  const openEntries = [...ledger.values()].filter((e) => e.status === 'open' && e.finding);
+  const suppressedCategories = new Set(
+    openEntries
+      .filter((e) => SUPPRESSIBLE.has(e.finding.category) && (e.reemits || 0) >= 3)
+      .map((e) => e.finding.category)
+  );
+  const reEmitted = [];
+  const reEmitFiles = new Set();
+  const ledgerAppends = [];
+  for (const e of openEntries) {
+    // entries without a hunk baseline (e.g. /review-sourced) can't be re-emitted or
+    // auto-resolved reliably — they exist for /review-stats only
+    if (!Array.isArray(e.fileHunks) || !e.fileHunks.length) continue;
+    const cur = fileHunks.get(e.finding.file);
+    if (!cur || !sameHunks(e.fileHunks || [], cur)) {
+      ledgerAppends.push({
+        branch,
+        status: 'resolved-changed',
+        finding: e.finding,
+        fileHunks: cur || [],
+      });
+    } else if (suppressedCategories.has(e.finding.category)) {
+      ledgerAppends.push({
+        branch,
+        status: 'suppressed',
+        finding: e.finding,
+        fileHunks: cur,
+        reemits: e.reemits || 0,
+      });
+    } else {
+      reEmitted.push(e.finding);
+      reEmitFiles.add(e.finding.file);
+      ledgerAppends.push({
+        branch,
+        status: 'open',
+        finding: e.finding,
+        fileHunks: cur,
+        reemits: (e.reemits || 0) + 1,
+      });
+    }
+  }
+  metric.reemits = reEmitted.length;
+
+  // files with verbatim re-emits don't go back to the model
+  const modelSegments = segments.filter((s) => !reEmitFiles.has(s.file));
+  const { diff, omitted, deletedCount } = assembleDiff(modelSegments, MAX);
+  if (!diff.trim() && !reEmitted.length) exit0();
 
   // trivial-change heuristic (comment/import/blank-only → skip)
   const codeLines = diff.split('\n').filter((l) => /^[+-]/.test(l) && !/^[+-]{3}/.test(l));
@@ -144,12 +205,13 @@ try {
     if (/^(import |use |pub use |mod |from )/.test(b)) return false;
     return true;
   });
-  if (!meaningful.length) {
+  if (!meaningful.length && !reEmitted.length) {
     // deletion-only / over-budget-only changes carry no +/- lines — the review is
     // skipped as a degradation, but the metrics must not read as "clean".
     if (deletedCount || omitted.length) logM({ outcome: 'degraded', blocked: false });
     exit0();
   }
+  const skipLLM = !meaningful.length; // everything left is re-emits — verdict is known
 
   // 5. Tier 0 — deterministic guards (confidence 1.0). Primary: the ast-grep pack
   // (.claude/review-rules/*.yml, discovered via repo-root sgconfig.yml — never pass
@@ -274,10 +336,11 @@ try {
   try {
     cache = new Set(fs.readFileSync(cachePath, 'utf8').split('\n').filter(Boolean));
   } catch {}
-  const hashes = hunkHashes(diff);
+  // cache membership is judged over ALL segments (incl. re-emit files)
+  const hashes = [...fileHunks.values()].flat();
   // pre-existing / warning-severity tier-0 hits must not defeat the cache forever
   const tier0Blocking = tier0.some((t) => t.introduced_by_diff && t.severity === 'HIGH');
-  if (hashes.length && hashes.every((h) => cache.has(h)) && !tier0Blocking) {
+  if (hashes.length && hashes.every((h) => cache.has(h)) && !tier0Blocking && !reEmitted.length) {
     logM({ outcome: 'cache-skip', blocked: false });
     exit0();
   }
@@ -288,10 +351,34 @@ try {
   if (tier0Blocking) {
     metric.model = 'none';
     metric.findings = countBySeverity(tier0);
+    appendLedger(cwd, ledgerAppends); // resolved/suppressed transitions still recorded
     logM({ outcome: 'tier0-block', blocked: true });
     block(
       `Review gate [tier-0 arch guards] — blocking issues, address then finish:\n\n${tier0
         .filter((t) => t.introduced_by_diff && t.severity === 'HIGH')
+        .map(formatFinding)
+        .join('\n')}`
+    );
+  }
+
+  // everything left in scope is verbatim re-emits — the verdict is already known,
+  // skip the LLM entirely
+  if (skipLLM) {
+    const reBlocking = blockingFindings(reEmitted, 0.6);
+    metric.model = 'none';
+    metric.findings = countBySeverity([...tier0, ...reEmitted]);
+    appendLedger(cwd, ledgerAppends);
+    if (reBlocking.length) {
+      logM({ outcome: 'reemit-block', blocked: true });
+      block(
+        `Review gate — unresolved findings from the previous review (file unchanged):\n\n${reBlocking
+          .map(formatFinding)
+          .join('\n')}`
+      );
+    }
+    logM({ outcome: 'reemit-advisory', blocked: false });
+    exit0(
+      `✓ Review gate: no new code to review.\nStill open from previous reviews:\n${reEmitted
         .map(formatFinding)
         .join('\n')}`
     );
@@ -434,10 +521,48 @@ ${diff}
   metric.parse_retries = r.parseRetries;
 
   // 9. deterministic verdict — from parsed findings, never from prose
-  let findings = [...tier0];
+  // convergence: from round 2 on, NEW MEDIUM/LOW are suppressed (anti-flapping —
+  // each round inventing fresh nits never converges); new HIGH/CRITICAL always surface.
+  // category suppression: parsed findings in a 3×-ignored suppressible category drop.
+  let parsed = r.findings ? [...r.findings] : null;
+  let suppressedNotes = [];
+  if (parsed) {
+    const suppress = (f, why) => {
+      ledgerAppends.push({
+        branch,
+        status: 'suppressed',
+        finding: f,
+        fileHunks: fileHunks.get(f.file) || [],
+      });
+      return why;
+    };
+    if (round2) {
+      const dropped = parsed.filter((f) => f.severity === 'MEDIUM' || f.severity === 'LOW');
+      if (dropped.length) {
+        parsed = parsed.filter((f) => !dropped.includes(f));
+        dropped.forEach((f) => suppress(f));
+        suppressedNotes.push(
+          `${dropped.length} new advisory finding(s) suppressed (convergence, round ≥2)`
+        );
+      }
+    }
+    if (suppressedCategories.size) {
+      const dropped = parsed.filter((f) => suppressedCategories.has(f.category));
+      if (dropped.length) {
+        parsed = parsed.filter((f) => !dropped.includes(f));
+        dropped.forEach((f) => suppress(f));
+        suppressedNotes.push(
+          `${dropped.length} finding(s) suppressed (category ignored 3×: ${[...suppressedCategories].join(', ')})`
+        );
+      }
+    }
+    metric.suppressed = ledgerAppends.filter((e) => e.status === 'suppressed').length;
+  }
+
+  let findings = [...tier0, ...reEmitted];
   let fallbackNote = '';
-  if (r.findings) {
-    findings.push(...r.findings);
+  if (parsed) {
+    findings.push(...parsed);
   } else if (r.raw && r.parseFailed) {
     // conservative fallback: unparseable output that talks about HIGH/CRITICAL blocks
     if (/\b(HIGH|CRITICAL)\b/.test(r.raw) && !/^APPROVED/i.test(r.raw)) {
@@ -481,49 +606,83 @@ ${diff}
   if (testable && !testChanged)
     advisory.push('changed logic without accompanying tests → run /add-tests');
 
+  // new surviving parsed findings become open ledger entries (re-emits already have
+  // theirs; tier-0 re-derives free every run and is never ledgered)
+  if (parsed)
+    for (const f of parsed)
+      if (fileHunks.has(f.file))
+        ledgerAppends.push({
+          branch,
+          status: 'open',
+          finding: f,
+          fileHunks: fileHunks.get(f.file),
+          reemits: 0,
+        });
+
+  const writeCache = (list) => {
+    if (!list.length) return;
+    try {
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+      fs.appendFileSync(cachePath, list.join('\n') + '\n');
+      // bound growth: keep only the most recent ~2000 hashes
+      const lines = fs.readFileSync(cachePath, 'utf8').split('\n').filter(Boolean);
+      if (lines.length > 2000) fs.writeFileSync(cachePath, lines.slice(-2000).join('\n') + '\n');
+    } catch {}
+  };
+  const fmt = (f) =>
+    formatFinding(f) + (reEmitted.includes(f) ? ' · (unresolved from previous review)' : '');
+
   if (blocking.length) {
-    // Do NOT cache blocking hunks. Unfixed HIGH/CRITICAL must be re-reviewed and
-    // re-blocked on the next finish until it is actually fixed — no whitelist-on-block.
+    // Never cache BLOCKING files' hunks — unfixed HIGH/CRITICAL re-blocks every finish
+    // (now via a free ledger re-emit). Files the model reviewed clean ARE cached so a
+    // fix-and-refinish cycle only re-reviews what actually changed.
+    appendLedger(cwd, ledgerAppends);
+    if (parsed) {
+      const blockedFiles = new Set(blocking.map((f) => f.file));
+      writeCache(
+        segments.filter((s) => !blockedFiles.has(s.file)).flatMap((s) => hunkHashes(s.text))
+      );
+    }
     logM({ outcome: 'blocked', blocked: true });
     block(
       `Review gate [${consulted.join(', ')}] — blocking issues, address then finish:\n\n${blocking
-        .map(formatFinding)
+        .map(fmt)
         .join('\n')}` +
         (unverified.length
-          ? `\n\nNon-blocking HIGH/CRITICAL (low confidence or pre-existing):\n${unverified.map(formatFinding).join('\n')}`
+          ? `\n\nNon-blocking HIGH/CRITICAL (low confidence or pre-existing):\n${unverified.map(fmt).join('\n')}`
           : '') +
         (advisory.length ? `\n\nAdvisory:\n- ${advisory.join('\n- ')}` : '') +
+        (suppressedNotes.length ? `\n\n${suppressedNotes.join('\n')}` : '') +
         fallbackNote
     );
   }
 
   // Fail-open, but visibly — and never cache hunks the model did not actually review.
+  // Ledger transitions (resolved/suppressed/re-emit counts) are still recorded.
   if (r.error === 'llm_unavailable') {
+    appendLedger(cwd, ledgerAppends);
     logM({ outcome: 'llm-unavailable', blocked: false, error: r.error });
     exit0('review-gate: LLM review skipped (reviewer unavailable) — diff NOT cached');
   }
   if (r.parseFailed) {
+    appendLedger(cwd, ledgerAppends);
     logM({ outcome: 'parse-failed', blocked: false });
     exit0('review-gate: reviewer output unparseable (no HIGH/CRITICAL text) — diff NOT cached');
   }
 
-  // No blocking findings → record reviewed hunks so a future finish skips this clean code.
-  try {
-    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-    fs.appendFileSync(cachePath, hashes.join('\n') + '\n');
-    // bound growth: keep only the most recent ~2000 hashes
-    const lines = fs.readFileSync(cachePath, 'utf8').split('\n').filter(Boolean);
-    if (lines.length > 2000) fs.writeFileSync(cachePath, lines.slice(-2000).join('\n') + '\n');
-  } catch {}
+  // No blocking findings → record ledger state + reviewed hunks so a future finish
+  // skips this clean code.
+  appendLedger(cwd, ledgerAppends);
+  writeCache(hashes);
 
   const advisoryOut = [];
   if (unverified.length)
     advisoryOut.push(
-      `Non-blocking HIGH/CRITICAL (low confidence or pre-existing):\n${unverified.map(formatFinding).join('\n')}`
+      `Non-blocking HIGH/CRITICAL (low confidence or pre-existing):\n${unverified.map(fmt).join('\n')}`
     );
-  if (lowmed.length)
-    advisoryOut.push(`Advisory findings:\n${lowmed.map(formatFinding).join('\n')}`);
+  if (lowmed.length) advisoryOut.push(`Advisory findings:\n${lowmed.map(fmt).join('\n')}`);
   if (advisory.length) advisoryOut.push(`Reminders:\n- ${advisory.join('\n- ')}`);
+  if (suppressedNotes.length) advisoryOut.push(suppressedNotes.join('\n'));
   logM({ outcome: advisoryOut.length ? 'advisory' : 'clean', blocked: false });
   if (advisoryOut.length) exit0(`✓ Review gate: no blocking issues.\n${advisoryOut.join('\n')}`);
   exit0();

--- a/.claude/hooks/review-lib.mjs
+++ b/.claude/hooks/review-lib.mjs
@@ -85,7 +85,10 @@ export const splitByFile = (blob) => {
  * Assemble per-file segments into one bounded diff, by priority: source → test →
  * docs (PR-Agent drop-order). Deletions and over-budget files degrade to
  * one-line notes; a single over-budget segment is cut at hunk boundaries only.
- * Returns { diff, omitted } — omitted = ['file (+a/-b)'].
+ * Returns { diff, omitted, deletedCount, kept } — omitted = ['file (+a/-b)'];
+ * kept = Map(file → the diff text ACTUALLY included). Cache writes must hash only
+ * `kept` — anything else (omitted files, deletion notes, cut hunk tails) was never
+ * shown to a reviewer and must never be marked reviewed-clean.
  */
 export const assembleDiff = (segments, max = 60000) => {
   const order = { source: 0, test: 1, docs: 2 };
@@ -94,6 +97,7 @@ export const assembleDiff = (segments, max = 60000) => {
   );
   let diff = '';
   const omitted = [];
+  const kept = new Map();
   let deletedCount = 0;
   for (const s of segs) {
     if (s.deleted) {
@@ -104,6 +108,7 @@ export const assembleDiff = (segments, max = 60000) => {
     const room = max - diff.length;
     if (s.text.length <= room) {
       diff += s.text;
+      kept.set(s.file, (kept.get(s.file) || '') + s.text);
       continue;
     }
     // Doesn't fit whole — keep the longest prefix of WHOLE hunks if there is
@@ -118,14 +123,19 @@ export const assembleDiff = (segments, max = 60000) => {
       const keep = cut > 0 ? s.text.slice(0, cut) : '';
       if (/^@@/m.test(keep)) {
         diff += keep + `# …remaining hunks of ${s.file} omitted (+${s.adds}/-${s.dels} total)\n`;
+        kept.set(s.file, (kept.get(s.file) || '') + keep);
         continue;
       }
     }
     omitted.push(`${s.file} (+${s.adds}/-${s.dels})`);
   }
   if (omitted.length) diff += `# omitted files (over budget): ${omitted.join(', ')}\n`;
-  return { diff, omitted, deletedCount };
+  return { diff, omitted, deletedCount, kept };
 };
+
+/** Hashes of the hunks a reviewer actually saw (from assembleDiff's `kept`). */
+export const keptHashes = (kept, excludeFiles = new Set()) =>
+  [...kept.entries()].filter(([f]) => !excludeFiles.has(f)).flatMap(([, text]) => hunkHashes(text));
 
 // ─── hunk hashing (body-only, line-number agnostic) ──────────────────────────
 

--- a/.claude/hooks/review-lib.mjs
+++ b/.claude/hooks/review-lib.mjs
@@ -286,6 +286,80 @@ export const runClaudeReview = ({ cwd, prompt, model, timeoutMs = 120000 }) => {
   };
 };
 
+// ─── findings ledger (cross-run finding state; clean-hunk state stays in
+// .review-cache — do not duplicate it here) ──────────────────────────────────
+
+const LEDGER_MAX_LINES = 5000;
+
+/** Per-file hunk hashes from diff segments: Map file → [sha1...]. */
+export const fileHunkHashes = (segments) => {
+  const m = new Map();
+  for (const s of segments) m.set(s.file, [...(m.get(s.file) || []), ...hunkHashes(s.text)]);
+  return m;
+};
+
+/** Stable identity for a finding across runs (summary rewording → new finding). */
+export const ledgerKey = (f) =>
+  `${f.file}|${f.category}|${crypto.createHash('sha1').update(f.summary).digest('hex').slice(0, 8)}`;
+
+/**
+ * Load the branch's ledger as Map(key → entry), last-status-wins.
+ * Entry: { ts, branch, status: 'open'|'resolved-changed'|'suppressed',
+ *          finding, fileHunks: [sha1...], reemits }.
+ */
+export const loadLedger = (cwd, branch) => {
+  const m = new Map();
+  try {
+    const lines = fs
+      .readFileSync(path.join(cwd, '.claude', '.review-ledger.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean);
+    for (const line of lines) {
+      try {
+        const e = JSON.parse(line);
+        if (e.branch === branch && e.finding) m.set(ledgerKey(e.finding), e);
+      } catch {}
+    }
+  } catch {}
+  return m;
+};
+
+/** True when a prior stop-gate run exists for this branch (convergence round ≥2). */
+export const hasPriorRun = (cwd, branch) => {
+  try {
+    return fs
+      .readFileSync(path.join(cwd, '.claude', '.review-metrics.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .some((l) => {
+        try {
+          const e = JSON.parse(l);
+          return e.branch === branch && e.kind === 'stop-gate';
+        } catch {
+          return false;
+        }
+      });
+  } catch {
+    return false;
+  }
+};
+
+/** Append ledger entries; trims to the most recent LEDGER_MAX_LINES. Never throws. */
+export const appendLedger = (cwd, entries) => {
+  if (!entries.length) return;
+  try {
+    const p = path.join(cwd, '.claude', '.review-ledger.jsonl');
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.appendFileSync(
+      p,
+      entries.map((e) => JSON.stringify({ ts: new Date().toISOString(), ...e })).join('\n') + '\n'
+    );
+    const lines = fs.readFileSync(p, 'utf8').split('\n').filter(Boolean);
+    if (lines.length > LEDGER_MAX_LINES)
+      fs.writeFileSync(p, lines.slice(-LEDGER_MAX_LINES).join('\n') + '\n');
+  } catch {}
+};
+
 // ─── metrics ─────────────────────────────────────────────────────────────────
 
 const METRICS_MAX_LINES = 5000;

--- a/.claude/review-config.md
+++ b/.claude/review-config.md
@@ -1,9 +1,11 @@
-# review-config — path rules + learnings for `pr-reviewer`
+# review-config — path rules + learnings for every review surface
 
-`pr-reviewer` reads this every run. Two jobs: (1) tell it which extra tools/risks
-apply per path, (2) record **learnings** — repo-specific facts that stop it from
-re-raising known false positives. Append a learning the moment a finding turns out
-to be a false positive.
+`pr-reviewer`, the Stop review-gate, `/review`, and `finding-verifier` all read this.
+Two jobs: (1) tell reviewers which extra tools/risks apply per path, (2) record
+**learnings** — repo-specific facts that stop known false positives from being
+re-raised. Append the moment a finding turns out to be a false positive, into the
+right section: **Hard exclusions** (never raise), **Signal-quality criteria** (how to
+verify before raising), **Precedents** (severity/design calls already made).
 
 ## Path-specific rules
 
@@ -16,16 +18,24 @@ to be a false positive.
 | `packages/prompts/**`                                                   | Prompt-injection posture: untrusted inputs fenced; user instruction bounded; honesty/grounding rules intact. No UI/`window`.                                                                                                                                                                                                |
 | `**/*.test.*`, `**/*.spec.*`                                            | Tests cover changed **edge/error/security** paths; no tautological assertions; fake-timer + async `act()` pitfalls.                                                                                                                                                                                                         |
 
-## Learnings (repo exceptions — do NOT flag these)
+## Hard exclusions (never re-raise — confirmed repo false positives)
 
 - **`architecture.rs` / `docs/architecture-rules.md` L0–L3 lists** intentionally enumerate every module per layer; repeated module names / parallel headings are the house style, **not** duplication/drift.
 - **Custom Tauri commands are NOT listed in `capabilities/default.json`** (e.g. `menu_take_pending`, all `autopilot_*`). Their absence is correct — do not raise "missing permission".
 - **`import type` everywhere** is enforced by `@typescript-eslint/consistent-type-imports` (auto-fix). It is required, not a smell.
 - **ESLint `noInlineConfig`** is on: never recommend `eslint-disable`/`@ts-ignore`. Refs read inside effects (`ref.current`) are exempt from `exhaustive-deps` **without** suppression — that's correct.
+- **Dotted-key mock overrides are valid** in renderer tests. `createMockClient` in `apps/desktop/src/renderer/test-support.tsx` is a `Proxy` whose `get` trap resolves dotted paths, so `createMockClient({ 'autopilot.takePendingFocus': fn })` correctly overrides `client.autopilot.takePendingFocus`. Do NOT flag this as a "wrong override shape / shallow-merge miss" (CodeRabbit raised this on #477; it was a false positive). The concrete-object variant at `renderer/lib/mock-client/mock-client.ts` is different — it takes nested objects — so match the override shape to whichever factory the test imports.
+- **`unwrap()`/`expect()` on a KNOWN-GOOD LITERAL inside a `LazyLock`/`OnceLock` static initializer** (e.g. `Regex::new(r"…").unwrap()` with a hardcoded pattern) is accepted house style (~70 instances) — flag static-init unwraps only when the input is fallible/externally influenced.
+- **`json!(local)` over a contract-shaped local in `commands/**`** is pervasive house style — flag `json!` only when it wholesale-serializes a domain/storage STRUCT across the IPC boundary.
+
+## Signal-quality criteria (what makes a finding real here)
+
 - **`noUncheckedIndexedAccess` is strict**: tests pass under esbuild (`pnpm test`) but `tsc`/CI is stricter. Always trust `rtk pnpm typecheck`, and guard array indices (no `!`).
 - **jsdom drops hex-stop `linear-gradient`** in the full `pnpm test` run — assert gradients via `data-*` seams, not computed CSS. Not a renderer bug.
 - **`rtk`-wrapped tool _output_ is lossy** (it substitutes tokens) — never trust `rtk rg`/`rtk git` stdout for exact symbol names, IDs, or GraphQL. Exit codes from `rtk pnpm typecheck`/`lint`/`cargo` ARE reliable.
-- **Cold-start intent buffers** (`PendingMenu`, `PendingFocus`) are `app.manage`d **early** in setup (before the deep-link handler), deliberately NOT in `tray::build` — that ordering is the fix, not a bug.
 - **New (untracked) files are invisible to plain `git diff`** — before raising "imported file missing from diff", run `git status` for `??` entries (the orchestrator should `git add -N` new files so review diffs include them; a Stop-gate review raised this falsely on PR C while typecheck + full vitest were green).
 - **Helper fns defined near the top of long components** (e.g. `stopProp` at `AutopilotCard/index.tsx:272`) sit outside a diff hunk's context lines — do NOT flag "undefined identifier / ReferenceError" from diff context alone; grep the whole file first (a Stop-gate review raised this falsely on PR C while typecheck + full vitest were green).
-- **Dotted-key mock overrides are valid** in renderer tests. `createMockClient` in `apps/desktop/src/renderer/test-support.tsx` is a `Proxy` whose `get` trap resolves dotted paths, so `createMockClient({ 'autopilot.takePendingFocus': fn })` correctly overrides `client.autopilot.takePendingFocus`. Do NOT flag this as a "wrong override shape / shallow-merge miss" (CodeRabbit raised this on #477; it was a false positive). The concrete-object variant at `renderer/lib/mock-client/mock-client.ts` is different — it takes nested objects — so match the override shape to whichever factory the test imports.
+
+## Precedents (severity + design calls already made)
+
+- **Cold-start intent buffers** (`PendingMenu`, `PendingFocus`) are `app.manage`d **early** in setup (before the deep-link handler), deliberately NOT in `tray::build` — that ordering is the fix, not a bug.

--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,7 @@ temp/
 .claude/memory/
 .claude/.review-cache
 .claude/.review-metrics.jsonl
+.claude/.review-ledger.jsonl
 .claude/*.bak-ruflo
 .claude-flow*
 # Per-task handoff files are transient; the template is committed.


### PR DESCRIPTION
PR 4 of 6 — review-system hardening program. Cross-run memory: findings stop flapping, unchanged code is never re-reviewed, and the system's own performance becomes measurable.

## What

- **Findings ledger** (\`.claude/.review-ledger.jsonl\`, gitignored, capped 5000): every surviving finding is recorded per branch with its file's hunk-hash baseline.
  - **Verbatim re-emit, zero LLM**: an open finding whose file diff is byte-identical re-emits without regeneration — its file is subtracted from the model prompt. An unresolved 🔴/🟠 re-blocks every finish for free (\`reemit-block\` outcome, \`model: none\`).
  - **Auto-resolve**: a changed file resolves its old findings (\`resolved-changed\`).
  - **Convergence** (Claude-Code-Review pattern): from round 2 on a branch, NEW MEDIUM/LOW are suppressed (each round inventing fresh nits never converges); new HIGH/CRITICAL always surface.
  - **Category auto-suppression** (Greptile pattern): a category ignored 3 consecutive times goes quiet — ONLY style/perf/i18n are suppressible; security/correctness/data-loss/arch/test-coverage never suppress.
  - Blocked runs now cache the files the model reviewed clean, so a fix-and-refinish cycle re-reviews only what changed.
- **Memory restructure**: \`review-config.md\` learnings → **Hard exclusions / Signal-quality criteria / Precedents** (the claude-code-security-review format), read by all four surfaces. Two new hard exclusions codify PR 3's empirically-dropped rules (literal unwrap in static init; \`json!(local)\` over contract-shaped locals).
- **\`/review\` integration**: loads the branch ledger (open findings are confirmed — no re-verification), appends its survivors as stats-only entries (no hunk baseline → the gate neither re-emits nor auto-resolves them).
- **NEW \`/review-stats\`**: outcome distribution, findings/run, block rate, parse-failure rate (>5% = contract drift), sg_fallback rate, cache/ledger savings, suppression volume, audited-skip trend, ignore streaks, per-category resolution rate, and best-effort **CodeRabbit miss rate** via \`gh api\` — the metric this whole program exists to drive down.

## Verification

Harness now **32/32** — four new ledger cases:
- K: blocked finding re-emits verbatim on an unchanged tree and blocks with the claude call-counter unchanged (zero LLM)
- L: fixing the hunk auto-resolves (\`resolved-changed\` recorded)
- M: round-2 new MEDIUM suppressed with a visible convergence note; new HIGH on the same round still blocks
- N: crafted ledger with style ignored 3× → style silenced, seeded HIGH unaffected, suppression recorded

\`check:agent-system\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)