### PR TITLE
fix(scraping): read the remoteok id per json variant

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/remoteok/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/remoteok/mod.rs
@@ -95,7 +95,7 @@ impl Scraper for RemoteOkScraper {
                     RemoteOkItem::Legend { .. } => continue, // skip legend entry
                 };
 
-            let id_str = id.map(|i| i.to_string()).unwrap_or_else(|| "".to_string());
+            let id_str = normalize_id(id);
             if id_str.is_empty() || position.is_none() {
                 continue;
             }
@@ -153,6 +153,24 @@ impl Scraper for RemoteOkScraper {
 
         Ok(out)
     }
+}
+
+/// RemoteOK's `id` arrives as either a JSON number or a JSON string, so read it
+/// per variant instead of via `Value::to_string()`.
+///
+/// `to_string()` JSON-*serialises*: `Value::String("1234567")` becomes
+/// `"\"1234567\""`, quotes included. Those quotes ended up inside
+/// `posting.id` (`remoteok:"1234567"`) and `external_id`, corrupting the stable
+/// PostingsCache key that dedup and interaction tracking rely on. Only the
+/// `Number` variant happened to serialise cleanly.
+fn normalize_id(id: Option<serde_json::Value>) -> String {
+    id.and_then(|i| {
+        i.as_str()
+            .map(str::to_string)
+            .or_else(|| i.as_i64().map(|n| n.to_string()))
+            .or_else(|| i.as_u64().map(|n| n.to_string()))
+    })
+    .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/scraping/boards/remoteok/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/remoteok/test.rs
@@ -1,5 +1,19 @@
 use super::*;
 
+/// RemoteOK sends `id` as a number for some rows and a string for others.
+/// `Value::to_string()` JSON-serialises, so the string variant used to come back
+/// WITH quotes and corrupt the posting id / external_id (the stable cache key).
+#[test]
+fn normalize_id_reads_the_value_per_variant() {
+    assert_eq!(normalize_id(Some(serde_json::json!(1234567))), "1234567");
+    assert_eq!(normalize_id(Some(serde_json::json!("1234567"))), "1234567");
+    assert_eq!(normalize_id(None), "");
+    // Anything that is neither a string nor an integer stays empty, so the
+    // caller's `id_str.is_empty()` guard drops the row as before.
+    assert_eq!(normalize_id(Some(serde_json::json!(null))), "");
+    assert_eq!(normalize_id(Some(serde_json::json!({}))), "");
+}
+
 #[test]
 fn test_remoteok_scraper_id() {
     let scraper = RemoteOkScraper;


### PR DESCRIPTION
## Summary

RemoteOK sends `id` as a JSON number for some rows and a JSON **string** for others. `Value::to_string()` JSON-serialises, so the string variant arrived with literal quotes and corrupted the posting id / `external_id` — the stable PostingsCache key. Fixes #769.

## Type of change

- [x] `fix` — Bug fix

## Changes

- New private helper `normalize_id()` reads the value per variant (`as_str` → `as_i64` → `as_u64`) instead of `Value::to_string()`.
  - `Value::String("1234567").to_string()` is `"\"1234567\""`; only the `Number` variant serialised to clean digits.
  - The quotes flowed into `id: format!("{}:{}", self.id(), id_str)` → `remoteok:"1234567"` and `external_id` → `"1234567"`, so the same job could take two identities depending on which type the API happened to send.
- Anything that is neither a string nor an integer still yields `""`, so the caller's existing `id_str.is_empty()` guard drops the row exactly as before.
- Test covering the number, string, `None`, `null` and object cases.

## Testing

- [x] `cargo test --lib remoteok` — 8 passed, 0 failed, 1 ignored (the `live_search_returns_results` network test).
- [x] `cargo test --lib` on the base commit for a baseline — 2689 passed, 0 failed.
- [x] `cargo fmt` clean.
- [x] Added tests for new logic.

The pre-existing tests only used a numeric id (`serde_json::json!(123)`) — the one variant that escapes the bug.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (helper is private, documented inline)
