### PR TITLE
fix(export): keep a subject-line-first letterhead-less letter's subject line

### DIFF
--- a/apps/desktop/src-tauri/src/export/docx/mod.rs
+++ b/apps/desktop/src-tauri/src/export/docx/mod.rs
@@ -91,13 +91,20 @@ fn generate_cover_letter_docx_classic(
         // market (was English/German only).
         let is_salutation = crate::locale::letter::is_salutation(&clean);
         let is_signoff = crate::locale::letter::is_signoff(&clean);
+        let is_subject_line = crate::locale::letter::is_subject_line(&clean);
 
         // First line is name — but ONLY a real letterhead name, not a letter that
-        // opens straight at the salutation. Without this guard a letterhead-less
-        // letter's "Dear …" was consumed as the name (replaced with the candidate
-        // name), the salutation arm never ran, `in_body` was never set, and the
-        // whole body rendered in the muted addressee style.
-        if !header_done && docx.document.children.is_empty() && !is_salutation && !is_signoff {
+        // opens straight at the salutation, sign-off, or subject/reference line
+        // (e.g. German "Betreff: …"). Without this guard a letterhead-less
+        // letter's "Dear …"/"Betreff: …" was consumed as the name (replaced with
+        // the candidate name), the salutation/subject arm never ran, `in_body`
+        // was never set, and the whole body rendered in the muted addressee style.
+        if !header_done
+            && docx.document.children.is_empty()
+            && !is_salutation
+            && !is_signoff
+            && !is_subject_line
+        {
             let name_text = meta
                 .and_then(|m| m.candidate_name.as_ref())
                 .map(|s| s.as_str())
@@ -187,7 +194,7 @@ fn generate_cover_letter_docx_classic(
         }
 
         // Subject line (Betreff/Objet/Oggetto/…) — bold, before the salutation.
-        if !in_body && crate::locale::letter::is_subject_line(&clean) {
+        if !in_body && is_subject_line {
             docx = docx.add_paragraph(
                 Paragraph::new()
                     .add_run(
@@ -320,13 +327,20 @@ fn generate_cover_letter_docx_layout(
 
         let is_salutation = crate::locale::letter::is_salutation(&clean);
         let is_signoff = crate::locale::letter::is_signoff(&clean);
+        let is_subject_line = crate::locale::letter::is_subject_line(&clean);
 
         // First line is name — but ONLY a real letterhead name, not a letter that
-        // opens straight at the salutation. Without this guard a letterhead-less
-        // letter's "Dear …" was consumed as the name (replaced with the candidate
-        // name), the salutation arm never ran, `in_body` was never set, and the
-        // whole body rendered in the muted addressee style.
-        if !header_done && docx.document.children.is_empty() && !is_salutation && !is_signoff {
+        // opens straight at the salutation, sign-off, or subject/reference line
+        // (e.g. German "Betreff: …"). Without this guard a letterhead-less
+        // letter's "Dear …"/"Betreff: …" was consumed as the name (replaced with
+        // the candidate name), the salutation/subject arm never ran, `in_body`
+        // was never set, and the whole body rendered in the muted addressee style.
+        if !header_done
+            && docx.document.children.is_empty()
+            && !is_salutation
+            && !is_signoff
+            && !is_subject_line
+        {
             let name_text = meta
                 .and_then(|m| m.candidate_name.as_ref())
                 .map(|s| s.as_str())
@@ -483,7 +497,7 @@ fn generate_cover_letter_docx_layout(
         }
 
         // Subject / reference line (Betreff/Objet/Re/…) — before the salutation.
-        if !in_body && crate::locale::letter::is_subject_line(&clean) {
+        if !in_body && is_subject_line {
             if is_refined {
                 // The always-on JOB REFERENCE line: caption suppressed when the
                 // subject already opens with the market's own label or "Re:" —

--- a/apps/desktop/src-tauri/src/export/docx/test.rs
+++ b/apps/desktop/src-tauri/src/export/docx/test.rs
@@ -440,3 +440,55 @@ fn letterhead_less_letter_keeps_its_salutation_and_body() {
         );
     }
 }
+
+/// A cover letter that opens directly at a subject/reference line (e.g. German
+/// "Betreff: …") with no letterhead name above it must keep that subject line —
+/// same defect class as `letterhead_less_letter_keeps_its_salutation_and_body`
+/// (#876), but for `is_subject_line` instead of `is_salutation`/`is_signoff`.
+/// The name block used to fire on the first non-blank line whatever it was, so
+/// the subject line was consumed as the name (replaced with
+/// `meta.candidate_name`) instead of rendering as a subject-styled line, and
+/// the salutation/body that follow it must still render normally. Covers BOTH
+/// letter renderers — `_classic` (Classic) and `_layout` (Refined/Banded).
+#[test]
+fn letterhead_less_letter_with_subject_line_keeps_subject_and_body() {
+    for layout in [
+        LetterLayout::Classic,
+        LetterLayout::Refined,
+        LetterLayout::Banded,
+    ] {
+        let request = ExportRequest {
+            text: "Betreff: Bewerbung als Software Engineer\n\nSehr geehrte Frau Dr. Weber,\n\nmit großem Interesse habe ich Ihre Stellenausschreibung gelesen und bewerbe mich hiermit.\n\nMit freundlichen Grüßen,\nMax Müller".to_string(),
+            format: ExportFormat::Docx,
+            document_type: DocumentType::CoverLetter,
+            template_id: TemplateId::Classic,
+            // `candidate_name` is what the buggy name block substituted IN PLACE
+            // of the subject line, so its presence makes the drop observable.
+            meta: Some(GenerationMeta {
+                candidate_name: Some("Max Müller".to_string()),
+                job_title: None,
+                company_name: None,
+                target_language: None,
+            }),
+            ats_mode: false,
+            locale: None,
+            contact: None,
+            accent: None,
+            letter_layout: layout,
+        };
+        let bytes = generate_docx(&request).expect("docx");
+        let xml = document_xml(&bytes);
+        assert!(
+            xml.contains("Betreff: Bewerbung als Software Engineer"),
+            "{layout:?}: the subject line was consumed as the letterhead name"
+        );
+        assert!(
+            xml.contains("Sehr geehrte Frau Dr. Weber"),
+            "{layout:?}: the salutation must still render after the subject line"
+        );
+        assert!(
+            xml.contains("mit großem Interesse"),
+            "{layout:?}: the body must still render after the subject line"
+        );
+    }
+}


### PR DESCRIPTION
Extends #876's name-block guard in both DOCX letter renderer arms with `!is_subject_line`, so a letter opening with a subject/reference line (e.g. a German `Betreff:` line) and no letterhead name no longer has that line consumed as the candidate name. Later subject-line call sites reuse the computed binding instead of recomputing.

Pinning test covers all three letter layouts (Classic/Refined/Banded) with a Betreff-first German letter — verified to fail on the unguarded renderer with the exact defect ('the subject line was consumed as the letterhead name') and pass with the fix. Full docx module 25/25, clippy `-D warnings` and fmt clean. Audited by the export domain critic with an independent revert-and-rerun check: zero findings.

Fixes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)