### PR TITLE
fix: pr-batch advisory follow-ups (extension)

### DIFF
--- a/apps/extension/src/lib/field-signal.test.ts
+++ b/apps/extension/src/lib/field-signal.test.ts
@@ -73,6 +73,9 @@ describe('matchNamedKey — phone', () => {
       'cell phone',
       'cellphone',
       'work phone',
+      // camelCase compound flattens to `workphone`; `work` is an enumerated
+      // prefix, so it still resolves to phone (see NAMED_KEY_PATTERNS note).
+      'workphone',
       'home phone',
       'mobile',
       'mobile_number',
@@ -88,8 +91,16 @@ describe('matchNamedKey — phone', () => {
 
   it('does not match a word that merely CONTAINS phone/mobile', () => {
     // Bare `phone`/`mobile` were unanchored substrings, so a "Smartphone model"
-    // field resolved to `phone` and received the user's phone number.
-    for (const signal of ['smartphone', 'smartphone model', 'iphone', 'microphone', 'automobile']) {
+    // field resolved to `phone` and received the user's phone number. `headphone`
+    // has a non-enumerated `head` prefix, so it stays a non-match too.
+    for (const signal of [
+      'smartphone',
+      'smartphone model',
+      'iphone',
+      'microphone',
+      'headphone',
+      'automobile',
+    ]) {
       expect(matchNamedKey(signal), signal).not.toBe('phone');
     }
   });
@@ -104,6 +115,10 @@ describe('matchNamedKey — location', () => {
       'candidate_city',
       'city_1',
       'current city',
+      // camelCase compounds flatten to `workcity` / `homecity`; `home`/`work` are
+      // enumerated prefixes, so they resolve to location (see NAMED_KEY_PATTERNS).
+      'workcity',
+      'homecity',
       'town',
       'hometown',
       'location',

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -75,7 +75,7 @@ const AMBIGUOUS = [
   // matches the generic `\bname\b` catch-all in `matchNamedKey` and mis-fills
   // with the applicant's OWN name. All are long, distinctive substrings with no
   // English-word collision (the short/collision-prone ones live in
-  // {@link AMBIGUOUS_WORDS} below).
+  // {@link AMBIGUOUS_WORDS} / {@link AMBIGUOUS_PREFIXED} below).
   'ansprechpartner', // DE contact person
   'notfall', // DE emergency (covers notfallkontakt/notfallnummer)
   'referenz', // DE reference (covers referenzperson/referenznummer)

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -369,8 +369,10 @@ const NAMED_KEY_PATTERNS: readonly { key: string; pattern: RegExp }[] = [
   // "microphone" and bare `mobile` ⊂ "automobile", so a "Smartphone model" field
   // received the user's phone number — a mis-fill, which this module's contract
   // forbids ("under-fills rather than mis-fills"). The known compound prefixes
-  // (`cell`/`home`/`work`/`day`/`tele`phone) are spelled out so they keep
-  // matching. The TRAILING side is deliberately left open — `_` is a word
+  // (`cell`/`home`/`work`/`day`/`tele`phone) are ENUMERATED so they keep matching
+  // — camelCase compounds flatten to the same lowercased signal (`workPhone` →
+  // `workphone` → `work`+`phone`), while a non-enumerated `headphone`/`smartphone`
+  // deliberately does NOT match. The TRAILING side is deliberately left open — `_` is a word
   // character, so a `\b`/trailing anchor would stop matching the very common
   // `phone_number`, `phoneNumber` and `mobile_number` field names. `(?:^|[^a-z])`
   // is used rather than a lookbehind because these patterns are only ever
@@ -404,14 +406,18 @@ const NAMED_KEY_PATTERNS: readonly { key: string; pattern: RegExp }[] = [
   },
   // `city`/`town` are anchored on their LEADING side (see the `phone` note
   // above): bare `city` ⊂ "ethnicity", so an EEO "Ethnicity" field was resolving
-  // to `location` and receiving the user's city. `hometown` is spelled out so it
-  // keeps matching. The trailing side stays open so `city_1` / `cityName` still
+  // to `location` and receiving the user's city. The compound prefixes
+  // (`home`/`work`) are ENUMERATED rather than allowing any letter before `city`,
+  // so a camelCase compound flattens and still matches (`workCity` → `workcity`
+  // → `work`+`city`) WITHOUT re-opening the `ethnicity` mis-fill (its `city` is
+  // preceded by an un-enumerated `ethni`). `hometown` is spelled out so it keeps
+  // matching. The trailing side stays open so `city_1` / `cityName` still
   // match. The other EU city/place terms use `\b` where they are
   // short/collision-prone, unchanged.
   {
     key: 'location',
     pattern:
-      /(?:^|[^a-z])(?:home)?(?:city|town)|\blocation\b|\bort\b|stadt|wohnort|\bville\b|ciudad|citta|plaats|miasto|cidade|localidad/,
+      /(?:^|[^a-z])(?:home|work)?(?:city|town)|\blocation\b|\bort\b|stadt|wohnort|\bville\b|ciudad|citta|plaats|miasto|cidade|localidad/,
   },
 ];
 

--- a/apps/extension/src/lib/submit-watch.test.ts
+++ b/apps/extension/src/lib/submit-watch.test.ts
@@ -165,6 +165,122 @@ describe('armSubmitWatch — apply-style click heuristic', () => {
   });
 });
 
+describe('armSubmitWatch — hidden résumé file input (#786 follow-up)', () => {
+  it('recognizes a form whose résumé file input is hidden behind a custom upload button', () => {
+    // A styled upload widget hides the native <input type=file> (display:none).
+    // With only one OTHER visible field the form falls below the 3-field bar, so
+    // without treating the hidden résumé input as decisive the real application
+    // form would go unrecognized. Visibility is computed-style only (isHidden).
+    setBody(`
+      <form id="f">
+        <input name="first_name" />
+        <input type="file" name="resume" style="display:none" />
+        <button type="submit">Submit application</button>
+      </form>
+    `);
+    const post = vi.fn();
+    armSubmitWatch(document, post);
+
+    (document.getElementById('f') as HTMLFormElement).dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('still ignores a hidden NON-résumé file input with too few visible fields', () => {
+    // The narrowing: only a résumé/CV-flavored hidden file input is decisive, so
+    // a bare hidden upload on a non-application form stays below the bar and the
+    // module keeps under-reporting rather than over-reporting.
+    setBody(`
+      <form id="f">
+        <input name="q" />
+        <input type="file" style="display:none" />
+        <button type="submit">Submit application</button>
+      </form>
+    `);
+    const post = vi.fn();
+    armSubmitWatch(document, post);
+
+    (document.getElementById('f') as HTMLFormElement).dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+
+    expect(post).not.toHaveBeenCalled();
+  });
+});
+
+describe('armSubmitWatch — non-application forms (#786 lows)', () => {
+  it('does NOT treat a checkbox/radio-only form as an application form', () => {
+    // A filter / cookie-consent / survey widget is built only from checkboxes or
+    // radios; a real application form clears the bar on its text/email/résumé
+    // fields, so these are excluded from the fillable-field count.
+    setBody(`
+      <form id="f">
+        <input type="checkbox" name="a" />
+        <input type="checkbox" name="b" />
+        <input type="radio" name="c" value="1" />
+        <input type="radio" name="c" value="2" />
+        <button type="submit">Submit application</button>
+      </form>
+    `);
+    const post = vi.fn();
+    armSubmitWatch(document, post);
+
+    (document.getElementById('f') as HTMLFormElement).dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when a "Save draft" button submits the application form', () => {
+    // Real browsers carry the pressed button as the SubmitEvent's `submitter`;
+    // a draft-save submit must not auto-advance the application to `applied`.
+    setBody(`
+      <form id="f">
+        ${APPLICATION_FIELDS}
+        <button id="draft" type="submit">Save draft</button>
+        <button id="send" type="submit">Submit application</button>
+      </form>
+    `);
+    const post = vi.fn();
+    armSubmitWatch(document, post);
+
+    (document.getElementById('f') as HTMLFormElement).dispatchEvent(
+      new SubmitEvent('submit', {
+        submitter: document.getElementById('draft'),
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('still fires when the real submit button sends the application form', () => {
+    setBody(`
+      <form id="f">
+        ${APPLICATION_FIELDS}
+        <button id="draft" type="submit">Save draft</button>
+        <button id="send" type="submit">Submit application</button>
+      </form>
+    `);
+    const post = vi.fn();
+    armSubmitWatch(document, post);
+
+    (document.getElementById('f') as HTMLFormElement).dispatchEvent(
+      new SubmitEvent('submit', {
+        submitter: document.getElementById('send'),
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('armSubmitWatch — fire-once guard', () => {
   it('posts AT MOST ONCE when the apply click AND its submit both fire', () => {
     setBody(`<form id="f">${APPLICATION_FIELDS}<button type="submit">Apply</button></form>`);

--- a/apps/extension/src/lib/submit-watch.ts
+++ b/apps/extension/src/lib/submit-watch.ts
@@ -34,7 +34,7 @@
  * dependency.
  */
 
-import { isHidden } from './field-signal';
+import { isHidden, textSignal } from './field-signal';
 
 /** Internal background message kind the injected watcher posts on a detected
  *  submit. Duplicated as a plain literal in `background.ts` (kept out of that
@@ -54,11 +54,59 @@ const APPLY_TEXT_RE = /apply|submit application|send application|finish/i;
 const STRICT_APPLY_TEXT_RE =
   /submit\s+(?:your|my|the)?\s*application|send\s+(?:your|my|the)?\s*application|finish/i;
 
+/** Submit-button text that means "not the final application send" — a
+ *  draft-save or an "add another entry" control. A `type="submit"` "Save draft"
+ *  button inside the real application form still fires the form's `submit`
+ *  event, and the listener sees the FORM, not the button; without inspecting the
+ *  `SubmitEvent`'s `submitter` it auto-advanced the application to `applied` on a
+ *  draft save (#786's documented follow-up gap). Kept narrow — over-matching only
+ *  costs a false negative (the user marks it by hand), the direction this module
+ *  prefers. */
+const NON_SUBMIT_TEXT_RE = /\bdraft\b|save (?:for )?later|add another/i;
+
 /** Minimum number of visible, fillable fields for a `<form>` to be treated as an
  *  application form. A site search box, a newsletter signup and a login form all
  *  have one or two; a real application form has more (and usually a résumé file
  *  input, which short-circuits this check outright). */
 const MIN_APPLICATION_FIELDS = 3;
+
+/** Control types that never count as a fillable application field: submit/button
+ *  furniture, a site search box, and — deliberately — checkbox/radio. A form
+ *  built ONLY from checkboxes or radios is a filter / cookie-consent / survey
+ *  widget, not an application; a real application form still clears the bar on
+ *  its text/email/résumé fields, so excluding these only removes a false
+ *  positive (under-report over over-report). */
+const NON_FILLABLE_TYPES = [
+  'hidden',
+  'submit',
+  'button',
+  'image',
+  'reset',
+  'search',
+  'checkbox',
+  'radio',
+];
+
+/** A file input's résumé-flavored name/id/placeholder/aria-label/label text. */
+const RESUME_FILE_TEXT_RE = /resume|curriculum|lebenslauf|(?:^|[^a-z])cv/;
+/** A file input's `accept` listing document (résumé) types, not `image/*` etc. */
+const RESUME_FILE_ACCEPT_RE = /pdf|\.docx?|msword|wordprocessingml/;
+
+/**
+ * True when `el` is a résumé/CV file input — the single strongest
+ * application-form signal. A custom upload widget routinely hides the native
+ * `<input type=file>` (`display:none`) behind a styled button, so this is the
+ * one field checked WITHOUT the visibility filter (the visible-file count below
+ * would otherwise miss a real application form — #786 follow-up). Restricted to
+ * résumé-flavored inputs (name/id/label/aria-label, or an `accept` listing
+ * document types) so an arbitrary hidden file input can't masquerade as an
+ * application form — the module UNDER-reports rather than over-reports.
+ */
+function isResumeFileInput(el: HTMLElement): boolean {
+  if ((el.getAttribute('type') ?? '').toLowerCase() !== 'file') return false;
+  const accept = (el.getAttribute('accept') ?? '').toLowerCase();
+  return RESUME_FILE_TEXT_RE.test(textSignal(el)) || RESUME_FILE_ACCEPT_RE.test(accept);
+}
 
 /**
  * Whether `form` looks like the application form rather than incidental page
@@ -69,14 +117,16 @@ const MIN_APPLICATION_FIELDS = 3;
  * submit was indistinguishable from sending the application.
  */
 function looksLikeApplicationForm(form: HTMLFormElement): boolean {
-  const fields = Array.from(form.querySelectorAll('input, textarea, select')).filter(
-    (el): el is HTMLElement => el instanceof HTMLElement && !isHidden(el)
+  const all = Array.from(form.querySelectorAll('input, textarea, select')).filter(
+    (el): el is HTMLElement => el instanceof HTMLElement
   );
-  const fillable = fields.filter((el) => {
-    const type = (el.getAttribute('type') ?? '').toLowerCase();
-    return !['hidden', 'submit', 'button', 'image', 'reset', 'search'].includes(type);
-  });
-  // A file input is the résumé upload — decisive on its own.
+  // A résumé/CV file input is decisive on its own — even when hidden behind a
+  // custom upload button (checked across ALL inputs; see isResumeFileInput).
+  if (all.some(isResumeFileInput)) return true;
+  const fillable = all
+    .filter((el) => !isHidden(el))
+    .filter((el) => !NON_FILLABLE_TYPES.includes((el.getAttribute('type') ?? '').toLowerCase()));
+  // Any other VISIBLE file input is very likely the résumé upload too — decisive.
   if (fillable.some((el) => (el.getAttribute('type') ?? '').toLowerCase() === 'file')) return true;
   return fillable.length >= MIN_APPLICATION_FIELDS;
 }
@@ -86,6 +136,14 @@ function looksLikeApplicationForm(form: HTMLFormElement): boolean {
 function applicationFormFor(el: HTMLElement): HTMLFormElement | null {
   const form = (el as HTMLButtonElement | HTMLInputElement).form ?? el.closest?.('form') ?? null;
   return form instanceof HTMLFormElement ? form : null;
+}
+
+/** The visible text of a submit/apply control: an input's `value`, else its
+ *  text content + `aria-label`. */
+function controlText(el: Element): string {
+  return el instanceof HTMLInputElement
+    ? el.value
+    : `${el.textContent ?? ''} ${el.getAttribute('aria-label') ?? ''}`;
 }
 
 /**
@@ -102,10 +160,7 @@ function isApplyControl(el: Element): boolean {
   const isSubmitInput = tag === 'INPUT' && type === 'submit';
   const isRoleButton = el.getAttribute('role') === 'button';
   if (!isSubmitButton && !isSubmitInput && !isRoleButton) return false;
-  const text =
-    el instanceof HTMLInputElement
-      ? el.value
-      : `${el.textContent ?? ''} ${el.getAttribute('aria-label') ?? ''}`;
+  const text = controlText(el);
   // Inside an application form the surrounding structure corroborates the text,
   // so the broad pattern is trusted. With no form to corroborate it, only an
   // explicit send verb counts — a bare "Apply now" out there is the button that
@@ -139,6 +194,14 @@ export function armSubmitWatch(doc: Document, post: (url: string) => void): void
     (ev) => {
       const form = ev.target;
       if (!(form instanceof HTMLFormElement) || !looksLikeApplicationForm(form)) return;
+      // A "Save draft"/"Add another" `type=submit` button inside the real form
+      // also fires this `submit` event. Real browsers carry the pressed button as
+      // the SubmitEvent's `submitter`; skip a non-final-submit control so a draft
+      // save isn't mis-reported as sending the application (#786 follow-up). A
+      // programmatic `form.submit()` (or a plain `Event`) has no submitter — fire
+      // as before.
+      const submitter = (ev as Partial<SubmitEvent>).submitter ?? null;
+      if (submitter && NON_SUBMIT_TEXT_RE.test(controlText(submitter))) return;
       fire();
     },
     true


### PR DESCRIPTION
## Summary

Deferred advisory follow-ups from the 2026-07-21 extension PR batch. Four items, all under `apps/extension/src/lib`, no protocol/permission changes.

## Items

**Item 1 — #786 MEDIUM: hidden résumé file input.** A custom upload widget hides the native `<input type=file>` (`display:none`) behind a styled button, which defeated the "decisive file input" short-circuit in `looksLikeApplicationForm` — a real application form with a hidden résumé input and fewer than three other visible fields went unrecognized. **Fix:** a résumé/CV-flavored file input (name/id/label/aria-label, or an `accept` listing document types) is now decisive **even when hidden**, checked across all inputs (not just the visible-filtered set). Narrowed to résumé-flavored inputs so an arbitrary hidden file input can't masquerade as an application form — the module keeps under-reporting over over-reporting. Visibility stays computed-style-only.

**Item 2 — #786 LOWs (both fixed; small + clearly correct under the under-report invariant):**
- *"Save draft" false positive:* a `type=submit` "Save draft"/"Add another" button inside the real application form still fires the form's `submit`, which the listener saw as sending the application. Now the `SubmitEvent`'s `submitter` is inspected and a non-final-submit control is skipped. A programmatic `form.submit()` (no submitter) still fires, as before.
- *checkbox/radio-only forms:* excluded checkbox/radio from the fillable-field count, so a filter / cookie-consent / survey widget no longer reads as an application form. Real application forms clear the bar on their text/email/résumé fields.

**Item 3 — #784 follow-up: camelCase compounds.** `textSignal` lowercases without splitting camelCase, so `name="workCity"` flattens to `workcity` and no longer matched the location pattern (`work` was not an enumerated city/town prefix). **Decision: extend, narrowly** — added `work` to the enumerated city/town prefix so `workCity` resolves to `location`, while keeping the leading-anchor enumeration so `ethnicity` stays a non-match (no new mis-fill surface). This favors the under-fill contract: it recovers a legitimate field without broadening the anchor. Phone needed no code change — `work` is already enumerated (`workPhone` matches), and `headphone`/`smartphone` correctly do not.

**Item 4 — #805 nit:** the localized-fields comment pointed only at `AMBIGUOUS_WORDS`, but the collision-prone `referr`/`reference`/`search` terms now live in `AMBIGUOUS_PREFIXED`. Comment now points at both lists.

## Tests

New fixtures pin every behavior change:
- `submit-watch.test.ts` — hidden résumé file input + <3 visible fields recognized; bare hidden non-résumé file input still ignored (the narrowing); checkbox/radio-only form ignored; "Save draft" `submitter` skipped; real submit `submitter` still fires.
- `field-signal.test.ts` — `headphone` (phone non-match), `workphone` (phone match), `workcity`/`homecity` (location match).

## Gates

- `pnpm lint:strict` — clean
- `TURBO_FORCE=1 pnpm typecheck` — 13/13 successful (cache bypassed)
- `pnpm test` (full) — 4050 passed / 373 files

Source PRs: #786, #784, #805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
