### PR TITLE
fix: match attribute-only and hyphenated name fields in autofill

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -35,6 +35,8 @@ The desktop half (bridge server, parser, Applications store) lives in `apps/desk
 5. Desktop receives frame → fetches/parses job → creates saved Application
 ```
 
+**Known limit — assisted autofill fills the TOP-LEVEL document only.** The filler is injected without `allFrames`, so a form rendered inside an `<iframe>` (a Greenhouse/Lever/Ashby form embedded on a company careers page) is not filled — open the form on the ATS's own page and fill it there. Reaching those frames is not a flag flip: they are cross-origin, so it would require `host_permissions` for every ATS origin — far beyond the `activeTab`-scoped access this extension asks for (see "Permissions — minimal & justified") — plus cross-frame merging of the fill summary. Under-filling is the intended trade.
+
 **Rate budget:** extension imports share the desktop's scrape rate budget (30 requests/min, 2 concurrent). This is the same budget as the in-app scrape commands; a rate-limited import returns an error in the popup rather than silently queuing. See `apps/desktop/src-tauri/src/limits/mod.rs` (`SCRAPE_RATE_MAX` / `SCRAPE_CONCURRENCY_MAX`) and the `handle_import` function in `apps/desktop/src-tauri/src/extension_bridge/mod.rs`.
 
 ---

--- a/apps/extension/src/lib/answers-capture.test.ts
+++ b/apps/extension/src/lib/answers-capture.test.ts
@@ -94,6 +94,28 @@ describe('collectAnswers — disabled / readonly fields are not answers', () => 
     expect(collectAnswers(document)).toEqual([]);
   });
 
+  it('leaves a readonly field out of the REWRITE scan, and unlocatable for rewriting', () => {
+    // The rewrite path (`collectFilledFields` → `locateFilledField`) is the one
+    // that would hand readonly boilerplate back as an editable "answer".
+    setForm(`
+      <label for="ro2">Standard terms</label><textarea id="ro2" readonly>Boilerplate text.</textarea>
+      <label for="ans">Why this role?</label><input id="ans" type="text" value="Because I love it." />
+    `);
+    expect(collectFilledFields(document)).toEqual([
+      { question: 'Why this role?', index: 0, answer: 'Because I love it.' },
+    ]);
+    expect(locateFilledField(document, 'Standard terms', 0, 1)).toBeNull();
+  });
+
+  it('skips a disabled <select> (the :disabled half applies to selects too)', () => {
+    setForm(`
+      <label for="sel">Work authorization</label>
+      <select id="sel" disabled><option value="yes" selected>Yes</option></select>
+    `);
+    expect(collectAnswers(document)).toEqual([]);
+    expect(hasAnswerCapturableFields(document)).toBe(false);
+  });
+
   it('leaves a readonly field out of the QUESTIONS scan too', () => {
     setForm(`
       <label for="ro">Posting id</label><input id="ro" type="text" readonly />

--- a/apps/extension/src/lib/answers-capture.test.ts
+++ b/apps/extension/src/lib/answers-capture.test.ts
@@ -72,6 +72,37 @@ describe('collectAnswers — textarea', () => {
   });
 });
 
+describe('collectAnswers — disabled / readonly fields are not answers', () => {
+  it('skips a readonly textarea (boilerplate) and a disabled input', () => {
+    // Mirrors autofill's `isCandidateField` gate — fill and capture must agree
+    // on what counts as a real, user-editable field.
+    setForm(`
+      <label for="terms">Terms</label><textarea id="terms" readonly>Standard terms apply.</textarea>
+      <label for="ref">Requisition</label><input id="ref" type="text" value="REQ-1" disabled />
+      <label for="q">Why this role?</label><input id="q" type="text" value="Because I love it." />
+    `);
+    expect(collectAnswers(document)).toEqual([
+      { question: 'Why this role?', answer: 'Because I love it.' },
+    ]);
+  });
+
+  it('skips a field disabled by an ancestor <fieldset disabled>', () => {
+    setForm(`
+      <fieldset disabled>
+        <label for="d">Notice period</label><input id="d" type="text" value="2 weeks" />
+      </fieldset>`);
+    expect(collectAnswers(document)).toEqual([]);
+  });
+
+  it('leaves a readonly field out of the QUESTIONS scan too', () => {
+    setForm(`
+      <label for="ro">Posting id</label><input id="ro" type="text" readonly />
+      <label for="open">Why this role?</label><input id="open" type="text" />
+    `);
+    expect(collectQuestions(document)).toEqual([{ question: 'Why this role?', index: 0 }]);
+  });
+});
+
 describe('collectAnswers — select captures the visible option text, not the value', () => {
   it("captures the selected option's displayed text", () => {
     setForm(`

--- a/apps/extension/src/lib/answers-capture.ts
+++ b/apps/extension/src/lib/answers-capture.ts
@@ -73,6 +73,14 @@ const CAPTURABLE_INPUT_TYPES = new Set(['text', '']);
  *  `Application.answers`. */
 function isCapturable(el: HTMLElement): boolean {
   if (isHidden(el)) return false;
+  // Mirrors autofill's `isCandidateField` gate (see this module's no-drift
+  // contract in `field-signal.ts`): a `disabled`/`readonly` field is not
+  // something the user answered — a readonly textarea is boilerplate (terms,
+  // a pre-filled job description), and a disabled one is not submitted at all,
+  // so neither belongs in `Application.answers` nor in the questions scan.
+  if (el.matches(':disabled')) return false;
+  if ((el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) && el.readOnly)
+    return false;
   if (matchAutocompleteKey(autocompleteToken(el)) !== null) return false;
   const signal = textSignal(el);
   if (isAmbiguousSignal(signal)) return false;

--- a/apps/extension/src/lib/answers-capture.ts
+++ b/apps/extension/src/lib/answers-capture.ts
@@ -22,6 +22,7 @@
  */
 
 import {
+  attributeSignal,
   autocompleteToken,
   isAmbiguousSignal,
   isHidden,
@@ -84,7 +85,7 @@ function isCapturable(el: HTMLElement): boolean {
   if (matchAutocompleteKey(autocompleteToken(el)) !== null) return false;
   const signal = textSignal(el);
   if (isAmbiguousSignal(signal)) return false;
-  return matchNamedKey(signal) === null;
+  return matchNamedKey(signal, attributeSignal(el)) === null;
 }
 
 /** The selected option's VISIBLE text (not its `value` attribute) — per the

--- a/apps/extension/src/lib/autofill.test.ts
+++ b/apps/extension/src/lib/autofill.test.ts
@@ -292,6 +292,122 @@ describe('planAndFill – name-split flag', () => {
   });
 });
 
+describe('planAndFill – attribute-only name fields (no "first name" phrase anywhere)', () => {
+  it('fills separate first/last boxes from underscore / camelCase / abbreviated NAME attributes', () => {
+    // The overwhelmingly common real-world shape: no <label>, no autocomplete —
+    // just a `name` attribute. All of these used to resolve to null (nothing
+    // filled at all) because the patterns required a literal space.
+    setForm(`
+      <input id="a" name="first_name" />
+      <input id="b" name="last_name" />
+      <input id="c" name="firstName" />
+      <input id="d" name="lastName" />
+      <input id="e" name="fname" />
+      <input id="f" name="lname" />
+      <input id="g" name="job_application[first_name]" />
+      <input id="h" name="job_application[last_name]" />
+    `);
+
+    const summary = planAndFill(document, PROFILE);
+
+    for (const id of ['a', 'c', 'e', 'g']) expect(val(id), id).toBe('Saeed');
+    for (const id of ['b', 'd', 'f', 'h']) expect(val(id), id).toBe('Kolivand');
+    expect(summary.nameSplit).toEqual({ first: 'Saeed', last: 'Kolivand' });
+  });
+
+  it('regression: HYPHENATED first/last fields no longer BOTH receive the full name', () => {
+    // `-` is not a word character, so these matched the generic `\bname\b`
+    // catch-all: "Saeed Kolivand" was written into every one of them, silently.
+    setForm(`
+      <input id="fn" name="first-name" />
+      <input id="gn" name="given-name" />
+      <input id="ln" name="last-name" />
+      <input id="famn" name="family-name" />
+    `);
+
+    planAndFill(document, PROFILE);
+
+    expect(val('fn')).toBe('Saeed');
+    expect(val('gn')).toBe('Saeed');
+    expect(val('ln')).toBe('Kolivand');
+    expect(val('famn')).toBe('Kolivand');
+  });
+
+  it('still refuses a username / user_name login field', () => {
+    setForm(`
+      <input id="u1" name="username" />
+      <input id="u2" name="user_name" />
+      <input id="u3" name="fullName" />
+    `);
+
+    planAndFill(document, PROFILE);
+
+    expect(val('u1')).toBe('');
+    expect(val('u2')).toBe('');
+    // …while the full-name attribute spelling next to them still fills.
+    expect(val('u3')).toBe('Saeed Kolivand');
+  });
+});
+
+describe('planAndFill – aria-labelledby labels (Workday / Ashby)', () => {
+  it('resolves an aria-labelledby id LIST into the field signal', () => {
+    setForm(`
+      <div id="lbl-first">First name</div>
+      <input id="wf" aria-labelledby="lbl-first" />
+      <div id="lbl-email">Email address</div>
+      <div id="lbl-req">(required)</div>
+      <input id="we" type="email" aria-labelledby="lbl-email lbl-req" />
+    `);
+
+    planAndFill(document, PROFILE);
+
+    expect(val('wf')).toBe('Saeed');
+    expect(val('we')).toBe('saeed@example.com');
+  });
+
+  it('ignores an aria-labelledby that points at a missing id', () => {
+    setForm(`<input id="ghost" aria-labelledby="does-not-exist" />`);
+    planAndFill(document, PROFILE);
+    expect(val('ghost')).toBe('');
+  });
+
+  it('applies the ambiguous denylist to an aria-labelledby label too', () => {
+    setForm(`
+      <div id="lbl-emg">Emergency contact phone</div>
+      <input id="emg" type="tel" aria-labelledby="lbl-emg" />
+    `);
+    planAndFill(document, PROFILE);
+    expect(val('emg')).toBe('');
+  });
+});
+
+describe('planAndFill – disabled / readonly fields', () => {
+  it('never writes into a disabled or readonly field', () => {
+    setForm(`
+      <label for="d1">Email</label><input id="d1" type="email" disabled />
+      <label for="r1">Full name</label><input id="r1" type="text" readonly />
+      <label for="ok1">Phone number</label><input id="ok1" type="tel" />
+    `);
+
+    const summary = planAndFill(document, PROFILE);
+
+    expect(val('d1')).toBe('');
+    expect(val('r1')).toBe('');
+    // Guard against a false positive: a normal sibling still fills, and the
+    // summary counts ONLY what was really written.
+    expect(val('ok1')).toBe('+31612345678');
+    expect(summary.filled.map((f) => f.key)).toEqual(['phone']);
+  });
+
+  it('does not report a page of only disabled/readonly fields as autofillable', () => {
+    setForm(`
+      <label for="d2">Email</label><input id="d2" type="email" disabled />
+      <label for="r2">First name</label><input id="r2" type="text" readonly />
+    `);
+    expect(hasAutofillableFields(document)).toBe(false);
+  });
+});
+
 describe('planAndFill – filled-nothing', () => {
   it('reports filledNothing when no field matches', () => {
     setForm(`

--- a/apps/extension/src/lib/autofill.test.ts
+++ b/apps/extension/src/lib/autofill.test.ts
@@ -420,6 +420,24 @@ describe('planAndFill – aria-labelledby labels (Workday / Ashby)', () => {
     expect(val('we')).toBe('saeed@example.com');
   });
 
+  it('fills the WHOLE name into a single box placeheld "First and Last Name"', () => {
+    // Prose names both halves; only the field's own ATTRIBUTE may veto the
+    // fullName row. Reading the placeholder as attribute-style evidence made
+    // this box fall through to lastName and receive just "Kolivand".
+    setForm(`
+      <label for="fn1">Full Name</label>
+      <input id="fn1" placeholder="First and Last Name" />
+      <label for="fn2">First and Last Name</label><input id="fn2" />
+      <input id="fn3" aria-label="First &amp; last name" />
+    `);
+
+    planAndFill(document, PROFILE);
+
+    expect(val('fn1')).toBe('Saeed Kolivand');
+    expect(val('fn2')).toBe('Saeed Kolivand');
+    expect(val('fn3')).toBe('Saeed Kolivand');
+  });
+
   it("lets each box's own attribute win over a shared 'Full Name' GROUP label", () => {
     // Workday/Ashby point every box of a group at one heading, so "Full Name"
     // reaches the first/last inputs' signals — and the fullName row runs first.

--- a/apps/extension/src/lib/autofill.test.ts
+++ b/apps/extension/src/lib/autofill.test.ts
@@ -333,6 +333,61 @@ describe('planAndFill – attribute-only name fields (no "first name" phrase any
     expect(val('famn')).toBe('Kolivand');
   });
 
+  it("never writes the user's name into a THIRD PARTY's name box", () => {
+    // The attribute spellings out-ran the denylist, which is prose-shaped
+    // (`AMBIGUOUS`) or leading-anchored (`AMBIGUOUS_PREFIXED`) — so every box
+    // below silently received the applicant's own name.
+    setForm(`
+      <input id="t1" name="professionalReferenceFirstName" />
+      <input id="t2" name="jobReferenceFirstName" />
+      <input id="t3" name="myReferrerFirstName" />
+      <input id="t4" name="spouseFirstName" />
+      <input id="t5" name="dependentLastName" />
+      <input id="t6" name="beneficiaryFirstName" />
+      <input id="t7" name="previousLastName" />
+      <input id="t8" name="aka_first_name" />
+      <input id="t9" name="childFirstName" />
+      <input id="t10" name="otherLastName" />
+    `);
+
+    const summary = planAndFill(document, PROFILE);
+
+    for (let i = 1; i <= 10; i += 1) expect(val(`t${i}`), `t${i}`).toBe('');
+    expect(summary.filledNothing).toBe(true);
+  });
+
+  it('skips a middle-name box instead of giving it the full name', () => {
+    // There is no middleName in the profile; `middle-name` used to reach the
+    // bare-"name" catch-all and receive "Saeed Kolivand".
+    setForm(`
+      <input id="m1" name="first-name" />
+      <input id="m2" name="middle-name" />
+      <input id="m3" name="middle_name" />
+      <input id="m4" name="last-name" />
+    `);
+
+    planAndFill(document, PROFILE);
+
+    expect(val('m1')).toBe('Saeed');
+    expect(val('m2')).toBe('');
+    expect(val('m3')).toBe('');
+    expect(val('m4')).toBe('Kolivand');
+  });
+
+  it('does not let the fullName attribute spellings escape the school/company denylist', () => {
+    setForm(`
+      <input id="s1" name="school_full_name" />
+      <input id="s2" name="universityFullName" />
+      <input id="s3" name="degreeFullName" />
+      <input id="s4" name="courseFullName" />
+    `);
+    planAndFill(document, PROFILE);
+    expect(val('s1')).toBe('');
+    expect(val('s2')).toBe('');
+    expect(val('s3')).toBe('');
+    expect(val('s4')).toBe('');
+  });
+
   it('still refuses a username / user_name login field', () => {
     setForm(`
       <input id="u1" name="username" />
@@ -363,6 +418,21 @@ describe('planAndFill – aria-labelledby labels (Workday / Ashby)', () => {
 
     expect(val('wf')).toBe('Saeed');
     expect(val('we')).toBe('saeed@example.com');
+  });
+
+  it("lets each box's own attribute win over a shared 'Full Name' GROUP label", () => {
+    // Workday/Ashby point every box of a group at one heading, so "Full Name"
+    // reaches the first/last inputs' signals — and the fullName row runs first.
+    setForm(`
+      <span id="grp">Full Name</span>
+      <input id="gf" name="first_name" aria-labelledby="grp" />
+      <input id="gl" name="last_name" aria-labelledby="grp" />
+    `);
+
+    planAndFill(document, PROFILE);
+
+    expect(val('gf')).toBe('Saeed');
+    expect(val('gl')).toBe('Kolivand');
   });
 
   it('ignores an aria-labelledby that points at a missing id', () => {
@@ -396,6 +466,25 @@ describe('planAndFill – disabled / readonly fields', () => {
     // Guard against a false positive: a normal sibling still fills, and the
     // summary counts ONLY what was really written.
     expect(val('ok1')).toBe('+31612345678');
+    expect(summary.filled.map((f) => f.key)).toEqual(['phone']);
+  });
+
+  it('skips a field disabled by an ancestor <fieldset disabled>', () => {
+    // `el.disabled` reflects only the element's OWN attribute, so the property
+    // check alone would fill (and count) a whole disabled section.
+    setForm(`
+      <fieldset disabled>
+        <label for="fs1">Email</label><input id="fs1" type="email" />
+        <input id="fs2" name="first_name" />
+      </fieldset>
+      <label for="live">Phone number</label><input id="live" type="tel" />
+    `);
+
+    const summary = planAndFill(document, PROFILE);
+
+    expect(val('fs1')).toBe('');
+    expect(val('fs2')).toBe('');
+    expect(val('live')).toBe('+31612345678');
     expect(summary.filled.map((f) => f.key)).toEqual(['phone']);
   });
 

--- a/apps/extension/src/lib/autofill.ts
+++ b/apps/extension/src/lib/autofill.ts
@@ -22,6 +22,7 @@
  */
 
 import {
+  attributeSignal,
   autocompleteToken,
   isAmbiguousSignal,
   isHidden,
@@ -167,8 +168,10 @@ function matchFieldKey(el: HTMLInputElement): string | null {
   if (tier1) return tier1;
 
   // ── Tier 2: unambiguous free-text signal (shared with answers-capture's
-  // exclude-identity-fields check — see `matchNamedKey`) ────────────────────
-  return matchNamedKey(signal);
+  // exclude-identity-fields check — see `matchNamedKey`). The field's own
+  // ATTRIBUTE signal goes along separately so a group label in the prose can't
+  // out-vote it (see `attributeSignal`). ────────────────────────────────────
+  return matchNamedKey(signal, attributeSignal(el));
 }
 
 /**

--- a/apps/extension/src/lib/autofill.ts
+++ b/apps/extension/src/lib/autofill.ts
@@ -122,13 +122,21 @@ export function splitName(fullName: string): { first: string; last: string } {
 }
 
 /**
- * The baseline gate shared by every fill tier: a fillable input TYPE, visible,
- * empty, not a card/password autocomplete token, and not matching the ambiguous/
- * sensitive denylist ({@link isAmbiguousSignal}). Extracted so the extra-link
- * matcher (Tier 2) applies the exact same discipline as the named-key matcher below.
+ * The baseline gate shared by every fill tier: a fillable input TYPE, writable
+ * (not `disabled`/`readonly`), visible, empty, not a card/password autocomplete
+ * token, and not matching the ambiguous/sensitive denylist
+ * ({@link isAmbiguousSignal}). Extracted so the extra-link matcher (Tier 2)
+ * applies the exact same discipline as the named-key matcher below.
  */
 function isCandidateField(el: HTMLInputElement): boolean {
   if (!FILLABLE_TYPES.has(el.type)) return false;
+  // A `disabled`/`readonly` field is one the page has declared un-editable: a
+  // disabled input is never even submitted, and writing to a readonly one (via
+  // the native setter, which bypasses the UI guard) puts a value where the user
+  // cannot correct it — and would then be COUNTED in the summary as filled,
+  // making the report a lie. Both are checked before the layout-free visibility
+  // walk because they are single property reads.
+  if (el.disabled || el.readOnly) return false;
   if (isHidden(el)) return false;
   if (el.value.trim() !== '') return false; // never overwrite
 

--- a/apps/extension/src/lib/autofill.ts
+++ b/apps/extension/src/lib/autofill.ts
@@ -134,9 +134,11 @@ function isCandidateField(el: HTMLInputElement): boolean {
   // disabled input is never even submitted, and writing to a readonly one (via
   // the native setter, which bypasses the UI guard) puts a value where the user
   // cannot correct it — and would then be COUNTED in the summary as filled,
-  // making the report a lie. Both are checked before the layout-free visibility
-  // walk because they are single property reads.
-  if (el.disabled || el.readOnly) return false;
+  // making the report a lie. `:disabled` rather than the `disabled` property so
+  // the check also covers a field disabled by an ancestor `<fieldset disabled>`
+  // (the property reflects only the element's OWN attribute) — ATS forms disable
+  // whole sections that way, and those fields are just as unsubmittable.
+  if (el.matches(':disabled') || el.readOnly) return false;
   if (isHidden(el)) return false;
   if (el.value.trim() !== '') return false; // never overwrite
 

--- a/apps/extension/src/lib/field-signal.test.ts
+++ b/apps/extension/src/lib/field-signal.test.ts
@@ -10,9 +10,9 @@
  * a visibly wrong box, which they may not notice and cannot undo.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { isAmbiguousSignal, matchNamedKey } from './field-signal';
+import { isAmbiguousSignal, labelText, matchNamedKey } from './field-signal';
 
 describe('isAmbiguousSignal', () => {
   it('still skips the genuinely ambiguous / sensitive fields', () => {
@@ -58,6 +58,77 @@ describe('isAmbiguousSignal', () => {
     // "Preferred first name" is ubiquitous on ATS forms; once it is no longer
     // treated as ambiguous it fills as a first name.
     expect(matchNamedKey('preferred first name')).toBe('firstName');
+  });
+});
+
+describe('isAmbiguousSignal — third-party / non-fillable name COMPOUNDS', () => {
+  it('skips a name that belongs to someone else — in attribute spellings too', () => {
+    // The denylist is prose-shaped (`AMBIGUOUS`) or leading-anchored
+    // (`AMBIGUOUS_PREFIXED`), so once the name patterns learned the attribute
+    // spellings, every camelCase third-party box below started receiving the
+    // USER's name. Skipping is the only correct answer for all of them.
+    for (const signal of [
+      'professionalreferencefirstname',
+      'jobreferencefirstname',
+      'proreferencelastname',
+      'workreferencelastname',
+      'myreferrerfirstname',
+      'staffreferralfirstname',
+      'refereelastname',
+      'spousefirstname',
+      'childfirstname',
+      'dependentlastname',
+      'beneficiaryfirstname',
+      'previouslastname',
+      'formerfirstname',
+      'otherlastname',
+      'aka_first_name',
+      // Already denied before this rule (leading-anchored / prose) — pinned so
+      // the compound rule can never be "simplified" into losing them.
+      'reference_first_name',
+      'references[0][first_name]',
+      'referencefirstname',
+      'emergencycontactfirstname',
+      'mothers_maiden_name',
+    ]) {
+      expect(isAmbiguousSignal(signal), signal).toBe(true);
+    }
+  });
+
+  it('skips the name parts we hold no profile value for (middle / additional / kana)', () => {
+    // There is no middleName key in the profile, so the ONLY safe outcome is a
+    // skip — a hyphenated `middle-name` used to reach the bare-name catch-all
+    // and receive the full name.
+    for (const signal of [
+      'middle name',
+      'middlename',
+      'middle_name',
+      'middle-name',
+      'middleinitial name',
+      'additional name',
+      'lastnamekana',
+      'name_kana',
+      'furigana',
+    ]) {
+      expect(isAmbiguousSignal(signal), signal).toBe(true);
+    }
+  });
+
+  it('still lets the preferred/research/preferences family through (the `referr` ⊂ "preferred" trap)', () => {
+    for (const signal of [
+      'preferred first name',
+      'preferred_first_name',
+      'preferredfirstname',
+      'preferred name',
+      'preferred pronouns',
+      'work preferences',
+      'research experience',
+      'notification preferences',
+    ]) {
+      expect(isAmbiguousSignal(signal), signal).toBe(false);
+    }
+    // …and the camelCase spelling resolves like the prose one.
+    expect(matchNamedKey('preferredfirstname')).toBe('firstName');
   });
 });
 
@@ -251,5 +322,75 @@ describe('matchNamedKey — first / last name', () => {
     ]) {
       expect(matchNamedKey(signal), signal).toBeNull();
     }
+  });
+
+  it('applies the school/company denylist to the fullName ATTRIBUTE spellings too', () => {
+    // The row-level `deny` exists for exactly this: the prose spelling
+    // ("University Name") has always been refused by the catch-all's denylist,
+    // but `university_full_name` matched the fullName row BEFORE the catch-all
+    // ever ran, so it escaped — and received the applicant's name.
+    for (const signal of [
+      'school_full_name',
+      'university_full_name',
+      'college_full_name',
+      'institution_full_name',
+      'program_full_name',
+      'course_full_name',
+      'schoolfullname',
+      'universityfullname',
+      'degreefullname',
+      'certificationfullname',
+      'coursefullname',
+      'majorfullname',
+    ]) {
+      expect(matchNamedKey(signal), signal).toBeNull();
+    }
+  });
+
+  it("lets a field's own first/last attribute out-specify a 'Full Name' GROUP label", () => {
+    // Workday/Ashby wire a group heading to each box via aria-labelledby, so
+    // "full name" lands in the signal of a `first_name` input — and the fullName
+    // row runs first, which put the WHOLE name in the first-name box.
+    expect(matchNamedKey('first_name full name')).toBe('firstName');
+    expect(matchNamedKey('last_name full name')).toBe('lastName');
+    expect(matchNamedKey('lname full name')).toBe('lastName');
+    // A real full-name field is unaffected…
+    expect(matchNamedKey('fullname full name')).toBe('fullName');
+    // …and so are the localized COMBINED phrases (they carry no first/last
+    // attribute token, only prose).
+    expect(matchNamedKey('vor- und nachname')).toBe('fullName');
+    expect(matchNamedKey('nombre y apellidos')).toBe('fullName');
+    expect(matchNamedKey('nome e cognome')).toBe('fullName');
+    expect(matchNamedKey('voor- en achternaam')).toBe('fullName');
+  });
+});
+
+describe('labelText', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('counts a label referenced BOTH by for= and aria-labelledby only once', () => {
+    // The React-Aria / headless-UI shape. `answers-capture` persists this string
+    // as the question key, so a duplicated label duplicates the stored question.
+    document.body.innerHTML = `
+      <label for="q" id="q-label">Why this role?</label>
+      <input id="q" aria-labelledby="q-label" />`;
+    const el = document.getElementById('q') as HTMLInputElement;
+    expect(labelText(el).trim()).toBe('Why this role?');
+  });
+
+  it('joins DISTINCT aria-labelledby references in order, after the <label>', () => {
+    document.body.innerHTML = `
+      <span id="g">Contact</span><span id="h">Email address</span>
+      <input id="e" aria-labelledby="g h" />`;
+    const el = document.getElementById('e') as HTMLInputElement;
+    expect(labelText(el).trim()).toBe('Contact Email address');
+  });
+
+  it('counts a wrapping label that also carries for= only once', () => {
+    document.body.innerHTML = `<label for="w">Notice period<input id="w" /></label>`;
+    const el = document.getElementById('w') as HTMLInputElement;
+    expect(labelText(el).trim()).toBe('Notice period');
   });
 });

--- a/apps/extension/src/lib/field-signal.test.ts
+++ b/apps/extension/src/lib/field-signal.test.ts
@@ -85,6 +85,13 @@ describe('isAmbiguousSignal — third-party / non-fillable name COMPOUNDS', () =
       'aka_first_name',
       'alsoknownasfirstname',
       'also_known_as_last_name',
+      // Taleo's `nm` abbreviation — the deny patterns end `n(?:ame|m)` for
+      // exactly these, and the name PATTERNS match them, so both halves must
+      // agree or a third party's `…Nm` box gets filled.
+      'spousefirstnm',
+      'referencelastnm',
+      'dependentlastnm',
+      'beneficiaryfirstnm',
       // A leading `[^p]` character guard (the first attempt at exempting
       // "preferred") silently exempted EVERY p-terminated prefix — these are
       // ordinary HRIS spellings and each one was filled with the user's name.
@@ -374,13 +381,31 @@ describe('matchNamedKey — first / last name', () => {
     }
   });
 
-  it("lets a field's own first/last attribute out-specify a 'Full Name' GROUP label", () => {
+  it('keeps a single box that asks for BOTH halves on fullName', () => {
+    // Prose freely names both halves of a name; the `lastName` row's `last name`
+    // matches such a label, so without the conjunction forms (and with the
+    // first/last veto reading prose) the box received only the surname.
+    for (const signal of [
+      'first and last name',
+      'first & last name',
+      'first/last name',
+      'first name and last name',
+      'full name first and last name', // label + placeholder, as one signal
+    ]) {
+      expect(matchNamedKey(signal, ''), signal).toBe('fullName');
+    }
+  });
+
+  it("lets a field's own first/last ATTRIBUTE out-specify a 'Full Name' GROUP label", () => {
     // Workday/Ashby wire a group heading to each box via aria-labelledby, so
     // "full name" lands in the signal of a `first_name` input — and the fullName
-    // row runs first, which put the WHOLE name in the first-name box.
-    expect(matchNamedKey('first_name full name')).toBe('firstName');
-    expect(matchNamedKey('last_name full name')).toBe('lastName');
-    expect(matchNamedKey('lname full name')).toBe('lastName');
+    // row runs first, which put the WHOLE name in the first-name box. The veto
+    // reads the ATTRIBUTE signal (2nd arg), never the prose.
+    expect(matchNamedKey('first_name full name', 'first_name')).toBe('firstName');
+    expect(matchNamedKey('last_name full name', 'last_name')).toBe('lastName');
+    expect(matchNamedKey('lname full name', 'lname')).toBe('lastName');
+    // …and the SAME prose with no first/last attribute stays a full-name field.
+    expect(matchNamedKey('full name first and last name', 'candidate_name')).toBe('fullName');
     // A real full-name field is unaffected…
     expect(matchNamedKey('fullname full name')).toBe('fullName');
     // …and so are the localized COMBINED phrases (they carry no first/last
@@ -419,5 +444,23 @@ describe('labelText', () => {
     document.body.innerHTML = `<label for="w">Notice period<input id="w" /></label>`;
     const el = document.getElementById('w') as HTMLInputElement;
     expect(labelText(el).trim()).toBe('Notice period');
+  });
+
+  it('collapses the markup whitespace inside a label', () => {
+    // The question text is persisted + sent over the bridge, so the same
+    // question must not key differently because of source indentation.
+    document.body.innerHTML = `
+      <label for="m">Why
+          this     role?</label><input id="m" />`;
+    const el = document.getElementById('m') as HTMLInputElement;
+    expect(labelText(el).trim()).toBe('Why this role?');
+  });
+
+  it('caps an aria-labelledby reference that points at a whole container', () => {
+    document.body.innerHTML = `
+      <div id="card">${'very long boilerplate '.repeat(60)}</div>
+      <input id="c" aria-labelledby="card" />`;
+    const el = document.getElementById('c') as HTMLInputElement;
+    expect(labelText(el).length).toBeLessThanOrEqual(310);
   });
 });

--- a/apps/extension/src/lib/field-signal.test.ts
+++ b/apps/extension/src/lib/field-signal.test.ts
@@ -83,6 +83,21 @@ describe('isAmbiguousSignal — third-party / non-fillable name COMPOUNDS', () =
       'formerfirstname',
       'otherlastname',
       'aka_first_name',
+      'alsoknownasfirstname',
+      'also_known_as_last_name',
+      // A leading `[^p]` character guard (the first attempt at exempting
+      // "preferred") silently exempted EVERY p-terminated prefix — these are
+      // ordinary HRIS spellings and each one was filled with the user's name.
+      'topreferencefirstname',
+      'groupreferencefirstname',
+      'helpreferencefirstname',
+      'backupreferencefirstname',
+      'signupreferencefirstname',
+      'stepreferencefirstname',
+      'shipreferencefirstname',
+      'campreferencefirstname',
+      'vipreferencefirstname',
+      'empreferencefirstname',
       // Already denied before this rule (leading-anchored / prose) — pinned so
       // the compound rule can never be "simplified" into losing them.
       'reference_first_name',
@@ -106,8 +121,12 @@ describe('isAmbiguousSignal — third-party / non-fillable name COMPOUNDS', () =
       'middle-name',
       'middleinitial name',
       'additional name',
+      // The kana reading appears on BOTH sides of the name token.
       'lastnamekana',
       'name_kana',
+      'kana_last_name',
+      'kanalastname',
+      'furigana_first_name',
       'furigana',
     ]) {
       expect(isAmbiguousSignal(signal), signal).toBe(true);
@@ -129,6 +148,14 @@ describe('isAmbiguousSignal — third-party / non-fillable name COMPOUNDS', () =
     }
     // …and the camelCase spelling resolves like the prose one.
     expect(matchNamedKey('preferredfirstname')).toBe('firstName');
+    // The exemption covers ONLY the reference family, so a "preferred" that
+    // sits next to another skip-stem does not un-deny the field.
+    expect(isAmbiguousSignal('preferred middle name')).toBe(true);
+    expect(isAmbiguousSignal('preferredspousefirstname')).toBe(true);
+    // Documented collateral: "…dPreferred…" and "…pReference…" are spelled
+    // alike apart from the word boundary, so the camelCase preferred-name field
+    // is skipped rather than risk filling a reference's box.
+    expect(isAmbiguousSignal('candidatepreferredfirstname')).toBe(true);
   });
 });
 

--- a/apps/extension/src/lib/field-signal.test.ts
+++ b/apps/extension/src/lib/field-signal.test.ts
@@ -141,3 +141,115 @@ describe('matchNamedKey — location', () => {
     }
   });
 });
+
+describe('matchNamedKey — first / last name', () => {
+  it('matches the attribute spellings of a first-name field, not just the "first name" phrase', () => {
+    for (const signal of [
+      'first name',
+      // camelCase `firstName` flattens to `firstname` in the lowercased signal.
+      'firstname',
+      'first_name',
+      'first-name',
+      'job_application[first_name]', // Greenhouse
+      'fname',
+      'fname_1',
+      'first_nm', // Taleo
+      'firstnm',
+      'given name',
+      'given-name',
+      'givenname',
+      'forename',
+      'candidate_first_name',
+      // No separator at all before `first` (camelCase `applicantFirstName`) —
+      // these patterns are deliberately NOT leading-anchored (nothing collides).
+      'applicantfirstname',
+      'preferred first name',
+      'vorname',
+      'prenom',
+    ]) {
+      expect(matchNamedKey(signal), signal).toBe('firstName');
+    }
+  });
+
+  it('matches the attribute spellings of a last-name field', () => {
+    for (const signal of [
+      'last name',
+      'lastname',
+      'last_name',
+      'last-name',
+      'job_application[last_name]', // Greenhouse
+      'lname',
+      'lnameinput',
+      'last_nm',
+      'lastnm',
+      'family name',
+      'family-name',
+      'familyname',
+      'surname',
+      'candidate_last_name',
+      'applicantlastname',
+      'nachname',
+      'nazwisko',
+    ]) {
+      expect(matchNamedKey(signal), signal).toBe('lastName');
+    }
+  });
+
+  it('regression: a HYPHENATED first/last field no longer falls through to the bare-name catch-all', () => {
+    // `-` is not a word character, so `first-name` / `family-name` used to match
+    // the generic `\bname\b` catch-all and receive the FULL name in BOTH boxes —
+    // a silent mis-fill, the one failure mode this module exists to prevent.
+    expect(matchNamedKey('first-name')).toBe('firstName');
+    expect(matchNamedKey('given-name')).toBe('firstName');
+    expect(matchNamedKey('last-name')).toBe('lastName');
+    expect(matchNamedKey('family-name')).toBe('lastName');
+  });
+
+  it('keeps full-name fields on fullName — including the attribute spellings', () => {
+    for (const signal of [
+      'full name',
+      'fullname',
+      'full_name',
+      'full-name',
+      'candidatefullname',
+      // The bare-"name" catch-all is unchanged and still runs LAST.
+      'name',
+      'your name',
+      'vollstandiger name',
+      'nombre completo',
+      'imie i nazwisko',
+    ]) {
+      expect(matchNamedKey(signal), signal).toBe('fullName');
+    }
+  });
+
+  it('does not let `lname` claim `fullname` (ordering + leading anchor)', () => {
+    // `lname` ⊂ "fu**llname**": unanchored it would turn every `fullName` field
+    // into a lastName one.
+    expect(matchNamedKey('fullname')).toBe('fullName');
+    expect(matchNamedKey('candidate_fullname')).toBe('fullName');
+  });
+
+  it('never routes a username-family / non-person "name" field to a person key', () => {
+    // `username`/`user name` are stopped by the denylist BEFORE matchNamedKey
+    // runs (both autofill's `isCandidateField` and capture's `isCapturable`
+    // check it first) …
+    expect(isAmbiguousSignal('username')).toBe(true);
+    expect(isAmbiguousSignal('user name')).toBe(true);
+    // … and matchNamedKey itself must refuse them too, so widening the name
+    // patterns can never write the user's name into a login field.
+    for (const signal of [
+      'username',
+      'user name',
+      'user_name',
+      'nickname',
+      'display name',
+      'file name',
+      'screen name',
+      'school name',
+      'university name',
+    ]) {
+      expect(matchNamedKey(signal), signal).toBeNull();
+    }
+  });
+});

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -219,9 +219,20 @@ function escapeId(id: string): string {
 }
 
 /** The associated label text for a form element: `<label for>` + any wrapping
- *  `<label>`. Takes `HTMLElement` (not just `HTMLInputElement`) so it works
- *  identically for `<textarea>`/`<select>` — every member it touches
- *  (`id`/`closest`) is generic to `Element`, not input-specific. */
+ *  `<label>` + every element referenced by `aria-labelledby`. Takes
+ *  `HTMLElement` (not just `HTMLInputElement`) so it works identically for
+ *  `<textarea>`/`<select>` — every member it touches (`id`/`closest`/
+ *  `getAttribute`) is generic to `Element`, not input-specific.
+ *
+ *  `aria-labelledby` is the ONLY label many modern ATS forms expose: Workday and
+ *  Ashby render their field labels as sibling `<div>`/`<span>`s wired by id
+ *  rather than a `<label for>`, so without this resolution those fields carried
+ *  an empty label and were matched from `name`/`id`/`placeholder` alone (or, for
+ *  answers-capture, skipped as unlabelled). The attribute is an id LIST
+ *  (space-separated, in reference order) — each referenced element's
+ *  `textContent` is appended, same shape as the label text above. `getElementById`
+ *  needs no escaping (unlike the `label[for=…]` selector) and is jsdom-safe; no
+ *  layout/computed-style read is involved. */
 export function labelText(el: HTMLElement): string {
   const doc = el.ownerDocument;
   let text = '';
@@ -231,6 +242,14 @@ export function labelText(el: HTMLElement): string {
   }
   const wrapping = el.closest('label');
   if (wrapping?.textContent) text += ` ${wrapping.textContent}`;
+  const labelledBy = el.getAttribute('aria-labelledby');
+  if (labelledBy) {
+    for (const id of labelledBy.split(/\s+/)) {
+      if (!id) continue;
+      const ref = doc.getElementById(id);
+      if (ref?.textContent) text += ` ${ref.textContent}`;
+    }
+  }
   return text;
 }
 
@@ -387,22 +406,50 @@ const NAMED_KEY_PATTERNS: readonly { key: string; pattern: RegExp }[] = [
   // ("Vor- und Nachname", "Nombre y apellidos", "Nome e cognome"), which would
   // otherwise PARTIALLY fill via the first/last patterns below (nachname →
   // lastName, nombre → firstName). `-?` tolerates the elided-hyphen DE/NL forms.
+  //
+  // `full[\s_-]*name` (was the space-only `\bfull name\b`) so the ATTRIBUTE
+  // spellings resolve here too — `fullname`, `full_name`, `full-name`, and the
+  // camelCase `fullName` (which flattens to `fullname` in the lowercased
+  // signal). Left unanchored on both sides, unlike `phone`/`city`: no English or
+  // EU word CONTAINS "fullname", so there is no collision to guard against,
+  // while an anchor would break the very common `candidateFullName`-style
+  // compound.
   {
     key: 'fullName',
     pattern:
-      /\bfull name\b|vollstandiger name|vor-? und nachname|nom complet|prenom et nom|nombre completo|nombre y apellidos?|nome completo|nome e cognome|imie i nazwisko|volledige naam|voor-? en achternaam|fullstandigt namn/,
+      /full[\s_-]*name|vollstandiger name|vor-? und nachname|nom complet|prenom et nom|nombre completo|nombre y apellidos?|nome completo|nome e cognome|imie i nazwisko|volledige naam|voor-? en achternaam|fullstandigt namn/,
   },
+  // First/last name — the separator between the two words is OPTIONAL
+  // (`[\s_-]*`), because a form field's strongest signal is usually its
+  // `name`/`id` ATTRIBUTE, not a prose label: `first_name`, `firstName`
+  // (→ `firstname` once lowercased), `given-name` and Greenhouse's
+  // `job_application[first_name]` are all the same field as a "First name"
+  // label. Before this, the space-only `first name`/`last name` patterns missed
+  // every one of them, and the HYPHENATED spellings were actively harmful: `-`
+  // is a non-word character, so `first-name`/`family-name` fell through to the
+  // generic `\bname\b` catch-all in `matchNamedKey` and received the FULL name
+  // in BOTH boxes.
+  //
+  // Anchoring follows the `phone`/`city` rule — anchor only what collides.
+  // `first`/`given`/`fore`/`last`/`family` + `name` collide with nothing, so
+  // they stay open on both sides (`applicantFirstName`, `first_name_1` and
+  // `firstNameInput` must all keep matching). The bare abbreviations DO collide
+  // and are LEADING-anchored: `lname` ⊂ "fullname" (which must stay `fullName`,
+  // not `lastName`) and `fname` is short enough to hide inside a future
+  // compound. The trailing side stays open for `fname_1`/`lnameInput`.
+  // `nm` is Taleo's abbreviation (`firstNm`/`lastNm`).
+  //
   // `nombre` (ES) and `nome` (IT/PT) mean "name" — excluded when they head a
   // username/company/full-name phrase so they only fire for a real first name.
   {
     key: 'firstName',
     pattern:
-      /first name|given name|forename|vorname|prenom|voornaam|fornamn|fornavn|etunimi|\bimie\b|\bnombre\b(?!\s*(?:de\b|completo))|\bnome\b(?!\s*(?:completo|utente|de\b|da\b|del))/,
+      /(?:first|given|fore)[\s_-]*(?:name|nm)|(?:^|[^a-z])fname|vorname|prenom|voornaam|fornamn|fornavn|etunimi|\bimie\b|\bnombre\b(?!\s*(?:de\b|completo))|\bnome\b(?!\s*(?:completo|utente|de\b|da\b|del))/,
   },
   {
     key: 'lastName',
     pattern:
-      /last name|surname|family name|nachname|familienname|nom de famille|\bapellidos?\b|cognome|achternaam|nazwisko|apelido|sobrenome|efternamn|efternavn|etternavn|sukunimi/,
+      /(?:last|family)[\s_-]*(?:name|nm)|(?:^|[^a-z])lname|surname|nachname|familienname|nom de famille|\bapellidos?\b|cognome|achternaam|nazwisko|apelido|sobrenome|efternamn|efternavn|etternavn|sukunimi/,
   },
   // `city`/`town` are anchored on their LEADING side (see the `phone` note
   // above): bare `city` ⊂ "ethnicity", so an EEO "Ethnicity" field was resolving

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -271,6 +271,14 @@ export function isHidden(el: HTMLElement): boolean {
   return false;
 }
 
+/** Per-source character cap for {@link labelText}. A label is a short phrase;
+ *  an `aria-labelledby` id may point at a whole CONTAINER (a fieldset, a card),
+ *  whose `textContent` is unbounded — and this string is persisted as the
+ *  answers-capture question key and sent over the bridge, so it must not grow
+ *  without limit. 300 is far above any real label and well below "swallowed the
+ *  page". */
+const LABEL_SOURCE_MAX = 300;
+
 /** CSS.escape when available (jsdom + browsers), else a conservative fallback. */
 function escapeId(id: string): string {
   if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(id);
@@ -306,7 +314,7 @@ export function labelText(el: HTMLElement): string {
   const append = (node: Element | null): void => {
     if (!node || seen.has(node) || !node.textContent) return;
     seen.add(node);
-    text += ` ${node.textContent}`;
+    text += ` ${node.textContent.slice(0, LABEL_SOURCE_MAX)}`;
   };
 
   if (el.id) append(doc.querySelector(`label[for="${escapeId(el.id)}"]`));
@@ -317,7 +325,11 @@ export function labelText(el: HTMLElement): string {
       if (id) append(doc.getElementById(id));
     }
   }
-  return text;
+  // Collapse the source markup's newlines/indentation into single spaces: this
+  // string is not only matched against, it is PERSISTED as the answers-capture
+  // question key and sent over the bridge, so "Why\n    this role?" and
+  // "Why this role?" must be one question, not two.
+  return text.replace(/\s+/g, ' ');
 }
 
 /** Fold an accented EU label to ASCII so it matches the accent-free keyword
@@ -355,6 +367,22 @@ export function textSignal(el: HTMLElement): string {
       el.getAttribute('aria-label') ?? '',
       labelText(el),
     ].join(' ')
+  ).toLowerCase();
+}
+
+/** The same normalization as {@link textSignal}, but from the field's OWN
+ *  ATTRIBUTES only (`name`/`id`/`autocomplete`) — no placeholder, aria-label or
+ *  label prose.
+ *
+ *  {@link matchNamedKey} takes this as a second, narrower signal because the two
+ *  carry different EVIDENCE. Prose is written for a human and freely names both
+ *  halves of a name ("First and Last Name" is a single full-name box; a "Full
+ *  Name" group heading sits above separate first/last boxes), while an attribute
+ *  names the ONE field it is on. A rule that must not be fooled by a group
+ *  heading — the `fullName` row's `denyAttribute` — therefore reads only this. */
+export function attributeSignal(el: HTMLElement): string {
+  return stripDiacritics(
+    [el.getAttribute('name') ?? '', el.id, el.getAttribute('autocomplete') ?? ''].join(' ')
   ).toLowerCase();
 }
 
@@ -460,29 +488,41 @@ const NON_PERSON_NAME_OWNER =
   /user|file|nick|screen|display|business|org|school|institution|university|college|degree|course|program|major|certificat|schule|hochschule|universitat|benutzer|\bfirma\b|unternehmen|ecole|universite|entreprise|societe|utilisateur|escuela|universidad|empresa|usuario|scuola|universita|azienda|utente|szkola|uczelnia|uzytkownik|gebruiker|bedrijf|foretag|anvandare|virksomhed|bruger|yritys|kayttaja/;
 
 /**
- * The ATTRIBUTE-style first/last spellings, on their own — the `fullName` row's
- * other half of {@link NamedKeyPattern.deny}.
+ * The first/last spellings, as the `fullName` row's
+ * {@link NamedKeyPattern.denyAttribute} — matched against the ATTRIBUTE signal
+ * ({@link attributeSignal}) only, never the prose one.
  *
  * A GROUP label reaches a field's signal through `aria-labelledby` (and, for a
  * wrapping `<label>`, through {@link labelText}), so a "Full Name" group heading
  * above `first_name` / `last_name` boxes lands the phrase "full name" in BOTH
  * their signals. Since the `fullName` row runs first, each box would then take
- * the WHOLE name. When the signal ALSO carries a first/last attribute token, the
- * field's own attribute is the more specific evidence and wins. The DE/ES/IT/PL
- * combined phrases ("vor- und nachname", "nombre y apellidos", …) contain none
- * of these tokens, so they are unaffected.
+ * the WHOLE name. When the field's OWN ATTRIBUTE says first/last, that is the
+ * more specific evidence and wins.
+ *
+ * Reading only the attribute signal is load-bearing, not a refinement: the
+ * separator class accepts a space, so against the full signal this also matched
+ * PROSE — the single full-name box placeheld "First and Last Name" was vetoed
+ * out of `fullName` and fell through to `lastName`, receiving only the surname.
+ * (Dropping `\s` from the class is NOT the fix — it re-opens the mirror case, a
+ * prose `aria-label="First name"` under a "Full Name" heading.) The DE/ES/IT/PL
+ * combined phrases contain none of these tokens either way.
  */
 const ATTRIBUTE_FIRST_LAST_NAME =
   /(?:first|given|fore)[\s_-]*(?:name|nm)|(?:^|[^a-z])fname|(?:last|family)[\s_-]*(?:name|nm)|(?:^|[^a-z])lname/;
 
 /** One row of {@link NAMED_KEY_PATTERNS}: the key it resolves to, the signal
- *  pattern that claims it, and an optional `deny` that VETOES the row (the
- *  matcher then falls through to the rows below, and finally to the catch-all)
- *  — the row-scoped equivalent of the catch-all's own denylist. */
+ *  pattern that claims it, and optional vetoes — the row-scoped equivalent of
+ *  the catch-all's own denylist. A veto makes the matcher fall through to the
+ *  rows below, and finally to the catch-all. */
 interface NamedKeyPattern {
   key: string;
   pattern: RegExp;
+  /** Vetoes the row when it matches the FULL signal (attributes + prose). */
   deny?: RegExp;
+  /** Vetoes the row only when it matches the field's own ATTRIBUTE signal
+   *  ({@link attributeSignal}) — for evidence that a human-facing label may
+   *  legitimately carry but an attribute may not. */
+  denyAttribute?: RegExp;
 }
 
 const NAMED_KEY_PATTERNS: readonly NamedKeyPattern[] = [
@@ -530,12 +570,20 @@ const NAMED_KEY_PATTERNS: readonly NamedKeyPattern[] = [
   // compound.
   {
     key: 'fullName',
+    // The English conjunction forms ("First and Last Name", "First name & last
+    // name", "first/last name") join the localized ones: a SINGLE box asking for
+    // both halves is a full-name field, and without them it fell to the
+    // `lastName` row below (its `last name` matches) and received only the
+    // surname.
     pattern:
-      /full[\s_-]*name|vollstandiger name|vor-? und nachname|nom complet|prenom et nom|nombre completo|nombre y apellidos?|nome completo|nome e cognome|imie i nazwisko|volledige naam|voor-? en achternaam|fullstandigt namn/,
-    // Veto: a non-person owner (school/company/user account — the same denylist
-    // the bare-"Name" catch-all applies), or a first/last ATTRIBUTE token that
-    // out-specifies a "Full Name" group label. See both consts above.
-    deny: new RegExp(`${NON_PERSON_NAME_OWNER.source}|${ATTRIBUTE_FIRST_LAST_NAME.source}`),
+      /full[\s_-]*name|first[\s_-]*(?:name)?[\s_-]*(?:and|&|\+|\/)[\s_-]*last[\s_-]*name|vollstandiger name|vor-? und nachname|nom complet|prenom et nom|nombre completo|nombre y apellidos?|nome completo|nome e cognome|imie i nazwisko|volledige naam|voor-? en achternaam|fullstandigt namn/,
+    // Veto 1 (whole signal): a non-person owner — the same denylist the
+    // bare-"Name" catch-all applies, so "University Full Name" is refused in
+    // prose AND attribute spellings.
+    deny: NON_PERSON_NAME_OWNER,
+    // Veto 2 (ATTRIBUTE signal only): the field's own name/id says first/last,
+    // so a "Full Name" GROUP heading in its prose must not win. See the const.
+    denyAttribute: ATTRIBUTE_FIRST_LAST_NAME,
   },
   // First/last name — the separator between the two words is OPTIONAL
   // (`[\s_-]*`), because a form field's strongest signal is usually its
@@ -586,9 +634,18 @@ const NAMED_KEY_PATTERNS: readonly NamedKeyPattern[] = [
   },
 ];
 
-export function matchNamedKey(signal: string): string | null {
-  for (const { key, pattern, deny } of NAMED_KEY_PATTERNS) {
-    if (pattern.test(signal) && !deny?.test(signal)) return key;
+/**
+ * @param signal the full {@link textSignal} (attributes + prose).
+ * @param attributes the narrower {@link attributeSignal}; defaults to `signal`,
+ *   which is the pre-split behavior — every DOM caller passes it explicitly, and
+ *   only a row's {@link NamedKeyPattern.denyAttribute} reads it.
+ */
+export function matchNamedKey(signal: string, attributes: string = signal): string | null {
+  for (const { key, pattern, deny, denyAttribute } of NAMED_KEY_PATTERNS) {
+    if (!pattern.test(signal)) continue;
+    if (deny?.test(signal)) continue;
+    if (denyAttribute?.test(attributes)) continue;
+    return key;
   }
   // Generic catch-all: a bare "Name" field → full name, UNLESS the name belongs
   // to a non-person owner ({@link NON_PERSON_NAME_OWNER}) — a school, a company,

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -148,18 +148,51 @@ const AMBIGUOUS_WORDS = /\b(?:dni|bsn|urgence)\b/;
 const AMBIGUOUS_PREFIXED = /(?:^|[^a-z])(?:referr|reference|search)/;
 
 /**
+ * Name fields that belong to SOMEONE ELSE (a reference, a referrer, a spouse /
+ * child / dependent / beneficiary) or to a name we hold no value for (a former /
+ * previous / other / middle / additional name, a Japanese kana reading) — all
+ * must be SKIPPED.
+ *
+ * Why a dedicated rule rather than more {@link AMBIGUOUS} entries: that list is
+ * PROSE-shaped (plain substrings of a rendered label) and
+ * {@link AMBIGUOUS_PREFIXED} is LEADING-anchored, so both miss the camelCase
+ * ATTRIBUTE spellings that {@link NAMED_KEY_PATTERNS} now matches —
+ * `jobReferenceFirstName`, `myReferrerFirstName`, `spouseFirstName`,
+ * `dependentLastName`, `previousLastName`. Widening the name patterns without
+ * this rule would write the USER's name into a third party's box: a mis-fill,
+ * which this module's contract forbids.
+ *
+ * Shape: a relation/qualifier stem, then (after any run of separators, and an
+ * optional first/last/full/middle/given/family qualifier) a REQUIRED trailing
+ * `name`/`nm` token. Requiring that trailing token is what keeps
+ * "work preferences" / "research experience" fillable — they have a stem but no
+ * name token. The trailing side stays open (`referenceFirstName1`).
+ *
+ * `referr`/`refere` additionally carry a `[^p]` guard: they are substrings of
+ * "**p**referred" / "**p**reference", and "Preferred first name" is one of the
+ * most common fields on an ATS form — it must keep filling (see
+ * {@link AMBIGUOUS_PREFIXED}'s note; this is the same trap in camelCase form).
+ * The kana/furigana alternative is written separately because the qualifier
+ * follows the name token there (`lastNameKana`).
+ */
+const AMBIGUOUS_NAME_COMPOUND =
+  /(?:(?:^|[^p])(?:referr|refere)|spouse|child|dependen|beneficiar|former|previous|other|aka|middle|additional)[a-z]*[\s_-]*(?:first|last|full|middle|given|family)?[\s_-]*n(?:ame|m)|n(?:ame|m)[\s_-]*(?:kana|furigana)|furigana/;
+
+/**
  * True when a field's {@link textSignal} is ambiguous or sensitive and must be
  * SKIPPED by both autofill ({@link textSignal} → `isCandidateField`) and
  * answers-capture (`isCapturable`). Combines the plain-substring {@link AMBIGUOUS}
- * denylist with the word-anchored {@link AMBIGUOUS_WORDS} and the
- * leading-anchored {@link AMBIGUOUS_PREFIXED} ones, so the two consumers can
- * never disagree on what counts as ambiguous.
+ * denylist with the word-anchored {@link AMBIGUOUS_WORDS}, the
+ * leading-anchored {@link AMBIGUOUS_PREFIXED} and the compound
+ * {@link AMBIGUOUS_NAME_COMPOUND} ones, so the two consumers can never disagree
+ * on what counts as ambiguous.
  */
 export function isAmbiguousSignal(signal: string): boolean {
   return (
     AMBIGUOUS.some((w) => signal.includes(w)) ||
     AMBIGUOUS_WORDS.test(signal) ||
-    AMBIGUOUS_PREFIXED.test(signal)
+    AMBIGUOUS_PREFIXED.test(signal) ||
+    AMBIGUOUS_NAME_COMPOUND.test(signal)
   );
 }
 
@@ -232,22 +265,30 @@ function escapeId(id: string): string {
  *  (space-separated, in reference order) — each referenced element's
  *  `textContent` is appended, same shape as the label text above. `getElementById`
  *  needs no escaping (unlike the `label[for=…]` selector) and is jsdom-safe; no
- *  layout/computed-style read is involved. */
+ *  layout/computed-style read is involved.
+ *
+ *  Each source element is counted ONCE (`seen`): the common React-Aria /
+ *  headless-UI shape points `aria-labelledby` at the very `<label for>` that is
+ *  already picked up above (and a wrapping `<label for>` matches twice on its
+ *  own), which would otherwise yield "First name First name" — harmless for
+ *  keyword matching, but `answers-capture.ts` persists this string as the
+ *  QUESTION key, so a duplicated label is a duplicated stored question. */
 export function labelText(el: HTMLElement): string {
   const doc = el.ownerDocument;
+  const seen = new Set<Element>();
   let text = '';
-  if (el.id) {
-    const forLabel = doc.querySelector(`label[for="${escapeId(el.id)}"]`);
-    if (forLabel?.textContent) text += ` ${forLabel.textContent}`;
-  }
-  const wrapping = el.closest('label');
-  if (wrapping?.textContent) text += ` ${wrapping.textContent}`;
+  const append = (node: Element | null): void => {
+    if (!node || seen.has(node) || !node.textContent) return;
+    seen.add(node);
+    text += ` ${node.textContent}`;
+  };
+
+  if (el.id) append(doc.querySelector(`label[for="${escapeId(el.id)}"]`));
+  append(el.closest('label'));
   const labelledBy = el.getAttribute('aria-labelledby');
   if (labelledBy) {
     for (const id of labelledBy.split(/\s+/)) {
-      if (!id) continue;
-      const ref = doc.getElementById(id);
-      if (ref?.textContent) text += ` ${ref.textContent}`;
+      if (id) append(doc.getElementById(id));
     }
   }
   return text;
@@ -371,7 +412,54 @@ export function matchAutocompleteKey(token: string): string | null {
  * is NOT in this table — it runs last, in {@link matchNamedKey}, only after
  * every specific pattern misses.
  */
-const NAMED_KEY_PATTERNS: readonly { key: string; pattern: RegExp }[] = [
+/**
+ * The owner of a "name" that is NOT the applicant: an account/system name
+ * (user/file/nick/screen/display), an organization, or a
+ * school/course/degree/major.
+ * Localized (accent-free — the signal is diacritic-stripped) so
+ * "Name der Schule" / "Nom de l'entreprise" never receive the person's name.
+ *
+ * `\bfirma\b` is anchored — a bare `firma` substring wrongly matches the English
+ * words "affirmative"/"confirmation", which would stop a legitimate
+ * "Name (Affirmative Action)" EEO field from filling.
+ *
+ * Hoisted to a const because it now gates TWO places that must never drift: the
+ * bare-"Name" catch-all in {@link matchNamedKey} (where it has always run) and
+ * the `fullName` row's {@link NamedKeyPattern.deny} below — without the latter,
+ * the attribute spellings the row gained (`school_full_name`,
+ * `universityFullName`, `degreeFullName`, …) walked straight past a denylist the
+ * prose spelling ("University Name") has always respected.
+ */
+const NON_PERSON_NAME_OWNER =
+  /user|file|nick|screen|display|business|org|school|institution|university|college|degree|course|program|major|certificat|schule|hochschule|universitat|benutzer|\bfirma\b|unternehmen|ecole|universite|entreprise|societe|utilisateur|escuela|universidad|empresa|usuario|scuola|universita|azienda|utente|szkola|uczelnia|uzytkownik|gebruiker|bedrijf|foretag|anvandare|virksomhed|bruger|yritys|kayttaja/;
+
+/**
+ * The ATTRIBUTE-style first/last spellings, on their own — the `fullName` row's
+ * other half of {@link NamedKeyPattern.deny}.
+ *
+ * A GROUP label reaches a field's signal through `aria-labelledby` (and, for a
+ * wrapping `<label>`, through {@link labelText}), so a "Full Name" group heading
+ * above `first_name` / `last_name` boxes lands the phrase "full name" in BOTH
+ * their signals. Since the `fullName` row runs first, each box would then take
+ * the WHOLE name. When the signal ALSO carries a first/last attribute token, the
+ * field's own attribute is the more specific evidence and wins. The DE/ES/IT/PL
+ * combined phrases ("vor- und nachname", "nombre y apellidos", …) contain none
+ * of these tokens, so they are unaffected.
+ */
+const ATTRIBUTE_FIRST_LAST_NAME =
+  /(?:first|given|fore)[\s_-]*(?:name|nm)|(?:^|[^a-z])fname|(?:last|family)[\s_-]*(?:name|nm)|(?:^|[^a-z])lname/;
+
+/** One row of {@link NAMED_KEY_PATTERNS}: the key it resolves to, the signal
+ *  pattern that claims it, and an optional `deny` that VETOES the row (the
+ *  matcher then falls through to the rows below, and finally to the catch-all)
+ *  — the row-scoped equivalent of the catch-all's own denylist. */
+interface NamedKeyPattern {
+  key: string;
+  pattern: RegExp;
+  deny?: RegExp;
+}
+
+const NAMED_KEY_PATTERNS: readonly NamedKeyPattern[] = [
   { key: 'linkedin', pattern: /linkedin/ },
   { key: 'github', pattern: /github/ },
   { key: 'website', pattern: /portfolio|personal (web ?site|site)/ },
@@ -418,6 +506,10 @@ const NAMED_KEY_PATTERNS: readonly { key: string; pattern: RegExp }[] = [
     key: 'fullName',
     pattern:
       /full[\s_-]*name|vollstandiger name|vor-? und nachname|nom complet|prenom et nom|nombre completo|nombre y apellidos?|nome completo|nome e cognome|imie i nazwisko|volledige naam|voor-? en achternaam|fullstandigt namn/,
+    // Veto: a non-person owner (school/company/user account — the same denylist
+    // the bare-"Name" catch-all applies), or a first/last ATTRIBUTE token that
+    // out-specifies a "Full Name" group label. See both consts above.
+    deny: new RegExp(`${NON_PERSON_NAME_OWNER.source}|${ATTRIBUTE_FIRST_LAST_NAME.source}`),
   },
   // First/last name — the separator between the two words is OPTIONAL
   // (`[\s_-]*`), because a form field's strongest signal is usually its
@@ -469,24 +561,13 @@ const NAMED_KEY_PATTERNS: readonly { key: string; pattern: RegExp }[] = [
 ];
 
 export function matchNamedKey(signal: string): string | null {
-  for (const { key, pattern } of NAMED_KEY_PATTERNS) {
-    if (pattern.test(signal)) return key;
+  for (const { key, pattern, deny } of NAMED_KEY_PATTERNS) {
+    if (pattern.test(signal) && !deny?.test(signal)) return key;
   }
-  // Generic catch-all: a bare "Name" field → full name, UNLESS it's a
-  // user/file/nick/display/business/org field OR a school/company/user-account
-  // "name" field. The denylist is localized (accent-free — the signal is
-  // diacritic-stripped) so "Name der Schule" / "Name des Unternehmens" /
-  // "Nom de l'entreprise"-style fields never receive the person's name.
-  if (
-    /\bname\b/.test(signal) &&
-    // `\bfirma\b` is anchored — a bare `firma` substring wrongly matches the
-    // English words "affirmative"/"confirmation", which would stop a legitimate
-    // "Name (Affirmative Action)" EEO field from filling.
-    !/user|file|nick|screen|display|business|org|school|institution|university|college|degree|course|program|certificat|schule|hochschule|universitat|benutzer|\bfirma\b|unternehmen|ecole|universite|entreprise|societe|utilisateur|escuela|universidad|empresa|usuario|scuola|universita|azienda|utente|szkola|uczelnia|uzytkownik|gebruiker|bedrijf|foretag|anvandare|virksomhed|bruger|yritys|kayttaja/.test(
-      signal
-    )
-  )
-    return 'fullName';
+  // Generic catch-all: a bare "Name" field → full name, UNLESS the name belongs
+  // to a non-person owner ({@link NON_PERSON_NAME_OWNER}) — a school, a company,
+  // or a user account.
+  if (/\bname\b/.test(signal) && !NON_PERSON_NAME_OWNER.test(signal)) return 'fullName';
 
   return null;
 }

--- a/apps/extension/src/lib/field-signal.ts
+++ b/apps/extension/src/lib/field-signal.ts
@@ -166,17 +166,32 @@ const AMBIGUOUS_PREFIXED = /(?:^|[^a-z])(?:referr|reference|search)/;
  * optional first/last/full/middle/given/family qualifier) a REQUIRED trailing
  * `name`/`nm` token. Requiring that trailing token is what keeps
  * "work preferences" / "research experience" fillable — they have a stem but no
- * name token. The trailing side stays open (`referenceFirstName1`).
+ * name token. The trailing side stays open (`referenceFirstName1`). The
+ * kana/furigana reading is listed BOTH as a stem (`kana_last_name`) and as a
+ * trailing alternative, because that qualifier can follow the name token
+ * (`lastNameKana`).
  *
- * `referr`/`refere` additionally carry a `[^p]` guard: they are substrings of
- * "**p**referred" / "**p**reference", and "Preferred first name" is one of the
- * most common fields on an ATS form — it must keep filling (see
- * {@link AMBIGUOUS_PREFIXED}'s note; this is the same trap in camelCase form).
- * The kana/furigana alternative is written separately because the qualifier
- * follows the name token there (`lastNameKana`).
+ * The reference/referrer family lives in its own {@link AMBIGUOUS_REFERENCE_NAME}
+ * because it — and only it — needs the "preferred" exemption; keeping it out of
+ * this rule means an unrelated "prefer" elsewhere in the signal can never
+ * un-deny a spouse/middle/kana field.
  */
 const AMBIGUOUS_NAME_COMPOUND =
-  /(?:(?:^|[^p])(?:referr|refere)|spouse|child|dependen|beneficiar|former|previous|other|aka|middle|additional)[a-z]*[\s_-]*(?:first|last|full|middle|given|family)?[\s_-]*n(?:ame|m)|n(?:ame|m)[\s_-]*(?:kana|furigana)|furigana/;
+  /(?:spouse|child|dependen|beneficiar|former|previous|other|aka|also[\s_-]*known[\s_-]*as|middle|additional|kana|furigana)[a-z]*[\s_-]*(?:first|last|full|middle|given|family)?[\s_-]*n(?:ame|m)|n(?:ame|m)[\s_-]*(?:kana|furigana)|furigana/;
+
+/**
+ * {@link AMBIGUOUS_NAME_COMPOUND}'s shape for the reference/referrer family
+ * (`jobReferenceFirstName`, `myReferrerLastName`, `refereeFirstName`).
+ *
+ * Deliberately UNANCHORED, unlike {@link AMBIGUOUS_PREFIXED}: a `[^p]` character
+ * guard (the obvious way to spare "**p**referred"/"**p**reference") exempts every
+ * p-terminated prefix, and `empReferenceFirstName`,
+ * `groupReferenceFirstName`, `backupReferenceFirstName`, `topReferenceFirstName`
+ * … are ordinary HRIS spellings that were each filled with the applicant's own
+ * name. The exemption is done by WORD in {@link isAmbiguousSignal} instead.
+ */
+const AMBIGUOUS_REFERENCE_NAME =
+  /(?:referr|refere)[a-z]*[\s_-]*(?:first|last|full|middle|given|family)?[\s_-]*n(?:ame|m)/;
 
 /**
  * True when a field's {@link textSignal} is ambiguous or sensitive and must be
@@ -186,13 +201,24 @@ const AMBIGUOUS_NAME_COMPOUND =
  * leading-anchored {@link AMBIGUOUS_PREFIXED} and the compound
  * {@link AMBIGUOUS_NAME_COMPOUND} ones, so the two consumers can never disagree
  * on what counts as ambiguous.
+ *
+ * {@link AMBIGUOUS_REFERENCE_NAME} is the one rule with an exemption: a signal
+ * where "prefer" STARTS a word is the ubiquitous "Preferred first name" /
+ * `preferred_first_name` field (its `refer` exists only because "prefer"
+ * contains one) and must keep filling. The anchor is what separates it from
+ * `empReferenceFirstName` / `topReferenceFirstName`, where the same letters are
+ * a prefix + "reference". A camelCase `candidatePreferredFirstName` is
+ * collateral of that ambiguity — the two are spelled identically apart from the
+ * word boundary, so it is skipped: an under-fill, which this module prefers to
+ * writing the user's name into a reference's box.
  */
 export function isAmbiguousSignal(signal: string): boolean {
   return (
     AMBIGUOUS.some((w) => signal.includes(w)) ||
     AMBIGUOUS_WORDS.test(signal) ||
     AMBIGUOUS_PREFIXED.test(signal) ||
-    AMBIGUOUS_NAME_COMPOUND.test(signal)
+    AMBIGUOUS_NAME_COMPOUND.test(signal) ||
+    (AMBIGUOUS_REFERENCE_NAME.test(signal) && !/(?:^|[^a-z])prefer/.test(signal))
   );
 }
 


### PR DESCRIPTION
The extension autofill name matcher required a literal space ("first name"), so attribute-only fields (first_name, firstName, fname, job_application[first_name]) never matched — while hyphenated first-name/last-name fell to the catch-all and wrote the FULL name into both boxes. Patterns now match attribute compounds; aria-labelledby labels are read (Workday/Ashby-class forms); disabled/readonly fields are skipped in fill AND capture.

Three review rounds hardened the ambiguity denylist against the widened reach: third-party name boxes (spouse/reference/beneficiary families incl. camelCase), edu/org full-name fields, group-label-vs-attribute precedence, label dedupe, kana/furigana, alsoKnownAs — all differential-pinned (558 extension tests; every new pin verified red against the old matcher). allFrames injection evaluated and rejected on least-privilege/store-policy grounds; documented as a known top-frame-only limit.

Review: extension-author → extension-reviewer (1 HIGH + 4 MEDIUM found and fixed; re-verify CONFIRMED-RESOLVED). Both store dists rebuilt; classic bundles remain import-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
