### PR TITLE
fix(prompts): only flag a language mismatch when both languages are known

### DIFF
--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -1377,4 +1377,30 @@ describe('validateMetadata', () => {
     expect(meta?.jobCountry).toBe('');
     expect(meta?.jobLocation).toBe('');
   });
+
+  it('does not flag a mismatch when a language is unknown', () => {
+    // `??` is nullish-only and there was no 'unknown' guard, so an undetected
+    // side raised a spurious "rewrite entirely / do not translate" instruction.
+    // Matches analyze/validate.ts and @ajh/shared's detectLanguages, which both
+    // require BOTH sides to be known.
+    const meta = validateMetadata('{"resumeLanguage":"en","jobAdLanguage":"unknown"}');
+    expect(meta?.mismatch).toBe(false);
+    expect(
+      validateMetadata('{"resumeLanguage":"unknown","jobAdLanguage":"unknown"}')?.mismatch
+    ).toBe(false);
+  });
+
+  it('does not flag a mismatch on an empty-string language', () => {
+    // The model answers with "" rather than omitting the key, and `'' ?? 'en'`
+    // is `''` — so `'' !== 'en'` used to read as a mismatch.
+    const meta = validateMetadata('{"resumeLanguage":"","jobAdLanguage":"en"}');
+    expect(meta?.resumeLanguage).toBe('en');
+    expect(meta?.mismatch).toBe(false);
+  });
+
+  it('still flags a real mismatch between two known languages', () => {
+    const meta = validateMetadata('{"resumeLanguage":"en","jobAdLanguage":"de"}');
+    expect(meta?.mismatch).toBe(true);
+    expect(meta?.targetLanguage).toBe('de');
+  });
 });

--- a/packages/prompts/src/generate/metadata/metadata.ts
+++ b/packages/prompts/src/generate/metadata/metadata.ts
@@ -46,18 +46,35 @@ Return ONLY the JSON object.`,
   };
 }
 
+/** A model-supplied language code, coerced to the `'en'` default. `??` alone is
+ *  not enough: the model routinely answers with an EMPTY STRING rather than
+ *  omitting the key, and `'' ?? 'en'` is `''`. */
+function toLanguage(v: unknown): string {
+  return typeof v === 'string' && v.trim() !== '' ? v.trim() : 'en';
+}
+
 export function validateMetadata(raw: string): GenerationMeta | null {
   try {
     const jsonStr = raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1);
     const parsed = JSON.parse(jsonStr);
+    // Coerce FIRST, then decide `mismatch` from the coerced values — the same
+    // order `analyze/validate.ts` and `@ajh/shared`'s `detectLanguages` use.
+    const resumeLanguage = toLanguage(parsed.resumeLanguage);
+    const jobAdLanguage = toLanguage(parsed.jobAdLanguage);
     return {
       candidateName: parsed.candidateName ?? '',
       jobTitle: parsed.jobTitle ?? '',
       companyName: parsed.companyName ?? '',
-      resumeLanguage: parsed.resumeLanguage ?? 'en',
-      jobAdLanguage: parsed.jobAdLanguage ?? 'en',
-      mismatch: (parsed.resumeLanguage ?? 'en') !== (parsed.jobAdLanguage ?? 'en'),
-      targetLanguage: parsed.jobAdLanguage ?? parsed.resumeLanguage ?? 'en',
+      resumeLanguage,
+      jobAdLanguage,
+      // Only a mismatch when BOTH sides are known and actually differ. Without
+      // the `'unknown'` guard, an undetected side raised a spurious
+      // "rewrite entirely / do not translate" instruction in the prompt.
+      mismatch:
+        resumeLanguage !== 'unknown' &&
+        jobAdLanguage !== 'unknown' &&
+        resumeLanguage !== jobAdLanguage,
+      targetLanguage: jobAdLanguage,
       topRequirements: Array.isArray(parsed.topRequirements) ? parsed.topRequirements : [],
       jobLocation: typeof parsed.jobLocation === 'string' ? parsed.jobLocation : '',
       // Normalize to an upper-case 2-letter code; drop anything that isn't one.


### PR DESCRIPTION
## Summary

`validateMetadata` reported a language mismatch when a language was `'unknown'` or an empty string, putting a spurious "different languages — rewrite entirely" instruction into the generation prompt. Fixes #808.

## Type of change

- [x] `fix` — Bug fix

## Changes

- New `toLanguage()` coercion: a non-blank string wins, anything else falls back to `'en'` — so an empty string now behaves like a missing key already did (`'' ?? 'en'` is `''`, which is what let it through).
- `mismatch` now requires **both** sides known and different, matching `analyze/validate.ts:126` and `@ajh/shared`'s `detectLanguages:147`. `validateMetadata` was the only one of the three without the guard.
- `targetLanguage` now uses the coerced `jobAdLanguage`, so a blank one resolves to `'en'` instead of `''`. Same bug class, one line away; behaviour for present values is unchanged.

## Testing

- [x] `pnpm exec vitest run` in `packages/prompts` — **519 passed**, 0 failed (15 files).
- [x] `pnpm --filter @ajh/prompts typecheck` — clean.
- [x] `pnpm exec eslint` / `prettier` — clean.
- [x] Added tests for new logic — unknown side, both-unknown, empty-string, and a real `en`/`de` mismatch that must still be flagged.

With the fix reverted:

```
× does not flag a mismatch when a language is unknown   → expected true to be false
× does not flag a mismatch on an empty-string language  → expected '' to be 'en'
```

The pre-existing `parses well-formed JSON and applies defaults` test — which asserts `mismatch: true` for a `de` ad against the defaulted `en` résumé — still passes, so the real-mismatch path is untouched.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (the helper is private, documented inline)
