### PR TITLE
fix: harden the extension bridge answer-assist streaming transport

### DIFF
--- a/apps/desktop/src-tauri/src/extension_bridge/answer_assist.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/answer_assist.rs
@@ -522,12 +522,12 @@ pub(super) async fn resolve_answer_assist(
     // One more charge for the compose call itself — the LAST fallible step
     // between the Pending entry `spawn_answer_assist`'s synchronous `begin`
     // already recorded (before this whole function was ever called) and
-    // entering `compose_draft_stream` (which owns the normal
-    // register/unregister pair). A rejected charge must `unregister` that
-    // `Pending` entry, or it leaks in this connection's registry until the
-    // connection closes or the reqId is reused — `compose_draft_stream` is
-    // never reached on this early-return path to clean it up itself.
-    charge_compose_budget(&limiter, completer.provider_id().as_str(), registry, req_id)?;
+    // entering `compose_draft_stream` (which `register`s it). A rejected
+    // charge is just another `Err` this function returns — it does NOT
+    // `unregister` here; `handle_answer_assist` is the SOLE unregister owner
+    // (see its doc), so this entry is still cleaned up exactly once, there
+    // too, regardless of which fallible step produced the `Err`.
+    charge_compose_budget(&limiter, completer.provider_id().as_str())?;
     let draft = clamp_chars(
         super::stream::compose_draft_stream(app, &completer, req_id, registry, &user, sink)
             .await
@@ -547,22 +547,15 @@ pub(super) async fn resolve_answer_assist(
 /// Charge the daily provider budget for the compose call — see the call
 /// site's comment for why this is the LAST fallible step between the
 /// pre-existing `Pending` entry (from `spawn_answer_assist`'s synchronous
-/// `begin`) and `compose_draft_stream` (which owns the normal
-/// register/unregister pair). On a rejected charge, `unregister`s that
-/// `Pending` entry, so a charge failure never leaks a registry entry. Takes a
-/// plain `&Limiter` (no `AppHandle`), so this is directly unit-testable.
-fn charge_compose_budget(
-    limiter: &crate::limits::Limiter,
-    provider_id: &str,
-    registry: &super::stream::AssistStreamRegistry,
-    req_id: &str,
-) -> AppResult<()> {
+/// `begin`) and `compose_draft_stream` (which `register`s it). Never touches
+/// the registry itself — `handle_answer_assist` is the SOLE unregister owner
+/// (see its doc), so a rejected charge here is just another `Err` that
+/// caller cleans up, once, at its single return point. Takes a plain
+/// `&Limiter` (no `AppHandle`), so this is directly unit-testable.
+fn charge_compose_budget(limiter: &crate::limits::Limiter, provider_id: &str) -> AppResult<()> {
     limiter
         .charge_provider_daily(provider_id, crate::limits::PROVIDER_DAILY_MAX)
-        .map_err(|e| {
-            registry.unregister(req_id);
-            to_draft_failed("daily budget exceeded before compose", e)
-        })
+        .map_err(|e| to_draft_failed("daily budget exceeded before compose", e))
 }
 
 /// Resolve the salary reference range: the matched Application's own scraped
@@ -642,9 +635,15 @@ async fn fetch_web_notes<S: crate::commands::ai::AnswerSearcher>(
 /// `answer.assist.result` reply. `registry` is the CALLER's (this
 /// connection's) [`super::stream::AssistStreamRegistry`] — see that type's
 /// doc for why it is per-connection rather than resolved off `BridgeState`.
+/// `gen` is the generation `spawn_answer_assist`'s synchronous
+/// `begin_or_reject_duplicate` was handed back by its `begin()` call — this
+/// function's OWN entry, never a reused-`reqId` successor's — threaded
+/// through unchanged so [`unregister_after_request`] can scope its cleanup to
+/// it (see that function's doc for why).
 pub(super) async fn handle_answer_assist(
     app: &AppHandle,
     req_id: &str,
+    gen: u64,
     payload: &Value,
     registry: &super::stream::AssistStreamRegistry,
     sink: &mut dyn super::FrameSink,
@@ -681,48 +680,76 @@ pub(super) async fn handle_answer_assist(
         )),
     };
 
-    unregister_on_err(registry, req_id, &outcome);
+    unregister_after_request(registry, req_id, gen);
     answer_assist_reply(req_id, outcome)
 }
 
-/// The one cleanup point every one of `resolve_answer_assist`'s early gates
-/// (and `handle_answer_assist`'s own store-unavailable branch) relies on.
+/// The SOLE unregister owner for a `reqId`'s registry entry — called exactly
+/// ONCE per request, here, at `handle_answer_assist`'s single return point,
+/// UNCONDITIONALLY (on both `Ok` and `Err`, not just failure), and scoped to
+/// the caller's OWN `gen` (the generation `begin()` minted for THIS request —
+/// see [`super::assist_registry::StreamEntry`]'s doc).
 ///
-/// `spawn_answer_assist`'s synchronous `begin_or_reject_duplicate` always ran
-/// before `handle_answer_assist` was ever called (see its doc), so a
-/// `Pending` entry for `req_id` always exists by the time this runs — even on
-/// every one of `resolve_answer_assist`'s early gates (the ai-assist opt-in
-/// off, an empty question, no provider/résumé, the `ai_research` limiter
-/// rejecting) and the store-unavailable branch, ALL of which `return
-/// Err(...)` without ever reaching `compose_draft_stream` (the thing that
-/// would otherwise `register`/`unregister` it). Left alone, EVERY one of
-/// those common failures would leak a `Pending` entry for the rest of this
-/// connection's lifetime — and a client retrying the SAME `req_id` after a
-/// failed attempt would be wrongly rejected as "already in progress" forever
-/// after. Unregistering here on any `Err` is the one idempotent cleanup point
-/// that covers all of them; it is a safe no-op against the two paths that
-/// already clean up themselves on success (`charge_compose_budget` on a
-/// rejected charge, `compose_draft_stream`'s own end-of-stream `unregister`)
-/// since `unregister` on an already-gone `req_id` is a no-op by design. A
-/// duplicate `reqId` never reaches `handle_answer_assist` at all (rejected
+/// This is a two-layer fix. Layer 1 (CodeRabbit): before, THREE sites could
+/// `unregister` the same `reqId` (`charge_compose_budget` on a rejected
+/// charge, `compose_draft_stream`'s own end-of-stream cleanup, and this
+/// function on an early-gate `Err`) — consolidated here as the ONE owner, so
+/// every other call site now only ever produces an `Ok`/`Err` outcome and
+/// never touches the registry itself.
+///
+/// Layer 2 (security review, on top of layer 1) — the ACCURATE invariant:
+/// single-ownership alone does NOT fully close the reuse clobber, because
+/// [`super::stream::AssistStreamRegistry::cancel`]/`cancel_all` remove an
+/// entry independently of this owner's cleanup, keyed by `reqId` alone. A
+/// request A can `register` Running, an `assist.cancel` can remove A's entry
+/// (cancelling its job) WHILE A's own `resolve_answer_assist` is still
+/// running, a client can then reuse the SAME `reqId` for a brand-new request
+/// B which `begin`s + `register`s successfully — and only THEN does A reach
+/// this call. Keyed by `reqId` alone, A's cleanup would clobber B's fresh
+/// entry, leaving B's billable job unreachable/uncancellable. Generation
+/// scoping is what actually closes it: `registry.unregister_gen(req_id, gen)`
+/// only ever removes the entry if its STORED generation still equals `gen` —
+/// B's entry always carries a strictly higher generation than A's, so A's
+/// call here is a no-op against it, no matter how late it arrives.
+///
+/// Verified against every path that can reach here: `spawn_answer_assist`'s
+/// synchronous `begin_or_reject_duplicate` always ran before
+/// `handle_answer_assist` was ever called (see its doc) and handed back the
+/// `gen` this function receives, so a `Pending(gen)` OR `Running(gen, _)`
+/// entry for `req_id` always exists by the time this runs — whether
+/// `resolve_answer_assist` returned early (the ai-assist opt-in off, an
+/// empty question, no provider/résumé, the `ai_research` limiter rejecting, a
+/// rejected daily-budget charge), the store-unavailable branch above returned
+/// early, OR `compose_draft_stream` ran to completion (success or a genuine
+/// provider error) and `register`ed a `Running` job (preserving the SAME
+/// `gen`) along the way. An `assist.cancel` landing anywhere in that window
+/// is unaffected: `cancel`/`register` already consume the entry themselves
+/// (`Running` → cancelled + removed, `Pending` → `CancelledEarly` → consumed
+/// by the next `register` call) — `cancel`/`cancel_all` may free the entry
+/// EARLIER than this call, by design, targeting whatever currently holds
+/// `req_id` regardless of generation — so THIS call is then simply a no-op:
+/// `unregister_gen` on an already-gone `req_id`, OR one whose generation has
+/// since moved on (a reused-`reqId` successor), is a no-op, never an error.
+/// A duplicate `reqId` never reaches `handle_answer_assist` at all (rejected
 /// earlier by `begin_or_reject_duplicate`), so this can never remove an
-/// ORIGINAL in-flight entry out from under it.
+/// ORIGINAL in-flight entry out from under it. A whole-connection disconnect
+/// is unaffected too — `cancel_all` reaps every entry on THIS connection's
+/// registry regardless of whether any individual request ever reaches this
+/// call.
 ///
-/// Factored into its own tiny, pure(-ish — one `Mutex` lock, no `AppHandle`)
-/// function so it's directly unit-testable without a live `AppHandle` — this
-/// crate has no `tauri::test` mock-app harness. `handle_answer_assist`'s own
-/// end-to-end wiring (this helper actually being called with the right
-/// `registry`/`req_id`) is covered by inspection plus the existing gate
-/// tests (`check_ai_assist_gate_refuses_when_opt_in_off`, etc.) — those
-/// exercise the exact `Err` values this cleans up after.
-fn unregister_on_err(
+/// Factored into its own tiny, pure function (no `AppHandle`) so it's
+/// directly unit-testable — this crate has no `tauri::test` mock-app
+/// harness. `handle_answer_assist`'s own end-to-end wiring (this being
+/// called exactly once, at the end, regardless of outcome, with the `gen` it
+/// was itself handed) is covered by inspection plus the existing gate tests
+/// (`check_ai_assist_gate_refuses_when_opt_in_off`, etc.) — those exercise
+/// the exact `Err` values this now-unconditional cleanup runs after too.
+fn unregister_after_request(
     registry: &super::stream::AssistStreamRegistry,
     req_id: &str,
-    outcome: &AppResult<AnswerAssistOk>,
+    gen: u64,
 ) {
-    if outcome.is_err() {
-        registry.unregister(req_id);
-    }
+    registry.unregister_gen(req_id, gen);
 }
 
 #[cfg(test)]
@@ -1124,7 +1151,8 @@ mod tests {
         );
     }
 
-    // ── charge_compose_budget (registry-leak fix: unregister on charge failure) ─
+    // ── charge_compose_budget (no longer touches the registry — single
+    // unregister owner is `unregister_after_request`, below) ───────────────
 
     #[test]
     fn charge_compose_budget_succeeds_and_leaves_the_registry_entry_in_place() {
@@ -1132,7 +1160,7 @@ mod tests {
         let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
         registry.begin("req-1");
 
-        let result = charge_compose_budget(&limiter, "openai", &registry, "req-1");
+        let result = charge_compose_budget(&limiter, "openai");
 
         assert!(result.is_ok());
         assert!(
@@ -1142,7 +1170,14 @@ mod tests {
     }
 
     #[test]
-    fn charge_compose_budget_unregisters_the_pending_entry_on_a_rejected_charge() {
+    fn charge_compose_budget_leaves_the_pending_entry_in_place_on_a_rejected_charge_too() {
+        // CodeRabbit consolidation: `charge_compose_budget` used to `unregister`
+        // on a rejected charge itself — now it NEVER touches the registry at
+        // all (single-owner fix), so a rejected charge must leave the entry
+        // exactly as `charge_compose_budget_succeeds_and_leaves_the_registry_
+        // entry_in_place` does; `unregister_after_request` (below) is the
+        // ONLY thing that ever cleans it up, at `handle_answer_assist`'s
+        // single return point.
         let limiter = crate::limits::Limiter::new();
         // Exhaust the SAME per-provider daily ceiling this call charges against.
         for _ in 0..crate::limits::PROVIDER_DAILY_MAX {
@@ -1153,79 +1188,135 @@ mod tests {
         let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
         registry.begin("req-1");
 
-        let result = charge_compose_budget(&limiter, "openai", &registry, "req-1");
+        let result = charge_compose_budget(&limiter, "openai");
 
         assert!(result.is_err());
         assert!(
-            !registry.contains("req-1"),
-            "a rejected charge must unregister the Pending entry, not leak it until the \
-             connection closes or the reqId is reused"
+            registry.contains("req-1"),
+            "charge_compose_budget must never unregister — that would reintroduce the \
+             multi-site clobber this consolidation closes"
         );
     }
 
-    // ── unregister_on_err (HIGH fix: registry leak on handle_answer_assist's
-    // early gates — a Pending entry that never reaches compose_draft_stream
-    // must still be cleaned up) ────────────────────────────────────────────
+    // ── unregister_after_request (SOLE unregister owner, called
+    // UNCONDITIONALLY — both Ok and Err — exactly once, at
+    // handle_answer_assist's single return point, GENERATION-scoped) ───────
 
     #[test]
-    fn unregister_on_err_removes_a_pending_entry_left_by_an_early_gate_failure() {
+    fn unregister_after_request_removes_a_pending_entry_left_by_an_early_gate_failure() {
         // Mirrors EVERY one of `resolve_answer_assist`'s early gates (ai-assist
-        // off, empty question, no provider/résumé, limiter rejection) and
-        // `handle_answer_assist`'s own store-unavailable branch: `begin`
-        // already ran (via `spawn_answer_assist`'s synchronous
-        // `begin_or_reject_duplicate`, simulated here directly), then the
-        // call fails before ever reaching `compose_draft_stream` — nothing
-        // else would ever clean up this entry.
+        // off, empty question, no provider/résumé, limiter rejection, a
+        // rejected daily-budget charge) and `handle_answer_assist`'s own
+        // store-unavailable branch: `begin` already ran (via
+        // `spawn_answer_assist`'s synchronous `begin_or_reject_duplicate`,
+        // simulated here directly), then the call fails before ever reaching
+        // `compose_draft_stream` — nothing else would ever clean up this entry.
         let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
-        registry.begin("req-1");
+        let gen = registry.begin("req-1").expect("a fresh reqId");
 
-        let outcome: AppResult<AnswerAssistOk> =
-            Err(AppError::Validation(AI_ASSIST_OFF_MESSAGE.to_string()));
-        unregister_on_err(&registry, "req-1", &outcome);
+        unregister_after_request(&registry, "req-1", gen);
 
         assert!(
             !registry.contains("req-1"),
-            "an early-gate Err must unregister the Pending entry, not leak it for the \
+            "an early-gate failure must unregister the Pending entry, not leak it for the \
              rest of this connection's lifetime"
         );
         assert!(
-            registry.begin("req-1"),
+            registry.begin("req-1").is_some(),
             "a client retrying the SAME reqId after a failed attempt must not be \
              wrongly rejected as \"already in progress\" forever after"
         );
     }
 
     #[test]
-    fn unregister_on_err_leaves_a_successful_outcomes_running_entry_untouched() {
+    fn unregister_after_request_also_removes_a_running_entry_on_a_successful_outcome() {
+        // The single-owner fix's key behavior change: unlike the old
+        // Err-only `unregister_on_err`, this runs on EVERY outcome — a
+        // successful compose (which already `register`ed a Running job via
+        // `compose_draft_stream`, which no longer unregisters itself) must
+        // still be cleaned up here, or a successful reqId would leak forever.
         let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
-        registry.register("req-1", "job-1"); // the normal Pending -> Running move
+        let gen = registry.begin("req-1").expect("a fresh reqId");
+        assert!(registry.register("req-1", "job-1")); // the Pending -> Running move
 
-        let outcome: AppResult<AnswerAssistOk> = Ok(AnswerAssistOk {
-            question: "Why this role?".to_string(),
-            draft: "Because…".to_string(),
-            sourced_web: false,
-            sourced_brief: false,
-            sourced_salary: false,
-        });
-        unregister_on_err(&registry, "req-1", &outcome);
+        unregister_after_request(&registry, "req-1", gen);
 
         assert!(
-            registry.contains("req-1"),
-            "a successful outcome must never touch the registry — compose_draft_stream \
-             already owns its own register/unregister pair"
+            !registry.contains("req-1"),
+            "a successful outcome must ALSO be unregistered — this is now the only \
+             cleanup site for req-1, on every outcome"
         );
     }
 
     #[test]
-    fn unregister_on_err_is_a_no_op_when_already_unregistered() {
-        // Double-unregister safety: the two EXISTING cleanup sites
-        // (`charge_compose_budget` on a rejected charge, `compose_draft_stream`'s
-        // own end-of-stream `unregister`) may already have removed the entry
-        // by the time `handle_answer_assist` reaches this call — must never panic.
+    fn unregister_after_request_is_a_no_op_when_already_unregistered() {
+        // Double-unregister safety: an `assist.cancel` may already have
+        // consumed the entry (a Running job cancelled + removed, or a
+        // Pending -> CancelledEarly -> consumed by a later register) by the
+        // time `handle_answer_assist` reaches this call — must never panic.
         let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
-        let outcome: AppResult<AnswerAssistOk> =
-            Err(AppError::Validation(AI_ASSIST_OFF_MESSAGE.to_string()));
-        unregister_on_err(&registry, "never-registered", &outcome); // must not panic
+        unregister_after_request(&registry, "never-registered", 0); // must not panic
         assert!(!registry.contains("never-registered"));
+    }
+
+    #[test]
+    fn unregister_after_request_then_a_fresh_begin_for_the_same_req_id_succeeds() {
+        // The retry-after-cleanup case: once a request completes (either
+        // outcome) and this runs, the reqId is fully free again — a client
+        // reusing it for a brand-new request must succeed, and there must be
+        // no SECOND unregister anywhere else that could reach in and remove
+        // that NEW entry out from under it (the exact clobber the single-owner
+        // + generation-scoping fixes close together).
+        let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
+        let gen = registry.begin("req-1").expect("a fresh reqId");
+        unregister_after_request(&registry, "req-1", gen);
+
+        assert!(
+            registry.begin("req-1").is_some(),
+            "req-1 must be fully free once its one owner cleaned it up"
+        );
+        assert!(
+            registry.contains("req-1"),
+            "the fresh begin's Pending entry must still be there — nothing else \
+             may reach in and remove it"
+        );
+    }
+
+    /// A `JobCanceller` implementor that just discards `job_id` — this test
+    /// only needs `cancel` to actually remove A's `Running` entry, not to
+    /// inspect what got cancelled (mirrors the tiny local test-only fakes
+    /// duplicated elsewhere in this codebase rather than reaching into a
+    /// sibling module's private `#[cfg(test)]` internals).
+    struct NoopCanceller;
+
+    impl crate::extension_bridge::assist_registry::JobCanceller for NoopCanceller {
+        fn cancel_job(&self, _job_id: &str) {}
+    }
+
+    #[test]
+    fn unregister_after_request_never_clobbers_a_reused_req_ids_successor_entry() {
+        // The security-review finding on top of the single-owner fix: A
+        // registers Running, an `assist.cancel` removes A's entry (job
+        // cancelled) WHILE A's own request is still resolving, a client
+        // reuses the SAME reqId for a brand-new request B which begins +
+        // registers successfully — and only THEN does A reach
+        // `unregister_after_request`. Generation scoping must make A's call a
+        // no-op against B's fresh, higher-generation entry.
+        let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
+        let canceller = NoopCanceller;
+        let gen_a = registry.begin("req-1").expect("A's begin succeeds");
+        assert!(registry.register("req-1", "job-a"));
+        registry.cancel(&canceller, "req-1"); // removes A's entry, cancels job-a
+
+        registry.begin("req-1").expect("B may reuse req-1");
+        assert!(registry.register("req-1", "job-b"));
+
+        // A's tail cleanup arrives LATE — after B has already registered.
+        unregister_after_request(&registry, "req-1", gen_a);
+
+        assert!(
+            registry.contains("req-1"),
+            "A's stale, lower-generation cleanup must never remove B's fresh entry"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/extension_bridge/answer_assist.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/answer_assist.rs
@@ -123,8 +123,10 @@ const DRAFT_FAILED_MESSAGE: &str = "Could not draft an answer. Please retry.";
 /// Fixed sentinel — `req_id` already names an ACTIVE (`Pending`/`Running`)
 /// stream on this connection (see [`super::stream::AssistStreamRegistry::begin`]).
 /// A client reusing an in-flight reqId is rejected outright rather than
-/// silently orphaning the original job.
-const DUPLICATE_REQUEST_MESSAGE: &str = "This request is already in progress.";
+/// silently orphaning the original job. `pub(super)` — `stream::
+/// spawn_answer_assist` (which now calls `begin` synchronously, before ever
+/// spawning — see its own doc for why) is this constant's only reader.
+pub(super) const DUPLICATE_REQUEST_MESSAGE: &str = "This request is already in progress.";
 
 /// Collapse a downstream error that MAY carry dynamic content (see
 /// [`DRAFT_FAILED_MESSAGE`]) to that one fixed sentinel, logging the real
@@ -479,18 +481,15 @@ pub(super) async fn resolve_answer_assist(
     let is_salary = super::answers_suggest::is_salary_question(&normalize_question(&question));
     let provider_id = completer.provider_id().as_str();
 
-    // Mark this reqId pending BEFORE the salary/web-notes awaits below — the
-    // realistic window (network round-trips) an `assist.cancel` could race
-    // ahead of `compose_draft_stream`'s own `register()` call. See
-    // `AssistStreamRegistry::begin`'s doc (the pre-registration cancel race
-    // fix): a cancel landing in this window is recorded here instead of
-    // being silently swallowed (nothing was registered yet to `take()`).
-    // A reqId already ACTIVE on this connection (a client reusing an
-    // in-flight reqId) is rejected outright rather than silently orphaning
-    // the original job — see `begin`'s doc.
-    if !registry.begin(req_id) {
-        return Err(AppError::Validation(DUPLICATE_REQUEST_MESSAGE.to_string()));
-    }
+    // `registry.begin(req_id)` already ran, SYNCHRONOUSLY, before this
+    // function was ever called — see `stream::spawn_answer_assist`'s doc for
+    // why it moved there (a same-connection `assist.cancel` for this `reqId`
+    // must never be able to race ahead of `begin` through `tokio::spawn`'s
+    // scheduling gap). The `Pending` entry it left behind is guaranteed to
+    // exist by this point; a duplicate `reqId` is already rejected before
+    // this task is even spawned. `register` below still handles the
+    // pre-compose cancel race exactly as before — a `CancelledEarly` marker
+    // is consumed and reported back as `false`.
 
     let salary_range = if is_salary {
         resolve_salary_range(&completer, &limiter, provider_id, app_ctx.as_ref()).await
@@ -521,12 +520,13 @@ pub(super) async fn resolve_answer_assist(
     );
 
     // One more charge for the compose call itself — the LAST fallible step
-    // between `registry.begin` above and entering `compose_draft_stream`
-    // (which owns the normal register/unregister pair). A rejected charge
-    // must `unregister` the `Pending` entry `begin` recorded, or it leaks in
-    // this connection's registry until the connection closes or the reqId is
-    // reused — `compose_draft_stream` is never reached on this early-return
-    // path to clean it up itself.
+    // between the Pending entry `spawn_answer_assist`'s synchronous `begin`
+    // already recorded (before this whole function was ever called) and
+    // entering `compose_draft_stream` (which owns the normal
+    // register/unregister pair). A rejected charge must `unregister` that
+    // `Pending` entry, or it leaks in this connection's registry until the
+    // connection closes or the reqId is reused — `compose_draft_stream` is
+    // never reached on this early-return path to clean it up itself.
     charge_compose_budget(&limiter, completer.provider_id().as_str(), registry, req_id)?;
     let draft = clamp_chars(
         super::stream::compose_draft_stream(app, &completer, req_id, registry, &user, sink)
@@ -545,12 +545,12 @@ pub(super) async fn resolve_answer_assist(
 }
 
 /// Charge the daily provider budget for the compose call — see the call
-/// site's comment for why this is the LAST fallible step between
-/// `registry.begin(req_id)` and `compose_draft_stream` (which owns the
-/// normal register/unregister pair). On a rejected charge, `unregister`s the
-/// `Pending` entry `begin` recorded FIRST, so a charge failure never leaks a
-/// registry entry. Takes a plain `&Limiter` (no `AppHandle`), so this is
-/// directly unit-testable.
+/// site's comment for why this is the LAST fallible step between the
+/// pre-existing `Pending` entry (from `spawn_answer_assist`'s synchronous
+/// `begin`) and `compose_draft_stream` (which owns the normal
+/// register/unregister pair). On a rejected charge, `unregister`s that
+/// `Pending` entry, so a charge failure never leaks a registry entry. Takes a
+/// plain `&Limiter` (no `AppHandle`), so this is directly unit-testable.
 fn charge_compose_budget(
     limiter: &crate::limits::Limiter,
     provider_id: &str,
@@ -681,7 +681,48 @@ pub(super) async fn handle_answer_assist(
         )),
     };
 
+    unregister_on_err(registry, req_id, &outcome);
     answer_assist_reply(req_id, outcome)
+}
+
+/// The one cleanup point every one of `resolve_answer_assist`'s early gates
+/// (and `handle_answer_assist`'s own store-unavailable branch) relies on.
+///
+/// `spawn_answer_assist`'s synchronous `begin_or_reject_duplicate` always ran
+/// before `handle_answer_assist` was ever called (see its doc), so a
+/// `Pending` entry for `req_id` always exists by the time this runs — even on
+/// every one of `resolve_answer_assist`'s early gates (the ai-assist opt-in
+/// off, an empty question, no provider/résumé, the `ai_research` limiter
+/// rejecting) and the store-unavailable branch, ALL of which `return
+/// Err(...)` without ever reaching `compose_draft_stream` (the thing that
+/// would otherwise `register`/`unregister` it). Left alone, EVERY one of
+/// those common failures would leak a `Pending` entry for the rest of this
+/// connection's lifetime — and a client retrying the SAME `req_id` after a
+/// failed attempt would be wrongly rejected as "already in progress" forever
+/// after. Unregistering here on any `Err` is the one idempotent cleanup point
+/// that covers all of them; it is a safe no-op against the two paths that
+/// already clean up themselves on success (`charge_compose_budget` on a
+/// rejected charge, `compose_draft_stream`'s own end-of-stream `unregister`)
+/// since `unregister` on an already-gone `req_id` is a no-op by design. A
+/// duplicate `reqId` never reaches `handle_answer_assist` at all (rejected
+/// earlier by `begin_or_reject_duplicate`), so this can never remove an
+/// ORIGINAL in-flight entry out from under it.
+///
+/// Factored into its own tiny, pure(-ish — one `Mutex` lock, no `AppHandle`)
+/// function so it's directly unit-testable without a live `AppHandle` — this
+/// crate has no `tauri::test` mock-app harness. `handle_answer_assist`'s own
+/// end-to-end wiring (this helper actually being called with the right
+/// `registry`/`req_id`) is covered by inspection plus the existing gate
+/// tests (`check_ai_assist_gate_refuses_when_opt_in_off`, etc.) — those
+/// exercise the exact `Err` values this cleans up after.
+fn unregister_on_err(
+    registry: &super::stream::AssistStreamRegistry,
+    req_id: &str,
+    outcome: &AppResult<AnswerAssistOk>,
+) {
+    if outcome.is_err() {
+        registry.unregister(req_id);
+    }
 }
 
 #[cfg(test)]
@@ -1120,5 +1161,71 @@ mod tests {
             "a rejected charge must unregister the Pending entry, not leak it until the \
              connection closes or the reqId is reused"
         );
+    }
+
+    // ── unregister_on_err (HIGH fix: registry leak on handle_answer_assist's
+    // early gates — a Pending entry that never reaches compose_draft_stream
+    // must still be cleaned up) ────────────────────────────────────────────
+
+    #[test]
+    fn unregister_on_err_removes_a_pending_entry_left_by_an_early_gate_failure() {
+        // Mirrors EVERY one of `resolve_answer_assist`'s early gates (ai-assist
+        // off, empty question, no provider/résumé, limiter rejection) and
+        // `handle_answer_assist`'s own store-unavailable branch: `begin`
+        // already ran (via `spawn_answer_assist`'s synchronous
+        // `begin_or_reject_duplicate`, simulated here directly), then the
+        // call fails before ever reaching `compose_draft_stream` — nothing
+        // else would ever clean up this entry.
+        let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
+        registry.begin("req-1");
+
+        let outcome: AppResult<AnswerAssistOk> =
+            Err(AppError::Validation(AI_ASSIST_OFF_MESSAGE.to_string()));
+        unregister_on_err(&registry, "req-1", &outcome);
+
+        assert!(
+            !registry.contains("req-1"),
+            "an early-gate Err must unregister the Pending entry, not leak it for the \
+             rest of this connection's lifetime"
+        );
+        assert!(
+            registry.begin("req-1"),
+            "a client retrying the SAME reqId after a failed attempt must not be \
+             wrongly rejected as \"already in progress\" forever after"
+        );
+    }
+
+    #[test]
+    fn unregister_on_err_leaves_a_successful_outcomes_running_entry_untouched() {
+        let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
+        registry.register("req-1", "job-1"); // the normal Pending -> Running move
+
+        let outcome: AppResult<AnswerAssistOk> = Ok(AnswerAssistOk {
+            question: "Why this role?".to_string(),
+            draft: "Because…".to_string(),
+            sourced_web: false,
+            sourced_brief: false,
+            sourced_salary: false,
+        });
+        unregister_on_err(&registry, "req-1", &outcome);
+
+        assert!(
+            registry.contains("req-1"),
+            "a successful outcome must never touch the registry — compose_draft_stream \
+             already owns its own register/unregister pair"
+        );
+    }
+
+    #[test]
+    fn unregister_on_err_is_a_no_op_when_already_unregistered() {
+        // Double-unregister safety: the two EXISTING cleanup sites
+        // (`charge_compose_budget` on a rejected charge, `compose_draft_stream`'s
+        // own end-of-stream `unregister`) may already have removed the entry
+        // by the time `handle_answer_assist` reaches this call — must never panic.
+        let registry = crate::extension_bridge::stream::AssistStreamRegistry::default();
+        let outcome: AppResult<AnswerAssistOk> =
+            Err(AppError::Validation(AI_ASSIST_OFF_MESSAGE.to_string()));
+        unregister_on_err(&registry, "never-registered", &outcome); // must not panic
+        assert!(!registry.contains("never-registered"));
     }
 }

--- a/apps/desktop/src-tauri/src/extension_bridge/assist_registry.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/assist_registry.rs
@@ -67,7 +67,8 @@ impl JobStarter for AppHandle {
 /// that race (the caller should treat it as `"Job cancelled"`); `Some(job_id)`
 /// otherwise. Safe to cancel unconditionally on the race path — `job_id` is a
 /// fresh UUID ([`crate::db::new_job_id`]), so it can never collide with a
-/// later, unrelated `start_job` call.
+/// later, unrelated `start_job` call. Does NOT need the reqId's generation —
+/// `register` reads and preserves whatever generation `begin` already minted.
 ///
 /// Generic over a combined [`JobStarter`] + [`JobCanceller`] recorder (not
 /// the concrete `AppHandle`) so this ordering is directly unit-testable
@@ -93,17 +94,57 @@ pub(super) fn start_and_register<T: JobStarter + JobCanceller>(
 /// spend) through to either a registered running job or an early
 /// cancellation. See [`super::stream`]'s module doc's "An `assist.cancel`
 /// races the pre-compose window" case.
+///
+/// Every variant carries the `reqId`'s **generation** — a per-registry
+/// monotonic counter [`AssistStreamRegistry::begin`] mints a fresh value from
+/// on every successful call. This is the generation-scoped-removal fix (a
+/// security-review + CodeRabbit finding): a client can reuse a `reqId` once
+/// its ORIGINAL entry is gone (job cancelled, or the request completed), and
+/// without a generation, a delayed cleanup call keyed by `reqId` ALONE could
+/// remove the REUSED request's fresh entry instead of the stale one it meant
+/// to clean up (e.g. A registers Running, `assist.cancel` removes it, a
+/// client reuses the same `reqId` for a brand-new request B which `begin`s +
+/// `register`s successfully, and only THEN does A's own tail cleanup run —
+/// keyed by `reqId` alone, it would clobber B's entry, leaving B's billable
+/// job unreachable/uncancellable). [`AssistStreamRegistry::unregister_gen`]
+/// is the fix: it only ever removes an entry whose STORED generation matches
+/// the one the caller was handed back by ITS OWN `begin` — B's entry always
+/// carries a strictly higher generation than A's, so A's stale cleanup is
+/// safely a no-op against it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum StreamEntry {
     /// Pre-compose work (gate/resume/limiter/salary/web-notes) is in
     /// flight — no job exists yet.
-    Pending,
+    Pending(u64),
     /// [`AssistStreamRegistry::register`] recorded its job id.
-    Running(String),
+    Running(u64, String),
     /// An `assist.cancel` arrived while still `Pending` — the pre-compose
     /// caller must short-circuit rather than proceed to the billable
     /// compose call. See [`AssistStreamRegistry::register`]'s return value.
-    CancelledEarly,
+    CancelledEarly(u64),
+}
+
+impl StreamEntry {
+    /// This entry's generation, regardless of which variant it currently is
+    /// — used by [`AssistStreamRegistry::unregister_gen`]'s match-the-caller
+    /// check.
+    fn gen(&self) -> u64 {
+        match self {
+            StreamEntry::Pending(g)
+            | StreamEntry::Running(g, _)
+            | StreamEntry::CancelledEarly(g) => *g,
+        }
+    }
+}
+
+/// The map plus its generation counter, under ONE lock — kept together
+/// (rather than a separate `AtomicU64` field) so `begin` mints a fresh
+/// generation and inserts `Pending` under the SAME critical section, with no
+/// TOCTOU between "read the next generation" and "insert the entry".
+#[derive(Default)]
+struct RegistryState {
+    entries: HashMap<String, StreamEntry>,
+    next_gen: u64,
 }
 
 /// Per-connection registry of in-flight/pending streaming `answer.assist`
@@ -111,15 +152,15 @@ enum StreamEntry {
 /// connection. See [`super::stream`]'s module doc's "Cancellation is
 /// per-connection" section.
 #[derive(Default)]
-pub(super) struct AssistStreamRegistry(Mutex<HashMap<String, StreamEntry>>);
+pub(super) struct AssistStreamRegistry(Mutex<RegistryState>);
 
 impl AssistStreamRegistry {
     /// Mark `req_id` as `Pending` BEFORE any pre-compose await (the gate/
     /// resume/limiter/salary/web-notes lookups in `resolve_answer_assist`) —
     /// the realistic window (network round-trips) an `assist.cancel` could
-    /// race ahead of [`Self::register`]. Returns `false` (leaving the
-    /// existing entry untouched) when `req_id` already names ANY entry on
-    /// this connection — `Pending`, `Running`, OR `CancelledEarly` — never
+    /// race ahead of [`Self::register`]. Returns `None` (leaving the existing
+    /// entry untouched) when `req_id` already names ANY entry on this
+    /// connection — `Pending`, `Running`, OR `CancelledEarly` — never
     /// silently overwriting it with a fresh `Pending`. Overwriting a
     /// `Running` entry would orphan its job (still running server-side, but
     /// no longer reachable from this registry, so a later `assist.cancel`
@@ -128,25 +169,34 @@ impl AssistStreamRegistry {
     /// direction: that marker is NOT settled — it is awaiting consumption by
     /// [`Self::register`] (which sees it, removes it, and reports `false` so
     /// the run that raced the cancel never starts a billable job) or removal
-    /// by [`Self::unregister`]/[`Self::cancel_all`]. Allowing a reuse before
-    /// that consumption would let a second run's fresh `Pending` slip in
-    /// under the same `req_id`; the FIRST (already-cancelled) run's later
+    /// by [`Self::unregister_gen`]/[`Self::cancel_all`]. Allowing a reuse
+    /// before that consumption would let a second run's fresh `Pending` slip
+    /// in under the same `req_id`; the FIRST (already-cancelled) run's later
     /// `register` call would then see that second run's `Pending` instead of
     /// its own `CancelledEarly` marker and register a billable job anyway —
     /// the cancel guarantee lost. It is always cleared within the original
     /// run's own lifecycle (consumed by `register`, or removed by an
-    /// `unregister`/`cancel_all`), so a `req_id` can never get stuck rejected
-    /// forever; a well-behaved client uses a fresh reqId per request anyway.
-    /// Returns `true` — and inserts `Pending` — only when `req_id` names no
+    /// `unregister_gen`/`cancel_all`), so a `req_id` can never get stuck
+    /// rejected forever; a well-behaved client uses a fresh reqId per request
+    /// anyway.
+    ///
+    /// Returns `Some(gen)` — a fresh, strictly-monotonic-per-registry
+    /// generation, and inserts `Pending(gen)` — only when `req_id` names no
     /// entry at all: a fresh `req_id`, or one that already fully settled and
-    /// was removed.
-    pub(super) fn begin(&self, req_id: &str) -> bool {
+    /// was removed. The caller MUST hold onto this `gen` and pass it to
+    /// [`Self::unregister_gen`] at the end of its own request — see
+    /// [`StreamEntry`]'s doc for the clobber this generation exists to close.
+    pub(super) fn begin(&self, req_id: &str) -> Option<u64> {
         let mut guard = self.0.lock();
-        if guard.contains_key(req_id) {
-            return false;
+        if guard.entries.contains_key(req_id) {
+            return None;
         }
-        guard.insert(req_id.to_string(), StreamEntry::Pending);
-        true
+        let gen = guard.next_gen;
+        guard.next_gen += 1;
+        guard
+            .entries
+            .insert(req_id.to_string(), StreamEntry::Pending(gen));
+        Some(gen)
     }
 
     /// Register an in-flight stream's `reqId -> jobId`, UNLESS `req_id` was
@@ -156,22 +206,50 @@ impl AssistStreamRegistry {
     /// billable job, rather than registering (and thus only becoming
     /// cancellable from this point forward) a stream the client already
     /// gave up on. Returns `true` otherwise: the normal `Pending` →
-    /// `Running` move, or a caller that never `begin`s at all.
+    /// `Running` move (preserving the SAME generation `begin` minted — no gen
+    /// parameter needed here, it's read off the existing entry), or a caller
+    /// that never `begin`s at all (mints a fresh generation on the spot, same
+    /// as `begin` would — this only ever happens in tests; every production
+    /// caller always `begin`s first).
     pub(super) fn register(&self, req_id: &str, job_id: &str) -> bool {
         let mut guard = self.0.lock();
-        if matches!(guard.get(req_id), Some(StreamEntry::CancelledEarly)) {
-            guard.remove(req_id);
+        if matches!(
+            guard.entries.get(req_id),
+            Some(StreamEntry::CancelledEarly(_))
+        ) {
+            guard.entries.remove(req_id);
             return false;
         }
-        guard.insert(req_id.to_string(), StreamEntry::Running(job_id.to_string()));
+        let gen = match guard.entries.get(req_id) {
+            Some(StreamEntry::Pending(gen)) => *gen,
+            _ => {
+                let gen = guard.next_gen;
+                guard.next_gen += 1;
+                gen
+            }
+        };
+        guard.entries.insert(
+            req_id.to_string(),
+            StreamEntry::Running(gen, job_id.to_string()),
+        );
         true
     }
 
-    /// Forget a stream's registration once it ends (success, failure, or an
-    /// already-raced cancel). A no-op when `req_id` is already gone — never
-    /// an error.
-    pub(super) fn unregister(&self, req_id: &str) {
-        self.0.lock().remove(req_id);
+    /// Remove `req_id`'s entry ONLY IF its stored generation equals `gen` —
+    /// generation-scoped removal, the SOLE way any "end of request" cleanup
+    /// may free an entry (see [`StreamEntry`]'s doc for the clobber this
+    /// closes). A no-op — never an error — when `req_id` names no entry at
+    /// all, OR names one whose generation has already moved on: either
+    /// [`Self::cancel`]/[`Self::cancel_all`] already consumed THIS caller's
+    /// own entry (a `Running` job cancelled + removed, or a `Pending` →
+    /// `CancelledEarly` → later consumed by `register`), or a LATER `begin`
+    /// for the same reused `req_id` minted a strictly higher generation — in
+    /// either case this call must never remove what it doesn't own.
+    pub(super) fn unregister_gen(&self, req_id: &str, gen: u64) {
+        let mut guard = self.0.lock();
+        if guard.entries.get(req_id).is_some_and(|e| e.gen() == gen) {
+            guard.entries.remove(req_id);
+        }
     }
 
     /// Remove + return the RUNNING job registered under `req_id` on THIS
@@ -193,9 +271,9 @@ impl AssistStreamRegistry {
         // returning, silently losing that state for anyone who checks
         // `req_id` afterward (this was a real bug caught by this file's own
         // pre-registration-race test).
-        match guard.get(req_id) {
-            Some(StreamEntry::Running(_)) => match guard.remove(req_id) {
-                Some(StreamEntry::Running(job_id)) => Some(job_id),
+        match guard.entries.get(req_id) {
+            Some(StreamEntry::Running(..)) => match guard.entries.remove(req_id) {
+                Some(StreamEntry::Running(_, job_id)) => Some(job_id),
                 _ => None,
             },
             _ => None,
@@ -205,11 +283,11 @@ impl AssistStreamRegistry {
     /// Test-only seam: whether ANY entry (`Pending`, `Running`, or
     /// `CancelledEarly`) exists for `req_id` — unlike [`Self::take`] (which
     /// only ever observes a `Running` job), this is what a leak-detection
-    /// test needs to assert a `Pending` entry was actually `unregister`ed,
-    /// not just left un-taken.
+    /// test needs to assert a `Pending` entry was actually removed, not just
+    /// left un-taken.
     #[cfg(test)]
     pub(super) fn contains(&self, req_id: &str) -> bool {
-        self.0.lock().contains_key(req_id)
+        self.0.lock().entries.contains_key(req_id)
     }
 
     /// Cancel the stream named by `req_id` on THIS registry, if any. A
@@ -217,9 +295,13 @@ impl AssistStreamRegistry {
     /// `chat_stream`'s `is_cancelled` polls every chunk, so the provider
     /// call itself stops on its next read) and forgotten. A still-`Pending`
     /// entry (no job yet — the pre-compose window) is marked
-    /// [`StreamEntry::CancelledEarly`] instead, so [`Self::register`]
-    /// reports `false` once the pre-compose caller reaches it. A no-op when
-    /// `req_id` names nothing on this connection at all. Generic over
+    /// [`StreamEntry::CancelledEarly`] instead (preserving its generation),
+    /// so [`Self::register`] reports `false` once the pre-compose caller
+    /// reaches it. A no-op when `req_id` names nothing on this connection at
+    /// all. Always removes/cancels whatever CURRENTLY holds `req_id`
+    /// regardless of generation — a cancel targets the current holder, not a
+    /// specific generation (only the end-of-request cleanup path,
+    /// [`Self::unregister_gen`], is generation-scoped). Generic over
     /// [`JobCanceller`] (not the concrete `AppHandle`) so this is
     /// unit-testable against a fake recorder — the sole production caller
     /// passes a real `&AppHandle` (which implements it).
@@ -234,13 +316,16 @@ impl AssistStreamRegistry {
         // decided in one critical section.
         let job_id = {
             let mut guard = self.0.lock();
-            match guard.get(req_id) {
-                Some(StreamEntry::Running(_)) => match guard.remove(req_id) {
-                    Some(StreamEntry::Running(job_id)) => Some(job_id),
+            match guard.entries.get(req_id) {
+                Some(StreamEntry::Running(..)) => match guard.entries.remove(req_id) {
+                    Some(StreamEntry::Running(_, job_id)) => Some(job_id),
                     _ => None,
                 },
-                Some(StreamEntry::Pending) => {
-                    guard.insert(req_id.to_string(), StreamEntry::CancelledEarly);
+                Some(StreamEntry::Pending(gen)) => {
+                    let gen = *gen;
+                    guard
+                        .entries
+                        .insert(req_id.to_string(), StreamEntry::CancelledEarly(gen));
                     None
                 }
                 _ => None,
@@ -258,27 +343,30 @@ impl AssistStreamRegistry {
     /// `assist.cancel` might have named (the CWE-639 fix stays: this only
     /// ever touches THIS connection's own map). A `Running` entry is
     /// cancelled via `canceller`; a still-`Pending` entry is marked
-    /// `CancelledEarly` (mirrors [`Self::cancel`]'s `Pending` arm) so
-    /// in-flight pre-compose work also short-circuits instead of reaching a
-    /// now-pointless billable compose call. Generic over [`JobCanceller`] —
-    /// see [`Self::cancel`]'s doc.
+    /// `CancelledEarly` (mirrors [`Self::cancel`]'s `Pending` arm, preserving
+    /// its generation) so in-flight pre-compose work also short-circuits
+    /// instead of reaching a now-pointless billable compose call. Generic
+    /// over [`JobCanceller`] — see [`Self::cancel`]'s doc.
     pub(super) fn cancel_all<C: JobCanceller>(&self, canceller: &C) {
         let mut guard = self.0.lock();
-        let drained: Vec<(String, StreamEntry)> = guard.drain().collect();
+        let drained: Vec<(String, StreamEntry)> = guard.entries.drain().collect();
         let mut running = Vec::new();
         for (req_id, entry) in drained {
             match entry {
-                StreamEntry::Running(job_id) => running.push(job_id),
+                StreamEntry::Running(_, job_id) => running.push(job_id),
                 // Exhaustive on purpose: BOTH still-pending AND
                 // already-cancelled-early entries must be reinserted as
-                // `CancelledEarly`. Dropping the latter (the original bug)
-                // loses the guard marker on a cancel-then-disconnect during
-                // the pre-compose window — the entry vanishes from the map,
-                // so the later `register` call for that `req_id` finds
-                // nothing, returns `true`, and starts a full billable
-                // generation for a request the user already cancelled.
-                StreamEntry::Pending | StreamEntry::CancelledEarly => {
-                    guard.insert(req_id, StreamEntry::CancelledEarly);
+                // `CancelledEarly` (preserving their generation). Dropping
+                // the latter (the original bug) loses the guard marker on a
+                // cancel-then-disconnect during the pre-compose window — the
+                // entry vanishes from the map, so the later `register` call
+                // for that `req_id` finds nothing, returns `true`, and starts
+                // a full billable generation for a request the user already
+                // cancelled.
+                StreamEntry::Pending(gen) | StreamEntry::CancelledEarly(gen) => {
+                    guard
+                        .entries
+                        .insert(req_id, StreamEntry::CancelledEarly(gen));
                 }
             }
         }
@@ -293,7 +381,7 @@ impl AssistStreamRegistry {
 mod tests {
     use super::*;
 
-    // ── AssistStreamRegistry: register / take / unregister ─────────────────
+    // ── AssistStreamRegistry: register / take / unregister_gen ──────────────
 
     #[test]
     fn register_then_take_returns_and_forgets_it() {
@@ -304,9 +392,9 @@ mod tests {
     }
 
     #[test]
-    fn unregister_on_an_unknown_req_id_is_a_no_op() {
+    fn unregister_gen_on_an_unknown_req_id_is_a_no_op() {
         let r = AssistStreamRegistry::default();
-        r.unregister("never-registered"); // must not panic
+        r.unregister_gen("never-registered", 0); // must not panic
         assert_eq!(r.take("never-registered"), None);
     }
 
@@ -323,10 +411,11 @@ mod tests {
     }
 
     #[test]
-    fn unregister_then_register_again_reflects_the_new_mapping() {
+    fn unregister_gen_then_register_again_reflects_the_new_mapping() {
         let r = AssistStreamRegistry::default();
+        let gen = r.begin("req-1").expect("a fresh reqId");
         assert!(r.register("req-1", "job-1"));
-        r.unregister("req-1");
+        r.unregister_gen("req-1", gen);
         assert!(r.register("req-1", "job-2"));
         assert_eq!(r.take("req-1"), Some("job-2".to_string()));
     }
@@ -442,7 +531,7 @@ mod tests {
         );
     }
 
-    // ── Pre-registration cancel race (LOW fix): begin() + register()'s bool ─
+    // ── Pre-registration cancel race (LOW fix): begin()'s Option<u64> + register()'s bool ─
 
     #[test]
     fn cancel_during_the_pending_window_prevents_the_later_register_call() {
@@ -480,7 +569,7 @@ mod tests {
     #[test]
     fn begin_on_a_fresh_req_id_succeeds() {
         let r = AssistStreamRegistry::default();
-        assert!(r.begin("req-1"));
+        assert!(r.begin("req-1").is_some());
     }
 
     #[test]
@@ -489,7 +578,7 @@ mod tests {
         r.begin("req-1"); // first request's pre-compose window is in flight
 
         assert!(
-            !r.begin("req-1"),
+            r.begin("req-1").is_none(),
             "a second begin for the same still-Pending reqId must be rejected"
         );
     }
@@ -504,7 +593,7 @@ mod tests {
         // running must be rejected — never silently overwrite the Running
         // entry with a fresh Pending, which would orphan job-1 (still
         // running server-side, but no longer reachable to cancel).
-        assert!(!r.begin("req-1"));
+        assert!(r.begin("req-1").is_none());
 
         r.cancel(&canceller, "req-1");
         assert_eq!(
@@ -522,9 +611,9 @@ mod tests {
         r.cancel(&canceller, "req-1"); // -> CancelledEarly, no job existed yet
 
         assert!(
-            !r.begin("req-1"),
+            r.begin("req-1").is_none(),
             "a CancelledEarly marker is not settled — reuse must be rejected \
-             until register (or unregister/cancel_all) consumes it"
+             until register (or cancel_all) consumes it"
         );
     }
 
@@ -542,7 +631,7 @@ mod tests {
         r.cancel(&canceller, "req-1"); // -> CancelledEarly, run A has no job yet
 
         assert!(
-            !r.begin("req-1"),
+            r.begin("req-1").is_none(),
             "a second run reusing req-1 must be rejected while the marker is un-consumed"
         );
         assert!(
@@ -551,8 +640,74 @@ mod tests {
              run A never starts a billable job"
         );
         assert!(
-            r.begin("req-1"),
+            r.begin("req-1").is_some(),
             "once consumed, req-1 names no entry at all — reuse is allowed again"
+        );
+    }
+
+    // ── Generation-scoped removal (security-review + CodeRabbit fix):
+    // unregister_gen must never clobber a reused reqId's successor entry ────
+
+    #[test]
+    fn unregister_gen_never_clobbers_a_reused_req_ids_successor_entry() {
+        // The exact clobber this generation token closes: A registers
+        // Running, an `assist.cancel` removes A's entry (cancelling job-a),
+        // then a client reuses the SAME reqId for a brand-new request B —
+        // B's `begin`/`register` succeed with a STRICTLY HIGHER generation.
+        // A's own end-of-request cleanup then arrives LATE (after B has
+        // already registered) — keyed by reqId alone, the old unconditional
+        // `unregister` would have clobbered B's fresh entry here.
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+
+        let gen_a = r
+            .begin("req-x")
+            .expect("A's begin succeeds on a fresh reqId");
+        assert!(r.register("req-x", "job-a"));
+        r.cancel(&canceller, "req-x"); // removes A's Running entry, cancels job-a
+
+        let gen_b = r
+            .begin("req-x")
+            .expect("B may reuse req-x once A's entry is gone");
+        assert!(
+            gen_b > gen_a,
+            "B's generation must be strictly higher than A's"
+        );
+        assert!(r.register("req-x", "job-b"));
+
+        // A's tail cleanup arrives LATE — after B has already begun and
+        // registered — the exact race the generation token exists to close.
+        r.unregister_gen("req-x", gen_a);
+
+        assert!(
+            r.contains("req-x"),
+            "A's stale, lower-generation cleanup must never remove B's fresh entry"
+        );
+
+        // B's job is still fully reachable AND cancellable — never clobbered.
+        r.cancel(&canceller, "req-x");
+        assert_eq!(
+            canceller.cancelled.into_inner(),
+            vec!["job-a".to_string(), "job-b".to_string()],
+            "B's job must still be cancellable after A's stale cleanup ran"
+        );
+    }
+
+    #[test]
+    fn unregister_gen_removes_the_entry_when_the_generation_still_matches() {
+        // The normal (non-reused-reqId) case: the caller's own gen still
+        // names the SAME entry it was handed for, so unregister_gen must
+        // actually remove it — this is the "one owner cleans up its own
+        // request" path every non-race request takes.
+        let r = AssistStreamRegistry::default();
+        let gen = r.begin("req-1").expect("a fresh reqId");
+        assert!(r.register("req-1", "job-1"));
+
+        r.unregister_gen("req-1", gen);
+
+        assert!(
+            !r.contains("req-1"),
+            "the matching generation must remove the entry"
         );
     }
 

--- a/apps/desktop/src-tauri/src/extension_bridge/assist_registry.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/assist_registry.rs
@@ -1,0 +1,643 @@
+//! The per-connection `answer.assist` stream registry — the `reqId` state
+//! machine ([`StreamEntry`]/[`AssistStreamRegistry`]) plus the two small
+//! `AppHandle`-abstracting seams ([`JobCanceller`]/[`JobStarter`]) and
+//! [`start_and_register`] that let its start/register/cancel ordering be
+//! unit-tested without a live `AppHandle` (this crate has no `tauri::test`
+//! mock-app harness). Split out of [`super::stream`] (R8 line-budget split —
+//! `stream.rs` orchestrates the writer/read-loop decoupling and the streaming
+//! compose call; this module IS the state machine those orchestrate). See
+//! [`super::stream`]'s module doc for the full picture this is a piece of
+//! (the write-backpressure/stalled-peer fix, the four ways a stream ends
+//! early, and the CWE-639 per-connection isolation this registry exists for).
+//!
+//! [`AssistStreamRegistry`] is re-exported from `stream` as `stream::
+//! AssistStreamRegistry` so every existing reference (`mod.rs`,
+//! `answer_assist.rs`, and their tests) keeps resolving unchanged.
+
+use std::collections::HashMap;
+
+use parking_lot::Mutex;
+use tauri::AppHandle;
+
+/// Abstracts "cancel one job by id" so [`AssistStreamRegistry::cancel`]/
+/// [`AssistStreamRegistry::cancel_all`]'s job-cancelling side effect is
+/// unit-testable against a fake recorder, without a live `AppHandle` — this
+/// crate has no `tauri::test` mock-app harness (mirrors the
+/// `SalarySearcher`/`AnswerSearcher` genericization precedent in
+/// `answer_assist`/`commands::ai`). The sole production implementor forwards
+/// to [`crate::commands::jobs::job_cancel`].
+pub(super) trait JobCanceller {
+    fn cancel_job(&self, job_id: &str);
+}
+
+impl JobCanceller for AppHandle {
+    fn cancel_job(&self, job_id: &str) {
+        crate::commands::jobs::job_cancel(self, job_id);
+    }
+}
+
+/// Abstracts "start a job by id" so [`start_and_register`]'s
+/// start-before-register ordering is unit-testable against a fake recorder,
+/// without a live `AppHandle` — mirrors [`JobCanceller`]'s existing seam. The
+/// sole production implementor forwards to [`crate::commands::jobs::job_start`]
+/// with this module's one fixed job kind (every job this registry ever tracks
+/// is an `"extension.answer_assist"` job).
+pub(super) trait JobStarter {
+    fn start_job(&self, job_id: &str);
+}
+
+impl JobStarter for AppHandle {
+    fn start_job(&self, job_id: &str) {
+        crate::commands::jobs::job_start(self, job_id, "extension.answer_assist");
+    }
+}
+
+/// Start a fresh job for `req_id` and register it with `registry` —
+/// deliberately `start` BEFORE `register`, the reverse of this module's
+/// original order. The original order had a TOCTOU: `register` published a
+/// `Running(job_id)` entry before the job existed, so an `assist.cancel`
+/// landing in that exact gap found `Running`, removed the entry, and called
+/// `cancel_job` on an id nothing had started yet (a no-op) — the job then
+/// started anyway, Running, with no cancel path left. Starting first closes
+/// it: a cancel racing this same gap instead finds the `Pending` marker
+/// [`AssistStreamRegistry::begin`] already left behind (set synchronously in
+/// `spawn_answer_assist`, before this task was even spawned), so `register`
+/// below correctly observes [`StreamEntry::CancelledEarly`] and this function
+/// cancels the very job it just started before reporting failure. `None` on
+/// that race (the caller should treat it as `"Job cancelled"`); `Some(job_id)`
+/// otherwise. Safe to cancel unconditionally on the race path — `job_id` is a
+/// fresh UUID ([`crate::db::new_job_id`]), so it can never collide with a
+/// later, unrelated `start_job` call.
+///
+/// Generic over a combined [`JobStarter`] + [`JobCanceller`] recorder (not
+/// the concrete `AppHandle`) so this ordering is directly unit-testable
+/// without a live `AppHandle` — this crate has no `tauri::test` mock-app
+/// harness. The sole production caller (`compose_draft_stream`, in
+/// [`super::stream`]) passes a real `&AppHandle` (which implements both).
+pub(super) fn start_and_register<T: JobStarter + JobCanceller>(
+    starter: &T,
+    registry: &AssistStreamRegistry,
+    req_id: &str,
+) -> Option<String> {
+    let job_id = crate::db::new_job_id();
+    starter.start_job(&job_id);
+    if !registry.register(req_id, &job_id) {
+        starter.cancel_job(&job_id);
+        return None;
+    }
+    Some(job_id)
+}
+
+/// One `reqId`'s lifecycle in the per-connection registry — from the moment
+/// `resolve_answer_assist` starts its pre-compose work (before ANY billable
+/// spend) through to either a registered running job or an early
+/// cancellation. See [`super::stream`]'s module doc's "An `assist.cancel`
+/// races the pre-compose window" case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StreamEntry {
+    /// Pre-compose work (gate/resume/limiter/salary/web-notes) is in
+    /// flight — no job exists yet.
+    Pending,
+    /// [`AssistStreamRegistry::register`] recorded its job id.
+    Running(String),
+    /// An `assist.cancel` arrived while still `Pending` — the pre-compose
+    /// caller must short-circuit rather than proceed to the billable
+    /// compose call. See [`AssistStreamRegistry::register`]'s return value.
+    CancelledEarly,
+}
+
+/// Per-connection registry of in-flight/pending streaming `answer.assist`
+/// requests (`reqId -> `[`StreamEntry`]) — deliberately scoped to ONE
+/// connection. See [`super::stream`]'s module doc's "Cancellation is
+/// per-connection" section.
+#[derive(Default)]
+pub(super) struct AssistStreamRegistry(Mutex<HashMap<String, StreamEntry>>);
+
+impl AssistStreamRegistry {
+    /// Mark `req_id` as `Pending` BEFORE any pre-compose await (the gate/
+    /// resume/limiter/salary/web-notes lookups in `resolve_answer_assist`) —
+    /// the realistic window (network round-trips) an `assist.cancel` could
+    /// race ahead of [`Self::register`]. Returns `false` (leaving the
+    /// existing entry untouched) when `req_id` already names ANY entry on
+    /// this connection — `Pending`, `Running`, OR `CancelledEarly` — never
+    /// silently overwriting it with a fresh `Pending`. Overwriting a
+    /// `Running` entry would orphan its job (still running server-side, but
+    /// no longer reachable from this registry, so a later `assist.cancel`
+    /// for that reqId could never reach it again). Overwriting a
+    /// `CancelledEarly` entry reopens the SAME hole from the other
+    /// direction: that marker is NOT settled — it is awaiting consumption by
+    /// [`Self::register`] (which sees it, removes it, and reports `false` so
+    /// the run that raced the cancel never starts a billable job) or removal
+    /// by [`Self::unregister`]/[`Self::cancel_all`]. Allowing a reuse before
+    /// that consumption would let a second run's fresh `Pending` slip in
+    /// under the same `req_id`; the FIRST (already-cancelled) run's later
+    /// `register` call would then see that second run's `Pending` instead of
+    /// its own `CancelledEarly` marker and register a billable job anyway —
+    /// the cancel guarantee lost. It is always cleared within the original
+    /// run's own lifecycle (consumed by `register`, or removed by an
+    /// `unregister`/`cancel_all`), so a `req_id` can never get stuck rejected
+    /// forever; a well-behaved client uses a fresh reqId per request anyway.
+    /// Returns `true` — and inserts `Pending` — only when `req_id` names no
+    /// entry at all: a fresh `req_id`, or one that already fully settled and
+    /// was removed.
+    pub(super) fn begin(&self, req_id: &str) -> bool {
+        let mut guard = self.0.lock();
+        if guard.contains_key(req_id) {
+            return false;
+        }
+        guard.insert(req_id.to_string(), StreamEntry::Pending);
+        true
+    }
+
+    /// Register an in-flight stream's `reqId -> jobId`, UNLESS `req_id` was
+    /// already marked [`StreamEntry::CancelledEarly`] (an `assist.cancel`
+    /// raced the pre-compose window) — in which case this is a no-op and
+    /// returns `false`, so the caller aborts BEFORE ever starting the
+    /// billable job, rather than registering (and thus only becoming
+    /// cancellable from this point forward) a stream the client already
+    /// gave up on. Returns `true` otherwise: the normal `Pending` →
+    /// `Running` move, or a caller that never `begin`s at all.
+    pub(super) fn register(&self, req_id: &str, job_id: &str) -> bool {
+        let mut guard = self.0.lock();
+        if matches!(guard.get(req_id), Some(StreamEntry::CancelledEarly)) {
+            guard.remove(req_id);
+            return false;
+        }
+        guard.insert(req_id.to_string(), StreamEntry::Running(job_id.to_string()));
+        true
+    }
+
+    /// Forget a stream's registration once it ends (success, failure, or an
+    /// already-raced cancel). A no-op when `req_id` is already gone — never
+    /// an error.
+    pub(super) fn unregister(&self, req_id: &str) {
+        self.0.lock().remove(req_id);
+    }
+
+    /// Remove + return the RUNNING job registered under `req_id` on THIS
+    /// registry — `None` when never registered here, already finished,
+    /// still `Pending` (no job yet), or belonging to a DIFFERENT
+    /// connection's registry (the CWE-639 case this type exists to close).
+    /// Pure (no `AppHandle`, no [`JobCanceller`]), so this security-relevant
+    /// property is directly unit-testable. Test-only: [`Self::cancel`] used
+    /// to call this (a separate `lock()` acquisition), but that shape was a
+    /// TOCTOU (a concurrent `register` could flip `Pending` -> `Running` in
+    /// the gap between this method's lock and `cancel`'s own); `cancel` now
+    /// inlines the same decision under ONE lock instead, leaving this method
+    /// only as a test seam.
+    #[cfg(test)]
+    pub(super) fn take(&self, req_id: &str) -> Option<String> {
+        let mut guard = self.0.lock();
+        // Checked BEFORE removing — a naive unconditional `remove` would
+        // destroy a `Pending`/`CancelledEarly` entry it isn't actually
+        // returning, silently losing that state for anyone who checks
+        // `req_id` afterward (this was a real bug caught by this file's own
+        // pre-registration-race test).
+        match guard.get(req_id) {
+            Some(StreamEntry::Running(_)) => match guard.remove(req_id) {
+                Some(StreamEntry::Running(job_id)) => Some(job_id),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Test-only seam: whether ANY entry (`Pending`, `Running`, or
+    /// `CancelledEarly`) exists for `req_id` — unlike [`Self::take`] (which
+    /// only ever observes a `Running` job), this is what a leak-detection
+    /// test needs to assert a `Pending` entry was actually `unregister`ed,
+    /// not just left un-taken.
+    #[cfg(test)]
+    pub(super) fn contains(&self, req_id: &str) -> bool {
+        self.0.lock().contains_key(req_id)
+    }
+
+    /// Cancel the stream named by `req_id` on THIS registry, if any. A
+    /// `Running` entry is job-cancelled via `canceller` (the SAME mechanism
+    /// `chat_stream`'s `is_cancelled` polls every chunk, so the provider
+    /// call itself stops on its next read) and forgotten. A still-`Pending`
+    /// entry (no job yet — the pre-compose window) is marked
+    /// [`StreamEntry::CancelledEarly`] instead, so [`Self::register`]
+    /// reports `false` once the pre-compose caller reaches it. A no-op when
+    /// `req_id` names nothing on this connection at all. Generic over
+    /// [`JobCanceller`] (not the concrete `AppHandle`) so this is
+    /// unit-testable against a fake recorder — the sole production caller
+    /// passes a real `&AppHandle` (which implements it).
+    pub(super) fn cancel<C: JobCanceller>(&self, canceller: &C, req_id: &str) {
+        // The whole "is it Running, or still Pending, or neither" decision
+        // happens under ONE lock acquisition — splitting it into `take`
+        // (its own lock) followed by a second, separate `self.0.lock()` (the
+        // original shape) leaves a gap between the two where a concurrent
+        // `register` can flip `Pending` -> `Running` on the multi-threaded
+        // runtime, so this call would see neither case and silently miss
+        // the cancel (TOCTOU). Same per-variant behavior as before, just
+        // decided in one critical section.
+        let job_id = {
+            let mut guard = self.0.lock();
+            match guard.get(req_id) {
+                Some(StreamEntry::Running(_)) => match guard.remove(req_id) {
+                    Some(StreamEntry::Running(job_id)) => Some(job_id),
+                    _ => None,
+                },
+                Some(StreamEntry::Pending) => {
+                    guard.insert(req_id.to_string(), StreamEntry::CancelledEarly);
+                    None
+                }
+                _ => None,
+            }
+        };
+        if let Some(job_id) = job_id {
+            canceller.cancel_job(&job_id);
+        }
+    }
+
+    /// Cancel EVERY stream currently registered on THIS connection's
+    /// registry — called once the connection's read loop exits (socket
+    /// closed/errored) so a client disconnect stops every billable
+    /// generation still running for it, not just the one an explicit
+    /// `assist.cancel` might have named (the CWE-639 fix stays: this only
+    /// ever touches THIS connection's own map). A `Running` entry is
+    /// cancelled via `canceller`; a still-`Pending` entry is marked
+    /// `CancelledEarly` (mirrors [`Self::cancel`]'s `Pending` arm) so
+    /// in-flight pre-compose work also short-circuits instead of reaching a
+    /// now-pointless billable compose call. Generic over [`JobCanceller`] —
+    /// see [`Self::cancel`]'s doc.
+    pub(super) fn cancel_all<C: JobCanceller>(&self, canceller: &C) {
+        let mut guard = self.0.lock();
+        let drained: Vec<(String, StreamEntry)> = guard.drain().collect();
+        let mut running = Vec::new();
+        for (req_id, entry) in drained {
+            match entry {
+                StreamEntry::Running(job_id) => running.push(job_id),
+                // Exhaustive on purpose: BOTH still-pending AND
+                // already-cancelled-early entries must be reinserted as
+                // `CancelledEarly`. Dropping the latter (the original bug)
+                // loses the guard marker on a cancel-then-disconnect during
+                // the pre-compose window — the entry vanishes from the map,
+                // so the later `register` call for that `req_id` finds
+                // nothing, returns `true`, and starts a full billable
+                // generation for a request the user already cancelled.
+                StreamEntry::Pending | StreamEntry::CancelledEarly => {
+                    guard.insert(req_id, StreamEntry::CancelledEarly);
+                }
+            }
+        }
+        drop(guard);
+        for job_id in running {
+            canceller.cancel_job(&job_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── AssistStreamRegistry: register / take / unregister ─────────────────
+
+    #[test]
+    fn register_then_take_returns_and_forgets_it() {
+        let r = AssistStreamRegistry::default();
+        assert!(r.register("req-1", "job-1"));
+        assert_eq!(r.take("req-1"), Some("job-1".to_string()));
+        assert_eq!(r.take("req-1"), None, "take also forgets the mapping");
+    }
+
+    #[test]
+    fn unregister_on_an_unknown_req_id_is_a_no_op() {
+        let r = AssistStreamRegistry::default();
+        r.unregister("never-registered"); // must not panic
+        assert_eq!(r.take("never-registered"), None);
+    }
+
+    #[test]
+    fn register_overwrites_a_prior_mapping_for_the_same_req_id() {
+        let r = AssistStreamRegistry::default();
+        assert!(r.register("req-1", "job-1"));
+        assert!(r.register("req-1", "job-2"));
+        assert_eq!(
+            r.take("req-1"),
+            Some("job-2".to_string()),
+            "a re-registration under the same reqId must replace, not duplicate"
+        );
+    }
+
+    #[test]
+    fn unregister_then_register_again_reflects_the_new_mapping() {
+        let r = AssistStreamRegistry::default();
+        assert!(r.register("req-1", "job-1"));
+        r.unregister("req-1");
+        assert!(r.register("req-1", "job-2"));
+        assert_eq!(r.take("req-1"), Some("job-2".to_string()));
+    }
+
+    // ── CWE-639 regression: a different connection's registry can never see
+    // (let alone cancel) another connection's stream ──────────────────────
+
+    #[test]
+    fn take_on_a_different_connections_registry_never_sees_another_connections_stream() {
+        // Two independent registries — one per connection, exactly as
+        // `handle_connection` creates a fresh one per socket.
+        let connection_a = AssistStreamRegistry::default();
+        let connection_b = AssistStreamRegistry::default();
+
+        connection_a.register("req-1", "job-1");
+
+        // Connection B never registered "req-1" — it must be a no-op, NEVER
+        // able to observe (let alone cancel) connection A's stream.
+        assert_eq!(
+            connection_b.take("req-1"),
+            None,
+            "a different connection's registry must never see this reqId"
+        );
+
+        // Connection A can still cancel its own stream — the isolation is
+        // per-connection, not "nobody can ever cancel it".
+        assert_eq!(connection_a.take("req-1"), Some("job-1".to_string()));
+    }
+
+    // ── AssistStreamRegistry::cancel / cancel_all (JobCanceller-generic —
+    // testable without a live AppHandle; this crate has no tauri::test
+    // mock-app harness) ─────────────────────────────────────────────────────
+
+    #[derive(Default)]
+    struct RecordingCanceller {
+        cancelled: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl JobCanceller for RecordingCanceller {
+        fn cancel_job(&self, job_id: &str) {
+            self.cancelled.borrow_mut().push(job_id.to_string());
+        }
+    }
+
+    #[test]
+    fn cancel_on_an_unknown_req_id_never_touches_the_canceller() {
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        r.cancel(&canceller, "never-registered");
+        assert!(canceller.cancelled.borrow().is_empty());
+    }
+
+    #[test]
+    fn cancel_on_a_running_req_id_cancels_its_job_and_forgets_the_mapping() {
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        r.register("req-1", "job-1");
+        r.cancel(&canceller, "req-1");
+        assert_eq!(canceller.cancelled.into_inner(), vec!["job-1".to_string()]);
+        assert_eq!(r.take("req-1"), None, "cancel also forgets the mapping");
+    }
+
+    #[test]
+    fn cancel_all_cancels_every_running_stream_and_leaves_pending_alone_besides_marking_it() {
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        r.register("req-1", "job-1");
+        r.register("req-2", "job-2");
+        r.begin("req-3"); // still pending — no job to cancel
+        r.cancel_all(&canceller);
+
+        let mut got = canceller.cancelled.into_inner();
+        got.sort();
+        assert_eq!(
+            got,
+            vec!["job-1".to_string(), "job-2".to_string()],
+            "only RUNNING entries are ever job-cancelled"
+        );
+        // The pending entry is now cancelled-early — a still in-flight
+        // pre-compose caller must never be allowed to register a job for it.
+        assert!(!r.register("req-3", "job-3"));
+    }
+
+    #[test]
+    fn cancel_all_on_an_empty_registry_is_a_no_op() {
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        r.cancel_all(&canceller);
+        assert!(canceller.cancelled.into_inner().is_empty());
+    }
+
+    #[test]
+    fn cancel_all_preserves_an_already_cancelled_early_entry() {
+        // HIGH regression: cancel-then-disconnect during the pre-compose
+        // window. `begin` + `cancel` leaves `req-1` as `CancelledEarly`
+        // BEFORE `cancel_all` ever runs; `cancel_all` must reinsert it
+        // (not drop it on the floor), or the later `register` call for the
+        // same `req_id` finds nothing, returns `true`, and starts a full
+        // billable generation for a request the user already cancelled.
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        r.begin("req-1");
+        r.cancel(&canceller, "req-1"); // -> CancelledEarly, no job existed yet
+        r.cancel_all(&canceller);
+
+        assert!(
+            canceller.cancelled.borrow().is_empty(),
+            "no Running job existed at any point — nothing to job_cancel"
+        );
+        assert!(
+            !r.register("req-1", "job-1"),
+            "the CancelledEarly guard must survive cancel_all's drain-and-reinsert"
+        );
+    }
+
+    // ── Pre-registration cancel race (LOW fix): begin() + register()'s bool ─
+
+    #[test]
+    fn cancel_during_the_pending_window_prevents_the_later_register_call() {
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        r.begin("req-1"); // pre-compose work has started — no job yet
+        r.cancel(&canceller, "req-1"); // assist.cancel races the awaits
+
+        assert!(
+            canceller.cancelled.borrow().is_empty(),
+            "no job exists yet — there is nothing to job_cancel"
+        );
+        assert!(
+            !r.register("req-1", "job-1"),
+            "the compose call must never start a billable job for an early-cancelled reqId"
+        );
+        assert_eq!(
+            r.take("req-1"),
+            None,
+            "the cancelled-early marker must never surface as a real job"
+        );
+    }
+
+    #[test]
+    fn register_without_a_prior_cancel_succeeds_normally_after_begin() {
+        let r = AssistStreamRegistry::default();
+        r.begin("req-1");
+        assert!(r.register("req-1", "job-1"));
+        assert_eq!(r.take("req-1"), Some("job-1".to_string()));
+    }
+
+    // ── Duplicate reqId rejection (MEDIUM fix): begin() on an already-active
+    // entry must never orphan the original job ─────────────────────────────
+
+    #[test]
+    fn begin_on_a_fresh_req_id_succeeds() {
+        let r = AssistStreamRegistry::default();
+        assert!(r.begin("req-1"));
+    }
+
+    #[test]
+    fn begin_on_an_already_pending_req_id_is_rejected() {
+        let r = AssistStreamRegistry::default();
+        r.begin("req-1"); // first request's pre-compose window is in flight
+
+        assert!(
+            !r.begin("req-1"),
+            "a second begin for the same still-Pending reqId must be rejected"
+        );
+    }
+
+    #[test]
+    fn begin_on_an_already_running_req_id_is_rejected_and_the_original_stays_cancellable() {
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        assert!(r.register("req-1", "job-1")); // the original request is now Running
+
+        // A client reusing the SAME reqId while the original is still
+        // running must be rejected — never silently overwrite the Running
+        // entry with a fresh Pending, which would orphan job-1 (still
+        // running server-side, but no longer reachable to cancel).
+        assert!(!r.begin("req-1"));
+
+        r.cancel(&canceller, "req-1");
+        assert_eq!(
+            canceller.cancelled.into_inner(),
+            vec!["job-1".to_string()],
+            "the original job must still be there and cancellable after the rejected begin"
+        );
+    }
+
+    #[test]
+    fn begin_on_a_cancelled_early_req_id_is_rejected() {
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        r.begin("req-1");
+        r.cancel(&canceller, "req-1"); // -> CancelledEarly, no job existed yet
+
+        assert!(
+            !r.begin("req-1"),
+            "a CancelledEarly marker is not settled — reuse must be rejected \
+             until register (or unregister/cancel_all) consumes it"
+        );
+    }
+
+    #[test]
+    fn begin_on_a_cancelled_early_req_id_is_rejected_until_register_consumes_it() {
+        // Full spend/cancel-integrity guarantee: a run that reused req-1
+        // before the CancelledEarly marker was consumed used to be able to
+        // slip a fresh Pending in, which let the FIRST (already-cancelled)
+        // run's later `register` call see that Pending instead of its own
+        // marker and start a billable job anyway — the exact hole this fix
+        // closes.
+        let r = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        r.begin("req-1"); // run A's pre-compose window opens
+        r.cancel(&canceller, "req-1"); // -> CancelledEarly, run A has no job yet
+
+        assert!(
+            !r.begin("req-1"),
+            "a second run reusing req-1 must be rejected while the marker is un-consumed"
+        );
+        assert!(
+            !r.register("req-1", "job-a"),
+            "register consumes the CancelledEarly marker and reports false — \
+             run A never starts a billable job"
+        );
+        assert!(
+            r.begin("req-1"),
+            "once consumed, req-1 names no entry at all — reuse is allowed again"
+        );
+    }
+
+    // ── start_and_register (HIGH fix: job_start-before-register TOCTOU —
+    // starting the job before registering it means a cancel racing the gap
+    // finds Pending, not a not-yet-existing Running job) ───────────────────
+
+    #[derive(Default)]
+    struct RecordingStarterCanceller {
+        started: std::cell::RefCell<Vec<String>>,
+        cancelled: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl JobStarter for RecordingStarterCanceller {
+        fn start_job(&self, job_id: &str) {
+            self.started.borrow_mut().push(job_id.to_string());
+        }
+    }
+
+    impl JobCanceller for RecordingStarterCanceller {
+        fn cancel_job(&self, job_id: &str) {
+            self.cancelled.borrow_mut().push(job_id.to_string());
+        }
+    }
+
+    #[test]
+    fn start_and_register_starts_the_job_then_registers_it_on_the_happy_path() {
+        let registry = AssistStreamRegistry::default();
+        let recorder = RecordingStarterCanceller::default();
+
+        let job_id = start_and_register(&recorder, &registry, "req-1")
+            .expect("a fresh reqId with no prior cancel must register successfully");
+
+        assert_eq!(
+            recorder.started.into_inner(),
+            vec![job_id.clone()],
+            "job_start must have run, unconditionally, before register was ever consulted"
+        );
+        assert!(
+            recorder.cancelled.borrow().is_empty(),
+            "a successful register must never cancel the job it just started"
+        );
+        assert_eq!(
+            registry.take("req-1"),
+            Some(job_id),
+            "register must have recorded the Running entry"
+        );
+    }
+
+    #[test]
+    fn start_and_register_cancels_the_just_started_job_when_a_cancel_already_raced_ahead() {
+        // The exact TOCTOU this reorder closes: an `assist.cancel` that
+        // arrived during the pre-compose window (captured here as a
+        // pre-seeded `CancelledEarly` marker — see `AssistStreamRegistry::
+        // begin`/`cancel`) must never leave a job that's Running but neither
+        // cancelled nor cancellable. `job_start` still runs — unconditionally,
+        // BEFORE `register` is ever consulted, proving the new order — but
+        // `register` then reports the race, and this function must cancel
+        // the very job it just started rather than leaving it orphaned.
+        let registry = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        registry.begin("req-1");
+        registry.cancel(&canceller, "req-1"); // -> CancelledEarly, no job existed yet
+
+        let recorder = RecordingStarterCanceller::default();
+        let result = start_and_register(&recorder, &registry, "req-1");
+
+        assert!(
+            result.is_none(),
+            "a raced-ahead cancel must make start_and_register report failure"
+        );
+        assert_eq!(
+            recorder.started.borrow().len(),
+            1,
+            "job_start must still have run — it happens BEFORE register is ever consulted"
+        );
+        let started_id = recorder.started.borrow()[0].clone();
+        assert_eq!(
+            recorder.cancelled.into_inner(),
+            vec![started_id],
+            "the job just started must be job-cancelled immediately — no leaked Running job"
+        );
+        assert!(
+            !registry.contains("req-1"),
+            "the CancelledEarly marker must be consumed, not left behind"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -765,8 +765,12 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
                 // so a multi-second stream never blocks THIS loop's
                 // `reader.next()` — the HIGH fix: an `assist.cancel` for this
                 // very stream (or any other frame) must still be read while it
-                // is in flight. No reply here — the spawned task sends its own
-                // `assist.chunk`/`assist.done`/terminal reply through `out_tx`.
+                // is in flight. No reply here for the normal path — the
+                // spawned task sends its own `assist.chunk`/`assist.done`/
+                // terminal reply through `out_tx`. A duplicate `reqId` is
+                // rejected SYNCHRONOUSLY inside `spawn_answer_assist` (before
+                // it ever spawns) with its own `answer.assist.result` error
+                // reply, also via `out_tx` — see that function's doc.
                 stream::spawn_answer_assist(
                     app.clone(),
                     req_id,

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -63,6 +63,7 @@ use crate::error::{AppError, AppResult};
 mod answer_assist;
 mod answers_save;
 mod answers_suggest;
+mod assist_registry;
 pub mod auth;
 pub mod handshake;
 mod import_flow;

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -604,6 +604,16 @@ async fn probe_ports(range: std::ops::RangeInclusive<u16>) -> Option<(TcpListene
 /// live WS sink; this loop only ever enqueues (never awaits a socket write),
 /// so it keeps polling `reader.next()` — including a same-connection
 /// `assist.cancel` — while a stream is in flight.
+///
+/// The read loop also observes [`stream::run_writer`]'s own `JoinHandle` (via
+/// [`stream::next_step`]), not just `reader.next()` — [`stream::run_writer`] is
+/// spawned DETACHED, so if nothing else raced it, this loop would never learn
+/// it ended (a `WRITE_STALL` timeout, or a genuine send error) until its OWN
+/// next inbound frame — which, for a stalled-but-open peer or a quiet/idle
+/// connection, may never arrive, leaving `cancel_all`/`set_connected(false)`
+/// below delayed indefinitely while the app still believes the extension is
+/// connected. Racing the writer handle alongside `reader.next()` means a
+/// writer-task end tears the connection down immediately instead.
 async fn handle_connection(app: AppHandle, stream: TcpStream) {
     use tokio_tungstenite::tungstenite::handshake::server::ErrorResponse;
     use tokio_tungstenite::tungstenite::http::StatusCode;
@@ -668,7 +678,9 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
     // spawned streaming task never blocks this loop from polling
     // `reader.next()` again.
     let (out_tx, out_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
-    tokio::spawn(stream::run_writer(writer, out_rx));
+    // Kept (not fire-and-forget-dropped) so the read loop below can race it
+    // via [`next_step`] — see `handle_connection`'s own doc for why.
+    let mut writer_task = tokio::spawn(stream::run_writer(writer, out_rx));
 
     // Per-connection handshake state; every socket starts by expecting `hello`.
     let mut conn = ConnState::AwaitingHello;
@@ -680,7 +692,27 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
     // rather than a field on the global `BridgeState`.
     let assist_streams = std::sync::Arc::new(stream::AssistStreamRegistry::default());
 
-    while let Some(frame) = reader.next().await {
+    loop {
+        let frame = match stream::next_step(reader.next(), &mut writer_task).await {
+            stream::NextStep::Frame(frame) => frame,
+            stream::NextStep::WriterEnded => {
+                // See `next_step`'s doc + `handle_connection`'s own doc: the
+                // writer task ending (a `WRITE_STALL` timeout or a send error)
+                // must tear this connection down immediately, not wait for
+                // this loop's own next inbound frame — which, for a
+                // stalled-but-open or quiet/idle connection, may never come.
+                // Falls through to the SAME cancel_all + set_connected(false)
+                // cleanup below as every other exit path.
+                log::warn!(
+                    "[extension_bridge] writer task ended (write-stall timeout or a \
+                     send error) — tearing down the connection"
+                );
+                break;
+            }
+        };
+        let Some(frame) = frame else {
+            break;
+        };
         let msg = match frame {
             Ok(m) => m,
             Err(e) => {

--- a/apps/desktop/src-tauri/src/extension_bridge/stream.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/stream.rs
@@ -72,7 +72,6 @@
 //! it checks the job's live status first, so a cancellation (any of the
 //! above, or an external `assist.cancel`) is never overwritten `Failed`.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::SinkExt;
@@ -82,6 +81,7 @@ use tauri::{AppHandle, Listener, Manager};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio_tungstenite::tungstenite::Message;
 
+use super::assist_registry::start_and_register;
 use super::msg;
 use crate::error::{AppError, AppResult};
 use crate::events::{AiStreamChunk, AI_STREAM};
@@ -258,275 +258,11 @@ fn begin_or_reject_duplicate(
     false
 }
 
-// ── Per-connection stream registry (register / cancel / pre-registration race) ──
-
-/// Abstracts "cancel one job by id" so [`AssistStreamRegistry::cancel`]/
-/// [`AssistStreamRegistry::cancel_all`]'s job-cancelling side effect is
-/// unit-testable against a fake recorder, without a live `AppHandle` — this
-/// crate has no `tauri::test` mock-app harness (mirrors the
-/// `SalarySearcher`/`AnswerSearcher` genericization precedent in
-/// `answer_assist`/`commands::ai`). The sole production implementor forwards
-/// to [`crate::commands::jobs::job_cancel`].
-pub(super) trait JobCanceller {
-    fn cancel_job(&self, job_id: &str);
-}
-
-impl JobCanceller for AppHandle {
-    fn cancel_job(&self, job_id: &str) {
-        crate::commands::jobs::job_cancel(self, job_id);
-    }
-}
-
-/// Abstracts "start a job by id" so [`start_and_register`]'s
-/// start-before-register ordering is unit-testable against a fake recorder,
-/// without a live `AppHandle` — mirrors [`JobCanceller`]'s existing seam. The
-/// sole production implementor forwards to [`crate::commands::jobs::job_start`]
-/// with this module's one fixed job kind (every job this registry ever tracks
-/// is an `"extension.answer_assist"` job).
-pub(super) trait JobStarter {
-    fn start_job(&self, job_id: &str);
-}
-
-impl JobStarter for AppHandle {
-    fn start_job(&self, job_id: &str) {
-        crate::commands::jobs::job_start(self, job_id, "extension.answer_assist");
-    }
-}
-
-/// Start a fresh job for `req_id` and register it with `registry` —
-/// deliberately `start` BEFORE `register`, the reverse of this module's
-/// original order. The original order had a TOCTOU: `register` published a
-/// `Running(job_id)` entry before the job existed, so an `assist.cancel`
-/// landing in that exact gap found `Running`, removed the entry, and called
-/// `cancel_job` on an id nothing had started yet (a no-op) — the job then
-/// started anyway, Running, with no cancel path left. Starting first closes
-/// it: a cancel racing this same gap instead finds the `Pending` marker
-/// [`AssistStreamRegistry::begin`] already left behind (set synchronously in
-/// `spawn_answer_assist`, before this task was even spawned), so `register`
-/// below correctly observes [`StreamEntry::CancelledEarly`] and this function
-/// cancels the very job it just started before reporting failure. `None` on
-/// that race (the caller should treat it as `"Job cancelled"`); `Some(job_id)`
-/// otherwise. Safe to cancel unconditionally on the race path — `job_id` is a
-/// fresh UUID ([`crate::db::new_job_id`]), so it can never collide with a
-/// later, unrelated `start_job` call.
-///
-/// Generic over a combined [`JobStarter`] + [`JobCanceller`] recorder (not
-/// the concrete `AppHandle`) so this ordering is directly unit-testable
-/// without a live `AppHandle` — this crate has no `tauri::test` mock-app
-/// harness. The sole production caller ([`compose_draft_stream`]) passes a
-/// real `&AppHandle` (which implements both).
-pub(super) fn start_and_register<T: JobStarter + JobCanceller>(
-    starter: &T,
-    registry: &AssistStreamRegistry,
-    req_id: &str,
-) -> Option<String> {
-    let job_id = crate::db::new_job_id();
-    starter.start_job(&job_id);
-    if !registry.register(req_id, &job_id) {
-        starter.cancel_job(&job_id);
-        return None;
-    }
-    Some(job_id)
-}
-
-/// One `reqId`'s lifecycle in the per-connection registry — from the moment
-/// `resolve_answer_assist` starts its pre-compose work (before ANY billable
-/// spend) through to either a registered running job or an early
-/// cancellation. See the module doc's "pre-registration cancel race" case.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum StreamEntry {
-    /// Pre-compose work (gate/resume/limiter/salary/web-notes) is in
-    /// flight — no job exists yet.
-    Pending,
-    /// [`AssistStreamRegistry::register`] recorded its job id.
-    Running(String),
-    /// An `assist.cancel` arrived while still `Pending` — the pre-compose
-    /// caller must short-circuit rather than proceed to the billable
-    /// compose call. See [`AssistStreamRegistry::register`]'s return value.
-    CancelledEarly,
-}
-
-/// Per-connection registry of in-flight/pending streaming `answer.assist`
-/// requests (`reqId -> `[`StreamEntry`]) — deliberately scoped to ONE
-/// connection. See the module doc's "Cancellation is per-connection" section.
-#[derive(Default)]
-pub(super) struct AssistStreamRegistry(Mutex<HashMap<String, StreamEntry>>);
-
-impl AssistStreamRegistry {
-    /// Mark `req_id` as `Pending` BEFORE any pre-compose await (the gate/
-    /// resume/limiter/salary/web-notes lookups in `resolve_answer_assist`) —
-    /// the realistic window (network round-trips) an `assist.cancel` could
-    /// race ahead of [`Self::register`]. Returns `false` (leaving the
-    /// existing entry untouched) when `req_id` already names ANY entry on
-    /// this connection — `Pending`, `Running`, OR `CancelledEarly` — never
-    /// silently overwriting it with a fresh `Pending`. Overwriting a
-    /// `Running` entry would orphan its job (still running server-side, but
-    /// no longer reachable from this registry, so a later `assist.cancel`
-    /// for that reqId could never reach it again). Overwriting a
-    /// `CancelledEarly` entry reopens the SAME hole from the other
-    /// direction: that marker is NOT settled — it is awaiting consumption by
-    /// [`Self::register`] (which sees it, removes it, and reports `false` so
-    /// the run that raced the cancel never starts a billable job) or removal
-    /// by [`Self::unregister`]/[`Self::cancel_all`]. Allowing a reuse before
-    /// that consumption would let a second run's fresh `Pending` slip in
-    /// under the same `req_id`; the FIRST (already-cancelled) run's later
-    /// `register` call would then see that second run's `Pending` instead of
-    /// its own `CancelledEarly` marker and register a billable job anyway —
-    /// the cancel guarantee lost. It is always cleared within the original
-    /// run's own lifecycle (consumed by `register`, or removed by an
-    /// `unregister`/`cancel_all`), so a `req_id` can never get stuck rejected
-    /// forever; a well-behaved client uses a fresh reqId per request anyway.
-    /// Returns `true` — and inserts `Pending` — only when `req_id` names no
-    /// entry at all: a fresh `req_id`, or one that already fully settled and
-    /// was removed.
-    pub(super) fn begin(&self, req_id: &str) -> bool {
-        let mut guard = self.0.lock();
-        if guard.contains_key(req_id) {
-            return false;
-        }
-        guard.insert(req_id.to_string(), StreamEntry::Pending);
-        true
-    }
-
-    /// Register an in-flight stream's `reqId -> jobId`, UNLESS `req_id` was
-    /// already marked [`StreamEntry::CancelledEarly`] (an `assist.cancel`
-    /// raced the pre-compose window) — in which case this is a no-op and
-    /// returns `false`, so the caller aborts BEFORE ever starting the
-    /// billable job, rather than registering (and thus only becoming
-    /// cancellable from this point forward) a stream the client already
-    /// gave up on. Returns `true` otherwise: the normal `Pending` →
-    /// `Running` move, or a caller that never `begin`s at all.
-    pub(super) fn register(&self, req_id: &str, job_id: &str) -> bool {
-        let mut guard = self.0.lock();
-        if matches!(guard.get(req_id), Some(StreamEntry::CancelledEarly)) {
-            guard.remove(req_id);
-            return false;
-        }
-        guard.insert(req_id.to_string(), StreamEntry::Running(job_id.to_string()));
-        true
-    }
-
-    /// Forget a stream's registration once it ends (success, failure, or an
-    /// already-raced cancel). A no-op when `req_id` is already gone — never
-    /// an error.
-    pub(super) fn unregister(&self, req_id: &str) {
-        self.0.lock().remove(req_id);
-    }
-
-    /// Remove + return the RUNNING job registered under `req_id` on THIS
-    /// registry — `None` when never registered here, already finished,
-    /// still `Pending` (no job yet), or belonging to a DIFFERENT
-    /// connection's registry (the CWE-639 case this type exists to close).
-    /// Pure (no `AppHandle`, no [`JobCanceller`]), so this security-relevant
-    /// property is directly unit-testable. Test-only: [`Self::cancel`] used
-    /// to call this (a separate `lock()` acquisition), but that shape was a
-    /// TOCTOU (a concurrent `register` could flip `Pending` -> `Running` in
-    /// the gap between this method's lock and `cancel`'s own); `cancel` now
-    /// inlines the same decision under ONE lock instead, leaving this method
-    /// only as a test seam.
-    #[cfg(test)]
-    pub(super) fn take(&self, req_id: &str) -> Option<String> {
-        let mut guard = self.0.lock();
-        // Checked BEFORE removing — a naive unconditional `remove` would
-        // destroy a `Pending`/`CancelledEarly` entry it isn't actually
-        // returning, silently losing that state for anyone who checks
-        // `req_id` afterward (this was a real bug caught by this file's own
-        // pre-registration-race test).
-        match guard.get(req_id) {
-            Some(StreamEntry::Running(_)) => match guard.remove(req_id) {
-                Some(StreamEntry::Running(job_id)) => Some(job_id),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Test-only seam: whether ANY entry (`Pending`, `Running`, or
-    /// `CancelledEarly`) exists for `req_id` — unlike [`Self::take`] (which
-    /// only ever observes a `Running` job), this is what a leak-detection
-    /// test needs to assert a `Pending` entry was actually `unregister`ed,
-    /// not just left un-taken.
-    #[cfg(test)]
-    pub(super) fn contains(&self, req_id: &str) -> bool {
-        self.0.lock().contains_key(req_id)
-    }
-
-    /// Cancel the stream named by `req_id` on THIS registry, if any. A
-    /// `Running` entry is job-cancelled via `canceller` (the SAME mechanism
-    /// `chat_stream`'s `is_cancelled` polls every chunk, so the provider
-    /// call itself stops on its next read) and forgotten. A still-`Pending`
-    /// entry (no job yet — the pre-compose window) is marked
-    /// [`StreamEntry::CancelledEarly`] instead, so [`Self::register`]
-    /// reports `false` once the pre-compose caller reaches it. A no-op when
-    /// `req_id` names nothing on this connection at all. Generic over
-    /// [`JobCanceller`] (not the concrete `AppHandle`) so this is
-    /// unit-testable against a fake recorder — the sole production caller
-    /// passes a real `&AppHandle` (which implements it).
-    pub(super) fn cancel<C: JobCanceller>(&self, canceller: &C, req_id: &str) {
-        // The whole "is it Running, or still Pending, or neither" decision
-        // happens under ONE lock acquisition — splitting it into `take`
-        // (its own lock) followed by a second, separate `self.0.lock()` (the
-        // original shape) leaves a gap between the two where a concurrent
-        // `register` can flip `Pending` -> `Running` on the multi-threaded
-        // runtime, so this call would see neither case and silently miss
-        // the cancel (TOCTOU). Same per-variant behavior as before, just
-        // decided in one critical section.
-        let job_id = {
-            let mut guard = self.0.lock();
-            match guard.get(req_id) {
-                Some(StreamEntry::Running(_)) => match guard.remove(req_id) {
-                    Some(StreamEntry::Running(job_id)) => Some(job_id),
-                    _ => None,
-                },
-                Some(StreamEntry::Pending) => {
-                    guard.insert(req_id.to_string(), StreamEntry::CancelledEarly);
-                    None
-                }
-                _ => None,
-            }
-        };
-        if let Some(job_id) = job_id {
-            canceller.cancel_job(&job_id);
-        }
-    }
-
-    /// Cancel EVERY stream currently registered on THIS connection's
-    /// registry — called once the connection's read loop exits (socket
-    /// closed/errored) so a client disconnect stops every billable
-    /// generation still running for it, not just the one an explicit
-    /// `assist.cancel` might have named (the CWE-639 fix stays: this only
-    /// ever touches THIS connection's own map). A `Running` entry is
-    /// cancelled via `canceller`; a still-`Pending` entry is marked
-    /// `CancelledEarly` (mirrors [`Self::cancel`]'s `Pending` arm) so
-    /// in-flight pre-compose work also short-circuits instead of reaching a
-    /// now-pointless billable compose call. Generic over [`JobCanceller`] —
-    /// see [`Self::cancel`]'s doc.
-    pub(super) fn cancel_all<C: JobCanceller>(&self, canceller: &C) {
-        let mut guard = self.0.lock();
-        let drained: Vec<(String, StreamEntry)> = guard.drain().collect();
-        let mut running = Vec::new();
-        for (req_id, entry) in drained {
-            match entry {
-                StreamEntry::Running(job_id) => running.push(job_id),
-                // Exhaustive on purpose: BOTH still-pending AND
-                // already-cancelled-early entries must be reinserted as
-                // `CancelledEarly`. Dropping the latter (the original bug)
-                // loses the guard marker on a cancel-then-disconnect during
-                // the pre-compose window — the entry vanishes from the map,
-                // so the later `register` call for that `req_id` finds
-                // nothing, returns `true`, and starts a full billable
-                // generation for a request the user already cancelled.
-                StreamEntry::Pending | StreamEntry::CancelledEarly => {
-                    guard.insert(req_id, StreamEntry::CancelledEarly);
-                }
-            }
-        }
-        drop(guard);
-        for job_id in running {
-            canceller.cancel_job(&job_id);
-        }
-    }
-}
+// ── Per-connection stream registry — the state machine itself now lives in
+// `assist_registry` (R8 split); re-exported here so every existing
+// `stream::AssistStreamRegistry` reference (mod.rs, answer_assist.rs, and
+// their tests) keeps resolving unchanged. ───────────────────────────────────
+pub(super) use super::assist_registry::AssistStreamRegistry;
 
 // ── Streaming compose internals (moved from `answer_assist` — R8 split) ─────
 
@@ -783,6 +519,7 @@ fn assist_done_frame(req_id: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::super::assist_registry::JobCanceller;
     use super::*;
 
     fn as_text(m: Message) -> String {
@@ -792,73 +529,16 @@ mod tests {
         }
     }
 
-    // ── AssistStreamRegistry: register / take / unregister ─────────────────
+    // `AssistStreamRegistry`'s own state-machine tests (register/take/
+    // unregister, CWE-639 isolation, cancel/cancel_all, the pre-registration
+    // cancel race, duplicate-reqId rejection) plus `start_and_register`'s
+    // tests now live in `assist_registry` (R8 split — see that module).
 
-    #[test]
-    fn register_then_take_returns_and_forgets_it() {
-        let r = AssistStreamRegistry::default();
-        assert!(r.register("req-1", "job-1"));
-        assert_eq!(r.take("req-1"), Some("job-1".to_string()));
-        assert_eq!(r.take("req-1"), None, "take also forgets the mapping");
-    }
-
-    #[test]
-    fn unregister_on_an_unknown_req_id_is_a_no_op() {
-        let r = AssistStreamRegistry::default();
-        r.unregister("never-registered"); // must not panic
-        assert_eq!(r.take("never-registered"), None);
-    }
-
-    #[test]
-    fn register_overwrites_a_prior_mapping_for_the_same_req_id() {
-        let r = AssistStreamRegistry::default();
-        assert!(r.register("req-1", "job-1"));
-        assert!(r.register("req-1", "job-2"));
-        assert_eq!(
-            r.take("req-1"),
-            Some("job-2".to_string()),
-            "a re-registration under the same reqId must replace, not duplicate"
-        );
-    }
-
-    #[test]
-    fn unregister_then_register_again_reflects_the_new_mapping() {
-        let r = AssistStreamRegistry::default();
-        assert!(r.register("req-1", "job-1"));
-        r.unregister("req-1");
-        assert!(r.register("req-1", "job-2"));
-        assert_eq!(r.take("req-1"), Some("job-2".to_string()));
-    }
-
-    // ── CWE-639 regression: a different connection's registry can never see
-    // (let alone cancel) another connection's stream ──────────────────────
-
-    #[test]
-    fn take_on_a_different_connections_registry_never_sees_another_connections_stream() {
-        // Two independent registries — one per connection, exactly as
-        // `handle_connection` creates a fresh one per socket.
-        let connection_a = AssistStreamRegistry::default();
-        let connection_b = AssistStreamRegistry::default();
-
-        connection_a.register("req-1", "job-1");
-
-        // Connection B never registered "req-1" — it must be a no-op, NEVER
-        // able to observe (let alone cancel) connection A's stream.
-        assert_eq!(
-            connection_b.take("req-1"),
-            None,
-            "a different connection's registry must never see this reqId"
-        );
-
-        // Connection A can still cancel its own stream — the isolation is
-        // per-connection, not "nobody can ever cancel it".
-        assert_eq!(connection_a.take("req-1"), Some("job-1".to_string()));
-    }
-
-    // ── AssistStreamRegistry::cancel / cancel_all (JobCanceller-generic —
-    // testable without a live AppHandle; this crate has no tauri::test
-    // mock-app harness) ─────────────────────────────────────────────────────
-
+    /// A tiny local copy of `assist_registry::tests::RecordingCanceller` —
+    /// duplicated (not shared) so this file's test module stays independent
+    /// of that module's own private test internals. Used only by the ONE
+    /// test below that needs to prove a cancel finds the Pending marker
+    /// `begin_or_reject_duplicate` leaves behind.
     #[derive(Default)]
     struct RecordingCanceller {
         cancelled: std::cell::RefCell<Vec<String>>,
@@ -868,191 +548,6 @@ mod tests {
         fn cancel_job(&self, job_id: &str) {
             self.cancelled.borrow_mut().push(job_id.to_string());
         }
-    }
-
-    #[test]
-    fn cancel_on_an_unknown_req_id_never_touches_the_canceller() {
-        let r = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        r.cancel(&canceller, "never-registered");
-        assert!(canceller.cancelled.borrow().is_empty());
-    }
-
-    #[test]
-    fn cancel_on_a_running_req_id_cancels_its_job_and_forgets_the_mapping() {
-        let r = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        r.register("req-1", "job-1");
-        r.cancel(&canceller, "req-1");
-        assert_eq!(canceller.cancelled.into_inner(), vec!["job-1".to_string()]);
-        assert_eq!(r.take("req-1"), None, "cancel also forgets the mapping");
-    }
-
-    #[test]
-    fn cancel_all_cancels_every_running_stream_and_leaves_pending_alone_besides_marking_it() {
-        let r = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        r.register("req-1", "job-1");
-        r.register("req-2", "job-2");
-        r.begin("req-3"); // still pending — no job to cancel
-        r.cancel_all(&canceller);
-
-        let mut got = canceller.cancelled.into_inner();
-        got.sort();
-        assert_eq!(
-            got,
-            vec!["job-1".to_string(), "job-2".to_string()],
-            "only RUNNING entries are ever job-cancelled"
-        );
-        // The pending entry is now cancelled-early — a still in-flight
-        // pre-compose caller must never be allowed to register a job for it.
-        assert!(!r.register("req-3", "job-3"));
-    }
-
-    #[test]
-    fn cancel_all_on_an_empty_registry_is_a_no_op() {
-        let r = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        r.cancel_all(&canceller);
-        assert!(canceller.cancelled.into_inner().is_empty());
-    }
-
-    #[test]
-    fn cancel_all_preserves_an_already_cancelled_early_entry() {
-        // HIGH regression: cancel-then-disconnect during the pre-compose
-        // window. `begin` + `cancel` leaves `req-1` as `CancelledEarly`
-        // BEFORE `cancel_all` ever runs; `cancel_all` must reinsert it
-        // (not drop it on the floor), or the later `register` call for the
-        // same `req_id` finds nothing, returns `true`, and starts a full
-        // billable generation for a request the user already cancelled.
-        let r = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        r.begin("req-1");
-        r.cancel(&canceller, "req-1"); // -> CancelledEarly, no job existed yet
-        r.cancel_all(&canceller);
-
-        assert!(
-            canceller.cancelled.borrow().is_empty(),
-            "no Running job existed at any point — nothing to job_cancel"
-        );
-        assert!(
-            !r.register("req-1", "job-1"),
-            "the CancelledEarly guard must survive cancel_all's drain-and-reinsert"
-        );
-    }
-
-    // ── Pre-registration cancel race (LOW fix): begin() + register()'s bool ─
-
-    #[test]
-    fn cancel_during_the_pending_window_prevents_the_later_register_call() {
-        let r = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        r.begin("req-1"); // pre-compose work has started — no job yet
-        r.cancel(&canceller, "req-1"); // assist.cancel races the awaits
-
-        assert!(
-            canceller.cancelled.borrow().is_empty(),
-            "no job exists yet — there is nothing to job_cancel"
-        );
-        assert!(
-            !r.register("req-1", "job-1"),
-            "the compose call must never start a billable job for an early-cancelled reqId"
-        );
-        assert_eq!(
-            r.take("req-1"),
-            None,
-            "the cancelled-early marker must never surface as a real job"
-        );
-    }
-
-    #[test]
-    fn register_without_a_prior_cancel_succeeds_normally_after_begin() {
-        let r = AssistStreamRegistry::default();
-        r.begin("req-1");
-        assert!(r.register("req-1", "job-1"));
-        assert_eq!(r.take("req-1"), Some("job-1".to_string()));
-    }
-
-    // ── Duplicate reqId rejection (MEDIUM fix): begin() on an already-active
-    // entry must never orphan the original job ─────────────────────────────
-
-    #[test]
-    fn begin_on_a_fresh_req_id_succeeds() {
-        let r = AssistStreamRegistry::default();
-        assert!(r.begin("req-1"));
-    }
-
-    #[test]
-    fn begin_on_an_already_pending_req_id_is_rejected() {
-        let r = AssistStreamRegistry::default();
-        r.begin("req-1"); // first request's pre-compose window is in flight
-
-        assert!(
-            !r.begin("req-1"),
-            "a second begin for the same still-Pending reqId must be rejected"
-        );
-    }
-
-    #[test]
-    fn begin_on_an_already_running_req_id_is_rejected_and_the_original_stays_cancellable() {
-        let r = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        assert!(r.register("req-1", "job-1")); // the original request is now Running
-
-        // A client reusing the SAME reqId while the original is still
-        // running must be rejected — never silently overwrite the Running
-        // entry with a fresh Pending, which would orphan job-1 (still
-        // running server-side, but no longer reachable to cancel).
-        assert!(!r.begin("req-1"));
-
-        r.cancel(&canceller, "req-1");
-        assert_eq!(
-            canceller.cancelled.into_inner(),
-            vec!["job-1".to_string()],
-            "the original job must still be there and cancellable after the rejected begin"
-        );
-    }
-
-    #[test]
-    fn begin_on_a_cancelled_early_req_id_is_rejected() {
-        let r = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        r.begin("req-1");
-        r.cancel(&canceller, "req-1"); // -> CancelledEarly, no job existed yet
-
-        assert!(
-            !r.begin("req-1"),
-            "a CancelledEarly marker is not settled — reuse must be rejected \
-             until register (or unregister/cancel_all) consumes it"
-        );
-    }
-
-    #[test]
-    fn begin_on_a_cancelled_early_req_id_is_rejected_until_register_consumes_it() {
-        // Full spend/cancel-integrity guarantee: a run that reused req-1
-        // before the CancelledEarly marker was consumed used to be able to
-        // slip a fresh Pending in, which let the FIRST (already-cancelled)
-        // run's later `register` call see that Pending instead of its own
-        // marker and start a billable job anyway — the exact hole this fix
-        // closes.
-        let r = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        r.begin("req-1"); // run A's pre-compose window opens
-        r.cancel(&canceller, "req-1"); // -> CancelledEarly, run A has no job yet
-
-        assert!(
-            !r.begin("req-1"),
-            "a second run reusing req-1 must be rejected while the marker is un-consumed"
-        );
-        assert!(
-            !r.register("req-1", "job-a"),
-            "register consumes the CancelledEarly marker and reports false — \
-             run A never starts a billable job"
-        );
-        assert!(
-            r.begin("req-1"),
-            "once consumed, req-1 names no entry at all — reuse is allowed again"
-        );
     }
 
     // ── begin_or_reject_duplicate (HIGH fix: pre-begin cancel-drop —
@@ -1114,90 +609,8 @@ mod tests {
         );
     }
 
-    // ── start_and_register (HIGH fix: job_start-before-register TOCTOU —
-    // starting the job before registering it means a cancel racing the gap
-    // finds Pending, not a not-yet-existing Running job) ───────────────────
-
-    #[derive(Default)]
-    struct RecordingStarterCanceller {
-        started: std::cell::RefCell<Vec<String>>,
-        cancelled: std::cell::RefCell<Vec<String>>,
-    }
-
-    impl JobStarter for RecordingStarterCanceller {
-        fn start_job(&self, job_id: &str) {
-            self.started.borrow_mut().push(job_id.to_string());
-        }
-    }
-
-    impl JobCanceller for RecordingStarterCanceller {
-        fn cancel_job(&self, job_id: &str) {
-            self.cancelled.borrow_mut().push(job_id.to_string());
-        }
-    }
-
-    #[test]
-    fn start_and_register_starts_the_job_then_registers_it_on_the_happy_path() {
-        let registry = AssistStreamRegistry::default();
-        let recorder = RecordingStarterCanceller::default();
-
-        let job_id = start_and_register(&recorder, &registry, "req-1")
-            .expect("a fresh reqId with no prior cancel must register successfully");
-
-        assert_eq!(
-            recorder.started.into_inner(),
-            vec![job_id.clone()],
-            "job_start must have run, unconditionally, before register was ever consulted"
-        );
-        assert!(
-            recorder.cancelled.borrow().is_empty(),
-            "a successful register must never cancel the job it just started"
-        );
-        assert_eq!(
-            registry.take("req-1"),
-            Some(job_id),
-            "register must have recorded the Running entry"
-        );
-    }
-
-    #[test]
-    fn start_and_register_cancels_the_just_started_job_when_a_cancel_already_raced_ahead() {
-        // The exact TOCTOU this reorder closes: an `assist.cancel` that
-        // arrived during the pre-compose window (captured here as a
-        // pre-seeded `CancelledEarly` marker — see `AssistStreamRegistry::
-        // begin`/`cancel`) must never leave a job that's Running but neither
-        // cancelled nor cancellable. `job_start` still runs — unconditionally,
-        // BEFORE `register` is ever consulted, proving the new order — but
-        // `register` then reports the race, and this function must cancel
-        // the very job it just started rather than leaving it orphaned.
-        let registry = AssistStreamRegistry::default();
-        let canceller = RecordingCanceller::default();
-        registry.begin("req-1");
-        registry.cancel(&canceller, "req-1"); // -> CancelledEarly, no job existed yet
-
-        let recorder = RecordingStarterCanceller::default();
-        let result = start_and_register(&recorder, &registry, "req-1");
-
-        assert!(
-            result.is_none(),
-            "a raced-ahead cancel must make start_and_register report failure"
-        );
-        assert_eq!(
-            recorder.started.borrow().len(),
-            1,
-            "job_start must still have run — it happens BEFORE register is ever consulted"
-        );
-        let started_id = recorder.started.borrow()[0].clone();
-        assert_eq!(
-            recorder.cancelled.into_inner(),
-            vec![started_id],
-            "the job just started must be job-cancelled immediately — no leaked Running job"
-        );
-        assert!(
-            !registry.contains("req-1"),
-            "the CancelledEarly marker must be consumed, not left behind"
-        );
-    }
+    // `start_and_register`'s tests (TOCTOU fix — job_start before register)
+    // now live in `assist_registry` alongside the function itself.
 
     // ── ChannelFrameSink / channel multiplexing (HIGH fix mechanism) ───────
 

--- a/apps/desktop/src-tauri/src/extension_bridge/stream.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/stream.rs
@@ -158,9 +158,12 @@ const WRITE_STALL: std::time::Duration = std::time::Duration::from_secs(25);
 /// Generic over `S` (rather than the concrete
 /// `SplitSink<WebSocketStream<TcpStream>, Message>`) purely so this is
 /// unit-testable against a fake sink whose `poll_ready` never resolves,
-/// without a live socket. Fire-and-forget, like every other spawn in this
-/// module — never explicitly joined, so a streaming task that never finishes
-/// can never hang the connection's own cleanup.
+/// without a live socket. Its OWN generation logic is still fire-and-forget
+/// (a streaming task that never finishes can never hang the connection's own
+/// cleanup) — but this function's `JoinHandle` itself is no longer purely
+/// dropped: `handle_connection`'s read loop keeps it and races it via
+/// [`next_step`], so this task ending (either `break` above) tears the
+/// connection down immediately instead of going unnoticed.
 pub(super) async fn run_writer<S>(mut writer: S, mut rx: UnboundedReceiver<Message>)
 where
     S: SinkExt<Message> + Unpin,
@@ -182,6 +185,50 @@ where
                 break;
             }
         }
+    }
+}
+
+/// Outcome of one [`next_step`] race — see its doc.
+pub(super) enum NextStep<T> {
+    /// A frame arrived off the read side (`None` = the stream ended naturally,
+    /// same as `reader.next()`'s own `None`).
+    Frame(T),
+    /// The writer task ended FIRST — a [`WRITE_STALL`] timeout, or a genuine
+    /// socket send error (see [`run_writer`]). Nothing can ever reach this
+    /// client again; the caller should tear its connection down immediately
+    /// rather than keep waiting for a next inbound frame that may never
+    /// arrive.
+    WriterEnded,
+}
+
+/// The exact `tokio::select!` race `handle_connection`'s read loop runs every
+/// iteration: `reader_next` (in production, `reader.next()`) against
+/// `writer_done` (in production, `&mut writer_task`, [`run_writer`]'s own
+/// `JoinHandle`) — whichever resolves first wins. CodeRabbit finding: a
+/// DETACHED `run_writer` task ending (its [`WRITE_STALL`] timeout, or a send
+/// error) used to go unnoticed by the read loop until ITS OWN next inbound
+/// frame — which, for a stalled-but-open peer or a quiet/idle connection, may
+/// never come — so `cancel_all`/`set_connected(false)` stayed delayed
+/// indefinitely. Racing the writer handle here closes that: the writer ending
+/// now tears the connection down immediately, the SAME way a read error does.
+///
+/// Generic over both futures (not the concrete `WebSocketStream`/`JoinHandle`
+/// types) so this race's OUTCOME is unit-testable without a live socket/
+/// `AppHandle` (this crate has no `tauri::test` mock-app harness): a fake
+/// "never resolves" reader racing an already-resolved writer proves the
+/// `WriterEnded` arm wins without ever blocking on the reader, and vice
+/// versa. Both real-world arms are cancel-safe (`futures::StreamExt::next`
+/// and `tokio::task::JoinHandle` both are — `tokio::select!` may drop either
+/// branch on any iteration without losing a frame or a writer-task
+/// completion), so re-entering this fresh every loop iteration is safe.
+pub(super) async fn next_step<R, W>(reader_next: R, writer_done: W) -> NextStep<R::Output>
+where
+    R: std::future::Future,
+    W: std::future::Future,
+{
+    tokio::select! {
+        frame = reader_next => NextStep::Frame(frame),
+        _ = writer_done => NextStep::WriterEnded,
     }
 }
 
@@ -217,13 +264,13 @@ pub(super) fn spawn_answer_assist(
     out_tx: UnboundedSender<Message>,
     registry: Arc<AssistStreamRegistry>,
 ) {
-    if !begin_or_reject_duplicate(&registry, &req_id, &out_tx) {
+    let Some(gen) = begin_or_reject_duplicate(&registry, &req_id, &out_tx) else {
         return;
-    }
+    };
     tokio::spawn(async move {
         let mut sink = ChannelFrameSink(out_tx.clone());
         let reply = super::answer_assist::handle_answer_assist(
-            &app, &req_id, &payload, &registry, &mut sink,
+            &app, &req_id, gen, &payload, &registry, &mut sink,
         )
         .await;
         let _ = out_tx.send(Message::text(reply));
@@ -233,20 +280,24 @@ pub(super) fn spawn_answer_assist(
 /// The synchronous half of [`spawn_answer_assist`] — factored out so it is
 /// directly unit-testable WITHOUT a live `AppHandle` (this crate has no
 /// `tauri::test` mock-app harness). A plain (non-`async`) function, so a
-/// caller observing `true` returned — or `registry.contains(req_id)` true
+/// caller observing `Some(_)` returned — or `registry.contains(req_id)` true
 /// right after — has proof `begin` ran on ITS OWN thread, not deferred into
-/// whatever thread `tokio::spawn`'s task eventually runs on. Returns `true`
-/// when `req_id` was free (the caller should go on to spawn the actual
-/// task); `false` when it already named an active entry — in which case this
-/// function has ALREADY enqueued the `DUPLICATE_REQUEST_MESSAGE` reply
-/// through `out_tx` itself, so the caller has nothing left to do but return.
+/// whatever thread `tokio::spawn`'s task eventually runs on. Returns
+/// `Some(gen)` — the generation `begin` minted for this reqId, which the
+/// caller MUST thread all the way to `handle_answer_assist`'s end-of-request
+/// `unregister_gen` call (see [`super::assist_registry::StreamEntry`]'s doc
+/// for the reused-reqId clobber this generation closes) — when `req_id` was
+/// free (the caller should go on to spawn the actual task); `None` when it
+/// already named an active entry — in which case this function has ALREADY
+/// enqueued the `DUPLICATE_REQUEST_MESSAGE` reply through `out_tx` itself, so
+/// the caller has nothing left to do but return.
 fn begin_or_reject_duplicate(
     registry: &AssistStreamRegistry,
     req_id: &str,
     out_tx: &UnboundedSender<Message>,
-) -> bool {
-    if registry.begin(req_id) {
-        return true;
+) -> Option<u64> {
+    if let Some(gen) = registry.begin(req_id) {
+        return Some(gen);
     }
     let reply = super::answer_assist::answer_assist_reply(
         req_id,
@@ -255,7 +306,7 @@ fn begin_or_reject_duplicate(
         )),
     );
     let _ = out_tx.send(Message::text(reply));
-    false
+    None
 }
 
 // ── Per-connection stream registry — the state machine itself now lives in
@@ -283,7 +334,11 @@ fn is_job_cancelled(app: &AppHandle, job_id: &str) -> bool {
 /// "Three ways a stream ends early" section for the full picture. Registers
 /// a fresh job under `req_id` on `registry` (THIS connection's own
 /// [`AssistStreamRegistry`] — so a client `assist.cancel` can stop it
-/// early), drives [`Completer::stream_complete`], forwards every
+/// early; does NOT `unregister` it on any path out of this function —
+/// `handle_answer_assist` (in `answer_assist`) is the SOLE unregister owner,
+/// once per request, at its single return point, so `req_id` can never be
+/// clobbered by two cleanup sites racing over the same key. See its doc),
+/// drives [`Completer::stream_complete`], forwards every
 /// visible-text delta through `sink` as a cap-clamped `assist.chunk` frame
 /// (see [`forward_chunk`]), sends a terminal `assist.done` frame once the
 /// stream ends, and returns the full accumulated text (or the provider's
@@ -399,7 +454,9 @@ pub(super) async fn compose_draft_stream(
     }
 
     app.unlisten(listener_id);
-    registry.unregister(req_id);
+    // No `registry.unregister(req_id)` here — see this function's doc:
+    // `handle_answer_assist` is the SOLE unregister owner (one call, at its
+    // single return point, covering every outcome of this function too).
     sink.send_frame(assist_done_frame(req_id)).await;
 
     if cap_reached {
@@ -557,14 +614,14 @@ mod tests {
     #[test]
     fn begin_or_reject_duplicate_marks_pending_synchronously_before_any_task_runs() {
         // This whole test has no `.await` at all — `begin_or_reject_duplicate`
-        // is a plain, non-async fn — so a `true` return, and `contains`
+        // is a plain, non-async fn — so a `Some(gen)` return, and `contains`
         // reporting `true` immediately after, already proves `begin` ran on
         // the CALLER's thread, not deferred into whatever thread a spawned
         // task eventually runs on.
         let registry = AssistStreamRegistry::default();
         let (out_tx, _out_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
 
-        assert!(begin_or_reject_duplicate(&registry, "req-1", &out_tx));
+        assert!(begin_or_reject_duplicate(&registry, "req-1", &out_tx).is_some());
         assert!(
             registry.contains("req-1"),
             "begin must have run synchronously — before any spawn, before any await"
@@ -592,7 +649,7 @@ mod tests {
         registry.begin("req-1"); // the original request is already in flight
         let (out_tx, mut out_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
 
-        assert!(!begin_or_reject_duplicate(&registry, "req-1", &out_tx));
+        assert!(begin_or_reject_duplicate(&registry, "req-1", &out_tx).is_none());
 
         let frame = out_rx
             .try_recv()
@@ -725,6 +782,50 @@ mod tests {
                 .await,
             "a subsequent send_frame must return false once run_writer's receiver is dropped"
         );
+    }
+
+    // ── next_step (CodeRabbit fix: propagate the writer-timeout into
+    // connection teardown — a DETACHED `run_writer` ending must not go
+    // unnoticed by the read loop until its own next inbound frame, which may
+    // never arrive) ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn next_step_reports_writer_ended_without_waiting_on_a_never_resolving_reader() {
+        // Mirrors a stalled-but-open (or quiet/idle) connection: `reader_next`
+        // here NEVER resolves — a real `reader.next()` on such a connection
+        // would behave identically (no frame ever arrives). The writer future
+        // resolves IMMEDIATELY (mirrors `run_writer`'s `JoinHandle` completing
+        // once its `WRITE_STALL` timeout fires). This test completing at all
+        // — rather than hanging forever — is the proof: `next_step` did not
+        // block on the never-resolving reader, so the connection tears down
+        // immediately instead of waiting indefinitely for a frame that may
+        // never come.
+        let reader_next = std::future::pending::<Option<i32>>();
+        let writer_done = std::future::ready(());
+
+        let outcome = next_step(reader_next, writer_done).await;
+
+        assert!(
+            matches!(outcome, NextStep::WriterEnded),
+            "the writer ending must win the race even though the reader never resolves"
+        );
+    }
+
+    #[tokio::test]
+    async fn next_step_still_reports_a_frame_when_the_writer_is_still_alive() {
+        // The normal case, unaffected by this fix: the writer task is still
+        // running (never resolves in this test), so a frame arriving must
+        // still be reported through — the writer race must never swallow or
+        // delay a normal inbound frame while the writer is healthy.
+        let reader_next = std::future::ready(Some(7));
+        let writer_done = std::future::pending::<()>();
+
+        let outcome = next_step(reader_next, writer_done).await;
+
+        let NextStep::Frame(value) = outcome else {
+            panic!("expected NextStep::Frame — the writer must never win while a frame is ready");
+        };
+        assert_eq!(value, Some(7));
     }
 
     // ── streaming: forwardable_delta / assist frame builders ────────────────

--- a/apps/desktop/src-tauri/src/extension_bridge/stream.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/stream.rs
@@ -47,7 +47,9 @@
 //!    (the connection's outbound channel is closed), and
 //!    [`compose_draft_stream`] cancels immediately: no consumer is left, so
 //!    waiting for the cap or a natural finish only burns more provider spend
-//!    for nobody.
+//!    for nobody. This also catches a peer that never explicitly closes —
+//!    [`run_writer`]'s `WRITE_STALL` timeout closes the channel after a
+//!    stalled write, so the NEXT `send_frame` reports gone the same way.
 //! 3. **The whole connection drops mid-stream** — `handle_connection` calls
 //!    [`AssistStreamRegistry::cancel_all`] once its read loop exits, so
 //!    every stream still registered for that connection is cancelled too,
@@ -57,9 +59,13 @@
 //!    BEFORE [`compose_draft_stream`] ever calls [`AssistStreamRegistry::register`];
 //!    a cancel arriving in that window used to be silently swallowed (there
 //!    was nothing yet to `take()`). [`AssistStreamRegistry::begin`] records a
-//!    `Pending` placeholder before those awaits so a racing cancel is
-//!    captured as [`StreamEntry::CancelledEarly`], and `register` reports
-//!    that back so the caller never starts the billable job at all.
+//!    `Pending` placeholder — called SYNCHRONOUSLY in `spawn_answer_assist`,
+//!    before `tokio::spawn` even schedules the task that runs those awaits —
+//!    so a racing cancel is captured as [`StreamEntry::CancelledEarly`], and
+//!    `register` reports that back so the caller never starts the billable
+//!    job at all; [`compose_draft_stream`] itself now starts that job
+//!    (`start_and_register`) BEFORE registering it, so a cancel racing that
+//!    exact gap still finds `Pending`, never a not-yet-existing `Running` job.
 //!
 //! Whichever of these fires, [`compose_draft_stream`]'s own error-path fix
 //! (item 2 of this pass) still only calls `job_fail` for a GENUINE failure —
@@ -73,10 +79,8 @@ use futures::SinkExt;
 use parking_lot::Mutex;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Listener, Manager};
-use tokio::net::TcpStream;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::WebSocketStream;
 
 use super::msg;
 use crate::error::{AppError, AppResult};
@@ -112,22 +116,71 @@ impl FrameSink for ChannelFrameSink {
     }
 }
 
+/// How long a single `writer.send(msg).await` inside [`run_writer`] may take
+/// before that peer is treated as stalled and the write loop breaks — see
+/// `run_writer`'s doc for the exact failure this closes. Chosen generously so
+/// a merely-slow-but-alive client is never killed (25s is well past any
+/// realistic Wi-Fi/mobile round-trip hiccup).
+///
+/// **Verified before picking this** — no existing redundant layer to lean on
+/// instead: `handle_connection`'s `WebSocketConfig` only sets
+/// `max_message_size`/`max_frame_size`; nothing in `extension_bridge`
+/// configures a periodic keepalive ping or any other read/write deadline on
+/// this socket. tungstenite auto-replies to a received `Ping` with a `Pong`,
+/// but neither tungstenite nor this module ever ORIGINATES its own periodic
+/// ping to notice a peer that has simply stopped reading without closing —
+/// so this timeout is the ONLY thing that ever detects that case, not a
+/// belt-and-braces duplicate of something else already watching for it.
+const WRITE_STALL: std::time::Duration = std::time::Duration::from_secs(25);
+
 /// The ONE task that ever writes to the live WS sink for a connection. Every
 /// outbound frame — handshake replies, synchronous verb replies, and every
 /// streaming `assist.chunk`/`assist.done`/terminal reply from a
 /// concurrently-running [`spawn_answer_assist`] task — funnels through `rx`,
 /// so `handle_connection`'s read loop never itself awaits a socket write.
+///
 /// Exits once every sender clone is dropped (the read loop's own sender AND
-/// every spawned streaming task's clone). Fire-and-forget, like every other
-/// spawn in this module — never explicitly joined, so a streaming task that
-/// never finishes can never hang the connection's own cleanup.
-pub(super) async fn run_writer(
-    mut writer: futures::stream::SplitSink<WebSocketStream<TcpStream>, Message>,
-    mut rx: UnboundedReceiver<Message>,
-) {
+/// every spawned streaming task's clone), OR once a single write stalls past
+/// [`WRITE_STALL`]. The latter closes a real hole: a peer that keeps the TCP
+/// connection open but stops reading parks a plain `writer.send(msg).await`
+/// forever with nothing else ever erroring — the channel's receiver stays
+/// alive, so `ChannelFrameSink::send_frame` keeps reporting success and
+/// `forward_chunk` keeps enqueueing `assist.chunk` frames into the unbounded
+/// channel for a consumer that will never read them (unbounded memory growth,
+/// plus a billable generation left running all the way to its cap for
+/// nobody). On timeout this loop breaks exactly like a closed-receiver error
+/// would: `writer`/`rx` are dropped, so the NEXT `send_frame` on this
+/// connection's channel returns `false` and the EXISTING `SinkGone` →
+/// `job_cancel` path (see [`compose_draft_stream`]) fires unchanged — no new
+/// cancellation mechanism, just an upper bound on how long a stalled write
+/// can go undetected.
+///
+/// Generic over `S` (rather than the concrete
+/// `SplitSink<WebSocketStream<TcpStream>, Message>`) purely so this is
+/// unit-testable against a fake sink whose `poll_ready` never resolves,
+/// without a live socket. Fire-and-forget, like every other spawn in this
+/// module — never explicitly joined, so a streaming task that never finishes
+/// can never hang the connection's own cleanup.
+pub(super) async fn run_writer<S>(mut writer: S, mut rx: UnboundedReceiver<Message>)
+where
+    S: SinkExt<Message> + Unpin,
+{
     while let Some(msg) = rx.recv().await {
-        if writer.send(msg).await.is_err() {
-            break;
+        match tokio::time::timeout(WRITE_STALL, writer.send(msg)).await {
+            Ok(Ok(())) => continue,
+            Ok(Err(_)) => break,
+            Err(_) => {
+                // Distinct from a genuine socket send error (the arm above) —
+                // this is a peer that never errored at all, just stopped
+                // reading. Worth its own log line so a stalled-peer teardown
+                // is diagnosable in the field, not indistinguishable from a
+                // normal disconnect.
+                log::debug!(
+                    "[extension_bridge] run_writer: write stalled past {WRITE_STALL:?} — \
+                     treating the peer as gone and closing this connection's writer"
+                );
+                break;
+            }
         }
     }
 }
@@ -135,10 +188,28 @@ pub(super) async fn run_writer(
 /// Drive a streaming `answer.assist` request on its OWN task, decoupled from
 /// the connection's read loop — see the module doc. The read loop's dispatch
 /// for `FrameDecision::AnswerAssist` calls this and moves on immediately (no
-/// reply is returned inline); the terminal `answer.assist.result` is sent
-/// from INSIDE this task once `handle_answer_assist` resolves, through the
-/// SAME channel as every `assist.chunk`/`assist.done` it already sent, so
-/// per-`reqId` ordering (chunks, then done, then result) holds.
+/// reply is returned inline for the normal path); the terminal
+/// `answer.assist.result` is sent from INSIDE the spawned task once
+/// `handle_answer_assist` resolves, through the SAME channel as every
+/// `assist.chunk`/`assist.done` it already sent, so per-`reqId` ordering
+/// (chunks, then done, then result) holds.
+///
+/// [`AssistStreamRegistry::begin`] is called HERE, synchronously, on the read
+/// loop's own thread — BEFORE `tokio::spawn` — rather than inside the spawned
+/// task (where it used to live, in `resolve_answer_assist`). `tokio::spawn`
+/// only SCHEDULES the task; it does not run it. Left inside the task, the
+/// single-threaded read loop could immediately read the NEXT frame — an
+/// `assist.cancel` for this very `reqId` — and dispatch it to
+/// `AssistStreamRegistry::cancel` (also synchronous) before the spawned task
+/// ever got scheduled to run its own `begin`. `cancel` would then find no
+/// entry at all, silently drop the cancel, and the task would go on to run
+/// `begin`→register→`job_start` regardless, billing a request the client
+/// already gave up on. Calling `begin` here closes that scheduling gap: the
+/// `Pending` marker exists before this function returns, so a same-connection
+/// `assist.cancel` dispatched anywhere after this call is guaranteed to see
+/// it. A duplicate `reqId` (one already `Pending`/`Running`/`CancelledEarly`
+/// on this connection) is rejected right here with its own
+/// `answer.assist.result` error reply — the task is never spawned at all.
 pub(super) fn spawn_answer_assist(
     app: AppHandle,
     req_id: String,
@@ -146,6 +217,9 @@ pub(super) fn spawn_answer_assist(
     out_tx: UnboundedSender<Message>,
     registry: Arc<AssistStreamRegistry>,
 ) {
+    if !begin_or_reject_duplicate(&registry, &req_id, &out_tx) {
+        return;
+    }
     tokio::spawn(async move {
         let mut sink = ChannelFrameSink(out_tx.clone());
         let reply = super::answer_assist::handle_answer_assist(
@@ -154,6 +228,34 @@ pub(super) fn spawn_answer_assist(
         .await;
         let _ = out_tx.send(Message::text(reply));
     });
+}
+
+/// The synchronous half of [`spawn_answer_assist`] — factored out so it is
+/// directly unit-testable WITHOUT a live `AppHandle` (this crate has no
+/// `tauri::test` mock-app harness). A plain (non-`async`) function, so a
+/// caller observing `true` returned — or `registry.contains(req_id)` true
+/// right after — has proof `begin` ran on ITS OWN thread, not deferred into
+/// whatever thread `tokio::spawn`'s task eventually runs on. Returns `true`
+/// when `req_id` was free (the caller should go on to spawn the actual
+/// task); `false` when it already named an active entry — in which case this
+/// function has ALREADY enqueued the `DUPLICATE_REQUEST_MESSAGE` reply
+/// through `out_tx` itself, so the caller has nothing left to do but return.
+fn begin_or_reject_duplicate(
+    registry: &AssistStreamRegistry,
+    req_id: &str,
+    out_tx: &UnboundedSender<Message>,
+) -> bool {
+    if registry.begin(req_id) {
+        return true;
+    }
+    let reply = super::answer_assist::answer_assist_reply(
+        req_id,
+        Err(AppError::Validation(
+            super::answer_assist::DUPLICATE_REQUEST_MESSAGE.to_string(),
+        )),
+    );
+    let _ = out_tx.send(Message::text(reply));
+    false
 }
 
 // ── Per-connection stream registry (register / cancel / pre-registration race) ──
@@ -173,6 +275,58 @@ impl JobCanceller for AppHandle {
     fn cancel_job(&self, job_id: &str) {
         crate::commands::jobs::job_cancel(self, job_id);
     }
+}
+
+/// Abstracts "start a job by id" so [`start_and_register`]'s
+/// start-before-register ordering is unit-testable against a fake recorder,
+/// without a live `AppHandle` — mirrors [`JobCanceller`]'s existing seam. The
+/// sole production implementor forwards to [`crate::commands::jobs::job_start`]
+/// with this module's one fixed job kind (every job this registry ever tracks
+/// is an `"extension.answer_assist"` job).
+pub(super) trait JobStarter {
+    fn start_job(&self, job_id: &str);
+}
+
+impl JobStarter for AppHandle {
+    fn start_job(&self, job_id: &str) {
+        crate::commands::jobs::job_start(self, job_id, "extension.answer_assist");
+    }
+}
+
+/// Start a fresh job for `req_id` and register it with `registry` —
+/// deliberately `start` BEFORE `register`, the reverse of this module's
+/// original order. The original order had a TOCTOU: `register` published a
+/// `Running(job_id)` entry before the job existed, so an `assist.cancel`
+/// landing in that exact gap found `Running`, removed the entry, and called
+/// `cancel_job` on an id nothing had started yet (a no-op) — the job then
+/// started anyway, Running, with no cancel path left. Starting first closes
+/// it: a cancel racing this same gap instead finds the `Pending` marker
+/// [`AssistStreamRegistry::begin`] already left behind (set synchronously in
+/// `spawn_answer_assist`, before this task was even spawned), so `register`
+/// below correctly observes [`StreamEntry::CancelledEarly`] and this function
+/// cancels the very job it just started before reporting failure. `None` on
+/// that race (the caller should treat it as `"Job cancelled"`); `Some(job_id)`
+/// otherwise. Safe to cancel unconditionally on the race path — `job_id` is a
+/// fresh UUID ([`crate::db::new_job_id`]), so it can never collide with a
+/// later, unrelated `start_job` call.
+///
+/// Generic over a combined [`JobStarter`] + [`JobCanceller`] recorder (not
+/// the concrete `AppHandle`) so this ordering is directly unit-testable
+/// without a live `AppHandle` — this crate has no `tauri::test` mock-app
+/// harness. The sole production caller ([`compose_draft_stream`]) passes a
+/// real `&AppHandle` (which implements both).
+pub(super) fn start_and_register<T: JobStarter + JobCanceller>(
+    starter: &T,
+    registry: &AssistStreamRegistry,
+    req_id: &str,
+) -> Option<String> {
+    let job_id = crate::db::new_job_id();
+    starter.start_job(&job_id);
+    if !registry.register(req_id, &job_id) {
+        starter.cancel_job(&job_id);
+        return None;
+    }
+    Some(job_id)
 }
 
 /// One `reqId`'s lifecycle in the per-connection registry — from the moment
@@ -430,14 +584,14 @@ pub(super) async fn compose_draft_stream(
     user: &str,
     sink: &mut dyn FrameSink,
 ) -> AppResult<String> {
-    let job_id = crate::db::new_job_id();
-    if !registry.register(req_id, &job_id) {
-        // An `assist.cancel` raced ahead of this call during the pre-compose
-        // window (see `AssistStreamRegistry::register`'s `CancelledEarly`
-        // arm) — the client already gave up; never start the billable job.
+    // `start_and_register` starts the job BEFORE registering it — see its own
+    // doc for the TOCTOU this order closes. `None` means an `assist.cancel`
+    // raced ahead of this call during the pre-compose window and the job
+    // `start_and_register` itself just started has already been cancelled —
+    // the client already gave up, so never proceed into the stream loop.
+    let Some(job_id) = start_and_register(app, registry, req_id) else {
         return Err(AppError::Message("Job cancelled".to_string()));
-    }
-    crate::commands::jobs::job_start(app, &job_id, "extension.answer_assist");
+    };
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<AiStreamChunk>();
     let listen_job_id = job_id.clone();
@@ -901,6 +1055,150 @@ mod tests {
         );
     }
 
+    // ── begin_or_reject_duplicate (HIGH fix: pre-begin cancel-drop —
+    // `begin` must run synchronously, on the read loop's own thread, BEFORE
+    // `tokio::spawn` ever schedules the streaming task) ────────────────────
+
+    #[test]
+    fn begin_or_reject_duplicate_marks_pending_synchronously_before_any_task_runs() {
+        // This whole test has no `.await` at all — `begin_or_reject_duplicate`
+        // is a plain, non-async fn — so a `true` return, and `contains`
+        // reporting `true` immediately after, already proves `begin` ran on
+        // the CALLER's thread, not deferred into whatever thread a spawned
+        // task eventually runs on.
+        let registry = AssistStreamRegistry::default();
+        let (out_tx, _out_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+
+        assert!(begin_or_reject_duplicate(&registry, "req-1", &out_tx));
+        assert!(
+            registry.contains("req-1"),
+            "begin must have run synchronously — before any spawn, before any await"
+        );
+
+        // The exact race this fix closes: a same-connection `assist.cancel`
+        // dispatched right after `spawn_answer_assist` returns (before the
+        // spawned task has run AT ALL) must still find the Pending marker,
+        // never nothing.
+        let canceller = RecordingCanceller::default();
+        registry.cancel(&canceller, "req-1");
+        assert!(
+            canceller.cancelled.borrow().is_empty(),
+            "no job exists yet — Pending just becomes CancelledEarly, nothing to job_cancel"
+        );
+        assert!(
+            !registry.register("req-1", "job-1"),
+            "the cancel that raced ahead of the spawned task's own register call must still win"
+        );
+    }
+
+    #[test]
+    fn begin_or_reject_duplicate_rejects_an_already_active_req_id_via_out_tx() {
+        let registry = AssistStreamRegistry::default();
+        registry.begin("req-1"); // the original request is already in flight
+        let (out_tx, mut out_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+
+        assert!(!begin_or_reject_duplicate(&registry, "req-1", &out_tx));
+
+        let frame = out_rx
+            .try_recv()
+            .expect("a duplicate-rejection reply must be enqueued through out_tx directly");
+        let v: Value = serde_json::from_str(&as_text(frame)).unwrap();
+        assert_eq!(v["payload"]["ok"], false);
+        assert_eq!(
+            v["payload"]["error"],
+            super::super::answer_assist::DUPLICATE_REQUEST_MESSAGE
+        );
+        assert!(
+            registry.contains("req-1"),
+            "the ORIGINAL request's entry must be left untouched by the rejected duplicate"
+        );
+    }
+
+    // ── start_and_register (HIGH fix: job_start-before-register TOCTOU —
+    // starting the job before registering it means a cancel racing the gap
+    // finds Pending, not a not-yet-existing Running job) ───────────────────
+
+    #[derive(Default)]
+    struct RecordingStarterCanceller {
+        started: std::cell::RefCell<Vec<String>>,
+        cancelled: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl JobStarter for RecordingStarterCanceller {
+        fn start_job(&self, job_id: &str) {
+            self.started.borrow_mut().push(job_id.to_string());
+        }
+    }
+
+    impl JobCanceller for RecordingStarterCanceller {
+        fn cancel_job(&self, job_id: &str) {
+            self.cancelled.borrow_mut().push(job_id.to_string());
+        }
+    }
+
+    #[test]
+    fn start_and_register_starts_the_job_then_registers_it_on_the_happy_path() {
+        let registry = AssistStreamRegistry::default();
+        let recorder = RecordingStarterCanceller::default();
+
+        let job_id = start_and_register(&recorder, &registry, "req-1")
+            .expect("a fresh reqId with no prior cancel must register successfully");
+
+        assert_eq!(
+            recorder.started.into_inner(),
+            vec![job_id.clone()],
+            "job_start must have run, unconditionally, before register was ever consulted"
+        );
+        assert!(
+            recorder.cancelled.borrow().is_empty(),
+            "a successful register must never cancel the job it just started"
+        );
+        assert_eq!(
+            registry.take("req-1"),
+            Some(job_id),
+            "register must have recorded the Running entry"
+        );
+    }
+
+    #[test]
+    fn start_and_register_cancels_the_just_started_job_when_a_cancel_already_raced_ahead() {
+        // The exact TOCTOU this reorder closes: an `assist.cancel` that
+        // arrived during the pre-compose window (captured here as a
+        // pre-seeded `CancelledEarly` marker — see `AssistStreamRegistry::
+        // begin`/`cancel`) must never leave a job that's Running but neither
+        // cancelled nor cancellable. `job_start` still runs — unconditionally,
+        // BEFORE `register` is ever consulted, proving the new order — but
+        // `register` then reports the race, and this function must cancel
+        // the very job it just started rather than leaving it orphaned.
+        let registry = AssistStreamRegistry::default();
+        let canceller = RecordingCanceller::default();
+        registry.begin("req-1");
+        registry.cancel(&canceller, "req-1"); // -> CancelledEarly, no job existed yet
+
+        let recorder = RecordingStarterCanceller::default();
+        let result = start_and_register(&recorder, &registry, "req-1");
+
+        assert!(
+            result.is_none(),
+            "a raced-ahead cancel must make start_and_register report failure"
+        );
+        assert_eq!(
+            recorder.started.borrow().len(),
+            1,
+            "job_start must still have run — it happens BEFORE register is ever consulted"
+        );
+        let started_id = recorder.started.borrow()[0].clone();
+        assert_eq!(
+            recorder.cancelled.into_inner(),
+            vec![started_id],
+            "the job just started must be job-cancelled immediately — no leaked Running job"
+        );
+        assert!(
+            !registry.contains("req-1"),
+            "the CancelledEarly marker must be consumed, not left behind"
+        );
+    }
+
     // ── ChannelFrameSink / channel multiplexing (HIGH fix mechanism) ───────
 
     #[tokio::test]
@@ -942,6 +1240,78 @@ mod tests {
             assert_eq!(as_text(msg), format!("chunk-{i}"));
         }
         assert_eq!(as_text(rx.recv().await.unwrap()), "done");
+    }
+
+    // ── run_writer (HIGH fix: write-backpressure / stalled-peer runaway) ───
+
+    /// A sink whose `poll_ready` never resolves `Ready` — mirrors a
+    /// TCP-open-but-not-reading peer: the OS write buffer stays full
+    /// forever, so a plain `writer.send(msg).await` would otherwise hang
+    /// this task indefinitely, with nothing ever erroring. Zero fields, so
+    /// it is `Unpin` automatically.
+    struct StalledSink;
+
+    impl futures::Sink<Message> for StalledSink {
+        type Error = std::io::Error;
+
+        fn poll_ready(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            std::task::Poll::Pending
+        }
+
+        fn start_send(self: std::pin::Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+            unreachable!("poll_ready never resolves Ready, so start_send is never reached")
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            std::task::Poll::Pending
+        }
+
+        fn poll_close(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            std::task::Poll::Pending
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_writer_breaks_the_loop_once_a_write_stalls_past_write_stall() {
+        // Mirrors the HIGH fix this closes: before, an unbounded channel plus
+        // a peer that keeps the socket open but never reads meant
+        // `writer.send(msg).await` parked forever — nothing ever errored, so
+        // the receiver never dropped, `send_frame` kept reporting success,
+        // and `forward_chunk` kept enqueueing frames for a consumer that
+        // would never read them.
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        tx.send(Message::text("hello")).unwrap();
+
+        let writer_task = tokio::spawn(run_writer(StalledSink, rx));
+
+        // Let the spawned task actually run once, so its `WRITE_STALL`
+        // timer registers with the (paused) clock before we advance past it.
+        tokio::task::yield_now().await;
+        tokio::time::advance(WRITE_STALL + std::time::Duration::from_millis(1)).await;
+
+        writer_task
+            .await
+            .expect("run_writer must return, not panic, once its write stalls out");
+
+        // The receiver `run_writer` owned is dropped once its loop breaks —
+        // the NEXT `send_frame` on this same channel must now report the
+        // sink gone, funneling into the EXISTING `SinkGone` → `job_cancel`
+        // path unchanged (no new cancellation mechanism).
+        assert!(
+            !ChannelFrameSink(tx)
+                .send_frame("after-stall".to_string())
+                .await,
+            "a subsequent send_frame must return false once run_writer's receiver is dropped"
+        );
     }
 
     // ── streaming: forwardable_delta / assist frame builders ────────────────


### PR DESCRIPTION
## Summary

Streaming-transport hardening for the extension bridge `answer.assist` path — the three advisory findings surfaced by the review of the streaming PR (#646), fixed. **Pure backend, no wire/protocol change.**

- **Write backpressure** (`run_writer`): the outbound frame channel is unbounded, and `SinkGone` only fired on receiver-drop — a TCP-open-but-not-reading peer parked the writer forever, growing memory without bound while a billable generation ran to the cap for a consumer that would never read. Now each write is wrapped in a `WRITE_STALL = 25s` `tokio::time::timeout`; on a stall the loop breaks → receiver drops → the next `send_frame` returns false → the existing `SinkGone → job_cancel` path fires. Kept the unbounded channel deliberately (a blocking bounded send would re-couple the read loop and reintroduce the "can't read `assist.cancel` mid-stream" bug; `try_send` would silently drop handshake/verb-reply frames). 25s is safe on a loopback bridge; oscillation-grief is bounded to one normally-capped generation (`DRAFT_CAP` + `max_tokens` + daily limiter).
- **Pre-`begin` cancel-drop**: `registry.begin` ran *inside* the spawned task, so a same-connection `assist.cancel` read by the (single-threaded) loop before the task was polled hit an absent entry and was silently dropped — billing a cancelled request. `begin` is now hoisted into the synchronous read-loop dispatch (before `tokio::spawn`); a cancel read next always finds the `Pending` marker (→ `CancelledEarly` → `register` aborts before `job_start`). Because hoisting `begin` ahead of the early gates would otherwise orphan a `Pending` entry on every gated failure (AI-assist off, no résumé, rate-limited, …), `handle_answer_assist` now `unregister`s on any early `Err` (idempotent against the two existing cleanup sites).
- **`register → job_start` TOCTOU**: `register` published `Running(job_id)` before `job_start` created the job, so a cancel in the gap no-op'd (job didn't exist yet) and left a Running billable job that was neither cancelled nor cancellable. `start_and_register` now does `job_start` before `register`, cancelling the just-started job if a cancel raced ahead — the cancel always targets a real job, no orphan.
- **0/0 spend rows on cancel/error** (end-of-stream-only providers): **left unchanged** — recording a 0/0 `ai_spend` row is intentional convention (`cli_agent` and `finish` both do it: "a call happened, at $0"). Guarding only the cancel/error branches would break that symmetry; guarding all sites would erase the intentional $0 marker. No diff.

## Review trail (pre-PR gates)

- `extension-reviewer` (bridge lens) + `tauri-security-reviewer` (billing/cancel-integrity lens), in parallel. Security PASS (~95%): all three fixes bound memory + wasted spend, none weakens CWE-639 isolation or exactly-once billing. Bridge lens caught a **HIGH** the security lens missed — hoisting `begin` ahead of the gates orphaned a `Pending` registry entry on every early-gate failure (a per-failed-request leak, and a retried reqId wrongly rejected as "already in progress"). Fixed via the single `unregister_on_err` cleanup point + 3 regression tests; re-verified HIGH-resolved (~93%). A LOW observability nit (distinguish stall-timeout from send-error in logs) folded in.

## Test plan

- Rust: 259 `extension_bridge` + 174 `ai_provider` tests. New: `run_writer_breaks_the_loop_once_a_write_stalls_past_write_stall` (paused-clock + stalled sink), `begin_or_reject_duplicate_*` (synchronous Pending marker + out_tx rejection), `start_and_register_*` (start-before-register + cancel-on-race, no leaked Running), `unregister_on_err_*` (no orphan on gate failure + reqId reusable + idempotent). Exact CI clippy `--all-features` + fmt clean.
- Not run: a live two-transport end-to-end (needs a running desktop + loaded extension); the wire shape is unchanged.

Follow-up to the shipped streaming transport (#646); part of clearing the deferred hardening items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of answer-assist request cancellation and duplicate-request handling, including safe cleanup across retries and reused request IDs.
  * Prevented stale/“leaked” requests from lingering after early failures.
  * Reduced risk of orphaned background jobs during cancellation races.
  * Added safeguards to close stalled streaming connections, avoiding indefinite hangs.
* **Tests**
  * Expanded/updated coverage for cancellation behavior, duplicate handling, cleanup correctness, connection isolation, and writer timeout termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->