### PR TITLE
refactor: split mission-control into sections and a pure model module

### DIFF
--- a/apps/landing/src/components/mission-control/ExternalLink.tsx
+++ b/apps/landing/src/components/mission-control/ExternalLink.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+
+// Off-site link (GitHub) — always new tab, always noopener/noreferrer.
+export function ExternalLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  );
+}

--- a/apps/landing/src/components/mission-control/MissionControl.tsx
+++ b/apps/landing/src/components/mission-control/MissionControl.tsx
@@ -1,245 +1,33 @@
 'use client';
 
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { MC_CONFIG } from '@/lib/mission-control/config';
+import { fetchSnapshotStamp, snapshotFreshnessLine } from '@/lib/mission-control/github';
+import { type BenchRun, summarizeBenchmarks } from '@/lib/mission-control/metrics';
 import {
-  fetchSnapshotStamp,
-  ghGet,
-  liveOrSnapshot,
-  snapshotFreshnessLine,
-} from '@/lib/mission-control/github';
-import {
-  type BenchRun,
-  chaossHealth,
-  commitsPerDay,
-  commitTypeRatio,
-  criticalIssueCount,
-  DAY_MS,
-  issuesByLabel,
-  latestGatingConclusion,
-  medianLeadTimeHours,
-  needsAttention,
-  releasesPerWeek,
-  staleCount,
-  summarizeBenchmarks,
-  summarizeOpenPulls,
-  totalReleaseDownloads,
-  workflowHealth,
-} from '@/lib/mission-control/metrics';
+  type BenchmarkGlobal,
+  buildModel,
+  loadAll,
+  type Model,
+  type RepoData,
+} from '@/lib/mission-control/model';
 import { clearToken, readToken, saveToken } from '@/lib/mission-control/pat';
-import type {
-  GhCommit,
-  GhIssue,
-  GhPull,
-  GhRelease,
-  GhRepo,
-  GhWorkflowRun,
-} from '@/lib/mission-control/types';
-import { computeVerdict, isRedConclusion } from '@/lib/mission-control/verdict';
 import {
   performWriteAction,
-  WRITE_ACTIONS,
   type WriteAction,
   type WriteActionContext,
 } from '@/lib/mission-control/write-actions';
 
 import { ConfirmDialog } from './ConfirmDialog';
+import { ExternalLink } from './ExternalLink';
+import { MissionControlSkeleton } from './MissionControlSkeleton';
+import { CommunitySection } from './sections/CommunitySection';
+import { DeliverySection } from './sections/DeliverySection';
+import { MaintainerActions } from './sections/MaintainerActions';
+import { QualitySection } from './sections/QualitySection';
+import { WorkSection } from './sections/WorkSection';
 import { SignInPanel } from './SignInPanel';
-import { Sparkline } from './Sparkline';
-
-interface RepoData {
-  repo: GhRepo | null;
-  releases: GhRelease[];
-  commits: GhCommit[];
-  openPulls: GhPull[];
-  closedPulls: GhPull[];
-  issues: GhIssue[];
-  runs: GhWorkflowRun[];
-}
-
-interface BenchmarkGlobal {
-  BENCHMARK_DATA?: { entries?: Record<string, BenchRun[]> };
-}
-
-const fmtInt = (n: number): string => new Intl.NumberFormat().format(Math.round(n));
-const round1 = (n: number): string => (Math.round(n * 10) / 10).toFixed(1);
-// null (empty sample) renders as an em dash, never a misleading 0% / 100%.
-const pctOrDash = (n: number | null): string => (n === null ? '—' : `${Math.round(n * 100)}%`);
-
-function actionById(id: string): WriteAction {
-  const action = WRITE_ACTIONS.find((a) => a.id === id);
-  if (!action) throw new Error(`unknown write action ${id}`);
-  return action;
-}
-
-async function safe<T>(promise: Promise<T>, fallback: T): Promise<T> {
-  try {
-    return await promise;
-  } catch {
-    return fallback;
-  }
-}
-
-async function loadAll(token: string): Promise<RepoData> {
-  const src = MC_CONFIG.dataSource;
-  const get = <T,>(key: string, path: string) =>
-    liveOrSnapshot(src, key, () => ghGet<T>(path, token));
-
-  // The repo call is the primary — if it throws (rate limit / network), the
-  // error surfaces to the UI rather than silently emptying the dashboard.
-  const repo = await get<GhRepo>('repo', '');
-  const [releases, commits, openPulls, closedPulls, issues, runsWrap] = await Promise.all([
-    safe(get<GhRelease[]>('releases', '/releases?per_page=30'), []),
-    safe(get<GhCommit[]>('commits', '/commits?per_page=100'), []),
-    safe(get<GhPull[]>('open-pulls', '/pulls?state=open&per_page=50'), []),
-    safe(
-      get<GhPull[]>('closed-pulls', '/pulls?state=closed&per_page=50&sort=updated&direction=desc'),
-      []
-    ),
-    safe(get<GhIssue[]>('issues', '/issues?state=open&per_page=100'), []),
-    safe(get<{ workflow_runs: GhWorkflowRun[] }>('runs', '/actions/runs?per_page=50&branch=main'), {
-      workflow_runs: [],
-    }),
-  ]);
-
-  return { repo, releases, commits, openPulls, closedPulls, issues, runs: runsWrap.workflow_runs };
-}
-
-function buildModel(data: RepoData) {
-  const now = Date.now();
-  const openPullViews = summarizeOpenPulls(data.openPulls, now);
-  const stale = staleCount(openPullViews, MC_CONFIG.staleDays);
-  const critical = criticalIssueCount(data.issues, MC_CONFIG.criticalLabels);
-  const gatingConclusion = latestGatingConclusion(data.runs, MC_CONFIG.gatingWorkflow);
-  const latestRelease = data.releases[0];
-  const daysSinceRelease = latestRelease?.published_at
-    ? Math.floor((now - Date.parse(latestRelease.published_at)) / DAY_MS)
-    : null;
-
-  const failedGatingRun = data.runs.find(
-    (r) =>
-      r.path.endsWith(MC_CONFIG.gatingWorkflow) &&
-      r.head_branch === 'main' &&
-      r.status === 'completed' &&
-      isRedConclusion(r.conclusion)
-  );
-
-  return {
-    now,
-    verdict: computeVerdict({
-      gatingRed: isRedConclusion(gatingConclusion),
-      gatingKnown: gatingConclusion !== null,
-      criticalIssueCount: critical,
-      daysSinceRelease,
-      openPrCount: openPullViews.length,
-      stalePrCount: stale,
-      staleDays: MC_CONFIG.staleDays,
-    }),
-    delivery: {
-      perWeek: releasesPerWeek(data.releases, now),
-      leadHours: medianLeadTimeHours(
-        data.closedPulls.filter((p) => p.merged_at !== null),
-        data.releases
-      ),
-      commitRatio: commitTypeRatio(data.commits),
-      health: workflowHealth(data.runs, MC_CONFIG.gatingWorkflow),
-      recentReleases: data.releases.slice(0, 5),
-      daysSinceRelease,
-    },
-    work: {
-      openPullViews: openPullViews.slice(0, 12),
-      totalOpenPulls: openPullViews.length,
-      stale,
-      critical,
-      labels: issuesByLabel(data.issues).slice(0, 8),
-      attention: needsAttention(data.issues, now, MC_CONFIG.staleDays).slice(0, 8),
-      failedGatingRun,
-    },
-    quality: {
-      chaoss: chaossHealth({
-        issues: data.issues,
-        closedPulls: data.closedPulls,
-        releases: data.releases,
-        commits: data.commits,
-        nowMs: now,
-      }),
-    },
-    community: {
-      repo: data.repo,
-      downloads: totalReleaseDownloads(data.releases),
-      commitActivity: commitsPerDay(data.commits, now, 21),
-    },
-  };
-}
-
-type Model = ReturnType<typeof buildModel>;
-
-// ── small presentational helpers ─────────────────────────────────────────────
-function Stat({
-  num,
-  unit,
-  label,
-  sub,
-}: {
-  num: string;
-  unit?: string;
-  label: string;
-  sub?: string;
-}) {
-  return (
-    <div className="mc-card">
-      <p>
-        <span className="mc-stat__num">{num}</span>
-        {unit ? <span className="mc-stat__unit">{unit}</span> : null}
-      </p>
-      <p className="mc-stat__label">{label}</p>
-      {sub ? <p className="mc-stat__sub">{sub}</p> : null}
-    </div>
-  );
-}
-
-function ExternalLink({ href, children }: { href: string; children: ReactNode }) {
-  return (
-    <a href={href} target="_blank" rel="noopener noreferrer">
-      {children}
-    </a>
-  );
-}
-
-// First-load placeholders so the page never shows a big blank gap while the
-// GitHub API resolves. Decorative (aria-hidden); the busy state is announced once.
-function SkeletonGrid({ n = 4 }: { n?: number }) {
-  return (
-    <div className="mc-grid" aria-hidden="true">
-      {Array.from({ length: n }, (_, i) => (
-        <div className="mc-card mc-skeleton" key={i}>
-          <div className="mc-skel" style={{ height: '34px', width: '58%', marginBottom: '10px' }} />
-          <div className="mc-skel" style={{ height: '10px', width: '80%' }} />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function MissionControlSkeleton() {
-  return (
-    <div aria-busy="true" aria-label="Loading whole-repo state">
-      <div className="mc-verdict mc-skeleton" aria-hidden="true">
-        <div className="mc-skel" style={{ height: '16px', width: '120px', marginBottom: '10px' }} />
-        <div className="mc-skel" style={{ height: '30px', width: '70%' }} />
-      </div>
-      <div className="mc-section" aria-hidden="true">
-        <div className="mc-skel" style={{ height: '26px', width: '180px', marginBottom: '16px' }} />
-        <SkeletonGrid />
-      </div>
-      <div className="mc-section" aria-hidden="true">
-        <div className="mc-skel" style={{ height: '26px', width: '150px', marginBottom: '16px' }} />
-        <SkeletonGrid n={3} />
-      </div>
-    </div>
-  );
-}
 
 export function MissionControl() {
   const [token, setToken] = useState('');
@@ -348,13 +136,6 @@ export function MissionControl() {
   const benchSummaries = useMemo(() => (bench ? summarizeBenchmarks(bench) : []), [bench]);
   const signedIn = token.length > 0;
 
-  const seriesColors = [
-    'var(--doc-series-1)',
-    'var(--doc-series-2)',
-    'var(--doc-series-3)',
-    'var(--doc-series-4)',
-  ];
-
   return (
     <div className="mc">
       <div className="mc-toolbar">
@@ -412,264 +193,17 @@ export function MissionControl() {
             <p className="mc-verdict__sub">{model.verdict.sub}</p>
           </section>
 
-          {/* ── Delivery ── */}
-          <section className="mc-section" aria-label="Delivery">
-            <p className="mc-section__eyebrow">how fast it ships</p>
-            <h2 className="mc-section__title">Delivery</h2>
-            <div className="mc-grid">
-              <Stat
-                num={round1(model.delivery.perWeek)}
-                unit="/wk"
-                label="Releases per week"
-                sub="8-week trailing average"
-              />
-              <Stat
-                num={model.delivery.leadHours === null ? '—' : round1(model.delivery.leadHours)}
-                unit={model.delivery.leadHours === null ? undefined : 'h'}
-                label="Merge → release lead time"
-                sub="median, DORA-lite"
-              />
-              <Stat
-                num={pctOrDash(model.delivery.commitRatio.ratio)}
-                label="fix: / revert: commits"
-                sub={`${model.delivery.commitRatio.fixish} of ${model.delivery.commitRatio.typed} typed commits (change-failure proxy)`}
-              />
-              <Stat
-                num={pctOrDash(model.delivery.health.successRate)}
-                label="CI gating pass rate"
-                sub={`last ${model.delivery.health.sampled} runs on main · latest: ${model.delivery.health.lastConclusion ?? 'unknown'}`}
-              />
-            </div>
-            {model.delivery.recentReleases.length > 0 ? (
-              <ul className="mc-list" style={{ marginTop: '14px' }}>
-                {model.delivery.recentReleases.map((release) => (
-                  <li key={release.tag_name} className="mc-row">
-                    <span className="mc-row__title">
-                      <ExternalLink href={release.html_url}>
-                        {release.name ?? release.tag_name}
-                      </ExternalLink>
-                    </span>
-                    <span className="mc-row__meta">
-                      {release.published_at
-                        ? new Date(release.published_at).toLocaleDateString()
-                        : 'draft'}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-          </section>
-
-          {/* ── Work ── */}
-          <section className="mc-section" aria-label="Work">
-            <p className="mc-section__eyebrow">what needs a human</p>
-            <h2 className="mc-section__title">Work</h2>
-            <div className="mc-grid">
-              <Stat
-                num={fmtInt(model.work.totalOpenPulls)}
-                label="Open pull requests"
-                sub={`${model.work.stale} gathering dust > ${MC_CONFIG.staleDays}d`}
-              />
-              <Stat
-                num={fmtInt(model.work.critical)}
-                label="Critical issues open"
-                sub={model.work.critical === 0 ? 'nothing on fire' : 'triage first'}
-              />
-              <Stat
-                num={fmtInt(model.work.attention.length)}
-                label="Issues needing attention"
-                sub="no reply + stale"
-              />
-            </div>
-
-            {model.work.openPullViews.length > 0 ? (
-              <ul className="mc-list" style={{ marginTop: '14px' }}>
-                {model.work.openPullViews.map((pr) => (
-                  <li key={pr.number} className="mc-row">
-                    <span className="mc-row__title">
-                      <ExternalLink href={pr.url}>
-                        #{pr.number} {pr.title}
-                      </ExternalLink>
-                    </span>
-                    <span className="mc-row__meta">{pr.ageDays}d old</span>
-                    {pr.draft ? <span className="mc-badge is-draft">draft</span> : null}
-                    {pr.awaitingReview ? (
-                      <span className="mc-badge is-review">review requested</span>
-                    ) : null}
-                    {!pr.draft && pr.ageDays > MC_CONFIG.staleDays ? (
-                      <span className="mc-badge is-stale">stale</span>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="mc-empty">no open pull requests</p>
-            )}
-
-            {model.work.attention.length > 0 ? (
-              <ul className="mc-list" style={{ marginTop: '14px' }}>
-                {model.work.attention.map((issue) => (
-                  <li key={issue.number} className="mc-row">
-                    <span className="mc-row__title">
-                      <ExternalLink href={issue.url}>
-                        #{issue.number} {issue.title}
-                      </ExternalLink>
-                    </span>
-                    <span className="mc-row__meta">{issue.ageDays}d, no reply</span>
-                    {signedIn ? (
-                      <span className="mc-row__actions">
-                        <button
-                          type="button"
-                          className="mc-btn"
-                          onClick={() =>
-                            void runAction(actionById('close-issue'), { issueNumber: issue.number })
-                          }
-                        >
-                          Close
-                        </button>
-                        <button
-                          type="button"
-                          className="mc-btn"
-                          onClick={() =>
-                            void runAction(actionById('label-issue'), {
-                              issueNumber: issue.number,
-                              label: 'needs-triage',
-                            })
-                          }
-                        >
-                          +triage
-                        </button>
-                      </span>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-          </section>
-
-          {/* ── Quality ── */}
-          <section className="mc-section" aria-label="Quality">
-            <p className="mc-section__eyebrow">is it actually healthy</p>
-            <h2 className="mc-section__title">Quality</h2>
-            <div className="mc-grid">
-              <Stat
-                num={
-                  model.quality.chaoss.timeToFirstResponseHours === null
-                    ? '—'
-                    : round1(model.quality.chaoss.timeToFirstResponseHours)
-                }
-                unit={model.quality.chaoss.timeToFirstResponseHours === null ? undefined : 'h'}
-                label="Time to first response"
-                sub="median (proxy: reply latency on commented issues)"
-              />
-              <Stat
-                num={pctOrDash(model.quality.chaoss.changeRequestClosureRatio)}
-                label="Change-request closure"
-                sub="merged ÷ all recently closed PRs"
-              />
-              <Stat
-                num={round1(model.quality.chaoss.releasesPerWeek)}
-                unit="/wk"
-                label="Release frequency"
-                sub="CHAOSS starter health"
-              />
-              <Stat
-                num={model.quality.chaoss.busFactorGag}
-                label="Bus factor"
-                sub="distinct recent commit authors"
-              />
-            </div>
-
-            {benchSummaries.length > 0 ? (
-              <div className="mc-grid" style={{ marginTop: '14px' }}>
-                {benchSummaries.map((suite, index) => (
-                  <div className="mc-card" key={suite.name}>
-                    <div className="mc-card__head">
-                      <span className="mc-stat__label">{suite.name}</span>
-                      {suite.deltaPct !== null ? (
-                        <span className="mc-row__meta">
-                          {suite.deltaPct >= 0 ? '+' : ''}
-                          {round1(suite.deltaPct)}%
-                        </span>
-                      ) : null}
-                    </div>
-                    <Sparkline
-                      values={suite.values}
-                      label={`${suite.name} benchmark trend`}
-                      stroke={seriesColors[index % seriesColors.length]}
-                    />
-                    <p className="mc-stat__sub">
-                      latest {fmtInt(suite.latest)} {suite.unit}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <p className="mc-empty" style={{ marginTop: '14px' }}>
-                benchmark series not loaded
-              </p>
-            )}
-          </section>
-
-          {/* ── Community ── */}
-          <section className="mc-section" aria-label="Community">
-            <p className="mc-section__eyebrow">who is watching</p>
-            <h2 className="mc-section__title">Community</h2>
-            <div className="mc-grid">
-              <Stat num={fmtInt(model.community.repo?.stargazers_count ?? 0)} label="Stars" />
-              <Stat num={fmtInt(model.community.repo?.forks_count ?? 0)} label="Forks" />
-              <Stat num={fmtInt(model.community.repo?.subscribers_count ?? 0)} label="Watchers" />
-              <Stat
-                num={fmtInt(model.community.downloads)}
-                label="Release asset downloads"
-                sub="all releases, all platforms"
-              />
-            </div>
-            <div className="mc-card" style={{ marginTop: '14px' }}>
-              <span className="mc-stat__label">Commit activity · last 21 days</span>
-              <Sparkline
-                values={model.community.commitActivity}
-                label="Commits per day over the last 21 days"
-                stroke="var(--doc-series-2)"
-              />
-            </div>
-          </section>
-
-          {/* ── Maintainer actions (signed-in, safe tier) ── */}
+          <DeliverySection delivery={model.delivery} />
+          <WorkSection
+            work={model.work}
+            staleDays={MC_CONFIG.staleDays}
+            signedIn={signedIn}
+            runAction={runAction}
+          />
+          <QualitySection quality={model.quality} benchSummaries={benchSummaries} />
+          <CommunitySection community={model.community} />
           {signedIn ? (
-            <section className="mc-section" aria-label="Maintainer actions">
-              <p className="mc-section__eyebrow">every one asks first, none of them merge</p>
-              <h2 className="mc-section__title">Maintainer actions</h2>
-              <div className="mc-maintainer">
-                <button
-                  type="button"
-                  className="mc-btn is-primary"
-                  onClick={() => void runAction(actionById('dispatch-release'), {}, true)}
-                >
-                  Dispatch release workflow
-                </button>
-                <button
-                  type="button"
-                  className="mc-btn is-danger"
-                  onClick={() => void runAction(actionById('dispatch-pages'), {}, true)}
-                >
-                  Dispatch pages deploy
-                </button>
-                {model.work.failedGatingRun ? (
-                  <button
-                    type="button"
-                    className="mc-btn is-danger"
-                    onClick={() =>
-                      void runAction(actionById('rerun-failed'), {
-                        runId: model.work.failedGatingRun?.id,
-                      })
-                    }
-                  >
-                    Re-run failed CI (#{model.work.failedGatingRun.id})
-                  </button>
-                ) : null}
-              </div>
-            </section>
+            <MaintainerActions failedGatingRun={model.work.failedGatingRun} runAction={runAction} />
           ) : null}
         </>
       ) : loading ? (

--- a/apps/landing/src/components/mission-control/MissionControlSkeleton.tsx
+++ b/apps/landing/src/components/mission-control/MissionControlSkeleton.tsx
@@ -1,0 +1,33 @@
+// First-load placeholders so the page never shows a big blank gap while the
+// GitHub API resolves. Decorative (aria-hidden); the busy state is announced once.
+function SkeletonGrid({ n = 4 }: { n?: number }) {
+  return (
+    <div className="mc-grid" aria-hidden="true">
+      {Array.from({ length: n }, (_, i) => (
+        <div className="mc-card mc-skeleton" key={i}>
+          <div className="mc-skel" style={{ height: '34px', width: '58%', marginBottom: '10px' }} />
+          <div className="mc-skel" style={{ height: '10px', width: '80%' }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function MissionControlSkeleton() {
+  return (
+    <div aria-busy="true" aria-label="Loading whole-repo state">
+      <div className="mc-verdict mc-skeleton" aria-hidden="true">
+        <div className="mc-skel" style={{ height: '16px', width: '120px', marginBottom: '10px' }} />
+        <div className="mc-skel" style={{ height: '30px', width: '70%' }} />
+      </div>
+      <div className="mc-section" aria-hidden="true">
+        <div className="mc-skel" style={{ height: '26px', width: '180px', marginBottom: '16px' }} />
+        <SkeletonGrid />
+      </div>
+      <div className="mc-section" aria-hidden="true">
+        <div className="mc-skel" style={{ height: '26px', width: '150px', marginBottom: '16px' }} />
+        <SkeletonGrid n={3} />
+      </div>
+    </div>
+  );
+}

--- a/apps/landing/src/components/mission-control/Section.tsx
+++ b/apps/landing/src/components/mission-control/Section.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+// The `mc-section` + `__eyebrow` + `__title` wrapper repeated across every
+// /mission-control section (Delivery, Work, Quality, Community, Maintainer
+// actions). Must render byte-identical markup at every call site.
+export function Section({
+  label,
+  eyebrow,
+  title,
+  children,
+}: {
+  label: string;
+  eyebrow: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="mc-section" aria-label={label}>
+      <p className="mc-section__eyebrow">{eyebrow}</p>
+      <h2 className="mc-section__title">{title}</h2>
+      {children}
+    </section>
+  );
+}

--- a/apps/landing/src/components/mission-control/Stat.tsx
+++ b/apps/landing/src/components/mission-control/Stat.tsx
@@ -1,0 +1,24 @@
+// Single metric card — the repeated `mc-card` / `mc-stat__*` shape used across
+// every /mission-control section (15 call sites).
+export function Stat({
+  num,
+  unit,
+  label,
+  sub,
+}: {
+  num: string;
+  unit?: string;
+  label: string;
+  sub?: string;
+}) {
+  return (
+    <div className="mc-card">
+      <p>
+        <span className="mc-stat__num">{num}</span>
+        {unit ? <span className="mc-stat__unit">{unit}</span> : null}
+      </p>
+      <p className="mc-stat__label">{label}</p>
+      {sub ? <p className="mc-stat__sub">{sub}</p> : null}
+    </div>
+  );
+}

--- a/apps/landing/src/components/mission-control/sections/CommunitySection.tsx
+++ b/apps/landing/src/components/mission-control/sections/CommunitySection.tsx
@@ -1,0 +1,30 @@
+import { fmtInt, type Model } from '@/lib/mission-control/model';
+
+import { Section } from '../Section';
+import { Sparkline } from '../Sparkline';
+import { Stat } from '../Stat';
+
+export function CommunitySection({ community }: { community: Model['community'] }) {
+  return (
+    <Section label="Community" eyebrow="who is watching" title="Community">
+      <div className="mc-grid">
+        <Stat num={fmtInt(community.repo?.stargazers_count ?? 0)} label="Stars" />
+        <Stat num={fmtInt(community.repo?.forks_count ?? 0)} label="Forks" />
+        <Stat num={fmtInt(community.repo?.subscribers_count ?? 0)} label="Watchers" />
+        <Stat
+          num={fmtInt(community.downloads)}
+          label="Release asset downloads"
+          sub="all releases, all platforms"
+        />
+      </div>
+      <div className="mc-card" style={{ marginTop: '14px' }}>
+        <span className="mc-stat__label">Commit activity · last 21 days</span>
+        <Sparkline
+          values={community.commitActivity}
+          label="Commits per day over the last 21 days"
+          stroke="var(--doc-series-2)"
+        />
+      </div>
+    </Section>
+  );
+}

--- a/apps/landing/src/components/mission-control/sections/DeliverySection.tsx
+++ b/apps/landing/src/components/mission-control/sections/DeliverySection.tsx
@@ -1,0 +1,54 @@
+import { type Model, pctOrDash, round1 } from '@/lib/mission-control/model';
+
+import { ExternalLink } from '../ExternalLink';
+import { Section } from '../Section';
+import { Stat } from '../Stat';
+
+export function DeliverySection({ delivery }: { delivery: Model['delivery'] }) {
+  return (
+    <Section label="Delivery" eyebrow="how fast it ships" title="Delivery">
+      <div className="mc-grid">
+        <Stat
+          num={round1(delivery.perWeek)}
+          unit="/wk"
+          label="Releases per week"
+          sub="8-week trailing average"
+        />
+        <Stat
+          num={delivery.leadHours === null ? '—' : round1(delivery.leadHours)}
+          unit={delivery.leadHours === null ? undefined : 'h'}
+          label="Merge → release lead time"
+          sub="median, DORA-lite"
+        />
+        <Stat
+          num={pctOrDash(delivery.commitRatio.ratio)}
+          label="fix: / revert: commits"
+          sub={`${delivery.commitRatio.fixish} of ${delivery.commitRatio.typed} typed commits (change-failure proxy)`}
+        />
+        <Stat
+          num={pctOrDash(delivery.health.successRate)}
+          label="CI gating pass rate"
+          sub={`last ${delivery.health.sampled} runs on main · latest: ${delivery.health.lastConclusion ?? 'unknown'}`}
+        />
+      </div>
+      {delivery.recentReleases.length > 0 ? (
+        <ul className="mc-list" style={{ marginTop: '14px' }}>
+          {delivery.recentReleases.map((release) => (
+            <li key={release.tag_name} className="mc-row">
+              <span className="mc-row__title">
+                <ExternalLink href={release.html_url}>
+                  {release.name ?? release.tag_name}
+                </ExternalLink>
+              </span>
+              <span className="mc-row__meta">
+                {release.published_at
+                  ? new Date(release.published_at).toLocaleDateString()
+                  : 'draft'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </Section>
+  );
+}

--- a/apps/landing/src/components/mission-control/sections/MaintainerActions.tsx
+++ b/apps/landing/src/components/mission-control/sections/MaintainerActions.tsx
@@ -1,0 +1,54 @@
+import type { Model } from '@/lib/mission-control/model';
+import {
+  actionById,
+  type WriteAction,
+  type WriteActionContext,
+} from '@/lib/mission-control/write-actions';
+
+import { Section } from '../Section';
+
+export function MaintainerActions({
+  failedGatingRun,
+  runAction,
+}: {
+  failedGatingRun: Model['work']['failedGatingRun'];
+  runAction: (action: WriteAction, ctx: WriteActionContext, danger?: boolean) => void;
+}) {
+  return (
+    <Section
+      label="Maintainer actions"
+      eyebrow="every one asks first, none of them merge"
+      title="Maintainer actions"
+    >
+      <div className="mc-maintainer">
+        <button
+          type="button"
+          className="mc-btn is-primary"
+          onClick={() => void runAction(actionById('dispatch-release'), {}, true)}
+        >
+          Dispatch release workflow
+        </button>
+        <button
+          type="button"
+          className="mc-btn is-danger"
+          onClick={() => void runAction(actionById('dispatch-pages'), {}, true)}
+        >
+          Dispatch pages deploy
+        </button>
+        {failedGatingRun ? (
+          <button
+            type="button"
+            className="mc-btn is-danger"
+            onClick={() =>
+              void runAction(actionById('rerun-failed'), {
+                runId: failedGatingRun?.id,
+              })
+            }
+          >
+            Re-run failed CI (#{failedGatingRun.id})
+          </button>
+        ) : null}
+      </div>
+    </Section>
+  );
+}

--- a/apps/landing/src/components/mission-control/sections/QualitySection.tsx
+++ b/apps/landing/src/components/mission-control/sections/QualitySection.tsx
@@ -1,0 +1,85 @@
+import type { BenchSummary } from '@/lib/mission-control/metrics';
+import { fmtInt, type Model, pctOrDash, round1 } from '@/lib/mission-control/model';
+
+import { Section } from '../Section';
+import { Sparkline } from '../Sparkline';
+import { Stat } from '../Stat';
+
+// Sparkline series colors — hoisted module constant, was recreated every render.
+const SERIES_COLORS = [
+  'var(--doc-series-1)',
+  'var(--doc-series-2)',
+  'var(--doc-series-3)',
+  'var(--doc-series-4)',
+];
+
+export function QualitySection({
+  quality,
+  benchSummaries,
+}: {
+  quality: Model['quality'];
+  benchSummaries: BenchSummary[];
+}) {
+  return (
+    <Section label="Quality" eyebrow="is it actually healthy" title="Quality">
+      <div className="mc-grid">
+        <Stat
+          num={
+            quality.chaoss.timeToFirstResponseHours === null
+              ? '—'
+              : round1(quality.chaoss.timeToFirstResponseHours)
+          }
+          unit={quality.chaoss.timeToFirstResponseHours === null ? undefined : 'h'}
+          label="Time to first response"
+          sub="median (proxy: reply latency on commented issues)"
+        />
+        <Stat
+          num={pctOrDash(quality.chaoss.changeRequestClosureRatio)}
+          label="Change-request closure"
+          sub="merged ÷ all recently closed PRs"
+        />
+        <Stat
+          num={round1(quality.chaoss.releasesPerWeek)}
+          unit="/wk"
+          label="Release frequency"
+          sub="CHAOSS starter health"
+        />
+        <Stat
+          num={quality.chaoss.busFactorGag}
+          label="Bus factor"
+          sub="distinct recent commit authors"
+        />
+      </div>
+
+      {benchSummaries.length > 0 ? (
+        <div className="mc-grid" style={{ marginTop: '14px' }}>
+          {benchSummaries.map((suite, index) => (
+            <div className="mc-card" key={suite.name}>
+              <div className="mc-card__head">
+                <span className="mc-stat__label">{suite.name}</span>
+                {suite.deltaPct !== null ? (
+                  <span className="mc-row__meta">
+                    {suite.deltaPct >= 0 ? '+' : ''}
+                    {round1(suite.deltaPct)}%
+                  </span>
+                ) : null}
+              </div>
+              <Sparkline
+                values={suite.values}
+                label={`${suite.name} benchmark trend`}
+                stroke={SERIES_COLORS[index % SERIES_COLORS.length]}
+              />
+              <p className="mc-stat__sub">
+                latest {fmtInt(suite.latest)} {suite.unit}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mc-empty" style={{ marginTop: '14px' }}>
+          benchmark series not loaded
+        </p>
+      )}
+    </Section>
+  );
+}

--- a/apps/landing/src/components/mission-control/sections/WorkSection.tsx
+++ b/apps/landing/src/components/mission-control/sections/WorkSection.tsx
@@ -1,0 +1,108 @@
+import { fmtInt, type Model } from '@/lib/mission-control/model';
+import {
+  actionById,
+  type WriteAction,
+  type WriteActionContext,
+} from '@/lib/mission-control/write-actions';
+
+import { ExternalLink } from '../ExternalLink';
+import { Section } from '../Section';
+import { Stat } from '../Stat';
+
+export function WorkSection({
+  work,
+  staleDays,
+  signedIn,
+  runAction,
+}: {
+  work: Model['work'];
+  staleDays: number;
+  signedIn: boolean;
+  runAction: (action: WriteAction, ctx: WriteActionContext, danger?: boolean) => void;
+}) {
+  return (
+    <Section label="Work" eyebrow="what needs a human" title="Work">
+      <div className="mc-grid">
+        <Stat
+          num={fmtInt(work.totalOpenPulls)}
+          label="Open pull requests"
+          sub={`${work.stale} gathering dust > ${staleDays}d`}
+        />
+        <Stat
+          num={fmtInt(work.critical)}
+          label="Critical issues open"
+          sub={work.critical === 0 ? 'nothing on fire' : 'triage first'}
+        />
+        <Stat
+          num={fmtInt(work.attention.length)}
+          label="Issues needing attention"
+          sub="no reply + stale"
+        />
+      </div>
+
+      {work.openPullViews.length > 0 ? (
+        <ul className="mc-list" style={{ marginTop: '14px' }}>
+          {work.openPullViews.map((pr) => (
+            <li key={pr.number} className="mc-row">
+              <span className="mc-row__title">
+                <ExternalLink href={pr.url}>
+                  #{pr.number} {pr.title}
+                </ExternalLink>
+              </span>
+              <span className="mc-row__meta">{pr.ageDays}d old</span>
+              {pr.draft ? <span className="mc-badge is-draft">draft</span> : null}
+              {pr.awaitingReview ? (
+                <span className="mc-badge is-review">review requested</span>
+              ) : null}
+              {!pr.draft && pr.ageDays > staleDays ? (
+                <span className="mc-badge is-stale">stale</span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mc-empty">no open pull requests</p>
+      )}
+
+      {work.attention.length > 0 ? (
+        <ul className="mc-list" style={{ marginTop: '14px' }}>
+          {work.attention.map((issue) => (
+            <li key={issue.number} className="mc-row">
+              <span className="mc-row__title">
+                <ExternalLink href={issue.url}>
+                  #{issue.number} {issue.title}
+                </ExternalLink>
+              </span>
+              <span className="mc-row__meta">{issue.ageDays}d, no reply</span>
+              {signedIn ? (
+                <span className="mc-row__actions">
+                  <button
+                    type="button"
+                    className="mc-btn"
+                    onClick={() =>
+                      void runAction(actionById('close-issue'), { issueNumber: issue.number })
+                    }
+                  >
+                    Close
+                  </button>
+                  <button
+                    type="button"
+                    className="mc-btn"
+                    onClick={() =>
+                      void runAction(actionById('label-issue'), {
+                        issueNumber: issue.number,
+                        label: 'needs-triage',
+                      })
+                    }
+                  >
+                    +triage
+                  </button>
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </Section>
+  );
+}

--- a/apps/landing/src/lib/mission-control/model.ts
+++ b/apps/landing/src/lib/mission-control/model.ts
@@ -1,0 +1,148 @@
+import { MC_CONFIG } from './config';
+import { ghGet, liveOrSnapshot } from './github';
+import {
+  type BenchRun,
+  chaossHealth,
+  commitsPerDay,
+  commitTypeRatio,
+  criticalIssueCount,
+  DAY_MS,
+  issuesByLabel,
+  latestGatingConclusion,
+  medianLeadTimeHours,
+  needsAttention,
+  releasesPerWeek,
+  staleCount,
+  summarizeOpenPulls,
+  totalReleaseDownloads,
+  workflowHealth,
+} from './metrics';
+import type { GhCommit, GhIssue, GhPull, GhRelease, GhRepo, GhWorkflowRun } from './types';
+import { computeVerdict, isRedConclusion } from './verdict';
+
+// Pure repo → dashboard reduction. Fetches the raw GitHub payloads (or their
+// nightly snapshot equivalents) and turns them into the shape every
+// /mission-control section renders from. Zero React — MissionControl.tsx owns
+// state/effects/composition only.
+
+export interface RepoData {
+  repo: GhRepo | null;
+  releases: GhRelease[];
+  commits: GhCommit[];
+  openPulls: GhPull[];
+  closedPulls: GhPull[];
+  issues: GhIssue[];
+  runs: GhWorkflowRun[];
+}
+
+export interface BenchmarkGlobal {
+  BENCHMARK_DATA?: { entries?: Record<string, BenchRun[]> };
+}
+
+export const fmtInt = (n: number): string => new Intl.NumberFormat().format(Math.round(n));
+export const round1 = (n: number): string => (Math.round(n * 10) / 10).toFixed(1);
+// null (empty sample) renders as an em dash, never a misleading 0% / 100%.
+export const pctOrDash = (n: number | null): string =>
+  n === null ? '—' : `${Math.round(n * 100)}%`;
+
+async function safe<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await promise;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function loadAll(token: string): Promise<RepoData> {
+  const src = MC_CONFIG.dataSource;
+  const get = <T>(key: string, path: string) =>
+    liveOrSnapshot(src, key, () => ghGet<T>(path, token));
+
+  // The repo call is the primary — if it throws (rate limit / network), the
+  // error surfaces to the UI rather than silently emptying the dashboard.
+  const repo = await get<GhRepo>('repo', '');
+  const [releases, commits, openPulls, closedPulls, issues, runsWrap] = await Promise.all([
+    safe(get<GhRelease[]>('releases', '/releases?per_page=30'), []),
+    safe(get<GhCommit[]>('commits', '/commits?per_page=100'), []),
+    safe(get<GhPull[]>('open-pulls', '/pulls?state=open&per_page=50'), []),
+    safe(
+      get<GhPull[]>('closed-pulls', '/pulls?state=closed&per_page=50&sort=updated&direction=desc'),
+      []
+    ),
+    safe(get<GhIssue[]>('issues', '/issues?state=open&per_page=100'), []),
+    safe(get<{ workflow_runs: GhWorkflowRun[] }>('runs', '/actions/runs?per_page=50&branch=main'), {
+      workflow_runs: [],
+    }),
+  ]);
+
+  return { repo, releases, commits, openPulls, closedPulls, issues, runs: runsWrap.workflow_runs };
+}
+
+export function buildModel(data: RepoData) {
+  const now = Date.now();
+  const openPullViews = summarizeOpenPulls(data.openPulls, now);
+  const stale = staleCount(openPullViews, MC_CONFIG.staleDays);
+  const critical = criticalIssueCount(data.issues, MC_CONFIG.criticalLabels);
+  const gatingConclusion = latestGatingConclusion(data.runs, MC_CONFIG.gatingWorkflow);
+  const latestRelease = data.releases[0];
+  const daysSinceRelease = latestRelease?.published_at
+    ? Math.floor((now - Date.parse(latestRelease.published_at)) / DAY_MS)
+    : null;
+
+  const failedGatingRun = data.runs.find(
+    (r) =>
+      r.path.endsWith(MC_CONFIG.gatingWorkflow) &&
+      r.head_branch === 'main' &&
+      r.status === 'completed' &&
+      isRedConclusion(r.conclusion)
+  );
+
+  return {
+    now,
+    verdict: computeVerdict({
+      gatingRed: isRedConclusion(gatingConclusion),
+      gatingKnown: gatingConclusion !== null,
+      criticalIssueCount: critical,
+      daysSinceRelease,
+      openPrCount: openPullViews.length,
+      stalePrCount: stale,
+      staleDays: MC_CONFIG.staleDays,
+    }),
+    delivery: {
+      perWeek: releasesPerWeek(data.releases, now),
+      leadHours: medianLeadTimeHours(
+        data.closedPulls.filter((p) => p.merged_at !== null),
+        data.releases
+      ),
+      commitRatio: commitTypeRatio(data.commits),
+      health: workflowHealth(data.runs, MC_CONFIG.gatingWorkflow),
+      recentReleases: data.releases.slice(0, 5),
+      daysSinceRelease,
+    },
+    work: {
+      openPullViews: openPullViews.slice(0, 12),
+      totalOpenPulls: openPullViews.length,
+      stale,
+      critical,
+      labels: issuesByLabel(data.issues).slice(0, 8),
+      attention: needsAttention(data.issues, now, MC_CONFIG.staleDays).slice(0, 8),
+      failedGatingRun,
+    },
+    quality: {
+      chaoss: chaossHealth({
+        issues: data.issues,
+        closedPulls: data.closedPulls,
+        releases: data.releases,
+        commits: data.commits,
+        nowMs: now,
+      }),
+    },
+    community: {
+      repo: data.repo,
+      downloads: totalReleaseDownloads(data.releases),
+      commitActivity: commitsPerDay(data.commits, now, 21),
+    },
+  };
+}
+
+export type Model = ReturnType<typeof buildModel>;

--- a/apps/landing/src/lib/mission-control/write-actions.ts
+++ b/apps/landing/src/lib/mission-control/write-actions.ts
@@ -25,6 +25,12 @@ export interface WriteAction {
   body?: (ctx: WriteActionContext) => unknown;
 }
 
+export function actionById(id: string): WriteAction {
+  const action = WRITE_ACTIONS.find((a) => a.id === id);
+  if (!action) throw new Error(`unknown write action ${id}`);
+  return action;
+}
+
 export const WRITE_ACTIONS: readonly WriteAction[] = [
   {
     id: 'rerun-failed',


### PR DESCRIPTION
## What

`MissionControl.tsx` was **701 lines** mixing GitHub data loading, view-model assembly, formatters, and five page sections in one file. This is PR 1 of 4 splitting the oversized `apps/landing` components.

**Pure logic → `lib/mission-control/model.ts`**, joining the eight already-tested modules in that directory:

- `RepoData` / `BenchmarkGlobal`
- `fmtInt` / `round1` / `pctOrDash`
- `safe`, `loadAll`
- `buildModel` + `type Model` — 66 lines of pure `RepoData → Model` with zero React

`actionById` moved beside `WRITE_ACTIONS` in `write-actions.ts` where it belongs.

**Markup → components**, collapsing the repeated shapes to one definition each:

| Component | Call sites collapsed |
| --- | ---: |
| `Stat.tsx` | 15 |
| `Section.tsx` (`mc-section` + eyebrow + title) | 5 |
| `ExternalLink.tsx` | 5 |
| `sections/{Delivery,Work,Quality,Community}Section.tsx`, `sections/MaintainerActions.tsx` | — |
| `MissionControlSkeleton.tsx` | — |

`MissionControl.tsx` now holds state, the four effects, `confirm`/`runAction`, the three `useMemo`s and composition — **235 lines**.

## Behavior

**Strictly behavior-preserving.** Rendered DOM, text content, class names, attribute values and interaction flow are unchanged. `seriesColors` was being recreated every render and is now a module constant — the only perf-visible difference.

## Verification

- `pnpm --filter @ajh/landing typecheck` — clean
- `pnpm --filter @ajh/landing test` — 167 tests, 21 files, all pass. The six existing `MissionControl.test.tsx` end-to-end tests are **untouched** and still green, including the two security-relevant ones (untrusted issue title stays escaped; write is gated behind the confirm dialog and the token never reaches a URL).
- `pnpm lint:strict` — clean at `--max-warnings 0`

Audited by `frontend-reviewer`: no HIGH/CRITICAL findings. It verified all 5 `Section` and all 15 `Stat` call sites reproduce their original markup, that `buildModel` kept every slice limit and `MC_CONFIG` read, and that no `dangerouslySetInnerHTML` or token-in-URL path was introduced.

## Note

The reviewer surfaced pre-existing dead code: `work.labels` (`issuesByLabel(...).slice(0, 8)`) is computed but never rendered — true on `main` too, so it is left alone here rather than smuggled into a behavior-preserving PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
