### PR TITLE
fix: parse jooble timezone-less timestamps instead of dropping posted_at

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
@@ -693,11 +693,22 @@ pub(super) fn map_jooble_job(j: JoobleJob, now: i64) -> Option<JobPosting> {
         source: "aggregator".to_string(),
         description: j.snippet.map(|d| html_to_markdown(&d)),
         requirements: None,
-        posted_at: j
-            .updated
-            .as_deref()
-            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-            .map(|dt| dt.timestamp_millis()),
+        // Jooble's real `updated` value has NO timezone offset (e.g.
+        // "2026-05-15T00:00:00.0000000") despite looking ISO-8601-ish, so plain
+        // RFC3339 parsing fails for every live job — `posted_at` silently stayed
+        // `None` for all of them. Try RFC3339 first (in case an entry ever does
+        // carry an offset), then fall back to a naive datetime — tolerant of
+        // Jooble's fractional-seconds-no-tz form — assumed UTC.
+        posted_at: j.updated.as_deref().and_then(|s| {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .ok()
+                .map(|dt| dt.timestamp_millis())
+                .or_else(|| {
+                    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
+                        .ok()
+                        .map(|ndt| ndt.and_utc().timestamp_millis())
+                })
+        }),
         captured_at: now,
         extra,
     })

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -652,6 +652,85 @@ fn jooble_response_maps_to_job_posting() {
     assert!(posting.posted_at.unwrap() > 0);
 }
 
+/// Jooble's REAL live `updated` value has NO timezone offset despite looking
+/// ISO-8601-ish (e.g. "2026-05-15T00:00:00.0000000", 7-digit fraction) — a
+/// live-key test found `parse_from_rfc3339` returns `None` for every real
+/// Jooble job with this shape. The naive-datetime fallback (assumed UTC) must
+/// recover it.
+#[test]
+fn jooble_updated_without_timezone_parses_as_utc() {
+    let job = JoobleJob {
+        id: Some("no-tz".to_string()),
+        title: Some("No-TZ job".to_string()),
+        company: None,
+        location: None,
+        snippet: None,
+        salary: None,
+        link: Some("https://jooble.org/desc/no-tz".to_string()),
+        updated: Some("2026-05-15T00:00:00.0000000".to_string()),
+    };
+    let posting = map_jooble_job(job, 0).unwrap();
+
+    let expected = chrono::NaiveDate::from_ymd_opt(2026, 5, 15)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp_millis();
+    assert_eq!(
+        posting.posted_at,
+        Some(expected),
+        "the naive-datetime (no-TZ) fallback must recover Jooble's real timestamp shape"
+    );
+}
+
+/// A TZ-bearing RFC3339 `updated` (in case an entry ever does carry an offset)
+/// must still parse via the FIRST branch, not the naive-datetime fallback.
+#[test]
+fn jooble_updated_with_timezone_still_parses_via_rfc3339() {
+    let job = JoobleJob {
+        id: Some("with-tz".to_string()),
+        title: Some("With-TZ job".to_string()),
+        company: None,
+        location: None,
+        snippet: None,
+        salary: None,
+        link: Some("https://jooble.org/desc/with-tz".to_string()),
+        updated: Some("2026-05-15T02:00:00+02:00".to_string()),
+    };
+    let posting = map_jooble_job(job, 0).unwrap();
+
+    let expected = chrono::NaiveDate::from_ymd_opt(2026, 5, 15)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp_millis();
+    assert_eq!(
+        posting.posted_at,
+        Some(expected),
+        "a TZ-bearing timestamp (+02:00, i.e. 00:00 UTC) must parse via RFC3339"
+    );
+}
+
+/// A malformed `updated` string matches neither branch → `posted_at` stays
+/// `None`, never a panic or a wrong guess.
+#[test]
+fn jooble_malformed_updated_yields_no_posted_at() {
+    let job = JoobleJob {
+        id: Some("bad-date".to_string()),
+        title: Some("Bad-date job".to_string()),
+        company: None,
+        location: None,
+        snippet: None,
+        salary: None,
+        link: Some("https://jooble.org/desc/bad-date".to_string()),
+        updated: Some("not-a-date".to_string()),
+    };
+    let posting = map_jooble_job(job, 0).unwrap();
+    assert_eq!(posting.posted_at, None);
+}
+
 /// Jooble's `id` can arrive as a bare integer — must parse and normalise to
 /// String (same shape as the Adzuna `id` regression this mirrors).
 #[test]


### PR DESCRIPTION
## What

Fast-follow to #618. Verified against the **live Jooble API** (with a real key): the `updated` field arrives as `2026-05-15T00:00:00.0000000` — **no timezone offset** — which `chrono::DateTime::parse_from_rfc3339` rejects. So `posted_at` was silently `None` for every real Jooble job (no dates, broken date-filtering). The unit-test fixtures used a well-formed RFC3339 timestamp and never caught it.

- `map_jooble_job` now tries RFC3339 first (in case any entry carries an offset), then falls back to a naive datetime assumed UTC, tolerant of Jooble's 7-digit-fraction/no-TZ form.
- Adzuna/JSearch parsing untouched.

## Tests

3 new cases beside the existing `map_jooble_job` mapping tests: the real no-TZ shape (`posted_at` = the correct UTC millis, computed via chrono not a magic number), a TZ-bearing RFC3339 shape (still parses via the first branch), and a malformed string (`None`, no panic). Full aggregator module: 113/113; clippy + `fmt --check` clean.

## Note

#618 merged before this fix landed, so it ships as a fast-follow. This is a live-key finding — the kind fixtures can't surface — so it's worth a spot-check that dates now populate when you next run a Jooble-fallback search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)