### PR TITLE
fix: pin document viewer header while output scrolls

### DIFF
--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
@@ -928,9 +928,11 @@ describe('GenerationOutput', () => {
   // Regression guard for the "header scrolls away" bug: the viewer used to grow
   // past its host (intrinsic `min-h-[32rem]` panel + no overflow of its own), so
   // the PARENT scrolled the whole component — header included. The scroll boundary
-  // now lives on the tabpanel and every control above it is a pinned `shrink-0`
-  // sibling, i.e. OUTSIDE the scrollport. jsdom has no layout, so these assert the
-  // structural invariants that produce the behaviour, not pixels.
+  // now lives on the tabpanel: the tab/action bar is a pinned `shrink-0` sibling
+  // OUTSIDE it, while the option strips live INSIDE and scroll with the document.
+  // jsdom has no layout, so these assert the structural invariants that produce the
+  // behaviour, not pixels — the pixel measurements come from the Chromium run
+  // recorded in the handoff.
 
   describe('scroll boundary', () => {
     const SCROLLS = /overflow-(?:y-)?(?:auto|scroll)/;
@@ -956,7 +958,20 @@ describe('GenerationOutput', () => {
       expect(root).not.toBeNull();
       expect(root?.className).toContain('min-h-0');
       expect(root?.className).toContain('flex-1');
+      expect(root?.className).toContain('overflow-hidden');
       expect(root?.className).not.toMatch(/min-h-(?!0\b)/);
+    });
+
+    it('gives the document region a floor so the scrollport can actually engage', () => {
+      // Without a floor every child is flex-1/h-full, content fits the scrollport
+      // exactly and `overflow-y-auto` can never fire (measured in Chromium:
+      // scrollHeight > clientHeight was false in 10/10 window configurations).
+      render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'resume' })} />);
+      const region = screen.getByTestId(TEST_IDS.documents.editableOutput).parentElement;
+      expect(region).not.toBeNull();
+      expect(region?.className).toMatch(/min-h-\[\d+rem\]/);
+      expect(region?.className).toContain('flex-1');
+      expect(screen.getByRole('tabpanel').contains(region)).toBe(true);
     });
 
     it('nothing between the root and the tabpanel is a second scroll container', () => {
@@ -984,13 +999,16 @@ describe('GenerationOutput', () => {
       );
     });
 
-    it('keeps the template / accent / letter-layout strips outside the scrollport', () => {
+    it('scrolls the template / accent / letter-layout strips WITH the document', () => {
+      // Pinning these costs 214px (résumé) / 426px (cover) of permanent chrome —
+      // measured at 17px / 0px of usable document at the 1280×800 default window,
+      // with the layout picker clipped out of reach. They belong in the scrollport.
       render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'cover' })} />);
       const panel = screen.getByRole('tabpanel');
-      expect(panel.contains(screen.getByTestId(TEST_IDS.documents.templatePicker))).toBe(false);
+      expect(panel.contains(screen.getByTestId(TEST_IDS.documents.templatePicker))).toBe(true);
       expect(
         panel.contains(screen.getByTestId(`${TEST_IDS.generation.letterLayoutOption}-classic`))
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 });

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
@@ -923,4 +923,74 @@ describe('GenerationOutput', () => {
       expect(screen.getByRole('tabpanel')).toHaveAttribute('tabindex', '0');
     });
   });
+
+  // ── 10. Scroll boundary — the tab/action header stays pinned ─────────────────
+  // Regression guard for the "header scrolls away" bug: the viewer used to grow
+  // past its host (intrinsic `min-h-[32rem]` panel + no overflow of its own), so
+  // the PARENT scrolled the whole component — header included. The scroll boundary
+  // now lives on the tabpanel and every control above it is a pinned `shrink-0`
+  // sibling, i.e. OUTSIDE the scrollport. jsdom has no layout, so these assert the
+  // structural invariants that produce the behaviour, not pixels.
+
+  describe('scroll boundary', () => {
+    const SCROLLS = /overflow-(?:y-)?(?:auto|scroll)/;
+
+    it('the tabpanel owns the vertical scroll', () => {
+      render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'resume' })} />);
+      expect(screen.getByRole('tabpanel').className).toMatch(SCROLLS);
+    });
+
+    it('the tabpanel is bounded by its host, with no intrinsic min-height', () => {
+      render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'resume' })} />);
+      const panel = screen.getByRole('tabpanel');
+      expect(panel.className).toContain('min-h-0');
+      expect(panel.className).toContain('flex-1');
+      // An arbitrary min-height (e.g. `min-h-[32rem]`) makes the panel taller than
+      // its host again, which pushes the scroll back up to the caller.
+      expect(panel.className).not.toMatch(/min-h-(?!0\b)/);
+    });
+
+    it('the root is height-bounded so the caller never has to scroll it', () => {
+      render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'resume' })} />);
+      const root = screen.getByRole('tabpanel').parentElement;
+      expect(root).not.toBeNull();
+      expect(root?.className).toContain('min-h-0');
+      expect(root?.className).toContain('flex-1');
+      expect(root?.className).not.toMatch(/min-h-(?!0\b)/);
+    });
+
+    it('nothing between the root and the tabpanel is a second scroll container', () => {
+      const { container } = render(
+        <GenerationOutput {...makeProps({ target: 'both', activeOut: 'resume' })} />
+      );
+      for (
+        let el = screen.getByRole('tabpanel').parentElement;
+        el !== null && el !== container;
+        el = el.parentElement
+      ) {
+        expect(el.className).not.toMatch(SCROLLS);
+      }
+    });
+
+    it('keeps the tabs and the Copy/Export actions outside the scrollport', () => {
+      render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'resume' })} />);
+      const panel = screen.getByRole('tabpanel');
+      expect(panel.contains(screen.getByRole('tablist'))).toBe(false);
+      expect(panel.contains(screen.getByRole('button', { name: /autopilot\.apply\.copy/i }))).toBe(
+        false
+      );
+      expect(panel.contains(screen.getByRole('button', { name: /aiGenerate\.export/i }))).toBe(
+        false
+      );
+    });
+
+    it('keeps the template / accent / letter-layout strips outside the scrollport', () => {
+      render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'cover' })} />);
+      const panel = screen.getByRole('tabpanel');
+      expect(panel.contains(screen.getByTestId(TEST_IDS.documents.templatePicker))).toBe(false);
+      expect(
+        panel.contains(screen.getByTestId(`${TEST_IDS.generation.letterLayoutOption}-classic`))
+      ).toBe(false);
+    });
+  });
 });

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.test.tsx
@@ -963,14 +963,12 @@ describe('GenerationOutput', () => {
     });
 
     it('gives the document region a floor so the scrollport can actually engage', () => {
-      // Without a floor every child is flex-1/h-full, content fits the scrollport
-      // exactly and `overflow-y-auto` can never fire (measured in Chromium:
-      // scrollHeight > clientHeight was false in 10/10 window configurations).
+      // Without a floor every child is flex-1/h-full, the content fits the
+      // scrollport exactly and `overflow-y-auto` can never fire.
       render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'resume' })} />);
-      const region = screen.getByTestId(TEST_IDS.documents.editableOutput).parentElement;
-      expect(region).not.toBeNull();
-      expect(region?.className).toMatch(/min-h-\[\d+rem\]/);
-      expect(region?.className).toContain('flex-1');
+      const region = screen.getByTestId(TEST_IDS.documents.documentRegion);
+      expect(region.className).toMatch(/min-h-\[\d+rem\]/);
+      expect(region.className).toContain('flex-1');
       expect(screen.getByRole('tabpanel').contains(region)).toBe(true);
     });
 
@@ -1000,9 +998,9 @@ describe('GenerationOutput', () => {
     });
 
     it('scrolls the template / accent / letter-layout strips WITH the document', () => {
-      // Pinning these costs 214px (résumé) / 426px (cover) of permanent chrome —
-      // measured at 17px / 0px of usable document at the 1280×800 default window,
-      // with the layout picker clipped out of reach. They belong in the scrollport.
+      // Pinning these costs more permanent chrome than a small window can spare:
+      // the document collapses to nothing and the last strip is clipped out of
+      // reach behind the root's overflow-hidden. They belong in the scrollport.
       render(<GenerationOutput {...makeProps({ target: 'both', activeOut: 'cover' })} />);
       const panel = screen.getByRole('tabpanel');
       expect(panel.contains(screen.getByTestId(TEST_IDS.documents.templatePicker))).toBe(true);

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy, Download, FileText, LayoutTemplate } from 'lucide-react';
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
+import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
 import { Button, cn, Dropdown, Switch, type TabItem, Tabs } from '@ajh/ui';
 
@@ -216,6 +217,8 @@ export function GenerationOutput({
   // pushes the scroll boundary back up to the caller and the header scrolls away with
   // the document (the bug this fixes). `overflow-hidden` keeps the rounded border a
   // real clip; every popover inside is portalled/fixed, so nothing is lost to it.
+  // The height chain above this component is load-bearing too — see TailorFlow's
+  // `min-h-0 flex-1` stage body (asserted in TailorFlow.test.tsx).
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-foreground/[0.06] bg-foreground/[0.02]">
       <div className="shrink-0 flex items-center justify-between border-b border-foreground/[0.06] px-3 py-2">
@@ -258,10 +261,10 @@ export function GenerationOutput({
         </div>
       </div>
       {/* The scrollport. ONLY the tab/action bar above pins — the option strips
-          scroll WITH the document. Pinning them was measured at 214px (résumé) /
-          426px (cover) of permanent chrome, which leaves 17px / 0px of document at
-          the 1280×800 default window and clips the layout picker out of reach; the
-          strips are occasional controls, the document is the content.
+          scroll WITH the document: pinning them too costs more permanent chrome
+          than a small window can spare, collapsing the document to nothing and
+          clipping the last strip out of reach. They are occasional controls; the
+          document is the content.
           The document region below carries a `min-h-[20rem]` FLOOR — that is what
           makes this a real scrollport. Without it every child is `flex-1`/`h-full`,
           content always fits exactly and `overflow-y-auto` can never engage.
@@ -357,7 +360,10 @@ export function GenerationOutput({
         {/* Document region — grows to fill the scrollport, but never shrinks below
             the floor, so a short window scrolls instead of collapsing the document
             to a few pixels. */}
-        <div className="flex min-h-[20rem] flex-1 flex-col px-3 py-2">
+        <div
+          data-testid={TEST_IDS.documents.documentRegion}
+          className="flex min-h-[20rem] flex-1 flex-col px-3 py-2"
+        >
           {view === 'jobAd' ? (
             <JobAdView
               jobDesc={jobDesc}

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
@@ -209,8 +209,13 @@ export function GenerationOutput({
     }
   };
 
+  // Three-part shape (mirrors the AI-Generate viewer + ModalShell, docs/PATTERNS.md §13):
+  // the root is HEIGHT-BOUNDED (`min-h-0 flex-1` inside the caller's `h-full` column)
+  // instead of growing past it, so the chrome stays put and only the tabpanel scrolls.
+  // Never give it an intrinsic min-height — that pushes the scroll boundary back up to
+  // the caller, and the header scrolls away with the document (the bug this fixes).
   return (
-    <div className="flex min-h-56 flex-1 flex-col rounded-lg border border-foreground/[0.06] bg-foreground/[0.02]">
+    <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-foreground/[0.06] bg-foreground/[0.02]">
       <div className="shrink-0 flex items-center justify-between border-b border-foreground/[0.06] px-3 py-2">
         <Tabs
           ariaLabel={t('autopilot.apply.tabs.outputTabs')}
@@ -327,12 +332,20 @@ export function GenerationOutput({
           <LetterLayoutPicker value={letterLayoutId} onChange={onLetterLayoutChange} />
         </div>
       )}
+      {/* The ONLY scroll boundary in this viewer: everything above is `shrink-0` and
+          therefore pinned (tabs + Copy/Export, and the template / accent / layout
+          strips that mutate what you're looking at). Because the pinned chrome is a
+          flex SIBLING — not sticky chrome overlaying this box — it can never obscure
+          a focused element inside it (WCAG 2.4.11), so no scroll-margin is needed.
+          Content normally fits (EditableOutput/JobAdView are `h-full`/`min-h-0` and
+          scroll internally); `overflow-y-auto` is the safety valve on short windows,
+          and the panel is focusable (`tabIndex={0}`) so it stays keyboard-scrollable. */}
       <div
         role="tabpanel"
         id={activePanelId}
         aria-labelledby={activeTabId}
         tabIndex={0}
-        className="flex min-h-[32rem] flex-1 flex-col px-3 py-2"
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto px-3 py-2"
       >
         {view === 'jobAd' ? (
           <JobAdView

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GenerationOutput.tsx
@@ -211,11 +211,13 @@ export function GenerationOutput({
 
   // Three-part shape (mirrors the AI-Generate viewer + ModalShell, docs/PATTERNS.md §13):
   // the root is HEIGHT-BOUNDED (`min-h-0 flex-1` inside the caller's `h-full` column)
-  // instead of growing past it, so the chrome stays put and only the tabpanel scrolls.
-  // Never give it an intrinsic min-height — that pushes the scroll boundary back up to
-  // the caller, and the header scrolls away with the document (the bug this fixes).
+  // instead of growing past it, so the tab/action header stays put and the scrollport
+  // below it does the scrolling. Never give the root an intrinsic min-height — that
+  // pushes the scroll boundary back up to the caller and the header scrolls away with
+  // the document (the bug this fixes). `overflow-hidden` keeps the rounded border a
+  // real clip; every popover inside is portalled/fixed, so nothing is lost to it.
   return (
-    <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-foreground/[0.06] bg-foreground/[0.02]">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-foreground/[0.06] bg-foreground/[0.02]">
       <div className="shrink-0 flex items-center justify-between border-b border-foreground/[0.06] px-3 py-2">
         <Tabs
           ariaLabel={t('autopilot.apply.tabs.outputTabs')}
@@ -255,138 +257,148 @@ export function GenerationOutput({
           />
         </div>
       </div>
-      {/* Filename + LIVE template picker strip (parity with the AI Generate done step).
-          The single chosen template/ATS drive BOTH docs' preview + export, so the
-          picker is shown on BOTH doc tabs (résumé AND cover) — never on the job-ad
-          tab. The ATS-safe toggle stays résumé-only (ATS single-column linearization
-          is a résumé concept; cover letters aren't two-column). */}
-      {view === 'doc' && (
-        <div className="shrink-0 flex flex-wrap items-center gap-2 border-b border-foreground/[0.06] px-3 py-1.5 text-[10px] text-foreground/30">
-          {meta && (
-            <>
-              <FileText size={10} />
-              <span className="font-mono">{buildFilename(meta, docType, 'pdf')}</span>
-            </>
-          )}
-          <div className="ml-auto flex items-center gap-2">
-            {/* Template dropdown — render-time switch (drives BOTH docs' preview +
-                export), no regeneration. */}
-            <div className="w-40">
-              <Dropdown
-                id="template-picker"
-                options={templateOptions}
-                value={templateId}
-                onChange={handleTemplateChange}
-                icon={<LayoutTemplate size={11} />}
-                listClassName="max-h-48"
-              />
-            </div>
-            {/* ATS-safe toggle — résumé-only + only meaningful for design-tier
-                templates (two-column OR photo, incl. Lebenslauf; copies
-                StepTemplate's switch markup; reuses the aiGenerate.atsMode keys). */}
-            {activeOut === 'resume' && isDesignTier(templateId) && (
-              <div
-                title={t(
-                  isTwoColumnTemplate(templateId)
-                    ? 'aiGenerate.atsModeHintTwoColumn'
-                    : 'aiGenerate.atsModeHintPhoto'
-                )}
-                className={cn(
-                  'flex h-auto items-center gap-1.5 rounded-lg border px-2 py-1 transition-all',
-                  atsMode
-                    ? 'border-brand/35 bg-brand/8 text-foreground/80'
-                    : 'border-foreground/[0.06] bg-transparent text-foreground/45'
-                )}
-              >
-                {/* Real <label htmlFor> so clicking the text toggles the switch
-                    (whole-control click) and supplies its accessible name. */}
-                <label
-                  htmlFor={atsSwitchId}
-                  className="cursor-pointer select-none text-[10px] font-medium"
-                >
-                  {t('aiGenerate.atsMode')}
-                </label>
-                <Switch
-                  id={atsSwitchId}
-                  size="sm"
-                  checked={atsMode}
-                  onCheckedChange={onAtsModeChange}
-                />
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-      {/* Document-accent strip — render-time colour override; drives BOTH docs'
-          preview + export, mirroring the template picker above. */}
-      {view === 'doc' && (
-        <div className="shrink-0 border-b border-foreground/[0.06] px-3 py-2">
-          <AccentPicker value={accent} onChange={onAccentChange} />
-        </div>
-      )}
-      {/* Letter-layout strip — cover-only (the layout only affects the letter; the
-          résumé is unaffected, so it's the cover-doc counterpart to the résumé-only
-          ATS toggle). Drives the cover preview + export. */}
-      {view === 'doc' && activeOut === 'cover' && (
-        <div className="shrink-0 border-b border-foreground/[0.06] px-3 py-2">
-          <LetterLayoutPicker value={letterLayoutId} onChange={onLetterLayoutChange} />
-        </div>
-      )}
-      {/* The ONLY scroll boundary in this viewer: everything above is `shrink-0` and
-          therefore pinned (tabs + Copy/Export, and the template / accent / layout
-          strips that mutate what you're looking at). Because the pinned chrome is a
-          flex SIBLING — not sticky chrome overlaying this box — it can never obscure
-          a focused element inside it (WCAG 2.4.11), so no scroll-margin is needed.
-          Content normally fits (EditableOutput/JobAdView are `h-full`/`min-h-0` and
-          scroll internally); `overflow-y-auto` is the safety valve on short windows,
-          and the panel is focusable (`tabIndex={0}`) so it stays keyboard-scrollable. */}
+      {/* The scrollport. ONLY the tab/action bar above pins — the option strips
+          scroll WITH the document. Pinning them was measured at 214px (résumé) /
+          426px (cover) of permanent chrome, which leaves 17px / 0px of document at
+          the 1280×800 default window and clips the layout picker out of reach; the
+          strips are occasional controls, the document is the content.
+          The document region below carries a `min-h-[20rem]` FLOOR — that is what
+          makes this a real scrollport. Without it every child is `flex-1`/`h-full`,
+          content always fits exactly and `overflow-y-auto` can never engage.
+          The pinned header is a flex SIBLING of this box (not sticky chrome
+          overlaying it), so it cannot obscure a focused element inside
+          (WCAG 2.4.11) and needs no scroll-margin; `tabIndex={0}` keeps the
+          scrollport keyboard-scrollable. */}
       <div
         role="tabpanel"
         id={activePanelId}
         aria-labelledby={activeTabId}
         tabIndex={0}
-        className="flex min-h-0 flex-1 flex-col overflow-y-auto px-3 py-2"
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto"
       >
-        {view === 'jobAd' ? (
-          <JobAdView
-            jobDesc={jobDesc}
-            onJobDescChange={onJobDescChange}
-            summary={jobAdSummary.summary}
-            generating={jobAdSummary.generating}
-            error={jobAdSummary.error}
-            onGenerateSummary={jobAdSummary.generate}
-            language={jobAdSummary.language}
-            onLanguageChange={jobAdSummary.setLanguage}
-            hasDesc={hasDesc}
-            fetchingDesc={fetchingDesc}
-            jobUrl={jobUrl}
-          />
-        ) : (
-          <EditableOutput
-            value={output}
-            onChange={handleEdit}
-            onBlur={handleBlur}
-            isPending={pending}
-            disabled={!editable}
-            docType={docType}
-            meta={meta}
-            className="flex h-full flex-col overflow-hidden"
-            textAreaClassName="h-full w-full bg-transparent text-[11px] leading-relaxed text-foreground/75 placeholder:text-foreground/20"
-            previewSlot={
-              <PdfPreview
-                text={committed[activeOut]}
-                docType={docType}
-                meta={meta}
-                templateId={templateId}
-                atsMode={atsMode}
-                accent={accent}
-                letterLayoutId={letterLayoutId}
-                paused={!editable}
-                className="h-full w-full"
-              />
-            }
-          />
+        {/* Filename + LIVE template picker strip (parity with the AI Generate done step).
+            The single chosen template/ATS drive BOTH docs' preview + export, so the
+            picker is shown on BOTH doc tabs (résumé AND cover) — never on the job-ad
+            tab. The ATS-safe toggle stays résumé-only (ATS single-column linearization
+            is a résumé concept; cover letters aren't two-column). */}
+        {view === 'doc' && (
+          <div className="shrink-0 flex flex-wrap items-center gap-2 border-b border-foreground/[0.06] px-3 py-1.5 text-[10px] text-foreground/30">
+            {meta && (
+              <>
+                <FileText size={10} />
+                <span className="font-mono">{buildFilename(meta, docType, 'pdf')}</span>
+              </>
+            )}
+            <div className="ml-auto flex items-center gap-2">
+              {/* Template dropdown — render-time switch (drives BOTH docs' preview +
+                  export), no regeneration. Its list is portalled to <body> (fixed),
+                  so the scrollport around it never clips the options. */}
+              <div className="w-40">
+                <Dropdown
+                  id="template-picker"
+                  options={templateOptions}
+                  value={templateId}
+                  onChange={handleTemplateChange}
+                  icon={<LayoutTemplate size={11} />}
+                  listClassName="max-h-48"
+                />
+              </div>
+              {/* ATS-safe toggle — résumé-only + only meaningful for design-tier
+                  templates (two-column OR photo, incl. Lebenslauf; copies
+                  StepTemplate's switch markup; reuses the aiGenerate.atsMode keys). */}
+              {activeOut === 'resume' && isDesignTier(templateId) && (
+                <div
+                  title={t(
+                    isTwoColumnTemplate(templateId)
+                      ? 'aiGenerate.atsModeHintTwoColumn'
+                      : 'aiGenerate.atsModeHintPhoto'
+                  )}
+                  className={cn(
+                    'flex h-auto items-center gap-1.5 rounded-lg border px-2 py-1 transition-all',
+                    atsMode
+                      ? 'border-brand/35 bg-brand/8 text-foreground/80'
+                      : 'border-foreground/[0.06] bg-transparent text-foreground/45'
+                  )}
+                >
+                  {/* Real <label htmlFor> so clicking the text toggles the switch
+                      (whole-control click) and supplies its accessible name. */}
+                  <label
+                    htmlFor={atsSwitchId}
+                    className="cursor-pointer select-none text-[10px] font-medium"
+                  >
+                    {t('aiGenerate.atsMode')}
+                  </label>
+                  <Switch
+                    id={atsSwitchId}
+                    size="sm"
+                    checked={atsMode}
+                    onCheckedChange={onAtsModeChange}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
         )}
+        {/* Document-accent strip — render-time colour override; drives BOTH docs'
+            preview + export, mirroring the template picker above. */}
+        {view === 'doc' && (
+          <div className="shrink-0 border-b border-foreground/[0.06] px-3 py-2">
+            <AccentPicker value={accent} onChange={onAccentChange} />
+          </div>
+        )}
+        {/* Letter-layout strip — cover-only (the layout only affects the letter; the
+            résumé is unaffected, so it's the cover-doc counterpart to the résumé-only
+            ATS toggle). Drives the cover preview + export. */}
+        {view === 'doc' && activeOut === 'cover' && (
+          <div className="shrink-0 border-b border-foreground/[0.06] px-3 py-2">
+            <LetterLayoutPicker value={letterLayoutId} onChange={onLetterLayoutChange} />
+          </div>
+        )}
+        {/* Document region — grows to fill the scrollport, but never shrinks below
+            the floor, so a short window scrolls instead of collapsing the document
+            to a few pixels. */}
+        <div className="flex min-h-[20rem] flex-1 flex-col px-3 py-2">
+          {view === 'jobAd' ? (
+            <JobAdView
+              jobDesc={jobDesc}
+              onJobDescChange={onJobDescChange}
+              summary={jobAdSummary.summary}
+              generating={jobAdSummary.generating}
+              error={jobAdSummary.error}
+              onGenerateSummary={jobAdSummary.generate}
+              language={jobAdSummary.language}
+              onLanguageChange={jobAdSummary.setLanguage}
+              hasDesc={hasDesc}
+              fetchingDesc={fetchingDesc}
+              jobUrl={jobUrl}
+            />
+          ) : (
+            <EditableOutput
+              value={output}
+              onChange={handleEdit}
+              onBlur={handleBlur}
+              isPending={pending}
+              disabled={!editable}
+              docType={docType}
+              meta={meta}
+              className="flex h-full flex-col overflow-hidden"
+              textAreaClassName="h-full w-full bg-transparent text-[11px] leading-relaxed text-foreground/75 placeholder:text-foreground/20"
+              previewSlot={
+                <PdfPreview
+                  text={committed[activeOut]}
+                  docType={docType}
+                  meta={meta}
+                  templateId={templateId}
+                  atsMode={atsMode}
+                  accent={accent}
+                  letterLayoutId={letterLayoutId}
+                  paused={!editable}
+                  className="h-full w-full"
+                />
+              }
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/ResultsPanel.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/ResultsPanel.test.tsx
@@ -2,10 +2,15 @@ import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
+import type * as AjhTranslations from '@ajh/translations';
+
 import { ResultsPanel } from './ResultsPanel';
 
-// Echo every key verbatim — no i18next runtime needed in jsdom.
-vi.mock('@ajh/translations', () => ({
+// Echo every key verbatim — no i18next runtime needed in jsdom. Only
+// `useTranslation` is replaced; every other export stays real, so adding one
+// doesn't silently break this file.
+vi.mock('@ajh/translations', async (importOriginal) => ({
+  ...(await importOriginal<typeof AjhTranslations>()),
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/ResultsPanel.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/ResultsPanel.test.tsx
@@ -1,0 +1,106 @@
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ResultsPanel } from './ResultsPanel';
+
+// Echo every key verbatim — no i18next runtime needed in jsdom.
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// The viewer itself is covered by GenerationOutput.test.tsx; here it is a marker
+// so the assertions are about ResultsPanel's own layout shape only.
+vi.mock('./GenerationOutput', () => ({
+  GenerationOutput: () => <div data-testid="generation-output-stub" />,
+}));
+
+function makeProps(): ComponentProps<typeof ResultsPanel> {
+  return {
+    target: 'both',
+    jobDesc: 'Full job description text',
+    onJobDescChange: vi.fn(),
+    hasDesc: true,
+    fetchingDesc: false,
+    jobUrl: 'https://example.com/job',
+    jobAdSummary: {
+      summary: '',
+      generating: false,
+      error: null,
+      generate: vi.fn(),
+      language: 'en',
+      setLanguage: vi.fn(),
+    },
+    activeOut: 'resume',
+    setActiveOut: vi.fn(),
+    templateId: 'classic',
+    atsMode: false,
+    accent: undefined,
+    letterLayoutId: undefined,
+    onTemplateChange: vi.fn(),
+    onAtsModeChange: vi.fn(),
+    onAccentChange: vi.fn(),
+    onLetterLayoutChange: vi.fn(),
+    output: 'Generated resume content',
+    onEdit: vi.fn(),
+    meta: null,
+    copied: false,
+    onCopy: vi.fn(),
+    exportOpen: false,
+    setExportOpen: vi.fn(),
+    onExport: vi.fn(),
+    onRegenerate: vi.fn(),
+    onEditSettings: vi.fn(),
+  };
+}
+
+// Regression guard for the "document viewer header scrolls away" bug: this panel
+// used to wrap GenerationOutput in an `overflow-y-auto` body, so IT scrolled the
+// whole viewer — pinned header included. The scroll boundary belongs inside
+// GenerationOutput (on its tabpanel); this body must stay height-bounded only.
+describe('ResultsPanel layout', () => {
+  const SCROLLS = /overflow-(?:y-)?(?:auto|scroll)/;
+
+  it('does not scroll the viewer — no scroll container above GenerationOutput', () => {
+    const { container } = render(<ResultsPanel {...makeProps()} />);
+
+    for (
+      let el = screen.getByTestId('generation-output-stub').parentElement;
+      el !== null && el !== container;
+      el = el.parentElement
+    ) {
+      expect(el.className).not.toMatch(SCROLLS);
+    }
+  });
+
+  it('bounds the viewer body so it can never grow past the panel', () => {
+    render(<ResultsPanel {...makeProps()} />);
+
+    const body = screen.getByTestId('generation-output-stub').parentElement;
+    expect(body).not.toBeNull();
+    expect(body?.className).toContain('min-h-0');
+    expect(body?.className).toContain('flex-1');
+  });
+
+  it('keeps the regenerate / edit-settings footer pinned below the body', () => {
+    render(<ResultsPanel {...makeProps()} />);
+
+    const footer = screen
+      .getByRole('button', { name: 'autopilot.apply.wizard.results.regenerate' })
+      .closest('div');
+    expect(footer).not.toBeNull();
+    expect(footer?.className).toContain('shrink-0');
+    expect(footer?.contains(screen.getByTestId('generation-output-stub'))).toBe(false);
+  });
+
+  it('forwards the footer actions to their callbacks', () => {
+    const props = makeProps();
+    render(<ResultsPanel {...props} />);
+
+    screen.getByRole('button', { name: 'autopilot.apply.wizard.results.regenerate' }).click();
+    screen.getByRole('button', { name: 'autopilot.apply.wizard.results.edit' }).click();
+
+    expect(props.onRegenerate).toHaveBeenCalledTimes(1);
+    expect(props.onEditSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/ResultsPanel.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/ResultsPanel.tsx
@@ -90,7 +90,11 @@ export function ResultsPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-8 py-6">
+      {/* Height-bounded body — NOT a scroll container. GenerationOutput owns its
+          own scroll boundary (below its pinned tab/action header), so the header
+          stays visible while the document scrolls. Making this scroll again would
+          re-break that: the whole viewer, header included, would scroll away. */}
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden px-8 py-6">
         <GenerationOutput
           target={target}
           activeOut={activeOut}

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
@@ -948,3 +948,44 @@ describe('TailorFlow — onJobDescChange host callback', () => {
     );
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Height chain (load-bearing layout)
+// ─────────────────────────────────────────────────────────────────────────────
+// GenerationOutput pins its header by being height-bounded, which only works if
+// every ancestor passes a bounded height down. These two links are that chain's
+// top: drop either and the viewer grows past the window again, an ancestor
+// becomes the scroll owner and the header scrolls away with the document — while
+// every assertion inside GenerationOutput/ResultsPanel stays green (they only
+// walk up to their own render container).
+
+describe('TailorFlow — height chain', () => {
+  it('bounds the stage body and stretches the stage to it, on every stage', () => {
+    for (const stage of ['configuring', 'done'] as const) {
+      genMock.resumeOut = stage === 'done' ? 'Generated resume text' : '';
+      genMock.output = genMock.resumeOut;
+
+      const { unmount } = renderFlow({});
+      const testId =
+        stage === 'done' ? TEST_IDS.documents.resultsPanel : TEST_IDS.documents.tailorWizard;
+
+      // Stage element (motion.div) must fill the stage body…
+      const stageEl = screen.getByTestId(testId).parentElement;
+      expect(stageEl, stage).not.toBeNull();
+      expect(stageEl?.className, stage).toContain('h-full');
+
+      // …and the stage body must be a bounded flex child, never content-sized.
+      const stageBody = stageEl?.parentElement;
+      expect(stageBody, stage).not.toBeNull();
+      expect(stageBody?.className, stage).toContain('min-h-0');
+      expect(stageBody?.className, stage).toContain('flex-1');
+
+      // The root the two hang off is itself height-bounded.
+      const root = stageBody?.parentElement;
+      expect(root?.className, stage).toContain('h-full');
+      expect(root?.className, stage).toContain('min-h-0');
+
+      unmount();
+    }
+  });
+});

--- a/packages/test-ids/src/test-ids.ts
+++ b/packages/test-ids/src/test-ids.ts
@@ -117,6 +117,8 @@ export const TEST_IDS = {
     thinkingBubble: 'thinking-bubble',
     stepDots: 'step-dots',
     jobAdViewTextarea: 'job-ad-view-textarea',
+    /** GenerationOutput's scrolling document region — carries the min-height floor. */
+    documentRegion: 'document-region',
   },
 
   /** Resume shared components (ResumeInputCard) */


### PR DESCRIPTION
The tailor-flow document viewer header (Resume | Cover letter | Job ad + Copy/Export) scrolled away because the parent panel owned the scroll. The scroll boundary now lives inside the viewer: the header pins, the option strips scroll with the document, and the document region keeps a 20rem floor.

Chromium-measured at 10 window/tab configurations: header moves 0px on scroll in 10/10; usable document area 340px in every config (the first iteration pinned the strips too and measured 0px at the app default window — caught by review and reverted to the measured-good shape).

Review: frontend-author → frontend-reviewer (1 HIGH, empirically measured, fixed + re-measured). Validation: 4103 tests; TailorFlow suites 272; typecheck 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
