### PR TITLE
ci: publish an accurate installer-only downloads badge

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 
 # ⚙️ GitHub Actions — workflow catalog
 
-10 workflows, grouped by role. Descriptions come from each workflow's own header comment.
+11 workflows, grouped by role. Descriptions come from each workflow's own header comment.
 **✅ Required** is the only role that gates merge (CI Pipeline → its `✅ CI OK` umbrella);
 **advisory** never blocks; **security** reports to the Security tab; **deploy** publishes on push to `main`.
 
@@ -20,6 +20,7 @@
 
 ### 🔎 Advisory — never blocks
 
+[![📥 Downloads Badge](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/downloads-badge.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/downloads-badge.yml)
 [![🎨 Format Guard](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/format-guard.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/format-guard.yml)
 [![🏷️ PR Labeler](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/labeler.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/labeler.yml)
 [![🔎 Quality](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/quality.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/quality.yml)
@@ -48,13 +49,14 @@
 
 ### 🔎 Advisory — never blocks
 
-| Workflow                              | Triggers         | What it does                                                                                                                    |
-| ------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| [🎨 Format Guard](format-guard.yml)   | push, manual     | Format Guard (push to main only) The main CI Pipeline runs on pull_request only — push to main is intentionally excluded there. |
-| [🏷️ PR Labeler](labeler.yml)          | PR               | Applies area/type labels to pull requests from their changed paths (config: .github/labeler.yml).                               |
-| [🔎 Quality](quality.yml)             | PR, push, manual | Advisory quality + perf (consolidated from quality/rust-quality/benchmark).                                                     |
-| [🖥️ UI Checks](ui-checks.yml)         | PR, manual       | Advisory renderer/UI checks (consolidated from e2e/lighthouse/visual).                                                          |
-| [🧹 Workflow Lint](workflow-lint.yml) | PR, manual       | Security-audits the GitHub Actions workflows & composite actions, and keeps the workflow catalog honest.                        |
+| Workflow                                  | Triggers         | What it does                                                                                                                                                   |
+| ----------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [📥 Downloads Badge](downloads-badge.yml) | daily, manual    | Recompute the "real installer downloads" count and publish a Shields endpoint-badge JSON. The stock github/downloads/<repo>/total badge is updater-inflated —… |
+| [🎨 Format Guard](format-guard.yml)       | push, manual     | Format Guard (push to main only) The main CI Pipeline runs on pull_request only — push to main is intentionally excluded there.                                |
+| [🏷️ PR Labeler](labeler.yml)              | PR               | Applies area/type labels to pull requests from their changed paths (config: .github/labeler.yml).                                                              |
+| [🔎 Quality](quality.yml)                 | PR, push, manual | Advisory quality + perf (consolidated from quality/rust-quality/benchmark).                                                                                    |
+| [🖥️ UI Checks](ui-checks.yml)             | PR, manual       | Advisory renderer/UI checks (consolidated from e2e/lighthouse/visual).                                                                                         |
+| [🧹 Workflow Lint](workflow-lint.yml)     | PR, manual       | Security-audits the GitHub Actions workflows & composite actions, and keeps the workflow catalog honest.                                                       |
 
 ### 🚀 Deploy — publishes on push to main
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,14 +49,14 @@
 
 ### 🔎 Advisory — never blocks
 
-| Workflow                                  | Triggers         | What it does                                                                                                                                                   |
-| ----------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [📥 Downloads Badge](downloads-badge.yml) | daily, manual    | Recompute the "real installer downloads" count and publish a Shields endpoint-badge JSON. The stock github/downloads/<repo>/total badge is updater-inflated —… |
-| [🎨 Format Guard](format-guard.yml)       | push, manual     | Format Guard (push to main only) The main CI Pipeline runs on pull_request only — push to main is intentionally excluded there.                                |
-| [🏷️ PR Labeler](labeler.yml)              | PR               | Applies area/type labels to pull requests from their changed paths (config: .github/labeler.yml).                                                              |
-| [🔎 Quality](quality.yml)                 | PR, push, manual | Advisory quality + perf (consolidated from quality/rust-quality/benchmark).                                                                                    |
-| [🖥️ UI Checks](ui-checks.yml)             | PR, manual       | Advisory renderer/UI checks (consolidated from e2e/lighthouse/visual).                                                                                         |
-| [🧹 Workflow Lint](workflow-lint.yml)     | PR, manual       | Security-audits the GitHub Actions workflows & composite actions, and keeps the workflow catalog honest.                                                       |
+| Workflow                                  | Triggers               | What it does                                                                                                                                                   |
+| ----------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [📥 Downloads Badge](downloads-badge.yml) | release, daily, manual | Recompute the "real installer downloads" count and publish a Shields endpoint-badge JSON. The stock github/downloads/<repo>/total badge is updater-inflated —… |
+| [🎨 Format Guard](format-guard.yml)       | push, manual           | Format Guard (push to main only) The main CI Pipeline runs on pull_request only — push to main is intentionally excluded there.                                |
+| [🏷️ PR Labeler](labeler.yml)              | PR                     | Applies area/type labels to pull requests from their changed paths (config: .github/labeler.yml).                                                              |
+| [🔎 Quality](quality.yml)                 | PR, push, manual       | Advisory quality + perf (consolidated from quality/rust-quality/benchmark).                                                                                    |
+| [🖥️ UI Checks](ui-checks.yml)             | PR, manual             | Advisory renderer/UI checks (consolidated from e2e/lighthouse/visual).                                                                                         |
+| [🧹 Workflow Lint](workflow-lint.yml)     | PR, manual             | Security-audits the GitHub Actions workflows & composite actions, and keeps the workflow catalog honest.                                                       |
 
 ### 🚀 Deploy — publishes on push to main
 

--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -1,0 +1,81 @@
+name: 📥 Downloads Badge
+
+# ──────────────────────────────────────────────────────────────────────
+# Accurate installer-downloads badge
+# ──────────────────────────────────────────────────────────────────────
+# Purpose: Recompute the "real installer downloads" count and publish a
+#   Shields endpoint-badge JSON. The stock github/downloads/<repo>/total badge
+#   is updater-inflated — it sums latest.json polling, .sig fetches and Tauri
+#   update payloads. scripts/compute-downloads-badge.mjs keeps only OS
+#   installers (.dmg/.exe/.msi/.AppImage/.deb/.rpm).
+# Triggers:
+#   - schedule: once daily, off-peak (04:17 UTC — deliberately off the hour to
+#       dodge GitHub's top-of-hour cron congestion)
+#   - workflow_dispatch: manual refresh
+#   - release published: refresh immediately after a new release ships
+# Publish target: the orphan `badges` branch, single file downloads.json at root
+#   (raw URL consumed by the README shields endpoint badge).
+# ──────────────────────────────────────────────────────────────────────
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+  release:
+    types: [published]
+
+# Only write access — needed to push the recomputed badge to the badges branch.
+permissions:
+  contents: write
+
+# Don't cancel an in-flight publish; queue overlapping runs (schedule + release).
+concurrency:
+  group: downloads-badge
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Compute & publish badge
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          package-manager-cache: false
+
+      - name: 🔢 Compute installer downloads
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/compute-downloads-badge.mjs
+
+      - name: 📤 Publish downloads.json to the badges branch
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Idempotent: skip when the badge already on `badges` is byte-identical
+          # (no empty commit, no branch churn). The fetch also no-ops cleanly on
+          # the first run, before the branch exists.
+          if git fetch --quiet origin badges 2>/dev/null; then
+            if git show FETCH_HEAD:downloads.json > prev-downloads.json 2>/dev/null \
+               && cmp -s prev-downloads.json badge-out/downloads.json; then
+              echo "Downloads badge unchanged — skipping publish."
+              exit 0
+            fi
+          fi
+
+          # Publish as a parentless (orphan) single-file commit so `badges` stays
+          # a 1-file branch with zero main-history noise, then force-update the ref.
+          blob="$(git hash-object -w badge-out/downloads.json)"
+          tree="$(printf '100644 blob %s\tdownloads.json\n' "$blob" | git mktree)"
+          commit="$(git commit-tree "$tree" -m 'chore: update installer downloads badge [skip ci]')"
+          git push --force origin "$commit:refs/heads/badges"
+          echo "Published downloads badge to the badges branch."

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ apps/extension/store-packages/
 .vite/
 .turbo/
 storybook-static/
+# Generated Shields endpoint-badge payload — published to the `badges` branch by
+# CI, never committed to main. (scripts/compute-downloads-badge.mjs)
+badge-out/
 
 # ── TypeScript ─────────────────────────────────────────────────────────────────
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 <p align="center">
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/releases"><img alt="Release" src="https://img.shields.io/github/v/release/saeedkolivand/ai-job-hunter-app?color=e24b4a&label=release"></a>
-  <a href="https://github.com/saeedkolivand/ai-job-hunter-app/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/saeedkolivand/ai-job-hunter-app/total?color=e24b4a&label=downloads"></a>
+  <a href="https://github.com/saeedkolivand/ai-job-hunter-app/releases"><img alt="Downloads" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/saeedkolivand/ai-job-hunter-app/badges/downloads.json"></a>
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/saeedkolivand/ai-job-hunter-app/ci-pipeline.yml?branch=main&label=CI"></a>
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/saeedkolivand/ai-job-hunter-app"></a>
   <a href="LICENSE"><img alt="License: PolyForm Noncommercial 1.0.0" src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-orange.svg"></a>
@@ -471,6 +471,7 @@ at-a-glance status of every workflow, grouped by role, fetched live from the Act
 
 ### 🔎 Advisory — never blocks
 
+[![📥 Downloads Badge](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/downloads-badge.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/downloads-badge.yml)
 [![🎨 Format Guard](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/format-guard.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/format-guard.yml)
 [![🏷️ PR Labeler](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/labeler.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/labeler.yml)
 [![🔎 Quality](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/quality.yml/badge.svg)](https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/quality.yml)

--- a/scripts/compute-downloads-badge.mjs
+++ b/scripts/compute-downloads-badge.mjs
@@ -1,0 +1,82 @@
+// Computes an accurate "real installer" downloads count for the README badge.
+//
+// Why not shields' github/downloads/<repo>/total? That badge sums EVERY release
+// asset's download_count, which for a Tauri auto-updating app is dominated by
+// updater-channel traffic — NOT fresh installs:
+//   - latest.json           → pure auto-update polling (hundreds of hits/day)
+//   - *.sig sidecars        → updater signature fetches
+//   - *.app.tar.gz          → macOS Tauri update payloads (in-place updates)
+//   - *.nsis.zip            → Windows Tauri update payloads
+//   - extension *.zip        → browser-store packaging bundles, not app installs
+//   - any other *.zip/*.tar.gz → update/extension artifacts, never a fresh install
+// Counting ONLY OS installer files gives the real "downloaded the app to install
+// it" number. Everything else is updater-channel or extension-store noise.
+//
+// Output: badge-out/downloads.json — a Shields endpoint-badge payload, published
+// by .github/workflows/downloads-badge.yml to the orphan `badges` branch.
+// Run locally: GITHUB_TOKEN=$(gh auth token) node scripts/compute-downloads-badge.mjs
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = 'saeedkolivand/ai-job-hunter-app';
+
+// Real OS installers only (case-insensitive). Excludes .sig, .json (latest.json),
+// .app.tar.gz / .nsis.zip / any .zip / any .tar.gz — those are updater or
+// extension-store artifacts, not fresh installs.
+const INSTALLER_RE = /\.(dmg|exe|msi|appimage|deb|rpm)$/i;
+
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+async function fetchAllReleases() {
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'ai-job-hunter-downloads-badge',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
+
+  const releases = [];
+  for (let page = 1; ; page++) {
+    const url = `https://api.github.com/repos/${REPO}/releases?per_page=100&page=${page}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      throw new Error(`GitHub API ${res.status} ${res.statusText}: ${await res.text()}`);
+    }
+    const batch = await res.json();
+    releases.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return releases;
+}
+
+// Shields does NOT humanize an endpoint `message`, so do it here:
+// <1000 verbatim, >=1000 as "X.Yk".
+function humanize(n) {
+  return n < 1000 ? String(n) : `${(n / 1000).toFixed(1)}k`;
+}
+
+const releases = await fetchAllReleases();
+
+let total = 0;
+for (const release of releases) {
+  for (const asset of release.assets ?? []) {
+    if (INSTALLER_RE.test(asset.name)) total += asset.download_count ?? 0;
+  }
+}
+
+const badge = {
+  schemaVersion: 1,
+  label: 'downloads',
+  message: humanize(total),
+  color: 'e24b4a',
+};
+
+const outDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'badge-out');
+mkdirSync(outDir, { recursive: true });
+writeFileSync(join(outDir, 'downloads.json'), `${JSON.stringify(badge, null, 2)}\n`);
+
+process.stderr.write(
+  `installer downloads: ${total} (badge message: ${badge.message}) -> badge-out/downloads.json\n`
+);

--- a/scripts/compute-downloads-badge.mjs
+++ b/scripts/compute-downloads-badge.mjs
@@ -20,7 +20,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const REPO = 'saeedkolivand/ai-job-hunter-app';
+const REPO = process.env.GITHUB_REPOSITORY || 'saeedkolivand/ai-job-hunter-app';
 
 // Real OS installers only (case-insensitive). Excludes .sig, .json (latest.json),
 // .app.tar.gz / .nsis.zip / any .zip / any .tar.gz — those are updater or

--- a/scripts/gen-workflow-catalog.mjs
+++ b/scripts/gen-workflow-catalog.mjs
@@ -103,6 +103,7 @@ function triggers(on) {
   const labels = [];
   if (keys.includes('pull_request') || keys.includes('pull_request_target')) labels.push('PR');
   if (keys.includes('push')) labels.push('push');
+  if (keys.includes('release')) labels.push('release');
   if (keys.includes('schedule')) labels.push(scheduleLabel(on?.schedule));
   if (keys.includes('issue_comment') || keys.includes('pull_request_review_comment'))
     labels.push('comment');


### PR DESCRIPTION
## Summary

Replaces the updater-inflated README download badge with an accurate installer-only count.

**The problem:** `img.shields.io/github/downloads/.../total` sums EVERY release asset — including `latest.json` (332 hits, pure auto-update polling), `.sig` sidecars (144), and Tauri update payloads (`.app.tar.gz`/`.nsis.zip`). Of the 1,000, only **343** are real OS installers.

**The fix:**
- `scripts/compute-downloads-badge.mjs` sums `download_count` across all releases keeping only real installers (`.dmg/.exe/.msi/.AppImage/.deb/.rpm`), excluding updater/extension-store artifacts. Verified locally: 1000 → **343**.
- `.github/workflows/downloads-badge.yml` (daily `schedule` + `workflow_dispatch` + `release: published`, `contents: write` only) publishes `{schemaVersion,label,message,color}` JSON to an orphan `badges` branch (one-file branch, zero main-history noise, idempotent skip on byte-identical). Default `GITHUB_TOKEN`; force-push scoped to `refs/heads/badges` only.
- README badge → Shields `endpoint` mode reading that JSON.

**Note:** after merge, run the workflow once (`workflow_dispatch`) to create the `badges` branch and light up the badge — the raw URL 404s until then (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an accurate downloads badge that counts downloads for supported installer formats.
  - The badge updates automatically after releases and on a daily schedule.
  - Added a workflow badge for the new downloads-badge process.

- **Documentation**
  - Updated the README to display the new downloads badge.
  - Expanded workflow documentation with details about the Downloads Badge workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->