### PR TITLE
docs: fix stale apps/tauri trees, app-data dir name, and ci badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,29 +207,30 @@ The Tauri app opens automatically. Hot-reload is enabled for the renderer.
 ## Monorepo Structure
 
 ```
-ai-job-hunter/
+ai-job-hunter-app/
 ├── apps/
-│   └── tauri/                  # Tauri app (Rust core + React renderer)
-│       ├── src-tauri/          # Rust core (commands, menu, tray, updater)
-│       └── src/                # React UI + tauri-client.ts
+│   ├── desktop/                 # Tauri app: Rust core + React renderer
+│   │   ├── src-tauri/           # Rust core (commands, scraping, AI, export, DB, extension bridge)
+│   │   └── src/                 # React UI + tauri-client
+│   └── extension/               # Browser extension (MV3, Chrome + Firefox)
 │
 ├── packages/
-│   ├── shared/                 # Types, Zod schemas, IPC contracts
-│   ├── core/                   # EventBus, JobQueue, TaskScheduler, logger
-│   ├── ai/                     # Ollama client, inference wrappers
-│   ├── data/                   # Scrapers, appliers, DB, vector store
-│   └── workers/                # Background workers
+│   ├── shared/                  # Types, Zod schemas, IPC contracts
+│   ├── ui/                      # @ajh/ui — React component library
+│   ├── prompts/                 # AI prompt templates
+│   ├── translations/            # i18n config + locale strings
+│   └── test-ids/                # @ajh/test-ids — central TEST_IDS map
 │
 ├── .github/
-│   ├── workflows/              # CI/CD pipelines
+│   ├── workflows/               # CI/CD pipelines
 │   └── ISSUE_TEMPLATE/
 │
-├── docs/                       # Architecture and design documentation
-├── eslint.config.mjs           # ESLint (flat config)
-├── .prettierrc.json            # Prettier
-├── commitlint.config.mjs       # Commit linting
-├── vitest.config.ts            # Unit tests
-└── .releaserc.json             # semantic-release config
+├── docs/                        # Architecture and design documentation
+├── eslint.config.mjs            # ESLint (flat config)
+├── .prettierrc.json             # Prettier
+├── commitlint.config.mjs        # Commit linting
+├── vitest.config.ts             # Unit tests
+└── .releaserc.json              # semantic-release config
 ```
 
 ### Package dependency graph
@@ -239,11 +240,13 @@ ai-job-hunter/
   └── @ajh/shared
   └── @ajh/ui
   └── @ajh/prompts
+  └── @ajh/translations
+  └── @ajh/test-ids
 @ajh/ui
   └── @ajh/shared
 ```
 
-Build order: `shared → ui / prompts → tauri`
+Build order: `shared → ui / prompts / translations / test-ids → desktop`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 <p align="center">
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/releases"><img alt="Release" src="https://img.shields.io/github/v/release/saeedkolivand/ai-job-hunter-app?color=e24b4a&label=release"></a>
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/releases"><img alt="Downloads" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/saeedkolivand/ai-job-hunter-app/badges/downloads.json"></a>
-  <a href="https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/saeedkolivand/ai-job-hunter-app/ci-pipeline.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/saeedkolivand/ai-job-hunter-app/ci-pipeline.yml?label=CI"></a>
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/saeedkolivand/ai-job-hunter-app"></a>
   <a href="LICENSE"><img alt="License: PolyForm Noncommercial 1.0.0" src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-orange.svg"></a>
 </p>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@ graph TB
     end
 
     subgraph Tauri["Tauri Core (Rust)"]
-        Commands["IPC Commands\n(23 namespaces)"]
+        Commands["IPC Commands\n(one namespace per domain)"]
         Keychain["OS Keychain\n(credentials)"]
         Updater["Auto-Updater"]
         Window["Window / Tray / Menu"]
@@ -128,33 +128,12 @@ The single source of truth for renderer ↔ Rust communication:
 ```
 packages/shared/src/
 ├── ipc/
-│   ├── contracts/          # 23 typed namespace definitions
-│   │   ├── ai.ts
-│   │   ├── aiGenerations.ts
-│   │   ├── autopilot.ts
-│   │   ├── boards.ts
-│   │   ├── cliAgents.ts
-│   │   ├── contactProfile.ts
-│   │   ├── credentials.ts
-│   │   ├── data.ts
-│   │   ├── dialog.ts
-│   │   ├── documents.ts
-│   │   ├── geocode.ts
-│   │   ├── jobPreferences.ts
-│   │   ├── jobs.ts
-│   │   ├── linkedin.ts
-│   │   ├── match.ts
-│   │   ├── privacy.ts
-│   │   ├── resume.ts
-│   │   ├── scrape.ts
-│   │   ├── search.ts
-│   │   ├── shortcuts.ts
-│   │   ├── support.ts
-│   │   ├── system.ts
-│   │   └── updater.ts
-│   └── contracts.ts        # Re-exports all namespaces
+│   ├── contracts/               # one typed namespace module per IPC domain, re-exported via index.ts
+│   ├── extension-protocol.ts    # browser-extension wire protocol
+│   └── extension-protocol-constants.ts
 ├── schemas/                # Zod validation schemas
 ├── types/                  # JobRecord, DocumentRecord, MatchScore, etc.
+├── events/                 # shared event-bus types
 ├── language-detection.ts   # franc.js language detection
 ├── ai-models.ts            # Model registry per provider
 └── utils.ts

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -319,16 +319,16 @@ This identifier is used for:
 
 The app stores all user data in the OS app data directory:
 
-| Platform | Path                                           |
-| -------- | ---------------------------------------------- |
-| Windows  | `%APPDATA%\ai-job-hunter\`                     |
-| macOS    | `~/Library/Application Support/ai-job-hunter/` |
-| Linux    | `~/.local/share/ai-job-hunter/`                |
+| Platform | Path                                             |
+| -------- | ------------------------------------------------ |
+| Windows  | `%APPDATA%\com.ajh.desktop\`                     |
+| macOS    | `~/Library/Application Support/com.ajh.desktop/` |
+| Linux    | `~/.local/share/com.ajh.desktop/`                |
 
 Contents:
 
 ```
-ai-job-hunter/
+com.ajh.desktop/
 ├── documents.db    ← imported docs + embedding vectors (vectors/posting_vectors/match_scores tables)
 ├── jobs.db         ← scraped/tracked jobs  (+ applications.db, ai_generations.db, job_preferences.db,
 │                     contact_profile.db, referrals.db, pipeline_cache.db — one SQLite file per domain)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -243,9 +243,9 @@ files include `documents.db` (imported documents **plus** embedding vectors — 
 
 App-data directory per OS (rooted at your home directory, `<HOME>`):
 
-- **Windows**: `<HOME>\AppData\Roaming\ai-job-hunter\`
-- **macOS**: `<HOME>/Library/Application Support/ai-job-hunter/`
-- **Linux**: `<HOME>/.local/share/ai-job-hunter/`
+- **Windows**: `<HOME>\AppData\Roaming\com.ajh.desktop\`
+- **macOS**: `<HOME>/Library/Application Support/com.ajh.desktop/`
+- **Linux**: `<HOME>/.local/share/com.ajh.desktop/`
 
 Embedding vectors live in the `vectors` table of `documents.db` and cosine similarity
 runs in-process in Rust — **no LanceDB, no `vectors/` directory**. To reset dev state,


### PR DESCRIPTION
Follow-up to #683 — the earlier pass missed a few stale directory trees and one real doc bug.

## Structure drift fixed (cross-checked against the actual filesystem)
- **`CONTRIBUTING.md`** — the Monorepo Structure tree had `ai-job-hunter/` root + `apps/tauri/` + a fictional `packages/{core,ai,data,workers}` (Node-sidecar era, long gone) → real layout: `ai-job-hunter-app/`, `apps/desktop`+`apps/extension`, packages `shared/ui/prompts/translations/test-ids`. Also fixed the build-order graph (`… → tauri` → `… → desktop`, added `translations`/`test-ids`).
- **`docs/ARCHITECTURE.md`** — a hand-enumerated `packages/shared` contracts tree pointed at a nonexistent `contracts.ts` re-export and listed files that don't exist (`search.ts`, `shortcuts.ts`) while missing real ones → rewritten as a thin, non-enumerated block (avoids re-drift); fixed the adjacent mermaid label.

## Real bug: wrong app-data directory
- **`docs/DEPLOYMENT.md` + `docs/DEVELOPMENT.md`** documented the OS app-data dir as `ai-job-hunter/` — it's actually **`com.ajh.desktop/`** (the `identifier` in `tauri.conf.json`; confirmed on-disk). The doc even contradicted its own "App Identifier" section. Fixed all platform paths + the data-dir tree.

## CI badge
- **`README.md`** top CI badge dropped `?branch=main` → `…/ci-pipeline.yml?label=CI`. `ci-pipeline.yml` runs only on `pull_request` (never `push` to main), so there were zero runs on `main` and the badge rendered "no status". Now shows the latest run.

Verified: every written path exists (`test -e`); `pnpm check:agent-system` + `pnpm gen:workflows:check` green, no residual diff. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)