### PR TITLE
fix(extension): anchor the collision-prone denylist terms

### DIFF
--- a/apps/extension/src/lib/field-signal.test.ts
+++ b/apps/extension/src/lib/field-signal.test.ts
@@ -12,7 +12,54 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { matchNamedKey } from './field-signal';
+import { isAmbiguousSignal, matchNamedKey } from './field-signal';
+
+describe('isAmbiguousSignal', () => {
+  it('still skips the genuinely ambiguous / sensitive fields', () => {
+    for (const signal of [
+      'referral source',
+      'referrer',
+      'job_referral',
+      'professional references',
+      'reference_name',
+      'site search',
+      'job_search',
+      'emergency contact',
+      'confirm password',
+      'company name',
+      'recruiter',
+      'ssn',
+      'passport number',
+      // \b-anchored short terms, unchanged
+      'dni',
+      "contact d'urgence",
+    ]) {
+      expect(isAmbiguousSignal(signal), signal).toBe(true);
+    }
+  });
+
+  it('does not skip a field that merely CONTAINS a denylist term', () => {
+    // `referr` ⊂ "preferred", `search` ⊂ "research", `reference` ⊂ "preferences".
+    // These were skipped entirely — never filled AND never captured.
+    for (const signal of [
+      'preferred first name',
+      'preferred name',
+      'preferred pronouns',
+      'research experience',
+      'research interests',
+      'work preferences',
+      'notification preferences',
+    ]) {
+      expect(isAmbiguousSignal(signal), signal).toBe(false);
+    }
+  });
+
+  it('lets a freed-up field resolve to its real key', () => {
+    // "Preferred first name" is ubiquitous on ATS forms; once it is no longer
+    // treated as ambiguous it fills as a first name.
+    expect(matchNamedKey('preferred first name')).toBe('firstName');
+  });
+});
 
 describe('matchNamedKey — phone', () => {
   it('matches real phone fields, including the separator-less compounds', () => {

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -32,9 +32,6 @@
  * bank/IBAN, visa status).
  */
 const AMBIGUOUS = [
-  'referr',
-  'referral',
-  'reference',
   'emergency',
   'confirm',
   'manager',
@@ -46,7 +43,6 @@ const AMBIGUOUS = [
   'organization',
   'organisation',
   'recruiter',
-  'search',
   'username',
   'user name',
   'password',
@@ -134,14 +130,37 @@ const AMBIGUOUS = [
 const AMBIGUOUS_WORDS = /\b(?:dni|bsn|urgence)\b/;
 
 /**
+ * Denylist terms that must not match INSIDE a longer word, anchored on their
+ * LEADING side only.
+ *
+ * As plain substrings these silently skipped extremely common fields:
+ * `referr` ⊂ "**preferr**ed" (→ "Preferred first name", "Preferred pronouns"),
+ * `search` ⊂ "re**search**" (→ "Research experience"), and `reference` ⊂
+ * "p**reference**s" (→ "Work preferences"). Skipping is doubly costly here: such
+ * a field is neither filled by autofill NOR captured by answers-capture, so the
+ * answer is lost rather than merely deferred.
+ *
+ * Only the leading side is anchored, for the same two reasons as
+ * {@link NAMED_KEY_PATTERNS}: `_` is a regex word character, so `\b` would stop
+ * matching `job_search` / `reference_name`, and the trailing side must stay open
+ * for `referral`, `referrer`, `references` and `searchTerm`.
+ */
+const AMBIGUOUS_PREFIXED = /(?:^|[^a-z])(?:referr|reference|search)/;
+
+/**
  * True when a field's {@link textSignal} is ambiguous or sensitive and must be
  * SKIPPED by both autofill ({@link textSignal} → `isCandidateField`) and
  * answers-capture (`isCapturable`). Combines the plain-substring {@link AMBIGUOUS}
- * denylist with the word-anchored {@link AMBIGUOUS_WORDS} one, so the two
- * consumers can never disagree on what counts as ambiguous.
+ * denylist with the word-anchored {@link AMBIGUOUS_WORDS} and the
+ * leading-anchored {@link AMBIGUOUS_PREFIXED} ones, so the two consumers can
+ * never disagree on what counts as ambiguous.
  */
 export function isAmbiguousSignal(signal: string): boolean {
-  return AMBIGUOUS.some((w) => signal.includes(w)) || AMBIGUOUS_WORDS.test(signal);
+  return (
+    AMBIGUOUS.some((w) => signal.includes(w)) ||
+    AMBIGUOUS_WORDS.test(signal) ||
+    AMBIGUOUS_PREFIXED.test(signal)
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

`referr`, `reference` and `search` were plain-substring denylist entries, so "Preferred first name", "Research experience" and "Work preferences" were treated as ambiguous — neither filled nor captured. Fixes #804.

## Type of change

- [x] `fix` — Bug fix

## Changes

- Moved the three collision-prone terms out of `AMBIGUOUS` into a new leading-anchored `AMBIGUOUS_PREFIXED = /(?:^|[^a-z])(?:referr|reference|search)/`, and folded it into `isAmbiguousSignal`.
- `referral` is dropped from the list as redundant — the `referr` alternative already covers it.

**Why leading-anchored only**, same two reasons as the identity patterns in #784:
- `_` is a regex word character, so `\breferr` / `\bsearch` would stop matching `job_search`, `reference_name`, `job_referral`;
- the trailing side must stay open for `referral`, `referrer`, `references`, `searchTerm`.

**Why this one bites harder than a normal under-fill:** `isAmbiguousSignal` gates *both* consumers — autofill's `isCandidateField` and answers-capture's `isCapturable` — so the field is skipped **and** the user's typed answer is never learned. "Preferred first name" is close to universal on ATS forms.

I also checked the rest of the list for the same class and deliberately left it alone: `company` ⊂ "accompany", `parent` ⊂ "apparent", `tax` ⊂ "syntax"/"taxonomy" are all real substring hits, but none is a plausible job-application field label, so anchoring them would be churn without benefit. Happy to include them if you'd rather have the list uniformly anchored.

## Testing

- [x] `pnpm exec vitest run src/lib/` — **272 passed**, 0 failed (10 files, incl. `autofill` and `answers-capture`, the two consumers).
- [x] `pnpm --filter @ajh/extension typecheck` — clean.
- [x] `pnpm exec eslint` / `prettier --check` on the changed files — clean.
- [x] Added tests for new logic — both directions: 16 signals that must still be skipped (including the `\b`-anchored `dni` / `contact d'urgence`, unchanged) and 7 that must not be.

With the fix reverted:

```
× does not skip a field that merely CONTAINS a denylist term
AssertionError: preferred first name: expected true to be false
```

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (the new const is private, documented inline)
