### PR TITLE
fix(prompts): count zero words for empty or whitespace-only resume

### DIFF
--- a/packages/prompts/src/context-manager/multi-pass.ts
+++ b/packages/prompts/src/context-manager/multi-pass.ts
@@ -74,7 +74,10 @@ export function getResumeStats(resume: string) {
   const pages = estimatePages(resume);
   const sections = detectSections(resume);
   const chars = resume.length;
-  const words = resume.split(/\s+/).length;
+  // `.split(/\s+/)` yields `['']` for empty input and empty tokens for
+  // leading/trailing whitespace, so trim first and bail out on empty.
+  const trimmed = resume.trim();
+  const words = trimmed ? trimmed.split(/\s+/).length : 0;
 
   return {
     characters: chars,


### PR DESCRIPTION
Fixes #678

`resume.split(/\s+/).length` returned `1` for an empty string and inflated counts by 1-2 for leading/trailing whitespace, so the `words` field in `getResumeStats` was systematically wrong on the edges. Trim first, bail out on empty.
