### PR TITLE
fix(export): keep body paragraphs separate in a letter with no letterhead

### DIFF
--- a/apps/desktop/src-tauri/src/export/typst_engine/letter.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/letter.rs
@@ -324,7 +324,16 @@ pub(super) fn parse_cover_letter(
         let clean = strip_md_links(trimmed);
 
         // Skip lines that were part of the header (name + blank + contact echo).
-        if skip_lines < 3
+        //
+        // Bounded to the PRE-BODY zone by `!body_started`: `skip_lines` only
+        // advances when this arm actually fires, so on a letter with fewer than
+        // three leading header lines the arm stayed armed into the body and ate
+        // its blank lines — swallowing the paragraph breaks (the `clean.is_empty()`
+        // flush below never ran) and space-joining the whole letter into one
+        // run-on block. Safe: `current_para_text` is only ever appended to in the
+        // `body_started` branch, so nothing can be pending while this is reachable.
+        if !body_started
+            && skip_lines < 3
             && (clean.is_empty()
                 || clean.trim().trim_end_matches([',', '.']).to_lowercase() == name_lower
                 || (!contact_md.is_empty() && contact_md.contains(clean.trim())))
@@ -611,6 +620,35 @@ Mit freundlichen Grüßen,
 
 Max Müller
 ";
+
+    #[test]
+    fn body_paragraphs_survive_a_letter_with_no_letterhead() {
+        // The agent's `draft_cover_letter` prompt asks for the finished letter
+        // only — "no preamble" — so the draft opens straight at the salutation
+        // with no name/contact echo to consume the three header skips. The skip
+        // arm then ate the BODY's blank lines and the whole letter collapsed into
+        // a single run-on paragraph.
+        let letter = "Dear Hiring Manager,\n\nFirst paragraph.\n\nSecond paragraph.\n\nThird paragraph.\n\nSincerely,\n\nJane Smith\n";
+        let model = parse_cover_letter(letter, None, Some("Jane Smith"), "us", "en", dummy_style());
+
+        assert_eq!(
+            model.body.len(),
+            3,
+            "each blank-line-separated paragraph must stay separate; got {:?}",
+            model.body
+        );
+        assert_eq!(model.salutation.as_deref(), Some("Dear Hiring Manager,"));
+    }
+
+    #[test]
+    fn body_paragraphs_survive_a_letter_with_only_a_date_and_salutation() {
+        // Two leading pre-body lines instead of three — still not enough to burn
+        // the skip budget before the body starts.
+        let letter = "12 March 2025\n\nDear Hiring Manager,\n\nFirst paragraph.\n\nSecond paragraph.\n\nSincerely,\n\nJane Smith\n";
+        let model = parse_cover_letter(letter, None, Some("Jane Smith"), "us", "en", dummy_style());
+
+        assert_eq!(model.body.len(), 2, "got {:?}", model.body);
+    }
 
     #[test]
     fn parses_english_letter_all_fields() {


### PR DESCRIPTION
Fixes #838

## What

`parse_cover_letter`'s header-skip arm was not anchored to the header:

```rust
if skip_lines < 3
    && (clean.is_empty() || …name… || …contact echo…)
{ skip_lines += 1; continue; }
```

`skip_lines` only advances when the arm fires, so it stays armed for the whole document until
three skippable lines accumulate. `clean.is_empty()` alone satisfies it, so **body** blank
lines got consumed by the `continue` and never reached the paragraph-flush branch — the next
body line was then space-joined onto the un-flushed paragraph.

A letter that opens straight at the salutation therefore rendered as one run-on block. That is
exactly what the agent produces (`COVER_LETTER_SYSTEM` asks for the letter only, "no preamble"),
and the natural hand-edited shape too, since the template renders the letterhead from
`ContactProfile` and the parser deliberately drops any contact echo from the body.

The fixture `EN_LETTER` happens to spend all three skips on its letterhead before the body,
which is why this was invisible to the existing tests.

## How

```diff
-if skip_lines < 3
+if !body_started
+    && skip_lines < 3
     && (clean.is_empty()
```

Safe by construction: `current_para_text` is only ever appended to in the `body_started`
branch, so no paragraph can be pending while this arm is reachable — the change can only
stop the arm from eating body blank lines, never alter header handling.

## Tests

Two cases in `letter.rs`'s test module:

- a letter opening at the salutation → **3** body paragraphs (and the salutation is still
  detected, so the change didn't just shift the problem);
- a letter with only a date + salutation ahead of the body — two pre-body lines, still not
  enough to burn the skip budget → **2** paragraphs.

Verified both **fail** on `main` with exactly the reported symptom (`left: 1, right: 3` and
`left: 1, right: 2`) and pass with the fix.

`parses_english_letter_all_fields`, `body_rich_text_preserves_bold` and
`all_caps_name_adopts_profile_casing` are unaffected — the full-letterhead fixture takes the
identical path as before.

## Checklist

- [x] `cargo test --all-features` — 2723 passed, 0 failed
- [x] `cargo test --test architecture` — 11 passed (incl. the R8 LOC cap)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Tests added
- [x] No IPC contract change, so no docs update needed
