### PR TITLE
feat: mutual hmac handshake for the extension bridge (protocol v2)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,22 @@
+# Gitleaks configuration.
+#
+# `[extend] useDefault = true` keeps the ENTIRE default ruleset (this file is only
+# consulted when present; absent → gitleaks uses its defaults). The allowlist below
+# adds narrow, value-scoped exceptions for deterministic test fixtures that only LOOK
+# like secrets — it never disables a rule or excludes a path, so a real secret
+# anywhere (including the same files) is still caught.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Deterministic known-answer test fixtures — fake values, not real secrets"
+regexTarget = "match"
+# The extension⇄desktop bridge HMAC handshake ships a cross-implementation known-answer
+# vector (a fixed, obviously-fake pairing token + nonces → expected proofs) so the Rust
+# (`hmac` crate) and TypeScript (Web Crypto) HMAC canonicalizations are pinned byte-for-
+# byte (packages/shared/src/ipc/extension-protocol-constants.ts, and the Rust KAT in
+# extension_bridge/handshake.rs). The fake token trips gitleaks' generic high-entropy
+# `token:` rule. Allowlist that one literal only.
+regexes = [
+  '''0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef''',
+]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -106,7 +106,6 @@ dependencies = [
  "flate2",
  "futures",
  "hmac 0.12.1",
- "hmac 0.13.0",
  "htmd",
  "image",
  "keyring-core",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "feed-rs",
  "flate2",
  "futures",
+ "hmac 0.12.1",
  "hmac 0.13.0",
  "htmd",
  "image",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -175,6 +175,13 @@ aes-gcm = "0.10"
 # deterministic, restart-stable hash so a stale or wrong-language cache row is a
 # natural miss. Resolves to 0.10.9 already in the tree (lopdf/tauri-codegen).
 sha2 = "0.10"
+# HMAC-SHA256 for the extension-bridge v2 mutual challenge-response handshake
+# (extension_bridge/handshake.rs): constant-time `Mac::verify_slice` of the
+# client proof, keyed by the pairing token's UTF-8 bytes. Cross-platform (the
+# `hmac = "0.13"` under `[target.'cfg(unix)']` pairs with sha1/digest-0.11 for
+# Chromium cookie PBKDF2 and is NOT usable with sha2 0.10 / digest-0.10 here).
+# 0.12.1 is already resolved in the lock and shares digest 0.10 with sha2 0.10.
+hmac = "0.12"
 htmd = "0.5.4"
 
 [target.'cfg(windows)'.dependencies]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -217,7 +217,14 @@ aes = "0.9"
 # macOS/Linux release build fails to compile (the path is `cfg(not(windows))`,
 # so it never surfaces in a Windows dev build).
 cbc = { version = "0.2", features = ["alloc", "block-padding"] }
-hmac = "0.13"
+# No direct `hmac` dep here — this crate never calls `hmac::` itself (only
+# `pbkdf2::pbkdf2_hmac::<Sha1>`, below); `pbkdf2`'s own `hmac` feature pulls
+# hmac 0.13 in transitively. A direct `hmac = "0.13"` here used to collide with
+# the top-level `hmac = "0.12"` (extension-bridge handshake HMAC) in the extern
+# prelude under `--all-features` (E0464: multiple candidates for `hmac`) — two
+# DIRECT deps of the same name are ambiguous even on disjoint cfg targets, since
+# `--all-features`/lockstep tooling can materialize both. Removing this direct
+# entry leaves exactly one `hmac` in the direct-dependency namespace.
 pbkdf2 = { version = "0.13", default-features = false, features = ["hmac"] }
 sha1 = "0.11"
 

--- a/apps/desktop/src-tauri/src/extension_bridge/auth.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/auth.rs
@@ -33,19 +33,21 @@ pub const ALLOWED_EXTENSION_IDS: &[&str] = &[
 /// loopback bridge. The host is our OWN native process (spawned by the browser,
 /// our exe in `--native-host` mode) bridging stdio → `ws://127.0.0.1`, so it has
 /// no `chrome-extension://`/`moz-extension://` origin of its own. Accepting this
-/// sentinel is defense-in-depth only: the real boundary stays the per-frame
-/// 256-bit pairing token over the loopback-only listener, which the host relays
-/// through unchanged.
+/// sentinel is defense-in-depth only: the real boundary is the v2 mutual HMAC
+/// handshake ([`super::handshake::verify_client_proof`]) over the loopback-only
+/// listener, which the host relays through unchanged.
 pub const NATIVE_HOST_ORIGIN: &str = "ajh-native-host";
 
 /// Whether a handshake `Origin` is an allowed extension origin.
 ///
 /// This check is **defense-in-depth, not the primary boundary**. The real
-/// authentication is the per-frame 256-bit pairing token enforced in
-/// [`super::classify_frame`] (every envelope token must equal `state.token()`),
-/// over a loopback-only (`127.0.0.1`) listener. The token is copied by the user
-/// from the app Settings and a sibling extension cannot read it, so even a local
-/// extension that opens a socket cannot import anything without it.
+/// authentication is the v2 mutual HMAC challenge-response
+/// ([`super::advance_frame`] drives it; [`super::handshake::verify_client_proof`]
+/// does the **constant-time** proof check) over a loopback-only (`127.0.0.1`)
+/// listener — the pairing token is used only as an HMAC key and is NEVER sent on
+/// the wire. The token is copied by the user from the app Settings and a sibling
+/// extension cannot read it, so even a local extension that opens a socket
+/// cannot import anything without proving it knows the token.
 ///
 /// Acceptance:
 /// - **Dev override** (checked first): any exact-match `dev_origins` entry (a
@@ -55,7 +57,7 @@ pub const NATIVE_HOST_ORIGIN: &str = "ajh-native-host";
 /// - **Firefox**: `moz-extension://<uuid>` where `<uuid>` is a well-formed
 ///   extension UUID ([`is_extension_uuid`]). The Firefox per-install UUID is
 ///   unknowable in advance, so the origin check can only assert scheme + UUID
-///   shape; the pairing token is what actually authenticates.
+///   shape; the mutual handshake is what actually authenticates.
 ///
 /// In all cases the origin must be scheme + host only — a trailing path or any
 /// extra slash segment is rejected.
@@ -73,15 +75,15 @@ pub fn is_allowed_origin(origin: &str, dev_origins: &[String]) -> bool {
     // UUID rather than leak it (Bugzilla 1607936 / 1257989). So the real Firefox
     // bridge handshake arrives as `null`, NOT `moz-extension://<uuid>`. Accept
     // it: the origin gate is defense-in-depth only — the actual boundary is the
-    // per-frame 256-bit pairing token over a loopback-only (`127.0.0.1`)
-    // listener, which a null-origin page cannot satisfy without the token the
+    // v2 mutual HMAC handshake over a loopback-only (`127.0.0.1`) listener, which
+    // a null-origin page cannot satisfy without proving it knows the token the
     // user copied from the app's Settings.
     if origin == "null" {
         return true;
     }
     // Native-messaging host (our own native process relaying to the loopback
-    // bridge — see `NATIVE_HOST_ORIGIN`). Exact match only; the per-frame token +
-    // loopback binding remain the real boundary.
+    // bridge — see `NATIVE_HOST_ORIGIN`). Exact match only; the mutual handshake
+    // + loopback binding remain the real boundary.
     if origin == NATIVE_HOST_ORIGIN {
         return true;
     }
@@ -180,7 +182,7 @@ mod tests {
         // extension background script — it strips the moz-extension UUID rather
         // than leak it (Bugzilla 1607936 / 1257989). This is the REAL Firefox
         // bridge handshake (NOT `moz-extension://<uuid>`). The origin gate is
-        // defense-in-depth only; the per-frame 256-bit pairing token over a
+        // defense-in-depth only; the v2 mutual HMAC handshake over a
         // loopback-only listener is the actual boundary.
         assert!(is_allowed_origin("null", &[]));
         // Leading/trailing whitespace is trimmed before the check.
@@ -199,7 +201,7 @@ mod tests {
     fn allows_native_host_sentinel_origin() {
         // Our native-messaging host relays to the loopback bridge with this
         // sentinel Origin (it has no extension origin of its own). Accepted
-        // (defense-in-depth); the per-frame token is the real boundary.
+        // (defense-in-depth); the v2 mutual HMAC handshake is the real boundary.
         assert!(is_allowed_origin(NATIVE_HOST_ORIGIN, &[]));
         assert!(is_allowed_origin("ajh-native-host", &[]));
         // Leading/trailing whitespace is trimmed before the check.

--- a/apps/desktop/src-tauri/src/extension_bridge/handshake.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/handshake.rs
@@ -1,0 +1,253 @@
+//! Extension-bridge v2 mutual HMAC challenge-response — the crypto core.
+//!
+//! The pairing token NEVER goes on the wire in v2. Instead both sides prove they
+//! know it via `HMAC-SHA256(key = token's UTF-8 bytes, msg = a canonical,
+//! domain-separated string)`:
+//!
+//! 1. Extension → `hello { protocol: 2, clientNonce }`
+//! 2. Desktop   → `challenge { serverNonce }`
+//! 3. Extension → `auth { proof }` — `proof = HMAC(token, CLIENT_MSG)`
+//! 4. Desktop verifies `proof` **constant-time**, then → `auth.ok { serverProof }`
+//!    where `serverProof = HMAC(token, SERVER_MSG)`
+//! 5. Extension verifies `serverProof` **constant-time** (mutual auth).
+//!
+//! The message string ([`handshake_message`]) is byte-identical to the TS side
+//! (`packages/shared/src/ipc/extension-protocol-constants.ts::handshakeMessage`);
+//! a shared known-answer vector pins both so the two canonicalizations can never
+//! silently drift. Pure functions, no I/O, no app state — fully unit-testable.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Domain-separation prefix (bumped with the protocol version). MUST equal the TS
+/// `HANDSHAKE_DOMAIN`.
+pub const DOMAIN: &str = "ajh-bridge/v2";
+
+/// The client proves in step 3.
+pub const ROLE_CLIENT: &str = "client";
+/// The server proves in step 4.
+pub const ROLE_SERVER: &str = "server";
+
+/// Nonce length on the wire: 16 random bytes → 32 lowercase-hex chars.
+const NONCE_BYTES: usize = 16;
+const NONCE_HEX_LEN: usize = NONCE_BYTES * 2;
+
+/// Build the canonical, domain-separated message both sides HMAC. Byte-for-byte
+/// identical to the TS `handshakeMessage`:
+/// `ajh-bridge/v2\n<role>\n<serverNonceHex>\n<clientNonceHex>`.
+pub fn handshake_message(role: &str, server_nonce: &str, client_nonce: &str) -> String {
+    format!("{DOMAIN}\n{role}\n{server_nonce}\n{client_nonce}")
+}
+
+/// A fresh 16-byte CSPRNG nonce as lowercase hex (32 chars). Never reused — one
+/// per connection. Mirrors [`super::new_token`]'s encoding.
+pub fn new_nonce() -> String {
+    use rand::Rng;
+    let mut bytes = [0u8; NONCE_BYTES];
+    rand::rng().fill_bytes(&mut bytes);
+    hex_encode(&bytes)
+}
+
+/// Whether `s` is a well-formed nonce we will accept from the peer: exactly
+/// [`NONCE_HEX_LEN`] lowercase-hex chars. Rejects junk (wrong length, uppercase,
+/// non-hex) before it reaches the HMAC.
+pub fn is_valid_nonce(s: &str) -> bool {
+    s.len() == NONCE_HEX_LEN
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
+}
+
+/// The client proof for step 3, lowercase hex. `key = token.as_bytes()`.
+pub fn client_proof(token: &str, server_nonce: &str, client_nonce: &str) -> String {
+    proof_hex(token, ROLE_CLIENT, server_nonce, client_nonce)
+}
+
+/// The server proof for step 4, lowercase hex. `key = token.as_bytes()`.
+pub fn server_proof(token: &str, server_nonce: &str, client_nonce: &str) -> String {
+    proof_hex(token, ROLE_SERVER, server_nonce, client_nonce)
+}
+
+/// Verify the client's step-3 `proof` (lowercase hex) **in constant time** via
+/// `Mac::verify_slice` — never a `==` on the tag. A malformed-hex proof is
+/// rejected (the hex is attacker-chosen, so decoding it is not a token oracle).
+#[must_use]
+pub fn verify_client_proof(
+    token: &str,
+    server_nonce: &str,
+    client_nonce: &str,
+    proof_hex: &str,
+) -> bool {
+    let Some(candidate) = hex_decode(proof_hex) else {
+        return false;
+    };
+    let mut mac = HmacSha256::new_from_slice(token.as_bytes())
+        .expect("HMAC-SHA256 accepts a key of any length");
+    mac.update(handshake_message(ROLE_CLIENT, server_nonce, client_nonce).as_bytes());
+    mac.verify_slice(&candidate).is_ok()
+}
+
+fn proof_hex(token: &str, role: &str, server_nonce: &str, client_nonce: &str) -> String {
+    let mut mac = HmacSha256::new_from_slice(token.as_bytes())
+        .expect("HMAC-SHA256 accepts a key of any length");
+    mac.update(handshake_message(role, server_nonce, client_nonce).as_bytes());
+    hex_encode(&mac.finalize().into_bytes())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Decode a lowercase-hex string to bytes, or `None` if it is not even-length
+/// lowercase hex. Not constant-time by design (the input is the caller-supplied,
+/// non-secret proof — only the final tag comparison must be constant-time).
+fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    let val = |b: u8| -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            _ => None,
+        }
+    };
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len() / 2);
+    for pair in bytes.chunks_exact(2) {
+        out.push((val(pair[0])? << 4) | val(pair[1])?);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Cross-implementation known-answer vector ───────────────────────────────
+    // These EXACT values are also asserted by the TS side
+    // (`apps/extension/src/lib/handshake.test.ts` via Web Crypto, and
+    // `packages/shared/.../extension-protocol-constants.ts::HANDSHAKE_TEST_VECTOR`).
+    // If the Rust (hmac crate) and TS (Web Crypto) byte-canonicalizations ever
+    // drift, one side's KAT fails loudly instead of the handshake silently never
+    // matching. DO NOT edit one side without recomputing the other.
+    const TOKEN: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const CLIENT_NONCE: &str = "00112233445566778899aabbccddeeff";
+    const SERVER_NONCE: &str = "ffeeddccbbaa99887766554433221100";
+    const CLIENT_PROOF: &str = "fe16f06234473b154c4e96d43bd25c603975cb2584f950d0d4f495edc5c44f1a";
+    const SERVER_PROOF: &str = "75c05269902c14d97ee61a05f4c9dbf812c532735b836665da250b19ce405831";
+
+    #[test]
+    fn handshake_message_is_canonical() {
+        assert_eq!(
+            handshake_message(ROLE_CLIENT, SERVER_NONCE, CLIENT_NONCE),
+            "ajh-bridge/v2\nclient\nffeeddccbbaa99887766554433221100\n00112233445566778899aabbccddeeff"
+        );
+        assert_eq!(
+            handshake_message(ROLE_SERVER, SERVER_NONCE, CLIENT_NONCE),
+            "ajh-bridge/v2\nserver\nffeeddccbbaa99887766554433221100\n00112233445566778899aabbccddeeff"
+        );
+    }
+
+    #[test]
+    fn kat_client_and_server_proofs_match_shared_vector() {
+        assert_eq!(
+            client_proof(TOKEN, SERVER_NONCE, CLIENT_NONCE),
+            CLIENT_PROOF,
+            "Rust client proof must equal the shared cross-impl vector"
+        );
+        assert_eq!(
+            server_proof(TOKEN, SERVER_NONCE, CLIENT_NONCE),
+            SERVER_PROOF,
+            "Rust server proof must equal the shared cross-impl vector"
+        );
+    }
+
+    #[test]
+    fn client_and_server_proofs_differ_by_role() {
+        // Domain separation: swapping the role must change the proof, so a client
+        // proof can never be replayed as a server proof (or vice versa).
+        assert_ne!(
+            client_proof(TOKEN, SERVER_NONCE, CLIENT_NONCE),
+            server_proof(TOKEN, SERVER_NONCE, CLIENT_NONCE)
+        );
+    }
+
+    #[test]
+    fn verify_accepts_the_correct_proof() {
+        assert!(verify_client_proof(
+            TOKEN,
+            SERVER_NONCE,
+            CLIENT_NONCE,
+            CLIENT_PROOF
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_a_tampered_or_wrong_proof() {
+        // A single flipped hex digit fails constant-time verification.
+        let mut tampered = CLIENT_PROOF.to_string();
+        tampered.replace_range(0..1, "0"); // 'f' → '0'
+        assert!(!verify_client_proof(
+            TOKEN,
+            SERVER_NONCE,
+            CLIENT_NONCE,
+            &tampered
+        ));
+        // The server proof is not a valid client proof (role mismatch).
+        assert!(!verify_client_proof(
+            TOKEN,
+            SERVER_NONCE,
+            CLIENT_NONCE,
+            SERVER_PROOF
+        ));
+        // A wrong token fails.
+        assert!(!verify_client_proof(
+            &"9".repeat(64),
+            SERVER_NONCE,
+            CLIENT_NONCE,
+            CLIENT_PROOF
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_malformed_hex() {
+        assert!(!verify_client_proof(TOKEN, SERVER_NONCE, CLIENT_NONCE, ""));
+        assert!(!verify_client_proof(
+            TOKEN,
+            SERVER_NONCE,
+            CLIENT_NONCE,
+            "xyz"
+        ));
+        // Odd length is not valid hex.
+        assert!(!verify_client_proof(
+            TOKEN,
+            SERVER_NONCE,
+            CLIENT_NONCE,
+            "abc"
+        ));
+        // Uppercase is rejected by the decoder (wire proofs are lowercase).
+        assert!(!verify_client_proof(
+            TOKEN,
+            SERVER_NONCE,
+            CLIENT_NONCE,
+            &CLIENT_PROOF.to_uppercase()
+        ));
+    }
+
+    #[test]
+    fn nonce_shape_and_freshness() {
+        let a = new_nonce();
+        let b = new_nonce();
+        assert_eq!(a.len(), NONCE_HEX_LEN);
+        assert!(is_valid_nonce(&a));
+        assert!(is_valid_nonce(&b));
+        assert_ne!(a, b, "each connection gets a fresh nonce");
+        // Rejects junk.
+        assert!(!is_valid_nonce(""));
+        assert!(!is_valid_nonce("tooshort"));
+        assert!(!is_valid_nonce(&"a".repeat(NONCE_HEX_LEN + 2)));
+        assert!(!is_valid_nonce("00112233445566778899AABBCCDDEEFF")); // uppercase
+    }
+}

--- a/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
@@ -4,9 +4,11 @@
 //! These tests are hermetic (no network). They exercise:
 //!  - `parse_from_html`: JSON-LD path (LinkedIn-style) and generic-meta path
 //!    (Indeed/Lever-style).
-//!  - `classify_frame`: the per-message security gate (size cap, per-frame token,
-//!    type dispatch) — empty/wrong token → `unauthorized` reply (no dispatch),
-//!    over-cap frame → close, SSRF private host blocked, non-JSON dropped.
+//!  - `advance_frame`: the v2 handshake state machine + per-message gate (size
+//!    cap, hello→challenge→auth mutual HMAC, session dispatch) — an outdated first
+//!    frame → `update_required` + close, a failed proof → close (never connected),
+//!    import/profile ONLY in the Authenticated state, over-cap → close, SSRF
+//!    private host blocked, non-JSON dropped.
 //!  - `upsert_for_origin`: saved/applied/dedup outcomes at the persistence
 //!    boundary (mirrors what `handle_import` calls in production).
 //!  - `normalize_job_url`: the exact dedup-key transforms (www/query/fragment/
@@ -18,7 +20,7 @@ use serde_json::json;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 
-use super::{classify_frame, BridgeState, FrameDecision, MAX_FRAME_BYTES};
+use super::{advance_frame, handshake, BridgeState, ConnState, FrameDecision, MAX_FRAME_BYTES};
 use crate::applications::{
     normalize_job_url, ApplicationOrigin, ApplicationStatus, ApplicationStore,
 };
@@ -535,100 +537,309 @@ fn persistence_matrix_reimport_with_applied_true_advances_saved_to_applied() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// B1. Per-frame token rejection (HIGH 1)
+// B1. v2 mutual-handshake state machine (the token-never-on-the-wire fix)
 //
-// `classify_frame` is the per-message security gate the connection loop runs
-// before any app-stateful work. A frame with an empty or wrong token must be
-// REJECTED with an `unauthorized` import.result reply and must NOT be classified
-// as an `Import` — so `handle_import` is never reached and NOTHING is persisted.
-// (handle_import is the only persistence path; a `Reply` decision can't reach it.)
+// `advance_frame` is the per-message gate the connection loop runs. The security
+// invariant: an `import.request` / `profile.get` is dispatched ONLY from the
+// `Authenticated` state (i.e. AFTER a verified client proof). A socket that has
+// not completed the handshake can NEVER reach `handle_import` — so nothing is
+// ever persisted for an unauthenticated peer.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// An empty `token` must be rejected as `unauthorized` and must not dispatch an
-/// import — even though the envelope is a well-formed `import.request`.
+/// A valid protocol-2 `hello` (with a well-formed clientNonce) is accepted:
+/// `Challenge` carrying a fresh `serverNonce`, advancing to `AwaitingAuth` bound
+/// to that nonce pair. NOT yet connected.
 #[test]
-fn frame_empty_token_is_unauthorized_and_persists_nothing() {
+fn hello_v2_is_accepted_and_advances_to_awaiting_auth() {
     let (_dir, state) = bridge_state();
+    let client_nonce = handshake::new_nonce();
 
     let frame = json!({
-        "token": "",
-        "reqId": "r-empty",
-        "type": super::msg::IMPORT_REQUEST,
-        "payload": { "url": "https://jobs.example.com/posting/1" }
+        "type": super::msg::HELLO,
+        "reqId": "r-hello",
+        "payload": { "protocol": super::PROTOCOL_VERSION, "clientNonce": client_nonce },
     })
     .to_string();
 
-    let decision = classify_frame(&state, &frame);
-    let reply = match decision {
-        FrameDecision::Unauthorized(text) => text,
-        other => panic!("empty token must produce an Unauthorized decision, got {other:?}"),
-    };
-    // An `Unauthorized` (not `Import`) means handle_import is never invoked → no
-    // persist; at the connection level it also closes the socket.
-    let err = reply_error(&reply).expect("empty token reply must carry an error");
-    assert!(!err.is_empty(), "unauthorized error must be non-empty");
-    assert!(
-        err.contains("unauthorized"),
-        "empty token must map to an unauthorized error, got {err:?}"
-    );
-    let parsed: serde_json::Value = serde_json::from_str(&reply).unwrap();
-    assert_eq!(
-        parsed.get("reqId").and_then(|r| r.as_str()),
-        Some("r-empty"),
-        "reply must echo the request id"
-    );
-}
-
-/// A wrong (non-matching) `token` must be rejected as `unauthorized` and must not
-/// dispatch an import.
-#[test]
-fn frame_wrong_token_is_unauthorized_and_persists_nothing() {
-    let (_dir, state) = bridge_state();
-    // A token that is the right shape but is NOT the state's secret.
-    let wrong = "f".repeat(64);
-    assert_ne!(
-        wrong,
-        state.token(),
-        "fixture must use a non-matching token"
-    );
-
-    let frame = json!({
-        "token": wrong,
-        "reqId": "r-wrong",
-        "type": super::msg::IMPORT_REQUEST,
-        "payload": { "url": "https://jobs.example.com/posting/2" }
-    })
-    .to_string();
-
-    match classify_frame(&state, &frame) {
-        FrameDecision::Unauthorized(reply) => {
-            let err = reply_error(&reply).expect("wrong token reply must carry an error");
+    match advance_frame(&state, &ConnState::AwaitingHello, &frame) {
+        FrameDecision::Challenge { reply, next } => {
+            let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+            assert_eq!(v["type"], super::msg::CHALLENGE);
+            assert_eq!(v["reqId"], "r-hello");
+            let server_nonce = v["payload"]["serverNonce"].as_str().unwrap();
             assert!(
-                err.contains("unauthorized"),
-                "wrong token must map to an unauthorized error, got {err:?}"
+                handshake::is_valid_nonce(server_nonce),
+                "challenge must carry a well-formed server nonce"
             );
+            match next {
+                ConnState::AwaitingAuth {
+                    server_nonce: sn,
+                    client_nonce: cn,
+                } => {
+                    assert_eq!(sn, server_nonce, "next state binds the sent server nonce");
+                    assert_eq!(cn, client_nonce, "next state binds the client nonce");
+                }
+                other => panic!("hello must advance to AwaitingAuth, got {other:?}"),
+            }
         }
-        other => panic!("wrong token must produce an Unauthorized decision, got {other:?}"),
+        other => panic!("a valid v2 hello must be Challenge, got {other:?}"),
     }
 }
 
-/// The matching token DOES classify an `import.request` as `Import` (positive
-/// control — proves the rejection tests above aren't passing for the wrong
-/// reason). The `Import` payload is forwarded verbatim to `handle_import`.
+/// A legacy `{type:'auth', token}` FIRST frame (an OLD extension) is `Outdated`:
+/// `update_required` reply then close — the force cutover, never an import.
 #[test]
-fn frame_correct_token_classifies_as_import() {
+fn legacy_auth_first_frame_is_outdated() {
     let (_dir, state) = bridge_state();
-    let token = state.token();
 
     let frame = json!({
-        "token": token,
-        "reqId": "r-ok",
+        "type": super::msg::AUTH,
+        "token": state.token(), // legacy plaintext token — must NOT authenticate
+        "reqId": "r-legacy",
+        "payload": serde_json::Value::Null,
+    })
+    .to_string();
+
+    match advance_frame(&state, &ConnState::AwaitingHello, &frame) {
+        FrameDecision::Outdated(reply) => {
+            let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+            assert_eq!(v["type"], super::msg::UPDATE_REQUIRED);
+            assert_eq!(v["reqId"], "r-legacy");
+            assert!(v["payload"]["error"].as_str().unwrap().contains("Update"));
+        }
+        other => panic!("a legacy token `auth` first frame must be Outdated, got {other:?}"),
+    }
+}
+
+/// A `hello` carrying a lower/older protocol is treated as an outdated client.
+#[test]
+fn hello_with_lower_protocol_is_outdated() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
+        "type": super::msg::HELLO,
+        "reqId": "r-old",
+        "payload": { "protocol": 1, "clientNonce": handshake::new_nonce() },
+    })
+    .to_string();
+    assert!(
+        matches!(
+            advance_frame(&state, &ConnState::AwaitingHello, &frame),
+            FrameDecision::Outdated(_)
+        ),
+        "protocol < 2 must be Outdated"
+    );
+}
+
+/// A `hello` with a malformed clientNonce (wrong shape) is rejected as outdated —
+/// junk never reaches the HMAC.
+#[test]
+fn hello_with_malformed_nonce_is_outdated() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
+        "type": super::msg::HELLO,
+        "reqId": "r-bad-nonce",
+        "payload": { "protocol": super::PROTOCOL_VERSION, "clientNonce": "not-hex!!" },
+    })
+    .to_string();
+    assert!(matches!(
+        advance_frame(&state, &ConnState::AwaitingHello, &frame),
+        FrameDecision::Outdated(_)
+    ));
+}
+
+/// An `import.request` in the AwaitingHello state is NEVER dispatched — it is an
+/// outdated first frame (not a hello). This is the core invariant: you cannot
+/// import before completing the handshake.
+#[test]
+fn import_before_handshake_is_not_dispatched() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
         "type": super::msg::IMPORT_REQUEST,
+        "reqId": "r-early",
+        "payload": { "url": "https://jobs.example.com/posting/early" },
+    })
+    .to_string();
+    match advance_frame(&state, &ConnState::AwaitingHello, &frame) {
+        FrameDecision::Outdated(_) => {}
+        other => panic!("an import.request before hello must NOT be an Import, got {other:?}"),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B1b. Handshake step 3: constant-time client-proof verification
+//
+// In the AwaitingAuth state, only an `auth { proof }` with a proof that verifies
+// constant-time against HMAC-SHA256(token, CLIENT_MSG) advances to Authenticated
+// (AuthOk, replying the server proof). A wrong/absent proof, or any non-auth
+// frame, closes the socket (Unauthorized) and never marks it connected.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Helper: the AwaitingAuth state for a fixed nonce pair, plus the CORRECT client
+/// proof the extension would compute for `state`'s token.
+fn awaiting_auth(state: &BridgeState) -> (ConnState, String) {
+    let server_nonce = handshake::new_nonce();
+    let client_nonce = handshake::new_nonce();
+    let proof = handshake::client_proof(&state.token(), &server_nonce, &client_nonce);
+    (
+        ConnState::AwaitingAuth {
+            server_nonce,
+            client_nonce,
+        },
+        proof,
+    )
+}
+
+/// A correct client proof advances to `AuthOk`: the reply is an `auth.ok`
+/// envelope whose `serverProof` equals `HMAC(token, SERVER_MSG)` for the bound
+/// nonces — so the extension can verify the desktop is genuine.
+#[test]
+fn correct_proof_yields_auth_ok_with_matching_server_proof() {
+    let (_dir, state) = bridge_state();
+    let (conn, proof) = awaiting_auth(&state);
+    let (server_nonce, client_nonce) = match &conn {
+        ConnState::AwaitingAuth {
+            server_nonce,
+            client_nonce,
+        } => (server_nonce.clone(), client_nonce.clone()),
+        _ => unreachable!(),
+    };
+
+    let frame = json!({
+        "type": super::msg::AUTH,
+        "reqId": "r-auth",
+        "payload": { "proof": proof },
+    })
+    .to_string();
+
+    match advance_frame(&state, &conn, &frame) {
+        FrameDecision::AuthOk(reply) => {
+            let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+            assert_eq!(v["type"], super::msg::AUTH_OK);
+            assert_eq!(v["reqId"], "r-auth");
+            let server_proof = v["payload"]["serverProof"].as_str().unwrap();
+            assert_eq!(
+                server_proof,
+                handshake::server_proof(&state.token(), &server_nonce, &client_nonce),
+                "the desktop must return the exact server proof the extension expects"
+            );
+        }
+        other => panic!("a correct client proof must be AuthOk, got {other:?}"),
+    }
+}
+
+/// A WRONG proof (right shape, wrong bytes) is `Unauthorized` — the socket closes
+/// and is never marked connected. This is the token-mismatch path (bad_token).
+#[test]
+fn wrong_proof_is_unauthorized() {
+    let (_dir, state) = bridge_state();
+    let (conn, _correct) = awaiting_auth(&state);
+    // A validly-shaped but wrong proof (all zeros).
+    let frame = json!({
+        "type": super::msg::AUTH,
+        "reqId": "r-bad",
+        "payload": { "proof": "0".repeat(64) },
+    })
+    .to_string();
+    assert!(matches!(
+        advance_frame(&state, &conn, &frame),
+        FrameDecision::Unauthorized
+    ));
+}
+
+/// An absent/empty proof is `Unauthorized` (never a panic, never connected).
+#[test]
+fn absent_proof_is_unauthorized() {
+    let (_dir, state) = bridge_state();
+    let (conn, _correct) = awaiting_auth(&state);
+    let frame = json!({
+        "type": super::msg::AUTH,
+        "reqId": "r-empty",
+        "payload": serde_json::Value::Null,
+    })
+    .to_string();
+    assert!(matches!(
+        advance_frame(&state, &conn, &frame),
+        FrameDecision::Unauthorized
+    ));
+}
+
+/// A non-auth frame in AwaitingAuth (e.g. an import.request trying to skip the
+/// proof) is `Unauthorized` — you cannot bypass step 3.
+#[test]
+fn non_auth_frame_mid_handshake_is_unauthorized() {
+    let (_dir, state) = bridge_state();
+    let (conn, _correct) = awaiting_auth(&state);
+    let frame = json!({
+        "type": super::msg::IMPORT_REQUEST,
+        "reqId": "r-skip",
+        "payload": { "url": "https://jobs.example.com/posting/skip" },
+    })
+    .to_string();
+    match advance_frame(&state, &conn, &frame) {
+        FrameDecision::Unauthorized => {}
+        other => panic!("an import.request mid-handshake must be Unauthorized, got {other:?}"),
+    }
+}
+
+/// End-to-end pure handshake: AwaitingHello --hello--> Challenge(next) ; feed the
+/// derived server+client nonces the REAL client proof --auth--> AuthOk. Proves the
+/// two-frame mutual handshake composes with the actual nonces the desktop issues.
+#[test]
+fn full_handshake_hello_then_auth_authenticates() {
+    let (_dir, state) = bridge_state();
+    let client_nonce = handshake::new_nonce();
+
+    let hello = json!({
+        "type": super::msg::HELLO,
+        "reqId": "h",
+        "payload": { "protocol": super::PROTOCOL_VERSION, "clientNonce": client_nonce },
+    })
+    .to_string();
+
+    let next = match advance_frame(&state, &ConnState::AwaitingHello, &hello) {
+        FrameDecision::Challenge { next, .. } => next,
+        other => panic!("hello must Challenge, got {other:?}"),
+    };
+    let server_nonce = match &next {
+        ConnState::AwaitingAuth { server_nonce, .. } => server_nonce.clone(),
+        _ => unreachable!(),
+    };
+
+    // The extension computes the client proof for the issued nonces.
+    let proof = handshake::client_proof(&state.token(), &server_nonce, &client_nonce);
+    let auth = json!({
+        "type": super::msg::AUTH,
+        "reqId": "a",
+        "payload": { "proof": proof },
+    })
+    .to_string();
+
+    assert!(
+        matches!(
+            advance_frame(&state, &next, &auth),
+            FrameDecision::AuthOk(_)
+        ),
+        "the real client proof for the issued nonces must authenticate"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B1c. Post-auth dispatch — import/profile ONLY in the Authenticated state
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// An authenticated `import.request` classifies as `Import` (positive control),
+/// carrying the payload verbatim to `handle_import`.
+#[test]
+fn authenticated_import_classifies_as_import() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
+        "type": super::msg::IMPORT_REQUEST,
+        "reqId": "r-ok",
         "payload": { "url": "https://jobs.example.com/posting/3" }
     })
     .to_string();
 
-    match classify_frame(&state, &frame) {
+    match advance_frame(&state, &ConnState::Authenticated, &frame) {
         FrameDecision::Import { req_id, payload } => {
             assert_eq!(req_id, "r-ok");
             assert_eq!(
@@ -636,254 +847,43 @@ fn frame_correct_token_classifies_as_import() {
                 Some("https://jobs.example.com/posting/3")
             );
         }
-        other => panic!("a valid token + import.request must classify as Import, got {other:?}"),
+        other => panic!("an authenticated import.request must be Import, got {other:?}"),
     }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// B1b. Connection-time `auth` frame (the wrong-token-never-connected fix)
-//
-// The extension sends an `auth` frame immediately after the socket opens to
-// verify the pairing before any import. A WRONG token must be `Unauthorized`
-// (reply carries the `unauthorized` error; the connection loop then closes the
-// socket and never marks it connected). A CORRECT token must be a `Reply` whose
-// `import.result` payload carries NO `error` (the extension reads "no error" =
-// authorized). The connection loop marks `connected` true only for `Reply` /
-// `Import` (token-validated), never for `Unauthorized`.
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// An `auth` frame with the WRONG token is `Unauthorized` (not `Reply`): the
-/// connection loop sends the reply then closes the socket and never marks it
-/// connected. This is the core fix — a wrong token is rejected at the handshake-
-/// adjacent first frame, never reported as connected/authorized.
+/// An authenticated `profile.get` classifies as `Profile`.
 #[test]
-fn auth_frame_wrong_token_is_unauthorized() {
+fn authenticated_profile_get_classifies_as_profile() {
     let (_dir, state) = bridge_state();
-    let wrong = "9".repeat(64);
-    assert_ne!(
-        wrong,
-        state.token(),
-        "fixture must use a non-matching token"
-    );
-
     let frame = json!({
-        "token": wrong,
-        "reqId": "r-auth-bad",
-        "type": super::msg::AUTH,
+        "type": super::msg::PROFILE_GET,
+        "reqId": "r-prof",
         "payload": serde_json::Value::Null,
     })
     .to_string();
-
-    match classify_frame(&state, &frame) {
-        FrameDecision::Unauthorized(reply) => {
-            let err = reply_error(&reply).expect("wrong-token auth reply must carry an error");
-            assert!(
-                err.contains("unauthorized"),
-                "wrong-token auth must map to an unauthorized error, got {err:?}"
-            );
-        }
-        other => panic!("an `auth` frame with a wrong token must be Unauthorized, got {other:?}"),
+    match advance_frame(&state, &ConnState::Authenticated, &frame) {
+        FrameDecision::Profile { req_id } => assert_eq!(req_id, "r-prof"),
+        other => panic!("an authenticated profile.get must be Profile, got {other:?}"),
     }
 }
 
-/// An `auth` frame with the CORRECT token is a `Reply` whose `import.result`
-/// payload contains NO `error` field — the extension treats "no error" as
-/// authorized. The `auth` frame does no import (empty fields), it only verifies
-/// the token.
+/// A reserved type in the Authenticated state gets an `import.result` error reply
+/// (never a panic).
 #[test]
-fn auth_frame_correct_token_replies_with_no_error() {
+fn authenticated_reserved_type_replies_with_error() {
     let (_dir, state) = bridge_state();
-    let token = state.token();
-
     let frame = json!({
-        "token": token,
-        "reqId": "r-auth-ok",
-        "type": super::msg::AUTH,
+        "type": super::msg::MATCH_LIVE,
+        "reqId": "r-reserved",
         "payload": serde_json::Value::Null,
     })
     .to_string();
-
-    match classify_frame(&state, &frame) {
+    match advance_frame(&state, &ConnState::Authenticated, &frame) {
         FrameDecision::Reply(reply) => {
-            assert!(
-                reply_error(&reply).is_none(),
-                "a correct-token auth reply must carry NO error (no error = authorized), got {reply}"
-            );
-            let parsed: serde_json::Value = serde_json::from_str(&reply).unwrap();
-            assert_eq!(
-                parsed.get("type").and_then(|t| t.as_str()),
-                Some(super::msg::IMPORT_RESULT),
-                "the auth ok reply reuses the import.result envelope"
-            );
-            assert_eq!(
-                parsed.get("reqId").and_then(|r| r.as_str()),
-                Some("r-auth-ok"),
-                "the auth reply must echo the request id"
-            );
+            let err = reply_error(&reply).expect("reserved type must carry an error");
+            assert!(err.contains("not implemented"), "got {err:?}");
         }
-        other => panic!("an `auth` frame with the correct token must be a Reply, got {other:?}"),
-    }
-}
-
-/// A wrong-token frame yields `Unauthorized` while a valid-token frame yields
-/// `Reply`/`Import` — and ONLY the latter two cause the connection loop to call
-/// `set_connected(true)`. `set_connected` lives in the async connection loop
-/// (not unit-reachable without a live socket), so we pin the classify-level
-/// variant split that drives it: `Unauthorized` (never connected) is a distinct
-/// variant from `Reply`/`Import` (connected). A fresh state is disconnected.
-#[test]
-fn unauthorized_variant_is_distinct_from_connecting_variants() {
-    let (_dir, state) = bridge_state();
-    assert!(
-        !state.is_connected(),
-        "a fresh bridge state is not connected until a token-validated frame arrives"
-    );
-
-    let bad = json!({
-        "token": "0".repeat(64),
-        "reqId": "r-bad",
-        "type": super::msg::AUTH,
-        "payload": serde_json::Value::Null,
-    })
-    .to_string();
-    assert!(
-        matches!(classify_frame(&state, &bad), FrameDecision::Unauthorized(_)),
-        "a wrong-token frame must classify as Unauthorized (loop never marks it connected)"
-    );
-
-    let ok = json!({
-        "token": state.token(),
-        "reqId": "r-ok",
-        "type": super::msg::AUTH,
-        "payload": serde_json::Value::Null,
-    })
-    .to_string();
-    assert!(
-        matches!(classify_frame(&state, &ok), FrameDecision::Reply(_)),
-        "a valid-token auth frame must classify as Reply (the loop marks it connected)"
-    );
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// B1c. classify_frame with absent / empty reqId
-//
-// When a frame's `reqId` field is absent OR is an empty string, `classify_frame`
-// defaults `req_id` to `""`. The reply is still emitted with `"reqId": ""`.
-//
-// KNOWN CORRELATION HAZARD: two concurrent requests both lacking `reqId` would
-// both receive `"reqId": ""` replies, making them indistinguishable on the
-// extension side. This is NOT fixed here — it is pinned as a documented behavior
-// so a future change (e.g. server-side reqId generation) has a test to land on.
-// Auth frames are normally sent one-at-a-time, so the hazard is advisory for now.
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// An `auth` frame whose `reqId` is ABSENT defaults `req_id` to `""`. The frame
-/// still classifies correctly (correct token → Reply, wrong token → Unauthorized)
-/// and the reply carries `"reqId": ""` rather than panicking or mis-routing to a
-/// non-existent request.
-#[test]
-fn classify_frame_auth_absent_req_id_defaults_to_empty_string() {
-    let (_dir, state) = bridge_state();
-    let token = state.token();
-
-    // Auth with correct token, NO reqId field at all.
-    let frame = json!({
-        "token": token,
-        "type": super::msg::AUTH,
-        "payload": serde_json::Value::Null,
-    })
-    .to_string();
-
-    match classify_frame(&state, &frame) {
-        FrameDecision::Reply(reply) => {
-            // Must not panic; error-free means "authorized".
-            assert!(
-                reply_error(&reply).is_none(),
-                "absent-reqId auth with correct token must reply with no error"
-            );
-            let parsed: serde_json::Value = serde_json::from_str(&reply).unwrap();
-            // PINNED BEHAVIOR: absent reqId → reply carries "reqId": "".
-            // If this assertion ever changes, the correlation-hazard comment above
-            // must be revisited (e.g. the bridge started generating its own reqId).
-            assert_eq!(
-                parsed.get("reqId").and_then(|r| r.as_str()),
-                Some(""),
-                "absent reqId must default the reply's reqId to empty string (pinned behavior)"
-            );
-        }
-        other => {
-            panic!("correct-token auth with absent reqId must classify as Reply, got {other:?}")
-        }
-    }
-}
-
-/// An `import.request` frame whose `reqId` is an empty string `""` is treated
-/// the same as absent — `req_id` is `""` and the `Import` decision carries it.
-/// This pins the correlation hazard: a reply for this request would have
-/// `"reqId": ""` and cannot be distinguished from another no-reqId import reply.
-#[test]
-fn classify_frame_import_empty_req_id_carries_empty_string() {
-    let (_dir, state) = bridge_state();
-    let token = state.token();
-
-    let frame = json!({
-        "token": token,
-        "reqId": "",  // explicitly empty — same as absent for correlation purposes
-        "type": super::msg::IMPORT_REQUEST,
-        "payload": { "url": "https://jobs.example.com/posting/empty-req" }
-    })
-    .to_string();
-
-    match classify_frame(&state, &frame) {
-        FrameDecision::Import { req_id, payload } => {
-            // PINNED BEHAVIOR: empty reqId passes through as "".
-            assert_eq!(
-                req_id, "",
-                "empty reqId must be carried as-is (empty string) into the Import decision"
-            );
-            assert_eq!(
-                payload.get("url").and_then(|u| u.as_str()),
-                Some("https://jobs.example.com/posting/empty-req")
-            );
-            // CORRELATION HAZARD (advisory, not a panic): `result_reply(&req_id, …)`
-            // will produce `"reqId": ""` — indistinguishable from any other empty-reqId
-            // reply. The extension always sets a non-empty reqId today, so this is
-            // defensive documentation rather than an active bug.
-        }
-        other => {
-            panic!("correct-token import with empty reqId must classify as Import, got {other:?}")
-        }
-    }
-}
-
-/// Wrong-token frame with ABSENT `reqId` still produces an Unauthorized reply
-/// (token gate runs before reqId is meaningful), and the reply carries `"reqId": ""`.
-#[test]
-fn classify_frame_unauthorized_absent_req_id_reply_carries_empty_string() {
-    let (_dir, state) = bridge_state();
-    let wrong = "a".repeat(64);
-    assert_ne!(wrong, state.token());
-
-    // No reqId field.
-    let frame = json!({
-        "token": wrong,
-        "type": super::msg::AUTH,
-        "payload": serde_json::Value::Null,
-    })
-    .to_string();
-
-    match classify_frame(&state, &frame) {
-        FrameDecision::Unauthorized(reply) => {
-            let err = reply_error(&reply).expect("unauthorized reply must carry an error");
-            assert!(err.contains("unauthorized"));
-            let parsed: serde_json::Value = serde_json::from_str(&reply).unwrap();
-            assert_eq!(
-                parsed.get("reqId").and_then(|r| r.as_str()),
-                Some(""),
-                "unauthorized reply with no reqId must echo empty string (pinned behavior)"
-            );
-        }
-        other => panic!("wrong-token + absent reqId must be Unauthorized, got {other:?}"),
+        other => panic!("a reserved type must be a Reply(error), got {other:?}"),
     }
 }
 
@@ -905,7 +905,8 @@ fn frame_over_size_cap_is_closed_without_dispatch() {
     let oversize = "a".repeat(MAX_FRAME_BYTES + 1);
     assert!(oversize.len() > MAX_FRAME_BYTES);
 
-    match classify_frame(&state, &oversize) {
+    // The size guard runs before parse/state — state-independent.
+    match advance_frame(&state, &ConnState::Authenticated, &oversize) {
         FrameDecision::CloseOverCap => {}
         other => panic!("an over-cap frame must be CloseOverCap, got {other:?}"),
     }
@@ -920,7 +921,7 @@ fn frame_exactly_at_cap_is_not_over_size() {
     assert_eq!(at_cap.len(), MAX_FRAME_BYTES);
 
     // Not over-cap → it is parsed; raw "aaa…" is not JSON → Drop (not CloseOverCap).
-    match classify_frame(&state, &at_cap) {
+    match advance_frame(&state, &ConnState::Authenticated, &at_cap) {
         FrameDecision::Drop => {}
         other => panic!("a frame exactly at the cap must parse (Drop here), got {other:?}"),
     }
@@ -931,29 +932,28 @@ fn frame_exactly_at_cap_is_not_over_size() {
 //
 // An authenticated import.request whose `url` is a private/loopback host must be
 // rejected by the SSRF gate `handle_import` applies (`is_safe_import_url`) before
-// any persistence. classify_frame correctly routes it to Import (auth passed);
+// any persistence. advance_frame (in the Authenticated state) routes it to Import;
 // we then assert the exact gate handle_import runs rejects the host, so nothing
 // is ever persisted.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// A private-host import URL passes the token gate (classified as Import) but is
+/// A private-host import URL classifies as Import (session-authenticated) but is
 /// blocked by the host SSRF guard handle_import applies before persisting.
 #[test]
 fn frame_private_host_import_is_blocked_by_ssrf_gate() {
     let (_dir, state) = bridge_state();
-    let token = state.token();
     let private_url = "http://192.168.1.1/job";
 
+    // v2: no token on the frame; the socket is already session-authenticated.
     let frame = json!({
-        "token": token,
         "reqId": "r-ssrf",
         "type": super::msg::IMPORT_REQUEST,
         "payload": { "url": private_url }
     })
     .to_string();
 
-    // Auth passes → Import; the URL is non-empty after normalization …
-    match classify_frame(&state, &frame) {
+    // Authenticated → Import; the URL is non-empty after normalization …
+    match advance_frame(&state, &ConnState::Authenticated, &frame) {
         FrameDecision::Import { payload, .. } => {
             let url = payload.get("url").and_then(|u| u.as_str()).unwrap();
             assert!(
@@ -976,7 +976,7 @@ fn frame_private_host_import_is_blocked_by_ssrf_gate() {
 #[test]
 fn frame_non_json_is_dropped() {
     let (_dir, state) = bridge_state();
-    match classify_frame(&state, "this is not json {") {
+    match advance_frame(&state, &ConnState::Authenticated, "this is not json {") {
         FrameDecision::Drop => {}
         other => panic!("non-JSON must Drop, got {other:?}"),
     }

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -17,15 +17,21 @@
 //!    unknowable in advance — see [`auth::is_allowed_origin`]. A dev override
 //!    (`platform::config::extension_dev_origins`) admits a locally-loaded
 //!    extension. The per-frame token (3) is what actually authenticates.
-//! 3. **Per-frame token** — every envelope carries the paired secret; a mismatch
-//!    is rejected with the `unauthorized` reply and closes the socket. The
-//!    extension verifies the pairing up front with an [`msg::AUTH`] frame sent
-//!    immediately after the socket opens (a token check with no payload): a
-//!    correct token gets an `import.result` reply with **no** `error`, a wrong
-//!    token gets the unauthorized reply and the socket is closed. The handshake
-//!    (1–2) alone does NOT mark the socket connected: `connected` flips true only
-//!    once a frame passes the token gate, so a wrong-token socket is never
-//!    reported as connected/authorized (see [`handle_connection`]).
+//! 3. **Mutual HMAC challenge-response (protocol v2)** — the pairing token is
+//!    NEVER transmitted. On connect the extension sends [`msg::HELLO`]
+//!    `{protocol, clientNonce}`; the desktop replies [`msg::CHALLENGE`]
+//!    `{serverNonce}`; the extension sends [`msg::AUTH`] `{proof}` where
+//!    `proof = HMAC-SHA256(token, CLIENT_MSG)`; the desktop verifies it
+//!    **constant-time** ([`handshake::verify_client_proof`]) and, on success,
+//!    replies [`msg::AUTH_OK`] `{serverProof}` (`HMAC-SHA256(token, SERVER_MSG)`)
+//!    so the extension can prove the desktop is genuine (not a port-squatter).
+//!    `connected` flips true ONLY once the client proof verifies — the WS
+//!    handshake and the `hello`/`challenge` exchange alone do NOT authorize.
+//!    After auth the socket is session-authenticated: `import.request` /
+//!    `profile.get` frames carry NO token (see [`advance_frame`]). A first frame
+//!    that is not a valid protocol-2 `hello` (an old extension's legacy
+//!    `{type:'auth', token}` frame, a lower protocol) gets [`msg::UPDATE_REQUIRED`]
+//!    and the socket closes — a hard cutover with no dual-support path.
 //! 4. **Size cap** — frames over [`MAX_FRAME_BYTES`] are rejected.
 //! 5. **URL/SSRF guard** — the imported `url` is normalized (http(s) only) and
 //!    run through [`auth::is_safe_public_host`] (rejects loopback/private/
@@ -57,6 +63,7 @@ use crate::error::{AppError, AppResult};
 use crate::events::{emit_event, APPLICATIONS_CHANGED};
 
 pub mod auth;
+pub mod handshake;
 #[cfg(test)]
 mod import_tests;
 pub mod native_host;
@@ -77,16 +84,28 @@ pub const NATIVE_HOST_MANIFEST: &str = "app.aijobhunter.bridge.json";
 /// in `packages/shared/src/ipc/extension-protocol.ts`. A parity test
 /// ([`test`]) pins these to the TS literals so the two can never drift.
 pub mod msg {
-    /// Connection-time token verification; no payload. The extension sends this
-    /// first frame right after the socket opens; the desktop replies with an
-    /// `import.result` envelope carrying no `error` on success (or the
-    /// unauthorized error reply on a bad token, after which the socket closes).
+    /// Handshake step 1 (extension → desktop): `{ protocol, clientNonce }`. NO
+    /// token — the proof (step 3) authenticates. Must be the FIRST frame.
+    pub const HELLO: &str = "hello";
+    /// Handshake step 2 (desktop → extension): `{ serverNonce }`.
+    pub const CHALLENGE: &str = "challenge";
+    /// Handshake step 3 (extension → desktop): `{ proof }` where
+    /// `proof = HMAC-SHA256(token, CLIENT_MSG)`. The token is NEVER on the wire
+    /// in v2; the desktop verifies `proof` constant-time (see [`super::handshake`]).
     pub const AUTH: &str = "auth";
+    /// Handshake step 4 (desktop → extension): `{ serverProof }` where
+    /// `serverProof = HMAC-SHA256(token, SERVER_MSG)` — the desktop proving IT
+    /// knows the token so the extension can reject a rogue/port-squatting peer.
+    pub const AUTH_OK: &str = "auth.ok";
+    /// Force-cutover reply (desktop → extension): sent, then the socket closes,
+    /// when a connection's first frame is not a valid protocol-2 `hello` (e.g. an
+    /// old extension's legacy `{type:'auth', token}` frame, or a lower protocol).
+    pub const UPDATE_REQUIRED: &str = "update.required";
     pub const IMPORT_REQUEST: &str = "import.request";
     pub const IMPORT_RESULT: &str = "import.result";
     /// Extension → desktop: fetch the contact profile for assisted autofill; no
-    /// payload (authed by the per-frame token). Returned only when the autofill
-    /// opt-in is on, else a refusal `error`.
+    /// payload (authed by the already-authenticated session). Returned only when
+    /// the autofill opt-in is on, else a refusal `error`.
     pub const PROFILE_GET: &str = "profile.get";
     /// Desktop → extension: the contact-profile fields for autofill (or an `error`).
     pub const PROFILE_RESULT: &str = "profile.result";
@@ -95,6 +114,11 @@ pub mod msg {
     /// RESERVED (not handled yet) — "have I already applied to this URL?".
     pub const APPLIED_CHECK: &str = "applied.check";
 }
+
+/// Handshake protocol version carried in the `hello` frame. MUST match the TS
+/// `EXTENSION_PROTOCOL_VERSION` in `packages/shared/.../extension-protocol-constants.ts`.
+/// A `hello` with a lower (or absent) protocol is treated as an outdated client.
+pub const PROTOCOL_VERSION: u64 = 2;
 
 /// Hard cap on a single WS message. A job page's full `outerHTML` can run to a
 /// few MB, so 8 MB matches the scraper's per-response cap
@@ -121,8 +145,9 @@ pub struct BridgeState {
     port: Mutex<Option<u16>>,
     /// The pairing secret. Persisted to disk; rotated by `regenerate`.
     token: Mutex<String>,
-    /// Last-writer-wins status hint: set `true` once a frame passes the
-    /// per-frame token gate (never on the bare handshake, so a wrong-token
+    /// Last-writer-wins status hint: set `true` once the extension's client
+    /// proof verifies (the v2 mutual handshake completes — never on the bare WS
+    /// handshake nor the `hello`/`challenge` exchange, so an unauthenticated
     /// client is never reported as connected) and `false` when a socket loop
     /// exits. It is **not** a refcount — this single bool assumes the de-facto
     /// single extension socket (loopback, one extension), so with concurrent
@@ -408,12 +433,14 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
         Some(s) => s,
         None => return,
     };
-    // NOT marked connected yet: the bare handshake (loopback + origin) is not
-    // authentication. `connected` flips true only once a frame passes the
-    // per-frame token gate (an `Import` or a `Reply` from `classify_frame`), so
-    // a wrong-token socket is never reported as connected/authorized.
+    // NOT marked connected yet: the bare WS handshake (loopback + origin) is not
+    // authentication. The socket walks the v2 mutual handshake below; `connected`
+    // flips true only once the extension's client proof verifies (an `AuthOk`
+    // decision), so an unauthenticated socket is never reported as connected.
 
     let (mut writer, mut reader) = ws.split();
+    // Per-connection handshake state; every socket starts by expecting `hello`.
+    let mut conn = ConnState::AwaitingHello;
 
     while let Some(frame) = reader.next().await {
         let msg = match frame {
@@ -434,41 +461,52 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
             _ => continue,
         };
 
-        // Classify the frame against the size + token + type gates (no app state).
-        // An over-cap frame closes the socket; a bad token replies `unauthorized`
-        // then closes; a reserved/unknown type replies with an error; only an
-        // authenticated import request reaches `app` state.
-        let reply = match classify_frame(&state, &text) {
+        // Advance the handshake state machine (pure — no app state). An over-cap
+        // frame closes; an outdated first frame gets `update_required` then close;
+        // a failed proof closes without marking connected; only an authenticated
+        // import/profile frame reaches `app` state.
+        let reply = match advance_frame(&state, &conn, &text) {
             FrameDecision::CloseOverCap => {
                 log::warn!("[extension_bridge] frame over size cap — closing");
                 break;
             }
             FrameDecision::Drop => None,
-            FrameDecision::Unauthorized(reply) => {
-                // A wrong-token client must not linger: send the unauthorized
-                // reply (best-effort) and close the socket without ever marking
-                // it connected.
+            FrameDecision::Outdated(reply) => {
+                // Force cutover: the first frame was not a valid protocol-2 hello
+                // (a legacy token `auth`, a missing/older protocol). Tell the
+                // client to update, then close — no dual-support path.
+                log::warn!(
+                    "[extension_bridge] rejected outdated/legacy first frame — \
+                     sending update_required and closing"
+                );
                 let _ = writer.send(Message::text(reply)).await;
                 break;
             }
-            FrameDecision::Reply(text) => {
-                // A token-validated frame (e.g. the `auth` ok reply, or a
-                // reserved-type error) — the socket is authenticated, mark it
-                // connected.
-                state.set_connected(true);
-                Some(text)
+            FrameDecision::Unauthorized => {
+                // A handshake step failed (bad/absent proof, or an unexpected
+                // frame mid-handshake). Close WITHOUT a reply and without ever
+                // marking the socket connected.
+                log::warn!("[extension_bridge] handshake auth failed — closing");
+                break;
             }
-            FrameDecision::Import { req_id, payload } => {
-                // A token-validated import — authenticated, mark connected.
+            FrameDecision::Challenge { reply, next } => {
+                // hello accepted → advance to AwaitingAuth (still NOT connected).
+                conn = next;
+                Some(reply)
+            }
+            FrameDecision::AuthOk(reply) => {
+                // Client proof verified — the mutual handshake completes. Only now
+                // is the socket authorized; mark it connected and reply auth.ok.
+                conn = ConnState::Authenticated;
                 state.set_connected(true);
+                Some(reply)
+            }
+            FrameDecision::Reply(text) => Some(text),
+            FrameDecision::Import { req_id, payload } => {
                 let outcome = handle_import(&app, payload).await;
                 Some(result_reply(&req_id, outcome))
             }
-            FrameDecision::Profile { req_id } => {
-                // A token-validated profile fetch — authenticated, mark connected.
-                state.set_connected(true);
-                Some(handle_profile(&app, &req_id))
-            }
+            FrameDecision::Profile { req_id } => Some(handle_profile(&app, &req_id)),
         };
         if let Some(reply) = reply {
             if writer.send(Message::text(reply)).await.is_err() {
@@ -480,24 +518,53 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
     state.set_connected(false);
 }
 
-/// Outcome of the per-frame security/dispatch decision, isolated from any
-/// `AppHandle` so the size + token + type gates are unit-testable. The connection
-/// loop runs the (async, app-stateful) import only for [`FrameDecision::Import`];
-/// every other variant is resolved here from pure inputs.
+/// Per-connection handshake state. A socket starts `AwaitingHello`; a valid
+/// protocol-2 `hello` moves it to `AwaitingAuth` (holding the two fresh nonces);
+/// a **verified** client proof moves it to `Authenticated`. Only in
+/// `Authenticated` are `import.request` / `profile.get` frames honored — the
+/// socket is session-authenticated, so those frames carry no token.
+#[cfg_attr(test, derive(Debug, Clone, PartialEq, Eq))]
+enum ConnState {
+    /// Fresh socket — the next frame must be a protocol-2 `hello`.
+    AwaitingHello,
+    /// `hello` accepted; a `challenge` was sent. The next frame must be
+    /// `auth { proof }`; these nonces bind the expected proof.
+    AwaitingAuth {
+        server_nonce: String,
+        client_nonce: String,
+    },
+    /// Mutual handshake complete — subsequent frames are session-authorized.
+    Authenticated,
+}
+
+/// Outcome of the per-frame handshake/dispatch decision, isolated from any
+/// `AppHandle` so the size gate + handshake state machine are unit-testable. The
+/// connection loop runs the (async, app-stateful) import only for
+/// [`FrameDecision::Import`]; every other variant is resolved here from pure
+/// inputs (+ the token off [`BridgeState`] for the constant-time proof check).
 #[cfg_attr(test, derive(Debug))]
 enum FrameDecision {
     /// Frame exceeds [`MAX_FRAME_BYTES`] — close the socket without parsing.
     CloseOverCap,
-    /// Not JSON (malformed) — drop silently, no reply.
+    /// Not JSON, or an ignorable frame — drop silently, no reply, stay in state.
     Drop,
-    /// A bad-token frame: send this ready-to-send `unauthorized` `import.result`
-    /// reply text, then CLOSE the socket. Distinct from [`FrameDecision::Reply`]
-    /// so the connection loop never marks an unauthorized socket connected and
-    /// never lets a wrong-token client linger.
-    Unauthorized(String),
-    /// A ready-to-send `import.result` reply text from a **token-validated**
-    /// frame (a reserved / unknown message type acknowledged as an error, or the
-    /// `auth` success reply). The socket stays open and is marked connected.
+    /// The first frame was not a valid protocol-2 `hello` (a legacy `{type:'auth',
+    /// token}` frame, a missing/older protocol): send this ready-to-send
+    /// [`msg::UPDATE_REQUIRED`] reply, then CLOSE. Force cutover — no dual path.
+    Outdated(String),
+    /// A handshake step failed (bad/absent proof, or an unexpected frame
+    /// mid-handshake): CLOSE without a reply and without marking connected.
+    /// Distinct from [`FrameDecision::AuthOk`] so the loop never authorizes a
+    /// socket whose proof did not verify.
+    Unauthorized,
+    /// `hello` accepted: send this `challenge` reply and advance to `next`
+    /// (`AwaitingAuth`). NOT yet connected.
+    Challenge { reply: String, next: ConnState },
+    /// The client proof VERIFIED (constant-time): send this `auth.ok` reply, mark
+    /// the socket connected, and advance to `Authenticated`.
+    AuthOk(String),
+    /// A ready-to-send reply from an authenticated frame (a reserved / unknown
+    /// message type acknowledged as an error). Stays `Authenticated`.
     Reply(String),
     /// An authenticated `import.request` to dispatch through [`handle_import`].
     Import { req_id: String, payload: Value },
@@ -506,13 +573,12 @@ enum FrameDecision {
     Profile { req_id: String },
 }
 
-/// The per-message security gate + dispatch routing, with the size cap, the JSON
-/// parse, the per-frame token check, and the type match — everything that does
-/// NOT need an `AppHandle`. Behaviorally identical to the prior inline path in
-/// [`handle_connection`]/`process_frame`: same order (size → parse → token →
-/// type), same replies (`unauthorized` / "not implemented" / "unknown message
-/// type"), and the same close-on-over-cap semantics.
-fn classify_frame(state: &BridgeState, text: &str) -> FrameDecision {
+/// The per-message handshake gate + dispatch routing (size cap → JSON parse →
+/// state-machine step) — everything that does NOT need an `AppHandle`. Pure
+/// aside from reading the pairing token off [`BridgeState`] for the
+/// constant-time proof check; the loop performs the I/O and the app-stateful
+/// import/profile work. See [`ConnState`] for the state transitions.
+fn advance_frame(state: &BridgeState, conn: &ConnState, text: &str) -> FrameDecision {
     if text.len() > MAX_FRAME_BYTES {
         return FrameDecision::CloseOverCap;
     }
@@ -522,48 +588,93 @@ fn classify_frame(state: &BridgeState, text: &str) -> FrameDecision {
         Err(_) => return FrameDecision::Drop, // not JSON — drop silently
     };
 
-    let token = envelope.get("token").and_then(|v| v.as_str()).unwrap_or("");
+    let kind = envelope.get("type").and_then(|v| v.as_str()).unwrap_or("");
     let req_id = envelope
         .get("reqId")
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    let kind = envelope.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    let payload = envelope.get("payload");
 
-    // Per-frame token check. A mismatch is an auth failure — reply with an error
-    // (so the caller learns to re-pair) but do NOT echo or confirm the token.
-    // Plain `!=` (non-constant-time) is acceptable here: the bridge binds
-    // loopback only (127.0.0.1) and the token is a 256-bit random secret, so
-    // remote timing side-channels are not a practical risk.
-    if token.is_empty() || token != state.token() {
-        log::warn!("[extension_bridge] rejected frame: bad token");
-        return FrameDecision::Unauthorized(result_reply(
-            &req_id,
-            Err(AppError::Validation("unauthorized".to_string())),
-        ));
+    match conn {
+        ConnState::AwaitingHello => advance_hello(kind, &req_id, payload),
+        ConnState::AwaitingAuth {
+            server_nonce,
+            client_nonce,
+        } => advance_auth(state, kind, &req_id, payload, server_nonce, client_nonce),
+        ConnState::Authenticated => advance_authenticated(kind, req_id, &envelope),
     }
+}
 
+/// Handshake step 1: the FIRST frame must be a valid protocol-2 `hello`. A legacy
+/// `{type:'auth', token}` frame, a missing/older `protocol`, or a malformed
+/// `clientNonce` are all treated as an outdated client → `update_required` + close.
+fn advance_hello(kind: &str, req_id: &str, payload: Option<&Value>) -> FrameDecision {
+    if kind != msg::HELLO {
+        return FrameDecision::Outdated(update_required_reply(req_id));
+    }
+    let protocol = payload
+        .and_then(|p| p.get("protocol"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let client_nonce = payload
+        .and_then(|p| p.get("clientNonce"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if protocol < PROTOCOL_VERSION || !handshake::is_valid_nonce(client_nonce) {
+        return FrameDecision::Outdated(update_required_reply(req_id));
+    }
+    // Fresh server nonce (CSPRNG, per connection). Bind it + the client nonce into
+    // the next state so the proof is verified against exactly this pair.
+    let server_nonce = handshake::new_nonce();
+    let reply = challenge_reply(req_id, &server_nonce);
+    FrameDecision::Challenge {
+        reply,
+        next: ConnState::AwaitingAuth {
+            server_nonce,
+            client_nonce: client_nonce.to_string(),
+        },
+    }
+}
+
+/// Handshake step 3: only an `auth { proof }` is valid here. The proof is verified
+/// CONSTANT-TIME against `HMAC-SHA256(token, CLIENT_MSG)`; on success the desktop
+/// proves ITSELF via `serverProof` (step 4). Any other frame, or a bad/absent
+/// proof, closes the socket (never connected).
+fn advance_auth(
+    state: &BridgeState,
+    kind: &str,
+    req_id: &str,
+    payload: Option<&Value>,
+    server_nonce: &str,
+    client_nonce: &str,
+) -> FrameDecision {
+    if kind != msg::AUTH {
+        return FrameDecision::Unauthorized;
+    }
+    let proof = payload
+        .and_then(|p| p.get("proof"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let token = state.token();
+    if !handshake::verify_client_proof(&token, server_nonce, client_nonce, proof) {
+        log::warn!("[extension_bridge] handshake: client proof failed constant-time verification");
+        return FrameDecision::Unauthorized;
+    }
+    let server_proof = handshake::server_proof(&token, server_nonce, client_nonce);
+    FrameDecision::AuthOk(auth_ok_reply(req_id, &server_proof))
+}
+
+/// Post-auth dispatch: the socket is session-authenticated, so frames carry no
+/// token. Routes `import.request` / `profile.get`; reserved / unknown types get
+/// an `import.result` error reply (never a panic).
+fn advance_authenticated(kind: &str, req_id: String, envelope: &Value) -> FrameDecision {
     match kind {
-        // Connection-time token check. The token already passed the gate above,
-        // so a minimal `Ok` outcome — serializing with NO `error` field — is the
-        // "authorized" reply the extension expects (no error = authorized). An
-        // `auth` frame does no import; the empty fields are never read.
-        msg::AUTH => FrameDecision::Reply(result_reply(
-            &req_id,
-            Ok(ImportOk {
-                application_id: String::new(),
-                status: String::new(),
-                title: String::new(),
-                company: String::new(),
-                partial: false,
-            }),
-        )),
         msg::IMPORT_REQUEST => {
             let payload = envelope.get("payload").cloned().unwrap_or(Value::Null);
             FrameDecision::Import { req_id, payload }
         }
         // Assisted autofill: fetch the contact profile fresh (gated on the opt-in).
-        // No payload is read — the token already passed the gate above.
         msg::PROFILE_GET => FrameDecision::Profile { req_id },
         // Reserved message types — acknowledged as unimplemented, never panic.
         msg::MATCH_LIVE | msg::APPLIED_CHECK => FrameDecision::Reply(result_reply(
@@ -579,6 +690,39 @@ fn classify_frame(state: &BridgeState, text: &str) -> FrameDecision {
             ))),
         )),
     }
+}
+
+/// Build the `challenge` reply (handshake step 2) carrying the fresh server nonce.
+fn challenge_reply(req_id: &str, server_nonce: &str) -> String {
+    json!({
+        "type": msg::CHALLENGE,
+        "reqId": req_id,
+        "payload": { "serverNonce": server_nonce },
+    })
+    .to_string()
+}
+
+/// Build the `auth.ok` reply (handshake step 4) carrying the desktop's proof.
+fn auth_ok_reply(req_id: &str, server_proof: &str) -> String {
+    json!({
+        "type": msg::AUTH_OK,
+        "reqId": req_id,
+        "payload": { "serverProof": server_proof },
+    })
+    .to_string()
+}
+
+/// Build the `update_required` force-cutover reply. Sent, then the socket closes,
+/// when the first frame is not a valid protocol-2 `hello` (an old extension).
+fn update_required_reply(req_id: &str) -> String {
+    json!({
+        "type": msg::UPDATE_REQUIRED,
+        "reqId": req_id,
+        "payload": {
+            "error": "Update the AI Job Hunter browser extension to reconnect (bridge protocol v2)."
+        },
+    })
+    .to_string()
 }
 
 /// The successful import outcome: the created/merged application id, its status,

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -16,7 +16,8 @@
 //!    (`moz-extension://<uuid>`), since its per-install internal UUID is
 //!    unknowable in advance — see [`auth::is_allowed_origin`]. A dev override
 //!    (`platform::config::extension_dev_origins`) admits a locally-loaded
-//!    extension. The per-frame token (3) is what actually authenticates.
+//!    extension. The mutual HMAC handshake below (3) is what actually
+//!    authenticates.
 //! 3. **Mutual HMAC challenge-response (protocol v2)** — the pairing token is
 //!    NEVER transmitted. On connect the extension sends [`msg::HELLO`]
 //!    `{protocol, clientNonce}`; the desktop replies [`msg::CHALLENGE`]
@@ -195,8 +196,10 @@ impl BridgeState {
     }
 
     /// Rotate the pairing token: generate a new secret, persist it, and return
-    /// it. Any already-paired socket will fail its next per-frame token check
-    /// and must re-pair with the new value.
+    /// it. Any socket that re-runs the v2 handshake (a fresh connection, or a
+    /// reconnect) with the old token will fail the client-proof check and must
+    /// re-pair with the new value; an already-authenticated session is
+    /// unaffected until it needs to reconnect.
     pub fn regenerate_token(&self) -> String {
         let fresh = new_token();
         *self.token.lock() = fresh.clone();
@@ -377,10 +380,21 @@ async fn probe_ports(range: std::ops::RangeInclusive<u16>) -> Option<(TcpListene
     None
 }
 
-/// Perform the WS handshake (validating `Origin`), then service frames until the
-/// socket closes or fails a guard. `connected` flips true only once a frame
-/// passes the per-frame token gate (not on the bare handshake); a wrong-token
-/// frame replies `unauthorized` and closes the socket without marking connected.
+/// Perform the WS handshake (validating `Origin`), then drive the v2 mutual
+/// HMAC challenge-response before servicing any application frame:
+/// `hello{clientNonce}` → `challenge{serverNonce}` →
+/// `auth{proof}` — verified **constant-time** via
+/// [`handshake::verify_client_proof`] — → `auth.ok{serverProof}`. The pairing
+/// token is never transmitted; both sides only prove they know it. `connected`
+/// flips true ONLY once the client proof verifies (see [`ConnState`]); the bare
+/// WS handshake and the `hello`/`challenge` exchange never mark it connected. A
+/// FAILED proof closes the socket with **NO reply** — by design, so a wrong
+/// token and a genuine app crash are indistinguishable on the wire (no oracle
+/// for a peer probing for a valid token). Once authenticated, subsequent frames
+/// (`import.request`, `profile.get`, …) are session-authorized — no per-frame
+/// secret. A first frame that isn't a valid protocol-2 `hello` (a legacy
+/// plaintext-token `auth` frame, a lower protocol) gets `update.required` and
+/// closes — the v1→v2 force cutover, no dual-support path.
 async fn handle_connection(app: AppHandle, stream: TcpStream) {
     use tokio_tungstenite::tungstenite::handshake::server::ErrorResponse;
     use tokio_tungstenite::tungstenite::http::StatusCode;

--- a/apps/desktop/src-tauri/src/extension_bridge/native_host.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/native_host.rs
@@ -214,7 +214,8 @@ mod tests {
     // this pins only the stdio framing — the one bit of non-trivial byte logic.
     #[tokio::test]
     async fn stdio_frame_round_trips() {
-        let value = json!({ "type": "import.request", "reqId": "1", "token": "abc" });
+        // v2 frames carry no token; the host is a dumb byte relay either way.
+        let value = json!({ "type": "import.request", "reqId": "1", "payload": { "url": "x" } });
         let json = value.to_string();
 
         // Encode: native-order u32 length prefix + UTF-8 JSON.

--- a/apps/desktop/src-tauri/src/extension_bridge/native_host.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/native_host.rs
@@ -15,8 +15,10 @@
 //! ```
 //!
 //! ## Not a protocol parser
-//! The host does NOT understand the bridge protocol. The per-frame pairing token
-//! flows through verbatim, so bridge auth ([`super::auth`]) + pairing UX are
+//! The host does NOT understand the bridge protocol. The v2 mutual-handshake
+//! frames (`hello`/`challenge`/`auth`/`auth.ok` — never a per-frame token) and
+//! every session-authorized frame after relay through **verbatim**, 1:1, so
+//! bridge auth ([`super::auth`], [`super::handshake`]) + pairing UX are
 //! untouched. The ONE thing it speaks itself is a transport-local readiness
 //! control frame (`bridge.ready`) so the extension can tell "app reachable" from
 //! "app down" — that frame never reaches the bridge and is NOT part of the

--- a/apps/desktop/src-tauri/src/extension_bridge/test.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/test.rs
@@ -26,7 +26,11 @@ fn message_type_constants_match_ts() {
     // Each Rust constant must appear as a single-quoted string literal in the TS
     // `EXTENSION_MESSAGE_TYPES` map (e.g. `import.request: 'import.request'`).
     for literal in [
+        msg::HELLO,
+        msg::CHALLENGE,
         msg::AUTH,
+        msg::AUTH_OK,
+        msg::UPDATE_REQUIRED,
         msg::IMPORT_REQUEST,
         msg::IMPORT_RESULT,
         msg::PROFILE_GET,
@@ -43,11 +47,34 @@ fn message_type_constants_match_ts() {
     }
 }
 
+/// Numeric parity companion to [`message_type_constants_match_ts`]: the
+/// message-type test only pins the `msg::*` STRING literals — it says nothing
+/// about the handshake's numeric `PROTOCOL_VERSION`. A one-sided bump (Rust
+/// bumps to 3 but TS stays at 2, or vice versa) would silently miscalibrate the
+/// force-cutover gate (`advance_hello`'s `protocol < PROTOCOL_VERSION` check) —
+/// this pins the exact literal on both sides. The needle includes the trailing
+/// `;` so `= 2` can never prefix-match a future `= 20` (etc).
+#[test]
+fn protocol_version_matches_ts() {
+    let ts = ts_protocol_source();
+    let needle = format!("EXTENSION_PROTOCOL_VERSION = {};", PROTOCOL_VERSION);
+    assert!(
+        ts.contains(&needle),
+        "Rust PROTOCOL_VERSION ({PROTOCOL_VERSION}) not found as `{needle}` in \
+         extension-protocol-constants.ts — the numeric handshake protocol version \
+         drifted from the TS EXTENSION_PROTOCOL_VERSION"
+    );
+}
+
 #[test]
 fn reserved_types_are_distinct() {
     // Every wire type must be a distinct string.
     let all = [
+        msg::HELLO,
+        msg::CHALLENGE,
         msg::AUTH,
+        msg::AUTH_OK,
+        msg::UPDATE_REQUIRED,
         msg::IMPORT_REQUEST,
         msg::IMPORT_RESULT,
         msg::PROFILE_GET,

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -289,7 +289,7 @@ The desktop bridge validates extension origins in the WS handshake (`apps/deskto
 
 - **Firefox:** a background-script WebSocket sends `Origin: null` (Firefox deliberately strips the per-install UUID to prevent fingerprinting per Bugzilla 1607936/1257989). The bridge accepts `null`. The gecko id (`job-importer@aijobhunter.app`) never appears as an origin and is intentionally absent from the allowlist.
 - **Chrome:** the bridge pins the published Chrome Web Store id `oaoekkgkhmgdfnpmfkpphgiikliaicll` in `ALLOWED_EXTENSION_IDS` (in `apps/desktop/src-tauri/src/extension_bridge/auth.rs`). A locally-loaded Chrome build is still admitted only via the dev-origin override (`AJH_EXTENSION_DEV_ORIGINS`).
-- **Native-messaging host:** sends the sentinel `Origin: ajh-native-host` (see `NATIVE_HOST_ORIGIN` in `auth.rs`). Defense-in-depth only; the per-frame token + loopback binding remain the real boundary.
+- **Native-messaging host:** sends the sentinel `Origin: ajh-native-host` (see `NATIVE_HOST_ORIGIN` in `auth.rs`). Defense-in-depth only; the v2 mutual HMAC handshake + loopback binding remain the real boundary.
 
 ---
 

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -149,38 +149,48 @@ both browsers; it grants **no** access to any public or LAN host.
 - **No data is ever sent to any remote or third-party server** by this
   extension. There is no telemetry, no analytics, no external API.
 - The only stored value is the pairing token, kept in `chrome.storage.local`,
-  used solely to authenticate to the local desktop app.
+  used solely as the HMAC key for the mutual challenge-response handshake with the
+  local desktop app — it is **never transmitted** to the app (or anywhere else).
 - The extension captures the page's rendered DOM **only when the user clicks Import this job** — never in the background — and sends it only to the local app. On restricted pages (e.g. browser system pages) DOM capture is skipped and only the URL is sent.
 - **Assisted autofill data flow:** the feature is **opt-in and off by default** (the toggle lives in the desktop app; the desktop refuses the request when it is off). When on and the user clicks **Fill this form**, the extension requests the user's Contact Profile from the desktop over the same loopback connection, holds it **transiently** to fill matching empty fields on the **current tab only** (`activeTab`, on the click), then discards it. The profile is the user's **own data**, never written to `chrome.storage`, and **never sent to any remote or third-party server** — it only ever moves from the user's desktop into a page the user chose to fill. This is why the Firefox AMO `data_collection_permissions` stays `["none"]` (see `src/manifest.ts`): the extension does not collect or transmit data to the developer or any third party.
 
 ### Threat model
 
-The extension finds the desktop bridge by probing `47615..47620` and sending
-the pairing token to the **first loopback port that answers** (see the
-`TODO(bridge)` comment in `src/lib/bridge.ts::probeRange`).
+The extension finds the desktop bridge by probing `47615..47620` and connecting
+to the **first loopback port that answers**. Authentication is a **mutual HMAC
+challenge-response (protocol v2)** in which the pairing token is used only as an
+HMAC key and is **never transmitted** — see `src/lib/handshake.ts` +
+`src/lib/bridge.ts::performHandshake` (extension) and
+`apps/desktop/src-tauri/src/extension_bridge/handshake.rs` (desktop).
 
-- **Risk (accepted for v1):** a malicious **same-account local process** that
-  squats one of those ports **before** the desktop app binds it could accept the
-  connection and harvest the pairing token on the user's first import.
-- **Preconditions:** this requires an attacker that is **already running on the
-  same machine under the same OS user account**. It is not reachable from the
-  network or from any website — the connection target is loopback-only
-  (`127.0.0.1`) and the host permission grants no public/LAN access.
-- **Bounded impact:** the token authorizes **local job-import** to the desktop
-  bridge, whose fetch path is **SSRF-guarded** — and, **when the user has turned
-  on Assisted form autofill**, it also authorizes reading the user's **Contact
-  Profile** (name, email, phone, location, LinkedIn/GitHub/website) via
-  `profile.get`. Autofill is **off by default**; a harvested token only reaches
-  the profile while that opt-in is on. The token is **rotatable** from the
-  app's Settings (re-pairing invalidates the old one), and there is no remote
-  backend or account to compromise — everything stays on the same loopback
-  device.
-- **Future fix:** add a server→client **challenge HMAC** over a nonce the
-  desktop app **shows in-app** at pair time (so only the genuine app, which
-  knows the nonce, can complete the handshake), or adopt the **native-messaging
-  fallback** described below — a native messaging host **cannot be
-  port-squatted**, since the browser launches it by registered name rather than
-  by connecting to a listening port.
+- **The token never goes on the wire.** The extension sends `hello{clientNonce}`,
+  the desktop replies `challenge{serverNonce}`, and the extension proves it knows
+  the token with
+  `HMAC-SHA256(token, "ajh-bridge/v2\nclient\n<serverNonce>\n<clientNonce>")` over
+  fresh per-connection CSPRNG nonces. A passive observer or a port-squatter learns
+  nothing about the token from that proof, and the desktop verifies it
+  **constant-time**.
+- **Mutual auth closes the v1 port-squat leak.** Before sending ANY job posting or
+  Contact-Profile data, the extension verifies the desktop's own reply
+  `auth.ok{serverProof}` (`HMAC(token, "…\nserver\n…")`) **constant-time**. A
+  malicious same-account process that squats the port **cannot** produce a valid
+  `serverProof` (it does not know the token), so the extension lands in the
+  untrusted (`bad_token`) state and sends **zero** PII — closing the v1
+  "harvest the token / read the profile on first import" risk.
+- **Preconditions unchanged:** any attacker must already run on the same machine
+  under the same OS user account; the bridge is loopback-only (`127.0.0.1`) and
+  the host permission grants no public/LAN access.
+- **Force cutover (no dual-support on the desktop).** The desktop no longer
+  accepts a plaintext-token frame: an old extension (still sending
+  `{type:'auth', token}`) is answered with `update.required` and disconnected,
+  and a new extension talking to an **old** desktop (which never sends a
+  `challenge`) shows a distinct **"Update the app"** state (separate from
+  `bad_token` and `app_not_running`). The token remains **rotatable** from the
+  app's Settings, and there is no remote backend or account to compromise —
+  everything stays on the same loopback device.
+- **Native messaging** cannot be port-squatted at all (the browser launches the
+  host by registered name, not by connecting to a listening port) and carries the
+  identical v2 handshake end-to-end.
 
 ---
 
@@ -275,7 +285,7 @@ emitted JS stays readable for review.
 
 ## Extension origin validation (bridge side)
 
-The desktop bridge validates extension origins in the handshake (`apps/desktop/src-tauri/src/extension_bridge/auth.rs::is_allowed_origin`). **The origin is not the auth boundary** — the per-frame 256-bit pairing token is; the origin is defense-in-depth.
+The desktop bridge validates extension origins in the WS handshake (`apps/desktop/src-tauri/src/extension_bridge/auth.rs::is_allowed_origin`). **The origin is not the auth boundary** — the v2 mutual HMAC challenge-response is (the 256-bit pairing token is proven, never transmitted); the origin is defense-in-depth.
 
 - **Firefox:** a background-script WebSocket sends `Origin: null` (Firefox deliberately strips the per-install UUID to prevent fingerprinting per Bugzilla 1607936/1257989). The bridge accepts `null`. The gecko id (`job-importer@aijobhunter.app`) never appears as an origin and is intentionally absent from the allowlist.
 - **Chrome:** the bridge pins the published Chrome Web Store id `oaoekkgkhmgdfnpmfkpphgiikliaicll` in `ALLOWED_EXTENSION_IDS` (in `apps/desktop/src-tauri/src/extension_bridge/auth.rs`). A locally-loaded Chrome build is still admitted only via the dev-origin override (`AJH_EXTENSION_DEV_ORIGINS`).
@@ -294,4 +304,4 @@ The extension uses **native-messaging as the primary transport**, with **loopbac
 
 2. **WebSocket fallback:** if the native host is not registered (old app / never installed), or native-messaging is unavailable, the extension probes `127.0.0.1:47615..47620` and falls back to the loopback WebSocket. Chrome and older desktop app versions keep working.
 
-All origins flow through unchanged (the per-frame 256-bit pairing token over the loopback-only listener remains the real boundary). Native messaging cannot be port-squatted and survives permission policies that block loopback WS.
+All origins flow through unchanged (the v2 mutual HMAC handshake over the loopback-only listener remains the real boundary — the token is proven, never transmitted). Native messaging cannot be port-squatted and survives permission policies that block loopback WS.

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -65,6 +65,9 @@ async function computeStatus(): Promise<ConnectionStatus> {
   let phase: ConnectionStatus['phase'];
   if (bridge.phase === 'bad_token') {
     phase = 'bad_token';
+  } else if (bridge.phase === 'outdated') {
+    // Desktop too old for the v2 handshake → prompt the user to update the app.
+    phase = 'outdated';
   } else if (bridge.phase === 'app_not_running') {
     phase = 'app_not_running';
   } else if (bridge.phase === 'searching') {
@@ -73,7 +76,7 @@ async function computeStatus(): Promise<ConnectionStatus> {
     // Bridge reachable but we have no secret yet → show the pairing screen.
     phase = 'not_paired';
   } else {
-    // bridge.phase === 'connected' AND hasToken, meaning the auth handshake succeeded.
+    // bridge.phase === 'connected' AND hasToken → the mutual handshake succeeded.
     phase = 'connected';
   }
   return { phase, port: bridge.port, hasToken };
@@ -136,7 +139,7 @@ async function runImport(applied: boolean): Promise<PopupResponse> {
     // ponytail: restricted page or scripting permission denied — URL-only fallback
   }
 
-  const result = await getClient().importJob(token, payload);
+  const result = await getClient().importJob(payload);
   return { ok: true, kind: 'import', result };
 }
 
@@ -183,7 +186,7 @@ async function runFill(): Promise<PopupResponse> {
     return { ok: false, error: 'Not paired. Paste your pairing token first.' };
   }
 
-  const profile = await getClient().getProfile(token);
+  const profile = await getClient().getProfile();
   if (profile.error) {
     // Desktop refused (autofill off) or the reply was malformed — surface it.
     return { ok: false, error: profile.error };

--- a/apps/extension/src/lib/bridge.test.ts
+++ b/apps/extension/src/lib/bridge.test.ts
@@ -16,9 +16,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from '@wxt-dev/browser';
 
-import { EXTENSION_MESSAGE_TYPES } from '@ajh/shared';
+import { EXTENSION_MESSAGE_TYPES, EXTENSION_PROTOCOL_VERSION } from '@ajh/shared';
 
 import { BridgeClient } from './bridge';
+import { computeProof } from './handshake';
 
 // Default `connectNative` THROWS so the existing ws describe-blocks (which never
 // mock it) go straight to the ws probe — native is treated as "host unavailable
@@ -121,9 +122,9 @@ function extractReqId(sentFrameArg: unknown): string {
 }
 
 function makeResultEnvelope(reqId: string, payload: unknown): string {
+  // v2 replies carry no token — the socket is already session-authenticated.
   return JSON.stringify({
     type: EXTENSION_MESSAGE_TYPES.importResult,
-    token: FAKE_TOKEN,
     reqId,
     payload,
   });
@@ -252,7 +253,7 @@ describe('BridgeClient – request/reply correlation', () => {
   it('resolves the correct pending promise when a matching reqId reply arrives', async () => {
     const { client, socket } = await connectedClient();
 
-    const importPromise = client.importJob(FAKE_TOKEN, makeImportRequest());
+    const importPromise = client.importJob(makeImportRequest());
 
     // Wait for the outgoing frame, then extract the real reqId and echo a reply.
     await vi.waitFor(() => {
@@ -274,7 +275,7 @@ describe('BridgeClient – request/reply correlation', () => {
 
     const { client, socket } = await connectedClient();
 
-    const importPromise = client.importJob(FAKE_TOKEN, makeImportRequest());
+    const importPromise = client.importJob(makeImportRequest());
 
     await vi.waitFor(() => {
       expect(socket.send).toHaveBeenCalled();
@@ -307,8 +308,8 @@ describe('BridgeClient – request/reply correlation', () => {
   it('resolves two concurrent requests independently via their reqIds', async () => {
     const { client, socket } = await connectedClient();
 
-    const p1 = client.importJob(FAKE_TOKEN, makeImportRequest());
-    const p2 = client.importJob(FAKE_TOKEN, makeImportRequest());
+    const p1 = client.importJob(makeImportRequest());
+    const p2 = client.importJob(makeImportRequest());
 
     // Wait for both frames to be sent.
     await vi.waitFor(() => {
@@ -367,7 +368,7 @@ describe('BridgeClient – Zod schema validation on incoming payload', () => {
     client: BridgeClient,
     socket: FakeWebSocket
   ): Promise<{ importPromise: Promise<unknown>; reqId: string }> {
-    const importPromise = client.importJob(FAKE_TOKEN, makeImportRequest());
+    const importPromise = client.importJob(makeImportRequest());
     await vi.waitFor(() => {
       expect(socket.send).toHaveBeenCalled();
     });
@@ -559,7 +560,7 @@ describe('BridgeClient – native messaging transport', () => {
     expect(client.status().phase).toBe('connected');
     expect(createdSockets).toHaveLength(0); // never touched ws
 
-    const importPromise = client.importJob(FAKE_TOKEN, makeImportRequest());
+    const importPromise = client.importJob(makeImportRequest());
     await vi.waitFor(() => {
       expect(port.postMessage).toHaveBeenCalled();
     });
@@ -569,7 +570,6 @@ describe('BridgeClient – native messaging transport', () => {
     // Reply arrives as a PARSED OBJECT (native auto-parses JSON), not a string.
     port.simulateMessage({
       type: EXTENSION_MESSAGE_TYPES.importResult,
-      token: FAKE_TOKEN,
       reqId: sent.reqId,
       payload: { applicationId: 'native-1', status: 'saved' },
     });
@@ -667,9 +667,9 @@ describe('BridgeClient – native messaging transport', () => {
   });
 });
 
-// ── auth handshake ─────────────────────────────────────────────────────────────
+// ── v2 mutual HMAC handshake ────────────────────────────────────────────────
 
-describe('BridgeClient – auth handshake', () => {
+describe('BridgeClient – v2 mutual handshake', () => {
   let latestSocket: FakeWebSocket | undefined;
   let restoreWS: () => void;
 
@@ -685,10 +685,10 @@ describe('BridgeClient – auth handshake', () => {
     vi.useRealTimers();
   });
 
-  /**
-   * Build a connected BridgeClient whose getStoredToken returns the given value.
-   * Opens the socket synchronously, then returns the socket for further control.
-   */
+  /** A fixed, well-formed server nonce (16 bytes = 32 lowercase-hex chars). */
+  const SERVER_NONCE = 'ffeeddccbbaa99887766554433221100';
+
+  /** Build a BridgeClient whose getStoredToken returns the given value + open the socket. */
   async function clientWithToken(
     storedToken: string | null
   ): Promise<{ client: BridgeClient; socket: FakeWebSocket; connectPromise: Promise<void> }> {
@@ -703,194 +703,217 @@ describe('BridgeClient – auth handshake', () => {
     return { client, socket, connectPromise };
   }
 
-  /** Reply to an auth frame: extract the reqId from the outgoing send call at
-   *  `callIndex` and simulate a desktop reply on the socket. */
-  function replyToAuth(
-    socket: FakeWebSocket,
-    callIndex: number,
-    payload: Record<string, unknown>
-  ): void {
-    const raw = socket.send.mock.calls[callIndex]?.[0] as string | undefined;
-    if (!raw) throw new Error(`No send call at index ${callIndex}`);
-    const frame = JSON.parse(raw) as { reqId: string };
+  const parseSend = (socket: FakeWebSocket, i: number) =>
+    JSON.parse(socket.send.mock.calls[i]?.[0] as string) as {
+      type: string;
+      reqId: string;
+      token?: unknown;
+      payload: { clientNonce?: string; proof?: string };
+    };
+
+  /** Wait for the opening `hello` frame; return its reqId + clientNonce. */
+  async function awaitHello(
+    socket: FakeWebSocket
+  ): Promise<{ helloReqId: string; clientNonce: string }> {
+    await vi.waitFor(() => {
+      expect(socket.send).toHaveBeenCalled();
+    });
+    const hello = parseSend(socket, 0);
+    expect(hello.type).toBe(EXTENSION_MESSAGE_TYPES.hello);
+    expect((hello.payload as { protocol?: number }).protocol).toBe(EXTENSION_PROTOCOL_VERSION);
+    // The token is NEVER on the wire.
+    expect(hello.token).toBeUndefined();
+    return { helloReqId: hello.reqId, clientNonce: hello.payload.clientNonce! };
+  }
+
+  function sendChallenge(socket: FakeWebSocket, reqId: string): void {
     socket.simulateMessage(
       JSON.stringify({
-        type: EXTENSION_MESSAGE_TYPES.importResult,
-        token: FAKE_TOKEN,
-        reqId: frame.reqId,
-        payload,
+        type: EXTENSION_MESSAGE_TYPES.challenge,
+        reqId,
+        payload: { serverNonce: SERVER_NONCE },
       })
     );
   }
 
-  it('sends an auth frame on open when a token is stored', async () => {
-    const { socket, connectPromise } = await clientWithToken(FAKE_TOKEN);
-
-    // Auth frame must be sent before the handshake resolves.
+  /** After the challenge, wait for the `auth` frame; return its reqId + proof. */
+  async function awaitAuth(socket: FakeWebSocket): Promise<{ authReqId: string; proof: string }> {
     await vi.waitFor(() => {
-      expect(socket.send).toHaveBeenCalled();
+      expect(socket.send.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
+    const auth = parseSend(socket, 1);
+    expect(auth.type).toBe(EXTENSION_MESSAGE_TYPES.auth);
+    expect(auth.token).toBeUndefined();
+    return { authReqId: auth.reqId, proof: auth.payload.proof! };
+  }
 
-    const raw = socket.send.mock.calls[0]?.[0] as string;
-    const frame = JSON.parse(raw) as { type: string; token: string; payload: unknown };
-    expect(frame.type).toBe(EXTENSION_MESSAGE_TYPES.auth);
-    expect(frame.token).toBe(FAKE_TOKEN);
-    expect(frame.payload).toBeNull();
+  async function sendAuthOk(
+    socket: FakeWebSocket,
+    reqId: string,
+    token: string,
+    clientNonce: string,
+    kind: 'valid' | 'invalid' = 'valid'
+  ): Promise<void> {
+    const serverProof =
+      kind === 'valid'
+        ? await computeProof(token, 'server', SERVER_NONCE, clientNonce)
+        : '0'.repeat(64);
+    socket.simulateMessage(
+      JSON.stringify({
+        type: EXTENSION_MESSAGE_TYPES.authOk,
+        reqId,
+        payload: { serverProof },
+      })
+    );
+  }
 
-    // Reply with success so the promise resolves cleanly.
-    replyToAuth(socket, 0, {
-      applicationId: '',
-      status: '',
-      title: '',
-      company: '',
-      partial: false,
-    });
-    await connectPromise;
-  });
-
-  it('sets phase to connected after a valid-token auth reply (no error field)', async () => {
+  it('completes the full handshake (hello→challenge→auth→auth.ok) and reaches connected', async () => {
     const { client, socket, connectPromise } = await clientWithToken(FAKE_TOKEN);
 
-    await vi.waitFor(() => {
-      expect(socket.send).toHaveBeenCalled();
-    });
+    const { helloReqId, clientNonce } = await awaitHello(socket);
+    sendChallenge(socket, helloReqId);
 
-    // Desktop replies with the success payload (no error field).
-    replyToAuth(socket, 0, {
-      applicationId: '',
-      status: '',
-      title: '',
-      company: '',
-      partial: false,
-    });
+    const { authReqId, proof } = await awaitAuth(socket);
+    // The client proof must be the real HMAC(token, CLIENT_MSG) for the issued
+    // nonces — proving the token is used as a key, never transmitted.
+    expect(proof).toBe(await computeProof(FAKE_TOKEN, 'client', SERVER_NONCE, clientNonce));
+
+    await sendAuthOk(socket, authReqId, FAKE_TOKEN, clientNonce, 'valid');
     await connectPromise;
 
     expect(client.status().phase).toBe('connected');
     client.dispose();
   });
 
-  it('sets phase to bad_token after an unauthorized auth reply and does NOT reconnect', async () => {
-    vi.useFakeTimers();
-    let socketCount = 0;
-    restoreWS();
-    restoreWS = installFakeWS((ws) => {
-      socketCount += 1;
-      latestSocket = ws;
-    });
+  it('enters bad_token on an INVALID serverProof and sends NO import/profile frame (no PII)', async () => {
+    const { client, socket, connectPromise } = await clientWithToken(FAKE_TOKEN);
 
-    const getStoredToken = vi.fn<[], Promise<string | null>>().mockResolvedValue(FAKE_TOKEN);
-    const client = new BridgeClient(vi.fn(), getStoredToken);
-    const connectPromise = client.ensureConnected();
-
-    await vi.waitFor(() => {
-      expect(latestSocket).toBeDefined();
-    });
-    const socket = latestSocket!;
-    socket.simulateOpen();
-
-    // Wait for the auth frame.
-    await vi.waitFor(() => {
-      expect(socket.send).toHaveBeenCalled();
-    });
-
-    // Desktop replies with unauthorized.
-    replyToAuth(socket, 0, { error: 'unauthorized' });
+    const { helloReqId, clientNonce } = await awaitHello(socket);
+    sendChallenge(socket, helloReqId);
+    const { authReqId } = await awaitAuth(socket);
+    // A rogue/port-squatting peer cannot produce a valid serverProof.
+    await sendAuthOk(socket, authReqId, FAKE_TOKEN, clientNonce, 'invalid');
     await connectPromise;
 
     expect(client.status().phase).toBe('bad_token');
-
-    // Advance well past all backoff intervals — must NOT trigger a reconnect.
-    const socketCountBefore = socketCount;
-    await vi.advanceTimersByTimeAsync(15_000);
-    expect(socketCount).toBe(socketCountBefore);
-
+    // CRITICAL: only hello + auth were ever sent — mutual auth failed BEFORE any
+    // import/profile frame, so no PII ever left the extension.
+    expect(socket.send.mock.calls.length).toBe(2);
     client.dispose();
   });
 
-  it('does NOT enter bad_token when the socket closes before the auth reply — transport failure, reconnect allowed', async () => {
-    vi.useFakeTimers();
-    let socketCount = 0;
-    restoreWS();
-    restoreWS = installFakeWS((ws) => {
-      socketCount += 1;
-      latestSocket = ws;
-    });
+  // ── unverified-peer race: importJob/getProfile must never race ahead of the
+  // handshake (a non-null transport does NOT mean the peer is verified) ────────
 
+  it('a concurrent importJob during a PENDING handshake sends NO import.request, and rejects (sending nothing) once the handshake times out unresolved', async () => {
+    // The attack this closes: a port-squatter answers `hello` with a `challenge`
+    // then WITHHOLDS `auth.ok` (stays silent). If a concurrent `importJob` (the
+    // user clicking Import mid-handshake) were gated on transport liveness
+    // (`this.transport !== null`, set by `attach()` BEFORE the peer is verified)
+    // instead of the authenticated session, it would ship the active-tab DOM to
+    // this unverified peer. It must instead await the SAME handshake and see it
+    // fail — sending nothing.
+    vi.useFakeTimers();
     const getStoredToken = vi.fn<[], Promise<string | null>>().mockResolvedValue(FAKE_TOKEN);
     const client = new BridgeClient(vi.fn(), getStoredToken);
-    const connectPromise = client.ensureConnected();
 
+    // Kick off the initial connection attempt (mirrors the background's
+    // module-load / reconnect-timer probe) — NOT awaited, so it is still
+    // in-flight when importJob is called below.
+    const initialConnect = client.ensureConnected();
     await vi.waitFor(() => {
       expect(latestSocket).toBeDefined();
     });
     const socket = latestSocket!;
     socket.simulateOpen();
 
-    // Wait for the auth frame to be sent.
-    await vi.waitFor(() => {
-      expect(socket.send).toHaveBeenCalled();
-    });
+    const { helloReqId } = await awaitHello(socket);
+    sendChallenge(socket, helloReqId);
+    await awaitAuth(socket); // client sent its auth{proof} — 2 frames total so far
+    const framesBeforeImport = socket.send.mock.calls.length;
+    expect(framesBeforeImport).toBe(2);
 
-    // Close the socket BEFORE any auth reply arrives — simulates disconnect
-    // during handshake (not an unauthorized rejection).
+    // The user clicks "Import" WHILE the handshake is still awaiting auth.ok —
+    // the port-squatter attack window. `this.transport` is already non-null here
+    // (set by attach() at open time) — the OLD (unpatched) `ensureConnected()`
+    // would see `isOpen()` true and return immediately, letting this send NOW.
+    const importPromise = client.importJob(makeImportRequest());
+    // Attach the outcome handler SYNCHRONOUSLY (same tick) so vitest never flags
+    // a transient "unhandled rejection" while we advance timers below — Node's
+    // unhandled-rejection check cares whether a handler is attached, not when the
+    // promise actually settles.
+    const outcomePromise = importPromise.then(
+      () => ({ ok: true as const }),
+      (e: unknown) => ({ ok: false as const, error: e })
+    );
+
+    // Flush microtasks and assert NO import.request was sent while the peer is
+    // still unverified.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(socket.send.mock.calls.length).toBe(framesBeforeImport);
+
+    // The port-squatter never replies — advance past the handshake timeout.
+    await vi.advanceTimersByTimeAsync(8_100);
+    await initialConnect;
+
+    const outcome = await outcomePromise;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toBeInstanceOf(Error);
+      expect((outcome.error as Error).message).toBe(
+        'Desktop app not reachable. Is AI Job Hunter running?'
+      );
+    }
+    // CRITICAL: the import.request frame was NEVER sent — only hello + auth.
+    expect(socket.send.mock.calls.length).toBe(2);
+    expect(client.status().phase).not.toBe('connected');
+
+    client.dispose();
+  });
+
+  it('a concurrent getProfile during a PENDING handshake sends NO profile.get, and rejects (sending nothing) if the peer closes without auth.ok', async () => {
+    const { client, socket, connectPromise } = await clientWithToken(FAKE_TOKEN);
+    const { helloReqId } = await awaitHello(socket);
+    sendChallenge(socket, helloReqId);
+    await awaitAuth(socket);
+    const framesBeforeProfile = socket.send.mock.calls.length;
+    expect(framesBeforeProfile).toBe(2);
+
+    // Fetching the Contact Profile mid-handshake — the highest-sensitivity PII
+    // this client sends. Must never race ahead of the mutual auth.
+    const profilePromise = client.getProfile();
+    // Attach synchronously — see the note in the importJob variant above.
+    const outcomePromise = profilePromise.then(
+      () => ({ ok: true as const }),
+      (e: unknown) => ({ ok: false as const, error: e })
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(socket.send.mock.calls.length).toBe(framesBeforeProfile);
+
+    // The peer closes without ever sending auth.ok (ambiguous silence).
     socket.simulateClose();
+    await connectPromise;
 
-    // Must NOT land in bad_token; onClose handles it as a transport failure.
-    await connectPromise.catch(() => {
-      // ensureConnected may reject if connect throws; that's fine.
-    });
-
-    // Allow pending microtasks/timers to settle.
-    await vi.advanceTimersByTimeAsync(0);
-
-    expect(client.status().phase).not.toBe('bad_token');
-    // Reconnect must be scheduled (phase is app_not_running, new socket probed).
-    const socketCountBefore = socketCount;
-    await vi.advanceTimersByTimeAsync(600);
-    expect(socketCount).toBeGreaterThan(socketCountBefore);
+    const outcome = await outcomePromise;
+    expect(outcome.ok).toBe(false);
+    // CRITICAL: profile.get was NEVER sent — only hello + auth.
+    expect(socket.send.mock.calls.length).toBe(2);
+    expect(client.status().phase).toBe('app_not_running');
 
     client.dispose();
   });
 
-  it('does NOT enter bad_token on auth timeout — transport failure, reconnect allowed', async () => {
-    vi.useFakeTimers();
-    restoreWS();
-    restoreWS = installFakeWS((ws) => {
-      latestSocket = ws;
-    });
-
-    const getStoredToken = vi.fn<[], Promise<string | null>>().mockResolvedValue(FAKE_TOKEN);
-    const client = new BridgeClient(vi.fn(), getStoredToken);
-    const connectPromise = client.ensureConnected();
-
-    await vi.waitFor(() => {
-      expect(latestSocket).toBeDefined();
-    });
-    const socket = latestSocket!;
-    socket.simulateOpen();
-
-    // Wait for the auth frame to be sent.
-    await vi.waitFor(() => {
-      expect(socket.send).toHaveBeenCalled();
-    });
-
-    // Advance past REQUEST_TIMEOUT_MS (30 000ms) with no reply — triggers timeout.
-    // This also drains any reconnect backoff timers that fire in the same window.
-    await vi.advanceTimersByTimeAsync(31_000);
-
-    await connectPromise.catch(() => {
-      // may reject; ignore
-    });
-
-    // Timeout is a transport failure — must NOT permanently lock out reconnect.
-    // Phase may be app_not_running or searching (if a reconnect probe already
-    // fired within the 31 s window), but never bad_token.
-    expect(client.status().phase).not.toBe('bad_token');
-
-    client.dispose();
-  });
-
-  it('a non-unauthorized error reply is a transport failure — phase never becomes bad_token and a reconnect is scheduled', async () => {
+  it('enters app_not_running (NOT bad_token) when the desktop closes without an auth.ok, and reconnect is allowed', async () => {
+    // The Rust `Unauthorized` path closes WITHOUT a reply BY DESIGN (a wrong
+    // proof and an app crash look identical on the wire) — this ambiguous
+    // silence must never assert a hard wrong-token verdict; it must stay
+    // recoverable so a genuine crash/restart doesn't strand the user in a
+    // manual-re-pair state.
     vi.useFakeTimers();
     let socketCount = 0;
     restoreWS();
@@ -902,37 +925,131 @@ describe('BridgeClient – auth handshake', () => {
     const getStoredToken = vi.fn<[], Promise<string | null>>().mockResolvedValue(FAKE_TOKEN);
     const client = new BridgeClient(vi.fn(), getStoredToken);
     const connectPromise = client.ensureConnected();
-
     await vi.waitFor(() => {
       expect(latestSocket).toBeDefined();
     });
     const socket = latestSocket!;
     socket.simulateOpen();
 
-    // Wait for the auth frame to be sent.
-    await vi.waitFor(() => {
-      expect(socket.send).toHaveBeenCalled();
-    });
+    const { helloReqId } = await awaitHello(socket);
+    sendChallenge(socket, helloReqId);
+    await awaitAuth(socket);
+    // Desktop spoke v2 (sent a challenge) but never replies auth.ok — closes.
+    socket.simulateClose();
+    await connectPromise;
 
-    // Desktop replies with a non-unauthorized error (transport/server crash, NOT token rejection).
-    replyToAuth(socket, 0, { error: 'server-crash' });
-
-    await connectPromise.catch(() => {
-      // may reject; ignore
-    });
-
-    // Allow the close + microtasks to settle (the bridge calls transport.close() which
-    // fires onClose synchronously in our fake, but microtasks still need to drain).
-    await vi.advanceTimersByTimeAsync(0);
-
-    // MUST NOT enter bad_token — 'server-crash' is not the sentinel 'unauthorized'.
+    expect(client.status().phase).toBe('app_not_running');
     expect(client.status().phase).not.toBe('bad_token');
-
-    // Reconnect must be scheduled: advance past backoff[0]=500ms and assert a new socket appears.
-    const socketCountBefore = socketCount;
+    // Reconnect IS scheduled (recoverable) — advance past backoff[0]=500ms.
+    const before = socketCount;
     await vi.advanceTimersByTimeAsync(600);
-    expect(socketCount).toBeGreaterThan(socketCountBefore);
+    expect(socketCount).toBeGreaterThan(before);
+    client.dispose();
+  });
 
+  it('resolves app_not_running (NOT bad_token) when the socket closes while computing the client proof', async () => {
+    // Race: the socket closes in the window between receiving the challenge and
+    // `performHandshake` noticing the transport is gone (after `await
+    // computeProof(...)` resolves) — the "closed while hashing" branch. Same
+    // ambiguity as above: never assert wrong-token from silence alone.
+    const { client, socket, connectPromise } = await clientWithToken(FAKE_TOKEN);
+    const { helloReqId } = await awaitHello(socket);
+    sendChallenge(socket, helloReqId);
+    // Close in the SAME synchronous tick as the challenge — `settle()` for step 1
+    // clears `handshakeClosed` synchronously before `performHandshake`'s
+    // continuation (which awaits `computeProof`) gets a chance to run as a
+    // microtask, so this close is only noticed by the post-hash `!this.transport`
+    // check — exactly the "closed while hashing" race, not the step-1 close path.
+    socket.simulateClose();
+    await connectPromise;
+
+    expect(client.status().phase).toBe('app_not_running');
+    expect(client.status().phase).not.toBe('bad_token');
+    client.dispose();
+  });
+
+  it('enters outdated when the desktop closes without a challenge (old desktop)', async () => {
+    const { client, socket, connectPromise } = await clientWithToken(FAKE_TOKEN);
+    await awaitHello(socket);
+    // An old desktop refuses the v2 hello and closes — no challenge ever arrives.
+    socket.simulateClose();
+    await connectPromise;
+    expect(client.status().phase).toBe('outdated');
+    client.dispose();
+  });
+
+  it('enters outdated when the desktop replies a non-challenge frame (legacy import.result)', async () => {
+    const { client, socket, connectPromise } = await clientWithToken(FAKE_TOKEN);
+    const { helloReqId } = await awaitHello(socket);
+    // An old v1 desktop replies import.result{unauthorized} to our hello (it read
+    // an empty token) instead of a challenge → we know it does not speak v2.
+    socket.simulateMessage(
+      JSON.stringify({
+        type: EXTENSION_MESSAGE_TYPES.importResult,
+        reqId: helloReqId,
+        payload: { error: 'unauthorized' },
+      })
+    );
+    await connectPromise;
+    expect(client.status().phase).toBe('outdated');
+    client.dispose();
+  });
+
+  it('enters outdated when the challenge carries a malformed serverNonce (defense-in-depth)', async () => {
+    // Mirrors the Rust `is_valid_nonce` shape check: a serverNonce that is not
+    // exactly 32 lowercase-hex chars must never feed the HMAC — reject it as a
+    // clean handshake failure before any proof is computed.
+    const { client, socket, connectPromise } = await clientWithToken(FAKE_TOKEN);
+    const { helloReqId } = await awaitHello(socket);
+    socket.simulateMessage(
+      JSON.stringify({
+        type: EXTENSION_MESSAGE_TYPES.challenge,
+        reqId: helloReqId,
+        payload: { serverNonce: 'not-hex!!' },
+      })
+    );
+    await connectPromise;
+    expect(client.status().phase).toBe('outdated');
+    // The malformed nonce must never reach computeProof — only the hello frame
+    // was ever sent (no auth frame follows a rejected challenge).
+    expect(socket.send.mock.calls.length).toBe(1);
+    client.dispose();
+  });
+
+  it('does NOT enter bad_token/outdated on a pure handshake timeout — reconnect allowed', async () => {
+    vi.useFakeTimers();
+    let socketCount = 0;
+    restoreWS();
+    restoreWS = installFakeWS((ws) => {
+      socketCount += 1;
+      latestSocket = ws;
+    });
+
+    const getStoredToken = vi.fn<[], Promise<string | null>>().mockResolvedValue(FAKE_TOKEN);
+    const client = new BridgeClient(vi.fn(), getStoredToken);
+    const connectPromise = client.ensureConnected();
+    await vi.waitFor(() => {
+      expect(latestSocket).toBeDefined();
+    });
+    const socket = latestSocket!;
+    socket.simulateOpen();
+    await awaitHello(socket);
+
+    // No challenge, no close — advance just past the handshake timeout (8s). This
+    // fires the timeout (→ app_not_running) and SCHEDULES the reconnect (500ms)
+    // without firing it yet.
+    await vi.advanceTimersByTimeAsync(8_100);
+    await connectPromise.catch(() => {
+      /* may reject; ignore */
+    });
+
+    // A silent timeout is a transport blip, not a token/outdated verdict.
+    expect(client.status().phase).not.toBe('bad_token');
+    expect(client.status().phase).not.toBe('outdated');
+    // Reconnect scheduled — advance past backoff[0]=500ms; a new socket appears.
+    const before = socketCount;
+    await vi.advanceTimersByTimeAsync(600);
+    expect(socketCount).toBeGreaterThan(before);
     client.dispose();
   });
 
@@ -948,51 +1065,38 @@ describe('BridgeClient – auth handshake', () => {
     const getStoredToken = vi.fn<[], Promise<string | null>>().mockResolvedValue(FAKE_TOKEN);
     const client = new BridgeClient(vi.fn(), getStoredToken);
     const connectPromise = client.ensureConnected();
-
     await vi.waitFor(() => {
       expect(latestSocket).toBeDefined();
     });
     const socket = latestSocket!;
     socket.simulateOpen();
 
-    await vi.waitFor(() => {
-      expect(socket.send).toHaveBeenCalled();
-    });
-
-    // Drive into bad_token via an explicit unauthorized reply.
-    replyToAuth(socket, 0, { error: 'unauthorized' });
+    const { helloReqId, clientNonce } = await awaitHello(socket);
+    sendChallenge(socket, helloReqId);
+    const { authReqId } = await awaitAuth(socket);
+    // A genuine, non-ambiguous rejection: the desktop DID reply auth.ok, but the
+    // serverProof does not verify → bad_token (a real mismatch, not silence).
+    await sendAuthOk(socket, authReqId, FAKE_TOKEN, clientNonce, 'invalid');
     await connectPromise;
-
-    // Confirm bad_token before recovery.
     expect(client.status().phase).toBe('bad_token');
 
-    // ── recovery ──────────────────────────────────────────────────────────────
     client.resetForNewToken();
-
-    // Phase must return to 'searching' (no longer bad_token).
     expect(client.status().phase).toBe('searching');
 
-    // The bad_token guard in ensureConnected() must now be lifted —
-    // a fresh ensureConnected() call must attempt a new socket.
-    const socketCountBefore = socketCount;
+    const before = socketCount;
     void client.ensureConnected();
     await vi.advanceTimersByTimeAsync(0);
-    expect(socketCount).toBeGreaterThan(socketCountBefore);
-
+    expect(socketCount).toBeGreaterThan(before);
     client.dispose();
   });
 
-  it('does NOT send an auth frame when no token is stored, and stays not-paired', async () => {
+  it('does NOT send any frame when no token is stored, and stays not-paired', async () => {
     const { client, socket, connectPromise } = await clientWithToken(null);
-
-    // Let the attach() complete (it awaits getStoredToken which resolves to null).
     await connectPromise;
-
-    // No auth frame should have been sent.
+    // No hello (nor any frame) is sent when unpaired.
     expect(socket.send).not.toHaveBeenCalled();
-    // Phase is 'connected' from bridge perspective (background will map to not_paired).
+    // Phase is 'connected' from the bridge perspective (background → not_paired).
     expect(client.status().phase).toBe('connected');
-
     client.dispose();
   });
 });
@@ -1029,7 +1133,6 @@ describe('BridgeClient – getProfile (assisted autofill)', () => {
   function makeProfileEnvelope(reqId: string, payload: unknown): string {
     return JSON.stringify({
       type: EXTENSION_MESSAGE_TYPES.profileResult,
-      token: FAKE_TOKEN,
       reqId,
       payload,
     });
@@ -1040,7 +1143,7 @@ describe('BridgeClient – getProfile (assisted autofill)', () => {
     client: BridgeClient,
     socket: FakeWebSocket
   ): Promise<{ profilePromise: Promise<unknown>; reqId: string }> {
-    const profilePromise = client.getProfile(FAKE_TOKEN);
+    const profilePromise = client.getProfile();
     await vi.waitFor(() => {
       expect(socket.send).toHaveBeenCalled();
     });

--- a/apps/extension/src/lib/bridge.ts
+++ b/apps/extension/src/lib/bridge.ts
@@ -12,8 +12,11 @@
  *    `apps/desktop/src-tauri/src/extension_bridge/mod.rs::PORT_RANGE`). Used when
  *    the native host isn't registered (old/never-installed app).
  *
- * Either way we hold a SINGLE transport, send `import.request` envelopes (token
- * on every frame), and correlate replies by `reqId`.
+ * Either way we hold a SINGLE transport. On connect we run the v2 mutual HMAC
+ * handshake (`hello` → `challenge` → `auth{proof}` → `auth.ok{serverProof}`) —
+ * the pairing token is used only as an HMAC key and is NEVER put on the wire —
+ * then send token-free `import.request` / `profile.get` envelopes over the
+ * now-authenticated socket, correlating replies by `reqId`.
  *
  * Lifecycle note (MV3): the background service worker can be evicted at any
  * time, tearing down this client. The background entry re-creates it on wake
@@ -26,11 +29,14 @@ import { type Browser, browser } from '@wxt-dev/browser';
 
 import {
   EXTENSION_MESSAGE_TYPES,
+  EXTENSION_PROTOCOL_VERSION,
   type ExtensionEnvelope,
   type ExtensionImportRequest,
   type ExtensionImportResult,
   type ExtensionProfileResult,
 } from '@ajh/shared/extension-protocol';
+
+import { computeProof, constantTimeHexEqual, isValidNonceHex, randomNonceHex } from './handshake';
 
 /** Inclusive probe range — mirrors the desktop `PORT_RANGE` (47615..=47620). */
 const PORT_START = 47615;
@@ -49,12 +55,12 @@ const BACKOFF_MS = [500, 1_000, 2_000, 5_000, 10_000];
 const OPEN_TIMEOUT_MS = 1_500;
 
 /**
- * The exact error string the desktop sends when the pairing token is wrong.
- * Only this string triggers permanent `bad_token` + no-reconnect.
- * Every other auth error (timeout / connection-closed / malformed) is a
- * TRANSPORT failure that allows reconnect via `app_not_running`.
+ * Per-step timeout for the v2 handshake (await challenge / await auth.ok). On
+ * loopback each step is a fast round-trip; a total silence (no frame, no close)
+ * is treated as a transient transport failure (reconnect), while an explicit
+ * close / a non-`challenge` reply is the outdated-desktop signal.
  */
-const AUTH_ERROR_UNAUTHORIZED = 'unauthorized';
+const HANDSHAKE_TIMEOUT_MS = 8_000;
 
 /** How long to wait for the native host's `bridge.ready` before falling back to ws. */
 const READY_TIMEOUT_MS = 1_500;
@@ -62,7 +68,18 @@ const READY_TIMEOUT_MS = 1_500;
 type PendingResolver = (result: ExtensionImportResult) => void;
 type ProfileResolver = (result: ExtensionProfileResult) => void;
 
-export type BridgePhase = 'searching' | 'connected' | 'app_not_running' | 'bad_token';
+export type BridgePhase = 'searching' | 'connected' | 'app_not_running' | 'outdated' | 'bad_token';
+
+/** One step of the v2 handshake: a frame arrived, the socket closed, or timeout. */
+type HandshakeStep =
+  { kind: 'frame'; env: Partial<ExtensionEnvelope> } | { kind: 'closed' } | { kind: 'timeout' };
+
+/** Read a non-empty string field (a nonce / proof) off a handshake payload. */
+function readHexField(payload: unknown, key: string): string | null {
+  if (typeof payload !== 'object' || payload === null) return null;
+  const v = (payload as Record<string, unknown>)[key];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
 
 export interface BridgeStatus {
   phase: BridgePhase;
@@ -286,9 +303,34 @@ export class BridgeClient {
   private backoffIndex = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private disposed = false;
-  private connecting = false;
+  /**
+   * The in-flight `doConnect()` promise (transport probe THROUGH the full v2
+   * handshake), or `null` when no connection attempt is running. A concurrent
+   * `ensureConnected()` call AWAITS this SAME promise instead of returning early
+   * — this is the fix for the "app frame reaches an unverified peer" race: the
+   * transport can be non-null while `performHandshake` is still verifying the
+   * peer's `serverProof`, so `isOpen()` alone is never a safe "ready" signal for
+   * a concurrent caller. See `importJob`/`getProfile`, which additionally gate on
+   * `this.phase === 'connected'` (the authenticated session), never on transport
+   * liveness.
+   */
+  private connectPromise: Promise<void> | null = null;
   /** When true the last close was an auth rejection — suppress normal reconnect. */
   private authRejected = false;
+  /**
+   * When true the desktop is too old for the v2 handshake (it never sent a
+   * `challenge`) — suppress the reconnect loop so we don't hammer an old app; the
+   * next popup open / Retry re-probes and recovers once the desktop is updated.
+   */
+  private outdated = false;
+  /**
+   * Set while a v2 handshake is in flight. `handshakeFrame` receives every
+   * incoming frame (so `performHandshake` can advance step by step);
+   * `handshakeClosed` is invoked on socket close so a step resolves as `closed`.
+   * Both are cleared when a step settles.
+   */
+  private handshakeFrame: ((env: Partial<ExtensionEnvelope>) => void) | null = null;
+  private handshakeClosed: (() => void) | null = null;
 
   /** Notified on every phase change so the background can broadcast status. */
   constructor(
@@ -307,52 +349,68 @@ export class BridgeClient {
   }
 
   /**
-   * Ensure a connection: if already open, no-op; otherwise try native then ws.
-   * Safe to call repeatedly (popup-open wake, reconnect button).
+   * Ensure a connection: if already open (authenticated), no-op; otherwise try
+   * native then ws — INCLUDING the full v2 handshake. Safe to call repeatedly
+   * (popup-open wake, reconnect button, a concurrent `importJob`/`getProfile`).
+   *
+   * A concurrent call while a connection attempt is already running AWAITS the
+   * SAME promise rather than short-circuiting — critical because `attach()` sets
+   * `this.transport` before `performHandshake` has verified the peer's
+   * `serverProof`. Without this, a second caller would see `isOpen()` (transport
+   * non-null) and treat an unverified transport as ready, sending an app frame
+   * (e.g. the active-tab DOM) to a peer that has not yet proven it knows the
+   * pairing token.
    */
   async ensureConnected(): Promise<void> {
-    if (this.disposed || this.isOpen() || this.connecting || this.phase === 'bad_token') return;
-    this.connecting = true;
+    if (this.disposed || this.phase === 'bad_token') return;
+    if (this.connectPromise) return this.connectPromise;
+    if (this.isOpen()) return; // already open + past a settled handshake
+    this.connectPromise = this.doConnect();
     try {
-      this.setPhase('searching');
-      // Native first. ponytail: serial single-in-flight is fine — the popup
-      // imports one job at a time, matching the Rust host's serial relay.
-      // `connectNative()` THROWS SYNCHRONOUSLY when the host isn't registered, so
-      // building the readiness promise is separated from awaiting it — that keeps
-      // the ws fallback probe firing in the SAME tick (no microtask hop) when
-      // native is unavailable, which the ws reconnect test relies on.
-      let readyPromise: Promise<NativeMessagingTransport> | null = null;
-      try {
-        readyPromise = connectNative();
-      } catch {
-        readyPromise = null; // host not registered → straight to ws, same tick.
-      }
-      if (readyPromise) {
-        try {
-          const native = await readyPromise;
-          this.port = null; // native has no port number; diagnostics only.
-          await this.attach(native);
-          return;
-        } catch (err) {
-          if (err instanceof Error && err.message === NATIVE_APP_DOWN) {
-            // Host reachable, app down — do NOT fall back to ws.
-            this.setPhase('app_not_running');
-            this.scheduleReconnect();
-            return;
-          }
-          // NATIVE_UNAVAILABLE → fall through to the ws probe.
-        }
-      }
-
-      const socket = await this.probeRange();
-      if (socket) {
-        await this.attach(new WebSocketTransport(socket));
-      } else {
-        this.setPhase('app_not_running');
-        this.scheduleReconnect();
-      }
+      await this.connectPromise;
     } finally {
-      this.connecting = false;
+      this.connectPromise = null;
+    }
+  }
+
+  /** The actual connect-then-handshake attempt tracked by {@link connectPromise}. */
+  private async doConnect(): Promise<void> {
+    this.setPhase('searching');
+    // Native first. ponytail: serial single-in-flight is fine — the popup
+    // imports one job at a time, matching the Rust host's serial relay.
+    // `connectNative()` THROWS SYNCHRONOUSLY when the host isn't registered, so
+    // building the readiness promise is separated from awaiting it — that keeps
+    // the ws fallback probe firing in the SAME tick (no microtask hop) when
+    // native is unavailable, which the ws reconnect test relies on.
+    let readyPromise: Promise<NativeMessagingTransport> | null;
+    try {
+      readyPromise = connectNative();
+    } catch {
+      readyPromise = null; // host not registered → straight to ws, same tick.
+    }
+    if (readyPromise) {
+      try {
+        const native = await readyPromise;
+        this.port = null; // native has no port number; diagnostics only.
+        await this.attach(native);
+        return;
+      } catch (err) {
+        if (err instanceof Error && err.message === NATIVE_APP_DOWN) {
+          // Host reachable, app down — do NOT fall back to ws.
+          this.setPhase('app_not_running');
+          this.scheduleReconnect();
+          return;
+        }
+        // NATIVE_UNAVAILABLE → fall through to the ws probe.
+      }
+    }
+
+    const socket = await this.probeRange();
+    if (socket) {
+      await this.attach(new WebSocketTransport(socket));
+    } else {
+      this.setPhase('app_not_running');
+      this.scheduleReconnect();
     }
   }
 
@@ -363,7 +421,8 @@ export class BridgeClient {
    */
   resetForNewToken(): void {
     this.authRejected = false;
-    if (this.phase === 'bad_token') {
+    this.outdated = false;
+    if (this.phase === 'bad_token' || this.phase === 'outdated') {
       this.setPhase('searching');
     }
   }
@@ -372,6 +431,10 @@ export class BridgeClient {
   dispose(): void {
     this.disposed = true;
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    // Settle any in-flight handshake step so its timeout timer is cleared.
+    this.handshakeClosed?.();
+    this.handshakeFrame = null;
+    this.handshakeClosed = null;
     for (const t of this.timers.values()) clearTimeout(t);
     this.timers.clear();
     this.pending.clear();
@@ -382,19 +445,26 @@ export class BridgeClient {
 
   /**
    * Send an `import.request` and resolve with the validated `import.result`
-   * payload. Rejects on no connection, timeout, or a malformed reply.
+   * payload. Rejects on no connection, timeout, or a malformed reply. The frame
+   * carries NO token — the socket is already authenticated by the v2 handshake.
+   *
+   * Gated on `this.phase === 'connected'` — the AUTHENTICATED SESSION — never on
+   * transport liveness. A non-null `this.transport` does NOT mean the peer is
+   * verified: `attach()` sets it before `performHandshake` checks the peer's
+   * `serverProof`. Only `'connected'` means the mutual handshake completed, so
+   * this is the seam that stops the active-tab DOM (or the profile) from ever
+   * reaching an unverified/rogue peer.
    */
-  async importJob(token: string, payload: ExtensionImportRequest): Promise<ExtensionImportResult> {
+  async importJob(payload: ExtensionImportRequest): Promise<ExtensionImportResult> {
     await this.ensureConnected();
-    const transport = this.transport;
-    if (!transport) {
+    if (this.phase !== 'connected' || !this.transport) {
       throw new Error('Desktop app not reachable. Is AI Job Hunter running?');
     }
+    const transport = this.transport;
 
     const reqId = newReqId();
     const envelope: ExtensionEnvelope = {
       type: EXTENSION_MESSAGE_TYPES.importRequest,
-      token,
       reqId,
       payload,
     };
@@ -426,17 +496,19 @@ export class BridgeClient {
    * on no connection / timeout / send failure. The profile is returned to the
    * caller transiently and is never stored by this client.
    */
-  async getProfile(token: string): Promise<ExtensionProfileResult> {
+  async getProfile(): Promise<ExtensionProfileResult> {
     await this.ensureConnected();
-    const transport = this.transport;
-    if (!transport) {
+    // Gate on the authenticated session — see the note on `importJob`. The
+    // Contact Profile is the highest-sensitivity payload this client sends;
+    // never hand it to a peer that has not proven it knows the pairing token.
+    if (this.phase !== 'connected' || !this.transport) {
       throw new Error('Desktop app not reachable. Is AI Job Hunter running?');
     }
+    const transport = this.transport;
 
     const reqId = newReqId();
     const envelope: ExtensionEnvelope = {
       type: EXTENSION_MESSAGE_TYPES.profileGet,
-      token,
       reqId,
       payload: null,
     };
@@ -471,14 +543,13 @@ export class BridgeClient {
 
   /** Try each port in order; resolve the first socket that reaches OPEN. */
   private async probeRange(): Promise<WebSocket | null> {
-    // TODO(bridge): the token is sent to the FIRST loopback port that answers in
-    // this range, so a same-account local process squatting a port before the app
-    // binds could harvest it on first import (accepted v1 risk). A harvested token
-    // now also grants Contact-Profile READ via profile.get (assisted autofill)
-    // whenever the user has that opt-in on, not just job-import — see the
-    // "Threat model" section in apps/extension/README.md for the full impact
-    // and the planned fix (server→client challenge HMAC over an in-app nonce, or
-    // the native-messaging fallback, which cannot be port-squatted).
+    // v2 mutual handshake: even though we still connect to the FIRST loopback
+    // port that answers, the pairing token is NEVER sent — the extension proves
+    // knowledge of it via HMAC and, crucially, verifies the desktop's own
+    // `serverProof` before sending ANY import/profile frame. A port-squatter that
+    // cannot produce a valid serverProof lands us in `bad_token` with zero PII
+    // sent (see performHandshake). See the "Threat model" section in
+    // apps/extension/README.md.
     this.setPhase('searching');
     for (let port = PORT_START; port <= PORT_END; port += 1) {
       const socket = await this.tryOpen(port);
@@ -526,90 +597,173 @@ export class BridgeClient {
     });
   }
 
-  /** Wire an opened transport, then perform the auth handshake if a token is stored. */
+  /** Wire an opened transport, then run the v2 handshake if a token is stored. */
   private async attach(transport: BridgeTransport): Promise<void> {
     this.transport = transport;
     this.backoffIndex = 0;
     this.authRejected = false;
+    this.outdated = false;
 
     transport.onMessage((env) => this.onMessage(env));
     transport.onClose(() => {
       this.transport = null;
       this.failAllPending('Connection to the desktop app closed.');
-      if (!this.disposed) {
-        if (this.authRejected) {
-          // Desktop closed the socket after rejecting our token — do NOT reconnect
-          // in a loop. The user must re-pair with a new token.
-          this.setPhase('bad_token');
-        } else {
-          this.setPhase('app_not_running');
-          this.scheduleReconnect();
-        }
+      // If a handshake is in flight, let it settle (it decides outdated /
+      // bad_token / reconnect) — don't set a phase or reconnect from here.
+      if (this.handshakeClosed) {
+        const notify = this.handshakeClosed;
+        this.handshakeClosed = null;
+        this.handshakeFrame = null;
+        notify();
+        return;
+      }
+      if (this.disposed) return;
+      if (this.authRejected) {
+        // Desktop rejected our proof (wrong token) — do NOT reconnect in a loop;
+        // the user must re-pair with a new token.
+        this.setPhase('bad_token');
+      } else if (this.outdated) {
+        // Desktop too old to speak v2 — recover on the next popup open / Retry.
+        this.setPhase('outdated');
+      } else {
+        this.setPhase('app_not_running');
+        this.scheduleReconnect();
       }
     });
 
-    // Auth handshake: if we have a stored token, verify it with the desktop
-    // before declaring the connection authorized.
+    // v2 mutual handshake: run it only if a token is stored. Without a token the
+    // socket is open but unpaired — computeStatus() surfaces that as 'not_paired'.
     const token = this.getStoredToken ? await this.getStoredToken() : null;
     if (!token) {
-      // No token stored — socket is open but we're not paired yet.  The
-      // background's computeStatus() will surface this as 'not_paired'.
       this.setPhase('connected');
       return;
     }
+    await this.performHandshake(token);
+  }
 
-    // Send the auth frame and await the import.result reply.
-    const reqId = newReqId();
-    const authEnvelope: ExtensionEnvelope = {
-      type: EXTENSION_MESSAGE_TYPES.auth,
-      token,
-      reqId,
-      payload: null,
-    };
+  /**
+   * Drive the v2 mutual HMAC handshake to completion. The token is used ONLY as
+   * an HMAC key — it never goes on the wire. The extension MUST verify the
+   * desktop's `serverProof` before this resolves `connected`; a peer that can't
+   * prove it knows the token (rogue/port-squatter) never receives any PII.
+   */
+  private async performHandshake(token: string): Promise<void> {
+    const transport = this.transport;
+    if (!transport) return;
 
-    const result = await new Promise<ExtensionImportResult>((resolve) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(reqId);
-        this.timers.delete(reqId);
-        // Treat a timeout the same as a failed auth — we cannot confirm.
-        resolve({ error: 'auth timeout' });
-      }, REQUEST_TIMEOUT_MS);
-      this.timers.set(reqId, timer);
-      this.pending.set(reqId, resolve);
+    const clientNonce = randomNonceHex();
 
-      try {
-        transport.send(authEnvelope);
-      } catch {
-        clearTimeout(timer);
-        this.timers.delete(reqId);
-        this.pending.delete(reqId);
-        resolve({ error: 'auth send failed' });
-      }
+    // Step 1: hello (no token) → await the desktop's challenge.
+    transport.send({
+      type: EXTENSION_MESSAGE_TYPES.hello,
+      reqId: newReqId(),
+      payload: { protocol: EXTENSION_PROTOCOL_VERSION, clientNonce },
     });
-
-    if (result.error === AUTH_ERROR_UNAUTHORIZED) {
-      // Explicit token rejection: block reconnect so the user must re-pair.
-      // The desktop closes the socket immediately after this reply; if it
-      // hasn't yet, close from our side so the onClose handler fires.
-      this.authRejected = true;
-      if (this.transport) {
-        this.transport.close();
-        this.transport = null;
-      }
-      this.setPhase('bad_token');
-    } else if (result.error) {
-      // Transport failure (timeout / connection-closed before reply / malformed):
-      // do NOT enter bad_token. Close cleanly so the onClose handler transitions
-      // to app_not_running + scheduleReconnect(), letting the extension recover
-      // when the desktop comes back.
-      if (this.transport) {
-        this.transport.close();
-        this.transport = null;
-      }
-      // onClose already fires on close(); don't double-set phase here.
-    } else {
-      this.setPhase('connected');
+    const step1 = await this.awaitHandshakeFrame();
+    if (step1.kind === 'timeout') {
+      // Total silence — treat as a transient transport failure (recoverable).
+      return this.finishHandshake('app_not_running');
     }
+    if (step1.kind === 'closed' || step1.env.type !== EXTENSION_MESSAGE_TYPES.challenge) {
+      // The desktop closed without a challenge, or replied a non-challenge frame
+      // (e.g. an old desktop's import.result / update.required). Either way it
+      // does not speak v2 → the user must update the desktop app.
+      return this.finishHandshake('outdated');
+    }
+    const serverNonce = readHexField(step1.env.payload, 'serverNonce');
+    // Defense-in-depth (mirrors the Rust `is_valid_nonce` shape check on the
+    // client nonce): reject a malformed/oversized serverNonce as a clean
+    // handshake failure BEFORE it feeds the HMAC — never silently proceed with
+    // attacker-shaped input. Grouped with "missing" as `outdated`: a peer whose
+    // very first reply doesn't carry a well-formed nonce does not properly speak
+    // v2.
+    if (!serverNonce || !isValidNonceHex(serverNonce)) {
+      return this.finishHandshake('outdated');
+    }
+
+    // Step 3: prove we know the token (HMAC over the client role) → await auth.ok.
+    const clientProof = await computeProof(token, 'client', serverNonce, clientNonce);
+    if (!this.transport) {
+      // Socket closed while we were computing the proof. AMBIGUOUS: the Rust
+      // `Unauthorized` path closes WITHOUT a reply BY DESIGN (see
+      // extension_bridge/mod.rs), so this is indistinguishable from a genuine
+      // app crash/restart. Never assert a hard wrong-token verdict from silence
+      // alone — recoverable, consistent with the step-1 timeout above.
+      return this.finishHandshake('app_not_running');
+    }
+    this.transport.send({
+      type: EXTENSION_MESSAGE_TYPES.auth,
+      reqId: newReqId(),
+      payload: { proof: clientProof },
+    });
+    const step2 = await this.awaitHandshakeFrame();
+    if (step2.kind === 'closed' || step2.kind === 'timeout') {
+      // No auth.ok arrived — silence (closed or timed out) after we already sent
+      // our proof. Same ambiguity as above: the Rust `Unauthorized` path closes
+      // without a reply, indistinguishable from a crash. Recoverable.
+      return this.finishHandshake('app_not_running');
+    }
+    if (step2.env.type !== EXTENSION_MESSAGE_TYPES.authOk) {
+      // The peer DID reply — with something other than auth.ok. Unlike silence,
+      // this is an actual, non-ambiguous response from a peer that spoke v2 far
+      // enough to send a challenge; treat it as untrusted → bad_token (re-pair).
+      return this.finishHandshake('bad_token');
+    }
+
+    // Step 5: verify the desktop's serverProof CONSTANT-TIME before trusting it.
+    const serverProof = readHexField(step2.env.payload, 'serverProof');
+    const expected = await computeProof(token, 'server', serverNonce, clientNonce);
+    if (!serverProof || !constantTimeHexEqual(serverProof, expected)) {
+      // The peer cannot prove it knows the token (rogue/port-squatter). We have
+      // sent NO PII (import/profile only happen after 'connected'); drop the
+      // socket and surface bad_token.
+      return this.finishHandshake('bad_token');
+    }
+
+    // Mutual auth complete — the socket is authenticated.
+    this.handshakeFrame = null;
+    this.handshakeClosed = null;
+    this.setPhase('connected');
+  }
+
+  /**
+   * Await the next handshake frame, a socket close, or a per-step timeout. While
+   * pending, `onMessage` routes EVERY incoming frame here (no import/profile
+   * frames are expected before the socket is authenticated).
+   */
+  private awaitHandshakeFrame(): Promise<HandshakeStep> {
+    return new Promise<HandshakeStep>((resolve) => {
+      let done = false;
+      const settle = (step: HandshakeStep): void => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        this.handshakeFrame = null;
+        this.handshakeClosed = null;
+        resolve(step);
+      };
+      const timer = setTimeout(() => settle({ kind: 'timeout' }), HANDSHAKE_TIMEOUT_MS);
+      this.handshakeFrame = (env) => settle({ kind: 'frame', env });
+      this.handshakeClosed = () => settle({ kind: 'closed' });
+    });
+  }
+
+  /**
+   * Terminal handshake outcome: clear the handshake hooks, set the phase, and
+   * drop the transport. `bad_token` / `outdated` suppress the reconnect loop;
+   * `app_not_running` schedules a reconnect (a transient transport blip).
+   */
+  private finishHandshake(phase: 'app_not_running' | 'outdated' | 'bad_token'): void {
+    this.handshakeFrame = null;
+    this.handshakeClosed = null;
+    if (phase === 'bad_token') this.authRejected = true;
+    if (phase === 'outdated') this.outdated = true;
+    const transport = this.transport;
+    this.transport = null;
+    transport?.close();
+    if (this.disposed) return;
+    this.setPhase(phase);
+    if (phase === 'app_not_running') this.scheduleReconnect();
   }
 
   /** Clear + return the correlation timer for a settled `reqId`. */
@@ -625,6 +779,15 @@ export class BridgeClient {
   private onMessage(parsed: unknown): void {
     if (typeof parsed !== 'object' || parsed === null) return;
     const env = parsed as Partial<ExtensionEnvelope>;
+
+    // While the v2 handshake is in flight, EVERY frame goes to the handshake
+    // driver (challenge / auth.ok / an unexpected non-v2 reply). No import or
+    // profile frames are expected before the socket is authenticated.
+    if (this.handshakeFrame) {
+      this.handshakeFrame(env);
+      return;
+    }
+
     const reqId = typeof env.reqId === 'string' ? env.reqId : '';
 
     // profile.result → the assisted-autofill contact profile (separate map).

--- a/apps/extension/src/lib/handshake.test.ts
+++ b/apps/extension/src/lib/handshake.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Cross-implementation known-answer test for the v2 handshake HMAC.
+ *
+ * This asserts the extension's REAL Web Crypto (`crypto.subtle`) proof equals the
+ * SAME shared vector the Rust side asserts against its `hmac` crate
+ * (`apps/desktop/src-tauri/src/extension_bridge/handshake.rs::kat_*`). If the two
+ * byte-canonicalizations ever drift, one side's KAT fails loudly instead of the
+ * handshake silently never matching. The vector lives in `@ajh/shared` so both
+ * the TS and Rust tests point at one source of truth.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { HANDSHAKE_TEST_VECTOR } from '@ajh/shared/extension-protocol';
+
+import { computeProof, constantTimeHexEqual, isValidNonceHex, randomNonceHex } from './handshake';
+
+describe('handshake HMAC — shared cross-impl known-answer vector', () => {
+  const v = HANDSHAKE_TEST_VECTOR;
+
+  it('the Web Crypto client proof matches the shared vector (byte-identical with Rust)', async () => {
+    expect(await computeProof(v.token, 'client', v.serverNonce, v.clientNonce)).toBe(v.clientProof);
+  });
+
+  it('the Web Crypto server proof matches the shared vector (byte-identical with Rust)', async () => {
+    expect(await computeProof(v.token, 'server', v.serverNonce, v.clientNonce)).toBe(v.serverProof);
+  });
+
+  it('the client and server proofs are domain-separated (role changes the proof)', async () => {
+    const client = await computeProof(v.token, 'client', v.serverNonce, v.clientNonce);
+    const server = await computeProof(v.token, 'server', v.serverNonce, v.clientNonce);
+    expect(client).not.toBe(server);
+  });
+});
+
+describe('constantTimeHexEqual', () => {
+  it('accepts equal strings and rejects any difference (content or length)', () => {
+    expect(constantTimeHexEqual('deadbeef', 'deadbeef')).toBe(true);
+    expect(constantTimeHexEqual('deadbeef', 'deadbeff')).toBe(false);
+    expect(constantTimeHexEqual('deadbeef', 'deadbee')).toBe(false);
+    expect(constantTimeHexEqual('', '')).toBe(true);
+  });
+});
+
+describe('randomNonceHex', () => {
+  it('returns 32 lowercase-hex chars (16 bytes), fresh per call', () => {
+    const a = randomNonceHex();
+    const b = randomNonceHex();
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
+    expect(b).toMatch(/^[0-9a-f]{32}$/);
+    expect(a).not.toBe(b);
+  });
+
+  it('every generated nonce passes isValidNonceHex (round-trip with the validator)', () => {
+    expect(isValidNonceHex(randomNonceHex())).toBe(true);
+  });
+});
+
+describe('isValidNonceHex', () => {
+  it('accepts exactly 32 lowercase-hex chars', () => {
+    expect(isValidNonceHex('00112233445566778899aabbccddeeff'.slice(0, 32))).toBe(true);
+    expect(isValidNonceHex('ffeeddccbbaa99887766554433221100')).toBe(true);
+  });
+
+  it('rejects wrong length, uppercase, and non-hex — mirrors the Rust is_valid_nonce shape check', () => {
+    expect(isValidNonceHex('')).toBe(false);
+    expect(isValidNonceHex('tooshort')).toBe(false);
+    expect(isValidNonceHex('a'.repeat(31))).toBe(false); // one short
+    expect(isValidNonceHex('a'.repeat(33))).toBe(false); // one over
+    expect(isValidNonceHex('00112233445566778899AABBCCDDEEFF')).toBe(false); // uppercase
+    expect(isValidNonceHex('not-hex!!'.padEnd(32, '0'))).toBe(false); // non-hex chars
+  });
+});

--- a/apps/extension/src/lib/handshake.ts
+++ b/apps/extension/src/lib/handshake.ts
@@ -1,0 +1,88 @@
+/**
+ * Extension side of the v2 mutual HMAC challenge-response handshake.
+ *
+ * The pairing token is used ONLY as an HMAC key here — it is NEVER sent on the
+ * wire. `computeProof` produces `HMAC-SHA256(key = utf8(token), msg =
+ * handshakeMessage(role, serverNonce, clientNonce))` as lowercase hex, using the
+ * MV3 service-worker's Web Crypto (`crypto.subtle`). The message
+ * canonicalization is imported from `@ajh/shared` so it is byte-identical to the
+ * Rust side; a shared known-answer vector ({@link handshake.test.ts}) pins both.
+ *
+ * MV3/AMO note: this uses only `crypto.subtle` + `crypto.getRandomValues`
+ * (available in the SW context) and imports from the zod-free
+ * `@ajh/shared/extension-protocol` — no `eval`, no dynamic import, no zod.
+ */
+
+import { handshakeMessage, type HandshakeRole } from '@ajh/shared/extension-protocol';
+
+const encoder = new TextEncoder();
+
+/** Nonce length on the wire: 16 random bytes → 32 lowercase-hex chars. */
+const NONCE_BYTES = 16;
+const NONCE_HEX_PATTERN = /^[0-9a-f]{32}$/;
+
+/** Lowercase-hex encode a byte buffer (matches the Rust/`token` hex encoding). */
+function bytesToHex(bytes: Uint8Array): string {
+  let out = '';
+  for (const b of bytes) out += b.toString(16).padStart(2, '0');
+  return out;
+}
+
+/**
+ * A fresh CSPRNG nonce as lowercase hex. 16 bytes (32 hex chars) — matches the
+ * desktop's `handshake::new_nonce`. Never reuse a nonce across connections.
+ */
+export function randomNonceHex(bytes: number = NONCE_BYTES): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return bytesToHex(buf);
+}
+
+/**
+ * Whether `s` is a well-formed nonce as this protocol emits: exactly 32
+ * lowercase-hex chars (16 bytes). Mirrors the Rust `handshake::is_valid_nonce`
+ * shape check. Applied to the desktop's `serverNonce` before it feeds the HMAC —
+ * defense-in-depth so a malformed/oversized peer nonce is a clean handshake
+ * failure, never silently accepted into the signed message.
+ */
+export function isValidNonceHex(s: string): boolean {
+  return NONCE_HEX_PATTERN.test(s);
+}
+
+/**
+ * Compute the handshake proof for a role. `key` is the token's raw UTF-8 bytes
+ * (the token is 64-char lowercase hex; its 64 ASCII bytes are the key). Returns
+ * the HMAC-SHA256 as lowercase hex.
+ */
+export async function computeProof(
+  token: string,
+  role: HandshakeRole,
+  serverNonce: string,
+  clientNonce: string
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(token),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const message = encoder.encode(handshakeMessage(role, serverNonce, clientNonce));
+  const sig = await crypto.subtle.sign('HMAC', key, message);
+  return bytesToHex(new Uint8Array(sig));
+}
+
+/**
+ * Constant-time equality for two lowercase-hex strings — used to verify the
+ * desktop's `serverProof` without an early-return timing side channel. The
+ * length check is safe (both proofs are a fixed 64 hex chars; length is not
+ * secret); the byte loop never short-circuits on the first mismatch.
+ */
+export function constantTimeHexEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -14,10 +14,17 @@ type ConnectionPhase =
   | 'searching'
   /** A bridge port answered but no token is stored — show the pairing screen. */
   | 'not_paired'
-  /** Paired token present and the auth handshake with the desktop succeeded. */
+  /** Paired + the v2 mutual handshake (incl. serverProof) with the desktop succeeded. */
   | 'connected'
   /** No bridge port answered in the probe range — the app is not running. */
   | 'app_not_running'
+  /**
+   * The desktop is too old to speak the v2 handshake (it never sent a
+   * `challenge` — it closed the socket instead) — the user must UPDATE the
+   * desktop app. Distinct from `bad_token` (a real token mismatch on a genuine
+   * v2 desktop) and `app_not_running` (nothing answered at all).
+   */
+  | 'outdated'
   /** The stored token was rejected by the desktop — the user must re-pair. */
   | 'bad_token';
 

--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -129,6 +129,17 @@
         <button id="btn-get-app" class="btn btn--primary" type="button">Get the app</button>
       </section>
 
+      <!-- Outdated-desktop state: the pill reads "⟳ Update the app". The stored
+           pairing token is fine — the desktop app is too old to speak the v2
+           handshake, so it must be updated (NOT re-paired). The header Retry
+           re-checks the connection once the app is updated. -->
+      <section id="view-outdated" class="view" hidden>
+        <p class="hint">
+          Your AI Job Hunter desktop app is out of date. Update it to reconnect the extension.
+        </p>
+        <button id="btn-update-app" class="btn btn--primary" type="button">Update the app</button>
+      </section>
+
       <!-- Searching state: the "○ Connecting…" pill conveys it; no body needed. -->
       <section id="view-searching" class="view"></section>
     </main>

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -56,6 +56,8 @@ function buildPopupDom(): void {
     <button id="btn-help"></button>
     <p id="help-popover" hidden></p>
     <button id="btn-get-app"></button>
+    <div id="view-outdated" hidden></div>
+    <button id="btn-update-app"></button>
   `;
 }
 
@@ -497,5 +499,33 @@ describe('offline-sticky — searching after app_not_running must not hide offli
     push('searching');
     expect(searchingView.hidden).toBe(false);
     expect(offlineView.hidden).toBe(true);
+  });
+});
+
+// ── outdated-desktop view (v2 handshake force cutover) ──────────────────────────
+
+describe('outdated-desktop view', () => {
+  const statusListener = vi.mocked(browser.runtime.onMessage.addListener).mock.calls[0]?.[0] as
+    ((message: unknown) => void) | undefined;
+  if (!statusListener) throw new Error('onMessage status listener not registered');
+  const push = (phase: ConnectionStatus['phase']) =>
+    statusListener({ ok: true, kind: 'status', status: { phase, port: null, hasToken: true } });
+
+  it('shows the dedicated update view (NOT the pairing view) and the update pill', () => {
+    push('outdated');
+
+    const outdatedView = byId<HTMLElement>('view-outdated');
+    const pairView = byId<HTMLElement>('view-pair');
+    const importView = byId<HTMLElement>('view-import');
+    const pill = byId<HTMLSpanElement>('status-pill');
+    const retry = byId<HTMLButtonElement>('btn-retry');
+
+    expect(outdatedView.hidden).toBe(false);
+    // Critical: an outdated desktop is NOT a token problem — never show pairing.
+    expect(pairView.hidden).toBe(true);
+    expect(importView.hidden).toBe(true);
+    expect(pill.textContent).toBe('⟳ Update the app');
+    // Retry is available so the user can re-probe after updating the app.
+    expect(retry.hidden).toBe(false);
   });
 });

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -99,6 +99,7 @@ const els = {
     import: byId<HTMLElement>('view-import'),
     pair: byId<HTMLElement>('view-pair'),
     offline: byId<HTMLElement>('view-offline'),
+    outdated: byId<HTMLElement>('view-outdated'),
     searching: byId<HTMLElement>('view-searching'),
   },
   btnImport: byId<HTMLButtonElement>('btn-import'),
@@ -114,6 +115,7 @@ const els = {
   btnHelp: byId<HTMLButtonElement>('btn-help'),
   helpPopover: byId<HTMLParagraphElement>('help-popover'),
   btnGetApp: byId<HTMLButtonElement>('btn-get-app'),
+  btnUpdateApp: byId<HTMLButtonElement>('btn-update-app'),
 };
 
 /** Actionable label for the pairing button; restored after a failed/cleared pair. */
@@ -134,6 +136,7 @@ const PILL_LABEL: Record<ConnectionStatus['phase'], string> = {
   not_paired: '⚠ Not paired',
   connected: '● Connected',
   app_not_running: '✕ App not running',
+  outdated: '⟳ Update the app',
   bad_token: '✕ Wrong token',
 };
 
@@ -179,6 +182,9 @@ function showView(phase: ConnectionStatus['phase']): void {
   // enter a corrected token in both cases.
   els.views.pair.hidden = phase !== 'not_paired' && phase !== 'bad_token';
   els.views.offline.hidden = phase !== 'app_not_running';
+  // Outdated desktop: a distinct "update the desktop app" view (NOT the pairing
+  // view — the token is fine; the app is too old to speak the v2 handshake).
+  els.views.outdated.hidden = phase !== 'outdated';
   els.views.searching.hidden = phase !== 'searching';
 }
 
@@ -192,7 +198,8 @@ function render(status: ConnectionStatus): void {
   } else if (
     status.phase === 'connected' ||
     status.phase === 'not_paired' ||
-    status.phase === 'bad_token'
+    status.phase === 'bad_token' ||
+    status.phase === 'outdated'
   ) {
     // A real outcome arrived — reset so the next session starts fresh.
     hasShownOffline = false;
@@ -211,9 +218,9 @@ function render(status: ConnectionStatus): void {
 
   els.pill.textContent = PILL_LABEL[status.phase];
   els.pill.className = `pill pill--${status.phase}`;
-  // Retry lives in the header (left of the pill) and only makes sense when the
-  // app is unreachable — a reconnect is a no-op once the app is up.
-  els.btnRetry.hidden = status.phase !== 'app_not_running';
+  // Retry lives in the header (left of the pill) and makes sense when the app is
+  // unreachable OR outdated (re-probe after the user updates the desktop app).
+  els.btnRetry.hidden = status.phase !== 'app_not_running' && status.phase !== 'outdated';
   showView(status.phase);
   // On bad_token, surface a clear error in the pairing view so the user knows
   // they need to copy the current token from the desktop app's Settings.
@@ -420,6 +427,9 @@ function wire(): void {
   els.btnRetry.addEventListener('click', () => void retry());
   els.btnOpenSettings.addEventListener('click', () => void openAppPairing());
   els.btnGetApp.addEventListener('click', () => void getApp());
+  // The outdated-desktop view sends the user to the same download page (which
+  // serves the latest build) to update their app.
+  els.btnUpdateApp.addEventListener('click', () => void getApp());
   els.btnHelp.addEventListener('click', toggleHelp);
 
   // Live status pushes from the background while the popup is open.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -124,22 +124,31 @@ _Avoid_: auto-apply / auto-submit (autofill never submits — the human does), s
 no file upload; complex ATS partial)
 
 **Pairing token**:
-The per-install secret the browser extension sends on every bridge frame (`token` field).
-Generated on app first-run, persisted to the app data dir, and rotatable via the
-`extension_bridge_regenerate_token` IPC command. Shown in Settings for the user to
-copy/paste into the extension. A mismatch closes the socket; the pair is 256-bit random,
-lowercase hex.
-_Avoid_: API key, credential (it authenticates only to the local app, never remote)
+The per-install shared secret that authenticates the browser extension to the local
+bridge. **In protocol v2 it is never transmitted** — it is used only as the
+**HMAC-SHA256 key** in a mutual challenge-response handshake (each side proves it knows
+the token over exchanged per-connection nonces; token stays on both machines). Generated
+on app first-run, persisted to the app data dir (per-user file perms), rotatable via the
+`extension_bridge_regenerate_token` IPC command, and shown in Settings to copy/paste into
+the extension. 256-bit random, lowercase hex. See [ADR 0010](adr/0010-bridge-hmac-handshake.md).
+_Avoid_: API key, credential (it authenticates only to the local app, never remote);
+"sent on every frame" / a `token` field on the wire (v1 behavior — v2 never puts the
+token on the wire)
 
 **Connection phase**:
 The bridge/extension link state the popup renders. Canonical set: `app_not_running`
-(desktop app unreachable), `searching` (probing/reconnecting — also the state a transient
-auth **timeout** folds into: transient → retry), `not_paired` (no token stored), `bad_token`
-(a wrong token, surfaced only via the server's **explicit error reply** before it closes the
-socket — never inferred from a timeout), and `connected` (auth handshake succeeded). A
-handshake timeout is a transport failure (→ `searching`), not a token failure.
-_Avoid_: an `auth_timeout` phase (a timeout is transient, not a distinct terminal state);
-treating a timeout as `bad_token` (falsely accuses a good token)
+(desktop unreachable — also where an **ambiguous silent socket-close** folds, because the
+v2 desktop rejects a bad proof by closing **without a reply**, indistinguishable from a
+crash, so it stays recoverable), `searching` (probing/reconnecting), `not_paired` (no token
+stored), `bad_token` (a real, **unambiguous** auth failure — the peer sent an `auth.ok`
+whose **`serverProof` fails verification**, i.e. a rogue/mismatched server; the extension
+sends zero PII), `outdated` (a **protocol-version mismatch** — a v2 extension reached a v1
+desktop or vice versa; the user must update the app/extension), and `connected` (the
+**mutual** handshake verified — the only state in which `import`/`profile.get` frames are
+sent). See [ADR 0010](adr/0010-bridge-hmac-handshake.md).
+_Avoid_: inferring `bad_token` from a silent close/timeout (v2 auth failure closes with no
+reply → ambiguous with a crash → treat as recoverable `app_not_running`, never falsely
+accuse a good token); an `auth_timeout` phase
 
 **Scan mode** vs **URL mode**:
 Two import paths on the extension bridge. **Scan mode** sends the rendered (authenticated)

--- a/docs/adr/0010-bridge-hmac-handshake.md
+++ b/docs/adr/0010-bridge-hmac-handshake.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+---
+
+# Bridge authentication via mutual HMAC handshake (protocol v2)
+
+## Context
+
+The desktop⇄extension bridge (Feature 2) authenticated every frame with the **pairing token sent in plaintext** — an `auth` frame right after the socket opens, then the same `token` field on every `import.request`. Three layers guarded the channel: the WS `Origin` allowlist, the per-frame token, and the up-front `auth` check.
+
+The weakness is that the token rides the wire. The bridge binds `127.0.0.1` loopback; a **malicious local process that squats the port before the real app starts** becomes the server the extension connects to, receives the `auth` frame, and **harvests a reusable token**. With the extension autofill feature ([ADR 0009](0009-assisted-autofill.md)), that token also grants Contact-Profile read, so the blast radius grew — a `tauri-security-reviewer` finding on that PR flagged the port-squat risk as newly PII-bearing and recommended a proper challenge/HMAC handshake now that PII rides the same auth path. The token comparison was also a plain `!=` (not constant-time).
+
+The threat is bounded (same-account local process, squat-before-bind, per-user `0o600` token file so the squatter can't just read it), but it is real on multi-user machines, and "a reusable secret transmitted in the clear" is the wrong shape for something now gating PII.
+
+## Decision
+
+Replace plaintext-token-per-frame auth with a **mutual HMAC-SHA256 challenge-response handshake (protocol v2)**. The pairing token becomes **only an HMAC key and is never transmitted**.
+
+**Handshake** (v2 envelope is `{type, reqId, payload}` — no `token` field):
+
+1. Extension → `hello { protocol: 2, clientNonce }`
+2. Desktop → `challenge { serverNonce }`
+3. Extension → `auth { proof }`, `proof = HMAC-SHA256(key=token, "ajh-bridge/v2\n" + "client" + "\n" + serverNonceHex + "\n" + clientNonceHex)`
+4. Desktop verifies **constant-time**; on failure it closes **with no reply** (no oracle). On success → `auth.ok { serverProof }` with role `"server"`.
+5. Extension verifies `serverProof` constant-time. **This is the mutual half** — if the server cannot prove it knows the token (a port-squatter), the extension aborts and sends **zero PII**. One-way auth would let a rogue server harvest the profile, so mutual is required.
+6. After the handshake the socket is an **authenticated session**: `import.request`/`profile.get` carry **no token** and are authorized by the verified connection, not a per-frame secret. The extension sends application frames **only** in the `connected` phase.
+
+**Invariants:** token never on the wire; HMAC over a domain-separated (`role`) canonical message so the client/server proofs are independent (no reflection); fresh CSPRNG nonces (≥16 bytes) per connection (no replay); constant-time verification both sides (Rust `Mac::verify_slice`, TS non-short-circuiting compare); the profile still honors the autofill opt-in gate desktop-side.
+
+**Rollout: force cutover (hard, no dual-support on the desktop).** The desktop **rejects** any legacy plaintext-token frame with an `update.required` reply and close. A new `outdated` connection phase surfaces the version mismatch on both sides ("update the desktop app" / "update the extension"). A **cross-implementation known-answer test vector** pins the Rust (`hmac` crate) and TS (Web Crypto) HMAC canonicalizations byte-for-byte so they can never drift silently.
+
+## Considered options
+
+1. **Mutual HMAC challenge-response, force cutover (chosen).** Token never transmitted; a squatter learns no reusable secret and cannot impersonate the app to obtain PII. Simplest desktop code (one path). Cost: the hard cutover breaks the bridge for any not-yet-updated install until both sides update, and needs clear "update required" UX on both ends.
+2. **Dual-support (accept v2 handshake AND legacy plaintext token), deprecate later.** No user breakage during transition, but keeps the plaintext path — and thus the vulnerability — alive until old installs age out, and doubles the auth code + its attack surface. Rejected: the owner chose the stronger immediate posture.
+3. **One-way auth (only the client proves knowledge).** Stops token-harvest but NOT a rogue server harvesting the profile (the client would still send PII to a squatter it can't distinguish from the app). Rejected: fails the actual goal (protecting PII), not just the token.
+4. **Per-frame MAC instead of session auth.** Re-authenticate every frame with an HMAC. Rejected: unnecessary for a fixed loopback socket whose identity is stable once the handshake verifies it; session auth is simpler with equal security.
+5. **OS-level port protection only** (e.g. exclusive bind). Rejected: can't prevent a squatter that binds _before_ the app starts, and doesn't address the plaintext-token-at-rest-in-transit shape.
+
+## Consequences
+
+- **Hard cutover has a transition window.** Until a user updates _both_ the desktop app and the extension, the bridge shows an `outdated`/update prompt and won't connect. The already-published old extension can't be given nicer UX; the new extension gets the clean `outdated` view. Releases should be sequenced with this in mind.
+- **`bad_token` now means an unambiguous rogue/mismatched server** (a failed `serverProof`), not "a wrong token inferred from a close." Because the desktop rejects a bad proof by closing with no reply (no oracle), an ambiguous silent close is treated as recoverable `app_not_running`, never as a false token accusation. The `Connection phase` and `Pairing token` glossary terms are updated accordingly.
+- **A second `hmac` crate version** (`0.12`, RustCrypto, digest-0.10, paired with the existing `sha2 0.10`) enters the tree alongside the pre-existing Unix-only `hmac 0.13`; tolerated by `deny.toml`'s `multiple-versions = "warn"`, both MIT/Apache and advisory-clean.
+- **The pairing UX is unchanged** — the token is still generated on first run, shown in Settings, pasted into the extension, and rotatable; only its _use_ changed (HMAC key, not a transmitted secret).
+- **Native-messaging and WS transports** both carry the handshake identically (the native host is a 1:1 relay).
+
+## References
+
+- Protocol: `packages/shared/src/ipc/extension-protocol-constants.ts` + `extension-protocol.ts` (`hello`/`challenge`/`auth`/`auth.ok`/`update.required`, `HANDSHAKE_TEST_VECTOR`, `EXTENSION_PROTOCOL_VERSION`).
+- Desktop: `apps/desktop/src-tauri/src/extension_bridge/handshake.rs` (HMAC core, constant-time verify, nonces, KAT), `mod.rs` (`ConnState` state machine).
+- Extension: `apps/extension/src/lib/handshake.ts` (Web-Crypto proof, constant-time hex compare), `bridge.ts` (`performHandshake`, `connected`-gated send path, `outdated` phase).
+- Related: [ADR 0009](0009-assisted-autofill.md) (the autofill PII path this hardens); `Pairing token` / `Connection phase` in `docs/CONTEXT.md`; `apps/extension/README.md` threat model.

--- a/packages/shared/src/ipc/extension-protocol-constants.ts
+++ b/packages/shared/src/ipc/extension-protocol-constants.ts
@@ -7,30 +7,68 @@
  * The zod schemas in `extension-protocol.ts` are bound to these interfaces so the
  * two can never drift. This module is pure data + types — no zod, no `window`,
  * no Node.
+ *
+ * ## Protocol v2 — mutual HMAC challenge-response (the token NEVER goes on the wire)
+ * v2 replaces the plaintext per-frame token with a mutual challenge-response so
+ * neither a passive observer nor a port-squatter ever sees the pairing secret:
+ *
+ * 1. Extension → `hello  { protocol: 2, clientNonce }`   (no token)
+ * 2. Desktop   → `challenge { serverNonce }`
+ * 3. Extension → `auth   { proof }`      proof = HMAC-SHA256(token, CLIENT_MSG)
+ * 4. Desktop verifies `proof` CONSTANT-TIME → `auth.ok { serverProof }`
+ *                                       serverProof = HMAC-SHA256(token, SERVER_MSG)
+ * 5. Extension verifies `serverProof` CONSTANT-TIME. Only then is the socket
+ *    authenticated; a bad `serverProof` means the peer can't prove it knows the
+ *    token (rogue/port-squatter) → the extension sends NO profile/PII.
+ * 6. After auth the socket is session-authenticated: subsequent frames
+ *    (`import.request`, `profile.get`, …) carry NO token — the desktop authorizes
+ *    them by the already-authenticated connection.
+ *
+ * The HMAC key is the token's raw UTF-8 bytes (the token is 64-char lowercase
+ * hex; its 64 ASCII bytes are the key). The message is domain-separated and
+ * canonical so both implementations build a byte-identical string — see
+ * {@link handshakeMessage}. Force cutover: the desktop rejects any legacy
+ * `{ type:'auth', token }` first frame with `update.required` and closes.
  */
 
+/** Current handshake protocol version carried in the `hello` frame. */
+export const EXTENSION_PROTOCOL_VERSION = 2;
+
 /**
- * Every wire message `type`. v1 implements `auth` / `import.request` /
- * `import.result`; `match.live` and `applied.check` are **reserved** — the type
- * strings are fixed now so a future build can add handlers without a protocol
- * bump, but the bridge does not handle them yet. `auth` is the connection-time
- * token check the extension sends immediately after the socket opens (no
- * payload): on success the desktop replies with an `import.result` envelope that
- * carries no `error`; a bad token gets the unauthorized error reply and the
- * socket is closed.
+ * Every wire message `type`. The v2 handshake types are `hello` / `challenge` /
+ * `auth` (now carrying `{ proof }`, NOT a token) / `auth.ok`; `update.required`
+ * is the force-cutover reply the desktop sends when a connection's first frame
+ * is not a valid v2 `hello` (a legacy token `auth`, a missing/older protocol).
+ * `import.request` / `import.result` / `profile.get` / `profile.result` are the
+ * post-auth application frames; `match.live` and `applied.check` are **reserved**
+ * (fixed now so a future build can add handlers without a protocol bump).
  */
 export const EXTENSION_MESSAGE_TYPES = {
-  /** Extension → desktop: connection-time token verification; no payload. */
+  /** Extension → desktop: handshake step 1 — `{ protocol, clientNonce }`, no token. */
+  hello: 'hello',
+  /** Desktop → extension: handshake step 2 — `{ serverNonce }`. */
+  challenge: 'challenge',
+  /** Extension → desktop: handshake step 3 — `{ proof }` (HMAC over the client role). */
   auth: 'auth',
-  /** Extension → desktop: import a job (URL mode, or Scan mode with `html`). */
+  /** Desktop → extension: handshake step 4 — `{ serverProof }` (HMAC over the server role). */
+  authOk: 'auth.ok',
+  /**
+   * Desktop → extension: force-cutover signal. Sent (then the socket closes) when
+   * a connection's first frame is not a valid protocol-2 `hello` — e.g. an old
+   * extension's legacy `{ type:'auth', token }` frame. The new extension surfaces
+   * this (and a never-a-`challenge` outcome) as an `outdated` state.
+   */
+  updateRequired: 'update.required',
+  /** Extension → desktop: import a job (URL mode, or Scan mode with `html`). No token. */
   importRequest: 'import.request',
   /** Desktop → extension: the import outcome (or an `error`). */
   importResult: 'import.result',
   /**
    * Extension → desktop: fetch the user's Contact Profile fresh for assisted
-   * autofill; no payload (authed by the per-frame token). The desktop returns
-   * the profile ONLY when the autofill opt-in is on, else a refusal `error`. The
-   * profile is held transiently for the one fill and NEVER persisted client-side.
+   * autofill; no payload (authed by the already-authenticated session). The
+   * desktop returns the profile ONLY when the autofill opt-in is on, else a
+   * refusal `error`. The profile is held transiently for the one fill and NEVER
+   * persisted client-side.
    */
   profileGet: 'profile.get',
   /** Desktop → extension: the contact profile fields for autofill (or an `error`). */
@@ -44,6 +82,81 @@ export const EXTENSION_MESSAGE_TYPES = {
 /** Union of all wire `type` strings. */
 export type ExtensionMessageType =
   (typeof EXTENSION_MESSAGE_TYPES)[keyof typeof EXTENSION_MESSAGE_TYPES];
+
+// ── Handshake message canonicalization (byte-identical on both sides) ──────────
+
+/**
+ * Domain-separation prefix for the handshake HMAC. Bumped with the protocol
+ * version so a v1↔v2 confusion can never produce a matching proof.
+ */
+export const HANDSHAKE_DOMAIN = 'ajh-bridge/v2';
+
+/** The two HMAC roles: the client proves in step 3, the server proves in step 4. */
+export type HandshakeRole = 'client' | 'server';
+
+/**
+ * Build the canonical, domain-separated message that both sides HMAC (keyed by
+ * the token's raw UTF-8 bytes). Byte-for-byte identical on the Rust and Web
+ * Crypto sides — the shared known-answer vector ({@link HANDSHAKE_TEST_VECTOR})
+ * pins this so the two canonicalizations can never silently drift:
+ *
+ * ```text
+ * ajh-bridge/v2\n<role>\n<serverNonceHex>\n<clientNonceHex>
+ * ```
+ *
+ * Nonces are lowercase-hex strings (≥16 random bytes, fresh per connection).
+ */
+export function handshakeMessage(
+  role: HandshakeRole,
+  serverNonceHex: string,
+  clientNonceHex: string
+): string {
+  return `${HANDSHAKE_DOMAIN}\n${role}\n${serverNonceHex}\n${clientNonceHex}`;
+}
+
+/**
+ * Cross-implementation known-answer vector for the handshake HMAC. Asserted by a
+ * TS test (Web Crypto) AND a Rust test (`extension_bridge::handshake`) against
+ * the SAME expected proofs — if the two byte-canonicalizations ever drift, one
+ * side's KAT fails loudly instead of the handshake silently never matching.
+ *
+ * `proof = HMAC-SHA256(key = utf8(token), msg = handshakeMessage(role, serverNonce, clientNonce))`,
+ * lowercase hex. The token here is a fixed 64-char hex string (its 64 ASCII bytes
+ * are the key).
+ */
+export const HANDSHAKE_TEST_VECTOR = {
+  token: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+  clientNonce: '00112233445566778899aabbccddeeff',
+  serverNonce: 'ffeeddccbbaa99887766554433221100',
+  clientProof: 'fe16f06234473b154c4e96d43bd25c603975cb2584f950d0d4f495edc5c44f1a',
+  serverProof: '75c05269902c14d97ee61a05f4c9dbf812c532735b836665da250b19ce405831',
+} as const;
+
+// ── Payload shapes ─────────────────────────────────────────────────────────────
+
+/** `hello` payload — the handshake opener. `protocol` gates the force cutover. */
+export interface ExtensionHelloPayload {
+  protocol: number;
+  /** Fresh client nonce, lowercase hex (≥16 bytes). */
+  clientNonce: string;
+}
+
+/** `challenge` payload — the server's fresh nonce, lowercase hex (≥16 bytes). */
+export interface ExtensionChallengePayload {
+  serverNonce: string;
+}
+
+/** `auth` payload — the client's proof; the token is NEVER on the wire in v2. */
+export interface ExtensionAuthPayload {
+  /** HMAC-SHA256(token, CLIENT_MSG) as lowercase hex. */
+  proof: string;
+}
+
+/** `auth.ok` payload — the server's proof the extension verifies before trusting. */
+export interface ExtensionAuthOkPayload {
+  /** HMAC-SHA256(token, SERVER_MSG) as lowercase hex. */
+  serverProof: string;
+}
 
 /**
  * `import.request` payload. `html` present ⇒ Scan mode (the extension supplies
@@ -97,11 +210,12 @@ export interface ExtensionProfileResult {
  * The transport envelope every frame is wrapped in. `payload` is left as
  * unknown here (each `type` narrows it via its own payload schema) so a single
  * envelope schema validates the frame shell before the handler dispatches.
+ *
+ * v2 removed the `token` field entirely: the handshake authenticates the socket
+ * (session auth), so no frame ever carries the pairing secret.
  */
 export interface ExtensionEnvelope {
   type: ExtensionMessageType;
-  /** The paired secret. The bridge rejects any frame whose token mismatches. */
-  token: string;
   /** Caller-chosen correlation id echoed back on the matching reply. */
   reqId: string;
   payload: unknown;

--- a/packages/shared/src/ipc/extension-protocol.test.ts
+++ b/packages/shared/src/ipc/extension-protocol.test.ts
@@ -91,12 +91,16 @@ describe('ExtensionEnvelopeSchema', () => {
     ).toThrow();
   });
 
-  it('rejects an envelope that still carries a token (v2 removed it — must not be required, but a bare token alone is not a valid frame)', () => {
-    // A frame WITH an extra token still parses (extra keys are ignored by zod object),
-    // but the security guarantee is that NEITHER side ever puts one there. This pins
-    // that the schema no longer REQUIRES a token: an envelope without one is valid.
-    const { ...noToken } = VALID_ENVELOPE;
-    expect(() => ExtensionEnvelopeSchema.parse(noToken)).not.toThrow();
+  it('ignores a stray token field (v2 envelopes are token-free)', () => {
+    // `z.object()`'s default behavior is to STRIP unknown keys (no `.strict()`/
+    // `.passthrough()` on ExtensionEnvelopeSchema) — verified empirically, not
+    // assumed. A frame that still carries a `token` (e.g. a stale caller that
+    // hasn't migrated) parses successfully AND the key is dropped from the
+    // output — the schema no longer requires OR echoes a token; the mutual
+    // handshake is what actually authenticates, never a per-frame secret.
+    const withStrayToken = { ...VALID_ENVELOPE, token: 'stale-v1-token' };
+    const parsed = ExtensionEnvelopeSchema.parse(withStrayToken);
+    expect(parsed).not.toHaveProperty('token');
   });
 
   it('rejects an envelope with an empty reqId', () => {

--- a/packages/shared/src/ipc/extension-protocol.test.ts
+++ b/packages/shared/src/ipc/extension-protocol.test.ts
@@ -5,7 +5,11 @@ import {
   ExtensionImportRequestSchema,
   ExtensionProfileResultSchema,
 } from './extension-protocol.js';
-import { EXTENSION_MESSAGE_TYPES } from './extension-protocol-constants.js';
+import {
+  EXTENSION_MESSAGE_TYPES,
+  HANDSHAKE_TEST_VECTOR,
+  handshakeMessage,
+} from './extension-protocol-constants.js';
 
 // ---------------------------------------------------------------------------
 // ExtensionImportRequestSchema
@@ -45,9 +49,10 @@ describe('ExtensionImportRequestSchema', () => {
 // ExtensionEnvelopeSchema
 // ---------------------------------------------------------------------------
 
+// v2 envelope: NO `token` field — the handshake authenticates the socket, so no
+// frame carries the pairing secret.
 const VALID_ENVELOPE = {
   type: EXTENSION_MESSAGE_TYPES.importRequest,
-  token: 'secret-token',
   reqId: 'req-001',
   payload: { url: 'https://example.com/job/1' },
 } as const;
@@ -63,23 +68,39 @@ describe('ExtensionEnvelopeSchema', () => {
     }
   });
 
+  it('accepts the v2 handshake frames (hello / challenge / auth / auth.ok)', () => {
+    expect(() =>
+      ExtensionEnvelopeSchema.parse({
+        type: EXTENSION_MESSAGE_TYPES.hello,
+        reqId: 'h1',
+        payload: { protocol: 2, clientNonce: 'abcd' },
+      })
+    ).not.toThrow();
+    expect(() =>
+      ExtensionEnvelopeSchema.parse({
+        type: EXTENSION_MESSAGE_TYPES.authOk,
+        reqId: 'a1',
+        payload: { serverProof: 'deadbeef' },
+      })
+    ).not.toThrow();
+  });
+
   it('rejects an unknown message type', () => {
     expect(() =>
       ExtensionEnvelopeSchema.parse({ ...VALID_ENVELOPE, type: 'unknown.type' })
     ).toThrow();
   });
 
-  it('rejects an envelope with an empty token', () => {
-    expect(() => ExtensionEnvelopeSchema.parse({ ...VALID_ENVELOPE, token: '' })).toThrow();
+  it('rejects an envelope that still carries a token (v2 removed it — must not be required, but a bare token alone is not a valid frame)', () => {
+    // A frame WITH an extra token still parses (extra keys are ignored by zod object),
+    // but the security guarantee is that NEITHER side ever puts one there. This pins
+    // that the schema no longer REQUIRES a token: an envelope without one is valid.
+    const { ...noToken } = VALID_ENVELOPE;
+    expect(() => ExtensionEnvelopeSchema.parse(noToken)).not.toThrow();
   });
 
   it('rejects an envelope with an empty reqId', () => {
     expect(() => ExtensionEnvelopeSchema.parse({ ...VALID_ENVELOPE, reqId: '' })).toThrow();
-  });
-
-  it('rejects an envelope missing the token field', () => {
-    const { token: _omit, ...noToken } = VALID_ENVELOPE;
-    expect(() => ExtensionEnvelopeSchema.parse(noToken)).toThrow();
   });
 
   it('rejects an envelope missing the reqId field', () => {
@@ -96,6 +117,22 @@ describe('ExtensionEnvelopeSchema', () => {
     // payload is intentionally z.unknown() — validation is deferred to the message-type-specific
     // handler, so the envelope schema accepts any payload shape (including null) without failing.
     expect(() => ExtensionEnvelopeSchema.parse({ ...VALID_ENVELOPE, payload: null })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handshake message canonicalization (byte-identical with the Rust side)
+// ---------------------------------------------------------------------------
+
+describe('handshakeMessage', () => {
+  it('builds the exact domain-separated, newline-delimited canonical string', () => {
+    const { clientNonce, serverNonce } = HANDSHAKE_TEST_VECTOR;
+    expect(handshakeMessage('client', serverNonce, clientNonce)).toBe(
+      `ajh-bridge/v2\nclient\n${serverNonce}\n${clientNonce}`
+    );
+    expect(handshakeMessage('server', serverNonce, clientNonce)).toBe(
+      `ajh-bridge/v2\nserver\n${serverNonce}\n${clientNonce}`
+    );
   });
 });
 
@@ -136,7 +173,6 @@ describe('ExtensionProfileResultSchema', () => {
     expect(() =>
       ExtensionEnvelopeSchema.parse({
         type: EXTENSION_MESSAGE_TYPES.profileResult,
-        token: 'secret-token',
         reqId: 'req-002',
         payload: { email: 'x@y.z' },
       })

--- a/packages/shared/src/ipc/extension-protocol.ts
+++ b/packages/shared/src/ipc/extension-protocol.ts
@@ -6,37 +6,59 @@
  * a parity test on the Rust side pins its message-type constants to the
  * `EXTENSION_MESSAGE_TYPES` values here so the two can never drift.
  *
- * The wire-message constants and payload TYPES live in the zod-free
- * `./extension-protocol-constants.ts` (so the browser extension can import them
- * without pulling zod into its bundle). This module owns the zod SCHEMAS and
- * binds each to its constants-file interface via `satisfies z.ZodType<…>` so the
- * schema and its type can never drift. It re-exports the constants/types so this
- * remains the single barrel entry for desktop/renderer consumers. Pure data +
- * Zod — no `window`, no Node.
+ * The wire-message constants, the handshake message canonicalization, and the
+ * payload TYPES live in the zod-free `./extension-protocol-constants.ts` (so the
+ * browser extension can import them without pulling zod into its bundle). This
+ * module owns the zod SCHEMAS and binds each to its constants-file interface via
+ * `satisfies z.ZodType<…>` so the schema and its type can never drift. It
+ * re-exports the constants/types so this remains the single barrel entry for
+ * desktop/renderer consumers. Pure data + Zod — no `window`, no Node.
  */
 
 import { z } from 'zod';
 
 import {
   EXTENSION_MESSAGE_TYPES,
+  EXTENSION_PROTOCOL_VERSION,
+  type ExtensionAuthOkPayload,
+  type ExtensionAuthPayload,
+  type ExtensionChallengePayload,
   type ExtensionEnvelope,
+  type ExtensionHelloPayload,
   type ExtensionImportRequest,
   type ExtensionImportResult,
   type ExtensionMessageType,
   type ExtensionProfileResult,
+  HANDSHAKE_DOMAIN,
+  HANDSHAKE_TEST_VECTOR,
+  handshakeMessage,
+  type HandshakeRole,
 } from './extension-protocol-constants.js';
 
 export {
   EXTENSION_MESSAGE_TYPES,
+  EXTENSION_PROTOCOL_VERSION,
+  type ExtensionAuthOkPayload,
+  type ExtensionAuthPayload,
+  type ExtensionChallengePayload,
   type ExtensionEnvelope,
+  type ExtensionHelloPayload,
   type ExtensionImportRequest,
   type ExtensionImportResult,
   type ExtensionMessageType,
   type ExtensionProfileResult,
+  HANDSHAKE_DOMAIN,
+  HANDSHAKE_TEST_VECTOR,
+  handshakeMessage,
+  type HandshakeRole,
 };
 
 export const ExtensionMessageTypeSchema = z.enum([
+  EXTENSION_MESSAGE_TYPES.hello,
+  EXTENSION_MESSAGE_TYPES.challenge,
   EXTENSION_MESSAGE_TYPES.auth,
+  EXTENSION_MESSAGE_TYPES.authOk,
+  EXTENSION_MESSAGE_TYPES.updateRequired,
   EXTENSION_MESSAGE_TYPES.importRequest,
   EXTENSION_MESSAGE_TYPES.importResult,
   EXTENSION_MESSAGE_TYPES.profileGet,
@@ -44,6 +66,27 @@ export const ExtensionMessageTypeSchema = z.enum([
   EXTENSION_MESSAGE_TYPES.matchLive,
   EXTENSION_MESSAGE_TYPES.appliedCheck,
 ]) satisfies z.ZodType<ExtensionMessageType>;
+
+/** `hello` payload (handshake step 1). No token — the proof authenticates later. */
+export const ExtensionHelloPayloadSchema = z.object({
+  protocol: z.number().int().positive(),
+  clientNonce: z.string().min(1),
+}) satisfies z.ZodType<ExtensionHelloPayload>;
+
+/** `challenge` payload (handshake step 2). */
+export const ExtensionChallengePayloadSchema = z.object({
+  serverNonce: z.string().min(1),
+}) satisfies z.ZodType<ExtensionChallengePayload>;
+
+/** `auth` payload (handshake step 3) — the client proof, NOT the token. */
+export const ExtensionAuthPayloadSchema = z.object({
+  proof: z.string().min(1),
+}) satisfies z.ZodType<ExtensionAuthPayload>;
+
+/** `auth.ok` payload (handshake step 4) — the server proof the extension verifies. */
+export const ExtensionAuthOkPayloadSchema = z.object({
+  serverProof: z.string().min(1),
+}) satisfies z.ZodType<ExtensionAuthOkPayload>;
 
 /**
  * `import.request` payload. `html` present ⇒ Scan mode (the extension supplies
@@ -92,11 +135,12 @@ export const ExtensionProfileResultSchema = z.object({
  * The transport envelope every frame is wrapped in. `payload` is left as
  * unknown here (each `type` narrows it via its own payload schema) so a single
  * envelope schema validates the frame shell before the handler dispatches.
+ *
+ * v2 removed the `token` field entirely: the handshake authenticates the socket,
+ * so no frame carries the pairing secret.
  */
 export const ExtensionEnvelopeSchema = z.object({
   type: ExtensionMessageTypeSchema,
-  /** The paired secret. The bridge rejects any frame whose token mismatches. */
-  token: z.string().min(1),
   /** Caller-chosen correlation id echoed back on the matching reply. */
   reqId: z.string().min(1),
   payload: z.unknown(),


### PR DESCRIPTION
## What

Replaces the bridge's plaintext-token-per-frame auth with a **mutual HMAC-SHA256 challenge-response** (protocol v2). The pairing token becomes **only an HMAC key and is never transmitted**. Closes the deferred port-squat finding from #625 (ADR-0009), now that the same auth path gates the Contact Profile.

## Handshake (v2 envelope drops `token`)

```
Ext → hello      { protocol: 2, clientNonce }
Ext ← challenge  { serverNonce }
Ext → auth       { proof = HMAC-SHA256(token, "ajh-bridge/v2\nclient\n"+serverNonce+"\n"+clientNonce) }
Ext ← auth.ok    { serverProof = HMAC-SHA256(token, "…\nserver\n"+serverNonce+"\n"+clientNonce) }
```
Then session-authorized frames (`import.request`, `profile.get`) carry **no token**.

**Why mutual:** the extension verifies `serverProof` before sending anything — so a loopback **port-squatter that doesn't know the token** can't prove it's the app, and the extension sends **zero PII and no reusable secret**. One-way auth wouldn't protect the profile from a rogue server.

## Invariants

- Token never on the wire (HMAC key only); domain-separated proofs (no reflection); fresh CSPRNG nonces per connection (no replay); **constant-time** verify both sides (Rust `Mac::verify_slice`, TS non-short-circuiting compare).
- Send path gated on the **authenticated session** (`connected` phase), never on transport liveness.
- **Cross-impl known-answer vector** pins the Rust (`hmac` crate) and TS (Web Crypto) canonicalizations byte-for-byte so they can't silently drift.
- Autofill opt-in gate on `profile.get` unchanged; Origin allowlist + envelope validation intact; both transports (native-messaging + WS) carry the handshake identically.

## Force cutover (chosen over dual-support)

No plaintext path survives on the desktop. Legacy frames get `update.required` + close; a new `outdated` connection phase surfaces the version mismatch on both sides ("update the desktop app" / "update the extension"). **Transition window:** until a user updates *both* app and extension, the bridge shows an update prompt. The pairing UX (Settings token, rotate) is otherwise unchanged.

## Security review (pre-PR, both cleared)

`tauri-security-reviewer` + `extension-reviewer` audited the crypto and threat model. No CRITICAL. Both **independently found one HIGH** — the send path originally gated on transport liveness, so a concurrent `importJob` could ship the active-tab DOM to a peer mid-handshake — now **fixed** (gate on `phase === 'connected'`; `ensureConnected` awaits the in-flight handshake) with a **race regression test verified to fail without the fix**. Also folded: ambiguous silent-close → recoverable `app_not_running` (not a false `bad_token`); a numeric `PROTOCOL_VERSION` Rust⇄TS parity test; and peer-`serverNonce` shape validation. Reflection/replay/constant-time/state-machine/token-never-on-wire all verified PASS.

## Tests

Whole-graph green: extension **118 pass**, desktop **2311**, `extension_bridge` **79** (incl. HMAC KAT + numeric-parity + race regressions), `@ajh/shared` **159**. clippy clean, `tsc` clean (direct), `fill.js` import-free in both builds, `cargo-deny` licenses OK.

## Docs

New **ADR-0010** (decision + 5 rejected options); CONTEXT `Pairing token` / `Connection phase` terms updated for v2; extension README threat model rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a secure mutual challenge-response connection handshake between the extension and desktop app.
  - Pairing secrets are no longer transmitted with requests.
  - Added protection against replay and unauthorized connections.
  - Added an “Update the app” state for incompatible desktop or extension versions.

- **Bug Fixes**
  - Prevented import and profile requests from being sent before connection verification.
  - Improved handling of failed authentication, reconnects, and outdated peers.

- **Documentation**
  - Updated protocol, security, privacy, and threat-model documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->