### PR TITLE
fix(ui): ignore a superseded geocode response

### DIFF
--- a/packages/ui/src/hooks/useGeocoding.test.ts
+++ b/packages/ui/src/hooks/useGeocoding.test.ts
@@ -31,6 +31,65 @@ describe('useGeocoding', () => {
     expect(result.current.activeIndex).toBe(-1);
   });
 
+  it('ignores a slow superseded response that resolves after a newer one', async () => {
+    // The 300ms debounce only bounds when a request STARTS. Resume typing after
+    // a pause and two are in flight; if the older (slower) one wins the race it
+    // used to overwrite the list with suggestions for a stale query.
+    const fetcher = vi.fn((q: string) =>
+      q === 'Be'
+        ? new Promise((resolve) =>
+            setTimeout(() => resolve([{ display: 'Belgrade, Serbia' }]), 2000)
+          )
+        : Promise.resolve([{ display: 'Berlin, Germany' }])
+    ) as unknown as (q: string) => Promise<{ display: string }[]>;
+
+    const { result, rerender } = renderHook(({ q }) => useGeocoding(q, fetcher), {
+      initialProps: { q: '' },
+    });
+
+    rerender({ q: 'Be' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350); // fires the slow 'Be' fetch
+    });
+
+    rerender({ q: 'Berlin' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350); // fires + resolves the fast 'Berlin' fetch
+    });
+    expect(result.current.suggestions).toEqual([{ display: 'Berlin, Germany' }]);
+
+    // Now let the stale 'Be' request land.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(result.current.suggestions).toEqual([{ display: 'Berlin, Germany' }]);
+  });
+
+  it('ignores an in-flight response after the query drops below 2 characters', async () => {
+    // The short-query branch returns early, but React still runs the previous
+    // cleanup first — so the superseded request must be flagged there too,
+    // otherwise it repopulates a list the hook just cleared.
+    const fetcher = vi.fn(
+      () =>
+        new Promise((resolve) => setTimeout(() => resolve([{ display: 'Berlin, Germany' }]), 2000))
+    ) as unknown as (q: string) => Promise<{ display: string }[]>;
+
+    const { result, rerender } = renderHook(({ q }) => useGeocoding(q, fetcher), {
+      initialProps: { q: '' },
+    });
+
+    rerender({ q: 'Berlin' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    rerender({ q: 'B' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(result.current.suggestions).toEqual([]);
+  });
+
   it('uses the default Nominatim fetch and parses the address shape', async () => {
     vi.stubGlobal(
       'fetch',

--- a/packages/ui/src/hooks/useGeocoding.ts
+++ b/packages/ui/src/hooks/useGeocoding.ts
@@ -62,6 +62,15 @@ export function useGeocoding(
 
   // Debounced fetch
   useEffect(() => {
+    // Marks this run superseded. The debounce only bounds when a request
+    // STARTS — once one is in flight nothing cancels it — so a slow older
+    // request could resolve after a faster newer one and overwrite the list
+    // with suggestions for a query the user has already typed past (and reset
+    // `activeIndex`, dropping their keyboard selection mid-interaction).
+    // React always runs the previous cleanup before the next effect run, so a
+    // superseded request is flagged even when the new run takes the
+    // `< 2 chars` early return. Also prevents a setState after unmount.
+    let cancelled = false;
     const trimmed = query.trim();
     if (trimmed.length < 2) {
       setSuggestions([]);
@@ -72,12 +81,14 @@ export function useGeocoding(
       fetchRef
         .current(trimmed)
         .then((s) => {
+          if (cancelled) return;
           setSuggestions(s);
           setActiveIndex(-1);
         })
         .catch(() => {});
     }, 300);
     return () => {
+      cancelled = true;
       if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, [query]);


### PR DESCRIPTION
Fixes #842

## What

`useGeocoding`'s cleanup cancels only the **pending timer**. Once a fetch has started nothing
cancels it and nothing marks its reply stale, so `setSuggestions(s)` ran for whichever request
resolved last rather than for the current query.

The 300 ms debounce does not serialize requests — it only bounds when one *starts*. Two are in
flight whenever the user resumes typing after a pause longer than the debounce, the normal
rhythm for typing a city name. When the slower older one wins, the dropdown shows results for
a query the user has already typed past, and `setActiveIndex(-1)` wipes their keyboard
highlight mid-selection.

## How

```diff
 useEffect(() => {
+  let cancelled = false;
   const trimmed = query.trim();
   …
     .then((s) => {
+      if (cancelled) return;
       setSuggestions(s);
       setActiveIndex(-1);
     })
   return () => {
+    cancelled = true;
     if (timerRef.current) clearTimeout(timerRef.current);
   };
 }, [query]);
```

React always runs the previous effect's cleanup before the next run, so this also covers the
`< 2 chars` early-return path — which otherwise let an in-flight request repopulate a list the
hook had just cleared. It also removes a setState-after-unmount.

## Tests

Two cases added to `useGeocoding.test.ts`:

- a slow `Be` request resolving **after** a fast `Berlin` one must not overwrite the list;
- an in-flight request must not repopulate the list after the query drops below 2 characters
  (the early-return path).

Verified both **fail** on `main` with exactly the reported symptom
(`expected [ { display: 'Belgrade, Serbia' } ] to deeply equal [ { display: 'Berlin, Germany' } ]`
and `expected [ { display: 'Berlin, Germany' } ] to deeply equal []`) and pass with the fix.
All 10 tests in the file pass.

## Checklist

- [x] `pnpm typecheck` passes (`@ajh/ui`)
- [x] `eslint --max-warnings 0` clean on the touched files
- [x] `prettier` clean
- [x] Tests added
- [x] No IPC contract change, so no docs update needed

<sub>Note on local verification: the full `pnpm test` run is not green in my sandbox, but the
failures are pre-existing on unmodified `main` — 13 files / 146 tests fail with
`TypeError: Cannot read properties of undefined (reading 'setItem')` (no `localStorage` in this
environment). Verified by checking out clean `main` and re-running. CI is authoritative.</sub>
