### PR TITLE
fix(export): keep Unicode letters in exported filenames

### DIFF
--- a/apps/desktop/src/renderer/lib/generate/export/export.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/export/export.test.ts
@@ -30,6 +30,17 @@ describe('buildFilename', () => {
       'Candidate-Role-Company-cover-letter.docx'
     );
   });
+
+  it('preserves Cyrillic and CJK characters instead of collapsing to the placeholder', () => {
+    const cyrillic = { ...meta, candidateName: 'Иван Петров' };
+    expect(buildFilename(cyrillic, 'resume', 'pdf')).toBe(
+      'Иван-Петров-Senior-Engineer-Acme-Co-resume.pdf'
+    );
+    const cjk = { ...meta, candidateName: '田中 太郎' };
+    expect(buildFilename(cjk, 'resume', 'pdf')).toBe(
+      '田中-太郎-Senior-Engineer-Acme-Co-resume.pdf'
+    );
+  });
 });
 
 describe('exportTXT', () => {

--- a/apps/desktop/src/renderer/lib/generate/export/export.ts
+++ b/apps/desktop/src/renderer/lib/generate/export/export.ts
@@ -12,7 +12,9 @@ function sanitize(str: string): string {
   return str
     .normalize('NFD')
     .replace(/[̀-ͯ]/g, '')
-    .replace(/[^a-zA-Z0-9\s-]/g, '')
+    // Keep any Unicode letter/number so non-Latin names (Cyrillic, CJK, Arabic,
+    // Greek, Hebrew, Thai, ...) survive instead of collapsing to the placeholder.
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
     .trim()
     .replace(/\s+/g, '-')
     .replace(/-{2,}/g, '-')

--- a/apps/desktop/src/renderer/lib/generate/export/export.ts
+++ b/apps/desktop/src/renderer/lib/generate/export/export.ts
@@ -9,16 +9,18 @@ import { type LetterLayoutId, type TemplateId, TEMPLATES } from '../templates';
 // ─── Filename ─────────────────────────────────────────────────────────────────
 
 function sanitize(str: string): string {
-  return str
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    // Keep any Unicode letter/number so non-Latin names (Cyrillic, CJK, Arabic,
-    // Greek, Hebrew, Thai, ...) survive instead of collapsing to the placeholder.
-    .replace(/[^\p{L}\p{N}\s-]/gu, '')
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/-{2,}/g, '-')
-    .slice(0, 40);
+  return (
+    str
+      .normalize('NFD')
+      .replace(/[̀-ͯ]/g, '')
+      // Keep any Unicode letter/number so non-Latin names (Cyrillic, CJK, Arabic,
+      // Greek, Hebrew, Thai, ...) survive instead of collapsing to the placeholder.
+      .replace(/[^\p{L}\p{N}\s-]/gu, '')
+      .trim()
+      .replace(/\s+/g, '-')
+      .replace(/-{2,}/g, '-')
+      .slice(0, 40)
+  );
 }
 
 export function buildFilename(


### PR DESCRIPTION
Closes #728.

## Summary

Filename sanitiser stripped every non-ASCII letter, so non-Latin names (Cyrillic, CJK, Arabic, Greek, Hebrew, Thai, ...) collapsed to \`\"\"\` and exports were named \`Candidate-Role-Company-<type>.<ext>\`. Switch the character class to \`\p{L}\p{N}\` with the \`u\` flag so any Unicode letter/number survives.

## Changes

- \`apps/desktop/src/renderer/lib/generate/export/export.ts\`: swap \`/[^a-zA-Z0-9\s-]/g\` → \`/[^\p{L}\p{N}\s-]/gu\`.
- \`apps/desktop/src/renderer/lib/generate/export/export.test.ts\`: add a \`buildFilename\` regression test covering a Cyrillic and a CJK name.

The pre-existing NFD-normalise + combining-mark strip runs first, so \`\"Jöhn Doe\"\` still collapses to \`\"John-Doe\"\` and the existing test continues to pass.

## Type of change

- [x] \`fix\` — Bug fix

## Testing

- [x] \`pnpm exec vitest run export.test.ts\` — **19/19 pass**, including the new Cyrillic (\`Иван Петров\`) and CJK (\`田中 太郎\`) regression cases.