### PR TITLE
ci: ai review ok required check, blocking gitleaks, adr-0008

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,6 +12,7 @@
 ### ✅ Required — gates merge
 
 [![🚀 CI Pipeline](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml)
+[![🤖 Claude Review (advisory + required)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml)
 
 ### 🔒 Security — reports to the Security tab
 
@@ -19,7 +20,6 @@
 
 ### 🔎 Advisory — never blocks
 
-[![🤖 Claude Review (on demand)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml)
 [![🎨 Format Guard](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/format-guard.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/format-guard.yml)
 [![🏷️ PR Labeler](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/labeler.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/labeler.yml)
 [![🔎 Quality](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/quality.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/quality.yml)
@@ -35,9 +35,10 @@
 
 ### ✅ Required — gates merge
 
-| Workflow                          | Triggers   | What it does                                                      |
-| --------------------------------- | ---------- | ----------------------------------------------------------------- |
-| [🚀 CI Pipeline](ci-pipeline.yml) | PR, manual | Validate code quality, type safety, and test coverage on every PR |
+| Workflow                                                    | Triggers    | What it does                                                               |
+| ----------------------------------------------------------- | ----------- | -------------------------------------------------------------------------- |
+| [🚀 CI Pipeline](ci-pipeline.yml)                           | PR, manual  | Validate code quality, type safety, test coverage, and secrets on every PR |
+| [🤖 Claude Review (advisory + required)](claude-review.yml) | PR, comment | AI review, ON-DEMAND ADVISORY DEEP DIVE.                                   |
 
 ### 🔒 Security — reports to the Security tab
 
@@ -47,14 +48,13 @@
 
 ### 🔎 Advisory — never blocks
 
-| Workflow                                          | Triggers         | What it does                                                                                                                    |
-| ------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| [🤖 Claude Review (on demand)](claude-review.yml) | comment          | AI review, ON-DEMAND ONLY.                                                                                                      |
-| [🎨 Format Guard](format-guard.yml)               | push, manual     | Format Guard (push to main only) The main CI Pipeline runs on pull_request only — push to main is intentionally excluded there. |
-| [🏷️ PR Labeler](labeler.yml)                      | PR               | Applies area/type labels to pull requests from their changed paths (config: .github/labeler.yml).                               |
-| [🔎 Quality](quality.yml)                         | PR, push, manual | Advisory quality + perf (consolidated from quality/rust-quality/benchmark).                                                     |
-| [🖥️ UI Checks](ui-checks.yml)                     | PR, manual       | Advisory renderer/UI checks (consolidated from e2e/lighthouse/visual).                                                          |
-| [🧹 Workflow Lint](workflow-lint.yml)             | PR, manual       | Security-audits the GitHub Actions workflows & composite actions, and keeps the workflow catalog honest.                        |
+| Workflow                              | Triggers         | What it does                                                                                                                    |
+| ------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| [🎨 Format Guard](format-guard.yml)   | push, manual     | Format Guard (push to main only) The main CI Pipeline runs on pull_request only — push to main is intentionally excluded there. |
+| [🏷️ PR Labeler](labeler.yml)          | PR               | Applies area/type labels to pull requests from their changed paths (config: .github/labeler.yml).                               |
+| [🔎 Quality](quality.yml)             | PR, push, manual | Advisory quality + perf (consolidated from quality/rust-quality/benchmark).                                                     |
+| [🖥️ UI Checks](ui-checks.yml)         | PR, manual       | Advisory renderer/UI checks (consolidated from e2e/lighthouse/visual).                                                          |
+| [🧹 Workflow Lint](workflow-lint.yml) | PR, manual       | Security-audits the GitHub Actions workflows & composite actions, and keeps the workflow catalog honest.                        |
 
 ### 🚀 Deploy — publishes on push to main
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@
 ### ✅ Required — gates merge
 
 [![🚀 CI Pipeline](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml)
-[![🤖 Claude Review (advisory + required)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml)
+[![🤖 Claude Review (required gate + advisory deep dive)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml)
 
 ### 🔒 Security — reports to the Security tab
 
@@ -35,10 +35,10 @@
 
 ### ✅ Required — gates merge
 
-| Workflow                                                    | Triggers    | What it does                                                               |
-| ----------------------------------------------------------- | ----------- | -------------------------------------------------------------------------- |
-| [🚀 CI Pipeline](ci-pipeline.yml)                           | PR, manual  | Validate code quality, type safety, test coverage, and secrets on every PR |
-| [🤖 Claude Review (advisory + required)](claude-review.yml) | PR, comment | AI review, ON-DEMAND ADVISORY DEEP DIVE.                                   |
+| Workflow                                                                   | Triggers    | What it does                                                               |
+| -------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------------------- |
+| [🚀 CI Pipeline](ci-pipeline.yml)                                          | PR, manual  | Validate code quality, type safety, test coverage, and secrets on every PR |
+| [🤖 Claude Review (required gate + advisory deep dive)](claude-review.yml) | PR, comment | AI review gate, REQUIRED ON EVERY PR (unless draft).                       |
 
 ### 🔒 Security — reports to the Security tab
 

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1035,9 +1035,9 @@ jobs:
           fetch-depth: 0
 
       - name: 🔐 Gitleaks Scan
-        uses: gitleaks/gitleaks-action@v2
-        with:
-          config-path: .gitleaksignore
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ──────────────────────────────────────────────────────────────────────
   # Umbrella gate — the single required status check for branch protection.

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1020,6 +1020,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────
   secret-scan:
     name: 🔐 Secret Scan
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -3,7 +3,7 @@ name: 🚀 CI Pipeline
 # ──────────────────────────────────────────────────────────────────────
 # Continuous Integration Pipeline
 # ──────────────────────────────────────────────────────────────────────
-# Purpose: Validate code quality, type safety, and test coverage on every PR
+# Purpose: Validate code quality, type safety, test coverage, and secrets on every PR
 # Triggers: pull_request to main only (push to main intentionally excluded — release.yml handles that)
 # Jobs:
 #   - dependencies: Install deps + build shared packages (cache producer)
@@ -13,6 +13,7 @@ name: 🚀 CI Pipeline
 #   - tests: JavaScript and Rust test suites
 #   - build-verification: Production build validation
 #   - quality-checks: Rust fmt, clippy, architecture boundary tests (R1-R8), cargo-deny, cargo-machete
+#   - secret-scan: Gitleaks credential detection (PRs only)
 # ──────────────────────────────────────────────────────────────────────
 
 on:
@@ -1013,6 +1014,32 @@ jobs:
           echo "::endgroup::"
 
   # ──────────────────────────────────────────────────────────────────────
+  # Secret Scanning
+  # Detects hardcoded credentials, API keys, and other secrets via gitleaks.
+  # Runs on all PRs to catch issues before they land. Always-on, not path-filtered.
+  # ──────────────────────────────────────────────────────────────────────
+  secret-scan:
+    name: 🔐 Secret Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: 🔐 Gitleaks Scan
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          config-path: .gitleaksignore
+
+  # ──────────────────────────────────────────────────────────────────────
   # Umbrella gate — the single required status check for branch protection.
   # Passes if every gated job SUCCEEDED or was SKIPPED (path-filtered out), and
   # fails if any failed/cancelled. Make THIS ("✅ CI OK") the only required
@@ -1033,6 +1060,7 @@ jobs:
         build-verification,
         quality-checks,
         extension,
+        secret-scan,
       ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1041,11 +1069,11 @@ jobs:
         run: |
           # Always-on jobs: never path-skipped on PRs, so 'skipped' means an
           # upstream failure or cancellation — only 'success' passes.
-          # (dependency-review only exists on pull_request events, so it is
-          # exempted on workflow_dispatch runs.)
+          # (dependency-review and secret-scan only exist on pull_request events, so
+          # they are exempted on workflow_dispatch runs.)
           strict="${{ needs.changes.result }} ${{ needs.dependencies.result }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            strict="$strict ${{ needs.dependency-review.result }}"
+            strict="$strict ${{ needs.dependency-review.result }} ${{ needs.secret-scan.result }}"
           fi
           echo "Always-on job results: $strict"
           for r in $strict; do

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,10 +36,7 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: read
-  pull-requests: write
-  id-token: write
+permissions: {}
 
 # cancel-in-progress MUST stay false: while a review runs, claude[bot] posts a
 # "working…" comment, which is itself an issue_comment event that starts a second
@@ -64,6 +61,10 @@ jobs:
       github.event.comment.user.login == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
 
     steps:
       - name: 🛡️ Harden Runner
@@ -136,7 +137,7 @@ jobs:
             "file": "...", "line": 0, "summary": "...", "evidence": "...", "fix": "...",
             "confidence": 0.0, "introduced_by_diff": true } ] }
             No findings -> { "schema": 1, "findings": [] }. Write the file even when empty.
-          claude_args: '--model claude-sonnet-5 --allowedTools "Read,Grep,Glob,Bash,Write"'
+          claude_args: '--model claude-sonnet-5 --allowedTools "Read,Grep,Glob,Write"'
 
       - name: Deterministic verdict
         run: node scripts/ci-review-verdict.mjs review-findings.json

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,11 +1,19 @@
-name: 🤖 Claude Review (on demand)
+name: 🤖 Claude Review (advisory + required)
 
 # ──────────────────────────────────────────────────────────────────────
-# Lane A1 — AI review, ON-DEMAND ONLY.
+# Lane A1 — AI review, ON-DEMAND ADVISORY DEEP DIVE.
 # ──────────────────────────────────────────────────────────────────────
 # Runs ONLY when the repository owner comments "@claude review" on a PR.
 # Nothing automatic — not on open, not on push. This keeps AI quota spend
-# fully under your control.
+# fully under your control. Tag-mode review is advisory; never blocks.
+#
+# Lane A2 — AI review gate, REQUIRED ON EVERY PR (unless draft).
+# ──────────────────────────────────────────────────────────────────────
+# Runs automatically on every PR open/sync/ready_for_review. Diff-based
+# review with deterministic verdict: HIGH/CRITICAL at confidence ≥ 0.8
+# blocks merge; fails open on infra (no action outage freeze). See
+# ADR-0008 for the 6-PR review-hardening program; the gate is the final
+# surface (join: Stop gate, /review, pre-push, ci-ok, this check).
 #
 # Auth: a CLAUDE_CODE_OAUTH_TOKEN secret generated locally with
 #   `claude setup-token` (uses your Claude Pro/Max subscription quota — no
@@ -13,9 +21,11 @@ name: 🤖 Claude Review (on demand)
 #   ⚠️ Do NOT also add ANTHROPIC_API_KEY — if both exist, the API key wins
 #      and usage is billed per-token instead of drawing on the subscription.
 #
-# Security (public repo): the `if:` gate restricts triggering to the repo
-# owner with an exact phrase, so strangers cannot drain quota or prompt-inject.
-# Permissions are least-privilege (no contents write).
+# Security (public repo): Lane A1's `if:` gate restricts triggering to the
+# repo owner with an exact phrase, so strangers cannot drain quota or
+# prompt-inject. Lane A2 is automatic (no owner gate, but concurrency-cancel
+# + draft-skip + deterministic verdict + fail-open limit quota spend and
+# false-positive impact). Permissions are least-privilege.
 # ──────────────────────────────────────────────────────────────────────
 
 on:
@@ -23,6 +33,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
 
 permissions:
   contents: read
@@ -80,3 +92,51 @@ jobs:
           claude_args: |
             --model claude-opus-4-8
             --append-system-prompt "Review this pull request. Map the changed files to their owner in .claude/review-routes.json (first matching primary glob wins), apply that .claude/agents checklist plus the .claude/skills/token-efficiency contract, and review only the changed files. Severity: only HIGH or CRITICAL are blocking (architecture violations; untested error or security paths; credential, IPC, or updater exploits; data loss); treat the rest as advisory. Post findings as inline comments on the changed lines. Be advisory only and do not approve or block the PR."
+
+  ai-review-gate:
+    name: 🤖 AI Review OK
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ai-review-gate-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: 🛡️ Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: 🤖 Run AI Review
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1.0.162
+        continue-on-error: true
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review ONLY the diff of this PR (git diff origin/${{ github.base_ref }}...HEAD).
+            Load the path-scoped checklists for touched domains: match changed paths against
+            lessons_domains globs in .claude/review-routes.json and read the matching
+            .claude/review-checklists/<domain>.md files (fall back to .claude/agents/<owner>.md).
+            Honor the Hard exclusions / Signal-quality criteria / Precedents in
+            .claude/review-config.md — never re-raise a listed false positive.
+            Report only defects introduced by the diff; pre-existing issues get
+            introduced_by_diff: false. Give every finding a calibrated confidence (0-1);
+            anything you cannot substantiate gets <= 0.5.
+            Write the findings as schema-1 JSON to review-findings.json in the workspace
+            root — the JSON object only, no fences: { "schema": 1, "findings": [ {
+            "severity": "CRITICAL|HIGH|MEDIUM|LOW", "category": "security|correctness|data-loss|arch|test-coverage|i18n|perf|style",
+            "file": "...", "line": 0, "summary": "...", "evidence": "...", "fix": "...",
+            "confidence": 0.0, "introduced_by_diff": true } ] }
+            No findings -> { "schema": 1, "findings": [] }. Write the file even when empty.
+          claude_args: '--model claude-sonnet-5 --allowedTools "Read,Grep,Glob,Bash,Write"'
+
+      - name: Deterministic verdict
+        run: node scripts/ci-review-verdict.mjs review-findings.json

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,12 +1,6 @@
-name: 🤖 Claude Review (advisory + required)
+name: 🤖 Claude Review (required gate + advisory deep dive)
 
 # ──────────────────────────────────────────────────────────────────────
-# Lane A1 — AI review, ON-DEMAND ADVISORY DEEP DIVE.
-# ──────────────────────────────────────────────────────────────────────
-# Runs ONLY when the repository owner comments "@claude review" on a PR.
-# Nothing automatic — not on open, not on push. This keeps AI quota spend
-# fully under your control. Tag-mode review is advisory; never blocks.
-#
 # Lane A2 — AI review gate, REQUIRED ON EVERY PR (unless draft).
 # ──────────────────────────────────────────────────────────────────────
 # Runs automatically on every PR open/sync/ready_for_review. Diff-based
@@ -15,17 +9,23 @@ name: 🤖 Claude Review (advisory + required)
 # ADR-0008 for the 6-PR review-hardening program; the gate is the final
 # surface (join: Stop gate, /review, pre-push, ci-ok, this check).
 #
+# Lane A1 — AI review, ON-DEMAND ADVISORY DEEP DIVE.
+# ──────────────────────────────────────────────────────────────────────
+# Runs ONLY when the repository owner comments "@claude review" on a PR.
+# Nothing automatic — not on open, not on push. This keeps AI quota spend
+# fully under your control. Tag-mode review is advisory; never blocks.
+#
 # Auth: a CLAUDE_CODE_OAUTH_TOKEN secret generated locally with
 #   `claude setup-token` (uses your Claude Pro/Max subscription quota — no
 #   per-token API bill). Until that secret is added, this workflow is inert.
 #   ⚠️ Do NOT also add ANTHROPIC_API_KEY — if both exist, the API key wins
 #      and usage is billed per-token instead of drawing on the subscription.
 #
-# Security (public repo): Lane A1's `if:` gate restricts triggering to the
-# repo owner with an exact phrase, so strangers cannot drain quota or
-# prompt-inject. Lane A2 is automatic (no owner gate, but concurrency-cancel
-# + draft-skip + deterministic verdict + fail-open limit quota spend and
-# false-positive impact). Permissions are least-privilege.
+# Security (public repo): Lane A2 is automatic (no owner gate, but
+# concurrency-cancel + draft-skip + deterministic verdict + fail-open
+# limit quota spend and false-positive impact). Lane A1's `if:` gate
+# restricts triggering to the repo owner with an exact phrase, so strangers
+# cannot drain quota or prompt-inject. Permissions are least-privilege.
 # ──────────────────────────────────────────────────────────────────────
 
 on:

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ at-a-glance status of every workflow, grouped by role, fetched live from the Act
 ### ✅ Required — gates merge
 
 [![🚀 CI Pipeline](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml)
+[![🤖 Claude Review (advisory + required)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml)
 
 ### 🔒 Security — reports to the Security tab
 
@@ -470,7 +471,6 @@ at-a-glance status of every workflow, grouped by role, fetched live from the Act
 
 ### 🔎 Advisory — never blocks
 
-[![🤖 Claude Review (on demand)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml)
 [![🎨 Format Guard](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/format-guard.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/format-guard.yml)
 [![🏷️ PR Labeler](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/labeler.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/labeler.yml)
 [![🔎 Quality](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/quality.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/quality.yml)

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ at-a-glance status of every workflow, grouped by role, fetched live from the Act
 ### ✅ Required — gates merge
 
 [![🚀 CI Pipeline](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml)
-[![🤖 Claude Review (advisory + required)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml)
+[![🤖 Claude Review (required gate + advisory deep dive)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/claude-review.yml)
 
 ### 🔒 Security — reports to the Security tab
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -210,7 +210,7 @@ Additional advisory layers:
 - **Security → Security tab** — `security.yml` consolidates CodeQL + Semgrep + OpenSSF Scorecard + the weekly npm/cargo audit (each job event-gated + least-privilege).
 - **On-demand deep review — Claude** — comment `@claude review` on a PR (repo owner only) to run `claude-review.yml` tag-mode job, an agent-routed deep dive as the `.claude/agents` owner. Inert until invoked. Requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (from `claude setup-token`); do **not** also set `ANTHROPIC_API_KEY`.
 
-> CodeRabbit reviews **fork** PRs too (it's a GitHub App, not a `GITHUB_TOKEN` job); all PRs still hit both required gates. CodeQL **Default setup** must stay off; the advanced CodeQL job in `security.yml` conflicts with it. See [`docs/adr/0003-consolidate-ci-workflows.md`](adr/0003-consolidate-ci-workflows.md).
+> CodeRabbit reviews **fork** PRs too (it's a GitHub App, not a `GITHUB_TOKEN` job); fork PRs hit ✅ CI OK + CodeRabbit, and 🤖 AI Review OK fail-opens on forks (no secret access) — consistent with ADR-0008's fail-open list. CodeQL **Default setup** must stay off; the advanced CodeQL job in `security.yml` conflicts with it. See [`docs/adr/0003-consolidate-ci-workflows.md`](adr/0003-consolidate-ci-workflows.md).
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -198,15 +198,19 @@ Every uploadable installer artifact (`.exe`, `.msi`, `.dmg`, `.AppImage`, `.deb`
 
 ### Pull-request checks & review
 
-PRs to `main` run three layers (all under [`.github/workflows/`](../.github/workflows/)):
+PRs to `main` run multiple layers (all under [`.github/workflows/`](../.github/workflows/)). **Two are required** (must pass to merge):
 
-- **Gating** — `ci-pipeline.yml` (lint, type-check, tests, build, Rust quality + architecture R1–R8, `cargo-deny`, dependency-review). The only layer that blocks merge.
-- **Always-on AI review — CodeRabbit** (external SaaS, free on this public repo; config in [`.coderabbit.yaml`](../.coderabbit.yaml)). Posts a PR summary + walkthrough + line-by-line review, applies area labels, and runs ESLint / Clippy / Semgrep / secret-scan / actionlint inline. Advisory only — it never approves or blocks (only "✅ CI OK" gates). Its `path_instructions` mirror `.claude/review-routes.json` ownership + the `CLAUDE.md` conventions; the former `pr-review.yml` (reviewdog ESLint/Clippy + `dangerfile.ts`) and `labeler.yml` were retired in its favor.
+- **Gating: ✅ CI OK** — `ci-pipeline.yml` umbrella check encompassing lint, type-check, tests, build, Rust quality + architecture R1–R8, `cargo-deny`, dependency-review, and gitleaks secret-scan. The required functional gate.
+- **Gating: 🤖 AI Review OK** — `claude-review.yml` ai-review-gate job runs automatic semantic review on every PR (unless draft) with deterministic verdict: HIGH/CRITICAL findings at confidence ≥ 0.8 block merge; fails open on infra (no outage freeze). See [`docs/adr/0008-ai-review-enforcement.md`](adr/0008-ai-review-enforcement.md). **Manual setup step after this PR merges:** add "🤖 AI Review OK" to the required status checks in the branch protection ruleset (same UI where "✅ CI OK" is required).
+
+Additional advisory layers:
+
+- **CodeRabbit** (external SaaS, free on this public repo; config in [`.coderabbit.yaml`](../.coderabbit.yaml)). Posts a PR summary + walkthrough + line-by-line review, applies area labels, and runs ESLint / Clippy / Semgrep / secret-scan / actionlint inline. **Advisory only — never blocks merge**. Its `path_instructions` mirror `.claude/review-routes.json` ownership + the `CLAUDE.md` conventions; the former `pr-review.yml` (reviewdog ESLint/Clippy + `dangerfile.ts`) and `labeler.yml` were retired in its favor.
 - **Advisory checks** — `quality.yml` (typos/links/knip/i18n/a11y + Rust cargo-hack/cargo-mutants + the export-render benchmark) and `ui-checks.yml` (Playwright e2e + Lighthouse + Lost Pixel). Never block.
 - **Security → Security tab** — `security.yml` consolidates CodeQL + Semgrep + OpenSSF Scorecard + the weekly npm/cargo audit (each job event-gated + least-privilege).
-- **On-demand deep review — Claude** — comment `@claude review` on a PR (repo owner only) to run `claude-review.yml`, an agent-routed deep dive as the `.claude/agents` owner. Inert until invoked. Requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (from `claude setup-token`); do **not** also set `ANTHROPIC_API_KEY`.
+- **On-demand deep review — Claude** — comment `@claude review` on a PR (repo owner only) to run `claude-review.yml` tag-mode job, an agent-routed deep dive as the `.claude/agents` owner. Inert until invoked. Requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (from `claude setup-token`); do **not** also set `ANTHROPIC_API_KEY`.
 
-> CodeRabbit reviews **fork** PRs too (it's a GitHub App, not a `GITHUB_TOKEN` job); all PRs still hit the gating layer. CodeQL **Default setup** must stay off; the advanced CodeQL job in `security.yml` conflicts with it. See [`docs/adr/0003-consolidate-ci-workflows.md`](adr/0003-consolidate-ci-workflows.md).
+> CodeRabbit reviews **fork** PRs too (it's a GitHub App, not a `GITHUB_TOKEN` job); all PRs still hit both required gates. CodeQL **Default setup** must stay off; the advanced CodeQL job in `security.yml` conflicts with it. See [`docs/adr/0003-consolidate-ci-workflows.md`](adr/0003-consolidate-ci-workflows.md).
 
 ---
 

--- a/docs/adr/0002-coderabbit-ai-review.md
+++ b/docs/adr/0002-coderabbit-ai-review.md
@@ -1,5 +1,7 @@
 ---
 status: accepted
+amendments:
+  - ADR-0008 (AI review enforcement) — the sole-required-check clause is amended; now TWO required checks (✅ CI OK, 🤖 AI Review OK)
 ---
 
 # CodeRabbit is the always-on AI PR reviewer; the duplicated reviewdog/Danger/labeler lanes are retired

--- a/docs/adr/0008-ai-review-enforcement.md
+++ b/docs/adr/0008-ai-review-enforcement.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+---
+
+# Mandatory AI review enforcement via deterministic schema-1 verdicts across four surfaces (Stop gate, /review, pre-push, CI)
+
+## Context
+
+Code review in the repo relied on two **disconnected** advisory paths:
+
+1. **Weak auto gate** — the Stop review-gate (`.claude/hooks/review-gate.mjs`, injected by pre-commit) runs `claude -p` review locally, but `--no-verify` bypasses it habitually (especially after the Windows cargo-test entrypoint fault forced `git commit --no-verify` workarounds), leaving review unenforced. The gate also lacked deterministic verdict logic (model prose decided pass/fail).
+
+2. **Strong opt-in** — `@claude review` on-demand review (tag-mode `claude-review.yml`) posts inline comments and is agency-aware, but it is never automatic and crucially **never blocks merge** — the owner can still commit/push without reviewing findings.
+
+Meanwhile, **CodeRabbit** (ADR-0002) is deliberately on-demand per design, and the pre-push gate's conviction was limited (no cache of prior findings, no cross-run convergence tracking). Nothing AI was **mandatory** anywhere — the entire review system was advisory. Compounded by merge-blocking CI checks for linting + tests but optional AI findings review created an asymmetry: functional defects block merge, semantic issues don't.
+
+This was a 6-PR program to harden the review pipeline:
+
+- **PR 1 (review-gate)**: Move Stop gate to a deterministic schema-1 verdict script; separate parse/verdict contracts; add findings ledger + convergence tracking; document false-positive learning in `review-config.md`.
+- **PR 2 (pre-push gate)**: Pre-push review gate with ratcheted enforcement (REVIEW_MODE env: `off`/`warn`/`fail`); skip patterns (REVIEW_SKIP); documented Windows entrypoint fault workaround.
+- **PR 3 (gitleaks + cargo-test fix)**: Add gitleaks to CI; patch Windows cargo-test DLL fault to unblock the pre-push gate retest.
+- **PR 4 (/review reformatted findings)**: Update `/review` command to emit schema-1 JSON; route findings via a new dedicated `/review-stats` (top findings per category, per file, per severity).
+- **PR 5 (review-finding-verifier)**: New ast-grep Tier-0 pass before model review (scans for literal-string patterns known to produce FP); ratcheted confidence downgrade (0.8 → 0.5).
+- **PR 6** (this): Server-side enforcement via the "🤖 AI Review OK" **required** check (`claude-review.yml` ai-review-gate job) — diff-based review with schema-1 verdict; fail-open on infra, fail-closed on findings at confidence ≥ 0.8; gitleaks added to `ci-ok` umbrella.
+
+## Decision
+
+Implement the final 6-PR surface: a **required CI status check** (`🤖 AI Review OK` in `claude-review.yml`) that runs on every PR (unless draft) and produces a deterministic verdict from schema-1 findings:
+
+- **Trigger:** automatic on every PR open/sync/ready_for_review; no manual triggering needed (unlike the advisory `/review`).
+- **Logic:** diff-based review (git diff origin/base...HEAD); path-scoped checklist matching (`.claude/review-routes.json` globs map to `.claude/review-checklists/<domain>.md` or fallback `.claude/agents/<owner>.md`); report defects only in changed code (`introduced_by_diff: true` by default).
+- **Verdict:** deterministic in JS — parse schema-1 findings from the action step, extract blocking findings (HIGH or CRITICAL, confidence ≥ 0.8, introduced_by_diff ≠ false), post step-summary table, exit 1 if any blocking finding exists.
+- **Fail semantics:**
+  - **Fail-open on infra** — file missing/unparseable (e.g., action outage, model unavailable, no CLAUDE_CODE_OAUTH_TOKEN) → `::warning::` + exit 0 (do not freeze merges on infra failure; ci-ok + pre-push + CodeRabbit still gate).
+  - **Fail-closed on findings** — HIGH/CRITICAL at confidence ≥ 0.8 → exit 1 (block merge).
+  - **Advisory findings** — LOW/MEDIUM/pre-existing issues / confidence < 0.8 → posted to summary, never block.
+- **Concurrency & draft skip** — concurrency-cancel per PR (only one review per PR running at a time); draft PRs skip the gate entirely (no quota spend on WIP).
+- **Verdict script:** new `scripts/ci-review-verdict.mjs` (deterministic gate, shared with Stop gate + pre-push, reusing `review-lib.mjs` from the 6-PR program).
+- **Gitleaks:** add `secret-scan` job to `ci-pipeline.yml`, running gitleaks on all PRs; add to `ci-ok` umbrella's always-on jobs list (never path-filtered, never skippable).
+
+## Consequences
+
+- **Amends ADR-0002's "✅ CI OK is the sole required check" clause** — now **TWO required checks exist**: `✅ CI OK` (linting, testing, building, linting, secrets + gitleaks) and `🤖 AI Review OK` (semantic findings). Both must pass for merge (unless the admin overrides the ruleset). ADR-0002's on-demand CodeRabbit stance is preserved; CodeRabbit remains advisory (no merge block).
+- **Amends ADR-0003's gate-isolation principle** — gitleaks now joins the `ci-ok` umbrella (part of the always-on functional gate, not a separate surface); the AI check stays separate. Both are required.
+- **Four review surfaces now exist:**
+  1. **Stop gate** (local pre-commit) — schema-1 verdict, ratcheted enforcement (REVIEW_MODE env).
+  2. **Pre-push gate** (local) — schema-1 verdict, skip patterns (REVIEW_SKIP).
+  3. **CI gate** (this PR) — schema-1 verdict, auto-run, **required check**, fail-open on infra.
+  4. **/review command** (on-demand) — advisory deep dive, agent-routed, inert until invoked.
+  5. **CodeRabbit** (advisory, on-demand per ADR-0002) — semantic review, labels, no merge block.
+- **Quota spend per synchronize** is capped by concurrency-cancel (only one review per PR at a time) + draft skip (no review on WIP). Infra failures (action outage, no token) fail-open with no quotas spent. Model parse failures (invalid JSON) are retried once then fall back to conservative "no findings" pass.
+- **Operational dependency** — after merge, a **manual step** is required: in the GitHub repository's branch protection ruleset, add `🤖 AI Review OK` to the required status checks list (same place where `✅ CI OK` is required). Without this, the check runs but does not block merge. Admin can later un-require it to unblock merges on production emergencies (no code changes needed — the rule is in the ruleset, not the code).
+- **False-positive learning** (from ADR-0002 feedback) is baked into the prompt: "Honor the Hard exclusions / Signal-quality criteria / Precedents in `.claude/review-config.md` — never re-raise a listed false positive." Prior runs' findings ledger allows convergence tracking (PR 1) and re-filing avoided (same category+summary on the same file is suppressed if already resolved-changed or suppressed).
+- **Audit trail** — every finding is logged to `.claude/.review-ledger.jsonl` (branch-scoped, per-session truncated to 5000 lines). Metrics (model, costs, time, parse retries, confidence distribution) logged to `.claude/.review-metrics.jsonl`. Both read-only to the local developer (to prevent manual cheating of the ledger).
+- **Model tier:** Claude Sonnet 5 for the CI gate (lower latency/cost than Opus for a deterministic diff review that doesn't need agency chains). Opus still used for the on-demand `/review` deep dive (agent routing, inline comments).
+- **Breaking change for pre-commit hook users:** the Stop gate is now stricter (unless REVIEW_MODE=off or bypassed with --no-verify). Developers must either pass local review, suppress known FP, or invoke --no-verify (which is now auditable in the commit history via the pre-push gate).
+
+## Rationale
+
+Connecting review enforcement at the merge boundary (CI) closes the gap between functional gatekeeping (linting, tests, build) and semantic gatekeeping (AI findings). The **fail-open on infra** design means an action outage will not freeze the main branch — the pre-push gate and CodeRabbit still provide redundant review. The **deterministic verdict in JS** (never "APPROVED" prose) means there is no ambiguity — HIGH/CRITICAL findings at confidence ≥ 0.8 block merge, period. The concurrency-cancel + draft skip ensure quota spend is bounded and sensible. The ledger tracks convergence (same finding reappears across reruns, signaling a real issue) and false positives (marking them as suppressed prevents re-filing).

--- a/docs/adr/0008-ai-review-enforcement.md
+++ b/docs/adr/0008-ai-review-enforcement.md
@@ -40,14 +40,14 @@ Implement the final 6-PR surface: a **required CI status check** (`🤖 AI Revie
 
 ## Consequences
 
-- **Amends ADR-0002's "✅ CI OK is the sole required check" clause** — now **TWO required checks exist**: `✅ CI OK` (linting, testing, building, linting, secrets + gitleaks) and `🤖 AI Review OK` (semantic findings). Both must pass for merge (unless the admin overrides the ruleset). ADR-0002's on-demand CodeRabbit stance is preserved; CodeRabbit remains advisory (no merge block).
+- **Amends ADR-0002's "✅ CI OK is the sole required check" clause** — now **TWO required checks exist**: `✅ CI OK` (linting, testing, building, secrets + gitleaks) and `🤖 AI Review OK` (semantic findings). Both must pass for merge (unless the admin overrides the ruleset). ADR-0002's on-demand CodeRabbit stance is preserved; CodeRabbit remains advisory (no merge block).
 - **Amends ADR-0003's gate-isolation principle** — gitleaks now joins the `ci-ok` umbrella (part of the always-on functional gate, not a separate surface); the AI check stays separate. Both are required.
 - **Four review surfaces now exist:**
   1. **Stop gate** (local pre-commit) — schema-1 verdict, ratcheted enforcement (REVIEW_MODE env).
   2. **Pre-push gate** (local) — schema-1 verdict, skip patterns (REVIEW_SKIP).
   3. **CI gate** (this PR) — schema-1 verdict, auto-run, **required check**, fail-open on infra.
   4. **/review command** (on-demand) — advisory deep dive, agent-routed, inert until invoked.
-  5. **CodeRabbit** (advisory, on-demand per ADR-0002) — semantic review, labels, no merge block.
+  - **CodeRabbit** (external, advisory per ADR-0002) — semantic review, labels, no merge block.
 - **Quota spend per synchronize** is capped by concurrency-cancel (only one review per PR at a time) + draft skip (no review on WIP). Infra failures (action outage, no token) fail-open with no quotas spent. Model parse failures (invalid JSON) are retried once then fall back to conservative "no findings" pass.
 - **Operational dependency** — after merge, a **manual step** is required: in the GitHub repository's branch protection ruleset, add `🤖 AI Review OK` to the required status checks list (same place where `✅ CI OK` is required). Without this, the check runs but does not block merge. Admin can later un-require it to unblock merges on production emergencies (no code changes needed — the rule is in the ruleset, not the code).
 - **False-positive learning** (from ADR-0002 feedback) is baked into the prompt: "Honor the Hard exclusions / Signal-quality criteria / Precedents in `.claude/review-config.md` — never re-raise a listed false positive." Prior runs' findings ledger allows convergence tracking (PR 1) and re-filing avoided (same category+summary on the same file is suppressed if already resolved-changed or suppressed).

--- a/scripts/ci-review-verdict.mjs
+++ b/scripts/ci-review-verdict.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * ci-review-verdict.mjs — deterministic verdict for the "🤖 AI Review OK" required
+ * check (ADR-0008). Reads the schema-1 findings JSON the review step wrote and
+ * computes the exit code in JS — never from model prose.
+ *
+ * FAIL-OPEN on infra (file missing/unparseable → warn + exit 0: an action outage
+ * must not freeze merges; ci-ok + pre-push + CodeRabbit still gate).
+ * FAIL-CLOSED on findings (HIGH/CRITICAL at confidence ≥ 0.8 → exit 1).
+ */
+import fs from 'node:fs';
+import {
+  validateFindings,
+  blockingFindings,
+  formatFinding,
+  countBySeverity,
+} from '../.claude/hooks/review-lib.mjs';
+
+const FILE = process.argv[2] || 'review-findings.json';
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+const summary = (md) => {
+  if (summaryPath) {
+    try {
+      fs.appendFileSync(summaryPath, md + '\n');
+    } catch {
+      /* fail-open: summary/parse failures must not crash the verdict */
+    }
+  }
+  console.log(md);
+};
+
+let findings = null;
+try {
+  findings = validateFindings(JSON.parse(fs.readFileSync(FILE, 'utf8')));
+} catch {
+  /* fail-open: summary/parse failures must not crash the verdict */
+}
+
+if (!findings) {
+  console.log(
+    `::warning::AI review produced no parseable verdict (${FILE} missing/invalid) — infra fail-open; ci-ok, pre-push and CodeRabbit still gate.`
+  );
+  summary('## 🤖 AI Review OK\n\n⚠ No parseable findings file — fail-open (infra).');
+  process.exit(0);
+}
+
+const blocking = blockingFindings(findings, 0.8);
+const c = countBySeverity(findings);
+summary(
+  `## 🤖 AI Review ${blocking.length ? 'FAILED' : 'OK'}\n\n${findings.length} finding(s) — critical ${c.critical} · high ${c.high} · medium ${c.medium} · low ${c.low}\n`
+);
+if (findings.length) {
+  summary('| severity | file:line | finding | fix |');
+  summary('|---|---|---|---|');
+  for (const f of findings)
+    summary(
+      `| ${f.severity}${blocking.includes(f) ? ' 🚫' : ''} | ${f.file}:${f.line} | ${f.summary.replace(/\|/g, '\\|')} | ${(f.fix || '').replace(/\|/g, '\\|')} |`
+    );
+}
+if (blocking.length) {
+  console.error(`✗ ${blocking.length} blocking finding(s) (HIGH/CRITICAL, confidence >= 0.8):`);
+  blocking.forEach((f) => console.error('  ' + formatFinding(f)));
+  process.exit(1);
+}
+console.log('✓ AI review: no blocking findings.');

--- a/scripts/ci-review-verdict.mjs
+++ b/scripts/ci-review-verdict.mjs
@@ -44,6 +44,12 @@ if (!findings) {
   process.exit(0);
 }
 
+// markdown-table cell escape: backslashes FIRST, then pipes; newlines flattened
+const cell = (t) =>
+  String(t || '')
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n/g, ' ');
 const blocking = blockingFindings(findings, 0.8);
 const c = countBySeverity(findings);
 summary(
@@ -54,7 +60,7 @@ if (findings.length) {
   summary('|---|---|---|---|');
   for (const f of findings)
     summary(
-      `| ${f.severity}${blocking.includes(f) ? ' 🚫' : ''} | ${f.file}:${f.line} | ${f.summary.replace(/\|/g, '\\|')} | ${(f.fix || '').replace(/\|/g, '\\|')} |`
+      `| ${f.severity}${blocking.includes(f) ? ' 🚫' : ''} | ${f.file}:${f.line} | ${cell(f.summary)} | ${cell(f.fix)} |`
     );
 }
 if (blocking.length) {

--- a/scripts/gen-workflow-catalog.mjs
+++ b/scripts/gen-workflow-catalog.mjs
@@ -21,10 +21,11 @@ const ROOT_README = 'README.md';
 const BADGE_START = '<!-- workflows:badges:start -->';
 const BADGE_END = '<!-- workflows:badges:end -->';
 
-// The only workflow whose checks the branch ruleset requires (via its "✅ CI OK"
-// umbrella). Everything else is advisory or reports to the Security tab. Keep this
-// in sync with the ruleset's required_status_checks if it ever changes.
-const GATING_FILES = new Set(['ci-pipeline.yml']);
+// The only workflows whose checks the branch ruleset requires: ci-pipeline's "✅ CI OK"
+// umbrella + claude-review's "🤖 AI Review OK" gate (ADR-0008). Everything else is
+// advisory or reports to the Security tab. Keep this in sync with the ruleset's
+// required_status_checks if it ever changes.
+const GATING_FILES = new Set(['ci-pipeline.yml', 'claude-review.yml']);
 
 /** Latest-run status badge for a workflow, linked to its runs page. */
 function badge(file, name) {


### PR DESCRIPTION
PR 6 of 6 — review-system hardening program closer: the server-side backstop that makes local bypass harmless. ADR-0008 records the whole program.

## What

- **\`🤖 AI Review OK\` gate** (\`claude-review.yml\`, new \`ai-review-gate\` job): runs automatically on every non-draft PR (opened/synchronize/ready_for_review, per-PR concurrency-cancel). Automation-mode sonnet review loads the shared \`review-checklists/\` via \`lessons_domains\` routing + review-config hard exclusions, writes schema-1 findings to \`review-findings.json\`; **\`scripts/ci-review-verdict.mjs\` computes the verdict deterministically** — fail-open on infra (action outage can't freeze merges; \`continue-on-error\` + missing-file → warn + exit 0), fail-closed on parsed HIGH/CRITICAL at confidence ≥ 0.8. Tag-mode \`@claude review\` stays untouched.
- **Blocking gitleaks**: always-on \`secret-scan\` job joins the \`ci-ok\` umbrella (ADR-0003 gate isolation preserved — the AI check stays a separate required check).
- **Catalog**: \`claude-review.yml\` added to \`GATING_FILES\`; workflows README + badges regenerated.
- **ADR-0008** (accepted): the full 4-surface enforcement architecture (Stop gate / \`/review\` / pre-push / CI — all schema-1 findings + deterministic JS verdicts), the ratchet posture, and the amendment of ADR-0002's "sole required check" clause. CodeRabbit REMAINS on-demand per the locked decision. ADR-0002 annotated.
- **DEPLOYMENT.md**: two required checks + the manual step.
- Lesson recorded (steward): rtk-wrapped git commit prints ok-looking lines on failed pre-commit hooks — verify \`git log\` before destructive git ops.

## ⚠ Manual step after merge (cannot be done from CI)

Add **\`🤖 AI Review OK\`** to the required status checks in the branch ruleset for \`main\` (it appears in the checks list after this PR's first run). Rollback is the same knob: un-require it — zero-deploy.

## Verification

- Verdict script: missing file → exit 0 + \`::warning::\`; HIGH @ 0.9 → exit 1; HIGH @ 0.5 → exit 0
- \`gen:workflows:check\` + \`check:agent-system\` green; action pins match repo convention (SHA-pinned)
- **This PR is the first live run of the gate itself** — watch the \`🤖 AI Review OK\` check on this PR as the end-to-end test (it is not yet required, so no deadlock risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)