### PR TITLE
feat: prefer extension job-root hint in generic page parsing

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
@@ -443,9 +443,16 @@ pub fn parse_from_html(url: &str, html: &str) -> Option<JobPosting> {
     // whitespace-only) yields (empty, `None`) for both fields, so it overrides
     // neither — the per-field fallback is the guarantee that a bad hint can
     // never make results worse than before.
+    //
+    // `hint_title_used` tracks whether the hint actually supplied a usable
+    // title — the signal the last-resort fallback below uses to tell "thin
+    // hint" (real signal, just no body) apart from "hostile/mis-marked hint"
+    // (no signal at all, treat as if there were no hint).
+    let mut hint_title_used = false;
     if let Some((hint_title, hint_description)) = job_root_generic_html(html) {
         if !hint_title.is_empty() {
             title = hint_title;
+            hint_title_used = true;
         }
         if hint_description.is_some() {
             description = hint_description;
@@ -483,8 +490,18 @@ pub fn parse_from_html(url: &str, html: &str) -> Option<JobPosting> {
         }
     }
 
-    // Main-content text as a last-resort description.
-    if description.is_none() {
+    // Main-content text as a last-resort description — SKIPPED when the hint
+    // already supplied a real title. `job_root_generic_html` scopes its own
+    // description search to that same hinted subtree, so if it honestly found
+    // no body text there (a title-only hint — e.g. the real description
+    // renders client-side in an ATS iframe the outerHTML capture can't see),
+    // escalating to a whole-DOCUMENT largest-block guess risks landing on an
+    // unrelated block (e.g. a bigger related-jobs sidebar) instead of just
+    // admitting there's no description to show. A hint that yielded NOTHING
+    // (no title either — hostile/mis-marked) carries no signal, so the
+    // whole-document heuristic chain still runs exactly as if there were no
+    // hint at all.
+    if description.is_none() && !hint_title_used {
         description = main_content_text(html);
     }
 
@@ -551,11 +568,13 @@ fn job_root_generic_html(html: &str) -> Option<(String, Option<String>)> {
         .map(|e| e.text().collect::<String>().trim().to_string())
         .unwrap_or_default();
 
-    // Exclude the title heading(s) from the description source: an h1-only
-    // hinted subtree must not turn its own title into a redundant description
-    // stub that would then clobber a real document-level meta description in
-    // the caller's per-field merge.
-    let body_html = JOB_ROOT_TITLE_RE.replace_all(&cleaned, " ");
+    // Exclude ONLY the title heading (the first <h1>) from the description
+    // source: an h1-only hinted subtree must not turn its own title into a
+    // redundant description stub that would then clobber a real document-level
+    // meta description in the caller's per-field merge. `replacen(.., 1, ..)`
+    // rather than `replace_all` — a later `<h1>` is a legitimate section
+    // heading (e.g. "Responsibilities") and must survive into the description.
+    let body_html = JOB_ROOT_TITLE_RE.replacen(&cleaned, 1, " ");
     let description = crate::scraping::http::html_to_markdown(&body_html);
     let description = (!description.trim().is_empty()).then_some(description);
 
@@ -567,9 +586,10 @@ static JOB_ROOT_SCRIPT_STYLE_RE: std::sync::LazyLock<regex::Regex> =
         regex::Regex::new(r"(?is)<(script|style)[\s\S]*?</(script|style)>").unwrap()
     });
 
-/// Strips `<h1>` elements out of the hinted subtree's (already script/style-
-/// cleaned) HTML before it becomes the description source — see the "exclude
-/// the title" note on [`job_root_generic_html`] above.
+/// Matches an `<h1>` element in the hinted subtree's (already script/style-
+/// cleaned) HTML; the caller only ever strips the FIRST match (`replacen`, not
+/// `replace_all`) — see the "exclude the title" note on [`job_root_generic_html`]
+/// above. A later `<h1>` is a legitimate section heading, not the title.
 static JOB_ROOT_TITLE_RE: std::sync::LazyLock<regex::Regex> =
     std::sync::LazyLock::new(|| regex::Regex::new(r"(?is)<h1[\s\S]*?</h1>").unwrap());
 

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
@@ -418,14 +418,39 @@ async fn try_ashby(url: &str) -> Result<Option<JobPosting>> {
 /// redirect chain and exhausted the named-board re-dispatch.
 ///
 /// Prefers JSON-LD `JobPosting` fields (title/description/location/company) when
-/// the page ships them, falling back to the generic `<title>`/`<h1>` + meta
-/// description and the `parse_generic_company` employer-name heuristic. Always
-/// returns `Some` for a successfully-parsed document — the title may be an empty
-/// string (e.g. a page with only a meta description) so the description-on-demand
-/// flow still surfaces the page. (The fetch half short-circuits earlier on a
-/// non-success status / rejected host.)
+/// the page ships them — structured data always wins over any DOM guess. Below
+/// that, the base pass is the generic `<title>`/`<h1>` + meta description parse,
+/// with the extension's `[data-ajh-job-root="true"]` hint (when present)
+/// overriding title/description FIELD BY FIELD rather than wholesale — see the
+/// per-field merge note below. `parse_generic_company` supplies the employer
+/// name. Always returns `Some` for a successfully-parsed document — the title
+/// may be an empty string (e.g. a page with only a meta description) so the
+/// description-on-demand flow still surfaces the page. (The fetch half
+/// short-circuits earlier on a non-success status / rejected host.)
 pub fn parse_from_html(url: &str, html: &str) -> Option<JobPosting> {
+    // Base: whole-document <title>/first-<h1> + meta description (today's floor).
     let (mut title, mut description) = parse_generic_html(html);
+
+    // Prefer the extension's `[data-ajh-job-root="true"]` hint (Scan-mode's
+    // best-effort "main job content" mark — see `markLikelyJobNode` in
+    // `apps/extension/src/content.ts`) over the base pass above, but FIELD BY
+    // FIELD rather than wholesale: override `title` only when the hinted
+    // subtree found a non-empty one, override `description` only when it found
+    // one. A wholesale swap would be wrong on a thin-body page (e.g. an ATS
+    // embeds the real description in an iframe and the hinted node is just an
+    // `<h1>`) — it would clobber a good document-level meta description with
+    // nothing useful. A mis-marked/hostile hint (wrong element, script/
+    // whitespace-only) yields (empty, `None`) for both fields, so it overrides
+    // neither — the per-field fallback is the guarantee that a bad hint can
+    // never make results worse than before.
+    if let Some((hint_title, hint_description)) = job_root_generic_html(html) {
+        if !hint_title.is_empty() {
+            title = hint_title;
+        }
+        if hint_description.is_some() {
+            description = hint_description;
+        }
+    }
     let mut location = None;
 
     // JSON-LD `JobPosting` is the richest source when present — let it override
@@ -485,6 +510,68 @@ pub fn parse_from_html(url: &str, html: &str) -> Option<JobPosting> {
         extra: HashMap::new(),
     })
 }
+
+/// Extraction from the extension's best-effort `[data-ajh-job-root="true"]`
+/// hint (pinned to the contract value — `markLikelyJobNode` in
+/// `apps/extension/src/content.ts` only ever sets `"true"`). Title is the first
+/// `h1` inside the hinted subtree; description is the subtree's own rendered
+/// text, EXCLUDING that title heading's own markup (see the `JOB_ROOT_TITLE_RE`
+/// strip below) so a hinted node that is just a heading — the real body
+/// rendered elsewhere, e.g. an ATS iframe the outerHTML capture can't see —
+/// yields no description at all rather than a title-redundant stub. Scoping to
+/// the hinted node — rather than re-running the largest-`main`/`article`-block
+/// guess ([`main_content_text`]) over the whole document — lets a page with
+/// several `main`/`article`-shaped blocks (e.g. a related-jobs sidebar bigger
+/// than the actual posting) resolve to the right one. Returns `None` when no
+/// hinted node exists in the document at all, so the no-hint path (including
+/// every server-fetch resolve where the hint can never be present) is
+/// untouched. The caller (`parse_from_html`) applies title and description
+/// independently, so either field alone may come back empty/`None`.
+// ponytail: single-node lookup + a couple of child selectors, no depth cap
+// needed (unlike the JSON-LD/NEXT_DATA walks) — scoped to whatever the
+// extension already marked.
+fn job_root_generic_html(html: &str) -> Option<(String, Option<String>)> {
+    let doc = Html::parse_document(html);
+    let root_sel = Selector::parse(r#"[data-ajh-job-root="true"]"#).ok()?;
+    let root = doc.select(&root_sel).next()?;
+
+    // Unlike this crate's own `html_to_text`, `html_to_markdown`'s `htmd` backend
+    // does not treat `<script>`/`<style>` as non-rendered — it leaks their raw
+    // contents into the output. A hostile/mis-marked hint node containing only a
+    // tracking script must not read as a "real" title or description, so strip
+    // them first — before extracting EITHER field, not just the description.
+    let inner_html = root.inner_html();
+    let cleaned = JOB_ROOT_SCRIPT_STYLE_RE.replace_all(&inner_html, " ");
+    let cleaned_doc = Html::parse_fragment(&cleaned);
+
+    let title_sel = Selector::parse("h1").ok()?;
+    let title = cleaned_doc
+        .select(&title_sel)
+        .next()
+        .map(|e| e.text().collect::<String>().trim().to_string())
+        .unwrap_or_default();
+
+    // Exclude the title heading(s) from the description source: an h1-only
+    // hinted subtree must not turn its own title into a redundant description
+    // stub that would then clobber a real document-level meta description in
+    // the caller's per-field merge.
+    let body_html = JOB_ROOT_TITLE_RE.replace_all(&cleaned, " ");
+    let description = crate::scraping::http::html_to_markdown(&body_html);
+    let description = (!description.trim().is_empty()).then_some(description);
+
+    Some((title, description))
+}
+
+static JOB_ROOT_SCRIPT_STYLE_RE: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"(?is)<(script|style)[\s\S]*?</(script|style)>").unwrap()
+    });
+
+/// Strips `<h1>` elements out of the hinted subtree's (already script/style-
+/// cleaned) HTML before it becomes the description source — see the "exclude
+/// the title" note on [`job_root_generic_html`] above.
+static JOB_ROOT_TITLE_RE: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| regex::Regex::new(r"(?is)<h1[\s\S]*?</h1>").unwrap());
 
 /// The subset of JSON-LD `JobPosting` fields the generic parse path consumes.
 struct JsonLdJob {

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
@@ -548,8 +548,18 @@ pub fn parse_from_html(url: &str, html: &str) -> Option<JobPosting> {
 // needed (unlike the JSON-LD/NEXT_DATA walks) — scoped to whatever the
 // extension already marked.
 fn job_root_generic_html(html: &str) -> Option<(String, Option<String>)> {
+    // Cheap substring check before the full-document reparse below: every
+    // server-fetch resolve call hits this with no hint attribute present at
+    // all, so skip `Html::parse_document` entirely on that (overwhelmingly
+    // common) path.
+    if !html.contains("data-ajh-job-root") {
+        return None;
+    }
+
     let doc = Html::parse_document(html);
     let root_sel = Selector::parse(r#"[data-ajh-job-root="true"]"#).ok()?;
+    // First-in-DOM-order match is the intended tie-break if a page ever
+    // contains several hinted nodes.
     let root = doc.select(&root_sel).next()?;
 
     // Unlike this crate's own `html_to_text`, `html_to_markdown`'s `htmd` backend

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
@@ -991,6 +991,202 @@ fn parse_from_html_unparseable_page_has_empty_title() {
     assert_eq!(posting.title, "", "nothing usable parsed → empty title");
 }
 
+// ── `[data-ajh-job-root]` hint (PR 3: desktop parser consumes the hint) ──────
+//
+// The extension's Scan-mode capture (`markLikelyJobNode` in
+// apps/extension/src/content.ts) best-effort marks one node with
+// `data-ajh-job-root="true"` before handing the full outerHTML to the desktop.
+// These tests cover the generic-fallback preference for that hinted subtree,
+// added ONLY to `job_root_generic_html` (and `parse_from_html`'s per-field
+// merge of its output) — the JSON-LD and __NEXT_DATA__ paths above are
+// untouched and still win when present.
+
+#[test]
+fn test_parse_from_html_job_root_hint_wins_over_larger_block() {
+    // No <title> tag, so parse_generic_html's `title, h1` selector would fall to
+    // the FIRST <h1> in the document — which, without the hint, is the unrelated
+    // sidebar block's heading (DOM-order first). Likewise main_content_text picks
+    // the LARGEST of the two <article> blocks, and the padded sidebar block is
+    // deliberately longer than the real posting. Both whole-document heuristics
+    // are wrong on this page; the `[data-ajh-job-root]` hint on the real posting
+    // must correct both title and description — the per-field merge overrides
+    // each field independently, and here BOTH fields happen to be present in
+    // the hinted subtree (see the thin-body test below for the single-field
+    // case, where only one of the two is overridden).
+    let padded = "Related jobs you might like, sponsored content, more links. ".repeat(20);
+    let html = format!(
+        r#"<html><head></head><body>
+            <nav>
+                <article><h1>Related: Other Job For SEO</h1><p>{padded}</p></article>
+            </nav>
+            <article data-ajh-job-root="true">
+                <h1>Backend Engineer</h1>
+                <p>We are looking for a backend engineer to build resilient distributed systems.</p>
+            </article>
+        </body></html>"#
+    );
+    let posting = parse_from_html("https://acme.example/j/hint-1", &html)
+        .expect("a hinted subtree with real content must yield a posting");
+    assert_eq!(
+        posting.title, "Backend Engineer",
+        "hinted subtree's h1 must win over the first (unrelated) h1 in DOM order"
+    );
+    let desc = posting.description.as_deref().unwrap_or_default();
+    assert!(
+        desc.contains("resilient distributed systems"),
+        "description must come from the hinted subtree, got: {desc}"
+    );
+    assert!(
+        !desc.contains("Related jobs"),
+        "description must NOT be the larger unrelated sidebar block, got: {desc}"
+    );
+}
+
+#[test]
+fn test_parse_from_html_job_root_hint_unusable_falls_through() {
+    // The hinted node is empty (whitespace only, no h1, no text) — a mis-marked
+    // hint. job_root_generic_html() yields ("", None) for it, so neither field
+    // of the per-field merge overrides, and parse_from_html falls through to
+    // parse_generic_html's <title>/meta-description path, exactly as if no hint
+    // existed at all.
+    let html = r#"
+        <html>
+            <head>
+                <title>Backend Engineer</title>
+                <meta name="description" content="Build APIs at Acme">
+            </head>
+            <body>
+                <div data-ajh-job-root="true">   </div>
+            </body>
+        </html>
+    "#;
+    let posting = parse_from_html("https://acme.example/j/hint-2", html)
+        .expect("an unusable hint must still fall through to a usable posting");
+    assert_eq!(
+        posting.title, "Backend Engineer",
+        "empty hinted node must fall through to the <title> tag"
+    );
+    assert_eq!(
+        posting.description.as_deref(),
+        Some("Build APIs at Acme"),
+        "empty hinted node must fall through to the meta description"
+    );
+}
+
+#[test]
+fn test_parse_from_html_no_hint_is_byte_identical_to_generic_path() {
+    // No `[data-ajh-job-root]` anywhere in this document — job_root_generic_html
+    // must return None, so parse_from_html falls through to parse_generic_html
+    // exactly as it did before this hint feature existed. Assert byte-identical
+    // equality against calling parse_generic_html directly (the no-hint floor),
+    // not just "looks right" — this is the guarantee that the server-fetch
+    // resolve path (which never has a hint) is provably unchanged.
+    let html = r#"
+        <html>
+            <head>
+                <title>Backend Engineer</title>
+                <meta name="description" content="Build APIs">
+                <meta property="og:site_name" content="Acme Corp">
+            </head>
+            <body></body>
+        </html>
+    "#;
+    let (expected_title, expected_description) = parse_generic_html(html);
+    let posting = parse_from_html("https://acme.example.com/jobs/9", html)
+        .expect("a title is present, so a posting is built");
+    assert_eq!(posting.title, expected_title);
+    assert_eq!(posting.description, expected_description);
+    assert_eq!(posting.company, "Acme Corp");
+}
+
+#[test]
+fn test_parse_from_html_hostile_hint_falls_through_safely() {
+    // The hinted node contains ONLY a script tag and whitespace — a hostile/
+    // mis-marked hint. html_to_markdown strips script content, so the hint
+    // yields an empty description and no title; neither field of the per-field
+    // merge overrides, and parse_from_html falls through to the whole-document
+    // heuristic chain (here: the <main> block) — never producing a worse
+    // (empty) result than the no-hint path would.
+    let html = r#"
+        <html>
+            <head><title>Backend Engineer</title></head>
+            <body>
+                <div data-ajh-job-root="true">
+                    <script>trackImpression();</script>
+
+
+                </div>
+                <main><p>We are hiring a backend engineer to build resilient distributed systems and own the platform end to end.</p></main>
+            </body>
+        </html>
+    "#;
+    let posting = parse_from_html("https://acme.example/j/hint-4", html)
+        .expect("a hostile hint must still fall through to a usable posting");
+    assert_eq!(posting.title, "Backend Engineer");
+    let desc = posting.description.as_deref().unwrap_or_default();
+    assert!(
+        desc.contains("resilient distributed systems"),
+        "description must come from the <main> fallback, not the hostile hint, got: {desc}"
+    );
+}
+
+#[test]
+fn test_parse_from_html_job_root_hint_thin_body_merges_per_field() {
+    // The hinted node has ONLY a title — no body text (the real description
+    // lives elsewhere, e.g. rendered client-side inside an ATS iframe the
+    // outerHTML capture can't see). A wholesale hint substitution would have
+    // discarded the document's real meta description in favor of a
+    // title-redundant stub ("Backend Engineer" markdownified); the per-field
+    // merge must take the better title from the hint while leaving the real
+    // meta description untouched.
+    let html = r#"
+        <html>
+            <head>
+                <title>Careers at Acme</title>
+                <meta name="description" content="We are hiring a backend engineer to build resilient distributed systems.">
+            </head>
+            <body>
+                <main data-ajh-job-root="true"><h1>Backend Engineer</h1></main>
+            </body>
+        </html>
+    "#;
+    let posting = parse_from_html("https://acme.example/j/hint-thin", html)
+        .expect("a title is present, so a posting is built");
+    assert_eq!(
+        posting.title, "Backend Engineer",
+        "title must come from the hint, not the generic <title> tag"
+    );
+    assert_eq!(
+        posting.description.as_deref(),
+        Some("We are hiring a backend engineer to build resilient distributed systems."),
+        "description must stay the real meta description, not a title-redundant hint stub"
+    );
+}
+
+#[test]
+fn test_job_root_script_style_re_strips_case_variant_and_nested_tags() {
+    // Uppercase/mixed-case tags (real-world markup isn't always lowercase) and a
+    // <script> whose own body contains markup-shaped text (must not confuse the
+    // non-greedy match into stopping early or matching across tags).
+    let html = concat!(
+        "<P>Keep me</P>",
+        "<SCRIPT type=\"text/javascript\">if (x < 1) { document.write(\"<b>fake</b>\"); }</SCRIPT>",
+        "<Style>.x { color: red; }</Style>",
+        "<p>Also keep me</p>",
+    );
+    let cleaned = JOB_ROOT_SCRIPT_STYLE_RE.replace_all(html, " ");
+    assert!(
+        !cleaned.contains("document.write"),
+        "script content must be stripped: {cleaned}"
+    );
+    assert!(
+        !cleaned.contains("color: red"),
+        "style content must be stripped: {cleaned}"
+    );
+    assert!(cleaned.contains("Keep me"));
+    assert!(cleaned.contains("Also keep me"));
+}
+
 // ── resolve Pass 3 — redirect→final-URL board re-dispatch ────────────────────
 //
 // Pass 3 of resolve(): after named boards miss on the ORIGINAL url, follow the

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
@@ -1187,6 +1187,153 @@ fn test_job_root_script_style_re_strips_case_variant_and_nested_tags() {
     assert!(cleaned.contains("Also keep me"));
 }
 
+#[test]
+fn test_parse_from_html_thin_hint_last_resort_does_not_scan_whole_document() {
+    // Regression for a HIGH ensemble-review finding: a thin hint (title-only,
+    // no body) on a page with no <meta name="description"> anywhere left
+    // `description` `None` after the per-field merge, so the OLD code ran
+    // `main_content_text` over the WHOLE document as a last resort — which
+    // can land on an unrelated decoy block bigger than the actual posting.
+    // Once the hint supplied a real title, that whole-document last resort
+    // must not run at all; description stays `None` rather than risk the
+    // decoy text.
+    let padded = "Totally unrelated marketing copy about our great company culture. ".repeat(20);
+    let html = format!(
+        r#"<html><body>
+            <article><p>{padded}</p></article>
+            <div data-ajh-job-root="true"><h1>Backend Engineer</h1></div>
+        </body></html>"#
+    );
+    let posting = parse_from_html("https://acme.example/j/thin-hint-no-scan", &html)
+        .expect("a hinted title alone still yields a posting");
+    assert_eq!(posting.title, "Backend Engineer");
+    assert_eq!(
+        posting.description, None,
+        "a thin hint's last resort must stay None, not the unrelated decoy article, got: {:?}",
+        posting.description
+    );
+}
+
+#[test]
+fn test_job_root_generic_html_keeps_non_title_h1_headings() {
+    // JOB_ROOT_TITLE_RE previously stripped EVERY <h1> in the hinted subtree,
+    // not just the title's — a job page that styles section headings (e.g.
+    // "Responsibilities") as <h1> would silently lose them from the
+    // description. Only the FIRST <h1> (the title) is excluded now.
+    let html = r#"
+        <html><body>
+            <div data-ajh-job-root="true">
+                <h1>Backend Engineer</h1>
+                <p>We build distributed systems.</p>
+                <h1>Responsibilities</h1>
+                <ul><li>Design APIs</li></ul>
+            </div>
+        </body></html>
+    "#;
+    let (title, description) = job_root_generic_html(html).expect("hint node present");
+    assert_eq!(title, "Backend Engineer");
+    let desc = description.unwrap_or_default();
+    assert!(
+        desc.contains("Responsibilities"),
+        "a non-title h1 section heading must survive in the description, got: {desc}"
+    );
+}
+
+#[test]
+fn test_parse_from_html_job_root_hint_description_only_leaves_title_alone() {
+    // Mirror of the thin-body test above: the hinted node has body text but no
+    // <h1>. job_root_generic_html() yields ("", Some(desc)), so the per-field
+    // merge must take the hint's description while leaving the document's own
+    // <title> untouched.
+    let html = r#"
+        <html>
+            <head><title>Careers at Acme</title></head>
+            <body>
+                <div data-ajh-job-root="true"><p>We are hiring a backend engineer to build resilient distributed systems.</p></div>
+            </body>
+        </html>
+    "#;
+    let posting = parse_from_html("https://acme.example/j/hint-desc-only", html)
+        .expect("a title is present, so a posting is built");
+    assert_eq!(
+        posting.title, "Careers at Acme",
+        "no h1 in the hinted node → title must stay the document's own <title>"
+    );
+    let desc = posting.description.as_deref().unwrap_or_default();
+    assert!(
+        desc.contains("resilient distributed systems"),
+        "hint's body text must override the (absent) base description, got: {desc}"
+    );
+}
+
+#[test]
+fn test_parse_from_html_hint_description_beats_meta_description() {
+    // Precedence pin: when the hinted subtree has its own body text, it wins
+    // over a real document-level <meta name="description"> — the per-field
+    // merge overrides `description` whenever the hint found ANY text, not
+    // only when the base pass came back empty.
+    let html = r#"
+        <html>
+            <head>
+                <title>Careers at Acme</title>
+                <meta name="description" content="Acme is a great place to work, join our team today.">
+            </head>
+            <body>
+                <div data-ajh-job-root="true">
+                    <h1>Backend Engineer</h1>
+                    <p>We are hiring a backend engineer to own resilient distributed systems end to end.</p>
+                </div>
+            </body>
+        </html>
+    "#;
+    let posting = parse_from_html("https://acme.example/j/hint-vs-meta", html)
+        .expect("a title is present, so a posting is built");
+    let desc = posting.description.as_deref().unwrap_or_default();
+    assert!(
+        desc.contains("own resilient distributed systems"),
+        "hint body text must win over the real meta description, got: {desc}"
+    );
+    assert!(
+        !desc.contains("great place to work"),
+        "the meta description must be overridden, not merged, got: {desc}"
+    );
+}
+
+#[test]
+fn test_parse_from_html_json_ld_beats_hint() {
+    // Precedence pin: JSON-LD JobPosting is applied AFTER the hint merge in
+    // parse_from_html and unconditionally overrides both fields when present —
+    // structured data always wins over the DOM hint, even when the hint itself
+    // found usable text.
+    let html = r#"
+        <html>
+            <head>
+                <title>Careers at Acme</title>
+                <script type="application/ld+json">
+                {
+                    "@type": "JobPosting",
+                    "title": "Senior Backend Engineer",
+                    "description": "The structured JSON-LD description wins."
+                }
+                </script>
+            </head>
+            <body>
+                <div data-ajh-job-root="true">
+                    <h1>Backend Engineer</h1>
+                    <p>The hinted DOM description must lose to JSON-LD.</p>
+                </div>
+            </body>
+        </html>
+    "#;
+    let posting = parse_from_html("https://acme.example/j/hint-vs-jsonld", html)
+        .expect("a title is present, so a posting is built");
+    assert_eq!(posting.title, "Senior Backend Engineer");
+    assert_eq!(
+        posting.description.as_deref(),
+        Some("The structured JSON-LD description wins.")
+    );
+}
+
 // ── resolve Pass 3 — redirect→final-URL board re-dispatch ────────────────────
 //
 // Pass 3 of resolve(): after named boards miss on the ORIGINAL url, follow the


### PR DESCRIPTION
## Summary

The desktop parser now consumes the extension's Scan-mode hint (PR 3 of the extension roadmap; desktop-only, no wire/extension changes):

- `content.ts` has always stamped `data-ajh-job-root="true"` on the likely job node before sending the captured DOM; `parse_from_html`'s generic-fallback pass now **per-field merges** that subtree over the whole-document heuristics — title and description each override only when the hinted subtree yields a non-empty value, so a mis-marked or thin hint can never make results worse than today.
- Script/style content is stripped from the hinted subtree locally before markdown conversion (the `htmd` backend doesn't strip it — found during hostile-hint testing; the shared helper with 11 other callers is deliberately untouched). Only the first (title) `h1` is excluded from the description source, preserving h1-styled section headings.
- When a usable hint title was applied, the whole-document largest-block last-resort is skipped — a thin hint no longer falls back to picking an unrelated decoy block.
- Selector pinned to the extension's contract value (`="true"`); JSON-LD / `__NEXT_DATA__` precedence unchanged and now test-pinned; the no-hint path (including the server-fetch resolve chain) is pinned byte-identical to `parse_generic_html`.

Fewer `partial: true` import stubs → less manual completion; compounds into everything JD-dependent (match scoring, answers, generation).

## Review trail (pre-PR gates)

- scraping-applier-expert: its HIGH (wholesale substitution could discard a real meta description on thin-body/ATS-iframe pages) fixed via the per-field merge; selector pin + title-path script-strip adopted.
- /review full-tier 3-pass ensemble: the surviving HIGH (unscoped last-resort on thin hints) and MEDIUM (global h1-strip losing section headings) fixed; both precedence regression pins and the description-only-hint matrix case added.
- Security assessment (via domain critic): a page self-planting the attribute gains no privilege it doesn't already have over its own content; parser is local, fetch-free, no new I/O.

## Test plan

- 11 new tests in `scrape_url/test.rs`: hint-wins-over-decoy, thin-hint last-resort scoping, per-field matrix (title-only / description-only / both / neither), hostile hint (script-only node), no-hint byte-identical (structural comparison against `parse_generic_html`), hint-vs-meta and hint-vs-JSON-LD precedence pins, regex unit test (case-variant/nested tags).
- Full crate 2205 passed; exact CI clippy (`--all-features`) clean; fmt clean; lint:strict clean.

Part of the approved extension roadmap (PR 3 of 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job posting extraction from pages that identify their primary content area.
  * More accurately prioritizes relevant titles and descriptions while ignoring scripts and styles.
  * Preserves reliable fallback behavior when page hints are empty, incomplete, or unavailable.
  * Improved handling of metadata and structured page content for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->