### PR TITLE
fix(language-detection): return 'unknown' for codes outside LANGUAGE_MAP

### DIFF
--- a/packages/shared/src/language-detection.ts
+++ b/packages/shared/src/language-detection.ts
@@ -88,8 +88,9 @@ export function detectLanguage(text: string): string {
     return 'unknown';
   }
 
-  // Map ISO 639-3 to ISO 639-1
-  return LANGUAGE_MAP[code] || code;
+  // Map ISO 639-3 to ISO 639-1. Fall back to 'unknown' (not the raw 3-letter
+  // code) so the return value always honours the ISO 639-1 contract above.
+  return LANGUAGE_MAP[code] ?? 'unknown';
 }
 
 /**


### PR DESCRIPTION
Closes #726.

## Summary

\`detectLanguage()\` promises to return an ISO 639-1 code but leaks franc's raw ISO 639-3 code (\`ukr\`, \`bul\`, \`ben\`, \`pes\`, \`isl\`, \`cym\`, ...) when the detected language isn't in \`LANGUAGE_MAP\`. Fall back to \`'unknown'\` so the contract holds.

## Changes

- \`packages/shared/src/language-detection.ts\`: swap \`LANGUAGE_MAP[code] || code\` → \`LANGUAGE_MAP[code] ?? 'unknown'\`.

## Type of change

- [x] \`fix\` — Bug fix

## Testing

- [x] \`pnpm --filter @ajh/shared test\` — **254/254 pass** (includes \`language-detection.test.ts\`).
- Adding a regression test for the unmapped-code path would depend on franc's classification of a specific unmapped language (e.g. a Welsh or Persian sample) — happy to add one if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection consistency by returning supported two-letter language codes.
  * Unrecognized language codes now return “unknown,” improving mismatch and language-name results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->