### PR TITLE
fix(prompts): stop the italic strip from eating bullet lists across newlines

### DIFF
--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -1317,6 +1317,19 @@ describe('extractPlainText', () => {
     expect(extractPlainText('**a** and *b*')).toBe('**a** and b');
   });
 
+  it('preserves a markdown `*`-bullet list across lines', () => {
+    // Regression: `[^*]+` in the italic-strip pass spanned newlines, so the
+    // leading `*` of one bullet paired with the leading `*` of the NEXT
+    // bullet (matching across the `\n`) and both list markers were eaten,
+    // leaving ` apple\n banana`.
+    const out = extractPlainText('* apple\n* banana');
+    expect(out).toBe('* apple\n* banana');
+  });
+
+  it('still strips a single-line italic span', () => {
+    expect(extractPlainText('This is *italic* text.')).toBe('This is italic text.');
+  });
+
   it('removes a fenced code block entirely (no orphaned backticks or code leak)', () => {
     // Regression: the inline-backtick pass used to consume the ``` fence markers
     // first, so the fenced regex could not match and the code body leaked.

--- a/packages/prompts/src/generate/text/text.ts
+++ b/packages/prompts/src/generate/text/text.ts
@@ -21,7 +21,10 @@ export function extractPlainText(raw: string): string {
       // up ACROSS each other, so `**Python**, **Go**` collapsed to
       // `*Python, Go*`. The prompts ask for 2-3 `**keyword**` bolds per bullet,
       // so this ran on essentially every generated document.
-      .replace(/(?<!\*)\*(?!\*)([^*]+)\*(?!\*)/g, '$1')
+      // `[^*\n]` (not `[^*]`) keeps the class inside one line — otherwise a
+      // `* apple\n* banana` markdown bullet list pairs the two leading list
+      // stars across the newline, eating them and leaving ` apple\n banana`.
+      .replace(/(?<!\*)\*(?!\*)([^*\n]+)\*(?!\*)/g, '$1')
       // Fenced blocks first — otherwise the inline-backtick pass below consumes
       // the ``` fence markers, orphaning them so the fenced regex no longer
       // matches and the code body leaks into the plain text.


### PR DESCRIPTION
## Summary

- Deferred follow-up from PR #792's review (fix(prompts): stop the italic strip from eating bold markup) — the italic-strip regex's `[^*]+` character class spanned newlines, so a markdown bullet list like `* apple\n* banana` paired the two leading list stars across the line break and ate them, leaving ` apple\n banana`.
- Fix: exclude newlines from the class (`[^*\n]`), keeping the match scoped to a single line.
- Added a regression test for a two-line `*`-bullet list passing through with its stars intact, plus a single-line italic case to confirm normal stripping is unaffected.

## Test plan

- [x] `pnpm -F @ajh/prompts test` — all 521 tests pass, including the two new cases
- [x] `TURBO_FORCE=1 pnpm typecheck` — whole-graph, green
- [x] `pnpm test` — whole-graph, 373 files / 4055 tests pass
- [x] `pnpm lint:strict` — clean, no eslint-disable used

🤖 Generated with [Claude Code](https://claude.com/claude-code)