### PR TITLE
test: de-flake use-extension-bridge cache-seeding assertion

### DIFF
--- a/apps/desktop/src/renderer/services/use-extension-bridge/use-extension-bridge.test.ts
+++ b/apps/desktop/src/renderer/services/use-extension-bridge/use-extension-bridge.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
 import { act, waitFor } from '@testing-library/react';
 
 import { createMockClient, makeQueryClient, renderHookWithClient } from '@/test-support';
@@ -13,6 +14,21 @@ import {
 } from './use-extension-bridge';
 
 const MOCK_STATUS = { port: 9712, connected: true, token: 'tok-abc123' };
+
+// makeQueryClient() defaults to gcTime: 0, which schedules an unobserved query
+// for near-immediate GC (TanStack Query's Query constructor calls scheduleGc()
+// on creation). A test that seeds a key via setQueryData without an active
+// useQuery observer races that GC timer against its own assertion — flaky
+// under load, since the removal and the check are two independent macrotasks.
+// gcTime: Infinity keeps the seeded entry alive deterministically (same fix
+// already applied in use-autopilot.test.ts's `persistentClient`).
+const persistentClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
 
 describe('useExtensionBridgeStatus', () => {
   it('returns the status payload from the client', async () => {
@@ -199,7 +215,7 @@ describe('useSetExtensionAiAssistSetting', () => {
       'extensionBridge.aiAssistEnabled': vi.fn().mockResolvedValue({ enabled: false }),
       'extensionBridge.setAiAssistEnabled': vi.fn().mockResolvedValue({ enabled: true }),
     });
-    const queryClient = makeQueryClient();
+    const queryClient = persistentClient();
 
     const { result: setResult } = renderHookWithClient(() => useSetExtensionAiAssistSetting(), {
       client,


### PR DESCRIPTION
Root cause: the test mounts only the mutation hook, so the cache entry seeded by `onSuccess` has zero observers; with the shared test client's `gcTime: 0`, TanStack Query schedules an immediate eviction macrotask that races `waitFor`'s polling — the entry can vanish before the first poll. Reproduced 1–2/40 in isolation; 4 documented red CI sightings (#874, #879, plus pre-push reds).

Fix is test-only: a `persistentClient()` (`gcTime`/`staleTime` Infinity) for that one test, mirroring `use-autopilot.test.ts`'s documented pattern for observer-less cache seeding. Proof: 40/40 consecutive isolated runs green, full renderer suite 2462/2462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)