### PR TITLE
fix(applications): standalone apply-by-email generation and scrollable jobs scrape form

### DIFF
--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.test.tsx
@@ -404,6 +404,24 @@ describe('ApplyByEmailTab — standalone generation', () => {
     expect(generateEmailMock).toHaveBeenCalledWith(expect.objectContaining({ jobAd: RESOLVED }));
   });
 
+  it('shows the loading skeleton while the job URL is still resolving', () => {
+    // Empty JD + no saved generation → the URL resolver is enabled and in-flight.
+    resolveJobUrlMock.mockReturnValue({ data: undefined, isFetching: true });
+
+    const { container } = render(
+      <ApplyByEmailTab
+        application={makeApp({ jobDescription: '' })}
+        matchingGenerations={NO_GENERATIONS}
+      />
+    );
+
+    // The loading gate short-circuits to the skeleton only...
+    expect(container.querySelector('.animate-skeleton')).not.toBeNull();
+    // ...so neither the Generate button nor the needsJob empty state has rendered.
+    expect(screen.queryByRole('button', { name: 'applications.detail.email.generate' })).toBeNull();
+    expect(screen.queryByText('applications.detail.email.needsJob')).toBeNull();
+  });
+
   it('detects the target language from a German job description (real detectLanguage)', async () => {
     const germanJd =
       'Wir suchen einen erfahrenen Softwareentwickler für unser Team in München. ' +

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.test.tsx
@@ -35,10 +35,30 @@ vi.mock('@/hooks/useDefaultResumeId', () => ({
   useDefaultResumeId: () => 'doc-1',
 }));
 
+// Router — the needsResume CTA calls useNavigate(); a bare hook throws without a
+// RouterProvider, so stub it and capture the navigation target.
+const navigateMock = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+// Mutable service returns (same idiom as generateEmailMock) so each case can
+// drive the résumé text, contact profile, and URL-resolved job description
+// independently.
+const documentTextMock = vi.fn<() => { data: string; isLoading: boolean }>();
+const contactProfileMock = vi.fn<() => { data?: { fullName?: string } }>();
+const resolveJobUrlMock =
+  vi.fn<
+    (url: string, enabled?: boolean) => { data?: { description?: string }; isFetching: boolean }
+  >();
+
 vi.mock('@/services', () => ({
   useDocuments: () => ({ isLoading: false }),
-  useDocumentText: () => ({ data: 'My résumé text.', isLoading: false }),
+  useDocumentText: () => documentTextMock(),
   useUpdateApplication: () => ({ mutate: vi.fn() }),
+  useContactProfile: () => contactProfileMock(),
+  useResolveJobUrl: (url: string, enabled?: boolean) => resolveJobUrlMock(url, enabled),
 }));
 
 // Deterministic: no recipient auto-fill from the (empty) job description.
@@ -140,6 +160,13 @@ beforeEach(() => {
     p.onToken?.(EMAIL_RAW);
     return EMAIL_RAW;
   });
+  navigateMock.mockClear();
+  documentTextMock.mockReset();
+  documentTextMock.mockReturnValue({ data: 'My résumé text.', isLoading: false });
+  contactProfileMock.mockReset();
+  contactProfileMock.mockReturnValue({ data: { fullName: 'Jane Applicant' } });
+  resolveJobUrlMock.mockReset();
+  resolveJobUrlMock.mockReturnValue({ data: undefined, isFetching: false });
   window.getSelection()?.removeAllRanges();
 });
 
@@ -319,5 +346,90 @@ describe('ApplyByEmailTab — select-to-rewrite', () => {
       '_blank'
     );
     openSpy.mockRestore();
+  });
+});
+
+// ── standalone generation (no prior document generation) ─────────────────────
+
+describe('ApplyByEmailTab — standalone generation', () => {
+  /** Render, click Generate, and wait for the streamed draft to settle. */
+  async function generate(application: Application) {
+    render(<ApplyByEmailTab application={application} matchingGenerations={NO_GENERATIONS} />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'applications.detail.email.generate' }));
+    });
+    await screen.findByText(BODY);
+  }
+
+  it('builds meta from the contact profile + application when there is no saved generation', async () => {
+    await generate(makeApp());
+
+    expect(generateEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          candidateName: 'Jane Applicant',
+          companyName: 'Acme',
+          jobTitle: 'Engineer',
+        }),
+      })
+    );
+    // The persisted JD is present, so the URL resolver is disabled.
+    expect(resolveJobUrlMock).toHaveBeenCalledWith('https://acme.com/job/1', false);
+  });
+
+  it('resolves the job description from the URL when the application has none', async () => {
+    const RESOLVED = 'Resolved job description fetched from the posting URL.';
+    resolveJobUrlMock.mockReturnValue({ data: { description: RESOLVED }, isFetching: false });
+
+    render(
+      <ApplyByEmailTab
+        application={makeApp({ jobDescription: '' })}
+        matchingGenerations={NO_GENERATIONS}
+      />
+    );
+
+    // The resolver is enabled ONLY because the JD is empty.
+    expect(resolveJobUrlMock).toHaveBeenCalledWith('https://acme.com/job/1', true);
+
+    const generateBtn = screen.getByRole('button', {
+      name: 'applications.detail.email.generate',
+    });
+    expect(generateBtn).toBeEnabled();
+
+    await act(async () => {
+      fireEvent.click(generateBtn);
+    });
+    await screen.findByText(BODY);
+
+    expect(generateEmailMock).toHaveBeenCalledWith(expect.objectContaining({ jobAd: RESOLVED }));
+  });
+
+  it('detects the target language from a German job description (real detectLanguage)', async () => {
+    const germanJd =
+      'Wir suchen einen erfahrenen Softwareentwickler für unser Team in München. ' +
+      'Sie arbeiten an spannenden Projekten und stimmen sich eng mit dem Produktteam ab.';
+
+    await generate(makeApp({ jobDescription: germanJd }));
+
+    expect(generateEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ meta: expect.objectContaining({ targetLanguage: 'de' }) })
+    );
+  });
+
+  it('disables Generate and shows the needsResume empty state + CTA when no résumé exists', () => {
+    documentTextMock.mockReturnValue({ data: '', isLoading: false });
+
+    render(<ApplyByEmailTab application={makeApp()} matchingGenerations={NO_GENERATIONS} />);
+
+    const generateBtn = screen.getByRole('button', {
+      name: 'applications.detail.email.generate',
+    });
+    expect(generateBtn).toBeDisabled();
+
+    expect(screen.getByText('applications.detail.email.needsResume')).toBeTruthy();
+
+    const cta = screen.getByRole('button', { name: 'applications.detail.email.addResume' });
+    fireEvent.click(cta);
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/documents' });
   });
 });

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.tsx
@@ -1,8 +1,9 @@
 import { Briefcase, Check, ClipboardCopy, FileText, Mail, Sparkles } from 'lucide-react';
 import { AnimatePresence } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 
-import type { AiGenerationRecord, Application } from '@ajh/shared';
+import { type AiGenerationRecord, type Application, detectLanguage } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
 import { Button, CardSkeleton, EmptyState, Input, RowSkeleton, StreamingText } from '@ajh/ui';
 
@@ -11,11 +12,18 @@ import {
   type RewriteTarget,
 } from '@/components/generation/EditableOutput/RewritePopover';
 import { useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
+import { ROUTES } from '@/constants/routes';
 import { useDefaultResumeId } from '@/hooks/useDefaultResumeId';
 import { generateApplicationEmail, type GenerationMeta } from '@/lib/generate';
 import { getSelectionOffsets } from '@/lib/selection-offsets';
 import { COPY_FEEDBACK_MS } from '@/lib/timings';
-import { useDocuments, useDocumentText, useUpdateApplication } from '@/services';
+import {
+  useContactProfile,
+  useDocuments,
+  useDocumentText,
+  useResolveJobUrl,
+  useUpdateApplication,
+} from '@/services';
 
 import { extractRecipient } from '../../lib/extract-recipient';
 
@@ -61,14 +69,26 @@ export function ApplyByEmailTab({ application, matchingGenerations }: Props) {
   const model = useSelectedModel();
   const { canUse } = useCanUseAI();
 
+  const navigate = useNavigate();
   const { isLoading: docsLoading } = useDocuments();
   const defaultResumeId = useDefaultResumeId();
   const resumeQuery = useDocumentText(defaultResumeId);
   const updateApplication = useUpdateApplication();
+  const profile = useContactProfile();
 
   const saved = matchingGenerations[0];
-  const jobDesc = (application.jobDescription ?? '').trim() || (saved?.jobAd ?? '').trim();
+  // application.jobDescription is the primary source; the saved generation's jobAd
+  // is a fallback for older records; URL resolution only fires when neither has
+  // content yet (mirrors InterviewPrepTab so email generation is self-sourcing).
+  const initialDesc = (application.jobDescription ?? '').trim() || (saved?.jobAd ?? '').trim();
+  const resolved = useResolveJobUrl(application.jobUrl, !initialDesc);
+  const jobDesc = initialDesc || (resolved.data?.description ?? '').trim();
   const resume = (resumeQuery.data ?? '').trim() || (saved?.resumeText ?? '').trim();
+
+  // Fallback target language when there is no saved generation to copy it from:
+  // detect from the job description, defaulting unknown/too-short text to English.
+  const detectedLanguage = detectLanguage(jobDesc);
+  const fallbackLanguage = detectedLanguage === 'unknown' ? 'en' : detectedLanguage;
 
   const meta: GenerationMeta = saved
     ? {
@@ -82,10 +102,10 @@ export function ApplyByEmailTab({ application, matchingGenerations }: Props) {
         topRequirements: saved.topRequirements,
       }
     : {
-        candidateName: '',
+        candidateName: profile.data?.fullName?.trim() ?? '',
         jobTitle: application.title,
         companyName: application.company,
-        targetLanguage: 'en',
+        targetLanguage: fallbackLanguage,
         resumeLanguage: 'en',
         jobAdLanguage: 'en',
         mismatch: false,
@@ -272,7 +292,11 @@ export function ApplyByEmailTab({ application, matchingGenerations }: Props) {
     );
   };
 
-  if (docsLoading || (!!defaultResumeId && resumeQuery.isLoading)) {
+  if (
+    docsLoading ||
+    (!!defaultResumeId && resumeQuery.isLoading) ||
+    (!initialDesc && resolved.isFetching)
+  ) {
     return (
       <div className="h-full overflow-y-auto px-6 py-5">
         <CardSkeleton />
@@ -362,6 +386,17 @@ export function ApplyByEmailTab({ application, matchingGenerations }: Props) {
             icon={FileText}
             title={t('applications.detail.email.needsResume')}
             className="py-12"
+            action={
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => void navigate({ to: ROUTES.RESUMES })}
+                className="gap-1.5"
+              >
+                <FileText size={13} />
+                {t('applications.detail.email.addResume')}
+              </Button>
+            }
           />
         )}
         {canUse && !!resume && !jobDesc && !hasDraft && (

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
@@ -765,3 +765,25 @@ describe('JobsPage — stable newest sort', () => {
     expect(filteredIds()).toEqual(['new', 'old', 'u1', 'u2']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Header/scrape-form scroll container — jsdom can't measure layout, so assert
+// the bounding + scroll classes are present on the wrapper. Without them, a
+// full board selection + open advanced grid overflows the viewport and the
+// Start button becomes unreachable at the 900x600 window floor.
+// ---------------------------------------------------------------------------
+
+describe('JobsPage — scrape form scroll container', () => {
+  beforeEach(() => {
+    postingsContainer.data = [];
+  });
+
+  it('bounds and scrolls the header wrapper so tall form content cannot clip the Start button', () => {
+    renderJobsPage();
+
+    const wrapper = screen.getByTestId(TEST_IDS.jobs.scrapeFormScroll);
+    expect(wrapper.className).toContain('overflow-y-auto');
+    expect(wrapper.className).toContain('max-h-[55vh]');
+    expect(wrapper.className).toContain('min-h-0');
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
@@ -784,6 +784,5 @@ describe('JobsPage — scrape form scroll container', () => {
     const wrapper = screen.getByTestId(TEST_IDS.jobs.scrapeFormScroll);
     expect(wrapper.className).toContain('overflow-y-auto');
     expect(wrapper.className).toContain('max-h-[55vh]');
-    expect(wrapper.className).toContain('min-h-0');
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -303,7 +303,7 @@ export function JobsPage() {
               owner below. Short content is unaffected (no scrollbar shown). */}
           <div
             data-testid={TEST_IDS.jobs.scrapeFormScroll}
-            className="min-h-0 max-h-[55vh] shrink-0 overflow-y-auto px-10 pt-10"
+            className="max-h-[55vh] shrink-0 overflow-y-auto px-10 pt-10"
           >
             <PageHeader
               title={t('jobs.title')}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -6,6 +6,7 @@ import {
   type BoardScrapeSummary,
   type DATE_FILTER_OPTIONS,
 } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
 import { Button, ConfirmModal, Dropdown, Input, SegmentedControl, useNotification } from '@ajh/ui';
 
@@ -295,8 +296,15 @@ export function JobsPage() {
             matching the dashboard. Both the pinned header and the scroll area
             sit inside so they stay visually aligned. */}
         <div className="mx-auto flex w-full min-h-0 flex-1 flex-col max-w-6xl 2xl:max-w-7xl">
-          {/* Pinned header + scrape form; the list below owns the scroll. */}
-          <div className="shrink-0 px-10 pt-10">
+          {/* Header + scrape form. Bounded + self-scrolling so that selecting all
+              boards and opening the advanced grid can't push the Start button off
+              the bottom of the viewport (900x600 floor) — it caps at 55vh and
+              scrolls internally, leaving the results list as the primary scroll
+              owner below. Short content is unaffected (no scrollbar shown). */}
+          <div
+            data-testid={TEST_IDS.jobs.scrapeFormScroll}
+            className="min-h-0 max-h-[55vh] shrink-0 overflow-y-auto px-10 pt-10"
+          >
             <PageHeader
               title={t('jobs.title')}
               subtitle={t('jobs.subtitle')}

--- a/packages/test-ids/src/test-ids.ts
+++ b/packages/test-ids/src/test-ids.ts
@@ -22,6 +22,8 @@ export const TEST_IDS = {
   /** Jobs feature — scraping, results, form */
   jobs: {
     scrapeForm: 'scrape-form',
+    /** Bounded, scrollable wrapper around the page header + scrape form. */
+    scrapeFormScroll: 'scrape-form-scroll',
     /** stub-only: no matching attribute on the real component */
     scrapeFilters: 'scrape-filters',
     aggregatorKeyHint: 'aggregator-key-hint',

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2552,7 +2552,8 @@
         "rewriteSubjectAriaLabel": "Betreff mit KI umschreiben",
         "rewriteBodyAriaLabel": "E-Mail-Inhalt mit KI umschreiben",
         "openMailto": "Per E-Mail-Client senden",
-        "needsResume": "Füge deinen Lebenslauf hinzu, um eine Bewerbungs-E-Mail zu generieren."
+        "needsResume": "Füge deinen Lebenslauf hinzu, um eine Bewerbungs-E-Mail zu generieren.",
+        "addResume": "Lebenslauf hinzufügen"
       },
       "tabsLabel": "Bewerbungsdetail-Tabs",
       "timelineTitle": "Verlauf",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2548,7 +2548,8 @@
         "rewriteSubjectAriaLabel": "Rewrite the subject with AI",
         "rewriteBodyAriaLabel": "Rewrite the email body with AI",
         "openMailto": "Send via mail client",
-        "needsResume": "Add your résumé to generate an application email."
+        "needsResume": "Add your résumé to generate an application email.",
+        "addResume": "Add a résumé"
       },
       "tabsLabel": "Application detail tabs",
       "timelineTitle": "Timeline",


### PR DESCRIPTION
## Problems (user-reported)

1. **Apply by email was dead until a resume/cover letter had been generated.** The tab's resume text and job description both fell back to the first saved AI generation record, and the fallback meta hardcoded an empty candidate name and English target language — so with no prior generation the Generate button never enabled, and even when it did, metadata was wrong.
2. **Jobs page: selecting all boards and opening advanced settings clipped the form with no scrollbar** — the header block sits under an `overflow-hidden` ancestor with no bounded height, so the bottom of the form (including the Start button) was unreachable.

## Fixes

- **ApplyByEmailTab**: job description now resolves `application.jobDescription` → saved generation → job URL via `useResolveJobUrl` (same pattern as InterviewPrepTab); fallback meta takes `candidateName` from the contact profile (authoritative source) and `targetLanguage` from `detectLanguage(jobDesc)` with unknown → en; the loading gate covers the in-flight URL resolve; the needs-resume empty state gains a CTA to the resumes page (new i18n key, en + de).
- **JobsPage**: the header/scrape-form wrapper is bounded with `max-h-[55vh] overflow-y-auto` (results list stays the primary scroll owner), with a test-id seam.

## Tests

5 new ApplyByEmailTab cases (standalone meta from profile, URL-resolved JD with enabled-only-when-empty, real detectLanguage German → de, true empty state + CTA, in-flight resolve skeleton) + a class-assertion guard on the scroll wrapper. Full desktop suite 2,379 tests green; monorepo pre-push gate clean; tsc/eslint/prettier clean.

## Review

Audited by frontend-reviewer: APPROVE, no HIGH/CRITICAL; both advisory items (in-flight loading test, inert `min-h-0`) already addressed in follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)