### PR TITLE
chore: raise pre-push llm review timeout to 300s

### DIFF
--- a/scripts/pre-push-review.mjs
+++ b/scripts/pre-push-review.mjs
@@ -201,8 +201,11 @@ ${learnings ? `\n## Known repo false positives — do NOT re-raise any of these\
 ${diff}
 \`\`\`
 `;
-  // no Stop-hook timeout constrains us here — give big pushes more headroom
-  const r = runClaudeReview({ cwd, prompt, model, timeoutMs: 180000 });
+  // no Stop-hook timeout constrains us here — give pushes real headroom: a
+  // MEASURED small-diff sonnet review takes ~170s in this environment, so 180s
+  // was razor-thin and real diffs always fail-opened (3x llm-unavailable streak
+  // before this was caught via the metrics log)
+  const r = runClaudeReview({ cwd, prompt, model, timeoutMs: 300000 });
   metric.parse_retries = r.parseRetries;
   if (r.error === 'llm_unavailable' || r.parseFailed) {
     say(


### PR DESCRIPTION
One-line calibration from the first /review-stats-class signal: the pre-push LLM layer had a 3-for-3 `llm-unavailable` streak. A timed diagnostic showed a small 2-file sonnet review takes ~170s in this environment (nested `claude -p` startup + model latency), so the 180s budget failed open on essentially every real diff — the layer was silently theater, exactly the failure mode the metrics log exists to catch. 300s gives the measured latency real headroom; in warn-mode the cost is latency only, never a block. The deterministic ast-grep layer and cache fast-path are unaffected (they carry the sub-second paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)