### PR TITLE
fix(ai-generations): make the mismatch merge follow a language-bearing save

### DIFF
--- a/apps/desktop/src-tauri/src/ai_generations/mod.rs
+++ b/apps/desktop/src-tauri/src/ai_generations/mod.rs
@@ -523,6 +523,12 @@ fn merge_application(
     incoming: AiGenerationRecord,
 ) -> AiGenerationRecord {
     let pick = |inc: String, ex: String| if inc.trim().is_empty() { ex } else { inc };
+    // `mismatch` is derived from the resume/jobAd language pair, so it is only
+    // meaningful when the incoming save actually carries that pair. An
+    // answers-only / interview-only save leaves the language fields blank and its
+    // `mismatch` defaults to `false` — not a real verdict.
+    let incoming_has_languages =
+        !incoming.resume_language.trim().is_empty() && !incoming.job_ad_language.trim().is_empty();
     AiGenerationRecord {
         id: existing.id,
         created_at: existing.created_at,
@@ -532,7 +538,16 @@ fn merge_application(
         resume_language: pick(incoming.resume_language, existing.resume_language),
         job_ad_language: pick(incoming.job_ad_language, existing.job_ad_language),
         target_language: pick(incoming.target_language, existing.target_language),
-        mismatch: incoming.mismatch || existing.mismatch,
+        // Follow the incoming verdict ONLY when this save computed the language
+        // pair — mirroring how the language fields themselves merge (`pick`), so a
+        // corrected regeneration (`mismatch=false`) clears a stale warning while a
+        // content-less save can't clobber a real prior verdict. The old
+        // `incoming || existing` made a `true` permanent.
+        mismatch: if incoming_has_languages {
+            incoming.mismatch
+        } else {
+            existing.mismatch
+        },
         top_requirements: if incoming.top_requirements.is_empty() {
             existing.top_requirements
         } else {

--- a/apps/desktop/src-tauri/src/ai_generations/test.rs
+++ b/apps/desktop/src-tauri/src/ai_generations/test.rs
@@ -152,6 +152,37 @@ fn merge_layers_interview_questions_without_clobbering_other_fields() {
     assert_eq!(merged.interview_questions, vec![interview_question("iq-1")]);
 }
 
+/// A corrected regeneration must be able to CLEAR a stale language-mismatch
+/// warning, and a content-less (answers/interview-only) save must NOT clobber a
+/// real prior verdict. The old `incoming || existing` made a `true` permanent.
+#[test]
+fn merge_mismatch_follows_a_language_bearing_save_and_ignores_a_content_less_one() {
+    // Prior verdict: mismatch (a German résumé generated against an English ad).
+    let mut existing = record("g1", "https://acme.com/job/1");
+    existing.mismatch = true;
+
+    // A corrected regeneration carries the language pair and says "no mismatch".
+    let mut fixed = record("g2", "https://acme.com/job/1");
+    fixed.resume_language = "en".into();
+    fixed.job_ad_language = "en".into();
+    fixed.mismatch = false;
+    assert!(
+        !merge_application(existing.clone(), fixed).mismatch,
+        "a language-bearing save with mismatch=false must clear the stale warning"
+    );
+
+    // An answers-only save carries no language pair; its default mismatch=false
+    // must not wipe the existing verdict.
+    let mut answers_only = record("g3", "https://acme.com/job/1");
+    answers_only.resume_language = String::new();
+    answers_only.job_ad_language = String::new();
+    answers_only.mismatch = false;
+    assert!(
+        merge_application(existing, answers_only).mismatch,
+        "a content-less save must not clobber a real prior mismatch verdict"
+    );
+}
+
 #[test]
 fn merge_layers_answers_onto_an_existing_cover_without_clobbering() {
     let mut existing = record("g1", "https://acme.com/job/1");


### PR DESCRIPTION
## Summary

`merge_application` OR-accumulated the language-`mismatch` flag, so a corrected regeneration could never clear a stale "languages differ" warning. Fixes #873.

## Type of change

- [x] `fix` — Bug fix

## Changes

- `mismatch` now follows `incoming.mismatch` **only when the incoming save carries the language pair** (both language fields non-empty), else keeps `existing.mismatch`.
- This mirrors how `resume_language` / `job_ad_language` / `target_language` themselves merge (`pick` — incoming wins only when non-empty), so `mismatch` stops being the lone `||` outlier.
- A corrected regeneration (`mismatch=false`, both languages present) now clears the warning; an answers-only / interview-only save (blank languages, default `mismatch=false`) no longer clobbers a real prior verdict.

## Testing

- [x] `cargo test --lib ai_generations` — 28 passed, 0 failed
- [x] `cargo test --test architecture` — 11 passed (R8 cap included)
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added tests for new logic

Regression test covers both directions. Against `main`:

```
a language-bearing save with mismatch=false must clear the stale warning
test result: FAILED
```

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
