### PR TITLE
fix(agent): clamp confirm-request args to the called tool's own cap

### DIFF
--- a/apps/desktop/src-tauri/src/agent/gate.rs
+++ b/apps/desktop/src-tauri/src/agent/gate.rs
@@ -26,10 +26,12 @@
 //! - **Prompt injection can REQUEST but never EXECUTE.** Hostile job/résumé text can
 //!   make the model *ask* for a write; it can never satisfy the gate on the user's
 //!   behalf — only a real `agent_confirm` IPC call (or a `resolve` in a test) can.
-//! - **Display/edit fidelity.** Confirm-request args are clamped to the LARGER of
-//!   [`COVER_LETTER_CAP`] and [`SAVED_RESUME_CAP`] (each gated Write tool's own
-//!   content cap), not an arbitrarily smaller number — the renderer shows/edits
-//!   exactly what will be persisted, never a truncated preview.
+//! - **Display/edit fidelity.** Confirm-request args are clamped to the CALLED
+//!   tool's own content cap ([`display_cap_for`]) — [`COVER_LETTER_CAP`] for
+//!   `save_cover_letter`, [`SAVED_RESUME_CAP`] for `save_resume` — so the renderer
+//!   shows/edits exactly what will be persisted: never a truncated preview, and
+//!   never more than the tool will keep. An unknown tool falls back to the larger
+//!   of the two, which preserves the never-show-less half of the guarantee.
 //!
 //! [`ToolKind::Write`]: super::tools::ToolKind
 //! [`ToolContext`]: super::tools::ToolContext
@@ -139,6 +141,26 @@ const ARGS_DISPLAY_CAP: usize = if COVER_LETTER_CAP > SAVED_RESUME_CAP {
 } else {
     SAVED_RESUME_CAP
 };
+
+/// The display/edit clamp for a specific tool: that tool's OWN content cap.
+///
+/// [`ARGS_DISPLAY_CAP`] is the max across both gated Write tools (40k, from
+/// `save_resume`), which guarantees we never show LESS than what gets saved — but
+/// for the tool with the SMALLER cap it shows MORE. `save_cover_letter` truncates
+/// at [`COVER_LETTER_CAP`] (20k), so a 20k–40k letter was displayed and edited in
+/// full and then silently clipped on save: the user approves text that is not the
+/// text that gets persisted.
+///
+/// Clamping per tool closes the gap from the other side. An unknown/future tool
+/// falls back to the max, keeping the "never show less than is saved" guarantee
+/// as the safe default.
+fn display_cap_for(tool: &str) -> usize {
+    match tool {
+        "save_cover_letter" => COVER_LETTER_CAP,
+        "save_resume" => SAVED_RESUME_CAP,
+        _ => ARGS_DISPLAY_CAP,
+    }
+}
 
 /// The trusted routing/egress + job-identity fields that live ONLY in
 /// [`ToolContext`] and may NEVER be supplied (or overridden) through tool args —
@@ -337,7 +359,7 @@ pub(super) async fn resolve_write(
         confirm: Some(ConfirmRequest {
             call_id: call_id.clone(),
             tool: call.name.clone(),
-            args: clamp_json_strings(&call.args, ARGS_DISPLAY_CAP),
+            args: clamp_json_strings(&call.args, display_cap_for(&call.name)),
         }),
     });
 
@@ -1085,5 +1107,37 @@ mod tests {
         assert!(got.ends_with('…'));
         // Short, structured values pass through unchanged.
         assert_eq!(clamped["nested"]["k"], "short");
+    }
+
+    /// The confirm step must show what the tool will actually PERSIST. The shared
+    /// ARGS_DISPLAY_CAP is the max across both Write tools (40k), so a cover letter
+    /// between 20k and 40k chars was shown and edited in full and then silently
+    /// clipped to COVER_LETTER_CAP on save.
+    #[test]
+    fn display_cap_matches_each_write_tool_own_content_cap() {
+        // The two caps really do differ — otherwise this per-tool split is a no-op.
+        // Compile-time, so it also fails the build if they are ever equalised.
+        const _: () = assert!(COVER_LETTER_CAP < SAVED_RESUME_CAP);
+
+        assert_eq!(display_cap_for("save_cover_letter"), COVER_LETTER_CAP);
+        assert_eq!(display_cap_for("save_resume"), SAVED_RESUME_CAP);
+        // An unknown/future tool keeps the safe default: never show LESS than the
+        // largest thing any Write tool can persist.
+        assert_eq!(display_cap_for("some_future_writer"), ARGS_DISPLAY_CAP);
+    }
+
+    /// A letter longer than the save cap is clamped for display to exactly what
+    /// `save_cover_letter` would keep — no more.
+    #[test]
+    fn a_long_cover_letter_is_displayed_at_the_save_cap() {
+        let long = "z".repeat(SAVED_RESUME_CAP);
+        let v = json!({ "coverLetterText": long });
+        let clamped = clamp_json_strings(&v, display_cap_for("save_cover_letter"));
+        let got = clamped["coverLetterText"].as_str().unwrap();
+        assert_eq!(
+            got.chars().count(),
+            COVER_LETTER_CAP + 1,
+            "shown at the cover-letter save cap (plus the ellipsis), not the resume cap"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The confirm gate clamped args to the **max** cap across both Write tools (40k), so a 20k–40k cover letter was shown and edited in full and then silently clipped to 20k on save. Now clamped to the called tool's own cap. Fixes #822.

## Type of change

- [x] `fix` — Bug fix

## Changes

- New `display_cap_for(tool)`: `COVER_LETTER_CAP` for `save_cover_letter`, `SAVED_RESUME_CAP` for `save_resume`, and `ARGS_DISPLAY_CAP` (the max) for anything unknown.
- `resolve_write` clamps with `display_cap_for(&call.name)` instead of the shared max.
- Updated the module's *Display/edit fidelity* security invariant to describe the per-tool rule, since it currently documents the max-based one.

`ARGS_DISPLAY_CAP` is kept and still guards the important direction — never show **less** than a Write tool will persist — which is why it stays the fallback for a future tool. The per-tool clamp closes the other direction for the tool with the smaller cap.

## Testing

- [x] `cargo test --lib` — **2706 passed**, 0 failed
- [x] `cargo test --lib agent::gate` — 23 passed
- [x] `cargo test --test architecture` — **11 passed**
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added tests for new logic

Two new tests: the per-tool mapping (including the unknown-tool fallback), and a >20k letter clamping to exactly `COVER_LETTER_CAP + 1` (the cap plus the ellipsis) rather than the resume cap. The pre-existing `clamp_json_strings_truncates_long_leaves_but_keeps_structure` is untouched and still passes.

The "these two caps actually differ" check is a `const _: () = assert!(…)`, so it fails the **build** if they're ever equalised — a runtime `assert!` on two consts trips `clippy::assertions_on_constants`.

**Honest note on severity:** this needs a >20 000-char generated cover letter to bite, which is well outside normal output (~2k). I filed it because the confirm gate is the safety core and "what you approved is what was saved" reads like an invariant worth keeping exact, not because I've seen it happen.

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (the helper is private, documented inline)
