### PR TITLE
fix(extraction): do not emit bare w:p docx paragraphs twice

### DIFF
--- a/apps/desktop/src-tauri/src/extraction/docx.rs
+++ b/apps/desktop/src-tauri/src/extraction/docx.rs
@@ -93,7 +93,7 @@ fn parse_document(xml: &str, rels: &HashMap<String, String>) -> (String, Vec<Lin
     let mut links: Vec<Link> = Vec::new();
 
     // Split on paragraph boundaries.
-    for para_xml in xml.split("<w:p ").chain(xml.split("<w:p>").skip(1)) {
+    for para_xml in paragraph_slices(xml) {
         let para_text = parse_paragraph(para_xml, rels, &mut links);
         let trimmed = para_text.trim().to_string();
         if !trimmed.is_empty() {
@@ -102,6 +102,38 @@ fn parse_document(xml: &str, rels: &HashMap<String, String>) -> (String, Vec<Lin
     }
 
     (paragraphs.join("\n"), links)
+}
+
+/// One slice per `<w:p …>` / `<w:p>` paragraph, each running up to the next
+/// paragraph start (any leading preamble before the first `<w:p` is dropped).
+///
+/// Writers disagree on the spelling: MS Word emits `<w:p w:rsidR="…">` while
+/// Google Docs / LibreOffice / python-docx emit a bare `<w:p>`, and a document
+/// can contain both. Splitting on one spelling and chaining the other emitted
+/// every paragraph TWICE for the bare form (the `"<w:p "` split matched nothing
+/// and returned the whole document as a single boundary-less element), so scan
+/// for the tag instead. The byte after `<w:p` must be `' '` or `'>'` — that is
+/// what keeps `<w:pPr>`/`<w:pict>` from being mistaken for a paragraph.
+fn paragraph_slices(xml: &str) -> Vec<&str> {
+    let bytes = xml.as_bytes();
+    let mut starts: Vec<usize> = Vec::new();
+    let mut from = 0usize;
+    while let Some(rel) = xml[from..].find("<w:p") {
+        let at = from + rel;
+        let after = at + "<w:p".len();
+        if matches!(bytes.get(after), Some(b' ') | Some(b'>')) {
+            starts.push(at);
+        }
+        from = after;
+    }
+    starts
+        .iter()
+        .enumerate()
+        .map(|(i, &start)| {
+            let end = starts.get(i + 1).copied().unwrap_or(xml.len());
+            &xml[start..end]
+        })
+        .collect()
 }
 
 fn parse_paragraph(xml: &str, rels: &HashMap<String, String>, links: &mut Vec<Link>) -> String {
@@ -204,4 +236,67 @@ fn attr_value(fragment: &str, name: &str) -> Option<String> {
     let start = fragment.find(&needle)? + needle.len();
     let end = fragment[start..].find('"')? + start;
     Some(fragment[start..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body(inner: &str) -> String {
+        format!("<w:document><w:body>{inner}</w:body></w:document>")
+    }
+
+    fn para(tag: &str, text: &str) -> String {
+        format!("{tag}<w:r><w:t>{text}</w:t></w:r></w:p>")
+    }
+
+    /// Google Docs / LibreOffice / python-docx write a bare `<w:p>`. Asserting
+    /// on the EXACT text (not `contains`) is the point: the old chained-split
+    /// emitted every paragraph twice — once mashed with no boundaries, once
+    /// per paragraph — and a `contains` assertion stayed green through it.
+    #[test]
+    fn bare_paragraph_tags_are_not_emitted_twice() {
+        let xml = body(&format!(
+            "{}{}",
+            para("<w:p>", "Jane Doe"),
+            para("<w:p>", "Engineer")
+        ));
+        let (text, _) = parse_document(&xml, &HashMap::new());
+        assert_eq!(text, "Jane Doe\nEngineer");
+    }
+
+    /// The MS-Word spelling (`<w:p w:rsidR="…">`) keeps working unchanged.
+    #[test]
+    fn attributed_paragraph_tags_still_split() {
+        let xml = body(&format!(
+            "{}{}",
+            para("<w:p w:rsidR=\"00A1\">", "Jane Doe"),
+            para("<w:p w:rsidR=\"00A2\">", "Engineer")
+        ));
+        let (text, _) = parse_document(&xml, &HashMap::new());
+        assert_eq!(text, "Jane Doe\nEngineer");
+    }
+
+    /// A document mixing both spellings — neither branch may drop or duplicate.
+    #[test]
+    fn mixed_paragraph_spellings_each_appear_once() {
+        let xml = body(&format!(
+            "{}{}{}",
+            para("<w:p w:rsidR=\"00A1\">", "Alpha"),
+            para("<w:p>", "Beta"),
+            para("<w:p w:rsidR=\"00A3\">", "Gamma")
+        ));
+        let (text, _) = parse_document(&xml, &HashMap::new());
+        assert_eq!(text, "Alpha\nBeta\nGamma");
+    }
+
+    /// `<w:pPr>` (paragraph properties) starts with `<w:p` but is not a
+    /// paragraph — it must not open a new slice.
+    #[test]
+    fn paragraph_properties_tag_is_not_a_paragraph() {
+        let xml =
+            body("<w:p><w:pPr><w:jc w:val=\"center\"/></w:pPr><w:r><w:t>Solo</w:t></w:r></w:p>");
+        let (text, _) = parse_document(&xml, &HashMap::new());
+        assert_eq!(text, "Solo");
+    }
 }

--- a/apps/desktop/src-tauri/src/extraction/docx.rs
+++ b/apps/desktop/src-tauri/src/extraction/docx.rs
@@ -113,15 +113,16 @@ fn parse_document(xml: &str, rels: &HashMap<String, String>) -> (String, Vec<Lin
 /// every paragraph TWICE for the bare form (the `"<w:p "` split matched nothing
 /// and returned the whole document as a single boundary-less element), so scan
 /// for the tag instead. The byte after `<w:p` must be `' '` or `'>'` — that is
-/// what keeps `<w:pPr>`/`<w:pict>` from being mistaken for a paragraph.
+/// what keeps `<w:pPr>`/`<w:pict>` from being mistaken for a paragraph. A
+/// self-closing `<w:p/>` is likewise not a start: it carries no runs, so it
+/// contributes no text either way, and the old splits ignored it too.
 fn paragraph_slices(xml: &str) -> Vec<&str> {
-    let bytes = xml.as_bytes();
     let mut starts: Vec<usize> = Vec::new();
     let mut from = 0usize;
     while let Some(rel) = xml[from..].find("<w:p") {
         let at = from + rel;
         let after = at + "<w:p".len();
-        if matches!(bytes.get(after), Some(b' ') | Some(b'>')) {
+        if matches!(xml.as_bytes().get(after), Some(b' ') | Some(b'>')) {
             starts.push(at);
         }
         from = after;
@@ -288,6 +289,20 @@ mod tests {
         ));
         let (text, _) = parse_document(&xml, &HashMap::new());
         assert_eq!(text, "Alpha\nBeta\nGamma");
+    }
+
+    /// A self-closing `<w:p/>` (an empty paragraph) is folded into the previous
+    /// slice rather than opening its own. It carries no runs, so it contributes
+    /// no text either way — pinning the boundary so the behaviour is on record.
+    #[test]
+    fn self_closing_empty_paragraph_neither_splits_nor_duplicates() {
+        let xml = body(&format!(
+            "{}<w:p/>{}",
+            para("<w:p>", "A"),
+            para("<w:p>", "B")
+        ));
+        let (text, _) = parse_document(&xml, &HashMap::new());
+        assert_eq!(text, "A\nB");
     }
 
     /// `<w:pPr>` (paragraph properties) starts with `<w:p` but is not a


### PR DESCRIPTION
## Summary

`parse_document` emitted every paragraph **twice** — once mashed together with no boundaries, once per paragraph — for any DOCX that uses the bare `<w:p>` tag (Google Docs, LibreOffice, python-docx). Fixes #763.

## Type of change

- [x] `fix` — Bug fix

## Changes

- `paragraph_slices()` now scans for the `<w:p` tag and requires the next byte to be `' '` or `'>'`, instead of `xml.split("<w:p ").chain(xml.split("<w:p>").skip(1))`.
  - The old chain was unconditional: for a bare-`<w:p>` document, `split("<w:p ")` (trailing space) matched nothing and returned **the whole document as a single element**, which `parse_paragraph` mined into one boundary-less blob — and the chained `split("<w:p>").skip(1)` then emitted each paragraph again.
  - MS Word documents escaped the bug only because their `w:rsidR` attributes leave the `<w:p>`-split branch empty.
  - Requiring `' '`/`'>'` after `<w:p` is what keeps `<w:pPr>` / `<w:pict>` from being treated as paragraph starts.
- Documents that **mix** both spellings are now handled correctly (the old code could not).
- Four regression tests in `docx.rs`.

Before → after for `<w:p><w:r><w:t>Jane Doe</w:t></w:r></w:p><w:p><w:r><w:t>Engineer</w:t></w:r></w:p>`:

```
- "Jane DoeEngineer\nJane Doe\nEngineer"
+ "Jane Doe\nEngineer"
```

## Testing

- [x] Ran `cargo test --lib extraction` locally — 49 passed, 0 failed (includes the pre-existing `docx_extracts_paragraphs` / `docx_resolves_hyperlink` tests).
- [x] Ran `cargo test --lib` on the base commit for a baseline — 2689 passed, 0 failed.
- [x] `cargo fmt` clean.
- [x] Added tests for new logic.

The new tests assert the **exact** extracted string rather than using `contains()`; the existing `contains()`-based coverage stays green even when the text is duplicated, which is why this went unnoticed.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (`paragraph_slices` is private, documented inline)
