### PR TITLE
fix(documents): validate an import bundle before clearing the store

### DIFF
--- a/apps/desktop/src-tauri/src/documents/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/mod.rs
@@ -1031,6 +1031,48 @@ pub fn make_doc_id() -> String {
     format!("doc-{}-{}", now_ms(), &Uuid::new_v4().to_string()[..8])
 }
 
+/// Read an exported document's optional embedding vector out of its JSON row.
+///
+/// Legacy exports carry no `vectorSpace` — they predate cloud embeddings and were
+/// all Ollama/nomic-embed-text, which is what the fallback records.
+fn parse_exported_vector(item: &serde_json::Value) -> Option<EmbeddingVector> {
+    let values: Vec<f64> = item
+        .get("vector")?
+        .as_array()?
+        .iter()
+        .filter_map(|v| v.as_f64())
+        .collect();
+    if values.is_empty() {
+        return None;
+    }
+    let dim = values.len();
+    let space = item
+        .get("vectorSpace")
+        .map(|s| EmbeddingSpace {
+            provider: s
+                .get("provider")
+                .and_then(|v| v.as_str())
+                .unwrap_or("ollama")
+                .to_string(),
+            model: s
+                .get("model")
+                .and_then(|v| v.as_str())
+                .unwrap_or("nomic-embed-text")
+                .to_string(),
+            dim: s
+                .get("dim")
+                .and_then(|v| v.as_u64())
+                .map(|d| d as usize)
+                .unwrap_or(dim),
+        })
+        .unwrap_or_else(|| EmbeddingSpace {
+            provider: "ollama".to_string(),
+            model: "nomic-embed-text".to_string(),
+            dim,
+        });
+    Some(EmbeddingVector { values, space })
+}
+
 impl DataStore for DocumentStore {
     fn key(&self) -> &'static str {
         "documents"
@@ -1058,48 +1100,32 @@ impl DataStore for DocumentStore {
 
     fn import(&self, data: &serde_json::Value) -> AppResult<usize> {
         let items = data.as_array().ok_or("documents: expected an array")?;
+        // Deserialize EVERY row before mutating the store. `clear_all` wipes
+        // documents, vectors, posting_vectors AND match_scores, so a malformed
+        // row (hand-edited bundle, newer schema, corruption) reached after that
+        // call used to destroy the user's whole document library + embeddings and
+        // still return Err — nothing left to restore from. The sibling stores
+        // (applications, ai_generations, dedup, discovered) all validate up-front
+        // for exactly this reason; documents was the lone outlier.
+        let parsed: Vec<(DocumentRecord, Option<EmbeddingVector>)> = items
+            .iter()
+            .map(|item| {
+                let record: DocumentRecord =
+                    serde_json::from_value(item.clone()).map_err(|e| e.to_string())?;
+                Ok((record, parse_exported_vector(item)))
+            })
+            .collect::<AppResult<_>>()?;
+
         self.clear_all();
         let mut count = 0;
         let mut default_id: Option<String> = None;
-        for item in items {
-            let record: DocumentRecord =
-                serde_json::from_value(item.clone()).map_err(|e| e.to_string())?;
+        for (record, vector) in &parsed {
             if record.is_default {
                 default_id = Some(record.id.clone());
             }
-            self.insert(&record)?;
-            if let Some(vector) = item.get("vector").and_then(|v| v.as_array()) {
-                let vec: Vec<f64> = vector.iter().filter_map(|v| v.as_f64()).collect();
-                if !vec.is_empty() {
-                    // Restore the vector's space if present; legacy exports without
-                    // it predate cloud embeddings and were all Ollama/nomic-embed-text.
-                    let dim = vec.len();
-                    let space = item
-                        .get("vectorSpace")
-                        .map(|s| EmbeddingSpace {
-                            provider: s
-                                .get("provider")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("ollama")
-                                .to_string(),
-                            model: s
-                                .get("model")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("nomic-embed-text")
-                                .to_string(),
-                            dim: s
-                                .get("dim")
-                                .and_then(|v| v.as_u64())
-                                .map(|d| d as usize)
-                                .unwrap_or(dim),
-                        })
-                        .unwrap_or_else(|| EmbeddingSpace {
-                            provider: "ollama".to_string(),
-                            model: "nomic-embed-text".to_string(),
-                            dim,
-                        });
-                    self.upsert_vector(&record.id, &EmbeddingVector { values: vec, space })?;
-                }
+            self.insert(record)?;
+            if let Some(vector) = vector {
+                self.upsert_vector(&record.id, vector)?;
             }
             count += 1;
         }

--- a/apps/desktop/src-tauri/src/documents/test.rs
+++ b/apps/desktop/src-tauri/src/documents/test.rs
@@ -273,6 +273,68 @@ fn test_keywords_json_round_trip() {
     );
 }
 
+/// `import` used to call `clear_all()` — which wipes documents, vectors,
+/// posting_vectors and match_scores — BEFORE deserializing the rows, so a
+/// malformed row partway through destroyed the user's entire existing library
+/// and still returned Err, leaving nothing to restore from.
+#[test]
+fn import_of_a_malformed_bundle_leaves_the_existing_library_intact() {
+    use crate::data_store::DataStore;
+
+    let temp_dir = TempDir::new().unwrap();
+    let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    let existing = DocumentRecord {
+        id: "doc-keep".to_string(),
+        title: "Keep".to_string(),
+        name: "keep.pdf".to_string(),
+        locale: None,
+        text: "precious".to_string(),
+        pages: None,
+        created_at: now_ms(),
+        indexed: false,
+        is_default: true,
+        keywords_json: None,
+    };
+    store.insert(&existing).unwrap();
+    store
+        .upsert_vector("doc-keep", &ev(vec![0.4, 0.5, 0.6]))
+        .unwrap();
+
+    // Row 0 is well-formed; row 1 is not (`created_at` is a string, and `title`
+    // is missing) — the failure must be detected before anything is deleted.
+    let bundle = serde_json::json!([
+        {
+            "id": "doc-new",
+            "title": "New",
+            "name": "new.pdf",
+            "text": "fresh",
+            "createdAt": now_ms(),
+            "indexed": false,
+            "isDefault": false,
+        },
+        { "id": "doc-bad", "createdAt": "not-a-number" },
+    ]);
+
+    assert!(
+        store.import(&bundle).is_err(),
+        "a malformed row must fail the import"
+    );
+
+    let docs = store.list();
+    assert_eq!(
+        docs.len(),
+        1,
+        "the prior library must survive a failed import"
+    );
+    assert_eq!(docs[0].id, "doc-keep");
+    assert_eq!(
+        store.get_vector("doc-keep").map(|e| e.values),
+        Some(vec![0.4, 0.5, 0.6]),
+        "embeddings must survive a failed import"
+    );
+}
+
 #[test]
 fn test_data_store_export_import_round_trip() {
     use crate::data_store::DataStore;


### PR DESCRIPTION
## Summary

`DocumentStore::import` called `clear_all()` **before** deserializing the rows, so a malformed row partway through a restore destroyed the user's entire document library, embeddings and match scores — and still returned `Err`, leaving nothing to restore from. Fixes #773.

## Type of change

- [x] `fix` — Bug fix

## Changes

- `import` now deserializes **every** `DocumentRecord` (and its optional embedding vector) before touching the store, then clears and repopulates — the same shape `ai_generations::import` already uses:
  > *"Deserialize EVERY record before mutating the store, so a malformed row aborts the import without having cleared the table."*

  `applications`, `dedup` and `discovered` all do this too; `documents` was the only outlier, and it is the store holding the résumés and their embeddings.
- The vector/`vectorSpace` reconstruction moved into a documented helper, `parse_exported_vector()`, so the import loop stays readable. Behaviour is unchanged, including the legacy-export fallback to Ollama/`nomic-embed-text`.
- Regression test `import_of_a_malformed_bundle_leaves_the_existing_library_intact`.

**Scope note:** this closes the reported failure — a bad *row* can no longer destroy the library. It does not wrap the clear+insert loop itself in a transaction, so an SQL-level failure mid-loop could still leave a partial state. Doing that properly means connection-scoped variants of `insert`/`set_default` (only `upsert_vector` has one today), which felt like a bigger change than this bug report warrants; happy to follow up if you'd prefer the full transactional version.

## Testing

- [x] `cargo test --lib documents::` — 71 passed, 0 failed (includes the pre-existing `test_data_store_export_import_round_trip`, which covers the happy path and the vector round trip).
- [x] `cargo test --lib` on the base commit for a baseline — 2689 passed, 0 failed.
- [x] `cargo fmt` clean.
- [x] Added tests for new logic.

With the fix reverted, the new test fails exactly as reported:

```
assertion `left == right` failed: the prior library must survive a failed import
  left: 0
 right: 1
```

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (helper is private, documented inline)
