### PR TITLE
fix: pr-batch advisory follow-ups (renderer)

### DIFF
--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
@@ -60,10 +60,14 @@ export function useAutopilotRun() {
         ),
       }));
     }
+    // Read the clock at dispatch time, not inside the reducer body: under
+    // StrictMode dev double-invocation the reducer runs twice from the same base,
+    // and `Date.now()` there would produce two different timestamps (impure).
+    const ts = Date.now();
     setStepLogs((prev) => ({
       [event.autopilotId]: [
         ...(prev[event.autopilotId] ?? []).slice(-49),
-        { step: event.step, detail: event.detail, ts: Date.now() },
+        { step: event.step, detail: event.detail, ts },
       ],
     }));
   }, []);

--- a/apps/desktop/src/renderer/features/jobs/hooks/usePostingActions.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/usePostingActions.test.ts
@@ -338,6 +338,38 @@ describe('usePostingActions — handleTailor', () => {
     );
   });
 
+  it('fires persistJob(applied) only AFTER saveFromPosting resolves', async () => {
+    // Deferred save: hold the promise open so we can prove the applied
+    // interaction is not persisted until the save settles (the #796 guarantee).
+    let resolveSave: (value: { id: string }) => void = () => {};
+    mockSaveFromPostingAsync.mockReturnValueOnce(
+      new Promise<{ id: string }>((resolve) => {
+        resolveSave = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => usePostingActions(makePosting()));
+
+    let tailorDone: Promise<void> = Promise.resolve();
+    act(() => {
+      tailorDone = result.current.handleTailor();
+    });
+
+    // Save is in flight but unresolved — applied must NOT be tracked yet.
+    expect(mockSaveFromPostingAsync).toHaveBeenCalledTimes(1);
+    expect(mockPersistJobAsync).not.toHaveBeenCalled();
+
+    // Resolve the save; only now may the applied interaction persist.
+    await act(async () => {
+      resolveSave({ id: 'app-1' });
+      await tailorDone;
+    });
+
+    expect(mockPersistJobAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ interactionType: 'applied' })
+    );
+  });
+
   it('does NOT mark applied when saveFromPosting rejects', async () => {
     // `trackInteraction` PERSISTS via persistJobMutation, and the failure paths
     // return without reverting — so firing it up-front left the posting reading

--- a/apps/desktop/src/renderer/features/jobs/hooks/usePostingActions.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/usePostingActions.ts
@@ -90,12 +90,8 @@ export function usePostingActions(posting: Posting) {
       notify.error({ message: t('jobs.tailorError') });
       return;
     }
-    // Mark `applied` only once the save actually succeeded. Firing it up-front
-    // was optimistic with no rollback: `trackInteraction` persists via
-    // `persistJobMutation`, and both failure paths above `return` without
-    // reverting, so a failed Tailor left the posting reading Applied — badge and
-    // stored interaction — for something the user never applied to. `handleSave`
-    // below already marks `bookmarked` only after success.
+    // Mark `applied` only after the save succeeds — trackInteraction persists via
+    // persistJobMutation and the failure paths above don't roll back. Mirrors handleSave.
     void trackInteraction('applied');
     setApplicationApply({
       applyForId: res.id,

--- a/apps/desktop/src/renderer/features/monitoring/components/Sparkline/index.tsx
+++ b/apps/desktop/src/renderer/features/monitoring/components/Sparkline/index.tsx
@@ -4,7 +4,9 @@ interface Props {
 
 export function Sparkline({ data }: Props) {
   const max = Math.max(1, ...data);
-  const now = new Date().getHours();
+  // The data is hours-ago indexed (bin 23 = the most recent hour), so the "now"
+  // bar is the last bucket — not `new Date().getHours()`, which mislabeled every tick.
+  const nowIndex = data.length - 1;
 
   return (
     <div className="relative">
@@ -41,14 +43,15 @@ export function Sparkline({ data }: Props) {
               width={w}
               height={h}
               rx={2}
-              fill={i === now ? 'url(#bar-fill-now)' : 'url(#bar-fill)'}
+              fill={i === nowIndex ? 'url(#bar-fill-now)' : 'url(#bar-fill)'}
             />
           );
         })}
       </svg>
-      {/* Hour labels */}
+      {/* Relative-time axis: leftmost bar ≈24h ago, rightmost is the current hour.
+          Compact notation kept language-neutral, matching the prior hardcoded labels. */}
       <div className="mt-1 flex justify-between text-[9px] text-foreground/25 px-0.5">
-        {['12am', '3am', '6am', '9am', '12pm', '3pm', '6pm', '9pm'].map((l) => (
+        {['-24h', '-18h', '-12h', '-6h', 'now'].map((l) => (
           <span key={l}>{l}</span>
         ))}
       </div>

--- a/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.ts
+++ b/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.ts
@@ -58,12 +58,7 @@ export function useActivityFeed(allJobs: JobRecord[], kindLabelMap: Record<strin
     // one useless entry, no historical id ever matched it, and every completed
     // job rendered twice (different React keys, so nothing else caught it).
     // Strip only the trailing `-<ts>` to recover the real job id.
-    const liveJobIds = new Set(
-      liveActivity.map((a) => {
-        const cut = a.id.lastIndexOf('-');
-        return cut > 0 ? a.id.slice(0, cut) : a.id;
-      })
-    );
+    const liveJobIds = new Set(liveActivity.map((a) => a.id.slice(0, a.id.lastIndexOf('-'))));
     return [...liveActivity, ...historicalActivity.filter((a) => !liveJobIds.has(a.id))].slice(
       0,
       40

--- a/apps/desktop/src/renderer/features/monitoring/lib/last-24-hours.test.ts
+++ b/apps/desktop/src/renderer/features/monitoring/lib/last-24-hours.test.ts
@@ -76,4 +76,16 @@ describe('binLast24Hours', () => {
     const bins = binLast24Hours([job({ finishedAt: NOW + HOUR })], NOW);
     expect(bins.reduce((a, b) => a + b, 0)).toBe(0);
   });
+
+  it('includes a completion at exactly now (inclusive upper boundary)', () => {
+    const bins = binLast24Hours([job({ finishedAt: NOW })], NOW);
+    expect(bins[LAST_24H_BUCKETS - 1]).toBe(1);
+    expect(bins.reduce((a, b) => a + b, 0)).toBe(1);
+  });
+
+  it('excludes a completion at exactly the window start (exclusive lower boundary)', () => {
+    const windowStart = NOW - LAST_24H_BUCKETS * HOUR;
+    const bins = binLast24Hours([job({ finishedAt: windowStart })], NOW);
+    expect(bins.reduce((a, b) => a + b, 0)).toBe(0);
+  });
 });

--- a/apps/desktop/src/renderer/features/settings/components/preferences/JobLocationPreferences/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/preferences/JobLocationPreferences/index.tsx
@@ -1,6 +1,6 @@
 import { MapPin, Plus, X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useTranslation } from '@ajh/translations';
@@ -35,6 +35,19 @@ export function JobLocationPreferences() {
     left: number;
     width: number;
   } | null>(null);
+
+  // The blur-hide and position-measure both run on a timer that calls setState.
+  // Keep their ids so a mid-timeout unmount can cancel them — a stray setState
+  // after jsdom teardown throws `window is not defined` and fails the whole run.
+  const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const positionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (blurTimerRef.current) clearTimeout(blurTimerRef.current);
+      if (positionTimerRef.current) clearTimeout(positionTimerRef.current);
+    },
+    []
+  );
 
   const filteredSuggestions = COMMON_LOCATIONS.filter(
     (loc) => loc.toLowerCase().includes(inputValue.toLowerCase()) && inputValue.length > 0
@@ -115,7 +128,8 @@ export function JobLocationPreferences() {
               setInputValue(e.target.value);
               setShowSuggestions(e.target.value.length > 0);
               if (e.target.value.length > 0) {
-                setTimeout(updateDropdownPosition, 0);
+                if (positionTimerRef.current) clearTimeout(positionTimerRef.current);
+                positionTimerRef.current = setTimeout(updateDropdownPosition, 0);
               }
             }}
             onFocus={() => {
@@ -124,7 +138,11 @@ export function JobLocationPreferences() {
                 updateDropdownPosition();
               }
             }}
-            onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+            onBlur={() => {
+              // 150ms delay so a click on a suggestion registers before the
+              // dropdown hides; the ref lets an unmount cancel the pending hide.
+              blurTimerRef.current = setTimeout(() => setShowSuggestions(false), 150);
+            }}
             placeholder={t('settings.location.searchPlaceholder')}
             className="flex-1"
           />


### PR DESCRIPTION
Deferred renderer follow-ups from the 2026-07-21 PR batch (#764–#803).

## Items

- **Test-suite de-flake (highest priority)** — `JobLocationPreferences` scheduled two `setTimeout`s (the 150ms `onBlur` hide and a 0ms position-measure) that call `setState` but were never cancelled on unmount. When a vitest file finished inside the 150ms window the deferred `setState` fired after jsdom teardown → `ReferenceError: window is not defined` → the whole Tests job exited 1 with all tests passing (red Tests on 5 PRs last batch). Both timer ids now live in refs and are cleared in a `useEffect` cleanup; the 150ms blur delay behaviour is preserved.
- **#800 follow-up** — the last-24h sparkline data is hours-ago indexed (bin 23 = most recent hour), but `Sparkline` still drew hour-of-day labels (`12am`…`9pm`) and highlighted `new Date().getHours()`, mislabeling every bar. Now highlights the last bucket and uses relative axis notation (`-24h … now`, following the component's existing hardcoded-label precedent). Adds the two boundary tests to `last-24-hours.test.ts`: a completion at exactly `now` is included, one at `windowStart` is excluded.
- **#798 follow-up** — dropped the unreachable `cut > 0 ? id.slice(0, cut) : a.id` fallback in `useActivityFeed` (every live id is `${jobId}-${ts}`, so `lastIndexOf('-')` is always positive); slice directly.
- **#796 follow-up** — compressed the 6-line `handleTailor` rationale comment to two lines, and added a deferred-save ordering test proving `persistJob('applied')` fires only after `saveFromPosting` resolves.
- **#794 follow-up (LOW advisory)** — applied the reducer-purity fix: `Date.now()` is now read at dispatch time and closed into the functional patch, so StrictMode dev double-invocation can't produce two timestamps in the `setStepLogs` reducer body.

## Gates

- `TURBO_FORCE=1 pnpm typecheck` — 13/13 packages green
- `pnpm lint:strict` — clean (`--max-warnings 0`)
- `pnpm test` — 373 files / 4052 tests passing (full suite, no jsdom flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
