### PR TITLE
fix(analyze): drop false language mismatch when a language is empty string

### DIFF
--- a/packages/prompts/src/analyze/analyze.test.ts
+++ b/packages/prompts/src/analyze/analyze.test.ts
@@ -232,6 +232,18 @@ describe('validateAndRepair', () => {
     expect(validateAndRepair('totally not json')).toBeNull();
   });
 
+  it('does not flag mismatch when a language field is an empty string', () => {
+    // The empty-string resume must coerce to 'unknown', and the mismatch check
+    // must run on the coerced value — otherwise the badge lights up alongside a
+    // resume language displayed as "unknown", which is self-contradictory.
+    const result = validateAndRepair(
+      JSON.stringify({ detectedLanguages: { resume: '', jobAd: 'fr' } })
+    ) as AnalysisResult;
+    expect(result.detectedLanguages.resume).toBe('unknown');
+    expect(result.detectedLanguages.jobAd).toBe('fr');
+    expect(result.detectedLanguages.mismatch).toBe(false);
+  });
+
   it('defaults missing sub-objects gracefully', () => {
     const result = validateAndRepair('{}') as AnalysisResult;
     expect(result.detectedLanguages.resume).toBe('unknown');

--- a/packages/prompts/src/analyze/validate.ts
+++ b/packages/prompts/src/analyze/validate.ts
@@ -112,20 +112,20 @@ export function validateAndRepair(raw: string): AnalysisResult | null {
     })
     .filter((r) => r.issue.length > 0);
 
+  // Coerce first, then decide mismatch on the coerced values — an empty-string
+  // language from the model would otherwise slip past the 'unknown' guard below.
+  const resumeLang = ensureString(langs.resume, 'unknown');
+  const jobAdLang = ensureString(langs.jobAd, 'unknown');
   return {
     detectedLanguages: {
-      resume: ensureString(langs.resume, 'unknown'),
-      jobAd: ensureString(langs.jobAd, 'unknown'),
+      resume: resumeLang,
+      jobAd: jobAdLang,
       // Only flag mismatch when both languages are actually known — matches
       // detectLanguages() in @ajh/shared. Otherwise an 'unknown' or missing
       // side would falsely trip the mismatch warning.
       mismatch:
         langs.mismatch === true ||
-        (typeof langs.resume === 'string' &&
-          typeof langs.jobAd === 'string' &&
-          langs.resume !== 'unknown' &&
-          langs.jobAd !== 'unknown' &&
-          langs.resume !== langs.jobAd),
+        (resumeLang !== 'unknown' && jobAdLang !== 'unknown' && resumeLang !== jobAdLang),
     },
     scores: {
       ats: clampScore(scores.ats),


### PR DESCRIPTION
Closes #730.

## Summary

\`validateAndRepair\` coerced an empty-string language to \`'unknown'\` in the output but then decided \`mismatch\` on the raw pre-coerce value, producing self-contradictory output like \`{ resume: 'unknown', jobAd: 'fr', mismatch: true }\`. Compute mismatch on the coerced values so the guard the comment describes actually applies.

## Changes

- \`packages/prompts/src/analyze/validate.ts\`: coerce \`resume\` / \`jobAd\` once and reuse them in the mismatch expression.
- \`packages/prompts/src/analyze/analyze.test.ts\`: new regression covering the empty-string case.

## Type of change

- [x] \`fix\` — Bug fix

## Testing

- [x] \`pnpm --filter @ajh/prompts test\` — **505/505 pass** (includes the new regression).
- [ ] Ran full \`pnpm test\` (skipped — same pre-existing zustand-persist / localStorage vitest env issue that fails ~115 unrelated tests on unmodified \`main\` in a fresh clone; CI on GitHub Actions runs the full suite).