### PR TITLE
docs: rewrite webgl-standards and gate-audit skills for terminal velocity

### DIFF
--- a/.claude/skills/webgl-gate-audit/SKILL.md
+++ b/.claude/skills/webgl-gate-audit/SKILL.md
@@ -5,9 +5,13 @@ description: Procedures for auditing apps/landing TERMINAL VELOCITY WebGL phase 
 
 # apps/landing WebGL gate-audit procedures (TERMINAL VELOCITY)
 
-The accessibility tree is blind to a canvas: screenshots, console, and performance traces are the
-ONLY evidence. Never edit code from this skill - it audits rendered output only. Contract + numbers
-live in `.claude/skills/webgl-standards/SKILL.md`; experience decisions in
+The accessibility tree is blind to a canvas, so **GL/canvas output** is judged only via
+screenshots, console, and performance traces - never edit code from this skill, it audits rendered
+output only. **Semantic-layer gates are the exception**: copy parity, real crawlable anchors,
+no-GL fallback rendering, and canvas absence are DOM facts, not pixels, and REQUIRE DOM inspection
+(accessibility snapshot / `eval` querying the DOM / DevTools Elements panel), not screenshots -
+see Copy parity and Reduced-motion + no-GL fallback render below. Contract + numbers live in
+`.claude/skills/webgl-standards/SKILL.md`; experience decisions in
 `docs/adr/0016-terminal-velocity-scroll-film-landing.md`.
 
 ## Driving the page
@@ -15,22 +19,24 @@ live in `.claude/skills/webgl-standards/SKILL.md`; experience decisions in
 Dev server: `pnpm --filter @ajh/landing dev` (http://localhost:3000). The film is canvas-only once
 GL mounts; DOM/accessibility snapshots see nothing but the hidden Semantic layer + a11y overlay.
 
-Scroll = the **playhead** `t` in `[0,1]` over ~3,000 vh. Drive it to a target `T`:
+Scroll = the **playhead** `t` in `[0,1]` over ~3,000 svh (a frozen pixel scroll-track computed once
+at mount, never a live `vh` unit - see `webgl-standards`). Drive it to a target `T`:
 `window.scrollTo(0, (document.documentElement.scrollHeight - innerHeight) * T)`
-then wait ~2 s for Lenis + scrub damping to settle before screenshotting. The **9 scenes** and their
-playhead ranges (scene active when `t` is in range):
+then wait ~2 s for Lenis + scrub damping to settle before screenshotting. The **9 scenes** use
+**half-open playhead ranges** `[lo, hi)` so adjacent scenes never overlap at a shared boundary
+(scene 8 alone is closed at both ends, `[0.95, 1.00]`) - matching `webgl-standards`' scroll map:
 
-| #   | Scene          | `t` range   | sample mid-scene `T` |
-| --- | -------------- | ----------- | -------------------- |
-| 0   | Cold open      | 0.00 - 0.05 | 0.025                |
-| 1   | The canyon     | 0.05 - 0.30 | 0.175                |
-| 2   | The surface    | 0.30 - 0.38 | 0.340 (splash/VAT)   |
-| 3   | The deep       | 0.38 - 0.52 | 0.450                |
-| 4   | Blackout       | 0.52 - 0.58 | 0.550                |
-| 5   | The catch      | 0.58 - 0.64 | 0.610                |
-| 6   | The ascent     | 0.64 - 0.85 | 0.745 (ascent fold)  |
-| 7   | Dawn           | 0.85 - 0.95 | 0.900                |
-| 8   | Finale/credits | 0.95 - 1.00 | 0.975                |
+| #   | Scene          | `t` range    | sample mid-scene `T` |
+| --- | -------------- | ------------ | -------------------- |
+| 0   | Cold open      | [0.00, 0.05) | 0.025                |
+| 1   | The canyon     | [0.05, 0.30) | 0.175                |
+| 2   | The surface    | [0.30, 0.38) | 0.340 (splash/VAT)   |
+| 3   | The deep       | [0.38, 0.52) | 0.450                |
+| 4   | Blackout       | [0.52, 0.58) | 0.550                |
+| 5   | The catch      | [0.58, 0.64) | 0.610                |
+| 6   | The ascent     | [0.64, 0.85) | 0.745 (ascent fold)  |
+| 7   | Dawn           | [0.85, 0.95) | 0.900                |
+| 8   | Finale/credits | [0.95, 1.00] | 0.975                |
 
 Sample mid-scene, not on a range boundary (transition gutters). Confirm the playhead never
 hijacks: no wheel `preventDefault`, no snap, native scroll maps 1:1.
@@ -88,11 +94,21 @@ monotonically climbing count as you scroll means a scene's assets are never disp
 
 ## Bundle-size probe vs 10 MB
 
-Build (`pnpm --filter @ajh/landing build`) and measure the shipped `apps/landing/out` payload -
-total transferred (JS + KTX2 textures + DRACO/meshopt geometry + VAT textures + audio) must be
-**<= 10 MB**. Confirm textures are KTX2/ETC1S, geometry is DRACO or meshopt, and the DRACO/KTX2
-**decoders are self-hosted** (a CDN-hosted decoder or a single uncompressed hero/VAT texture is a
-blocker). Report the byte total and the largest three assets.
+**Accounting (deterministic, reproducible):** the 10 MB budget measures **content-encoded (gzip)
+transfer** - GitHub Pages serves gzip only, no brotli - of the **initial route plus every
+story-streamed asset**, summed from the DevTools **Network log of one full playthrough** (scroll
+the film start to finish once, network throttling off, cache disabled, so every story-position
+asset actually loads). Build first (`pnpm --filter @ajh/landing build`), serve the exported
+`apps/landing/out` directory with a gzip-enabled static file server (measuring against `next dev`
+undercounts - no production minify/compress), then record the trace against that build. Sum the
+transferred-size column (reflects gzip encoding, not the uncompressed `Content-Length`) across
+every request: JS/CSS chunks, KTX2 textures, DRACO/meshopt geometry, VAT textures, audio, and the
+self-hosted DRACO/KTX2 decoder WASM/JS. **Exclude `.map` source-map requests** (dev-only, never
+fetched by real users at this cost); **include** the self-hosted decoders (a CDN-hosted decoder is
+a separate blocker, see below, but if self-hosted it still counts against the budget). Total must
+be **<= 10 MB**. Confirm textures are KTX2/ETC1S, geometry is DRACO or meshopt, and the DRACO/KTX2
+**decoders are self-hosted** (a CDN-hosted decoder is a blocker). Report the byte total and the
+largest three assets.
 
 ## Luminance-delta / strobe check (blackout -> dawn at max scrub velocity)
 
@@ -115,11 +131,19 @@ crawlable anchor in the Semantic layer. Any missing, extra, or reworded line fai
   slideshow / prerendered Semantic HTML with identical copy and GL must NOT mount (no canvas). Also
   verify the **in-page motion toggle** produces the same stepped-slideshow fallback.
 - Verify each Experience-gate condition independently falls back to the Semantic page with NO
-  canvas: sub-threshold viewport (narrow), coarse pointer, and WebGL2 unavailable. Force WebGL2
-  failure via `mcp__chrome-devtools__navigate_page` `initScript` stubbing
-  `HTMLCanvasElement.prototype.getContext` to return null for `webgl2`, then reload (fallback: a CDP
-  `Page.addScriptToEvaluateOnNewDocument` call). Same bar for every condition: Semantic page
-  renders, no canvas mounts, all links + the CTA remain real anchors, scroll height intact.
+  canvas, via DOM inspection (accessibility snapshot / `eval` querying `document.querySelector`
+  for a `<canvas>`), not a screenshot:
+  - **Narrow viewport**: resize/emulate to CSS width **<= 900px** - the gate's authoritative
+    breakpoint (`webgl-standards`' Experience gate: width > 900px required to mount GL).
+  - **Coarse pointer**: DevTools device-toolbar touch-device emulation, or the CDP call
+    `Emulation.setEmulatedMedia({ features: [{ name: 'pointer', value: 'coarse' }] })`.
+  - **WebGL2 unavailable**: force context creation to fail via
+    `mcp__chrome-devtools__navigate_page`'s `initScript` param, stubbing
+    `HTMLCanvasElement.prototype.getContext` to return null for `webgl2`, then reload (fallback: a
+    CDP `Page.addScriptToEvaluateOnNewDocument` call).
+
+  Same bar for every condition above: Semantic page renders, no `<canvas>` element exists in the
+  DOM, all links + the CTA remain real anchors, scroll height intact.
 
 ## Report
 

--- a/.claude/skills/webgl-gate-audit/SKILL.md
+++ b/.claude/skills/webgl-gate-audit/SKILL.md
@@ -1,97 +1,128 @@
 ---
 name: webgl-gate-audit
-description: Procedures for auditing apps/landing RIPBOOK WebGL phase gates - driving the browser to exact t positions across the 9 pages, screenshot discipline, FPS sampling, scrub + rip-reversal determinism, draw-call probing, strobe budget, copy-parity, and reduced-motion verification. Load when running /gate or reviewing rendered GL output.
+description: Procedures for auditing apps/landing TERMINAL VELOCITY WebGL phase gates - driving the browser to exact playhead positions across the 9 scenes, screenshot discipline, scrub + VAT determinism (scrub down THEN rewind to the same playhead -> identical frame), FPS sampling at the risk scenes, draw-call + bundle-size probes vs budget, the blackout->dawn luminance-delta/strobe check at max scrub velocity, copy-parity vs landing/index.html, and reduced-motion + no-GL fallback verification. Load when running /gate or reviewing rendered GL output.
 ---
 
-# apps/landing WebGL gate-audit procedures
+# apps/landing WebGL gate-audit procedures (TERMINAL VELOCITY)
 
 The accessibility tree is blind to a canvas: screenshots, console, and performance traces are the
-ONLY evidence. Never edit code from this skill -- it audits rendered output only.
+ONLY evidence. Never edit code from this skill - it audits rendered output only. Contract + numbers
+live in `.claude/skills/webgl-standards/SKILL.md`; experience decisions in
+`docs/adr/0016-terminal-velocity-scroll-film-landing.md`.
 
 ## Driving the page
 
-Dev server: `pnpm --filter @ajh/landing dev` (http://localhost:3000). The experience is
-canvas-only once GL mounts; DOM/accessibility snapshots see nothing.
+Dev server: `pnpm --filter @ajh/landing dev` (http://localhost:3000). The film is canvas-only once
+GL mounts; DOM/accessibility snapshots see nothing but the hidden Semantic layer + a11y overlay.
 
-Scroll to a global t in [0,1]:
+Scroll = the **playhead** `t` in `[0,1]` over ~3,000 vh. Drive it to a target `T`:
 `window.scrollTo(0, (document.documentElement.scrollHeight - innerHeight) * T)`
-then wait ~2s for Lenis to settle before screenshotting. There are **9 pages**; page `i` is
-active for `t` in `[i/9, (i+1)/9]`, in order: 0 Cover (hinge-open), 1 Slump (corner tear),
-2 DescentA (horizontal mid-rip), 3 DescentB (vertical tear), 4 Fried (crumple + toss),
-5 AreYouSure (folds to a paper plane), 6 Features (diagonal tear), 7 Testimonials (perforation
-zip), 8 Godmode -> back cover (signature + stamp, no rip). Within a page, `p` in `[0,0.72]`
-**plays** and `p` in `[0.72,1]` **scrubs the rip**. To sample a page mid-play use
-`t = i/9 + 0.4/9`; to sample its rip use `t = i/9 + 0.85/9`. Avoid exact `i/9` boundaries
-(transition gutters).
+then wait ~2 s for Lenis + scrub damping to settle before screenshotting. The **9 scenes** and their
+playhead ranges (scene active when `t` is in range):
+
+| #   | Scene          | `t` range   | sample mid-scene `T` |
+| --- | -------------- | ----------- | -------------------- |
+| 0   | Cold open      | 0.00 - 0.05 | 0.025                |
+| 1   | The canyon     | 0.05 - 0.30 | 0.175                |
+| 2   | The surface    | 0.30 - 0.38 | 0.340 (splash/VAT)   |
+| 3   | The deep       | 0.38 - 0.52 | 0.450                |
+| 4   | Blackout       | 0.52 - 0.58 | 0.550                |
+| 5   | The catch      | 0.58 - 0.64 | 0.610                |
+| 6   | The ascent     | 0.64 - 0.85 | 0.745 (ascent fold)  |
+| 7   | Dawn           | 0.85 - 0.95 | 0.900                |
+| 8   | Finale/credits | 0.95 - 1.00 | 0.975                |
+
+Sample mid-scene, not on a range boundary (transition gutters). Confirm the playhead never
+hijacks: no wheel `preventDefault`, no snap, native scroll maps 1:1.
 
 ## Tools
 
-Preferred: Chrome DevTools MCP (mcp__chrome-devtools) -- performance traces, CPU/network
+Preferred: Chrome DevTools MCP (`mcp__chrome-devtools`) - performance traces, CPU/network
 throttling, console with stack traces, screenshots. Fallback if the DevTools MCP is unavailable:
-the `agent-browser` CLI (`agent-browser open <url>`, `eval "<js>"`, `screenshot <path>`,
-`console`) plus rAF-counter FPS sampling; mark those checks self-reported. Screenshots stay in the
-audit context -- report only pass/fail + evidence lines, never raw images.
+the `agent-browser` CLI (`agent-browser open <url>`, `eval "<js>"`, `screenshot <path>`, `console`)
+plus rAF-counter FPS sampling; mark those checks self-reported. Screenshots stay in the audit
+context - report only pass/fail + evidence lines, never raw images.
 
-## FPS
+## Scrub determinism (the core gate)
 
-DevTools MCP: record a trace while scrolling a segment; read the FPS track. Fallback rAF sampler
-(~2s, scroll during it):
+Everything is a pure `f(t)`, so a given playhead must produce ONE frame regardless of direction.
+Pick a `T` inside a scene (not a boundary). Approach it **from below** (scroll to `T-0.02`, settle,
+then `T`) and **from above** (scroll to `T+0.02`, settle, then `T`); screenshot both. The frames
+MUST match - identical camera pose, character pose, light/grade state, post state. Run it on a
+motion-heavy scene (the canyon fall) AND a light-transition scene (the deep). Any drift = a
+time-accumulated state or a `crossFadeTo` leaked in = HIGH failure.
+
+## Down-AND-rewind determinism
+
+Scroll **forward through** a scene into the next, then **back** to the earlier `T`; after settle the
+frame must match the first pass exactly - no leftover pose, no half-played VAT, no stuck light
+state, no doubled particles. The film is reversible end to end; a scene that stays "played" on
+scroll-back is a HIGH failure. Exercise it across scene 2->3 (surface into deep) and scene 6->7
+(ascent into dawn - the axis inverts here, highest risk).
+
+## VAT scrub determinism (scene 2 splash)
+
+At the splash (`T ~= 0.34`), the crown is a VAT played by sampling at time t. Approach `T` from
+below and from above (as in scrub determinism) AND forward-then-rewind: the crown geometry MUST be
+frame-identical each time (VAT sampling is deterministic; inter-frame interpolation must be
+symmetric). A crown that differs by approach direction, or that "sticks" at its peak on rewind,
+means the VAT time is not pure `f(t)` = HIGH failure.
+
+## FPS sampling (risk scenes first)
+
+Sample the two heaviest scenes explicitly: the **splash/VAT** (scene 2, `T~=0.34`) and the **ascent
+fold** (scene 6, `T~=0.745`, paper-planes-in-formation); then spot-check the canyon storm (scene 1).
+DevTools MCP: record a trace while scrubbing the segment, read the FPS track. Fallback rAF sampler
+(~2 s, scrub during it):
 `new Promise(res => { let f=0; const t0=performance.now(); const loop=()=>{f++; performance.now()-t0<2000 ? requestAnimationFrame(loop) : res(Math.round(f/2));}; requestAnimationFrame(loop); })`
-LOW tier: CPU-throttle 4x (DevTools) and re-measure.
+The governor should hold the tier steady above 45 fps (its downgrade floor); a scene that sits below
+45 fps without the governor stepping down a rung is a failure. LOW tier: CPU-throttle 4x (DevTools)
+and re-measure; also verify on real budget-Android where possible (fp16 banding / PBR cost).
 
-## Scrub determinism
+## Draw-call probe vs budget
 
-Pick a t inside a page (not a boundary). Approach it from below (scroll to t-0.03, then t) and from
-above (t+0.03, then t); screenshot both after settle. The frames MUST match -- same camera pose,
-same stroke draw-on state, same post state. Test one **play** region (a normal page, `p<0.72`) and
-one **exit** region (`p>0.72`) -- a rip page (e.g. Fried crumple) AND a non-rip exit (page 0 cover
-hinge-open, page 8 signature + stamp + back-cover close), since those exits are not rips.
+At each sampled scene read `renderer.info.render.calls` (expose it, or read via the R3F store in an
+`eval`): **< 100 on desktop, < 50 on mobile** at every `t`. Confirm the paper storm stays ONE draw
+call (a call count that scales with sheet count means the InstancedMesh path regressed). A
+monotonically climbing count as you scroll means a scene's assets are never disposed.
 
-## Exit-reversal determinism
+## Bundle-size probe vs 10 MB
 
-Scroll **into** a page's exit (`t = i/9 + 0.85/9`, so `p>0.72`) then back **below** 0.72
-(`t = i/9 + 0.4/9`); after settle the page must **fully reassemble** -- no torn/missing geometry,
-no leftover crumple/fold, and the Desk pile `.count` must not double-count the page. Run it on a
-rip page AND on page 0 (hinge must re-close) and page 8 (signature/stamp must clear). Reversibility
-is the core contract (the rig is pure `f(t)`); a page that stays exited on scroll-back is a HIGH
-failure.
+Build (`pnpm --filter @ajh/landing build`) and measure the shipped `apps/landing/out` payload -
+total transferred (JS + KTX2 textures + DRACO/meshopt geometry + VAT textures + audio) must be
+**<= 10 MB**. Confirm textures are KTX2/ETC1S, geometry is DRACO or meshopt, and the DRACO/KTX2
+**decoders are self-hosted** (a CDN-hosted decoder or a single uncompressed hero/VAT texture is a
+blocker). Report the byte total and the largest three assets.
 
-## Draw-call probe
+## Luminance-delta / strobe check (blackout -> dawn at max scrub velocity)
 
-At each sampled page read `renderer.info.render.calls` (expose it, or read via the R3F store in an
-`eval`): it must stay **< 120** at every t. Also confirm **visibility scoping** -- only the active
-page +/-1 is mounted; distant pages are disposed (a monotonically climbing call count as you scroll
-means a page is never disposed).
+The photosensitivity risk is fast scrubbing compressing a slow fade into flashing. Scrub the
+blackout -> catch -> ascent -> dawn span (scenes 4-7) as FAST as the input allows and confirm the
+luminance-delta clamp holds: **no more than 3 full-frame luminance flashes in any rolling second**
+(frame-by-frame trace screenshots, or a flash-budget console counter if exposed). Also confirm zero
+THREE/WebGL console errors at any `t`. A fade that strobes only under fast scrub = HIGH failure
+(the velocity clamp is missing).
 
-## Strobe budget
+## Copy parity
 
-Zero THREE/WebGL console errors are allowed at any t. Generic strobe guard (the post chain never
-toggles now, so this is content-agnostic): across **any** page -- including the Fried crumple and
-the AreYouSure paper-plane fold -- confirm no more than 3 full-frame flashes in any rolling second
-(frame-by-frame trace screenshots, or a flash-budget console counter if exposed).
+Run the bidirectional copy-diff against `landing/index.html`. Every joke and link must keep a home:
+the diegetic in-world copy (monitor gags, tower signage, HUD, end-credits footer) AND a real
+crawlable anchor in the Semantic layer. Any missing, extra, or reworded line fails the gate.
 
-## Copy parity (gate step from M3)
+## Reduced-motion + no-GL fallback render
 
-Run the bidirectional copy-diff script against `landing/index.html`. Every visible line of GL SDF
-copy must match the semantic source 1:1; any diff (missing, extra, or reworded line) fails the gate.
-
-## Reduced-motion + gate
-
-Emulate `prefers-reduced-motion: reduce` (DevTools emulation): the page MUST render the prerendered
-semantic HTML and GL must NOT mount -- no canvas at all. Likewise verify a sub-threshold viewport
-(width <= 900), a coarse pointer, and a WebGL2-unavailable context each fall back to the legacy
-semantic page with no canvas (same bar for every gate condition).
-
-## WebGL2 unavailable
-
-Force context creation to fail with Chrome DevTools MCP: `mcp__chrome-devtools__navigate_page`'s
-`initScript` param, stubbing `HTMLCanvasElement.prototype.getContext` to return null for `webgl2`,
-then navigate/reload. Fallback (no DevTools MCP): a browser launch flag or equivalent CDP
-`Page.addScriptToEvaluateOnNewDocument` call. The semantic page MUST still render and no canvas
-may mount, same bar as the reduced-motion/narrow/coarse fallbacks above.
+- Emulate `prefers-reduced-motion: reduce` (DevTools): the page MUST render the chapter-stepped
+  slideshow / prerendered Semantic HTML with identical copy and GL must NOT mount (no canvas). Also
+  verify the **in-page motion toggle** produces the same stepped-slideshow fallback.
+- Verify each Experience-gate condition independently falls back to the Semantic page with NO
+  canvas: sub-threshold viewport (narrow), coarse pointer, and WebGL2 unavailable. Force WebGL2
+  failure via `mcp__chrome-devtools__navigate_page` `initScript` stubbing
+  `HTMLCanvasElement.prototype.getContext` to return null for `webgl2`, then reload (fallback: a CDP
+  `Page.addScriptToEvaluateOnNewDocument` call). Same bar for every condition: Semantic page
+  renders, no canvas mounts, all links + the CTA remain real anchors, scroll height intact.
 
 ## Report
 
 One pass/fail table row per gate check with a one-line evidence note. Numbers, not adjectives
-(measured FPS, t positions compared, console error count). Screenshots never leave the audit
-context.
+(measured FPS, `t` positions compared, draw-call count, byte total, console error count).
+Screenshots never leave the audit context.

--- a/.claude/skills/webgl-standards/SKILL.md
+++ b/.claude/skills/webgl-standards/SKILL.md
@@ -83,36 +83,42 @@ with `npm view <pkg> version` / `... peerDependencies`; the lockfile must match 
 ## The playhead model
 
 Scroll = a single global **playhead** `t` in `[0,1]`, mapped 1:1 from native scroll over a total
-page length of **3,000 vh** (_tunable_, ADR envelope 2,000-4,000 vh; use `svh`/`dvh` or px
-triggers, never `vh`). One idea per scroll step. Everything scroll-driven is a **pure function of
-`t`**, scrub-safe both directions - no time-accumulated state driving scroll visuals.
+page length of **3,000 svh** (_tunable_, ADR envelope 2,000-4,000 svh) - a `100vh`-equivalent
+computed ONCE at mount from `window.visualViewport?.height ?? window.innerHeight` and **frozen**
+into a fixed pixel scroll-track height for the session (never a live `vh` unit, which reflows on
+mobile browser chrome show/hide and would move the playhead under the user's finger). One idea per
+scroll step. Everything scroll-driven is a **pure function of `t`**, scrub-safe both directions -
+no time-accumulated state driving scroll visuals.
 
-**Scrub smoothing:** damp the raw playhead with a scrub factor of **0.6** (_tunable_, ADR range
-0.5-1) plus Lenis lerp; **both smoothings are DISABLED under reduced motion / the in-page motion
-toggle** (the reduced-motion path is a chapter-stepped slideshow, not a damped scrub).
+**Scrub smoothing:** damp the raw playhead with a scrub factor of **0.6** (_skill-owned starting
+value, tunable in the 0.5-1 band - not an ADR figure) plus Lenis lerp; **both smoothings are
+DISABLED under reduced motion / the in-page motion toggle** (the reduced-motion path is a
+chapter-stepped slideshow, not a damped scrub).
 
 **Scrub-never-hijack:** no wheel `preventDefault`, no scroll snap, no scroll-ownership override.
 Native scroll maps straight to the playhead. Interactions perturb particles / play vignettes but
 **never move the playhead** (determinism is load-bearing).
 
-**The 9-scene scroll map** (playhead range copied from ADR 0016; scene `i` active when `t` is in
-its range):
+**The 9-scene scroll map** expands ADR 0016's approximate `%` ranges into **half-open intervals**
+`[lo, hi)` (skill-owned precision refinement) so adjacent scenes never overlap at a shared
+boundary; only the final scene is closed at both ends. Scene `i` is active when `t` is in
+`[lo_i, hi_i)` (`[0.95, 1.00]` for scene 8):
 
 | #   | Scene          | playhead `t` | Locked beat                                                                            |
 | --- | -------------- | ------------ | -------------------------------------------------------------------------------------- |
-| 0   | Cold open      | 0.00 - 0.05  | Live monitor (FINAL_v9, 2:47 AM), chair tips past balance, title card, floor dissolves |
-| 1   | The canyon     | 0.05 - 0.30  | Slow-mo backward fall down glowing rejection towers; paper storm thickens              |
-| 2   | The surface    | 0.30 - 0.38  | Hits the paper ocean; the one hard beat - letterbox flexes, sound cuts, splash crown   |
-| 3   | The deep       | 0.38 - 0.52  | Underwater, god-rays thin band by band; he goes limp - the saddest frame               |
-| 4   | Blackout       | 0.52 - 0.58  | Near-total dark, breathing only; a single amber point of light appears below           |
-| 5   | The catch      | 0.58 - 0.64  | A submersible drone catches him gently; the "Are you sure?" HUD gag                    |
-| 6   | The ascent     | 0.64 - 0.85  | Axis inverts; robot carries him up; paper folds into planes in formation; he sleeps    |
-| 7   | Dawn           | 0.85 - 0.95  | Surface break into flat calm at sunrise; first warm full-color frame                   |
-| 8   | Finale/credits | 0.95 - 1.00  | Robot surfaces holding one red SEND button (the CTA); credits roll; creature sting     |
+| 0   | Cold open      | [0.00, 0.05) | Live monitor (FINAL_v9, 2:47 AM), chair tips past balance, title card, floor dissolves |
+| 1   | The canyon     | [0.05, 0.30) | Slow-mo backward fall down glowing rejection towers; paper storm thickens              |
+| 2   | The surface    | [0.30, 0.38) | Hits the paper ocean; the one hard beat - letterbox flexes, sound cuts, splash crown   |
+| 3   | The deep       | [0.38, 0.52) | Underwater, god-rays thin band by band; he goes limp - the saddest frame               |
+| 4   | Blackout       | [0.52, 0.58) | Near-total dark, breathing only; a single amber point of light appears below           |
+| 5   | The catch      | [0.58, 0.64) | A submersible drone catches him gently; the "Are you sure?" HUD gag                    |
+| 6   | The ascent     | [0.64, 0.85) | Axis inverts; robot carries him up; paper folds into planes in formation; he sleeps    |
+| 7   | Dawn           | [0.85, 0.95) | Surface break into flat calm at sunrise; first warm full-color frame                   |
+| 8   | Finale/credits | [0.95, 1.00] | Robot surfaces holding one red SEND button (the CTA); credits roll; creature sting     |
 
-Per-scene local progress `sp` = `(t - lo) / (hi - lo)` clamped to `[0,1]`; scenes map their own
-sub-beats off `sp`, never off wall-clock. The axis bends back up at the ascent so the SAME water is
-descended (scene 3) then re-ascended (scene 6) - one world, reversible.
+Per-scene local progress `sp` = `(t - lo) / (hi - lo)` clamped to `[0,1)` (`[0,1]` for scene 8);
+scenes map their own sub-beats off `sp`, never off wall-clock. The axis bends back up at the ascent
+so the SAME water is descended (scene 3) then re-ascended (scene 6) - one world, reversible.
 
 ## Scroll rig contract
 
@@ -200,10 +206,18 @@ blocker); **draw calls < 100 desktop / < 50 mobile** (probe `renderer.info.rende
 **Startup tier:** `detect-gpu` picks the initial tier (tier 3 -> HIGH, 2 -> MID, 1 -> LOW; tier 0 /
 no WebGL2 -> Experience gate fails, semantic fallback, GL never mounts).
 
-**Runtime governor:** a frame-time loop with **hysteresis** - **downgrade below 45 fps**, **upgrade
-above 83 fps**, with a **cooldown (~3 s, _tunable_)** between switches so it never oscillates. Turn
-knobs **in this order** (ADR-locked): **pixel ratio -> post samples -> geometry density -> effect
-toggles.**
+**Runtime governor:** ADR 0016 records the envelope as its 120 Hz-class illustration (downgrade
+below 45 fps, upgrade above 83 fps); **this skill owns the mechanism**, and 83 fps is unreachable
+on a 60 Hz display - a session downgraded once could never recover under a literal fps trigger. The
+real trigger is **sustained frame time relative to the display's own refresh budget**
+(`1000 / screen.refreshRate` if available, else assume 60 Hz -> ~16.7 ms budget): **downgrade**
+when the rolling frame-time average exceeds **1.35x** the refresh budget (~22.5 ms on 60 Hz -
+matches the ADR's ~45 fps figure at 60 Hz), **upgrade** when it stays sustained below **0.8x** the
+budget (~13.4 ms on 60 Hz) for the sustain window, with a **cooldown (~3 s, _tunable_)** between
+switches so it never oscillates. On a 120 Hz display the same 1.35x/0.8x ratios land near the
+ADR's literal 45/83 fps figures - the ratio IS the mechanism, the fps numbers are one worked
+example, not the trigger itself. Turn knobs **in this order** (ADR-locked): **pixel ratio -> post
+samples -> geometry density -> effect toggles.**
 
 Per-tier ladder (starting values, all _tunable_; the governor moves BETWEEN rungs, it does not
 invent new ones):
@@ -215,7 +229,8 @@ invent new ones):
 | LOW          | 1.0     | SMAA | 900               | 16            | off | on    |
 | MOBILE floor | 1.0     | SMAA | 600               | 12            | off | light |
 
-Mobile below the narrow breakpoint may use the **fixed-camera variant** (ADR-allowed). drei
+Mobile below the narrow breakpoint (CSS width <= 900px) may use the **fixed-camera variant**
+(ADR-allowed). drei
 `PerformanceMonitor` `onDecline` is the sanctioned adaptive hook if the static rungs are not enough.
 Budget-Android testing from day one (fp16 banding + dynamic-PBR cost on Adreno/Mali is where
 realistic real-time dies) - verify on real low-end hardware, not just a desktop throttle.
@@ -225,6 +240,21 @@ realistic real-time dies) - verify on real low-end hardware, not just a desktop 
 - **Reduced motion / in-page motion toggle = a chapter-stepped slideshow** of stills with identical
   copy and a frozen camera. Ship the toggle IN-PAGE (OS `prefers-reduced-motion` misses many
   vestibular users); both scrub smoothings off in this mode.
+- **Runtime toggle transition (GL already mounted).** The Experience gate only blocks GL at
+  _mount_; the in-page motion toggle can flip while GL is live, so the transition is explicit and
+  reversible, implemented as one state machine (`gl-live` <-> `slideshow`) driven by the toggle -
+  never two independent gate evaluations that can race:
+  - **Toggling ON** (motion reduced) while GL is mounted: stop the rAF loop and Lenis so no further
+    frames render, **freeze the playhead** at its current `t`, remove the Lenis scroll intercept so
+    scroll returns to native, hide the canvas the same way as the Semantic layer
+    (`visibility:hidden` + `inert` - never `display:none`), and reveal the chapter-stepped
+    slideshow **at the chapter containing the frozen `t`** (map `t` to its scene via the scroll map
+    above, jump the slideshow to that chapter).
+  - **Toggling OFF** (motion restored): re-run the full Experience gate (WebGL2 + fine pointer +
+    width + NOT reduced-motion must all still pass); on pass, remount GL, resume the rAF loop +
+    Lenis, and seed the playhead at the **same chapter's** range-start `t` (the slideshow has no
+    sub-chapter position, so exact `t` is not preserved - only the chapter); on fail (e.g. the OS
+    preference re-asserts), stay on the slideshow.
 - **Photosensitivity (WCAG 2.3.1):** cap luminance delta **per unit of REAL time, not scroll
   distance** - fast scrubbing can compress a slow fade into >3 Hz flashing. Clamp playhead velocity
   through the blackout -> dawn transition (scenes 4-7) so the fade can never strobe.
@@ -244,10 +274,12 @@ realistic real-time dies) - verify on real low-end hardware, not just a desktop 
 
 ## Capability gate + Semantic layer + a11y overlay (structural, from ADR 0014 - still binds)
 
-- **Experience gate to GL:** WebGL2 AND fine pointer AND width above the narrow breakpoint AND NOT
-  reduced-motion (plus any pre-launch `flipped()` guard until the owner flip). Fail any -> the
-  prerendered Semantic HTML runs and GL never mounts. Reduced-motion / no-WebGL2 / coarse-pointer /
-  narrow visitors therefore never reach the film - the fallback holds them whole.
+- **Experience gate to GL:** WebGL2 AND fine pointer (`matchMedia('(pointer: fine)')`) AND CSS
+  width **> 900px** (the narrow breakpoint - width <= 900px fails the gate; this is the
+  authoritative figure `webgl-gate-audit`'s fallback procedure drives to) AND NOT reduced-motion
+  (plus any pre-launch `flipped()` guard until the owner flip). Fail any -> the prerendered
+  Semantic HTML runs and GL never mounts. Reduced-motion / no-WebGL2 / coarse-pointer / narrow
+  visitors therefore never reach the film - the fallback holds them whole.
 - **Semantic layer is the scroll-height authority.** When GL mounts it gets `visibility:hidden` +
   `inert` - **NEVER `display:none`** (that collapses scroll height and breaks the scroll rig). It
   keeps owning SEO + machine-readable copy + scroll height while hidden; it is NOT the interactive

--- a/.claude/skills/webgl-standards/SKILL.md
+++ b/.claude/skills/webgl-standards/SKILL.md
@@ -1,177 +1,280 @@
 ---
 name: webgl-standards
-description: apps/landing WebGL landing conventions + verified version pins the GL authors and critics load first - R3F v9 / three ~0.185 / postprocessing 6.39.2 / gsap+lenis, the RIPBOOK 9-page p-space scroll model, the uBoil stepped-boil contract, the rip system, the single always-on post chain, capability gate, quality tiers, and the ASCII-only source rule. Load for any change under apps/landing/src/**.
+description: apps/landing WebGL conventions + verified version pins the GL authors and critics load first for TERMINAL VELOCITY - the realistic CG scroll-film. Owns the tunable constants ADR 0016 defers here - R3F v9 / three 0.185 / postprocessing 6.39.2 / three-good-godrays / gsap+lenis / detect-gpu / zustand, the one-shot playhead + 9-scene scroll map, the WebGL2 lane, the scroll rig, glTF-clip camera/character scrub, VAT splash playback, Gerstner water + godrays, the instanced paper storm, the filmic post chain, per-tier budgets + quality governor, the capability gate + semantic layer + a11y overlay, and the ASCII-only source rule. Load for any change under apps/landing/src/**.
 ---
 
-# apps/landing WebGL standards (RIPBOOK)
-
-> **⚠ SUPERSEDED CONCEPT - awaits its TERMINAL VELOCITY revision.** RIPBOOK was abandoned
-> mid-M3 (2026-07-18); the landing is now **TERMINAL VELOCITY**, a realistic CG scroll-film
-> (`docs/adr/0016-terminal-velocity-scroll-film-landing.md`). Every RIPBOOK-specific rule below
-> (the 9-page p-space model, the Rip system, `uBoil`/line-boil, in-canvas troika SDF text, the
-> single ink post chain, and the RIPBOOK budgets) is **superseded by ADR 0016** and no longer
-> the contract. What still holds: the Next 16 static-export stack, the capability gate + semantic
-> layer, and the ASCII-only source rule. This skill will be rewritten for TERMINAL VELOCITY
-> (WebGL2 lane, VAT playback, Gerstner water, godrays, glTF-clip scrub, quality governor) by the
-> GL authors in a later task; until then treat the numbers here as historical.
+# apps/landing WebGL standards (TERMINAL VELOCITY)
 
 The single source both GL authors (`webgl-author`, `shader-engineer`) and their critics
 (`webgl-reviewer`, `gate-auditor`, `webgl-perf-profiler`) read before touching `apps/landing`.
-Architecture rationale: `docs/adr/0014-landing-gl-takeover.md` as amended by
-`docs/adr/0015-ripbook-notebook-landing.md` (RIPBOOK).
+Experience contract + rationale: `docs/adr/0016-terminal-velocity-scroll-film-landing.md` (the
+source of truth). Still-binding structural machinery (Next 16 static export, Semantic layer,
+Experience gate, `landing/` passthrough, staged flip): `docs/adr/0014-landing-gl-takeover.md`.
+**The ADR holds the decisions; this skill holds the tunable numbers and their current starting
+values.** Every constant below marked _tunable_ may move within its ADR envelope during M1..M6.
 
-## The stack (Next 16 static export)
+## What TERMINAL VELOCITY is
 
-Full-canvas R3F v9 + three ~0.185 + postprocessing 6.39.2 + gsap + lenis + zustand -- **RIPBOOK**,
-a kraft-paper **notebook on a dark desk**, camera looking down ~25 degrees. Every story beat is a
-rippable **Page**; scroll plays a Page then Rips it out; ripped pages persist as a Desk pile
-(the progress indicator). **ALL copy renders in GL as SDF text** (troika) -- no DOM text over the
-canvas. A prerendered semantic HTML layer stays the SEO/a11y/scroll-height authority.
+A realistic CG **scroll-film** (~2:40). Scroll IS the **playhead** (native-scroll -> timeline
+0->1), fully reversible: scrolling up rewinds. One camera, one continuous vertical world, zero
+cuts - a burned-out job hunter tips off his chair at 2:47 AM and falls through a canyon of
+rejection towers into a paper ocean to the lightless bottom, where a robot finds him and carries
+him back up to dawn. It does everything except press send (the finale SEND button is the one real
+action). Copy is diegetic and in-world; the prerendered **Semantic layer** keeps the
+machine-readable and crawlable copy. RIPBOOK (the notebook / rip / boil / in-canvas SDF model) is
+fully retired - see ADR 0016 Supersessions; do not carry any RIPBOOK rule forward.
 
-## Version pins (verified - do NOT drift)
+## Ownership split (who edits what)
 
-| Package             | Pin                    | Note                                                                               |
-| ------------------- | ---------------------- | ---------------------------------------------------------------------------------- |
-| three               | 0.185.1                | the `~0.185` line R3F v9 + drei target                                             |
-| @react-three/fiber  | 9.6.1                  | pairs with React 19                                                                |
-| @react-three/drei   | 10.7.7                 |                                                                                    |
-| postprocessing      | 6.39.2 -- NEVER 6.39.0 | 6.39.0's three peer range excludes 0.185; a lockfile resolving 6.39.0 is a blocker |
-| troika (three-text) | 0.52.4                 | TTF-only; explicit `characters`                                                    |
-| gsap                | 3.15.0                 | ONE ScrollTrigger master timeline, `scrub:true`                                    |
-| lenis               | 1.3.25                 | owns document scroll; synced to ScrollTrigger                                      |
-| framer-motion       | (DOM-only)             | loader / mute toggle / a11y overlay ONLY -- never over the canvas                  |
-| typescript          | 6.0.3                  |                                                                                    |
+- **`webgl-author`**: the R3F scene graph, the scroll rig + store + governor wiring, instancing
+  and DataTexture bookkeeping, glTF-clip mixer scrub, asset loading + KTX2/DRACO decoder wiring,
+  the a11y overlay + semantic layer, camera/animation `useFrame` loops.
+- **`shader-engineer`**: all GLSL, custom postprocessing `Effect`/`Pass` classes, `onBeforeCompile`
+  material patches, `src/post/**`, the Gerstner/caustics/godrays/VAT-decode shader math. Hand those
+  to `shader-engineer`; the author wires the material + uniforms, never authors the shader.
 
-Caveats that bite:
+## The stack + version pins (verified 2026-07-18 - do NOT drift)
 
-- **troika / drei `Text` is TTF-only** -- no woff2. Every `Text` needs an explicit `characters`
-  prop or troika silently drops glyphs. Per-word `Text` splits are **headlines only** (each split
-  is its own draw call + SDF atlas).
-- **Ink strokes = `Line2` fat lines** from `three/addons/lines` (LineGeometry + LineMaterial),
-  `dashed` + animated `dashOffset` for draw-on. Never plain `THREE.Line`. Salvaged `doodles.json`
-  SVG paths feed these for 2D page-surface ink.
-- **Line boil is a VERTEX-SHADER effect** keyed to the stepped `uBoil` uniform (below) -- NEVER
-  re-`setPositions()` on the CPU per frame (allocation + upload storm).
+Full-canvas R3F v9 + three 0.185 on a **WebGL2 lane** for v1 (TSL/WebGPU is a deliberate tier-up
+experiment only - it would force rebuilding the whole post chain). Every pin below was verified
+with `npm view <pkg> version` / `... peerDependencies`; the lockfile must match `apps/landing/package.json`.
 
-## The 9-page p-space model
+| Package            | Pin      | Why / peer note                                                                                                                                         |
+| ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| three              | 0.185.1  | the `~0.185` line R3F v9 + drei target                                                                                                                  |
+| @react-three/fiber | 9.6.1    | pairs with React 19 (peer `react >=19 <19.3`, `three >=0.156`)                                                                                          |
+| @react-three/drei  | 10.7.7   | peer `@react-three/fiber ^9.0.0`, `three >=0.159`, `react ^19`                                                                                          |
+| postprocessing     | 6.39.2   | pmndrs composer; peer `three >= 0.168.0 < 0.186.0` (0.185.1 OK). See caveat below                                                                       |
+| three-good-godrays | 0.12.0   | shadow-map raymarched shafts. PEER MISMATCH - see caveat, unresolved pin                                                                                |
+| gsap               | 3.15.0   | ONE ScrollTrigger master timeline, `scrub:true`                                                                                                         |
+| lenis              | 1.3.25   | owns document scroll; rAF driven from `gsap.ticker`                                                                                                     |
+| detect-gpu         | 5.0.70   | startup quality tier (no three peer)                                                                                                                    |
+| zustand            | 5.0.14   | per-frame scroll/store reads via `getState()`, never a per-frame hook selector                                                                          |
+| VAT playback       | in-house | `three-vat` does NOT exist on npm. In-house shader; see VAT caveat below                                                                                |
+| react / react-dom  | 19.2.7   | R3F v9 requires React 19 (peer `>=19 <19.3`)                                                                                                            |
+| next               | 16.2.10  | static export (`output: 'export'`)                                                                                                                      |
+| typescript         | 6.0.3    |                                                                                                                                                         |
+| troika-three-text  | 0.52.4   | OPTIONAL, chrome-only (letterbox/timecode/depth-gauge labels). NOT the copy authority any more; the Semantic layer is. TTF-only, explicit `characters`. |
+| framer-motion      | ^12      | DOM-only: title card / mute toggle / a11y overlay - NEVER over the canvas                                                                               |
 
-Everything scroll-driven is a pure function of a single global `t` in `[0,1]` (scrub-safe both
-directions -- no time-accumulated state driving scroll visuals). Page `i` is **active** when
-`t` is in `[i/9, (i+1)/9]`. The 9 pages, in order, with their Rip exit:
+**Pin caveats that bite:**
 
-| #   | Page         | Exit                                                                     |
-| --- | ------------ | ------------------------------------------------------------------------ |
-| 0   | Cover        | hinge-opens                                                              |
-| 1   | Slump        | corner tear                                                              |
-| 2   | DescentA     | horizontal mid-rip                                                       |
-| 3   | DescentB     | vertical tear                                                            |
-| 4   | Fried        | crumple + toss (ink-native rage, NO glitch pass)                         |
-| 5   | AreYouSure   | folds into a paper plane                                                 |
-| 6   | Features     | diagonal tear                                                            |
-| 7   | Testimonials | perforation zip                                                          |
-| 8   | Godmode      | -> back cover; pencil signature + stamp, **no rip**, two-moment timeline |
+- **postprocessing - NEVER 6.39.0.** 6.39.0's three peer is `>= 0.168.0 < 0.184.0`, which excludes
+  our three 0.185.1; a lockfile resolving 6.39.0 is a blocker. 6.39.2 (and 6.39.3, same peer
+  `< 0.186.0`) fix it. Stay on 6.39.2 to match the lockfile; do not float.
+- **three-good-godrays 0.12.0 - declared peer excludes our three.** Its peer is
+  `three '>= 0.125.0 <= 0.182.0'` (postprocessing `^6.33.4`, satisfied). Our three 0.185.1 is
+  ABOVE that hard cap, so `pnpm install` emits an unmet-peer WARNING (not an error - the repo has no
+  `strict-peer-dependencies`, so it installs). This is UNVERIFIED-at-runtime until M3: the godrays
+  Pass raymarches the shadow map through stable three API, so it is likely fine on 0.185, but that
+  is an assumption. Resolution options, decide at M3: (a) widen the peer with a
+  `pnpm-workspace.yaml` `packageExtensions` entry and verify the shafts actually render, keeping an
+  inline raymarch effect as fallback; (b) if it breaks, inline the raymarch as an in-house
+  postprocessing Effect (shader-engineer). Do not silently ship broken shafts.
+- **VAT playback is in-house (no dep).** The package `three-vat` named in early notes does NOT
+  exist on npm (404). The only real three.js VAT lib is `@floatingworld/vat3-threejs@0.1.1` (MIT,
+  SideFX Labs VAT 3.0) - but it is a single unproven 0.1.1 release and its peer `three ^0.175.0`
+  (caret on 0.x = `>=0.175.0 <0.176.0`) also excludes our 0.185.1. Decision: **do VAT decode
+  in-house** - it is ~40 lines of deterministic vertex-shader texture sampling we must own anyway
+  for the scrub contract, and it avoids a micro-dependency on the critical path. Crib the VAT 3.0
+  decode math (position + normal texture layout, fluid mode) from `@floatingworld/vat3-threejs`
+  (MIT) as reference; do not add it as a runtime dep. (shader-engineer owns the decode shader.)
 
-**Page-local `p`.** Map `t` within the active page to `p` in `[0,1]`: `p` in `[0,0.72]` **plays**
-the page, `p` in `[0.72,1]` scrubs the page's **exit**. A **Rip** is the usual exit (pages 1-7);
-page 0's exit is the cover **hinge-open** and page 8's exit is the **pencil signature + stamp +
-back-cover close** (no rip) -- same `[0.72,1]` window, different exit. Both regions are pure `f(t)`
-and fully reversible.
+## The playhead model
 
-**One timeline, channels bridge.** Lenis owns document scroll; a **single** GSAP ScrollTrigger
-`scrub:true` master timeline (absolute tweens ONLY -- no `+=`) writes into **preallocated
-channels** + the zustand store. GL reads `store.getState()` per frame; React never re-renders per
-frame. Lenis->ScrollTrigger sync: drive `lenis.raf` from `gsap.ticker`, call `ScrollTrigger.update`
-on `lenis.on('scroll', ...)`, and let the semantic layer's 9 x 140vh sections own scroll height.
+Scroll = a single global **playhead** `t` in `[0,1]`, mapped 1:1 from native scroll over a total
+page length of **3,000 vh** (_tunable_, ADR envelope 2,000-4,000 vh; use `svh`/`dvh` or px
+triggers, never `vh`). One idea per scroll step. Everything scroll-driven is a **pure function of
+`t`**, scrub-safe both directions - no time-accumulated state driving scroll visuals.
 
-## Post pipeline (RIPBOOK chain - single, always-on)
+**Scrub smoothing:** damp the raw playhead with a scrub factor of **0.6** (_tunable_, ADR range
+0.5-1) plus Lenis lerp; **both smoothings are DISABLED under reduced motion / the in-page motion
+toggle** (the reduced-motion path is a chapter-stepped slideshow, not a damped scrub).
 
-Built on the **raw** postprocessing composer. Order:
+**Scrub-never-hijack:** no wheel `preventDefault`, no scroll snap, no scroll-ownership override.
+Native scroll maps straight to the playhead. Interactions perturb particles / play vignettes but
+**never move the playhead** (determinism is load-bearing).
 
-1. `RenderPass`
-2. `EffectPass` -- **tilt-shift DOF** (focus band on the active page)
-3. `EffectPass` -- **merged Crease + PaperGrain + Vignette** (Sobel crease lines; paper grain
-   `<= 0.035`, stepped at boil fps; warm vignette)
+**The 9-scene scroll map** (playhead range copied from ADR 0016; scene `i` active when `t` is in
+its range):
 
-with `multisampling: 4` (MSAA; SMAA fallback where MSAA is unavailable). **No pass EVER toggles at
-runtime.** **No bloom, no chromatic aberration, no halftone** -- the deep-fried Pass B set-piece is
-retired (ADR 0015); the Fried page gets ink-native aggression instead (editor-red rage strokes,
-heavy boil amplitude, dense cross-hatch), not effect passes.
+| #   | Scene          | playhead `t` | Locked beat                                                                            |
+| --- | -------------- | ------------ | -------------------------------------------------------------------------------------- |
+| 0   | Cold open      | 0.00 - 0.05  | Live monitor (FINAL_v9, 2:47 AM), chair tips past balance, title card, floor dissolves |
+| 1   | The canyon     | 0.05 - 0.30  | Slow-mo backward fall down glowing rejection towers; paper storm thickens              |
+| 2   | The surface    | 0.30 - 0.38  | Hits the paper ocean; the one hard beat - letterbox flexes, sound cuts, splash crown   |
+| 3   | The deep       | 0.38 - 0.52  | Underwater, god-rays thin band by band; he goes limp - the saddest frame               |
+| 4   | Blackout       | 0.52 - 0.58  | Near-total dark, breathing only; a single amber point of light appears below           |
+| 5   | The catch      | 0.58 - 0.64  | A submersible drone catches him gently; the "Are you sure?" HUD gag                    |
+| 6   | The ascent     | 0.64 - 0.85  | Axis inverts; robot carries him up; paper folds into planes in formation; he sleeps    |
+| 7   | Dawn           | 0.85 - 0.95  | Surface break into flat calm at sunrise; first warm full-color frame                   |
+| 8   | Finale/credits | 0.95 - 1.00  | Robot surfaces holding one red SEND button (the CTA); credits roll; creature sting     |
 
-## uBoil singleton-uniform contract
+Per-scene local progress `sp` = `(t - lo) / (hi - lo)` clamped to `[0,1]`; scenes map their own
+sub-beats off `sp`, never off wall-clock. The axis bends back up at the ascent so the SAME water is
+descended (scene 3) then re-ascended (scene 6) - one world, reversible.
 
-`uBoil` is **one uniform object shared by reference** across every ink/hatch/crease material. The
-**single writer** is the composer's `priority 1` `useFrame`; it sets
-`uBoil = floor(time * boilHz) / boilHz` once per frame, where `boilHz` is the **active quality
-tier's** boil rate (HIGH 10, LOW 8 -- see Quality tiers). It is **not** a fixed 10 Hz. No material
-owns its own boil clock, and nothing else writes it. Re-seed all ink jitter from `uBoil` so the
-whole page boils on the same step.
+## Scroll rig contract
 
-## Boil-vs-smooth split
+- **Lenis owns document scroll**, its rAF driven from `gsap.ticker` (not its own rAF); call
+  `ScrollTrigger.update` on `lenis.on('scroll', ...)`.
+- **ONE master GSAP ScrollTrigger, `scrub:true` timeline.** Absolute tweens ONLY - no `+=`
+  accumulation anywhere in the scroll path (a given `t` must produce one deterministic state).
+- **Scroll writes into preallocated refs / a zustand store; GL reads per frame** via
+  `store.getState()` inside the loop. React never re-renders per frame; never a hook selector for a
+  per-frame value.
+- **Fully reversible.** Down AND rewind to the same `t` -> identical frame. This is the whole
+  contract (gate-enforced).
+- **The Semantic layer's scroll sections own scroll height** (see Capability gate section). One
+  master timeline binds camera, baked light state, and shader uniforms so grade and blocking move
+  as one.
 
-The hand-drawn **jitter** (ink re-seed, cross-hatch, crease wobble, grain) steps on `uBoil` so it
-reads hand-drawn. The **camera, physics, rip bend, and DOF** run off real time and stay **smooth
-60fps**. Never step the camera or the rip morph on `uBoil` -- stepping motion, not just ink, looks
-broken.
+## Character + camera scrub (one clip)
 
-## Rip system invariants
+- The protagonist, the robot, and the camera spline are ONE long **Blender glTF** clip.
+- Drive it with `mixer.setTime(duration * progress)` from a **damped** scrub value (fast flicks
+  must not pop poses) - one source of truth, reversible for free.
+- **Cross-blend by driving action weights MANUALLY** (`action.weight = ...`); **never
+  `crossFadeTo`** - it assumes wall-clock and breaks under scrubbing.
+- Character animation may step "on twos" at ~12 fps against the 60 fps camera; NEVER step the
+  camera/physics/light on the stepped clock (stepping motion, not just the character, looks broken).
 
-- **Pre-split at load.** Each **rippable** page (1-7) is authored as a tear mesh at load time
-  (never re-triangulated per frame). Page 0 (cover hinge) and page 8 (signature + stamp + back-cover
-  close) use their own exit meshes, not the tear/morph rig.
-- **Vertex-shader bend + morph targets.** The Rip is a vertex-shader bend plus morph-target
-  crumple/fold driven by `p` in `[0.72,1]` -- pure `f(t)`, so scrubbing back below 0.72 fully
-  reassembles the page.
-- **Pile via `.count`.** The Desk pile is one `InstancedMesh`; reveal ripped pages by raising
-  `.count`, never by adding meshes.
-- **Dispose + prefetch.** Dispose a page's geometry when its page-distance > 2, and rebuild on
-  approach (prefetch). A disposal/prefetch bug reads as a black/blank page.
+## VAT contract (splash crown)
 
-## Paper-bake budget
+- The **splash crown** (scene 2) is a **Houdini FLIP** sim baked to a **VAT** (SideFX Labs VAT 3.0,
+  fluid mode) - position + normal textures. Playback = **sample the texture at time t** in the
+  vertex shader (shader-engineer owns the decode); no CPU per-frame work.
+- **Inter-frame interpolation ON** (lerp between the two nearest VAT frames) so slow scrubs read
+  smooth. Deterministic + reversible: VAT frame = `round-free lerp(scene-2 sp)`, pure `f(t)`.
+- **Bake budget: <= 2 MB compressed** (KTX2, _tunable_) for the crown VAT set. A single
+  uncompressed VAT blows the 10 MB envelope on its own.
 
-**One shared kraft bake** (albedo + normal + roughness) baked once at load, plus **one seeded
-stain/smudge atlas** -- reused across all pages. **Never per-page 4096^2 bakes.** HIGH bakes at
-4096^2, LOW at 2048^2. No downloaded textures.
+## Water + light
 
-## Budgets (the numbers other docs point at) + visibility scoping
+- **Bounded Gerstner water patch** (sum of ~4-6 Gerstner waves, _tunable_) + normal maps +
+  **ripple-drag injection** (cursor wake written into a small displacement DataTexture). **FFT
+  ocean is tier-up only** - not in the v1 WebGL2 lane.
+- **God-rays via `three-good-godrays`** (shadow-map raymarched shafts) for scenes 3-4; the pass is
+  scene-gated + governor-gated (see Post chain - it is a MIDDLE pass, never the last).
+- **Caustics via the differential-area GLSL technique** (screen-space derivative caustic band),
+  shader-engineer.
+- The monitor-blue -> dawn-gold arc ships as **baked, crossfaded light states per scroll segment**
+  (not dynamic PBR lights) - cheaper and reversible.
 
-This skill owns the RIPBOOK performance budgets; ADR 0015 and CONTEXT.md point here instead of
-copying them:
+## Paper storm
 
-- **Frame rate:** 60fps @ 1440p on M1 / GTX 1660 through every page and exit (incl. the crumple rip).
-- **JS bundle:** <= 1.3 MB gzipped.
-- **Draw calls:** < 120 -- probe with `renderer.info.render.calls`.
+- **ONE `InstancedMesh`** for the thousands of falling sheets - one draw call. Per-instance **phase
+  in a DataTexture**; **bend is analytic in the vertex shader** (no CPU transforms per sheet);
+  letter text from **one atlas**.
+- **True cloth only for the few hero sheets** you can pluck and read (scene 1 discovery), not the
+  storm.
+- InstancedMesh discipline (blank/white-instance bugs): after `setColorAt()` set
+  `instanceColor.needsUpdate = true`; after `setMatrixAt()` set `instanceMatrix.needsUpdate =
+true`. `instanceColor` is `null` until the first `setColorAt`, and any instance you NEVER set
+  renders WHITE - initialize every slot even if the storm reveals via `.count`.
 
-Visibility scoping keeps the draw-call budget: only the **active page +/-1** is mounted; distant
-pages are disposed (see Rip system). The pile is one instanced draw; per-word troika splits are
-headlines-only precisely because each is its own draw call.
+## Post chain (raw postprocessing composer, filmic)
 
-## Capability gate + the semantic layer + the a11y overlay
+Built on the **raw** pmndrs composer. Starting pass order (_tunable_ within the milestone that
+builds it; keep the LAST pass fixed - see the composer safety note):
 
-- **Gate to GL:** WebGL2 AND fine pointer AND width > 900 AND NOT reduced-motion, **and** a
-  `flipped()` pre-launch guard until the production flip. Fail any -> the legacy prerendered DOM
-  page runs and GL never mounts. Reduced-motion users therefore never reach the boil/exit motion.
+1. `RenderPass` (scene)
+2. `GodraysPass` (three-good-godrays) - scene-gated to the deep/blackout band + governor-gated.
+   MIDDLE pass, may toggle.
+3. `EffectPass` -> `DepthOfFieldEffect` (cinematic focus pull bound to the story subject)
+4. `EffectPass` (FINAL, owns `renderToScreen`) -> merged `[ ToneMappingEffect (filmic / AgX),
+VignetteEffect, NoiseEffect grain <= ~0.04 ]`
+
+`multisampling: 4` (MSAA; SMAA fallback where MSAA is unavailable). **Letterbox** bars (with the
+hand-lettered act titles / timecode / depth gauge) are **chrome, drawn in the DOM/overlay layer,
+not a GL pass** - keeps caption text crisp and keeps them in the a11y tree (decision confirmable at
+the chrome milestone M6). **Nothing toggles at runtime except (a) the quality governor and (b) the
+scene-gated middle godrays pass.** The FINAL pass NEVER toggles.
+
+## Budgets + quality governor
+
+Locked envelope (ADR 0016): **<= 10 MB total shipped** (KTX2/ETC1S textures, DRACO or meshopt
+geometry, procedural gradients over images, **self-hosted decoders** - a CDN-hosted decoder is a
+blocker); **draw calls < 100 desktop / < 50 mobile** (probe `renderer.info.render.calls`).
+
+**Startup tier:** `detect-gpu` picks the initial tier (tier 3 -> HIGH, 2 -> MID, 1 -> LOW; tier 0 /
+no WebGL2 -> Experience gate fails, semantic fallback, GL never mounts).
+
+**Runtime governor:** a frame-time loop with **hysteresis** - **downgrade below 45 fps**, **upgrade
+above 83 fps**, with a **cooldown (~3 s, _tunable_)** between switches so it never oscillates. Turn
+knobs **in this order** (ADR-locked): **pixel ratio -> post samples -> geometry density -> effect
+toggles.**
+
+Per-tier ladder (starting values, all _tunable_; the governor moves BETWEEN rungs, it does not
+invent new ones):
+
+| Tier         | dpr cap | MSAA | paper storm count | godrays steps | DOF | grain |
+| ------------ | ------- | ---- | ----------------- | ------------- | --- | ----- |
+| HIGH         | 2.0     | 4    | 4000              | 60            | on  | on    |
+| MID          | 1.5     | 2    | 2000              | 32            | on  | on    |
+| LOW          | 1.0     | SMAA | 900               | 16            | off | on    |
+| MOBILE floor | 1.0     | SMAA | 600               | 12            | off | light |
+
+Mobile below the narrow breakpoint may use the **fixed-camera variant** (ADR-allowed). drei
+`PerformanceMonitor` `onDecline` is the sanctioned adaptive hook if the static rungs are not enough.
+Budget-Android testing from day one (fp16 banding + dynamic-PBR cost on Adreno/Mali is where
+realistic real-time dies) - verify on real low-end hardware, not just a desktop throttle.
+
+## A11y / UX gates
+
+- **Reduced motion / in-page motion toggle = a chapter-stepped slideshow** of stills with identical
+  copy and a frozen camera. Ship the toggle IN-PAGE (OS `prefers-reduced-motion` misses many
+  vestibular users); both scrub smoothings off in this mode.
+- **Photosensitivity (WCAG 2.3.1):** cap luminance delta **per unit of REAL time, not scroll
+  distance** - fast scrubbing can compress a slow fade into >3 Hz flashing. Clamp playhead velocity
+  through the blackout -> dawn transition (scenes 4-7) so the fade can never strobe.
+- **Mobile:** `svh`/`dvh` or px triggers, never `vh`; **tap-vs-swipe discrimination** on every
+  touchable system; tilt parallax is an **opt-in easter egg only**.
+- **Chapter dots / scene deep-links** are hash-deep-linkable (e.g. `#the-deep`) - a hash on load
+  jumps the playhead to that scene's range start.
+- Copy parity: every joke and link from `landing/index.html` keeps a diegetic home AND a real
+  crawlable anchor in the Semantic layer; enforced by a bidirectional diff (gate step).
+
+## Loading choreography
+
+- **DOM-first title card is the LCP anchor** (canvas is excluded from LCP by spec). GL boots BEHIND
+  it and **streams assets by story position**: canyon during the title, ocean during the fall,
+  robot during the sink - the **blackout beat (scene 4) is a free preload window**.
+- **Reserve canvas dimensions for CLS**; ship JSON-LD in the Semantic layer.
+
+## Capability gate + Semantic layer + a11y overlay (structural, from ADR 0014 - still binds)
+
+- **Experience gate to GL:** WebGL2 AND fine pointer AND width above the narrow breakpoint AND NOT
+  reduced-motion (plus any pre-launch `flipped()` guard until the owner flip). Fail any -> the
+  prerendered Semantic HTML runs and GL never mounts. Reduced-motion / no-WebGL2 / coarse-pointer /
+  narrow visitors therefore never reach the film - the fallback holds them whole.
 - **Semantic layer is the scroll-height authority.** When GL mounts it gets `visibility:hidden` +
-  `inert` -- NEVER `display:none` (that collapses scroll height and breaks the scroll rig). It keeps
-  owning SEO + machine-readable copy while hidden; it is NOT the interactive surface once GL runs.
-- **a11y overlay is the accessible interface while GL runs.** Because copy is in-canvas SDF (opaque
-  to the a11y tree), a **visually-hidden but focusable** DOM overlay carries the accessibility: REAL
-  `<a>`/`<button>` elements positioned over the canvas hotspots (CTA, film hints, footer / store /
-  sponsor links, the sound / "mute the guy" toggle, doodle pokes, dialog buttons), a **skip-link
-  first in tab order**, and an `aria-live` region that mirrors the gag/speech-bubble text as it
-  changes. The overlay is keyboard + screen-reader operable even though it is visually hidden; the
-  canvas itself stays `aria-hidden`. Do not put the interactive controls only on the canvas.
+  `inert` - **NEVER `display:none`** (that collapses scroll height and breaks the scroll rig). It
+  keeps owning SEO + machine-readable copy + scroll height while hidden; it is NOT the interactive
+  surface once GL runs.
+- **a11y overlay is the accessible interface while GL runs.** Because copy is diegetic / in-canvas
+  (opaque to the a11y tree), a **visually-hidden but focusable** DOM overlay carries accessibility:
+  REAL `<a>`/`<button>` elements over each canvas hotspot (the finale SEND / CTA, the projector-slate
+  menu chip - download / GitHub / privacy / creature / skip-to-end, the cold-open early-exit
+  captions, the end-credits footer with all legacy + store + sponsor links + byline + foot-nav, the
+  mute / "mute the guy" toggle, dialog buttons), a **skip-link first in tab order**, and an
+  `aria-live` region mirroring the letterbox captions / speech-bubble text as it changes. The
+  overlay is keyboard + screen-reader operable while visually hidden; the canvas stays `aria-hidden`.
+  Never leave an interactive control canvas-only.
 
-## Quality tiers
+## Scrub-safety contract (the invariants a critic checks first)
 
-| Tier | dpr  | boil   | paper bake | stroke budget |
-| ---- | ---- | ------ | ---------- | ------------- |
-| HIGH | 2    | 10 fps | 4096^2     | full          |
-| LOW  | 1.25 | 8 fps  | 2048^2     | halved        |
-
-Degradation ladder (owned by `webgl-perf-profiler`, applied in order, stop at first pass): halve
-stroke budget -> boil 10->8 fps -> dpr 2->1.25 -> reduce tilt-shift DOF sample quality -> grain
-off. drei `PerformanceMonitor` `onDecline` is the sanctioned adaptive hook if the static rungs are
-not enough. (There is no "disable Pass B" rung any more -- the post chain never toggles.)
+- Everything scroll-driven is a pure function of `t` - **no `+=` accumulation** in the scroll path
+  (GSAP tweens absolute; store writes idempotent for a given `t`; `mixer.setTime` and VAT sampling
+  and manual weight blends all pure `f(t)`).
+- Read scroll state per-frame via `store.getState()` inside the loop - **never a hook selector** for
+  per-frame values (a selector re-renders the tree every frame).
+- **A numeric `useFrame` priority disables R3F auto-render.** ONE `priority 1` `useFrame`, owned by
+  the composer, drives the render; every animation `useFrame` stays at the default priority `0`.
+- **InstancedMesh:** initialize every instance (unset instances render WHITE); `needsUpdate` after
+  every `setColorAt`/`setMatrixAt` (see Paper storm).
+- **No `window`/`document` at render scope.** Canvas trees are `'use client'` but still
+  SSR-prerendered - guard any `window`/`document` access inside effects / event handlers only.
 
 ## ASCII-only source (hard rule)
 
@@ -179,23 +282,10 @@ Source files under `apps/landing/src/**` must be pure ASCII. Turbopack's merged 
 on multi-byte characters (the rope bug). Any user-facing copy with non-ASCII glyphs lives
 `\uXXXX`-escaped in `src/content/`, never inline in a component.
 
-## Scrub-safety contract
-
-- Everything scroll-driven is a pure function of `t` -- **no `+=` accumulation** anywhere in the
-  scroll path (GSAP tweens absolute; store writes idempotent for a given `t`).
-- Read scroll state per-frame via `store.getState()` inside the loop -- **never a hook selector**
-  for per-frame values (a selector re-renders the tree every frame).
-- **One** `priority 1` `useFrame`, owned by the composer, drives the render + `uBoil`; every other
-  animation `useFrame` stays at the default priority `0`.
-- **InstancedMesh:** `setColorAt()` then `instanceColor.needsUpdate = true`; `setMatrixAt()` then
-  `instanceMatrix.needsUpdate = true`. `instanceColor` is `null` until the first `setColorAt`, and
-  any instance you never set renders WHITE -- set every instance (the pile reveals via `.count`,
-  but every slot must be initialized first).
-
-## autoRenderToScreen historical note
+## postprocessing composer safety note (durable, library-general)
 
 postprocessing's `autoRenderToScreen` statically pins `renderToScreen=true` on the array-last pass
 at construction; if that pass is ever disabled the last enabled pass renders offscreen and the
-canvas goes black. RIPBOOK's chain **never toggles a pass**, so this hazard does not arise at
-runtime -- but keep `composer.autoRenderToScreen = false` and set `renderToScreen` explicitly on the
-last pass, as a durable safety default (learned P4, 2026-07-18).
+canvas goes black. TERMINAL VELOCITY only toggles MIDDLE passes (godrays) and never the last, but
+keep `composer.autoRenderToScreen = false` and set `renderToScreen` explicitly on the FINAL pass as
+a durable safety default (learned P4, 2026-07-18, still valid post-pivot).

--- a/docs/adr/0016-terminal-velocity-scroll-film-landing.md
+++ b/docs/adr/0016-terminal-velocity-scroll-film-landing.md
@@ -87,10 +87,11 @@ synth at the light -> strings building on the ascent -> morning birds at dawn. S
 (paper snap, ripple, servo beep) spatialized to the cursor. Audio is a first-class deliverable.
 
 **Renderer: WebGL2 lane for v1.** R3F + three + the pmndrs `postprocessing` composer already
-pinned in this repo, plus `three-good-godrays` (shadow-map raymarched shafts), `three-vat`
-(baked sims), a bounded **Gerstner** water patch, and DataTexture GPGPU - all WebGL2-only and
-all proven. **TSL/WebGPU is a deliberate tier-up experiment, not the base** (it would force
-rebuilding the whole post chain).
+pinned in this repo, plus `three-good-godrays` (shadow-map raymarched shafts), an in-house VAT
+decode shader for baked sims (errata, verified 2026-07-18: `three-vat` does not exist on npm;
+VAT playback is in-house per `.claude/skills/webgl-standards/SKILL.md`), a bounded **Gerstner**
+water patch, and DataTexture GPGPU - all WebGL2-only and all proven. **TSL/WebGPU is a deliberate
+tier-up experiment, not the base** (it would force rebuilding the whole post chain).
 
 **Character + camera = ONE clip.** The protagonist, the robot, and the camera spline are one
 long **Blender glTF** clip driven by `mixer.setTime(duration * progress)` - one source of
@@ -100,7 +101,8 @@ fast flicks do not pop poses. One master timeline binds camera, baked light stat
 uniforms together so grade and blocking move as one.
 
 **Baked heavy sims, instanced paper.** The **splash crown** is a **Houdini FLIP** sim baked to
-**VAT** (Vertex Animation Texture) and played back via `three-vat` - scrubbing a VAT is just
+**VAT** (Vertex Animation Texture) and played back via an in-house VAT decode shader (no
+`three-vat` package - see errata above) - scrubbing a VAT is just
 sampling a texture at time t: deterministic, reversible, cheap. The **paper storm** is ONE
 `InstancedMesh` (thousands of sheets, one draw call): per-instance phase in a DataTexture,
 bending analytic in the vertex shader, letter text from one atlas; true cloth only for the few


### PR DESCRIPTION
## What

Rewrites the two GL skill contracts from RIPBOOK to the ADR-0016 TERMINAL VELOCITY contract (the flagged follow-up from #718). Skills-only — no `apps/landing` source.

- **`.claude/skills/webgl-standards/SKILL.md`** — full rewrite: one-shot playhead model + 9-scene map (playhead ranges from ADR-0016), scroll rig (Lenis on GSAP ticker, one master scrub timeline, absolute tweens), Blender glTF clip scrub via `mixer.setTime`, VAT splash playback contract, Gerstner water + godrays + caustics, one-InstancedMesh paper storm, filmic post chain, per-tier budget ladders + 45/83 fps governor, a11y/UX gates (reduced-motion slideshow, WCAG 2.3.1 luminance clamp, svh/dvh), loading choreography, carried-over capability gate + semantic layer + ASCII rule.
- **`.claude/skills/webgl-gate-audit/SKILL.md`** — gate procedures re-scoped: playhead-position driving, scrub down-AND-rewind + VAT determinism, FPS at the risk scenes, draw-call + 10 MB bundle probes, blackout→dawn strobe check at max scrub velocity, copy-parity, reduced-motion/no-GL fallback.

## Verification notes (recorded in the skill, not hand-waved)

- All version pins verified live against npm (three 0.185.1, R3F 9.6.1, drei 10.7.7, postprocessing 6.39.2, gsap 3.15.0, lenis 1.3.25, detect-gpu 5.0.70, zustand 5.0.14).
- `three-good-godrays` 0.12.0 declared peer caps at three ≤0.182 — installs with a warning; resolution path (packageExtensions widen + M3 verify, in-house raymarch Effect fallback) is written into the skill.
- `three-vat` **does not exist on npm** — VAT decode is ruled in-house (~40 lines of deterministic vertex-shader sampling we must own for the scrub contract anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated WebGL standards and audit guidance for the TERMINAL VELOCITY experience.
  * Documented nine playhead-driven scenes with deterministic scrubbing and rewind behavior.
  * Added performance checks for frame rate, draw calls, bundle size, and throttled devices.
  * Expanded strobe-safety, accessibility, reduced-motion, and no-WebGL fallback verification.
  * Clarified semantic HTML, keyboard access, captions, and screen-reader behavior.
  * Added guidance for WebGL2 rendering, animation, water, particle, post-processing, and scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->