### PR TITLE
fix: persist completed stream text so the poll fallback works

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/cli_agent/mod.rs
@@ -525,6 +525,12 @@ async fn run_stream(
     // Whether a non-blank content delta has streamed yet — gates leading-blank
     // suppression so plain-text agents don't emit a stray newline before the answer.
     let mut seen_content = false;
+    // The full completed answer, accumulated from the exact non-thinking deltas
+    // we stream (post leading-blank suppression) — the same shape the renderer
+    // buffers. Persisted by `emit_done` so a renderer that missed frames or the
+    // terminal `done` event recovers it by polling, exactly like the cloud
+    // `stream::finish` path.
+    let mut answer = String::new();
 
     loop {
         // Race the next line read against a cancel poll so a cancellation mid-line
@@ -594,6 +600,7 @@ async fn run_stream(
                     }
                     seen_content = true;
                 }
+                answer.push_str(&text);
                 emit_event(
                     app,
                     AI_STREAM,
@@ -660,7 +667,7 @@ async fn run_stream(
     // `AiProvider::complete_with_usage`'s DEFAULT impl, which already reports
     // zero usage for any provider (like this one) that doesn't override it.
     super::record_usage(app, backend.id().as_str(), model, 0, 0, None);
-    emit_done(app, job_id);
+    emit_done(app, job_id, &answer);
     trace.end(status.and_then(|s| s.code()).map(|c| c as u16), true);
     Ok(())
 }
@@ -848,7 +855,12 @@ fn is_cancelled(app: &AppHandle, job_id: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn emit_done(app: &AppHandle, job_id: &str) {
+/// Emit the terminal `ai:stream` event and mark the job complete, persisting the
+/// completed `answer` as `result.text` (think-stripped via the shared
+/// [`super::stream::strip_think_blocks`]) so a CLI-agent generation's poll
+/// fallback recovers the finished document just like the cloud `stream::finish`
+/// path — the poll contract is provider-agnostic.
+fn emit_done(app: &AppHandle, job_id: &str, answer: &str) {
     emit_event(
         app,
         AI_STREAM,
@@ -860,7 +872,11 @@ fn emit_done(app: &AppHandle, job_id: &str) {
             thinking: None,
         },
     );
-    crate::commands::jobs::job_complete(app, job_id, json!({ "done": true }));
+    crate::commands::jobs::job_complete(
+        app,
+        job_id,
+        json!({ "done": true, "text": super::stream::strip_think_blocks(answer) }),
+    );
 }
 
 /// All `system` message content, joined — passed to the agent as its system prompt.

--- a/apps/desktop/src-tauri/src/commands/ai_provider/stream.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/stream.rs
@@ -109,6 +109,22 @@ fn emit_delta(app: &AppHandle, job_id: &str, delta: &str, thinking: bool) {
 /// never reported any) against today's AI spend. `base_url` is passed through
 /// to the free/paid cost gate — only meaningful for `openai-compatible`
 /// (LM Studio/vLLM/OpenRouter/…), ignored for every other provider.
+///
+/// `answer` is the full completed text accumulated from this stream's
+/// **non-thinking** deltas (see `stream_response`'s loop) — exactly what the
+/// renderer feeds its `<think>` splitter. It is persisted into the job result
+/// as `result.text` so a renderer that missed stream frames (or the terminal
+/// `done` event) can recover the finished document by polling `jobs_get`
+/// instead of resolving a truncated stream buffer. This is provider-agnostic:
+/// every provider routes through here, so a new adapter inherits the behavior
+/// for free. Before persisting, inline `<think>…</think>` reasoning is stripped
+/// via [`strip_think_blocks`] so the persisted text is the SAME think-stripped
+/// shape the renderer assembles — critical because the renderer's poll fallback
+/// prefers the LONGER of {persisted, streamed buffer}, and its streamed buffer
+/// is already think-stripped. Persisting raw `<think>` markup would make the
+/// persisted side spuriously longer AND leak reasoning markup into the final
+/// document; stripping here keeps both sides of that length comparison in the
+/// same shape.
 #[allow(clippy::too_many_arguments)]
 fn finish(
     app: &AppHandle,
@@ -119,6 +135,7 @@ fn finish(
     model: &str,
     base_url: &str,
     usage: Usage,
+    answer: &str,
 ) {
     emit_event(
         app,
@@ -131,7 +148,11 @@ fn finish(
             thinking: None,
         },
     );
-    crate::commands::jobs::job_complete(app, job_id, json!({ "done": true }));
+    crate::commands::jobs::job_complete(
+        app,
+        job_id,
+        json!({ "done": true, "text": strip_think_blocks(answer) }),
+    );
     trace.end(Some(status), true);
     super::record_usage(
         app,
@@ -141,6 +162,52 @@ fn finish(
         usage.output_tokens,
         Some(base_url),
     );
+}
+
+/// Remove inline `<think>…</think>` reasoning blocks, mirroring the renderer's
+/// `createThinkSplitter` (`renderer/lib/generate/think-split.ts`) so the
+/// persisted answer text is byte-for-byte the shape the renderer assembles from
+/// the live stream. Local reasoning models (DeepSeek-R1, Qwen3, …) embed the
+/// tags directly in their answer content; cloud providers flag reasoning
+/// structurally (those deltas never reach `answer` in the first place, since the
+/// loop only accumulates non-thinking deltas), so for them this is a no-op.
+///
+/// Semantics match the splitter's final output exactly: text outside a block is
+/// kept, text inside a `<think>…</think>` pair is dropped, and an UNTERMINATED
+/// `<think>` (no closing tag) discards everything from that tag onward — the
+/// splitter drops an unterminated block at `flush()`. Because the whole answer
+/// is stripped in one pass here (not incrementally across deltas), a `</think>`
+/// split across two stream frames — which the renderer's streaming splitter can
+/// mis-handle — is resolved correctly, so the persisted text can only ever be
+/// equal-or-more-correct than the buffer, and never contains reasoning markup.
+///
+/// Shared with the CLI-agent streaming path (`cli_agent::run_stream`), which has
+/// its own subprocess transport but persists the completed answer the SAME way,
+/// so a CLI-agent generation's poll fallback works too and no provider path can
+/// leak `<think>` markup.
+pub(super) fn strip_think_blocks(text: &str) -> String {
+    const OPEN: &str = "<think>";
+    const CLOSE: &str = "</think>";
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    loop {
+        match rest.find(OPEN) {
+            Some(open) => {
+                out.push_str(&rest[..open]);
+                let after = &rest[open + OPEN.len()..];
+                match after.find(CLOSE) {
+                    Some(close) => rest = &after[close + CLOSE.len()..],
+                    // Unterminated block — the renderer discards it at flush; drop the rest.
+                    None => break,
+                }
+            }
+            None => {
+                out.push_str(rest);
+                break;
+            }
+        }
+    }
+    out
 }
 
 /// Whether `job_id` has been cancelled.
@@ -164,8 +231,11 @@ enum StreamSink {
     /// Provider's end-of-stream sentinel — emit terminal event + complete +
     /// record spend. Carries the LATEST [`Usage`] seen across the whole
     /// stream (mirroring `stream_response`/`finish`'s "last write wins" +
-    /// "record once, at completion" behavior).
-    Complete(Usage),
+    /// "record once, at completion" behavior) AND the accumulated answer text
+    /// (only non-thinking deltas — exactly what the renderer buffers) that
+    /// [`finish`] think-strips via [`strip_think_blocks`] and persists into the
+    /// job result as `result.text`.
+    Complete(Usage, String),
     /// Cancelled mid-stream — fail with `"Job cancelled"`, no terminal event
     /// (mirroring production: no `job_complete`), but STILL carrying
     /// whatever [`Usage`] was last seen before the cancel, so it can be
@@ -209,6 +279,7 @@ async fn drive_stream<Cancel, Next, Fut, B, P>(
 {
     let mut buf = String::new();
     let mut usage = Usage::default();
+    let mut answer = String::new();
     loop {
         if cancelled() {
             on(StreamSink::Cancelled(usage));
@@ -222,13 +293,16 @@ async fn drive_stream<Cancel, Next, Fut, B, P>(
                         usage = u;
                     }
                     if !piece.delta.is_empty() {
+                        if !piece.thinking {
+                            answer.push_str(&piece.delta);
+                        }
                         on(StreamSink::Emit {
                             delta: piece.delta,
                             thinking: piece.thinking,
                         });
                     }
                     if piece.done {
-                        on(StreamSink::Complete(usage));
+                        on(StreamSink::Complete(usage, std::mem::take(&mut answer)));
                         return;
                     }
                 }
@@ -240,7 +314,7 @@ async fn drive_stream<Cancel, Next, Fut, B, P>(
             }
         }
     }
-    on(StreamSink::Complete(usage));
+    on(StreamSink::Complete(usage, answer));
 }
 
 /// Drive a provider's streaming response to completion.
@@ -297,6 +371,13 @@ where
 {
     let mut buf = String::new();
     let mut usage = Usage::default();
+    // The full completed answer, accumulated from non-thinking deltas only —
+    // the same shape the renderer buffers — persisted by `finish` so a dropped
+    // frame or missed `done` event can be recovered by polling. A cancel/error
+    // never reaches `finish`, so the partial answer is intentionally discarded
+    // on those paths (the renderer fails the run rather than persisting a
+    // truncated result).
+    let mut answer = String::new();
     loop {
         if is_cancelled(app, job_id) {
             drop(response);
@@ -339,10 +420,15 @@ where
                         usage = u;
                     }
                     if !piece.delta.is_empty() {
+                        if !piece.thinking {
+                            answer.push_str(&piece.delta);
+                        }
                         emit_delta(app, job_id, &piece.delta, piece.thinking);
                     }
                     if piece.done {
-                        finish(app, job_id, trace, status, provider, model, base_url, usage);
+                        finish(
+                            app, job_id, trace, status, provider, model, base_url, usage, &answer,
+                        );
                         return Ok(());
                     }
                 }
@@ -369,7 +455,9 @@ where
         }
     }
 
-    finish(app, job_id, trace, status, provider, model, base_url, usage);
+    finish(
+        app, job_id, trace, status, provider, model, base_url, usage, &answer,
+    );
     Ok(())
 }
 
@@ -396,11 +484,13 @@ mod tests {
 
     /// Collect the sink actions `drive_stream` produces for a canned chunk list.
     /// Each piece is identified by `(emit:delta/thinking, complete, cancelled, error)`.
-    /// `Complete` carries the final [`Usage`] — see the usage-tracking tests below.
+    /// `Complete` carries the final [`Usage`] AND the accumulated answer text
+    /// (non-thinking deltas only) that `finish` persists — see the usage- and
+    /// answer-tracking tests below.
     #[derive(Debug, PartialEq)]
     enum Act {
         Emit(String, bool),
-        Complete(Usage),
+        Complete(Usage, String),
         Cancelled(Usage),
         Error(String, Usage),
     }
@@ -432,7 +522,7 @@ mod tests {
             |sink| {
                 let act = match sink {
                     StreamSink::Emit { delta, thinking } => Act::Emit(delta, thinking),
-                    StreamSink::Complete(usage) => Act::Complete(usage),
+                    StreamSink::Complete(usage, answer) => Act::Complete(usage, answer),
                     StreamSink::Cancelled(usage) => Act::Cancelled(usage),
                     StreamSink::Error(e, usage) => Act::Error(e.to_string(), usage),
                 };
@@ -475,7 +565,7 @@ mod tests {
             vec![
                 Act::Emit("hello".to_string(), false),
                 Act::Emit("world".to_string(), false),
-                Act::Complete(Usage::default()),
+                Act::Complete(Usage::default(), "helloworld".to_string()),
             ]
         );
     }
@@ -493,7 +583,7 @@ mod tests {
             vec![
                 Act::Emit("a".to_string(), false),
                 Act::Emit("b".to_string(), false),
-                Act::Complete(Usage::default()),
+                Act::Complete(Usage::default(), "ab".to_string()),
             ]
         );
     }
@@ -562,7 +652,7 @@ mod tests {
             acts,
             vec![
                 Act::Emit("tail".to_string(), false),
-                Act::Complete(Usage::default())
+                Act::Complete(Usage::default(), "tail".to_string())
             ]
         );
     }
@@ -605,10 +695,15 @@ mod tests {
         );
         assert_eq!(
             acts,
-            vec![Act::Complete(Usage {
-                input_tokens: 10,
-                output_tokens: 99,
-            })],
+            vec![Act::Complete(
+                Usage {
+                    input_tokens: 10,
+                    output_tokens: 99,
+                },
+                // Usage-only pieces carry no visible delta, so the persisted
+                // answer is empty here.
+                String::new(),
+            )],
             "only the LAST usage piece must be recorded, not the first or a sum"
         );
     }
@@ -685,5 +780,162 @@ mod tests {
             "a transport error must still carry the REAL usage already seen, never fabricated \
              but never silently dropped either"
         );
+    }
+
+    // ── Persisted answer text (the poll-fallback contract) ─────────────────────
+    //
+    // `finish` persists the accumulated answer as `result.text` so a renderer
+    // that missed stream frames or the terminal `done` event recovers the
+    // finished document by polling `jobs_get`. These tests pin the two
+    // properties that make that safe: (1) only NON-thinking deltas contribute
+    // (reasoning is never persisted), and (2) inline `<think>…</think>` markup
+    // is stripped, so the poll fallback's longer-wins branch can never resolve
+    // reasoning markup into the final document.
+
+    #[test]
+    fn complete_carries_only_non_thinking_answer_text() {
+        // A parser marking `T:`-prefixed lines as reasoning; everything else is
+        // answer. The `Complete` sink (what `finish` persists) must carry ONLY
+        // the answer deltas — reasoning is excluded, exactly as the renderer
+        // routes provider-flagged `thinking` chunks away from its answer buffer.
+        let parser = |buf: &mut String| -> Vec<StreamPiece> {
+            let mut out = Vec::new();
+            while let Some(nl) = buf.find('\n') {
+                let line = buf[..nl].trim().to_string();
+                *buf = buf[nl + 1..].to_string();
+                if line == "END" {
+                    out.push(StreamPiece::done(""));
+                } else if let Some(reason) = line.strip_prefix("T:") {
+                    out.push(StreamPiece::thinking(reason.to_string()));
+                } else if !line.is_empty() {
+                    out.push(StreamPiece::text(line));
+                }
+            }
+            out
+        };
+        let acts = run(
+            vec![Ok(Some(
+                b"Dear team,\nT:they want speed\nI apply.\nEND\n".to_vec(),
+            ))],
+            None,
+            parser,
+        );
+        assert_eq!(
+            acts,
+            vec![
+                Act::Emit("Dear team,".to_string(), false),
+                Act::Emit("they want speed".to_string(), true),
+                Act::Emit("I apply.".to_string(), false),
+                Act::Complete(Usage::default(), "Dear team,I apply.".to_string()),
+            ],
+            "the persisted answer must exclude provider-flagged reasoning deltas"
+        );
+    }
+
+    #[test]
+    fn persisted_answer_strips_inline_think_markup_it_never_leaks() {
+        // A local reasoning model embeds <think>…</think> inline in a single
+        // answer delta (thinking:false — the renderer's splitter, not the
+        // provider, separates it). The loop accumulates the RAW delta...
+        let parser = |buf: &mut String| -> Vec<StreamPiece> {
+            let s = std::mem::take(buf);
+            if s.is_empty() {
+                vec![]
+            } else {
+                vec![StreamPiece::done(s)]
+            }
+        };
+        let raw = "Dear team,<think>they want speed, be brief</think> I apply now.";
+        let acts = run(vec![Ok(Some(raw.as_bytes().to_vec()))], None, parser);
+        assert_eq!(
+            acts,
+            vec![
+                Act::Emit(raw.to_string(), false),
+                Act::Complete(Usage::default(), raw.to_string()),
+            ],
+            "the accumulated answer is the raw stream; stripping happens in `finish`"
+        );
+        // ...but `finish` persists the THINK-STRIPPED text, so reasoning markup
+        // can never reach the final document via the poll fallback.
+        let persisted = strip_think_blocks(raw);
+        assert_eq!(persisted, "Dear team, I apply now.");
+        assert!(
+            !persisted.contains("<think>") && !persisted.contains("</think>"),
+            "persisted text must never contain reasoning markup"
+        );
+    }
+
+    #[test]
+    fn a_close_tag_split_across_frames_still_strips_clean() {
+        // `</think>` arrives split across two frames. The renderer's STREAMING
+        // splitter can mis-handle this, but the persisted answer accumulates the
+        // whole stream first and strips in one pass — so the persisted text is
+        // strictly equal-or-more-correct and never leaks markup.
+        let passthrough = |buf: &mut String| -> Vec<StreamPiece> {
+            let s = std::mem::take(buf);
+            if s.is_empty() {
+                vec![]
+            } else {
+                vec![StreamPiece::text(s)]
+            }
+        };
+        let acts = run(
+            vec![
+                Ok(Some(b"a<think>b</thi".to_vec())),
+                Ok(Some(b"nk>c".to_vec())),
+                Ok(None),
+            ],
+            None,
+            passthrough,
+        );
+        assert_eq!(
+            acts,
+            vec![
+                Act::Emit("a<think>b</thi".to_string(), false),
+                Act::Emit("nk>c".to_string(), false),
+                Act::Complete(Usage::default(), "a<think>b</think>c".to_string()),
+            ]
+        );
+        assert_eq!(
+            strip_think_blocks("a<think>b</think>c"),
+            "ac",
+            "a </think> split across two stream frames still strips clean once the full \
+             answer is accumulated"
+        );
+    }
+
+    #[test]
+    fn strip_think_blocks_matches_the_renderer_splitter() {
+        // Plain text is untouched.
+        assert_eq!(strip_think_blocks("hello world"), "hello world");
+        // A single block is removed, surrounding text kept.
+        assert_eq!(
+            strip_think_blocks("answer<think>reasoning</think>more"),
+            "answermore"
+        );
+        // Multiple blocks.
+        assert_eq!(
+            strip_think_blocks("a<think>x</think>b<think>y</think>c"),
+            "abc"
+        );
+        // A leading block.
+        assert_eq!(strip_think_blocks("<think>r</think>visible"), "visible");
+        // An empty block.
+        assert_eq!(strip_think_blocks("a<think></think>b"), "ab");
+        // An UNTERMINATED block discards everything from the tag onward — the
+        // renderer's splitter drops an unterminated block at flush().
+        assert_eq!(strip_think_blocks("keep<think>dropped forever"), "keep");
+        // Whatever the input, the output can never contain reasoning markup.
+        for s in [
+            "answer<think>reasoning</think>more",
+            "<think>r</think>visible",
+            "keep<think>dropped forever",
+        ] {
+            let out = strip_think_blocks(s);
+            assert!(
+                !out.contains("<think>") && !out.contains("</think>"),
+                "{s:?} leaked markup"
+            );
+        }
     }
 }

--- a/apps/desktop/src/renderer/lib/generate/stream-promise.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/stream-promise.test.ts
@@ -4,6 +4,15 @@
  * The poll exists precisely because streamed deltas can be dropped (a missed
  * `done`, or a lost chunk mid-stream), so what it resolves must not trust the
  * streamed buffer over the persisted job result.
+ *
+ * The mock below mirrors the REAL backend contract: on a streamed generation's
+ * completion, `finish` (apps/desktop/src-tauri/src/commands/ai_provider/stream.rs)
+ * persists `result = { done: true, text }`, where `text` is the full completed
+ * answer with inline `<think>…</think>` reasoning already stripped backend-side
+ * (`strip_think_blocks`, mirroring `think-split.ts`). The renderer trusts that
+ * text verbatim — it does NOT re-strip — so the no-markup guarantee lives in the
+ * backend. Before this backend change the result was `{ done: true }` with no
+ * `text`, which made this poll fallback a runtime no-op (PR #802 review finding).
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -18,8 +27,12 @@ interface StreamChunk {
   thinking?: boolean;
 }
 
-/** A minimal `AppClient` whose stream can be driven by hand and whose job
- *  status reports `completed` with the given persisted text. */
+/** A minimal `AppClient` whose stream can be driven by hand and whose
+ *  `jobs.get` reports `completed` with the REAL persisted result shape the
+ *  backend produces: `{ done: true, text }` (see `finish` in stream.rs).
+ *  `persisted === undefined` models an older/other backend whose completed
+ *  result carries `done` but no `text` — the poll must then fall back to the
+ *  streamed buffer. */
 function makeApi(persisted: string | undefined) {
   let onChunk: ((chunk: StreamChunk) => void) | null = null;
   const api = {
@@ -36,8 +49,8 @@ function makeApi(persisted: string | undefined) {
         .fn()
         .mockResolvedValue(
           persisted === undefined
-            ? { status: 'completed' }
-            : { status: 'completed', result: { text: persisted } }
+            ? { status: 'completed', result: { done: true } }
+            : { status: 'completed', result: { done: true, text: persisted } }
         ),
       cancel: vi.fn().mockResolvedValue(undefined),
     },
@@ -60,8 +73,8 @@ describe('awaitAiStream — poll fallback', () => {
   });
 
   it('keeps the streamed buffer when it is the longer of the two', async () => {
-    // The persisted text is missing/empty (older backend, or a result shape
-    // without `text`) — the streamed answer is all there is.
+    // The completed result carries `done` but no `text` (older/other backend) —
+    // the streamed answer is all there is, so the buffer must win.
     const { api, push } = makeApi(undefined);
 
     const promise = awaitAiStream(api, 'job-2', { pollIntervalMs: 1 });
@@ -77,5 +90,25 @@ describe('awaitAiStream — poll fallback', () => {
     push({ jobId: 'job-3', delta: 'complete answer', done: true });
 
     await expect(promise).resolves.toBe('complete answer');
+  });
+
+  it('recovered persisted text never contains reasoning markup', async () => {
+    // The local model reasoned inline (`<think>…</think>`), but the backend's
+    // `finish` strips it before persisting `result.text` (see `strip_think_blocks`
+    // in stream.rs), so the poll's longer-wins branch resolves a clean document.
+    // This pins the end-to-end guarantee: because the persisted contract is
+    // think-stripped, a persisted result can never leak reasoning markup into the
+    // resolved text — even though the renderer trusts `result.text` verbatim.
+    const clean = 'Dear hiring manager, I am a strong fit for this role. Sincerely, Jane.';
+    const { api, push } = makeApi(clean);
+
+    const promise = awaitAiStream(api, 'job-4', { pollIntervalMs: 1 });
+    // Only a truncated prefix streamed; no `done` chunk ever lands.
+    push({ jobId: 'job-4', delta: 'Dear hiring manager, ', done: false });
+
+    const resolved = await promise;
+    expect(resolved).toBe(clean);
+    expect(resolved).not.toContain('<think>');
+    expect(resolved).not.toContain('</think>');
   });
 });


### PR DESCRIPTION
## Why

PR #802 ("prefer the persisted result over a truncated stream buffer") made the renderer's poll fallback (`awaitAiStream`) resolve `persisted.length > buffer.length ? persisted : buffer`, reading `result.text` from the completed job. Its review found the fix was a **runtime no-op**: the backend never populated any text on the completed-generation path — the job result was `{ done: true }` — so `result.text` was always `undefined`. A dropped interior stream frame (or a missed terminal `done` event) still resolved a truncated buffer.

## What

Populate the fallback for real, backend-side, at the **provider-agnostic** completion seam:

- **`stream::finish`** (shared by openai / anthropic / gemini / ollama via `stream_response`) now accumulates the completed answer from **non-thinking deltas only** and persists it as `result.text`. A new adapter inherits this for free.
- **`cli_agent::emit_done`** (the CLI-agent subprocess streaming path — claude-code / codex / gemini-cli — which feeds the *same* `awaitAiStream` contract) does the same, so the poll fallback is fixed for that provider family too. No per-provider duplication: both call one shared `strip_think_blocks`.

## Think-strip decision (the critical consistency point)

The renderer's streamed buffer is `<think>`-stripped renderer-side (via `think-split.ts`), and the poll prefers the **longer** of {persisted, buffer}. If the backend persisted **raw** `<think>…</think>` markup, that side would be spuriously longer **and** would resolve reasoning markup into the final document.

I chose to **persist think-stripped text backend-side** (not strip at the renderer comparison boundary), via `strip_think_blocks` mirroring `createThinkSplitter`'s final output exactly (blocks removed; an unterminated `<think>` discards to end). This keeps both sides of the length comparison in the **same shape**, guarantees no path can leak reasoning markup, and needs **no renderer-source change** — only the test was updated. (A `</think>` split across two stream frames — which the renderer's streaming splitter can mis-handle — is resolved correctly here because the whole answer is stripped in one pass, so the persisted text is strictly equal-or-more-correct.)

## Persistence / size

The job result is stored as SQLite `TEXT` (`jobs.result`) and rides the `job.completed` event `Value` — both untyped JSON, so the new `text` field is additive. A generation is at most a few hundred KB (already streamed delta-by-delta); well within SQLite's TEXT limit — **no truncation**.

## Tests

- Rust (`stream.rs`): pinned that the persisted answer excludes provider-flagged reasoning deltas, that inline `<think>` is stripped and **can never leak markup**, cross-frame close-tag robustness, and `strip_think_blocks` cases mirroring the renderer splitter. The tested control-flow core (`drive_stream` / `StreamSink::Complete`) now carries the accumulated answer so it stays an honest mirror of production.
- Renderer (`stream-promise.test.ts`): rewrote the false-confidence mock (was `result: { text }`, a shape the backend never produced) to the **real** contract `result: { done: true, text }`, and added a case pinning that a recovered persisted result never surfaces `<think>` markup.

Gates: `cargo clippy --all-targets --all-features --locked -D warnings`, `cargo fmt --check`, `cargo test` (ai_provider), `pnpm typecheck`, full `pnpm test`, `pnpm lint:strict` — all green (one unrelated `use-extension-bridge` timing flake, passes in isolation).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed AI responses are now reliably saved and recovered when streamed updates are missed.
  * Reasoning content and `<think>` markup are excluded from final responses.
  * Recovered responses no longer expose internal reasoning tags.

* **Tests**
  * Added coverage for response recovery, persisted completion text, and reasoning-content filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->