### PR TITLE
fix(applications): read the row inside set_status's transaction

### DIFF
--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -739,8 +739,16 @@ impl ApplicationStore {
     /// Transition an Application's status, appending one history event and bumping
     /// `updated_at`. Sets `applied_at` the first time it leaves `saved`.
     pub fn set_status(&self, id: &str, to: ApplicationStatus, note: &str) -> AppResult<()> {
-        let existing = self
-            .get(id)
+        // The READ joins the same transaction as the two writes. The row UPDATE
+        // and its append-only status event must land together or not at all —
+        // otherwise a crash between them leaves the status changed with no
+        // history row — and reading through a separately-released lock let a
+        // concurrent transition land in the gap, so `from_status` below recorded
+        // a status this row no longer had. `.transaction()` needs
+        // `&mut Connection`, so call on `&mut *guard`.
+        let mut guard = self.conn.lock();
+        let tx = guard.transaction()?;
+        let existing = Self::row_by_id_conn(&tx, id)?
             .ok_or_else(|| AppError::Validation(format!("application not found: {id}")))?;
         let now = now_ms();
         let applied_at = if existing.applied_at.is_none() && !to.is_pre_apply() {
@@ -748,12 +756,6 @@ impl ApplicationStore {
         } else {
             existing.applied_at
         };
-        // The row UPDATE and its append-only status event must land together or
-        // not at all — otherwise a crash between them leaves the status changed
-        // with no history row (or vice-versa). One transaction; `.transaction()`
-        // needs `&mut Connection`, so call on `&mut *guard`.
-        let mut guard = self.conn.lock();
-        let tx = guard.transaction()?;
         tx.execute(
             "UPDATE applications SET status = ?2, applied_at = ?3, updated_at = ?4 WHERE id = ?1",
             params![id, to.as_id(), applied_at.map(ts_to_db), ts_to_db(now)],

--- a/apps/desktop/src-tauri/src/applications/test.rs
+++ b/apps/desktop/src-tauri/src/applications/test.rs
@@ -2661,6 +2661,73 @@ fn upsert_and_merge_answers_race_never_loses_an_update() {
     );
 }
 
+/// `set_status` read the row through a lock it then RELEASED before opening the
+/// write transaction, so a concurrent transition could land in the gap and the
+/// `status_events` row it appended recorded a `from_status` the row no longer
+/// had — a history chain that never happened.
+///
+/// Two threads drive the same Application between two statuses. Ordered by
+/// `rowid` (insert order under the shared connection, so commit order), the
+/// events must form an unbroken chain: each `from_status` is the previous
+/// event's `to_status`. `at` is millisecond-resolution and ties freely, which is
+/// why this reads `rowid` directly rather than going through `events()`.
+#[test]
+fn set_status_records_a_consistent_history_chain_under_contention() {
+    let dir = TempDir::new().unwrap();
+    let store = std::sync::Arc::new(ApplicationStore::open(dir.path()).unwrap());
+    let id = store
+        .upsert_for_origin(
+            "https://acme.com/job/status-race",
+            "linkedin",
+            &meta("Acme", "Engineer"),
+            ApplicationOrigin::Saved,
+            None,
+        )
+        .unwrap();
+
+    const ITERS: usize = 60;
+
+    let threads: Vec<_> = [ApplicationStatus::Applied, ApplicationStatus::Saved]
+        .into_iter()
+        .map(|to| {
+            let store = store.clone();
+            let id = id.clone();
+            std::thread::spawn(move || {
+                for _ in 0..ITERS {
+                    store.set_status(&id, to, "").unwrap();
+                }
+            })
+        })
+        .collect();
+    for t in threads {
+        t.join().unwrap();
+    }
+
+    let conn = store.conn.lock();
+    let mut stmt = conn
+        .prepare(
+            "SELECT from_status, to_status FROM status_events
+             WHERE application_id = ?1 ORDER BY rowid",
+        )
+        .unwrap();
+    let events: Vec<(String, String)> = stmt
+        .query_map(params![id], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+
+    assert!(events.len() >= ITERS, "expected every transition to record");
+    for (i, (from, _to)) in events.iter().enumerate().skip(1) {
+        assert_eq!(
+            from,
+            &events[i - 1].1,
+            "event {i} records from_status {from:?}, but the previous event moved the row to {:?} \
+             — the read happened outside the write's transaction",
+            events[i - 1].1
+        );
+    }
+}
+
 /// `update_fields` carried the SAME two-lock structure `upsert_internal` was
 /// fixed for: `get` took and released the mutex, then the write retook it and
 /// re-persisted EVERY column from the now-stale snapshot. A concurrent


### PR DESCRIPTION
## Summary

`set_status` read the row through a lock it released before opening its write transaction, so a concurrent transition landing in the gap made it append a `status_events` row with a `from_status` the row no longer had. Fixes #810.

## Type of change

- [x] `fix` — Bug fix

## Changes

- The read now joins the **existing** transaction, via the conn-scoped `row_by_id_conn` instead of the self-locking `get`. The transaction was already there for the two writes; the read was simply outside it.
- Comment updated to say why the read belongs inside.
- New race test `set_status_records_a_consistent_history_chain_under_contention`.

**Scope, explicitly:** this makes the recorded history correct and the read+write atomic. It does **not** turn `set_status` into a compare-and-set — an unconditional setter is its contract, and `transition_status_if` already covers callers that need CAS (its doc comment even names this hazard).

**On `applications/mod.rs` and the R8 cap:** the file is 1395 LOC on `main` against a 1400 hard cap, so I kept this deliberately tight — net **+2 LOC (1397)**. (I tripped R8 with an earlier PR and would rather not repeat it.)

## Testing

- [x] `cargo test --lib` — **2705 passed**, 0 failed
- [x] `cargo test --test architecture` — **11 passed** (R8 included)
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added tests for new logic

The test drives two threads between `applied` and `saved`, then walks `status_events` **ordered by `rowid`** — insert order under the shared connection, so commit order — and asserts each `from_status` equals the previous event's `to_status`. It reads `rowid` directly rather than going through `events()` because `at` is millisecond-resolution and ties freely, which would make the ordering (and therefore the assertion) ambiguous.

Against `main`'s `set_status` it fails **3 of 3** runs:

```
assertion failed: event 9 records from_status "saved", but the previous event moved the row to "applied"
```

With the fix it passed **5/5** consecutive runs.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
