### PR TITLE
feat: landing gl takeover p1 - engine spine

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -10,14 +10,22 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-three/drei": "10.7.7",
+    "@react-three/fiber": "9.6.1",
+    "gsap": "3.15.0",
+    "lenis": "1.3.25",
     "next": "16.2.10",
+    "postprocessing": "6.39.2",
     "react": "19.2.7",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.7",
+    "three": "0.185.1",
+    "zustand": "5.0.14"
   },
   "devDependencies": {
     "@types/node": "26.1.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "@types/three": "0.185.1",
     "typescript": "6.0.3"
   }
 }

--- a/apps/landing/src/app/GLLoader.tsx
+++ b/apps/landing/src/app/GLLoader.tsx
@@ -1,38 +1,101 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useState } from "react";
+import { Component, type ReactNode, useCallback, useEffect, useState } from "react";
 
 import { gateVerdict } from "@/engine/gate";
+import { initLegacy } from "@/fallback/legacy";
 
-// GL takeover boot. On mount it runs the one-shot capability probe (client-only)
-// and, only when the gate passes, dynamically imports the WebGL Experience
-// (ssr:false -- the static export ships zero GL JS on the legacy path) and hands
-// the page to GL: the prerendered semantic layer is hidden + made inert so it
-// stays the scroll-height / SEO / a11y authority without stealing paint or
-// focus. It is NEVER display:none'd (that would collapse scroll height and break
-// the journey). LegacyBoot reads the same cached verdict and stands down.
+// GL takeover boot. On mount it runs the one-shot capability probe (client-only);
+// when the gate passes it dynamically imports the WebGL Experience (ssr:false --
+// the static export ships zero GL JS on the legacy path). The prerendered semantic
+// layer stays visible and interactive until Experience reports onReady on its
+// first painted frame -- only then is it hidden + made inert (never display:none,
+// that would collapse scroll height). If Experience throws post-mount, or the
+// visitor activates the skip-link below, GLLoader unmounts it, reverts the
+// semantic layer, and boots the legacy engine itself -- LegacyBoot already stood
+// down because the initial gate verdict was GL, so this is the only place left
+// that can still start it.
 const Experience = dynamic(() => import("@/experience/Experience"), {
   ssr: false,
 });
 
+// Last-line fallback for the GL Experience: catches render-time errors in the
+// Canvas tree (a bad shader compile, a missing resource) and hands control back
+// to `onError` instead of leaving a blank canvas over an inert page.
+class ExperienceBoundary extends Component<
+  { onError: () => void; children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch() {
+    this.props.onError();
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
 export default function GLLoader() {
-  // null = undecided (pre-probe). The probe touches window, so it only runs
-  // after mount; nothing renders until the verdict is in.
+  // null = undecided (pre-probe); the probe touches window so it only runs
+  // after mount. false and a later fallback both render nothing here --
+  // LegacyBoot / initLegacy own the accessible page in that case.
   const [mount, setMount] = useState<boolean | null>(null);
+  const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    if (!gateVerdict().gl) {
-      setMount(false);
-      return;
-    }
-    const root = document.getElementById("semantic-root");
-    if (root) {
-      root.style.visibility = "hidden";
-      root.setAttribute("inert", "");
-    }
-    setMount(true);
+    setMount(gateVerdict().gl);
   }, []);
 
-  return mount ? <Experience /> : null;
+  // Hide + inert the semantic root only once GL has actually painted a frame.
+  // The cleanup reverts both -- Strict Mode's double-invoke, a future route
+  // change, or falling back to legacy all flip `ready` back to false -- so the
+  // semantic layer never gets stuck hidden.
+  useEffect(() => {
+    if (!ready) return;
+    const root = document.getElementById("semantic-root");
+    if (!root) return;
+    root.style.visibility = "hidden";
+    root.setAttribute("inert", "");
+    return () => {
+      root.style.visibility = "";
+      root.removeAttribute("inert");
+    };
+  }, [ready]);
+
+  const fallBackToLegacy = useCallback(() => {
+    setReady(false);
+    setMount(false);
+    initLegacy();
+  }, []);
+
+  if (!mount) return null;
+
+  return (
+    <>
+      {/* P1 a11y strategy: a one-keystroke escape hatch to the fully accessible
+          semantic page for AT users on a capable desktop (deeper semantic twins
+          land in P6). Rendered first so it is the first focusable element/Tab
+          stop whenever GL is mounted. */}
+      <a
+        href="#semantic-root"
+        className="skip-gl"
+        onClick={(e) => {
+          e.preventDefault();
+          fallBackToLegacy();
+        }}
+      >
+        view accessible version
+      </a>
+      <ExperienceBoundary onError={fallBackToLegacy}>
+        <Experience onReady={() => setReady(true)} />
+      </ExperienceBoundary>
+    </>
+  );
 }

--- a/apps/landing/src/app/GLLoader.tsx
+++ b/apps/landing/src/app/GLLoader.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+
+import { gateVerdict } from "@/engine/gate";
+
+// GL takeover boot. On mount it runs the one-shot capability probe (client-only)
+// and, only when the gate passes, dynamically imports the WebGL Experience
+// (ssr:false -- the static export ships zero GL JS on the legacy path) and hands
+// the page to GL: the prerendered semantic layer is hidden + made inert so it
+// stays the scroll-height / SEO / a11y authority without stealing paint or
+// focus. It is NEVER display:none'd (that would collapse scroll height and break
+// the journey). LegacyBoot reads the same cached verdict and stands down.
+const Experience = dynamic(() => import("@/experience/Experience"), {
+  ssr: false,
+});
+
+export default function GLLoader() {
+  // null = undecided (pre-probe). The probe touches window, so it only runs
+  // after mount; nothing renders until the verdict is in.
+  const [mount, setMount] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!gateVerdict().gl) {
+      setMount(false);
+      return;
+    }
+    const root = document.getElementById("semantic-root");
+    if (root) {
+      root.style.visibility = "hidden";
+      root.setAttribute("inert", "");
+    }
+    setMount(true);
+  }, []);
+
+  return mount ? <Experience /> : null;
+}

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -411,6 +411,20 @@ a.cta:focus-visible     { border-radius:12px 9px 13px 8px }
 #cookie button:focus-visible{ border-radius:10px }
 .dialog button:focus-visible{ border-radius:4px }
 
+/* ---------- GL skip-link ----------
+   Only rendered while the GL Experience is mounted (P1 a11y strategy): off-screen
+   until :focus, then a real, visible, keyboard-reachable link back to the fully
+   accessible semantic page. Rendered first in the body so it is the first
+   focusable element / first Tab stop whenever GL is mounted. */
+.skip-gl{
+  position:absolute; top:-40px; left:8px; z-index:1000;
+  background:var(--paper); color:var(--ink);
+  font-family:var(--mono); font-size:13px;
+  padding:8px 14px; border-radius:8px;
+  text-decoration:none;
+}
+.skip-gl:focus{ top:8px }
+
 /* reduced motion */
 @media (prefers-reduced-motion: reduce){
   /* Kill decorative animations and transitions. The focus-visible outline is a

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 
+import GLLoader from "./GLLoader";
+
 import "./globals.css";
 
 // Inline SVG data-URI favicon, transcribed verbatim from landing/index.html.
@@ -62,7 +64,12 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body>{children}</body>
+      <body>
+        {children}
+        {/* Capability-gated GL takeover. Mounts the WebGL Experience only when
+            the gate passes; otherwise renders nothing and legacy boots. */}
+        <GLLoader />
+      </body>
     </html>
   );
 }

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -65,10 +65,12 @@ export default function RootLayout({
         />
       </head>
       <body>
-        {children}
         {/* Capability-gated GL takeover. Mounts the WebGL Experience only when
-            the gate passes; otherwise renders nothing and legacy boots. */}
+            the gate passes; otherwise renders nothing and legacy boots. Placed
+            first so its skip-link (when GL is mounted) is the first body
+            element and first Tab stop. */}
         <GLLoader />
+        {children}
       </body>
     </html>
   );

--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Page() {
   return (
     <>
       <Chrome />
-      <main>
+      <main id="semantic-root">
         <Hero />
         <Beat1 />
         <Beat2 />

--- a/apps/landing/src/engine/beats.ts
+++ b/apps/landing/src/engine/beats.ts
@@ -1,0 +1,33 @@
+// The 8 beats, in story order, each owning an equal slice of t-space that
+// lines up with the waypoint arc in journey.ts. SceneManager mounts a beat's
+// Scene when it is the active slice or an immediate neighbour (+/-1).
+
+import type { ComponentType } from "react";
+
+import Descent from "@/scenes/Descent";
+import Features from "@/scenes/Features";
+import Finale from "@/scenes/Finale";
+import Fried from "@/scenes/Fried";
+import Godmode from "@/scenes/Godmode";
+import Hero from "@/scenes/Hero";
+import Slump from "@/scenes/Slump";
+import Testimonials from "@/scenes/Testimonials";
+
+export interface Beat {
+  id: string;
+  range: [number, number];
+  Scene: ComponentType;
+}
+
+const S = 1 / 8;
+
+export const BEATS: Beat[] = [
+  { id: "hero", range: [0 * S, 1 * S], Scene: Hero },
+  { id: "slump", range: [1 * S, 2 * S], Scene: Slump },
+  { id: "descent", range: [2 * S, 3 * S], Scene: Descent },
+  { id: "fried", range: [3 * S, 4 * S], Scene: Fried },
+  { id: "godmode", range: [4 * S, 5 * S], Scene: Godmode },
+  { id: "features", range: [5 * S, 6 * S], Scene: Features },
+  { id: "testimonials", range: [6 * S, 7 * S], Scene: Testimonials },
+  { id: "finale", range: [7 * S, 8 * S], Scene: Finale },
+];

--- a/apps/landing/src/engine/clocks.ts
+++ b/apps/landing/src/engine/clocks.ts
@@ -1,0 +1,11 @@
+// Stepped clocks for hand-drawn motion. The ink line-boil must NOT wobble at
+// render framerate -- it reads as digital jitter instead of a hand redrawing
+// the line. boilTime quantizes elapsed seconds to a low step rate (the tier's
+// boilFps, ~8-10) so the vertex-shader noise only advances a few times a
+// second. Feed the result into the boil uniform; identical inputs give
+// identical outputs, so it stays scrub-safe.
+
+export function boilTime(elapsed: number, fps: number): number {
+  if (fps <= 0) return elapsed;
+  return Math.floor(elapsed * fps) / fps;
+}

--- a/apps/landing/src/engine/gate.ts
+++ b/apps/landing/src/engine/gate.ts
@@ -1,0 +1,42 @@
+// Capability gate: the single source of truth for whether the WebGL experience
+// takes over or the legacy prerendered DOM page runs. GLLoader (mounts GL) and
+// LegacyBoot (binds the legacy scroll engine) both read gateVerdict(); the
+// verdict is computed once, lazily, and cached so the two always agree.
+//
+// GL requires ALL of: WebGL2, a fine pointer, viewport wider than 900px, and
+// no reduced-motion preference. Failing any one hands the page to legacy -- so
+// reduced-motion users never reach the fried glitch/CA/dither (comfort
+// contract). No window access at module scope: the probe runs on first call,
+// which is always client-side (GLLoader/LegacyBoot invoke it from an effect).
+
+export interface GateVerdict {
+  gl: boolean;
+  reason: string;
+}
+
+let cached: GateVerdict | null = null;
+
+function probe(): GateVerdict {
+  if (typeof window === "undefined") return { gl: false, reason: "ssr" };
+
+  let webgl2 = false;
+  try {
+    webgl2 = !!document.createElement("canvas").getContext("webgl2");
+  } catch {
+    // webgl2 stays false: a throwing/blocked getContext means no WebGL2.
+  }
+  if (!webgl2) return { gl: false, reason: "no-webgl2" };
+  if (!window.matchMedia("(pointer: fine)").matches) {
+    return { gl: false, reason: "no-fine-pointer" };
+  }
+  if (window.innerWidth <= 900) return { gl: false, reason: "viewport-narrow" };
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    return { gl: false, reason: "reduced-motion" };
+  }
+  return { gl: true, reason: "ok" };
+}
+
+export function gateVerdict(): GateVerdict {
+  if (cached === null) cached = probe();
+  return cached;
+}

--- a/apps/landing/src/engine/journey.ts
+++ b/apps/landing/src/engine/journey.ts
@@ -1,0 +1,96 @@
+// The t-space camera journey: one continuous world the camera rides as global
+// t sweeps [0,1]. Story arc, all in ONE world space:
+//   hero desk (y=0) -> slump (dips down/forward) -> descent (plunges to y=-40)
+//   -> fried (the bottom) -> godmode (rises to y=+20) -> features corridor
+//   -> testimonials wall -> finale (back at the desk).
+//
+// evalPose(t) is a pure function of t (scrub-safe both directions) and writes
+// into module-scoped reusable objects -- ZERO per-frame allocation. Position
+// and look-target each ride their own CatmullRomCurve3; the eye quaternion is
+// derived from a lookAt each frame. Segment lookup is a binary search over the
+// authored waypoint t-values. hardCut waypoints snap (no interpolation into
+// them) so a beat can cut rather than glide -- unused by the P1 spine (the ride
+// is continuous) but wired so later phases can flag a boundary.
+
+import * as THREE from "three";
+
+export interface Waypoint {
+  t: number;
+  position: THREE.Vector3;
+  look: THREE.Vector3;
+  hardCut?: boolean;
+}
+
+// Authored in t-space (ascending, spanning 0..1). One waypoint per beat
+// boundary so the curve threads every beat's vantage point.
+export const WAYPOINTS: Waypoint[] = [
+  { t: 0 / 8, position: new THREE.Vector3(0, 0, 12), look: new THREE.Vector3(0, 0, 0) },
+  { t: 1 / 8, position: new THREE.Vector3(0, -3, 10), look: new THREE.Vector3(1, -4, 0) },
+  { t: 2 / 8, position: new THREE.Vector3(2, -18, 9), look: new THREE.Vector3(2, -24, 0) },
+  { t: 3 / 8, position: new THREE.Vector3(1, -36, 7), look: new THREE.Vector3(0, -42, 0) },
+  { t: 4 / 8, position: new THREE.Vector3(0, -40, 6), look: new THREE.Vector3(0, -44, 0) },
+  { t: 5 / 8, position: new THREE.Vector3(0, 20, 14), look: new THREE.Vector3(0, 22, 0) },
+  { t: 6 / 8, position: new THREE.Vector3(10, 19, 10), look: new THREE.Vector3(22, 19, 0) },
+  { t: 7 / 8, position: new THREE.Vector3(26, 17, 12), look: new THREE.Vector3(26, 17, 0) },
+  { t: 8 / 8, position: new THREE.Vector3(0, 0, 12), look: new THREE.Vector3(0, 0, 0) },
+];
+
+const N = WAYPOINTS.length;
+
+// Curves built once. centripetal parametrization avoids the cusps/overshoot a
+// uniform Catmull-Rom throws on the sharp fried->godmode reversal.
+const posCurve = new THREE.CatmullRomCurve3(
+  WAYPOINTS.map((w) => w.position),
+  false,
+  "centripetal",
+);
+const lookCurve = new THREE.CatmullRomCurve3(
+  WAYPOINTS.map((w) => w.look),
+  false,
+  "centripetal",
+);
+
+// Reusable scratch -- never reallocated per frame.
+const _pos = new THREE.Vector3();
+const _look = new THREE.Vector3();
+const _quat = new THREE.Quaternion();
+const _mat = new THREE.Matrix4();
+const _up = new THREE.Vector3(0, 1, 0);
+const _pose = { position: _pos, quaternion: _quat };
+
+// Binary search: largest i with WAYPOINTS[i].t <= t, clamped to [0, N-2] so
+// i+1 is always a valid neighbour.
+function segmentIndex(t: number): number {
+  let lo = 0;
+  let hi = N - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (WAYPOINTS[mid]!.t <= t) lo = mid;
+    else hi = mid - 1;
+  }
+  return Math.min(lo, N - 2);
+}
+
+export function evalPose(t: number): { position: THREE.Vector3; quaternion: THREE.Quaternion } {
+  const tc = t < 0 ? 0 : t > 1 ? 1 : t;
+  const i = segmentIndex(tc);
+  const a = WAYPOINTS[i]!;
+  const b = WAYPOINTS[i + 1]!;
+
+  // Local fraction inside the segment; snap to the segment start across a hard
+  // cut so the pose holds then jumps at the boundary instead of gliding.
+  const span = b.t - a.t;
+  let f = span > 1e-6 ? (tc - a.t) / span : 0;
+  if (b.hardCut) f = 0;
+
+  // getPoint maps u in [0,1] across (N-1) segments by point index, so
+  // u = (i + f) / (N - 1) samples exactly this segment at fraction f.
+  const u = (i + f) / (N - 1);
+  posCurve.getPoint(u, _pos);
+  lookCurve.getPoint(u, _look);
+
+  _mat.lookAt(_pos, _look, _up);
+  _quat.setFromRotationMatrix(_mat);
+
+  return _pose;
+}

--- a/apps/landing/src/engine/journey.ts
+++ b/apps/landing/src/engine/journey.ts
@@ -36,6 +36,7 @@ export const WAYPOINTS: Waypoint[] = [
 ];
 
 const N = WAYPOINTS.length;
+if (N < 2) throw new Error("journey: WAYPOINTS needs at least 2 entries");
 
 // Curves built once. centripetal parametrization avoids the cusps/overshoot a
 // uniform Catmull-Rom throws on the sharp fried->godmode reversal.
@@ -65,7 +66,8 @@ function segmentIndex(t: number): number {
   let hi = N - 1;
   while (lo < hi) {
     const mid = (lo + hi + 1) >> 1;
-    if (WAYPOINTS[mid]!.t <= t) lo = mid;
+    const wp = WAYPOINTS[mid];
+    if (wp && wp.t <= t) lo = mid;
     else hi = mid - 1;
   }
   return Math.min(lo, N - 2);
@@ -74,8 +76,9 @@ function segmentIndex(t: number): number {
 export function evalPose(t: number): { position: THREE.Vector3; quaternion: THREE.Quaternion } {
   const tc = t < 0 ? 0 : t > 1 ? 1 : t;
   const i = segmentIndex(tc);
-  const a = WAYPOINTS[i]!;
-  const b = WAYPOINTS[i + 1]!;
+  const a = WAYPOINTS[i];
+  const b = WAYPOINTS[i + 1];
+  if (!a || !b) return _pose; // segmentIndex clamps i to [0, N-2], so both are always defined
 
   // Local fraction inside the segment; snap to the segment start across a hard
   // cut so the pose holds then jumps at the boundary instead of gliding.

--- a/apps/landing/src/engine/quality.ts
+++ b/apps/landing/src/engine/quality.ts
@@ -1,0 +1,36 @@
+// Quality tier resolution: one-shot device probe that picks HIGH or LOW at
+// gate time and caches the result module-level so every consumer (dpr, the
+// line-boil clock, the stroke budget) reads one consistent tier for the whole
+// session. Mirrors gate.ts: no window access at module scope, computed lazily
+// on the first client call. HIGH is the safe default under SSR (returned
+// uncached so the first real client call still probes and caches).
+//
+// LOW when the device looks weak -- devicePixelRatio < 1.5 (no retina) OR
+// hardwareConcurrency <= 4 (few cores) -- else HIGH. See TIER_TABLE.
+
+export interface Tier {
+  dpr: number;
+  boilFps: number;
+  strokeBudget: number;
+}
+
+// The webgl-standards quality-tier table, in code. strokeBudget is a scale:
+// 1 = full, 0.5 = halved.
+export const TIER_TABLE: { HIGH: Tier; LOW: Tier } = {
+  HIGH: { dpr: 2, boilFps: 10, strokeBudget: 1 },
+  LOW: { dpr: 1.25, boilFps: 8, strokeBudget: 0.5 },
+};
+
+let cached: Tier | null = null;
+
+function probe(): Tier {
+  const lowDpr = (window.devicePixelRatio || 1) < 1.5;
+  const fewCores = (navigator.hardwareConcurrency || 1) <= 4;
+  return lowDpr || fewCores ? TIER_TABLE.LOW : TIER_TABLE.HIGH;
+}
+
+export function resolveTier(): Tier {
+  if (typeof window === "undefined") return TIER_TABLE.HIGH;
+  if (cached === null) cached = probe();
+  return cached;
+}

--- a/apps/landing/src/engine/scroll.ts
+++ b/apps/landing/src/engine/scroll.ts
@@ -1,0 +1,71 @@
+// Scroll driver: binds Lenis smooth-scroll to GSAP ScrollTrigger and pumps the
+// single global t into journeyStore. The hidden semantic layer supplies the
+// document scroll height, so Lenis runs on the document (no wrapper) and the
+// one ScrollTrigger spans document.body 0..max. GSAP's ticker owns the RAF loop
+// (lagSmoothing off so scrub stays frame-locked), and every Lenis scroll event
+// forces ScrollTrigger.update so the two clocks never drift.
+//
+// initScroll() is call-once from a client effect and returns its own cleanup.
+// Nothing here touches window at module scope (SSR-safe); the whole graph is
+// built inside initScroll, which only ever runs client-side.
+
+import gsap from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import Lenis from "lenis";
+
+import { journeyStore } from "./store";
+
+export function initScroll(): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  gsap.registerPlugin(ScrollTrigger);
+
+  const lenis = new Lenis();
+
+  // GSAP ticker drives Lenis; lagSmoothing off keeps scrub deterministic.
+  const raf = (time: number) => lenis.raf(time * 1000);
+  gsap.ticker.add(raf);
+  gsap.ticker.lagSmoothing(0);
+
+  lenis.on("scroll", ScrollTrigger.update);
+
+  const st = ScrollTrigger.create({
+    trigger: document.body,
+    start: 0,
+    end: "max",
+    scrub: true,
+    onUpdate: (self) => {
+      journeyStore.setState({ t: self.progress, vel: lenis.velocity });
+    },
+  });
+
+  // Height is only correct once webfonts have laid out; refresh again on resize.
+  document.fonts.ready.then(() => ScrollTrigger.refresh());
+
+  let resizeTimer: ReturnType<typeof setTimeout> | undefined;
+  const onResize = () => {
+    if (resizeTimer !== undefined) clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => ScrollTrigger.refresh(), 150);
+  };
+  window.addEventListener("resize", onResize);
+
+  // Debug ride: ?t=0.42 jumps straight to that progress once layout is settled.
+  const param = new URLSearchParams(window.location.search).get("t");
+  if (param !== null) {
+    const target = Number(param);
+    if (Number.isFinite(target)) {
+      const clamped = Math.min(1, Math.max(0, target));
+      ScrollTrigger.refresh();
+      lenis.scrollTo(st.end * clamped, { immediate: true });
+    }
+  }
+
+  return () => {
+    window.removeEventListener("resize", onResize);
+    if (resizeTimer !== undefined) clearTimeout(resizeTimer);
+    lenis.off("scroll", ScrollTrigger.update);
+    gsap.ticker.remove(raf);
+    st.kill();
+    lenis.destroy();
+  };
+}

--- a/apps/landing/src/engine/store.ts
+++ b/apps/landing/src/engine/store.ts
@@ -1,0 +1,18 @@
+// Journey state: the single vanilla zustand store the whole GL engine reads
+// per-frame. scroll.ts is the ONLY writer (via ScrollTrigger.onUpdate); every
+// consumer (camera, beats, effects) reads journeyStore.getState() inside its
+// useFrame -- never a React selector in a hot path, which would re-render on
+// every scroll tick. Two fields only: t (global progress in [0,1], the t-space
+// authority) and vel (Lenis scroll velocity, for motion-reactive effects).
+
+import { createStore } from "zustand/vanilla";
+
+export interface JourneyState {
+  t: number;
+  vel: number;
+}
+
+export const journeyStore = createStore<JourneyState>(() => ({
+  t: 0,
+  vel: 0,
+}));

--- a/apps/landing/src/experience/Experience.tsx
+++ b/apps/landing/src/experience/Experience.tsx
@@ -8,13 +8,14 @@
 // journeyStore, and LoaderLift clears the boot overlay on the first painted GL
 // frame.
 //
-// GLLoader only mounts this after the capability gate passes and after hiding
-// (visibility:hidden + inert, never display:none) the semantic layer, which
-// remains the scroll-height / SEO / a11y authority. The canvas wrapper is
-// pointer-events:none for this phase -- there are no GL-side hit targets yet and
-// the semantic layer is inert, so nothing should intercept pointer input.
+// GLLoader mounts this after the capability gate passes, but only hides
+// (visibility:hidden + inert, never display:none) the semantic layer once
+// this component reports onReady on its first painted frame -- see GLLoader
+// for the full choreography (error boundary + skip-link fall back to legacy).
+// The canvas wrapper is pointer-events:none for this phase -- there are no
+// GL-side hit targets yet, so nothing should intercept pointer input.
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Canvas, useFrame } from "@react-three/fiber";
 
 import { resolveTier } from "@/engine/quality";
@@ -23,23 +24,27 @@ import { Composer } from "@/post/composer";
 
 import SceneManager from "./SceneManager";
 
-// One-shot boot-overlay lift. Runs at priority 2 -- after Composer's priority-1
-// composer.render() -- so #loader only starts fading once GL has actually
-// painted its first frame (no flash of empty canvas). In GL mode the legacy
-// engine, which normally clears the loader, stood down at the gate, so this is
-// the only thing that lifts it. Idempotent via the module-guard-free ref-less
-// early return once the class is applied.
-function LoaderLift() {
+// One-shot boot-overlay lift + ready signal. Runs at priority 2 -- after
+// Composer's priority-1 composer.render() -- so #loader only starts fading,
+// and onReady only fires, once GL has actually painted its first frame (no
+// flash of empty canvas). In GL mode the legacy engine, which normally clears
+// the loader, stood down at the gate, so this is the only thing that lifts
+// it. Guarded by a `done` ref, checked first, so the per-frame DOM lookup
+// only ever runs once per mount instead of every frame for the whole
+// session. If #loader is missing entirely, still mark done and fire onReady
+// -- otherwise the semantic root would never hide.
+function LoaderLift({ onReady }: { onReady: () => void }) {
+  const done = useRef(false);
   useFrame(() => {
-    const loader = document.getElementById("loader");
-    if (loader && !loader.classList.contains("gone")) {
-      loader.classList.add("gone");
-    }
+    if (done.current) return;
+    document.getElementById("loader")?.classList.add("gone");
+    done.current = true;
+    onReady();
   }, 2);
   return null;
 }
 
-export default function Experience() {
+export default function Experience({ onReady }: { onReady: () => void }) {
   const tier = resolveTier();
 
   // Scroll spine: mounted once, client-only. initScroll returns its own cleanup
@@ -64,7 +69,7 @@ export default function Experience() {
     >
       <SceneManager />
       <Composer />
-      <LoaderLift />
+      <LoaderLift onReady={onReady} />
     </Canvas>
   );
 }

--- a/apps/landing/src/experience/Experience.tsx
+++ b/apps/landing/src/experience/Experience.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+// The GL takeover root (Wire phase). Mounts the full-canvas R3F <Canvas> that
+// carries the 8-beat t-space sketchbook journey: SceneManager keeps the beats
+// near the camera mounted, Composer owns the sole render loop (RenderPass + the
+// always-on SketchbookEffect) and drives the camera pose from the scroll-driven
+// global t. initScroll wires Lenis + ScrollTrigger to pump that t into
+// journeyStore, and LoaderLift clears the boot overlay on the first painted GL
+// frame.
+//
+// GLLoader only mounts this after the capability gate passes and after hiding
+// (visibility:hidden + inert, never display:none) the semantic layer, which
+// remains the scroll-height / SEO / a11y authority. The canvas wrapper is
+// pointer-events:none for this phase -- there are no GL-side hit targets yet and
+// the semantic layer is inert, so nothing should intercept pointer input.
+
+import { useEffect } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
+
+import { resolveTier } from "@/engine/quality";
+import { initScroll } from "@/engine/scroll";
+import { Composer } from "@/post/composer";
+
+import SceneManager from "./SceneManager";
+
+// One-shot boot-overlay lift. Runs at priority 2 -- after Composer's priority-1
+// composer.render() -- so #loader only starts fading once GL has actually
+// painted its first frame (no flash of empty canvas). In GL mode the legacy
+// engine, which normally clears the loader, stood down at the gate, so this is
+// the only thing that lifts it. Idempotent via the module-guard-free ref-less
+// early return once the class is applied.
+function LoaderLift() {
+  useFrame(() => {
+    const loader = document.getElementById("loader");
+    if (loader && !loader.classList.contains("gone")) {
+      loader.classList.add("gone");
+    }
+  }, 2);
+  return null;
+}
+
+export default function Experience() {
+  const tier = resolveTier();
+
+  // Scroll spine: mounted once, client-only. initScroll returns its own cleanup
+  // (kills the ScrollTrigger, destroys Lenis, detaches the ticker/listeners), so
+  // a StrictMode double-mount tears the first graph down cleanly.
+  useEffect(() => initScroll(), []);
+
+  return (
+    <Canvas
+      frameloop="always"
+      dpr={tier.dpr}
+      gl={{ antialias: false }}
+      style={{
+        position: "fixed",
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        zIndex: 1,
+        pointerEvents: "none",
+      }}
+    >
+      <SceneManager />
+      <Composer />
+      <LoaderLift />
+    </Canvas>
+  );
+}

--- a/apps/landing/src/experience/SceneManager.tsx
+++ b/apps/landing/src/experience/SceneManager.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+// Mounts only the beats near the camera. Every frame it reads the scrub value
+// straight off the vanilla store (journeyStore.getState().t -- no React
+// selector in the hot path) and resolves which beat slice t sits in. It keeps
+// the active beat and its two neighbours mounted and lets R3F unmount+dispose
+// the rest, so the scene graph stays small as the camera rides the journey.
+
+import { useState } from "react";
+import { useFrame } from "@react-three/fiber";
+
+import { BEATS } from "@/engine/beats";
+import { journeyStore } from "@/engine/store";
+
+function activeIndex(t: number): number {
+  for (let i = 0; i < BEATS.length; i++) {
+    const [lo, hi] = BEATS[i]!.range;
+    if (t < hi) return t < lo ? 0 : i;
+  }
+  return BEATS.length - 1;
+}
+
+export default function SceneManager() {
+  const [active, setActive] = useState(0);
+
+  // Default priority (0): observe the store, drive React only when the active
+  // beat actually changes -- not a per-frame setState.
+  useFrame(() => {
+    const idx = activeIndex(journeyStore.getState().t);
+    if (idx !== active) setActive(idx);
+  });
+
+  return (
+    <>
+      {BEATS.map((beat, i) => {
+        if (Math.abs(i - active) > 1) return null;
+        const Scene = beat.Scene;
+        return <Scene key={beat.id} />;
+      })}
+    </>
+  );
+}

--- a/apps/landing/src/experience/SceneManager.tsx
+++ b/apps/landing/src/experience/SceneManager.tsx
@@ -14,7 +14,9 @@ import { journeyStore } from "@/engine/store";
 
 function activeIndex(t: number): number {
   for (let i = 0; i < BEATS.length; i++) {
-    const [lo, hi] = BEATS[i]!.range;
+    const beat = BEATS[i];
+    if (!beat) continue; // loop bound guarantees this index is always defined
+    const [lo, hi] = beat.range;
     if (t < hi) return t < lo ? 0 : i;
   }
   return BEATS.length - 1;

--- a/apps/landing/src/fallback/LegacyBoot.tsx
+++ b/apps/landing/src/fallback/LegacyBoot.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from "react";
 
+import { gateVerdict } from "@/engine/gate";
+
 import { initLegacy } from "./legacy";
 
 // Client boot shim. The static markup rendered by the semantic server components
@@ -10,6 +12,9 @@ import { initLegacy } from "./legacy";
 // those selectors by initLegacy(). initLegacy has its own double-init guard.
 export default function LegacyBoot() {
   useEffect(() => {
+    // Single source of truth: when GL mounts, the legacy scroll engine must NOT
+    // also bind. GLLoader reads the same cached verdict from the gate module.
+    if (gateVerdict().gl) return;
     initLegacy();
   }, []);
   return null;

--- a/apps/landing/src/post/composer.tsx
+++ b/apps/landing/src/post/composer.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+// The one and only render driver for the GL experience. Lives inside the R3F
+// <Canvas>. It owns the postprocessing EffectComposer (built once) and the sole
+// priority>0 useFrame in the app: because a positive priority hands the render
+// loop to us, R3F stops auto-rendering and every frame flows through
+// composer.render() here.
+//
+// Per frame it: (1) reads the scroll-driven global t from journeyStore, (2)
+// evaluates the camera pose for that t and copies it onto the default camera
+// (evalPose writes into reusable objects -> zero per-frame allocation), (3)
+// advances the sketchbook boil clock via clocks.boilTime (stepped to the tier's
+// boilFps), then (4) renders the composer.
+
+import { EffectComposer, EffectPass, RenderPass } from "postprocessing";
+import { useEffect,useMemo } from "react";
+import { HalfFloatType, type Uniform } from "three";
+import { useFrame, useThree } from "@react-three/fiber";
+
+import { boilTime } from "@/engine/clocks";
+import { evalPose } from "@/engine/journey";
+import { resolveTier } from "@/engine/quality";
+import { journeyStore } from "@/engine/store";
+import { SketchbookEffect } from "@/post/sketchbook-effect";
+
+export function Composer() {
+  const gl = useThree((s) => s.gl);
+  const scene = useThree((s) => s.scene);
+  const camera = useThree((s) => s.camera);
+
+  // Build the pipeline once. RenderPass draws the scene, then Pass A (the always
+  // -on SketchbookEffect). Rebuilds only if the renderer/scene/camera identity
+  // changes (it does not, in practice).
+  const { composer, boilUniform, tier } = useMemo(() => {
+    const tier = resolveTier();
+    const composer = new EffectComposer(gl, {
+      frameBufferType: HalfFloatType,
+      multisampling: 0,
+    });
+    composer.addPass(new RenderPass(scene, camera));
+    const sketchbook = new SketchbookEffect();
+    composer.addPass(new EffectPass(camera, sketchbook));
+    const boilUniform = sketchbook.uniforms.get("uBoilTime") as Uniform;
+    return { composer, boilUniform, tier };
+  }, [gl, scene, camera]);
+
+  // Keep the composer's buffers matched to the viewport. setSize takes CSS pixels
+  // and applies the renderer pixel ratio internally.
+  useEffect(() => {
+    const onResize = () => composer.setSize(window.innerWidth, window.innerHeight);
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [composer]);
+
+  // Release GPU resources when the Canvas unmounts.
+  useEffect(() => () => composer.dispose(), [composer]);
+
+  useFrame((state, delta) => {
+    const t = journeyStore.getState().t;
+    const pose = evalPose(t);
+    state.camera.position.copy(pose.position);
+    state.camera.quaternion.copy(pose.quaternion);
+    boilUniform.value = boilTime(state.clock.elapsedTime, tier.boilFps);
+    composer.render(delta);
+  }, 1);
+
+  return null;
+}

--- a/apps/landing/src/post/composer.tsx
+++ b/apps/landing/src/post/composer.tsx
@@ -13,7 +13,7 @@
 // boilFps), then (4) renders the composer.
 
 import { EffectComposer, EffectPass, RenderPass } from "postprocessing";
-import { useEffect,useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { HalfFloatType, type Uniform } from "three";
 import { useFrame, useThree } from "@react-three/fiber";
 

--- a/apps/landing/src/post/sketchbook-effect.ts
+++ b/apps/landing/src/post/sketchbook-effect.ts
@@ -73,7 +73,7 @@ void mainImage(const in vec4 inputColor, const in vec2 uv, out vec4 outputColor)
   color *= vec3(1.03, 1.0, 0.94);
 
   // Warm vignette: fade to a warm brown toward the edges, scaled by uVignette.
-  float vig = smoothstep(0.8, 0.4, length(uv - 0.5));
+  float vig = 1.0 - smoothstep(0.4, 0.8, length(uv - 0.5));
   float vigAmt = mix(1.0, vig, uVignette);
   color *= mix(vec3(1.0), vec3(0.82, 0.76, 0.68), 1.0 - vigAmt);
 

--- a/apps/landing/src/post/sketchbook-effect.ts
+++ b/apps/landing/src/post/sketchbook-effect.ts
@@ -1,0 +1,101 @@
+// Pass A of the two-pass post pipeline (always on): one merged custom Effect
+// that gives the whole frame its "living sketchbook" surface -- procedural paper
+// grain + fiber (fbm hash noise, warm tint), a subtle derivative-based ink bleed
+// (luminance-edge darkening -- NO neighbor-tap convolution, so this Effect needs
+// no CONVOLUTION attribute and composes freely in one EffectPass), and a warm
+// vignette. All animation is keyed to uBoilTime (stepped by clocks.boilTime), so
+// the grain "boils" at a hand-drawn cadence instead of shimmering per-frame.
+//
+// Uniforms (all float): uGrain, uBleed, uVignette, uBoilTime.
+// GLSL is ASCII-only (Turbopack multi-byte sourcemap crash); every helper is
+// prefixed ajh_ to avoid colliding with postprocessing's injected built-ins
+// (resolution, texelSize, aspect, time). blendFunction is fixed at construction
+// and never swapped at runtime (a swap recompiles the whole EffectPass).
+
+import { Effect } from "postprocessing";
+import { Uniform } from "three";
+
+// inputColor arrives already in the composer's working (linear) space -- there is
+// no external texture sampled here, so no manual pow(rgb, 2.2) sRGB decode is
+// needed (that rule is for textures you sample yourself).
+const fragmentShader = /* glsl */ `
+uniform float uGrain;
+uniform float uBleed;
+uniform float uVignette;
+uniform float uBoilTime;
+
+float ajh_hash(vec2 p) {
+  p = fract(p * vec2(123.34, 456.21));
+  p += dot(p, p + 45.32);
+  return fract(p.x * p.y);
+}
+
+float ajh_noise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  f = f * f * (3.0 - 2.0 * f);
+  float a = ajh_hash(i);
+  float b = ajh_hash(i + vec2(1.0, 0.0));
+  float c = ajh_hash(i + vec2(0.0, 1.0));
+  float d = ajh_hash(i + vec2(1.0, 1.0));
+  return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+float ajh_fbm(vec2 p) {
+  float v = 0.0;
+  float amp = 0.5;
+  for (int i = 0; i < 4; i++) {
+    v += amp * ajh_noise(p);
+    p *= 2.0;
+    amp *= 0.5;
+  }
+  return v;
+}
+
+void mainImage(const in vec4 inputColor, const in vec2 uv, out vec4 outputColor) {
+  vec3 color = inputColor.rgb;
+
+  // Ink bleed: darken luminance edges using screen-space derivatives only, so no
+  // neighbor texel is sampled (derivative-based -> no CONVOLUTION attribute).
+  float lum = dot(color, vec3(0.299, 0.587, 0.114));
+  float edge = length(vec2(dFdx(lum), dFdy(lum)));
+  color *= 1.0 - clamp(edge * uBleed * 8.0, 0.0, 0.55);
+
+  // Paper grain + fiber, pixel-locked and animated on the stepped boil clock so
+  // the surface "boils" at a hand-drawn cadence rather than per-frame shimmer.
+  vec2 gp = uv * resolution;
+  float fiber = ajh_fbm(gp * 0.03 + uBoilTime * 0.13);
+  float grain = ajh_hash(gp + uBoilTime * 1.7) - 0.5;
+  color *= mix(1.0, 0.85 + 0.30 * fiber, 0.6);
+  color += grain * uGrain;
+
+  // Warm paper tint.
+  color *= vec3(1.03, 1.0, 0.94);
+
+  // Warm vignette: fade to a warm brown toward the edges, scaled by uVignette.
+  float vig = smoothstep(0.8, 0.4, length(uv - 0.5));
+  float vigAmt = mix(1.0, vig, uVignette);
+  color *= mix(vec3(1.0), vec3(0.82, 0.76, 0.68), 1.0 - vigAmt);
+
+  outputColor = vec4(color, inputColor.a);
+}
+`;
+
+export interface SketchbookOptions {
+  grain?: number;
+  bleed?: number;
+  vignette?: number;
+}
+
+export class SketchbookEffect extends Effect {
+  constructor({ grain = 0.06, bleed = 0.5, vignette = 0.35 }: SketchbookOptions = {}) {
+    super("SketchbookEffect", fragmentShader, {
+      uniforms: new Map<string, Uniform>([
+        ["uGrain", new Uniform(grain)],
+        ["uBleed", new Uniform(bleed)],
+        ["uVignette", new Uniform(vignette)],
+        ["uBoilTime", new Uniform(0)],
+      ]),
+    });
+  }
+}

--- a/apps/landing/src/scenes/Descent.tsx
+++ b/apps/landing/src/scenes/Descent.tsx
@@ -1,0 +1,17 @@
+// P1 placeholder -- a tall vertical page marking the plunge shaft. Elongated
+// so the drop reads as motion as the camera falls past it. No fonts in P1.
+// ponytail: flat MeshBasic stand-in (ceiling: no art yet).
+export default function Descent() {
+  return (
+    <group position={[2, -24, 0]}>
+      <mesh>
+        <planeGeometry args={[6, 16]} />
+        <meshBasicMaterial color="#f4ecdc" side={2} />
+      </mesh>
+      <mesh position={[0, 0, 0.1]}>
+        <boxGeometry args={[0.6, 12, 0.1]} />
+        <meshBasicMaterial color="#1c1812" />
+      </mesh>
+    </group>
+  );
+}

--- a/apps/landing/src/scenes/Features.tsx
+++ b/apps/landing/src/scenes/Features.tsx
@@ -1,0 +1,19 @@
+// P1 placeholder -- the corridor: a wide page with a row of dark blocks the
+// camera tracks along at x=22. No fonts in P1.
+// ponytail: flat MeshBasic stand-in (ceiling: no art yet).
+export default function Features() {
+  return (
+    <group position={[22, 19, 0]}>
+      <mesh>
+        <planeGeometry args={[14, 6]} />
+        <meshBasicMaterial color="#f4ecdc" side={2} />
+      </mesh>
+      {[-4.5, 0, 4.5].map((x) => (
+        <mesh key={x} position={[x, 0, 0.1]}>
+          <boxGeometry args={[2.6, 3, 0.1]} />
+          <meshBasicMaterial color="#1c1812" />
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/apps/landing/src/scenes/Finale.tsx
+++ b/apps/landing/src/scenes/Finale.tsx
@@ -1,0 +1,21 @@
+// P1 placeholder -- back at the desk (world origin) to close the loop, with a
+// framed accent so it reads distinct from the hero page. No fonts in P1.
+// ponytail: flat MeshBasic stand-in (ceiling: no art yet).
+export default function Finale() {
+  return (
+    <group position={[0, 0, 0]}>
+      <mesh>
+        <planeGeometry args={[10, 6]} />
+        <meshBasicMaterial color="#f4ecdc" side={2} />
+      </mesh>
+      <mesh position={[0, 0, 0.1]}>
+        <boxGeometry args={[7, 4, 0.1]} />
+        <meshBasicMaterial color="#1c1812" />
+      </mesh>
+      <mesh position={[0, 0, 0.2]}>
+        <boxGeometry args={[6, 3, 0.1]} />
+        <meshBasicMaterial color="#f4ecdc" />
+      </mesh>
+    </group>
+  );
+}

--- a/apps/landing/src/scenes/Fried.tsx
+++ b/apps/landing/src/scenes/Fried.tsx
@@ -1,0 +1,26 @@
+// P1 placeholder -- the bottom of the shaft: a page scattered with jittered
+// dark blocks, standing in for the deep-fried glitch beat (Pass B lives here in
+// a later phase). No fonts in P1.
+// ponytail: flat MeshBasic stand-in (ceiling: no glitch/CA/dither yet).
+export default function Fried() {
+  return (
+    <group position={[0, -43, 0]}>
+      <mesh>
+        <planeGeometry args={[10, 8]} />
+        <meshBasicMaterial color="#f4ecdc" side={2} />
+      </mesh>
+      <mesh position={[-2.5, 1.2, 0.1]} rotation={[0, 0, 0.2]}>
+        <boxGeometry args={[2.4, 1.2, 0.1]} />
+        <meshBasicMaterial color="#1c1812" />
+      </mesh>
+      <mesh position={[2, -0.6, 0.1]} rotation={[0, 0, -0.3]}>
+        <boxGeometry args={[1.8, 1.6, 0.1]} />
+        <meshBasicMaterial color="#1c1812" />
+      </mesh>
+      <mesh position={[0.4, 2, 0.1]} rotation={[0, 0, 0.5]}>
+        <boxGeometry args={[1.2, 0.8, 0.1]} />
+        <meshBasicMaterial color="#1c1812" />
+      </mesh>
+    </group>
+  );
+}

--- a/apps/landing/src/scenes/Godmode.tsx
+++ b/apps/landing/src/scenes/Godmode.tsx
@@ -1,0 +1,18 @@
+// P1 placeholder -- the high point: an inverted page (dark ground, light
+// accent) up at y=+22 to signal the tonal flip after the fried bottom. No fonts
+// in P1.
+// ponytail: flat MeshBasic stand-in (ceiling: no art yet).
+export default function Godmode() {
+  return (
+    <group position={[0, 22, 0]}>
+      <mesh>
+        <planeGeometry args={[12, 8]} />
+        <meshBasicMaterial color="#1c1812" side={2} />
+      </mesh>
+      <mesh position={[0, 0, 0.1]}>
+        <boxGeometry args={[7, 1, 0.1]} />
+        <meshBasicMaterial color="#f4ecdc" />
+      </mesh>
+    </group>
+  );
+}

--- a/apps/landing/src/scenes/Hero.tsx
+++ b/apps/landing/src/scenes/Hero.tsx
@@ -1,0 +1,18 @@
+// P1 placeholder -- paper page + a single dark title bar. Sits at the desk
+// (world origin), the hero waypoint's look target. No fonts in P1 (that is P2).
+// ponytail: flat MeshBasic paper stand-in (ceiling: no ink/boil/text yet).
+// Upgrade path: P2 replaces the accent geometry with drei Text + Line2 strokes.
+export default function Hero() {
+  return (
+    <group position={[0, 0, 0]}>
+      <mesh>
+        <planeGeometry args={[10, 6]} />
+        <meshBasicMaterial color="#f4ecdc" side={2} />
+      </mesh>
+      <mesh position={[0, 1, 0.1]}>
+        <boxGeometry args={[6, 0.8, 0.1]} />
+        <meshBasicMaterial color="#1c1812" />
+      </mesh>
+    </group>
+  );
+}

--- a/apps/landing/src/scenes/Slump.tsx
+++ b/apps/landing/src/scenes/Slump.tsx
@@ -1,0 +1,17 @@
+// P1 placeholder -- a slightly tilted paper page sitting down/forward of the
+// desk. Tilt telegraphs the slump before the plunge. No fonts in P1.
+// ponytail: flat MeshBasic stand-in (ceiling: no art yet).
+export default function Slump() {
+  return (
+    <group position={[1, -4, 0]} rotation={[0, 0, -0.14]}>
+      <mesh>
+        <planeGeometry args={[9, 6]} />
+        <meshBasicMaterial color="#ece2cd" side={2} />
+      </mesh>
+      <mesh position={[0, -1, 0.1]}>
+        <boxGeometry args={[4.5, 0.6, 0.1]} />
+        <meshBasicMaterial color="#1c1812" />
+      </mesh>
+    </group>
+  );
+}

--- a/apps/landing/src/scenes/Testimonials.tsx
+++ b/apps/landing/src/scenes/Testimonials.tsx
@@ -1,0 +1,25 @@
+// P1 placeholder -- the wall: a page carrying a 2x2 grid of dark cards at
+// x=26. No fonts in P1.
+// ponytail: flat MeshBasic stand-in (ceiling: no art yet).
+export default function Testimonials() {
+  const cells: [number, number][] = [
+    [-2.4, 1.6],
+    [2.4, 1.6],
+    [-2.4, -1.6],
+    [2.4, -1.6],
+  ];
+  return (
+    <group position={[26, 17, 0]}>
+      <mesh>
+        <planeGeometry args={[10, 8]} />
+        <meshBasicMaterial color="#f4ecdc" side={2} />
+      </mesh>
+      {cells.map(([x, y]) => (
+        <mesh key={`${x},${y}`} position={[x, y, 0.1]}>
+          <boxGeometry args={[3.4, 2.4, 0.1]} />
+          <meshBasicMaterial color="#1c1812" />
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "dev": "pnpm build:packages && cargo fetch --manifest-path apps/desktop/src-tauri/Cargo.toml && pnpm --filter @ajh/desktop dev",
+    "dev:landing": "pnpm --filter @ajh/landing dev",
     "build": "turbo build",
     "build:packages": "turbo build --filter=!@ajh/desktop",
     "build:chrome": "pnpm --filter @ajh/extension build:chrome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,15 +262,36 @@ importers:
 
   apps/landing:
     dependencies:
+      '@react-three/drei':
+        specifier: 10.7.7
+        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1))(@types/react@19.2.17)(@types/three@0.185.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1)
+      '@react-three/fiber':
+        specifier: 9.6.1
+        version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1)
+      gsap:
+        specifier: 3.15.0
+        version: 3.15.0
+      lenis:
+        specifier: 1.3.25
+        version: 1.3.25(react@19.2.7)
       next:
         specifier: 16.2.10
         version: 16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      postprocessing:
+        specifier: 6.39.2
+        version: 6.39.2(three@0.185.1)
       react:
         specifier: 19.2.7
         version: 19.2.7
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      three:
+        specifier: 0.185.1
+        version: 0.185.1
+      zustand:
+        specifier: 5.0.14
+        version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
       '@types/node':
         specifier: 26.1.1
@@ -281,6 +302,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/three':
+        specifier: 0.185.1
+        version: 0.185.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -736,6 +760,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/core@1.11.0':
     resolution: {integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==}
@@ -1314,6 +1341,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mediapipe/tasks-vision@0.10.17':
+    resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
+
+  '@monogrid/gainmap-js@3.4.0':
+    resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -1808,6 +1843,42 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@react-three/drei@10.7.7':
+    resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
+    peerDependencies:
+      '@react-three/fiber': ^9.0.0
+      react: ^19
+      react-dom: ^19
+      three: '>=0.159'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  '@react-three/fiber@9.6.1':
+    resolution: {integrity: sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
 
   '@rolldown/binding-android-arm64@1.1.4':
     resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
@@ -2658,6 +2729,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -2690,6 +2764,9 @@ packages:
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+
+  '@types/draco3d@1.4.10':
+    resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -2727,16 +2804,30 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.185.1':
+    resolution: {integrity: sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2746,6 +2837,9 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@typescript-eslint/eslint-plugin@8.63.0':
     resolution: {integrity: sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==}
@@ -2965,6 +3059,14 @@ packages:
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
+
+  '@use-gesture/core@10.3.1':
+    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
+
+  '@use-gesture/react@10.3.1':
+    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
+    peerDependencies:
+      react: '>= 16.8.0'
 
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
@@ -3196,6 +3298,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.40:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
@@ -3229,6 +3334,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -3248,6 +3356,12 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  camera-controls@3.1.2:
+    resolution: {integrity: sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==}
+    engines: {node: '>=22.0.0', npm: '>=10.5.1'}
+    peerDependencies:
+      three: '>=0.126.1'
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
@@ -3455,6 +3569,11 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3542,6 +3661,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-gpu@5.0.70:
+    resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -3574,6 +3696,9 @@ packages:
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
+
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3836,6 +3961,12 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.6.10:
+    resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
     engines: {node: '>=4'}
@@ -3995,6 +4126,9 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  glsl-noise@0.0.0:
+    resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -4004,6 +4138,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gsap@3.15.0:
+    resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -4055,6 +4192,9 @@ packages:
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
   hook-std@4.0.0:
     resolution: {integrity: sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==}
@@ -4129,6 +4269,9 @@ packages:
   idb-keyval@6.2.5:
     resolution: {integrity: sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -4136,6 +4279,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -4306,6 +4452,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -4394,6 +4543,11 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
+
   java-properties@1.0.2:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
@@ -4481,9 +4635,26 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  lenis@1.3.25:
+    resolution: {integrity: sha512-mOKxayErlaONK8fm4LN3XNd99Qu4plTpn9h9qf8wxzjGrJDzuD84FYzZ81HCd6ZsWp++VWVwOzL286Pf2s2u4A==}
+    peerDependencies:
+      '@nuxt/kit': '>=3.0.0'
+      react: '>=17.0.0'
+      vue: '>=3.0.0'
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      react:
+        optional: true
+      vue:
+        optional: true
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -4641,6 +4812,12 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  maath@0.10.8:
+    resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
+    peerDependencies:
+      '@types/three': '>=0.134.0'
+      three: '>=0.134.0'
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -4731,6 +4908,14 @@ packages:
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  meshline@3.3.1:
+    resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
+    peerDependencies:
+      three: '>=0.137'
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -5274,6 +5459,14 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postprocessing@6.39.2:
+    resolution: {integrity: sha512-AxPY+xFyVOsz+8bbHSyQBoOK4AUqSQspTXXIsNcKhmGJRm/afHRAwZ8bKC02AeSPII0PW6lbCN84SgAoWFsKKA==}
+    peerDependencies:
+      three: '>= 0.168.0 < 0.186.0'
+
+  potpack@1.0.2:
+    resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5298,6 +5491,9 @@ packages:
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  promise-worker-transferable@1.0.4:
+    resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -5411,6 +5607,15 @@ packages:
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -5687,6 +5892,15 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stats-gl@2.4.2:
+    resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
+    peerDependencies:
+      '@types/three': '*'
+      three: '*'
+
+  stats.js@0.17.0:
+    resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -5836,6 +6050,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -5873,6 +6092,19 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  three-mesh-bvh@0.8.3:
+    resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
+  three-stdlib@2.36.1:
+    resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
+    peerDependencies:
+      three: '>=0.128.0'
+
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
 
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
@@ -5943,6 +6175,19 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  troika-three-text@0.52.4:
+    resolution: {integrity: sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-three-utils@0.52.4:
+    resolution: {integrity: sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-worker-utils@0.52.0:
+    resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
+
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
@@ -5967,6 +6212,9 @@ packages:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
@@ -6156,6 +6404,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -6269,6 +6521,12 @@ packages:
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
+
+  webgl-constants@1.1.1:
+    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
+
+  webgl-sdf-generator@1.1.1:
+    resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -6410,6 +6668,21 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zustand@5.0.14:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
@@ -6769,6 +7042,8 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@emnapi/core@1.11.0':
     dependencies:
@@ -7207,6 +7482,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mediapipe/tasks-vision@0.10.17': {}
+
+  '@monogrid/gainmap-js@3.4.0(three@0.185.1)':
+    dependencies:
+      promise-worker-transferable: 1.0.4
+      three: 0.185.1
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
       '@emnapi/core': 1.11.0
@@ -7526,6 +7808,59 @@ snapshots:
       config-chain: 1.1.13
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1))(@types/react@19.2.17)(@types/three@0.185.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mediapipe/tasks-vision': 0.10.17
+      '@monogrid/gainmap-js': 3.4.0(three@0.185.1)
+      '@react-three/fiber': 9.6.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1)
+      '@use-gesture/react': 10.3.1(react@19.2.7)
+      camera-controls: 3.1.2(three@0.185.1)
+      cross-env: 7.0.3
+      detect-gpu: 5.0.70
+      glsl-noise: 0.0.0
+      hls.js: 1.6.16
+      maath: 0.10.8(@types/three@0.185.1)(three@0.185.1)
+      meshline: 3.3.1(three@0.185.1)
+      react: 19.2.7
+      stats-gl: 2.4.2(@types/three@0.185.1)(three@0.185.1)
+      stats.js: 0.17.0
+      suspend-react: 0.1.3(react@19.2.7)
+      three: 0.185.1
+      three-mesh-bvh: 0.8.3(three@0.185.1)
+      three-stdlib: 2.36.1(three@0.185.1)
+      troika-three-text: 0.52.4(three@0.185.1)
+      tunnel-rat: 0.1.2(@types/react@19.2.17)(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      utility-types: 3.11.0
+      zustand: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/three'
+      - immer
+
+  '@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-use-measure: 2.1.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.7)
+      three: 0.185.1
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      zustand: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
 
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
@@ -8333,6 +8668,8 @@ snapshots:
   '@turbo/windows-arm64@2.10.5':
     optional: true
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -8379,6 +8716,8 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/draco3d@1.4.10': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree-jsx@1.0.5':
@@ -8413,7 +8752,13 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/offscreencanvas@2019.7.3': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react-reconciler@0.28.9(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
 
@@ -8423,11 +8768,24 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.185.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -8632,6 +8990,13 @@ snapshots:
     optional: true
 
   '@ungap/structured-clone@1.3.2': {}
+
+  '@use-gesture/core@10.3.1': {}
+
+  '@use-gesture/react@10.3.1(react@19.2.7)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 19.2.7
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
@@ -8918,6 +9283,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.40: {}
 
   before-after-hook@4.0.0: {}
@@ -8951,6 +9318,11 @@ snapshots:
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -8973,6 +9345,10 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
+
+  camera-controls@3.1.2(three@0.185.1):
+    dependencies:
+      three: 0.185.1
 
   caniuse-lite@1.0.30001799: {}
 
@@ -9166,6 +9542,10 @@ snapshots:
       '@epic-web/invariant': 1.0.0
       cross-spawn: 7.0.6
 
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -9251,6 +9631,10 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-gpu@5.0.70:
+    dependencies:
+      webgl-constants: 1.1.1
+
   detect-libc@2.1.2: {}
 
   devlop@1.1.0:
@@ -9278,6 +9662,8 @@ snapshots:
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
+
+  draco3d@1.5.7: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -9682,6 +10068,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fflate@0.6.10: {}
+
+  fflate@0.8.3: {}
+
   figures@2.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -9847,11 +10237,15 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  glsl-noise@0.0.0: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
+
+  gsap@3.15.0: {}
 
   handlebars@4.7.9:
     dependencies:
@@ -9917,6 +10311,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   highlight.js@10.7.3: {}
+
+  hls.js@1.6.16: {}
 
   hook-std@4.0.0: {}
 
@@ -10015,9 +10411,13 @@ snapshots:
 
   idb-keyval@6.2.5: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immediate@3.0.6: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -10172,6 +10572,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@2.2.2: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -10260,6 +10662,13 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
+
+  its-fine@2.0.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.17)
+      react: 19.2.7
+    transitivePeerDependencies:
+      - '@types/react'
 
   java-properties@1.0.2: {}
 
@@ -10360,10 +10769,18 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  lenis@1.3.25(react@19.2.7):
+    optionalDependencies:
+      react: 19.2.7
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -10497,6 +10914,11 @@ snapshots:
       react: 19.2.7
 
   lz-string@1.5.0: {}
+
+  maath@0.10.8(@types/three@0.185.1)(three@0.185.1):
+    dependencies:
+      '@types/three': 0.185.1
+      three: 0.185.1
 
   magic-string@0.30.21:
     dependencies:
@@ -10695,6 +11117,12 @@ snapshots:
   meow@14.1.0: {}
 
   merge-stream@2.0.0: {}
+
+  meshline@3.3.1(three@0.185.1):
+    dependencies:
+      three: 0.185.1
+
+  meshoptimizer@1.1.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -11315,6 +11743,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postprocessing@6.39.2(three@0.185.1):
+    dependencies:
+      three: 0.185.1
+
+  potpack@1.0.2: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.9.4: {}
@@ -11332,6 +11766,11 @@ snapshots:
       parse-ms: 4.0.0
 
   process-nextick-args@2.0.1: {}
+
+  promise-worker-transferable@1.0.4:
+    dependencies:
+      is-promise: 2.2.2
+      lie: 3.3.0
 
   prop-types@15.8.1:
     dependencies:
@@ -11487,6 +11926,12 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-use-measure@2.1.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
 
@@ -11892,6 +12337,13 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stats-gl@2.4.2(@types/three@0.185.1)(three@0.185.1):
+    dependencies:
+      '@types/three': 0.185.1
+      three: 0.185.1
+
+  stats.js@0.17.0: {}
+
   std-env@4.1.0: {}
 
   stdin-discarder@0.3.2: {}
@@ -12072,6 +12524,10 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  suspend-react@0.1.3(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
@@ -12114,6 +12570,22 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  three-mesh-bvh@0.8.3(three@0.185.1):
+    dependencies:
+      three: 0.185.1
+
+  three-stdlib@2.36.1(three@0.185.1):
+    dependencies:
+      '@types/draco3d': 1.4.10
+      '@types/offscreencanvas': 2019.7.3
+      '@types/webxr': 0.5.24
+      draco3d: 1.5.7
+      fflate: 0.6.10
+      potpack: 1.0.2
+      three: 0.185.1
+
+  three@0.185.1: {}
 
   through2@2.0.5:
     dependencies:
@@ -12172,6 +12644,20 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  troika-three-text@0.52.4(three@0.185.1):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.185.1
+      troika-three-utils: 0.52.4(three@0.185.1)
+      troika-worker-utils: 0.52.0
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-utils@0.52.4(three@0.185.1):
+    dependencies:
+      three: 0.185.1
+
+  troika-worker-utils@0.52.0: {}
+
   trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
@@ -12193,6 +12679,14 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-rat@0.1.2(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
 
   tunnel@0.0.6: {}
 
@@ -12390,6 +12884,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  utility-types@3.11.0: {}
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -12463,6 +12959,10 @@ snapshots:
   wasm-feature-detect@1.8.0: {}
 
   web-worker@1.5.0: {}
+
+  webgl-constants@1.1.1: {}
+
+  webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -12609,6 +13109,13 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zustand@4.5.7(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   zustand@5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:


### PR DESCRIPTION
## What

P1 of the landing GL takeover (docs/adr/0014): the engine spine. A capability-gated R3F canvas now mounts over the inert semantic layer and rides a Catmull-Rom journey through 8 placeholder beats with the base sketchbook post stack.

- `engine/gate.ts` + `GLLoader`: WebGL2 + fine-pointer + width>900 + no-reduced-motion; fail → P0 legacy page boots unchanged (single shared verdict, legacy and GL are mutually exclusive)
- `engine/scroll.ts` + `store.ts`: Lenis → gsap ticker → one scrub ScrollTrigger → vanilla zustand `{t, vel}`; `?t=` debug param; refresh on fonts.ready/resize
- `engine/journey.ts`: waypoints in t-space, centripetal CatmullRom pos+look curves, binary-searched zero-alloc `evalPose(t)`, hardCut support
- `engine/beats.ts` + `SceneManager`: 8 beats, active±1 mount window; placeholder paper-plane scenes (real staging lands P3–P5)
- `post/sketchbook-effect.ts` + `composer.tsx`: HalfFloat composer, RenderPass + one merged EffectPass (paper grain/fiber, derivative-based ink bleed — no CONVOLUTION, warm vignette); the sole priority-1 useFrame rides the camera + renders
- `engine/quality.ts`/`clocks.ts`: HIGH/LOW one-shot tier, stepped boil clock
- root `dev:landing` script

## Gate audit (browser-driven, 1440x900 HIGH tier)

| Check | Verdict | Evidence |
|---|---|---|
| GL mounts, console clean | PASS | 1 canvas, loader lifted, semantic hidden+inert; zero errors |
| Scrub determinism t=0.30 | PASS | out-and-back frames pixel-match (camera pure f(t)) |
| Camera ride | PASS | t=0/.2/.4/.6/.8/1 show six distinct beats |
| Reduced-motion | PASS | zero canvas; legacy boots; semantic visible |
| FPS full ride | PASS | frame-time median 2.1ms / worst 4.3ms (empty world) |

## Notes

- 4 `no-non-null-assertion` sites replaced with zero-alloc guards (strict lint gate)
- placeholder scenes carry `ponytail:` ceilings; fonts/ink strokes intentionally absent (P2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an immersive, scroll-driven 3D landing page experience with cinematic scenes and visual effects.
  * Added automatic fallback to the existing page experience when WebGL, viewport, pointer, or motion preferences are unsuitable.
  * Added adaptive rendering quality for different device capabilities.
  * Added a dedicated command for launching the landing page in development.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->