### PR TITLE
fix(scraping): cap the body read on the user-supplied-url path

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/http/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/http/mod.rs
@@ -99,6 +99,63 @@ pub struct FetchResult {
     pub text: String,
 }
 
+/// Read a response body as text, refusing to buffer more than `cap` bytes.
+///
+/// Two guards: a cheap `Content-Length` pre-check for honest servers, then a
+/// streamed accumulation that aborts the moment the running total exceeds `cap`
+/// — so a server that lies about or omits `Content-Length` still can't drive us
+/// into OOM. The charset comes from `Content-Type`, mirroring what
+/// `reqwest::Response::text()` does internally, so German umlauts / € decode
+/// correctly regardless of the cap.
+///
+/// Public to the crate because callers that hold a `Response` from their OWN
+/// client — e.g. the SSRF-guarded `net::http::get_guarded*` used for
+/// attacker-influenced URLs — cannot route through [`fetch_text`] (that would
+/// drop the guard) but need the same bound.
+pub(crate) async fn read_text_capped(response: reqwest::Response, cap: usize) -> AppResult<String> {
+    if let Some(content_length) = response.content_length() {
+        if content_length > cap as u64 {
+            return Err(AppError::Validation("Response too large".to_string()));
+        }
+    }
+
+    let encoding = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|ct| ct.to_str().ok())
+        .and_then(|ct| {
+            // Extract charset=... from e.g. "text/html; Charset="ISO-8859-1""
+            // Key match is case-insensitive; strip surrounding quotes from value.
+            ct.split(';').find_map(|part| {
+                let p = part.trim();
+                let eq = p.find('=')?;
+                if !p[..eq].trim().eq_ignore_ascii_case("charset") {
+                    return None;
+                }
+                let cs = p[eq + 1..].trim().trim_matches(|c| c == '"' || c == '\'');
+                Some(cs.to_ascii_lowercase())
+            })
+        })
+        .and_then(|cs| encoding_rs::Encoding::for_label(cs.as_bytes()))
+        .unwrap_or(encoding_rs::UTF_8);
+
+    let mut stream = response.bytes_stream();
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        // .without_url() — reqwest::Error's Display embeds the full request URL
+        // (incl. query string), which can carry secrets like an API token/key;
+        // strip it before it reaches BoardScrapeSummary.error → IPC → renderer.
+        let chunk = chunk.map_err(|e| AppError::Network(e.without_url().to_string()))?;
+        if buf.len().saturating_add(chunk.len()) > cap {
+            return Err(AppError::Validation("Response too large".to_string()));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+
+    let (cow, _enc, _had_errors) = encoding.decode(&buf);
+    Ok(cow.into_owned())
+}
+
 pub async fn fetch_text(
     url: &str,
     opts: FetchOptions,
@@ -194,56 +251,7 @@ pub async fn fetch_text(
                     continue;
                 }
 
-                // Cheap pre-check: honest servers that declare content-length
-                // let us abort before reading a single byte.
-                if let Some(content_length) = response.content_length() {
-                    if content_length > cap as u64 {
-                        return Err(AppError::Validation("Response too large".to_string()));
-                    }
-                }
-
-                // Determine charset from Content-Type (mirrors what reqwest::Response::text()
-                // does internally) so German umlauts / € decode correctly regardless of cap.
-                let encoding = headers
-                    .get(reqwest::header::CONTENT_TYPE)
-                    .and_then(|ct| ct.to_str().ok())
-                    .and_then(|ct| {
-                        // Extract charset=... from e.g. "text/html; Charset="ISO-8859-1""
-                        // Key match is case-insensitive; strip surrounding quotes from value.
-                        ct.split(';').find_map(|part| {
-                            let p = part.trim();
-                            let eq = p.find('=')?;
-                            if !p[..eq].trim().eq_ignore_ascii_case("charset") {
-                                return None;
-                            }
-                            let cs = p[eq + 1..].trim().trim_matches(|c| c == '"' || c == '\'');
-                            Some(cs.to_ascii_lowercase())
-                        })
-                    })
-                    .and_then(|cs| encoding_rs::Encoding::for_label(cs.as_bytes()))
-                    .unwrap_or(encoding_rs::UTF_8);
-
-                // Stream the body, accumulating bytes and aborting as soon as the
-                // running total exceeds the effective cap — prevents OOM from a
-                // server that lies about or omits Content-Length.
-                let mut stream = response.bytes_stream();
-                let mut buf: Vec<u8> = Vec::new();
-                while let Some(chunk) = stream.next().await {
-                    // .without_url() — reqwest::Error's Display embeds the full
-                    // request URL (incl. query string), which can carry secrets
-                    // like an API token/key; strip it before it reaches
-                    // BoardScrapeSummary.error → IPC → renderer + logs.
-                    let chunk =
-                        chunk.map_err(|e| AppError::Network(e.without_url().to_string()))?;
-                    if buf.len().saturating_add(chunk.len()) > cap {
-                        return Err(AppError::Validation("Response too large".to_string()));
-                    }
-                    buf.extend_from_slice(&chunk);
-                }
-
-                // Decode using the charset we extracted above.
-                let (cow, _enc, _had_errors) = encoding.decode(&buf);
-                let text = cow.into_owned();
+                let text = read_text_capped(response, cap).await?;
 
                 return Ok(FetchResult {
                     status_code,

--- a/apps/desktop/src-tauri/src/scraping/http/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/http/test.rs
@@ -756,3 +756,45 @@ fn test_html_to_markdown_falls_back_on_empty_output() {
     // returns a clean string (trimmed).
     assert_eq!(result.trim(), result, "result must already be trimmed");
 }
+
+/// `read_text_capped` is the shared bound for callers that hold their own
+/// `Response` — notably `scrape_url`, whose URL is attacker-influenced and so
+/// must go through the SSRF-guarded client rather than `fetch_text`.
+#[tokio::test]
+async fn read_text_capped_returns_the_body_under_the_cap() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("Hello World"))
+        .mount(&mock_server)
+        .await;
+
+    let response = reqwest::get(mock_server.uri()).await.unwrap();
+    assert_eq!(
+        read_text_capped(response, 1024).await.unwrap(),
+        "Hello World"
+    );
+}
+
+#[tokio::test]
+async fn read_text_capped_rejects_a_body_over_the_cap() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("x".repeat(4096)))
+        .mount(&mock_server)
+        .await;
+
+    let response = reqwest::get(mock_server.uri()).await.unwrap();
+    let err = read_text_capped(response, 64)
+        .await
+        .expect_err("a body over the cap must not be buffered");
+    assert!(
+        format!("{err}").contains("too large"),
+        "expected a size error, got: {err}"
+    );
+}

--- a/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
@@ -15,6 +15,11 @@ use anyhow::Result;
 use scraper::{Html, Selector};
 use std::collections::HashMap;
 
+/// Byte cap for a generic-HTML body read here — the same 8 MB the board fetch
+/// path applies. A job page that legitimately exceeds this is not something the
+/// generic extractor could make sense of anyway.
+const SCRAPE_URL_MAX_BYTES: usize = 8 * 1024 * 1024;
+
 /// Try every named-board handler on `url` in order; return the first match.
 /// Returns `Ok(None)` when no board recognises the URL (without making any
 /// network request beyond the board-pattern parse — each handler does an early
@@ -100,7 +105,14 @@ async fn resolve_uncached(url: &str) -> Result<Option<JobPosting>> {
     // Pass 4: generic HTML fallback on the already-fetched body — no second
     // fetch. The body was fetched through the guarded client so the host is
     // already validated; parse it directly.
-    let html = match res.text().await {
+    //
+    // Read it through the SAME byte cap the board path uses. This URL is
+    // attacker-influenced (that is why it goes through `get_guarded*`), and
+    // `Response::text()` buffers the whole body — a hostile host could stream an
+    // arbitrarily large one and drive us into OOM. The 20s timeout bounds how
+    // LONG we read, not how MUCH. Going through `fetch_text` instead is not an
+    // option here: it uses the shared client and would drop the SSRF guard.
+    let html = match crate::scraping::http::read_text_capped(res, SCRAPE_URL_MAX_BYTES).await {
         Ok(h) => h,
         Err(_) => return Ok(None),
     };


### PR DESCRIPTION
## Summary

`resolve_uncached` buffered an attacker-influenced response body with `Response::text()` and no size limit. Now capped at the same 8 MB the board path uses. Fixes #820.

## Type of change

- [x] `fix` — Bug fix

## Changes

- Extracted the existing capped-read logic out of `fetch_text` into `scraping::http::read_text_capped(response, cap)` — `Content-Length` pre-check, streamed accumulation that aborts mid-body, and the same `Content-Type` charset handling (so umlauts / € still decode correctly).
- `fetch_text` now calls it, so there is **one** implementation rather than a copy.
- `resolve_uncached` reads its generic-HTML fallback through it with an 8 MB cap.

**Why not just call `fetch_text` there:** it uses the shared client, so routing this path through it would drop the SSRF guard — `scrape_url` deliberately fetches via `net::http::get_guarded_following_redirects` because the URL is user-supplied. The shared *reader* gives the bound without touching *which client* connects.

The 20s timeout bounds how long we read, not how much, so it isn't a substitute for this.

## Testing

- [x] `cargo test --lib` — **2706 passed**, 0 failed
- [x] `cargo test --lib scraping` — 880 passed (the `scrape_url` and `http` suites both exercise the touched paths)
- [x] `cargo test --test architecture` — **11 passed**
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added tests for new logic

Two new wiremock tests cover the helper directly: a body under the cap round-trips, and one over it fails with "Response too large" instead of being buffered. The 40 pre-existing `scraping::http` tests still pass, which is what covers the `fetch_text` refactor being behaviour-preserving.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (`read_text_capped` is `pub(crate)`, documented inline)
