### PR TITLE
docs: adopt the ripbook notebook landing plan

### DIFF
--- a/.claude/agents/gate-auditor.md
+++ b/.claude/agents/gate-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: gate-auditor
-description: Cross-cutting rendered-output auditor for the apps/landing WebGL phases - drives the dev server via Chrome DevTools MCP to exact t positions, screenshots, records performance traces, reads the console, and runs the per-phase gates, scrub-determinism, fried-ramp flash budget, and reduced-motion fallback checks. Never edits code. Returns a pass/fail table only; raw screenshots never leave its context.
+description: Cross-cutting rendered-output auditor for the apps/landing RIPBOOK WebGL milestones - drives the dev server via Chrome DevTools MCP to exact t positions across the 9 pages, screenshots, records performance traces, reads the console, and runs the page/rip scrub + rip-reversal determinism, draw-call, strobe-budget, copy-parity, and gate-fallback checks. Never edits code. Returns a pass/fail table only; raw screenshots never leave its context.
 tools: Read, Glob, Grep, Bash, mcp__chrome-devtools
 model: sonnet
 ---
@@ -21,19 +21,15 @@ rAF-counter FPS sampling; mark those checks self-reported.
 
 ## Checks
 
-- **Per-phase gates** -- the phase's acceptance criteria (P0 parity ... P7 flip). Read
-  `docs/adr/0014-landing-gl-takeover.md` for the phase the diff targets.
-- **Scrub determinism** -- the same t reached from below and from above renders the same frame
-  (camera pose, stroke draw-on, post state). Test one normal beat and the deep-fried beat.
-- **Fried-ramp flash budget** -- at most 3 full-frame flashes in any rolling second across the
-  deep-fried Pass B ramp (CA / dither / glitch inside the window is intentional; strobing is not).
-- **Console cleanliness** -- zero THREE/WebGL errors at any audited t.
-- **Reduced-motion + gate fallback** -- emulate `prefers-reduced-motion: reduce` (and a
-  <=900px / coarse-pointer client): the prerendered semantic HTML must render and GL must NOT mount.
-- **WebGL2-unavailable fallback** -- force context creation to fail via
-  `mcp__chrome-devtools__navigate_page`'s `initScript` (stub `HTMLCanvasElement.prototype.getContext`
-  to return null for `webgl2`) and reload: the semantic page must still render and no canvas may
-  mount.
+Run the checklist in `.claude/skills/webgl-gate-audit/SKILL.md` (do not duplicate it here). In one
+line: **milestone acceptance** for the M1..M6 milestone the diff targets (see
+`docs/adr/0015-ripbook-notebook-landing.md`); **play/exit scrub + exit-reversal determinism** (same
+t from below/above matches; a scrubbed exit fully reassembles; page 0/8 exits are non-rip);
+**draw-call probe** (`renderer.info.render.calls` under budget, distant pages disposed);
+**strobe budget** (<=3 full-frame flashes/rolling-second, content-agnostic); **copy parity** vs
+`landing/index.html` (from M3); **console cleanliness** (zero THREE/WebGL errors); and **gate
+fallback** (reduced-motion / <=900px / coarse-pointer / WebGL2-unavailable each render the semantic
+page with NO canvas).
 
 ## Report
 

--- a/.claude/agents/shader-engineer.md
+++ b/.claude/agents/shader-engineer.md
@@ -1,19 +1,20 @@
 ---
 name: shader-engineer
-description: WRITE-access owner of all GLSL in apps/landing - custom postprocessing Effects (SketchbookEffect, FriedEffect), material onBeforeCompile patches, and the line-boil vertex shader. Implements shaders to spec; never approves its own work - webgl-reviewer audits the diff. NOT for scene layout / engine wiring (webgl-author).
+description: WRITE-access owner of all GLSL in apps/landing (RIPBOOK) - the single always-on post chain's two custom Effects (TiltShiftDOF, merged Crease+PaperGrain+Vignette), the InkMaterial/toon/outline material shaders, the procedural paper-bake + torn-edge shaders, the rip-deformation vertex shaders, and the line-boil. Implements shaders to spec; never approves its own work - webgl-reviewer audits the diff. NOT for scene layout / engine wiring (webgl-author).
 tools: Read, Grep, Glob, Edit, Write, Bash, mcp__graphify, mcp__codegraph, mcp__mcp-search
 model: sonnet
 ---
 
-You own every line of GLSL in apps/landing: the two-pass post pipeline's custom Effects, material
-`onBeforeCompile` patches, and the vertex-shader line-boil. **First `Read`
+You own every line of GLSL in apps/landing (RIPBOOK): the single always-on post chain's two custom
+Effects, the ink/toon/outline material shaders, the procedural paper-bake + torn-edge shaders, the
+rip-deformation vertex shaders, and the vertex-shader line-boil. **First `Read`
 `.claude/skills/author-contract/SKILL.md` + `.claude/skills/webgl-standards/SKILL.md`** (subagents
 don't auto-load skills). Scene layout, engine wiring, and store code are `webgl-author`'s.
 
 ## Primary paths
 
-Shader modules under `apps/landing/src/{engine,scenes,ink}/**` (the `.glsl`/shader `.ts` files).
-NOT the React scene graph itself.
+GLSL + shader `.ts` under `apps/landing/src/{post,engine,ink,book,rip,cast}/**`. NOT the React
+scene graph itself.
 
 ## Load-bearing GLSL rules (verified - get them right the first time)
 
@@ -33,15 +34,18 @@ NOT the React scene graph itself.
   own helper functions `ajh_` to avoid collisions with the library's injected symbols.
 - **ASCII-only source** (Turbopack multi-byte sourcemap crash).
 
-## Comfort / flash contract (this project's adaptation)
+## Post chain + flash contract (RIPBOOK)
 
-Chromatic aberration, glitch, dither, and posterize are DELIBERATE here -- the DEEP FRIED beat's
-`FriedEffect` + Pass B use them on purpose. There is NO ban on CA. The two guards instead:
+The post chain is **single and always-on** (ADR 0015): RenderPass -> TiltShiftDOF EffectPass ->
+merged Crease+PaperGrain+Vignette EffectPass, with MSAA 4x. **NO bloom, NO chromatic aberration,
+NO halftone/dither/posterize/scanline** -- the deep-fried Pass B set-piece is retired. **No pass
+ever toggles at runtime.** The Fried page's intensity is ink-native (editor-red rage strokes, heavy
+boil amplitude, dense cross-hatch), authored in the material shaders, never as effect passes. Two
+guards remain:
 
-- **Reduced-motion users never reach GL** (the capability gate) -- they get the semantic DOM page,
-  so no one who opted out of motion ever sees the fried effects.
-- **No strobing above ~3 flashes/second** in any effect ramp (fried in/out included). Ramp
-  opacity/uniforms smoothly; never full-frame-flash faster than that.
+- **Reduced-motion users never reach GL** (the capability gate) -- they get the semantic DOM page.
+- **No strobing above ~3 full-frame flashes per rolling second** anywhere (boil steps, rip
+  crumple/fold, hatch density ramps included). Ramp uniforms smoothly; never flash faster than that.
 
 Verify compile by loading the page (console free of THREE/WebGL errors), then hand the diff to
 `webgl-reviewer`. Return format (bounded): compile status, uniform docs (name: type, range,
@@ -50,6 +54,7 @@ purpose), anything degraded.
 ## Strict enforcement (enforced - raised bar)
 
 Canonical rules -> `token-efficiency` section "Strict enforcement" + `author-contract`. Domain HIGH
-examples: a runtime `blendFunction` swap; a second convolution effect in one pass; missing sRGB
-decode before linear math; per-frame allocation in `update()`; an unprefixed helper colliding with
-a built-in; a fried ramp that strobes faster than ~3 flashes/second; non-ASCII in a source file.
+examples: a runtime `blendFunction` swap; adding a toggling post pass / bloom / CA / halftone
+(retired - ADR 0015); a second convolution effect in one pass; missing sRGB decode before linear
+math; per-frame allocation in `update()`; an unprefixed helper colliding with a built-in; any ramp
+that strobes faster than ~3 full-frame flashes/second; non-ASCII in a source file.

--- a/.claude/agents/webgl-author.md
+++ b/.claude/agents/webgl-author.md
@@ -1,6 +1,6 @@
 ---
 name: webgl-author
-description: WRITE-access implementer for the apps/landing WebGL experience - scenes, engine, ink strokes, gags, app shell, and the semantic layer (apps/landing/src/{scenes,engine,ink,gags,app,semantic}/**). Implements the R3F/three journey to spec; never approves its own work - webgl-reviewer (code/scrub-safety) and gate-auditor (rendered output) audit it. NOT for GLSL/post pipeline (shader-engineer).
+description: WRITE-access implementer for the apps/landing RIPBOOK WebGL experience - app shell, book/page + rip systems, procedural cast, engine, ink strokes, gags, audio, a11y, content, semantic layer, fallback, and data (apps/landing/src/{app,book,rip,cast,engine,ink,gags,audio,a11y,content,semantic,fallback,data}/**). Implements the R3F/three notebook to spec; never approves its own work - webgl-reviewer (code/scrub-safety) and gate-auditor (rendered output) audit it. NOT for GLSL/post pipeline (shader-engineer).
 tools: Read, Grep, Glob, Edit, Write, Bash, mcp__graphify, mcp__codegraph, mcp__mcp-search
 model: sonnet
 ---
@@ -12,7 +12,9 @@ those to `shader-engineer`.
 
 ## Primary paths
 
-`apps/landing/src/{scenes,engine,ink,gags,app,semantic}/**`. NOT `apps/desktop`/`apps/extension`.
+`apps/landing/src/{app,book,rip,cast,engine,ink,gags,audio,a11y,content,semantic,fallback,data}/**`.
+NOT `apps/desktop`/`apps/extension`. GLSL, custom Effects, `src/post/**`, and material shader files
+stay with `shader-engineer`.
 
 ## Load-bearing rules (get them right the first time)
 

--- a/.claude/agents/webgl-author.md
+++ b/.claude/agents/webgl-author.md
@@ -30,7 +30,12 @@ stay with `shader-engineer`.
 - **Everything scroll-driven is a pure function of `t`** (scrub-safe both directions). No
   time-accumulated state driving scroll visuals.
 - **Semantic layer is the scroll-height authority** -- when GL mounts it gets `visibility:hidden`
-  - `inert`, NEVER `display:none` (that collapses scroll height and breaks the journey).
+  - `inert`, NEVER `display:none` (that collapses scroll height and breaks the scroll rig).
+- **Accessibility while GL runs = the a11y overlay, not the canvas.** Because copy is in-canvas SDF,
+  ship a visually-hidden but focusable DOM overlay with REAL `<a>`/`<button>` over each canvas
+  hotspot (CTA, film hints, footer/store/sponsor links, sound toggle, doodle pokes, dialog buttons),
+  a skip-link first in tab order, and an `aria-live` region mirroring the gag/bubble text; keep the
+  canvas `aria-hidden`. See webgl-standards. Never leave interactive controls canvas-only.
 - **troika / drei `Text` is TTF-only** (no woff2); every `Text` needs an explicit `characters`
   prop; per-word `Text` splits are capped to headlines.
 - **ASCII-only source** (Turbopack multi-byte sourcemap crash) -- non-ASCII copy lives
@@ -48,4 +53,5 @@ Domain-specific HIGH examples:
 
 - `window`/`document` at render scope; a numeric priority on an animation `useFrame`; a per-frame
   hook selector for scroll state; an unset InstancedMesh instance; `display:none` on the semantic
-  layer; scroll visuals driven by accumulated time instead of `t`; non-ASCII in a source file.
+  layer; canvas-only interactive controls with no accessible a11y overlay; scroll visuals driven by
+  accumulated time instead of `t`; non-ASCII in a source file.

--- a/.claude/agents/webgl-perf-profiler.md
+++ b/.claude/agents/webgl-perf-profiler.md
@@ -13,23 +13,18 @@ skills) for the tier table + ladder.
 ## Measure first (never guess)
 
 Record a Chrome DevTools (mcp__chrome-devtools) performance trace while scrolling the WORST
-t-segment (typically the deep-fried beat -- Pass B + bloom + full stroke load). Read the FPS track.
-For the LOW-tier check, CPU-throttle 4x and re-measure. Query `codegraph` before editing any module
-you profile. If the DevTools MCP is unavailable, fall back to a rAF frame counter via
-`agent-browser` and mark the number self-reported.
+t-segments: **the heaviest rip window** (the crumple-page rip + Desk pile + dust) and **the
+fullest-cast page**. Read the FPS track. For the LOW-tier check, CPU-throttle 4x and re-measure.
+Query `codegraph` before editing any module you profile. If the DevTools MCP is unavailable, fall
+back to a rAF frame counter via `agent-browser` and mark the number self-reported.
 
-## The degradation ladder (apply IN ORDER, stop at first pass)
+## The degradation ladder (pointer - do not duplicate)
 
-1. halve the stroke budget
-2. line-boil 10 -> 8 fps
-3. dpr 2 -> 1.25
-4. disable Pass B extras (scanline, then dither)
-5. grain off
-
-Re-measure after each rung; stop the moment target FPS is met -- do NOT apply lower rungs "for
+Apply the ladder defined in `.claude/skills/webgl-standards/SKILL.md` (Quality tiers) IN ORDER,
+re-measuring after each rung; stop the moment target FPS is met -- do NOT apply lower rungs "for
 safety". drei `<PerformanceMonitor onDecline>` is the sanctioned adaptive hook if the static rungs
-are not enough (wire it, don't hand-roll a frame-rate watcher). Uniform-driven toggles and
-`pass.enabled` are free; NEVER swap `blendFunction` at runtime (recompile).
+are not enough (wire it, don't hand-roll a frame-rate watcher). The post chain never toggles a pass
+(ADR 0015), so there is no "disable Pass B" rung; NEVER swap `blendFunction` at runtime (recompile).
 
 ## Report (bounded)
 

--- a/.claude/skills/webgl-gate-audit/SKILL.md
+++ b/.claude/skills/webgl-gate-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webgl-gate-audit
-description: Procedures for auditing apps/landing WebGL phase gates - driving the browser to exact t positions, screenshot discipline, FPS sampling, scrub-determinism checks, fried-ramp flash counting, and reduced-motion verification. Load when running /gate or reviewing rendered GL output.
+description: Procedures for auditing apps/landing RIPBOOK WebGL phase gates - driving the browser to exact t positions across the 9 pages, screenshot discipline, FPS sampling, scrub + rip-reversal determinism, draw-call probing, strobe budget, copy-parity, and reduced-motion verification. Load when running /gate or reviewing rendered GL output.
 ---
 
 # apps/landing WebGL gate-audit procedures
@@ -15,10 +15,14 @@ canvas-only once GL mounts; DOM/accessibility snapshots see nothing.
 
 Scroll to a global t in [0,1]:
 `window.scrollTo(0, (document.documentElement.scrollHeight - innerHeight) * T)`
-then wait ~2s for Lenis to settle before screenshotting. The 8 beats (hero, slump, descent,
-deep-fried, godmode, features, testimonials, finale) map onto t sub-ranges from the journey
-definition. For a mid-beat sample use t = start + 0.2*(end - start), not the exact boundary
-(boundaries are transition gutters).
+then wait ~2s for Lenis to settle before screenshotting. There are **9 pages**; page `i` is
+active for `t` in `[i/9, (i+1)/9]`, in order: 0 Cover (hinge-open), 1 Slump (corner tear),
+2 DescentA (horizontal mid-rip), 3 DescentB (vertical tear), 4 Fried (crumple + toss),
+5 AreYouSure (folds to a paper plane), 6 Features (diagonal tear), 7 Testimonials (perforation
+zip), 8 Godmode -> back cover (signature + stamp, no rip). Within a page, `p` in `[0,0.72]`
+**plays** and `p` in `[0.72,1]` **scrubs the rip**. To sample a page mid-play use
+`t = i/9 + 0.4/9`; to sample its rip use `t = i/9 + 0.85/9`. Avoid exact `i/9` boundaries
+(transition gutters).
 
 ## Tools
 
@@ -37,22 +41,43 @@ LOW tier: CPU-throttle 4x (DevTools) and re-measure.
 
 ## Scrub determinism
 
-Pick a t inside a beat (not a boundary). Approach it from below (scroll to t-0.03, then t) and from
+Pick a t inside a page (not a boundary). Approach it from below (scroll to t-0.03, then t) and from
 above (t+0.03, then t); screenshot both after settle. The frames MUST match -- same camera pose,
-same stroke draw-on state, same post state. Repeat for one normal beat and the deep-fried beat.
+same stroke draw-on state, same post state. Test one **play** region (a normal page, `p<0.72`) and
+one **rip** region (the Fried crumple page, `p>0.72`).
 
-## Fried-ramp flash budget
+## Rip-reversal determinism
 
-Zero THREE/WebGL console errors are allowed at any t. Across the deep-fried beat's Pass B ramp,
-confirm no more than 3 full-frame flashes in any rolling second (frame-by-frame trace screenshots,
-or a flash-budget console counter if one is exposed). CA / dither / glitch inside the fried window
-is intentional -- the audit checks it never strobes above ~3 flashes/second, not that it is absent.
+Scroll **into** a page's rip (`t = i/9 + 0.85/9`, so `p>0.72`) then back **below** 0.72
+(`t = i/9 + 0.4/9`); after settle the page must **fully reassemble** -- no torn/missing geometry,
+no leftover crumple, and the Desk pile `.count` must not double-count the page. Reversibility is the
+core contract (the rig is pure `f(t)`); a page that stays torn on scroll-back is a HIGH failure.
+
+## Draw-call probe
+
+At each sampled page read `renderer.info.render.calls` (expose it, or read via the R3F store in an
+`eval`): it must stay **< 120** at every t. Also confirm **visibility scoping** -- only the active
+page +/-1 is mounted; distant pages are disposed (a monotonically climbing call count as you scroll
+means a page is never disposed).
+
+## Strobe budget
+
+Zero THREE/WebGL console errors are allowed at any t. Generic strobe guard (the post chain never
+toggles now, so this is content-agnostic): across **any** page -- including the Fried crumple and
+the AreYouSure paper-plane fold -- confirm no more than 3 full-frame flashes in any rolling second
+(frame-by-frame trace screenshots, or a flash-budget console counter if exposed).
+
+## Copy parity (gate step from M3)
+
+Run the bidirectional copy-diff script against `landing/index.html`. Every visible line of GL SDF
+copy must match the semantic source 1:1; any diff (missing, extra, or reworded line) fails the gate.
 
 ## Reduced-motion + gate
 
 Emulate `prefers-reduced-motion: reduce` (DevTools emulation): the page MUST render the prerendered
-semantic HTML and GL must NOT mount -- no canvas, no fried effects. Likewise verify a sub-threshold
-viewport (width <= 900) or coarse pointer falls back to the DOM page.
+semantic HTML and GL must NOT mount -- no canvas at all. Likewise verify a sub-threshold viewport
+(width <= 900), a coarse pointer, and a WebGL2-unavailable context each fall back to the legacy
+semantic page with no canvas (same bar for every gate condition).
 
 ## WebGL2 unavailable
 

--- a/.claude/skills/webgl-gate-audit/SKILL.md
+++ b/.claude/skills/webgl-gate-audit/SKILL.md
@@ -44,14 +44,17 @@ LOW tier: CPU-throttle 4x (DevTools) and re-measure.
 Pick a t inside a page (not a boundary). Approach it from below (scroll to t-0.03, then t) and from
 above (t+0.03, then t); screenshot both after settle. The frames MUST match -- same camera pose,
 same stroke draw-on state, same post state. Test one **play** region (a normal page, `p<0.72`) and
-one **rip** region (the Fried crumple page, `p>0.72`).
+one **exit** region (`p>0.72`) -- a rip page (e.g. Fried crumple) AND a non-rip exit (page 0 cover
+hinge-open, page 8 signature + stamp + back-cover close), since those exits are not rips.
 
-## Rip-reversal determinism
+## Exit-reversal determinism
 
-Scroll **into** a page's rip (`t = i/9 + 0.85/9`, so `p>0.72`) then back **below** 0.72
+Scroll **into** a page's exit (`t = i/9 + 0.85/9`, so `p>0.72`) then back **below** 0.72
 (`t = i/9 + 0.4/9`); after settle the page must **fully reassemble** -- no torn/missing geometry,
-no leftover crumple, and the Desk pile `.count` must not double-count the page. Reversibility is the
-core contract (the rig is pure `f(t)`); a page that stays torn on scroll-back is a HIGH failure.
+no leftover crumple/fold, and the Desk pile `.count` must not double-count the page. Run it on a
+rip page AND on page 0 (hinge must re-close) and page 8 (signature/stamp must clear). Reversibility
+is the core contract (the rig is pure `f(t)`); a page that stays exited on scroll-back is a HIGH
+failure.
 
 ## Draw-call probe
 

--- a/.claude/skills/webgl-standards/SKILL.md
+++ b/.claude/skills/webgl-standards/SKILL.md
@@ -62,7 +62,10 @@ directions -- no time-accumulated state driving scroll visuals). Page `i` is **a
 | 8   | Godmode      | -> back cover; pencil signature + stamp, **no rip**, two-moment timeline |
 
 **Page-local `p`.** Map `t` within the active page to `p` in `[0,1]`: `p` in `[0,0.72]` **plays**
-the page, `p` in `[0.72,1]` **scrubs the Rip**. Both regions are pure `f(t)` and fully reversible.
+the page, `p` in `[0.72,1]` scrubs the page's **exit**. A **Rip** is the usual exit (pages 1-7);
+page 0's exit is the cover **hinge-open** and page 8's exit is the **pencil signature + stamp +
+back-cover close** (no rip) -- same `[0.72,1]` window, different exit. Both regions are pure `f(t)`
+and fully reversible.
 
 **One timeline, channels bridge.** Lenis owns document scroll; a **single** GSAP ScrollTrigger
 `scrub:true` master timeline (absolute tweens ONLY -- no `+=`) writes into **preallocated
@@ -87,9 +90,11 @@ heavy boil amplitude, dense cross-hatch), not effect passes.
 ## uBoil singleton-uniform contract
 
 `uBoil` is **one uniform object shared by reference** across every ink/hatch/crease material. The
-**single writer** is the composer's `priority 1` `useFrame`; it sets `uBoil = floor(time*10)/10`
-(HIGH 10 fps, LOW 8 fps) once per frame. No material owns its own boil clock, and nothing else
-writes it. Re-seed all ink jitter from `uBoil` so the whole page boils on the same step.
+**single writer** is the composer's `priority 1` `useFrame`; it sets
+`uBoil = floor(time * boilHz) / boilHz` once per frame, where `boilHz` is the **active quality
+tier's** boil rate (HIGH 10, LOW 8 -- see Quality tiers). It is **not** a fixed 10 Hz. No material
+owns its own boil clock, and nothing else writes it. Re-seed all ink jitter from `uBoil` so the
+whole page boils on the same step.
 
 ## Boil-vs-smooth split
 
@@ -100,8 +105,9 @@ broken.
 
 ## Rip system invariants
 
-- **Pre-split at load.** Each page is authored as a tear mesh at load time (never re-triangulated
-  per frame).
+- **Pre-split at load.** Each **rippable** page (1-7) is authored as a tear mesh at load time
+  (never re-triangulated per frame). Page 0 (cover hinge) and page 8 (signature + stamp + back-cover
+  close) use their own exit meshes, not the tear/morph rig.
 - **Vertex-shader bend + morph targets.** The Rip is a vertex-shader bend plus morph-target
   crumple/fold driven by `p` in `[0.72,1]` -- pure `f(t)`, so scrubbing back below 0.72 fully
   reassembles the page.
@@ -116,19 +122,34 @@ broken.
 stain/smudge atlas** -- reused across all pages. **Never per-page 4096^2 bakes.** HIGH bakes at
 4096^2, LOW at 2048^2. No downloaded textures.
 
-## Draw-call budget (< 120) + visibility scoping
+## Budgets (the numbers other docs point at) + visibility scoping
 
-Keep total draw calls under 120. Only the **active page +/-1** is mounted; distant pages are
-disposed (see Rip system). Probe with `renderer.info.render.calls`. The pile is one instanced draw;
-per-word troika splits are headlines-only precisely because each is its own draw call.
+This skill owns the RIPBOOK performance budgets; ADR 0015 and CONTEXT.md point here instead of
+copying them:
 
-## Capability gate + the semantic layer
+- **Frame rate:** 60fps @ 1440p on M1 / GTX 1660 through every page and exit (incl. the crumple rip).
+- **JS bundle:** <= 1.3 MB gzipped.
+- **Draw calls:** < 120 -- probe with `renderer.info.render.calls`.
+
+Visibility scoping keeps the draw-call budget: only the **active page +/-1** is mounted; distant
+pages are disposed (see Rip system). The pile is one instanced draw; per-word troika splits are
+headlines-only precisely because each is its own draw call.
+
+## Capability gate + the semantic layer + the a11y overlay
 
 - **Gate to GL:** WebGL2 AND fine pointer AND width > 900 AND NOT reduced-motion, **and** a
   `flipped()` pre-launch guard until the production flip. Fail any -> the legacy prerendered DOM
-  page runs and GL never mounts. Reduced-motion users therefore never reach the boil/rip motion.
+  page runs and GL never mounts. Reduced-motion users therefore never reach the boil/exit motion.
 - **Semantic layer is the scroll-height authority.** When GL mounts it gets `visibility:hidden` +
-  `inert` -- NEVER `display:none` (that collapses scroll height and breaks the scroll rig).
+  `inert` -- NEVER `display:none` (that collapses scroll height and breaks the scroll rig). It keeps
+  owning SEO + machine-readable copy while hidden; it is NOT the interactive surface once GL runs.
+- **a11y overlay is the accessible interface while GL runs.** Because copy is in-canvas SDF (opaque
+  to the a11y tree), a **visually-hidden but focusable** DOM overlay carries the accessibility: REAL
+  `<a>`/`<button>` elements positioned over the canvas hotspots (CTA, film hints, footer / store /
+  sponsor links, the sound / "mute the guy" toggle, doodle pokes, dialog buttons), a **skip-link
+  first in tab order**, and an `aria-live` region that mirrors the gag/speech-bubble text as it
+  changes. The overlay is keyboard + screen-reader operable even though it is visually hidden; the
+  canvas itself stays `aria-hidden`. Do not put the interactive controls only on the canvas.
 
 ## Quality tiers
 

--- a/.claude/skills/webgl-standards/SKILL.md
+++ b/.claude/skills/webgl-standards/SKILL.md
@@ -1,70 +1,146 @@
 ---
 name: webgl-standards
-description: apps/landing WebGL landing conventions + verified version pins the GL authors and critics load first - R3F v9 / three ~0.185 / postprocessing 6.39.2, the 8-beat t-space camera journey, ink-stroke line-boil, the two-pass post pipeline, capability gate, quality tiers, and the ASCII-only source rule. Load for any change under apps/landing/src/**.
+description: apps/landing WebGL landing conventions + verified version pins the GL authors and critics load first - R3F v9 / three ~0.185 / postprocessing 6.39.2 / gsap+lenis, the RIPBOOK 9-page p-space scroll model, the uBoil stepped-boil contract, the rip system, the single always-on post chain, capability gate, quality tiers, and the ASCII-only source rule. Load for any change under apps/landing/src/**.
 ---
 
-# apps/landing WebGL standards
+# apps/landing WebGL standards (RIPBOOK)
 
 The single source both GL authors (`webgl-author`, `shader-engineer`) and their critics
 (`webgl-reviewer`, `gate-auditor`, `webgl-perf-profiler`) read before touching `apps/landing`.
-Architecture rationale: `docs/adr/0014-landing-gl-takeover.md`.
+Architecture rationale: `docs/adr/0014-landing-gl-takeover.md` as amended by
+`docs/adr/0015-ripbook-notebook-landing.md` (RIPBOOK).
 
 ## The stack (Next 16 static export)
 
-Full-canvas R3F v9 + three ~0.185 + postprocessing 6.39.2 + Lenis + zustand -- a "living
-sketchbook". The camera rides a Catmull-Rom journey; ALL text renders in GL (no DOM text over
-the canvas). A prerendered semantic HTML layer stays the SEO/a11y/scroll-height authority.
+Full-canvas R3F v9 + three ~0.185 + postprocessing 6.39.2 + gsap + lenis + zustand -- **RIPBOOK**,
+a kraft-paper **notebook on a dark desk**, camera looking down ~25 degrees. Every story beat is a
+rippable **Page**; scroll plays a Page then Rips it out; ripped pages persist as a Desk pile
+(the progress indicator). **ALL copy renders in GL as SDF text** (troika) -- no DOM text over the
+canvas. A prerendered semantic HTML layer stays the SEO/a11y/scroll-height authority.
 
 ## Version pins (verified - do NOT drift)
 
-- **postprocessing `^6.39.2` -- NEVER `6.39.0`.** 6.39.0's three peer range excludes 0.185; only
-  6.39.2+ accepts the pinned three. A lockfile that resolves 6.39.0 is a blocker.
-- **troika / drei Text is TTF-only** -- no woff2. Every drei `Text` needs an explicit `characters`
-  prop (the glyph set it will render) or troika silently drops glyphs. Per-word `Text` splits are
-  capped to headlines only (each split is its own draw call + SDF atlas).
+| Package             | Pin                    | Note                                                                               |
+| ------------------- | ---------------------- | ---------------------------------------------------------------------------------- |
+| three               | 0.185.1                | the `~0.185` line R3F v9 + drei target                                             |
+| @react-three/fiber  | 9.6.1                  | pairs with React 19                                                                |
+| @react-three/drei   | 10.7.7                 |                                                                                    |
+| postprocessing      | 6.39.2 -- NEVER 6.39.0 | 6.39.0's three peer range excludes 0.185; a lockfile resolving 6.39.0 is a blocker |
+| troika (three-text) | 0.52.4                 | TTF-only; explicit `characters`                                                    |
+| gsap                | 3.15.0                 | ONE ScrollTrigger master timeline, `scrub:true`                                    |
+| lenis               | 1.3.25                 | owns document scroll; synced to ScrollTrigger                                      |
+| framer-motion       | (DOM-only)             | loader / mute toggle / a11y overlay ONLY -- never over the canvas                  |
+| typescript          | 6.0.3                  |                                                                                    |
+
+Caveats that bite:
+
+- **troika / drei `Text` is TTF-only** -- no woff2. Every `Text` needs an explicit `characters`
+  prop or troika silently drops glyphs. Per-word `Text` splits are **headlines only** (each split
+  is its own draw call + SDF atlas).
 - **Ink strokes = `Line2` fat lines** from `three/addons/lines` (LineGeometry + LineMaterial),
-  with `dashed` + animated `dashOffset` for draw-on. Never plain `THREE.Line`.
-- **Line-boil = a VERTEX-SHADER effect** -- per-vertex noise keyed to a STEPPED `uTime` uniform
-  (quantize to ~10 fps so the wobble reads hand-drawn). NEVER re-`setPositions()` on the CPU per
-  frame (allocation + upload storm).
+  `dashed` + animated `dashOffset` for draw-on. Never plain `THREE.Line`. Salvaged `doodles.json`
+  SVG paths feed these for 2D page-surface ink.
+- **Line boil is a VERTEX-SHADER effect** keyed to the stepped `uBoil` uniform (below) -- NEVER
+  re-`setPositions()` on the CPU per frame (allocation + upload storm).
 
-## The 8-beat t-space journey
+## The 9-page p-space model
 
-Everything scroll-driven is a pure function of a single global `t` in [0,1] (scrub-safe both
-directions -- no time-accumulated state driving scroll visuals). The beats, in order:
+Everything scroll-driven is a pure function of a single global `t` in `[0,1]` (scrub-safe both
+directions -- no time-accumulated state driving scroll visuals). Page `i` is **active** when
+`t` is in `[i/9, (i+1)/9]`. The 9 pages, in order, with their Rip exit:
 
-1. hero 2. slump 3. descent 4. deep-fried 5. godmode 6. features 7. testimonials 8. finale
+| #   | Page         | Exit                                                                     |
+| --- | ------------ | ------------------------------------------------------------------------ |
+| 0   | Cover        | hinge-opens                                                              |
+| 1   | Slump        | corner tear                                                              |
+| 2   | DescentA     | horizontal mid-rip                                                       |
+| 3   | DescentB     | vertical tear                                                            |
+| 4   | Fried        | crumple + toss (ink-native rage, NO glitch pass)                         |
+| 5   | AreYouSure   | folds into a paper plane                                                 |
+| 6   | Features     | diagonal tear                                                            |
+| 7   | Testimonials | perforation zip                                                          |
+| 8   | Godmode      | -> back cover; pencil signature + stamp, **no rip**, two-moment timeline |
 
-The DEEP FRIED beat (4) is a deliberate glitch window: Pass B (below) only runs inside it.
+**Page-local `p`.** Map `t` within the active page to `p` in `[0,1]`: `p` in `[0,0.72]` **plays**
+the page, `p` in `[0.72,1]` **scrubs the Rip**. Both regions are pure `f(t)` and fully reversible.
 
-## Post pipeline (two passes)
+**One timeline, channels bridge.** Lenis owns document scroll; a **single** GSAP ScrollTrigger
+`scrub:true` master timeline (absolute tweens ONLY -- no `+=`) writes into **preallocated
+channels** + the zustand store. GL reads `store.getState()` per frame; React never re-renders per
+frame. Lenis->ScrollTrigger sync: drive `lenis.raf` from `gsap.ticker`, call `ScrollTrigger.update`
+on `lenis.on('scroll', ...)`, and let the semantic layer's 9 x 140vh sections own scroll height.
 
-- **Pass A - always on.** One merged custom `SketchbookEffect`: paper grain / fiber, ink bleed,
-  warm vignette.
-- **Pass B - fried window only.** Bloom (mipmapBlur) + ChromaticAberration + a custom
-  `FriedEffect` (posterize + Bayer dither + saturation) + Scanline. Enabled only across the
-  deep-fried `t` sub-range; disabled elsewhere via `pass.enabled` / uniform ramps, never by
-  rebuilding the composer.
+## Post pipeline (RIPBOOK chain - single, always-on)
+
+Built on the **raw** postprocessing composer. Order:
+
+1. `RenderPass`
+2. `EffectPass` -- **tilt-shift DOF** (focus band on the active page)
+3. `EffectPass` -- **merged Crease + PaperGrain + Vignette** (Sobel crease lines; paper grain
+   `<= 0.035`, stepped at boil fps; warm vignette)
+
+with `multisampling: 4` (MSAA; SMAA fallback where MSAA is unavailable). **No pass EVER toggles at
+runtime.** **No bloom, no chromatic aberration, no halftone** -- the deep-fried Pass B set-piece is
+retired (ADR 0015); the Fried page gets ink-native aggression instead (editor-red rage strokes,
+heavy boil amplitude, dense cross-hatch), not effect passes.
+
+## uBoil singleton-uniform contract
+
+`uBoil` is **one uniform object shared by reference** across every ink/hatch/crease material. The
+**single writer** is the composer's `priority 1` `useFrame`; it sets `uBoil = floor(time*10)/10`
+(HIGH 10 fps, LOW 8 fps) once per frame. No material owns its own boil clock, and nothing else
+writes it. Re-seed all ink jitter from `uBoil` so the whole page boils on the same step.
+
+## Boil-vs-smooth split
+
+The hand-drawn **jitter** (ink re-seed, cross-hatch, crease wobble, grain) steps on `uBoil` so it
+reads hand-drawn. The **camera, physics, rip bend, and DOF** run off real time and stay **smooth
+60fps**. Never step the camera or the rip morph on `uBoil` -- stepping motion, not just ink, looks
+broken.
+
+## Rip system invariants
+
+- **Pre-split at load.** Each page is authored as a tear mesh at load time (never re-triangulated
+  per frame).
+- **Vertex-shader bend + morph targets.** The Rip is a vertex-shader bend plus morph-target
+  crumple/fold driven by `p` in `[0.72,1]` -- pure `f(t)`, so scrubbing back below 0.72 fully
+  reassembles the page.
+- **Pile via `.count`.** The Desk pile is one `InstancedMesh`; reveal ripped pages by raising
+  `.count`, never by adding meshes.
+- **Dispose + prefetch.** Dispose a page's geometry when its page-distance > 2, and rebuild on
+  approach (prefetch). A disposal/prefetch bug reads as a black/blank page.
+
+## Paper-bake budget
+
+**One shared kraft bake** (albedo + normal + roughness) baked once at load, plus **one seeded
+stain/smudge atlas** -- reused across all pages. **Never per-page 4096^2 bakes.** HIGH bakes at
+4096^2, LOW at 2048^2. No downloaded textures.
+
+## Draw-call budget (< 120) + visibility scoping
+
+Keep total draw calls under 120. Only the **active page +/-1** is mounted; distant pages are
+disposed (see Rip system). Probe with `renderer.info.render.calls`. The pile is one instanced draw;
+per-word troika splits are headlines-only precisely because each is its own draw call.
 
 ## Capability gate + the semantic layer
 
-- **Gate to GL:** WebGL2 AND fine pointer AND width > 900 AND NOT reduced-motion. Fail any -> the
-  legacy prerendered DOM page runs and GL never mounts. Reduced-motion users therefore NEVER reach
-  the fried glitch/CA/dither -- that is the comfort contract for this project.
+- **Gate to GL:** WebGL2 AND fine pointer AND width > 900 AND NOT reduced-motion, **and** a
+  `flipped()` pre-launch guard until the production flip. Fail any -> the legacy prerendered DOM
+  page runs and GL never mounts. Reduced-motion users therefore never reach the boil/rip motion.
 - **Semantic layer is the scroll-height authority.** When GL mounts it gets `visibility:hidden` +
-  `inert` -- NEVER `display:none` (that would collapse scroll height and break the journey).
+  `inert` -- NEVER `display:none` (that collapses scroll height and breaks the scroll rig).
 
 ## Quality tiers
 
-| Tier | dpr  | line-boil | stroke budget |
-| ---- | ---- | --------- | ------------- |
-| HIGH | 2    | 10 fps    | full          |
-| LOW  | 1.25 | 8 fps     | halved        |
+| Tier | dpr  | boil   | paper bake | stroke budget |
+| ---- | ---- | ------ | ---------- | ------------- |
+| HIGH | 2    | 10 fps | 4096^2     | full          |
+| LOW  | 1.25 | 8 fps  | 2048^2     | halved        |
 
-Degradation ladder (owned by `webgl-perf-profiler`, applied in order, stop at first pass):
-halve stroke budget -> boil 10->8 fps -> dpr 2->1.25 -> disable Pass B extras (scanline, dither)
--> grain off. drei `PerformanceMonitor` `onDecline` is the sanctioned adaptive hook if the static
-rungs are not enough.
+Degradation ladder (owned by `webgl-perf-profiler`, applied in order, stop at first pass): halve
+stroke budget -> boil 10->8 fps -> dpr 2->1.25 -> reduce tilt-shift DOF sample quality -> grain
+off. drei `PerformanceMonitor` `onDecline` is the sanctioned adaptive hook if the static rungs are
+not enough. (There is no "disable Pass B" rung any more -- the post chain never toggles.)
 
 ## ASCII-only source (hard rule)
 
@@ -72,12 +148,23 @@ Source files under `apps/landing/src/**` must be pure ASCII. Turbopack's merged 
 on multi-byte characters (the rope bug). Any user-facing copy with non-ASCII glyphs lives
 `\uXXXX`-escaped in `src/content/`, never inline in a component.
 
-## Composer pass-toggling gotcha (learned P4, 2026-07-18)
+## Scrub-safety contract
 
-postprocessing's autoRenderToScreen statically pins renderToScreen=true on the ARRAY-LAST pass
-at construction. If that pass is ever disabled (recipe windows), the last ENABLED pass renders
-offscreen and the canvas goes black outside the window. When any pass toggles enabled: set
-autoRenderToScreen=false on the composer and drive renderToScreen per frame in the recipe
-(flip only at shoulders where the ramp is zero - no pop). Also verified in 6.39.2 source:
-ChromaticAberrationEffect is the CONVOLUTION-class effect (not Bloom - its glow is precomputed
-into its own map); mainUv effects (e.g. FriedEffect barrel) cannot share a pass with CA.
+- Everything scroll-driven is a pure function of `t` -- **no `+=` accumulation** anywhere in the
+  scroll path (GSAP tweens absolute; store writes idempotent for a given `t`).
+- Read scroll state per-frame via `store.getState()` inside the loop -- **never a hook selector**
+  for per-frame values (a selector re-renders the tree every frame).
+- **One** `priority 1` `useFrame`, owned by the composer, drives the render + `uBoil`; every other
+  animation `useFrame` stays at the default priority `0`.
+- **InstancedMesh:** `setColorAt()` then `instanceColor.needsUpdate = true`; `setMatrixAt()` then
+  `instanceMatrix.needsUpdate = true`. `instanceColor` is `null` until the first `setColorAt`, and
+  any instance you never set renders WHITE -- set every instance (the pile reveals via `.count`,
+  but every slot must be initialized first).
+
+## autoRenderToScreen historical note
+
+postprocessing's `autoRenderToScreen` statically pins `renderToScreen=true` on the array-last pass
+at construction; if that pass is ever disabled the last enabled pass renders offscreen and the
+canvas goes black. RIPBOOK's chain **never toggles a pass**, so this hazard does not arise at
+runtime -- but keep `composer.autoRenderToScreen = false` and set `renderToScreen` explicitly on the
+last pass, as a durable safety default (learned P4, 2026-07-18).

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -213,26 +213,35 @@ Was one of the 8 places the Journey's camera visited. Replaced by **Page**.
 _Avoid_: reusing "Beat" for a notebook page
 
 **Page**:
-One of the 9 rippable notebook pages of the RIPBOOK landing (Cover, Slump, DescentA, DescentB,
-Fried, AreYouSure, Features, Testimonials, Godmode/back cover - see [ADR 0015](adr/0015-ripbook-notebook-landing.md)).
-The unit that replaces a Beat; scrolling plays a Page then Rips it out.
-_Avoid_: Beat (retired), section / panel (those name the semantic-layer DOM, not the 3D page)
+One of the 9 notebook pages of the RIPBOOK landing (Cover, Slump, DescentA, DescentB, Fried,
+AreYouSure, Features, Testimonials, Godmode/back cover - see [ADR 0015](adr/0015-ripbook-notebook-landing.md)).
+The unit that replaces a Beat; scrolling plays a Page then runs its **Exit**.
+_Avoid_: Beat (retired), section / panel (those name the semantic-layer DOM, not the 3D page);
+"rippable page" as a synonym for Page (pages 0 and 8 don't rip)
+
+**Exit**:
+The animation that plays a Page out as you scroll past it (the trailing slice of the Page's
+scroll). A **Rip** is the usual Exit; page 0's Exit is the cover hinge-open and page 8's Exit is
+the pencil signature + stamp + back-cover close. Pure function of scroll, fully reversible.
+_Avoid_: assuming every Exit is a Rip (two pages exit without a rip)
 
 **Rip**:
-The `p` in `[0.72,1]` scrubbed exit that tears / crumples / folds a Page out of the notebook.
-Each Page has its own exit style (corner tear, crumple, paper-plane fold, ...); it is a pure
-function of scroll and fully **reversible** (scroll back and the Page reassembles).
-_Avoid_: transition / animation (a Rip is the specific scrubbed page-exit, not any tween)
+The usual kind of **Exit** - the scrubbed animation that tears / crumples / folds a Page out of
+the notebook (pages 1-7, each with its own style: corner tear, crumple, paper-plane fold, ...).
+Reversible; scroll back and the Page reassembles. The split point lives in webgl-standards.
+_Avoid_: treating Rip as every page's Exit (pages 0/8 hinge-open and sign/stamp instead);
+transition / animation generically
 
 **p-space**:
-Page-local progress `p` in `[0,1]` - the active Page's slice of the global scroll `t` remapped so
-`[0,0.72]` **plays** the Page and `[0.72,1]` scrubs its **Rip**. Distinct from the global `t`.
+Page-local progress `p` in `[0,1]` - the active Page's slice of the global scroll `t`, remapped so
+an early range **plays** the Page and the trailing range scrubs its **Exit**. The exact split is a
+webgl-standards constant. Distinct from the global `t`.
 _Avoid_: conflating p-space with global scroll t (t spans all 9 pages; p is within one)
 
 **Desk pile**:
-The persistent stack of already-ripped Pages on the desk - the landing's progress indicator (with
+The persistent stack of already-exited Pages on the desk - the landing's progress indicator (with
 the odometer). Rendered as one instanced draw revealed by its `.count`.
-_Avoid_: "progress bar" (there is no bar; the pile of torn pages IS the indicator)
+_Avoid_: "progress bar" (there is no bar; the pile of pages IS the indicator)
 
 **Foley**:
 The procedural paper sound effects synthesized in-app - rip, crumple, whoosh, scribble, stamp.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -189,8 +189,9 @@ _Avoid_: premium tier, template category
 
 ## Domain - Landing experience
 
-See docs/adr/0014-landing-gl-takeover.md for the full contract and the webgl-standards skill
-for implementation rules; entries below are definitions only.
+See docs/adr/0014-landing-gl-takeover.md (amended by docs/adr/0015-ripbook-notebook-landing.md,
+the RIPBOOK notebook rebuild) for the full contract and the webgl-standards skill for
+implementation rules; entries below are definitions only.
 
 **Semantic layer**:
 The prerendered content HTML that is always in the DOM - what the visitor reads when the GL
@@ -202,15 +203,46 @@ The single capability check that decides whether the GL experience mounts over t
 layer. See the ADR for the exact conditions.
 _Avoid_: scattered feature detection (the decision lives in one gate)
 
-**Journey**:
-The scroll-scrubbed camera ride through the landing story - scroll position drives camera
-position.
-_Avoid_: overloading Autopilot (the app's job-application run - a different concept)
+**Journey** (superseded by [ADR 0015](adr/0015-ripbook-notebook-landing.md)):
+Was the 8-Beat scroll-scrubbed camera ride. Retired in the RIPBOOK rebuild - the landing is now
+a 9-**Page** notebook you scroll through and **Rip**. Use Page / Rip / p-space instead.
+_Avoid_: reusing "Journey" for the new model; overloading Autopilot (the app's job-application run)
 
-**Beat**:
-One of the 8 places the Journey's camera visits (hero through finale - see the ADR for the
-list).
-_Avoid_: section / panel (those name DOM content; a Beat is a place in 3D space)
+**Beat** (superseded by [ADR 0015](adr/0015-ripbook-notebook-landing.md)):
+Was one of the 8 places the Journey's camera visited. Replaced by **Page**.
+_Avoid_: reusing "Beat" for a notebook page
+
+**Page**:
+One of the 9 rippable notebook pages of the RIPBOOK landing (Cover, Slump, DescentA, DescentB,
+Fried, AreYouSure, Features, Testimonials, Godmode/back cover - see [ADR 0015](adr/0015-ripbook-notebook-landing.md)).
+The unit that replaces a Beat; scrolling plays a Page then Rips it out.
+_Avoid_: Beat (retired), section / panel (those name the semantic-layer DOM, not the 3D page)
+
+**Rip**:
+The `p` in `[0.72,1]` scrubbed exit that tears / crumples / folds a Page out of the notebook.
+Each Page has its own exit style (corner tear, crumple, paper-plane fold, ...); it is a pure
+function of scroll and fully **reversible** (scroll back and the Page reassembles).
+_Avoid_: transition / animation (a Rip is the specific scrubbed page-exit, not any tween)
+
+**p-space**:
+Page-local progress `p` in `[0,1]` - the active Page's slice of the global scroll `t` remapped so
+`[0,0.72]` **plays** the Page and `[0.72,1]` scrubs its **Rip**. Distinct from the global `t`.
+_Avoid_: conflating p-space with global scroll t (t spans all 9 pages; p is within one)
+
+**Desk pile**:
+The persistent stack of already-ripped Pages on the desk - the landing's progress indicator (with
+the odometer). Rendered as one instanced draw revealed by its `.count`.
+_Avoid_: "progress bar" (there is no bar; the pile of torn pages IS the indicator)
+
+**Foley**:
+The procedural paper sound effects synthesized in-app - rip, crumple, whoosh, scribble, stamp.
+Distinct from the Gibberish voice.
+_Avoid_: sound assets / audio files (Foley is synthesized, not sampled)
+
+**Gibberish voice**:
+The ported voice synth that mutters as the protagonist "speaks" - non-lexical, silenced by the
+"mute the guy" toggle.
+_Avoid_: narration / TTS (it renders no real words)
 
 **Passthrough files**:
 The `landing/` files copied verbatim into the exported site by the postbuild
@@ -218,8 +250,8 @@ merge-passthrough script - source that ships unchanged.
 _Avoid_: "static assets" (too generic; see the ADR for the merge mechanics)
 
 **Line boil**:
-The shader-driven wobble of the ink strokes on a stepped clock, giving the hand-drawn
-sketchbook look its core motion. See the webgl-standards skill for the implementation
-contract.
+The shader-driven wobble of the ink strokes on a stepped clock (the shared `uBoil` uniform),
+giving the hand-drawn notebook look its core motion while camera/physics stay smooth. See the
+webgl-standards skill for the implementation contract.
 _Avoid_: CPU geometry jitter (Line boil is a vertex-shader effect, not per-frame geometry
 re-jitter); jitter / noise generically

--- a/docs/adr/0014-landing-gl-takeover.md
+++ b/docs/adr/0014-landing-gl-takeover.md
@@ -5,19 +5,25 @@ amended-by: 0015
 
 # Landing becomes a built GL experience with a semantic fallback
 
-> **Amended by [ADR 0015](0015-ripbook-notebook-landing.md) (2026-07-18).** 0015 replaces
-> this ADR's landing _experience_ - the 8-beat scroll-scrubbed camera Journey, the "beat copy
-> in a screen-space DOM overlay" ruling, and the deep-fried Pass B glitch set-piece - with the
-> RIPBOOK notebook (9 rippable pages, all copy as in-canvas SDF text, one always-on post chain).
-> Everything _structural_ here still binds: the Next 16 static export, the Semantic layer as the
-> SEO/a11y/scroll-height authority, the single Experience gate, the `landing/` passthrough merge,
-> and the staged flip procedure (delete `landing/index.html` only at the owner-approved flip).
+> # ⚠ PARTIALLY HISTORICAL - read [ADR 0015](0015-ripbook-notebook-landing.md) for the active experience contract
+>
+> **Amended by ADR 0015 (2026-07-18).** 0015 **supersedes** this ADR's landing _experience_ - the
+> 8-beat scroll-scrubbed camera Journey, the "beat copy in a screen-space DOM overlay" ruling, and
+> the deep-fried Pass B glitch set-piece - with the RIPBOOK notebook (9 rippable pages, all copy as
+> in-canvas SDF text, one always-on post chain). Sections describing those are marked _Historical_
+> below and are NO LONGER the contract.
+>
+> Everything _structural_ here **still binds (active):** the Next 16 static export, the Semantic
+> layer as the SEO/a11y/scroll-height authority, the single Experience gate, the `landing/`
+> passthrough merge, and the staged flip procedure (delete `landing/index.html` only at the
+> owner-approved flip). Those sections are marked _Active_ below.
 
 ## Context
 
 The landing page shipped as a single hand-authored `landing/index.html` served
 verbatim by GitHub Pages (no build step). The next landing iteration is a
-full-canvas WebGL experience - a scroll-scrubbed camera Journey through 8 Beats -
+full-canvas WebGL experience - _(Historical: originally a scroll-scrubbed camera
+Journey through 8 Beats; ADR 0015 replaces this with the RIPBOOK 9-page notebook.)_ -
 which cannot live in one hand-maintained HTML file: it needs a component tree, a
 module graph, and a bundler.
 
@@ -26,7 +32,7 @@ option: the content must stay fully readable and crawlable when WebGL does not r
 (no WebGL2, coarse pointer, narrow viewport, or reduced-motion), and the deploy
 must stay a static artifact on GitHub Pages.
 
-## Decision
+## Decision _(Active - still binds)_
 
 The landing index becomes a **Next 16 static-export app** at `apps/landing`
 (package `@ajh/landing`). It prerenders a **Semantic layer** - the content HTML
@@ -36,7 +42,11 @@ mounts the full-canvas WebGL experience on top of it only when the single
 `landing/` directory becomes **Passthrough files** copied verbatim into the export
 by the postbuild merge-passthrough script.
 
-## Considered options
+## Considered options _(Historical rationale)_
+
+_These weighed the build-vs-no-build question; the "Journey" framing is the
+superseded experience (see ADR 0015). The rejection reasons for the app structure
+still hold._
 
 1. **GL background sandwich behind the DOM.** A canvas fixed behind the existing
    DOM content. Rejected: reduces the experience to wallpaper - it cannot drive a
@@ -49,17 +59,19 @@ by the postbuild merge-passthrough script.
    the DOM between a hand file and a bundle and leaves the semantic content
    un-built and drift-prone.
 
-## Consequences
+## Consequences _(Active - still binds)_
 
 - Pages now has a build step: see `.github/workflows/pages.yml` (build
   `@ajh/landing`, upload `apps/landing/out`).
-- The passthrough merge means `landing/` inputs still ship verbatim; at the flip
-  (P7) `landing/index.html` is deleted and the app owns the index.
-- Delivery is staged behind per-phase gates rather than one big cutover.
+- The passthrough merge means `landing/` inputs still ship verbatim; at the
+  owner-approved flip `landing/index.html` is deleted and the app owns the index.
+- Delivery is staged behind gates rather than one big cutover (0015 restates the
+  milestone map as M1..M6 + the held flip PR).
 - The Semantic layer and Experience gate keep the no-WebGL visitor whole.
 
 ## References
 
-- Glossary: `docs/CONTEXT.md` (Semantic layer, Experience gate, Journey, Beat,
-  Passthrough files, Line boil).
+- Active experience contract: `docs/adr/0015-ripbook-notebook-landing.md`.
+- Glossary: `docs/CONTEXT.md` (Semantic layer, Experience gate, Passthrough files,
+  Line boil are active; Journey and Beat are superseded by 0015).
 - App: `apps/landing`; passthrough source: `landing/`; deploy: `.github/workflows/pages.yml`.

--- a/docs/adr/0014-landing-gl-takeover.md
+++ b/docs/adr/0014-landing-gl-takeover.md
@@ -1,8 +1,17 @@
 ---
 status: accepted
+amended-by: 0015
 ---
 
 # Landing becomes a built GL experience with a semantic fallback
+
+> **Amended by [ADR 0015](0015-ripbook-notebook-landing.md) (2026-07-18).** 0015 replaces
+> this ADR's landing _experience_ - the 8-beat scroll-scrubbed camera Journey, the "beat copy
+> in a screen-space DOM overlay" ruling, and the deep-fried Pass B glitch set-piece - with the
+> RIPBOOK notebook (9 rippable pages, all copy as in-canvas SDF text, one always-on post chain).
+> Everything _structural_ here still binds: the Next 16 static export, the Semantic layer as the
+> SEO/a11y/scroll-height authority, the single Experience gate, the `landing/` passthrough merge,
+> and the staged flip procedure (delete `landing/index.html` only at the owner-approved flip).
 
 ## Context
 

--- a/docs/adr/0015-ripbook-notebook-landing.md
+++ b/docs/adr/0015-ripbook-notebook-landing.md
@@ -1,0 +1,133 @@
+---
+status: accepted
+supersedes-parts-of: 0014
+---
+
+# Landing rebuilds as RIPBOOK - a full-WebGL kraft notebook that rips out pages
+
+## Context
+
+Recorded from the grill session on 2026-07-18 (owner-approved).
+
+The GL landing shipped through P0-P5 as the "living sketchbook" of
+[ADR 0014](0014-landing-gl-takeover.md) - a scroll-scrubbed camera Journey through
+8 Beats - then was reset to an empty `apps/landing` in #710. The owner judged the
+sketchbook journey **not premium enough** and approved a rebuild under a new concept,
+**RIPBOOK**. The old Next 16 app at git `66c36c68` remains **salvage material**, not the
+baseline.
+
+Everything structural in 0014 still constrains this rebuild: the deploy stays a Next 16
+**static export** on GitHub Pages, and the content must stay fully readable and crawlable
+when WebGL does not run. RIPBOOK changes the _experience_, not that machinery.
+
+## Decision
+
+The landing becomes **RIPBOOK**: a full-WebGL kraft-paper **notebook** on a dark desk,
+camera looking down ~25 degrees. Every story beat is a notebook **Page**; scrolling plays
+the Page then **Rips** it out; ripped pages persist as a **Desk pile** that is the progress
+indicator (with an odometer).
+
+**The 9 pages (index - name - exit):**
+
+| #   | Page         | Exit style                                                            |
+| --- | ------------ | --------------------------------------------------------------------- |
+| 0   | Cover        | hinge-opens                                                           |
+| 1   | Slump        | corner tear                                                           |
+| 2   | DescentA     | horizontal mid-rip                                                    |
+| 3   | DescentB     | vertical tear                                                         |
+| 4   | Fried        | crumple + toss                                                        |
+| 5   | AreYouSure   | folds into a paper plane                                              |
+| 6   | Features     | diagonal tear                                                         |
+| 7   | Testimonials | perforation zip                                                       |
+| 8   | Godmode      | -> back cover (pencil signature + stamp, NO rip; two-moment timeline) |
+
+**Scroll rig.** Lenis owns document scroll; the prerendered semantic layer stays the
+scroll-height authority (9 x 140vh sections). Lenis is synced to **one** GSAP ScrollTrigger
+`scrub:true` master timeline (absolute tweens only) writing into preallocated channels + a
+zustand store; GL reads `store.getState()` per frame. Page-local progress `p` in `[0,0.72]`
+plays the Page, `[0.72,1]` scrubs the Rip; the whole thing is a pure function of scroll and
+**fully reversible**. Contract in `.claude/skills/webgl-standards/SKILL.md`.
+
+**Full-GL text.** All copy renders as SDF text **in-canvas** via troika (TTF-only, explicit
+`characters`). There is no DOM text over the canvas. (Supersession below.)
+
+**Post chain (strict, always-on, nothing toggles).** RenderPass -> tilt-shift DOF (focus
+band on the active page) -> paper/grain composite (grain <= 0.035, stepped at boil fps) ->
+vignette, with MSAA 4x (SMAA fallback). **No bloom, no chromatic aberration, no halftone.**
+Built on the **raw** postprocessing composer (6.39.2 pin unchanged).
+
+**Hand-drawn look.** A global stepped **boil** uniform (`uBoil = floor(time*10)/10`)
+re-seeds all ink jitter while camera/physics stay smooth 60fps; 3-band toon + procedural
+cross-hatch atlas; inverted-hull screen-constant outlines; Sobel crease lines; pencil grain;
+seeded smudge / eraser-ghost decals; procedural kraft paper **baked once at load** (no
+downloaded textures).
+
+**Audio.** The legacy gibberish-voice synth is ported verbatim to TS, plus new procedural
+paper **Foley** (rip / crumple / whoosh / scribble / stamp). A mute toggle ("mute the guy").
+
+**Characters.** True 3D **procedural** meshes, no model files: a sad protagonist that
+degrades page by page, a recruiter creature, a resume robot, four recruiters, an instanced
+swarm, and the godmode guy.
+
+**Copy parity.** 1:1 with `landing/index.html`, enforced by a bidirectional diff script (a
+gate step from M3).
+
+**Salvage strategy.** The old app at `66c36c68` is reference-only. `src/data/doodles.json`
+(extracted legacy SVG stroke art) is salvaged for page-surface 2D ink, lazily loaded; the
+cast is rebuilt as procedural 3D (no salvaged meshes).
+
+**New dependencies.** `gsap 3.15.0` + `lenis 1.3.25` (scroll rig); `framer-motion` **DOM-only**
+(loader, mute toggle, a11y overlay - never over the canvas). Version pins live in
+`.claude/skills/webgl-standards/SKILL.md`.
+
+**Budgets.** 60fps @ 1440p on M1 / GTX 1660 through every rip; JS <= 1.3 MB gz; draw calls
+< 120.
+
+**Delivery.** PRs land docs -> scaffold -> M1..M6 and merge autonomously. The **production
+flip** PR (pages.yml builds `apps/landing/out` and deletes only `landing/index.html`) is
+**opened but held for owner approval** (the #707 pre-launch-gate precedent).
+
+## Supersessions
+
+This ADR supersedes three previously locked rulings; each is named so the reader can find
+what changed:
+
+1. **The 8-beat t-space camera Journey** (0014 Context; the "8-beat t-space journey" section
+   of `webgl-standards`). Replaced by the **9-Page notebook + Rip** model - global `t` still
+   drives everything, but page `i` owns `t` in `[i/9,(i+1)/9]` with the play/rip `p`-space
+   split at 0.72.
+2. **The art-brief ruling "beat copy in a screen-space DOM overlay."** Replaced by **all copy
+   as in-canvas SDF text** (troika). The semantic layer keeps the _machine-readable_ copy;
+   the _visible_ copy is GL.
+3. **The deep-fried Pass B glitch set-piece** (Bloom + ChromaticAberration + FriedEffect
+   posterize/dither + Scanline; the "Post pipeline (two passes)" section of `webgl-standards`).
+   **Fully retired.** The Fried page instead uses **ink-native aggression** - editor-red rage
+   strokes, heavy boil amplitude, dense cross-hatch, crumple exit - under the single always-on
+   post chain. No effect ever toggles at runtime.
+
+## Consequences
+
+- The two-pass composer (Pass A always-on / Pass B fried-window) collapses to **one always-on
+  chain**; the `autoRenderToScreen` pass-toggle hazard no longer arises at runtime (kept as a
+  historical note in `webgl-standards`).
+- **GSAP scrub discipline is load-bearing.** Every tween absolute, no `+=` accumulation, one
+  master timeline - a single relative tween breaks reversibility. Enforced by the scrub-safety
+  contract + the gate's rip-reversal check.
+- **troika per-glyph boil risk.** Stepping every glyph's jitter at boil fps can spike draw
+  calls / re-layout; the fallback is per-word (not per-glyph) boil on headlines only, with body
+  copy static under boil.
+- **Budget enforcement.** Draw calls < 120 and JS <= 1.3 MB gz are gate-enforced (`renderer.info`
+  probe + bundle check); the procedural bakes and rip pre-splits must fit inside them.
+- **Rip lifecycle risk.** Pages dispose at page-distance > 2 and rebuild on approach; a disposal
+  or prefetch bug reads as a black/blank page - covered by the gate's disposal + reversal checks.
+- Reduced-motion / no-WebGL2 / coarse-pointer / narrow visitors never reach any of this: the
+  Experience gate + semantic layer of 0014 still hold them whole.
+
+## References
+
+- Amended parent: `docs/adr/0014-landing-gl-takeover.md`.
+- Glossary: `docs/CONTEXT.md` (Page, Rip, p-space, Desk pile, Foley, Gibberish voice; and the
+  still-binding Semantic layer, Experience gate, Passthrough files, Line boil).
+- Implementation rules: `.claude/skills/webgl-standards/SKILL.md`; gate procedures:
+  `.claude/skills/webgl-gate-audit/SKILL.md`.
+- Salvage source: git `66c36c68`; copy source of truth: `landing/index.html`; app: `apps/landing`.

--- a/docs/adr/0015-ripbook-notebook-landing.md
+++ b/docs/adr/0015-ripbook-notebook-landing.md
@@ -22,10 +22,11 @@ when WebGL does not run. RIPBOOK changes the _experience_, not that machinery.
 
 ## Decision
 
-The landing becomes **RIPBOOK**: a full-WebGL kraft-paper **notebook** on a dark desk,
-camera looking down ~25 degrees. Every story beat is a notebook **Page**; scrolling plays
-the Page then **Rips** it out; ripped pages persist as a **Desk pile** that is the progress
-indicator (with an odometer).
+The landing becomes **RIPBOOK**: a full-WebGL kraft-paper **notebook** on a dark desk, camera
+looking down at it. Every story beat is a notebook **Page**; scrolling plays the Page then runs
+its **exit** (usually a **Rip**); exited pages persist as a **Desk pile** that is the progress
+indicator (with an odometer). Operational constants (angles, splits, sizes, pins, budgets) live in
+`.claude/skills/webgl-standards/SKILL.md`; this ADR records the decision, not the numbers.
 
 **The 9 pages (index - name - exit):**
 
@@ -41,26 +42,31 @@ indicator (with an odometer).
 | 7   | Testimonials | perforation zip                                                       |
 | 8   | Godmode      | -> back cover (pencil signature + stamp, NO rip; two-moment timeline) |
 
+Each page has a **play** phase then an **exit** phase (the trailing slice of its scroll). A
+**Rip** is the usual exit (pages 1-7); page 0 exits by hinge-opening the cover and page 8 by the
+pencil signature + stamp + back-cover close - not every page rips.
+
 **Scroll rig.** Lenis owns document scroll; the prerendered semantic layer stays the
-scroll-height authority (9 x 140vh sections). Lenis is synced to **one** GSAP ScrollTrigger
-`scrub:true` master timeline (absolute tweens only) writing into preallocated channels + a
-zustand store; GL reads `store.getState()` per frame. Page-local progress `p` in `[0,0.72]`
-plays the Page, `[0.72,1]` scrubs the Rip; the whole thing is a pure function of scroll and
-**fully reversible**. Contract in `.claude/skills/webgl-standards/SKILL.md`.
+scroll-height authority. Lenis is synced to **one** GSAP ScrollTrigger `scrub:true` master
+timeline (absolute tweens only) writing into preallocated channels + a zustand store; GL reads
+`store.getState()` per frame. The whole thing is a pure function of scroll and **fully
+reversible** (scrolling back reassembles an exited page). The `p`-space split, section heights,
+and sync pattern live in `.claude/skills/webgl-standards/SKILL.md`.
 
 **Full-GL text.** All copy renders as SDF text **in-canvas** via troika (TTF-only, explicit
 `characters`). There is no DOM text over the canvas. (Supersession below.)
 
 **Post chain (strict, always-on, nothing toggles).** RenderPass -> tilt-shift DOF (focus
-band on the active page) -> paper/grain composite (grain <= 0.035, stepped at boil fps) ->
-vignette, with MSAA 4x (SMAA fallback). **No bloom, no chromatic aberration, no halftone.**
-Built on the **raw** postprocessing composer (6.39.2 pin unchanged).
+band on the active page) -> paper/grain composite -> vignette, with MSAA (SMAA fallback).
+**No bloom, no chromatic aberration, no halftone.** Built on the **raw** postprocessing composer.
+Pass order, MSAA sample count, and grain cap live in the skill.
 
-**Hand-drawn look.** A global stepped **boil** uniform (`uBoil = floor(time*10)/10`)
-re-seeds all ink jitter while camera/physics stay smooth 60fps; 3-band toon + procedural
-cross-hatch atlas; inverted-hull screen-constant outlines; Sobel crease lines; pencil grain;
-seeded smudge / eraser-ghost decals; procedural kraft paper **baked once at load** (no
-downloaded textures).
+**Hand-drawn look.** A global stepped **boil** uniform re-seeds all ink jitter (stepped at the
+active quality tier's boil rate, not a fixed clock) while camera/physics stay smooth; 3-band toon
+
+- procedural cross-hatch atlas; inverted-hull screen-constant outlines; Sobel crease lines; pencil
+  grain; seeded smudge / eraser-ghost decals; procedural kraft paper **baked once at load** (no
+  downloaded textures). The `uBoil` formula, tier rates, and bake sizes live in the skill.
 
 **Audio.** The legacy gibberish-voice synth is ported verbatim to TS, plus new procedural
 paper **Foley** (rip / crumple / whoosh / scribble / stamp). A mute toggle ("mute the guy").
@@ -76,12 +82,11 @@ gate step from M3).
 (extracted legacy SVG stroke art) is salvaged for page-surface 2D ink, lazily loaded; the
 cast is rebuilt as procedural 3D (no salvaged meshes).
 
-**New dependencies.** `gsap 3.15.0` + `lenis 1.3.25` (scroll rig); `framer-motion` **DOM-only**
-(loader, mute toggle, a11y overlay - never over the canvas). Version pins live in
-`.claude/skills/webgl-standards/SKILL.md`.
+**New dependencies.** `gsap` + `lenis` (the scroll rig); `framer-motion` **DOM-only** (loader,
+mute toggle, a11y overlay - never over the canvas). Exact version pins live in the skill.
 
-**Budgets.** 60fps @ 1440p on M1 / GTX 1660 through every rip; JS <= 1.3 MB gz; draw calls
-< 120.
+**Budgets.** Hard, gate-enforced budgets on frame rate (through every exit), JS bundle size, and
+draw calls; the numbers live in the skill's Budgets section.
 
 **Delivery.** PRs land docs -> scaffold -> M1..M6 and merge autonomously. The **production
 flip** PR (pages.yml builds `apps/landing/out` and deletes only `landing/index.html`) is
@@ -93,9 +98,9 @@ This ADR supersedes three previously locked rulings; each is named so the reader
 what changed:
 
 1. **The 8-beat t-space camera Journey** (0014 Context; the "8-beat t-space journey" section
-   of `webgl-standards`). Replaced by the **9-Page notebook + Rip** model - global `t` still
-   drives everything, but page `i` owns `t` in `[i/9,(i+1)/9]` with the play/rip `p`-space
-   split at 0.72.
+   of `webgl-standards`). Replaced by the **9-Page notebook** model - global `t` still drives
+   everything, but each page owns its slice of `t`, split into a play phase then an exit phase
+   (see the skill's p-space section for the exact split).
 2. **The art-brief ruling "beat copy in a screen-space DOM overlay."** Replaced by **all copy
    as in-canvas SDF text** (troika). The semantic layer keeps the _machine-readable_ copy;
    the _visible_ copy is GL.
@@ -116,8 +121,9 @@ what changed:
 - **troika per-glyph boil risk.** Stepping every glyph's jitter at boil fps can spike draw
   calls / re-layout; the fallback is per-word (not per-glyph) boil on headlines only, with body
   copy static under boil.
-- **Budget enforcement.** Draw calls < 120 and JS <= 1.3 MB gz are gate-enforced (`renderer.info`
-  probe + bundle check); the procedural bakes and rip pre-splits must fit inside them.
+- **Budget enforcement.** The frame-rate, JS-size, and draw-call budgets (numbers in the skill)
+  are gate-enforced (`renderer.info` probe + bundle check); the procedural bakes and rip pre-splits
+  must fit inside them.
 - **Rip lifecycle risk.** Pages dispose at page-distance > 2 and rebuild on approach; a disposal
   or prefetch bug reads as a black/blank page - covered by the gate's disposal + reversal checks.
 - Reduced-motion / no-WebGL2 / coarse-pointer / narrow visitors never reach any of this: the


### PR DESCRIPTION
## What

Adopts the RIPBOOK plan: rebuilding the landing page as a full-WebGL kraft-paper notebook in `apps/landing` (9 rippable pages, boiling hand-drawn ink, scroll-scrubbed rips).

- **ADR 0015** (new, accepted): notebook concept, 9-page map with per-page exits, Lenis + single GSAP `scrub:true` scroll rig, full-GL SDF copy, strict always-on post chain (MSAA -> tilt-shift DOF -> paper/grain -> vignette; no bloom/CA/halftone), gibberish-voice port + procedural foley, 1:1 copy-parity enforcement, salvage strategy, flip-held-for-approval delivery.
- **ADR 0014**: `amended-by: 0015` note — what's superseded (8-beat journey, DOM-overlay copy, fried Pass B) vs what still binds (static export, semantic layer, capability gate, passthrough/merge, flip procedure).
- **webgl-standards skill**: rewritten for the 9-page p-space model, uBoil contract, rip invariants, paper-bake budget, RIPBOOK post chain; pins table gains gsap/lenis/framer-motion (DOM-only).
- **webgl-gate-audit skill**: 9-page driving guide, rip-reversal determinism, draw-call probe, generic strobe budget, copy-parity gate from M3; fried Pass B check retired.
- **webgl-author agent**: primary paths amended to the new src tree.
- **CONTEXT.md**: glossary — Journey/Beat retired; Page, Rip, p-space, Desk pile, Foley, Gibberish voice added.

## Why

Landing GL restart (post #710 reset). Grill session 2026-07-18 locked three supersessions and the delivery shape; this PR makes the docs/skills teach the new model before any code lands.

## Validation

- `pnpm check:agent-system` PASS
- `pnpm check:landing-drift` PASS (`landing/` untouched)
- Docs-only change; no code, no workflows.

First of the RIPBOOK series: docs -> scaffold -> M1..M6 -> flip (flip PR will be held for owner approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the RIPBOOK landing experience design specification, including a nine-page scroll narrative and notebook-inspired visual direction.
  * Defined fallback behavior for reduced-motion settings, limited pointer capabilities, and unavailable WebGL2 support.
  * Established requirements for readable, crawlable content when WebGL is unavailable.

* **Documentation**
  * Updated landing experience terminology, architecture decisions, implementation standards, and audit procedures.
  * Documented performance, animation, determinism, copy parity, and accessibility validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->