### PR TITLE
feat: add status.update bridge verb for one-click mark as applied

### DIFF
--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -760,10 +760,12 @@ impl ApplicationStore {
     /// `Ok(false)` when zero rows matched (no such id, or its status had
     /// already moved off `from` since the caller last checked — never a
     /// partial write). Mirrors `set_status`'s field semantics for the matched
-    /// row: `updated_at` always bumps; `applied_at` is set to now only when
-    /// `to == Applied` (this method's only caller today is the narrow
-    /// `saved -> applied` transition, where the row can never already carry an
-    /// `applied_at`); the event's `note` defaults to `""` when `None`.
+    /// row: `updated_at` always bumps; `applied_at` is first-applied-wins (only
+    /// set when currently `NULL`) when `to == Applied` — a `saved` row CAN
+    /// already carry a prior `applied_at` from an earlier applied -> saved
+    /// demotion via the stage picker, and that timestamp must survive a
+    /// re-transition back to `applied`; the event's `note` defaults to `""`
+    /// when `None`.
     pub(crate) fn transition_status_if(
         &self,
         id: &str,
@@ -776,7 +778,7 @@ impl ApplicationStore {
         let tx = guard.transaction()?;
         let rows = if to == ApplicationStatus::Applied {
             tx.execute(
-                "UPDATE applications SET status = ?2, applied_at = ?3, updated_at = ?4
+                "UPDATE applications SET status = ?2, applied_at = COALESCE(applied_at, ?3), updated_at = ?4
                  WHERE id = ?1 AND status = ?5",
                 params![id, to.as_id(), ts_to_db(now), ts_to_db(now), from.as_id()],
             )?

--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -657,7 +657,7 @@ impl ApplicationStore {
                     status.as_id(),
                     "",
                     now,
-                );
+                )?;
             }
             tx.commit()?;
             return Ok(app.id);
@@ -699,7 +699,7 @@ impl ApplicationStore {
         let mut guard = self.conn.lock();
         let tx = guard.transaction()?;
         Self::write_row_conn(&tx, &app)?;
-        Self::append_event_conn(&tx, &app.id, "", status.as_id(), "", now);
+        Self::append_event_conn(&tx, &app.id, "", status.as_id(), "", now)?;
         tx.commit()?;
         Ok(app.id)
     }
@@ -756,16 +756,18 @@ impl ApplicationStore {
     /// the first caller (`extension_bridge::status_update::resolve_status_update`).
     ///
     /// Returns `Ok(true)` iff exactly one row matched `from` and was
-    /// transitioned (with its status event appended, same transaction);
-    /// `Ok(false)` when zero rows matched (no such id, or its status had
-    /// already moved off `from` since the caller last checked — never a
-    /// partial write). Mirrors `set_status`'s field semantics for the matched
-    /// row: `updated_at` always bumps; `applied_at` is first-applied-wins (only
-    /// set when currently `NULL`) when `to == Applied` — a `saved` row CAN
-    /// already carry a prior `applied_at` from an earlier applied -> saved
-    /// demotion via the stage picker, and that timestamp must survive a
-    /// re-transition back to `applied`; the event's `note` defaults to `""`
-    /// when `None`.
+    /// transitioned (with its status event appended, same transaction — an
+    /// event-insert failure propagates and rolls the whole transaction back,
+    /// so the status flip and its history row always commit or roll back
+    /// together); `Ok(false)` when zero rows matched (no such id, or its
+    /// status had already moved off `from` since the caller last checked —
+    /// never a partial write). Mirrors `set_status`'s field semantics for the
+    /// matched row: `updated_at` always bumps; `applied_at` is
+    /// first-applied-wins (only set when currently `NULL`) whenever `to` is
+    /// not pre-apply — a `saved` row CAN already carry a prior `applied_at`
+    /// from an earlier applied -> saved demotion via the stage picker, and
+    /// that timestamp must survive a re-transition back to `applied`; the
+    /// event's `note` defaults to `""` when `None`.
     pub(crate) fn transition_status_if(
         &self,
         id: &str,
@@ -776,7 +778,7 @@ impl ApplicationStore {
         let now = now_ms();
         let mut guard = self.conn.lock();
         let tx = guard.transaction()?;
-        let rows = if to == ApplicationStatus::Applied {
+        let rows = if !to.is_pre_apply() {
             tx.execute(
                 "UPDATE applications SET status = ?2, applied_at = COALESCE(applied_at, ?3), updated_at = ?4
                  WHERE id = ?1 AND status = ?5",
@@ -792,7 +794,7 @@ impl ApplicationStore {
             tx.commit()?;
             return Ok(false);
         }
-        Self::append_event_conn(&tx, id, from.as_id(), to.as_id(), note.unwrap_or(""), now);
+        Self::append_event_conn(&tx, id, from.as_id(), to.as_id(), note.unwrap_or(""), now)?;
         tx.commit()?;
         Ok(true)
     }
@@ -923,12 +925,24 @@ impl ApplicationStore {
     }
 
     /// Connection-scoped status-event append, callable inside a transaction.
-    fn append_event_conn(conn: &Connection, id: &str, from: &str, to: &str, note: &str, at: u64) {
-        let _ = conn.execute(
+    /// Propagates an insert failure (`?`) rather than swallowing it — every
+    /// caller runs this inside the SAME transaction as its row write, so an
+    /// event-insert error rolls the whole transaction back on drop instead of
+    /// leaving a status flip with no history row.
+    fn append_event_conn(
+        conn: &Connection,
+        id: &str,
+        from: &str,
+        to: &str,
+        note: &str,
+        at: u64,
+    ) -> AppResult<()> {
+        conn.execute(
             "INSERT INTO status_events (application_id, from_status, to_status, at, note)
              VALUES (?1,?2,?3,?4,?5)",
             params![id, from, to, ts_to_db(at), note],
-        );
+        )?;
+        Ok(())
     }
 }
 
@@ -1159,7 +1173,7 @@ impl DataStore for ApplicationStore {
                 app.status.as_id(),
                 "imported",
                 app.updated_at,
-            );
+            )?;
         }
         tx.commit()?;
         Ok(apps.len())

--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -746,6 +746,55 @@ impl ApplicationStore {
         Ok(())
     }
 
+    /// Atomic compare-and-set: transition an Application's status ONLY if its
+    /// CURRENT status is exactly `from` — the read-check-write happens under
+    /// ONE lock/transaction (`UPDATE ... WHERE id=? AND status=?`), unlike a
+    /// caller doing its own `.get()` status check and then calling
+    /// [`Self::set_status`] (which re-locks separately and writes
+    /// unconditionally) — that pattern can lose a race between the check and
+    /// the write. `pub(crate)`: the extension bridge's `status.update` guard is
+    /// the first caller (`extension_bridge::status_update::resolve_status_update`).
+    ///
+    /// Returns `Ok(true)` iff exactly one row matched `from` and was
+    /// transitioned (with its status event appended, same transaction);
+    /// `Ok(false)` when zero rows matched (no such id, or its status had
+    /// already moved off `from` since the caller last checked — never a
+    /// partial write). Mirrors `set_status`'s field semantics for the matched
+    /// row: `updated_at` always bumps; `applied_at` is set to now only when
+    /// `to == Applied` (this method's only caller today is the narrow
+    /// `saved -> applied` transition, where the row can never already carry an
+    /// `applied_at`); the event's `note` defaults to `""` when `None`.
+    pub(crate) fn transition_status_if(
+        &self,
+        id: &str,
+        from: ApplicationStatus,
+        to: ApplicationStatus,
+        note: Option<&str>,
+    ) -> AppResult<bool> {
+        let now = now_ms();
+        let mut guard = self.conn.lock();
+        let tx = guard.transaction()?;
+        let rows = if to == ApplicationStatus::Applied {
+            tx.execute(
+                "UPDATE applications SET status = ?2, applied_at = ?3, updated_at = ?4
+                 WHERE id = ?1 AND status = ?5",
+                params![id, to.as_id(), ts_to_db(now), ts_to_db(now), from.as_id()],
+            )?
+        } else {
+            tx.execute(
+                "UPDATE applications SET status = ?2, updated_at = ?3 WHERE id = ?1 AND status = ?4",
+                params![id, to.as_id(), ts_to_db(now), from.as_id()],
+            )?
+        };
+        if rows == 0 {
+            tx.commit()?;
+            return Ok(false);
+        }
+        Self::append_event_conn(&tx, id, from.as_id(), to.as_id(), note.unwrap_or(""), now);
+        tx.commit()?;
+        Ok(true)
+    }
+
     /// Patch the user-editable tracking fields. Each `None` leaves its field
     /// unchanged; bumps `updated_at` whenever called.
     #[allow(clippy::too_many_arguments)]

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -604,6 +604,141 @@ fn set_status_bumps_updated_at_and_appends_event() {
     assert_eq!(last_event.note, "moved to screening");
 }
 
+/// `transition_status_if` (the CAS the extension bridge's `status.update`
+/// guard relies on): a matching `from` transitions the row, appends exactly
+/// one status event, and sets `applied_at` — same field semantics as
+/// `set_status`.
+#[test]
+fn transition_status_if_matches_from_transitions_and_appends_event() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let id = store
+        .upsert_for_origin(
+            "https://x.com/1",
+            "b",
+            &meta("C", "T"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+    let events_before = store.events(&id).len();
+
+    let ok = store
+        .transition_status_if(
+            &id,
+            ApplicationStatus::Saved,
+            ApplicationStatus::Applied,
+            Some("via extension"),
+        )
+        .unwrap();
+    assert!(ok, "a matching `from` must transition and return true");
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(app.status, ApplicationStatus::Applied);
+    assert!(
+        app.applied_at.is_some(),
+        "applied_at must be set on saved -> applied"
+    );
+
+    let events_after = store.events(&id);
+    assert_eq!(
+        events_after.len(),
+        events_before + 1,
+        "exactly one event appended"
+    );
+    let last = events_after.last().unwrap();
+    assert_eq!(last.from_status, "saved");
+    assert_eq!(last.to_status, "applied");
+    assert_eq!(last.note, "via extension");
+}
+
+/// A `from` that does NOT match the row's current status is refused
+/// (`Ok(false)`) — no write, no event appended. This is the compare-and-set
+/// guard itself: it must never transition an unexpected starting status.
+#[test]
+fn transition_status_if_refuses_when_from_does_not_match_current_status() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let id = store.track_manual("", "", &meta("C", "T")).unwrap(); // starts `applied`
+    let events_before = store.events(&id).len();
+
+    let ok = store
+        .transition_status_if(
+            &id,
+            ApplicationStatus::Saved,
+            ApplicationStatus::Applied,
+            Some("via extension"),
+        )
+        .unwrap();
+    assert!(!ok, "a from mismatch must refuse (Ok(false)), never write");
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(
+        app.status,
+        ApplicationStatus::Applied,
+        "status must be unchanged"
+    );
+    assert_eq!(
+        store.events(&id).len(),
+        events_before,
+        "no event appended on refusal"
+    );
+}
+
+/// The lost-race scenario the review flagged: two callers race the same
+/// saved->applied transition. Only the FIRST succeeds; the SECOND must see
+/// `Ok(false)` (the guard lost the race) — never a second event, never a
+/// re-bumped `applied_at`.
+#[test]
+fn transition_status_if_second_racing_call_loses_and_appends_nothing() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let id = store
+        .upsert_for_origin(
+            "https://race.example/1",
+            "b",
+            &meta("C", "T"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let first = store
+        .transition_status_if(
+            &id,
+            ApplicationStatus::Saved,
+            ApplicationStatus::Applied,
+            Some("via extension"),
+        )
+        .unwrap();
+    assert!(first, "the first call wins the race");
+    let applied_at_after_first = store.get(&id).unwrap().applied_at;
+    let events_after_first = store.events(&id).len();
+
+    // Simulate the lost race: a second concurrent caller attempts the exact
+    // same saved -> applied transition after the first already committed.
+    let second = store
+        .transition_status_if(
+            &id,
+            ApplicationStatus::Saved,
+            ApplicationStatus::Applied,
+            Some("via extension"),
+        )
+        .unwrap();
+    assert!(!second, "the second call must lose the race (Ok(false))");
+
+    assert_eq!(
+        store.events(&id).len(),
+        events_after_first,
+        "the losing call must not append a second status event"
+    );
+    assert_eq!(
+        store.get(&id).unwrap().applied_at,
+        applied_at_after_first,
+        "the losing call must not bump applied_at again"
+    );
+}
+
 /// Parity guard: the Rust stage registry order/ids must match the shared-TS
 /// `APPLICATION_STAGES`. The expected list is HARD-CODED from the TS `as const`
 /// so any drift on either side fails the build (see

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -811,6 +811,52 @@ fn transition_status_if_preserves_prior_applied_at_after_demotion_round_trip() {
     );
 }
 
+/// If the status-event INSERT fails, the whole transaction must roll back —
+/// no status flip with a missing history row. Forces the failure by dropping
+/// `status_events` out from under the store via a second raw connection to
+/// the same db file (same trick the demotion round-trip test above uses to
+/// poke the row directly), then asserts the row is UNCHANGED afterward.
+#[test]
+fn transition_status_if_rolls_back_status_when_event_insert_fails() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let id = store
+        .upsert_for_origin(
+            "https://rollback.example/1",
+            "b",
+            &meta("C", "T"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    {
+        let conn = Connection::open(dir.path().join("applications.db")).unwrap();
+        conn.execute("DROP TABLE status_events", []).unwrap();
+    }
+
+    let err = store
+        .transition_status_if(
+            &id,
+            ApplicationStatus::Saved,
+            ApplicationStatus::Applied,
+            Some("via extension"),
+        )
+        .expect_err("the event insert must fail (no such table) and propagate");
+    let _ = err; // exact AppError variant isn't the contract here, only that it's Err
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(
+        app.status,
+        ApplicationStatus::Saved,
+        "the status UPDATE must roll back together with the failed event insert"
+    );
+    assert!(
+        app.applied_at.is_none(),
+        "applied_at must not be stamped when the whole transaction rolled back"
+    );
+}
+
 /// Parity guard: the Rust stage registry order/ids must match the shared-TS
 /// `APPLICATION_STAGES`. The expected list is HARD-CODED from the TS `as const`
 /// so any drift on either side fails the build (see

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -739,6 +739,78 @@ fn transition_status_if_second_racing_call_loses_and_appends_nothing() {
     );
 }
 
+/// A `saved` row CAN already carry a prior `applied_at` — from an earlier
+/// `applied -> saved` demotion via the stage picker (`set_status` never clears
+/// `applied_at` on a demotion to a pre-apply status). Re-transitioning that row
+/// back to `applied` through `transition_status_if` (the extension bridge's
+/// guard) must preserve the ORIGINAL `applied_at`, not stamp a fresh `now()` —
+/// first-applied-wins, same semantics as `set_status`.
+#[test]
+fn transition_status_if_preserves_prior_applied_at_after_demotion_round_trip() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let id = store
+        .upsert_for_origin(
+            "https://demote.example/1",
+            "b",
+            &meta("C", "T"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    // Simulate the applied -> saved round-trip via `set_status` (the stage
+    // picker's path): leaving saved sets applied_at, then demoting back to
+    // saved must NOT clear it.
+    store
+        .set_status(&id, ApplicationStatus::Applied, "applied")
+        .unwrap();
+    let original_applied_at = store.get(&id).unwrap().applied_at;
+    assert!(
+        original_applied_at.is_some(),
+        "leaving saved must set applied_at"
+    );
+
+    store
+        .set_status(&id, ApplicationStatus::Saved, "demoted back to saved")
+        .unwrap();
+    assert_eq!(
+        store.get(&id).unwrap().applied_at,
+        original_applied_at,
+        "a saved demotion must not clear the prior applied_at"
+    );
+
+    // Pin an unmistakably distinct sentinel directly on the row so the final
+    // assertion can't pass by clock-resolution coincidence with `now()` — it
+    // must come from a genuine COALESCE preservation, not a lucky same-ms read.
+    {
+        let conn = Connection::open(dir.path().join("applications.db")).unwrap();
+        conn.execute(
+            "UPDATE applications SET applied_at = 12345 WHERE id = ?1",
+            rusqlite::params![id],
+        )
+        .unwrap();
+    }
+
+    let ok = store
+        .transition_status_if(
+            &id,
+            ApplicationStatus::Saved,
+            ApplicationStatus::Applied,
+            Some("via extension"),
+        )
+        .unwrap();
+    assert!(ok, "saved -> applied must still transition");
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(app.status, ApplicationStatus::Applied);
+    assert_eq!(
+        app.applied_at,
+        Some(12345),
+        "transition_status_if must preserve the prior applied_at (first-applied-wins), not stamp a fresh now()"
+    );
+}
+
 /// Parity guard: the Rust stage registry order/ids must match the shared-TS
 /// `APPLICATION_STAGES`. The expected list is HARD-CODED from the TS `as const`
 /// so any drift on either side fails the build (see

--- a/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
@@ -1215,6 +1215,358 @@ fn applied_result_reply_carries_error_on_malformed_url() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// D. status.update — the narrowest possible write: `saved → applied` on an
+// EXACT url-key match, and nothing else. Mirrors the applied.check section
+// above: dispatch classification + the 3 auth-boundary guards, then
+// `resolve_status_update` (a private, synchronous fn — no `AppHandle` — so,
+// like `resolve_applied_check`, it IS directly unit-testable at the exact
+// boundary `handle_status_update` calls).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// An authenticated `status.update` classifies as `StatusUpdate`, carrying the
+/// payload verbatim (mirrors `authenticated_applied_check_classifies_as_applied_check`).
+#[test]
+fn authenticated_status_update_classifies_as_status_update() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
+        "type": super::msg::STATUS_UPDATE,
+        "reqId": "r-status",
+        "payload": { "url": "https://jobs.example.com/posting/10", "to": "applied" }
+    })
+    .to_string();
+
+    match advance_frame(&state, &ConnState::Authenticated, &frame) {
+        FrameDecision::StatusUpdate { req_id, payload } => {
+            assert_eq!(req_id, "r-status");
+            assert_eq!(
+                payload.get("url").and_then(|u| u.as_str()),
+                Some("https://jobs.example.com/posting/10")
+            );
+            assert_eq!(payload.get("to").and_then(|t| t.as_str()), Some("applied"));
+        }
+        other => panic!("an authenticated status.update must be StatusUpdate, got {other:?}"),
+    }
+}
+
+/// A `status.update` before the handshake completes is NEVER dispatched — same
+/// invariant as `applied_check_before_handshake_is_not_dispatched`: only a
+/// hello may be the first frame.
+#[test]
+fn status_update_before_handshake_is_not_dispatched() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
+        "type": super::msg::STATUS_UPDATE,
+        "reqId": "r-early",
+        "payload": { "url": "https://jobs.example.com/posting/early", "to": "applied" },
+    })
+    .to_string();
+    match advance_frame(&state, &ConnState::AwaitingHello, &frame) {
+        FrameDecision::Outdated(_) => {}
+        other => panic!("a status.update before hello must NOT be StatusUpdate, got {other:?}"),
+    }
+}
+
+/// Same mid-handshake bypass guard as `applied_check_mid_handshake_is_unauthorized`
+/// — a `status.update` cannot skip the proof step either. This is the one
+/// verb where skipping this guard would matter most (it is a WRITE), so it
+/// gets the same three auth-boundary tests as every other authenticated verb.
+#[test]
+fn status_update_mid_handshake_is_unauthorized() {
+    let (_dir, state) = bridge_state();
+    let (conn, _correct) = awaiting_auth(&state);
+    let frame = json!({
+        "type": super::msg::STATUS_UPDATE,
+        "reqId": "r-skip",
+        "payload": { "url": "https://jobs.example.com/posting/skip", "to": "applied" },
+    })
+    .to_string();
+    match advance_frame(&state, &conn, &frame) {
+        FrameDecision::Unauthorized => {}
+        other => panic!("a status.update mid-handshake must be Unauthorized, got {other:?}"),
+    }
+}
+
+/// The happy path: a `saved` Application at the exact url transitions to
+/// `applied` — the status event is appended with the fixed note "via
+/// extension" (no page-derived text) and `applied_at` is set.
+#[test]
+fn resolve_status_update_transitions_saved_to_applied_and_appends_event() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/status-1";
+    let id = store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Backend Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let out = super::status_update::resolve_status_update(
+        &store,
+        &json!({ "url": url, "to": "applied" }),
+    )
+    .expect("saved -> applied must succeed");
+    assert_eq!(out.application_id, id);
+    assert_eq!(out.status, "applied");
+
+    let row = store.get(&id).unwrap();
+    assert_eq!(row.status, ApplicationStatus::Applied);
+    assert!(row.applied_at.is_some(), "applied_at must be set");
+
+    let events = store.events(&id);
+    let last = events.last().expect("set_status must append an event");
+    assert_eq!(last.to_status, "applied");
+    assert_eq!(
+        last.note, "via extension",
+        "the status event note must be a short fixed string — never page-derived text"
+    );
+}
+
+/// Regression guard for the non-atomic-guard review finding (HIGH): the
+/// desktop-side guard is `ApplicationStore::transition_status_if`, a single
+/// atomic compare-and-set. Simulate two callers racing the exact same
+/// `saved -> applied` transition by calling it twice directly — only the
+/// FIRST may succeed; the SECOND must lose the race (`Ok(false)`), appending
+/// no second status event and never re-bumping `applied_at`.
+#[test]
+fn transition_status_if_second_call_after_already_applied_loses_the_race() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/race-1";
+    let id = store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Race Condition Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let first = store
+        .transition_status_if(
+            &id,
+            ApplicationStatus::Saved,
+            ApplicationStatus::Applied,
+            Some("via extension"),
+        )
+        .unwrap();
+    assert!(first, "the first caller wins the race");
+    let applied_at_after_first = store.get(&id).unwrap().applied_at;
+    let events_after_first = store.events(&id).len();
+
+    // A second caller racing the same transition after the first already
+    // committed (e.g. two extension clicks, or a retry) must lose — never a
+    // second write, never a duplicate status event.
+    let second = store
+        .transition_status_if(
+            &id,
+            ApplicationStatus::Saved,
+            ApplicationStatus::Applied,
+            Some("via extension"),
+        )
+        .unwrap();
+    assert!(!second, "the second racing caller must lose (Ok(false))");
+    assert_eq!(
+        store.events(&id).len(),
+        events_after_first,
+        "the losing call must not append a second status event"
+    );
+    assert_eq!(
+        store.get(&id).unwrap().applied_at,
+        applied_at_after_first,
+        "the losing call must not re-bump applied_at"
+    );
+}
+
+/// A row that is ALREADY `applied` refuses — this verb can never re-fire the
+/// transition (no "re-apply", no bumping `applied_at` again).
+#[test]
+fn resolve_status_update_refuses_when_already_applied() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/status-2";
+    store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Staff Engineer"),
+            ApplicationOrigin::Saved,
+            Some(true), // already applied
+        )
+        .unwrap();
+
+    let err = super::status_update::resolve_status_update(
+        &store,
+        &json!({ "url": url, "to": "applied" }),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("no longer saved"), "got: {err}");
+}
+
+/// A row mid-pipeline (picked: `interviewing`) also refuses — the allowlist is
+/// `saved -> applied` ONLY, not "anything not yet applied".
+#[test]
+fn resolve_status_update_refuses_mid_pipeline_status() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/status-3";
+    let id = store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Platform Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+    store
+        .set_status(&id, ApplicationStatus::Interviewing, "test setup")
+        .unwrap();
+
+    let err = super::status_update::resolve_status_update(
+        &store,
+        &json!({ "url": url, "to": "applied" }),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("no longer saved"), "got: {err}");
+
+    // The refusal must never have written anything — status stays exactly as
+    // the test setup left it.
+    let row = store.get(&id).unwrap();
+    assert_eq!(row.status, ApplicationStatus::Interviewing);
+}
+
+/// No Application exists for the url at all → a clear "couldn't find" refusal,
+/// never a create-on-miss.
+#[test]
+fn resolve_status_update_rejects_when_no_match() {
+    let (_dir, store) = open_store();
+    let err = super::status_update::resolve_status_update(
+        &store,
+        &json!({ "url": "https://jobs.example.com/posting/none", "to": "applied" }),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("couldn't find"), "got: {err}");
+}
+
+/// An empty url is a Validation error — never a panic.
+#[test]
+fn resolve_status_update_rejects_empty_url() {
+    let (_dir, store) = open_store();
+    let err =
+        super::status_update::resolve_status_update(&store, &json!({ "url": "", "to": "applied" }))
+            .unwrap_err();
+    assert!(err.to_string().contains("required"));
+}
+
+/// A non-empty but malformed url (an explicit non-http(s) scheme — the same
+/// chokepoint `resolve_applied_check_rejects_non_http_scheme` exercises) hits
+/// the DISTINCT "url is not a valid http(s) URL" sentinel — never confused
+/// with "url is required" (empty input, tested above) or "couldn't find" (a
+/// well-formed url with no matching row, tested below).
+#[test]
+fn resolve_status_update_rejects_malformed_url() {
+    let (_dir, store) = open_store();
+    let err = super::status_update::resolve_status_update(
+        &store,
+        &json!({ "url": "javascript:alert(1)", "to": "applied" }),
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("not a valid"),
+        "a malformed/dangerous-scheme url must hit the distinct invalid-url sentinel, got: {err}"
+    );
+}
+
+/// `to` must literal-match "applied" — re-validated on the Rust side
+/// independently of the TS zod literal. Any other value (including a missing
+/// field) is rejected BEFORE the store is even queried.
+#[test]
+fn resolve_status_update_rejects_to_not_applied() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/status-4";
+    store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "QA Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let wrong_value = super::status_update::resolve_status_update(
+        &store,
+        &json!({ "url": url, "to": "interviewing" }),
+    )
+    .unwrap_err();
+    assert!(
+        wrong_value.to_string().contains("unsupported"),
+        "got: {wrong_value}"
+    );
+
+    let missing_field =
+        super::status_update::resolve_status_update(&store, &json!({ "url": url })).unwrap_err();
+    assert!(
+        missing_field.to_string().contains("unsupported"),
+        "got: {missing_field}"
+    );
+
+    // Neither rejected attempt may have written anything.
+    let row = store.list().into_iter().find(|a| a.job_url == url).unwrap();
+    assert_eq!(row.status, ApplicationStatus::Saved);
+}
+
+/// `status_result_reply` builds a well-formed `status.update` success envelope
+/// (mirrors `applied_result_reply_carries_type_and_found_flag`).
+#[test]
+fn status_result_reply_carries_ok_true_and_fields() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/status-5";
+    store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Reply Test Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+    let outcome = super::status_update::resolve_status_update(
+        &store,
+        &json!({ "url": url, "to": "applied" }),
+    );
+    let reply = super::status_update::status_result_reply("req-11", outcome);
+    let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+    assert_eq!(v["type"], super::msg::STATUS_RESULT);
+    assert_eq!(v["reqId"], "req-11");
+    assert_eq!(v["payload"]["ok"], true);
+    assert_eq!(v["payload"]["status"], "applied");
+    assert!(v["payload"]["applicationId"].is_string());
+}
+
+/// UNLIKE `applied.result`, a `status.update` failure carries a fixed,
+/// user-facing `error` string — this verb's errors are surfaced to the user
+/// (it answers a deliberate click), so the reply must never fold the failure
+/// into a silent/blank payload.
+#[test]
+fn status_result_reply_carries_user_facing_error() {
+    let (_dir, store) = open_store();
+    let outcome = super::status_update::resolve_status_update(
+        &store,
+        &json!({ "url": "https://jobs.example.com/posting/none", "to": "applied" }),
+    );
+    let reply = super::status_update::status_result_reply("req-12", outcome);
+    let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+    assert_eq!(v["type"], super::msg::STATUS_RESULT);
+    assert_eq!(v["payload"]["ok"], false);
+    assert!(v["payload"]["error"]
+        .as_str()
+        .unwrap()
+        .contains("couldn't find"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // A4. Port-probe fallback — hermetic, non-flaky
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -69,6 +69,7 @@ pub mod handshake;
 mod import_tests;
 pub mod native_host;
 pub mod register;
+mod status_update;
 #[cfg(test)]
 mod test;
 
@@ -121,6 +122,18 @@ pub mod msg {
     /// application id/status/title/appliedAt), or `{ found: false, error }` on
     /// a malformed/empty url.
     pub const APPLIED_RESULT: &str = "applied.result";
+    /// Extension → desktop: "mark this URL applied" — a user-gestured WRITE,
+    /// structurally restricted to the single `saved → applied` transition on
+    /// an EXACT normalized-URL-key match. Never any other transition, never a
+    /// fuzzy match; see [`super::status_update::resolve_status_update`] for
+    /// the allowlist.
+    pub const STATUS_UPDATE: &str = "status.update";
+    /// Desktop → extension: the `status.update` outcome — `{ ok: true,
+    /// applicationId, status }` on success, `{ ok: false, error }` on a
+    /// refusal (no match / wrong starting status / unsupported transition) or
+    /// a malformed request. UNLIKE `applied.result`, this verb's errors ARE
+    /// user-facing (it answers a deliberate click, not a passive check).
+    pub const STATUS_RESULT: &str = "status.result";
 }
 
 /// Handshake protocol version carried in the `hello` frame. MUST match the TS
@@ -531,6 +544,9 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
             FrameDecision::AppliedCheck { req_id, payload } => {
                 Some(handle_applied_check(&app, &req_id, &payload))
             }
+            FrameDecision::StatusUpdate { req_id, payload } => {
+                Some(status_update::handle_status_update(&app, &req_id, &payload))
+            }
         };
         if let Some(reply) = reply {
             if writer.send(Message::text(reply)).await.is_err() {
@@ -600,6 +616,13 @@ enum FrameDecision {
     /// read `url`. Read-only by construction: resolved from the local
     /// `ApplicationStore` only — never the network.
     AppliedCheck { req_id: String, payload: Value },
+    /// An authenticated `status.update` to answer through
+    /// [`status_update::handle_status_update`]. Carries the payload verbatim so
+    /// the handler can read `url` + `to`. The ONLY write this dispatch can
+    /// route to besides `Import`;
+    /// [`status_update::resolve_status_update`] is what actually restricts it
+    /// to `saved → applied` on an exact match.
+    StatusUpdate { req_id: String, payload: Value },
 }
 
 /// The per-message handshake gate + dispatch routing (size cap → JSON parse →
@@ -695,8 +718,9 @@ fn advance_auth(
 }
 
 /// Post-auth dispatch: the socket is session-authenticated, so frames carry no
-/// token. Routes `import.request` / `profile.get` / `applied.check`; reserved /
-/// unknown types get an `import.result` error reply (never a panic).
+/// token. Routes `import.request` / `profile.get` / `applied.check` /
+/// `status.update`; reserved / unknown types get an `import.result` error
+/// reply (never a panic).
 fn advance_authenticated(kind: &str, req_id: String, envelope: &Value) -> FrameDecision {
     match kind {
         msg::IMPORT_REQUEST => {
@@ -709,6 +733,12 @@ fn advance_authenticated(kind: &str, req_id: String, envelope: &Value) -> FrameD
         msg::APPLIED_CHECK => {
             let payload = envelope.get("payload").cloned().unwrap_or(Value::Null);
             FrameDecision::AppliedCheck { req_id, payload }
+        }
+        // "Mark this URL applied" — the narrowest possible write (saved → applied
+        // on an exact URL-key match only).
+        msg::STATUS_UPDATE => {
+            let payload = envelope.get("payload").cloned().unwrap_or(Value::Null);
+            FrameDecision::StatusUpdate { req_id, payload }
         }
         // Reserved message types — acknowledged as unimplemented, never panic.
         msg::MATCH_LIVE => FrameDecision::Reply(result_reply(

--- a/apps/desktop/src-tauri/src/extension_bridge/status_update.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/status_update.rs
@@ -1,0 +1,194 @@
+//! "Mark as applied" (`status.update` → `status.result`) — the narrowest
+//! possible WRITE the bridge supports: `saved → applied` on an EXACT
+//! normalized-url match, and nothing else. Split out of `mod.rs` to keep that
+//! module under the R8 hard LOC cap (`tests/architecture.rs`); mirrors
+//! `resolve_applied_check`/`handle_applied_check`'s pure/impure split in the
+//! parent module — `resolve_status_update` takes no `AppHandle` so it stays
+//! directly unit-testable (see `import_tests.rs`), while `handle_status_update`
+//! does the app-stateful notify/emit tail.
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Manager};
+
+use super::msg;
+use crate::applications::{normalize_job_url, ApplicationStatus, ApplicationStore};
+use crate::error::{AppError, AppResult};
+use crate::events::{emit_event, APPLICATIONS_CHANGED};
+
+/// The `status.update` outcome: the transitioned Application's id + new status
+/// (always `"applied"`), plus a title/company snapshot used ONLY to name the
+/// Notification Center card in [`handle_status_update`] — NOT sent over the
+/// wire (see [`status_result_reply`], which sends `{ applicationId, status }`
+/// alone). The snapshot is already-stored, previously-trusted data (the same
+/// title/company already shown on the Applications page), not fresh page
+/// content.
+#[derive(Debug)]
+pub(super) struct StatusUpdateOk {
+    pub(super) application_id: String,
+    pub(super) status: String,
+    pub(super) title: String,
+    pub(super) company: String,
+}
+
+/// Build the `status.update` reply. UNLIKE `applied_result_reply`, this verb's
+/// errors ARE user-facing (a `status.update` answers a deliberate click, not a
+/// passive background check) — the popup must render the `error` text, never
+/// fold it into a silent no-op.
+pub(super) fn status_result_reply(req_id: &str, outcome: AppResult<StatusUpdateOk>) -> String {
+    let payload = match outcome {
+        Ok(ok) => json!({
+            "ok": true,
+            "applicationId": ok.application_id,
+            "status": ok.status,
+        }),
+        // Wire-error discipline: this must stay fixed sentinel text (no dynamic/path/PII
+        // content) — detailed context belongs in the desktop log, not on the wire.
+        Err(e) => json!({ "ok": false, "error": e.to_string() }),
+    };
+    json!({
+        "type": msg::STATUS_RESULT,
+        "reqId": req_id,
+        "payload": payload,
+    })
+    .to_string()
+}
+
+/// Core `status.update`: normalize the `url` field the SAME way
+/// `resolve_applied_check`/`handle_import` do, then perform the ONE transition
+/// this verb can ever perform — `saved → applied` on an EXACT normalized-url
+/// match. Every other combination is a refusal, never a write:
+///   - `to` must literal-match `"applied"` — re-validated here independently
+///     of the TS zod literal (TS is spec, Rust is the boundary).
+///   - the row must exist for the exact normalized url (no fuzzy match, no
+///     create-on-miss).
+///   - the row's CURRENT status must be exactly `saved` (no transition out of
+///     any other stage, no re-applying an already-applied row).
+///
+/// The actual guard is [`ApplicationStore::transition_status_if`]'s atomic
+/// compare-and-set (`UPDATE ... WHERE id=? AND status=?` in one
+/// lock/transaction) — the `find_by_job_url` + status-check below is
+/// presentation only (it distinguishes "no match" from "not saved" for the
+/// user-facing message), so a status change racing between that read and the
+/// write can never be silently overwritten. The CAS appends the status event
+/// with a short fixed note ("via extension" — no page-derived text, per the
+/// untrusted-text discipline) and sets `applied_at` in the SAME transaction.
+pub(super) fn resolve_status_update(
+    store: &ApplicationStore,
+    payload: &Value,
+) -> AppResult<StatusUpdateOk> {
+    let url = payload
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if url.is_empty() {
+        return Err(AppError::Validation("url is required".to_string()));
+    }
+    let to = payload.get("to").and_then(|v| v.as_str()).unwrap_or("");
+    if to != "applied" {
+        return Err(AppError::Validation(
+            "unsupported status transition".to_string(),
+        ));
+    }
+
+    let canonical = crate::scraping::scrape_url::canonical_job_url(&url);
+    let effective_url = canonical.as_deref().unwrap_or(url.as_str());
+    let normalized = normalize_job_url(effective_url);
+    if normalized.is_empty() {
+        return Err(AppError::Validation(
+            "url is not a valid http(s) URL".to_string(),
+        ));
+    }
+
+    let app = store.find_by_job_url(&normalized).ok_or_else(|| {
+        AppError::Validation("couldn't find a saved job for this page".to_string())
+    })?;
+    if app.status != ApplicationStatus::Saved {
+        return Err(AppError::Validation(
+            "this job is no longer saved — its status already moved on".to_string(),
+        ));
+    }
+
+    // Compare-and-set: re-checks the current status atomically (one
+    // lock/transaction) instead of trusting the read above, which could be
+    // stale by the time we write. `Ok(false)` means the guard lost the race
+    // (status moved on between the read and here) — refuse with the same
+    // user-facing sentinel as the pre-check above, never a partial write.
+    let transitioned = store
+        .transition_status_if(
+            &app.id,
+            ApplicationStatus::Saved,
+            ApplicationStatus::Applied,
+            Some("via extension"),
+        )
+        .map_err(|e| {
+            // Wire-error discipline: never let a raw store error (path/SQL
+            // detail) reach `status_result_reply` — log it, reply a fixed
+            // sentinel.
+            log::warn!("[extension_bridge] status.update store error: {e}");
+            AppError::Storage("could not update this application".to_string())
+        })?;
+    if !transitioned {
+        return Err(AppError::Validation(
+            "this job is no longer saved — its status already moved on".to_string(),
+        ));
+    }
+
+    Ok(StatusUpdateOk {
+        application_id: app.id,
+        status: ApplicationStatus::Applied.as_id().to_string(),
+        title: app.title,
+        company: app.company,
+    })
+}
+
+/// Answer an authenticated `status.update`: resolve the `saved → applied`
+/// transition against the local `ApplicationStore`, and on success also drop a
+/// Notification Center record + refresh the Applications view (mirrors
+/// `handle_import`'s notify tail) so the change is visible without reopening
+/// the app. No consent gate — a deliberate click writing to the user's own
+/// local store on an exact match, strictly narrower than the already-ungated
+/// `import.request{applied:true}` (see the doc note on [`msg::STATUS_UPDATE`]).
+pub(super) fn handle_status_update(app: &AppHandle, req_id: &str, payload: &Value) -> String {
+    let outcome = app
+        .try_state::<ApplicationStore>()
+        .ok_or_else(|| AppError::Config("applications store unavailable".to_string()))
+        .and_then(|store| resolve_status_update(store.inner(), payload));
+
+    if let Ok(ok) = &outcome {
+        let display_name = if ok.title.trim().is_empty() {
+            ok.company.clone()
+        } else {
+            ok.title.clone()
+        };
+        emit_event(
+            app,
+            APPLICATIONS_CHANGED,
+            json!({
+                "applicationId": ok.application_id.clone(),
+                "status": ok.status.clone(),
+            }),
+        );
+        let mut search = serde_json::Map::new();
+        search.insert(
+            "highlight".to_string(),
+            Value::String(ok.application_id.clone()),
+        );
+        crate::commands::notifications::push_and_notify(
+            app,
+            crate::notifications::NewNotification {
+                kind: "status.update".to_string(),
+                title: format!("Marked \"{display_name}\" as applied"),
+                body: "via the browser extension".to_string(),
+                route: Some(crate::notifications::NotificationRoute {
+                    to: "/applications".to_string(),
+                    search: Some(search),
+                }),
+            },
+            crate::commands::notifications::OsBanner::WhenUnfocused,
+        );
+    }
+
+    status_result_reply(req_id, outcome)
+}

--- a/apps/desktop/src-tauri/src/extension_bridge/test.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/test.rs
@@ -38,6 +38,8 @@ fn message_type_constants_match_ts() {
         msg::MATCH_LIVE,
         msg::APPLIED_CHECK,
         msg::APPLIED_RESULT,
+        msg::STATUS_UPDATE,
+        msg::STATUS_RESULT,
     ] {
         let needle = format!("'{literal}'");
         assert!(
@@ -83,6 +85,8 @@ fn reserved_types_are_distinct() {
         msg::MATCH_LIVE,
         msg::APPLIED_CHECK,
         msg::APPLIED_RESULT,
+        msg::STATUS_UPDATE,
+        msg::STATUS_RESULT,
     ];
     let set: std::collections::HashSet<_> = all.iter().collect();
     assert_eq!(set.len(), all.len(), "wire type constants must be unique");

--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -34,6 +34,7 @@ const mockClient = vi.hoisted(() => ({
   importJob: vi.fn(),
   getProfile: vi.fn(),
   checkApplied: vi.fn(),
+  updateStatus: vi.fn(),
 }));
 
 vi.mock('@wxt-dev/browser', () => ({
@@ -93,6 +94,7 @@ beforeEach(() => {
   mockClient.getProfile.mockReset();
   mockClient.importJob.mockReset();
   mockClient.checkApplied.mockReset();
+  mockClient.updateStatus.mockReset();
 });
 
 // ── not-paired short-circuit ────────────────────────────────────────────────
@@ -250,5 +252,72 @@ describe('appliedCheck request', () => {
 
     expect(res).toEqual({ ok: true, kind: 'appliedCheck', result: { found: false } });
     expect(mockClient.checkApplied).not.toHaveBeenCalled();
+  });
+});
+
+// ── statusUpdate request — errors are NOT folded (unlike appliedCheck) ────────
+
+describe('statusUpdate request', () => {
+  it('returns the updateStatus success result', async () => {
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
+    ]);
+    mockClient.updateStatus.mockResolvedValue({
+      ok: true,
+      applicationId: 'app-1',
+      status: 'applied',
+    });
+
+    const res = await send({ kind: 'statusUpdate' });
+
+    expect(res).toEqual({
+      ok: true,
+      kind: 'statusUpdate',
+      result: { ok: true, applicationId: 'app-1', status: 'applied' },
+    });
+    expect(mockClient.updateStatus).toHaveBeenCalledWith('https://jobs.example.com/posting/9');
+  });
+
+  it('passes a desktop-side refusal straight through as result (never folds it, unlike appliedCheck)', async () => {
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/none' } as never,
+    ]);
+    mockClient.updateStatus.mockResolvedValue({
+      ok: false,
+      error: "couldn't find a saved job for this page",
+    });
+
+    const res = await send({ kind: 'statusUpdate' });
+
+    expect(res).toEqual({
+      ok: true,
+      kind: 'statusUpdate',
+      result: { ok: false, error: "couldn't find a saved job for this page" },
+    });
+  });
+
+  it('surfaces a transport-level rejection as ok:false at the OUTER level (UNLIKE appliedCheck, which folds every rejection)', async () => {
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
+    ]);
+    mockClient.updateStatus.mockRejectedValue(
+      new Error('Desktop app not reachable. Is AI Job Hunter running?')
+    );
+
+    const res = await send({ kind: 'statusUpdate' });
+
+    expect(res).toEqual({
+      ok: false,
+      error: 'Desktop app not reachable. Is AI Job Hunter running?',
+    });
+  });
+
+  it('surfaces "Could not read the current tab URL." when there is no active tab, without calling updateStatus', async () => {
+    tabsQueryMock.mockResolvedValue([]);
+
+    const res = await send({ kind: 'statusUpdate' });
+
+    expect(res).toEqual({ ok: false, error: 'Could not read the current tab URL.' });
+    expect(mockClient.updateStatus).not.toHaveBeenCalled();
   });
 });

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -223,6 +223,21 @@ async function runAppliedCheck(): Promise<PopupResponse> {
   }
 }
 
+/**
+ * User-clicked "Mark as applied" for the active tab's URL. UNLIKE
+ * `runAppliedCheck`, failures are NOT folded away here: a transport-level
+ * rejection (not paired, bridge unreachable, timeout) propagates up to
+ * `handleRequest`'s outer catch as `{ ok: false, error }`, and a resolved
+ * desktop-side refusal (`{ ok: false, error }` — no match / wrong starting
+ * status / unsupported transition) still passes straight through as `result`
+ * — this is a deliberate click action, so the user must see why it failed.
+ */
+async function runStatusUpdate(): Promise<PopupResponse> {
+  const url = await activeTabUrl();
+  const result = await getClient().updateStatus(url);
+  return { ok: true, kind: 'statusUpdate', result };
+}
+
 /** Central popup-request dispatcher. Never throws — maps errors to `ok:false`. */
 async function handleRequest(req: PopupRequest): Promise<PopupResponse> {
   try {
@@ -263,6 +278,8 @@ async function handleRequest(req: PopupRequest): Promise<PopupResponse> {
         return await runFill();
       case 'appliedCheck':
         return await runAppliedCheck();
+      case 'statusUpdate':
+        return await runStatusUpdate();
       default: {
         // Exhaustiveness guard — a new PopupRequest variant must be handled.
         const _never: never = req;

--- a/apps/extension/src/lib/bridge.test.ts
+++ b/apps/extension/src/lib/bridge.test.ts
@@ -1308,3 +1308,143 @@ describe('BridgeClient – checkApplied', () => {
     client.dispose();
   });
 });
+
+// ── "mark this URL applied" status.update ↔ status.result ─────────────────────
+
+describe('BridgeClient – updateStatus', () => {
+  let latestSocket: FakeWebSocket | undefined;
+  let createdSockets: FakeWebSocket[] = [];
+  let restoreWS: () => void;
+
+  beforeEach(() => {
+    latestSocket = undefined;
+    createdSockets = [];
+    restoreWS = installFakeWS((ws) => {
+      latestSocket = ws;
+      createdSockets.push(ws);
+    });
+  });
+
+  afterEach(() => {
+    restoreWS();
+    vi.useRealTimers();
+  });
+
+  async function connectedClient(): Promise<{ client: BridgeClient; socket: FakeWebSocket }> {
+    const client = new BridgeClient(vi.fn());
+    const p = client.ensureConnected();
+    await vi.waitFor(() => {
+      expect(latestSocket).toBeDefined();
+    });
+    const socket = latestSocket!;
+    socket.simulateOpen();
+    await p;
+    return { client, socket };
+  }
+
+  function makeStatusEnvelope(reqId: string, payload: unknown): string {
+    return JSON.stringify({
+      type: EXTENSION_MESSAGE_TYPES.statusResult,
+      reqId,
+      payload,
+    });
+  }
+
+  /** Start an updateStatus and wait until the outgoing frame is sent; return the reqId. */
+  async function startUpdateStatus(
+    client: BridgeClient,
+    socket: FakeWebSocket,
+    url: string
+  ): Promise<{ resultPromise: Promise<unknown>; reqId: string }> {
+    const resultPromise = client.updateStatus(url);
+    await vi.waitFor(() => {
+      expect(socket.send).toHaveBeenCalled();
+    });
+    const raw = socket.send.mock.calls[socket.send.mock.calls.length - 1]?.[0] as string;
+    const frame = JSON.parse(raw) as { type: string; reqId: string; payload: unknown };
+    expect(frame.type).toBe(EXTENSION_MESSAGE_TYPES.statusUpdate);
+    expect(frame.payload).toEqual({ url, to: 'applied' });
+    return { resultPromise, reqId: frame.reqId };
+  }
+
+  it('round-trips a success result into the resolved payload', async () => {
+    const { client, socket } = await connectedClient();
+    const url = 'https://jobs.example.com/posting/9';
+    const { resultPromise, reqId } = await startUpdateStatus(client, socket, url);
+
+    const payload = { ok: true, applicationId: 'app-1', status: 'applied' };
+    socket.simulateMessage(makeStatusEnvelope(reqId, payload));
+
+    const result = await resultPromise;
+    expect(result).toEqual(payload);
+
+    client.dispose();
+  });
+
+  it('round-trips a desktop-side refusal (ok:false + error) into the resolved payload — never rejects', async () => {
+    const { client, socket } = await connectedClient();
+    const { resultPromise, reqId } = await startUpdateStatus(
+      client,
+      socket,
+      'https://jobs.example.com/posting/none'
+    );
+
+    socket.simulateMessage(
+      makeStatusEnvelope(reqId, { ok: false, error: "couldn't find a saved job for this page" })
+    );
+
+    const result = await resultPromise;
+    expect(result).toEqual({ ok: false, error: "couldn't find a saved job for this page" });
+
+    client.dispose();
+  });
+
+  it('resolves with a malformed error (never throws) when the payload is bad', async () => {
+    const { client, socket } = await connectedClient();
+    const { resultPromise, reqId } = await startUpdateStatus(
+      client,
+      socket,
+      'https://jobs.example.com/posting/bad'
+    );
+
+    // ok must be a boolean; a string breaks the guard.
+    socket.simulateMessage(makeStatusEnvelope(reqId, { ok: 'yes' }));
+
+    const result = (await resultPromise) as { ok: boolean; error?: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/malformed/i);
+
+    client.dispose();
+  });
+
+  it('rejects when not connected — every port fails and the ws probe exhausts', async () => {
+    vi.useFakeTimers();
+
+    const client = new BridgeClient(vi.fn());
+    const updatePromise = client.updateStatus('https://jobs.example.com/posting/x');
+    // Attach synchronously so vitest never flags a transient "unhandled
+    // rejection" while the probe below runs to completion.
+    const outcomePromise = updatePromise.then(
+      () => ({ ok: true as const }),
+      (e: unknown) => ({ ok: false as const, error: e })
+    );
+
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const idx = attempt;
+      await vi.waitFor(() => {
+        expect(createdSockets.length).toBeGreaterThanOrEqual(idx + 1);
+      });
+      createdSockets[idx]!.simulateClose();
+    }
+
+    const outcome = await outcomePromise;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toBeInstanceOf(Error);
+      expect((outcome.error as Error).message).toMatch(/not reachable/i);
+    }
+    expect(client.status().phase).toBe('app_not_running');
+
+    client.dispose();
+  });
+});

--- a/apps/extension/src/lib/bridge.ts
+++ b/apps/extension/src/lib/bridge.ts
@@ -35,6 +35,7 @@ import {
   type ExtensionImportRequest,
   type ExtensionImportResult,
   type ExtensionProfileResult,
+  type ExtensionStatusUpdateResult,
 } from '@ajh/shared/extension-protocol';
 
 import { computeProof, constantTimeHexEqual, isValidNonceHex, randomNonceHex } from './handshake';
@@ -69,6 +70,7 @@ const READY_TIMEOUT_MS = 1_500;
 type PendingResolver = (result: ExtensionImportResult) => void;
 type ProfileResolver = (result: ExtensionProfileResult) => void;
 type AppliedResolver = (result: ExtensionAppliedCheckResult) => void;
+type StatusResolver = (result: ExtensionStatusUpdateResult) => void;
 
 export type BridgePhase = 'searching' | 'connected' | 'app_not_running' | 'outdated' | 'bad_token';
 
@@ -185,6 +187,36 @@ function normalizeAppliedCheckResult(payload: unknown): ExtensionAppliedCheckRes
   if (src.status !== undefined) out.status = src.status;
   if (src.title !== undefined) out.title = src.title;
   if (src.appliedAt !== undefined) out.appliedAt = src.appliedAt;
+  if (src.error !== undefined) out.error = src.error;
+  return out;
+}
+
+/**
+ * Hand-written guard for a `status.update` payload (extension stays
+ * zod-free). Mirrors `ExtensionStatusUpdateResultSchema`: `ok` must be a
+ * boolean; every other field is an optional string.
+ */
+function isExtensionStatusUpdateResult(v: unknown): v is ExtensionStatusUpdateResult {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  const optStr = (x: unknown): boolean => x === undefined || typeof x === 'string';
+  return (
+    typeof o.ok === 'boolean' && optStr(o.applicationId) && optStr(o.status) && optStr(o.error)
+  );
+}
+
+/** Rebuild an {@link ExtensionStatusUpdateResult} from only the known,
+ *  defined keys — mirrors `normalizeAppliedCheckResult`. UNLIKE that
+ *  malformed-reply fallback, this verb's errors are surfaced to the user, so
+ *  the fallback text is written the same way: `ok:false` + a plain `error`. */
+function normalizeStatusUpdateResult(payload: unknown): ExtensionStatusUpdateResult {
+  if (!isExtensionStatusUpdateResult(payload)) {
+    return { ok: false, error: 'The desktop app sent a malformed status-update result.' };
+  }
+  const src = payload;
+  const out: ExtensionStatusUpdateResult = { ok: src.ok };
+  if (src.applicationId !== undefined) out.applicationId = src.applicationId;
+  if (src.status !== undefined) out.status = src.status;
   if (src.error !== undefined) out.error = src.error;
   return out;
 }
@@ -340,6 +372,9 @@ export class BridgeClient {
   /** In-flight `applied.check` resolvers, correlated by `reqId`. Kept separate
    *  from {@link pending} for the same reason as {@link pendingProfile}. */
   private readonly pendingApplied = new Map<string, AppliedResolver>();
+  /** In-flight `status.update` resolvers, correlated by `reqId`. Kept separate
+   *  from {@link pending} for the same reason as {@link pendingProfile}. */
+  private readonly pendingStatus = new Map<string, StatusResolver>();
   private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
   private backoffIndex = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -481,6 +516,7 @@ export class BridgeClient {
     this.pending.clear();
     this.pendingProfile.clear();
     this.pendingApplied.clear();
+    this.pendingStatus.clear();
     this.transport?.close();
     this.transport = null;
   }
@@ -612,6 +648,48 @@ export class BridgeClient {
         clearTimeout(timer);
         this.timers.delete(reqId);
         this.pendingApplied.delete(reqId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  /**
+   * Send a `status.update { url, to: 'applied' }` and resolve with the
+   * validated `status.update` payload. Rejects only on no connection /
+   * timeout / send failure — UNLIKE `checkApplied`, a well-formed `ok:false`
+   * reply is NOT folded away here: this is a deliberate click action, so the
+   * caller (background.ts) must pass the `error` straight through to the
+   * popup instead of swallowing it.
+   */
+  async updateStatus(url: string): Promise<ExtensionStatusUpdateResult> {
+    await this.ensureConnected();
+    if (this.phase !== 'connected' || !this.transport) {
+      throw new Error('Desktop app not reachable. Is AI Job Hunter running?');
+    }
+    const transport = this.transport;
+
+    const reqId = newReqId();
+    const envelope: ExtensionEnvelope = {
+      type: EXTENSION_MESSAGE_TYPES.statusUpdate,
+      reqId,
+      payload: { url, to: 'applied' },
+    };
+
+    return new Promise<ExtensionStatusUpdateResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingStatus.delete(reqId);
+        this.timers.delete(reqId);
+        reject(new Error('Timed out waiting for the desktop app to respond.'));
+      }, REQUEST_TIMEOUT_MS);
+      this.timers.set(reqId, timer);
+      this.pendingStatus.set(reqId, resolve);
+
+      try {
+        transport.send(envelope);
+      } catch (err) {
+        clearTimeout(timer);
+        this.timers.delete(reqId);
+        this.pendingStatus.delete(reqId);
         reject(err instanceof Error ? err : new Error(String(err)));
       }
     });
@@ -894,6 +972,16 @@ export class BridgeClient {
       return;
     }
 
+    // status.result → the "mark as applied" outcome (separate map).
+    if (env.type === EXTENSION_MESSAGE_TYPES.statusResult) {
+      const resolveStatus = this.pendingStatus.get(reqId);
+      if (typeof resolveStatus !== 'function') return;
+      this.pendingStatus.delete(reqId);
+      this.clearTimer(reqId);
+      resolveStatus(normalizeStatusUpdateResult(env.payload));
+      return;
+    }
+
     if (env.type !== EXTENSION_MESSAGE_TYPES.importResult) return;
     const resolve = this.pending.get(reqId);
     if (typeof resolve !== 'function') return;
@@ -938,9 +1026,15 @@ export class BridgeClient {
       if (timer) clearTimeout(timer);
       resolve({ found: false, error: reason });
     }
+    for (const [reqId, resolve] of this.pendingStatus.entries()) {
+      const timer = this.timers.get(reqId);
+      if (timer) clearTimeout(timer);
+      resolve({ ok: false, error: reason });
+    }
     this.pending.clear();
     this.pendingProfile.clear();
     this.pendingApplied.clear();
+    this.pendingStatus.clear();
     this.timers.clear();
   }
 

--- a/apps/extension/src/lib/bridge.ts
+++ b/apps/extension/src/lib/bridge.ts
@@ -193,16 +193,17 @@ function normalizeAppliedCheckResult(payload: unknown): ExtensionAppliedCheckRes
 
 /**
  * Hand-written guard for a `status.update` payload (extension stays
- * zod-free). Mirrors `ExtensionStatusUpdateResultSchema`: `ok` must be a
- * boolean; every other field is an optional string.
+ * zod-free). Mirrors `ExtensionStatusUpdateResultSchema`'s discriminated
+ * union: `ok:true` requires a string `applicationId` + the literal
+ * `status: 'applied'`; `ok:false` requires a string `error`. Success and
+ * failure fields can never mix.
  */
 function isExtensionStatusUpdateResult(v: unknown): v is ExtensionStatusUpdateResult {
   if (typeof v !== 'object' || v === null) return false;
   const o = v as Record<string, unknown>;
-  const optStr = (x: unknown): boolean => x === undefined || typeof x === 'string';
-  return (
-    typeof o.ok === 'boolean' && optStr(o.applicationId) && optStr(o.status) && optStr(o.error)
-  );
+  if (o.ok === true) return typeof o.applicationId === 'string' && o.status === 'applied';
+  if (o.ok === false) return typeof o.error === 'string';
+  return false;
 }
 
 /** Rebuild an {@link ExtensionStatusUpdateResult} from only the known,
@@ -213,12 +214,9 @@ function normalizeStatusUpdateResult(payload: unknown): ExtensionStatusUpdateRes
   if (!isExtensionStatusUpdateResult(payload)) {
     return { ok: false, error: 'The desktop app sent a malformed status-update result.' };
   }
-  const src = payload;
-  const out: ExtensionStatusUpdateResult = { ok: src.ok };
-  if (src.applicationId !== undefined) out.applicationId = src.applicationId;
-  if (src.status !== undefined) out.status = src.status;
-  if (src.error !== undefined) out.error = src.error;
-  return out;
+  return payload.ok
+    ? { ok: true, applicationId: payload.applicationId, status: payload.status }
+    : { ok: false, error: payload.error };
 }
 
 // ── transport seam ──────────────────────────────────────────────────────────

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -4,7 +4,11 @@
  * `browser.runtime.sendMessage` inside the extension only.
  */
 
-import type { ExtensionAppliedCheckResult, ExtensionImportResult } from '@ajh/shared';
+import type {
+  ExtensionAppliedCheckResult,
+  ExtensionImportResult,
+  ExtensionStatusUpdateResult,
+} from '@ajh/shared';
 
 import type { AutofillSummary } from './autofill';
 
@@ -50,7 +54,13 @@ export type PopupRequest =
    * active tab, run once when the popup shows the connected view. Read-only;
    * never blocks the import controls.
    */
-  | { kind: 'appliedCheck' };
+  | { kind: 'appliedCheck' }
+  /**
+   * User-clicked "Mark as applied" for the active tab's URL. Unlike
+   * `appliedCheck`, this is a deliberate WRITE action — its failures are
+   * surfaced to the user, never folded away.
+   */
+  | { kind: 'statusUpdate' };
 
 /** background → popup responses (discriminated by the originating request). */
 export type PopupResponse =
@@ -65,4 +75,11 @@ export type PopupResponse =
    * special-case an error path for this passive, best-effort check.
    */
   | { ok: true; kind: 'appliedCheck'; result: ExtensionAppliedCheckResult }
+  /**
+   * `ok:true` at the transport level; the desktop's own `ok`/`error` on
+   * `result` is what the popup renders — this verb's failures are NOT
+   * folded away (unlike `appliedCheck`), so the popup must check
+   * `result.ok` itself.
+   */
+  | { ok: true; kind: 'statusUpdate'; result: ExtensionStatusUpdateResult }
   | { ok: false; error: string };

--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -85,6 +85,9 @@
              popup opens (background auto-check). Empty/hidden until (and unless)
              an existing Application is found — never shown on a failure/timeout. -->
         <p id="applied-status" class="msg msg--ok" role="status" aria-live="polite" hidden></p>
+        <!-- Shown only for a found+saved applied.check result; hides itself once
+             the job is marked applied (re-fires the same auto-check). -->
+        <button id="btn-mark-applied" class="btn" type="button" hidden>Mark as applied</button>
         <div class="actions">
           <button id="btn-import" class="btn btn--primary" type="button">Import this job</button>
           <button

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -45,6 +45,7 @@ function buildPopupDom(): void {
     <div id="view-searching"></div>
     <button id="btn-import"></button>
     <button id="btn-fill"></button>
+    <button id="btn-mark-applied" hidden></button>
     <p id="applied-status" hidden></p>
     <input id="chk-applied" type="checkbox" />
     <p id="import-msg"></p>
@@ -73,6 +74,8 @@ const {
   resolveFillResponse,
   resolveAppliedStatusLine,
   resolveImportButtonLabel,
+  resolveShowMarkAppliedButton,
+  resolveMarkAppliedResponse,
 } = await import('./popup');
 
 const sendMessageMock = vi.mocked(browser.runtime.sendMessage);
@@ -444,6 +447,113 @@ describe('resolveImportButtonLabel', () => {
       result: { found: true, status: 'saved' },
     };
     expect(resolveImportButtonLabel(res)).toBe('Re-import / update');
+  });
+});
+
+// ── resolveShowMarkAppliedButton ───────────────────────────────────────────────
+
+describe('resolveShowMarkAppliedButton', () => {
+  it('returns false for a non-appliedCheck response', () => {
+    const res = { ok: true as const, kind: 'token' as const };
+    expect(resolveShowMarkAppliedButton(res)).toBe(false);
+  });
+
+  it('returns false when ok is false', () => {
+    const res = { ok: false as const, error: 'boom' };
+    expect(resolveShowMarkAppliedButton(res)).toBe(false);
+  });
+
+  it('returns false when not found', () => {
+    const res = { ok: true as const, kind: 'appliedCheck' as const, result: { found: false } };
+    expect(resolveShowMarkAppliedButton(res)).toBe(false);
+  });
+
+  it('returns false when the result carries an error', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: false, error: 'malformed' },
+    };
+    expect(resolveShowMarkAppliedButton(res)).toBe(false);
+  });
+
+  it('returns true for a found + saved result', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'saved' },
+    };
+    expect(resolveShowMarkAppliedButton(res)).toBe(true);
+  });
+
+  it('returns true for a found result with no status (treated as saved)', () => {
+    const res = { ok: true as const, kind: 'appliedCheck' as const, result: { found: true } };
+    expect(resolveShowMarkAppliedButton(res)).toBe(true);
+  });
+
+  it('returns false for a found + already-applied result', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'applied' },
+    };
+    expect(resolveShowMarkAppliedButton(res)).toBe(false);
+  });
+
+  it('returns false for a found + mid-pipeline result', () => {
+    const res = {
+      ok: true as const,
+      kind: 'appliedCheck' as const,
+      result: { found: true, status: 'interviewing' },
+    };
+    expect(resolveShowMarkAppliedButton(res)).toBe(false);
+  });
+});
+
+// ── resolveMarkAppliedResponse ─────────────────────────────────────────────────
+
+describe('resolveMarkAppliedResponse', () => {
+  it('surfaces a transport-level error (unlike the passive appliedCheck fold)', () => {
+    const res = { ok: false as const, error: 'Desktop app not reachable.' };
+    const { text, tone } = resolveMarkAppliedResponse(res);
+    expect(tone).toBe('err');
+    expect(text).toBe('Desktop app not reachable.');
+  });
+
+  it('returns the unexpected-response error when kind is not statusUpdate', () => {
+    const res = { ok: true as const, kind: 'token' as const };
+    const { text, tone } = resolveMarkAppliedResponse(res);
+    expect(tone).toBe('err');
+    expect(text).toBe('Unexpected response — please retry.');
+  });
+
+  it('surfaces the desktop refusal text when result.ok is false', () => {
+    const res = {
+      ok: true as const,
+      kind: 'statusUpdate' as const,
+      result: { ok: false, error: "couldn't find a saved job for this page" },
+    };
+    const { text, tone } = resolveMarkAppliedResponse(res);
+    expect(tone).toBe('err');
+    expect(text).toBe("couldn't find a saved job for this page");
+  });
+
+  it('falls back to a generic refusal message when result.ok is false with no error text', () => {
+    const res = { ok: true as const, kind: 'statusUpdate' as const, result: { ok: false } };
+    const { text, tone } = resolveMarkAppliedResponse(res);
+    expect(tone).toBe('err');
+    expect(text).toBe('Could not mark this job as applied.');
+  });
+
+  it('reports success when result.ok is true', () => {
+    const res = {
+      ok: true as const,
+      kind: 'statusUpdate' as const,
+      result: { ok: true, applicationId: 'app-1', status: 'applied' },
+    };
+    const { text, tone } = resolveMarkAppliedResponse(res);
+    expect(tone).toBe('ok');
+    expect(text).toBe('Marked as applied.');
   });
 });
 
@@ -820,6 +930,21 @@ describe('appliedCheck auto-check', () => {
     expect(status.hidden).toBe(false);
     expect(status.textContent).toContain('Already in your pipeline');
     expect(byId<HTMLButtonElement>('btn-import').textContent).toBe('Re-import / update');
+    // Already applied — the mark-applied button has nothing left to do.
+    expect(byId<HTMLButtonElement>('btn-mark-applied').hidden).toBe(true);
+  });
+
+  it('shows the mark-applied button for a found+saved result', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'appliedCheck',
+      result: { found: true, status: 'saved' },
+    });
+
+    push('connected');
+    await flush();
+
+    expect(byId<HTMLButtonElement>('btn-mark-applied').hidden).toBe(false);
   });
 
   it('renders nothing and keeps the default button label when not found', async () => {
@@ -876,14 +1001,17 @@ describe('appliedCheck auto-check', () => {
 
     const status = byId<HTMLParagraphElement>('applied-status');
     const btnImport = byId<HTMLButtonElement>('btn-import');
+    const btnMarkApplied = byId<HTMLButtonElement>('btn-mark-applied');
     expect(status.hidden).toBe(false);
     expect(btnImport.textContent).toBe('Re-import / update');
+    expect(btnMarkApplied.hidden).toBe(true); // job A is already applied
 
     // Desktop drops the connection — job A's stale line/label must not survive.
     push('app_not_running');
     expect(status.hidden).toBe(true);
     expect(status.textContent).toBe('');
     expect(btnImport.textContent).toBe('Import this job');
+    expect(btnMarkApplied.hidden).toBe(true);
 
     // Reconnect for job B — before its own check resolves, the pre-resolve
     // state must already be clean (no lingering job-A text while it's in flight).
@@ -896,6 +1024,10 @@ describe('appliedCheck auto-check', () => {
     expect(status.hidden).toBe(true);
     expect(status.textContent).toBe('');
     expect(btnImport.textContent).toBe('Import this job');
+    expect(btnMarkApplied.hidden).toBe(true);
+    await flush();
+    // Job B's check resolves as found+saved — the button appears for it.
+    expect(btnMarkApplied.hidden).toBe(false);
   });
 
   it('ignores a stale in-flight response that resolves after a newer check has already rendered', async () => {
@@ -931,5 +1063,81 @@ describe('appliedCheck auto-check', () => {
 
     expect(status.textContent).toBe('“Job B” is saved in your pipeline.');
     expect(btnImport.textContent).toBe('Re-import / update');
+  });
+});
+
+// ── doMarkApplied (#btn-mark-applied) ─────────────────────────────────────────
+
+describe('doMarkApplied (#btn-mark-applied)', () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+    byId<HTMLButtonElement>('btn-mark-applied').hidden = false;
+    byId<HTMLButtonElement>('btn-mark-applied').disabled = false;
+    byId<HTMLParagraphElement>('import-msg').textContent = '';
+  });
+
+  it('shows "Marking as applied…" then re-fires the auto-check on success, hiding the button', async () => {
+    sendMessageMock
+      .mockResolvedValueOnce({
+        ok: true,
+        kind: 'statusUpdate',
+        result: { ok: true, applicationId: 'app-1', status: 'applied' },
+      })
+      // The success-path re-fire of runAppliedAutoCheck sends a SECOND
+      // request — the same generation-guarded path every other render goes
+      // through, never a hand-rolled DOM update.
+      .mockResolvedValueOnce({
+        ok: true,
+        kind: 'appliedCheck',
+        result: { found: true, status: 'applied' },
+      });
+
+    const btn = byId<HTMLButtonElement>('btn-mark-applied');
+    btn.click();
+    expect(btn.disabled).toBe(true);
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe('Marking as applied…');
+
+    await flush();
+    await flush();
+
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe('Marked as applied.');
+    expect(sendMessageMock).toHaveBeenNthCalledWith(1, { kind: 'statusUpdate' });
+    expect(sendMessageMock).toHaveBeenNthCalledWith(2, { kind: 'appliedCheck' });
+    // The re-fired auto-check's found+applied result hides the button.
+    expect(btn.hidden).toBe(true);
+  });
+
+  it('surfaces the desktop refusal text and re-enables the button (errors ARE shown, unlike the passive check)', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'statusUpdate',
+      result: { ok: false, error: "couldn't find a saved job for this page" },
+    });
+
+    const btn = byId<HTMLButtonElement>('btn-mark-applied');
+    btn.click();
+    await flush();
+
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
+      "couldn't find a saved job for this page"
+    );
+    expect(btn.disabled).toBe(false);
+    // No auto-check re-fire on failure — only one request went out.
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a retry message and re-enables the button when sendMessage rejects', async () => {
+    sendMessageMock.mockRejectedValueOnce(new Error('message channel closed'));
+
+    const btn = byId<HTMLButtonElement>('btn-mark-applied');
+    btn.click();
+    await flush();
+
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
+      'Could not mark this job as applied. Please retry.'
+    );
+    expect(btn.disabled).toBe(false);
   });
 });

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -486,9 +486,9 @@ describe('resolveShowMarkAppliedButton', () => {
     expect(resolveShowMarkAppliedButton(res)).toBe(true);
   });
 
-  it('returns true for a found result with no status (treated as saved)', () => {
+  it('returns false for a found result with no status (CAS precondition requires an explicit saved status)', () => {
     const res = { ok: true as const, kind: 'appliedCheck' as const, result: { found: true } };
-    expect(resolveShowMarkAppliedButton(res)).toBe(true);
+    expect(resolveShowMarkAppliedButton(res)).toBe(false);
   });
 
   it('returns false for a found + already-applied result', () => {

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -147,6 +147,49 @@ export function resolveImportButtonLabel(res: PopupResponse): string {
 }
 
 /**
+ * Whether the "Mark as applied" button should show: only for a found
+ * Application whose status is exactly `saved` (or absent, treated the same
+ * as {@link resolveAppliedStatusLine}'s "saved" bucket) — the ONLY status
+ * this write can ever transition FROM. Any other status (already applied,
+ * mid-pipeline, or not found/error) keeps the button hidden; those cases use
+ * the existing "I already applied" import checkbox, not this button.
+ *
+ * Pure: no DOM access, no side effects.
+ */
+export function resolveShowMarkAppliedButton(res: PopupResponse): boolean {
+  if (!res.ok || res.kind !== 'appliedCheck') return false;
+  const { result } = res;
+  if (result.error || !result.found) return false;
+  return !result.status || result.status === 'saved';
+}
+
+/**
+ * Given a `statusUpdate` response, return the message text + tone. UNLIKE
+ * `resolveAppliedStatusLine`/`resolveImportButtonLabel` (which fold every
+ * failure into "render nothing" — this is a passive, best-effort check),
+ * this verb's errors ARE shown: it answers a deliberate click. A
+ * transport-level `ok:false` surfaces its `error`; a resolved
+ * `result.ok === false` (the desktop's own refusal — no match / wrong
+ * starting status) surfaces `result.error`.
+ *
+ * Pure: no DOM access, no side effects.
+ */
+export function resolveMarkAppliedResponse(res: PopupResponse): {
+  text: string;
+  tone: 'ok' | 'err';
+} {
+  if (!res.ok) return { text: res.error, tone: 'err' };
+  if (res.kind !== 'statusUpdate') {
+    return { text: 'Unexpected response — please retry.', tone: 'err' };
+  }
+  const { result } = res;
+  if (!result.ok) {
+    return { text: result.error ?? 'Could not mark this job as applied.', tone: 'err' };
+  }
+  return { text: 'Marked as applied.', tone: 'ok' };
+}
+
+/**
  * Given a `fill` response, return the popup message + tone. The detailed summary
  * lives in the in-page overlay; the popup shows a short confirmation (or the
  * desktop's refusal when autofill is opted out). Handles the "nothing matched"
@@ -186,6 +229,7 @@ const els = {
   },
   btnImport: byId<HTMLButtonElement>('btn-import'),
   btnFill: byId<HTMLButtonElement>('btn-fill'),
+  btnMarkApplied: byId<HTMLButtonElement>('btn-mark-applied'),
   appliedStatus: byId<HTMLParagraphElement>('applied-status'),
   chkApplied: byId<HTMLInputElement>('chk-applied'),
   importMsg: byId<HTMLParagraphElement>('import-msg'),
@@ -298,6 +342,8 @@ function render(status: ConnectionStatus): void {
     els.appliedStatus.hidden = true;
     els.appliedStatus.textContent = '';
     els.btnImport.textContent = IMPORT_LABEL_DEFAULT;
+    els.btnMarkApplied.hidden = true;
+    els.btnMarkApplied.disabled = false;
   }
   lastRenderedPhase = status.phase;
 
@@ -438,6 +484,8 @@ async function runAppliedAutoCheck(): Promise<void> {
   els.appliedStatus.hidden = true;
   els.appliedStatus.textContent = '';
   els.btnImport.textContent = IMPORT_LABEL_DEFAULT;
+  els.btnMarkApplied.hidden = true;
+  els.btnMarkApplied.disabled = false;
   try {
     const res = await send({ kind: 'appliedCheck' });
     // A newer check started while this one was in flight — its result (or the
@@ -448,11 +496,46 @@ async function runAppliedAutoCheck(): Promise<void> {
     els.appliedStatus.hidden = line === null;
     els.appliedStatus.textContent = line ?? '';
     els.btnImport.textContent = resolveImportButtonLabel(res);
+    // Only a found+saved result shows the button — reset disabled here too,
+    // so a re-fire after a successful "Mark as applied" click (which left the
+    // button disabled) ends re-enabled for whatever this fresh check renders.
+    els.btnMarkApplied.hidden = !resolveShowMarkAppliedButton(res);
+    els.btnMarkApplied.disabled = false;
   } catch {
     if (myGeneration !== appliedCheckGeneration) return;
     els.appliedStatus.hidden = true;
     els.appliedStatus.textContent = '';
     els.btnImport.textContent = IMPORT_LABEL_DEFAULT;
+    els.btnMarkApplied.hidden = true;
+    els.btnMarkApplied.disabled = false;
+  }
+}
+
+/**
+ * Click handler for "Mark as applied". Sends `status.update` and shows the
+ * result in the existing message area — UNLIKE the passive auto-check,
+ * failures ARE shown here (this is a deliberate click action). On success it
+ * re-fires {@link runAppliedAutoCheck} (the SAME generation-guarded path
+ * every other applied.check render goes through) instead of hand-rolling a
+ * DOM update, so the status line flips to the applied wording and this
+ * button hides itself once the fresh check confirms it.
+ */
+async function doMarkApplied(): Promise<void> {
+  els.btnMarkApplied.disabled = true;
+  setMsg(els.importMsg, 'Marking as applied…', 'muted');
+  try {
+    const res = await send({ kind: 'statusUpdate' });
+    const { text, tone } = resolveMarkAppliedResponse(res);
+    setMsg(els.importMsg, text, tone);
+    if (tone === 'ok') {
+      void runAppliedAutoCheck();
+    } else {
+      els.btnMarkApplied.disabled = false;
+    }
+  } catch {
+    // A transport/messaging rejection must not strand the button disabled.
+    setMsg(els.importMsg, 'Could not mark this job as applied. Please retry.', 'err');
+    els.btnMarkApplied.disabled = false;
   }
 }
 
@@ -575,6 +658,7 @@ async function getApp(): Promise<void> {
 function wire(): void {
   els.btnImport.addEventListener('click', () => void doImport());
   els.btnFill.addEventListener('click', () => void doFill());
+  els.btnMarkApplied.addEventListener('click', () => void doMarkApplied());
   els.btnSaveToken.addEventListener('click', () => void savePairing());
   els.tokenInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') void savePairing();

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -148,11 +148,13 @@ export function resolveImportButtonLabel(res: PopupResponse): string {
 
 /**
  * Whether the "Mark as applied" button should show: only for a found
- * Application whose status is exactly `saved` (or absent, treated the same
- * as {@link resolveAppliedStatusLine}'s "saved" bucket) — the ONLY status
- * this write can ever transition FROM. Any other status (already applied,
- * mid-pipeline, or not found/error) keeps the button hidden; those cases use
- * the existing "I already applied" import checkbox, not this button.
+ * Application whose status is EXPLICITLY `saved` — the ONLY status this
+ * write's CAS precondition can ever transition FROM (the bridge's
+ * `saved → applied` compare-and-set requires the current status to already
+ * be `saved`; an absent/unknown status is not the same guarantee). Any other
+ * status (already applied, mid-pipeline, missing, or not found/error) keeps
+ * the button hidden; those cases use the existing "I already applied" import
+ * checkbox, not this button.
  *
  * Pure: no DOM access, no side effects.
  */
@@ -160,7 +162,7 @@ export function resolveShowMarkAppliedButton(res: PopupResponse): boolean {
   if (!res.ok || res.kind !== 'appliedCheck') return false;
   const { result } = res;
   if (result.error || !result.found) return false;
-  return !result.status || result.status === 'saved';
+  return result.status === 'saved';
 }
 
 /**

--- a/packages/shared/src/ipc/extension-protocol-constants.ts
+++ b/packages/shared/src/ipc/extension-protocol-constants.ts
@@ -40,14 +40,18 @@ export const EXTENSION_PROTOCOL_VERSION = 2;
  * is the force-cutover reply the desktop sends when a connection's first frame
  * is not a valid v2 `hello` (a legacy token `auth`, a missing/older protocol).
  * `import.request` / `import.result` / `profile.get` / `profile.result` /
- * `applied.check` / `applied.result` are the post-auth application frames;
- * `match.live` is **reserved** (fixed now so a future build can add a handler
- * without a protocol bump).
+ * `applied.check` / `applied.result` / `status.update` / `status.result` are
+ * the post-auth application frames; `match.live` is **reserved** (fixed now
+ * so a future build can add a handler without a protocol bump).
  *
- * **Consent-gate boundary** (the rule the next 9 post-auth verbs copy): a
+ * **Consent-gate boundary** (the rule the remaining post-auth verbs copy): a
  * read-only lookup over the user's own device-local metadata (`applied.check`)
- * needs no desktop opt-in gate; anything returning fresh PII (`profile.get`)
- * or doing billable/egress work requires a desktop-enforced opt-in.
+ * needs no desktop opt-in gate; a user-gestured WRITE to the user's own local
+ * store on an exact match (`status.update`) needs no gate either — it is a
+ * deliberate click, not a passive/background write, exactly like the
+ * existing ungated `import.request{applied:true}`; anything returning fresh
+ * PII (`profile.get`) or doing billable/egress work requires a
+ * desktop-enforced opt-in.
  */
 export const EXTENSION_MESSAGE_TYPES = {
   /** Extension → desktop: handshake step 1 — `{ protocol, clientNonce }`, no token. */
@@ -90,6 +94,21 @@ export const EXTENSION_MESSAGE_TYPES = {
   appliedCheck: 'applied.check',
   /** Desktop → extension: the `applied.check` outcome (or an `error`). */
   appliedResult: 'applied.result',
+  /**
+   * Extension → desktop: "mark this URL applied" — a user-gestured WRITE,
+   * structurally restricted to the single `saved → applied` transition on an
+   * EXACT normalized-url match (see {@link ExtensionStatusUpdateRequest}). No
+   * consent gate: a deliberate click writing to the user's own local store,
+   * strictly narrower than the already-ungated `import.request{applied:true}`.
+   */
+  statusUpdate: 'status.update',
+  /**
+   * Desktop → extension: the `status.update` outcome. UNLIKE
+   * `applied.result`, this verb's errors are user-facing — the popup must
+   * render `error`, never fold it into a silent no-op (it answers a
+   * deliberate click, not a passive background check).
+   */
+  statusResult: 'status.result',
 } as const;
 
 /** Union of all wire `type` strings. */
@@ -242,6 +261,31 @@ export interface ExtensionAppliedCheckResult {
   status?: string;
   title?: string;
   appliedAt?: number;
+  error?: string;
+}
+
+/**
+ * `status.update` payload — mark a `saved` Application `applied` on an exact
+ * URL-key match. `to` is narrowed to the literal `'applied'` in both this
+ * schema and the Rust re-validation: the verb is structurally incapable of
+ * any other transition (no allowlist to bypass — there is only one value).
+ */
+export interface ExtensionStatusUpdateRequest {
+  url: string;
+  to: 'applied';
+}
+
+/**
+ * `status.update` payload. `ok:true` carries the updated `applicationId` +
+ * `status` (always `"applied"`); `ok:false` carries a user-facing `error`
+ * (no match / the row's status was not `saved` / a malformed request).
+ * UNLIKE {@link ExtensionAppliedCheckResult}, this verb's errors ARE shown to
+ * the user — it answers a deliberate click, not a passive background check.
+ */
+export interface ExtensionStatusUpdateResult {
+  ok: boolean;
+  applicationId?: string;
+  status?: string;
   error?: string;
 }
 

--- a/packages/shared/src/ipc/extension-protocol-constants.ts
+++ b/packages/shared/src/ipc/extension-protocol-constants.ts
@@ -276,18 +276,16 @@ export interface ExtensionStatusUpdateRequest {
 }
 
 /**
- * `status.update` payload. `ok:true` carries the updated `applicationId` +
- * `status` (always `"applied"`); `ok:false` carries a user-facing `error`
- * (no match / the row's status was not `saved` / a malformed request).
- * UNLIKE {@link ExtensionAppliedCheckResult}, this verb's errors ARE shown to
- * the user — it answers a deliberate click, not a passive background check.
+ * `status.update` payload — a discriminated union so a reply can never mix
+ * success and failure fields: `ok:true` always carries the updated
+ * `applicationId` + `status` (the literal `'applied'`); `ok:false` always
+ * carries a user-facing `error` (no match / the row's status was not `saved`
+ * / a malformed request). UNLIKE {@link ExtensionAppliedCheckResult}, this
+ * verb's errors ARE shown to the user — it answers a deliberate click, not a
+ * passive background check.
  */
-export interface ExtensionStatusUpdateResult {
-  ok: boolean;
-  applicationId?: string;
-  status?: string;
-  error?: string;
-}
+export type ExtensionStatusUpdateResult =
+  { ok: true; applicationId: string; status: 'applied' } | { ok: false; error: string };
 
 /**
  * The transport envelope every frame is wrapped in. `payload` is left as

--- a/packages/shared/src/ipc/extension-protocol.test.ts
+++ b/packages/shared/src/ipc/extension-protocol.test.ts
@@ -313,6 +313,32 @@ describe('ExtensionStatusUpdateResultSchema', () => {
     expect(() => ExtensionStatusUpdateResultSchema.parse({ ok: 'yes' })).toThrow();
   });
 
+  it('rejects an incomplete ok:true payload missing applicationId and status', () => {
+    expect(() => ExtensionStatusUpdateResultSchema.parse({ ok: true })).toThrow();
+  });
+
+  it('rejects an ok:true payload missing status', () => {
+    expect(() =>
+      ExtensionStatusUpdateResultSchema.parse({ ok: true, applicationId: 'app-1' })
+    ).toThrow();
+  });
+
+  it('rejects an ok:true payload missing applicationId', () => {
+    expect(() =>
+      ExtensionStatusUpdateResultSchema.parse({ ok: true, status: 'applied' })
+    ).toThrow();
+  });
+
+  it('rejects a contradictory ok:false payload carrying success fields but no error', () => {
+    expect(() =>
+      ExtensionStatusUpdateResultSchema.parse({
+        ok: false,
+        applicationId: 'app-1',
+        status: 'applied',
+      })
+    ).toThrow();
+  });
+
   it('carries status.update / status.result through a valid envelope', () => {
     expect(() =>
       ExtensionEnvelopeSchema.parse({

--- a/packages/shared/src/ipc/extension-protocol.test.ts
+++ b/packages/shared/src/ipc/extension-protocol.test.ts
@@ -6,6 +6,8 @@ import {
   ExtensionEnvelopeSchema,
   ExtensionImportRequestSchema,
   ExtensionProfileResultSchema,
+  ExtensionStatusUpdateRequestSchema,
+  ExtensionStatusUpdateResultSchema,
 } from './extension-protocol.js';
 import {
   EXTENSION_MESSAGE_TYPES,
@@ -242,6 +244,88 @@ describe('ExtensionAppliedCheckResultSchema', () => {
         type: EXTENSION_MESSAGE_TYPES.appliedResult,
         reqId: 'req-003',
         payload: { found: false },
+      })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ExtensionStatusUpdateRequestSchema / ExtensionStatusUpdateResultSchema
+// ---------------------------------------------------------------------------
+
+describe('ExtensionStatusUpdateRequestSchema', () => {
+  it('accepts a valid request', () => {
+    expect(() =>
+      ExtensionStatusUpdateRequestSchema.parse({
+        url: 'https://example.com/job/123',
+        to: 'applied',
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects an empty url', () => {
+    expect(() => ExtensionStatusUpdateRequestSchema.parse({ url: '', to: 'applied' })).toThrow();
+  });
+
+  it('rejects a request with no url field', () => {
+    expect(() => ExtensionStatusUpdateRequestSchema.parse({ to: 'applied' })).toThrow();
+  });
+
+  it('rejects any `to` value other than the literal "applied" — the allowlist is visible in the contract itself', () => {
+    expect(() =>
+      ExtensionStatusUpdateRequestSchema.parse({ url: 'https://example.com/job/123', to: 'saved' })
+    ).toThrow();
+    expect(() =>
+      ExtensionStatusUpdateRequestSchema.parse({
+        url: 'https://example.com/job/123',
+        to: 'interviewing',
+      })
+    ).toThrow();
+  });
+
+  it('rejects a request with no `to` field', () => {
+    expect(() =>
+      ExtensionStatusUpdateRequestSchema.parse({ url: 'https://example.com/job/123' })
+    ).toThrow();
+  });
+});
+
+describe('ExtensionStatusUpdateResultSchema', () => {
+  it('round-trips a success payload', () => {
+    const payload = { ok: true, applicationId: 'app-1', status: 'applied' };
+    expect(ExtensionStatusUpdateResultSchema.parse(payload)).toEqual(payload);
+  });
+
+  it("accepts a user-facing failure payload (this verb's errors are shown, unlike applied.check)", () => {
+    expect(() =>
+      ExtensionStatusUpdateResultSchema.parse({
+        ok: false,
+        error: "couldn't find a saved job for this page",
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects a missing ok field', () => {
+    expect(() => ExtensionStatusUpdateResultSchema.parse({})).toThrow();
+  });
+
+  it('rejects a non-boolean ok field', () => {
+    expect(() => ExtensionStatusUpdateResultSchema.parse({ ok: 'yes' })).toThrow();
+  });
+
+  it('carries status.update / status.result through a valid envelope', () => {
+    expect(() =>
+      ExtensionEnvelopeSchema.parse({
+        type: EXTENSION_MESSAGE_TYPES.statusUpdate,
+        reqId: 'req-004',
+        payload: { url: 'https://example.com/job/123', to: 'applied' },
+      })
+    ).not.toThrow();
+    expect(() =>
+      ExtensionEnvelopeSchema.parse({
+        type: EXTENSION_MESSAGE_TYPES.statusResult,
+        reqId: 'req-005',
+        payload: { ok: true, applicationId: 'app-1', status: 'applied' },
       })
     ).not.toThrow();
   });

--- a/packages/shared/src/ipc/extension-protocol.ts
+++ b/packages/shared/src/ipc/extension-protocol.ts
@@ -175,16 +175,15 @@ export const ExtensionStatusUpdateRequestSchema = z.object({
 }) satisfies z.ZodType<ExtensionStatusUpdateRequest>;
 
 /**
- * `status.update` payload. Mirrors {@link ExtensionStatusUpdateResult} —
- * `ok` is required; the rest are optional (success carries
- * `applicationId`/`status`, failure carries `error`).
+ * `status.update` payload. Mirrors {@link ExtensionStatusUpdateResult} — a
+ * discriminated union on `ok` so success/failure fields can never mix:
+ * `ok:true` requires `applicationId` + the literal `status: 'applied'`;
+ * `ok:false` requires `error`.
  */
-export const ExtensionStatusUpdateResultSchema = z.object({
-  ok: z.boolean(),
-  applicationId: z.string().optional(),
-  status: z.string().optional(),
-  error: z.string().optional(),
-}) satisfies z.ZodType<ExtensionStatusUpdateResult>;
+export const ExtensionStatusUpdateResultSchema = z.discriminatedUnion('ok', [
+  z.object({ ok: z.literal(true), applicationId: z.string(), status: z.literal('applied') }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]) satisfies z.ZodType<ExtensionStatusUpdateResult>;
 
 /**
  * The transport envelope every frame is wrapped in. `payload` is left as

--- a/packages/shared/src/ipc/extension-protocol.ts
+++ b/packages/shared/src/ipc/extension-protocol.ts
@@ -31,6 +31,8 @@ import {
   type ExtensionImportResult,
   type ExtensionMessageType,
   type ExtensionProfileResult,
+  type ExtensionStatusUpdateRequest,
+  type ExtensionStatusUpdateResult,
   HANDSHAKE_DOMAIN,
   HANDSHAKE_TEST_VECTOR,
   handshakeMessage,
@@ -51,6 +53,8 @@ export {
   type ExtensionImportResult,
   type ExtensionMessageType,
   type ExtensionProfileResult,
+  type ExtensionStatusUpdateRequest,
+  type ExtensionStatusUpdateResult,
   HANDSHAKE_DOMAIN,
   HANDSHAKE_TEST_VECTOR,
   handshakeMessage,
@@ -70,6 +74,8 @@ export const ExtensionMessageTypeSchema = z.enum([
   EXTENSION_MESSAGE_TYPES.matchLive,
   EXTENSION_MESSAGE_TYPES.appliedCheck,
   EXTENSION_MESSAGE_TYPES.appliedResult,
+  EXTENSION_MESSAGE_TYPES.statusUpdate,
+  EXTENSION_MESSAGE_TYPES.statusResult,
 ]) satisfies z.ZodType<ExtensionMessageType>;
 
 /** `hello` payload (handshake step 1). No token — the proof authenticates later. */
@@ -157,6 +163,28 @@ export const ExtensionAppliedCheckResultSchema = z.object({
   appliedAt: z.number().optional(),
   error: z.string().optional(),
 }) satisfies z.ZodType<ExtensionAppliedCheckResult>;
+
+/**
+ * `status.update` payload — the url to mark applied. `to` is a literal, not a
+ * free string: the allowlist is visible in the contract itself, not just the
+ * Rust re-validation. Mirrors {@link ExtensionStatusUpdateRequest}.
+ */
+export const ExtensionStatusUpdateRequestSchema = z.object({
+  url: z.string().min(1),
+  to: z.literal('applied'),
+}) satisfies z.ZodType<ExtensionStatusUpdateRequest>;
+
+/**
+ * `status.update` payload. Mirrors {@link ExtensionStatusUpdateResult} —
+ * `ok` is required; the rest are optional (success carries
+ * `applicationId`/`status`, failure carries `error`).
+ */
+export const ExtensionStatusUpdateResultSchema = z.object({
+  ok: z.boolean(),
+  applicationId: z.string().optional(),
+  status: z.string().optional(),
+  error: z.string().optional(),
+}) satisfies z.ZodType<ExtensionStatusUpdateResult>;
 
 /**
  * The transport envelope every frame is wrapped in. `payload` is left as


### PR DESCRIPTION
## Summary

Adds `status.update` — one-click **"Mark as applied"** from the extension popup (PR 2 of the extension roadmap; first write verb beyond import, deliberately the narrowest possible one):

- **Popup**: when the auto-check finds the page as a `saved` application, a "Mark as applied" button appears; click → status flips, the status line refreshes through the generation-guarded auto-check path, and failures are shown (user action ⇒ errors are user-facing, unlike the passive check's silent folding).
- **Desktop**: new `extension_bridge/status_update.rs` (own module, keeps `mod.rs` under the R8 LOC cap). The transition is enforced with a new atomic store primitive `ApplicationStore::transition_status_if` — a compare-and-set `UPDATE … WHERE id=? AND status='saved'` plus the status event in one transaction, rows-affected checked, `applied_at = COALESCE(applied_at, now)` preserving first-applied-wins. Structurally nothing but `saved → applied` on an exact URL-key match can ever be written, even under concurrent writers. `to` is re-validated byte-exact in Rust; wire errors are fixed sentinels; the status-event note is the fixed string "via extension".
- **Shared**: `status.update`/`status.result` literals, `to: z.literal('applied')` (the allowlist is visible in the contract), parity tests extended.
- Untracked pages keep the existing `import.request {applied:true}` checkbox path — no duplication.

## Review trail (pre-PR gates)

- tauri-security-reviewer: no HIGH/CRITICAL; its MEDIUM (TOCTOU between guard and write) fixed via the CAS primitive; adversarial checklist clean (exact-match only, no capability leak, fixed sentinels, auth-boundary ×3).
- extension-reviewer: its two HIGHs (same TOCTOU; raw store error reaching the wire) fixed; race regression + malformed-url tests added.
- /review full-tier 3-pass ensemble: PASS ×3; the one survivor (`applied_at` reset diverging from `set_status`'s first-applied-wins) fixed with `COALESCE` + a demotion-round-trip test.

## Test plan

- Rust: store CAS tests (happy, wrong-from refusal, two-call race, prior-`applied_at` preservation), bridge verb tests (all refusal branches, reply shapes, auth-boundary ×3); full crate green; exact CI clippy clean.
- Extension: 176 tests (button state machine incl. disable-in-flight and error re-enable, no-folding asymmetry, pendingStatus lifecycle).
- Shared: schema accept/reject suites; `gen:ipc:check` clean; whole-graph typecheck + lint:strict clean.

Part of the approved extension roadmap (PR 2 of 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Mark as applied” button to the browser extension for saved applications.
  * Marking an application as applied now updates the desktop app and refreshes the Applications view automatically.
  * Added clear success, validation, connection, and desktop refusal messages in the extension.
  * Added secure authenticated communication between the extension and desktop app for status updates.

* **Bug Fixes**
  * Prevented duplicate status changes and duplicate activity records during concurrent updates.
  * Preserved the original application timestamp when statuses are changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->