### PR TITLE
docs: adr-0016 — terminal velocity scroll-film supersedes ripbook

### DIFF
--- a/.claude/skills/webgl-standards/SKILL.md
+++ b/.claude/skills/webgl-standards/SKILL.md
@@ -5,6 +5,17 @@ description: apps/landing WebGL landing conventions + verified version pins the 
 
 # apps/landing WebGL standards (RIPBOOK)
 
+> **⚠ SUPERSEDED CONCEPT - awaits its TERMINAL VELOCITY revision.** RIPBOOK was abandoned
+> mid-M3 (2026-07-18); the landing is now **TERMINAL VELOCITY**, a realistic CG scroll-film
+> (`docs/adr/0016-terminal-velocity-scroll-film-landing.md`). Every RIPBOOK-specific rule below
+>
+> - the 9-page p-space model, the Rip system, `uBoil`/line-boil, in-canvas troika SDF text, the
+>   single ink post chain, and the RIPBOOK budgets - is **superseded by ADR 0016** and no longer
+>   the contract. What still holds: the Next 16 static-export stack, the capability gate + semantic
+>   layer, and the ASCII-only source rule. This skill will be rewritten for TERMINAL VELOCITY
+>   (WebGL2 lane, VAT playback, Gerstner water, godrays, glTF-clip scrub, quality governor) by the
+>   GL authors in a later task; until then treat the numbers here as historical.
+
 The single source both GL authors (`webgl-author`, `shader-engineer`) and their critics
 (`webgl-reviewer`, `gate-auditor`, `webgl-perf-profiler`) read before touching `apps/landing`.
 Architecture rationale: `docs/adr/0014-landing-gl-takeover.md` as amended by

--- a/.claude/skills/webgl-standards/SKILL.md
+++ b/.claude/skills/webgl-standards/SKILL.md
@@ -8,13 +8,12 @@ description: apps/landing WebGL landing conventions + verified version pins the 
 > **⚠ SUPERSEDED CONCEPT - awaits its TERMINAL VELOCITY revision.** RIPBOOK was abandoned
 > mid-M3 (2026-07-18); the landing is now **TERMINAL VELOCITY**, a realistic CG scroll-film
 > (`docs/adr/0016-terminal-velocity-scroll-film-landing.md`). Every RIPBOOK-specific rule below
->
-> - the 9-page p-space model, the Rip system, `uBoil`/line-boil, in-canvas troika SDF text, the
->   single ink post chain, and the RIPBOOK budgets - is **superseded by ADR 0016** and no longer
->   the contract. What still holds: the Next 16 static-export stack, the capability gate + semantic
->   layer, and the ASCII-only source rule. This skill will be rewritten for TERMINAL VELOCITY
->   (WebGL2 lane, VAT playback, Gerstner water, godrays, glTF-clip scrub, quality governor) by the
->   GL authors in a later task; until then treat the numbers here as historical.
+> (the 9-page p-space model, the Rip system, `uBoil`/line-boil, in-canvas troika SDF text, the
+> single ink post chain, and the RIPBOOK budgets) is **superseded by ADR 0016** and no longer
+> the contract. What still holds: the Next 16 static-export stack, the capability gate + semantic
+> layer, and the ASCII-only source rule. This skill will be rewritten for TERMINAL VELOCITY
+> (WebGL2 lane, VAT playback, Gerstner water, godrays, glTF-clip scrub, quality governor) by the
+> GL authors in a later task; until then treat the numbers here as historical.
 
 The single source both GL authors (`webgl-author`, `shader-engineer`) and their critics
 (`webgl-reviewer`, `gate-auditor`, `webgl-perf-profiler`) read before touching `apps/landing`.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -189,9 +189,10 @@ _Avoid_: premium tier, template category
 
 ## Domain - Landing experience
 
-See docs/adr/0014-landing-gl-takeover.md (amended by docs/adr/0015-ripbook-notebook-landing.md,
-the RIPBOOK notebook rebuild) for the full contract and the webgl-standards skill for
-implementation rules; entries below are definitions only.
+See docs/adr/0016-terminal-velocity-scroll-film-landing.md (the active TERMINAL VELOCITY
+scroll-film; supersedes the RIPBOOK rebuild 0015, which superseded parts of the original GL
+takeover 0014) for the full contract and the webgl-standards skill for implementation rules;
+entries below are definitions only. RIPBOOK-era terms are kept below marked _superseded_.
 
 **Semantic layer**:
 The prerendered content HTML that is always in the DOM - what the visitor reads when the GL
@@ -203,54 +204,113 @@ The single capability check that decides whether the GL experience mounts over t
 layer. See the ADR for the exact conditions.
 _Avoid_: scattered feature detection (the decision lives in one gate)
 
-**Journey** (superseded by [ADR 0015](adr/0015-ripbook-notebook-landing.md)):
-Was the 8-Beat scroll-scrubbed camera ride. Retired in the RIPBOOK rebuild - the landing is now
-a 9-**Page** notebook you scroll through and **Rip**. Use Page / Rip / p-space instead.
+**TERMINAL VELOCITY**:
+The active landing concept ([ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)): a
+realistic CG **scroll-film** (~2:40) retelling `landing/index.html`'s story as one continuous
+vertical fall-then-rise, scrolled to watch. Replaces RIPBOOK. The name = the screen (terminal)
+
+- the fall (terminal velocity).
+  _Avoid_: RIPBOOK / notebook (retired), "the landing animation" (it is a directed film, one shot)
+
+**Scroll-film**:
+The form TERMINAL VELOCITY takes: a single continuous camera shot where **scroll is the
+playhead**, fully reversible, with no page/section cuts. Distinct from the retired RIPBOOK
+per-Page notebook model.
+_Avoid_: slideshow, scrollytelling sections (there are no discrete DOM sections driving it - one
+timeline); "video" (it is real-time GL, not a media file)
+
+**Playhead**:
+The film's 0->100% timeline position, mapped 1:1 from native scroll (~2:40 of runtime).
+Reversible - scrolling up rewinds. Interactions never move it (determinism is load-bearing).
+_Avoid_: "scroll progress" used loosely (the playhead is a time axis the whole render is a pure
+function of); global `t` (that was the RIPBOOK scroll variable)
+
+**Scroll map** (the 9 scenes):
+The ordered set of nine scenes the playhead runs through: Cold open, The canyon, The surface
+(splash), The deep, Blackout, The catch, The ascent, Dawn, Finale/credits. See the ADR for
+each scene's range and beat. The TERMINAL VELOCITY analogue of RIPBOOK's 9 Pages, but scenes
+are camera moments in one shot, not discrete rippable pages.
+_Avoid_: Pages (retired), Beats (the older 0014 term), "chapters" when the scene ranges are meant
+
+**Depth gauge**:
+The film's diegetic progress indicator - meters below sea level shown in the chrome. Because the
+whole film is one vertical axis, depth IS progress; paired with the timecode (00:00 -> 02:40).
+Replaces RIPBOOK's Desk-pile odometer.
+_Avoid_: progress bar (there is none - depth + timecode are the only progress UI), Desk pile (retired)
+
+**Letterbox chrome**:
+The cinematic frame drawn over the film: top/bottom bars carrying hand-lettered act titles and
+captions, plus the always-available projector-slate menu chip (download, GitHub, privacy, the
+creature, skip-to-end). The only web chrome besides the timecode + depth gauge.
+_Avoid_: "the nav bar" / "the header" (it is diegetic film framing, not web UI); HUD (that names
+the robot-lens in-world overlay, a different thing)
+
+**Style frames**:
+The nine approved FLUX.2 color-script frames rendered 2026-07-18 - the look-dev ground truth for
+grade, lighting arc, and mood per scene. Stored outside the repo; referenced, never checked in.
+_Avoid_: concept art (broader), storyboard (that is shot blocking, not the color script);
+treating them as shippable assets (they are reference only)
+
+**VAT** (Vertex Animation Texture):
+A baked simulation stored as a texture and played back by sampling at time t (via `three-vat`) -
+used for the splash crown (a Houdini FLIP bake). Scrubbing a VAT is deterministic and reversible
+for free, which is why heavy sims are baked, not run real-time.
+_Avoid_: "the water sim" (the bounded Gerstner water patch is separate and real-time); running
+FLIP live (the crown is pre-baked)
+
+**Quality governor**:
+The runtime tiering system: pick a startup tier (detect-gpu), then a frame-time loop with
+**hysteresis** (downgrade under 45 fps, upgrade over 83 fps, cooldown between) turns knobs in a
+fixed order - pixel ratio, post samples, geometry density, effect toggles. Per-tier ladders live
+in the webgl-standards skill.
+_Avoid_: "auto quality" (the order and hysteresis are deliberate - a bare fps check flip-flops);
+the RIPBOOK boil-tier scheme (retired)
+
+**Journey** (superseded - [ADR 0015](adr/0015-ripbook-notebook-landing.md), then [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)):
+Was the 8-Beat scroll-scrubbed camera ride (0014). Retired. The active landing is the TERMINAL
+VELOCITY **scroll-film** - one continuous shot scrolled as a playhead through 9 **scenes**. Use
+scroll-film / playhead / scene, not Journey (and not the RIPBOOK Page/Rip either).
 _Avoid_: reusing "Journey" for the new model; overloading Autopilot (the app's job-application run)
 
-**Beat** (superseded by [ADR 0015](adr/0015-ripbook-notebook-landing.md)):
-Was one of the 8 places the Journey's camera visited. Replaced by **Page**.
-_Avoid_: reusing "Beat" for a notebook page
+**Beat** (superseded - [ADR 0015](adr/0015-ripbook-notebook-landing.md), then [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)):
+Was one of the 8 places the Journey's camera visited (0014). Retired. The TERMINAL VELOCITY unit
+is a **scene** (one of 9); the intervening RIPBOOK **Page** is also retired.
+_Avoid_: reusing "Beat" for a scene or a page
 
-**Page**:
-One of the 9 notebook pages of the RIPBOOK landing (Cover, Slump, DescentA, DescentB, Fried,
-AreYouSure, Features, Testimonials, Godmode/back cover - see [ADR 0015](adr/0015-ripbook-notebook-landing.md)).
-The unit that replaces a Beat; scrolling plays a Page then runs its **Exit**.
-_Avoid_: Beat (retired), section / panel (those name the semantic-layer DOM, not the 3D page);
-"rippable page" as a synonym for Page (pages 0 and 8 don't rip)
+**Page** (superseded by [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)):
+Was one of the 9 RIPBOOK notebook pages. Retired with the notebook. The TERMINAL VELOCITY unit
+is a **scene** in one continuous shot - see Scroll map. No pages, no per-page Exit.
+_Avoid_: reusing Page for a TERMINAL VELOCITY scene; section / panel (those name the semantic-layer DOM)
 
-**Exit**:
-The animation that plays a Page out as you scroll past it (the trailing slice of the Page's
-scroll). A **Rip** is the usual Exit; page 0's Exit is the cover hinge-open and page 8's Exit is
-the pencil signature + stamp + back-cover close. Pure function of scroll, fully reversible.
-_Avoid_: assuming every Exit is a Rip (two pages exit without a rip)
+**Exit** (superseded by [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)):
+Was the trailing animation that played a RIPBOOK Page out (a Rip, hinge-open, or sign/stamp).
+Retired - the scroll-film has no per-page exits, only continuous camera motion.
+_Avoid_: reusing Exit for TERMINAL VELOCITY scene transitions (there are no cuts)
 
-**Rip**:
-The usual kind of **Exit** - the scrubbed animation that tears / crumples / folds a Page out of
-the notebook (pages 1-7, each with its own style: corner tear, crumple, paper-plane fold, ...).
-Reversible; scroll back and the Page reassembles. The split point lives in webgl-standards.
-_Avoid_: treating Rip as every page's Exit (pages 0/8 hinge-open and sign/stamp instead);
-transition / animation generically
+**Rip** (superseded by [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)):
+Was the usual RIPBOOK Exit - a scrubbed tear/crumple/fold of a Page. Retired with the notebook;
+TERMINAL VELOCITY has no rips.
+_Avoid_: reusing Rip for any TERMINAL VELOCITY motion
 
-**p-space**:
-Page-local progress `p` in `[0,1]` - the active Page's slice of the global scroll `t`, remapped so
-an early range **plays** the Page and the trailing range scrubs its **Exit**. The exact split is a
-webgl-standards constant. Distinct from the global `t`.
-_Avoid_: conflating p-space with global scroll t (t spans all 9 pages; p is within one)
+**p-space** (superseded by [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)):
+Was RIPBOOK's page-local progress `p` (a Page's slice of the global scroll `t`). Retired.
+TERMINAL VELOCITY drives everything off one **playhead** (0->100%), not a per-page remap.
+_Avoid_: reusing `p`/`t` for the playhead; per-scene progress remaps (the film is one timeline)
 
-**Desk pile**:
-The persistent stack of already-exited Pages on the desk - the landing's progress indicator (with
-the odometer). Rendered as one instanced draw revealed by its `.count`.
-_Avoid_: "progress bar" (there is no bar; the pile of pages IS the indicator)
+**Desk pile** (superseded by [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)):
+Was RIPBOOK's stack of exited Pages serving as the progress odometer. Retired. TERMINAL VELOCITY
+shows progress via the **depth gauge + timecode**.
+_Avoid_: reusing Desk pile for any TERMINAL VELOCITY indicator
 
 **Foley**:
-The procedural paper sound effects synthesized in-app - rip, crumple, whoosh, scribble, stamp.
-Distinct from the Gibberish voice.
+The procedural sound effects synthesized in-app, spatialized to the cursor. Under TERMINAL
+VELOCITY these are film-world sounds (paper snap, ripple, servo beep); the RIPBOOK set (rip,
+crumple, scribble, stamp) is retired. Distinct from the Gibberish voice.
 _Avoid_: sound assets / audio files (Foley is synthesized, not sampled)
 
 **Gibberish voice**:
-The ported voice synth that mutters as the protagonist "speaks" - non-lexical, silenced by the
-"mute the guy" toggle.
+The voice synth that mutters as the protagonist "speaks" - non-lexical, silenced by the "mute the
+guy" toggle. Carries over to TERMINAL VELOCITY (e.g. the poke-to-flail yelp with doppler).
 _Avoid_: narration / TTS (it renders no real words)
 
 **Passthrough files**:
@@ -258,9 +318,8 @@ The `landing/` files copied verbatim into the exported site by the postbuild
 merge-passthrough script - source that ships unchanged.
 _Avoid_: "static assets" (too generic; see the ADR for the merge mechanics)
 
-**Line boil**:
-The shader-driven wobble of the ink strokes on a stepped clock (the shared `uBoil` uniform),
-giving the hand-drawn notebook look its core motion while camera/physics stay smooth. See the
-webgl-standards skill for the implementation contract.
-_Avoid_: CPU geometry jitter (Line boil is a vertex-shader effect, not per-frame geometry
-re-jitter); jitter / noise generically
+**Line boil** (superseded by [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)):
+Was the shader-driven wobble of ink strokes (`uBoil`) that gave RIPBOOK its hand-drawn look.
+Retired - TERMINAL VELOCITY is a PBR realistic film, no ink boil. The only "on twos" that
+carries over is character animation stepped at ~12 fps against a smooth 60 fps camera.
+_Avoid_: reusing Line boil / `uBoil` for any TERMINAL VELOCITY effect

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -207,10 +207,9 @@ _Avoid_: scattered feature detection (the decision lives in one gate)
 **TERMINAL VELOCITY**:
 The active landing concept ([ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)): a
 realistic CG **scroll-film** (~2:40) retelling `landing/index.html`'s story as one continuous
-vertical fall-then-rise, scrolled to watch. Replaces RIPBOOK. The name = the screen (terminal)
-
-- the fall (terminal velocity).
-  _Avoid_: RIPBOOK / notebook (retired), "the landing animation" (it is a directed film, one shot)
+vertical fall-then-rise, scrolled to watch. Replaces RIPBOOK. The name plays on two meanings:
+the screen (terminal) and the physics of the fall (terminal velocity).
+_Avoid_: RIPBOOK / notebook (retired), "the landing animation" (it is a directed film, one shot)
 
 **Scroll-film**:
 The form TERMINAL VELOCITY takes: a single continuous camera shot where **scroll is the
@@ -259,11 +258,12 @@ _Avoid_: "the water sim" (the bounded Gerstner water patch is separate and real-
 FLIP live (the crown is pre-baked)
 
 **Quality governor**:
-The runtime tiering system: pick a startup tier (detect-gpu), then a frame-time loop with
-**hysteresis** (downgrade under 45 fps, upgrade over 83 fps, cooldown between) turns knobs in a
-fixed order - pixel ratio, post samples, geometry density, effect toggles. Per-tier ladders live
-in the webgl-standards skill.
-_Avoid_: "auto quality" (the order and hysteresis are deliberate - a bare fps check flip-flops);
+The runtime tiering system (TERMINAL VELOCITY): detect a startup tier at load, then dynamically
+adjust at runtime via a frame-time loop with **hysteresis** - downgrade when performance drops
+below a threshold, upgrade when it recovers above a higher threshold, with a cooldown between
+changes. Turns knobs in a fixed priority order: pixel ratio, post samples, geometry density,
+effect toggles. Thresholds and per-tier ladders are locked in [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md).
+_Avoid_: "auto quality" (the order and hysteresis are deliberate, not a bare fps flip-flop);
 the RIPBOOK boil-tier scheme (retired)
 
 **Journey** (superseded - [ADR 0015](adr/0015-ripbook-notebook-landing.md), then [ADR 0016](adr/0016-terminal-velocity-scroll-film-landing.md)):

--- a/docs/adr/0014-landing-gl-takeover.md
+++ b/docs/adr/0014-landing-gl-takeover.md
@@ -1,17 +1,19 @@
 ---
 status: accepted
-amended-by: 0015
+amended-by: 0016
 ---
 
 # Landing becomes a built GL experience with a semantic fallback
 
-> # ⚠ PARTIALLY HISTORICAL - read [ADR 0015](0015-ripbook-notebook-landing.md) for the active experience contract
+> # ⚠ PARTIALLY HISTORICAL - read [ADR 0016](0016-terminal-velocity-scroll-film-landing.md) for the active experience contract
 >
-> **Amended by ADR 0015 (2026-07-18).** 0015 **supersedes** this ADR's landing _experience_ - the
-> 8-beat scroll-scrubbed camera Journey, the "beat copy in a screen-space DOM overlay" ruling, and
-> the deep-fried Pass B glitch set-piece - with the RIPBOOK notebook (9 rippable pages, all copy as
-> in-canvas SDF text, one always-on post chain). Sections describing those are marked _Historical_
-> below and are NO LONGER the contract.
+> **Amended by ADR 0016 (2026-07-18).** This ADR's landing _experience_ - the 8-beat
+> scroll-scrubbed camera Journey, the "beat copy in a screen-space DOM overlay" ruling, and the
+> deep-fried Pass B glitch set-piece - was first replaced by RIPBOOK
+> ([ADR 0015](0015-ripbook-notebook-landing.md)) and, when RIPBOOK was abandoned mid-M3 the same
+> day, by **TERMINAL VELOCITY** (ADR 0016, a realistic CG scroll-film). ADR 0015 is now itself
+> **superseded**; read 0016 for the live experience contract. Sections describing the original
+> Journey are marked _Historical_ below and are NO LONGER the contract.
 >
 > Everything _structural_ here **still binds (active):** the Next 16 static export, the Semantic
 > layer as the SEO/a11y/scroll-height authority, the single Experience gate, the `landing/`
@@ -71,7 +73,8 @@ still hold._
 
 ## References
 
-- Active experience contract: `docs/adr/0015-ripbook-notebook-landing.md`.
-- Glossary: `docs/CONTEXT.md` (Semantic layer, Experience gate, Passthrough files,
-  Line boil are active; Journey and Beat are superseded by 0015).
+- Active experience contract: `docs/adr/0016-terminal-velocity-scroll-film-landing.md`
+  (RIPBOOK, `docs/adr/0015-ripbook-notebook-landing.md`, is the superseded intermediate).
+- Glossary: `docs/CONTEXT.md` (Semantic layer, Experience gate, Passthrough files are active;
+  Journey, Beat, and the RIPBOOK terms are superseded).
 - App: `apps/landing`; passthrough source: `landing/`; deploy: `.github/workflows/pages.yml`.

--- a/docs/adr/0015-ripbook-notebook-landing.md
+++ b/docs/adr/0015-ripbook-notebook-landing.md
@@ -1,9 +1,21 @@
 ---
-status: accepted
+status: superseded
+superseded-by: 0016
 supersedes-parts-of: 0014
 ---
 
 # Landing rebuilds as RIPBOOK - a full-WebGL kraft notebook that rips out pages
+
+> # ⚠ SUPERSEDED - read [ADR 0016](0016-terminal-velocity-scroll-film-landing.md) for the active landing contract
+>
+> **Superseded by ADR 0016 (2026-07-18).** RIPBOOK was **abandoned mid-M3** the same day it
+> was recorded; the owner replaced it with **TERMINAL VELOCITY**, a realistic CG scroll-film,
+> and `apps/landing` was stripped to a bare Next skeleton (#717). **Nothing in this ADR is the
+> contract anymore** - the 9-page notebook, the Rip/Exit system, the Desk pile, in-canvas
+> troika SDF text, the `p`-space model, and the hand-drawn ink/boil look are all retired. The
+> still-binding machinery this ADR inherited from [ADR 0014](0014-landing-gl-takeover.md) (Next
+> 16 static export, Semantic layer, Experience gate, Passthrough merge, held flip) carries
+> forward under ADR 0016, not here. Kept for history only.
 
 ## Context
 

--- a/docs/adr/0016-terminal-velocity-scroll-film-landing.md
+++ b/docs/adr/0016-terminal-velocity-scroll-film-landing.md
@@ -1,0 +1,207 @@
+---
+status: accepted
+supersedes: 0015
+supersedes-parts-of: 0014
+---
+
+# Landing rebuilds as TERMINAL VELOCITY - a realistic CG scroll-film
+
+## Context
+
+Recorded from the ideation session on 2026-07-18 (owner-approved).
+
+RIPBOOK ([ADR 0015](0015-ripbook-notebook-landing.md)) - the full-WebGL kraft-paper
+notebook - was **abandoned mid-M3** on 2026-07-18. The owner judged the notebook concept
+the wrong vehicle and approved a complete replacement, **TERMINAL VELOCITY**. `apps/landing`
+was stripped back to a bare Next skeleton in #717; RIPBOOK's in-flight M3 branch is dead
+and is **not** a baseline. This is a concept pivot, not a tuning pass - it gets a fresh ADR
+and a stripped app, not an in-place mutation of 0015.
+
+Everything **structural** in [ADR 0014](0014-landing-gl-takeover.md) still constrains this
+rebuild, unchanged: the deploy stays a **Next 16 static export** on GitHub Pages; a
+prerendered **Semantic layer** owns SEO, accessibility, and scroll height and stays fully
+readable/crawlable when WebGL does not run; the single **Experience gate** decides whether GL
+mounts; the `landing/` **Passthrough** merge and the owner-held production flip still apply.
+TERMINAL VELOCITY changes the _experience_, not that machinery - same as RIPBOOK did.
+
+## Decision
+
+The landing becomes **TERMINAL VELOCITY**: a realistic CG **scroll-film** (~2:40) that the
+visitor scrolls to watch. It retells the story of `landing/index.html` (despair -> robot ->
+still unemployed) as one continuous vertical shot - a burned-out job hunter tips off his
+chair at 2:47 AM and falls through a canyon of rejection towers into a paper ocean to the
+lightless bottom, where a small robot finds him and carries him back up to dawn. It does
+everything except press send. Operational constants (spline knots, per-tier ladders, exact
+texture sizes, uniform names, foley params) live in `.claude/skills/webgl-standards/SKILL.md`
+once revised for TERMINAL VELOCITY; this ADR records the decisions, not the tuning numbers.
+
+**One-shot playhead.** Zero cuts: one camera, one continuous vertical world. Scroll IS the
+**playhead**, mapped native-scroll -> timeline 0->100% (~2:40), and **fully reversible** -
+scrolling up rewinds the film at any point. The axis bends back up at the ascent so the same
+water is descended then re-ascended. Interactions perturb particles and play vignettes but
+**never move the playhead** (determinism is load-bearing).
+
+**The 9-scene scroll map** (scene - range - the locked beat):
+
+| #   | Scene          | %      | Locked beat                                                                            |
+| --- | -------------- | ------ | -------------------------------------------------------------------------------------- |
+| 0   | Cold open      | 0-5    | Live monitor (FINAL_v9, 2:47 AM), chair tips past balance, title card, floor dissolves |
+| 1   | The canyon     | 5-30   | Slow-mo backward fall down glowing rejection towers; paper storm thickens              |
+| 2   | The surface    | 30-38  | Hits the paper ocean; the one hard beat - letterbox flexes, sound cuts, splash crown   |
+| 3   | The deep       | 38-52  | Underwater, god-rays thin band by band; he goes limp - the saddest frame               |
+| 4   | Blackout       | 52-58  | Near-total dark, breathing only; a single amber point of light appears below           |
+| 5   | The catch      | 58-64  | A submersible drone catches him gently; the "Are you sure?" HUD gag                    |
+| 6   | The ascent     | 64-85  | Axis inverts; robot carries him up; paper folds into planes in formation; he sleeps    |
+| 7   | Dawn           | 85-95  | Surface break into flat calm at sunrise; first warm full-color frame                   |
+| 8   | Finale/credits | 95-100 | Robot surfaces holding one red SEND button (the CTA); credits roll; creature sting     |
+
+**Chrome.** No web UI. A **letterbox** frame (bars carry hand-lettered act titles/captions),
+a **timecode** (00:00 -> 02:40), and a **depth gauge** (meters below sea level) - the whole
+film is one axis, so depth IS progress. A persistent projector-slate menu chip lives in the
+top bar (download - GitHub - privacy - the creature - skip to end) reachable at any scroll
+position; the cold-open letterbox carries the two legacy early-exit captions.
+
+**Diegetic copy parity.** Every joke and link from `landing/index.html` keeps a home, told
+diegetically (no UI copy): screencap gags -> the cold-open monitor + falling objects; the
+24-board swarm -> tower signage; the ATS robot -> the server floor behind tower glass; the
+LinkedIn feed -> an animated billboard facade; counters -> the elevator indicator (descent)
+
+- robot HUD (ascent); the "Are you sure?" dialog -> the robot lens HUD; testimonials /
+  features / the honest paragraph -> the **end-credits roll as the full footer** (all legacy
+  links, license line, store links, sponsor links, byline, foot-nav). Parity stays enforced
+  by a bidirectional diff against `landing/index.html`, and every one of those links also
+  exists as a real crawlable anchor in the Semantic layer.
+
+**Interactive layer.** A film you can touch, never scrub-hijacking. The cursor is a physical
+**presence** (camera parallax, papers flutter from it, an underwater ripple wake; device tilt
+
+- touch on mobile). Every scene has at least one touchable system plus one hidden discovery
+  (live monitor, poke-to-flail, pluck-and-read a rejection sheet, tower-window vignettes,
+  splash droplet nudge, bioluminescent cursor in the deep, the fake-button HUD, plane
+  barrel-rolls, drag-ripples at dawn, the robot-nods SEND hover). The **SEND button at the
+  finale is the one real action** in the whole film - the product's thesis. Easter eggs are
+  preserved verbatim (konami "OFFER" flip, scroll-too-fast wind roar + protest, mute-the-guy,
+  console greeting).
+
+**Sound arc.** Wind + city hum -> hard silence + sub bass at the splash/deep -> a single warm
+synth at the light -> strings building on the ascent -> morning birds at dawn. Scrubbing fast
+= tape whir; mute drops dialogue to letterbox captions; interactions carry their own foley
+(paper snap, ripple, servo beep) spatialized to the cursor. Audio is a first-class deliverable.
+
+**Renderer: WebGL2 lane for v1.** R3F + three + the pmndrs `postprocessing` composer already
+pinned in this repo, plus `three-good-godrays` (shadow-map raymarched shafts), `three-vat`
+(baked sims), a bounded **Gerstner** water patch, and DataTexture GPGPU - all WebGL2-only and
+all proven. **TSL/WebGPU is a deliberate tier-up experiment, not the base** (it would force
+rebuilding the whole post chain).
+
+**Character + camera = ONE clip.** The protagonist, the robot, and the camera spline are one
+long **Blender glTF** clip driven by `mixer.setTime(duration * progress)` - one source of
+truth, reversible for free. Cross-blend by driving weights manually (never `crossFadeTo`,
+which assumes wall-clock and breaks under scrubbing); feed the scrub from a damped value so
+fast flicks do not pop poses. One master timeline binds camera, baked light state, and shader
+uniforms together so grade and blocking move as one.
+
+**Baked heavy sims, instanced paper.** The **splash crown** is a **Houdini FLIP** sim baked to
+**VAT** (Vertex Animation Texture) and played back via `three-vat` - scrubbing a VAT is just
+sampling a texture at time t: deterministic, reversible, cheap. The **paper storm** is ONE
+`InstancedMesh` (thousands of sheets, one draw call): per-instance phase in a DataTexture,
+bending analytic in the vertex shader, letter text from one atlas; true cloth only for the few
+hero sheets you can pluck and read. The monitor-blue -> dawn-gold lighting arc ships as
+**baked, crossfaded light states** per scroll segment, not dynamic PBR lights.
+
+**Budgets + quality governor.** Locked envelope: **<= 10 MB total shipped** (KTX2/ETC1S
+textures, DRACO/meshopt geometry, procedural gradients over images, **self-hosted decoders**);
+**draw calls < 100 desktop / < 50 mobile**. A **quality governor** picks a startup tier
+(detect-gpu) then runs a runtime frame-time loop with **hysteresis** (downgrade below 45 fps,
+upgrade above 83 fps, cooldown between), turning knobs in order: pixel ratio -> post samples ->
+geometry density -> effect toggles. Per-tier ladders live in the skill.
+
+**Scroll + a11y contract.** **Scrub, never hijack**: no wheel `preventDefault`, no scroll
+snap, no ownership override - native scroll maps 1:1 to the playhead. Page length **~2,000-4,000
+vh**, one idea per scroll step. **Reduced motion** = a chapter-stepped slideshow of stills with
+identical copy and a frozen camera, plus an **in-page motion toggle** (OS preference misses many
+vestibular users). **Photosensitivity (WCAG 2.3.1)**: cap luminance delta **per unit of real
+time, not scroll distance** - fast scrubbing can compress slow fades into >3 Hz flashing; clamp
+velocity through the blackout -> dawn transition. **Mobile**: `svh`/`dvh` or px triggers, never
+`vh`; tap-vs-swipe discrimination; tilt parallax is an opt-in easter egg only; a fixed-camera
+variant below the narrow breakpoint is allowed.
+
+**Loading choreography.** **DOM-first title card** as the LCP anchor (canvas is excluded from
+LCP by spec); GL boots behind it and streams assets by story position (canyon during the title,
+ocean during the fall, robot during the sink - the blackout beat is a free preload window).
+Reserve canvas dimensions for CLS; ship JSON-LD in the Semantic layer.
+
+**Delivery.** PRs land docs -> scaffold -> M1..M6 (below) and merge autonomously through the
+agent fleet; the main session orchestrates only. The **production flip** PR (pages.yml builds
+`apps/landing/out`, deletes only `landing/index.html`) is **opened but held for owner approval**.
+
+## Milestones
+
+RIPBOOK kept its milestone map inline in the ADR; TERMINAL VELOCITY does the same. Six
+milestone PR chains, each closed by `project-steward` (docs/lessons sync + `graphify update .`
+
+- `codegraph sync`). Gate = one line of what must pass before the next milestone opens.
+
+| M   | Scope                                                               | Gate                                                                                     |
+| --- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| M1  | Scroll rig + playhead + Semantic-layer parity                       | Playhead reversible down AND rewind; copy-parity diff clean; a11y fallback whole         |
+| M2  | The canyon + paper storm                                            | One-draw storm within draw-call budget; scrub-deterministic tower vignettes              |
+| M3  | Water surface + splash VAT + deep/blackout                          | VAT scrub deterministic both directions; luminance-delta clamp verified through blackout |
+| M4  | Robot + the catch + ascent + dawn                                   | One glTF clip scrubbed via mixer.setTime, no pose pop on fast flick; ascent reversible   |
+| M5  | Interactive layer + audio                                           | Interactions never move the playhead; foley spatialized; mute/captions parity            |
+| M6  | Chrome + credits + a11y + perf gates + production flip (owner-held) | <= 10 MB / draw-call / fps gates green; strobe + reduced-motion pass; flip PR held       |
+
+## Supersessions
+
+This ADR **fully supersedes ADR 0015 (RIPBOOK)**. Every RIPBOOK-specific ruling dies; the
+0014 machinery restated above carries over. Named so the reader can find what changed:
+
+1. **The 9-page notebook model** (0015 Decision; the "9-page p-space model" of
+   `webgl-standards`). Retired. Replaced by the **9-scene scroll-film** driven by a single
+   playhead - no pages, no per-page `p`-space split.
+2. **The Rip / Exit system** (corner tears, crumples, paper-plane folds, the Desk pile
+   progress indicator). Retired. The film has no rips; progress is the **depth gauge +
+   timecode**.
+3. **All copy as in-canvas troika SDF text.** Retired as a mandate. TERMINAL VELOCITY is
+   realistic CG with diegetic copy in-world; the **Semantic layer** keeps the machine-readable
+   and crawlable copy (0014, still active).
+4. **The hand-drawn ink / boil look** (`uBoil` stepped-boil, cross-hatch, crease lines,
+   Line2 fat-line ink, the kraft-paper bake, animated-on-twos ink). Retired. TERMINAL VELOCITY
+   is a **PBR realistic** look with filmic post; the only "on twos" that carries over is
+   character animation stepped at ~12 fps against a 60 fps camera.
+5. **Procedural-only characters** (no model files). Retired. The cast is now an authored
+   **Blender glTF** clip (see DCC pipeline below).
+
+## Consequences
+
+- **DCC pipeline ownership is a new, honest cost.** The Houdini FLIP bakes, the master Blender
+  glTF clip, and the VAT textures are **authored assets, not agent-generated code** - the
+  repo's GL agents write code, not DCC content. Who bakes them is an open follow-up that must be
+  resolved before M3/M4 can close.
+- **Asset-budget discipline is load-bearing.** The <= 10 MB envelope holds only with KTX2/ETC1S,
+  DRACO/meshopt, atlas discipline, and self-hosted decoders; a single uncompressed hero texture
+  or a CDN-hosted decoder blows it. Gate-enforced.
+- **Scrub determinism is the whole contract.** VAT sampling, `mixer.setTime`, manual weight
+  blends, and one-directional-free reversibility all exist to keep the film a pure function of
+  scroll. Any time-accumulated state or `crossFadeTo` breaks rewind - covered by the gate's
+  down-AND-rewind check.
+- **Budget-Android testing from day one.** fp16 banding and dynamic-PBR cost on Adreno/Mali is
+  where realistic real-time dies; baked light states and a fixed-camera mobile variant are the
+  mitigation, verified on real low-end hardware, not just a desktop throttle.
+- **Reduced-motion / no-WebGL2 / coarse-pointer / narrow visitors never reach any of this**: the
+  Experience gate + Semantic layer of 0014 hold them whole.
+
+## References
+
+- Superseded: `docs/adr/0015-ripbook-notebook-landing.md` (RIPBOOK, fully retired).
+- Still-binding machinery: `docs/adr/0014-landing-gl-takeover.md` (Next 16 static export,
+  Semantic layer, Experience gate, Passthrough files, staged flip).
+- Glossary: `docs/CONTEXT.md` (TERMINAL VELOCITY, scroll-film, playhead, scroll map / scenes,
+  depth gauge, letterbox chrome, style frames, VAT, quality governor; RIPBOOK terms marked
+  superseded).
+- Implementation rules: `.claude/skills/webgl-standards/SKILL.md` (awaits its TERMINAL VELOCITY
+  revision; RIPBOOK constants there are superseded by this ADR). Gate procedures:
+  `.claude/skills/webgl-gate-audit/SKILL.md`.
+- Look-dev ground truth: the 9 approved FLUX.2 style frames (2026-07-18), stored outside the repo.
+- Copy source of truth: `landing/index.html`; app: `apps/landing`; deploy:
+  `.github/workflows/pages.yml`.

--- a/docs/adr/0016-terminal-velocity-scroll-film-landing.md
+++ b/docs/adr/0016-terminal-velocity-scroll-film-landing.md
@@ -64,24 +64,22 @@ position; the cold-open letterbox carries the two legacy early-exit captions.
 **Diegetic copy parity.** Every joke and link from `landing/index.html` keeps a home, told
 diegetically (no UI copy): screencap gags -> the cold-open monitor + falling objects; the
 24-board swarm -> tower signage; the ATS robot -> the server floor behind tower glass; the
-LinkedIn feed -> an animated billboard facade; counters -> the elevator indicator (descent)
-
-- robot HUD (ascent); the "Are you sure?" dialog -> the robot lens HUD; testimonials /
-  features / the honest paragraph -> the **end-credits roll as the full footer** (all legacy
-  links, license line, store links, sponsor links, byline, foot-nav). Parity stays enforced
-  by a bidirectional diff against `landing/index.html`, and every one of those links also
-  exists as a real crawlable anchor in the Semantic layer.
+LinkedIn feed -> an animated billboard facade; counters -> the elevator indicator (descent) +
+robot HUD (ascent); the "Are you sure?" dialog -> the robot lens HUD; testimonials /
+features / the honest paragraph -> the **end-credits roll as the full footer** (all legacy
+links, license line, store links, sponsor links, byline, foot-nav). Parity stays enforced
+by a bidirectional diff against `landing/index.html`, and every one of those links also
+exists as a real crawlable anchor in the Semantic layer.
 
 **Interactive layer.** A film you can touch, never scrub-hijacking. The cursor is a physical
-**presence** (camera parallax, papers flutter from it, an underwater ripple wake; device tilt
-
-- touch on mobile). Every scene has at least one touchable system plus one hidden discovery
-  (live monitor, poke-to-flail, pluck-and-read a rejection sheet, tower-window vignettes,
-  splash droplet nudge, bioluminescent cursor in the deep, the fake-button HUD, plane
-  barrel-rolls, drag-ripples at dawn, the robot-nods SEND hover). The **SEND button at the
-  finale is the one real action** in the whole film - the product's thesis. Easter eggs are
-  preserved verbatim (konami "OFFER" flip, scroll-too-fast wind roar + protest, mute-the-guy,
-  console greeting).
+**presence** (camera parallax, papers flutter from it, an underwater ripple wake; device tilt +
+touch on mobile). Every scene has at least one touchable system plus one hidden discovery
+(live monitor, poke-to-flail, pluck-and-read a rejection sheet, tower-window vignettes,
+splash droplet nudge, bioluminescent cursor in the deep, the fake-button HUD, plane
+barrel-rolls, drag-ripples at dawn, the robot-nods SEND hover). The **SEND button at the
+finale is the one real action** in the whole film - the product's thesis. Easter eggs are
+preserved verbatim (konami "OFFER" flip, scroll-too-fast wind roar + protest, mute-the-guy,
+console greeting).
 
 **Sound arc.** Wind + city hum -> hard silence + sub bass at the splash/deep -> a single warm
 synth at the light -> strings building on the ascent -> morning birds at dawn. Scrubbing fast
@@ -138,9 +136,8 @@ agent fleet; the main session orchestrates only. The **production flip** PR (pag
 ## Milestones
 
 RIPBOOK kept its milestone map inline in the ADR; TERMINAL VELOCITY does the same. Six
-milestone PR chains, each closed by `project-steward` (docs/lessons sync + `graphify update .`
-
-- `codegraph sync`). Gate = one line of what must pass before the next milestone opens.
+milestone PR chains, each closed by `project-steward` (docs/lessons sync + `graphify update .` +
+`codegraph sync`). Gate = one line of what must pass before the next milestone opens.
 
 | M   | Scope                                                               | Gate                                                                                     |
 | --- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## What

Officially pivots the landing from RIPBOOK to **TERMINAL VELOCITY** — the owner-approved realistic CG scroll-film concept (ideation session 2026-07-18).

- **New `docs/adr/0016-terminal-velocity-scroll-film-landing.md`** — the experience contract: one-shot playhead (scroll = timeline 0→100%, ~2:40, fully reversible), the 9-scene scroll map, letterbox/timecode/depth-gauge chrome, diegetic copy parity with `landing/index.html`, interactive layer + easter eggs, WebGL2 lane for v1 (postprocessing + three-good-godrays + three-vat + Gerstner water), one Blender glTF clip scrubbed via `mixer.setTime`, VAT splash crown, one-InstancedMesh paper storm, budget envelope (≤10 MB, <100/<50 draw calls, 45/83 fps governor), scrub-never-hijack, reduced-motion slideshow, WCAG 2.3.1 luminance clamp, M1–M6 milestones with owner-held production flip.
- **ADR-0015** → `status: superseded` + banner; **ADR-0014** pointers re-aimed at 0016 (its structural machinery — static export, semantic layer, experience gate — carries over unchanged).
- **`docs/CONTEXT.md`** — TERMINAL VELOCITY glossary terms added; RIPBOOK terms kept but marked superseded per repo convention.
- **`.claude/skills/webgl-standards/SKILL.md`** — superseded banner only; full rewrite is a flagged follow-up for the GL authors.

## Why

RIPBOOK was abandoned mid-M3; `apps/landing` was already stripped to a bare skeleton in #717. This lands the replacement direction as a first-class decision record before any build work starts (M1 scroll rig is next).

Docs-only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)