### PR TITLE
ci: bump codeql-action init to 4.37.3 in lockstep with analyze

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,4 +73,5 @@ updates:
     groups:
       codeql-action:
         patterns:
-          - github/codeql-action*
+          - github/codeql-action
+          - github/codeql-action/*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,3 +67,10 @@ updates:
 
     labels:
       - github-actions
+
+    # codeql-action init/analyze must move in lockstep: init writes a config
+    # stamped with its own version and a newer analyze refuses to load it.
+    groups:
+      codeql-action:
+        patterns:
+          - github/codeql-action*

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -61,13 +61,13 @@ jobs:
           fetch-depth: 1
 
       - name: 🧰 Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: 🔬 Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: '/language:${{ matrix.language }}'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: 📤 Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: semgrep.sarif
           category: semgrep
@@ -140,7 +140,7 @@ jobs:
 
       - name: 📤 Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif
           category: scorecard


### PR DESCRIPTION
## Why

#850 (merged) bumped only the `analyze` pin to 4.37.3 while `init` stayed at 4.37.0. The init step writes a config stamped with its own version and the newer analyze refuses to load it, so every CodeQL run on main now fails with:

> Loaded a configuration file for version '4.37.0', but running version '4.37.3'

This was the exact failure already visible on #850's own PR checks before merge.

## What

- `.github/workflows/security.yml`: bump `codeql-action/init` to the same 4.37.3 SHA as `analyze` (comments now carry the exact version).
- `.github/dependabot.yml`: group `github/codeql-action*` so future bumps arrive as a single PR instead of drifting apart again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)