### PR TITLE
fix(prompts): stop the italic strip from eating bold markup

### DIFF
--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -1298,10 +1298,23 @@ describe('extractPlainText', () => {
     expect(out).toContain('body');
   });
 
-  it('reduces emphasis markers (triple/single asterisks collapse)', () => {
-    // The single-italic pass also unwraps the inner pair of a bold run.
-    expect(extractPlainText('***strong***')).toBe('*strong*');
+  it('reduces emphasis markers (triple collapses to bold, single italic is stripped)', () => {
+    expect(extractPlainText('***strong***')).toBe('**strong**');
     expect(extractPlainText('an *italic* word')).toBe('an italic word');
+  });
+
+  it('leaves **bold** keyword markup intact', () => {
+    // The italic pass used to match the INNER pair of a bold run, downgrading
+    // `**bold**` to `*bold*`; and since `[^*]+` matches spaces and commas, two
+    // adjacent bold spans paired up across each other and swallowed the text
+    // between them. The prompts ask for 2-3 `**keyword**` bolds per bullet, so
+    // this corrupted essentially every generated document.
+    expect(extractPlainText('**bold**')).toBe('**bold**');
+    expect(extractPlainText('Skills: **Python**, **Go**, **Kubernetes**')).toBe(
+      'Skills: **Python**, **Go**, **Kubernetes**'
+    );
+    // Bold and italic in the same line: only the italic is stripped.
+    expect(extractPlainText('**a** and *b*')).toBe('**a** and b');
   });
 
   it('removes a fenced code block entirely (no orphaned backticks or code leak)', () => {

--- a/packages/prompts/src/generate/text/text.ts
+++ b/packages/prompts/src/generate/text/text.ts
@@ -14,7 +14,14 @@ export function extractPlainText(raw: string): string {
       .replace(/<\/?leakage_check>/gi, '') // stray unclosed tags
       .replace(/^#{1,6}\s/gm, '')
       .replace(/\*\*\*(.+?)\*\*\*/g, '**$1**') // triple → double (preserve bold)
-      .replace(/\*([^*]+)\*/g, '$1') // single italic → plain
+      // Single italic → plain, but ONLY a `*` that is not part of a `**` run.
+      // Without the guards this pass ate bold too: the leftmost match inside
+      // `**bold**` is the inner `*bold*`, leaving `*bold*` — and because
+      // `[^*]+` also matches spaces and commas, two adjacent bold spans paired
+      // up ACROSS each other, so `**Python**, **Go**` collapsed to
+      // `*Python, Go*`. The prompts ask for 2-3 `**keyword**` bolds per bullet,
+      // so this ran on essentially every generated document.
+      .replace(/(?<!\*)\*(?!\*)([^*]+)\*(?!\*)/g, '$1')
       // Fenced blocks first — otherwise the inline-backtick pass below consumes
       // the ``` fence markers, orphaning them so the fenced regex no longer
       // matches and the code body leaks into the plain text.


### PR DESCRIPTION
## Summary

The italic-strip pass in `extractPlainText` was not bold-aware, so it downgraded `**bold**` to `*bold*` and — worse — merged adjacent bold spans, swallowing the text between them. Fixes #791.

## Type of change

- [x] `fix` — Bug fix

## Changes

- The italic strip now matches only a `*` that is **not** part of a `**` run:
  ```diff
  -.replace(/\*([^*]+)\*/g, '$1')
  +.replace(/(?<!\*)\*(?!\*)([^*]+)\*(?!\*)/g, '$1')
  ```
- Before → after, run through the real pipeline:

  | input | before | after |
  | --- | --- | --- |
  | `**bold**` | `*bold*` | `**bold**` |
  | `Skills: **Python**, **Go**, **Kubernetes**` | `Skills: *Python, Go, Kubernetes*` | unchanged |
  | `an *italic* word` | `an italic word` | `an italic word` |
  | `***strong***` | `*strong*` | `**strong**` |
  | `**a** and *b*` | `*a and b*` | `**a** and b` |

- Tests: added coverage for the merge case and for bold+italic on one line.

**One existing assertion changed**, deliberately:

```diff
-// The single-italic pass also unwraps the inner pair of a bold run.
-expect(extractPlainText('***strong***')).toBe('*strong*');
+expect(extractPlainText('***strong***')).toBe('**strong**');
```

That assertion documented the downgrade rather than intending it — the pass immediately above it exists to *"preserve bold"*, which `*strong*` doesn't. The multi-keyword merge on the same code path is unambiguously wrong and was untested.

This runs on every generated résumé, cover letter, email and answer, and the prompts ask the model for 2–3 `**keyword**` bolds per bullet, so it fired on essentially every document.

## Testing

- [x] `pnpm exec vitest run` in `packages/prompts` — 516 passed, 0 failed (15 files).
- [x] `pnpm --filter @ajh/prompts typecheck` — clean.
- [x] `pnpm exec prettier --check` — clean.
- [x] Added tests for new logic.

With the fix reverted:

```
× reduces emphasis markers … → expected '*strong*' to be '**strong**'
× leaves **bold** keyword markup intact → expected '*bold*' to be '**bold**'
```

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
