### PR TITLE
fix(links): capture markdown urls containing balanced parens

### DIFF
--- a/apps/desktop/src/renderer/lib/generate/links.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/links.test.ts
@@ -104,6 +104,16 @@ describe('buildLinkSuggestions — in-doc harvest from docValue', () => {
     const result = buildLinkSuggestions({ contactProfile: null, docValue: '' });
     expect(result).toEqual([]);
   });
+
+  it('captures a URL that itself contains a balanced paren pair (e.g. wikipedia disambiguation)', () => {
+    const docValue =
+      'See [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) for context.';
+    const result = buildLinkSuggestions({ contactProfile: null, docValue });
+    expect(result).toContainEqual({
+      label: 'Python',
+      url: 'https://en.wikipedia.org/wiki/Python_(programming_language)',
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/renderer/lib/generate/links.ts
+++ b/apps/desktop/src/renderer/lib/generate/links.ts
@@ -15,9 +15,12 @@ import type { LinkSuggestion } from '@ajh/ui';
 /**
  * An inline markdown link span `[label](url)` in the live document. Mirrors the
  * `MD_LINK_SPAN_RE` shape in packages/prompts/src/generate/links.ts; the two
- * capture groups are the label and the raw URL.
+ * capture groups are the label and the raw URL. The URL group allows one level
+ * of balanced parens so Wikipedia-style URLs (e.g. `Python_(programming_language)`)
+ * are captured whole instead of being truncated at the first `)`. Bounded
+ * quantifiers (200/2000) cap adversarial input to keep the regex linear.
  */
-const MD_LINK_SPAN_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+const MD_LINK_SPAN_RE = /\[([^\]]{1,200})\]\(((?:[^()]|\([^()]{0,200}\)){1,2000})\)/g;
 
 /** URL schemes we surface — matches the dialog's `isAllowedLinkUrl` gate. */
 const ALLOWED_SCHEMES = new Set(['http:', 'https:', 'mailto:']);


### PR DESCRIPTION
Closes #732.

## Summary

\`MD_LINK_SPAN_RE\` used \`[^)]+\` for the URL, so a markdown link like \`[Python](https://en.wikipedia.org/wiki/Python_(programming_language))\` was captured truncated at the first \`)\` — the editor's link pick-list surfaced \`https://en.wikipedia.org/wiki/Python_(programming\`. Allow one level of balanced parens inside the URL group, keep the 200/2000-char bounds so the regex stays linear.

## Changes

- \`apps/desktop/src/renderer/lib/generate/links.ts\`: extend URL group to allow one nested \`(...)\` pair; refresh the mirrored-shape comment.
- \`apps/desktop/src/renderer/lib/generate/links.test.ts\`: new \`buildLinkSuggestions\` regression for a Wikipedia-disambiguation URL.

## Type of change

- [x] \`fix\` — Bug fix

## Testing

- [x] \`pnpm exec vitest run links.test.ts\` — **32/32 pass**, including the new balanced-paren regression.
- [ ] Ran full \`pnpm test\` (skipped — same pre-existing zustand-persist / localStorage vitest env issue that fails ~115 unrelated tests on unmodified \`main\`; CI on GitHub Actions runs the full suite).