### PR TITLE
feat: fill portfolio and custom link fields from contact profile extra links

### DIFF
--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -847,6 +847,45 @@ struct AutofillProfile {
     github: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     website: Option<String>,
+    /// Additional labelled links (Portfolio, Dribbble, Stack Overflow, …) beyond
+    /// the named platform fields — see [`clean_extra_links`] for the projection
+    /// rules. Additive/optional on the wire: an old extension ignores the key,
+    /// and it is omitted entirely (not `[]`) when there is nothing to send, so
+    /// an old desktop's replies (which never carry it) parse identically.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    extra_links: Vec<crate::contact_profile::ContactLink>,
+}
+
+/// Cap on the number of extra links projected to the extension — a form has no
+/// use for an unbounded list, and this bounds the reply size.
+const MAX_EXTRA_LINKS: usize = 10;
+
+/// Filter + cap the stored extra links for the wire: drop an entry with an empty
+/// label, drop a url that (after trimming) is empty or not `http(s)`, then keep
+/// at most [`MAX_EXTRA_LINKS`] of what remains, in order. `photo` is never
+/// projected at all — unrelated to this list and always dropped.
+fn clean_extra_links(
+    links: &[crate::contact_profile::ContactLink],
+) -> Vec<crate::contact_profile::ContactLink> {
+    links
+        .iter()
+        .filter_map(|link| {
+            let label = link.label.trim();
+            let url = link.url.trim();
+            if label.is_empty() {
+                return None;
+            }
+            let lower = url.to_ascii_lowercase();
+            if !(lower.starts_with("http://") || lower.starts_with("https://")) {
+                return None;
+            }
+            Some(crate::contact_profile::ContactLink {
+                label: label.to_string(),
+                url: url.to_string(),
+            })
+        })
+        .take(MAX_EXTRA_LINKS)
+        .collect()
 }
 
 impl AutofillProfile {
@@ -873,6 +912,7 @@ impl AutofillProfile {
             linkedin: clean(&p.linkedin),
             github: clean(&p.github),
             website: clean(&p.website),
+            extra_links: clean_extra_links(&p.extra_links),
         }
     }
 }

--- a/apps/desktop/src-tauri/src/extension_bridge/test.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/test.rs
@@ -256,6 +256,135 @@ fn profile_result_reply_carries_refusal_error() {
         .contains("Autofill is off"));
 }
 
+// ── extra_links projection (from_contact / clean_extra_links) ─────────────────
+// Additive optional field — PR 4 of the extension roadmap: old extensions
+// ignore the key; old desktops never send it (see the omitted-when-absent
+// test below), so neither side needs a protocol bump.
+
+#[test]
+fn from_contact_projects_valid_extra_links_verbatim_and_trims_whitespace() {
+    use crate::contact_profile::{ContactLink, ContactProfile};
+    let profile = ContactProfile {
+        extra_links: vec![
+            ContactLink {
+                label: "Portfolio".to_string(),
+                url: "https://saeed.dev".to_string(),
+            },
+            ContactLink {
+                label: "  Dribbble  ".to_string(),
+                url: "  http://dribbble.com/saeed  ".to_string(),
+            },
+        ],
+        ..Default::default()
+    };
+    let out = AutofillProfile::from_contact(&profile);
+    assert_eq!(out.extra_links.len(), 2);
+    assert_eq!(out.extra_links[0].label, "Portfolio");
+    assert_eq!(out.extra_links[0].url, "https://saeed.dev");
+    assert_eq!(out.extra_links[1].label, "Dribbble");
+    assert_eq!(
+        out.extra_links[1].url, "http://dribbble.com/saeed",
+        "surrounding whitespace is trimmed; the URL itself is otherwise verbatim"
+    );
+}
+
+#[test]
+fn from_contact_drops_empty_label_empty_url_and_non_http_scheme_entries() {
+    use crate::contact_profile::{ContactLink, ContactProfile};
+    let profile = ContactProfile {
+        extra_links: vec![
+            ContactLink {
+                label: "".to_string(),
+                url: "https://example.com".to_string(),
+            },
+            ContactLink {
+                label: "   ".to_string(),
+                url: "https://example.com".to_string(),
+            },
+            ContactLink {
+                label: "Notes".to_string(),
+                url: "".to_string(),
+            },
+            ContactLink {
+                label: "Sketchy".to_string(),
+                url: "javascript:alert(1)".to_string(),
+            },
+            ContactLink {
+                label: "FTP".to_string(),
+                url: "ftp://example.com/file".to_string(),
+            },
+            ContactLink {
+                label: "Portfolio".to_string(),
+                url: "https://saeed.dev".to_string(),
+            },
+        ],
+        ..Default::default()
+    };
+    let out = AutofillProfile::from_contact(&profile);
+    assert_eq!(
+        out.extra_links.len(),
+        1,
+        "only the one valid http(s)-scheme, non-empty-label entry survives"
+    );
+    assert_eq!(out.extra_links[0].label, "Portfolio");
+}
+
+#[test]
+fn from_contact_caps_extra_links_at_ten() {
+    use crate::contact_profile::{ContactLink, ContactProfile};
+    let profile = ContactProfile {
+        extra_links: (0..15)
+            .map(|i| ContactLink {
+                label: format!("Link {i}"),
+                url: format!("https://example.com/{i}"),
+            })
+            .collect(),
+        ..Default::default()
+    };
+    let out = AutofillProfile::from_contact(&profile);
+    assert_eq!(out.extra_links.len(), MAX_EXTRA_LINKS);
+    assert_eq!(out.extra_links[0].label, "Link 0");
+    assert_eq!(out.extra_links[9].label, "Link 9");
+}
+
+#[test]
+fn profile_result_reply_omits_extra_links_key_when_absent() {
+    use crate::contact_profile::ContactProfile;
+    let out = resolve_profile(
+        true,
+        Some(&ContactProfile {
+            email: Some("x@y.z".to_string()),
+            ..Default::default()
+        }),
+    );
+    let reply = profile_result_reply("req-99", out);
+    let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+    assert!(
+        v["payload"].get("extraLinks").is_none(),
+        "absent extra_links must be OMITTED from the JSON (not an empty array) so an \
+         old extension that has never heard of the key parses the reply unchanged"
+    );
+}
+
+#[test]
+fn profile_result_reply_carries_extra_links_camel_cased() {
+    use crate::contact_profile::{ContactLink, ContactProfile};
+    let out = resolve_profile(
+        true,
+        Some(&ContactProfile {
+            extra_links: vec![ContactLink {
+                label: "Portfolio".to_string(),
+                url: "https://saeed.dev".to_string(),
+            }],
+            ..Default::default()
+        }),
+    );
+    let reply = profile_result_reply("req-100", out);
+    let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+    assert_eq!(v["payload"]["extraLinks"][0]["label"], "Portfolio");
+    assert_eq!(v["payload"]["extraLinks"][0]["url"], "https://saeed.dev");
+}
+
 // ── Spawn-from-no-runtime regression (boot panic) ────────────────────────────
 
 /// Regression guard for the boot panic: `start()` is called from the Tauri

--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -201,6 +201,29 @@ describe('fill request — success path', () => {
 
     expect(res).toEqual({ ok: true, kind: 'fill', summary });
   });
+
+  it('forwards extraLinks from the profile.result reply into the injected fill fields', async () => {
+    getTokenMock.mockResolvedValue(FAKE_TOKEN);
+    mockClient.getProfile.mockResolvedValue({
+      email: 'saeed@example.com',
+      extraLinks: [{ label: 'Portfolio', url: 'https://saeed.dev' }],
+    });
+    tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://example.com/apply' } as never]);
+    const summary: AutofillSummary = {
+      filled: [{ key: 'extraLink:Portfolio', label: 'Portfolio', count: 1 }],
+      nameSplit: null,
+      filledNothing: false,
+    };
+    executeScriptMock
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([{ result: summary }] as never);
+
+    await send({ kind: 'fill' });
+
+    const secondCallArgs = executeScriptMock.mock.calls[1]?.[0] as { args?: unknown[] };
+    const [fields] = secondCallArgs.args as [{ extraLinks?: unknown }];
+    expect(fields.extraLinks).toEqual([{ label: 'Portfolio', url: 'https://saeed.dev' }]);
+  });
 });
 
 // ── appliedCheck request — always ok:true, every failure folds into found:false ─

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -201,6 +201,7 @@ async function runFill(): Promise<PopupResponse> {
     linkedin: profile.linkedin,
     github: profile.github,
     website: profile.website,
+    extraLinks: profile.extraLinks,
   };
   const summary = await injectFill(fields);
   return { ok: true, kind: 'fill', summary };

--- a/apps/extension/src/lib/autofill.test.ts
+++ b/apps/extension/src/lib/autofill.test.ts
@@ -295,6 +295,136 @@ describe('planAndFill – filled-nothing', () => {
   });
 });
 
+describe('planAndFill – Tier-2 extra-link matching', () => {
+  // `website` deliberately unset: a "Portfolio"-labelled field maps to the
+  // generic `website` key first (the pre-existing heuristic), and only falls
+  // through to the extra-link matcher when that named slot is empty — see
+  // the `planAndFill` doc comment.
+  const PROFILE_WITH_LINKS: AutofillProfile = {
+    ...PROFILE,
+    website: undefined,
+    extraLinks: [
+      { label: 'Portfolio', url: 'https://saeed.dev/work' },
+      { label: 'Dribbble', url: 'https://dribbble.com/saeed' },
+    ],
+  };
+
+  it('fills a field whose label unambiguously matches one extra link', () => {
+    setForm(`<label for="p">Portfolio</label><input id="p" type="url" />`);
+    const summary = planAndFill(document, PROFILE_WITH_LINKS);
+    expect(val('p')).toBe('https://saeed.dev/work');
+    expect(summary.filled).toContainEqual({
+      key: 'extraLink:Portfolio',
+      label: 'Portfolio',
+      count: 1,
+    });
+  });
+
+  it('matches case/diacritic-insensitively, as whole-word tokens (not a substring)', () => {
+    setForm(`<label for="so">Stäck Overflöw profile</label><input id="so" type="url" />`);
+    const profile: AutofillProfile = {
+      extraLinks: [{ label: 'Stack Overflow', url: 'https://stackoverflow.com/users/1' }],
+    };
+    planAndFill(document, profile);
+    expect(val('so')).toBe('https://stackoverflow.com/users/1');
+  });
+
+  it('requires a whole-word token match, not a coincidental substring (e.g. "Dribbble" must not match "Dribbblers")', () => {
+    setForm(`<label for="d">Dribbblers only</label><input id="d" type="url" />`);
+    const profile: AutofillProfile = {
+      extraLinks: [{ label: 'Dribbble', url: 'https://dribbble.com/saeed' }],
+    };
+    planAndFill(document, profile);
+    expect(val('d')).toBe('');
+  });
+
+  it('skips (ambiguous) a field whose signal matches MULTIPLE extra links, and flags it in the summary', () => {
+    setForm(`<label for="both">Portfolio Dribbble</label><input id="both" type="url" />`);
+    const summary = planAndFill(document, PROFILE_WITH_LINKS);
+    expect(val('both')).toBe('');
+    expect(summary.skippedAmbiguous).toBe(1);
+    expect(summary.filled).toHaveLength(0);
+  });
+
+  it('does NOT match a bare "Website" field label to an extra link literally labelled "Website"', () => {
+    setForm(`<label for="w">Website</label><input id="w" type="url" />`);
+    const profile: AutofillProfile = {
+      extraLinks: [{ label: 'Website', url: 'https://saeed.dev/secondary' }],
+    };
+    const summary = planAndFill(document, profile);
+    expect(val('w')).toBe('');
+    expect(summary.skippedAmbiguous ?? 0).toBe(0);
+    expect(summary.filledNothing).toBe(true);
+  });
+
+  it('never overwrites an already-filled field, even when its label matches a link', () => {
+    setForm(`<label for="p">Portfolio</label><input id="p" type="url" value="https://keep.me" />`);
+    planAndFill(document, PROFILE_WITH_LINKS);
+    expect(val('p')).toBe('https://keep.me');
+  });
+
+  it('never fills a hidden (honeypot) field even when its label matches a link', () => {
+    setForm(
+      `<div style="display:none"><label for="hp">Portfolio</label><input id="hp" type="url" /></div>`
+    );
+    planAndFill(document, PROFILE_WITH_LINKS);
+    expect(val('hp')).toBe('');
+  });
+
+  it('leaves a field with no matching link untouched', () => {
+    setForm(`<label for="cl">Cover letter link</label><input id="cl" type="url" />`);
+    const summary = planAndFill(document, PROFILE_WITH_LINKS);
+    expect(val('cl')).toBe('');
+    expect(summary.filledNothing).toBe(true);
+  });
+
+  it('a field filled by a named key WITH a value is never additionally reconsidered against extraLinks', () => {
+    setForm(`<label for="li">LinkedIn profile</label><input id="li" type="url" />`);
+    const profile: AutofillProfile = {
+      linkedin: 'https://linkedin.com/in/saeed',
+      extraLinks: [{ label: 'LinkedIn Extra', url: 'https://example.com/other' }],
+    };
+    planAndFill(document, profile);
+    expect(val('li')).toBe('https://linkedin.com/in/saeed');
+  });
+
+  it('does NOT fall through to the extra-link matcher for a non-website named key with an empty profile value (only `website` falls through)', () => {
+    setForm(`<label for="li">LinkedIn</label><input id="li" type="url" />`);
+    const profile: AutofillProfile = {
+      extraLinks: [{ label: 'LinkedIn', url: 'https://linkedin.com/in/other' }],
+    };
+    const summary = planAndFill(document, profile);
+    expect(val('li')).toBe(''); // named `linkedin` key claims it; no fallthrough
+    expect(summary.filledNothing).toBe(true);
+  });
+
+  it('never fills an email/tel-typed field via the extra-link matcher (a URL is syntactically invalid there)', () => {
+    setForm(`<label for="pe">Portfolio</label><input id="pe" type="email" />`);
+    const summary = planAndFill(document, PROFILE_WITH_LINKS);
+    expect(val('pe')).toBe('');
+    expect(summary.filledNothing).toBe(true);
+  });
+
+  it('never matches a link labelled a bare "Profile" (GENERIC_LINK_LABELS)', () => {
+    setForm(`<label for="prof">Profile</label><input id="prof" type="url" />`);
+    const profile: AutofillProfile = {
+      extraLinks: [{ label: 'Profile', url: 'https://example.com/profile' }],
+    };
+    const summary = planAndFill(document, profile);
+    expect(val('prof')).toBe('');
+    expect(summary.filledNothing).toBe(true);
+  });
+
+  it('is a no-op when the profile has no extraLinks (absence tolerated)', () => {
+    // "Dribbble" matches no existing Tier 1/2 named-key heuristic, so this
+    // field is left untouched purely by the `links.length === 0` short-circuit.
+    setForm(`<label for="d">Dribbble</label><input id="d" type="url" />`);
+    const summary = planAndFill(document, PROFILE);
+    expect(val('d')).toBe('');
+    expect(summary.skippedAmbiguous ?? 0).toBe(0);
+  });
+});
+
 describe('renderSummaryOverlay', () => {
   it('renders a dismissable overlay listing the filled fields', () => {
     const summary = {
@@ -330,6 +460,29 @@ describe('renderSummaryOverlay', () => {
     renderSummaryOverlay(document, { filled: [], nameSplit: null, filledNothing: true });
     renderSummaryOverlay(document, { filled: [], nameSplit: null, filledNothing: true });
     expect(document.querySelectorAll('#ajh-autofill-overlay')).toHaveLength(1);
+  });
+
+  it('notes skipped-ambiguous extra-link fields alongside a successful fill', () => {
+    renderSummaryOverlay(document, {
+      filled: [{ key: 'extraLink:Portfolio', label: 'Portfolio', count: 1 }],
+      nameSplit: null,
+      filledNothing: false,
+      skippedAmbiguous: 2,
+    });
+    const overlay = document.getElementById('ajh-autofill-overlay');
+    expect(overlay!.textContent).toContain('Portfolio → 1 field');
+    expect(overlay!.textContent).toContain('2 fields skipped');
+  });
+
+  it('omits the skipped-ambiguous note when there is nothing to report', () => {
+    renderSummaryOverlay(document, {
+      filled: [{ key: 'email', label: 'Email', count: 1 }],
+      nameSplit: null,
+      filledNothing: false,
+      skippedAmbiguous: 0,
+    });
+    const overlay = document.getElementById('ajh-autofill-overlay');
+    expect(overlay!.textContent).not.toContain('skipped');
   });
 });
 

--- a/apps/extension/src/lib/autofill.test.ts
+++ b/apps/extension/src/lib/autofill.test.ts
@@ -423,6 +423,56 @@ describe('planAndFill – Tier-2 extra-link matching', () => {
     expect(val('d')).toBe('');
     expect(summary.skippedAmbiguous ?? 0).toBe(0);
   });
+
+  it('token-normalizes the generic-label denylist against punctuation/hyphen variants', () => {
+    // Matching is token-based, so a bare exact-string check on the denylist
+    // (e.g. "website!" not literally in the set) would let these slip through
+    // while still token-matching the plain field label.
+    const cases: Array<[linkLabel: string, fieldLabel: string]> = [
+      ['Website!', 'Website'],
+      ['Web-Site', 'Web Site'],
+      ['Personal-Site', 'Personal Site'],
+    ];
+    for (const [linkLabel, fieldLabel] of cases) {
+      setForm(`<label for="f">${fieldLabel}</label><input id="f" type="url" />`);
+      const summary = planAndFill(document, {
+        extraLinks: [{ label: linkLabel, url: 'https://example.com/x' }],
+      });
+      expect(val('f')).toBe('');
+      expect(summary.filledNothing).toBe(true);
+    }
+  });
+
+  it('fills BOTH fields when two fields share one label and one matching link exists', () => {
+    setForm(`
+      <label for="p1">Portfolio</label><input id="p1" type="url" />
+      <label for="p2">Portfolio</label><input id="p2" type="url" />
+    `);
+    const summary = planAndFill(document, PROFILE_WITH_LINKS);
+    expect(val('p1')).toBe('https://saeed.dev/work');
+    expect(val('p2')).toBe('https://saeed.dev/work');
+    expect(summary.skippedAmbiguous ?? 0).toBe(0);
+    expect(summary.filled).toContainEqual({
+      key: 'extraLink:Portfolio',
+      label: 'Portfolio',
+      count: 2,
+    });
+  });
+
+  it('matches a diacritic link label against an equivalent plain-ASCII field label (symmetry)', () => {
+    // The reverse of the "Stäck Overflöw" case above: here the LINK carries
+    // the diacritic and the FIELD is plain ASCII.
+    setForm(`<label for="up">Uberprofil</label><input id="up" type="url" />`);
+    const summary = planAndFill(document, {
+      extraLinks: [{ label: 'Überprofil', url: 'https://example.com/uber' }],
+    });
+    expect(val('up')).toBe('https://example.com/uber');
+    expect(summary.filled).toContainEqual({
+      key: 'extraLink:Überprofil',
+      label: 'Überprofil',
+      count: 1,
+    });
+  });
 });
 
 describe('renderSummaryOverlay', () => {
@@ -483,6 +533,21 @@ describe('renderSummaryOverlay', () => {
     });
     const overlay = document.getElementById('ajh-autofill-overlay');
     expect(overlay!.textContent).not.toContain('skipped');
+  });
+
+  it('suppresses the "no matchable fields" line when fields were skipped as ambiguous instead', () => {
+    // filledNothing + skippedAmbiguous both true reads as contradictory
+    // ("no matchable fields" + "N fields skipped") — the skipped-note alone
+    // already explains the outcome.
+    renderSummaryOverlay(document, {
+      filled: [],
+      nameSplit: null,
+      filledNothing: true,
+      skippedAmbiguous: 1,
+    });
+    const overlay = document.getElementById('ajh-autofill-overlay');
+    expect(overlay!.textContent).not.toContain('No matchable fields found');
+    expect(overlay!.textContent).toContain('1 field skipped');
   });
 });
 

--- a/apps/extension/src/lib/autofill.test.ts
+++ b/apps/extension/src/lib/autofill.test.ts
@@ -443,6 +443,18 @@ describe('planAndFill – Tier-2 extra-link matching', () => {
     }
   });
 
+  it('token-normalizes the generic-label denylist independent of word order (e.g. "Site Web" vs "Website")', () => {
+    // The denylist comparison must be order-insensitive since the field
+    // matcher itself is (tokens.every) — otherwise "Site Web" would bypass
+    // the denylisted "web site" while still token-matching a "Website" field.
+    setForm(`<label for="f">Website</label><input id="f" type="url" />`);
+    const summary = planAndFill(document, {
+      extraLinks: [{ label: 'Site Web', url: 'https://example.com/x' }],
+    });
+    expect(val('f')).toBe('');
+    expect(summary.filledNothing).toBe(true);
+  });
+
   it('fills BOTH fields when two fields share one label and one matching link exists', () => {
     setForm(`
       <label for="p1">Portfolio</label><input id="p1" type="url" />

--- a/apps/extension/src/lib/autofill.ts
+++ b/apps/extension/src/lib/autofill.ts
@@ -23,6 +23,14 @@
  */
 export const AUTOFILL_GLOBAL = '__ajhRunAutofill';
 
+/** One additional labelled link beyond the named platform fields (e.g.
+ *  Portfolio, Dribbble, Behance, Stack Overflow). Matched by Tier 2 only —
+ *  see {@link matchExtraLink}. */
+export interface AutofillLink {
+  label: string;
+  url: string;
+}
+
 /** The flat contact-profile projection sent by the desktop for autofill. */
 export interface AutofillProfile {
   fullName?: string;
@@ -32,13 +40,17 @@ export interface AutofillProfile {
   linkedin?: string;
   github?: string;
   website?: string;
+  extraLinks?: AutofillLink[];
 }
 
-/** One profile field that was written, with how many form fields received it. */
+/** One profile field that was written, with how many form fields received it.
+ *  An extra-link fill uses the synthetic key `extraLink:<label>` (its `label`
+ *  is the link's own label, e.g. "Portfolio") so it never collides with a
+ *  named key. */
 export interface AutofillFilledField {
-  /** Logical key: email | phone | fullName | firstName | lastName | location | linkedin | github | website. */
+  /** Logical key: email | phone | fullName | firstName | lastName | location | linkedin | github | website | extraLink:<label>. */
   key: string;
-  /** Human label shown in the summary (e.g. "Email"). */
+  /** Human label shown in the summary (e.g. "Email", or the extra link's own label). */
   label: string;
   /** How many form fields received this value. */
   count: number;
@@ -54,6 +66,14 @@ export interface AutofillSummary {
   nameSplit: { first: string; last: string } | null;
   /** True when no field matched — surfaced so a no-op reads as intentional. */
   filledNothing: boolean;
+  /**
+   * Count of otherwise-fillable fields skipped because their signal matched
+   * MORE THAN ONE extra link — under-fill over guessing which one is right.
+   * Optional (not just `0`) so every pre-existing `AutofillSummary` literal
+   * (tests, the popup) stays valid without this field; `planAndFill` always
+   * sets it.
+   */
+  skippedAmbiguous?: number;
 }
 
 /** DOM id of the injected summary overlay (also used to clear a prior pass). */
@@ -117,6 +137,9 @@ const KEY_LABELS: Record<string, string> = {
   github: 'GitHub',
   website: 'Website',
 };
+
+/** `AutofillFilledField.key` prefix for an extra-link fill (see {@link matchExtraLink}). */
+const EXTRA_LINK_PREFIX = 'extraLink:';
 
 /** Split a full name into first token + remainder (a flagged guess). */
 export function splitName(fullName: string): { first: string; last: string } {
@@ -214,6 +237,26 @@ function autocompleteField(el: HTMLInputElement): string {
 }
 
 /**
+ * The baseline gate shared by every fill tier: a fillable input TYPE, visible,
+ * empty, not a card/password autocomplete token, and not matching the
+ * {@link AMBIGUOUS} denylist. Extracted so the extra-link matcher (Tier 2)
+ * applies the exact same discipline as the named-key matcher below.
+ */
+function isCandidateField(el: HTMLInputElement): boolean {
+  if (!FILLABLE_TYPES.has(el.type)) return false;
+  if (isHidden(el)) return false;
+  if (el.value.trim() !== '') return false; // never overwrite
+
+  const ac = autocompleteField(el);
+  if (ac.startsWith('cc-') || ac === 'current-password' || ac === 'new-password') return false;
+
+  const signal = textSignal(el);
+  if (AMBIGUOUS.some((w) => signal.includes(w))) return false;
+
+  return true;
+}
+
+/**
  * Decide which logical profile key an input should receive, or `null` to skip.
  * Tier 1 = the standard `autocomplete` token (always fill). Tier 2 = an
  * unambiguous label/name/id/placeholder signal. Social/website under-fill: they
@@ -221,16 +264,10 @@ function autocompleteField(el: HTMLInputElement): string {
  * "Website"/"URL" is ambiguous and skipped.
  */
 export function matchFieldKey(el: HTMLInputElement): string | null {
-  const type = el.type;
-  if (!FILLABLE_TYPES.has(type)) return null;
-  if (isHidden(el)) return null;
-  if (el.value.trim() !== '') return null; // never overwrite
+  if (!isCandidateField(el)) return null;
 
   const ac = autocompleteField(el);
-  if (ac.startsWith('cc-') || ac === 'current-password' || ac === 'new-password') return null;
-
   const signal = textSignal(el);
-  if (AMBIGUOUS.some((w) => signal.includes(w))) return null;
 
   // ── Tier 1: standard autocomplete tokens ──────────────────────────────────
   switch (ac) {
@@ -323,27 +360,150 @@ function setValue(el: HTMLInputElement, value: string): void {
 }
 
 /**
+ * Extra-link labels too generic to ever safely match a field: a bare
+ * "Website"/"Link" field either already resolves via the named `website` key
+ * (Tier 1/2 above) or is genuinely ambiguous — it must never receive an
+ * arbitrary secondary link, even in the edge case where the user themselves
+ * labelled an extra link this generically.
+ */
+const GENERIC_LINK_LABELS = new Set([
+  'website',
+  'web site',
+  'site',
+  'link',
+  'url',
+  'web',
+  'homepage',
+  'home page',
+  'personal site',
+  'personal website',
+  'profile',
+  'portal',
+]);
+
+/** Lowercase, diacritic-stripped, trimmed normalization for label matching.
+ *  NFD-decomposes (é → e + ´) then strips every combining mark via the
+ *  `\p{Diacritic}` Unicode property escape. */
+function normalizeLabel(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim();
+}
+
+/** A normalized label split into whole-word tokens (e.g. "Stack Overflow" → ["stack", "overflow"]). */
+function labelTokens(label: string): string[] {
+  return normalizeLabel(label)
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/** Input types the extra-link matcher will fill — narrower than the baseline
+ *  {@link FILLABLE_TYPES}: `email`/`tel` pass the named-key gate (a same-shaped
+ *  value can go there), but a URL is syntactically invalid in either, so
+ *  Tier-2 link matching never fires on them even if the label otherwise
+ *  matches. */
+const EXTRA_LINK_FILLABLE_TYPES = new Set(['text', 'url', '']);
+
+/**
+ * Tier-2 extra-link matcher: does this field's free-text signal contain EVERY
+ * token of an extra link's label as a whole word (diacritic/case-insensitive)?
+ * Conservative by construction — a partial/coincidental substring hit never
+ * counts, and a link whose own label is one of {@link GENERIC_LINK_LABELS} is
+ * excluded entirely. A field whose signal matches MORE THAN ONE distinct link
+ * is ambiguous (`ambiguous: true`) — never guess which one is right.
+ *
+ * A single-token label (e.g. a link labelled just "Profile" or "Portal") is
+ * the highest false-positive-risk case: a common English word is likely to
+ * appear by coincidence in an unrelated field's name/id/placeholder/label.
+ * {@link GENERIC_LINK_LABELS} is the mitigation — every label that is itself
+ * a bare generic noun is excluded from matching entirely, no matter how the
+ * rest of the form reads.
+ */
+function matchExtraLink(
+  el: HTMLInputElement,
+  links: readonly AutofillLink[]
+): { link: AutofillLink | null; ambiguous: boolean } {
+  if (!EXTRA_LINK_FILLABLE_TYPES.has(el.type)) return { link: null, ambiguous: false };
+
+  // Normalize the signal the SAME way as the label (diacritic-strip first) —
+  // otherwise a non-ASCII char in the field's own text would fracture a token
+  // (e.g. "Stäck" splitting into "st"/"ck") before the comparison ever runs.
+  const signalTokens = new Set(
+    normalizeLabel(textSignal(el))
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean)
+  );
+  const matches = links.filter((link) => {
+    const norm = normalizeLabel(link.label);
+    if (!norm || GENERIC_LINK_LABELS.has(norm)) return false;
+    const tokens = labelTokens(link.label);
+    return tokens.length > 0 && tokens.every((t) => signalTokens.has(t));
+  });
+  if (matches.length === 0) return { link: null, ambiguous: false };
+  if (matches.length > 1) return { link: null, ambiguous: true };
+  return { link: matches[0] ?? null, ambiguous: false };
+}
+
+/**
  * Scan `doc` for fillable inputs, fill each matching EMPTY field from `profile`,
  * and return a summary. Pure w.r.t. profile persistence — nothing is stored.
+ *
+ * A field a named key (Tier 1/2) matches WITH a value is filled from that key
+ * exclusively — never additionally reconsidered against `extraLinks`. The ONE
+ * exception is the `website` key: a field mapped to it but with NOTHING in
+ * the profile (e.g. a "Portfolio" field maps to the generic `website` key,
+ * but the profile's `website` is empty) falls through to the extra-link
+ * matcher instead of being given up on — a specific "Portfolio" extra link is
+ * a better answer than an empty guess. Every OTHER named key (email, phone,
+ * linkedin, github, …) claims its field exclusively regardless of value — an
+ * empty profile value there is a legitimate "nothing to fill", not a signal
+ * to try the extra-link matcher, so those fields stay strictly additive.
  */
 export function planAndFill(doc: Document, profile: AutofillProfile): AutofillSummary {
   const split = splitName(profile.fullName ?? '');
+  const links = profile.extraLinks ?? [];
   const counts = new Map<string, number>();
   let usedSplit = false;
+  let skippedAmbiguous = 0;
 
   for (const el of Array.from(doc.querySelectorAll('input'))) {
+    if (!isCandidateField(el)) continue;
+
     const key = matchFieldKey(el);
-    if (!key) continue;
-    const value = valueForKey(key, profile, split);
-    if (!value) continue; // profile has nothing for this field → leave it empty
-    setValue(el, value);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-    if (key === 'firstName' || key === 'lastName') usedSplit = true;
+    if (key) {
+      const value = valueForKey(key, profile, split);
+      if (value) {
+        setValue(el, value);
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+        if (key === 'firstName' || key === 'lastName') usedSplit = true;
+        continue;
+      }
+      // Named slot matched but empty — only `website` falls through to the
+      // extra-link matcher (the portfolio→website heuristic collision this
+      // was built for); every other named key claims the field regardless of
+      // value, so it stays skipped rather than reconsidered.
+      if (key !== 'website') continue;
+    }
+
+    if (links.length === 0) continue;
+    const { link, ambiguous } = matchExtraLink(el, links);
+    if (ambiguous) {
+      skippedAmbiguous += 1;
+      continue;
+    }
+    if (!link) continue;
+    setValue(el, link.url);
+    const linkKey = `${EXTRA_LINK_PREFIX}${link.label}`;
+    counts.set(linkKey, (counts.get(linkKey) ?? 0) + 1);
   }
 
   const filled: AutofillFilledField[] = Array.from(counts.entries()).map(([key, count]) => ({
     key,
-    label: KEY_LABELS[key] ?? key,
+    label: key.startsWith(EXTRA_LINK_PREFIX)
+      ? key.slice(EXTRA_LINK_PREFIX.length)
+      : (KEY_LABELS[key] ?? key),
     count,
   }));
 
@@ -351,6 +511,7 @@ export function planAndFill(doc: Document, profile: AutofillProfile): AutofillSu
     filled,
     nameSplit: usedSplit ? split : null,
     filledNothing: filled.length === 0,
+    skippedAmbiguous,
   };
 }
 
@@ -406,6 +567,13 @@ export function renderSummaryOverlay(doc: Document, summary: AutofillSummary): v
     verify.textContent = 'Review the filled fields, then submit yourself.';
     list.appendChild(verify);
     box.appendChild(list);
+  }
+
+  if (summary.skippedAmbiguous) {
+    const ambiguous = doc.createElement('div');
+    ambiguous.style.cssText = 'margin-top:6px;color:#fbbf24';
+    ambiguous.textContent = `${summary.skippedAmbiguous} field${summary.skippedAmbiguous === 1 ? '' : 's'} skipped — matched more than one saved link, so nothing was guessed.`;
+    box.appendChild(ambiguous);
   }
 
   const close = doc.createElement('button');

--- a/apps/extension/src/lib/autofill.ts
+++ b/apps/extension/src/lib/autofill.ts
@@ -382,17 +382,18 @@ const GENERIC_LINK_LABELS = new Set([
 ]);
 
 /**
- * {@link GENERIC_LINK_LABELS}, but run through {@link labelTokens} and
- * re-joined with a single space — the same normalization the label/field
- * matcher itself uses below. `matchExtraLink` matching is TOKEN-based (case,
- * diacritics, and punctuation all stripped before comparison), so gating on
- * the raw strings above would let a link labelled "Website!"/"Web-Site" slip
- * past the denylist (its exact string isn't in the set) while still
- * token-matching a bare "Website" field. Comparing tokenized-vs-tokenized
- * keeps the two checks in lockstep.
+ * {@link GENERIC_LINK_LABELS}, but run through {@link labelTokens}, sorted,
+ * and re-joined with a single space — the same normalization the label/field
+ * matcher itself uses below. `matchExtraLink` matching is TOKEN-based and
+ * order-insensitive (case, diacritics, punctuation, and word order are all
+ * ignored before comparison), so gating on the raw strings above — or on
+ * tokens joined in their original order — would let a link labelled
+ * "Website!"/"Web-Site"/"Site Web" slip past the denylist while still
+ * token-matching a bare "Website" field. Comparing sorted-tokenized-vs-
+ * sorted-tokenized keeps the two checks in lockstep regardless of word order.
  */
 const GENERIC_LINK_LABEL_TOKENS = new Set(
-  Array.from(GENERIC_LINK_LABELS, (label) => labelTokens(label).join(' '))
+  Array.from(GENERIC_LINK_LABELS, (label) => [...labelTokens(label)].sort().join(' '))
 );
 
 /** Lowercase, diacritic-stripped, trimmed normalization for label matching.
@@ -451,7 +452,8 @@ function matchExtraLink(
   );
   const matches = links.filter((link) => {
     const tokens = labelTokens(link.label);
-    if (tokens.length === 0 || GENERIC_LINK_LABEL_TOKENS.has(tokens.join(' '))) return false;
+    const sortedTokenKey = [...tokens].sort().join(' ');
+    if (tokens.length === 0 || GENERIC_LINK_LABEL_TOKENS.has(sortedTokenKey)) return false;
     return tokens.every((t) => signalTokens.has(t));
   });
   if (matches.length === 0) return { link: null, ambiguous: false };

--- a/apps/extension/src/lib/autofill.ts
+++ b/apps/extension/src/lib/autofill.ts
@@ -381,6 +381,20 @@ const GENERIC_LINK_LABELS = new Set([
   'portal',
 ]);
 
+/**
+ * {@link GENERIC_LINK_LABELS}, but run through {@link labelTokens} and
+ * re-joined with a single space — the same normalization the label/field
+ * matcher itself uses below. `matchExtraLink` matching is TOKEN-based (case,
+ * diacritics, and punctuation all stripped before comparison), so gating on
+ * the raw strings above would let a link labelled "Website!"/"Web-Site" slip
+ * past the denylist (its exact string isn't in the set) while still
+ * token-matching a bare "Website" field. Comparing tokenized-vs-tokenized
+ * keeps the two checks in lockstep.
+ */
+const GENERIC_LINK_LABEL_TOKENS = new Set(
+  Array.from(GENERIC_LINK_LABELS, (label) => labelTokens(label).join(' '))
+);
+
 /** Lowercase, diacritic-stripped, trimmed normalization for label matching.
  *  NFD-decomposes (é → e + ´) then strips every combining mark via the
  *  `\p{Diacritic}` Unicode property escape. */
@@ -436,10 +450,9 @@ function matchExtraLink(
       .filter(Boolean)
   );
   const matches = links.filter((link) => {
-    const norm = normalizeLabel(link.label);
-    if (!norm || GENERIC_LINK_LABELS.has(norm)) return false;
     const tokens = labelTokens(link.label);
-    return tokens.length > 0 && tokens.every((t) => signalTokens.has(t));
+    if (tokens.length === 0 || GENERIC_LINK_LABEL_TOKENS.has(tokens.join(' '))) return false;
+    return tokens.every((t) => signalTokens.has(t));
   });
   if (matches.length === 0) return { link: null, ambiguous: false };
   if (matches.length > 1) return { link: null, ambiguous: true };
@@ -546,9 +559,14 @@ export function renderSummaryOverlay(doc: Document, summary: AutofillSummary): v
   box.appendChild(title);
 
   if (summary.filledNothing) {
-    const p = doc.createElement('div');
-    p.textContent = 'No matchable fields found on this page. Nothing was changed.';
-    box.appendChild(p);
+    // Suppress this line when fields WERE skipped as ambiguous — the
+    // skipped-note below already explains the outcome; showing both reads as
+    // contradictory ("no matchable fields" + "N fields skipped").
+    if (!summary.skippedAmbiguous) {
+      const p = doc.createElement('div');
+      p.textContent = 'No matchable fields found on this page. Nothing was changed.';
+      box.appendChild(p);
+    }
   } else {
     const list = doc.createElement('div');
     for (const f of summary.filled) {

--- a/apps/extension/src/lib/bridge.test.ts
+++ b/apps/extension/src/lib/bridge.test.ts
@@ -1173,6 +1173,80 @@ describe('BridgeClient – getProfile (assisted autofill)', () => {
     client.dispose();
   });
 
+  it('round-trips extraLinks (additive/optional field) into the resolved profile', async () => {
+    const { client, socket } = await connectedClient();
+    const { profilePromise, reqId } = await startProfile(client, socket);
+
+    const payload = {
+      email: 'saeed@example.com',
+      extraLinks: [
+        { label: 'Portfolio', url: 'https://saeed.dev' },
+        { label: 'Dribbble', url: 'https://dribbble.com/saeed' },
+      ],
+    };
+    socket.simulateMessage(makeProfileEnvelope(reqId, payload));
+
+    const result = await profilePromise;
+    expect(result).toEqual(payload);
+
+    client.dispose();
+  });
+
+  it('tolerates the absence of extraLinks (old desktop reply, additive field)', async () => {
+    const { client, socket } = await connectedClient();
+    const { profilePromise, reqId } = await startProfile(client, socket);
+
+    socket.simulateMessage(makeProfileEnvelope(reqId, { email: 'saeed@example.com' }));
+
+    const result = (await profilePromise) as { email?: string; extraLinks?: unknown };
+    expect(result.email).toBe('saeed@example.com');
+    expect(result.extraLinks).toBeUndefined();
+
+    client.dispose();
+  });
+
+  it('resolves with a malformed error (never throws) when an extraLinks entry is missing url', async () => {
+    const { client, socket } = await connectedClient();
+    const { profilePromise, reqId } = await startProfile(client, socket);
+
+    socket.simulateMessage(makeProfileEnvelope(reqId, { extraLinks: [{ label: 'Portfolio' }] }));
+
+    const result = (await profilePromise) as { error?: string; extraLinks?: unknown };
+    expect(result.error).toMatch(/malformed/i);
+    expect(result.extraLinks).toBeUndefined();
+
+    client.dispose();
+  });
+
+  it('resolves with a malformed error (never throws) when extraLinks is not an array', async () => {
+    const { client, socket } = await connectedClient();
+    const { profilePromise, reqId } = await startProfile(client, socket);
+
+    socket.simulateMessage(makeProfileEnvelope(reqId, { extraLinks: 'https://saeed.dev' }));
+
+    const result = (await profilePromise) as { error?: string };
+    expect(result.error).toMatch(/malformed/i);
+
+    client.dispose();
+  });
+
+  it('resolves with a malformed error (never throws) when an extraLinks entry has a non-http(s) url', async () => {
+    const { client, socket } = await connectedClient();
+    const { profilePromise, reqId } = await startProfile(client, socket);
+
+    socket.simulateMessage(
+      makeProfileEnvelope(reqId, {
+        extraLinks: [{ label: 'Portfolio', url: 'javascript:alert(1)' }],
+      })
+    );
+
+    const result = (await profilePromise) as { error?: string; extraLinks?: unknown };
+    expect(result.error).toMatch(/malformed/i);
+    expect(result.extraLinks).toBeUndefined();
+
+    client.dispose();
+  });
+
   it('resolves with the refusal error when autofill is opted out on the desktop', async () => {
     const { client, socket } = await connectedClient();
     const { profilePromise, reqId } = await startProfile(client, socket);

--- a/apps/extension/src/lib/bridge.test.ts
+++ b/apps/extension/src/lib/bridge.test.ts
@@ -1205,15 +1205,25 @@ describe('BridgeClient – getProfile (assisted autofill)', () => {
     client.dispose();
   });
 
-  it('resolves with a malformed error (never throws) when an extraLinks entry is missing url', async () => {
+  it('drops an extraLinks entry missing url, keeping the rest of the profile', async () => {
     const { client, socket } = await connectedClient();
     const { profilePromise, reqId } = await startProfile(client, socket);
 
-    socket.simulateMessage(makeProfileEnvelope(reqId, { extraLinks: [{ label: 'Portfolio' }] }));
+    socket.simulateMessage(
+      makeProfileEnvelope(reqId, {
+        email: 'saeed@example.com',
+        extraLinks: [{ label: 'Portfolio' }],
+      })
+    );
 
-    const result = (await profilePromise) as { error?: string; extraLinks?: unknown };
-    expect(result.error).toMatch(/malformed/i);
-    expect(result.extraLinks).toBeUndefined();
+    const result = (await profilePromise) as {
+      error?: string;
+      email?: string;
+      extraLinks?: unknown;
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.email).toBe('saeed@example.com');
+    expect(result.extraLinks).toEqual([]);
 
     client.dispose();
   });
@@ -1230,19 +1240,53 @@ describe('BridgeClient – getProfile (assisted autofill)', () => {
     client.dispose();
   });
 
-  it('resolves with a malformed error (never throws) when an extraLinks entry has a non-http(s) url', async () => {
+  it('drops an extraLinks entry with a non-http(s) url, keeping the rest of the profile (never a payload-level malformed error)', async () => {
     const { client, socket } = await connectedClient();
     const { profilePromise, reqId } = await startProfile(client, socket);
 
     socket.simulateMessage(
       makeProfileEnvelope(reqId, {
+        email: 'saeed@example.com',
         extraLinks: [{ label: 'Portfolio', url: 'javascript:alert(1)' }],
       })
     );
 
-    const result = (await profilePromise) as { error?: string; extraLinks?: unknown };
-    expect(result.error).toMatch(/malformed/i);
-    expect(result.extraLinks).toBeUndefined();
+    const result = (await profilePromise) as {
+      error?: string;
+      email?: string;
+      extraLinks?: unknown;
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.email).toBe('saeed@example.com');
+    expect(result.extraLinks).toEqual([]);
+
+    client.dispose();
+  });
+
+  it('filters a mixed valid/invalid extraLinks array down to only the valid entries', async () => {
+    const { client, socket } = await connectedClient();
+    const { profilePromise, reqId } = await startProfile(client, socket);
+
+    socket.simulateMessage(
+      makeProfileEnvelope(reqId, {
+        extraLinks: [
+          { label: 'Portfolio', url: 'https://saeed.dev' },
+          { label: 'Bad Scheme', url: 'javascript:alert(1)' },
+          { label: 'Missing Url' },
+          { label: 'Dribbble', url: 'https://dribbble.com/saeed' },
+        ],
+      })
+    );
+
+    const result = (await profilePromise) as {
+      error?: string;
+      extraLinks?: { label: string; url: string }[];
+    };
+    expect(result.error).toBeUndefined();
+    expect(result.extraLinks).toEqual([
+      { label: 'Portfolio', url: 'https://saeed.dev' },
+      { label: 'Dribbble', url: 'https://dribbble.com/saeed' },
+    ]);
 
     client.dispose();
   });

--- a/apps/extension/src/lib/bridge.ts
+++ b/apps/extension/src/lib/bridge.ts
@@ -132,8 +132,11 @@ function isLinkEntry(x: unknown): x is { label: string; url: string } {
 /**
  * Hand-written guard for a `profile.result` payload (extension stays zod-free).
  * Mirrors `ExtensionProfileResultSchema`: every field is an optional string,
- * except `extraLinks` — an optional array of `{label, url}` entries, additive
- * to the payload (an old desktop's reply simply never carries the key).
+ * except `extraLinks` — an optional array, additive to the payload (an old
+ * desktop's reply simply never carries the key). Only the array shape is
+ * gated here; individual entries are validated/dropped one-by-one in
+ * {@link normalizeProfileResult} via {@link isLinkEntry} so one malformed
+ * link (e.g. a `javascript:` scheme) never rejects the whole profile.
  */
 function isExtensionProfileResult(v: unknown): v is ExtensionProfileResult {
   if (typeof v !== 'object' || v === null) return false;
@@ -147,13 +150,14 @@ function isExtensionProfileResult(v: unknown): v is ExtensionProfileResult {
     optStr(o.linkedin) &&
     optStr(o.github) &&
     optStr(o.website) &&
-    (o.extraLinks === undefined ||
-      (Array.isArray(o.extraLinks) && o.extraLinks.every(isLinkEntry))) &&
+    (o.extraLinks === undefined || Array.isArray(o.extraLinks)) &&
     optStr(o.error)
   );
 }
 
-/** Rebuild an {@link ExtensionProfileResult} from only the known, defined keys. */
+/** Rebuild an {@link ExtensionProfileResult} from only the known, defined keys.
+ *  `extraLinks` is filtered (not `.every`-gated) so a single malformed entry
+ *  is dropped rather than failing the entire profile. */
 function normalizeProfileResult(payload: unknown): ExtensionProfileResult {
   if (!isExtensionProfileResult(payload)) {
     return { error: 'The desktop app sent a malformed profile result.' };
@@ -167,7 +171,7 @@ function normalizeProfileResult(payload: unknown): ExtensionProfileResult {
   if (src.linkedin !== undefined) out.linkedin = src.linkedin;
   if (src.github !== undefined) out.github = src.github;
   if (src.website !== undefined) out.website = src.website;
-  if (src.extraLinks !== undefined) out.extraLinks = src.extraLinks;
+  if (src.extraLinks !== undefined) out.extraLinks = src.extraLinks.filter(isLinkEntry);
   if (src.error !== undefined) out.error = src.error;
   return out;
 }

--- a/apps/extension/src/lib/bridge.ts
+++ b/apps/extension/src/lib/bridge.ts
@@ -117,9 +117,23 @@ function isExtensionImportResult(v: unknown): v is ExtensionImportResult {
   );
 }
 
+/** True when `x` is a plain `{label: string, url: string}` link entry — `url`
+ *  must additionally be `http(s)://`. This is defense-in-depth against a
+ *  buggy/older desktop sending a malformed scheme (e.g. `javascript:`): the
+ *  bridge's own auth/allowlist model doesn't cover payload content, and a URL
+ *  is the one field here that gets set into a form's `value` and dispatched
+ *  as an event, so it self-defends rather than trusting the server. */
+function isLinkEntry(x: unknown): x is { label: string; url: string } {
+  if (typeof x !== 'object' || x === null) return false;
+  const o = x as Record<string, unknown>;
+  return typeof o.label === 'string' && typeof o.url === 'string' && /^https?:\/\//i.test(o.url);
+}
+
 /**
  * Hand-written guard for a `profile.result` payload (extension stays zod-free).
- * Mirrors `ExtensionProfileResultSchema`: every field is an optional string.
+ * Mirrors `ExtensionProfileResultSchema`: every field is an optional string,
+ * except `extraLinks` — an optional array of `{label, url}` entries, additive
+ * to the payload (an old desktop's reply simply never carries the key).
  */
 function isExtensionProfileResult(v: unknown): v is ExtensionProfileResult {
   if (typeof v !== 'object' || v === null) return false;
@@ -133,6 +147,8 @@ function isExtensionProfileResult(v: unknown): v is ExtensionProfileResult {
     optStr(o.linkedin) &&
     optStr(o.github) &&
     optStr(o.website) &&
+    (o.extraLinks === undefined ||
+      (Array.isArray(o.extraLinks) && o.extraLinks.every(isLinkEntry))) &&
     optStr(o.error)
   );
 }
@@ -151,6 +167,7 @@ function normalizeProfileResult(payload: unknown): ExtensionProfileResult {
   if (src.linkedin !== undefined) out.linkedin = src.linkedin;
   if (src.github !== undefined) out.github = src.github;
   if (src.website !== undefined) out.website = src.website;
+  if (src.extraLinks !== undefined) out.extraLinks = src.extraLinks;
   if (src.error !== undefined) out.error = src.error;
   return out;
 }

--- a/packages/shared/src/ipc/extension-protocol-constants.ts
+++ b/packages/shared/src/ipc/extension-protocol-constants.ts
@@ -51,7 +51,10 @@ export const EXTENSION_PROTOCOL_VERSION = 2;
  * deliberate click, not a passive/background write, exactly like the
  * existing ungated `import.request{applied:true}`; anything returning fresh
  * PII (`profile.get`) or doing billable/egress work requires a
- * desktop-enforced opt-in.
+ * desktop-enforced opt-in. `profile.result.extraLinks` (additional labelled
+ * link URLs) is fresh PII of exactly the same class as the rest of that
+ * payload (`linkedin`/`github`/`website`, …), so it rides the SAME `profile.get`
+ * opt-in gate — no separate consent surface, no protocol bump.
  */
 export const EXTENSION_MESSAGE_TYPES = {
   /** Extension → desktop: handshake step 1 — `{ protocol, clientNonce }`, no token. */
@@ -225,6 +228,14 @@ export interface ExtensionImportResult {
  * `ContactProfile.location.default`). On refusal (autofill opt-in off) or failure
  * carries `error`. These fields are transient: the extension uses them for the one
  * fill and never writes them to `chrome.storage`.
+ *
+ * `extraLinks` is fresh PII-over-the-wire exactly like the rest of this payload
+ * (a link URL, same as `linkedin`/`github`/`website`) — it rides the SAME
+ * autofill opt-in gate; there is no separate consent surface for it. Additive
+ * and optional: an old extension that has never heard of the key ignores it,
+ * and an old desktop simply never sends it, so there is no protocol bump. The
+ * desktop caps it at 10 entries and drops any entry with an empty label or a
+ * non-`http(s)` url before it is ever sent.
  */
 export interface ExtensionProfileResult {
   fullName?: string;
@@ -234,6 +245,7 @@ export interface ExtensionProfileResult {
   linkedin?: string;
   github?: string;
   website?: string;
+  extraLinks?: { label: string; url: string }[];
   /** Refusal (autofill disabled) or failure reason; present ⇒ no fields were sent. */
   error?: string;
 }

--- a/packages/shared/src/ipc/extension-protocol.test.ts
+++ b/packages/shared/src/ipc/extension-protocol.test.ts
@@ -177,6 +177,41 @@ describe('ExtensionProfileResultSchema', () => {
     expect(() => ExtensionProfileResultSchema.parse({ email: 42 })).toThrow();
   });
 
+  it('accepts a profile with extraLinks', () => {
+    const payload = {
+      email: 'x@y.z',
+      extraLinks: [
+        { label: 'Portfolio', url: 'https://saeed.dev' },
+        { label: 'Dribbble', url: 'https://dribbble.com/saeed' },
+      ],
+    };
+    expect(ExtensionProfileResultSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('accepts a profile with no extraLinks field (additive — old replies omit it)', () => {
+    expect(() => ExtensionProfileResultSchema.parse({ email: 'x@y.z' })).not.toThrow();
+    const parsed = ExtensionProfileResultSchema.parse({ email: 'x@y.z' });
+    expect(parsed.extraLinks).toBeUndefined();
+  });
+
+  it('rejects a malformed extraLinks entry (missing url)', () => {
+    expect(() =>
+      ExtensionProfileResultSchema.parse({ extraLinks: [{ label: 'Portfolio' }] })
+    ).toThrow();
+  });
+
+  it('rejects a malformed extraLinks entry (non-string label)', () => {
+    expect(() =>
+      ExtensionProfileResultSchema.parse({
+        extraLinks: [{ label: 42, url: 'https://saeed.dev' }],
+      })
+    ).toThrow();
+  });
+
+  it('rejects a non-array extraLinks', () => {
+    expect(() => ExtensionProfileResultSchema.parse({ extraLinks: 'https://saeed.dev' })).toThrow();
+  });
+
   it('carries profile.result through a valid envelope', () => {
     expect(() =>
       ExtensionEnvelopeSchema.parse({

--- a/packages/shared/src/ipc/extension-protocol.ts
+++ b/packages/shared/src/ipc/extension-protocol.ts
@@ -129,7 +129,11 @@ export const ExtensionImportResultSchema = z.object({
 /**
  * `profile.result` payload. Every profile field is optional (a sparse profile is
  * normal); `error` (present on refusal/failure) is mutually exclusive with the
- * fields in practice. Mirrors {@link ExtensionProfileResult}.
+ * fields in practice. `extraLinks` is additive/optional — absent on an old
+ * desktop's reply, ignored by an old extension — and each entry is validated as
+ * a plain `{label, url}` shape here (the non-empty-label / http(s)-url / cap-of-10
+ * rules are enforced desktop-side before the payload is ever sent). Mirrors
+ * {@link ExtensionProfileResult}.
  */
 export const ExtensionProfileResultSchema = z.object({
   fullName: z.string().optional(),
@@ -139,6 +143,7 @@ export const ExtensionProfileResultSchema = z.object({
   linkedin: z.string().optional(),
   github: z.string().optional(),
   website: z.string().optional(),
+  extraLinks: z.array(z.object({ label: z.string(), url: z.string() })).optional(),
   error: z.string().optional(),
 }) satisfies z.ZodType<ExtensionProfileResult>;
 


### PR DESCRIPTION
## Summary

Autofill v2: the extension can now fill portfolio/custom-link fields from the contact profile's `extra_links` (PR 4 of the extension roadmap; additive optional field — no new verb, no protocol bump, old desktop/extension pairs unaffected in both directions):

- **Desktop**: `AutofillProfile::from_contact` projects `extra_links` through `clean_extra_links` — a positive http(s) **allowlist** (case/whitespace/protocol-relative/unicode-lookalike vectors all fail to the safe drop path), trim, cap 10, `serde(skip_serializing_if)` so absence means the key is omitted entirely.
- **Extension matcher** (`autofill.ts`): conservative Tier-2 rule — whole-word token-subset matching (diacritic/case-insensitive, both sides), a **token-normalized** generic-label denylist (website/link/url/profile/portal…, punctuation variants included), multi-match → ambiguous skip (counted in the overlay), only `text`/`url`/untyped inputs qualify, and the named-key fallthrough is scoped to the `website` key alone — every other named key exclusively claims its field. URLs are written verbatim via the native value setter; false-negative over false-positive throughout.
- **Guard hardening**: `isLinkEntry` re-asserts the http(s) scheme extension-side (self-defending against an older/buggy desktop).
- Rides the existing autofill opt-in unchanged (same PII class as linkedin/github/website — documented in the consent-gate boundary note); fetch-fresh/never-persist discipline intact.

## Review trail (pre-PR gates)

- tauri-security-reviewer: PASS — allowlist cleaning verified against bypass vectors; no egress-gate bypass; values never touch innerHTML/href; no persistence or logging.
- extension-reviewer: its HIGH (blanket named-key fallthrough) fixed by website-only scoping; input-type restriction + denylist additions adopted.
- /review full-tier 3-pass ensemble: the surviving HIGH (punctuation-variant denylist bypass, e.g. "Website!") fixed by token-normalizing the denylist comparison; coverage gaps (one-link-two-fields, label-side diacritics) and the overlay wording nit closed.

## Test plan

- Extension: 201 tests — matcher matrix (whole-word vs substring, diacritics both sides, generic labels incl. punctuation variants, ambiguous multi-match, type restriction, website-only fallthrough, filled/hidden untouched, absence no-op), guard round-trips + malformed/javascript: entries, background arg projection, overlay rendering.
- Rust: projection tests (trim, drops, cap, key omitted when absent, camelCase when present); full crate 2210 passed; exact CI clippy clean.
- Shared: schema accept/reject suites; `gen:ipc:check` clean; whole-graph typecheck + lint:strict clean.

Part of the approved extension roadmap (PR 4 of 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Assisted autofill now supports additional labeled contact links, such as portfolio or personal website URLs.
  - Links are validated, safely filtered, and capped before being shared.
  - Autofill matches labeled links to relevant form fields while avoiding ambiguous matches.
  - Autofill summaries now indicate when fields were skipped due to ambiguous matches.
  - Existing profiles without additional links remain fully supported.

- **Bug Fixes**
  - Improved validation prevents malformed or unsafe links from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->