### PR TITLE
fix: surface matched application status in extension import popup

### DIFF
--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -481,6 +481,23 @@ describe('doImport (#btn-import)', () => {
     // The checkbox was unticked — the outgoing request must carry applied: false.
     expect(sendMessageMock).toHaveBeenCalledWith({ kind: 'import', applied: false });
   });
+
+  it('shows the plain "Imported" success message and re-enables the button', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'import',
+      result: { applicationId: 'app-new', status: 'saved', title: 'Senior Rust Engineer' },
+    });
+
+    const btn = byId<HTMLButtonElement>('btn-import');
+    btn.click();
+    await flush();
+
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
+      'Imported “Senior Rust Engineer”. Open AI Job Hunter → Applications to view it.'
+    );
+    expect(btn.disabled).toBe(false);
+  });
 });
 
 describe('get the app (#btn-get-app)', () => {

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -105,7 +105,7 @@ describe('resolveStatusResponse', () => {
 describe('resolveImportResponse', () => {
   it('returns an error message when ok=false', () => {
     const res = { ok: false as const, error: 'Bridge unavailable.' };
-    const { text, tone } = resolveImportResponse(res);
+    const { text, tone } = resolveImportResponse(res, false);
     expect(tone).toBe('err');
     expect(text).toBe('Bridge unavailable.');
   });
@@ -114,7 +114,7 @@ describe('resolveImportResponse', () => {
     // Dead-end state: background replied with a non-import kind to an import
     // request (e.g. a stale status push, message ordering issue).
     const res = { ok: true as const, kind: 'token' as const };
-    const { text, tone } = resolveImportResponse(res);
+    const { text, tone } = resolveImportResponse(res, false);
     expect(tone).toBe('err');
     expect(text).toBe('Unexpected response — please retry.');
   });
@@ -125,7 +125,7 @@ describe('resolveImportResponse', () => {
       kind: 'import' as const,
       result: { error: 'Desktop app rejected the job URL.' },
     };
-    const { text, tone } = resolveImportResponse(res);
+    const { text, tone } = resolveImportResponse(res, false);
     expect(tone).toBe('err');
     expect(text).toBe('Desktop app rejected the job URL.');
   });
@@ -136,7 +136,7 @@ describe('resolveImportResponse', () => {
       kind: 'import' as const,
       result: { applicationId: 'app-123', status: 'saved', title: 'Senior Rust Engineer' },
     };
-    const { text, tone } = resolveImportResponse(res);
+    const { text, tone } = resolveImportResponse(res, false);
     expect(tone).toBe('ok');
     expect(text).toBe(
       'Imported “Senior Rust Engineer”. Open AI Job Hunter → Applications to view it.'
@@ -149,7 +149,7 @@ describe('resolveImportResponse', () => {
       kind: 'import' as const,
       result: { applicationId: 'app-456' },
     };
-    const { text, tone } = resolveImportResponse(res);
+    const { text, tone } = resolveImportResponse(res, false);
     expect(tone).toBe('ok');
     expect(text).toBe('Imported. Open AI Job Hunter → Applications to view it.');
   });
@@ -160,7 +160,7 @@ describe('resolveImportResponse', () => {
       kind: 'import' as const,
       result: { applicationId: 'app-789', title: 'Frontend Engineer', partial: true },
     };
-    const { text, tone } = resolveImportResponse(res);
+    const { text, tone } = resolveImportResponse(res, false);
     expect(tone).toBe('ok');
     expect(text).toBe(
       "Imported “Frontend Engineer” — couldn't read the description. Open AI Job Hunter → Applications to paste it."
@@ -173,10 +173,78 @@ describe('resolveImportResponse', () => {
       kind: 'import' as const,
       result: { applicationId: 'app-000', partial: true },
     };
-    const { text, tone } = resolveImportResponse(res);
+    const { text, tone } = resolveImportResponse(res, false);
     expect(tone).toBe('ok');
     expect(text).toBe(
       "Imported — couldn't read the description. Open AI Job Hunter → Applications to paste it."
+    );
+  });
+
+  // ── status transparency (dedup-merge into a pre-existing non-saved row) ─────
+
+  it('surfaces a "already tracked" transparency message when the matched row is already past saved and the checkbox was unticked', () => {
+    const res = {
+      ok: true as const,
+      kind: 'import' as const,
+      result: { applicationId: 'app-existing', status: 'applied', title: 'Backend Engineer' },
+    };
+    const { text, tone } = resolveImportResponse(res, false);
+    expect(tone).toBe('ok');
+    expect(text).toBe(
+      '“Backend Engineer” is already tracked as Applied — nothing was changed. Open AI Job Hunter → Applications to view it.'
+    );
+  });
+
+  it('surfaces the transparency message without a title when the desktop parsed none', () => {
+    const res = {
+      ok: true as const,
+      kind: 'import' as const,
+      result: { applicationId: 'app-existing', status: 'interviewing' },
+    };
+    const { text, tone } = resolveImportResponse(res, false);
+    expect(tone).toBe('ok');
+    expect(text).toBe(
+      'This job is already tracked as Interviewing — nothing was changed. Open AI Job Hunter → Applications to view it.'
+    );
+  });
+
+  it('does not show the transparency message when status is saved (unchanged behavior)', () => {
+    const res = {
+      ok: true as const,
+      kind: 'import' as const,
+      result: { applicationId: 'app-1', status: 'saved', title: 'QA Engineer' },
+    };
+    const { text, tone } = resolveImportResponse(res, false);
+    expect(tone).toBe('ok');
+    expect(text).toBe('Imported “QA Engineer”. Open AI Job Hunter → Applications to view it.');
+  });
+
+  it('does not show the transparency message when the checkbox was ticked, even for a non-saved status', () => {
+    const res = {
+      ok: true as const,
+      kind: 'import' as const,
+      result: { applicationId: 'app-2', status: 'applied', title: 'DevOps Engineer' },
+    };
+    const { text, tone } = resolveImportResponse(res, true);
+    expect(tone).toBe('ok');
+    expect(text).toBe('Imported “DevOps Engineer”. Open AI Job Hunter → Applications to view it.');
+  });
+
+  it('prefers the partial message over the transparency message (partial stub → unchanged)', () => {
+    const res = {
+      ok: true as const,
+      kind: 'import' as const,
+      result: {
+        applicationId: 'app-3',
+        status: 'applied',
+        title: 'Frontend Engineer',
+        partial: true,
+      },
+    };
+    const { text, tone } = resolveImportResponse(res, false);
+    expect(tone).toBe('ok');
+    expect(text).toBe(
+      "Imported “Frontend Engineer” — couldn't read the description. Open AI Job Hunter → Applications to paste it."
     );
   });
 });

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -191,7 +191,7 @@ describe('resolveImportResponse', () => {
     const { text, tone } = resolveImportResponse(res, false);
     expect(tone).toBe('ok');
     expect(text).toBe(
-      '“Backend Engineer” is already tracked as Applied — nothing was changed. Open AI Job Hunter → Applications to view it.'
+      '“Backend Engineer” is already tracked as Applied — status unchanged. Open AI Job Hunter → Applications to view it.'
     );
   });
 
@@ -204,7 +204,7 @@ describe('resolveImportResponse', () => {
     const { text, tone } = resolveImportResponse(res, false);
     expect(tone).toBe('ok');
     expect(text).toBe(
-      'This job is already tracked as Interviewing — nothing was changed. Open AI Job Hunter → Applications to view it.'
+      'This job is already tracked as Interviewing — status unchanged. Open AI Job Hunter → Applications to view it.'
     );
   });
 

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -448,6 +448,41 @@ describe('doFill (#btn-fill)', () => {
   });
 });
 
+describe('doImport (#btn-import)', () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+    byId<HTMLButtonElement>('btn-import').disabled = false;
+    byId<HTMLParagraphElement>('import-msg').textContent = '';
+    byId<HTMLInputElement>('chk-applied').checked = false;
+  });
+
+  it('shows "Importing…" then the already-tracked transparency message, sends applied: false, and re-enables the button', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'import',
+      result: { applicationId: 'app-existing', status: 'applied', title: 'Backend Engineer' },
+    });
+
+    const btn = byId<HTMLButtonElement>('btn-import');
+    btn.click();
+    // The click handler disables the button and sets "Importing…" synchronously,
+    // before the (mocked) sendMessage promise resolves.
+    expect(btn.disabled).toBe(true);
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe('Importing…');
+
+    await flush();
+
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
+      '“Backend Engineer” is already tracked as Applied — status unchanged. Open AI Job Hunter → Applications to view it.'
+    );
+    expect(btn.disabled).toBe(false);
+    // The checkbox was unticked — the outgoing request must carry applied: false.
+    expect(sendMessageMock).toHaveBeenCalledWith({ kind: 'import', applied: false });
+  });
+});
+
 describe('get the app (#btn-get-app)', () => {
   const flush = () => new Promise((r) => setTimeout(r, 0));
   const tabsCreateMock = vi.mocked(browser.tabs.create);

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -45,9 +45,20 @@ const IMPORT_PARTIAL_HINT = 'Open AI Job Hunter → Applications to paste it.';
  * success it names the imported job (when the desktop parsed a title) and points
  * the user at where it landed, instead of a bare “Imported”.
  *
+ * `requestedApplied` is the "I already applied" checkbox state sent with the
+ * request. The desktop dedup-merges by URL and only ever advances a matched
+ * Application's status OUT of `saved` — it never demotes an existing
+ * applied-or-further row. So when the checkbox was NOT ticked and the matched
+ * row's status is already past `saved`, a bare "Imported" success would read
+ * like a fresh/changed import when nothing was actually touched — surface that
+ * explicitly instead.
+ *
  * Pure: no DOM access, no side effects.
  */
-export function resolveImportResponse(res: PopupResponse): { text: string; tone: 'ok' | 'err' } {
+export function resolveImportResponse(
+  res: PopupResponse,
+  requestedApplied: boolean
+): { text: string; tone: 'ok' | 'err' } {
   if (!res.ok) return { text: res.error, tone: 'err' };
   if (res.kind !== 'import') return { text: 'Unexpected response — please retry.', tone: 'err' };
   const { result } = res;
@@ -59,6 +70,13 @@ export function resolveImportResponse(res: PopupResponse): { text: string; tone:
       text: `${lead} — couldn't read the description. ${IMPORT_PARTIAL_HINT}`,
       tone: 'ok',
     };
+  }
+  if (!requestedApplied && result.status && result.status !== 'saved') {
+    const label = result.status.charAt(0).toUpperCase() + result.status.slice(1);
+    const lead = title
+      ? `“${title}” is already tracked as ${label}`
+      : `This job is already tracked as ${label}`;
+    return { text: `${lead} — nothing was changed. ${IMPORT_LANDING_HINT}`, tone: 'ok' };
   }
   const lead = title ? `Imported “${title}”.` : 'Imported.';
   return { text: `${lead} ${IMPORT_LANDING_HINT}`, tone: 'ok' };
@@ -305,8 +323,9 @@ async function doImport(): Promise<void> {
   els.btnImport.disabled = true;
   setMsg(els.importMsg, 'Importing…', 'muted');
   try {
-    const res = await send({ kind: 'import', applied: els.chkApplied.checked });
-    const { text, tone } = resolveImportResponse(res);
+    const requestedApplied = els.chkApplied.checked;
+    const res = await send({ kind: 'import', applied: requestedApplied });
+    const { text, tone } = resolveImportResponse(res, requestedApplied);
     setMsg(els.importMsg, text, tone);
   } catch {
     // A transport/messaging rejection must not strand the status on "Importing…".

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -76,7 +76,7 @@ export function resolveImportResponse(
     const lead = title
       ? `“${title}” is already tracked as ${label}`
       : `This job is already tracked as ${label}`;
-    return { text: `${lead} — nothing was changed. ${IMPORT_LANDING_HINT}`, tone: 'ok' };
+    return { text: `${lead} — status unchanged. ${IMPORT_LANDING_HINT}`, tone: 'ok' };
   }
   const lead = title ? `Imported “${title}”.` : 'Imported.';
   return { text: `${lead} ${IMPORT_LANDING_HINT}`, tone: 'ok' };

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -50,8 +50,9 @@ const IMPORT_PARTIAL_HINT = 'Open AI Job Hunter → Applications to paste it.';
  * Application's status OUT of `saved` — it never demotes an existing
  * applied-or-further row. So when the checkbox was NOT ticked and the matched
  * row's status is already past `saved`, a bare "Imported" success would read
- * like a fresh/changed import when nothing was actually touched — surface that
- * explicitly instead.
+ * like the status had changed when only the status was left untouched (the
+ * desktop meta merge still refreshes title/company/description/answers) —
+ * surface that explicitly instead.
  *
  * Pure: no DOM access, no side effects.
  */


### PR DESCRIPTION
## Summary

- An extension import whose URL dedup-merges into an existing application already past `saved` (e.g. `applied`) used to show the generic "Imported" success — reading like a mis-import (the `docs/NEXT_ISSUES.md` "Indeed import lands as applied" report).
- Root cause confirmed as **not a bug**: `upsert_for_origin` never demotes and the reported status is re-read post-upsert; the popup message was just opaque. No Rust changes.
- The popup (`apps/extension/src/popup/popup.ts`) now renders "«Title» is already tracked as <Status> — status unchanged." when the matched row is past `saved` and the "I already applied" checkbox was unticked. Copy is deliberately scoped to *status* (the meta merge may legitimately refresh title/company/description).
- `resolveImportResponse` takes the checkbox state (`requestedApplied`), captured once before the await (no mid-flight toggle race). Partial-stub messaging keeps precedence.

## Review trail (pre-PR gates)

- extension-reviewer: no HIGH/CRITICAL; independently re-verified the Rust never-demotes trace.
- tauri-security-reviewer: no HIGH/CRITICAL; its MEDIUM ("nothing was changed" overclaimed vs. the meta merge) fixed in `e2963419`.
- /review full-tier 3-pass ensemble: PASS ×3; the single LOW advisory (missing click-driven `doImport` test) closed in `70c00d1d`.

## Test plan

- 124/124 extension tests (5 new `resolveImportResponse` branch tests + 1 click-driven `doImport` DOM test asserting the outgoing `applied: false` payload and exact transparency copy).
- `pnpm typecheck`, `pnpm lint:strict` clean.

Part of the approved extension roadmap (PR 0 of 11); no wire/manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
