### PR TITLE
fix(autopilot): key the ai-notes skip on the merge's canonical key

### DIFF
--- a/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
@@ -453,8 +453,8 @@ impl NoteEnv for LiveNoteEnv<'_> {
     }
 }
 
-/// The pure(ish) notes loop: for each job whose `url` is genuinely new (∉
-/// `prior_urls`), request one note through `env`, honoring — every iteration — the
+/// The pure(ish) notes loop: for each job whose merge key is genuinely new (∉
+/// `prior_keys`), request one note through `env`, honoring — every iteration — the
 /// top-N call ceiling, the run's cancellation token, and the shared daily-ceiling
 /// charge. Split from [`generate_assistant_notes`] (mirroring
 /// `agent::controller::run_agent`'s split from its `AgentEnv`) so a fake `env`
@@ -468,7 +468,7 @@ async fn run_notes_loop(
     env: &dyn NoteEnv,
     resume_fence: &str,
     found_jobs: &mut [FoundJob],
-    prior_urls: &HashSet<&str>,
+    prior_keys: &HashSet<String>,
     cancel: &CancellationToken,
 ) -> usize {
     // `calls` bounds *provider calls* (the real cost) to ≤ ASSISTANT_NOTES_MAX,
@@ -479,7 +479,12 @@ async fn run_notes_loop(
         if calls >= ASSISTANT_NOTES_MAX {
             break; // top-N call ceiling reached — hard cost bound
         }
-        if prior_urls.contains(job.url.as_str()) {
+        // Key on the merge's own identity (`canonical_job_key`): comparing raw URLs
+        // re-paid for a job re-surfacing under new tracking params, and the merge
+        // then discarded the note.
+        let key =
+            crate::scraping::boards::common::canonical_job_key(&job.url, &job.title, &job.company);
+        if prior_keys.contains(&key) {
             continue; // re-surfaced: keeps its prior note via merge, don't re-pay
         }
         if cancel.is_cancelled() {
@@ -532,8 +537,8 @@ async fn run_notes_loop(
 /// Write, no agent loop, no confirm gate. Cost is triple-bounded — the top-N *call*
 /// ceiling, the shared per-provider daily charge (stop on exceed; the discovery run
 /// still completes), and the run's cancellation token (stop immediately, even
-/// mid-call — see [`run_notes_loop`]). Only genuinely-new matches (`url` ∉
-/// `prior_urls`) are annotated: a re-surfaced job keeps its earlier note for free
+/// mid-call — see [`run_notes_loop`]). Only genuinely-new matches (whose
+/// `canonical_job_key` ∉ `prior_keys`) are annotated: a re-surfaced job keeps its earlier note for free
 /// via the store merge, so re-generating would just burn a call whose result the
 /// merge discards — in steady state (nothing new) this makes ZERO provider calls.
 /// `completer` is `None` when the caller's [`Completer::from_active`] found no
@@ -549,7 +554,7 @@ pub(crate) async fn generate_assistant_notes(
     limiter: Arc<Limiter>,
     autopilot: &Autopilot,
     found_jobs: &mut [FoundJob],
-    prior_urls: &HashSet<&str>,
+    prior_keys: &HashSet<String>,
     cancel: &CancellationToken,
 ) -> usize {
     if !notes_enabled(autopilot.assistant, autopilot.resume_text.as_deref()) {
@@ -579,7 +584,7 @@ pub(crate) async fn generate_assistant_notes(
     // cosmetic tradeoff for a notification that is never blocked unboundedly.
     match tokio::time::timeout(
         NOTES_STEP_TIMEOUT,
-        run_notes_loop(&env, &resume_fence, found_jobs, prior_urls, cancel),
+        run_notes_loop(&env, &resume_fence, found_jobs, prior_keys, cancel),
     )
     .await
     {
@@ -1167,7 +1172,7 @@ mod tests {
         let mut jobs: Vec<FoundJob> = (0..5)
             .map(|i| stub_job(&format!("https://acme.example/{i}")))
             .collect();
-        let prior: HashSet<&str> = HashSet::new();
+        let prior: HashSet<String> = HashSet::new();
         let generated = run_notes_loop(
             &env,
             "<candidate_resume>\nr\n</candidate_resume>",
@@ -1187,16 +1192,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn jobs_all_in_prior_urls_make_zero_calls() {
+    async fn jobs_already_seen_make_zero_calls_even_under_new_tracking_params() {
         // Every match already surfaced in a prior run → the merge preserves its
         // earlier note for free; re-generating would just burn a call for nothing.
         let env = FakeNoteEnv::ok("note");
+        // Re-surfaced under new tracking params: same job to the merge.
         let mut jobs = vec![
-            stub_job("https://acme.example/1"),
-            stub_job("https://acme.example/2"),
+            stub_job("https://acme.example/1?utm_source=indeed"),
+            stub_job("https://acme.example/2#apply"),
         ];
-        let prior: HashSet<&str> = ["https://acme.example/1", "https://acme.example/2"]
+        let prior: HashSet<String> = ["https://acme.example/1", "https://acme.example/2"]
             .into_iter()
+            .map(|u| crate::scraping::boards::common::canonical_job_key(u, "Engineer", "Acme"))
             .collect();
         let generated = run_notes_loop(
             &env,
@@ -1225,7 +1232,7 @@ mod tests {
             stub_job("https://acme.example/2"),
             stub_job("https://acme.example/3"),
         ];
-        let prior: HashSet<&str> = HashSet::new();
+        let prior: HashSet<String> = HashSet::new();
         let generated = run_notes_loop(
             &env,
             "<candidate_resume>\nr\n</candidate_resume>",
@@ -1272,7 +1279,7 @@ mod tests {
         }
 
         let mut jobs = vec![stub_job("https://acme.example/1")];
-        let prior: HashSet<&str> = HashSet::new();
+        let prior: HashSet<String> = HashSet::new();
         let cancel = CancellationToken::new();
         let cancel_task = cancel.clone();
         tokio::spawn(async move {

--- a/apps/desktop/src-tauri/src/commands/autopilot.rs
+++ b/apps/desktop/src-tauri/src/commands/autopilot.rs
@@ -372,16 +372,20 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
     // short AI-reasoned note to the top NEW matches. Bounded (≤ ASSISTANT_NOTES_MAX
     // provider calls, per-provider daily ceiling, cancellable mid-call, AND an
     // overall wall-clock timeout — see `generate_assistant_notes`) and best-effort —
-    // a provider/config error just means no notes, never a failed run. `prior_urls`
+    // a provider/config error just means no notes, never a failed run. `prior_keys`
     // (this record's pre-run found jobs) lets the step skip re-surfaced jobs, whose
     // notes the store merge preserves for free, so a steady-state run makes zero
     // provider calls. No-op unless `autopilot.assistant` is set. Runs BEFORE
     // `record_run`/`on_new_jobs` below, so the wall-clock timeout is what keeps a
     // hung provider from delaying the user-facing "new jobs" notification.
-    let prior_urls: std::collections::HashSet<&str> = autopilot
+    // Keyed on `canonical_job_key` — the SAME identity `merge_found_jobs` uses —
+    // not the raw URL. A job that re-surfaces under different tracking params is
+    // the same job to the merge, so keying on the raw URL paid for a note the
+    // merge then discarded, every single run.
+    let prior_keys: std::collections::HashSet<String> = autopilot
         .found_jobs
         .iter()
-        .map(|j| j.url.as_str())
+        .map(|j| crate::scraping::boards::common::canonical_job_key(&j.url, &j.title, &j.company))
         .collect();
 
     // Resolve the active provider from the BACKEND-OWNED store (task #16) through
@@ -419,7 +423,7 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
         limiter,
         &autopilot,
         &mut found_jobs,
-        &prior_urls,
+        &prior_keys,
         &cancel_token,
     )
     .await;


### PR DESCRIPTION
## Summary

The AI-notes skip set was built from raw URLs while the store merge keys on `canonical_job_key`, so a job re-surfacing under new tracking params was paid for and then discarded — every run. Fixes #812.

## Type of change

- [x] `fix` — Bug fix

## Changes

- `prior_urls: &HashSet<&str>` → `prior_keys: &HashSet<String>`, built and compared with `canonical_job_key(url, title, company)` — the identity `merge_key` / `merge_found_jobs` already use.
- Threaded through `generate_assistant_notes` → `run_notes_loop`; doc comments updated to say "merge key" rather than "url".
- The existing `jobs_all_in_prior_urls_make_zero_calls` test is renamed and strengthened: the two already-seen jobs now re-surface **with tracking params** (`?utm_source=indeed`, `#apply`), which is the case that was broken.

This closes the gap the skip's own comment describes — *"in steady state (nothing new) this makes ZERO provider calls"* — which raw-URL comparison could not deliver, since aggregators append varying `utm_*` params.

**On `autopilot_helpers/mod.rs` and the R8 cap:** the file is 1392 LOC on `main` against the 1400 hard cap. My first draft landed at 1403 and R8 caught it locally, so the comments and the test fixture are written tight — final is **1399**.

## Testing

- [x] `cargo test --lib` — **2704 passed**, 0 failed
- [x] `cargo test --test architecture` — **11 passed** (R8 included)
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added tests for new logic (strengthened the existing one)

Reverting just the comparison to the raw URL, keeping the test:

```
assertion `left == right` failed
  left: 2
 right: 0
```

— i.e. two provider calls charged for jobs the merge would have collapsed.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
