### PR TITLE
feat: bundle a verified company-to-ats-slug seed directory (data only)

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/ats_seed.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ats_seed.rs
@@ -1,0 +1,119 @@
+//! Curated company -> (ATS, slug) seed, live-verified 2026-07-11.
+//!
+//! Lets the company-scoped ATS boards (Greenhouse, Lever, Ashby,
+//! SmartRecruiters, Recruitee, Personio, Workable) be exercised without the
+//! user hand-typing a company slug. **Data + lookup only** — nothing here is
+//! wired into the scrape engine or autopilot yet; that's a follow-up PR.
+//!
+//! Quirks encoded per entry (see live-verify notes for detail — not
+//! re-checked by this module):
+//! - **Personio** — one TLD per company (`.de` OR `.com`); [`AtsSeedEntry::tld`]
+//!   is `Some` only for Personio entries, `None` everywhere else.
+//! - **Ashby** — slug casing is exact and must match the registered board
+//!   (e.g. `Linear`, `Perplexity`) — preserved verbatim, never lowercased.
+//! - **Lever** and **SmartRecruiters** slugs churn fastest (boards migrate
+//!   off or go dormant) — re-verify live before trusting a future update to
+//!   this table.
+
+/// One curated company -> ATS slug mapping.
+#[derive(Debug, Clone, Copy)]
+pub struct AtsSeedEntry {
+    pub company: &'static str,
+    /// Matches a [`crate::scraping::types::Scraper::id`] in the `SCRAPERS`
+    /// registry (`scraping/boards/mod.rs`) exactly.
+    pub ats: &'static str,
+    pub slug: &'static str,
+    /// Personio only: `"de"` or `"com"` — the company's single registered TLD.
+    pub tld: Option<&'static str>,
+    /// DACH (Germany/Austria/Switzerland) market flag.
+    pub dach: bool,
+}
+
+#[rustfmt::skip]
+static SEED: &[AtsSeedEntry] = &[
+    // Greenhouse (27) — boards-api.greenhouse.io/v1/boards/{slug}/jobs
+    AtsSeedEntry { company: "Stripe",           ats: "greenhouse", slug: "stripe",             tld: None, dach: false },
+    AtsSeedEntry { company: "Airbnb",           ats: "greenhouse", slug: "airbnb",             tld: None, dach: false },
+    AtsSeedEntry { company: "Coinbase",         ats: "greenhouse", slug: "coinbase",           tld: None, dach: false },
+    AtsSeedEntry { company: "Databricks",       ats: "greenhouse", slug: "databricks",         tld: None, dach: false },
+    AtsSeedEntry { company: "Dropbox",          ats: "greenhouse", slug: "dropbox",            tld: None, dach: false },
+    AtsSeedEntry { company: "GitLab",           ats: "greenhouse", slug: "gitlab",             tld: None, dach: false },
+    AtsSeedEntry { company: "Reddit",           ats: "greenhouse", slug: "reddit",             tld: None, dach: false },
+    AtsSeedEntry { company: "Cloudflare",       ats: "greenhouse", slug: "cloudflare",         tld: None, dach: false },
+    AtsSeedEntry { company: "Pinterest",        ats: "greenhouse", slug: "pinterest",          tld: None, dach: false },
+    AtsSeedEntry { company: "Figma",            ats: "greenhouse", slug: "figma",              tld: None, dach: false },
+    AtsSeedEntry { company: "Twilio",           ats: "greenhouse", slug: "twilio",             tld: None, dach: false },
+    AtsSeedEntry { company: "Asana",            ats: "greenhouse", slug: "asana",              tld: None, dach: false },
+    AtsSeedEntry { company: "Lyft",             ats: "greenhouse", slug: "lyft",               tld: None, dach: false },
+    AtsSeedEntry { company: "Instacart",        ats: "greenhouse", slug: "instacart",          tld: None, dach: false },
+    AtsSeedEntry { company: "Elastic",          ats: "greenhouse", slug: "elastic",            tld: None, dach: false },
+    AtsSeedEntry { company: "HelloFresh",       ats: "greenhouse", slug: "hellofresh",         tld: None, dach: true },
+    AtsSeedEntry { company: "Celonis",          ats: "greenhouse", slug: "celonis",            tld: None, dach: true },
+    AtsSeedEntry { company: "GetYourGuide",     ats: "greenhouse", slug: "getyourguide",       tld: None, dach: true },
+    AtsSeedEntry { company: "Contentful",       ats: "greenhouse", slug: "contentful",         tld: None, dach: true },
+    AtsSeedEntry { company: "N26",              ats: "greenhouse", slug: "n26",                tld: None, dach: true },
+    AtsSeedEntry { company: "Trade Republic",   ats: "greenhouse", slug: "traderepublicbank",  tld: None, dach: true },
+    AtsSeedEntry { company: "Bitpanda",         ats: "greenhouse", slug: "bitpanda",           tld: None, dach: true },
+    AtsSeedEntry { company: "SumUp",            ats: "greenhouse", slug: "sumup",              tld: None, dach: true },
+    AtsSeedEntry { company: "Cherry Ventures",  ats: "greenhouse", slug: "cherryventures",     tld: None, dach: true },
+    AtsSeedEntry { company: "Raisin",           ats: "greenhouse", slug: "raisin",             tld: None, dach: true },
+    AtsSeedEntry { company: "Flix (FlixBus)",   ats: "greenhouse", slug: "flix",               tld: None, dach: true },
+    AtsSeedEntry { company: "Staffbase",        ats: "greenhouse", slug: "staffbase",          tld: None, dach: true },
+
+    // Lever (4) — api.lever.co/v0/postings/{slug}?mode=json
+    AtsSeedEntry { company: "Palantir Technologies", ats: "lever", slug: "palantir",    tld: None, dach: false },
+    AtsSeedEntry { company: "Spotify",               ats: "lever", slug: "spotify",     tld: None, dach: false },
+    AtsSeedEntry { company: "Veeva Systems",         ats: "lever", slug: "veeva",       tld: None, dach: false },
+    AtsSeedEntry { company: "Sword Health",          ats: "lever", slug: "swordhealth", tld: None, dach: false },
+
+    // Ashby (9) — api.ashbyhq.com/posting-api/job-board/{slug} (slug casing matters)
+    AtsSeedEntry { company: "OpenAI",       ats: "ashby", slug: "openai",     tld: None, dach: false },
+    AtsSeedEntry { company: "Notion",       ats: "ashby", slug: "notion",     tld: None, dach: false },
+    AtsSeedEntry { company: "Linear",       ats: "ashby", slug: "Linear",     tld: None, dach: false },
+    AtsSeedEntry { company: "Ramp",         ats: "ashby", slug: "ramp",       tld: None, dach: false },
+    AtsSeedEntry { company: "PostHog",      ats: "ashby", slug: "posthog",    tld: None, dach: false },
+    AtsSeedEntry { company: "Supabase",     ats: "ashby", slug: "supabase",   tld: None, dach: false },
+    AtsSeedEntry { company: "Perplexity AI",ats: "ashby", slug: "Perplexity", tld: None, dach: false },
+    AtsSeedEntry { company: "ElevenLabs",   ats: "ashby", slug: "elevenlabs", tld: None, dach: false },
+    AtsSeedEntry { company: "Cohere",       ats: "ashby", slug: "cohere",     tld: None, dach: false },
+
+    // SmartRecruiters (4) — api.smartrecruiters.com/v1/companies/{slug}/postings
+    AtsSeedEntry { company: "Bosch",        ats: "smartrecruiters", slug: "BoschGroup",   tld: None, dach: true },
+    AtsSeedEntry { company: "Continental",  ats: "smartrecruiters", slug: "Continental",  tld: None, dach: true },
+    AtsSeedEntry { company: "Ubisoft",      ats: "smartrecruiters", slug: "Ubisoft2",     tld: None, dach: false },
+    AtsSeedEntry { company: "Visa",         ats: "smartrecruiters", slug: "Visa",         tld: None, dach: false },
+
+    // Recruitee (5) — {slug}.recruitee.com/api/offers/
+    AtsSeedEntry { company: "Fastned",   ats: "recruitee", slug: "fastned",       tld: None, dach: false },
+    AtsSeedEntry { company: "Fixico",    ats: "recruitee", slug: "fixico",        tld: None, dach: false },
+    AtsSeedEntry { company: "Skytree",   ats: "recruitee", slug: "skytree",       tld: None, dach: false },
+    AtsSeedEntry { company: "Makersite", ats: "recruitee", slug: "makersitegmbh", tld: None, dach: true },
+    AtsSeedEntry { company: "AIHR",      ats: "recruitee", slug: "aihr",          tld: None, dach: false },
+
+    // Personio (7, all DACH) — {slug}.jobs.personio.{de|com}/
+    AtsSeedEntry { company: "Jung von Matt",         ats: "personio", slug: "jungvonmatt",          tld: Some("de"),  dach: true },
+    AtsSeedEntry { company: "Audi Formula Racing",   ats: "personio", slug: "audi-formula-racing",  tld: Some("de"),  dach: true },
+    AtsSeedEntry { company: "lavera / Laverana",     ats: "personio", slug: "lavera",               tld: Some("de"),  dach: true },
+    AtsSeedEntry { company: "deskbird",              ats: "personio", slug: "deskbird",             tld: Some("com"), dach: true },
+    AtsSeedEntry { company: "Cardmarket",            ats: "personio", slug: "cardmarket",           tld: Some("com"), dach: true },
+    AtsSeedEntry { company: "Athereon GRC",          ats: "personio", slug: "athereon",             tld: Some("com"), dach: true },
+    AtsSeedEntry { company: "Groß & Partner",        ats: "personio", slug: "gross-und-partner",    tld: Some("de"),  dach: true },
+
+    // Workable (3) — POST-only, apply.workable.com/api/v3/accounts/{slug}/jobs
+    AtsSeedEntry { company: "Startups.com", ats: "workable", slug: "startups",     tld: None, dach: false },
+    AtsSeedEntry { company: "500 Global",   ats: "workable", slug: "500startups",  tld: None, dach: false },
+    AtsSeedEntry { company: "atmio",        ats: "workable", slug: "atmio",        tld: None, dach: true },
+];
+
+/// All curated entries, in source (per-ATS-block) order.
+pub fn all() -> &'static [AtsSeedEntry] {
+    SEED
+}
+
+/// Entries for one ATS board id (e.g. `"greenhouse"`), in source order.
+pub fn by_ats(board_id: &str) -> impl Iterator<Item = &'static AtsSeedEntry> + use<'_> {
+    SEED.iter().filter(move |e| e.ats == board_id)
+}
+
+#[cfg(test)]
+mod test;

--- a/apps/desktop/src-tauri/src/scraping/boards/ats_seed/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ats_seed/test.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+#[test]
+fn table_is_non_empty_and_every_entry_has_required_fields() {
+    let entries = all();
+    assert!(!entries.is_empty(), "seed table must not be empty");
+    for e in entries {
+        assert!(!e.company.is_empty(), "entry has empty company: {e:?}");
+        assert!(!e.ats.is_empty(), "entry has empty ats: {e:?}");
+        assert!(!e.slug.is_empty(), "entry has empty slug: {e:?}");
+    }
+}
+
+/// Locks the curated count so a partial paste/merge mistake trips a test
+/// instead of silently shipping fewer rows than verified.
+#[test]
+fn table_has_the_verified_entry_count() {
+    assert_eq!(all().len(), 59, "expected 59 verified seed entries");
+}
+
+// ---------------------------------------------------------------------------
+// `ats` must route to a real board — cross-checked against the live registry,
+// not a hardcoded copy of the id list, so a future SCRAPERS rename trips this.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_ats_value_matches_a_registered_scraper_id() {
+    let registered: std::collections::HashSet<&str> = crate::scraping::boards::all()
+        .iter()
+        .map(|s| s.id())
+        .collect();
+    for e in all() {
+        assert!(
+            registered.contains(e.ats),
+            "seed entry '{}' has ats '{}' which is not a registered SCRAPERS id",
+            e.company,
+            e.ats
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Personio TLD quirk
+// ---------------------------------------------------------------------------
+
+#[test]
+fn personio_entries_have_tld_others_dont() {
+    for e in all() {
+        if e.ats == "personio" {
+            assert!(
+                e.tld.is_some(),
+                "personio entry '{}' must have a tld",
+                e.company
+            );
+        } else {
+            assert!(
+                e.tld.is_none(),
+                "non-personio entry '{}' must not have a tld",
+                e.company
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DACH coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dach_count_is_at_least_twenty() {
+    let dach = all().iter().filter(|e| e.dach).count();
+    assert!(dach >= 20, "expected >= 20 DACH entries, got {dach}");
+}
+
+// ---------------------------------------------------------------------------
+// by_ats
+// ---------------------------------------------------------------------------
+
+#[test]
+fn by_ats_greenhouse_and_personio_are_non_empty() {
+    assert!(
+        by_ats("greenhouse").count() > 0,
+        "expected >=1 greenhouse entry"
+    );
+    assert!(
+        by_ats("personio").count() > 0,
+        "expected >=1 personio entry"
+    );
+}
+
+#[test]
+fn by_ats_only_returns_matching_entries() {
+    for e in by_ats("lever") {
+        assert_eq!(e.ats, "lever");
+    }
+    assert!(by_ats("not-a-real-board").next().is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Uniqueness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_duplicate_ats_slug_pairs() {
+    let mut seen = std::collections::HashSet::new();
+    for e in all() {
+        let key = (e.ats, e.slug);
+        assert!(seen.insert(key), "duplicate (ats, slug) pair: {key:?}");
+    }
+}

--- a/apps/desktop/src-tauri/src/scraping/boards/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/mod.rs
@@ -2,6 +2,9 @@ pub mod aggregator;
 pub mod arbeitnow;
 pub mod arbeitsagentur;
 pub mod ashby;
+/// Curated company -> (ATS, slug) seed data + lookup. Not a `Scraper` — not
+/// registered in `SCRAPERS`; a later wiring PR routes these into search input.
+pub mod ats_seed;
 pub mod bamboohr;
 pub mod berlinstartupjobs;
 pub mod breezy;


### PR DESCRIPTION
## What

P2 step 2 (after #618 Jooble). Bundles a curated, **live-verified (2026-07-11)** seed of **59 companies → (ATS, slug)** across greenhouse/lever/ashby/smartrecruiters/recruitee/personio/workable — **23 of them DACH** — so the existing ATS-direct scrapers can be exercised without the user hand-typing company slugs (they mostly don't know them).

- New `scraping/boards/ats_seed` module: `AtsSeedEntry { company, ats, slug, tld, dach }` + a static `SEED` table + `all()` / `by_ats()` lookups. **Data only** — NOT added to `SCRAPERS`, no engine/autopilot wiring yet (that's the next PR).
- The `ats` ids are **cross-checked against the live `Scraper::id()` registry in tests**, not a hardcoded copy — so a future board-id rename trips the test.
- Verified quirks encoded as data: Personio `.de`/`.com` TLD per company; Ashby slug casing preserved verbatim (`Linear`, `Perplexity`).
- Doc note flags Lever/SmartRecruiters slug churn → periodic re-verify.

## Review

scraping-applier-expert: **no HIGH/CRITICAL** — purity, registry cross-check, quirk encoding, and dedup-free table all verified (via branch-relative diff). Two informational notes only (a Rust 1.82+ iterator-capture syntax CI's stable toolchain handles, and an intentional `>= 20` DACH floor).

## Validation

8 unit tests (count locked, no duplicate (ats,slug), tld invariant, registry cross-check, by_ats hits/misses); `cargo check --tests` + clippy + `fmt --check` clean.

Next PR wires this seed into the engine + autopilot so unattended runs gain ATS-direct coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)