### PR TITLE
feat: add jobicy keyless remote-jobs board with full descriptions

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/jobicy/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/jobicy/mod.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
-struct Job {
+pub(crate) struct Job {
     id: Option<i64>,
     url: Option<String>,
     #[serde(rename = "jobTitle")]
@@ -83,8 +83,9 @@ fn is_valid_jobicy_url(url: &str) -> bool {
     reqwest::Url::parse(url)
         .map(|u| {
             (u.scheme() == "http" || u.scheme() == "https")
-                && u.host_str()
-                    .is_some_and(|h| crate::scraping::trust::matches_domain_list(h, &["jobicy.com"]))
+                && u.host_str().is_some_and(|h| {
+                    crate::scraping::trust::matches_domain_list(h, &["jobicy.com"])
+                })
         })
         .unwrap_or(false)
 }
@@ -113,11 +114,14 @@ pub(crate) fn map_job(j: Job, scraper_id: &str, now: i64) -> Option<JobPosting> 
         location: j.job_geo.filter(|s| !s.trim().is_empty()),
         url,
         source: scraper_id.to_string(),
-        // Full HTML → Markdown. Falls back to the (also HTML) excerpt on the
-        // rare response missing `jobDescription`.
+        // Full HTML → Markdown. Falls back to the (also HTML) excerpt when
+        // `jobDescription` is absent OR a blank string (some rows send `""`
+        // rather than omitting the key) — mirrors how title/url/company
+        // already treat blank strings as missing.
         description: j
             .job_description
-            .or(j.job_excerpt)
+            .filter(|s| !s.trim().is_empty())
+            .or(j.job_excerpt.filter(|s| !s.trim().is_empty()))
             .map(|html| html_to_markdown(&html)),
         requirements: None,
         posted_at: j
@@ -131,6 +135,41 @@ pub(crate) fn map_job(j: Job, scraper_id: &str, now: i64) -> Option<JobPosting> 
             map
         },
     })
+}
+
+/// Decide whether a raw HTTP response is a genuine failure or a
+/// (possibly-404-but-JSON) empty/successful result, then parse it into
+/// postings. Pure — no network, no `ScrapeContext` — so the load-bearing
+/// "a real outage is never misread as empty" contract is hermetically unit
+/// testable; previously it was only exercised by an `#[ignore]`d live-network
+/// test.
+///
+/// Jobicy returns HTTP 404 with a valid JSON body
+/// (`{"jobs":[],"success":false,"message":"Nothing found..."}`) for a genuine
+/// zero-match `tag` search (live-verified) — a normal empty result, not a
+/// fetch failure. Every OTHER non-2xx status (a real routing/server error
+/// returns an HTML body, not this JSON shape) still propagates as an `Err`,
+/// surfaced in `BoardScrapeSummary.error`, per this codebase's "never a
+/// silent empty result on failure" rule.
+pub(crate) fn parse_response(
+    status_code: u16,
+    body: &str,
+    scraper_id: &str,
+    now: i64,
+) -> anyhow::Result<Vec<JobPosting>> {
+    if status_code != 200 && status_code != 404 {
+        return Err(anyhow::anyhow!("HTTP {status_code}"));
+    }
+
+    let resp: Resp = serde_json::from_str(body).map_err(|e| {
+        log::warn!("[jobicy] response parse failure (HTTP {status_code}): {e}");
+        anyhow::anyhow!("response body did not match the expected schema")
+    })?;
+
+    Ok(rows_to_jobs(resp.jobs)
+        .into_iter()
+        .filter_map(|j| map_job(j, scraper_id, now))
+        .collect())
 }
 
 pub struct JobicyScraper;
@@ -178,46 +217,23 @@ impl Scraper for JobicyScraper {
             // 400s ("Invalid 'geo' value" — enum validation), while an
             // unmatched `tag` 404s with `{"success":false,"message":"Nothing
             // found..."}` — a legitimate zero-result search, not a rejected
-            // value. That 404-for-zero-matches case is handled below (treated
-            // as an authoritative empty result, never a fetch failure).
+            // value. That 404-for-zero-matches case is handled in
+            // `parse_response` below (treated as an authoritative empty
+            // result, never a fetch failure).
             url.push_str(&format!("&tag={}", urlencoding::encode(q)));
         }
 
         let res = fetch_text(&url, Default::default(), ctx.signal).await?;
 
-        // Jobicy returns HTTP 404 with a valid JSON body
-        // (`{"jobs":[],"success":false,"message":"Nothing found..."}`) for a
-        // genuine zero-match `tag` search (live-verified) — a normal empty
-        // result, not a fetch failure. Every OTHER non-2xx status (a real
-        // routing/server error returns an HTML body, not this JSON shape)
-        // still propagates as an `Err`, surfaced in `BoardScrapeSummary.error`,
-        // per this codebase's "never a silent empty result on failure" rule.
-        if res.status_code != 200 && res.status_code != 404 {
-            return Err(anyhow::anyhow!("HTTP {}", res.status_code));
-        }
-
-        let resp: Resp = serde_json::from_str(&res.text).map_err(|e| {
-            log::warn!(
-                "[jobicy] response parse failure (HTTP {}): {e}",
-                res.status_code
-            );
-            anyhow::anyhow!("response body did not match the expected schema")
-        })?;
-
-        let jobs = rows_to_jobs(resp.jobs);
         let now = chrono::Utc::now().timestamp_millis();
-        let mut out = vec![];
+        // 404-vs-other-status decision + parse lives in `parse_response` (pure,
+        // hermetically unit tested) — see its doc comment for the contract.
+        let out = parse_response(res.status_code, &res.text, self.id(), now)?;
 
-        for j in jobs {
-            let Some(posting) = map_job(j, self.id(), now) else {
-                continue;
-            };
-
-            if let Some(ref on_item) = ctx.on_item {
+        if let Some(ref on_item) = ctx.on_item {
+            for posting in &out {
                 on_item(posting.clone());
             }
-
-            out.push(posting);
         }
 
         if let Some(ref on_progress) = ctx.on_progress {

--- a/apps/desktop/src-tauri/src/scraping/boards/jobicy/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/jobicy/mod.rs
@@ -1,0 +1,232 @@
+/// Jobicy — public JSON API (`https://jobicy.com/api/v2/remote-jobs`), keyless,
+/// remote jobs only. Unlike most feeds here, Jobicy returns the FULL job
+/// description HTML inline (`jobDescription`) — no truncated snippet, no
+/// detail-fetch wall — so this board never needs `scrape_url`'s resolve-on-open
+/// path.
+///
+/// ATTRIBUTION (Jobicy ToS — `friendlyNotice` on every API response): Jobicy
+/// requires visible credit and that every posting link back to the ORIGINAL
+/// jobicy.com job URL. `map_job` below passes `url` through unmodified (it is
+/// already jobicy.com's own posting page, and `is_valid_jobicy_url` below
+/// REJECTS anything else) and `source`/`display_name()` surface as "Jobicy" in
+/// the jobs UI — never replace either with a third-party/apply redirect link.
+///
+/// `from_url()` is intentionally left at the trait default (`Ok(None)`, same as
+/// every other HTTP board here): verified live that the API has no by-id/by-slug
+/// lookup (`?id=`/`?jobSlug=` both 400 with "Unexpected parameter") — there is no
+/// keyless way to re-fetch a single posting, so a shared jobicy.com link falls
+/// through to `scrape_url`'s generic HTML fallback, same as any other
+/// unregistered host.
+use super::super::http::{fetch_text, html_to_markdown};
+use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
+use async_trait::async_trait;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Job {
+    id: Option<i64>,
+    url: Option<String>,
+    #[serde(rename = "jobTitle")]
+    job_title: Option<String>,
+    #[serde(rename = "companyName")]
+    company_name: Option<String>,
+    #[serde(rename = "jobGeo")]
+    job_geo: Option<String>,
+    #[serde(rename = "jobExcerpt")]
+    job_excerpt: Option<String>,
+    #[serde(rename = "jobDescription")]
+    job_description: Option<String>,
+    #[serde(rename = "pubDate")]
+    pub_date: Option<String>,
+}
+
+/// Top-level response envelope. `jobs` is deserialized as raw `Value` rows
+/// (not `Vec<Job>` directly) so [`rows_to_jobs`] can drop a single malformed
+/// row instead of failing the whole batch — see its doc comment.
+#[derive(Debug, Deserialize)]
+struct Resp {
+    #[serde(default)]
+    jobs: Vec<serde_json::Value>,
+}
+
+/// Deserialize each job row independently, dropping (with a debug log) any
+/// row that fails to type-check — e.g. a future response sending `id` as a
+/// string on one row. Mirrors Comeet/Workable/Breezy/Rippling's `rows_to_jobs`
+/// resilience idiom: without this, `Vec<Job>`'s atomic deserialize would fail
+/// the WHOLE batch on a single drifted row (silent zero-jobs).
+pub(crate) fn rows_to_jobs(values: Vec<serde_json::Value>) -> Vec<Job> {
+    let total = values.len();
+    let jobs: Vec<Job> = values
+        .into_iter()
+        .filter_map(|v| match serde_json::from_value::<Job>(v) {
+            Ok(job) => Some(job),
+            Err(e) => {
+                log::debug!("[jobicy] skipping malformed row: {e}");
+                None
+            }
+        })
+        .collect();
+    let skipped = total - jobs.len();
+    if skipped > 0 {
+        log::warn!("[jobicy] skipped {skipped}/{total} malformed rows");
+    }
+    jobs
+}
+
+/// Validate that a job URL from the response is `http(s)://jobicy.com/…` (or
+/// a `*.jobicy.com` subdomain), reusing the trust module's suffix-anchored
+/// domain match. A drifting/hostile response could inject an arbitrary URL
+/// into `JobPosting.url`; this is also the ToS-required attribution link (see
+/// the module doc comment), so a non-jobicy.com URL is never usable here
+/// regardless — the row is dropped rather than kept with a foreign URL.
+fn is_valid_jobicy_url(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .map(|u| {
+            (u.scheme() == "http" || u.scheme() == "https")
+                && u.host_str()
+                    .is_some_and(|h| crate::scraping::trust::matches_domain_list(h, &["jobicy.com"]))
+        })
+        .unwrap_or(false)
+}
+
+/// Map one already-deserialized Jobicy job into the app's `JobPosting`.
+/// Extracted from `search()` so tests can drive the mapping directly without
+/// a network call. `None` when a required field (id/title/url) is missing or
+/// the url isn't a genuine jobicy.com link — dropped rather than fabricated,
+/// mirroring the other feed boards here.
+pub(crate) fn map_job(j: Job, scraper_id: &str, now: i64) -> Option<JobPosting> {
+    let id = j.id?;
+    let title = j.job_title.filter(|s| !s.trim().is_empty())?;
+    let url = j
+        .url
+        .filter(|s| !s.trim().is_empty())
+        .filter(|u| is_valid_jobicy_url(u))?;
+
+    Some(JobPosting {
+        id: format!("{scraper_id}:{id}"),
+        external_id: Some(id.to_string()),
+        title,
+        company: j
+            .company_name
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "Unknown".to_string()),
+        location: j.job_geo.filter(|s| !s.trim().is_empty()),
+        url,
+        source: scraper_id.to_string(),
+        // Full HTML → Markdown. Falls back to the (also HTML) excerpt on the
+        // rare response missing `jobDescription`.
+        description: j
+            .job_description
+            .or(j.job_excerpt)
+            .map(|html| html_to_markdown(&html)),
+        requirements: None,
+        posted_at: j
+            .pub_date
+            .and_then(|d| chrono::DateTime::parse_from_rfc3339(&d).ok())
+            .map(|dt| dt.timestamp_millis()),
+        captured_at: now,
+        extra: {
+            let mut map = std::collections::HashMap::new();
+            map.insert("remote".to_string(), serde_json::json!(true));
+            map
+        },
+    })
+}
+
+pub struct JobicyScraper;
+
+#[async_trait]
+impl Scraper for JobicyScraper {
+    fn id(&self) -> &'static str {
+        "jobicy"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Jobicy"
+    }
+
+    fn mode(&self) -> ScraperMode {
+        ScraperMode::Http
+    }
+
+    async fn search(
+        &self,
+        input: BoardSearchInput,
+        ctx: ScrapeContext,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        let q = input.query.trim();
+        // Documented cap is 50; clamp defensively even though a live check
+        // showed higher counts are honored — staying inside the documented
+        // contract rather than relying on undocumented behavior.
+        let count = input.amount.clamp(1, 50);
+
+        // NOTE (`supports_location` stays the trait default `false`): Jobicy's
+        // `geo` param is NOT a free-text location — it only accepts a fixed set
+        // of predefined `geoSlug`s (verified live: an arbitrary value 400s with
+        // "Invalid 'geo' value"). Passing the user's raw location string through
+        // would break the whole search on any non-matching value, so this board
+        // leaves `geo` unset and lets the engine's central post-filter handle it.
+        let mut url = format!("https://jobicy.com/api/v2/remote-jobs?count={count}");
+        if !q.is_empty() {
+            // LIVE-VERIFIED (2026-07-17): unlike `geo`, `tag` genuinely performs
+            // relevance-ranked full-text search over title/description, NOT a
+            // fixed category whitelist — `tag=dev` surfaces "Sales Development
+            // Representative" / "Developer Portal" (substring match on "dev",
+            // not a "dev" category), and a full free-text phrase
+            // `tag=senior%20backend%20engineer` returns highly relevant senior
+            // backend roles. Confirmed by the ERROR MODE too: `geo=garbage`
+            // 400s ("Invalid 'geo' value" — enum validation), while an
+            // unmatched `tag` 404s with `{"success":false,"message":"Nothing
+            // found..."}` — a legitimate zero-result search, not a rejected
+            // value. That 404-for-zero-matches case is handled below (treated
+            // as an authoritative empty result, never a fetch failure).
+            url.push_str(&format!("&tag={}", urlencoding::encode(q)));
+        }
+
+        let res = fetch_text(&url, Default::default(), ctx.signal).await?;
+
+        // Jobicy returns HTTP 404 with a valid JSON body
+        // (`{"jobs":[],"success":false,"message":"Nothing found..."}`) for a
+        // genuine zero-match `tag` search (live-verified) — a normal empty
+        // result, not a fetch failure. Every OTHER non-2xx status (a real
+        // routing/server error returns an HTML body, not this JSON shape)
+        // still propagates as an `Err`, surfaced in `BoardScrapeSummary.error`,
+        // per this codebase's "never a silent empty result on failure" rule.
+        if res.status_code != 200 && res.status_code != 404 {
+            return Err(anyhow::anyhow!("HTTP {}", res.status_code));
+        }
+
+        let resp: Resp = serde_json::from_str(&res.text).map_err(|e| {
+            log::warn!(
+                "[jobicy] response parse failure (HTTP {}): {e}",
+                res.status_code
+            );
+            anyhow::anyhow!("response body did not match the expected schema")
+        })?;
+
+        let jobs = rows_to_jobs(resp.jobs);
+        let now = chrono::Utc::now().timestamp_millis();
+        let mut out = vec![];
+
+        for j in jobs {
+            let Some(posting) = map_job(j, self.id(), now) else {
+                continue;
+            };
+
+            if let Some(ref on_item) = ctx.on_item {
+                on_item(posting.clone());
+            }
+
+            out.push(posting);
+        }
+
+        if let Some(ref on_progress) = ctx.on_progress {
+            on_progress(1.0);
+        }
+
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/apps/desktop/src-tauri/src/scraping/boards/jobicy/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/jobicy/test.rs
@@ -108,8 +108,7 @@ fn test_parse_fixture_job1_full_html_description_becomes_markdown() {
     assert_eq!(j.company, "TechMagic");
     assert_eq!(j.location.as_deref(), Some("Ukraine"));
     assert_eq!(
-        j.url,
-        "https://jobicy.com/jobs/146131-customer-experience-analyst",
+        j.url, "https://jobicy.com/jobs/146131-customer-experience-analyst",
         "url must be the unmodified jobicy.com link (ToS attribution requirement)"
     );
     assert_eq!(j.source, "jobicy");
@@ -133,10 +132,7 @@ fn test_parse_fixture_job1_full_html_description_becomes_markdown() {
         .unwrap()
         .timestamp_millis();
     assert_eq!(j.posted_at, Some(expected_ms));
-    assert_eq!(
-        j.extra.get("remote").and_then(|v| v.as_bool()),
-        Some(true)
-    );
+    assert_eq!(j.extra.get("remote").and_then(|v| v.as_bool()), Some(true));
 }
 
 #[test]
@@ -154,6 +150,45 @@ fn test_parse_fixture_job2_falls_back_to_excerpt_when_description_missing() {
         !desc.contains("<p>"),
         "excerpt fallback must still be HTML-converted, got: {desc:?}"
     );
+}
+
+#[test]
+fn test_map_job_empty_description_falls_back_to_excerpt() {
+    // `jobDescription: ""` (present but blank) must NOT short-circuit `.or` —
+    // it must fall back to `jobExcerpt` just like a missing/`None` field.
+    let j: Job = serde_json::from_str(
+        r#"{
+            "id": 1,
+            "url": "https://jobicy.com/jobs/1-x",
+            "jobTitle": "Some Job",
+            "jobDescription": "",
+            "jobExcerpt": "<p>Fallback excerpt text</p>"
+        }"#,
+    )
+    .unwrap();
+    let posting = map_job(j, "jobicy", 0).expect("id/title/url all present");
+    let desc = posting.description.as_deref().unwrap_or("");
+    assert!(
+        desc.contains("Fallback excerpt text"),
+        "blank jobDescription must fall back to jobExcerpt, got: {desc:?}"
+    );
+}
+
+#[test]
+fn test_map_job_blank_description_and_excerpt_yields_none() {
+    // Both fields present but blank — no fabricated description.
+    let j: Job = serde_json::from_str(
+        r#"{
+            "id": 1,
+            "url": "https://jobicy.com/jobs/1-x",
+            "jobTitle": "Some Job",
+            "jobDescription": "   ",
+            "jobExcerpt": ""
+        }"#,
+    )
+    .unwrap();
+    let posting = map_job(j, "jobicy", 0).expect("id/title/url all present");
+    assert_eq!(posting.description, None);
 }
 
 // ── map_job edge cases ───────────────────────────────────────────────────────
@@ -282,6 +317,57 @@ fn test_missing_jobs_field_defaults_to_empty_vec() {
     // parse error or a fabricated result.
     let resp: Resp = serde_json::from_str(r#"{"jobCount": 0}"#).unwrap();
     assert!(resp.jobs.is_empty());
+}
+
+// ── parse_response (hermetic — the 404-vs-other-status contract) ────────────
+//
+// `search()` delegates its "is this a real failure or a 404-but-valid-empty-
+// result" decision to `parse_response`, a pure function with no network call,
+// so this load-bearing contract no longer relies solely on the `#[ignore]`d
+// live-network tests below.
+
+#[test]
+fn test_parse_response_500_is_err() {
+    let result = parse_response(500, "Internal Server Error", "jobicy", 0);
+    assert!(result.is_err(), "a real 5xx outage must never be Ok");
+}
+
+#[test]
+fn test_parse_response_403_is_err() {
+    let result = parse_response(403, "Forbidden", "jobicy", 0);
+    assert!(result.is_err(), "a 403 must never be misread as empty");
+}
+
+#[test]
+fn test_parse_response_404_with_empty_jobs_json_is_ok_empty() {
+    let body = r#"{"jobs":[],"success":false,"message":"Nothing found..."}"#;
+    let result = parse_response(404, body, "jobicy", 0);
+    assert!(
+        result.is_ok(),
+        "a 404 with a valid empty-jobs JSON body is a genuine zero-match search"
+    );
+    assert!(result.unwrap().is_empty());
+}
+
+#[test]
+fn test_parse_response_200_with_jobs_is_ok_with_postings() {
+    let result = parse_response(200, FIXTURE_JSON, "jobicy", 0);
+    assert!(result.is_ok(), "a 200 with a well-formed body must parse");
+    // job3 has no id and is dropped; job1+job2 survive (see FIXTURE_JSON doc).
+    assert_eq!(result.unwrap().len(), 2);
+}
+
+#[test]
+fn test_parse_response_404_with_html_body_is_err() {
+    // A real routing 404 (e.g. a CDN/edge error page) returns HTML, not the
+    // `{"jobs":[...]}` shape — JSON parsing must fail and propagate as `Err`,
+    // never a silently-empty `Ok`.
+    let body = "<html><body>404 Not Found</body></html>";
+    let result = parse_response(404, body, "jobicy", 0);
+    assert!(
+        result.is_err(),
+        "a 404 with an HTML (non-JSON) body is a real outage, not an empty result"
+    );
 }
 
 // ── live network (ignored in CI) ─────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/scraping/boards/jobicy/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/jobicy/test.rs
@@ -1,0 +1,434 @@
+use super::*;
+// Not re-exported from `mod.rs` (no override there — see fix below), imported
+// directly here just for this one assertion.
+use crate::scraping::types::AuthRequirement;
+
+// ── identity / mode / auth ───────────────────────────────────────────────────
+
+#[test]
+fn test_jobicy_scraper_id() {
+    let scraper = JobicyScraper;
+    assert_eq!(scraper.id(), "jobicy");
+}
+
+#[test]
+fn test_jobicy_scraper_display_name() {
+    let scraper = JobicyScraper;
+    assert_eq!(scraper.display_name(), "Jobicy");
+}
+
+#[test]
+fn test_jobicy_scraper_mode() {
+    let scraper = JobicyScraper;
+    assert_eq!(scraper.mode(), ScraperMode::Http);
+}
+
+#[test]
+fn test_jobicy_scraper_auth_is_guest() {
+    // Keyless API — no session/login ever required. No explicit `auth()`
+    // override in `mod.rs` (it would only duplicate the trait default); this
+    // guards that default against a future accidental regression.
+    assert_eq!(JobicyScraper.auth(), AuthRequirement::Guest);
+}
+
+// ── JSON fixture parse ───────────────────────────────────────────────────────
+//
+// Shaped after a live `GET /api/v2/remote-jobs` response (verified 2026-07-17):
+// job1 has a full HTML `jobDescription`; job2 omits it (must fall back to the
+// HTML `jobExcerpt`); job3 has no `id` (must be dropped, sibling still parses).
+
+const FIXTURE_JSON: &str = r#"{
+  "apiVersion": "2.2.14",
+  "jobCount": 3,
+  "friendlyNotice": "Thanks for using Jobicy API! Please ensure Jobicy is clearly credited...",
+  "jobs": [
+    {
+      "id": 146131,
+      "url": "https://jobicy.com/jobs/146131-customer-experience-analyst",
+      "jobSlug": "146131-customer-experience-analyst",
+      "jobTitle": "Customer Experience Analyst",
+      "companyName": "TechMagic",
+      "jobIndustry": ["Customer Success"],
+      "jobType": ["Full-Time"],
+      "jobGeo": "Ukraine",
+      "jobLevel": "Midweight",
+      "jobExcerpt": "We are looking for a Customer Experience Analyst&hellip;",
+      "jobDescription": "<p>We are looking for a <strong>Customer Experience Analyst</strong>.</p><ul><li>3+ years experience</li></ul>",
+      "pubDate": "2026-07-17T11:20:05+00:00"
+    },
+    {
+      "id": 146472,
+      "url": "https://jobicy.com/jobs/146472-seo-analyst-fully-remote",
+      "jobSlug": "146472-seo-analyst-fully-remote",
+      "jobTitle": "SEO Analyst (Fully Remote)",
+      "companyName": "PadSplit",
+      "jobIndustry": ["SEO"],
+      "jobType": ["Full-Time"],
+      "jobGeo": "USA",
+      "jobLevel": "Midweight",
+      "jobExcerpt": "<p>Own and scale our organic search strategy&hellip;</p>",
+      "pubDate": "2026-07-17T09:45:04+00:00"
+    },
+    {
+      "url": "https://jobicy.com/jobs/no-id-job",
+      "jobTitle": "No ID Job",
+      "companyName": "Ghost Corp"
+    }
+  ],
+  "success": true
+}"#;
+
+fn fixture_postings() -> Vec<JobPosting> {
+    let now = chrono::Utc::now().timestamp_millis();
+    let resp: Resp = serde_json::from_str(FIXTURE_JSON).expect("fixture must deserialize");
+    rows_to_jobs(resp.jobs)
+        .into_iter()
+        .filter_map(|j| map_job(j, "jobicy", now))
+        .collect()
+}
+
+#[test]
+fn test_parse_fixture_drops_job_with_no_id() {
+    let postings = fixture_postings();
+    assert_eq!(
+        postings.len(),
+        2,
+        "job3 has no id and must be dropped; job1+job2 must survive"
+    );
+}
+
+#[test]
+fn test_parse_fixture_job1_full_html_description_becomes_markdown() {
+    let postings = fixture_postings();
+    let j = &postings[0];
+
+    assert_eq!(j.id, "jobicy:146131");
+    assert_eq!(j.external_id.as_deref(), Some("146131"));
+    assert_eq!(j.title, "Customer Experience Analyst");
+    assert_eq!(j.company, "TechMagic");
+    assert_eq!(j.location.as_deref(), Some("Ukraine"));
+    assert_eq!(
+        j.url,
+        "https://jobicy.com/jobs/146131-customer-experience-analyst",
+        "url must be the unmodified jobicy.com link (ToS attribution requirement)"
+    );
+    assert_eq!(j.source, "jobicy");
+
+    let desc = j.description.as_deref().unwrap_or("");
+    assert!(
+        desc.contains("Customer Experience Analyst"),
+        "description should retain the text, got: {desc:?}"
+    );
+    assert!(
+        !desc.contains("<p>") && !desc.contains("<strong>") && !desc.contains("<li>"),
+        "description still contains raw HTML tags, got: {desc:?}"
+    );
+    // htmd renders <li> as a markdown bullet, not a stripped/collapsed line.
+    assert!(
+        desc.contains('-') || desc.contains('*'),
+        "expected a markdown bullet for the <ul><li> block, got: {desc:?}"
+    );
+
+    let expected_ms = chrono::DateTime::parse_from_rfc3339("2026-07-17T11:20:05+00:00")
+        .unwrap()
+        .timestamp_millis();
+    assert_eq!(j.posted_at, Some(expected_ms));
+    assert_eq!(
+        j.extra.get("remote").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+}
+
+#[test]
+fn test_parse_fixture_job2_falls_back_to_excerpt_when_description_missing() {
+    let postings = fixture_postings();
+    let j = &postings[1];
+
+    assert_eq!(j.id, "jobicy:146472");
+    let desc = j.description.as_deref().unwrap_or("");
+    assert!(
+        desc.contains("Own and scale"),
+        "missing jobDescription must fall back to jobExcerpt, got: {desc:?}"
+    );
+    assert!(
+        !desc.contains("<p>"),
+        "excerpt fallback must still be HTML-converted, got: {desc:?}"
+    );
+}
+
+// ── map_job edge cases ───────────────────────────────────────────────────────
+
+#[test]
+fn test_map_job_drops_when_title_blank() {
+    let j: Job = serde_json::from_str(
+        r#"{"id": 1, "url": "https://jobicy.com/jobs/1-x", "jobTitle": "   "}"#,
+    )
+    .unwrap();
+    assert!(map_job(j, "jobicy", 0).is_none());
+}
+
+#[test]
+fn test_map_job_drops_when_url_missing() {
+    let j: Job = serde_json::from_str(r#"{"id": 1, "jobTitle": "Some Job"}"#).unwrap();
+    assert!(map_job(j, "jobicy", 0).is_none());
+}
+
+#[test]
+fn test_map_job_defaults_company_to_unknown_when_missing() {
+    let j: Job = serde_json::from_str(
+        r#"{"id": 1, "url": "https://jobicy.com/jobs/1-x", "jobTitle": "Some Job"}"#,
+    )
+    .unwrap();
+    let posting = map_job(j, "jobicy", 0).expect("id/title/url all present");
+    assert_eq!(posting.company, "Unknown");
+    assert_eq!(posting.location, None);
+    assert_eq!(posting.description, None);
+    assert_eq!(posting.posted_at, None);
+}
+
+#[test]
+fn test_map_job_bad_pub_date_yields_posted_at_none() {
+    let j: Job = serde_json::from_str(
+        r#"{"id": 1, "url": "https://jobicy.com/jobs/1-x", "jobTitle": "Some Job", "pubDate": "not-a-date"}"#,
+    )
+    .unwrap();
+    let posting = map_job(j, "jobicy", 0).expect("id/title/url all present");
+    assert_eq!(posting.posted_at, None, "malformed pubDate must not panic");
+}
+
+// ── url host validation (security defense-in-depth) ─────────────────────────
+
+#[test]
+fn test_is_valid_jobicy_url_accepts_https_jobicy_host() {
+    assert!(is_valid_jobicy_url(
+        "https://jobicy.com/jobs/146131-customer-experience-analyst"
+    ));
+}
+
+#[test]
+fn test_is_valid_jobicy_url_accepts_http_and_subdomain() {
+    assert!(is_valid_jobicy_url("http://jobicy.com/jobs/1-x"));
+    assert!(is_valid_jobicy_url("https://www.jobicy.com/jobs/1-x"));
+}
+
+#[test]
+fn test_is_valid_jobicy_url_rejects_non_jobicy_host() {
+    assert!(!is_valid_jobicy_url("https://evil-phish.example/jobs/1-x"));
+    // A host that merely CONTAINS "jobicy" as a substring must not pass —
+    // matches_domain_list is suffix/label-anchored, not a bare `contains`.
+    assert!(!is_valid_jobicy_url("https://jobicy.com.evil.example/x"));
+}
+
+#[test]
+fn test_is_valid_jobicy_url_rejects_non_http_scheme() {
+    assert!(!is_valid_jobicy_url("javascript:alert(1)"));
+    assert!(!is_valid_jobicy_url("ftp://jobicy.com/x"));
+}
+
+#[test]
+fn test_map_job_drops_row_with_non_jobicy_url() {
+    // A drifting/hostile response could inject a foreign URL — must be
+    // dropped, never kept with a non-jobicy.com link.
+    let j: Job = serde_json::from_str(
+        r#"{"id": 1, "url": "https://evil-phish.example/x", "jobTitle": "Some Job"}"#,
+    )
+    .unwrap();
+    assert!(map_job(j, "jobicy", 0).is_none());
+}
+
+// ── per-row deserialization resilience ───────────────────────────────────────
+
+#[test]
+fn test_rows_to_jobs_skips_malformed_row_keeps_good_ones() {
+    // One row has `id` as a STRING (schema drift on a single row); the other
+    // two are well-formed. Without per-row resilience, `Vec<Job>`'s atomic
+    // deserialize would zero the whole batch on that one bad row.
+    let values: Vec<serde_json::Value> = serde_json::from_str(
+        r#"[
+            {"id": 1, "url": "https://jobicy.com/jobs/1-x", "jobTitle": "Good Job A"},
+            {"id": "not-a-number", "url": "https://jobicy.com/jobs/2-x", "jobTitle": "Bad Row"},
+            {"id": 3, "url": "https://jobicy.com/jobs/3-x", "jobTitle": "Good Job B"}
+        ]"#,
+    )
+    .unwrap();
+
+    let jobs = rows_to_jobs(values);
+    assert_eq!(
+        jobs.len(),
+        2,
+        "the malformed row must be skipped; both good rows must survive"
+    );
+    assert_eq!(jobs[0].job_title.as_deref(), Some("Good Job A"));
+    assert_eq!(jobs[1].job_title.as_deref(), Some("Good Job B"));
+}
+
+#[test]
+fn test_rows_to_jobs_empty_input_returns_empty() {
+    assert!(rows_to_jobs(Vec::new()).is_empty());
+}
+
+// ── keyless/empty response ───────────────────────────────────────────────────
+
+#[test]
+fn test_empty_jobs_array_parses_to_empty_vec() {
+    let resp: Resp = serde_json::from_str(r#"{"jobs": []}"#).unwrap();
+    assert!(resp.jobs.is_empty());
+}
+
+#[test]
+fn test_missing_jobs_field_defaults_to_empty_vec() {
+    // Defensive: an unexpected/absent `jobs` key must not fail deserialization
+    // (`#[serde(default)]`) — a keyless-empty response is `Ok(vec![])`, never a
+    // parse error or a fabricated result.
+    let resp: Resp = serde_json::from_str(r#"{"jobCount": 0}"#).unwrap();
+    assert!(resp.jobs.is_empty());
+}
+
+// ── live network (ignored in CI) ─────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "live network"]
+async fn live_search_returns_results() {
+    let scraper = JobicyScraper;
+    let input = BoardSearchInput {
+        query: "engineer".to_string(),
+        location: None,
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: Vec::new(),
+    };
+    let ctx = ScrapeContext {
+        signal: tokio_util::sync::CancellationToken::new(),
+        on_progress: None,
+        on_item: None,
+        on_truncation: None,
+        on_note: None,
+    };
+    let results = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        scraper.search(input, ctx),
+    )
+    .await
+    .expect("live search timed out");
+    assert!(results.is_ok(), "search failed: {:?}", results.err());
+    let postings = results.unwrap();
+    assert!(!postings.is_empty(), "expected >=1 posting, got 0");
+    let first = &postings[0];
+    assert!(!first.title.is_empty(), "first posting has empty title");
+    assert!(!first.url.is_empty(), "first posting has empty url");
+    assert!(
+        first.description.is_some(),
+        "jobicy always returns a full description — feed changed?"
+    );
+    println!("jobicy: {} results", postings.len());
+    println!("first: {:?}", first.title);
+}
+
+#[tokio::test]
+#[ignore = "live network"]
+async fn live_garbage_tag_returns_ok_empty_not_error() {
+    // Regression guard for the live-verified quirk `search()` depends on:
+    // Jobicy returns HTTP 404 with a valid JSON body for a genuine zero-match
+    // `tag` search. That must resolve `Ok(vec![])`, not an `Err` — otherwise a
+    // healthy "no results for this keyword" search would misreport as a
+    // failed board in `BoardScrapeSummary.error`.
+    let scraper = JobicyScraper;
+    let input = BoardSearchInput {
+        query: "zzz-guaranteed-no-match-xyz123".to_string(),
+        location: None,
+        amount: 5,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: Vec::new(),
+    };
+    let ctx = ScrapeContext {
+        signal: tokio_util::sync::CancellationToken::new(),
+        on_progress: None,
+        on_item: None,
+        on_truncation: None,
+        on_note: None,
+    };
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        scraper.search(input, ctx),
+    )
+    .await
+    .expect("live search timed out");
+    assert!(
+        result.is_ok(),
+        "a zero-match tag search must be Ok(empty), not Err: {:?}",
+        result.err()
+    );
+    assert!(result.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn search_respects_pre_cancelled_token() {
+    // Not `#[ignore = "live network"]`: `fetch_text` checks `signal.is_cancelled()`
+    // BEFORE issuing any request (scraping/http/mod.rs), so a pre-cancelled token
+    // makes zero network calls — this hermetically exercises the cancellation
+    // contract. `AppError::Cancelled` must propagate as an `Err`, not a
+    // fabricated empty success.
+    let scraper = JobicyScraper;
+    let signal = tokio_util::sync::CancellationToken::new();
+    signal.cancel();
+    let input = BoardSearchInput {
+        query: "".to_string(),
+        location: None,
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: Vec::new(),
+    };
+    let ctx = ScrapeContext {
+        signal,
+        on_progress: None,
+        on_item: None,
+        on_truncation: None,
+        on_note: None,
+    };
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        scraper.search(input, ctx),
+    )
+    .await
+    .expect("cancelled search must not hang");
+    assert!(
+        result.is_err(),
+        "a pre-cancelled token must surface as an error, not a silent empty Ok"
+    );
+}

--- a/apps/desktop/src-tauri/src/scraping/boards/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/mod.rs
@@ -14,6 +14,7 @@ pub mod comeet;
 pub(crate) mod common;
 pub mod germantechjobs;
 pub mod greenhouse;
+pub mod jobicy;
 pub mod lever;
 pub mod linkedin;
 pub mod personio;
@@ -38,6 +39,7 @@ pub use breezy::BreezyScraper;
 pub use comeet::ComeetScraper;
 pub use germantechjobs::GermanTechJobsScraper;
 pub use greenhouse::GreenhouseScraper;
+pub use jobicy::JobicyScraper;
 pub use lever::LeverScraper;
 pub use linkedin::LinkedInScraper;
 pub use personio::PersonioScraper;
@@ -66,6 +68,7 @@ static SCRAPERS: &[&dyn Scraper] = &[
     &RemoteOkScraper,
     &WeWorkRemotelyScraper,
     &ArbeitnowScraper,
+    &JobicyScraper,
     &BerlinStartupJobsScraper,
     &GermanTechJobsScraper,
     &GreenhouseScraper,

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -9,17 +9,18 @@ fn test_browser_sem() -> Arc<TokioSemaphore> {
 fn test_catalog() {
     let engine = ScraperEngine::new();
     let catalog = engine.catalog();
-    assert_eq!(catalog.len(), 23);
+    assert_eq!(catalog.len(), 24);
 
     // Check specific scrapers
     assert!(catalog.iter().any(|s| s.id == "linkedin"));
     assert!(catalog.iter().any(|s| s.id == "ycombinator"));
     assert!(catalog.iter().any(|s| s.id == "aggregator"));
     assert!(catalog.iter().any(|s| s.id == "greenhouse"));
-    // The 23-count alone doesn't prove which ids make it up — assert the two
-    // newest boards are actually present, not just that *some* 23 ids are.
+    // The 24-count alone doesn't prove which ids make it up — assert the
+    // newest boards are actually present, not just that *some* 24 ids are.
     assert!(catalog.iter().any(|s| s.id == "workable"));
     assert!(catalog.iter().any(|s| s.id == "comeet"));
+    assert!(catalog.iter().any(|s| s.id == "jobicy"));
 
     // Retired anti-bot boards must not appear in the catalog.
     assert!(!catalog.iter().any(|s| s.id == "indeed"));
@@ -230,7 +231,7 @@ fn test_catalog_listed_flags() {
         "comeet must be hidden from the picker until live-verified"
     );
 
-    // Every board except the hidden Comeet is listed (23 registered, 1 hidden).
+    // Every board except the hidden Comeet is listed (24 registered, 1 hidden).
     let listed_count = catalog.iter().filter(|e| e.listed).count();
     assert_eq!(
         listed_count,
@@ -238,8 +239,8 @@ fn test_catalog_listed_flags() {
         "all boards except the hidden Comeet should be listed"
     );
     assert_eq!(
-        listed_count, 22,
-        "22 of the 23 registered boards are listed"
+        listed_count, 23,
+        "23 of the 24 registered boards are listed"
     );
 }
 
@@ -249,7 +250,7 @@ fn test_health() {
     let health = engine.health();
     assert_eq!(health.mode, "in-process");
     assert!(health.ready);
-    assert_eq!(health.scrapers.len(), 23);
+    assert_eq!(health.scrapers.len(), 24);
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/scraping/trust/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/trust/mod.rs
@@ -54,7 +54,7 @@ const SUSPICIOUS_DOMAINS: &[&str] = &[
 ];
 
 /// Hosts a `CompanyDomainMismatch` is never raised against: real ATS
-/// platforms (career-ops's original list) plus the hosts our own 23
+/// platforms (career-ops's original list) plus the hosts our
 /// `SCRAPERS` boards legitimately return as `JobPosting.url` where that host
 /// is the BOARD's own domain rather than the employer's — LinkedIn
 /// (`linkedin.com`, always `/jobs/view/<id>`), Berlin Startup Jobs

--- a/apps/desktop/src-tauri/src/scraping/trust/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/trust/mod.rs
@@ -61,7 +61,9 @@ const SUSPICIOUS_DOMAINS: &[&str] = &[
 /// (`berlinstartupjobs.com`, its own WordPress RSS permalink), and the Adzuna
 /// aggregator (`api.adzuna.com` — the country code is a *path* segment, e.g.
 /// `/v1/api/jobs/de/redirects/…`, not a subdomain, so this one host covers
-/// every market's `redirect_url`) — so those boards' results aren't
+/// every market's `redirect_url`), and Jobicy (`jobicy.com` — its own posting
+/// page URL is REQUIRED by Jobicy's ToS attribution, see
+/// `scraping/boards/jobicy/mod.rs`) — so those boards' results aren't
 /// systematically flagged. JSearch's `job_apply_link` is the real employer
 /// URL, so it's intentionally left off this list.
 const ATS_ALLOWLIST: &[&str] = &[
@@ -95,6 +97,7 @@ const ATS_ALLOWLIST: &[&str] = &[
     "berlinstartupjobs.com",
     "api.adzuna.com",
     "comeet.co",
+    "jobicy.com",
 ];
 
 /// Score/flag a posting from its apply `url` and `company` name. Pure, no I/O;


### PR DESCRIPTION
## What

Add **Jobicy** — a keyless remote-jobs board — to the scraper registry. Jobicy returns the FULL job-description HTML inline, so unlike the aggregator boards it never truncates or needs a detail-fetch. Surfaced by the OSS-source scan as the one genuinely new, keyless, full-text job source.

## How

- New `scraping/boards/jobicy/` (Scraper impl + tests), registered in `SCRAPERS` — registry is now **24 boards**; the hardcoded board-count assertions in `scraping/engine/test.rs` are bumped accordingly.
- **Keyword search** via the `tag` param — live-verified as genuine free-text relevance search (not a fixed category enum like `geo`).
- **Zero-match handling:** a no-results `tag` search returns HTTP **404** with a valid empty-JSON body. Using `fetch_text` (not `fetch_json`) we treat 200/404 as an authoritative result and still `Err` on any *other* non-2xx (a real routing 404 returns HTML → JSON parse fails → error) — so an honest "no jobs match" is never misreported as a broken board (the repo's "never a silent/false empty on failure" rule).
- **Security:** the API-supplied `url` is constrained to the `jobicy.com` host (`is_valid_jobicy_url`, mirroring Comeet), and `jobicy.com` is added to the trust `ATS_ALLOWLIST` (the posting URL is Jobicy's own host, like RemoteOK/Remotive — otherwise every posting gets a false `CompanyDomainMismatch`).
- **Resilience:** `rows_to_jobs` deserializes each row independently so one drifted row can't zero the batch (Comeet/Workable idiom).
- `geo` left unset (fixed-slug enum) and `from_url` a no-op (no single-job endpoint) — both live-verified, documented in code.
- **Attribution (ToS):** postings link back to the unmodified jobicy.com URL; source surfaces as "Jobicy".

## Tests

`cargo test --lib scraping::boards::jobicy` 21 passed / 2 ignored (live-network); `scraping::trust` 18 passed; `scraping::` 819 passed; `cargo clippy --all-features --lib` clean.

## Reviews

`scraping-applier-expert` + `tauri-security-reviewer` approved (no HIGH/CRITICAL). Their advisories — live-verify `tag`, URL host-validation, per-row resilience — are all resolved here.

## Follow-up (not in this PR)

Registry is now 24 boards. The user-facing "23 boards" marketing copy (README + landing) is a one-line bump, deliberately kept out of this PR to avoid conflicting with docs PR #698 — a tiny follow-up once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
