### PR TITLE
ui: regroup the extension popup by task with a context probe and collapsed answer tools

### DIFF
--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -315,6 +315,62 @@ describe('appliedCheck request', () => {
   });
 });
 
+// ── fieldsProbe request — always ok:true, EVERY failure fails OPEN (unlike
+// appliedCheck, which fails CLOSED into found:false) ────────────────────────
+
+describe('fieldsProbe request', () => {
+  it('returns the injected probe result on success (fields found)', async () => {
+    tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/apply' } as never]);
+    executeScriptMock.mockResolvedValueOnce([{ result: true }] as never);
+
+    const res = await send({ kind: 'fieldsProbe' });
+
+    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: true });
+    expect(executeScriptMock).toHaveBeenCalledWith({
+      target: { tabId: 7 },
+      files: ['probe-fields.js'],
+    });
+    // Never touches the token/bridge — this is a page-only, offline-safe read.
+    expect(getTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the injected probe result on success (no fields)', async () => {
+    tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/listing' } as never]);
+    executeScriptMock.mockResolvedValueOnce([{ result: false }] as never);
+
+    const res = await send({ kind: 'fieldsProbe' });
+
+    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: false });
+  });
+
+  it('fails OPEN (hasFields:true) when there is no active tab', async () => {
+    tabsQueryMock.mockResolvedValue([]);
+
+    const res = await send({ kind: 'fieldsProbe' });
+
+    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: true });
+    expect(executeScriptMock).not.toHaveBeenCalled();
+  });
+
+  it('fails OPEN (hasFields:true) when the injected result is not a boolean (malformed/blocked page)', async () => {
+    tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/apply' } as never]);
+    executeScriptMock.mockResolvedValueOnce([{ result: null }] as never);
+
+    const res = await send({ kind: 'fieldsProbe' });
+
+    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: true });
+  });
+
+  it('fails OPEN (hasFields:true) when executeScript REJECTS (restricted page/scripting denied)', async () => {
+    tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/apply' } as never]);
+    executeScriptMock.mockRejectedValueOnce(new Error('Cannot access a chrome:// URL'));
+
+    const res = await send({ kind: 'fieldsProbe' });
+
+    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: true });
+  });
+});
+
 // ── statusUpdate request — errors are NOT folded (unlike appliedCheck) ────────
 
 describe('statusUpdate request', () => {
@@ -1462,6 +1518,20 @@ describe('arming the submit watcher after a gesture request (Task #22 review clo
     mockClient.autotrackEnabled.mockResolvedValue(true);
 
     await send({ kind: 'getStatus' });
+    await flush();
+
+    expect(mockClient.autotrackEnabled).not.toHaveBeenCalled();
+    expect(executeScriptMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ files: ['submit-watch.js'] })
+    );
+  });
+
+  it('a fieldsProbe request never arms the watcher (a passive scan, not a user gesture)', async () => {
+    mockClient.autotrackEnabled.mockResolvedValue(true);
+    tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://example.com/apply' } as never]);
+    executeScriptMock.mockResolvedValueOnce([{ result: true }] as never);
+
+    await send({ kind: 'fieldsProbe' });
     await flush();
 
     expect(mockClient.autotrackEnabled).not.toHaveBeenCalled();

--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -319,13 +319,20 @@ describe('appliedCheck request', () => {
 // appliedCheck, which fails CLOSED into found:false) ────────────────────────
 
 describe('fieldsProbe request', () => {
-  it('returns the injected probe result on success (fields found)', async () => {
+  it('returns the injected probe result on success (both signals true)', async () => {
     tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/apply' } as never]);
-    executeScriptMock.mockResolvedValueOnce([{ result: true }] as never);
+    executeScriptMock.mockResolvedValueOnce([
+      { result: { hasFormFields: true, hasAnswerFields: true } },
+    ] as never);
 
     const res = await send({ kind: 'fieldsProbe' });
 
-    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: true });
+    expect(res).toEqual({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: true,
+      hasAnswerFields: true,
+    });
     expect(executeScriptMock).toHaveBeenCalledWith({
       target: { tabId: 7 },
       files: ['probe-fields.js'],
@@ -334,40 +341,78 @@ describe('fieldsProbe request', () => {
     expect(getTokenMock).not.toHaveBeenCalled();
   });
 
-  it('returns the injected probe result on success (no fields)', async () => {
-    tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/listing' } as never]);
-    executeScriptMock.mockResolvedValueOnce([{ result: false }] as never);
+  it('passes through an identity-only-form result (hasFormFields true, hasAnswerFields false — the union split)', async () => {
+    tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/apply' } as never]);
+    executeScriptMock.mockResolvedValueOnce([
+      { result: { hasFormFields: true, hasAnswerFields: false } },
+    ] as never);
 
     const res = await send({ kind: 'fieldsProbe' });
 
-    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: false });
+    expect(res).toEqual({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: true,
+      hasAnswerFields: false,
+    });
   });
 
-  it('fails OPEN (hasFields:true) when there is no active tab', async () => {
+  it('returns the injected probe result on success (no fields at all)', async () => {
+    tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/listing' } as never]);
+    executeScriptMock.mockResolvedValueOnce([
+      { result: { hasFormFields: false, hasAnswerFields: false } },
+    ] as never);
+
+    const res = await send({ kind: 'fieldsProbe' });
+
+    expect(res).toEqual({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: false,
+      hasAnswerFields: false,
+    });
+  });
+
+  it('fails OPEN (both signals true) when there is no active tab', async () => {
     tabsQueryMock.mockResolvedValue([]);
 
     const res = await send({ kind: 'fieldsProbe' });
 
-    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: true });
+    expect(res).toEqual({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: true,
+      hasAnswerFields: true,
+    });
     expect(executeScriptMock).not.toHaveBeenCalled();
   });
 
-  it('fails OPEN (hasFields:true) when the injected result is not a boolean (malformed/blocked page)', async () => {
+  it('fails OPEN (both signals true) when the injected result is malformed (missing/non-boolean fields)', async () => {
     tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/apply' } as never]);
-    executeScriptMock.mockResolvedValueOnce([{ result: null }] as never);
+    executeScriptMock.mockResolvedValueOnce([{ result: { hasFormFields: true } }] as never);
 
     const res = await send({ kind: 'fieldsProbe' });
 
-    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: true });
+    expect(res).toEqual({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: true,
+      hasAnswerFields: true,
+    });
   });
 
-  it('fails OPEN (hasFields:true) when executeScript REJECTS (restricted page/scripting denied)', async () => {
+  it('fails OPEN (both signals true) when executeScript REJECTS (restricted page/scripting denied)', async () => {
     tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://jobs.example.com/apply' } as never]);
     executeScriptMock.mockRejectedValueOnce(new Error('Cannot access a chrome:// URL'));
 
     const res = await send({ kind: 'fieldsProbe' });
 
-    expect(res).toEqual({ ok: true, kind: 'fieldsProbe', hasFields: true });
+    expect(res).toEqual({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: true,
+      hasAnswerFields: true,
+    });
   });
 });
 
@@ -1529,7 +1574,9 @@ describe('arming the submit watcher after a gesture request (Task #22 review clo
   it('a fieldsProbe request never arms the watcher (a passive scan, not a user gesture)', async () => {
     mockClient.autotrackEnabled.mockResolvedValue(true);
     tabsQueryMock.mockResolvedValue([{ id: 7, url: 'https://example.com/apply' } as never]);
-    executeScriptMock.mockResolvedValueOnce([{ result: true }] as never);
+    executeScriptMock.mockResolvedValueOnce([
+      { result: { hasFormFields: true, hasAnswerFields: true } },
+    ] as never);
 
     await send({ kind: 'fieldsProbe' });
     await flush();

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -401,6 +401,44 @@ async function runAppliedCheck(): Promise<PopupResponse> {
 }
 
 /**
+ * Inject the fillable-fields probe into the active tab and return its
+ * boolean completion value. Single-step injection — same pattern as
+ * `captureActiveTabQuestions`. UNLIKE the other capture injections, this
+ * never needs a token check first: it never touches the bridge/desktop at
+ * all, only the active tab's DOM.
+ */
+async function captureActiveTabFieldsProbe(): Promise<boolean> {
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  const tabId = tab?.id;
+  if (typeof tabId !== 'number') throw new Error('No active tab to scan.');
+
+  const results = await browser.scripting.executeScript({
+    target: { tabId },
+    files: ['probe-fields.js'],
+  });
+  const hasFields = results[0]?.result;
+  if (typeof hasFields !== 'boolean') throw new Error('Could not scan this page.');
+  return hasFields;
+}
+
+/**
+ * Passive "does this page have fillable form fields?" probe, run once when
+ * the popup shows the connected view — gates the Form group / Answer-tools
+ * disclosure. Mirrors `runAppliedCheck`'s never-surfaces-`ok:false` fold, but
+ * FAILS OPEN instead of closed: any failure (no active tab, restricted page,
+ * scripting permission denied) resolves `hasFields:true` so a probe bug can
+ * never hide those features — only a CONFIRMED empty scan hides them.
+ */
+async function runFieldsProbe(): Promise<PopupResponse> {
+  try {
+    const hasFields = await captureActiveTabFieldsProbe();
+    return { ok: true, kind: 'fieldsProbe', hasFields };
+  } catch {
+    return { ok: true, kind: 'fieldsProbe', hasFields: true };
+  }
+}
+
+/**
  * User-clicked "Mark as applied" for the active tab's URL. UNLIKE
  * `runAppliedCheck`, failures are NOT folded away here: a transport-level
  * rejection (not paired, bridge unreachable, timeout) propagates up to
@@ -884,6 +922,8 @@ async function dispatchRequest(req: PopupRequest): Promise<PopupResponse> {
         return await runFill();
       case 'appliedCheck':
         return await runAppliedCheck();
+      case 'fieldsProbe':
+        return await runFieldsProbe();
       case 'statusUpdate':
         return await runStatusUpdate();
       case 'answersSave':

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -400,14 +400,29 @@ async function runAppliedCheck(): Promise<PopupResponse> {
   }
 }
 
+/** The `probe-fields.js` completion value — see that file's doc for why two
+ *  independent booleans, not one. */
+interface FieldsProbeResult {
+  hasFormFields: boolean;
+  hasAnswerFields: boolean;
+}
+
+/** Minimal guard for the `{hasFormFields, hasAnswerFields}` object that
+ *  crossed the `executeScript` boundary (probe-fields.js's completion value). */
+function isFieldsProbeResult(v: unknown): v is FieldsProbeResult {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return typeof o.hasFormFields === 'boolean' && typeof o.hasAnswerFields === 'boolean';
+}
+
 /**
  * Inject the fillable-fields probe into the active tab and return its
- * boolean completion value. Single-step injection — same pattern as
- * `captureActiveTabQuestions`. UNLIKE the other capture injections, this
- * never needs a token check first: it never touches the bridge/desktop at
- * all, only the active tab's DOM.
+ * `{hasFormFields, hasAnswerFields}` completion value. Single-step injection
+ * — same pattern as `captureActiveTabQuestions`. UNLIKE the other capture
+ * injections, this never needs a token check first: it never touches the
+ * bridge/desktop at all, only the active tab's DOM.
  */
-async function captureActiveTabFieldsProbe(): Promise<boolean> {
+async function captureActiveTabFieldsProbe(): Promise<FieldsProbeResult> {
   const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
   const tabId = tab?.id;
   if (typeof tabId !== 'number') throw new Error('No active tab to scan.');
@@ -416,9 +431,9 @@ async function captureActiveTabFieldsProbe(): Promise<boolean> {
     target: { tabId },
     files: ['probe-fields.js'],
   });
-  const hasFields = results[0]?.result;
-  if (typeof hasFields !== 'boolean') throw new Error('Could not scan this page.');
-  return hasFields;
+  const probe = results[0]?.result;
+  if (!isFieldsProbeResult(probe)) throw new Error('Could not scan this page.');
+  return probe;
 }
 
 /**
@@ -426,15 +441,15 @@ async function captureActiveTabFieldsProbe(): Promise<boolean> {
  * the popup shows the connected view — gates the Form group / Answer-tools
  * disclosure. Mirrors `runAppliedCheck`'s never-surfaces-`ok:false` fold, but
  * FAILS OPEN instead of closed: any failure (no active tab, restricted page,
- * scripting permission denied) resolves `hasFields:true` so a probe bug can
- * never hide those features — only a CONFIRMED empty scan hides them.
+ * scripting permission denied) resolves BOTH signals `true` so a probe bug
+ * can never hide either feature — only a CONFIRMED empty scan hides them.
  */
 async function runFieldsProbe(): Promise<PopupResponse> {
   try {
-    const hasFields = await captureActiveTabFieldsProbe();
-    return { ok: true, kind: 'fieldsProbe', hasFields };
+    const { hasFormFields, hasAnswerFields } = await captureActiveTabFieldsProbe();
+    return { ok: true, kind: 'fieldsProbe', hasFormFields, hasAnswerFields };
   } catch {
-    return { ok: true, kind: 'fieldsProbe', hasFields: true };
+    return { ok: true, kind: 'fieldsProbe', hasFormFields: true, hasAnswerFields: true };
   }
 }
 

--- a/apps/extension/src/lib/answers-capture.test.ts
+++ b/apps/extension/src/lib/answers-capture.test.ts
@@ -13,6 +13,7 @@ import {
   collectAnswers,
   collectFilledFields,
   collectQuestions,
+  hasFillableFields,
   locateFilledField,
   locateQuestionField,
 } from './answers-capture';
@@ -443,5 +444,33 @@ describe('locateFilledField — re-scans the CURRENT filled candidates by (quest
       </select>
     `);
     expect(locateFilledField(document, 'Years of experience', 0, 1)).toBeNull();
+  });
+});
+
+describe('hasFillableFields — the popup fields-probe (Form group / Answer-tools gating)', () => {
+  it('returns false for a page with no form fields at all (a plain job listing)', () => {
+    setForm(`<p>Senior Rust Engineer at Acme Corp.</p>`);
+    expect(hasFillableFields(document)).toBe(false);
+  });
+
+  it('returns true when the page has an EMPTY, capturable candidate field', () => {
+    setForm(`<label for="q1">Why this role?</label><input id="q1" type="text" value="" />`);
+    expect(hasFillableFields(document)).toBe(true);
+  });
+
+  it('returns true when the page has a FILLED, capturable candidate field', () => {
+    setForm(
+      `<label for="q1">Why this role?</label><input id="q1" type="text" value="Because I love it." />`
+    );
+    expect(hasFillableFields(document)).toBe(true);
+  });
+
+  it('returns false when every candidate field is excluded (ambiguous/identity/hidden — same gates as Save/Suggest)', () => {
+    setForm(`
+      <label for="pw">Password</label><input id="pw" type="text" value="" />
+      <label for="ln">LinkedIn URL</label><input id="ln" type="text" value="https://linkedin.com/in/x" />
+      <label for="h">Honeypot</label><input id="h" type="text" value="" style="display:none" />
+    `);
+    expect(hasFillableFields(document)).toBe(false);
   });
 });

--- a/apps/extension/src/lib/answers-capture.test.ts
+++ b/apps/extension/src/lib/answers-capture.test.ts
@@ -13,7 +13,7 @@ import {
   collectAnswers,
   collectFilledFields,
   collectQuestions,
-  hasFillableFields,
+  hasAnswerCapturableFields,
   locateFilledField,
   locateQuestionField,
 } from './answers-capture';
@@ -447,22 +447,22 @@ describe('locateFilledField — re-scans the CURRENT filled candidates by (quest
   });
 });
 
-describe('hasFillableFields — the popup fields-probe (Form group / Answer-tools gating)', () => {
+describe("hasAnswerCapturableFields — the popup fields-probe's NARROWER signal (Answer-tools gating)", () => {
   it('returns false for a page with no form fields at all (a plain job listing)', () => {
     setForm(`<p>Senior Rust Engineer at Acme Corp.</p>`);
-    expect(hasFillableFields(document)).toBe(false);
+    expect(hasAnswerCapturableFields(document)).toBe(false);
   });
 
   it('returns true when the page has an EMPTY, capturable candidate field', () => {
     setForm(`<label for="q1">Why this role?</label><input id="q1" type="text" value="" />`);
-    expect(hasFillableFields(document)).toBe(true);
+    expect(hasAnswerCapturableFields(document)).toBe(true);
   });
 
   it('returns true when the page has a FILLED, capturable candidate field', () => {
     setForm(
       `<label for="q1">Why this role?</label><input id="q1" type="text" value="Because I love it." />`
     );
-    expect(hasFillableFields(document)).toBe(true);
+    expect(hasAnswerCapturableFields(document)).toBe(true);
   });
 
   it('returns false when every candidate field is excluded (ambiguous/identity/hidden — same gates as Save/Suggest)', () => {
@@ -471,6 +471,15 @@ describe('hasFillableFields — the popup fields-probe (Form group / Answer-tool
       <label for="ln">LinkedIn URL</label><input id="ln" type="text" value="https://linkedin.com/in/x" />
       <label for="h">Honeypot</label><input id="h" type="text" value="" style="display:none" />
     `);
-    expect(hasFillableFields(document)).toBe(false);
+    expect(hasAnswerCapturableFields(document)).toBe(false);
+  });
+
+  it("returns false for an IDENTITY-ONLY form (name/email/phone) — the narrow signal deliberately excludes these; hasAutofillableFields (lib/autofill.ts) covers them for the Form group's wider union", () => {
+    setForm(`
+      <label for="name">Full name</label><input id="name" type="text" value="" />
+      <label for="email">Email</label><input id="email" type="email" value="" />
+      <label for="phone">Phone</label><input id="phone" type="tel" value="" />
+    `);
+    expect(hasAnswerCapturableFields(document)).toBe(false);
   });
 });

--- a/apps/extension/src/lib/answers-capture.ts
+++ b/apps/extension/src/lib/answers-capture.ts
@@ -305,3 +305,18 @@ export function locateFilledField(
   if (matches.length !== expectedCount) return null;
   return matches[index] ?? null;
 }
+
+/**
+ * Passive "does this page have at least one fillable form field?" probe —
+ * the union of {@link emptyCandidateFields} and {@link filledCandidateFields},
+ * i.e. any labelled, visible, non-ambiguous/non-identity candidate field
+ * regardless of its current EMPTY-vs-FILLED state. Reuses the SAME gates
+ * "Save my answers"/"Suggest answers" already apply (no separate notion of
+ * "fillable" is introduced) — never reads a field's VALUE beyond what those
+ * collectors already need to classify it. Used to gate the popup's Form
+ * group + Answer-tools disclosure: a plain job-listing page with no
+ * application form has neither.
+ */
+export function hasFillableFields(doc: Document): boolean {
+  return emptyCandidateFields(doc).length > 0 || filledCandidateFields(doc).length > 0;
+}

--- a/apps/extension/src/lib/answers-capture.ts
+++ b/apps/extension/src/lib/answers-capture.ts
@@ -307,16 +307,24 @@ export function locateFilledField(
 }
 
 /**
- * Passive "does this page have at least one fillable form field?" probe —
- * the union of {@link emptyCandidateFields} and {@link filledCandidateFields},
+ * Passive "does this page have at least one answer-capturable field?" probe
+ * — the union of {@link emptyCandidateFields} and {@link filledCandidateFields},
  * i.e. any labelled, visible, non-ambiguous/non-identity candidate field
  * regardless of its current EMPTY-vs-FILLED state. Reuses the SAME gates
  * "Save my answers"/"Suggest answers" already apply (no separate notion of
- * "fillable" is introduced) — never reads a field's VALUE beyond what those
- * collectors already need to classify it. Used to gate the popup's Form
- * group + Answer-tools disclosure: a plain job-listing page with no
- * application form has neither.
+ * "capturable" is introduced) — never reads a field's VALUE beyond what those
+ * collectors already need to classify it.
+ *
+ * DELIBERATELY NARROWER than "does this page have anything Fill/Save can act
+ * on": these candidate lists EXCLUDE identity fields (name/email/phone/…,
+ * see `isCapturable`'s identity exclusion) by design — they're profile-
+ * sourced contact details, not "application questions". So this alone gates
+ * ONLY the Answer-tools disclosure (Suggest/rewrite have nothing to act on
+ * without a non-identity field); the popup's Form group ("Fill this form" /
+ * "Save my answers") is gated on the WIDER union with autofill's own
+ * `hasAutofillableFields` (`lib/autofill.ts`) instead — see `probe-fields.ts`,
+ * which combines both.
  */
-export function hasFillableFields(doc: Document): boolean {
+export function hasAnswerCapturableFields(doc: Document): boolean {
   return emptyCandidateFields(doc).length > 0 || filledCandidateFields(doc).length > 0;
 }

--- a/apps/extension/src/lib/autofill.test.ts
+++ b/apps/extension/src/lib/autofill.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   AUTOFILL_GLOBAL,
   type AutofillProfile,
+  hasAutofillableFields,
   planAndFill,
   renderSummaryOverlay,
   runAutofill,
@@ -589,5 +590,42 @@ describe('AUTOFILL_GLOBAL', () => {
     // autofill.ts, or fill.js would gain an ES import and break classic injection).
     // If this value changes, update the local const in background.ts too.
     expect(AUTOFILL_GLOBAL).toBe('__ajhRunAutofill');
+  });
+});
+
+describe("hasAutofillableFields — the popup fields-probe's WIDER signal (Form group gating)", () => {
+  it('returns false for a page with no form fields at all (a plain job listing)', () => {
+    document.body.innerHTML = `<p>Senior Rust Engineer at Acme Corp.</p>`;
+    expect(hasAutofillableFields(document)).toBe(false);
+  });
+
+  it("returns true for an IDENTITY-ONLY form (name/email/phone) — the exact case answers-capture's narrower signal misses, since it excludes identity fields by design", () => {
+    setForm(`
+      <label for="name">Full name</label><input id="name" type="text" value="" />
+      <label for="email">Email</label><input id="email" type="email" value="" />
+      <label for="phone">Phone</label><input id="phone" type="tel" value="" />
+    `);
+    expect(hasAutofillableFields(document)).toBe(true);
+  });
+
+  it('returns true when only ONE identity field is present', () => {
+    setForm(`<label for="email">Email</label><input id="email" type="email" value="" />`);
+    expect(hasAutofillableFields(document)).toBe(true);
+  });
+
+  it('returns false when every input is non-identity/ambiguous/hidden (nothing autofill would ever touch)', () => {
+    setForm(`
+      <label for="q1">Why this role?</label><input id="q1" type="text" value="" />
+      <label for="pw">Password</label><input id="pw" type="password" value="" />
+      <label for="h">Honeypot email</label><input id="h" type="email" value="" style="display:none" />
+    `);
+    expect(hasAutofillableFields(document)).toBe(false);
+  });
+
+  it('returns false for an already-FILLED identity field (autofill never overwrites — nothing left for Fill to do)', () => {
+    setForm(
+      `<label for="email">Email</label><input id="email" type="email" value="already@example.com" />`
+    );
+    expect(hasAutofillableFields(document)).toBe(false);
   });
 });

--- a/apps/extension/src/lib/autofill.ts
+++ b/apps/extension/src/lib/autofill.ts
@@ -162,6 +162,25 @@ export function matchFieldKey(el: HTMLInputElement): string | null {
   return matchNamedKey(signal);
 }
 
+/**
+ * Passive "does this page have at least one autofill-supported identity
+ * field?" probe — the SAME gates {@link planAndFill} uses ({@link matchFieldKey}
+ * returning a matched key, which already requires {@link isCandidateField}),
+ * but stops at the first match and never writes anything. Answers-capture's
+ * own candidate lists deliberately EXCLUDE identity fields (they're
+ * profile-sourced, not "application questions" — see `answers-capture.ts`'s
+ * `isCapturable`), so a page with ONLY name/email/phone fields would
+ * otherwise look answer-capture-empty even though "Fill this form" has
+ * plenty to do. This is the other half of the popup's fields-probe union —
+ * see `probe-fields.ts`.
+ */
+export function hasAutofillableFields(doc: Document): boolean {
+  for (const el of Array.from(doc.querySelectorAll('input'))) {
+    if (matchFieldKey(el) !== null) return true;
+  }
+  return false;
+}
+
 /** The value for a logical key from the profile (+ split for first/last). */
 function valueForKey(
   key: string,

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -63,6 +63,14 @@ export type PopupRequest =
    */
   | { kind: 'appliedCheck' }
   /**
+   * Fire-and-forget "does this page have any fillable form fields?" probe,
+   * run once when the popup shows the connected view — gates the Form group
+   * and the Answer-tools disclosure (a page with no form, e.g. a plain job
+   * listing, shows only the Job group). Read-only (counts candidate fields,
+   * reads no values); like `appliedCheck`, never blocks the import controls.
+   */
+  | { kind: 'fieldsProbe' }
+  /**
    * User-clicked "Mark as applied" for the active tab's URL. Unlike
    * `appliedCheck`, this is a deliberate WRITE action — its failures are
    * surfaced to the user, never folded away.
@@ -171,6 +179,13 @@ export type PopupResponse =
    * special-case an error path for this passive, best-effort check.
    */
   | { ok: true; kind: 'appliedCheck'; result: ExtensionAppliedCheckResult }
+  /**
+   * Always `ok:true` — like `appliedCheck`, EVERY failure (no active tab, a
+   * restricted page, scripting permission denied) folds into `hasFields:true`
+   * (fail OPEN) so a probe bug can never hide the Form group / Answer-tools
+   * disclosure — only a CONFIRMED empty scan (`hasFields:false`) hides them.
+   */
+  | { ok: true; kind: 'fieldsProbe'; hasFields: boolean }
   /**
    * `ok:true` at the transport level; the desktop's own `ok`/`error` on
    * `result` is what the popup renders — this verb's failures are NOT

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -68,6 +68,8 @@ export type PopupRequest =
    * and the Answer-tools disclosure (a page with no form, e.g. a plain job
    * listing, shows only the Job group). Read-only (counts candidate fields,
    * reads no values); like `appliedCheck`, never blocks the import controls.
+   * Two independent signals come back — see `PopupResponse`'s `fieldsProbe`
+   * doc for why they can't be one boolean.
    */
   | { kind: 'fieldsProbe' }
   /**
@@ -181,11 +183,22 @@ export type PopupResponse =
   | { ok: true; kind: 'appliedCheck'; result: ExtensionAppliedCheckResult }
   /**
    * Always `ok:true` — like `appliedCheck`, EVERY failure (no active tab, a
-   * restricted page, scripting permission denied) folds into `hasFields:true`
-   * (fail OPEN) so a probe bug can never hide the Form group / Answer-tools
-   * disclosure — only a CONFIRMED empty scan (`hasFields:false`) hides them.
+   * restricted page, scripting permission denied) folds into `{hasFormFields:
+   * true, hasAnswerFields: true}` (fail OPEN) so a probe bug can never hide
+   * either feature — only a CONFIRMED empty scan hides them.
+   *
+   * TWO signals, not one: `hasFormFields` (gates the Form group — "Fill this
+   * form" / "Save my answers") is the UNION of autofill-supported identity
+   * fields (name/email/phone/…) and answer-capturable non-identity fields —
+   * those two candidate sets are DISJOINT BY DESIGN (answers-capture
+   * excludes identity fields, see `hasAnswerCapturableFields`'s doc), so a
+   * single narrower boolean would wrongly hide "Fill this form" on a page
+   * with ONLY identity fields. `hasAnswerFields` (gates the Answer-tools
+   * disclosure — Suggest/rewrite) is the narrower answer-capturable-only
+   * signal, since those tools have nothing to act on from identity fields
+   * alone. See `probe-fields.ts` for where both are computed.
    */
-  | { ok: true; kind: 'fieldsProbe'; hasFields: boolean }
+  | { ok: true; kind: 'fieldsProbe'; hasFormFields: boolean; hasAnswerFields: boolean }
   /**
    * `ok:true` at the transport level; the desktop's own `ok`/`error` on
    * `result` is what the popup renders — this verb's failures are NOT

--- a/apps/extension/src/lib/storage.test.ts
+++ b/apps/extension/src/lib/storage.test.ts
@@ -11,7 +11,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from '@wxt-dev/browser';
 
-import { clearToken, getToken, looksLikeToken, setToken } from './storage';
+import {
+  clearToken,
+  getAnswerToolsExpanded,
+  getToken,
+  looksLikeToken,
+  setAnswerToolsExpanded,
+  setToken,
+} from './storage';
 
 // ── Hoisted store (must be created before vi.mock factory executes) ───────────
 
@@ -120,6 +127,30 @@ describe('storage – malformed / missing stored value shape check', () => {
     getStorageLocalMock().get.mockResolvedValueOnce({});
     const result = await getToken();
     expect(result).toBeNull();
+  });
+});
+
+describe('storage – answer-tools expand/collapse preference (UI boolean, not PII/job data)', () => {
+  beforeEach(resetStorage);
+
+  it('defaults to false (collapsed) when nothing has been stored', async () => {
+    expect(await getAnswerToolsExpanded()).toBe(false);
+  });
+
+  it('round-trips true', async () => {
+    await setAnswerToolsExpanded(true);
+    expect(await getAnswerToolsExpanded()).toBe(true);
+  });
+
+  it('round-trips back to false after being set true', async () => {
+    await setAnswerToolsExpanded(true);
+    await setAnswerToolsExpanded(false);
+    expect(await getAnswerToolsExpanded()).toBe(false);
+  });
+
+  it('defaults to false (does not throw) for a malformed stored value', async () => {
+    getStorageLocalMock().get.mockResolvedValueOnce({ answerToolsExpanded: 'yes' });
+    expect(await getAnswerToolsExpanded()).toBe(false);
   });
 });
 

--- a/apps/extension/src/lib/storage.ts
+++ b/apps/extension/src/lib/storage.ts
@@ -11,6 +11,10 @@ import { browser } from '@wxt-dev/browser';
 
 const TOKEN_KEY = 'pairingToken';
 
+/** Popup UI preference — NOT PII/job data, just whether the "Answer tools"
+ *  disclosure should render pre-expanded. */
+const ANSWER_TOOLS_EXPANDED_KEY = 'answerToolsExpanded';
+
 /** The desktop token is 32 random bytes as lowercase hex → 64 chars. */
 const TOKEN_HEX_LENGTH = 64;
 
@@ -43,4 +47,16 @@ export async function clearToken(): Promise<void> {
  */
 export function looksLikeToken(value: string): boolean {
   return TOKEN_REGEX.test(value.trim());
+}
+
+/** Whether the popup's "Answer tools" disclosure should render pre-expanded.
+ *  Defaults to `false` (collapsed) when never set. */
+export async function getAnswerToolsExpanded(): Promise<boolean> {
+  const stored = await browser.storage.local.get(ANSWER_TOOLS_EXPANDED_KEY);
+  return stored[ANSWER_TOOLS_EXPANDED_KEY] === true;
+}
+
+/** Persist the Answer-tools disclosure's current expanded/collapsed state. */
+export async function setAnswerToolsExpanded(expanded: boolean): Promise<void> {
+  await browser.storage.local.set({ [ANSWER_TOOLS_EXPANDED_KEY]: expanded });
 }

--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -58,13 +58,18 @@
 
       <!-- Help popover: explains the local-only connection and what to do when the
            app isn't running — the guidance the offline view used to spell out inline.
-           Toggled by #btn-help; hidden by default. -->
-      <p id="help-popover" class="help-popover" role="region" aria-label="How this works" hidden>
-        The extension talks to the desktop app only on your own computer (loopback). If the status
-        shows “App not running”, open AI Job Hunter and reopen this popup.
-      </p>
+           Toggled by #btn-help; hidden by default. Also hosts "Unpair this device" —
+           moved off the import view's standing row (see #view-import's Job group). -->
+      <div id="help-popover" class="help-popover" role="region" aria-label="How this works" hidden>
+        <p>
+          The extension talks to the desktop app only on your own computer (loopback). If the status
+          shows “App not running”, open AI Job Hunter and reopen this popup.
+        </p>
+        <button id="btn-unpair" class="link" type="button">Unpair this device</button>
+      </div>
 
-      <!-- Import view: shown when paired + connected. -->
+      <!-- Import view: shown when paired + connected. Grouped by job-to-be-done
+           (Job / Form / Answer tools) instead of one flat stack. -->
       <section id="view-import" class="view" hidden>
         <!-- Persistent "authorized" cue: this section only renders when phase ===
              'connected', which requires a stored pairing token — so the button is
@@ -81,145 +86,172 @@
           ✓ Authorized
         </button>
         <p class="hint">Import the job on this page into your desktop app.</p>
-        <!-- Fire-and-forget "have I already applied?" line, populated after the
-             popup opens (background auto-check). Empty/hidden until (and unless)
-             an existing Application is found — never shown on a failure/timeout. -->
-        <p id="applied-status" class="msg msg--ok" role="status" aria-live="polite" hidden></p>
-        <!-- Shown only for a found+saved applied.check result; hides itself once
-             the job is marked applied (re-fires the same auto-check). -->
-        <button id="btn-mark-applied" class="btn" type="button" hidden>Mark as applied</button>
-        <div class="actions">
+
+        <!-- Job group: always shown — import, fit-check, applied state. -->
+        <section class="group" aria-label="Job">
+          <!-- Fire-and-forget "have I already applied?" line, populated after the
+               popup opens (background auto-check). Empty/hidden until (and unless)
+               an existing Application is found — never shown on a failure/timeout. -->
+          <p id="applied-status" class="msg msg--ok" role="status" aria-live="polite" hidden></p>
+          <!-- Shown only for a found+saved applied.check result; hides itself once
+               the job is marked applied (re-fires the same auto-check). -->
+          <button id="btn-mark-applied" class="btn btn--quiet" type="button" hidden>
+            Mark as applied
+          </button>
           <button id="btn-import" class="btn btn--primary" type="button">Import this job</button>
+          <!-- Explicit, never automatic: scores the default/most-recent resume against
+               this page's posting (keyword coverage only — a local computation; only
+               the score + a few missing keywords ever leave the device). -->
+          <button
+            id="btn-check-fit"
+            class="btn btn--quiet"
+            type="button"
+            title="Score your resume against this page's job posting"
+          >
+            Check fit
+          </button>
+          <div id="match-result" class="match-result" hidden></div>
+          <label class="check">
+            <input id="chk-applied" type="checkbox" />
+            <span>I already applied to this job</span>
+          </label>
+        </section>
+
+        <!-- Form group: assisted autofill + answer capture — hidden (together with
+             the Answer-tools disclosure below) when this page has no fillable
+             fields (see popup.ts's fields probe, run once on connect). -->
+        <section id="group-form" class="group group--divided" aria-label="Form">
           <button
             id="btn-fill"
-            class="btn"
+            class="btn btn--primary"
             type="button"
             title="Fill this page's form with your saved contact details (opt-in, review before submitting)"
           >
             Fill this form
           </button>
-        </div>
-        <label class="check">
-          <input id="chk-applied" type="checkbox" />
-          <span>I already applied to this job</span>
-        </label>
-        <!-- Always offered alongside the mark-as-applied flow — the post-submit
-             one-stop gesture. No match for this page → the desktop refuses with
-             a message to import the job first (never auto-creates). -->
-        <button
-          id="btn-save-answers"
-          class="btn"
-          type="button"
-          title="Save the answers you typed on this page's application form"
-        >
-          Save my answers from this page
-        </button>
-        <!-- Fuzzy-matches this page's EMPTY questions against every past answer.
-             Populated on click; rows carry per-suggestion Copy + (when a live
-             field target exists and it isn't salary-like) Fill actions. -->
-        <button
-          id="btn-suggest-answers"
-          class="btn"
-          type="button"
-          title="Suggest answers from your past applications for this page's empty questions"
-        >
-          Suggest answers for this form
-        </button>
-        <div id="suggestions-list" class="suggestions" hidden></div>
-        <!-- AI answer drafting ("Help me answer…") — billable, gated on a
-             SEPARATE desktop opt-in from autofill/suggestions above. The
-             picker is fed by the SAME questions-mode scan "Suggest answers
-             for this form" already ran (no separate scan injection); a
-             pasted/typed question always works too. -->
-        <div class="assist">
-          <label class="assist__label" for="assist-picker">Or pick a scanned question</label>
-          <select id="assist-picker" class="assist__picker">
-            <option value="">— Paste or type a question below —</option>
-          </select>
-          <textarea
-            id="assist-question"
-            class="assist__question"
-            placeholder="Paste or type an application question…"
-            aria-label="Application question"
-            rows="2"
-          ></textarea>
-          <label class="check">
-            <input id="chk-search-web" type="checkbox" />
-            <span>Search the web for this answer</span>
-          </label>
+          <!-- Always offered alongside the mark-as-applied flow — the post-submit
+               one-stop gesture. No match for this page → the desktop refuses with
+               a message to import the job first (never auto-creates). -->
           <button
-            id="btn-assist"
-            class="btn"
+            id="btn-save-answers"
+            class="btn btn--quiet"
             type="button"
-            title="Draft a paste-ready answer using your resume and this page's context"
+            title="Save the answers you typed on this page's application form"
           >
-            Help me answer…
+            Save my answers from this page
           </button>
-          <div id="assist-result" class="assist-result" hidden>
-            <p id="assist-draft" class="assist-result__draft"></p>
-            <button id="btn-copy-assist" class="btn btn--small" type="button">Copy</button>
-          </div>
-        </div>
-        <!-- AI answer REWRITE ("Rewrite an answer", extension PR 11) — the SAME
-             billable opt-in as drafting above (never the autofill one). The
-             picker is fed by the SAME filled-fields scan "Save my answers from
-             this page" already ran (no separate scan injection). Pure text
-             transform: never pulls résumé/job grounding, only transforms the
-             picked field's existing text per a preset or free-text instruction. -->
-        <div class="assist">
-          <label class="assist__label" for="rewrite-picker">Pick a filled answer to rewrite</label>
-          <select id="rewrite-picker" class="assist__picker">
-            <option value="">— Save my answers first to scan this page —</option>
-          </select>
-          <div class="rewrite-presets" role="group" aria-label="Quick rewrite presets">
-            <button type="button" class="btn btn--small" data-preset="shorten">Shorten</button>
-            <button type="button" class="btn btn--small" data-preset="expand">Expand</button>
-            <button type="button" class="btn btn--small" data-preset="rephrase">Rephrase</button>
-            <button type="button" class="btn btn--small" data-preset="impact">More impact</button>
-            <button type="button" class="btn btn--small" data-preset="grammar">Fix grammar</button>
-          </div>
-          <input
-            id="rewrite-instruction"
-            class="assist__question"
-            type="text"
-            placeholder="Or type your own instruction…"
-            aria-label="Rewrite instruction"
-          />
+        </section>
+
+        <!-- Answer tools: collapsed by default (persisted expand/collapse
+             preference — see popup.ts's initAnswerToolsPreference); auto-expands
+             if a streamed AI answer is buffered/still running on reopen. Hidden
+             (together with the Form group above) when this page has no fillable
+             fields. -->
+        <details id="answer-tools" class="group group--divided">
+          <summary>Answer tools</summary>
+          <!-- Fuzzy-matches this page's EMPTY questions against every past answer.
+               Populated on click; rows carry per-suggestion Copy + (when a live
+               field target exists and it isn't salary-like) Fill actions. -->
           <button
-            id="btn-rewrite"
-            class="btn"
+            id="btn-suggest-answers"
+            class="btn btn--quiet"
             type="button"
-            title="Rewrite the picked answer using your typed instruction"
+            title="Suggest answers from your past applications for this page's empty questions"
           >
-            Rewrite this answer
+            Suggest answers for this form
           </button>
-          <div id="rewrite-result" class="assist-result" hidden>
-            <p id="rewrite-draft" class="assist-result__draft"></p>
-            <div class="rewrite-result__actions">
-              <button id="btn-copy-rewrite" class="btn btn--small" type="button">Copy</button>
-              <button id="btn-accept-rewrite" class="btn btn--small btn--primary" type="button">
-                Accept
-              </button>
-              <button id="btn-restore-rewrite" class="btn btn--small" type="button">
-                Restore original
+          <div id="suggestions-list" class="suggestions" hidden></div>
+          <!-- AI answer drafting ("Help me answer…") — billable, gated on a
+               SEPARATE desktop opt-in from autofill/suggestions above. The
+               picker is fed by the SAME questions-mode scan "Suggest answers
+               for this form" already ran (no separate scan injection); a
+               pasted/typed question always works too. -->
+          <div class="assist">
+            <label class="assist__label" for="assist-picker">Or pick a scanned question</label>
+            <select id="assist-picker" class="assist__picker">
+              <option value="">— Paste or type a question below —</option>
+            </select>
+            <textarea
+              id="assist-question"
+              class="assist__question"
+              placeholder="Paste or type an application question…"
+              aria-label="Application question"
+              rows="2"
+            ></textarea>
+            <label class="check">
+              <input id="chk-search-web" type="checkbox" />
+              <span>Search the web for this answer</span>
+            </label>
+            <button
+              id="btn-assist"
+              class="btn btn--quiet"
+              type="button"
+              title="Draft a paste-ready answer using your resume and this page's context"
+            >
+              Help me answer…
+            </button>
+            <div id="assist-result" class="assist-result" hidden>
+              <p id="assist-draft" class="assist-result__draft"></p>
+              <button id="btn-copy-assist" class="btn btn--small btn--quiet" type="button">
+                Copy
               </button>
             </div>
           </div>
-        </div>
-        <!-- Explicit, never automatic: scores the default/most-recent resume against
-             this page's posting (keyword coverage only — a local computation; only
-             the score + a few missing keywords ever leave the device). -->
-        <button
-          id="btn-check-fit"
-          class="btn"
-          type="button"
-          title="Score your resume against this page's job posting"
-        >
-          Check fit
-        </button>
-        <div id="match-result" class="match-result" hidden></div>
+          <!-- AI answer REWRITE ("Rewrite an answer", extension PR 11) — the SAME
+               billable opt-in as drafting above (never the autofill one). The
+               picker is fed by the SAME filled-fields scan "Save my answers from
+               this page" already ran (no separate scan injection). Pure text
+               transform: never pulls résumé/job grounding, only transforms the
+               picked field's existing text per a preset or free-text instruction. -->
+          <div class="assist">
+            <label class="assist__label" for="rewrite-picker"
+              >Pick a filled answer to rewrite</label
+            >
+            <select id="rewrite-picker" class="assist__picker">
+              <option value="">— Save my answers first to scan this page —</option>
+            </select>
+            <label class="assist__label" for="rewrite-preset">Quick preset</label>
+            <select id="rewrite-preset" class="assist__picker" aria-label="Quick rewrite preset">
+              <option value="">— Pick a preset —</option>
+              <option value="shorten">Shorten</option>
+              <option value="expand">Expand</option>
+              <option value="rephrase">Rephrase</option>
+              <option value="impact">More impact</option>
+              <option value="grammar">Fix grammar</option>
+            </select>
+            <input
+              id="rewrite-instruction"
+              class="assist__question"
+              type="text"
+              placeholder="Or type your own instruction…"
+              aria-label="Rewrite instruction"
+            />
+            <button
+              id="btn-rewrite"
+              class="btn btn--quiet"
+              type="button"
+              title="Rewrite the picked answer using your typed instruction"
+            >
+              Rewrite this answer
+            </button>
+            <div id="rewrite-result" class="assist-result" hidden>
+              <p id="rewrite-draft" class="assist-result__draft"></p>
+              <div class="rewrite-result__actions">
+                <button id="btn-copy-rewrite" class="btn btn--small btn--quiet" type="button">
+                  Copy
+                </button>
+                <button id="btn-accept-rewrite" class="btn btn--small btn--quiet" type="button">
+                  Accept
+                </button>
+                <button id="btn-restore-rewrite" class="btn btn--small btn--quiet" type="button">
+                  Restore original
+                </button>
+              </div>
+            </div>
+          </div>
+        </details>
+
         <p id="import-msg" class="msg" role="status" aria-live="polite"></p>
-        <button id="btn-unpair" class="link" type="button">Unpair this device</button>
       </section>
 
       <!-- Pairing view: shown when the app is reachable but no token is stored. -->

--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -60,12 +60,25 @@
            app isn't running — the guidance the offline view used to spell out inline.
            Toggled by #btn-help; hidden by default. Also hosts "Unpair this device" —
            moved off the import view's standing row (see #view-import's Job group). -->
-      <div id="help-popover" class="help-popover" role="region" aria-label="How this works" hidden>
+      <div
+        id="help-popover"
+        class="help-popover"
+        role="region"
+        aria-label="How this works, and pairing options"
+        hidden
+      >
         <p>
           The extension talks to the desktop app only on your own computer (loopback). If the status
           shows “App not running”, open AI Job Hunter and reopen this popup.
         </p>
-        <button id="btn-unpair" class="link" type="button">Unpair this device</button>
+        <!-- Only shown while a pairing token is actually stored (toggled in
+             render() from ConnectionStatus.hasToken) — nothing to unpair
+             otherwise. Hidden by default here too, matching that no-token
+             starting assumption before the first status arrives. -->
+        <div id="unpair-group" class="help-popover__unpair" hidden>
+          <p class="help-popover__hint">Reset pairing</p>
+          <button id="btn-unpair" class="link" type="button">Unpair this device</button>
+        </div>
       </div>
 
       <!-- Import view: shown when paired + connected. Grouped by job-to-be-done
@@ -119,7 +132,12 @@
 
         <!-- Form group: assisted autofill + answer capture — hidden (together with
              the Answer-tools disclosure below) when this page has no fillable
-             fields (see popup.ts's fields probe, run once on connect). -->
+             fields (see popup.ts's fields probe, run once on connect). NOT
+             hidden by default here: the probe fails OPEN, so this group (and
+             Answer tools) render visible until/unless a CONFIRMED empty scan
+             says otherwise — a deliberate brief flash-then-hide on a
+             fields:false page, never the reverse (a probe bug hiding a
+             feature that's actually there). -->
         <section id="group-form" class="group group--divided" aria-label="Form">
           <button
             id="btn-fill"
@@ -143,7 +161,7 @@
         </section>
 
         <!-- Answer tools: collapsed by default (persisted expand/collapse
-             preference — see popup.ts's initAnswerToolsPreference); auto-expands
+             preference — see popup.ts's bootstrapAnswerTools); auto-expands
              if a streamed AI answer is buffered/still running on reopen. Hidden
              (together with the Form group above) when this page has no fillable
              fields. -->
@@ -211,7 +229,7 @@
               <option value="">— Save my answers first to scan this page —</option>
             </select>
             <label class="assist__label" for="rewrite-preset">Quick preset</label>
-            <select id="rewrite-preset" class="assist__picker" aria-label="Quick rewrite preset">
+            <select id="rewrite-preset" class="assist__picker">
               <option value="">— Pick a preset —</option>
               <option value="shorten">Shorten</option>
               <option value="expand">Expand</option>
@@ -240,7 +258,7 @@
                 <button id="btn-copy-rewrite" class="btn btn--small btn--quiet" type="button">
                   Copy
                 </button>
-                <button id="btn-accept-rewrite" class="btn btn--small btn--quiet" type="button">
+                <button id="btn-accept-rewrite" class="btn btn--small btn--primary" type="button">
                   Accept
                 </button>
                 <button id="btn-restore-rewrite" class="btn btn--small btn--quiet" type="button">

--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -88,6 +88,21 @@
         <!-- Shown only for a found+saved applied.check result; hides itself once
              the job is marked applied (re-fires the same auto-check). -->
         <button id="btn-mark-applied" class="btn" type="button" hidden>Mark as applied</button>
+        <div class="actions">
+          <button id="btn-import" class="btn btn--primary" type="button">Import this job</button>
+          <button
+            id="btn-fill"
+            class="btn"
+            type="button"
+            title="Fill this page's form with your saved contact details (opt-in, review before submitting)"
+          >
+            Fill this form
+          </button>
+        </div>
+        <label class="check">
+          <input id="chk-applied" type="checkbox" />
+          <span>I already applied to this job</span>
+        </label>
         <!-- Always offered alongside the mark-as-applied flow — the post-submit
              one-stop gesture. No match for this page → the desktop refuses with
              a message to import the job first (never auto-creates). -->
@@ -203,21 +218,6 @@
           Check fit
         </button>
         <div id="match-result" class="match-result" hidden></div>
-        <div class="actions">
-          <button id="btn-import" class="btn btn--primary" type="button">Import this job</button>
-          <button
-            id="btn-fill"
-            class="btn"
-            type="button"
-            title="Fill this page's form with your saved contact details (opt-in, review before submitting)"
-          >
-            Fill this form
-          </button>
-        </div>
-        <label class="check">
-          <input id="chk-applied" type="checkbox" />
-          <span>I already applied to this job</span>
-        </label>
         <p id="import-msg" class="msg" role="status" aria-live="polite"></p>
         <button id="btn-unpair" class="link" type="button">Unpair this device</button>
       </section>

--- a/apps/extension/src/popup/popup.css
+++ b/apps/extension/src/popup/popup.css
@@ -50,6 +50,9 @@
   --pill-down-border: var(--red-ink);
   --btn-text-on-red: #fff;
   --focus-ring: var(--red);
+  /* Low-opacity group divider — derived from --card-border so it adapts to
+   * the dark-mode override below without a second definition. */
+  --divider: color-mix(in srgb, var(--card-border) 22%, transparent);
 }
 
 * {
@@ -226,7 +229,9 @@ body {
   outline-offset: 2px;
 }
 
-/* Help text panel revealed under the header by #btn-help. */
+/* Help text panel revealed under the header by #btn-help. Now also hosts the
+ * "Unpair this device" link at its bottom (moved off the import view's
+ * standing row). */
 .help-popover {
   margin: -4px 0 12px;
   padding: 9px 11px;
@@ -239,10 +244,58 @@ body {
   border-radius: 10px 8px 11px 7px / 7px 11px 8px 10px;
 }
 
+.help-popover p {
+  margin: 0 0 8px;
+}
+
 .view {
   display: flex;
   flex-direction: column;
-  gap: 11px;
+  gap: 18px;
+}
+
+/* One job-to-be-done group (Job / Form / Answer tools) — tighter internal
+ * rhythm than the top-level view gap above. */
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* A group that follows another one gets a hairline divider instead of relying
+ * on the view gap alone. */
+.group--divided {
+  padding-top: 12px;
+  border-top: 1px solid var(--divider);
+}
+
+details.group {
+  /* Reset the UA default marker/indent — replaced by the ::before chevron below. */
+  margin: 0;
+}
+
+details.group > summary {
+  cursor: pointer;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+  list-style: none;
+}
+
+details.group > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.group > summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 6px;
+  transition: transform 0.12s ease;
+}
+
+details.group[open] > summary::before {
+  transform: rotate(90deg);
 }
 
 .hint {
@@ -254,11 +307,6 @@ body {
 
 .hint strong {
   color: var(--ink);
-}
-
-.actions {
-  display: flex;
-  gap: 8px;
 }
 
 .btn {
@@ -305,6 +353,21 @@ body {
 
 .btn--primary:hover:not(:disabled) {
   background: var(--primary-hover);
+}
+
+/* Quiet/flat secondary tier — every button EXCEPT the one raised primary CTA
+ * per context (Import, Fill, Save & pair, Get/Update app) gets this: a
+ * hairline border and no drop shadow, so the primary CTA is the only one
+ * that visually "pops". */
+.btn--quiet {
+  border-width: 1px;
+  box-shadow: none;
+}
+
+.btn--quiet:hover:not(:disabled),
+.btn--quiet:active:not(:disabled) {
+  transform: none;
+  box-shadow: none;
 }
 
 /* Persistent "✓ Authorized" status button in the import view. Always disabled
@@ -414,7 +477,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 8px 10px;
+  padding: 6px 9px;
   border: 1.5px solid var(--card-border);
   border-radius: 10px 8px 11px 7px / 7px 11px 8px 10px;
   background: var(--card);
@@ -465,7 +528,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 8px 10px;
+  padding: 6px 9px;
   border: 1.5px solid var(--card-border);
   border-radius: 10px 8px 11px 7px / 7px 11px 8px 10px;
   background: var(--card);
@@ -508,9 +571,18 @@ body {
   box-shadow: 2px 2px 0 var(--shadow);
 }
 
+/* .btn--small's own shadow (above) would otherwise outrank .btn--quiet's
+ * (equal specificity, later in source order) — this combined selector wins
+ * on specificity regardless of declaration order, so a small quiet button
+ * (e.g. the suggestion-row Copy/Fill buttons) stays flat. */
+.btn--small.btn--quiet {
+  box-shadow: none;
+}
+
 /* answer.assist ("Help me answer…") — question picker + textarea + draft
- * result card. Mirrors .token's dashed-border input styling and
- * .match-result's card treatment. */
+ * result card. The dashed hand-drawn border accent stays ONLY on .token (the
+ * pairing input); these get a plain 1px hairline instead, so the assist/
+ * rewrite controls read as calmer, denser form controls. */
 .assist {
   display: flex;
   flex-direction: column;
@@ -530,7 +602,7 @@ body {
   font-size: 12px;
   padding: 8px 10px;
   border-radius: 10px 8px 11px 7px / 7px 11px 8px 10px;
-  border: 2px dashed var(--ink);
+  border: 1px solid var(--card-border);
   background: var(--token-bg);
   color: var(--ink);
 }
@@ -547,14 +619,13 @@ body {
 .assist__question:focus {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
-  border-style: solid;
 }
 
 .assist-result {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 8px 10px;
+  padding: 6px 9px;
   border: 1.5px solid var(--card-border);
   border-radius: 10px 8px 11px 7px / 7px 11px 8px 10px;
   background: var(--card);
@@ -568,14 +639,9 @@ body {
   white-space: pre-wrap;
 }
 
-/* Rewrite mode (PR 11) — quick-preset row + Accept/Restore/Copy action row.
- * Mirrors .suggestion__actions's flex-row treatment. */
-.rewrite-presets {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
+/* Rewrite mode (PR 11) — Accept/Restore/Copy action row (the quick-preset row
+ * is now the #rewrite-preset <select> — see .assist__picker). Mirrors
+ * .suggestion__actions's flex-row treatment. */
 .rewrite-result__actions {
   display: flex;
   align-items: center;

--- a/apps/extension/src/popup/popup.css
+++ b/apps/extension/src/popup/popup.css
@@ -53,6 +53,13 @@
   /* Low-opacity group divider — derived from --card-border so it adapts to
    * the dark-mode override below without a second definition. */
   --divider: color-mix(in srgb, var(--card-border) 22%, transparent);
+  /* Border for the quiet/flat button tier + the assist/rewrite inputs.
+   * Light mode: --card-border is already opaque ink against a near-white
+   * card (>>3:1) — safe to reuse directly. Dark mode overrides this to its
+   * own higher-alpha value below (see that block's comment) since
+   * --card-border there is a low-alpha wash tuned for thin 1.5px card
+   * outlines, not a load-bearing 1px interactive-control border. */
+  --quiet-border: var(--card-border);
 }
 
 * {
@@ -248,6 +255,22 @@ body {
   margin: 0 0 8px;
 }
 
+/* Wraps the "Unpair this device" link — hidden together as a unit when no
+ * token is stored (see popup.ts's render(), toggled from hasToken). */
+.help-popover__unpair {
+  padding-top: 8px;
+  border-top: 1px solid var(--divider);
+}
+
+/* Small sub-label distinguishing "Unpair this device" as a "Reset pairing"
+ * action from the explanatory paragraph above it. */
+.help-popover__hint {
+  margin: 0 0 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ink-soft);
+}
+
 .view {
   display: flex;
   flex-direction: column;
@@ -361,6 +384,7 @@ details.group[open] > summary::before {
  * that visually "pops". */
 .btn--quiet {
   border-width: 1px;
+  border-color: var(--quiet-border);
   box-shadow: none;
 }
 
@@ -602,7 +626,7 @@ details.group[open] > summary::before {
   font-size: 12px;
   padding: 8px 10px;
   border-radius: 10px 8px 11px 7px / 7px 11px 8px 10px;
-  border: 1px solid var(--card-border);
+  border: 1px solid var(--quiet-border);
   background: var(--token-bg);
   color: var(--ink);
 }
@@ -667,6 +691,10 @@ details.group[open] > summary::before {
   .btn {
     transition: none;
   }
+
+  details.group > summary::before {
+    transition: none;
+  }
 }
 
 /* Warm-dark variant — mirrors the light paper-blend identity on a dark
@@ -685,8 +713,19 @@ details.group[open] > summary::before {
     --warn: #e0b35a;
     --shadow: rgba(0, 0, 0, 0.45);
 
-    /* Warm light border replaces the ink border on dark surfaces. */
+    /* Warm light border replaces the ink border on dark surfaces. Kept
+     * low-alpha for the thin 1.5px card outlines (.suggestion/.match-result/
+     * .assist-result/.help-popover) it was tuned for. */
     --card-border: rgba(240, 231, 214, 0.16);
+    /* --quiet-border and --divider get their OWN higher alpha here — deriving
+     * either from --card-border above would compound its already-low alpha
+     * into an effectively invisible ~1.05:1 wash (verified: WCAG contrast
+     * against --card #241f19). 0.4 clears the ≥3:1 non-text-contrast target
+     * for the quiet button tier + assist/rewrite inputs; 0.28 is a
+     * deliberately lighter touch for the group dividers, which are
+     * decorative section separators, not interactive-control borders. */
+    --quiet-border: rgba(240, 231, 214, 0.4);
+    --divider: rgba(240, 231, 214, 0.28);
 
     --token-bg: #1f1a15;
     --placeholder: #8c826e;

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browser } from '@wxt-dev/browser';
 
 import type { ConnectionStatus } from '../lib/messages';
-import { looksLikeToken } from '../lib/storage';
+import { getAnswerToolsExpanded, looksLikeToken, setAnswerToolsExpanded } from '../lib/storage';
 
 // vi.mock must come before the import that triggers the module side-effects.
 // popup.ts imports @wxt-dev/browser; stub it out so the module-level
@@ -31,6 +31,10 @@ vi.mock('@wxt-dev/browser', () => ({
 
 vi.mock('../lib/storage', () => ({
   looksLikeToken: vi.fn(() => false),
+  // Default: collapsed, matching the fresh-install default (no stored value
+  // yet) — individual tests override via mockResolvedValueOnce as needed.
+  getAnswerToolsExpanded: vi.fn(() => Promise.resolve(false)),
+  setAnswerToolsExpanded: vi.fn(() => Promise.resolve(undefined)),
 }));
 
 // Build the minimal DOM that popup.ts queries at module load (byId calls).
@@ -46,33 +50,39 @@ function buildPopupDom(): void {
     <button id="btn-import"></button>
     <button id="btn-fill"></button>
     <button id="btn-mark-applied" hidden></button>
-    <button id="btn-save-answers"></button>
-    <button id="btn-suggest-answers"></button>
-    <div id="suggestions-list" hidden></div>
-    <select id="assist-picker"><option value=""></option></select>
-    <textarea id="assist-question"></textarea>
-    <input id="chk-search-web" type="checkbox" />
-    <button id="btn-assist"></button>
-    <div id="assist-result" hidden>
-      <p id="assist-draft"></p>
-      <button id="btn-copy-assist"></button>
-    </div>
-    <select id="rewrite-picker"><option value=""></option></select>
-    <div class="rewrite-presets">
-      <button type="button" data-preset="shorten"></button>
-      <button type="button" data-preset="expand"></button>
-      <button type="button" data-preset="rephrase"></button>
-      <button type="button" data-preset="impact"></button>
-      <button type="button" data-preset="grammar"></button>
-    </div>
-    <input id="rewrite-instruction" type="text" />
-    <button id="btn-rewrite"></button>
-    <div id="rewrite-result" hidden>
-      <p id="rewrite-draft"></p>
-      <button id="btn-copy-rewrite"></button>
-      <button id="btn-accept-rewrite"></button>
-      <button id="btn-restore-rewrite"></button>
-    </div>
+    <section id="group-form">
+      <button id="btn-save-answers"></button>
+    </section>
+    <details id="answer-tools">
+      <summary>Answer tools</summary>
+      <button id="btn-suggest-answers"></button>
+      <div id="suggestions-list" hidden></div>
+      <select id="assist-picker"><option value=""></option></select>
+      <textarea id="assist-question"></textarea>
+      <input id="chk-search-web" type="checkbox" />
+      <button id="btn-assist"></button>
+      <div id="assist-result" hidden>
+        <p id="assist-draft"></p>
+        <button id="btn-copy-assist"></button>
+      </div>
+      <select id="rewrite-picker"><option value=""></option></select>
+      <select id="rewrite-preset">
+        <option value=""></option>
+        <option value="shorten"></option>
+        <option value="expand"></option>
+        <option value="rephrase"></option>
+        <option value="impact"></option>
+        <option value="grammar"></option>
+      </select>
+      <input id="rewrite-instruction" type="text" />
+      <button id="btn-rewrite"></button>
+      <div id="rewrite-result" hidden>
+        <p id="rewrite-draft"></p>
+        <button id="btn-copy-rewrite"></button>
+        <button id="btn-accept-rewrite"></button>
+        <button id="btn-restore-rewrite"></button>
+      </div>
+    </details>
     <button id="btn-check-fit"></button>
     <div id="match-result" hidden></div>
     <p id="applied-status" hidden></p>
@@ -112,10 +122,14 @@ const {
   resolveAnswerAssistResponse,
   resolveAssistProgressView,
   buildAssistPickerOptions,
+  resolveFieldsProbeResponse,
+  bootstrapAnswerTools,
 } = await import('./popup');
 
 const sendMessageMock = vi.mocked(browser.runtime.sendMessage);
 const looksLikeTokenMock = vi.mocked(looksLikeToken);
+const getAnswerToolsExpandedMock = vi.mocked(getAnswerToolsExpanded);
+const setAnswerToolsExpandedMock = vi.mocked(setAnswerToolsExpanded);
 const byId = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 
 // ── resolveStatusResponse ─────────────────────────────────────────────────────
@@ -595,6 +609,30 @@ describe('resolveShowMarkAppliedButton', () => {
   });
 });
 
+// ── resolveFieldsProbeResponse ──────────────────────────────────────────────────
+
+describe('resolveFieldsProbeResponse', () => {
+  it('returns the probe result when ok with kind=fieldsProbe (fields found)', () => {
+    const res = { ok: true as const, kind: 'fieldsProbe' as const, hasFields: true };
+    expect(resolveFieldsProbeResponse(res)).toBe(true);
+  });
+
+  it('returns the probe result when ok with kind=fieldsProbe (no fields)', () => {
+    const res = { ok: true as const, kind: 'fieldsProbe' as const, hasFields: false };
+    expect(resolveFieldsProbeResponse(res)).toBe(false);
+  });
+
+  it('fails OPEN (true) on a transport-level ok:false', () => {
+    const res = { ok: false as const, error: 'message channel closed' };
+    expect(resolveFieldsProbeResponse(res)).toBe(true);
+  });
+
+  it('fails OPEN (true) for an unexpected response kind', () => {
+    const res = { ok: true as const, kind: 'token' as const };
+    expect(resolveFieldsProbeResponse(res)).toBe(true);
+  });
+});
+
 // ── resolveMarkAppliedResponse ─────────────────────────────────────────────────
 
 describe('resolveMarkAppliedResponse', () => {
@@ -1066,7 +1104,10 @@ describe('appliedCheck auto-check', () => {
     });
     push('connected');
     await flush();
-    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    // Entering `connected` fires BOTH fire-and-forget auto-checks — appliedCheck
+    // and fieldsProbe (see the sibling `fieldsProbe auto-check` describe block).
+    expect(sendMessageMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageMock).toHaveBeenCalledWith({ kind: 'fieldsProbe' });
 
     sendMessageMock.mockClear();
     push('connected'); // same phase again — not a transition
@@ -1148,6 +1189,92 @@ describe('appliedCheck auto-check', () => {
 
     expect(status.textContent).toBe('“Job B” is saved in your pipeline.');
     expect(btnImport.textContent).toBe('Re-import / update');
+  });
+});
+
+// ── fieldsProbe auto-check (fire-and-forget on entering `connected`) ──────────
+// Gates the Form group (#group-form) + the Answer-tools disclosure
+// (#answer-tools) on "does this page have fillable form fields?". Runs
+// ALONGSIDE the appliedCheck auto-check above on the SAME transition — the
+// first queued sendMessage response answers appliedCheck (code calls it
+// first), the second answers fieldsProbe.
+
+describe('fieldsProbe auto-check (Form group + Answer-tools gating)', () => {
+  const statusListener = vi.mocked(browser.runtime.onMessage.addListener).mock.calls[0]?.[0] as
+    ((message: unknown) => void) | undefined;
+  if (!statusListener) throw new Error('onMessage status listener not registered');
+  const push = (phase: ConnectionStatus['phase']) =>
+    statusListener({ ok: true, kind: 'status', status: { phase, port: null, hasToken: true } });
+
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  const NEUTRAL_APPLIED_CHECK = {
+    ok: true as const,
+    kind: 'appliedCheck' as const,
+    result: { found: false },
+  };
+
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+    // Force a genuine transition for the next push('connected') below.
+    push('searching');
+  });
+
+  it('shows the Form group + Answer-tools disclosure when the probe finds fillable fields', async () => {
+    sendMessageMock
+      .mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK)
+      .mockResolvedValueOnce({ ok: true, kind: 'fieldsProbe', hasFields: true });
+
+    push('connected');
+    await flush();
+
+    expect(byId<HTMLElement>('group-form').hidden).toBe(false);
+    expect(byId<HTMLDetailsElement>('answer-tools').hidden).toBe(false);
+  });
+
+  it('hides the Form group + Answer-tools disclosure when the probe finds no fillable fields', async () => {
+    sendMessageMock
+      .mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK)
+      .mockResolvedValueOnce({ ok: true, kind: 'fieldsProbe', hasFields: false });
+
+    push('connected');
+    await flush();
+
+    expect(byId<HTMLElement>('group-form').hidden).toBe(true);
+    expect(byId<HTMLDetailsElement>('answer-tools').hidden).toBe(true);
+  });
+
+  it('fails OPEN (shows both groups) when the probe request rejects', async () => {
+    sendMessageMock
+      .mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK)
+      .mockRejectedValueOnce(new Error('message channel closed'));
+
+    push('connected');
+    await flush();
+
+    expect(byId<HTMLElement>('group-form').hidden).toBe(false);
+    expect(byId<HTMLDetailsElement>('answer-tools').hidden).toBe(false);
+  });
+
+  it('re-shows both groups on a fresh page after a previous page hid them (no stale hide across a reconnect)', async () => {
+    sendMessageMock
+      .mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK)
+      .mockResolvedValueOnce({ ok: true, kind: 'fieldsProbe', hasFields: false });
+    push('connected');
+    await flush();
+    expect(byId<HTMLElement>('group-form').hidden).toBe(true);
+
+    // Disconnect (leaving `connected` resets to the fail-open default) then
+    // reconnect for a fresh page whose own probe hasn't resolved yet.
+    push('app_not_running');
+    expect(byId<HTMLElement>('group-form').hidden).toBe(false);
+
+    sendMessageMock
+      .mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK)
+      .mockResolvedValueOnce({ ok: true, kind: 'fieldsProbe', hasFields: true });
+    push('connected');
+    await flush();
+    expect(byId<HTMLElement>('group-form').hidden).toBe(false);
   });
 });
 
@@ -1797,6 +1924,14 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
     picker.dispatchEvent(new Event('change'));
   }
 
+  /** Pick a preset from the #rewrite-preset <select> (replaces the old
+   *  per-preset button row) — mirrors picking any other option. */
+  function selectRewritePreset(preset: string): void {
+    const select = byId<HTMLSelectElement>('rewrite-preset');
+    select.value = preset;
+    select.dispatchEvent(new Event('change'));
+  }
+
   beforeEach(() => {
     sendMessageMock.mockReset();
     byId<HTMLButtonElement>('btn-save-answers').disabled = false;
@@ -1848,7 +1983,7 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
     );
   });
 
-  it('a preset button click sends mode:rewrite + existingAnswer + preset and renders the streamed draft', async () => {
+  it('picking a preset from the select sends mode:rewrite + existingAnswer + the SAME preset id and renders the streamed draft', async () => {
     await pickFilledField();
     sendMessageMock.mockResolvedValueOnce({
       ok: true,
@@ -1856,7 +1991,7 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
       result: { ok: true, question: 'Why this role?', draft: 'Shorter answer.', sourced: {} },
     });
 
-    document.querySelector<HTMLButtonElement>('[data-preset="shorten"]')!.click();
+    selectRewritePreset('shorten');
     await flush();
 
     expect(sendMessageMock).toHaveBeenCalledWith({
@@ -1869,6 +2004,29 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
     });
     expect(byId<HTMLDivElement>('rewrite-result').hidden).toBe(false);
     expect(byId<HTMLParagraphElement>('rewrite-draft').textContent).toBe('Shorter answer.');
+  });
+
+  it('resets the preset select back to its placeholder after firing (so re-selecting the same preset fires again)', async () => {
+    await pickFilledField();
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answerAssist',
+      result: { ok: true, question: 'Why this role?', draft: 'Shorter answer.', sourced: {} },
+    });
+
+    selectRewritePreset('shorten');
+    await flush();
+
+    expect(byId<HTMLSelectElement>('rewrite-preset').value).toBe('');
+  });
+
+  it('ignores a change back to the placeholder option (never re-fires a rewrite)', async () => {
+    await pickFilledField();
+
+    selectRewritePreset('');
+    await flush();
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
   });
 
   it('the free-text submit button sends the typed instruction instead of a preset', async () => {
@@ -1901,7 +2059,7 @@ describe('rewrite mode (#rewrite-picker, #btn-rewrite, Accept/Restore/Copy)', ()
       result: { ok: false, error: 'AI answer drafting is off.' },
     });
 
-    document.querySelector<HTMLButtonElement>('[data-preset="shorten"]')!.click();
+    selectRewritePreset('shorten');
     await flush();
 
     expect(byId<HTMLParagraphElement>('import-msg').textContent).toBe('AI answer drafting is off.');
@@ -2663,5 +2821,115 @@ describe('doMarkApplied (#btn-mark-applied)', () => {
       'Could not mark this job as applied. Please retry.'
     );
     expect(btn.disabled).toBe(false);
+  });
+});
+
+// ── Answer-tools expand/collapse (#answer-tools <details>) ──────────────────
+// Collapsed by default; the expand/collapse state persists via
+// chrome.storage.local (a UI boolean, not PII/job data); a buffered/still-
+// running stream always wins over a persisted "collapsed" preference.
+
+describe('answer-tools persistence (toggle → storage)', () => {
+  beforeEach(() => {
+    setAnswerToolsExpandedMock.mockClear();
+  });
+
+  it('persists the CURRENT open state when the disclosure is toggled', () => {
+    const details = byId<HTMLDetailsElement>('answer-tools');
+    details.open = true;
+    details.dispatchEvent(new Event('toggle'));
+
+    expect(setAnswerToolsExpandedMock).toHaveBeenCalledWith(true);
+  });
+
+  it('persists collapsed the same way', () => {
+    const details = byId<HTMLDetailsElement>('answer-tools');
+    details.open = false;
+    details.dispatchEvent(new Event('toggle'));
+
+    expect(setAnswerToolsExpandedMock).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('bootstrapAnswerTools (applies the persisted preference, reattach can override it)', () => {
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+    getAnswerToolsExpandedMock.mockReset();
+    byId<HTMLDetailsElement>('answer-tools').open = false;
+    byId<HTMLButtonElement>('btn-assist').disabled = false;
+  });
+
+  it('defaults to collapsed when no preference has been stored', async () => {
+    getAnswerToolsExpandedMock.mockResolvedValueOnce(false);
+    // No buffered stream — reattach's send() resolves with nothing to reattach.
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answerAssistProgress',
+      text: '',
+      done: true,
+      interrupted: false,
+    });
+    byId<HTMLDetailsElement>('answer-tools').open = true; // start non-default to prove it actually applies
+
+    await bootstrapAnswerTools();
+
+    expect(byId<HTMLDetailsElement>('answer-tools').open).toBe(false);
+  });
+
+  it('applies a persisted "expanded" preference when no stream is buffered', async () => {
+    getAnswerToolsExpandedMock.mockResolvedValueOnce(true);
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answerAssistProgress',
+      text: '',
+      done: true,
+      interrupted: false,
+    });
+
+    await bootstrapAnswerTools();
+
+    expect(byId<HTMLDetailsElement>('answer-tools').open).toBe(true);
+  });
+
+  it('auto-expands even over a persisted "collapsed" preference when a stream is buffered/still running', async () => {
+    getAnswerToolsExpandedMock.mockResolvedValueOnce(false);
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'answerAssistProgress',
+      text: 'Because I ',
+      done: false,
+      interrupted: false,
+    });
+
+    await bootstrapAnswerTools();
+
+    expect(byId<HTMLDetailsElement>('answer-tools').open).toBe(true);
+    expect(byId<HTMLParagraphElement>('assist-draft').textContent).toBe('Because I ');
+  });
+});
+
+// ── unpair (#btn-unpair, now reachable via the "?" help popover) ────────────
+// Moved off the import view's standing row in popup.html — the click handler
+// itself is unchanged/unaffected by that relocation.
+
+describe('unpair (#btn-unpair)', () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it('clears the token and returns to the pairing view', async () => {
+    sendMessageMock.mockReset();
+    sendMessageMock
+      .mockResolvedValueOnce({ ok: true, kind: 'token' }) // clearToken
+      .mockResolvedValueOnce({
+        ok: true,
+        kind: 'status',
+        status: { phase: 'not_paired', port: 1, hasToken: false },
+      });
+    byId<HTMLElement>('view-pair').hidden = true;
+
+    byId<HTMLButtonElement>('btn-unpair').click();
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenCalledWith({ kind: 'clearToken' });
+    expect(byId<HTMLElement>('view-pair').hidden).toBe(false);
   });
 });

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -88,7 +88,9 @@ function buildPopupDom(): void {
     <p id="applied-status" hidden></p>
     <input id="chk-applied" type="checkbox" />
     <p id="import-msg"></p>
-    <button id="btn-unpair"></button>
+    <div id="unpair-group" hidden>
+      <button id="btn-unpair"></button>
+    </div>
     <input id="token-input" type="text" />
     <p id="pair-msg"></p>
     <button id="btn-save-token"></button>
@@ -2912,8 +2914,13 @@ describe('bootstrapAnswerTools (applies the persisted preference, reattach can o
 // Moved off the import view's standing row in popup.html — the click handler
 // itself is unchanged/unaffected by that relocation.
 
-describe('unpair (#btn-unpair)', () => {
+describe('unpair (#btn-unpair, #unpair-group hasToken-gated)', () => {
   const flush = () => new Promise((r) => setTimeout(r, 0));
+  const statusListener = vi.mocked(browser.runtime.onMessage.addListener).mock.calls[0]?.[0] as
+    ((message: unknown) => void) | undefined;
+  if (!statusListener) throw new Error('onMessage status listener not registered');
+  const push = (hasToken: boolean, phase: ConnectionStatus['phase'] = 'not_paired') =>
+    statusListener({ ok: true, kind: 'status', status: { phase, port: null, hasToken } });
 
   it('clears the token and returns to the pairing view', async () => {
     sendMessageMock.mockReset();
@@ -2931,5 +2938,16 @@ describe('unpair (#btn-unpair)', () => {
 
     expect(sendMessageMock).toHaveBeenCalledWith({ kind: 'clearToken' });
     expect(byId<HTMLElement>('view-pair').hidden).toBe(false);
+  });
+
+  it('shows the "Unpair this device" group only while a pairing token is stored', () => {
+    push(false);
+    expect(byId<HTMLElement>('unpair-group').hidden).toBe(true);
+
+    push(true, 'connected');
+    expect(byId<HTMLElement>('unpair-group').hidden).toBe(false);
+
+    push(false, 'app_not_running');
+    expect(byId<HTMLElement>('unpair-group').hidden).toBe(true);
   });
 });

--- a/apps/extension/src/popup/popup.test.ts
+++ b/apps/extension/src/popup/popup.test.ts
@@ -614,24 +614,59 @@ describe('resolveShowMarkAppliedButton', () => {
 // ── resolveFieldsProbeResponse ──────────────────────────────────────────────────
 
 describe('resolveFieldsProbeResponse', () => {
-  it('returns the probe result when ok with kind=fieldsProbe (fields found)', () => {
-    const res = { ok: true as const, kind: 'fieldsProbe' as const, hasFields: true };
-    expect(resolveFieldsProbeResponse(res)).toBe(true);
+  it('returns both signals when ok with kind=fieldsProbe (fields found)', () => {
+    const res = {
+      ok: true as const,
+      kind: 'fieldsProbe' as const,
+      hasFormFields: true,
+      hasAnswerFields: true,
+    };
+    expect(resolveFieldsProbeResponse(res)).toEqual({
+      showFormGroup: true,
+      showAnswerTools: true,
+    });
   });
 
-  it('returns the probe result when ok with kind=fieldsProbe (no fields)', () => {
-    const res = { ok: true as const, kind: 'fieldsProbe' as const, hasFields: false };
-    expect(resolveFieldsProbeResponse(res)).toBe(false);
+  it('returns both signals when ok with kind=fieldsProbe (no fields at all)', () => {
+    const res = {
+      ok: true as const,
+      kind: 'fieldsProbe' as const,
+      hasFormFields: false,
+      hasAnswerFields: false,
+    };
+    expect(resolveFieldsProbeResponse(res)).toEqual({
+      showFormGroup: false,
+      showAnswerTools: false,
+    });
   });
 
-  it('fails OPEN (true) on a transport-level ok:false', () => {
+  it('splits the two signals independently (identity-only form: Form group visible, Answer tools hidden)', () => {
+    const res = {
+      ok: true as const,
+      kind: 'fieldsProbe' as const,
+      hasFormFields: true,
+      hasAnswerFields: false,
+    };
+    expect(resolveFieldsProbeResponse(res)).toEqual({
+      showFormGroup: true,
+      showAnswerTools: false,
+    });
+  });
+
+  it('fails OPEN (both true) on a transport-level ok:false', () => {
     const res = { ok: false as const, error: 'message channel closed' };
-    expect(resolveFieldsProbeResponse(res)).toBe(true);
+    expect(resolveFieldsProbeResponse(res)).toEqual({
+      showFormGroup: true,
+      showAnswerTools: true,
+    });
   });
 
-  it('fails OPEN (true) for an unexpected response kind', () => {
+  it('fails OPEN (both true) for an unexpected response kind', () => {
     const res = { ok: true as const, kind: 'token' as const };
-    expect(resolveFieldsProbeResponse(res)).toBe(true);
+    expect(resolveFieldsProbeResponse(res)).toEqual({
+      showFormGroup: true,
+      showAnswerTools: true,
+    });
   });
 });
 
@@ -1223,9 +1258,12 @@ describe('fieldsProbe auto-check (Form group + Answer-tools gating)', () => {
   });
 
   it('shows the Form group + Answer-tools disclosure when the probe finds fillable fields', async () => {
-    sendMessageMock
-      .mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK)
-      .mockResolvedValueOnce({ ok: true, kind: 'fieldsProbe', hasFields: true });
+    sendMessageMock.mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK).mockResolvedValueOnce({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: true,
+      hasAnswerFields: true,
+    });
 
     push('connected');
     await flush();
@@ -1234,15 +1272,33 @@ describe('fieldsProbe auto-check (Form group + Answer-tools gating)', () => {
     expect(byId<HTMLDetailsElement>('answer-tools').hidden).toBe(false);
   });
 
-  it('hides the Form group + Answer-tools disclosure when the probe finds no fillable fields', async () => {
-    sendMessageMock
-      .mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK)
-      .mockResolvedValueOnce({ ok: true, kind: 'fieldsProbe', hasFields: false });
+  it('hides the Form group + Answer-tools disclosure when the probe finds no fillable fields at all', async () => {
+    sendMessageMock.mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK).mockResolvedValueOnce({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: false,
+      hasAnswerFields: false,
+    });
 
     push('connected');
     await flush();
 
     expect(byId<HTMLElement>('group-form').hidden).toBe(true);
+    expect(byId<HTMLDetailsElement>('answer-tools').hidden).toBe(true);
+  });
+
+  it('shows the Form group but hides Answer tools for an IDENTITY-ONLY form (name/email/phone) — the union vs. narrower-signal split', async () => {
+    sendMessageMock.mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK).mockResolvedValueOnce({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: true, // hasAutofillableFields matched name/email/phone
+      hasAnswerFields: false, // hasAnswerCapturableFields excludes identity fields
+    });
+
+    push('connected');
+    await flush();
+
+    expect(byId<HTMLElement>('group-form').hidden).toBe(false);
     expect(byId<HTMLDetailsElement>('answer-tools').hidden).toBe(true);
   });
 
@@ -1259,9 +1315,12 @@ describe('fieldsProbe auto-check (Form group + Answer-tools gating)', () => {
   });
 
   it('re-shows both groups on a fresh page after a previous page hid them (no stale hide across a reconnect)', async () => {
-    sendMessageMock
-      .mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK)
-      .mockResolvedValueOnce({ ok: true, kind: 'fieldsProbe', hasFields: false });
+    sendMessageMock.mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK).mockResolvedValueOnce({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: false,
+      hasAnswerFields: false,
+    });
     push('connected');
     await flush();
     expect(byId<HTMLElement>('group-form').hidden).toBe(true);
@@ -1271,12 +1330,46 @@ describe('fieldsProbe auto-check (Form group + Answer-tools gating)', () => {
     push('app_not_running');
     expect(byId<HTMLElement>('group-form').hidden).toBe(false);
 
-    sendMessageMock
-      .mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK)
-      .mockResolvedValueOnce({ ok: true, kind: 'fieldsProbe', hasFields: true });
+    sendMessageMock.mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK).mockResolvedValueOnce({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: true,
+      hasAnswerFields: true,
+    });
     push('connected');
     await flush();
     expect(byId<HTMLElement>('group-form').hidden).toBe(false);
+  });
+
+  it('a stale hasFields:false response that resolves AFTER leaving connected must not hide the groups again (generation invalidated on disconnect)', async () => {
+    // The probe starts on entering `connected` but its response never
+    // resolves yet (simulates it still being in flight when the user
+    // disconnects before it settles).
+    let resolveProbe: ((res: unknown) => void) | undefined;
+    const pendingProbe = new Promise((resolve) => {
+      resolveProbe = resolve;
+    });
+    sendMessageMock.mockResolvedValueOnce(NEUTRAL_APPLIED_CHECK).mockReturnValueOnce(pendingProbe);
+    push('connected');
+    await flush();
+    expect(byId<HTMLElement>('group-form').hidden).toBe(false);
+
+    // Leave `connected` BEFORE the probe resolves — this must invalidate it.
+    push('app_not_running');
+    expect(byId<HTMLElement>('group-form').hidden).toBe(false);
+    expect(byId<HTMLDetailsElement>('answer-tools').hidden).toBe(false);
+
+    // The stale probe finally resolves as "no fields" — must be a no-op now.
+    resolveProbe?.({
+      ok: true,
+      kind: 'fieldsProbe',
+      hasFormFields: false,
+      hasAnswerFields: false,
+    });
+    await flush();
+
+    expect(byId<HTMLElement>('group-form').hidden).toBe(false);
+    expect(byId<HTMLDetailsElement>('answer-tools').hidden).toBe(false);
   });
 });
 

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -536,6 +536,7 @@ const els = {
   appliedStatus: byId<HTMLParagraphElement>('applied-status'),
   chkApplied: byId<HTMLInputElement>('chk-applied'),
   importMsg: byId<HTMLParagraphElement>('import-msg'),
+  unpairGroup: byId<HTMLElement>('unpair-group'),
   btnUnpair: byId<HTMLButtonElement>('btn-unpair'),
   tokenInput: byId<HTMLInputElement>('token-input'),
   pairMsg: byId<HTMLParagraphElement>('pair-msg'),
@@ -692,6 +693,9 @@ function showView(phase: ConnectionStatus['phase']): void {
 
 function render(status: ConnectionStatus): void {
   lastKnownHasToken = status.hasToken;
+  // The help popover is global (not scoped to any one view/phase) — only show
+  // "Unpair this device" while there is actually something to unpair.
+  els.unpairGroup.hidden = !status.hasToken;
 
   if (status.phase === 'connected') {
     // Fire-and-forget, on each transition INTO connected (never on a repeated

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -14,7 +14,7 @@ import type { ExtensionAnswerSuggestion, ExtensionRewritePreset } from '@ajh/sha
 
 import type { FilledField, ScannedQuestion } from '../lib/answers-capture';
 import type { ConnectionStatus, PopupRequest, PopupResponse } from '../lib/messages';
-import { looksLikeToken } from '../lib/storage';
+import { getAnswerToolsExpanded, looksLikeToken, setAnswerToolsExpanded } from '../lib/storage';
 
 import './popup.css';
 
@@ -180,6 +180,20 @@ export function resolveShowMarkAppliedButton(res: PopupResponse): boolean {
   const { result } = res;
   if (result.error || !result.found) return false;
   return result.status === 'saved';
+}
+
+/**
+ * Given a `fieldsProbe` response, whether the Form group + Answer-tools
+ * disclosure should be shown. Fails OPEN (`true`) on a transport-level
+ * `ok:false` or an unexpected `kind` — mirrors the background's own
+ * fail-open fold (`runFieldsProbe`) so a probe bug can never hide those
+ * features; only a CONFIRMED `hasFields:false` hides them.
+ *
+ * Pure: no DOM access, no side effects.
+ */
+export function resolveFieldsProbeResponse(res: PopupResponse): boolean {
+  if (!res.ok || res.kind !== 'fieldsProbe') return true;
+  return res.hasFields;
 }
 
 /**
@@ -496,6 +510,8 @@ const els = {
   btnImport: byId<HTMLButtonElement>('btn-import'),
   btnFill: byId<HTMLButtonElement>('btn-fill'),
   btnMarkApplied: byId<HTMLButtonElement>('btn-mark-applied'),
+  groupForm: byId<HTMLElement>('group-form'),
+  answerTools: byId<HTMLDetailsElement>('answer-tools'),
   btnSaveAnswers: byId<HTMLButtonElement>('btn-save-answers'),
   btnSuggestAnswers: byId<HTMLButtonElement>('btn-suggest-answers'),
   suggestionsList: byId<HTMLDivElement>('suggestions-list'),
@@ -509,6 +525,7 @@ const els = {
   assistDraft: byId<HTMLParagraphElement>('assist-draft'),
   btnCopyAssist: byId<HTMLButtonElement>('btn-copy-assist'),
   rewritePicker: byId<HTMLSelectElement>('rewrite-picker'),
+  rewritePreset: byId<HTMLSelectElement>('rewrite-preset'),
   rewriteInstruction: byId<HTMLInputElement>('rewrite-instruction'),
   btnRewrite: byId<HTMLButtonElement>('btn-rewrite'),
   rewriteResult: byId<HTMLDivElement>('rewrite-result'),
@@ -653,6 +670,14 @@ async function send(req: PopupRequest): Promise<PopupResponse> {
   return res;
 }
 
+/** Toggle the Form group + Answer-tools disclosure together — both gated on
+ *  the SAME "does this page have fillable fields?" probe (see
+ *  `runFieldsProbeCheck`). */
+function setToolGroupsVisible(visible: boolean): void {
+  els.groupForm.hidden = !visible;
+  els.answerTools.hidden = !visible;
+}
+
 function showView(phase: ConnectionStatus['phase']): void {
   els.views.import.hidden = phase !== 'connected';
   // Show the pairing view for both not_paired and bad_token — the user must
@@ -674,6 +699,7 @@ function render(status: ConnectionStatus): void {
     // this render.
     if (lastRenderedPhase !== 'connected') {
       void runAppliedAutoCheck();
+      void runFieldsProbeCheck();
     }
   } else {
     // Left (or never entered) `connected` — clear any status line/button label
@@ -704,6 +730,10 @@ function render(status: ConnectionStatus): void {
     els.rewriteResult.hidden = true;
     els.rewriteDraft.textContent = '';
     els.rewriteInstruction.value = '';
+    els.rewritePreset.value = '';
+    // A stale "no fields on the previous page" hide must never linger onto a
+    // fresh page before its own probe resolves — default open/visible again.
+    setToolGroupsVisible(true);
   }
   lastRenderedPhase = status.phase;
 
@@ -868,6 +898,35 @@ async function runAppliedAutoCheck(): Promise<void> {
     els.btnImport.textContent = IMPORT_LABEL_DEFAULT;
     els.btnMarkApplied.hidden = true;
     els.btnMarkApplied.disabled = false;
+  }
+}
+
+/**
+ * Generation guard for {@link runFieldsProbeCheck} — mirrors
+ * `appliedCheckGeneration` exactly (same stale-response race the applied
+ * auto-check already guards against).
+ */
+let fieldsProbeGeneration = 0;
+
+/**
+ * Run the fire-and-forget "does this page have fillable form fields?" probe
+ * on entering `connected` and gate the Form group + Answer-tools disclosure
+ * on the result. `runFieldsProbe` in background.ts already folds every
+ * failure (no active tab, restricted page, scripting denied) into
+ * `hasFields:true` (fail OPEN), so the catch here only guards a
+ * transport-level rejection (message-channel closed) — either way this never
+ * hides the groups on a probe bug, only on a confirmed empty scan.
+ */
+async function runFieldsProbeCheck(): Promise<void> {
+  fieldsProbeGeneration += 1;
+  const myGeneration = fieldsProbeGeneration;
+  try {
+    const res = await send({ kind: 'fieldsProbe' });
+    if (myGeneration !== fieldsProbeGeneration) return;
+    setToolGroupsVisible(resolveFieldsProbeResponse(res));
+  } catch {
+    if (myGeneration !== fieldsProbeGeneration) return;
+    setToolGroupsVisible(true);
   }
 }
 
@@ -1046,7 +1105,7 @@ function buildSuggestionRow(item: RenderedSuggestion): HTMLElement {
 
   const copyBtn = document.createElement('button');
   copyBtn.type = 'button';
-  copyBtn.className = 'btn btn--small';
+  copyBtn.className = 'btn btn--small btn--quiet';
   copyBtn.textContent = 'Copy';
   copyBtn.addEventListener('click', () => void doCopySuggestion(suggestion.answer, copyBtn));
   actions.append(copyBtn);
@@ -1056,7 +1115,7 @@ function buildSuggestionRow(item: RenderedSuggestion): HTMLElement {
   if (!suggestion.salary && fieldIndex !== null) {
     const fillBtn = document.createElement('button');
     fillBtn.type = 'button';
-    fillBtn.className = 'btn btn--small btn--primary';
+    fillBtn.className = 'btn btn--small btn--quiet';
     fillBtn.textContent = 'Fill this field';
     fillBtn.addEventListener(
       'click',
@@ -1581,11 +1640,11 @@ function wire(): void {
   els.btnAssist.addEventListener('click', () => void doAssist());
   els.btnCopyAssist.addEventListener('click', () => void doCopyAssistDraft());
   els.rewritePicker.addEventListener('change', onRewritePickerChange);
-  document.querySelectorAll<HTMLButtonElement>('.rewrite-presets [data-preset]').forEach((btn) => {
-    btn.addEventListener(
-      'click',
-      () => void doRewrite(btn.dataset.preset as ExtensionRewritePreset)
-    );
+  els.rewritePreset.addEventListener('change', () => {
+    const preset = els.rewritePreset.value;
+    if (!preset) return;
+    void doRewrite(preset as ExtensionRewritePreset);
+    els.rewritePreset.value = '';
   });
   els.btnRewrite.addEventListener('click', () => void doRewrite());
   els.btnCopyRewrite.addEventListener('click', () => void doCopyRewriteDraft());
@@ -1603,6 +1662,14 @@ function wire(): void {
   // serves the latest build) to update their app.
   els.btnUpdateApp.addEventListener('click', () => void getApp());
   els.btnHelp.addEventListener('click', toggleHelp);
+  // Persist the Answer-tools expand/collapse preference across popup opens —
+  // a UI boolean only, not PII/job data. Fires on BOTH a user click on the
+  // <summary> and a programmatic `.open` set (e.g. the stream-reattach
+  // auto-expand), per the `toggle` event's spec — that is fine here, the
+  // stored preference is just "what state it was last left in".
+  els.answerTools.addEventListener('toggle', () => {
+    void setAnswerToolsExpanded(els.answerTools.open);
+  });
 
   // Live status pushes from the background while the popup is open.
   browser.runtime.onMessage.addListener((message: unknown) => {
@@ -1666,6 +1733,10 @@ async function reattachAssistProgress(): Promise<void> {
     els.btnAssist.disabled = !res.done;
     const view = resolveAssistProgressView(res);
     if (view.draft === null) return;
+    // A buffered/still-streaming draft exists from before this popup opened —
+    // auto-expand the Answer-tools disclosure so it's visible (never leave the
+    // user hunting for a result they already started).
+    els.answerTools.open = true;
     els.assistDraft.textContent = view.draft;
     els.assistResult.hidden = false;
     if (view.tone === 'err') setMsg(els.importMsg, view.text, 'err');
@@ -1674,6 +1745,25 @@ async function reattachAssistProgress(): Promise<void> {
   }
 }
 
+/**
+ * Apply the persisted Answer-tools expand/collapse preference, THEN check for
+ * a reattachable stream — in that order, so an active/buffered draft (which
+ * always wins) is never immediately re-collapsed by a stale "collapsed"
+ * preference applied after it.
+ *
+ * Exported (unlike the other `do*`/render helpers) because nothing wires a
+ * user click to re-run this bootstrap — it only ever runs once, automatically,
+ * at popup load — so it has no other seam for tests to drive it directly.
+ */
+export async function bootstrapAnswerTools(): Promise<void> {
+  try {
+    els.answerTools.open = await getAnswerToolsExpanded();
+  } catch {
+    // Best-effort — a storage read hiccup just keeps the collapsed default.
+  }
+  await reattachAssistProgress();
+}
+
 wire();
 void refreshStatusWithTimeout();
-void reattachAssistProgress();
+void bootstrapAnswerTools();

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -182,18 +182,35 @@ export function resolveShowMarkAppliedButton(res: PopupResponse): boolean {
   return result.status === 'saved';
 }
 
+/** Whether the Form group + the Answer-tools disclosure should each be
+ *  shown — see {@link resolveFieldsProbeResponse}. */
+export interface FieldsProbeView {
+  showFormGroup: boolean;
+  showAnswerTools: boolean;
+}
+
 /**
- * Given a `fieldsProbe` response, whether the Form group + Answer-tools
- * disclosure should be shown. Fails OPEN (`true`) on a transport-level
- * `ok:false` or an unexpected `kind` — mirrors the background's own
- * fail-open fold (`runFieldsProbe`) so a probe bug can never hide those
- * features; only a CONFIRMED `hasFields:false` hides them.
+ * Given a `fieldsProbe` response, whether the Form group and the
+ * Answer-tools disclosure should each be shown. Fails OPEN (`true` for both)
+ * on a transport-level `ok:false` or an unexpected `kind` — mirrors the
+ * background's own fail-open fold (`runFieldsProbe`) so a probe bug can
+ * never hide either feature; only a CONFIRMED `false` signal hides one.
+ *
+ * The two booleans are NOT the same gate: `hasFormFields` is the union of
+ * autofill-supported identity fields and answer-capturable non-identity
+ * fields (so "Fill this form" still shows on an identity-only form, e.g.
+ * name/email/phone), while `hasAnswerFields` is the narrower
+ * answer-capturable-only signal the Answer-tools disclosure uses (Suggest/
+ * rewrite have nothing to act on from identity fields alone) — see
+ * `PopupResponse`'s `fieldsProbe` doc.
  *
  * Pure: no DOM access, no side effects.
  */
-export function resolveFieldsProbeResponse(res: PopupResponse): boolean {
-  if (!res.ok || res.kind !== 'fieldsProbe') return true;
-  return res.hasFields;
+export function resolveFieldsProbeResponse(res: PopupResponse): FieldsProbeView {
+  if (!res.ok || res.kind !== 'fieldsProbe') {
+    return { showFormGroup: true, showAnswerTools: true };
+  }
+  return { showFormGroup: res.hasFormFields, showAnswerTools: res.hasAnswerFields };
 }
 
 /**
@@ -671,12 +688,12 @@ async function send(req: PopupRequest): Promise<PopupResponse> {
   return res;
 }
 
-/** Toggle the Form group + Answer-tools disclosure together — both gated on
- *  the SAME "does this page have fillable fields?" probe (see
- *  `runFieldsProbeCheck`). */
-function setToolGroupsVisible(visible: boolean): void {
-  els.groupForm.hidden = !visible;
-  els.answerTools.hidden = !visible;
+/** Toggle the Form group + Answer-tools disclosure — each on its OWN signal
+ *  (see {@link FieldsProbeView}'s doc for why they differ), driven by the
+ *  fields probe (`runFieldsProbeCheck`). */
+function setToolGroupsVisible(view: FieldsProbeView): void {
+  els.groupForm.hidden = !view.showFormGroup;
+  els.answerTools.hidden = !view.showAnswerTools;
 }
 
 function showView(phase: ConnectionStatus['phase']): void {
@@ -735,9 +752,15 @@ function render(status: ConnectionStatus): void {
     els.rewriteDraft.textContent = '';
     els.rewriteInstruction.value = '';
     els.rewritePreset.value = '';
+    // Invalidate any in-flight fieldsProbe BEFORE resetting visibility: a
+    // pending `hasFields:false` from the page just left could otherwise
+    // resolve AFTER this reset and hide the groups again in a phase that was
+    // never gated on it (e.g. after a disconnect) — bumping the generation
+    // makes runFieldsProbeCheck's own resolved-response branch a no-op.
+    fieldsProbeGeneration += 1;
     // A stale "no fields on the previous page" hide must never linger onto a
     // fresh page before its own probe resolves — default open/visible again.
-    setToolGroupsVisible(true);
+    setToolGroupsVisible({ showFormGroup: true, showAnswerTools: true });
   }
   lastRenderedPhase = status.phase;
 
@@ -915,11 +938,12 @@ let fieldsProbeGeneration = 0;
 /**
  * Run the fire-and-forget "does this page have fillable form fields?" probe
  * on entering `connected` and gate the Form group + Answer-tools disclosure
- * on the result. `runFieldsProbe` in background.ts already folds every
- * failure (no active tab, restricted page, scripting denied) into
- * `hasFields:true` (fail OPEN), so the catch here only guards a
- * transport-level rejection (message-channel closed) — either way this never
- * hides the groups on a probe bug, only on a confirmed empty scan.
+ * on the result (each on its own signal — see {@link resolveFieldsProbeResponse}).
+ * `runFieldsProbe` in background.ts already folds every failure (no active
+ * tab, restricted page, scripting denied) into both signals `true` (fail
+ * OPEN), so the catch here only guards a transport-level rejection
+ * (message-channel closed) — either way this never hides a group on a probe
+ * bug, only on a confirmed empty scan.
  */
 async function runFieldsProbeCheck(): Promise<void> {
   fieldsProbeGeneration += 1;
@@ -930,7 +954,7 @@ async function runFieldsProbeCheck(): Promise<void> {
     setToolGroupsVisible(resolveFieldsProbeResponse(res));
   } catch {
     if (myGeneration !== fieldsProbeGeneration) return;
-    setToolGroupsVisible(true);
+    setToolGroupsVisible({ showFormGroup: true, showAnswerTools: true });
   }
 }
 

--- a/apps/extension/src/probe-fields.ts
+++ b/apps/extension/src/probe-fields.ts
@@ -1,0 +1,21 @@
+/**
+ * Fillable-fields probe, injected entry (compiled to `probe-fields.js`).
+ *
+ * Injected via `chrome.scripting.executeScript({ files: ['probe-fields.js'] })`
+ * when the popup's connected view opens — single-step, mirroring
+ * `capture-questions.ts`'s pattern (no PII to pass in transiently; it only
+ * reads the page and returns one boolean). Read-only: counts candidate
+ * fields, reads no values.
+ *
+ * Bundled with ZERO `import` statements: `./lib/answers-capture` is inlined
+ * here because this file is built by its OWN isolated Rollup pass — see the
+ * `injectedEntries` plugin in `vite.config.ts` — so it never shares a chunk
+ * with the other injected entries.
+ */
+
+import { hasFillableFields } from './lib/answers-capture';
+
+// ── injected-execution entry-point ────────────────────────────────────────────
+// Completion value returned to executeScript → background (mirrors
+// capture-questions.ts: the IIFE's return value is the last statement's value).
+(() => hasFillableFields(document))();

--- a/apps/extension/src/probe-fields.ts
+++ b/apps/extension/src/probe-fields.ts
@@ -4,18 +4,38 @@
  * Injected via `chrome.scripting.executeScript({ files: ['probe-fields.js'] })`
  * when the popup's connected view opens — single-step, mirroring
  * `capture-questions.ts`'s pattern (no PII to pass in transiently; it only
- * reads the page and returns one boolean). Read-only: counts candidate
+ * reads the page and returns two booleans). Read-only: counts candidate
  * fields, reads no values.
  *
- * Bundled with ZERO `import` statements: `./lib/answers-capture` is inlined
- * here because this file is built by its OWN isolated Rollup pass — see the
- * `injectedEntries` plugin in `vite.config.ts` — so it never shares a chunk
- * with the other injected entries.
+ * Combines TWO independent signals (deliberately different — see each
+ * function's own doc):
+ *  - `hasFormFields` — the UNION of `hasAutofillableFields` (identity fields
+ *    Fill can use) and `hasAnswerCapturableFields` (non-identity fields Save
+ *    can capture). Gates the popup's Form group ("Fill this form" / "Save my
+ *    answers"): a page with ONLY name/email/phone fields still has plenty
+ *    for Fill to do, even though it has nothing Save/Suggest/Rewrite can act
+ *    on.
+ *  - `hasAnswerFields` — `hasAnswerCapturableFields` alone. Gates the
+ *    Answer-tools disclosure (Suggest/rewrite have nothing to act on without
+ *    a non-identity field, so the union would be too permissive there).
+ *
+ * Bundled with ZERO `import` statements: `./lib/answers-capture` and
+ * `./lib/autofill` are inlined here because this file is built by its OWN
+ * isolated Rollup pass — see the `injectedEntries` plugin in
+ * `vite.config.ts` — so it never shares a chunk with the other injected
+ * entries.
  */
 
-import { hasFillableFields } from './lib/answers-capture';
+import { hasAnswerCapturableFields } from './lib/answers-capture';
+import { hasAutofillableFields } from './lib/autofill';
 
 // ── injected-execution entry-point ────────────────────────────────────────────
 // Completion value returned to executeScript → background (mirrors
 // capture-questions.ts: the IIFE's return value is the last statement's value).
-(() => hasFillableFields(document))();
+(() => {
+  const hasAnswerFields = hasAnswerCapturableFields(document);
+  return {
+    hasFormFields: hasAnswerFields || hasAutofillableFields(document),
+    hasAnswerFields,
+  };
+})();

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -49,8 +49,9 @@ function webExtensionAssets(): Plugin {
 /**
  * `fill.ts` (assisted autofill), `capture.ts` (answers capture),
  * `capture-questions.ts` (questions-mode collector), `answer-fill.ts`
- * (single-field answer fill), and `answer-replace.ts` (single-field answer
- * REPLACE, extension PR 11's rewrite Accept/Restore) are ALL injected via
+ * (single-field answer fill), `answer-replace.ts` (single-field answer
+ * REPLACE, extension PR 11's rewrite Accept/Restore), and `probe-fields.ts`
+ * (the popup's fillable-fields probe) are ALL injected via
  * `chrome.scripting.executeScript({ files: [...] })`, which runs as a CLASSIC
  * script (no ES modules) — so each compiled bundle must carry ZERO `import`
  * statements. Since PR 5 of the extension roadmap, they genuinely share
@@ -85,6 +86,7 @@ function injectedEntries(): Plugin {
         'answer-fill',
         'answer-replace',
         'submit-watch',
+        'probe-fields',
       ]) {
         await build({
           configFile: false,


### PR DESCRIPTION
## Summary

**Popup de-crowding restructure** (user-requested). The connected view had accreted ~15 always-rendered controls across 11 feature PRs — every button equal weight, both AI panels permanently expanded, no awareness of what page you're on. This PR regroups it by job-to-be-done and makes it context-aware. No new permissions, no manifest change, no bridge/protocol change, no desktop change.

## What changed

- **Three real sections** replace the flat stack: **Job** (Import · Check fit · already-applied · mark-applied), **Form** (Fill this form · Save my answers), **Answer tools** (Suggest · AI draft · AI rewrite) — the last collapsed in a native `<details>` (persisted preference; auto-expands only when a buffered/live AI stream re-attaches on reopen).
- **Passive context probe:** on entering `connected`, one read-only injected scan (the same field-detection gates Save-answers already uses — reads zero values, returns a boolean) decides whether the Form group + Answer tools render at all. A pure job page now shows a calm two-block popup. **Fails open** on every error path (no-tab, restricted page, malformed, transport) so a probe bug can never lock features away — each path unit-tested, and `fieldsProbe` is pinned as a non-gesture (can never arm the submit-watcher).
- **Visual tier:** one raised primary CTA per context (Import / Fill / Save & pair / Get app / rewrite-Accept); everything else `btn--quiet` with a dedicated dark-mode border token (≈3.3:1 — the first cut reused a token that landed at 1.05:1, caught in review); the 5 rewrite preset buttons became a labeled `<select>` (same wire ids); dashed borders now only mark the pairing-token input; group dividers with their own dark-mode alpha.
- **Unpair** moved into the "?" popover, rendered only when a token exists, with a "Reset pairing" sub-label.
- Reduced-motion covers the new chevron; the preset select's accessible name matches its visible label (WCAG 2.5.3).

## Review trail

extension-reviewer **PASS** (probe verified read-only + boolean-only + activeTab-scoped under the popup-open gesture; store-policy posture unchanged; MV3 classic-script discipline; Firefox `data_collection_permissions` untouched). ui-ux-expert BLOCK→resolved: 3 HIGH (dark-mode quiet-button contrast, reduced-motion gap, label-in-name) + 3 MEDIUM (divider alpha, Accept demotion, unpair gating) — all fixed with regression tests.

## Test plan

`pnpm -F @ajh/extension test` **469** (probe gating incl. fail-open paths, details persistence + stream auto-expand, unpair phase/hasToken gating, preset-select wire parity, non-gesture pin) · typecheck · lint · both browser builds (`popup.*` byte-identical Chrome/Firefox; manifest diff = the pre-existing platform divergence only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Form and Answer tools are now shown based on whether the current page contains fillable fields.
  - Answer tools expansion state is remembered between sessions.
  - In-progress answer tool drafts automatically reopen when appropriate.
  - Added clearer help and unpair controls, plus reorganized Job and Form sections.
  - Rewrite options now use streamlined dropdown selectors.

- **Bug Fixes**
  - Form-related controls remain visible when page checks fail, preventing accidental hiding.
  - Improved popup state handling when reconnecting or switching pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->