### PR TITLE
feat: ripbook m1 - notebook shell and rip rig proof

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -7,7 +7,9 @@
     "dev": "next dev",
     "build": "next build",
     "postbuild": "node scripts/merge-passthrough.mjs",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@react-three/drei": "10.7.7",
@@ -29,6 +31,7 @@
     "@types/react-dom": "19.2.3",
     "@types/three": "0.185.1",
     "svg-path-properties": "2.0.1",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/landing/src/app/GLLoader.tsx
+++ b/apps/landing/src/app/GLLoader.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { type ReactNode, useCallback, useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import {
+  Component,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 
 import { gateVerdict } from "@/engine/gate";
 import { initLegacy } from "@/fallback/legacy";
@@ -10,19 +17,37 @@ import { initLegacy } from "@/fallback/legacy";
 // layer stays visible and interactive until Experience reports onReady on its
 // first painted frame -- only then is it hidden + made inert (never display:none,
 // that would collapse scroll height). If the visitor activates the skip-link
-// below, GLLoader unmounts GL, reverts the semantic layer, and boots the legacy
-// engine itself -- LegacyBoot already stood down because the initial gate verdict
-// was GL, so this is the only place left that can still start it.
+// below, or the Experience throws during render, GLLoader unmounts GL, reverts
+// the semantic layer, and boots the legacy engine itself -- LegacyBoot already
+// stood down because the initial gate verdict was GL, so this is the only place
+// left that can still start it.
 //
-// RIPBOOK scaffold (PR0): the WebGL Experience is not built yet -- it arrives in
-// M1. RipbookExperience is a placeholder that renders nothing and never reports
-// ready, so on the GL-pass path the semantic layer simply stays visible. When the
-// real Experience lands (M1) it replaces this stub with a dynamic ssr:false import
-// that calls onReady on its first painted frame, and the boot restores the
-// font-preload warm-up + a render-error boundary around it.
-// TODO(ripbook M1): dynamic-import the real GL Experience here.
-function RipbookExperience(_props: { onReady: () => void }): ReactNode {
-  return null;
+// The real RIPBOOK Experience (M1) is dynamically imported with ssr:false: it
+// touches window/WebGL, so it must never run during the static prerender. It
+// calls onReady on its first painted frame.
+const RipbookExperience = dynamic(
+  () => import("@/experience/RipbookExperience"),
+  { ssr: false },
+);
+
+// Render-phase error boundary around the Experience. A WebGL/init throw here is
+// caught and turned into a legacy fallback instead of a blank page. (Event-time
+// failures like context loss are a later hardening pass; M1 covers the render
+// path.)
+class ExperienceBoundary extends Component<
+  { onError: () => void; children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  componentDidCatch() {
+    this.props.onError();
+  }
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
 }
 
 export default function GLLoader() {
@@ -42,13 +67,20 @@ export default function GLLoader() {
   // semantic layer never gets stuck hidden.
   useEffect(() => {
     if (!ready) return;
+    // .gl-active hides the legacy fixed chrome (see globals.css) that lives
+    // outside #semantic-root; the root itself is hidden + inert.
+    document.documentElement.classList.add("gl-active");
     const root = document.getElementById("semantic-root");
-    if (!root) return;
-    root.style.visibility = "hidden";
-    root.setAttribute("inert", "");
+    if (root) {
+      root.style.visibility = "hidden";
+      root.setAttribute("inert", "");
+    }
     return () => {
-      root.style.visibility = "";
-      root.removeAttribute("inert");
+      document.documentElement.classList.remove("gl-active");
+      if (root) {
+        root.style.visibility = "";
+        root.removeAttribute("inert");
+      }
     };
   }, [ready]);
 
@@ -76,7 +108,9 @@ export default function GLLoader() {
       >
         view accessible version
       </a>
-      <RipbookExperience onReady={() => setReady(true)} />
+      <ExperienceBoundary onError={fallBackToLegacy}>
+        <RipbookExperience onReady={() => setReady(true)} />
+      </ExperienceBoundary>
     </>
   );
 }

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -458,6 +458,29 @@ a.cta:focus-visible     { border-radius:12px 9px 13px 8px }
 }
 .skip-gl:focus{ top:8px }
 
+/* ---------- GL scroll pacing ----------
+   When the RIPBOOK scroll rig mounts, scroll.ts adds .gl-paced to #semantic-root
+   so the (now visibility:hidden, still layout-measured) semantic sections supply
+   generous, evenly paced scroll height for the 9-page t-space. Content is
+   untouched -- only each direct section's min-height grows. Removed on rig
+   teardown. */
+#semantic-root.gl-paced > *{min-height:140vh}
+
+/* When the GL experience has painted, the prerendered legacy fixed chrome
+   (progress bar, odometer, sound toggle, cookie, journey ink, toasts) must
+   yield: it lives OUTSIDE #semantic-root so visibility:hidden on that root does
+   not cover it, and its behaviour (LegacyBoot) stood down at the gate, so these
+   are dead controls over the canvas. GLLoader adds .gl-active on <html> when
+   ready and removes it on teardown/fallback. #loader is intentionally excluded
+   -- the GL first-frame lift owns it. */
+html.gl-active #progress-wrap,
+html.gl-active #odometer,
+html.gl-active #sound-toggle,
+html.gl-active #cookie,
+html.gl-active #journey,
+html.gl-active #slowdown,
+html.gl-active #jk{display:none}
+
 /* reduced motion */
 @media (prefers-reduced-motion: reduce){
   /* Kill decorative animations and transitions. The focus-visible outline is a

--- a/apps/landing/src/book/PageMesh.tsx
+++ b/apps/landing/src/book/PageMesh.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+// The one M1 page: the pre-split corner-tear kraft page. Renders the two
+// geometries from presplitCornerTear -- the HELD piece static on the notebook,
+// the FREE corner piece inside a group the composer throws (rigid, f(exitP)).
+// Both meshes share ONE RipPaperMaterial program (distinguished only by a uSide
+// flag): the vertex shader gates the tear front along aSeamArc and bends the
+// peel near the seam, all pure f(uRipP) so scrubbing back reassembles the page;
+// the fragment is the placeholder kraft (real bake lands in M2). The split and
+// the two material instances are built once (pure f(seed)) and disposed on
+// unmount.
+
+import { type RefObject, useEffect, useMemo } from "react";
+import type { Group } from "three";
+
+import { createRipPaperMaterial, RIP_PAPER_SIDE } from "@/materials/RipPaperMaterial";
+import { presplitCornerTear } from "@/rip/presplit";
+
+export default function PageMesh({ freeRef }: { freeRef: RefObject<Group | null> }) {
+  const split = useMemo(() => presplitCornerTear(1), []);
+  const heldMat = useMemo(() => createRipPaperMaterial(RIP_PAPER_SIDE.HELD), []);
+  const freeMat = useMemo(() => createRipPaperMaterial(RIP_PAPER_SIDE.FREE), []);
+
+  useEffect(
+    () => () => {
+      split.held.dispose();
+      split.free.dispose();
+      heldMat.dispose();
+      freeMat.dispose();
+    },
+    [split, heldMat, freeMat],
+  );
+
+  return (
+    <group>
+      <mesh geometry={split.held} material={heldMat} />
+      <group ref={freeRef}>
+        <mesh geometry={split.free} material={freeMat} />
+      </group>
+    </group>
+  );
+}

--- a/apps/landing/src/debug/Hud.tsx
+++ b/apps/landing/src/debug/Hud.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+// Dev-only telemetry overlay for the gate-auditor: global t, active page, that
+// page's p / exitP, fps, and the last frame's renderer.info.render.calls. A DOM
+// element (never over canvas hit targets, pointer-events:none), driven by its
+// own rAF poll reading the store + channels + hudStats -- it never re-renders
+// React and never touches the GL loop. Gated to NODE_ENV development OR a ?hud=1
+// param; renders nothing otherwise. window is only read inside an effect.
+
+import { useEffect, useRef, useState } from "react";
+
+import { channels } from "@/engine/channels";
+import { hudStats } from "@/engine/stats";
+import { ripbookStore } from "@/engine/store";
+
+export default function Hud() {
+  const [on, setOn] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const enabled =
+      process.env.NODE_ENV === "development" ||
+      new URLSearchParams(window.location.search).has("hud");
+    if (enabled) setOn(true);
+  }, []);
+
+  useEffect(() => {
+    if (!on) return;
+    let raf = 0;
+    let last = performance.now();
+    let frames = 0;
+    let acc = 0;
+    let fps = 0;
+    const tick = (now: number) => {
+      const dt = now - last;
+      last = now;
+      frames += 1;
+      acc += dt;
+      if (acc >= 500) {
+        fps = Math.round((frames * 1000) / acc);
+        frames = 0;
+        acc = 0;
+      }
+      const s = ripbookStore.getState();
+      const ch = channels[s.activePage];
+      const el = ref.current;
+      if (el && ch) {
+        el.textContent =
+          `t ${s.t.toFixed(3)}  page ${s.activePage}  ` +
+          `p ${ch.p.toFixed(2)}  exitP ${ch.exitP.toFixed(2)}  ` +
+          `fps ${fps}  calls ${hudStats.calls}`;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [on]);
+
+  if (!on) return null;
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: "fixed",
+        left: "8px",
+        bottom: "8px",
+        zIndex: 200,
+        padding: "4px 8px",
+        borderRadius: "6px",
+        background: "rgba(8,10,16,0.72)",
+        color: "#9fe8c2",
+        font: "11px/1.4 monospace",
+        letterSpacing: "0.02em",
+        pointerEvents: "none",
+        whiteSpace: "nowrap",
+      }}
+    />
+  );
+}

--- a/apps/landing/src/debug/Hud.tsx
+++ b/apps/landing/src/debug/Hud.tsx
@@ -20,7 +20,7 @@ export default function Hud() {
   useEffect(() => {
     const enabled =
       process.env.NODE_ENV === "development" ||
-      new URLSearchParams(window.location.search).has("hud");
+      new URLSearchParams(window.location.search).get("hud") === "1";
     if (enabled) setOn(true);
   }, []);
 

--- a/apps/landing/src/engine/channels.ts
+++ b/apps/landing/src/engine/channels.ts
@@ -1,0 +1,19 @@
+// The GSAP -> GL bridge. One preallocated channel object per page, written by
+// the single scrub master timeline (scroll.ts) with ABSOLUTE tweens and read by
+// reference inside the composer's useFrame. This array is allocated exactly
+// once, at module load; nothing pushes/splices or replaces an entry afterwards,
+// so the per-frame GL path never allocates. p/exitP mirror pages.pageProgress
+// (p = whole-slice progress, exitP = exit sub-slice progress) but are driven by
+// GSAP so a single timeline owns all page motion.
+
+import { PAGE_COUNT } from "./pages";
+
+export interface PageChannel {
+  p: number;
+  exitP: number;
+}
+
+export const channels: PageChannel[] = Array.from(
+  { length: PAGE_COUNT },
+  () => ({ p: 0, exitP: 0 }),
+);

--- a/apps/landing/src/engine/pages.test.ts
+++ b/apps/landing/src/engine/pages.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  activePageFor,
+  CORNER_TEAR_PAGE,
+  EXIT_START,
+  PAGE_COUNT,
+  pageProgress,
+  PAGES,
+} from './pages';
+
+// t that lands page `i` at local progress `p` (inverse of pageProgress's core:
+// p = t * PAGE_COUNT - i, so t = (i + p) / PAGE_COUNT).
+const tFor = (i: number, p: number): number => (i + p) / PAGE_COUNT;
+
+describe('pageProgress', () => {
+  it('is zero at the very start (t=0, page 0)', () => {
+    const { p, exitP } = pageProgress(0, 0);
+    expect(p).toBe(0);
+    expect(exitP).toBe(0);
+  });
+
+  it('is fully played and fully exited at the very end (t=1, page 8)', () => {
+    const { p, exitP } = pageProgress(1, PAGE_COUNT - 1);
+    expect(p).toBe(1);
+    expect(exitP).toBe(1);
+  });
+
+  it('hands off cleanly at each page boundary i/PAGE_COUNT', () => {
+    // At t=i/9, page i-1 is fully played (p=1) and page i is just starting (p=0).
+    for (let i = 1; i < PAGE_COUNT; i++) {
+      const t = i / PAGE_COUNT;
+      expect(pageProgress(t, i - 1).p).toBeCloseTo(1, 6);
+      expect(pageProgress(t, i).p).toBeCloseTo(0, 6);
+    }
+  });
+
+  it('runs local p from 0 to 1 across each page slice', () => {
+    for (let i = 0; i < PAGE_COUNT; i++) {
+      expect(pageProgress(tFor(i, 0), i).p).toBeCloseTo(0, 6);
+      expect(pageProgress(tFor(i, 1), i).p).toBeCloseTo(1, 6);
+    }
+  });
+
+  // --- the EXIT_START (0.72) play/exit split ---
+
+  it('keeps exitP at 0 while p is below the exit split', () => {
+    const { p, exitP } = pageProgress(tFor(1, 0.5), 1);
+    expect(p).toBeCloseTo(0.5, 6);
+    expect(exitP).toBe(0);
+  });
+
+  it('keeps exitP at 0 exactly at the exit split (p === EXIT_START)', () => {
+    // i=0, t=0.08 yields p === 0.72 exactly; the split is inclusive (p <= 0.72).
+    const t = 0.08;
+    const { p, exitP } = pageProgress(t, 0);
+    expect(p).toBe(EXIT_START);
+    expect(exitP).toBe(0);
+  });
+
+  it('remaps the exit sub-slice so mid-exit p=0.86 -> exitP=0.5', () => {
+    // (0.86 - 0.72) / (1 - 0.72) = 0.14 / 0.28 = 0.5.
+    const { p, exitP } = pageProgress(tFor(1, 0.86), 1);
+    expect(p).toBeCloseTo(0.86, 6);
+    expect(exitP).toBeCloseTo(0.5, 6);
+  });
+
+  it('reaches exitP=1 when the page is fully played (p=1)', () => {
+    expect(pageProgress(tFor(1, 1), 1).exitP).toBe(1);
+  });
+
+  it('clamps p and exitP to 0 below the page slice', () => {
+    const { p, exitP } = pageProgress(tFor(1, -0.5), 1);
+    expect(p).toBe(0);
+    expect(exitP).toBe(0);
+  });
+
+  it('clamps p and exitP to 1 above the page slice', () => {
+    const { p, exitP } = pageProgress(tFor(1, 4), 1);
+    expect(p).toBe(1);
+    expect(exitP).toBe(1);
+  });
+});
+
+describe('PAGES registry', () => {
+  it('has exactly PAGE_COUNT entries', () => {
+    expect(PAGES.length).toBe(PAGE_COUNT);
+  });
+
+  it('marks the corner-tear page at CORNER_TEAR_PAGE', () => {
+    expect(PAGES[CORNER_TEAR_PAGE]?.exit).toBe('corner-tear');
+  });
+});
+
+describe('activePageFor', () => {
+  it('is page 0 at t=0 and page 8 at t=1', () => {
+    expect(activePageFor(0)).toBe(0);
+    expect(activePageFor(1)).toBe(PAGE_COUNT - 1);
+  });
+
+  it('clamps t outside [0,1] to the end pages', () => {
+    expect(activePageFor(-0.5)).toBe(0);
+    expect(activePageFor(1.5)).toBe(PAGE_COUNT - 1);
+  });
+
+  it('transitions to page i exactly at and above each boundary i/PAGE_COUNT', () => {
+    const eps = 1e-9;
+    for (let i = 1; i < PAGE_COUNT; i++) {
+      const b = i / PAGE_COUNT;
+      expect(activePageFor(b - eps)).toBe(i - 1);
+      expect(activePageFor(b)).toBe(i);
+      expect(activePageFor(b + eps)).toBe(i);
+    }
+  });
+
+  it('never returns an out-of-range page index', () => {
+    for (const t of [0, 0.2, 0.5, 0.999, 1, 2]) {
+      const page = activePageFor(t);
+      expect(page).toBeGreaterThanOrEqual(0);
+      expect(page).toBeLessThan(PAGE_COUNT);
+    }
+  });
+});

--- a/apps/landing/src/engine/pages.ts
+++ b/apps/landing/src/engine/pages.ts
@@ -1,0 +1,74 @@
+// The 9-page p-space registry (webgl-standards "The 9-page p-space model").
+// Everything scroll-driven is a pure function of the global t in [0,1]. Page i
+// is active when t is in [i/9, (i+1)/9]. Within a page, p in [0,1] maps that
+// slice; p in [0, EXIT_START] plays the page and p in [EXIT_START, 1] scrubs
+// its exit (a Rip for pages 1-7, the hinge for page 0, the signature for page
+// 8). pageProgress is pure math -- exported for the shader chunk and unit tests.
+
+export const PAGE_COUNT = 9;
+
+// Play/exit split: p <= 0.72 plays, p > 0.72 scrubs the exit.
+export const EXIT_START = 0.72;
+
+// Physical page dimensions (world units), shared by the pre-split geometry and
+// the camera framing so the notebook fills the desk view consistently.
+export const PAGE_W = 2.2;
+export const PAGE_H = 3.0;
+
+export type PageExit =
+  | "hinge"
+  | "corner-tear"
+  | "horizontal-rip"
+  | "vertical-tear"
+  | "crumple"
+  | "paper-plane"
+  | "diagonal-tear"
+  | "perforation-zip"
+  | "signature";
+
+export interface PageDef {
+  id: string;
+  exit: PageExit;
+}
+
+// Order is load-bearing: index === page number. Exit styles are recorded now so
+// later milestones plug their exit mesh in by id without renumbering.
+export const PAGES: readonly PageDef[] = [
+  { id: "cover", exit: "hinge" },
+  { id: "slump", exit: "corner-tear" },
+  { id: "descentA", exit: "horizontal-rip" },
+  { id: "descentB", exit: "vertical-tear" },
+  { id: "fried", exit: "crumple" },
+  { id: "areYouSure", exit: "paper-plane" },
+  { id: "features", exit: "diagonal-tear" },
+  { id: "testimonials", exit: "perforation-zip" },
+  { id: "godmode", exit: "signature" },
+] as const;
+
+// The one page M1 authors as a real tear mesh: the corner-tear "slump" page.
+export const CORNER_TEAR_PAGE = 1;
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+// Which page owns t. floor(t * 9), clamped so t === 1 stays on the last page.
+export function activePageFor(t: number): number {
+  const i = Math.floor(clamp01(t) * PAGE_COUNT);
+  return i >= PAGE_COUNT ? PAGE_COUNT - 1 : i < 0 ? 0 : i;
+}
+
+export interface PageProgress {
+  // Progress through page i's whole scroll slice, [0,1].
+  p: number;
+  // Progress through page i's exit sub-slice, [0,1] (0 until p passes EXIT_START).
+  exitP: number;
+}
+
+// Map global t to page i's local play/exit progress. Pure and idempotent for a
+// given t -- the scrub-safety contract depends on it.
+export function pageProgress(t: number, i: number): PageProgress {
+  const p = clamp01(t * PAGE_COUNT - i);
+  const exitP = p <= EXIT_START ? 0 : (p - EXIT_START) / (1 - EXIT_START);
+  return { p, exitP };
+}

--- a/apps/landing/src/engine/quality.ts
+++ b/apps/landing/src/engine/quality.ts
@@ -1,0 +1,31 @@
+// Quality tier resolution: a one-shot device probe picked at first client call
+// and cached module-level so every consumer reads one consistent tier for the
+// session. Mirrors gate.ts: no window access at module scope, computed lazily.
+// HIGH is the safe SSR default (returned uncached so the first real client call
+// still probes). Only the boil rate is a hard per-tier constant M1 consumes
+// (uBoil steps at boilHz); dpr is exposed for later tiering but the Canvas
+// itself clamps devicePixelRatio to [1,2] per the M1 brief.
+
+export interface Tier {
+  dpr: number;
+  boilHz: number;
+}
+
+export const TIER_TABLE: { HIGH: Tier; LOW: Tier } = {
+  HIGH: { dpr: 2, boilHz: 10 },
+  LOW: { dpr: 1.25, boilHz: 8 },
+};
+
+let cached: Tier | null = null;
+
+function probe(): Tier {
+  const lowDpr = (window.devicePixelRatio || 1) < 1.5;
+  const fewCores = (navigator.hardwareConcurrency || 1) <= 4;
+  return lowDpr || fewCores ? TIER_TABLE.LOW : TIER_TABLE.HIGH;
+}
+
+export function resolveTier(): Tier {
+  if (typeof window === "undefined") return TIER_TABLE.HIGH;
+  if (cached === null) cached = probe();
+  return cached;
+}

--- a/apps/landing/src/engine/scroll.ts
+++ b/apps/landing/src/engine/scroll.ts
@@ -1,0 +1,104 @@
+// The scroll spine. Lenis owns document scroll; the prerendered semantic layer
+// supplies the height (its sections are visibility:hidden, never display:none,
+// so layout height survives -- and .gl-paced stretches each to a generous,
+// evenly paced min-height for the 9-page t-space). GSAP's ticker drives Lenis
+// (lagSmoothing off so scrub stays frame-locked), and every Lenis scroll forces
+// ScrollTrigger.update so the two clocks never drift.
+//
+// A SINGLE ScrollTrigger (scrub:true) scrubs ONE master timeline of duration 9.
+// The timeline is the only GSAP -> GL bridge: per-page it tweens channels[i].p
+// across that page's whole slice and channels[i].exitP across its exit
+// sub-slice, with ABSOLUTE fromTo tweens (ease none) and never += / -=, so
+// scrubbing back down fully reverses every page. The ScrollTrigger onUpdate
+// writes the global t / velocity / active-page index into the zustand store.
+//
+// initScroll() is call-once from a client effect and returns its own teardown.
+// Nothing touches window at module scope (SSR-safe); the whole graph is built
+// inside initScroll, which only ever runs client-side.
+
+import gsap from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import Lenis from "lenis";
+
+import { channels } from "./channels";
+import { activePageFor, EXIT_START } from "./pages";
+import { setScroll } from "./store";
+
+export function initScroll(): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  gsap.registerPlugin(ScrollTrigger);
+
+  // Stretch the (hidden) semantic sections so scroll height paces the 9 pages.
+  const root = document.getElementById("semantic-root");
+  root?.classList.add("gl-paced");
+
+  const lenis = new Lenis();
+
+  // GSAP ticker drives Lenis; lagSmoothing off keeps scrub deterministic.
+  const raf = (time: number) => lenis.raf(time * 1000);
+  gsap.ticker.add(raf);
+  gsap.ticker.lagSmoothing(0);
+
+  lenis.on("scroll", ScrollTrigger.update);
+
+  // The master timeline: page i occupies timeline time [i, i+1]. p ramps across
+  // the whole unit; exitP ramps only across [i + EXIT_START, i + 1]. paused so
+  // it never auto-plays -- ScrollTrigger drives its playhead from scroll.
+  const master = gsap.timeline({ paused: true });
+  let i = 0;
+  for (const ch of channels) {
+    master.fromTo(ch, { p: 0 }, { p: 1, duration: 1, ease: "none" }, i);
+    master.fromTo(
+      ch,
+      { exitP: 0 },
+      { exitP: 1, duration: 1 - EXIT_START, ease: "none" },
+      i + EXIT_START,
+    );
+    i += 1;
+  }
+
+  const st = ScrollTrigger.create({
+    trigger: document.body,
+    start: 0,
+    end: "max",
+    scrub: true,
+    animation: master,
+    onUpdate: (self) => {
+      const t = self.progress;
+      setScroll(t, lenis.velocity, activePageFor(t));
+    },
+  });
+
+  // Height is only correct once webfonts have laid out; refresh again on resize.
+  document.fonts.ready.then(() => ScrollTrigger.refresh());
+
+  let resizeTimer: ReturnType<typeof setTimeout> | undefined;
+  const onResize = () => {
+    if (resizeTimer !== undefined) clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => ScrollTrigger.refresh(), 150);
+  };
+  window.addEventListener("resize", onResize);
+
+  // Debug ride: ?t=0.42 jumps straight to that progress once layout is settled.
+  const param = new URLSearchParams(window.location.search).get("t");
+  if (param !== null) {
+    const target = Number(param);
+    if (Number.isFinite(target)) {
+      const clamped = Math.min(1, Math.max(0, target));
+      ScrollTrigger.refresh();
+      lenis.scrollTo(st.end * clamped, { immediate: true });
+    }
+  }
+
+  return () => {
+    window.removeEventListener("resize", onResize);
+    if (resizeTimer !== undefined) clearTimeout(resizeTimer);
+    lenis.off("scroll", ScrollTrigger.update);
+    gsap.ticker.remove(raf);
+    st.kill();
+    master.kill();
+    lenis.destroy();
+    root?.classList.remove("gl-paced");
+  };
+}

--- a/apps/landing/src/engine/scroll.ts
+++ b/apps/landing/src/engine/scroll.ts
@@ -13,8 +13,10 @@
 // writes the global t / velocity / active-page index into the zustand store.
 //
 // initScroll() is call-once from a client effect and returns its own teardown.
-// Nothing touches window at module scope (SSR-safe); the whole graph is built
-// inside initScroll, which only ever runs client-side.
+// The teardown is idempotent and also runs if setup throws mid-init (so the
+// pacing class / listeners / ticker hook can't leak into the legacy fallback),
+// and it restores the SHARED GSAP ticker's default lagSmoothing that init turned
+// off. Nothing touches window at module scope (SSR-safe).
 
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
@@ -29,76 +31,103 @@ export function initScroll(): () => void {
 
   gsap.registerPlugin(ScrollTrigger);
 
-  // Stretch the (hidden) semantic sections so scroll height paces the 9 pages.
   const root = document.getElementById("semantic-root");
-  root?.classList.add("gl-paced");
 
-  const lenis = new Lenis();
-
-  // GSAP ticker drives Lenis; lagSmoothing off keeps scrub deterministic.
-  const raf = (time: number) => lenis.raf(time * 1000);
-  gsap.ticker.add(raf);
-  gsap.ticker.lagSmoothing(0);
-
-  lenis.on("scroll", ScrollTrigger.update);
-
-  // The master timeline: page i occupies timeline time [i, i+1]. p ramps across
-  // the whole unit; exitP ramps only across [i + EXIT_START, i + 1]. paused so
-  // it never auto-plays -- ScrollTrigger drives its playhead from scroll.
-  const master = gsap.timeline({ paused: true });
-  let i = 0;
-  for (const ch of channels) {
-    master.fromTo(ch, { p: 0 }, { p: 1, duration: 1, ease: "none" }, i);
-    master.fromTo(
-      ch,
-      { exitP: 0 },
-      { exitP: 1, duration: 1 - EXIT_START, ease: "none" },
-      i + EXIT_START,
-    );
-    i += 1;
-  }
-
-  const st = ScrollTrigger.create({
-    trigger: document.body,
-    start: 0,
-    end: "max",
-    scrub: true,
-    animation: master,
-    onUpdate: (self) => {
-      const t = self.progress;
-      setScroll(t, lenis.velocity, activePageFor(t));
-    },
-  });
-
-  // Height is only correct once webfonts have laid out; refresh again on resize.
-  document.fonts.ready.then(() => ScrollTrigger.refresh());
-
+  let lenis: Lenis | undefined;
+  let raf: ((time: number) => void) | undefined;
+  let st: ScrollTrigger | undefined;
+  let master: ReturnType<typeof gsap.timeline> | undefined;
+  let onResize: (() => void) | undefined;
   let resizeTimer: ReturnType<typeof setTimeout> | undefined;
-  const onResize = () => {
-    if (resizeTimer !== undefined) clearTimeout(resizeTimer);
-    resizeTimer = setTimeout(() => ScrollTrigger.refresh(), 150);
-  };
-  window.addEventListener("resize", onResize);
 
-  // Debug ride: ?t=0.42 jumps straight to that progress once layout is settled.
-  const param = new URLSearchParams(window.location.search).get("t");
-  if (param !== null) {
-    const target = Number(param);
-    if (Number.isFinite(target)) {
-      const clamped = Math.min(1, Math.max(0, target));
-      ScrollTrigger.refresh();
-      lenis.scrollTo(st.end * clamped, { immediate: true });
-    }
-  }
-
-  return () => {
-    window.removeEventListener("resize", onResize);
+  // Idempotent teardown: undoes every side effect and restores the shared GSAP
+  // ticker's DEFAULT lagSmoothing (500, 33) that init disabled globally. Runs
+  // both as the returned cleanup and from the init catch below.
+  let torn = false;
+  const teardown = () => {
+    if (torn) return;
+    torn = true;
+    if (onResize) window.removeEventListener("resize", onResize);
     if (resizeTimer !== undefined) clearTimeout(resizeTimer);
-    lenis.off("scroll", ScrollTrigger.update);
-    gsap.ticker.remove(raf);
-    st.kill();
-    master.kill();
-    lenis.destroy();
+    lenis?.off("scroll", ScrollTrigger.update);
+    if (raf) gsap.ticker.remove(raf);
+    gsap.ticker.lagSmoothing(500, 33);
+    st?.kill();
+    master?.kill();
+    lenis?.destroy();
     root?.classList.remove("gl-paced");
   };
+
+  try {
+    // Stretch the (hidden) semantic sections so scroll height paces the 9 pages.
+    root?.classList.add("gl-paced");
+
+    const l = new Lenis();
+    lenis = l;
+
+    // GSAP ticker drives Lenis; lagSmoothing off keeps scrub deterministic
+    // (restored to the default in teardown -- the ticker is global).
+    const r = (time: number) => l.raf(time * 1000);
+    raf = r;
+    gsap.ticker.add(r);
+    gsap.ticker.lagSmoothing(0);
+
+    l.on("scroll", ScrollTrigger.update);
+
+    // The master timeline: page i occupies timeline time [i, i+1]. p ramps across
+    // the whole unit; exitP ramps only across [i + EXIT_START, i + 1]. paused so
+    // it never auto-plays -- ScrollTrigger drives its playhead from scroll.
+    const tl = gsap.timeline({ paused: true });
+    master = tl;
+    let i = 0;
+    for (const ch of channels) {
+      tl.fromTo(ch, { p: 0 }, { p: 1, duration: 1, ease: "none" }, i);
+      tl.fromTo(
+        ch,
+        { exitP: 0 },
+        { exitP: 1, duration: 1 - EXIT_START, ease: "none" },
+        i + EXIT_START,
+      );
+      i += 1;
+    }
+
+    const trigger = ScrollTrigger.create({
+      trigger: document.body,
+      start: 0,
+      end: "max",
+      scrub: true,
+      animation: tl,
+      onUpdate: (self) => {
+        const t = self.progress;
+        setScroll(t, l.velocity, activePageFor(t));
+      },
+    });
+    st = trigger;
+
+    // Height is only correct once webfonts have laid out; refresh again on resize.
+    document.fonts.ready.then(() => ScrollTrigger.refresh());
+
+    const handleResize = () => {
+      if (resizeTimer !== undefined) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => ScrollTrigger.refresh(), 150);
+    };
+    onResize = handleResize;
+    window.addEventListener("resize", handleResize);
+
+    // Debug ride: ?t=0.42 jumps straight to that progress once layout is settled.
+    const param = new URLSearchParams(window.location.search).get("t");
+    if (param !== null) {
+      const target = Number(param);
+      if (Number.isFinite(target)) {
+        const clamped = Math.min(1, Math.max(0, target));
+        ScrollTrigger.refresh();
+        l.scrollTo(trigger.end * clamped, { immediate: true });
+      }
+    }
+  } catch (err) {
+    teardown();
+    throw err;
+  }
+
+  return teardown;
 }

--- a/apps/landing/src/engine/stats.ts
+++ b/apps/landing/src/engine/stats.ts
@@ -1,0 +1,6 @@
+// Dev-HUD telemetry bridge. The composer (which owns the renderer) writes the
+// last frame's draw-call count here after composer.render(); the dev HUD reads
+// it. A single shared mutable object, updated in place -- no per-frame
+// allocation, and a no-op cost in production where the HUD never mounts.
+
+export const hudStats = { calls: 0 };

--- a/apps/landing/src/engine/store.ts
+++ b/apps/landing/src/engine/store.ts
@@ -1,0 +1,28 @@
+// RIPBOOK scroll state: the single vanilla zustand store the whole GL engine
+// reads per-frame. scroll.ts is the ONLY writer (via ScrollTrigger.onUpdate);
+// every consumer (composer, page transforms, HUD) reads ripbookStore.getState()
+// inside its useFrame -- never a React selector in a hot path, which would
+// re-render the tree on every scroll tick. Three fields only: t (global scroll
+// progress in [0,1], the t-space authority), vel (Lenis scroll velocity), and
+// activePage (the 0..8 page index t currently sits in).
+
+import { createStore } from "zustand/vanilla";
+
+export interface RipbookState {
+  t: number;
+  vel: number;
+  activePage: number;
+}
+
+export const ripbookStore = createStore<RipbookState>(() => ({
+  t: 0,
+  vel: 0,
+  activePage: 0,
+}));
+
+// Single scroll-write setter. Called only from scroll.ts's ScrollTrigger
+// onUpdate (a scroll event, not the render loop), so the small partial-object
+// churn here never touches the per-frame path.
+export function setScroll(t: number, vel: number, activePage: number): void {
+  ripbookStore.setState({ t, vel, activePage });
+}

--- a/apps/landing/src/engine/uniforms.ts
+++ b/apps/landing/src/engine/uniforms.ts
@@ -1,0 +1,17 @@
+// Singleton uniform objects, shared by reference across every material that
+// needs them. The SINGLE writer is the composer's priority-1 useFrame -- nothing
+// else mutates these. Sharing one object per uniform means a material added
+// later (the rip vertex shader, ink, crease passes) picks up the same live value
+// with zero wiring. Kept as plain { value } holders so they drop straight into a
+// three uniform slot.
+//
+//  uBoil       stepped hand-drawn boil clock: floor(elapsed * boilHz) / boilHz.
+//  uRipP       Float32Array(9) -- per-page rip/exit progress, uRipP[i] mirrors
+//              channels[i].exitP; the rip vertex shader reads uRipP[pageIndex].
+//  uResolution drawing-buffer size, refreshed on resize.
+
+import { Vector2 } from "three";
+
+export const uBoil = { value: 0 };
+export const uRipP = { value: new Float32Array(9) };
+export const uResolution = { value: new Vector2(1, 1) };

--- a/apps/landing/src/engine/uniforms.ts
+++ b/apps/landing/src/engine/uniforms.ts
@@ -6,8 +6,12 @@
 // three uniform slot.
 //
 //  uBoil       stepped hand-drawn boil clock: floor(elapsed * boilHz) / boilHz.
-//  uRipP       Float32Array(9) -- per-page rip/exit progress, uRipP[i] mirrors
-//              channels[i].exitP; the rip vertex shader reads uRipP[pageIndex].
+//  uRipP       Float32Array(9) -- per-page tear-front drive; uRipP[i] is the
+//              PHASED tearP = smoothstep(0, 0.62, channels[i].exitP), NOT raw
+//              exitP -- so the seam fully separates before the free piece is
+//              thrown. Still a pure curve of the page's EXIT window (p in
+//              [0.72,1] per ADR 0015), not its play window. Shader reads
+//              uRipP[pageIndex]; the single writer is the composer.
 //  uResolution drawing-buffer size, refreshed on resize.
 
 import { Vector2 } from "three";

--- a/apps/landing/src/experience/Composer.tsx
+++ b/apps/landing/src/experience/Composer.tsx
@@ -33,8 +33,8 @@ export const CAMERA = { x: 0, y: 2.5, z: 5.4, fov: 35 } as const;
 const PARALLAX = 0.16;
 const CAM_DAMP = 4;
 
-// Rigid ballistic throw of the free corner piece, f(exitP). exitP 0 -> identity
-// (piece at rest on the seam); exitP 1 -> tossed up-right toward camera with a
+// Rigid ballistic throw of the free corner piece, f(throwP). throwP 0 -> identity
+// (piece at rest on the seam); throwP 1 -> tossed up-right toward camera with a
 // tumble. y is a parabola (rise then fall) for a ballistic arc.
 const THROW = {
   x: 1.3,
@@ -45,6 +45,16 @@ const THROW = {
   ry: 0.7,
   rz: 1.8,
 } as const;
+
+// Tear/throw phasing (both pure f(exitP), so scrubbing back is exact): the
+// shader tear-front (uRipP -> tearP) fully separates the seam by exitP 0.62
+// BEFORE the piece is meaningfully thrown (throwP starts at 0.5), so the free
+// group never rigid-translates while the seam is still attached. The 0.5-0.62
+// overlap keeps the motion lively.
+function smoothstep(e0: number, e1: number, x: number): number {
+  const t = Math.min(1, Math.max(0, (x - e0) / (e1 - e0)));
+  return t * t * (3 - 2 * t);
+}
 
 export function Composer({ freeRef }: { freeRef: RefObject<Group | null> }) {
   const gl = useThree((s) => s.gl);
@@ -97,27 +107,31 @@ export function Composer({ freeRef }: { freeRef: RefObject<Group | null> }) {
     camera.position.z = CAMERA.z;
     camera.lookAt(0, 0, 0);
 
-    // (2) Free corner piece rigid throw, pure f(exitP).
+    // (2) Free corner piece rigid throw, phased so it only flies once the seam
+    // is (nearly) fully torn. Pure f(exitP) -> reversible.
     const tearCh = channels[CORNER_TEAR_PAGE];
     const exitP = tearCh ? tearCh.exitP : 0;
+    const throwP = smoothstep(0.5, 1, exitP);
     const g = freeRef.current;
     if (g) {
       g.position.set(
-        THROW.x * exitP,
-        THROW.up * exitP - THROW.grav * exitP * exitP,
-        THROW.z * exitP,
+        THROW.x * throwP,
+        THROW.up * throwP - THROW.grav * throwP * throwP,
+        THROW.z * throwP,
       );
-      g.rotation.set(THROW.rx * exitP, THROW.ry * exitP, THROW.rz * exitP);
+      g.rotation.set(THROW.rx * throwP, THROW.ry * throwP, THROW.rz * throwP);
     }
 
     // (3) Stepped boil clock -- single writer.
     uBoil.value = Math.floor(state.clock.elapsedTime * tier.boilHz) / tier.boilHz;
 
-    // (4) Per-page rip progress uploaded for the (later) rip vertex shader.
+    // (4) Per-page tear-front drive for the rip vertex shader: the PHASED tearP
+    // (smoothstep of the page's exit progress), not raw exitP -- so the seam
+    // separates and completes before the throw pulls the piece away.
     const rip = uRipP.value;
     let ri = 0;
     for (const ch of channels) {
-      rip[ri] = ch.exitP;
+      rip[ri] = smoothstep(0, 0.62, ch.exitP);
       ri += 1;
     }
 

--- a/apps/landing/src/experience/Composer.tsx
+++ b/apps/landing/src/experience/Composer.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+// The one and only render driver. Lives inside the R3F <Canvas>. It owns the
+// postprocessing EffectComposer (built once, RenderPass only in M1 -- the DOF /
+// crease / grain passes are shader-engineer's later milestones) and the SOLE
+// priority>0 useFrame in the app: a positive priority hands the render loop to
+// us, so R3F stops auto-rendering and every frame flows through composer.render()
+// here. Per frame it: (1) applies camera micro-parallax (pointer, time-damped --
+// NOT scroll state) around the fixed down-look pose, (2) drives the free corner
+// piece's rigid ballistic throw from channels[CORNER_TEAR_PAGE].exitP (pure
+// f(exitP), so scrubbing back re-seats it), (3) steps uBoil, (4) uploads uRipP,
+// then (5) renders. Reused module scratch + in-place mutation keep it
+// allocation-free.
+
+import { EffectComposer, RenderPass } from "postprocessing";
+import { type RefObject,useEffect, useMemo } from "react";
+import { type Group, MathUtils } from "three";
+import { useFrame, useThree } from "@react-three/fiber";
+
+import { channels } from "@/engine/channels";
+import { CORNER_TEAR_PAGE } from "@/engine/pages";
+import { resolveTier } from "@/engine/quality";
+import { hudStats } from "@/engine/stats";
+import { uBoil, uResolution, uRipP } from "@/engine/uniforms";
+
+// Fixed camera pose: above and in front of the notebook, looking down ~25 deg at
+// the page centred at the origin. Shared with the Canvas so the first frame is
+// already framed. atan(y / z) ~= 25 deg.
+export const CAMERA = { x: 0, y: 2.5, z: 5.4, fov: 35 } as const;
+
+// Pointer micro-parallax: at ~6 units of range, 0.16 world units ~= 1.5 deg of
+// apparent tilt. Damping is frame-rate independent (lambda per second).
+const PARALLAX = 0.16;
+const CAM_DAMP = 4;
+
+// Rigid ballistic throw of the free corner piece, f(exitP). exitP 0 -> identity
+// (piece at rest on the seam); exitP 1 -> tossed up-right toward camera with a
+// tumble. y is a parabola (rise then fall) for a ballistic arc.
+const THROW = {
+  x: 1.3,
+  up: 1.15,
+  grav: 0.85,
+  z: 1.4,
+  rx: -1.1,
+  ry: 0.7,
+  rz: 1.8,
+} as const;
+
+export function Composer({ freeRef }: { freeRef: RefObject<Group | null> }) {
+  const gl = useThree((s) => s.gl);
+  const scene = useThree((s) => s.scene);
+  const camera = useThree((s) => s.camera);
+  const tier = useMemo(() => resolveTier(), []);
+
+  // Build the pipeline once. RenderPass draws the scene straight to screen (M1
+  // has no effect passes yet). autoRenderToScreen stays off with renderToScreen
+  // set explicitly on the last pass -- the durable safety default so a future
+  // pass insertion can never leave the canvas black.
+  const composer = useMemo(() => {
+    const c = new EffectComposer(gl, { multisampling: 4 });
+    const renderPass = new RenderPass(scene, camera);
+    c.addPass(renderPass);
+    c.autoRenderToScreen = false;
+    renderPass.renderToScreen = true;
+    return c;
+  }, [gl, scene, camera]);
+
+  // Keep composer buffers + uResolution matched to the viewport.
+  useEffect(() => {
+    const onResize = () => {
+      composer.setSize(window.innerWidth, window.innerHeight);
+      gl.getDrawingBufferSize(uResolution.value);
+    };
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [composer, gl]);
+
+  // Release GPU resources when the Canvas unmounts.
+  useEffect(() => () => composer.dispose(), [composer]);
+
+  // Warm the page shader programs once, behind the loader, so the first scrub
+  // into the tear has no compile hitch. Fire-and-forget (the material would
+  // compile lazily on first render anyway); swallow rejection so a lost context
+  // never surfaces as a console error.
+  useEffect(() => {
+    void gl.compileAsync(scene, camera).catch(() => {});
+  }, [gl, scene, camera]);
+
+  useFrame((state, delta) => {
+    // (1) Camera micro-parallax around the fixed down-look pose. Time-damped
+    // toward a pointer-driven target; never reads scroll state.
+    const targetX = CAMERA.x + state.pointer.x * PARALLAX;
+    const targetY = CAMERA.y + state.pointer.y * PARALLAX;
+    camera.position.x = MathUtils.damp(camera.position.x, targetX, CAM_DAMP, delta);
+    camera.position.y = MathUtils.damp(camera.position.y, targetY, CAM_DAMP, delta);
+    camera.position.z = CAMERA.z;
+    camera.lookAt(0, 0, 0);
+
+    // (2) Free corner piece rigid throw, pure f(exitP).
+    const tearCh = channels[CORNER_TEAR_PAGE];
+    const exitP = tearCh ? tearCh.exitP : 0;
+    const g = freeRef.current;
+    if (g) {
+      g.position.set(
+        THROW.x * exitP,
+        THROW.up * exitP - THROW.grav * exitP * exitP,
+        THROW.z * exitP,
+      );
+      g.rotation.set(THROW.rx * exitP, THROW.ry * exitP, THROW.rz * exitP);
+    }
+
+    // (3) Stepped boil clock -- single writer.
+    uBoil.value = Math.floor(state.clock.elapsedTime * tier.boilHz) / tier.boilHz;
+
+    // (4) Per-page rip progress uploaded for the (later) rip vertex shader.
+    const rip = uRipP.value;
+    let ri = 0;
+    for (const ch of channels) {
+      rip[ri] = ch.exitP;
+      ri += 1;
+    }
+
+    // (5) Render, then publish the frame's draw-call count for the dev HUD.
+    composer.render(delta);
+    hudStats.calls = gl.info.render.calls;
+  }, 1);
+
+  return null;
+}

--- a/apps/landing/src/experience/RipbookExperience.tsx
+++ b/apps/landing/src/experience/RipbookExperience.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+// The GL takeover root (M1). Mounts the full-canvas R3F <Canvas> that carries
+// the RIPBOOK notebook on a dark desk: one pre-split kraft page (PageMesh), the
+// composer that owns the sole render loop + camera + uniforms, and the scroll
+// spine (initScroll) that pumps the global t / channels. LoaderLift clears the
+// boot overlay on the first painted GL frame and reports onReady; GLLoader then
+// hides the semantic layer. The dev HUD is a DOM sibling (never over hit
+// targets, pointer-events:none). The canvas is pointer-events:none for M1 --
+// there are no GL-side hit targets yet.
+
+import { useEffect, useRef } from "react";
+import type { Group } from "three";
+import { Canvas, useFrame } from "@react-three/fiber";
+
+import PageMesh from "@/book/PageMesh";
+import Hud from "@/debug/Hud";
+import { initScroll } from "@/engine/scroll";
+
+import { CAMERA, Composer } from "./Composer";
+
+// One-shot boot-overlay lift + ready signal. Runs at priority 2 -- after
+// Composer's priority-1 composer.render() -- so #loader only fades, and onReady
+// only fires, once GL has actually painted its first frame (no flash of empty
+// canvas). In GL mode the legacy engine (which normally clears the loader) stood
+// down at the gate, so this is the only thing that lifts it. Guarded by a ref so
+// the per-frame DOM lookup runs once. If #loader is missing, still fire onReady
+// or the semantic root would never hide.
+function LoaderLift({ onReady }: { onReady: () => void }) {
+  const done = useRef(false);
+  useFrame(() => {
+    if (done.current) return;
+    document.getElementById("loader")?.classList.add("gone");
+    done.current = true;
+    onReady();
+  }, 2);
+  return null;
+}
+
+export default function RipbookExperience({ onReady }: { onReady: () => void }) {
+  const freeRef = useRef<Group>(null);
+
+  // Scroll spine: mounted once, client-only. initScroll returns its own cleanup
+  // (kills the ScrollTrigger + master timeline, destroys Lenis, detaches the
+  // ticker/listeners), so a StrictMode double-mount tears the first graph down
+  // cleanly.
+  useEffect(() => initScroll(), []);
+
+  return (
+    <>
+      <Canvas
+        frameloop="always"
+        dpr={[1, 2]}
+        gl={{ antialias: true }}
+        camera={{
+          position: [CAMERA.x, CAMERA.y, CAMERA.z],
+          fov: CAMERA.fov,
+          near: 0.1,
+          far: 100,
+        }}
+        style={{
+          position: "fixed",
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          zIndex: 1,
+          pointerEvents: "none",
+        }}
+      >
+        {/* Dark kraft desk. */}
+        <color attach="background" args={["#141013"]} />
+        <Composer freeRef={freeRef} />
+        <PageMesh freeRef={freeRef} />
+        <LoaderLift onReady={onReady} />
+      </Canvas>
+      <Hud />
+    </>
+  );
+}

--- a/apps/landing/src/materials/RipPaperMaterial.ts
+++ b/apps/landing/src/materials/RipPaperMaterial.ts
@@ -1,0 +1,211 @@
+// The M1 rip-paper material: ONE ShaderMaterial program used for BOTH the held
+// page and the free corner piece, distinguished only by a uSide flag. Everything
+// the vertex shader does is a pure function of the singleton uniforms (uRipP,
+// uBoil) -- no time-accumulated state, no position-buffer writes -- so scrubbing
+// the tear backward fully reassembles the page (at ripP = 0 every displacement
+// term is exactly 0, so the free edge sits back on the seam gaplessly).
+//
+// The JS-vs-shader split (see .claude/scratch/ripbook-pr1.md): the composer owns
+// the free piece's rigid ballistic THROW (the whole freeRef group), pure
+// f(exitP). This material owns the tear-front SEPARATION GATE (progressive along
+// aSeamArc) plus the near-seam PEEL BEND (cylindrical curl on the free flap, a
+// few-mm lift on the held lip). Both key off the same driver: uRipP[uPageIndex]
+// mirrors channels[i].exitP, so gate + throw stay in lockstep.
+//
+// The fragment is a PLACEHOLDER for M2 (the real kraft bake): flat kraft +
+// cheap 3-octave value-noise fiber tint (screen-stable, no external textures),
+// a brighter raw-pulp lightening within the torn-edge band, and a one-light
+// lambert so the peel curl reads in 3D. Helper functions are ajh_-prefixed to
+// avoid colliding with three's injected symbols.
+//
+// Uniforms (see also engine/uniforms.ts for the shared singletons):
+//   uBoil       float          -- stepped boil clock; seeds the torn-edge jitter.
+//   uRipP       float[9]       -- per-page rip/exit progress (shared singleton).
+//   uPageIndex  int  [0..8]    -- which page this material renders (const per mat).
+//   uSide       float 0|1      -- 0 = held page, 1 = free corner flap.
+
+import { DoubleSide, ShaderMaterial } from "three";
+
+import { CORNER_TEAR_PAGE } from "@/engine/pages";
+import { uBoil, uRipP } from "@/engine/uniforms";
+
+// Side flag values for the one shared program.
+export const RIP_PAPER_SIDE = { HELD: 0, FREE: 1 } as const;
+
+const VERTEX = /* glsl */ `
+  attribute float aSeamDist;
+  attribute float aSeamArc;
+  attribute float aEdgeFlag;
+  attribute float aNoise;
+
+  uniform float uBoil;
+  uniform float uRipP[9];
+  uniform int uPageIndex;
+  uniform float uSide;
+
+  varying vec2 vUv;
+  varying float vSeamDist;
+  varying float vEdge;
+  varying vec3 vWorldN;
+
+  // Placeholder rig tuning (real values land with the M2 paper bake).
+  const float AJH_FRONT_W = 0.15;                 // tear-front softness (arc space)
+  const float AJH_CURL = 2.4;                     // peel curl curvature (1/world)
+  const vec2  AJH_FLAP_DIR = vec2(0.847, 0.531);  // in-plane seam -> free corner
+  const float AJH_LIP_WIDTH = 0.14;               // held-lip lift band (world)
+  const float AJH_LIP_LIFT = 0.03;                // held-lip max lift (~3mm)
+  const float AJH_EDGE_BOIL = 0.006;              // torn-edge jitter (<0.5% page W)
+
+  float ajh_hash11(float n) {
+    return fract(sin(n * 12.9898) * 43758.5453123);
+  }
+
+  // Read this material's page from the shared uRipP array. Indexed by a loop
+  // counter (a constant-index-expression) so it compiles on GLSL ES 1.00 / ANGLE
+  // even though uPageIndex is a runtime uniform.
+  float ajh_ripForPage() {
+    float r = 0.0;
+    for (int k = 0; k < 9; k++) {
+      if (k == uPageIndex) r = uRipP[k];
+    }
+    return r;
+  }
+
+  void main() {
+    float ripP = ajh_ripForPage();
+
+    // Tear-front gate: the front sweeps -w -> 1+w across the seam arc as ripP
+    // goes 0 -> 1. g = 1 where still attached, 0 where the front has passed.
+    float w = AJH_FRONT_W;
+    float front = -w + ripP * (1.0 + 2.0 * w);
+    float g = smoothstep(front - w, front, aSeamArc);
+    float sep = 1.0 - g;
+
+    vec3 pos = position;
+    vec3 nrm = vec3(0.0, 0.0, 1.0);
+
+    if (uSide > 0.5) {
+      // FREE flap: cylindrical peel roll about the seam. Hinges at the seam
+      // (s = 0) and the curl accumulates outward; gated by sep so the corner
+      // peels progressively rather than all at once. Additive displacement
+      // (both terms -> 0 as curvature -> 0), so ripP = 0 is exactly identity.
+      float s = max(0.0, -aSeamDist);
+      float kappa = AJH_CURL * ripP * sep;
+      if (kappa > 1.0e-4) {
+        float ks = kappa * s;
+        float horiz = sin(ks) / kappa - s;      // <= 0, draws the tip back
+        float lift = (1.0 - cos(ks)) / kappa;   // >= 0, lifts toward camera (+z)
+        pos.xy += AJH_FLAP_DIR * horiz;
+        pos.z += lift;
+        nrm = normalize(cos(ks) * vec3(0.0, 0.0, 1.0) - sin(ks) * vec3(AJH_FLAP_DIR, 0.0));
+      }
+    } else {
+      // HELD lip: a few-mm 3D lift on the torn edge, falling off with |aSeamDist|
+      // and gated by the same front so the lip only rises where the tear passed.
+      float prox = 1.0 - smoothstep(0.0, AJH_LIP_WIDTH, abs(aSeamDist));
+      pos.z += AJH_LIP_LIFT * ripP * sep * prox;
+    }
+
+    // Torn-edge boil: tiny in-plane jitter seeded off aNoise + the stepped uBoil,
+    // ramped in with ripP so the edge sits exactly on the seam at rest (the two
+    // pieces' duplicated edge verts only diverge once the tear is under way).
+    if (aEdgeFlag > 0.5) {
+      float amp = AJH_EDGE_BOIL * clamp(ripP * 4.0, 0.0, 1.0);
+      float h1 = ajh_hash11(aNoise * 91.7 + uBoil * 13.3);
+      float h2 = ajh_hash11(aNoise * 47.3 + uBoil * 7.1 + 5.0);
+      pos.xy += (vec2(h1, h2) - 0.5) * amp;
+    }
+
+    vUv = uv;
+    vSeamDist = aSeamDist;
+    vEdge = aEdgeFlag;
+    vWorldN = normalize(mat3(modelMatrix) * nrm);
+
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+  }
+`;
+
+const FRAGMENT = /* glsl */ `
+  varying vec2 vUv;
+  varying float vSeamDist;
+  varying float vEdge;
+  varying vec3 vWorldN;
+
+  // Authored in LINEAR space -- there is no texture sample to sRGB-decode here,
+  // and the composer encodes the final output to sRGB, so these are the linear
+  // conversions of the placeholder kraft / raw-pulp tones.
+  const vec3  AJH_KRAFT = vec3(0.565, 0.413, 0.220);  // ~#c6ac81
+  const vec3  AJH_RAW   = vec3(0.720, 0.550, 0.320);  // brighter torn-edge pulp
+  const vec3  AJH_LIGHT = vec3(-0.333, 0.667, 0.667); // world light dir (upper-front)
+  const float AJH_AMBIENT = 0.55;
+  const float AJH_FIBER = 0.13;   // fine-fiber tint depth
+  const float AJH_BLOTCH = 0.10;  // coarse tone variation depth
+
+  float ajh_hash21(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+  }
+
+  float ajh_vnoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    float a = ajh_hash21(i);
+    float b = ajh_hash21(i + vec2(1.0, 0.0));
+    float c = ajh_hash21(i + vec2(0.0, 1.0));
+    float d = ajh_hash21(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+  }
+
+  float ajh_fbm(vec2 p) {
+    float sum = 0.0;
+    float amp = 0.5;
+    for (int o = 0; o < 3; o++) {
+      sum += amp * ajh_vnoise(p);
+      p *= 2.0;
+      amp *= 0.5;
+    }
+    return sum;
+  }
+
+  void main() {
+    // Screen-stable fiber tint from object UVs (fixed per surface point, so it
+    // does not swim as the camera or the flap moves).
+    float fiber = ajh_fbm(vUv * 80.0) - 0.5;
+    float blotch = ajh_fbm(vUv * 4.0) - 0.5;
+    vec3 col = AJH_KRAFT * (1.0 + fiber * AJH_FIBER + blotch * AJH_BLOTCH);
+
+    // Brighter raw pulp within the torn-edge band (seam-distance falloff, pinned
+    // bright on the actual snapped edge verts via vEdge).
+    float edge = 1.0 - smoothstep(0.0, 0.04, abs(vSeamDist));
+    edge = max(edge, vEdge);
+    col = mix(col, AJH_RAW, edge * 0.6);
+
+    // One-light lambert so the peel curl reads; double-sided, so flip on back.
+    vec3 nrm = normalize(vWorldN);
+    if (!gl_FrontFacing) nrm = -nrm;
+    float lam = clamp(dot(nrm, normalize(AJH_LIGHT)), 0.0, 1.0);
+    col *= AJH_AMBIENT + (1.0 - AJH_AMBIENT) * lam;
+
+    gl_FragColor = vec4(col, 1.0);
+  }
+`;
+
+// One program, two instances (held + free) sharing the singleton uniform objects
+// BY REFERENCE -- the composer's single writer updates both for free. uPageIndex
+// and uSide are per-material constants set at creation.
+export function createRipPaperMaterial(side: number): ShaderMaterial {
+  return new ShaderMaterial({
+    name: "RipPaperMaterial",
+    side: DoubleSide,
+    uniforms: {
+      uBoil,
+      uRipP,
+      uPageIndex: { value: CORNER_TEAR_PAGE },
+      uSide: { value: side },
+    },
+    vertexShader: VERTEX,
+    fragmentShader: FRAGMENT,
+  });
+}

--- a/apps/landing/src/rip/presplit.test.ts
+++ b/apps/landing/src/rip/presplit.test.ts
@@ -1,0 +1,213 @@
+import type { BufferGeometry } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_CORNER_TEAR, presplitCornerTear } from './presplit';
+
+// Grid resolution is a fixed contract of the builder (96 x 128 segments, 2
+// triangles per cell). Kept in sync with COLS/ROWS in presplit.ts.
+const GRID_TRIANGLES = 96 * 128 * 2;
+
+const ATTR_NAMES = [
+  'position',
+  'normal',
+  'uv',
+  'aSeamDist',
+  'aSeamArc',
+  'aEdgeFlag',
+  'aNoise',
+] as const;
+
+function defined<T>(value: T | null | undefined, what: string): T {
+  if (value === null || value === undefined) throw new Error(`missing ${what}`);
+  return value;
+}
+
+function attr(geo: BufferGeometry, name: string) {
+  return defined(geo.getAttribute(name), name);
+}
+
+function indexArray(geo: BufferGeometry): ArrayLike<number> {
+  return defined(geo.getIndex(), 'index').array;
+}
+
+// -1 = identical, -2 = length mismatch, else the first differing element index.
+function firstDiff(a: ArrayLike<number>, b: ArrayLike<number>): number {
+  if (a.length !== b.length) return -2;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return i;
+  }
+  return -1;
+}
+
+function edgePoints(geo: BufferGeometry): Array<[number, number, number]> {
+  const flag = attr(geo, 'aEdgeFlag');
+  const pos = attr(geo, 'position');
+  const out: Array<[number, number, number]> = [];
+  for (let i = 0; i < flag.count; i++) {
+    if (flag.getX(i) === 1) {
+      const p: [number, number, number] = [pos.getX(i), pos.getY(i), pos.getZ(i)];
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function triangleCount(geo: BufferGeometry): number {
+  return defined(geo.getIndex(), 'index').count / 3;
+}
+
+// Smallest triangle area across the whole piece (0 => a degenerate triangle).
+// Positions are planar (z=0), so the 2D shoelace magnitude is the area.
+function minTriangleArea(geo: BufferGeometry): number {
+  const idx = defined(geo.getIndex(), 'index');
+  const pos = attr(geo, 'position');
+  let min = Infinity;
+  for (let t = 0; t + 2 < idx.count; t += 3) {
+    const a = idx.getX(t);
+    const b = idx.getX(t + 1);
+    const c = idx.getX(t + 2);
+    const ax = pos.getX(a);
+    const ay = pos.getY(a);
+    const abx = pos.getX(b) - ax;
+    const aby = pos.getY(b) - ay;
+    const acx = pos.getX(c) - ax;
+    const acy = pos.getY(c) - ay;
+    const area = Math.abs(abx * acy - acx * aby) / 2;
+    if (area < min) min = area;
+  }
+  return min;
+}
+
+function attrRange(geo: BufferGeometry, name: string): { min: number; max: number } {
+  const a = attr(geo, name);
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < a.count; i++) {
+    const v = a.getX(i);
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  return { min, max };
+}
+
+describe('presplitCornerTear', () => {
+  describe('determinism', () => {
+    it('produces byte-identical geometry for the same seed', () => {
+      const a = presplitCornerTear(7);
+      const b = presplitCornerTear(7);
+      for (const name of ATTR_NAMES) {
+        expect(firstDiff(attr(a.held, name).array, attr(b.held, name).array)).toBe(-1);
+        expect(firstDiff(attr(a.free, name).array, attr(b.free, name).array)).toBe(-1);
+      }
+      expect(firstDiff(indexArray(a.held), indexArray(b.held))).toBe(-1);
+      expect(firstDiff(indexArray(a.free), indexArray(b.free))).toBe(-1);
+    });
+
+    it('produces different geometry for a different seed (seed is actually used)', () => {
+      const a = presplitCornerTear(7);
+      const c = presplitCornerTear(99);
+      // At least one of the seam-driven arrays must differ.
+      const posDiff = firstDiff(attr(a.held, 'position').array, attr(c.held, 'position').array);
+      expect(posDiff).not.toBe(-1);
+    });
+  });
+
+  describe('watertightness', () => {
+    it('every held torn-edge vertex has a positionally-identical free partner', () => {
+      const split = presplitCornerTear(1);
+      const held = edgePoints(split.held);
+      const free = edgePoints(split.free);
+
+      expect(held.length).toBeGreaterThan(0);
+      // Both pieces duplicate the same snapped seam vertices.
+      expect(held.length).toBe(free.length);
+
+      const eps = 1e-5;
+      for (const h of held) {
+        const matched = free.some(
+          (f) => Math.hypot(f[0] - h[0], f[1] - h[1], f[2] - h[2]) <= eps,
+        );
+        expect(matched).toBe(true);
+      }
+    });
+  });
+
+  describe('completeness', () => {
+    it('held + free triangles account for the whole grid', () => {
+      const split = presplitCornerTear(1);
+      const held = triangleCount(split.held);
+      const free = triangleCount(split.free);
+      expect(held).toBeGreaterThan(0);
+      expect(free).toBeGreaterThan(0);
+      expect(held + free).toBe(GRID_TRIANGLES);
+    });
+
+    it('contains no degenerate (zero-area) triangles', () => {
+      const split = presplitCornerTear(1);
+      expect(minTriangleArea(split.held)).toBeGreaterThan(1e-9);
+      expect(minTriangleArea(split.free)).toBeGreaterThan(1e-9);
+    });
+  });
+
+  describe('non-default style', () => {
+    it('splits watertight for a straight-chord (jag=0) style and differs from default', () => {
+      const style = { ...DEFAULT_CORNER_TEAR, jag: 0 };
+      const split = presplitCornerTear(1, style);
+
+      // Still watertight: every torn-edge held vertex has a free partner.
+      const held = edgePoints(split.held);
+      const free = edgePoints(split.free);
+      expect(held.length).toBeGreaterThan(0);
+      expect(held.length).toBe(free.length);
+      const eps = 1e-5;
+      for (const h of held) {
+        const matched = free.some(
+          (f) => Math.hypot(f[0] - h[0], f[1] - h[1], f[2] - h[2]) <= eps,
+        );
+        expect(matched).toBe(true);
+      }
+
+      // Still complete: every grid triangle assigned to exactly one piece.
+      expect(triangleCount(split.held) + triangleCount(split.free)).toBe(GRID_TRIANGLES);
+
+      // A different style yields a different seam -> different geometry.
+      const dflt = presplitCornerTear(1);
+      expect(
+        firstDiff(attr(split.held, 'position').array, attr(dflt.held, 'position').array),
+      ).not.toBe(-1);
+    });
+  });
+
+  describe('attribute sanity', () => {
+    it('aSeamArc stays within [0,1] on both pieces', () => {
+      const split = presplitCornerTear(1);
+      for (const geo of [split.held, split.free]) {
+        const { min, max } = attrRange(geo, 'aSeamArc');
+        expect(min).toBeGreaterThanOrEqual(-1e-6);
+        expect(max).toBeLessThanOrEqual(1 + 1e-6);
+      }
+    });
+
+    it('aNoise stays within [0,1)', () => {
+      const split = presplitCornerTear(1);
+      for (const geo of [split.held, split.free]) {
+        const { min, max } = attrRange(geo, 'aNoise');
+        expect(min).toBeGreaterThanOrEqual(0);
+        expect(max).toBeLessThan(1);
+      }
+    });
+
+    it('aSeamDist sign matches the piece: held >= 0, free <= 0', () => {
+      const split = presplitCornerTear(1);
+      const held = attrRange(split.held, 'aSeamDist');
+      const free = attrRange(split.free, 'aSeamDist');
+      // Held vertices sit on the positive (kept) side; free on the negative side;
+      // snapped seam vertices are ~0. Allow a tiny epsilon for float noise.
+      expect(held.min).toBeGreaterThanOrEqual(-1e-6);
+      expect(free.max).toBeLessThanOrEqual(1e-6);
+      // Each piece actually carries seam distance (not collapsed to all zeros).
+      expect(held.max).toBeGreaterThan(0);
+      expect(free.min).toBeLessThan(0);
+    });
+  });
+});

--- a/apps/landing/src/rip/presplit.ts
+++ b/apps/landing/src/rip/presplit.ts
@@ -1,0 +1,386 @@
+// Row-snap corner-tear pre-split. Runs ONCE at load (never per frame): it takes
+// a dense grid plane and splits it into two watertight BufferGeometries -- the
+// HELD page and the FREE corner piece -- that share a torn seam. A seeded fbm
+// polyline seam arcs across the top-right corner; every grid cell is classified
+// held or free by its centre; the vertices straddling that boundary are snapped
+// exactly onto the seam and duplicated (held keeps the originals, free gets its
+// own copies at the same positions), so at rest the two pieces meet with no gap
+// and no T-junction. The rip vertex shader (shader-engineer's pass) then reads
+// the per-vertex attributes below to gate the tear front and bend the peel; JS
+// throws the free piece as a rigid body. Everything here is a pure function of
+// (seed, style) -- deterministic, so tests and shaders can rely on it.
+//
+// Per-vertex attributes written on both pieces:
+//   aSeamDist  signed distance to the seam curve. + on the held side, - on the
+//              free side, ~0 on the snapped seam vertices. The peel bend weights
+//              by |aSeamDist| (bend concentrates near the seam).
+//   aSeamArc   0..1 arc position of the nearest seam point -- the tear front
+//              sweeps along this as the rip progresses.
+//   aEdgeFlag  1 on the snapped seam (torn-edge) vertices, else 0.
+//   aNoise     stable per-vertex hash seed for ink/edge jitter.
+
+import {
+  BufferGeometry,
+  Float32BufferAttribute,
+  Uint32BufferAttribute,
+} from "three";
+
+import { PAGE_H, PAGE_W } from "@/engine/pages";
+
+// Grid resolution: 96 x 128 segments -> 97 x 129 vertices.
+const COLS = 96;
+const ROWS = 128;
+
+// Bounds-safe read. Every index in this builder is structurally in range (grid
+// indices), so the fallback never fires; it just satisfies
+// noUncheckedIndexedAccess without scattering non-null assertions.
+function at(a: ArrayLike<number>, i: number): number {
+  const v = a[i];
+  return v === undefined ? 0 : v;
+}
+
+export interface CornerTearStyle {
+  // Where the seam meets the top edge, as a fraction of width in from the
+  // top-right corner (0 = at the corner, larger = a wider corner piece).
+  topFrac: number;
+  // Where the seam meets the right edge, as a fraction of height down from the
+  // top-right corner.
+  rightFrac: number;
+  // Ragged-edge amplitude (fraction of the shorter page dimension).
+  jag: number;
+  // fbm frequency along the seam (higher = finer raggedness).
+  jagFreq: number;
+  // How far the seam bulges toward the corner (0 = straight chord, 1 = through
+  // the corner). Gives the tear a natural arc.
+  bulge: number;
+}
+
+export const DEFAULT_CORNER_TEAR: CornerTearStyle = {
+  topFrac: 0.3,
+  rightFrac: 0.35,
+  jag: 0.02,
+  jagFreq: 9,
+  bulge: 0.45,
+};
+
+export interface SeamDescriptor {
+  // Flat [x0,y0, x1,y1, ...] seam polyline, top-edge start to right-edge end.
+  points: Float32Array;
+  // Cumulative arc length at each sample (points.length / 2 entries).
+  arc: Float32Array;
+  length: number;
+  start: [number, number];
+  end: [number, number];
+}
+
+export interface PreSplit {
+  held: BufferGeometry;
+  free: BufferGeometry;
+  seam: SeamDescriptor;
+}
+
+// Deterministic hash in [0,1) from an integer.
+function hash1(n: number): number {
+  const s = Math.sin(n * 127.1 + 311.7) * 43758.5453123;
+  return s - Math.floor(s);
+}
+
+// Value-noise fbm along a 1D parameter, seeded.
+function fbm(x: number, seed: number): number {
+  let sum = 0;
+  let amp = 0.5;
+  let freq = 1;
+  for (let o = 0; o < 4; o++) {
+    const xf = x * freq + seed * 17.13;
+    const i = Math.floor(xf);
+    const f = xf - i;
+    const u = f * f * (3 - 2 * f);
+    const a = hash1(i + seed * 57);
+    const b = hash1(i + 1 + seed * 57);
+    sum += (a + (b - a) * u - 0.5) * 2 * amp;
+    amp *= 0.5;
+    freq *= 2;
+  }
+  return sum;
+}
+
+const SEAM_SAMPLES = 160;
+
+// Build the seam polyline: a quadratic-Bezier arc from the top edge to the right
+// edge, pulled toward the corner, plus fbm jag along its normal.
+function buildSeam(style: CornerTearStyle, seed: number): SeamDescriptor {
+  const halfW = PAGE_W / 2;
+  const halfH = PAGE_H / 2;
+  const start: [number, number] = [halfW - style.topFrac * PAGE_W, halfH];
+  const end: [number, number] = [halfW, halfH - style.rightFrac * PAGE_H];
+  const corner: [number, number] = [halfW, halfH];
+  // Control point: chord midpoint pulled toward the corner by `bulge`.
+  const midX = (start[0] + end[0]) / 2;
+  const midY = (start[1] + end[1]) / 2;
+  const cx = midX + (corner[0] - midX) * style.bulge;
+  const cy = midY + (corner[1] - midY) * style.bulge;
+
+  const jagAmp = style.jag * Math.min(PAGE_W, PAGE_H);
+  const n = SEAM_SAMPLES;
+  const points = new Float32Array(n * 2);
+  const arc = new Float32Array(n);
+
+  // First pass: base Bezier points.
+  for (let k = 0; k < n; k++) {
+    const u = k / (n - 1);
+    const iu = 1 - u;
+    // Quadratic Bezier B(u) = iu^2*start + 2*iu*u*C + u^2*end.
+    let px = iu * iu * start[0] + 2 * iu * u * cx + u * u * end[0];
+    let py = iu * iu * start[1] + 2 * iu * u * cy + u * u * end[1];
+    // Tangent (derivative) for the normal direction.
+    const tx = 2 * iu * (cx - start[0]) + 2 * u * (end[0] - cx);
+    const ty = 2 * iu * (cy - start[1]) + 2 * u * (end[1] - cy);
+    const tl = Math.hypot(tx, ty) || 1;
+    const nx = -ty / tl;
+    const ny = tx / tl;
+    // fbm jag, faded to zero at both ends so the seam stays pinned to the edges.
+    const fade = Math.sin(Math.PI * u);
+    const j = fbm(u * style.jagFreq, seed) * jagAmp * fade;
+    px += nx * j;
+    py += ny * j;
+    points[k * 2] = px;
+    points[k * 2 + 1] = py;
+  }
+
+  // Second pass: cumulative arc length.
+  let acc = 0;
+  arc[0] = 0;
+  for (let k = 1; k < n; k++) {
+    const dx = at(points, k * 2) - at(points, (k - 1) * 2);
+    const dy = at(points, k * 2 + 1) - at(points, (k - 1) * 2 + 1);
+    acc += Math.hypot(dx, dy);
+    arc[k] = acc;
+  }
+
+  return { points, arc, length: acc, start, end };
+}
+
+// Nearest point on the seam polyline to (px,py): distance and the normalized
+// arc position of that nearest point.
+interface Nearest {
+  dist: number;
+  arcN: number;
+}
+
+function nearestOnSeam(seam: SeamDescriptor, px: number, py: number): Nearest {
+  const pts = seam.points;
+  const n = pts.length / 2;
+  let bestD = Infinity;
+  let bestArc = 0;
+  for (let k = 0; k < n - 1; k++) {
+    const ax = at(pts, k * 2);
+    const ay = at(pts, k * 2 + 1);
+    const ex = at(pts, (k + 1) * 2) - ax;
+    const ey = at(pts, (k + 1) * 2 + 1) - ay;
+    const len2 = ex * ex + ey * ey || 1;
+    let s = ((px - ax) * ex + (py - ay) * ey) / len2;
+    if (s < 0) s = 0;
+    else if (s > 1) s = 1;
+    const cxp = ax + ex * s;
+    const cyp = ay + ey * s;
+    const dx = px - cxp;
+    const dy = py - cyp;
+    const d = dx * dx + dy * dy;
+    if (d < bestD) {
+      bestD = d;
+      const segArc = at(seam.arc, k) + s * (at(seam.arc, k + 1) - at(seam.arc, k));
+      bestArc = segArc / (seam.length || 1);
+    }
+  }
+  return { dist: Math.sqrt(bestD), arcN: bestArc };
+}
+
+// Nearest actual point on the seam polyline (position, for snapping).
+function nearestPoint(
+  seam: SeamDescriptor,
+  px: number,
+  py: number,
+): { x: number; y: number } {
+  const pts = seam.points;
+  const n = pts.length / 2;
+  let bestD = Infinity;
+  let rx = px;
+  let ry = py;
+  for (let k = 0; k < n - 1; k++) {
+    const ax = at(pts, k * 2);
+    const ay = at(pts, k * 2 + 1);
+    const ex = at(pts, (k + 1) * 2) - ax;
+    const ey = at(pts, (k + 1) * 2 + 1) - ay;
+    const len2 = ex * ex + ey * ey || 1;
+    let s = ((px - ax) * ex + (py - ay) * ey) / len2;
+    if (s < 0) s = 0;
+    else if (s > 1) s = 1;
+    const cxp = ax + ex * s;
+    const cyp = ay + ey * s;
+    const dx = px - cxp;
+    const dy = py - cyp;
+    const d = dx * dx + dy * dy;
+    if (d < bestD) {
+      bestD = d;
+      rx = cxp;
+      ry = cyp;
+    }
+  }
+  return { x: rx, y: ry };
+}
+
+// Ray-cast point-in-polygon over the free-corner polygon (seam samples + the
+// corner). True = inside the free corner piece.
+function pointInFree(seam: SeamDescriptor, px: number, py: number): boolean {
+  const pts = seam.points;
+  const n = pts.length / 2;
+  const cornerX = PAGE_W / 2;
+  const cornerY = PAGE_H / 2;
+  const vx = (idx: number) => (idx < n ? at(pts, idx * 2) : cornerX);
+  const vy = (idx: number) => (idx < n ? at(pts, idx * 2 + 1) : cornerY);
+  const total = n + 1;
+  let inside = false;
+  for (let i = 0, j = total - 1; i < total; j = i++) {
+    const xi = vx(i);
+    const yi = vy(i);
+    const xj = vx(j);
+    const yj = vy(j);
+    const intersects =
+      yi > py !== yj > py &&
+      px < ((xj - xi) * (py - yi)) / (yj - yi || 1e-9) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+export function presplitCornerTear(
+  seed = 1,
+  style: CornerTearStyle = DEFAULT_CORNER_TEAR,
+): PreSplit {
+  const nx = COLS + 1;
+  const ny = ROWS + 1;
+  const vCount = nx * ny;
+  const seam = buildSeam(style, seed);
+
+  // Base grid: centred plane in the XY plane, +z front, y up. UV matches the
+  // grid; top-right corner (i=COLS, j=ROWS) is where the tear originates.
+  const bx = new Float32Array(vCount);
+  const by = new Float32Array(vCount);
+  const bu = new Float32Array(vCount);
+  const bv = new Float32Array(vCount);
+  for (let j = 0; j <= ROWS; j++) {
+    const v = j / ROWS;
+    const y = v * PAGE_H - PAGE_H / 2;
+    for (let i = 0; i <= COLS; i++) {
+      const u = i / COLS;
+      const idx = j * nx + i;
+      bx[idx] = u * PAGE_W - PAGE_W / 2;
+      by[idx] = y;
+      bu[idx] = u;
+      bv[idx] = v;
+    }
+  }
+
+  // Classify each cell by its centre; mark which side touches each vertex.
+  const touchHeld = new Uint8Array(vCount);
+  const touchFree = new Uint8Array(vCount);
+  const cellFree = new Uint8Array(COLS * ROWS);
+  for (let j = 0; j < ROWS; j++) {
+    for (let i = 0; i < COLS; i++) {
+      const c00 = j * nx + i;
+      const c01 = (j + 1) * nx + i;
+      const cx = (at(bx, c00) + at(bx, c00 + 1)) / 2;
+      const cy = (at(by, c00) + at(by, c01)) / 2;
+      const free = pointInFree(seam, cx, cy) ? 1 : 0;
+      cellFree[j * COLS + i] = free;
+      const touch = free ? touchFree : touchHeld;
+      touch[c00] = 1;
+      touch[c00 + 1] = 1;
+      touch[c01] = 1;
+      touch[c01 + 1] = 1;
+    }
+  }
+
+  // Snap boundary vertices (touched by both sides) onto the seam so the torn
+  // edge follows the curve exactly and both pieces share the same positions.
+  const isEdge = new Uint8Array(vCount);
+  for (let idx = 0; idx < vCount; idx++) {
+    if (at(touchHeld, idx) && at(touchFree, idx)) {
+      isEdge[idx] = 1;
+      const near = nearestPoint(seam, at(bx, idx), at(by, idx));
+      bx[idx] = near.x;
+      by[idx] = near.y;
+    }
+  }
+
+  // Per-vertex attributes from the final positions.
+  const aDist = new Float32Array(vCount);
+  const aArc = new Float32Array(vCount);
+  const aNoise = new Float32Array(vCount);
+  for (let idx = 0; idx < vCount; idx++) {
+    const near = nearestOnSeam(seam, at(bx, idx), at(by, idx));
+    // Sign from which piece owns the vertex (edge vertices -> 0 distance).
+    const sign = at(isEdge, idx) ? 0 : at(touchFree, idx) ? -1 : 1;
+    aDist[idx] = sign * near.dist;
+    aArc[idx] = near.arcN;
+    aNoise[idx] = hash1(idx * 2.399 + 0.5);
+  }
+
+  const buildPiece = (wantFree: number): BufferGeometry => {
+    const remap = new Int32Array(vCount).fill(-1);
+    const pos: number[] = [];
+    const nor: number[] = [];
+    const uv: number[] = [];
+    const sd: number[] = [];
+    const sa: number[] = [];
+    const ef: number[] = [];
+    const nz: number[] = [];
+    const index: number[] = [];
+    let count = 0;
+    const emit = (idx: number): number => {
+      let r = at(remap, idx);
+      if (r < 0) {
+        r = count++;
+        remap[idx] = r;
+        pos.push(at(bx, idx), at(by, idx), 0);
+        nor.push(0, 0, 1);
+        uv.push(at(bu, idx), at(bv, idx));
+        sd.push(at(aDist, idx));
+        sa.push(at(aArc, idx));
+        ef.push(at(isEdge, idx));
+        nz.push(at(aNoise, idx));
+      }
+      return r;
+    };
+    for (let j = 0; j < ROWS; j++) {
+      for (let i = 0; i < COLS; i++) {
+        if (at(cellFree, j * COLS + i) !== wantFree) continue;
+        const c00 = j * nx + i;
+        const c01 = (j + 1) * nx + i;
+        const r00 = emit(c00);
+        const r10 = emit(c00 + 1);
+        const r01 = emit(c01);
+        const r11 = emit(c01 + 1);
+        // CCW winding, front toward +z.
+        index.push(r00, r10, r11, r00, r11, r01);
+      }
+    }
+    const geo = new BufferGeometry();
+    geo.setAttribute("position", new Float32BufferAttribute(pos, 3));
+    geo.setAttribute("normal", new Float32BufferAttribute(nor, 3));
+    geo.setAttribute("uv", new Float32BufferAttribute(uv, 2));
+    geo.setAttribute("aSeamDist", new Float32BufferAttribute(sd, 1));
+    geo.setAttribute("aSeamArc", new Float32BufferAttribute(sa, 1));
+    geo.setAttribute("aEdgeFlag", new Float32BufferAttribute(ef, 1));
+    geo.setAttribute("aNoise", new Float32BufferAttribute(nz, 1));
+    geo.setIndex(new Uint32BufferAttribute(index, 1));
+    geo.computeBoundingSphere();
+    return geo;
+  };
+
+  return {
+    held: buildPiece(0),
+    free: buildPiece(1),
+    seam,
+  };
+}

--- a/apps/landing/vitest.config.ts
+++ b/apps/landing/vitest.config.ts
@@ -1,0 +1,26 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+// Minimal node-env project for the landing app's pure logic (scroll p-space
+// math + the pre-split geometry builder). No DOM: these modules are plain math
+// over typed arrays / three BufferGeometry, so jsdom is unnecessary. Joins the
+// root run via the `projects` array in the repo-root vitest.config.ts and runs
+// standalone via `pnpm -F @ajh/landing test`.
+const here = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    name: 'landing',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts'],
+  },
+  resolve: {
+    // Mirror the tsconfig `@/* -> ./src/*` path so modules under test that use
+    // the alias (e.g. presplit.ts imports `@/engine/pages`) resolve. Regex form
+    // matches only the `@/` prefix, never bare `@`-scoped package names.
+    alias: [{ find: /^@\//, replacement: `${resolve(here, 'src')}/` }],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/prompts:
     devDependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
       // every story as a test; selectable on its own with `--project storybook`.
       'packages/ui/vitest.storybook.config.ts',
       'apps/desktop',
+      // Node-env project for the landing app's pure logic (scroll p-space math
+      // + pre-split geometry). Config: apps/landing/vitest.config.ts. Not in the
+      // coverage include/thresholds below, so it adds tests without gating.
+      'apps/landing',
       // Node-env project for build/release scripts (e.g. the empty-release-notes
       // guard plugin). Config: scripts/vitest.config.ts.
       'scripts',


### PR DESCRIPTION
## What

M1 of the RIPBOOK series (ADR 0015): the scroll-rig spine + ONE kraft page that corner-tears and fully reverses. Everything later milestones ride on.

- **Scroll rig:** Lenis owns document scroll (semantic layer stays scroll-height authority) → ONE `scrub:true` ScrollTrigger scrubbing ONE master timeline (duration 9, absolute tweens only) → preallocated `channels[]` (the only GSAP→GL bridge) + zustand store (`getState()` reads in frame code). `?t=` debug jump, `?hud=1` dev HUD.
- **Rip system v1:** row-snap seam pre-split (96×128 plane, seeded fbm corner seam, watertight, attributes `aSeamDist/aSeamArc/aEdgeFlag/aNoise`) + shared `RipPaperMaterial` ShaderMaterial: tear-front gate sweeping `aSeamArc`, cylindrical peel bend, torn-edge boil (stepped `uBoil`), all pure `f(uRipP)` — `ripP=0` reproduces `position` exactly (gapless reassembly). JS owns the free piece's ballistic throw, f(exitP).
- **Experience:** Canvas + raw-composer skeleton (RenderPass only, `autoRenderToScreen=false`, the single priority-1 useFrame owns camera/uniform writes), `compileAsync` warmup behind the loader, GLLoader now really mounts GL behind the capability gate + `flipped()` guard, error boundary → legacy fallback.

## Fleet review (already run)

- **webgl-reviewer: APPROVE — 0 HIGH/CRITICAL.** Scrub-safety, disposal, allocations, uniform sharing, SSR safety, gate correctness, ASCII all verified. 1 LOW advisory (iterator micro-alloc) noted, non-blocking. The "programmatic scrollTo fights Lenis" concern was investigated against lenis 1.3.25 source and classified an automation-only artifact — all real user inputs (wheel, keyboard, scrollbar) advance t.
- **gate-auditor: 13/13 PASS** — GL mounts; scrub determinism at mid-play AND mid-exit (approach from both sides, identical frames); rip reversal pixel-identical; real-input scroll drive (wheel/PageDown/End); console clean; draw calls flat at 2 (<30 budget); full fallback matrix (reduced-motion / 800px / WebGL2-stubbed / prod-build no-`?gl=1`) all land on the working legacy page; strobe budget trivially met.

## Validation

typecheck ✓ · build (static export) ✓ · eslint strict ✓ · ASCII-only ✓ · full pre-push gate ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new interactive WebGL page experience with scroll-driven transitions and animated page effects.
  * Introduced a realistic corner-tear animation with dynamic paper shading.
  * Added adaptive rendering quality for different device capabilities.
  * Added a development-only performance HUD, available automatically in development or with `?hud`.
* **Bug Fixes**
  * WebGL initialization failures now fall back to the legacy experience instead of leaving a blank page.
  * Improved loading-state cleanup and legacy interface visibility during WebGL activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->