### PR TITLE
fix(analyze): don't flag language mismatch when a language is unknown

### DIFF
--- a/packages/prompts/src/analyze/validate.ts
+++ b/packages/prompts/src/analyze/validate.ts
@@ -116,7 +116,16 @@ export function validateAndRepair(raw: string): AnalysisResult | null {
     detectedLanguages: {
       resume: ensureString(langs.resume, 'unknown'),
       jobAd: ensureString(langs.jobAd, 'unknown'),
-      mismatch: langs.mismatch === true || langs.resume !== langs.jobAd,
+      // Only flag mismatch when both languages are actually known — matches
+      // detectLanguages() in @ajh/shared. Otherwise an 'unknown' or missing
+      // side would falsely trip the mismatch warning.
+      mismatch:
+        langs.mismatch === true ||
+        (typeof langs.resume === 'string' &&
+          typeof langs.jobAd === 'string' &&
+          langs.resume !== 'unknown' &&
+          langs.jobAd !== 'unknown' &&
+          langs.resume !== langs.jobAd),
     },
     scores: {
       ats: clampScore(scores.ats),


### PR DESCRIPTION
Fixes #677

`validateAndRepair`'s mismatch fallback compared `langs.resume` to `langs.jobAd` directly, so a missing or `'unknown'` value on either side flipped `mismatch` to `true` (e.g. `{resume: 'en', jobAd: 'unknown'}` reported a mismatch).

Now mirrors `detectLanguages()` in `@ajh/shared`: mismatch only when both codes are present, non-`'unknown'`, and different.
