### PR TITLE
test: pin xing and stepstone list urls as already canonical

### DIFF
--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -183,6 +183,32 @@ fn retains_per_host_identifying_query_params_for_dedup() {
     );
 }
 
+/// Companion to the `canonical_xing_*`/`canonical_stepstone_*` tests in
+/// `scraping::scrape_url::test` (PR 7): both hosts put the job id in the PATH, so
+/// neither has an entry in `identifying_query_params` — the whole query must be
+/// dropped, not just the tracking param, via `retain_identifying_params` seeing an
+/// empty allowlist for the host. Pinned against the real detail-URL shapes
+/// (including their tracking params, Xing `?ijt=`/StepStone `?rltr=`) captured
+/// live during PR 7's browser probe, so this fails if either host ever gains a
+/// query-param allowlist entry without an accompanying deliberate decision, or if
+/// `retain_identifying_params`/`identifying_query_params` regress to leaking an
+/// unlisted host's query through.
+#[test]
+fn xing_and_stepstone_tracking_query_is_dropped_entirely() {
+    assert_eq!(
+        normalize_job_url(
+            "https://www.xing.com/jobs/berlin-senior-software-engineer-155853218?ijt=jb_55"
+        ),
+        "https://xing.com/jobs/berlin-senior-software-engineer-155853218"
+    );
+    assert_eq!(
+        normalize_job_url(
+            "https://www.stepstone.de/stellenangebote--Software-Engineer-m-w-d-Distribution-Berlin-GEMA-Gesellschaft-fuer-musik-Auffuehrungs-und-mechan-Vervielfaeltigungsrechte--14009455-inline.html?rltr=1_1_25_seorl_m_0_0_0_0_0_0"
+        ),
+        "https://stepstone.de/stellenangebote--software-engineer-m-w-d-distribution-berlin-gema-gesellschaft-fuer-musik-auffuehrungs-und-mechan-vervielfaeltigungsrechte--14009455-inline.html"
+    );
+}
+
 #[test]
 fn status_from_id_is_relaxed_and_round_trips() {
     for &s in ApplicationStatus::ALL {

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
@@ -149,8 +149,32 @@ pub fn canonical_job_url(url: &str) -> Option<String> {
         return None;
     }
 
-    // TODO(import): Glassdoor (jobListingId/jl), Xing, StepStone — need a real
-    // captured URL to pin the param + canonical template. Tracked as a follow-up.
+    // Xing (live-probed, PR 7): as observed in public/no-login sessions, selecting
+    // a job in the list navigates straight to the path-canonical URL — clicking a
+    // job title is a full same-tab navigation to `xing.com/jobs/<slug>-<id>`, never
+    // a shell URL with the selection only in a query param. So there is nothing for
+    // this function to rewrite; the per-visit tracking param Xing appends (`?ijt=`)
+    // is dropped whole by `applications::normalize_job_url`'s `retain_identifying_
+    // params` step, which consults `identifying_query_params(host)` for what to
+    // keep — Xing has no entry there, so the whole query is dropped. See
+    // `canonical_xing_*` tests below for the pinned evidence.
+    //
+    // TODO(import): StepStone — the same "nothing to rewrite" finding held for the
+    // public/no-login list flow (a job title opens the canonical detail URL, id in
+    // the path, in a new tab — `stepstone.de/stellenangebote--<slug>--<id>-inline.
+    // html`; its tracking param `?rltr=` is dropped the same way as Xing's `?ijt=`,
+    // see `canonical_stepstone_*` tests below). But the site also has a login-gated
+    // "inline preview" / split-view mode — a signup modal intercepted the
+    // card-body click during the live probe, so that mode was (correctly) never
+    // explored, and this resolver's only real caller is the extension import path
+    // on the user's authenticated tab. That mode may carry the selected job in a
+    // query param instead. Reopen if authenticated imports are observed resolving
+    // a list shell rather than the selected job.
+    //
+    // TODO(import): Glassdoor (jobListingId/jl) — still needs a real captured URL;
+    // glassdoor.com/.de returned a Cloudflare "Just a moment…" challenge page for
+    // this session (homepage + search, both TLDs), blocking live verification.
+    // Tracked as a follow-up.
     None
 }
 

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
@@ -808,6 +808,55 @@ fn canonical_unknown_host_is_none() {
     );
 }
 
+// PR 7 verify-live gate: Xing and StepStone were live-probed via browser
+// automation (public, no-login search); in those sessions neither host left the
+// current tab on a list-shell URL with the selected job only in a query param —
+// clicking a job title fully navigated straight to the canonical detail URL (id
+// already in the path). These four tests are regression guards against a
+// careless future match arm "fixing" a shape that was never broken: they pin
+// `canonical_job_url` returning `None` for the exact captured list-search and
+// detail URL shapes (tracking query params included, to prove the function
+// ignores them) for both hosts. See the TODO above `canonical_job_url` for the
+// StepStone login-gated caveat this observation doesn't cover.
+
+#[test]
+fn canonical_xing_list_search_url_is_none() {
+    assert_eq!(
+        super::canonical_job_url(
+            "https://www.xing.com/jobs/search?keywords=software+engineer&location=Berlin"
+        ),
+        None
+    );
+}
+
+#[test]
+fn canonical_xing_detail_url_is_none() {
+    assert_eq!(
+        super::canonical_job_url(
+            "https://www.xing.com/jobs/berlin-senior-software-engineer-155853218"
+        ),
+        None
+    );
+}
+
+#[test]
+fn canonical_stepstone_list_search_url_is_none() {
+    assert_eq!(
+        super::canonical_job_url("https://www.stepstone.de/jobs/software-engineer/in-berlin"),
+        None
+    );
+}
+
+#[test]
+fn canonical_stepstone_detail_url_is_none() {
+    assert_eq!(
+        super::canonical_job_url(
+            "https://www.stepstone.de/stellenangebote--Software-Engineer-m-w-d-Distribution-Berlin-GEMA-Gesellschaft-fuer-musik-Auffuehrungs-und-mechan-Vervielfaeltigungsrechte--14009455-inline.html"
+        ),
+        None
+    );
+}
+
 // ── Hardened JSON-LD / __NEXT_DATA__ / multi-location / main-content ──────────
 
 #[test]

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
@@ -833,7 +833,7 @@ fn canonical_xing_list_search_url_is_none() {
 fn canonical_xing_detail_url_is_none() {
     assert_eq!(
         super::canonical_job_url(
-            "https://www.xing.com/jobs/berlin-senior-software-engineer-155853218"
+            "https://www.xing.com/jobs/berlin-senior-software-engineer-155853218?ijt=jb_55"
         ),
         None
     );
@@ -851,7 +851,7 @@ fn canonical_stepstone_list_search_url_is_none() {
 fn canonical_stepstone_detail_url_is_none() {
     assert_eq!(
         super::canonical_job_url(
-            "https://www.stepstone.de/stellenangebote--Software-Engineer-m-w-d-Distribution-Berlin-GEMA-Gesellschaft-fuer-musik-Auffuehrungs-und-mechan-Vervielfaeltigungsrechte--14009455-inline.html"
+            "https://www.stepstone.de/stellenangebote--Software-Engineer-m-w-d-Distribution-Berlin-GEMA-Gesellschaft-fuer-musik-Auffuehrungs-und-mechan-Vervielfaeltigungsrechte--14009455-inline.html?rltr=1_1_25_seorl_m_0_0_0_0_0_0"
         ),
         None
     );


### PR DESCRIPTION
## Summary

Verify-live outcome for the planned Glassdoor/Xing/StepStone list-view canonicalizers (PR 7 of the extension roadmap) — **zero behavior change, and that's the finding**:

- **Xing — verified, nothing to rewrite**: in public/no-login sessions, selecting a job in the list performs a full navigation to the path-canonical URL (`/jobs/<slug>-<id>`); there is no LinkedIn-style list-shell+param state to canonicalize. Adding a match arm would be dead code.
- **StepStone — verified for the public flow, residual TODO kept**: the title link opens the path-canonical detail URL directly; however the probe surfaced a login-gated "inline preview" mode that was deliberately not explored (no account creation), and since `canonical_job_url`'s only real caller is the authenticated extension-import path, StepStone keeps a scoped TODO rather than a silent close.
- **Glassdoor — unverifiable, skipped**: Cloudflare challenges the entire site (not just detail pages, as previously believed); no URL shape could be captured. TODO stays open with the evidence inline.

Shipped as documentation + regression guards: the `canonical_job_url` TODO comment now records the session-scoped findings and the real mechanism (`normalize_job_url` → `retain_identifying_params` with the empty allowlist dropping `?ijt=`/`?rltr=` trackers), four `canonical_*` guards pin the captured URL shapes (trackers included) against careless future match arms, and a companion test pins the tracking-query drop where it actually happens.

## Review trail (pre-PR gates)

- scraping-applier-expert: its HIGH (source comment silently closed StepStone despite the probe's login-wall evidence) fixed — TODO reopened, language scoped to observed sessions, mechanism attribution corrected, companion test added.
- /review 2-pass ensemble: PASS ×2; the one survivor (doc comment misdescribing which tests carry the trackers) fixed by carrying the captured trackers in the detail-URL guards.
- Lesson recorded for future verify-live gates: a login-wall hit during probing is a required residual TODO, not a closable caveat — the consumer's real traffic is authenticated.

## Test plan

- `cargo test --lib scraping::scrape_url::` 84 passed; `applications::` 67 passed (companion test); full crate + architecture (R1–R8) green; exact CI clippy + fmt clean.
- No TS changes (both boards are path-based — no dedup-allowlist lockstep needed; `applications/mod.rs` untouched at its LOC cap).

Part of the approved extension roadmap (PR 7 of 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job link normalization for Xing and StepStone listings and detail pages.
  * Removed tracking and unnecessary query parameters from supported job URLs, producing cleaner canonical links.
  * Preserved job identifiers in both path-based and query-based URL formats.
* **Tests**
  * Added regression coverage to help ensure consistent handling of these URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->