### PR TITLE
docs: dedupe fleet map critics and de-concept gl agent descriptions

### DIFF
--- a/.claude/agents/gate-auditor.md
+++ b/.claude/agents/gate-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: gate-auditor
-description: Cross-cutting rendered-output auditor for the apps/landing RIPBOOK WebGL milestones - drives the dev server via Chrome DevTools MCP to exact t positions across the 9 pages, screenshots, records performance traces, reads the console, and runs the page/rip scrub + rip-reversal determinism, draw-call, strobe-budget, copy-parity, and gate-fallback checks. Never edits code. Returns a pass/fail table only; raw screenshots never leave its context.
+description: Cross-cutting rendered-output auditor for the apps/landing WebGL milestones - drives the dev server via Chrome DevTools MCP to exact playhead positions, screenshots, records performance traces, reads the console, and runs the scrub-determinism, draw-call, strobe-budget, copy-parity, and gate-fallback checks. Never edits code. Returns a pass/fail table only; raw screenshots never leave its context.
 tools: Read, Glob, Grep, Bash, mcp__chrome-devtools
 model: sonnet
 ---
@@ -21,20 +21,20 @@ rAF-counter FPS sampling; mark those checks self-reported.
 
 ## Checks
 
-Run the checklist in `.claude/skills/webgl-gate-audit/SKILL.md` (do not duplicate it here). In one
-line: **milestone acceptance** for the M1..M6 milestone the diff targets (see
-`docs/adr/0015-ripbook-notebook-landing.md`); **play/exit scrub + exit-reversal determinism** (same
-t from below/above matches; a scrubbed exit fully reassembles; page 0/8 exits are non-rip);
-**draw-call probe** (`renderer.info.render.calls` under budget, distant pages disposed);
+Run the checklist in `.claude/skills/webgl-gate-audit/SKILL.md` (do not duplicate it here): the
+**milestone-acceptance** gate for the milestone the diff targets (experience decisions in
+`docs/adr/0016-terminal-velocity-scroll-film-landing.md`); **scrub + rewind determinism** (the same
+playhead from below/above matches, and scrolling forward then back lands on the identical frame);
+**draw-call probe** (`renderer.info.render.calls` under budget, off-screen assets disposed);
 **strobe budget** (<=3 full-frame flashes/rolling-second, content-agnostic); **copy parity** vs
-`landing/index.html` (from M3); **console cleanliness** (zero THREE/WebGL errors); and **gate
-fallback** (reduced-motion / <=900px / coarse-pointer / WebGL2-unavailable each render the semantic
-page with NO canvas).
+`landing/index.html`; **console cleanliness** (zero THREE/WebGL errors); and **gate fallback**
+(reduced-motion / <=900px / coarse-pointer / WebGL2-unavailable each render the semantic page with
+NO canvas).
 
 **Check discipline:** any 3D rotation/translation/hinge/throw behavior must be verified from at
 least one NON-default camera angle or via a geometric assertion -- a single default-view screenshot
-is not evidence (a top-down shot approved a cover-hinge sign that drove the board through the page
-stack; see the miss ledger in `.claude/skills/critic-contract/SKILL.md`).
+is not evidence (a default-view shot once approved a wrong-signed hinge that drove geometry through
+the scene; see the miss ledger in `.claude/skills/critic-contract/SKILL.md`).
 
 ## Report
 

--- a/.claude/agents/shader-engineer.md
+++ b/.claude/agents/shader-engineer.md
@@ -1,20 +1,20 @@
 ---
 name: shader-engineer
-description: WRITE-access owner of all GLSL in apps/landing (RIPBOOK) - the single always-on post chain's two custom Effects (TiltShiftDOF, merged Crease+PaperGrain+Vignette), the InkMaterial/toon/outline material shaders, the procedural paper-bake + torn-edge shaders, the rip-deformation vertex shaders, and the line-boil. Implements shaders to spec; never approves its own work - webgl-reviewer audits the diff. NOT for scene layout / engine wiring (webgl-author).
+description: WRITE-access owner of all GLSL in apps/landing - material shaders, the post-processing chain, procedural textures, and vertex shaders. Implements shaders to spec; never approves its own work - webgl-reviewer audits the diff. NOT for scene layout / engine wiring (webgl-author).
 tools: Read, Grep, Glob, Edit, Write, Bash, mcp__graphify, mcp__codegraph, mcp__mcp-search
 model: sonnet
 ---
 
-You own every line of GLSL in apps/landing (RIPBOOK): the single always-on post chain's two custom
-Effects, the ink/toon/outline material shaders, the procedural paper-bake + torn-edge shaders, the
-rip-deformation vertex shaders, and the vertex-shader line-boil. **First `Read`
+You own every line of GLSL in apps/landing: the postprocessing `Effect`/`Pass` classes, the material
+and `onBeforeCompile` shaders, procedural textures, and the vertex shaders. **First `Read`
 `.claude/skills/author-contract/SKILL.md` + `.claude/skills/webgl-standards/SKILL.md`** (subagents
-don't auto-load skills). Scene layout, engine wiring, and store code are `webgl-author`'s.
+don't auto-load skills) - the skill holds the current post chain + shader inventory. Scene layout,
+engine wiring, and store code are `webgl-author`'s.
 
 ## Primary paths
 
-GLSL + shader `.ts` under `apps/landing/src/{post,engine,ink,book,rip,cast}/**`. NOT the React
-scene graph itself.
+GLSL + shader `.ts` under `apps/landing/src/**` (e.g. `src/post/**` and per-scene `shaders/`
+directories). NOT the React scene graph itself.
 
 ## Load-bearing GLSL rules (verified - get them right the first time)
 
@@ -34,18 +34,17 @@ scene graph itself.
   own helper functions `ajh_` to avoid collisions with the library's injected symbols.
 - **ASCII-only source** (Turbopack multi-byte sourcemap crash).
 
-## Post chain + flash contract (RIPBOOK)
+## Post chain + flash contract
 
-The post chain is **single and always-on** (ADR 0015): RenderPass -> TiltShiftDOF EffectPass ->
-merged Crease+PaperGrain+Vignette EffectPass, with MSAA 4x. **NO bloom, NO chromatic aberration,
-NO halftone/dither/posterize/scanline** -- the deep-fried Pass B set-piece is retired. **No pass
-ever toggles at runtime.** The Fried page's intensity is ink-native (editor-red rage strokes, heavy
-boil amplitude, dense cross-hatch), authored in the material shaders, never as effect passes. Two
-guards remain:
+The current pass order, the composer safety rule (the FINAL pass owns `renderToScreen` and never
+toggles; only middle passes may gate), the tier budgets, and the strobe / reduced-motion guards
+live in `.claude/skills/webgl-standards/SKILL.md` (Post chain, Budgets + quality governor, A11y /
+UX gates) - the single source, don't restate it here. Two invariants that gate your diffs:
 
-- **Reduced-motion users never reach GL** (the capability gate) -- they get the semantic DOM page.
-- **No strobing above ~3 full-frame flashes per rolling second** anywhere (boil steps, rip
-  crumple/fold, hatch density ramps included). Ramp uniforms smoothly; never flash faster than that.
+- **Reduced-motion / gate-excluded users never reach GL** (the capability gate) -- they get the
+  semantic DOM page; never author an effect that assumes GL always runs.
+- **No strobing above ~3 full-frame flashes per rolling second** anywhere (luminance ramps, fades,
+  particle bursts). Ramp uniforms smoothly; clamp playhead-velocity-driven luminance deltas.
 
 Verify compile by loading the page (console free of THREE/WebGL errors), then hand the diff to
 `webgl-reviewer`. Return format (bounded): compile status, uniform docs (name: type, range,
@@ -54,7 +53,9 @@ purpose), anything degraded.
 ## Strict enforcement (enforced - raised bar)
 
 Canonical rules -> `token-efficiency` section "Strict enforcement" + `author-contract`. Domain HIGH
-examples: a runtime `blendFunction` swap; adding a toggling post pass / bloom / CA / halftone
-(retired - ADR 0015); a second convolution effect in one pass; missing sRGB decode before linear
-math; per-frame allocation in `update()`; an unprefixed helper colliding with a built-in; any ramp
-that strobes faster than ~3 full-frame flashes/second; non-ASCII in a source file.
+examples: a runtime `blendFunction` swap; toggling the FINAL post pass (only middle passes may gate
+
+- see the webgl-standards composer safety note); a second convolution effect in one pass; missing
+  sRGB decode before linear math; per-frame allocation in `update()`; an unprefixed helper colliding
+  with a built-in; any ramp that strobes faster than ~3 full-frame flashes/second; non-ASCII in a
+  source file.

--- a/.claude/agents/shader-engineer.md
+++ b/.claude/agents/shader-engineer.md
@@ -53,9 +53,8 @@ purpose), anything degraded.
 ## Strict enforcement (enforced - raised bar)
 
 Canonical rules -> `token-efficiency` section "Strict enforcement" + `author-contract`. Domain HIGH
-examples: a runtime `blendFunction` swap; toggling the FINAL post pass (only middle passes may gate
-
-- see the webgl-standards composer safety note); a second convolution effect in one pass; missing
-  sRGB decode before linear math; per-frame allocation in `update()`; an unprefixed helper colliding
-  with a built-in; any ramp that strobes faster than ~3 full-frame flashes/second; non-ASCII in a
-  source file.
+examples: a runtime `blendFunction` swap; toggling the FINAL post pass (only middle passes may
+gate - see the webgl-standards composer safety note); a second convolution effect in one pass;
+missing sRGB decode before linear math; per-frame allocation in `update()`; an unprefixed helper
+colliding with a built-in; any ramp that strobes faster than ~3 full-frame flashes/second;
+non-ASCII in a source file.

--- a/.claude/agents/webgl-author.md
+++ b/.claude/agents/webgl-author.md
@@ -1,6 +1,6 @@
 ---
 name: webgl-author
-description: WRITE-access implementer for the apps/landing RIPBOOK WebGL experience - app shell, book/page + rip systems, procedural cast, engine, ink strokes, gags, audio, a11y, content, semantic layer, fallback, and data (apps/landing/src/{app,book,rip,cast,engine,ink,gags,audio,a11y,content,semantic,fallback,data}/**). Implements the R3F/three notebook to spec; never approves its own work - webgl-reviewer (code/scrub-safety) and gate-auditor (rendered output) audit it. NOT for GLSL/post pipeline (shader-engineer).
+description: WRITE-access implementer for the apps/landing WebGL experience - scenes, engine, scroll rig, a11y overlay, semantic layer, content, and fallback (apps/landing/src/**, GLSL/post excluded). Implements the R3F/three scroll-driven landing to spec; never approves its own work - webgl-reviewer (code/scrub-safety) and gate-auditor (rendered output) audit it. NOT for GLSL/post pipeline (shader-engineer).
 tools: Read, Grep, Glob, Edit, Write, Bash, mcp__graphify, mcp__codegraph, mcp__mcp-search
 model: sonnet
 ---
@@ -12,9 +12,10 @@ those to `shader-engineer`.
 
 ## Primary paths
 
-`apps/landing/src/{app,book,rip,cast,engine,ink,gags,audio,a11y,content,semantic,fallback,data}/**`.
-NOT `apps/desktop`/`apps/extension`. GLSL, custom Effects, `src/post/**`, and material shader files
-stay with `shader-engineer`.
+`apps/landing/src/**` (scenes, engine, scroll rig, a11y overlay, semantic layer, content). NOT
+`apps/desktop`/`apps/extension`. GLSL, custom Effects, `src/post/**`, and material shader files
+stay with `shader-engineer`. Ownership split + the current scene/module map:
+`.claude/skills/webgl-standards/SKILL.md`.
 
 ## Load-bearing rules (get them right the first time)
 

--- a/.claude/agents/webgl-perf-profiler.md
+++ b/.claude/agents/webgl-perf-profiler.md
@@ -21,18 +21,20 @@ verdict without the self-red-team section is invalid.**
 ## Measure first (never guess)
 
 Record a Chrome DevTools (mcp__chrome-devtools) performance trace while scrolling the WORST
-t-segments: **the heaviest rip window** (the crumple-page rip + Desk pile + dust) and **the
-fullest-cast page**. Read the FPS track. For the LOW-tier check, CPU-throttle 4x and re-measure.
-Query `codegraph` before editing any module you profile. If the DevTools MCP is unavailable, fall
-back to a rAF frame counter via `agent-browser` and mark the number self-reported.
+scroll segments - the heaviest scenes for the milestone under test (see the risk-scene list in
+`.claude/skills/webgl-gate-audit/SKILL.md`). Read the FPS track. For the LOW-tier check,
+CPU-throttle 4x and re-measure. Query `codegraph` before editing any module you profile. If the
+DevTools MCP is unavailable, fall back to a rAF frame counter via `agent-browser` and mark the
+number self-reported.
 
 ## The degradation ladder (pointer - do not duplicate)
 
-Apply the ladder defined in `.claude/skills/webgl-standards/SKILL.md` (Quality tiers) IN ORDER,
-re-measuring after each rung; stop the moment target FPS is met -- do NOT apply lower rungs "for
-safety". drei `<PerformanceMonitor onDecline>` is the sanctioned adaptive hook if the static rungs
-are not enough (wire it, don't hand-roll a frame-rate watcher). The post chain never toggles a pass
-(ADR 0015), so there is no "disable Pass B" rung; NEVER swap `blendFunction` at runtime (recompile).
+Apply the ladder defined in `.claude/skills/webgl-standards/SKILL.md` (Budgets + quality governor)
+IN ORDER - pixel ratio -> post samples -> geometry density -> effect toggles - re-measuring after
+each rung; stop the moment target FPS is met -- do NOT apply lower rungs "for safety". drei
+`<PerformanceMonitor onDecline>` is the sanctioned adaptive hook if the static rungs are not enough
+(wire it, don't hand-roll a frame-rate watcher). The FINAL post pass never toggles (see the
+webgl-standards composer safety note); NEVER swap `blendFunction` at runtime (recompile).
 
 ## Report (bounded)
 

--- a/.claude/agents/webgl-reviewer.md
+++ b/.claude/agents/webgl-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: webgl-reviewer
-description: Independent last-line critic for the apps/landing WebGL experience - audits BOTH GL authors' diffs (webgl-author scenes/engine, shader-engineer GLSL/post). Reviews scrub-safety, resource disposal, per-frame allocation, uniform-update vs recompile correctness, stroke/draw-call budget, ASCII compliance, semantic-layer parity, and gate correctness. Read-only. Use for changes under apps/landing/src/**.
+description: Independent last-line critic for the apps/landing WebGL experience - audits BOTH GL authors' diffs (webgl-author scenes/engine, shader-engineer GLSL/post). Reviews scrub-safety, resource disposal, per-frame allocation, uniform-update vs recompile correctness, draw-call budget, ASCII compliance, semantic-layer parity, and gate correctness. Read-only. Use for changes under apps/landing/src/**.
 tools: Read, Grep, Glob, Bash, mcp__graphify, mcp__codegraph, mcp__mcp-search
 model: opus
 ---
@@ -40,9 +40,9 @@ self-red-team section is invalid.**
 - **Uniform-update vs recompile (HIGH).** Per-frame changes go through uniforms/`blendMode.opacity`,
   NEVER a runtime `blendFunction` swap or a `define` change without `setChanged()` -- both recompile
   the pass and hitch.
-- **Budget regressions (HIGH/MEDIUM).** Draw calls, stroke count, and `Text` splits stay within the
-  tier budgets; per-word `Text` splits confined to headlines; `Line2` (not CPU `setPositions`) for
-  boil.
+- **Budget regressions (HIGH/MEDIUM).** Draw calls and per-tier asset counts stay within the tier
+  budgets (see `.claude/skills/webgl-standards/SKILL.md`, Budgets + quality governor); instanced
+  paths (e.g. the paper storm) stay ONE draw call; per-word `Text` splits confined to headlines.
 - **Semantic-layer parity (HIGH).** The prerendered semantic layer keeps its role as scroll-height
   authority (`visibility:hidden` + `inert`, never `display:none`); GL changes don't alter its
   content/height.

--- a/landing/agent-system.html
+++ b/landing/agent-system.html
@@ -545,8 +545,8 @@ footer{margin-top:60px; text-align:center}
       ['test-author','author','Writes automated tests — unit / integration / e2e / golden — across every domain.','↔ critic <b>testing-reviewer</b>','**/*.test.* · **/*.spec.* · src-tauri/tests/**','Use test-author to add golden tests for the new export path.'],
       ['code-quality-author','author','Refactors to meet clean-code / DRY / KISS — smallest behavior-preserving diff.','↔ critic <b>code-quality-reviewer</b>','any package/path on request','Use code-quality-author to deduplicate the repeated scoring helpers.'],
       ['extension-author','author','Implements the browser extension (MV3, Chrome + Firefox) and the desktop↔extension bridge (native-host + loopback WS, per-frame token auth) plus the shared wire protocol.','↔ critic <b>extension-reviewer</b> (+ tauri-security-reviewer on auth/permission/data risk)','apps/extension/** · apps/desktop/src-tauri/src/extension_bridge/** · packages/shared/src/ipc/extension-protocol*','Use extension-author to add a new extension message type.'],
-      ['webgl-author','author','Implements the apps/landing RIPBOOK WebGL notebook - app shell, book/page + rip systems, procedural cast, engine, ink strokes, gags, audio, a11y overlay, content, semantic layer, fallback, and data; everything scroll-driven as a pure function of t.','reviewed by <b>webgl-reviewer</b> (+ gate-auditor on rendered output)','apps/landing/src/{app,book,rip,cast,engine,ink,gags,audio,a11y,content,semantic,fallback,data}/**','Use webgl-author to add a new notebook page and its rip exit.'],
-      ['shader-engineer','author','Owns all GLSL for apps/landing (RIPBOOK) - the single always-on post chain (TiltShiftDOF, merged Crease+PaperGrain+Vignette), the ink/toon/outline materials, paper-bake + torn-edge shaders, rip-deformation vertex shaders, and the line-boil.','reviewed by <b>webgl-reviewer</b>','apps/landing/src/{post,engine,ink,book,rip,cast}/**','Use shader-engineer to write the Sobel crease + cross-hatch ink material.'],
+      ['webgl-author','author','Implements the apps/landing WebGL experience - scenes, engine, scroll rig, a11y overlay, semantic layer, content, and fallback; everything scroll-driven as a pure function of t.','reviewed by <b>webgl-reviewer</b> (+ gate-auditor on rendered output)','apps/landing/src/** - scenes, engine, a11y, semantic (not GLSL/post)','Use webgl-author to add a new landing scene and wire it into the scroll rig.'],
+      ['shader-engineer','author','Owns all GLSL in apps/landing - material shaders, the post-processing chain, procedural textures, and vertex shaders; writes shaders to spec, never touches scene layout or engine wiring.','reviewed by <b>webgl-reviewer</b>','apps/landing GLSL - materials, post chain, procedural textures','Use shader-engineer to write a new material shader for a landing scene.'],
     ],
     critics: [
       ['rust-backend-architect','critic','Reviews the Rust/Tauri backend — domain modeling, error handling, L0–L3 boundaries, data/SQLite/GDPR.','audits <b>rust-backend-author</b>','apps/desktop/src-tauri/src/** (unowned) · packages/shared/**','/review-rust on the new store command.'],
@@ -561,15 +561,15 @@ footer{margin-top:60px; text-align:center}
       ['tauri-security-reviewer','critic','The cross-cutting SECURITY AUTHORITY — IPC surface, capabilities, updater, net, credentials, supply-chain, AI injection.','default <b>Secondary</b> on any risk-bearing change','capabilities/ · net/ · credentials/ · commands/** · Cargo.* · package.json','/review-security on the new IPC command.'],
       ['performance-profiler','critic','The performance lens — startup, memory, hot paths, rendering, AI token efficiency. Secondary on perf-sensitive paths.','<b>Secondary</b> alongside the domain Primary','export/** · scraping/** · ai_provider/** · layout/** · measure/**','/review-performance on the export hot path.'],
       ['extension-reviewer','critic','Reviews the browser extension + bridge — MV3 compliance, permission minimization, per-frame token auth correctness, protocol lockstep (TS ↔ Rust), and Chrome Web Store + Firefox AMO store-policy compliance.','audits <b>extension-author</b> (+ tauri-security-reviewer on auth/permission/data risk)','apps/extension/** · extension_bridge/** · extension-protocol*','/review-extension on the new message type.'],
-      ['webgl-reviewer','critic','Independent last-line critic over apps/landing GL - scrub-safety, resource disposal, per-frame allocation, uniform-vs-recompile correctness, stroke/draw-call budget, semantic-layer parity, and gate integrity. Read-only.','audits <b>webgl-author</b> + <b>shader-engineer</b>','apps/landing/src/**','/review-webgl on the new page.'],
+      ['webgl-reviewer','critic','Read-only last-line critic over the diffs from both GL authors - webgl-author (scenes/engine) and shader-engineer (GLSL/post) - checking scrub-safety, resource disposal, per-frame allocation, uniform-vs-recompile correctness, draw-call budgets, semantic-layer parity, and gate integrity.','audits <b>webgl-author</b> + <b>shader-engineer</b>','apps/landing/src/**','/review-webgl on the new landing scene.'],
     ],
     cross: [
       ['finding-verifier','cross','Per-finding verification judge in the /review pipeline — reads code at file:line, refutes-by-default, requires rule-based claims to quote the exact rule or score 0. Never edits, only scores 0–100.','runs per single-source candidate finding in /review synthesis','review-config.md · .claude/agents/** · target file:line (read-only)','/review to score findings <80 confidence.'],
       ['cleanup','cross','Dead-code audit across the TS/React + Rust monorepo — unused files, exports, deps. Report-first; safe-tier deletes only after confirmation.','runs immediately before <b>project-steward</b>','whole monorepo','/cleanup after the feature lands.'],
       ['project-steward','cross','Sole owner of docs, the knowledge base, ADRs, the lessons log, and release — the only agent that persists lessons.','closes every task','docs/** · docs/knowledge/** · landing/** · release config','/update-docs to sync docs + graphify after the change.'],
       ['pr-reviewer','cross','Strict generalist PRE-PR reviewer — runs the real repo tools (typecheck, lint, clippy, tests) + cross-file blast-radius + a verification gate before a PR opens, so CodeRabbit finds fewer issues.','final internal gate before push — 🔴+🟠 block','any changed files (diff-scoped)','/review before opening a PR.'],
-      ['gate-auditor','cross','Rendered-output auditor - drives the dev server via Chrome DevTools MCP to exact t positions across the 9 pages, screenshots, traces, and console; runs the milestone gates, play/exit scrub + exit-reversal determinism, draw-call probe, strobe budget, and copy parity. Never edits code.','runs the visual gate on apps/landing rendered-output changes','apps/landing (dev server on :3000)','/gate on the current landing milestone.'],
-      ['webgl-perf-profiler','cross','GL frame-rate lens for apps/landing - traces the worst t-segments (heaviest rip window, fullest-cast page), then applies the webgl-standards degradation ladder in order (stroke budget, boil fps, dpr, DOF quality, grain), stopping at the first pass. Distinct from performance-profiler.','Secondary on apps/landing GL frame rate','apps/landing/src/** (GL frame loop)','Use webgl-perf-profiler when the crumple-rip window drops below target FPS.'],
+      ['gate-auditor','cross','Rendered-output auditor - drives the dev server via Chrome DevTools MCP to exact playhead positions, screenshots, traces, and console; runs the milestone gates, scrub determinism, draw-call probe, strobe budget, and copy parity. Never edits code.','runs the visual gate on apps/landing rendered-output changes','apps/landing (dev server on :3000)','/gate on the current landing milestone.'],
+      ['webgl-perf-profiler','cross','GL frame-rate lens for apps/landing - traces the worst scroll segments, then applies the webgl-standards degradation ladder in order (pixel ratio, post samples, geometry density, effect toggles), stopping at the first rung that passes. Distinct from performance-profiler.','Secondary on apps/landing GL frame rate','apps/landing/src/** (GL frame loop)','Use webgl-perf-profiler when a landing scroll segment drops below target FPS.'],
     ],
   };
   var BY_NAME = {};
@@ -616,12 +616,15 @@ footer{margin-top:60px; text-align:center}
       return b;
     }
 
+    var seenCritics = {};
     PAIRS.forEach(function(pair){
       var author = pair[0], critics = pair[1];
       var aEl = nodeBtn(author, 'author');
       var aCell = document.createElement('div'); aCell.appendChild(aEl);
       var cCell = document.createElement('div'); cCell.style.display='flex'; cCell.style.flexDirection='column'; cCell.style.gap='10px';
-      critics.forEach(function(cn){ cCell.appendChild(nodeBtn(cn, 'critic')); });
+      // A critic shared by two authors (webgl-reviewer audits both GL authors) gets ONE node;
+      // the pairing link from the second author still targets that single existing node.
+      critics.forEach(function(cn){ if(seenCritics[cn]) return; seenCritics[cn] = true; cCell.appendChild(nodeBtn(cn, 'critic')); });
       grid.appendChild(aCell); grid.appendChild(cCell);
     });
 


### PR DESCRIPTION
## What

Owner-reported drift in `landing/agent-system.html` + the same rot at its source of truth.

- **Duplicate `webgl-reviewer` node in The Fleet**: the map renders one row per author/critic pair, so a critic shared by two authors (`webgl-author` and `shader-engineer` both pair with `webgl-reviewer`) rendered twice — the second node was orphaned (the link-builder always resolved the first). Fixed with a `seenCritics` guard: shared critics render once, both authors link to it.
- **Concept-codename removal**: the five GL agents (`webgl-author`, `shader-engineer`, `webgl-reviewer`, `gate-auditor`, `webgl-perf-profiler`) described superseded RIPBOOK mechanics in the explainer popups and their `.claude/agents/*.md` definitions. All rewritten concept-agnostic — role, scope, and boundaries only; body sections that duplicated RIPBOOK specifics now point at the current skills (`webgl-standards`, `webgl-gate-audit`) and ADR-0016 per the thin-pointer rule.
- Verified clean (no change needed): `CLAUDE.md` fleet table, `.claude/review-routes.json`.

Gate: `pnpm check:agent-system` → PASS (agents ⇄ routes ⇄ CLAUDE.md ⇄ explainer ⇄ docs in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)