### PR TITLE
feat: ripbook m2 - kraft paper material system

### DIFF
--- a/apps/landing/src/app/GLLoader.tsx
+++ b/apps/landing/src/app/GLLoader.tsx
@@ -109,7 +109,10 @@ export default function GLLoader() {
         view accessible version
       </a>
       <ExperienceBoundary onError={fallBackToLegacy}>
-        <RipbookExperience onReady={() => setReady(true)} />
+        <RipbookExperience
+          onReady={() => setReady(true)}
+          onError={fallBackToLegacy}
+        />
       </ExperienceBoundary>
     </>
   );

--- a/apps/landing/src/bake/bake.ts
+++ b/apps/landing/src/bake/bake.ts
@@ -1,0 +1,392 @@
+// The at-load bake harness (TS-only orchestration; the real bake GLSL is
+// shader-engineer's). bakeAll(renderer) runs ONCE behind the loader, before
+// onReady: for each target it allocates a WebGLRenderTarget (mips + max
+// anisotropy), renders a fullscreen triangle with that target's bake
+// ShaderMaterial, lets three generate the mip chain, and publishes the texture
+// into the `bakes` singleton by reference. The bake-time quad + materials are
+// disposed once every target is baked; the render targets themselves live for
+// the whole session (their textures are what the paper/ink materials sample), so
+// they are intentionally NOT disposed on unmount -- see disposeBakes for the only
+// full-teardown path.
+//
+// bakeShaders is the registry of one ShaderMaterial factory per target. The real
+// procedural bake GLSL (kraft fiber albedo + roughness, height-derived normal
+// map, seeded stain/smudge atlases, channel-packed pencil hatch) lives in the
+// factory bodies below; shared noise/height helpers are in ./chunks. The
+// harness, RT config, sequencing, and timing are unchanged from the placeholder
+// version -- only the factory outputs are real now.
+//
+// Fullscreen-triangle contract for the bake ShaderMaterials (placeholder + real):
+//   attribute vec3 position  -- already in clip space (xy in [-1,3], z ignored)
+//   attribute vec2 uv        -- [0,1] across the visible target, extends to 2 on
+//                               the oversized third vertex
+//   the vertex shader is just: gl_Position = vec4(position.xy, 0.0, 1.0);
+//   (the camera is irrelevant; frustum culling is disabled on the quad).
+
+import {
+  BufferGeometry,
+  Camera,
+  Float32BufferAttribute,
+  LinearFilter,
+  LinearMipmapLinearFilter,
+  Mesh,
+  NoColorSpace,
+  Scene,
+  ShaderMaterial,
+  type WebGLRenderer,
+  WebGLRenderTarget,
+} from "three";
+
+import { resolveTier, TIER_TABLE } from "@/engine/quality";
+
+import { type BakeName, bakes } from "./bakes";
+import { NOISE, PAPER_HEIGHT } from "./chunks";
+
+// Paper bake resolution is quality-tiered (webgl-standards: HIGH 4096, LOW 2048).
+// The atlases are fixed-size regardless of tier.
+const PAPER_HIGH = 4096;
+const PAPER_LOW = 2048;
+const STAIN_SIZE = 1024;
+const SMUDGE_SIZE = 512;
+const HATCH_SIZE = 2048;
+
+// Shared placeholder vertex shader for every bake target: pass the clip-space
+// fullscreen triangle straight through and forward uv.
+const BAKE_VERT = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position.xy, 0.0, 1.0);
+  }
+`;
+
+// Current paper-bake resolution (tier-driven, same value bakeAll uses). Needed
+// inside the normal/height factory to size the central-difference offset and to
+// keep the derived normal tilt resolution-independent.
+function paperSize(): number {
+  return resolveTier() === TIER_TABLE.HIGH ? PAPER_HIGH : PAPER_LOW;
+}
+
+// Bump strength constant for the paper normal. Multiplied by paperSize in the
+// factory so the per-texel central difference resolves to the SAME surface tilt
+// at 4096 (HIGH) and 2048 (LOW) instead of flattening on the finer tier.
+const NRM_K = 0.0006;
+
+// A small ShaderMaterial honouring the fullscreen-triangle contract.
+function bakeMaterial(name: string, frag: string, uniforms = {}): ShaderMaterial {
+  return new ShaderMaterial({
+    name,
+    uniforms,
+    vertexShader: BAKE_VERT,
+    fragmentShader: frag,
+  });
+}
+
+// paperAlbedoRough: rgb = kraft albedo (LINEAR), a = roughness. Domain-rotated
+// multi-octave fbm fiber tooth (anisotropic, from the shared height field) +
+// coarse blotch tone, sparse dark flecks, faint ruled lines + editor-red margin
+// line, and edge darkening toward the page borders. Palette (kraft #C9A876,
+// kraft-deep #A8875A, ink #17130F, editor-red #B33A2B) is sRGB->linear decoded
+// here since the render target is DATA (NoColorSpace), not display-referred.
+function bakeAlbedoRough(): ShaderMaterial {
+  return bakeMaterial(
+    "BakeAlbedoRough",
+    /* glsl */ `
+      ${NOISE}
+      ${PAPER_HEIGHT}
+      varying vec2 vUv;
+      void main() {
+        vec2 uv = vUv;
+        float h = ajh_paperHeight(uv);
+
+        vec3 kraft = ajh_srgb2lin(vec3(0.788, 0.659, 0.463)); // #C9A876
+        vec3 kdeep = ajh_srgb2lin(vec3(0.659, 0.529, 0.353)); // #A8875A
+        vec3 ink   = ajh_srgb2lin(vec3(0.090, 0.075, 0.059)); // #17130F
+        vec3 red   = ajh_srgb2lin(vec3(0.702, 0.227, 0.169)); // #B33A2B
+
+        // Base tone: coarse blotch mix, brightened where the fiber tooth rises.
+        float blotch = ajh_fbm5(uv * 3.3 + 11.0);
+        vec3 col = mix(kdeep, kraft, blotch);
+        col *= 0.82 + h * 0.36;
+
+        // Sparse dark flecks toward ink.
+        float fleck = smoothstep(0.985, 0.995, ajh_hash21(floor(uv * vec2(420.0, 560.0))));
+        col = mix(col, ink, fleck * 0.5);
+
+        // Faint ruled lines (printed flat ink), ~26 across the page height.
+        float ly = abs(fract(uv.y * 26.0) - 0.5);
+        float ruled = smoothstep(0.045, 0.010, ly) * 0.06;
+        col = mix(col, ink, ruled);
+
+        // Editor-red margin line near the left edge.
+        float margin = smoothstep(0.007, 0.0025, abs(uv.x - 0.12)) * 0.55;
+        col = mix(col, red, margin);
+
+        // Edge darkening toward the borders.
+        float eb = min(min(uv.x, 1.0 - uv.x), min(uv.y, 1.0 - uv.y));
+        col *= mix(0.72, 1.0, smoothstep(0.0, 0.07, eb));
+
+        // Roughness: grooves rougher, printed ink a touch smoother.
+        float rough = clamp(0.72 + (0.5 - h) * 0.14 - margin * 0.08, 0.55, 0.9);
+
+        gl_FragColor = vec4(col, rough);
+      }
+    `,
+  );
+}
+
+// paperNormalHeight: rg = tangent-space normal xy, b = height, a = free. The
+// normal is derived IN THE BAKE from the shared height field by central
+// differences (+/- one texel), so the material gets a real normal map aligned to
+// the albedo's fibers. uInvSize = one texel in uv; uNrmScale folds in paperSize
+// so the tilt is resolution-independent.
+function bakeNormalHeight(): ShaderMaterial {
+  const size = paperSize();
+  return bakeMaterial(
+    "BakeNormalHeight",
+    /* glsl */ `
+      ${NOISE}
+      ${PAPER_HEIGHT}
+      uniform float uInvSize;
+      uniform float uNrmScale;
+      varying vec2 vUv;
+      void main() {
+        vec2 uv = vUv;
+        float e = uInvSize;
+        float hl = ajh_paperHeight(uv - vec2(e, 0.0));
+        float hr = ajh_paperHeight(uv + vec2(e, 0.0));
+        float hd = ajh_paperHeight(uv - vec2(0.0, e));
+        float hu = ajh_paperHeight(uv + vec2(0.0, e));
+        vec3 n = normalize(vec3((hl - hr) * uNrmScale, (hd - hu) * uNrmScale, 1.0));
+        gl_FragColor = vec4(n.xy * 0.5 + 0.5, ajh_paperHeight(uv), 1.0);
+      }
+    `,
+    {
+      uInvSize: { value: 1 / size },
+      uNrmScale: { value: NRM_K * size },
+    },
+  );
+}
+
+// stain: 4x4 atlas of distinct seeded coffee/ink stains. rgb = brown tint
+// (linear, rim darker), a = coverage. Each cell is a coffee RING (dark outer rim
+// + faint interior) or a soft BLOTCH, chosen + shaped by a per-cell hash, with a
+// noise-wobbled radius so nothing is a perfect circle. The page material picks a
+// cell + places it via a seed-driven transform.
+function bakeStain(): ShaderMaterial {
+  return bakeMaterial(
+    "BakeStain",
+    /* glsl */ `
+      ${NOISE}
+      varying vec2 vUv;
+      void main() {
+        vec2 grid = vUv * 4.0;
+        vec2 cell = floor(grid);
+        vec2 lp = fract(grid);
+        float id = cell.y * 4.0 + cell.x;
+        float seed = ajh_hash11(id * 3.17 + 1.0);
+
+        vec2 c = (lp - 0.5) * 2.0;
+        float ang = atan(c.y, c.x);
+        float wob = (ajh_vnoise(vec2(ang * 2.0 + seed * 20.0, seed * 7.0)) - 0.5) * 0.22;
+        float r = length(c) * (1.0 + wob);
+
+        float ring = smoothstep(0.020, 0.0, abs(r - 0.72));
+        float fillC = smoothstep(0.8, 0.0, r) * 0.28;
+        float blot = smoothstep(0.75, 0.35, r);
+        float isRing = step(0.5, seed);
+        float cov = mix(blot, max(ring, fillC), isRing);
+        cov *= smoothstep(1.0, 0.9, r);
+        cov = clamp(cov, 0.0, 1.0);
+
+        vec3 brown = ajh_srgb2lin(vec3(0.42, 0.28, 0.16));
+        vec3 dark  = ajh_srgb2lin(vec3(0.22, 0.14, 0.08));
+        vec3 tint = mix(brown, dark, ring);
+        gl_FragColor = vec4(tint, cov);
+      }
+    `,
+  );
+}
+
+// smudge: r = graphite smear density. Anisotropic fbm stretched along a slanted
+// direction, thresholded into streaks and gated by a coarse patch mask so the
+// smears sit in a few places rather than covering the atlas. The page material
+// darkens by this.
+function bakeSmudge(): ShaderMaterial {
+  return bakeMaterial(
+    "BakeSmudge",
+    /* glsl */ `
+      ${NOISE}
+      varying vec2 vUv;
+      void main() {
+        vec2 d = ajh_rot(0.6) * vUv;
+        float streak = ajh_fbm3(vec2(d.x * 7.0, d.y * 46.0));
+        // NB: 'patch' is a GLSL-ES reserved word (tessellation) -> use 'mask'.
+        float mask = ajh_fbm5(vUv * 2.4 + 3.0);
+        float dens = clamp(smoothstep(0.45, 0.8, streak) * smoothstep(0.35, 0.7, mask), 0.0, 1.0);
+        gl_FragColor = vec4(vec3(dens), 1.0);
+      }
+    `,
+  );
+}
+
+// hatch: channel-packed pencil hatch. R = single-direction strokes, G =
+// cross-hatch (two directions), B = heavy/dense scribble (three directions), A =
+// blue-noise (interleaved gradient noise, two decorrelated layers -- a good
+// hash-based approximation). Strokes read hand-drawn: per-stroke width + darkness
+// jitter, slight waviness, broken-stroke gaps.
+function bakeHatch(): ShaderMaterial {
+  return bakeMaterial(
+    "BakeHatch",
+    /* glsl */ `
+      ${NOISE}
+      varying vec2 vUv;
+
+      float ajh_strokes(vec2 uv, float ang, float freq, float dens, float seed) {
+        vec2 r = ajh_rot(ang) * uv;
+        float wav = (ajh_vnoise(vec2(r.y * 3.0 + seed, seed * 1.7)) - 0.5) * 0.12;
+        float x = r.x * freq + wav * freq;
+        float line = floor(x);
+        float fx = fract(x);
+        float wj = ajh_hash11(line * 1.7 + seed);
+        float dj = 0.6 + 0.4 * ajh_hash11(line * 4.3 + seed + 9.0);
+        float halfw = mix(0.12, 0.34, wj);
+        float present = step(1.0 - dens, ajh_hash11(line * 2.9 + seed + 3.0));
+        float cov = smoothstep(halfw, halfw * 0.4, abs(fx - 0.5)) * dj * present;
+        float gap = smoothstep(0.25, 0.5, ajh_vnoise(vec2(r.y * 9.0 + line, seed)));
+        return clamp(cov * gap, 0.0, 1.0);
+      }
+
+      float ajh_ign(vec2 p, float o) {
+        return fract(52.9829189 * fract(dot(p + o, vec2(0.06711056, 0.00583715))));
+      }
+
+      void main() {
+        vec2 uv = vUv;
+        float single = ajh_strokes(uv, 0.7, 26.0, 0.85, 1.0);
+
+        float crossA = ajh_strokes(uv, 0.7, 26.0, 0.80, 5.0);
+        float crossB = ajh_strokes(uv, -0.7, 26.0, 0.80, 12.0);
+        float crossH = clamp(max(crossA, crossB), 0.0, 1.0);
+
+        float heavyA = ajh_strokes(uv, 0.5, 34.0, 0.95, 20.0);
+        float heavyB = ajh_strokes(uv, -0.9, 34.0, 0.95, 27.0);
+        float heavyC = ajh_strokes(uv, 1.9, 30.0, 0.90, 33.0);
+        float heavy = clamp(heavyA + heavyB * 0.8 + heavyC * 0.7, 0.0, 1.0);
+
+        vec2 pp = uv * 2048.0;
+        float blue = fract(ajh_ign(pp, 0.0) + ajh_ign(pp, 37.0) * 0.5);
+
+        gl_FragColor = vec4(single, crossH, heavy, blue);
+      }
+    `,
+  );
+}
+
+// The registry the harness renders. Each factory returns a ShaderMaterial
+// honouring the fullscreen-triangle contract; bakeAll allocates the target and
+// generates the mip chain.
+export const bakeShaders: Record<BakeName, () => ShaderMaterial> = {
+  paperAlbedoRough: bakeAlbedoRough,
+  paperNormalHeight: bakeNormalHeight,
+  stain: bakeStain,
+  smudge: bakeSmudge,
+  hatch: bakeHatch,
+};
+
+interface BakeTarget {
+  name: BakeName;
+  size: number;
+}
+
+// Module-held render targets so the GPU-side framebuffers are not orphaned
+// (three only frees them on an explicit dispose). Session-lifetime by design.
+let rendered: WebGLRenderTarget[] = [];
+
+// A screen-covering triangle in clip space with uv that hits [0,1] across the
+// visible target. Bounds are the standard oversized triangle.
+function fullscreenTriangle(): BufferGeometry {
+  const geo = new BufferGeometry();
+  geo.setAttribute(
+    "position",
+    new Float32BufferAttribute([-1, -1, 0, 3, -1, 0, -1, 3, 0], 3),
+  );
+  geo.setAttribute("uv", new Float32BufferAttribute([0, 0, 2, 0, 0, 2], 2));
+  return geo;
+}
+
+// Run every bake once. Idempotent: a StrictMode double-mount (or any second
+// call) sees the paper target already filled and returns immediately, so the
+// bakes never run twice. Times each target and logs ONE summary line the visual
+// gate reads (total target < 1.5s).
+export function bakeAll(renderer: WebGLRenderer): void {
+  if (bakes.paperAlbedoRough.value !== null) return;
+
+  const paperSize = resolveTier() === TIER_TABLE.HIGH ? PAPER_HIGH : PAPER_LOW;
+  const targets: BakeTarget[] = [
+    { name: "paperAlbedoRough", size: paperSize },
+    { name: "paperNormalHeight", size: paperSize },
+    { name: "stain", size: STAIN_SIZE },
+    { name: "smudge", size: SMUDGE_SIZE },
+    { name: "hatch", size: HATCH_SIZE },
+  ];
+
+  const maxAniso = renderer.capabilities.getMaxAnisotropy();
+  const prevTarget = renderer.getRenderTarget();
+
+  const geo = fullscreenTriangle();
+  const quad = new Mesh(geo);
+  quad.frustumCulled = false; // clip-space verts: never cull the bake quad
+  const scene = new Scene();
+  scene.add(quad);
+  const cam = new Camera(); // ignored by the vertex shader; render() needs one
+
+  const mats: ShaderMaterial[] = [];
+  const timings: string[] = [];
+  const t0 = performance.now();
+
+  // try/finally so a bake shader that throws mid-loop still restores the render
+  // target and disposes the shared quad geometry + created materials (the RTs
+  // stay -- session lifetime). The error is NOT swallowed: it propagates out so
+  // the boot sequence can fall back to legacy instead of the loader hanging.
+  try {
+    for (const { name, size } of targets) {
+      const s0 = performance.now();
+      const rt = new WebGLRenderTarget(size, size, {
+        minFilter: LinearMipmapLinearFilter,
+        magFilter: LinearFilter,
+        generateMipmaps: true, // three generates the mip chain at render end
+        anisotropy: maxAniso,
+        colorSpace: NoColorSpace,
+        depthBuffer: false,
+        stencilBuffer: false,
+      });
+      const mat = bakeShaders[name]();
+      mats.push(mat);
+      quad.material = mat;
+      renderer.setRenderTarget(rt);
+      renderer.render(scene, cam);
+      bakes[name].value = rt.texture;
+      rendered.push(rt);
+      timings.push(`${name} ${size} ${(performance.now() - s0).toFixed(1)}ms`);
+    }
+  } finally {
+    renderer.setRenderTarget(prevTarget);
+    for (const m of mats) m.dispose();
+    geo.dispose();
+  }
+
+  const total = (performance.now() - t0).toFixed(1);
+  // One summary line the visual gate reads. console.warn (not .info) because the
+  // shared lint config only allows warn/error and bans inline disables.
+  console.warn(`[ripbook bake] ${timings.join(" | ")} | total ${total}ms`);
+}
+
+// Full teardown for the session-lifetime bakes. Not called on unmount (the
+// textures are meant to persist); exposed only so a hard reset can free the GPU
+// memory if one is ever wired.
+export function disposeBakes(): void {
+  for (const rt of rendered) rt.dispose();
+  rendered = [];
+  for (const key of Object.keys(bakes) as BakeName[]) bakes[key].value = null;
+}

--- a/apps/landing/src/bake/bake.ts
+++ b/apps/landing/src/bake/bake.ts
@@ -114,12 +114,14 @@ function bakeAlbedoRough(): ShaderMaterial {
         col = mix(col, ink, fleck * 0.5);
 
         // Faint ruled lines (printed flat ink), ~26 across the page height.
+        // Ascending-edge smoothstep + invert (GLSL smoothstep is UNDEFINED when
+        // edge0 >= edge1); 1 - smoothstep(lo,hi) is the descending ramp we want.
         float ly = abs(fract(uv.y * 26.0) - 0.5);
-        float ruled = smoothstep(0.045, 0.010, ly) * 0.06;
+        float ruled = (1.0 - smoothstep(0.010, 0.045, ly)) * 0.06;
         col = mix(col, ink, ruled);
 
         // Editor-red margin line near the left edge.
-        float margin = smoothstep(0.007, 0.0025, abs(uv.x - 0.12)) * 0.55;
+        float margin = (1.0 - smoothstep(0.0025, 0.007, abs(uv.x - 0.12))) * 0.55;
         col = mix(col, red, margin);
 
         // Edge darkening toward the borders.
@@ -191,12 +193,14 @@ function bakeStain(): ShaderMaterial {
         float wob = (ajh_vnoise(vec2(ang * 2.0 + seed * 20.0, seed * 7.0)) - 0.5) * 0.22;
         float r = length(c) * (1.0 + wob);
 
-        float ring = smoothstep(0.020, 0.0, abs(r - 0.72));
-        float fillC = smoothstep(0.8, 0.0, r) * 0.28;
-        float blot = smoothstep(0.75, 0.35, r);
+        // Ascending-edge smoothstep + invert (edge0 < edge1 always; GLSL
+        // smoothstep is undefined otherwise) -- same descending falloffs.
+        float ring = 1.0 - smoothstep(0.0, 0.020, abs(r - 0.72));
+        float fillC = (1.0 - smoothstep(0.0, 0.8, r)) * 0.28;
+        float blot = 1.0 - smoothstep(0.35, 0.75, r);
         float isRing = step(0.5, seed);
         float cov = mix(blot, max(ring, fillC), isRing);
-        cov *= smoothstep(1.0, 0.9, r);
+        cov *= 1.0 - smoothstep(0.9, 1.0, r);
         cov = clamp(cov, 0.0, 1.0);
 
         vec3 brown = ajh_srgb2lin(vec3(0.42, 0.28, 0.16));
@@ -252,7 +256,8 @@ function bakeHatch(): ShaderMaterial {
         float dj = 0.6 + 0.4 * ajh_hash11(line * 4.3 + seed + 9.0);
         float halfw = mix(0.12, 0.34, wj);
         float present = step(1.0 - dens, ajh_hash11(line * 2.9 + seed + 3.0));
-        float cov = smoothstep(halfw, halfw * 0.4, abs(fx - 0.5)) * dj * present;
+        // Ascending-edge smoothstep + invert (halfw > halfw*0.4): stroke core.
+        float cov = (1.0 - smoothstep(halfw * 0.4, halfw, abs(fx - 0.5))) * dj * present;
         float gap = smoothstep(0.25, 0.5, ajh_vnoise(vec2(r.y * 9.0 + line, seed)));
         return clamp(cov * gap, 0.0, 1.0);
       }
@@ -342,13 +347,19 @@ export function bakeAll(renderer: WebGLRenderer): void {
   const cam = new Camera(); // ignored by the vertex shader; render() needs one
 
   const mats: ShaderMaterial[] = [];
+  // Provisional: render every target into local RTs first and publish the holder
+  // .value assignments ONLY after all succeed -> the bake is transactional. The
+  // idempotence/retry guard reads paperAlbedoRough.value, so a partial success
+  // must never assign it; otherwise a retry would skip the missing targets.
+  const provisional: { name: BakeName; rt: WebGLRenderTarget }[] = [];
   const timings: string[] = [];
   const t0 = performance.now();
 
-  // try/finally so a bake shader that throws mid-loop still restores the render
-  // target and disposes the shared quad geometry + created materials (the RTs
-  // stay -- session lifetime). The error is NOT swallowed: it propagates out so
-  // the boot sequence can fall back to legacy instead of the loader hanging.
+  // try/catch/finally: a bake shader that throws mid-loop disposes every
+  // provisional RT (catch) and leaves the holders null so a retry re-bakes
+  // cleanly, always restores the render target + tears down the shared quad
+  // geometry/materials (finally), and re-throws so the boot sequence can fall
+  // back to legacy instead of the loader hanging.
   try {
     for (const { name, size } of targets) {
       const s0 = performance.now();
@@ -366,10 +377,17 @@ export function bakeAll(renderer: WebGLRenderer): void {
       quad.material = mat;
       renderer.setRenderTarget(rt);
       renderer.render(scene, cam);
-      bakes[name].value = rt.texture;
-      rendered.push(rt);
+      provisional.push({ name, rt });
       timings.push(`${name} ${size} ${(performance.now() - s0).toFixed(1)}ms`);
     }
+    // All targets rendered -> publish atomically.
+    for (const { name, rt } of provisional) {
+      bakes[name].value = rt.texture;
+      rendered.push(rt);
+    }
+  } catch (err) {
+    for (const { rt } of provisional) rt.dispose();
+    throw err;
   } finally {
     renderer.setRenderTarget(prevTarget);
     for (const m of mats) m.dispose();

--- a/apps/landing/src/bake/bakes.ts
+++ b/apps/landing/src/bake/bakes.ts
@@ -1,0 +1,43 @@
+// The bake-texture singletons, shared by reference the same way engine/uniforms
+// exposes uBoil/uRipP. Each entry is a plain { value } holder that starts null
+// and is filled in-place by bakeAll (bake.ts) once, at load, behind the loader.
+// A material that wants a bake passes the SAME holder object as its sampler
+// uniform (e.g. uPaper: bakes.paperAlbedoRough) so it picks up the baked texture
+// by reference the instant bakeAll assigns .value -- zero re-wiring, no per-page
+// re-bake. The textures live for the whole session (never disposed on unmount);
+// only the bake-time quad/materials are torn down (see bake.ts).
+//
+// Channel layout each bake target packs (authored by shader-engineer; the harness
+// only owns the render targets + this contract):
+//   paperAlbedoRough  rgb = kraft albedo (linear),      a = roughness
+//   paperNormalHeight rg  = tangent-space normal xy,     b = height, a = free
+//   stain    1024^2  seeded coffee/ink stain atlas (rgb tint, a = coverage)
+//   smudge    512^2  seeded graphite/eraser smudge atlas (r = density)
+//   hatch    2048^2  channel-packed pencil hatch: R single / G cross / B heavy
+//                    / A blue-noise grain
+//
+// colorSpace: every target is authored + sampled as raw data (NoColorSpace) --
+// albedo is stored linear, the rest are non-color data (roughness, normal,
+// height, masks). The material does any decode/lighting; nothing here is a
+// display-referred sRGB texture.
+
+import type { Texture } from "three";
+
+export type BakeName =
+  | "paperAlbedoRough"
+  | "paperNormalHeight"
+  | "stain"
+  | "smudge"
+  | "hatch";
+
+export interface BakeHolder {
+  value: Texture | null;
+}
+
+export const bakes: Record<BakeName, BakeHolder> = {
+  paperAlbedoRough: { value: null },
+  paperNormalHeight: { value: null },
+  stain: { value: null },
+  smudge: { value: null },
+  hatch: { value: null },
+};

--- a/apps/landing/src/bake/chunks.ts
+++ b/apps/landing/src/bake/chunks.ts
@@ -1,0 +1,84 @@
+// Shared GLSL helper chunks for the RIPBOOK bake + material shaders. These are
+// plain template strings concatenated into ShaderMaterial fragment/vertex
+// bodies; every helper is ajh_-prefixed so it never collides with three's
+// injected symbols (or postprocessing's built-ins in the effect passes).
+//
+// NOISE bundles the hashes, value noise, a domain-rotated fbm (rotating the
+// domain each octave kills axis-aligned tiling artifacts), and an sRGB->linear
+// decode for authoring palette colours in the linear space the bakes / lit
+// materials work in. PAPER_HEIGHT is the ONE fiber-tooth height field shared by
+// the albedo bake (as a tint) and the normal/height bake (as the surface the
+// normal is derived from) so the light catches exactly the fibers the albedo
+// shows. Include NOISE before PAPER_HEIGHT.
+//
+// GLSL ES 1.00 constraints honoured: texture2D (not texture), constant loop
+// bounds, mat2 column-major construction.
+
+export const NOISE = /* glsl */ `
+  float ajh_hash11(float n) {
+    return fract(sin(n * 12.9898) * 43758.5453123);
+  }
+  float ajh_hash21(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+  }
+  float ajh_vnoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    float a = ajh_hash21(i);
+    float b = ajh_hash21(i + vec2(1.0, 0.0));
+    float c = ajh_hash21(i + vec2(0.0, 1.0));
+    float d = ajh_hash21(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+  }
+  // Column-major rotation: columns (c,s) and (-s,c) -> R * v rotates by +a.
+  mat2 ajh_rot(float a) {
+    float s = sin(a);
+    float c = cos(a);
+    return mat2(c, s, -s, c);
+  }
+  float ajh_fbm5(vec2 p) {
+    float sum = 0.0;
+    float amp = 0.5;
+    float nrm = 0.0;
+    for (int i = 0; i < 5; i++) {
+      sum += amp * ajh_vnoise(p);
+      nrm += amp;
+      p = ajh_rot(0.73) * p * 2.0;
+      amp *= 0.5;
+    }
+    return sum / nrm;
+  }
+  float ajh_fbm3(vec2 p) {
+    float sum = 0.0;
+    float amp = 0.5;
+    float nrm = 0.0;
+    for (int i = 0; i < 3; i++) {
+      sum += amp * ajh_vnoise(p);
+      nrm += amp;
+      p = ajh_rot(0.53) * p * 2.02;
+      amp *= 0.5;
+    }
+    return sum / nrm;
+  }
+  vec3 ajh_srgb2lin(vec3 c) {
+    return pow(c, vec3(2.2));
+  }
+`;
+
+export const PAPER_HEIGHT = /* glsl */ `
+  // Fiber tooth + coarse tone. uv in [0,1] across the page. Fibers run along +y
+  // (page height), so the tooth noise is ANISOTROPIC: high frequency across x,
+  // stretched (low frequency) along y. Frequencies are tuned so a fiber cell is
+  // ~4 texels at 4096^2 -> crisp (>= ~1.5 texel/px) at the closest DPR2 camera,
+  // not mushy.
+  float ajh_paperHeight(vec2 uv) {
+    float coarse = ajh_fbm5(uv * 5.0);
+    float fiber = ajh_fbm3(vec2(uv.x * 900.0, uv.y * 90.0));
+    float fiber2 = ajh_vnoise(vec2(uv.x * 1550.0, uv.y * 44.0));
+    float h = 0.52 + (fiber - 0.5) * 0.46 + (fiber2 - 0.5) * 0.16 + (coarse - 0.5) * 0.18;
+    return clamp(h, 0.0, 1.0);
+  }
+`;

--- a/apps/landing/src/book/Book.tsx
+++ b/apps/landing/src/book/Book.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+// The notebook assembly around the one live page (PageMesh renders separately at
+// z = 0 as the top page). Book builds the static shell that gives the page a body
+// to sit in:
+//   - a back cover board (kraft board, thicker) behind the stack
+//   - a page-stack block just behind the top page (paper-edge thickness)
+//   - the spiral binding along the top edge: ONE InstancedMesh of a torus ring,
+//     EVERY instance matrix set at init (an unset instance would render white)
+//   - the front cover, hinged about the top binding edge -- page 0's exit. The
+//     composer (the single frame writer) rotates coverRef about x from
+//     channels[0].exitP; this component only exposes the pivot group + geometry.
+//
+// The cover board + page-stack edge use the baked-paper shell materials
+// (bookMaterials): the board reuses the shared kraft bake at low frequency, the
+// stack is a procedural page-layers edge. The spiral binding stays a
+// MeshStandardMaterial (metal), lit by the one scene directional light added in
+// RipbookExperience. Geometry/material for the imperatively-built binding + the
+// two shell materials are disposed on unmount; the JSX primitives rely on R3F's
+// default auto-dispose.
+
+import { type RefObject, useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import {
+  type Group,
+  type InstancedMesh,
+  type Material,
+  Matrix4,
+  MeshStandardMaterial,
+  TorusGeometry,
+} from "three";
+
+import { createBoardMaterial, createStackEdgeMaterial } from "@/book/bookMaterials";
+import { PAGE_H, PAGE_W } from "@/engine/pages";
+
+// Kraft board overhangs the page slightly and is a few mm thick; the stack is a
+// thin block of "pages"; the front cover closes just in front of the top page.
+const BOARD_OVERHANG = 0.12;
+const BOARD_THICK = 0.03;
+const COVER_Z = 0.06;
+const BACK_Z = -0.13;
+const STACK_Z = -0.05;
+const STACK_THICK = 0.08;
+
+// Spiral binding stays a standard metal material (kept per the M2 contract).
+const BINDING_METAL = "#9a9ea6";
+
+const BINDING_COUNT = 18;
+const BINDING_MARGIN_X = 0.16;
+
+// Spiral binding: one InstancedMesh of a small torus ring, laid along the top
+// edge. The torus is rotated so its hole axis runs along x (the binding rod). We
+// set EVERY instance matrix -- a never-set instance would render at the identity
+// (a white ring stacked at the origin), the classic InstancedMesh gotcha.
+function SpiralBinding() {
+  const ref = useRef<InstancedMesh>(null);
+
+  const geo = useMemo(() => {
+    const g = new TorusGeometry(0.055, 0.016, 8, 16);
+    g.rotateY(Math.PI / 2);
+    return g;
+  }, []);
+  const mat = useMemo(
+    () =>
+      new MeshStandardMaterial({
+        color: BINDING_METAL,
+        metalness: 0.85,
+        roughness: 0.4,
+      }),
+    [],
+  );
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const m = new Matrix4();
+    const usableW = PAGE_W - BINDING_MARGIN_X * 2;
+    for (let k = 0; k < BINDING_COUNT; k += 1) {
+      const f = k / (BINDING_COUNT - 1);
+      const x = -usableW / 2 + f * usableW;
+      m.makeTranslation(x, PAGE_H / 2 + 0.02, 0);
+      mesh.setMatrixAt(k, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }, []);
+
+  useEffect(
+    () => () => {
+      geo.dispose();
+      mat.dispose();
+    },
+    [geo, mat],
+  );
+
+  return <instancedMesh ref={ref} args={[geo, mat, BINDING_COUNT]} />;
+}
+
+// Front cover, hinged about the top binding edge. The pivot group sits at the top
+// edge; the board is offset down so it covers the page when closed. rotation.x is
+// written each frame by the composer (channels[0].exitP), so nothing here reads
+// scroll state.
+function FrontCover({
+  coverRef,
+  boardMat,
+}: {
+  coverRef: RefObject<Group | null>;
+  boardMat: Material;
+}) {
+  return (
+    <group ref={coverRef} position={[0, PAGE_H / 2, COVER_Z]}>
+      <mesh position={[0, -PAGE_H / 2, 0]} material={boardMat}>
+        <boxGeometry
+          args={[PAGE_W + BOARD_OVERHANG, PAGE_H + BOARD_OVERHANG, BOARD_THICK]}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+export default function Book({ coverRef }: { coverRef: RefObject<Group | null> }) {
+  // The board (front + back covers) and the page-stack edge are custom baked-
+  // shell materials. Built once, disposed on unmount.
+  const boardMat = useMemo(() => createBoardMaterial(), []);
+  const stackMat = useMemo(() => createStackEdgeMaterial(), []);
+  useEffect(
+    () => () => {
+      boardMat.dispose();
+      stackMat.dispose();
+    },
+    [boardMat, stackMat],
+  );
+
+  return (
+    <group>
+      {/* Back cover board. */}
+      <mesh position={[0, 0, BACK_Z]} material={boardMat}>
+        <boxGeometry
+          args={[PAGE_W + BOARD_OVERHANG, PAGE_H + BOARD_OVERHANG, BOARD_THICK]}
+        />
+      </mesh>
+
+      {/* Page stack behind the top page (paper-edge thickness). */}
+      <mesh position={[0, 0, STACK_Z]} material={stackMat}>
+        <boxGeometry args={[PAGE_W - 0.02, PAGE_H - 0.02, STACK_THICK]} />
+      </mesh>
+
+      <SpiralBinding />
+      <FrontCover coverRef={coverRef} boardMat={boardMat} />
+    </group>
+  );
+}

--- a/apps/landing/src/book/bookMaterials.ts
+++ b/apps/landing/src/book/bookMaterials.ts
@@ -1,0 +1,81 @@
+// The notebook shell materials (cover board + page-stack edge). Both are cheap
+// custom ShaderMaterials lit by the SAME hardcoded key direction as the paper +
+// ink (matching RipbookExperience's directionalLight) so the whole notebook reads
+// under one light without depending on the scene light rig. Output is LINEAR (the
+// composer encodes to sRGB), same convention as RipPaperMaterial. Helpers are
+// ajh_-prefixed; ASCII only.
+//
+//   createBoardMaterial()     -- kraft board for the front + back covers. Reuses
+//     the shared paper bake (bakes.paperAlbedoRough) sampled at LOW frequency for
+//     a coarse board grain, tinted darker toward the kraft-deep board tone.
+//     Uniform: uPaper (paper bake, by reference).
+//   createStackEdgeMaterial() -- the page-stack block edge: a cheap procedural
+//     page-layers stripe + fiber noise in cream. No bake sample.
+//
+// Both dispose with the mesh that owns them (Book wires the cleanup).
+
+import { ShaderMaterial } from "three";
+
+import { bakes } from "@/bake/bakes";
+import { NOISE } from "@/bake/chunks";
+
+const SURFACE_VERT = /* glsl */ `
+  varying vec2 vUv;
+  varying vec3 vWorldN;
+  void main() {
+    vUv = uv;
+    vWorldN = normalize(mat3(modelMatrix) * normal);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+export function createBoardMaterial(): ShaderMaterial {
+  return new ShaderMaterial({
+    name: "CoverBoardMaterial",
+    uniforms: { uPaper: bakes.paperAlbedoRough },
+    vertexShader: SURFACE_VERT,
+    fragmentShader: /* glsl */ `
+      uniform sampler2D uPaper;
+      varying vec2 vUv;
+      varying vec3 vWorldN;
+      ${NOISE}
+      void main() {
+        // Coarse board grain: zoom INTO the paper bake (low frequency) and use
+        // its luminance as a grain scalar over a dark kraft-board tint.
+        float grain = texture2D(uPaper, vUv * 0.35).r;
+        vec3 board = ajh_srgb2lin(vec3(0.42, 0.32, 0.20)); // dark kraft board
+        vec3 col = board * (0.70 + grain * 0.60);
+        vec3 N = normalize(vWorldN);
+        if (!gl_FrontFacing) N = -N;
+        float lam = clamp(dot(N, normalize(vec3(-0.333, 0.667, 0.667))), 0.0, 1.0);
+        col *= 0.50 + 0.50 * lam;
+        gl_FragColor = vec4(col, 1.0);
+      }
+    `,
+  });
+}
+
+export function createStackEdgeMaterial(): ShaderMaterial {
+  return new ShaderMaterial({
+    name: "PageStackMaterial",
+    vertexShader: SURFACE_VERT,
+    fragmentShader: /* glsl */ `
+      varying vec2 vUv;
+      varying vec3 vWorldN;
+      ${NOISE}
+      void main() {
+        // Layered-paper edge: dense horizontal sheet lines + fiber grain, cream.
+        vec3 cream = ajh_srgb2lin(vec3(0.86, 0.80, 0.68));
+        vec3 shade = ajh_srgb2lin(vec3(0.62, 0.55, 0.42));
+        float lines = smoothstep(0.35, 0.50, fract(vUv.y * 140.0));
+        float grain = ajh_vnoise(vUv * vec2(30.0, 220.0));
+        vec3 col = mix(shade, cream, lines * 0.6 + grain * 0.4);
+        vec3 N = normalize(vWorldN);
+        if (!gl_FrontFacing) N = -N;
+        float lam = clamp(dot(N, normalize(vec3(-0.333, 0.667, 0.667))), 0.0, 1.0);
+        col *= 0.55 + 0.45 * lam;
+        gl_FragColor = vec4(col, 1.0);
+      }
+    `,
+  });
+}

--- a/apps/landing/src/desk/Desk.tsx
+++ b/apps/landing/src/desk/Desk.tsx
@@ -25,7 +25,7 @@ import {
   PlaneGeometry,
   RingGeometry,
 } from "three";
-import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
+import { mergeGeometries } from "three/addons/utils/BufferGeometryUtils.js";
 
 import { createDeskMaterial } from "@/desk/deskMaterial";
 

--- a/apps/landing/src/desk/Desk.tsx
+++ b/apps/landing/src/desk/Desk.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// The desk: a large dark surface plane behind the notebook plus procedural
+// dressing (pencil, eraser, two tape bits, a coffee ring) placed OUTSIDE the
+// book's focus area. All the dressing is baked into ONE vertex-coloured merged
+// geometry -> a single draw call; each piece carries its own colour in a per-
+// vertex `color` attribute so the one MeshStandardMaterial can show them all.
+// The desk surface uses a quiet custom felt material (deskMaterial); the dressing
+// keeps its low-contrast vertex-coloured MeshStandardMaterial (the coffee ring
+// becomes a real stain decal later).
+//
+// The merged geometry + its material are built imperatively (they need geometry
+// merging + baked transforms), so they are disposed explicitly on unmount; the
+// desk-surface material is disposed with the plane it drives.
+
+import { useEffect, useMemo } from "react";
+import {
+  BoxGeometry,
+  type BufferGeometry,
+  Color,
+  ConeGeometry,
+  CylinderGeometry,
+  Float32BufferAttribute,
+  MeshStandardMaterial,
+  PlaneGeometry,
+  RingGeometry,
+} from "three";
+import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
+
+import { createDeskMaterial } from "@/desk/deskMaterial";
+
+const SURFACE_Z = -0.3;
+const DRESSING_Z = -0.16;
+
+// sRGB placeholder tones -> linear via three colour management (Color decodes).
+const PENCIL_BODY = "#d8a13a";
+const PENCIL_WOOD = "#b5895a";
+const ERASER_PINK = "#d98fa4";
+const TAPE_GREY = "#c8ccce";
+const COFFEE_BROWN = "#6b4a2c";
+
+// Write one flat colour into a geometry's per-vertex `color` attribute so it
+// survives the merge (mergeGeometries needs matching attributes on every input;
+// the primitives all already carry position/normal/uv).
+function tint(geo: BufferGeometry, hex: string): BufferGeometry {
+  const c = new Color(hex);
+  const n = geo.getAttribute("position").count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i += 1) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute("color", new Float32BufferAttribute(arr, 3));
+  return geo;
+}
+
+// Build every dressing piece, bake its placement into the vertices, tint it, and
+// merge to one geometry. Positions sit off to the sides / bottom, clear of the
+// notebook's centred focus area.
+function buildDressing(): BufferGeometry {
+  const parts: BufferGeometry[] = [];
+
+  // Pencil: a thin cylinder body laid along x with a cone tip. rotateZ(-90) maps
+  // the default +y axis onto +x.
+  const body = new CylinderGeometry(0.03, 0.03, 1.3, 12);
+  body.rotateZ(-Math.PI / 2);
+  body.translate(-1.9, -0.5, DRESSING_Z);
+  parts.push(tint(body, PENCIL_BODY));
+
+  const tip = new ConeGeometry(0.03, 0.18, 12);
+  tip.rotateZ(-Math.PI / 2);
+  tip.translate(-1.9 + 0.65 + 0.09, -0.5, DRESSING_Z);
+  parts.push(tint(tip, PENCIL_WOOD));
+
+  // Eraser: a small box, upper-left.
+  const eraser = new BoxGeometry(0.2, 0.11, 0.11);
+  eraser.rotateZ(0.25);
+  eraser.translate(-1.7, 0.7, DRESSING_Z);
+  parts.push(tint(eraser, ERASER_PINK));
+
+  // Tape bits: two thin quads, right side, slightly rotated.
+  const tapeA = new PlaneGeometry(0.28, 0.18);
+  tapeA.rotateZ(-0.4);
+  tapeA.translate(1.85, 0.5, DRESSING_Z);
+  parts.push(tint(tapeA, TAPE_GREY));
+
+  const tapeB = new PlaneGeometry(0.24, 0.16);
+  tapeB.rotateZ(0.5);
+  tapeB.translate(1.6, 0.1, DRESSING_Z);
+  parts.push(tint(tapeB, TAPE_GREY));
+
+  // Coffee ring: a flat ring quad, lower-right (a stain decal later).
+  const ring = new RingGeometry(0.18, 0.26, 32);
+  ring.translate(1.7, -0.85, DRESSING_Z);
+  parts.push(tint(ring, COFFEE_BROWN));
+
+  const merged = mergeGeometries(parts, false);
+  for (const p of parts) p.dispose();
+  return merged;
+}
+
+function Dressing() {
+  const geo = useMemo(() => buildDressing(), []);
+  const mat = useMemo(
+    () => new MeshStandardMaterial({ vertexColors: true, roughness: 0.9, metalness: 0 }),
+    [],
+  );
+  useEffect(
+    () => () => {
+      geo.dispose();
+      mat.dispose();
+    },
+    [geo, mat],
+  );
+  return <mesh geometry={geo} material={mat} />;
+}
+
+export default function Desk() {
+  const surfaceMat = useMemo(() => createDeskMaterial(), []);
+  useEffect(() => () => surfaceMat.dispose(), [surfaceMat]);
+  return (
+    <group>
+      {/* Quiet felt desk surface behind the notebook. */}
+      <mesh position={[0, 0, SURFACE_Z]} material={surfaceMat}>
+        <planeGeometry args={[24, 24]} />
+      </mesh>
+      <Dressing />
+    </group>
+  );
+}

--- a/apps/landing/src/desk/InkDummy.tsx
+++ b/apps/landing/src/desk/InkDummy.tsx
@@ -15,7 +15,7 @@
 
 import { useEffect, useMemo } from "react";
 import { CapsuleGeometry, SphereGeometry } from "three";
-import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
+import { mergeGeometries } from "three/addons/utils/BufferGeometryUtils.js";
 
 import { createInkMaterial, createInkOutlineMaterial } from "@/ink/InkMaterial";
 

--- a/apps/landing/src/desk/InkDummy.tsx
+++ b/apps/landing/src/desk/InkDummy.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+// The ink test prop: a small sphere-on-capsule knick-knack on the desk edge (dev
+// proving ground for the ink system; harmless to keep as a desk trinket in prod).
+// It exercises the TWO ink material slots end-to-end:
+//   - the ink fill (createInkMaterial) on the model itself, and
+//   - the inverted-hull outline (createInkOutlineMaterial): the SAME geometry,
+//     scaled up slightly, rendered with front faces culled (BackSide) so only a
+//     rim shows behind the fill.
+// The ink fill (createInkMaterial) is a 3-band toon + tri-planar hatch; the
+// outline (createInkOutlineMaterial) shader-extrudes the hull to a screen-
+// constant width in CLIP space, so the outline mesh renders at scale 1 (no CPU
+// hull inflation). The merged geometry + the two materials are disposed on
+// unmount.
+
+import { useEffect, useMemo } from "react";
+import { CapsuleGeometry, SphereGeometry } from "three";
+import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
+
+import { createInkMaterial, createInkOutlineMaterial } from "@/ink/InkMaterial";
+
+// The hull width is shader-driven now (screen-constant clip-space extrusion), so
+// the mesh itself is unscaled.
+const OUTLINE_SCALE = 1.0;
+
+export default function InkDummy() {
+  const geo = useMemo(() => {
+    const head = new SphereGeometry(0.16, 24, 16);
+    head.translate(0, 0.2, 0);
+    const body = new CapsuleGeometry(0.1, 0.24, 8, 16);
+    body.translate(0, -0.08, 0);
+    const merged = mergeGeometries([head, body], false);
+    head.dispose();
+    body.dispose();
+    return merged;
+  }, []);
+
+  const inkMat = useMemo(() => createInkMaterial(), []);
+  const outlineMat = useMemo(() => createInkOutlineMaterial(), []);
+
+  useEffect(
+    () => () => {
+      geo.dispose();
+      inkMat.dispose();
+      outlineMat.dispose();
+    },
+    [geo, inkMat, outlineMat],
+  );
+
+  return (
+    <group position={[1.5, -1.55, -0.12]}>
+      <mesh geometry={geo} material={outlineMat} scale={OUTLINE_SCALE} />
+      <mesh geometry={geo} material={inkMat} />
+    </group>
+  );
+}

--- a/apps/landing/src/desk/deskMaterial.ts
+++ b/apps/landing/src/desk/deskMaterial.ts
@@ -1,0 +1,39 @@
+// The desk surface material: a dark, low-contrast wood/felt (#3E3226) with subtle
+// two-scale variation. It stays QUIET on purpose -- the desk sits behind the
+// notebook and gets tilt-shifted out of focus later, so the material trades any
+// detail for calm. Lit by the same hardcoded key direction as the rest of the
+// notebook; output LINEAR (composer encodes to sRGB). Helpers ajh_-prefixed.
+
+import { ShaderMaterial } from "three";
+
+import { NOISE } from "@/bake/chunks";
+
+export function createDeskMaterial(): ShaderMaterial {
+  return new ShaderMaterial({
+    name: "DeskMaterial",
+    vertexShader: /* glsl */ `
+      varying vec2 vUv;
+      varying vec3 vWorldN;
+      void main() {
+        vUv = uv;
+        vWorldN = normalize(mat3(modelMatrix) * normal);
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: /* glsl */ `
+      varying vec2 vUv;
+      varying vec3 vWorldN;
+      ${NOISE}
+      void main() {
+        vec3 felt = ajh_srgb2lin(vec3(0.243, 0.196, 0.149)); // #3E3226
+        float n = ajh_fbm5(vUv * 40.0) - 0.5;               // coarse mottle
+        float n2 = ajh_vnoise(vUv * 380.0) - 0.5;           // fine felt speckle
+        vec3 col = felt * (1.0 + n * 0.10 + n2 * 0.06);
+        vec3 N = normalize(vWorldN);
+        float lam = clamp(dot(N, normalize(vec3(-0.333, 0.667, 0.667))), 0.0, 1.0);
+        col *= 0.70 + 0.30 * lam; // low contrast, quiet
+        gl_FragColor = vec4(col, 1.0);
+      }
+    `,
+  });
+}

--- a/apps/landing/src/engine/pointer.ts
+++ b/apps/landing/src/engine/pointer.ts
@@ -1,0 +1,22 @@
+// Window-level normalized pointer -- the source for the camera micro-parallax.
+// The Canvas is pointer-events:none (so document scroll stays with Lenis and the
+// future a11y overlay can sit above the canvas without the canvas eating its
+// clicks), which means R3F's own state.pointer never updates. Parallax reads THIS
+// instead, fed by a single window pointermove listener. x/y are NDC-style
+// [-1,1] with y up (matching R3F's pointer convention). One shared mutable
+// object, read once per frame in the composer loop -> no per-frame allocation.
+
+export const pointer = { x: 0, y: 0 };
+
+// Attach the window pointermove listener; returns its own teardown. SSR-safe (no
+// window at module scope; guarded here) and passive (it never preventDefaults, so
+// it can't interfere with scroll or selection).
+export function trackPointer(): () => void {
+  if (typeof window === "undefined") return () => {};
+  const onMove = (e: PointerEvent) => {
+    pointer.x = (e.clientX / window.innerWidth) * 2 - 1;
+    pointer.y = -(e.clientY / window.innerHeight) * 2 + 1;
+  };
+  window.addEventListener("pointermove", onMove, { passive: true });
+  return () => window.removeEventListener("pointermove", onMove);
+}

--- a/apps/landing/src/experience/Composer.tsx
+++ b/apps/landing/src/experience/Composer.tsx
@@ -48,10 +48,13 @@ const THROW = {
 } as const;
 
 // Cover hinge-open (page 0's exit). The front cover pivots about the top binding
-// edge; a positive x-rotation swings it up and back, clearing the page. Driven by
-// channels[0].exitP (pure f(t)) so scrubbing back re-closes it. ~150 deg fully
-// open.
-const HINGE_MAX = 2.6;
+// edge and its board extends toward -y. The board sits just in FRONT of the page
+// (pivot z = +0.06); a NEGATIVE x-rotation lifts the board up and toward the
+// camera (+z), staying clear of the page (z=0) and the stack/back-cover (z<0). A
+// positive rotation would sweep the board backward THROUGH the page + stack.
+// Driven by channels[0].exitP (pure f(t)) so scrubbing back re-closes it. ~150
+// deg fully open.
+const HINGE_MAX = -2.6;
 
 // Tear/throw phasing (both pure f(exitP), so scrubbing back is exact): the
 // shader tear-front (uRipP -> tearP) fully separates the seam by exitP 0.62

--- a/apps/landing/src/experience/Composer.tsx
+++ b/apps/landing/src/experience/Composer.tsx
@@ -19,6 +19,7 @@ import { useFrame, useThree } from "@react-three/fiber";
 
 import { channels } from "@/engine/channels";
 import { CORNER_TEAR_PAGE } from "@/engine/pages";
+import { pointer, trackPointer } from "@/engine/pointer";
 import { resolveTier } from "@/engine/quality";
 import { hudStats } from "@/engine/stats";
 import { uBoil, uResolution, uRipP } from "@/engine/uniforms";
@@ -46,6 +47,12 @@ const THROW = {
   rz: 1.8,
 } as const;
 
+// Cover hinge-open (page 0's exit). The front cover pivots about the top binding
+// edge; a positive x-rotation swings it up and back, clearing the page. Driven by
+// channels[0].exitP (pure f(t)) so scrubbing back re-closes it. ~150 deg fully
+// open.
+const HINGE_MAX = 2.6;
+
 // Tear/throw phasing (both pure f(exitP), so scrubbing back is exact): the
 // shader tear-front (uRipP -> tearP) fully separates the seam by exitP 0.62
 // BEFORE the piece is meaningfully thrown (throwP starts at 0.5), so the free
@@ -56,7 +63,13 @@ function smoothstep(e0: number, e1: number, x: number): number {
   return t * t * (3 - 2 * t);
 }
 
-export function Composer({ freeRef }: { freeRef: RefObject<Group | null> }) {
+export function Composer({
+  freeRef,
+  coverRef,
+}: {
+  freeRef: RefObject<Group | null>;
+  coverRef: RefObject<Group | null>;
+}) {
   const gl = useThree((s) => s.gl);
   const scene = useThree((s) => s.scene);
   const camera = useThree((s) => s.camera);
@@ -89,19 +102,22 @@ export function Composer({ freeRef }: { freeRef: RefObject<Group | null> }) {
   // Release GPU resources when the Canvas unmounts.
   useEffect(() => () => composer.dispose(), [composer]);
 
-  // Warm the page shader programs once, behind the loader, so the first scrub
-  // into the tear has no compile hitch. Fire-and-forget (the material would
-  // compile lazily on first render anyway); swallow rejection so a lost context
-  // never surfaces as a console error.
-  useEffect(() => {
-    void gl.compileAsync(scene, camera).catch(() => {});
-  }, [gl, scene, camera]);
+  // Feed the camera parallax from a window pointermove listener. The Canvas is
+  // pointer-events:none (Lenis keeps document scroll; the a11y overlay will sit
+  // above the canvas), so R3F's state.pointer never updates -- we read the
+  // window-level `pointer` singleton instead.
+  useEffect(() => trackPointer(), []);
+
+  // (Shader warmup moved to the boot sequence in RipbookExperience so it runs
+  // AFTER the bakes and once the full scene has mounted: bakes -> compileAsync ->
+  // onReady.)
 
   useFrame((state, delta) => {
     // (1) Camera micro-parallax around the fixed down-look pose. Time-damped
-    // toward a pointer-driven target; never reads scroll state.
-    const targetX = CAMERA.x + state.pointer.x * PARALLAX;
-    const targetY = CAMERA.y + state.pointer.y * PARALLAX;
+    // toward the window-pointer target (see engine/pointer); never reads scroll
+    // state.
+    const targetX = CAMERA.x + pointer.x * PARALLAX;
+    const targetY = CAMERA.y + pointer.y * PARALLAX;
     camera.position.x = MathUtils.damp(camera.position.x, targetX, CAM_DAMP, delta);
     camera.position.y = MathUtils.damp(camera.position.y, targetY, CAM_DAMP, delta);
     camera.position.z = CAMERA.z;
@@ -121,6 +137,13 @@ export function Composer({ freeRef }: { freeRef: RefObject<Group | null> }) {
       );
       g.rotation.set(THROW.rx * throwP, THROW.ry * throwP, THROW.rz * throwP);
     }
+
+    // (2b) Cover hinge-open, page 0's exit. Pure f(channels[0].exitP) so it
+    // scrubs closed again; eased for a heavier board swing.
+    const coverCh = channels[0];
+    const openP = coverCh ? smoothstep(0, 1, coverCh.exitP) : 0;
+    const cover = coverRef.current;
+    if (cover) cover.rotation.x = HINGE_MAX * openP;
 
     // (3) Stepped boil clock -- single writer.
     uBoil.value = Math.floor(state.clock.elapsedTime * tier.boilHz) / tier.boilHz;

--- a/apps/landing/src/experience/RipbookExperience.tsx
+++ b/apps/landing/src/experience/RipbookExperience.tsx
@@ -1,45 +1,117 @@
 "use client";
 
-// The GL takeover root (M1). Mounts the full-canvas R3F <Canvas> that carries
-// the RIPBOOK notebook on a dark desk: one pre-split kraft page (PageMesh), the
-// composer that owns the sole render loop + camera + uniforms, and the scroll
-// spine (initScroll) that pumps the global t / channels. LoaderLift clears the
-// boot overlay on the first painted GL frame and reports onReady; GLLoader then
-// hides the semantic layer. The dev HUD is a DOM sibling (never over hit
-// targets, pointer-events:none). The canvas is pointer-events:none for M1 --
-// there are no GL-side hit targets yet.
+// The GL takeover root (M2). Mounts the full-canvas R3F <Canvas> carrying the
+// RIPBOOK notebook on a dark desk: the notebook shell (Book), the one live
+// corner-tear page (PageMesh), the desk + dressing (Desk), the ink test prop
+// (InkDummy), the composer that owns the sole render loop + camera + uniforms,
+// and the scroll spine (initScroll).
+//
+// Boot sequencing (Stage): the bake harness runs FIRST behind the loader
+// (bakeAll fills the `bakes` singletons), then the scene mounts with those baked
+// textures, then the shader programs are warmed (compileAsync), and only THEN is
+// onReady reported -- the loader stays up the whole time. The M1 LoaderLift is
+// folded into Stage's priority-2 useFrame so the overlay lifts on the first
+// painted frame after warmup. The canvas is pointer-events:none for M2 -- there
+// are no GL-side hit targets yet.
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Group } from "three";
-import { Canvas, useFrame } from "@react-three/fiber";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
 
+import { bakeAll } from "@/bake/bake";
+import Book from "@/book/Book";
 import PageMesh from "@/book/PageMesh";
 import Hud from "@/debug/Hud";
+import Desk from "@/desk/Desk";
+import InkDummy from "@/desk/InkDummy";
 import { initScroll } from "@/engine/scroll";
 
 import { CAMERA, Composer } from "./Composer";
 
-// One-shot boot-overlay lift + ready signal. Runs at priority 2 -- after
-// Composer's priority-1 composer.render() -- so #loader only fades, and onReady
-// only fires, once GL has actually painted its first frame (no flash of empty
-// canvas). In GL mode the legacy engine (which normally clears the loader) stood
-// down at the gate, so this is the only thing that lifts it. Guarded by a ref so
-// the per-frame DOM lookup runs once. If #loader is missing, still fire onReady
-// or the semantic root would never hide.
-function LoaderLift({ onReady }: { onReady: () => void }) {
-  const done = useRef(false);
+// Everything inside the Canvas. Owns the refs the composer drives (free corner
+// piece + cover hinge), the bake -> compile -> ready sequence, and the loader
+// lift. The composer stays mounted throughout (it owns the render loop); the rest
+// of the scene mounts only once the bakes are in, so no material ever samples a
+// null bake texture.
+function Stage({ onReady }: { onReady: () => void }) {
+  const gl = useThree((s) => s.gl);
+  const scene = useThree((s) => s.scene);
+  const camera = useThree((s) => s.camera);
+
+  const freeRef = useRef<Group>(null);
+  const coverRef = useRef<Group>(null);
+
+  const [baked, setBaked] = useState(false);
+  const [, forwardBakeError] = useState<Error>();
+  const ready = useRef(false);
+  const lifted = useRef(false);
+
+  // (1) Bakes first, behind the loader. bakeAll is synchronous (RT renders) and
+  // idempotent, so a StrictMode double-mount never re-bakes. On success unlock the
+  // scene mount; on failure re-raise DURING RENDER (setState updater that throws)
+  // so GLLoader's ExperienceBoundary catches it -> fallBackToLegacy. An error
+  // thrown in an effect would otherwise escape the boundary and hang the loader.
+  useEffect(() => {
+    try {
+      bakeAll(gl);
+      setBaked(true);
+    } catch (err) {
+      forwardBakeError(() => {
+        throw err instanceof Error ? err : new Error(String(err));
+      });
+    }
+  }, [gl]);
+
+  // (2) Once the scene has mounted with its baked textures, warm the shader
+  // programs so the first scrub has no compile hitch; only then flag ready.
+  // Fire-and-forget with rejection swallowed (a lost context must not surface as
+  // a console error); finally() still flags ready so the loader can never stick.
+  useEffect(() => {
+    if (!baked) return;
+    let cancelled = false;
+    gl.compileAsync(scene, camera)
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) ready.current = true;
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [baked, gl, scene, camera]);
+
+  // (3) Lift the boot overlay + report ready on the first painted frame after
+  // warmup. Priority 2 runs after the composer's priority-1 render, so onReady
+  // only fires once GL has actually painted the full scene.
   useFrame(() => {
-    if (done.current) return;
+    if (lifted.current || !ready.current) return;
     document.getElementById("loader")?.classList.add("gone");
-    done.current = true;
+    lifted.current = true;
     onReady();
   }, 2);
-  return null;
+
+  return (
+    <>
+      {/* One scene directional light (+ ambient) for the placeholder standard
+          materials on the book + desk; the paper + ink materials carry their own
+          light for now. Direction matches the paper shader's upper-front key. */}
+      <ambientLight intensity={0.55} />
+      <directionalLight position={[-3, 5, 4]} intensity={1.5} />
+
+      <Composer freeRef={freeRef} coverRef={coverRef} />
+
+      {baked && (
+        <>
+          <Book coverRef={coverRef} />
+          <PageMesh freeRef={freeRef} />
+          <Desk />
+          <InkDummy />
+        </>
+      )}
+    </>
+  );
 }
 
 export default function RipbookExperience({ onReady }: { onReady: () => void }) {
-  const freeRef = useRef<Group>(null);
-
   // Scroll spine: mounted once, client-only. initScroll returns its own cleanup
   // (kills the ScrollTrigger + master timeline, destroys Lenis, detaches the
   // ticker/listeners), so a StrictMode double-mount tears the first graph down
@@ -70,9 +142,7 @@ export default function RipbookExperience({ onReady }: { onReady: () => void }) 
       >
         {/* Dark kraft desk. */}
         <color attach="background" args={["#141013"]} />
-        <Composer freeRef={freeRef} />
-        <PageMesh freeRef={freeRef} />
-        <LoaderLift onReady={onReady} />
+        <Stage onReady={onReady} />
       </Canvas>
       <Hud />
     </>

--- a/apps/landing/src/experience/RipbookExperience.tsx
+++ b/apps/landing/src/experience/RipbookExperience.tsx
@@ -33,7 +33,13 @@ import { CAMERA, Composer } from "./Composer";
 // lift. The composer stays mounted throughout (it owns the render loop); the rest
 // of the scene mounts only once the bakes are in, so no material ever samples a
 // null bake texture.
-function Stage({ onReady }: { onReady: () => void }) {
+function Stage({
+  onReady,
+  onError,
+}: {
+  onReady: () => void;
+  onError: () => void;
+}) {
   const gl = useThree((s) => s.gl);
   const scene = useThree((s) => s.scene);
   const camera = useThree((s) => s.camera);
@@ -42,42 +48,46 @@ function Stage({ onReady }: { onReady: () => void }) {
   const coverRef = useRef<Group>(null);
 
   const [baked, setBaked] = useState(false);
-  const [, forwardBakeError] = useState<Error>();
   const ready = useRef(false);
   const lifted = useRef(false);
 
   // (1) Bakes first, behind the loader. bakeAll is synchronous (RT renders) and
   // idempotent, so a StrictMode double-mount never re-bakes. On success unlock the
-  // scene mount; on failure re-raise DURING RENDER (setState updater that throws)
-  // so GLLoader's ExperienceBoundary catches it -> fallBackToLegacy. An error
-  // thrown in an effect would otherwise escape the boundary and hang the loader.
+  // scene mount; on failure call onError (a PLAIN function -> GLLoader's
+  // fallBackToLegacy). We deliberately do NOT re-throw to a React boundary: the
+  // bake runs inside the R3F reconciler root, whose errors never cross into the
+  // DOM tree where GLLoader's ExperienceBoundary lives -- a throw here would just
+  // hang the loader. A direct callback is boundary-independent.
   useEffect(() => {
     try {
       bakeAll(gl);
       setBaked(true);
     } catch (err) {
-      forwardBakeError(() => {
-        throw err instanceof Error ? err : new Error(String(err));
-      });
+      console.error("[ripbook] bake failed; falling back to legacy", err);
+      onError();
     }
-  }, [gl]);
+  }, [gl, onError]);
 
   // (2) Once the scene has mounted with its baked textures, warm the shader
-  // programs so the first scrub has no compile hitch; only then flag ready.
-  // Fire-and-forget with rejection swallowed (a lost context must not surface as
-  // a console error); finally() still flags ready so the loader can never stick.
+  // programs so the first scrub has no compile hitch, then flag ready. A failed
+  // warmup means the GL path is broken -> fall back to legacy (via onError)
+  // rather than lifting the loader onto a possibly-black canvas.
   useEffect(() => {
     if (!baked) return;
     let cancelled = false;
     gl.compileAsync(scene, camera)
-      .catch(() => {})
-      .finally(() => {
+      .then(() => {
         if (!cancelled) ready.current = true;
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("[ripbook] shader warmup failed; falling back", err);
+        onError();
       });
     return () => {
       cancelled = true;
     };
-  }, [baked, gl, scene, camera]);
+  }, [baked, gl, scene, camera, onError]);
 
   // (3) Lift the boot overlay + report ready on the first painted frame after
   // warmup. Priority 2 runs after the composer's priority-1 render, so onReady
@@ -111,7 +121,13 @@ function Stage({ onReady }: { onReady: () => void }) {
   );
 }
 
-export default function RipbookExperience({ onReady }: { onReady: () => void }) {
+export default function RipbookExperience({
+  onReady,
+  onError,
+}: {
+  onReady: () => void;
+  onError: () => void;
+}) {
   // Scroll spine: mounted once, client-only. initScroll returns its own cleanup
   // (kills the ScrollTrigger + master timeline, destroys Lenis, detaches the
   // ticker/listeners), so a StrictMode double-mount tears the first graph down
@@ -142,7 +158,7 @@ export default function RipbookExperience({ onReady }: { onReady: () => void }) 
       >
         {/* Dark kraft desk. */}
         <color attach="background" args={["#141013"]} />
-        <Stage onReady={onReady} />
+        <Stage onReady={onReady} onError={onError} />
       </Canvas>
       <Hud />
     </>

--- a/apps/landing/src/ink/InkMaterial.ts
+++ b/apps/landing/src/ink/InkMaterial.ts
@@ -1,0 +1,179 @@
+// The RIPBOOK ink system, proven on the desk ink dummy (desk/InkDummy). Two
+// material slots, both keyed off the shared singleton uniforms BY REFERENCE
+// (uBoil from engine/uniforms drives the hand-drawn boil step; uResolution keeps
+// the OUTLINE screen-constant; uHatch is the baked hatch atlas holder):
+//
+//   createInkMaterial()        -- 3-band toon fill. Two smoothstep thresholds on
+//     a full-lambert N.L (thresholds sit inside the visible N.L range so all three
+//     bands read at the fixed top-down framing) split the surface into band 0 =
+//     bare kraft paper, band 1 = single-direction pencil hatch, band 2 =
+//     cross-hatch (single+cross, visibly denser). The hatch is sampled TRI-PLANAR
+//     in object space (no UVs needed on the merged dummy), distance-compensated to
+//     a screen-stable stroke size (UV scaled by a power-of-two of camera distance
+//     so strokes never swim -- no uResolution needed here), phase-jittered by the
+//     stepped uBoil, with the atlas blue-noise channel (A) multiplied INSIDE
+//     stroke coverage only for a pencil grain.
+//
+//   createInkOutlineMaterial() -- inverted-hull outline. The vertex shader
+//     extrudes along the normal in CLIP space to a screen-constant width
+//     (uWidthPx px, via clip.w / uResolution), with a boil-stepped curl wobble
+//     and a per-vertex pressure width jitter (hash of position + uBoil). Front
+//     faces are culled (BackSide) so only the rim shows behind the fill; flat ink
+//     colour with a slight opacity jitter. Because the width is shader-driven the
+//     dummy no longer needs to scale the hull (OUTLINE_SCALE is back to 1).
+//
+// Everything is pure f(uniforms): all jitter re-seeds from the stepped uBoil, so
+// nothing accumulates time state and the whole prop boils on one step. Ink colour
+// is #17130F on kraft. Helpers are ajh_-prefixed.
+
+import { BackSide, ShaderMaterial } from "three";
+
+import { bakes } from "@/bake/bakes";
+import { NOISE } from "@/bake/chunks";
+import { uBoil, uResolution } from "@/engine/uniforms";
+
+// Outline width in device pixels (webgl-standards: 1.5-3px screen-constant).
+const OUTLINE_WIDTH_PX = 2.2;
+
+export function createInkMaterial(): ShaderMaterial {
+  return new ShaderMaterial({
+    name: "InkMaterial",
+    uniforms: {
+      uBoil,
+      uHatch: bakes.hatch,
+    },
+    vertexShader: /* glsl */ `
+      varying vec3 vObjPos;
+      varying vec3 vObjN;
+      varying vec3 vWorldPos;
+      varying vec3 vWorldN;
+      void main() {
+        vObjPos = position;
+        vObjN = normal;
+        vec4 wp = modelMatrix * vec4(position, 1.0);
+        vWorldPos = wp.xyz;
+        vWorldN = normalize(mat3(modelMatrix) * normal);
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: /* glsl */ `
+      uniform float uBoil;
+      uniform sampler2D uHatch;
+
+      varying vec3 vObjPos;
+      varying vec3 vObjN;
+      varying vec3 vWorldPos;
+      varying vec3 vWorldN;
+
+      ${NOISE}
+
+      const vec3 AJH_LIGHT = vec3(-0.333, 0.667, 0.667);
+      const float AJH_HSCALE = 5.0; // strokes-per-world unit at lod 1
+
+      // Tri-planar hatch lookup. p/n are object-space; comp is the power-of-two
+      // camera-distance step. UV divided by comp -> screen-stable stroke size.
+      // fract() wraps the atlas (RepeatWrapping on the RT would drop the fract,
+      // but fract is safe either way for this small prop).
+      vec4 ajh_triHatch(vec3 p, vec3 n, float comp) {
+        vec3 an = abs(normalize(n));
+        an /= (an.x + an.y + an.z);
+        vec2 j = (vec2(ajh_hash11(uBoil * 13.1), ajh_hash11(uBoil * 7.3 + 2.0)) - 0.5) * 0.18;
+        float s = AJH_HSCALE / comp;
+        vec4 hx = texture2D(uHatch, fract(p.zy * s + j));
+        vec4 hy = texture2D(uHatch, fract(p.xz * s + j));
+        vec4 hz = texture2D(uHatch, fract(p.xy * s + j));
+        return hx * an.x + hy * an.y + hz * an.z;
+      }
+
+      void main() {
+        vec3 N = normalize(vWorldN);
+        vec3 L = normalize(AJH_LIGHT);
+        // Full lambert: the shadowed hemisphere reaches N.L = 0, so band 2 is
+        // reachable at the fixed top-down framing. (Half-lambert compressed the
+        // dark end above the darkest visible pixel, hiding the cross-hatch band.)
+        float ndl = clamp(dot(N, L), 0.0, 1.0);
+
+        float dist = length(cameraPosition - vWorldPos);
+        float comp = exp2(floor(log2(max(dist, 0.001))));
+        vec4 h = ajh_triHatch(vObjPos, vObjN, comp);
+        float blue = h.a;
+
+        // Pencil grain: blue-noise multiplied INSIDE stroke coverage only.
+        float single = h.r * mix(0.55, 1.0, blue);
+        float crossH = h.g * mix(0.55, 1.0, blue);
+
+        // Two smoothstep thresholds -> 3 bands, thresholds inside the visible
+        // N.L range so all three read: band0 bright = bare paper, band1 mid =
+        // single hatch, band2 dark = cross-hatch. band2 adds single+cross so it
+        // is visibly DENSER than band1 (not just the same coverage darker).
+        const float EW = 0.06;
+        float b1 = smoothstep(0.26 - EW, 0.26 + EW, ndl);
+        float b2 = smoothstep(0.56 - EW, 0.56 + EW, ndl);
+        float wDark = 1.0 - b1;
+        float wMid = b1 * (1.0 - b2);
+        float band1Ink = single;
+        float band2Ink = clamp(single + crossH, 0.0, 1.0);
+        float ink = clamp(wMid * band1Ink + wDark * band2Ink, 0.0, 1.0);
+
+        vec3 kraft = ajh_srgb2lin(vec3(0.788, 0.659, 0.463)); // #C9A876
+        vec3 INK = ajh_srgb2lin(vec3(0.090, 0.075, 0.059));   // #17130F
+        vec3 col = mix(kraft, INK, ink);
+        gl_FragColor = vec4(col, 1.0);
+      }
+    `,
+  });
+}
+
+export function createInkOutlineMaterial(): ShaderMaterial {
+  return new ShaderMaterial({
+    name: "InkOutline",
+    side: BackSide, // cull front faces -> only the rim shows behind the fill
+    transparent: true, // slight opacity jitter reads as pen pressure
+    uniforms: {
+      uBoil,
+      uResolution,
+      uWidthPx: { value: OUTLINE_WIDTH_PX },
+    },
+    vertexShader: /* glsl */ `
+      uniform float uBoil;
+      uniform vec2 uResolution;
+      uniform float uWidthPx;
+
+      ${NOISE}
+
+      void main() {
+        // Boil-stepped curl wobble along the normal + a tiny tangential jitter,
+        // re-seeded off the stepped uBoil (never per-frame smooth -> hand-drawn).
+        float wob = ajh_vnoise(position.xy * 7.0 + position.z * 3.0 + uBoil * 3.3) - 0.5;
+        vec2 tj = vec2(
+          ajh_vnoise(position.yz * 6.0 + uBoil * 2.1),
+          ajh_vnoise(position.zx * 6.0 + uBoil * 4.7)
+        ) - 0.5;
+        vec3 pos = position + normal * wob * 0.012 + vec3(tj * 0.006, 0.0);
+
+        // Per-vertex pressure width jitter (hash of position + boil).
+        float pj = 0.7 + 0.6 * ajh_hash11(dot(position, vec3(12.3, 7.7, 3.1)) + uBoil * 5.0);
+
+        vec4 clip = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+        vec3 vN = normalize(normalMatrix * normal);
+        // Guard the clip-space normal: a hull normal pointing down the view axis
+        // projects to ~(0,0) in clip xy, and normalize() of that is NaN. Fall
+        // back to +y so those verts extrude a stable (if arbitrary) direction.
+        vec2 cxy = (projectionMatrix * vec4(vN, 0.0)).xy;
+        float clen = length(cxy);
+        vec2 cN = clen > 1e-4 ? cxy / clen : vec2(0.0, 1.0);
+        clip.xy += cN * uWidthPx * pj * 2.0 / uResolution * clip.w;
+        gl_Position = clip;
+      }
+    `,
+    fragmentShader: /* glsl */ `
+      uniform float uBoil;
+      ${NOISE}
+      void main() {
+        vec3 INK = ajh_srgb2lin(vec3(0.055, 0.050, 0.045));
+        float op = 0.9 + 0.1 * ajh_hash11(uBoil * 3.1);
+        gl_FragColor = vec4(INK, op);
+      }
+    `,
+  });
+}

--- a/apps/landing/src/materials/RipPaperMaterial.ts
+++ b/apps/landing/src/materials/RipPaperMaterial.ts
@@ -186,8 +186,12 @@ const FRAGMENT = /* glsl */ `
     vec4 stB = texture2D(uStain, (cellB + lpB) / 4.0);
     albedo = mix(albedo, stB.rgb, stB.a * 0.06);
 
-    // Graphite smudge: seed-offset density, darkens the paper slightly.
-    float sm = texture2D(uSmudge, rs * vUv * 1.3 + vec2(ajh_hash11(uPageSeed + 2.0), ajh_hash11(uPageSeed + 8.0))).r;
+    // Graphite smudge: seed-offset density, darkens the paper slightly. Wrap the
+    // rotated/offset lookup with fract() (the smear field tiles) so it never
+    // leaves [0,1] into the clamp-to-edge border texels -- which would smear one
+    // edge row across the page. Intensity unchanged; mirrors the hatch path.
+    vec2 smUv = fract(rs * vUv * 1.3 + vec2(ajh_hash11(uPageSeed + 2.0), ajh_hash11(uPageSeed + 8.0)));
+    float sm = texture2D(uSmudge, smUv).r;
     albedo *= 1.0 - sm * 0.10;
 
     // Normal-mapped light catch. Flat page tangent frame: T=+x, B=+y, N=vWorldN

--- a/apps/landing/src/materials/RipPaperMaterial.ts
+++ b/apps/landing/src/materials/RipPaperMaterial.ts
@@ -12,20 +12,34 @@
 // few-mm lift on the held lip). Both key off the same driver: uRipP[uPageIndex]
 // mirrors channels[i].exitP, so gate + throw stay in lockstep.
 //
-// The fragment is a PLACEHOLDER for M2 (the real kraft bake): flat kraft +
-// cheap 3-octave value-noise fiber tint (screen-stable, no external textures),
-// a brighter raw-pulp lightening within the torn-edge band, and a one-light
-// lambert so the peel curl reads in 3D. Helper functions are ajh_-prefixed to
-// avoid colliding with three's injected symbols.
+// The fragment is the M2 page v2: it samples the shared kraft bake
+// (bakes.paperAlbedoRough rgb=linear albedo / a=roughness, bakes.paperNormalHeight
+// rg=tangent normal / b=height), perturbs the geometry normal by the fiber map,
+// lights it with the scene's single directional (the hardcoded AJH_LIGHT, matching
+// RipbookExperience's directionalLight) plus an ambient wrap, adds a roughness-
+// modulated soft sheen, and overlays per-page seeded stains + a graphite smudge
+// (bakes.stain / bakes.smudge) via uPageSeed-driven transforms. The M1 torn-edge
+// raw-pulp band is kept. The bake textures are DATA (NoColorSpace) authored linear,
+// so there is NO sRGB decode on sample. Helpers are ajh_-prefixed.
+//
+// Per-page variation follows the ONE-shared-bake rule: never a per-page bake --
+// the single stain/smudge atlas is transformed per page by uPageSeed here.
 //
 // Uniforms (see also engine/uniforms.ts for the shared singletons):
 //   uBoil       float          -- stepped boil clock; seeds the torn-edge jitter.
 //   uRipP       float[9]       -- per-page rip/exit progress (shared singleton).
 //   uPageIndex  int  [0..8]    -- which page this material renders (const per mat).
 //   uSide       float 0|1      -- 0 = held page, 1 = free corner flap.
+//   uPaper      sampler2D      -- kraft albedo (rgb linear) + roughness (a).
+//   uPaperN     sampler2D      -- tangent normal (rg) + height (b) map.
+//   uStain      sampler2D      -- seeded coffee/ink stain atlas (rgb tint, a cov).
+//   uSmudge     sampler2D      -- seeded graphite smudge (r density).
+//   uPageSeed   float [0,1)    -- per-page seed for the stain/smudge transforms.
 
 import { DoubleSide, ShaderMaterial } from "three";
 
+import { bakes } from "@/bake/bakes";
+import { NOISE } from "@/bake/chunks";
 import { CORNER_TEAR_PAGE } from "@/engine/pages";
 import { uBoil, uRipP } from "@/engine/uniforms";
 
@@ -126,75 +140,91 @@ const VERTEX = /* glsl */ `
 `;
 
 const FRAGMENT = /* glsl */ `
+  uniform sampler2D uPaper;
+  uniform sampler2D uPaperN;
+  uniform sampler2D uStain;
+  uniform sampler2D uSmudge;
+  uniform float uPageSeed;
+
   varying vec2 vUv;
   varying float vSeamDist;
   varying float vEdge;
   varying vec3 vWorldN;
 
-  // Authored in LINEAR space -- there is no texture sample to sRGB-decode here,
-  // and the composer encodes the final output to sRGB, so these are the linear
-  // conversions of the placeholder kraft / raw-pulp tones.
-  const vec3  AJH_KRAFT = vec3(0.565, 0.413, 0.220);  // ~#c6ac81
-  const vec3  AJH_RAW   = vec3(0.720, 0.550, 0.320);  // brighter torn-edge pulp
+  ${NOISE}
+
   const vec3  AJH_LIGHT = vec3(-0.333, 0.667, 0.667); // world light dir (upper-front)
-  const float AJH_AMBIENT = 0.55;
-  const float AJH_FIBER = 0.13;   // fine-fiber tint depth
-  const float AJH_BLOTCH = 0.10;  // coarse tone variation depth
-
-  float ajh_hash21(vec2 p) {
-    p = fract(p * vec2(123.34, 456.21));
-    p += dot(p, p + 45.32);
-    return fract(p.x * p.y);
-  }
-
-  float ajh_vnoise(vec2 p) {
-    vec2 i = floor(p);
-    vec2 f = fract(p);
-    vec2 u = f * f * (3.0 - 2.0 * f);
-    float a = ajh_hash21(i);
-    float b = ajh_hash21(i + vec2(1.0, 0.0));
-    float c = ajh_hash21(i + vec2(0.0, 1.0));
-    float d = ajh_hash21(i + vec2(1.0, 1.0));
-    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
-  }
-
-  float ajh_fbm(vec2 p) {
-    float sum = 0.0;
-    float amp = 0.5;
-    for (int o = 0; o < 3; o++) {
-      sum += amp * ajh_vnoise(p);
-      p *= 2.0;
-      amp *= 0.5;
-    }
-    return sum;
-  }
+  const float AJH_AMBIENT = 0.5;
 
   void main() {
-    // Screen-stable fiber tint from object UVs (fixed per surface point, so it
-    // does not swim as the camera or the flap moves).
-    float fiber = ajh_fbm(vUv * 80.0) - 0.5;
-    float blotch = ajh_fbm(vUv * 4.0) - 0.5;
-    vec3 col = AJH_KRAFT * (1.0 + fiber * AJH_FIBER + blotch * AJH_BLOTCH);
+    // Bake samples are DATA (NoColorSpace) authored LINEAR -> NO sRGB decode.
+    vec4 ar = texture2D(uPaper, vUv);
+    vec3 albedo = ar.rgb;
+    float rough = ar.a;
+    vec2 nxy = texture2D(uPaperN, vUv).rg * 2.0 - 1.0;
+    float nz = sqrt(max(0.0, 1.0 - dot(nxy, nxy)));
 
-    // Brighter raw pulp within the torn-edge band (seam-distance falloff, pinned
-    // bright on the actual snapped edge verts via vEdge).
+    // Torn-edge raw-pulp band (kept from M1): brighter exposed fibers, pinned on
+    // the actual snapped edge verts via vEdge.
     float edge = 1.0 - smoothstep(0.0, 0.04, abs(vSeamDist));
     edge = max(edge, vEdge);
-    col = mix(col, AJH_RAW, edge * 0.6);
+    vec3 raw = ajh_srgb2lin(vec3(0.80, 0.66, 0.44));
+    albedo = mix(albedo, raw, edge * 0.6);
 
-    // One-light lambert so the peel curl reads; double-sided, so flip on back.
-    vec3 nrm = normalize(vWorldN);
-    if (!gl_FrontFacing) nrm = -nrm;
-    float lam = clamp(dot(nrm, normalize(AJH_LIGHT)), 0.0, 1.0);
-    col *= AJH_AMBIENT + (1.0 - AJH_AMBIENT) * lam;
+    // Per-page stains: two taps into the shared stain atlas, each a hashed cell
+    // placed + rotated by uPageSeed (never a per-page bake). Coverage stays low.
+    mat2 rs = ajh_rot(uPageSeed * 6.2831);
+    float idA = floor(ajh_hash11(uPageSeed * 3.1 + 1.0) * 16.0);
+    vec2 cellA = vec2(mod(idA, 4.0), floor(idA / 4.0));
+    vec2 lpA = clamp(rs * (vUv - vec2(0.62, 0.55)) * 1.6 + 0.5, 0.03, 0.97);
+    vec4 stA = texture2D(uStain, (cellA + lpA) / 4.0);
+    albedo = mix(albedo, stA.rgb, stA.a * 0.09);
+
+    float idB = floor(ajh_hash11(uPageSeed * 5.7 + 4.0) * 16.0);
+    vec2 cellB = vec2(mod(idB, 4.0), floor(idB / 4.0));
+    vec2 lpB = clamp(ajh_rot(uPageSeed * 4.0 + 1.0) * (vUv - vec2(0.30, 0.28)) * 1.9 + 0.5, 0.03, 0.97);
+    vec4 stB = texture2D(uStain, (cellB + lpB) / 4.0);
+    albedo = mix(albedo, stB.rgb, stB.a * 0.06);
+
+    // Graphite smudge: seed-offset density, darkens the paper slightly.
+    float sm = texture2D(uSmudge, rs * vUv * 1.3 + vec2(ajh_hash11(uPageSeed + 2.0), ajh_hash11(uPageSeed + 8.0))).r;
+    albedo *= 1.0 - sm * 0.10;
+
+    // Normal-mapped light catch. Flat page tangent frame: T=+x, B=+y, N=vWorldN
+    // (the peel curl already tilts vWorldN); flip on back faces (double-sided).
+    vec3 N = normalize(vWorldN);
+    if (!gl_FrontFacing) N = -N;
+    vec3 T = normalize(vec3(1.0, 0.0, 0.0) - N * N.x);
+    vec3 B = cross(N, T);
+    vec3 Nw = normalize(T * nxy.x + B * nxy.y + N * nz);
+
+    vec3 L = normalize(AJH_LIGHT);
+    float lam = clamp(dot(Nw, L), 0.0, 1.0);
+    float wrap = clamp(dot(Nw, L) * 0.5 + 0.5, 0.0, 1.0); // ambient wrap
+    float diff = mix(wrap, lam, 0.5);
+    vec3 col = albedo * (AJH_AMBIENT + (1.0 - AJH_AMBIENT) * diff);
+
+    // Soft sheen: rougher paper -> softer, weaker highlight. View ~ +z for the
+    // near-flat page (cheap, no camera vector needed).
+    vec3 V = vec3(0.0, 0.0, 1.0);
+    vec3 H = normalize(L + V);
+    float sh = pow(clamp(dot(Nw, H), 0.0, 1.0), mix(40.0, 8.0, rough)) * (1.0 - rough) * 0.18;
+    col += sh;
 
     gl_FragColor = vec4(col, 1.0);
   }
 `;
 
+// Per-page seed for the stain/smudge transforms. A stable golden-ratio hash of
+// the page index so held + free pieces share the same stains and each page reads
+// differently once more pages come online.
+const PAGE_SEED = (CORNER_TEAR_PAGE * 0.61803398875) % 1;
+
 // One program, two instances (held + free) sharing the singleton uniform objects
-// BY REFERENCE -- the composer's single writer updates both for free. uPageIndex
-// and uSide are per-material constants set at creation.
+// BY REFERENCE -- the composer's single writer updates both for free. The bake
+// holders (bakes.*) are likewise shared by reference: they are filled before the
+// scene (hence this material) mounts, so the sampler is never null. uPageIndex,
+// uSide, and uPageSeed are per-material constants set at creation.
 export function createRipPaperMaterial(side: number): ShaderMaterial {
   return new ShaderMaterial({
     name: "RipPaperMaterial",
@@ -204,6 +234,11 @@ export function createRipPaperMaterial(side: number): ShaderMaterial {
       uRipP,
       uPageIndex: { value: CORNER_TEAR_PAGE },
       uSide: { value: side },
+      uPaper: bakes.paperAlbedoRough,
+      uPaperN: bakes.paperNormalHeight,
+      uStain: bakes.stain,
+      uSmudge: bakes.smudge,
+      uPageSeed: { value: PAGE_SEED },
     },
     vertexShader: VERTEX,
     fragmentShader: FRAGMENT,


### PR DESCRIPTION
## What

M2 of the RIPBOOK series (ADR 0015): the paper becomes real.

- **Bake pipeline** (at load, behind the loader): kraft paper albedo+roughness and height-derived normal RTs (4096²/2048² by tier), stain (1024²), smudge (512²), channel-packed hatch (2048²) — domain-rotated fbm (no tiling), ruled lines + editor-red margin, mips + max anisotropy. ONE shared bake; per-page variation via `uPageSeed` transforms. Measured total ~460ms software-render (budget 1500ms). Exception-safe: try/finally + boot fallback to legacy.
- **Page material v2:** consumes the bakes, normal-mapped light catch, seeded stains/smudges at 6-10%; all M1 rip vertex behavior untouched (phased tearP contract).
- **Ink system proven on test geometry:** 3-band toon (bare/hatch/cross-hatch) with object-space tri-planar hatch, distance compensation, blue-noise pencil grain inside strokes, and a screen-constant (~2.2px) inverted-hull outline with curl-noise boil — all stepped off `uBoil`.
- **Notebook + desk:** cover board with hinge-open as page 0's exit (pure f(exitP), scrub-deterministic), page-stack edge, instanced spiral binding (every matrix set), merged procedural desk dressing, quiet desk surface.
- **Pointer parallax** now fed by a window-level pointermove singleton (canvas keeps pointerEvents:none — safe for Lenis and the M6 a11y overlay).

## Fleet review

- **webgl-reviewer: APPROVE — 0 HIGH/CRITICAL** (scrub-safety, lifecycle, allocations, GLSL ES 1.00 correctness, ~199MiB HIGH-tier RT budget math verified acceptable).
- **gate-auditor: full table + delta re-audit all PASS.** Two real bugs caught live and fixed: a GLSL-ES reserved word (`patch`) broke the smudge bake, and pointerEvents:none made the parallax dead code. Fiber tooth resolved at DPR2, zero tiling, smudges/stains visible, 3 toon bands read, boil isolated to ink while camera stays smooth, draw calls flat at 10 (<40), bake ~460ms, fallback matrix intact.

## Validation

typecheck ✓ · build ✓ · 25/25 landing tests ✓ · eslint strict ✓ · prettier ✓ · ASCII ✓ · zero console/shader errors live ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a detailed 3D notebook scene with book covers, page edges, spiral binding, desk accessories, felt surface, and ink styling.
  * Introduced GPU-generated paper, stain, smudge, hatch, and surface textures for richer materials.
  * Added pointer-driven camera parallax and animated cover hinge movement.
  * Improved loading so the experience becomes ready only after textures, shaders, and the first rendered frame are prepared.
* **Visual Improvements**
  * Enhanced kraft paper, torn-page edges, ink shading, outlines, desk materials, and per-page texture variation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->