### PR TITLE
fix(scraping): cap the personio feed body read

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs
@@ -1337,7 +1337,13 @@ async fn try_personio(url: &str) -> Result<Option<JobPosting>> {
     if !res.status().is_success() {
         return Ok(None);
     }
-    let xml = res.text().await?;
+    // Same unbounded-body risk as the generic-HTML fallback above: this host is
+    // attacker-influenced, and `Response::text()` buffers the whole body with no
+    // limit. Read it through the shared cap instead.
+    let xml = match crate::scraping::http::read_text_capped(res, SCRAPE_URL_MAX_BYTES).await {
+        Ok(x) => x,
+        Err(_) => return Ok(None),
+    };
 
     // Shared feed parser (regex set + capture loop) lives in the Personio board.
     // Here we pick the single position whose id matches the URL query and map it


### PR DESCRIPTION
## Summary
- One-item follow-up from PR #821's security review: `try_personio` (`apps/desktop/src-tauri/src/scraping/scrape_url/mod.rs`) fetches the Personio XML feed via the SSRF-guarded `get_guarded` client, but was reading the body unbounded with `res.text().await?`.
- PR #821 capped the sibling generic-HTML fallback in this same resolver at 8 MB via `crate::scraping::http::read_text_capped`; this applies the identical cap here, returning `Ok(None)` on an over-cap/error body the same way the redirect-follow path already does.
- Local single-user OOM class, gated behind a Personio-host match — mechanical one-change fix, no scope creep.

## Test plan
- No new test added: `try_personio`'s network fetch has no hermetic seam in this module (confirmed via the existing note in `scrape_url/test.rs` — "no hermetic network-mock infrastructure for resolve() in this file... out of scope per the existing test style"). PR #821 covered the shared `read_text_capped` helper itself with wiremock tests in `scraping/http/test.rs`, which already exercises this exact code path.
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo test` (scraping module) — 882 passed, 23 ignored, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)