### PR TITLE
ci: group typst family bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,15 @@ updates:
     labels:
       - dependencies
 
+    # The typst family (typst, typst-pdf, typst-svg, typst-render,
+    # typst-layout) is exact-pinned and must bump in lockstep — a partial
+    # bump splits the pins (#851) and risks mixed-version rendering.
+    groups:
+      typst:
+        patterns:
+          - typst
+          - typst-*
+
     commit-message:
       prefix: chore
 


### PR DESCRIPTION
## Why

The typst crates are exact-pinned and must move in lockstep. Dependabot treats each crate as a separate dependency, so it proposed them one at a time — #851 merged a typst-layout-only bump and split the pins, which #865 had to repair. #858/#860 were the next piecemeal bumps in the queue.

## What

Add a `typst` group (patterns `typst`, `typst-*`) to the cargo ecosystem in `.github/dependabot.yml`, mirroring the codeql-action group added in #857. Future family releases arrive as one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)