### PR TITLE
fix(export): do not consume a letter's salutation as the letterhead name

### DIFF
--- a/apps/desktop/src-tauri/src/export/docx/mod.rs
+++ b/apps/desktop/src-tauri/src/export/docx/mod.rs
@@ -92,8 +92,12 @@ fn generate_cover_letter_docx_classic(
         let is_salutation = crate::locale::letter::is_salutation(&clean);
         let is_signoff = crate::locale::letter::is_signoff(&clean);
 
-        // First line is name
-        if !header_done && docx.document.children.is_empty() {
+        // First line is name — but ONLY a real letterhead name, not a letter that
+        // opens straight at the salutation. Without this guard a letterhead-less
+        // letter's "Dear …" was consumed as the name (replaced with the candidate
+        // name), the salutation arm never ran, `in_body` was never set, and the
+        // whole body rendered in the muted addressee style.
+        if !header_done && docx.document.children.is_empty() && !is_salutation && !is_signoff {
             let name_text = meta
                 .and_then(|m| m.candidate_name.as_ref())
                 .map(|s| s.as_str())
@@ -317,8 +321,12 @@ fn generate_cover_letter_docx_layout(
         let is_salutation = crate::locale::letter::is_salutation(&clean);
         let is_signoff = crate::locale::letter::is_signoff(&clean);
 
-        // First line is name.
-        if !header_done && docx.document.children.is_empty() {
+        // First line is name — but ONLY a real letterhead name, not a letter that
+        // opens straight at the salutation. Without this guard a letterhead-less
+        // letter's "Dear …" was consumed as the name (replaced with the candidate
+        // name), the salutation arm never ran, `in_body` was never set, and the
+        // whole body rendered in the muted addressee style.
+        if !header_done && docx.document.children.is_empty() && !is_salutation && !is_signoff {
             let name_text = meta
                 .and_then(|m| m.candidate_name.as_ref())
                 .map(|s| s.as_str())

--- a/apps/desktop/src-tauri/src/export/docx/test.rs
+++ b/apps/desktop/src-tauri/src/export/docx/test.rs
@@ -397,3 +397,46 @@ fn cover_letter_docx_layouts_produce_distinct_bytes() {
     assert_ne!(classic, banded, "Classic and Banded DOCX bytes must differ");
     assert_ne!(refined, banded, "Refined and Banded DOCX bytes must differ");
 }
+
+/// A cover letter that opens directly at the salutation (no letterhead name/
+/// contact lines) must keep its "Dear …" line and render the body normally.
+///
+/// The name block used to fire on the FIRST non-blank line whatever it was, so a
+/// letterhead-less letter had its salutation consumed as the name (replaced with
+/// `meta.candidate_name`) and, because `in_body` is set only in the salutation
+/// arm, the whole body then rendered in the muted addressee style. Covers BOTH
+/// letter renderers — `_classic` (Classic) and `_layout` (Refined/Banded).
+#[test]
+fn letterhead_less_letter_keeps_its_salutation_and_body() {
+    for layout in [
+        LetterLayout::Classic,
+        LetterLayout::Refined,
+        LetterLayout::Banded,
+    ] {
+        let request = ExportRequest {
+            text: "Dear Hiring Manager,\n\nI am writing to apply for the role.\n\nSincerely,\nJane Smith".to_string(),
+            format: ExportFormat::Docx,
+            document_type: DocumentType::CoverLetter,
+            template_id: TemplateId::Classic,
+            // `candidate_name` is what the buggy name block substituted IN PLACE
+            // of the salutation, so its presence makes the drop observable.
+            meta: Some(GenerationMeta {
+                candidate_name: Some("Jane Smith".to_string()),
+                job_title: None,
+                company_name: None,
+                target_language: None,
+            }),
+            ats_mode: false,
+            locale: None,
+            contact: None,
+            accent: None,
+            letter_layout: layout,
+        };
+        let bytes = generate_docx(&request).expect("docx");
+        let xml = document_xml(&bytes);
+        assert!(
+            xml.contains("Dear Hiring Manager"),
+            "{layout:?}: the salutation was consumed as the letterhead name"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Both DOCX letter renderers consumed the first non-blank line as the letterhead name whatever it was, so a letter opening at the salutation lost its "Dear …" line and rendered the body in the muted addressee style. Fixes #875.

## Type of change

- [x] `fix` — Bug fix

## Changes

- Guarded the name block with `!is_salutation && !is_signoff` (both already computed just above it), so a salutation-first, letterhead-less letter falls through to the salutation arm — which is the only place `header_done` / `in_body` get set.
- Applied to **both** copies of the block: `generate_cover_letter_docx_classic` (`:96`, Classic) and `generate_cover_letter_docx_layout` (`:321`, Refined/Banded).

## Testing

- [x] `cargo test --lib export::docx` — 24 passed, 0 failed
- [x] `cargo test --test architecture` — 11 passed
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added tests for new logic

New test opens a letterhead-less letter (`meta.candidate_name` set so the drop is observable) and asserts `"Dear Hiring Manager"` survives, across all three layouts. Against `main`:

```
Classic: the salutation was consumed as the letterhead name
test result: FAILED
```

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] No `console.log` left in source code
- [x] No `@ts-ignore` added without explanation
- [x] New public APIs are documented (no new public API)
