### PR TITLE
ci: grant actions write so claude review runs can cache

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -72,6 +72,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      actions: write # cache writes (Actions cache service) need actions: write
 
     steps:
       - name: 🛡️ Harden Runner
@@ -112,6 +113,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
+      actions: write # cache writes (Actions cache service) need actions: write
 
     steps:
       - name: 🛡️ Harden Runner


### PR DESCRIPTION
## Summary

Every claude-review run logs "Cache reservation failed: cache write denied: token has no writable scopes" (e.g. run 29369668267) and re-downloads instead of caching: the jobs grant contents/pull-requests/id-token but GitHub's cache service requires `actions: write` on the job token for cache writes. Adds that scope to both jobs with an explanatory comment. Concurrency block untouched (documented cancel-in-progress gotcha). Only workflow using claude-code-action (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)