### PR TITLE
fix: bring hmac keyinit trait into scope for the 0.13 api

### DIFF
--- a/apps/desktop/src-tauri/src/extension_bridge/handshake.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/handshake.rs
@@ -16,7 +16,7 @@
 //! a shared known-answer vector pins both so the two canonicalizations can never
 //! silently drift. Pure functions, no I/O, no app state — fully unit-testable.
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 type HmacSha256 = Hmac<Sha256>;


### PR DESCRIPTION
**Urgent — `main` doesn't compile.** hmac 0.13 (#672) moved `Hmac::new_from_slice` from an inherent method to the `KeyInit` trait, so `cargo check` fails in the extension_bridge pairing handshake.

**Fix:** one import — `use hmac::{Hmac, KeyInit, Mac};` in `handshake.rs`. Zero logic change: same MAC key material, message construction, and constant-time `verify_slice`; the known-answer-vector + tamper/reject tests pass unchanged.

**Also checked (no changes needed):** sha2 0.11 (#669) and tokio-tungstenite 0.30 (#670) — both major bumps, but every use site was already API-compatible (sha2 already imports `Digest`; tungstenite's `Utf8Bytes` derefs to `str` so `.to_string()` still works). aes-gcm 0.11 was fixed separately in #662.

### Verified (from `apps/desktop/src-tauri`)
`cargo check --all-targets --all-features --locked` clean · `clippy -- -D warnings` clean · `cargo test` 2417 passed · `cargo fmt --check` clean.

Third `main` breakage from a merged Dependabot **major** without a green Rust gate (after #660 TS 7 and #659 aes-gcm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)