### PR TITLE
docs: fix architecture drift (rusqlite not drizzle, semantic scoring not hybrid search)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,25 +237,14 @@ sequenceDiagram
     IPC-->>UI: success + document metadata
 ```
 
-### Hybrid Search
+### Semantic Similarity Scoring
 
-```mermaid
-sequenceDiagram
-    participant UI as Search Page
-    participant IPC as Tauri IPC
-    participant Search as Search Handler
-    participant Lance as SQLite (vectors)
-    participant SQL as SQLite
+The **semantic scoring** component is an **optional, opt-in (default OFF)** half of a match score. When enabled, the app computes embedding-based cosine similarity between a résumé and a job posting, blending it with ATS/keyword coverage. See `CONTEXT.md` ("Semantic scoring") for the definition and `match.rs` for the implementation.
 
-    UI->>IPC: search.hybrid({query, collection, topK, semanticWeight})
-    IPC->>Search: route request
-    Search->>Lance: vector search (semantic, in-process cosine)
-    Lance-->>Search: scored document IDs
-    Search->>SQL: keyword filter on matched IDs
-    SQL-->>Search: refined result set
-    Search-->>IPC: HybridSearchResult[]
-    IPC-->>UI: ranked results
-```
+- Embeddings are vectorized locally (Ollama) or via a cloud provider (OpenAI, Anthropic, Gemini).
+- Vectors are cached in the `posting_vectors` table (self-invalidating on space/text change).
+- Match-score results are cached in `match_scores` (composite PK encodes formula version, space, semantic flag, text hash).
+- **The removed Cmd+K hybrid search surface is gone.** Semantic scoring is now tied to opt-in Match Score calculation only, not a separate search UI.
 
 ### Autopilot Execution
 
@@ -304,7 +293,9 @@ const result = await client.ai.generate(req);
 
 ## Database Schema
 
-### SQLite (Drizzle ORM)
+### SQLite (rusqlite)
+
+The app uses **rusqlite** (`Cargo.toml`: `rusqlite = "0.40"`, bundled) for local-first persistence. All SQL operations are Rust-native with in-process schema management: **in-code migrations in `src-tauri/src/db.rs`** (each an `up` closure), applied transactionally and tracked via `PRAGMA user_version` — no `.sql` files, no `migrations/` dir. No ORM; direct `rusqlite::Connection` queries scoped by `db::open()` (L0 shared infra).
 
 ```mermaid
 erDiagram

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -239,9 +239,9 @@ sequenceDiagram
 
 ### Semantic Similarity Scoring
 
-The **semantic scoring** component is an **optional, opt-in (default OFF)** half of a match score. When enabled, the app computes embedding-based cosine similarity between a résumé and a job posting, blending it with ATS/keyword coverage. See `CONTEXT.md` ("Semantic scoring") for the definition and `match.rs` for the implementation.
+The **semantic scoring** component is an **optional, opt-in (default OFF)** half of a match score. When enabled, the app computes embedding-based cosine similarity between a résumé and a job posting, blending it with ATS/keyword coverage. See `docs/CONTEXT.md` ("Semantic scoring") for the definition and `apps/desktop/src-tauri/src/commands/match_resume.rs` (the `match_resume` command) for the implementation.
 
-- Embeddings are vectorized locally (Ollama) or via a cloud provider (OpenAI, Anthropic, Gemini).
+- Embeddings are vectorized locally (Ollama) or via a cloud provider (OpenAI, Gemini) — Anthropic has no embeddings API.
 - Vectors are cached in the `posting_vectors` table (self-invalidating on space/text change).
 - Match-score results are cached in `match_scores` (composite PK encodes formula version, space, semantic flag, text hash).
 - **The removed Cmd+K hybrid search surface is gone.** Semantic scoring is now tied to opt-in Match Score calculation only, not a separate search UI.
@@ -295,7 +295,7 @@ const result = await client.ai.generate(req);
 
 ### SQLite (rusqlite)
 
-The app uses **rusqlite** (`Cargo.toml`: `rusqlite = "0.40"`, bundled) for local-first persistence. All SQL operations are Rust-native with in-process schema management: **in-code migrations in `src-tauri/src/db.rs`** (each an `up` closure), applied transactionally and tracked via `PRAGMA user_version` — no `.sql` files, no `migrations/` dir. No ORM; direct `rusqlite::Connection` queries scoped by `db::open()` (L0 shared infra).
+The app uses **rusqlite** (`Cargo.toml`: `rusqlite = "0.40"`, bundled) for local-first persistence. All SQL operations are Rust-native with in-process schema management: **in-code migrations in `apps/desktop/src-tauri/src/db.rs`** (each an `up` closure), applied transactionally and tracked via `PRAGMA user_version` — no `.sql` files, no `migrations/` dir. No ORM; direct `rusqlite::Connection` queries scoped by `db::open()` (L0 shared infra).
 
 ```mermaid
 erDiagram

--- a/docs/architecture-analysis.md
+++ b/docs/architecture-analysis.md
@@ -11,7 +11,7 @@ Last updated: 2026-06-03
 > boundary contract.
 >
 > Historic measurements: **36 top-level modules, 162 source files, ~28,000 non-test LOC
-> (June 2026).** For current codebase stats, run `find apps/desktop/src-tauri/src -name "*.rs" | xargs wc -l`.
+> (June 2026).** For current _total_ source-tree LOC — note this includes inline `#[cfg(test)]` tests, so it is not directly comparable to the non-test figure above — run `find apps/desktop/src-tauri/src -name "*.rs" | xargs wc -l`.
 
 ---
 

--- a/docs/architecture-analysis.md
+++ b/docs/architecture-analysis.md
@@ -2,15 +2,16 @@
 
 Last updated: 2026-06-03
 
-> **Status:** discovery report (Phase 1). Read-only — describes the architecture **as it
-> actually exists** in `apps/desktop/src-tauri/`, measured from the source tree, not an
-> idealized target. The enforceable rules derived from this report live in
+> **⚠️ Point-in-time snapshot (June 2026).** This is a discovery report (Phase 1) captured on
+> `feat/rust-arch-enforcement` branch; it is read-only and describes the architecture
+> **as it existed on that date**. The codebase has evolved since then (LOC figures are
+> no longer current). The enforceable rules derived from this report live in
 > [`architecture-rules.md`](architecture-rules.md); they are enforced by
-> `apps/desktop/src-tauri/tests/architecture.rs` and CI.
+> `apps/desktop/src-tauri/tests/architecture.rs` and CI — those rules remain the live
+> boundary contract.
 >
-> Measurements taken at commit on branch `feat/rust-arch-enforcement`: **36 top-level
-> modules, 162 source files, ~28,000 non-test LOC.** Regenerate with the methodology in
-> the appendix.
+> Historic measurements: **36 top-level modules, 162 source files, ~28,000 non-test LOC
+> (June 2026).** For current codebase stats, run `find apps/desktop/src-tauri/src -name "*.rs" | xargs wc -l`.
 
 ---
 


### PR DESCRIPTION
## What

Fixes verified architecture-doc drift (docs only — no code change).

- **`ARCHITECTURE.md`** — "SQLite (**Drizzle ORM**)" was wrong; the app uses **rusqlite 0.40** with in-code migrations in `src-tauri/src/db.rs` tracked via `PRAGMA user_version` (no ORM, no `migrations/` dir). The "**Hybrid Search**" section documented a **removed** Cmd+K surface; rewritten as **Semantic Similarity Scoring** (opt-in, default-OFF embedding half of the match score, `posting_vectors`/`match_scores` caching), consistent with `CONTEXT.md`.
- **`architecture-analysis.md`** — marked a **dated point-in-time snapshot** (its ~28k-LOC figure is a year stale vs ~66k now); `architecture-rules.md` remains the live contract.

**Verified against code** before committing: `posting_vectors`, `match_scores`, `db::open()` are real; a first-draft invented `migrations/` path was corrected to the real in-`db.rs` mechanism.

**Deliberately not changed:** the `tech-stack.ts` "Drizzle" entry. On review, `COMMON_TECH` is a 198-entry **user-facing autocomplete/recognition dictionary** (JavaScript, Rust, TypeORM, Sequelize, Mongoose, Drizzle…), not the app's own stack — removing Drizzle would regress a user's skill autocomplete. The audit's "stale Drizzle" flag was a misread.

Closes P4 — the ~1.1GB `.claude/worktrees` cleanup + branch pruning (incl. discarding two superseded worktree commits) was local, no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to describe optional, opt-in semantic similarity scoring and its local or cloud-based processing.
  * Clarified database persistence and migration details.
  * Removed references to the previous Cmd+K hybrid search interface.
  * Marked the architecture analysis as a read-only, point-in-time snapshot from June 2026, with guidance for refreshing measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->