### PR TITLE
test: settle the extension-bridge ai-assist cache assertion with waitfor

### DIFF
--- a/apps/desktop/src/renderer/services/use-extension-bridge/use-extension-bridge.test.ts
+++ b/apps/desktop/src/renderer/services/use-extension-bridge/use-extension-bridge.test.ts
@@ -139,7 +139,9 @@ describe('useSetExtensionAiAssistSetting', () => {
       await setResult.current.mutateAsync({ enabled: true });
     });
 
-    expect(queryClient.getQueryData(keys.extensionBridge.aiAssist)).toEqual({ enabled: true });
+    await waitFor(() =>
+      expect(queryClient.getQueryData(keys.extensionBridge.aiAssist)).toEqual({ enabled: true })
+    );
   });
 
   it('forwards just the enabled flag when turning the opt-in OFF', async () => {


### PR DESCRIPTION
## Summary

Kills the one intermittent failure in the suite: `use-extension-bridge.test.ts` → "caches the returned setting so a re-read reflects it immediately". It failed rarely under full-suite parallel load with `expected undefined to deeply equal { enabled: true }`, and passed 9/9 in isolation — it bit the `pnpm test` pre-push gate during #22 (PR #687) and cost a retry.

## Cause

The test read `queryClient.getQueryData(...)` **synchronously** on the line right after `mutateAsync` resolved, so it raced the `onSuccess` → `setQueryData` settle. Under parallel load the read sometimes won.

The hook is correct and unchanged — `useSetExtensionAiAssistSetting` (`use-extension-bridge.ts:101`) does `qc.setQueryData(keys.extensionBridge.aiAssist, data)` in `onSuccess` exactly as intended. This was a test-timing bug, not a product bug.

## Fix

Wrap the cache assertion in `await waitFor(...)`, matching the idiom the repo's other cache assertions already use (`use-ai-generations.test.ts:43-45`, `:49-51`). `waitFor` was already imported in the file. The assertion's meaning is identical — the cache must hold `{ enabled: true }`.

Checked the sibling setters for the same latent shape: `useSetExtensionAutofillSetting` / `useSetExtensionAutoTrackSetting` have no cache test in this file, so there was nothing else to harden.

## Test plan

`vitest run src/renderer/services/use-extension-bridge` → 9 passed / 0 failed · `pnpm lint:strict --max-warnings 0` clean · `pnpm typecheck` 12/12 · full `pnpm test` green through the pre-push gate.

Test-only diff (3 insertions, 1 deletion) — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
