### PR TITLE
fix: prime world videos on ios and classify tablets as desktop

### DIFF
--- a/apps/landing/src/app/world/WorldClient.tsx
+++ b/apps/landing/src/app/world/WorldClient.tsx
@@ -24,30 +24,21 @@ const THEME_CSS = `
 
 export function WorldClient() {
   const containerRef = useRef<HTMLDivElement>(null);
-  // React 19 StrictMode double-invokes effects in dev. The engine wires up
-  // window-level scroll/resize listeners it never tears down, so re-running it
-  // would double-register them (not just duplicate DOM) — a ref flag, not a
-  // cleanup return, is what actually prevents that.
-  const mountedRef = useRef(false);
 
-  // The vendored engine has NO teardown API: it registers window scroll/
-  // resize/orientationchange/pointer listeners plus an unbounded rAF loop, and
-  // never revokes the blob object URLs it creates per clip (intentional —
-  // clips must stay seekable for the page's whole lifetime; don't "fix" that
-  // upstream). mountedRef only guards StrictMode's double-invoke, not a route
-  // remount, so /world must only be entered via a full navigation (raw <a>,
-  // as the home body.html link is) — never an in-app Next <Link>, which would
-  // stack a second listener set + rAF loop over the first render's detached DOM.
+  // mountScrollWorld returns a disposer (an ADR-0019 deviation — upstream returns
+  // nothing and never unregisters its window listeners or its rAF loop). Handing
+  // that straight back from the effect is all the cleanup React needs: StrictMode's
+  // dev double-invoke and a client-side route remount both unwind properly, so
+  // /world no longer has to be entered via a full navigation.
   useEffect(() => {
     const container = containerRef.current;
-    if (!container || mountedRef.current) return;
-    mountedRef.current = true;
+    if (!container) return;
     // Desktop ships AV1 (~40% smaller at equal quality) with the H.264 files as
     // the fallback for browsers without AV1 decode (older Safari); mobile stays
     // H.264-only because phone software AV1 decode can't keep up with scrubbing.
     const av1 =
       document.createElement('video').canPlayType('video/mp4; codecs="av01.0.08M.08"') !== '';
-    mountScrollWorld(container, av1 ? withAv1Sources(WORLD_CONFIG) : WORLD_CONFIG);
+    return mountScrollWorld(container, av1 ? withAv1Sources(WORLD_CONFIG) : WORLD_CONFIG);
   }, []);
 
   return (

--- a/apps/landing/src/app/world/scrub-engine.d.ts
+++ b/apps/landing/src/app/world/scrub-engine.d.ts
@@ -4,4 +4,8 @@
 // deliberate: the JS module accepts any plain config object, and `object`
 // accepts WorldClient.tsx's typed WORLD_CONFIG (world-config.ts) without
 // TS demanding a matching index signature on that named interface.
-export function mountScrollWorld(container: HTMLElement, config: object): void;
+// Returns a disposer: it removes every window listener, cancels the rAF loop,
+// releases each clip's decoder + blob URL and empties the container, so the
+// engine can be mounted again (StrictMode's double-invoke, a route change, a
+// test). See ADR-0019's deviation log — upstream returns nothing.
+export function mountScrollWorld(container: HTMLElement, config: object): () => void;

--- a/apps/landing/src/app/world/scrub-engine.js
+++ b/apps/landing/src/app/world/scrub-engine.js
@@ -30,20 +30,21 @@
 
    MOBILE (the clipMobile/connectorsMobile variants are the opt-in mobile version;
    the rest of the phone handling below is always on)
-     The engine is phone-aware out of the box: on a coarse-pointer / ≤860px viewport it
+     The engine is phone-aware out of the box: on a phone (coarse pointer + phone-sized screen) it
        - loads `clipMobile` / `connectorsMobile` when provided (encode these smaller +
          tighter-GOP — seek cost on a phone decoder is dominated by frames-from-keyframe,
          so a 720p, -g 4 file scrubs far smoother than the 1080p desktop master; see
          pipeline.md). Falls back to the desktop `clip` if no mobile variant is given.
        - uses `stillMobile` as the scene poster when provided (pair it with native 9:16
          clipMobile renders so the poster matches the portrait video's first frame instead
-         of flashing from a landscape crop). Chosen once at mount; a desktop resize into
-         phone width keeps the desktop poster (clips still switch via isMobile()).
+         of flashing from a landscape crop). The phone/desktop split is decided once at
+         mount, so posters and clips always come from the same set (never a mix).
        - coalesces seeks (never issues a new currentTime while the decoder is still
          `seeking`) so fast flicks can't pile up and freeze the video.
        - keeps the still as a live poster until the clip actually paints its first frame,
-         and primes each video (muted play→pause) on first touch — this is what stops iOS
-         from showing a blank scene before the first seek.
+         and primes each video (muted play→pause) on every touch and again whenever a clip
+         is created after the first touch — this is what stops iOS from showing a blank
+         scene (iOS won't load media data for a video created outside a gesture).
        - drops the drifting particles and ignores URL-bar-only resizes (no scroll jump).
      Nothing here is required — a config with only `clip`/`connectors` still works on
      phones; the mobile variants just make it lighter and smoother.
@@ -65,12 +66,17 @@
 
 function mountScrollWorld(container, config) {
   const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  // Phone detection. `coarse` is captured once (input type doesn't change mid-session);
-  // the ≤860px query is read live via isMobile() so a desktop resize/DevTools toggle
-  // switches sources and seek behaviour without a reload.
+  // Phone detection, decided ONCE at mount so a rotation/resize can never mix two device
+  // sets mid-session. `coarse` on its own matches tablets and touch laptops at ANY width,
+  // so a large screen has to override it: a phone is a coarse pointer AND a phone-sized
+  // screen. The screen's SHORT side is the test — rotation-proof and independent of the
+  // URL bar (iPhone Pro Max ≈440 → phone, iPad mini 744 → desktop). Non-touch windows keep
+  // the old ≤860px rule so a narrow desktop browser still gets the lighter encodes, just
+  // frozen at mount instead of read live.
   const coarse = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
-  const smallMQ = window.matchMedia('(max-width: 860px)');
-  const isMobile = () => coarse || smallMQ.matches;
+  const isMobile = coarse
+    ? Math.min(window.screen.width, window.screen.height) <= 500
+    : window.matchMedia('(max-width: 860px)').matches;
   const SECTIONS = config.sections || [];
   const CONNECTORS = config.connectors || [];
   const CONNECTORS_M = config.connectorsMobile || [];
@@ -171,7 +177,7 @@ function mountScrollWorld(container, config) {
     img.alt = '';
     img.decoding = 'async';
     img.loading = 'lazy';
-    const poster = isMobile() && s.stillM ? s.stillM : s.still;
+    const poster = isMobile && s.stillM ? s.stillM : s.still;
     if (poster) img.src = poster;
     scene.appendChild(img);
     stage.appendChild(scene);
@@ -181,6 +187,8 @@ function mountScrollWorld(container, config) {
     s.hasClip = false;
     s.loading = false;
     s.ready = false;
+    s.primed = false;
+    s.tries = 0;
     s.cur = 0;
     s.target = 0;
     s.visible = false;
@@ -266,10 +274,13 @@ function mountScrollWorld(container, config) {
   function loadClip(s) {
     // Under prefers-reduced-motion we never load the clips at all — the stills stay up
     // and simply cross-dissolve as you scroll. No scrubbed video motion, no decode cost.
-    if (reduce || s.loading || !s.clip) return;
+    // A clip whose fetch or decode keeps failing must not refetch on every scroll tick:
+    // a failure clears `loading` so a later scroll can retry, and `tries` bounds it.
+    if (reduce || s.loading || !s.clip || s.tries >= 3) return;
     s.loading = true;
+    s.tries++;
     // Serve the lighter mobile encode on phones when one was provided.
-    const url = isMobile() && s.clipM ? s.clipM : s.clip;
+    const url = isMobile && s.clipM ? s.clipM : s.clip;
     fetch(url)
       .then((r) => (r.ok ? r.blob() : Promise.reject(new Error('404'))))
       .then((blob) => {
@@ -299,11 +310,28 @@ function mountScrollWorld(container, config) {
           try {
             v.pause();
           } catch (e) {}
-          if (userReady) primeVideo(v);
+          if (userReady) primeVideo(s);
+        });
+        // A decode/network error must not latch `loading` forever, and a dead <video>
+        // must not sit on top of the poster. Reset the segment back to its still so a
+        // later scroll can retry (bounded by `tries`).
+        v.addEventListener('error', () => {
+          if (v.parentNode) v.parentNode.removeChild(v);
+          if (s.video === v) s.video = null;
+          s.el.classList.remove('has-clip');
+          s.hasClip = false;
+          s.ready = false;
+          s.primed = false;
+          s.loading = false;
         });
         s.el.appendChild(v);
         s.video = v;
         s.hasClip = true;
+        // iOS won't load media data for a video created outside a user gesture, so a clip
+        // that appears after the first touch never fires loadeddata and would keep showing
+        // its poster forever. A muted+playsinline play() IS permitted there and forces the
+        // load, so prime the moment the clip exists once the user has interacted.
+        if (userReady) primeVideo(s);
       })
       .catch(() => {
         s.loading = false;
@@ -376,7 +404,7 @@ function mountScrollWorld(container, config) {
   }
 
   function raf() {
-    const eps = isMobile() ? 0.02 : 0.008; // coarser seek step on phones = fewer decodes
+    const eps = isMobile ? 0.02 : 0.008; // coarser seek step on phones = fewer decodes
     for (let i = 0; i < NSEG; i++) {
       const s = SEGMENTS[i];
       if (!s.hasClip || !s.ready || !s.video) continue;
@@ -397,13 +425,21 @@ function mountScrollWorld(container, config) {
     requestAnimationFrame(raf);
   }
 
-  // iOS needs a user gesture before a muted video will decode/paint reliably. On the
-  // first touch we prime every loaded clip (muted play→pause) so the first seek is
-  // instant instead of showing a blank frame. `userReady` also makes freshly-loaded
-  // clips prime themselves (see loadClip).
+  // iOS needs a user gesture before a muted video will decode/paint reliably, and it
+  // won't load media data at all for a video created outside one — so a one-shot
+  // {once:true} primer only ever reaches the clips that existed at the first touch, and
+  // every later scene stays stuck on its poster. The listeners therefore stay registered:
+  // on any touch, every clip that exists but hasn't been primed yet is primed (muted
+  // play→pause). That also covers a first touch landing while clip 0's fetch is
+  // still in flight. `s.primed` keeps it to one play() per segment; `userReady` lets a
+  // freshly-created clip prime itself (see loadClip). Gated on `coarse`, not `isMobile`:
+  // this is a WebKit-on-touch policy, not an asset-tier choice — iPads need it too even
+  // though they now take the desktop set.
   let userReady = false;
-  function primeVideo(v) {
-    if (!isMobile() || !v) return;
+  function primeVideo(s) {
+    const v = s.video;
+    if (!coarse || !v || s.primed) return;
+    s.primed = true;
     try {
       const p = v.play();
       if (p && p.then)
@@ -411,18 +447,23 @@ function mountScrollWorld(container, config) {
           try {
             v.pause();
           } catch (e) {}
-        }).catch(() => {});
-    } catch (e) {}
+        }).catch(() => {
+          s.primed = false; // priming was refused — let the next gesture try again
+        });
+    } catch (e) {
+      s.primed = false;
+    }
   }
-  function onFirstGesture() {
-    if (userReady) return;
+  function onGesture() {
     userReady = true;
-    SEGMENTS.forEach((s) => primeVideo(s.video));
+    SEGMENTS.forEach((s) => primeVideo(s));
   }
-  window.addEventListener('pointerdown', onFirstGesture, { once: true, passive: true });
-  window.addEventListener('touchstart', onFirstGesture, { once: true, passive: true });
+  window.addEventListener('pointerdown', onGesture, { passive: true });
+  window.addEventListener('touchstart', onGesture, { passive: true });
 
-  // Particles are a per-frame cost we can't afford alongside video scrubbing on a phone.
+  // Particles are a per-frame cost we can't afford alongside video scrubbing on a touch
+  // device — gated on `coarse` (not `isMobile`) so tablets stay light too. Same for the
+  // URL-bar resize guard below: both are touch-browser traits, not asset-tier choices.
   seedParticles(particles, reduce || coarse);
   window.addEventListener(
     'scroll',

--- a/apps/landing/src/app/world/scrub-engine.js
+++ b/apps/landing/src/app/world/scrub-engine.js
@@ -6,8 +6,9 @@
    plain HTML, Next.js (call from a ref/useEffect), Vue (onMounted), a server-
    rendered page, anything.
 
-   USAGE
-     mountScrollWorld(document.getElementById('world'), {
+   USAGE  (returns a disposer — call it to remove every listener, stop the rAF loop,
+            release the clips and empty the container)
+     const unmount = mountScrollWorld(document.getElementById('world'), {
        brand: { name: 'Pearl & Co.', href: '#top' },
        diveScroll: 1.3,   // viewport-heights of scroll per dive clip
        connScroll: 0.9,   // ...per connector clip
@@ -95,7 +96,7 @@ function mountScrollWorld(container, config) {
   const CONN_W = config.connScroll || 0.9;
   const CROSSFADE = config.crossfade != null ? config.crossfade : 0.12; // seam dissolve width (vh)
   const N = SECTIONS.length;
-  if (!N) return;
+  if (!N) return function unmount() {}; // nothing mounted — still hand back a disposer
 
   injectCSS();
   container.classList.add('sw-root');
@@ -259,6 +260,8 @@ function mountScrollWorld(container, config) {
     activeIndex = -1,
     ticking = false;
   let laidOutW = window.innerWidth; // width the current layout was computed at (see onResize)
+  let rafId = 0;
+  let stopped = false; // flipped by the disposer returned at the end of this function
 
   function layout() {
     vh = window.innerHeight;
@@ -296,6 +299,7 @@ function mountScrollWorld(container, config) {
     fetch(url)
       .then((r) => (r.ok ? r.blob() : Promise.reject(new Error('404'))))
       .then((blob) => {
+        if (stopped) return; // unmounted while this clip was still in flight
         const v = document.createElement('video');
         v.className = 'sw-scene__video';
         v.muted = true;
@@ -340,14 +344,7 @@ function mountScrollWorld(container, config) {
           // reset the live clip (that would freeze it and stack a second <video>).
           if (!live()) return;
           if (v.parentNode) v.parentNode.removeChild(v);
-          // Clear the source and re-run the load algorithm BEFORE revoking: a detached
-          // element can hold decoder resources until its source is dropped, and the retry
-          // path can make up to three of these per segment. Live clips keep their blob URL
-          // for the page's lifetime by design — a torn-down one is just dead weight.
-          const dead = v.src;
-          v.removeAttribute('src');
-          v.load();
-          URL.revokeObjectURL(dead);
+          releaseClip(v);
           s.video = null;
           s.el.classList.remove('has-clip');
           s.hasClip = false;
@@ -371,6 +368,7 @@ function mountScrollWorld(container, config) {
   }
 
   function read() {
+    if (stopped) return;
     const y = window.scrollY || window.pageYOffset;
     const fade = CROSSFADE * vh;
     let ci = 0;
@@ -436,6 +434,7 @@ function mountScrollWorld(container, config) {
   }
 
   function raf() {
+    if (stopped) return;
     const eps = isMobile ? 0.02 : 0.008; // coarser seek step on phones = fewer decodes
     for (let i = 0; i < NSEG; i++) {
       const s = SEGMENTS[i];
@@ -454,7 +453,7 @@ function mountScrollWorld(container, config) {
         } catch (e) {}
       }
     }
-    requestAnimationFrame(raf);
+    rafId = requestAnimationFrame(raf);
   }
 
   // iOS needs a user gesture before a muted video will decode/paint reliably, and it
@@ -504,16 +503,13 @@ function mountScrollWorld(container, config) {
   // device — gated on `coarse` (not `isMobile`) so tablets stay light too. Same for the
   // URL-bar resize guard below: both are touch-browser traits, not asset-tier choices.
   seedParticles(particles, reduce || coarse);
-  window.addEventListener(
-    'scroll',
-    () => {
-      if (!ticking) {
-        ticking = true;
-        requestAnimationFrame(read);
-      }
-    },
-    { passive: true }
-  );
+  function onScroll() {
+    if (!ticking) {
+      ticking = true;
+      requestAnimationFrame(read);
+    }
+  }
+  window.addEventListener('scroll', onScroll, { passive: true });
   // Mobile browsers fire `resize` every time the URL bar slides in/out. Re-running
   // layout() there rebuilds the track height and yanks the scroll position, so on
   // touch we ignore height-only changes and only relayout when the width actually
@@ -527,9 +523,47 @@ function mountScrollWorld(container, config) {
   window.addEventListener('orientationchange', layout);
   window.addEventListener('load', layout);
   layout();
-  requestAnimationFrame(raf);
+  rafId = requestAnimationFrame(raf);
+  return unmount;
 
   // ---- helpers ----
+  // Deviation from the vendored original: upstream registers window listeners and an
+  // unbounded rAF loop and never unregisters them, so a second mount (React StrictMode's
+  // double-invoke, a client-side route change, a test file) stacks another listener set
+  // and another loop over the first. Returning a disposer makes the engine remountable.
+  // The injected <style id="sw-css"> is deliberately left alone — it is id-guarded and
+  // shared with any other mount that may still be live.
+  function unmount() {
+    if (stopped) return;
+    stopped = true;
+    cancelAnimationFrame(rafId);
+    window.removeEventListener('pointerdown', onGesture);
+    window.removeEventListener('touchstart', onGesture);
+    window.removeEventListener('scroll', onScroll);
+    window.removeEventListener('resize', onResize);
+    window.removeEventListener('orientationchange', layout);
+    window.removeEventListener('load', layout);
+    SEGMENTS.forEach((s) => {
+      if (!s.video) return;
+      releaseClip(s.video);
+      s.video = null;
+    });
+    container.replaceChildren();
+    container.classList.remove('sw-root');
+  }
+  // Release a clip's decoder and then its blob URL. Order matters: a detached element can
+  // hold decode resources until its source is dropped and the load algorithm re-run.
+  // Live clips keep their blob for the page's lifetime by design (they must stay
+  // seekable); this is only ever for a clip that is being thrown away.
+  function releaseClip(v) {
+    const dead = v.src;
+    try {
+      v.pause();
+    } catch (e) {}
+    v.removeAttribute('src');
+    v.load();
+    URL.revokeObjectURL(dead);
+  }
   function el(tag, cls) {
     const n = document.createElement(tag);
     if (cls) n.className = cls;

--- a/apps/landing/src/app/world/scrub-engine.js
+++ b/apps/landing/src/app/world/scrub-engine.js
@@ -77,6 +77,13 @@ function mountScrollWorld(container, config) {
   const isMobile = coarse
     ? Math.min(window.screen.width, window.screen.height) <= 500
     : window.matchMedia('(max-width: 860px)').matches;
+  // Video priming (see primeVideo) is gated separately from the asset tier: since
+  // iPadOS 13.4 an iPad with a Magic Keyboard/trackpad reports hover:hover +
+  // pointer:fine, so `coarse` misses it — yet WebKit still gates media loading on a
+  // gesture there, which would strand exactly that config on posters forever.
+  // maxTouchPoints catches every touch-capable browser (a Windows touch laptop just
+  // takes a harmless muted play→pause); a real desktop reports 0 and never primes.
+  const canTouch = navigator.maxTouchPoints > 0;
   const SECTIONS = config.sections || [];
   const CONNECTORS = config.connectors || [];
   const CONNECTORS_M = config.connectorsMobile || [];
@@ -316,8 +323,15 @@ function mountScrollWorld(container, config) {
         // must not sit on top of the poster. Reset the segment back to its still so a
         // later scroll can retry (bounded by `tries`).
         v.addEventListener('error', () => {
+          // A late error from an element this segment has already replaced must not
+          // reset the live clip (that would freeze it and stack a second <video>).
+          if (s.video !== v) return;
           if (v.parentNode) v.parentNode.removeChild(v);
-          if (s.video === v) s.video = null;
+          // Live clips keep their blob URL for the page's lifetime by design, but a
+          // torn-down one is dead weight — release it or a failing segment leaks
+          // multi-MB blobs once per retry.
+          URL.revokeObjectURL(v.src);
+          s.video = null;
           s.el.classList.remove('has-clip');
           s.hasClip = false;
           s.ready = false;
@@ -432,13 +446,14 @@ function mountScrollWorld(container, config) {
   // on any touch, every clip that exists but hasn't been primed yet is primed (muted
   // play→pause). That also covers a first touch landing while clip 0's fetch is
   // still in flight. `s.primed` keeps it to one play() per segment; `userReady` lets a
-  // freshly-created clip prime itself (see loadClip). Gated on `coarse`, not `isMobile`:
-  // this is a WebKit-on-touch policy, not an asset-tier choice — iPads need it too even
-  // though they now take the desktop set.
+  // freshly-created clip prime itself (see loadClip). Gated on `canTouch`, not `coarse`
+  // (a trackpad-attached iPad is pointer:fine yet still needs this) and not `isMobile`
+  // (a WebKit-on-touch policy is not an asset-tier choice — iPads need priming even
+  // though they now take the desktop set).
   let userReady = false;
   function primeVideo(s) {
     const v = s.video;
-    if (!coarse || !v || s.primed) return;
+    if (!canTouch || !v || s.primed) return;
     s.primed = true;
     try {
       const p = v.play();
@@ -450,6 +465,9 @@ function mountScrollWorld(container, config) {
         }).catch(() => {
           s.primed = false; // priming was refused — let the next gesture try again
         });
+      // Pre-promise WebKit returns undefined from play(); without this the primed
+      // clip just keeps playing underneath the scrubber.
+      else v.pause();
     } catch (e) {
       s.primed = false;
     }

--- a/apps/landing/src/app/world/scrub-engine.js
+++ b/apps/landing/src/app/world/scrub-engine.js
@@ -45,7 +45,11 @@
          and primes each video (muted play→pause) on every touch and again whenever a clip
          is created after the first touch — this is what stops iOS from showing a blank
          scene (iOS won't load media data for a video created outside a gesture).
-       - drops the drifting particles and ignores URL-bar-only resizes (no scroll jump).
+       - drops the drifting particles and ignores URL-bar-only resizes (no scroll jump)
+         — these two key off the coarse pointer ALONE, so tablets get them as well.
+     Priming keys off neither tier: it needs only touch capability (maxTouchPoints),
+     because a trackpad-attached iPad reports a FINE pointer yet still gates media
+     loading on a gesture. Three separate gates, deliberately — see mountScrollWorld.
      Nothing here is required — a config with only `clip`/`connectors` still works on
      phones; the mobile variants just make it lighter and smoother.
 
@@ -195,6 +199,7 @@ function mountScrollWorld(container, config) {
     s.loading = false;
     s.ready = false;
     s.primed = false;
+    s.primeTries = 0;
     s.tries = 0;
     s.cur = 0;
     s.target = 0;
@@ -299,7 +304,14 @@ function mountScrollWorld(container, config) {
         v.setAttribute('muted', '');
         v.setAttribute('playsinline', '');
         v.src = URL.createObjectURL(blob);
+        // Every listener below checks this first. A media element keeps firing after the
+        // segment has torn it down and replaced it (see the error handler), and a late
+        // event from a discarded element would otherwise mutate the LIVE clip's state —
+        // e.g. flagging `ready` while the live video has no metadata at all, after which
+        // raf() seeks it against the `duration || 1` fallback.
+        const live = () => s.video === v;
         v.addEventListener('loadedmetadata', () => {
+          if (!live()) return;
           s.ready = true;
           read();
         });
@@ -309,6 +321,7 @@ function mountScrollWorld(container, config) {
         v.addEventListener(
           'seeked',
           () => {
+            if (!live()) return;
             s.el.classList.add('has-clip');
           },
           { once: true }
@@ -317,7 +330,7 @@ function mountScrollWorld(container, config) {
           try {
             v.pause();
           } catch (e) {}
-          if (userReady) primeVideo(s);
+          if (live() && userReady) primeVideo(s);
         });
         // A decode/network error must not latch `loading` forever, and a dead <video>
         // must not sit on top of the poster. Reset the segment back to its still so a
@@ -325,17 +338,22 @@ function mountScrollWorld(container, config) {
         v.addEventListener('error', () => {
           // A late error from an element this segment has already replaced must not
           // reset the live clip (that would freeze it and stack a second <video>).
-          if (s.video !== v) return;
+          if (!live()) return;
           if (v.parentNode) v.parentNode.removeChild(v);
-          // Live clips keep their blob URL for the page's lifetime by design, but a
-          // torn-down one is dead weight — release it or a failing segment leaks
-          // multi-MB blobs once per retry.
-          URL.revokeObjectURL(v.src);
+          // Clear the source and re-run the load algorithm BEFORE revoking: a detached
+          // element can hold decoder resources until its source is dropped, and the retry
+          // path can make up to three of these per segment. Live clips keep their blob URL
+          // for the page's lifetime by design — a torn-down one is just dead weight.
+          const dead = v.src;
+          v.removeAttribute('src');
+          v.load();
+          URL.revokeObjectURL(dead);
           s.video = null;
           s.el.classList.remove('has-clip');
           s.hasClip = false;
           s.ready = false;
           s.primed = false;
+          s.primeTries = 0;
           s.loading = false;
         });
         s.el.appendChild(v);
@@ -453,8 +471,11 @@ function mountScrollWorld(container, config) {
   let userReady = false;
   function primeVideo(s) {
     const v = s.video;
-    if (!canTouch || !v || s.primed) return;
+    // `primeTries` mirrors `tries`: a browser that refuses muted playback outright would
+    // otherwise take a fresh play() on every pointerdown for the life of the page.
+    if (!canTouch || !v || s.primed || s.primeTries >= 3) return;
     s.primed = true;
+    s.primeTries++;
     try {
       const p = v.play();
       if (p && p.then)

--- a/apps/landing/src/app/world/scrub-engine.test.ts
+++ b/apps/landing/src/app/world/scrub-engine.test.ts
@@ -56,10 +56,13 @@ function configFor(prefix: string) {
   };
 }
 
+/** Every mount's disposer, unwound in afterEach so mounts can't leak across tests. */
+const disposers: Array<() => void> = [];
+
 function mount(prefix: string) {
   const container = document.createElement('div');
   document.body.appendChild(container);
-  mountScrollWorld(container, configFor(prefix));
+  disposers.push(mountScrollWorld(container, configFor(prefix)));
   return container;
 }
 
@@ -138,6 +141,7 @@ const inside = (els: HTMLMediaElement[], container: HTMLElement) =>
 
 const originalCreateObjectURL = URL.createObjectURL;
 const originalRevokeObjectURL = URL.revokeObjectURL;
+const originalScreen = { width: window.screen.width, height: window.screen.height };
 
 /** A touch device whose clips actually materialise as <video> elements. */
 function touchDeviceWithVideos(playResult: 'resolve' | 'reject' | 'no-promise') {
@@ -151,10 +155,14 @@ function touchDeviceWithVideos(playResult: 'resolve' | 'reject' | 'no-promise') 
 }
 
 afterEach(() => {
+  // Unwind mounts BEFORE restoring globals: the disposer calls cancelAnimationFrame
+  // and URL.revokeObjectURL, which several tests stub.
+  disposers.splice(0).forEach((dispose) => dispose());
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   URL.createObjectURL = originalCreateObjectURL;
   URL.revokeObjectURL = originalRevokeObjectURL;
+  stubScreen(originalScreen.width, originalScreen.height);
   stubTouchPoints(0);
   stubScrollY(0);
   document.body.replaceChildren();
@@ -170,6 +178,23 @@ describe('device classification picks the asset set', () => {
   const CASES = [
     { name: 'iPhone 15 Pro Max', coarse: true, narrow: true, w: 430, h: 932, set: 'mobile' },
     { name: 'Android phone', coarse: true, narrow: true, w: 412, h: 915, set: 'mobile' },
+    // The threshold itself, from both sides — the rule is inclusive on the phone side.
+    {
+      name: 'touch device on the threshold',
+      coarse: true,
+      narrow: true,
+      w: 500,
+      h: 900,
+      set: 'mobile',
+    },
+    {
+      name: 'touch device one px over',
+      coarse: true,
+      narrow: true,
+      w: 501,
+      h: 900,
+      set: 'desktop',
+    },
     { name: 'iPad mini portrait', coarse: true, narrow: true, w: 744, h: 1133, set: 'desktop' },
     { name: 'iPad mini landscape', coarse: true, narrow: false, w: 1133, h: 744, set: 'desktop' },
     { name: 'Android tablet', coarse: true, narrow: true, w: 800, h: 1280, set: 'desktop' },
@@ -364,6 +389,52 @@ describe('iOS video priming', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Teardown — upstream returns nothing and never unregisters, so a remount stacked
+// a second listener set and a second unbounded rAF loop over the first.
+// ---------------------------------------------------------------------------
+describe('the disposer mountScrollWorld returns', () => {
+  it('stops listening, stops the frame loop, releases the clips and empties the host', async () => {
+    touchDeviceWithVideos('resolve');
+    const revoked: string[] = [];
+    URL.revokeObjectURL = (url: string) => void revoked.push(url);
+    const urls = stubFetch('ok');
+    const container = mount('teardown');
+    await flush();
+
+    const clips = container.querySelectorAll('video.sw-scene__video').length;
+    expect(clips).toBeGreaterThan(0);
+    const fetchesBefore = urls.length;
+
+    const dispose = disposers.pop();
+    if (!dispose) throw new Error('mountScrollWorld returned no disposer');
+    dispose();
+
+    expect(container.children).toHaveLength(0);
+    expect(container.classList.contains('sw-root')).toBe(false);
+    expect(revoked).toHaveLength(clips); // one blob released per live clip
+
+    // Nothing the engine used to listen to can wake it up again.
+    window.dispatchEvent(new Event('orientationchange'));
+    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    expect(urls).toHaveLength(fetchesBefore);
+
+    // And it is idempotent — React can call an effect cleanup more than once.
+    expect(() => dispose()).not.toThrow();
+  });
+
+  it('hands back a working disposer even when the config has no sections', () => {
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    stubMatchMedia({ coarse: false, narrow: false, reduce: false });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const dispose = mountScrollWorld(container, { sections: [] });
+    expect(() => dispose()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Bug A hardening — a successful fetch latched `loading` forever, so a clip that
 // then failed to decode wedged its scene; a failing fetch did the opposite and
 // re-requested on every scroll tick.
@@ -399,12 +470,13 @@ describe('clip failure recovery', () => {
     expect(attempts()).toBe(1);
 
     // orientationchange re-runs layout()→read() synchronously, i.e. a scroll tick.
-    // NOTE: the engine has no teardown API, so every mount from an earlier test in
-    // this file is still listening and will re-run its own read() on this event.
-    // That is why `configFor` gives each mount unique asset paths and every
-    // assertion here filters by prefix or by `container.contains`. A new assertion
-    // over an unscoped global (total fetch count, prototype spy call counts, a
-    // document-wide querySelectorAll) will pick up those foreign mounts — scope it.
+    // NOTE: window events reach EVERY live mount, not just this test's. afterEach now
+    // disposes each mount, so tests no longer leak into one another — but a single
+    // test that mounts twice still has two listeners on this event. The belt-and-
+    // braces stays: `configFor` gives each mount unique asset paths and assertions
+    // scope by prefix or `container.contains`. An assertion over an unscoped global
+    // (total fetch count, prototype spy counts, a document-wide querySelectorAll)
+    // would pick up the sibling mount — scope it the same way.
     for (let i = 0; i < 5; i++) {
       window.dispatchEvent(new Event('orientationchange'));
       await flush();

--- a/apps/landing/src/app/world/scrub-engine.test.ts
+++ b/apps/landing/src/app/world/scrub-engine.test.ts
@@ -93,7 +93,44 @@ function trackPriming(playResult: 'resolve' | 'reject' | 'no-promise') {
   ) {
     paused.push(this);
   });
+  // The engine calls load() when tearing a failed clip down; jsdom's stub only emits
+  // a virtual-console error, so silence it to keep failures readable.
+  vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
   return { played, paused };
+}
+
+/**
+ * Makes a <video> scrubbable in jsdom (which has no media stack) and reports the
+ * currentTime the engine seeks it to.
+ */
+function fakeMedia(video: HTMLVideoElement) {
+  const state = { currentTime: 0 };
+  Object.defineProperty(video, 'duration', { configurable: true, value: 1 });
+  Object.defineProperty(video, 'seeking', { configurable: true, value: false });
+  Object.defineProperty(video, 'currentTime', {
+    configurable: true,
+    get: () => state.currentTime,
+    set: (t: number) => {
+      state.currentTime = t;
+    },
+  });
+  return state;
+}
+
+/** Captures the engine's rAF callbacks so a single frame can be driven by hand. */
+function captureFrames() {
+  const frames: FrameRequestCallback[] = [];
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => frames.push(cb));
+  return () => {
+    const frame = frames[0];
+    if (!frame) throw new Error('engine never scheduled a frame');
+    frame(0);
+  };
+}
+
+/** Puts the page mid-scroll so segment 0 has a non-zero seek target. */
+function stubScrollY(y: number) {
+  Object.defineProperty(window, 'scrollY', { configurable: true, value: y });
 }
 
 const inside = (els: HTMLMediaElement[], container: HTMLElement) =>
@@ -119,6 +156,7 @@ afterEach(() => {
   URL.createObjectURL = originalCreateObjectURL;
   URL.revokeObjectURL = originalRevokeObjectURL;
   stubTouchPoints(0);
+  stubScrollY(0);
   document.body.replaceChildren();
 });
 
@@ -153,6 +191,40 @@ describe('device classification picks the asset set', () => {
     expect(poster).toBe(set === 'mobile' ? '/cls/m0.png' : '/cls/d0.png');
     expect(urls).toContain(set === 'mobile' ? '/cls/m0.mp4' : '/cls/d0.mp4');
     expect(urls).not.toContain(set === 'mobile' ? '/cls/d0.mp4' : '/cls/m0.mp4');
+  });
+
+  // The third consumer of the frozen classification, and the one the poster/clip
+  // assertions above can't see: raf()'s seek step (`eps`). A re-vendor that restored
+  // a live `isMobile()` at this call site alone would slip past every other test.
+  it('scrubs a tablet at the desktop seek step and a phone at the coarser one', async () => {
+    async function seekAfterOneFrame(prefix: string, w: number, h: number) {
+      const runFrame = captureFrames();
+      stubMatchMedia({ coarse: true, narrow: true, reduce: false });
+      stubScreen(w, h);
+      stubTouchPoints(5);
+      URL.createObjectURL = () => 'blob:scrub-engine-test';
+      trackPriming('resolve');
+      stubFetch('ok');
+      const container = mount(prefix);
+      await flush();
+
+      const video = container.querySelector('video');
+      if (!video) throw new Error('engine did not create a clip');
+      const media = fakeMedia(video);
+      video.dispatchEvent(new Event('loadedmetadata'));
+      runFrame();
+      return media.currentTime;
+    }
+
+    // Same scroll offset and the same 0.18 lerp for both, so the single lerped step
+    // is identical — it just lands between the two thresholds (0.008 and 0.02).
+    stubScrollY(60);
+    const tablet = await seekAfterOneFrame('epstab', 800, 1280);
+    const phone = await seekAfterOneFrame('epsphone', 430, 932);
+
+    expect(tablet).toBeGreaterThan(0.008);
+    expect(tablet).toBeLessThan(0.02);
+    expect(phone).toBe(0); // below the coarse step, so the seek is coalesced away
   });
 });
 
@@ -262,6 +334,22 @@ describe('iOS video priming', () => {
     expect(inside(played, container)).toHaveLength(0);
   });
 
+  it('gives up re-priming after 3 refusals rather than retrying on every touch', async () => {
+    const { played } = touchDeviceWithVideos('reject');
+    stubFetch('ok');
+    const container = mount('primecap');
+    await flush();
+
+    for (let i = 0; i < 6; i++) {
+      window.dispatchEvent(new Event('pointerdown'));
+      await flush();
+    }
+
+    const clips = container.querySelectorAll('video.sw-scene__video').length;
+    expect(clips).toBeGreaterThan(0);
+    expect(inside(played, container)).toHaveLength(clips * 3);
+  });
+
   it('pauses straight away when play() returns no promise (pre-promise WebKit)', async () => {
     const { played, paused } = touchDeviceWithVideos('no-promise');
     stubFetch('ok');
@@ -311,12 +399,59 @@ describe('clip failure recovery', () => {
     expect(attempts()).toBe(1);
 
     // orientationchange re-runs layout()→read() synchronously, i.e. a scroll tick.
+    // NOTE: the engine has no teardown API, so every mount from an earlier test in
+    // this file is still listening and will re-run its own read() on this event.
+    // That is why `configFor` gives each mount unique asset paths and every
+    // assertion here filters by prefix or by `container.contains`. A new assertion
+    // over an unscoped global (total fetch count, prototype spy call counts, a
+    // document-wide querySelectorAll) will pick up those foreign mounts — scope it.
     for (let i = 0; i < 5; i++) {
       window.dispatchEvent(new Event('orientationchange'));
       await flush();
       failClip();
     }
     expect(attempts()).toBe(3);
+  });
+
+  it('ignores late loadedmetadata / seeked from a video the segment has replaced', async () => {
+    // Tablet-classified so eps is the fine 0.008 — a wrongly-ready segment would
+    // visibly seek the live clip, which is what makes this assertion meaningful.
+    stubScrollY(60);
+    stubMatchMedia({ coarse: true, narrow: true, reduce: false });
+    stubScreen(800, 1280);
+    stubTouchPoints(5);
+    URL.createObjectURL = () => 'blob:scrub-engine-test';
+    URL.revokeObjectURL = () => {};
+    trackPriming('resolve');
+    const runFrame = captureFrames();
+    stubFetch('ok');
+    const container = mount('latemeta');
+    await flush();
+
+    const scene = sceneOf(container);
+    const first = scene.querySelector('video');
+    first?.dispatchEvent(new Event('error'));
+    window.dispatchEvent(new Event('orientationchange'));
+    await flush();
+
+    const second = scene.querySelector('video');
+    if (!second) throw new Error('engine did not retry the clip');
+    expect(second).not.toBe(first);
+    const media = fakeMedia(second);
+
+    // The discarded element finally reports metadata and a seek. Unguarded, this
+    // flags the segment ready and reveals it while the LIVE clip has no metadata,
+    // so raf() then scrubs it against the `duration || 1` fallback.
+    first?.dispatchEvent(new Event('loadedmetadata'));
+    first?.dispatchEvent(new Event('seeked'));
+    expect(scene.classList.contains('has-clip')).toBe(false);
+    runFrame();
+    expect(media.currentTime).toBe(0);
+
+    // Sanity: the live element's own metadata does mark the segment ready.
+    second.dispatchEvent(new Event('loadedmetadata'));
+    runFrame();
+    expect(media.currentTime).toBeGreaterThan(0);
   });
 
   it('ignores a late error from a video the segment has already replaced', async () => {

--- a/apps/landing/src/app/world/scrub-engine.test.ts
+++ b/apps/landing/src/app/world/scrub-engine.test.ts
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mountScrollWorld } from './scrub-engine';
+
+// Behavioural regression tests for the two device bugs the vendored engine shipped
+// with: iPhones showing every scene past the first as a frozen poster, and iPads
+// being served the low-quality portrait phone encodes. The engine is vanilla JS
+// with no exported internals, so everything here is asserted through what it does
+// to the DOM/network — which is also the only surface a re-vendor could break.
+//
+// jsdom never decodes media, so `loadedmetadata` / `loadeddata` / `seeked` never
+// fire here. That is exactly the iOS failure mode these tests need to reproduce:
+// a clip whose events never arrive must still be primed and must still recover.
+
+const CLIP_TIMEOUT = 0;
+
+const flush = () => new Promise<void>((resolve) => setTimeout(() => resolve(), CLIP_TIMEOUT));
+
+/** The three media queries the engine probes, driven per-test. */
+function stubMatchMedia(opts: { coarse: boolean; narrow: boolean; reduce: boolean }) {
+  vi.stubGlobal('matchMedia', (query: string) => {
+    let matches = opts.narrow; // '(max-width: 860px)'
+    if (query.includes('prefers-reduced-motion')) matches = opts.reduce;
+    else if (query.includes('pointer: coarse')) matches = opts.coarse;
+    return { matches, media: query, addEventListener() {}, removeEventListener() {} };
+  });
+}
+
+function stubScreen(width: number, height: number) {
+  Object.defineProperty(window.screen, 'width', { configurable: true, value: width });
+  Object.defineProperty(window.screen, 'height', { configurable: true, value: height });
+}
+
+/** Unique asset paths per test so earlier mounts' listeners can't pollute a filter. */
+function configFor(prefix: string) {
+  const section = (n: number) => ({
+    id: `${prefix}-${n}`,
+    label: `S${n}`,
+    title: `S${n}`,
+    accent: 'rebeccapurple',
+    still: `/${prefix}/d${n}.png`,
+    stillMobile: `/${prefix}/m${n}.png`,
+    clip: `/${prefix}/d${n}.mp4`,
+    clipMobile: `/${prefix}/m${n}.mp4`,
+  });
+  return {
+    nav: false,
+    atmosphere: false,
+    sections: [section(0), section(1)],
+    connectors: [`/${prefix}/c0.mp4`],
+    connectorsMobile: [`/${prefix}/c0m.mp4`],
+  };
+}
+
+function mount(prefix: string) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  mountScrollWorld(container, configFor(prefix));
+  return container;
+}
+
+/** Records every fetched URL; the returned promise factory controls resolution. */
+function stubFetch(mode: 'pending' | 'ok') {
+  const urls: string[] = [];
+  vi.stubGlobal('fetch', (url: string) => {
+    urls.push(url);
+    if (mode === 'pending') return new Promise<Response>(() => {});
+    const response = { ok: true, blob: () => Promise.resolve(new Blob()) };
+    return Promise.resolve(response as unknown as Response);
+  });
+  return urls;
+}
+
+/** Captures which <video> elements the engine tried to prime (muted play→pause). */
+function trackPriming(playResult: 'resolve' | 'reject') {
+  const played: HTMLMediaElement[] = [];
+  vi.spyOn(HTMLMediaElement.prototype, 'play').mockImplementation(function (
+    this: HTMLMediaElement
+  ) {
+    played.push(this);
+    return playResult === 'resolve'
+      ? Promise.resolve()
+      : Promise.reject(new Error('gesture required'));
+  });
+  vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+  return played;
+}
+
+const primedIn = (played: HTMLMediaElement[], container: HTMLElement) =>
+  played.filter((v) => container.contains(v));
+
+const originalCreateObjectURL = URL.createObjectURL;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  URL.createObjectURL = originalCreateObjectURL;
+  document.body.innerHTML = '';
+});
+
+// ---------------------------------------------------------------------------
+// Bug B — a coarse pointer alone used to mean "phone", so every tablet and touch
+// laptop got the 720x1280 crf28 portrait encodes (and desktop CSS then cropped
+// them). Mobile now means coarse AND a phone-sized screen, measured on the
+// screen's SHORT side so rotating the device can't flip the decision mid-session.
+// ---------------------------------------------------------------------------
+describe('device classification picks the asset set', () => {
+  const CASES = [
+    { name: 'iPhone 15 Pro Max', coarse: true, narrow: true, w: 430, h: 932, set: 'mobile' },
+    { name: 'Android phone', coarse: true, narrow: true, w: 412, h: 915, set: 'mobile' },
+    { name: 'iPad mini portrait', coarse: true, narrow: true, w: 744, h: 1133, set: 'desktop' },
+    { name: 'iPad mini landscape', coarse: true, narrow: false, w: 1133, h: 744, set: 'desktop' },
+    { name: 'Android tablet', coarse: true, narrow: true, w: 800, h: 1280, set: 'desktop' },
+    { name: 'touch laptop', coarse: true, narrow: false, w: 1512, h: 982, set: 'desktop' },
+    { name: 'desktop', coarse: false, narrow: false, w: 2560, h: 1440, set: 'desktop' },
+    // Preserved legacy behaviour: a non-touch window narrower than 860px still
+    // gets the light encodes — now frozen at mount instead of re-read per clip.
+    { name: 'narrow desktop window', coarse: false, narrow: true, w: 2560, h: 1440, set: 'mobile' },
+  ] as const;
+
+  it.each(CASES)('$name gets the $set set', ({ coarse, narrow, w, h, set }) => {
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    stubMatchMedia({ coarse, narrow, reduce: false });
+    stubScreen(w, h);
+    const urls = stubFetch('pending');
+    const container = mount('cls');
+
+    const poster = container.querySelector('.sw-scene__still')?.getAttribute('src');
+    expect(poster).toBe(set === 'mobile' ? '/cls/m0.png' : '/cls/d0.png');
+    expect(urls).toContain(set === 'mobile' ? '/cls/m0.mp4' : '/cls/d0.mp4');
+    expect(urls).not.toContain(set === 'mobile' ? '/cls/d0.mp4' : '/cls/m0.mp4');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug A — the primer was registered {once:true} and only reached the clips that
+// already existed at the first touch (segment 0). iOS refuses to load media data
+// for a video created outside a gesture, so every later clip stayed event-less
+// and its scene never left the poster.
+// ---------------------------------------------------------------------------
+describe('iOS video priming', () => {
+  function phoneWithVideos(playResult: 'resolve' | 'reject') {
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    stubMatchMedia({ coarse: true, narrow: true, reduce: false });
+    stubScreen(430, 932);
+    URL.createObjectURL = () => 'blob:scrub-engine-test';
+    return { played: trackPriming(playResult) };
+  }
+
+  it('primes clips that appear after the touch (their load events never fire on iOS)', async () => {
+    const { played } = phoneWithVideos('resolve');
+    const resolvers: Array<() => void> = [];
+    vi.stubGlobal(
+      'fetch',
+      () =>
+        new Promise<Response>((resolve) => {
+          const response = { ok: true, blob: () => Promise.resolve(new Blob()) };
+          resolvers.push(() => resolve(response as unknown as Response));
+        })
+    );
+    const container = mount('late');
+
+    // The touch lands while the clips are still in flight — nothing to prime yet.
+    window.dispatchEvent(new Event('pointerdown'));
+    expect(primedIn(played, container)).toHaveLength(0);
+
+    resolvers.forEach((resolve) => resolve());
+    await flush();
+
+    const videos = container.querySelectorAll('video.sw-scene__video');
+    expect(videos.length).toBeGreaterThan(0);
+    expect(primedIn(played, container)).toHaveLength(videos.length);
+  });
+
+  it('re-primes on a later touch when play() was refused (the listener is not once-only)', async () => {
+    const { played } = phoneWithVideos('reject');
+    stubFetch('ok');
+    const container = mount('retry');
+    await flush();
+
+    // Clips created before any gesture must not be primed yet.
+    expect(primedIn(played, container)).toHaveLength(0);
+
+    window.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    const afterFirstTouch = primedIn(played, container).length;
+    expect(afterFirstTouch).toBeGreaterThan(0);
+
+    // A once:true listener would be gone by now and this would stay flat.
+    window.dispatchEvent(new Event('touchstart'));
+    await flush();
+    expect(primedIn(played, container)).toHaveLength(afterFirstTouch * 2);
+  });
+
+  it('primes each clip only once while play() keeps succeeding', async () => {
+    const { played } = phoneWithVideos('resolve');
+    stubFetch('ok');
+    const container = mount('once');
+    await flush();
+
+    window.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    const primed = primedIn(played, container).length;
+
+    window.dispatchEvent(new Event('pointerdown'));
+    window.dispatchEvent(new Event('touchstart'));
+    await flush();
+    expect(primedIn(played, container)).toHaveLength(primed);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug A hardening — a successful fetch latched `loading` forever, so a clip that
+// then failed to decode wedged its scene; a failing fetch did the opposite and
+// re-requested on every scroll tick.
+// ---------------------------------------------------------------------------
+describe('clip failure recovery', () => {
+  it('drops the dead video back to its poster and stops retrying after 3 attempts', async () => {
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    stubMatchMedia({ coarse: true, narrow: true, reduce: false });
+    stubScreen(430, 932);
+    URL.createObjectURL = () => 'blob:scrub-engine-test';
+    trackPriming('resolve');
+    const urls = stubFetch('ok');
+    const container = mount('fail');
+    await flush();
+
+    const scene = container.querySelector('.sw-scene');
+    if (!scene) throw new Error('engine did not build a scene');
+    // The engine only adds has-clip on `seeked`, which jsdom never fires; set it
+    // by hand so the error path's cleanup of it is actually observable.
+    scene.classList.add('has-clip');
+    const failClip = () => scene.querySelector('video')?.dispatchEvent(new Event('error'));
+
+    failClip();
+    expect(scene.querySelector('video')).toBeNull();
+    expect(scene.classList.contains('has-clip')).toBe(false);
+
+    const attempts = () => urls.filter((u) => u === '/fail/m0.mp4').length;
+    expect(attempts()).toBe(1);
+
+    // orientationchange re-runs layout()→read() synchronously, i.e. a scroll tick.
+    for (let i = 0; i < 5; i++) {
+      window.dispatchEvent(new Event('orientationchange'));
+      await flush();
+      failClip();
+    }
+    expect(attempts()).toBe(3);
+  });
+});

--- a/apps/landing/src/app/world/scrub-engine.test.ts
+++ b/apps/landing/src/app/world/scrub-engine.test.ts
@@ -13,9 +13,7 @@ import { mountScrollWorld } from './scrub-engine';
 // fire here. That is exactly the iOS failure mode these tests need to reproduce:
 // a clip whose events never arrive must still be primed and must still recover.
 
-const CLIP_TIMEOUT = 0;
-
-const flush = () => new Promise<void>((resolve) => setTimeout(() => resolve(), CLIP_TIMEOUT));
+const flush = () => new Promise<void>((resolve) => setTimeout(() => resolve(), 0));
 
 /** The three media queries the engine probes, driven per-test. */
 function stubMatchMedia(opts: { coarse: boolean; narrow: boolean; reduce: boolean }) {
@@ -30,6 +28,11 @@ function stubMatchMedia(opts: { coarse: boolean; narrow: boolean; reduce: boolea
 function stubScreen(width: number, height: number) {
   Object.defineProperty(window.screen, 'width', { configurable: true, value: width });
   Object.defineProperty(window.screen, 'height', { configurable: true, value: height });
+}
+
+/** Drives the priming gate — deliberately independent of the coarse-pointer query. */
+function stubTouchPoints(points: number) {
+  Object.defineProperty(window.navigator, 'maxTouchPoints', { configurable: true, value: points });
 }
 
 /** Unique asset paths per test so earlier mounts' listeners can't pollute a filter. */
@@ -73,30 +76,50 @@ function stubFetch(mode: 'pending' | 'ok') {
 }
 
 /** Captures which <video> elements the engine tried to prime (muted play→pause). */
-function trackPriming(playResult: 'resolve' | 'reject') {
+function trackPriming(playResult: 'resolve' | 'reject' | 'no-promise') {
   const played: HTMLMediaElement[] = [];
+  const paused: HTMLMediaElement[] = [];
   vi.spyOn(HTMLMediaElement.prototype, 'play').mockImplementation(function (
     this: HTMLMediaElement
   ) {
     played.push(this);
+    if (playResult === 'no-promise') return undefined as unknown as Promise<void>;
     return playResult === 'resolve'
       ? Promise.resolve()
       : Promise.reject(new Error('gesture required'));
   });
-  vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
-  return played;
+  vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(function (
+    this: HTMLMediaElement
+  ) {
+    paused.push(this);
+  });
+  return { played, paused };
 }
 
-const primedIn = (played: HTMLMediaElement[], container: HTMLElement) =>
-  played.filter((v) => container.contains(v));
+const inside = (els: HTMLMediaElement[], container: HTMLElement) =>
+  els.filter((v) => container.contains(v));
 
 const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+/** A touch device whose clips actually materialise as <video> elements. */
+function touchDeviceWithVideos(playResult: 'resolve' | 'reject' | 'no-promise') {
+  vi.stubGlobal('requestAnimationFrame', () => 0);
+  stubMatchMedia({ coarse: true, narrow: true, reduce: false });
+  stubScreen(430, 932);
+  stubTouchPoints(5);
+  URL.createObjectURL = () => 'blob:scrub-engine-test';
+  URL.revokeObjectURL = () => {};
+  return trackPriming(playResult);
+}
 
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   URL.createObjectURL = originalCreateObjectURL;
-  document.body.innerHTML = '';
+  URL.revokeObjectURL = originalRevokeObjectURL;
+  stubTouchPoints(0);
+  document.body.replaceChildren();
 });
 
 // ---------------------------------------------------------------------------
@@ -140,16 +163,8 @@ describe('device classification picks the asset set', () => {
 // and its scene never left the poster.
 // ---------------------------------------------------------------------------
 describe('iOS video priming', () => {
-  function phoneWithVideos(playResult: 'resolve' | 'reject') {
-    vi.stubGlobal('requestAnimationFrame', () => 0);
-    stubMatchMedia({ coarse: true, narrow: true, reduce: false });
-    stubScreen(430, 932);
-    URL.createObjectURL = () => 'blob:scrub-engine-test';
-    return { played: trackPriming(playResult) };
-  }
-
   it('primes clips that appear after the touch (their load events never fire on iOS)', async () => {
-    const { played } = phoneWithVideos('resolve');
+    const { played } = touchDeviceWithVideos('resolve');
     const resolvers: Array<() => void> = [];
     vi.stubGlobal(
       'fetch',
@@ -163,50 +178,100 @@ describe('iOS video priming', () => {
 
     // The touch lands while the clips are still in flight — nothing to prime yet.
     window.dispatchEvent(new Event('pointerdown'));
-    expect(primedIn(played, container)).toHaveLength(0);
+    expect(inside(played, container)).toHaveLength(0);
 
     resolvers.forEach((resolve) => resolve());
     await flush();
 
     const videos = container.querySelectorAll('video.sw-scene__video');
     expect(videos.length).toBeGreaterThan(0);
-    expect(primedIn(played, container)).toHaveLength(videos.length);
+    expect(inside(played, container)).toHaveLength(videos.length);
   });
 
   it('re-primes on a later touch when play() was refused (the listener is not once-only)', async () => {
-    const { played } = phoneWithVideos('reject');
+    const { played } = touchDeviceWithVideos('reject');
     stubFetch('ok');
     const container = mount('retry');
     await flush();
 
     // Clips created before any gesture must not be primed yet.
-    expect(primedIn(played, container)).toHaveLength(0);
+    expect(inside(played, container)).toHaveLength(0);
 
     window.dispatchEvent(new Event('pointerdown'));
     await flush();
-    const afterFirstTouch = primedIn(played, container).length;
+    const afterFirstTouch = inside(played, container).length;
     expect(afterFirstTouch).toBeGreaterThan(0);
 
     // A once:true listener would be gone by now and this would stay flat.
     window.dispatchEvent(new Event('touchstart'));
     await flush();
-    expect(primedIn(played, container)).toHaveLength(afterFirstTouch * 2);
+    expect(inside(played, container)).toHaveLength(afterFirstTouch * 2);
   });
 
   it('primes each clip only once while play() keeps succeeding', async () => {
-    const { played } = phoneWithVideos('resolve');
+    const { played } = touchDeviceWithVideos('resolve');
     stubFetch('ok');
     const container = mount('once');
     await flush();
 
     window.dispatchEvent(new Event('pointerdown'));
     await flush();
-    const primed = primedIn(played, container).length;
+    const primed = inside(played, container).length;
 
     window.dispatchEvent(new Event('pointerdown'));
     window.dispatchEvent(new Event('touchstart'));
     await flush();
-    expect(primedIn(played, container)).toHaveLength(primed);
+    expect(inside(played, container)).toHaveLength(primed);
+  });
+
+  it('primes a trackpad-attached iPad, which reports a fine pointer but is still touch', async () => {
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    // iPadOS 13.4+ with a Magic Keyboard: hover:hover + pointer:fine, yet WebKit
+    // still gates media loading on a gesture. `coarse` misses this device entirely.
+    stubMatchMedia({ coarse: false, narrow: false, reduce: false });
+    stubScreen(1024, 1366);
+    stubTouchPoints(5);
+    URL.createObjectURL = () => 'blob:scrub-engine-test';
+    const { played } = trackPriming('resolve');
+    stubFetch('ok');
+    const container = mount('ipadtrackpad');
+    await flush();
+
+    window.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    const videos = container.querySelectorAll('video.sw-scene__video');
+    expect(videos.length).toBeGreaterThan(0);
+    expect(inside(played, container)).toHaveLength(videos.length);
+  });
+
+  it('never primes on a non-touch desktop', async () => {
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    stubMatchMedia({ coarse: false, narrow: false, reduce: false });
+    stubScreen(2560, 1440);
+    stubTouchPoints(0);
+    URL.createObjectURL = () => 'blob:scrub-engine-test';
+    const { played } = trackPriming('resolve');
+    stubFetch('ok');
+    const container = mount('nontouch');
+    await flush();
+
+    expect(container.querySelectorAll('video.sw-scene__video').length).toBeGreaterThan(0);
+    window.dispatchEvent(new Event('pointerdown'));
+    window.dispatchEvent(new Event('touchstart'));
+    await flush();
+    expect(inside(played, container)).toHaveLength(0);
+  });
+
+  it('pauses straight away when play() returns no promise (pre-promise WebKit)', async () => {
+    const { played, paused } = touchDeviceWithVideos('no-promise');
+    stubFetch('ok');
+    const container = mount('nopromise');
+    await flush();
+
+    window.dispatchEvent(new Event('pointerdown'));
+    await flush();
+    expect(inside(played, container).length).toBeGreaterThan(0);
+    expect(inside(paused, container)).toHaveLength(inside(played, container).length);
   });
 });
 
@@ -216,18 +281,21 @@ describe('iOS video priming', () => {
 // re-requested on every scroll tick.
 // ---------------------------------------------------------------------------
 describe('clip failure recovery', () => {
+  function sceneOf(container: HTMLElement) {
+    const scene = container.querySelector('.sw-scene');
+    if (!scene) throw new Error('engine did not build a scene');
+    return scene;
+  }
+
   it('drops the dead video back to its poster and stops retrying after 3 attempts', async () => {
-    vi.stubGlobal('requestAnimationFrame', () => 0);
-    stubMatchMedia({ coarse: true, narrow: true, reduce: false });
-    stubScreen(430, 932);
-    URL.createObjectURL = () => 'blob:scrub-engine-test';
-    trackPriming('resolve');
+    touchDeviceWithVideos('resolve');
+    const revoked: string[] = [];
+    URL.revokeObjectURL = (url: string) => void revoked.push(url);
     const urls = stubFetch('ok');
     const container = mount('fail');
     await flush();
 
-    const scene = container.querySelector('.sw-scene');
-    if (!scene) throw new Error('engine did not build a scene');
+    const scene = sceneOf(container);
     // The engine only adds has-clip on `seeked`, which jsdom never fires; set it
     // by hand so the error path's cleanup of it is actually observable.
     scene.classList.add('has-clip');
@@ -236,6 +304,8 @@ describe('clip failure recovery', () => {
     failClip();
     expect(scene.querySelector('video')).toBeNull();
     expect(scene.classList.contains('has-clip')).toBe(false);
+    // The discarded blob is released; live clips deliberately keep theirs.
+    expect(revoked).toEqual(['blob:scrub-engine-test']);
 
     const attempts = () => urls.filter((u) => u === '/fail/m0.mp4').length;
     expect(attempts()).toBe(1);
@@ -247,5 +317,31 @@ describe('clip failure recovery', () => {
       failClip();
     }
     expect(attempts()).toBe(3);
+  });
+
+  it('ignores a late error from a video the segment has already replaced', async () => {
+    touchDeviceWithVideos('resolve');
+    stubFetch('ok');
+    const container = mount('stale');
+    await flush();
+
+    const scene = sceneOf(container);
+    const first = scene.querySelector('video');
+    first?.dispatchEvent(new Event('error'));
+    window.dispatchEvent(new Event('orientationchange'));
+    await flush();
+
+    const second = scene.querySelector('video');
+    expect(second).toBeTruthy();
+    expect(second).not.toBe(first);
+
+    // The discarded element errors again; without the identity guard this resets
+    // the segment and the next tick stacks a third <video> over the live one.
+    first?.dispatchEvent(new Event('error'));
+    window.dispatchEvent(new Event('orientationchange'));
+    await flush();
+
+    expect(scene.querySelectorAll('video')).toHaveLength(1);
+    expect(scene.querySelector('video')).toBe(second);
   });
 });

--- a/docs/adr/0019-scroll-world-landing-route.md
+++ b/docs/adr/0019-scroll-world-landing-route.md
@@ -86,17 +86,32 @@ Now a phone is a coarse pointer **and** a phone-sized screen, tested on the scre
 
 The result is a `const` evaluated **once at mount**, not a function: a live check let a resize serve one scene's poster from one set and the next scene's clip from the other. **Behaviour change:** a desktop browser resized (or a DevTools device toggle flipped) across 860px no longer switches asset sets without a reload.
 
-`coarse` on its own is still the right gate for the particle drop, the URL-bar resize guard, and video priming (D3) — those are touch-browser traits, not asset-tier choices. The two must not be conflated.
+Three call sites consume it: the scene poster (`stillMobile` vs `still`), the clip URL in `loadClip`, and — easy to miss — the `raf()` seek step `eps`. Tablets therefore also move from the phone's coarse `0.02` to the desktop `0.008`, i.e. finer scrubbing and more decodes. That is the intended pairing with the heavier desktop encode they now receive, and it stays bounded by the existing `s.video.seeking` coalescer, which already refuses to queue a seek while the decoder is busy.
+
+`coarse` on its own remains the gate for the particle drop and the URL-bar resize guard — genuine touch-browser traits. It is **not** the gate for priming; see D3.
 
 ### D3 — iOS priming: persistent listeners + prime on creation
 
 Upstream registered the primer `{once:true}` on `pointerdown`/`touchstart`, so it only reached videos that existed at the first touch — in practice segment 0 alone, because `loadClip` is gated on scroll proximity. iOS WebKit refuses to load media data for a video created outside a gesture, so every later clip never fired `loadeddata`/`loadedmetadata`, `s.ready` stayed false, `raf()` skipped it, `seeked` never fired, `has-clip` was never added, and every scene past the first showed its poster forever.
 
-Two changes: `loadClip` primes a clip **immediately on creation** when `userReady` is already set (a muted + `playsinline` `play()` _is_ permitted outside a gesture and forces the data load), and the gesture listeners **stay registered** (still passive) so any later touch primes anything still unprimed — which also covers a first touch landing while segment 0's blob fetch is in flight. `primeVideo` now takes the segment and dedupes on a per-segment `s.primed` flag (reset if `play()` is refused, so the next gesture retries); it is gated on `coarse`, not `isMobile`, because iPads need priming even though D2 gives them the desktop set.
+Two changes: `loadClip` primes a clip **immediately on creation** when `userReady` is already set (a muted + `playsinline` `play()` _is_ permitted outside a gesture and forces the data load), and the gesture listeners **stay registered** (still passive) so any later touch primes anything still unprimed — which also covers a first touch landing while segment 0's blob fetch is in flight. `primeVideo` now takes the segment and dedupes on a per-segment `s.primed` flag (reset if `play()` is refused, so the next gesture retries).
+
+The priming gate is `canTouch = navigator.maxTouchPoints > 0`, evaluated once at mount — **not** `coarse` and **not** `isMobile`:
+
+- Not `isMobile`, because WebKit's gesture-gated media loading is a browser policy, not an asset tier — iPads need priming even though D2 now gives them the desktop set.
+- Not `coarse`, because since iPadOS 13.4 an iPad with a Magic Keyboard/trackpad reports `hover:hover` + `pointer:fine`. A `coarse` gate leaves exactly that configuration on posters forever — the original bug, on a device the original fix's rationale claimed to cover.
+
+`maxTouchPoints` catches every touch-capable browser. The cost is a harmless muted `play()`→`pause()` on Windows touch laptops; a real desktop reports `0` and never primes at all (locked by a test, since that guard is the only thing standing between desktop and a burst of spurious `play()` calls).
+
+`play()` returning a non-promise (pre-promise WebKit) now pauses on the spot rather than leaving the clip running under the scrubber.
 
 ### D4 — bounded clip-failure recovery
 
 Upstream latched `s.loading = true` forever on success (a clip that then failed to decode wedged its scene on the poster with no path back) while a failing `fetch` cleared the latch and re-requested on **every scroll tick**. An `error` listener on the video now removes the dead element, drops `has-clip`, and resets the segment so a later scroll can retry; a per-segment `s.tries` counter caps that at 3 attempts, so neither failure mode storms or wedges.
+
+The handler's first line is an identity guard, `if (s.video !== v) return;`. Media elements can fire `error` more than once and a discarded element outlives its replacement, so without it a late error from an already-replaced `<video>` resets the segment while the **live** clip is still mounted — freezing that clip and stacking a second `<video>` into the scene on the next tick.
+
+Teardown also calls `URL.revokeObjectURL(v.src)`. Live clips keeping their blob URL for the page's lifetime stays deliberate (they must remain seekable); a torn-down element is a different case, and without the revoke a failing segment leaks a multi-MB blob per retry.
 
 ### D5 — header doc comment
 

--- a/docs/adr/0019-scroll-world-landing-route.md
+++ b/docs/adr/0019-scroll-world-landing-route.md
@@ -80,13 +80,13 @@ Turbopack statically analyzes this file as ESM and doesn't see the conditional C
 
 ### D2 — device classification: coarse **and** phone-sized, frozen at mount
 
-Upstream: `const isMobile = () => coarse || smallMQ.matches`, consulted live per clip. `(hover:none) and (pointer:coarse)` matches iPadOS, Android tablets and touch laptops at **any** width, so every tablet permanently took the 720×1280 crf28 portrait phone encodes, the AV1 desktop branch was dead for them, and desktop CSS (>860px) cropped/upscaled a portrait video.
+Upstream classified on the coarse-pointer query **or** a narrow viewport, re-read live on every clip load. A coarse pointer matches iPadOS, Android tablets and touch laptops at **any** width, so every tablet permanently took the portrait phone encodes, the AV1 desktop branch was dead for them, and the desktop stylesheet cropped/upscaled a portrait video.
 
-Now a phone is a coarse pointer **and** a phone-sized screen, tested on the screen's **short side** (`Math.min(screen.width, screen.height) <= 500`) so rotating the device can't flip the decision — iPhone Pro Max ≈440 → phone, iPad mini 744 → desktop. Non-touch windows keep the legacy `≤860px` rule.
+The rule is now: a phone is a coarse pointer **and** a phone-sized screen. "Phone-sized" is measured on the screen's **short side**, so rotating the device cannot flip the decision and a large phone still classifies as a phone. Non-touch windows keep the legacy narrow-viewport rule. The predicate and its threshold live in the `isMobile` const at the top of `mountScrollWorld` (`scrub-engine.js`) — read it there rather than duplicating the number here.
 
-The result is a `const` evaluated **once at mount**, not a function: a live check let a resize serve one scene's poster from one set and the next scene's clip from the other. **Behaviour change:** a desktop browser resized (or a DevTools device toggle flipped) across 860px no longer switches asset sets without a reload.
+It is a `const` evaluated **once at mount**, not a function: a live check let a resize serve one scene's poster from one set and the next scene's clip from the other. **Behaviour change:** resizing a desktop browser (or flipping a DevTools device toggle) across the narrow-viewport breakpoint no longer switches asset sets without a reload.
 
-Three call sites consume it: the scene poster (`stillMobile` vs `still`), the clip URL in `loadClip`, and — easy to miss — the `raf()` seek step `eps`. Tablets therefore also move from the phone's coarse `0.02` to the desktop `0.008`, i.e. finer scrubbing and more decodes. That is the intended pairing with the heavier desktop encode they now receive, and it stays bounded by the existing `s.video.seeking` coalescer, which already refuses to queue a seek while the decoder is busy.
+Three call sites consume it: the scene poster (`stillMobile` vs `still`), the clip URL in `loadClip`, and — easy to miss — the seek step `eps` in `raf()`. Tablets therefore also move from the coarse phone step to the finer desktop one: more decodes, finer scrubbing. That is the intended pairing with the heavier desktop encode they now receive, and it stays bounded by the existing `s.video.seeking` coalescer, which already refuses to queue a seek while the decoder is busy. Both step values are in `raf()`.
 
 `coarse` on its own remains the gate for the particle drop and the URL-bar resize guard — genuine touch-browser traits. It is **not** the gate for priming; see D3.
 
@@ -103,11 +103,11 @@ The priming gate is `canTouch = navigator.maxTouchPoints > 0`, evaluated once at
 
 `maxTouchPoints` catches every touch-capable browser. The cost is a harmless muted `play()`→`pause()` on Windows touch laptops; a real desktop reports `0` and never primes at all (locked by a test, since that guard is the only thing standing between desktop and a burst of spurious `play()` calls).
 
-`play()` returning a non-promise (pre-promise WebKit) now pauses on the spot rather than leaving the clip running under the scrubber. A per-segment `s.primeTries` caps priming at 3 attempts, mirroring `s.tries` in D4 — a browser that refuses muted playback outright would otherwise take a fresh `play()` on every `pointerdown` for the life of the page, since a refusal deliberately clears `s.primed`.
+`play()` returning a non-promise (pre-promise WebKit) now pauses on the spot rather than leaving the clip running under the scrubber. A per-segment `s.primeTries` bounds priming the way `s.tries` bounds fetches in D4 (cap in the `primeVideo` guard) — a browser that refuses muted playback outright would otherwise take a fresh `play()` on every `pointerdown` for the life of the page, since a refusal deliberately clears `s.primed`.
 
 ### D4 — bounded clip-failure recovery
 
-Upstream latched `s.loading = true` forever on success (a clip that then failed to decode wedged its scene on the poster with no path back) while a failing `fetch` cleared the latch and re-requested on **every scroll tick**. An `error` listener on the video now removes the dead element, drops `has-clip`, and resets the segment so a later scroll can retry; a per-segment `s.tries` counter caps that at 3 attempts, so neither failure mode storms or wedges.
+Upstream latched `s.loading = true` forever on success (a clip that then failed to decode wedged its scene on the poster with no path back) while a failing `fetch` cleared the latch and re-requested on **every scroll tick**. An `error` listener on the video now removes the dead element, drops `has-clip`, and resets the segment so a later scroll can retry; a per-segment `s.tries` counter bounds the retries (cap in `loadClip`'s guard), so neither failure mode storms or wedges.
 
 **Every** listener on the clip now opens with a shared liveness check, `const live = () => s.video === v;`. Media elements keep firing after a segment has torn them down and replaced them, and a discarded element outlives its replacement, so an unguarded late event mutates the state of the **live** clip:
 
@@ -116,13 +116,21 @@ Upstream latched `s.loading = true` forever on success (a clip that then failed 
 - `seeked` (`{once:true}`) — adds `has-clip`, hiding the poster to reveal a video that was never painted.
 - `loadeddata` — `v.pause()` stays unguarded (it must pause the element that fired), but the priming decision is gated.
 
-Teardown order matters: `v.removeAttribute('src')` + `v.load()` run **before** `URL.revokeObjectURL(...)`, because a detached element can hold decoder resources until its source is dropped and the load algorithm re-run — and the retry path can produce up to three such elements per segment. Live clips keeping their blob URL for the page's lifetime stays deliberate (they must remain seekable); a torn-down element is a different case, and without the revoke a failing segment leaks a multi-MB blob per retry.
+Discarding a clip goes through one shared `releaseClip(v)` helper, and its order matters: `pause()` → `removeAttribute('src')` → `load()` → **then** `URL.revokeObjectURL(...)`. A detached element can hold decoder resources until its source is dropped and the load algorithm re-run, and the retry path produces one such element per attempt. Live clips keeping their blob URL for the page's lifetime stays deliberate (they must remain seekable); a clip being thrown away is a different case, and without the revoke a failing segment leaks a multi-MB blob per retry. D6's disposer reuses the same helper.
 
 ### D5 — header doc comment
 
-The file's usage/`MOBILE` comment block was updated to describe D2–D4 accurately (frozen phone/desktop split, continuous priming). No behaviour.
+The file's usage/`MOBILE` comment block was updated to describe D2–D4 and D6 accurately (frozen phone/desktop split, continuous priming, the returned disposer). No behaviour.
 
 It also no longer lists the particle drop and the URL-bar resize guard as phone-tier behaviours: both key off the coarse pointer **alone**, so tablets get them too. As written before, the header contradicted the inline comments and D2. The block now states all three gates explicitly.
+
+### D6 — the mount returns a disposer
+
+Upstream `mountScrollWorld` returns nothing and never unregisters: it leaves `pointerdown`/`touchstart`/`scroll`/`resize`/`orientationchange`/`load` listeners on `window` plus a self-rescheduling rAF loop, and holds every clip's blob URL. A second mount — React StrictMode's dev double-invoke, a client-side route change, consecutive tests — therefore stacked a whole second engine over the first, driving detached DOM forever.
+
+It now returns an idempotent disposer that cancels the pending frame, removes all six listeners, releases each clip via `releaseClip`, and empties the container. `read()` and `raf()` early-return once torn down, and `loadClip`'s `fetch` continuation bails if the mount died while a clip was in flight, so a late resolution can't append a `<video>` to a dead scene. An empty config returns a no-op disposer rather than `undefined`. The injected `<style id="sw-css">` is deliberately **not** removed: it is id-guarded and may be shared with another live mount.
+
+Consequences: `scrub-engine.d.ts` returns `() => void`; `WorldClient.tsx` returns it straight from its `useEffect` and no longer needs the `mountedRef` StrictMode latch, so `/world` no longer has to be entered via a full navigation; the test file disposes every mount in `afterEach` instead of relying purely on per-mount asset-path scoping.
 
 ### Runtime consequence of D2 for AV1
 

--- a/docs/adr/0019-scroll-world-landing-route.md
+++ b/docs/adr/0019-scroll-world-landing-route.md
@@ -103,19 +103,26 @@ The priming gate is `canTouch = navigator.maxTouchPoints > 0`, evaluated once at
 
 `maxTouchPoints` catches every touch-capable browser. The cost is a harmless muted `play()`→`pause()` on Windows touch laptops; a real desktop reports `0` and never primes at all (locked by a test, since that guard is the only thing standing between desktop and a burst of spurious `play()` calls).
 
-`play()` returning a non-promise (pre-promise WebKit) now pauses on the spot rather than leaving the clip running under the scrubber.
+`play()` returning a non-promise (pre-promise WebKit) now pauses on the spot rather than leaving the clip running under the scrubber. A per-segment `s.primeTries` caps priming at 3 attempts, mirroring `s.tries` in D4 — a browser that refuses muted playback outright would otherwise take a fresh `play()` on every `pointerdown` for the life of the page, since a refusal deliberately clears `s.primed`.
 
 ### D4 — bounded clip-failure recovery
 
 Upstream latched `s.loading = true` forever on success (a clip that then failed to decode wedged its scene on the poster with no path back) while a failing `fetch` cleared the latch and re-requested on **every scroll tick**. An `error` listener on the video now removes the dead element, drops `has-clip`, and resets the segment so a later scroll can retry; a per-segment `s.tries` counter caps that at 3 attempts, so neither failure mode storms or wedges.
 
-The handler's first line is an identity guard, `if (s.video !== v) return;`. Media elements can fire `error` more than once and a discarded element outlives its replacement, so without it a late error from an already-replaced `<video>` resets the segment while the **live** clip is still mounted — freezing that clip and stacking a second `<video>` into the scene on the next tick.
+**Every** listener on the clip now opens with a shared liveness check, `const live = () => s.video === v;`. Media elements keep firing after a segment has torn them down and replaced them, and a discarded element outlives its replacement, so an unguarded late event mutates the state of the **live** clip:
 
-Teardown also calls `URL.revokeObjectURL(v.src)`. Live clips keeping their blob URL for the page's lifetime stays deliberate (they must remain seekable); a torn-down element is a different case, and without the revoke a failing segment leaks a multi-MB blob per retry.
+- `error` — resets the segment while the live clip is mounted, freezing it and stacking a second `<video>` into the scene on the next tick.
+- `loadedmetadata` — sets `s.ready = true` when the live video has no metadata at all, after which `raf()` scrubs it against the `duration || 1` fallback.
+- `seeked` (`{once:true}`) — adds `has-clip`, hiding the poster to reveal a video that was never painted.
+- `loadeddata` — `v.pause()` stays unguarded (it must pause the element that fired), but the priming decision is gated.
+
+Teardown order matters: `v.removeAttribute('src')` + `v.load()` run **before** `URL.revokeObjectURL(...)`, because a detached element can hold decoder resources until its source is dropped and the load algorithm re-run — and the retry path can produce up to three such elements per segment. Live clips keeping their blob URL for the page's lifetime stays deliberate (they must remain seekable); a torn-down element is a different case, and without the revoke a failing segment leaks a multi-MB blob per retry.
 
 ### D5 — header doc comment
 
 The file's usage/`MOBILE` comment block was updated to describe D2–D4 accurately (frozen phone/desktop split, continuous priming). No behaviour.
+
+It also no longer lists the particle drop and the URL-bar resize guard as phone-tier behaviours: both key off the coarse pointer **alone**, so tablets get them too. As written before, the header contradicted the inline comments and D2. The block now states all three gates explicitly.
 
 ### Runtime consequence of D2 for AV1
 

--- a/docs/adr/0019-scroll-world-landing-route.md
+++ b/docs/adr/0019-scroll-world-landing-route.md
@@ -24,8 +24,8 @@ Six dive scenes tell the story (slump → doomscroll → workshop → robot engi
 
 - **Source**: `apps/landing/src/app/world/scrub-engine.js` — portable vanilla-JS (zero dependencies) scroll-scrubbing engine, framework-agnostic (works in plain HTML, Next, Vue, server-rendered, anything).
 - **Mount point**: `WorldClient.tsx` — a React client component (`'use client'`) that calls `mountScrollWorld(container, config)` from a `useEffect` hook and mounts the engine's DOM + CSS into a `<div id="world">` ref.
-- **Byte fidelity**: The engine file is vendored verbatim from the scroll-world skill. **One documented deviation is present and must be re-applied on future re-vendors**: the file ends with `export { mountScrollWorld }` (lines 450–456) as an ESM export. Reason: Turbopack statically analyzes this file and doesn't see the conditional CJS tail (`typeof module !== 'undefined' && …`), so without an explicit `export` the dev import resolves to no exports and `/world` returns a 500. The real export converts the file to an ES module, but the CJS/global paths above still run unchanged — **the file remains portable**. When re-vendoring the engine from upstream, preserve this export line.
-- **Mobile awareness**: The engine is phone-aware out of the box. It detects coarse-pointer (touch) + ≤860px viewport, loads lighter `clipMobile` / `connectorsMobile` variants when provided, primes video decoders on first touch (iOS workaround), coalesces seek requests (prevents frame-pile freezes), and drops particle effects on mobile.
+- **Byte fidelity**: The engine file is vendored from the scroll-world skill and stays as close to verbatim as possible. **Every deviation must be listed in the deviation log below and re-applied on future re-vendors**; edits stay minimal and well-scoped so a future re-vendor diff remains readable.
+- **Mobile awareness**: The engine is phone-aware out of the box. It classifies the device once at mount (coarse pointer **and** a phone-sized screen — see D2), loads lighter `clipMobile` / `connectorsMobile` variants when provided, primes video decoders on touch (iOS workaround — see D3), coalesces seek requests (prevents frame-pile freezes), and drops particle effects on touch devices.
 - **A11y**: On `prefers-reduced-motion: reduce`, the engine loads stills + copy, skips video playback, and presents a static fallback view. This is built into the engine.
 
 ### Media pipeline (local, zero cost)
@@ -66,22 +66,45 @@ All media is same-origin (`apps/landing/public/world/`). The scrub-engine inject
 - **Mobile exclusion optional**: A page can use the engine with `clip` + `connectors` only (no mobile variants); it still works on phones (just heavier). `clipMobile` + `connectorsMobile` are opt-in optimizations.
 - **Edit safety**: When editing the `scrub-engine.js` file, **use Bash heredoc (`cat >> file <<'EOF'`)** or direct file operations (not the Edit tool). The Edit tool's post-processing rewrites the file wholesale, which strips the vendored-integrity guarantee. Commit the file with `git diff` to verify byte-for-byte fidelity against the source before pushing.
 
-## Addendum: The ESM-export deviation
+## Addendum: engine deviation log
 
-The vendored engine file includes one modification from the upstream skill's original:
+`scrub-engine.js` is vendored third-party code. Every change from the upstream skill's original is recorded here and **must be re-applied on a re-vendor**. `apps/landing/src/app/world/scrub-engine.test.ts` is the mechanical guard: it mounts the engine in jsdom and asserts D2–D4 behaviourally, so a re-vendor that drops a deviation fails `pnpm -F @ajh/landing test` instead of silently regressing on hardware nobody has to hand.
+
+### D1 — ESM export (Turbopack)
 
 ```javascript
-// Line 450–456 (re-apply on re-vendoring)
-// Deviation from the vendored original (re-apply this line on re-vendoring):
-// Turbopack statically analyzes this file as ESM and doesn't see the
-// conditional CJS tail above, so without a real `export` the dev import
-// resolves to no exports and /world 500s. A real export just makes this an
-// ES module too (`typeof module` stays safely undefined); the CJS/global
-// lines above still run unchanged.
 export { mountScrollWorld };
 ```
 
-This is the **only** documented change from the upstream source. On future re-vendors, reapply this export line to maintain Turbopack compatibility.
+Turbopack statically analyzes this file as ESM and doesn't see the conditional CJS tail above it, so without a real `export` the dev import resolves to no exports and `/world` 500s. A real export just makes this an ES module too (`typeof module` stays safely undefined); the CJS/global lines still run unchanged — **the file remains portable**.
+
+### D2 — device classification: coarse **and** phone-sized, frozen at mount
+
+Upstream: `const isMobile = () => coarse || smallMQ.matches`, consulted live per clip. `(hover:none) and (pointer:coarse)` matches iPadOS, Android tablets and touch laptops at **any** width, so every tablet permanently took the 720×1280 crf28 portrait phone encodes, the AV1 desktop branch was dead for them, and desktop CSS (>860px) cropped/upscaled a portrait video.
+
+Now a phone is a coarse pointer **and** a phone-sized screen, tested on the screen's **short side** (`Math.min(screen.width, screen.height) <= 500`) so rotating the device can't flip the decision — iPhone Pro Max ≈440 → phone, iPad mini 744 → desktop. Non-touch windows keep the legacy `≤860px` rule.
+
+The result is a `const` evaluated **once at mount**, not a function: a live check let a resize serve one scene's poster from one set and the next scene's clip from the other. **Behaviour change:** a desktop browser resized (or a DevTools device toggle flipped) across 860px no longer switches asset sets without a reload.
+
+`coarse` on its own is still the right gate for the particle drop, the URL-bar resize guard, and video priming (D3) — those are touch-browser traits, not asset-tier choices. The two must not be conflated.
+
+### D3 — iOS priming: persistent listeners + prime on creation
+
+Upstream registered the primer `{once:true}` on `pointerdown`/`touchstart`, so it only reached videos that existed at the first touch — in practice segment 0 alone, because `loadClip` is gated on scroll proximity. iOS WebKit refuses to load media data for a video created outside a gesture, so every later clip never fired `loadeddata`/`loadedmetadata`, `s.ready` stayed false, `raf()` skipped it, `seeked` never fired, `has-clip` was never added, and every scene past the first showed its poster forever.
+
+Two changes: `loadClip` primes a clip **immediately on creation** when `userReady` is already set (a muted + `playsinline` `play()` _is_ permitted outside a gesture and forces the data load), and the gesture listeners **stay registered** (still passive) so any later touch primes anything still unprimed — which also covers a first touch landing while segment 0's blob fetch is in flight. `primeVideo` now takes the segment and dedupes on a per-segment `s.primed` flag (reset if `play()` is refused, so the next gesture retries); it is gated on `coarse`, not `isMobile`, because iPads need priming even though D2 gives them the desktop set.
+
+### D4 — bounded clip-failure recovery
+
+Upstream latched `s.loading = true` forever on success (a clip that then failed to decode wedged its scene on the poster with no path back) while a failing `fetch` cleared the latch and re-requested on **every scroll tick**. An `error` listener on the video now removes the dead element, drops `has-clip`, and resets the segment so a later scroll can retry; a per-segment `s.tries` counter caps that at 3 attempts, so neither failure mode storms or wedges.
+
+### D5 — header doc comment
+
+The file's usage/`MOBILE` comment block was updated to describe D2–D4 accurately (frozen phone/desktop split, continuous priming). No behaviour.
+
+### Runtime consequence of D2 for AV1
+
+`WorldClient.tsx` is unchanged: it still picks AV1 vs H.264 via `canPlayType` before mounting. That branch was previously unreachable for tablets and is now live for them. WebKit only reports AV1 support where there is hardware decode, which most iPads lack, so they resolve to `''` and take the **H.264 desktop** set — correct and intended. `withAv1Sources` never touches `clipMobile`/`connectorsMobile`, so the phone path is unaffected either way.
 
 ## References
 


### PR DESCRIPTION
Two /world device bugs:
- iPhone: only the first scene ever played — the one-shot first-gesture primer only reached videos that existed at first touch, and iPhone WebKit refuses to load media data without a gesture. Videos are now primed on creation once a gesture has occurred, gesture listeners persist (re-priming any unprimed segment), and the priming gate is navigator.maxTouchPoints (covers trackpad-attached iPads that report a fine pointer).
- iPad: coarse-pointer detection classified every tablet as mobile at any width → 720×1280 portrait low-quality clips cropped into the desktop layout. Classification is now coarse AND short-side ≤500 CSS px, frozen at mount (tablets/touch-laptops get the desktop set; the AV1 branch becomes live for capable iPads).
- hardening from review: bounded retry (3) with error teardown + blob revoke, stale-error identity guard, non-promise play() pause.

Engine changes are anchored minimal edits to the vendored scrub-engine (each deviation logged in ADR-0019); world.html byte-identical apart from the content-hashed chunk name. 160 landing tests (16 engine, differential-verified); build + copy-parity + landing-drift green.

Post-deploy: run the 9-point real-device QA checklist from review (iPhone bare + flick race, iPad with and without keyboard, AV1 iPad Pro, split view, Android phone + tablet, reduced-motion, throttle) on aijobhunter.app/world.

Review: frontend-author → frontend-reviewer (APPROVE; advisories applied incl. the Magic-Keyboard iPad gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile and iOS video playback reliability during scroll-based scenes.
  * Ensured dynamically loaded clips are primed after user interaction.
  * Added bounded retries and recovery when video clips fail to load or decode.
  * Prevented stale video errors from disrupting active playback.
  * Improved device-specific asset selection across phones, tablets, and desktops.

* **Documentation**
  * Updated the `/world` route documentation with device behavior, playback safeguards, and engine deviations.

* **Tests**
  * Added coverage for device detection, iOS priming, clip recovery, retry limits, and stale video handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->