### PR TITLE
chore: pre-push ai review gate with cargo fault mitigation

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -68,6 +68,7 @@ export TURBO_FORCE=1
 # diff against the merge-base with origin/main. Any failure → FULL gate.
 ZERO=0000000000000000000000000000000000000000
 CHANGED=""
+RANGES=""
 HAVE_RANGE=0
 while read -r local_ref local_sha remote_ref remote_sha; do
   if [ -z "${local_sha:-}" ] || [ "$local_sha" = "$ZERO" ]; then
@@ -85,6 +86,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     range="$remote_sha..$local_sha"
   fi
   files=$(git diff --name-only "$range" 2>/dev/null || true)
+  RANGES="$RANGES $range"
   CHANGED="$CHANGED
 $files"
   HAVE_RANGE=1
@@ -181,8 +183,19 @@ if [ -n "$RUST" ]; then
   echo "▶ Running cargo check..."
   cargo check --all-targets --all-features --locked
 
-  echo "▶ Running Rust tests (incl. architecture boundary tests)..."
-  cargo test --all-features --locked
+  if [ -n "${AJH_SKIP_CARGO_TEST:-}" ]; then
+    echo "⚠ AJH_SKIP_CARGO_TEST=1 — skipping ONLY cargo test (known host DLL fault). CI still runs it."
+  else
+    echo "▶ Running Rust tests (incl. architecture boundary tests)..."
+    test_out=$(cargo test --all-features --locked 2>&1) || {
+      if printf '%s' "$test_out" | grep -qi "STATUS_ENTRYPOINT_NOT_FOUND\|0xc0000139"; then
+        echo "⚠ cargo test hit the known host entrypoint fault — skipping ONLY cargo test; check/clippy/fmt/deny still run. CI remains authoritative."
+      else
+        printf '%s\n' "$test_out"
+        exit 1
+      fi
+    }
+  fi
 
   echo "▶ Running Rust clippy..."
   cargo clippy --all-targets --all-features --locked -- -D warnings
@@ -208,6 +221,19 @@ if [ -n "$RUST" ]; then
   fi
 
   cd "$GIT_ROOT"
+fi
+
+# ── AI review of the push range (ADR-0008) ─────────────────────────────────────
+# Deterministic findings (ast-grep) block from day one; LLM findings are in
+# RATCHET warn mode (REVIEW_MODE=block to enforce). REVIEW_SKIP=1 skips but is
+# AUDITED in .claude/.review-metrics.jsonl — prefer it over --no-verify, which
+# silently skips this whole gate.
+if [ -n "${REVIEW_SKIP:-}" ]; then
+  echo "⚠ REVIEW_SKIP=1 — AI pre-push review skipped (audited)."
+  PREPUSH_RANGES="$RANGES" node scripts/pre-push-review.mjs --log-skip || true
+else
+  echo "▶ AI review of push range..."
+  PREPUSH_RANGES="$RANGES" node scripts/pre-push-review.mjs
 fi
 
 echo "✓ Pre-push gate complete"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -287,11 +287,11 @@ Then run `gitleaks detect --source . -v` in the repo root to catch hardcoded cre
 
 ### Pre-push AI review
 
-An LLM review runs immediately before each push. The gate has **three layers** (all run concurrently for speed):
+An LLM review runs immediately before each push. The gate has **three layers** (run sequentially, cheapest first, short-circuiting on the first blocking layer):
 
 1. **Cache fast-path** — hunks already reviewed by a prior Stop gate pass through in <1s
 2. **ast-grep deterministic scan** — structural rules from `.claude/review-rules/` (zero false-positives); any HIGH/CRITICAL finding **blocks the push immediately**
-3. **One Sonnet schema-1 review** — in `RATCHET warn mode` (advisory); set `REVIEW_MODE=block` in `.claude/review-metrics.jsonl` to enforce block-on-finding after `/review-stats` shows a clean false-positive rate
+3. **One Sonnet schema-1 review** — in `RATCHET warn mode` (advisory); set `REVIEW_MODE=block` via environment variable (`REVIEW_MODE=block git push`) or permanently by exporting it / flipping the script default to enforce block-on-finding after `/review-stats` shows a clean false-positive rate
 
 **Escape hatches:**
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -285,6 +285,22 @@ scoop install gitleaks               # Windows (alternative)
 
 Then run `gitleaks detect --source . -v` in the repo root to catch hardcoded credentials, API keys, etc. The reviewer falls back to a grep-based scan if gitleaks is absent.
 
+### Pre-push AI review
+
+An LLM review runs immediately before each push. The gate has **three layers** (all run concurrently for speed):
+
+1. **Cache fast-path** — hunks already reviewed by a prior Stop gate pass through in <1s
+2. **ast-grep deterministic scan** — structural rules from `.claude/review-rules/` (zero false-positives); any HIGH/CRITICAL finding **blocks the push immediately**
+3. **One Sonnet schema-1 review** — in `RATCHET warn mode` (advisory); set `REVIEW_MODE=block` in `.claude/review-metrics.jsonl` to enforce block-on-finding after `/review-stats` shows a clean false-positive rate
+
+**Escape hatches:**
+
+- `REVIEW_SKIP=1 git push` — skips AI review but is **audited** in `.claude/.review-metrics.jsonl` (preferred over `--no-verify`, which hides the audit trail)
+- `AJH_SKIP_CARGO_TEST=1` — skip `cargo test` only (known Windows `STATUS_ENTRYPOINT_NOT_FOUND` DLL fault; CI is authoritative). Use this to work around the host issue without hiding the full pre-push audit.
+- `--no-verify` — unsafe; bypasses entire hook but leaves no audit trail
+
+The hook flows: `CHANGED` files → `RANGES` per commit → passed to `scripts/pre-push-review.mjs` via `PREPUSH_RANGES` env var. If the script exits non-zero, the push fails; `REVIEW_SKIP=1` allows the push and logs it.
+
 ---
 
 ## Optional: Knowledge-Graph MCP (graphify)

--- a/scripts/pre-push-review.mjs
+++ b/scripts/pre-push-review.mjs
@@ -114,8 +114,13 @@ try {
     // unresolved blockers from previous reviews ride the deterministic lane
     say('✗ AI review: unresolved HIGH/CRITICAL findings from previous reviews:');
     openBlocking.forEach((f) => say('  ' + formatFinding(f)));
-    logM({ outcome: 'reemit-block', blocked: true });
-    process.exit(REVIEW_MODE === 'block' ? 1 : 0); // ledger re-emits ratchet too
+    if (REVIEW_MODE === 'block') {
+      logM({ outcome: 'reemit-block', blocked: true });
+      process.exit(1);
+    }
+    // warn mode: record the re-emits but CONTINUE into layers 2-3 — a stale open
+    // finding must not suppress fresh review of the NEW code in this push
+    metric.reemits = openBlocking.length;
   }
 
   // added (+) lines per file — everything in the push range is being pushed, but

--- a/scripts/pre-push-review.mjs
+++ b/scripts/pre-push-review.mjs
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+/**
+ * pre-push-review.mjs — AI review gate for the push range (ADR-0008).
+ *
+ * Reads ranges from PREPUSH_RANGES (space-separated "A..B", accumulated by
+ * .husky/pre-push's stdin loop — stdin is consumed there and cannot be re-read).
+ *
+ * Layers, cheapest first:
+ *  1. cache fast-path — hunks the Stop gate already reviewed clean pass in <1s
+ *  2. ast-grep deterministic scan — error-severity findings exit 1 from DAY ONE
+ *  3. one sonnet schema-1 review — RATCHET: REVIEW_MODE=warn (default) prints
+ *     loudly + exit 0 with a would_block metric; flip to block once
+ *     /review-stats shows the FP rate is tolerable (~2 weeks)
+ *
+ * Fail-open on infra (no binary / timeout / double parse-fail) — CI is the
+ * backstop. REVIEW_SKIP=1 skips but logs an AUDITED entry. Never bypass with
+ * --no-verify: that skips the whole hook, this valve is visible.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  SKIP_GLOBS,
+  matchesAny,
+  splitByFile,
+  assembleDiff,
+  keptHashes,
+  fileHunkHashes,
+  FINDING_CONTRACT,
+  blockingFindings,
+  formatFinding,
+  countBySeverity,
+  runClaudeReview,
+  appendMetrics,
+  readLearnings,
+  loadLedger,
+  appendLedger,
+} from '../.claude/hooks/review-lib.mjs';
+
+const cwd = process.cwd();
+const t0 = Date.now();
+const metric = { kind: 'pre-push', branch: '', model: '', files: 0 };
+const logM = (extra) => appendMetrics(cwd, { ...metric, duration_ms: Date.now() - t0, ...extra });
+const say = (s) => process.stdout.write(s + '\n');
+
+const git = (args) =>
+  execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+try {
+  metric.branch = git(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+} catch {
+  /* fail-open (ADR-0008): a hook bug must never block the push */
+}
+
+// audited escape hatch (REVIEW_SKIP=1 in .husky/pre-push routes here)
+if (process.argv.includes('--log-skip')) {
+  logM({ outcome: 'skipped', skipped: true, ranges: process.env.PREPUSH_RANGES || '' });
+  process.exit(0);
+}
+
+const ranges = (process.env.PREPUSH_RANGES || '').trim().split(/\s+/).filter(Boolean);
+const REVIEW_MODE = (process.env.REVIEW_MODE || 'warn').toLowerCase(); // ratchet default
+
+try {
+  if (!ranges.length) {
+    say('⚠ AI review: no push range — skipping (CI is the backstop).');
+    logM({ outcome: 'no-range', error: 'no_range' });
+    process.exit(0);
+  }
+
+  // ── scope: the exact commits being pushed ──
+  const segments = [];
+  for (const range of ranges) {
+    try {
+      segments.push(...splitByFile(git(['diff', '-M', '--unified=3', range])));
+    } catch {
+      /* fail-open (ADR-0008): a hook bug must never block the push */
+    }
+  }
+  const scoped = segments.filter((s) => !matchesAny(s.file, SKIP_GLOBS));
+  if (!scoped.length) {
+    say('✓ AI review: nothing reviewable in the push range.');
+    logM({ outcome: 'clean', blocked: false });
+    process.exit(0);
+  }
+  metric.files = new Set(scoped.map((s) => s.file)).size;
+
+  // ── 1. cache fast-path (hunks the Stop gate already reviewed clean) ──
+  const fileHunks = fileHunkHashes(scoped);
+  const allHashes = [...fileHunks.values()].flat();
+  let cache = new Set();
+  try {
+    cache = new Set(
+      fs
+        .readFileSync(path.join(cwd, '.claude', '.review-cache'), 'utf8')
+        .split('\n')
+        .filter(Boolean)
+    );
+  } catch {
+    /* fail-open (ADR-0008): a hook bug must never block the push */
+  }
+  const ledger = loadLedger(cwd, metric.branch);
+  const openBlocking = [...ledger.values()]
+    .filter((e) => e.status === 'open' && e.finding)
+    .map((e) => e.finding)
+    .filter(
+      (f) => (f.severity === 'HIGH' || f.severity === 'CRITICAL') && (f.confidence ?? 1) >= 0.6
+    );
+  if (allHashes.length && allHashes.every((h) => cache.has(h)) && !openBlocking.length) {
+    say('✓ AI review: push range already reviewed clean.');
+    logM({ outcome: 'cache-skip', blocked: false });
+    process.exit(0);
+  }
+  if (openBlocking.length) {
+    // unresolved blockers from previous reviews ride the deterministic lane
+    say('✗ AI review: unresolved HIGH/CRITICAL findings from previous reviews:');
+    openBlocking.forEach((f) => say('  ' + formatFinding(f)));
+    logM({ outcome: 'reemit-block', blocked: true });
+    process.exit(REVIEW_MODE === 'block' ? 1 : 0); // ledger re-emits ratchet too
+  }
+
+  // added (+) lines per file — everything in the push range is being pushed, but
+  // pre-existing violations in touched files still must not block (CI owns them)
+  const addedByFile = new Map();
+  for (const s of scoped) {
+    const added = s.text
+      .split('\n')
+      .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+      .map((l) => l.slice(1))
+      .join('\n');
+    addedByFile.set(s.file, (addedByFile.get(s.file) || '') + added + '\n');
+  }
+  const introducedIn = (file, snippet) => {
+    const probe = (snippet || '').split('\n')[0].trim();
+    return probe ? (addedByFile.get(file) || '').includes(probe) : false;
+  };
+
+  // ── 2. deterministic ast-grep layer (blocks from day one, even in warn mode) ──
+  const detFindings = [];
+  try {
+    const files = [...new Set(scoped.map((s) => s.file))];
+    const r = spawnSync(
+      'pnpm',
+      ['exec', 'ast-grep', 'scan', '--json=compact', '--', ...files.map((f) => `"${f}"`)],
+      { cwd, encoding: 'utf8', shell: true, timeout: 60000, maxBuffer: 20 * 1024 * 1024 }
+    );
+    const outTxt = (r.stdout || '').trim();
+    const matches = !r.error && r.status === 0 && !outTxt ? [] : JSON.parse(outTxt);
+    for (const m of matches) {
+      const file = String(m.file || '').replace(/\\/g, '/');
+      if (m.severity !== 'error' || !introducedIn(file, m.text)) continue;
+      detFindings.push({
+        severity: 'HIGH',
+        category: 'arch',
+        file,
+        line: (m.range && m.range.start && m.range.start.line + 1) || 0,
+        summary: m.message || m.ruleId,
+        evidence: `ast-grep rule ${m.ruleId}`,
+        fix: m.note || '',
+        confidence: 1,
+        introduced_by_diff: true,
+      });
+    }
+  } catch {
+    metric.sg_fallback = true; // sg unavailable — the LLM layer still runs
+  }
+  if (detFindings.length) {
+    say('✗ AI review: deterministic rule violations (blocking):');
+    detFindings.forEach((f) => say('  ' + formatFinding(f)));
+    logM({ outcome: 'tier0-block', blocked: true, findings: countBySeverity(detFindings) });
+    process.exit(1);
+  }
+
+  // ── 3. one sonnet schema-1 review of the range ──
+  const { diff, kept } = assembleDiff(scoped, 60000);
+  const meaningful = diff
+    .split('\n')
+    .filter((l) => /^[+-]/.test(l) && !/^[+-]{3}/.test(l))
+    .some((l) => {
+      const b = l.slice(1).trim();
+      return b && !/^(\/\/|\/\*|\*|#)/.test(b) && !/^(import |use |pub use |mod |from )/.test(b);
+    });
+  if (!meaningful) {
+    say('✓ AI review: only trivial changes in the push range.');
+    logM({ outcome: 'clean', blocked: false });
+    process.exit(0);
+  }
+  const model = 'sonnet';
+  metric.model = model;
+  const learnings = readLearnings(cwd, 4000);
+  const prompt = `You are a STRICT but calibrated pre-push code reviewer. Review ONLY the diff below — the exact commits about to be pushed. Report ONLY defects a reviewer would block a push for: correctness, security, data loss, contract breakage, untested error paths. No style commentary.
+
+${FINDING_CONTRACT}
+${learnings ? `\n## Known repo false positives — do NOT re-raise any of these\n${learnings}\n` : ''}
+## Diff
+\`\`\`diff
+${diff}
+\`\`\`
+`;
+  const r = runClaudeReview({ cwd, prompt, model });
+  metric.parse_retries = r.parseRetries;
+  if (r.error === 'llm_unavailable' || r.parseFailed) {
+    say(
+      `⚠ AI review: reviewer ${r.error ? 'unavailable' : 'output unparseable'} — passing (CI is the backstop).`
+    );
+    logM({
+      outcome: r.error ? 'llm-unavailable' : 'parse-failed',
+      blocked: false,
+      error: r.error || undefined,
+    });
+    process.exit(0);
+  }
+  const blocking = blockingFindings(r.findings, 0.6);
+  metric.findings = countBySeverity(r.findings);
+  if (!blocking.length) {
+    // seed the cache with ONLY what the model actually saw (kept), so the Stop gate
+    // + the next push skip this clean range — omitted files are never marked clean
+    try {
+      const p = path.join(cwd, '.claude', '.review-cache');
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.appendFileSync(p, keptHashes(kept).join('\n') + '\n');
+    } catch {
+      /* fail-open (ADR-0008): a hook bug must never block the push */
+    }
+    say('✓ AI review: push range clean.');
+    logM({ outcome: 'clean', blocked: false });
+    process.exit(0);
+  }
+  appendLedger(
+    cwd,
+    blocking
+      .filter((f) => fileHunks.has(f.file))
+      .map((f) => ({
+        branch: metric.branch,
+        status: 'open',
+        source: 'pre-push',
+        finding: f,
+        fileHunks: fileHunks.get(f.file),
+        reemits: 0,
+      }))
+  );
+  say(`${REVIEW_MODE === 'block' ? '✗' : '⚠'} AI review findings (${REVIEW_MODE} mode):`);
+  blocking.forEach((f) => say('  ' + formatFinding(f)));
+  if (REVIEW_MODE === 'block') {
+    logM({ outcome: 'blocked', blocked: true });
+    say('Fix the findings (or REVIEW_SKIP=1 git push for an audited skip).');
+    process.exit(1);
+  }
+  logM({ outcome: 'would-block', blocked: false, would_block: true, mode: 'warn' });
+  say(
+    '(warn mode — push proceeds; flip REVIEW_MODE=block after /review-stats shows a clean FP rate)'
+  );
+  process.exit(0);
+} catch (e) {
+  try {
+    logM({
+      outcome: 'error',
+      error: 'prepush_exception',
+      message: String(e && e.message).slice(0, 300),
+    });
+  } catch {
+    /* fail-open (ADR-0008): a hook bug must never block the push */
+  }
+  say('⚠ AI review: internal error — passing (CI is the backstop).');
+  process.exit(0);
+}

--- a/scripts/pre-push-review.mjs
+++ b/scripts/pre-push-review.mjs
@@ -196,7 +196,8 @@ ${learnings ? `\n## Known repo false positives — do NOT re-raise any of these\
 ${diff}
 \`\`\`
 `;
-  const r = runClaudeReview({ cwd, prompt, model });
+  // no Stop-hook timeout constrains us here — give big pushes more headroom
+  const r = runClaudeReview({ cwd, prompt, model, timeoutMs: 180000 });
   metric.parse_retries = r.parseRetries;
   if (r.error === 'llm_unavailable' || r.parseFailed) {
     say(


### PR DESCRIPTION
PR 5 of 6 — review-system hardening program. The user-chosen enforcement point: nothing reaches GitHub unreviewed — and the reason `--no-verify` became a daily habit is fixed in the same PR (a gate behind a bypassed hook is theater).

## What

- **NEW \`scripts/pre-push-review.mjs\`** — AI review of the exact push range (\`PREPUSH_RANGES\` accumulated in the hook's stdin ref loop; stdin can't be re-read). Layers, cheapest first:
  1. **cache fast-path** — hunks the Stop gate already reviewed clean pass in <1s (in the normal workflow this makes pre-push near-free)
  2. **ledger lane** — unresolved open HIGH/CRITICAL findings from previous reviews surface without any LLM call
  3. **ast-grep deterministic scan** — error-severity findings **exit 1 from day one**, even in warn mode
  4. **one sonnet schema-1 review** — **RATCHET (user decision): \`REVIEW_MODE=warn\` default** — prints loudly, exits 0, logs \`would_block\`; flip to \`block\` after \`/review-stats\` shows a clean FP rate (~2 weeks). Evidence: day-one full blocking → ~40% dev bypass within a week.
  - Fail-open on infra (binary missing / 180s timeout / double parse-fail) — CI is the backstop. \`REVIEW_SKIP=1\` skips but logs an **audited** metrics entry.
- **\`.husky/pre-push\`**: range accumulation; the AI review as the final step; and the **cargo-test entrypoint-fault fix** — \`STATUS_ENTRYPOINT_NOT_FOUND\`/\`0xc0000139\` is auto-detected (or \`AJH_SKIP_CARGO_TEST=1\`) and skips ONLY cargo test with a loud warning while check/clippy/fmt/deny still run. Any other test failure still aborts the push.
- \`docs/DEVELOPMENT.md\`: the three layers, both escape hatches, and why \`--no-verify\` is now the wrong tool (it hides the audit trail).

## Verification (all against the real script/hook, not mocks)

- Canary commit with \`std::env::var\` outside \`platform/\` → script exits 1 with the ast-grep finding, \`tier0-block\` metric
- \`--log-skip\` → audited \`skipped:true\` metric; empty range → warned fail-open; \`sh -n\` clean
- Nested \`claude -p\` verified working from hook context (earlier \`llm-unavailable\` was the 120s timeout on a large diff — pre-push now gets 180s, no Stop-hook constraint applies)
- **Acceptance test: this PR's own push ran through the FULL hook with no \`--no-verify\`** — pre-push AI review made a live sonnet pass and logged \`clean\`
- \`check:agent-system\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)