### PR TITLE
fix(jobs): post-756 review findings and ai review sticky restyle

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -173,7 +173,7 @@ jobs:
             if (findings.length) {
               body = marker + '\n' + fs.readFileSync('review-comment.md', 'utf8');
             } else if (sticky) {
-              body = marker + '\n## 🤖 AI Review OK\n\n✓ Latest run found no findings — earlier findings are resolved or superseded.';
+              body = marker + '\n## 🤖 AI Review OK\n\n**Verdict: no blocking findings** — ✓ latest run found no findings; earlier findings are resolved or superseded.';
             }
             if (!body) return; // clean run and no prior sticky: stay silent
             if (sticky) {

--- a/apps/desktop/src-tauri/src/commands/dedup.rs
+++ b/apps/desktop/src-tauri/src/commands/dedup.rs
@@ -137,6 +137,62 @@ mod tests {
     }
 
     #[test]
+    fn clamp_collapses_duplicate_other_keys_preserving_first_seen_order() {
+        // The SAME key repeated (interleaved) collapses to ONE entry, and the
+        // surviving order is first-seen: `b` before `a` because `b` appears first.
+        let keys = vec![
+            "b".to_string(),
+            "a".to_string(),
+            "b".to_string(), // dup of the first-seen `b`
+            "a".to_string(), // dup of `a`
+            "c".to_string(),
+        ];
+        let (_, clamped) = clamp_split_request("member", &keys).expect("valid request");
+        assert_eq!(
+            clamped,
+            vec!["b".to_string(), "a".to_string(), "c".to_string()],
+            "duplicates collapse to one entry, first-seen order preserved"
+        );
+    }
+
+    #[test]
+    fn clamp_dedup_before_cap_yields_full_distinct_capacity() {
+        // 40 DISTINCT keys, with the first key hammered 20 extra times
+        // interleaved. De-dup runs BEFORE the 32-cap, so the repeats collapse and
+        // do NOT steal slots — the result is the FULL 32 distinct keys (d0..d31),
+        // not fewer.
+        let mut keys: Vec<String> = Vec::new();
+        for i in 0..40 {
+            keys.push(format!("d{i}"));
+            if i < 20 {
+                keys.push("d0".to_string()); // repeatedly hammer one key
+            }
+        }
+        let (_, clamped) = clamp_split_request("member", &keys).expect("valid request");
+        assert_eq!(
+            clamped.len(),
+            MAX_OTHER_KEYS,
+            "dedup-before-cap must yield the FULL 32 distinct slots, not fewer"
+        );
+        let unique: std::collections::HashSet<&String> = clamped.iter().collect();
+        assert_eq!(
+            unique.len(),
+            clamped.len(),
+            "all surviving keys are distinct"
+        );
+        // The cap keeps the first 32 DISTINCT keys in first-seen order.
+        assert_eq!(clamped.first().map(String::as_str), Some("d0"));
+        assert!(
+            clamped.contains(&"d31".to_string()),
+            "a distinct key up to the cap survives despite the repeats"
+        );
+        assert!(
+            !clamped.contains(&"d32".to_string()),
+            "distinct keys beyond the cap are dropped"
+        );
+    }
+
+    #[test]
     fn clamp_deduplicates_repeated_keys_before_the_cap() {
         // 33 entries where two are duplicates (k0 and k1 each appear twice) → 31
         // DISTINCT keys. De-dup runs BEFORE the 32-cap, so all 31 are kept

--- a/apps/desktop/src-tauri/src/commands/dedup.rs
+++ b/apps/desktop/src-tauri/src/commands/dedup.rs
@@ -37,7 +37,8 @@ fn clamp_bytes(mut s: String, max: usize) -> String {
 
 /// Normalize an untrusted split request at the command boundary (CWE-770):
 /// trim + byte-clamp `member_key`, then trim / drop-blank / byte-clamp each
-/// `other_key`, drop self-pairs, and cap the count at [`MAX_OTHER_KEYS`].
+/// `other_key`, drop self-pairs, DE-DUPLICATE (first-seen order preserved) so a
+/// repeated key can't waste a slot, and cap the count at [`MAX_OTHER_KEYS`].
 /// Returns `None` when there is nothing usable to record (empty member, or no
 /// usable others) so the command no-ops instead of doing an unbounded/junk
 /// insert. Pure (no `AppHandle`) so it is unit-tested directly.
@@ -46,10 +47,14 @@ fn clamp_split_request(member_key: &str, other_keys: &[String]) -> Option<(Strin
     if member.is_empty() {
         return None;
     }
+    // De-dup BEFORE the count cap: an insert is idempotent (`INSERT OR IGNORE`),
+    // so a repeated key would otherwise consume one of the 32 slots for nothing.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let others: Vec<String> = other_keys
         .iter()
         .map(|k| clamp_bytes(k.trim().to_string(), MAX_DEDUP_KEY_BYTES))
         .filter(|k| !k.is_empty() && *k != member)
+        .filter(|k| seen.insert(k.clone()))
         .take(MAX_OTHER_KEYS)
         .collect();
     if others.is_empty() {
@@ -129,6 +134,28 @@ mod tests {
             vec!["real".to_string()],
             "trimmed, blank + self dropped"
         );
+    }
+
+    #[test]
+    fn clamp_deduplicates_repeated_keys_before_the_cap() {
+        // 33 entries where two are duplicates (k0 and k1 each appear twice) → 31
+        // DISTINCT keys. De-dup runs BEFORE the 32-cap, so all 31 are kept
+        // (first-seen order) and a repeated key never wastes a slot.
+        let mut keys: Vec<String> = (0..31).map(|i| format!("k{i}")).collect();
+        keys.push("k0".to_string()); // duplicate
+        keys.push("k1".to_string()); // duplicate
+        assert_eq!(keys.len(), 33);
+
+        let (_, clamped) = clamp_split_request("member", &keys).expect("valid request");
+        assert_eq!(
+            clamped.len(),
+            31,
+            "the two duplicate keys must not consume slots — 31 distinct pairs"
+        );
+        // No duplicates survive, and first-seen order is preserved.
+        let unique: std::collections::HashSet<&String> = clamped.iter().collect();
+        assert_eq!(unique.len(), clamped.len(), "no duplicate key survives");
+        assert_eq!(clamped.first().map(String::as_str), Some("k0"));
     }
 
     #[test]

--- a/apps/desktop/src/renderer/features/settings/components/preferences/AgencyCompaniesPreferences/AgencyCompaniesPreferences.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/preferences/AgencyCompaniesPreferences/AgencyCompaniesPreferences.test.tsx
@@ -114,4 +114,18 @@ describe('AgencyCompaniesPreferences', () => {
     render(<AgencyCompaniesPreferences />);
     expect(screen.getByText('settings.agencyCompanies.empty')).toBeInTheDocument();
   });
+
+  it('does not call the setter before job preferences have loaded (pre-load guard)', async () => {
+    // prefs.data stays undefined (beforeEach default) — the query hasn't
+    // resolved, so adding would replace the saved list with just this entry.
+    const user = userEvent.setup();
+    render(<AgencyCompaniesPreferences />);
+
+    await user.type(
+      screen.getByPlaceholderText('settings.agencyCompanies.placeholder'),
+      'Hays{Enter}'
+    );
+
+    expect(mockSetExtra).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/renderer/features/settings/components/preferences/AgencyCompaniesPreferences/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/preferences/AgencyCompaniesPreferences/index.tsx
@@ -22,6 +22,10 @@ export function AgencyCompaniesPreferences() {
   const [inputValue, setInputValue] = useState('');
 
   const add = (raw: string) => {
+    // Guard the pre-load window: `jobPrefs` (and thus `list`) is undefined/[]
+    // until the query resolves, so an add here would replace the saved list with
+    // just this one entry (single-column setter, but still column data loss).
+    if (!jobPrefs) return;
     const value = raw.trim();
     if (!value) return;
     if (list.some((c) => c.toLowerCase() === value.toLowerCase())) {
@@ -32,7 +36,10 @@ export function AgencyCompaniesPreferences() {
     setInputValue('');
   };
 
-  const remove = (name: string) => setExtraAgencyCompanies.mutate(list.filter((c) => c !== name));
+  const remove = (name: string) => {
+    if (!jobPrefs) return;
+    setExtraAgencyCompanies.mutate(list.filter((c) => c !== name));
+  };
 
   return (
     <GlassCard>

--- a/docs/knowledge/decision-records/adr-029-cross-board-job-clustering-recompute-at-ingest.md
+++ b/docs/knowledge/decision-records/adr-029-cross-board-job-clustering-recompute-at-ingest.md
@@ -113,7 +113,7 @@ records load unchanged). Live-stream rows remain unclustered until the completio
 strong cluster mate. The same rule also tightens one edge: a cluster whose best-scored member is
 below the bar is dropped whole even if it contains an unscored member (previously the unscored copy
 survived); this is intended and locked by test `mixed_cluster_with_below_bar_scored_representative_is_dropped_even_with_unscored_member`.
-Cosine path is dormant until vectors exist at ingest time — making embeddings
+Normalization trade-off: the bare dash-tail strip (trailing segments after a dash) means same-company titles differing only by a single trailing word (team/department/tech qualifiers — e.g. Platform vs Payments suffix) normalize identically and cluster together; recovery is the user split (pair tombstone verdict). Cosine path is dormant until vectors exist at ingest time — making embeddings
 primary would require ingest-time `ai_provider` calls, explicitly out of scope. Fast-follows
 (recorded in `docs/knowledge/scraping-domain.md` at feature close): split-undo, ingest-time embeddings,
 agency-list growth.

--- a/docs/knowledge/scraping-domain.md
+++ b/docs/knowledge/scraping-domain.md
@@ -301,6 +301,8 @@ Beyond exact canonical_job_key matching, a fuzzy clustering layer recomputed at 
 4. **LinkedIn card shape extraction** — extract a pure `parse_job_cards(html)` seam from LinkedIn `search_guest` so acceptance fixtures can use real card shape (currently uses GermanTechJobs feed parser).
 5. **Batch-level deferrals** — active slug prober, extension-side ATS fingerprinting, community slug directory, cross-user analytics (shared with other deferred post-launch batch work).
 6. **Split-view selection re-point** — when a selected live-streamed row becomes non-canonical at completion, `JobsResults` falls back to top-of-list instead of the row's cluster canonical; `absorbedInto` doesn't cover cluster collapses. Narrow UX gap: re-point via clusterId.
+7. **Precompute trigram sets in blocking** — per-item trigram set computed once in `resolve_block` instead of per-comparison; bounded perf nit (AI review gate, low priority).
+8. **Tighten bare dash-tail location heuristic** — consider restricting `normalize_title` dash-tail strip to closed place-name list or parenthetical-only if team-suffix merges (Platform vs Payments) annoy users in practice.
 
 ## Jobs-page diagnostics surface (PR C, 2026-07-10)
 

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -514,8 +514,9 @@ export const JobPreferencesSchema = z.object({
   // Extra recruiting/staffing agency company names, merged with the built-in
   // const list when cross-board dedup flags a posting's `isAgency` (ADR-029 §i).
   // Free text; the Rust store clamps each entry + the list length at the write
-  // boundary (per the dedicated single-column setter, PR #695 pattern).
-  extraAgencyCompanies: z.array(z.string().trim().min(1)).optional(),
+  // boundary (per the dedicated single-column setter, PR #695 pattern). `.max`
+  // mirrors the Rust `MAX_EXTRA_AGENCY_COMPANIES` cap (same guard as otherKeys).
+  extraAgencyCompanies: z.array(z.string().trim().min(1)).max(500).optional(),
 });
 
 // Cross-board dedup "split" request (ADR-029 §h): mark `memberKey` as NOT a

--- a/scripts/ci-review-verdict.mjs
+++ b/scripts/ci-review-verdict.mjs
@@ -51,29 +51,43 @@ if (!findings) {
   console.log(
     `::warning::AI review produced no parseable verdict (${FILE} missing/invalid) — infra fail-open; ci-ok, pre-push and CodeRabbit still gate.`
   );
-  summary('## 🤖 AI Review OK\n\n⚠ No parseable findings file — fail-open (infra).');
+  summary('## 🤖 AI Review OK\n\n**Verdict: fail-open (infra)** — ⚠ no parseable findings file.');
   writeSummaryFile();
   process.exit(0);
 }
 
-// markdown-table cell escape: backslashes FIRST, then pipes; newlines flattened
-const cell = (t) =>
-  String(t || '')
-    .replace(/\\/g, '\\\\')
-    .replace(/\|/g, '\\|')
-    .replace(/\r?\n/g, ' ');
+// Presentation only — no table to pipe-escape for, just flatten embedded newlines.
+const flatten = (t) => String(t || '').replace(/\r?\n/g, ' ');
+
+// Expanded severity sections, in display order (LOW gets its own collapsed block below).
+const SEVERITY_SECTIONS = [
+  ['CRITICAL', '🔴 Critical'],
+  ['HIGH', '🟠 High'],
+  ['MEDIUM', '🟡 Medium'],
+];
+
 const blocking = blockingFindings(findings, 0.8);
 const c = countBySeverity(findings);
 summary(
-  `## 🤖 AI Review ${blocking.length ? 'FAILED' : 'OK'}\n\n${findings.length} finding(s) — critical ${c.critical} · high ${c.high} · medium ${c.medium} · low ${c.low}\n`
+  `## 🤖 AI Review ${blocking.length ? 'FAILED' : 'OK'}\n\n**Verdict: ${blocking.length ? `${blocking.length} blocking finding(s)` : 'no blocking findings'}** (blocking = HIGH/CRITICAL at confidence ≥ 0.8) — ${findings.length} finding(s): critical ${c.critical} · high ${c.high} · medium ${c.medium} · low ${c.low}.`
 );
-if (findings.length) {
-  summary('| severity | file:line | finding | fix |');
-  summary('|---|---|---|---|');
-  for (const f of findings)
+
+for (const [severity, heading] of SEVERITY_SECTIONS) {
+  const group = findings.filter((f) => f.severity === severity);
+  if (!group.length) continue;
+  summary(`\n### ${heading}\n`);
+  for (const f of group)
     summary(
-      `| ${f.severity}${blocking.includes(f) ? ' 🚫' : ''} | ${f.file}:${f.line} | ${cell(f.summary)} | ${cell(f.fix)} |`
+      `**\`${f.file}:${f.line}\`**${blocking.includes(f) ? ' 🚫' : ''} — ${flatten(f.summary)}\n**Fix:** ${flatten(f.fix)}\n`
     );
+}
+
+const low = findings.filter((f) => f.severity === 'LOW');
+if (low.length) {
+  summary(`\n<details><summary>⚪ Low (${low.length}, advisory)</summary>\n`);
+  for (const f of low)
+    summary(`- **\`${f.file}:${f.line}\`** — ${flatten(f.summary)}. _Fix:_ ${flatten(f.fix)}`);
+  summary('\n</details>');
 }
 writeSummaryFile();
 if (blocking.length) {

--- a/scripts/ci-review-verdict.test.mjs
+++ b/scripts/ci-review-verdict.test.mjs
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const scriptPath = join(__dirname, 'ci-review-verdict.mjs');
+
+// review-comment.md is written to cwd, so each test runs in its own temp dir.
+const testTmpDir = join(tmpdir(), `ci-review-verdict-test-${Date.now()}`);
+
+const finding = (overrides) => ({
+  category: 'correctness',
+  file: 'a.ts',
+  line: 1,
+  summary: 'summary',
+  evidence: 'evidence',
+  fix: 'fix it',
+  confidence: 1,
+  introduced_by_diff: true,
+  ...overrides,
+});
+
+/** Run the script against a fixture findings file written into testTmpDir. */
+function run(findings) {
+  const findingsPath = join(testTmpDir, 'findings.json');
+  writeFileSync(findingsPath, JSON.stringify({ schema: 1, findings }));
+  try {
+    execFileSync('node', [scriptPath, findingsPath], { cwd: testTmpDir, encoding: 'utf8' });
+    return { exitCode: 0, comment: readFileSync(join(testTmpDir, 'review-comment.md'), 'utf8') };
+  } catch (err) {
+    return {
+      exitCode: err.status,
+      comment: readFileSync(join(testTmpDir, 'review-comment.md'), 'utf8'),
+    };
+  }
+}
+
+describe('ci-review-verdict sticky comment rendering', () => {
+  beforeEach(() => mkdirSync(testTmpDir, { recursive: true }));
+  afterEach(() => rmSync(testTmpDir, { recursive: true, force: true }));
+
+  it('exits 0 with an OK headline and verdict line when no findings', () => {
+    const { exitCode, comment } = run([]);
+    expect(exitCode).toBe(0);
+    expect(comment).toContain('## 🤖 AI Review OK');
+    expect(comment).toContain('**Verdict: no blocking findings**');
+  });
+
+  it('exits 1 and groups a blocking HIGH finding under a severity section, marked 🚫', () => {
+    const { exitCode, comment } = run([
+      finding({ severity: 'HIGH', file: 'x.ts', line: 42, confidence: 0.9 }),
+    ]);
+    expect(exitCode).toBe(1);
+    expect(comment).toContain('## 🤖 AI Review FAILED');
+    expect(comment).toContain('**Verdict: 1 blocking finding(s)**');
+    expect(comment).toContain('### 🟠 High');
+    expect(comment).toContain('**`x.ts:42`** 🚫 — summary');
+    expect(comment).toContain('**Fix:** fix it');
+  });
+
+  it('does not mark a HIGH finding below the confidence threshold as blocking', () => {
+    const { exitCode, comment } = run([
+      finding({ severity: 'HIGH', file: 'x.ts', line: 1, confidence: 0.5 }),
+    ]);
+    expect(exitCode).toBe(0);
+    expect(comment).toContain('## 🤖 AI Review OK');
+    expect(comment).not.toContain('🚫');
+  });
+
+  it('collapses LOW findings into a <details> block and skips empty severity sections', () => {
+    const { comment } = run([finding({ severity: 'LOW', file: 'y.ts', line: 5 })]);
+    expect(comment).toContain('<details><summary>⚪ Low (1, advisory)</summary>');
+    expect(comment).toContain('- **`y.ts:5`** — summary. _Fix:_ fix it');
+    expect(comment).not.toContain('### 🔴 Critical');
+    expect(comment).not.toContain('### 🟠 High');
+    expect(comment).not.toContain('### 🟡 Medium');
+  });
+});


### PR DESCRIPTION
## Summary

Fix-forward for the AI Review gate findings that landed on #756 moments before merge, plus the requested sticky-comment restyle.

- **HIGH — agency list pre-load guard**: `AgencyCompaniesPreferences` `add()`/`remove()` could fire before the `useJobPreferences()` query resolved and replace the saved list with a single entry; now guarded like its sibling panels (92e5302b), with a regression test.
- **LOW — contract hygiene**: `extraAgencyCompanies` Zod schema gains `.max(500)` mirroring the Rust cap (codegen unchanged, verified).
- **LOW — clamp hardening**: `clamp_split_request` de-duplicates `otherKeys` (first-seen order) before the 32-cap so repeats can't waste slots; includes the Stop-gate-mandated tests (duplicate collapse + full-distinct-capacity under repeats).
- **Docs**: ADR-029 consequences note broadened (bare dash-tail strip can cluster same-company team/department-suffixed titles; recovery = user split), and two fast-follows logged (trigram-set precompute; dash-tail heuristic tightening).
- **CI (owner request)**: the `🤖 AI Review` sticky comment is restyled from a flat table into claude-review-style severity sections (bold `file:line` anchors + Fix lines, 🚫 on blocking, collapsed ⚪ Low advisories). Deterministic verdict logic (ADR-0008) untouched; new subprocess tests per the sibling-script precedent.

Declined from the same findings batch (with reasons on #756): dedup-command rate limiting (accepted advisory; server-side clamp bounds the work).

## Tests

Full `cargo test` + `pnpm test` green through the pre-push gate; scoped: 56 dedup tests, 5 agency-panel tests, 35 scripts tests (4 new), fmt/clippy/lint:strict/typecheck/gen:ipc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)