### PR TITLE
fix(autopilot): derive step patches from the reducer state, not a snapshot

### DIFF
--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
@@ -21,6 +21,13 @@ vi.mock('@ajh/translations', () => ({
 
 const runMutateAsync = vi.fn();
 
+/** Captures the step handler the hook registers, so a test can deliver step
+ *  events the way the Tauri event bridge does. */
+const stepEvents = vi.hoisted(() => ({
+  handler: null as
+    ((event: { jobId: string; autopilotId: string; step: string; detail: string }) => void) | null,
+}));
+
 vi.mock('@/services', async (importActual) => {
   const actual = await importActual<Record<string, unknown>>();
   return {
@@ -29,7 +36,9 @@ vi.mock('@/services', async (importActual) => {
     usePauseAutopilot: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
     useResumeAutopilot: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
     useRemoveAutopilot: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
-    useAutopilotStepEvents: () => {},
+    useAutopilotStepEvents: (cb: (event: never) => void) => {
+      stepEvents.handler = cb as unknown as typeof stepEvents.handler;
+    },
   };
 });
 
@@ -156,5 +165,27 @@ describe('useAutopilotRun — handleRun error-payload handling', () => {
 
     expect(result.current.runStates.ap7).toBe('done');
     expect(result.current.error).toBeNull();
+  });
+});
+
+describe('useAutopilotRun — batched step events', () => {
+  it('keeps both step-log entries when two events for one autopilot land in the same batch', () => {
+    const { result } = renderHookWithClient(() => useAutopilotRun());
+    const deliver = stepEvents.handler;
+    expect(deliver, 'the hook must register a step handler').toBeTruthy();
+
+    // Two events for the SAME autopilotId inside ONE act() — i.e. one React
+    // batch, with no re-render in between. Patches computed from the render
+    // snapshot both start from the same base, so the second overwrites the
+    // first and the scrape_start line is lost.
+    act(() => {
+      deliver?.({ jobId: 'j1', autopilotId: 'ap-batch', step: 'scrape_start', detail: 'boards' });
+      deliver?.({ jobId: 'j1', autopilotId: 'ap-batch', step: 'scrape_done', detail: '12 jobs' });
+    });
+
+    const steps = (result.current.stepLogs['ap-batch'] ?? []).map((entry) => entry.step);
+    expect(steps).toEqual(['scrape_start', 'scrape_done']);
+    // The machine also advanced through BOTH transitions, not just the last.
+    expect(result.current.runStates['ap-batch']).toBe('ranking');
   });
 });

--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
@@ -14,16 +14,27 @@ import {
   useRunAutopilot,
 } from '@/services';
 
+/**
+ * A reducer patch: the fields to merge, or a function of the CURRENT state that
+ * produces them.
+ *
+ * The functional form is required whenever the new value DERIVES from the old
+ * one. Computing it from a render snapshot instead means two events for the same
+ * key inside one React batch both read the same base, so the second patch
+ * overwrites the first.
+ */
+type Patch<T> = Partial<T> | ((prev: T) => Partial<T>);
+
 export function useAutopilotRun() {
   const { t } = useTranslation();
   const [runStates, setRunStates] = useReducer(
-    (prev: RunStateMap, patch: Partial<RunStateMap>): RunStateMap =>
-      ({ ...prev, ...patch }) as RunStateMap,
+    (prev: RunStateMap, patch: Patch<RunStateMap>): RunStateMap =>
+      ({ ...prev, ...(typeof patch === 'function' ? patch(prev) : patch) }) as RunStateMap,
     {} as RunStateMap
   );
   const [stepLogs, setStepLogs] = useReducer(
-    (prev: StepLogMap, patch: Partial<StepLogMap>): StepLogMap =>
-      ({ ...prev, ...patch }) as StepLogMap,
+    (prev: StepLogMap, patch: Patch<StepLogMap>): StepLogMap =>
+      ({ ...prev, ...(typeof patch === 'function' ? patch(prev) : patch) }) as StepLogMap,
     {} as StepLogMap
   );
   const [error, setError] = useState<string | null>(null);
@@ -33,27 +44,29 @@ export function useAutopilotRun() {
   const resumeAutopilot = useResumeAutopilot();
   const removeAutopilot = useRemoveAutopilot();
 
-  const handleStep = useCallback(
-    (event: AutopilotStepEvent) => {
-      const ev = stepToEvent(event.step);
-      if (ev) {
-        setRunStates({
-          [event.autopilotId]: machineTransition(
-            autopilotRunMachine,
-            runStates[event.autopilotId] ?? 'idle',
-            ev
-          ),
-        });
-      }
-      setStepLogs({
-        [event.autopilotId]: [
-          ...(stepLogs[event.autopilotId] ?? []).slice(-49),
-          { step: event.step, detail: event.detail, ts: Date.now() },
-        ],
-      });
-    },
-    [runStates, stepLogs]
-  );
+  const handleStep = useCallback((event: AutopilotStepEvent) => {
+    // Both patches DERIVE from the current value, so they must read the
+    // reducer's `prev` — not the render snapshot this callback closed over.
+    // Two step events for the same autopilotId inside one React batch would
+    // otherwise both start from the same base, and the second would overwrite
+    // the first: a dropped step-log line and a skipped state transition.
+    const ev = stepToEvent(event.step);
+    if (ev) {
+      setRunStates((prev) => ({
+        [event.autopilotId]: machineTransition(
+          autopilotRunMachine,
+          prev[event.autopilotId] ?? 'idle',
+          ev
+        ),
+      }));
+    }
+    setStepLogs((prev) => ({
+      [event.autopilotId]: [
+        ...(prev[event.autopilotId] ?? []).slice(-49),
+        { step: event.step, detail: event.detail, ts: Date.now() },
+      ],
+    }));
+  }, []);
 
   useAutopilotStepEvents(handleStep);
 


### PR DESCRIPTION
## Summary

`handleStep` computed its reducer patches from the render snapshot rather than the reducer's `prev`, so two step events for one autopilot in the same React batch lost the first one. Fixes #793.

## Type of change

- [x] `fix` — Bug fix

## Changes

- Both reducers now accept a **functional** patch (`Patch<T> = Partial<T> | ((prev: T) => Partial<T>)`), and `handleStep` derives `runStates` / `stepLogs` from `prev`.
- `handleStep`'s `useCallback` deps drop to `[]` — it no longer closes over any state, so the handler identity is stable too.
- Every other call site keeps passing a plain object patch, unchanged (`setRunStates({ [id]: 'scraping' })` etc.); the functional form is only needed where the new value derives from the old one.
- Regression test `keeps both step-log entries when two events for one autopilot land in the same batch`.

## Testing

- [x] `pnpm exec vitest run src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts` — 9 passed, 0 failed (8 pre-existing + 1 new).
- [x] `pnpm exec eslint` / `prettier` on the changed files — clean.
- [x] Added tests for new logic.

With the fix reverted:

```
× keeps both step-log entries when two events for one autopilot land in the same batch
AssertionError: expected [ 'scrape_done' ] to deeply equal [ 'scrape_start', 'scrape_done' ]
```

**Note on `pnpm typecheck`:** I could not run it — on a fresh clone `apps/desktop` fails to typecheck because `routeTree.gen.ts` doesn't exist until the router plugin has run (`Cannot find module '@/routeTree.gen'`, plus the ~15 route errors that follow from it). That is pre-existing on `main` and unrelated to this change; the test suite runs fine since vitest doesn't typecheck.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (the `Patch<T>` helper type is documented inline)
