### PR TITLE
fix(export): bump typst family to 0.15.1 in lockstep

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -8811,9 +8811,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typst"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8bf2a5a9d58cc542764a88dd43c8a679b683db4ae23e36267219339ab36b01"
+checksum = "d1cb79435d128de5d5443a058a983f6dcc16738760fa55ed703762bc278b1fd3"
 dependencies = [
  "arrayvec",
  "comemo",
@@ -8841,9 +8841,9 @@ dependencies = [
 
 [[package]]
 name = "typst-eval"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d064876305073ab75d5af039ae5e8dcb32c4cac4aa9f43d0f5aae347baef7c3"
+checksum = "a8823e1822bd181d8bee47b05632d16bf3a0a8ab042e01d815826350d7ae16c3"
 dependencies = [
  "comemo",
  "ecow",
@@ -8861,9 +8861,9 @@ dependencies = [
 
 [[package]]
 name = "typst-html"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d442f92bae44087735efc8b83508b259c573bbccf027e098ac68c8f4ca879f76"
+checksum = "f41bcfbe480b640c4447d8bf9bb59020da610f239aa032d53328651a03572c09"
 dependencies = [
  "az",
  "bumpalo",
@@ -8999,9 +8999,9 @@ dependencies = [
 
 [[package]]
 name = "typst-pdf"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7b33bcabc3357480768f6c78dda99a838d621c71b4738b25e09ac30ac063c9"
+checksum = "3aef841ff3e606542f3057ce5dd0ff264d53a439e00ed4a91ec00ec8568b3b7f"
 dependencies = [
  "az",
  "bytemuck",
@@ -9028,9 +9028,9 @@ dependencies = [
 
 [[package]]
 name = "typst-realize"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917e09614771258b13409b9a8d4f3915b2a2f7f28ca987701695f82fc6a7c0b9"
+checksum = "a8f2eb73ab25add88cab03b26effabc657977fe850ff81556b28c6b137ff4bf1"
 dependencies = [
  "arrayvec",
  "bumpalo",
@@ -9047,9 +9047,9 @@ dependencies = [
 
 [[package]]
 name = "typst-render"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040ab6e56e91099963ef69dd9f0d284adda66c066b742f1866a20b8295ebb2e3"
+checksum = "de8a657a5fa5b9b7d3d458f482978674de910b54889d46f3bb55ca89f570f83e"
 dependencies = [
  "bytemuck",
  "comemo",
@@ -9070,9 +9070,9 @@ dependencies = [
 
 [[package]]
 name = "typst-svg"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878b6e1293c2bea77a8be50670d1cbca4e676af96480313a105cba539da51d1c"
+checksum = "5df6dc785695aae085678bd6657aa04a1d26058a76ed042e738658078bca681e"
 dependencies = [
  "base64 0.22.1",
  "comemo",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -144,8 +144,8 @@ pdf-extract = "0.12"
 zip = "8"
 docx-rs = "0.4.20"
 lopdf = "0.44"
-typst = "=0.15.0"
-typst-pdf = "=0.15.0"
+typst = "=0.15.1"
+typst-pdf = "=0.15.1"
 # `PagedDocument` moved out of `typst-library` into the `typst-layout` crate in
 # 0.15, so the engine's compile path imports it directly. Already a transitive
 # dep of `typst`; exact pin kept in lockstep with the rest of the family.
@@ -154,7 +154,7 @@ typst-layout = "=0.15.1"
 # the preview command returns per-page SVG strings shown via <img> in the UI.
 # Exact pin matches typst/typst-pdf. typst is already a runtime dep, so this is a
 # small surface add over the existing Typst stack.
-typst-svg = "=0.15.0"
+typst-svg = "=0.15.1"
 image = "=0.25.10"
 
 # ATS keyword matching: language-aware stemming + language detection (match_resume).
@@ -279,7 +279,7 @@ wiremock = "0.6.5"
 # one salary_research timeout test, which would otherwise need a real 25s wait.
 tokio = { version = "1", features = ["test-util"] }
 # Rasteriser for the generate_templates_showcase_banner test — dev-only, NOT in the shipped binary.
-typst-render = "=0.15.0"
+typst-render = "=0.15.1"
 # (typst-svg moved to [dependencies] — it now backs the live-preview render path.)
 criterion = "0.8.2"
 


### PR DESCRIPTION
## Why
PR #851 bumped only `typst-layout` to `=0.15.1`, leaving the rest of the typst family (`typst`, `typst-pdf`, `typst-svg`, `typst-render`) pinned at `=0.15.0`. That split the family across two point releases — against the in-file pin comment ("exact pin kept in lockstep with the rest of the family") and the repo's hard rule that the typst family must bump together.

## What
- `apps/desktop/src-tauri/Cargo.toml` — bump every remaining typst-family exact pin `=0.15.0 → =0.15.1`:
  - `typst`
  - `typst-pdf`
  - `typst-svg`
  - `typst-render` (dev-dependency, showcase-banner rasteriser)
  - (`typst-layout` was already `=0.15.1` from #851)
- `apps/desktop/src-tauri/Cargo.lock` — regenerated via `cargo update --precise 0.15.1`; transitive `typst-eval`, `typst-html`, `typst-realize` also advance 0.15.0 → 0.15.1. Every `typst-*` crate in the lockfile now resolves to 0.15.1.
- Comments left intact and accurate (they already assert lockstep / matching pins).

All four family members have a published 0.15.1 release, so `cargo update` resolved cleanly (no forcing).

## Test evidence
`cargo test` in `apps/desktop/src-tauri` (delayload fix present on main):
- Full suite: **2741 passed, 26 ignored, 0 failed** (5 suites, exit 0).
- Export subset (`cargo test export::`): **264 passed, 3 ignored, 0 failed** (exit 0) — covers the typst PDF/SVG render path (valid-PDF, per-template render, multipage sidebar, ATS reading-order, contact-link annotations, accent fallback) and the docx path.
- **Golden status: no drift.** The export tests are structural/property assertions (not committed byte-diff snapshot fixtures); typst 0.15.1 shifted no layout invariant — all passed and the working tree shows **only** `Cargo.toml` + `Cargo.lock` changed (no snapshot files regenerated).
- Re-ran the export subset against the post-merge tree (main's docx-rs/tokio bumps that the pre-push hook merged in): still 264 passed / exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
