### PR TITLE
fix(credentials): never treat an unreadable metadata index as empty

### DIFF
--- a/apps/desktop/src-tauri/src/credentials/mod.rs
+++ b/apps/desktop/src-tauri/src/credentials/mod.rs
@@ -112,17 +112,16 @@ impl CredentialStore {
             .set_password(password)
             .map_err(|e| format!("keyring set error: {e}"))?;
 
-        let mut meta = self.load_meta();
-        meta.insert(
-            board_id.to_string(),
-            CredentialMeta {
-                board_id: board_id.to_string(),
-                username: username.to_string(),
-                saved_at: now_ms(),
-            },
-        );
-        self.save_meta(meta)?;
-        Ok(())
+        self.mutate_meta(|meta| {
+            meta.insert(
+                board_id.to_string(),
+                CredentialMeta {
+                    board_id: board_id.to_string(),
+                    username: username.to_string(),
+                    saved_at: now_ms(),
+                },
+            );
+        })
     }
 
     pub fn remove(&self, board_id: &str) -> AppResult<()> {
@@ -131,10 +130,9 @@ impl CredentialStore {
             // entry if the keychain was cleared externally.
             entry.delete_credential().ok();
         }
-        let mut meta = self.load_meta();
-        meta.remove(board_id);
-        self.save_meta(meta)?;
-        Ok(())
+        self.mutate_meta(|meta| {
+            meta.remove(board_id);
+        })
     }
 
     /// Remove every stored credential — board passwords and all AI/provider keys
@@ -158,25 +156,62 @@ impl CredentialStore {
 
     // ── Meta persistence ──────────────────────────────────────────────────────
 
+    /// Read the index off disk, distinguishing "no file yet" (first run — an empty
+    /// index) from "the file is there but unreadable or corrupt" (an error).
+    ///
+    /// The difference matters because [`Self::mutate_meta`] writes the WHOLE map:
+    /// treating a corrupt read as empty would make the next `set` persist only its
+    /// own entry and orphan every previously saved credential from the index. The
+    /// keychain secrets survive, but nothing can find them again.
+    fn read_meta_file(&self) -> AppResult<HashMap<String, CredentialMeta>> {
+        match std::fs::read_to_string(&self.meta_file) {
+            Ok(s) => serde_json::from_str(&s)
+                .map_err(|e| AppError::Parse(format!("parse credential metadata: {e}"))),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(HashMap::new()),
+            Err(e) => Err(AppError::Storage(format!("read credential metadata: {e}"))),
+        }
+    }
+
     fn load_meta(&self) -> HashMap<String, CredentialMeta> {
         let mut guard = self.cache.lock();
         if let Some(ref c) = guard.0 {
             return c.clone();
         }
-        let loaded: HashMap<String, CredentialMeta> = std::fs::read_to_string(&self.meta_file)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default();
-        guard.0 = Some(loaded.clone());
-        loaded
+        match self.read_meta_file() {
+            Ok(loaded) => {
+                guard.0 = Some(loaded.clone());
+                loaded
+            }
+            // Report empty to this read-only caller, but do NOT cache it — a later
+            // `set` must not mistake an unreadable index for an empty one.
+            Err(e) => {
+                log::error!("[credentials] {e}");
+                HashMap::new()
+            }
+        }
     }
 
-    fn save_meta(&self, meta: HashMap<String, CredentialMeta>) -> AppResult<()> {
+    /// Apply `f` to the index and persist it, holding the cache lock across the
+    /// whole read-modify-write.
+    ///
+    /// `set`/`remove` used to `load_meta()` (locking, then RELEASING) and only then
+    /// `save_meta()` (locking again), so two concurrent writers could both start
+    /// from the same snapshot and the second would drop the first's entry.
+    fn mutate_meta<F>(&self, f: F) -> AppResult<()>
+    where
+        F: FnOnce(&mut HashMap<String, CredentialMeta>),
+    {
+        let mut guard = self.cache.lock();
+        let mut meta = match guard.0 {
+            Some(ref c) => c.clone(),
+            None => self.read_meta_file()?,
+        };
+        f(&mut meta);
         let json = serde_json::to_string_pretty(&meta)
             .map_err(|e| AppError::Parse(format!("serialize credential metadata: {e}")))?;
         std::fs::write(&self.meta_file, json)
             .map_err(|e| AppError::Storage(format!("write credential metadata: {e}")))?;
-        self.cache.lock().0 = Some(meta);
+        guard.0 = Some(meta);
         Ok(())
     }
 }

--- a/apps/desktop/src-tauri/src/credentials/test.rs
+++ b/apps/desktop/src-tauri/src/credentials/test.rs
@@ -336,3 +336,89 @@ fn read_credential_non_no_entry_error_returns_storage_err() {
         "non-NoEntry keyring error must map to AppError::Storage; got {result:?}"
     );
 }
+
+/// A corrupt `credential-meta.json` must never be treated as an EMPTY index.
+///
+/// `load_meta` used to map any read/parse failure to `unwrap_or_default()` AND
+/// cache it, so the next write — which persists the whole map — would have kept
+/// only its own entry and orphaned every previously saved credential from the
+/// index (the keychain secrets survive, but nothing can find them again).
+#[test]
+fn a_corrupt_meta_file_is_not_cached_as_empty() {
+    let dir = TempDir::new().unwrap();
+    let meta_path = dir.path().join("credential-meta.json");
+    std::fs::write(&meta_path, "{ this is not json").unwrap();
+    let store = CredentialStore::new(&dir.path().to_path_buf());
+
+    // The read-only path degrades to empty (it has nothing better to report)…
+    assert!(store.list().is_empty());
+
+    // …but the failure must not have been cached as authoritative: a write still
+    // reads the file, fails, and refuses rather than silently replacing the index.
+    let err = store
+        .remove("greenhouse")
+        .expect_err("a write must not proceed on an unreadable index");
+    assert!(
+        format!("{err}").contains("credential metadata"),
+        "expected a credential-metadata error, got: {err}"
+    );
+
+    // The user's file is untouched, so it can still be recovered by hand.
+    assert_eq!(
+        std::fs::read_to_string(&meta_path).unwrap(),
+        "{ this is not json"
+    );
+}
+
+/// Two writers must not lose each other's entry — `set`/`remove` now hold the
+/// cache lock across the whole read-modify-write.
+#[test]
+fn concurrent_meta_writes_do_not_lose_an_entry() {
+    let dir = TempDir::new().unwrap();
+    let store = std::sync::Arc::new(write_meta_direct(
+        dir.path(),
+        &[("seed", "seed@example.com", 1)],
+    ));
+
+    const ITERS: usize = 40;
+    let threads: Vec<_> = ["alpha", "beta"]
+        .into_iter()
+        .map(|prefix| {
+            let store = store.clone();
+            std::thread::spawn(move || {
+                for i in 0..ITERS {
+                    store
+                        .mutate_meta(|meta| {
+                            let id = format!("{prefix}-{i}");
+                            meta.insert(
+                                id.clone(),
+                                CredentialMeta {
+                                    board_id: id,
+                                    username: "u".into(),
+                                    saved_at: 0,
+                                },
+                            );
+                        })
+                        .unwrap();
+                }
+            })
+        })
+        .collect();
+    for t in threads {
+        t.join().unwrap();
+    }
+
+    // Re-read from disk (fresh store, no cache) — every entry must have landed.
+    let reloaded = CredentialStore::new(&dir.path().to_path_buf());
+    let ids: std::collections::HashSet<String> =
+        reloaded.list().into_iter().map(|m| m.board_id).collect();
+    for prefix in ["alpha", "beta"] {
+        for i in 0..ITERS {
+            assert!(
+                ids.contains(&format!("{prefix}-{i}")),
+                "{prefix}-{i} was lost to a concurrent write"
+            );
+        }
+    }
+    assert!(ids.contains("seed"), "the pre-existing entry must survive");
+}


### PR DESCRIPTION
## Summary

A corrupt `credential-meta.json` was cached as an **empty** index, so the next write replaced the file with a single entry and orphaned every other saved credential; and `set`/`remove` were a non-atomic read-modify-write. Fixes #817.

## Type of change

- [x] `fix` — Bug fix

## Changes

- **`read_meta_file()`** distinguishes the three outcomes: file absent → empty index (first run), present-but-unparseable → `Parse` error, unreadable → `Storage` error.
- **`load_meta()`** (the read-only path) still degrades to empty for its callers — it has nothing better to report — but no longer **caches** that, so a later write can't mistake an unreadable index for an empty one. The failure is logged.
- **`mutate_meta(f)`** holds the cache lock across the entire read-modify-write and is now the single write path for `set`/`remove`. On an unreadable index it returns the error instead of replacing the file, so the user's file stays recoverable by hand.
- `save_meta` is gone — `mutate_meta` subsumes it (and leaving it would trip `clippy -D warnings` as dead code).

## Testing

- [x] `cargo test --lib` — **2706 passed**, 0 failed
- [x] `cargo test --test architecture` — **11 passed**
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added tests for new logic

Two new tests: a corrupt index must not be cached as empty and must make a write refuse (asserting the file is left byte-for-byte intact), and 80 concurrent writes across two threads must all land.

**On demonstrating the "before":** I couldn't run these unchanged against `main`, because they exercise `mutate_meta`, which this PR introduces — I'd rather say that than imply a clean before/after. So I isolated defect (1) instead, reverting only the corrupt-read behaviour to `unwrap_or_default()` while keeping everything else:

```
thread 'credentials::test::a_corrupt_meta_file_is_not_cached_as_empty' panicked:
a write must not proceed on an unreadable index
```

i.e. with the old behaviour the write goes through and the index is replaced.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (both new helpers are private, documented inline)
