### PR TITLE
feat: add detector-resistant sampling params for prose generation

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai_provider/anthropic.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/anthropic.rs
@@ -167,6 +167,61 @@ fn parse_anthropic_frames(buf: &mut String, last_event: &mut String) -> Vec<Stre
     out
 }
 
+/// Build the `/messages` streaming request body for a given [`AiGenerateRequest`].
+/// Pure + unit-tested. `top_p` is Anthropic's only sampling knob beyond
+/// temperature (no frequency/presence penalty in this API) — set only when the
+/// caller supplied it (prose surfaces). CRITICAL: extended thinking forces
+/// `temperature=1.0` and the Anthropic API rejects `top_p` alongside `thinking`
+/// (400), so `top_p` is skipped whenever thinking is enabled.
+fn build_chat_stream_body(req: &AiGenerateRequest) -> Value {
+    let temperature = req.temperature.unwrap_or(0.7);
+    let max_tokens = req.max_tokens.unwrap_or(4096);
+
+    let system_content: String = req
+        .messages
+        .iter()
+        .filter(|m| m.role == "system")
+        .map(|m| m.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let messages: Vec<Value> = req
+        .messages
+        .iter()
+        .filter(|m| m.role != "system")
+        .map(|m| json!({ "role": m.role, "content": m.content }))
+        .collect();
+
+    // Extended thinking for balanced effort and above — but ONLY on models that
+    // support it. Enabling it forces temperature=1 and spends extra output
+    // tokens; an unsupported model 400s on a `thinking` block, so we gate on the
+    // model id. A caller can opt out by selecting a non-thinking model.
+    let thinking_budget = if max_tokens >= 2048 && anthropic_supports_thinking(&req.model) {
+        max_tokens / 2
+    } else {
+        0
+    };
+    let actual_max_tokens = max_tokens + thinking_budget;
+
+    let mut body = json!({
+        "model": req.model,
+        "messages": messages,
+        "max_tokens": actual_max_tokens,
+        "stream": true,
+        "temperature": if thinking_budget > 0 { 1.0 } else { temperature },
+    });
+    if thinking_budget > 0 {
+        body["thinking"] = json!({ "type": "enabled", "budget_tokens": thinking_budget });
+    } else if let Some(top_p) = req.top_p {
+        // Anthropic 400s if `top_p` rides alongside `thinking` — only add it on
+        // the non-thinking path.
+        body["top_p"] = json!(top_p);
+    }
+    if !system_content.is_empty() {
+        body["system"] = json!(system_content);
+    }
+    body
+}
+
 pub struct AnthropicClient;
 
 impl AnthropicClient {
@@ -272,47 +327,7 @@ impl AiProvider for AnthropicClient {
         let endpoint = format!("{BASE}/messages");
         let trace = RequestTrace::begin(ProviderId::Anthropic, &req.model, "/messages", BASE, true);
 
-        let temperature = req.temperature.unwrap_or(0.7);
-        let max_tokens = req.max_tokens.unwrap_or(4096);
-
-        let system_content: String = req
-            .messages
-            .iter()
-            .filter(|m| m.role == "system")
-            .map(|m| m.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n");
-        let messages: Vec<Value> = req
-            .messages
-            .iter()
-            .filter(|m| m.role != "system")
-            .map(|m| json!({ "role": m.role, "content": m.content }))
-            .collect();
-
-        // Extended thinking for balanced effort and above — but ONLY on models that
-        // support it. Enabling it forces temperature=1 and spends extra output
-        // tokens; an unsupported model 400s on a `thinking` block, so we gate on the
-        // model id. A caller can opt out by selecting a non-thinking model.
-        let thinking_budget = if max_tokens >= 2048 && anthropic_supports_thinking(&req.model) {
-            max_tokens / 2
-        } else {
-            0
-        };
-        let actual_max_tokens = max_tokens + thinking_budget;
-
-        let mut body = json!({
-            "model": req.model,
-            "messages": messages,
-            "max_tokens": actual_max_tokens,
-            "stream": true,
-            "temperature": if thinking_budget > 0 { 1.0 } else { temperature },
-        });
-        if thinking_budget > 0 {
-            body["thinking"] = json!({ "type": "enabled", "budget_tokens": thinking_budget });
-        }
-        if !system_content.is_empty() {
-            body["system"] = json!(system_content);
-        }
+        let body = build_chat_stream_body(req);
 
         let response = crate::net::http::shared()
             .post(&endpoint)
@@ -608,11 +623,65 @@ impl AiProvider for AnthropicClient {
 #[cfg(test)]
 mod tests {
     use super::{
-        anthropic_supports_thinking, join_text_blocks, parse_anthropic_frames,
-        parse_anthropic_turn, StreamPiece,
+        anthropic_supports_thinking, build_chat_stream_body, join_text_blocks,
+        parse_anthropic_frames, parse_anthropic_turn, StreamPiece,
     };
-    use crate::commands::ai_provider::{StopReason, ToolCall};
+    use crate::commands::ai_provider::{AiGenerateRequest, StopReason, ToolCall};
+    use crate::ipc_contracts::ai::AiGenerateRequestMessage;
     use serde_json::json;
+
+    fn base_request(model: &str) -> AiGenerateRequest {
+        AiGenerateRequest {
+            model: model.to_string(),
+            messages: vec![AiGenerateRequestMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            locale: "en".to_string(),
+            temperature: Some(0.8),
+            top_p: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            repeat_penalty: None,
+            max_tokens: None,
+            context_window: None,
+            provider: None,
+            base_url: None,
+            effort: None,
+        }
+    }
+
+    #[test]
+    fn chat_stream_body_serializes_top_p_when_set_on_a_non_thinking_model() {
+        let mut req = base_request("claude-3-5-sonnet-20241022");
+        req.top_p = Some(0.95);
+        let body = build_chat_stream_body(&req);
+        assert_eq!(body["top_p"], json!(0.95));
+        assert!(body.get("thinking").is_none());
+    }
+
+    #[test]
+    fn chat_stream_body_omits_top_p_when_none() {
+        let body = build_chat_stream_body(&base_request("claude-3-5-sonnet-20241022"));
+        assert!(body.get("top_p").is_none());
+    }
+
+    #[test]
+    fn chat_stream_body_skips_top_p_when_extended_thinking_is_enabled() {
+        // Extended thinking forces temperature=1 and the API rejects `top_p`
+        // alongside `thinking` — must never be sent together, even if the caller
+        // (an application-answer/cover-letter prose call) supplied top_p.
+        let mut req = base_request("claude-opus-4-20250514");
+        req.top_p = Some(0.95);
+        req.max_tokens = Some(4096); // >= 2048 → thinking budget kicks in
+        let body = build_chat_stream_body(&req);
+        assert!(body.get("thinking").is_some(), "thinking should be enabled");
+        assert_eq!(body["temperature"], json!(1.0));
+        assert!(
+            body.get("top_p").is_none(),
+            "top_p must be omitted when thinking is enabled"
+        );
+    }
 
     #[test]
     fn thinking_gate_enables_only_extended_thinking_models() {

--- a/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
@@ -242,6 +242,59 @@ fn parse_gemini_frames(buf: &mut String, state: &mut GeminiScanner) -> Vec<Strea
     out
 }
 
+/// Build the `streamGenerateContent` request body for a given
+/// [`AiGenerateRequest`]. Pure + unit-tested. `topP`/`frequencyPenalty`/
+/// `presencePenalty` are the detector-resistance sampling knobs (RAID, ACL
+/// 2024) the renderer sets only for prose generation surfaces — the v1beta API
+/// supports all three on `generationConfig`, each added only when `Some`
+/// (never sent as `null`).
+fn build_chat_stream_body(req: &AiGenerateRequest) -> Value {
+    let temperature = req.temperature.unwrap_or(0.7);
+    let system_text: String = req
+        .messages
+        .iter()
+        .filter(|m| m.role == "system")
+        .map(|m| m.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let contents: Vec<Value> = req
+        .messages
+        .iter()
+        .filter(|m| m.role != "system")
+        .map(|m| {
+            let role = if m.role == "assistant" {
+                "model"
+            } else {
+                "user"
+            };
+            json!({ "role": role, "parts": [{ "text": m.content }] })
+        })
+        .collect();
+
+    let mut generation_config = json!({ "temperature": temperature });
+    if let Some(top_p) = req.top_p {
+        generation_config["topP"] = json!(top_p);
+    }
+    if let Some(fp) = req.frequency_penalty {
+        generation_config["frequencyPenalty"] = json!(fp);
+    }
+    if let Some(pp) = req.presence_penalty {
+        generation_config["presencePenalty"] = json!(pp);
+    }
+    if let Some(mt) = req.max_tokens {
+        generation_config["maxOutputTokens"] = json!(mt);
+    }
+    // Ask thinking-capable models to stream their reasoning as `thought` parts.
+    if gemini_supports_thinking(&req.model) {
+        generation_config["thinkingConfig"] = json!({ "includeThoughts": true });
+    }
+    let mut body = json!({ "contents": contents, "generationConfig": generation_config });
+    if !system_text.is_empty() {
+        body["systemInstruction"] = json!({ "parts": [{ "text": system_text }] });
+    }
+    body
+}
+
 pub struct GeminiClient;
 
 impl GeminiClient {
@@ -343,40 +396,7 @@ impl AiProvider for GeminiClient {
         let trace =
             RequestTrace::begin(ProviderId::Gemini, &req.model, &endpoint_label, BASE, true);
 
-        let temperature = req.temperature.unwrap_or(0.7);
-        let system_text: String = req
-            .messages
-            .iter()
-            .filter(|m| m.role == "system")
-            .map(|m| m.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n");
-        let contents: Vec<Value> = req
-            .messages
-            .iter()
-            .filter(|m| m.role != "system")
-            .map(|m| {
-                let role = if m.role == "assistant" {
-                    "model"
-                } else {
-                    "user"
-                };
-                json!({ "role": role, "parts": [{ "text": m.content }] })
-            })
-            .collect();
-
-        let mut generation_config = json!({ "temperature": temperature });
-        if let Some(mt) = req.max_tokens {
-            generation_config["maxOutputTokens"] = json!(mt);
-        }
-        // Ask thinking-capable models to stream their reasoning as `thought` parts.
-        if gemini_supports_thinking(&req.model) {
-            generation_config["thinkingConfig"] = json!({ "includeThoughts": true });
-        }
-        let mut body = json!({ "contents": contents, "generationConfig": generation_config });
-        if !system_text.is_empty() {
-            body["systemInstruction"] = json!({ "parts": [{ "text": system_text }] });
-        }
+        let body = build_chat_stream_body(req);
 
         let url = format!("{BASE}{endpoint_label}");
         let response = crate::net::http::shared()
@@ -704,12 +724,56 @@ impl AiProvider for GeminiClient {
 #[cfg(test)]
 mod tests {
     use super::{
-        gemini_supports_thinking, join_parts_text, parse_gemini_frames, parse_gemini_parts,
-        parse_gemini_turn, validate_gemini_key, GeminiScanner, StreamPiece,
+        build_chat_stream_body, gemini_supports_thinking, join_parts_text, parse_gemini_frames,
+        parse_gemini_parts, parse_gemini_turn, validate_gemini_key, GeminiScanner, StreamPiece,
     };
-    use crate::commands::ai_provider::{StopReason, ToolCall};
+    use crate::commands::ai_provider::{AiGenerateRequest, StopReason, ToolCall};
     use crate::error::AppError;
+    use crate::ipc_contracts::ai::AiGenerateRequestMessage;
     use serde_json::json;
+
+    fn base_request() -> AiGenerateRequest {
+        AiGenerateRequest {
+            model: "gemini-1.5-flash".to_string(),
+            messages: vec![AiGenerateRequestMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            locale: "en".to_string(),
+            temperature: Some(0.8),
+            top_p: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            repeat_penalty: None,
+            max_tokens: None,
+            context_window: None,
+            provider: None,
+            base_url: None,
+            effort: None,
+        }
+    }
+
+    #[test]
+    fn chat_stream_body_serializes_sampling_params_when_set() {
+        let mut req = base_request();
+        req.top_p = Some(0.95);
+        req.frequency_penalty = Some(0.3);
+        req.presence_penalty = Some(0.2);
+        let body = build_chat_stream_body(&req);
+        let config = &body["generationConfig"];
+        assert_eq!(config["topP"], json!(0.95));
+        assert_eq!(config["frequencyPenalty"], json!(0.3));
+        assert_eq!(config["presencePenalty"], json!(0.2));
+    }
+
+    #[test]
+    fn chat_stream_body_omits_sampling_params_when_none() {
+        let body = build_chat_stream_body(&base_request());
+        let config = &body["generationConfig"];
+        assert!(config.get("topP").is_none());
+        assert!(config.get("frequencyPenalty").is_none());
+        assert!(config.get("presencePenalty").is_none());
+    }
 
     #[test]
     fn blank_or_missing_key_is_rejected_with_unauthorized() {

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
@@ -782,11 +782,13 @@ fn parse_ollama_frames(buf: &mut String) -> Vec<StreamPiece> {
     out
 }
 
-async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> AppResult<()> {
-    let base = host();
-    let endpoint = format!("{base}/api/chat");
-    let trace = RequestTrace::begin(ProviderId::Ollama, &req.model, "/api/chat", &base, true);
-
+/// Build the `/api/chat` streaming request body for a given [`AiGenerateRequest`].
+/// Pure + unit-tested. `options.top_p`/`options.repeat_penalty` are the
+/// detector-resistance sampling knobs (RAID, ACL 2024) the renderer sets only
+/// for prose generation surfaces, added only when `Some` (never sent as
+/// `null`). `repeat_penalty` uses Ollama's own field/semantics — it is NEVER a
+/// remap of `frequency_penalty` (different math, different field).
+fn build_chat_stream_body(req: &AiGenerateRequest) -> Value {
     let messages = serde_json::to_value(
         req.messages
             .iter()
@@ -800,6 +802,12 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
     if let Some(t) = req.temperature {
         options.insert("temperature".to_string(), json!(t));
     }
+    if let Some(top_p) = req.top_p {
+        options.insert("top_p".to_string(), json!(top_p));
+    }
+    if let Some(rp) = req.repeat_penalty {
+        options.insert("repeat_penalty".to_string(), json!(rp));
+    }
     if let Some(mt) = req.max_tokens {
         options.insert("num_predict".to_string(), json!(mt));
     }
@@ -812,6 +820,15 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
         body["options"] = Value::Object(options);
     }
     body["keep_alive"] = json!(crate::performance::ollama_keep_alive());
+    body
+}
+
+async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> AppResult<()> {
+    let base = host();
+    let endpoint = format!("{base}/api/chat");
+    let trace = RequestTrace::begin(ProviderId::Ollama, &req.model, "/api/chat", &base, true);
+
+    let body = build_chat_stream_body(req);
 
     let response = crate::net::http::shared()
         .post(&endpoint)
@@ -854,11 +871,52 @@ async fn stream_chat(app: &AppHandle, job_id: &str, req: &AiGenerateRequest) -> 
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_show, ollama_supports_tools, parse_ollama_frames, parse_ollama_turn,
-        parse_web_search, StreamPiece,
+        build_chat_stream_body, normalize_show, ollama_supports_tools, parse_ollama_frames,
+        parse_ollama_turn, parse_web_search, StreamPiece,
     };
-    use crate::commands::ai_provider::{StopReason, ToolCall};
+    use crate::commands::ai_provider::{AiGenerateRequest, StopReason, ToolCall};
+    use crate::ipc_contracts::ai::AiGenerateRequestMessage;
     use serde_json::json;
+
+    fn base_request() -> AiGenerateRequest {
+        AiGenerateRequest {
+            model: "llama3.1:8b".to_string(),
+            messages: vec![AiGenerateRequestMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            locale: "en".to_string(),
+            temperature: Some(0.8),
+            top_p: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            repeat_penalty: None,
+            max_tokens: None,
+            context_window: None,
+            provider: None,
+            base_url: None,
+            effort: None,
+        }
+    }
+
+    #[test]
+    fn chat_stream_body_serializes_top_p_and_repeat_penalty_when_set() {
+        let mut req = base_request();
+        req.top_p = Some(0.95);
+        req.repeat_penalty = Some(1.15);
+        let body = build_chat_stream_body(&req);
+        assert_eq!(body["options"]["top_p"], json!(0.95));
+        assert_eq!(body["options"]["repeat_penalty"], json!(1.15));
+        // frequency_penalty is never remapped into Ollama's repeat_penalty field.
+        assert!(body["options"].get("frequency_penalty").is_none());
+    }
+
+    #[test]
+    fn chat_stream_body_omits_sampling_options_when_none() {
+        let body = build_chat_stream_body(&base_request());
+        assert!(body["options"].get("top_p").is_none());
+        assert!(body["options"].get("repeat_penalty").is_none());
+    }
 
     #[test]
     fn parse_ollama_frames_splits_thinking_and_content() {

--- a/apps/desktop/src-tauri/src/commands/ai_provider/openai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/openai.rs
@@ -190,6 +190,44 @@ fn parse_openai_frames(buf: &mut String) -> Vec<StreamPiece> {
     out
 }
 
+/// Build the `/chat/completions` streaming request body for a given
+/// [`AiGenerateRequest`] + capability matrix. Pure + unit-tested — this is the
+/// shared body shape for native OpenAI, any OpenAI-compatible gateway, and
+/// Ollama Cloud (all backed by [`OpenAiClient`]). `top_p`/`frequency_penalty`/
+/// `presence_penalty` are the detector-resistance sampling knobs (RAID, ACL
+/// 2024) the renderer sets only for prose generation surfaces — each is only
+/// ever added when `Some` (never sent as `null`), and skipped entirely on
+/// reasoning models that reject `temperature`.
+fn build_chat_stream_body(req: &AiGenerateRequest, caps: ModelCapabilities) -> Value {
+    let messages = req
+        .messages
+        .iter()
+        .map(|m| json!({ "role": m.role, "content": m.content }))
+        .collect::<Vec<_>>();
+
+    let mut body = json!({ "model": req.model, "messages": messages, "stream": true });
+    if caps.supports_temperature {
+        body["temperature"] = json!(req.temperature.unwrap_or(0.7));
+        if let Some(top_p) = req.top_p {
+            body["top_p"] = json!(top_p);
+        }
+        if let Some(fp) = req.frequency_penalty {
+            body["frequency_penalty"] = json!(fp);
+        }
+        if let Some(pp) = req.presence_penalty {
+            body["presence_penalty"] = json!(pp);
+        }
+    }
+    if let Some(mt) = req.max_tokens {
+        let field = match caps.token_param {
+            TokenParam::MaxCompletionTokens => "max_completion_tokens",
+            _ => "max_tokens",
+        };
+        body[field] = json!(mt);
+    }
+    body
+}
+
 pub struct OpenAiClient {
     id: ProviderId,
     base_url: String,
@@ -344,23 +382,7 @@ impl AiProvider for OpenAiClient {
             true,
         );
 
-        let messages = req
-            .messages
-            .iter()
-            .map(|m| json!({ "role": m.role, "content": m.content }))
-            .collect::<Vec<_>>();
-
-        let mut body = json!({ "model": req.model, "messages": messages, "stream": true });
-        if caps.supports_temperature {
-            body["temperature"] = json!(req.temperature.unwrap_or(0.7));
-        }
-        if let Some(mt) = req.max_tokens {
-            let field = match caps.token_param {
-                TokenParam::MaxCompletionTokens => "max_completion_tokens",
-                _ => "max_tokens",
-            };
-            body[field] = json!(mt);
-        }
+        let body = build_chat_stream_body(req, caps);
 
         let response = crate::net::http::shared()
             .post(&endpoint)
@@ -703,11 +725,85 @@ impl AiProvider for OpenAiClient {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_reasoning_model, join_responses_text, parse_openai_delta, parse_openai_frames,
-        parse_openai_turn, should_list_model, OpenAiClient,
+        build_chat_stream_body, is_reasoning_model, join_responses_text, parse_openai_delta,
+        parse_openai_frames, parse_openai_turn, should_list_model, OpenAiClient,
     };
-    use crate::commands::ai_provider::{AiProvider, ProviderId, StopReason, ToolCall};
+    use crate::commands::ai_provider::{
+        AiGenerateRequest, AiProvider, ModelCapabilities, ProviderId, StopReason, TokenParam,
+        ToolCall,
+    };
+    use crate::ipc_contracts::ai::AiGenerateRequestMessage;
     use serde_json::json;
+
+    fn base_request() -> AiGenerateRequest {
+        AiGenerateRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![AiGenerateRequestMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            locale: "en".to_string(),
+            temperature: Some(0.8),
+            top_p: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            repeat_penalty: None,
+            max_tokens: None,
+            context_window: None,
+            provider: None,
+            base_url: None,
+            effort: None,
+        }
+    }
+
+    fn chat_caps(supports_temperature: bool) -> ModelCapabilities {
+        ModelCapabilities {
+            supports_temperature,
+            supports_system_role: true,
+            supports_streaming: true,
+            supports_reasoning: !supports_temperature,
+            supports_tools: true,
+            supports_json_mode: true,
+            supports_embeddings: true,
+            supports_web_search: false,
+            token_param: TokenParam::MaxTokens,
+        }
+    }
+
+    #[test]
+    fn chat_stream_body_serializes_sampling_params_when_set() {
+        let mut req = base_request();
+        req.top_p = Some(0.95);
+        req.frequency_penalty = Some(0.3);
+        req.presence_penalty = Some(0.2);
+        let body = build_chat_stream_body(&req, chat_caps(true));
+        assert_eq!(body["top_p"], json!(0.95));
+        assert_eq!(body["frequency_penalty"], json!(0.3));
+        assert_eq!(body["presence_penalty"], json!(0.2));
+    }
+
+    #[test]
+    fn chat_stream_body_omits_sampling_params_when_none() {
+        let body = build_chat_stream_body(&base_request(), chat_caps(true));
+        assert!(body.get("top_p").is_none());
+        assert!(body.get("frequency_penalty").is_none());
+        assert!(body.get("presence_penalty").is_none());
+    }
+
+    #[test]
+    fn chat_stream_body_skips_sampling_params_on_reasoning_models() {
+        // o-series models reject `temperature` entirely — sampling knobs must be
+        // skipped alongside it, never sent to a model that 400s on them.
+        let mut req = base_request();
+        req.top_p = Some(0.95);
+        req.frequency_penalty = Some(0.3);
+        req.presence_penalty = Some(0.2);
+        let body = build_chat_stream_body(&req, chat_caps(false));
+        assert!(body.get("temperature").is_none());
+        assert!(body.get("top_p").is_none());
+        assert!(body.get("frequency_penalty").is_none());
+        assert!(body.get("presence_penalty").is_none());
+    }
 
     #[test]
     fn embedding_cap_is_token_safe_for_every_language() {

--- a/apps/desktop/src-tauri/src/ipc_contracts/ai.rs
+++ b/apps/desktop/src-tauri/src/ipc_contracts/ai.rs
@@ -13,6 +13,14 @@ pub struct AiGenerateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repeat_penalty: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_window: Option<u32>,

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.test.ts
@@ -807,7 +807,7 @@ describe('per-step temperature override', () => {
     emit('Dear Hiring Team.');
     done();
     await p;
-    // cover override resolves; the medium tier's 0.55 default is overridden.
+    // cover override resolves; the small tier's 0.58 default is overridden.
     expect(tempOf(client)).toBeCloseTo(0.85);
   });
 
@@ -840,8 +840,129 @@ describe('per-step temperature override', () => {
     emit('Dear Hiring Team.');
     done();
     await p;
-    // large tier default for cloud = 0.55; the ollama override does not apply.
-    expect(tempOf(client)).toBeCloseTo(0.55);
+    // large tier default for cloud = 0.8; the ollama override does not apply.
+    expect(tempOf(client)).toBeCloseTo(0.8);
+  });
+});
+
+describe('prose detector-resistance sampling params', () => {
+  // RAID (ACL 2024): random sampling + repetition/frequency penalties drop
+  // AI-detector accuracy. Applied only to prose surfaces — resume/analysis stay
+  // LEXICAL (no new params) to protect exact ATS keyword repetition.
+  const META = {
+    resumeLanguage: 'en',
+    jobAdLanguage: 'en',
+    mismatch: false,
+    candidateName: 'X',
+    jobTitle: 'Y',
+    companyName: 'Z',
+    targetLanguage: 'en',
+    topRequirements: [],
+  };
+
+  const samplingOf = (client: ReturnType<typeof register>) => {
+    const call = (client.ai.generatePipeline as ReturnType<typeof vi.fn>).mock.calls[0];
+    const arg = call?.[0] as {
+      temperature?: number;
+      topP?: number;
+      frequencyPenalty?: number;
+      presencePenalty?: number;
+      repeatPenalty?: number;
+    };
+    const { temperature, topP, frequencyPenalty, presencePenalty, repeatPenalty } = arg;
+    return { temperature, topP, frequencyPenalty, presencePenalty, repeatPenalty };
+  };
+
+  it('cover letter (small-tier local model) tightens topP to limit drift', async () => {
+    // 'llama3' has no size suffix → classified small tier (see model-size.ts);
+    // small local models compound drift when the full 0.95 topP stacks with
+    // repeatPenalty, so the small tier tightens topP to 0.9.
+    const client = register();
+    const p = generateCoverLetter('My resume', 'Job ad', META, 'recruiter', 'llama3', vi.fn());
+    await flushUntilStreaming();
+    emit('Dear Hiring Team.');
+    done();
+    await p;
+    expect(samplingOf(client)).toEqual({
+      temperature: 0.58,
+      topP: 0.9,
+      frequencyPenalty: 0.3,
+      presencePenalty: 0.2,
+      repeatPenalty: 1.15,
+    });
+  });
+
+  it('cover letter (large-tier cloud model) keeps the shared topP default', async () => {
+    usePreferencesStore.setState({
+      aiProviderConfig: { activeProvider: 'openai', providers: { openai: { model: 'gpt-4o' } } },
+    });
+    const client = register();
+    const p = generateCoverLetter('My resume', 'Job ad', META, 'recruiter', 'gpt-4o', vi.fn());
+    await flushUntilStreaming();
+    emit('Dear Hiring Team.');
+    done();
+    await p;
+    expect(samplingOf(client)).toEqual({
+      temperature: 0.8,
+      topP: 0.95,
+      frequencyPenalty: 0.3,
+      presencePenalty: 0.2,
+      repeatPenalty: 1.15,
+    });
+  });
+
+  it('application answer generation drops presencePenalty and lowers temperature (no-fabrication surface)', async () => {
+    // Résumé-grounded: presencePenalty pushes toward new topics (fabrication
+    // risk) so it's dropped; temperature stays lower than the freer prose
+    // surfaces to limit factual drift, while topP/frequencyPenalty/
+    // repeatPenalty still resist AI-detector fingerprinting.
+    const client = register();
+    const p = generateApplicationAnswer({
+      question: 'Why do you want to work here?',
+      resume: 'My resume',
+      jobAd: 'Backend role at Acme',
+      meta: META,
+      model: 'llama3',
+    });
+    await flushUntilStreaming();
+    emit('Because I love building things.');
+    done();
+    await p;
+    expect(samplingOf(client)).toEqual({
+      temperature: 0.5,
+      topP: 0.95,
+      frequencyPenalty: 0.3,
+      presencePenalty: undefined,
+      repeatPenalty: 1.15,
+    });
+  });
+
+  it('resume generation carries no sampling params (LEXICAL — protects ATS keyword repetition)', async () => {
+    const client = register();
+    const p = generateResume('My resume', 'Job ad', META, 'ats', 'llama3', vi.fn());
+    await flushUntilStreaming();
+    emit('RESUME CONTENT');
+    done();
+    await p;
+    const sampling = samplingOf(client);
+    expect(sampling.topP).toBeUndefined();
+    expect(sampling.frequencyPenalty).toBeUndefined();
+    expect(sampling.presencePenalty).toBeUndefined();
+    expect(sampling.repeatPenalty).toBeUndefined();
+  });
+
+  it('metadata extraction (analysis) carries no sampling params', async () => {
+    const client = register();
+    const p = extractMetadata('My resume', 'Job ad', 'llama3');
+    await flushUntilStreaming();
+    emit('{}');
+    done();
+    await p;
+    const sampling = samplingOf(client);
+    expect(sampling.topP).toBeUndefined();
+    expect(sampling.frequencyPenalty).toBeUndefined();
+    expect(sampling.presencePenalty).toBeUndefined();
+    expect(sampling.repeatPenalty).toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -83,6 +83,48 @@ function resolveTemperature(step: TemperatureStep, stepDefault: number): number 
   return override ?? stepDefault;
 }
 
+/** Effective sampling parameters for one generation step. */
+interface SamplingParams {
+  temperature: number;
+  topP?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  repeatPenalty?: number;
+}
+
+// ponytail: detector-resistance sampling knobs. RAID (ACL 2024) found that
+// random sampling + repetition/frequency penalties drop AI-detector accuracy
+// by up to 38 points — today the app only plumbs temperature. Applied ONLY to
+// PROSE generation surfaces (cover letter, application answers, email,
+// referral, interview); resume/analysis/inline-rewrite stay excluded because
+// frequency/presence penalties would suppress the exact job-ad keyword
+// repetition ATS keyword-matching needs. NOTE: on Anthropic's extended-thinking
+// path these knobs are a near-no-op — `top_p` is dropped and temperature is
+// forced to 1.0 (the API rejects `top_p` alongside `thinking`), and Anthropic
+// has no frequency/presence/repeat penalty params at all — don't assume this
+// set is "active" there.
+const PROSE_SAMPLING = {
+  topP: 0.95,
+  frequencyPenalty: 0.3,
+  presencePenalty: 0.2,
+  repeatPenalty: 1.15,
+} as const;
+
+/** Generalizes {@link resolveTemperature} into a per-step sampling resolver:
+ *  the temperature override lookup is unchanged, and `prose: true` layers on
+ *  the shared {@link PROSE_SAMPLING} penalty set for detector-resistant steps.
+ *  `overrides` lets one surface tune a specific knob (e.g. drop a penalty, or
+ *  tighten topP for a drift-prone small model) without forking the shared set. */
+function resolveSampling(
+  step: TemperatureStep,
+  temperatureDefault: number,
+  prose = false,
+  overrides?: Partial<Omit<SamplingParams, 'temperature'>>
+): SamplingParams {
+  const temperature = resolveTemperature(step, temperatureDefault);
+  return prose ? { temperature, ...PROSE_SAMPLING, ...overrides } : { temperature };
+}
+
 async function streamGenerate(
   model: string,
   system: string,
@@ -91,7 +133,8 @@ async function streamGenerate(
   temperature = 0.3,
   locale = 'en',
   signal?: AbortSignal,
-  onThinking?: (tok: string) => void
+  onThinking?: (tok: string) => void,
+  sampling?: Omit<SamplingParams, 'temperature'>
 ): Promise<string> {
   const api = getClient();
   const { activeProvider, providerSettings, activeModel } = resolveActiveProvider(model);
@@ -110,6 +153,12 @@ async function streamGenerate(
     ],
     locale: safeLocale(locale),
     temperature,
+    // Detector-resistance sampling knobs — present only for prose steps that
+    // opted in (see PROSE_SAMPLING); omitted (undefined) everywhere else.
+    topP: sampling?.topP,
+    frequencyPenalty: sampling?.frequencyPenalty,
+    presencePenalty: sampling?.presencePenalty,
+    repeatPenalty: sampling?.repeatPenalty,
     // Always send the active provider — the backend routes strictly and will
     // not fall back to Ollama. baseUrl only applies to OpenAI-compatible servers.
     provider: activeProvider,
@@ -398,20 +447,31 @@ export async function generateCoverLetter(
     market,
     applicant
   );
-  // Cover letters are prose: a little more temperature loosens the phrasing so it
-  // reads human, not mechanical. Small models stay lower to limit drift. A
-  // per-model override (if set) wins over this tier-based default.
-  const stepDefault = tier === 'small' ? 0.4 : 0.55;
-  const temperature = resolveTemperature('cover', stepDefault);
+  // Cover letters are prose: more temperature + the shared detector-resistance
+  // penalty set (see PROSE_SAMPLING) loosens the phrasing so it reads human, not
+  // mechanical, and resists AI-detector fingerprinting. Small models stay lower
+  // to limit drift (raised proportionally from the previous 0.4/0.55 split). A
+  // per-model override (if set) wins over this tier-based default. Small local
+  // models (7-8B) also compound drift when the full topP randomness stacks with
+  // repeatPenalty, so tighten topP for the small tier only; large stays at the
+  // shared PROSE_SAMPLING default.
+  const stepDefault = tier === 'small' ? 0.58 : 0.8;
+  const sampling = resolveSampling(
+    'cover',
+    stepDefault,
+    true,
+    tier === 'small' ? { topP: 0.9 } : undefined
+  );
   const raw = await streamGenerate(
     model,
     system,
     user,
     onToken,
-    temperature,
+    sampling.temperature,
     locale,
     signal,
-    onThinking
+    onThinking,
+    sampling
   );
   return {
     text: injectLinksIntoGeneratedText(extractPlainText(raw), getLinkMap(resume)),
@@ -484,14 +544,22 @@ export async function generateApplicationAnswer(params: {
     guidance,
     salaryRange,
   });
+  // Application answers are prose but résumé-grounded (no-fabrication surface):
+  // keep topP/frequencyPenalty/repeatPenalty for detector resistance, but drop
+  // presencePenalty (it pushes toward new topics, which risks factual drift
+  // here) and use a lower temperature than the freer prose surfaces (cover
+  // letter, referral) to keep answers traceable to the résumé.
+  const sampling = resolveSampling('answers', 0.5, true, { presencePenalty: undefined });
   const raw = await streamGenerate(
     model,
     system,
     user,
     onToken ?? (() => {}),
-    resolveTemperature('answers', 0.3),
+    sampling.temperature,
     meta.targetLanguage || 'en',
-    signal
+    signal,
+    undefined,
+    sampling
   );
   return extractPlainText(raw);
 }
@@ -584,14 +652,19 @@ export async function generateInterviewQuestions(params: {
     target: profile,
     market,
   });
+  // Interview questions are prose: keep the existing 0.5 temperature default,
+  // adding only the shared detector-resistance penalty set (see PROSE_SAMPLING).
+  const sampling = resolveSampling('answers', 0.5, true);
   const raw = await streamGenerate(
     model,
     system,
     user,
     onToken ?? (() => {}),
-    resolveTemperature('answers', 0.5),
+    sampling.temperature,
     meta.targetLanguage || 'en',
-    signal
+    signal,
+    undefined,
+    sampling
   );
   return extractPlainText(raw);
 }
@@ -812,14 +885,19 @@ export async function generateReferral(params: {
     { personName, personRole, companyName, jobTitle, resume, format, charLimit },
     profile
   );
+  // Referral messages are prose: randomness + the shared detector-resistance
+  // penalty set (see PROSE_SAMPLING) resist AI-detector fingerprinting.
+  const sampling = resolveSampling('referral', 0.7, true);
   const raw = await streamGenerate(
     model,
     system,
     user,
     onToken ?? (() => {}),
-    resolveTemperature('referral', 0.4),
+    sampling.temperature,
     locale,
-    signal
+    signal,
+    undefined,
+    sampling
   );
   return extractPlainText(raw);
 }
@@ -881,14 +959,19 @@ export async function generateReferralImprove(params: {
     },
     profile
   );
+  // Referral messages are prose: randomness + the shared detector-resistance
+  // penalty set (see PROSE_SAMPLING) resist AI-detector fingerprinting.
+  const sampling = resolveSampling('referral', 0.7, true);
   const raw = await streamGenerate(
     model,
     system,
     user,
     onToken ?? (() => {}),
-    resolveTemperature('referral', 0.4),
+    sampling.temperature,
     locale,
-    signal
+    signal,
+    undefined,
+    sampling
   );
   return extractPlainText(raw);
 }
@@ -927,13 +1010,18 @@ export async function generateApplicationEmail(params: {
     { resume, jobAd, meta, recipientName, recipientEmail, companyBrief },
     profile
   );
+  // Application emails are prose: randomness + the shared detector-resistance
+  // penalty set (see PROSE_SAMPLING) resist AI-detector fingerprinting.
+  const sampling = resolveSampling('cover', 0.7, true);
   return streamGenerate(
     model,
     system,
     user,
     onToken ?? (() => {}),
-    resolveTemperature('cover', 0.5),
+    sampling.temperature,
     meta.targetLanguage ?? 'en',
-    signal
+    signal,
+    undefined,
+    sampling
   );
 }

--- a/packages/shared/src/schemas/index.test.ts
+++ b/packages/shared/src/schemas/index.test.ts
@@ -102,6 +102,30 @@ describe('AiGenerateRequestSchema', () => {
     expect(() => AiGenerateRequestSchema.parse({ ...valid, temperature: -0.1 })).toThrow();
     expect(() => AiGenerateRequestSchema.parse({ ...valid, temperature: 1.5 })).not.toThrow();
   });
+
+  it('accepts every sampling param unset (all optional)', () => {
+    expect(() => AiGenerateRequestSchema.parse(valid)).not.toThrow();
+  });
+
+  it('clamps topP to 0–1', () => {
+    expect(() => AiGenerateRequestSchema.parse({ ...valid, topP: -0.1 })).toThrow();
+    expect(() => AiGenerateRequestSchema.parse({ ...valid, topP: 1.1 })).toThrow();
+    expect(() => AiGenerateRequestSchema.parse({ ...valid, topP: 0.95 })).not.toThrow();
+  });
+
+  it('clamps frequencyPenalty and presencePenalty to -2–2', () => {
+    for (const key of ['frequencyPenalty', 'presencePenalty'] as const) {
+      expect(() => AiGenerateRequestSchema.parse({ ...valid, [key]: -2.1 })).toThrow();
+      expect(() => AiGenerateRequestSchema.parse({ ...valid, [key]: 2.1 })).toThrow();
+      expect(() => AiGenerateRequestSchema.parse({ ...valid, [key]: 0.3 })).not.toThrow();
+    }
+  });
+
+  it('clamps repeatPenalty to 1–2 (Ollama semantics)', () => {
+    expect(() => AiGenerateRequestSchema.parse({ ...valid, repeatPenalty: 0.9 })).toThrow();
+    expect(() => AiGenerateRequestSchema.parse({ ...valid, repeatPenalty: 2.1 })).toThrow();
+    expect(() => AiGenerateRequestSchema.parse({ ...valid, repeatPenalty: 1.15 })).not.toThrow();
+  });
 });
 
 describe('AutopilotCreateSchema', () => {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -51,6 +51,19 @@ export const AiGenerateRequestSchema = z.object({
   messages: z.array(AiMessageSchema).min(1),
   locale: LocaleSchema,
   temperature: z.number().min(0).max(2).optional(),
+  /**
+   * Nucleus-sampling threshold. Detector-resistance knob (RAID, ACL 2024):
+   * random sampling + repetition penalties measurably drop AI-detector
+   * accuracy — applied only to prose generation surfaces (cover letter,
+   * application answers, email, referral, interview), never resume/analysis.
+   */
+  topP: z.number().min(0).max(1).optional(),
+  /** OpenAI/OpenAI-compatible + Gemini frequency penalty. */
+  frequencyPenalty: z.number().min(-2).max(2).optional(),
+  /** OpenAI/OpenAI-compatible + Gemini presence penalty. */
+  presencePenalty: z.number().min(-2).max(2).optional(),
+  /** Ollama `repeat_penalty` (distinct semantics from frequency/presence penalty — never remap). */
+  repeatPenalty: z.number().min(1).max(2).optional(),
   maxTokens: z.number().int().min(1).max(32768).optional(),
   /**
    * Context window in tokens (Ollama `num_ctx`). Local models only — large


### PR DESCRIPTION
## What

First of two PRs fixing the 80–100% AI-detection scores on generated cover letters/answers (research-backed: RAID, ACL 2024 — repetition penalty + random sampling drop detector accuracy by up to 38 points; the app previously plumbed **temperature only**).

- **Contract**: 4 new optional, Zod range-validated fields on `AiGenerateRequestSchema` — `topP` (0–1), `frequencyPenalty`/`presencePenalty` (−2–2), `repeatPenalty` (1–2). `ipc_contracts/ai.rs` regenerated.
- **Providers** (body construction extracted into pure, unit-tested `build_chat_stream_body` fns; `Some`-only serialization, never null):
  - OpenAI/compatible/Ollama-Cloud: `top_p` + penalties, gated by `supports_temperature` (o-series parity)
  - Anthropic: `top_p` only, never alongside extended thinking (API 400s)
  - Gemini: `generationConfig.topP/frequencyPenalty/presencePenalty`
  - Ollama: `options.top_p` + `options.repeat_penalty` (`frequencyPenalty` never remapped — different semantics)
- **Renderer**: `resolveSampling()` — prose surfaces only. Cover letter 0.8 large / 0.58 small (small tier `topP` 0.9), answers 0.5 without `presencePenalty` (grounded no-fabrication surface), email+referral 0.7, interview 0.5. Shared prose set: `topP` 0.95, `frequencyPenalty` 0.3, `repeatPenalty` 1.15. **Resume/analysis/rewrite byte-for-byte unchanged** — penalties would suppress the exact keyword repetition ATS matching needs.
- Deliberately did NOT extend `AiProvider::complete()` (translation/agent-tools/autopilot-notes) — no prose surface uses it; confirmed by review.

## Review

ai-provider-expert audited: **no HIGH/CRITICAL**; both MEDIUM value-tuning findings applied (answers 0.65→0.5 minus presencePenalty; small-tier topP 0.95→0.9). Known limitation documented in-code: Anthropic extended-thinking path is a near-no-op for these knobs.

## Validation

- `cargo check` + `cargo check --tests` clean (host cargo test unusable — CI authoritative)
- Whole-graph typecheck + `pnpm test`: 328 files / 3,465 tests green (values round: 201 files / 2,231 renderer tests)

Part 2 (per-language anti-tell lexicons + style transfer from the user's own writing + forced personal specifics in `packages/prompts`) follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)