### PR TITLE
feat: landing gl takeover p3 - slump and descent beats

### DIFF
--- a/apps/landing/src/engine/journey.ts
+++ b/apps/landing/src/engine/journey.ts
@@ -26,8 +26,13 @@ export interface Waypoint {
 export const WAYPOINTS: Waypoint[] = [
   { t: 0 / 8, position: new THREE.Vector3(0, 0, 12), look: new THREE.Vector3(0, 0, 0) },
   { t: 1 / 8, position: new THREE.Vector3(0, -3, 10), look: new THREE.Vector3(1, -4, 0) },
-  { t: 2 / 8, position: new THREE.Vector3(2, -18, 9), look: new THREE.Vector3(2, -24, 0) },
-  { t: 3 / 8, position: new THREE.Vector3(1, -36, 7), look: new THREE.Vector3(0, -42, 0) },
+  // descent: tip forward off the slump lip and plunge the shaft. Steep pitch
+  // (~46deg entry -> ~55deg mid) + a 22-unit vertical drop reads as a fall; the
+  // look-target leads down the shaft toward the disc. Exit lands just above the
+  // black hole (P4's fried beat owns the crash-through). Both neighbours still
+  // frame: slump-mid look ~y=-13, fried-mid look ~y=-43.5.
+  { t: 2 / 8, position: new THREE.Vector3(1.6, -14, 8.8), look: new THREE.Vector3(1, -23, 0) },
+  { t: 3 / 8, position: new THREE.Vector3(0, -36, 5), look: new THREE.Vector3(0, -42.5, 0) },
   { t: 4 / 8, position: new THREE.Vector3(0, -40, 6), look: new THREE.Vector3(0, -44, 0) },
   { t: 5 / 8, position: new THREE.Vector3(0, 20, 14), look: new THREE.Vector3(0, 22, 0) },
   { t: 6 / 8, position: new THREE.Vector3(10, 19, 10), look: new THREE.Vector3(22, 19, 0) },

--- a/apps/landing/src/ink/InkStrokes.tsx
+++ b/apps/landing/src/ink/InkStrokes.tsx
@@ -31,6 +31,7 @@ import { useEffect, useMemo, useRef } from "react";
 import {
   Color,
   DoubleSide,
+  type Group,
   Mesh,
   MeshBasicMaterial,
   type Object3D,
@@ -104,6 +105,7 @@ export default function InkStrokes({
   const mode = drawOn ? "draw" : "decor";
   const drawRef = useRef(drawOn);
   drawRef.current = drawOn;
+  const groupRef = useRef<Group | null>(null);
 
   const built = useMemo<Built>(() => {
     const objects: Object3D[] = [];
@@ -254,10 +256,19 @@ export default function InkStrokes({
     const raw = span > 1e-6 ? (t - d.t0) / span : t >= d.t1 ? 1 : 0;
     const prog = raw < 0 ? 0 : raw > 1 ? 1 : raw;
     for (const it of built.dashItems) it.mat.dashOffset = it.len * (1 - prog);
+    // Draw-call cull: at prog 0 every stroke's dash gap already covers its whole
+    // line, so the doodle is 100% invisible yet each stroke still costs a draw
+    // call. Hiding the group there submits zero draws for a not-yet-drawn (or
+    // scrubbed-back-before-window) doodle -- the win in the co-mounted beat
+    // overlap, where a neighbour beat's doodles sit pre-window. Pure f(t) and
+    // scrub-safe: visibility is a function of t only, and it flips exactly at t0
+    // where the strokes (and fills) are already invisible, so nothing on screen
+    // changes -- only off-screen/hidden geometry stops being drawn.
+    if (groupRef.current) groupRef.current.visible = prog > 0;
   });
 
   return (
-    <group position={position} rotation={rotation} scale={scale}>
+    <group ref={groupRef} position={position} rotation={rotation} scale={scale}>
       {built.objects.map((o, i) => (
         <primitive key={i} object={o} dispose={null} />
       ))}

--- a/apps/landing/src/ink/InkStrokes.tsx
+++ b/apps/landing/src/ink/InkStrokes.tsx
@@ -88,6 +88,7 @@ function strokeColor(raw?: string): Color {
 interface Built {
   objects: Object3D[];
   dashItems: { mat: LineMaterial; len: number }[];
+  fillItems: { mat: MeshBasicMaterial }[];
   disposables: { dispose(): void }[];
 }
 
@@ -110,12 +111,13 @@ export default function InkStrokes({
   const built = useMemo<Built>(() => {
     const objects: Object3D[] = [];
     const dashItems: { mat: LineMaterial; len: number }[] = [];
+    const fillItems: { mat: MeshBasicMaterial }[] = [];
     const disposables: { dispose(): void }[] = [];
 
     const doodle = DOODLES.find((d) => d.name === name);
     if (!doodle) {
       if (typeof console !== "undefined") console.warn("InkStrokes: unknown doodle " + name);
-      return { objects, dashItems, disposables };
+      return { objects, dashItems, fillItems, disposables };
     }
 
     const [vw, vh] = doodle.viewBox;
@@ -226,14 +228,23 @@ export default function InkStrokes({
         shp.lineTo(lx(xi), ly(yi));
       }
       const geo = new ShapeGeometry(shp);
-      const mat = new MeshBasicMaterial({ color: strokeColor(s.color), side: DoubleSide });
+      // Draw mode: fill chases the linework, so it starts transparent and the
+      // useFrame below ramps opacity with prog. Decor mode has no reveal
+      // window -- stays opaque, no per-frame cost.
+      const mat = new MeshBasicMaterial({
+        color: strokeColor(s.color),
+        side: DoubleSide,
+        transparent: mode === "draw",
+        opacity: mode === "draw" ? 0 : 1,
+      });
       const mesh = new Mesh(geo, mat);
       mesh.position.z = -0.01;
       objects.push(mesh);
       disposables.push(geo, mat);
+      if (mode === "draw") fillItems.push({ mat });
     }
 
-    return { objects, dashItems, disposables };
+    return { objects, dashItems, fillItems, disposables };
   }, [name, scale, mode]);
 
   useEffect(() => {
@@ -250,12 +261,17 @@ export default function InkStrokes({
   // the strokes.
   useFrame(() => {
     const d = drawRef.current;
-    if (!d || built.dashItems.length === 0) return;
+    if (!d || (built.dashItems.length === 0 && built.fillItems.length === 0)) return;
     const t = journeyStore.getState().t;
     const span = d.t1 - d.t0;
     const raw = span > 1e-6 ? (t - d.t0) / span : t >= d.t1 ? 1 : 0;
     const prog = raw < 0 ? 0 : raw > 1 ? 1 : raw;
     for (const it of built.dashItems) it.mat.dashOffset = it.len * (1 - prog);
+    // Fill chases the linework: opacity ramps over a lagged window so fills
+    // arrive after outlines are largely drawn (art brief section 2). Pure
+    // f(prog) -- scrub-safe both directions, zero allocation.
+    const fillOpacity = Math.min(1, Math.max(0, (prog - 0.35) / 0.3));
+    for (const it of built.fillItems) it.mat.opacity = fillOpacity;
     // Draw-call cull: at prog 0 every stroke's dash gap already covers its whole
     // line, so the doodle is 100% invisible yet each stroke still costs a draw
     // call. Hiding the group there submits zero draws for a not-yet-drawn (or

--- a/apps/landing/src/ink/text.ts
+++ b/apps/landing/src/ink/text.ts
@@ -9,6 +9,7 @@
 
 import { preloadFont } from "troika-three-text";
 
+import { beat1 } from "@/content/beat1";
 import { beat2 } from "@/content/beat2";
 import { features } from "@/content/features";
 import { hero } from "@/content/hero";
@@ -70,11 +71,31 @@ export function charactersFor(...strings: string[]): string {
 // that render <Text> never drift apart -- scenes should build their
 // `characters` prop from this, not from ad hoc strings.
 export const FONT_TEXTS: Record<FontKey, string[]> = {
-  impact: [hero.h1a],
-  scrawl: [hero.scrollhint],
-  hand: [features.c2t, beat2.feed[0], hero.sub, hero.subBold],
+  impact: [hero.h1a, beat2.blackholeYell],
+  scrawl: [hero.scrollhint, beat1.sectionLabel, beat2.h2],
+  hand: [
+    features.c2t,
+    beat2.feed[0],
+    hero.sub,
+    hero.subBold,
+    beat1.thought,
+    beat1.counterA,
+    beat1.counterB,
+    beat1.counterC,
+    beat2.linkedinTitle,
+    "0123456789",
+  ],
   caveat: [hero.dontClick, hero.h1a, hero.h1b, hero.h1ul, hero.h1c],
-  mono: [hero.kicker.toUpperCase(), features.c1t, testimonials.stars],
+  mono: [
+    hero.kicker.toUpperCase(),
+    features.c1t,
+    testimonials.stars,
+    ...beat1.screencaps,
+    beat2.atsBold,
+    beat2.recruitersTitle,
+    beat2.chipsMore,
+    ...beat2.chips,
+  ],
   monoBold: [beat2.blackholeMain],
 };
 

--- a/apps/landing/src/scenes/Descent.tsx
+++ b/apps/landing/src/scenes/Descent.tsx
@@ -1,17 +1,329 @@
-// P1 placeholder -- a tall vertical page marking the plunge shaft. Elongated
-// so the drop reads as motion as the camera falls past it. No fonts in P1.
-// ponytail: flat MeshBasic stand-in (ceiling: no art yet).
-export default function Descent() {
+"use client";
+
+// P3 DESCENT -- beat 3/8, the plunge. The camera tips forward out of the slump
+// room (journey waypoint 2, t=0.25) and falls a vertical shaft down to the
+// black-hole disc just above the fried bottom (waypoint 3, t=0.375). All layout
+// is a pure function of authored world position -- NOTHING here is time-driven,
+// so the whole shaft is scrub-safe: the camera moves past static furniture, the
+// furniture never moves. See engine/journey.ts for the matching camera pitch.
+//
+// Layers, back to front (+z toward camera):
+//   - ShaftPaper : one tall graph-paper quad (Hero's linear-space grid shader),
+//                  the receding paper the shaft is drawn on. One draw call.
+//   - Walls      : one merged drei <Line segments> batch (worldUnits fat lines,
+//                  built once, no per-frame upload) -- sparse vertical shaft
+//                  edges, faint graph rungs, perspective guides converging on the
+//                  disc, and every chip's red strike-through. One draw call.
+//   - cards      : the 4 rejection-collage concepts from content/beat2 as tilted
+//                  paper quads spiralling down at increasing depth (x alternates,
+//                  y falls, z parallax) -- ink-outline border + one Space Mono /
+//                  Patrick snippet each.
+//   - chips      : the platform swarm as small Space Mono quads orbit-scattered
+//                  on the shaft walls (strikes live in the Walls batch).
+//   - beat2-dood : the frazzled guy mid-shaft, hero-tier per-stroke InkStrokes
+//                  drawing on as the camera reaches him; deco-beat2-* scattered.
+//   - BlackHole  : the dark radial-gradient disc at the shaft bottom (linear-
+//                  space shader like ShaftPaper) with "HELLO??" (Anton) yelled
+//                  around its rim. The camera LANDS just above it; the crash-
+//                  through belongs to P4's fried beat.
+//   - h2         : "the descent" (Gloria) at the shaft entry.
+//
+// ponytail: walls/borders/strikes are static fat lines (no line-boil) -- ceiling:
+// they read a touch cleaner than the hand-inked hero strokes. Cheap on purpose.
+
+import { useMemo } from "react";
+import { Color, DoubleSide, Vector2 } from "three";
+import { Line, Text } from "@react-three/drei";
+
+import { beat2 } from "@/content/beat2";
+import InkStrokes from "@/ink/InkStrokes";
+import { PALETTE } from "@/ink/palette";
+import { charactersFor, FONT, FONT_TEXTS } from "@/ink/text";
+
+// --- shared linear-space grid shader (same emit rule as Hero's GraphPaper) ---
+const GRID_VERT = /* glsl */ `
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}
+`;
+const GRID_FRAG = /* glsl */ `
+uniform vec3 uPaper;
+uniform vec3 uLine;
+uniform vec2 uSize;
+varying vec2 vUv;
+void main() {
+  vec2 c = vUv * uSize;                       // 1 cell == 1 world unit
+  vec2 g = abs( fract( c - 0.5 ) - 0.5 ) / fwidth( c );
+  float ln = 1.0 - min( min( g.x, g.y ), 1.0 );
+  vec3 col = mix( uPaper, uLine, ln * 0.5 );
+  gl_FragColor = vec4( col, 1.0 );
+}
+`;
+
+const SHAFT_W = 26;
+const SHAFT_H = 34;
+
+function ShaftPaper() {
+  const uniforms = useMemo(
+    () => ({
+      uPaper: { value: new Color(PALETTE.paper) },
+      uLine: { value: new Color(PALETTE.line) },
+      uSize: { value: new Vector2(SHAFT_W, SHAFT_H) },
+    }),
+    [],
+  );
   return (
-    <group position={[2, -24, 0]}>
-      <mesh>
-        <planeGeometry args={[6, 16]} />
-        <meshBasicMaterial color="#f4ecdc" side={2} />
-      </mesh>
-      <mesh position={[0, 0, 0.1]}>
-        <boxGeometry args={[0.6, 12, 0.1]} />
-        <meshBasicMaterial color="#1c1812" />
-      </mesh>
+    <mesh position={[0, -28, -1.2]}>
+      <planeGeometry args={[SHAFT_W, SHAFT_H]} />
+      <shaderMaterial uniforms={uniforms} vertexShader={GRID_VERT} fragmentShader={GRID_FRAG} />
+    </mesh>
+  );
+}
+
+// --- the black-hole disc: dark radial gradient, linear-space, rim fades to paper.
+const DISC_FRAG = /* glsl */ `
+uniform vec3 uInner;
+uniform vec3 uOuter;
+uniform vec3 uRing;
+varying vec2 vUv;
+void main() {
+  float d = length( vUv - 0.5 ) * 2.0;         // 0 at core .. 1 at rim
+  vec3 col = mix( uInner, uOuter, pow( clamp( d, 0.0, 1.0 ), 1.7 ) );
+  float ring = smoothstep( 0.6, 0.68, d ) * ( 1.0 - smoothstep( 0.68, 0.78, d ) );
+  col = mix( col, uRing, ring * 0.55 );
+  float alpha = 1.0 - smoothstep( 0.88, 1.0, d );
+  gl_FragColor = vec4( col, alpha );
+}
+`;
+
+function BlackHole() {
+  const uniforms = useMemo(
+    () => ({
+      uInner: { value: new Color("#0a0806") },
+      uOuter: { value: new Color(PALETTE.paper) },
+      uRing: { value: new Color(PALETTE.red) },
+    }),
+    [],
+  );
+  return (
+    <mesh position={[0, -42, 0]} renderOrder={0}>
+      <circleGeometry args={[5, 48]} />
+      <shaderMaterial
+        uniforms={uniforms}
+        vertexShader={GRID_VERT}
+        fragmentShader={DISC_FRAG}
+        transparent
+        depthWrite={false}
+      />
+    </mesh>
+  );
+}
+
+// --- chip swarm: platform names X'd out, orbit-scattered on the shaft walls ---
+// [label, x, y]. First 6 of beat2.chips; strike diagonals feed the Walls batch.
+const CHIPS: [string, number, number][] = [
+  [beat2.chips[0], -5.2, -17],
+  [beat2.chips[1], 5.0, -20.5],
+  [beat2.chips[2], -5.6, -24.5],
+  [beat2.chips[3], 5.4, -29],
+  [beat2.chips[4], -5.0, -34],
+  [beat2.chips[5], 4.8, -38],
+];
+
+// --- rejection cards: the 4 collage concepts, spiralling down at rising depth.
+// pos is authored world layout only (never time-animated). [text, fontKey,
+// color, x, y, z, rotZ, w, h, fontSize, maxWidth]
+const CARDS: {
+  text: string;
+  fontKey: keyof typeof FONT;
+  color: string;
+  pos: [number, number, number];
+  rot: number;
+  w: number;
+  h: number;
+  fs: number;
+  maxW: number;
+}[] = [
+  { text: beat2.blackholeMain, fontKey: "monoBold", color: PALETTE.ink, pos: [-3.0, -17.5, 0.2], rot: 0.1, w: 4.4, h: 2.8, fs: 0.3, maxW: 3.7 },
+  { text: beat2.atsBold, fontKey: "mono", color: PALETTE.red, pos: [3.1, -22.5, 0.4], rot: -0.14, w: 4.0, h: 2.2, fs: 0.5, maxW: 3.5 },
+  { text: beat2.recruitersTitle, fontKey: "mono", color: PALETTE.ink, pos: [-3.3, -30.5, 0.6], rot: 0.15, w: 4.2, h: 2.4, fs: 0.34, maxW: 3.5 },
+  { text: beat2.linkedinTitle, fontKey: "hand", color: PALETTE.ink, pos: [3.0, -35, 0.5], rot: -0.1, w: 4.4, h: 2.4, fs: 0.4, maxW: 3.7 },
+];
+
+// One merged fat-line batch: shaft edges + faint graph rungs + perspective
+// guides converging on the disc + chip strikes. Built once (useMemo), so no
+// per-frame setPositions -- the drei <Line> uploads these buffers a single time.
+function useWalls() {
+  return useMemo(() => {
+    const INK = new Color(PALETTE.ink);
+    const FAINT = new Color(PALETTE.line);
+    const RED = new Color(PALETTE.red);
+    const points: [number, number, number][] = [];
+    const colors: Color[] = [];
+    const seg = (
+      ax: number, ay: number, bx: number, by: number, c: Color,
+    ) => {
+      points.push([ax, ay, 0], [bx, by, 0]);
+      colors.push(c, c);
+    };
+    // broken vertical shaft edges (sketchbook look), both walls
+    seg(-6, -12, -6, -28, INK);
+    seg(-6, -31, -6, -43, INK);
+    seg(-5, -15, -5, -26, INK);
+    seg(6, -12, 6, -28, INK);
+    seg(6, -31, 6, -43, INK);
+    seg(5, -16, 5, -27, INK);
+    // perspective guides converging on the disc -- sells the drop
+    seg(-6, -13, -1.2, -40, INK);
+    seg(6, -13, 1.2, -40, INK);
+    seg(-5, -26, -0.8, -41, FAINT);
+    seg(5, -26, 0.8, -41, FAINT);
+    // faint graph rungs receding down
+    seg(-6, -20, -3, -20, FAINT);
+    seg(3, -20, 6, -20, FAINT);
+    seg(-6, -32, -3, -32, FAINT);
+    seg(3, -32, 6, -32, FAINT);
+    // chip strike-throughs (red)
+    for (const [, x, y] of CHIPS) seg(x - 1.1, y - 0.22, x + 1.1, y + 0.22, RED);
+    return { points, colors };
+  }, []);
+}
+
+export default function Descent() {
+  const walls = useWalls();
+  return (
+    <group>
+      <ShaftPaper />
+
+      {/* shaft edges + graph hints + perspective guides + chip strikes (1 batch) */}
+      <Line points={walls.points} vertexColors={walls.colors} segments worldUnits linewidth={0.055} />
+
+      {/* h2 at the shaft entry */}
+      <Text
+        font={FONT.scrawl}
+        characters={charactersFor(...FONT_TEXTS.scrawl)}
+        position={[-0.3, -15.5, 0.4]}
+        rotation={[0, 0, 0.03]}
+        fontSize={1.0}
+        anchorX="center"
+        anchorY="middle"
+        color={PALETTE.ink}
+      >
+        {beat2.h2}
+      </Text>
+
+      {/* rejection cards: static spiral, camera falls past them */}
+      {CARDS.map((c, i) => (
+        <group key={i} position={c.pos} rotation={[0, 0, c.rot]}>
+          <mesh>
+            <planeGeometry args={[c.w, c.h]} />
+            <meshBasicMaterial color={PALETTE.paper} side={DoubleSide} />
+          </mesh>
+          <Line
+            points={[
+              [-c.w / 2, -c.h / 2, 0.01],
+              [c.w / 2, -c.h / 2, 0.01],
+              [c.w / 2, c.h / 2, 0.01],
+              [-c.w / 2, c.h / 2, 0.01],
+              [-c.w / 2, -c.h / 2, 0.01],
+            ]}
+            color={PALETTE.ink}
+            worldUnits
+            linewidth={0.04}
+          />
+          <Text
+            font={FONT[c.fontKey]}
+            characters={charactersFor(c.text)}
+            position={[0, 0, 0.06]}
+            fontSize={c.fs}
+            maxWidth={c.maxW}
+            lineHeight={1.15}
+            anchorX="center"
+            anchorY="middle"
+            textAlign="center"
+            color={c.color}
+          >
+            {c.text}
+          </Text>
+        </group>
+      ))}
+
+      {/* chip swarm: platform names, X'd out (strikes are in the Walls batch) */}
+      {CHIPS.map(([label, x, y], i) => (
+        <Text
+          key={i}
+          font={FONT.mono}
+          characters={charactersFor(...FONT_TEXTS.mono)}
+          position={[x, y, 0.15]}
+          fontSize={0.32}
+          anchorX="center"
+          anchorY="middle"
+          color={PALETTE.ink}
+          fillOpacity={0.7}
+        >
+          {label}
+        </Text>
+      ))}
+      <Text
+        font={FONT.mono}
+        characters={charactersFor(...FONT_TEXTS.mono)}
+        position={[4.2, -41, 0.15]}
+        fontSize={0.3}
+        anchorX="center"
+        anchorY="middle"
+        color={PALETTE.ink}
+        fillOpacity={0.55}
+      >
+        {beat2.chipsMore}
+      </Text>
+
+      {/* frazzled guy mid-shaft (hero tier) + scattered deco */}
+      <InkStrokes name="beat2-dood" position={[0.2, -26.5, 0.7]} scale={0.022} drawOn={{ t0: 0.275, t1: 0.32 }} />
+      <InkStrokes name="deco-beat2-1" position={[-5.0, -19, 0.1]} scale={0.03} drawOn={{ t0: 0.255, t1: 0.285 }} />
+      <InkStrokes name="deco-beat2-3" position={[4.6, -27, 0.1]} scale={0.035} drawOn={{ t0: 0.29, t1: 0.32 }} />
+      <InkStrokes name="deco-beat2-6" position={[-4.4, -38, 0.1]} scale={0.03} drawOn={{ t0: 0.33, t1: 0.36 }} />
+
+      {/* the black hole at the shaft bottom + HELLO?? yelled around its rim */}
+      <BlackHole />
+      <Text
+        font={FONT.impact}
+        characters={charactersFor(...FONT_TEXTS.impact)}
+        position={[0, -38.2, 0.3]}
+        fontSize={0.85}
+        anchorX="center"
+        anchorY="middle"
+        color={PALETTE.red}
+      >
+        {beat2.blackholeYell}
+      </Text>
+      <Text
+        font={FONT.impact}
+        characters={charactersFor(...FONT_TEXTS.impact)}
+        position={[-3.4, -41.6, 0.3]}
+        rotation={[0, 0, 0.32]}
+        fontSize={0.66}
+        anchorX="center"
+        anchorY="middle"
+        color={PALETTE.red}
+        fillOpacity={0.85}
+      >
+        {beat2.blackholeYell}
+      </Text>
+      <Text
+        font={FONT.impact}
+        characters={charactersFor(...FONT_TEXTS.impact)}
+        position={[3.2, -42.8, 0.3]}
+        rotation={[0, 0, -0.32]}
+        fontSize={0.66}
+        anchorX="center"
+        anchorY="middle"
+        color={PALETTE.red}
+        fillOpacity={0.7}
+      >
+        {beat2.blackholeYell}
+      </Text>
     </group>
   );
 }

--- a/apps/landing/src/scenes/Hero.tsx
+++ b/apps/landing/src/scenes/Hero.tsx
@@ -76,10 +76,19 @@ function GraphPaper() {
 }
 
 // --- headline pieces (line 2 lays out around a centred "robot") -------------
+// The red "robot" is its own centred Text; "So I built a" (right-anchored) and
+// "to do it." (left-anchored) sit on either side. The gap on each side is an
+// explicit x-offset -- half of robot's rendered width (~0.98 world at fontSize
+// H) plus one space (~0.25) -- so the words land a clean space-gap off the
+// punchline. The old 0.95 offset was NARROWER than robot's half-width, so the
+// neighbours collided with it and the line read "arobotto"; authoring the gap
+// as geometry (rather than trusting a trailing/leading space glyph to survive
+// troika's per-segment layout) makes the spacing deterministic.
 const L1 = hero.h1a; // "Job hunting broke me."
 const P1 = hero.h1b.trim(); // "So I built a"
 const ROBOT = hero.h1ul; // "robot"
 const P3 = hero.h1c.trim(); // "to do it."
+const ROBOT_GAP = 1.23; // robot half-width (~0.98) + one space (~0.25) at H
 const KICKER = hero.kicker.toUpperCase();
 const SUB = hero.sub + hero.subBold;
 const H = 1.05; // headline fontSize (world units)
@@ -148,7 +157,7 @@ export default function Hero() {
       <Text
         font={FONT.caveat}
         characters={charactersFor(...FONT_TEXTS.caveat)}
-        position={[-0.95, 2.15, 0.1]}
+        position={[-ROBOT_GAP, 2.15, 0.1]}
         fontSize={H}
         anchorX="right"
         anchorY="middle"
@@ -174,7 +183,7 @@ export default function Hero() {
       <Text
         font={FONT.caveat}
         characters={charactersFor(...FONT_TEXTS.caveat)}
-        position={[0.95, 2.15, 0.1]}
+        position={[ROBOT_GAP, 2.15, 0.1]}
         fontSize={H}
         anchorX="left"
         anchorY="middle"

--- a/apps/landing/src/scenes/Slump.tsx
+++ b/apps/landing/src/scenes/Slump.tsx
@@ -1,17 +1,247 @@
-// P1 placeholder -- a slightly tilted paper page sitting down/forward of the
-// desk. Tilt telegraphs the slump before the plunge. No fonts in P1.
-// ponytail: flat MeshBasic stand-in (ceiling: no art yet).
-export default function Slump() {
+"use client";
+
+// P3 SLUMP -- the 2:47 AM room. Beat 2/8, t-range [0.125, 0.25], waypoint 1.
+// The whole scene is authored in local units around the group origin, which is
+// parked at world (1.8, -13.1, 0) -- the camera's look target at the mid-beat
+// pose evalPose(0.1875). At that pose ~15 world units of height are visible, so
+// everything readable is kept within roughly +/-7 of the origin; the content
+// naturally sweeps up through frame as t moves off mid-beat (the plunge feel).
+//
+// Layers, back to front (+z toward camera):
+//   - backdrop  : one darker paper quad (PALETTE.paper mixed ~20% toward ink) so
+//                 the mood drops from the hero without leaving the sketchbook.
+//   - room bars : skirting + two wall-edge strokes (thin ink boxes) for a
+//                 pencil-margin room-corner feel.
+//   - beat1-dood: the slumped guy at the monitor (desk rect + tear fill), a
+//                 hero-tier InkStrokes with boil, drawn on as you enter the beat.
+//   - cards     : the 5 screencap tabs as paper cards (ink-bordered quads + Space
+//                 Mono), scattered/tilted, each fading in on its own t-window.
+//   - deco      : deco-beat1-1..4 scribbles, staggered draw-on windows.
+//   - GL text   : "2:47 AM" (Gloria) above; thought + counter (Patrick Hand)
+//                 below. Counters show their FINAL values as static text (live
+//                 ticking is a P6 gag).
+//
+// ponytail: the SMIL tear animation does not port -- the tear renders as a
+// static fill. Swaying just the tear would need a per-stroke handle InkStrokes
+// does not expose (it owns its objects); swaying the whole guy would be wrong.
+// Ceiling: static tear. Upgrade path: a named sub-stroke ref out of InkStrokes.
+// ponytail: all static ink outlines -- the room-corner scaffolding (skirting +
+// two wall edges) AND the 5 card borders -- are merged into ONE drei <Line
+// segments worldUnits> batch, built once (useMemo), no per-frame upload. This is
+// Descent's proven draw-call pattern: it folds the 3 room-bar box meshes and the
+// 5 per-card ink quads into a single draw (a ~7-draw cut in the hero+slump+
+// descent mount overlap). Trade: the borders are now STATIC (no per-card fade),
+// so a card's ink frame is drawn before its paper + text fade in on their f(t)
+// window -- which reads fine: an empty inked frame is the sketch pre-drawing the
+// screencap lands into. The fade writes only paper-quad opacity + text
+// fillOpacity now.
+// ponytail: beat1-dood fill polys (desk, tear) pop in at mount while the line
+// strokes still draw on -- same at-rest-fill ceiling as Hero's hero-dood.
+
+import { useMemo, useRef } from "react";
+import { Color, type Group, type MeshBasicMaterial } from "three";
+import { Line, Text } from "@react-three/drei";
+import { useFrame } from "@react-three/fiber";
+
+import { beat1 } from "@/content/beat1";
+import { journeyStore } from "@/engine/store";
+import InkStrokes from "@/ink/InkStrokes";
+import { PALETTE } from "@/ink/palette";
+import { charactersFor, FONT, FONT_TEXTS } from "@/ink/text";
+
+// Glyph unions, built once from the single-source registry so they stay warm
+// with the preloadAllFonts() pass.
+const SCRAWL_CHARS = charactersFor(...FONT_TEXTS.scrawl);
+const MONO_CHARS = charactersFor(...FONT_TEXTS.mono);
+const HAND_CHARS = charactersFor(...FONT_TEXTS.hand);
+
+// Counter line, final values baked in (248 apps; the 248th was the crush, so 247
+// unfortunatelies). Template pieces are imported already-escaped from content.
+const COUNTER = beat1.counterA + "248" + beat1.counterB + "247" + beat1.counterC;
+
+// Pure f(t): 0 before the window, 1 after -- scrubbing backwards un-reveals.
+function progAt(t: number, t0: number, t1: number): number {
+  const raw = (t - t0) / (t1 - t0);
+  return raw < 0 ? 0 : raw > 1 ? 1 : raw;
+}
+
+interface CardProps {
+  line: string;
+  position: [number, number, number];
+  rotation: number;
+  win: [number, number];
+}
+
+// One screencap tab. A priority-0 useFrame maps t -> a fade progress and writes
+// opacity onto the paper quad and the troika fill (fillOpacity is read every
+// frame in troika's onBeforeRender, so no sync() is needed). The ink border is
+// no longer a per-card quad -- it lives in the shared static Line batch below
+// and stays drawn -- so the fade only touches paper opacity + text fillOpacity.
+// Cheap uniform writes only; the fading paper + text are culled while hidden.
+const CARD_W = 4.8;
+const CARD_H = 1.5;
+function ScreenCard({ line, position, rotation, win }: CardProps) {
+  const groupRef = useRef<Group | null>(null);
+  const paperRef = useRef<MeshBasicMaterial | null>(null);
+  const textRef = useRef<{ fillOpacity: number } | null>(null);
+
+  useFrame(() => {
+    const p = progAt(journeyStore.getState().t, win[0], win[1]);
+    if (groupRef.current) groupRef.current.visible = p > 0.001;
+    if (paperRef.current) paperRef.current.opacity = p;
+    if (textRef.current) textRef.current.fillOpacity = p;
+  });
+
   return (
-    <group position={[1, -4, 0]} rotation={[0, 0, -0.14]}>
+    <group ref={groupRef} position={position} rotation={[0, 0, rotation]} visible={false}>
       <mesh>
-        <planeGeometry args={[9, 6]} />
-        <meshBasicMaterial color="#ece2cd" side={2} />
+        <planeGeometry args={[CARD_W, CARD_H]} />
+        <meshBasicMaterial ref={paperRef} color={PALETTE.paper} transparent opacity={0} />
       </mesh>
-      <mesh position={[0, -1, 0.1]}>
-        <boxGeometry args={[4.5, 0.6, 0.1]} />
-        <meshBasicMaterial color="#1c1812" />
+      <Text
+        ref={textRef}
+        font={FONT.mono}
+        characters={MONO_CHARS}
+        position={[0, 0, 0.02]}
+        fontSize={0.15}
+        maxWidth={CARD_W - 0.6}
+        lineHeight={1.3}
+        anchorX="center"
+        anchorY="middle"
+        textAlign="center"
+        color={PALETTE.ink}
+        fillOpacity={0}
+      >
+        {line}
+      </Text>
+    </group>
+  );
+}
+
+// The 5 screencap tabs, scattered/tilted around the guy, staggered so all have
+// drawn in by the mid-beat pose (~0.1875) when the scene reads centred.
+const CARDS: CardProps[] = [
+  { line: beat1.screencaps[0], position: [-6.9, 3.3, 0.2], rotation: 0.08, win: [0.132, 0.15] },
+  { line: beat1.screencaps[1], position: [6.7, 3.0, 0.2], rotation: -0.07, win: [0.14, 0.158] },
+  { line: beat1.screencaps[2], position: [-7.4, -0.6, 0.2], rotation: -0.05, win: [0.148, 0.166] },
+  { line: beat1.screencaps[3], position: [7.2, -1.0, 0.2], rotation: 0.06, win: [0.156, 0.174] },
+  { line: beat1.screencaps[4], position: [3.6, -4.8, 0.2], rotation: -0.04, win: [0.164, 0.182] },
+];
+
+// One merged fat-line batch: room-corner scaffolding (skirting + two wall edges)
+// + the 5 static card borders. Built once (useMemo) so the drei <Line> uploads
+// these buffers a single time -- no per-frame setPositions. Local coords, since
+// the whole thing rides the root group at world (1.8, -13.1, 0). Card borders
+// are the authored card layout (position + z rotation) traced as rectangles a
+// hair in front of each fading paper quad.
+const CARD_HW = CARD_W / 2;
+const CARD_HH = CARD_H / 2;
+function useInkBatch() {
+  return useMemo(() => {
+    const pts: [number, number, number][] = [];
+    const seg = (ax: number, ay: number, az: number, bx: number, by: number, bz: number) => {
+      pts.push([ax, ay, az], [bx, by, bz]);
+    };
+    // room corner: skirting + left + right wall edges (were 3 ink box meshes)
+    seg(-13, -6.9, -0.85, 13, -6.9, -0.85);
+    seg(-10.5, -6.8, -0.85, -10.5, 3.2, -0.85);
+    seg(10.5, -6.8, -0.85, 10.5, 3.2, -0.85);
+    // 5 card borders: rotated rectangles at the authored card layout (were the
+    // outer ink quad of each 2-quad card).
+    for (const c of CARDS) {
+      const px = c.position[0];
+      const py = c.position[1];
+      const bz = c.position[2] + 0.015;
+      const cos = Math.cos(c.rotation);
+      const sin = Math.sin(c.rotation);
+      const rx = (sx: number, sy: number) => px + sx * CARD_HW * cos - sy * CARD_HH * sin;
+      const ry = (sx: number, sy: number) => py + sx * CARD_HW * sin + sy * CARD_HH * cos;
+      seg(rx(-1, -1), ry(-1, -1), bz, rx(1, -1), ry(1, -1), bz);
+      seg(rx(1, -1), ry(1, -1), bz, rx(1, 1), ry(1, 1), bz);
+      seg(rx(1, 1), ry(1, 1), bz, rx(-1, 1), ry(-1, 1), bz);
+      seg(rx(-1, 1), ry(-1, 1), bz, rx(-1, -1), ry(-1, -1), bz);
+    }
+    return pts;
+  }, []);
+}
+
+export default function Slump() {
+  // Darker paper: PALETTE.paper mixed ~20% toward ink (linear-space lerp -- both
+  // Colors decode sRGB->linear on construction, matching the post pipeline).
+  const darkPaper = useMemo(() => new Color(PALETTE.paper).lerp(new Color(PALETTE.ink), 0.2), []);
+  const inkBatch = useInkBatch();
+
+  return (
+    <group position={[1.8, -13.1, 0]}>
+      {/* darker paper backdrop */}
+      <mesh position={[0, 0, -0.9]}>
+        <planeGeometry args={[30, 20]} />
+        <meshBasicMaterial color={darkPaper} />
       </mesh>
+
+      {/* room-corner scaffolding + 5 card borders, merged into one batch (1 draw) */}
+      <Line points={inkBatch} color={PALETTE.ink} segments worldUnits linewidth={0.05} />
+
+      {/* the slumped guy: hero-tier per-stroke + boil, drawn on as you arrive */}
+      <InkStrokes name="beat1-dood" position={[0, -1, 0]} scale={0.03} drawOn={{ t0: 0.128, t1: 0.17 }} />
+
+      {/* deco scribbles: staggered draw-on across the beat slice */}
+      <InkStrokes name="deco-beat1-1" position={[-9, 4.5, 0.05]} scale={0.02} drawOn={{ t0: 0.135, t1: 0.152 }} />
+      <InkStrokes name="deco-beat1-2" position={[9, 4.2, 0.05]} scale={0.022} drawOn={{ t0: 0.145, t1: 0.162 }} />
+      <InkStrokes name="deco-beat1-3" position={[9.5, -4.5, 0.05]} scale={0.024} drawOn={{ t0: 0.155, t1: 0.172 }} />
+      <InkStrokes name="deco-beat1-4" position={[-9.5, -4, 0.05]} scale={0.03} drawOn={{ t0: 0.165, t1: 0.182 }} />
+
+      {/* screencap tabs */}
+      {CARDS.map((c, i) => (
+        <ScreenCard key={i} {...c} />
+      ))}
+
+      {/* "2:47 AM" section label, small Gloria above the scene */}
+      <Text
+        font={FONT.scrawl}
+        characters={SCRAWL_CHARS}
+        position={[0, 5.2, 0.2]}
+        fontSize={0.5}
+        letterSpacing={0.04}
+        anchorX="center"
+        anchorY="middle"
+        color={PALETTE.ink}
+        fillOpacity={0.8}
+      >
+        {beat1.sectionLabel}
+      </Text>
+
+      {/* thought line */}
+      <Text
+        font={FONT.hand}
+        characters={HAND_CHARS}
+        position={[0, -5.8, 0.2]}
+        fontSize={0.44}
+        maxWidth={11}
+        anchorX="center"
+        anchorY="middle"
+        textAlign="center"
+        color={PALETTE.ink}
+      >
+        {beat1.thought}
+      </Text>
+
+      {/* counter line: FINAL values, static (live tick is a P6 gag) */}
+      <Text
+        font={FONT.hand}
+        characters={HAND_CHARS}
+        position={[0, -6.6, 0.2]}
+        fontSize={0.3}
+        maxWidth={12}
+        lineHeight={1.2}
+        anchorX="center"
+        anchorY="middle"
+        textAlign="center"
+        color={PALETTE.ink}
+        fillOpacity={0.72}
+      >
+        {COUNTER}
+      </Text>
     </group>
   );
 }

--- a/docs/design/landing-gl-art-direction-brief.md
+++ b/docs/design/landing-gl-art-direction-brief.md
@@ -1,0 +1,100 @@
+# Landing GL Art Direction Brief -- "Living Sketchbook"
+
+Grill target: aijobhunter.app full-canvas WebGL rebuild (`apps/landing`, Next 16 + R3F).
+Baseline: P3, judged NOT premium. This brief is decision-by-decision; recommendations are bolded.
+
+## 1. THE DIAGNOSIS (why P3 reads cheap vs the reference class)
+
+- The camera never rests: it rides one uniform Catmull-Rom (`journey.ts` waypoints at flat `t=i/8`), so type is always in motion-blur territory -- ITom and Apple product pages only ever show text at a velocity plateau.
+- Post + lighting are ONE global stack; every beat has the same flat mood. Active Theory v4 grades palette/exposure/prop-density per environment so scenes never feel repetitive.
+- Draw-on already exists (`InkStrokes.tsx` dashed `Line2`, `dashOffset` = pure `f(t)`) but is used as ambient garnish, not the scroll verb. The reference "scroll = the drawing draws itself" beat is missing.
+- Strokes are uniform-width `Line2` (`linewidth` constant per stroke) -> they read as debug lines. Every hand-drawn ref has taper/pressure/paper texture (mattdesl ribbon, ITom sketch-texture reveal).
+- GL text is world-space troika (`text.ts`) parented into the scene -> it inherits camera curvature and reads pasted-on (defect 1 + 7). Obys/ITom keep type either fully diegetic or screen-locked, never half-in-world while moving.
+
+## 2. CORE MECHANIC -- "scroll = pencil"
+
+The pencil IS the scrubber. `dashOffset` is already `f(t)` and scrub-reversible; promote it from decor to the primary verb so line-boil is a _side effect_ of scrubbing, never ambient.
+
+Per-beat choreography (local beat-t 0..1, drives `InkStrokes` `{t0,t1}` windows):
+
+- 0.00-0.15 camera settles into framing; only the anchor doodle leads the camera in.
+- 0.10-0.55 OUTLINES draw in a spatial wave, near-to-camera first, +/-8-15% randomized per-path offset (hand-inked, not typewriter order).
+- 0.35-0.65 color/fill cross-fades in BEHIND completed strokes, lagging ~20% -- color chases line, never leads.
+- 0.55-0.80 GL text strokes in last, camera near-still (legibility window).
+- 0.75-1.00 camera un-pins toward next beat; drawn strokes drop to idle line-boil so past beats stay alive.
+- Scroll-back: everything is `f(local-t)`, so reversing un-draws in exact mirror -- no reverse timeline needed (already true today).
+
+Variant A -- DRAW-THEN-TRAVEL (dwell rhythm). Non-uniform `t`-spacing clusters scroll around each beat; draw completes IN the plateau, camera travels only in the spent-ink gap. Pro: max legibility, cinematic breathing, matches every ref. Con: needs the `t`-remap (Sec 3) and tight `{t0,t1}` authoring per beat. **Recommended.**
+
+Variant B -- DRAW-WHILE-TRAVELING (continuous). Linework leads on a faster eased curve, camera lags ~20% behind so lines visibly precede the lens (Codrops SVG-map pattern). Pro: keeps unbroken journey feel, less authoring. Con: text has nowhere quiet to land -> defect 1 persists unless text goes fully screen-space. Use only for the two fast travel legs (descent shaft, godmode sky).
+
+## 3. TEXT READABILITY
+
+Store already carries `vel` next to `t` (`engine/store.ts`), so velocity gating is nearly free -- no new plumbing.
+
+RECOMMENDED -- hybrid (e): dwell-eased `t` + screen-space text + velocity gate.
+
+- `journey.ts`: add a `dwellRemap(scrollT)->journeyT` that plateaus near each `i/8` (smoothstep clusters), OR shift waypoint `t` values off the uniform grid. Camera decelerates into every beat for free; `evalPose` stays pure `f(t)`, scrub-safe.
+- Text out of world-space: render beat copy as a screen-space layer (drei `Html` overlay, or troika billboarded + gated), decoupled from the camera quaternion. Kills "pasted-on" + "unreadable while moving" at once.
+- Gate opacity by `journeyStore.getState().vel`: fade in only when `abs(vel) < threshold`; smoothed threshold + hysteresis so trackpad inertia never flickers.
+
+RUNNER-UP -- screen-space pin only (b): move text to the overlay, opacity keyed to beat `t` range, skip the velocity gate. Highest raw readability, lowest cost, slightly less "earned" feel. Fallback if the dwell remap slips.
+
+## 4. COMPOSITION FIDELITY (top 6 mismatches vs `landing/index.html`)
+
+| #   | beat    | mismatch                                                                               | fix                                           |
+| --- | ------- | -------------------------------------------------------------------------------------- | --------------------------------------------- |
+| 1   | Hero    | doodle demoted to floor (`y=-4.3`), below h1 -- original is a CROWN above the headline | move to `y~=+4.3, x=0`, above kicker          |
+| 2   | Hero    | read order inverted (kicker->h1->sub->doodle)                                          | restore kicker->doodle->h1->sub top-down axis |
+| 3   | Slump   | 5 screencap tabs flung to `x=+/-7` orbit, unrelated to doodle footprint                | cluster tight under the doodle                |
+| 4   | Slump   | doodle far below its "2:47 AM" label, dead gap                                         | raise doodle to `y~=2`, hug the label         |
+| 5   | Descent | doodle buried mid-shaft (`y=-26.5`) below half the cards                               | pull up right after h2, before chips/cards    |
+| 6   | Descent | swarm chips scattered both walls straddling the doodle                                 | resequence chips as one wave AFTER doodle     |
+
+Per-beat re-composition rule (translating the original's flat vertical column to camera-facing 3D):
+For each beat, treat the camera's look-target as the page's vertical axis. Place elements along the axis in original read order -- **doodle-as-crown always above its headline** -- and keep secondary props (cards, chips, tabs) in a tight tilted cluster within ~1 world-unit of the axis, never flung to frame edges. Tilt is fine (+/-2-3 deg); sprawl is not. Counters/codas stay last, smallest, axis-bottom (already correct in all beats).
+
+## 5. PREMIUM GAP CLOSERS (ranked; cost S/M/L)
+
+1. Text only at scroll-rest (velocity gate). What: `vel`-gated opacity + screen-space text. Why: fixes defect 1 outright, the universal ref pattern. Cost: **S** (`vel` already in store).
+2. Per-beat LUT/lighting grade. What: swap a small uniform set (tint, exposure, vignette, grain) per beat off `t` in the post composer. Why: kills flat mood (defect 5); Active Theory discipline. Cost: **S-M** (one uniform block, no new passes).
+3. Dwell-eased `t`-spacing. What: `dwellRemap` clustering scroll at each beat. Why: gives text its quiet window + cinematic breathing. Cost: **M** (remap + re-time `{t0,t1}` per beat).
+4. Draw-on promoted to primary verb. What: tighten `{t0,t1}` to the dwell plateau, lead camera with linework. Why: the core "sketchbook draws itself" bit (defect 3). Cost: **M** (authoring, mechanism exists).
+5. Per-section blocking. What: vary camera height/FOV + prop density explicitly per beat (Sec 4). Why: fixes lost rhythm + sparse world (defects 2, 6). Cost: **M-L** (re-place every scene).
+6. Stroke quality upgrade (defect 4). Paths, cheapest first:
+   - a) Pressure-stepped `Line2`: split each stroke into N sub-`Line2` with a sine/noise `linewidth` ramp along arc-length. Fakes taper, reuses current pipeline. Cost **S-M**.
+   - b) Sketch-texture reveal a la ITom `PaintRevealMaterial`: `onBeforeCompile` noise-blend a paper/graphite texture into the stroke so edges bleed. Cost **M**.
+   - c) Custom ribbon geometry (mattdesl triangle-strip) with true per-vertex width + pressure curve + UV for a brush-alpha texture. Best ceiling, real cost. Cost **L**.
+     Recommend **a) now, c) only if the hero beat still reads thin after a+b**.
+
+## 6. DECISION LIST (rule on each)
+
+1. Core mechanic rhythm: (A) draw-then-travel dwell / (B) draw-while-traveling continuous / (C) A everywhere, B only on the 2 fast legs. **Rec: C.**
+2. Text placement: (A) screen-space overlay `Html` / (B) billboarded troika in-scene / (C) keep world-space. **Rec: A.**
+3. Text reveal trigger: (A) velocity gate + hysteresis / (B) beat-`t` range only / (C) both. **Rec: A.**
+4. Dwell easing: (A) `dwellRemap(scrollT)` smoothstep / (B) shift waypoint `t` off the grid / (C) none, stay uniform. **Rec: A.**
+5. Stroke upgrade depth: (A) pressure-stepped `Line2` / (B) + sketch-texture reveal / (C) full custom ribbon. **Rec: A now, B for hero, C deferred.**
+6. Per-beat grading: (A) per-beat uniform block off `t` / (B) discrete LUT textures / (C) keep single global. **Rec: A.**
+7. Composition fix scope: (A) all 6 mismatches / (B) Hero + Descent crowns only / (C) defer. **Rec: A** (the doodle-as-crown rule is the signature).
+8. Draw choreography authoring: (A) hand-author `{t0,t1}` + stagger per beat / (B) derive from a single density curve / (C) leave ambient. **Rec: A** for 3-5 hero strokes, B for background doodles.
+9. World density: (A) add secondary background doodles per beat (low-opacity wave) / (B) leave sparse / (C) only fried + godmode. **Rec: A**, budget-capped at 3-5 choreographed + one bg wave.
+10. Line-boil scope: (A) idle boil on drawn/past beats only / (B) all strokes always / (C) off. **Rec: A** (alive-past-beats, cheap).
+11. Fried beat treatment: keep the nuclear post spike as the one loud set-piece? **Rec: YES** -- restraint elsewhere makes it land (Active Theory "transitions are events").
+12. Rollout order: which single change ships first to re-test the ceiling? **Rec: #1 text-at-rest + #2 grading** (both cost S, together they answer "is it premium yet" before the M/L work).
+
+## 7. RULINGS (grill session, locked)
+
+| #   | Decision       | Ruling                                                                                                                                                            |
+| --- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Rhythm         | C - dwell everywhere, draw-while-traveling on the 2 fast legs (descent shaft, godmode rise)                                                                       |
+| 2   | Text placement | A - screen-space DOM overlay for beat copy; diegetic display moments stay GL (amends the P1 all-text-in-GL ruling)                                                |
+| 3   | Text reveal    | A - velocity gate + hysteresis                                                                                                                                    |
+| 4   | Dwell impl     | A - dwellRemap(scrollT) with per-beat plateau table in journey.ts                                                                                                 |
+| 5   | Strokes        | A now + B (sketch-texture) on hero doodles; C (ribbon) deferred until hero still reads thin                                                                       |
+| 6   | Grading        | A - per-beat uniform block (tint/exposure/vignette/grain) crossfaded off t                                                                                        |
+| 7   | Composition    | A - all 6 mismatches + the crown rule (look-target = vertical axis, original read order, doodle-as-crown, tilt not sprawl)                                        |
+| 8   | Choreography   | A/B split - hand-authored {t0,t1}+stagger for 3-5 hero strokes per beat; density-curve derivation for background waves                                            |
+| 9   | Density        | USER OVERRIDE: dense everywhere (not budget-capped-per-beat) - enforce via merged batches; draw budget may be raised for measured LOW-tier headroom               |
+| 10  | Boil           | USER OVERRIDE: all strokes always (incl. mid-draw) - current behavior stays                                                                                       |
+| 11  | Fried spike    | YES - the single loud set-piece, clean ramps, confined t-window                                                                                                   |
+| 12  | Rollout        | Text-at-rest + per-beat grading ship as the FIRST art-pass PR (S-cost ceiling re-test with user screenshot judgment); then dwell remap, stroke upgrade, restaging |


### PR DESCRIPTION
## What

P3 of the landing GL takeover (docs/adr/0014): the slump and descent beats staged, and the camera genuinely plunges.

- Slump: 2:47AM room — darker paper mood, slumped guy + desk, five screencap tabs as tilted paper cards fading on pure f(t) windows, deco scribbles on draw-on
- Descent: waypoints refined (pitch 27°→55° across a 22-unit drop) so the camera falls a vertical shaft past rejection cards, the chip swarm, the frazzled guy, landing above the black-hole disc with orbiting HELLO?? — crash-through belongs to P4
- Draw-budget work: static ink outlines merged into single fat-line batches; fully-undrawn draw-mode doodles cull (visible=false at prog 0) — overlap peak 87→60 draws; hero headline word-gap fix

## Gate audit

Ride t=0→0.45 passes (each beat reads as its place, zero console errors); scrub determinism bit-identical on camera pose; mount window verified via runtime scene-graph probe (finale never resident early; active±1 exact); frame-time 2.1ms median at the 87-draw pre-fix worst case; zero context loss.

## Note

Staging is deliberately lean: a comprehensive art-direction pass (documented in docs/design/landing-gl-art-direction-brief.md, decisions being grilled now) follows P5 and will restage visuals — this PR ships the skeleton and mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fully illustrated descent scene with grid-paper visuals, rejection cards, ink animations, and black-hole effects.
  * Replaced the slump placeholder with a complete illustrated scene featuring animated cards, text, and ink details.
  * Expanded landing-page typography support for additional displayed copy.

* **Bug Fixes**
  * Improved headline spacing to prevent collisions around the highlighted “robot” text.
  * Prevented hidden ink artwork from generating unnecessary drawing work.

* **Documentation**
  * Added an art-direction brief covering the landing experience’s visual style and animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->