### PR TITLE
fix: restore rewrite-mode review fixes lost in #649

### DIFF
--- a/apps/desktop/src-tauri/src/extension_bridge/answer_assist.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/answer_assist.rs
@@ -313,6 +313,50 @@ fn resolve_rewrite_instruction(preset: Option<&str>, instruction: &str) -> AppRe
     Ok(instruction.to_string())
 }
 
+/// The system prompt + max-token cap [`resolve_answer_assist`] passes to
+/// [`super::stream::compose_draft_stream`] for `mode` — draft always selects
+/// [`ANSWER_ASSIST_SYSTEM`]/[`ANSWER_ASSIST_MAX_TOKENS`], rewrite always
+/// selects [`super::answer_rewrite::REWRITE_SYSTEM`] (same token cap — no
+/// in-app precedent to size a distinct one for rewrite, see
+/// `ANSWER_ASSIST_MAX_TOKENS`'s own doc). A PURE function (no
+/// `AppHandle`/`Limiter`/`Completer`) so this MODE → PROMPT mapping is
+/// directly unit-testable even though `resolve_answer_assist` itself cannot
+/// be driven end-to-end in this crate (no `tauri::test` mock-app harness) —
+/// the grounding differences (the `user` message / salary / web-notes) are
+/// covered separately by `build_user_message`'s and
+/// `answer_rewrite::build_rewrite_user_message`'s own tests, which already
+/// prove rewrite mode fences no résumé/job/company/salary block.
+fn assist_prompt_for_mode(mode: AssistMode) -> (&'static str, u32) {
+    match mode {
+        AssistMode::Draft => (ANSWER_ASSIST_SYSTEM, ANSWER_ASSIST_MAX_TOKENS),
+        AssistMode::Rewrite => (
+            super::answer_rewrite::REWRITE_SYSTEM,
+            ANSWER_ASSIST_MAX_TOKENS,
+        ),
+    }
+}
+
+/// Validate rewrite mode's required fields — `existingAnswer` non-empty and
+/// a usable preset-or-instruction (via [`resolve_rewrite_instruction`]) —
+/// and return `(existing_answer, instruction)` on success. A PURE function:
+/// it takes only `payload`, no `Limiter`/`AppHandle`/`Completer`, so it is
+/// structurally INCAPABLE of touching the `ai_research` limiter — calling it
+/// before `resolve_answer_assist` ever acquires that limiter is what closes
+/// the "malformed rewrite frame burns a rate-window slot at zero provider
+/// spend" gap (`limits::Limiter` never releases a slot early on a guard
+/// drop, so a rejection AFTER acquire would otherwise still cost one).
+fn validate_rewrite_fields(payload: &Value) -> AppResult<(String, String)> {
+    let existing_answer = parse_existing_answer(payload);
+    if existing_answer.trim().is_empty() {
+        return Err(AppError::Validation(
+            "existingAnswer is required".to_string(),
+        ));
+    }
+    let preset = parse_preset(payload);
+    let instruction = resolve_rewrite_instruction(preset.as_deref(), &parse_instruction(payload))?;
+    Ok((existing_answer, instruction))
+}
+
 // ── Consent gate ──────────────────────────────────────────────────────────────
 
 /// The `answer.assist` consent gate in isolation: refuse with the fixed
@@ -495,10 +539,18 @@ pub(super) fn answer_assist_reply(req_id: &str, outcome: AppResult<AnswerAssistO
 /// Core `answer.assist`: gate on the ai-assist opt-in FIRST (fixed sentinel,
 /// before any parsing/spend), clamp the question, resolve a provider from the
 /// persisted snapshot (fixed sentinel when unusable), resolve the default
-/// résumé (fixed sentinel when none), THEN acquire the shared `"ai_research"`
-/// limiter bucket for the rest of the call. Routes salary-shaped questions
-/// through the salary machinery (scraped range → market lookup) and every
-/// other question through a grounded draft — see the module doc.
+/// résumé (fixed sentinel when none, draft mode only), validate rewrite
+/// mode's required fields (`existingAnswer` non-empty, a usable
+/// preset-or-instruction — see [`resolve_rewrite_instruction`]), THEN acquire
+/// the shared `"ai_research"` limiter bucket for the rest of the call. Every
+/// one of those checks — the `question` gate, provider/résumé resolution,
+/// AND the rewrite-field validation — runs BEFORE the limiter acquire: per
+/// `limits::Limiter`'s own doc, a rate-window slot is consumed on ACQUIRE and
+/// never released early on a guard drop, so a validation failure at this
+/// point is free to return `Err` without spending one of a legitimate
+/// caller's limited slots. Routes salary-shaped questions through the salary
+/// machinery (scraped range → market lookup) and every other question
+/// through a grounded draft — see the module doc.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn resolve_answer_assist(
     app: &AppHandle,
@@ -545,6 +597,20 @@ pub(super) async fn resolve_answer_assist(
         AssistMode::Rewrite => String::new(),
     };
 
+    // Rewrite mode's required-field validation — moved here (BEFORE the
+    // limiter acquire below), mirroring the `question` gate above: a
+    // malformed rewrite frame (empty `existingAnswer`, or neither a
+    // recognized `preset` nor a usable free-text `instruction`) must never
+    // consume an `ai_research` rate-window slot at zero provider spend.
+    // `validate_rewrite_fields` is a PURE function (no `Limiter`/`AppHandle`
+    // reachable from it at all) — computed once here; the
+    // `AssistMode::Rewrite` arm further down consumes the result directly
+    // instead of re-parsing/re-validating.
+    let rewrite_fields = match mode {
+        AssistMode::Rewrite => Some(validate_rewrite_fields(payload)?),
+        AssistMode::Draft => None,
+    };
+
     // Bound spend for the rest of this call — the SAME bucket
     // `ai_lookup_salary`/`ai_research_company`/`ai_research_answer` share.
     let limiter = app
@@ -571,11 +637,17 @@ pub(super) async fn resolve_answer_assist(
     // pre-compose cancel race exactly as before — a `CancelledEarly` marker
     // is consumed and reported back as `false`.
 
-    // Job/company/salary/web-search grounding, the rewrite user message, and
-    // the system prompt/token cap for the compose call — ALL diverge by mode
-    // right here; everything below this match is shared again (the one
-    // `compose_draft_stream` call and the reply shaping).
-    let (user, system, max_tokens, company_brief, web_notes, salary_range) = match mode {
+    // The system prompt + token cap for the compose call — a small, pure
+    // (no `AppHandle`) MODE → PROMPT mapping, factored into its own function
+    // so it's directly unit-testable in isolation (this crate has no
+    // `tauri::test` mock-app harness to drive `resolve_answer_assist` itself
+    // end-to-end — see `assist_prompt_for_mode`'s own doc).
+    let (system, max_tokens) = assist_prompt_for_mode(mode);
+
+    // Job/company/salary/web-search grounding + the rewrite user message —
+    // diverge by mode right here; everything below this match is shared
+    // again (the one `compose_draft_stream` call and the reply shaping).
+    let (user, company_brief, web_notes, salary_range) = match mode {
         AssistMode::Draft => {
             let app_ctx = resolve_context(app_store, url.as_deref());
             let job_description = app_ctx
@@ -616,35 +688,18 @@ pub(super) async fn resolve_answer_assist(
                 &web_notes,
                 salary_range.as_ref(),
             );
-            (
-                user,
-                ANSWER_ASSIST_SYSTEM,
-                ANSWER_ASSIST_MAX_TOKENS,
-                company_brief,
-                web_notes,
-                salary_range,
-            )
+            (user, company_brief, web_notes, salary_range)
         }
         AssistMode::Rewrite => {
-            let existing_answer = parse_existing_answer(payload);
-            if existing_answer.trim().is_empty() {
-                return Err(AppError::Validation(
-                    "existingAnswer is required".to_string(),
-                ));
-            }
-            let preset = parse_preset(payload);
-            let instruction =
-                resolve_rewrite_instruction(preset.as_deref(), &parse_instruction(payload))?;
+            // Already validated above, BEFORE the limiter acquire — see
+            // `rewrite_fields`'s own comment for why. `AssistMode::Rewrite`
+            // here guarantees `Some` (the match above is exhaustive over the
+            // SAME `mode`), so this never actually panics.
+            let (existing_answer, instruction) =
+                rewrite_fields.expect("validated before the limiter acquire, above");
             let user =
                 super::answer_rewrite::build_rewrite_user_message(&existing_answer, &instruction);
-            (
-                user,
-                super::answer_rewrite::REWRITE_SYSTEM,
-                ANSWER_ASSIST_MAX_TOKENS,
-                String::new(),
-                String::new(),
-                None,
-            )
+            (user, String::new(), String::new(), None)
         }
     };
 

--- a/apps/desktop/src-tauri/src/extension_bridge/answer_assist_tests.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/answer_assist_tests.rs
@@ -143,6 +143,86 @@ fn resolve_rewrite_instruction_refuses_when_neither_preset_nor_instruction_is_us
         .contains("preset or instruction is required"));
 }
 
+// ── assist_prompt_for_mode (thread 1 — the smallest testable seam over
+// resolve_answer_assist's MODE -> PROMPT selection; the crate has no
+// tauri::test mock-app harness to drive resolve_answer_assist itself
+// end-to-end, so this pure mapping is what's directly unit-tested) ────────
+
+#[test]
+fn assist_prompt_for_mode_selects_answer_assist_system_for_draft() {
+    let (system, max_tokens) = assist_prompt_for_mode(AssistMode::Draft);
+    assert_eq!(system, ANSWER_ASSIST_SYSTEM);
+    assert_eq!(max_tokens, ANSWER_ASSIST_MAX_TOKENS);
+}
+
+#[test]
+fn assist_prompt_for_mode_selects_rewrite_system_for_rewrite() {
+    let (system, max_tokens) = assist_prompt_for_mode(AssistMode::Rewrite);
+    assert_eq!(system, super::super::answer_rewrite::REWRITE_SYSTEM);
+    // Same token cap as draft today — no in-app precedent to size a distinct
+    // one for rewrite (see the function's own doc).
+    assert_eq!(max_tokens, ANSWER_ASSIST_MAX_TOKENS);
+    // The two modes must never select the SAME system prompt.
+    assert_ne!(system, ANSWER_ASSIST_SYSTEM);
+}
+
+// ── validate_rewrite_fields (limiter-ordering fix — a PURE function, no
+// Limiter/AppHandle reachable from it at all, so calling it BEFORE
+// `resolve_answer_assist` acquires the `ai_research` limiter structurally
+// guarantees a malformed rewrite frame never consumes a rate-window slot) ──
+
+#[test]
+fn validate_rewrite_fields_rejects_an_empty_existing_answer() {
+    let err = validate_rewrite_fields(&json!({ "mode": "rewrite", "existingAnswer": "   " }))
+        .unwrap_err();
+    assert!(err.to_string().contains("existingAnswer is required"));
+}
+
+#[test]
+fn validate_rewrite_fields_rejects_a_missing_existing_answer() {
+    let err = validate_rewrite_fields(&json!({ "mode": "rewrite" })).unwrap_err();
+    assert!(err.to_string().contains("existingAnswer is required"));
+}
+
+#[test]
+fn validate_rewrite_fields_rejects_neither_a_preset_nor_an_instruction() {
+    let err = validate_rewrite_fields(&json!({
+        "mode": "rewrite",
+        "existingAnswer": "Because I like it."
+    }))
+    .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("preset or instruction is required"));
+}
+
+#[test]
+fn validate_rewrite_fields_resolves_a_recognized_preset() {
+    let (existing_answer, instruction) = validate_rewrite_fields(&json!({
+        "mode": "rewrite",
+        "existingAnswer": "Because I like it.",
+        "preset": "shorten"
+    }))
+    .unwrap();
+    assert_eq!(existing_answer, "Because I like it.");
+    assert_eq!(
+        instruction,
+        super::super::answer_rewrite::preset_instruction("shorten").unwrap()
+    );
+}
+
+#[test]
+fn validate_rewrite_fields_falls_back_to_free_text_instruction() {
+    let (existing_answer, instruction) = validate_rewrite_fields(&json!({
+        "mode": "rewrite",
+        "existingAnswer": "Because I like it.",
+        "instruction": "Make it punchier."
+    }))
+    .unwrap();
+    assert_eq!(existing_answer, "Because I like it.");
+    assert_eq!(instruction, "Make it punchier.");
+}
+
 // ── clamp helpers ─────────────────────────────────────────────────────
 
 #[test]

--- a/apps/extension/src/answer-replace.ts
+++ b/apps/extension/src/answer-replace.ts
@@ -25,10 +25,16 @@ import {
 (
   globalThis as unknown as Record<
     string,
-    (question: string, index: number, count: number, text: string) => FillAnswerResult
+    (
+      question: string,
+      index: number,
+      count: number,
+      text: string,
+      expectedValue: string
+    ) => FillAnswerResult
   >
-)[ANSWER_REPLACE_GLOBAL] = (question, index, count, text) =>
-  replaceFilledField(document, question, index, count, text);
+)[ANSWER_REPLACE_GLOBAL] = (question, index, count, text, expectedValue) =>
+  replaceFilledField(document, question, index, count, text, expectedValue);
 
 // Ensure this file is treated as an ES module.
 export {};

--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -1223,6 +1223,7 @@ describe('answerReplace request — not-paired short-circuit', () => {
       index: 0,
       count: 1,
       text: 'A rewritten answer.',
+      expectedValue: 'Because I like it.',
     });
 
     expect(res).toEqual({ ok: false, error: 'Not paired. Paste your pairing token first.' });
@@ -1231,7 +1232,7 @@ describe('answerReplace request — not-paired short-circuit', () => {
 });
 
 describe('answerReplace request', () => {
-  it('injects answer-replace.js then invokes it with the correlation + text, returning the outcome', async () => {
+  it('injects answer-replace.js then invokes it with the correlation + text + expectedValue, returning the outcome', async () => {
     getTokenMock.mockResolvedValue(FAKE_TOKEN);
     tabsQueryMock.mockResolvedValue([
       { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
@@ -1245,6 +1246,7 @@ describe('answerReplace request', () => {
       index: 0,
       count: 1,
       text: 'A rewritten answer.',
+      expectedValue: 'Because I like it.',
     });
 
     expect(executeScriptMock).toHaveBeenNthCalledWith(1, {
@@ -1255,7 +1257,14 @@ describe('answerReplace request', () => {
       2,
       expect.objectContaining({
         target: { tabId: 7 },
-        args: ['Why this role?', 0, 1, 'A rewritten answer.', '__ajhRunAnswerReplace'],
+        args: [
+          'Why this role?',
+          0,
+          1,
+          'A rewritten answer.',
+          'Because I like it.',
+          '__ajhRunAnswerReplace',
+        ],
       })
     );
     expect(res).toEqual({ ok: true, kind: 'answerReplace', result: { filled: true } });
@@ -1279,12 +1288,47 @@ describe('answerReplace request', () => {
       index: 0,
       count: 1,
       text: 'A rewritten answer.',
+      expectedValue: 'Because I like it.',
     });
 
     expect(res).toEqual({
       ok: true,
       kind: 'answerReplace',
       result: { filled: false, error: 'Could not find this field — the page may have changed.' },
+    });
+  });
+
+  it('surfaces the changed-since-pick refusal straight through — never overwrites a manual edit', async () => {
+    getTokenMock.mockResolvedValue(FAKE_TOKEN);
+    tabsQueryMock.mockResolvedValue([
+      { id: 7, url: 'https://jobs.example.com/posting/9' } as never,
+    ]);
+    executeScriptMock.mockResolvedValueOnce([{}] as never);
+    executeScriptMock.mockResolvedValueOnce([
+      {
+        result: {
+          filled: false,
+          error: 'This field changed since you picked it — re-pick it to rewrite.',
+        },
+      },
+    ] as never);
+
+    const res = await send({
+      kind: 'answerReplace',
+      question: 'Why this role?',
+      index: 0,
+      count: 1,
+      text: 'A rewritten answer.',
+      expectedValue: 'Because I like it.',
+    });
+
+    expect(res).toEqual({
+      ok: true,
+      kind: 'answerReplace',
+      result: {
+        filled: false,
+        error: 'This field changed since you picked it — re-pick it to rewrite.',
+      },
     });
   });
 
@@ -1302,6 +1346,7 @@ describe('answerReplace request', () => {
       index: 0,
       count: 1,
       text: 'A rewritten answer.',
+      expectedValue: 'Because I like it.',
     });
 
     expect(res).toEqual({ ok: false, error: 'Could not replace this field.' });

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -692,17 +692,20 @@ async function runAnswerFill(
 /**
  * Inject the single-field REPLACER into the active tab and run it against
  * `(question, index)` — refusing unless the CURRENT count of same-question
- * FILLED fields still equals pick-time `count` — with `text`. Two-step like
- * `injectAnswerFill`: the replacement text (the AI-rewritten draft, or the
- * frozen original answer on Restore) is passed in transiently via the
- * second `executeScript({ func, args })` rather than baked into the `files`
- * injection.
+ * FILLED fields still equals pick-time `count`, AND unless the field's
+ * CURRENT text still equals `expectedValue` (never overwrite a manual edit
+ * made since the pick — see `replaceFilledField`'s doc) — with `text`.
+ * Two-step like `injectAnswerFill`: the replacement text (the AI-rewritten
+ * draft, or the frozen original answer on Restore) is passed in transiently
+ * via the second `executeScript({ func, args })` rather than baked into the
+ * `files` injection.
  */
 async function injectAnswerReplace(
   question: string,
   index: number,
   count: number,
-  text: string
+  text: string,
+  expectedValue: string
 ): Promise<FillAnswerResult> {
   const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
   const tabId = tab?.id;
@@ -712,12 +715,19 @@ async function injectAnswerReplace(
 
   const results = await browser.scripting.executeScript({
     target: { tabId },
-    func: (q: string, i: number, c: number, t: string, key: string): FillAnswerResult | null => {
+    func: (
+      q: string,
+      i: number,
+      c: number,
+      t: string,
+      ev: string,
+      key: string
+    ): FillAnswerResult | null => {
       const runner = (globalThis as Record<string, unknown>)[key] as
-        ((q: string, i: number, c: number, t: string) => FillAnswerResult) | undefined;
-      return runner ? runner(q, i, c, t) : null;
+        ((q: string, i: number, c: number, t: string, ev: string) => FillAnswerResult) | undefined;
+      return runner ? runner(q, i, c, t, ev) : null;
     },
-    args: [question, index, count, text, ANSWER_REPLACE_GLOBAL],
+    args: [question, index, count, text, expectedValue, ANSWER_REPLACE_GLOBAL],
   });
 
   const result = results[0]?.result;
@@ -730,22 +740,24 @@ async function injectAnswerReplace(
 /**
  * Rewrite mode's Accept/Restore click (PR 11) — SAME request kind, only
  * `text` differs. Like `runAnswerFill`, failures are NOT folded away and
- * this NEVER replaces a different field than the one that was picked —
- * `injectAnswerReplace`/`replaceFilledField` fail safe (`{filled:false,
- * error}`) on any page mutation since the pick. Never submits the form.
+ * this NEVER replaces a different field than the one that was picked, NOR a
+ * field whose CURRENT text no longer matches `expectedValue` (a manual edit
+ * since the pick) — `injectAnswerReplace`/`replaceFilledField` fail safe
+ * (`{filled:false, error}`) on either. Never submits the form.
  */
 async function runAnswerReplace(
   question: string,
   index: number,
   count: number,
-  text: string
+  text: string,
+  expectedValue: string
 ): Promise<PopupResponse> {
   const token = await getToken();
   if (!token) {
     return { ok: false, error: 'Not paired. Paste your pairing token first.' };
   }
 
-  const result = await injectAnswerReplace(question, index, count, text);
+  const result = await injectAnswerReplace(question, index, count, text, expectedValue);
   return { ok: true, kind: 'answerReplace', result };
 }
 
@@ -811,7 +823,13 @@ async function handleRequest(req: PopupRequest): Promise<PopupResponse> {
       case 'answerAssistProgress':
         return { ok: true, kind: 'answerAssistProgress', ...assistBuffer };
       case 'answerReplace':
-        return await runAnswerReplace(req.question, req.index, req.count, req.text);
+        return await runAnswerReplace(
+          req.question,
+          req.index,
+          req.count,
+          req.text,
+          req.expectedValue
+        );
       default: {
         // Exhaustiveness guard — a new PopupRequest variant must be handled.
         const _never: never = req;

--- a/apps/extension/src/lib/answer-fill.test.ts
+++ b/apps/extension/src/lib/answer-fill.test.ts
@@ -171,7 +171,14 @@ describe('replaceFilledField — happy path (Accept and Restore both go through 
       changeFired = true;
     });
 
-    const result = replaceFilledField(document, 'Why this role?', 0, 1, 'Rewritten answer.');
+    const result = replaceFilledField(
+      document,
+      'Why this role?',
+      0,
+      1,
+      'Rewritten answer.',
+      'Because I love it.'
+    );
 
     expect(result).toEqual({ filled: true });
     expect(el.value).toBe('Rewritten answer.');
@@ -181,7 +188,14 @@ describe('replaceFilledField — happy path (Accept and Restore both go through 
 
   it('replaces a filled textarea', () => {
     setForm(`<label for="cl">Cover letter</label><textarea id="cl">Original text.</textarea>`);
-    const result = replaceFilledField(document, 'Cover letter', 0, 1, 'Rewritten text.');
+    const result = replaceFilledField(
+      document,
+      'Cover letter',
+      0,
+      1,
+      'Rewritten text.',
+      'Original text.'
+    );
     expect(result).toEqual({ filled: true });
     expect((document.getElementById('cl') as HTMLTextAreaElement).value).toBe('Rewritten text.');
   });
@@ -191,7 +205,7 @@ describe('replaceFilledField — happy path (Accept and Restore both go through 
       <label for="q1">Comments</label><input id="q1" type="text" value="First" />
       <label for="q2">Comments</label><input id="q2" type="text" value="Second" />
     `);
-    replaceFilledField(document, 'Comments', 1, 2, 'Rewritten second');
+    replaceFilledField(document, 'Comments', 1, 2, 'Rewritten second', 'Second');
     expect((document.getElementById('q1') as HTMLInputElement).value).toBe('First');
     expect((document.getElementById('q2') as HTMLInputElement).value).toBe('Rewritten second');
   });
@@ -200,12 +214,56 @@ describe('replaceFilledField — happy path (Accept and Restore both go through 
     setForm(
       `<label for="q1">Why this role?</label><input id="q1" type="text" value="Original." />`
     );
-    replaceFilledField(document, 'Why this role?', 0, 1, 'Rewritten.');
+    replaceFilledField(document, 'Why this role?', 0, 1, 'Rewritten.', 'Original.');
     expect((document.getElementById('q1') as HTMLInputElement).value).toBe('Rewritten.');
 
-    // Restore original: the SAME function, the frozen pre-rewrite text.
-    replaceFilledField(document, 'Why this role?', 0, 1, 'Original.');
+    // Restore original: the SAME function, the frozen pre-rewrite text — the
+    // caller must pass the UPDATED expected value ("Rewritten.", what the
+    // field holds now), not the original, mirroring how popup.ts tracks
+    // `rewriteTarget.expectedValue` across a successful Accept.
+    replaceFilledField(document, 'Why this role?', 0, 1, 'Original.', 'Rewritten.');
     expect((document.getElementById('q1') as HTMLInputElement).value).toBe('Original.');
+  });
+});
+
+describe('replaceFilledField — refuses (never clobbers) when the field changed since the pick', () => {
+  it('refuses when the field holds a DIFFERENT non-empty value than expected — a manual edit since the pick', () => {
+    setForm(
+      `<label for="q1">Why this role?</label><input id="q1" type="text" value="A manual edit the user made." />`
+    );
+
+    // The popup still believes the field holds the ORIGINAL text it picked —
+    // it has no idea the user retyped it since.
+    const result = replaceFilledField(
+      document,
+      'Why this role?',
+      0,
+      1,
+      'A rewritten draft.',
+      'Because I love it.'
+    );
+
+    expect(result.filled).toBe(false);
+    expect(result.error).toMatch(/changed since you picked it/i);
+    // The user's manual edit is NEVER overwritten.
+    expect((document.getElementById('q1') as HTMLInputElement).value).toBe(
+      'A manual edit the user made.'
+    );
+  });
+
+  it('accepts when the CURRENT value matches expected exactly (the common, unmodified case)', () => {
+    setForm(`<label for="q1">Why this role?</label><input id="q1" type="text" value="Kept." />`);
+    const result = replaceFilledField(document, 'Why this role?', 0, 1, 'Rewritten.', 'Kept.');
+    expect(result).toEqual({ filled: true });
+    expect((document.getElementById('q1') as HTMLInputElement).value).toBe('Rewritten.');
+  });
+
+  it('tolerates only whitespace differences (the value is captured/compared trimmed, like the scan itself)', () => {
+    setForm(
+      `<label for="q1">Why this role?</label><input id="q1" type="text" value="  Kept.  " />`
+    );
+    const result = replaceFilledField(document, 'Why this role?', 0, 1, 'Rewritten.', 'Kept.');
+    expect(result).toEqual({ filled: true });
   });
 });
 
@@ -214,7 +272,14 @@ describe('replaceFilledField — fail-safe on any mutation since the pick', () =
     setForm(`<label for="q1">Why this role?</label><input id="q1" type="text" value="Kept." />`);
     (document.getElementById('q1') as HTMLInputElement).value = '';
 
-    const result = replaceFilledField(document, 'Why this role?', 0, 1, 'A different answer');
+    const result = replaceFilledField(
+      document,
+      'Why this role?',
+      0,
+      1,
+      'A different answer',
+      'Kept.'
+    );
 
     expect(result.filled).toBe(false);
     expect(result.error).toMatch(/page may have changed/i);
@@ -229,7 +294,14 @@ describe('replaceFilledField — fail-safe on any mutation since the pick', () =
         <option value="1" selected>5-10 years</option>
       </select>
     `);
-    const result = replaceFilledField(document, 'Years of experience', 0, 1, 'Twenty years');
+    const result = replaceFilledField(
+      document,
+      'Years of experience',
+      0,
+      1,
+      'Twenty years',
+      '5-10 years'
+    );
     expect(result.filled).toBe(false);
   });
 
@@ -242,7 +314,7 @@ describe('replaceFilledField — fail-safe on any mutation since the pick', () =
       `<label for="q0">Comments</label><input id="q0" type="text" value="New." />`
     );
 
-    const result = replaceFilledField(document, 'Comments', 0, 1, 'An answer');
+    const result = replaceFilledField(document, 'Comments', 0, 1, 'An answer', 'Kept.');
 
     expect(result.filled).toBe(false);
     expect((document.getElementById('q0') as HTMLInputElement).value).toBe('New.');

--- a/apps/extension/src/lib/answer-fill.ts
+++ b/apps/extension/src/lib/answer-fill.ts
@@ -46,6 +46,15 @@ const NOT_FOUND: FillAnswerResult = {
   error: 'Could not find this field — the page may have changed.',
 };
 
+/** Fixed fail-safe result: the located field's CURRENT text no longer
+ *  matches what the caller expected at pick time (see
+ *  {@link replaceFilledField}) — the user edited it manually since then.
+ *  Never overwrite a newer manual edit the user hasn't seen rewritten. */
+const CHANGED_SINCE_PICK: FillAnswerResult = {
+  filled: false,
+  error: 'This field changed since you picked it — re-pick it to rewrite.',
+};
+
 /** Set a value the way a framework-controlled input notices (native setter +
  *  events) — mirrors `autofill.ts`'s private `setValue`. */
 function setInputValue(el: HTMLInputElement | HTMLTextAreaElement, value: string): void {
@@ -105,27 +114,45 @@ export function fillAnswerField(
  * Locate the FILLED field at `(question, index)` among the CURRENT filled
  * candidates (via {@link locateFilledField}) — refusing when the CURRENT
  * count of fields sharing `question` no longer equals `expectedCount` (the
- * pick-time count) — and overwrite it with `text` (reusing
- * {@link setInputValue}'s native-setter + bubbling-events discipline).
+ * pick-time count), AND refusing ({@link CHANGED_SINCE_PICK}) when the
+ * located field's CURRENT text no longer matches `expectedValue` (the text
+ * the caller believes is still there — the frozen original at pick time, or
+ * whatever this same function last wrote) — only then overwrites it with
+ * `text` (reusing {@link setInputValue}'s native-setter + bubbling-events
+ * discipline).
+ *
+ * `locateFilledField`'s own correlation (label/index/count) answers "is this
+ * the RIGHT field?" but says nothing about its CONTENT — a user who manually
+ * edits the picked field between pick and Accept/Restore would otherwise
+ * have that edit silently clobbered by a rewrite of stale text. This
+ * extends the extension's "never write an unexpected field" discipline to
+ * "never overwrite unexpected content" too.
  *
  * Backs BOTH extension PR 11 flows: Accept writes the rewritten draft,
  * Restore-original writes the SAME frozen text the field held at pick time —
- * the caller (background.ts) just passes a different `text`, there is no
- * separate "restore" code path. Text inputs/textarea ONLY (never `<select>`,
- * matching {@link locateFilledField}'s own scope) — fails safe
- * ({@link NOT_FOUND}) on any page mutation since the pick, exactly like
- * {@link fillAnswerField}. Never dispatches a submit.
+ * the caller (background.ts) just passes a different `text`/`expectedValue`,
+ * there is no separate "restore" code path. The caller (popup.ts) MUST
+ * update its own tracked `expectedValue` to `text` after a successful call,
+ * so the NEXT Accept/Restore compares against the right baseline (otherwise
+ * a successful Accept would make an immediately-following Restore refuse,
+ * since the field no longer holds the ORIGINAL text this function itself
+ * just replaced). Text inputs/textarea ONLY (never `<select>`, matching
+ * {@link locateFilledField}'s own scope) — fails safe ({@link NOT_FOUND}) on
+ * any page mutation since the pick, exactly like {@link fillAnswerField}.
+ * Never dispatches a submit.
  */
 export function replaceFilledField(
   doc: Document,
   question: string,
   index: number,
   expectedCount: number,
-  text: string
+  text: string,
+  expectedValue: string
 ): FillAnswerResult {
   const el = locateFilledField(doc, question, index, expectedCount);
   if (!el) return NOT_FOUND;
   if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    if (el.value.trim() !== expectedValue.trim()) return CHANGED_SINCE_PICK;
     setInputValue(el, text);
     return { filled: true };
   }

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -141,10 +141,22 @@ export type PopupRequest =
    * shape exactly: `question`/`index`/`count` are the picked field's OWN
    * scan-time correlation (from the SAME filled-fields scan
    * `answersSave`'s `filled` list carries — see `PopupResponse`), never
-   * anything the background remembers on its own. Locates + replaces via the
-   * same fail-safe re-scan `answerFill` uses; never submits.
+   * anything the background remembers on its own. `expectedValue` is what
+   * the popup believes the field CURRENTLY holds (the frozen original at
+   * pick time, or whatever a prior successful Accept/Restore wrote) —
+   * `replaceFilledField` refuses (never clobbers) when the field's ACTUAL
+   * current text no longer matches, i.e. the user edited it manually since
+   * the pick. Locates + replaces via the same fail-safe re-scan `answerFill`
+   * uses; never submits.
    */
-  | { kind: 'answerReplace'; question: string; index: number; count: number; text: string };
+  | {
+      kind: 'answerReplace';
+      question: string;
+      index: number;
+      count: number;
+      text: string;
+      expectedValue: string;
+    };
 
 /** background → popup responses (discriminated by the originating request). */
 export type PopupResponse =

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -1817,6 +1817,25 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
     );
   });
 
+  it('resetting the picker back to its placeholder clears the target — never silently re-picks index 0 (Number("") === 0, not NaN)', async () => {
+    await pickFilledField();
+
+    // Change the picker back to its placeholder (value '').
+    const picker = byId<HTMLSelectElement>('rewrite-picker');
+    picker.value = '';
+    picker.dispatchEvent(new Event('change'));
+
+    byId<HTMLButtonElement>('btn-rewrite').click();
+    await flush();
+
+    // Must refuse exactly like "nothing ever picked" — not silently reuse
+    // whatever field happens to be first in the last scan.
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
+      'Pick a filled answer first.'
+    );
+  });
+
   it('refuses to rewrite with neither a preset nor a typed instruction', async () => {
     await pickFilledField();
 
@@ -1889,7 +1908,7 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
     expect(byId<HTMLDivElement>('rewrite-result').hidden).toBe(true);
   });
 
-  it('Accept sends answerReplace with the rewritten draft and the picked field correlation', async () => {
+  it('Accept sends answerReplace with the rewritten draft, the picked field correlation, and the expected current value', async () => {
     await pickFilledField();
     byId<HTMLParagraphElement>('rewrite-draft').textContent = 'Shorter answer.';
     sendMessageMock.mockResolvedValueOnce({
@@ -1907,6 +1926,7 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
       index: 0,
       count: 1,
       text: 'Shorter answer.',
+      expectedValue: 'Because I like it.',
     });
     expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
       'Replaced the field on the page.'
@@ -1933,10 +1953,43 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
       index: 0,
       count: 1,
       text: 'Because I like it.',
+      expectedValue: 'Because I like it.',
     });
     expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
       'Restored the original answer.'
     );
+  });
+
+  it('after a successful Accept, a following Restore compares against the JUST-WRITTEN text, not the stale original', async () => {
+    await pickFilledField();
+    byId<HTMLParagraphElement>('rewrite-draft').textContent = 'Shorter answer.';
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answerReplace',
+      result: { filled: true },
+    });
+
+    byId<HTMLButtonElement>('btn-accept-rewrite').click();
+    await flush();
+
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answerReplace',
+      result: { filled: true },
+    });
+    byId<HTMLButtonElement>('btn-restore-rewrite').click();
+    await flush();
+
+    // The SECOND call (Restore) must expect "Shorter answer." — what Accept
+    // just wrote — never the pick-time original as the expected CURRENT value.
+    expect(sendMessageMock).toHaveBeenLastCalledWith({
+      kind: 'answerReplace',
+      question: 'Why this role?',
+      index: 0,
+      count: 1,
+      text: 'Because I like it.',
+      expectedValue: 'Shorter answer.',
+    });
   });
 
   it('surfaces the fail-safe not-found error on Accept without folding it away', async () => {
@@ -1953,6 +2006,26 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
 
     expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
       'Could not find this field — the page may have changed.'
+    );
+  });
+
+  it('surfaces the changed-since-pick refusal on Accept without folding it away or clobbering', async () => {
+    await pickFilledField();
+    byId<HTMLParagraphElement>('rewrite-draft').textContent = 'Shorter answer.';
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answerReplace',
+      result: {
+        filled: false,
+        error: 'This field changed since you picked it — re-pick it to rewrite.',
+      },
+    });
+
+    byId<HTMLButtonElement>('btn-accept-rewrite').click();
+    await flush();
+
+    expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe(
+      'This field changed since you picked it — re-pick it to rewrite.'
     );
   });
 

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -1992,6 +1992,67 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
     });
   });
 
+  it('a mid-flight re-pick to a different field does not corrupt the new field’s expectedValue baseline', async () => {
+    // Scan with TWO distinct filled fields so there is a different field to
+    // re-pick mid-flight.
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answersSave',
+      result: { ok: true, applicationId: 'app-1', saved: 2, skipped: 0 },
+      filled: [
+        { question: 'Why this role?', index: 0, answer: 'Because I like it.' },
+        { question: 'Salary expectation?', index: 0, answer: '80000' },
+      ],
+    });
+    byId<HTMLButtonElement>('btn-save-answers').click();
+    await flush();
+    sendMessageMock.mockReset();
+
+    const picker = byId<HTMLSelectElement>('rewrite-picker');
+    picker.value = '0';
+    picker.dispatchEvent(new Event('change'));
+    byId<HTMLParagraphElement>('rewrite-draft').textContent = 'Shorter answer.';
+
+    // Accept for field 0 starts but does not resolve yet (simulates it still
+    // being in flight when the user re-picks).
+    let resolveAccept: ((res: unknown) => void) | undefined;
+    sendMessageMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveAccept = resolve;
+      })
+    );
+    byId<HTMLButtonElement>('btn-accept-rewrite').click();
+
+    // RACE: while that Accept is still in flight, the user re-picks a
+    // DIFFERENT field.
+    picker.value = '1';
+    picker.dispatchEvent(new Event('change'));
+
+    // The in-flight Accept now resolves successfully.
+    resolveAccept?.({ ok: true, kind: 'answerReplace', result: { filled: true } });
+    await flush();
+
+    // Restore on the NEWLY picked field must still expect ITS OWN original
+    // value ("80000") — never "Shorter answer." bled in from the stale
+    // Accept that belonged to the field picked before it.
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answerReplace',
+      result: { filled: true },
+    });
+    byId<HTMLButtonElement>('btn-restore-rewrite').click();
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenLastCalledWith({
+      kind: 'answerReplace',
+      question: 'Salary expectation?',
+      index: 0,
+      count: 1,
+      text: '80000',
+      expectedValue: '80000',
+    });
+  });
+
   it('surfaces the fail-safe not-found error on Accept without folding it away', async () => {
     await pickFilledField();
     byId<HTMLParagraphElement>('rewrite-draft').textContent = 'Shorter answer.';

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -1328,18 +1328,20 @@ async function sendRewriteReplace(
   failureFallback: string
 ): Promise<void> {
   if (!rewriteTarget || !text) return;
+  // capture before await: a mid-flight re-pick must not corrupt a different target's expectedValue
+  const target = rewriteTarget;
   btn.disabled = true;
   try {
     const res = await send({
       kind: 'answerReplace',
-      question: rewriteTarget.question,
-      index: rewriteTarget.index,
-      count: rewriteTarget.expectedCount,
+      question: target.question,
+      index: target.index,
+      count: target.expectedCount,
       text,
-      expectedValue: rewriteTarget.expectedValue,
+      expectedValue: target.expectedValue,
     });
     if (res.ok && res.kind === 'answerReplace' && res.result.filled) {
-      if (rewriteTarget) rewriteTarget.expectedValue = text;
+      target.expectedValue = text;
       setMsg(els.importMsg, successMsg, 'ok');
     } else {
       const msg =

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -613,15 +613,22 @@ let lastScannedFilled: FilledField[] = [];
 /**
  * The currently-picked rewrite target — the field's scan-time correlation
  * (`question`/`index`/`expectedCount`, mirroring `answerFill`'s own
- * correlation shape) plus the FROZEN original text at pick time (what
- * "Restore original" re-injects). `null` until the picker selects a field;
- * reset whenever the picker changes or a fresh scan re-renders it.
+ * correlation shape), the FROZEN original text at pick time (what "Restore
+ * original" re-injects, NEVER updated), and `expectedValue` — what THIS
+ * popup instance believes the field currently holds, sent on every
+ * Accept/Restore so `replaceFilledField` can refuse (never clobber) a
+ * manual edit made since. Starts equal to `originalAnswer` and is updated to
+ * whatever text a successful Accept/Restore just wrote, so the NEXT
+ * Accept/Restore compares against the right baseline — see
+ * `sendRewriteReplace`. `null` until the picker selects a field; reset
+ * whenever the picker changes or a fresh scan re-renders it.
  */
 let rewriteTarget: {
   question: string;
   index: number;
   expectedCount: number;
   originalAnswer: string;
+  expectedValue: string;
 } | null = null;
 
 /**
@@ -1208,10 +1215,17 @@ function renderRewritePicker(filled: FilledField[]): void {
  *  {@link rewriteTarget}, so Accept/Restore always act on exactly the field
  *  the user picked, never a moving target. `expectedCount` is the total
  *  number of scanned fields sharing this exact question text — the same
- *  fail-safe correlation `locateFilledField` re-checks on Accept/Restore. */
+ *  fail-safe correlation `locateFilledField` re-checks on Accept/Restore.
+ *
+ *  `raw` is checked for emptiness BEFORE the `Number()` coercion —
+ *  `Number('')` is `0`, not `NaN`, so a naive `Number.isInteger(Number(raw))`
+ *  guard would treat the picker's OWN placeholder (value `''`, selected when
+ *  the user picks it back, or on a fresh render) as if index 0 had been
+ *  picked, silently re-freezing whatever field happens to be first in
+ *  `lastScannedFilled` instead of correctly clearing {@link rewriteTarget}. */
 function onRewritePickerChange(): void {
-  const i = Number(els.rewritePicker.value);
-  const picked = Number.isInteger(i) ? lastScannedFilled[i] : undefined;
+  const raw = els.rewritePicker.value;
+  const picked = raw ? lastScannedFilled[Number(raw)] : undefined;
   els.rewriteResult.hidden = true;
   els.rewriteDraft.textContent = '';
   els.rewriteInstruction.value = '';
@@ -1225,6 +1239,7 @@ function onRewritePickerChange(): void {
     index: picked.index,
     expectedCount,
     originalAnswer: picked.answer,
+    expectedValue: picked.answer,
   };
 }
 
@@ -1288,12 +1303,24 @@ async function doCopyRewriteDraft(): Promise<void> {
   }, 1200);
 }
 
-/** Send an `answerReplace` for {@link rewriteTarget} with `text`, showing the
- *  outcome in the shared message area — shared by Accept (the rewritten
- *  draft) and Restore original (the frozen `originalAnswer`); the ONLY
- *  difference between the two is which `text` is passed. Fails safe on any
- *  page mutation since the pick (never a different field) — see
- *  `replaceFilledField`. Never submits the form. */
+/**
+ * Send an `answerReplace` for {@link rewriteTarget} with `text`, showing the
+ * outcome in the shared message area — shared by Accept (the rewritten
+ * draft) and Restore original (the frozen `originalAnswer`); the ONLY
+ * difference between the two is which `text` is passed. Sends the tracked
+ * `expectedValue` too, so `replaceFilledField` can refuse (a distinct
+ * error, surfaced verbatim below) rather than clobber a manual edit the
+ * user made to the field since the pick.
+ * Fails safe on any page mutation since the pick (never a different field)
+ * — see `replaceFilledField`. Never submits the form.
+ *
+ * On a SUCCESSFUL write, updates `rewriteTarget.expectedValue` to `text` —
+ * the field now holds `text`, not whatever it held before — so the NEXT
+ * Accept/Restore compares against the CURRENT baseline instead of a stale
+ * one (without this, a successful Accept would make an immediately
+ * following Restore wrongly refuse, since the field no longer holds the
+ * value this same popup last believed was there).
+ */
 async function sendRewriteReplace(
   text: string,
   btn: HTMLButtonElement,
@@ -1309,8 +1336,10 @@ async function sendRewriteReplace(
       index: rewriteTarget.index,
       count: rewriteTarget.expectedCount,
       text,
+      expectedValue: rewriteTarget.expectedValue,
     });
     if (res.ok && res.kind === 'answerReplace' && res.result.filled) {
+      if (rewriteTarget) rewriteTarget.expectedValue = text;
       setMsg(els.importMsg, successMsg, 'ok');
     } else {
       const msg =


### PR DESCRIPTION
## Summary

Restores the **PR 11 rewrite-mode review fixes** that were lost when #649 merged
before they landed. #649 shipped the rewrite feature itself; this re-applies the
three review findings (all already resolved on that PR's threads, all three lenses
+ claude + CodeRabbit) that were sitting on a not-yet-merged commit at merge time.

## What lands

- **Value-drift guard on Accept/Restore** (`answer-fill.ts` — `CHANGED_SINCE_PICK`):
  `replaceFilledField` now compares the picked field's CURRENT text to the pick-time
  snapshot and refuses if the user edited it since — never clobbers an unseen manual
  edit with a rewrite of stale text. Extends the "never write an unexpected field"
  discipline to "never overwrite unexpected content".
- **Picker `Number('') === 0` fix** (`popup.ts`): resetting the picker to the
  placeholder silently re-picked index 0; now guarded so an empty selection resolves
  to `undefined`, not the first field. Adds `expectedValue` tracking on the rewrite
  target so the next Accept/Restore compares against the right baseline.
- **Validate-before-charge ordering** (`answer_assist.rs` — `validate_rewrite_fields`):
  rewrite inputs are validated as a pure step BEFORE the `ai_research` limiter is
  acquired, so a malformed rewrite request can't consume the daily charge. Adds the
  `assist_prompt_for_mode` pure mode→prompt seam.

## Why a separate PR

The fixes lived on `d6c244c4`, which hadn't merged when #649 landed (a fix-push kept
aborting on the pre-push sync-merge loop). Rather than force anything onto `main`, this
cherry-picks that commit onto current `main` (which already has the #674 hmac-import
repair), so `main` ends with the rewrite feature **and** its review fixes.

## Review trail

Fully reviewed already on #649: three lenses (extension-reviewer, tauri-security-reviewer,
ai-provider-expert), claude, and all CodeRabbit threads resolved. No new logic — this is
the exact reviewed diff, re-applied. Rust `extension_bridge` + `agent` suites, extension
vitest (collector/locate/replace + rewrite-UI + preset-parity), `lint:strict`, typecheck,
and both browser builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
