### PR TITLE
feat: use dom_smoothie readability pass in scrape_url generic extraction fallback

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "criterion",
  "dbus-secret-service-keyring-store",
  "docx-rs",
+ "dom_smoothie",
  "encoding_rs",
  "feed-rs",
  "flate2",
@@ -2108,6 +2109,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "dom_query"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac5fca71e65e94cc718a6e2af65d6e0f9c6027751c2aa562fbb5087fda639bc"
+dependencies = [
+ "bit-set",
+ "cssparser 0.37.0",
+ "foldhash 0.2.0",
+ "html5ever 0.39.0",
+ "nom 8.0.0",
+ "precomputed-hash",
+ "selectors 0.38.0",
+ "tendril",
+]
+
+[[package]]
+name = "dom_smoothie"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8b9b294aabb8010b37c49a07d6f82175152f4927855d534979a38737721875"
+dependencies = [
+ "dom_query 0.28.0",
+ "flagset",
+ "foldhash 0.2.0",
+ "gjson",
+ "html-escape",
+ "once_cell",
+ "phf",
+ "tendril",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2550,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -2986,6 +3027,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gjson"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43503cc176394dd30a6525f5f36e838339b8b5619be33ed9a7783841580a97b6"
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,6 +3491,12 @@ dependencies = [
  "markup5ever_rcdom",
  "phf",
 ]
+
+[[package]]
+name = "html-escape"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
 
 [[package]]
 name = "html5ever"
@@ -8277,7 +8330,7 @@ dependencies = [
  "brotli",
  "cargo_metadata",
  "ctor",
- "dom_query",
+ "dom_query 0.27.0",
  "dunce",
  "glob",
  "http",
@@ -10721,7 +10774,7 @@ dependencies = [
  "cookie",
  "crossbeam-channel",
  "dirs 6.0.0",
- "dom_query",
+ "dom_query 0.27.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -183,6 +183,13 @@ sha2 = "0.11"
 # 0.12.1 is already resolved in the lock and shares digest 0.10 with sha2 0.10.
 hmac = "0.13"
 htmd = "0.5.4"
+# Real readability pass for `scraping::scrape_url`'s generic-HTML last resort:
+# a faithful Rust port of Mozilla's Readability.js (used by Firefox Reader
+# View). MIT-licensed. Replaces the old whole-document largest-`main`/
+# `article`-block guess as the higher-precision fallback when neither the
+# extension hint nor JSON-LD `JobPosting` matched — the guess itself stays as
+# the final fallback below it.
+dom_smoothie = "0.18"
 
 # IMAP client for email-confirmation watching (task #23, opt-in, default OFF —
 # `email_watch`). `native-tls` (the crate's default), NOT `rustls-tls`: the

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -185,10 +185,11 @@ hmac = "0.13"
 htmd = "0.5.4"
 # Real readability pass for `scraping::scrape_url`'s generic-HTML last resort:
 # a faithful Rust port of Mozilla's Readability.js (used by Firefox Reader
-# View). MIT-licensed. Replaces the old whole-document largest-`main`/
-# `article`-block guess as the higher-precision fallback when neither the
-# extension hint nor JSON-LD `JobPosting` matched — the guess itself stays as
-# the final fallback below it.
+# View). Replaces the old whole-document largest-`main`/`article`-block guess
+# as the higher-precision fallback when neither the extension hint nor
+# JSON-LD `JobPosting` matched — the guess itself stays as the final fallback
+# below it. MIT-licensed — permitted under deny.toml's `[licenses] allow`
+# list, enforced by CI's `cargo deny check`.
 dom_smoothie = "0.18"
 
 # IMAP client for email-confirmation watching (task #23, opt-in, default OFF —

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
@@ -514,19 +514,25 @@ pub fn parse_from_html(url: &str, html: &str) -> Option<JobPosting> {
         }
     }
 
-    // Main-content text as a last-resort description — SKIPPED when the hint
-    // already supplied a real title. `job_root_generic_html` scopes its own
+    // Whole-document last-resort description — SKIPPED when the hint already
+    // supplied a real title. `job_root_generic_html` scopes its own
     // description search to that same hinted subtree, so if it honestly found
     // no body text there (a title-only hint — e.g. the real description
     // renders client-side in an ATS iframe the outerHTML capture can't see),
-    // escalating to a whole-DOCUMENT largest-block guess risks landing on an
-    // unrelated block (e.g. a bigger related-jobs sidebar) instead of just
-    // admitting there's no description to show. A hint that yielded NOTHING
-    // (no title either — hostile/mis-marked) carries no signal, so the
-    // whole-document heuristic chain still runs exactly as if there were no
-    // hint at all.
+    // escalating to a whole-DOCUMENT guess risks landing on an unrelated block
+    // (e.g. a bigger related-jobs sidebar) instead of just admitting there's
+    // no description to show. A hint that yielded NOTHING (no title either —
+    // hostile/mis-marked) carries no signal, so the whole-document heuristic
+    // chain still runs exactly as if there were no hint at all.
+    //
+    // Within that chain, `readability_content_text` (a real Mozilla-Readability
+    // port) runs FIRST — it scores/prunes nav, footer, and boilerplate rather
+    // than just picking the largest `main`/`article` block, so it's the
+    // higher-precision guess on a page with no JSON-LD. `main_content_text`'s
+    // largest-block guess stays as the final fallback for when readability's
+    // own pre-check (`is_probably_readable`) or `parse()` comes back empty.
     if description.is_none() && !hint_title_used {
-        description = main_content_text(html);
+        description = readability_content_text(url, html).or_else(|| main_content_text(html));
     }
 
     let host = reqwest::Url::parse(url)
@@ -812,10 +818,60 @@ fn next_data_job(html: &str) -> Option<JsonLdJob> {
     find(&json, 0)
 }
 
-/// Largest main-content text block as a last-resort description: pick the longest
-/// rendered text among `main` / `[role="main"]` / `article`.
-// ponytail: largest-block heuristic, not a Readability port; good enough for ATS
-// detail pages. Upgrade path = a real content-extraction crate if it falls short.
+/// Real-readability last-resort description: run `dom_smoothie` (a faithful
+/// Rust port of Mozilla's Readability.js) over the whole document, so nav/
+/// footer/boilerplate get scored out instead of surviving a naive
+/// largest-block guess. `is_probably_readable()` must run before `parse()`
+/// (it inspects the un-mutated document; `parse()` mutates it) and gates
+/// documents too thin to trust — e.g. a nav-only shell with no real article.
+/// Both the pre-check and `parse()` are best-effort: any `Err` (bad URL,
+/// `max_elements_to_parse` exceeded, no candidate found) falls through to
+/// `None` — the caller then tries `main_content_text` — rather than
+/// propagating, since this is an enrichment, not a hard requirement.
+fn readability_content_text(url: &str, html: &str) -> Option<String> {
+    let cfg = dom_smoothie::Config {
+        // `text_content` becomes ready-to-use markdown straight off the
+        // cleaned readability DOM — skips a second html_to_markdown pass over
+        // `article.content` (which would re-parse already-cleaned HTML).
+        text_mode: dom_smoothie::TextMode::Markdown,
+        // Defense-in-depth against a hostile/huge page: default `0` means
+        // UNLIMITED, letting an attacker-sized document drive an unbounded
+        // multi-pass scoring parse (CPU/peak-memory amplification). 4000 is
+        // comfortably above any real job posting page (dom_smoothie's own
+        // test suite parses a full Wikipedia article — far denser than a job
+        // page — under 10,000 with no false-positive `TooManyElements`)
+        // while still bounding abuse. Tripping the cap returns
+        // `Err(TooManyElements)`, handled by the `Err ⇒ None` arm below —
+        // clean fall-through to `main_content_text`.
+        max_elements_to_parse: 4000,
+        ..Default::default()
+    };
+    let mut readability = match dom_smoothie::Readability::new(html, Some(url), Some(cfg)) {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!("[scraping::scrape_url] dom_smoothie::Readability::new failed: {e}");
+            return None;
+        }
+    };
+    if !readability.is_probably_readable() {
+        return None;
+    }
+    match readability.parse() {
+        Ok(article) => {
+            let text = article.text_content.trim().to_string();
+            (!text.is_empty()).then_some(text)
+        }
+        Err(e) => {
+            log::warn!("[scraping::scrape_url] dom_smoothie parse failed: {e}");
+            None
+        }
+    }
+}
+
+/// Largest main-content text block as a FINAL last-resort description (below
+/// `readability_content_text`): pick the longest rendered text among `main` /
+/// `[role="main"]` / `article`. Kept as the floor for when readability's own
+/// pre-check or `parse()` comes back empty — a naive guess beats nothing.
 fn main_content_text(html: &str) -> Option<String> {
     let doc = Html::parse_document(html);
     let sel = Selector::parse(r#"main, [role="main"], article"#).ok()?;

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
@@ -828,7 +828,19 @@ fn next_data_job(html: &str) -> Option<JsonLdJob> {
 /// `max_elements_to_parse` exceeded, no candidate found) falls through to
 /// `None` — the caller then tries `main_content_text` — rather than
 /// propagating, since this is an enrichment, not a hard requirement.
+// TODO(perf): this runs synchronous CPU parsing on the async executor with no
+// `spawn_blocking` (same as every other rung of `parse_from_html`'s generic-HTML
+// fallback — all use `Html::parse_document`). Deferred: wrap the whole generic
+// fallback in `spawn_blocking` at its async call sites (including the
+// extension-bridge Scan path) — a broader refactor, out of scope here.
 fn readability_content_text(url: &str, html: &str) -> Option<String> {
+    // Host only — never log the raw dom_smoothie error, which can embed the
+    // scraped `url` (see the `host`-only convention at parse_from_html's own
+    // `reqwest::Url::parse` call and the `linkedin` job-id log above).
+    let host = reqwest::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_string))
+        .unwrap_or_default();
     let cfg = dom_smoothie::Config {
         // `text_content` becomes ready-to-use markdown straight off the
         // cleaned readability DOM — skips a second html_to_markdown pass over
@@ -848,8 +860,10 @@ fn readability_content_text(url: &str, html: &str) -> Option<String> {
     };
     let mut readability = match dom_smoothie::Readability::new(html, Some(url), Some(cfg)) {
         Ok(r) => r,
-        Err(e) => {
-            log::warn!("[scraping::scrape_url] dom_smoothie::Readability::new failed: {e}");
+        Err(_) => {
+            log::debug!(
+                "[scraping::scrape_url] dom_smoothie::Readability::new failed for host {host}"
+            );
             return None;
         }
     };
@@ -861,8 +875,8 @@ fn readability_content_text(url: &str, html: &str) -> Option<String> {
             let text = article.text_content.trim().to_string();
             (!text.is_empty()).then_some(text)
         }
-        Err(e) => {
-            log::warn!("[scraping::scrape_url] dom_smoothie parse failed: {e}");
+        Err(_) => {
+            log::debug!("[scraping::scrape_url] dom_smoothie parse failed for host {host}");
             None
         }
     }

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
@@ -1030,6 +1030,67 @@ fn parse_from_html_main_content_description_fallback() {
 }
 
 #[test]
+fn parse_from_html_readability_skips_in_article_decoy_block() {
+    // No JSON-LD, no __NEXT_DATA__, no meta description, no extension hint —
+    // the whole-document last-resort chain runs. The decoy block below is
+    // nested INSIDE the <article> alongside the real job paragraphs — NOT a
+    // <nav>/<footer> sibling — so only Readability's own per-node scoring
+    // (its `UNLIKELY_CANDIDATES` class-pattern strip, matched here by
+    // `class="related sponsor"`) can drop it. `main_content_text`'s selector
+    // (`main, [role="main"], article`) would keep the WHOLE <article>
+    // innerHTML verbatim, decoy included — so this is the case that actually
+    // fails if `readability_content_text` were never wired in.
+    let html = r#"<html><head>
+        <title>Senior Backend Engineer at Acme</title>
+    </head><body>
+        <article>
+            <h1>Senior Backend Engineer</h1>
+            <p>We are looking for a Senior Backend Engineer to join our platform
+            team and help us scale the systems that power millions of requests
+            every day across our global user base. You will design and build
+            resilient distributed systems, own the API platform end to end, and
+            mentor junior engineers on best practices for scalable, reliable
+            architecture and long-term maintainability.</p>
+            <div class="related sponsor">
+                <p>Related Jobs: DevOps Engineer, Site Reliability Engineer,
+                Platform Engineer. Sponsored listings from our partner network.</p>
+            </div>
+            <p>Responsibilities include architecting microservices,
+            collaborating closely with product and design teams on new
+            features, and maintaining our CI/CD pipeline for rapid, safe
+            deployments across every environment we run in production today,
+            including our growing multi-region rollout.</p>
+        </article>
+    </body></html>"#;
+    let posting = parse_from_html("https://acme.example/j/readability-1", html)
+        .expect("a page with a real article body must produce a posting");
+    let desc = posting.description.as_deref().unwrap_or_default();
+    assert!(
+        desc.contains("resilient distributed systems") && desc.contains("architecting microservices"),
+        "description must contain the real job body on both sides of the decoy, got: {desc}"
+    );
+    assert!(
+        !desc.contains("Related Jobs") && !desc.contains("Sponsored listings"),
+        "description must NOT contain the in-article decoy block, got: {desc}"
+    );
+}
+
+#[test]
+fn readability_content_text_returns_none_for_sparse_page() {
+    // A page with too little real content to trust: `is_probably_readable()`
+    // (dom_smoothie's own pre-check, default `min_content_length` 140 chars)
+    // must gate it out BEFORE `parse()` ever runs, so `readability_content_text`
+    // returns `None` — letting `parse_from_html`'s `.or_else(|| main_content_text(html))`
+    // fall through cleanly instead of readability guessing at a too-thin document.
+    let html = r#"<html><body><main><p>Short posting.</p></main></body></html>"#;
+    let result = readability_content_text("https://acme.example/j/sparse", html);
+    assert_eq!(
+        result, None,
+        "a too-thin document must fail the is_probably_readable() gate and yield None, got: {result:?}"
+    );
+}
+
+#[test]
 fn parse_from_html_unparseable_page_has_empty_title() {
     // A page with no title/h1/JSON-LD/__NEXT_DATA__/main yields a posting whose
     // title is empty — so `extension_bridge::usable` would be false and

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/test.rs
@@ -1066,7 +1066,8 @@ fn parse_from_html_readability_skips_in_article_decoy_block() {
         .expect("a page with a real article body must produce a posting");
     let desc = posting.description.as_deref().unwrap_or_default();
     assert!(
-        desc.contains("resilient distributed systems") && desc.contains("architecting microservices"),
+        desc.contains("resilient distributed systems")
+            && desc.contains("architecting microservices"),
         "description must contain the real job body on both sides of the decoy, got: {desc}"
     );
     assert!(


### PR DESCRIPTION
## What

On job pages without JSON-LD (or the extension's DOM hint node), `scrape_url`'s generic extraction fell back to a largest-`main`/`article`-block guess that let nav/footer/boilerplate through. This adds a Mozilla-Readability-grade pass (`dom_smoothie`, MIT) as the **last-resort rung**, keeping the largest-block guess as the final floor.

## How

- `readability_content_text()` in `scraping/scrape_url/mod.rs` runs ONLY after the higher-precision rungs (extension hint node, JSON-LD `JobPosting`) miss — those are unchanged.
- Guarded by `is_probably_readable()` before `parse()`; any error / false pre-check / empty output → `None` → falls through to the unchanged `main_content_text`.
- `TextMode::Markdown` keeps the output shape identical to the existing fallbacks (no new format contract; `JobDetailPane` already renders markdown).
- `max_elements_to_parse: 4000` bounds parsing of hostile/huge HTML (trips → `TooManyElements` → clean fall-through) — defense-in-depth flagged by both reviewers.

## Dependency

`dom_smoothie 0.18` (MIT) + its transitives — all already in the `deny.toml` allowlist; no GPL/AGPL pulled in; blast radius is 5 crates (verified against `Cargo.lock`; the rest already ship via existing deps).

## Tests

- `parse_from_html_readability_skips_in_article_decoy_block` — a decoy nested INSIDE `<article>` (which the old selector-scoped guess would NOT have excluded) is dropped, proving the readability differentiator; verified it fails without the change.
- `readability_content_text_returns_none_for_sparse_page` — sparse posting fails `is_probably_readable()` → clean fall-through.
- Full crate `cargo test --lib`: 2546 passed; `cargo clippy --lib` clean.

## Reviews

`scraping-applier-expert` + `tauri-security-reviewer` both approved — no HIGH/CRITICAL. Supply-chain clean; parse element-capped per both reviewers' advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
