### PR TITLE
fix(ai-generations): key the per-job aggregate on the normalized url

### DIFF
--- a/apps/desktop/src-tauri/src/ai_generations/mod.rs
+++ b/apps/desktop/src-tauri/src/ai_generations/mod.rs
@@ -308,8 +308,20 @@ impl AiGenerationStore {
     /// résumé, cover letter, answers, and brief from separate user actions land on
     /// one record; otherwise insert a fresh row (manual generations with no link).
     /// Returns the id of the affected row.
-    pub fn save_application(&self, incoming: AiGenerationRecord) -> AppResult<String> {
-        if let Some(existing) = self.find_by_job_url(&incoming.job_url) {
+    pub fn save_application(&self, mut incoming: AiGenerationRecord) -> AppResult<String> {
+        // Key the aggregate on the NORMALIZED url — the identity `ApplicationStore`
+        // already dedupes on. Matching the raw url split the same job into two
+        // "one-per-job" rows as soon as it was reached under different tracking
+        // params, which is the norm on query-id boards like Indeed.
+        let normalized = crate::applications::normalize_job_url(&incoming.job_url);
+        let raw = std::mem::replace(&mut incoming.job_url, normalized);
+        let mut found = self.find_by_job_url(&incoming.job_url);
+        // A row written before this normalization still carries its raw url; match
+        // it too, and the write below migrates it onto the normalized key.
+        if found.is_none() && !incoming.job_url.is_empty() && raw != incoming.job_url {
+            found = self.find_by_job_url(&raw);
+        }
+        if let Some(existing) = found {
             let merged = merge_application(existing, incoming);
             let id = merged.id.clone();
             self.update(&merged)?;

--- a/apps/desktop/src-tauri/src/ai_generations/test.rs
+++ b/apps/desktop/src-tauri/src/ai_generations/test.rs
@@ -195,6 +195,59 @@ fn save_application_upserts_by_job_url_into_one_aggregate() {
     assert_eq!(list[0].application_answers, vec![answer("why-company")]);
 }
 
+/// The aggregate is "one row per job", but it used to key on the RAW url, so the
+/// same job reached under different tracking params (the norm on query-id boards
+/// like Indeed) missed its own row and split into a second aggregate.
+#[test]
+fn save_application_merges_the_same_job_across_tracking_params() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+
+    store
+        .save_application(record("g1", "https://acme.com/job/1?utm_source=indeed"))
+        .unwrap();
+    let mut second = record("g2", "https://acme.com/job/1#apply");
+    second.resume_text = String::new();
+    second.cover_letter_text = String::new();
+    second.application_answers = vec![answer("why-company")];
+    store.save_application(second).unwrap();
+
+    let list = store.list();
+    assert_eq!(list.len(), 1, "one aggregate row per job");
+    assert_eq!(list[0].id, "g1", "merged into the first row");
+    assert_eq!(list[0].cover_letter_text, "C", "cover preserved");
+    assert_eq!(list[0].application_answers, vec![answer("why-company")]);
+    assert_eq!(
+        list[0].job_url, "https://acme.com/job/1",
+        "the aggregate is keyed on the normalized url"
+    );
+}
+
+/// A row written before the normalization carries its raw url; a later save must
+/// still find it (and migrate it onto the normalized key) rather than fork.
+#[test]
+fn save_application_still_merges_a_legacy_raw_url_row() {
+    let dir = TempDir::new().unwrap();
+    let store = AiGenerationStore::open(&dir.path().to_path_buf()).unwrap();
+
+    // Written directly, bypassing save_application's normalization.
+    store
+        .insert(&record("legacy", "https://acme.com/job/2?utm_source=old"))
+        .unwrap();
+
+    let mut incoming = record("g2", "https://acme.com/job/2?utm_source=old");
+    incoming.application_answers = vec![answer("why-company")];
+    store.save_application(incoming).unwrap();
+
+    let list = store.list();
+    assert_eq!(list.len(), 1, "must merge, not fork off the legacy row");
+    assert_eq!(list[0].id, "legacy");
+    assert_eq!(
+        list[0].job_url, "https://acme.com/job/2",
+        "the legacy row is migrated onto the normalized key"
+    );
+}
+
 #[test]
 fn save_application_inserts_separate_rows_when_unlinked() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

The per-job generation aggregate keyed on the **raw** `job_url`, so the same job reached under different tracking params split into two rows. Fixes #815.

## Type of change

- [x] `fix` — Bug fix

## Changes

- `save_application` normalizes `incoming.job_url` through `applications::normalize_job_url` before the lookup **and** before the write, so the stored key is the same identity `ApplicationStore` dedupes on.
- **Legacy rows are migrated, not orphaned:** if the normalized lookup misses, it falls back to the raw url. A row written before this change is then merged and rewritten onto the normalized key (`merge_application` takes the incoming `job_url`, which is now normalized). Guarded so an unusable url (`normalize_job_url` → `""`) can't accidentally merge into an unrelated legacy row.

Closes the raw-vs-normalized split the codebase already documents at `commands/ai_generations.rs:84-86` — *"which never matches for query-id boards like Indeed"*.

**Blast radius check:** `AiGenerationStore::applied_job_urls()` returns these stored urls, so normalizing them could in principle move a consumer's goalposts. It has no production consumer — the `applied` flag in `commands/autopilot.rs:71` comes from `ApplicationStore::applied_job_urls()`, which is already normalized. So nothing downstream changes shape.

## Testing

- [x] `cargo test --lib` — **2706 passed**, 0 failed
- [x] `cargo test --test architecture` — **11 passed**
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added tests for new logic

Two new tests: the same job under `?utm_source=indeed` / `#apply` merging into one row keyed on the normalized url, and a legacy raw-url row still merging and being migrated. Against `main`:

```
assertion `left == right` failed: one aggregate row per job
  left: 2
 right: 1
```

The pre-existing `save_application_upserts_by_job_url_into_one_aggregate` and `save_application_inserts_separate_rows_when_unlinked` both still pass.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
