### PR TITLE
ci: drop invalid setup-node input from downloads badge workflow

### DIFF
--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -47,7 +47,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
-          package-manager-cache: false
 
       - name: 🔢 Compute installer downloads
         env:


### PR DESCRIPTION
Removes `package-manager-cache: false` from the downloads-badge workflow's setup-node step — it's not a real `actions/setup-node` input (the input is `cache`, which defaults to no caching) and was silently ignored. This job runs no dependency install, so nothing else is needed. Flagged by the AI review gate on #644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated build configuration to use the default package manager caching behavior.
  * Continued using Node.js version 22 for the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->