### PR TITLE
fix(referral): pass ISO code instead of display name to locale

### DIFF
--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.ts
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/ReferralModal/useReferralDraft.ts
@@ -96,9 +96,9 @@ export function useReferralDraft({
         format: channel,
         charLimit: channel === 'connection_note' ? CONNECTION_NOTE_LIMIT : undefined,
         model,
-        // Write the message in the résumé's language — same client-side detection
-        // the cover-letter/metadata path uses; `safeLocale` clamps it downstream.
-        locale: detectLanguages(resume, '').resumeName,
+        // Write the message in the résumé's language — pass the ISO 639-1 code
+        // (not the display name) so `safeLocale` downstream doesn't collapse it to 'en'.
+        locale: detectLanguages(resume, '').resume,
         onToken: (tok) => setDraft((prev) => prev + tok),
         signal: controller.signal,
       });
@@ -147,7 +147,7 @@ export function useReferralDraft({
         format: channel,
         charLimit: channel === 'connection_note' ? CONNECTION_NOTE_LIMIT : undefined,
         model,
-        locale: detectLanguages(resume, '').resumeName,
+        locale: detectLanguages(resume, '').resume,
         onToken: (tok) => {
           if (firstToken) {
             // Replace the snapshot with the first streaming token.


### PR DESCRIPTION
Closes #724.

## Summary

\`useReferralDraft\` was passing the language *display name* (\`\"Deutsch\"\`) into \`locale\`, which \`safeLocale()\` doesn't recognise and clamps to \`'en'\`. Every non-English résumé produced an English referral draft. Fix: pass \`.resume\` (ISO 639-1 code) instead of \`.resumeName\`.

## Changes

- \`useReferralDraft.ts\`: swap \`.resumeName\` → \`.resume\` at both call sites.

## Type of change

- [x] \`fix\` — Bug fix

## Testing

- [x] \`pnpm exec vitest run useReferralDraft.test.ts\` — **26/26 pass**
- [ ] Ran full \`pnpm test\` (skipped — a pre-existing zustand-persist / localStorage issue causes ~86 unrelated tests to fail on \`main\` in a fresh clone; my change doesn't touch that surface).
- Manual end-to-end verification not run (no local Ollama setup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved referral generation language detection by using the correct resume language code.
  * Prevented supported locales from incorrectly defaulting to English during referral drafting and refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->