### PR TITLE
feat: capture filled application answers from the extension

### DIFF
--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -614,7 +614,13 @@ impl ApplicationStore {
             }
         };
 
-        if let Some(existing) = self.find_by_job_url(normalized) {
+        // Lookup + write share ONE lock/transaction (`row_by_job_url_conn`, not
+        // self-locking `find_by_job_url`) — the old separately-released lookup
+        // lock left a gap where a concurrent `merge_answers` commit got clobbered.
+        let mut guard = self.conn.lock();
+        let tx = guard.transaction()?;
+
+        if let Some(existing) = Self::row_by_job_url_conn(&tx, normalized)? {
             let now = now_ms();
             let (status, new_applied_at) = if existing.status.is_pre_apply() && applied_at.is_some()
             {
@@ -659,11 +665,7 @@ impl ApplicationStore {
                     .clone()
                     .or_else(|| existing.salary_currency.clone()),
             };
-            // Row write + the (conditional) status event in ONE transaction so an
-            // upsert that changes status can never persist the row without its
-            // history event. `.transaction()` needs `&mut Connection`.
-            let mut guard = self.conn.lock();
-            let tx = guard.transaction()?;
+            // Row write + status event share the transaction opened above.
             Self::write_row_conn(&tx, &app)?;
             if status != existing.status {
                 Self::append_event_conn(
@@ -716,9 +718,7 @@ impl ApplicationStore {
             salary_max: meta.salary_max,
             salary_currency: meta.salary_currency.clone(),
         };
-        // New Application: the row + its seed status event in ONE transaction.
-        let mut guard = self.conn.lock();
-        let tx = guard.transaction()?;
+        // New row: its seed status event shares the same transaction.
         Self::write_row_conn(&tx, &app)?;
         Self::append_event_conn(&tx, &app.id, "", status.as_id(), "", now)?;
         tx.commit()?;
@@ -1106,6 +1106,19 @@ impl ApplicationStore {
         use rusqlite::OptionalExtension;
         let mut stmt = conn.prepare(&format!("{SELECT_COLS} WHERE id = ?1"))?;
         Ok(stmt.query_row(params![id], row_to_application).optional()?)
+    }
+
+    /// `find_by_job_url` sibling for [`Self::upsert_internal`] (self-locking here would deadlock).
+    fn row_by_job_url_conn(conn: &Connection, normalized: &str) -> AppResult<Option<Application>> {
+        use rusqlite::OptionalExtension;
+        if normalized.is_empty() {
+            return Ok(None);
+        }
+        let sql = format!("{SELECT_COLS} WHERE job_url = ?1 ORDER BY created_at DESC LIMIT 1");
+        let mut stmt = conn.prepare(&sql)?;
+        Ok(stmt
+            .query_row(params![normalized], row_to_application)
+            .optional()?)
     }
 
     /// Connection-scoped status-event append, callable inside a transaction.

--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -139,6 +139,13 @@ pub struct ApplicationMeta {
     pub candidate: String,
     pub brief: String,
     pub job_description: String,
+    /// Merged by QUESTION rather than wholesale-replaced like the scalar
+    /// fields above — see [`ApplicationStore::merge_answers_by_question`]
+    /// (this struct's merge path, used by every in-app writer) vs
+    /// [`ApplicationStore::merge_answers`] (the extension's separate
+    /// append-only capture path). A non-empty `answers` here (re)writes
+    /// matching questions and adds new ones; it never drops an existing
+    /// answer for a question this call doesn't mention.
     pub answers: Vec<ApplicationAnswer>,
     pub job_summary: String,
     /// Scraped salary range (Adzuna only, today) — grounds the salary application
@@ -160,12 +167,15 @@ pub struct ApplicationMeta {
 pub(crate) const MAX_JOB_DESCRIPTION_BYTES: usize = 200_000;
 
 /// Hard cap on the total number of `answers` entries [`ApplicationStore::merge_answers`]
-/// will store per application. `answers.save`'s per-call cap
+/// / [`ApplicationStore::merge_answers_by_question`] will store per
+/// application. `answers.save`'s per-call cap
 /// (`extension_bridge::answers_save::MAX_ANSWERS_PER_CALL`) only bounds one
 /// capture; this bounds the CUMULATIVE total across every capture on the same
 /// application, so repeated captures (or a hostile/buggy collector called many
-/// times) can't grow the stored list unboundedly.
-const MAX_TOTAL_ANSWERS: usize = 500;
+/// times) can't grow the stored list unboundedly. `pub(crate)` so
+/// `extension_bridge`'s tests can seed right up to the cap without
+/// duplicating the literal.
+pub(crate) const MAX_TOTAL_ANSWERS: usize = 500;
 
 /// Clamp a job description to at most `MAX_JOB_DESCRIPTION_BYTES` bytes, cutting on
 /// a UTF-8 char boundary so the stored text is always valid UTF-8. Truncate (never
@@ -583,7 +593,8 @@ impl ApplicationStore {
     /// Core upsert: `normalized` is already normalized; `applied_at` Some marks the
     /// Application `applied`, None keeps it `saved`. Merges into an existing row
     /// when the (non-empty) url already has an Application; only ever advances OUT
-    /// of `saved`, never demotes an applied+ row.
+    /// of `saved`, never demotes an applied+ row. `answers` merge by QUESTION via
+    /// [`Self::merge_answers_by_question`] — not a wholesale replace.
     fn upsert_internal(
         &self,
         normalized: &str,
@@ -614,11 +625,8 @@ impl ApplicationStore {
             } else {
                 (existing.status, existing.applied_at)
             };
-            let answers = if meta.answers.is_empty() {
-                existing.answers.clone()
-            } else {
-                meta.answers.clone()
-            };
+            let answers =
+                Self::merge_answers_by_question(existing.answers.clone(), meta.answers.clone());
             let app = Application {
                 id: existing.id.clone(),
                 status,
@@ -811,11 +819,16 @@ impl ApplicationStore {
     /// list — an APPEND-only dedup merge, `pub(crate)` so the extension
     /// bridge's `answers.save` handler
     /// (`extension_bridge::answers_save::resolve_answers_save`) is the first
-    /// caller. Deliberately independent of `upsert_internal`'s meta-merge
-    /// path — that path REPLACES `answers` wholesale
-    /// (`meta.answers.is_empty() ? existing : meta.answers`), which would
-    /// silently drop every prior answer the first time an answers-bearing
-    /// upsert ran again; this method only ever ADDS.
+    /// caller. Deliberately independent of
+    /// [`Self::merge_answers_by_question`] (`upsert_internal`'s meta-merge
+    /// path, used by every in-app writer — `ai_generations_save`, manual
+    /// edits, legacy-generation backfill): that path lets `incoming` win for
+    /// a matching question, because those writers legitimately re-save
+    /// EDITED text for a question the user already answered. THIS method
+    /// must never do that — a stray/duplicate extension re-capture of the
+    /// same page must never clobber an answer the user already reviewed —
+    /// so here the EXISTING answer always wins and only genuinely new
+    /// questions are appended.
     ///
     /// Dedup key: the NORMALIZED question text (trim + lowercase + collapse
     /// internal whitespace runs) compared against the CURRENT answers — an
@@ -886,6 +899,57 @@ impl ApplicationStore {
         }
         tx.commit()?;
         Ok(added)
+    }
+
+    /// Merge `incoming` onto `existing` by NORMALIZED question text —
+    /// `upsert_internal`'s `answers` merge path, used on every in-app
+    /// writer's re-upsert (`ai_generations_save`'s AI-generated answer set,
+    /// `track_manual`, the legacy-generation backfill). Unlike
+    /// [`Self::merge_answers`] (the extension's separate append-only
+    /// capture path, where an EXISTING answer always wins), here `incoming`
+    /// wins for a matching question: `ai_generations_save` re-saves the
+    /// CURRENT full answer set on every call, including in-app edits to a
+    /// question the user already answered, and "existing wins" would
+    /// silently discard that edit. Existing answers for a question NOT
+    /// present in `incoming` are preserved untouched — this is what fixes
+    /// the previous wholesale-replace data-loss hazard, where a non-empty
+    /// `meta.answers` simply became the whole stored list, dropping every
+    /// answer another writer (e.g. the extension's `answers.save`) had
+    /// appended in between. An empty `incoming` is a no-op. Same
+    /// [`MAX_TOTAL_ANSWERS`] cap as `merge_answers`; entries beyond the cap
+    /// are dropped.
+    fn merge_answers_by_question(
+        existing: Vec<ApplicationAnswer>,
+        incoming: Vec<ApplicationAnswer>,
+    ) -> Vec<ApplicationAnswer> {
+        if incoming.is_empty() {
+            return existing;
+        }
+        let incoming_keys: std::collections::HashSet<String> = incoming
+            .iter()
+            .map(|a| normalize_question(&a.question))
+            .filter(|k| !k.is_empty())
+            .collect();
+        // Existing answers survive as-is unless `incoming` carries a
+        // (re)answer for the same question — those are dropped here and
+        // replaced below.
+        let mut merged: Vec<ApplicationAnswer> = existing
+            .into_iter()
+            .filter(|a| !incoming_keys.contains(&normalize_question(&a.question)))
+            .collect();
+
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for ans in incoming {
+            if merged.len() >= MAX_TOTAL_ANSWERS {
+                break; // per-application cap — remaining incoming entries are dropped
+            }
+            let key = normalize_question(&ans.question);
+            if key.is_empty() || !seen.insert(key) {
+                continue; // blank question, or a duplicate within this same incoming batch
+            }
+            merged.push(ans);
+        }
+        merged
     }
 
     /// Patch the user-editable tracking fields. Each `None` leaves its field

--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -921,8 +921,14 @@ impl ApplicationStore {
     /// `meta.answers` simply became the whole stored list, dropping every
     /// answer another writer (e.g. the extension's `answers.save`) had
     /// appended in between. An empty `incoming` is a no-op. Same
-    /// [`MAX_TOTAL_ANSWERS`] cap as `merge_answers`; entries beyond the cap
-    /// are dropped.
+    /// [`MAX_TOTAL_ANSWERS`] cap as `merge_answers`, but the cap only ever
+    /// blocks a genuinely NEW question: a same-question replacement is a
+    /// swap for an entry already removed from `merged` below, so it is
+    /// always applied regardless of the cap — otherwise a legacy row that
+    /// already sits at/over the cap (seeded before this cap existed) would
+    /// have the matching existing answer removed to make room, then the cap
+    /// check block the incoming replacement from ever being pushed back in,
+    /// making the question vanish entirely instead of being rewritten.
     fn merge_answers_by_question(
         existing: Vec<ApplicationAnswer>,
         incoming: Vec<ApplicationAnswer>,
@@ -930,6 +936,10 @@ impl ApplicationStore {
         if incoming.is_empty() {
             return existing;
         }
+        let existing_keys: std::collections::HashSet<String> = existing
+            .iter()
+            .map(|a| normalize_question(&a.question))
+            .collect();
         let incoming_keys: std::collections::HashSet<String> = incoming
             .iter()
             .map(|a| normalize_question(&a.question))
@@ -945,12 +955,16 @@ impl ApplicationStore {
 
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         for ans in incoming {
-            if merged.len() >= MAX_TOTAL_ANSWERS {
-                break; // per-application cap — remaining incoming entries are dropped
-            }
             let key = normalize_question(&ans.question);
-            if key.is_empty() || !seen.insert(key) {
+            if key.is_empty() || !seen.insert(key.clone()) {
                 continue; // blank question, or a duplicate within this same incoming batch
+            }
+            // A same-question replacement always wins (see doc comment above);
+            // only a brand-new question is subject to the cap. `continue`
+            // (not `break`) so a later replacement in this same batch still
+            // gets applied even after a run of new-question entries hit it.
+            if !existing_keys.contains(&key) && merged.len() >= MAX_TOTAL_ANSWERS {
+                continue; // per-application cap — this new-question entry is dropped
             }
             merged.push(ans);
         }

--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -159,6 +159,14 @@ pub struct ApplicationMeta {
 // of hardcoding a second literal.
 pub(crate) const MAX_JOB_DESCRIPTION_BYTES: usize = 200_000;
 
+/// Hard cap on the total number of `answers` entries [`ApplicationStore::merge_answers`]
+/// will store per application. `answers.save`'s per-call cap
+/// (`extension_bridge::answers_save::MAX_ANSWERS_PER_CALL`) only bounds one
+/// capture; this bounds the CUMULATIVE total across every capture on the same
+/// application, so repeated captures (or a hostile/buggy collector called many
+/// times) can't grow the stored list unboundedly.
+const MAX_TOTAL_ANSWERS: usize = 500;
+
 /// Clamp a job description to at most `MAX_JOB_DESCRIPTION_BYTES` bytes, cutting on
 /// a UTF-8 char boundary so the stored text is always valid UTF-8. Truncate (never
 /// reject): an over-cap import is clamped, not dropped.
@@ -799,6 +807,87 @@ impl ApplicationStore {
         Ok(true)
     }
 
+    /// Append newly-captured extension answers onto Application `id`'s answer
+    /// list — an APPEND-only dedup merge, `pub(crate)` so the extension
+    /// bridge's `answers.save` handler
+    /// (`extension_bridge::answers_save::resolve_answers_save`) is the first
+    /// caller. Deliberately independent of `upsert_internal`'s meta-merge
+    /// path — that path REPLACES `answers` wholesale
+    /// (`meta.answers.is_empty() ? existing : meta.answers`), which would
+    /// silently drop every prior answer the first time an answers-bearing
+    /// upsert ran again; this method only ever ADDS.
+    ///
+    /// Dedup key: the NORMALIZED question text (trim + lowercase + collapse
+    /// internal whitespace runs) compared against the CURRENT answers — an
+    /// existing answer for a given question always wins and is NEVER
+    /// overwritten, so a re-capture of the same page only ever adds
+    /// genuinely new questions. The dedup set also accumulates across
+    /// `incoming` itself, so two same-normalized entries in one call collapse
+    /// to a single added answer rather than two. A blank (post-trim) question
+    /// is dropped.
+    ///
+    /// The dedup READ and the WRITE happen in the SAME transaction (via
+    /// [`Self::row_by_id_conn`], not the self-locking [`Self::get`] — calling
+    /// `get` here would deadlock the non-reentrant `parking_lot::Mutex`), so
+    /// there is no earlier separate read a concurrent caller could race
+    /// against; only `answers` + `updated_at` are touched. Returns the count
+    /// of NEWLY ADDED answers (`0` when every captured question was already
+    /// present or blank).
+    ///
+    /// Capped at [`MAX_TOTAL_ANSWERS`] merged answers per application: once
+    /// that many are stored, further incoming entries are dropped rather than
+    /// appended (they count toward the caller's `skipped`, same as a dedup
+    /// hit — never rejected outright).
+    pub(crate) fn merge_answers(
+        &self,
+        id: &str,
+        incoming: Vec<ApplicationAnswer>,
+    ) -> AppResult<usize> {
+        let mut guard = self.conn.lock();
+        let tx = guard.transaction()?;
+
+        let existing = Self::row_by_id_conn(&tx, id)?
+            .ok_or_else(|| AppError::Validation(format!("application not found: {id}")))?;
+
+        let mut seen: std::collections::HashSet<String> = existing
+            .answers
+            .iter()
+            .map(|a| normalize_question(&a.question))
+            .collect();
+
+        let mut merged = existing.answers;
+        let mut added = 0usize;
+        for ans in incoming {
+            if merged.len() >= MAX_TOTAL_ANSWERS {
+                break; // per-application cap hit — remaining entries count as skipped
+            }
+            let key = normalize_question(&ans.question);
+            if key.is_empty() || !seen.insert(key) {
+                continue; // blank question, or an existing answer already wins
+            }
+            merged.push(ApplicationAnswer {
+                id: make_answer_id(),
+                question: ans.question,
+                answer: ans.answer,
+            });
+            added += 1;
+        }
+
+        if added > 0 {
+            // `?` (not `.unwrap_or_else(|_| "[]".into())`): a serialize failure
+            // must abort the transaction (never committed, so the existing
+            // `answers` column is untouched) rather than writing an empty `[]`
+            // that would silently wipe every previously-stored answer.
+            let answers_json = serde_json::to_string(&merged)?;
+            tx.execute(
+                "UPDATE applications SET answers = ?2, updated_at = ?3 WHERE id = ?1",
+                params![id, answers_json, ts_to_db(now_ms())],
+            )?;
+        }
+        tx.commit()?;
+        Ok(added)
+    }
+
     /// Patch the user-editable tracking fields. Each `None` leaves its field
     /// unchanged; bumps `updated_at` whenever called.
     #[allow(clippy::too_many_arguments)]
@@ -922,6 +1011,18 @@ impl ApplicationStore {
             ],
         )?;
         Ok(())
+    }
+
+    /// Connection-scoped single-row read by id, callable inside an existing
+    /// lock/transaction — unlike [`Self::get`] (which takes its OWN lock;
+    /// calling `get` while already holding `self.conn.lock()` would deadlock
+    /// the non-reentrant `parking_lot::Mutex`). Used by
+    /// [`Self::merge_answers`] so its dedup read and its write land in the
+    /// exact same transaction.
+    fn row_by_id_conn(conn: &Connection, id: &str) -> AppResult<Option<Application>> {
+        use rusqlite::OptionalExtension;
+        let mut stmt = conn.prepare(&format!("{SELECT_COLS} WHERE id = ?1"))?;
+        Ok(stmt.query_row(params![id], row_to_application).optional()?)
     }
 
     /// Connection-scoped status-event append, callable inside a transaction.
@@ -1132,6 +1233,25 @@ fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> String {
 
 pub fn make_application_id() -> String {
     format!("app-{}-{}", now_ms(), &Uuid::new_v4().to_string()[..8])
+}
+
+/// Fresh id for an answer merged in by [`ApplicationStore::merge_answers`] —
+/// same shape as [`make_application_id`].
+fn make_answer_id() -> String {
+    format!("ans-{}-{}", now_ms(), &Uuid::new_v4().to_string()[..8])
+}
+
+/// Normalize a question for dedup comparison in
+/// [`ApplicationStore::merge_answers`]: trim, lowercase, and collapse
+/// internal whitespace runs to a single space — so "Why  this role?" and
+/// "why this role?" (a different capture pass / incidental whitespace) dedup
+/// to the same key.
+fn normalize_question(q: &str) -> String {
+    q.trim()
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 impl DataStore for ApplicationStore {

--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -696,7 +696,12 @@ impl ApplicationStore {
             company: meta.company.clone(),
             title: meta.title.clone(),
             candidate: meta.candidate.clone(),
-            answers: meta.answers.clone(),
+            // Route the new-row branch through the same capped+deduped merge as an
+            // existing-row update (against an empty existing list) so a caller
+            // handing `upsert_for_origin` an oversized/duplicate-question
+            // `meta.answers` on FIRST creation can't bypass `MAX_TOTAL_ANSWERS` the
+            // way storing `meta.answers` verbatim did.
+            answers: Self::merge_answers_by_question(Vec::new(), meta.answers.clone()),
             brief: meta.brief.clone(),
             job_description: clamped_jd.to_string(),
             notes: String::new(),

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -2278,4 +2278,108 @@ fn merge_answers_caps_total_stored_answers_and_drops_the_rest() {
         MAX_TOTAL_ANSWERS,
         "total stored answers never exceeds the per-application cap"
     );
+    // A seeded answer (by content, not just count) must survive the cap
+    // untouched — the cap drops INCOMING overflow, never existing rows.
+    let seeded = app
+        .answers
+        .iter()
+        .find(|a| a.id == "seed-0")
+        .expect("a seeded answer must survive the cap by id");
+    assert_eq!(seeded.question, "Existing question 0?");
+    assert_eq!(seeded.answer, "Existing answer 0");
+}
+
+/// Regression for the HIGH cross-feature data-loss hazard: `upsert_internal`'s
+/// meta-merge path used to REPLACE `answers` wholesale, so an
+/// `ai_generations_save`-shaped upsert (a non-empty `meta.answers`) silently
+/// wiped every answer the extension's `answers.save` had appended in
+/// between. Seed extension-captured answers via `merge_answers`, then run an
+/// `upsert_for_origin` carrying a DIFFERENT non-empty answer set (one
+/// matching an existing question, one genuinely new) and assert: the
+/// extension-only answer survives, the matching question's text is updated
+/// to the incoming (AI) text, and the new AI answer is added.
+#[test]
+fn upsert_for_origin_merges_answers_by_question_instead_of_replacing() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let url = "https://acme.com/job/merge/cross-feature";
+    let id = store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &meta("Acme", "Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    // Extension-captured answers land first, via the append-only path.
+    store
+        .merge_answers(
+            &id,
+            vec![
+                ApplicationAnswer {
+                    id: String::new(),
+                    question: "Why this role?".to_string(),
+                    answer: "Extension-captured original".to_string(),
+                },
+                ApplicationAnswer {
+                    id: String::new(),
+                    question: "Are you willing to relocate?".to_string(),
+                    answer: "Extension-only, no AI equivalent".to_string(),
+                },
+            ],
+        )
+        .unwrap();
+
+    // Simulates `ai_generations_save`: a full generated answer set, one
+    // question matching an existing extension answer (an in-app rewrite),
+    // one genuinely new.
+    let mut ai_meta = meta("Acme", "Engineer");
+    ai_meta.answers = vec![
+        ApplicationAnswer {
+            id: String::new(),
+            question: "Why this role?".to_string(),
+            answer: "AI-rewritten answer".to_string(),
+        },
+        ApplicationAnswer {
+            id: String::new(),
+            question: "What's your expected salary?".to_string(),
+            answer: "100k".to_string(),
+        },
+    ];
+    store
+        .upsert_for_origin(url, "linkedin", &ai_meta, ApplicationOrigin::Generate, None)
+        .unwrap();
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(
+        app.answers.len(),
+        3,
+        "all 3 distinct questions must be present"
+    );
+
+    let relocate = app
+        .answers
+        .iter()
+        .find(|a| a.question == "Are you willing to relocate?")
+        .expect("the extension-only answer must survive the AI upsert");
+    assert_eq!(relocate.answer, "Extension-only, no AI equivalent");
+
+    let rewritten = app
+        .answers
+        .iter()
+        .find(|a| a.question == "Why this role?")
+        .expect("the matching question must still be present");
+    assert_eq!(
+        rewritten.answer, "AI-rewritten answer",
+        "a matching question must be updated to the incoming text"
+    );
+
+    assert!(
+        app.answers
+            .iter()
+            .any(|a| a.question == "What's your expected salary?" && a.answer == "100k"),
+        "a genuinely new AI answer must be added"
+    );
 }

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -2289,6 +2289,90 @@ fn merge_answers_caps_total_stored_answers_and_drops_the_rest() {
     assert_eq!(seeded.answer, "Existing answer 0");
 }
 
+/// HIGH regression: when `existing.answers` already sits AT or OVER
+/// `MAX_TOTAL_ANSWERS` (a legacy row seeded before the on-creation cap
+/// shipped), `merge_answers_by_question` used to remove the matching existing
+/// answer from `merged` to make room for the incoming replacement, then the
+/// cap check unconditionally blocked that same replacement from ever being
+/// pushed back in — the question vanished entirely instead of being
+/// rewritten. Seed a row with `MAX_TOTAL_ANSWERS + 1` answers via a raw SQL
+/// UPDATE (bypassing the store's own cap enforcement, simulating a legacy
+/// row), then upsert one incoming answer matching an existing question: it
+/// must survive with the incoming text, and the total must not grow.
+#[test]
+fn merge_answers_by_question_swaps_a_replacement_even_when_existing_is_already_over_cap() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let url = "https://acme.com/job/merge/over-cap-swap";
+    let id = store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &meta("Acme", "Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    // Seed MAX_TOTAL_ANSWERS + 1 distinct answers directly via raw SQL — a
+    // legacy shape the on-creation cap (which runs on every upsert today)
+    // would never itself produce, but a pre-existing over-cap row must still
+    // be handled safely.
+    let seeded: Vec<ApplicationAnswer> = (0..MAX_TOTAL_ANSWERS + 1)
+        .map(|i| ApplicationAnswer {
+            id: format!("seed-{i}"),
+            question: format!("Existing question {i}?"),
+            answer: format!("Existing answer {i}"),
+        })
+        .collect();
+    {
+        let conn = Connection::open(dir.path().join("applications.db")).unwrap();
+        conn.execute(
+            "UPDATE applications SET answers = ?1 WHERE id = ?2",
+            rusqlite::params![serde_json::to_string(&seeded).unwrap(), id],
+        )
+        .unwrap();
+    }
+
+    // Re-upsert with one incoming answer matching an existing question (a
+    // rewrite) — no genuinely new question, so this exercises the swap path
+    // alone.
+    let mut m = meta("Acme", "Engineer");
+    m.answers = vec![ApplicationAnswer {
+        id: String::new(),
+        question: "Existing question 0?".to_string(),
+        answer: "Rewritten answer".to_string(),
+    }];
+    let id2 = store
+        .upsert_for_origin(url, "linkedin", &m, ApplicationOrigin::Saved, None)
+        .unwrap();
+    assert_eq!(id, id2, "same url merges into the same Application");
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(
+        app.answers.len(),
+        MAX_TOTAL_ANSWERS + 1,
+        "a same-question swap must not grow (or shrink) an already over-cap row"
+    );
+    let swapped = app
+        .answers
+        .iter()
+        .find(|a| a.question == "Existing question 0?")
+        .expect("the matching question must survive the swap, not vanish");
+    assert_eq!(
+        swapped.answer, "Rewritten answer",
+        "the incoming replacement must win, not silently disappear"
+    );
+    assert_eq!(
+        app.answers
+            .iter()
+            .filter(|a| a.question != "Existing question 0?")
+            .count(),
+        MAX_TOTAL_ANSWERS,
+        "every other seeded answer must be untouched"
+    );
+}
+
 /// MEDIUM fix: `upsert_internal`'s NEW-ROW branch used to store `meta.answers`
 /// verbatim, bypassing `MAX_TOTAL_ANSWERS` entirely (only the existing-row merge
 /// branch enforced it). Creating a brand-new Application (no prior row for the

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -2533,3 +2533,104 @@ fn upsert_for_origin_merges_answers_by_question_instead_of_replacing() {
         "a genuinely new AI answer must be added"
     );
 }
+
+/// Regression proxy for the upsert/`merge_answers` TOCTOU fix:
+/// `upsert_internal` used to look up the existing row via the self-locking
+/// `find_by_job_url` (its own lock acquired and released BEFORE the write
+/// transaction re-acquired the lock), leaving a gap where a concurrent
+/// `merge_answers` commit could be silently overwritten by the upsert's
+/// stale pre-gap snapshot. The fix folds both into one lock/transaction via
+/// `row_by_job_url_conn`.
+///
+/// A deterministic reproduction of the OLD race isn't feasible here: its
+/// window was the interval between two `Mutex` acquisitions inside a single
+/// call, on the order of nanoseconds, and hitting it reliably would need a
+/// test-only pause hook inside `upsert_internal` — production-code scope
+/// creep beyond this fix. As an honest proxy, this test instead hammers the
+/// SAME Application from two real threads — one repeatedly appending via
+/// `merge_answers`, the other repeatedly upserting via `upsert_for_origin` —
+/// each iteration contributing one distinct, individually-traceable
+/// question, and asserts every single one survives. With the fix, the
+/// lookup+write critical section is atomic under the shared lock, so no
+/// interleaving can lose an update; this test would be flaky (and could
+/// fail) against the old two-lock structure under real contention.
+#[test]
+fn upsert_and_merge_answers_race_never_loses_an_update() {
+    let dir = TempDir::new().unwrap();
+    let store = std::sync::Arc::new(ApplicationStore::open(dir.path()).unwrap());
+    let url = "https://acme.com/job/race";
+    let id = store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &meta("Acme", "Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    const ITERS: usize = 40;
+
+    let merge_store = store.clone();
+    let merge_id = id.clone();
+    let merge_thread = std::thread::spawn(move || {
+        for i in 0..ITERS {
+            merge_store
+                .merge_answers(
+                    &merge_id,
+                    vec![ApplicationAnswer {
+                        id: String::new(),
+                        question: format!("merge-question-{i}"),
+                        answer: format!("merge-answer-{i}"),
+                    }],
+                )
+                .unwrap();
+        }
+    });
+
+    let upsert_store = store.clone();
+    let upsert_url = url.to_string();
+    let upsert_thread = std::thread::spawn(move || {
+        for i in 0..ITERS {
+            let mut m = meta("Acme", "Engineer");
+            m.answers = vec![ApplicationAnswer {
+                id: String::new(),
+                question: format!("upsert-question-{i}"),
+                answer: format!("upsert-answer-{i}"),
+            }];
+            upsert_store
+                .upsert_for_origin(
+                    &upsert_url,
+                    "linkedin",
+                    &m,
+                    ApplicationOrigin::Generate,
+                    None,
+                )
+                .unwrap();
+        }
+    });
+
+    merge_thread.join().unwrap();
+    upsert_thread.join().unwrap();
+
+    let app = store.get(&id).unwrap();
+    for i in 0..ITERS {
+        assert!(
+            app.answers
+                .iter()
+                .any(|a| a.question == format!("merge-question-{i}")),
+            "merge_answers entry {i} was lost to a concurrent upsert"
+        );
+        assert!(
+            app.answers
+                .iter()
+                .any(|a| a.question == format!("upsert-question-{i}")),
+            "upsert entry {i} was lost to a concurrent merge_answers"
+        );
+    }
+    assert_eq!(
+        app.answers.len(),
+        ITERS * 2,
+        "no answer from either concurrent writer may be dropped"
+    );
+}

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -2047,3 +2047,235 @@ fn salary_fields_persist_merge_and_export_import_round_trip() {
     assert_eq!(imported.salary_max, Some(90_000.0));
     assert_eq!(imported.salary_currency, Some("EUR".to_string()));
 }
+
+// ── merge_answers (extension bridge `answers.save`'s store-write boundary) ────
+// APPEND-only dedup merge — deliberately NOT `upsert_internal`'s meta path
+// (which REPLACES `answers` wholesale). See `extension_bridge::answers_save`
+// for the caller.
+
+#[test]
+fn merge_answers_adds_new_answers_and_returns_count() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let id = store
+        .upsert_for_origin(
+            "https://acme.com/job/merge/1",
+            "linkedin",
+            &meta("Acme", "Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let added = store
+        .merge_answers(
+            &id,
+            vec![
+                ApplicationAnswer {
+                    id: String::new(),
+                    question: "Why this role?".to_string(),
+                    answer: "Because I love it.".to_string(),
+                },
+                ApplicationAnswer {
+                    id: String::new(),
+                    question: "Salary expectation?".to_string(),
+                    answer: "100k".to_string(),
+                },
+            ],
+        )
+        .unwrap();
+    assert_eq!(added, 2);
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(app.answers.len(), 2);
+    // Each merged answer gets a fresh, non-empty generated id.
+    assert!(app.answers.iter().all(|a| !a.id.is_empty()));
+}
+
+#[test]
+fn merge_answers_dedups_by_normalized_question_and_never_overwrites() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let mut m = meta("Acme", "Engineer");
+    m.answers = vec![ApplicationAnswer {
+        id: "seed-1".to_string(),
+        question: "Why this role?".to_string(),
+        answer: "Original".to_string(),
+    }];
+    let id = store
+        .upsert_for_origin(
+            "https://acme.com/job/merge/2",
+            "linkedin",
+            &m,
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    // A re-capture with different whitespace/case for the SAME question, plus
+    // one genuinely new question.
+    let added = store
+        .merge_answers(
+            &id,
+            vec![
+                ApplicationAnswer {
+                    id: String::new(),
+                    question: "  WHY this   role?".to_string(),
+                    answer: "A newer answer that must be dropped".to_string(),
+                },
+                ApplicationAnswer {
+                    id: String::new(),
+                    question: "New question?".to_string(),
+                    answer: "New answer".to_string(),
+                },
+            ],
+        )
+        .unwrap();
+    assert_eq!(added, 1, "only the genuinely new question is added");
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(app.answers.len(), 2);
+    let original = app
+        .answers
+        .iter()
+        .find(|a| a.question == "Why this role?")
+        .unwrap();
+    assert_eq!(
+        original.answer, "Original",
+        "existing answer never overwritten"
+    );
+    assert_eq!(
+        original.id, "seed-1",
+        "existing answer's id is untouched too"
+    );
+}
+
+#[test]
+fn merge_answers_dedups_within_the_same_incoming_batch() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let id = store
+        .upsert_for_origin(
+            "https://acme.com/job/merge/3",
+            "linkedin",
+            &meta("Acme", "Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    // Two entries in ONE call that normalize to the same question — only the
+    // first should be added.
+    let added = store
+        .merge_answers(
+            &id,
+            vec![
+                ApplicationAnswer {
+                    id: String::new(),
+                    question: "Why this role?".to_string(),
+                    answer: "First".to_string(),
+                },
+                ApplicationAnswer {
+                    id: String::new(),
+                    question: "why THIS role?".to_string(),
+                    answer: "Second (dropped)".to_string(),
+                },
+            ],
+        )
+        .unwrap();
+    assert_eq!(added, 1);
+    let app = store.get(&id).unwrap();
+    assert_eq!(app.answers.len(), 1);
+    assert_eq!(app.answers[0].answer, "First");
+}
+
+#[test]
+fn merge_answers_leaves_updated_at_unchanged_when_nothing_new_added() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let mut m = meta("Acme", "Engineer");
+    m.answers = vec![ApplicationAnswer {
+        id: "seed-1".to_string(),
+        question: "Why this role?".to_string(),
+        answer: "Original".to_string(),
+    }];
+    let id = store
+        .upsert_for_origin(
+            "https://acme.com/job/merge/4",
+            "linkedin",
+            &m,
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+    let before = store.get(&id).unwrap().updated_at;
+
+    let added = store
+        .merge_answers(
+            &id,
+            vec![ApplicationAnswer {
+                id: String::new(),
+                question: "Why this role?".to_string(),
+                answer: "Ignored".to_string(),
+            }],
+        )
+        .unwrap();
+    assert_eq!(added, 0);
+    assert_eq!(
+        store.get(&id).unwrap().updated_at,
+        before,
+        "an all-dedup merge (nothing added) must not touch updated_at"
+    );
+}
+
+#[test]
+fn merge_answers_returns_error_for_unknown_id() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let err = store.merge_answers("does-not-exist", vec![]).unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn merge_answers_caps_total_stored_answers_and_drops_the_rest() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+    let mut m = meta("Acme", "Engineer");
+    // Seed to exactly (cap - 2) existing distinct answers.
+    m.answers = (0..MAX_TOTAL_ANSWERS - 2)
+        .map(|i| ApplicationAnswer {
+            id: format!("seed-{i}"),
+            question: format!("Existing question {i}?"),
+            answer: format!("Existing answer {i}"),
+        })
+        .collect();
+    let id = store
+        .upsert_for_origin(
+            "https://acme.com/job/merge/cap",
+            "linkedin",
+            &m,
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    // 5 new distinct questions incoming — only 2 fit under the cap; the rest
+    // are dropped (the caller derives `skipped` from `incoming_len - added`).
+    let incoming: Vec<ApplicationAnswer> = (0..5)
+        .map(|i| ApplicationAnswer {
+            id: String::new(),
+            question: format!("New question {i}?"),
+            answer: format!("New answer {i}"),
+        })
+        .collect();
+
+    let added = store.merge_answers(&id, incoming).unwrap();
+    assert_eq!(added, 2, "only enough to reach the cap are added");
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(
+        app.answers.len(),
+        MAX_TOTAL_ANSWERS,
+        "total stored answers never exceeds the per-application cap"
+    );
+}

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -2289,6 +2289,72 @@ fn merge_answers_caps_total_stored_answers_and_drops_the_rest() {
     assert_eq!(seeded.answer, "Existing answer 0");
 }
 
+/// MEDIUM fix: `upsert_internal`'s NEW-ROW branch used to store `meta.answers`
+/// verbatim, bypassing `MAX_TOTAL_ANSWERS` entirely (only the existing-row merge
+/// branch enforced it). Creating a brand-new Application (no prior row for the
+/// url) with an oversized, duplicate-question `meta.answers` must still come out
+/// deduped-by-question and capped at `MAX_TOTAL_ANSWERS`.
+#[test]
+fn upsert_for_origin_caps_and_dedupes_answers_on_new_row_creation() {
+    let dir = TempDir::new().unwrap();
+    let store = ApplicationStore::open(dir.path()).unwrap();
+
+    // MAX_TOTAL_ANSWERS + 2 distinct questions, plus one duplicate (different
+    // case/whitespace of question 0) inserted right after it — still over the
+    // cap even after the duplicate is dropped.
+    let mut answers: Vec<ApplicationAnswer> = (0..MAX_TOTAL_ANSWERS + 2)
+        .map(|i| ApplicationAnswer {
+            id: String::new(),
+            question: format!("Question {i}?"),
+            answer: format!("Answer {i}"),
+        })
+        .collect();
+    answers.insert(
+        1,
+        ApplicationAnswer {
+            id: String::new(),
+            question: "  question 0?  ".to_string(),
+            answer: "Duplicate (dropped)".to_string(),
+        },
+    );
+
+    let mut m = meta("Acme", "Engineer");
+    m.answers = answers;
+
+    let id = store
+        .upsert_for_origin(
+            "https://acme.com/job/new-row-cap",
+            "linkedin",
+            &m,
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let app = store.get(&id).unwrap();
+    assert_eq!(
+        app.answers.len(),
+        MAX_TOTAL_ANSWERS,
+        "a brand-new Application's answers are capped on creation, not just on merge"
+    );
+    // The genuine duplicate must never reach the stored row at all (dropped as a
+    // within-batch dupe, not merely truncated by the cap).
+    assert_eq!(
+        app.answers
+            .iter()
+            .filter(|a| a.answer == "Duplicate (dropped)")
+            .count(),
+        0,
+        "a duplicate-question answer must be deduped, not stored twice"
+    );
+    let first = app
+        .answers
+        .iter()
+        .find(|a| a.question == "Question 0?")
+        .expect("the first-seen answer for the duplicated question must survive");
+    assert_eq!(first.answer, "Answer 0");
+}
+
 /// Regression for the HIGH cross-feature data-loss hazard: `upsert_internal`'s
 /// meta-merge path used to REPLACE `answers` wholesale, so an
 /// `ai_generations_save`-shaped upsert (a non-empty `meta.answers`) silently

--- a/apps/desktop/src-tauri/src/extension_bridge/answers_save.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/answers_save.rs
@@ -106,20 +106,25 @@ pub(super) fn answers_result_reply(req_id: &str, outcome: AppResult<AnswersSaveO
     .to_string()
 }
 
-/// Parse + clamp the incoming `answers` array off the payload: caps at
-/// [`MAX_ANSWERS_PER_CALL`] entries, and clamps each question/answer at its
-/// byte cap (char-boundary safe). A malformed entry (missing/non-string
-/// `question`/`answer`) is skipped, not rejected — a blank question or
-/// answer (after trimming) is dropped too, since the collector should never
-/// send one but the store boundary re-validates independently rather than
-/// trusting the page-derived input.
-fn parse_answers(payload: &Value) -> Vec<ApplicationAnswer> {
-    payload
+/// Parse + clamp the incoming `answers` array off the payload, then cap at
+/// [`MAX_ANSWERS_PER_CALL`] entries. Returns `(capped_list, raw_len)` where
+/// `raw_len` is the count of well-formed entries BEFORE the per-call cap —
+/// the caller derives `skipped` from it so an overflow past
+/// `MAX_ANSWERS_PER_CALL` is counted as skipped instead of vanishing
+/// silently (the cap used to apply via `.take()` before this count was
+/// taken, so entries beyond it appeared in neither `saved` nor `skipped`).
+/// A malformed entry (missing/non-string `question`/`answer`) is dropped,
+/// not rejected — a blank question or answer (after trimming) is dropped
+/// too, since the collector should never send one but the store boundary
+/// re-validates independently rather than trusting the page-derived input.
+/// Neither of these drops counts toward `raw_len`/`skipped`: they were never
+/// well-formed captures to begin with.
+fn parse_answers(payload: &Value) -> (Vec<ApplicationAnswer>, usize) {
+    let well_formed: Vec<ApplicationAnswer> = payload
         .get("answers")
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
-                .take(MAX_ANSWERS_PER_CALL)
                 .filter_map(|entry| {
                     let question = entry.get("question")?.as_str()?.trim();
                     let answer = entry.get("answer")?.as_str()?.trim();
@@ -136,7 +141,11 @@ fn parse_answers(payload: &Value) -> Vec<ApplicationAnswer> {
                 })
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    let raw_len = well_formed.len();
+    let mut capped = well_formed;
+    capped.truncate(MAX_ANSWERS_PER_CALL);
+    (capped, raw_len)
 }
 
 /// Core `answers.save`: gate on the autofill opt-in (refusal mirrors
@@ -144,9 +153,12 @@ fn parse_answers(payload: &Value) -> Vec<ApplicationAnswer> {
 /// normalize + match `url` the SAME way `resolve_applied_check`/
 /// `resolve_status_update` do, then merge the (clamped, capped) captured
 /// answers onto the matched Application via
-/// [`ApplicationStore::merge_answers`] — NEVER `upsert_internal` (whose meta
-/// path replaces `answers` wholesale). No match → a fixed sentinel telling
-/// the user to import the job first; this verb never auto-creates.
+/// [`ApplicationStore::merge_answers`] — NEVER `upsert_internal`'s meta path
+/// (`ApplicationStore::merge_answers_by_question`), which lets `incoming`
+/// win for a matching question; that's right for an in-app rewrite but wrong
+/// here, where a stray re-capture must never clobber an answer the user
+/// already reviewed. No match → a fixed sentinel telling the user to import
+/// the job first; this verb never auto-creates.
 pub(super) fn resolve_answers_save(
     store: &ApplicationStore,
     autofill_enabled: bool,
@@ -183,8 +195,7 @@ pub(super) fn resolve_answers_save(
         )
     })?;
 
-    let incoming = parse_answers(payload);
-    let incoming_len = incoming.len();
+    let (incoming, raw_len) = parse_answers(payload);
     let saved = store.merge_answers(&app.id, incoming).map_err(|e| {
         // Wire-error discipline: never let a raw store error (path/SQL detail)
         // reach `answers_result_reply` — log it, reply a fixed sentinel.
@@ -195,7 +206,10 @@ pub(super) fn resolve_answers_save(
     Ok(AnswersSaveOk {
         application_id: app.id,
         saved,
-        skipped: incoming_len.saturating_sub(saved),
+        // `raw_len` (well-formed entries BEFORE the per-call cap) so an
+        // over-cap capture and a dedup-drop both land in `skipped` — see
+        // `parse_answers`.
+        skipped: raw_len.saturating_sub(saved),
         title: (!app.title.trim().is_empty()).then_some(app.title),
         company: (!app.company.trim().is_empty()).then_some(app.company),
     })

--- a/apps/desktop/src-tauri/src/extension_bridge/answers_save.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/answers_save.rs
@@ -1,0 +1,221 @@
+//! "Save my answers from this page" (`answers.save` → `answers.result`) —
+//! append newly-captured application-form answers onto the matched
+//! Application's answer list. Split out of `mod.rs` per the R8 LOC cap
+//! (mirrors `status_update.rs`'s module split); `resolve_*`/`handle_*` pure/
+//! impure split mirrors `resolve_applied_check`/`handle_applied_check` and
+//! `resolve_status_update`/`handle_status_update`.
+//!
+//! **Consent-gate boundary**: this verb WRITES freshly-captured page-derived
+//! text into the local store, so — unlike `applied.check`/`status.update`
+//! (read-only / an exact-match write to the user's OWN existing metadata, no
+//! fresh page content) — it rides the SAME assisted-autofill opt-in as
+//! `profile.get`/`fill` (`BridgeState::autofill_enabled`): capture and fill
+//! are the two directions of the one PII-adjacent consent gate (extension
+//! roadmap PR-5, plan decision 4).
+//!
+//! **Never auto-creates**: a `url` with no matching Application is a fixed
+//! refusal telling the user to import the job first — this verb only
+//! appends onto an existing pursuit, exactly like `status.update` never
+//! creates a row for a `saved → applied` click.
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Manager};
+
+use super::msg;
+use crate::ai_generations::ApplicationAnswer;
+use crate::applications::{normalize_job_url, ApplicationStore};
+use crate::error::{AppError, AppResult};
+
+/// Per-question / per-answer byte caps, char-boundary safe (mirrors
+/// `applications::clamp_job_description`'s discipline) — untrusted
+/// page-derived text is clamped at this store boundary, never dropped
+/// wholesale. A question/label is short (a form label); an answer can run to
+/// a paragraph but not a full essay.
+const MAX_QUESTION_BYTES: usize = 1_000;
+const MAX_ANSWER_BYTES: usize = 8_000;
+
+/// Hard cap on the number of `{question, answer}` entries a single
+/// `answers.save` call may carry — a pathological page (or a buggy/hostile
+/// collector) can't force an unbounded write; extra entries are silently
+/// dropped, not rejected (mirrors the `MAX_EXTRA_LINKS` cap-not-reject style
+/// in `mod.rs`).
+const MAX_ANSWERS_PER_CALL: usize = 50;
+
+/// Clamp `s` to at most `max` bytes, cutting on a UTF-8 char boundary so the
+/// stored text is always valid UTF-8. Truncate (never reject) — same
+/// discipline as `applications::clamp_job_description`, duplicated here as a
+/// tiny pure helper rather than exported cross-module (that cap is a
+/// distinct constant/concern owned by `applications`).
+fn clamp_bytes(mut s: String, max: usize) -> String {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+    s
+}
+
+/// The `answers.save` outcome — see [`msg::ANSWERS_SAVE`] docs. `title`/
+/// `company` ride the WIRE reply (unlike `status.update`'s `StatusUpdateOk`,
+/// which keeps them notification-only): the handler already loaded the
+/// Application row for this verb, so surfacing them here is the smaller
+/// change than threading the popup's separately-fetched `applied.check`
+/// state through to this confirmation — see the PR-5 handoff.
+#[derive(Debug)]
+pub(super) struct AnswersSaveOk {
+    pub(super) application_id: String,
+    /// Newly-added count (never overwrites an existing answer).
+    pub(super) saved: usize,
+    /// Dedup-dropped count (already present, or blank after clamping).
+    pub(super) skipped: usize,
+    pub(super) title: Option<String>,
+    pub(super) company: Option<String>,
+}
+
+/// Build the `answers.save` reply. Like `status_result_reply`, this verb's
+/// errors ARE user-facing (a deliberate click, not a passive background
+/// check) — the popup must render the `error` text, never fold it away.
+pub(super) fn answers_result_reply(req_id: &str, outcome: AppResult<AnswersSaveOk>) -> String {
+    let payload = match outcome {
+        Ok(ok) => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("ok".to_string(), json!(true));
+            obj.insert("applicationId".to_string(), json!(ok.application_id));
+            obj.insert("saved".to_string(), json!(ok.saved));
+            obj.insert("skipped".to_string(), json!(ok.skipped));
+            if let Some(t) = ok.title {
+                obj.insert("title".to_string(), json!(t));
+            }
+            if let Some(c) = ok.company {
+                obj.insert("company".to_string(), json!(c));
+            }
+            Value::Object(obj)
+        }
+        // Wire-error discipline: fixed sentinel text only (no dynamic/path/PII
+        // content) — detailed context belongs in the desktop log, not on the wire.
+        Err(e) => json!({ "ok": false, "error": e.to_string() }),
+    };
+    json!({
+        "type": msg::ANSWERS_RESULT,
+        "reqId": req_id,
+        "payload": payload,
+    })
+    .to_string()
+}
+
+/// Parse + clamp the incoming `answers` array off the payload: caps at
+/// [`MAX_ANSWERS_PER_CALL`] entries, and clamps each question/answer at its
+/// byte cap (char-boundary safe). A malformed entry (missing/non-string
+/// `question`/`answer`) is skipped, not rejected — a blank question or
+/// answer (after trimming) is dropped too, since the collector should never
+/// send one but the store boundary re-validates independently rather than
+/// trusting the page-derived input.
+fn parse_answers(payload: &Value) -> Vec<ApplicationAnswer> {
+    payload
+        .get("answers")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .take(MAX_ANSWERS_PER_CALL)
+                .filter_map(|entry| {
+                    let question = entry.get("question")?.as_str()?.trim();
+                    let answer = entry.get("answer")?.as_str()?.trim();
+                    if question.is_empty() || answer.is_empty() {
+                        return None;
+                    }
+                    Some(ApplicationAnswer {
+                        // Ignored on write — `ApplicationStore::merge_answers`
+                        // assigns a fresh id to every newly-added answer.
+                        id: String::new(),
+                        question: clamp_bytes(question.to_string(), MAX_QUESTION_BYTES),
+                        answer: clamp_bytes(answer.to_string(), MAX_ANSWER_BYTES),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Core `answers.save`: gate on the autofill opt-in (refusal mirrors
+/// `resolve_profile`'s fixed sentinel — see [`super::AUTOFILL_OFF_MESSAGE`]),
+/// normalize + match `url` the SAME way `resolve_applied_check`/
+/// `resolve_status_update` do, then merge the (clamped, capped) captured
+/// answers onto the matched Application via
+/// [`ApplicationStore::merge_answers`] — NEVER `upsert_internal` (whose meta
+/// path replaces `answers` wholesale). No match → a fixed sentinel telling
+/// the user to import the job first; this verb never auto-creates.
+pub(super) fn resolve_answers_save(
+    store: &ApplicationStore,
+    autofill_enabled: bool,
+    payload: &Value,
+) -> AppResult<AnswersSaveOk> {
+    if !autofill_enabled {
+        return Err(AppError::Validation(
+            super::AUTOFILL_OFF_MESSAGE.to_string(),
+        ));
+    }
+
+    let url = payload
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if url.is_empty() {
+        return Err(AppError::Validation("url is required".to_string()));
+    }
+
+    let canonical = crate::scraping::scrape_url::canonical_job_url(&url);
+    let effective_url = canonical.as_deref().unwrap_or(url.as_str());
+    let normalized = normalize_job_url(effective_url);
+    if normalized.is_empty() {
+        return Err(AppError::Validation(
+            "url is not a valid http(s) URL".to_string(),
+        ));
+    }
+
+    let app = store.find_by_job_url(&normalized).ok_or_else(|| {
+        AppError::Validation(
+            "couldn't find a saved job for this page — import it first".to_string(),
+        )
+    })?;
+
+    let incoming = parse_answers(payload);
+    let incoming_len = incoming.len();
+    let saved = store.merge_answers(&app.id, incoming).map_err(|e| {
+        // Wire-error discipline: never let a raw store error (path/SQL detail)
+        // reach `answers_result_reply` — log it, reply a fixed sentinel.
+        log::warn!("[extension_bridge] answers.save store error: {e}");
+        AppError::Storage("could not save these answers".to_string())
+    })?;
+
+    Ok(AnswersSaveOk {
+        application_id: app.id,
+        saved,
+        skipped: incoming_len.saturating_sub(saved),
+        title: (!app.title.trim().is_empty()).then_some(app.title),
+        company: (!app.company.trim().is_empty()).then_some(app.company),
+    })
+}
+
+/// Answer an authenticated `answers.save`: resolve against the local
+/// `ApplicationStore` (gated on the autofill opt-in) and return a
+/// ready-to-send `answers.result` reply. No notification/status-event tail —
+/// unlike `status.update`, this verb never touches status, and captured page
+/// text is never echoed into a notification (the wire reply above already
+/// carries the only page-adjacent text the popup renders — fixed counts plus
+/// the already-trusted title/company snapshot).
+pub(super) fn handle_answers_save(app: &AppHandle, req_id: &str, payload: &Value) -> String {
+    let enabled = app
+        .try_state::<super::BridgeState>()
+        .map(|s| s.autofill_enabled())
+        .unwrap_or(false);
+    let outcome = app
+        .try_state::<ApplicationStore>()
+        .ok_or_else(|| AppError::Config("applications store unavailable".to_string()))
+        .and_then(|store| resolve_answers_save(store.inner(), enabled, payload));
+    answers_result_reply(req_id, outcome)
+}

--- a/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
@@ -1821,7 +1821,8 @@ fn resolve_answers_save_clamps_oversized_question_and_answer_bytes() {
 }
 
 /// More than 50 entries in one call are capped — extras are silently
-/// dropped, never rejected outright.
+/// dropped, never rejected outright, and MUST still be reflected in
+/// `skipped` (not silently vanish from both counts).
 #[test]
 fn resolve_answers_save_caps_at_max_answers_per_call() {
     let (_dir, store) = open_store();
@@ -1846,6 +1847,55 @@ fn resolve_answers_save_caps_at_max_answers_per_call() {
     )
     .unwrap();
     assert_eq!(out.saved, 50, "extras beyond the 50-entry cap are dropped");
+    assert_eq!(
+        out.skipped, 25,
+        "the 25 entries beyond the per-call cap must reconcile into skipped, not vanish"
+    );
+}
+
+/// The STORE-level 500-answer cap (not the 50-per-call cap above) is what
+/// limits this call: a well-under-50 batch still can't push the total past
+/// [`crate::applications::MAX_TOTAL_ANSWERS`], and the overflow must land in
+/// `skipped` exactly like the per-call cap does.
+#[test]
+fn resolve_answers_save_reflects_store_level_total_cap_in_skipped() {
+    use crate::applications::MAX_TOTAL_ANSWERS;
+
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/answers-store-cap";
+    let mut meta = app_meta("Acme", "Cap Test Engineer");
+    // Seed to exactly (cap - 2) existing distinct answers via the store
+    // directly — bypassing the 50-per-call wire cap entirely.
+    meta.answers = (0..MAX_TOTAL_ANSWERS - 2)
+        .map(|i| ApplicationAnswer {
+            id: format!("seed-{i}"),
+            question: format!("Existing question {i}?"),
+            answer: format!("Existing answer {i}"),
+        })
+        .collect();
+    store
+        .upsert_for_origin(url, "linkedin", &meta, ApplicationOrigin::Saved, None)
+        .unwrap();
+
+    // 5 new distinct questions — well under MAX_ANSWERS_PER_CALL (50), so the
+    // per-call cap never triggers; only the store's cumulative 500 cap does.
+    let answers: Vec<serde_json::Value> = (0..5)
+        .map(|i| json!({ "question": format!("New question {i}?"), "answer": format!("New answer {i}") }))
+        .collect();
+    let out = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({ "url": url, "answers": answers }),
+    )
+    .unwrap();
+    assert_eq!(
+        out.saved, 2,
+        "only enough new answers to reach the store cap are saved"
+    );
+    assert_eq!(
+        out.skipped, 3,
+        "the 3 answers that didn't fit under the store's total cap must show up as skipped"
+    );
 }
 
 /// `answers_result_reply` builds a well-formed success envelope carrying the

--- a/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/import_tests.rs
@@ -21,6 +21,7 @@ use tempfile::TempDir;
 use tokio::net::TcpListener;
 
 use super::{advance_frame, handshake, BridgeState, ConnState, FrameDecision, MAX_FRAME_BYTES};
+use crate::ai_generations::ApplicationAnswer;
 use crate::applications::{
     normalize_job_url, ApplicationOrigin, ApplicationStatus, ApplicationStore,
 };
@@ -1564,6 +1565,338 @@ fn status_result_reply_carries_user_facing_error() {
         .as_str()
         .unwrap()
         .contains("couldn't find"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// E. answers.save — "save my answers from this page". Mirrors the
+// status.update section above: dispatch classification + the 3 auth-boundary
+// guards, then `resolve_answers_save` (a private, synchronous fn — no
+// `AppHandle`) directly. Rides the SAME autofill opt-in as `profile.get`
+// (unlike `applied.check`/`status.update`, which need no consent gate).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// An authenticated `answers.save` classifies as `AnswersSave`, carrying the
+/// payload verbatim (mirrors `authenticated_status_update_classifies_as_status_update`).
+#[test]
+fn authenticated_answers_save_classifies_as_answers_save() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
+        "type": super::msg::ANSWERS_SAVE,
+        "reqId": "r-answers",
+        "payload": {
+            "url": "https://jobs.example.com/posting/11",
+            "answers": [{ "question": "Why this role?", "answer": "Because I love it." }],
+        }
+    })
+    .to_string();
+
+    match advance_frame(&state, &ConnState::Authenticated, &frame) {
+        FrameDecision::AnswersSave { req_id, payload } => {
+            assert_eq!(req_id, "r-answers");
+            assert_eq!(
+                payload.get("url").and_then(|u| u.as_str()),
+                Some("https://jobs.example.com/posting/11")
+            );
+            assert!(payload.get("answers").is_some_and(|a| a.is_array()));
+        }
+        other => panic!("an authenticated answers.save must be AnswersSave, got {other:?}"),
+    }
+}
+
+/// An `answers.save` before the handshake completes is NEVER dispatched —
+/// same invariant as `status_update_before_handshake_is_not_dispatched`.
+#[test]
+fn answers_save_before_handshake_is_not_dispatched() {
+    let (_dir, state) = bridge_state();
+    let frame = json!({
+        "type": super::msg::ANSWERS_SAVE,
+        "reqId": "r-early",
+        "payload": { "url": "https://jobs.example.com/posting/early", "answers": [] },
+    })
+    .to_string();
+    match advance_frame(&state, &ConnState::AwaitingHello, &frame) {
+        FrameDecision::Outdated(_) => {}
+        other => panic!("an answers.save before hello must NOT be AnswersSave, got {other:?}"),
+    }
+}
+
+/// Same mid-handshake bypass guard as `status_update_mid_handshake_is_unauthorized`
+/// — `answers.save` cannot skip the proof step either (it is a WRITE, so it
+/// gets the same three auth-boundary tests as every other authenticated verb).
+#[test]
+fn answers_save_mid_handshake_is_unauthorized() {
+    let (_dir, state) = bridge_state();
+    let (conn, _correct) = awaiting_auth(&state);
+    let frame = json!({
+        "type": super::msg::ANSWERS_SAVE,
+        "reqId": "r-skip",
+        "payload": { "url": "https://jobs.example.com/posting/skip", "answers": [] },
+    })
+    .to_string();
+    match advance_frame(&state, &conn, &frame) {
+        FrameDecision::Unauthorized => {}
+        other => panic!("an answers.save mid-handshake must be Unauthorized, got {other:?}"),
+    }
+}
+
+/// Opt-in OFF is a fixed refusal mirroring `resolve_profile`'s exact sentinel
+/// — even when a matching Application exists, no answer is ever merged.
+#[test]
+fn resolve_answers_save_refuses_when_opt_in_off() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/answers-1";
+    let id = store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Backend Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let err = super::answers_save::resolve_answers_save(
+        &store,
+        false,
+        &json!({ "url": url, "answers": [{ "question": "Why?", "answer": "Because." }] }),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("Autofill is off"), "got: {err}");
+
+    // The refusal must never have written anything.
+    assert!(store.get(&id).unwrap().answers.is_empty());
+}
+
+/// An empty url is a Validation error — never a panic.
+#[test]
+fn resolve_answers_save_rejects_empty_url() {
+    let (_dir, store) = open_store();
+    let err = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({ "url": "", "answers": [] }),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("required"));
+}
+
+/// A malformed (dangerous-scheme) url hits the distinct invalid-url sentinel
+/// — mirrors `resolve_status_update_rejects_malformed_url`.
+#[test]
+fn resolve_answers_save_rejects_malformed_url() {
+    let (_dir, store) = open_store();
+    let err = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({ "url": "javascript:alert(1)", "answers": [] }),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("not a valid"), "got: {err}");
+}
+
+/// No Application exists for the url → a clear "import it first" refusal,
+/// never a create-on-miss (this verb only appends onto an existing pursuit).
+#[test]
+fn resolve_answers_save_rejects_when_no_match() {
+    let (_dir, store) = open_store();
+    let err = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({ "url": "https://jobs.example.com/posting/none", "answers": [] }),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("import it first"), "got: {err}");
+}
+
+/// An empty `answers` array is a well-formed no-op: `saved: 0, skipped: 0`,
+/// never an error.
+#[test]
+fn resolve_answers_save_handles_empty_list() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/answers-2";
+    store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "QA Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let out = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({ "url": url, "answers": [] }),
+    )
+    .unwrap();
+    assert_eq!(out.saved, 0);
+    assert_eq!(out.skipped, 0);
+}
+
+/// The happy path: new questions are added, a re-captured (differently-
+/// whitespaced/cased) duplicate of an EXISTING question is skipped, and the
+/// existing answer is NEVER overwritten. `title`/`company` ride the reply.
+#[test]
+fn resolve_answers_save_dedups_against_existing_and_never_overwrites() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/answers-3";
+    let mut meta = app_meta("Acme", "Backend Engineer");
+    meta.answers = vec![ApplicationAnswer {
+        id: "seed-1".to_string(),
+        question: "Why this role?".to_string(),
+        answer: "Original answer".to_string(),
+    }];
+    let id = store
+        .upsert_for_origin(url, "linkedin", &meta, ApplicationOrigin::Saved, None)
+        .unwrap();
+
+    let out = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({
+            "url": url,
+            "answers": [
+                { "question": "why   THIS role?", "answer": "A different answer that must be dropped" },
+                { "question": "What's your salary expectation?", "answer": "100k" },
+            ],
+        }),
+    )
+    .unwrap();
+    assert_eq!(out.saved, 1, "only the genuinely new question is added");
+    assert_eq!(out.skipped, 1, "the re-captured duplicate is dedup-dropped");
+    assert_eq!(out.title.as_deref(), Some("Backend Engineer"));
+    assert_eq!(out.company.as_deref(), Some("Acme"));
+
+    let row = store.get(&id).unwrap();
+    assert_eq!(row.answers.len(), 2);
+    let original = row
+        .answers
+        .iter()
+        .find(|a| a.question == "Why this role?")
+        .expect("the seeded answer must survive");
+    assert_eq!(
+        original.answer, "Original answer",
+        "an existing answer must NEVER be overwritten by a re-capture"
+    );
+    assert!(row
+        .answers
+        .iter()
+        .any(|a| a.question == "What's your salary expectation?" && a.answer == "100k"));
+}
+
+/// Oversized question/answer text is clamped (char-boundary safe), not
+/// dropped — mirrors `applications::clamp_job_description`'s discipline.
+#[test]
+fn resolve_answers_save_clamps_oversized_question_and_answer_bytes() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/answers-4";
+    let id = store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Staff Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let huge_question = "q".repeat(5_000);
+    let huge_answer = "a".repeat(20_000);
+    let out = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({
+            "url": url,
+            "answers": [{ "question": huge_question, "answer": huge_answer }],
+        }),
+    )
+    .unwrap();
+    assert_eq!(out.saved, 1);
+
+    let row = store.get(&id).unwrap();
+    let saved = &row.answers[0];
+    assert!(saved.question.len() <= 1_000, "question must be clamped");
+    assert!(saved.answer.len() <= 8_000, "answer must be clamped");
+}
+
+/// More than 50 entries in one call are capped — extras are silently
+/// dropped, never rejected outright.
+#[test]
+fn resolve_answers_save_caps_at_max_answers_per_call() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/answers-5";
+    store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Principal Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    let answers: Vec<serde_json::Value> = (0..75)
+        .map(|i| json!({ "question": format!("Question {i}?"), "answer": format!("Answer {i}") }))
+        .collect();
+    let out = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({ "url": url, "answers": answers }),
+    )
+    .unwrap();
+    assert_eq!(out.saved, 50, "extras beyond the 50-entry cap are dropped");
+}
+
+/// `answers_result_reply` builds a well-formed success envelope carrying the
+/// counts + title/company (mirrors `status_result_reply_carries_ok_true_and_fields`).
+#[test]
+fn answers_result_reply_carries_ok_true_and_counts() {
+    let (_dir, store) = open_store();
+    let url = "https://jobs.example.com/posting/answers-6";
+    store
+        .upsert_for_origin(
+            url,
+            "linkedin",
+            &app_meta("Acme", "Reply Test Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+    let outcome = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({ "url": url, "answers": [{ "question": "Why?", "answer": "Because." }] }),
+    );
+    let reply = super::answers_save::answers_result_reply("req-13", outcome);
+    let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+    assert_eq!(v["type"], super::msg::ANSWERS_RESULT);
+    assert_eq!(v["reqId"], "req-13");
+    assert_eq!(v["payload"]["ok"], true);
+    assert_eq!(v["payload"]["saved"], 1);
+    assert_eq!(v["payload"]["skipped"], 0);
+    assert_eq!(v["payload"]["title"], "Reply Test Engineer");
+    assert!(v["payload"]["applicationId"].is_string());
+}
+
+/// UNLIKE `applied.result`, an `answers.save` failure carries a fixed,
+/// user-facing `error` string — this verb's errors are surfaced to the user.
+#[test]
+fn answers_result_reply_carries_user_facing_error() {
+    let (_dir, store) = open_store();
+    let outcome = super::answers_save::resolve_answers_save(
+        &store,
+        true,
+        &json!({ "url": "https://jobs.example.com/posting/none", "answers": [] }),
+    );
+    let reply = super::answers_save::answers_result_reply("req-14", outcome);
+    let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+    assert_eq!(v["type"], super::msg::ANSWERS_RESULT);
+    assert_eq!(v["payload"]["ok"], false);
+    assert!(v["payload"]["error"]
+        .as_str()
+        .unwrap()
+        .contains("import it first"));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -63,6 +63,7 @@ use crate::applications::{
 use crate::error::{AppError, AppResult};
 use crate::events::{emit_event, APPLICATIONS_CHANGED};
 
+mod answers_save;
 pub mod auth;
 pub mod handshake;
 #[cfg(test)]
@@ -72,6 +73,14 @@ pub mod register;
 mod status_update;
 #[cfg(test)]
 mod test;
+
+/// Refusal text for the assisted-autofill opt-in gate — shared verbatim by
+/// [`resolve_profile`] (`profile.get`) and
+/// [`answers_save::resolve_answers_save`] (`answers.save`), the fill/capture
+/// mirror pair riding the SAME consent gate. A single constant (not two
+/// copies) so the two can never drift.
+pub(crate) const AUTOFILL_OFF_MESSAGE: &str =
+    "Autofill is off. Turn it on in AI Job Hunter → Settings → Accounts → Browser extension.";
 
 /// Native-messaging host name — the registered identifier the browser uses to
 /// spawn our relay (our exe in `--native-host` mode). MUST match the extension
@@ -134,6 +143,18 @@ pub mod msg {
     /// a malformed request. UNLIKE `applied.result`, this verb's errors ARE
     /// user-facing (it answers a deliberate click, not a passive check).
     pub const STATUS_RESULT: &str = "status.result";
+    /// Extension → desktop: "save my answers from this page" — append the
+    /// captured `{question, answer}` pairs onto the Application matched by
+    /// (canonicalized + normalized) `url`. No match → a refusal telling the
+    /// user to import the job first; NEVER auto-creates. Rides the SAME
+    /// assisted-autofill opt-in as `profile.get` (capture is the mirror
+    /// direction of fill) — see [`super::answers_save::resolve_answers_save`].
+    pub const ANSWERS_SAVE: &str = "answers.save";
+    /// Desktop → extension: the `answers.save` outcome — `{ ok: true,
+    /// applicationId, saved, skipped, title?, company? }` on success, `{ ok:
+    /// false, error }` on a refusal (opt-in off / no match / malformed
+    /// request). Like `status.update`, this verb's errors ARE user-facing.
+    pub const ANSWERS_RESULT: &str = "answers.result";
 }
 
 /// Handshake protocol version carried in the `hello` frame. MUST match the TS
@@ -547,6 +568,9 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
             FrameDecision::StatusUpdate { req_id, payload } => {
                 Some(status_update::handle_status_update(&app, &req_id, &payload))
             }
+            FrameDecision::AnswersSave { req_id, payload } => {
+                Some(answers_save::handle_answers_save(&app, &req_id, &payload))
+            }
         };
         if let Some(reply) = reply {
             if writer.send(Message::text(reply)).await.is_err() {
@@ -623,6 +647,10 @@ enum FrameDecision {
     /// [`status_update::resolve_status_update`] is what actually restricts it
     /// to `saved → applied` on an exact match.
     StatusUpdate { req_id: String, payload: Value },
+    /// An authenticated `answers.save` to answer through
+    /// [`answers_save::handle_answers_save`]. Carries the payload verbatim so
+    /// the handler can read `url` + `answers`.
+    AnswersSave { req_id: String, payload: Value },
 }
 
 /// The per-message handshake gate + dispatch routing (size cap → JSON parse →
@@ -719,8 +747,8 @@ fn advance_auth(
 
 /// Post-auth dispatch: the socket is session-authenticated, so frames carry no
 /// token. Routes `import.request` / `profile.get` / `applied.check` /
-/// `status.update`; reserved / unknown types get an `import.result` error
-/// reply (never a panic).
+/// `status.update` / `answers.save`; reserved / unknown types get an
+/// `import.result` error reply (never a panic).
 fn advance_authenticated(kind: &str, req_id: String, envelope: &Value) -> FrameDecision {
     match kind {
         msg::IMPORT_REQUEST => {
@@ -739,6 +767,11 @@ fn advance_authenticated(kind: &str, req_id: String, envelope: &Value) -> FrameD
         msg::STATUS_UPDATE => {
             let payload = envelope.get("payload").cloned().unwrap_or(Value::Null);
             FrameDecision::StatusUpdate { req_id, payload }
+        }
+        // "Save my answers from this page" — a consent-gated append-only write.
+        msg::ANSWERS_SAVE => {
+            let payload = envelope.get("payload").cloned().unwrap_or(Value::Null);
+            FrameDecision::AnswersSave { req_id, payload }
         }
         // Reserved message types — acknowledged as unimplemented, never panic.
         msg::MATCH_LIVE => FrameDecision::Reply(result_reply(
@@ -925,10 +958,7 @@ fn resolve_profile(
     profile: Option<&crate::contact_profile::ContactProfile>,
 ) -> AppResult<AutofillProfile> {
     if !enabled {
-        return Err(AppError::Validation(
-            "Autofill is off. Turn it on in AI Job Hunter → Settings → Accounts → Browser extension."
-                .to_string(),
-        ));
+        return Err(AppError::Validation(AUTOFILL_OFF_MESSAGE.to_string()));
     }
     let profile =
         profile.ok_or_else(|| AppError::Config("contact profile unavailable".to_string()))?;

--- a/apps/desktop/src-tauri/src/extension_bridge/test.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/test.rs
@@ -40,6 +40,8 @@ fn message_type_constants_match_ts() {
         msg::APPLIED_RESULT,
         msg::STATUS_UPDATE,
         msg::STATUS_RESULT,
+        msg::ANSWERS_SAVE,
+        msg::ANSWERS_RESULT,
     ] {
         let needle = format!("'{literal}'");
         assert!(
@@ -87,6 +89,8 @@ fn reserved_types_are_distinct() {
         msg::APPLIED_RESULT,
         msg::STATUS_UPDATE,
         msg::STATUS_RESULT,
+        msg::ANSWERS_SAVE,
+        msg::ANSWERS_RESULT,
     ];
     let set: std::collections::HashSet<_> = all.iter().collect();
     assert_eq!(set.len(), all.len(), "wire type constants must be unique");

--- a/apps/extension/scripts/package.mjs
+++ b/apps/extension/scripts/package.mjs
@@ -14,7 +14,7 @@
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
-import { existsSync, rmSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -25,9 +25,38 @@ const DIST = path.join(EXT_ROOT, 'dist');
 const { version } = createRequire(import.meta.url)('../package.json');
 const TARGETS = ['chrome', 'firefox'];
 
+// `fill.js`/`capture.js` are injected via
+// `chrome.scripting.executeScript({ files: [...] })` as CLASSIC scripts — no
+// ES module support. `vite.config.ts`'s `injectedEntries` plugin builds them
+// each in an isolated Rollup pass specifically so no `import`/`export`
+// statement ever leaks in (see field-signal.ts's header comment); this is the
+// automated guard that invariant doesn't silently regress.
+const INJECTED_CLASSIC_SCRIPTS = ['fill.js', 'capture.js'];
+const IMPORT_EXPORT_RE = /^\s*(?:import|export)\b/m;
+
 // `zip` present? (CI/macOS/Linux). Detect via a cheap version probe.
 const HAS_ZIP = spawnSync('zip', ['-v'], { stdio: 'ignore' }).status === 0;
 const rel = (p) => path.relative(REPO_ROOT, p).split(path.sep).join('/');
+
+function assertClassicScripts(srcDir) {
+  for (const file of INJECTED_CLASSIC_SCRIPTS) {
+    const filePath = path.join(srcDir, file);
+    if (!existsSync(filePath)) {
+      console.error(
+        `error: ${rel(filePath)} not found — build first: pnpm -F @ajh/extension build`
+      );
+      process.exit(1);
+    }
+    if (IMPORT_EXPORT_RE.test(readFileSync(filePath, 'utf8'))) {
+      console.error(
+        `error: ${rel(filePath)} contains an import/export statement — it must be a classic ` +
+          `script (chrome.scripting.executeScript({ files: [...] }) can't load ES modules). ` +
+          `The injectedEntries isolated-build guarantee in vite.config.ts has regressed.`
+      );
+      process.exit(1);
+    }
+  }
+}
 
 function zipTarget(target) {
   const srcDir = path.join(DIST, target);
@@ -37,6 +66,7 @@ function zipTarget(target) {
     );
     process.exit(1);
   }
+  assertClassicScripts(srcDir);
   const out = path.join(DIST, `ai-job-hunter-extension-${target}-${version}.zip`);
   rmSync(out, { force: true }); // avoid `zip` appending stale entries
 

--- a/apps/extension/scripts/package.mjs
+++ b/apps/extension/scripts/package.mjs
@@ -32,7 +32,22 @@ const TARGETS = ['chrome', 'firefox'];
 // statement ever leaks in (see field-signal.ts's header comment); this is the
 // automated guard that invariant doesn't silently regress.
 const INJECTED_CLASSIC_SCRIPTS = ['fill.js', 'capture.js'];
-const IMPORT_EXPORT_RE = /^\s*(?:import|export)\b/m;
+const IMPORT_EXPORT_TOKEN_RE = /\b(?:import|export)\b/;
+// A minifier can emit `import`/`export` mid-line (e.g. `...;import{x}from"y";...`),
+// so a line-anchored `^\s*` check misses it. Strip string/template literals and
+// comments first (so the bare word "import"/"export" inside quoted text or a
+// comment doesn't false-positive), then look for the token anywhere in what's
+// left — that also catches a dynamic `import(...)`, which is equally illegal in
+// a classic `executeScript` bundle.
+function containsImportOrExportStatement(src) {
+  const stripped = src
+    .replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
+    .replace(/\/\/[^\n]*/g, ' ') // line comments
+    .replace(/`(?:\\.|[^`\\])*`/g, ' ') // template literals
+    .replace(/"(?:\\.|[^"\\])*"/g, ' ') // double-quoted strings
+    .replace(/'(?:\\.|[^'\\])*'/g, ' '); // single-quoted strings
+  return IMPORT_EXPORT_TOKEN_RE.test(stripped);
+}
 
 // `zip` present? (CI/macOS/Linux). Detect via a cheap version probe.
 const HAS_ZIP = spawnSync('zip', ['-v'], { stdio: 'ignore' }).status === 0;
@@ -47,7 +62,7 @@ function assertClassicScripts(srcDir) {
       );
       process.exit(1);
     }
-    if (IMPORT_EXPORT_RE.test(readFileSync(filePath, 'utf8'))) {
+    if (containsImportOrExportStatement(readFileSync(filePath, 'utf8'))) {
       console.error(
         `error: ${rel(filePath)} contains an import/export statement — it must be a classic ` +
           `script (chrome.scripting.executeScript({ files: [...] }) can't load ES modules). ` +

--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -35,6 +35,7 @@ const mockClient = vi.hoisted(() => ({
   getProfile: vi.fn(),
   checkApplied: vi.fn(),
   updateStatus: vi.fn(),
+  saveAnswers: vi.fn(),
 }));
 
 vi.mock('@wxt-dev/browser', () => ({
@@ -95,6 +96,7 @@ beforeEach(() => {
   mockClient.importJob.mockReset();
   mockClient.checkApplied.mockReset();
   mockClient.updateStatus.mockReset();
+  mockClient.saveAnswers.mockReset();
 });
 
 // ── not-paired short-circuit ────────────────────────────────────────────────
@@ -342,5 +344,106 @@ describe('statusUpdate request', () => {
 
     expect(res).toEqual({ ok: false, error: 'Could not read the current tab URL.' });
     expect(mockClient.updateStatus).not.toHaveBeenCalled();
+  });
+});
+
+// ── answersSave request — capture then send; errors are NOT folded ──────────
+
+describe('answersSave request', () => {
+  it('injects capture.js, sends the captured answers, and returns the success result', async () => {
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
+    ]);
+    const captured = [{ question: 'Why this role?', answer: 'Because I love it.' }];
+    executeScriptMock.mockResolvedValueOnce([{ result: captured }] as never);
+    mockClient.saveAnswers.mockResolvedValue({
+      ok: true,
+      applicationId: 'app-1',
+      saved: 1,
+      skipped: 0,
+      title: 'Backend Engineer',
+      company: 'Acme',
+    });
+
+    const res = await send({ kind: 'answersSave' });
+
+    expect(executeScriptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ target: { tabId: 7 }, files: ['capture.js'] })
+    );
+    expect(mockClient.saveAnswers).toHaveBeenCalledWith(
+      'https://jobs.example.com/posting/9',
+      captured
+    );
+    expect(res).toEqual({
+      ok: true,
+      kind: 'answersSave',
+      result: {
+        ok: true,
+        applicationId: 'app-1',
+        saved: 1,
+        skipped: 0,
+        title: 'Backend Engineer',
+        company: 'Acme',
+      },
+    });
+  });
+
+  it('passes a desktop-side refusal straight through as result (never folds it, unlike appliedCheck)', async () => {
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/none' } as never,
+    ]);
+    executeScriptMock.mockResolvedValueOnce([{ result: [] }] as never);
+    mockClient.saveAnswers.mockResolvedValue({
+      ok: false,
+      error: "couldn't find a saved job for this page — import it first",
+    });
+
+    const res = await send({ kind: 'answersSave' });
+
+    expect(res).toEqual({
+      ok: true,
+      kind: 'answersSave',
+      result: { ok: false, error: "couldn't find a saved job for this page — import it first" },
+    });
+  });
+
+  it('surfaces "Could not read the answers on this page." when the injected script returns a non-array', async () => {
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
+    ]);
+    executeScriptMock.mockResolvedValueOnce([{ result: null }] as never);
+
+    const res = await send({ kind: 'answersSave' });
+
+    expect(res).toEqual({ ok: false, error: 'Could not read the answers on this page.' });
+    expect(mockClient.saveAnswers).not.toHaveBeenCalled();
+  });
+
+  it('surfaces "Could not read the current tab URL." when there is no active tab, without calling saveAnswers', async () => {
+    // activeTabUrl() runs BEFORE the capture injection (mirrors runStatusUpdate).
+    tabsQueryMock.mockResolvedValue([]);
+
+    const res = await send({ kind: 'answersSave' });
+
+    expect(res).toEqual({ ok: false, error: 'Could not read the current tab URL.' });
+    expect(executeScriptMock).not.toHaveBeenCalled();
+    expect(mockClient.saveAnswers).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a transport-level rejection as ok:false (UNLIKE appliedCheck, which folds every rejection)', async () => {
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
+    ]);
+    executeScriptMock.mockResolvedValueOnce([{ result: [] }] as never);
+    mockClient.saveAnswers.mockRejectedValue(
+      new Error('Desktop app not reachable. Is AI Job Hunter running?')
+    );
+
+    const res = await send({ kind: 'answersSave' });
+
+    expect(res).toEqual({
+      ok: false,
+      error: 'Desktop app not reachable. Is AI Job Hunter running?',
+    });
   });
 });

--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -349,8 +349,21 @@ describe('statusUpdate request', () => {
 
 // ── answersSave request — capture then send; errors are NOT folded ──────────
 
+describe('answersSave request — not-paired short-circuit', () => {
+  it('surfaces "Not paired" and never reaches the tab capture or saveAnswers when no token is stored', async () => {
+    getTokenMock.mockResolvedValue(null);
+
+    const res = await send({ kind: 'answersSave' });
+
+    expect(res).toEqual({ ok: false, error: 'Not paired. Paste your pairing token first.' });
+    expect(executeScriptMock).not.toHaveBeenCalled();
+    expect(mockClient.saveAnswers).not.toHaveBeenCalled();
+  });
+});
+
 describe('answersSave request', () => {
   it('injects capture.js, sends the captured answers, and returns the success result', async () => {
+    getTokenMock.mockResolvedValue(FAKE_TOKEN);
     tabsQueryMock.mockResolvedValue([
       { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
     ]);
@@ -389,6 +402,7 @@ describe('answersSave request', () => {
   });
 
   it('passes a desktop-side refusal straight through as result (never folds it, unlike appliedCheck)', async () => {
+    getTokenMock.mockResolvedValue(FAKE_TOKEN);
     tabsQueryMock.mockResolvedValue([
       { id: 7, url: 'https://jobs.example.com/posting/none' } as never,
     ]);
@@ -408,6 +422,7 @@ describe('answersSave request', () => {
   });
 
   it('surfaces "Could not read the answers on this page." when the injected script returns a non-array', async () => {
+    getTokenMock.mockResolvedValue(FAKE_TOKEN);
     tabsQueryMock.mockResolvedValue([
       { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
     ]);
@@ -421,6 +436,7 @@ describe('answersSave request', () => {
 
   it('surfaces "Could not read the current tab URL." when there is no active tab, without calling saveAnswers', async () => {
     // activeTabUrl() runs BEFORE the capture injection (mirrors runStatusUpdate).
+    getTokenMock.mockResolvedValue(FAKE_TOKEN);
     tabsQueryMock.mockResolvedValue([]);
 
     const res = await send({ kind: 'answersSave' });
@@ -431,6 +447,7 @@ describe('answersSave request', () => {
   });
 
   it('surfaces a transport-level rejection as ok:false (UNLIKE appliedCheck, which folds every rejection)', async () => {
+    getTokenMock.mockResolvedValue(FAKE_TOKEN);
     tabsQueryMock.mockResolvedValue([
       { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
     ]);

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -288,9 +288,16 @@ async function captureActiveTabAnswers(): Promise<CapturedAnswer[]> {
  * `runStatusUpdate` — so a capture/transport failure propagates up to
  * `handleRequest`'s outer catch as `{ ok: false, error }`, and a resolved
  * desktop-side refusal (`{ ok: false, error }` — autofill off / no match /
- * malformed) still passes straight through as `result`.
+ * malformed) still passes straight through as `result`. Mirrors `runFill`'s
+ * not-paired short-circuit: the token check runs BEFORE the capture injection,
+ * so an unpaired browser never reads the page.
  */
 async function runAnswersSave(): Promise<PopupResponse> {
+  const token = await getToken();
+  if (!token) {
+    return { ok: false, error: 'Not paired. Paste your pairing token first.' };
+  }
+
   const url = await activeTabUrl();
   const answers = await captureActiveTabAnswers();
   const result = await getClient().saveAnswers(url, answers);

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -12,6 +12,11 @@ import { browser } from '@wxt-dev/browser';
 
 import type { ExtensionImportRequest } from '@ajh/shared';
 
+// Same type-only rationale as the autofill.ts import above — capture.js is
+// ALSO a classic-script injection target (see vite.config.ts's
+// `injectedEntries`), so this import must stay type-only (erased at build)
+// to keep answers-capture.ts's runtime code out of the background's bundle.
+import type { CapturedAnswer } from './lib/answers-capture';
 // TYPE-ONLY import from the autofill module. This is deliberate: `fill.js` is
 // injected via `executeScript({ files })`, which runs as a CLASSIC script (no ES
 // modules) — so `fill.js` must bundle with ZERO `import` statements. If the
@@ -38,6 +43,21 @@ function isFillSummary(v: unknown): v is AutofillSummary {
   if (typeof v !== 'object' || v === null) return false;
   const o = v as Record<string, unknown>;
   return Array.isArray(o.filled) && typeof o.filledNothing === 'boolean';
+}
+
+/** Minimal guard for the `{question, answer}[]` array that crossed the
+ *  `executeScript` boundary (capture.js's completion value). */
+function isCapturedAnswers(v: unknown): v is CapturedAnswer[] {
+  return (
+    Array.isArray(v) &&
+    v.every(
+      (e) =>
+        typeof e === 'object' &&
+        e !== null &&
+        typeof (e as Record<string, unknown>).question === 'string' &&
+        typeof (e as Record<string, unknown>).answer === 'string'
+    )
+  );
 }
 
 /** Lazily-built, worker-lifetime-scoped client. Recreated after eviction. */
@@ -239,6 +259,44 @@ async function runStatusUpdate(): Promise<PopupResponse> {
   return { ok: true, kind: 'statusUpdate', result };
 }
 
+/**
+ * Inject the answers-capture collector into the active tab and return its
+ * `{question, answer}[]`. Single-step injection (unlike `injectFill`'s
+ * files+func two-step): the collector takes no PII input to pass in
+ * transiently, it only reads the page and returns data — same pattern as
+ * `captureActiveTabHtml`.
+ */
+async function captureActiveTabAnswers(): Promise<CapturedAnswer[]> {
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  const tabId = tab?.id;
+  if (typeof tabId !== 'number') throw new Error('No active tab to capture.');
+
+  const results = await browser.scripting.executeScript({
+    target: { tabId },
+    files: ['capture.js'],
+  });
+  const answers = results[0]?.result;
+  if (!isCapturedAnswers(answers)) {
+    throw new Error('Could not read the answers on this page.');
+  }
+  return answers;
+}
+
+/**
+ * User-clicked "Save my answers from this page". UNLIKE `runAppliedCheck`,
+ * failures are NOT folded away — a deliberate click action, like
+ * `runStatusUpdate` — so a capture/transport failure propagates up to
+ * `handleRequest`'s outer catch as `{ ok: false, error }`, and a resolved
+ * desktop-side refusal (`{ ok: false, error }` — autofill off / no match /
+ * malformed) still passes straight through as `result`.
+ */
+async function runAnswersSave(): Promise<PopupResponse> {
+  const url = await activeTabUrl();
+  const answers = await captureActiveTabAnswers();
+  const result = await getClient().saveAnswers(url, answers);
+  return { ok: true, kind: 'answersSave', result };
+}
+
 /** Central popup-request dispatcher. Never throws — maps errors to `ok:false`. */
 async function handleRequest(req: PopupRequest): Promise<PopupResponse> {
   try {
@@ -281,6 +339,8 @@ async function handleRequest(req: PopupRequest): Promise<PopupResponse> {
         return await runAppliedCheck();
       case 'statusUpdate':
         return await runStatusUpdate();
+      case 'answersSave':
+        return await runAnswersSave();
       default: {
         // Exhaustiveness guard — a new PopupRequest variant must be handled.
         const _never: never = req;

--- a/apps/extension/src/capture.ts
+++ b/apps/extension/src/capture.ts
@@ -1,0 +1,24 @@
+/**
+ * Answers-capture injected entry (compiled to `capture.js`).
+ *
+ * Injected via `chrome.scripting.executeScript({ files: ['capture.js'] })` on
+ * the user's "Save my answers from this page" click — a single-step classic
+ * script (mirrors `content.ts`'s pattern, not `fill.ts`'s two-step
+ * register+invoke): the collector takes no PII to pass in transiently, it
+ * only reads the page and returns data, so there is nothing to keep off a
+ * stored/registered surface.
+ *
+ * Bundled with ZERO `import` statements: `./lib/answers-capture` (and the
+ * `./lib/field-signal` helpers it shares with `autofill.ts`) is inlined here
+ * because this file is built by its OWN isolated Rollup pass — see the
+ * `injectedEntries` plugin in `vite.config.ts` — so it never shares a chunk
+ * with `fill.js`.
+ */
+
+import { collectAnswers } from './lib/answers-capture';
+
+// ── injected-execution entry-point ────────────────────────────────────────────
+// Completion value returned to executeScript → background (mirrors content.ts:
+// the IIFE's return value is the last statement's value, which is what
+// `executeScript` hands back).
+(() => collectAnswers(document))();

--- a/apps/extension/src/lib/answers-capture.test.ts
+++ b/apps/extension/src/lib/answers-capture.test.ts
@@ -167,6 +167,24 @@ describe('collectAnswers — excludes identity fields (contact-profile data, not
   });
 });
 
+describe('collectAnswers — autocomplete-aware identity exclusion (shared with autofill.ts Tier 1)', () => {
+  it('does not capture an autocomplete="name" field even under a quirky, non-identity-looking label', () => {
+    setForm(
+      `<label for="fn">Your details</label><input id="fn" type="text" autocomplete="name" value="Jane Doe" />`
+    );
+    expect(collectAnswers(document)).toEqual([]);
+  });
+
+  it('still captures an autocomplete="off" textarea labelled as a genuine question', () => {
+    setForm(
+      `<label for="q">Why this role?</label><textarea id="q" autocomplete="off">Because I love it.</textarea>`
+    );
+    expect(collectAnswers(document)).toEqual([
+      { question: 'Why this role?', answer: 'Because I love it.' },
+    ]);
+  });
+});
+
 describe('collectAnswers — visibility (computed-style-only, jsdom-safe)', () => {
   it('skips a field hidden by an ancestor display:none', () => {
     setForm(

--- a/apps/extension/src/lib/answers-capture.test.ts
+++ b/apps/extension/src/lib/answers-capture.test.ts
@@ -142,6 +142,13 @@ describe('collectAnswers — the AMBIGUOUS/sensitive denylist (shared with autof
     `);
     expect(collectAnswers(document)).toEqual([]);
   });
+
+  it('does not capture a filled "Driver\'s license number" field', () => {
+    setForm(
+      `<label for="dl">Driver's license number</label><input id="dl" type="text" value="D1234567" />`
+    );
+    expect(collectAnswers(document)).toEqual([]);
+  });
 });
 
 describe('collectAnswers — excludes identity fields (contact-profile data, not answers)', () => {

--- a/apps/extension/src/lib/answers-capture.test.ts
+++ b/apps/extension/src/lib/answers-capture.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the answers-capture collector
+ * (apps/extension/src/lib/answers-capture.ts).
+ *
+ * jsdom is provided by the vitest environment declared in vitest.config.ts.
+ * Mirrors autofill.test.ts's style: build a real form in `document`, run the
+ * REAL implementation, and assert which fields were captured.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { collectAnswers } from './answers-capture';
+
+function setForm(html: string): void {
+  document.body.innerHTML = `<form>${html}</form>`;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.head.querySelectorAll('style[data-ajh-test]').forEach((s) => s.remove());
+});
+
+describe('collectAnswers — label pairing', () => {
+  it('pairs a filled text input with its <label for> text', () => {
+    setForm(
+      `<label for="q1">Why this role?</label><input id="q1" type="text" value="Because I love it." />`
+    );
+    expect(collectAnswers(document)).toEqual([
+      { question: 'Why this role?', answer: 'Because I love it.' },
+    ]);
+  });
+
+  it('pairs a filled field with its wrapping <label> text', () => {
+    setForm(`<label>Why this role? <input type="text" value="Because I love it." /></label>`);
+    const result = collectAnswers(document);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.answer).toBe('Because I love it.');
+    expect(result[0]?.question).toContain('Why this role?');
+  });
+
+  it('captures multiple filled fields, each paired with its own label', () => {
+    setForm(`
+      <label for="q1">Why this role?</label><input id="q1" type="text" value="A" />
+      <label for="q2">Notice period?</label><input id="q2" type="text" value="2 weeks" />
+    `);
+    const result = collectAnswers(document);
+    expect(result).toContainEqual({ question: 'Why this role?', answer: 'A' });
+    expect(result).toContainEqual({ question: 'Notice period?', answer: '2 weeks' });
+  });
+});
+
+describe('collectAnswers — textarea', () => {
+  it('captures a filled, labelled textarea', () => {
+    setForm(
+      `<label for="cl">Cover letter</label><textarea id="cl">I would love to join.</textarea>`
+    );
+    expect(collectAnswers(document)).toEqual([
+      { question: 'Cover letter', answer: 'I would love to join.' },
+    ]);
+  });
+
+  it('skips an empty/whitespace-only textarea', () => {
+    setForm(`<label for="cl">Cover letter</label><textarea id="cl">   </textarea>`);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+});
+
+describe('collectAnswers — select captures the visible option text, not the value', () => {
+  it("captures the selected option's displayed text", () => {
+    setForm(`
+      <label for="yrs">Years of experience</label>
+      <select id="yrs">
+        <option value="0">Choose one</option>
+        <option value="1" selected>5-10 years</option>
+      </select>
+    `);
+    expect(collectAnswers(document)).toEqual([
+      { question: 'Years of experience', answer: '5-10 years' },
+    ]);
+  });
+
+  it('skips a select with nothing meaningfully selected (blank option text)', () => {
+    setForm(`
+      <label for="yrs">Years of experience</label>
+      <select id="yrs">
+        <option value="" selected></option>
+        <option value="1">5-10 years</option>
+      </select>
+    `);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+
+  it('skips a select whose selected option has an empty value even when its text is non-blank (placeholder)', () => {
+    setForm(`
+      <label for="yrs">Years of experience</label>
+      <select id="yrs">
+        <option value="" selected>Choose one</option>
+        <option value="1">5-10 years</option>
+      </select>
+    `);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+});
+
+describe('collectAnswers — skips password/hidden/file/checkbox/radio inputs', () => {
+  it('never captures a password, hidden, file, checkbox, or radio input', () => {
+    setForm(`
+      <label for="pw">Password</label><input id="pw" type="password" value="secret" />
+      <label for="hid">Hidden</label><input id="hid" type="hidden" value="x" />
+      <label for="file">Resume</label><input id="file" type="file" />
+      <label for="chk">Agree</label><input id="chk" type="checkbox" checked />
+      <label for="rad">Choice</label><input id="rad" type="radio" checked value="a" />
+    `);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+});
+
+describe('collectAnswers — skips unlabeled and blank/whitespace fields', () => {
+  it('skips a filled field with no associated label text', () => {
+    setForm(`<input id="nolabel" type="text" value="orphan answer" />`);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+
+  it('skips an empty text input', () => {
+    setForm(`<label for="q">Question</label><input id="q" type="text" value="" />`);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+
+  it('skips a whitespace-only text input', () => {
+    setForm(`<label for="q">Question</label><input id="q" type="text" value="   " />`);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+});
+
+describe('collectAnswers — the AMBIGUOUS/sensitive denylist (shared with autofill.ts)', () => {
+  it('skips ambiguous/sensitive labels (referrer, ssn, company, confirm)', () => {
+    setForm(`
+      <label for="ref">Referrer name</label><input id="ref" type="text" value="Jane" />
+      <label for="ssn">SSN</label><input id="ssn" type="text" value="123-45-6789" />
+      <label for="co">Company you work for now</label><input id="co" type="text" value="Acme" />
+      <label for="cf">Confirm answer</label><input id="cf" type="text" value="yes" />
+    `);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+});
+
+describe('collectAnswers — excludes identity fields (contact-profile data, not answers)', () => {
+  it('does not capture a filled "Full Name" text field', () => {
+    setForm(`<label for="fn">Full Name</label><input id="fn" type="text" value="Jane Doe" />`);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+
+  it('does not capture a filled "LinkedIn" text field', () => {
+    setForm(
+      `<label for="li">LinkedIn</label><input id="li" type="text" value="https://linkedin.com/in/jane" />`
+    );
+    expect(collectAnswers(document)).toEqual([]);
+  });
+
+  it('still captures a genuine application question', () => {
+    setForm(
+      `<label for="q">Why do you want to work here?</label><input id="q" type="text" value="Because I love it." />`
+    );
+    expect(collectAnswers(document)).toEqual([
+      { question: 'Why do you want to work here?', answer: 'Because I love it.' },
+    ]);
+  });
+});
+
+describe('collectAnswers — visibility (computed-style-only, jsdom-safe)', () => {
+  it('skips a field hidden by an ancestor display:none', () => {
+    setForm(
+      `<div style="display:none"><label for="q">Question</label><input id="q" type="text" value="A" /></div>`
+    );
+    expect(collectAnswers(document)).toEqual([]);
+  });
+
+  it('skips a field hidden by an ancestor CSS class (honeypot), not just inline style', () => {
+    const style = document.createElement('style');
+    style.setAttribute('data-ajh-test', '');
+    style.textContent = '.ajh-visually-hidden { display: none; }';
+    document.head.appendChild(style);
+
+    setForm(
+      `<div class="ajh-visually-hidden"><label for="q">Question</label><input id="q" type="text" value="A" /></div>`
+    );
+    expect(collectAnswers(document)).toEqual([]);
+  });
+
+  it('still captures a normal visible sibling alongside a hidden honeypot field', () => {
+    setForm(`
+      <div style="display:none"><label for="hp">Trap</label><input id="hp" type="text" value="bot" /></div>
+      <label for="q">Question</label><input id="q" type="text" value="A" />
+    `);
+    expect(collectAnswers(document)).toEqual([{ question: 'Question', answer: 'A' }]);
+  });
+});

--- a/apps/extension/src/lib/answers-capture.ts
+++ b/apps/extension/src/lib/answers-capture.ts
@@ -1,0 +1,101 @@
+/**
+ * Answers-capture collector (runs in the page's isolated world).
+ *
+ * Injected via `capture.ts` (compiled to `capture.js`,
+ * `chrome.scripting.executeScript({ files: ['capture.js'] })`) when the user
+ * clicks "Save my answers from this page" in the popup. Walks FILLED, visible
+ * `input[type=text]` / `textarea` / `select` elements, pairs each with its
+ * label text, and returns `{question, answer}[]` for the background to send
+ * on as `answers.save`.
+ *
+ * Shares the label/visibility/denylist primitives with `autofill.ts`
+ * (`./field-signal`) so the two directions (fill vs. capture) never drift on
+ * what counts as "labelled"/"hidden"/"ambiguous". This module and
+ * `autofill.ts` are still bundled into SEPARATE injected files (`capture.js`
+ * / `fill.js`) via isolated Rollup passes (see `vite.config.ts`'s
+ * `injectedEntries` plugin), so the shared helpers are inlined into EACH
+ * rather than hoisted into a chunk that either classic script would then
+ * have to `import`.
+ *
+ * Pure DOM — no extension APIs, no network — so it is unit-testable against a
+ * jsdom document.
+ */
+
+import { AMBIGUOUS, isHidden, labelText, matchNamedKey, textSignal } from './field-signal';
+
+/** One captured question/answer pair. */
+export interface CapturedAnswer {
+  question: string;
+  answer: string;
+}
+
+/** `<input>` types this collector reads. Narrower than autofill's
+ *  `FILLABLE_TYPES` (no `email`/`tel`/`url`): a free-text application-form
+ *  answer lives in a plain text input, and the omission avoids re-capturing
+ *  the user's own contact details (already sourced from the profile) as an
+ *  "answer". `''` is included defensively, same as autofill's set — a real
+ *  `<input>` with no `type` attribute normalizes to `"text"`. */
+const CAPTURABLE_INPUT_TYPES = new Set(['text', '']);
+
+/** True when `el`'s free-text signal is visible, not on the ambiguous/
+ *  sensitive denylist (the same discipline `autofill.ts`'s
+ *  `isCandidateField` applies, minus autofill's fill-direction-only checks —
+ *  autocomplete tokens, "already has a value"), AND not a known IDENTITY
+ *  field (name/first/last/email/phone/linkedin/github/website/location, via
+ *  the shared `matchNamedKey`) — a filled "Full Name" or "LinkedIn URL" text
+ *  field is contact-profile data, not a genuine application question, and
+ *  must never pollute `Application.answers`. */
+function isCapturable(el: HTMLElement): boolean {
+  if (isHidden(el)) return false;
+  const signal = textSignal(el);
+  if (AMBIGUOUS.some((w) => signal.includes(w))) return false;
+  return matchNamedKey(signal) === null;
+}
+
+/** The selected option's VISIBLE text (not its `value` attribute) — per the
+ *  capture spec, a `<select>`'s answer is what the user saw/chose, not the
+ *  form's internal value. `''` when nothing is selected OR the selected
+ *  option's `value` is empty — an empty value is how a placeholder option
+ *  (e.g. `<option value="">Choose one</option>`) is conventionally marked as
+ *  "nothing chosen" even though its visible text is non-blank; without this
+ *  check that placeholder text would be captured as if it were a real
+ *  answer. */
+function selectAnswer(el: HTMLSelectElement): string {
+  const opt = el.options.item(el.selectedIndex);
+  if (!opt || opt.value === '') return '';
+  return opt.text.trim();
+}
+
+/**
+ * Scan `doc` for filled, visible, labelled `input[type=text]` / `textarea` /
+ * `select` fields (skipping the ambiguous/sensitive denylist and any
+ * unlabelled or blank-valued field) and return their question/answer pairs.
+ * Pure — no side effects.
+ */
+export function collectAnswers(doc: Document): CapturedAnswer[] {
+  const out: CapturedAnswer[] = [];
+  const fields = doc.querySelectorAll<HTMLElement>('input, textarea, select');
+
+  for (const el of Array.from(fields)) {
+    let answer: string;
+    if (el instanceof HTMLInputElement) {
+      if (!CAPTURABLE_INPUT_TYPES.has(el.type)) continue;
+      answer = el.value.trim();
+    } else if (el instanceof HTMLTextAreaElement) {
+      answer = el.value.trim();
+    } else if (el instanceof HTMLSelectElement) {
+      answer = selectAnswer(el);
+    } else {
+      continue;
+    }
+    if (!answer) continue;
+    if (!isCapturable(el)) continue;
+
+    const question = labelText(el).trim();
+    if (!question) continue;
+
+    out.push({ question, answer });
+  }
+
+  return out;
+}

--- a/apps/extension/src/lib/answers-capture.ts
+++ b/apps/extension/src/lib/answers-capture.ts
@@ -21,7 +21,15 @@
  * jsdom document.
  */
 
-import { AMBIGUOUS, isHidden, labelText, matchNamedKey, textSignal } from './field-signal';
+import {
+  AMBIGUOUS,
+  autocompleteToken,
+  isHidden,
+  labelText,
+  matchAutocompleteKey,
+  matchNamedKey,
+  textSignal,
+} from './field-signal';
 
 /** One captured question/answer pair. */
 export interface CapturedAnswer {
@@ -40,13 +48,17 @@ const CAPTURABLE_INPUT_TYPES = new Set(['text', '']);
 /** True when `el`'s free-text signal is visible, not on the ambiguous/
  *  sensitive denylist (the same discipline `autofill.ts`'s
  *  `isCandidateField` applies, minus autofill's fill-direction-only checks —
- *  autocomplete tokens, "already has a value"), AND not a known IDENTITY
- *  field (name/first/last/email/phone/linkedin/github/website/location, via
- *  the shared `matchNamedKey`) — a filled "Full Name" or "LinkedIn URL" text
- *  field is contact-profile data, not a genuine application question, and
- *  must never pollute `Application.answers`. */
+ *  "already has a value"), AND not a known IDENTITY field
+ *  (name/first/last/email/phone/linkedin/github/website/location) — via
+ *  EITHER the shared `matchNamedKey` free-text signal OR the field's own
+ *  `autocomplete` attribute mapped through autofill's Tier-1
+ *  `matchAutocompleteKey` — a filled "Full Name" text field, or one merely
+ *  marked `autocomplete="name"` under a quirky label, is contact-profile
+ *  data, not a genuine application question, and must never pollute
+ *  `Application.answers`. */
 function isCapturable(el: HTMLElement): boolean {
   if (isHidden(el)) return false;
+  if (matchAutocompleteKey(autocompleteToken(el)) !== null) return false;
   const signal = textSignal(el);
   if (AMBIGUOUS.some((w) => signal.includes(w))) return false;
   return matchNamedKey(signal) === null;

--- a/apps/extension/src/lib/autofill.test.ts
+++ b/apps/extension/src/lib/autofill.test.ts
@@ -254,6 +254,14 @@ describe('planAndFill – skips ambiguous / sensitive / hidden / filled', () => 
     expect(val('dob')).toBe('');
   });
 
+  it('skips a "Driver\'s license number" field even though the matcher never targets it', () => {
+    setForm(
+      `<label for="dl">Driver's license number</label><input id="dl" type="text" autocomplete="email" />`
+    );
+    planAndFill(document, PROFILE);
+    expect(val('dl')).toBe('');
+  });
+
   it('does not map structured address sub-parts (street) from a single location string', () => {
     setForm(`<input id="street" autocomplete="street-address" />`);
     planAndFill(document, PROFILE);

--- a/apps/extension/src/lib/autofill.ts
+++ b/apps/extension/src/lib/autofill.ts
@@ -14,7 +14,14 @@
  *  - Renders an in-page summary of exactly what it did (incl. the "nothing
  *    matched" case) so a no-op never looks broken. Name is split (first token /
  *    remainder) for separate first/last fields and FLAGGED as a guess.
+ *
+ * The label/visibility/denylist primitives (`labelText`/`textSignal`/
+ * `isHidden`/`escapeId`/`AMBIGUOUS`) live in `./field-signal` — shared with
+ * `answers-capture.ts` (PR 5 of the extension roadmap) so fill and capture
+ * never disagree on what counts as labelled/visible/ambiguous.
  */
+
+import { AMBIGUOUS, isHidden, matchNamedKey, textSignal } from './field-signal';
 
 /**
  * Isolated-world global key under which `fill.ts` exposes {@link runAutofill};
@@ -83,48 +90,6 @@ const OVERLAY_ID = 'ajh-autofill-overlay';
  *  number, date, search, checkbox, radio, file, submit, …) is skipped. */
 const FILLABLE_TYPES = new Set(['text', 'email', 'tel', 'url', '']);
 
-/**
- * Substrings that make a field ambiguous or sensitive — a match on the label /
- * name / id / placeholder skips the field entirely (under-fill over mis-fill).
- * Includes the grilled set (referrer/emergency/confirm/manager/parent) plus the
- * fields most likely to receive the WRONG identity on a job-application form
- * (company/employer/recruiter), login/search noise, and — defense-in-depth, since
- * the matcher only ever writes our own name/email/phone/socials — sensitive PII
- * categories it should never touch even by accident (SSN/tax id, passport,
- * date of birth).
- */
-const AMBIGUOUS = [
-  'referr',
-  'referral',
-  'reference',
-  'emergency',
-  'confirm',
-  'manager',
-  'supervisor',
-  'parent',
-  'guardian',
-  'company',
-  'employer',
-  'organization',
-  'organisation',
-  'recruiter',
-  'search',
-  'username',
-  'user name',
-  'password',
-  'captcha',
-  'coupon',
-  'promo',
-  'maiden',
-  'ssn',
-  'social security',
-  'tax',
-  'passport',
-  'dob',
-  'birth',
-  'date of birth',
-];
-
 /** Human labels for the summary, per logical key. */
 const KEY_LABELS: Record<string, string> = {
   email: 'Email',
@@ -147,86 +112,6 @@ export function splitName(fullName: string): { first: string; last: string } {
   const first = parts[0] ?? '';
   const last = parts.slice(1).join(' ');
   return { first, last };
-}
-
-/**
- * True when the element or ANY ancestor is hidden — via the `hidden` attribute
- * or COMPUTED style (not just inline `style`): `display:none`/`visibility:hidden`,
- * `opacity:0`, off-screen absolute/fixed positioning (`left`/`top` shoved past
- * -9999px — the classic honeypot trap), or a box whose computed `width` AND
- * `height` are BOTH exactly `0px`. Computed style (not just inline `style`) is
- * what catches an external-stylesheet / `<style>` CSS-class honeypot — this is
- * how anti-bot honeypot fields are commonly planted on real ATS forms
- * (Greenhouse/Lever/Workday). An inline-only or display/visibility-only check
- * would fill them, and a filled invisible field is worse than an ordinary
- * mis-fill (the user can't see it to undo, and it can flag them as a bot).
- *
- * NOT caught, deliberately: clip-based hiding (`clip:rect(0,0,0,0)`/
- * `clip-path`) or a single-dimension-zero box (e.g. the `width:1px;height:1px`
- * shape common to `.sr-only`-style utility classes) — that is also exactly how a
- * LEGITIMATE screen-reader-only field is hidden visually while staying
- * functionally real, so treating it as hidden (and skip-filling it) would be
- * wrong. Only an unambiguous honeypot shape — display/visibility/opacity-off,
- * off-screen, or BOTH dimensions zero — is treated as hidden.
- *
- * Deliberately `getComputedStyle`-ONLY — never `getBoundingClientRect`/
- * `offsetWidth`/layout reads. jsdom (the test environment) always reports those
- * as zero, which would make every field — including normal visible ones — read
- * as hidden. Computed style has no such gap: a real field's computed `width` is
- * `auto`/a real length (never the literal string `'0px'`), its `position` is
- * `static`, and its `opacity` is `1`, so this stays jsdom-safe.
- */
-function isHidden(el: HTMLElement): boolean {
-  const view = el.ownerDocument.defaultView;
-  let node: HTMLElement | null = el;
-  while (node) {
-    if (node.hidden) return true;
-    const cs = view?.getComputedStyle(node);
-    if (cs) {
-      if (cs.display === 'none' || cs.visibility === 'hidden') return true;
-      if (Number.parseFloat(cs.opacity) === 0) return true;
-      if (
-        (cs.position === 'absolute' || cs.position === 'fixed') &&
-        (Number.parseFloat(cs.left) <= -9999 || Number.parseFloat(cs.top) <= -9999)
-      )
-        return true;
-      if (cs.width === '0px' && cs.height === '0px') return true;
-    }
-    node = node.parentElement;
-  }
-  return false;
-}
-
-/** CSS.escape when available (jsdom + browsers), else a conservative fallback. */
-function escapeId(id: string): string {
-  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(id);
-  return id.replace(/["\\]/g, '\\$&');
-}
-
-/** The associated label text for an input: `<label for>` + any wrapping `<label>`. */
-function labelText(el: HTMLInputElement): string {
-  const doc = el.ownerDocument;
-  let text = '';
-  if (el.id) {
-    const forLabel = doc.querySelector(`label[for="${escapeId(el.id)}"]`);
-    if (forLabel?.textContent) text += ` ${forLabel.textContent}`;
-  }
-  const wrapping = el.closest('label');
-  if (wrapping?.textContent) text += ` ${wrapping.textContent}`;
-  return text;
-}
-
-/** The lowercased free-text signal for Tier-2 matching (name/id/placeholder/aria/label). */
-function textSignal(el: HTMLInputElement): string {
-  return [
-    el.getAttribute('name') ?? '',
-    el.id,
-    el.getAttribute('placeholder') ?? '',
-    el.getAttribute('aria-label') ?? '',
-    labelText(el),
-  ]
-    .join(' ')
-    .toLowerCase();
 }
 
 /** The last (field) token of an `autocomplete` value, e.g. "shipping email" → "email". */
@@ -293,30 +178,9 @@ export function matchFieldKey(el: HTMLInputElement): string | null {
       break;
   }
 
-  // ── Tier 2: unambiguous free-text signal ──────────────────────────────────
-  if (signal.includes('linkedin')) return 'linkedin';
-  if (signal.includes('github')) return 'github';
-  if (signal.includes('portfolio') || /personal (web ?site|site)/.test(signal)) return 'website';
-  if (signal.includes('email') || signal.includes('e-mail')) return 'email';
-  if (signal.includes('phone') || signal.includes('mobile') || signal.includes('telephone'))
-    return 'phone';
-  if (/first name|given name|forename/.test(signal)) return 'firstName';
-  if (/last name|surname|family name/.test(signal)) return 'lastName';
-  if (signal.includes('city') || signal.includes('town') || /\blocation\b/.test(signal))
-    return 'location';
-  if (/\bfull name\b/.test(signal)) return 'fullName';
-  // A bare "Name" field (not user/file/nick/display/business/org and not an
-  // education field — "School Name"/"University Name"/"Degree Name"/… — and not
-  // a first/last variant already handled) → full name.
-  if (
-    /\bname\b/.test(signal) &&
-    !/user|file|nick|screen|display|business|org|school|institution|university|college|degree|course|program|certificat/.test(
-      signal
-    )
-  )
-    return 'fullName';
-
-  return null;
+  // ── Tier 2: unambiguous free-text signal (shared with answers-capture's
+  // exclude-identity-fields check — see `matchNamedKey`) ────────────────────
+  return matchNamedKey(signal);
 }
 
 /** The value for a logical key from the profile (+ split for first/last). */

--- a/apps/extension/src/lib/autofill.ts
+++ b/apps/extension/src/lib/autofill.ts
@@ -21,7 +21,14 @@
  * never disagree on what counts as labelled/visible/ambiguous.
  */
 
-import { AMBIGUOUS, isHidden, matchNamedKey, textSignal } from './field-signal';
+import {
+  AMBIGUOUS,
+  autocompleteToken,
+  isHidden,
+  matchAutocompleteKey,
+  matchNamedKey,
+  textSignal,
+} from './field-signal';
 
 /**
  * Isolated-world global key under which `fill.ts` exposes {@link runAutofill};
@@ -114,13 +121,6 @@ export function splitName(fullName: string): { first: string; last: string } {
   return { first, last };
 }
 
-/** The last (field) token of an `autocomplete` value, e.g. "shipping email" → "email". */
-function autocompleteField(el: HTMLInputElement): string {
-  const raw = (el.getAttribute('autocomplete') ?? '').trim().toLowerCase();
-  if (!raw || raw === 'off' || raw === 'on') return '';
-  return raw.split(/\s+/).at(-1) ?? '';
-}
-
 /**
  * The baseline gate shared by every fill tier: a fillable input TYPE, visible,
  * empty, not a card/password autocomplete token, and not matching the
@@ -132,7 +132,7 @@ function isCandidateField(el: HTMLInputElement): boolean {
   if (isHidden(el)) return false;
   if (el.value.trim() !== '') return false; // never overwrite
 
-  const ac = autocompleteField(el);
+  const ac = autocompleteToken(el);
   if (ac.startsWith('cc-') || ac === 'current-password' || ac === 'new-password') return false;
 
   const signal = textSignal(el);
@@ -151,32 +151,11 @@ function isCandidateField(el: HTMLInputElement): boolean {
 export function matchFieldKey(el: HTMLInputElement): string | null {
   if (!isCandidateField(el)) return null;
 
-  const ac = autocompleteField(el);
   const signal = textSignal(el);
 
-  // ── Tier 1: standard autocomplete tokens ──────────────────────────────────
-  switch (ac) {
-    case 'email':
-      return 'email';
-    case 'tel':
-    case 'tel-national':
-    case 'tel-local':
-      return 'phone';
-    case 'given-name':
-      return 'firstName';
-    case 'family-name':
-      return 'lastName';
-    case 'name':
-      return 'fullName';
-    case 'url':
-      return 'website';
-    // Only the city-level address token maps to the single free-text location;
-    // street/postal/state/country sub-parts can't be filled from one string.
-    case 'address-level2':
-      return 'location';
-    default:
-      break;
-  }
+  // ── Tier 1: standard autocomplete tokens (see `matchAutocompleteKey`) ─────
+  const tier1 = matchAutocompleteKey(autocompleteToken(el));
+  if (tier1) return tier1;
 
   // ── Tier 2: unambiguous free-text signal (shared with answers-capture's
   // exclude-identity-fields check — see `matchNamedKey`) ────────────────────

--- a/apps/extension/src/lib/bridge.test.ts
+++ b/apps/extension/src/lib/bridge.test.ts
@@ -1566,3 +1566,179 @@ describe('BridgeClient – updateStatus', () => {
     client.dispose();
   });
 });
+
+// ── "save my answers from this page" answers.save ↔ answers.result ────────────
+
+describe('BridgeClient – saveAnswers', () => {
+  let latestSocket: FakeWebSocket | undefined;
+  let createdSockets: FakeWebSocket[] = [];
+  let restoreWS: () => void;
+
+  beforeEach(() => {
+    latestSocket = undefined;
+    createdSockets = [];
+    restoreWS = installFakeWS((ws) => {
+      latestSocket = ws;
+      createdSockets.push(ws);
+    });
+  });
+
+  afterEach(() => {
+    restoreWS();
+    vi.useRealTimers();
+  });
+
+  async function connectedClient(): Promise<{ client: BridgeClient; socket: FakeWebSocket }> {
+    const client = new BridgeClient(vi.fn());
+    const p = client.ensureConnected();
+    await vi.waitFor(() => {
+      expect(latestSocket).toBeDefined();
+    });
+    const socket = latestSocket!;
+    socket.simulateOpen();
+    await p;
+    return { client, socket };
+  }
+
+  function makeAnswersEnvelope(reqId: string, payload: unknown): string {
+    return JSON.stringify({
+      type: EXTENSION_MESSAGE_TYPES.answersResult,
+      reqId,
+      payload,
+    });
+  }
+
+  /** Start a saveAnswers and wait until the outgoing frame is sent; return the reqId. */
+  async function startSaveAnswers(
+    client: BridgeClient,
+    socket: FakeWebSocket,
+    url: string,
+    answers: { question: string; answer: string }[]
+  ): Promise<{ resultPromise: Promise<unknown>; reqId: string }> {
+    const resultPromise = client.saveAnswers(url, answers);
+    await vi.waitFor(() => {
+      expect(socket.send).toHaveBeenCalled();
+    });
+    const raw = socket.send.mock.calls[socket.send.mock.calls.length - 1]?.[0] as string;
+    const frame = JSON.parse(raw) as { type: string; reqId: string; payload: unknown };
+    expect(frame.type).toBe(EXTENSION_MESSAGE_TYPES.answersSave);
+    expect(frame.payload).toEqual({ url, answers });
+    return { resultPromise, reqId: frame.reqId };
+  }
+
+  it('round-trips a success result (incl. title/company) into the resolved payload', async () => {
+    const { client, socket } = await connectedClient();
+    const url = 'https://jobs.example.com/posting/9';
+    const answers = [{ question: 'Why this role?', answer: 'Because I love it.' }];
+    const { resultPromise, reqId } = await startSaveAnswers(client, socket, url, answers);
+
+    const payload = {
+      ok: true,
+      applicationId: 'app-1',
+      saved: 1,
+      skipped: 0,
+      title: 'Backend Engineer',
+      company: 'Acme',
+    };
+    socket.simulateMessage(makeAnswersEnvelope(reqId, payload));
+
+    const result = await resultPromise;
+    expect(result).toEqual(payload);
+
+    client.dispose();
+  });
+
+  it('round-trips a success result WITHOUT title/company (both optional)', async () => {
+    const { client, socket } = await connectedClient();
+    const { resultPromise, reqId } = await startSaveAnswers(
+      client,
+      socket,
+      'https://jobs.example.com/posting/10',
+      []
+    );
+
+    socket.simulateMessage(
+      makeAnswersEnvelope(reqId, { ok: true, applicationId: 'app-1', saved: 0, skipped: 0 })
+    );
+
+    const result = await resultPromise;
+    expect(result).toEqual({ ok: true, applicationId: 'app-1', saved: 0, skipped: 0 });
+
+    client.dispose();
+  });
+
+  it('round-trips a desktop-side refusal (ok:false + error) into the resolved payload — never rejects', async () => {
+    const { client, socket } = await connectedClient();
+    const { resultPromise, reqId } = await startSaveAnswers(
+      client,
+      socket,
+      'https://jobs.example.com/posting/none',
+      []
+    );
+
+    socket.simulateMessage(
+      makeAnswersEnvelope(reqId, {
+        ok: false,
+        error: "couldn't find a saved job for this page — import it first",
+      })
+    );
+
+    const result = await resultPromise;
+    expect(result).toEqual({
+      ok: false,
+      error: "couldn't find a saved job for this page — import it first",
+    });
+
+    client.dispose();
+  });
+
+  it('resolves with a malformed error (never throws) when the payload is bad', async () => {
+    const { client, socket } = await connectedClient();
+    const { resultPromise, reqId } = await startSaveAnswers(
+      client,
+      socket,
+      'https://jobs.example.com/posting/bad',
+      []
+    );
+
+    // saved must be a number; a string breaks the guard.
+    socket.simulateMessage(
+      makeAnswersEnvelope(reqId, { ok: true, applicationId: 'app-1', saved: 'one', skipped: 0 })
+    );
+
+    const result = (await resultPromise) as { ok: boolean; error?: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/malformed/i);
+
+    client.dispose();
+  });
+
+  it('rejects when not connected — every port fails and the ws probe exhausts', async () => {
+    vi.useFakeTimers();
+
+    const client = new BridgeClient(vi.fn());
+    const savePromise = client.saveAnswers('https://jobs.example.com/posting/x', []);
+    const outcomePromise = savePromise.then(
+      () => ({ ok: true as const }),
+      (e: unknown) => ({ ok: false as const, error: e })
+    );
+
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const idx = attempt;
+      await vi.waitFor(() => {
+        expect(createdSockets.length).toBeGreaterThanOrEqual(idx + 1);
+      });
+      createdSockets[idx]!.simulateClose();
+    }
+
+    const outcome = await outcomePromise;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toBeInstanceOf(Error);
+      expect((outcome.error as Error).message).toMatch(/not reachable/i);
+    }
+    expect(client.status().phase).toBe('app_not_running');
+
+    client.dispose();
+  });
+});

--- a/apps/extension/src/lib/bridge.ts
+++ b/apps/extension/src/lib/bridge.ts
@@ -30,6 +30,8 @@ import { type Browser, browser } from '@wxt-dev/browser';
 import {
   EXTENSION_MESSAGE_TYPES,
   EXTENSION_PROTOCOL_VERSION,
+  type ExtensionAnswerPair,
+  type ExtensionAnswersSaveResult,
   type ExtensionAppliedCheckResult,
   type ExtensionEnvelope,
   type ExtensionImportRequest,
@@ -71,6 +73,7 @@ type PendingResolver = (result: ExtensionImportResult) => void;
 type ProfileResolver = (result: ExtensionProfileResult) => void;
 type AppliedResolver = (result: ExtensionAppliedCheckResult) => void;
 type StatusResolver = (result: ExtensionStatusUpdateResult) => void;
+type AnswersResolver = (result: ExtensionAnswersSaveResult) => void;
 
 export type BridgePhase = 'searching' | 'connected' | 'app_not_running' | 'outdated' | 'bad_token';
 
@@ -240,6 +243,50 @@ function normalizeStatusUpdateResult(payload: unknown): ExtensionStatusUpdateRes
     : { ok: false, error: payload.error };
 }
 
+/**
+ * Hand-written guard for an `answers.save` payload (extension stays
+ * zod-free). Mirrors `ExtensionAnswersSaveResultSchema`'s discriminated
+ * union: `ok:true` requires a string `applicationId` + numeric
+ * `saved`/`skipped` (title/company optional strings); `ok:false` requires a
+ * string `error`.
+ */
+function isExtensionAnswersSaveResult(v: unknown): v is ExtensionAnswersSaveResult {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  const optStr = (x: unknown): boolean => x === undefined || typeof x === 'string';
+  if (o.ok === true) {
+    return (
+      typeof o.applicationId === 'string' &&
+      typeof o.saved === 'number' &&
+      typeof o.skipped === 'number' &&
+      optStr(o.title) &&
+      optStr(o.company)
+    );
+  }
+  if (o.ok === false) return typeof o.error === 'string';
+  return false;
+}
+
+/** Rebuild an {@link ExtensionAnswersSaveResult} from only the known, defined
+ *  keys — mirrors `normalizeStatusUpdateResult`. This verb's errors are
+ *  surfaced to the user (like `status.update`), so the fallback text is
+ *  written the same way: `ok:false` + a plain `error`. */
+function normalizeAnswersSaveResult(payload: unknown): ExtensionAnswersSaveResult {
+  if (!isExtensionAnswersSaveResult(payload)) {
+    return { ok: false, error: 'The desktop app sent a malformed answers-save result.' };
+  }
+  if (!payload.ok) return { ok: false, error: payload.error };
+  const out: ExtensionAnswersSaveResult = {
+    ok: true,
+    applicationId: payload.applicationId,
+    saved: payload.saved,
+    skipped: payload.skipped,
+  };
+  if (payload.title !== undefined) out.title = payload.title;
+  if (payload.company !== undefined) out.company = payload.company;
+  return out;
+}
+
 // ── transport seam ──────────────────────────────────────────────────────────
 
 /**
@@ -394,6 +441,9 @@ export class BridgeClient {
   /** In-flight `status.update` resolvers, correlated by `reqId`. Kept separate
    *  from {@link pending} for the same reason as {@link pendingProfile}. */
   private readonly pendingStatus = new Map<string, StatusResolver>();
+  /** In-flight `answers.save` resolvers, correlated by `reqId`. Kept separate
+   *  from {@link pending} for the same reason as {@link pendingProfile}. */
+  private readonly pendingAnswers = new Map<string, AnswersResolver>();
   private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
   private backoffIndex = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -536,6 +586,7 @@ export class BridgeClient {
     this.pendingProfile.clear();
     this.pendingApplied.clear();
     this.pendingStatus.clear();
+    this.pendingAnswers.clear();
     this.transport?.close();
     this.transport = null;
   }
@@ -709,6 +760,51 @@ export class BridgeClient {
         clearTimeout(timer);
         this.timers.delete(reqId);
         this.pendingStatus.delete(reqId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  /**
+   * Send an `answers.save { url, answers }` and resolve with the validated
+   * `answers.result` payload. Rejects only on no connection / timeout / send
+   * failure — like `updateStatus`, a well-formed `ok:false` reply is NOT
+   * folded away here: this is a deliberate click action, so the caller
+   * (background.ts) must pass the `error` straight through to the popup
+   * instead of swallowing it.
+   */
+  async saveAnswers(
+    url: string,
+    answers: ExtensionAnswerPair[]
+  ): Promise<ExtensionAnswersSaveResult> {
+    await this.ensureConnected();
+    if (this.phase !== 'connected' || !this.transport) {
+      throw new Error('Desktop app not reachable. Is AI Job Hunter running?');
+    }
+    const transport = this.transport;
+
+    const reqId = newReqId();
+    const envelope: ExtensionEnvelope = {
+      type: EXTENSION_MESSAGE_TYPES.answersSave,
+      reqId,
+      payload: { url, answers },
+    };
+
+    return new Promise<ExtensionAnswersSaveResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingAnswers.delete(reqId);
+        this.timers.delete(reqId);
+        reject(new Error('Timed out waiting for the desktop app to respond.'));
+      }, REQUEST_TIMEOUT_MS);
+      this.timers.set(reqId, timer);
+      this.pendingAnswers.set(reqId, resolve);
+
+      try {
+        transport.send(envelope);
+      } catch (err) {
+        clearTimeout(timer);
+        this.timers.delete(reqId);
+        this.pendingAnswers.delete(reqId);
         reject(err instanceof Error ? err : new Error(String(err)));
       }
     });
@@ -1001,6 +1097,16 @@ export class BridgeClient {
       return;
     }
 
+    // answers.result → the "save my answers" outcome (separate map).
+    if (env.type === EXTENSION_MESSAGE_TYPES.answersResult) {
+      const resolveAnswers = this.pendingAnswers.get(reqId);
+      if (typeof resolveAnswers !== 'function') return;
+      this.pendingAnswers.delete(reqId);
+      this.clearTimer(reqId);
+      resolveAnswers(normalizeAnswersSaveResult(env.payload));
+      return;
+    }
+
     if (env.type !== EXTENSION_MESSAGE_TYPES.importResult) return;
     const resolve = this.pending.get(reqId);
     if (typeof resolve !== 'function') return;
@@ -1050,10 +1156,16 @@ export class BridgeClient {
       if (timer) clearTimeout(timer);
       resolve({ ok: false, error: reason });
     }
+    for (const [reqId, resolve] of this.pendingAnswers.entries()) {
+      const timer = this.timers.get(reqId);
+      if (timer) clearTimeout(timer);
+      resolve({ ok: false, error: reason });
+    }
     this.pending.clear();
     this.pendingProfile.clear();
     this.pendingApplied.clear();
     this.pendingStatus.clear();
+    this.pendingAnswers.clear();
     this.timers.clear();
   }
 

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -28,7 +28,8 @@
  * to receive the WRONG identity on a job-application form
  * (company/employer/recruiter), login/search noise, and — defense-in-depth —
  * sensitive PII categories that should never be touched even by accident
- * (SSN/tax id, passport, date of birth).
+ * (SSN/tax id, passport, date of birth, national id, driver's license,
+ * bank/IBAN, visa status).
  */
 export const AMBIGUOUS = [
   'referr',
@@ -60,6 +61,17 @@ export const AMBIGUOUS = [
   'dob',
   'birth',
   'date of birth',
+  'national id',
+  'national insurance',
+  'license',
+  'licence',
+  'iban',
+  'bank account',
+  'routing number',
+  'sort code',
+  'visa status',
+  'green card',
+  'immigration status',
 ];
 
 /**

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -148,6 +148,52 @@ export function textSignal(el: HTMLElement): string {
     .toLowerCase();
 }
 
+/** The last (field) token of an `autocomplete` attribute value, e.g.
+ *  "shipping email" → "email". `''` for a missing/`off`/`on` attribute. Takes
+ *  `HTMLElement` (not just `HTMLInputElement`) so `answers-capture.ts` can call
+ *  it on a `<textarea>`/`<select>` too — an `autocomplete` attribute there
+ *  simply normalizes to `''`/`off`, same as no match. Shared so autofill's
+ *  Tier-1 token reading and answers-capture's identity check never drift on
+ *  what the raw token is. */
+export function autocompleteToken(el: HTMLElement): string {
+  const raw = (el.getAttribute('autocomplete') ?? '').trim().toLowerCase();
+  if (!raw || raw === 'off' || raw === 'on') return '';
+  return raw.split(/\s+/).at(-1) ?? '';
+}
+
+/**
+ * Map a standard `autocomplete` {@link autocompleteToken} to autofill's Tier-1
+ * logical key, or `null` for a token with no fill/identity meaning here.
+ * Mirrors `matchFieldKey`'s Tier-1 switch (`autofill.ts`) — factored out here
+ * so `isCapturable` (`answers-capture.ts`) can exclude a field whose
+ * `autocomplete` attribute marks it as identity (e.g. `autocomplete="name"`)
+ * WITHOUT duplicating the token→key literals in a second copy.
+ */
+export function matchAutocompleteKey(token: string): string | null {
+  switch (token) {
+    case 'email':
+      return 'email';
+    case 'tel':
+    case 'tel-national':
+    case 'tel-local':
+      return 'phone';
+    case 'given-name':
+      return 'firstName';
+    case 'family-name':
+      return 'lastName';
+    case 'name':
+      return 'fullName';
+    case 'url':
+      return 'website';
+    // Only the city-level address token maps to the single free-text location;
+    // street/postal/state/country sub-parts can't be filled from one string.
+    case 'address-level2':
+      return 'location';
+    default:
+      return null;
+  }
+}
+
 /**
  * Resolve a lowercased field {@link textSignal} to a known identity key, or
  * `null` when it doesn't unambiguously match one. This is autofill's "Tier 2"

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -1,0 +1,187 @@
+/**
+ * Shared form-field signal primitives — label text, visibility, and the
+ * ambiguous/sensitive denylist. Factored out of `autofill.ts` (PR 5 of the
+ * extension roadmap) so BOTH `fill.ts` (assisted autofill, via
+ * `autofill.ts`) and `capture.ts` (answers capture, via
+ * `answers-capture.ts`) share ONE definition of "what counts as a labelled /
+ * visible / ambiguous field" — never two copies that could drift.
+ *
+ * Pure DOM — no extension APIs, no network — so it is unit-testable against a
+ * jsdom document. Behavior is UNCHANGED from what previously lived inline in
+ * `autofill.ts`; this is a pure extraction (its existing tests pin the
+ * behavior and pass unmodified).
+ *
+ * Build note: `fill.js` and `capture.js` are each injected via
+ * `chrome.scripting.executeScript({ files: [...] })` as CLASSIC scripts (no
+ * ES module support) — they must bundle with ZERO `import` statements. Since
+ * BOTH now genuinely share this module at runtime, `vite.config.ts` builds
+ * each in its OWN isolated Rollup pass (the `injectedEntries` plugin) so this
+ * file is inlined into EACH bundle rather than hoisted into a shared chunk
+ * that either classic script would then have to `import`.
+ */
+
+/**
+ * Substrings that make a field ambiguous or sensitive — a match on the label /
+ * name / id / placeholder skips the field entirely (under-fill over mis-fill
+ * for autofill; skip-don't-capture for answers capture). Includes the grilled
+ * set (referrer/emergency/confirm/manager/parent) plus the fields most likely
+ * to receive the WRONG identity on a job-application form
+ * (company/employer/recruiter), login/search noise, and — defense-in-depth —
+ * sensitive PII categories that should never be touched even by accident
+ * (SSN/tax id, passport, date of birth).
+ */
+export const AMBIGUOUS = [
+  'referr',
+  'referral',
+  'reference',
+  'emergency',
+  'confirm',
+  'manager',
+  'supervisor',
+  'parent',
+  'guardian',
+  'company',
+  'employer',
+  'organization',
+  'organisation',
+  'recruiter',
+  'search',
+  'username',
+  'user name',
+  'password',
+  'captcha',
+  'coupon',
+  'promo',
+  'maiden',
+  'ssn',
+  'social security',
+  'tax',
+  'passport',
+  'dob',
+  'birth',
+  'date of birth',
+];
+
+/**
+ * True when `el` or ANY ancestor is hidden — via the `hidden` attribute or
+ * COMPUTED style (not just inline `style`): `display:none`/`visibility:hidden`,
+ * `opacity:0`, off-screen absolute/fixed positioning (`left`/`top` shoved past
+ * -9999px — the classic honeypot trap), or a box whose computed `width` AND
+ * `height` are BOTH exactly `0px`. Computed style (not just inline `style`) is
+ * what catches an external-stylesheet / `<style>` CSS-class honeypot — this is
+ * how anti-bot honeypot fields are commonly planted on real ATS forms
+ * (Greenhouse/Lever/Workday). An inline-only or display/visibility-only check
+ * would fill/capture them, and a filled invisible field is worse than an
+ * ordinary mis-fill (the user can't see it to undo, and it can flag them as a
+ * bot).
+ *
+ * NOT caught, deliberately: clip-based hiding (`clip:rect(0,0,0,0)`/
+ * `clip-path`) or a single-dimension-zero box (e.g. the `width:1px;height:1px`
+ * shape common to `.sr-only`-style utility classes) — that is also exactly how a
+ * LEGITIMATE screen-reader-only field is hidden visually while staying
+ * functionally real, so treating it as hidden (and skipping it) would be
+ * wrong. Only an unambiguous honeypot shape — display/visibility/opacity-off,
+ * off-screen, or BOTH dimensions zero — is treated as hidden.
+ *
+ * Deliberately `getComputedStyle`-ONLY — never `getBoundingClientRect`/
+ * `offsetWidth`/layout reads. jsdom (the test environment) always reports those
+ * as zero, which would make every field — including normal visible ones — read
+ * as hidden. Computed style has no such gap: a real field's computed `width` is
+ * `auto`/a real length (never the literal string `'0px'`), its `position` is
+ * `static`, and its `opacity` is `1`, so this stays jsdom-safe.
+ */
+export function isHidden(el: HTMLElement): boolean {
+  const view = el.ownerDocument.defaultView;
+  let node: HTMLElement | null = el;
+  while (node) {
+    if (node.hidden) return true;
+    const cs = view?.getComputedStyle(node);
+    if (cs) {
+      if (cs.display === 'none' || cs.visibility === 'hidden') return true;
+      if (Number.parseFloat(cs.opacity) === 0) return true;
+      if (
+        (cs.position === 'absolute' || cs.position === 'fixed') &&
+        (Number.parseFloat(cs.left) <= -9999 || Number.parseFloat(cs.top) <= -9999)
+      )
+        return true;
+      if (cs.width === '0px' && cs.height === '0px') return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
+
+/** CSS.escape when available (jsdom + browsers), else a conservative fallback. */
+export function escapeId(id: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(id);
+  return id.replace(/["\\]/g, '\\$&');
+}
+
+/** The associated label text for a form element: `<label for>` + any wrapping
+ *  `<label>`. Takes `HTMLElement` (not just `HTMLInputElement`) so it works
+ *  identically for `<textarea>`/`<select>` — every member it touches
+ *  (`id`/`closest`) is generic to `Element`, not input-specific. */
+export function labelText(el: HTMLElement): string {
+  const doc = el.ownerDocument;
+  let text = '';
+  if (el.id) {
+    const forLabel = doc.querySelector(`label[for="${escapeId(el.id)}"]`);
+    if (forLabel?.textContent) text += ` ${forLabel.textContent}`;
+  }
+  const wrapping = el.closest('label');
+  if (wrapping?.textContent) text += ` ${wrapping.textContent}`;
+  return text;
+}
+
+/** The lowercased free-text signal (name/id/placeholder/aria-label/label) used
+ *  both for autofill's Tier-2 field matching and the answers-capture
+ *  denylist check. Takes `HTMLElement` for the same reason as `labelText`. */
+export function textSignal(el: HTMLElement): string {
+  return [
+    el.getAttribute('name') ?? '',
+    el.id,
+    el.getAttribute('placeholder') ?? '',
+    el.getAttribute('aria-label') ?? '',
+    labelText(el),
+  ]
+    .join(' ')
+    .toLowerCase();
+}
+
+/**
+ * Resolve a lowercased field {@link textSignal} to a known identity key, or
+ * `null` when it doesn't unambiguously match one. This is autofill's "Tier 2"
+ * signal matching (`matchFieldKey` in `autofill.ts`), factored out so it's
+ * shared with answers-capture: `isCapturable` (`answers-capture.ts`) calls it
+ * to EXCLUDE any field whose signal identifies it as one of these keys — a
+ * filled "Full Name" or "LinkedIn URL" text field must never be captured into
+ * `Application.answers` as if it were a genuine application question. Pure
+ * string matching — no element/autocomplete-attribute lookup (that stays
+ * `autofill.ts`-only "Tier 1", since capture also runs against `<select>`/
+ * `<textarea>` which don't carry the same autocomplete semantics).
+ */
+export function matchNamedKey(signal: string): string | null {
+  if (signal.includes('linkedin')) return 'linkedin';
+  if (signal.includes('github')) return 'github';
+  if (signal.includes('portfolio') || /personal (web ?site|site)/.test(signal)) return 'website';
+  if (signal.includes('email') || signal.includes('e-mail')) return 'email';
+  if (signal.includes('phone') || signal.includes('mobile') || signal.includes('telephone'))
+    return 'phone';
+  if (/first name|given name|forename/.test(signal)) return 'firstName';
+  if (/last name|surname|family name/.test(signal)) return 'lastName';
+  if (signal.includes('city') || signal.includes('town') || /\blocation\b/.test(signal))
+    return 'location';
+  if (/\bfull name\b/.test(signal)) return 'fullName';
+  // A bare "Name" field (not user/file/nick/display/business/org and not an
+  // education field — "School Name"/"University Name"/"Degree Name"/… — and not
+  // a first/last variant already handled) → full name.
+  if (
+    /\bname\b/.test(signal) &&
+    !/user|file|nick|screen|display|business|org|school|institution|university|college|degree|course|program|certificat/.test(
+      signal
+    )
+  )
+    return 'fullName';
+
+  return null;
+}

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  ExtensionAnswersSaveResult,
   ExtensionAppliedCheckResult,
   ExtensionImportResult,
   ExtensionStatusUpdateResult,
@@ -60,7 +61,14 @@ export type PopupRequest =
    * `appliedCheck`, this is a deliberate WRITE action — its failures are
    * surfaced to the user, never folded away.
    */
-  | { kind: 'statusUpdate' };
+  | { kind: 'statusUpdate' }
+  /**
+   * User-clicked "Save my answers from this page": capture the active tab's
+   * filled form fields and send them on as `answers.save`. Like
+   * `statusUpdate`, this is a deliberate WRITE action — its failures are
+   * surfaced to the user, never folded away.
+   */
+  | { kind: 'answersSave' };
 
 /** background → popup responses (discriminated by the originating request). */
 export type PopupResponse =
@@ -82,4 +90,10 @@ export type PopupResponse =
    * `result.ok` itself.
    */
   | { ok: true; kind: 'statusUpdate'; result: ExtensionStatusUpdateResult }
+  /**
+   * `ok:true` at the transport level; like `statusUpdate`, the desktop's own
+   * `ok`/`error` on `result` is what the popup renders — this verb's
+   * failures are NOT folded away.
+   */
+  | { ok: true; kind: 'answersSave'; result: ExtensionAnswersSaveResult }
   | { ok: false; error: string };

--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -88,6 +88,17 @@
         <!-- Shown only for a found+saved applied.check result; hides itself once
              the job is marked applied (re-fires the same auto-check). -->
         <button id="btn-mark-applied" class="btn" type="button" hidden>Mark as applied</button>
+        <!-- Always offered alongside the mark-as-applied flow — the post-submit
+             one-stop gesture. No match for this page → the desktop refuses with
+             a message to import the job first (never auto-creates). -->
+        <button
+          id="btn-save-answers"
+          class="btn"
+          type="button"
+          title="Save the answers you typed on this page's application form"
+        >
+          Save my answers from this page
+        </button>
         <div class="actions">
           <button id="btn-import" class="btn btn--primary" type="button">Import this job</button>
           <button

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -1111,7 +1111,7 @@ describe('resolveAnswersSaveResponse', () => {
     };
     const { text, tone } = resolveAnswersSaveResponse(res);
     expect(tone).toBe('ok');
-    expect(text).toBe('Saved 7 answers to Backend Engineer @ Acme.');
+    expect(text).toBe('Saved 7 answers to Backend Engineer @ Acme — 2 already recorded.');
   });
 
   it('singularizes the count for exactly one saved answer', () => {
@@ -1125,7 +1125,18 @@ describe('resolveAnswersSaveResponse', () => {
     expect(text).toBe('Saved 1 answer.');
   });
 
-  it('falls back to a generic "no new answers" message when saved is 0', () => {
+  it('falls back to a generic "no new answers" message when saved and skipped are both 0', () => {
+    const res = {
+      ok: true as const,
+      kind: 'answersSave' as const,
+      result: { ok: true as const, applicationId: 'app-1', saved: 0, skipped: 0 },
+    };
+    const { text, tone } = resolveAnswersSaveResponse(res);
+    expect(tone).toBe('ok');
+    expect(text).toBe('No new answers to save from this page.');
+  });
+
+  it('shows a distinct "already recorded" message when saved is 0 but skipped is not', () => {
     const res = {
       ok: true as const,
       kind: 'answersSave' as const,
@@ -1133,7 +1144,17 @@ describe('resolveAnswersSaveResponse', () => {
     };
     const { text, tone } = resolveAnswersSaveResponse(res);
     expect(tone).toBe('ok');
-    expect(text).toBe('No new answers to save from this page.');
+    expect(text).toBe('All 3 answers were already recorded.');
+  });
+
+  it('singularizes the "already recorded" message for exactly one skipped answer', () => {
+    const res = {
+      ok: true as const,
+      kind: 'answersSave' as const,
+      result: { ok: true as const, applicationId: 'app-1', saved: 0, skipped: 1 },
+    };
+    const { text } = resolveAnswersSaveResponse(res);
+    expect(text).toBe('All 1 answer was already recorded.');
   });
 
   it('names the job with only a title when company is absent', () => {

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -46,6 +46,7 @@ function buildPopupDom(): void {
     <button id="btn-import"></button>
     <button id="btn-fill"></button>
     <button id="btn-mark-applied" hidden></button>
+    <button id="btn-save-answers"></button>
     <p id="applied-status" hidden></p>
     <input id="chk-applied" type="checkbox" />
     <p id="import-msg"></p>
@@ -76,6 +77,7 @@ const {
   resolveImportButtonLabel,
   resolveShowMarkAppliedButton,
   resolveMarkAppliedResponse,
+  resolveAnswersSaveResponse,
 } = await import('./popup');
 
 const sendMessageMock = vi.mocked(browser.runtime.sendMessage);
@@ -1063,6 +1065,161 @@ describe('appliedCheck auto-check', () => {
 
     expect(status.textContent).toBe('“Job B” is saved in your pipeline.');
     expect(btnImport.textContent).toBe('Re-import / update');
+  });
+});
+
+// ── resolveAnswersSaveResponse ─────────────────────────────────────────────────
+
+describe('resolveAnswersSaveResponse', () => {
+  it('surfaces a transport-level error (unlike the passive appliedCheck fold)', () => {
+    const res = { ok: false as const, error: 'Desktop app not reachable.' };
+    const { text, tone } = resolveAnswersSaveResponse(res);
+    expect(tone).toBe('err');
+    expect(text).toBe('Desktop app not reachable.');
+  });
+
+  it('returns the unexpected-response error when kind is not answersSave', () => {
+    const res = { ok: true as const, kind: 'token' as const };
+    const { text, tone } = resolveAnswersSaveResponse(res);
+    expect(tone).toBe('err');
+    expect(text).toBe('Unexpected response — please retry.');
+  });
+
+  it('surfaces the desktop refusal text when result.ok is false', () => {
+    const res = {
+      ok: true as const,
+      kind: 'answersSave' as const,
+      result: { ok: false as const, error: "couldn't find a saved job for this page" },
+    };
+    const { text, tone } = resolveAnswersSaveResponse(res);
+    expect(tone).toBe('err');
+    expect(text).toBe("couldn't find a saved job for this page");
+  });
+
+  it('names the job with title @ company and the saved count on success', () => {
+    const res = {
+      ok: true as const,
+      kind: 'answersSave' as const,
+      result: {
+        ok: true as const,
+        applicationId: 'app-1',
+        saved: 7,
+        skipped: 2,
+        title: 'Backend Engineer',
+        company: 'Acme',
+      },
+    };
+    const { text, tone } = resolveAnswersSaveResponse(res);
+    expect(tone).toBe('ok');
+    expect(text).toBe('Saved 7 answers to Backend Engineer @ Acme.');
+  });
+
+  it('singularizes the count for exactly one saved answer', () => {
+    const res = {
+      ok: true as const,
+      kind: 'answersSave' as const,
+      result: { ok: true as const, applicationId: 'app-1', saved: 1, skipped: 0 },
+    };
+    const { text, tone } = resolveAnswersSaveResponse(res);
+    expect(tone).toBe('ok');
+    expect(text).toBe('Saved 1 answer.');
+  });
+
+  it('falls back to a generic "no new answers" message when saved is 0', () => {
+    const res = {
+      ok: true as const,
+      kind: 'answersSave' as const,
+      result: { ok: true as const, applicationId: 'app-1', saved: 0, skipped: 3 },
+    };
+    const { text, tone } = resolveAnswersSaveResponse(res);
+    expect(tone).toBe('ok');
+    expect(text).toBe('No new answers to save from this page.');
+  });
+
+  it('names the job with only a title when company is absent', () => {
+    const res = {
+      ok: true as const,
+      kind: 'answersSave' as const,
+      result: {
+        ok: true as const,
+        applicationId: 'app-1',
+        saved: 2,
+        skipped: 0,
+        title: 'QA Engineer',
+      },
+    };
+    const { text } = resolveAnswersSaveResponse(res);
+    expect(text).toBe('Saved 2 answers to QA Engineer.');
+  });
+});
+
+// ── doSaveAnswers (#btn-save-answers) ─────────────────────────────────────────
+
+describe('doSaveAnswers (#btn-save-answers)', () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+    byId<HTMLButtonElement>('btn-save-answers').disabled = false;
+    byId<HTMLParagraphElement>('import-msg').textContent = '';
+  });
+
+  it('shows "Saving your answers…" then the success confirmation, and re-enables the button', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answersSave',
+      result: {
+        ok: true,
+        applicationId: 'app-1',
+        saved: 7,
+        skipped: 0,
+        title: 'Backend Engineer',
+        company: 'Acme',
+      },
+    });
+
+    const btn = byId<HTMLButtonElement>('btn-save-answers');
+    btn.click();
+    expect(btn.disabled).toBe(true);
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe('Saving your answers…');
+
+    await flush();
+
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
+      'Saved 7 answers to Backend Engineer @ Acme.'
+    );
+    expect(btn.disabled).toBe(false);
+    expect(sendMessageMock).toHaveBeenCalledWith({ kind: 'answersSave' });
+  });
+
+  it('surfaces the desktop refusal text and re-enables the button (errors ARE shown)', async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answersSave',
+      result: { ok: false, error: "couldn't find a saved job for this page — import it first" },
+    });
+
+    const btn = byId<HTMLButtonElement>('btn-save-answers');
+    btn.click();
+    await flush();
+
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
+      "couldn't find a saved job for this page — import it first"
+    );
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('shows a retry message and re-enables the button when sendMessage rejects', async () => {
+    sendMessageMock.mockRejectedValueOnce(new Error('message channel closed'));
+
+    const btn = byId<HTMLButtonElement>('btn-save-answers');
+    btn.click();
+    await flush();
+
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
+      'Could not save your answers. Please retry.'
+    );
+    expect(btn.disabled).toBe(false);
   });
 });
 

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -192,6 +192,39 @@ export function resolveMarkAppliedResponse(res: PopupResponse): {
 }
 
 /**
+ * Given an `answersSave` response, return the message text + tone. Mirrors
+ * `resolveMarkAppliedResponse` — this verb's errors ARE shown (a deliberate
+ * click, not a passive check). On success names the job from the reply's
+ * `title`/`company` (the smaller change vs. threading the separately-fetched
+ * `appliedCheck` state through this confirmation — see the PR-5 handoff) and
+ * reports the saved count; a re-capture with nothing new to add reads as a
+ * benign "no new answers", never an error.
+ *
+ * Pure: no DOM access, no side effects.
+ */
+export function resolveAnswersSaveResponse(res: PopupResponse): {
+  text: string;
+  tone: 'ok' | 'err';
+} {
+  if (!res.ok) return { text: res.error, tone: 'err' };
+  if (res.kind !== 'answersSave') {
+    return { text: 'Unexpected response — please retry.', tone: 'err' };
+  }
+  const { result } = res;
+  if (!result.ok) return { text: result.error, tone: 'err' };
+
+  const title = result.title?.trim();
+  const company = result.company?.trim();
+  const name = title && company ? `${title} @ ${company}` : (title ?? company);
+
+  if (result.saved === 0) {
+    return { text: 'No new answers to save from this page.', tone: 'ok' };
+  }
+  const count = `${result.saved} answer${result.saved === 1 ? '' : 's'}`;
+  return { text: name ? `Saved ${count} to ${name}.` : `Saved ${count}.`, tone: 'ok' };
+}
+
+/**
  * Given a `fill` response, return the popup message + tone. The detailed summary
  * lives in the in-page overlay; the popup shows a short confirmation (or the
  * desktop's refusal when autofill is opted out). Handles the "nothing matched"
@@ -232,6 +265,7 @@ const els = {
   btnImport: byId<HTMLButtonElement>('btn-import'),
   btnFill: byId<HTMLButtonElement>('btn-fill'),
   btnMarkApplied: byId<HTMLButtonElement>('btn-mark-applied'),
+  btnSaveAnswers: byId<HTMLButtonElement>('btn-save-answers'),
   appliedStatus: byId<HTMLParagraphElement>('applied-status'),
   chkApplied: byId<HTMLInputElement>('chk-applied'),
   importMsg: byId<HTMLParagraphElement>('import-msg'),
@@ -541,6 +575,26 @@ async function doMarkApplied(): Promise<void> {
   }
 }
 
+/**
+ * Click handler for "Save my answers from this page". Sends `answersSave`
+ * and shows the result in the existing message area — UNLIKE the passive
+ * auto-check, failures ARE shown here (this is a deliberate click action).
+ */
+async function doSaveAnswers(): Promise<void> {
+  els.btnSaveAnswers.disabled = true;
+  setMsg(els.importMsg, 'Saving your answers…', 'muted');
+  try {
+    const res = await send({ kind: 'answersSave' });
+    const { text, tone } = resolveAnswersSaveResponse(res);
+    setMsg(els.importMsg, text, tone);
+  } catch {
+    // A transport/messaging rejection must not strand the status on "Saving…".
+    setMsg(els.importMsg, 'Could not save your answers. Please retry.', 'err');
+  } finally {
+    els.btnSaveAnswers.disabled = false;
+  }
+}
+
 async function doImport(): Promise<void> {
   els.btnImport.disabled = true;
   setMsg(els.importMsg, 'Importing…', 'muted');
@@ -661,6 +715,7 @@ function wire(): void {
   els.btnImport.addEventListener('click', () => void doImport());
   els.btnFill.addEventListener('click', () => void doFill());
   els.btnMarkApplied.addEventListener('click', () => void doMarkApplied());
+  els.btnSaveAnswers.addEventListener('click', () => void doSaveAnswers());
   els.btnSaveToken.addEventListener('click', () => void savePairing());
   els.tokenInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') void savePairing();

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -198,7 +198,9 @@ export function resolveMarkAppliedResponse(res: PopupResponse): {
  * `title`/`company` (the smaller change vs. threading the separately-fetched
  * `appliedCheck` state through this confirmation — see the PR-5 handoff) and
  * reports the saved count; a re-capture with nothing new to add reads as a
- * benign "no new answers", never an error.
+ * benign "no new answers", never an error. When the desktop dedupes/caps some
+ * answers, `skipped` is folded into the copy too — `saved === 0` gets a
+ * distinct "already recorded" message instead of the generic no-new-answers one.
  *
  * Pure: no DOM access, no side effects.
  */
@@ -218,10 +220,17 @@ export function resolveAnswersSaveResponse(res: PopupResponse): {
   const name = title && company ? `${title} @ ${company}` : (title ?? company);
 
   if (result.saved === 0) {
+    if (result.skipped > 0) {
+      const was = result.skipped === 1 ? 'was' : 'were';
+      const noun = `answer${result.skipped === 1 ? '' : 's'}`;
+      return { text: `All ${result.skipped} ${noun} ${was} already recorded.`, tone: 'ok' };
+    }
     return { text: 'No new answers to save from this page.', tone: 'ok' };
   }
   const count = `${result.saved} answer${result.saved === 1 ? '' : 's'}`;
-  return { text: name ? `Saved ${count} to ${name}.` : `Saved ${count}.`, tone: 'ok' };
+  const base = name ? `Saved ${count} to ${name}` : `Saved ${count}`;
+  const suffix = result.skipped > 0 ? ` — ${result.skipped} already recorded.` : '.';
+  return { text: `${base}${suffix}`, tone: 'ok' };
 }
 
 /**

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -46,12 +46,60 @@ function webExtensionAssets(): Plugin {
   };
 }
 
+/**
+ * `fill.ts` (assisted autofill) and `capture.ts` (answers capture) are BOTH
+ * injected via `chrome.scripting.executeScript({ files: [...] })`, which runs
+ * as a CLASSIC script (no ES modules) — so each compiled bundle must carry
+ * ZERO `import` statements. Since PR 5 of the extension roadmap, they
+ * genuinely share runtime code (`lib/field-signal.ts`, via `lib/autofill.ts`
+ * and `lib/answers-capture.ts` respectively): if built together with the main
+ * multi-entry pass above, Rollup's default cross-entry chunking would hoist
+ * that shared module into a `chunks/*.js` file that BOTH `fill.js` and
+ * `capture.js` would then `import` — breaking classic-script injection
+ * (verified empirically: two entries sharing a static import always get
+ * split into a shared chunk in one Rollup pass, even with no other config).
+ *
+ * The fix: build each in its OWN isolated single-entry Rollup pass (this
+ * plugin's `closeBundle`, which runs after the main bundle above has already
+ * written background/content/popup + the manifest/icons). A single-entry
+ * pass has nothing to hoist against, so the shared helpers are INLINED into
+ * each file instead. `emptyOutDir: false` so neither pass wipes what the
+ * other (or the main build) already wrote.
+ */
+function injectedEntries(): Plugin {
+  return {
+    name: 'ajh-injected-classic-scripts',
+    apply: 'build',
+    async closeBundle() {
+      const { build } = await import('vite');
+      for (const name of ['fill', 'capture']) {
+        await build({
+          configFile: false,
+          root: srcDir,
+          logLevel: 'warn',
+          build: {
+            outDir,
+            emptyOutDir: false,
+            target: 'es2022',
+            modulePreload: false,
+            rollupOptions: {
+              input: { [name]: resolve(srcDir, `${name}.ts`) },
+              output: { entryFileNames: '[name].js', format: 'es' },
+            },
+          },
+          esbuild: { legalComments: 'none' },
+        });
+      }
+    },
+  };
+}
+
 export default defineConfig({
   root: srcDir,
   // Relative base so the popup HTML references ./popup.js / ./popup.css from the
   // extension root rather than an absolute path the packaged extension can't use.
   base: './',
-  plugins: [webExtensionAssets()],
+  plugins: [webExtensionAssets(), injectedEntries()],
   build: {
     outDir,
     emptyOutDir: true,
@@ -61,8 +109,6 @@ export default defineConfig({
       input: {
         background: resolve(srcDir, 'background.ts'),
         content: resolve(srcDir, 'content.ts'),
-        // Assisted-autofill injected script (executeScript files: ['fill.js']).
-        fill: resolve(srcDir, 'fill.ts'),
         popup: resolve(srcDir, 'popup.html'),
       },
       output: {

--- a/packages/shared/src/ipc/extension-protocol-constants.ts
+++ b/packages/shared/src/ipc/extension-protocol-constants.ts
@@ -40,9 +40,10 @@ export const EXTENSION_PROTOCOL_VERSION = 2;
  * is the force-cutover reply the desktop sends when a connection's first frame
  * is not a valid v2 `hello` (a legacy token `auth`, a missing/older protocol).
  * `import.request` / `import.result` / `profile.get` / `profile.result` /
- * `applied.check` / `applied.result` / `status.update` / `status.result` are
- * the post-auth application frames; `match.live` is **reserved** (fixed now
- * so a future build can add a handler without a protocol bump).
+ * `applied.check` / `applied.result` / `status.update` / `status.result` /
+ * `answers.save` / `answers.result` are the post-auth application frames;
+ * `match.live` is **reserved** (fixed now so a future build can add a
+ * handler without a protocol bump).
  *
  * **Consent-gate boundary** (the rule the remaining post-auth verbs copy): a
  * read-only lookup over the user's own device-local metadata (`applied.check`)
@@ -54,7 +55,12 @@ export const EXTENSION_PROTOCOL_VERSION = 2;
  * desktop-enforced opt-in. `profile.result.extraLinks` (additional labelled
  * link URLs) is fresh PII of exactly the same class as the rest of that
  * payload (`linkedin`/`github`/`website`, …), so it rides the SAME `profile.get`
- * opt-in gate — no separate consent surface, no protocol bump.
+ * opt-in gate — no separate consent surface, no protocol bump. `answers.save`
+ * WRITES freshly-captured page-derived text into the local store — the
+ * mirror direction of `profile.get`'s fill (capture vs. fill are the two
+ * directions of the one PII-adjacent gesture) — so it rides that SAME
+ * assisted-autofill opt-in too, not the read-only/exact-match-write carve-out
+ * `applied.check`/`status.update` get.
  */
 export const EXTENSION_MESSAGE_TYPES = {
   /** Extension → desktop: handshake step 1 — `{ protocol, clientNonce }`, no token. */
@@ -112,6 +118,22 @@ export const EXTENSION_MESSAGE_TYPES = {
    * deliberate click, not a passive background check).
    */
   statusResult: 'status.result',
+  /**
+   * Extension → desktop: "save my answers from this page" — append the
+   * captured `{question, answer}` pairs from the active tab's filled form
+   * fields onto the Application matched by (canonicalized + normalized)
+   * `url`. No match → a refusal telling the user to import the job first
+   * (see {@link ExtensionAnswersSaveResult}); NEVER auto-creates. Rides the
+   * assisted-autofill opt-in (same gate as `profile.get`/`fill` — capture is
+   * the mirror direction of fill).
+   */
+  answersSave: 'answers.save',
+  /**
+   * Desktop → extension: the `answers.save` outcome. Like `status.update`,
+   * this verb's errors are user-facing — the popup must render `error`,
+   * never fold it into a silent no-op (it answers a deliberate click).
+   */
+  answersResult: 'answers.result',
 } as const;
 
 /** Union of all wire `type` strings. */
@@ -298,6 +320,50 @@ export interface ExtensionStatusUpdateRequest {
  */
 export type ExtensionStatusUpdateResult =
   { ok: true; applicationId: string; status: 'applied' } | { ok: false; error: string };
+
+/** One captured application-form question/answer pair (page-derived, UNTRUSTED
+ *  text) — see {@link ExtensionAnswersSaveRequest}. */
+export interface ExtensionAnswerPair {
+  question: string;
+  answer: string;
+}
+
+/**
+ * `answers.save` payload — the active tab's url plus the captured
+ * `{question, answer}` pairs to append onto the matched Application. Untrusted
+ * page-derived content: the desktop clamps each field's byte length and the
+ * array's entry count at the store boundary (client-side validation here is
+ * shape-only).
+ */
+export interface ExtensionAnswersSaveRequest {
+  url: string;
+  answers: ExtensionAnswerPair[];
+}
+
+/**
+ * `answers.save` payload — a discriminated union so a reply can never mix
+ * success and failure fields: `ok:true` carries the matched `applicationId`,
+ * `saved` (newly-added count) and `skipped` (dedup-dropped count), plus the
+ * OPTIONAL `title`/`company` of the matched Application — included on the
+ * wire (unlike {@link ExtensionStatusUpdateResult}, which keeps them
+ * notification-only) because the handler already loaded the Application row
+ * for this verb, so surfacing them here is the smaller change than threading
+ * the popup's separately-fetched `applied.check` state through to this
+ * confirmation. `ok:false` always carries a user-facing `error` (autofill
+ * opt-in off / no match — import the job first / a malformed request).
+ * UNLIKE {@link ExtensionAppliedCheckResult}, this verb's errors ARE shown to
+ * the user — it answers a deliberate click, not a passive background check.
+ */
+export type ExtensionAnswersSaveResult =
+  | {
+      ok: true;
+      applicationId: string;
+      saved: number;
+      skipped: number;
+      title?: string;
+      company?: string;
+    }
+  | { ok: false; error: string };
 
 /**
  * The transport envelope every frame is wrapped in. `payload` is left as

--- a/packages/shared/src/ipc/extension-protocol.test.ts
+++ b/packages/shared/src/ipc/extension-protocol.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  ExtensionAnswersSaveRequestSchema,
+  ExtensionAnswersSaveResultSchema,
   ExtensionAppliedCheckRequestSchema,
   ExtensionAppliedCheckResultSchema,
   ExtensionEnvelopeSchema,
@@ -387,6 +389,129 @@ describe('ExtensionStatusUpdateResultSchema', () => {
         type: EXTENSION_MESSAGE_TYPES.statusResult,
         reqId: 'req-005',
         payload: { ok: true, applicationId: 'app-1', status: 'applied' },
+      })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ExtensionAnswersSaveRequestSchema / ExtensionAnswersSaveResultSchema
+// ---------------------------------------------------------------------------
+
+describe('ExtensionAnswersSaveRequestSchema', () => {
+  it('accepts a valid request with captured pairs', () => {
+    expect(() =>
+      ExtensionAnswersSaveRequestSchema.parse({
+        url: 'https://example.com/job/123',
+        answers: [{ question: 'Why this role?', answer: 'Because I love it.' }],
+      })
+    ).not.toThrow();
+  });
+
+  it('accepts an empty answers array', () => {
+    expect(() =>
+      ExtensionAnswersSaveRequestSchema.parse({ url: 'https://example.com/job/123', answers: [] })
+    ).not.toThrow();
+  });
+
+  it('rejects an empty url', () => {
+    expect(() => ExtensionAnswersSaveRequestSchema.parse({ url: '', answers: [] })).toThrow();
+  });
+
+  it('rejects a request with no url field', () => {
+    expect(() => ExtensionAnswersSaveRequestSchema.parse({ answers: [] })).toThrow();
+  });
+
+  it('rejects a request with no answers field', () => {
+    expect(() =>
+      ExtensionAnswersSaveRequestSchema.parse({ url: 'https://example.com/job/123' })
+    ).toThrow();
+  });
+
+  it('rejects a malformed answer entry (missing answer)', () => {
+    expect(() =>
+      ExtensionAnswersSaveRequestSchema.parse({
+        url: 'https://example.com/job/123',
+        answers: [{ question: 'Why this role?' }],
+      })
+    ).toThrow();
+  });
+
+  it('rejects a non-array answers field', () => {
+    expect(() =>
+      ExtensionAnswersSaveRequestSchema.parse({
+        url: 'https://example.com/job/123',
+        answers: 'not-an-array',
+      })
+    ).toThrow();
+  });
+});
+
+describe('ExtensionAnswersSaveResultSchema', () => {
+  it('round-trips a success payload with title/company', () => {
+    const payload = {
+      ok: true,
+      applicationId: 'app-1',
+      saved: 3,
+      skipped: 1,
+      title: 'Backend Engineer',
+      company: 'Acme',
+    };
+    expect(ExtensionAnswersSaveResultSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('round-trips a success payload without title/company (both optional)', () => {
+    const payload = { ok: true, applicationId: 'app-1', saved: 0, skipped: 0 };
+    expect(ExtensionAnswersSaveResultSchema.parse(payload)).toEqual(payload);
+  });
+
+  it("accepts a user-facing failure payload (this verb's errors are shown, unlike applied.check)", () => {
+    expect(() =>
+      ExtensionAnswersSaveResultSchema.parse({
+        ok: false,
+        error: "couldn't find a saved job for this page — import it first",
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects a missing ok field', () => {
+    expect(() => ExtensionAnswersSaveResultSchema.parse({})).toThrow();
+  });
+
+  it('rejects a non-boolean ok field', () => {
+    expect(() => ExtensionAnswersSaveResultSchema.parse({ ok: 'yes' })).toThrow();
+  });
+
+  it('rejects an incomplete ok:true payload missing saved/skipped', () => {
+    expect(() =>
+      ExtensionAnswersSaveResultSchema.parse({ ok: true, applicationId: 'app-1' })
+    ).toThrow();
+  });
+
+  it('rejects a contradictory ok:false payload carrying success fields but no error', () => {
+    expect(() =>
+      ExtensionAnswersSaveResultSchema.parse({
+        ok: false,
+        applicationId: 'app-1',
+        saved: 1,
+        skipped: 0,
+      })
+    ).toThrow();
+  });
+
+  it('carries answers.save / answers.result through a valid envelope', () => {
+    expect(() =>
+      ExtensionEnvelopeSchema.parse({
+        type: EXTENSION_MESSAGE_TYPES.answersSave,
+        reqId: 'req-006',
+        payload: { url: 'https://example.com/job/123', answers: [] },
+      })
+    ).not.toThrow();
+    expect(() =>
+      ExtensionEnvelopeSchema.parse({
+        type: EXTENSION_MESSAGE_TYPES.answersResult,
+        reqId: 'req-007',
+        payload: { ok: true, applicationId: 'app-1', saved: 1, skipped: 0 },
       })
     ).not.toThrow();
   });

--- a/packages/shared/src/ipc/extension-protocol.ts
+++ b/packages/shared/src/ipc/extension-protocol.ts
@@ -20,6 +20,9 @@ import { z } from 'zod';
 import {
   EXTENSION_MESSAGE_TYPES,
   EXTENSION_PROTOCOL_VERSION,
+  type ExtensionAnswerPair,
+  type ExtensionAnswersSaveRequest,
+  type ExtensionAnswersSaveResult,
   type ExtensionAppliedCheckRequest,
   type ExtensionAppliedCheckResult,
   type ExtensionAuthOkPayload,
@@ -42,6 +45,9 @@ import {
 export {
   EXTENSION_MESSAGE_TYPES,
   EXTENSION_PROTOCOL_VERSION,
+  type ExtensionAnswerPair,
+  type ExtensionAnswersSaveRequest,
+  type ExtensionAnswersSaveResult,
   type ExtensionAppliedCheckRequest,
   type ExtensionAppliedCheckResult,
   type ExtensionAuthOkPayload,
@@ -76,6 +82,8 @@ export const ExtensionMessageTypeSchema = z.enum([
   EXTENSION_MESSAGE_TYPES.appliedResult,
   EXTENSION_MESSAGE_TYPES.statusUpdate,
   EXTENSION_MESSAGE_TYPES.statusResult,
+  EXTENSION_MESSAGE_TYPES.answersSave,
+  EXTENSION_MESSAGE_TYPES.answersResult,
 ]) satisfies z.ZodType<ExtensionMessageType>;
 
 /** `hello` payload (handshake step 1). No token — the proof authenticates later. */
@@ -189,6 +197,40 @@ export const ExtensionStatusUpdateResultSchema = z.discriminatedUnion('ok', [
   z.object({ ok: z.literal(true), applicationId: z.string(), status: z.literal('applied') }),
   z.object({ ok: z.literal(false), error: z.string() }),
 ]) satisfies z.ZodType<ExtensionStatusUpdateResult>;
+
+/** One captured `{question, answer}` pair. Mirrors {@link ExtensionAnswerPair}. */
+export const ExtensionAnswerPairSchema = z.object({
+  question: z.string(),
+  answer: z.string(),
+}) satisfies z.ZodType<ExtensionAnswerPair>;
+
+/**
+ * `answers.save` payload — the url plus the captured pairs to append. Mirrors
+ * {@link ExtensionAnswersSaveRequest}. Shape-only (no byte/entry caps): the
+ * desktop store boundary is the real clamp, matching the sibling request
+ * schemas above (`ExtensionImportRequestSchema` et al. don't cap either).
+ */
+export const ExtensionAnswersSaveRequestSchema = z.object({
+  url: z.string().min(1),
+  answers: z.array(ExtensionAnswerPairSchema),
+}) satisfies z.ZodType<ExtensionAnswersSaveRequest>;
+
+/**
+ * `answers.save` payload. Mirrors {@link ExtensionAnswersSaveResult} — a
+ * discriminated union on `ok`: `ok:true` requires `applicationId` + numeric
+ * `saved`/`skipped` (title/company optional); `ok:false` requires `error`.
+ */
+export const ExtensionAnswersSaveResultSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+    applicationId: z.string(),
+    saved: z.number(),
+    skipped: z.number(),
+    title: z.string().optional(),
+    company: z.string().optional(),
+  }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]) satisfies z.ZodType<ExtensionAnswersSaveResult>;
 
 /**
  * The transport envelope every frame is wrapped in. `payload` is left as


### PR DESCRIPTION
## Summary

Answers capture — the foundation for answer replay (PR 5 of the extension roadmap): one explicit popup click saves the screening answers you just typed on an application form into the matched application.

- **Collector** (`capture.js`, new injected classic script): walks filled, visible, labeled `text`/`textarea`/`select` fields; excludes identity fields (name/email/phone/linkedin/…, via the new shared `matchNamedKey`), the sensitive-signal denylist, password/hidden types, select placeholders (empty-`value` options), and unlabeled fields. Computed-style-only visibility. Label extraction factored into `lib/field-signal.ts`, shared with autofill (behavior-preserving — autofill's tests unchanged).
- **Wire**: `answers.save {url, answers}` → discriminated `answers.result` (`{ok:true, applicationId, saved, skipped, title?, company?} | {ok:false, error}`). `skipped` reconciles every drop site (dedup + per-call cap + store cap). Gated on the autofill opt-in desktop-side; errors user-facing; fixed sentinels.
- **Store**: new `ApplicationStore::merge_answers` — single transaction, normalized-question dedup, existing answers always win, 1KB/8KB char-boundary clamps, 50/call + 500/application caps, serialize failures roll back.
- **Data-loss fix the ensemble caught**: `upsert_internal` used to wholesale-replace `answers` — the moment this PR added a second writer, the in-app AI answers save would have silently wiped extension-captured answers. `upsert_internal` now merges **by question** (incoming wins per normalized question, everything else preserved), which also fixed the legacy `backfill_from_generations` path. Regression test pins the cross-feature ordering.
- **Build safety**: `fill.js`/`capture.js` are built in isolated single-entry passes (shared modules would otherwise hoist into an ES chunk and break classic-script injection); the packaging step now hard-fails if either bundle ever contains `import`/`export`.
- Popup: pairing-gated before any DOM read; confirmation shows saved + already-recorded counts.

## Review trail (pre-PR gates)

- tauri-security-reviewer: PASS — untrusted-text boundary enforced Rust-side; sensitive-field exclusion verified; parameterized SQL; no auto-create; device-local only. Its two adoptable LOWs (total cap, serialize rollback) implemented.
- extension-reviewer: HIGH (uniqueness-test drift) + 3 MEDIUMs (identity-field capture pollution, select placeholders, automated import-free assertion) all fixed.
- /review full-tier 3-pass ensemble: the surviving HIGH (cross-feature answers wipe, above) and MEDIUM (`skipped` reconciliation + popup rendering) fixed; coverage nits closed.

## Test plan

- Rust: 63 applications + 121 extension_bridge tests (merge semantics both writers, caps incl. content-survival, cross-feature regression, auth-boundary ×3, clamps, opt-in refusal, store-cap `skipped`); full crate 2219; exact CI clippy clean.
- Extension: 245 tests (collector matrix, guard round-trips, pairing short-circuit, popup states incl. skipped copy).
- Shared: 203 tests; `gen:ipc:check` clean; whole-graph typecheck + lint:strict clean.

Part of the approved extension roadmap (PR 5 of 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Save my answers from this page” to the browser extension.
  * Captures eligible, visible form responses and saves them to matching applications.
  * Displays saved and skipped answer counts with clear success and error messages.

* **Bug Fixes**
  * Prevents duplicate answers and limits stored responses to protect against excessive growth.
  * Preserves existing answers while updating matching questions.
  * Improves handling of invalid pages, unavailable applications, and malformed form data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->