### PR TITLE
fix: scraping response caps, country backfill, jobicy label

### DIFF
--- a/apps/desktop/src-tauri/src/commands/autopilot.rs
+++ b/apps/desktop/src-tauri/src/commands/autopilot.rs
@@ -1,11 +1,13 @@
 use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
-use std::time::Duration;
 
 use parking_lot::Mutex;
 
 use crate::autopilot::{AutopilotFilter, AutopilotStatus, AutopilotStore, FoundJob, RunStatus};
 use crate::autopilot_helpers::autopilot_scrape;
+// The save-path `country_code` backfill (a location saved without a geocode
+// pick) — shared with the manual scrape path since trust-fix #2.
+use crate::commands::geocoding::derive_country_code;
 use crate::db::{new_job_id, now_ms};
 use crate::scraping::{JobPosting, ScraperEngine};
 use serde_json::{json, Value};
@@ -97,68 +99,6 @@ pub fn autopilot_get(app: AppHandle, autopilot_id: String) -> Value {
         ap
     });
     json!(ap)
-}
-
-/// Whether `location` is non-empty after trimming — the only precondition for
-/// attempting a geocode lookup. Pure (no network) so it's unit-tested directly.
-fn should_derive_country_code(location: Option<&str>) -> bool {
-    location.map(str::trim).is_some_and(|s| !s.is_empty())
-}
-
-/// Pick a country code out of the geocode service's ranked suggestions: the
-/// first hit that actually CARRIES a VALID one wins (not just the first hit —
-/// an earlier suggestion with an absent/null/malformed `countryCode` must not
-/// block a usable later one), lower-cased to match
-/// `BoardSearchInput::country_code`'s convention. Each candidate is validated
-/// against the SAME 2-ASCII-letter shape `AutopilotTargetSchema.countryCode`
-/// enforces (`^[A-Za-z]{2}$`) — a geocoded value written server-side bypasses
-/// the IPC schema, so a `"USA"` / `"1a"`-style value is skipped, not accepted.
-/// Pure — no network — so this is unit-tested directly; the HTTP round trip
-/// inside `commands::geocoding::suggest` is not (no fixture for it).
-fn country_code_from_suggestions(suggestions: &[Value]) -> Option<String> {
-    suggestions
-        .iter()
-        .find_map(|s| {
-            s.get("countryCode")
-                .and_then(|v| v.as_str())
-                .filter(|cc| cc.len() == 2 && cc.bytes().all(|b| b.is_ascii_alphabetic()))
-        })
-        .map(str::to_lowercase)
-}
-
-/// Cap the save-path geocode lookup tighter than `geocoding::suggest`'s own 5s
-/// reqwest timeout: that 5s is SHARED with the interactive `geocode_suggest`
-/// picker (where the user is waiting on the result and a longer wait is
-/// acceptable), so it can't be lowered there. On the save path this lookup is a
-/// best-effort backfill — `autopilot_create`/`autopilot_update` should not block
-/// the user's save for up to 5s on a slow geocode. On timeout we fall through to
-/// no suggestion (`None`), and the aggregator's guessed-market guard still
-/// covers the residual case.
-const SAVE_GEOCODE_TIMEOUT: Duration = Duration::from_secs(2);
-
-/// Best-effort: when a target has a real `location` but no `country_code` (the
-/// autopilot aggregator zero-jobs bug — a prefilled/typed location saved without
-/// a geocode pick), look one up via the SAME geocode service the manual picker
-/// uses (`commands::geocoding::suggest`) and backfill it before persisting.
-/// Never blocks or fails the save: a network error / no match / timeout just
-/// leaves `country_code` absent, exactly as it would without this fix — the
-/// aggregator's own guessed-market guard (`scraping::boards::aggregator`)
-/// covers that residual case too.
-async fn derive_country_code(location: Option<&str>) -> Option<String> {
-    if !should_derive_country_code(location) {
-        return None;
-    }
-    // Safe: `should_derive_country_code` just proved this is `Some`.
-    let location = location.unwrap_or_default().trim();
-    // Cap the save-path lookup at SAVE_GEOCODE_TIMEOUT (see const above): a
-    // timeout yields an empty Vec -> None (best-effort), never a slow save.
-    let suggestions = tokio::time::timeout(
-        SAVE_GEOCODE_TIMEOUT,
-        crate::commands::geocoding::suggest(location),
-    )
-    .await
-    .unwrap_or_default();
-    country_code_from_suggestions(&suggestions)
 }
 
 #[tauri::command]
@@ -799,105 +739,9 @@ mod tests {
         }
     }
 
-    // ── country_code save-time derivation (autopilot aggregator zero-jobs fix) ──
-
-    #[test]
-    fn should_derive_country_code_requires_a_real_location() {
-        assert!(should_derive_country_code(Some("London")));
-        // Whitespace-only or absent location → nothing to geocode.
-        assert!(!should_derive_country_code(Some("   ")));
-        assert!(!should_derive_country_code(Some("")));
-        assert!(!should_derive_country_code(None));
-    }
-
-    #[test]
-    fn country_code_from_suggestions_takes_first_hit_lowercased() {
-        let suggestions = vec![
-            json!({ "display": "London, United Kingdom", "countryCode": "GB" }),
-            json!({ "display": "London, Canada", "countryCode": "CA" }),
-        ];
-        assert_eq!(
-            country_code_from_suggestions(&suggestions),
-            Some("gb".to_string()),
-            "must take the first (best-ranked) suggestion and lower-case it to \
-             match BoardSearchInput::country_code's convention"
-        );
-    }
-
-    #[test]
-    fn country_code_from_suggestions_empty_or_missing_field_yields_none() {
-        assert_eq!(country_code_from_suggestions(&[]), None);
-        // A suggestion missing `countryCode` entirely (e.g. an ambiguous hit).
-        let no_country = vec![json!({ "display": "Atlantis" })];
-        assert_eq!(country_code_from_suggestions(&no_country), None);
-    }
-
-    #[test]
-    fn country_code_from_suggestions_skips_a_leading_hit_with_no_country_code() {
-        // The first (best-ranked) hit has no countryCode (absent AND explicit
-        // null) — must not block a usable later suggestion.
-        let absent_then_present = vec![
-            json!({ "display": "Ambiguous place" }),
-            json!({ "display": "Munich, Germany", "countryCode": "DE" }),
-        ];
-        assert_eq!(
-            country_code_from_suggestions(&absent_then_present),
-            Some("de".to_string()),
-            "an absent countryCode on the first hit must not block a later, \
-             usable suggestion"
-        );
-
-        let null_then_present = vec![
-            json!({ "display": "Ambiguous place", "countryCode": null }),
-            json!({ "display": "Munich, Germany", "countryCode": "DE" }),
-        ];
-        assert_eq!(
-            country_code_from_suggestions(&null_then_present),
-            Some("de".to_string()),
-            "an explicit null countryCode on the first hit must not block a \
-             later, usable suggestion"
-        );
-    }
-
-    #[test]
-    fn country_code_from_suggestions_skips_malformed_country_codes() {
-        // A geocoded value written server-side bypasses the IPC schema's
-        // `^[A-Za-z]{2}$` guard, so a leading 3-letter ("USA") or non-alpha
-        // ("1a") countryCode must be SKIPPED in favour of a later valid hit —
-        // not accepted (it would fail BoardSearchInput's 2-letter contract).
-        let malformed_then_present = vec![
-            json!({ "display": "United States", "countryCode": "USA" }),
-            json!({ "display": "Nowhere", "countryCode": "1a" }),
-            json!({ "display": "Munich, Germany", "countryCode": "DE" }),
-        ];
-        assert_eq!(
-            country_code_from_suggestions(&malformed_then_present),
-            Some("de".to_string()),
-            "malformed leading countryCodes (3-letter, non-alpha) must be \
-             skipped in favour of a valid 2-letter hit"
-        );
-
-        // All candidates malformed → None (nothing usable to backfill).
-        let all_malformed = vec![
-            json!({ "display": "United States", "countryCode": "USA" }),
-            json!({ "display": "Nowhere", "countryCode": "1a" }),
-            json!({ "display": "Solo", "countryCode": "G" }),
-        ];
-        assert_eq!(
-            country_code_from_suggestions(&all_malformed),
-            None,
-            "an all-malformed list yields no country code"
-        );
-    }
-
-    #[tokio::test]
-    async fn derive_country_code_skips_geocode_when_location_absent() {
-        // No location at all → must resolve to None WITHOUT attempting a
-        // network call (a real HTTP hit here would make this test flaky/slow).
-        assert_eq!(derive_country_code(None).await, None);
-        assert_eq!(derive_country_code(Some("")).await, None);
-        assert_eq!(derive_country_code(Some("   ")).await, None);
-    }
+    // The `country_code` save-time derivation tests moved to
+    // `commands::geocoding` with the helpers themselves (they are now shared
+    // with the manual scrape path).
 
     #[test]
     fn no_filters_keep_everything() {

--- a/apps/desktop/src-tauri/src/commands/geocoding.rs
+++ b/apps/desktop/src-tauri/src/commands/geocoding.rs
@@ -116,6 +116,71 @@ pub(crate) async fn suggest(query: &str) -> Vec<Value> {
         .collect()
 }
 
+/// Whether `location` is non-empty after trimming — the only precondition for
+/// attempting a geocode lookup. Pure (no network) so it's unit-tested directly.
+fn should_derive_country_code(location: Option<&str>) -> bool {
+    location.map(str::trim).is_some_and(|s| !s.is_empty())
+}
+
+/// Pick a country code out of the geocode service's ranked suggestions: the
+/// first hit that actually CARRIES a VALID one wins (not just the first hit —
+/// an earlier suggestion with an absent/null/malformed `countryCode` must not
+/// block a usable later one), lower-cased to match
+/// `BoardSearchInput::country_code`'s convention. Each candidate is validated
+/// against the SAME 2-ASCII-letter shape `AutopilotTargetSchema.countryCode`
+/// enforces (`^[A-Za-z]{2}$`) — a geocoded value written server-side bypasses
+/// the IPC schema, so a `"USA"` / `"1a"`-style value is skipped, not accepted.
+/// Pure — no network — so this is unit-tested directly; the HTTP round trip
+/// inside [`suggest`] is not (no fixture for it).
+fn country_code_from_suggestions(suggestions: &[Value]) -> Option<String> {
+    suggestions
+        .iter()
+        .find_map(|s| {
+            s.get("countryCode")
+                .and_then(|v| v.as_str())
+                .filter(|cc| cc.len() == 2 && cc.bytes().all(|b| b.is_ascii_alphabetic()))
+        })
+        .map(str::to_lowercase)
+}
+
+/// Cap a server-side backfill lookup tighter than [`suggest`]'s own 5s reqwest
+/// timeout: that 5s is SHARED with the interactive `geocode_suggest` picker
+/// (where the user is waiting on the result and a longer wait is acceptable), so
+/// it can't be lowered there. On a backfill path this lookup is best-effort — an
+/// autopilot save / a scrape run should not stall for up to 5s on a slow
+/// geocode. On timeout we fall through to no suggestion (`None`), and the
+/// aggregator's guessed-market guard still covers the residual case.
+const BACKFILL_GEOCODE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Best-effort: when a search target has a real `location` but no
+/// `country_code` (a prefilled or typed-freehand location that never went
+/// through the picker — the aggregator zero-jobs bug), look one up via the SAME
+/// geocode service the manual picker uses and return it for backfill.
+///
+/// Shared by both entry points that can receive a location without a picked
+/// suggestion: autopilot save (`commands::autopilot`) and manual board scrape
+/// (`commands::scrape`). Without it the aggregator hardcodes a `'de'` market
+/// guess AND suppresses its sparse-city broadening, so e.g. a typed "Germany"
+/// or "Amsterdam" search silently under-returns.
+///
+/// Never blocks or fails the caller: a network error / no match / timeout just
+/// leaves `country_code` absent, exactly as it would without this fix — the
+/// aggregator's own guessed-market guard (`scraping::boards::aggregator`)
+/// covers that residual case too.
+pub(crate) async fn derive_country_code(location: Option<&str>) -> Option<String> {
+    if !should_derive_country_code(location) {
+        return None;
+    }
+    // Safe: `should_derive_country_code` just proved this is `Some`.
+    let location = location.unwrap_or_default().trim();
+    // Cap the lookup at BACKFILL_GEOCODE_TIMEOUT (see const above): a timeout
+    // yields an empty Vec -> None (best-effort), never a stalled caller.
+    let suggestions = tokio::time::timeout(BACKFILL_GEOCODE_TIMEOUT, suggest(location))
+        .await
+        .unwrap_or_default();
+    country_code_from_suggestions(&suggestions)
+}
+
 #[tauri::command]
 pub async fn geocode_suggest(query: String) -> Value {
     json!(suggest(&query).await)

--- a/apps/desktop/src-tauri/src/commands/geocoding/test.rs
+++ b/apps/desktop/src-tauri/src/commands/geocoding/test.rs
@@ -1,11 +1,17 @@
-//! Unit tests for `to_city_country`.
+//! Unit tests for `to_city_country` and the server-side `country_code`
+//! backfill helpers (`should_derive_country_code`,
+//! `country_code_from_suggestions`, `derive_country_code`) — the latter moved
+//! here with the helpers when the manual scrape path started sharing the
+//! autopilot save path's backfill.
 //!
-//! This child module can reach the private parent helper via
-//! `super::to_city_country`. Tests are authored by the test-author stage.
+//! This child module can reach the private parent helpers via `super::…`.
+//! Tests are authored by the test-author stage.
 
 use serde_json::json;
 
-use super::to_city_country;
+use super::{
+    country_code_from_suggestions, derive_country_code, should_derive_country_code, to_city_country,
+};
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -499,4 +505,111 @@ fn road_with_parent_city_collapses_to_city() {
     );
     assert_eq!(lat(&result), Some(52.5), "lat must be preserved");
     assert_eq!(lon(&result), Some(13.4), "lon must be preserved");
+}
+
+// ---------------------------------------------------------------------------
+// country_code_from_suggestions / should_derive_country_code
+//
+// The server-side `country_code` backfill for a location that never went
+// through the picker. Shared by the autopilot save path and the manual scrape
+// path, so these live here (next to `suggest`) rather than in one command
+// module.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn should_derive_country_code_requires_a_real_location() {
+    assert!(should_derive_country_code(Some("London")));
+    // Whitespace-only or absent location → nothing to geocode.
+    assert!(!should_derive_country_code(Some("   ")));
+    assert!(!should_derive_country_code(Some("")));
+    assert!(!should_derive_country_code(None));
+}
+
+#[test]
+fn country_code_from_suggestions_takes_first_hit_lowercased() {
+    let suggestions = vec![
+        json!({ "display": "London, United Kingdom", "countryCode": "GB" }),
+        json!({ "display": "London, Canada", "countryCode": "CA" }),
+    ];
+    assert_eq!(
+        country_code_from_suggestions(&suggestions),
+        Some("gb".to_string()),
+        "must take the first (best-ranked) suggestion and lower-case it to \
+         match BoardSearchInput::country_code's convention"
+    );
+}
+
+#[test]
+fn country_code_from_suggestions_empty_or_missing_field_yields_none() {
+    assert_eq!(country_code_from_suggestions(&[]), None);
+    // A suggestion missing `countryCode` entirely (e.g. an ambiguous hit).
+    let no_country = vec![json!({ "display": "Atlantis" })];
+    assert_eq!(country_code_from_suggestions(&no_country), None);
+}
+
+#[test]
+fn country_code_from_suggestions_skips_a_leading_hit_with_no_country_code() {
+    // The first (best-ranked) hit has no countryCode (absent AND explicit
+    // null) — must not block a usable later suggestion.
+    let absent_then_present = vec![
+        json!({ "display": "Ambiguous place" }),
+        json!({ "display": "Munich, Germany", "countryCode": "DE" }),
+    ];
+    assert_eq!(
+        country_code_from_suggestions(&absent_then_present),
+        Some("de".to_string()),
+        "an absent countryCode on the first hit must not block a later, \
+         usable suggestion"
+    );
+
+    let null_then_present = vec![
+        json!({ "display": "Ambiguous place", "countryCode": null }),
+        json!({ "display": "Munich, Germany", "countryCode": "DE" }),
+    ];
+    assert_eq!(
+        country_code_from_suggestions(&null_then_present),
+        Some("de".to_string()),
+        "an explicit null countryCode on the first hit must not block a \
+         later, usable suggestion"
+    );
+}
+
+#[test]
+fn country_code_from_suggestions_skips_malformed_country_codes() {
+    // A geocoded value written server-side bypasses the IPC schema's
+    // `^[A-Za-z]{2}$` guard, so a leading 3-letter ("USA") or non-alpha
+    // ("1a") countryCode must be SKIPPED in favour of a later valid hit —
+    // not accepted (it would fail BoardSearchInput's 2-letter contract).
+    let malformed_then_present = vec![
+        json!({ "display": "United States", "countryCode": "USA" }),
+        json!({ "display": "Nowhere", "countryCode": "1a" }),
+        json!({ "display": "Munich, Germany", "countryCode": "DE" }),
+    ];
+    assert_eq!(
+        country_code_from_suggestions(&malformed_then_present),
+        Some("de".to_string()),
+        "malformed leading countryCodes (3-letter, non-alpha) must be \
+         skipped in favour of a valid 2-letter hit"
+    );
+
+    // All candidates malformed → None (nothing usable to backfill).
+    let all_malformed = vec![
+        json!({ "display": "United States", "countryCode": "USA" }),
+        json!({ "display": "Nowhere", "countryCode": "1a" }),
+        json!({ "display": "Solo", "countryCode": "G" }),
+    ];
+    assert_eq!(
+        country_code_from_suggestions(&all_malformed),
+        None,
+        "an all-malformed list yields no country code"
+    );
+}
+
+#[tokio::test]
+async fn derive_country_code_skips_geocode_when_location_absent() {
+    // No location at all → must resolve to None WITHOUT attempting a
+    // network call (a real HTTP hit here would make this test flaky/slow).
+    assert_eq!(derive_country_code(None).await, None);
+    assert_eq!(derive_country_code(Some("")).await, None);
+    assert_eq!(derive_country_code(Some("   ")).await, None);
 }

--- a/apps/desktop/src-tauri/src/commands/scrape.rs
+++ b/apps/desktop/src-tauri/src/commands/scrape.rs
@@ -84,7 +84,7 @@ pub async fn scrape_boards(app: AppHandle, req: ScrapeBoardsRequest) -> Value {
     crate::commands::jobs::job_start(&app, &job_id, "scrape.board");
 
     let engine = app.state::<std::sync::Arc<ScraperEngine>>().inner().clone();
-    let input = BoardSearchInput {
+    let mut input = BoardSearchInput {
         query: req.query.clone(),
         location: req.location.clone(),
         // `amount` is the per-board cap: each board returns up to this many results.
@@ -174,6 +174,20 @@ pub async fn scrape_boards(app: AppHandle, req: ScrapeBoardsRequest) -> Value {
     tokio::spawn(async move {
         // Hold the concurrency guard for the whole scrape; dropped on completion.
         let _guard = guard;
+
+        // Backfill the market for a location the user TYPED instead of picking
+        // from the geocode suggestions: the renderer only sends `countryCode`
+        // for a picked suggestion, so a freehand "Germany"/"Amsterdam" arrives
+        // with none — and the aggregator then hardcodes a 'de' guess AND
+        // suppresses its sparse-city broadening (silent under-return). Same
+        // best-effort lookup autopilot does on save; runs INSIDE the spawned
+        // task so the command still returns its `jobId` immediately, and a
+        // network error / no match / 2s timeout just leaves it absent.
+        if input.country_code.is_none() {
+            input.country_code =
+                crate::commands::geocoding::derive_country_code(input.location.as_deref()).await;
+        }
+
         let result = engine
             .scrape_boards(
                 &boards,

--- a/apps/desktop/src-tauri/src/commands/scrape.rs
+++ b/apps/desktop/src-tauri/src/commands/scrape.rs
@@ -167,7 +167,7 @@ pub async fn scrape_boards(app: AppHandle, req: ScrapeBoardsRequest) -> Value {
     // never a no-op. `scrape_boards` detects the pre-registered slot and reuses
     // it (we_minted=false) and therefore will NOT remove it — we clean up below.
     let cancel_token = tokio_util::sync::CancellationToken::new();
-    engine.register_token(&job_id, cancel_token).await;
+    engine.register_token(&job_id, cancel_token.clone()).await;
 
     let app_clone = app.clone();
     let job_id_clone = job_id.clone();
@@ -183,9 +183,33 @@ pub async fn scrape_boards(app: AppHandle, req: ScrapeBoardsRequest) -> Value {
         // best-effort lookup autopilot does on save; runs INSIDE the spawned
         // task so the command still returns its `jobId` immediately, and a
         // network error / no match / 2s timeout just leaves it absent.
+        //
+        // CANCELLATION: this await must race the token, because a cancel landing
+        // here would otherwise be LOST — `ScraperEngine::cancel` REMOVES the job
+        // slot before cancelling it, so the later `scrape_boards` finds no
+        // pre-registered token and mints a FRESH, un-cancelled one. The abandoned
+        // run would then scrape to completion and its first streamed item would
+        // `clear_all()` the postings cache the user's NEW search is already
+        // filling (the Jobs page cancels-then-starts). `biased;` polls
+        // cancellation first so an already-cancelled run never starts the lookup.
         if input.country_code.is_none() {
-            input.country_code =
-                crate::commands::geocoding::derive_country_code(input.location.as_deref()).await;
+            let derived = tokio::select! {
+                biased;
+                () = cancel_token.cancelled() => None,
+                cc = crate::commands::geocoding::derive_country_code(input.location.as_deref()) => cc,
+            };
+            input.country_code = derived;
+        }
+
+        // Covers the same window without a geocode (a cancel arriving between the
+        // command returning its jobId and this task waking): never START a scrape
+        // for a run the user already cancelled. `jobs_cancel` has already emitted
+        // `job.cancelled`, so there is no terminal event to report here — just
+        // release the slot (idempotent; `cancel` already removed it) and the
+        // concurrency guard held by `_guard`.
+        if cancel_token.is_cancelled() {
+            engine.unregister_token(&job_id_clone).await;
+            return;
         }
 
         let result = engine

--- a/apps/desktop/src-tauri/src/commands/scrape.rs
+++ b/apps/desktop/src-tauri/src/commands/scrape.rs
@@ -60,6 +60,63 @@ pub struct ScrapeUpdateDescriptionRequest {
 /// so a caller can tell the write didn't take effect as sent.
 const MAX_DESCRIPTION_LEN: usize = 256 * 1024;
 
+/// Fill `input.country_code` for a location the user TYPED instead of picking
+/// from the geocode suggestions: the renderer only sends `countryCode` for a
+/// picked suggestion, so a freehand "Germany"/"Amsterdam" arrives with none —
+/// and the aggregator then hardcodes a `'de'` guess AND suppresses its
+/// sparse-city broadening (a silent under-return). Same best-effort lookup
+/// autopilot does on save; a network error / no match / 2s timeout just leaves
+/// the field absent.
+///
+/// Returns **false when the run was cancelled** (the caller must abandon it),
+/// true otherwise. Two cancellation concerns, both handled here:
+/// - the lookup is raced against `token` with a `biased;` select, so a Stop
+///   during the ≤2s geocode takes effect immediately instead of after it — and
+///   an already-cancelled run never issues the request at all;
+/// - a cancel that landed before this ran (between the command returning its
+///   `jobId` and the spawned task waking) is caught by the same final check.
+///
+/// This narrows the window at the COMMAND layer; it is closed at the engine
+/// layer by [`crate::scraping::ScraperEngine::cancel`] cancelling the job slot
+/// in place instead of removing it, so a cancel landing after this returns
+/// `true` is still honored by the engine rather than lost to a freshly minted
+/// token. Takes a bare token + `&mut BoardSearchInput` so it is unit-testable
+/// without an `AppHandle`.
+async fn backfill_country_code(
+    token: &tokio_util::sync::CancellationToken,
+    input: &mut BoardSearchInput,
+) -> bool {
+    // Owned so the lookup future doesn't borrow `input` while we write to it.
+    let location = input.location.clone();
+    backfill_country_code_with(
+        token,
+        input,
+        crate::commands::geocoding::derive_country_code(location.as_deref()),
+    )
+    .await
+}
+
+/// [`backfill_country_code`] with the geocode lookup injected, so the
+/// cancellation behavior is testable against a hung / instant / never-polled
+/// future instead of the real Nominatim round trip (no network in tests).
+///
+/// `lookup` is only ever POLLED when `country_code` is absent — an existing
+/// (picked) country is never clobbered and costs no request.
+async fn backfill_country_code_with(
+    token: &tokio_util::sync::CancellationToken,
+    input: &mut BoardSearchInput,
+    lookup: impl std::future::Future<Output = Option<String>>,
+) -> bool {
+    if input.country_code.is_none() {
+        input.country_code = tokio::select! {
+            biased;
+            () = token.cancelled() => None,
+            cc = lookup => cc,
+        };
+    }
+    !token.is_cancelled()
+}
+
 #[tauri::command]
 pub async fn scrape_boards(app: AppHandle, req: ScrapeBoardsRequest) -> Value {
     let job_id = new_job_id();
@@ -175,39 +232,12 @@ pub async fn scrape_boards(app: AppHandle, req: ScrapeBoardsRequest) -> Value {
         // Hold the concurrency guard for the whole scrape; dropped on completion.
         let _guard = guard;
 
-        // Backfill the market for a location the user TYPED instead of picking
-        // from the geocode suggestions: the renderer only sends `countryCode`
-        // for a picked suggestion, so a freehand "Germany"/"Amsterdam" arrives
-        // with none — and the aggregator then hardcodes a 'de' guess AND
-        // suppresses its sparse-city broadening (silent under-return). Same
-        // best-effort lookup autopilot does on save; runs INSIDE the spawned
-        // task so the command still returns its `jobId` immediately, and a
-        // network error / no match / 2s timeout just leaves it absent.
-        //
-        // CANCELLATION: this await must race the token, because a cancel landing
-        // here would otherwise be LOST — `ScraperEngine::cancel` REMOVES the job
-        // slot before cancelling it, so the later `scrape_boards` finds no
-        // pre-registered token and mints a FRESH, un-cancelled one. The abandoned
-        // run would then scrape to completion and its first streamed item would
-        // `clear_all()` the postings cache the user's NEW search is already
-        // filling (the Jobs page cancels-then-starts). `biased;` polls
-        // cancellation first so an already-cancelled run never starts the lookup.
-        if input.country_code.is_none() {
-            let derived = tokio::select! {
-                biased;
-                () = cancel_token.cancelled() => None,
-                cc = crate::commands::geocoding::derive_country_code(input.location.as_deref()) => cc,
-            };
-            input.country_code = derived;
-        }
-
-        // Covers the same window without a geocode (a cancel arriving between the
-        // command returning its jobId and this task waking): never START a scrape
-        // for a run the user already cancelled. `jobs_cancel` has already emitted
-        // `job.cancelled`, so there is no terminal event to report here — just
-        // release the slot (idempotent; `cancel` already removed it) and the
-        // concurrency guard held by `_guard`.
-        if cancel_token.is_cancelled() {
+        // Fill in the market for a typed (not picked) location, unless the user
+        // already cancelled — see [`backfill_country_code`].
+        if !backfill_country_code(&cancel_token, &mut input).await {
+            // `jobs_cancel` already emitted `job.cancelled`, so there is no
+            // terminal event to report here — just release the slot and the
+            // concurrency guard held by `_guard`.
             engine.unregister_token(&job_id_clone).await;
             return;
         }
@@ -641,5 +671,131 @@ mod test {
         let id = validate_update_description("  job-1  ", &at_cap)
             .expect("a trimmed non-empty id with an at-cap description must validate");
         assert_eq!(id, "job-1", "the validated id must be trimmed");
+    }
+
+    // ── backfill_country_code (pre-scrape cancellation) ──────────────────────
+    //
+    // Driven through the injected-lookup seam so every case is hermetic: no
+    // Nominatim round trip, no `AppHandle`, no timing sleeps.
+
+    fn input_with(location: Option<&str>, country_code: Option<&str>) -> BoardSearchInput {
+        BoardSearchInput {
+            query: "rust".to_string(),
+            location: location.map(str::to_string),
+            amount: 25,
+            pages: 1,
+            date_filter: None,
+            job_type: None,
+            work_type: None,
+            experience_level: None,
+            easy_apply: None,
+            actively_hiring: None,
+            verified: None,
+            sort_by: None,
+            country_code: country_code.map(str::to_string),
+            latitude: None,
+            longitude: None,
+            radius_km: None,
+            companies: Vec::new(),
+        }
+    }
+
+    /// Already cancelled when the task wakes → abandon the run AND never poll the
+    /// lookup. The `biased;` ordering is what guarantees the second half: an
+    /// unbiased select picks a ready branch at random and could fire the geocode
+    /// request for a run nobody is waiting on.
+    #[tokio::test]
+    async fn pre_cancelled_run_is_abandoned_without_polling_the_lookup() {
+        let token = tokio_util::sync::CancellationToken::new();
+        token.cancel();
+        let mut input = input_with(Some("Germany"), None);
+        let polled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = polled.clone();
+
+        let proceed = backfill_country_code_with(&token, &mut input, async move {
+            flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            Some("de".to_string())
+        })
+        .await;
+
+        assert!(!proceed, "a cancelled run must not proceed to the scrape");
+        assert!(
+            !polled.load(std::sync::atomic::Ordering::SeqCst),
+            "the geocode lookup must never be issued for an already-cancelled run"
+        );
+        assert!(input.country_code.is_none());
+    }
+
+    /// A cancel landing WHILE the lookup is in flight wins immediately — the run
+    /// is abandoned instead of waiting out the 2s geocode cap. `pending()` stands
+    /// in for a hung Nominatim call: without the select the test would hang.
+    #[tokio::test]
+    async fn cancel_during_the_lookup_abandons_the_run() {
+        let token = tokio_util::sync::CancellationToken::new();
+        let mut input = input_with(Some("Amsterdam"), None);
+
+        let canceller = token.clone();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            canceller.cancel();
+        });
+
+        let proceed = backfill_country_code_with(
+            &token,
+            &mut input,
+            std::future::pending::<Option<String>>(),
+        )
+        .await;
+
+        assert!(
+            !proceed,
+            "a cancel during the lookup must abandon the run, not wait it out"
+        );
+        assert!(
+            input.country_code.is_none(),
+            "an interrupted lookup must leave the field absent"
+        );
+    }
+
+    /// The happy path: the lookup resolves, its country is written, and the run
+    /// proceeds.
+    #[tokio::test]
+    async fn a_resolved_lookup_fills_the_country_and_proceeds() {
+        let token = tokio_util::sync::CancellationToken::new();
+        let mut input = input_with(Some("Amsterdam"), None);
+
+        let proceed =
+            backfill_country_code_with(&token, &mut input, std::future::ready(Some("nl".into())))
+                .await;
+
+        assert!(proceed);
+        assert_eq!(input.country_code.as_deref(), Some("nl"));
+    }
+
+    /// A country the user PICKED is authoritative: no lookup is polled and the
+    /// value is never overwritten (the backfill is for typed locations only).
+    #[tokio::test]
+    async fn an_existing_country_code_is_kept_and_costs_no_lookup() {
+        let token = tokio_util::sync::CancellationToken::new();
+        let mut input = input_with(Some("Austin, United States"), Some("us"));
+        let polled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = polled.clone();
+
+        let proceed = backfill_country_code_with(&token, &mut input, async move {
+            flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            Some("de".to_string())
+        })
+        .await;
+
+        assert!(proceed);
+        assert_eq!(
+            input.country_code.as_deref(),
+            Some("us"),
+            "a picked country must never be clobbered by the backfill"
+        );
+        assert!(
+            !polled.load(std::sync::atomic::Ordering::SeqCst),
+            "no geocode request may be issued when the country is already known"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/scraping/boards/ashby/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ashby/mod.rs
@@ -3,9 +3,9 @@
 //! Endpoint: `https://api.ashbyhq.com/posting-api/job-board/{company}?includeCompensation=true`
 //! No global keyword search — requires a company slug. The engine skips this
 //! board with `"needs-company"` when `input.companies` is empty.
-use super::super::http::fetch_json;
+use super::super::http::{fetch_json, FetchOptions};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::{ats_all_fetches_failed, normalize_companies};
+use super::common::{ats_all_fetches_failed, ats_failed_fetches_note, normalize_companies};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -82,6 +82,7 @@ impl Scraper for AshbyScraper {
         let total = companies.len();
 
         let mut successful_fetches = 0usize;
+        let mut failed_fetches = 0usize;
         let mut first_fetch_error: Option<String> = None;
 
         for (i, company) in companies.iter().enumerate() {
@@ -94,25 +95,32 @@ impl Scraper for AshbyScraper {
                 urlencoding::encode(company)
             );
 
-            let data =
-                match fetch_json::<AshbyResponse>(&url, Default::default(), ctx.signal.clone())
-                    .await
-                {
-                    Ok(d) => d,
-                    Err(e) => {
-                        // Check cancellation first: a fetch that failed because
-                        // the run was cancelled is not a real board-level error.
-                        if ctx.signal.is_cancelled() {
-                            break;
-                        }
-                        log::warn!("[ashby] fetch failed for '{}': {e}", company);
-                        first_fetch_error.get_or_insert_with(|| e.to_string());
-                        if let Some(ref on_progress) = ctx.on_progress {
-                            on_progress((i + 1) as f32 / total as f32);
-                        }
-                        continue;
+            let opts = FetchOptions {
+                // One Ashby call returns a company's WHOLE board, so a large
+                // employer's payload can exceed the 8 MB default guard (observed:
+                // openai → "Response too large", i.e. a silently dropped company).
+                // Raise the per-request cap only here.
+                max_bytes: Some(16 * 1024 * 1024),
+                ..Default::default()
+            };
+
+            let data = match fetch_json::<AshbyResponse>(&url, opts, ctx.signal.clone()).await {
+                Ok(d) => d,
+                Err(e) => {
+                    // Check cancellation first: a fetch that failed because
+                    // the run was cancelled is not a real board-level error.
+                    if ctx.signal.is_cancelled() {
+                        break;
                     }
-                };
+                    log::warn!("[ashby] fetch failed for '{}': {e}", company);
+                    failed_fetches += 1;
+                    first_fetch_error.get_or_insert_with(|| e.to_string());
+                    if let Some(ref on_progress) = ctx.on_progress {
+                        on_progress((i + 1) as f32 / total as f32);
+                    }
+                    continue;
+                }
+            };
 
             // A non-2xx / schema-drift response is now an `Err` above (which records
             // `first_fetch_error`), so reaching here means a real success — count it.
@@ -155,6 +163,16 @@ impl Scraper for AshbyScraper {
 
             if let Some(ref on_progress) = ctx.on_progress {
                 on_progress((i + 1) as f32 / total as f32);
+            }
+        }
+
+        // A PARTIAL run (some companies fetched, some failed) still returns Ok, so
+        // the failures would otherwise be log-only — surface the count as ONE
+        // informational note. Gated on non-cancellation: a benign interruption
+        // reports nothing (mirrors `ats_finish_search`).
+        if !ctx.signal.is_cancelled() {
+            if let Some(note) = ats_failed_fetches_note(successful_fetches, failed_fetches) {
+                ctx.report_note(note);
             }
         }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/ashby/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ashby/mod.rs
@@ -43,6 +43,37 @@ struct AshbyResponse {
 /// Prevents an unbounded number of outbound requests from a large IPC payload.
 const MAX_COMPANIES: usize = 50;
 
+/// Production Ashby API host. Factored into a constant (rather than inlined)
+/// purely so tests can drive [`AshbyScraper::search_with_base`] against a local
+/// `wiremock` base instead — mirrors Lever's `LEVER_BASE_URL`.
+const ASHBY_BASE_URL: &str = "https://api.ashbyhq.com";
+
+/// Fetch ONE company's whole board. Split out of the search loop so the
+/// per-company request — including the raised byte cap — is drivable against a
+/// mock host, which is what makes the partial-failure note testable without the
+/// live API.
+async fn fetch_ashby_company(
+    base_url: &str,
+    company: &str,
+    signal: tokio_util::sync::CancellationToken,
+) -> crate::error::AppResult<AshbyResponse> {
+    let url = format!(
+        "{base_url}/posting-api/job-board/{}?includeCompensation=true",
+        urlencoding::encode(company)
+    );
+
+    let opts = FetchOptions {
+        // One Ashby call returns a company's WHOLE board, so a large employer's
+        // payload can exceed the 8 MB default guard (observed: openai →
+        // "Response too large", i.e. a silently dropped company). Raise the
+        // per-request cap only here.
+        max_bytes: Some(16 * 1024 * 1024),
+        ..Default::default()
+    };
+
+    fetch_json::<AshbyResponse>(&url, opts, signal).await
+}
+
 pub struct AshbyScraper;
 
 #[async_trait]
@@ -68,6 +99,20 @@ impl Scraper for AshbyScraper {
         input: BoardSearchInput,
         ctx: ScrapeContext,
     ) -> anyhow::Result<Vec<JobPosting>> {
+        self.search_with_base(ASHBY_BASE_URL, input, ctx).await
+    }
+}
+
+impl AshbyScraper {
+    /// The real search loop, parameterized by API base URL so tests can point it
+    /// at a mock server ([`fetch_ashby_company`]). `search` supplies
+    /// [`ASHBY_BASE_URL`]; nothing else calls this.
+    async fn search_with_base(
+        &self,
+        base_url: &str,
+        input: BoardSearchInput,
+        ctx: ScrapeContext,
+    ) -> anyhow::Result<Vec<JobPosting>> {
         // Engine skips us when companies is empty; guard defensively anyway.
         if input.companies.is_empty() {
             return Ok(vec![]);
@@ -90,21 +135,7 @@ impl Scraper for AshbyScraper {
                 break;
             }
 
-            let url = format!(
-                "https://api.ashbyhq.com/posting-api/job-board/{}?includeCompensation=true",
-                urlencoding::encode(company)
-            );
-
-            let opts = FetchOptions {
-                // One Ashby call returns a company's WHOLE board, so a large
-                // employer's payload can exceed the 8 MB default guard (observed:
-                // openai → "Response too large", i.e. a silently dropped company).
-                // Raise the per-request cap only here.
-                max_bytes: Some(16 * 1024 * 1024),
-                ..Default::default()
-            };
-
-            let data = match fetch_json::<AshbyResponse>(&url, opts, ctx.signal.clone()).await {
+            let data = match fetch_ashby_company(base_url, company, ctx.signal.clone()).await {
                 Ok(d) => d,
                 Err(e) => {
                     // Check cancellation first: a fetch that failed because

--- a/apps/desktop/src-tauri/src/scraping/boards/ashby/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ashby/mod.rs
@@ -168,12 +168,12 @@ impl Scraper for AshbyScraper {
 
         // A PARTIAL run (some companies fetched, some failed) still returns Ok, so
         // the failures would otherwise be log-only — surface the count as ONE
-        // informational note. Gated on non-cancellation: a benign interruption
-        // reports nothing (mirrors `ats_finish_search`).
-        if !ctx.signal.is_cancelled() {
-            if let Some(note) = ats_failed_fetches_note(successful_fetches, failed_fetches) {
-                ctx.report_note(note);
-            }
+        // informational note. NOT gated on cancellation, for the reason spelled
+        // out in `lever`'s copy: the engine cancels `ctx.signal` as soon as the
+        // central `amount` cap fills, and `failed_fetches` only counts
+        // non-cancellation errors anyway.
+        if let Some(note) = ats_failed_fetches_note(successful_fetches, failed_fetches) {
+            ctx.report_note(note);
         }
 
         // Return Err only when every attempt failed — see `ats_all_fetches_failed`.

--- a/apps/desktop/src-tauri/src/scraping/boards/ashby/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/ashby/test.rs
@@ -249,6 +249,146 @@ async fn all_blank_companies_returns_ok_empty() {
     assert!(result.unwrap().is_empty());
 }
 
+/// The partial-failure note, end to end against a mock Ashby host: company
+/// `good` returns a board (200), company `rotted` 404s. The board must KEEP the
+/// good company's postings (`Ok`, not a whole-board error) and report exactly
+/// `companies-failed:1` through the `on_note` sink — the failure that used to be
+/// log-only whenever a sibling company succeeded. Mirrors lever's copy.
+#[tokio::test]
+async fn partial_company_failure_reports_the_companies_failed_note() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/posting-api/job-board/good"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "apiVersion": "1",
+            "jobs": [{
+                "id": "abc123",
+                "title": "Rust Engineer",
+                "locationName": "Berlin",
+                "isRemote": true,
+                "jobUrl": "https://jobs.ashbyhq.com/good/abc123",
+                "descriptionPlain": "Build things in Rust.",
+                "publishedAt": "2026-06-01T09:00:00Z",
+            }],
+        })))
+        .mount(&server)
+        .await;
+    // A rotted/renamed slug — the exact shape that used to vanish silently.
+    Mock::given(method("GET"))
+        .and(path("/posting-api/job-board/rotted"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let notes = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let sink = notes.clone();
+    let ctx = ScrapeContext {
+        signal: tokio_util::sync::CancellationToken::new(),
+        on_progress: None,
+        on_item: None,
+        on_truncation: None,
+        on_note: Some(std::sync::Arc::new(move |n: String| {
+            sink.lock().expect("note sink poisoned").push(n)
+        })),
+    };
+    let input = BoardSearchInput {
+        query: String::new(),
+        location: None,
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: vec!["good".to_string(), "rotted".to_string()],
+    };
+
+    let out = AshbyScraper
+        .search_with_base(&server.uri(), input, ctx)
+        .await
+        .expect("a partial run must stay Ok — one succeeding company is a result");
+
+    assert_eq!(
+        out.len(),
+        1,
+        "the succeeding company's postings must be kept, got {out:?}"
+    );
+    assert_eq!(
+        notes.lock().expect("note sink poisoned").as_slice(),
+        ["companies-failed:1".to_string()],
+        "the failed company must surface as exactly one companies-failed note"
+    );
+}
+
+/// The complement: every company succeeds → NO note (a clean run must not grow a
+/// chip). Guards against the counter being incremented on a success path.
+#[tokio::test]
+async fn clean_run_reports_no_note() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "apiVersion": "1",
+            "jobs": [],
+        })))
+        .mount(&server)
+        .await;
+
+    let notes = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let sink = notes.clone();
+    let ctx = ScrapeContext {
+        signal: tokio_util::sync::CancellationToken::new(),
+        on_progress: None,
+        on_item: None,
+        on_truncation: None,
+        on_note: Some(std::sync::Arc::new(move |n: String| {
+            sink.lock().expect("note sink poisoned").push(n)
+        })),
+    };
+    let input = BoardSearchInput {
+        query: String::new(),
+        location: None,
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: vec!["good".to_string()],
+    };
+
+    AshbyScraper
+        .search_with_base(&server.uri(), input, ctx)
+        .await
+        .expect("an all-success run must be Ok");
+
+    assert!(
+        notes.lock().expect("note sink poisoned").is_empty(),
+        "a run with zero failures must emit no note"
+    );
+}
+
 #[tokio::test]
 #[ignore = "live network"]
 async fn live_search_returns_results() {

--- a/apps/desktop/src-tauri/src/scraping/boards/common.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common.rs
@@ -219,6 +219,32 @@ pub(crate) fn ats_partial_note(
     (rows_dropped > 0).then(|| format!("rows-dropped:{rows_dropped}"))
 }
 
+/// Companion to [`ats_partial_note`] for the ATS boards that fetch one company
+/// at a time WITHOUT a pre-fetch slug validator (Ashby, Lever): `failed_fetches`
+/// of the attempted per-company fetches failed (404 on a rotted slug, 403, a
+/// rate-limited 429, a response over the byte cap) while at least one sibling
+/// succeeded — so [`ats_all_fetches_failed`] keeps the run `Ok` and those
+/// failures were previously log-only, invisible to the user (the whole point of
+/// this note: a run that quietly fetched 3 of 10 companies looked complete).
+///
+/// Emits the same PR-D `kind:value` grammar as [`ats_partial_note`]:
+/// `companies-failed:<n>`. Returns `None` when nothing failed, OR when EVERY
+/// fetch failed (`successful_fetches == 0`) — that whole-board FAILURE is
+/// surfaced as an `Err`, never as a note. Company names are deliberately NOT in
+/// the token: it crosses IPC into a chip, so it stays a count (the per-company
+/// detail is already in the `log::warn!` each board emits).
+///
+/// Pure — directly unit-testable without a mock server. The caller emits the
+/// returned token via `ScrapeContext::report_note`, gated on non-cancellation
+/// (a benign interruption reports nothing, mirroring [`ats_finish_search`]).
+pub(crate) fn ats_failed_fetches_note(
+    successful_fetches: usize,
+    failed_fetches: usize,
+) -> Option<String> {
+    (successful_fetches > 0 && failed_fetches > 0)
+        .then(|| format!("companies-failed:{failed_fetches}"))
+}
+
 /// Decide the pagination-failure policy for a page fetch: a page reached with
 /// nothing collected yet (typically page 0) propagates the fetch failure as a
 /// board error; a later page that fails after some items were already

--- a/apps/desktop/src-tauri/src/scraping/boards/common.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common.rs
@@ -235,8 +235,13 @@ pub(crate) fn ats_partial_note(
 /// detail is already in the `log::warn!` each board emits).
 ///
 /// Pure — directly unit-testable without a mock server. The caller emits the
-/// returned token via `ScrapeContext::report_note`, gated on non-cancellation
-/// (a benign interruption reports nothing, mirroring [`ats_finish_search`]).
+/// returned token via `ScrapeContext::report_note`, and — unlike
+/// [`ats_partial_note`]'s callers — does NOT gate that on cancellation: the
+/// engine cancels `ctx.signal` as soon as the central `amount` cap fills, which
+/// on a long seeded company list is exactly when failures are most likely to
+/// have accumulated. The count stays honest because a fetch that failed *because
+/// of* cancellation is never recorded (each board breaks on a cancelled signal
+/// before incrementing).
 pub(crate) fn ats_failed_fetches_note(
     successful_fetches: usize,
     failed_fetches: usize,

--- a/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/common/test.rs
@@ -211,6 +211,45 @@ fn partial_note_clean_run_returns_none() {
     assert!(ats_partial_note(5, 0, 0).is_none());
 }
 
+// ── ats_failed_fetches_note (partial per-company fetch failures) ─────────────
+//
+// The gap this closes: a Lever/Ashby run where SOME companies failed (404 on a
+// rotted slug, 403, 429, a payload over the byte cap) but at least one sibling
+// succeeded returns `Ok` — so the failures were log-only and the run looked
+// complete to the user.
+
+/// SOME companies failed while ≥1 succeeded → `companies-failed:<n>` where `n`
+/// is the FAILED count (not the success count) — that is the number the chip
+/// shows, so getting it backwards would understate a mostly-broken run.
+#[test]
+fn failed_fetches_note_partial_run_reports_failed_count() {
+    assert_eq!(
+        ats_failed_fetches_note(3, 7).as_deref(),
+        Some("companies-failed:7"),
+        "a partial run must surface the FAILED company count, not the successful one",
+    );
+}
+
+/// Zero failures → no note (a clean run must stay chip-free / plain success).
+#[test]
+fn failed_fetches_note_clean_run_returns_none() {
+    assert!(ats_failed_fetches_note(5, 0).is_none());
+}
+
+/// Zero successes → `None` even with failures recorded: an all-fail run is a
+/// whole-board FAILURE (`ats_all_fetches_failed` surfaces the Err), never a
+/// note — and the engine drops notes on the Err path anyway, so emitting one
+/// here would be invisible AND wrong.
+#[test]
+fn failed_fetches_note_all_failed_returns_none() {
+    assert!(
+        ats_failed_fetches_note(0, 4).is_none(),
+        "all-failed is an error, not a partial note",
+    );
+    // Nothing attempted at all (empty/blank company list) is also not a note.
+    assert!(ats_failed_fetches_note(0, 0).is_none());
+}
+
 // ── should_propagate_page_error ──────────────────────────────────────────────
 
 #[test]

--- a/apps/desktop/src-tauri/src/scraping/boards/lever/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/lever/mod.rs
@@ -39,6 +39,37 @@ pub(crate) fn map_posted_at(created_at: Option<i64>) -> Option<i64> {
     created_at // createdAt is already epoch-milliseconds — pass through verbatim
 }
 
+/// Production Lever API host. Factored into a constant (rather than inlined)
+/// purely so tests can drive [`LeverScraper::search_with_base`] against a local
+/// `wiremock` base instead — the aggregator's `JOOBLE_BASE_URL` pattern.
+const LEVER_BASE_URL: &str = "https://api.lever.co";
+
+/// Fetch ONE company's whole board. Split out of the search loop so the
+/// per-company request — including the raised byte cap — is drivable against a
+/// mock host, which is what makes the partial-failure note testable without the
+/// live API.
+async fn fetch_lever_company(
+    base_url: &str,
+    company: &str,
+    signal: tokio_util::sync::CancellationToken,
+) -> crate::error::AppResult<Vec<LeverPosting>> {
+    let url = format!(
+        "{base_url}/v0/postings/{}?mode=json",
+        urlencoding::encode(company)
+    );
+
+    let opts = FetchOptions {
+        // One Lever call returns a company's WHOLE board, so a large employer's
+        // payload can exceed the 8 MB default guard (observed: veeva →
+        // "Response too large", i.e. a silently dropped company). Raise the
+        // per-request cap only here.
+        max_bytes: Some(16 * 1024 * 1024),
+        ..Default::default()
+    };
+
+    fetch_json::<Vec<LeverPosting>>(&url, opts, signal).await
+}
+
 pub struct LeverScraper;
 
 #[async_trait]
@@ -61,6 +92,20 @@ impl Scraper for LeverScraper {
 
     async fn search(
         &self,
+        input: BoardSearchInput,
+        ctx: ScrapeContext,
+    ) -> anyhow::Result<Vec<JobPosting>> {
+        self.search_with_base(LEVER_BASE_URL, input, ctx).await
+    }
+}
+
+impl LeverScraper {
+    /// The real search loop, parameterized by API base URL so tests can point it
+    /// at a mock server ([`fetch_lever_company`]). `search` supplies
+    /// [`LEVER_BASE_URL`]; nothing else calls this.
+    async fn search_with_base(
+        &self,
+        base_url: &str,
         input: BoardSearchInput,
         ctx: ScrapeContext,
     ) -> anyhow::Result<Vec<JobPosting>> {
@@ -87,35 +132,20 @@ impl Scraper for LeverScraper {
                 continue;
             }
 
-            let url = format!(
-                "https://api.lever.co/v0/postings/{}?mode=json",
-                urlencoding::encode(company)
-            );
-
-            let opts = FetchOptions {
-                // One Lever call returns a company's WHOLE board, so a large
-                // employer's payload can exceed the 8 MB default guard (observed:
-                // veeva → "Response too large", i.e. a silently dropped company).
-                // Raise the per-request cap only here.
-                max_bytes: Some(16 * 1024 * 1024),
-                ..Default::default()
-            };
-
-            let postings =
-                match fetch_json::<Vec<LeverPosting>>(&url, opts, ctx.signal.clone()).await {
-                    Ok(d) => d,
-                    Err(e) => {
-                        // A fetch that failed because the run was cancelled is not
-                        // a real board-level error.
-                        if ctx.signal.is_cancelled() {
-                            break;
-                        }
-                        log::warn!("[lever] fetch failed for '{}': {e}", company);
-                        failed_fetches += 1;
-                        first_fetch_error.get_or_insert_with(|| e.to_string());
-                        continue;
+            let postings = match fetch_lever_company(base_url, company, ctx.signal.clone()).await {
+                Ok(d) => d,
+                Err(e) => {
+                    // A fetch that failed because the run was cancelled is not
+                    // a real board-level error.
+                    if ctx.signal.is_cancelled() {
+                        break;
                     }
-                };
+                    log::warn!("[lever] fetch failed for '{}': {e}", company);
+                    failed_fetches += 1;
+                    first_fetch_error.get_or_insert_with(|| e.to_string());
+                    continue;
+                }
+            };
             successful_fetches += 1;
 
             for p in postings {
@@ -148,12 +178,17 @@ impl Scraper for LeverScraper {
 
         // A PARTIAL run (some companies fetched, some failed) still returns Ok, so
         // the failures would otherwise be log-only — surface the count as ONE
-        // informational note. Gated on non-cancellation: a benign interruption
-        // reports nothing (mirrors `ats_finish_search`).
-        if !ctx.signal.is_cancelled() {
-            if let Some(note) = ats_failed_fetches_note(successful_fetches, failed_fetches) {
-                ctx.report_note(note);
-            }
+        // informational note.
+        //
+        // Deliberately NOT gated on cancellation (unlike `ats_partial_note`'s
+        // callers): the engine cancels `ctx.signal` the moment the central
+        // `amount` cap fills, which on a long seeded company list is exactly when
+        // failures are most likely to have accumulated — gating here would
+        // suppress the note precisely when it matters. `failed_fetches` only ever
+        // counts non-cancellation errors (the loop breaks on a cancelled signal
+        // before recording), so the count stays honest either way.
+        if let Some(note) = ats_failed_fetches_note(successful_fetches, failed_fetches) {
+            ctx.report_note(note);
         }
 
         // Distinguishes an all-slug 403/parse-drift run from a genuine zero result;

--- a/apps/desktop/src-tauri/src/scraping/boards/lever/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/lever/mod.rs
@@ -3,9 +3,9 @@
 /// Endpoint: `https://api.lever.co/v0/postings/{company}?mode=json`
 /// No global keyword search — requires a company slug. The engine skips this
 /// board with `"needs-company"` when `input.companies` is empty.
-use super::super::http::fetch_json;
+use super::super::http::{fetch_json, FetchOptions};
 use super::super::types::{BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode};
-use super::common::ats_all_fetches_failed;
+use super::common::{ats_all_fetches_failed, ats_failed_fetches_note};
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -74,6 +74,7 @@ impl Scraper for LeverScraper {
         let total = input.companies.len();
 
         let mut successful_fetches = 0usize;
+        let mut failed_fetches = 0usize;
         let mut first_fetch_error: Option<String> = None;
 
         for (i, company) in input.companies.iter().enumerate() {
@@ -91,10 +92,17 @@ impl Scraper for LeverScraper {
                 urlencoding::encode(company)
             );
 
+            let opts = FetchOptions {
+                // One Lever call returns a company's WHOLE board, so a large
+                // employer's payload can exceed the 8 MB default guard (observed:
+                // veeva → "Response too large", i.e. a silently dropped company).
+                // Raise the per-request cap only here.
+                max_bytes: Some(16 * 1024 * 1024),
+                ..Default::default()
+            };
+
             let postings =
-                match fetch_json::<Vec<LeverPosting>>(&url, Default::default(), ctx.signal.clone())
-                    .await
-                {
+                match fetch_json::<Vec<LeverPosting>>(&url, opts, ctx.signal.clone()).await {
                     Ok(d) => d,
                     Err(e) => {
                         // A fetch that failed because the run was cancelled is not
@@ -103,6 +111,7 @@ impl Scraper for LeverScraper {
                             break;
                         }
                         log::warn!("[lever] fetch failed for '{}': {e}", company);
+                        failed_fetches += 1;
                         first_fetch_error.get_or_insert_with(|| e.to_string());
                         continue;
                     }
@@ -134,6 +143,16 @@ impl Scraper for LeverScraper {
 
             if let Some(ref on_progress) = ctx.on_progress {
                 on_progress((i + 1) as f32 / total as f32);
+            }
+        }
+
+        // A PARTIAL run (some companies fetched, some failed) still returns Ok, so
+        // the failures would otherwise be log-only — surface the count as ONE
+        // informational note. Gated on non-cancellation: a benign interruption
+        // reports nothing (mirrors `ats_finish_search`).
+        if !ctx.signal.is_cancelled() {
+            if let Some(note) = ats_failed_fetches_note(successful_fetches, failed_fetches) {
+                ctx.report_note(note);
             }
         }
 

--- a/apps/desktop/src-tauri/src/scraping/boards/lever/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/lever/test.rs
@@ -105,6 +105,141 @@ async fn empty_companies_returns_empty_without_network() {
     );
 }
 
+/// The partial-failure note, end to end against a mock Lever host: company
+/// `good` returns a board (200), company `rotted` 404s. The board must KEEP the
+/// good company's postings (`Ok`, not a whole-board error) and report exactly
+/// `companies-failed:1` through the `on_note` sink — the failure that used to be
+/// log-only whenever a sibling company succeeded.
+#[tokio::test]
+async fn partial_company_failure_reports_the_companies_failed_note() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v0/postings/good"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([{
+                "id": "abc123",
+                "text": "Rust Engineer",
+                "hostedUrl": "https://jobs.lever.co/good/abc123",
+                "categories": { "location": "Berlin" },
+                "descriptionPlain": "Build things in Rust.",
+                "createdAt": 1_700_000_000_000_i64,
+            }])),
+        )
+        .mount(&server)
+        .await;
+    // A rotted/renamed slug — the exact shape that used to vanish silently.
+    Mock::given(method("GET"))
+        .and(path("/v0/postings/rotted"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let notes = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let sink = notes.clone();
+    let ctx = ScrapeContext {
+        signal: tokio_util::sync::CancellationToken::new(),
+        on_progress: None,
+        on_item: None,
+        on_truncation: None,
+        on_note: Some(std::sync::Arc::new(move |n: String| {
+            sink.lock().expect("note sink poisoned").push(n)
+        })),
+    };
+    let input = BoardSearchInput {
+        query: String::new(),
+        location: None,
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: vec!["good".to_string(), "rotted".to_string()],
+    };
+
+    let out = LeverScraper
+        .search_with_base(&server.uri(), input, ctx)
+        .await
+        .expect("a partial run must stay Ok — one succeeding company is a result");
+
+    assert_eq!(
+        out.len(),
+        1,
+        "the succeeding company's postings must be kept, got {out:?}"
+    );
+    assert_eq!(
+        notes.lock().expect("note sink poisoned").as_slice(),
+        ["companies-failed:1".to_string()],
+        "the failed company must surface as exactly one companies-failed note"
+    );
+}
+
+/// The complement: every company succeeds → NO note (a clean run must not grow a
+/// chip). Guards against the counter being incremented on a success path.
+#[tokio::test]
+async fn clean_run_reports_no_note() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    let notes = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let sink = notes.clone();
+    let ctx = ScrapeContext {
+        signal: tokio_util::sync::CancellationToken::new(),
+        on_progress: None,
+        on_item: None,
+        on_truncation: None,
+        on_note: Some(std::sync::Arc::new(move |n: String| {
+            sink.lock().expect("note sink poisoned").push(n)
+        })),
+    };
+    let input = BoardSearchInput {
+        query: String::new(),
+        location: None,
+        amount: 10,
+        pages: 1,
+        date_filter: None,
+        job_type: None,
+        work_type: None,
+        experience_level: None,
+        easy_apply: None,
+        actively_hiring: None,
+        verified: None,
+        sort_by: None,
+        country_code: None,
+        latitude: None,
+        longitude: None,
+        radius_km: None,
+        companies: vec!["good".to_string()],
+    };
+
+    LeverScraper
+        .search_with_base(&server.uri(), input, ctx)
+        .await
+        .expect("an all-success run must be Ok");
+
+    assert!(
+        notes.lock().expect("note sink poisoned").is_empty(),
+        "a run with zero failures must emit no note"
+    );
+}
+
 #[tokio::test]
 #[ignore = "live network"]
 async fn live_search_returns_results() {

--- a/apps/desktop/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/mod.rs
@@ -956,9 +956,27 @@ impl ScraperEngine {
     }
 
     /// Signal cancellation to a running job by id. No-op if the id is unknown.
+    ///
+    /// Cancels the slot **in place** — it is deliberately NOT removed. Removing
+    /// it lost any cancel that landed before the run reached
+    /// [`Self::scrape_boards_with_resolver_and_overrides`]: that function mints a
+    /// FRESH (un-cancelled) token when it finds no slot, so the run proceeded as
+    /// if nothing had been cancelled. Callers do pre-scrape async work between
+    /// `register_token` and the engine call — `commands::scrape` awaits a geocode
+    /// backfill, and the engine's own `sem.acquire_owned()` can wait seconds
+    /// behind other scrapes — so that window is real, not theoretical. Leaving
+    /// the cancelled token in place makes the mint-fresh path unreachable for a
+    /// cancelled job: the run reuses the slot, sees `is_cancelled()`, and stops.
+    ///
+    /// No leak: the slot is owned by whoever registered it, and every owner
+    /// removes it on EVERY exit path — `commands::scrape::scrape_boards` (both
+    /// the early cancelled return and after the engine call) and
+    /// `commands::autopilot::autopilot_run` (scrape-Err, cancelled, and success
+    /// paths) — while an engine-minted slot is removed by the `we_minted` branch.
+    /// An unknown id still inserts nothing.
     pub async fn cancel(&self, job_id: &str) {
-        let mut jobs = self.jobs.lock().await;
-        if let Some(token) = jobs.remove(job_id) {
+        let jobs = self.jobs.lock().await;
+        if let Some(token) = jobs.get(job_id) {
             token.cancel();
         }
     }

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -541,6 +541,45 @@ async fn cancel_reaches_a_pre_registered_token() {
     assert!(token.is_cancelled());
 }
 
+/// `cancel` REMOVES the slot before cancelling it, so a `scrape_boards` that
+/// starts AFTER the cancel finds no pre-registered token and mints a fresh,
+/// un-cancelled one — the cancel is invisible to it.
+///
+/// This is a contract test, not a wish: `commands::scrape::scrape_boards` awaits
+/// a geocode backfill between registering its token and calling the engine, and
+/// relies on this exact behavior being true to justify holding its OWN clone of
+/// the token and checking it before starting the scrape. If `cancel` ever keeps
+/// the slot (making the mint-fresh path unreachable), this test fails and that
+/// guard can be simplified — until then, removing it silently resurrects the
+/// lost-cancel window.
+#[tokio::test]
+async fn cancel_removes_the_slot_so_a_later_run_mints_a_fresh_token() {
+    let engine = ScraperEngine::new();
+    let registered = tokio_util::sync::CancellationToken::new();
+
+    engine
+        .register_token("job-lost-cancel", registered.clone())
+        .await;
+    engine.cancel("job-lost-cancel").await;
+    assert!(
+        registered.is_cancelled(),
+        "the registered clone must flip — that part reaches the caller"
+    );
+
+    // The slot is gone: re-registering under the same id succeeds and the NEW
+    // token is un-cancelled, which is exactly what `scrape_boards` would mint.
+    let fresh = tokio_util::sync::CancellationToken::new();
+    engine
+        .register_token("job-lost-cancel", fresh.clone())
+        .await;
+    assert!(
+        !fresh.is_cancelled(),
+        "a token registered after the cancel is un-cancelled — a run started \
+         here would ignore the user's cancel unless the caller checks its own \
+         clone first (see commands::scrape::scrape_boards)"
+    );
+}
+
 // ── run_boards tests ──────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/apps/desktop/src-tauri/src/scraping/engine/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/test.rs
@@ -541,42 +541,95 @@ async fn cancel_reaches_a_pre_registered_token() {
     assert!(token.is_cancelled());
 }
 
-/// `cancel` REMOVES the slot before cancelling it, so a `scrape_boards` that
-/// starts AFTER the cancel finds no pre-registered token and mints a fresh,
-/// un-cancelled one — the cancel is invisible to it.
+/// The lost-cancel regression guard: a cancel that lands BEFORE the run reaches
+/// the engine must still be honored — no items streamed, `Err("scrape
+/// cancelled")` returned.
 ///
-/// This is a contract test, not a wish: `commands::scrape::scrape_boards` awaits
-/// a geocode backfill between registering its token and calling the engine, and
-/// relies on this exact behavior being true to justify holding its OWN clone of
-/// the token and checking it before starting the scrape. If `cancel` ever keeps
-/// the slot (making the mint-fresh path unreachable), this test fails and that
-/// guard can be simplified — until then, removing it silently resurrects the
-/// lost-cancel window.
+/// `cancel` used to `remove()` the slot before cancelling it, so a run starting
+/// afterwards found no slot, MINTED a fresh un-cancelled token, and scraped on
+/// as if nothing had happened — its streamed items then clobbering whatever the
+/// user started next. The window is real: callers do async work between
+/// `register_token` and the engine call (`commands::scrape` awaits a geocode
+/// backfill) and the engine itself waits on `sem.acquire_owned()`.
+///
+/// Drives the REAL path (`scrape_boards_with_resolver` + `FakeScraper`), not the
+/// map bookkeeping — a token registered after a cancel is un-cancelled by
+/// construction, so asserting that would prove nothing.
 #[tokio::test]
-async fn cancel_removes_the_slot_so_a_later_run_mints_a_fresh_token() {
+async fn a_cancel_before_the_run_reaches_the_engine_is_honored() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static FAKE: std::sync::LazyLock<FakeScraper> =
+        std::sync::LazyLock::new(|| FakeScraper::http(25));
+
     let engine = ScraperEngine::new();
-    let registered = tokio_util::sync::CancellationToken::new();
-
+    let token = CancellationToken::new();
     engine
-        .register_token("job-lost-cancel", registered.clone())
+        .register_token("job-cancel-before-engine", token.clone())
         .await;
-    engine.cancel("job-lost-cancel").await;
-    assert!(
-        registered.is_cancelled(),
-        "the registered clone must flip — that part reaches the caller"
+
+    // The user hits Stop while the command is still in its pre-scrape phase.
+    engine.cancel("job-cancel-before-engine").await;
+    assert!(token.is_cancelled(), "the caller's own clone must flip");
+
+    let streamed = std::sync::Arc::new(AtomicUsize::new(0));
+    let streamed_cb = streamed.clone();
+
+    let result = engine
+        .scrape_boards_with_resolver(
+            &["board-x".to_string()],
+            fake_input(25),
+            "job-cancel-before-engine".to_string(),
+            None,
+            Some(std::sync::Arc::new(move |_item| {
+                streamed_cb.fetch_add(1, Ordering::SeqCst);
+            })),
+            std::path::Path::new("."),
+            |_id| Ok(&*FAKE as &'static dyn super::super::types::Scraper),
+        )
+        .await;
+
+    assert_eq!(
+        streamed.load(Ordering::SeqCst),
+        0,
+        "a run the user already cancelled must stream ZERO items — anything \
+         streamed here lands in the postings cache and wipes the search the \
+         user started instead"
     );
-
-    // The slot is gone: re-registering under the same id succeeds and the NEW
-    // token is un-cancelled, which is exactly what `scrape_boards` would mint.
-    let fresh = tokio_util::sync::CancellationToken::new();
-    engine
-        .register_token("job-lost-cancel", fresh.clone())
-        .await;
+    let err = result.expect_err("a fully-cancelled run must report Err, not a silent empty Ok");
     assert!(
-        !fresh.is_cancelled(),
-        "a token registered after the cancel is un-cancelled — a run started \
-         here would ignore the user's cancel unless the caller checks its own \
-         clone first (see commands::scrape::scrape_boards)"
+        err.to_string().contains("cancelled"),
+        "the error must name cancellation, got: {err}"
+    );
+}
+
+/// Companion: `cancel` must LEAVE the slot in place (that is what makes the
+/// mint-fresh path unreachable above), so a second cancel for the same job — a
+/// double-click on Stop, or a tray cancel racing the UI — still resolves to the
+/// same token rather than silently doing nothing.
+#[tokio::test]
+async fn cancel_leaves_the_slot_in_place_and_is_idempotent() {
+    let engine = ScraperEngine::new();
+    let token = CancellationToken::new();
+    engine
+        .register_token("job-double-cancel", token.clone())
+        .await;
+
+    engine.cancel("job-double-cancel").await;
+    engine.cancel("job-double-cancel").await;
+    assert!(token.is_cancelled());
+
+    // The slot survives, so the owner's `unregister_token` is still the single
+    // remover — the invariant the no-leak argument in `cancel`'s doc rests on.
+    engine.unregister_token("job-double-cancel").await;
+    let late = CancellationToken::new();
+    engine
+        .register_token("job-double-cancel", late.clone())
+        .await;
+    engine.unregister_token("job-double-cancel").await;
+    assert!(
+        !late.is_cancelled(),
+        "a fresh registration after the owner released the slot must be clean"
     );
 }
 

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.i18n.test.ts
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.i18n.test.ts
@@ -44,4 +44,18 @@ describe('PR H partial-ATS note i18n — en/de parity', () => {
     expect(out).not.toBe(key);
     expect(out).toContain(String(count));
   });
+
+  it.each([
+    ['en', 1],
+    ['en', 3],
+    ['de', 1],
+    ['de', 3],
+  ] as const)('%s resolves the pluralized companies-failed chip (count=%i)', (lng, count) => {
+    const key = 'jobs.boardSummary.note.companiesFailed';
+    expect(i18n.exists(key, { lng, count, fallbackLng: false }), `${lng}:${key}`).toBe(true);
+    const t = i18n.getFixedT(lng);
+    const out = t(key, { count });
+    expect(out).not.toBe(key);
+    expect(out).toContain(String(count));
+  });
 });

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.test.tsx
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.test.tsx
@@ -402,6 +402,19 @@ describe('BoardSummaryChips — partial ATS note chips (PR H)', () => {
     expect(chip?.textContent).not.toContain('rows-dropped:2');
   });
 
+  it('maps "companies-failed:<n>" to the pluralized informational (processing) label', () => {
+    // Lever/Ashby partial run: some companies fetched, some failed (404/403/429
+    // or an over-cap payload). The board still returns Ok, so this note is the
+    // ONLY user-visible signal that the run was incomplete.
+    render(
+      <BoardSummaryChips summaries={[{ board: 'lever', count: 12, note: 'companies-failed:2' }]} />
+    );
+    const chip = chips()[0];
+    expect(chip?.getAttribute('data-color')).toBe('processing');
+    expect(chip?.textContent).toContain('jobs.boardSummary.note.companiesFailed:2');
+    expect(chip?.textContent).not.toContain('companies-failed:2');
+  });
+
   it('rejects n=0 (these tokens are only emitted for n>0) — falls through to the success chip', () => {
     render(
       <BoardSummaryChips summaries={[{ board: 'greenhouse', count: 6, note: 'slugs-invalid:0' }]} />

--- a/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
+++ b/apps/desktop/src/renderer/components/scrape/BoardSummaryChips.tsx
@@ -156,9 +156,9 @@ function skipDetail(skipped: string, t: TFunction): string {
  *   - `location-filtered:<n>` (PR F) — the engine emits this unconditionally for
  *     a board without server-side location support (even n=0, "checked, nothing
  *     hidden"); n=0 gets a plain marker label, n>0 the pluralized hidden-count.
- *   - `slugs-invalid:<n>` / `rows-dropped:<n>` (PR H) — partial per-company
- *     visibility from the ATS boards; both emitted ONLY when n>0, so unlike
- *     `location-filtered` a zero/malformed n renders no chip.
+ *   - `slugs-invalid:<n>` / `rows-dropped:<n>` (PR H) / `companies-failed:<n>` —
+ *     partial per-company visibility from the ATS boards; all emitted ONLY when
+ *     n>0, so unlike `location-filtered` a zero/malformed n renders no chip.
  */
 function noteDetail(note: string, t: TFunction, locale: string): string | null {
   const sep = note.indexOf(':');
@@ -181,20 +181,22 @@ function noteDetail(note: string, t: TFunction, locale: string): string | null {
       : t('jobs.boardSummary.note.locationFiltered', { count: n });
   }
 
-  // `slugs-invalid:<n>` / `rows-dropped:<n>` (PR H) — partial per-company
-  // visibility from the ATS boards: `n` company slugs were rejected by the
-  // pre-fetch SSRF/DNS-label validator, or `n` rows failed to deserialize on an
-  // otherwise-reached company. Both are emitted ONLY when n>0 (an all-fail run
-  // surfaces as an error, never a note), so — unlike location-filtered's n=0
-  // marker — a zero / empty / non-integer / negative n is malformed and renders
-  // no chip (tolerant, like an unknown token).
-  if (kind === 'slugs-invalid' || kind === 'rows-dropped') {
+  // `slugs-invalid:<n>` / `rows-dropped:<n>` (PR H) / `companies-failed:<n>` —
+  // partial per-company visibility from the ATS boards: `n` company slugs were
+  // rejected by the pre-fetch SSRF/DNS-label validator, `n` rows failed to
+  // deserialize on an otherwise-reached company, or `n` per-company fetches
+  // failed (404/403/429/over-cap) while a sibling succeeded. All are emitted
+  // ONLY when n>0 (an all-fail run surfaces as an error, never a note), so —
+  // unlike location-filtered's n=0 marker — a zero / empty / non-integer /
+  // negative n is malformed and renders no chip (tolerant, like an unknown
+  // token).
+  if (kind === 'slugs-invalid' || kind === 'rows-dropped' || kind === 'companies-failed') {
     if (!value) return null;
     const n = Number(value);
     if (!Number.isInteger(n) || n <= 0) return null;
-    return kind === 'slugs-invalid'
-      ? t('jobs.boardSummary.note.slugsInvalid', { count: n })
-      : t('jobs.boardSummary.note.rowsDropped', { count: n });
+    if (kind === 'slugs-invalid') return t('jobs.boardSummary.note.slugsInvalid', { count: n });
+    if (kind === 'rows-dropped') return t('jobs.boardSummary.note.rowsDropped', { count: n });
+    return t('jobs.boardSummary.note.companiesFailed', { count: n });
   }
 
   // `kind:<cc>` — alpha-2 only; a malformed multi-colon token (e.g.

--- a/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/wizard-steps/StepTarget/index.tsx
@@ -149,7 +149,7 @@ export function StepTarget({ prefilled }: StepTargetProps) {
                           : 'border-[var(--border-clear)] text-foreground/40 hover:bg-muted hover:text-foreground/65'
                       )}
                     >
-                      {t(`jobs.boards.${id}`)}
+                      {t(`jobs.boards.${id}`, { defaultValue: id })}
                     </Button>
                   );
                 })}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -414,7 +414,11 @@ export function JobsPage() {
               scraping={scraping}
               scrapeOutcome={scrapeOutcome}
               onToggle={() => setShowScrapeForm(!showScrapeForm)}
-              onFormChange={(updates) => setScrapeForm({ ...scrapeForm, ...updates })}
+              // Functional update: two changes dispatched in one tick (e.g. a
+              // location pick firing onChange then onSelectSuggestion) would
+              // otherwise both spread the SAME captured `scrapeForm` and the
+              // first would be lost.
+              onFormChange={(updates) => setScrapeForm((f) => ({ ...f, ...updates }))}
               onStart={handleStartScrape}
               onCancel={cancelScrape}
               onGeocode={geocodeSuggest}

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/BoardConnectChip.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/BoardConnectChip.tsx
@@ -66,7 +66,7 @@ export function BoardConnectChip({ board, required = false }: BoardConnectChipPr
     }
   };
 
-  const boardLabel = t(`jobs.boards.${board}`);
+  const boardLabel = t(`jobs.boards.${board}`, { defaultValue: board });
 
   if (connected) {
     return (

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.test.tsx
@@ -40,14 +40,20 @@ vi.mock('@ajh/ui', async (importOriginal) => {
         onChange={(e) => onChange(e.target.value)}
       />
       <actual.Button
-        onClick={() =>
+        onClick={() => {
+          // Fire in the REAL order LocationInput.select() uses: onChange(display)
+          // FIRST, then onSelectSuggestion(s). The ordering matters — if the
+          // clearing onChange ran last it would wipe the structured payload the
+          // pick just captured, and a stub that only fires onSelectSuggestion
+          // could never catch that.
+          onChange('Berlin, Germany');
           onSelectSuggestion?.({
             display: 'Berlin, Germany',
             countryCode: 'DE',
             lat: 52.52,
             lon: 13.4,
-          })
-        }
+          });
+        }}
       >
         pick
       </actual.Button>
@@ -109,7 +115,10 @@ describe('ScrapeFilters — location', () => {
 
     fireEvent.click(screen.getByText('pick'));
 
-    expect(onFormChange).toHaveBeenCalledWith({
+    // Assert on the LAST call, not "any call": the pick fires the clearing
+    // onChange first, so a bare `toHaveBeenCalledWith` would still pass if the
+    // clear ran second and threw the picked payload away.
+    expect(onFormChange.mock.calls.at(-1)?.[0]).toEqual({
       location: 'Berlin, Germany',
       countryCode: 'DE',
       latitude: 52.52,

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * ScrapeFilters — location field ownership of the picked-suggestion payload.
+ *
+ * The bug this pins: after picking "Berlin, Germany" (countryCode/lat/lon
+ * captured) the user types over it — e.g. "Amsterdam". The typed text is NOT a
+ * pick, so the stale structured payload must be dropped: otherwise the scrape
+ * runs against the old market and the backend's geocode backfill (which only
+ * fires when `countryCode` is absent) never runs. Mirrors autopilot StepTarget.
+ *
+ * `LocationInput` is stubbed down to a plain controlled field: its own picker
+ * behavior (portal dropdown, debounced geocode) is covered by packages/ui's
+ * LocationInput.test.tsx — what matters here is which payload ScrapeFilters
+ * forwards to `onFormChange`.
+ */
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import type * as AjhUi from '@ajh/ui';
+
+import type { ScrapeFormState } from './constants';
+
+// i18n: identity t() so labels are stable keys.
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+// Stub ONLY LocationInput; every other @ajh/ui primitive stays real.
+vi.mock('@ajh/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof AjhUi>();
+  const LocationInputStub = ({
+    value,
+    onChange,
+    onSelectSuggestion,
+  }: ComponentProps<typeof actual.LocationInput>) => (
+    <>
+      <actual.Input
+        data-testid="location-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <actual.Button
+        onClick={() =>
+          onSelectSuggestion?.({
+            display: 'Berlin, Germany',
+            countryCode: 'DE',
+            lat: 52.52,
+            lon: 13.4,
+          })
+        }
+      >
+        pick
+      </actual.Button>
+    </>
+  );
+  return { ...actual, LocationInput: LocationInputStub };
+});
+
+import { ScrapeFilters } from './ScrapeFilters';
+
+function buildForm(overrides: Partial<ScrapeFormState> = {}): ScrapeFormState {
+  return {
+    boards: ['aggregator'],
+    query: '',
+    location: 'Berlin, Germany',
+    countryCode: 'DE',
+    latitude: 52.52,
+    longitude: 13.4,
+    radiusKm: 0,
+    amount: 25,
+    dateFilter: '',
+    companies: [],
+    ...overrides,
+  };
+}
+
+function renderFilters(onFormChange = vi.fn(), form = buildForm()) {
+  render(
+    <ScrapeFilters
+      form={form}
+      scraping={false}
+      boardConnected={false}
+      onFormChange={onFormChange}
+      onGeocode={() => Promise.resolve([])}
+    />
+  );
+  return onFormChange;
+}
+
+describe('ScrapeFilters — location', () => {
+  it('clears the stale picked countryCode/lat/lon when the location is typed over', () => {
+    const onFormChange = renderFilters();
+
+    fireEvent.change(screen.getByTestId('location-input'), { target: { value: 'Amsterdam' } });
+
+    expect(onFormChange).toHaveBeenCalledWith({
+      location: 'Amsterdam',
+      countryCode: undefined,
+      latitude: undefined,
+      longitude: undefined,
+    });
+  });
+
+  it('keeps the structured payload when a suggestion is PICKED', () => {
+    const onFormChange = renderFilters(
+      vi.fn(),
+      buildForm({ location: '', countryCode: undefined })
+    );
+
+    fireEvent.click(screen.getByText('pick'));
+
+    expect(onFormChange).toHaveBeenCalledWith({
+      location: 'Berlin, Germany',
+      countryCode: 'DE',
+      latitude: 52.52,
+      longitude: 13.4,
+    });
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.tsx
@@ -32,9 +32,14 @@ export function ScrapeFilters({ form, scraping, boardConnected, onFormChange, on
         <label className={LABEL}>{t('jobs.location')}</label>
         <LocationInput
           value={form.location}
-          // Freehand typing invalidates the previously PICKED suggestion: keeping
-          // its countryCode/lat/lon would search the old market (and the backend
-          // would skip its geocode backfill). Mirrors autopilot's StepTarget.
+          // Freehand typing invalidates the previously PICKED suggestion, so drop
+          // the whole structured payload it captured. `countryCode` is the part
+          // that changes behavior today: a stale one searches the old market AND
+          // suppresses the backend's geocode backfill (which only runs when it is
+          // absent). lat/lon go with it for consistency — no board consumes them
+          // yet, but they ride into the same `LocationSpec`, and coordinates from
+          // a city the user just typed away from would make that spec incoherent.
+          // Mirrors autopilot's StepTarget.
           onChange={(v) =>
             onFormChange({
               location: v,

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeFilters.tsx
@@ -32,7 +32,17 @@ export function ScrapeFilters({ form, scraping, boardConnected, onFormChange, on
         <label className={LABEL}>{t('jobs.location')}</label>
         <LocationInput
           value={form.location}
-          onChange={(v) => onFormChange({ location: v })}
+          // Freehand typing invalidates the previously PICKED suggestion: keeping
+          // its countryCode/lat/lon would search the old market (and the backend
+          // would skip its geocode backfill). Mirrors autopilot's StepTarget.
+          onChange={(v) =>
+            onFormChange({
+              location: v,
+              countryCode: undefined,
+              latitude: undefined,
+              longitude: undefined,
+            })
+          }
           onSelectSuggestion={(s) =>
             onFormChange({
               location: s.display,

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/index.tsx
@@ -307,7 +307,7 @@ export function ScrapeForm({
                           'disabled:cursor-not-allowed disabled:opacity-40'
                         )}
                       >
-                        {t(`jobs.boards.${id}`)}
+                        {t(`jobs.boards.${id}`, { defaultValue: id })}
                       </Button>
                     );
                   })}
@@ -393,7 +393,9 @@ export function ScrapeForm({
                 className="mb-2 text-[11px] text-amber-400/70"
               >
                 {t('jobs.needsLogin.blockedHint', {
-                  boards: unconnectedRequired.map((id) => t(`jobs.boards.${id}`)).join(', '),
+                  boards: unconnectedRequired
+                    .map((id) => t(`jobs.boards.${id}`, { defaultValue: id }))
+                    .join(', '),
                 })}
               </p>
             )}

--- a/packages/shared/src/ipc/contracts/boards.ts
+++ b/packages/shared/src/ipc/contracts/boards.ts
@@ -88,6 +88,14 @@ export interface BoardsContract {
  *     while the rest parsed. If EVERY row of a company dropped it's counted as
  *     a fetch failure, not a note. At most one of `slugs-invalid`/`rows-dropped`
  *     is emitted per board per run (`slugs-invalid` wins when both apply).
+ *   - `"companies-failed:<n>"` — a company-slug ATS board (Lever, Ashby) could
+ *     not fetch `<n>` of the requested companies (404 on a rotted slug, 403,
+ *     429, or a payload over the byte cap) while at least one other company
+ *     succeeded, so the run still returned results. If EVERY fetch failed it's
+ *     an `error`, not a note. Emitted independently of the
+ *     `slugs-invalid`/`rows-dropped` pair above — those come from boards that
+ *     validate slugs pre-fetch, this one from the boards that don't — but a
+ *     board still reports at most ONE note per run overall.
  *   `<cc>` is an ISO country code; the field never carries the raw location text.
  */
 export interface BoardScrapeSummary {

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1903,6 +1903,7 @@
       "comeet": "Comeet",
       "remoteok": "RemoteOK",
       "remotive": "Remotive",
+      "jobicy": "Jobicy",
       "arbeitnow": "Arbeit Now",
       "themuse": "The Muse",
       "wwr": "WWR",
@@ -1962,7 +1963,9 @@
         "slugsInvalid_one": "{{count}} Firmenname ungültig",
         "slugsInvalid_other": "{{count}} Firmennamen ungültig",
         "rowsDropped_one": "{{count}} Zeile unlesbar — Board-Format eventuell geändert",
-        "rowsDropped_other": "{{count}} Zeilen unlesbar — Board-Format eventuell geändert"
+        "rowsDropped_other": "{{count}} Zeilen unlesbar — Board-Format eventuell geändert",
+        "companiesFailed_one": "{{count}} Firma konnte nicht abgerufen werden",
+        "companiesFailed_other": "{{count}} Firmen konnten nicht abgerufen werden"
       }
     },
     "viewList": "Liste",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1899,6 +1899,7 @@
       "comeet": "Comeet",
       "remoteok": "RemoteOK",
       "remotive": "Remotive",
+      "jobicy": "Jobicy",
       "arbeitnow": "Arbeit Now",
       "themuse": "The Muse",
       "wwr": "WWR",
@@ -1958,7 +1959,9 @@
         "slugsInvalid_one": "{{count}} company name invalid",
         "slugsInvalid_other": "{{count}} company names invalid",
         "rowsDropped_one": "{{count}} row unreadable — board format may have changed",
-        "rowsDropped_other": "{{count}} rows unreadable — board format may have changed"
+        "rowsDropped_other": "{{count}} rows unreadable — board format may have changed",
+        "companiesFailed_one": "{{count}} company could not be fetched",
+        "companiesFailed_other": "{{count}} companies could not be fetched"
       }
     },
     "viewList": "List",


### PR DESCRIPTION
- raise lever/ashby per-request response cap to 16 MB (GTJ precedent) and surface per-company fetch failures as a `companies-failed:<n>` summary chip (en+de) instead of dropping them silently
- backfill `country_code` server-side on manual scrapes via the shared geocode helper (autopilot parity) — cancel-safe: the backfill sits in a `biased` select on the scrape cancel token, with an engine-contract regression test for the lost-cancel window
- clear stale `countryCode`/lat/lon when the user types over a picked location
- add the missing `jobs.boards.jobicy` label (en+de) + `defaultValue` fallbacks at the 4 bare board-label call sites

Review: scraping-applier-author → scraping-applier-expert (1 HIGH + 4 MEDIUM found and fixed, incl. a wiremock seam for the note wiring). Validation: cargo 2751 pass + CI-exact clippy clean; 4099 renderer tests; typecheck 13/13; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
