### PR TITLE
fix(postings): write interactions atomically and stop swallowing write errors

### DIFF
--- a/apps/desktop/src-tauri/src/postings/mod.rs
+++ b/apps/desktop/src-tauri/src/postings/mod.rs
@@ -411,8 +411,39 @@ impl InteractionStore {
             return;
         }
         let records = self.records();
-        if let Ok(json) = serde_json::to_string_pretty(&records) {
-            std::fs::write(&self.data_file, json).ok();
+        let json = match serde_json::to_string_pretty(&records) {
+            Ok(json) => json,
+            Err(e) => {
+                log::error!(
+                    "[postings] save skipped: could not serialize {} interaction(s): {e}",
+                    records.len()
+                );
+                return;
+            }
+        };
+        // Write-then-rename, so the file is replaced atomically. `fs::write`
+        // truncates the target in place, so a crash mid-write left
+        // `interactions.json` truncated — and the discarded `Result` meant a
+        // failed write (disk full, read-only volume) still looked like a success
+        // to `upsert`/`import_bundle`, with the record living only in memory and
+        // silently lost on the next restart.
+        let tmp = self.data_file.with_extension("json.tmp");
+        if let Err(e) = std::fs::write(&tmp, &json) {
+            log::error!(
+                "[postings] failed to write {}: {e} — interaction NOT persisted",
+                tmp.display()
+            );
+            std::fs::remove_file(&tmp).ok();
+            return;
+        }
+        if let Err(e) = std::fs::rename(&tmp, &self.data_file) {
+            log::error!(
+                "[postings] failed to move {} onto {}: {e} — interaction NOT persisted \
+                 (the previous file is intact)",
+                tmp.display(),
+                self.data_file.display()
+            );
+            std::fs::remove_file(&tmp).ok();
         }
     }
 }

--- a/apps/desktop/src-tauri/src/postings/test.rs
+++ b/apps/desktop/src-tauri/src/postings/test.rs
@@ -441,6 +441,35 @@ fn test_interaction_record_serialization() {
     assert_eq!(deserialized.interaction_type, record.interaction_type);
 }
 
+/// `save` writes to `interactions.json.tmp` and renames it over the real file,
+/// so the on-disk copy is replaced atomically instead of being truncated in
+/// place. The temp file must never be left behind on the happy path.
+#[test]
+fn save_replaces_the_file_atomically_and_leaves_no_temp_file() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().to_path_buf();
+    let mut store = InteractionStore::new(&data_dir);
+
+    store.upsert(interaction("job-1", "viewed"));
+    store.upsert(interaction("job-2", "applied"));
+
+    let data_file = data_dir.join("interactions.json");
+    assert!(data_file.exists(), "the interactions file must be written");
+    assert!(
+        !data_dir.join("interactions.json.tmp").exists(),
+        "the temp file must be renamed away, not left behind"
+    );
+
+    // The file is complete and parses — a truncated write would not.
+    let on_disk: Vec<InteractionRecord> =
+        serde_json::from_str(&std::fs::read_to_string(&data_file).unwrap()).unwrap();
+    assert_eq!(on_disk.len(), 2);
+
+    // A fresh store hydrating from that file sees both interactions.
+    let mut reopened = InteractionStore::new(&data_dir);
+    assert_eq!(reopened.list(None).len(), 2);
+}
+
 #[test]
 fn test_interaction_store_new() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

`InteractionStore::save` truncated `interactions.json` in place and threw away the write `Result`, so a failed write looked like a success and a crash mid-write left the file truncated. Fixes #775.

## Type of change

- [x] `fix` — Bug fix

## Changes

- `save` now writes `interactions.json.tmp` and `fs::rename`s it over the target, so the file is replaced **atomically** — the same `with_extension` pattern the corrupt-file backup path at `:371` already uses.
- Write, rename and serialization failures are now logged (`log::error!`) instead of being discarded by `.ok()` / `if let Ok(json)`. On any failure the temp file is cleaned up and the previous `interactions.json` is left intact.
- Regression test `save_replaces_the_file_atomically_and_leaves_no_temp_file`.

**On propagating instead of logging:** `save()` is called from `upsert`, `clear_all` and `import_bundle`, none of which return a `Result`, so making it propagate would change three public signatures and their call sites. This PR keeps the change contained and at least makes the failure visible; glad to do the propagating version if you prefer it.

## Testing

- [x] `cargo test --lib postings::` — 31 passed, 0 failed.
- [x] `cargo test --lib` on the base commit for a baseline — 2689 passed, 0 failed.
- [x] `cargo fmt` clean.
- [x] Added tests for new logic.

The test asserts the file is written and parses completely, that no `.tmp` file is left behind, and that a freshly-opened store hydrates both records from it.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
