### PR TITLE
fix: email copy scope, questions language picker, prep result link

### DIFF
--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.test.tsx
@@ -3,7 +3,8 @@
  *
  * Covers:
  *  - Feature #2: the subject copy button writes JUST the subject (no "Subject:"
- *    prefix, no body) and is independent of the whole-email Copy button.
+ *    prefix, no body) and is independent of the body Copy button, which in turn
+ *    writes JUST the body (the subject is never re-prepended).
  *  - Feature #5: select-to-rewrite wiring — clicking Rewrite opens RewritePopover
  *    with docType='email' and the selected span (or the whole field when nothing
  *    is selected); accepting splices the replacement back into the mutable draft.
@@ -210,14 +211,18 @@ describe('ApplyByEmailTab — subject-only copy', () => {
     );
   });
 
-  it('the whole-email Copy button still writes the "Subject: …" + body blob', async () => {
+  it('the body Copy button writes JUST the body (no "Subject: …" prefix)', async () => {
     await renderWithDraft();
 
     fireEvent.click(screen.getByRole('button', { name: 'applications.detail.email.copy' }));
 
     await waitFor(() => {
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`Subject: ${SUBJECT}\n\n${BODY}`);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(BODY);
     });
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalledWith(
+      `Subject: ${SUBJECT}\n\n${BODY}`
+    );
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalledWith(EMAIL_RAW);
   });
 });
 
@@ -331,13 +336,12 @@ describe('ApplyByEmailTab — select-to-rewrite', () => {
 
     const rewrittenBody = 'Hello, I am REWRITTEN in the role.';
 
-    // Whole-email Copy writes the post-rewrite blob (not the original BODY).
+    // Body Copy writes the post-rewrite body (not the original BODY, and no subject).
     fireEvent.click(screen.getByRole('button', { name: 'applications.detail.email.copy' }));
     await waitFor(() => {
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        `Subject: ${SUBJECT}\n\n${rewrittenBody}`
-      );
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(rewrittenBody);
     });
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalledWith(BODY);
 
     // mailto encodes the post-rewrite body too.
     fireEvent.click(screen.getByRole('button', { name: 'applications.detail.email.openMailto' }));

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplyByEmailTab.tsx
@@ -192,10 +192,12 @@ export function ApplyByEmailTab({ application, matchingGenerations }: Props) {
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Body-only copy — the subject has its own copy button (see handleCopySubject),
+  // so re-prepending "Subject: …" here would force the user to strip it back out
+  // before pasting into a mail client's body field.
   const handleCopy = () => {
-    const full = subject ? `Subject: ${subject}\n\n${body}` : body;
     void navigator.clipboard
-      .writeText(full)
+      .writeText(body)
       .then(() => {
         setCopied(true);
         if (copyTimerRef.current) clearTimeout(copyTimerRef.current);

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/InterviewPrepTab.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/InterviewPrepTab.test.tsx
@@ -62,6 +62,7 @@ const iqMock = {
   seedTopics: '',
   setSeedTopics: vi.fn(),
   language: 'en',
+  detectedLanguage: 'en',
   setLanguage: vi.fn(),
   audiences: ['recruiter'] as string[],
   toggleAudience: vi.fn(),
@@ -173,6 +174,7 @@ beforeEach(() => {
   resolveJobUrlState.isLoading = false;
   iqMock.questions = [];
   iqMock.language = 'en';
+  iqMock.detectedLanguage = 'en';
   iqMock.setLanguage.mockClear();
   iqMock.generate.mockClear();
   practiceMock.generate.mockClear();
@@ -309,6 +311,49 @@ describe('InterviewPrepTab — output language selector', () => {
     fireEvent.click(screen.getByText('Français'));
 
     expect(iqMock.setLanguage).toHaveBeenCalledWith('fr');
+  });
+
+  it('names a detected language the picker does not stock, instead of showing English', () => {
+    // Dutch is not in OUTPUT_LANGUAGES, but it IS what generation will use.
+    iqMock.language = 'nl';
+    iqMock.detectedLanguage = 'nl';
+    render(<InterviewPrepTab application={makeApp()} matchingGenerations={[]} />);
+
+    expect(trigger()).toHaveTextContent('Dutch');
+    expect(trigger()).not.toHaveTextContent('English');
+  });
+
+  it('offers the ad-language option as "match the job ad" when nothing was detected', () => {
+    iqMock.language = '';
+    iqMock.detectedLanguage = '';
+    render(<InterviewPrepTab application={makeApp()} matchingGenerations={[]} />);
+
+    expect(trigger()).toHaveTextContent('applications.detail.interview.languageAuto');
+  });
+
+  it('keeps the ad-language option reachable after an explicit pick', () => {
+    // The user picked Spanish, but the ad is Dutch — the Dutch option must still
+    // be listed so the choice can be undone.
+    iqMock.language = 'es';
+    iqMock.detectedLanguage = 'nl';
+    render(<InterviewPrepTab application={makeApp()} matchingGenerations={[]} />);
+
+    expect(trigger()).toHaveTextContent('Español');
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByText('Dutch'));
+
+    expect(iqMock.setLanguage).toHaveBeenCalledWith('nl');
+  });
+
+  it('does not duplicate a detected language the picker already stocks', () => {
+    iqMock.language = 'de';
+    iqMock.detectedLanguage = 'de';
+    render(<InterviewPrepTab application={makeApp()} matchingGenerations={[]} />);
+
+    fireEvent.click(trigger());
+    // Exactly one "Deutsch" OPTION — no synthetic duplicate alongside the real
+    // one. (Scoped to role=option: the trigger also renders the selected label.)
+    expect(screen.getAllByRole('option', { name: 'Deutsch' })).toHaveLength(1);
   });
 
   it('is part of the ask-mode toolbar only (hidden in practice mode)', () => {

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/InterviewPrepTab.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/InterviewPrepTab.test.tsx
@@ -61,6 +61,8 @@ let capturedHasDesc: boolean | undefined = undefined;
 const iqMock = {
   seedTopics: '',
   setSeedTopics: vi.fn(),
+  language: 'en',
+  setLanguage: vi.fn(),
   audiences: ['recruiter'] as string[],
   toggleAudience: vi.fn(),
   questions: [] as { id: string; question: string; audience: string }[],
@@ -170,6 +172,8 @@ beforeEach(() => {
   resolveJobUrlState.data = undefined;
   resolveJobUrlState.isLoading = false;
   iqMock.questions = [];
+  iqMock.language = 'en';
+  iqMock.setLanguage.mockClear();
   iqMock.generate.mockClear();
   practiceMock.generate.mockClear();
   practiceMock.getFeedback.mockClear();
@@ -280,5 +284,41 @@ describe('InterviewPrepTab — mode toggle', () => {
 
     expect(screen.getByTestId('audience-selector')).toBeInTheDocument();
     expect(screen.queryByTestId('practice-panel')).not.toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Output-language selector (ask-mode toolbar)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('InterviewPrepTab — output language selector', () => {
+  /** The dropdown trigger, named by the sr-only <label htmlFor="iq-language">. */
+  const trigger = () => screen.getByLabelText('applications.detail.interview.languageLabel');
+
+  it('shows the hook language as the selected option, labelled by its endonym', () => {
+    iqMock.language = 'de';
+    render(<InterviewPrepTab application={makeApp()} matchingGenerations={[]} />);
+
+    expect(trigger()).toHaveTextContent('Deutsch');
+  });
+
+  it('forwards a picked language to the hook as a locale CODE', () => {
+    render(<InterviewPrepTab application={makeApp()} matchingGenerations={[]} />);
+
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByText('Français'));
+
+    expect(iqMock.setLanguage).toHaveBeenCalledWith('fr');
+  });
+
+  it('is part of the ask-mode toolbar only (hidden in practice mode)', () => {
+    render(<InterviewPrepTab application={makeApp()} matchingGenerations={[]} />);
+    expect(trigger()).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('applications.detail.interview.toggle.practice'));
+
+    expect(
+      screen.queryByLabelText('applications.detail.interview.languageLabel')
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/InterviewPrepTab.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/InterviewPrepTab.tsx
@@ -1,7 +1,12 @@
 import { MessagesSquare, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 
-import type { AiGenerationRecord, Application, InterviewQuestion } from '@ajh/shared';
+import {
+  type AiGenerationRecord,
+  type Application,
+  getLanguageName,
+  type InterviewQuestion,
+} from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
 import { Button, CardSkeleton, Dropdown, EmptyState, SegmentedControl, TextArea } from '@ajh/ui';
 
@@ -70,7 +75,27 @@ export function InterviewPrepTab({ application, matchingGenerations }: Props) {
   // Sourced from OUTPUT_LANGUAGES (the single locale source of truth) so each value
   // is a locale CODE the generation pipeline accepts; labels are endonyms, each
   // language shown in its own script (mirrors the tailor flow's summary picker).
-  const languageOptions = OUTPUT_LANGUAGES.map((l) => ({ value: l.code, label: l.endonym }));
+  //
+  // Prepended: the ad's OWN language, whenever the list above doesn't already
+  // offer it. Questions are generated in the detected language whether or not the
+  // picker can name it, so without this a Dutch ad would display "English" while
+  // producing Dutch. Value `''` (nothing detected) keeps the same slot as an
+  // explicit "match the job ad" choice, and pinning the option to the DETECTED
+  // language — not the current selection — keeps it reachable after a manual pick.
+  const detected = iq.detectedLanguage;
+  const languageOptions = [
+    ...(OUTPUT_LANGUAGES.some((l) => l.code === detected)
+      ? []
+      : [
+          {
+            value: detected,
+            label: detected
+              ? getLanguageName(detected)
+              : t('applications.detail.interview.languageAuto'),
+          },
+        ]),
+    ...OUTPUT_LANGUAGES.map((l) => ({ value: l.code, label: l.endonym })),
+  ];
 
   if (docsQuery.isLoading || (!!defaultResumeId && resumeQuery.isLoading)) {
     return (

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/InterviewPrepTab.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/InterviewPrepTab.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import type { AiGenerationRecord, Application, InterviewQuestion } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
-import { Button, CardSkeleton, EmptyState, SegmentedControl, TextArea } from '@ajh/ui';
+import { Button, CardSkeleton, Dropdown, EmptyState, SegmentedControl, TextArea } from '@ajh/ui';
 
 import { AudienceSelector } from '@/components/interview/AudienceSelector';
 import { InterviewPracticePanel } from '@/components/interview/InterviewPracticePanel';
@@ -12,6 +12,7 @@ import { useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
 import { useInterviewPractice } from '@/hooks/use-interview-practice';
 import { useInterviewQuestions } from '@/hooks/use-interview-questions';
 import { useDefaultResumeId } from '@/hooks/useDefaultResumeId';
+import { OUTPUT_LANGUAGES } from '@/lib/generate';
 import { useDocuments, useDocumentText, useResolveJobUrl } from '@/services';
 
 interface Props {
@@ -66,6 +67,11 @@ export function InterviewPrepTab({ application, matchingGenerations }: Props) {
   });
   const practice = useInterviewPractice({ resume, jobDesc, model, canUse, hasDesc });
 
+  // Sourced from OUTPUT_LANGUAGES (the single locale source of truth) so each value
+  // is a locale CODE the generation pipeline accepts; labels are endonyms, each
+  // language shown in its own script (mirrors the tailor flow's summary picker).
+  const languageOptions = OUTPUT_LANGUAGES.map((l) => ({ value: l.code, label: l.endonym }));
+
   if (docsQuery.isLoading || (!!defaultResumeId && resumeQuery.isLoading)) {
     return (
       <div className="h-full overflow-y-auto px-6 py-5">
@@ -97,9 +103,24 @@ export function InterviewPrepTab({ application, matchingGenerations }: Props) {
         <>
           {/* Toolbar — audience selector + seed topics + generate */}
           <div className="shrink-0 space-y-2 border-b border-[var(--border-soft)] px-8 py-3">
-            <span className="block text-xs font-medium text-foreground/70">
-              {t('applications.detail.interview.audienceLabel')}
-            </span>
+            <div className="flex items-center justify-between gap-2">
+              <span className="block text-xs font-medium text-foreground/70">
+                {t('applications.detail.interview.audienceLabel')}
+              </span>
+              {/* Output language of the generated questions. The label is
+                  visually redundant with the selected language, so sr-only keeps
+                  the toolbar uncluttered while the trigger stays named. */}
+              <label htmlFor="iq-language" className="sr-only">
+                {t('applications.detail.interview.languageLabel')}
+              </label>
+              <Dropdown
+                id="iq-language"
+                value={iq.language}
+                onChange={iq.setLanguage}
+                options={languageOptions}
+                size="sm"
+              />
+            </div>
             <AudienceSelector selected={iq.audiences} onToggle={iq.toggleAudience} />
             <label htmlFor="iq-seeds" className="block pt-1 text-xs font-medium text-foreground/70">
               {t('applications.detail.interview.seedLabel')}

--- a/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
@@ -29,7 +29,7 @@ import type React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
-import type { AgentStepEvent, JobEvent, JobRecord } from '@ajh/shared';
+import type { AgentStepEvent, ApplicationTrackRequest, JobEvent, JobRecord } from '@ajh/shared';
 import type * as AjhUi from '@ajh/ui';
 
 import type { Posting } from '@/features/jobs/types';
@@ -89,7 +89,7 @@ let stubbedJobRecord: JobRecord | undefined;
 const mockRunMutateAsync = vi.fn().mockResolvedValue({ jobId: 'job-1' });
 const mockCancelMutateAsync = vi.fn().mockResolvedValue(undefined);
 const mockConfirmMutateAsync = vi.fn().mockResolvedValue({ ok: true });
-const mockSaveFromPosting = vi.fn<() => Promise<{ id?: string }>>();
+const mockSaveFromPosting = vi.fn<(req: ApplicationTrackRequest) => Promise<{ id?: string }>>();
 
 vi.mock('@/services', () => ({
   useAgentRun: () => ({ mutateAsync: mockRunMutateAsync, isPending: false }),
@@ -405,14 +405,13 @@ describe('PrepApplicationPanel — view the created application', () => {
     await completeRun();
     await clickView();
 
-    // Exactly the shape usePostingActions.handleTailor sends, so both entry
-    // points resolve to the SAME record rather than creating a second one.
+    // Identity fields only — enough to dedupe by jobUrl, or to create the row
+    // when it somehow doesn't exist yet.
     expect(mockSaveFromPosting).toHaveBeenCalledWith({
       jobUrl: POSTING.url,
       board: POSTING.source,
       company: POSTING.company,
       title: POSTING.title,
-      jobDescription: POSTING.description,
       salaryMin: undefined,
       salaryMax: undefined,
       salaryCurrency: undefined,
@@ -422,6 +421,26 @@ describe('PrepApplicationPanel — view the created application', () => {
       params: { id: 'app-9' },
       search: { tab: 'documents', from: 'jobs' },
     });
+  });
+
+  it('never sends jobDescription (the merge is non-blank-wins — it would clobber user edits)', async () => {
+    await completeRun();
+    await clickView();
+
+    const req = mockSaveFromPosting.mock.calls[0]?.[0];
+    expect(req).toBeDefined();
+    expect(req).not.toHaveProperty('jobDescription');
+    // Guard against a "send it as undefined" regression that would still read
+    // as blank server-side but re-introduce the field on the wire.
+    expect(POSTING.description).toBeTruthy(); // the posting HAS one to leak
+  });
+
+  it('notifies when navigation itself rejects', async () => {
+    navigateMock.mockRejectedValueOnce(new Error('route blew up'));
+    await completeRun();
+    await clickView();
+
+    expect(notifyError).toHaveBeenCalledWith({ message: 'jobs.prep.viewApplicationError' });
   });
 
   it('notifies instead of navigating when the save returns no id', async () => {

--- a/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
@@ -435,12 +435,17 @@ describe('PrepApplicationPanel — view the created application', () => {
     expect(POSTING.description).toBeTruthy(); // the posting HAS one to leak
   });
 
-  it('notifies when navigation itself rejects', async () => {
+  it('notifies AND keeps the modal open when navigation itself rejects', async () => {
     navigateMock.mockRejectedValueOnce(new Error('route blew up'));
     await completeRun();
     await clickView();
 
     expect(notifyError).toHaveBeenCalledWith({ message: 'jobs.prep.viewApplicationError' });
+    // Closing before the navigation lands would bin the run log and leave the
+    // user with nothing but a toast — the proposal must still be on screen.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('jobs.prep.proposalTitle')).toBeInTheDocument();
+    expect(screen.getByText('jobs.prep.viewApplication')).toBeInTheDocument();
   });
 
   it('notifies instead of navigating when the save returns no id', async () => {

--- a/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/PrepApplicationPanel.test.tsx
@@ -16,6 +16,9 @@
  *  - `job.cancelled` renders the distinct "cancelled" copy, NOT ErrorState.
  *  - Stop calls jobs.cancel with the run's jobId.
  *  - Retry-from-error restarts the run and can reach `done` again.
+ *  - A COMPLETED run offers "View application", which idempotently saves the
+ *    posting and navigates to that application; a no-id/rejected save notifies
+ *    instead, and a cancelled/in-flight run never offers it at all.
  *
  * `@ajh/ui` primitives run for real (only ModalShell is simplified, dropping
  * the portal/focus-trap plumbing, but still rendering its footer) so the test
@@ -39,10 +42,15 @@ vi.mock('@ajh/translations', () => ({
 
 // ── @ajh/ui — keep everything real, simplify only ModalShell ────────────────
 
+const notifyError = vi.fn();
+
 vi.mock('@ajh/ui', async (importOriginal) => {
   const actual = await importOriginal<typeof AjhUi>();
   return {
     ...actual,
+    // The real hook throws outside NotificationProvider; the panel only ever
+    // uses it to surface a failed "View application".
+    useNotification: () => ({ error: notifyError, success: vi.fn() }),
     ModalShell: ({
       open,
       header,
@@ -81,6 +89,7 @@ let stubbedJobRecord: JobRecord | undefined;
 const mockRunMutateAsync = vi.fn().mockResolvedValue({ jobId: 'job-1' });
 const mockCancelMutateAsync = vi.fn().mockResolvedValue(undefined);
 const mockConfirmMutateAsync = vi.fn().mockResolvedValue({ ok: true });
+const mockSaveFromPosting = vi.fn<() => Promise<{ id?: string }>>();
 
 vi.mock('@/services', () => ({
   useAgentRun: () => ({ mutateAsync: mockRunMutateAsync, isPending: false }),
@@ -94,6 +103,15 @@ vi.mock('@/services', () => ({
   useJobEvents: (cb: (event: JobEvent) => void) => {
     jobEventHandler = cb;
   },
+  useSaveFromPosting: () => ({ mutateAsync: mockSaveFromPosting, isPending: false }),
+}));
+
+// ── Router — capture the navigation target of "View application" ─────────────
+
+const navigateMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
 }));
 
 // ── component under test ──────────────────────────────────────────────────────
@@ -145,6 +163,10 @@ beforeEach(() => {
   mockCancelMutateAsync.mockClear();
   mockConfirmMutateAsync.mockClear();
   mockConfirmMutateAsync.mockResolvedValue({ ok: true });
+  mockSaveFromPosting.mockReset();
+  mockSaveFromPosting.mockResolvedValue({ id: 'app-9' });
+  navigateMock.mockClear();
+  notifyError.mockClear();
   stepHandler = undefined;
   jobEventHandler = undefined;
   stubbedJobRecord = undefined;
@@ -350,6 +372,99 @@ describe('PrepApplicationPanel — useJob reconciliation fallback (no stuck spin
 
     expect(screen.getByText('jobs.prep.stopped.cancelled')).toBeInTheDocument();
     expect(screen.queryByText('jobs.prep.starting')).not.toBeInTheDocument();
+  });
+});
+
+describe('PrepApplicationPanel — view the created application', () => {
+  /** Drive a run all the way to a completed terminal state. */
+  async function completeRun(stoppedReason = 'done') {
+    openModal();
+    await clickStart();
+    act(() => {
+      stepHandler?.(
+        turnStep({ step: 5, text: 'Proposing: move to Applied.', tools: [], kind: 'proposal' })
+      );
+    });
+    act(() => {
+      jobEventHandler?.({
+        type: 'job.completed',
+        jobId: 'job-1',
+        data: { finalText: 'Proposing: move to Applied.', steps: 4, stoppedReason },
+        ts: 0,
+      });
+    });
+  }
+
+  const clickView = async () => {
+    await act(async () => {
+      fireEvent.click(screen.getByText('jobs.prep.viewApplication'));
+    });
+  };
+
+  it('saves the posting (idempotent, dedupes by jobUrl) and navigates to that application', async () => {
+    await completeRun();
+    await clickView();
+
+    // Exactly the shape usePostingActions.handleTailor sends, so both entry
+    // points resolve to the SAME record rather than creating a second one.
+    expect(mockSaveFromPosting).toHaveBeenCalledWith({
+      jobUrl: POSTING.url,
+      board: POSTING.source,
+      company: POSTING.company,
+      title: POSTING.title,
+      jobDescription: POSTING.description,
+      salaryMin: undefined,
+      salaryMax: undefined,
+      salaryCurrency: undefined,
+    });
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/applications/$id',
+      params: { id: 'app-9' },
+      search: { tab: 'documents', from: 'jobs' },
+    });
+  });
+
+  it('notifies instead of navigating when the save returns no id', async () => {
+    mockSaveFromPosting.mockResolvedValue({});
+    await completeRun();
+    await clickView();
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledWith({ message: 'jobs.prep.viewApplicationError' });
+  });
+
+  it('notifies instead of navigating when the save rejects', async () => {
+    mockSaveFromPosting.mockRejectedValue(new Error('boom'));
+    await completeRun();
+    await clickView();
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledWith({ message: 'jobs.prep.viewApplicationError' });
+  });
+
+  it('is not offered for a cancelled run (no result to follow through on)', async () => {
+    openModal();
+    await clickStart();
+    act(() => {
+      jobEventHandler?.({ type: 'job.cancelled', jobId: 'job-1', ts: 0 });
+    });
+
+    expect(screen.queryByText('jobs.prep.viewApplication')).not.toBeInTheDocument();
+  });
+
+  it('is not offered when a completed payload reports a cancelled stop', async () => {
+    await completeRun('cancelled');
+
+    expect(screen.queryByText('jobs.prep.viewApplication')).not.toBeInTheDocument();
+    // The run-again affordance is still there — only the follow-through is gone.
+    expect(screen.getByText('jobs.prep.runAgain')).toBeInTheDocument();
+  });
+
+  it('is not offered while the run is still in flight', async () => {
+    openModal();
+    await clickStart();
+
+    expect(screen.queryByText('jobs.prep.viewApplication')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/index.tsx
@@ -339,12 +339,14 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
         notify.error({ message: t('jobs.prep.viewApplicationError') });
         return;
       }
-      setOpen(false);
+      // Close only AFTER the navigation lands: closing first would tear the run
+      // log down and leave a failed navigation showing nothing but a toast.
       await navigate({
         to: '/applications/$id',
         params: { id: res.id },
         search: { tab: 'documents', from: 'jobs' },
       });
+      setOpen(false);
     } catch {
       notify.error({ message: t('jobs.prep.viewApplicationError') });
     }

--- a/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/index.tsx
@@ -315,8 +315,14 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
    * Open the application this run produced. `saveFromPosting` is idempotent and
    * dedupes by `jobUrl` — the same key the agent's own saves used — so it returns
    * the SAME record the run wrote to rather than creating a second one (and still
-   * yields a row to open when the user denied every save). Request shape mirrors
-   * `usePostingActions.handleTailor`, the other entry point into this record.
+   * yields a row to open when the user denied every save).
+   *
+   * `jobDescription` is deliberately OMITTED: the backend merge is a
+   * non-blank-wins `pick`, so sending the posting's ad text would overwrite a
+   * description the user edited on the detail page. This button reads as
+   * navigation, not a re-import — it must not mutate content. (Tailor sends it
+   * on purpose; that flow is an explicit import.) A brand-new row therefore
+   * lands without an ad text, which the detail page resolves from the URL.
    */
   const openApplication = async () => {
     try {
@@ -325,7 +331,6 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
         board: posting.source,
         company: posting.company,
         title: posting.title,
-        jobDescription: posting.description,
         salaryMin: posting.salaryMin,
         salaryMax: posting.salaryMax,
         salaryCurrency: posting.salaryCurrency,

--- a/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/PrepApplicationPanel/index.tsx
@@ -1,9 +1,28 @@
-import { CheckCircle2, Circle, CircleMinus, Loader2, Sparkles, Square, X } from 'lucide-react';
+import {
+  ArrowRight,
+  CheckCircle2,
+  Circle,
+  CircleMinus,
+  Loader2,
+  Sparkles,
+  Square,
+  X,
+} from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 
 import type { AgentConfirmPayload, AgentStepEvent, JobEvent } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
-import { Button, EmptyState, ErrorState, GlassCard, ModalShell, StreamingText, Tag } from '@ajh/ui';
+import {
+  Button,
+  EmptyState,
+  ErrorState,
+  GlassCard,
+  ModalShell,
+  StreamingText,
+  Tag,
+  useNotification,
+} from '@ajh/ui';
 
 import { AgentConfirm } from '@/features/jobs/components/AgentConfirm';
 import type { Posting } from '@/features/jobs/types';
@@ -17,6 +36,7 @@ import {
   useGenerateConfig,
   useJob,
   useJobEvents,
+  useSaveFromPosting,
 } from '@/services';
 
 interface AgentRunResult {
@@ -99,6 +119,8 @@ function findLastMatch(steps: AgentStepEvent[], item: ChecklistItem): AgentStepE
  */
 export function PrepApplicationPanel({ posting }: { posting: Posting }) {
   const { t } = useTranslation();
+  const notify = useNotification();
+  const navigate = useNavigate();
   const [open, setOpen] = useState(false);
 
   const resumeId = useDefaultResumeId();
@@ -133,6 +155,7 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
 
   const runAgent = useAgentRun();
   const cancelJob = useCancelJob();
+  const saveFromPosting = useSaveFromPosting();
 
   const isBusy =
     machineState !== 'idle' &&
@@ -288,6 +311,40 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
     void cancelJob.mutateAsync(runJobId).catch(() => {});
   };
 
+  /**
+   * Open the application this run produced. `saveFromPosting` is idempotent and
+   * dedupes by `jobUrl` — the same key the agent's own saves used — so it returns
+   * the SAME record the run wrote to rather than creating a second one (and still
+   * yields a row to open when the user denied every save). Request shape mirrors
+   * `usePostingActions.handleTailor`, the other entry point into this record.
+   */
+  const openApplication = async () => {
+    try {
+      const res = await saveFromPosting.mutateAsync({
+        jobUrl: posting.url,
+        board: posting.source,
+        company: posting.company,
+        title: posting.title,
+        jobDescription: posting.description,
+        salaryMin: posting.salaryMin,
+        salaryMax: posting.salaryMax,
+        salaryCurrency: posting.salaryCurrency,
+      });
+      if (!res?.id) {
+        notify.error({ message: t('jobs.prep.viewApplicationError') });
+        return;
+      }
+      setOpen(false);
+      await navigate({
+        to: '/applications/$id',
+        params: { id: res.id },
+        search: { tab: 'documents', from: 'jobs' },
+      });
+    } catch {
+      notify.error({ message: t('jobs.prep.viewApplicationError') });
+    }
+  };
+
   const rows = CHECKLIST.map((item) => {
     const match = findLastMatch(steps, item);
     const isLatest = !!match && steps[steps.length - 1] === match;
@@ -324,6 +381,13 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
   const showEmpty = machineState === 'idle' && steps.length === 0;
   const showStarting = isBusy && steps.length === 0;
   const showLog = steps.length > 0;
+  // Only a run that actually COMPLETED gets the follow-through action: a stopped
+  // or failed run produces no `result`, and a `cancelled` stoppedReason means the
+  // agent never reached its proposal (`finishRun` only sets `result` on
+  // completion, so this is belt-and-suspenders against a completed-but-cancelled
+  // payload).
+  const showViewApplication =
+    machineState === 'done' && !!result && result.stoppedReason !== 'cancelled';
   const showFooter = (isBusy && !!runJobId) || canRunAgain;
 
   return (
@@ -386,12 +450,25 @@ export function PrepApplicationPanel({ posting }: { posting: Posting }) {
               )}
               {canRunAgain && (
                 <Button
-                  variant="primary"
+                  // Re-running is the secondary action once there's an
+                  // application to open — one primary per footer.
+                  variant={showViewApplication ? 'glass' : 'primary'}
                   onClick={() => void start()}
                   className="w-full justify-center gap-1.5"
                 >
                   <Sparkles size={12} />{' '}
                   {machineState === 'done' ? t('jobs.prep.runAgain') : t('jobs.prep.start')}
+                </Button>
+              )}
+              {showViewApplication && (
+                <Button
+                  variant="primary"
+                  disabled={saveFromPosting.isPending}
+                  loading={saveFromPosting.isPending}
+                  onClick={() => void openApplication()}
+                  className="w-full justify-center gap-1.5"
+                >
+                  {t('jobs.prep.viewApplication')} <ArrowRight size={12} />
                 </Button>
               )}
             </div>

--- a/apps/desktop/src/renderer/hooks/use-interview-questions.test.ts
+++ b/apps/desktop/src/renderer/hooks/use-interview-questions.test.ts
@@ -22,11 +22,12 @@ vi.mock('@/services/query-client', () => ({
 // can assert it lands on `questions`; `generateInterviewQuestions` is the seam we
 // assert the selected audiences flow into.
 vi.mock('@/lib/generate', async () => {
-  // `safeLocale` is the REAL clamp (the locales module is dependency-free) so the
-  // language default is exercised, not re-implemented by the mock.
-  const { safeLocale } = await import('@/lib/generate/locales');
+  // The REAL locale allowlist + clamp (that module is dependency-free), so the
+  // language default is exercised rather than re-implemented by the mock.
+  const { safeLocale, OUTPUT_LANGUAGES } = await import('@/lib/generate/locales');
   return {
     safeLocale,
+    OUTPUT_LANGUAGES,
     extractMetadata: vi.fn().mockResolvedValue({
       candidateName: 'Ada',
       jobTitle: 'Engineer',
@@ -73,6 +74,11 @@ const render = (p: Parameters<typeof useInterviewQuestions>[0] = params) =>
 const GERMAN_JD =
   'Wir suchen einen erfahrenen Softwareentwickler für unser Team in München. ' +
   'Sie arbeiten an spannenden Projekten und stimmen sich eng mit dem Produktteam ab.';
+
+/** Dutch — detectable by franc, but NOT one of the picker's OUTPUT_LANGUAGES. */
+const DUTCH_JD =
+  'Wij zoeken een ervaren softwareontwikkelaar voor ons team in Amsterdam. ' +
+  'Je werkt aan uitdagende projecten en stemt nauw af met het productteam.';
 
 const metaWithLanguage = (targetLanguage: string): GenerationMeta => ({
   candidateName: 'Ada',
@@ -180,7 +186,7 @@ describe('useInterviewQuestions', () => {
     expect(render({ ...params, meta: metaWithLanguage('nl') }).result.current.language).toBe('en');
   });
 
-  it('passes the chosen language to the generator and persists it as targetLanguage', async () => {
+  it('passes the chosen language to the generator WITHOUT writing it to the shared record', async () => {
     // Ad is German, so the default is 'de' — the explicit pick must win over it.
     const { result } = render({ ...params, jobDesc: GERMAN_JD });
     expect(result.current.language).toBe('de');
@@ -195,9 +201,60 @@ describe('useInterviewQuestions', () => {
     expect(generateInterviewQuestions).toHaveBeenCalledWith(
       expect.objectContaining({ language: 'es' })
     );
-    // The saved record carries the language the questions were written in, not
-    // the 'en' that extractMetadata detected.
-    expect(save).toHaveBeenCalledWith(expect.objectContaining({ targetLanguage: 'es' }));
+    // `targetLanguage` is SHARED with the email tab / export meta / tailor seed,
+    // so the picker must never write to it — the extracted value stands.
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ targetLanguage: 'en' }));
+    expect(save).not.toHaveBeenCalledWith(expect.objectContaining({ targetLanguage: 'es' }));
+  });
+
+  it('leaves the record targetLanguage alone on the untouched default path too', async () => {
+    // franc says 'de' (the ad), extractMetadata says 'en' — they disagree, and
+    // the save must still carry the EXTRACTED value while generation uses the ad's.
+    const { result } = render({ ...params, jobDesc: GERMAN_JD });
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(generateInterviewQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'de' })
+    );
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ targetLanguage: 'en' }));
+  });
+
+  it('sends a detected language the picker cannot show, without collapsing it to English', async () => {
+    const { result } = render({ ...params, jobDesc: DUTCH_JD });
+    // Dutch is not in OUTPUT_LANGUAGES, so the picker falls back to English…
+    expect(result.current.language).toBe('en');
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    // …but generation still asks for Dutch.
+    expect(generateInterviewQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'nl' })
+    );
+  });
+
+  it('omits the language entirely when nothing can be detected (prompt falls back to meta)', async () => {
+    // 'JD' is below detectLanguage's length floor → 'unknown'.
+    const { result } = render();
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(generateInterviewQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ language: undefined })
+    );
+  });
+
+  it('accepts a language NAME from extractMetadata fallback as the picker default', () => {
+    // extractMetadata's regex fallback can yield 'German' rather than 'de'.
+    expect(render({ ...params, meta: metaWithLanguage('German') }).result.current.language).toBe(
+      'de'
+    );
   });
 
   it('does not call the generator when no audience is selected', async () => {

--- a/apps/desktop/src/renderer/hooks/use-interview-questions.test.ts
+++ b/apps/desktop/src/renderer/hooks/use-interview-questions.test.ts
@@ -70,6 +70,13 @@ const wrapper = ({ children }: { children: ReactNode }) =>
 const render = (p: Parameters<typeof useInterviewQuestions>[0] = params) =>
   renderHook(() => useInterviewQuestions(p), { wrapper });
 
+/** Same, but props-driven so a test can `rerender` with different inputs. */
+const renderProps = (initialProps: Parameters<typeof useInterviewQuestions>[0]) =>
+  renderHook((p: Parameters<typeof useInterviewQuestions>[0]) => useInterviewQuestions(p), {
+    wrapper,
+    initialProps,
+  });
+
 /** Long enough for the real `detectLanguage` heuristic to settle on German. */
 const GERMAN_JD =
   'Wir suchen einen erfahrenen Softwareentwickler für unser Team in München. ' +
@@ -182,8 +189,12 @@ describe('useInterviewQuestions', () => {
     expect(result.current.language).toBe('fr');
   });
 
-  it('clamps a language outside OUTPUT_LANGUAGES to English', () => {
-    expect(render({ ...params, meta: metaWithLanguage('nl') }).result.current.language).toBe('en');
+  it('keeps a language outside OUTPUT_LANGUAGES instead of clamping it to English', () => {
+    // The picker renders it as an extra option; clamping here would make the UI
+    // claim "English" while generation produced Dutch.
+    const { result } = render({ ...params, meta: metaWithLanguage('nl') });
+    expect(result.current.language).toBe('nl');
+    expect(result.current.detectedLanguage).toBe('nl');
   });
 
   it('passes the chosen language to the generator WITHOUT writing it to the shared record', async () => {
@@ -222,24 +233,26 @@ describe('useInterviewQuestions', () => {
     expect(save).toHaveBeenCalledWith(expect.objectContaining({ targetLanguage: 'en' }));
   });
 
-  it('sends a detected language the picker cannot show, without collapsing it to English', async () => {
+  it('generates in a detected language the picker cannot name, and says so', async () => {
     const { result } = render({ ...params, jobDesc: DUTCH_JD });
-    // Dutch is not in OUTPUT_LANGUAGES, so the picker falls back to English…
-    expect(result.current.language).toBe('en');
+    // What the picker displays IS what generates — no silent "English".
+    expect(result.current.language).toBe('nl');
+    expect(result.current.detectedLanguage).toBe('nl');
 
     await act(async () => {
       await result.current.generate();
     });
 
-    // …but generation still asks for Dutch.
     expect(generateInterviewQuestions).toHaveBeenCalledWith(
       expect.objectContaining({ language: 'nl' })
     );
   });
 
   it('omits the language entirely when nothing can be detected (prompt falls back to meta)', async () => {
-    // 'JD' is below detectLanguage's length floor → 'unknown'.
+    // 'JD' is below detectLanguage's length floor → 'unknown' → '' (the picker's
+    // "match the job ad" slot), and no language on the request.
     const { result } = render();
+    expect(result.current.language).toBe('');
 
     await act(async () => {
       await result.current.generate();
@@ -255,6 +268,81 @@ describe('useInterviewQuestions', () => {
     expect(render({ ...params, meta: metaWithLanguage('German') }).result.current.language).toBe(
       'de'
     );
+  });
+
+  it('keeps an explicit pick across a jobDesc/meta change (the default must not win back)', () => {
+    const { result, rerender } = renderProps({ ...params, jobDesc: GERMAN_JD });
+    expect(result.current.language).toBe('de');
+
+    act(() => result.current.setLanguage('it'));
+    expect(result.current.language).toBe('it');
+
+    // The ad is replaced (and metadata arrives) — the derived default would now
+    // say 'nl'/'fr', but the user's choice owns the value from here on.
+    rerender({ ...params, jobDesc: DUTCH_JD, meta: metaWithLanguage('fr') });
+
+    expect(result.current.language).toBe('it');
+    expect(result.current.detectedLanguage).toBe('fr');
+  });
+
+  describe('generate() failure handling', () => {
+    it('surfaces the error message and clears the generating flag', async () => {
+      vi.mocked(generateInterviewQuestions).mockRejectedValueOnce(new Error('model exploded'));
+      const { result } = render();
+
+      await act(async () => {
+        await result.current.generate();
+      });
+
+      expect(result.current.error).toBe('model exploded');
+      expect(result.current.generating).toBe(false);
+      // A failed run must not half-populate the UI or persist anything.
+      expect(result.current.questions).toEqual([]);
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a fixed message when the rejection is not an Error', async () => {
+      vi.mocked(generateInterviewQuestions).mockRejectedValueOnce('just a string');
+      const { result } = render();
+
+      await act(async () => {
+        await result.current.generate();
+      });
+
+      expect(result.current.error).toBe('Failed to generate interview questions');
+      expect(result.current.generating).toBe(false);
+    });
+
+    it('clears a previous error when a later run succeeds', async () => {
+      vi.mocked(generateInterviewQuestions).mockRejectedValueOnce(new Error('transient'));
+      const { result } = render();
+
+      await act(async () => {
+        await result.current.generate();
+      });
+      expect(result.current.error).toBe('transient');
+
+      await act(async () => {
+        await result.current.generate();
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.questions).toHaveLength(1);
+    });
+
+    it('reports a failure raised by the persistence step, not just the generator', async () => {
+      save.mockRejectedValueOnce(new Error('disk full'));
+      const { result } = render();
+
+      await act(async () => {
+        await result.current.generate();
+      });
+
+      expect(result.current.error).toBe('disk full');
+      expect(result.current.generating).toBe(false);
+      // The questions still parsed, so the UI keeps them despite the save failing.
+      expect(result.current.questions).toHaveLength(1);
+    });
   });
 
   it('does not call the generator when no audience is selected', async () => {

--- a/apps/desktop/src/renderer/hooks/use-interview-questions.test.ts
+++ b/apps/desktop/src/renderer/hooks/use-interview-questions.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 
-import { generateInterviewQuestions } from '@/lib/generate';
+import { generateInterviewQuestions, type GenerationMeta } from '@/lib/generate';
 
 import { useInterviewQuestions } from './use-interview-questions';
 
@@ -21,23 +21,29 @@ vi.mock('@/services/query-client', () => ({
 // Stub the generation pipeline. `parseInterviewQuestions` returns a fixed set so we
 // can assert it lands on `questions`; `generateInterviewQuestions` is the seam we
 // assert the selected audiences flow into.
-vi.mock('@/lib/generate', () => ({
-  extractMetadata: vi.fn().mockResolvedValue({
-    candidateName: 'Ada',
-    jobTitle: 'Engineer',
-    companyName: 'Acme',
-    resumeLanguage: 'en',
-    jobAdLanguage: 'en',
-    mismatch: false,
-    targetLanguage: 'en',
-    topRequirements: [],
-  }),
-  researchCompany: vi.fn().mockResolvedValue('BRIEF'),
-  generateInterviewQuestions: vi.fn().mockResolvedValue('RAW'),
-  parseInterviewQuestions: vi
-    .fn()
-    .mockReturnValue([{ id: 'iq-1', question: 'Q1', why: 'because', audience: 'recruiter' }]),
-}));
+vi.mock('@/lib/generate', async () => {
+  // `safeLocale` is the REAL clamp (the locales module is dependency-free) so the
+  // language default is exercised, not re-implemented by the mock.
+  const { safeLocale } = await import('@/lib/generate/locales');
+  return {
+    safeLocale,
+    extractMetadata: vi.fn().mockResolvedValue({
+      candidateName: 'Ada',
+      jobTitle: 'Engineer',
+      companyName: 'Acme',
+      resumeLanguage: 'en',
+      jobAdLanguage: 'en',
+      mismatch: false,
+      targetLanguage: 'en',
+      topRequirements: [],
+    }),
+    researchCompany: vi.fn().mockResolvedValue('BRIEF'),
+    generateInterviewQuestions: vi.fn().mockResolvedValue('RAW'),
+    parseInterviewQuestions: vi
+      .fn()
+      .mockReturnValue([{ id: 'iq-1', question: 'Q1', why: 'because', audience: 'recruiter' }]),
+  };
+});
 
 // Active provider + Ollama web-search key — controllable so we can exercise the
 // needsResearchKey hint (Ollama-family provider without the key).
@@ -60,7 +66,24 @@ const params = {
 // a QueryClientProvider.
 const wrapper = ({ children }: { children: ReactNode }) =>
   createElement(QueryClientProvider, { client: new QueryClient() }, children);
-const render = (p = params) => renderHook(() => useInterviewQuestions(p), { wrapper });
+const render = (p: Parameters<typeof useInterviewQuestions>[0] = params) =>
+  renderHook(() => useInterviewQuestions(p), { wrapper });
+
+/** Long enough for the real `detectLanguage` heuristic to settle on German. */
+const GERMAN_JD =
+  'Wir suchen einen erfahrenen Softwareentwickler für unser Team in München. ' +
+  'Sie arbeiten an spannenden Projekten und stimmen sich eng mit dem Produktteam ab.';
+
+const metaWithLanguage = (targetLanguage: string): GenerationMeta => ({
+  candidateName: 'Ada',
+  jobTitle: 'Engineer',
+  companyName: 'Acme',
+  resumeLanguage: 'en',
+  jobAdLanguage: targetLanguage,
+  mismatch: false,
+  targetLanguage,
+  topRequirements: [],
+});
 
 describe('useInterviewQuestions', () => {
   beforeEach(() => {
@@ -141,6 +164,40 @@ describe('useInterviewQuestions', () => {
     mockProvider = 'ollama';
     mockHasOllamaKey = true;
     expect(render().result.current.needsResearchKey).toBe(false);
+  });
+
+  it('defaults the output language to the one detected from the job description', () => {
+    expect(render({ ...params, jobDesc: GERMAN_JD }).result.current.language).toBe('de');
+  });
+
+  it('prefers an already-detected meta.targetLanguage over re-detecting the ad', () => {
+    // German ad text, but the tailor flow already resolved the target as French.
+    const { result } = render({ ...params, jobDesc: GERMAN_JD, meta: metaWithLanguage('fr') });
+    expect(result.current.language).toBe('fr');
+  });
+
+  it('clamps a language outside OUTPUT_LANGUAGES to English', () => {
+    expect(render({ ...params, meta: metaWithLanguage('nl') }).result.current.language).toBe('en');
+  });
+
+  it('passes the chosen language to the generator and persists it as targetLanguage', async () => {
+    // Ad is German, so the default is 'de' — the explicit pick must win over it.
+    const { result } = render({ ...params, jobDesc: GERMAN_JD });
+    expect(result.current.language).toBe('de');
+
+    act(() => result.current.setLanguage('es'));
+    expect(result.current.language).toBe('es');
+
+    await act(async () => {
+      await result.current.generate();
+    });
+
+    expect(generateInterviewQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'es' })
+    );
+    // The saved record carries the language the questions were written in, not
+    // the 'en' that extractMetadata detected.
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ targetLanguage: 'es' }));
   });
 
   it('does not call the generator when no audience is selected', async () => {

--- a/apps/desktop/src/renderer/hooks/use-interview-questions.ts
+++ b/apps/desktop/src/renderer/hooks/use-interview-questions.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { detectLanguage, type InterviewQuestion } from '@ajh/shared';
@@ -12,7 +12,6 @@ import {
   OUTPUT_LANGUAGES,
   parseInterviewQuestions,
   researchCompany as fetchCompanyBrief,
-  safeLocale,
 } from '@/lib/generate';
 import { useAppClient } from '@/providers/AppClientProvider';
 import { useHasProviderKey } from '@/services';
@@ -23,13 +22,23 @@ import type { AiProvider } from '@/store/preferences-schema';
 const DEFAULT_AUDIENCES = ['recruiter', 'hiringManager'];
 
 /**
- * Locale CODE the picker can display. Accepts a code ('de') OR an English
- * language NAME ('German') — `extractMetadata`'s regex fallback can produce
- * either — and clamps anything outside OUTPUT_LANGUAGES to English.
+ * Normalize a detected language to a locale CODE. Accepts a code ('de') OR an
+ * English language NAME ('German') — `extractMetadata`'s regex fallback can
+ * produce either. `'unknown'` (detectLanguage's sentinel) and blanks become `''`,
+ * meaning "not determined": the picker then shows its auto option and the prompt
+ * falls back to its `meta`-derived language note.
+ *
+ * Deliberately NOT clamped to OUTPUT_LANGUAGES — a language the picker doesn't
+ * offer (Dutch, Polish, Czech…) must survive to both the prompt and the picker
+ * label, or the UI would read "English" while generating Dutch.
  */
-function toPickerCode(value: string): string {
-  const byName = OUTPUT_LANGUAGES.find((l) => l.englishName.toLowerCase() === value.toLowerCase());
-  return safeLocale(byName?.code ?? value);
+function toLanguageCode(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'unknown') return '';
+  const byName = OUTPUT_LANGUAGES.find(
+    (l) => l.englishName.toLowerCase() === trimmed.toLowerCase()
+  );
+  return byName?.code ?? trimmed;
 }
 
 interface Params {
@@ -83,19 +92,18 @@ export function useInterviewQuestions({
   const [error, setError] = useState<string | null>(null);
   // Output language. Derived during render (no effect) so the default keeps
   // tracking the ad as `jobDesc`/`meta` load in; the user's explicit pick then
-  // wins for good. TWO values on purpose:
-  //  - `language` is what the picker DISPLAYS, so it must be an OUTPUT_LANGUAGES
-  //    code the Dropdown can render.
-  //  - `generationLanguage` is what the prompt gets. Until the user picks, it is
-  //    the RAW detected language, so an ad in a language the picker doesn't offer
-  //    (Dutch, Polish, Czech…) still yields questions in that language instead of
-  //    collapsing to English. `undefined` when nothing was detected — the prompt
-  //    then falls back to its `meta`-derived note.
+  // wins for good. ONE effective value — what the picker shows IS what generates
+  // (the UI adds an option for `detectedLanguage` when it isn't one of the
+  // picker's own, so a Dutch ad reads as "Dutch", never as "English").
+  // `''` means "not determined": the prompt then falls back to its `meta` note.
   const [languageOverride, setLanguageOverride] = useState<string | null>(null);
-  const detectedLanguage = meta?.targetLanguage?.trim() || detectLanguage(jobDesc);
-  const language = languageOverride ?? toPickerCode(detectedLanguage);
-  const generationLanguage =
-    languageOverride ?? (detectedLanguage === 'unknown' ? undefined : detectedLanguage);
+  // franc is not free, and this hook re-renders on every seed-topics keystroke.
+  const detectedLanguage = useMemo(
+    () => toLanguageCode(meta?.targetLanguage ?? '') || toLanguageCode(detectLanguage(jobDesc)),
+    [meta?.targetLanguage, jobDesc]
+  );
+  const language = languageOverride ?? detectedLanguage;
+  const generationLanguage = language || undefined;
 
   const toggleAudience = (aud: string) =>
     setAudiences((prev) => (prev.includes(aud) ? prev.filter((a) => a !== aud) : [...prev, aud]));
@@ -175,6 +183,9 @@ export function useInterviewQuestions({
     seedTopics,
     setSeedTopics,
     language,
+    /** The ad's own language (`''` when undetermined) — the UI offers it as an
+     *  option when the picker's list doesn't already contain it. */
+    detectedLanguage,
     setLanguage: setLanguageOverride,
     audiences,
     toggleAudience,

--- a/apps/desktop/src/renderer/hooks/use-interview-questions.ts
+++ b/apps/desktop/src/renderer/hooks/use-interview-questions.ts
@@ -9,6 +9,7 @@ import {
   extractMetadata,
   generateInterviewQuestions,
   type GenerationMeta,
+  OUTPUT_LANGUAGES,
   parseInterviewQuestions,
   researchCompany as fetchCompanyBrief,
   safeLocale,
@@ -20,6 +21,16 @@ import type { AiProvider } from '@/store/preferences-schema';
 
 /** Default target interviewers — the two earliest rounds (recruiter/HR + hiring manager). */
 const DEFAULT_AUDIENCES = ['recruiter', 'hiringManager'];
+
+/**
+ * Locale CODE the picker can display. Accepts a code ('de') OR an English
+ * language NAME ('German') — `extractMetadata`'s regex fallback can produce
+ * either — and clamps anything outside OUTPUT_LANGUAGES to English.
+ */
+function toPickerCode(value: string): string {
+  const byName = OUTPUT_LANGUAGES.find((l) => l.englishName.toLowerCase() === value.toLowerCase());
+  return safeLocale(byName?.code ?? value);
+}
 
 interface Params {
   resume: string;
@@ -46,8 +57,9 @@ interface Params {
  * per-job aiGenerations aggregate (merge-upsert by `jobUrl`).
  *
  * The output `language` defaults to the ad's language (from `meta` when given,
- * else detected from `jobDesc`) and is user-overridable via `setLanguage`; the
- * chosen code is what gets persisted as the record's `targetLanguage`.
+ * else detected from `jobDesc`) and is user-overridable via `setLanguage`. It is
+ * generation-only: the persisted record keeps the DETECTED `targetLanguage`,
+ * because that field is shared with the email/export/tailor surfaces.
  */
 export function useInterviewQuestions({
   resume,
@@ -69,12 +81,21 @@ export function useInterviewQuestions({
   const [questions, setQuestions] = useState<InterviewQuestion[]>([]);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Output language, as a locale CODE ('en', 'de', …) matching an OUTPUT_LANGUAGES
-  // entry. Derived during render (no effect) so the default keeps tracking the ad
-  // as `jobDesc`/`meta` load in; the user's explicit pick then wins for good.
-  // `safeLocale` clamps an unsupported/undetected language to 'en'.
+  // Output language. Derived during render (no effect) so the default keeps
+  // tracking the ad as `jobDesc`/`meta` load in; the user's explicit pick then
+  // wins for good. TWO values on purpose:
+  //  - `language` is what the picker DISPLAYS, so it must be an OUTPUT_LANGUAGES
+  //    code the Dropdown can render.
+  //  - `generationLanguage` is what the prompt gets. Until the user picks, it is
+  //    the RAW detected language, so an ad in a language the picker doesn't offer
+  //    (Dutch, Polish, Czech…) still yields questions in that language instead of
+  //    collapsing to English. `undefined` when nothing was detected — the prompt
+  //    then falls back to its `meta`-derived note.
   const [languageOverride, setLanguageOverride] = useState<string | null>(null);
-  const language = languageOverride ?? safeLocale(meta?.targetLanguage || detectLanguage(jobDesc));
+  const detectedLanguage = meta?.targetLanguage?.trim() || detectLanguage(jobDesc);
+  const language = languageOverride ?? toPickerCode(detectedLanguage);
+  const generationLanguage =
+    languageOverride ?? (detectedLanguage === 'unknown' ? undefined : detectedLanguage);
 
   const toggleAudience = (aud: string) =>
     setAudiences((prev) => (prev.includes(aud) ? prev.filter((a) => a !== aud) : [...prev, aud]));
@@ -111,7 +132,7 @@ export function useInterviewQuestions({
         companyBrief: brief,
         seedTopics: seeds,
         audiences,
-        language,
+        language: generationLanguage,
       });
       const parsed = parseInterviewQuestions(raw);
       setQuestions(parsed);
@@ -124,9 +145,12 @@ export function useInterviewQuestions({
         companyName: detected.companyName,
         resumeLanguage: detected.resumeLanguage,
         jobAdLanguage: detected.jobAdLanguage,
-        // The language the questions were actually written in — the user's pick,
-        // not the detected one, so the saved record matches what it holds.
-        targetLanguage: language,
+        // NOT the picked language. `targetLanguage` is a SHARED field on the
+        // per-job aggregate (the Rust merge is a non-blank-wins `pick`), read by
+        // the email tab, the export meta and the tailor seed — writing the
+        // questions' output language here would silently switch the email draft
+        // and the export header. The pick stays generation-only.
+        targetLanguage: detected.targetLanguage,
         mismatch: detected.mismatch,
         topRequirements: detected.topRequirements,
         mode: 'ats',

--- a/apps/desktop/src/renderer/hooks/use-interview-questions.ts
+++ b/apps/desktop/src/renderer/hooks/use-interview-questions.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
-import type { InterviewQuestion } from '@ajh/shared';
+import { detectLanguage, type InterviewQuestion } from '@ajh/shared';
 
 import { useSelectedProvider } from '@/components/ui/ModelSelector';
 import { isOllamaFamily } from '@/lib/ai-providers/provider-meta';
@@ -11,6 +11,7 @@ import {
   type GenerationMeta,
   parseInterviewQuestions,
   researchCompany as fetchCompanyBrief,
+  safeLocale,
 } from '@/lib/generate';
 import { useAppClient } from '@/providers/AppClientProvider';
 import { useHasProviderKey } from '@/services';
@@ -43,6 +44,10 @@ interface Params {
  * layer (ADR-010). Detects metadata once (reusing the tailor flow's when given),
  * generates the delimited list, parses it leniently, then persists onto the
  * per-job aiGenerations aggregate (merge-upsert by `jobUrl`).
+ *
+ * The output `language` defaults to the ad's language (from `meta` when given,
+ * else detected from `jobDesc`) and is user-overridable via `setLanguage`; the
+ * chosen code is what gets persisted as the record's `targetLanguage`.
  */
 export function useInterviewQuestions({
   resume,
@@ -64,6 +69,12 @@ export function useInterviewQuestions({
   const [questions, setQuestions] = useState<InterviewQuestion[]>([]);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Output language, as a locale CODE ('en', 'de', …) matching an OUTPUT_LANGUAGES
+  // entry. Derived during render (no effect) so the default keeps tracking the ad
+  // as `jobDesc`/`meta` load in; the user's explicit pick then wins for good.
+  // `safeLocale` clamps an unsupported/undetected language to 'en'.
+  const [languageOverride, setLanguageOverride] = useState<string | null>(null);
+  const language = languageOverride ?? safeLocale(meta?.targetLanguage || detectLanguage(jobDesc));
 
   const toggleAudience = (aud: string) =>
     setAudiences((prev) => (prev.includes(aud) ? prev.filter((a) => a !== aud) : [...prev, aud]));
@@ -100,6 +111,7 @@ export function useInterviewQuestions({
         companyBrief: brief,
         seedTopics: seeds,
         audiences,
+        language,
       });
       const parsed = parseInterviewQuestions(raw);
       setQuestions(parsed);
@@ -112,7 +124,9 @@ export function useInterviewQuestions({
         companyName: detected.companyName,
         resumeLanguage: detected.resumeLanguage,
         jobAdLanguage: detected.jobAdLanguage,
-        targetLanguage: detected.targetLanguage,
+        // The language the questions were actually written in — the user's pick,
+        // not the detected one, so the saved record matches what it holds.
+        targetLanguage: language,
         mismatch: detected.mismatch,
         topRequirements: detected.topRequirements,
         mode: 'ats',
@@ -136,6 +150,8 @@ export function useInterviewQuestions({
   return {
     seedTopics,
     setSeedTopics,
+    language,
+    setLanguage: setLanguageOverride,
     audiences,
     toggleAudience,
     questions,

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.test.ts
@@ -12,6 +12,7 @@ import {
   generateApplicationAnswer,
   generateCoverLetter,
   generateGitHubProjects,
+  generateInterviewQuestions,
   generateResume,
   lookupSalaryRange,
   researchAnswer,
@@ -1048,5 +1049,66 @@ describe('output tone wiring (Settings → Output Tone)', () => {
     done();
     await p;
     expect(systemOf(client)).toMatch(/TONE: polished, warm, and professional/);
+  });
+});
+
+describe('generateInterviewQuestions output language', () => {
+  // The grounded user prompt is always messages[1] (see streamGenerate).
+  const userOf = (client: ReturnType<typeof register>) => {
+    const call = (client.ai.generatePipeline as ReturnType<typeof vi.fn>).mock.calls[0];
+    const messages = (call?.[0] as { messages: { role: string; content: string }[] }).messages;
+    return messages[1]?.content ?? '';
+  };
+
+  // A GERMAN job (jobCountry DE) whose ad language is German — so a language
+  // override can be seen NOT to drag the market register with it.
+  const DE_META = {
+    resumeLanguage: 'en',
+    jobAdLanguage: 'de',
+    mismatch: false,
+    candidateName: 'X',
+    jobTitle: 'Y',
+    companyName: 'Z',
+    targetLanguage: 'de',
+    jobCountry: 'DE',
+    topRequirements: [],
+  };
+
+  const run = async (language?: string) => {
+    const client = register();
+    const p = generateInterviewQuestions({
+      resume: 'My resume',
+      jobAd: 'Backend role at Acme',
+      meta: DE_META,
+      model: 'llama3',
+      language,
+    });
+    await flushUntilStreaming();
+    emit('Q: Anything?\nWHY: because\nAUDIENCE: recruiter');
+    done();
+    await p;
+    return client;
+  };
+
+  it('resolves an allowlisted picker code to its English language name', async () => {
+    expect(userOf(await run('es'))).toContain('Write the questions entirely in Spanish');
+  });
+
+  it('keeps the market register on the job country when only the language changes', async () => {
+    const prompt = userOf(await run('es'));
+    expect(prompt).toContain('Write the questions entirely in Spanish');
+    // Register still follows the German job market, not the Spanish output.
+    expect(prompt).toMatch(/Market: Germany/);
+  });
+
+  it('passes a language outside the picker allowlist through verbatim (no English collapse)', async () => {
+    const prompt = userOf(await run('nl'));
+    expect(prompt).toContain('Write the questions entirely in nl');
+    expect(prompt).not.toContain('entirely in English');
+  });
+
+  it('falls back to the meta-derived language note when no language is given', async () => {
+    const prompt = userOf(await run());
+    expect(prompt).toContain('Write the questions in de.');
   });
 });

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.test.ts
@@ -1053,12 +1053,14 @@ describe('output tone wiring (Settings → Output Tone)', () => {
 });
 
 describe('generateInterviewQuestions output language', () => {
-  // The grounded user prompt is always messages[1] (see streamGenerate).
-  const userOf = (client: ReturnType<typeof register>) => {
+  // System prompt is messages[0], the grounded user prompt messages[1].
+  const messageAt = (client: ReturnType<typeof register>, index: number) => {
     const call = (client.ai.generatePipeline as ReturnType<typeof vi.fn>).mock.calls[0];
     const messages = (call?.[0] as { messages: { role: string; content: string }[] }).messages;
-    return messages[1]?.content ?? '';
+    return messages[index]?.content ?? '';
   };
+  const systemOf = (client: ReturnType<typeof register>) => messageAt(client, 0);
+  const userOf = (client: ReturnType<typeof register>) => messageAt(client, 1);
 
   // A GERMAN job (jobCountry DE) whose ad language is German — so a language
   // override can be seen NOT to drag the market register with it.
@@ -1101,14 +1103,38 @@ describe('generateInterviewQuestions output language', () => {
     expect(prompt).toMatch(/Market: Germany/);
   });
 
-  it('passes a language outside the picker allowlist through verbatim (no English collapse)', async () => {
+  it('names a language outside the picker allowlist instead of emitting a bare ISO code', async () => {
     const prompt = userOf(await run('nl'));
-    expect(prompt).toContain('Write the questions entirely in nl');
+    expect(prompt).toContain('Write the questions entirely in Dutch');
+    expect(prompt).not.toContain('entirely in nl');
     expect(prompt).not.toContain('entirely in English');
   });
 
   it('falls back to the meta-derived language note when no language is given', async () => {
     const prompt = userOf(await run());
     expect(prompt).toContain('Write the questions in de.');
+  });
+
+  it('selects the anti-AI-tell lexicon for the picked language, not the ad language', async () => {
+    // German ad, Spanish output → the tell-list must follow the OUTPUT language.
+    const system = systemOf(await run('es'));
+    expect(system).toMatch(/Spanish/);
+  });
+
+  it('falls back to the ad language for the lexicon when nothing is picked', async () => {
+    // meta.targetLanguage is 'de', and German has a curated tell-list.
+    expect(systemOf(await run())).not.toBe(systemOf(await run('en')));
+  });
+
+  it('sends the output language as the request locale', async () => {
+    const localeOf = (client: ReturnType<typeof register>) => {
+      const call = (client.ai.generatePipeline as ReturnType<typeof vi.fn>).mock.calls[0];
+      return (call?.[0] as { locale: string }).locale;
+    };
+    expect(localeOf(await run('es'))).toBe('es');
+    // Unsupported locales clamp (safeLocale) rather than reaching the backend raw.
+    expect(localeOf(await run('nl'))).toBe('en');
+    // No pick → the ad's language.
+    expect(localeOf(await run())).toBe('de');
   });
 });

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -619,6 +619,10 @@ export async function generateInterviewQuestions(params: {
   seedTopics?: string[];
   /** Target interviewers (canonical audience ids) — N questions per audience. */
   audiences?: string[];
+  /** Output-language CODE ('de', 'es', …) chosen by the user; overrides
+   *  `meta.targetLanguage`. Deliberately does NOT feed `resolveMarket` — the
+   *  register stays that of the job's country even when only the language changes. */
+  language?: string;
   signal?: AbortSignal;
   onToken?: (tok: string) => void;
 }): Promise<string> {
@@ -630,6 +634,7 @@ export async function generateInterviewQuestions(params: {
     companyBrief = '',
     seedTopics = [],
     audiences = [],
+    language,
     signal,
     onToken,
   } = params;
@@ -638,6 +643,10 @@ export async function generateInterviewQuestions(params: {
     jobCountry: meta.jobCountry,
     targetLanguage: meta.targetLanguage,
   });
+  // Same contract as generateJobAdSummary: the picker hands over a locale CODE,
+  // the prompt wants a human language NAME and streamGenerate wants the code.
+  // Resolving through OUTPUT_LANGUAGES keeps an arbitrary string out of the prompt.
+  const lang = language ? OUTPUT_LANGUAGES.find((l) => l.code === language) : undefined;
 
   const system = buildInterviewQuestionsSystemPrompt();
   const user = buildInterviewQuestionsPrompt({
@@ -649,6 +658,7 @@ export async function generateInterviewQuestions(params: {
     audiences,
     target: profile,
     market,
+    language: lang?.englishName,
   });
   // Interview questions are prose: keep the existing 0.5 temperature default,
   // adding only the shared detector-resistance penalty set (see PROSE_SAMPLING).
@@ -659,7 +669,7 @@ export async function generateInterviewQuestions(params: {
     user,
     onToken ?? (() => {}),
     sampling.temperature,
-    meta.targetLanguage || 'en',
+    lang?.code ?? (meta.targetLanguage || 'en'),
     signal,
     undefined,
     sampling

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -619,9 +619,11 @@ export async function generateInterviewQuestions(params: {
   seedTopics?: string[];
   /** Target interviewers (canonical audience ids) — N questions per audience. */
   audiences?: string[];
-  /** Output-language CODE ('de', 'es', …) chosen by the user; overrides
-   *  `meta.targetLanguage`. Deliberately does NOT feed `resolveMarket` — the
-   *  register stays that of the job's country even when only the language changes. */
+  /** Output language: a locale CODE ('de', 'es', …) when it came from the picker,
+   *  otherwise whatever the ad detection produced (a code outside the picker's
+   *  allowlist, or a language NAME). Overrides `meta.targetLanguage`, and
+   *  deliberately does NOT feed `resolveMarket` — the register stays that of the
+   *  job's country even when only the output language changes. */
   language?: string;
   signal?: AbortSignal;
   onToken?: (tok: string) => void;
@@ -643,10 +645,13 @@ export async function generateInterviewQuestions(params: {
     jobCountry: meta.jobCountry,
     targetLanguage: meta.targetLanguage,
   });
-  // Same contract as generateJobAdSummary: the picker hands over a locale CODE,
-  // the prompt wants a human language NAME and streamGenerate wants the code.
-  // Resolving through OUTPUT_LANGUAGES keeps an arbitrary string out of the prompt.
+  // The prompt wants a human language NAME, streamGenerate wants a locale code.
+  // An allowlisted picker code resolves to its English name; anything else (a
+  // detected language the picker doesn't offer, e.g. 'nl') is interpolated
+  // verbatim rather than collapsed to English — the same treatment the prompt
+  // already gives `meta.targetLanguage`, so this adds no new interpolation surface.
   const lang = language ? OUTPUT_LANGUAGES.find((l) => l.code === language) : undefined;
+  const languageName = lang?.englishName ?? language;
 
   const system = buildInterviewQuestionsSystemPrompt();
   const user = buildInterviewQuestionsPrompt({
@@ -658,7 +663,7 @@ export async function generateInterviewQuestions(params: {
     audiences,
     target: profile,
     market,
-    language: lang?.englishName,
+    language: languageName,
   });
   // Interview questions are prose: keep the existing 0.5 temperature default,
   // adding only the shared detector-resistance penalty set (see PROSE_SAMPLING).

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -50,7 +50,7 @@ import {
   validateMetadata,
 } from '@ajh/prompts/generate';
 import type { GitHubRepo } from '@ajh/shared';
-import { detectLanguages } from '@ajh/shared/language-detection';
+import { detectLanguages, getLanguageName } from '@ajh/shared/language-detection';
 
 import { usePreferencesStore } from '@/store/preferences-store';
 
@@ -647,13 +647,16 @@ export async function generateInterviewQuestions(params: {
   });
   // The prompt wants a human language NAME, streamGenerate wants a locale code.
   // An allowlisted picker code resolves to its English name; anything else (a
-  // detected language the picker doesn't offer, e.g. 'nl') is interpolated
-  // verbatim rather than collapsed to English — the same treatment the prompt
-  // already gives `meta.targetLanguage`, so this adds no new interpolation surface.
+  // detected language the picker doesn't offer, e.g. 'nl') goes through
+  // `getLanguageName` — 28 codes, degrading to the code itself — rather than
+  // being collapsed to English or interpolated as a bare ISO code.
   const lang = language ? OUTPUT_LANGUAGES.find((l) => l.code === language) : undefined;
-  const languageName = lang?.englishName ?? language;
+  const languageName = lang?.englishName ?? (language ? getLanguageName(language) : undefined);
+  // The anti-AI-tell lexicon is per-language: without this, questions written in
+  // German were still policed by the English tell-list.
+  const languageCode = lang?.code ?? language ?? meta.targetLanguage;
 
-  const system = buildInterviewQuestionsSystemPrompt();
+  const system = buildInterviewQuestionsSystemPrompt(languageCode);
   const user = buildInterviewQuestionsPrompt({
     resume,
     jobAd,
@@ -674,7 +677,9 @@ export async function generateInterviewQuestions(params: {
     user,
     onToken ?? (() => {}),
     sampling.temperature,
-    lang?.code ?? (meta.targetLanguage || 'en'),
+    // Same code the lexicon uses; `streamGenerate` clamps it via `safeLocale`,
+    // so a language outside the supported set falls back to 'en' here only.
+    languageCode || 'en',
     signal,
     undefined,
     sampling

--- a/packages/prompts/src/generate/interview-questions/interview-questions.test.ts
+++ b/packages/prompts/src/generate/interview-questions/interview-questions.test.ts
@@ -42,6 +42,21 @@ describe('buildInterviewQuestionsSystemPrompt', () => {
   it('carries the positive HUMANIZE_PROSE cadence anchor (candidate voice, not just bans)', () => {
     expect(buildInterviewQuestionsSystemPrompt()).toContain('CADENCE');
   });
+
+  it('selects the anti-AI-tell ruleset for the output language, not always English', () => {
+    const en = buildInterviewQuestionsSystemPrompt('en');
+    const de = buildInterviewQuestionsSystemPrompt('de');
+    const nl = buildInterviewQuestionsSystemPrompt('nl');
+
+    // German questions policed by the English tell-list was the bug.
+    expect(de).not.toBe(en);
+    expect(de).toBe(buildInterviewQuestionsSystemPrompt('de'));
+    // A language with no curated list still gets its own generic ruleset.
+    expect(nl).not.toBe(en);
+    expect(nl).toMatch(/Dutch/);
+    // No argument keeps the previous English default.
+    expect(buildInterviewQuestionsSystemPrompt()).toBe(en);
+  });
 });
 
 describe('buildInterviewQuestionsPrompt', () => {

--- a/packages/prompts/src/generate/interview-questions/interview-questions.test.ts
+++ b/packages/prompts/src/generate/interview-questions/interview-questions.test.ts
@@ -146,6 +146,18 @@ describe('buildInterviewQuestionsPrompt', () => {
     expect(prompt).toContain('Write the questions in de.');
   });
 
+  // Both meta branches stay LIVE: the caller omits `language` whenever the ad's
+  // language can't be determined, and `mismatch` still selects the firmer phrasing.
+  it('uses the firmer mismatch phrasing when no explicit language is given', () => {
+    const prompt = buildInterviewQuestionsPrompt({
+      resume: 'R',
+      jobAd: 'JD',
+      meta: { ...META, mismatch: true, targetLanguage: 'de' },
+    });
+    expect(prompt).toContain('Write the questions entirely in de');
+    expect(prompt).not.toContain('Write the questions in de.');
+  });
+
   it('an explicit language overrides meta.targetLanguage without touching the market register', () => {
     const prompt = buildInterviewQuestionsPrompt({
       resume: 'R',

--- a/packages/prompts/src/generate/interview-questions/interview-questions.test.ts
+++ b/packages/prompts/src/generate/interview-questions/interview-questions.test.ts
@@ -136,4 +136,38 @@ describe('buildInterviewQuestionsPrompt', () => {
     const prompt = buildInterviewQuestionsPrompt({ resume: 'R', jobAd: 'JD', meta: META });
     expect(prompt).toContain('JD');
   });
+
+  it('writes in meta.targetLanguage when no explicit language is given', () => {
+    const prompt = buildInterviewQuestionsPrompt({
+      resume: 'R',
+      jobAd: 'JD',
+      meta: { ...META, targetLanguage: 'de' },
+    });
+    expect(prompt).toContain('Write the questions in de.');
+  });
+
+  it('an explicit language overrides meta.targetLanguage without touching the market register', () => {
+    const prompt = buildInterviewQuestionsPrompt({
+      resume: 'R',
+      jobAd: 'JD',
+      meta: { ...META, targetLanguage: 'de' },
+      market: 'de',
+      language: 'Spanish',
+    });
+    expect(prompt).toContain('Write the questions entirely in Spanish');
+    expect(prompt).not.toContain('Write the questions in de.');
+    // Register still follows the job's market, not the output language.
+    expect(prompt).toMatch(/Market: Germany/i);
+  });
+
+  it('an explicit language wins over the meta.mismatch phrasing', () => {
+    const prompt = buildInterviewQuestionsPrompt({
+      resume: 'R',
+      jobAd: 'JD',
+      meta: { ...META, mismatch: true, targetLanguage: 'de' },
+      language: 'French',
+    });
+    expect(prompt).toContain('Write the questions entirely in French');
+    expect(prompt).not.toContain('entirely in de');
+  });
 });

--- a/packages/prompts/src/generate/interview-questions/interview-questions.ts
+++ b/packages/prompts/src/generate/interview-questions/interview-questions.ts
@@ -106,6 +106,10 @@ export function buildInterviewQuestionsPrompt(params: {
   target?: PromptTarget;
   /** Resolved job-market id (see `resolveMarket`) — drives register. */
   market?: string;
+  /** Explicit output-language NAME ('German', 'Spanish', …) the user picked. When
+   *  set it overrides the `meta`-derived language instruction; `market` is
+   *  unaffected, so the register stays that of the job's country. */
+  language?: string;
 }): string {
   const {
     resume,
@@ -118,6 +122,7 @@ export function buildInterviewQuestionsPrompt(params: {
     count = INTERVIEW_QUESTIONS_COUNT,
     target = 'large',
     market = 'intl',
+    language,
   } = params;
 
   // Keep only canonical audience ids, in their canonical display order.
@@ -132,9 +137,13 @@ export function buildInterviewQuestionsPrompt(params: {
     : '';
 
   const conv = letterConventions(market);
-  const langNote = meta.mismatch
-    ? `Write the questions entirely in ${meta.targetLanguage}, using natural phrasing for that market.`
-    : `Write the questions in ${meta.targetLanguage || 'en'}.`;
+  // An explicit `language` is a deliberate user choice, so it wins over the
+  // `meta.mismatch` proxy (which only guesses that the ad and résumé disagree).
+  const langNote = language
+    ? `Write the questions entirely in ${language}, using natural phrasing for that market.`
+    : meta.mismatch
+      ? `Write the questions entirely in ${meta.targetLanguage}, using natural phrasing for that market.`
+      : `Write the questions in ${meta.targetLanguage || 'en'}.`;
   const marketNote = `Market: ${conv.country}. Register: ${conv.formality}. Match this market's professional conventions.`;
 
   // Audience-targeted mode (N per interviewer, each tuned to its lens) vs the

--- a/packages/prompts/src/generate/interview-questions/interview-questions.ts
+++ b/packages/prompts/src/generate/interview-questions/interview-questions.ts
@@ -59,8 +59,14 @@ const AUDIENCE_FOCUS: Record<InterviewAudience, string> = {
 /** The per-item delimited markers the model must emit and the client parses. */
 export const INTERVIEW_QUESTION_MARKERS = { question: 'Q:', why: 'WHY:', audience: 'AUDIENCE:' };
 
-/** System prompt — the quality bar for questions that land positively. */
-export function buildInterviewQuestionsSystemPrompt(): string {
+/**
+ * System prompt — the quality bar for questions that land positively.
+ * `language` (ISO-639-1, e.g. the picked output language or `meta.targetLanguage`)
+ * selects the anti-AI-tell ruleset (see {@link antiAiTellProse}); defaults to
+ * English. Without it, questions written in German were still policed by the
+ * English tell-list.
+ */
+export function buildInterviewQuestionsSystemPrompt(language?: string): string {
   return `You are helping a job candidate prepare SHARP questions to ASK their interviewer.
 
 GOAL: questions that leave a strong positive impression — each one signals genuine interest, real research, and seniority, and opens a substantive conversation.
@@ -79,7 +85,7 @@ Q: <the question, a single sentence>
 WHY: <one short line: what asking it signals / why it lands>
 AUDIENCE: <recruiter | hiringManager | team | leadership | general>
 
-${antiAiTellProse()}
+${antiAiTellProse(language)}
 ${HUMANIZE_PROSE}`;
 }
 

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2627,6 +2627,7 @@
         "needsJob": "Für passende Fragen wird eine Stellenbeschreibung benötigt.",
         "audienceLabel": "Fragen generieren für",
         "languageLabel": "Sprache der Fragen",
+        "languageAuto": "Sprache der Stellenanzeige",
         "audience": {
           "recruiter": "Recruiter / HR (1. Runde)",
           "hiringManager": "Hiring Manager",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1799,7 +1799,9 @@
         "propose": "Nächster Schritt wird vorgeschlagen"
       },
       "proposalTitle": "Vorgeschlagener nächster Schritt",
-      "proposalHint": "Momentan nur zur Anzeige — es wird nichts automatisch übernommen.",
+      "proposalHint": "Es wird nichts automatisch abgeschickt oder übernommen. Alles, was du während des Laufs genehmigt hast, ist in dieser Bewerbung gespeichert.",
+      "viewApplication": "Bewerbung ansehen",
+      "viewApplicationError": "Die Bewerbung konnte nicht geöffnet werden. Bitte erneut versuchen.",
       "stopped": {
         "done": "Abgeschlossen",
         "truncated": "Vorzeitig gestoppt — Ausgabe wurde gekürzt",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2581,7 +2581,7 @@
         "needsJob": "Für die E-Mail-Generierung wird eine Stellenbeschreibung benötigt.",
         "subjectLabel": "Betreff",
         "bodyLabel": "Inhalt",
-        "copy": "Kopieren",
+        "copy": "Inhalt kopieren",
         "copied": "Kopiert!",
         "copySubject": "Betreff kopieren",
         "rewrite": "Mit KI umschreiben",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2624,6 +2624,7 @@
         "needsModel": "Wähle in den Einstellungen ein KI-Modell, um Fragen zu generieren.",
         "needsJob": "Für passende Fragen wird eine Stellenbeschreibung benötigt.",
         "audienceLabel": "Fragen generieren für",
+        "languageLabel": "Sprache der Fragen",
         "audience": {
           "recruiter": "Recruiter / HR (1. Runde)",
           "hiringManager": "Hiring Manager",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2623,6 +2623,7 @@
         "needsJob": "A job description is needed to tailor the questions.",
         "audienceLabel": "Generate questions for",
         "languageLabel": "Question language",
+        "languageAuto": "Match the job ad",
         "audience": {
           "recruiter": "Recruiter / HR (1st round)",
           "hiringManager": "Hiring manager",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2577,7 +2577,7 @@
         "needsJob": "A job description is needed to generate the email.",
         "subjectLabel": "Subject",
         "bodyLabel": "Body",
-        "copy": "Copy",
+        "copy": "Copy body",
         "copied": "Copied!",
         "copySubject": "Copy subject",
         "rewrite": "Rewrite with AI",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2620,6 +2620,7 @@
         "needsModel": "Select an AI model in settings to generate questions.",
         "needsJob": "A job description is needed to tailor the questions.",
         "audienceLabel": "Generate questions for",
+        "languageLabel": "Question language",
         "audience": {
           "recruiter": "Recruiter / HR (1st round)",
           "hiringManager": "Hiring manager",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1795,7 +1795,9 @@
         "propose": "Proposing next step"
       },
       "proposalTitle": "Proposed next step",
-      "proposalHint": "Display-only for now — nothing is applied automatically.",
+      "proposalHint": "Nothing is submitted or applied automatically. Anything you approved during the run is saved on this application.",
+      "viewApplication": "View application",
+      "viewApplicationError": "Couldn't open the application. Please try again.",
       "stopped": {
         "done": "Completed",
         "truncated": "Stopped early — output was truncated",


### PR DESCRIPTION
- Copy under the email body now copies the body only (subject keeps its own copy button); label clarified to "Copy body"/"Inhalt kopieren"
- interview questions gained a language selector (11 languages, endonym dropdown); the chosen language drives generation while the market register stays keyed to the job country; unlisted detected languages (nl, pl, …) pass through verbatim instead of collapsing to English
- the "Prep this application" flow now ends with a "View application" button deep-linking to the created application (idempotent by job url; no JD overwrite on the view path)
- review-guarded: the picked language is generation-only — the shared aggregate targetLanguage (read by the email draft + export header) is never clobbered

Review: frontend-author → frontend-reviewer (1 HIGH + 3 MEDIUM found and fixed). Validation: 4119 tests; typecheck 13/13; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
