### PR TITLE
fix(extension): only auto-track a submit that came from the application form

### DIFF
--- a/apps/extension/src/lib/submit-watch.test.ts
+++ b/apps/extension/src/lib/submit-watch.test.ts
@@ -18,13 +18,23 @@ function setBody(html: string): void {
   document.body.innerHTML = html;
 }
 
+/** The fields that make a `<form>` read as a real application form rather than
+ *  a search box / newsletter signup (see `looksLikeApplicationForm`). */
+const APPLICATION_FIELDS = `
+  <input name="first_name" />
+  <input name="email" type="email" />
+  <input name="resume" type="file" />
+`;
+
 afterEach(() => {
   document.body.innerHTML = '';
 });
 
 describe('armSubmitWatch — real form submit', () => {
   it('posts once on a real form submit', () => {
-    setBody(`<form id="f"><button type="submit">Submit application</button></form>`);
+    setBody(
+      `<form id="f">${APPLICATION_FIELDS}<button type="submit">Submit application</button></form>`
+    );
     const post = vi.fn();
     armSubmitWatch(document, post);
 
@@ -36,8 +46,28 @@ describe('armSubmitWatch — real form submit', () => {
     expect(typeof post.mock.calls[0]?.[0]).toBe('string');
   });
 
+  it('does NOT post on a search / newsletter form submit', () => {
+    // The listener sees EVERY form on the page and reports only location.href,
+    // so an unscoped submit listener auto-marked the application "applied" when
+    // the user pressed Enter in the site's search box.
+    setBody(`
+      <form id="search"><input type="search" name="q" /><button type="submit">Search</button></form>
+      <form id="news"><input type="email" name="email" /><button type="submit">Subscribe</button></form>
+    `);
+    const post = vi.fn();
+    armSubmitWatch(document, post);
+
+    for (const id of ['search', 'news']) {
+      (document.getElementById(id) as HTMLFormElement).dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    }
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
   it('OBSERVES ONLY — never preventDefault on the submit', () => {
-    setBody(`<form id="f"><button type="submit">Apply</button></form>`);
+    setBody(`<form id="f">${APPLICATION_FIELDS}<button type="submit">Apply</button></form>`);
     armSubmitWatch(document, vi.fn());
 
     const form = document.getElementById('f') as HTMLFormElement;
@@ -50,8 +80,8 @@ describe('armSubmitWatch — real form submit', () => {
 });
 
 describe('armSubmitWatch — apply-style click heuristic', () => {
-  it('posts on a click of an apply-style submit button', () => {
-    setBody(`<button type="submit">Apply now</button>`);
+  it('posts on a click of an apply-style submit button inside the application form', () => {
+    setBody(`<form>${APPLICATION_FIELDS}<button type="submit">Apply now</button></form>`);
     const post = vi.fn();
     armSubmitWatch(document, post);
 
@@ -60,6 +90,21 @@ describe('armSubmitWatch — apply-style click heuristic', () => {
       .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 
     expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT post on a bare "Apply now" that is not inside an application form', () => {
+    // On a job-listing page this control OPENS the application (often a modal);
+    // nothing has been submitted, so the app must not be marked applied.
+    setBody(`<button type="submit">Apply now</button><div role="button">Apply</div>`);
+    const post = vi.fn();
+    armSubmitWatch(document, post);
+
+    document.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    document
+      .querySelector('[role="button"]')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(post).not.toHaveBeenCalled();
   });
 
   it('posts on a role="button" apply control (Easy-Apply / SPA, no native submit)', () => {
@@ -85,7 +130,9 @@ describe('armSubmitWatch — apply-style click heuristic', () => {
   });
 
   it('resolves the control when the click lands on a child element', () => {
-    setBody(`<button type="submit"><span>Apply</span> now</button>`);
+    setBody(
+      `<form>${APPLICATION_FIELDS}<button type="submit"><span>Apply</span> now</button></form>`
+    );
     const post = vi.fn();
     armSubmitWatch(document, post);
 
@@ -95,6 +142,8 @@ describe('armSubmitWatch — apply-style click heuristic', () => {
   });
 
   it('does NOT fire on a non-apply submit button (e.g. "Save draft")', () => {
+    // Formless, so only the click heuristic is in play — a submit button inside
+    // a form implicitly submits it, which is a separate (and legitimate) signal.
     setBody(`<button type="submit">Save draft</button>`);
     const post = vi.fn();
     armSubmitWatch(document, post);
@@ -105,7 +154,8 @@ describe('armSubmitWatch — apply-style click heuristic', () => {
   });
 
   it('does NOT fire on a hidden (display:none) apply button — computed-style only', () => {
-    setBody(`<button type="submit" style="display:none">Apply</button>`);
+    // The text matches, so `isHidden` is the only thing keeping this quiet.
+    setBody(`<button type="submit" style="display:none">Submit application</button>`);
     const post = vi.fn();
     armSubmitWatch(document, post);
 
@@ -117,7 +167,7 @@ describe('armSubmitWatch — apply-style click heuristic', () => {
 
 describe('armSubmitWatch — fire-once guard', () => {
   it('posts AT MOST ONCE when the apply click AND its submit both fire', () => {
-    setBody(`<form id="f"><button type="submit">Apply</button></form>`);
+    setBody(`<form id="f">${APPLICATION_FIELDS}<button type="submit">Apply</button></form>`);
     const post = vi.fn();
     armSubmitWatch(document, post);
 

--- a/apps/extension/src/lib/submit-watch.ts
+++ b/apps/extension/src/lib/submit-watch.ts
@@ -11,6 +11,11 @@
  * Invariants:
  *  - NEVER blocks or alters the submit: no `preventDefault`/`stopPropagation`,
  *    so the real form submission proceeds untouched.
+ *  - UNDER-reports rather than over-reports. The message auto-advances a saved
+ *    application to `applied`, so a false positive silently lies about what the
+ *    user did; a false negative just leaves them to mark it by hand. Hence the
+ *    {@link looksLikeApplicationForm} gate on the submit path and the strict
+ *    text requirement for a control with no form around it.
  *  - Fires AT MOST ONCE per arming — a click on the apply button AND the submit
  *    it triggers post a single message, not two (the `fired` closure guard).
  *  - Reads `location.href` SYNCHRONOUSLY in the handler, so a full-page-nav
@@ -37,8 +42,51 @@ import { isHidden } from './field-signal';
 export const SUBMIT_DETECTED_MSG = 'submitDetected';
 
 /** Visible text that marks a control as a real "send the application" action
- *  (an apply/submit/finish button), not a "save draft"/"add another" control. */
+ *  (an apply/submit/finish button), not a "save draft"/"add another" control.
+ *  Only trusted for a control that sits inside an application form — see
+ *  {@link STRICT_APPLY_TEXT_RE}. */
 const APPLY_TEXT_RE = /apply|submit application|send application|finish/i;
+
+/** The subset of {@link APPLY_TEXT_RE} trusted with NO surrounding form to
+ *  corroborate it (a pure SPA control). A bare "Apply"/"Apply now" is excluded:
+ *  outside a form it is overwhelmingly the button that OPENS the application,
+ *  not the one that sends it. */
+const STRICT_APPLY_TEXT_RE =
+  /submit\s+(?:your|my|the)?\s*application|send\s+(?:your|my|the)?\s*application|finish/i;
+
+/** Minimum number of visible, fillable fields for a `<form>` to be treated as an
+ *  application form. A site search box, a newsletter signup and a login form all
+ *  have one or two; a real application form has more (and usually a résumé file
+ *  input, which short-circuits this check outright). */
+const MIN_APPLICATION_FIELDS = 3;
+
+/**
+ * Whether `form` looks like the application form rather than incidental page
+ * furniture (search box, filter, newsletter signup, login).
+ *
+ * The `submit` event fires for EVERY form on the page, and the watcher has no
+ * other way to tell them apart — it only reports `location.href`, so a search
+ * submit was indistinguishable from sending the application.
+ */
+function looksLikeApplicationForm(form: HTMLFormElement): boolean {
+  const fields = Array.from(form.querySelectorAll('input, textarea, select')).filter(
+    (el): el is HTMLElement => el instanceof HTMLElement && !isHidden(el)
+  );
+  const fillable = fields.filter((el) => {
+    const type = (el.getAttribute('type') ?? '').toLowerCase();
+    return !['hidden', 'submit', 'button', 'image', 'reset', 'search'].includes(type);
+  });
+  // A file input is the résumé upload — decisive on its own.
+  if (fillable.some((el) => (el.getAttribute('type') ?? '').toLowerCase() === 'file')) return true;
+  return fillable.length >= MIN_APPLICATION_FIELDS;
+}
+
+/** The application form this control belongs to, if any — `form` for a native
+ *  submit control, otherwise the nearest `<form>` ancestor (SPA `role=button`). */
+function applicationFormFor(el: HTMLElement): HTMLFormElement | null {
+  const form = (el as HTMLButtonElement | HTMLInputElement).form ?? el.closest?.('form') ?? null;
+  return form instanceof HTMLFormElement ? form : null;
+}
 
 /**
  * True when `el` is an apply-style control worth treating as a submit: a real
@@ -58,7 +106,13 @@ function isApplyControl(el: Element): boolean {
     el instanceof HTMLInputElement
       ? el.value
       : `${el.textContent ?? ''} ${el.getAttribute('aria-label') ?? ''}`;
-  return APPLY_TEXT_RE.test(text);
+  // Inside an application form the surrounding structure corroborates the text,
+  // so the broad pattern is trusted. With no form to corroborate it, only an
+  // explicit send verb counts — a bare "Apply now" out there is the button that
+  // OPENS the application.
+  const form = el instanceof HTMLElement ? applicationFormFor(el) : null;
+  if (form) return looksLikeApplicationForm(form) && APPLY_TEXT_RE.test(text);
+  return STRICT_APPLY_TEXT_RE.test(text);
 }
 
 /**
@@ -76,8 +130,19 @@ export function armSubmitWatch(doc: Document, post: (url: string) => void): void
     post(doc.defaultView?.location?.href ?? '');
   };
 
-  // Real form submit — any submit path that fires the native event.
-  doc.addEventListener('submit', () => fire(), true);
+  // Real form submit — but ONLY for a form that looks like the application form.
+  // The listener sees every form on the page and reports nothing but
+  // `location.href`, so without this check a search box, filter or newsletter
+  // signup submit was indistinguishable from sending the application.
+  doc.addEventListener(
+    'submit',
+    (ev) => {
+      const form = ev.target;
+      if (!(form instanceof HTMLFormElement) || !looksLikeApplicationForm(form)) return;
+      fire();
+    },
+    true
+  );
 
   // Apply-style click — backstop for role=button / JS-driven submits that never
   // fire a native `submit`. The click can land on a child (an icon/span), so


### PR DESCRIPTION
## Summary

The submit watcher fired on **any** form submit and on a bare "Apply" control, so a search-box submit or merely opening the application modal auto-marked the job `applied`. Fixes #785.

## Type of change

- [x] `fix` — Bug fix

## Changes

- **Submit path is scoped to the application form.** `looksLikeApplicationForm()` requires a visible file input (the résumé upload — decisive on its own) or ≥3 visible fillable fields. A site search box, a newsletter signup and a login form all fall below that; a real application form does not.
- **Click path is corroborated by structure.** A control **inside** an application-looking form keeps the existing broad `APPLY_TEXT_RE`. A control with **no** form around it (pure SPA / `role="button"`) now needs `STRICT_APPLY_TEXT_RE` — an explicit send verb (`submit/send [your|my|the] application`, `finish`) — because out there a bare "Apply now" is the button that *opens* the application.
- Documented the direction as an invariant in the module header: this signal auto-advances a `saved` application to `applied`, so a false positive silently misreports what the user did, while a false negative just leaves them to mark it by hand.

**Known remaining gap (pre-existing, not introduced here):** a *"Save draft"* `type="submit"` button inside the real application form implicitly submits that form, so the submit listener still fires for it. Distinguishing that needs the submitter's identity (`SubmitEvent.submitter`) rather than the form, which felt like a separate change — happy to do it here if you'd like.

## Testing

- [x] `pnpm exec vitest run src/lib/submit-watch.test.ts src/lib/auto-track.test.ts src/lib/autofill.test.ts` — 97 passed, 0 failed.
- [x] `pnpm --filter @ajh/extension typecheck` — clean.
- [x] `pnpm exec eslint` / `prettier --check` on the changed files — clean.
- [x] Added tests for new logic.

Two new tests, both of which fail against the current code:

```
× does NOT post on a search / newsletter form submit
× does NOT post on a bare "Apply now" that is not inside an application form
```

**Existing tests I had to adjust, and why** — all of them were fixtures that no longer describe a real application page, not changes of intent:

| Test | Change |
| --- | --- |
| `posts once on a real form submit` | form had no fields at all; added the résumé/name/email fields |
| `OBSERVES ONLY — never preventDefault` | same fixture fix |
| `posts on a click of an apply-style submit button` | `<button>Apply now</button>` had no form; wrapped it in the application form (renamed to say so) |
| `resolves the control when the click lands on a child` | same fixture fix |
| `does NOT fire on … "Save draft"` | kept it **formless** so it still exercises the click heuristic alone (inside a form, a submit button implicitly submits — see the gap above) |
| `does NOT fire on a hidden apply button` | text changed to "Submit application" so `isHidden` is genuinely the only thing keeping it quiet |

Unchanged and still passing: the `role="button"` Easy-Apply case, the `input[type=submit] value="Finish"` case, and the fire-once guard.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (both new helpers are private, documented inline)
