### PR TITLE
fix(extension): anchor the city and phone identity keywords

### DIFF
--- a/apps/extension/src/lib/field-signal.test.ts
+++ b/apps/extension/src/lib/field-signal.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the named-key matcher (apps/extension/src/lib/field-signal.ts).
+ *
+ * `matchNamedKey` is a pure signal → key function, so these tests drive it with
+ * the raw signal strings `textSignal` produces (name + id + placeholder +
+ * aria-label + label, diacritic-stripped and lowercased).
+ *
+ * The focus is the module's stated contract: it must **under-fill rather than
+ * mis-fill**. A field that resolves to the wrong key writes the user's PII into
+ * a visibly wrong box, which they may not notice and cannot undo.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { matchNamedKey } from './field-signal';
+
+describe('matchNamedKey — phone', () => {
+  it('matches real phone fields, including the separator-less compounds', () => {
+    for (const signal of [
+      'phone',
+      'phone number',
+      'phonenumber',
+      'phone_number',
+      'primary phone',
+      'candidate_phone',
+      'cell phone',
+      'cellphone',
+      'work phone',
+      'home phone',
+      'mobile',
+      'mobile_number',
+      'mobilenumber',
+      'telephone',
+      'telefonnummer',
+      'telefoon',
+      'puhelin',
+    ]) {
+      expect(matchNamedKey(signal), signal).toBe('phone');
+    }
+  });
+
+  it('does not match a word that merely CONTAINS phone/mobile', () => {
+    // Bare `phone`/`mobile` were unanchored substrings, so a "Smartphone model"
+    // field resolved to `phone` and received the user's phone number.
+    for (const signal of ['smartphone', 'smartphone model', 'iphone', 'microphone', 'automobile']) {
+      expect(matchNamedKey(signal), signal).not.toBe('phone');
+    }
+  });
+});
+
+describe('matchNamedKey — location', () => {
+  it('matches real city/town fields, including the separator-less compounds', () => {
+    for (const signal of [
+      'city',
+      'city name',
+      'cityname',
+      'candidate_city',
+      'city_1',
+      'current city',
+      'town',
+      'hometown',
+      'location',
+      'wohnort',
+      'ciudad',
+      'plaats',
+      'miasto',
+      'cidade',
+      'localidad',
+    ]) {
+      expect(matchNamedKey(signal), signal).toBe('location');
+    }
+  });
+
+  it('does not match a word that merely CONTAINS city', () => {
+    // `city` ⊂ "ethnicity": an EEO ethnicity field used to resolve to `location`
+    // and be filled with the user's city.
+    for (const signal of ['ethnicity', 'ethnicity / race', 'race and ethnicity']) {
+      expect(matchNamedKey(signal), signal).not.toBe('location');
+    }
+  });
+});

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -344,10 +344,22 @@ const NAMED_KEY_PATTERNS: readonly { key: string; pattern: RegExp }[] = [
   // DE/ES/IT/PT/SV/DA/NO/PL; `telefoon` (NL) and `telephone` (FR/EN) differ.
   // `handy`/`mobil` stay `\b`-anchored (bare `handy` ⊂ "handyman", bare `mobil`
   // ⊂ "automobil…"), so the concatenated DE compounds are listed explicitly.
+  //
+  // `phone`/`mobile` are anchored on their LEADING side for the same reason the
+  // authors anchored `handy`/`mobil`: bare `phone` ⊂ "smartphone"/"iphone"/
+  // "microphone" and bare `mobile` ⊂ "automobile", so a "Smartphone model" field
+  // received the user's phone number — a mis-fill, which this module's contract
+  // forbids ("under-fills rather than mis-fills"). The known compound prefixes
+  // (`cell`/`home`/`work`/`day`/`tele`phone) are spelled out so they keep
+  // matching. The TRAILING side is deliberately left open — `_` is a word
+  // character, so a `\b`/trailing anchor would stop matching the very common
+  // `phone_number`, `phoneNumber` and `mobile_number` field names. `(?:^|[^a-z])`
+  // is used rather than a lookbehind because these patterns are only ever
+  // `.test()`ed, so consuming the boundary character is harmless.
   {
     key: 'phone',
     pattern:
-      /phone|mobile|telephone|telefon|telefoon|handynummer|handytelefon|mobilnummer|mobiltelefon|\bhandy\b|\bmobil\b|puhelin/,
+      /(?:^|[^a-z])(?:cell|home|work|day|tele)?phone|(?:^|[^a-z])mobile|telefon|telefoon|handynummer|handytelefon|mobilnummer|mobiltelefon|\bhandy\b|\bmobil\b|puhelin/,
   },
   // Combined full-name phrases — MUST precede first/last (see table doc): both
   // the "completo"-style forms AND the "first AND last" conjunction forms
@@ -371,12 +383,16 @@ const NAMED_KEY_PATTERNS: readonly { key: string; pattern: RegExp }[] = [
     pattern:
       /last name|surname|family name|nachname|familienname|nom de famille|\bapellidos?\b|cognome|achternaam|nazwisko|apelido|sobrenome|efternamn|efternavn|etternavn|sukunimi/,
   },
-  // `city`/`town` stay plain substrings (unchanged English behavior); the added
-  // EU city/place terms use `\b` where they are short/collision-prone.
+  // `city`/`town` are anchored on their LEADING side (see the `phone` note
+  // above): bare `city` ⊂ "ethnicity", so an EEO "Ethnicity" field was resolving
+  // to `location` and receiving the user's city. `hometown` is spelled out so it
+  // keeps matching. The trailing side stays open so `city_1` / `cityName` still
+  // match. The other EU city/place terms use `\b` where they are
+  // short/collision-prone, unchanged.
   {
     key: 'location',
     pattern:
-      /city|town|\blocation\b|\bort\b|stadt|wohnort|\bville\b|ciudad|citta|plaats|miasto|cidade|localidad/,
+      /(?:^|[^a-z])(?:home)?(?:city|town)|\blocation\b|\bort\b|stadt|wohnort|\bville\b|ciudad|citta|plaats|miasto|cidade|localidad/,
   },
 ];
 


### PR DESCRIPTION
## Summary

`city` and `phone`/`mobile` were unanchored substrings in `NAMED_KEY_PATTERNS`, so `"ethnicity"` resolved to `location` and `"smartphone"` to `phone` — writing the user's city into an EEO field and their phone number into a "Smartphone model" field. Fixes #783.

## Type of change

- [x] `fix` — Bug fix

## Changes

- Anchored `city` / `town` / `phone` / `mobile` on their **leading** side with `(?:^|[^a-z])`, matching the intent already expressed by the neighbouring `\bhandy\b` / `\bmobil\b` / `\bort\b` / `\bville\b` anchors and their comment (*"bare `mobil` ⊂ 'automobil…'"*).
- Legitimate compounds are spelled out so they keep matching: `cell|home|work|day|tele` + `phone`, and `hometown`.

**Why not `\b`:** `_` is a regex word character, so `\bphone\b` would stop matching `phone_number`, `candidate_phone`, `mobile_number` and `city_1` — all extremely common ATS field names. Leaving the **trailing** side open also keeps the camelCase-flattened signals working (`textSignal` joins `name`/`id`/`placeholder`/`aria-label`/label without splitting camelCase, so `name="phoneNumber"` arrives as `phonenumber`).

**Why `(?:^|[^a-z])` and not a lookbehind:** these patterns are only ever `.test()`ed (`matchNamedKey`), so consuming the boundary character is harmless, and this form has no engine-support caveats.

Incidental improvements from the same anchor: `"iphone"`, `"microphone"` and `"headphone"` no longer resolve to `phone` either.

## Testing

- [x] New `apps/extension/src/lib/field-signal.test.ts` — covers both directions: 17 phone signals + 15 location signals that must still match, and the words that must not.
- [x] `pnpm exec vitest run src/lib/field-signal.test.ts src/lib/autofill.test.ts src/lib/answers-capture.test.ts` — 128 passed, 0 failed. (`autofill` and `answers-capture` are the two consumers of these patterns.)
- [x] `pnpm --filter @ajh/extension typecheck` — clean.
- [x] `pnpm exec eslint` on the changed files — clean.
- [x] `pnpm exec prettier --check` — clean.
- [x] Added tests for new logic.

With the fix reverted, the new tests fail on exactly the reported inputs:

```
AssertionError: smartphone: expected 'phone' not to be 'phone'
AssertionError: ethnicity: expected 'location' not to be 'location'
```

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
