### PR TITLE
fix(scraper): keep distinct Hacker News job ids apart in cross-source dedup

### DIFF
--- a/apps/desktop/src-tauri/src/applications/mod.rs
+++ b/apps/desktop/src-tauri/src/applications/mod.rs
@@ -1280,13 +1280,16 @@ pub fn normalize_job_url(url: &str) -> String {
 
 /// Per-host allowlist of *identifying* query params that must survive normalization
 /// (every other query param — utm_*, ref, tracking — is dropped, and hosts absent
-/// here drop the entire query). Keep in sync with the canonical URL builders in
-/// `scraping::scrape_url` that place a job id in the query string: currently only
-/// Indeed (`/viewjob?jk=<id>`). LinkedIn et al. put the id in the PATH, so they need
-/// no entry here and normalize exactly as before.
+/// here drop the entire query, so a host whose id lives in the QUERY collapses to
+/// one key for every job). Keep in sync with every canonical URL builder that does
+/// that: Indeed (`/viewjob?jk=<id>`) and Hacker News (`/item?id=<id>`, built by
+/// `boards::ycombinator` when a job story has no external url). Path-based ids
+/// (LinkedIn et al.) need no entry.
 fn identifying_query_params(host: &str) -> &'static [&'static str] {
     if host == "indeed.com" || host.ends_with(".indeed.com") {
         &["jk"]
+    } else if host == "news.ycombinator.com" {
+        &["id"]
     } else {
         &[]
     }

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -3242,6 +3242,52 @@ fn dedup_posting_with_extra(
 }
 
 #[test]
+fn dedup_cross_source_keeps_distinct_hacker_news_job_ids_apart() {
+    // `boards::ycombinator` falls back to `news.ycombinator.com/item?id=<id>`
+    // whenever an HN job story carries no external url — the id lives in the
+    // QUERY. `normalize_job_url` drops the whole query for any host without an
+    // allowlist entry, so every such posting used to normalize to the bare
+    // `/item` path and collapse into one row.
+    let out = dedup_cross_source(vec![
+        dedup_posting(
+            "ycombinator",
+            "https://news.ycombinator.com/item?id=44100001",
+            "Backend Engineer",
+            "Acme",
+            None,
+        ),
+        dedup_posting(
+            "ycombinator",
+            "https://news.ycombinator.com/item?id=44100002",
+            "Frontend Engineer",
+            "Beta",
+            None,
+        ),
+    ]);
+    assert_eq!(out.len(), 2, "distinct HN job ids must not collapse");
+
+    // Tracking params on the SAME id must still collapse — the allowlist keeps
+    // only `id`, so this is the behaviour the allowlist exists to preserve.
+    let out = dedup_cross_source(vec![
+        dedup_posting(
+            "ycombinator",
+            "https://news.ycombinator.com/item?id=44100001",
+            "Backend Engineer",
+            "Acme",
+            None,
+        ),
+        dedup_posting(
+            "ycombinator",
+            "https://news.ycombinator.com/item?id=44100001&utm_source=x",
+            "Backend Engineer",
+            "Acme",
+            None,
+        ),
+    ]);
+    assert_eq!(out.len(), 1, "the same HN id must still dedup");
+}
+
+#[test]
 fn dedup_cross_source_upgrades_description_and_extra_but_keeps_incumbent_identity() {
     // Same job, two boards: "aggregator" FIRST (incumbent) — truncated snippet,
     // but carries the salary fields Adzuna scrapes into `extra`; "board" SECOND

--- a/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.test.ts
@@ -120,4 +120,19 @@ describe('canonicalJobKey — URL normalization details (mirror normalize_job_ur
     // Same input twice must key identically (determinism, not just no-crash).
     expect(canonicalJobKey('https:///path', 'Engineer', 'Acme')).toBe(key);
   });
+
+  it('keeps distinct Hacker News job ids apart', () => {
+    // `boards::ycombinator` builds `news.ycombinator.com/item?id=<id>` when an HN
+    // job story has no external link, so the id lives in the query — which is
+    // dropped for any host without an allowlist entry.
+    const a = canonicalJobKey('https://news.ycombinator.com/item?id=44100001', 'BE', 'Acme');
+    const b = canonicalJobKey('https://news.ycombinator.com/item?id=44100002', 'FE', 'Beta');
+    expect(a).not.toBe(b);
+    expect(a).toBe('https://news.ycombinator.com/item?id=44100001');
+
+    // Tracking params on the same id still collapse, in either order.
+    expect(
+      canonicalJobKey('https://news.ycombinator.com/item?utm_source=x&id=44100001', 'BE', 'Acme')
+    ).toBe(a);
+  });
 });

--- a/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.ts
+++ b/apps/desktop/src/renderer/features/jobs/lib/canonical-job-key.ts
@@ -46,6 +46,11 @@ function explicitScheme(input: string): string | null {
  */
 function identifyingQueryParams(host: string): readonly string[] {
   if (host === 'indeed.com' || host.endsWith('.indeed.com')) return ['jk'];
+  // news.ycombinator.com/item?id=<id> — the URL `boards::ycombinator` builds when
+  // an HN job story has no external link. Without this every such posting
+  // normalizes to the bare `/item` path and cross-source dedup collapses them all
+  // into one row.
+  if (host === 'news.ycombinator.com') return ['id'];
   return [];
 }
 


### PR DESCRIPTION
Fixes #844

## What

`identifying_query_params` allowlisted only Indeed, so `normalize_job_url` discards the entire
query for every other host. `boards::ycombinator` puts the job id **in the query** whenever an
HN job story has no external link:

```
https://news.ycombinator.com/item?id=44100001  ->  https://news.ycombinator.com/item
https://news.ycombinator.com/item?id=44100002  ->  https://news.ycombinator.com/item
```

so `dedup_cross_source` collapsed every text-only HN posting into one row.

The allowlist's own doc comment already stated the rule it was violating — *"Keep in sync with
the canonical URL builders … that place a job id in the query string"* — and the aggregator's
`canonical_url` documents the same hazard from the other direction.

## How

Add the `news.ycombinator.com` → `id` entry on **both** sides of the lockstep pair:

- `applications/mod.rs` — `identifying_query_params`
- `renderer/features/jobs/lib/canonical-job-key.ts` — `identifyingQueryParams`

Tracking params on the same id still collapse (only `id` is retained, in the allowlist's fixed
order), so the dedup this allowlist exists to enable is unchanged.

I also tightened the doc comment on the Rust side: the fix pushed `applications/mod.rs` to
1401 LOC, over the R8 hard cap of 1400. It now sits at **1399** and
`cargo test --test architecture` passes.

## Tests

- `scraping/engine/test.rs` — two distinct HN ids must not collapse **and** the same id with a
  tracking param must still collapse, so the test pins both directions rather than just
  loosening the key.
- `canonical-job-key.test.ts` — the mirrored assertions, including param-order independence.

Verified both **fail** on `main` with exactly the reported symptom (Rust `left: 1, right: 2`;
TS `expected 'https://news.ycombinator.com/item' not to be 'https://news.ycombinator.com/item'`)
and pass with the fix.

## Known residual (not fixed here)

JSearch rows that fall back to `job_google_link` put their identity in the URL **fragment**,
which `normalize_job_url` drops unconditionally — an allowlist entry cannot address that. Left
alone deliberately rather than widened into this PR.

## Checklist

- [x] `cargo test --all-features` — 2722 passed, 0 failed
- [x] `cargo test --test architecture` — 11 passed (incl. the R8 LOC cap; file now 1399/1400)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `eslint --max-warnings 0` + `prettier` clean on the touched TS
- [x] Tests added on both sides of the lockstep pair
- [x] No IPC contract change, so no docs update needed
