### PR TITLE
feat: terminal velocity m3 — water, splash vat, deep and blackout

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -16,7 +16,6 @@
     "@react-three/drei": "10.7.7",
     "@react-three/fiber": "9.6.1",
     "detect-gpu": "5.0.70",
-    "framer-motion": "^12",
     "gsap": "3.15.0",
     "lenis": "1.3.25",
     "next": "16.2.10",
@@ -24,7 +23,6 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "three": "0.185.1",
-    "troika-three-text": "0.52.4",
     "zustand": "5.0.14"
   },
   "devDependencies": {
@@ -32,7 +30,6 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "0.185.1",
-    "svg-path-properties": "2.0.1",
     "typescript": "6.0.3",
     "vitest": "^4.1.10"
   }

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -121,7 +121,10 @@ a {
   position: fixed;
   left: 0;
   right: 0;
-  height: clamp(28px, 7vh, 64px);
+  /* Responsive base height + the splash-beat flex (Chrome sets --lb-extra from
+     letterboxFlex(t), a pure f(t) so it scrubs both ways). No CSS transition:
+     the value is already frame-smooth and a transition would fight determinism. */
+  height: calc(clamp(28px, 7vh, 64px) + var(--lb-extra, 0px));
   background: #000;
 }
 .letterbox-top {

--- a/apps/landing/src/cast/world/CanyonWorld.tsx
+++ b/apps/landing/src/cast/world/CanyonWorld.tsx
@@ -1,75 +1,142 @@
 "use client";
 
-// The world root for M2. Owns the ONE camera + fog useFrame (default priority 0
-// -- no numeric priority until the composer lands, which would disable R3F
-// auto-render), reads the playhead via the store singleton every frame (never a
-// hook selector), and gates visibility: the canyon renders while the playhead is
-// in the scene 0-2 range, the kept placeholder markers render below it. The
-// camera is one continuous pure-f(t) descent with a backward-fall framing across
-// the canyon (looks up/along as the towers stream past). Nothing here allocates
-// per frame -- all scratch objects are preallocated.
+// The world root (scenes 0-4 as of M3). Owns the ONE camera + fog + exposure
+// useFrame (default priority 0 -- no numeric priority until the composer lands,
+// which would disable R3F auto-render), reads the playhead via the store
+// singleton every frame (never a hook selector), and gates each scene's group by
+// the pure worldLayers() visibility map. The camera is one continuous pure-f(t)
+// descent: canyon backward-fall framing (scenes 0-2), then looking down through
+// the surface into the deep (scenes 2-4). Nothing here allocates per frame -- all
+// scratch objects are preallocated.
+//
+// The single real-time smoothing in the render path lives here: the luminance-
+// velocity clamp (LuminanceClamp) eases the APPLIED tone-mapping exposure toward
+// the pure-f(t) target (sceneLuminance) so fast scrubbing cannot strobe the
+// blackout transitions (WCAG 2.3.1; see engine/luminance-clamp.ts). At rest it
+// converges to the target, so determinism holds.
 
 import { useMemo, useRef } from "react";
-import { FogExp2, type Group, Vector3 } from "three";
+import { FogExp2, type Group, type PointLight, Vector3 } from "three";
 import { useFrame } from "@react-three/fiber";
 
+import { LuminanceClamp } from "@/engine/luminance-clamp";
 import { playhead, type QualityTier } from "@/engine/store";
 
-import {
-  cameraLookUpY,
-  cameraSwayX,
-  cameraY,
-  cameraZ,
-  canyonFogRGB,
-} from "./canyon-layout";
+import { cameraLookUpY, cameraSwayX, cameraY, cameraZ } from "./canyon-layout";
 import { CanyonScene } from "./CanyonScene";
+import { DeepScene } from "./DeepScene";
 import { PlaceholderMarkers } from "./PlaceholderMarkers";
+import { SplashCrown } from "./SplashCrown";
+import {
+  amberIntensity,
+  amberLightY,
+  cameraLookDownOffset,
+  MAX_LUMINANCE_SLEW_PER_SEC,
+  sceneLuminance,
+  worldFog,
+  type WorldLayers,
+  writeWorldLayers,
+} from "./water-layout";
+import { WaterSurface } from "./WaterSurface";
 
 export function CanyonWorld({ tier }: { tier: QualityTier }) {
   const canyonRef = useRef<Group>(null);
+  const waterRef = useRef<Group>(null);
+  const splashRef = useRef<Group>(null);
+  const deepRef = useRef<Group>(null);
   const markersRef = useRef<Group>(null);
+  const amberRef = useRef<PointLight>(null);
 
   // Preallocated scratch -- mutated in place each frame, never reallocated.
   const fog = useMemo(() => new FogExp2(0x0a0f18, 0.012), []);
   const target = useMemo(() => new Vector3(), []);
   const fogRGB = useMemo<[number, number, number]>(() => [0, 0, 0], []);
+  const layers = useMemo<WorldLayers>(
+    () => ({ canyon: false, water: false, splash: false, deep: false, markers: false }),
+    [],
+  );
+  // The ONE real-time (delta-driven) smoothing in the render path -- the WCAG
+  // luminance clamp. The constructor's `initial` argument is a throwaway: the
+  // class hard-cuts to the ACTUAL scene target on its very first step() call
+  // (see engine/luminance-clamp.ts "MOUNT PRIMING"), so a (re)mount landing
+  // anywhere in the dark scenes -- a hash deep-link, or the reduce->restore GL
+  // remount -- renders the correct target immediately instead of visibly fading
+  // in from this constant.
+  const luminance = useMemo(() => new LuminanceClamp(1, MAX_LUMINANCE_SLEW_PER_SEC), []);
 
-  useFrame((state) => {
+  useFrame((state, delta) => {
     const t = playhead.t;
 
-    // One continuous descent + canyon backward-fall framing (pure f(t)).
+    // One continuous descent: canyon backward-fall framing up top, looking down
+    // through the surface into the deep below (both pure f(t), and the two
+    // framings never overlap -- canyon look-up is 0 by the surface).
     const cam = state.camera;
     cam.position.set(cameraSwayX(t), cameraY(t), cameraZ(t));
-    target.set(cameraSwayX(t) * 0.4, cameraY(t) + cameraLookUpY(t), -8);
+    target.set(
+      cameraSwayX(t) * 0.4,
+      cameraY(t) + cameraLookUpY(t) + cameraLookDownOffset(t),
+      -8,
+    );
     cam.lookAt(target);
 
-    // Depth-graded haze (sodium-orange -> cold blue). Sharing fog.color as the
-    // scene background blends distant towers into the haze for the depth read.
-    canyonFogRGB(t, fogRGB);
+    // Depth-graded haze for the whole descent: sodium/blue canyon night up top,
+    // midnight blue-black closing in for the deep + blackout below.
+    const density = worldFog(t, fogRGB);
     fog.color.setRGB(fogRGB[0], fogRGB[1], fogRGB[2]);
+    fog.density = density;
     state.scene.fog = fog;
     state.scene.background = fog.color;
 
-    // Visibility gate: canyon for scenes 0-2, markers below (skips the other
-    // group's draw calls entirely -> canyon segment stays within budget).
-    const inCanyon = playhead.scene <= 2;
-    if (canyonRef.current) canyonRef.current.visible = inCanyon;
-    if (markersRef.current) markersRef.current.visible = !inCanyon;
+    // Luminance-velocity clamp: ease the APPLIED exposure toward the pure-f(t)
+    // target, rate-limited per REAL second so a fast scrub cannot strobe the
+    // blackout transitions (the ONE render-path real-time smoothing exception).
+    state.gl.toneMappingExposure = luminance.step(sceneLuminance(t), delta);
+
+    // The single warm amber point appearing below and growing in the blackout
+    // (pure f(t); slow, so no clamp needed).
+    const amber = amberRef.current;
+    if (amber) {
+      amber.intensity = amberIntensity(t);
+      amber.position.set(0, amberLightY(t), -2);
+    }
+
+    // Visibility gate: only the active scene's group draws (keeps each segment
+    // within the draw-call budget). Writes into the preallocated `layers` scratch
+    // -- no fresh object per frame.
+    writeWorldLayers(playhead.scene, layers);
+    if (canyonRef.current) canyonRef.current.visible = layers.canyon;
+    if (waterRef.current) waterRef.current.visible = layers.water;
+    if (splashRef.current) splashRef.current.visible = layers.splash;
+    if (deepRef.current) deepRef.current.visible = layers.deep;
+    if (markersRef.current) markersRef.current.visible = layers.markers;
   });
 
   return (
     <>
       {/* Baked night light rig (ADR-0016: "baked, crossfaded light states, not
-          dynamic PBR lights") -- cheap stock three lights, no per-window point
-          lights. Cool navy ambient floor + a cool-sky/warm-ground hemisphere
-          (the "warm rim from windows, cool ambient" cast on the lit paper/tower
-          materials) + a cool blue directional key for shape definition. */}
+          dynamic PBR lights") -- cool navy ambient floor + a cool-sky/warm-ground
+          hemisphere + a cool blue directional key. The deep dims via the exposure
+          clamp above (not by touching these), so the canyon look is unchanged. */}
       <ambientLight color="#0d1626" intensity={0.35} />
       <hemisphereLight color="#2c3a52" groundColor="#3a2410" intensity={0.6} />
       <directionalLight color="#5b7fb5" position={[4, 8, 6]} intensity={0.4} />
+      {/* The blackout amber point -- position + intensity driven per frame. */}
+      <pointLight ref={amberRef} color="#ff8a3c" intensity={0} distance={150} decay={1.3} />
 
       <group ref={canyonRef}>
         <CanyonScene tier={tier} />
+      </group>
+
+      <group ref={waterRef} visible={false}>
+        <WaterSurface tier={tier} />
+      </group>
+
+      <group ref={splashRef} visible={false}>
+        <SplashCrown />
+      </group>
+
+      <group ref={deepRef} visible={false}>
+        <DeepScene tier={tier} />
       </group>
 
       <group ref={markersRef} visible={false}>

--- a/apps/landing/src/cast/world/DeepScene.tsx
+++ b/apps/landing/src/cast/world/DeepScene.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+// The deep (M3, scenes 3-4 [0.38, 0.58)): the underwater volume. Depth-graded
+// blue-black fog + the exposure dimming are owned by CanyonWorld; this file
+// composes the volume contents:
+//   - GodrayShafts: a handful of additive cone shafts thinning band by band into
+//     the deep (the M3 godrays FALLBACK path -- no post composer; see the handoff).
+//   - DeepPapers: a sparse frozen cloud of sinking sheets the camera drifts
+//     through (reuses the storm InstancedMesh + shader pattern, one draw call).
+//   - LimpFigure: a procedural capsule-body silhouette going limp as it sinks
+//     (placeholder; the authored glTF clip is a later milestone).
+// Everything is pure f(t). Animation useFrames stay at the DEFAULT priority (0).
+
+import { useEffect, useMemo, useRef } from "react";
+import {
+  AdditiveBlending,
+  Color,
+  ConeGeometry,
+  DoubleSide,
+  Euler,
+  type Group,
+  InstancedBufferAttribute,
+  type InstancedMesh,
+  Matrix4,
+  MeshBasicMaterial,
+  MeshLambertMaterial,
+  MeshStandardMaterial,
+  PlaneGeometry,
+  Quaternion,
+  Vector3,
+} from "three";
+import { useFrame } from "@react-three/fiber";
+
+import { deepPaperCountForTier, godrayShaftCountForTier } from "@/engine/quality-ladder";
+import { playhead, type QualityTier } from "@/engine/store";
+
+import { installGodrayShaftShader } from "./shaders/godray-shaft-shader";
+import { installStormShader } from "./shaders/paper-storm-shader";
+import {
+  deepPaperInstance,
+  type FigureState,
+  godrayShaft,
+  godrayStrength,
+  SURFACE_WORLD_Y,
+  writeLimpFigure,
+} from "./water-layout";
+
+// ---- sparse drifting papers (reuses the storm instancing + shader) ----------
+
+function DeepPapers({ tier }: { tier: QualityTier }) {
+  const meshRef = useRef<InstancedMesh>(null);
+  const count = deepPaperCountForTier(tier);
+
+  const { geometry, material, uniforms } = useMemo(() => {
+    const geo = new PlaneGeometry(0.8, 1.1, 2, 1);
+    const seeds = new Float32Array(count);
+    const phases = new Float32Array(count);
+    for (let i = 0; i < count; i++) {
+      const inst = deepPaperInstance(i);
+      seeds[i] = inst.seed;
+      phases[i] = inst.phase;
+    }
+    geo.setAttribute("aSeed", new InstancedBufferAttribute(seeds, 1));
+    geo.setAttribute("aPhase", new InstancedBufferAttribute(phases, 1));
+    const mat = new MeshLambertMaterial({ color: 0x6b6a63, side: DoubleSide, fog: true });
+    const u = installStormShader(mat);
+    return { geometry: geo, material: mat, uniforms: u };
+  }, [count]);
+
+  useEffect(() => {
+    return () => {
+      geometry.dispose();
+      material.dispose();
+    };
+  }, [geometry, material]);
+
+  // Initialize every instance once (no unset/white slot).
+  useEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+    const m = new Matrix4();
+    const pos = new Vector3();
+    const quat = new Quaternion();
+    const euler = new Euler();
+    const scl = new Vector3();
+    for (let i = 0; i < count; i++) {
+      const inst = deepPaperInstance(i);
+      pos.set(inst.x, inst.y, inst.z);
+      euler.set(inst.rotX, inst.rotY, inst.rotZ);
+      quat.setFromEuler(euler);
+      scl.setScalar(inst.scale);
+      m.compose(pos, quat, scl);
+      mesh.setMatrixAt(i, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [count]);
+
+  useFrame(() => {
+    uniforms.uStormT.value = playhead.t; // slow flutter -- pure f(t), reversible
+  });
+
+  return <instancedMesh ref={meshRef} args={[geometry, material, count]} frustumCulled={false} />;
+}
+
+// ---- limp figure silhouette (procedural capsules; no character work) --------
+
+function LimpFigure() {
+  const groupRef = useRef<Group>(null);
+  const scratch = useMemo<FigureState>(
+    () => ({ x: 0, y: 0, z: 0, rx: 0, ry: 0, rz: 0, visible: false }),
+    [],
+  );
+  const bodyMat = useMemo(
+    () => new MeshStandardMaterial({ color: 0x0a0e14, roughness: 0.95, metalness: 0 }),
+    [],
+  );
+  useEffect(() => {
+    return () => bodyMat.dispose();
+  }, [bodyMat]);
+
+  useFrame(() => {
+    const g = groupRef.current;
+    if (!g) return;
+    writeLimpFigure(playhead.t, scratch);
+    g.visible = scratch.visible;
+    if (!scratch.visible) return;
+    g.position.set(scratch.x, scratch.y, scratch.z);
+    g.rotation.set(scratch.rx, scratch.ry, scratch.rz);
+  });
+
+  // A loose, face-up-ish limp pose -- torso + head + splayed limbs. Silhouette
+  // only; art comes later.
+  return (
+    <group ref={groupRef} visible={false}>
+      <mesh material={bodyMat} rotation={[0, 0, 0.12]}>
+        <capsuleGeometry args={[0.32, 1.0, 4, 8]} />
+      </mesh>
+      <mesh material={bodyMat} position={[0, 0.86, 0]}>
+        <sphereGeometry args={[0.26, 16, 12]} />
+      </mesh>
+      <mesh material={bodyMat} position={[-0.45, 0.3, 0.05]} rotation={[0, 0, 1.15]}>
+        <capsuleGeometry args={[0.12, 0.8, 4, 6]} />
+      </mesh>
+      <mesh material={bodyMat} position={[0.5, 0.28, -0.05]} rotation={[0, 0, -1.32]}>
+        <capsuleGeometry args={[0.12, 0.8, 4, 6]} />
+      </mesh>
+      <mesh material={bodyMat} position={[-0.22, -0.95, 0.04]} rotation={[0.2, 0, 0.22]}>
+        <capsuleGeometry args={[0.15, 0.95, 4, 6]} />
+      </mesh>
+      <mesh material={bodyMat} position={[0.24, -0.95, -0.03]} rotation={[-0.15, 0, -0.16]}>
+        <capsuleGeometry args={[0.15, 0.95, 4, 6]} />
+      </mesh>
+    </group>
+  );
+}
+
+// ---- additive god-ray shafts (the M3 fallback path) -------------------------
+
+// Below this strength the additive cones are visually gone (uStrength alone
+// already zeroes their alpha), but the fragments still rasterize -- gate the
+// whole group's `visible` off below the threshold so the draw calls (and the
+// additive overdraw) actually disappear through most of the blackout, not just
+// the color.
+const GODRAY_VISIBLE_THRESHOLD = 0.01;
+
+function GodrayShafts({ tier }: { tier: QualityTier }) {
+  const groupRef = useRef<Group>(null);
+  const count = godrayShaftCountForTier(tier);
+
+  // The cone geometry + additive material are count-INDEPENDENT (each shaft is
+  // the same unit cone, scaled per instance via mesh props), so they are built
+  // once; the shaft count only drives how many meshes are rendered.
+  const { geometry, material, uniforms } = useMemo(() => {
+    const geo = new ConeGeometry(1, 1, 14, 1, true); // unit cone, scaled per shaft
+    const mat = new MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      depthWrite: false,
+      blending: AdditiveBlending,
+      side: DoubleSide,
+      fog: false,
+    });
+    // Shaft color darkened (M3 review fix): the old pale 0x9fc4d8 was bright
+    // enough on its own that additive stacking of several shafts overexposed the
+    // deep; a dimmer, less saturated blue keeps the "light shaft" hue read
+    // without contributing so much raw luminance per shaft.
+    const u = installGodrayShaftShader(mat, new Color(0x4a6478));
+    return { geometry: geo, material: mat, uniforms: u };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      geometry.dispose();
+      material.dispose();
+    };
+  }, [geometry, material]);
+
+  useFrame(() => {
+    const strength = godrayStrength(playhead.t); // thins with depth -- pure f(t)
+    uniforms.uStrength.value = strength;
+    // Gate the whole group off once the shafts are visually gone -- kills the
+    // draw calls (and the additive overdraw) through most of the blackout,
+    // rather than leaving 7 near-zero-alpha cones still rasterizing every frame.
+    const g = groupRef.current;
+    if (g) g.visible = strength > GODRAY_VISIBLE_THRESHOLD;
+  });
+
+  // A handful of additive cones (count is small -- these ARE the shaft draw
+  // calls). Apex near the surface, widening down into the deep; placed statically
+  // per shaft. dispose={null} so R3F never disposes the shared geo/material when a
+  // single cone unmounts -- the effect above owns their disposal.
+  return (
+    <group ref={groupRef} visible={false}>
+      {Array.from({ length: count }, (_, i) => {
+        const s = godrayShaft(i);
+        return (
+          <mesh
+            key={i}
+            geometry={geometry}
+            material={material}
+            position={[s.x, SURFACE_WORLD_Y - s.len * 0.5 + 4, s.z]}
+            rotation={[s.tiltX, 0, s.tiltZ]}
+            scale={[s.radius, s.len, s.radius]}
+            frustumCulled={false}
+            dispose={null}
+          />
+        );
+      })}
+    </group>
+  );
+}
+
+export function DeepScene({ tier }: { tier: QualityTier }) {
+  return (
+    <>
+      <GodrayShafts tier={tier} />
+      <DeepPapers tier={tier} />
+      <LimpFigure />
+    </>
+  );
+}

--- a/apps/landing/src/cast/world/SplashCrown.tsx
+++ b/apps/landing/src/cast/world/SplashCrown.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+// The splash crown (M3, scene 2 [0.30, 0.38)): the full in-house VAT playback
+// path, playing a PROCEDURAL stand-in bake so the real Houdini FLIP crown is a
+// drop-in later (DCC ownership is an open ADR-0016 item). At load it bakes an
+// analytic crown (splash-crown.ts) into a small float DataTexture -- 64 frames x
+// the ring vertex count -- then plays it back via the in-house VAT decode shader.
+// The frame pair + blend are the deterministic, unit-tested engine/vat.ts math
+// keyed off scene-2 progress, so the splash is scrub-reversible both directions.
+// Animation useFrame stays at the DEFAULT priority (0). The bake runs in useMemo,
+// which only executes client-side (the crown mounts under gl-live behind the
+// Experience gate) and touches no window/document, so it is SSR-safe.
+
+import { useEffect, useMemo } from "react";
+import {
+  BufferAttribute,
+  DataTexture,
+  DoubleSide,
+  FloatType,
+  MeshStandardMaterial,
+  NearestFilter,
+  RGBAFormat,
+  RingGeometry,
+} from "three";
+import { useFrame } from "@react-three/fiber";
+
+import { sceneProgress } from "@/engine/scene-resolver";
+import { playhead } from "@/engine/store";
+import { frameRowV, type VatFrameSample, type VatMeta, vatProgress, writeVatFrameIndex } from "@/engine/vat";
+
+import { installVatCrownShader } from "./shaders/vat-crown-shader";
+import {
+  CROWN_FRAMES,
+  CROWN_RADIUS,
+  CROWN_RINGS,
+  CROWN_SEGMENTS,
+  crownVertexAt,
+  normalizeAngle,
+} from "./splash-crown";
+import { SURFACE_WORLD_Y } from "./water-layout";
+
+export function SplashCrown() {
+  const { geometry, material, uniforms, meta } = useMemo(() => {
+    // Rest mesh: a radial disc of vertices (RingGeometry lays vertices out ring by
+    // ring). The bake writes one absolute crown position per (frame, vertex).
+    const geo = new RingGeometry(0.02, CROWN_RADIUS, CROWN_SEGMENTS, CROWN_RINGS);
+    const posAttr = geo.getAttribute("position"); // non-optional accessor
+    const vertices = posAttr.count;
+
+    const ids = new Float32Array(vertices);
+    for (let i = 0; i < vertices; i++) ids[i] = i;
+    geo.setAttribute("aVatId", new BufferAttribute(ids, 1)); // per-vertex texture column
+
+    // Bake: row = frame, column = vertex, RGB = baked position.
+    const data = new Float32Array(CROWN_FRAMES * vertices * 4);
+    const out: [number, number, number] = [0, 0, 0];
+    for (let fr = 0; fr < CROWN_FRAMES; fr++) {
+      for (let v = 0; v < vertices; v++) {
+        const rx = posAttr.getX(v);
+        const ry = posAttr.getY(v); // RingGeometry lies in the XY plane
+        const radius = Math.hypot(rx, ry);
+        const angle = normalizeAngle(Math.atan2(ry, rx));
+        crownVertexAt(radius, angle, fr, CROWN_FRAMES, out);
+        const idx = (fr * vertices + v) * 4;
+        data[idx] = out[0];
+        data[idx + 1] = out[1];
+        data[idx + 2] = out[2];
+        data[idx + 3] = 1;
+      }
+    }
+    const tex = new DataTexture(data, vertices, CROWN_FRAMES, RGBAFormat, FloatType);
+    tex.minFilter = NearestFilter; // exact texel per column; row lerp is done on the CPU (uBlend)
+    tex.magFilter = NearestFilter;
+    tex.generateMipmaps = false;
+    tex.needsUpdate = true;
+
+    const mat = new MeshStandardMaterial({
+      color: 0xbcccd6, // pale foam
+      emissive: 0x0e161e,
+      roughness: 0.3,
+      metalness: 0,
+      transparent: true,
+      opacity: 0.85,
+      side: DoubleSide, // displaced disc -- render both faces so the crown never gaps
+    });
+    const u = installVatCrownShader(mat, tex, vertices);
+    const m: VatMeta = { frames: CROWN_FRAMES, vertices, duration: 0.85 };
+    return { geometry: geo, material: mat, uniforms: u, meta: m };
+  }, []);
+
+  useEffect(() => {
+    const tex = uniforms.uVatTex.value as { dispose?: () => void } | null;
+    return () => {
+      geometry.dispose();
+      material.dispose();
+      tex?.dispose?.();
+    };
+  }, [geometry, material, uniforms]);
+
+  // Preallocated scratch -- writeVatFrameIndex mutates it in place each frame,
+  // never reallocated.
+  const sample = useMemo<VatFrameSample>(() => ({ a: 0, b: 0, blend: 0 }), []);
+
+  useFrame(() => {
+    const p = vatProgress(sceneProgress(playhead.t, 2), meta);
+    writeVatFrameIndex(p, meta.frames, sample);
+    uniforms.uRowA.value = frameRowV(sample.a, meta.frames);
+    uniforms.uRowB.value = frameRowV(sample.b, meta.frames);
+    uniforms.uBlend.value = sample.blend; // pure f(t) -- reversible on rewind
+  });
+
+  return (
+    <mesh
+      geometry={geometry}
+      material={material}
+      position={[0, SURFACE_WORLD_Y, -4]}
+      frustumCulled={false}
+    />
+  );
+}

--- a/apps/landing/src/cast/world/WaterSurface.tsx
+++ b/apps/landing/src/cast/world/WaterSurface.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+// The paper-ocean surface (M3): a bounded Gerstner water patch seen from above
+// during the fall approach (scene 2) and from below in the deep (scene 3), paved
+// with a sparse instanced layer of floating rejection letters. The water plane's
+// swell is analytic in the vertex shader (installWaterShader, pure f(t)); the
+// floating letters ride the SAME Gerstner surface (water-layout.gerstnerSurface,
+// the shared source of truth) with per-frame matrices, and reuse the storm shader
+// for the letter atlas + a wet-paper micro-flutter. One draw call for the water,
+// one for the letters. Animation useFrame stays at the DEFAULT priority (0).
+
+import { useEffect, useMemo, useRef } from "react";
+import {
+  DoubleSide,
+  InstancedBufferAttribute,
+  type InstancedMesh,
+  Matrix4,
+  MeshLambertMaterial,
+  MeshStandardMaterial,
+  PlaneGeometry,
+  Quaternion,
+  Vector3,
+} from "three";
+import { useFrame } from "@react-three/fiber";
+
+import { surfaceLetterCountForTier, waterSegmentsForTier } from "@/engine/quality-ladder";
+import { playhead, type QualityTier } from "@/engine/store";
+
+import { installStormShader } from "./shaders/paper-storm-shader";
+import { installWaterShader } from "./shaders/water-surface-shader";
+import {
+  gerstnerSurface,
+  SURFACE_PATCH,
+  SURFACE_WORLD_Y,
+  type SurfaceLetter,
+  surfaceLetterInstance,
+  type SurfacePoint,
+} from "./water-layout";
+
+const UNIT_Z = new Vector3(0, 0, 1);
+
+export function WaterSurface({ tier }: { tier: QualityTier }) {
+  const lettersRef = useRef<InstancedMesh>(null);
+  const seg = waterSegmentsForTier(tier);
+  const letterCount = surfaceLetterCountForTier(tier);
+
+  // Water plane: rotate the GEOMETRY (not the mesh) into the XZ plane so the
+  // shader's y-up Gerstner displacement works in object space directly.
+  const { waterGeo, waterMat, waterUniforms } = useMemo(() => {
+    const geo = new PlaneGeometry(SURFACE_PATCH, SURFACE_PATCH, seg, seg);
+    geo.rotateX(-Math.PI / 2);
+    const mat = new MeshStandardMaterial({
+      color: 0x05080e, // dark midnight water (ADR palette)
+      roughness: 0.14,
+      metalness: 0,
+      side: DoubleSide,
+      fog: true,
+    });
+    const u = installWaterShader(mat);
+    return { waterGeo: geo, waterMat: mat, waterUniforms: u };
+  }, [seg]);
+
+  // Floating letters: NOT rotated (faces object +Z), so the reused storm shader's
+  // object-space flutter curls the sheet along its own normal. aSeed/aPhase drive
+  // the atlas cell + flutter, exactly like the storm.
+  const { letterGeo, letterMat, letterUniforms } = useMemo(() => {
+    const geo = new PlaneGeometry(0.9, 1.2, 3, 1);
+    const seeds = new Float32Array(letterCount);
+    const phases = new Float32Array(letterCount);
+    for (let i = 0; i < letterCount; i++) {
+      const inst = surfaceLetterInstance(i);
+      seeds[i] = inst.seed;
+      phases[i] = inst.phase;
+    }
+    geo.setAttribute("aSeed", new InstancedBufferAttribute(seeds, 1));
+    geo.setAttribute("aPhase", new InstancedBufferAttribute(phases, 1));
+    const mat = new MeshLambertMaterial({ color: 0x8f8a7e, side: DoubleSide, fog: true });
+    const u = installStormShader(mat);
+    return { letterGeo: geo, letterMat: mat, letterUniforms: u };
+  }, [letterCount]);
+
+  useEffect(() => {
+    return () => {
+      waterGeo.dispose();
+      waterMat.dispose();
+      letterGeo.dispose();
+      letterMat.dispose();
+    };
+  }, [waterGeo, waterMat, letterGeo, letterMat]);
+
+  // Preallocated scratch -- mutated in place each frame, never reallocated.
+  const scratch = useMemo(
+    () => ({
+      m: new Matrix4(),
+      pos: new Vector3(),
+      quat: new Quaternion(),
+      yaw: new Quaternion(),
+      normal: new Vector3(),
+      scl: new Vector3(),
+      pt: { x: 0, y: 0, z: 0, nx: 0, ny: 1, nz: 0 } as SurfacePoint,
+      letters: [] as SurfaceLetter[],
+    }),
+    [],
+  );
+
+  // Initialize every letter instance once (no unset/white slot), then let the
+  // frame loop ride them on the swell while the surface is on-screen.
+  useEffect(() => {
+    const mesh = lettersRef.current;
+    if (!mesh) return;
+    scratch.letters = Array.from({ length: letterCount }, (_, i) => surfaceLetterInstance(i));
+    for (let i = 0; i < letterCount; i++) {
+      const l = scratch.letters[i];
+      if (!l) continue;
+      scratch.pos.set(l.x, SURFACE_WORLD_Y, l.z);
+      scratch.scl.setScalar(l.scale);
+      scratch.m.compose(scratch.pos, scratch.quat.identity(), scratch.scl);
+      mesh.setMatrixAt(i, scratch.m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [letterCount, scratch]);
+
+  useFrame(() => {
+    const t = playhead.t;
+    waterUniforms.uWaterT.value = t; // pure f(t) swell -- reversible on rewind
+    letterUniforms.uStormT.value = t; // pure f(t) wet-paper micro-flutter on the letters
+
+    // Only re-ride the letters while the surface is on-screen (scene 2 or 3) --
+    // outside that the group is hidden, so skip the per-letter matrix work.
+    const active = playhead.scene === 2 || playhead.scene === 3;
+    const mesh = lettersRef.current;
+    if (!active || !mesh) return;
+    const letters = scratch.letters;
+    for (let i = 0; i < letters.length; i++) {
+      const l = letters[i];
+      if (!l) continue;
+      gerstnerSurface(l.x, l.z, t, scratch.pt);
+      // gerstnerSurface returns the already-displaced world x/z (rest + horizontal
+      // Gerstner swirl); y is the height above the surface plane.
+      scratch.pos.set(scratch.pt.x, SURFACE_WORLD_Y + scratch.pt.y, scratch.pt.z);
+      scratch.normal.set(scratch.pt.nx, scratch.pt.ny, scratch.pt.nz);
+      scratch.quat.setFromUnitVectors(UNIT_Z, scratch.normal);
+      scratch.yaw.setFromAxisAngle(UNIT_Z, l.yaw);
+      scratch.quat.multiply(scratch.yaw); // spin about the paper face, then align to the normal
+      scratch.scl.setScalar(l.scale);
+      scratch.m.compose(scratch.pos, scratch.quat, scratch.scl);
+      mesh.setMatrixAt(i, scratch.m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <>
+      <mesh geometry={waterGeo} material={waterMat} position={[0, SURFACE_WORLD_Y, 0]} frustumCulled={false} />
+      <instancedMesh ref={lettersRef} args={[letterGeo, letterMat, letterCount]} frustumCulled={false} />
+    </>
+  );
+}

--- a/apps/landing/src/cast/world/canyon-layout.test.ts
+++ b/apps/landing/src/cast/world/canyon-layout.test.ts
@@ -50,7 +50,21 @@ describe("stormDensity", () => {
   it("thickens (rises) across the canyon to full near the floor", () => {
     expect(stormDensity(0.1)).toBeLessThan(stormDensity(0.2));
     expect(stormDensity(0.2)).toBeLessThan(stormDensity(0.26));
-    expect(stormDensity(0.28)).toBeCloseTo(1, 5);
+    // Full right at the rise's own upper edge (0.26), BEFORE the fade-out
+    // window starts (0.27) -- the fade-out was tightened to [0.27, 0.32] (M3
+    // review round 2: the storm must clear well before the middle of scene 2
+    // so the water plane + splash crown read, not a dense paper tumble), so
+    // 0.28 (used pre-fix) is no longer "still full" -- it is already fading.
+    expect(stormDensity(0.26)).toBeCloseTo(1, 5);
+  });
+
+  it("clears out approaching the surface crossing so scene 2 reads clean", () => {
+    // M3 review round 2: tightened from the old [0.31, 0.4] fade-out so the
+    // storm is fully gone by the surface crossing (0.32), not still ~74% dense
+    // mid scene-2 (0.34) hiding the water plane + splash crown behind it.
+    expect(stormDensity(0.32)).toBeCloseTo(0, 5);
+    expect(stormDensity(0.34)).toBe(0);
+    expect(stormDensity(0.38)).toBe(0);
   });
 });
 

--- a/apps/landing/src/cast/world/canyon-layout.ts
+++ b/apps/landing/src/cast/world/canyon-layout.ts
@@ -43,10 +43,16 @@ export function hash01(n: number): number {
 // ---- paper-storm density (thickens through the canyon per the ADR) --------
 
 // Storm thickness as a pure function of t: thin at the canyon mouth, thickening
-// to full by the canyon floor, then fading out past the surface (M2 renders the
-// storm only around the canyon band).
+// to full by the canyon floor, then fading out approaching the surface.
+//
+// Fade-out window tightened (M3 review round 2 fix): the old [0.31, 0.4] window
+// kept the storm at ~74% density through the MIDDLE of scene 2 (t=0.34) --
+// still a dense paper tumble hiding the water plane + splash crown behind it.
+// The storm's job is done by the splash; the ADR beat there is the CROWN, not
+// more paper. Fade-out now completes by t=0.32 (just past the surface
+// crossing), so the storm has fully cleared for the rest of scene 2.
 export function stormDensity(t: number): number {
-  return smoothstep(0.05, 0.26, t) * (1 - smoothstep(0.31, 0.4, t));
+  return smoothstep(0.05, 0.26, t) * (1 - smoothstep(0.27, 0.32, t));
 }
 
 // Active instances to reveal via InstancedMesh.count for this t. Every slot is
@@ -94,7 +100,17 @@ export function cameraLookUpY(t: number): number {
 // washed daylight grey-brown mid-blend. Warm end skews hard red/orange (barely
 // any blue -- a sodium-vapor ember, not a tan); cold end is a saturated deep
 // navy (barely any red).
-const FOG_WARM: readonly [number, number, number] = [0.06, 0.024, 0.008];
+//
+// FOG_WARM retuned twice (M3 review): round 1 ([0.06,0.024,0.008] ->
+// [0.11,0.028,0.002]) still read chocolate live -- round 1 pushed the RATIO
+// further red-dominant but did not raise the overall magnitude enough, and
+// R:G had drifted to ~3.9:1 (too close to pure red, not enough orange/amber
+// presence to read as "ember" once gamma-corrected). Round 2: R:G brought back
+// to ~3:1 (a known-good ember ratio, e.g. #FF5500) and overall magnitude more
+// than doubled again so the gamma-boosted screen output lands bright enough to
+// read as a saturated glow rather than a dim muddy tone. B kept low but
+// nonzero (a touch of warmth, not pure red-only).
+const FOG_WARM: readonly [number, number, number] = [0.24, 0.08, 0.015];
 const FOG_COLD: readonly [number, number, number] = [0.006, 0.014, 0.032];
 
 // Writes the fog rgb for this t into `out` (caller-owned, so the per-frame path

--- a/apps/landing/src/cast/world/canyon-layout.ts
+++ b/apps/landing/src/cast/world/canyon-layout.ts
@@ -111,7 +111,10 @@ export function cameraLookUpY(t: number): number {
 // read as a saturated glow rather than a dim muddy tone. B kept low but
 // nonzero (a touch of warmth, not pure red-only).
 const FOG_WARM: readonly [number, number, number] = [0.24, 0.08, 0.015];
-const FOG_COLD: readonly [number, number, number] = [0.006, 0.014, 0.032];
+// Exported (PR #722 CodeRabbit fix): water-layout.ts's worldFog anchors its deep
+// branch's SURFACE_T boundary to this SAME constant (not a re-typed copy) so the
+// waterline crossing can never drift out of sync if this value is retuned again.
+export const FOG_COLD: readonly [number, number, number] = [0.006, 0.014, 0.032];
 
 // Writes the fog rgb for this t into `out` (caller-owned, so the per-frame path
 // never allocates). Sodium-orange city glow up top graded to cold blue in the

--- a/apps/landing/src/cast/world/shaders/godray-shaft-shader.ts
+++ b/apps/landing/src/cast/world/shaders/godray-shaft-shader.ts
@@ -1,0 +1,100 @@
+// Additive god-ray shaft patch (M3 fallback path -- see the godrays decision in
+// the handoff / webgl-standards). A handful of these cone meshes stand in for
+// volumetric god-rays WITHOUT a post composer (which M3 does not build). The real
+// three-good-godrays GodraysPass is a middle composer pass and belongs to the
+// post-chain milestone; this is the cheap, always-available LOW/failure path.
+//
+// OWNERSHIP: webgl-author seeded the soft length + facing fade; shader-engineer
+// refined the look: fresnel-style edge softening (head-on core, soft grazing
+// silhouette), along-shaft depth-graded thinning, and a subtle animated density
+// band. Scene wiring (DeepScene.tsx) never reaches into this file.
+//
+// CONTRACT: appearance is a PURE function of the uStrength uniform, itself a pure
+// f(t) (water-layout.godrayStrength) -- so the shafts thin band by band into the
+// deep and rewind exactly. The density band is phased by uStrength too, so it
+// stays pure f(t) with NO wall-clock and NO extra per-frame uniform (the scene
+// only ever sets uStrength; adding a monotonic deep-time uniform would be a
+// scene-wiring change owned by webgl-author, deliberately avoided here).
+
+import type { MeshBasicMaterial } from "three";
+
+export interface GodrayUniforms {
+  uStrength: { value: number };
+  uShaftColor: { value: unknown };
+}
+
+// Own varyings + our own length coord derived from object-space position rather
+// than the geometry's `uv` attribute. NOTE: three DOES declare `uv` as a vertex
+// attribute unconditionally whenever the bound geometry provides one (ConeGeometry
+// does) -- WebGLProgram emits the attribute straight from the geometry's own
+// attributes, independent of the `USE_UV` macro (that macro only gates the `vUv`
+// VARYING assignment inside three's own chunks). We still avoid it here on
+// purpose: deriving vAjhV from the unit cone's own object-space y keeps this
+// shader correct even if the geometry is ever swapped for one with a different
+// (or no) uv layout, with no extra attribute lookup. vAjhV = cone length coord
+// (base -0.5 -> apex +0.5, remapped to 0..1); vAjhFacing = how head-on the
+// surface faces the camera (softens the silhouette edge).
+const VERTEX_PARS = /* glsl */ `
+  varying float vAjhV;
+  varying float vAjhFacing;
+`;
+
+const VERTEX_BODY = /* glsl */ `
+  vAjhV = position.y + 0.5;
+  vec3 ajh_n = normalize(normalMatrix * normal);
+  vec3 ajh_view = normalize(-mvPosition.xyz);
+  vAjhFacing = abs(dot(ajh_n, ajh_view));
+`;
+
+const FRAGMENT_PARS = /* glsl */ `
+  varying float vAjhV;
+  varying float vAjhFacing;
+  uniform float uStrength;
+  uniform vec3 uShaftColor;
+`;
+
+// Soft shaft body -> additive output alpha. Layers four falloffs:
+//   ajh_len   -- along-shaft length window (fade in from the deep base, taper
+//                before the surface apex) so the cone has no hard caps.
+//   ajh_depth -- depth-graded thinning: full near the surface apex (vAjhV -> 1),
+//                fainter into the deep base (vAjhV -> 0). The band-by-band thinning
+//                with the playhead itself is carried by uStrength (godrayStrength).
+//   ajh_core  -- fresnel-style edge softening: a head-on core (facing -> 1) with a
+//                soft grazing silhouette (facing -> 0), so the cone never shows a
+//                hard geometric outline against the deep.
+//   ajh_dens  -- a subtle density band travelling along the shaft, phased by
+//                uStrength so it drifts as the rays thin and rewinds exactly.
+const FRAGMENT_BODY = /* glsl */ `
+  float ajh_len = smoothstep(0.0, 0.22, vAjhV) * (1.0 - smoothstep(0.6, 1.0, vAjhV));
+  float ajh_depth = mix(0.4, 1.0, vAjhV);
+  float ajh_fres = pow(clamp(vAjhFacing, 0.0, 1.0), 1.6);
+  float ajh_edge = smoothstep(0.0, 0.26, vAjhFacing);
+  float ajh_core = mix(0.28, 1.0, ajh_fres) * ajh_edge;
+  float ajh_dens = 0.85 + 0.15 * sin(vAjhV * 18.0 - uStrength * 12.0);
+  diffuseColor.rgb = uShaftColor;
+  diffuseColor.a *= uStrength * ajh_len * ajh_depth * ajh_core * ajh_dens;
+`;
+
+// Patch a transparent + additive MeshBasicMaterial. The caller sets
+// uStrength.value = godrayStrength(t) each frame. Fail-soft on chunk drift.
+export function installGodrayShaftShader(
+  material: MeshBasicMaterial,
+  shaftColor: unknown,
+): GodrayUniforms {
+  const uniforms: GodrayUniforms = {
+    uStrength: { value: 0 },
+    uShaftColor: { value: shaftColor },
+  };
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.uStrength = uniforms.uStrength;
+    shader.uniforms.uShaftColor = uniforms.uShaftColor;
+    shader.vertexShader = shader.vertexShader
+      .replace("#include <common>", `#include <common>\n${VERTEX_PARS}`)
+      .replace("#include <project_vertex>", `#include <project_vertex>\n${VERTEX_BODY}`);
+    shader.fragmentShader = shader.fragmentShader
+      .replace("#include <common>", `#include <common>\n${FRAGMENT_PARS}`)
+      .replace("#include <color_fragment>", `#include <color_fragment>\n${FRAGMENT_BODY}`);
+  };
+  return uniforms;
+}

--- a/apps/landing/src/cast/world/shaders/tower-window-shader.ts
+++ b/apps/landing/src/cast/world/shaders/tower-window-shader.ts
@@ -51,6 +51,20 @@ const FRAGMENT_PARS = /* glsl */ `
 
 // Injected right after `#include <emissivemap_fragment>` (totalEmissiveRadiance
 // exists). Side faces only -- top/bottom are masked via the object normal.
+//
+// ANTI-ALIASING (M3 review fix -- webgl-author, localized GLSL change): at
+// grazing angles / far distances, the grid's screen-space footprint spans many
+// window cells per pixel. The per-cell hashed on/off pattern has no analytic
+// pre-filtered form (fwidth() can smooth a single continuous EDGE, but not a hard
+// jump between two unrelated per-cell hash values), so sampling it undersampled
+// aliased into a glitchy yellow/black barcode/moire. Two mitigations, both keyed
+// off fwidth(grid) (the cells-per-pixel footprint): (1) the pane-inset edges
+// become an analytic screen-space-sized smoothstep instead of a hard step, and
+// (2) the whole per-cell pattern (lit / pane / brightness / tint) fades toward
+// its known statistical average once undersampled -- the standard mitigation for
+// a hashed pattern that cannot be box-filtered directly, matching what the far
+// side of a real window wall does (resolves to a flat average glow, not a
+// flickering per-window barcode).
 const FRAGMENT_BODY = /* glsl */ `
   float side = step(abs(vObjNormal.y), 0.5);
 
@@ -60,10 +74,24 @@ const FRAGMENT_BODY = /* glsl */ `
     : vec2(vObjPos.x, vObjPos.y);
   vec2 uvw = face + 0.5;
 
-  float cols = mix(3.0, 5.0, hashT(vTowerSeed));
+  // Cell size raised ~2.7x (M3 review round 2 fix): fewer, bigger windows per
+  // face -- the style frames show big readable window grids, and the old
+  // higher-frequency grid aliased badly at our camera distances even with AA.
+  float cols = mix(1.1, 1.8, hashT(vTowerSeed));
   vec2 grid = uvw * vec2(cols, cols * 6.0); // taller-than-wide window rows
   vec2 cell = fract(grid);
   vec2 cid = floor(grid);
+
+  // Cells-per-pixel footprint + the AA blend it drives (0 = crisp near/head-on
+  // pattern, 1 = fully averaged far/grazing wash). Hardened (M3 review round 2
+  // fix): ramps over [0.2, 0.5] cells/pixel instead of [1, 3] -- moire persisted
+  // at grazing angles under the old, looser threshold, so undersampling is now
+  // caught much earlier and fully averaged (no residual pattern) by 0.5
+  // cells/pixel, well before a pixel starts straddling multiple cells' worth of
+  // uncorrelated hash values.
+  vec2 gridFw = fwidth(grid);
+  float cellsPerPixel = max(gridFw.x, gridFw.y);
+  float aaBlend = smoothstep(0.2, 0.5, cellsPerPixel);
 
   // Stable per-window key + its static on/off (unchanged look for most windows).
   float wKey = cid.x * 3.1 + cid.y * 7.7 + vTowerSeed * 19.0;
@@ -81,8 +109,14 @@ const FRAGMENT_BODY = /* glsl */ `
   float animLit = smoothstep(0.42, 0.58, osc); // slow on/off for animating windows
   float lit = mix(baseLit, animLit, animates);
 
-  float pane = step(0.14, cell.x) * step(cell.x, 0.86)
-             * step(0.16, cell.y) * step(cell.y, 0.84);
+  // Pane inset edges: analytic screen-space AA (an fwidth-sized smoothstep)
+  // instead of a hard step -- the inset boundary softens exactly as fast as the
+  // grid itself compresses toward the camera, instead of hard-stepping into a
+  // moire barcode at grazing angles.
+  vec2 cellFw = fwidth(cell) * 0.5;
+  vec2 paneLo = smoothstep(vec2(0.14, 0.16) - cellFw, vec2(0.14, 0.16) + cellFw, cell);
+  vec2 paneHi = 1.0 - smoothstep(vec2(0.86, 0.84) - cellFw, vec2(0.86, 0.84) + cellFw, cell);
+  float pane = paneLo.x * paneHi.x * paneLo.y * paneHi.y;
   float bright = 0.4 + 0.6 * hashT(cid.x * 1.7 + cid.y * 2.3 + vTowerSeed * 7.0);
 
   // Slight per-window warm/cool variance around uWinColor (static, cheap): warmer
@@ -90,7 +124,20 @@ const FRAGMENT_BODY = /* glsl */ `
   float wc = hashT(wKey * 0.7 + 1.3) - 0.5; // -0.5..0.5
   vec3 winTint = uWinColor + vec3(wc * 0.10, wc * 0.02, -wc * 0.14);
 
-  totalEmissiveRadiance += winTint * (side * lit * pane * bright * uWinIntensity);
+  // Fade the whole per-cell pattern toward its known statistical average once
+  // undersampled (aaBlend -> 1). AVG_* are the means of the uniform-hash
+  // distributions used above (baseLit ~ Bernoulli(0.82), pane coverage from the
+  // inset thresholds ~0.72*0.68, bright ~ Uniform[0.4,1.0]) -- so the averaged
+  // result reads as a flat, correctly-lit wall glow instead of a barcode.
+  const float AVG_LIT = 0.82;
+  const float AVG_PANE = 0.49;
+  const float AVG_BRIGHT = 0.7;
+  float litF = mix(lit, AVG_LIT, aaBlend);
+  float paneF = mix(pane, AVG_PANE, aaBlend);
+  float brightF = mix(bright, AVG_BRIGHT, aaBlend);
+  vec3 tintF = mix(winTint, uWinColor, aaBlend);
+
+  totalEmissiveRadiance += tintF * (side * litF * paneF * brightF * uWinIntensity);
 `;
 
 // Patch a MeshStandardMaterial in place and return the live uniforms. uWinColor /

--- a/apps/landing/src/cast/world/shaders/vat-crown-shader.ts
+++ b/apps/landing/src/cast/world/shaders/vat-crown-shader.ts
@@ -1,0 +1,117 @@
+// In-house VAT decode vertex patch for the splash crown (M3).
+//
+// OWNERSHIP: webgl-author seeded the onBeforeCompile scaffold + the position-
+// texture sampling that plays the baked crown (index/interp math from the
+// unit-tested engine/vat.ts). shader-engineer refined the GLSL so the crown
+// LIGHTS correctly and reads as foam:
+//   - Normal reconstruction: the VAT decode moves the vertices but not the flat
+//     rest-disc normal, so the fragment rebuilds a face normal from the decoded
+//     view-space position via its screen derivatives (needs no baked normal
+//     channel and is a drop-in for the real Houdini bake, which ships a normal
+//     texture in the SAME row=frame/column=vertex layout -- decode it here the
+//     same way the position is decoded, remap [0,1]->[-1,1], and set objectNormal).
+//   - Foam brightening at the crest, keyed off the decoded displacement height.
+// The frame-pair uniforms (uRowA/uRowB/uBlend) are unchanged.
+//
+// CONTRACT: playback is pure f(t). The CPU (SplashCrown.tsx) computes the
+// deterministic frame pair + blend from scene-2 progress via vatFrameIndex and
+// feeds them as uniforms; this shader only samples row A and row B for the vertex
+// and lerps -- so scrubbing the splash is just reading a texture at time t,
+// reversible and cheap. Each ROW is a frame, each COLUMN a baked vertex (indexed
+// by the aVatId attribute the geometry carries in bake order).
+
+import type { Material } from "three";
+
+export interface VatCrownUniforms {
+  uVatTex: { value: unknown };
+  uVatWidth: { value: number };
+  uRowA: { value: number };
+  uRowB: { value: number };
+  uBlend: { value: number };
+}
+
+const VERTEX_PARS = /* glsl */ `
+  attribute float aVatId;    // baked vertex index (texture column)
+  uniform sampler2D uVatTex; // baked positions: row = frame, column = vertex
+  uniform float uVatWidth;   // baked vertex count (texture width)
+  uniform float uRowA;       // V of the lower frame row
+  uniform float uRowB;       // V of the upper frame row
+  uniform float uBlend;      // lerp weight A -> B, in [0,1]
+  varying vec3 vAjhView;     // view-space decoded position -> fragment normal reconstruction
+  varying float vAjhFoam;    // decoded crest height -> foam brightening
+`;
+
+// Replace the geometry position with the interpolated baked crown position. Two
+// nearest-filtered samples (one per frame row) lerped by the CPU-computed blend
+// -- the interpolation weight is deterministic, so playback is pure f(t). Also
+// carry the view-space position (for the fragment face-normal reconstruction) and
+// the crest height (for foam) forward as varyings.
+const VERTEX_BODY = /* glsl */ `
+  float ajh_u = (aVatId + 0.5) / uVatWidth;
+  vec3 ajh_pA = texture2D(uVatTex, vec2(ajh_u, uRowA)).xyz;
+  vec3 ajh_pB = texture2D(uVatTex, vec2(ajh_u, uRowB)).xyz;
+  transformed = mix(ajh_pA, ajh_pB, uBlend);
+  vAjhView = (modelViewMatrix * vec4(transformed, 1.0)).xyz;
+  vAjhFoam = transformed.y; // crown height above the flat rest disc = crest magnitude
+`;
+
+const FRAGMENT_PARS = /* glsl */ `
+  varying vec3 vAjhView;
+  varying float vAjhFoam;
+`;
+
+// Reconstruct the shading normal from the decoded geometry. The VAT decode
+// displaces the vertices but leaves three's rest-disc normal, so the crown would
+// light as a flat plane. Rebuild a per-fragment face normal from the screen-space
+// derivatives of the decoded view-space position and orient it toward the camera
+// (view-space origin) so the DOUBLE-sided crown lights on both faces.
+const FRAGMENT_NORMAL = /* glsl */ `
+  vec3 ajh_fn = normalize(cross(dFdx(vAjhView), dFdy(vAjhView)));
+  vec3 ajh_V = normalize(-vAjhView);
+  if (dot(ajh_fn, ajh_V) < 0.0) ajh_fn = -ajh_fn;
+  normal = ajh_fn;
+`;
+
+// Foam-ish brightening at the crest: the higher the decoded displacement, the
+// whiter/foamier the paper-ocean spray. Pure f(t) via the decoded position, so it
+// erupts and recedes with the splash and rewinds exactly.
+const FRAGMENT_FOAM = /* glsl */ `
+  float ajh_foam = smoothstep(0.6, 3.2, vAjhFoam);
+  diffuseColor.rgb = mix(diffuseColor.rgb, vec3(0.96, 0.99, 1.0), ajh_foam * 0.7);
+`;
+
+// Patch any position-based material (MeshStandardMaterial here) to play the VAT.
+// The caller owns the uniform object and updates uRowA / uRowB / uBlend each frame
+// from vatFrameIndex + frameRowV. Fail-soft: a drifted chunk name is a no-op.
+export function installVatCrownShader(
+  material: Material,
+  vatTexture: unknown,
+  vertices: number,
+): VatCrownUniforms {
+  const uniforms: VatCrownUniforms = {
+    uVatTex: { value: vatTexture },
+    uVatWidth: { value: vertices },
+    uRowA: { value: 0 },
+    uRowB: { value: 0 },
+    uBlend: { value: 0 },
+  };
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.uVatTex = uniforms.uVatTex;
+    shader.uniforms.uVatWidth = uniforms.uVatWidth;
+    shader.uniforms.uRowA = uniforms.uRowA;
+    shader.uniforms.uRowB = uniforms.uRowB;
+    shader.uniforms.uBlend = uniforms.uBlend;
+    shader.vertexShader = shader.vertexShader
+      .replace("#include <common>", `#include <common>\n${VERTEX_PARS}`)
+      .replace("#include <begin_vertex>", `#include <begin_vertex>\n${VERTEX_BODY}`);
+    shader.fragmentShader = shader.fragmentShader
+      .replace("#include <common>", `#include <common>\n${FRAGMENT_PARS}`)
+      .replace(
+        "#include <normal_fragment_maps>",
+        `#include <normal_fragment_maps>\n${FRAGMENT_NORMAL}`,
+      )
+      .replace("#include <color_fragment>", `#include <color_fragment>\n${FRAGMENT_FOAM}`);
+  };
+  return uniforms;
+}

--- a/apps/landing/src/cast/world/shaders/water-surface-shader.ts
+++ b/apps/landing/src/cast/world/shaders/water-surface-shader.ts
@@ -1,0 +1,185 @@
+// Gerstner water-surface vertex/fragment patch for the bounded ocean patch (M3).
+//
+// OWNERSHIP: webgl-author seeded the onBeforeCompile scaffold + the analytic
+// Gerstner displacement + normal; shader-engineer refined the fragment look:
+// (1) a real derivative-based multi-octave micro-detail normal map (replacing the
+// 2-sine placeholder) and (2) a fresnel-graded horizon sky reflection. The
+// Gerstner VERTEX displacement is UNCHANGED -- it must stay bit-identical with
+// water-layout.gerstnerSurface (shared GERSTNER_WAVES). The cursor ripple-drag
+// DataTexture wake + differential-area caustics stay TODO (they need a scene-fed
+// wake texture, i.e. scene wiring, so they are a separate pass). Scene wiring
+// (WaterSurface.tsx) never reaches into this file.
+//
+// CONTRACT: the displacement is a PURE function of the playhead uniform uWaterT
+// (never a wall-clock uTime), so scrubbing up rewinds the swell exactly and a
+// paused scroll freezes it. The wave set is generated from the SINGLE source of
+// truth in water-layout.ts (GERSTNER_WAVES), so the surface this shader draws
+// matches the surface the CPU floating-letter layer rides (gerstnerSurface).
+
+import type { MeshStandardMaterial } from "three";
+
+import { GERSTNER_WAVES } from "../water-layout";
+
+export interface WaterUniforms {
+  uWaterT: { value: number };
+}
+
+// GLSL float literal (always has a decimal point so it is a float, not an int).
+function f(n: number): string {
+  return n.toFixed(6);
+}
+
+// Build the GLSL const wave arrays from the CPU wave list (directions
+// pre-normalized here so the shader loop does not have to). vec4 = (dirX, dirZ,
+// amp, wavelength); vec2 = (steepness, omega).
+function waveArraysGLSL(): string {
+  const wv: string[] = [];
+  const wq: string[] = [];
+  for (const w of GERSTNER_WAVES) {
+    const dl = Math.hypot(w.dx, w.dz) || 1;
+    wv.push(`vec4(${f(w.dx / dl)}, ${f(w.dz / dl)}, ${f(w.amp)}, ${f(w.len)})`);
+    wq.push(`vec2(${f(w.steep)}, ${f(w.omega)})`);
+  }
+  const n = GERSTNER_WAVES.length;
+  return `
+  const int AJH_NW = ${n};
+  const vec4 AJH_WV[${n}] = vec4[](${wv.join(", ")});
+  const vec2 AJH_WQ[${n}] = vec2[](${wq.join(", ")});`;
+}
+
+// Head of the vertex pars; the generated wave arrays are spliced between this and
+// the gerstner function so the const arrays are declared before the loop reads them.
+const VERTEX_PARS_HEAD = /* glsl */ `
+  uniform float uWaterT;   // playhead t in [0,1] -- the ONLY animation clock
+  varying vec2 vAjhXZ;     // rest xz -> fragment (procedural micro-detail domain)
+  varying vec3 vAjhView;   // view-space displaced position -> fragment (view dir + tangents)
+  vec3 ajh_pos;            // displaced object position, shared normal->body`;
+
+const VERTEX_PARS_FN = /* glsl */ `
+  // Sum-of-Gerstner-waves displacement + analytic normal. Pure f(xz, t); mirrors
+  // water-layout.gerstnerSurface exactly (same constants, same math).
+  vec3 ajh_gerstner(vec2 xz, float t, out vec3 nrm) {
+    vec3 p = vec3(xz.x, 0.0, xz.y);
+    float sNx = 0.0; float sNy = 0.0; float sNz = 0.0;
+    for (int i = 0; i < AJH_NW; i++) {
+      vec4 wv = AJH_WV[i];
+      vec2 wq = AJH_WQ[i];
+      vec2 dir = wv.xy;
+      float amp = wv.z;
+      float k = 6.283185307 / wv.w;
+      float steep = wq.x;
+      float phase = k * dot(dir, xz) + t * wq.y;
+      float c = cos(phase); float s = sin(phase);
+      p.x += steep * amp * dir.x * c;
+      p.z += steep * amp * dir.y * c;
+      p.y += amp * s;
+      float wa = k * amp;
+      sNx += dir.x * wa * c;
+      sNz += dir.y * wa * c;
+      sNy += steep * wa * s;
+    }
+    nrm = normalize(vec3(-sNx, 1.0 - sNy, -sNz));
+    return p;
+  }
+`;
+
+// The ONE Gerstner evaluation per vertex: perturb the normal (so lit shading +
+// specular track the swell) and stash the displaced position for begin_vertex.
+const VERTEX_NORMAL = /* glsl */ `
+  vec3 ajh_n;
+  ajh_pos = ajh_gerstner(position.xz, uWaterT, ajh_n);
+  objectNormal = ajh_n;
+`;
+
+const VERTEX_BODY = /* glsl */ `
+  transformed = ajh_pos;
+  vAjhXZ = position.xz;
+  // View-space displaced position: self-contained source for the fragment view
+  // direction + tangent frame (never depends on three's internal vViewPosition).
+  vAjhView = (modelViewMatrix * vec4(ajh_pos, 1.0)).xyz;
+`;
+
+const FRAGMENT_PARS = /* glsl */ `
+  uniform float uWaterT;
+  varying vec2 vAjhXZ;      // rest xz -> procedural micro-detail domain
+  varying vec3 vAjhView;    // view-space surface position (self-contained view dir + tangents)
+
+  // Fresnel term computed once the shading normal is final (normal_fragment_maps)
+  // and reused for the horizon reflection at lights_fragment_end. Declared global
+  // (like the storm shader's ajh_dz) so a theoretical chunk-name drift on one
+  // inject can never leave it undeclared.
+  float ajh_fres;
+
+  // Cool moonlit sky tint the water reflects at grazing angles, plus the micro-
+  // detail tilt strength. Both kept modest so the floating-letter layer stays
+  // readable: looking straight DOWN onto the letters the fresnel ~ 0, so the
+  // water stays dark under them; only the far horizon brightens, where few
+  // letters sit, and the micro-tilt is a gentle sparkle, not a wash.
+  const vec3 AJH_SKY_REFLECT = vec3(0.05, 0.09, 0.15);
+  const float AJH_MICRO = 0.025;
+
+  // Analytic gradient of a 3-octave travelling ripple height field h(xz, t):
+  // d/dp of sum( amp * sin(dot(p,dir)*freq + t*speed) ) = sum( dir*freq*amp*cos ).
+  // Pure f(t, xz) -- the micro-glints animate with the swell and rewind exactly.
+  vec2 ajh_microGrad(vec2 p, float t) {
+    vec2 g = vec2(0.0);
+    vec2 d1 = vec2(0.94, 0.34); float f1 = 1.6;
+    g += d1 * f1 * (0.90 * cos(dot(p, d1) * f1 + t * 26.0));
+    vec2 d2 = vec2(-0.42, 0.91); float f2 = 3.3;
+    g += d2 * f2 * (0.50 * cos(dot(p, d2) * f2 + t * 37.0));
+    vec2 d3 = vec2(0.71, -0.70); float f3 = 6.7;
+    g += d3 * f3 * (0.26 * cos(dot(p, d3) * f3 - t * 51.0));
+    return g;
+  }
+`;
+
+// Derivative-based multi-octave micro-detail normal map (replaces the 2-sine
+// placeholder). Builds a view-space tangent frame from the surface's screen-space
+// derivatives and tilts the shading normal by the analytic ripple gradient, so
+// the low-roughness moonlit specular sparkles with high-frequency detail the
+// coarse Gerstner vertex mesh cannot carry. Then measures the fresnel toward the
+// horizon (camera at the view-space origin) for the sky reflection below.
+const FRAGMENT_NORMAL = /* glsl */ `
+  vec2 ajh_g = ajh_microGrad(vAjhXZ, uWaterT);
+  vec3 ajh_dpx = dFdx(vAjhView);
+  vec3 ajh_T = dot(ajh_dpx, ajh_dpx) > 1e-10 ? normalize(ajh_dpx) : vec3(1.0, 0.0, 0.0);
+  vec3 ajh_B = normalize(cross(normal, ajh_T));
+  normal = normalize(normal - (ajh_T * ajh_g.x + ajh_B * ajh_g.y) * AJH_MICRO);
+
+  vec3 ajh_V = normalize(-vAjhView);
+  ajh_fres = pow(1.0 - clamp(dot(normal, ajh_V), 0.0, 1.0), 5.0);
+`;
+
+// Fresnel-graded reflectivity toward the horizon: add a cool sky tint to the
+// indirect specular, scaled by the fresnel term. Grazing angles (the far
+// horizon) reflect the sky; head-on (looking down onto the letters) adds nothing.
+const FRAGMENT_REFLECT = /* glsl */ `
+  reflectedLight.indirectSpecular += ajh_fres * AJH_SKY_REFLECT;
+`;
+
+// Patch a MeshStandardMaterial in place and return the live uniform object the
+// scene updates each frame (uWaterT.value = playhead.t). Fail-soft: if a three
+// chunk name ever drifts the String.replace is a no-op (no injection, no crash).
+export function installWaterShader(material: MeshStandardMaterial): WaterUniforms {
+  const uniforms: WaterUniforms = { uWaterT: { value: 0 } };
+  const pars = `${VERTEX_PARS_HEAD}\n${waveArraysGLSL()}\n${VERTEX_PARS_FN}`;
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.uWaterT = uniforms.uWaterT;
+    shader.vertexShader = shader.vertexShader
+      .replace("#include <common>", `#include <common>\n${pars}`)
+      .replace("#include <beginnormal_vertex>", `#include <beginnormal_vertex>\n${VERTEX_NORMAL}`)
+      .replace("#include <begin_vertex>", `#include <begin_vertex>\n${VERTEX_BODY}`);
+    shader.fragmentShader = shader.fragmentShader
+      .replace("#include <common>", `#include <common>\n${FRAGMENT_PARS}`)
+      .replace(
+        "#include <normal_fragment_maps>",
+        `#include <normal_fragment_maps>\n${FRAGMENT_NORMAL}`,
+      )
+      .replace(
+        "#include <lights_fragment_end>",
+        `#include <lights_fragment_end>\n${FRAGMENT_REFLECT}`,
+      );
+  };
+  return uniforms;
+}

--- a/apps/landing/src/cast/world/splash-crown.test.ts
+++ b/apps/landing/src/cast/world/splash-crown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { CROWN_FRAMES, crownVertexAt, normalizeAngle } from "./splash-crown";
+import { CROWN_FRAMES, CROWN_RADIUS, crownVertexAt, normalizeAngle } from "./splash-crown";
 
 function vert(): [number, number, number] {
   return [0, 0, 0];
@@ -37,6 +37,44 @@ describe("crownVertexAt (procedural VAT stand-in bake, deterministic)", () => {
       expect(Number.isFinite(out[0] + out[1] + out[2])).toBe(true);
     }
   });
+
+  it("produces finite positions across a sweep of frame, radius, AND angle", () => {
+    // Broader than the single-radius/angle sweep above (PR #722 CodeRabbit ask)
+    // -- covers the rest position (radius 0), the outer rim (CROWN_RADIUS), and
+    // wrap-around angles, at every frame in the clip.
+    const out = vert();
+    const radii = [0, 1.5, CROWN_RADIUS * 0.5, CROWN_RADIUS, CROWN_RADIUS * 1.1];
+    const angles = [0, Math.PI * 0.5, Math.PI, Math.PI * 1.5, Math.PI * 2 - 0.001];
+    for (let f = 0; f < CROWN_FRAMES; f++) {
+      for (const radius of radii) {
+        for (const angle of angles) {
+          crownVertexAt(radius, angle, f, CROWN_FRAMES, out);
+          expect(Number.isFinite(out[0])).toBe(true);
+          expect(Number.isFinite(out[1])).toBe(true);
+          expect(Number.isFinite(out[2])).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("degenerate bake (frames <= 1): flat (zero height) and finite, never divides by zero", () => {
+    // frames<=1 has no frame RANGE to interpolate a position within -- the
+    // `frames <= 1 ? 0 : ...` guard in the fp computation exists exactly to
+    // avoid a frames-1 === 0 division; assert that guard actually holds for
+    // both frames=1 and the frames=0 edge (an even-more-degenerate bake).
+    for (const frames of [1, 0]) {
+      const out = vert();
+      crownVertexAt(4, 1.2, 0, frames, out);
+      expect(out[1]).toBe(0); // flat: fp is forced to 0 -> env = sin(0) = 0 -> height = 0 exactly
+      expect(Number.isFinite(out[0])).toBe(true);
+      expect(Number.isFinite(out[1])).toBe(true);
+      expect(Number.isFinite(out[2])).toBe(true);
+      // Non-zero `frame` input is also ignored/safe under the degenerate guard.
+      const out2 = vert();
+      crownVertexAt(4, 1.2, 30, frames, out2);
+      expect(out2).toEqual(out);
+    }
+  });
 });
 
 describe("normalizeAngle", () => {
@@ -44,5 +82,12 @@ describe("normalizeAngle", () => {
     expect(normalizeAngle(-Math.PI)).toBeCloseTo(Math.PI, 10);
     expect(normalizeAngle(0)).toBe(0);
     expect(normalizeAngle(3 * Math.PI)).toBeCloseTo(Math.PI, 10);
+  });
+
+  it("wraps the exact upper bound (2PI) down to 0, not up to 2PI", () => {
+    // a % a === 0 exactly in IEEE 754 (no rounding error), so this must be an
+    // EXACT 0, not merely close to it -- the untested boundary the interval is
+    // half-open [0, 2PI) around.
+    expect(normalizeAngle(Math.PI * 2)).toBe(0);
   });
 });

--- a/apps/landing/src/cast/world/splash-crown.test.ts
+++ b/apps/landing/src/cast/world/splash-crown.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { CROWN_FRAMES, crownVertexAt, normalizeAngle } from "./splash-crown";
+
+function vert(): [number, number, number] {
+  return [0, 0, 0];
+}
+
+describe("crownVertexAt (procedural VAT stand-in bake, deterministic)", () => {
+  it("is deterministic: the same (radius, angle, frame) always bakes the same position", () => {
+    const a = vert();
+    const b = vert();
+    crownVertexAt(3.2, 1.1, 20, CROWN_FRAMES, a);
+    crownVertexAt(3.2, 1.1, 20, CROWN_FRAMES, b);
+    expect(a).toEqual(b);
+  });
+
+  it("is flat (zero height) at the first and last frame -- the crown erupts then falls back", () => {
+    const a = vert();
+    const b = vert();
+    crownVertexAt(4, 0.7, 0, CROWN_FRAMES, a);
+    crownVertexAt(4, 0.7, CROWN_FRAMES - 1, CROWN_FRAMES, b);
+    expect(a[1]).toBeCloseTo(0, 10); // sin(0) == 0 exactly
+    expect(b[1]).toBeCloseTo(0, 10); // sin(PI) is ~1e-16, not literally 0
+  });
+
+  it("rises to a positive crown height mid-clip", () => {
+    const mid = vert();
+    crownVertexAt(7, 0, Math.floor(CROWN_FRAMES / 2), CROWN_FRAMES, mid);
+    expect(mid[1]).toBeGreaterThan(0);
+  });
+
+  it("produces finite positions across the whole clip", () => {
+    const out = vert();
+    for (let f = 0; f < CROWN_FRAMES; f++) {
+      crownVertexAt(5, 2.4, f, CROWN_FRAMES, out);
+      expect(Number.isFinite(out[0] + out[1] + out[2])).toBe(true);
+    }
+  });
+});
+
+describe("normalizeAngle", () => {
+  it("wraps into [0, 2PI)", () => {
+    expect(normalizeAngle(-Math.PI)).toBeCloseTo(Math.PI, 10);
+    expect(normalizeAngle(0)).toBe(0);
+    expect(normalizeAngle(3 * Math.PI)).toBeCloseTo(Math.PI, 10);
+  });
+});

--- a/apps/landing/src/cast/world/splash-crown.ts
+++ b/apps/landing/src/cast/world/splash-crown.ts
@@ -1,0 +1,81 @@
+// Procedural stand-in crown for the splash VAT (M3). The real hero asset is a
+// Houdini FLIP crown baked to a VAT -- a DCC deliverable that does not exist yet
+// (DCC ownership is an open ADR-0016 item). This is the placeholder bake: an
+// analytic milk-crown (a ring of displaced verts rising then falling with radial
+// falloff), baked ONCE at load into a small float DataTexture and played back
+// through the SAME in-house VAT decode path the real bake will drop into. Visually
+// a placeholder; contractually identical (baked position per frame per vertex).
+//
+// This file owns only the PURE, three-free displacement math (unit-tested). The
+// component (SplashCrown.tsx) reads its rest geometry, calls crownVertexAt per
+// (frame, vertex), and packs the result into a DataTexture.
+
+const TWO_PI = Math.PI * 2;
+
+// Bake dimensions (kept small -- the texture is generated at runtime, so it ships
+// 0 bytes and never touches the <=10 MB asset budget). A RingGeometry at these
+// segment counts is the rest mesh; its vertex count is the texture width.
+export const CROWN_RADIUS = 7;
+export const CROWN_RINGS = 12;
+export const CROWN_SEGMENTS = 40;
+export const CROWN_FRAMES = 64;
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0;
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  if (edge0 === edge1) return x < edge0 ? 0 : 1;
+  const t = clamp01((x - edge0) / (edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+function mix(a: number, b: number, x: number): number {
+  return a + (b - a) * x;
+}
+
+// Baked crown position for a rest vertex at (radius, angle) at a normalized frame
+// position, written into `out` (caller-owned). PURE + deterministic so the bake
+// never drifts across sessions (consistent with the scrub contract). The crown is
+// FLAT at frame 0 and the last frame (env = 0 there), rising to a scalloped rim +
+// centre jet at mid -- a splash that erupts and falls back.
+export function crownVertexAt(
+  radius: number,
+  angle: number,
+  frame: number,
+  frames: number,
+  out: [number, number, number],
+): void {
+  const fp = frames <= 1 ? 0 : clamp01(frame / (frames - 1));
+  const env = Math.sin(Math.PI * fp); // 0 at start/end, 1 at mid: rise then fall
+  const rise = Math.pow(env, 0.7);
+
+  // Expanding rim ring: grows from a tight splash to the full radius then settles.
+  const rim = mix(0.15, 1, smoothstep(0, 0.55, fp)) * CROWN_RADIUS;
+  const width = CROWN_RADIUS * 0.28;
+  const d = radius - rim;
+  const g = Math.exp(-(d * d) / (2 * width * width));
+  const spikes = 1 + 0.35 * Math.cos(CROWN_SEGMENTS * 0.5 * angle); // scalloped rim
+
+  // Central jet: a thin column that shoots up as the crown opens then recedes.
+  const jw = CROWN_RADIUS * 0.14;
+  const centerJet =
+    Math.exp(-(radius * radius) / (2 * jw * jw)) *
+    smoothstep(0.1, 0.45, fp) *
+    (1 - smoothstep(0.5, 0.9, fp));
+
+  const height = rise * (g * spikes * CROWN_RADIUS * 0.5 + centerJet * CROWN_RADIUS * 0.7);
+  const expand = 1 + 0.16 * rise; // slight horizontal spread as it erupts
+  out[0] = Math.cos(angle) * radius * expand;
+  out[1] = height;
+  out[2] = Math.sin(angle) * radius * expand;
+}
+
+// Normalize an atan2 angle into [0, 2PI) -- helper for the component when it
+// derives (radius, angle) from a rest vertex position.
+export function normalizeAngle(a: number): number {
+  let x = a % TWO_PI;
+  if (x < 0) x += TWO_PI;
+  return x;
+}

--- a/apps/landing/src/cast/world/water-layout.test.ts
+++ b/apps/landing/src/cast/world/water-layout.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+
+import { cameraY } from "./canyon-layout";
+import {
+  cameraLookDownOffset,
+  gerstnerHeight,
+  gerstnerSurface,
+  godrayStrength,
+  sceneLuminance,
+  SURFACE_WORLD_Y,
+  type SurfacePoint,
+  worldFog,
+  type WorldLayers,
+  worldLayers,
+  writeWorldLayers,
+} from "./water-layout";
+
+function pt(): SurfacePoint {
+  return { x: 0, y: 0, z: 0, nx: 0, ny: 1, nz: 0 };
+}
+
+describe("Gerstner surface (pure f(t, xz), scrub-safe)", () => {
+  it("is deterministic: the same (x, z, t) always yields the same point", () => {
+    const a = pt();
+    const b = pt();
+    gerstnerSurface(12.5, -7.25, 0.42, a);
+    gerstnerSurface(12.5, -7.25, 0.42, b);
+    expect(a).toEqual(b);
+  });
+
+  it("is reversible: re-evaluating at an earlier t retraces the exact point", () => {
+    const t0 = pt();
+    const mid = pt();
+    const back = pt();
+    gerstnerSurface(3, 4, 0.33, t0);
+    gerstnerSurface(3, 4, 0.51, mid); // move forward
+    gerstnerSurface(3, 4, 0.33, back); // scrub back
+    expect(back).toEqual(t0);
+    // and the forward frame genuinely differed (the surface actually animates)
+    expect(mid.y).not.toBeCloseTo(t0.y, 6);
+  });
+
+  it("returns a unit-length normal", () => {
+    const p = pt();
+    for (const t of [0, 0.3, 0.44, 0.77, 1]) {
+      gerstnerSurface(-18, 9, t, p);
+      expect(Math.hypot(p.nx, p.ny, p.nz)).toBeCloseTo(1, 6);
+    }
+  });
+
+  it("gerstnerHeight matches the full-surface y (cheap path is consistent)", () => {
+    const p = pt();
+    gerstnerSurface(21, -5, 0.4, p);
+    expect(gerstnerHeight(21, -5, 0.4)).toBeCloseTo(p.y, 10);
+  });
+
+  it("produces finite output across the patch for finite inputs", () => {
+    // The kernel mirrors the guard-free water vertex shader (callers pass finite
+    // letter positions + the already-clamped playhead t) -- assert it stays finite
+    // over the sampled range, corners included.
+    const p = pt();
+    for (const x of [-150, -37, 0, 88, 150]) {
+      for (const t of [0.3, 0.44, 0.58]) {
+        gerstnerSurface(x, -x * 0.5, t, p);
+        expect(Number.isFinite(p.x + p.y + p.z)).toBe(true);
+        expect(Number.isFinite(p.nx + p.ny + p.nz)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("scene-range visibility (worldLayers)", () => {
+  it("shows only the canyon in the cold-open + canyon (scenes 0-1)", () => {
+    for (const s of [0, 1]) {
+      expect(worldLayers(s)).toEqual({
+        canyon: true,
+        water: false,
+        splash: false,
+        deep: false,
+        markers: false,
+      });
+    }
+  });
+
+  it("shows canyon + water + splash at the surface (scene 2)", () => {
+    expect(worldLayers(2)).toEqual({
+      canyon: true,
+      water: true,
+      splash: true,
+      deep: false,
+      markers: false,
+    });
+  });
+
+  it("shows water + deep in the deep (scene 3) and deep-only in the blackout (scene 4)", () => {
+    expect(worldLayers(3)).toEqual({
+      canyon: false,
+      water: true,
+      splash: false,
+      deep: true,
+      markers: false,
+    });
+    expect(worldLayers(4)).toEqual({
+      canyon: false,
+      water: false,
+      splash: false,
+      deep: true,
+      markers: false,
+    });
+  });
+
+  it("shows the placeholder markers only for the not-yet-built scenes 5-8", () => {
+    for (const s of [5, 6, 7, 8]) {
+      expect(worldLayers(s).markers).toBe(true);
+      expect(worldLayers(s).deep).toBe(false);
+      expect(worldLayers(s).canyon).toBe(false);
+    }
+  });
+});
+
+describe("writeWorldLayers (the zero-per-frame-allocation out-param path)", () => {
+  it("mutates the SAME out object across calls instead of allocating a fresh one", () => {
+    const out: WorldLayers = { canyon: false, water: false, splash: false, deep: false, markers: false };
+    const identity = out;
+    writeWorldLayers(0, out);
+    expect(out).toBe(identity); // same reference -- no reallocation
+    expect(out.canyon).toBe(true);
+    writeWorldLayers(3, out);
+    expect(out).toBe(identity);
+    expect(out).toEqual({ canyon: false, water: true, splash: false, deep: true, markers: false });
+  });
+
+  it("agrees with worldLayers() (the fresh-object wrapper) for every scene", () => {
+    const out: WorldLayers = { canyon: false, water: false, splash: false, deep: false, markers: false };
+    for (let s = 0; s <= 8; s++) {
+      writeWorldLayers(s, out);
+      expect(out).toEqual(worldLayers(s));
+    }
+  });
+});
+
+describe("luminance target + godray strength (pure f(t))", () => {
+  it("sceneLuminance is full through the canyon and never leaves [0, 1]", () => {
+    for (const t of [0, 0.1, 0.29, 0.3]) expect(sceneLuminance(t)).toBe(1);
+    for (const t of [0, 0.3, 0.4, 0.52, 0.58, 0.7, 1]) {
+      const l = sceneLuminance(t);
+      expect(l).toBeGreaterThanOrEqual(0);
+      expect(l).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("sceneLuminance dims monotonically from the surface into the blackout", () => {
+    const samples = [0.3, 0.34, 0.38, 0.45, 0.52, 0.55, 0.58];
+    for (let i = 0; i < samples.length - 1; i++) {
+      const hi = sceneLuminance(samples[i] as number);
+      const lo = sceneLuminance(samples[i + 1] as number);
+      expect(lo).toBeLessThanOrEqual(hi + 1e-9);
+    }
+    expect(sceneLuminance(0.58)).toBeLessThan(0.1); // near-black by the blackout
+  });
+
+  it("godrayStrength is zero outside the deep band and positive within it", () => {
+    expect(godrayStrength(0.3)).toBe(0); // above the surface
+    expect(godrayStrength(0.57)).toBe(0); // gone by the blackout
+    expect(godrayStrength(0.42)).toBeGreaterThan(0); // mid-deep
+  });
+});
+
+describe("cameraLookDownOffset (the M3 review round-2 camera-aim fix)", () => {
+  it("is exactly zero outside the water-crossing window", () => {
+    expect(cameraLookDownOffset(0.2)).toBe(0); // deep in the canyon
+    expect(cameraLookDownOffset(0.27)).toBe(0); // exactly the ramp-in edge
+    expect(cameraLookDownOffset(0.58)).toBe(0); // exactly the blackout cutoff
+    expect(cameraLookDownOffset(0.7)).toBe(0); // well past the blackout
+  });
+
+  it("holds the look-at target close to the fixed water plane through scene 2", () => {
+    // Numerically verified (see the M3 handoff log for the full sweep + the
+    // frustum-angle check this bound was chosen from): the OLD offset let the
+    // aim drift ~20 units from the plane by mid scene-2, pointing the camera
+    // away from the paved ocean + splash crown entirely. The fixed offset keeps
+    // the aim within a small, bounded distance of the plane for the WHOLE of
+    // scene 2 [0.30, 0.38), not just an instant at the crossing.
+    for (let t = 0.3; t <= 0.38; t += 0.005) {
+      const aimY = cameraY(t) + cameraLookDownOffset(t);
+      expect(Math.abs(aimY - SURFACE_WORLD_Y)).toBeLessThan(8);
+    }
+  });
+
+  it("converges to exactly the deep-scene magnitude once solidly past the crossing", () => {
+    // Matches the ORIGINAL constant (-12) the coordinator already approved for
+    // the deep/blackout framing at t=0.45 -- this fix's transition-window
+    // change must not alter that already-approved look.
+    for (const t of [0.43, 0.45, 0.48, 0.5, 0.53]) {
+      expect(cameraLookDownOffset(t)).toBeCloseTo(-12, 6);
+    }
+  });
+});
+
+describe("worldFog (cold-open density pullback + the whole-descent grade)", () => {
+  const rgb: [number, number, number] = [0, 0, 0];
+
+  it("reduces density at the cold open relative to the established canyon density", () => {
+    const openDensity = worldFog(0.02, rgb);
+    const canyonDensity = worldFog(0.15, rgb); // deep in the canyon fall
+    expect(openDensity).toBeLessThan(canyonDensity);
+    expect(openDensity).toBeGreaterThan(0); // never fully clear (still atmosphere)
+  });
+
+  it("ramps the cold-open density up to the canyon density by t=0.05", () => {
+    const at0 = worldFog(0, rgb);
+    const at005 = worldFog(0.05, rgb);
+    const canyonDensity = worldFog(0.15, rgb);
+    expect(at0).toBeLessThan(at005);
+    expect(at005).toBeCloseTo(canyonDensity, 6);
+  });
+
+  it("returns a valid, finite density and rgb across the whole descent", () => {
+    for (let t = 0; t <= 1; t += 0.05) {
+      const d = worldFog(t, rgb);
+      expect(Number.isFinite(d)).toBe(true);
+      expect(d).toBeGreaterThan(0);
+      expect(Number.isFinite(rgb[0] + rgb[1] + rgb[2])).toBe(true);
+    }
+  });
+});
+
+describe("world anchors", () => {
+  it("the surface plane sits below the camera's surface-crossing altitude", () => {
+    expect(Number.isFinite(SURFACE_WORLD_Y)).toBe(true);
+    expect(SURFACE_WORLD_Y).toBeLessThan(0);
+  });
+});

--- a/apps/landing/src/cast/world/water-layout.test.ts
+++ b/apps/landing/src/cast/world/water-layout.test.ts
@@ -7,6 +7,7 @@ import {
   gerstnerSurface,
   godrayStrength,
   sceneLuminance,
+  SURFACE_T,
   SURFACE_WORLD_Y,
   type SurfacePoint,
   worldFog,
@@ -222,6 +223,20 @@ describe("worldFog (cold-open density pullback + the whole-descent grade)", () =
       expect(d).toBeGreaterThan(0);
       expect(Number.isFinite(rgb[0] + rgb[1] + rgb[2])).toBe(true);
     }
+  });
+
+  it("is continuous across the SURFACE_T waterline crossing (PR #722 fix -- no visible pop)", () => {
+    // The canyon branch is used for c < SURFACE_T and the deep branch for
+    // c >= SURFACE_T (worldFog's own `c < SURFACE_T` split), so sampling just
+    // below and exactly at SURFACE_T exercises both branches right at the seam.
+    const below: [number, number, number] = [0, 0, 0];
+    const above: [number, number, number] = [0, 0, 0];
+    const densityBelow = worldFog(SURFACE_T - 1e-6, below);
+    const densityAbove = worldFog(SURFACE_T, above);
+    expect(densityAbove).toBeCloseTo(densityBelow, 4);
+    expect(above[0]).toBeCloseTo(below[0], 4);
+    expect(above[1]).toBeCloseTo(below[1], 4);
+    expect(above[2]).toBeCloseTo(below[2], 4);
   });
 });
 

--- a/apps/landing/src/cast/world/water-layout.ts
+++ b/apps/landing/src/cast/world/water-layout.ts
@@ -1,0 +1,424 @@
+// Pure water / deep / blackout math (M3) -- NO three / NO DOM imports, so it is
+// unit-testable in plain node. Every function here is a pure function of the
+// playhead t (or a per-instance index), so the whole M3 band is scrub-safe and
+// reversible: the same t always yields the same visual state and rewinding
+// retraces it exactly (the ADR-0016 scrub contract). The ONE deliberate
+// exception is the luminance-velocity clamp, which is a real-time rate limiter
+// living in engine/luminance-clamp.ts -- this file only owns its pure f(t)
+// TARGET (sceneLuminance) and the tunable slew cap. The .tsx components own all
+// three objects + per-frame plumbing; this file owns only the deterministic
+// numbers.
+
+import { cameraY, canyonFogRGB, hash01 } from "./canyon-layout";
+
+const TWO_PI = Math.PI * 2;
+
+// ---- small pure helpers (mirrors canyon-layout; kept local, not exported) ----
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0;
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  if (edge0 === edge1) return x < edge0 ? 0 : 1;
+  const t = clamp01((x - edge0) / (edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+function mix(a: number, b: number, x: number): number {
+  return a + (b - a) * x;
+}
+
+// ---- world anchors ---------------------------------------------------------
+
+// Scene 2 lo (matches scene-resolver): the paper-ocean surface crossing.
+export const SURFACE_T = 0.3;
+
+// The paper-ocean patch extent (bounded Gerstner patch per the skill). 300 units
+// square, centred on the world axis; large enough to fill the frame across the
+// scene 2-3 camera range without recentering it per frame (camera x/z barely move
+// below the canyon, so a fixed patch stays under the camera).
+export const SURFACE_PATCH = 300;
+const SURFACE_HALF = SURFACE_PATCH / 2;
+
+// World Y of the surface plane. Sits just BELOW the camera at the crossing (the
+// camera descends through cameraY(SURFACE_T) = -72), so the surface is seen from
+// above during the approach then from below in the deep.
+export const SURFACE_WORLD_Y = cameraY(SURFACE_T) - 2;
+
+// ---- Gerstner water (sum of a few analytic waves; pure f(t, xz)) -----------
+
+export interface GerstnerWave {
+  readonly dx: number; // direction (normalized inside the sum)
+  readonly dz: number;
+  readonly amp: number; // amplitude (world units)
+  readonly len: number; // wavelength (world units)
+  readonly steep: number; // Gerstner sharpness Q in [0, 1]
+  readonly omega: number; // angular speed vs the playhead t (t spans [0,1])
+}
+
+// Four Gerstner waves (skill envelope 4-6). Shared source of truth: the water
+// vertex shader builds its GLSL const array from THIS list, so the surface the
+// shader draws matches the surface the CPU floating-letter layer rides.
+export const GERSTNER_WAVES: readonly GerstnerWave[] = [
+  { dx: 0.92, dz: 0.39, amp: 1.35, len: 62, steep: 0.6, omega: 44 },
+  { dx: -0.42, dz: 0.91, amp: 0.72, len: 33, steep: 0.52, omega: 61 },
+  { dx: 0.71, dz: -0.7, amp: 0.36, len: 19, steep: 0.44, omega: 79 },
+  { dx: -0.86, dz: -0.51, amp: 0.18, len: 11, steep: 0.34, omega: 98 },
+];
+
+export interface SurfacePoint {
+  x: number;
+  y: number;
+  z: number;
+  nx: number;
+  ny: number;
+  nz: number;
+}
+
+// Full Gerstner displacement + analytic normal for a rest particle at (x, z) at
+// playhead t, written into `out` (caller-owned -> no per-frame allocation). Pure
+// f(t): re-evaluating at the same t gives the identical point, so floating props
+// riding the surface rewind exactly. Mirrors the water vertex shader.
+export function gerstnerSurface(x: number, z: number, t: number, out: SurfacePoint): void {
+  let px = x;
+  let pz = z;
+  let py = 0;
+  let sumNx = 0;
+  let sumNy = 0;
+  let sumNz = 0;
+  for (let i = 0; i < GERSTNER_WAVES.length; i++) {
+    const w = GERSTNER_WAVES[i];
+    if (!w) continue;
+    const dl = Math.hypot(w.dx, w.dz) || 1;
+    const dX = w.dx / dl;
+    const dZ = w.dz / dl;
+    const k = TWO_PI / w.len;
+    const phase = k * (dX * x + dZ * z) + t * w.omega;
+    const c = Math.cos(phase);
+    const s = Math.sin(phase);
+    px += w.steep * w.amp * dX * c;
+    pz += w.steep * w.amp * dZ * c;
+    py += w.amp * s;
+    const wa = k * w.amp;
+    sumNx += dX * wa * c;
+    sumNz += dZ * wa * c;
+    sumNy += w.steep * wa * s;
+  }
+  out.x = px;
+  out.y = py;
+  out.z = pz;
+  const nX = -sumNx;
+  const nY = 1 - sumNy;
+  const nZ = -sumNz;
+  const nl = Math.hypot(nX, nY, nZ) || 1;
+  out.nx = nX / nl;
+  out.ny = nY / nl;
+  out.nz = nZ / nl;
+}
+
+// Just the surface height (y displacement) for a rest particle -- the cheap path
+// where the normal is not needed.
+export function gerstnerHeight(x: number, z: number, t: number): number {
+  let py = 0;
+  for (let i = 0; i < GERSTNER_WAVES.length; i++) {
+    const w = GERSTNER_WAVES[i];
+    if (!w) continue;
+    const dl = Math.hypot(w.dx, w.dz) || 1;
+    const dX = w.dx / dl;
+    const dZ = w.dz / dl;
+    const k = TWO_PI / w.len;
+    py += w.amp * Math.sin(k * (dX * x + dZ * z) + t * w.omega);
+  }
+  return py;
+}
+
+// ---- floating letters paving the surface -----------------------------------
+
+export interface SurfaceLetter {
+  x: number; // base (rest) world x
+  z: number; // base (rest) world z
+  yaw: number; // flat-on-water spin about the surface normal
+  scale: number;
+  seed: number; // [0,1) atlas-cell + flutter decorrelation (reuses the storm shader)
+  phase: number; // [0,2PI) flutter start phase
+}
+
+// One floating rejection sheet's base transform. Deterministic scatter across the
+// patch; the component rides each one on the Gerstner surface per frame.
+export function surfaceLetterInstance(i: number): SurfaceLetter {
+  const h = (s: number): number => hash01(i * 6151 + s * 33469 + 17);
+  const r = SURFACE_HALF * 0.92;
+  return {
+    x: (h(1) - 0.5) * 2 * r,
+    z: (h(2) - 0.5) * 2 * r,
+    yaw: h(3) * TWO_PI,
+    scale: 0.5 + h(4) * 0.5,
+    seed: h(5),
+    phase: h(6) * TWO_PI,
+  };
+}
+
+// ---- deep drifting papers (sparse; reuses the storm instancing pattern) ----
+
+export interface DeepPaper {
+  x: number;
+  y: number;
+  z: number;
+  rotX: number;
+  rotY: number;
+  rotZ: number;
+  scale: number;
+  seed: number;
+  phase: number;
+}
+
+// One sinking sheet in the deep band (a frozen sparse cloud the camera drifts
+// through, exactly like the canyon storm -- camera parallax + the shader's
+// analytic flutter, no CPU per-sheet animation).
+export function deepPaperInstance(i: number): DeepPaper {
+  const h = (s: number): number => hash01(i * 3187 + s * 50077 + 71);
+  return {
+    x: (h(1) - 0.5) * 44,
+    y: SURFACE_WORLD_Y - 8 - h(2) * 74, // deep band below the surface
+    z: 4 - h(3) * 44, // in front of the descending camera (looking -Z)
+    rotX: h(4) * TWO_PI,
+    rotY: h(5) * TWO_PI,
+    rotZ: h(6) * TWO_PI,
+    scale: 0.6 + h(7) * 0.8,
+    seed: h(8),
+    phase: h(9) * TWO_PI,
+  };
+}
+
+// ---- limp figure placeholder (procedural capsule body; no character work) --
+
+export interface FigureState {
+  x: number;
+  y: number;
+  z: number;
+  rx: number;
+  ry: number;
+  rz: number;
+  visible: boolean;
+}
+
+// The limp protagonist sinking through the deep, written into `out`
+// (caller-owned). Pure f(t): tumble + sink are functions of t, so rewinding
+// un-sinks them exactly. A slow limp tumble, face-up-ish. Placeholder silhouette;
+// the authored glTF clip is a later milestone.
+export function writeLimpFigure(t: number, out: FigureState): void {
+  const c = clamp01(t);
+  const vis = smoothstep(0.36, 0.4, c) * (1 - smoothstep(0.56, 0.6, c));
+  out.visible = vis > 0.01;
+  if (!out.visible) return;
+  const sink = smoothstep(0.34, 0.58, c);
+  out.x = Math.sin(c * 5) * 1.1;
+  out.y = SURFACE_WORLD_Y - 6 - sink * 60; // sinks through the deep band
+  out.z = -6 + Math.sin(c * 3) * 1;
+  out.rx = 0.4 + Math.sin(c * 7) * 0.25; // limp, drifting tumble
+  out.ry = c * 2;
+  out.rz = Math.sin(c * 4) * 0.4;
+}
+
+// ---- god-ray shafts (additive-shaft fallback; see the M3 godrays decision) --
+
+export interface GodrayShaftDef {
+  x: number;
+  z: number;
+  tiltX: number;
+  tiltZ: number;
+  len: number;
+  radius: number;
+}
+
+// One additive light shaft slanting down from the surface. A handful of these
+// (per-tier count) stand in for volumetric god-rays without a post composer.
+//
+// radius retuned (M3 review fix): the original 3-6 world-unit radius rendered as
+// huge pale columns filling most of the frame at the deep's typical viewing
+// distance -- the ADR beat wants "thin, dying bands", not columns. Shrunk ~6-7x.
+export function godrayShaft(i: number): GodrayShaftDef {
+  const h = (s: number): number => hash01(i * 2749 + s * 40961 + 5);
+  return {
+    x: (h(1) - 0.5) * 42,
+    z: -4 - h(2) * 30,
+    tiltX: -0.12 + (h(3) - 0.5) * 0.18, // near-vertical, slight lean (light from above)
+    tiltZ: (h(4) - 0.5) * 0.18,
+    len: 70 + h(5) * 40,
+    radius: 0.35 + h(6) * 0.55, // thin, dying bands -- not columns
+  };
+}
+
+// Overall shaft strength as a pure function of t: rays are strong entering the
+// deep and thin band by band as he sinks, gone before the blackout (the light is
+// lost by then). Drives the additive material opacity. The ramp-in aligns with
+// the deep-layer entry (scene 3, t=0.38) so the shafts fade IN rather than pop on
+// when the deep group becomes visible.
+//
+// Peak capped well below 1 (M3 review fix): the god-rays are supposed to read as
+// faint, dying bands against near-black per the ADR ("the saddest frame"), not a
+// bright wash that hides the limp figure -- the old uncapped strength combined
+// with the additive blending and the old wide shafts overexposed the whole
+// scene. Combined with the radius shrink above, this keeps the deep genuinely
+// dark with the figure reading against, not lost behind, a shaft.
+export function godrayStrength(t: number): number {
+  const c = clamp01(t);
+  return 0.3 * smoothstep(0.38, 0.43, c) * (1 - smoothstep(0.48, 0.56, c));
+}
+
+// ---- camera framing extension (scenes 2-4) ---------------------------------
+
+// Offset ADDED to cameraY(t) to get the look-at target's Y through the surface +
+// deep. Zero in the canyon (so it never fights the canyon backward-fall framing)
+// and eased off in the blackout (nothing left to see). Pure f(t).
+//
+// REDESIGNED (M3 review fix -- "the surface has no visible water"): cameraY(t)
+// is one continuous linear descent (-t * WORLD_HEIGHT) that does NOT slow down
+// for the water crossing, so by mid scene-2 (t=0.34) the camera has ALREADY
+// fallen ~7.6 world units below the fixed SURFACE_WORLD_Y plane. The OLD offset
+// was a flat -12 (look down) the instant `inWater` ramped in (from t=0.27) --
+// so at t=0.34 the camera was both below the plane AND aimed even further
+// below it, pointing straight away from the paved ocean / splash crown into
+// the void: nothing of the surface beat was ever in frame.
+//
+// Fixed by blending the look TARGET (not the camera's own position) from
+// "hold near the fixed water-plane Y" -- which keeps the paved ocean + splash
+// crown framed through the WHOLE crossing regardless of how far the camera's
+// own Y has already fallen past that fixed Y -- to "look steeply down" only
+// once solidly past the crossing, at the SAME magnitude (-12 offset once fully
+// saturated) the original tuning used for the deep/blackout framing the
+// coordinator already approved.
+//
+// intoDeep window widened 0.34-0.4 -> 0.37-0.43 (M3 review round 2 fix,
+// NUMERICALLY VERIFIED, not just reasoned): the round-1 window still let the
+// crown drift out of the camera's vertical half-FOV (27.5deg) by t=0.36 (a
+// standalone node script reimplementing this exact math measured the
+// crown-to-view-direction angle across [0.30, 0.38] at 0.005 steps -- see the
+// M3 handoff log for the printed numbers). Re-run with this window: worst-case
+// angle across the WHOLE of [0.30, 0.38] is 22.0deg (crown) / 17.7deg (plane),
+// both comfortably inside the 27.5deg half-FOV -- the water plane + splash
+// crown are PROVABLY in frame for all of scene 2, not just its middle third.
+// The deep-scene regression check (same script) confirms the offset is still
+// EXACTLY -12 at t=0.45+ -- the coordinator's approved deep framing is
+// numerically byte-for-byte unchanged by widening this window.
+export function cameraLookDownOffset(t: number): number {
+  const c = clamp01(t);
+  const inWater = smoothstep(0.27, 0.32, c) * (1 - smoothstep(0.54, 0.58, c));
+  if (inWater <= 0) return 0;
+  const intoDeep = smoothstep(0.37, 0.43, c);
+  const surfaceAimY = SURFACE_WORLD_Y - 3; // just below eye level -- keeps the plane + crown centred
+  const deepAimY = cameraY(c) - 12; // matches the original constant once fully saturated
+  const aimY = mix(surfaceAimY, deepAimY, intoDeep);
+  return (aimY - cameraY(c)) * inWater;
+}
+
+// ---- depth-graded fog for the whole descent --------------------------------
+
+// Writes the fog rgb for this t into `out` and RETURNS the FogExp2 density. Above
+// the surface it delegates to the canyon night grade; below it grades midnight
+// blue -> near-black and closes the density in for the blackout, so the deep
+// reads as a lightless volume rather than clear water.
+//
+// Cold-open density pulled back (M3 review round 2 fix): a flat 0.012 density
+// from t=0 read as an opaque flat brown WALL at the cold open (t~0.02) -- the
+// canyon's own density was tuned for the fall (scene 1), not the still-mostly-
+// static cold-open framing (scene 0, [0, 0.05)) which needs to show RECEDING
+// depth (towers fading into dark distance) rather than a uniform paint-out.
+// Ramps up to the established 0.012 by t=0.05, handing off right where
+// canyonActive itself starts engaging (0.04-0.09) so the transition into the
+// fall reads continuous. NOTE: the cold-open's camera/framing is placeholder
+// until the home-office scene exists (a later milestone) -- this only fixes the
+// fog from reading as a flat wall in the meantime, not the scene's content.
+export function worldFog(t: number, out: [number, number, number]): number {
+  const c = clamp01(t);
+  if (c < SURFACE_T) {
+    canyonFogRGB(c, out);
+    return mix(0.003, 0.012, smoothstep(0, 0.05, c));
+  }
+  const pDeep = smoothstep(SURFACE_T, 0.52, c);
+  const pBlk = smoothstep(0.52, 0.58, c);
+  out[0] = mix(0.01, 0.001, pDeep) * (1 - pBlk);
+  out[1] = mix(0.022, 0.004, pDeep) * (1 - pBlk);
+  out[2] = mix(0.048, 0.01, pDeep) * (1 - 0.7 * pBlk);
+  return mix(0.02, 0.075, pDeep) + pBlk * 0.03;
+}
+
+// ---- luminance target + slew cap (the WCAG 2.3.1 clamp lives in engine/) ----
+
+// Tunable max luminance change per unit of REAL time (exposure units / second)
+// the luminance-velocity clamp allows through the dark scenes. Chosen so the
+// biggest blackout<->bright transition (range ~1.0) takes >= ~0.6 s, making a
+// full dark-bright-dark strobe cycle < ~1 Hz -- comfortably under the WCAG 3 Hz
+// limit no matter how fast the playhead is scrubbed.
+export const MAX_LUMINANCE_SLEW_PER_SEC = 1.6;
+
+// The TARGET rendered luminance (used as a global tone-mapping exposure) as a
+// pure function of t: full in the canyon, dimming through the surface + deep to
+// near-black in the blackout. The luminance-velocity clamp eases the APPLIED
+// exposure toward this so fast scrubbing cannot strobe the transitions; AT REST
+// the applied value converges here, so determinism holds.
+//
+// Deep-band anchors darkened (M3 review fix): the deep read overblown/bright at
+// t=0.45 (partly the god-rays, fixed above, but the base exposure plateau was
+// also too high) -- 0.55/0.12 lowered to 0.42/0.08 so the deep genuinely reads
+// dark even with the god-rays present. The blackout's terminal 0.03 anchor is
+// unchanged (already correctly near-black per the coordinator's live check).
+export function sceneLuminance(t: number): number {
+  const c = clamp01(t);
+  if (c <= SURFACE_T) return 1;
+  if (c <= 0.38) return mix(1, 0.42, smoothstep(SURFACE_T, 0.38, c));
+  if (c <= 0.52) return mix(0.42, 0.08, smoothstep(0.38, 0.52, c));
+  if (c <= 0.58) return mix(0.08, 0.03, smoothstep(0.52, 0.58, c));
+  return 0.03; // held near-black; M4 (the catch) raises it as the amber grows
+}
+
+// ---- the one warm amber point of light appearing below (blackout) ----------
+
+// Amber point-light intensity: 0 until the blackout, then grows (a single warm
+// point appearing below and growing). Pure f(t); slow, so it needs no clamp.
+export function amberIntensity(t: number): number {
+  return 4 * smoothstep(0.52, 0.585, clamp01(t));
+}
+
+// World Y for the amber light -- always some distance below the descending
+// camera ("appears below").
+export function amberLightY(t: number): number {
+  return cameraY(t) - 24;
+}
+
+// ---- scene-range visibility (which world layers render for a scene) --------
+
+export interface WorldLayers {
+  canyon: boolean;
+  water: boolean;
+  splash: boolean;
+  deep: boolean;
+  markers: boolean;
+}
+
+// Pure visibility gate keyed by the discrete scene index. Skips whole groups'
+// draw calls outside their range so each segment stays within the draw-call
+// budget. M3 builds scenes 2-4, so the M1 debug markers now only cover the
+// not-yet-built scenes 5-8.
+//
+// Writes into `out` (caller-owned) -- the CanyonWorld useFrame loop preallocates
+// ONE WorldLayers and reuses it every frame instead of allocating a fresh object,
+// per the zero-per-frame-allocation discipline. worldLayers() below is a thin
+// fresh-object wrapper over this for tests / one-off callers that don't need to
+// avoid the allocation; this is the single source of truth for the logic.
+export function writeWorldLayers(scene: number, out: WorldLayers): void {
+  out.canyon = scene <= 2;
+  out.water = scene === 2 || scene === 3; // surface from above (2) + from below (3)
+  out.splash = scene === 2;
+  out.deep = scene === 3 || scene === 4;
+  out.markers = scene >= 5;
+}
+
+// Fresh-object convenience wrapper over writeWorldLayers -- see its doc.
+export function worldLayers(scene: number): WorldLayers {
+  const out: WorldLayers = { canyon: false, water: false, splash: false, deep: false, markers: false };
+  writeWorldLayers(scene, out);
+  return out;
+}

--- a/apps/landing/src/cast/world/water-layout.ts
+++ b/apps/landing/src/cast/world/water-layout.ts
@@ -9,7 +9,7 @@
 // three objects + per-frame plumbing; this file owns only the deterministic
 // numbers.
 
-import { cameraY, canyonFogRGB, hash01 } from "./canyon-layout";
+import { cameraY, canyonFogRGB, FOG_COLD, hash01 } from "./canyon-layout";
 
 const TWO_PI = Math.PI * 2;
 
@@ -331,6 +331,16 @@ export function cameraLookDownOffset(t: number): number {
 // fall reads continuous. NOTE: the cold-open's camera/framing is placeholder
 // until the home-office scene exists (a later milestone) -- this only fixes the
 // fog from reading as a flat wall in the meantime, not the scene's content.
+//
+// SURFACE_T boundary aligned exactly (PR #722 CodeRabbit fix): the deep branch's
+// pDeep=0 anchor used to be a separately-tuned [0.01,0.022,0.048]@0.02 that did
+// NOT match the canyon side's value at t->SURFACE_T (FOG_COLD @ the established
+// 0.012 canyon density) -- a real, visible pop in both density and hue right at
+// the waterline crossing. The deep branch's pDeep=0 anchor now IS FOG_COLD / the
+// canyon density (not a re-typed copy -- imported from canyon-layout.ts, so the
+// two sides cannot drift out of sync again), making worldFog exactly continuous
+// (C0) across SURFACE_T: mix(x, ..., 0) === x at t=SURFACE_T on the deep side,
+// which equals the canyon side's value in the limit t->SURFACE_T from below.
 export function worldFog(t: number, out: [number, number, number]): number {
   const c = clamp01(t);
   if (c < SURFACE_T) {
@@ -339,10 +349,10 @@ export function worldFog(t: number, out: [number, number, number]): number {
   }
   const pDeep = smoothstep(SURFACE_T, 0.52, c);
   const pBlk = smoothstep(0.52, 0.58, c);
-  out[0] = mix(0.01, 0.001, pDeep) * (1 - pBlk);
-  out[1] = mix(0.022, 0.004, pDeep) * (1 - pBlk);
-  out[2] = mix(0.048, 0.01, pDeep) * (1 - 0.7 * pBlk);
-  return mix(0.02, 0.075, pDeep) + pBlk * 0.03;
+  out[0] = mix(FOG_COLD[0], 0.001, pDeep) * (1 - pBlk);
+  out[1] = mix(FOG_COLD[1], 0.004, pDeep) * (1 - pBlk);
+  out[2] = mix(FOG_COLD[2], 0.01, pDeep) * (1 - 0.7 * pBlk);
+  return mix(0.012, 0.075, pDeep) + pBlk * 0.03;
 }
 
 // ---- luminance target + slew cap (the WCAG 2.3.1 clamp lives in engine/) ----

--- a/apps/landing/src/chrome/Chrome.tsx
+++ b/apps/landing/src/chrome/Chrome.tsx
@@ -9,6 +9,7 @@
 
 import { useEffect, useRef } from "react";
 
+import { letterboxFlex } from "@/engine/letterbox";
 import { SCENES } from "@/engine/scene-resolver";
 import { playhead, useRig } from "@/engine/store";
 import {
@@ -19,6 +20,11 @@ import {
   timecodeSeconds,
 } from "@/engine/timecode";
 
+// Peak extra letterbox bar height (px) at the splash impact. The flex is pure
+// f(t) so it scrubs both directions with the playhead; the accompanying silence
+// beat is an audio hook deferred to M5.
+const LETTERBOX_FLEX_PX = 42;
+
 // SSR-rendered initial text: computed from t=0 (never hand-duplicated) so the
 // server-rendered markup always matches what the first client tick would write,
 // and hydration never has to reconcile a stale hardcoded string here.
@@ -26,6 +32,7 @@ const INITIAL_TIMECODE = formatTimecode(0);
 const INITIAL_GAUGE = formatGauge(0);
 
 export function Chrome() {
+  const chromeRef = useRef<HTMLDivElement>(null);
   const timecodeRef = useRef<HTMLSpanElement>(null);
   const gaugeRef = useRef<HTMLSpanElement>(null);
   const scene = useRig((s) => s.scene);
@@ -39,6 +46,7 @@ export function Chrome() {
     let lastSeconds = -1;
     let lastGaugeM = Number.NaN;
     let lastPhase: boolean | null = null;
+    let lastFlexPx = -1;
     const tick = (): void => {
       const t = playhead.t;
       const seconds = timecodeSeconds(t);
@@ -53,6 +61,14 @@ export function Chrome() {
         lastPhase = phase;
         if (gaugeRef.current) gaugeRef.current.textContent = formatGauge(t);
       }
+      // Letterbox flex at the splash impact -- pushed to a CSS var (only on real
+      // change) so the bars widen briefly then relax; the CSS composes it onto the
+      // responsive base height, so the clamp() sizing is preserved.
+      const flexPx = Math.round(letterboxFlex(t) * LETTERBOX_FLEX_PX);
+      if (flexPx !== lastFlexPx) {
+        lastFlexPx = flexPx;
+        chromeRef.current?.style.setProperty("--lb-extra", `${flexPx}px`);
+      }
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
@@ -60,7 +76,7 @@ export function Chrome() {
   }, []);
 
   return (
-    <div className="chrome" aria-hidden>
+    <div className="chrome" aria-hidden ref={chromeRef}>
       <div className="letterbox letterbox-top">
         <span className="act-title">{act}</span>
       </div>

--- a/apps/landing/src/engine/letterbox.test.ts
+++ b/apps/landing/src/engine/letterbox.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { letterboxFlex } from "./letterbox";
+
+describe("letterboxFlex (splash-beat chrome hook, pure f(t))", () => {
+  it("is zero everywhere outside the splash beat", () => {
+    for (const t of [0, 0.1, 0.29, 0.4, 0.5, 0.8, 1]) {
+      expect(letterboxFlex(t)).toBe(0);
+    }
+  });
+
+  it("widens at the surface impact and eases back out", () => {
+    expect(letterboxFlex(0.32)).toBeGreaterThan(0.5); // near the peak
+    expect(letterboxFlex(0.32)).toBeGreaterThan(letterboxFlex(0.3)); // rising into impact
+    expect(letterboxFlex(0.32)).toBeGreaterThan(letterboxFlex(0.37)); // relaxing after
+  });
+
+  it("stays within [0, 1]", () => {
+    for (let i = 0; i <= 100; i++) {
+      const v = letterboxFlex(i / 100);
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("is deterministic (scrub-safe both directions)", () => {
+    expect(letterboxFlex(0.315)).toBe(letterboxFlex(0.315));
+  });
+});

--- a/apps/landing/src/engine/letterbox.ts
+++ b/apps/landing/src/engine/letterbox.ts
@@ -1,0 +1,22 @@
+// The splash-beat letterbox flex (chrome hook). At the surface impact (scene 2)
+// the letterbox bars widen briefly then relax -- the film's one hard beat. Pure
+// f(t) so it is scrub-safe both directions, read by Chrome's rAF loop and mapped
+// to extra bar height. The SILENCE beat that lands with it is an audio hook
+// deferred to M5 (no audio in M3); this module is the visual half only.
+
+import { clamp01 } from "./clamp";
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  if (edge0 === edge1) return x < edge0 ? 0 : 1;
+  const t = clamp01((x - edge0) / (edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+// Letterbox flex amount in [0, 1]: a sharp widen right at the impact (~0.30) that
+// eases back out by ~0.37. Zero everywhere outside the splash beat.
+export function letterboxFlex(t: number): number {
+  const c = clamp01(t);
+  const rise = smoothstep(0.298, 0.315, c);
+  const fall = 1 - smoothstep(0.33, 0.375, c);
+  return rise * fall;
+}

--- a/apps/landing/src/engine/luminance-clamp.test.ts
+++ b/apps/landing/src/engine/luminance-clamp.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { LuminanceClamp } from "./luminance-clamp";
+
+describe("LuminanceClamp (WCAG 2.3.1 luminance-velocity clamp)", () => {
+  it("caps the slew: applied moves by at most maxSlew * dt toward the target", () => {
+    const c = new LuminanceClamp(0, 2); // 2 units/sec
+    c.step(0, 0.016); // consume the mount-prime (target === initial -> no visible effect)
+    expect(c.step(1, 0.1)).toBeCloseTo(0.2, 10); // 2 * 0.1 = 0.2, not the full 1.0
+    expect(c.step(1, 0.1)).toBeCloseTo(0.4, 10);
+  });
+
+  it("caps the slew downward symmetrically", () => {
+    const c = new LuminanceClamp(1, 2);
+    c.step(1, 0.016); // consume the mount-prime
+    expect(c.step(0, 0.1)).toBeCloseTo(0.8, 10);
+  });
+
+  it("converges to a steady target and then holds it exactly (determinism at rest)", () => {
+    const c = new LuminanceClamp(0, 2);
+    c.step(0, 0.016); // consume the mount-prime
+    for (let i = 0; i < 200; i++) c.step(1, 0.016);
+    expect(c.value).toBe(1); // snapped exactly, no asymptotic drift
+    // At rest the applied value equals the pure-f(t) target every frame.
+    expect(c.step(1, 0.016)).toBe(1);
+    expect(c.step(1, 0.5)).toBe(1);
+  });
+
+  it("snaps exactly when the target is within reach this frame", () => {
+    const c = new LuminanceClamp(0, 2);
+    c.step(0, 0.016); // consume the mount-prime
+    // diff (0.2) === maxSlew*dt (2 * 0.1) -> within reach -> exact snap
+    expect(c.step(0.2, 0.1)).toBe(0.2);
+  });
+
+  it("reset jumps immediately with no slew limit, and the next step() slews normally from there", () => {
+    const c = new LuminanceClamp(1, 2);
+    c.reset(0.05);
+    expect(c.value).toBe(0.05);
+    expect(c.step(1, 0.1)).toBeCloseTo(0.25, 10); // 0.05 + 2*0.1 -- properly rate-limited
+  });
+
+  it("holds on a non-positive dt or a non-finite target", () => {
+    const c = new LuminanceClamp(0.5, 2);
+    c.step(0.5, 0.016); // consume the mount-prime (target === initial -> no visible effect)
+    expect(c.step(1, 0)).toBe(0.5);
+    expect(c.step(1, -1)).toBe(0.5);
+    expect(c.step(Number.NaN, 0.1)).toBe(0.5);
+  });
+
+  it("is deterministic for a given (target, dt) sequence regardless of scrub direction history", () => {
+    const down = new LuminanceClamp(1, 1.6);
+    const up = new LuminanceClamp(0, 1.6);
+    down.step(1, 0.016); // consume each instance's own mount-prime first
+    up.step(0, 0.016);
+    // Both driven to a steady 0.3 target long enough to converge -> identical.
+    for (let i = 0; i < 500; i++) {
+      down.step(0.3, 0.016);
+      up.step(0.3, 0.016);
+    }
+    expect(down.value).toBe(0.3);
+    expect(up.value).toBe(0.3);
+  });
+});
+
+// Regression coverage for the M3 review HIGH: a fresh mount (or remount) landing
+// at a playhead far from the constructor's throwaway `initial` -- a hash
+// deep-link straight into the blackout, or the reduce->restore GL remount --
+// must render the correct target on the very first frame, not visibly fade
+// in/out from `initial` over the first ~maxSlew window (an inverted-WCAG flash
+// at boot, the opposite of what this class exists to prevent).
+describe("mount priming (a fresh mount/reset is a hard cut, not a slew)", () => {
+  it("the very first step() call after construction hard-cuts to the target regardless of the slew cap", () => {
+    const brightMount = new LuminanceClamp(1, 1.6); // constructed bright...
+    expect(brightMount.step(0.03, 0.016)).toBe(0.03); // ...but mounts straight into a dark target
+    const darkMount = new LuminanceClamp(0, 1.6); // constructed dark...
+    expect(darkMount.step(1, 0.016)).toBe(1); // ...but mounts straight into a bright target
+  });
+
+  it("only the very first call is primed -- every subsequent call is rate-limited normally", () => {
+    const c = new LuminanceClamp(1, 1.6);
+    expect(c.step(0.03, 0.016)).toBe(0.03); // mount prime: hard cut
+    expect(c.step(1, 0.016)).toBeCloseTo(0.03 + 1.6 * 0.016, 10); // now properly slewed
+  });
+
+  it("an explicit reset() before any step() call also counts as priming (no double hard-cut)", () => {
+    const c = new LuminanceClamp(1, 1.6);
+    c.reset(0.5); // an external hard cut before the mount's first frame ever ticks
+    expect(c.step(1, 0.016)).toBeCloseTo(0.5 + 1.6 * 0.016, 10); // slewed, not re-primed
+  });
+});

--- a/apps/landing/src/engine/luminance-clamp.ts
+++ b/apps/landing/src/engine/luminance-clamp.ts
@@ -1,0 +1,73 @@
+// Luminance-velocity clamp -- the WCAG 2.3.1 photosensitivity mechanism the skill
+// (webgl-standards "A11y / UX gates" -> Photosensitivity) mandates for the dark
+// scenes. The scene TARGET luminance is a pure f(t) (water-layout.sceneLuminance),
+// but because scrolling drives the playhead, a FAST scrub could compress a slow
+// blackout -> bright fade into a >3 Hz strobe. This rate limiter eases the APPLIED
+// luminance toward the target, capping the change per unit of REAL time (delta
+// seconds) so a flash can never complete faster than the WCAG-safe rate no matter
+// how fast t is scrubbed.
+//
+// EXPLICIT EXCEPTION to the scrub-determinism rule: this is the ONE real-time
+// (delta-driven), a11y-mandated smoothing in the render path -- deliberately NOT a
+// pure f(t) (it is distinct from, and additional to, the scroll-rig's playhead
+// damping). Determinism still holds AT REST: when the target is steady the applied
+// value converges EXACTLY to it (the within-reach branch snaps, no asymptote), so
+// a paused playhead at any t renders the identical frame -- the down-and-rewind
+// parity contract survives. Only the transient DURING a fast scrub is rate-limited,
+// which is exactly the strobe the clamp exists to prevent.
+
+export class LuminanceClamp {
+  private applied: number;
+  private readonly maxSlew: number; // luminance units per second
+  private primed: boolean;
+
+  constructor(initial: number, maxSlewPerSecond: number) {
+    this.applied = Number.isFinite(initial) ? initial : 0;
+    this.maxSlew = maxSlewPerSecond > 0 ? maxSlewPerSecond : 0;
+    this.primed = false;
+  }
+
+  get value(): number {
+    return this.applied;
+  }
+
+  // Hard-set the applied value to a target with no slew limit, and mark the
+  // clamp primed. Used explicitly for a discrete seek / deep-link jump, where
+  // there is no visual continuity to protect: a hard cut is not a strobe, so
+  // rate-limiting it would just be a slow unwanted fade. step() also calls this
+  // internally for the very first call after construction (see below), so a
+  // fresh mount gets the same hard-cut treatment automatically.
+  reset(target: number): void {
+    if (Number.isFinite(target)) this.applied = target;
+    this.primed = true;
+  }
+
+  // Advance one real frame: move the applied luminance toward `target` by at most
+  // maxSlew * dt. Within reach -> snap exactly to target (determinism at rest).
+  // Non-finite target or dt <= 0 -> hold (no change).
+  //
+  // MOUNT PRIMING: the FIRST call after construction (or after an explicit
+  // reset()) hard-cuts to the target instead of slewing, by delegating to
+  // reset(). Without this, a fresh component mount landing far from the
+  // constructor's throwaway `initial` value -- a hash deep-link straight into
+  // the blackout, or the reduce-motion restore GL remount -- would visibly fade
+  // from `initial` toward the real target over the first ~maxSlew window: an
+  // unwanted, WCAG-INVERTING flash right at boot, the opposite of what this
+  // class exists to prevent. A discrete mount has no prior visual continuity to
+  // protect, exactly like an explicit reset() -- so the very first sample just
+  // IS the correct target, immediately.
+  step(target: number, dtSeconds: number): number {
+    const tgt = Number.isFinite(target) ? target : this.applied;
+    if (!this.primed) {
+      this.reset(tgt);
+      return this.applied;
+    }
+    const dt = Number.isFinite(dtSeconds) && dtSeconds > 0 ? dtSeconds : 0;
+    const maxDelta = this.maxSlew * dt;
+    const diff = tgt - this.applied;
+    if (diff > maxDelta) this.applied += maxDelta;
+    else if (diff < -maxDelta) this.applied -= maxDelta;
+    else this.applied = tgt;
+    return this.applied;
+  }
+}

--- a/apps/landing/src/engine/quality-ladder.test.ts
+++ b/apps/landing/src/engine/quality-ladder.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { qualityLadder, stormCountForTier, towerCountForTier } from "./quality-ladder";
+import {
+  deepPaperCountForTier,
+  godrayShaftCountForTier,
+  qualityLadder,
+  stormCountForTier,
+  surfaceLetterCountForTier,
+  towerCountForTier,
+  waterSegmentsForTier,
+} from "./quality-ladder";
 import type { QualityTier } from "./store";
 
 const TIERS: QualityTier[] = ["HIGH", "MID", "LOW"];
@@ -36,6 +44,37 @@ describe("quality ladder", () => {
     for (const tier of TIERS) {
       expect(stormCountForTier(tier)).toBe(qualityLadder(tier).stormCount);
       expect(towerCountForTier(tier)).toBe(qualityLadder(tier).towerCount);
+    }
+  });
+
+  it("M3 water/deep density knobs are positive integers and never rise HIGH -> LOW", () => {
+    const selectors = [
+      waterSegmentsForTier,
+      surfaceLetterCountForTier,
+      deepPaperCountForTier,
+      godrayShaftCountForTier,
+    ];
+    for (const sel of selectors) {
+      for (const tier of TIERS) {
+        expect(Number.isInteger(sel(tier))).toBe(true);
+        expect(sel(tier)).toBeGreaterThan(0);
+      }
+      for (let i = 0; i < TIERS.length - 1; i++) {
+        const hi = TIERS[i];
+        const lo = TIERS[i + 1];
+        if (!hi || !lo) continue;
+        expect(sel(hi)).toBeGreaterThanOrEqual(sel(lo));
+      }
+    }
+  });
+
+  it("M3 selectors agree with the ladder object", () => {
+    for (const tier of TIERS) {
+      const l = qualityLadder(tier);
+      expect(waterSegmentsForTier(tier)).toBe(l.waterSegments);
+      expect(surfaceLetterCountForTier(tier)).toBe(l.surfaceLetterCount);
+      expect(deepPaperCountForTier(tier)).toBe(l.deepPaperCount);
+      expect(godrayShaftCountForTier(tier)).toBe(l.godrayShaftCount);
     }
   });
 });

--- a/apps/landing/src/engine/quality-ladder.ts
+++ b/apps/landing/src/engine/quality-ladder.ts
@@ -14,12 +14,43 @@ export interface QualityLadder {
   // this is a vertex/overdraw knob, not a draw-call one. Author-chosen within the
   // ADR envelope (not a fixed skill figure).
   readonly towerCount: number;
+  // M3 water/deep density knobs (all one draw call each except the god-ray
+  // shafts, which are a handful of separate additive cones). Author-chosen within
+  // the ADR envelope -- geometry-density rungs the governor moves between.
+  readonly waterSegments: number; // Gerstner patch subdivisions per side
+  readonly surfaceLetterCount: number; // floating letters paving the surface
+  readonly deepPaperCount: number; // sparse drifting papers in the deep
+  readonly godrayShaftCount: number; // additive god-ray cones (draw calls: this many)
 }
 
+// godrayShaftCount lowered (M3 review fix, alongside the shaft radius/strength
+// retune in water-layout.ts): fewer, thinner, dimmer shafts so additive
+// overlap can't stack back up into the overblown wash the coordinator flagged.
 const LADDER: Record<QualityTier, QualityLadder> = {
-  HIGH: { stormCount: 4000, towerCount: 160 },
-  MID: { stormCount: 2000, towerCount: 96 },
-  LOW: { stormCount: 900, towerCount: 56 },
+  HIGH: {
+    stormCount: 4000,
+    towerCount: 160,
+    waterSegments: 96,
+    surfaceLetterCount: 140,
+    deepPaperCount: 70,
+    godrayShaftCount: 4,
+  },
+  MID: {
+    stormCount: 2000,
+    towerCount: 96,
+    waterSegments: 64,
+    surfaceLetterCount: 90,
+    deepPaperCount: 44,
+    godrayShaftCount: 3,
+  },
+  LOW: {
+    stormCount: 900,
+    towerCount: 56,
+    waterSegments: 40,
+    surfaceLetterCount: 48,
+    deepPaperCount: 24,
+    godrayShaftCount: 2,
+  },
 };
 
 export function qualityLadder(tier: QualityTier): QualityLadder {
@@ -32,4 +63,20 @@ export function stormCountForTier(tier: QualityTier): number {
 
 export function towerCountForTier(tier: QualityTier): number {
   return LADDER[tier].towerCount;
+}
+
+export function waterSegmentsForTier(tier: QualityTier): number {
+  return LADDER[tier].waterSegments;
+}
+
+export function surfaceLetterCountForTier(tier: QualityTier): number {
+  return LADDER[tier].surfaceLetterCount;
+}
+
+export function deepPaperCountForTier(tier: QualityTier): number {
+  return LADDER[tier].deepPaperCount;
+}
+
+export function godrayShaftCountForTier(tier: QualityTier): number {
+  return LADDER[tier].godrayShaftCount;
 }

--- a/apps/landing/src/engine/vat.test.ts
+++ b/apps/landing/src/engine/vat.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  frameRowV,
+  vatFrameIndex,
+  type VatFrameSample,
+  type VatMeta,
+  vatProgress,
+  writeVatFrameIndex,
+} from "./vat";
+
+describe("vatFrameIndex (deterministic frame pair + blend, pure f(progress))", () => {
+  it("returns a degenerate sample for a single-frame clip", () => {
+    expect(vatFrameIndex(0.5, 1)).toEqual({ a: 0, b: 0, blend: 0 });
+  });
+
+  it("lands on the first frame at progress 0 and the last frame at progress 1", () => {
+    expect(vatFrameIndex(0, 64)).toEqual({ a: 0, b: 1, blend: 0 });
+    expect(vatFrameIndex(1, 64)).toEqual({ a: 63, b: 63, blend: 0 });
+  });
+
+  it("hits an exact interior frame with zero blend", () => {
+    // frames=5 -> pos = 0.5 * 4 = 2.0 -> frame 2, no blend
+    expect(vatFrameIndex(0.5, 5)).toEqual({ a: 2, b: 3, blend: 0 });
+  });
+
+  it("interpolates between the two nearest frames (blend in [0, 1))", () => {
+    const s = vatFrameIndex(0.3, 5); // pos = 1.2 -> a=1, b=2, blend=0.2
+    expect(s.a).toBe(1);
+    expect(s.b).toBe(2);
+    expect(s.blend).toBeCloseTo(0.2, 6);
+    expect(s.blend).toBeGreaterThanOrEqual(0);
+    expect(s.blend).toBeLessThan(1);
+  });
+
+  it("advances monotonically: a + blend never decreases as progress rises", () => {
+    let prev = -1;
+    for (let i = 0; i <= 100; i++) {
+      const s = vatFrameIndex(i / 100, 64);
+      const abs = s.a + s.blend;
+      expect(abs).toBeGreaterThanOrEqual(prev - 1e-9);
+      prev = abs;
+    }
+  });
+
+  it("is reversible: the same progress always yields the same sample", () => {
+    expect(vatFrameIndex(0.37, 64)).toEqual(vatFrameIndex(0.37, 64));
+  });
+
+  it("clamps out-of-range and non-finite progress", () => {
+    expect(vatFrameIndex(-5, 64)).toEqual({ a: 0, b: 1, blend: 0 });
+    expect(vatFrameIndex(9, 64)).toEqual({ a: 63, b: 63, blend: 0 });
+    const nan = vatFrameIndex(Number.NaN, 64);
+    expect(nan.a).toBe(0);
+    expect(Number.isFinite(nan.blend)).toBe(true);
+  });
+});
+
+describe("writeVatFrameIndex (the zero-per-frame-allocation out-param path)", () => {
+  it("mutates the SAME out object across calls instead of allocating a fresh one", () => {
+    const out: VatFrameSample = { a: 0, b: 0, blend: 0 };
+    const identity = out;
+    writeVatFrameIndex(0, 64, out);
+    expect(out).toBe(identity); // same reference -- no reallocation
+    expect(out).toEqual({ a: 0, b: 1, blend: 0 });
+    writeVatFrameIndex(0.5, 5, out);
+    expect(out).toBe(identity);
+    expect(out).toEqual({ a: 2, b: 3, blend: 0 });
+  });
+
+  it("agrees with vatFrameIndex() (the fresh-object wrapper) across the clip", () => {
+    const out: VatFrameSample = { a: 0, b: 0, blend: 0 };
+    for (let i = 0; i <= 100; i++) {
+      const p = i / 100;
+      writeVatFrameIndex(p, 64, out);
+      expect(out).toEqual(vatFrameIndex(p, 64));
+    }
+  });
+});
+
+describe("frameRowV (row-centre texture V)", () => {
+  it("returns the half-texel row centre, strictly inside (0, 1)", () => {
+    expect(frameRowV(0, 64)).toBeCloseTo(0.5 / 64, 10);
+    expect(frameRowV(63, 64)).toBeCloseTo(63.5 / 64, 10);
+    expect(frameRowV(0, 64)).toBeGreaterThan(0);
+    expect(frameRowV(63, 64)).toBeLessThan(1);
+  });
+});
+
+describe("vatProgress (scene progress -> clip play window)", () => {
+  const meta: VatMeta = { frames: 64, vertices: 100, duration: 0.85 };
+
+  it("reaches 1 when the scene passes the clip's play window, then holds", () => {
+    expect(vatProgress(0, meta)).toBe(0);
+    expect(vatProgress(0.85, meta)).toBeCloseTo(1, 6);
+    expect(vatProgress(1, meta)).toBe(1); // held on the last frame while the camera sinks on
+  });
+
+  it("clamps non-finite scene progress to 0", () => {
+    expect(vatProgress(Number.NaN, meta)).toBe(0);
+  });
+});

--- a/apps/landing/src/engine/vat.ts
+++ b/apps/landing/src/engine/vat.ts
@@ -1,0 +1,88 @@
+// In-house VAT (Vertex Animation Texture) decode contract. `three-vat` does not
+// exist on npm and the only real lib excludes our three pin (see webgl-standards
+// "VAT contract"), so we own the ~decode ourselves -- it is a handful of
+// deterministic texture-sampling math we need for the scrub contract anyway.
+//
+// This module owns the PURE, three-free index/interpolation math (unit-tested).
+// The GPU side is a vertex shader (shaders/vat-crown-shader.ts) that samples the
+// baked position texture: each ROW is one frame, each COLUMN is one baked vertex.
+// The CPU computes the deterministic frame pair + blend from scene progress and
+// hands them to the shader as uniforms, so the whole decode stays a pure f(t) --
+// deterministic and reversible, the same as the rest of the film.
+
+export interface VatMeta {
+  readonly frames: number; // baked frame count (texture rows / height)
+  readonly vertices: number; // baked vertex count (texture columns / width)
+  readonly duration: number; // scene-progress span the clip plays over, in [0, 1]
+}
+
+export interface VatFrameSample {
+  a: number; // lower frame row, in [0, frames - 1]
+  b: number; // upper frame row, in [0, frames - 1]
+  blend: number; // lerp weight a -> b, in [0, 1]
+}
+
+// Deterministic two-frame sample + blend for a scene progress in [0, 1], written
+// into `out` (caller-owned) -- the splash crown's useFrame loop preallocates ONE
+// VatFrameSample and reuses it every frame instead of allocating a fresh object,
+// per the zero-per-frame-allocation discipline. Pure f(progress): the same
+// progress always yields the same sample and reversing progress retraces the
+// frames exactly (the scrub contract). Inter-frame interpolation is ON -- the
+// fractional position between the two nearest baked frames -- so slow scrubs
+// read smooth instead of stepping. Guards non-finite input (a stray NaN resolves
+// to frame 0, never leaks through). vatFrameIndex() below is a thin fresh-object
+// wrapper over this for tests / one-off callers that don't need to avoid the
+// allocation; this is the single source of truth for the logic.
+export function writeVatFrameIndex(progress: number, frames: number, out: VatFrameSample): void {
+  if (frames <= 1) {
+    out.a = 0;
+    out.b = 0;
+    out.blend = 0;
+    return;
+  }
+  const p = Number.isFinite(progress) ? (progress < 0 ? 0 : progress > 1 ? 1 : progress) : 0;
+  const pos = p * (frames - 1); // 0 .. frames - 1
+  const last = frames - 1;
+  const a = Math.floor(pos);
+  const aClamped = a < 0 ? 0 : a > last ? last : a;
+  const b = aClamped >= last ? last : aClamped + 1;
+  const blend = pos - aClamped; // [0, 1)
+  out.a = aClamped;
+  out.b = b;
+  out.blend = blend;
+}
+
+// Fresh-object convenience wrapper over writeVatFrameIndex -- see its doc.
+export function vatFrameIndex(progress: number, frames: number): VatFrameSample {
+  const out: VatFrameSample = { a: 0, b: 0, blend: 0 };
+  writeVatFrameIndex(progress, frames, out);
+  return out;
+}
+
+// The texture V coordinate (row centre) for a baked frame -- the vertex shader
+// samples at this V for the given frame row. The half-texel offset lands solidly
+// inside the row instead of exactly on a row boundary, so floating-point
+// rounding at the edge can never nudge the sample into the adjacent frame's row.
+// (The VAT texture samples with NearestFilter -- see SplashCrown.tsx -- so there
+// is no GPU linear filtering to bleed between rows; inter-frame interpolation is
+// the CPU-computed `blend` weight above, lerped in the decode shader.)
+export function frameRowV(frame: number, frames: number): number {
+  if (frames <= 0) return 0;
+  return (frame + 0.5) / frames;
+}
+
+// Map a scene's local progress onto the clip's play window. When duration < 1 the
+// crown finishes before the scene ends (then holds on its last frame), which is
+// how a splash settles while the camera keeps sinking. Pure f(progress).
+export function vatProgress(sceneProgress: number, meta: VatMeta): number {
+  const sp = Number.isFinite(sceneProgress)
+    ? sceneProgress < 0
+      ? 0
+      : sceneProgress > 1
+        ? 1
+        : sceneProgress
+    : 0;
+  const dur = meta.duration > 0 ? meta.duration : 1;
+  const p = sp / dur;
+  return p > 1 ? 1 : p;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,9 +271,6 @@ importers:
       detect-gpu:
         specifier: 5.0.70
         version: 5.0.70
-      framer-motion:
-        specifier: ^12
-        version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       gsap:
         specifier: 3.15.0
         version: 3.15.0
@@ -295,9 +292,6 @@ importers:
       three:
         specifier: 0.185.1
         version: 0.185.1
-      troika-three-text:
-        specifier: 0.52.4
-        version: 0.52.4(three@0.185.1)
       zustand:
         specifier: 5.0.14
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -314,9 +308,6 @@ importers:
       '@types/three':
         specifier: 0.185.1
         version: 0.185.1
-      svg-path-properties:
-        specifier: 2.0.1
-        version: 2.0.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -6069,10 +6060,6 @@ packages:
     resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
     peerDependencies:
       react: '>=17.0'
-
-  svg-path-properties@2.0.1:
-    resolution: {integrity: sha512-CGax/Hk6vN29RpntTIOr2+OC0+Ca9O6xp6MYSdl9v2dOsmLumy7xzZnLx3Pp8mUsmMXzpImW0VxvtyHegpknnw==}
-    engines: {node: '>=22.0.0'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -12546,8 +12533,6 @@ snapshots:
   suspend-react@0.1.3(react@19.2.7):
     dependencies:
       react: 19.2.7
-
-  svg-path-properties@2.0.1: {}
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
## What

**M3 of TERMINAL VELOCITY** per ADR-0016: scenes 2–4, playhead [0.30, 0.58) — the splash, the deep, and the blackout. 26 files, 2,407 insertions.

- **Gerstner water surface** (`cast/world/WaterSurface.tsx`): bounded analytic patch, derivative-based multi-octave micro-normals, fresnel horizon grading, letter-paved surface layer. GLSL displacement verified term-by-term identical with the tested JS math.
- **In-house VAT pipeline** (`engine/vat.ts` + `SplashCrown.tsx`): full decode contract (frame indexing, inter-frame blend, NearestFilter float textures) driving a procedural stand-in crown — the real Houdini FLIP bake drops in later per the ADR errata. Boundary math unit-tested.
- **The deep** (`DeepScene.tsx`): thin dying god-ray shafts (additive fallback implementation; `three-good-godrays` deferred to the post-chain milestone with the peer-widen plan recorded), sparse drifting papers, limp-figure silhouette, near-black grade.
- **Blackout**: fog closes to near-total dark, single amber point growing below.
- **WCAG luminance-velocity clamp** (`engine/luminance-clamp.ts`): the one documented real-time smoothing exception — self-priming on mount (deep-links into dark scenes render dark from frame 1), converges exactly to pure `f(t)` at rest, slew-capped per real second. Unit-tested.
- **Altitude→depth gauge handoff**, extended camera path, scene lifecycle gating, quality-tier ladders. **127 unit tests.**
- Pruned unused skeleton deps: `troika-three-text`, `svg-path-properties`, `framer-motion`.

## Review + verification trail

- `webgl-reviewer`: CHANGES REQUESTED → all fixed → core contract verified (Gerstner identity, VAT boundaries, injection anchors against installed three, zero wall-clock). The HIGH (clamp mount-flash inverting WCAG intent on dark-scene deep-links) was caught pre-merge and fixed with self-priming.
- **Three rounds of live-browser visual iteration** (agent-browser + dev server): **scrub rewind determinism pixel-verified** (t=0.45 from above vs rewound = identical frames); deep + blackout verified excellent; surface beat reads (storm clears to reveal the water); camera-frustum placement proven numerically (worst-case 22.0° vs 27.5° half-FOV).
- Also killed a stale Turbopack dev cache serving pre-strip RIPBOOK chunks (dev-only; production export was clean).

## Known visual backlog (documented, non-blocking — M6 gate pass)

1. Tower window moiré at near/grazing angles — procedural AA improved it twice; the real fix is a mip-mapped texture-based window pattern (shader-engineer, M6). Present since M2, not an M3 regression.
2. Cold-open framing is placeholder until the home-office scene exists (later milestone) — the fog column reads flat at t<0.05.
3. Crown legibility at the splash beat awaits the real Houdini bake (DCC ownership still open per ADR).

Gates: build ✓ typecheck ✓ lint --max-warnings 0 ✓ tests 127/127 ✓ check:parity ✓ ASCII ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cinematic descent sequence featuring animated water, splash effects, deep-water visuals, floating letters, god rays, and a procedural figure.
  * Added quality-based visual scaling to improve performance across devices.
  * Added smooth splash-responsive letterbox framing and adaptive lighting.

* **Bug Fixes**
  * Improved fog transitions and timing during the canyon-to-water sequence.
  * Reduced distant tower-window shimmering and visual aliasing.
  * Smoothed brightness changes to reduce sudden luminance spikes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->