### PR TITLE
ui: autopilot board results behind an info popover

### DIFF
--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/AutopilotCard.test.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/AutopilotCard.test.tsx
@@ -71,6 +71,7 @@ vi.mock('lucide-react', () => ({
   ChevronUp: () => null,
   ExternalLink: () => null,
   Eye: () => null,
+  Info: () => null,
   Pause: () => null,
   Pencil: () => null,
   Play: () => null,
@@ -90,16 +91,25 @@ vi.mock('@ajh/ui', () => ({
     disabled,
     'aria-label': ariaLabel,
     title,
+    'data-degraded': dataDegraded,
   }: {
     children?: React.ReactNode;
     onClick?: () => void;
     disabled?: boolean;
     'aria-label'?: string;
     title?: string;
+    'data-degraded'?: boolean;
   }) =>
     // Use createElement to avoid the JSXOpeningElement[name="button"] lint rule.
     // A native <button> is required so disabled + keyboard behavior are real.
-    React.createElement('button', { onClick, 'aria-label': ariaLabel, title, disabled }, children),
+    // `data-degraded` is forwarded (not the raw className) as the seam for the
+    // amber-tone assertion — a data-* seam over a Tailwind class string, per the
+    // jsdom-CSS-parsing lesson.
+    React.createElement(
+      'button',
+      { onClick, 'aria-label': ariaLabel, title, disabled, 'data-degraded': dataDegraded },
+      children
+    ),
   ConfirmModal: () => null,
   GlassCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   // Render both trigger and panel content so the badge label AND its hover
@@ -876,5 +886,65 @@ describe('AutopilotCard — persisted per-board chips', () => {
       runState: 'scraping',
     });
     expect(screen.queryAllByTestId('chip')).toHaveLength(0);
+    // Asserted independently of the chips (not just implied by sharing one JSX
+    // conditional) so a future refactor decoupling the two is still caught.
+    expect(
+      screen.queryByRole('button', { name: 'autopilot.boardResults.infoLabel' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows an info button with a localized aria-label that reveals the chips when persisted summaries exist', () => {
+    renderCard(
+      withRun('completedWithErrors', [
+        { board: 'greenhouse', count: 4 },
+        { board: 'linkedin', count: 0, error: 'blocked' },
+      ])
+    );
+    // The chips themselves stay in the DOM (behind the HoverPopover mock, which
+    // renders trigger + content unconditionally) — the meaningful assertion is
+    // that the on-demand trigger exists with a real, localized accessible name.
+    expect(
+      screen.getByRole('button', { name: 'autopilot.boardResults.infoLabel' })
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId('chip').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does NOT render the info button when there are no persisted summaries', () => {
+    renderCard(makeAutopilot());
+    expect(
+      screen.queryByRole('button', { name: 'autopilot.boardResults.infoLabel' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('escalates the info trigger to the degraded tone when a board is merely skipped beside a succeeding one, even though no colored badge fires', () => {
+    // Plain `completed` + one skipped board: `RUN_STATUS_BADGE` has no entry
+    // for `completed`, so no colored badge renders at all — the info
+    // trigger's own tone is the ONLY surviving "something's off" signal.
+    renderCard(
+      withRun('completed', [
+        { board: 'xing', count: 0, skipped: 'needs-login' },
+        { board: 'linkedin', count: 5 },
+      ])
+    );
+    expect(screen.queryByText('autopilot.badge.failed')).not.toBeInTheDocument();
+    expect(screen.queryByText('autopilot.badge.completedWithErrors')).not.toBeInTheDocument();
+    expect(screen.queryByText('autopilot.badge.needsConfig')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'autopilot.boardResults.infoLabel' })
+    ).toHaveAttribute('data-degraded', 'true');
+  });
+
+  it('keeps the resting (non-degraded) tone when every board succeeded', () => {
+    renderCard(withRun('completed', [{ board: 'linkedin', count: 5 }]));
+    expect(
+      screen.getByRole('button', { name: 'autopilot.boardResults.infoLabel' })
+    ).toHaveAttribute('data-degraded', 'false');
+  });
+
+  it('does NOT escalate for an informational location note alone (no cry-wolf amber)', () => {
+    renderCard(withRun('completed', [{ board: 'linkedin', count: 5, note: 'broadened:de' }]));
+    expect(
+      screen.getByRole('button', { name: 'autopilot.boardResults.infoLabel' })
+    ).toHaveAttribute('data-degraded', 'false');
   });
 });

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -164,8 +164,8 @@ export function AutopilotCard({
     : ap.runStatus
       ? RUN_STATUS_BADGE[ap.runStatus]
       : undefined;
-  // Optional hover/focus explainer for the neutral/amber badges now that the
-  // chip strip spells out the per-board detail below.
+  // Optional hover/focus explainer for the neutral/amber badges — the
+  // per-board detail itself lives behind the info icon next to "Found N".
   const badgeHintKey = needsConfig
     ? BADGE_HINT_KEY.needsConfig
     : ap.runStatus === 'completedWithErrors'

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -4,6 +4,7 @@ import {
   ChevronUp,
   ExternalLink,
   Eye,
+  Info,
   Pause,
   Pencil,
   Play,
@@ -140,6 +141,14 @@ export function AutopilotCard({
   // step log (below), this survives the run ending, so a zero/partial/failed
   // result stays explainable. Empty for the happy path + pre-summaries records.
   const lastRunSummaries = ap.lastRunSummaries ?? [];
+  // Discoverability guard: `runStatus` doesn't escalate for a board that's
+  // merely `skipped`/`truncated` beside an otherwise-succeeding board (e.g.
+  // "Xing · needs login" next to a clean LinkedIn run reads as plain
+  // `completed` — no colored badge at all), so the collapsed info trigger is
+  // the ONLY surviving signal and must carry its own amber tone. An
+  // informational `note` (e.g. a broadened-location hint) does NOT count —
+  // it's benign, not a cry-wolf amber.
+  const boardsDegraded = lastRunSummaries.some((s) => s.error || s.skipped || s.truncated);
   // Cry-wolf guard (PR B carry-over 2): a `failed` run whose boards were ALL
   // merely skipped (none errored) is an UNCONFIGURED run, not a failure.
   const needsConfig =
@@ -385,8 +394,58 @@ export function AutopilotCard({
             <span>
               · {t('autopilot.wizard.lastRun')} {lastRun}
             </span>
-            <span>
-              · {t('autopilot.wizard.found')} {foundJobs.length}
+            {/* gap-1 sub-group: the info trigger reads as an annotation ON the
+                found-count, not a stray icon floating at the row's gap-4. */}
+            <span className="inline-flex items-center gap-1">
+              <span>
+                · {t('autopilot.wizard.found')} {foundJobs.length}
+              </span>
+              {!running && lastRunSummaries.length > 0 && (
+                // stopProp wrapper: same reason as the badge popover above —
+                // keeps this from also toggling the card's found-jobs panel.
+                // The trigger is a real <Button> (native focus, no tabIndex
+                // needed), so the HoverPopover's focus-opens-it mechanic is
+                // keyboard-reachable by default (Tab to it, Esc to close)
+                // without extra wiring.
+                <span onClick={stopProp} onKeyDown={stopProp} className="inline-flex shrink-0">
+                  <HoverPopover
+                    placement="top"
+                    ariaLabel={t('autopilot.boardResults.infoLabel')}
+                    contentClassName="max-w-[280px] rounded-lg border border-[var(--border-clear)] bg-card px-3 py-2 shadow-lg"
+                    trigger={
+                      <Button
+                        variant="unstyled"
+                        type="button"
+                        aria-label={t('autopilot.boardResults.infoLabel')}
+                        title={t('autopilot.boardResults.infoLabel')}
+                        data-degraded={boardsDegraded}
+                        className={cn(
+                          // ≥20px hit target (14px icon + p-1). Discoverability:
+                          // a degraded board (error/skipped/truncated) escalates
+                          // to the same amber the warning badges use, at
+                          // near-full opacity — it's the ONLY surviving signal
+                          // once runStatus itself doesn't escalate (e.g. one
+                          // skipped board beside an otherwise-clean run). Clean
+                          // runs rest at the documented /70 floor, never lower.
+                          'inline-flex items-center justify-center rounded p-1 transition-colors',
+                          // No hover shade on the degraded state: amber-200
+                          // isn't in tokens.css's light-scheme remap (only
+                          // 300/400/500 are), so it'd render raw pale amber on
+                          // light (~1.2:1). Already near-full opacity; the
+                          // popover itself is the real hover feedback.
+                          boardsDegraded
+                            ? 'text-amber-300'
+                            : 'text-foreground/70 hover:text-foreground'
+                        )}
+                      >
+                        <Info size={14} />
+                      </Button>
+                    }
+                  >
+                    <BoardSummaryChips summaries={lastRunSummaries} />
+                  </HoverPopover>
+                </span>
+              )}
             </span>
           </div>
         </div>
@@ -445,13 +504,6 @@ export function AutopilotCard({
         )}
       </AnimatePresence>
 
-      {/* Persisted per-board outcome of the LAST run — visible after the run
-          ends (the live step log above only shows while running), so a zero /
-          partial / needs-configuration result is always explainable. */}
-      {!running && lastRunSummaries.length > 0 && (
-        <BoardSummaryChips summaries={lastRunSummaries} />
-      )}
-
       {/* Found jobs from the most recent run */}
       <AnimatePresence>
         {showFound && foundJobs.length > 0 && (
@@ -474,9 +526,9 @@ export function AutopilotCard({
                   onClick={() => setShowFound(false)}
                   aria-label={t('autopilot.collapse')}
                   title={t('autopilot.collapse')}
-                  className="rounded p-0.5 text-foreground/30 transition-colors hover:text-foreground/70"
+                  className="rounded p-1 text-foreground/30 transition-colors hover:text-foreground/70"
                 >
-                  <ChevronUp size={12} />
+                  <ChevronUp size={14} />
                 </Button>
               </div>
               <div

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1336,7 +1336,7 @@
       "applied": "Beworben",
       "failed": "Fehlgeschlagen",
       "completedWithErrors": "Teilweise Ergebnisse",
-      "completedWithErrorsHint": "Einige Boards schlugen fehl oder lieferten nur einen Teil ihrer Ergebnisse. Siehe die Board-Übersicht unten.",
+      "completedWithErrorsHint": "Einige Boards schlugen fehl oder lieferten nur einen Teil ihrer Ergebnisse. Fahre mit der Maus über das Info-Symbol neben der Trefferzahl für die Board-Übersicht.",
       "needsConfig": "Konfiguration nötig",
       "needsConfigHint": "Kein Board konnte laufen — melde dich bei den Boards unter Einstellungen → Konten an, oder hinterlege die API-Schlüssel in den Einstellungen → Jobs, und starte erneut.",
       "interrupted": "Unterbrochen"

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1344,6 +1344,9 @@
     "card": {
       "boardsCount": "{{count}} Boards"
     },
+    "boardResults": {
+      "infoLabel": "Board-Ergebnisse"
+    },
     "apply": {
       "back": "Zurück zum Autopilot",
       "match": "Übereinstimmung",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1332,7 +1332,7 @@
       "applied": "Applied",
       "failed": "Failed",
       "completedWithErrors": "Partial results",
-      "completedWithErrorsHint": "Some boards errored or returned only part of their results. See the per-board summary below.",
+      "completedWithErrorsHint": "Some boards errored or returned only part of their results. Hover the info icon next to the found count for per-board results.",
       "needsConfig": "Needs configuration",
       "needsConfigHint": "No board could run — sign in to boards under Settings → Accounts, or add API keys in Settings → Jobs, then run again.",
       "interrupted": "Interrupted"

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1340,6 +1340,9 @@
     "card": {
       "boardsCount": "{{count}} boards"
     },
+    "boardResults": {
+      "infoLabel": "Board results"
+    },
     "apply": {
       "back": "Back to autopilot",
       "match": "match",


### PR DESCRIPTION
User-requested UX change: autopilot cards no longer render the per-board result chips inline ("LinkedIn · 14 jobs", "Aggregator · few local results — showing Germany wide") — a compact info ("i") trigger in the meta row (grouped with "Found N") opens a HoverPopover containing the same unchanged BoardSummaryChips. Cards get shorter and quieter; no data is lost, just one interaction deeper.

## Review trail (author + two critics, per repo flow)

- **frontend-author** implemented; **frontend-reviewer** approved (its MEDIUM — running-state absence assertion — fixed).
- **ui-ux-expert BLOCKED the first version** with a real find: a merely-*skipped* board (needs-login) beside a succeeding one never escalates the run-status badge, so hiding the chips left NO visible signal for an actionable configuration problem. Fixed: the trigger computes `boardsDegraded` (error/skipped/truncated — informational notes excluded) and escalates to the same warning amber the card's badges use (`data-degraded` test seam + regression test for the exact no-badge skip-only path); clean resting tone raised to the documented /70 floor; "Found N"+icon grouped `gap-1`; both card icon buttons bumped to ≥20px hit targets. **Re-audit: approve.** Final LOW (hover shade missing from the light-scheme amber remap) also fixed.
- i18n: `autopilot.boardResults.infoLabel` added to en+de; trigger is a focusable Button with localized aria-label; HoverPopover focus-opens/Esc-closes per the file's existing a11y convention.

## Verification

47/47 AutopilotCard tests (incl. 4 new: accessible-name presence, running-state absence, skip-only-partial escalation, note-only non-escalation), typecheck, lint:strict, landing-drift all green. Pushed through the full pre-push gate incl. the AI review of the range. BoardSummaryChips and the Jobs page inline usage untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)