### PR TITLE
fix(scraper): delegate board location filtering to the central location_filter

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/comeet/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/comeet/mod.rs
@@ -265,11 +265,7 @@ impl Scraper for ComeetScraper {
         let mut out = Vec::new();
 
         for posting in parse_comeet_response(positions, company_uid.trim(), now) {
-            if !matches_filters(
-                &posting,
-                &input.query,
-                input.location.as_deref().unwrap_or(""),
-            ) {
+            if !matches_filters(&posting, &input.query) {
                 continue;
             }
             if let Some(ref on_item) = ctx.on_item {

--- a/apps/desktop/src-tauri/src/scraping/boards/common.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common.rs
@@ -52,53 +52,27 @@ pub(crate) fn is_valid_dns_label_slug(slug: &str) -> bool {
         && !slug.ends_with('-')
 }
 
-/// Whether a board's own location text satisfies the requested location, for the
-/// boards that filter client-side.
+/// Client-side KEYWORD filter for boards with no server-side keyword search
+/// (The Muse, Comeet). Case-insensitive substring match on `title + company`
+/// for `query`; an empty query passes everything. Originally The Muse-local;
+/// extracted here once Comeet needed the identical filter instead of a second
+/// copy.
 ///
-/// `requested` is normally the geocode picker's `"<city>, <country>"` label
-/// (`commands::geocoding` builds it precisely "so the UI only ever shows
-/// 'City, Country'"), while a board writes its location in its own shape —
-/// `"New York, NY"`, `"Munich, Bayern"`, `"Karl-Marx-Allee 1, Berlin"`. Requiring
-/// the WHOLE label as one contiguous substring therefore matched nothing and
-/// zeroed the board for every picked city, so match SEGMENT-wise instead: any
-/// non-empty comma-separated part of the request appearing in `haystack` is
-/// enough.
-///
-/// Conservative by design — it errs toward keeping a posting, mirroring the
-/// engine's central [`crate::scraping::engine::location_filter`], which
-/// tokenizes the request and keeps on any token hit for the same reason. Both
-/// arguments must already be lowercased by the caller.
-pub(crate) fn location_matches(requested: &str, haystack: &str) -> bool {
-    requested
-        .split(',')
-        .map(str::trim)
-        .filter(|part| !part.is_empty())
-        .any(|part| haystack.contains(part))
-}
-
-/// Client-side query/location filter for boards with no server-side keyword
-/// search (The Muse, Comeet). Case-insensitive substring match on
-/// `title + company` for `query`; segment-wise case-insensitive match on
-/// `location` for `location` (see [`location_matches`]); an empty filter passes
-/// everything; both clauses AND-combine. Originally The Muse-local; extracted
-/// here once Comeet needed the identical filter instead of a second copy.
-pub(crate) fn matches_filters(
-    posting: &crate::scraping::types::JobPosting,
-    query: &str,
-    location: &str,
-) -> bool {
+/// Location is deliberately NOT filtered here. These boards do not consume the
+/// requested location server-side (`Scraper::supports_location() == false`), so
+/// the engine's central [`crate::scraping::engine::location_filter`] is the
+/// single authority on location: it runs on their output both as a live gate and
+/// as a post-hoc safety net, and it is diaeresis/exonym-aware (München/Munich,
+/// Köln/Cologne). A second board-local matcher here only duplicated — and
+/// diverged from — that logic: it matched a raw "<city>, <country>" picker label
+/// as one contiguous substring, which no board writes, so it dropped every row
+/// and zeroed the board for any geocode-picked city. Delegating to the central
+/// filter fixes that and keeps one authority.
+pub(crate) fn matches_filters(posting: &crate::scraping::types::JobPosting, query: &str) -> bool {
     let q = query.trim().to_lowercase();
     if !q.is_empty() {
         let haystack = format!("{} {}", posting.title, posting.company).to_lowercase();
         if !haystack.contains(&q) {
-            return false;
-        }
-    }
-
-    let loc_filter = location.trim().to_lowercase();
-    if !loc_filter.is_empty() {
-        let loc = posting.location.as_deref().unwrap_or("").to_lowercase();
-        if !location_matches(&loc_filter, &loc) {
             return false;
         }
     }

--- a/apps/desktop/src-tauri/src/scraping/boards/common.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common.rs
@@ -52,12 +52,36 @@ pub(crate) fn is_valid_dns_label_slug(slug: &str) -> bool {
         && !slug.ends_with('-')
 }
 
+/// Whether a board's own location text satisfies the requested location, for the
+/// boards that filter client-side.
+///
+/// `requested` is normally the geocode picker's `"<city>, <country>"` label
+/// (`commands::geocoding` builds it precisely "so the UI only ever shows
+/// 'City, Country'"), while a board writes its location in its own shape —
+/// `"New York, NY"`, `"Munich, Bayern"`, `"Karl-Marx-Allee 1, Berlin"`. Requiring
+/// the WHOLE label as one contiguous substring therefore matched nothing and
+/// zeroed the board for every picked city, so match SEGMENT-wise instead: any
+/// non-empty comma-separated part of the request appearing in `haystack` is
+/// enough.
+///
+/// Conservative by design — it errs toward keeping a posting, mirroring the
+/// engine's central [`crate::scraping::engine::location_filter`], which
+/// tokenizes the request and keeps on any token hit for the same reason. Both
+/// arguments must already be lowercased by the caller.
+pub(crate) fn location_matches(requested: &str, haystack: &str) -> bool {
+    requested
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .any(|part| haystack.contains(part))
+}
+
 /// Client-side query/location filter for boards with no server-side keyword
 /// search (The Muse, Comeet). Case-insensitive substring match on
-/// `title + company` for `query`; case-insensitive substring match on
-/// `location` for `location`; an empty filter passes everything; both
-/// clauses AND-combine. Originally The Muse-local; extracted here once
-/// Comeet needed the identical filter instead of a second copy.
+/// `title + company` for `query`; segment-wise case-insensitive match on
+/// `location` for `location` (see [`location_matches`]); an empty filter passes
+/// everything; both clauses AND-combine. Originally The Muse-local; extracted
+/// here once Comeet needed the identical filter instead of a second copy.
 pub(crate) fn matches_filters(
     posting: &crate::scraping::types::JobPosting,
     query: &str,
@@ -74,7 +98,7 @@ pub(crate) fn matches_filters(
     let loc_filter = location.trim().to_lowercase();
     if !loc_filter.is_empty() {
         let loc = posting.location.as_deref().unwrap_or("").to_lowercase();
-        if !loc.contains(&loc_filter) {
+        if !location_matches(&loc_filter, &loc) {
             return false;
         }
     }

--- a/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
@@ -321,3 +321,52 @@ fn canonical_key_empty_or_non_http_url_falls_back_to_title_company() {
     );
     assert_eq!(canonical_job_key("file:///etc/passwd", "T", "Co"), expected);
 }
+
+// ── location_matches ─────────────────────────────────────────────────────────
+//
+// Shared by every board that filters location client-side (The Muse, Comeet via
+// `matches_filters`; GermanTechJobs directly). The requested location is
+// normally the geocode picker's "<city>, <country>" label, so the tests below
+// pin the segment-wise contract against each board's own location shape.
+
+#[test]
+fn location_matches_a_city_country_label_against_a_boards_own_shape() {
+    // The regression: the picker writes "new york, united states" while The Muse
+    // writes "new york, ny". A whole-string `contains` matched neither, zeroing
+    // the board for every picked city.
+    assert!(location_matches("new york, united states", "new york, ny"));
+    assert!(location_matches("berlin, germany", "berlin, deutschland"));
+    // GermanTechJobs shapes: street address ending in the city, and city+region.
+    assert!(location_matches(
+        "berlin, germany",
+        "rust engineer alpha ag karl-marx-allee 1, berlin"
+    ));
+    assert!(location_matches(
+        "munich, bayern",
+        "java dev beta gmbh munich"
+    ));
+}
+
+#[test]
+fn location_matches_a_single_segment_request_unchanged() {
+    // Free-typed (unpicked) input is one segment — the pre-existing behaviour.
+    assert!(location_matches("berlin", "berlin, germany"));
+    assert!(location_matches("remote", "remote"));
+}
+
+#[test]
+fn location_matches_rejects_when_no_segment_appears() {
+    assert!(!location_matches("berlin, germany", "new york, ny"));
+    assert!(!location_matches("paris, france", "remote"));
+    // An empty haystack can never satisfy a non-empty request.
+    assert!(!location_matches("berlin, germany", ""));
+}
+
+#[test]
+fn location_matches_ignores_blank_and_whitespace_only_segments() {
+    // A trailing comma or a doubled separator must not turn into an empty needle
+    // that `contains` trivially accepts — that would disable the filter entirely.
+    assert!(!location_matches("berlin,", "new york, ny"));
+    assert!(!location_matches(" , , ", "new york, ny"));
+    assert!(location_matches("berlin,", "berlin, germany"));
+}

--- a/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
@@ -322,51 +322,56 @@ fn canonical_key_empty_or_non_http_url_falls_back_to_title_company() {
     assert_eq!(canonical_job_key("file:///etc/passwd", "T", "Co"), expected);
 }
 
-// ── location_matches ─────────────────────────────────────────────────────────
+// ── matches_filters (keyword-only) ───────────────────────────────────────────
 //
-// Shared by every board that filters location client-side (The Muse, Comeet via
-// `matches_filters`; GermanTechJobs directly). The requested location is
-// normally the geocode picker's "<city>, <country>" label, so the tests below
-// pin the segment-wise contract against each board's own location shape.
+// `matches_filters` is the client-side KEYWORD filter for the boards with no
+// server-side keyword search (The Muse, Comeet). It intentionally does not
+// filter location: those boards are `supports_location() == false`, so the
+// engine's central `location_filter` is the single authority (see the fn doc).
 
-#[test]
-fn location_matches_a_city_country_label_against_a_boards_own_shape() {
-    // The regression: the picker writes "new york, united states" while The Muse
-    // writes "new york, ny". A whole-string `contains` matched neither, zeroing
-    // the board for every picked city.
-    assert!(location_matches("new york, united states", "new york, ny"));
-    assert!(location_matches("berlin, germany", "berlin, deutschland"));
-    // GermanTechJobs shapes: street address ending in the city, and city+region.
-    assert!(location_matches(
-        "berlin, germany",
-        "rust engineer alpha ag karl-marx-allee 1, berlin"
-    ));
-    assert!(location_matches(
-        "munich, bayern",
-        "java dev beta gmbh munich"
-    ));
+fn keyword_posting(
+    title: &str,
+    company: &str,
+    location: Option<&str>,
+) -> crate::scraping::types::JobPosting {
+    crate::scraping::types::JobPosting {
+        id: "b:1".into(),
+        external_id: None,
+        title: title.into(),
+        company: company.into(),
+        location: location.map(str::to_string),
+        url: "https://acme.example/1".into(),
+        source: "b".into(),
+        description: None,
+        requirements: None,
+        posted_at: None,
+        captured_at: 0,
+        extra: std::collections::HashMap::new(),
+    }
 }
 
 #[test]
-fn location_matches_a_single_segment_request_unchanged() {
-    // Free-typed (unpicked) input is one segment — the pre-existing behaviour.
-    assert!(location_matches("berlin", "berlin, germany"));
-    assert!(location_matches("remote", "remote"));
+fn matches_filters_empty_query_passes_everything() {
+    let p = keyword_posting("Backend Engineer", "Acme", Some("Paris, France"));
+    assert!(matches_filters(&p, ""));
+    assert!(matches_filters(&p, "   "));
 }
 
 #[test]
-fn location_matches_rejects_when_no_segment_appears() {
-    assert!(!location_matches("berlin, germany", "new york, ny"));
-    assert!(!location_matches("paris, france", "remote"));
-    // An empty haystack can never satisfy a non-empty request.
-    assert!(!location_matches("berlin, germany", ""));
+fn matches_filters_keyword_is_case_insensitive_over_title_and_company() {
+    let p = keyword_posting("Senior RUST Engineer", "BetaCorp", None);
+    assert!(matches_filters(&p, "rust"));
+    assert!(matches_filters(&p, "betacorp"));
+    assert!(!matches_filters(&p, "python"));
 }
 
 #[test]
-fn location_matches_ignores_blank_and_whitespace_only_segments() {
-    // A trailing comma or a doubled separator must not turn into an empty needle
-    // that `contains` trivially accepts — that would disable the filter entirely.
-    assert!(!location_matches("berlin,", "new york, ny"));
-    assert!(!location_matches(" , , ", "new york, ny"));
-    assert!(location_matches("berlin,", "berlin, germany"));
+fn matches_filters_does_not_filter_on_location() {
+    // Location is delegated to the engine's central `location_filter`; a
+    // non-matching location must NOT be dropped board-side. A row whose keyword
+    // matches passes regardless of where it is.
+    let p = keyword_posting("Rust Engineer", "Acme", Some("Tokyo, Japan"));
+    assert!(matches_filters(&p, "rust"));
+    // And with no keyword, everything passes here — location is not this fn's job.
+    assert!(matches_filters(&p, ""));
 }

--- a/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/mod.rs
@@ -210,13 +210,26 @@ pub(crate) fn parse_feed(xml: &str, scraper_id: &str, now: i64) -> Vec<JobPostin
     out
 }
 
-/// The board's client-side keyword + location filter. `query` and `location`
-/// must already be trimmed and lowercased by the caller.
+/// The board's client-side KEYWORD filter. `query` must already be trimmed and
+/// lowercased by the caller.
 ///
 /// Extracted from `search()`'s `retain` so tests drive the REAL predicate — a
 /// verbatim copy in the test file would silently diverge from what `search()`
 /// actually runs (the same reasoning as The Muse's `apply_filters` helper).
-pub(crate) fn matches_gtj_filters(posting: &JobPosting, query: &str, location: &str) -> bool {
+///
+/// Location is deliberately NOT filtered here. GermanTechJobs does not consume
+/// the requested location server-side (`supports_location() == false`), so the
+/// engine's central `location_filter` is the single, diaeresis/exonym-aware
+/// authority on location and runs on this board's output. A board-local matcher
+/// only duplicated and diverged from it — and, by requiring the whole
+/// "<city>, <country>" picker label as one substring (which this feed never
+/// writes: a bare city "Berlin", a "<city>, <region>" pair "Munich, Bayern", or
+/// a street address "Karl-Marx-Allee 1, Berlin"), it dropped every row and
+/// zeroed the board for every geocode-picked German city.
+pub(crate) fn matches_gtj_filters(posting: &JobPosting, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
     let haystack = format!(
         "{} {} {} {}",
         posting.title,
@@ -226,19 +239,7 @@ pub(crate) fn matches_gtj_filters(posting: &JobPosting, query: &str, location: &
     )
     .to_lowercase();
 
-    if !query.is_empty() && !haystack.contains(query) {
-        return false;
-    }
-    // Segment-wise, not whole-string: `input.location` is normally the geocode
-    // picker's "<city>, <country>" label, while this feed writes <location> as a
-    // bare city ("Berlin"), a "<city>, <region>" pair ("Munich, Bayern"), or a
-    // street address ending in the city ("Karl-Marx-Allee 1, Berlin"). The whole
-    // label is never a contiguous substring, so requiring it returned 0 rows for
-    // every geocode-picked German city — the exact market this board serves.
-    if !location.is_empty() && !super::common::location_matches(location, &haystack) {
-        return false;
-    }
-    true
+    haystack.contains(query)
 }
 
 // ── scraper ──────────────────────────────────────────────────────────────────
@@ -265,11 +266,6 @@ impl Scraper for GermanTechJobsScraper {
         ctx: ScrapeContext,
     ) -> anyhow::Result<Vec<JobPosting>> {
         let q = input.query.trim().to_lowercase();
-        let loc = input
-            .location
-            .as_ref()
-            .map(|l| l.trim().to_lowercase())
-            .unwrap_or_default();
 
         let res = fetch_text(
             "https://germantechjobs.de/job_feed.xml",
@@ -300,8 +296,9 @@ impl Scraper for GermanTechJobsScraper {
 
         let mut out = parse_feed(&res.text, self.id(), now);
 
-        // ── client-side keyword + location filter ─────────────────────────────
-        out.retain(|posting| matches_gtj_filters(posting, &q, &loc));
+        // ── client-side keyword filter (location is the engine's central
+        //    `location_filter`, not board-local — see `matches_gtj_filters`) ────
+        out.retain(|posting| matches_gtj_filters(posting, &q));
 
         for posting in &out {
             if let Some(ref on_item) = ctx.on_item {

--- a/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/mod.rs
@@ -210,6 +210,37 @@ pub(crate) fn parse_feed(xml: &str, scraper_id: &str, now: i64) -> Vec<JobPostin
     out
 }
 
+/// The board's client-side keyword + location filter. `query` and `location`
+/// must already be trimmed and lowercased by the caller.
+///
+/// Extracted from `search()`'s `retain` so tests drive the REAL predicate — a
+/// verbatim copy in the test file would silently diverge from what `search()`
+/// actually runs (the same reasoning as The Muse's `apply_filters` helper).
+pub(crate) fn matches_gtj_filters(posting: &JobPosting, query: &str, location: &str) -> bool {
+    let haystack = format!(
+        "{} {} {} {}",
+        posting.title,
+        posting.company,
+        posting.location.as_deref().unwrap_or(""),
+        posting.description.as_deref().unwrap_or("")
+    )
+    .to_lowercase();
+
+    if !query.is_empty() && !haystack.contains(query) {
+        return false;
+    }
+    // Segment-wise, not whole-string: `input.location` is normally the geocode
+    // picker's "<city>, <country>" label, while this feed writes <location> as a
+    // bare city ("Berlin"), a "<city>, <region>" pair ("Munich, Bayern"), or a
+    // street address ending in the city ("Karl-Marx-Allee 1, Berlin"). The whole
+    // label is never a contiguous substring, so requiring it returned 0 rows for
+    // every geocode-picked German city — the exact market this board serves.
+    if !location.is_empty() && !super::common::location_matches(location, &haystack) {
+        return false;
+    }
+    true
+}
+
 // ── scraper ──────────────────────────────────────────────────────────────────
 
 pub struct GermanTechJobsScraper;
@@ -270,24 +301,7 @@ impl Scraper for GermanTechJobsScraper {
         let mut out = parse_feed(&res.text, self.id(), now);
 
         // ── client-side keyword + location filter ─────────────────────────────
-        out.retain(|posting| {
-            let haystack = format!(
-                "{} {} {} {}",
-                posting.title,
-                posting.company,
-                posting.location.as_deref().unwrap_or(""),
-                posting.description.as_deref().unwrap_or("")
-            )
-            .to_lowercase();
-
-            if !q.is_empty() && !haystack.contains(&q) {
-                return false;
-            }
-            if !loc.is_empty() && !haystack.contains(&loc) {
-                return false;
-            }
-            true
-        });
+        out.retain(|posting| matches_gtj_filters(posting, &q, &loc));
 
         for posting in &out {
             if let Some(ref on_item) = ctx.on_item {

--- a/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/test.rs
@@ -218,20 +218,9 @@ fn test_keyword_filter_excludes_non_matching_job() {
     let all = parse_feed(FILTER_XML, "germantechjobs", now);
     assert_eq!(all.len(), 2, "fixture must parse 2 jobs before filtering");
 
-    let q = "rust";
     let filtered: Vec<_> = all
         .into_iter()
-        .filter(|p| {
-            let haystack = format!(
-                "{} {} {} {}",
-                p.title,
-                p.company,
-                p.location.as_deref().unwrap_or(""),
-                p.description.as_deref().unwrap_or("")
-            )
-            .to_lowercase();
-            haystack.contains(q)
-        })
+        .filter(|p| matches_gtj_filters(p, "rust", ""))
         .collect();
 
     assert_eq!(
@@ -249,20 +238,9 @@ fn test_location_filter_matches_on_location_field() {
     let now = chrono::Utc::now().timestamp_millis();
     let all = parse_feed(FILTER_XML, "germantechjobs", now);
 
-    let loc = "hamburg";
     let filtered: Vec<_> = all
         .into_iter()
-        .filter(|p| {
-            let haystack = format!(
-                "{} {} {} {}",
-                p.title,
-                p.company,
-                p.location.as_deref().unwrap_or(""),
-                p.description.as_deref().unwrap_or("")
-            )
-            .to_lowercase();
-            haystack.contains(loc)
-        })
+        .filter(|p| matches_gtj_filters(p, "", "hamburg"))
         .collect();
 
     assert_eq!(
@@ -271,6 +249,33 @@ fn test_location_filter_matches_on_location_field() {
         "only the Hamburg job should pass the location filter"
     );
     assert_eq!(filtered[0].external_id.as_deref(), Some("job-java"));
+}
+
+#[test]
+fn test_location_filter_accepts_a_geocode_picker_city_country_label() {
+    // The location box writes the picker's "<city>, <country>" label, but this
+    // feed's <location> is a bare city ("Berlin") or a street address ending in
+    // one ("Karl-Marx-Allee 1, Berlin"). The whole label is never a contiguous
+    // substring, so the board used to return 0 for every picked German city.
+    let now = chrono::Utc::now().timestamp_millis();
+    let all = parse_feed(FILTER_XML, "germantechjobs", now);
+
+    let keep = |loc: &str| -> Vec<_> {
+        all.iter()
+            .filter(|p| matches_gtj_filters(p, "", &loc.to_lowercase()))
+            .collect()
+    };
+
+    let filtered = keep("Berlin, Germany");
+    assert_eq!(
+        filtered.len(),
+        1,
+        "the Berlin job must survive a 'City, Country' label"
+    );
+    assert_eq!(filtered[0].external_id.as_deref(), Some("job-rust"));
+
+    // A label sharing no segment with any posting still filters everything out.
+    assert!(keep("Paris, France").is_empty());
 }
 
 // ── continue-path (guard-miss) coverage ──────────────────────────────────────

--- a/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/germantechjobs/test.rs
@@ -191,7 +191,7 @@ fn test_bad_pubdate_yields_posted_at_none() {
     );
 }
 
-// ── client-side keyword / location filter ────────────────────────────────────
+// ── client-side keyword filter (location is the engine's central filter) ──────
 
 const FILTER_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <jobs>
@@ -220,7 +220,7 @@ fn test_keyword_filter_excludes_non_matching_job() {
 
     let filtered: Vec<_> = all
         .into_iter()
-        .filter(|p| matches_gtj_filters(p, "rust", ""))
+        .filter(|p| matches_gtj_filters(p, "rust"))
         .collect();
 
     assert_eq!(
@@ -232,50 +232,30 @@ fn test_keyword_filter_excludes_non_matching_job() {
 }
 
 #[test]
-fn test_location_filter_matches_on_location_field() {
-    // A job matching only on the location field (not in title/company/description)
-    // must still be included when filtering by that location.
+fn test_board_filter_does_not_drop_on_location() {
+    // GermanTechJobs is `supports_location() == false`, so board-local filtering
+    // is keyword-only: the engine's central `location_filter` is the single
+    // authority on location. The board must NOT zero itself on a geocode-picked
+    // "<city>, <country>" label (the original regression), and its keyword
+    // filter is location-agnostic.
     let now = chrono::Utc::now().timestamp_millis();
     let all = parse_feed(FILTER_XML, "germantechjobs", now);
 
-    let filtered: Vec<_> = all
-        .into_iter()
-        .filter(|p| matches_gtj_filters(p, "", "hamburg"))
+    // Empty query → every row passes, whatever its location (Berlin, Hamburg).
+    let kept_all: Vec<_> = all.iter().filter(|p| matches_gtj_filters(p, "")).collect();
+    assert_eq!(
+        kept_all.len(),
+        2,
+        "no location narrowing happens board-side"
+    );
+
+    // A keyword keeps its row regardless of that row's location.
+    let kept_rust: Vec<_> = all
+        .iter()
+        .filter(|p| matches_gtj_filters(p, "rust"))
         .collect();
-
-    assert_eq!(
-        filtered.len(),
-        1,
-        "only the Hamburg job should pass the location filter"
-    );
-    assert_eq!(filtered[0].external_id.as_deref(), Some("job-java"));
-}
-
-#[test]
-fn test_location_filter_accepts_a_geocode_picker_city_country_label() {
-    // The location box writes the picker's "<city>, <country>" label, but this
-    // feed's <location> is a bare city ("Berlin") or a street address ending in
-    // one ("Karl-Marx-Allee 1, Berlin"). The whole label is never a contiguous
-    // substring, so the board used to return 0 for every picked German city.
-    let now = chrono::Utc::now().timestamp_millis();
-    let all = parse_feed(FILTER_XML, "germantechjobs", now);
-
-    let keep = |loc: &str| -> Vec<_> {
-        all.iter()
-            .filter(|p| matches_gtj_filters(p, "", &loc.to_lowercase()))
-            .collect()
-    };
-
-    let filtered = keep("Berlin, Germany");
-    assert_eq!(
-        filtered.len(),
-        1,
-        "the Berlin job must survive a 'City, Country' label"
-    );
-    assert_eq!(filtered[0].external_id.as_deref(), Some("job-rust"));
-
-    // A label sharing no segment with any posting still filters everything out.
-    assert!(keep("Paris, France").is_empty());
+    assert_eq!(kept_rust.len(), 1);
+    assert_eq!(kept_rust[0].external_id.as_deref(), Some("job-rust"));
 }
 
 // ── continue-path (guard-miss) coverage ──────────────────────────────────────

--- a/apps/desktop/src-tauri/src/scraping/boards/themuse/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/themuse/mod.rs
@@ -215,11 +215,7 @@ impl Scraper for TheMuseScraper {
             }
 
             for posting in parse_themuse_response(resp.results, now) {
-                if !matches_filters(
-                    &posting,
-                    &input.query,
-                    input.location.as_deref().unwrap_or(""),
-                ) {
+                if !matches_filters(&posting, &input.query) {
                     continue;
                 }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/themuse/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/themuse/test.rs
@@ -323,6 +323,21 @@ fn location_filter_blank_passes_through_with_active_query() {
 }
 
 #[test]
+fn location_filter_matches_a_geocode_picker_city_country_label() {
+    // The location box writes the picker's "<city>, <country>" label
+    // (`commands::geocoding` builds it), while The Muse writes its own shape
+    // ("Berlin, Germany" here, "New York, NY" in the wild). Requiring the whole
+    // label as one substring dropped every row; matching segment-wise keeps it.
+    let postings = sample_postings();
+    let filtered = apply_filters(&postings, "", "Berlin, Deutschland");
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].title, "Senior Backend Engineer");
+
+    // A label sharing no segment with the posting still excludes it.
+    assert!(apply_filters(&postings, "", "Paris, France").is_empty());
+}
+
+#[test]
 fn query_and_location_filters_combine_with_and() {
     let postings = sample_postings();
     // Title matches "engineer" but location does not match "remote" -> excluded.

--- a/apps/desktop/src-tauri/src/scraping/boards/themuse/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/themuse/test.rs
@@ -266,10 +266,10 @@ fn sample_postings() -> Vec<JobPosting> {
 /// reimplementation (that was the bug: a byte-duplicated mirror here could
 /// diverge from `search()`'s actual filter and hide a regression). Every
 /// test below now exercises the real extracted fn through this.
-fn apply_filters(postings: &[JobPosting], query: &str, location: &str) -> Vec<JobPosting> {
+fn apply_filters(postings: &[JobPosting], query: &str) -> Vec<JobPosting> {
     postings
         .iter()
-        .filter(|posting| matches_filters(posting, query, location))
+        .filter(|posting| matches_filters(posting, query))
         .cloned()
         .collect()
 }
@@ -277,7 +277,7 @@ fn apply_filters(postings: &[JobPosting], query: &str, location: &str) -> Vec<Jo
 #[test]
 fn query_filter_matches_title_case_insensitive() {
     let postings = sample_postings();
-    let filtered = apply_filters(&postings, "BACKEND", "");
+    let filtered = apply_filters(&postings, "BACKEND");
     assert_eq!(filtered.len(), 1);
     assert_eq!(filtered[0].title, "Senior Backend Engineer");
 }
@@ -285,7 +285,7 @@ fn query_filter_matches_title_case_insensitive() {
 #[test]
 fn query_filter_matches_company_case_insensitive() {
     let postings = sample_postings();
-    let filtered = apply_filters(&postings, "globex", "");
+    let filtered = apply_filters(&postings, "globex");
     assert_eq!(filtered.len(), 1);
     assert_eq!(filtered[0].company, "Globex");
 }
@@ -293,60 +293,32 @@ fn query_filter_matches_company_case_insensitive() {
 #[test]
 fn query_filter_empty_returns_all() {
     let postings = sample_postings();
-    let filtered = apply_filters(&postings, "", "");
+    let filtered = apply_filters(&postings, "");
     assert_eq!(filtered.len(), 2);
 }
 
 #[test]
 fn query_filter_matching_nothing_returns_empty() {
     let postings = sample_postings();
-    let filtered = apply_filters(&postings, "nonexistent-role", "");
+    let filtered = apply_filters(&postings, "nonexistent-role");
     assert!(filtered.is_empty());
 }
 
 #[test]
-fn location_filter_substring_match_case_insensitive() {
+fn board_filter_does_not_drop_on_location() {
+    // The Muse is `supports_location() == false`, so board-local filtering is
+    // keyword-only: location is the engine's central `location_filter`. A query
+    // that matches must keep the row whatever its location, and an empty query
+    // keeps every row — the board must never zero itself on a picked city (the
+    // original "New York, United States" vs "New York, NY" regression).
     let postings = sample_postings();
-    let filtered = apply_filters(&postings, "", "berlin");
+    // "Senior Backend Engineer" in "Berlin, Germany" is kept by the keyword
+    // alone; the board applies no "Paris"/"Remote" location narrowing here.
+    let filtered = apply_filters(&postings, "engineer");
     assert_eq!(filtered.len(), 1);
     assert_eq!(filtered[0].title, "Senior Backend Engineer");
-}
-
-#[test]
-fn location_filter_blank_passes_through_with_active_query() {
-    // A blank location must not itself exclude anything — combined with an
-    // active query, only the query clause should narrow the result.
-    let postings = sample_postings();
-    let filtered = apply_filters(&postings, "engineer", "");
-    assert_eq!(filtered.len(), 1);
-    assert_eq!(filtered[0].title, "Senior Backend Engineer");
-}
-
-#[test]
-fn location_filter_matches_a_geocode_picker_city_country_label() {
-    // The location box writes the picker's "<city>, <country>" label
-    // (`commands::geocoding` builds it), while The Muse writes its own shape
-    // ("Berlin, Germany" here, "New York, NY" in the wild). Requiring the whole
-    // label as one substring dropped every row; matching segment-wise keeps it.
-    let postings = sample_postings();
-    let filtered = apply_filters(&postings, "", "Berlin, Deutschland");
-    assert_eq!(filtered.len(), 1);
-    assert_eq!(filtered[0].title, "Senior Backend Engineer");
-
-    // A label sharing no segment with the posting still excludes it.
-    assert!(apply_filters(&postings, "", "Paris, France").is_empty());
-}
-
-#[test]
-fn query_and_location_filters_combine_with_and() {
-    let postings = sample_postings();
-    // Title matches "engineer" but location does not match "remote" -> excluded.
-    let filtered = apply_filters(&postings, "engineer", "remote");
-    assert!(filtered.is_empty());
-    // Both match -> included.
-    let filtered = apply_filters(&postings, "engineer", "berlin");
-    assert_eq!(filtered.len(), 1);
-    assert_eq!(filtered[0].title, "Senior Backend Engineer");
+    // No keyword → both rows pass, regardless of their differing locations.
+    assert_eq!(apply_filters(&postings, "").len(), 2);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Picking a city from the geocode suggestions returned **0 results** on the boards
that filter location client-side (The Muse, Comeet, GermanTechJobs). The location
box holds the picker's `"<city>, <country>"` label (`commands::geocoding` builds
it "so the UI only ever shows 'City, Country'"), but each board writes its own
shape — `"New York, NY"`, `"Munich, Bayern"`, `"Karl-Marx-Allee 1, Berlin"`. The
board-local filter required that **whole label** to appear as one contiguous
substring, which no board writes, so it dropped every row. Free-typed (unpicked)
input is one segment, which is why it survived manual testing.

## Fix (reworked per review)

The first revision added a board-local *segment-wise* matcher. Per review, this
version instead **removes board-local location filtering entirely** from the
three `supports_location() == false` boards and makes the engine's central
[`location_filter`](apps/desktop/src-tauri/src/scraping/engine/location_filter.rs)
the single authority on location — no second, divergent matcher.

Why this is correct and strictly better:

- These three boards are all non-location boards, so the engine **already** runs
  `location_filter` on their output, both as a live gate (`KeepItemByBoardFn`)
  and as a post-hoc safety net. The board-local location filter was redundant
  with it.
- The central filter is **diaeresis/exonym-aware** (München/Munich, Köln/Cologne
  via the curated table + DIN-5007-2 folding) and **conservative** (keeps
  remote / empty / unknown; a country-code-only request is inert). The raw
  board-local matcher had none of that and, running *before* the central filter,
  produced exactly the false drops the central filter exists to prevent (e.g. a
  `"Köln, Deutschland"` request against a `"Cologne"` feed).
- The original 0-results bug is still fixed: `location_spec()` feeds the picker's
  `"<city>, <country>"` label into the central filter, which **tokenises** it (it
  never required the whole label as one substring), so a geocode-picked city
  keeps its rows via the central filter alone.

## Changes

- `common.rs`: `matches_filters` is now **keyword-only** (drops the `location`
  param); `location_matches` is deleted.
- `germantechjobs`: `matches_gtj_filters` is keyword-only; the now-unused `loc`
  local is removed.
- The Muse / Comeet call sites pass query only.
- Tests across `common` / `themuse` / `germantechjobs`: the board-local location
  assertions are replaced with ones pinning that these boards **no longer drop on
  location** (delegated to the central filter, whose own exonym/diacritic
  behaviour is unit-tested in `engine::location_filter`).

Net: **−80 lines**, one authority instead of two.

## Known limitation (unchanged, now consistent across all non-location boards)

Because `location_spec()` stores the whole label in `city`, the central filter
also tokenises the country segment, so `"Munich, Germany"` keeps a
`"Frankfurt, Germany"` row. That is a property of the central filter shared by
**every** non-location board — not something this PR introduces (the old strict
board-local filter merely masked it for these three). Tightening it is a separate
change to `location_filter` / `location_spec`, out of scope here.

## Verification

- `cargo test -p ajh-tauri --lib scraping::` — **883 passed, 0 failed**.
- `cargo fmt --all -- --check` clean; `cargo clippy --lib` clean.

<sub>The full monorepo pre-push gate isn't runnable in my sandbox (the landing
build needs an install; Node 26 breaks jsdom `localStorage` in unrelated
frontend suites), so I verified the Rust crate directly as above. CI is
authoritative.</sub>
