### PR TITLE
fix(extension): reply via the response callback so popup requests work on chrome

### DIFF
--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -97,15 +97,38 @@ const setBadgeTextMock = vi.mocked(browser.action.setBadgeText);
 const listener = vi.mocked(browser.runtime.onMessage.addListener).mock.calls[0]?.[0] as
   | ((
       message: unknown,
-      sender: Browser.runtime.MessageSender
-    ) => Promise<PopupResponse> | undefined)
+      sender: Browser.runtime.MessageSender,
+      sendResponse: (response?: PopupResponse) => void
+    ) => true | undefined)
   | undefined;
 
+/**
+ * Drive the registered listener the way the browser does: hand it a
+ * `sendResponse` callback and resolve on the reply.
+ *
+ * The `kept === true` assertion is the point — Chromium keeps the message
+ * channel open for an async reply ONLY for a literal `true` return. Anything
+ * else (including a returned Promise, which is truthy but not `true`) closes it
+ * immediately and `sendMessage` resolves `undefined`, which the popup reports as
+ * "No response from the extension background."
+ */
 function send(req: PopupRequest): Promise<PopupResponse> {
   if (!listener) throw new Error('onMessage listener not registered');
-  return listener(req, {
-    id: EXTENSION_ID,
-  } as Browser.runtime.MessageSender) as Promise<PopupResponse>;
+  return new Promise<PopupResponse>((resolve, reject) => {
+    const kept = listener(
+      req,
+      { id: EXTENSION_ID } as Browser.runtime.MessageSender,
+      (response?: PopupResponse) => {
+        if (response) resolve(response);
+        else reject(new Error('listener called sendResponse with no response'));
+      }
+    );
+    if (kept !== true) {
+      reject(
+        new Error(`listener must return literal true to keep the channel open, got ${String(kept)}`)
+      );
+    }
+  });
 }
 
 /** Flush the fire-and-forget async work `handleRequest`/the raw listener kick

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1015,7 +1015,11 @@ async function handleRequest(req: PopupRequest): Promise<PopupResponse> {
 // ── wiring ────────────────────────────────────────────────────────────────────
 
 browser.runtime.onMessage.addListener(
-  (message: unknown, sender: Browser.runtime.MessageSender): Promise<PopupResponse> | undefined => {
+  (
+    message: unknown,
+    sender: Browser.runtime.MessageSender,
+    sendResponse: (response?: PopupResponse) => void
+  ): true | undefined => {
     // The injected submit-watcher posts a fire-and-forget `submitDetected` — it
     // is NOT a popup request and expects no response, so handle it out-of-band.
     if (isSubmitDetected(message)) {
@@ -1028,7 +1032,25 @@ browser.runtime.onMessage.addListener(
       }
       return undefined;
     }
-    return handleRequest(message as PopupRequest);
+    // Reply via `sendResponse` + a LITERAL `true`, never by returning a Promise.
+    // `@wxt-dev/browser` is a thin `browser ?? chrome` pass-through (its README
+    // says so explicitly — it is not `webextension-polyfill`), and Chromium's
+    // `chrome.runtime.onMessage` has never supported a Promise return value: it
+    // keeps the channel open only for a literal `true`. A returned Promise is
+    // truthy but not `true`, so the channel closed immediately, `sendMessage`
+    // resolved `undefined`, and every request/response action (import, fill,
+    // save, mark-applied, check-fit, status) came back as "No response from the
+    // extension background." — while the one-way background→popup pushes kept
+    // working, so the pill could still read "Connected".
+    //
+    // `sendResponse` + `return true` is the shape BOTH engines accept, so this
+    // is correct on Firefox regardless.
+    void handleRequest(message as PopupRequest).then(sendResponse, (err: unknown) => {
+      // A rejection here would otherwise leave the port open until it times out,
+      // which the popup surfaces as the same "No response" message.
+      sendResponse({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    });
+    return true;
   }
 );
 


### PR DESCRIPTION
## Summary

The background `onMessage` listener replied by returning a Promise, which Chromium does not support — so every popup request/response action returned "No response from the extension background." Fixes #787.

## Type of change

- [x] `fix` — Bug fix

## Changes

- The listener now takes `sendResponse`, calls it with the result, and returns the **literal** `true`.
- A rejection from `handleRequest` also calls `sendResponse` (with `{ok:false, error}`) instead of leaving the port open until it times out — which the popup would surface as the same "No response" message.
- `background.test.ts`'s `send()` helper now drives the listener the way the browser does (passing a `sendResponse` callback) and **asserts the listener returned literal `true`**, so this can't regress silently.

Why this is a Chrome-only failure, and why the package doesn't save us — `@wxt-dev/browser`'s entire runtime is a pass-through:

```js
// node_modules/@wxt-dev/browser/src/index.mjs
export const browser = globalThis.browser?.runtime?.id ? globalThis.browser : globalThis.chrome;
```

No wrapper and no `webextension-polyfill` dependency, so on Chromium `browser === chrome` and a Promise return (truthy, but not `true`) closes the channel immediately. Firefox's native `browser.*` accepts the Promise form, which is why this never showed up there.

`sendResponse` + `return true` is accepted by **both** engines, so this is safe on Firefox as well.

## Testing

- [x] `pnpm exec vitest run src/background.test.ts` — 65 passed, 0 failed.
- [x] `pnpm --filter @ajh/extension typecheck` — clean.
- [x] `pnpm exec eslint` / `prettier --check` on the changed files — clean.
- [x] Added tests for new logic (the harness assertion).

With the fix reverted, the new harness assertion catches it across the board:

```
Error: listener must return literal true to keep the channel open, got [object Promise]
⎯ Failed Tests 62 ⎯
```

The three that still passed are the ones that don't go through the request/response path — which is exactly the asymmetry that made this hard to notice in the first place.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
