### PR TITLE
fix(ui): stop rendering "0mo ago" for a 28-29 day old timestamp

### DIFF
--- a/apps/desktop/src/renderer/hooks/use-format-relative-time.test.ts
+++ b/apps/desktop/src/renderer/hooks/use-format-relative-time.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useFormatRelativeTime } from './use-format-relative-time';
+
+/** Echoes the i18n key plus its interpolation values, so a test can assert both. */
+const t = ((key: string, vars?: Record<string, unknown>) =>
+  vars ? `${key}:${JSON.stringify(vars)}` : key) as never;
+
+const NOW = 1_750_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('useFormatRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps the tiers contiguous across the week to month handover', () => {
+    // Days 28-29 used to fall through `weeks < 4` into the month tier, where
+    // `months = floor(days / 30)` is still 0 — rendering "0mo ago".
+    const format = useFormatRelativeTime(t);
+    const at = (days: number) => format(NOW - days * DAY);
+
+    expect(at(27)).toBe('jobs.timeWeeksAgo:{"w":3}');
+    expect(at(28)).toBe('jobs.timeWeeksAgo:{"w":4}');
+    expect(at(29)).toBe('jobs.timeWeeksAgo:{"w":4}');
+    expect(at(30)).toBe('jobs.timeMonthsAgo:{"m":1}');
+    expect(at(75)).toBe('jobs.timeMonthsAgo:{"m":2}');
+  });
+
+  it('never interpolates a zero count in any tier', () => {
+    const format = useFormatRelativeTime(t);
+
+    for (let days = 1; days <= 400; days += 1) {
+      expect(format(NOW - days * DAY)).not.toMatch(/:\{"[a-z]":0\}$/);
+    }
+  });
+
+  it('formats the sub-week tiers unchanged', () => {
+    const format = useFormatRelativeTime(t);
+
+    expect(format(NOW)).toBe('jobs.timeJustNow');
+    expect(format(NOW - 5 * 60_000)).toBe('jobs.timeMinutesAgo:{"m":5}');
+    expect(format(NOW - 3 * 60 * 60_000)).toBe('jobs.timeHoursAgo:{"h":3}');
+    expect(format(NOW - 6 * DAY)).toBe('jobs.timeDaysAgo:{"d":6}');
+    expect(format(undefined)).toBe('');
+  });
+
+  it('uses the resume namespace when asked', () => {
+    const format = useFormatRelativeTime(t, 'resumes.relativeTime');
+
+    expect(format(NOW - 29 * DAY)).toBe('resumes.relativeTime.weeksAgo:{"w":4}');
+  });
+});

--- a/apps/desktop/src/renderer/hooks/use-format-relative-time.ts
+++ b/apps/desktop/src/renderer/hooks/use-format-relative-time.ts
@@ -63,7 +63,11 @@ export function useFormatRelativeTime(t: TFunction, nsPrefix: string = 'jobs') {
     if (minutes < 60) return t(keys.minutesAgo, { m: minutes });
     if (hours < 24) return t(keys.hoursAgo, { h: hours });
     if (days < 7) return t(keys.daysAgo, { d: days });
-    if (weeks < 4) return t(keys.weeksAgo, { w: weeks });
+    // Hand over to the month tier at the same 30-day boundary `months` is
+    // floored on. `weeks < 4` ended the week tier at day 28, so days 28–29 fell
+    // through to `monthsAgo` with `months = floor(days / 30) = 0` — rendering
+    // "0mo ago" for a month-old posting.
+    if (days < 30) return t(keys.weeksAgo, { w: weeks });
     return t(keys.monthsAgo, { m: months });
   };
 }


### PR DESCRIPTION
Fixes #832

## What

`useFormatRelativeTime`'s tier ladder had a two-day gap: the week tier ended at `weeks < 4`
(day 28) while the month tier is floored on `days / 30`. Days 28 and 29 fell past the week
tier into `monthsAgo` with `months === 0`, so a month-old posting rendered **"0mo ago"**
(`"vor 0 Mo."` in de).

## How

Hand over to the month tier at the same 30-day boundary `months` is actually computed on:

```diff
 if (days < 7) return t(keys.daysAgo, { d: days });
-if (weeks < 4) return t(keys.weeksAgo, { w: weeks });
+if (days < 30) return t(keys.weeksAgo, { w: weeks });
 return t(keys.monthsAgo, { m: months });
```

| age | before | after |
|---|---|---|
| 27 days | `3w ago` | `3w ago` |
| 28 days | **`0mo ago`** | `4w ago` |
| 29 days | **`0mo ago`** | `4w ago` |
| 30 days | `1mo ago` | `1mo ago` |

Every other tier is byte-identical — `days < 7` still owns days 0-6, day 30 still starts
`1mo ago`. No translation strings change: `timeWeeksAgo` / `weeksAgo` already exist in every
locale.

Both namespaces were affected, so this shows up in more than one screen: `jobs` (posting
`postedAt` on the Jobs page) and `resumes.relativeTime` (`ApplicationDetailPage`,
`GenerationCard`, `InteractionRow`).

## Tests

Adds `use-format-relative-time.test.ts` — the hook had no test file:

- the week → month handover, pinning days 27/28/29/30/75;
- a sweep over days 1-400 asserting **no** tier ever interpolates a zero count. That is the
  property that was actually violated, so it guards the whole ladder rather than just this
  one boundary;
- the sub-week tiers and the falsy-timestamp case, unchanged;
- the `resumes.relativeTime` namespace.

I confirmed the suite fails on `main` with exactly the reported symptom
(`Expected "jobs.timeWeeksAgo:{"w":4}"` / `Received "jobs.timeMonthsAgo:{"m":0}"`) and passes
with the fix.

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint:strict` passes (no warnings)
- [x] `pnpm format:check` passes
- [x] Tests added
- [x] No IPC contract change, so no docs update needed

<sub>Note on local verification: the full `pnpm test` run is not green in my sandbox, but the
failures are pre-existing on unmodified `main` — 13 files / 146 tests fail with
`TypeError: Cannot read properties of undefined (reading 'setItem')` (no `localStorage` in
this environment). I verified that by checking out clean `main` and re-running. The targeted
suite above and the lint/format/typecheck gates all pass; CI is authoritative.</sub>
