### PR TITLE
fix: contain model selector within its panel row

### DIFF
--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.test.tsx
@@ -340,15 +340,14 @@ describe('JobAdView — ModelSelector visibility', () => {
   // intrinsic width while its wrapper row lacked `min-w-0`. jsdom can't measure
   // layout, so this asserts the structural fix (the classes that make it
   // shrink/truncate inside its row) rather than pixels.
-  it('passes containment classes (min-w-0 flex-1) to ModelSelector so it shrinks inside the toolbar row', () => {
+  it('passes the containment class (min-w-0) to ModelSelector so it shrinks inside the toolbar row, without stretching it', () => {
     render(<JobAdView {...makeProps({ jobDesc: 'Normal full description.', hasDesc: true })} />);
     const stub = screen.getByTestId('model-selector-stub');
-    expect(stub.className).toContain('min-w-0');
-    expect(stub.className).toContain('flex-1');
-    expect(stub.className).not.toContain('shrink-0');
+    expect(stub).toHaveClass('min-w-0');
+    expect(stub).not.toHaveClass('shrink-0', 'flex-1');
     // Its immediate row wrapper must also allow shrinking, or the fix on
     // ModelSelector alone can't stop the row itself from overflowing.
-    expect(stub.parentElement?.className).toContain('min-w-0');
+    expect(stub.parentElement).toHaveClass('min-w-0');
   });
 });
 

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.test.tsx
@@ -36,8 +36,12 @@ vi.mock('@ajh/translations', () => ({
 // The real component pulls React Query + AppClient; a stub that renders a
 // sentinel element is sufficient to assert it mounts on the summary tab.
 
+// className is forwarded so the containment test below can assert it — the
+// real component applies `className` to its own root div.
 vi.mock('@/components/ui/ModelSelector', () => ({
-  ModelSelector: () => <div data-testid="model-selector-stub" />,
+  ModelSelector: ({ className }: { className?: string }) => (
+    <div data-testid="model-selector-stub" className={className} />
+  ),
 }));
 
 // ── ExternalLink — thin anchor wrapper, no special provider needed ─────────────
@@ -329,6 +333,22 @@ describe('JobAdView — ModelSelector visibility', () => {
     // Switch to source tab.
     await userEvent.click(screen.getByText('autopilot.apply.tabs.jobAd'));
     expect(screen.queryByTestId('model-selector-stub')).not.toBeInTheDocument();
+  });
+
+  // Regression: the model dropdown + guidance line used to overflow the card's
+  // right edge because `shrink-0` on ModelSelector pinned it to its full
+  // intrinsic width while its wrapper row lacked `min-w-0`. jsdom can't measure
+  // layout, so this asserts the structural fix (the classes that make it
+  // shrink/truncate inside its row) rather than pixels.
+  it('passes containment classes (min-w-0 flex-1) to ModelSelector so it shrinks inside the toolbar row', () => {
+    render(<JobAdView {...makeProps({ jobDesc: 'Normal full description.', hasDesc: true })} />);
+    const stub = screen.getByTestId('model-selector-stub');
+    expect(stub.className).toContain('min-w-0');
+    expect(stub.className).toContain('flex-1');
+    expect(stub.className).not.toContain('shrink-0');
+    // Its immediate row wrapper must also allow shrinking, or the fix on
+    // ModelSelector alone can't stop the row itself from overflowing.
+    expect(stub.parentElement?.className).toContain('min-w-0');
   });
 });
 

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
@@ -112,9 +112,9 @@ export function JobAdView({
               size="sm"
             />
             {/* `min-w-0` lets it shrink below its content (model label + guidance
-                line) instead of pushing past the card edge; `flex-1` gives it the
-                remaining row space so the language dropdown stays compact. */}
-            <ModelSelector className="min-w-0 flex-1" />
+                line) instead of pushing past the card edge; no `flex-1` — that would
+                also stretch it to fill the row on wide cards, beyond this bug fix. */}
+            <ModelSelector className="min-w-0" />
           </div>
         )}
       </div>

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
@@ -98,7 +98,7 @@ export function JobAdView({
           ariaLabel={t('autopilot.apply.jobAdView.label')}
         />
         {tab === 'summary' && (
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2">
             {/* Explicit label bound to the trigger (id) — visually redundant with
                 the selected language, so sr-only keeps the toolbar uncluttered. */}
             <label htmlFor="job-ad-summary-language" className="sr-only">
@@ -111,7 +111,10 @@ export function JobAdView({
               options={languageOptions}
               size="sm"
             />
-            <ModelSelector className="min-w-0 shrink-0" />
+            {/* `min-w-0` lets it shrink below its content (model label + guidance
+                line) instead of pushing past the card edge; `flex-1` gives it the
+                remaining row space so the language dropdown stays compact. */}
+            <ModelSelector className="min-w-0 flex-1" />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

User-reported rendering bug: on the Application detail page → Documents → Job ad view, the AI model picker overflowed the card's right edge and its guidance line was clipped off-screen.

Root cause: `JobAdView.tsx` passed `className="min-w-0 shrink-0"` to `ModelSelector` — `shrink-0` pins the flex item to its full intrinsic width (model label + guidance sentence), overriding `min-w-0`, and the wrapper row also lacked `min-w-0`, so the selector pushed past the card edge instead of shrinking. Only this composition squeezes `ModelSelector` against siblings in a flex row; the other three call sites render it in plain block containers and are unaffected.

Fix (2 lines, one file): wrapper row gains `min-w-0`; the selector becomes `min-w-0 flex-1`. Its internal dropdown already truncates and the guidance line already wraps — they just needed a container that can actually shrink. Regression test asserts the containment classes on both nodes (jsdom can't measure layout; the structural fix is pinned).

## Test plan

- 2312 renderer tests green (including the new containment regression test); typecheck + lint:strict clean.
- Other `ModelSelector` usages (AnalyzeLeftPanel, ReferralModal, StepModel) pass no `className` and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Summary toolbar layout to prevent the language and model selector row from overflowing its container.
  * Updated the model selector to resize appropriately within available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->