### PR TITLE
fix(monitoring): gate the running pulse on a stable id, not a translated label

### DIFF
--- a/apps/desktop/src/renderer/features/monitoring/components/MonitoringPage/index.tsx
+++ b/apps/desktop/src/renderer/features/monitoring/components/MonitoringPage/index.tsx
@@ -39,8 +39,11 @@ export function MonitoringPage() {
 
   const last24h = useMemo(() => binLast24Hours(allJobs, Date.now()), [allJobs]);
 
+  // `id` is the stable identity: `label` is translated, so branching on it (as
+  // the pulse below used to) only ever holds in English.
   const metrics = [
     {
+      id: 'completed',
       label: t('monitoring.metrics.completed'),
       value: counters.completed,
       icon: CheckCircle2,
@@ -48,6 +51,7 @@ export function MonitoringPage() {
       bg: 'bg-emerald-500/10',
     },
     {
+      id: 'running',
       label: t('monitoring.metrics.running'),
       value: counters.running,
       icon: Loader2,
@@ -55,6 +59,7 @@ export function MonitoringPage() {
       bg: 'bg-blue-500/10',
     },
     {
+      id: 'failed',
       label: t('monitoring.metrics.failed'),
       value: counters.failed,
       icon: XCircle,
@@ -62,6 +67,7 @@ export function MonitoringPage() {
       bg: 'bg-amber-500/10',
     },
     {
+      id: 'successRate',
       label: t('monitoring.metrics.successRate'),
       value: `${successRate}%`,
       icon: Zap,
@@ -94,15 +100,15 @@ export function MonitoringPage() {
         />
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-          {metrics.map(({ label, value, icon: Icon, color, bg }) => (
+          {metrics.map(({ id, label, value, icon: Icon, color, bg }) => (
             <MetricCard
-              key={label}
+              key={id}
               label={label}
               value={value}
               icon={Icon}
               color={color}
               bg={bg}
-              animate={label === 'Running' && counters.running > 0}
+              animate={id === 'running' && counters.running > 0}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

The Running metric's pulse was gated on `label === 'Running'`, where `label` is the **translated** string — so it only ever animated in English. Fixes #806.

## Type of change

- [x] `fix` — Bug fix

## Changes

- Each metric now carries a stable `id` (`completed` / `running` / `failed` / `successRate`).
- `animate` gates on `id === 'running'`, and the list `key` moved from the translated `label` to `id` — same underlying problem, keying a list on translated text.

Concretely, `monitoring.metrics.running` is `"Running"` in `en` but `"Läuft"` in `de`, so the comparison was false for every non-English UI while jobs were actually running.

## Testing

- [x] `pnpm exec vitest run src/renderer/features/monitoring/` — 8 passed, 0 failed.
- [x] `pnpm exec eslint` / `prettier --check` on the changed file — clean.
- [ ] Added tests for new logic — see below.

**No new test, deliberately.** `CONTRIBUTING.md` § Testing lists UI components under *"Skip"*, and `vitest.config.ts` excludes `renderer/features/**` from coverage as *"presentational composition … covered by the Playwright E2E suite"*. Driving `MonitoringPage` in a unit test would mean standing up the router, query client, i18n and four service hooks to assert one boolean prop. Happy to add it if you'd rather have the coverage.

**Note on `pnpm typecheck`:** not runnable here — on a fresh clone `apps/desktop` fails typecheck because `routeTree.gen.ts` doesn't exist until the router plugin has run. Pre-existing on `main`, unrelated to this change.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
