### PR TITLE
fix: restore agent-fleet assembly-line scroll pin broken by doc-shell overflow

### DIFF
--- a/apps/landing/src/styles/doc-shell.css
+++ b/apps/landing/src/styles/doc-shell.css
@@ -29,7 +29,7 @@ body {
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   position: relative;
-  overflow-x: hidden;
+  overflow-x: clip; /* clip not hidden: hidden makes .doc-shell a scroll container and breaks sticky pins inside (agent-fleet belt) */
 }
 /* faint film grain so the dark never reads flat (decorative, pointer-safe) */
 .doc-shell::after {

--- a/apps/landing/src/styles/doc-shell.css
+++ b/apps/landing/src/styles/doc-shell.css
@@ -29,6 +29,7 @@ body {
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   position: relative;
+  overflow-x: hidden; /* fallback: Safari <16 etc. lack overflow:clip — keep clipping there */
   overflow-x: clip; /* clip not hidden: hidden makes .doc-shell a scroll container and breaks sticky pins inside (agent-fleet belt) */
 }
 /* faint film grain so the dark never reads flat (decorative, pointer-safe) */


### PR DESCRIPTION
## Problem

On the landing site's `/agent-system` page ("The Agent Fleet"), the **Assembly Line** section stopped pinning. It's built to pin to the viewport (`position: sticky; top: 0; height: 100vh`) while a `height: 340vh` runway scrolls past, so the conveyor belt scrubs horizontally as you scroll. Instead, the panel just scrolled away with the page.

## Root cause

Regression from **#742** (`774468eb`, the docs-tier / `DocShell` conversion), *not* the recent TSX PRs. That commit moved the page under the shared `DocShell` wrapper and put `overflow-x: hidden` on the `.doc-shell` **div** — whereas the old standalone `agent-system.html` had it on `<body>`.

- `overflow` on `<body>` propagates to the **viewport**, which stays the scroll container → `position: sticky` pins fine.
- `overflow-x: hidden` on an ordinary div forces the computed `overflow-y` to `auto` (CSS Overflow L3), making `.doc-shell` a **scroll container**. The sticky panel then resolves against `.doc-shell` — which grows with its content and never scrolls internally — so it has zero scroll range and never pins.

## Fix

Use `overflow-x: clip` on `.doc-shell`. `clip` clips horizontal overflow **without** establishing a scroll container, so descendant sticky pins resolve against the viewport again. A layered `overflow-x: hidden` fallback sits under it for engines without `clip` (Safari <16 / Chrome <90 / Firefox <81) — those keep today's clipping behavior (no regression); modern engines apply `clip` (last-valid-wins) and get the pin back. The repo has no `browserslist` baseline, hence the fallback.

```css
.doc-shell {
  …
  overflow-x: hidden; /* fallback for engines without overflow:clip */
  overflow-x: clip;   /* clip not hidden — hidden makes .doc-shell a scroll container and breaks sticky pins */
}
```

## Verification

Reproduced and fixed in a live browser (Chrome, dev server):

| | `overflow-x: hidden` (before) | `overflow-x: clip` (after) |
|---|---|---|
| Sticky panel top vs viewport at mid-runway | **−1170px** (scrolled away) | **0px** (pinned) |
| Pinned across 0/25/50/75% of runway | no | **yes** |
| Computed `overflow-y` | `auto` (scroll container) | `visible` |
| Horizontal scrollbar | no | no (`scrollWidth === clientWidth`) |

Confirmed visually: belt pins and scrubs horizontally through the 9 stations with the diff chip riding along.

## Scope

One rule in `apps/landing/src/styles/doc-shell.css`. `frontend-reviewer`: APPROVE (no HIGH/CRITICAL). No other `DocShell`-wrapped route (`architecture-map`, `mission-control`) relies on `.doc-shell` scroll containment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
