### PR TITLE
feat: add jooble as a byo-key aggregator fallback provider

### DIFF
--- a/apps/desktop/src-tauri/src/ipc_contracts/provider_slots.rs
+++ b/apps/desktop/src-tauri/src/ipc_contracts/provider_slots.rs
@@ -5,6 +5,7 @@
 pub const ADZUNA_APP_ID: &str = "adzuna-app-id";
 pub const ADZUNA_APP_KEY: &str = "adzuna-app-key";
 pub const JSEARCH_KEY: &str = "jsearch-key";
+pub const JOOBLE_KEY: &str = "jooble-key";
 pub const APIFY_TOKEN: &str = "apify-token";
 pub const COMEET_COMPANY_UID: &str = "comeet-company-uid";
 pub const COMEET_API_TOKEN: &str = "comeet-api-token";

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -143,19 +143,17 @@ async fn primary_chain(
     let fallback = providers.iter().find(|p| p.provider_id() == "jsearch");
     let jooble = providers.iter().find(|p| p.provider_id() == "jooble");
 
-    // Track whether Adzuna was configured-but-failed so we can distinguish
-    // "keys present, request failed" from "no keys at all" at the end.
+    // Track whether each provider was CONFIGURED but its call FAILED, so we can
+    // distinguish "keys present, request failed" from "no keys at all" at the
+    // end. All three are collected (not just the first) — see the total-failure
+    // resolution below: a LATER-tier provider's failure must never be silently
+    // dropped just because an EARLIER-tier provider also failed.
     let mut adzuna_configured_failed: Option<anyhow::Error> = None;
-    // Same tracking for JSearch: its raw error must be returned VERBATIM (no
-    // "add a JSearch key" suffix — that suffix only makes sense when JSearch was
-    // never configured at all) when Jooble also fails to salvage a result.
     let mut jsearch_configured_failed: Option<anyhow::Error> = None;
-    // Same tracking for Jooble — lowest precedence of the three (checked last,
-    // below): without it, a user with ONLY a Jooble key whose Jooble call fails
-    // got a silent `Ok(empty)` ("no jobs found") instead of an honest error —
-    // exactly the silent-empty-failure bug the trust program eliminated. Its raw
-    // error already carries the `"jooble: "` prefix from the provider, so — like
-    // `jsearch_configured_failed` — it is returned verbatim, no added suffix.
+    // Jooble's tracking closes the same silent-empty-failure gap Adzuna/JSearch
+    // already guard: without it, a user with ONLY a Jooble key whose Jooble call
+    // fails would get a silent `Ok(empty)` ("no jobs found") instead of an
+    // honest error.
     let mut jooble_configured_failed: Option<anyhow::Error> = None;
 
     // Real (non-empty) but SPARSE items from a GUESSED market. We distrust them
@@ -308,34 +306,55 @@ async fn primary_chain(
         return Ok(dedupe(items));
     }
 
-    // JSearch had keys but failed (Jooble either absent/unconfigured or also
-    // failed) → surface JSearch's own error verbatim, matching this function's
-    // pre-Jooble contract (no "add a JSearch key" suffix — that phrasing only
-    // applies when JSearch was never configured at all).
-    if let Some(e) = jsearch_configured_failed {
-        return Err(e);
-    }
+    // Total-failure resolution: gather every CONFIGURED-and-failed provider's
+    // error (tier order — adzuna, jsearch, jooble), not just the first. Each
+    // provider's error message is already self-prefixed (`"adzuna: …"` /
+    // `"jsearch: …"` / `"jooble: …"`) at its own call site, so combining them
+    // (when more than one failed) names every failing provider instead of
+    // surfacing only the first and silently dropping the rest — e.g. Adzuna AND
+    // Jooble both configured+failing with JSearch unconfigured must name BOTH,
+    // not just Adzuna's (with a now-stale "add a JSearch key" nudge on top).
+    // The engine records the result in BoardScrapeSummary.error, which the Jobs
+    // page renders as a partial-failure warning and autopilot logs as a skipped
+    // board.
+    let failures: Vec<(&'static str, anyhow::Error)> = [
+        adzuna_configured_failed.map(|e| ("adzuna", e)),
+        jsearch_configured_failed.map(|e| ("jsearch", e)),
+        jooble_configured_failed.map(|e| ("jooble", e)),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
 
-    // Adzuna had keys but failed (e.g. unsupported country, or an EMPTY guessed
-    // market) AND neither JSearch nor Jooble produced a result → surface a
-    // diagnostic error instead of a silent empty result. The engine records this
-    // in BoardScrapeSummary.error, which the Jobs page renders as a partial-failure
-    // warning and autopilot logs as a skipped board.
-    if let Some(e) = adzuna_configured_failed {
-        return Err(anyhow::anyhow!(
-            "{e}; add a JSearch key in Settings → API Keys for global coverage"
-        ));
-    }
-
-    // Jooble had keys but failed, and NEITHER Adzuna nor JSearch was configured
-    // (otherwise one of the checks above would already have returned) → surface
-    // Jooble's own error rather than a silent empty result. This is the case a
-    // user with ONLY a Jooble key hits: without this check, a failing Jooble call
-    // degraded to `Ok(vec![])` ("no jobs found"), indistinguishable from a
-    // genuine zero-results search — the exact silent-empty-failure bug the trust
-    // program (PR #597-#604) eliminated for Adzuna/JSearch.
-    if let Some(e) = jooble_configured_failed {
-        return Err(e);
+    if failures.len() == 1 {
+        // Solo failure — the pre-multi-failure per-provider contract is
+        // unchanged: JSearch-alone or Jooble-alone returns its own message
+        // verbatim (no suffix). Adzuna-alone keeps its "add a fallback" nudge —
+        // reaching here with Adzuna as the ONLY failure means neither JSearch
+        // nor Jooble was ever configured (a configured provider either
+        // succeeds — an early return above — or fails, landing in `failures`),
+        // so the nudge is still accurate; the wording now names both fallback
+        // options instead of only JSearch.
+        let (source, e) = failures
+            .into_iter()
+            .next()
+            .expect("len == 1, checked above");
+        return Err(if source == "adzuna" {
+            anyhow::anyhow!(
+                "{e}; add a JSearch or Jooble key in Settings → API Keys for global coverage"
+            )
+        } else {
+            e
+        });
+    } else if !failures.is_empty() {
+        // Two or more configured providers failed — combine so every one is
+        // named. No suffix: the combined message already names what failed.
+        let combined = failures
+            .into_iter()
+            .map(|(_, e)| e.to_string())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(anyhow::anyhow!("{combined}"));
     }
 
     // None of the providers configured → keyless-empty (intended, never an error).

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -150,6 +150,13 @@ async fn primary_chain(
     // "add a JSearch key" suffix — that suffix only makes sense when JSearch was
     // never configured at all) when Jooble also fails to salvage a result.
     let mut jsearch_configured_failed: Option<anyhow::Error> = None;
+    // Same tracking for Jooble — lowest precedence of the three (checked last,
+    // below): without it, a user with ONLY a Jooble key whose Jooble call fails
+    // got a silent `Ok(empty)` ("no jobs found") instead of an honest error —
+    // exactly the silent-empty-failure bug the trust program eliminated. Its raw
+    // error already carries the `"jooble: "` prefix from the provider, so — like
+    // `jsearch_configured_failed` — it is returned verbatim, no added suffix.
+    let mut jooble_configured_failed: Option<anyhow::Error> = None;
 
     // Real (non-empty) but SPARSE items from a GUESSED market. We distrust them
     // enough to prefer a fallback, but if there is no working fallback they beat
@@ -280,6 +287,7 @@ async fn primary_chain(
                 Ok(items) => return Ok(dedupe(items)),
                 Err(e) => {
                     log::warn!("[aggregator] jooble fallback failed: {e}");
+                    jooble_configured_failed = Some(e);
                     // Fall through to the sparse-guessed salvage / diagnostic below,
                     // same as a JSearch failure would without Jooble configured.
                 }
@@ -317,6 +325,17 @@ async fn primary_chain(
         return Err(anyhow::anyhow!(
             "{e}; add a JSearch key in Settings → API Keys for global coverage"
         ));
+    }
+
+    // Jooble had keys but failed, and NEITHER Adzuna nor JSearch was configured
+    // (otherwise one of the checks above would already have returned) → surface
+    // Jooble's own error rather than a silent empty result. This is the case a
+    // user with ONLY a Jooble key hits: without this check, a failing Jooble call
+    // degraded to `Ok(vec![])` ("no jobs found"), indistinguishable from a
+    // genuine zero-results search — the exact silent-empty-failure bug the trust
+    // program (PR #597-#604) eliminated for Adzuna/JSearch.
+    if let Some(e) = jooble_configured_failed {
+        return Err(e);
     }
 
     // None of the providers configured → keyless-empty (intended, never an error).

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/mod.rs
@@ -1,13 +1,20 @@
-/// Aggregator board — Adzuna (primary) with JSearch (paid fallback).
+/// Aggregator board — Adzuna (primary) → JSearch (paid fallback) → Jooble
+/// (last-resort fallback).
 ///
 /// Design:
 /// * One `Scraper` in the registry (id = `"aggregator"`).
-/// * Internally holds an ordered `JobProvider` registry: Adzuna → JSearch.
-/// * Fallback semantics (enforced in `search_with_providers`):
-///   - Adzuna configured + `Ok(items)` (even empty) → use those, do NOT call JSearch.
+/// * Internally holds an ordered `JobProvider` registry: Adzuna → JSearch → Jooble.
+/// * Fallback semantics (enforced in `primary_chain`):
+///   - Adzuna configured + `Ok(items)` (even empty) → use those, do NOT call JSearch/Jooble.
 ///   - Adzuna configured + `Err(_)` → log, try JSearch if configured.
 ///   - Adzuna not configured → try JSearch if configured.
-///   - Neither configured → `Ok(vec![])` (keyless-empty, never an error).
+///   - JSearch configured + `Ok(items)` (even empty) → use those, do NOT call Jooble.
+///   - JSearch configured + `Err(_)`, or not configured → try Jooble if configured
+///     (Jooble is a LAST-RESORT tier — it only fires once both Adzuna and JSearch
+///     have failed to produce a decisive result, e.g. the unsupported-country case,
+///     never on a routine "genuinely zero results" search, since its rate limit is
+///     undocumented).
+///   - None of the three configured → `Ok(vec![])` (keyless-empty, never an error).
 /// * Keys are optional: absent = keyless-empty.  Never hardcoded, never logged.
 /// * Keys are read from the OS keychain via `credentials::read_credential`,
 ///   under the `ai:` keyring namespace + the BARE slot names generated from the
@@ -16,13 +23,14 @@
 ///   - `ai:adzuna-app-id`   (`provider_slots::ADZUNA_APP_ID`)  — Adzuna application ID
 ///   - `ai:adzuna-app-key`  (`provider_slots::ADZUNA_APP_KEY`) — Adzuna application key
 ///   - `ai:jsearch-key`     (`provider_slots::JSEARCH_KEY`)    — RapidAPI key for JSearch
+///   - `ai:jooble-key`      (`provider_slots::JOOBLE_KEY`)     — Jooble API key
 ///   - `ai:apify-token`     (`provider_slots::APIFY_TOKEN`)    — Apify Bearer token
 ///
 /// Rate-limiting and cancellation are honoured: every network call flows
 /// through `scraping::http::fetch_json` (which checks `ctx.signal` and calls
 /// the per-host `rate_limiter`).
 ///
-/// The three `JobProvider` impls (Adzuna/JSearch/Apify) live in `providers.rs`
+/// The `JobProvider` impls (Adzuna/JSearch/Jooble/Apify) live in `providers.rs`
 /// (split out to stay under the R8 module-size cap); this file holds the shared
 /// `JobProvider` trait, the fallback orchestration (`primary_chain` /
 /// `search_with_providers`), the credential-state helpers, and the `Scraper` impl.
@@ -108,6 +116,14 @@ pub(crate) trait JobProvider: Send + Sync {
 /// unaffected — `Ok(empty)` there returns as before.
 ///
 /// Items from each provider are keyed by their `external_id` to deduplicate.
+///
+/// **Jooble (last-resort tier)**: tried only when JSearch ALSO fails to produce
+/// a decisive result (unconfigured or `Err`) — i.e. only in the terminal branches
+/// this function would otherwise resolve to a diagnostic `Err` or keyless-empty.
+/// A JSearch `Ok(items)` (even empty) still short-circuits before Jooble is ever
+/// reached, symmetric with Adzuna's own "configured Ok, even empty, wins" rule —
+/// this keeps Jooble off the hot path for a routine zero-results search (its rate
+/// limit is undocumented) and reserves it for genuinely unmet capacity.
 async fn primary_chain(
     providers: &[Box<dyn JobProvider>],
     query: &str,
@@ -121,13 +137,19 @@ async fn primary_chain(
         return Ok(vec![]);
     }
 
-    // Locate primary (Adzuna) and fallback (JSearch) by id.
+    // Locate primary (Adzuna), fallback (JSearch), and the last-resort tier
+    // (Jooble) by id.
     let primary = providers.iter().find(|p| p.provider_id() == "adzuna");
     let fallback = providers.iter().find(|p| p.provider_id() == "jsearch");
+    let jooble = providers.iter().find(|p| p.provider_id() == "jooble");
 
     // Track whether Adzuna was configured-but-failed so we can distinguish
     // "keys present, request failed" from "no keys at all" at the end.
     let mut adzuna_configured_failed: Option<anyhow::Error> = None;
+    // Same tracking for JSearch: its raw error must be returned VERBATIM (no
+    // "add a JSearch key" suffix — that suffix only makes sense when JSearch was
+    // never configured at all) when Jooble also fails to salvage a result.
+    let mut jsearch_configured_failed: Option<anyhow::Error> = None;
 
     // Real (non-empty) but SPARSE items from a GUESSED market. We distrust them
     // enough to prefer a fallback, but if there is no working fallback they beat
@@ -207,10 +229,43 @@ async fn primary_chain(
         return Ok(vec![]);
     }
 
-    // Try fallback.
+    // Try JSearch fallback.
     if let Some(f) = fallback {
         if f.is_configured() {
             match f
+                .search(
+                    query,
+                    location,
+                    country,
+                    country_guessed,
+                    date_filter,
+                    None,
+                    signal.clone(),
+                )
+                .await
+            {
+                Ok(items) => return Ok(dedupe(items)),
+                Err(e) => {
+                    // JSearch itself failed. Don't salvage/return yet — Jooble (the
+                    // last-resort tier, below) still gets a chance at a decisive
+                    // result before falling back to the sparse-guessed salvage or
+                    // the diagnostic error.
+                    log::warn!("[aggregator] jsearch error, attempting jooble fallback: {e}");
+                    jsearch_configured_failed = Some(e);
+                }
+            }
+        }
+    }
+
+    // Guard: don't fire a paid/rate-limited Jooble call after cancellation.
+    if signal.is_cancelled() {
+        return Ok(vec![]);
+    }
+
+    // Try Jooble — LAST-RESORT tier (see the doc comment above `primary_chain`).
+    if let Some(j) = jooble {
+        if j.is_configured() {
+            match j
                 .search(
                     query,
                     location,
@@ -224,18 +279,9 @@ async fn primary_chain(
             {
                 Ok(items) => return Ok(dedupe(items)),
                 Err(e) => {
-                    // Fallback itself failed. If we retained sparse-but-real Adzuna
-                    // items from a guessed market, return those (better than nothing)
-                    // rather than surfacing the fallback error and losing legit hits.
-                    if let Some(items) = sparse_guessed_items.take() {
-                        log::warn!(
-                            "[aggregator] jsearch fallback failed ({e}); returning {} \
-                             sparse guessed-market adzuna result(s) instead",
-                            items.len()
-                        );
-                        return Ok(dedupe(items));
-                    }
-                    return Err(e);
+                    log::warn!("[aggregator] jooble fallback failed: {e}");
+                    // Fall through to the sparse-guessed salvage / diagnostic below,
+                    // same as a JSearch failure would without Jooble configured.
                 }
             }
         }
@@ -245,28 +291,35 @@ async fn primary_chain(
     // them rather than the diagnostic — a user with only Adzuna keys keeps their few
     // legit hits (better than nothing). The uncertainty was already logged above.
     //
-    // NOTE (deliberately under-surfaced, PR D): this salvage path — and the sibling
-    // one at the `sparse_guessed_items.take()` above — return the sparse guessed
-    // hits WITHOUT a `BoardScrapeSummary.note`, because only `primary_chain` (not
-    // `AdzunaProvider`, which holds the note sink) knows the guess was salvaged
+    // NOTE (deliberately under-surfaced, PR D): this salvage path returns the sparse
+    // guessed hits WITHOUT a `BoardScrapeSummary.note`, because only `primary_chain`
+    // (not `AdzunaProvider`, which holds the note sink) knows the guess was salvaged
     // rather than authoritative or replaced. Revisit when PR F threads location
     // context through this path.
     if let Some(items) = sparse_guessed_items {
         return Ok(dedupe(items));
     }
 
+    // JSearch had keys but failed (Jooble either absent/unconfigured or also
+    // failed) → surface JSearch's own error verbatim, matching this function's
+    // pre-Jooble contract (no "add a JSearch key" suffix — that phrasing only
+    // applies when JSearch was never configured at all).
+    if let Some(e) = jsearch_configured_failed {
+        return Err(e);
+    }
+
     // Adzuna had keys but failed (e.g. unsupported country, or an EMPTY guessed
-    // market) AND JSearch is not configured → surface a diagnostic error instead
-    // of a silent empty result. The engine records this in BoardScrapeSummary.error,
-    // which the Jobs page renders as a partial-failure warning and autopilot logs
-    // as a skipped board.
+    // market) AND neither JSearch nor Jooble produced a result → surface a
+    // diagnostic error instead of a silent empty result. The engine records this
+    // in BoardScrapeSummary.error, which the Jobs page renders as a partial-failure
+    // warning and autopilot logs as a skipped board.
     if let Some(e) = adzuna_configured_failed {
         return Err(anyhow::anyhow!(
             "{e}; add a JSearch key in Settings → API Keys for global coverage"
         ));
     }
 
-    // Neither provider configured → keyless-empty (intended, never an error).
+    // None of the providers configured → keyless-empty (intended, never an error).
     Ok(vec![])
 }
 
@@ -330,8 +383,8 @@ fn dedupe_by_url(items: Vec<JobPosting>) -> Vec<JobPosting> {
 
 /// Top-level provider orchestration.
 ///
-/// 1. **Primary result** — the Adzuna → JSearch fallback chain ([`primary_chain`]),
-///    with its existing semantics fully preserved.
+/// 1. **Primary result** — the Adzuna → JSearch → Jooble fallback chain
+///    ([`primary_chain`]), with its existing semantics fully preserved.
 /// 2. **Additive LinkedIn (Apify)** — runs IN ADDITION to (never as a fallback of)
 ///    the primary result, and ONLY when `apify_linkedin` is configured (the toggle
 ///    is ON and a token is present). Its results are merged onto the primary,
@@ -442,25 +495,32 @@ async fn search_with_providers(
 fn aggregator_has_configured_provider() -> bool {
     AdzunaProvider::new().is_configured()
         || JSearchProvider::new().is_configured()
+        || JoobleProvider::new().is_configured()
         || ApifyLinkedInProvider::new().is_configured()
 }
 
 /// First keyring READ error across the aggregator's provider credential slots
-/// (Adzuna id/key, JSearch key, and the Apify token), if any. Probes the SAME slot
-/// set [`aggregator_has_configured_provider`] counts — including the Apify token —
-/// so a faulting Apify slot (with Adzuna/JSearch merely absent) is classified as a
-/// store error rather than a misleading `needs-keys` skip. Distinguishes a
-/// credential-store FAULT (surfaced as a board error) from mere key absence
-/// (surfaced as a `needs-keys` skip). Returns `None` when every slot reads
-/// cleanly — whether the key is present or simply absent.
+/// (Adzuna id/key, JSearch key, Jooble key, and the Apify token), if any. Probes
+/// the SAME slot set [`aggregator_has_configured_provider`] counts — including
+/// Jooble and the Apify token — so a faulting slot (with the others merely
+/// absent) is classified as a store error rather than a misleading `needs-keys`
+/// skip. Distinguishes a credential-store FAULT (surfaced as a board error) from
+/// mere key absence (surfaced as a `needs-keys` skip). Returns `None` when every
+/// slot reads cleanly — whether the key is present or simply absent.
 ///
 /// The error string is a keyring backend message + slot name only; it never
 /// carries a credential value (see `credentials::read_credential`).
 fn aggregator_store_error() -> Option<String> {
     use crate::ipc_contracts::provider_slots::{
-        ADZUNA_APP_ID, ADZUNA_APP_KEY, APIFY_TOKEN, JSEARCH_KEY,
+        ADZUNA_APP_ID, ADZUNA_APP_KEY, APIFY_TOKEN, JOOBLE_KEY, JSEARCH_KEY,
     };
-    for slot in [ADZUNA_APP_ID, ADZUNA_APP_KEY, JSEARCH_KEY, APIFY_TOKEN] {
+    for slot in [
+        ADZUNA_APP_ID,
+        ADZUNA_APP_KEY,
+        JSEARCH_KEY,
+        JOOBLE_KEY,
+        APIFY_TOKEN,
+    ] {
         if let Err(e) = crate::credentials::read_credential(&format!("ai:{slot}")) {
             return Some(e.to_string());
         }
@@ -552,6 +612,9 @@ impl Scraper for AggregatorScraper {
         let providers: Vec<Box<dyn JobProvider>> = vec![
             Box::new(AdzunaProvider::new().with_note_sink(ctx.on_note.clone())),
             Box::new(JSearchProvider::new()),
+            // Last-resort fallback (see `primary_chain`'s doc comment) — only
+            // reached once both Adzuna and JSearch fail to produce a result.
+            Box::new(JoobleProvider::new()),
             // Additive, opt-in, paid: only runs when the toggle is ON and a token
             // is present (gated in `ApifyLinkedInProvider::is_configured`).
             Box::new(ApifyLinkedInProvider::new()),

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
@@ -615,6 +615,195 @@ impl JobProvider for JSearchProvider {
     }
 }
 
+// ── Jooble provider (last-resort fallback, after Adzuna + JSearch) ──────────────
+
+#[derive(Debug, Deserialize)]
+pub(super) struct JoobleJob {
+    #[serde(default, deserialize_with = "de_opt_string_or_number")]
+    pub(super) id: Option<String>,
+    pub(super) title: Option<String>,
+    pub(super) company: Option<String>,
+    pub(super) location: Option<String>,
+    /// TRUNCATED description — same caveat as Adzuna's `description`: never
+    /// treat this as full job text.
+    pub(super) snippet: Option<String>,
+    /// Free-text salary string (e.g. "$50,000 - $70,000"); not parsed into a
+    /// number — stashed verbatim in `extra.salaryText` rather than risking a
+    /// wrong numeric parse of an undocumented format.
+    pub(super) salary: Option<String>,
+    pub(super) link: Option<String>,
+    /// ISO-8601.
+    pub(super) updated: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct JoobleResp {
+    pub(super) jobs: Vec<JoobleJob>,
+}
+
+/// Production Jooble host. Factored into a constant (rather than inlined in
+/// [`fetch_jooble`]) purely so `JoobleProvider::search` reads as "the real
+/// host" at a glance; tests pass a local `wiremock` base instead.
+pub(super) const JOOBLE_BASE_URL: &str = "https://jooble.org";
+
+/// Build the Jooble search endpoint for a given base + key. Factored out of
+/// [`fetch_jooble`] so the URL shape (key in the PATH, not a header/query) is
+/// independently testable.
+pub(super) fn jooble_endpoint(base_url: &str, api_key: &str) -> String {
+    format!("{base_url}/api/{}", urlencoding::encode(api_key))
+}
+
+/// Map one Jooble result to a [`JobPosting`]. Drops items missing a usable
+/// title or link (mirrors JSearch's `filter_map` policy — such an item can't
+/// be shown or opened). Pulled out of [`fetch_jooble`] so the mapping is
+/// unit-testable without a network call.
+pub(super) fn map_jooble_job(j: JoobleJob, now: i64) -> Option<JobPosting> {
+    let title = j
+        .title
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+    let url = j
+        .link
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+    let id_part =
+        j.id.map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| url.clone());
+
+    let mut extra = std::collections::HashMap::new();
+    if let Some(salary) = j
+        .salary
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    {
+        extra.insert("salaryText".to_string(), serde_json::json!(salary));
+    }
+
+    Some(JobPosting {
+        id: format!("aggregator:jooble-{id_part}"),
+        external_id: Some(format!("jooble-{id_part}")),
+        title,
+        company: j.company.unwrap_or_default(),
+        location: j
+            .location
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
+        url,
+        source: "aggregator".to_string(),
+        description: j.snippet.map(|d| html_to_markdown(&d)),
+        requirements: None,
+        posted_at: j
+            .updated
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.timestamp_millis()),
+        captured_at: now,
+        extra,
+    })
+}
+
+/// Build + fetch + parse the Jooble search response for a given base URL.
+/// Factored out of `JoobleProvider::search` (mirrors `fetch_adzuna_page`'s
+/// testable-base pattern) so the non-2xx / mapping contract is unit-testable
+/// against a local mock server without a real key or hitting the live host.
+pub(super) async fn fetch_jooble(
+    base_url: &str,
+    api_key: &str,
+    query: &str,
+    location: &str,
+    amount: Option<u32>,
+    signal: tokio_util::sync::CancellationToken,
+) -> anyhow::Result<Vec<JobPosting>> {
+    // Jooble's contract puts the key in the URL PATH, not a header or query
+    // param: `POST /api/{apiKey}`. `redact_path: true` below keeps it out of
+    // `fetch_json`'s non-2xx / schema-drift log lines (the shared query-only
+    // redaction doesn't cover a path-embedded secret) — including on the exact
+    // "bad key" 403 that would otherwise echo it straight back.
+    let url = jooble_endpoint(base_url, api_key);
+
+    let body = match amount {
+        Some(n) => {
+            serde_json::json!({ "keywords": query, "location": location, "ResultOnPage": n })
+        }
+        None => serde_json::json!({ "keywords": query, "location": location }),
+    };
+
+    // A non-2xx or schema-drift response propagates as `Err` from `fetch_json`
+    // (carrying the HTTP status); `?` surfaces it as a provider failure. The
+    // "jooble:" prefix is required — the aggregator board fronts multiple
+    // providers, so an unattributed "HTTP 403" in BoardScrapeSummary.error
+    // wouldn't say which one failed.
+    let resp = fetch_json::<JoobleResp>(
+        &url,
+        FetchOptions {
+            method: Some(reqwest::Method::POST),
+            body: Some(body.to_string()),
+            headers: Some(vec![(
+                "content-type".to_string(),
+                "application/json".to_string(),
+            )]),
+            redact_path: true,
+            ..FetchOptions::default()
+        },
+        signal,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("jooble: {e}"))?;
+
+    let now = chrono::Utc::now().timestamp_millis();
+    Ok(resp
+        .jobs
+        .into_iter()
+        .filter_map(|j| map_jooble_job(j, now))
+        .collect())
+}
+
+pub(crate) struct JoobleProvider {
+    pub(super) api_key: Option<String>,
+}
+
+impl JoobleProvider {
+    pub(super) fn new() -> Self {
+        use crate::ipc_contracts::provider_slots::JOOBLE_KEY;
+        Self {
+            api_key: crate::credentials::read_credential(&format!("ai:{JOOBLE_KEY}"))
+                .unwrap_or_else(|e| {
+                    log::warn!("[aggregator] {JOOBLE_KEY} keyring error: {e}");
+                    None
+                }),
+        }
+    }
+}
+
+#[async_trait]
+impl JobProvider for JoobleProvider {
+    fn provider_id(&self) -> &'static str {
+        "jooble"
+    }
+
+    fn is_configured(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        location: &str,
+        _country: &str,
+        _country_guessed: bool,
+        _date_filter: Option<&str>,
+        amount: Option<u32>,
+        signal: tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        if !self.is_configured() {
+            return Err(anyhow::anyhow!("jooble: not configured"));
+        }
+        let api_key = self.api_key.as_deref().unwrap_or("");
+        fetch_jooble(JOOBLE_BASE_URL, api_key, query, location, amount, signal).await
+    }
+}
+
 // ── Non-secret aggregator settings (plugin-store JSON) ──────────────────────────
 //
 // The "Include LinkedIn (Apify)" opt-in toggle and the optional actor-id override

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -147,6 +147,45 @@ async fn adzuna_ok_empty_does_not_call_jsearch() {
     );
 }
 
+/// JSearch Ok(empty) → empty returned, Jooble NOT called. Symmetric with
+/// Adzuna's own "configured Ok, even empty, wins" rule: a JSearch `Ok(vec![])`
+/// is a DECISIVE (if empty) result, not "nothing" — it must short-circuit
+/// before the Jooble last-resort tier, exactly like
+/// `adzuna_ok_empty_does_not_call_jsearch` above one tier up.
+///
+/// Adzuna is UNCONFIGURED here (not `Ok(empty)`) so control actually reaches
+/// the JSearch tier — an `Ok(empty)` Adzuna would short-circuit before JSearch
+/// is ever consulted (see the sibling test above), which would make this test
+/// pass for the wrong reason.
+#[tokio::test]
+async fn jsearch_ok_empty_does_not_call_jooble() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::unconfigured("adzuna")),
+        Box::new(FakeProvider::ok("jsearch", vec![])),
+        // Jooble is configured and would return items — but must not be called.
+        Box::new(FakeProvider::err("jooble", "should not be called")),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "berlin",
+        "de",
+        false,
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        result.len(),
+        0,
+        "Jooble must not be called when JSearch returns Ok(empty)"
+    );
+}
+
 /// Adzuna Err → JSearch called and its results returned.
 #[tokio::test]
 async fn adzuna_err_falls_back_to_jsearch() {
@@ -305,6 +344,17 @@ fn jsearch_is_configured_reflects_key_presence() {
 
     let with_key = JSearchProvider {
         api_key: Some("rapidapikey".to_string()),
+    };
+    assert!(with_key.is_configured());
+}
+
+#[test]
+fn jooble_is_configured_reflects_key_presence() {
+    let no_key = JoobleProvider { api_key: None };
+    assert!(!no_key.is_configured());
+
+    let with_key = JoobleProvider {
+        api_key: Some("joobleapikey".to_string()),
     };
     assert!(with_key.is_configured());
 }
@@ -569,6 +619,219 @@ fn jsearch_drops_jobs_without_any_link() {
     assert_eq!(count, 1, "job without either link must be dropped");
 }
 
+// ── Jooble response → JobPosting mapping ─────────────────────────────────────
+
+#[test]
+fn jooble_response_maps_to_job_posting() {
+    let json = serde_json::json!({
+        "totalCount": 1,
+        "jobs": [{
+            "id": "abc-1",
+            "title": "Backend Engineer",
+            "company": "Acme",
+            "location": "Munich",
+            "snippet": "Truncated description…",
+            "salary": "€60,000",
+            "link": "https://jooble.org/desc/abc-1",
+            "updated": "2026-05-01T10:00:00Z"
+        }]
+    });
+    let resp: JoobleResp = serde_json::from_value(json).unwrap();
+    let posting = map_jooble_job(resp.jobs.into_iter().next().unwrap(), 0).unwrap();
+
+    assert_eq!(posting.external_id.as_deref(), Some("jooble-abc-1"));
+    assert_eq!(posting.id, "aggregator:jooble-abc-1");
+    assert_eq!(posting.title, "Backend Engineer");
+    assert_eq!(posting.company, "Acme");
+    assert_eq!(posting.location.as_deref(), Some("Munich"));
+    assert_eq!(posting.url, "https://jooble.org/desc/abc-1");
+    assert_eq!(
+        posting.extra.get("salaryText").and_then(|v| v.as_str()),
+        Some("€60,000")
+    );
+    assert!(posting.posted_at.unwrap() > 0);
+}
+
+/// Jooble's `id` can arrive as a bare integer — must parse and normalise to
+/// String (same shape as the Adzuna `id` regression this mirrors).
+#[test]
+fn jooble_integer_id_deserializes_to_string() {
+    let json = serde_json::json!({
+        "jobs": [{
+            "id": 987654,
+            "title": "QA Engineer",
+            "company": "Corp",
+            "location": null,
+            "snippet": null,
+            "salary": null,
+            "link": "https://jooble.org/desc/987654",
+            "updated": null
+        }]
+    });
+    let resp: JoobleResp = serde_json::from_value(json).expect("integer id must deserialize");
+    assert_eq!(resp.jobs[0].id.as_deref(), Some("987654"));
+}
+
+/// A job missing `id` falls back to the URL as the dedupe key, still prefixed
+/// `"jooble-"` — dedup must never crash/collapse on a missing id.
+#[test]
+fn jooble_missing_id_falls_back_to_url_based_external_id() {
+    let job = JoobleJob {
+        id: None,
+        title: Some("No-id job".to_string()),
+        company: Some("Co".to_string()),
+        location: None,
+        snippet: None,
+        salary: None,
+        link: Some("https://jooble.org/desc/no-id".to_string()),
+        updated: None,
+    };
+    let posting = map_jooble_job(job, 0).unwrap();
+    assert_eq!(
+        posting.external_id.as_deref(),
+        Some("jooble-https://jooble.org/desc/no-id")
+    );
+}
+
+/// Jobs missing a title, or missing a link, are dropped — neither can be shown
+/// nor opened.
+#[test]
+fn jooble_drops_jobs_without_title_or_link() {
+    let no_title = JoobleJob {
+        id: Some("1".to_string()),
+        title: None,
+        company: None,
+        location: None,
+        snippet: None,
+        salary: None,
+        link: Some("https://jooble.org/desc/1".to_string()),
+        updated: None,
+    };
+    let no_link = JoobleJob {
+        id: Some("2".to_string()),
+        title: Some("Has title".to_string()),
+        company: None,
+        location: None,
+        snippet: None,
+        salary: None,
+        link: None,
+        updated: None,
+    };
+    assert!(map_jooble_job(no_title, 0).is_none());
+    assert!(map_jooble_job(no_link, 0).is_none());
+}
+
+// ── Jooble is_configured() / network-avoidance guard ───────────────────────────
+
+#[tokio::test]
+async fn jooble_unconfigured_returns_err_without_network() {
+    let p = JoobleProvider { api_key: None };
+    let result = p
+        .search("engineer", "berlin", "de", false, None, None, make_token())
+        .await;
+    assert!(result.is_err(), "unconfigured Jooble must return Err");
+    assert!(
+        result.unwrap_err().to_string().contains("not configured"),
+        "error must say 'not configured'"
+    );
+}
+
+// ── Jooble non-2xx / redact_path wiring (wiremock) ──────────────────────────────
+
+/// A non-2xx (e.g. a bad-key 403) propagates as a provider failure prefixed
+/// `"jooble:"` — so `BoardScrapeSummary.error` names which provider failed —
+/// and the API key (embedded in the URL PATH per Jooble's contract, not a
+/// header/query) never appears in the surfaced message, only the HTTP status.
+#[tokio::test]
+async fn jooble_non_2xx_maps_to_prefixed_err() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(403).set_body_string(r#"{"message":"bad key"}"#))
+        .mount(&mock_server)
+        .await;
+
+    let result = fetch_jooble(
+        &mock_server.uri(),
+        "totally-fake-key",
+        "engineer",
+        "Berlin",
+        None,
+        make_token(),
+    )
+    .await;
+
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.starts_with("jooble:"),
+        "error must be prefixed so BoardScrapeSummary.error names the provider; got: {msg}"
+    );
+    assert!(
+        msg.contains("403"),
+        "the HTTP status must be carried; got: {msg}"
+    );
+    assert!(
+        !msg.contains("totally-fake-key"),
+        "the API key (URL-path-embedded) must never appear in the surfaced error; got: {msg}"
+    );
+}
+
+/// A 2xx Jooble response round-trips end-to-end through `fetch_jooble` (POST +
+/// path-embedded key + `redact_path` wiring + response mapping) into a
+/// `"jooble-"`-prefixed posting.
+#[tokio::test]
+async fn jooble_ok_response_maps_end_to_end() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "totalCount": 1,
+            "jobs": [{
+                "id": 555,
+                "title": "Rust Engineer",
+                "company": "JoobleCo",
+                "location": "Remote",
+                "snippet": "Truncated…",
+                "salary": "$80,000 - $100,000",
+                "link": "https://jooble.org/desc/555",
+                "updated": "2026-06-01T09:00:00Z"
+            }]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let items = fetch_jooble(
+        &mock_server.uri(),
+        "fake-key",
+        "engineer",
+        "Berlin",
+        None,
+        make_token(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].external_id.as_deref(), Some("jooble-555"));
+    assert_eq!(items[0].url, "https://jooble.org/desc/555");
+}
+
+/// `jooble_endpoint` puts the key in the PATH, not a query param — pins the
+/// URL shape independently of the network round trip above.
+#[test]
+fn jooble_endpoint_puts_key_in_path() {
+    let url = jooble_endpoint("https://jooble.org", "my-key");
+    assert_eq!(url, "https://jooble.org/api/my-key");
+    assert!(
+        !url.contains('?'),
+        "the key must be a path segment, not a query param"
+    );
+}
+
 // ── Scraper trait basics ──────────────────────────────────────────────────────
 
 #[test]
@@ -724,7 +987,7 @@ async fn cancelled_after_adzuna_err_skips_jsearch() {
 use std::sync::Mutex;
 
 use crate::ipc_contracts::provider_slots::{
-    ADZUNA_APP_ID, ADZUNA_APP_KEY, APIFY_TOKEN, JSEARCH_KEY,
+    ADZUNA_APP_ID, ADZUNA_APP_KEY, APIFY_TOKEN, JOOBLE_KEY, JSEARCH_KEY,
 };
 
 static AGG_KEYRING_LOCK: Mutex<()> = Mutex::new(());
@@ -747,16 +1010,22 @@ fn apify_slot() -> String {
     format!("ai:{APIFY_TOKEN}")
 }
 
+fn jooble_slot() -> String {
+    format!("ai:{JOOBLE_KEY}")
+}
+
 /// Delete the aggregator's fixed keyring slots so a test starts from a known
 /// "absent" baseline regardless of what a previous serialized test left behind.
 fn clear_aggregator_slots() {
     let adzuna = adzuna_slots();
     let jsearch = jsearch_slot();
     let apify = apify_slot();
+    let jooble = jooble_slot();
     for slot in adzuna
         .iter()
         .chain(std::iter::once(&jsearch))
         .chain(std::iter::once(&apify))
+        .chain(std::iter::once(&jooble))
     {
         if let Ok(entry) = keyring_core::Entry::new(crate::credentials::SERVICE, slot) {
             // NoEntry on a clean slot is fine; we only care it ends up absent.
@@ -1017,6 +1286,86 @@ fn aggregator_apify_slot_read_failure_surfaces_as_search_error() {
     assert!(
         result.is_err(),
         "an Apify-slot store fault must surface as a board error, not Ok(empty)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("credential store unavailable"),
+        "the diagnostic must name the store as unavailable; got: {msg}"
+    );
+
+    clear_aggregator_slots();
+}
+
+/// Arm a non-NoEntry failure on the JOOBLE key slot only (Adzuna + JSearch +
+/// Apify stay absent — `NoEntry` → `Ok(None)`). One-shot — see the doc comment
+/// on [`arm_apify_slot_fault`] for why callers must arm immediately before the
+/// single probe they intend to exercise, never reuse one arm across two reads.
+fn arm_jooble_slot_fault() {
+    let entry = keyring_core::Entry::new(crate::credentials::SERVICE, &jooble_slot()).unwrap();
+    let mock: &keyring_core::mock::Cred = entry.as_any().downcast_ref().unwrap();
+    mock.set_error(keyring_core::Error::Invalid(
+        "induced".to_string(),
+        "keyring backend unavailable".to_string(),
+    ));
+}
+
+/// Consistency guard (this PR's regression risk): `aggregator_has_configured_provider`
+/// counts the Jooble provider, so a Jooble-only configured key must clear the
+/// needs-keys skip — otherwise the aggregator board is wrongly skipped when only
+/// a Jooble key is set.
+#[test]
+fn aggregator_does_not_need_keys_when_only_jooble_configured() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    keyring_core::Entry::new(crate::credentials::SERVICE, &jooble_slot())
+        .unwrap()
+        .set_password("configured")
+        .unwrap();
+
+    assert!(
+        !AggregatorScraper.needs_keys(),
+        "a Jooble-only configured aggregator must report needs_keys()==false"
+    );
+
+    clear_aggregator_slots();
+}
+
+/// `aggregator_store_error` must probe the Jooble slot too. A keyring READ
+/// FAILURE on the JOOBLE slot ALONE (others merely absent) must classify as a
+/// store error — `needs_keys()` false — NOT a misleading `needs-keys` skip.
+#[test]
+fn aggregator_jooble_slot_read_failure_is_not_a_needs_keys_skip() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    arm_jooble_slot_fault();
+
+    assert!(
+        !AggregatorScraper.needs_keys(),
+        "a Jooble-slot store fault (others absent) must NOT be a needs-keys skip"
+    );
+
+    clear_aggregator_slots();
+}
+
+/// Companion to the classification test above: a JOOBLE-slot-only store fault
+/// (others merely absent) makes `search` return a board error naming the store
+/// as unavailable — NOT a silent `Ok(empty)`.
+#[test]
+fn aggregator_jooble_slot_read_failure_surfaces_as_search_error() {
+    let _guard = AGG_KEYRING_LOCK.lock().unwrap();
+    crate::credentials::install_mock_keyring();
+    clear_aggregator_slots();
+
+    arm_jooble_slot_fault();
+
+    let result = block_on(AggregatorScraper.search(make_input(), make_ctx()));
+    assert!(
+        result.is_err(),
+        "a Jooble-slot store fault must surface as a board error, not Ok(empty)"
     );
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -1462,6 +1811,158 @@ async fn unsupported_country_no_keys_returns_keyless_empty() {
     assert!(
         result.is_empty(),
         "no keys at all must still return keyless-empty (no diagnostic needed)"
+    );
+}
+
+// ── Jooble last-resort tier ───────────────────────────────────────────────────
+//
+// Jooble is a THIRD tier, tried only once Adzuna AND JSearch have both failed
+// to produce a decisive result (unconfigured or `Err`) — never merely because
+// one of them returned an empty-but-Ok page. See `primary_chain`'s doc comment.
+
+/// Both Adzuna and JSearch unconfigured (a Jooble-only setup) → Jooble is
+/// consulted and its results win.
+#[tokio::test]
+async fn jooble_fires_when_adzuna_and_jsearch_unconfigured() {
+    let jooble_posting = sample_posting("j1", "jooble");
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::unconfigured("adzuna")),
+        Box::new(FakeProvider::unconfigured("jsearch")),
+        Box::new(FakeProvider::ok("jooble", vec![jooble_posting.clone()])),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "Seoul",
+        "xx",
+        false,
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].external_id, jooble_posting.external_id);
+}
+
+/// Adzuna AND JSearch both configured-but-erroring (e.g. the unsupported-country
+/// case with a JSearch key that's also failing) → Jooble is consulted and its
+/// results win.
+#[tokio::test]
+async fn jooble_fires_after_adzuna_and_jsearch_both_err() {
+    let jooble_posting = sample_posting("j2", "jooble");
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::err(
+            "adzuna",
+            "adzuna: country 'xx' is not in Adzuna's supported market list",
+        )),
+        Box::new(FakeProvider::err("jsearch", "jsearch upstream 500")),
+        Box::new(FakeProvider::ok("jooble", vec![jooble_posting.clone()])),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "Seoul",
+        "xx",
+        false,
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].external_id, jooble_posting.external_id);
+}
+
+/// Adzuna returns real results → Jooble must NOT be called (the fake Jooble
+/// always errors, proving it wasn't reached).
+#[tokio::test]
+async fn jooble_not_called_when_adzuna_succeeds() {
+    let adzuna_posting = sample_posting("a1", "adzuna");
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::ok("adzuna", vec![adzuna_posting.clone()])),
+        Box::new(FakeProvider::err("jsearch", "should not be called")),
+        Box::new(FakeProvider::err("jooble", "should not be called")),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "berlin",
+        "de",
+        false,
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].external_id, adzuna_posting.external_id);
+}
+
+/// Adzuna fails but JSearch returns real results → Jooble must NOT be called.
+#[tokio::test]
+async fn jooble_not_called_when_jsearch_succeeds() {
+    let jsearch_posting = sample_posting("js1", "jsearch");
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::err("adzuna", "adzuna down")),
+        Box::new(FakeProvider::ok("jsearch", vec![jsearch_posting.clone()])),
+        Box::new(FakeProvider::err("jooble", "should not be called")),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "berlin",
+        "de",
+        false,
+        None,
+        100,
+        make_token(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].external_id, jsearch_posting.external_id);
+}
+
+/// Adzuna + JSearch + Jooble all configured-but-erroring, no sparse-guessed
+/// salvage available → JSearch's raw error (not Adzuna's wrapped diagnostic) is
+/// surfaced, matching the pre-Jooble contract for a configured-but-failing
+/// JSearch.
+#[tokio::test]
+async fn jooble_erroring_falls_through_to_jsearch_raw_error() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::err("adzuna", "adzuna down")),
+        Box::new(FakeProvider::err("jsearch", "jsearch upstream 500")),
+        Box::new(FakeProvider::err("jooble", "jooble upstream 500")),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "berlin",
+        "de",
+        false,
+        None,
+        100,
+        make_token(),
+    )
+    .await;
+
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("jsearch upstream 500"),
+        "must surface JSearch's raw error (not Adzuna's) when Jooble also fails; got: {msg}"
     );
 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -1966,6 +1966,43 @@ async fn jooble_erroring_falls_through_to_jsearch_raw_error() {
     );
 }
 
+/// Adzuna + JSearch both UNCONFIGURED (a Jooble-only setup) and Jooble is
+/// configured but ERRORS → the aggregator must surface Jooble's error, NOT a
+/// silent `Ok(empty)`. Regression guard: a user with only a Jooble key whose
+/// Jooble call fails must get an honest diagnostic, not "no jobs found" — the
+/// exact silent-empty-failure bug the trust program (PR #597-#604) eliminated
+/// for Adzuna/JSearch.
+#[tokio::test]
+async fn jooble_only_configured_failure_surfaces_error() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::unconfigured("adzuna")),
+        Box::new(FakeProvider::unconfigured("jsearch")),
+        Box::new(FakeProvider::err("jooble", "jooble upstream 500")),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "berlin",
+        "de",
+        false,
+        None,
+        100,
+        make_token(),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "a Jooble-only setup with a failing Jooble call must return Err, not silent Ok(empty)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("jooble upstream 500"),
+        "the diagnostic must carry Jooble's own error; got: {msg}"
+    );
+}
+
 // ── Guessed-market empty-result guard (autopilot aggregator zero-jobs fix) ────
 //
 // When the caller supplied NO `country_code`, `AggregatorScraper::search` defaults

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -294,8 +294,8 @@ async fn adzuna_configured_err_and_no_jsearch_returns_diagnostic_err() {
         "diagnostic error must include the original Adzuna failure ('timeout'); got: {msg}"
     );
     assert!(
-        msg.contains("add a JSearch key in Settings"),
-        "diagnostic error must include the actionable JSearch-remedy suffix; got: {msg}"
+        msg.contains("add a JSearch or Jooble key in Settings"),
+        "diagnostic error must include the actionable fallback-remedy suffix; got: {msg}"
     );
 }
 
@@ -1935,12 +1935,12 @@ async fn jooble_not_called_when_jsearch_succeeds() {
     assert_eq!(result[0].external_id, jsearch_posting.external_id);
 }
 
-/// Adzuna + JSearch + Jooble all configured-but-erroring, no sparse-guessed
-/// salvage available → JSearch's raw error (not Adzuna's wrapped diagnostic) is
-/// surfaced, matching the pre-Jooble contract for a configured-but-failing
-/// JSearch.
+/// Adzuna + JSearch + Jooble ALL configured-but-erroring, no sparse-guessed
+/// salvage available → the combined diagnostic names EVERY failing provider,
+/// not just the first. Regression guard for the "only the first configured
+/// failure surfaces, silently dropping the rest" bug.
 #[tokio::test]
-async fn jooble_erroring_falls_through_to_jsearch_raw_error() {
+async fn all_three_configured_and_erroring_combines_every_failure() {
     let providers: Vec<Box<dyn JobProvider>> = vec![
         Box::new(FakeProvider::err("adzuna", "adzuna down")),
         Box::new(FakeProvider::err("jsearch", "jsearch upstream 500")),
@@ -1961,8 +1961,67 @@ async fn jooble_erroring_falls_through_to_jsearch_raw_error() {
 
     let msg = result.unwrap_err().to_string();
     assert!(
+        msg.contains("adzuna down"),
+        "combined diagnostic must name Adzuna's failure too; got: {msg}"
+    );
+    assert!(
         msg.contains("jsearch upstream 500"),
-        "must surface JSearch's raw error (not Adzuna's) when Jooble also fails; got: {msg}"
+        "combined diagnostic must name JSearch's failure; got: {msg}"
+    );
+    assert!(
+        msg.contains("jooble upstream 500"),
+        "combined diagnostic must name Jooble's failure — not silently dropped \
+         behind Adzuna's/JSearch's; got: {msg}"
+    );
+    assert!(
+        !msg.contains("add a JSearch"),
+        "a combined multi-provider failure must not carry the stale single-provider \
+         fallback-remedy suffix; got: {msg}"
+    );
+}
+
+/// Adzuna + Jooble both configured-and-erroring, JSearch UNCONFIGURED — the
+/// exact scenario the review flagged: previously only Adzuna's message (with a
+/// now-stale "add a JSearch key" suffix) surfaced, and Jooble's real failure
+/// was silently dropped. The combined diagnostic must name BOTH.
+#[tokio::test]
+async fn adzuna_and_jooble_both_failing_combines_both_names() {
+    let providers: Vec<Box<dyn JobProvider>> = vec![
+        Box::new(FakeProvider::err("adzuna", "adzuna down")),
+        Box::new(FakeProvider::unconfigured("jsearch")),
+        Box::new(FakeProvider::err("jooble", "jooble upstream 500")),
+    ];
+
+    let result = search_with_providers(
+        &providers,
+        "engineer",
+        "berlin",
+        "de",
+        false,
+        None,
+        100,
+        make_token(),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "two configured providers failing must surface Err, not silent Ok(empty)"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("adzuna down"),
+        "combined diagnostic must name Adzuna's failure; got: {msg}"
+    );
+    assert!(
+        msg.contains("jooble upstream 500"),
+        "combined diagnostic must name Jooble's failure, not drop it silently \
+         behind Adzuna's; got: {msg}"
+    );
+    assert!(
+        !msg.contains("add a JSearch key in Settings"),
+        "must not carry the stale 'add a JSearch key' nudge when Jooble is \
+         ALSO configured and already failing; got: {msg}"
     );
 }
 
@@ -2085,8 +2144,8 @@ async fn guessed_market_empty_with_location_and_no_jsearch_returns_diagnostic_er
         "diagnostic must NOT leak the raw user-entered location (PII); got: {msg}"
     );
     assert!(
-        msg.contains("add a JSearch key in Settings"),
-        "diagnostic error must include the actionable JSearch-remedy suffix; got: {msg}"
+        msg.contains("add a JSearch or Jooble key in Settings"),
+        "diagnostic error must include the actionable fallback-remedy suffix; got: {msg}"
     );
 }
 

--- a/apps/desktop/src-tauri/src/scraping/http/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/http/mod.rs
@@ -68,6 +68,14 @@ pub struct FetchOptions {
     /// Set it for third-party egresses that need a hard ceiling (e.g. the GitHub
     /// repo import) so a slow/stalled connection can't hang indefinitely.
     pub timeout: Option<Duration>,
+    /// When true, `fetch_json`'s non-2xx / schema-drift log lines omit the URL
+    /// PATH entirely (only scheme+host+port are logged). The default log-safe
+    /// URL strips the query string (where most callers' secrets live, e.g.
+    /// Adzuna's `app_key`) but keeps the path — that leaks a credential embedded
+    /// directly in the path instead, e.g. Jooble's `POST /api/{apiKey}`. Set this
+    /// for that shape so the key never reaches the logs, including on the exact
+    /// "bad key" 403 that would otherwise echo it straight back.
+    pub redact_path: bool,
 }
 
 impl Default for FetchOptions {
@@ -79,6 +87,7 @@ impl Default for FetchOptions {
             retries: 2,
             max_bytes: None,
             timeout: None,
+            redact_path: false,
         }
     }
 }
@@ -281,6 +290,27 @@ fn retry_after_ms(headers: &reqwest::header::HeaderMap) -> Option<u64> {
     Some(secs.saturating_mul(1_000).min(30_000))
 }
 
+/// Build the log-safe representation of a request URL: scheme + host + port,
+/// and the path UNLESS `redact_path` is set — never the query string or
+/// userinfo/fragment (those are where most callers' secrets live, e.g. Adzuna's
+/// `app_key`). `redact_path` additionally drops the path for the rarer shape
+/// where a caller embeds a secret directly IN the path instead of the query
+/// (e.g. Jooble's `POST /api/{apiKey}`), which the query-only redaction above
+/// doesn't cover. Pulled out of `fetch_json` so the redaction contract is
+/// independently unit-testable without a network call.
+fn safe_log_url(url: &str, redact_path: bool) -> String {
+    reqwest::Url::parse(url)
+        .map(|u| {
+            let port = u.port().map(|p| format!(":{p}")).unwrap_or_default();
+            let path = if redact_path { "" } else { u.path() };
+            match u.host_str() {
+                Some(host) => format!("{}://{}{}{}", u.scheme(), host, port, path),
+                None => format!("{}:{}", u.scheme(), path),
+            }
+        })
+        .unwrap_or_else(|_| "<unparseable-url>".to_string())
+}
+
 /// Fetch a URL and deserialize a 2xx JSON body into `T`.
 ///
 /// Failures are **representable** — a caller can tell these three apart:
@@ -298,6 +328,9 @@ pub async fn fetch_json<T: for<'de> serde::Deserialize<'de>>(
     opts: FetchOptions,
     signal: tokio_util::sync::CancellationToken,
 ) -> AppResult<T> {
+    // Captured before `opts` is moved into the `..opts` struct-update below.
+    let redact_path = opts.redact_path;
+
     // Merge `accept: application/json` into caller headers.
     // Caller-supplied headers win — if the caller already set an `accept` header we
     // leave it as-is; otherwise we prepend the JSON accept so fetch_text's broader
@@ -321,17 +354,7 @@ pub async fn fetch_json<T: for<'de> serde::Deserialize<'de>>(
     )
     .await?;
 
-    // Log scheme+host+port+path only — never query (may contain API
-    // secrets like Adzuna app_key) or userinfo/fragment.
-    let safe_url = reqwest::Url::parse(url)
-        .map(|u| {
-            let port = u.port().map(|p| format!(":{p}")).unwrap_or_default();
-            match u.host_str() {
-                Some(host) => format!("{}://{}{}{}", u.scheme(), host, port, u.path()),
-                None => format!("{}:{}", u.scheme(), u.path()),
-            }
-        })
-        .unwrap_or_else(|_| "<unparseable-url>".to_string());
+    let safe_url = safe_log_url(url, redact_path);
 
     if res.status_code < 200 || res.status_code >= 300 {
         log::warn!(

--- a/apps/desktop/src-tauri/src/scraping/http/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/http/test.rs
@@ -40,6 +40,38 @@ fn test_fetch_options_timeout_field_contract() {
     assert_eq!(with_timeout.retries, 2);
 }
 
+/// `redact_path: false` (the default) keeps the path — the shared query-only
+/// redaction is what protects the common case (Adzuna/Comeet-style secrets in
+/// the query string).
+#[test]
+fn test_safe_log_url_keeps_path_by_default() {
+    let url = "https://jooble.org/api/super-secret-key";
+    assert_eq!(
+        safe_log_url(url, false),
+        "https://jooble.org/api/super-secret-key"
+    );
+}
+
+/// `redact_path: true` — for endpoints that embed a secret directly in the URL
+/// PATH (e.g. Jooble's `POST /api/{apiKey}`) — must drop the path entirely so
+/// the credential never reaches a non-2xx / schema-drift log line.
+#[test]
+fn test_safe_log_url_redacts_path_when_requested() {
+    let url = "https://jooble.org/api/super-secret-key";
+    let redacted = safe_log_url(url, true);
+    assert_eq!(redacted, "https://jooble.org");
+    assert!(!redacted.contains("super-secret-key"));
+}
+
+/// Regression guard: the query string (Adzuna `app_key`, Comeet token, …) must
+/// never appear in the log-safe URL regardless of `redact_path`.
+#[test]
+fn test_safe_log_url_never_includes_query() {
+    let url = "https://api.adzuna.com/v1/api/jobs/de/search/1?app_key=secret123";
+    assert!(!safe_log_url(url, false).contains("secret123"));
+    assert!(!safe_log_url(url, true).contains("secret123"));
+}
+
 #[test]
 fn test_strip_html_basic() {
     let html = "<p>Hello <b>World</b></p>";

--- a/apps/desktop/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/AggregatorKeysSettings.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/AggregatorKeysSettings.test.tsx
@@ -111,9 +111,9 @@ function getPasswordInputs(container: HTMLElement) {
 // ── tests — not connected (default keyState = all false) ──────────────────
 
 describe('AggregatorKeysSettings — not connected', () => {
-  it('renders password inputs for all six key fields (incl. Comeet)', () => {
+  it('renders password inputs for all seven key fields (incl. Jooble, Comeet)', () => {
     const { container } = render(<AggregatorKeysSettings />);
-    expect(getPasswordInputs(container).length).toBe(6);
+    expect(getPasswordInputs(container).length).toBe(7);
   });
 
   it('Save buttons are disabled when inputs are empty', () => {
@@ -122,28 +122,61 @@ describe('AggregatorKeysSettings — not connected', () => {
     saveButtons.forEach((btn) => expect(btn).toBeDisabled());
   });
 
-  it('eye-toggle buttons have accessible names for all six fields', () => {
+  it('eye-toggle buttons have accessible names for all seven fields', () => {
     render(<AggregatorKeysSettings />);
     const eyeToggles = screen.getAllByRole('button', {
       name: 'settings.aiProvider.showKey',
     });
-    expect(eyeToggles.length).toBe(6);
+    expect(eyeToggles.length).toBe(7);
   });
 
   it('toggling the first eye-button switches that field from password to text', async () => {
     const user = userEvent.setup();
     const { container } = render(<AggregatorKeysSettings />);
 
-    expect(getPasswordInputs(container).length).toBe(6);
+    expect(getPasswordInputs(container).length).toBe(7);
 
     const toggles = screen.getAllByRole('button', { name: 'settings.aiProvider.showKey' });
     const firstToggle = toggles[0];
     if (!firstToggle) throw new Error('No eye-toggle found');
     await user.click(firstToggle);
 
-    expect(getPasswordInputs(container).length).toBe(5);
+    expect(getPasswordInputs(container).length).toBe(6);
     // actor-id input is always type="text"; toggled credential input adds a second.
     expect(Array.from(container.querySelectorAll('input[type="text"]')).length).toBe(2);
+  });
+
+  it('renders the Jooble field with its "get a free key" docs link', () => {
+    render(<AggregatorKeysSettings />);
+    expect(screen.getByText('settings.aggregatorKeys.joobleKey.label')).toBeInTheDocument();
+    expect(screen.getByText('jooble.org/api/about')).toBeInTheDocument();
+  });
+
+  it('calls setProviderKey with the Jooble slot on Save', async () => {
+    mockSetMutateAsync.mockClear();
+    const user = userEvent.setup();
+    render(<AggregatorKeysSettings />);
+
+    const label = screen.getByText('settings.aggregatorKeys.joobleKey.label');
+    const row = label.parentElement;
+    if (!row) throw new Error('Jooble field row not found');
+
+    const joobleInput = within(row).getByPlaceholderText(
+      'settings.aggregatorKeys.joobleKey.placeholder'
+    );
+    await user.type(joobleInput, 'my-jooble-key');
+
+    const joobleSave = within(row).getByRole('button', {
+      name: /settings\.aggregatorKeys\.save/i,
+    });
+    await user.click(joobleSave);
+
+    await waitFor(() =>
+      expect(mockSetMutateAsync).toHaveBeenCalledWith({
+        provider: PROVIDER_SLOTS.joobleKey,
+        apiKey: 'my-jooble-key',
+      })
+    );
   });
 
   it('calls setProviderKey with the correct slot and value on Save', async () => {

--- a/apps/desktop/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/preferences/AggregatorKeysSettings/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/services';
 
 const ADZUNA_DOCS_URL = 'https://developer.adzuna.com';
+const JOOBLE_DOCS_URL = 'https://jooble.org/api/about';
 
 // ── Credential key field (reused for every provider) ─────────────────────────
 
@@ -299,6 +300,29 @@ export function AggregatorKeysSettings() {
           removeConfirmTitleKey="settings.aggregatorKeys.jsearchKey.removeConfirmTitle"
           removeConfirmDescKey="settings.aggregatorKeys.jsearchKey.removeConfirmDesc"
         />
+
+        {/* Jooble — last-resort fallback fired only once Adzuna + JSearch both
+            come up empty/erroring (see aggregator/mod.rs: primary_chain). */}
+        <div className="space-y-1.5">
+          <AggregatorKeyField
+            slot={PROVIDER_SLOTS.joobleKey}
+            labelKey="settings.aggregatorKeys.joobleKey.label"
+            placeholderKey="settings.aggregatorKeys.joobleKey.placeholder"
+            connectedKey="settings.aggregatorKeys.joobleKey.connected"
+            removeConfirmTitleKey="settings.aggregatorKeys.joobleKey.removeConfirmTitle"
+            removeConfirmDescKey="settings.aggregatorKeys.joobleKey.removeConfirmDesc"
+          />
+          <p className="text-xs text-foreground/40">
+            {t('settings.aggregatorKeys.joobleKey.helper')}{' '}
+            <Button
+              variant="unstyled"
+              onClick={() => void openExternal.mutateAsync(JOOBLE_DOCS_URL)}
+              className="text-brand-soft/70 underline underline-offset-2 hover:text-brand-soft"
+            >
+              jooble.org/api/about
+            </Button>
+          </p>
+        </div>
 
         {/* Apify API token — credential slot for the LinkedIn (Apify) provider */}
         <AggregatorKeyField

--- a/packages/shared/src/provider-slots.ts
+++ b/packages/shared/src/provider-slots.ts
@@ -15,6 +15,10 @@ export const PROVIDER_SLOTS = {
   adzunaAppId: 'adzuna-app-id',
   adzunaAppKey: 'adzuna-app-key',
   jsearchKey: 'jsearch-key',
+  // Jooble API key — path-segment auth (`POST /api/{key}`) for the Jooble
+  // aggregator fallback provider (fires after Adzuna + JSearch both come up
+  // empty/erroring — see `aggregator/mod.rs: primary_chain`).
+  joobleKey: 'jooble-key',
   // Apify API token — Bearer auth for the LinkedIn (Apify) aggregator provider.
   apifyToken: 'apify-token',
   // Comeet board credentials — company UID + API token for the

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -708,6 +708,14 @@
         "removeConfirmTitle": "JSearch-Schlüssel entfernen?",
         "removeConfirmDesc": "Dadurch wird der gespeicherte JSearch-Schlüssel gelöscht. Der JSearch-Fallback wird deaktiviert, bis Sie ihn erneut hinzufügen."
       },
+      "joobleKey": {
+        "label": "Jooble-API-Schlüssel — optional",
+        "placeholder": "Jooble-API-Schlüssel einfügen…",
+        "connected": "Jooble-API-Schlüssel sicher gespeichert",
+        "removeConfirmTitle": "Jooble-API-Schlüssel entfernen?",
+        "removeConfirmDesc": "Dadurch wird der gespeicherte Jooble-API-Schlüssel gelöscht. Der Jooble-Fallback wird deaktiviert, bis Sie ihn erneut hinzufügen.",
+        "helper": "Jooble ist ein letzter Fallback, der nur genutzt wird, wenn Adzuna und JSearch beide keine Ergebnisse liefern. Einen kostenlosen Schlüssel erhalten Sie unter"
+      },
       "apifyToken": {
         "label": "Apify API-Token",
         "placeholder": "Apify API-Token einfügen…",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -708,6 +708,14 @@
         "removeConfirmTitle": "Remove JSearch key?",
         "removeConfirmDesc": "This deletes the saved JSearch key. The JSearch fallback will be disabled until you add it again."
       },
+      "joobleKey": {
+        "label": "Jooble API key — optional",
+        "placeholder": "Paste your Jooble API key…",
+        "connected": "Jooble API key stored securely",
+        "removeConfirmTitle": "Remove Jooble API key?",
+        "removeConfirmDesc": "This deletes the saved Jooble API key. The Jooble fallback will be disabled until you add it again.",
+        "helper": "Jooble is a last-resort fallback used only when Adzuna and JSearch both come up empty. Get a free key at"
+      },
       "apifyToken": {
         "label": "Apify API token",
         "placeholder": "Paste your Apify API token…",


### PR DESCRIPTION
## What

First of the P2 sourcing-depth PRs. Adds **Jooble** (jooble.org/api) as a new bring-your-own-key aggregator provider — **~67-country coverage vs Adzuna's ~19 markets**, directly patching the unsupported-country zero-jobs case.

- Wired as a **third fallback tier**: fires only when Adzuna AND JSearch come up unconfigured/empty/err, so it never hammers Jooble's undocumented quota on searches the primary chain already answers. JSearch `Ok(empty)` short-circuits before Jooble — symmetric with Adzuna's existing empty-means-stop rule (**both edges regression-tested**).
- New `JoobleProvider` modeled on JSearch; key from the `ai:jooble-key` keyring slot, degrades a read error to `None` (optional-key policy).
- Routes through `fetch_json` — inherits the trust-program's failure-representable fetch, 429/503 backoff, per-host rate limiting, and cancellation. Errors prefixed `jooble:`; `external_id` prefixed `jooble-` for dedup.
- **Security**: Jooble puts the API key in the URL *path*, so the error-log line would have leaked it on a bad-key 403 → added opt-in `FetchOptions.redact_path` + `safe_log_url()` that strips the path (default `false` = byte-identical for the 20+ existing callers). Key percent-encoded; query/location go in the POST body.
- Provider-slot contract + a settings `AggregatorKeyField` (en+de) with a "get a free key" link.

## Review

**scraping-applier-expert + tauri-security-reviewer: no HIGH/CRITICAL.** Security verified the credential-in-log fix airtight on every response path; domain confirmed the fallback wiring and trust-program non-regression.

**Note (needs a live key to confirm — deferred):** Jooble's real rate-limit/quota response shape is unverified. The failure-representable path handles a real 403/429 regardless; the one consistent-with-Adzuna/JSearch risk is if Jooble signals quota as `200 OK` empty rather than non-2xx (would short-circuit silently, same as the other providers' genuine-empty case). Worth a spot-check when you add a key.

## Validation

- 18 Jooble unit tests + full aggregator module (106) + http module — green; clippy clean; whole-graph typecheck + `@ajh/desktop` tests pass; `gen:ipc:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)