### PR TITLE
fix: hold the gl experience behind a pre-launch gate

### DIFF
--- a/apps/landing/src/engine/gate.ts
+++ b/apps/landing/src/engine/gate.ts
@@ -16,8 +16,18 @@ export interface GateVerdict {
 
 let cached: GateVerdict | null = null;
 
+// Pre-launch guard: the GL experience is still being built (phases P4-P7,
+// docs/adr/0014). Until the production flip, GL mounts only in dev or with an
+// explicit ?gl=1 opt-in; every other visitor gets the legacy page exactly as
+// shipped today. Remove this guard at the P7 flip.
+function flipped(): boolean {
+  if (process.env.NODE_ENV === "development") return true;
+  return new URLSearchParams(window.location.search).has("gl");
+}
+
 function probe(): GateVerdict {
   if (typeof window === "undefined") return { gl: false, reason: "ssr" };
+  if (!flipped()) return { gl: false, reason: "pre-launch" };
 
   let webgl2 = false;
   try {


### PR DESCRIPTION
## What

**Recommend merging this ahead of the normal review cycle — it affects live production.**

The Pages pipeline has served the new app's index.html since P0 (#702), which means the capability gate has been mounting the in-progress GL skeleton for capable desktop visitors since P1 (#703) — placeholder beats and all. Per the ruling that production flips only when everything is done:

- `gateVerdict()` now returns `gl:false` (reason `pre-launch`) unless the build is dev or the URL carries `?gl=1`
- Every production visitor gets the legacy page exactly as it behaves today (semantic layer + legacy.ts)
- The GL work stays previewable live at `aijobhunter.app/?gl=1`
- The P7 flip removes this guard (documented in the phase task + code comment)

## Verification

typecheck, eslint --max-warnings 0, static-export build + passthrough merge, ASCII scan — all green. One file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)