### PR TITLE
fix: pr-batch advisory follow-ups (rust/shared)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/applications.rs
+++ b/apps/desktop/src-tauri/src/commands/applications.rs
@@ -60,9 +60,19 @@ fn parse_next_action_at(raw: Option<Value>) -> AppResult<Option<Option<u64>>> {
         None => Ok(None),
         Some(Value::Null) => Ok(Some(None)),
         Some(other) => other.as_u64().map(|ms| Some(Some(ms))).ok_or_else(|| {
-            AppError::Validation(
-                "next_action_at must be null or a non-negative integer timestamp in ms".into(),
-            )
+            // Echo the offending JSON type so a renderer sending the wrong shape
+            // (a string, a negative/fractional number, an object) sees why.
+            let kind = match &other {
+                Value::Null => "null",
+                Value::Bool(_) => "a boolean",
+                Value::Number(_) => "a non-integer or out-of-range number",
+                Value::String(_) => "a string",
+                Value::Array(_) => "an array",
+                Value::Object(_) => "an object",
+            };
+            AppError::Validation(format!(
+                "next_action_at must be null or a non-negative integer epoch-ms, got {kind}"
+            ))
         }),
     }
 }

--- a/apps/desktop/src-tauri/src/commands/autopilot.rs
+++ b/apps/desktop/src-tauri/src/commands/autopilot.rs
@@ -196,6 +196,33 @@ pub fn autopilot_remove(app: AppHandle, autopilot_id: String) -> Value {
     json!(null)
 }
 
+/// Finalize a user-cancelled autopilot run identically at both cancel sites (a
+/// Stop caught in the scrape `Err` arm, and a Stop caught before we record
+/// results). Clears the live run status AND the prior run's stale summaries
+/// (this run never reached `record_run`, so a lingering chip strip would render
+/// stale board data as if it belonged to this cancelled run), marks the job
+/// cancelled, ends the `span` with the site-specific `span_msg`, and returns the
+/// cancelled payload. Extracted so the two sites can't drift.
+///
+/// The engine cancel token is unregistered by each caller at its own point (the
+/// scrape `Err` arm has already done so before reaching here; the pre-record
+/// site does it inline just before the call), so that is deliberately NOT part
+/// of this helper.
+fn finish_cancelled(
+    app: &AppHandle,
+    span: &crate::observability::Span,
+    autopilot_id: &str,
+    job_id: &str,
+    span_msg: &str,
+) -> Value {
+    store(app)
+        .lock()
+        .set_run_status_clearing_summaries(autopilot_id, RunStatus::Completed);
+    crate::commands::jobs::job_cancel(app, job_id);
+    span.end_with(span_msg, false);
+    json!({ "jobId": job_id, "cancelled": true })
+}
+
 #[tauri::command]
 pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
     // Concurrent-run guard: a double-invoke of the SAME autopilot must not
@@ -262,12 +289,13 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
             // `outcome_failed` true, which re-runs the very scrape they stopped.
             // Mirrors the Ok-path cancel handler below.
             if cancel_token.is_cancelled() {
-                store(&app)
-                    .lock()
-                    .set_run_status_clearing_summaries(&autopilot_id, RunStatus::Completed);
-                crate::commands::jobs::job_cancel(&app, &job_id);
-                span.end_with("cancelled during scrape", false);
-                return json!({ "jobId": job_id, "cancelled": true });
+                return finish_cancelled(
+                    &app,
+                    &span,
+                    &autopilot_id,
+                    &job_id,
+                    "cancelled during scrape",
+                );
             }
             // Whole-batch failure never reached `record_run`, so there are no
             // fresh summaries for this run — clear the PRIOR run's, or a later
@@ -430,17 +458,13 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
     // not overwrites, the slot), so cancels during scrape land here too.
     if cancel_token.is_cancelled() {
         engine.unregister_token(&job_id).await;
-        // User-initiated stop, not a failure or crash — clear the live status so
-        // it isn't later reconciled to "interrupted". This run never reached
-        // `record_run`, so it has no fresh summaries either — clear the PRIOR
-        // run's `last_run_summaries` too, or a future chip strip would render
-        // stale board data as if it belonged to this cancelled run.
-        store(&app)
-            .lock()
-            .set_run_status_clearing_summaries(&autopilot_id, RunStatus::Completed);
-        crate::commands::jobs::job_cancel(&app, &job_id);
-        span.end_with("cancelled before recording results", false);
-        return json!({ "jobId": job_id, "cancelled": true });
+        return finish_cancelled(
+            &app,
+            &span,
+            &autopilot_id,
+            &job_id,
+            "cancelled before recording results",
+        );
     }
 
     // Derive the honest run outcome from the per-board summaries BEFORE they are

--- a/apps/desktop/src-tauri/src/spend/mod.rs
+++ b/apps/desktop/src-tauri/src/spend/mod.rs
@@ -328,7 +328,13 @@ fn is_free_call(provider: &str, base_url: Option<&str>) -> bool {
 /// way. Both are loopbacks the caller means to treat as free.
 fn is_localhost_url(url: &str) -> bool {
     let without_scheme = url.rsplit_once("://").map_or(url, |(_, rest)| rest);
-    let host_and_port = without_scheme.split(['/', '?']).next().unwrap_or("");
+    let authority = without_scheme.split(['/', '?']).next().unwrap_or("");
+    // Strip an optional `userinfo@` prefix (`user@[::1]`, `user:pass@[::1]`) — a
+    // host can't contain `@`, so the segment after the last `@` is the host. Left
+    // in place, the userinfo defeated the bracket match below.
+    let host_and_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, rest)| rest);
     let host = if let Some(close) = host_and_port.find(']') {
         // Bracketed IPv6: the host is everything up to and including `]`.
         &host_and_port[..=close]
@@ -340,9 +346,21 @@ fn is_localhost_url(url: &str) -> bool {
             .split_once(':')
             .map_or(host_and_port, |(h, _)| h)
     };
+    // Literal spellings only — this is a cost/display gate, never routing or
+    // security, so an IP-parsing crate would be overkill. Both the `::1`
+    // shorthand and its fully-expanded (`0:0:0:0:0:0:0:1`) and IPv4-mapped
+    // (`::ffff:127.0.0.1`) forms count, bracketed or bare.
     matches!(
         host,
-        "localhost" | "127.0.0.1" | "0.0.0.0" | "::1" | "[::1]"
+        "localhost"
+            | "127.0.0.1"
+            | "0.0.0.0"
+            | "::1"
+            | "[::1]"
+            | "0:0:0:0:0:0:0:1"
+            | "[0:0:0:0:0:0:0:1]"
+            | "::ffff:127.0.0.1"
+            | "[::ffff:127.0.0.1]"
     )
 }
 

--- a/apps/desktop/src-tauri/src/spend/test.rs
+++ b/apps/desktop/src-tauri/src/spend/test.rs
@@ -103,6 +103,18 @@ fn is_localhost_url_recognizes_common_local_forms() {
         "[::1]",
         // The bare (unbracketed) spelling the match arm below also accepts.
         "::1",
+        // Fully-expanded and IPv4-mapped IPv6 loopback spellings, bracketed
+        // (with/without a port) and bare — all the same free local call.
+        "http://[0:0:0:0:0:0:0:1]:1234/v1",
+        "http://[0:0:0:0:0:0:0:1]",
+        "0:0:0:0:0:0:0:1",
+        "http://[::ffff:127.0.0.1]:8080/v1",
+        "http://[::ffff:127.0.0.1]",
+        "::ffff:127.0.0.1",
+        // A `userinfo@` prefix must not defeat the host match.
+        "http://user@[::1]/v1",
+        "http://user:pass@[::1]:1234/v1",
+        "http://user@127.0.0.1:1234/v1",
     ] {
         assert!(is_localhost_url(url), "{url} should be recognized as local");
     }

--- a/packages/shared/src/language-detection.test.ts
+++ b/packages/shared/src/language-detection.test.ts
@@ -23,6 +23,11 @@ const ARABIC =
   'نبحث عن مهندس برمجيات ذي خبرة للانضمام إلى فريقنا. ستكون مسؤولاً عن تصميم وتطوير خدمات خلفية عالية الجودة والعمل بشكل وثيق مع مديري المنتجات والمصممين لتسليم المشاريع في الوقت المحدد.';
 const NORWEGIAN =
   'Vi ser etter en erfaren programvareutvikler som vil bli med i teamet vårt. Du vil ha ansvaret for å designe og utvikle backend-tjenester av høy kvalitet, og samarbeide tett med produktsjefer og designere.';
+// Nynorsk — franc emits the INDIVIDUAL code `nno` (never the macrolanguage
+// `nor`), a different franc code from Bokmål's `nob` above, so this exercises the
+// separate `nno` map entry rather than the `nob` one.
+const NYNORSK =
+  'Me søkjer ein erfaren programvareutviklar som vil bli med i teamet vårt. Du vil ha ansvaret for å designe og utvikle backend-tenester av høg kvalitet, og samarbeide tett med produktsjefar og designarar for å levere prosjekt til rett tid.';
 
 describe('detectLanguage', () => {
   it('returns "unknown" for empty or very short text', () => {
@@ -47,6 +52,10 @@ describe('detectLanguage', () => {
     expect(detectLanguage(CHINESE)).toBe('zh');
     expect(detectLanguage(ARABIC)).toBe('ar');
     expect(detectLanguage(NORWEGIAN)).toBe('no');
+  });
+
+  it('detects Nynorsk (franc emits nno, distinct from Bokmål nob) and maps to no', () => {
+    expect(detectLanguage(NYNORSK)).toBe('no');
   });
 });
 

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -387,7 +387,10 @@ export type ApplicationTrackRequest = z.infer<typeof ApplicationTrackSchema>;
 export const ApplicationUpdateSchema = z.object({
   id: z.string().min(1),
   notes: z.string().optional(),
-  nextActionAt: z.number().int().nullable().optional(),
+  // Non-negative: the server-side guard (`parse_next_action_at`) rejects a
+  // negative epoch-ms, so the wire contract mirrors it rather than silently
+  // clearing the reminder on a bad value.
+  nextActionAt: z.number().int().min(0).nullable().optional(),
   comp: z.string().optional(),
   contactName: z.string().optional(),
   contactEmail: z.string().optional(),


### PR DESCRIPTION
Small deferred advisory follow-ups from the 2026-07-21 PR batch merge (#764–#803). Each is low-risk drift-prevention / contract-tightening; no behaviour change to shipped happy paths.

## Items

- **#778** — `refactor(autopilot)`: the cancel branch in `autopilot_run` was duplicated across the scrape `Err` arm and the pre-record guard. Extracted one private `finish_cancelled` helper (site-specific span message passed as a parameter) so the two sites can't drift. Behaviour is byte-identical; the engine token unregister stays at each caller's own point.
- **#780** — `fix(spend)`: the free-call loopback gate matched hosts by literal string only, so the fully-expanded `[0:0:0:0:0:0:0:1]` and IPv4-mapped `[::ffff:127.0.0.1]` spellings billed a local `openai-compatible` server at the unknown-model rate, and a `user@[::1]` userinfo prefix defeated the bracket match. Added the extra literal arms (bracketed + bare) and strip an optional `userinfo@` before host parsing. Still literal-only — this is a cost/display gate, never routing or security, so no IP-parsing crate. Tests added.
- **#782** — `fix(shared)`: added `.min(0)` to `ApplicationUpdateSchema.nextActionAt` so the wire contract matches the server-side `parse_next_action_at` guard that already rejects a negative epoch-ms. `pnpm gen:ipc` produced no IPC `.rs` diff (`.min(0)` is a runtime refinement, not a type change). Also made that guard's rejection message echo the offending JSON type for easier renderer-side debugging.
- **#790** — `test(shared)`: `language-detection` maps both `nob` (Bokmål) and `nno` (Nynorsk) to `no`, but the suite only exercised the `nob` sample. Added a Nynorsk sample (verified franc detects it as `nno`) so the `nno` branch isn't silently regressable.

## Validation

- `cargo clippy --all-features` — clean (touched crate)
- `cargo test` — spend / autopilot / applications module tests pass; full pre-push suite incl. architecture boundary tests green
- `cargo fmt --check` — clean
- `pnpm typecheck` (whole graph, forced) — 13/13
- `pnpm test` — 4047 passed (incl. the new Nynorsk case and the shared namespace-enumeration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)