### PR TITLE
fix(jobs): mark a posting applied only after tailor succeeds

### DIFF
--- a/apps/desktop/src/renderer/features/jobs/hooks/usePostingActions.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/usePostingActions.test.ts
@@ -327,7 +327,7 @@ describe('usePostingActions — handleView', () => {
 // The two score-presence variants below override via a fresh mock per test.
 
 describe('usePostingActions — handleTailor', () => {
-  it('tracks applied interaction (optimistic set) before awaiting the mutation', async () => {
+  it('tracks the applied interaction once the save has succeeded', async () => {
     const { result } = renderHook(() => usePostingActions(makePosting()));
     await act(async () => {
       await result.current.handleTailor();
@@ -336,6 +336,36 @@ describe('usePostingActions — handleTailor', () => {
     expect(mockPersistJobAsync).toHaveBeenCalledWith(
       expect.objectContaining({ interactionType: 'applied' })
     );
+  });
+
+  it('does NOT mark applied when saveFromPosting rejects', async () => {
+    // `trackInteraction` PERSISTS via persistJobMutation, and the failure paths
+    // return without reverting — so firing it up-front left the posting reading
+    // Applied for a Tailor that visibly failed.
+    mockSaveFromPostingAsync.mockRejectedValueOnce(new Error('backend down'));
+
+    const { result } = renderHook(() => usePostingActions(makePosting()));
+    await act(async () => {
+      await result.current.handleTailor();
+    });
+
+    expect(notifyError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'jobs.tailorError' })
+    );
+    expect(mockPersistJobAsync).not.toHaveBeenCalled();
+    expect(result.current.has('applied')).toBe(false);
+  });
+
+  it('does NOT mark applied when saveFromPosting resolves without an id', async () => {
+    mockSaveFromPostingAsync.mockResolvedValueOnce({ id: null });
+
+    const { result } = renderHook(() => usePostingActions(makePosting()));
+    await act(async () => {
+      await result.current.handleTailor();
+    });
+
+    expect(mockPersistJobAsync).not.toHaveBeenCalled();
+    expect(result.current.has('applied')).toBe(false);
   });
 
   it('forwards scraped salary fields to saveFromPosting when present', async () => {

--- a/apps/desktop/src/renderer/features/jobs/hooks/usePostingActions.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/usePostingActions.ts
@@ -70,7 +70,6 @@ export function usePostingActions(posting: Posting) {
   };
 
   const handleTailor = async () => {
-    void trackInteraction('applied');
     let res;
     try {
       res = await saveFromPostingMutation.mutateAsync({
@@ -91,6 +90,13 @@ export function usePostingActions(posting: Posting) {
       notify.error({ message: t('jobs.tailorError') });
       return;
     }
+    // Mark `applied` only once the save actually succeeded. Firing it up-front
+    // was optimistic with no rollback: `trackInteraction` persists via
+    // `persistJobMutation`, and both failure paths above `return` without
+    // reverting, so a failed Tailor left the posting reading Applied — badge and
+    // stored interaction — for something the user never applied to. `handleSave`
+    // below already marks `bookmarked` only after success.
+    void trackInteraction('applied');
     setApplicationApply({
       applyForId: res.id,
       applySeedResume: null,


### PR DESCRIPTION
## Summary

`handleTailor` fired `trackInteraction('applied')` before the save and never reverted it on failure, so a failed Tailor left the posting reading **Applied**. Fixes #795.

## Type of change

- [x] `fix` — Bug fix

## Changes

- `trackInteraction('applied')` moved below the `res?.id` guard, so it runs only after the save actually succeeded — matching the sibling `handleSave`, which already marks `bookmarked` only in its `.then()`.
- Two tests: `saveFromPosting` rejecting, and resolving without an `id`.

The optimistic call was not just local state: `trackInteraction` awaits `persistJobMutation.mutateAsync({ job, interactionType })`, so the interaction was written to the backend and survived a restart, while both failure paths `return`ed without undoing it — the user saw an error toast and an Applied badge at the same time.

## Testing

- [x] `pnpm exec vitest run src/renderer/features/jobs/hooks/usePostingActions.test.ts` — 28 passed, 0 failed (26 pre-existing + 2 new).
- [x] `pnpm exec eslint` / `prettier --check` on the changed files — clean.
- [x] Added tests for new logic.

With the fix reverted, both new tests fail:

```
× does NOT mark applied when saveFromPosting rejects
× does NOT mark applied when saveFromPosting resolves without an id
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

One existing test was renamed — `tracks applied interaction (optimistic set) before awaiting the mutation` → `tracks the applied interaction once the save has succeeded`. Its assertion is unchanged and still passes; only the title described the old ordering.

**Note on `pnpm typecheck`:** not runnable here — on a fresh clone `apps/desktop` fails typecheck because `routeTree.gen.ts` doesn't exist until the router plugin has run. Pre-existing on `main` and unrelated to this change.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
