### PR TITLE
fix(settings): clear a pending blur timer before re-arming it

### DIFF
--- a/apps/desktop/src/renderer/features/settings/components/preferences/JobLocationPreferences/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/preferences/JobLocationPreferences/index.tsx
@@ -141,6 +141,9 @@ export function JobLocationPreferences() {
             onBlur={() => {
               // 150ms delay so a click on a suggestion registers before the
               // dropdown hides; the ref lets an unmount cancel the pending hide.
+              // Clear any prior pending hide before re-arming so a blur → refocus
+              // → blur burst can't orphan a timer that unmount cleanup then misses.
+              if (blurTimerRef.current) clearTimeout(blurTimerRef.current);
               blurTimerRef.current = setTimeout(() => setShowSuggestions(false), 150);
             }}
             placeholder={t('settings.location.searchPlaceholder')}


### PR DESCRIPTION
Follow-up to the LOW flagged in #824's review — the exact bug class that PR targeted. In `JobLocationPreferences`, `onBlur` overwrote `blurTimerRef.current` without clearing any prior pending id, so a blur → refocus-within-150ms → blur sequence orphaned the first timer; an unmount in that window cleared only the second, letting the first fire after jsdom teardown (`ReferenceError: window is not defined`) and re-open the test-flake it was meant to close. This clears the pending id before re-arming, mirroring the position-timer pattern already in the same component. One-line change; the component's tests and `pnpm typecheck` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
