### PR TITLE
ci: sticky findings comment on the ai review gate

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,9 +5,16 @@ name: 🤖 Claude Review (required gate + advisory deep dive)
 # ──────────────────────────────────────────────────────────────────────
 # Runs automatically on every PR open/sync/ready_for_review. Diff-based
 # review with deterministic verdict: HIGH/CRITICAL at confidence ≥ 0.8
-# blocks merge; fails open on infra (no action outage freeze). See
-# ADR-0008 for the 6-PR review-hardening program; the gate is the final
-# surface (join: Stop gate, /review, pre-push, ci-ok, this check).
+# blocks merge; fails open on infra (no action outage freeze). Findings
+# are posted as a STICKY PR comment (edited in place per push; only when
+# findings exist; flipped to "resolved" when a later run is clean). The
+# check status stays the blocking signal. See ADR-0008 for the 6-PR
+# review-hardening program; the gate is the final surface (join: Stop
+# gate, /review, pre-push, ci-ok, this check).
+#
+# Permissions trade: pull-requests: write is re-added to post the sticky
+# comment, accepting this over strict least-privilege for in-PR findings
+# visibility.
 #
 # Lane A1 — AI review, ON-DEMAND ADVISORY DEEP DIVE.
 # ──────────────────────────────────────────────────────────────────────
@@ -104,6 +111,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
 
     steps:
       - name: 🛡️ Harden Runner
@@ -141,3 +149,33 @@ jobs:
 
       - name: Deterministic verdict
         run: node scripts/ci-review-verdict.mjs review-findings.json
+
+      - name: 💬 Sticky findings comment
+        if: ${{ !cancelled() }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- ai-review-gate-sticky -->';
+            let findings = [];
+            try {
+              findings = JSON.parse(fs.readFileSync('review-findings.json', 'utf8')).findings || [];
+            } catch {
+              /* fail-open: no findings file means nothing to post */
+            }
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: context.issue.number, per_page: 100,
+            });
+            const sticky = comments.find((c) => c.body && c.body.includes(marker));
+            let body = null;
+            if (findings.length) {
+              body = marker + '\n' + fs.readFileSync('review-comment.md', 'utf8');
+            } else if (sticky) {
+              body = marker + '\n## 🤖 AI Review OK\n\n✓ Latest run found no findings — earlier findings are resolved or superseded.';
+            }
+            if (!body) return; // clean run and no prior sticky: stay silent
+            if (sticky) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: sticky.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body });
+            }

--- a/scripts/ci-review-verdict.mjs
+++ b/scripts/ci-review-verdict.mjs
@@ -18,7 +18,10 @@ import {
 
 const FILE = process.argv[2] || 'review-findings.json';
 const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+const lines = [];
+
 const summary = (md) => {
+  lines.push(md);
   if (summaryPath) {
     try {
       fs.appendFileSync(summaryPath, md + '\n');
@@ -27,6 +30,14 @@ const summary = (md) => {
     }
   }
   console.log(md);
+};
+
+const writeSummaryFile = () => {
+  try {
+    fs.writeFileSync('review-comment.md', lines.join('\n'));
+  } catch {
+    /* fail-open: file write failures must not crash the verdict */
+  }
 };
 
 let findings = null;
@@ -41,6 +52,7 @@ if (!findings) {
     `::warning::AI review produced no parseable verdict (${FILE} missing/invalid) — infra fail-open; ci-ok, pre-push and CodeRabbit still gate.`
   );
   summary('## 🤖 AI Review OK\n\n⚠ No parseable findings file — fail-open (infra).');
+  writeSummaryFile();
   process.exit(0);
 }
 
@@ -63,6 +75,7 @@ if (findings.length) {
       `| ${f.severity}${blocking.includes(f) ? ' 🚫' : ''} | ${f.file}:${f.line} | ${cell(f.summary)} | ${cell(f.fix)} |`
     );
 }
+writeSummaryFile();
 if (blocking.length) {
   console.error(`✗ ${blocking.length} blocking finding(s) (HIGH/CRITICAL, confidence >= 0.8):`);
   blocking.forEach((f) => console.error('  ' + formatFinding(f)));


### PR DESCRIPTION
Follow-up to #610 (user-requested): the `🤖 AI Review OK` gate now surfaces its findings in the PR itself.

## What

- `scripts/ci-review-verdict.mjs` writes the rendered findings markdown to `review-comment.md` on **every** exit path (fail-open note / OK heading / findings table).
- The gate job gains a pinned `actions/github-script` step (`if: !cancelled()` — runs even when the verdict fails) that upserts ONE marker-keyed sticky comment: posted only when findings exist, edited in place on re-runs, flipped to "resolved" when a later run comes back clean, silent on clean runs with no prior comment. The check status remains the blocking signal.
- Permission trade (documented in the workflow header): the job regains `pull-requests: write` at job scope — accepted over strict least-privilege for in-PR visibility. Bash remains excluded from the gate's tools.

## Verification

Verdict script behavior re-proven on all three paths (missing file → exit 0 + fail-open note in the file; HIGH@0.9 → exit 1 + table; clean → exit 0 + OK heading); `gen:workflows:check` + `check:agent-system` green. Note: the gate anti-tamper-skips on THIS PR (it edits the workflow) — the sticky comment goes live on the first PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)