### PR TITLE
feat: jobs page command bar, scrape drawer, responsive split view

### DIFF
--- a/apps/desktop/src/renderer/features/jobs/components/JobDetailPane/JobDetailPane.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobDetailPane/JobDetailPane.test.tsx
@@ -1177,3 +1177,54 @@ describe('JobDetailPane — cross-board cluster split', () => {
     expect(screen.queryByTestId(TEST_IDS.jobs.clusterMembers)).not.toBeInTheDocument();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Header action cluster — narrow-pane wrap contract (bug 6a regression)
+// ─────────────────────────────────────────────────────────────────────────────
+// The cluster used to be `shrink-0 flex-wrap`, which pins it at max-content so
+// the wrap NEVER fired; at a ~500px detail pane the trailing actions
+// (Tailor / Prep / ⋯) overflowed and were clipped by four overflow-hidden
+// ancestors. jsdom has no layout engine, so the fix is asserted on the classes
+// that produce it.
+
+describe('JobDetailPane — header action cluster wrap contract', () => {
+  /** The action cluster is the parent of the Tailor button. */
+  async function renderCluster(): Promise<HTMLElement> {
+    await act(async () => {
+      render(
+        <JobDetailPane
+          posting={makePosting('wrap', { description: 'x' })}
+          formatRelativeTime={formatRelativeTime}
+        />
+      );
+    });
+    const cluster = screen.getByRole('button', { name: /jobs\.tailor/ }).parentElement;
+    if (!cluster) throw new Error('action cluster not rendered');
+    return cluster;
+  }
+
+  it('can shrink below max-content so flex-wrap actually fires', async () => {
+    const cluster = await renderCluster();
+    expect(cluster.className).toContain('flex-wrap');
+    expect(cluster.className).toContain('min-w-0');
+    // `shrink-0` is exactly what defeated the wrap.
+    expect(cluster.className).not.toContain('shrink-0');
+  });
+
+  it('takes its own full-width row under a narrow pane and returns inline when wide', async () => {
+    const cluster = await renderCluster();
+    // Narrow pane (< 42rem container): full-width row beneath the title.
+    expect(cluster.className).toContain('w-full');
+    // Wide pane: back inline, right-aligned.
+    expect(cluster.className).toContain('@2xl:w-auto');
+    expect(cluster.className).toContain('@2xl:justify-end');
+  });
+
+  it('marks the header as a container so the decision is pane-width based, not viewport based', async () => {
+    const cluster = await renderCluster();
+    const header = cluster.parentElement?.parentElement;
+    // A container-query variant without a @container ancestor silently no-ops
+    // (docs/PATTERNS.md §15) — this is the ancestor that makes @2xl: fire.
+    expect(header?.className).toContain('@container');
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/components/JobDetailPane/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobDetailPane/index.tsx
@@ -239,7 +239,12 @@ function DetailContent({
       {/* Header — flush with hairline bottom divider; no outer card margin.
           `@container`: the header decides its own layout from the DETAIL PANE's
           width, not the viewport (docs/PATTERNS.md §15) — the pane is a
-          width-varying panel, so a viewport breakpoint would be wrong here. */}
+          width-varying panel, so a viewport breakpoint would be wrong here.
+          Note the container is THIS element, so `@2xl` (42rem) is measured
+          against its CONTENT box — the pane minus this `px-5`. Measured: the
+          content box reaches 714px (42rem at the app's 17px rem root) when the
+          pane is ~757px, and that is where the action cluster below goes
+          inline. */}
       <div className="@container shrink-0 border-b border-[var(--border-clear)] px-5 pb-4 pt-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           {/* LEFT: title + meta + match score + status tags */}
@@ -295,9 +300,9 @@ function DetailContent({
               `shrink-0` used to pin this at max-content, so `flex-wrap` never
               fired and the trailing actions were clipped by the pane's
               overflow-hidden on a narrow window. `min-w-0` lets it shrink below
-              max-content so the wrap actually happens; under a ~672px pane it
-              takes its own full-width row beneath the title instead of fighting
-              the title for a single line. */}
+              max-content so the wrap actually happens; under a ~757px pane (see
+              the header's container note) it takes its own full-width row
+              beneath the title instead of fighting it for a single line. */}
           <div className="@2xl:w-auto @2xl:justify-end flex w-full min-w-0 flex-wrap items-center gap-2">
             <motion.div layout transition={transition.fast} className="shrink-0">
               <Button

--- a/apps/desktop/src/renderer/features/jobs/components/JobDetailPane/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobDetailPane/index.tsx
@@ -236,8 +236,11 @@ function DetailContent({
       transition={resolvedTransition}
       className="flex h-full flex-col overflow-hidden"
     >
-      {/* Header — flush with hairline bottom divider; no outer card margin */}
-      <div className="shrink-0 border-b border-[var(--border-clear)] px-5 pb-4 pt-4">
+      {/* Header — flush with hairline bottom divider; no outer card margin.
+          `@container`: the header decides its own layout from the DETAIL PANE's
+          width, not the viewport (docs/PATTERNS.md §15) — the pane is a
+          width-varying panel, so a viewport breakpoint would be wrong here. */}
+      <div className="@container shrink-0 border-b border-[var(--border-clear)] px-5 pb-4 pt-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           {/* LEFT: title + meta + match score + status tags */}
           <div className="min-w-0 flex-1">
@@ -288,8 +291,14 @@ function DetailContent({
             </div>
           </div>
 
-          {/* RIGHT: action cluster — Save/View, Tailor, ActionMenu */}
-          <div className="flex shrink-0 flex-wrap items-center gap-2">
+          {/* RIGHT: action cluster — Save/View, Tailor, Prep, ActionMenu.
+              `shrink-0` used to pin this at max-content, so `flex-wrap` never
+              fired and the trailing actions were clipped by the pane's
+              overflow-hidden on a narrow window. `min-w-0` lets it shrink below
+              max-content so the wrap actually happens; under a ~672px pane it
+              takes its own full-width row beneath the title instead of fighting
+              the title for a single line. */}
+          <div className="@2xl:w-auto @2xl:justify-end flex w-full min-w-0 flex-wrap items-center gap-2">
             <motion.div layout transition={transition.fast} className="shrink-0">
               <Button
                 variant="primary"

--- a/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/JobsCommandBar.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/JobsCommandBar.test.tsx
@@ -154,9 +154,30 @@ describe('JobsCommandBar — active filter chips', () => {
 
   it('renders the sanitized failure note in the chips row when one is passed', () => {
     renderBar({ failureNote: 'connection refused' });
+    const chips = screen.getByTestId(TEST_IDS.jobs.filterChips);
     expect(
-      screen.getByText('jobs.lastScrapeFailed[reason=connection refused]')
+      within(chips).getByText('jobs.lastScrapeFailed[reason=connection refused]')
     ).toBeInTheDocument();
+  });
+
+  it('names the row for what it actually holds, not always "active filters"', () => {
+    // Diagnostics-only: calling this "Active filters" describes a row that has
+    // no filters in it.
+    renderBar({ boardSummaries: [{ board: 'linkedin', count: 4 }] });
+    expect(screen.getByTestId(TEST_IDS.jobs.filterChips)).toBe(
+      screen.getByRole('group', { name: 'jobs.commandBar.statusRow' })
+    );
+    expect(
+      screen.queryByRole('group', { name: 'jobs.filters.activeLabel' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('switches the row name to "active filters" once a filter is applied', () => {
+    setJobs({ filter: 'rust' });
+    renderBar({ boardSummaries: [{ board: 'linkedin', count: 4 }] });
+    expect(screen.getByTestId(TEST_IDS.jobs.filterChips)).toBe(
+      screen.getByRole('group', { name: 'jobs.filters.activeLabel' })
+    );
   });
 });
 
@@ -181,6 +202,14 @@ describe('JobsCommandBar — view mode + count', () => {
     expect(screen.getByRole('button', { name: 'jobs.sort' })).toBeInTheDocument();
   });
 
+  it('names the filter input with a short label, not its instructional placeholder', () => {
+    renderBar();
+    // The placeholder ("Filter by title, company, location…") reads as an
+    // instruction in a rotor's control list, not as a name.
+    const input = screen.getByRole('textbox', { name: 'jobs.commandBar.filterLabel' });
+    expect(input).toHaveAttribute('placeholder', 'jobs.searchPlaceholder');
+  });
+
   it('the segmented control switches viewMode to split', async () => {
     const user = userEvent.setup();
     renderBar();
@@ -197,6 +226,56 @@ describe('JobsCommandBar — view mode + count', () => {
       within(screen.getByTestId(TEST_IDS.jobs.hideAgencyToggle)).getByRole('button')
     );
     expect(useSessionStore.getState().jobs.hideAgency).toBe(true);
+  });
+});
+
+describe('JobsCommandBar — status live region', () => {
+  it('mounts the live region up front, empty, even with nothing to announce', () => {
+    renderBar({ scraping: false });
+
+    // A role="status" node created at the same instant as its text is
+    // unreliably announced by NVDA/JAWS — the region has to pre-exist so the
+    // change is what fires. Matters here because the strip it announces is the
+    // only Cancel affordance once the drawer closes.
+    const live = screen.getByTestId(TEST_IDS.jobs.scrapeStatusLive);
+    expect(live).toHaveAttribute('role', 'status');
+    expect(live).toHaveAttribute('aria-live', 'polite');
+    expect(live.className).toContain('sr-only');
+    expect(live).toHaveTextContent('');
+  });
+
+  it('writes the scrape status into the SAME region rather than mounting a new one', () => {
+    const { rerender } = renderBar({ scraping: false });
+    const live = screen.getByTestId(TEST_IDS.jobs.scrapeStatusLive);
+
+    rerender(<JobsCommandBar {...baseProps} scraping scrapeProgress={0.42} />);
+
+    // Same DOM node, new text — that is what makes the announcement reliable.
+    expect(screen.getByTestId(TEST_IDS.jobs.scrapeStatusLive)).toBe(live);
+    expect(live).toHaveTextContent('jobs.scanningPercent[percent=42]');
+  });
+
+  it('announces a scrape failure through the same region', () => {
+    renderBar({ failureNote: 'connection refused' });
+    expect(screen.getByTestId(TEST_IDS.jobs.scrapeStatusLive)).toHaveTextContent(
+      'jobs.lastScrapeFailed[reason=connection refused]'
+    );
+  });
+
+  it('hides the visual copies from AT so nothing is announced twice', () => {
+    renderBar({ scraping: true, scrapeProgress: 0.42, failureNote: 'boom' });
+
+    const strip = screen.getByTestId(TEST_IDS.jobs.scrapeStatusStrip);
+    expect(within(strip).getByText('jobs.scanningPercent[percent=42]')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+    // The Cancel button is a CONTROL, not status — it stays exposed.
+    expect(within(strip).getByRole('button', { name: 'jobs.cancel' })).toBeInTheDocument();
+    expect(screen.getByText('jobs.lastScrapeFailed[reason=boom]')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
   });
 });
 
@@ -251,10 +330,14 @@ describe('JobsCommandBar — narrow-window layout contract', () => {
     expect(bar.className).not.toContain('overflow');
     expect(bar.className).toContain('shrink-0');
 
-    const controlRow = bar.firstElementChild;
+    // Anchored on the title rather than `firstElementChild` — the sr-only live
+    // region is the first child, and positional lookups silently retarget.
+    const controlRow = screen.getByRole('heading', { level: 1 }).parentElement;
     expect(controlRow?.className).toContain('flex-wrap');
-    // A `shrink-0` on the row would re-pin it at max-content and reintroduce the clip.
-    expect(controlRow?.className).not.toContain('shrink-0');
+    // A `shrink-0` on the row would re-pin it at max-content and reintroduce the
+    // clip. Token match, not substring: `group-hover:shrink-0` etc. must not
+    // read as a hit.
+    expect(controlRow?.className.split(/\s+/)).not.toContain('shrink-0');
   });
 
   it('keeps the chips row to a single line, scrolling sideways instead of growing taller', () => {

--- a/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/JobsCommandBar.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/JobsCommandBar.test.tsx
@@ -115,19 +115,40 @@ describe('JobsCommandBar — active filter chips', () => {
     ).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('names only the removable filter chips as the "active filters" group', () => {
+  it('makes the scrolling chips row itself a named, reachable tab stop', () => {
+    setJobs({ filter: 'rust' });
+    renderBar({
+      boardSummaries: [
+        { board: 'linkedin', count: 4 },
+        { board: 'indeed', count: 0, skipped: 'needs-login' },
+        { board: 'xing', count: 0, error: 'rate limited' },
+      ],
+    });
+
+    // The row scrolls (see the single-line contract below), so everything past
+    // its right edge is keyboard-unreachable unless the CONTAINER is focusable —
+    // only the leftmost chip's × is a tab stop otherwise. axe stays silent on
+    // this: one focusable descendant satisfies scrollable-region-focusable.
+    const chips = screen.getByTestId(TEST_IDS.jobs.filterChips);
+    expect(chips).toBe(screen.getByRole('group', { name: 'jobs.filters.activeLabel' }));
+    expect(chips).toHaveAttribute('tabindex', '0');
+    // A focusable div renders no ring by default.
+    expect(chips.className).toContain('focus-visible:ring-2');
+
+    chips.focus();
+    expect(document.activeElement).toBe(chips);
+  });
+
+  it('keeps scrape diagnostics beside the filter chips, not nested in their own group', () => {
     setJobs({ filter: 'rust' });
     renderBar({ boardSummaries: [{ board: 'linkedin', count: 4 }] });
 
-    // Scrape diagnostics are OUTPUT, not applied filters — they sit beside the
-    // group, not inside it.
-    const group = screen.getByRole('group', { name: 'jobs.filters.activeLabel' });
+    // Diagnostics are OUTPUT, not applied filters; they keep their own group
+    // label rather than being absorbed into "active filters".
+    const chips = screen.getByTestId(TEST_IDS.jobs.filterChips);
     expect(
-      within(group).getByRole('button', { name: 'jobs.filters.remove[name=rust]' })
+      within(chips).getByRole('button', { name: 'jobs.filters.remove[name=rust]' })
     ).toBeInTheDocument();
-    expect(
-      within(group).queryByRole('group', { name: 'jobs.boardSummary.label' })
-    ).not.toBeInTheDocument();
     expect(screen.getByRole('group', { name: 'jobs.boardSummary.label' })).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/JobsCommandBar.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/JobsCommandBar.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * JobsCommandBar — the compact bar that replaced the Jobs hero.
+ *
+ * Covered:
+ *  - Active-filter chips appear/disappear with the underlying session state and
+ *    each chip's × removes only its own filter (per-chip remove + clear-all).
+ *  - The chips row is absent entirely when nothing is filtered and there are no
+ *    scrape diagnostics (it is a *conditional* second row, not a permanent one).
+ *  - The view-mode SegmentedControl writes viewMode through setJobs.
+ *  - The live scrape strip (progress label + Cancel) only exists while scraping —
+ *    the drawer auto-closes, so this is the sole remaining cancel affordance.
+ *  - The narrow-window contract: the control row wraps instead of clipping, and
+ *    no descendant pins it to a no-wrap `shrink-0` strip.
+ *
+ * The real Zustand session store is used (no mock) so state flows naturally;
+ * `@ajh/ui` is real so the chips' close buttons are the real controls.
+ */
+import type { ComponentProps } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TEST_IDS } from '@ajh/test-ids';
+
+import { useSessionStore } from '@/store/session-store';
+
+// t() renders "key[param=value,…]" so both key and params are assertable.
+// `i18n.language` is required by the real BoardSummaryChips.
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({
+    t: (k: string, p?: Record<string, unknown>) =>
+      p
+        ? `${k}[${Object.entries(p)
+            .map(([key, val]) => `${key}=${String(val)}`)
+            .join(',')}]`
+        : k,
+    i18n: { language: 'en' },
+  }),
+}));
+
+import { JobsCommandBar } from './index';
+
+type BarProps = ComponentProps<typeof JobsCommandBar>;
+
+const baseProps: BarProps = {
+  shownCount: 3,
+  totalCount: 5,
+  scraping: false,
+  scrapeProgress: null,
+  canClear: true,
+  onClear: vi.fn(),
+  onScrape: vi.fn(),
+  onCancelScrape: vi.fn(),
+  boardSummaries: [],
+  failureNote: null,
+};
+
+function renderBar(overrides: Partial<BarProps> = {}) {
+  return render(<JobsCommandBar {...baseProps} {...overrides} />);
+}
+
+function setJobs(patch: Parameters<ReturnType<typeof useSessionStore.getState>['setJobs']>[0]) {
+  act(() => {
+    useSessionStore.getState().setJobs(patch);
+  });
+}
+
+beforeEach(() => {
+  setJobs({ filter: '', sortBy: 'newest', viewMode: 'list', hideAgency: false });
+});
+
+describe('JobsCommandBar — active filter chips', () => {
+  it('renders no chips row at all when nothing is filtered and there are no diagnostics', () => {
+    renderBar();
+    expect(screen.queryByTestId(TEST_IDS.jobs.filterChips)).not.toBeInTheDocument();
+  });
+
+  it('shows a search chip carrying the current text filter', () => {
+    setJobs({ filter: 'rust' });
+    renderBar();
+
+    const chips = screen.getByTestId(TEST_IDS.jobs.filterChips);
+    expect(within(chips).getByText('jobs.filters.searchChip[query=rust]')).toBeInTheDocument();
+  });
+
+  it('ignores a whitespace-only filter (no chip, no clear-all)', () => {
+    setJobs({ filter: '   ' });
+    renderBar();
+    expect(screen.queryByTestId(TEST_IDS.jobs.filterChips)).not.toBeInTheDocument();
+  });
+
+  it("the search chip's × clears only the text filter, leaving hideAgency alone", async () => {
+    const user = userEvent.setup();
+    setJobs({ filter: 'rust', hideAgency: true });
+    renderBar();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'jobs.filters.remove[name=jobs.filters.searchChip[query=rust]]',
+      })
+    );
+
+    expect(useSessionStore.getState().jobs.filter).toBe('');
+    expect(useSessionStore.getState().jobs.hideAgency).toBe(true);
+  });
+
+  it("the hide-agency chip's × clears only hideAgency, leaving the text filter alone", async () => {
+    const user = userEvent.setup();
+    setJobs({ filter: 'rust', hideAgency: true });
+    renderBar();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'jobs.filters.remove[name=jobs.filters.hideAgency]',
+      })
+    );
+
+    expect(useSessionStore.getState().jobs.hideAgency).toBe(false);
+    expect(useSessionStore.getState().jobs.filter).toBe('rust');
+  });
+
+  it('clear-all removes both filters in one go', async () => {
+    const user = userEvent.setup();
+    setJobs({ filter: 'rust', hideAgency: true });
+    renderBar();
+
+    await user.click(screen.getByRole('button', { name: 'jobs.filters.clearAll' }));
+
+    expect(useSessionStore.getState().jobs.filter).toBe('');
+    expect(useSessionStore.getState().jobs.hideAgency).toBe(false);
+  });
+
+  it('offers no clear-all when only scrape diagnostics (not filters) populate the row', () => {
+    renderBar({ boardSummaries: [{ board: 'linkedin', count: 4 }] });
+
+    expect(screen.getByTestId(TEST_IDS.jobs.filterChips)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'jobs.filters.clearAll' })).not.toBeInTheDocument();
+  });
+
+  it('renders the sanitized failure note in the chips row when one is passed', () => {
+    renderBar({ failureNote: 'connection refused' });
+    expect(
+      screen.getByText('jobs.lastScrapeFailed[reason=connection refused]')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('JobsCommandBar — view mode + count', () => {
+  it('shows the terse "shown / total" count with a spelled-out accessible name', () => {
+    renderBar({ shownCount: 3, totalCount: 5 });
+    const count = screen.getByLabelText('jobs.commandBar.shownCount[shown=3,total=5]');
+    expect(count).toHaveTextContent('3 / 5');
+  });
+
+  it('the segmented control switches viewMode to split', async () => {
+    const user = userEvent.setup();
+    renderBar();
+
+    await user.click(screen.getByRole('radio', { name: 'jobs.viewSplit' }));
+    expect(useSessionStore.getState().jobs.viewMode).toBe('split');
+  });
+
+  it('the hide-agency toggle writes hideAgency', async () => {
+    const user = userEvent.setup();
+    renderBar();
+
+    await user.click(
+      within(screen.getByTestId(TEST_IDS.jobs.hideAgencyToggle)).getByRole('button')
+    );
+    expect(useSessionStore.getState().jobs.hideAgency).toBe(true);
+  });
+});
+
+describe('JobsCommandBar — live scrape strip', () => {
+  it('is absent while idle', () => {
+    renderBar({ scraping: false });
+    expect(screen.queryByTestId(TEST_IDS.jobs.scrapeStatusStrip)).not.toBeInTheDocument();
+  });
+
+  it('shows an indeterminate label + Cancel before the first board completes', async () => {
+    const user = userEvent.setup();
+    const onCancelScrape = vi.fn();
+    renderBar({ scraping: true, scrapeProgress: null, onCancelScrape });
+
+    const strip = screen.getByTestId(TEST_IDS.jobs.scrapeStatusStrip);
+    expect(within(strip).getByText('jobs.scraping')).toBeInTheDocument();
+
+    await user.click(within(strip).getByRole('button', { name: 'jobs.cancel' }));
+    expect(onCancelScrape).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a rounded percentage once progress is known', () => {
+    renderBar({ scraping: true, scrapeProgress: 0.666 });
+    const strip = screen.getByTestId(TEST_IDS.jobs.scrapeStatusStrip);
+    expect(within(strip).getByText('jobs.scanningPercent[percent=67]')).toBeInTheDocument();
+  });
+
+  it('hides the destructive Clear action while a scrape runs (canClear=false)', () => {
+    renderBar({ scraping: true, canClear: false });
+    expect(screen.queryByRole('button', { name: /jobs\.clear$/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('JobsCommandBar — narrow-window layout contract', () => {
+  it('wraps the control row instead of clipping it, and never scrolls horizontally', () => {
+    renderBar();
+
+    const bar = screen.getByTestId(TEST_IDS.jobs.commandBar);
+    // The bar itself owns no overflow — the old bounded `overflow-y-auto`
+    // wrapper is what produced the stray horizontal scrollbar.
+    expect(bar.className).not.toContain('overflow');
+    expect(bar.className).toContain('shrink-0');
+    // Container-query context so children size off the page column, not the viewport.
+    expect(bar.className).toContain('@container');
+
+    const controlRow = bar.firstElementChild;
+    expect(controlRow?.className).toContain('flex-wrap');
+    // A `shrink-0` on the row would re-pin it at max-content and reintroduce the clip.
+    expect(controlRow?.className).not.toContain('shrink-0');
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/JobsCommandBar.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/JobsCommandBar.test.tsx
@@ -94,47 +94,41 @@ describe('JobsCommandBar — active filter chips', () => {
     setJobs({ filter: 'rust', hideAgency: true });
     renderBar();
 
-    await user.click(
-      screen.getByRole('button', {
-        name: 'jobs.filters.remove[name=jobs.filters.searchChip[query=rust]]',
-      })
-    );
+    // The remove label is the BARE query — prefixing it with the chip's own
+    // "Search:" label produced a double colon in the announcement.
+    await user.click(screen.getByRole('button', { name: 'jobs.filters.remove[name=rust]' }));
 
     expect(useSessionStore.getState().jobs.filter).toBe('');
     expect(useSessionStore.getState().jobs.hideAgency).toBe(true);
   });
 
-  it("the hide-agency chip's × clears only hideAgency, leaving the text filter alone", async () => {
-    const user = userEvent.setup();
-    setJobs({ filter: 'rust', hideAgency: true });
+  it('does NOT chip hide-agency — its toggle is already visible in the row above', () => {
+    setJobs({ hideAgency: true });
     renderBar();
 
-    await user.click(
-      screen.getByRole('button', {
-        name: 'jobs.filters.remove[name=jobs.filters.hideAgency]',
-      })
-    );
-
-    expect(useSessionStore.getState().jobs.hideAgency).toBe(false);
-    expect(useSessionStore.getState().jobs.filter).toBe('rust');
+    // Duplicating an always-visible control as a chip cost a whole extra line of
+    // bar height, which is the scarce resource at the 900×600 floor in German.
+    expect(screen.queryByTestId(TEST_IDS.jobs.filterChips)).not.toBeInTheDocument();
+    // The toggle itself still reflects the state.
+    expect(
+      within(screen.getByTestId(TEST_IDS.jobs.hideAgencyToggle)).getByRole('button')
+    ).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('clear-all removes both filters in one go', async () => {
-    const user = userEvent.setup();
-    setJobs({ filter: 'rust', hideAgency: true });
-    renderBar();
-
-    await user.click(screen.getByRole('button', { name: 'jobs.filters.clearAll' }));
-
-    expect(useSessionStore.getState().jobs.filter).toBe('');
-    expect(useSessionStore.getState().jobs.hideAgency).toBe(false);
-  });
-
-  it('offers no clear-all when only scrape diagnostics (not filters) populate the row', () => {
+  it('names only the removable filter chips as the "active filters" group', () => {
+    setJobs({ filter: 'rust' });
     renderBar({ boardSummaries: [{ board: 'linkedin', count: 4 }] });
 
-    expect(screen.getByTestId(TEST_IDS.jobs.filterChips)).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'jobs.filters.clearAll' })).not.toBeInTheDocument();
+    // Scrape diagnostics are OUTPUT, not applied filters — they sit beside the
+    // group, not inside it.
+    const group = screen.getByRole('group', { name: 'jobs.filters.activeLabel' });
+    expect(
+      within(group).getByRole('button', { name: 'jobs.filters.remove[name=rust]' })
+    ).toBeInTheDocument();
+    expect(
+      within(group).queryByRole('group', { name: 'jobs.boardSummary.label' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'jobs.boardSummary.label' })).toBeInTheDocument();
   });
 
   it('renders the sanitized failure note in the chips row when one is passed', () => {
@@ -146,10 +140,24 @@ describe('JobsCommandBar — active filter chips', () => {
 });
 
 describe('JobsCommandBar — view mode + count', () => {
-  it('shows the terse "shown / total" count with a spelled-out accessible name', () => {
+  it('shows the terse "shown / total" count with a spelled-out screen-reader form', () => {
     renderBar({ shownCount: 3, totalCount: 5 });
-    const count = screen.getByLabelText('jobs.commandBar.shownCount[shown=3,total=5]');
-    expect(count).toHaveTextContent('3 / 5');
+
+    // `aria-label` on a bare span is a prohibited-and-dropped ARIA mapping, so
+    // the accessible form has to be REAL (visually hidden) text.
+    const terse = screen.getByText('3 / 5');
+    expect(terse).toHaveAttribute('aria-hidden', 'true');
+
+    const spelled = screen.getByText('jobs.commandBar.shownCount[shown=3,total=5]');
+    expect(spelled).toBeInTheDocument();
+    expect(spelled.className).toContain('sr-only');
+  });
+
+  it('gives the sort dropdown a name that says what it does, not just its value', () => {
+    renderBar();
+    // Without this the trigger's only accessible name is the selected option
+    // ("Newest first"), which never mentions sorting.
+    expect(screen.getByRole('button', { name: 'jobs.sort' })).toBeInTheDocument();
   });
 
   it('the segmented control switches viewMode to split', async () => {
@@ -183,10 +191,21 @@ describe('JobsCommandBar — live scrape strip', () => {
     renderBar({ scraping: true, scrapeProgress: null, onCancelScrape });
 
     const strip = screen.getByTestId(TEST_IDS.jobs.scrapeStatusStrip);
-    expect(within(strip).getByText('jobs.scraping')).toBeInTheDocument();
+    // Same copy as the results skeleton, so the two progress surfaces never
+    // word the same state differently.
+    expect(within(strip).getByText('jobs.scanning')).toBeInTheDocument();
 
     await user.click(within(strip).getByRole('button', { name: 'jobs.cancel' }));
     expect(onCancelScrape).toHaveBeenCalledTimes(1);
+  });
+
+  it('meets the light-scheme contrast floor on the row carrying the only Cancel', () => {
+    renderBar({ scraping: true });
+    const strip = screen.getByTestId(TEST_IDS.jobs.scrapeStatusStrip);
+    // The light-legibility remap in utilities.css lifts ONLY /20…/50, so /55
+    // renders lighter than /50 and measured 3.67:1 — below AA.
+    expect(strip.className).toContain('text-foreground/70');
+    expect(strip.className).not.toContain('text-foreground/55');
   });
 
   it('shows a rounded percentage once progress is known', () => {
@@ -202,7 +221,7 @@ describe('JobsCommandBar — live scrape strip', () => {
 });
 
 describe('JobsCommandBar — narrow-window layout contract', () => {
-  it('wraps the control row instead of clipping it, and never scrolls horizontally', () => {
+  it('wraps the control row instead of clipping it, and never scrolls itself', () => {
     renderBar();
 
     const bar = screen.getByTestId(TEST_IDS.jobs.commandBar);
@@ -210,12 +229,32 @@ describe('JobsCommandBar — narrow-window layout contract', () => {
     // wrapper is what produced the stray horizontal scrollbar.
     expect(bar.className).not.toContain('overflow');
     expect(bar.className).toContain('shrink-0');
-    // Container-query context so children size off the page column, not the viewport.
-    expect(bar.className).toContain('@container');
 
     const controlRow = bar.firstElementChild;
     expect(controlRow?.className).toContain('flex-wrap');
     // A `shrink-0` on the row would re-pin it at max-content and reintroduce the clip.
     expect(controlRow?.className).not.toContain('shrink-0');
+  });
+
+  it('keeps the chips row to a single line, scrolling sideways instead of growing taller', () => {
+    setJobs({ filter: 'rust' });
+    renderBar({
+      boardSummaries: [
+        { board: 'linkedin', count: 4 },
+        { board: 'indeed', count: 0, skipped: 'needs-login' },
+        { board: 'xing', count: 0, error: 'rate limited' },
+      ],
+    });
+
+    const chips = screen.getByTestId(TEST_IDS.jobs.filterChips);
+    // Height is the scarce resource at the 900×600 floor (German runs ~30%
+    // longer); a wrapping diagnostics row ate the results list.
+    expect(chips.className).toContain('flex-nowrap');
+    expect(chips.className).toContain('overflow-x-auto');
+    expect(chips.className).not.toContain('flex-wrap');
+    // Children must not shrink, or "nowrap" would just squash them instead.
+    for (const child of Array.from(chips.children)) {
+      expect(child.className).toContain('shrink-0');
+    }
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
@@ -195,32 +195,33 @@ export function JobsCommandBar({
 
       {/* Applied filters + last-scrape diagnostics — one strictly single-line row
           that scrolls sideways rather than wrapping, so diagnostics can never
-          grow the bar and squeeze the results list at the 900×600 floor. */}
+          grow the bar and squeeze the results list at the 900×600 floor.
+          Because it scrolls, the container itself must be a tab stop: content
+          past the right edge is otherwise unreachable by keyboard (only the
+          leftmost chip's × is focusable, which is also why axe's
+          scrollable-region-focusable rule stays silent here — one focusable
+          descendant satisfies it). A focusable div gets no ring by default, so
+          the focus-visible style is explicit. */}
       {showChipsRow && (
         <div
           data-testid={TEST_IDS.jobs.filterChips}
-          className="scrollbar-thin mt-2 flex flex-nowrap items-center gap-1.5 overflow-x-auto pb-0.5"
+          tabIndex={0}
+          role="group"
+          aria-label={t('jobs.filters.activeLabel')}
+          className="scrollbar-thin mt-2 flex flex-nowrap items-center gap-1.5 overflow-x-auto rounded pb-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent"
         >
-          {/* The group names the REMOVABLE filter chips only — the scrape
-              diagnostics beside them are output, not applied filters. */}
           {trimmedFilter.length > 0 && (
-            <div
-              role="group"
-              aria-label={t('jobs.filters.activeLabel')}
-              className="flex shrink-0 items-center gap-1.5"
+            <Tag
+              color="processing"
+              closable
+              closeLabel={t('jobs.filters.remove', { name: trimmedFilter })}
+              onClose={() => setJobs({ filter: '' })}
+              className="max-w-[16rem] shrink-0 text-[10px] font-normal"
             >
-              <Tag
-                color="processing"
-                closable
-                closeLabel={t('jobs.filters.remove', { name: trimmedFilter })}
-                onClose={() => setJobs({ filter: '' })}
-                className="max-w-[16rem] text-[10px] font-normal"
-              >
-                <span className="truncate">
-                  {t('jobs.filters.searchChip', { query: trimmedFilter })}
-                </span>
-              </Tag>
-            </div>
+              <span className="truncate">
+                {t('jobs.filters.searchChip', { query: trimmedFilter })}
+              </span>
+            </Tag>
           )}
           {boardSummaries.length > 0 && (
             <BoardSummaryChips summaries={boardSummaries} className="shrink-0 flex-nowrap" />

--- a/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
@@ -74,8 +74,28 @@ export function JobsCommandBar({
   const { filter, sortBy, viewMode, hideAgency } = jobs;
 
   const trimmedFilter = filter.trim();
-  const showChipsRow =
-    trimmedFilter.length > 0 || boardSummaries.length > 0 || failureNote !== null;
+  const hasActiveFilter = trimmedFilter.length > 0;
+  const showChipsRow = hasActiveFilter || boardSummaries.length > 0 || failureNote !== null;
+
+  // The row is shared: it holds removable FILTER chips and/or read-only scrape
+  // DIAGNOSTICS. Announcing "Active filters" over a row that only carries
+  // diagnostics misdescribes it, so the label follows the contents.
+  const chipsRowLabel = hasActiveFilter
+    ? t('jobs.filters.activeLabel')
+    : t('jobs.commandBar.statusRow');
+
+  // Single always-mounted live region (below). A `role="status"` node that is
+  // created at the same moment as its text is unreliably announced by NVDA/JAWS
+  // — the region has to exist BEFORE the content lands in it. This matters more
+  // than usual here: the scraping strip is the only Cancel affordance once the
+  // drawer closes, so a user who never hears it never learns it exists.
+  const liveStatus = scraping
+    ? scrapeProgress == null
+      ? t('jobs.scanning')
+      : t('jobs.scanningPercent', { percent: Math.round(scrapeProgress * 100) })
+    : failureNote !== null
+      ? t('jobs.lastScrapeFailed', { reason: failureNote })
+      : '';
 
   return (
     <div
@@ -84,6 +104,18 @@ export function JobsCommandBar({
       aria-label={t('jobs.commandBar.label')}
       className="shrink-0 px-10 pb-3 pt-6"
     >
+      {/* Always-mounted live region — see `liveStatus`. Kept empty when there is
+          nothing to say; the visual surfaces below are aria-hidden so a change
+          is announced exactly once. */}
+      <div
+        data-testid={TEST_IDS.jobs.scrapeStatusLive}
+        role="status"
+        aria-live="polite"
+        className="sr-only"
+      >
+        {liveStatus}
+      </div>
+
       {/* Control row — wraps; never a fixed no-wrap strip. */}
       <div className="flex flex-wrap items-center gap-2">
         <h1 className="text-body-strong shrink-0 text-foreground/90">{t('jobs.title')}</h1>
@@ -95,7 +127,10 @@ export function JobsCommandBar({
           value={filter}
           onChange={(e) => setJobs({ filter: e.target.value })}
           placeholder={t('jobs.searchPlaceholder')}
-          aria-label={t('jobs.searchPlaceholder')}
+          // A short name, not the placeholder — the placeholder is an
+          // instruction ("Filter by title, company, location…") and reads as
+          // one in a rotor's control list.
+          aria-label={t('jobs.commandBar.filterLabel')}
           className="text-foreground/75 placeholder:text-foreground/30"
           variant="default"
           wrapperClassName="min-w-[8rem] max-w-[18rem] grow basis-44"
@@ -177,12 +212,13 @@ export function JobsCommandBar({
       {scraping && (
         <div
           data-testid={TEST_IDS.jobs.scrapeStatusStrip}
-          role="status"
-          aria-live="polite"
           className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-foreground/70"
         >
           <Loader2 size={11} aria-hidden="true" className="animate-spin text-brand-soft" />
-          <span>
+          {/* The TEXT is mirrored into the always-mounted live region above, so
+              it is hidden here — otherwise the same update is announced twice.
+              The Cancel button stays exposed: it is a control, not status. */}
+          <span aria-hidden="true">
             {scrapeProgress == null
               ? t('jobs.scanning')
               : t('jobs.scanningPercent', { percent: Math.round(scrapeProgress * 100) })}
@@ -207,7 +243,7 @@ export function JobsCommandBar({
           data-testid={TEST_IDS.jobs.filterChips}
           tabIndex={0}
           role="group"
-          aria-label={t('jobs.filters.activeLabel')}
+          aria-label={chipsRowLabel}
           className="scrollbar-thin mt-2 flex flex-nowrap items-center gap-1.5 overflow-x-auto rounded pb-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent"
         >
           {trimmedFilter.length > 0 && (
@@ -227,9 +263,10 @@ export function JobsCommandBar({
             <BoardSummaryChips summaries={boardSummaries} className="shrink-0 flex-nowrap" />
           )}
           {failureNote !== null && (
+            // Mirrored into the always-mounted live region above, so hidden here
+            // — a live region that mounts WITH its text is unreliably announced.
             <p
-              role="status"
-              aria-live="polite"
+              aria-hidden="true"
               className="shrink-0 whitespace-nowrap text-[11px] text-red-400/80"
             >
               {t('jobs.lastScrapeFailed', { reason: failureNote })}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
@@ -1,4 +1,5 @@
 import { LayoutList, LayoutPanelLeft, ListFilter, Loader2, Plus, Trash2 } from 'lucide-react';
+import type { Ref } from 'react';
 
 import type { BoardScrapeSummary } from '@ajh/shared';
 import { TEST_IDS } from '@ajh/test-ids';
@@ -30,18 +31,26 @@ interface JobsCommandBarProps {
   boardSummaries: BoardScrapeSummary[];
   /** Sanitized note for an outright scrape failure; gated like `boardSummaries`. */
   failureNote: string | null;
+  /**
+   * Forwarded to the Scrape button. It is the only ALWAYS-mounted control that
+   * opens the scrape drawer, so the drawer uses it as its focus-return fallback
+   * when the empty-state CTA it was opened from has since unmounted.
+   */
+  scrapeButtonRef?: Ref<HTMLButtonElement>;
 }
 
 /**
  * Compact command bar that replaced the Jobs hero (title + subtitle + inline
  * form). One wrapping row of controls, plus two conditional thin rows below it:
- * the active-filter chips and the live scrape status.
+ * the live scrape status and the active-filter chips.
  *
  * Responsive contract: the control row is `flex-wrap` with no `shrink-0`
  * no-wrap container, so at the 900px window floor the trailing action group
- * wraps onto a second line instead of being clipped. The bar is `@container`
- * so its children can respond to the page column's width rather than the
- * viewport (`docs/PATTERNS.md` §15).
+ * wraps onto a second line instead of being clipped. HEIGHT is the scarce
+ * resource there — German runs ~30% longer and pushed this bar to 56% of the
+ * content column — so every row below the first stays strictly single-line: the
+ * chips row scrolls sideways instead of wrapping, and a filter that is already
+ * visible as a control (hide-agency, 40px above) gets no chip at all.
  *
  * Filter/sort/view state is read straight from the session store (the same
  * source `JobsPage` and `JobsResults` read) so the page doesn't have to thread
@@ -58,30 +67,26 @@ export function JobsCommandBar({
   onCancelScrape,
   boardSummaries,
   failureNote,
+  scrapeButtonRef,
 }: JobsCommandBarProps) {
   const { t } = useTranslation();
   const { jobs, setJobs } = useSessionStore();
   const { filter, sortBy, viewMode, hideAgency } = jobs;
 
   const trimmedFilter = filter.trim();
-  const searchChipLabel = t('jobs.filters.searchChip', { query: trimmedFilter });
-  const hasFilterChips = trimmedFilter.length > 0 || hideAgency;
-  const showChipsRow = hasFilterChips || boardSummaries.length > 0 || failureNote !== null;
-
-  const clearAllFilters = () => setJobs({ filter: '', hideAgency: false });
+  const showChipsRow =
+    trimmedFilter.length > 0 || boardSummaries.length > 0 || failureNote !== null;
 
   return (
     <div
       data-testid={TEST_IDS.jobs.commandBar}
       role="group"
       aria-label={t('jobs.commandBar.label')}
-      className="@container shrink-0 px-10 pb-3 pt-6"
+      className="shrink-0 px-10 pb-3 pt-6"
     >
       {/* Control row — wraps; never a fixed no-wrap strip. */}
       <div className="flex flex-wrap items-center gap-2">
-        <h1 className="text-gradient shrink-0 text-lg font-bold tracking-tight">
-          {t('jobs.title')}
-        </h1>
+        <h1 className="text-body-strong shrink-0 text-foreground/90">{t('jobs.title')}</h1>
 
         <Input
           id="jobs-filter-query"
@@ -97,6 +102,22 @@ export function JobsCommandBar({
           allowClear
         />
 
+        {/* Count sits with the input it describes — alone on the right it
+            stranded a void of whitespace once the action group wrapped away. */}
+        <span className="shrink-0 tabular-nums text-[11px] text-foreground/50">
+          <span aria-hidden="true">
+            {shownCount} / {totalCount}
+          </span>
+          {/* `aria-label` on a bare span is a prohibited-and-dropped mapping, so
+              the spelled-out form is real (visually hidden) text instead. */}
+          <span className="sr-only">
+            {t('jobs.commandBar.shownCount', {
+              shown: String(shownCount),
+              total: String(totalCount),
+            })}
+          </span>
+        </span>
+
         <Dropdown
           options={[
             { value: 'newest', label: t('jobs.sortNewest') },
@@ -106,24 +127,13 @@ export function JobsCommandBar({
           value={sortBy}
           onChange={(value) => setJobs({ sortBy: value as 'newest' | 'oldest' | 'company' })}
           placeholder={t('jobs.sort')}
+          aria-label={t('jobs.sort')}
         />
 
         <span data-testid={TEST_IDS.jobs.hideAgencyToggle} className="inline-flex">
           <Tag.CheckableTag checked={hideAgency} onChange={(v) => setJobs({ hideAgency: v })}>
             {t('jobs.filters.hideAgency')}
           </Tag.CheckableTag>
-        </span>
-
-        {/* Count — the visible "N / M" stays the terse glanceable form; the
-            accessible name spells it out for AT. */}
-        <span
-          className="shrink-0 tabular-nums text-[11px] text-foreground/50"
-          aria-label={t('jobs.commandBar.shownCount', {
-            shown: String(shownCount),
-            total: String(totalCount),
-          })}
-        >
-          {shownCount} / {totalCount}
         </span>
 
         {/* Trailing actions — right-aligned when there is room, wrapped to their
@@ -151,7 +161,7 @@ export function JobsCommandBar({
               {t('jobs.clear')}
             </Button>
           )}
-          <Button variant="primary" onClick={onScrape}>
+          <Button ref={scrapeButtonRef} variant="primary" onClick={onScrape}>
             <Plus size={12} />
             {t('jobs.scrapeJobs')}
           </Button>
@@ -159,19 +169,22 @@ export function JobsCommandBar({
       </div>
 
       {/* Live scrape status — the scrape form now lives in a drawer that closes
-          as soon as results stream in, so progress + cancel have to stay
-          reachable here. */}
+          on Search, so progress + cancel have to stay reachable here. Same
+          scanning copy as the results skeleton, so the two never disagree.
+          `/70`, not `/55`: the light-scheme legibility remap in utilities.css
+          lifts only /20…/50, so /55 renders LIGHTER than /50 and measured
+          3.67:1 — under AA — on the one row carrying the only Cancel control. */}
       {scraping && (
         <div
           data-testid={TEST_IDS.jobs.scrapeStatusStrip}
           role="status"
           aria-live="polite"
-          className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-foreground/55"
+          className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-foreground/70"
         >
           <Loader2 size={11} aria-hidden="true" className="animate-spin text-brand-soft" />
           <span>
             {scrapeProgress == null
-              ? t('jobs.scraping')
+              ? t('jobs.scanning')
               : t('jobs.scanningPercent', { percent: Math.round(scrapeProgress * 100) })}
           </span>
           <Button variant="ghost" onClick={onCancelScrape}>
@@ -180,45 +193,44 @@ export function JobsCommandBar({
         </div>
       )}
 
-      {/* Applied filters + last-scrape diagnostics — only when there is
-          something to show. */}
+      {/* Applied filters + last-scrape diagnostics — one strictly single-line row
+          that scrolls sideways rather than wrapping, so diagnostics can never
+          grow the bar and squeeze the results list at the 900×600 floor. */}
       {showChipsRow && (
         <div
           data-testid={TEST_IDS.jobs.filterChips}
-          role="group"
-          aria-label={t('jobs.filters.activeLabel')}
-          className="mt-2 flex flex-wrap items-center gap-1.5"
+          className="scrollbar-thin mt-2 flex flex-nowrap items-center gap-1.5 overflow-x-auto pb-0.5"
         >
+          {/* The group names the REMOVABLE filter chips only — the scrape
+              diagnostics beside them are output, not applied filters. */}
           {trimmedFilter.length > 0 && (
-            <Tag
-              color="processing"
-              closable
-              closeLabel={t('jobs.filters.remove', { name: searchChipLabel })}
-              onClose={() => setJobs({ filter: '' })}
-              className="max-w-[16rem] text-[10px] font-normal"
+            <div
+              role="group"
+              aria-label={t('jobs.filters.activeLabel')}
+              className="flex shrink-0 items-center gap-1.5"
             >
-              <span className="truncate">{searchChipLabel}</span>
-            </Tag>
+              <Tag
+                color="processing"
+                closable
+                closeLabel={t('jobs.filters.remove', { name: trimmedFilter })}
+                onClose={() => setJobs({ filter: '' })}
+                className="max-w-[16rem] text-[10px] font-normal"
+              >
+                <span className="truncate">
+                  {t('jobs.filters.searchChip', { query: trimmedFilter })}
+                </span>
+              </Tag>
+            </div>
           )}
-          {hideAgency && (
-            <Tag
-              color="processing"
-              closable
-              closeLabel={t('jobs.filters.remove', { name: t('jobs.filters.hideAgency') })}
-              onClose={() => setJobs({ hideAgency: false })}
-              className="text-[10px] font-normal"
-            >
-              {t('jobs.filters.hideAgency')}
-            </Tag>
+          {boardSummaries.length > 0 && (
+            <BoardSummaryChips summaries={boardSummaries} className="shrink-0 flex-nowrap" />
           )}
-          {hasFilterChips && (
-            <Button variant="ghost" onClick={clearAllFilters}>
-              {t('jobs.filters.clearAll')}
-            </Button>
-          )}
-          {boardSummaries.length > 0 && <BoardSummaryChips summaries={boardSummaries} />}
           {failureNote !== null && (
-            <p role="status" aria-live="polite" className="text-[11px] text-red-400/80">
+            <p
+              role="status"
+              aria-live="polite"
+              className="shrink-0 whitespace-nowrap text-[11px] text-red-400/80"
+            >
               {t('jobs.lastScrapeFailed', { reason: failureNote })}
             </p>
           )}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
@@ -1,0 +1,229 @@
+import { LayoutList, LayoutPanelLeft, ListFilter, Loader2, Plus, Trash2 } from 'lucide-react';
+
+import type { BoardScrapeSummary } from '@ajh/shared';
+import { TEST_IDS } from '@ajh/test-ids';
+import { useTranslation } from '@ajh/translations';
+import { Button, Dropdown, Input, SegmentedControl, Tag } from '@ajh/ui';
+
+import { BoardSummaryChips } from '@/components/scrape/BoardSummaryChips';
+import { useSessionStore } from '@/store/session-store';
+
+interface JobsCommandBarProps {
+  /** Postings currently visible (numerator of the "N / M" count). */
+  shownCount: number;
+  /** Distinct postings before the text filter / hide-agency (denominator). */
+  totalCount: number;
+  /** True while a scrape job is running — swaps in the live status strip. */
+  scraping: boolean;
+  /** Boards-done/total fraction (0..1); null until the first board completes. */
+  scrapeProgress?: number | null;
+  /** Whether the "Clear" destructive action is offered at all. */
+  canClear: boolean;
+  onClear: () => void;
+  onScrape: () => void;
+  onCancelScrape: () => void;
+  /**
+   * Per-board outcome of the last scrape, ALREADY gated by the caller — the
+   * empty state (JobsResults) is the sole owner of the explanation when there
+   * are zero results, so the page passes `[]` in that case.
+   */
+  boardSummaries: BoardScrapeSummary[];
+  /** Sanitized note for an outright scrape failure; gated like `boardSummaries`. */
+  failureNote: string | null;
+}
+
+/**
+ * Compact command bar that replaced the Jobs hero (title + subtitle + inline
+ * form). One wrapping row of controls, plus two conditional thin rows below it:
+ * the active-filter chips and the live scrape status.
+ *
+ * Responsive contract: the control row is `flex-wrap` with no `shrink-0`
+ * no-wrap container, so at the 900px window floor the trailing action group
+ * wraps onto a second line instead of being clipped. The bar is `@container`
+ * so its children can respond to the page column's width rather than the
+ * viewport (`docs/PATTERNS.md` §15).
+ *
+ * Filter/sort/view state is read straight from the session store (the same
+ * source `JobsPage` and `JobsResults` read) so the page doesn't have to thread
+ * eight extra props through.
+ */
+export function JobsCommandBar({
+  shownCount,
+  totalCount,
+  scraping,
+  scrapeProgress,
+  canClear,
+  onClear,
+  onScrape,
+  onCancelScrape,
+  boardSummaries,
+  failureNote,
+}: JobsCommandBarProps) {
+  const { t } = useTranslation();
+  const { jobs, setJobs } = useSessionStore();
+  const { filter, sortBy, viewMode, hideAgency } = jobs;
+
+  const trimmedFilter = filter.trim();
+  const searchChipLabel = t('jobs.filters.searchChip', { query: trimmedFilter });
+  const hasFilterChips = trimmedFilter.length > 0 || hideAgency;
+  const showChipsRow = hasFilterChips || boardSummaries.length > 0 || failureNote !== null;
+
+  const clearAllFilters = () => setJobs({ filter: '', hideAgency: false });
+
+  return (
+    <div
+      data-testid={TEST_IDS.jobs.commandBar}
+      role="group"
+      aria-label={t('jobs.commandBar.label')}
+      className="@container shrink-0 px-10 pb-3 pt-6"
+    >
+      {/* Control row — wraps; never a fixed no-wrap strip. */}
+      <div className="flex flex-wrap items-center gap-2">
+        <h1 className="text-gradient shrink-0 text-lg font-bold tracking-tight">
+          {t('jobs.title')}
+        </h1>
+
+        <Input
+          id="jobs-filter-query"
+          name="jobs-filter-query"
+          prefix={<ListFilter size={12} />}
+          value={filter}
+          onChange={(e) => setJobs({ filter: e.target.value })}
+          placeholder={t('jobs.searchPlaceholder')}
+          aria-label={t('jobs.searchPlaceholder')}
+          className="text-foreground/75 placeholder:text-foreground/30"
+          variant="default"
+          wrapperClassName="min-w-[8rem] max-w-[18rem] grow basis-44"
+          allowClear
+        />
+
+        <Dropdown
+          options={[
+            { value: 'newest', label: t('jobs.sortNewest') },
+            { value: 'oldest', label: t('jobs.sortOldest') },
+            { value: 'company', label: t('jobs.sortCompany') },
+          ]}
+          value={sortBy}
+          onChange={(value) => setJobs({ sortBy: value as 'newest' | 'oldest' | 'company' })}
+          placeholder={t('jobs.sort')}
+        />
+
+        <span data-testid={TEST_IDS.jobs.hideAgencyToggle} className="inline-flex">
+          <Tag.CheckableTag checked={hideAgency} onChange={(v) => setJobs({ hideAgency: v })}>
+            {t('jobs.filters.hideAgency')}
+          </Tag.CheckableTag>
+        </span>
+
+        {/* Count — the visible "N / M" stays the terse glanceable form; the
+            accessible name spells it out for AT. */}
+        <span
+          className="shrink-0 tabular-nums text-[11px] text-foreground/50"
+          aria-label={t('jobs.commandBar.shownCount', {
+            shown: String(shownCount),
+            total: String(totalCount),
+          })}
+        >
+          {shownCount} / {totalCount}
+        </span>
+
+        {/* Trailing actions — right-aligned when there is room, wrapped to their
+            own line when there isn't. */}
+        <div className="ml-auto flex items-center gap-2">
+          {/* View mode toggle — SegmentedControl (WAI-ARIA radiogroup + roving arrow keys) */}
+          <SegmentedControl
+            ariaLabel={t('jobs.viewMode')}
+            value={viewMode}
+            onChange={(v) => setJobs({ viewMode: v })}
+            options={[
+              { value: 'list', label: <LayoutList size={13} />, title: t('jobs.viewList') },
+              {
+                value: 'split',
+                label: <LayoutPanelLeft size={13} />,
+                title: t('jobs.viewSplit'),
+              },
+            ]}
+            tone="brand"
+            size="sm"
+          />
+          {canClear && (
+            <Button variant="ghost" onClick={onClear} title={t('jobs.clearScrapedJobs')}>
+              <Trash2 size={12} />
+              {t('jobs.clear')}
+            </Button>
+          )}
+          <Button variant="primary" onClick={onScrape}>
+            <Plus size={12} />
+            {t('jobs.scrapeJobs')}
+          </Button>
+        </div>
+      </div>
+
+      {/* Live scrape status — the scrape form now lives in a drawer that closes
+          as soon as results stream in, so progress + cancel have to stay
+          reachable here. */}
+      {scraping && (
+        <div
+          data-testid={TEST_IDS.jobs.scrapeStatusStrip}
+          role="status"
+          aria-live="polite"
+          className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-foreground/55"
+        >
+          <Loader2 size={11} aria-hidden="true" className="animate-spin text-brand-soft" />
+          <span>
+            {scrapeProgress == null
+              ? t('jobs.scraping')
+              : t('jobs.scanningPercent', { percent: Math.round(scrapeProgress * 100) })}
+          </span>
+          <Button variant="ghost" onClick={onCancelScrape}>
+            {t('jobs.cancel')}
+          </Button>
+        </div>
+      )}
+
+      {/* Applied filters + last-scrape diagnostics — only when there is
+          something to show. */}
+      {showChipsRow && (
+        <div
+          data-testid={TEST_IDS.jobs.filterChips}
+          role="group"
+          aria-label={t('jobs.filters.activeLabel')}
+          className="mt-2 flex flex-wrap items-center gap-1.5"
+        >
+          {trimmedFilter.length > 0 && (
+            <Tag
+              color="processing"
+              closable
+              closeLabel={t('jobs.filters.remove', { name: searchChipLabel })}
+              onClose={() => setJobs({ filter: '' })}
+              className="max-w-[16rem] text-[10px] font-normal"
+            >
+              <span className="truncate">{searchChipLabel}</span>
+            </Tag>
+          )}
+          {hideAgency && (
+            <Tag
+              color="processing"
+              closable
+              closeLabel={t('jobs.filters.remove', { name: t('jobs.filters.hideAgency') })}
+              onClose={() => setJobs({ hideAgency: false })}
+              className="text-[10px] font-normal"
+            >
+              {t('jobs.filters.hideAgency')}
+            </Tag>
+          )}
+          {hasFilterChips && (
+            <Button variant="ghost" onClick={clearAllFilters}>
+              {t('jobs.filters.clearAll')}
+            </Button>
+          )}
+          {boardSummaries.length > 0 && <BoardSummaryChips summaries={boardSummaries} />}
+          {failureNote !== null && (
+            <p role="status" aria-live="polite" className="text-[11px] text-red-400/80">
+              {t('jobs.lastScrapeFailed', { reason: failureNote })}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.cluster-filter.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.cluster-filter.test.tsx
@@ -73,15 +73,6 @@ vi.mock('@/hooks/use-format-relative-time', () => ({
   useFormatRelativeTime: () => (ts: number) => String(ts),
 }));
 
-vi.mock('@/components/layout/PageHeader', () => ({
-  PageHeader: ({ title, actions }: { title: string; actions?: ReactNode }) => (
-    <div>
-      {title}
-      {actions}
-    </div>
-  ),
-}));
-
 vi.mock('@/components/layout/PageTransition', () => ({
   PageTransition: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
@@ -133,6 +124,8 @@ vi.mock('@ajh/ui', () => {
       </div>
     ),
     ConfirmModal: () => null,
+    Drawer: ({ open, children }: { open: boolean; children: ReactNode }) =>
+      open ? <div role="dialog">{children}</div> : null,
     Dropdown: () => null,
     Input: () => null,
     SegmentedControl: () => null,

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.dedup-throttle.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.dedup-throttle.test.tsx
@@ -107,12 +107,6 @@ vi.mock('@/hooks/use-format-relative-time', () => ({
   useFormatRelativeTime: () => (ts: number) => String(ts),
 }));
 
-vi.mock('@/components/layout/PageHeader', () => ({
-  PageHeader: ({ title }: { title: string }) => (
-    <div data-testid={TEST_IDS.layout.pageHeader}>{title}</div>
-  ),
-}));
-
 vi.mock('@/components/layout/PageTransition', () => ({
   PageTransition: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
@@ -153,6 +147,8 @@ vi.mock('@ajh/ui', () => ({
     </div>
   ),
   ConfirmModal: () => null,
+  Drawer: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div role="dialog">{children}</div> : null,
   Dropdown: () => null,
   Input: () => null,
   SegmentedControl: () => null,

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
@@ -16,6 +16,7 @@
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { TEST_IDS } from '@ajh/test-ids';
 
@@ -55,7 +56,14 @@ const resultsProps = {
   failureNote: undefined as unknown,
   totalCount: undefined as unknown,
   filtered: undefined as unknown,
+  // The empty state's "Search jobs" CTA — must open the same scrape drawer as
+  // the command bar's primary action.
+  onScrape: undefined as unknown,
 };
+
+// ScrapeForm prop capture — the drawer hands the form its own dismiss callback
+// (`onToggle`); firing it must close the drawer.
+const scrapeFormContainer = { onToggle: null as (() => void) | null };
 
 // usePostings — mutable container so tests can simulate "results present" vs
 // "zero results" for the header-strip mutual-exclusivity gating (the header
@@ -129,15 +137,6 @@ vi.mock('@/hooks/use-format-relative-time', () => ({
   useFormatRelativeTime: () => (ts: number) => String(ts),
 }));
 
-vi.mock('@/components/layout/PageHeader', () => ({
-  PageHeader: ({ title, actions }: { title: string; actions?: ReactNode }) => (
-    <div data-testid={TEST_IDS.layout.pageHeader}>
-      {title}
-      {actions}
-    </div>
-  ),
-}));
-
 vi.mock('@/components/layout/PageTransition', () => ({
   PageTransition: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
@@ -148,11 +147,13 @@ vi.mock('@/features/jobs/components/JobsResults', () => ({
     failureNote,
     totalCount,
     filtered,
+    onScrape,
   }: {
     boardSummaries?: unknown;
     failureNote?: unknown;
     totalCount?: unknown;
     filtered?: unknown;
+    onScrape?: unknown;
   }) => {
     // Records the summaries + failure note + unfiltered count forwarded into
     // the empty-state wiring, plus the sorted `filtered` list so the stable
@@ -161,6 +162,7 @@ vi.mock('@/features/jobs/components/JobsResults', () => ({
     resultsProps.failureNote = failureNote;
     resultsProps.totalCount = totalCount;
     resultsProps.filtered = filtered;
+    resultsProps.onScrape = onScrape;
     return <div data-testid={TEST_IDS.jobs.jobsResults} />;
   },
 }));
@@ -176,7 +178,10 @@ vi.mock('@/components/scrape/BoardSummaryChips', () => ({
 }));
 
 vi.mock('@/features/jobs/components/ScrapeForm', () => ({
-  ScrapeForm: () => <div data-testid={TEST_IDS.jobs.scrapeForm} />,
+  ScrapeForm: ({ onToggle }: { onToggle?: () => void }) => {
+    scrapeFormContainer.onToggle = onToggle ?? null;
+    return <div data-testid={TEST_IDS.jobs.scrapeForm} />;
+  },
 }));
 
 vi.mock('@/features/jobs/providers', () => ({
@@ -203,6 +208,8 @@ vi.mock('@ajh/ui', () => ({
     </div>
   ),
   ConfirmModal: () => null,
+  Drawer: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div role="dialog">{children}</div> : null,
   Dropdown: () => null,
   Input: () => null,
   SegmentedControl: ({ onChange }: { onChange?: (v: string) => void }) => {
@@ -770,22 +777,70 @@ describe('JobsPage — stable newest sort', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Header/scrape-form scroll container — jsdom can't measure layout, so assert
-// the bounding + scroll classes are present on the wrapper. Without them, a
-// full board selection + open advanced grid overflows the viewport and the
-// Start button becomes unreachable at the 900x600 window floor.
+// Scrape drawer — the form moved out of the page flow into a right slide-over.
+// It must be closed on mount (so it can never displace the results list), open
+// from the command bar's Scrape action, and close again from the form's own
+// dismiss control. jsdom can't measure layout, so the "tall form content can't
+// clip the Start button" guarantee is asserted as the scroll class on the
+// drawer body (which is now the sole scroll owner for the form).
 // ---------------------------------------------------------------------------
 
-describe('JobsPage — scrape form scroll container', () => {
+describe('JobsPage — scrape drawer', () => {
   beforeEach(() => {
     postingsContainer.data = [];
   });
 
-  it('bounds and scrolls the header wrapper so tall form content cannot clip the Start button', () => {
+  it('is closed on mount — the form never occupies page flow', () => {
+    renderJobsPage();
+    expect(screen.queryByTestId(TEST_IDS.jobs.scrapeForm)).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens from the command bar Scrape action and renders the reused ScrapeForm', async () => {
+    const user = userEvent.setup();
     renderJobsPage();
 
-    const wrapper = screen.getByTestId(TEST_IDS.jobs.scrapeFormScroll);
-    expect(wrapper.className).toContain('overflow-y-auto');
-    expect(wrapper.className).toContain('max-h-[55vh]');
+    await user.click(screen.getByRole('button', { name: /jobs\.scrapeJobs/ }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_IDS.jobs.scrapeForm)).toBeInTheDocument();
+  });
+
+  it('the drawer body scrolls, so tall form content cannot put the Start button out of reach', async () => {
+    const user = userEvent.setup();
+    renderJobsPage();
+
+    await user.click(screen.getByRole('button', { name: /jobs\.scrapeJobs/ }));
+
+    const body = screen.getByTestId(TEST_IDS.jobs.scrapeFormScroll);
+    expect(body.className).toContain('overflow-y-auto');
+    expect(body.className).toContain('min-h-0');
+  });
+
+  it("closes again via the form's own dismiss control (onToggle)", async () => {
+    const user = userEvent.setup();
+    renderJobsPage();
+
+    await user.click(screen.getByRole('button', { name: /jobs\.scrapeJobs/ }));
+    expect(screen.getByTestId(TEST_IDS.jobs.scrapeForm)).toBeInTheDocument();
+
+    act(() => {
+      scrapeFormContainer.onToggle?.();
+    });
+
+    expect(screen.queryByTestId(TEST_IDS.jobs.scrapeForm)).not.toBeInTheDocument();
+  });
+
+  it('the empty-state CTA opens the same drawer', async () => {
+    renderJobsPage();
+    expect(screen.queryByTestId(TEST_IDS.jobs.scrapeForm)).not.toBeInTheDocument();
+
+    // JobsResults is stubbed — invoke the `onScrape` prop it was handed, which
+    // is the empty state's "Search jobs" CTA on the real component.
+    act(() => {
+      (resultsProps.onScrape as (() => void) | undefined)?.();
+    });
+
+    expect(screen.getByTestId(TEST_IDS.jobs.scrapeForm)).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
@@ -13,7 +13,7 @@
  * shared-object container (avoids the vi.mock factory scope isolation constraint)
  * so we can fire synthetic events directly in each test.
  */
-import type { ReactNode } from 'react';
+import type { ReactNode, Ref } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -61,9 +61,17 @@ const resultsProps = {
   onScrape: undefined as unknown,
 };
 
-// ScrapeForm prop capture — the drawer hands the form its own dismiss callback
-// (`onToggle`); firing it must close the drawer.
-const scrapeFormContainer = { onToggle: null as (() => void) | null };
+// ScrapeForm prop capture — the drawer hands the form its dismiss callback
+// (`onToggle`) and its submit (`onStart`); either must close the drawer.
+const scrapeFormContainer = {
+  onToggle: null as (() => void) | null,
+  onStart: null as (() => void) | null,
+};
+
+// Drawer prop capture — asserts the focus-return fallback the page wires in.
+const drawerContainer = {
+  returnFocusTo: null as { current: HTMLElement | null } | null,
+};
 
 // usePostings — mutable container so tests can simulate "results present" vs
 // "zero results" for the header-strip mutual-exclusivity gating (the header
@@ -178,8 +186,9 @@ vi.mock('@/components/scrape/BoardSummaryChips', () => ({
 }));
 
 vi.mock('@/features/jobs/components/ScrapeForm', () => ({
-  ScrapeForm: ({ onToggle }: { onToggle?: () => void }) => {
+  ScrapeForm: ({ onToggle, onStart }: { onToggle?: () => void; onStart?: () => void }) => {
     scrapeFormContainer.onToggle = onToggle ?? null;
+    scrapeFormContainer.onStart = onStart ?? null;
     return <div data-testid={TEST_IDS.jobs.scrapeForm} />;
   },
 }));
@@ -202,14 +211,34 @@ vi.mock('@ajh/translations', () => ({
 }));
 
 vi.mock('@ajh/ui', () => ({
-  Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
-    <div role="button" onClick={onClick}>
+  // A real <button> (not a div) so `ref` forwarding — which the drawer's
+  // focus-return fallback depends on — is actually exercised.
+  Button: ({
+    children,
+    onClick,
+    ref,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    ref?: Ref<HTMLButtonElement>;
+  }) => (
+    <button type="button" ref={ref} onClick={onClick}>
       {children}
-    </div>
+    </button>
   ),
   ConfirmModal: () => null,
-  Drawer: ({ open, children }: { open: boolean; children: ReactNode }) =>
-    open ? <div role="dialog">{children}</div> : null,
+  Drawer: ({
+    open,
+    children,
+    returnFocusTo,
+  }: {
+    open: boolean;
+    children: ReactNode;
+    returnFocusTo?: { current: HTMLElement | null };
+  }) => {
+    drawerContainer.returnFocusTo = returnFocusTo ?? null;
+    return open ? <div role="dialog">{children}</div> : null;
+  },
   Dropdown: () => null,
   Input: () => null,
   SegmentedControl: ({ onChange }: { onChange?: (v: string) => void }) => {
@@ -806,15 +835,55 @@ describe('JobsPage — scrape drawer', () => {
     expect(screen.getByTestId(TEST_IDS.jobs.scrapeForm)).toBeInTheDocument();
   });
 
-  it('the drawer body scrolls, so tall form content cannot put the Start button out of reach', async () => {
+  it('closes on Search — in the click handler, not from a background stream event', async () => {
+    const user = userEvent.setup();
+    renderJobsPage();
+
+    await user.click(screen.getByRole('button', { name: /jobs\.scrapeJobs/ }));
+    expect(screen.getByTestId(TEST_IDS.jobs.scrapeForm)).toBeInTheDocument();
+
+    act(() => {
+      scrapeFormContainer.onStart?.();
+    });
+
+    // Closing here (user-initiated) rather than from an effect on the first
+    // streamed posting is what keeps focus predictable: the old effect yanked
+    // focus mid-interaction and, on the first-run path, closed the drawer only
+    // AFTER the empty-state CTA it would return focus to had unmounted.
+    expect(screen.queryByTestId(TEST_IDS.jobs.scrapeForm)).not.toBeInTheDocument();
+  });
+
+  it('stays closed when a scrape returns ZERO results (nothing ever streams)', async () => {
+    const user = userEvent.setup();
+    renderJobsPage();
+
+    await user.click(screen.getByRole('button', { name: /jobs\.scrapeJobs/ }));
+    act(() => {
+      scrapeFormContainer.onStart?.();
+    });
+
+    // A completion with no postings must not strand the drawer open — the old
+    // livePostings-driven close never fired for an empty result set.
+    fireJobEvent({
+      type: 'job.completed',
+      jobId: 'job-123',
+      data: { boards: [{ board: 'linkedin', count: 0 }] },
+    });
+
+    expect(screen.queryByTestId(TEST_IDS.jobs.scrapeForm)).not.toBeInTheDocument();
+  });
+
+  it('hands the drawer an always-mounted focus-return target', async () => {
     const user = userEvent.setup();
     renderJobsPage();
 
     await user.click(screen.getByRole('button', { name: /jobs\.scrapeJobs/ }));
 
-    const body = screen.getByTestId(TEST_IDS.jobs.scrapeFormScroll);
-    expect(body.className).toContain('overflow-y-auto');
-    expect(body.className).toContain('min-h-0');
+    // The empty-state CTA can unmount while the drawer is open, so the drawer
+    // needs a fallback that never does — the command bar's Scrape button.
+    expect(drawerContainer.returnFocusTo?.current).toBe(
+      screen.getByRole('button', { name: /jobs\.scrapeJobs/ })
+    );
   });
 
   it("closes again via the form's own dismiss control (onToggle)", async () => {

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
@@ -697,9 +697,14 @@ describe('JobsPage — header strip mutual exclusivity with the empty state', ()
     fireJobEvent({ type: 'job.failed', jobId: 'job-123', data: 'connection refused' });
 
     await waitFor(() => expect(resultsProps.failureNote).toBe('sanitized:connection refused'));
+    // Deliberately TWO nodes: the visible (aria-hidden) chip-row copy and the
+    // always-mounted sr-only live region the command bar announces through.
     expect(
-      screen.getByText('jobs.lastScrapeFailed[reason=sanitized:connection refused]')
-    ).toBeInTheDocument();
+      screen.getAllByText('jobs.lastScrapeFailed[reason=sanitized:connection refused]')
+    ).toHaveLength(2);
+    expect(screen.getByTestId(TEST_IDS.jobs.scrapeStatusLive)).toHaveTextContent(
+      'jobs.lastScrapeFailed[reason=sanitized:connection refused]'
+    );
   });
 });
 

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -5,7 +5,6 @@ import {
   type BoardScrapeSummary,
   type DATE_FILTER_OPTIONS,
 } from '@ajh/shared';
-import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
 import { ConfirmModal, Drawer, useNotification } from '@ajh/ui';
 
@@ -46,6 +45,11 @@ export function JobsPage() {
   const { jobs } = useSessionStore();
   const { filter, sortBy, hideAgency } = jobs;
   const [showScrapeForm, setShowScrapeForm] = useState(false);
+  // Always-mounted opener for the scrape drawer. The drawer normally returns
+  // focus to whatever opened it, but the empty-state "Search jobs" CTA unmounts
+  // the moment a scrape starts, so this is the fallback that keeps focus off
+  // <body> on the first-run path.
+  const scrapeButtonRef = useRef<HTMLButtonElement>(null);
   const [confirmClear, setConfirmClear] = useState(false);
   // Per-board outcome of the most recent scrape. Kept in page state (not dropped
   // after reading) so the chip strip persists in the results header once the
@@ -204,10 +208,6 @@ export function JobsPage() {
     };
   }, []);
 
-  useEffect(() => {
-    if (livePostings.length > 0) setShowScrapeForm(false);
-  }, [livePostings.length]);
-
   // `absorbedInto` traces which live-stream ids collapsed into which survivor id
   // (boards stream at different speeds and the persisted refetch can land under a
   // DIFFERENT incumbent than the one currently selected) — JobsResults consumes it
@@ -230,9 +230,18 @@ export function JobsPage() {
   // Start a fresh scrape — drop the previous run's chip strip/failure note so
   // neither reads as the new run's outcome (a fresh one arrives on the next
   // job.completed / job.failed).
+  //
+  // Closing the drawer here, in the USER-INITIATED handler, is deliberate. It
+  // used to close from an effect on `livePostings.length` — i.e. driven by a
+  // background stream event, which yanked focus out from under whatever the
+  // user was doing and, on the first-run path (empty state → "Search jobs" →
+  // drawer), unmounted the very CTA the drawer would restore focus to, dropping
+  // focus to <body>. Closing on the click also means a scrape that returns ZERO
+  // results still closes the drawer instead of stranding it open (WCAG 2.4.3).
   const handleStartScrape = () => {
     setLastSummaries([]);
     setLastFailureNote(null);
+    setShowScrapeForm(false);
     void startScrape();
   };
 
@@ -334,6 +343,7 @@ export function JobsPage() {
             onCancelScrape={cancelScrape}
             boardSummaries={showDiagnostics ? lastSummaries : []}
             failureNote={showDiagnostics ? lastFailureNote : null}
+            scrapeButtonRef={scrapeButtonRef}
           />
 
           <JobsResults
@@ -358,28 +368,25 @@ export function JobsPage() {
       {/* New Scrape — a right slide-over instead of an inline block, so the form
           can't push the results list (or its own Start button) off screen at the
           900x600 window floor. Batch-apply is unchanged: edits only take effect
-          when the user hits Search. The drawer body owns the scroll. */}
+          when the user hits Search. ScrapeForm owns the pinned header/footer and
+          the single scrolling body inside the panel. */}
       <Drawer
         open={showScrapeForm}
         onClose={() => setShowScrapeForm(false)}
         ariaLabel={t('jobs.newScrape')}
+        returnFocusTo={scrapeButtonRef}
       >
-        <div
-          data-testid={TEST_IDS.jobs.scrapeFormScroll}
-          className="min-h-0 flex-1 overflow-y-auto p-4"
-        >
-          <ScrapeForm
-            show={showScrapeForm}
-            form={scrapeForm}
-            scraping={scraping}
-            scrapeOutcome={scrapeOutcome}
-            onToggle={() => setShowScrapeForm(false)}
-            onFormChange={(updates) => setScrapeForm({ ...scrapeForm, ...updates })}
-            onStart={handleStartScrape}
-            onCancel={cancelScrape}
-            onGeocode={geocodeSuggest}
-          />
-        </div>
+        <ScrapeForm
+          show={showScrapeForm}
+          form={scrapeForm}
+          scraping={scraping}
+          scrapeOutcome={scrapeOutcome}
+          onToggle={() => setShowScrapeForm(false)}
+          onFormChange={(updates) => setScrapeForm({ ...scrapeForm, ...updates })}
+          onStart={handleStartScrape}
+          onCancel={cancelScrape}
+          onGeocode={geocodeSuggest}
+        />
       </Drawer>
 
       <ConfirmModal

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -1,4 +1,3 @@
-import { LayoutList, LayoutPanelLeft, ListFilter, Plus, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
@@ -8,19 +7,11 @@ import {
 } from '@ajh/shared';
 import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
-import {
-  Button,
-  ConfirmModal,
-  Dropdown,
-  Input,
-  SegmentedControl,
-  Tag,
-  useNotification,
-} from '@ajh/ui';
+import { ConfirmModal, Drawer, useNotification } from '@ajh/ui';
 
-import { PageHeader } from '@/components/layout/PageHeader';
 import { PageTransition } from '@/components/layout/PageTransition';
-import { BoardSummaryChips, sanitizeReason } from '@/components/scrape/BoardSummaryChips';
+import { sanitizeReason } from '@/components/scrape/BoardSummaryChips';
+import { JobsCommandBar } from '@/features/jobs/components/JobsCommandBar';
 import { JobsResults } from '@/features/jobs/components/JobsResults';
 import { ScrapeForm } from '@/features/jobs/components/ScrapeForm';
 import type { ScrapeFormState } from '@/features/jobs/components/ScrapeForm/constants';
@@ -52,10 +43,8 @@ export function JobsPage() {
   const clearPostings = useClearPostings();
   const invalidatePostings = useInvalidatePostings();
 
-  const { jobs, setJobs } = useSessionStore();
-  const { filter, sortBy, viewMode, hideAgency } = jobs;
-  const setFilter = (v: string) => setJobs({ filter: v });
-  const setSortBy = (v: 'newest' | 'oldest' | 'company') => setJobs({ sortBy: v });
+  const { jobs } = useSessionStore();
+  const { filter, sortBy, hideAgency } = jobs;
   const [showScrapeForm, setShowScrapeForm] = useState(false);
   const [confirmClear, setConfirmClear] = useState(false);
   // Per-board outcome of the most recent scrape. Kept in page state (not dropped
@@ -315,129 +304,37 @@ export function JobsPage() {
 
   const resumeId = useDefaultResumeId();
 
+  // Persistent per-board outcome — survives the drawer auto-closing so the user
+  // can always see what each board did on the last scrape. Gated on results
+  // being present: when there are ZERO results the empty state (JobsResults) is
+  // the SOLE owner of the explanation — without this gate both would render at
+  // once. The same gate covers the outright-failure note (which has no
+  // per-board summaries to chip).
+  const showDiagnostics = !scraping && filtered.length > 0;
+
   return (
     <MatchScoresProvider resumeId={resumeId}>
       <PageTransition className="flex h-full flex-col overflow-hidden">
         {/* Centered column: constrains content to max-w-6xl on large displays,
-            matching the dashboard. Both the pinned header and the scroll area
+            matching the dashboard. Both the command bar and the results area
             sit inside so they stay visually aligned. */}
         <div className="mx-auto flex w-full min-h-0 flex-1 flex-col max-w-6xl 2xl:max-w-7xl">
-          {/* Header + scrape form. Bounded + self-scrolling so that selecting all
-              boards and opening the advanced grid can't push the Start button off
-              the bottom of the viewport (900x600 floor) — it caps at 55vh and
-              scrolls internally, leaving the results list as the primary scroll
-              owner below. Short content is unaffected (no scrollbar shown). */}
-          <div
-            data-testid={TEST_IDS.jobs.scrapeFormScroll}
-            className="max-h-[55vh] shrink-0 overflow-y-auto px-10 pt-10"
-          >
-            <PageHeader
-              title={t('jobs.title')}
-              subtitle={t('jobs.subtitle')}
-              badge={t('jobs.eyebrow')}
-              actions={
-                <div className="flex items-center gap-2">
-                  <Button
-                    variant="primary"
-                    onClick={() => setShowScrapeForm(!showScrapeForm)}
-                    className="transition-all duration-150 ease-out"
-                  >
-                    <Plus size={12} />
-                    {t('jobs.scrapeJobs')}
-                  </Button>
-                  {allPostings.length > 0 && !scraping && (
-                    <Button
-                      variant="ghost"
-                      onClick={() => setConfirmClear(true)}
-                      title={t('jobs.clearScrapedJobs')}
-                    >
-                      <Trash2 size={12} />
-                      {t('jobs.clear')}
-                    </Button>
-                  )}
-                  <Input
-                    id="jobs-filter-query"
-                    name="jobs-filter-query"
-                    prefix={<ListFilter size={12} />}
-                    value={filter}
-                    onChange={(e) => setFilter(e.target.value)}
-                    placeholder={t('jobs.searchPlaceholder')}
-                    className="text-foreground/75 placeholder:text-foreground/30"
-                    variant="default"
-                    wrapperClassName="w-48"
-                    allowClear
-                  />
-                  <Dropdown
-                    options={[
-                      { value: 'newest', label: t('jobs.sortNewest') },
-                      { value: 'oldest', label: t('jobs.sortOldest') },
-                      { value: 'company', label: t('jobs.sortCompany') },
-                    ]}
-                    value={sortBy}
-                    onChange={(value) => setSortBy(value as 'newest' | 'oldest' | 'company')}
-                    placeholder={t('jobs.sort')}
-                  />
-                  <span data-testid={TEST_IDS.jobs.hideAgencyToggle} className="inline-flex">
-                    <Tag.CheckableTag
-                      checked={hideAgency}
-                      onChange={(v) => setJobs({ hideAgency: v })}
-                    >
-                      {t('jobs.filters.hideAgency')}
-                    </Tag.CheckableTag>
-                  </span>
-                  <span className="text-[11px] text-foreground/40">
-                    {filtered.length} / {distinctCount}
-                  </span>
-                  {/* View mode toggle — SegmentedControl (WAI-ARIA radiogroup + roving arrow keys) */}
-                  <SegmentedControl
-                    ariaLabel={t('jobs.viewMode')}
-                    value={viewMode}
-                    onChange={(v) => setJobs({ viewMode: v })}
-                    options={[
-                      { value: 'list', label: <LayoutList size={13} />, title: t('jobs.viewList') },
-                      {
-                        value: 'split',
-                        label: <LayoutPanelLeft size={13} />,
-                        title: t('jobs.viewSplit'),
-                      },
-                    ]}
-                    tone="brand"
-                    size="sm"
-                  />
-                </div>
-              }
-            />
-
-            <ScrapeForm
-              show={showScrapeForm}
-              form={scrapeForm}
-              scraping={scraping}
-              scrapeOutcome={scrapeOutcome}
-              onToggle={() => setShowScrapeForm(!showScrapeForm)}
-              onFormChange={(updates) => setScrapeForm({ ...scrapeForm, ...updates })}
-              onStart={handleStartScrape}
-              onCancel={cancelScrape}
-              onGeocode={geocodeSuggest}
-            />
-
-            {/* Persistent per-board outcome — survives the form auto-closing so
-                the user can always see what each board did on the last scrape.
-                Gated on results being present: when there are ZERO results the
-                empty state (JobsResults) is the SOLE owner of the explanation —
-                without this gate both would render at once. */}
-            {!scraping && filtered.length > 0 && lastSummaries.length > 0 && (
-              <BoardSummaryChips summaries={lastSummaries} className="mb-4" />
-            )}
-            {/* An outright scrape failure has no per-board summaries to chip —
-                keep a minimal sanitized note visible instead of going silent
-                once the dismissible form-footer note is gone. Same
-                results-present gating as above. */}
-            {!scraping && filtered.length > 0 && lastFailureNote && (
-              <p role="status" aria-live="polite" className="mb-4 text-[11px] text-red-400/80">
-                {t('jobs.lastScrapeFailed', { reason: lastFailureNote })}
-              </p>
-            )}
-          </div>
+          {/* Command bar — replaces the old hero + inline form. It is `shrink-0`
+              with NO overflow of its own (the previous bounded `overflow-y-auto`
+              wrapper is what produced the stray horizontal scrollbar), so the
+              results area below owns the full remaining height. */}
+          <JobsCommandBar
+            shownCount={filtered.length}
+            totalCount={distinctCount}
+            scraping={scraping}
+            scrapeProgress={scrapeProgress}
+            canClear={allPostings.length > 0 && !scraping}
+            onClear={() => setConfirmClear(true)}
+            onScrape={() => setShowScrapeForm(true)}
+            onCancelScrape={cancelScrape}
+            boardSummaries={showDiagnostics ? lastSummaries : []}
+            failureNote={showDiagnostics ? lastFailureNote : null}
+          />
 
           <JobsResults
             filtered={filtered}
@@ -457,6 +354,33 @@ export function JobsPage() {
           />
         </div>
       </PageTransition>
+
+      {/* New Scrape — a right slide-over instead of an inline block, so the form
+          can't push the results list (or its own Start button) off screen at the
+          900x600 window floor. Batch-apply is unchanged: edits only take effect
+          when the user hits Search. The drawer body owns the scroll. */}
+      <Drawer
+        open={showScrapeForm}
+        onClose={() => setShowScrapeForm(false)}
+        ariaLabel={t('jobs.newScrape')}
+      >
+        <div
+          data-testid={TEST_IDS.jobs.scrapeFormScroll}
+          className="min-h-0 flex-1 overflow-y-auto p-4"
+        >
+          <ScrapeForm
+            show={showScrapeForm}
+            form={scrapeForm}
+            scraping={scraping}
+            scrapeOutcome={scrapeOutcome}
+            onToggle={() => setShowScrapeForm(false)}
+            onFormChange={(updates) => setScrapeForm({ ...scrapeForm, ...updates })}
+            onStart={handleStartScrape}
+            onCancel={cancelScrape}
+            onGeocode={geocodeSuggest}
+          />
+        </div>
+      </Drawer>
 
       <ConfirmModal
         open={confirmClear}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsResults/JobsResults.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsResults/JobsResults.test.tsx
@@ -413,6 +413,22 @@ describe('JobsResults — board diagnostics in the empty state', () => {
   });
 });
 
+// ── split-mode container-query host ──────────────────────────────────────────
+
+describe('JobsResults — split-mode container host', () => {
+  it('marks the results card as a @container so the split can size off pane width', () => {
+    STORE_STATE.jobs = { viewMode: 'split', selectedId: 'a' };
+    renderResults({ filtered: [posting('a', 'A')], resumeId: null });
+
+    // JobsSplitView gates two-pane on `@3xl`. A container-query variant with NO
+    // `@container` ancestor silently never fires (docs/PATTERNS.md §15), so the
+    // split would collapse to one column at every width without this class.
+    const card = screen.getByTestId('jobs-split-view').parentElement;
+    expect(card?.className).toContain('@container');
+    expect(card?.className).toContain('surface-card');
+  });
+});
+
 // ── split-mode auto-select ────────────────────────────────────────────────────
 
 describe('JobsResults — split-mode auto-select', () => {

--- a/apps/desktop/src/renderer/features/jobs/components/JobsResults/JobsResults.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsResults/JobsResults.test.tsx
@@ -131,6 +131,7 @@ const formatRelativeTime = () => '';
 function renderResults(opts: {
   filtered: Posting[];
   scraping?: boolean;
+  scrapeProgress?: number | null;
   resumeId?: string | null;
   boardSummaries?: BoardScrapeSummary[];
   failureNote?: string | null;
@@ -145,6 +146,7 @@ function renderResults(opts: {
       filtered={opts.filtered}
       formatRelativeTime={formatRelativeTime}
       scraping={opts.scraping ?? false}
+      scrapeProgress={opts.scrapeProgress}
       boardSummaries={opts.boardSummaries}
       failureNote={opts.failureNote}
       totalCount={opts.totalCount}
@@ -186,6 +188,17 @@ describe('JobsResults — gating', () => {
     expect(screen.getByText('jobs.searching')).toBeInTheDocument();
     expect(screen.queryByTestId(TEST_IDS.jobs.postingRow)).not.toBeInTheDocument();
     expect(screen.queryByText('jobs.showMore')).not.toBeInTheDocument();
+  });
+
+  it('leaves the scanning copy to the command bar — the bar under the progress fill is unlabelled', () => {
+    renderResults({ filtered: [], scraping: true, scrapeProgress: 0.42 });
+
+    // The command bar's status strip sits ~60px above with the SAME copy and
+    // owns Cancel; two identical lines updating out of step read as a stutter.
+    expect(screen.queryByText(/jobs\.scanningPercent/)).not.toBeInTheDocument();
+    expect(screen.queryByText('jobs.scanning')).not.toBeInTheDocument();
+    // The fill itself stays — it is the non-duplicated part of the signal.
+    expect(screen.getByText('jobs.searching')).toBeInTheDocument();
   });
 
   it('keeps existing rows visible during show-more (scraping=true with results already present)', () => {

--- a/apps/desktop/src/renderer/features/jobs/components/JobsResults/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsResults/index.tsx
@@ -246,7 +246,11 @@ export function JobsResults({
   if (viewMode === 'split') {
     return (
       <div className="min-h-0 flex-1 overflow-hidden px-10 pb-10">
-        <div className="surface-card flex h-full min-h-0 overflow-hidden rounded-2xl">
+        {/* `@container`: the split decides list-vs-two-pane from the CARD's own
+            width, not the viewport (docs/PATTERNS.md §15). A viewport `md:`
+            fired even when the sidebar left the card ~390px wide, which is far
+            too narrow for two panes. */}
+        <div className="surface-card @container flex h-full min-h-0 overflow-hidden rounded-2xl">
           <JobsSplitView
             display={filtered}
             formatRelativeTime={formatRelativeTime}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsResults/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsResults/index.tsx
@@ -162,15 +162,11 @@ export function JobsResults({
             <div className="w-full max-w-2xl space-y-2">
               {/* Transient live scrape progress — a thin fill that advances as
                   each board finishes; shown only while a fresh scrape has no
-                  results yet. */}
-              <div className="space-y-1">
-                <ProgressBar value={(scrapeProgress ?? 0) * 100} showLabel={false} />
-                <div className="text-[10px] text-foreground/45">
-                  {scrapeProgress == null
-                    ? t('jobs.scanning')
-                    : t('jobs.scanningPercent', { percent: Math.round(scrapeProgress * 100) })}
-                </div>
-              </div>
+                  results yet. The bar carries no label of its own: the command
+                  bar's status strip sits ~60px above with the SAME copy, and
+                  two identical lines reading out of step looked like a stutter.
+                  The strip is the labelled surface (it also owns Cancel). */}
+              <ProgressBar value={(scrapeProgress ?? 0) * 100} showLabel={false} />
               <RowSkeleton />
               <RowSkeleton />
               <RowSkeleton />

--- a/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/JobsSplitView.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/JobsSplitView.test.tsx
@@ -529,3 +529,56 @@ describe('JobsSplitView — scroll persist (RAF-throttled)', () => {
     expect(useSessionStore.getState().jobs.listScrollTop).toBe(0);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Responsive width contract (narrow-window regression)
+// ─────────────────────────────────────────────────────────────────────────────
+// `md:` is ALWAYS active (900px window floor — docs/PATTERNS.md §15), so the
+// old fixed `md:w-[420px]` ladder left the detail pane ~248px at the floor and
+// clipped its action cluster. jsdom has no layout engine, so the contract is
+// asserted on the classes that produce it — the same seam the ModalShell
+// responsive test uses.
+
+describe('JobsSplitView — responsive width contract', () => {
+  function panes(): { root: HTMLElement; aside: HTMLElement; detail: HTMLElement } {
+    const aside = screen.getByRole('complementary');
+    const root = aside.parentElement;
+    const detail = screen.getByTestId('job-detail').closest('section');
+    if (!root || !detail) throw new Error('split panes not rendered');
+    return { root, aside, detail };
+  }
+
+  it('sizes the list pane proportionally with a floor and a ceiling, not a fixed px ladder', () => {
+    renderSplit();
+    const { aside } = panes();
+
+    expect(aside.className).toContain('md:w-[34%]');
+    expect(aside.className).toContain('md:min-w-[280px]');
+    expect(aside.className).toContain('md:max-w-[480px]');
+    // The fixed ladder is what starved the detail pane at the 900px floor.
+    expect(aside.className).not.toContain('md:w-[420px]');
+    expect(aside.className).not.toContain('xl:w-[480px]');
+    expect(aside.className).not.toContain('2xl:w-[520px]');
+  });
+
+  it('keeps the list pane from being squeezed by detail-pane content', () => {
+    renderSplit();
+    expect(panes().aside.className).toContain('md:shrink-0');
+  });
+
+  it('lets the root fill the results card instead of resolving to max-content', () => {
+    renderSplit();
+    const { root } = panes();
+    // Without w-full + min-w-0 this lone flex child sizes to max-content and the
+    // two panes overflow the card (which clips with overflow-hidden).
+    expect(root.className).toContain('w-full');
+    expect(root.className).toContain('min-w-0');
+  });
+
+  it('keeps the detail pane shrinkable (min-w-0) so it can compress rather than overflow', () => {
+    renderSplit();
+    const { detail } = panes();
+    expect(detail.className).toContain('min-w-0');
+    expect(detail.className).toContain('flex-1');
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/JobsSplitView.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/JobsSplitView.test.tsx
@@ -536,7 +536,10 @@ describe('JobsSplitView — scroll persist (RAF-throttled)', () => {
 // Two defects, one contract. (1) `md:` is a VIEWPORT breakpoint and is always
 // active at the 900px window floor, so it forced two panes even when the
 // expanded sidebar left the results card ~390px wide — the gate has to read the
-// card's own width (`@3xl`, docs/PATTERNS.md §15). (2) The fixed
+// card's own width (`@2xl` = 42rem — the card reaches it at a ~1100px window
+// and still yields 280px of list + ~434px of detail; `@3xl` needed 1200px,
+// 1340px at large text scale, which starved the narrow windows this redesign
+// exists to serve — docs/PATTERNS.md §15). (2) The fixed
 // `md:w-[420px] xl: 2xl:` ladder left the detail pane ~248px, which is what
 // clipped its action cluster. jsdom has no layout engine, so the contract is
 // asserted on the classes that produce it — the same seam ModalShell's
@@ -555,9 +558,9 @@ describe('JobsSplitView — responsive width contract', () => {
     renderSplit();
     const { aside } = panes();
 
-    expect(aside.className).toContain('@3xl:w-[34%]');
-    expect(aside.className).toContain('@3xl:min-w-[280px]');
-    expect(aside.className).toContain('@3xl:max-w-[480px]');
+    expect(aside.className).toContain('@2xl:w-[34%]');
+    expect(aside.className).toContain('@2xl:min-w-[280px]');
+    expect(aside.className).toContain('@2xl:max-w-[480px]');
     // The fixed ladder is what starved the detail pane at the 900px floor.
     expect(aside.className).not.toContain('w-[420px]');
     expect(aside.className).not.toContain('xl:w-[480px]');
@@ -566,7 +569,7 @@ describe('JobsSplitView — responsive width contract', () => {
 
   it('keeps the list pane from being squeezed by detail-pane content', () => {
     renderSplit();
-    expect(panes().aside.className).toContain('@3xl:shrink-0');
+    expect(panes().aside.className).toContain('@2xl:shrink-0');
   });
 
   it('gates two-pane on the CARD width, never on the viewport', () => {
@@ -575,7 +578,7 @@ describe('JobsSplitView — responsive width contract', () => {
 
     // Every layout decision is a container query. A viewport `md:` fired at the
     // 900px floor even when the sidebar left the card far too narrow to split.
-    expect(root.className).toContain('@3xl:flex-row');
+    expect(root.className).toContain('@2xl:flex-row');
     expect(root.className).not.toMatch(/(^|\s)md:/);
     expect(aside.className).not.toMatch(/(^|\s)md:/);
     expect(detail.className).not.toMatch(/(^|\s)md:/);

--- a/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/JobsSplitView.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/JobsSplitView.test.tsx
@@ -533,10 +533,13 @@ describe('JobsSplitView — scroll persist (RAF-throttled)', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // Responsive width contract (narrow-window regression)
 // ─────────────────────────────────────────────────────────────────────────────
-// `md:` is ALWAYS active (900px window floor — docs/PATTERNS.md §15), so the
-// old fixed `md:w-[420px]` ladder left the detail pane ~248px at the floor and
+// Two defects, one contract. (1) `md:` is a VIEWPORT breakpoint and is always
+// active at the 900px window floor, so it forced two panes even when the
+// expanded sidebar left the results card ~390px wide — the gate has to read the
+// card's own width (`@3xl`, docs/PATTERNS.md §15). (2) The fixed
+// `md:w-[420px] xl: 2xl:` ladder left the detail pane ~248px, which is what
 // clipped its action cluster. jsdom has no layout engine, so the contract is
-// asserted on the classes that produce it — the same seam the ModalShell
+// asserted on the classes that produce it — the same seam ModalShell's
 // responsive test uses.
 
 describe('JobsSplitView — responsive width contract', () => {
@@ -552,18 +555,30 @@ describe('JobsSplitView — responsive width contract', () => {
     renderSplit();
     const { aside } = panes();
 
-    expect(aside.className).toContain('md:w-[34%]');
-    expect(aside.className).toContain('md:min-w-[280px]');
-    expect(aside.className).toContain('md:max-w-[480px]');
+    expect(aside.className).toContain('@3xl:w-[34%]');
+    expect(aside.className).toContain('@3xl:min-w-[280px]');
+    expect(aside.className).toContain('@3xl:max-w-[480px]');
     // The fixed ladder is what starved the detail pane at the 900px floor.
-    expect(aside.className).not.toContain('md:w-[420px]');
+    expect(aside.className).not.toContain('w-[420px]');
     expect(aside.className).not.toContain('xl:w-[480px]');
     expect(aside.className).not.toContain('2xl:w-[520px]');
   });
 
   it('keeps the list pane from being squeezed by detail-pane content', () => {
     renderSplit();
-    expect(panes().aside.className).toContain('md:shrink-0');
+    expect(panes().aside.className).toContain('@3xl:shrink-0');
+  });
+
+  it('gates two-pane on the CARD width, never on the viewport', () => {
+    renderSplit();
+    const { root, aside, detail } = panes();
+
+    // Every layout decision is a container query. A viewport `md:` fired at the
+    // 900px floor even when the sidebar left the card far too narrow to split.
+    expect(root.className).toContain('@3xl:flex-row');
+    expect(root.className).not.toMatch(/(^|\s)md:/);
+    expect(aside.className).not.toMatch(/(^|\s)md:/);
+    expect(detail.className).not.toMatch(/(^|\s)md:/);
   });
 
   it('lets the root fill the results card instead of resolving to max-content', () => {

--- a/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/index.tsx
@@ -111,14 +111,23 @@ export function JobsSplitView({
 
   return (
     // flex-col on mobile, flex-row on md+. min-h-0 required for nested overflow.
-    <div className="flex h-full min-h-0 flex-col md:flex-row">
+    // w-full + min-w-0: this element is the lone flex child of the results card,
+    // so without them its main size resolves to max-content and the two panes
+    // overflow (clipped by the card's overflow-hidden) instead of sharing the
+    // available width.
+    <div className="flex h-full w-full min-h-0 min-w-0 flex-col md:flex-row">
       {/* ── Left: list pane ── */}
-      {/* Narrow: hidden when a job is selected. Wide: fixed width, always visible. */}
+      {/* Narrow: hidden when a job is selected. Wide: always visible.
+          Width is proportional-with-bounds (the utility equivalent of
+          `clamp(280px, 34%, 480px)`) rather than a fixed 420/480/520px ladder:
+          at the 900px window floor a fixed 420px left over ~248px for the detail
+          pane, which is what clipped its action cluster. `shrink-0` keeps the
+          percentage authoritative once the detail pane's content grows. */}
       <aside
         className={[
           'flex flex-col overflow-hidden border-r border-[var(--border-clear)]',
           selectedPosting ? 'hidden md:flex' : 'flex',
-          'md:w-[420px] xl:w-[480px] 2xl:w-[520px]',
+          'md:w-[34%] md:min-w-[280px] md:max-w-[480px] md:shrink-0',
         ].join(' ')}
       >
         {/* List scroll container — virtualizer targets this.

--- a/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/index.tsx
@@ -111,14 +111,17 @@ export function JobsSplitView({
 
   return (
     // Single column until the CARD (not the viewport) is wide enough for two
-    // panes, then a row — `@3xl` = 48rem, roughly the point where a 280px list
-    // still leaves the detail pane a usable ~450px. The parent results card
-    // carries `@container`; a viewport `md:` here fired even when the expanded
-    // sidebar left the card ~390px wide (docs/PATTERNS.md §15).
+    // panes, then a row. `@2xl` = 42rem: the card reaches it at a ~1100px window
+    // and still yields 280px of list + ~434px of detail, both usable. `@3xl`
+    // (48rem) needed a 1200px window — 1340px at large text scale — which
+    // pushed most narrow-window users into one column, the very complaint this
+    // redesign started from. The parent results card carries `@container`; a
+    // viewport `md:` here fired even when the expanded sidebar left the card
+    // ~390px wide (docs/PATTERNS.md §15).
     // w-full + min-w-0: this element is the lone flex child of that card, so
     // without them its main size resolves to max-content and the panes overflow
     // (clipped by the card's overflow-hidden) instead of sharing the width.
-    <div className="@3xl:flex-row flex h-full w-full min-h-0 min-w-0 flex-col">
+    <div className="@2xl:flex-row flex h-full w-full min-h-0 min-w-0 flex-col">
       {/* ── Left: list pane ── */}
       {/* Single-column: hidden when a job is selected. Two-pane: always visible.
           Width is proportional-with-bounds (the utility equivalent of
@@ -129,8 +132,8 @@ export function JobsSplitView({
       <aside
         className={[
           'flex flex-col overflow-hidden border-r border-[var(--border-clear)]',
-          selectedPosting ? '@3xl:flex hidden' : 'flex',
-          '@3xl:w-[34%] @3xl:min-w-[280px] @3xl:max-w-[480px] @3xl:shrink-0',
+          selectedPosting ? '@2xl:flex hidden' : 'flex',
+          '@2xl:w-[34%] @2xl:min-w-[280px] @2xl:max-w-[480px] @2xl:shrink-0',
         ].join(' ')}
       >
         {/* List scroll container — virtualizer targets this.
@@ -189,12 +192,12 @@ export function JobsSplitView({
       <section
         className={[
           'flex-col overflow-hidden min-w-0 flex-1',
-          selectedPosting ? 'flex' : '@3xl:flex hidden',
+          selectedPosting ? 'flex' : '@2xl:flex hidden',
         ].join(' ')}
       >
         {/* Controls bar — Back button for the single-column layout only */}
         {selectedPosting && (
-          <div className="@3xl:hidden flex shrink-0 items-center gap-2 border-b border-[var(--border-clear)] py-2 pl-5 pr-0">
+          <div className="@2xl:hidden flex shrink-0 items-center gap-2 border-b border-[var(--border-clear)] py-2 pl-5 pr-0">
             <Button variant="ghost" onClick={handleBack} aria-label={t('jobs.backToList')}>
               <ChevronLeft size={13} /> {t('jobs.backToList')}
             </Button>

--- a/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/index.tsx
@@ -110,14 +110,17 @@ export function JobsSplitView({
   );
 
   return (
-    // flex-col on mobile, flex-row on md+. min-h-0 required for nested overflow.
-    // w-full + min-w-0: this element is the lone flex child of the results card,
-    // so without them its main size resolves to max-content and the two panes
-    // overflow (clipped by the card's overflow-hidden) instead of sharing the
-    // available width.
-    <div className="flex h-full w-full min-h-0 min-w-0 flex-col md:flex-row">
+    // Single column until the CARD (not the viewport) is wide enough for two
+    // panes, then a row — `@3xl` = 48rem, roughly the point where a 280px list
+    // still leaves the detail pane a usable ~450px. The parent results card
+    // carries `@container`; a viewport `md:` here fired even when the expanded
+    // sidebar left the card ~390px wide (docs/PATTERNS.md §15).
+    // w-full + min-w-0: this element is the lone flex child of that card, so
+    // without them its main size resolves to max-content and the panes overflow
+    // (clipped by the card's overflow-hidden) instead of sharing the width.
+    <div className="@3xl:flex-row flex h-full w-full min-h-0 min-w-0 flex-col">
       {/* ── Left: list pane ── */}
-      {/* Narrow: hidden when a job is selected. Wide: always visible.
+      {/* Single-column: hidden when a job is selected. Two-pane: always visible.
           Width is proportional-with-bounds (the utility equivalent of
           `clamp(280px, 34%, 480px)`) rather than a fixed 420/480/520px ladder:
           at the 900px window floor a fixed 420px left over ~248px for the detail
@@ -126,8 +129,8 @@ export function JobsSplitView({
       <aside
         className={[
           'flex flex-col overflow-hidden border-r border-[var(--border-clear)]',
-          selectedPosting ? 'hidden md:flex' : 'flex',
-          'md:w-[34%] md:min-w-[280px] md:max-w-[480px] md:shrink-0',
+          selectedPosting ? '@3xl:flex hidden' : 'flex',
+          '@3xl:w-[34%] @3xl:min-w-[280px] @3xl:max-w-[480px] @3xl:shrink-0',
         ].join(' ')}
       >
         {/* List scroll container — virtualizer targets this.
@@ -182,16 +185,16 @@ export function JobsSplitView({
       </aside>
 
       {/* ── Right: detail pane ── */}
-      {/* Narrow: shown only when a job is selected. Wide: always visible. */}
+      {/* Single-column: shown only when a job is selected. Two-pane: always. */}
       <section
         className={[
           'flex-col overflow-hidden min-w-0 flex-1',
-          selectedPosting ? 'flex' : 'hidden md:flex',
+          selectedPosting ? 'flex' : '@3xl:flex hidden',
         ].join(' ')}
       >
-        {/* Controls bar — mobile Back button only; desktop never shows it */}
+        {/* Controls bar — Back button for the single-column layout only */}
         {selectedPosting && (
-          <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-clear)] py-2 pl-5 pr-0 md:hidden">
+          <div className="@3xl:hidden flex shrink-0 items-center gap-2 border-b border-[var(--border-clear)] py-2 pl-5 pr-0">
             <Button variant="ghost" onClick={handleBack} aria-label={t('jobs.backToList')}>
               <ChevronLeft size={13} /> {t('jobs.backToList')}
             </Button>

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/ScrapeForm.test.tsx
@@ -280,8 +280,71 @@ describe('ScrapeForm — hidden when show=false', () => {
         onGeocode={async () => []}
       />
     );
-    // AnimatePresence renders nothing when show=false
     expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drawer-panel layout: the form is hosted in a full-height right slide-over, so
+// it owns pinned chrome around ONE scrolling region. Before this, the whole form
+// sat in a single scrolling body and at the 900×600 floor its content overflowed
+// (scrollHeight 625 > 598) with Start below the fold. jsdom has no layout
+// engine, so the contract is asserted on the classes that produce it.
+// ---------------------------------------------------------------------------
+
+describe('ScrapeForm — pinned drawer-panel chrome', () => {
+  function renderPanel() {
+    stubCatalog = LISTED_CATALOG;
+    stubLoading = false;
+    return render(
+      <ScrapeForm
+        show
+        form={DEFAULT_FORM}
+        scraping={false}
+        scrapeOutcome={null}
+        onToggle={NOOP}
+        onFormChange={NOOP}
+        onStart={NOOP}
+        onCancel={NOOP}
+        onGeocode={async () => []}
+      />
+    );
+  }
+
+  it('is a full-height column: pinned header, one scrolling body, pinned footer', () => {
+    renderPanel();
+
+    const root = screen.getByTestId(TEST_IDS.jobs.scrapeForm);
+    expect(root.className).toContain('h-full');
+    expect(root.className).toContain('flex-col');
+    expect(root.className).toContain('min-h-0');
+
+    const body = screen.getByTestId(TEST_IDS.jobs.scrapeFormScroll);
+    expect(body.className).toContain('overflow-y-auto');
+    expect(body.className).toContain('min-h-0');
+    expect(body.className).toContain('flex-1');
+
+    // Exactly three regions; header and footer must NOT be inside the scroller.
+    const regions = Array.from(root.children);
+    expect(regions).toHaveLength(3);
+    expect(regions[0]?.className).toContain('shrink-0');
+    expect(regions[2]?.className).toContain('shrink-0');
+  });
+
+  it('keeps Start in the pinned footer, outside the scrolling body', () => {
+    renderPanel();
+
+    const start = screen.getByTestId(TEST_IDS.jobs.scrapeStartButton);
+    const body = screen.getByTestId(TEST_IDS.jobs.scrapeFormScroll);
+    expect(body.contains(start)).toBe(false);
+  });
+
+  it('renders no nested card surface — the drawer is the surface', () => {
+    const { container } = renderPanel();
+    // A GlassCard inside the panel doubled the inset (36px) and the entrance
+    // fade (drawer slide + card fade on the same frame). `surface-card` is the
+    // default GlassCard tone class, `glass-card` the opt-in frosted one.
+    expect(container.querySelector('.surface-card, .glass-card')).toBeNull();
   });
 });
 

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/index.tsx
@@ -1,20 +1,11 @@
 import { Info, Loader2, Search, X } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useRef } from 'react';
 import { flushSync } from 'react-dom';
 
 import { AGGREGATOR_BOARD_ID, type BoardCatalogEntry, PROVIDER_SLOTS } from '@ajh/shared';
 import { TEST_IDS } from '@ajh/test-ids';
 import { useTranslation } from '@ajh/translations';
-import {
-  Button,
-  CardSkeleton,
-  cn,
-  type CompanyTypeaheadHandle,
-  GlassCard,
-  Input,
-  transition,
-} from '@ajh/ui';
+import { Button, CardSkeleton, cn, type CompanyTypeaheadHandle, Input } from '@ajh/ui';
 
 import { LocationFilterNote } from '@/components/scrape/LocationFilterNote';
 import { SeededCompaniesNote } from '@/components/scrape/SeededCompaniesNote';
@@ -29,6 +20,8 @@ import type { ScrapeFormState } from './constants';
 import { ScrapeFilters } from './ScrapeFilters';
 
 interface ScrapeFormProps {
+  /** Mount gate. The drawer that hosts the form already unmounts it on close;
+   *  this stays so the form can be rendered conditionally anywhere else. */
   show: boolean;
   form: ScrapeFormState;
   scraping: boolean;
@@ -164,280 +157,275 @@ export function ScrapeForm({
       ? (catalogRaw?.find((e) => e.id === form.boards[0])?.displayName ?? form.boards[0])
       : countLabel;
 
+  if (!show) return null;
+
   return (
-    <AnimatePresence>
-      {show && (
-        <motion.div
-          initial={{ opacity: 0, y: -8 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -8 }}
-          transition={transition.normal}
-          className="mb-4"
+    // Pinned-chrome panel: header and footer are `shrink-0`, only the middle
+    // scrolls. The drawer that hosts this is a full-height flex column, so the
+    // Start button can never be pushed below the fold — which it was when the
+    // whole form lived inside one scrolling body at the 900×600 floor.
+    // No GlassCard and no entrance animation here: the drawer IS the surface and
+    // owns the transition (a card-in-a-panel doubled both the inset and the fade).
+    <div data-testid={TEST_IDS.jobs.scrapeForm} className="flex h-full min-h-0 flex-col">
+      {/* Header — pinned */}
+      <div className="flex shrink-0 items-center justify-between border-b border-[var(--border-clear)] px-5 py-3">
+        <div className="flex items-center gap-2">
+          <div className="flex h-5 w-5 items-center justify-center rounded-md bg-brand/15">
+            <Search size={11} className="text-brand-soft" />
+          </div>
+          <h2 className="text-body-strong text-foreground/90">{t('jobs.newScrape')}</h2>
+        </div>
+        <Button
+          variant="ghost"
+          aria-label={t('common.close')}
+          onClick={onToggle}
+          className="rounded-md p-1 text-foreground/50 hover:bg-muted hover:text-foreground/80 h-auto"
         >
-          <GlassCard className="p-5">
-            {/* Header */}
-            <div className="mb-4 flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <div className="flex h-5 w-5 items-center justify-center rounded-md bg-brand/15">
-                  <Search size={11} className="text-brand-soft" />
-                </div>
-                <span className="text-xs font-medium text-foreground/70">
-                  {t('jobs.newScrape')}
-                </span>
-              </div>
-              <Button
-                variant="ghost"
-                aria-label={t('common.close')}
-                onClick={onToggle}
-                className="rounded-md p-1 text-foreground/40 hover:bg-muted hover:text-foreground/70 h-auto"
-              >
-                <X size={13} />
-              </Button>
-            </div>
+          <X size={13} />
+        </Button>
+      </div>
 
-            {/* Query — hero input */}
-            <div className="mb-4">
-              <Input
-                id="jobs-scrape-query"
-                name="jobs-scrape-query"
-                type="text"
-                value={form.query}
-                onChange={(e) => onFormChange({ query: e.target.value })}
-                onKeyDown={(e) => {
-                  if (
-                    e.key === 'Enter' &&
-                    !scraping &&
-                    !blockedByRequiredLogin &&
-                    form.query.trim()
-                  ) {
-                    e.preventDefault();
-                    handleStart();
-                  }
-                }}
-                placeholder={t('jobs.queryPlaceholder')}
-                disabled={scraping}
-                allowClear
-                className="w-full bg-field shadow-none text-sm text-foreground placeholder:text-foreground/25 disabled:opacity-50"
-              />
-            </div>
+      {/* Body — the only scrolling region */}
+      <div
+        data-testid={TEST_IDS.jobs.scrapeFormScroll}
+        className="min-h-0 flex-1 overflow-y-auto px-5 py-4"
+      >
+        {/* Query — hero input */}
+        <div className="mb-4">
+          <Input
+            id="jobs-scrape-query"
+            name="jobs-scrape-query"
+            type="text"
+            value={form.query}
+            onChange={(e) => onFormChange({ query: e.target.value })}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !scraping && !blockedByRequiredLogin && form.query.trim()) {
+                e.preventDefault();
+                handleStart();
+              }
+            }}
+            placeholder={t('jobs.queryPlaceholder')}
+            disabled={scraping}
+            allowClear
+            className="w-full bg-field shadow-none text-sm text-foreground placeholder:text-foreground/25 disabled:opacity-50"
+          />
+        </div>
 
-            {/* Board picker — multi-select toggle group */}
-            <div className="mb-4">
-              <div className="mb-2 flex items-center gap-2">
-                <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/55">
-                  {t('jobs.board')}
-                </span>
-                {!catalogLoading && listedBoards.length > 0 && (
-                  <>
-                    <span
-                      aria-live="polite"
-                      aria-atomic="true"
-                      className="rounded-full bg-brand/20 px-1.5 py-px text-[10px] font-medium text-brand-soft"
-                    >
-                      {countLabel}
-                    </span>
-                    <div className="ml-auto flex items-center gap-1">
-                      <Button
-                        variant="ghost"
-                        disabled={scraping || allSelected}
-                        onClick={handleSelectAll}
-                        className="h-auto rounded px-1.5 py-1 text-[10px] text-foreground/50 hover:text-foreground/80 disabled:opacity-40"
-                      >
-                        {t('jobs.selectAll')}
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        disabled={scraping || form.boards.length <= 1}
-                        onClick={handleClear}
-                        className="h-auto rounded px-1.5 py-1 text-[10px] text-foreground/50 hover:text-foreground/80 disabled:opacity-40"
-                      >
-                        {t('jobs.clearBoards')}
-                      </Button>
-                    </div>
-                  </>
-                )}
-              </div>
-              {catalogLoading ? (
-                <CardSkeleton className="h-8 w-full" />
-              ) : (
-                <div
-                  role="group"
-                  aria-label={t('jobs.board')}
-                  className="flex flex-wrap gap-1.5"
-                  onKeyDown={
-                    scraping
-                      ? undefined
-                      : makeMultiSelectKeyHandler(
-                          listedBoards.length,
-                          focusedBoardIdx,
-                          boardRefs,
-                          (idx) => {
-                            const id = listedBoards[idx]?.id;
-                            if (!id) return;
-                            // Prevent deselecting the last board.
-                            if (selectedSet.has(id) && form.boards.length === 1) return;
-                            onFormChange({ boards: toggleBoard(form.boards, id) });
-                          }
-                        )
-                  }
+        {/* Board picker — multi-select toggle group */}
+        <div className="mb-4">
+          <div className="mb-2 flex items-center gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/55">
+              {t('jobs.board')}
+            </span>
+            {!catalogLoading && listedBoards.length > 0 && (
+              <>
+                <span
+                  aria-live="polite"
+                  aria-atomic="true"
+                  className="rounded-full bg-brand/20 px-1.5 py-px text-[10px] font-medium text-brand-soft"
                 >
-                  {listedBoards.map(({ id }, i) => {
-                    const active = selectedSet.has(id);
-                    return (
-                      <Button
-                        key={id}
-                        ref={(el) => {
-                          boardRefs.current[i] = el;
-                        }}
-                        aria-pressed={active}
-                        tabIndex={i === focusedBoardIdx.current ? 0 : -1}
-                        variant="ghost"
-                        disabled={scraping}
-                        onClick={() => {
-                          // Prevent deselecting the last board.
-                          if (active && form.boards.length === 1) return;
-                          focusedBoardIdx.current = i;
-                          onFormChange({ boards: toggleBoard(form.boards, id) });
-                        }}
-                        className={cn(
-                          'rounded-lg px-2.5 py-1 text-[11px] transition-all',
-                          active
-                            ? 'bg-brand/20 text-brand-soft ring-1 ring-brand/40'
-                            : 'bg-card border border-[var(--border-clear)] text-foreground/50 hover:bg-muted hover:text-foreground/80',
-                          'disabled:cursor-not-allowed disabled:opacity-40'
-                        )}
-                      >
-                        {t(`jobs.boards.${id}`)}
-                      </Button>
-                    );
-                  })}
+                  {countLabel}
+                </span>
+                <div className="ml-auto flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    disabled={scraping || allSelected}
+                    onClick={handleSelectAll}
+                    className="h-auto rounded px-1.5 py-1 text-[10px] text-foreground/50 hover:text-foreground/80 disabled:opacity-40"
+                  >
+                    {t('jobs.selectAll')}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    disabled={scraping || form.boards.length <= 1}
+                    onClick={handleClear}
+                    className="h-auto rounded px-1.5 py-1 text-[10px] text-foreground/50 hover:text-foreground/80 disabled:opacity-40"
+                  >
+                    {t('jobs.clearBoards')}
+                  </Button>
                 </div>
-              )}
+              </>
+            )}
+          </div>
+          {catalogLoading ? (
+            <CardSkeleton className="h-8 w-full" />
+          ) : (
+            <div
+              role="group"
+              aria-label={t('jobs.board')}
+              className="flex flex-wrap gap-1.5"
+              onKeyDown={
+                scraping
+                  ? undefined
+                  : makeMultiSelectKeyHandler(
+                      listedBoards.length,
+                      focusedBoardIdx,
+                      boardRefs,
+                      (idx) => {
+                        const id = listedBoards[idx]?.id;
+                        if (!id) return;
+                        // Prevent deselecting the last board.
+                        if (selectedSet.has(id) && form.boards.length === 1) return;
+                        onFormChange({ boards: toggleBoard(form.boards, id) });
+                      }
+                    )
+              }
+            >
+              {listedBoards.map(({ id }, i) => {
+                const active = selectedSet.has(id);
+                return (
+                  <Button
+                    key={id}
+                    ref={(el) => {
+                      boardRefs.current[i] = el;
+                    }}
+                    aria-pressed={active}
+                    tabIndex={i === focusedBoardIdx.current ? 0 : -1}
+                    variant="ghost"
+                    disabled={scraping}
+                    onClick={() => {
+                      // Prevent deselecting the last board.
+                      if (active && form.boards.length === 1) return;
+                      focusedBoardIdx.current = i;
+                      onFormChange({ boards: toggleBoard(form.boards, id) });
+                    }}
+                    className={cn(
+                      'rounded-lg px-2.5 py-1 text-[11px] transition-all',
+                      active
+                        ? 'bg-brand/20 text-brand-soft ring-1 ring-brand/40'
+                        : 'bg-card border border-[var(--border-clear)] text-foreground/50 hover:bg-muted hover:text-foreground/80',
+                      'disabled:cursor-not-allowed disabled:opacity-40'
+                    )}
+                  >
+                    {t(`jobs.boards.${id}`)}
+                  </Button>
+                );
+              })}
             </div>
+          )}
+        </div>
 
-            {/* Auth affordance — compact "needs login" row per selected board */}
-            {needsLoginBoards.length > 0 && (
-              <div className="mb-3 flex flex-wrap items-center gap-1.5">
-                <span className="text-[10px] text-foreground/55">{t('jobs.needsLogin.label')}</span>
-                {needsLoginBoards.map((e) => (
-                  <BoardConnectChip key={e.id} board={e.id} required={e.auth === 'required'} />
-                ))}
-              </div>
-            )}
+        {/* Auth affordance — compact "needs login" row per selected board */}
+        {needsLoginBoards.length > 0 && (
+          <div className="mb-3 flex flex-wrap items-center gap-1.5">
+            <span className="text-[10px] text-foreground/55">{t('jobs.needsLogin.label')}</span>
+            {needsLoginBoards.map((e) => (
+              <BoardConnectChip key={e.id} board={e.id} required={e.auth === 'required'} />
+            ))}
+          </div>
+        )}
 
-            {/* Honest location hint — names selected boards that don't filter by
+        {/* Honest location hint — names selected boards that don't filter by
                 location server-side (results are matched on-device instead). */}
-            <LocationFilterNote boards={selectedListedBoards} hasLocation={hasLocation} />
+        <LocationFilterNote boards={selectedListedBoards} hasLocation={hasLocation} />
 
-            {/* Seeded-companies disclosure — names the curated companies a
+        {/* Seeded-companies disclosure — names the curated companies a
                 company-scoped ATS board (Greenhouse/Lever/Ashby/…) will query (#621) */}
-            <SeededCompaniesNote boards={selectedListedBoards} />
+        <SeededCompaniesNote boards={selectedListedBoards} />
 
-            {/* Aggregator key hint — shown when aggregator selected but Adzuna keys absent */}
-            {showAggregatorKeyHint && (
-              <p
-                role="status"
-                data-testid={TEST_IDS.jobs.aggregatorKeyHint}
-                className="mb-3 flex items-center gap-1.5 text-[11px] text-amber-400/70"
-              >
-                <Info size={11} aria-hidden="true" />
-                {t('jobs.aggregatorKeyHint')}
-              </p>
-            )}
+        {/* Aggregator key hint — shown when aggregator selected but Adzuna keys absent */}
+        {showAggregatorKeyHint && (
+          <p
+            role="status"
+            data-testid={TEST_IDS.jobs.aggregatorKeyHint}
+            className="mb-3 flex items-center gap-1.5 text-[11px] text-amber-400/70"
+          >
+            <Info size={11} aria-hidden="true" />
+            {t('jobs.aggregatorKeyHint')}
+          </p>
+        )}
 
-            {/* Companies typeahead — only shown when an ATS board (requiresCompany)
+        {/* Companies typeahead — only shown when an ATS board (requiresCompany)
                 is selected. Slugs are added as chips feeding form.companies; the
                 suggestions merge passively-harvested slugs (ADR-030) with the
                 selected boards' curated seeds. */}
-            {showCompanyInput && (
-              <div className="mb-4">
-                <label
-                  htmlFor="scrape-companies"
-                  className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/55"
-                >
-                  {t('jobs.companies.label')}
-                </label>
-                <CompanySlugField
-                  ref={companyFieldRef}
-                  companies={form.companies}
-                  onChange={(companies) => onFormChange({ companies })}
-                  seededBoards={selectedListedBoards}
-                  disabled={scraping}
-                />
-              </div>
-            )}
-
-            <ScrapeFilters
-              form={form}
-              scraping={scraping}
-              boardConnected={anyAuthBenefitConnected}
-              onFormChange={onFormChange}
-              onGeocode={onGeocode}
+        {showCompanyInput && (
+          <div className="mb-4">
+            <label
+              htmlFor="scrape-companies"
+              className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/55"
+            >
+              {t('jobs.companies.label')}
+            </label>
+            <CompanySlugField
+              ref={companyFieldRef}
+              companies={form.companies}
+              onChange={(companies) => onFormChange({ companies })}
+              seededBoards={selectedListedBoards}
+              disabled={scraping}
             />
+          </div>
+        )}
 
-            {/* Scraping status — an honest indeterminate signal only (the earlier
-                fake 85% progress bar fabricated progress and was removed). The real
-                per-board progress is the streamed-results count shown in JobsResults. */}
-            {scraping && (
-              <div className="mb-4 flex items-center gap-1.5 text-[11px] text-foreground/40">
-                <Loader2 size={10} className="animate-spin" />
-                {t('jobs.scraping')} {scrapingLabel}…
-              </div>
-            )}
+        <ScrapeFilters
+          form={form}
+          scraping={scraping}
+          boardConnected={anyAuthBenefitConnected}
+          onFormChange={onFormChange}
+          onGeocode={onGeocode}
+        />
 
-            {/* Footer */}
-            {!scraping && blockedByRequiredLogin && (
-              <p
-                id="scrape-blocked-hint"
-                aria-live="polite"
-                className="mb-2 text-[11px] text-amber-400/70"
+        {/* Scraping status — an honest indeterminate signal only (the earlier
+            fake 85% progress bar fabricated progress and was removed). The real
+            per-board progress is the streamed-results count shown in JobsResults. */}
+        {scraping && (
+          <div className="flex items-center gap-1.5 text-[11px] text-foreground/60">
+            <Loader2 size={10} className="animate-spin" />
+            {t('jobs.scraping')} {scrapingLabel}…
+          </div>
+        )}
+      </div>
+
+      {/* Footer — pinned; Start is always reachable without scrolling */}
+      <div className="shrink-0 border-t border-[var(--border-clear)] px-5 py-3">
+        {!scraping && blockedByRequiredLogin && (
+          <p
+            id="scrape-blocked-hint"
+            aria-live="polite"
+            className="mb-2 text-[11px] text-amber-400/70"
+          >
+            {t('jobs.needsLogin.blockedHint', {
+              boards: unconnectedRequired.map((id) => t(`jobs.boards.${id}`)).join(', '),
+            })}
+          </p>
+        )}
+        <div className="flex items-center justify-end gap-2">
+          {scraping ? (
+            <Button variant="ghost" onClick={onCancel}>
+              {t('jobs.cancel')}
+            </Button>
+          ) : (
+            scrapeOutcome && (
+              <span
+                className={cn(
+                  'min-w-0 flex-1 truncate text-[11px]',
+                  scrapeOutcome.ok && !scrapeOutcome.note
+                    ? 'text-emerald-400/70'
+                    : 'text-amber-400/70'
+                )}
               >
-                {t('jobs.needsLogin.blockedHint', {
-                  boards: unconnectedRequired.map((id) => t(`jobs.boards.${id}`)).join(', '),
-                })}
-              </p>
-            )}
-            <div className="flex items-center justify-end gap-2">
-              {scraping ? (
-                <Button variant="ghost" onClick={onCancel}>
-                  {t('jobs.cancel')}
-                </Button>
-              ) : (
-                scrapeOutcome && (
-                  <span
-                    className={cn(
-                      'text-[11px]',
-                      scrapeOutcome.ok && !scrapeOutcome.note
-                        ? 'text-emerald-400/70'
-                        : scrapeOutcome.ok && scrapeOutcome.note
-                          ? 'text-amber-400/70'
-                          : 'text-amber-400/70'
-                    )}
-                  >
-                    {scrapeOutcome.ok
-                      ? (scrapeOutcome.note ?? t('jobs.done'))
-                      : (scrapeOutcome.note ?? t('jobs.failed'))}
-                  </span>
-                )
-              )}
-              <Button
-                variant="primary"
-                onClick={handleStart}
-                disabled={scraping || !form.query.trim() || blockedByRequiredLogin}
-                loading={scraping}
-                aria-describedby={
-                  !scraping && blockedByRequiredLogin ? 'scrape-blocked-hint' : undefined
-                }
-                data-testid={TEST_IDS.jobs.scrapeStartButton}
-                className="transition-all duration-150 ease-out"
-              >
-                {!scraping && <Search size={12} />}
-                {scraping ? t('jobs.scraping') : t('jobs.startScrape')}
-              </Button>
-            </div>
-          </GlassCard>
-        </motion.div>
-      )}
-    </AnimatePresence>
+                {scrapeOutcome.ok
+                  ? (scrapeOutcome.note ?? t('jobs.done'))
+                  : (scrapeOutcome.note ?? t('jobs.failed'))}
+              </span>
+            )
+          )}
+          <Button
+            variant="primary"
+            onClick={handleStart}
+            disabled={scraping || !form.query.trim() || blockedByRequiredLogin}
+            loading={scraping}
+            aria-describedby={
+              !scraping && blockedByRequiredLogin ? 'scrape-blocked-hint' : undefined
+            }
+            data-testid={TEST_IDS.jobs.scrapeStartButton}
+            className="shrink-0 transition-all duration-150 ease-out"
+          >
+            {!scraping && <Search size={12} />}
+            {scraping ? t('jobs.scraping') : t('jobs.startScrape')}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/packages/test-ids/src/test-ids.ts
+++ b/packages/test-ids/src/test-ids.ts
@@ -22,8 +22,15 @@ export const TEST_IDS = {
   /** Jobs feature — scraping, results, form */
   jobs: {
     scrapeForm: 'scrape-form',
-    /** Bounded, scrollable wrapper around the page header + scrape form. */
+    /** Scrollable body of the scrape drawer — owns the form's overflow so tall
+     *  form content can never push the Start button out of reach. */
     scrapeFormScroll: 'scrape-form-scroll',
+    /** Compact command bar above the results (title + filters + view + actions). */
+    commandBar: 'jobs-command-bar',
+    /** Second command-bar row: the active-filter chips (only when non-empty). */
+    filterChips: 'jobs-filter-chips',
+    /** Live scrape strip in the command bar — progress label + cancel. */
+    scrapeStatusStrip: 'jobs-scrape-status',
     /** stub-only: no matching attribute on the real component */
     scrapeFilters: 'scrape-filters',
     aggregatorKeyHint: 'aggregator-key-hint',

--- a/packages/test-ids/src/test-ids.ts
+++ b/packages/test-ids/src/test-ids.ts
@@ -31,6 +31,8 @@ export const TEST_IDS = {
     filterChips: 'jobs-filter-chips',
     /** Live scrape strip in the command bar — progress label + cancel. */
     scrapeStatusStrip: 'jobs-scrape-status',
+    /** Always-mounted sr-only live region the command bar writes status into. */
+    scrapeStatusLive: 'jobs-scrape-status-live',
     /** stub-only: no matching attribute on the real component */
     scrapeFilters: 'scrape-filters',
     aggregatorKeyHint: 'aggregator-key-hint',

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1744,9 +1744,7 @@
     }
   },
   "jobs": {
-    "eyebrow": "Live-Anzeigen",
     "title": "Jobbörse",
-    "subtitle": "Gescrapte Job-Anzeigen von Ihren konfigurierten Boards. Filtern, öffnen und Bewerbung anpassen.",
     "searchPlaceholder": "Nach Titel, Unternehmen, Ort filtern…",
     "empty": "Noch keine Anzeigen. Starten Sie einen Scrape, um dieses Board zu füllen.",
     "emptyCta": "Jobs suchen",
@@ -1972,7 +1970,15 @@
     "selectAJob": "Job auswählen, um Details anzuzeigen",
     "agencyChip": "Personalvermittler",
     "filters": {
-      "hideAgency": "Vermittleranzeigen ausblenden"
+      "hideAgency": "Vermittleranzeigen ausblenden",
+      "activeLabel": "Aktive Filter",
+      "searchChip": "Suche: {{query}}",
+      "remove": "Filter entfernen: {{name}}",
+      "clearAll": "Filter zurücksetzen"
+    },
+    "commandBar": {
+      "label": "Jobbörsen-Steuerung",
+      "shownCount": "{{shown}} von {{total}} Jobs angezeigt"
     },
     "cluster": {
       "alsoOn": "Auch auf",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1984,7 +1984,9 @@
     },
     "commandBar": {
       "label": "Jobbörsen-Steuerung",
-      "shownCount": "{{shown}} von {{total}} Jobs angezeigt"
+      "shownCount": "{{shown}} von {{total}} Jobs angezeigt",
+      "statusRow": "Status des letzten Scrapings",
+      "filterLabel": "Jobs filtern"
     },
     "cluster": {
       "alsoOn": "Auch auf",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1834,7 +1834,7 @@
     "scrapeFailed": "Scraping fehlgeschlagen",
     "searching": "Suche nach Jobs…",
     "scanning": "Boards werden durchsucht…",
-    "scanningPercent": "Wird durchsucht: {{percent}} %",
+    "scanningPercent": "Wird durchsucht: {{percent}} %",
     "cancel": "Abbrechen",
     "clear": "Löschen",
     "clearScrapedJobs": "Gescrapte Jobs löschen",
@@ -1973,8 +1973,7 @@
       "hideAgency": "Vermittleranzeigen ausblenden",
       "activeLabel": "Aktive Filter",
       "searchChip": "Suche: {{query}}",
-      "remove": "Filter entfernen: {{name}}",
-      "clearAll": "Filter zurücksetzen"
+      "remove": "Filter entfernen: {{name}}"
     },
     "commandBar": {
       "label": "Jobbörsen-Steuerung",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1826,7 +1826,7 @@
         }
       }
     },
-    "scrapeJobs": "Scrape Jobs",
+    "scrapeJobs": "Scrape jobs",
     "scrapeFailed": "Scraping failed",
     "searching": "Searching for jobs…",
     "scanning": "Scanning boards…",
@@ -1969,8 +1969,7 @@
       "hideAgency": "Hide agency posts",
       "activeLabel": "Active filters",
       "searchChip": "Search: {{query}}",
-      "remove": "Remove filter: {{name}}",
-      "clearAll": "Clear filters"
+      "remove": "Remove filter: {{name}}"
     },
     "commandBar": {
       "label": "Job board controls",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1980,7 +1980,9 @@
     },
     "commandBar": {
       "label": "Job board controls",
-      "shownCount": "{{shown}} of {{total}} jobs shown"
+      "shownCount": "{{shown}} of {{total}} jobs shown",
+      "statusRow": "Last scrape status",
+      "filterLabel": "Filter jobs"
     },
     "cluster": {
       "alsoOn": "Also on",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1740,9 +1740,7 @@
     }
   },
   "jobs": {
-    "eyebrow": "Live postings",
     "title": "Job board",
-    "subtitle": "Scraped job postings from your configured boards. Filter, open a posting, and tailor your application.",
     "searchPlaceholder": "Filter by title, company, location…",
     "empty": "No postings yet. Start a scrape to populate this board.",
     "emptyCta": "Search jobs",
@@ -1968,7 +1966,15 @@
     "selectAJob": "Select a job to see details",
     "agencyChip": "Agency",
     "filters": {
-      "hideAgency": "Hide agency posts"
+      "hideAgency": "Hide agency posts",
+      "activeLabel": "Active filters",
+      "searchChip": "Search: {{query}}",
+      "remove": "Remove filter: {{name}}",
+      "clearAll": "Clear filters"
+    },
+    "commandBar": {
+      "label": "Job board controls",
+      "shownCount": "{{shown}} of {{total}} jobs shown"
     },
     "cluster": {
       "alsoOn": "Also on",

--- a/packages/ui/src/components/CompanyTypeahead/CompanyTypeahead.tsx
+++ b/packages/ui/src/components/CompanyTypeahead/CompanyTypeahead.tsx
@@ -178,6 +178,11 @@ export function CompanyTypeahead({
       if (active) commit(active.slug);
       else if (query.trim()) commit(query);
     } else if (e.key === 'Escape') {
+      // Innermost-layer-wins: only an OPEN suggestion panel consumes Escape, so
+      // it can't also reach an ancestor dialog/drawer (listening on `window`)
+      // and close the whole surface. With the panel already closed, Escape
+      // falls through to that ancestor, as it should.
+      if (open) e.stopPropagation();
       setOpen(false);
       setActiveIndex(-1);
     } else if (e.key === 'Backspace' && query === '' && selected.length > 0) {

--- a/packages/ui/src/components/Drawer/Drawer.test.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.test.tsx
@@ -1,10 +1,11 @@
 import { useRef, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { variants } from '../../lib/motion';
 import { Dropdown } from '../Dropdown';
+import { LocationInput } from '../LocationInput';
 import { Drawer, drawerTransition, drawerVariants } from './Drawer';
 
 /** The scrim GlassOverlay renders — the only `aria-hidden` fixed sibling. */
@@ -320,6 +321,33 @@ describe('Drawer', () => {
     expect(onClose).not.toHaveBeenCalled();
 
     // Second Escape, popover now closed: falls through to the drawer.
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the same Escape layering to a LocationInput inside the drawer', async () => {
+    // LocationInput reaches the drawer through ScrapeFilters, so without the
+    // guard, dismissing location suggestions tore the whole drawer down with
+    // them — the drawer INTRODUCED that regression for a pre-existing input.
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} ariaLabel="Filters">
+        <LocationInput id="loc" value="" onChange={() => {}} placeholder="Any location" />
+      </Drawer>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Any location/ }));
+
+    // The panel focuses its search input on a timer; wait for it so Escape is
+    // dispatched at the input that owns the handler.
+    const search = await screen.findByPlaceholderText('Search city or postcode…');
+    await waitFor(() => expect(search).toHaveFocus());
+
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByPlaceholderText('Search city or postcode…')).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Panel closed: Escape now belongs to the drawer.
     await userEvent.keyboard('{Escape}');
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/ui/src/components/Drawer/Drawer.test.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.test.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { Drawer } from './Drawer';
+import { variants } from '../../lib/motion';
+import { Dropdown } from '../Dropdown';
+import { Drawer, drawerTransition, drawerVariants } from './Drawer';
 
 /** The scrim GlassOverlay renders — the only `aria-hidden` fixed sibling. */
 function backdrop(): HTMLElement {
@@ -176,5 +178,170 @@ describe('Drawer', () => {
       </Drawer>
     );
     expect(screen.getByRole('dialog', { name: 'New scrape' })).toBeInTheDocument();
+  });
+
+  it('frosts the app shell while open and clears it on close (WebView2 workaround)', () => {
+    const { rerender } = render(
+      <Drawer open={false} onClose={() => {}} ariaLabel="Filters">
+        <p>body</p>
+      </Drawer>
+    );
+    expect(document.body.classList.contains('modal-blur-active')).toBe(false);
+
+    rerender(
+      <Drawer open onClose={() => {}} ariaLabel="Filters">
+        <p>body</p>
+      </Drawer>
+    );
+    // A portaled overlay's own backdrop-filter does not composite reliably under
+    // WebView2 — without this body class the drawer's glass is a flat scrim.
+    expect(document.body.classList.contains('modal-blur-active')).toBe(true);
+
+    rerender(
+      <Drawer open={false} onClose={() => {}} ariaLabel="Filters">
+        <p>body</p>
+      </Drawer>
+    );
+    expect(document.body.classList.contains('modal-blur-active')).toBe(false);
+  });
+
+  it('falls back to returnFocusTo when closing also unmounts the opener', async () => {
+    // Models the first-run path: the empty-state CTA opens the drawer, and the
+    // drawer's own action (start a scrape) replaces that empty state — so the
+    // opener and the drawer disappear in the SAME commit.
+    function Harness() {
+      const [phase, setPhase] = useState<'idle' | 'open' | 'done'>('idle');
+      const fallback = useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button ref={fallback}>always here</button>
+          {phase !== 'done' && <button onClick={() => setPhase('open')}>transient opener</button>}
+          <Drawer
+            open={phase === 'open'}
+            onClose={() => setPhase('done')}
+            ariaLabel="Filters"
+            returnFocusTo={fallback}
+          >
+            <button>inside</button>
+          </Drawer>
+        </>
+      );
+    }
+    render(<Harness />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'transient opener' }));
+    await userEvent.keyboard('{Escape}');
+
+    // Without the fallback focus would land on <body> — a WCAG 2.4.3 failure.
+    expect(screen.queryByRole('button', { name: 'transient opener' })).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'always here' }));
+  });
+
+  it('never parks focus on <body> when the opener is already gone at open time', async () => {
+    // Degenerate case: the trigger unmounts as the drawer opens, so the captured
+    // "opener" is whatever activeElement degraded to — `<body>`.
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      const fallback = useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button ref={fallback}>always here</button>
+          {!open && <button onClick={() => setOpen(true)}>vanishing opener</button>}
+          <Drawer
+            open={open}
+            onClose={() => setOpen(false)}
+            ariaLabel="Filters"
+            returnFocusTo={fallback}
+          >
+            <button>inside</button>
+          </Drawer>
+        </>
+      );
+    }
+    render(<Harness />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'vanishing opener' }));
+    await userEvent.keyboard('{Escape}');
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'always here' }));
+  });
+
+  it('prefers the live opener over returnFocusTo when both exist', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      const fallback = useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button ref={fallback}>fallback</button>
+          <button onClick={() => setOpen(true)}>opener</button>
+          <Drawer
+            open={open}
+            onClose={() => setOpen(false)}
+            ariaLabel="Filters"
+            returnFocusTo={fallback}
+          >
+            <button>inside</button>
+          </Drawer>
+        </>
+      );
+    }
+    render(<Harness />);
+
+    const opener = screen.getByRole('button', { name: 'opener' });
+    await userEvent.click(opener);
+    await userEvent.keyboard('{Escape}');
+
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('lets an open popover inside consume Escape instead of closing the whole drawer', async () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} ariaLabel="Filters">
+        <Dropdown
+          options={[
+            { value: 'newest', label: 'Newest' },
+            { value: 'oldest', label: 'Oldest' },
+          ]}
+          value="newest"
+          onChange={() => {}}
+          aria-label="Sort"
+        />
+      </Drawer>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Sort' });
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // First Escape: innermost layer only.
+    await userEvent.keyboard('{Escape}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Second Escape, popover now closed: falls through to the drawer.
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('drawerVariants / drawerTransition — reduced-motion seam', () => {
+  it('slides horizontally at rest', () => {
+    expect(drawerVariants(false)).toBe(variants.slideOverRight);
+    expect(drawerVariants(false).initial).toMatchObject({ x: '100%' });
+  });
+
+  it('drops the translate ENTIRELY under reduce — opacity only, no positional jump', () => {
+    const reduced = drawerVariants(true);
+    expect(reduced).toBe(variants.overlay);
+    for (const phase of [reduced.initial, reduced.animate, reduced.exit]) {
+      expect(phase).not.toHaveProperty('x');
+    }
+  });
+
+  it('uses a duration proportional to the travel, and zero under reduce', () => {
+    // 180ms across a full panel width reads as a snap rather than a slide.
+    expect(drawerTransition(false)).toMatchObject({ duration: 0.22 });
+    expect(drawerTransition(true)).toMatchObject({ duration: 0 });
   });
 });

--- a/packages/ui/src/components/Drawer/Drawer.test.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.test.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Drawer } from './Drawer';
+
+/** The scrim GlassOverlay renders — the only `aria-hidden` fixed sibling. */
+function backdrop(): HTMLElement {
+  const el = document.body.querySelector('[aria-hidden="true"]');
+  if (!el) throw new Error('backdrop not rendered');
+  return el as HTMLElement;
+}
+
+describe('Drawer', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <Drawer open={false} onClose={() => {}} ariaLabel="Filters">
+        <p>panel body</p>
+      </Drawer>
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.queryByText('panel body')).not.toBeInTheDocument();
+  });
+
+  it('renders a labelled modal dialog into a portal when open', () => {
+    render(
+      <Drawer open onClose={() => {}} ariaLabel="Filters">
+        <p>panel body</p>
+      </Drawer>
+    );
+    const dialog = screen.getByRole('dialog', { name: 'Filters' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog.parentElement).toBe(document.body);
+    expect(screen.getByText('panel body')).toBeInTheDocument();
+  });
+
+  it('closes on Escape', async () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} ariaLabel="Filters">
+        <p>body</p>
+      </Drawer>
+    );
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not listen for Escape while closed', async () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open={false} onClose={onClose} ariaLabel="Filters">
+        <p>body</p>
+      </Drawer>
+    );
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes on a backdrop click', async () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} ariaLabel="Filters">
+        <p>body</p>
+      </Drawer>
+    );
+    await userEvent.click(backdrop());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT close on a backdrop click when closeOnBackdrop={false}', async () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} ariaLabel="Filters" closeOnBackdrop={false}>
+        <p>body</p>
+      </Drawer>
+    );
+    await userEvent.click(backdrop());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close when a control inside the panel is clicked', async () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open onClose={onClose} ariaLabel="Filters">
+        <button>inside</button>
+      </Drawer>
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'inside' }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('moves focus into the panel and traps Tab inside it', async () => {
+    render(
+      <>
+        <button>outside</button>
+        <Drawer open onClose={() => {}} ariaLabel="Filters">
+          <button>first</button>
+          <button>last</button>
+        </Drawer>
+      </>
+    );
+
+    const first = screen.getByRole('button', { name: 'first' });
+    const last = screen.getByRole('button', { name: 'last' });
+    expect(document.activeElement).toBe(first);
+
+    await userEvent.tab();
+    expect(document.activeElement).toBe(last);
+    // Tab off the last focusable wraps back into the panel — never to `outside`.
+    await userEvent.tab();
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('returns focus to the control that opened it when it closes', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>open drawer</button>
+          <Drawer open={open} onClose={() => setOpen(false)} ariaLabel="Filters">
+            <button>inside</button>
+          </Drawer>
+        </>
+      );
+    }
+    render(<Harness />);
+
+    const opener = screen.getByRole('button', { name: 'open drawer' });
+    await userEvent.click(opener);
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'inside' }));
+
+    await userEvent.keyboard('{Escape}');
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('does not throw when the opener is gone by the time it closes', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          {/* The trigger unmounts while the drawer is open. */}
+          {!open && <button onClick={() => setOpen(true)}>open drawer</button>}
+          <Drawer open={open} onClose={() => setOpen(false)} ariaLabel="Filters">
+            <button>inside</button>
+          </Drawer>
+        </>
+      );
+    }
+    render(<Harness />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'open drawer' }));
+    await userEvent.keyboard('{Escape}');
+
+    expect(screen.getByRole('button', { name: 'open drawer' })).toBeInTheDocument();
+  });
+
+  it('pins the panel to the right edge and clamps its width to the window', () => {
+    render(
+      <Drawer open onClose={() => {}} ariaLabel="Filters">
+        <p>body</p>
+      </Drawer>
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toContain('inset-y-0');
+    expect(dialog.className).toContain('right-0');
+    // Never wider than the window minus a gutter — usable at the 900px floor.
+    expect(dialog.className).toContain('w-[30rem]');
+    expect(dialog.className).toContain('max-w-[calc(100vw-5rem)]');
+  });
+
+  it('accepts aria-labelledby instead of aria-label', () => {
+    render(
+      <Drawer open onClose={() => {}} ariaLabelledby="drawer-title">
+        <h2 id="drawer-title">New scrape</h2>
+      </Drawer>
+    );
+    expect(screen.getByRole('dialog', { name: 'New scrape' })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/Drawer/Drawer.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,111 @@
+import { AnimatePresence, motion } from 'motion/react';
+import { type ReactNode, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useFocusTrap } from '../../hooks/use-focus-trap';
+import { cn } from '../../lib/cn';
+import { resolveTransition, transition, variants } from '../../lib/motion';
+import { GlassOverlay } from '../GlassOverlay';
+
+export interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  /** Accessible name when there is no visible title element to reference. */
+  ariaLabel?: string;
+  /** id of the element labelling the dialog (wired to `aria-labelledby`). */
+  ariaLabelledby?: string;
+  /**
+   * Width of the panel. Defaults to a clamped sheet that never exceeds the
+   * window minus a gutter, so it stays usable at the 900×600 window floor.
+   */
+  widthClass?: string;
+  /** Extra classes forwarded to the panel element. */
+  className?: string;
+  /** z-index layer — default 600 (`--z-modal`), matching {@link ModalShell}. */
+  zIndex?: number;
+  /** When false, a backdrop click does NOT close the drawer. Default `true`. */
+  closeOnBackdrop?: boolean;
+}
+
+/**
+ * Right-edge slide-over panel (drawer / sheet) — the lateral sibling of
+ * `ModalShell`: same portal + scrim + focus trap + Escape contract, but the
+ * panel is pinned full-height to the right edge instead of centred.
+ *
+ * Use it for a task surface the user edits and then applies (a filter/search
+ * form), where the content behind should stay legible; use `ModalShell` for a
+ * decision that must be answered before continuing.
+ *
+ * Motion respects `prefers-reduced-motion`: the horizontal travel is dropped
+ * (opacity only) rather than merely shortened, so there is no positional jump.
+ */
+export function Drawer({
+  open,
+  onClose,
+  children,
+  ariaLabel,
+  ariaLabelledby,
+  widthClass = 'w-[30rem] max-w-[calc(100vw-5rem)]',
+  className,
+  zIndex = 600,
+  closeOnBackdrop = true,
+}: DrawerProps) {
+  // Focus return (WCAG 2.4.3 Focus Order). MUST be declared BEFORE useFocusTrap:
+  // effects run in hook-call order, so this one still sees the opener as
+  // `activeElement`; the trap's effect moves focus into the panel right after.
+  const openerRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (!open) return;
+    openerRef.current = document.activeElement as HTMLElement | null;
+    return () => {
+      const opener = openerRef.current;
+      openerRef.current = null;
+      // The opener can be gone by the time the drawer closes (a route change,
+      // a conditionally-rendered trigger) — only refocus something still live.
+      if (opener && document.contains(opener)) opener.focus();
+    };
+  }, [open]);
+
+  const trapRef = useFocusTrap(open);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  const resolved = resolveTransition(transition.normal);
+  const isInstant = resolved.duration === 0;
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <>
+          <GlassOverlay zIndex={zIndex - 1} onClick={closeOnBackdrop ? onClose : undefined} />
+          <motion.div
+            ref={trapRef as React.RefObject<HTMLDivElement>}
+            role="dialog"
+            aria-modal="true"
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
+            className={cn(
+              'glass-modal fixed inset-y-0 right-0 flex flex-col overflow-hidden border-l border-white/[0.12] shadow-xl',
+              widthClass,
+              className
+            )}
+            style={{ zIndex }}
+            {...(isInstant ? variants.overlay : variants.slideOverRight)}
+            transition={resolved}
+          >
+            {children}
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
+}

--- a/packages/ui/src/components/Drawer/Drawer.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.tsx
@@ -4,8 +4,28 @@ import { createPortal } from 'react-dom';
 
 import { useFocusTrap } from '../../hooks/use-focus-trap';
 import { cn } from '../../lib/cn';
-import { resolveTransition, transition, variants } from '../../lib/motion';
+import { setModalBlur } from '../../lib/modal-blur';
+import { prefersReducedMotion, transition, variants } from '../../lib/motion';
 import { GlassOverlay } from '../GlassOverlay';
+
+/**
+ * Entrance/exit variants for the panel, as a pure function of the user's motion
+ * preference — exported so the reduced-motion branch is unit-testable without
+ * driving `matchMedia` through a rendered tree.
+ *
+ * Under `reduce` the horizontal travel is dropped ENTIRELY (opacity only)
+ * rather than merely shortened, so there is no positional jump.
+ */
+export function drawerVariants(reduced: boolean) {
+  return reduced ? variants.overlay : variants.slideOverRight;
+}
+
+/** Panel transition, likewise a pure function of the motion preference. */
+export function drawerTransition(reduced: boolean) {
+  // `relaxed` (220ms), not `normal` (180ms) — the panel travels its full width,
+  // and a short duration over a long distance reads as a snap, not a slide.
+  return reduced ? transition.instant : transition.relaxed;
+}
 
 export interface DrawerProps {
   open: boolean;
@@ -15,6 +35,13 @@ export interface DrawerProps {
   ariaLabel?: string;
   /** id of the element labelling the dialog (wired to `aria-labelledby`). */
   ariaLabelledby?: string;
+  /**
+   * Where focus goes on close when the control that OPENED the drawer no longer
+   * exists — e.g. an empty-state CTA that the drawer's own action replaced.
+   * Point this at a control that is always mounted (typically the persistent
+   * trigger for the same drawer); without it focus would fall to `<body>`.
+   */
+  returnFocusTo?: React.RefObject<HTMLElement | null>;
   /**
    * Width of the panel. Defaults to a clamped sheet that never exceeds the
    * window minus a gutter, so it stays usable at the 900×600 window floor.
@@ -30,15 +57,18 @@ export interface DrawerProps {
 
 /**
  * Right-edge slide-over panel (drawer / sheet) — the lateral sibling of
- * `ModalShell`: same portal + scrim + focus trap + Escape contract, but the
- * panel is pinned full-height to the right edge instead of centred.
+ * `ModalShell`: same portal + scrim + app-shell frosting + focus trap + Escape
+ * contract, but the panel is pinned full-height to the right edge instead of
+ * centred.
  *
  * Use it for a task surface the user edits and then applies (a filter/search
  * form), where the content behind should stay legible; use `ModalShell` for a
  * decision that must be answered before continuing.
  *
- * Motion respects `prefers-reduced-motion`: the horizontal travel is dropped
- * (opacity only) rather than merely shortened, so there is no positional jump.
+ * The panel is a flex column the height of the viewport, so content that needs
+ * pinned chrome renders its own `shrink-0` header/footer around a
+ * `min-h-0 flex-1 overflow-y-auto` body (see `ScrapeForm`) — nothing scrolls
+ * out of reach.
  */
 export function Drawer({
   open,
@@ -46,6 +76,7 @@ export function Drawer({
   children,
   ariaLabel,
   ariaLabelledby,
+  returnFocusTo,
   widthClass = 'w-[30rem] max-w-[calc(100vw-5rem)]',
   className,
   zIndex = 600,
@@ -55,15 +86,26 @@ export function Drawer({
   // effects run in hook-call order, so this one still sees the opener as
   // `activeElement`; the trap's effect moves focus into the panel right after.
   const openerRef = useRef<HTMLElement | null>(null);
+  // Mirrored so the cleanup below reads the CURRENT fallback without making the
+  // effect re-run (and re-capture the opener) whenever the prop identity changes.
+  const fallbackRef = useRef(returnFocusTo);
+  fallbackRef.current = returnFocusTo;
   useEffect(() => {
     if (!open) return;
     openerRef.current = document.activeElement as HTMLElement | null;
     return () => {
       const opener = openerRef.current;
       openerRef.current = null;
-      // The opener can be gone by the time the drawer closes (a route change,
-      // a conditionally-rendered trigger) — only refocus something still live.
-      if (opener && document.contains(opener)) opener.focus();
+      // The opener can be gone by the time the drawer closes — a route change, or
+      // a conditionally-rendered trigger the drawer's own action replaced. Only
+      // refocus something still in the document, else fall back to the caller's
+      // always-mounted trigger; never leave focus on <body>.
+      // `<body>` passes `contains` but is not a focus target — it is what
+      // `activeElement` degrades to when the focused node is removed, so
+      // accepting it would silently swallow the fallback.
+      const live = (el: HTMLElement | null | undefined) =>
+        el && el !== document.body && document.contains(el) ? el : null;
+      (live(opener) ?? live(fallbackRef.current?.current))?.focus();
     };
   }, [open]);
 
@@ -78,8 +120,15 @@ export function Drawer({
     return () => window.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
-  const resolved = resolveTransition(transition.normal);
-  const isInstant = resolved.duration === 0;
+  // Frost the app shell behind the drawer — see `lib/modal-blur` for why the
+  // blur can't live on the portaled overlay itself under WebView2.
+  useEffect(() => {
+    if (!open) return;
+    setModalBlur(true);
+    return () => setModalBlur(false);
+  }, [open]);
+
+  const reduced = prefersReducedMotion();
 
   return createPortal(
     <AnimatePresence>
@@ -98,8 +147,8 @@ export function Drawer({
               className
             )}
             style={{ zIndex }}
-            {...(isInstant ? variants.overlay : variants.slideOverRight)}
-            transition={resolved}
+            {...drawerVariants(reduced)}
+            transition={drawerTransition(reduced)}
           >
             {children}
           </motion.div>

--- a/packages/ui/src/components/Drawer/index.ts
+++ b/packages/ui/src/components/Drawer/index.ts
@@ -1,0 +1,1 @@
+export * from './Drawer';

--- a/packages/ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.tsx
@@ -30,6 +30,12 @@ export interface DropdownProps {
   icon?: ReactNode;
   /** Forwarded to the trigger button so an external `<label htmlFor>` can name the control. */
   id?: string;
+  /**
+   * Accessible name for the trigger when there is no visible label. Without it
+   * the trigger's only name is the SELECTED OPTION ("Newest first"), which says
+   * nothing about what the control does.
+   */
+  'aria-label'?: string;
   /** Override auto-search detection. Defaults to true when options.length >= 8. */
   searchable?: boolean;
   /** Tailwind max-height class applied to the options list. Defaults to 'max-h-56'. */
@@ -62,6 +68,7 @@ export function Dropdown({
   size = 'md',
   tone = 'default',
   className,
+  'aria-label': ariaLabel,
 }: DropdownProps) {
   const generatedId = useId();
   const id = idProp ?? generatedId;
@@ -174,6 +181,7 @@ export function Dropdown({
         disabled={disabled}
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-label={ariaLabel}
         onClick={() => {
           if (!disabled) {
             setOpen((o) => !o);

--- a/packages/ui/src/components/LocationInput/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput/LocationInput.tsx
@@ -104,6 +104,12 @@ export function LocationInput({
         select({ display: query.trim() });
       }
     } else if (e.key === 'Escape') {
+      // Innermost-layer-wins (see `useDropdownKeyboard`): only an OPEN suggestion
+      // panel consumes Escape, so it can't also reach an ancestor dialog/drawer
+      // listening on `window` and close the whole surface. This input now renders
+      // inside the scrape drawer via ScrapeFilters, where dismissing suggestions
+      // used to tear down the drawer with them.
+      if (open) e.stopPropagation();
       setOpen(false);
     }
   };

--- a/packages/ui/src/components/ModalShell/ModalShell.tsx
+++ b/packages/ui/src/components/ModalShell/ModalShell.tsx
@@ -4,28 +4,9 @@ import { createPortal } from 'react-dom';
 
 import { useFocusTrap } from '../../hooks/use-focus-trap';
 import { cn } from '../../lib/cn';
+import { setModalBlur } from '../../lib/modal-blur';
 import { transition, variants } from '../../lib/motion';
 import { GlassOverlay } from '../GlassOverlay';
-
-/**
- * Number of currently-open ModalShells. WebView2 does not reliably composite the
- * portaled overlay's `backdrop-filter`, so the frosted-glass effect comes from
- * blurring the in-flow app shell instead (see the `.modal-blur-active` rule in
- * the app CSS). The class is ref-counted so stacked modals keep the blur until
- * the last one closes. Toggling a body class keeps this primitive app-agnostic.
- */
-let openModalCount = 0;
-
-function setModalBlur(active: boolean): void {
-  if (typeof document === 'undefined') return;
-  if (active) {
-    openModalCount += 1;
-    document.body.classList.add('modal-blur-active');
-  } else {
-    openModalCount = Math.max(0, openModalCount - 1);
-    if (openModalCount === 0) document.body.classList.remove('modal-blur-active');
-  }
-}
 
 export interface ModalShellProps {
   open: boolean;
@@ -80,11 +61,8 @@ export function ModalShell({
     return () => window.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
-  // Frost the app shell behind the modal. GlassOverlay supplies the dim scrim,
-  // but its `backdrop-filter` blur is unreliable across WebView2 portal stacking
-  // contexts, so the actual blur is an in-flow `filter` on the app shell driven
-  // by this body class (see `.modal-blur-active` in the app CSS). Ref-counted via
-  // `setModalBlur` so stacked modals don't clear it early.
+  // Frost the app shell behind the modal — see `lib/modal-blur` for why the blur
+  // can't live on the portaled overlay itself under WebView2.
   useEffect(() => {
     if (!open) return;
     setModalBlur(true);

--- a/packages/ui/src/components/Tag/Tag.test.tsx
+++ b/packages/ui/src/components/Tag/Tag.test.tsx
@@ -48,6 +48,26 @@ describe('Tag', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
     expect(screen.getByText('keep')).toBeInTheDocument();
   });
+
+  it('closable: names the close button per tag so siblings are distinguishable', () => {
+    render(
+      <Tag closable closeLabel="Remove filter: rust">
+        rust
+      </Tag>
+    );
+    // Several closable tags in a row would otherwise all announce as "Close".
+    expect(screen.getByRole('button', { name: 'Remove filter: rust' })).toBeInTheDocument();
+  });
+
+  it('closable: pads the close button up to a ~24px target without shifting layout', () => {
+    render(<Tag closable>x</Tag>);
+    const close = screen.getByRole('button', { name: 'Close' });
+    // 11px glyph + p-1.5 (6px each side) ≈ 23.5px — WCAG 2.5.8. `p-1` measured
+    // only 19.5px. The negative margins cancel the padding so nothing moves.
+    expect(close.className).toContain('p-1.5');
+    expect(close.className).toContain('-m-1.5');
+    expect(close.className).toContain('-mr-2');
+  });
 });
 
 describe('Tag.CheckableTag', () => {

--- a/packages/ui/src/components/Tag/Tag.tsx
+++ b/packages/ui/src/components/Tag/Tag.tsx
@@ -147,9 +147,11 @@ function TagBase({
           type="button"
           aria-label={closeLabel}
           onClick={handleClose}
-          // `-m-1 p-1` grows the hit box to ~24px (WCAG 2.5.8 Target Size)
-          // around the 11px glyph without changing an inch of the layout.
-          className="-m-1 -mr-1.5 inline-flex items-center rounded p-1 opacity-60 transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50"
+          // `p-1.5` + matching negative margin takes the 11px glyph to a
+          // ~23.5px hit box (WCAG 2.5.8 Target Size) without moving anything:
+          // `p-1` measured only 19.5px. The extra -0.5 on the right preserves
+          // the original `-mr-0.5` optical inset.
+          className="-m-1.5 -mr-2 inline-flex items-center rounded p-1.5 opacity-60 transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50"
         >
           {closeIcon ?? <X size={11} strokeWidth={2.5} />}
         </button>

--- a/packages/ui/src/components/Tag/Tag.tsx
+++ b/packages/ui/src/components/Tag/Tag.tsx
@@ -147,7 +147,9 @@ function TagBase({
           type="button"
           aria-label={closeLabel}
           onClick={handleClose}
-          className="-mr-0.5 inline-flex items-center rounded opacity-60 transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50"
+          // `-m-1 p-1` grows the hit box to ~24px (WCAG 2.5.8 Target Size)
+          // around the 11px glyph without changing an inch of the layout.
+          className="-m-1 -mr-1.5 inline-flex items-center rounded p-1 opacity-60 transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50"
         >
           {closeIcon ?? <X size={11} strokeWidth={2.5} />}
         </button>

--- a/packages/ui/src/components/Tag/Tag.tsx
+++ b/packages/ui/src/components/Tag/Tag.tsx
@@ -39,6 +39,12 @@ export interface TagProps {
   closable?: boolean;
   /** Custom close icon (when `closable`). */
   closeIcon?: ReactNode;
+  /**
+   * Accessible name for the close button. Pass a per-tag, localized string when
+   * several closable tags sit side by side — rotor/voice-control users would
+   * otherwise meet N identical "Close" controls. Defaults to `'Close'`.
+   */
+  closeLabel?: string;
   /** Fired on close click; call `preventDefault()` to keep the tag mounted. */
   onClose?: (e: ReactMouseEvent<HTMLButtonElement>) => void;
   /** Draw the 1px border. Default `true`. */
@@ -94,6 +100,7 @@ function TagBase({
   icon,
   closable,
   closeIcon,
+  closeLabel = 'Close',
   onClose,
   bordered = true,
   onClick,
@@ -138,9 +145,9 @@ function TagBase({
       {closable && (
         <button
           type="button"
-          aria-label="Close"
+          aria-label={closeLabel}
           onClick={handleClose}
-          className="-mr-0.5 inline-flex items-center opacity-60 transition-opacity hover:opacity-100"
+          className="-mr-0.5 inline-flex items-center rounded opacity-60 transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50"
         >
           {closeIcon ?? <X size={11} strokeWidth={2.5} />}
         </button>

--- a/packages/ui/src/hooks/useDropdownKeyboard.ts
+++ b/packages/ui/src/hooks/useDropdownKeyboard.ts
@@ -35,12 +35,19 @@ export function useDropdownKeyboard({
         return;
       }
       if (e.key === 'Escape') {
-        // Innermost-layer-wins: an OPEN popover consumes Escape so it can't also
-        // reach an ancestor dialog/drawer (which listens on `window`) and close
-        // the whole surface. React delegates from the root container, which sits
-        // below `window` in the propagation path, so stopping here is enough —
-        // and the `!open` early-return above leaves a CLOSED dropdown's Escape
-        // free to reach the drawer, as it should.
+        // ── Innermost-layer-wins (shared contract) ──────────────────────────
+        // An OPEN popover consumes Escape so it can't also reach an ancestor
+        // dialog/drawer (which listens on `window`) and close the whole surface.
+        // React delegates from the root container, which sits below `window` in
+        // the propagation path, so stopping here is enough — and the `!open`
+        // early-return above leaves a CLOSED dropdown's Escape free to reach the
+        // drawer, as it should.
+        //
+        // Every dismissible popover that can render inside an overlay owes the
+        // same guard: `CompanyTypeahead` and `LocationInput` mirror it. NOT yet
+        // applied to `ActionMenu` (its Escape handler is a document listener, so
+        // the fix differs) — it is the next candidate if it ever lands in a
+        // dialog.
         e.stopPropagation();
         setOpen(false);
         triggerRef.current?.focus();

--- a/packages/ui/src/hooks/useDropdownKeyboard.ts
+++ b/packages/ui/src/hooks/useDropdownKeyboard.ts
@@ -35,6 +35,13 @@ export function useDropdownKeyboard({
         return;
       }
       if (e.key === 'Escape') {
+        // Innermost-layer-wins: an OPEN popover consumes Escape so it can't also
+        // reach an ancestor dialog/drawer (which listens on `window`) and close
+        // the whole surface. React delegates from the root container, which sits
+        // below `window` in the propagation path, so stopping here is enough —
+        // and the `!open` early-return above leaves a CLOSED dropdown's Escape
+        // free to reach the drawer, as it should.
+        e.stopPropagation();
         setOpen(false);
         triggerRef.current?.focus();
         return;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -92,6 +92,7 @@ export {
 
 // ── Overlays & Modals ─────────────────────────────────────────────────────
 export { ConfirmModal } from './components/ConfirmModal/index';
+export { Drawer, type DrawerProps } from './components/Drawer/index';
 export { GlassOverlay } from './components/GlassOverlay/index';
 export { HoverPopover, type HoverPopoverProps } from './components/HoverPopover/index';
 export { ModalShell, type ModalShellProps } from './components/ModalShell/index';

--- a/packages/ui/src/lib/modal-blur.ts
+++ b/packages/ui/src/lib/modal-blur.ts
@@ -1,0 +1,29 @@
+/**
+ * App-shell frosting for portaled overlays.
+ *
+ * WebView2 does not reliably composite a portaled overlay's `backdrop-filter`,
+ * so the frosted-glass effect comes from blurring the in-flow app shell instead
+ * (the `.modal-blur-active` rule in the app CSS). The class is ref-counted so
+ * stacked overlays — a drawer that opens a confirm modal, say — keep the blur
+ * until the LAST one closes. Toggling a body class keeps this app-agnostic.
+ *
+ * Every portaled surface (`ModalShell`, `Drawer`, …) must call this or its glass
+ * silently degrades to a flat scrim on the shipping platform.
+ */
+let openOverlayCount = 0;
+
+export function setModalBlur(active: boolean): void {
+  if (typeof document === 'undefined') return;
+  if (active) {
+    openOverlayCount += 1;
+    document.body.classList.add('modal-blur-active');
+  } else {
+    openOverlayCount = Math.max(0, openOverlayCount - 1);
+    if (openOverlayCount === 0) document.body.classList.remove('modal-blur-active');
+  }
+}
+
+/** Test-only introspection of the ref count. */
+export function modalBlurCount(): number {
+  return openOverlayCount;
+}

--- a/packages/ui/src/lib/motion.ts
+++ b/packages/ui/src/lib/motion.ts
@@ -140,6 +140,14 @@ export const variants = {
     animate: { opacity: 1, x: 0 },
     exit: { opacity: 0, x: 12 },
   },
+  /** Right-edge slide-over (drawer / sheet) — travels the full panel width so the
+   *  panel enters from and exits past the viewport's right edge. Pair with
+   *  `variants.overlay` under `prefers-reduced-motion` (drop the translate). */
+  slideOverRight: {
+    initial: { opacity: 0, x: '100%' },
+    animate: { opacity: 1, x: 0 },
+    exit: { opacity: 0, x: '100%' },
+  },
 } as const;
 
 // ── Stagger system ────────────────────────────────────────────────────────


### PR DESCRIPTION
Full Jobs-page redesign: the tall hero is replaced by a compact wrapping command bar (title · filter · sort · hide-agency · count · view toggle · Scrape), the scrape form moves into a new right slide-over Drawer primitive (focus-managed, WebView2 modal-blur, pinned header/footer inside the form), and the split view gets the full remaining height with proportional clamped panes gated by container queries.

Fixes the reported narrow-window bugs: at the 900×600 floor the detail pane goes from 0px (measured) to ~454px at the two-pane flip, the action cluster wraps instead of clipping, and the stray horizontal scrollbar is gone. Also fixes a latent bug where Cancel became unreachable mid-scrape.

Two full review rounds (code + measured UX audit in headless Chromium against the built stylesheet): drawer focus-return survives same-commit opener unmount, strip contrast 6.15:1 AA, German bar at the floor 276→151px, chips row keyboard-accessible (axe can't detect that gap), Escape layering (nested dropdown Esc no longer closes the drawer), Tag hit boxes, U+202F German percent spacing.

Review: frontend-author → frontend-reviewer (APPROVE + advisories, all applied) + ui-ux-expert (3 HIGH found, fixed, CONFIRMED-RESOLVED). Validation: 447 jobs + 512 ui tests; typecheck/format/lint all exit-0; built-CSS emission verified per class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
