### PR TITLE
ci: publish ui storybook to pages at /storybook/

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,7 +60,7 @@
 
 ### 🚀 Deploy — publishes on push to main
 
-| Workflow                            | Triggers     | What it does                                               |
-| ----------------------------------- | ------------ | ---------------------------------------------------------- |
-| [🌐 Deploy Landing Page](pages.yml) | push, manual | Build and publish the landing experience to GitHub Pages   |
-| [🚀 Release](release.yml)           | manual       | Manual semantic release + on-demand Tauri installer builds |
+| Workflow                            | Triggers     | What it does                                                                                         |
+| ----------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------- |
+| [🌐 Deploy Landing Page](pages.yml) | push, manual | Build and publish the landing experience (plus the @ajh/ui Storybook at /storybook/) to GitHub Pages |
+| [🚀 Release](release.yml)           | manual       | Manual semantic release + on-demand Tauri installer builds                                           |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,13 +3,15 @@ name: 🌐 Deploy Landing Page
 # ──────────────────────────────────────────────────────────────────────
 # GitHub Pages Deploy
 # ──────────────────────────────────────────────────────────────────────
-# Purpose: Build and publish the landing experience to GitHub Pages
-# Triggers: push to main touching the app, passthrough source, the lockfile,
-#           or this workflow, plus manual dispatch
+# Purpose: Build and publish the landing experience (plus the @ajh/ui
+#          Storybook at /storybook/) to GitHub Pages
+# Triggers: push to main touching the app, passthrough source, the UI
+#           package, the lockfile, or this workflow, plus manual dispatch
 # Source:   apps/landing = the Next 16 static-export app (@ajh/landing);
 #           landing/ = passthrough source copied verbatim into the export by
 #           the postbuild merge-passthrough script. Build output lands in
-#           apps/landing/out.
+#           apps/landing/out. packages/ui = the @ajh/ui design system; its
+#           Storybook build is copied into out/storybook/.
 # Note:     Runs independently of release.yml (also push-to-main) — separate jobs.
 # ──────────────────────────────────────────────────────────────────────
 
@@ -20,6 +22,7 @@ on:
     paths:
       - 'apps/landing/**'
       - 'landing/**'
+      - 'packages/ui/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - '.github/workflows/pages.yml'
@@ -56,6 +59,18 @@ jobs:
           # 6 GiB clears the CI runner headroom without a swap.
           NODE_OPTIONS: --max-old-space-size=6144
         run: pnpm --filter @ajh/landing build
+
+      - name: 📚 Build Storybook (@ajh/ui)
+        env:
+          # Storybook's Vite bundle peaks near the landing build's ceiling;
+          # reuse the same heap headroom so CI never OOMs.
+          NODE_OPTIONS: --max-old-space-size=6144
+        # Runs AFTER Build Landing so apps/landing/out already exists (the
+        # landing postbuild merged the passthrough pages in). Copy the static
+        # Storybook into out/storybook/ so it ships inside the Pages artifact.
+        run: |
+          pnpm --filter @ajh/ui build-storybook
+          cp -r packages/ui/storybook-static apps/landing/out/storybook
 
       - name: 📤 Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -118,6 +118,7 @@ export default tseslint.config(
       '**/dist/**',
       '**/out/**',
       '**/.next/**',
+      '**/storybook-static/**',
       // Generated browser-store packaging output (unpacked dirs + zips) — minified
       // bundles, never source; like dist/, must not be linted.
       'apps/extension/store-packages/**',

--- a/landing/agent-system.html
+++ b/landing/agent-system.html
@@ -526,7 +526,7 @@ footer{margin-top:60px; text-align:center}
   <footer>
     <p class="byline">30 specialists, zero of them with a real job either.</p>
     <p class="foot-links">
-      <a href="/">home</a> · <a href="/download">download</a> · <a href="/privacy">privacy</a> · <a href="/creature">▶ the short film</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener noreferrer">Firefox extension</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener noreferrer">♥ sponsor</a>
+      <a href="/">home</a> · <a href="/download">download</a> · <a href="/privacy">privacy</a> · <a href="/creature">▶ the short film</a> · <a href="/storybook/">design system</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener noreferrer">Firefox extension</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener noreferrer">♥ sponsor</a>
     </p>
   </footer>
 

--- a/landing/download.html
+++ b/landing/download.html
@@ -221,7 +221,7 @@ footer{margin-top:60px; text-align:center}
   <footer>
     <p class="byline">made by Saeed, between rejections.</p>
     <p class="foot-links">
-      <a href="/">home</a> · download · <a href="/privacy">privacy</a> · <a href="/creature">▶ the short film</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener noreferrer">Firefox extension</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener noreferrer">♥ sponsor</a>
+      <a href="/">home</a> · download · <a href="/privacy">privacy</a> · <a href="/creature">▶ the short film</a> · <a href="/storybook/">design system</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener noreferrer">Firefox extension</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener noreferrer">♥ sponsor</a>
     </p>
   </footer>
 

--- a/landing/how-it-works.html
+++ b/landing/how-it-works.html
@@ -1059,7 +1059,7 @@
     <footer>
       <p class="byline">made by Saeed, between rejections.</p>
       <p class="foot-links">
-        <a href="/">home</a> · <a href="/download">download</a> · <a href="/privacy">privacy</a> · <a href="/creature">▶ the short film</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener noreferrer">Firefox extension</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener noreferrer">♥ sponsor</a>
+        <a href="/">home</a> · <a href="/download">download</a> · <a href="/privacy">privacy</a> · <a href="/creature">▶ the short film</a> · <a href="/storybook/">design system</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener noreferrer">Firefox extension</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener noreferrer">♥ sponsor</a>
       </p>
     </footer>
 

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -300,7 +300,7 @@ h2 .anchor:focus-visible{border-radius:2px}
   <footer>
     <p class="byline">made by Saeed, between rejections.</p>
     <p class="foot-links">
-      <a href="/">home</a> · <a href="/download">download</a> · privacy · <a href="/creature">▶ the short film</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener noreferrer">Firefox extension</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener noreferrer">♥ sponsor</a>
+      <a href="/">home</a> · <a href="/download">download</a> · privacy · <a href="/creature">▶ the short film</a> · <a href="/storybook/">design system</a> · <a href="https://github.com/saeedkolivand/ai-job-hunter-app" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll" target="_blank" rel="noopener noreferrer">Chrome extension</a> · <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter-job-importer/" target="_blank" rel="noopener noreferrer">Firefox extension</a> · <a href="https://github.com/sponsors/saeedkolivand" target="_blank" rel="noopener noreferrer">♥ sponsor</a>
     </p>
   </footer>
 


### PR DESCRIPTION
## What

Publishes the @ajh/ui Storybook to GitHub Pages at https://aijobhunter.app/storybook/ as part of the existing landing deploy — the design system joins the repo's public engineering-showcase pages.

- `pages.yml`: builds `@ajh/ui` Storybook (~8s warm) after the landing app, copies `storybook-static/` into the Pages artifact at `/storybook/`; `packages/ui/**` added to triggers so the published Storybook can't go stale
- `landing/how-it-works.html`: "design system" link in the footer nav (passthrough page — no port mirror needed)
- `eslint.config.mjs`: `**/storybook-static/**` ignored globally (local Storybook builds otherwise feed 12k minified-bundle errors to repo-wide lint runs)

## Verification

- Storybook build verified locally (93 files, index+iframe present); artifact simulated: `out/storybook/index.html` alongside `out/index.html` + passthrough pages
- Secret scan of the Storybook output: clean
- pages.yml parses; step style matches the workflow's conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)