### PR TITLE
fix(monitoring): dedup the activity feed on the real job id

### DIFF
--- a/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.test.ts
+++ b/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.test.ts
@@ -1,0 +1,92 @@
+/**
+ * useActivityFeed — live/historical merge.
+ *
+ * The feed shows live job events on top and the persisted job records below,
+ * deduped so a job that just finished is not listed twice. The dedup keys the
+ * live item's id back to the job id it was built from.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+// ── services ─────────────────────────────────────────────────────────────────
+
+const mockFetchJob = vi.fn();
+/** The job-event handler the hook registers, so a test can deliver events. */
+const jobEvents = vi.hoisted(() => ({
+  handler: null as ((event: unknown) => void) | null,
+}));
+
+vi.mock('@/services', () => ({
+  fetchJob: (...args: unknown[]) => mockFetchJob(...args),
+  useJobEvents: (cb: (event: unknown) => void) => {
+    jobEvents.handler = cb;
+  },
+}));
+
+import type { JobRecord } from '@/features/monitoring/types';
+
+import { useActivityFeed } from './useActivityFeed';
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+/** Real shape: `format!("job-{}", Uuid::new_v4())` on the Rust side. */
+const JOB_ID = 'job-3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+
+function completedJob(overrides: Partial<JobRecord> = {}): JobRecord {
+  return {
+    id: JOB_ID,
+    kind: 'scrape.run',
+    status: 'completed',
+    progress: 1,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_001_000,
+    finishedAt: 1_700_000_001_000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jobEvents.handler = null;
+  mockFetchJob.mockReset();
+  mockFetchJob.mockResolvedValue(completedJob());
+});
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe('useActivityFeed — live/historical dedup', () => {
+  it('lists a just-completed job once, not twice', async () => {
+    const { result } = renderHook(() =>
+      useActivityFeed([completedJob()], { 'scrape.run': 'Scrape' })
+    );
+
+    // Only the historical row so far.
+    expect(result.current.activity).toHaveLength(1);
+
+    // The same job completes live. Its live id is `${jobId}-${ts}`, so the
+    // historical row for that job must now be filtered out — not rendered again.
+    await act(async () => {
+      jobEvents.handler?.({ type: 'job.completed', jobId: JOB_ID, ts: 1_700_000_001_500 });
+    });
+
+    await waitFor(() => expect(result.current.liveActivity).toHaveLength(1));
+    expect(result.current.activity).toHaveLength(1);
+    expect(result.current.activity[0]?.id).toBe(`${JOB_ID}-1700000001500`);
+  });
+
+  it('keeps a historical job that has no live counterpart', async () => {
+    const other = completedJob({ id: 'job-11111111-2222-3333-4444-555555555555' });
+    const { result } = renderHook(() =>
+      useActivityFeed([completedJob(), other], { 'scrape.run': 'Scrape' })
+    );
+
+    await act(async () => {
+      jobEvents.handler?.({ type: 'job.completed', jobId: JOB_ID, ts: 1_700_000_001_500 });
+    });
+
+    await waitFor(() => expect(result.current.liveActivity).toHaveLength(1));
+    // One live row for JOB_ID + the untouched historical row for the other job.
+    expect(result.current.activity).toHaveLength(2);
+    expect(result.current.activity.map((a) => a.id)).toEqual([`${JOB_ID}-1700000001500`, other.id]);
+  });
+});

--- a/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.ts
+++ b/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.ts
@@ -53,7 +53,17 @@ export function useActivityFeed(allJobs: JobRecord[], kindLabelMap: Record<strin
 
   // Merge live (top) with historical (deduped)
   const activity = useMemo(() => {
-    const liveJobIds = new Set(liveActivity.map((a) => a.id.split('-')[0]));
+    // A live item's id is `${event.jobId}-${event.ts}` and a job id is itself
+    // `job-<uuid>`, so `split('-')[0]` was ALWAYS the literal "job": the set held
+    // one useless entry, no historical id ever matched it, and every completed
+    // job rendered twice (different React keys, so nothing else caught it).
+    // Strip only the trailing `-<ts>` to recover the real job id.
+    const liveJobIds = new Set(
+      liveActivity.map((a) => {
+        const cut = a.id.lastIndexOf('-');
+        return cut > 0 ? a.id.slice(0, cut) : a.id;
+      })
+    );
     return [...liveActivity, ...historicalActivity.filter((a) => !liveJobIds.has(a.id))].slice(
       0,
       40


### PR DESCRIPTION
## Summary

The Activity feed's live/historical dedup keyed on `a.id.split('-')[0]`, which is always the literal `"job"` — so nothing was ever deduped and every completed job rendered twice. Fixes #797.

## Type of change

- [x] `fix` — Bug fix

## Changes

- Recover the real job id by stripping only the trailing `-<ts>`:
  ```diff
  -const liveJobIds = new Set(liveActivity.map((a) => a.id.split('-')[0]));
  +const liveJobIds = new Set(
  +  liveActivity.map((a) => {
  +    const cut = a.id.lastIndexOf('-');
  +    return cut > 0 ? a.id.slice(0, cut) : a.id;
  +  })
  +);
  ```
  A job id is itself hyphenated (`format!("job-{}", Uuid::new_v4())`, `db.rs:144`) and the live item's id is `` `${event.jobId}-${event.ts}` ``, so splitting on the first `-` yielded `"job"` for every entry — a one-element set no historical id could match.
- New `useActivityFeed.test.ts` covering both directions: a job with a live counterpart is listed once, and a job without one is still kept.

## Testing

- [x] `pnpm exec vitest run src/renderer/features/monitoring/hooks/useActivityFeed.test.ts` — 2 passed, 0 failed.
- [x] `pnpm exec eslint` / `prettier` on the changed files — clean.
- [x] Added tests for new logic.

With the fix reverted, both fail:

```
× lists a just-completed job once, not twice
   AssertionError: expected [ … ] to have a length of 1 but got 2
× keeps a historical job that has no live counterpart
   AssertionError: expected [ … ] to have a length of 2 but got 3
```

**Note on `pnpm typecheck`:** not runnable here — on a fresh clone `apps/desktop` fails typecheck because `routeTree.gen.ts` doesn't exist until the router plugin has run. Pre-existing on `main` and unrelated to this change.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
