### PR TITLE
feat: add applied.check bridge verb with adaptive popup status

### DIFF
--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -507,8 +507,10 @@ impl ApplicationStore {
     }
 
     /// Most-recent Application for a normalized url, if any — the row a per-job
-    /// upsert merges into so one job keeps a single aggregate.
-    fn find_by_job_url(&self, normalized: &str) -> Option<Application> {
+    /// upsert merges into so one job keeps a single aggregate. `pub(crate)` so
+    /// `extension_bridge`'s `applied.check` handler can run the same read-only
+    /// lookup (it never fetches or writes — see `resolve_applied_check`).
+    pub(crate) fn find_by_job_url(&self, normalized: &str) -> Option<Application> {
         if normalized.is_empty() {
             return None;
         }

--- a/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
@@ -887,6 +887,66 @@ fn authenticated_reserved_type_replies_with_error() {
     }
 }
 
+/// An authenticated `applied.check` classifies as `AppliedCheck`, carrying the
+/// payload verbatim (mirrors the `Import`/`Profile` classify tests above).
+#[test]
+fn authenticated_applied_check_classifies_as_applied_check() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
+        "type": super::msg::APPLIED_CHECK,
+        "reqId": "r-applied",
+        "payload": { "url": "https://jobs.example.com/posting/9" }
+    })
+    .to_string();
+
+    match advance_frame(&state, &ConnState::Authenticated, &frame) {
+        FrameDecision::AppliedCheck { req_id, payload } => {
+            assert_eq!(req_id, "r-applied");
+            assert_eq!(
+                payload.get("url").and_then(|u| u.as_str()),
+                Some("https://jobs.example.com/posting/9")
+            );
+        }
+        other => panic!("an authenticated applied.check must be AppliedCheck, got {other:?}"),
+    }
+}
+
+/// An `applied.check` before the handshake completes is NEVER dispatched — same
+/// invariant as `import_before_handshake_is_not_dispatched`: only a hello may
+/// be the first frame.
+#[test]
+fn applied_check_before_handshake_is_not_dispatched() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
+        "type": super::msg::APPLIED_CHECK,
+        "reqId": "r-early",
+        "payload": { "url": "https://jobs.example.com/posting/early" },
+    })
+    .to_string();
+    match advance_frame(&state, &ConnState::AwaitingHello, &frame) {
+        FrameDecision::Outdated(_) => {}
+        other => panic!("an applied.check before hello must NOT be AppliedCheck, got {other:?}"),
+    }
+}
+
+/// Same mid-handshake bypass guard as `non_auth_frame_mid_handshake_is_unauthorized`
+/// — an `applied.check` cannot skip the proof step either.
+#[test]
+fn applied_check_mid_handshake_is_unauthorized() {
+    let (_dir, state) = bridge_state();
+    let (conn, _correct) = awaiting_auth(&state);
+    let frame = json!({
+        "type": super::msg::APPLIED_CHECK,
+        "reqId": "r-skip",
+        "payload": { "url": "https://jobs.example.com/posting/skip" },
+    })
+    .to_string();
+    match advance_frame(&state, &conn, &frame) {
+        FrameDecision::Unauthorized => {}
+        other => panic!("an applied.check mid-handshake must be Unauthorized, got {other:?}"),
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // B2. Oversize-frame rejection (HIGH 2)
 //
@@ -1027,6 +1087,131 @@ fn normalize_job_url_neutralizes_non_http_schemes_to_empty() {
     assert_eq!(normalize_job_url("ftp://acme.example/x"), "");
     // Empty input → empty.
     assert_eq!(normalize_job_url("   "), "");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C. applied.check — pure store lookup (found saved / found applied / not
+// found / malformed url). `resolve_applied_check` is a private, synchronous fn
+// (no `AppHandle`), so unlike `handle_import` it IS directly unit-testable —
+// these tests exercise the exact boundary `handle_applied_check` calls.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// No Application exists yet for the url → `found: false`, everything else
+/// `None`, never an error.
+#[test]
+fn resolve_applied_check_not_found_when_no_application() {
+    let (_dir, store) = open_store();
+    let payload = json!({ "url": "https://jobs.example.com/posting/none" });
+    let out = super::resolve_applied_check(&store, &payload).unwrap();
+    assert!(!out.found);
+    assert!(out.application_id.is_none());
+    assert!(out.status.is_none());
+    assert!(out.applied_at.is_none());
+}
+
+/// A `saved` Application (not yet applied) is found with status "saved", the
+/// posting's title, and NO `appliedAt` (it hasn't left `saved`).
+#[test]
+fn resolve_applied_check_found_saved_has_no_applied_at() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/saved-1";
+    store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Backend Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let out = super::resolve_applied_check(&store, &json!({ "url": url })).unwrap();
+    assert!(out.found);
+    assert_eq!(out.status.as_deref(), Some("saved"));
+    assert_eq!(out.title.as_deref(), Some("Backend Engineer"));
+    assert!(out.applied_at.is_none());
+}
+
+/// An `applied` Application is found with status "applied" and a non-null
+/// `appliedAt` (epoch ms) — the field the popup formats into a date.
+#[test]
+fn resolve_applied_check_found_applied_carries_applied_at() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/applied-1";
+    store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Staff Engineer"),
+            ApplicationOrigin::Saved,
+            Some(true),
+        )
+        .unwrap();
+
+    let out = super::resolve_applied_check(&store, &json!({ "url": url })).unwrap();
+    assert!(out.found);
+    assert_eq!(out.status.as_deref(), Some("applied"));
+    assert!(
+        out.applied_at.is_some(),
+        "an applied row must carry applied_at"
+    );
+}
+
+/// An empty url is a Validation error — never a panic, never a false `found`.
+#[test]
+fn resolve_applied_check_rejects_empty_url() {
+    let (_dir, store) = open_store();
+    let err = super::resolve_applied_check(&store, &json!({ "url": "" })).unwrap_err();
+    assert!(err.to_string().contains("required"));
+}
+
+/// A non-http(s) url normalizes to empty and is rejected the same way
+/// `handle_import` rejects it (dangerous explicit schemes never round-trip).
+#[test]
+fn resolve_applied_check_rejects_non_http_scheme() {
+    let (_dir, store) = open_store();
+    let err =
+        super::resolve_applied_check(&store, &json!({ "url": "javascript:alert(1)" })).unwrap_err();
+    assert!(err.to_string().contains("not a valid"));
+}
+
+/// `applied_result_reply` builds a well-formed `applied.result` envelope
+/// carrying `found`/`status`/`appliedAt` on success (mirrors
+/// `profile_result_reply_carries_type_and_req_id`).
+#[test]
+fn applied_result_reply_carries_type_and_found_flag() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/reply-1";
+    store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "QA Engineer"),
+            ApplicationOrigin::Saved,
+            Some(true),
+        )
+        .unwrap();
+    let outcome = super::resolve_applied_check(&store, &json!({ "url": url }));
+    let reply = super::applied_result_reply("req-9", outcome);
+    let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+    assert_eq!(v["type"], super::msg::APPLIED_RESULT);
+    assert_eq!(v["reqId"], "req-9");
+    assert_eq!(v["payload"]["found"], true);
+    assert_eq!(v["payload"]["status"], "applied");
+    assert!(v["payload"]["appliedAt"].is_number());
+}
+
+/// A malformed (empty) url produces `{ found: false, error }` — never a panic,
+/// never a bare `{error}` without `found` (the extension's guard requires it).
+#[test]
+fn applied_result_reply_carries_error_on_malformed_url() {
+    let (_dir, store) = open_store();
+    let outcome = super::resolve_applied_check(&store, &json!({ "url": "" }));
+    let reply = super::applied_result_reply("req-10", outcome);
+    let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+    assert_eq!(v["type"], super::msg::APPLIED_RESULT);
+    assert_eq!(v["payload"]["found"], false);
+    assert!(v["payload"]["error"].as_str().unwrap().contains("required"));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -112,8 +112,15 @@ pub mod msg {
     pub const PROFILE_RESULT: &str = "profile.result";
     /// RESERVED (not handled yet) — live ATS match for the open posting.
     pub const MATCH_LIVE: &str = "match.live";
-    /// RESERVED (not handled yet) — "have I already applied to this URL?".
+    /// Extension → desktop: "have I already applied to this URL?" — a pure,
+    /// read-only lookup against the local `ApplicationStore` keyed by the
+    /// normalized job url (no fetch, never mutates, no consent gate — this is
+    /// the user's own metadata, device-local, loopback only).
     pub const APPLIED_CHECK: &str = "applied.check";
+    /// Desktop → extension: the `applied.check` outcome (found + optional
+    /// application id/status/title/appliedAt), or `{ found: false, error }` on
+    /// a malformed/empty url.
+    pub const APPLIED_RESULT: &str = "applied.result";
 }
 
 /// Handshake protocol version carried in the `hello` frame. MUST match the TS
@@ -521,6 +528,9 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
                 Some(result_reply(&req_id, outcome))
             }
             FrameDecision::Profile { req_id } => Some(handle_profile(&app, &req_id)),
+            FrameDecision::AppliedCheck { req_id, payload } => {
+                Some(handle_applied_check(&app, &req_id, &payload))
+            }
         };
         if let Some(reply) = reply {
             if writer.send(Message::text(reply)).await.is_err() {
@@ -585,6 +595,11 @@ enum FrameDecision {
     /// An authenticated `profile.get` to answer through [`handle_profile`]. Carries
     /// no payload — the reply is gated on the autofill opt-in, not on any input.
     Profile { req_id: String },
+    /// An authenticated `applied.check` to answer through
+    /// [`handle_applied_check`]. Carries the payload verbatim so the handler can
+    /// read `url`. Read-only by construction: resolved from the local
+    /// `ApplicationStore` only — never the network.
+    AppliedCheck { req_id: String, payload: Value },
 }
 
 /// The per-message handshake gate + dispatch routing (size cap → JSON parse →
@@ -680,8 +695,8 @@ fn advance_auth(
 }
 
 /// Post-auth dispatch: the socket is session-authenticated, so frames carry no
-/// token. Routes `import.request` / `profile.get`; reserved / unknown types get
-/// an `import.result` error reply (never a panic).
+/// token. Routes `import.request` / `profile.get` / `applied.check`; reserved /
+/// unknown types get an `import.result` error reply (never a panic).
 fn advance_authenticated(kind: &str, req_id: String, envelope: &Value) -> FrameDecision {
     match kind {
         msg::IMPORT_REQUEST => {
@@ -690,8 +705,13 @@ fn advance_authenticated(kind: &str, req_id: String, envelope: &Value) -> FrameD
         }
         // Assisted autofill: fetch the contact profile fresh (gated on the opt-in).
         msg::PROFILE_GET => FrameDecision::Profile { req_id },
+        // "Have I already applied to this URL?" — pure, read-only store lookup.
+        msg::APPLIED_CHECK => {
+            let payload = envelope.get("payload").cloned().unwrap_or(Value::Null);
+            FrameDecision::AppliedCheck { req_id, payload }
+        }
         // Reserved message types — acknowledged as unimplemented, never panic.
-        msg::MATCH_LIVE | msg::APPLIED_CHECK => FrameDecision::Reply(result_reply(
+        msg::MATCH_LIVE => FrameDecision::Reply(result_reply(
             &req_id,
             Err(AppError::Validation(format!(
                 "message type '{kind}' is not implemented"
@@ -872,6 +892,107 @@ fn handle_profile(app: &AppHandle, req_id: &str) -> String {
         .try_state::<crate::contact_profile::ContactProfileStore>()
         .map(|s| s.get());
     profile_result_reply(req_id, resolve_profile(enabled, profile.as_ref()))
+}
+
+// ── "Have I already applied?" (applied.check → applied.result) ────────────────
+
+/// The `applied.check` outcome — see [`msg::APPLIED_CHECK`] docs. Read-only:
+/// this only reads the existing [`ApplicationStore`] row for the normalized
+/// url; it never fetches, scrapes, or writes anything.
+#[derive(Debug)]
+struct AppliedCheckOk {
+    found: bool,
+    application_id: Option<String>,
+    status: Option<String>,
+    title: Option<String>,
+    applied_at: Option<u64>,
+}
+
+/// Build the `applied.result` envelope (success or error). Mirrors
+/// [`profile_result_reply`]/[`result_reply`] for the sibling verbs.
+fn applied_result_reply(req_id: &str, outcome: AppResult<AppliedCheckOk>) -> String {
+    let payload = match outcome {
+        Ok(ok) => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("found".to_string(), json!(ok.found));
+            if let Some(v) = ok.application_id {
+                obj.insert("applicationId".to_string(), json!(v));
+            }
+            if let Some(v) = ok.status {
+                obj.insert("status".to_string(), json!(v));
+            }
+            if let Some(v) = ok.title {
+                obj.insert("title".to_string(), json!(v));
+            }
+            if let Some(v) = ok.applied_at {
+                obj.insert("appliedAt".to_string(), json!(v));
+            }
+            Value::Object(obj)
+        }
+        Err(e) => json!({ "found": false, "error": e.to_string() }),
+    };
+    json!({
+        "type": msg::APPLIED_RESULT,
+        "reqId": req_id,
+        "payload": payload,
+    })
+    .to_string()
+}
+
+/// Core `applied.check`: normalize the `url` field the SAME way `handle_import`
+/// does (the canonical SPA/list-view rewrite, then [`normalize_job_url`]) so a
+/// check against the active tab's URL resolves to the exact identity an import
+/// would have used — then looks up any existing Application for it. Pure
+/// read-only store lookup: no fetch, no SSRF host gate (there is nothing to
+/// fetch), and it never creates, merges, or advances a row.
+fn resolve_applied_check(store: &ApplicationStore, payload: &Value) -> AppResult<AppliedCheckOk> {
+    let url = payload
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if url.is_empty() {
+        return Err(AppError::Validation("url is required".to_string()));
+    }
+
+    let canonical = crate::scraping::scrape_url::canonical_job_url(&url);
+    let effective_url = canonical.as_deref().unwrap_or(url.as_str());
+    let normalized = normalize_job_url(effective_url);
+    if normalized.is_empty() {
+        return Err(AppError::Validation(
+            "url is not a valid http(s) URL".to_string(),
+        ));
+    }
+
+    Ok(match store.find_by_job_url(&normalized) {
+        Some(app) => AppliedCheckOk {
+            found: true,
+            application_id: Some(app.id),
+            status: Some(app.status.as_id().to_string()),
+            title: (!app.title.trim().is_empty()).then_some(app.title),
+            applied_at: app.applied_at,
+        },
+        None => AppliedCheckOk {
+            found: false,
+            application_id: None,
+            status: None,
+            title: None,
+            applied_at: None,
+        },
+    })
+}
+
+/// Answer an authenticated `applied.check`: resolve against the local
+/// `ApplicationStore` and return a ready-to-send `applied.result` reply. No
+/// consent gate (unlike `profile.get`) — this is the user's own metadata,
+/// device-local, loopback only.
+fn handle_applied_check(app: &AppHandle, req_id: &str, payload: &Value) -> String {
+    let outcome = app
+        .try_state::<ApplicationStore>()
+        .ok_or_else(|| AppError::Config("applications store unavailable".to_string()))
+        .and_then(|store| resolve_applied_check(store.inner(), payload));
+    applied_result_reply(req_id, outcome)
 }
 
 /// Persist a parsed [`JobPosting`] from an import as a Saved Application and

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -929,6 +929,8 @@ fn applied_result_reply(req_id: &str, outcome: AppResult<AppliedCheckOk>) -> Str
             }
             Value::Object(obj)
         }
+        // Wire-error discipline: this must stay fixed sentinel text (no dynamic/path/PII
+        // content) — detailed context belongs in the desktop log, not on the wire.
         Err(e) => json!({ "found": false, "error": e.to_string() }),
     };
     json!({

--- a/apps/desktop/src-tauri/src/extension_bridge/test.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/test.rs
@@ -37,6 +37,7 @@ fn message_type_constants_match_ts() {
         msg::PROFILE_RESULT,
         msg::MATCH_LIVE,
         msg::APPLIED_CHECK,
+        msg::APPLIED_RESULT,
     ] {
         let needle = format!("'{literal}'");
         assert!(
@@ -81,6 +82,7 @@ fn reserved_types_are_distinct() {
         msg::PROFILE_RESULT,
         msg::MATCH_LIVE,
         msg::APPLIED_CHECK,
+        msg::APPLIED_RESULT,
     ];
     let set: std::collections::HashSet<_> = all.iter().collect();
     assert_eq!(set.len(), all.len(), "wire type constants must be unique");

--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -33,6 +33,7 @@ const mockClient = vi.hoisted(() => ({
   resetForNewToken: vi.fn(),
   importJob: vi.fn(),
   getProfile: vi.fn(),
+  checkApplied: vi.fn(),
 }));
 
 vi.mock('@wxt-dev/browser', () => ({
@@ -91,6 +92,7 @@ beforeEach(() => {
   executeScriptMock.mockReset();
   mockClient.getProfile.mockReset();
   mockClient.importJob.mockReset();
+  mockClient.checkApplied.mockReset();
 });
 
 // ── not-paired short-circuit ────────────────────────────────────────────────
@@ -196,5 +198,57 @@ describe('fill request — success path', () => {
     const res = await send({ kind: 'fill' });
 
     expect(res).toEqual({ ok: true, kind: 'fill', summary });
+  });
+});
+
+// ── appliedCheck request — always ok:true, every failure folds into found:false ─
+
+describe('appliedCheck request', () => {
+  it('returns the checkApplied result on success', async () => {
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
+    ]);
+    mockClient.checkApplied.mockResolvedValue({
+      found: true,
+      applicationId: 'app-1',
+      status: 'applied',
+      appliedAt: 1_718_000_000_000,
+    });
+
+    const res = await send({ kind: 'appliedCheck' });
+
+    expect(res).toEqual({
+      ok: true,
+      kind: 'appliedCheck',
+      result: {
+        found: true,
+        applicationId: 'app-1',
+        status: 'applied',
+        appliedAt: 1_718_000_000_000,
+      },
+    });
+    expect(mockClient.checkApplied).toHaveBeenCalledWith('https://jobs.example.com/posting/9');
+  });
+
+  it('folds a checkApplied REJECTION (e.g. old-desktop unknown message type) into found:false, never ok:false', async () => {
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
+    ]);
+    mockClient.checkApplied.mockRejectedValue(
+      new Error("The desktop app sent an error: unknown message type 'applied.check'")
+    );
+
+    const res = await send({ kind: 'appliedCheck' });
+
+    expect(res).toEqual({ ok: true, kind: 'appliedCheck', result: { found: false } });
+  });
+
+  it('folds a missing active tab into found:false, never ok:false', async () => {
+    tabsQueryMock.mockResolvedValue([]);
+
+    const res = await send({ kind: 'appliedCheck' });
+
+    expect(res).toEqual({ ok: true, kind: 'appliedCheck', result: { found: false } });
+    expect(mockClient.checkApplied).not.toHaveBeenCalled();
   });
 });

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -206,6 +206,23 @@ async function runFill(): Promise<PopupResponse> {
   return { ok: true, kind: 'fill', summary };
 }
 
+/**
+ * Fire-and-forget "have I already applied?" check for the active tab's URL —
+ * a read-only, best-effort enhancement over the import view. NEVER surfaces
+ * `ok:false`: any failure (not paired, bridge unreachable, an old desktop's
+ * unrecognized message type, a malformed reply) folds into `{ found: false }`
+ * so the popup renders nothing rather than an error.
+ */
+async function runAppliedCheck(): Promise<PopupResponse> {
+  try {
+    const url = await activeTabUrl();
+    const result = await getClient().checkApplied(url);
+    return { ok: true, kind: 'appliedCheck', result };
+  } catch {
+    return { ok: true, kind: 'appliedCheck', result: { found: false } };
+  }
+}
+
 /** Central popup-request dispatcher. Never throws — maps errors to `ok:false`. */
 async function handleRequest(req: PopupRequest): Promise<PopupResponse> {
   try {
@@ -244,6 +261,8 @@ async function handleRequest(req: PopupRequest): Promise<PopupResponse> {
         return await runImport(req.applied);
       case 'fill':
         return await runFill();
+      case 'appliedCheck':
+        return await runAppliedCheck();
       default: {
         // Exhaustiveness guard — a new PopupRequest variant must be handled.
         const _never: never = req;

--- a/apps/extension/src/lib/bridge.test.ts
+++ b/apps/extension/src/lib/bridge.test.ts
@@ -1199,3 +1199,112 @@ describe('BridgeClient – getProfile (assisted autofill)', () => {
     client.dispose();
   });
 });
+
+// ── "have I already applied?" applied.check ↔ applied.result ──────────────────
+
+describe('BridgeClient – checkApplied', () => {
+  let latestSocket: FakeWebSocket | undefined;
+  let restoreWS: () => void;
+
+  beforeEach(() => {
+    latestSocket = undefined;
+    restoreWS = installFakeWS((ws) => {
+      latestSocket = ws;
+    });
+  });
+
+  afterEach(() => {
+    restoreWS();
+  });
+
+  async function connectedClient(): Promise<{ client: BridgeClient; socket: FakeWebSocket }> {
+    const client = new BridgeClient(vi.fn());
+    const p = client.ensureConnected();
+    await vi.waitFor(() => {
+      expect(latestSocket).toBeDefined();
+    });
+    const socket = latestSocket!;
+    socket.simulateOpen();
+    await p;
+    return { client, socket };
+  }
+
+  function makeAppliedEnvelope(reqId: string, payload: unknown): string {
+    return JSON.stringify({
+      type: EXTENSION_MESSAGE_TYPES.appliedResult,
+      reqId,
+      payload,
+    });
+  }
+
+  /** Start a checkApplied and wait until the outgoing frame is sent; return the reqId. */
+  async function startAppliedCheck(
+    client: BridgeClient,
+    socket: FakeWebSocket,
+    url: string
+  ): Promise<{ resultPromise: Promise<unknown>; reqId: string }> {
+    const resultPromise = client.checkApplied(url);
+    await vi.waitFor(() => {
+      expect(socket.send).toHaveBeenCalled();
+    });
+    const raw = socket.send.mock.calls[socket.send.mock.calls.length - 1]?.[0] as string;
+    const frame = JSON.parse(raw) as { type: string; reqId: string; payload: unknown };
+    expect(frame.type).toBe(EXTENSION_MESSAGE_TYPES.appliedCheck);
+    expect(frame.payload).toEqual({ url });
+    return { resultPromise, reqId: frame.reqId };
+  }
+
+  it('round-trips a found+applied result into the resolved payload', async () => {
+    const { client, socket } = await connectedClient();
+    const url = 'https://jobs.example.com/posting/9';
+    const { resultPromise, reqId } = await startAppliedCheck(client, socket, url);
+
+    const payload = {
+      found: true,
+      applicationId: 'app-1',
+      status: 'applied',
+      title: 'Senior Rust Engineer',
+      appliedAt: 1_718_000_000_000,
+    };
+    socket.simulateMessage(makeAppliedEnvelope(reqId, payload));
+
+    const result = await resultPromise;
+    expect(result).toEqual(payload);
+
+    client.dispose();
+  });
+
+  it('round-trips a not-found result', async () => {
+    const { client, socket } = await connectedClient();
+    const { resultPromise, reqId } = await startAppliedCheck(
+      client,
+      socket,
+      'https://jobs.example.com/posting/none'
+    );
+
+    socket.simulateMessage(makeAppliedEnvelope(reqId, { found: false }));
+
+    const result = await resultPromise;
+    expect(result).toEqual({ found: false });
+
+    client.dispose();
+  });
+
+  it('resolves with a malformed error (never throws) when the payload is bad', async () => {
+    const { client, socket } = await connectedClient();
+    const { resultPromise, reqId } = await startAppliedCheck(
+      client,
+      socket,
+      'https://jobs.example.com/posting/bad'
+    );
+
+    // found must be a boolean; a string breaks the guard.
+    socket.simulateMessage(makeAppliedEnvelope(reqId, { found: 'yes' }));
+
+    const result = (await resultPromise) as { found: boolean; error?: string };
+    expect(result.found).toBe(false);
+    expect(result.error).toMatch(/malformed/i);
+
+    client.dispose();
+  });
+});

--- a/apps/extension/src/lib/bridge.ts
+++ b/apps/extension/src/lib/bridge.ts
@@ -30,6 +30,7 @@ import { type Browser, browser } from '@wxt-dev/browser';
 import {
   EXTENSION_MESSAGE_TYPES,
   EXTENSION_PROTOCOL_VERSION,
+  type ExtensionAppliedCheckResult,
   type ExtensionEnvelope,
   type ExtensionImportRequest,
   type ExtensionImportResult,
@@ -67,6 +68,7 @@ const READY_TIMEOUT_MS = 1_500;
 
 type PendingResolver = (result: ExtensionImportResult) => void;
 type ProfileResolver = (result: ExtensionProfileResult) => void;
+type AppliedResolver = (result: ExtensionAppliedCheckResult) => void;
 
 export type BridgePhase = 'searching' | 'connected' | 'app_not_running' | 'outdated' | 'bad_token';
 
@@ -147,6 +149,42 @@ function normalizeProfileResult(payload: unknown): ExtensionProfileResult {
   if (src.linkedin !== undefined) out.linkedin = src.linkedin;
   if (src.github !== undefined) out.github = src.github;
   if (src.website !== undefined) out.website = src.website;
+  if (src.error !== undefined) out.error = src.error;
+  return out;
+}
+
+/**
+ * Hand-written guard for an `applied.result` payload (extension stays
+ * zod-free). Mirrors `ExtensionAppliedCheckResultSchema`: `found` must be a
+ * boolean; every other field is an optional string, except `appliedAt` (an
+ * optional number, epoch ms).
+ */
+function isExtensionAppliedCheckResult(v: unknown): v is ExtensionAppliedCheckResult {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  const optStr = (x: unknown): boolean => x === undefined || typeof x === 'string';
+  return (
+    typeof o.found === 'boolean' &&
+    optStr(o.applicationId) &&
+    optStr(o.status) &&
+    optStr(o.title) &&
+    (o.appliedAt === undefined || typeof o.appliedAt === 'number') &&
+    optStr(o.error)
+  );
+}
+
+/** Rebuild an {@link ExtensionAppliedCheckResult} from only the known, defined
+ *  keys — mirrors `normalizeProfileResult`. */
+function normalizeAppliedCheckResult(payload: unknown): ExtensionAppliedCheckResult {
+  if (!isExtensionAppliedCheckResult(payload)) {
+    return { found: false, error: 'The desktop app sent a malformed applied-check result.' };
+  }
+  const src = payload;
+  const out: ExtensionAppliedCheckResult = { found: src.found };
+  if (src.applicationId !== undefined) out.applicationId = src.applicationId;
+  if (src.status !== undefined) out.status = src.status;
+  if (src.title !== undefined) out.title = src.title;
+  if (src.appliedAt !== undefined) out.appliedAt = src.appliedAt;
   if (src.error !== undefined) out.error = src.error;
   return out;
 }
@@ -299,6 +337,9 @@ export class BridgeClient {
    *  separate from {@link pending} so the battle-tested import/auth path is
    *  untouched; both share the {@link timers} map (reqIds are unique UUIDs). */
   private readonly pendingProfile = new Map<string, ProfileResolver>();
+  /** In-flight `applied.check` resolvers, correlated by `reqId`. Kept separate
+   *  from {@link pending} for the same reason as {@link pendingProfile}. */
+  private readonly pendingApplied = new Map<string, AppliedResolver>();
   private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
   private backoffIndex = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -439,6 +480,7 @@ export class BridgeClient {
     this.timers.clear();
     this.pending.clear();
     this.pendingProfile.clear();
+    this.pendingApplied.clear();
     this.transport?.close();
     this.transport = null;
   }
@@ -528,6 +570,48 @@ export class BridgeClient {
         clearTimeout(timer);
         this.timers.delete(reqId);
         this.pendingProfile.delete(reqId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  /**
+   * Send an `applied.check` for `url` and resolve with the validated
+   * `applied.result` payload — whether an Application already exists for it,
+   * or `{ found: false, error }` when the reply is malformed. Rejects only on
+   * no connection / timeout / send failure; the popup's fire-and-forget auto
+   * check swallows every rejection into a silent no-render (read-only, never
+   * blocks the import controls — see `popup.ts`).
+   */
+  async checkApplied(url: string): Promise<ExtensionAppliedCheckResult> {
+    await this.ensureConnected();
+    if (this.phase !== 'connected' || !this.transport) {
+      throw new Error('Desktop app not reachable. Is AI Job Hunter running?');
+    }
+    const transport = this.transport;
+
+    const reqId = newReqId();
+    const envelope: ExtensionEnvelope = {
+      type: EXTENSION_MESSAGE_TYPES.appliedCheck,
+      reqId,
+      payload: { url },
+    };
+
+    return new Promise<ExtensionAppliedCheckResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingApplied.delete(reqId);
+        this.timers.delete(reqId);
+        reject(new Error('Timed out waiting for the desktop app to respond.'));
+      }, REQUEST_TIMEOUT_MS);
+      this.timers.set(reqId, timer);
+      this.pendingApplied.set(reqId, resolve);
+
+      try {
+        transport.send(envelope);
+      } catch (err) {
+        clearTimeout(timer);
+        this.timers.delete(reqId);
+        this.pendingApplied.delete(reqId);
         reject(err instanceof Error ? err : new Error(String(err)));
       }
     });
@@ -800,6 +884,16 @@ export class BridgeClient {
       return;
     }
 
+    // applied.result → the "have I already applied?" outcome (separate map).
+    if (env.type === EXTENSION_MESSAGE_TYPES.appliedResult) {
+      const resolveApplied = this.pendingApplied.get(reqId);
+      if (typeof resolveApplied !== 'function') return;
+      this.pendingApplied.delete(reqId);
+      this.clearTimer(reqId);
+      resolveApplied(normalizeAppliedCheckResult(env.payload));
+      return;
+    }
+
     if (env.type !== EXTENSION_MESSAGE_TYPES.importResult) return;
     const resolve = this.pending.get(reqId);
     if (typeof resolve !== 'function') return;
@@ -839,8 +933,14 @@ export class BridgeClient {
       if (timer) clearTimeout(timer);
       resolve({ error: reason });
     }
+    for (const [reqId, resolve] of this.pendingApplied.entries()) {
+      const timer = this.timers.get(reqId);
+      if (timer) clearTimeout(timer);
+      resolve({ found: false, error: reason });
+    }
     this.pending.clear();
     this.pendingProfile.clear();
+    this.pendingApplied.clear();
     this.timers.clear();
   }
 

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -4,7 +4,7 @@
  * `browser.runtime.sendMessage` inside the extension only.
  */
 
-import type { ExtensionImportResult } from '@ajh/shared';
+import type { ExtensionAppliedCheckResult, ExtensionImportResult } from '@ajh/shared';
 
 import type { AutofillSummary } from './autofill';
 
@@ -44,7 +44,13 @@ export type PopupRequest =
   | { kind: 'reconnect' }
   | { kind: 'import'; applied: boolean }
   /** Assisted autofill: fetch the profile fresh + inject the filler on this tab. */
-  | { kind: 'fill' };
+  | { kind: 'fill' }
+  /**
+   * Fire-and-forget "have I already applied to this URL?" check for the
+   * active tab, run once when the popup shows the connected view. Read-only;
+   * never blocks the import controls.
+   */
+  | { kind: 'appliedCheck' };
 
 /** background → popup responses (discriminated by the originating request). */
 export type PopupResponse =
@@ -52,4 +58,11 @@ export type PopupResponse =
   | { ok: true; kind: 'token' }
   | { ok: true; kind: 'import'; result: ExtensionImportResult }
   | { ok: true; kind: 'fill'; summary: AutofillSummary }
+  /**
+   * Always `ok:true` — every failure mode (not paired, bridge down, malformed
+   * reply, an old desktop's unrecognized message type) is folded into
+   * `result.found === false` by the background, so the popup never has to
+   * special-case an error path for this passive, best-effort check.
+   */
+  | { ok: true; kind: 'appliedCheck'; result: ExtensionAppliedCheckResult }
   | { ok: false; error: string };

--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -81,6 +81,10 @@
           ✓ Authorized
         </button>
         <p class="hint">Import the job on this page into your desktop app.</p>
+        <!-- Fire-and-forget "have I already applied?" line, populated after the
+             popup opens (background auto-check). Empty/hidden until (and unless)
+             an existing Application is found — never shown on a failure/timeout. -->
+        <p id="applied-status" class="msg msg--ok" role="status" aria-live="polite" hidden></p>
         <div class="actions">
           <button id="btn-import" class="btn btn--primary" type="button">Import this job</button>
           <button

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -897,4 +897,39 @@ describe('appliedCheck auto-check', () => {
     expect(status.textContent).toBe('');
     expect(btnImport.textContent).toBe('Import this job');
   });
+
+  it('ignores a stale in-flight response that resolves after a newer check has already rendered', async () => {
+    // Check A starts on entering `connected` for job A, but its response never
+    // resolves yet (simulates it still being in flight when a reconnect fires).
+    let resolveA: ((res: unknown) => void) | undefined;
+    const pendingA = new Promise((resolve) => {
+      resolveA = resolve;
+    });
+    sendMessageMock.mockReturnValueOnce(pendingA);
+    push('connected');
+
+    // Disconnect → reconnect: a fresh, edge-triggered check B starts for job B
+    // and resolves before A does.
+    push('app_not_running');
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'appliedCheck',
+      result: { found: true, status: 'saved', title: 'Job B' },
+    });
+    push('connected');
+    await flush();
+
+    const status = byId<HTMLParagraphElement>('applied-status');
+    const btnImport = byId<HTMLButtonElement>('btn-import');
+    expect(status.textContent).toBe('“Job B” is saved in your pipeline.');
+    expect(btnImport.textContent).toBe('Re-import / update');
+
+    // Check A finally resolves late (found:false for job A) — it must NOT
+    // overwrite the already-rendered job B result.
+    resolveA?.({ ok: true, kind: 'appliedCheck', result: { found: false } });
+    await flush();
+
+    expect(status.textContent).toBe('“Job B” is saved in your pipeline.');
+    expect(btnImport.textContent).toBe('Re-import / update');
+  });
 });

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -396,6 +396,21 @@ describe('resolveAppliedStatusLine', () => {
     };
     expect(resolveAppliedStatusLine(res)).toBe('Already in your pipeline.');
   });
+
+  it('includes the year in the applied date when it differs from the current year', () => {
+    // Relative to the current year so this never rots — June avoids any
+    // UTC/local timezone day-boundary rollover into a different year.
+    const priorYear = new Date().getFullYear() - 1;
+    const appliedAt = Date.UTC(priorYear, 5, 12);
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'applied', appliedAt },
+    };
+    expect(resolveAppliedStatusLine(res)).toMatch(
+      new RegExp(`^Already in your pipeline — applied .+\\b${priorYear}\\.$`)
+    );
+  });
 });
 
 describe('resolveImportButtonLabel', () => {

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -45,6 +45,7 @@ function buildPopupDom(): void {
     <div id="view-searching"></div>
     <button id="btn-import"></button>
     <button id="btn-fill"></button>
+    <p id="applied-status" hidden></p>
     <input id="chk-applied" type="checkbox" />
     <p id="import-msg"></p>
     <button id="btn-unpair"></button>
@@ -66,8 +67,13 @@ buildPopupDom();
 // Dynamic import AFTER DOM + mocks are in place. The module wires its DOM event
 // listeners at load (wire()), so the behavioral tests below drive the controller
 // by dispatching real clicks on the wired buttons and asserting DOM state.
-const { resolveStatusResponse, resolveImportResponse, resolveFillResponse } =
-  await import('./popup');
+const {
+  resolveStatusResponse,
+  resolveImportResponse,
+  resolveFillResponse,
+  resolveAppliedStatusLine,
+  resolveImportButtonLabel,
+} = await import('./popup');
 
 const sendMessageMock = vi.mocked(browser.runtime.sendMessage);
 const looksLikeTokenMock = vi.mocked(looksLikeToken);
@@ -308,6 +314,121 @@ describe('resolveFillResponse', () => {
     const { text, tone } = resolveFillResponse(res);
     expect(tone).toBe('ok');
     expect(text).toBe('Filled 1 field — review them on the page (name split is a guess — verify).');
+  });
+});
+
+// ── resolveAppliedStatusLine / resolveImportButtonLabel ───────────────────────
+
+describe('resolveAppliedStatusLine', () => {
+  it('returns null when the response is not an appliedCheck response', () => {
+    const res = { ok: true as const, kind: 'token' as const };
+    expect(resolveAppliedStatusLine(res)).toBeNull();
+  });
+
+  it('returns null when ok is false', () => {
+    const res = { ok: false as const, error: 'boom' };
+    expect(resolveAppliedStatusLine(res)).toBeNull();
+  });
+
+  it('returns null when the result carries an error (soft-fail)', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: false, error: 'malformed' },
+    };
+    expect(resolveAppliedStatusLine(res)).toBeNull();
+  });
+
+  it('returns null when not found', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: false },
+    };
+    expect(resolveAppliedStatusLine(res)).toBeNull();
+  });
+
+  it('reports "Saved in your pipeline" for a found saved status with no title', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'saved' },
+    };
+    expect(resolveAppliedStatusLine(res)).toBe('Saved in your pipeline.');
+  });
+
+  it('names the job when a title is present for a found saved status', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'saved', title: 'Senior Rust Engineer' },
+    };
+    expect(resolveAppliedStatusLine(res)).toBe('“Senior Rust Engineer” is saved in your pipeline.');
+  });
+
+  it('reports the applied date for a found non-saved status with appliedAt', () => {
+    const appliedAt = Date.UTC(2026, 5, 12); // Jun 12, 2026 (UTC)
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'applied', appliedAt },
+    };
+    expect(resolveAppliedStatusLine(res)).toMatch(/^Already in your pipeline — applied .+\.$/);
+  });
+
+  it('names the job + date together when both a title and appliedAt are present', () => {
+    const appliedAt = Date.UTC(2026, 5, 12);
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'interviewing', title: 'Backend Engineer', appliedAt },
+    };
+    expect(resolveAppliedStatusLine(res)).toMatch(
+      /^“Backend Engineer” is already in your pipeline — applied .+\.$/
+    );
+  });
+
+  it('falls back to a dateless message when a non-saved status carries no appliedAt', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'applied' },
+    };
+    expect(resolveAppliedStatusLine(res)).toBe('Already in your pipeline.');
+  });
+});
+
+describe('resolveImportButtonLabel', () => {
+  it('returns the default label when not found', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: false },
+    };
+    expect(resolveImportButtonLabel(res)).toBe('Import this job');
+  });
+
+  it('returns the default label when the result carries an error', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, error: 'malformed' },
+    };
+    expect(resolveImportButtonLabel(res)).toBe('Import this job');
+  });
+
+  it('returns the default label for a non-appliedCheck response', () => {
+    const res = { ok: true as const, kind: 'token' as const };
+    expect(resolveImportButtonLabel(res)).toBe('Import this job');
+  });
+
+  it('returns the relabeled action when found', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'saved' },
+    };
+    expect(resolveImportButtonLabel(res)).toBe('Re-import / update');
   });
 });
 
@@ -647,5 +768,84 @@ describe('outdated-desktop view', () => {
     expect(pill.textContent).toBe('⟳ Update the app');
     // Retry is available so the user can re-probe after updating the app.
     expect(retry.hidden).toBe(false);
+  });
+});
+
+// ── appliedCheck auto-check (fire-and-forget on entering `connected`) ──────────
+
+describe('appliedCheck auto-check', () => {
+  const statusListener = vi.mocked(browser.runtime.onMessage.addListener).mock.calls[0]?.[0] as
+    ((message: unknown) => void) | undefined;
+  if (!statusListener) throw new Error('onMessage status listener not registered');
+  const push = (phase: ConnectionStatus['phase']) =>
+    statusListener({ ok: true, kind: 'status', status: { phase, port: null, hasToken: true } });
+
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+    // Force a non-connected phase first so the next `push('connected')` below is
+    // a genuine transition regardless of what an earlier test left behind — the
+    // auto-check only fires on ENTERING `connected`, not on a repeated push.
+    push('searching');
+  });
+
+  it('sends an appliedCheck request and renders the found+applied status line with the relabeled button', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'appliedCheck',
+      result: { found: true, status: 'applied', appliedAt: Date.UTC(2026, 5, 12) },
+    });
+
+    push('connected');
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenCalledWith({ kind: 'appliedCheck' });
+    const status = byId<HTMLParagraphElement>('applied-status');
+    expect(status.hidden).toBe(false);
+    expect(status.textContent).toContain('Already in your pipeline');
+    expect(byId<HTMLButtonElement>('btn-import').textContent).toBe('Re-import / update');
+  });
+
+  it('renders nothing and keeps the default button label when not found', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'appliedCheck',
+      result: { found: false },
+    });
+
+    push('connected');
+    await flush();
+
+    const status = byId<HTMLParagraphElement>('applied-status');
+    expect(status.hidden).toBe(true);
+    expect(byId<HTMLButtonElement>('btn-import').textContent).toBe('Import this job');
+  });
+
+  it('soft-fails silently (no status line, default label, no thrown error) when the request rejects', async () => {
+    sendMessageMock.mockRejectedValueOnce(new Error('message channel closed'));
+
+    push('connected');
+    await flush();
+
+    const status = byId<HTMLParagraphElement>('applied-status');
+    expect(status.hidden).toBe(true);
+    expect(byId<HTMLButtonElement>('btn-import').textContent).toBe('Import this job');
+  });
+
+  it('does not re-fire the check on a repeated connected push with no intervening phase change', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'appliedCheck',
+      result: { found: true, status: 'saved' },
+    });
+    push('connected');
+    await flush();
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+
+    sendMessageMock.mockClear();
+    push('connected'); // same phase again — not a transition
+    await flush();
+    expect(sendMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -848,4 +848,38 @@ describe('appliedCheck auto-check', () => {
     await flush();
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
+
+  it('clears the stale status line + button label on leaving connected, with no flash before the next check resolves', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'appliedCheck',
+      result: { found: true, status: 'applied', appliedAt: Date.UTC(2026, 5, 12) },
+    });
+
+    push('connected');
+    await flush();
+
+    const status = byId<HTMLParagraphElement>('applied-status');
+    const btnImport = byId<HTMLButtonElement>('btn-import');
+    expect(status.hidden).toBe(false);
+    expect(btnImport.textContent).toBe('Re-import / update');
+
+    // Desktop drops the connection — job A's stale line/label must not survive.
+    push('app_not_running');
+    expect(status.hidden).toBe(true);
+    expect(status.textContent).toBe('');
+    expect(btnImport.textContent).toBe('Import this job');
+
+    // Reconnect for job B — before its own check resolves, the pre-resolve
+    // state must already be clean (no lingering job-A text while it's in flight).
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'appliedCheck',
+      result: { found: true, status: 'saved' },
+    });
+    push('connected');
+    expect(status.hidden).toBe(true);
+    expect(status.textContent).toBe('');
+    expect(btnImport.textContent).toBe('Import this job');
+  });
 });

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -96,10 +96,14 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-/** Format an epoch-ms timestamp as a short local date (e.g. "Jun 12") — no
- *  year, popup-local formatting, no date library. */
+/** Format an epoch-ms timestamp as a short local date (e.g. "Jun 12", or
+ *  "Jun 12, 2025" when the date's year differs from the current year) —
+ *  popup-local formatting, no date library. */
 function formatShortDate(epochMs: number): string {
-  return new Date(epochMs).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const date = new Date(epochMs);
+  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
+  if (date.getFullYear() !== new Date().getFullYear()) opts.year = 'numeric';
+  return date.toLocaleDateString(undefined, opts);
 }
 
 /**

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -73,7 +73,7 @@ export function resolveImportResponse(
     };
   }
   if (!requestedApplied && result.status && result.status !== 'saved') {
-    const label = result.status.charAt(0).toUpperCase() + result.status.slice(1);
+    const label = capitalize(result.status);
     const lead = title
       ? `“${title}” is already tracked as ${label}`
       : `This job is already tracked as ${label}`;
@@ -81,6 +81,65 @@ export function resolveImportResponse(
   }
   const lead = title ? `Imported “${title}”.` : 'Imported.';
   return { text: `${lead} ${IMPORT_LANDING_HINT}`, tone: 'ok' };
+}
+
+/** Default/found labels for the import button — adaptive per the applied.check
+ *  outcome (same click action either way; the desktop always dedup-merges by
+ *  url, so "re-import" is just the honest label when a row already exists). */
+const IMPORT_LABEL_DEFAULT = 'Import this job';
+const IMPORT_LABEL_FOUND = 'Re-import / update';
+
+/** Capitalize a single-word lowercase id (e.g. an `ApplicationStatus` wire id)
+ *  for display — reused by both the import transparency message and the
+ *  applied-check status line. */
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/** Format an epoch-ms timestamp as a short local date (e.g. "Jun 12") — no
+ *  year, popup-local formatting, no date library. */
+function formatShortDate(epochMs: number): string {
+  return new Date(epochMs).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Given an `appliedCheck` response, return the status line to render above the
+ * import controls, or `null` when nothing should be shown — not found, or ANY
+ * error (the check is a silent best-effort enhancement, never a blocker; see
+ * `runAppliedCheck` in background.ts, which already folds every failure mode
+ * into `result.found === false`).
+ *
+ * Pure: no DOM access, no side effects.
+ */
+export function resolveAppliedStatusLine(res: PopupResponse): string | null {
+  if (!res.ok || res.kind !== 'appliedCheck') return null;
+  const { result } = res;
+  if (result.error || !result.found) return null;
+
+  const title = result.title?.trim();
+  const lead = title ? `“${title}”` : null;
+  if (!result.status || result.status === 'saved') {
+    return lead ? `${lead} is saved in your pipeline.` : 'Saved in your pipeline.';
+  }
+  const when = typeof result.appliedAt === 'number' ? formatShortDate(result.appliedAt) : null;
+  if (lead && when) return `${lead} is already in your pipeline — applied ${when}.`;
+  if (lead) return `${lead} is already in your pipeline.`;
+  if (when) return `Already in your pipeline — applied ${when}.`;
+  return 'Already in your pipeline.';
+}
+
+/**
+ * The import button's label: unchanged when no existing Application was found
+ * for the active tab's url, {@link IMPORT_LABEL_FOUND} when one was. Any
+ * non-found/error outcome (including one still in flight) keeps the default.
+ *
+ * Pure: no DOM access, no side effects.
+ */
+export function resolveImportButtonLabel(res: PopupResponse): string {
+  if (res.ok && res.kind === 'appliedCheck' && !res.result.error && res.result.found) {
+    return IMPORT_LABEL_FOUND;
+  }
+  return IMPORT_LABEL_DEFAULT;
 }
 
 /**
@@ -123,6 +182,7 @@ const els = {
   },
   btnImport: byId<HTMLButtonElement>('btn-import'),
   btnFill: byId<HTMLButtonElement>('btn-fill'),
+  appliedStatus: byId<HTMLParagraphElement>('applied-status'),
   chkApplied: byId<HTMLInputElement>('chk-applied'),
   importMsg: byId<HTMLParagraphElement>('import-msg'),
   btnUnpair: byId<HTMLButtonElement>('btn-unpair'),
@@ -188,6 +248,16 @@ let lastKnownHasToken = false;
  */
 let hasShownOffline = false;
 
+/**
+ * The phase from the previous `render()` call. Used to fire the
+ * fire-and-forget `appliedCheck` auto-check exactly once per TRANSITION into
+ * `connected` — not on every status push while already connected (a repeated
+ * live-status push during a stable connection must not re-fire it), but a
+ * genuine reconnect after a drop naturally re-checks, since that is a fresh
+ * transition too.
+ */
+let lastRenderedPhase: ConnectionStatus['phase'] | null = null;
+
 /** Send a typed request to the background and return its typed response. */
 async function send(req: PopupRequest): Promise<PopupResponse> {
   const res = (await browser.runtime.sendMessage(req)) as PopupResponse | undefined;
@@ -209,6 +279,14 @@ function showView(phase: ConnectionStatus['phase']): void {
 
 function render(status: ConnectionStatus): void {
   lastKnownHasToken = status.hasToken;
+
+  // Fire-and-forget, on each transition INTO connected (never on a repeated
+  // push while already connected) — never awaited here, so it can never delay
+  // this render.
+  if (status.phase === 'connected' && lastRenderedPhase !== 'connected') {
+    void runAppliedAutoCheck();
+  }
+  lastRenderedPhase = status.phase;
 
   // Track whether the offline view has been shown so we can suppress the
   // flickering "Connecting…" spinner during background reconnect attempts.
@@ -317,6 +395,28 @@ async function refreshUntilSettled(attempts = 5, gapMs = 600): Promise<void> {
       return;
     }
     if (i < attempts - 1) await delay(gapMs);
+  }
+}
+
+/**
+ * Run the fire-and-forget `appliedCheck` and render its outcome: the status
+ * line above the import controls, plus the adaptive import-button label.
+ * `runAppliedCheck` in background.ts already folds every failure mode into
+ * `ok:true, result:{found:false}`, so the try/catch here only guards a
+ * transport-level rejection (message-channel closed) — either way nothing is
+ * ever shown but "no line, default label".
+ */
+async function runAppliedAutoCheck(): Promise<void> {
+  try {
+    const res = await send({ kind: 'appliedCheck' });
+    const line = resolveAppliedStatusLine(res);
+    els.appliedStatus.hidden = line === null;
+    els.appliedStatus.textContent = line ?? '';
+    els.btnImport.textContent = resolveImportButtonLabel(res);
+  } catch {
+    els.appliedStatus.hidden = true;
+    els.appliedStatus.textContent = '';
+    els.btnImport.textContent = IMPORT_LABEL_DEFAULT;
   }
 }
 

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -280,11 +280,20 @@ function showView(phase: ConnectionStatus['phase']): void {
 function render(status: ConnectionStatus): void {
   lastKnownHasToken = status.hasToken;
 
-  // Fire-and-forget, on each transition INTO connected (never on a repeated
-  // push while already connected) — never awaited here, so it can never delay
-  // this render.
-  if (status.phase === 'connected' && lastRenderedPhase !== 'connected') {
-    void runAppliedAutoCheck();
+  if (status.phase === 'connected') {
+    // Fire-and-forget, on each transition INTO connected (never on a repeated
+    // push while already connected) — never awaited here, so it can never delay
+    // this render.
+    if (lastRenderedPhase !== 'connected') {
+      void runAppliedAutoCheck();
+    }
+  } else {
+    // Left (or never entered) `connected` — clear any status line/button label
+    // left over from a previous page so it can't flash stale for the next one
+    // before its own check resolves.
+    els.appliedStatus.hidden = true;
+    els.appliedStatus.textContent = '';
+    els.btnImport.textContent = IMPORT_LABEL_DEFAULT;
   }
   lastRenderedPhase = status.phase;
 
@@ -407,6 +416,13 @@ async function refreshUntilSettled(attempts = 5, gapMs = 600): Promise<void> {
  * ever shown but "no line, default label".
  */
 async function runAppliedAutoCheck(): Promise<void> {
+  // Clear synchronously before the request goes out (belt-and-suspenders): if
+  // render() re-enters `connected` for a new page while a previous check is
+  // still in flight, the previous page's line/label must not linger while
+  // this fresh one resolves.
+  els.appliedStatus.hidden = true;
+  els.appliedStatus.textContent = '';
+  els.btnImport.textContent = IMPORT_LABEL_DEFAULT;
   try {
     const res = await send({ kind: 'appliedCheck' });
     const line = resolveAppliedStatusLine(res);

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -412,6 +412,15 @@ async function refreshUntilSettled(attempts = 5, gapMs = 600): Promise<void> {
 }
 
 /**
+ * Generation counter guarding {@link runAppliedAutoCheck} against a stale
+ * in-flight response. A disconnect→reconnect re-enters `connected` and fires
+ * a fresh check while the previous one may still be awaiting `send()`; if the
+ * stale one resolves (or rejects) AFTER the newer check has started, it must
+ * not overwrite the newer result.
+ */
+let appliedCheckGeneration = 0;
+
+/**
  * Run the fire-and-forget `appliedCheck` and render its outcome: the status
  * line above the import controls, plus the adaptive import-button label.
  * `runAppliedCheck` in background.ts already folds every failure mode into
@@ -420,6 +429,8 @@ async function refreshUntilSettled(attempts = 5, gapMs = 600): Promise<void> {
  * ever shown but "no line, default label".
  */
 async function runAppliedAutoCheck(): Promise<void> {
+  appliedCheckGeneration += 1;
+  const myGeneration = appliedCheckGeneration;
   // Clear synchronously before the request goes out (belt-and-suspenders): if
   // render() re-enters `connected` for a new page while a previous check is
   // still in flight, the previous page's line/label must not linger while
@@ -429,11 +440,16 @@ async function runAppliedAutoCheck(): Promise<void> {
   els.btnImport.textContent = IMPORT_LABEL_DEFAULT;
   try {
     const res = await send({ kind: 'appliedCheck' });
+    // A newer check started while this one was in flight — its result (or the
+    // DOM state the newer check already wrote) must win; bail before touching
+    // the DOM.
+    if (myGeneration !== appliedCheckGeneration) return;
     const line = resolveAppliedStatusLine(res);
     els.appliedStatus.hidden = line === null;
     els.appliedStatus.textContent = line ?? '';
     els.btnImport.textContent = resolveImportButtonLabel(res);
   } catch {
+    if (myGeneration !== appliedCheckGeneration) return;
     els.appliedStatus.hidden = true;
     els.appliedStatus.textContent = '';
     els.btnImport.textContent = IMPORT_LABEL_DEFAULT;

--- a/packages/shared/src/ipc/extension-protocol-constants.ts
+++ b/packages/shared/src/ipc/extension-protocol-constants.ts
@@ -43,6 +43,11 @@ export const EXTENSION_PROTOCOL_VERSION = 2;
  * `applied.check` / `applied.result` are the post-auth application frames;
  * `match.live` is **reserved** (fixed now so a future build can add a handler
  * without a protocol bump).
+ *
+ * **Consent-gate boundary** (the rule the next 9 post-auth verbs copy): a
+ * read-only lookup over the user's own device-local metadata (`applied.check`)
+ * needs no desktop opt-in gate; anything returning fresh PII (`profile.get`)
+ * or doing billable/egress work requires a desktop-enforced opt-in.
  */
 export const EXTENSION_MESSAGE_TYPES = {
   /** Extension → desktop: handshake step 1 — `{ protocol, clientNonce }`, no token. */

--- a/packages/shared/src/ipc/extension-protocol-constants.ts
+++ b/packages/shared/src/ipc/extension-protocol-constants.ts
@@ -39,9 +39,10 @@ export const EXTENSION_PROTOCOL_VERSION = 2;
  * `auth` (now carrying `{ proof }`, NOT a token) / `auth.ok`; `update.required`
  * is the force-cutover reply the desktop sends when a connection's first frame
  * is not a valid v2 `hello` (a legacy token `auth`, a missing/older protocol).
- * `import.request` / `import.result` / `profile.get` / `profile.result` are the
- * post-auth application frames; `match.live` and `applied.check` are **reserved**
- * (fixed now so a future build can add handlers without a protocol bump).
+ * `import.request` / `import.result` / `profile.get` / `profile.result` /
+ * `applied.check` / `applied.result` are the post-auth application frames;
+ * `match.live` is **reserved** (fixed now so a future build can add a handler
+ * without a protocol bump).
  */
 export const EXTENSION_MESSAGE_TYPES = {
   /** Extension → desktop: handshake step 1 — `{ protocol, clientNonce }`, no token. */
@@ -75,8 +76,15 @@ export const EXTENSION_MESSAGE_TYPES = {
   profileResult: 'profile.result',
   /** RESERVED — live ATS match for the open posting (not yet handled). */
   matchLive: 'match.live',
-  /** RESERVED — "have I already applied to this URL?" (not yet handled). */
+  /**
+   * Extension → desktop: "have I already applied to this URL?" — a pure,
+   * read-only lookup keyed by the normalized job url (no fetch, never
+   * mutates). No consent gate: this is the user's own metadata, device-local,
+   * loopback only.
+   */
   appliedCheck: 'applied.check',
+  /** Desktop → extension: the `applied.check` outcome (or an `error`). */
+  appliedResult: 'applied.result',
 } as const;
 
 /** Union of all wire `type` strings. */
@@ -203,6 +211,32 @@ export interface ExtensionProfileResult {
   github?: string;
   website?: string;
   /** Refusal (autofill disabled) or failure reason; present ⇒ no fields were sent. */
+  error?: string;
+}
+
+/**
+ * `applied.check` payload — the active tab's URL to look up. Read-only: this
+ * never fetches or creates anything, it only asks "does an Application already
+ * exist for this url?".
+ */
+export interface ExtensionAppliedCheckRequest {
+  url: string;
+}
+
+/**
+ * `applied.result` payload. `found` is always present; the rest are populated
+ * only when an Application already exists for the (canonicalized + normalized)
+ * url. `status` is the lowercase `ApplicationStatus` id (`saved`, `applied`,
+ * …). `appliedAt` is epoch ms (matches `Application.applied_at`) — the popup
+ * formats it locally. `error` carries a malformed-request or lookup failure;
+ * the popup treats ANY error the same as "not found" (renders nothing).
+ */
+export interface ExtensionAppliedCheckResult {
+  found: boolean;
+  applicationId?: string;
+  status?: string;
+  title?: string;
+  appliedAt?: number;
   error?: string;
 }
 

--- a/packages/shared/src/ipc/extension-protocol.test.ts
+++ b/packages/shared/src/ipc/extension-protocol.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  ExtensionAppliedCheckRequestSchema,
+  ExtensionAppliedCheckResultSchema,
   ExtensionEnvelopeSchema,
   ExtensionImportRequestSchema,
   ExtensionProfileResultSchema,
@@ -179,6 +181,67 @@ describe('ExtensionProfileResultSchema', () => {
         type: EXTENSION_MESSAGE_TYPES.profileResult,
         reqId: 'req-002',
         payload: { email: 'x@y.z' },
+      })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ExtensionAppliedCheckRequestSchema / ExtensionAppliedCheckResultSchema
+// ---------------------------------------------------------------------------
+
+describe('ExtensionAppliedCheckRequestSchema', () => {
+  it('accepts a minimal request', () => {
+    expect(() =>
+      ExtensionAppliedCheckRequestSchema.parse({ url: 'https://example.com/job/123' })
+    ).not.toThrow();
+  });
+
+  it('rejects an empty url', () => {
+    expect(() => ExtensionAppliedCheckRequestSchema.parse({ url: '' })).toThrow();
+  });
+
+  it('rejects a request with no url field', () => {
+    expect(() => ExtensionAppliedCheckRequestSchema.parse({})).toThrow();
+  });
+});
+
+describe('ExtensionAppliedCheckResultSchema', () => {
+  it('accepts a not-found result (found only)', () => {
+    expect(() => ExtensionAppliedCheckResultSchema.parse({ found: false })).not.toThrow();
+  });
+
+  it('round-trips a found+applied result with appliedAt', () => {
+    const payload = {
+      found: true,
+      applicationId: 'app-1',
+      status: 'applied',
+      title: 'Senior Rust Engineer',
+      appliedAt: 1_718_000_000_000,
+    };
+    expect(ExtensionAppliedCheckResultSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('accepts an error payload (malformed/empty url on the desktop side)', () => {
+    expect(() =>
+      ExtensionAppliedCheckResultSchema.parse({ found: false, error: 'url is required' })
+    ).not.toThrow();
+  });
+
+  it('rejects a missing found field', () => {
+    expect(() => ExtensionAppliedCheckResultSchema.parse({})).toThrow();
+  });
+
+  it('rejects a non-boolean found field', () => {
+    expect(() => ExtensionAppliedCheckResultSchema.parse({ found: 'yes' })).toThrow();
+  });
+
+  it('carries applied.result through a valid envelope', () => {
+    expect(() =>
+      ExtensionEnvelopeSchema.parse({
+        type: EXTENSION_MESSAGE_TYPES.appliedResult,
+        reqId: 'req-003',
+        payload: { found: false },
       })
     ).not.toThrow();
   });

--- a/packages/shared/src/ipc/extension-protocol.ts
+++ b/packages/shared/src/ipc/extension-protocol.ts
@@ -20,6 +20,8 @@ import { z } from 'zod';
 import {
   EXTENSION_MESSAGE_TYPES,
   EXTENSION_PROTOCOL_VERSION,
+  type ExtensionAppliedCheckRequest,
+  type ExtensionAppliedCheckResult,
   type ExtensionAuthOkPayload,
   type ExtensionAuthPayload,
   type ExtensionChallengePayload,
@@ -38,6 +40,8 @@ import {
 export {
   EXTENSION_MESSAGE_TYPES,
   EXTENSION_PROTOCOL_VERSION,
+  type ExtensionAppliedCheckRequest,
+  type ExtensionAppliedCheckResult,
   type ExtensionAuthOkPayload,
   type ExtensionAuthPayload,
   type ExtensionChallengePayload,
@@ -65,6 +69,7 @@ export const ExtensionMessageTypeSchema = z.enum([
   EXTENSION_MESSAGE_TYPES.profileResult,
   EXTENSION_MESSAGE_TYPES.matchLive,
   EXTENSION_MESSAGE_TYPES.appliedCheck,
+  EXTENSION_MESSAGE_TYPES.appliedResult,
 ]) satisfies z.ZodType<ExtensionMessageType>;
 
 /** `hello` payload (handshake step 1). No token — the proof authenticates later. */
@@ -130,6 +135,28 @@ export const ExtensionProfileResultSchema = z.object({
   website: z.string().optional(),
   error: z.string().optional(),
 }) satisfies z.ZodType<ExtensionProfileResult>;
+
+/**
+ * `applied.check` payload — the active tab's URL to look up. Mirrors
+ * {@link ExtensionAppliedCheckRequest}.
+ */
+export const ExtensionAppliedCheckRequestSchema = z.object({
+  url: z.string().min(1),
+}) satisfies z.ZodType<ExtensionAppliedCheckRequest>;
+
+/**
+ * `applied.result` payload. `found` is required; every other field is
+ * optional (populated only when an Application was found, or `error` on a
+ * malformed/empty url). Mirrors {@link ExtensionAppliedCheckResult}.
+ */
+export const ExtensionAppliedCheckResultSchema = z.object({
+  found: z.boolean(),
+  applicationId: z.string().optional(),
+  status: z.string().optional(),
+  title: z.string().optional(),
+  appliedAt: z.number().optional(),
+  error: z.string().optional(),
+}) satisfies z.ZodType<ExtensionAppliedCheckResult>;
 
 /**
  * The transport envelope every frame is wrapped in. `payload` is left as


### PR DESCRIPTION
## Summary

Implements the reserved `applied.check` bridge verb end-to-end (PR 1 of the extension roadmap; no protocol bump — the verb was pre-wired for exactly this):

- **Popup**: on entering the `connected` phase, fire-and-forget `applied.check {url}` for the active tab (popup-open is the `activeTab` grant — no new permissions). Renders a status line ("Already in your pipeline — applied Jun 12" / "Saved in your pipeline") and relabels the import button to "Re-import / update" when found. Soft-fails silently (including against older desktops); never delays first paint; status/label reset on any phase change so nothing stale survives a reconnect.
- **Desktop** (`extension_bridge`): `FrameDecision::AppliedCheck` replaces the reserved stub — pure read-only lookup (`canonical_job_url` → `normalize_job_url` → `find_by_job_url`, widened `pub(crate)`), fetch-free by construction (no SSRF surface), behind `ConnState::Authenticated`. Replies `applied.result {found, applicationId?, status?, title?, appliedAt?}`.
- **Shared**: `applied.result` literal + request/result interfaces + zod schemas; TS↔Rust parity test extended.
- Background folds every failure into `{found:false}` — no error path reaches the user.

## Review trail (pre-PR gates)

- extension-reviewer: no HIGH/CRITICAL; validated the edge-triggered auto-check design and the new-verb pattern the next 9 PRs copy.
- tauri-security-reviewer: cleared — fetch-free confirmed structurally, auth-gated dispatch, reply never enters page context, no PII logging.
- /review full-tier 3-pass ensemble: PASS ×3; both surviving advisories fixed (stale status/label reset on phase change; year shown for prior-year dates).

## Test plan

- Rust: 10 new bridge tests (found saved/applied, not-found, empty/non-http url, envelope shape, auth-boundary ×3); full crate suite + exact CI clippy (`--all-features`) green.
- Extension: 150 tests (bridge guard round-trips, background failure-folding, popup auto-check edge-trigger + reconnect-reset + date formatting).
- Shared: zod schema suites; `gen:ipc:check` clean; whole-graph typecheck + lint:strict clean.

Part of the approved extension roadmap (PR 1 of 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatic check in the extension popup to determine whether the current job has already been added.
  * Displays the existing application status, title, and date when available.
  * Updates the import button label when an application is already saved or applied.
  * Added secure request and response handling for applied-status checks.

* **Bug Fixes**
  * Applied-status lookup failures now fail silently without disrupting the popup experience.
  * Stale status messages are cleared when switching away from the connected state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->