### PR TITLE
fix(shared): map the iso codes franc actually emits for zh, ar and no

### DIFF
--- a/packages/shared/src/language-detection.test.ts
+++ b/packages/shared/src/language-detection.test.ts
@@ -14,6 +14,15 @@ const GERMAN =
   'Erfahrener Softwareentwickler mit fundierten Kenntnissen in der Entwicklung skalierbarer Webanwendungen und verteilter Backend-Systeme für große Unternehmen.';
 const FRENCH =
   "Ingénieur logiciel expérimenté possédant une solide expérience dans la création d'applications web évolutives et de systèmes backend distribués pour de grandes organisations.";
+// franc emits the INDIVIDUAL ISO 639-3 code for these — cmn / arb / nob — never
+// the macrolanguage zho / ara / nor, so mapping on the macrolanguage code left
+// the entry dead and every one of these resolved to 'unknown'.
+const CHINESE =
+  '我们正在寻找一位经验丰富的软件工程师加入我们的团队。您将负责设计和开发高质量的后端服务，与产品经理和设计师紧密合作，推动项目按时交付。';
+const ARABIC =
+  'نبحث عن مهندس برمجيات ذي خبرة للانضمام إلى فريقنا. ستكون مسؤولاً عن تصميم وتطوير خدمات خلفية عالية الجودة والعمل بشكل وثيق مع مديري المنتجات والمصممين لتسليم المشاريع في الوقت المحدد.';
+const NORWEGIAN =
+  'Vi ser etter en erfaren programvareutvikler som vil bli med i teamet vårt. Du vil ha ansvaret for å designe og utvikle backend-tjenester av høy kvalitet, og samarbeide tett med produktsjefer og designere.';
 
 describe('detectLanguage', () => {
   it('returns "unknown" for empty or very short text', () => {
@@ -32,6 +41,12 @@ describe('detectLanguage', () => {
 
   it('detects French', () => {
     expect(detectLanguage(FRENCH)).toBe('fr');
+  });
+
+  it('detects Chinese, Arabic and Norwegian (franc emits cmn/arb/nob)', () => {
+    expect(detectLanguage(CHINESE)).toBe('zh');
+    expect(detectLanguage(ARABIC)).toBe('ar');
+    expect(detectLanguage(NORWEGIAN)).toBe('no');
   });
 });
 

--- a/packages/shared/src/language-detection.ts
+++ b/packages/shared/src/language-detection.ts
@@ -7,6 +7,11 @@ import { franc } from 'franc';
 
 /**
  * ISO 639-1 language code mapping from franc's ISO 639-3 codes.
+ *
+ * franc emits the **individual** ISO 639-3 code, never the macrolanguage one —
+ * `cmn` (Mandarin) not `zho`, `arb` (Standard Arabic) not `ara`, `nob`/`nno`
+ * (Bokmål/Nynorsk) not `nor`. Keying on the macrolanguage codes leaves the entry
+ * dead and `detectLanguage` falls through to `'unknown'`.
  */
 const LANGUAGE_MAP: Record<string, string> = {
   eng: 'en',
@@ -16,16 +21,17 @@ const LANGUAGE_MAP: Record<string, string> = {
   ita: 'it',
   por: 'pt',
   rus: 'ru',
-  zho: 'zh',
+  cmn: 'zh',
   jpn: 'ja',
   kor: 'ko',
-  ara: 'ar',
+  arb: 'ar',
   hin: 'hi',
   tur: 'tr',
   nld: 'nl',
   pol: 'pl',
   swe: 'sv',
-  nor: 'no',
+  nob: 'no',
+  nno: 'no',
   dan: 'da',
   fin: 'fi',
   ces: 'cs',


### PR DESCRIPTION
## Summary

`LANGUAGE_MAP` keyed Chinese/Arabic/Norwegian on the **macrolanguage** ISO 639-3 codes (`zho`/`ara`/`nor`), which franc never emits — so all three always resolved to `'unknown'`. Fixes #789.

## Type of change

- [x] `fix` — Bug fix

## Changes

- `zho → cmn`, `ara → arb`, `nor → nob`, plus `nno` (Nynorsk) also mapping to `no`.
- Added a doc comment on the map recording *why* — franc emits the individual code, never the macrolanguage one — so the next entry doesn't repeat it.
- Test with real Chinese, Arabic and Norwegian text.

Verified against the installed franc 6.2.0:

```
Chinese    -> cmn
Arabic     -> arb
Norwegian  -> nob
German     -> deu     ← one of the codes that already mapped correctly
```

Same class as the `swe → sv` fix in commit #679; these three were just missed. The existing tests only covered `en`/`de`/`fr`, all of which happen to use codes franc really does emit, so nothing caught it.

Downstream effect of the fix: `detectLanguages(...).mismatch` can now flag a Chinese/Arabic résumé against an English ad (it requires both sides known), and referral drafts stop collapsing `'unknown'` → `'en'` for those users.

## Testing

- [x] `pnpm exec vitest run src/language-detection.test.ts` (in `packages/shared`) — 13 passed, 0 failed.
- [x] `pnpm --filter @ajh/shared typecheck` — clean.
- [x] `pnpm exec prettier --check` — clean.
- [x] Added tests for new logic.

With the fix reverted:

```
× detects Chinese, Arabic and Norwegian (franc emits cmn/arb/nob)
  → expected 'unknown' to be 'zh'
```

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
