### PR TITLE
fix(ai): stop corrupting streamed text at a chunk boundary

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
@@ -668,8 +668,10 @@ pub async fn pull(app: &AppHandle, job_id: &str, model: &str) -> AppResult<()> {
     }
 
     let mut line_buf = String::new();
+    // Bytes from a read that ended mid-UTF-8-sequence — see `stream::push_utf8`.
+    let mut carry: Vec<u8> = Vec::new();
     while let Some(bytes) = response.chunk().await.map_err(|e| e.to_string())? {
-        line_buf.push_str(&String::from_utf8_lossy(&bytes));
+        super::stream::push_utf8(&mut line_buf, &mut carry, &bytes);
         // Walk by a `consumed` offset and drain the parsed prefix once after the
         // inner loop, instead of reallocating the whole tail per line (O(n²)).
         let mut consumed = 0;

--- a/apps/desktop/src-tauri/src/commands/ai_provider/stream.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/stream.rs
@@ -210,6 +210,52 @@ pub(super) fn strip_think_blocks(text: &str) -> String {
     out
 }
 
+/// Append one transport read to `buf` as UTF-8, holding back an incomplete
+/// trailing sequence in `carry` for the next read.
+///
+/// `reqwest::Response::chunk` splits the body at arbitrary byte offsets — a
+/// chunked-transfer body surfaces as the socket reads land, and h2 DATA frames
+/// are cut wherever the server flushed. So one multi-byte character (an em dash,
+/// a curly quote, an accented letter, an emoji) routinely straddles two reads.
+/// Decoding each read on its own with `String::from_utf8_lossy` replaced BOTH
+/// halves with `U+FFFD`, and since a replacement char is legal inside a JSON
+/// string the frame still parsed — the mojibake was forwarded to the renderer
+/// and persisted as the finished document, with no error anywhere.
+///
+/// Genuinely invalid bytes (a corrupt transfer, never a provider) still collapse
+/// to a single `U+FFFD` and are skipped, so a malformed stream can never stall
+/// the loop.
+pub(super) fn push_utf8(buf: &mut String, carry: &mut Vec<u8>, bytes: &[u8]) {
+    carry.extend_from_slice(bytes);
+    loop {
+        match std::str::from_utf8(carry) {
+            Ok(text) => {
+                buf.push_str(text);
+                carry.clear();
+                return;
+            }
+            Err(e) => {
+                let valid = e.valid_up_to();
+                // `valid_up_to()` is by definition a valid UTF-8 prefix.
+                buf.push_str(std::str::from_utf8(&carry[..valid]).unwrap_or_default());
+                match e.error_len() {
+                    // A truly invalid sequence: emit one replacement char, skip
+                    // it, and keep decoding the rest of this read.
+                    Some(n) => {
+                        buf.push(char::REPLACEMENT_CHARACTER);
+                        carry.drain(..valid + n);
+                    }
+                    // An incomplete tail: hold it back for the next read.
+                    None => {
+                        carry.drain(..valid);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Whether `job_id` has been cancelled.
 fn is_cancelled(app: &AppHandle, job_id: &str) -> bool {
     app.state::<Mutex<JobTracker>>()
@@ -278,6 +324,8 @@ async fn drive_stream<Cancel, Next, Fut, B, P>(
     P: FnMut(&mut String) -> Vec<StreamPiece>,
 {
     let mut buf = String::new();
+    // Bytes from a read that ended mid-UTF-8-sequence — see `push_utf8`.
+    let mut carry: Vec<u8> = Vec::new();
     let mut usage = Usage::default();
     let mut answer = String::new();
     loop {
@@ -287,7 +335,7 @@ async fn drive_stream<Cancel, Next, Fut, B, P>(
         }
         match next_chunk().await {
             Ok(Some(bytes)) => {
-                buf.push_str(&String::from_utf8_lossy(bytes.as_ref()));
+                push_utf8(&mut buf, &mut carry, bytes.as_ref());
                 for piece in parse(&mut buf) {
                     if let Some(u) = piece.usage {
                         usage = u;
@@ -370,6 +418,8 @@ where
     F: FnMut(&mut String) -> Vec<StreamPiece> + Send,
 {
     let mut buf = String::new();
+    // Bytes from a read that ended mid-UTF-8-sequence — see `push_utf8`.
+    let mut carry: Vec<u8> = Vec::new();
     let mut usage = Usage::default();
     // The full completed answer, accumulated from non-thinking deltas only —
     // the same shape the renderer buffers — persisted by `finish` so a dropped
@@ -414,7 +464,7 @@ where
 
         match response.chunk().await {
             Ok(Some(bytes)) => {
-                buf.push_str(&String::from_utf8_lossy(&bytes));
+                push_utf8(&mut buf, &mut carry, &bytes);
                 for piece in parse(&mut buf) {
                     if let Some(u) = piece.usage {
                         usage = u;
@@ -566,6 +616,93 @@ mod tests {
                 Act::Emit("hello".to_string(), false),
                 Act::Emit("world".to_string(), false),
                 Act::Complete(Usage::default(), "helloworld".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_multibyte_char_split_across_reads_is_not_corrupted() {
+        // `response.chunk()` cuts the body at arbitrary byte offsets, so one
+        // multi-byte char routinely straddles two reads. Decoding each read on
+        // its own turned BOTH halves into U+FFFD, and the mojibake was persisted
+        // as the finished document. The em dash here is E2 80 94, cut 1|2.
+        let acts = run(
+            vec![
+                Ok(Some(vec![b'a', 0xE2])),
+                Ok(Some(vec![0x80, 0x94, b'b', b'\n'])),
+                Ok(None),
+            ],
+            None,
+            line_parser,
+        );
+        assert_eq!(
+            acts,
+            vec![
+                Act::Emit("a\u{2014}b".to_string(), false),
+                Act::Complete(Usage::default(), "a\u{2014}b".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_multibyte_char_split_2_1_and_across_three_reads_is_not_corrupted() {
+        // Same char cut 2|1, plus a 4-byte emoji (F0 9F 9A 80) dribbled one byte
+        // per read — the carry must survive an arbitrary number of empty-yield
+        // reads, not just one.
+        let acts = run(
+            vec![
+                Ok(Some(vec![0xE2, 0x80])),
+                Ok(Some(vec![0x94])),
+                Ok(Some(vec![0xF0])),
+                Ok(Some(vec![0x9F])),
+                Ok(Some(vec![0x9A])),
+                Ok(Some(vec![0x80, b'\n'])),
+                Ok(None),
+            ],
+            None,
+            line_parser,
+        );
+        assert_eq!(
+            acts,
+            vec![
+                Act::Emit("\u{2014}\u{1F680}".to_string(), false),
+                Act::Complete(Usage::default(), "\u{2014}\u{1F680}".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn genuinely_invalid_bytes_still_collapse_to_one_replacement_char() {
+        // A corrupt transfer (never a provider) must not stall the loop: an
+        // invalid sequence becomes exactly one U+FFFD and decoding continues.
+        let acts = run(
+            vec![Ok(Some(vec![b'a', 0xFF, b'b', b'\n'])), Ok(None)],
+            None,
+            line_parser,
+        );
+        assert_eq!(
+            acts,
+            vec![
+                Act::Emit("a\u{FFFD}b".to_string(), false),
+                Act::Complete(Usage::default(), "a\u{FFFD}b".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_incomplete_trailing_sequence_at_end_of_body_does_not_hang() {
+        // The body ends mid-character: the held-back bytes are simply dropped and
+        // the loop still completes exactly once.
+        let acts = run(
+            vec![Ok(Some(vec![b'a', b'\n', 0xE2])), Ok(None)],
+            None,
+            line_parser,
+        );
+        assert_eq!(
+            acts,
+            vec![
+                Act::Emit("a".to_string(), false),
+                Act::Complete(Usage::default(), "a".to_string()),
             ]
         );
     }


### PR DESCRIPTION
Fixes #836

## What

The shared streaming loop decoded every transport read on its own:

```rust
buf.push_str(&String::from_utf8_lossy(&bytes));
```

`reqwest::Response::chunk()` splits the body at arbitrary byte offsets, so a multi-byte
character routinely straddles two reads. `from_utf8_lossy` replaced **both** halves with
`U+FFFD` and consumed the partial bytes — nothing carried the incomplete tail forward.

The failure was silent: `U+FFFD` is legal inside a JSON string, so the frame still parsed and
the mojibake flowed to the live view **and** into `answer` → `finish()` → `result.text`,
meaning the renderer's poll fallback recovered the same corrupted document. Cover letters
routinely contain `—`, `’`, `“ ”`, `é`, `ü`, `€` — all 2-3 byte sequences.

This is the one loop behind **every** cloud adapter (openai / anthropic / gemini / ollama and
every OpenAI-compatible gateway), so all of them were affected.

## How

Add `push_utf8`, which holds an incomplete trailing sequence in a `carry` buffer until the
next read completes it:

```rust
fn push_utf8(buf: &mut String, carry: &mut Vec<u8>, bytes: &[u8]) {
    carry.extend_from_slice(bytes);
    loop {
        match std::str::from_utf8(carry) {
            Ok(text) => { buf.push_str(text); carry.clear(); return; }
            Err(e) => {
                let valid = e.valid_up_to();
                buf.push_str(std::str::from_utf8(&carry[..valid]).unwrap_or_default());
                match e.error_len() {
                    Some(n) => { buf.push(char::REPLACEMENT_CHARACTER); carry.drain(..valid + n); }
                    None => { carry.drain(..valid); return; }
                }
            }
        }
    }
}
```

Genuinely invalid bytes — a corrupt transfer, never a provider — still collapse to a single
`U+FFFD` and are skipped, so a malformed stream can never stall the loop. The `Err(_)`
`error_len()` distinction is what separates "incomplete, wait for more" from "invalid, move
on".

Applied at **all three** sites that decoded a read in isolation, so no path is left behind:

1. the production `stream_response` loop,
2. the test-only `drive_stream` core (kept in lockstep — it is the harness the tests use),
3. `ollama::pull`'s progress stream.

## Tests

Four cases through the real `drive_stream` core:

- an em dash cut **1|2** across two reads → `a—b`;
- the same char cut **2|1**, plus a 4-byte emoji dribbled **one byte per read** — the carry
  must survive an arbitrary number of reads that yield no complete character, not just one;
- genuinely invalid bytes (`0xFF`) still produce exactly one `U+FFFD` and decoding continues,
  pinning the no-stall guarantee;
- a body that **ends** mid-character still completes exactly once (no hang, held-back bytes
  dropped).

Verified the two split-char tests **fail** on `main` and pass with the fix. The other two pass
either way by design — they guard behaviour the fix must not change.

The pre-existing loop tests are untouched and still pass, including
`completes_once_on_end_of_body_without_sentinel` (Gemini's no-sentinel completion) and the
three cancellation tests.

## Checklist

- [x] `cargo test --all-features` — 2725 passed, 0 failed
- [x] `cargo test --test architecture` — 11 passed (incl. the R8 LOC cap)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Tests added
- [x] No IPC contract change, so no docs update needed
