### PR TITLE
test: cover the pure modules extracted from the landing component split

### DIFF
--- a/apps/landing/src/lib/agent-system/belt.test.ts
+++ b/apps/landing/src/lib/agent-system/belt.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { STATIONS } from '@/data/agent-fleet';
+
+import { activeStationX, beltProgress, nearestStationIndex, STATION_COUNT } from './belt';
+
+describe('STATION_COUNT', () => {
+  it('is derived from STATIONS, never a hardcoded literal', () => {
+    expect(STATION_COUNT).toBe(STATIONS.length);
+  });
+});
+
+describe('beltProgress', () => {
+  it.each([
+    // [sectionTop, sectionHeight, viewportHeight, expected, why]
+    [0, 500, 500, 0, 'zero runway (height === viewport) never divides by zero'],
+    [0, 400, 500, 0, 'negative runway (section shorter than viewport) also stays 0'],
+    [50, 600, 500, 0, 'not yet scrolled into view (positive top) clamps to 0'],
+    [0, 600, 500, 0, 'exactly at the top of the runway is 0'],
+    [-50, 600, 500, 0.5, 'linear interior point of a 100px runway'],
+    [-100, 600, 500, 1, 'exactly at the end of the runway is 1'],
+    [-1000, 600, 500, 1, 'scrolled well past the runway clamps to 1'],
+  ] as const)(
+    'beltProgress(%d, %d, %d) === %d (%s)',
+    (sectionTop, sectionHeight, viewportHeight, expected, _why) => {
+      expect(beltProgress(sectionTop, sectionHeight, viewportHeight)).toBe(expected);
+    }
+  );
+});
+
+describe('activeStationX', () => {
+  it('interpolates linearly between the first and last station centers', () => {
+    expect(activeStationX(0, 100, 0)).toBe(0);
+    expect(activeStationX(0, 100, 1)).toBe(100);
+    expect(activeStationX(0, 100, 0.5)).toBe(50);
+  });
+
+  it('is not itself clamped — callers pass an already-clamped beltProgress', () => {
+    expect(activeStationX(0, 100, 2)).toBe(200);
+    expect(activeStationX(0, 100, -1)).toBe(-100);
+  });
+});
+
+describe('nearestStationIndex', () => {
+  it.each([
+    [[0, 100, 200], -50, 0, 'out-of-bounds x below the first center snaps to it'],
+    [[0, 100, 200], 1000, 2, 'out-of-bounds x above the last center snaps to it'],
+    [[0, 100, 200], 100, 1, 'exact hit on a center'],
+    [[0, 100], 50, 0, 'exactly between two stations picks the first (strict <, first wins ties)'],
+    [[42], -999, 0, 'a single station is always the answer'],
+    [[42], 999, 0, 'a single station is always the answer'],
+  ] as const)('nearestStationIndex(%j, %d) === %d (%s)', (centers, activeX, expected, _why) => {
+    expect(nearestStationIndex(centers, activeX)).toBe(expected);
+  });
+
+  it('always returns a valid index into a non-empty centers array', () => {
+    const centers = [0, 50, 120, 121, 500];
+    for (const activeX of [-Infinity, -1e6, -1, 0, 60, 120.5, 1e6, Infinity]) {
+      const index = nearestStationIndex(centers, activeX);
+      expect(index).toBeGreaterThanOrEqual(0);
+      expect(index).toBeLessThan(centers.length);
+    }
+  });
+
+  it('returns 0 on an empty centers array (documented current behavior, not a valid index)', () => {
+    // centers.forEach never runs, so `step` never advances past its initial 0 —
+    // but an empty array has no index 0. Never hit in practice since STATION_COUNT
+    // (and therefore every centers array built from it) is never empty.
+    expect(nearestStationIndex([], 42)).toBe(0);
+  });
+});

--- a/apps/landing/src/lib/agent-system/clipboard.test.ts
+++ b/apps/landing/src/lib/agent-system/clipboard.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { copyChip, copyChipOnKeyDown } from './clipboard';
+import { COPIED_TIMEOUT_MS } from './constants';
+
+function stubClipboard(writeText = vi.fn().mockResolvedValue(undefined)) {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+  return writeText;
+}
+
+function mouseEvent(el: HTMLElement): ReactMouseEvent<HTMLElement> {
+  return { currentTarget: el } as unknown as ReactMouseEvent<HTMLElement>;
+}
+
+function keyEvent(key: string, el: HTMLElement): ReactKeyboardEvent<HTMLElement> {
+  return {
+    key,
+    currentTarget: el,
+    preventDefault: vi.fn(),
+  } as unknown as ReactKeyboardEvent<HTMLElement>;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+describe('copyChip', () => {
+  it('copies data-copy in preference to textContent', () => {
+    const writeText = stubClipboard();
+    const el = document.createElement('span');
+    el.setAttribute('data-copy', 'pnpm install');
+    el.textContent = 'install';
+    copyChip(mouseEvent(el));
+    expect(writeText).toHaveBeenCalledWith('pnpm install');
+  });
+
+  it('falls back to textContent when data-copy is absent', () => {
+    const writeText = stubClipboard();
+    const el = document.createElement('span');
+    el.textContent = 'fallback text';
+    copyChip(mouseEvent(el));
+    expect(writeText).toHaveBeenCalledWith('fallback text');
+  });
+
+  it('copies an empty string when neither data-copy nor textContent exist', () => {
+    const writeText = stubClipboard();
+    const el = document.createElement('span');
+    copyChip(mouseEvent(el));
+    expect(writeText).toHaveBeenCalledWith('');
+  });
+
+  it('is a no-op when navigator.clipboard is unavailable', () => {
+    const el = document.createElement('span');
+    el.textContent = 'x';
+    expect(() => copyChip(mouseEvent(el))).not.toThrow();
+    expect(el.classList.contains('copied')).toBe(false);
+  });
+
+  it('adds "copied" once the write resolves, then removes it after COPIED_TIMEOUT_MS', async () => {
+    vi.useFakeTimers();
+    stubClipboard();
+    const el = document.createElement('span');
+    el.textContent = 'cmd';
+
+    copyChip(mouseEvent(el));
+    expect(el.classList.contains('copied')).toBe(false); // writeText promise hasn't resolved yet
+
+    await vi.advanceTimersByTimeAsync(0); // flush the writeText microtask
+    expect(el.classList.contains('copied')).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(COPIED_TIMEOUT_MS - 1);
+    expect(el.classList.contains('copied')).toBe(true); // not yet — one ms short
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(el.classList.contains('copied')).toBe(false);
+  });
+});
+
+describe('copyChipOnKeyDown', () => {
+  it.each(['Enter', ' '])('activates copyChip and prevents default on "%s"', async (key) => {
+    vi.useFakeTimers();
+    stubClipboard();
+    const el = document.createElement('span');
+    el.textContent = 'cmd';
+    const event = keyEvent(key, el);
+
+    copyChipOnKeyDown(event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(el.classList.contains('copied')).toBe(true);
+  });
+
+  it.each(['Escape', 'Tab', 'a', 'ArrowDown'])('ignores "%s"', (key) => {
+    const writeText = stubClipboard();
+    const el = document.createElement('span');
+    const event = keyEvent(key, el);
+
+    copyChipOnKeyDown(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/apps/landing/src/lib/agent-system/links.test.ts
+++ b/apps/landing/src/lib/agent-system/links.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { linkPathD, type LinkRect } from './links';
+
+/** Parses `M sx sy C c1x c1y c2x c2y ex ey` into its numeric parts. */
+function parseD(d: string) {
+  const match =
+    /^M(-?[\d.]+) (-?[\d.]+) C(-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+)$/.exec(
+      d
+    );
+  if (!match) throw new Error(`unparseable path d: ${d}`);
+  const [, sx, sy, c1x, c1y, c2x, c2y, ex, ey] = match;
+  return {
+    sx: Number(sx),
+    sy: Number(sy),
+    c1x: Number(c1x),
+    c1y: Number(c1y),
+    c2x: Number(c2x),
+    c2y: Number(c2y),
+    ex: Number(ex),
+    ey: Number(ey),
+  };
+}
+
+const grid = { left: 100, top: 50 };
+
+function rect(overrides: Partial<LinkRect> = {}): LinkRect {
+  return { left: 0, right: 0, top: 0, height: 0, ...overrides };
+}
+
+describe('linkPathD', () => {
+  it('starts at the author rect right-edge midpoint, relative to the grid', () => {
+    const author = rect({ left: 120, right: 220, top: 60, height: 40 });
+    const critic = rect({ left: 400, right: 500, top: 60, height: 40 });
+    const { sx, sy } = parseD(linkPathD(grid, author, critic));
+    expect(sx).toBe(author.right - grid.left);
+    expect(sy).toBe(author.top + author.height / 2 - grid.top);
+  });
+
+  it('ends at the critic rect left-edge midpoint, relative to the grid', () => {
+    const author = rect({ left: 120, right: 220, top: 60, height: 40 });
+    const critic = rect({ left: 400, right: 500, top: 90, height: 60 });
+    const { ex, ey } = parseD(linkPathD(grid, author, critic));
+    expect(ex).toBe(critic.left - grid.left);
+    expect(ey).toBe(critic.top + critic.height / 2 - grid.top);
+  });
+
+  it('is a cubic whose control points exit/enter horizontally (c1y === sy, c2y === ey)', () => {
+    const author = rect({ left: 120, right: 220, top: 60, height: 40 });
+    const critic = rect({ left: 400, right: 500, top: 300, height: 60 });
+    const { sy, ey, c1y, c2y } = parseD(linkPathD(grid, author, critic));
+    expect(c1y).toBe(sy);
+    expect(c2y).toBe(ey);
+  });
+
+  it('places both control points at the horizontal midpoint between start and end', () => {
+    const author = rect({ left: 120, right: 220, top: 60, height: 40 });
+    const critic = rect({ left: 400, right: 500, top: 300, height: 60 });
+    const { sx, ex, c1x, c2x } = parseD(linkPathD(grid, author, critic));
+    const mx = (sx + ex) / 2;
+    expect(c1x).toBe(mx);
+    expect(c2x).toBe(mx);
+  });
+
+  it('collapses to a single point when source and target rects are identical', () => {
+    const same = rect({ left: 200, right: 200, top: 60, height: 40 });
+    const { sx, sy, c1x, c1y, c2x, c2y, ex, ey } = parseD(linkPathD(grid, same, same));
+    expect([sx, c1x, c2x, ex].every((x) => x === sx)).toBe(true);
+    expect([sy, c1y, c2y, ey].every((y) => y === sy)).toBe(true);
+  });
+
+  it('handles zero-size rects (all coordinates collapse to the grid origin)', () => {
+    const zero = rect();
+    const d = linkPathD({ left: 0, top: 0 }, zero, zero);
+    expect(d).toBe('M0 0 C0 0 0 0 0 0');
+  });
+
+  it('is relative to the grid origin, not absolute page coordinates', () => {
+    const author = rect({ left: 300, right: 400, top: 150, height: 50 });
+    const critic = rect({ left: 600, right: 700, top: 150, height: 50 });
+    const atOrigin = linkPathD({ left: 0, top: 0 }, author, critic);
+    const shifted = linkPathD(
+      { left: 100, top: 20 },
+      rect({ ...author, left: author.left + 100, right: author.right + 100, top: author.top + 20 }),
+      rect({ ...critic, left: critic.left + 100, right: critic.right + 100, top: critic.top + 20 })
+    );
+    expect(shifted).toBe(atOrigin);
+  });
+});

--- a/apps/landing/src/lib/agent-system/reveal.test.ts
+++ b/apps/landing/src/lib/agent-system/reveal.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { COUNT_UP_DURATION_MS } from './constants';
+import { countUp, easeOutCubic, sceneProgress } from './reveal';
+
+describe('easeOutCubic', () => {
+  it('is 0 at p=0 and 1 at p=1', () => {
+    expect(easeOutCubic(0)).toBe(0);
+    expect(easeOutCubic(1)).toBe(1);
+  });
+
+  it('is monotonically increasing and decelerating across [0,1]', () => {
+    const samples = [0, 0.2, 0.4, 0.6, 0.8, 1].map(easeOutCubic);
+    const deltas: number[] = [];
+    for (let i = 1; i < samples.length; i += 1) {
+      const prev = samples[i - 1] ?? 0;
+      const cur = samples[i] ?? 0;
+      expect(cur).toBeGreaterThan(prev); // monotonic
+      deltas.push(cur - prev);
+    }
+    // decelerating: each step's gain is smaller than the previous step's
+    for (let i = 1; i < deltas.length; i += 1) {
+      const prev = deltas[i - 1] ?? 0;
+      const cur = deltas[i] ?? 0;
+      expect(cur).toBeLessThan(prev);
+    }
+  });
+
+  it('is not clamped to [0,1] itself — callers clamp p before calling', () => {
+    expect(easeOutCubic(2)).toBe(2); // 1 - (1-2)^3 = 1 - (-1) = 2
+  });
+});
+
+describe('sceneProgress', () => {
+  it.each([
+    [1000, 500, 500, 0, 'far below the viewport (not yet reached) clamps to 0'],
+    [-2000, 500, 500, 1, 'scrolled well past the scene clamps to 1'],
+    [0, 500, 500, 0.5, 'top at the viewport edge with height === viewport is the midpoint'],
+    [500, 500, 500, 0, 'top === viewportHeight is exactly the lower bound'],
+    [-500, 500, 500, 1, 'top === -viewportHeight is exactly the upper bound'],
+  ] as const)(
+    'sceneProgress(top=%d, height=%d, viewportHeight=%d) === %d (%s)',
+    (top, height, viewportHeight, expected, _why) => {
+      expect(sceneProgress(top, height, viewportHeight)).toBe(expected);
+    }
+  );
+
+  it('is NaN (not clamped) when height + viewportHeight is 0 — a 0/0 division', () => {
+    // Documented current behavior: a zero-height scene in a zero-height viewport
+    // never happens in practice, but the clamp comparisons (p < 0, p > 1) are both
+    // false for NaN, so the raw NaN passes through unclamped.
+    expect(Number.isNaN(sceneProgress(0, 0, 0))).toBe(true);
+  });
+});
+
+describe('countUp', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reduced-motion: sets textContent to the final value synchronously, no window access', () => {
+    const el = { textContent: null as string | null } as unknown as HTMLElement;
+    // `window` is deliberately left unstubbed (undefined in this node-env test) to
+    // prove the reduced-motion branch never touches it.
+    countUp(el, 247, true);
+    expect(el.textContent).toBe('247');
+  });
+
+  it('reduced-motion with to=0 still sets "0"', () => {
+    const el = { textContent: null as string | null } as unknown as HTMLElement;
+    countUp(el, 0, true);
+    expect(el.textContent).toBe('0');
+  });
+
+  it('animated: eases from 0 up to `to`, then snaps exactly to `to` on the final frame', () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal('window', {
+      requestAnimationFrame: (cb: FrameRequestCallback) => {
+        frames.push(cb);
+        return frames.length;
+      },
+    });
+    const el = { textContent: null as string | null } as unknown as HTMLElement;
+
+    countUp(el, 200, false);
+    expect(el.textContent).toBe('0'); // synchronous initial paint
+    expect(frames).toHaveLength(1);
+
+    const runNextFrame = (t: number) => {
+      const cb = frames.shift();
+      if (!cb) throw new Error('expected a scheduled animation frame');
+      cb(t);
+    };
+
+    const start = 1000;
+    runNextFrame(start); // p = 0
+    expect(el.textContent).toBe(String(Math.round(easeOutCubic(0) * 200)));
+    expect(frames).toHaveLength(1); // reschedules itself
+
+    runNextFrame(start + COUNT_UP_DURATION_MS / 2); // p = 0.5
+    expect(el.textContent).toBe(String(Math.round(easeOutCubic(0.5) * 200)));
+    expect(frames).toHaveLength(1);
+
+    runNextFrame(start + COUNT_UP_DURATION_MS); // p = 1, done
+    expect(el.textContent).toBe('200');
+    expect(frames).toHaveLength(0); // no further frame scheduled
+  });
+});

--- a/apps/landing/src/lib/architecture-map/filter.test.ts
+++ b/apps/landing/src/lib/architecture-map/filter.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { FIXES, KNOWN_BUGS, type MapEdge, type MapNode } from '@/data/architecture-map';
+
+import { buildAdjacency, hasBadge, passEdgeFilter, passNodeFilter } from './filter';
+
+function node(overrides: Partial<MapNode> = {}): MapNode {
+  return {
+    id: 'n',
+    cluster: 'client',
+    label: 'Node',
+    sub: '',
+    x: 0,
+    y: 0,
+    w: 100,
+    h: 40,
+    color: 'client',
+    role: '',
+    plain: '',
+    path: '',
+    notes: [],
+    tag: [],
+    ...overrides,
+  };
+}
+
+function edge(overrides: Partial<MapEdge> = {}): MapEdge {
+  return { from: 'a', to: 'b', kind: 'normal', tag: [], ...overrides };
+}
+
+// Real ids from architecture-map.ts's FIXES/KNOWN_BUGS data, so hasBadge (and
+// anything built on it) is exercised against the actual dataset rather than a
+// hand-rolled stand-in.
+const FIX_ONLY_ID = Object.keys(FIXES)[0];
+const BUG_ONLY_ID = Object.keys(KNOWN_BUGS)[0];
+const NO_BADGE_ID = 'no-such-node-id';
+
+if (!FIX_ONLY_ID || !BUG_ONLY_ID) {
+  throw new Error('expected FIXES and KNOWN_BUGS to be non-empty in the fixture dataset');
+}
+
+describe('buildAdjacency', () => {
+  it('maps every node to its neighbors in both directions', () => {
+    const nodes = [node({ id: 'a' }), node({ id: 'b' }), node({ id: 'c' })];
+    const edges = [edge({ from: 'a', to: 'b' })];
+    const adj = buildAdjacency(nodes, edges);
+    expect(adj.get('a')).toEqual(new Set(['b']));
+    expect(adj.get('b')).toEqual(new Set(['a']));
+    expect(adj.get('c')).toEqual(new Set()); // present, but no neighbors
+  });
+
+  it('every declared node gets an entry even with an empty edge list', () => {
+    const nodes = [node({ id: 'a' }), node({ id: 'b' })];
+    const adj = buildAdjacency(nodes, []);
+    expect([...adj.keys()]).toEqual(['a', 'b']);
+    expect(adj.get('a')).toEqual(new Set());
+  });
+
+  it('returns an empty map for an empty node list, ignoring dangling edges silently', () => {
+    const adj = buildAdjacency([], [edge({ from: 'a', to: 'b' })]);
+    expect(adj.size).toBe(0);
+  });
+
+  it('dedupes a self-loop and repeated edges via the underlying Set', () => {
+    const nodes = [node({ id: 'a' }), node({ id: 'b' })];
+    const edges = [
+      edge({ from: 'a', to: 'a' }),
+      edge({ from: 'a', to: 'b' }),
+      edge({ from: 'a', to: 'b' }),
+    ];
+    const adj = buildAdjacency(nodes, edges);
+    expect(adj.get('a')).toEqual(new Set(['a', 'b']));
+  });
+});
+
+describe('hasBadge', () => {
+  it('is true for an id with a planned fix, an id with a known bug, and false otherwise', () => {
+    expect(hasBadge(FIX_ONLY_ID)).toBe(true);
+    expect(hasBadge(BUG_ONLY_ID)).toBe(true);
+    expect(hasBadge(NO_BADGE_ID)).toBe(false);
+  });
+});
+
+describe('passNodeFilter', () => {
+  it.each(['all', 'overview'] as const)('"%s" passes every node regardless of tag', (filter) => {
+    expect(passNodeFilter(node({ tag: [] }), filter)).toBe(true);
+    expect(passNodeFilter(node({ tag: ['scraper'] }), filter)).toBe(true);
+  });
+
+  it('"bugs" passes only nodes with a fix or bug badge', () => {
+    expect(passNodeFilter(node({ id: FIX_ONLY_ID }), 'bugs')).toBe(true);
+    expect(passNodeFilter(node({ id: BUG_ONLY_ID }), 'bugs')).toBe(true);
+    expect(passNodeFilter(node({ id: NO_BADGE_ID }), 'bugs')).toBe(false);
+  });
+
+  it('a tag id passes only nodes whose tag array includes it', () => {
+    expect(passNodeFilter(node({ tag: ['scraper', 'core'] }), 'scraper')).toBe(true);
+    expect(passNodeFilter(node({ tag: ['core'] }), 'scraper')).toBe(false);
+    expect(passNodeFilter(node({ tag: [] }), 'scraper')).toBe(false);
+  });
+});
+
+describe('passEdgeFilter', () => {
+  it('"all" passes every edge', () => {
+    expect(passEdgeFilter(edge({ kind: 'normal', tag: [] }), 'all')).toBe(true);
+  });
+
+  it('"bugs" fails every edge unconditionally', () => {
+    expect(passEdgeFilter(edge({ kind: 'critical', tag: ['overview'] }), 'bugs')).toBe(false);
+  });
+
+  describe('"overview" — either endpoint of the OR can pass it', () => {
+    it('passes when kind !== "normal", even with no overview tag', () => {
+      expect(passEdgeFilter(edge({ kind: 'critical', tag: [] }), 'overview')).toBe(true);
+    });
+
+    it('passes a "normal" kind edge when the tag includes "overview"', () => {
+      expect(passEdgeFilter(edge({ kind: 'normal', tag: ['overview'] }), 'overview')).toBe(true);
+    });
+
+    it('passes when both sides of the OR are true', () => {
+      expect(passEdgeFilter(edge({ kind: 'critical', tag: ['overview'] }), 'overview')).toBe(true);
+    });
+
+    it('fails a "normal" kind edge whose tag omits "overview"', () => {
+      expect(passEdgeFilter(edge({ kind: 'normal', tag: ['support'] }), 'overview')).toBe(false);
+    });
+  });
+
+  it('a tag id passes only edges whose tag array includes it', () => {
+    expect(passEdgeFilter(edge({ tag: ['support', 'all'] }), 'support')).toBe(true);
+    expect(passEdgeFilter(edge({ tag: ['all'] }), 'support')).toBe(false);
+  });
+});

--- a/apps/landing/src/lib/architecture-map/geometry.test.ts
+++ b/apps/landing/src/lib/architecture-map/geometry.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MapNode } from '@/data/architecture-map';
+
+import {
+  CANVAS,
+  edgePath,
+  ensureVisible,
+  fit,
+  screenToVB,
+  stageCenter,
+  type Viewport,
+  ZOOM_MAX,
+  ZOOM_MIN,
+  zoomAt,
+} from './geometry';
+
+function node(overrides: Partial<MapNode> = {}): MapNode {
+  return {
+    id: 'n',
+    cluster: 'client',
+    label: 'Node',
+    sub: '',
+    x: 0,
+    y: 0,
+    w: 100,
+    h: 40,
+    color: 'client',
+    role: '',
+    plain: '',
+    path: '',
+    notes: [],
+    tag: [],
+    ...overrides,
+  };
+}
+
+/** Parses `M sx sy C c1x c1y, c2x c2y, ex ey` into its numeric parts. */
+function parseD(d: string) {
+  const match =
+    /^M (-?[\d.]+) (-?[\d.]+) C (-?[\d.]+) (-?[\d.]+), (-?[\d.]+) (-?[\d.]+), (-?[\d.]+) (-?[\d.]+)$/.exec(
+      d
+    );
+  if (!match) throw new Error(`unparseable path d: ${d}`);
+  const [, sx, sy, c1x, c1y, c2x, c2y, ex, ey] = match;
+  return {
+    sx: Number(sx),
+    sy: Number(sy),
+    c1x: Number(c1x),
+    c1y: Number(c1y),
+    c2x: Number(c2x),
+    c2y: Number(c2y),
+    ex: Number(ex),
+    ey: Number(ey),
+  };
+}
+
+describe('edgePath', () => {
+  it("exits at a's right-middle edge and enters at b's left-middle edge when b is to the right", () => {
+    const a = node({ x: 0, y: 0, w: 200, h: 80 });
+    const b = node({ x: 500, y: 100, w: 200, h: 60 });
+    const { d, mx, my } = edgePath(a, b);
+    const { sx, sy, ex, ey, c1y, c2y } = parseD(d);
+    expect(sx).toBe(a.x + a.w);
+    expect(sy).toBe(a.y + a.h / 2);
+    expect(ex).toBe(b.x);
+    expect(ey).toBe(b.y + b.h / 2);
+    // it's a cubic that exits/enters horizontally
+    expect(c1y).toBe(sy);
+    expect(c2y).toBe(ey);
+    expect(mx).toBe((sx + ex) / 2);
+    expect(my).toBe((sy + ey) / 2);
+  });
+
+  it("routes a return edge (b to the left of a) out of a's left edge and into b's right edge", () => {
+    const a = node({ x: 500, y: 0, w: 200, h: 80 });
+    const b = node({ x: 0, y: 100, w: 200, h: 60 });
+    const { sx, ex } = parseD(edgePath(a, b).d);
+    expect(sx).toBe(a.x); // a's LEFT edge, not a.x + a.w
+    expect(ex).toBe(b.x + b.w); // b's RIGHT edge, not b.x
+  });
+
+  it('degenerates to a single point for coincident zero-size rects', () => {
+    const a = node({ x: 10, y: 10, w: 0, h: 0 });
+    const { sx, sy, ex, ey } = parseD(edgePath(a, a).d);
+    expect(sx).toBe(ex);
+    expect(sy).toBe(ey);
+  });
+
+  it('enforces a minimum 40px control-point spread even for adjacent nodes', () => {
+    const a = node({ x: 0, y: 0, w: 100, h: 40 }); // right edge at x=100
+    const b = node({ x: 101, y: 0, w: 100, h: 40 }); // left edge at x=101, 1px gap
+    const { sx, c1x } = parseD(edgePath(a, b).d);
+    expect(Math.abs(c1x - sx)).toBe(40);
+  });
+});
+
+describe('fit', () => {
+  it('scales by the width ratio when width is the constraining dimension', () => {
+    // CANVAS is 3060x1330 (an ~2.3:1 aspect). A tall/narrow rect is width-constrained.
+    const vp = fit({ width: 1000, height: 2000 });
+    const byWidth = (1000 / CANVAS.w) * 0.98;
+    expect(vp.scale).toBeCloseTo(byWidth, 10);
+  });
+
+  it('scales by the height ratio when height is the constraining dimension', () => {
+    // A short/wide rect is height-constrained.
+    const vp = fit({ width: 5000, height: 500 });
+    const byHeight = (500 / CANVAS.h) * 0.98;
+    expect(vp.scale).toBeCloseTo(byHeight, 10);
+  });
+
+  it('centers CANVAS within the given rect, leaving ~2% margin on the constrained axis', () => {
+    const rect = { width: 1000, height: 2000 };
+    const vp = fit(rect);
+    expect(vp.tx).toBe((rect.width - CANVAS.w * vp.scale) / 2);
+    expect(vp.ty).toBe((rect.height - CANVAS.h * vp.scale) / 2);
+    // the constrained dimension (width, here) fits within a whisker of the rect
+    expect(CANVAS.w * vp.scale).toBeLessThanOrEqual(rect.width);
+    expect(CANVAS.w * vp.scale).toBeGreaterThan(rect.width * 0.97);
+  });
+
+  it('does not throw on a zero-size rect', () => {
+    const vp = fit({ width: 0, height: 0 });
+    expect(vp.scale).toBe(0);
+    expect(vp.tx).toBe(0);
+    expect(vp.ty).toBe(0);
+  });
+});
+
+describe('screenToVB', () => {
+  it('subtracts the containing rect origin from the screen point', () => {
+    expect(screenToVB({ left: 10, top: 20 }, 15, 25)).toEqual({ x: 5, y: 5 });
+  });
+
+  it("composed with the viewport's inverse transform, recovers the original canvas point", () => {
+    const rect = { left: 40, top: 12 };
+    const vp: Viewport = { tx: -120, ty: 30, scale: 1.6 };
+    const canvasPoint = { x: 900, y: 250 };
+
+    // Forward: canvas -> local stage coords (as the SVG's translate/scale would render it)
+    const localX = canvasPoint.x * vp.scale + vp.tx;
+    const localY = canvasPoint.y * vp.scale + vp.ty;
+    // ...and local -> screen, as the browser would report it in a pointer event
+    const screenPoint = { x: rect.left + localX, y: rect.top + localY };
+
+    const local = screenToVB(rect, screenPoint.x, screenPoint.y);
+    expect(local).toEqual({ x: localX, y: localY });
+
+    // Inverse: local stage coords -> canvas coords
+    const recovered = { x: (local.x - vp.tx) / vp.scale, y: (local.y - vp.ty) / vp.scale };
+    expect(recovered.x).toBeCloseTo(canvasPoint.x, 10);
+    expect(recovered.y).toBeCloseTo(canvasPoint.y, 10);
+  });
+});
+
+describe('stageCenter', () => {
+  it.each([
+    [{ width: 800, height: 600 }, [400, 300]],
+    [{ width: 0, height: 0 }, [0, 0]],
+    [{ width: 1, height: 1 }, [0.5, 0.5]],
+  ] as const)('stageCenter(%j) === %j', (rect, expected) => {
+    expect(stageCenter(rect)).toEqual(expected);
+  });
+});
+
+describe('zoomAt', () => {
+  const base: Viewport = { tx: 0, ty: 0, scale: 1 };
+
+  it.each([
+    [1, 2, 2, 'mid-range zoom-in is unclamped'],
+    [4, 1, ZOOM_MAX, 'already at max, factor 1 stays at max'],
+    [4, 2, ZOOM_MAX, 'zooming in past max clamps to ZOOM_MAX'],
+    [3, 3, ZOOM_MAX, 'a factor that would overshoot max clamps to it exactly'],
+    [ZOOM_MIN, 1, ZOOM_MIN, 'already at min, factor 1 stays at min'],
+    [0.2, 0.1, ZOOM_MIN, 'zooming out past min clamps to ZOOM_MIN'],
+    [ZOOM_MIN, 0.5, ZOOM_MIN, 'a factor that would undershoot min clamps to it exactly'],
+  ] as const)(
+    'scale=%d, factor=%d -> next.scale === %d (%s)',
+    (scale, factor, expectedScale, _why) => {
+      const next = zoomAt({ ...base, scale }, 100, 50, factor);
+      expect(next.scale).toBe(expectedScale);
+    }
+  );
+
+  it('keeps the focal point fixed under the transform (standard zoom-at-cursor math)', () => {
+    const vp: Viewport = { tx: 0, ty: 0, scale: 1 };
+    const next = zoomAt(vp, 100, 50, 2);
+    expect(next.scale).toBe(2);
+    const k = next.scale / vp.scale;
+    expect(next.tx).toBe(100 - (100 - vp.tx) * k);
+    expect(next.ty).toBe(50 - (50 - vp.ty) * k);
+  });
+
+  it('recomputes tx/ty from the clamped scale, not the raw requested one', () => {
+    const vp: Viewport = { tx: 10, ty: -10, scale: 3 };
+    const next = zoomAt(vp, 0, 0, 3); // raw = 9, clamped to ZOOM_MAX (4)
+    const k = ZOOM_MAX / vp.scale;
+    expect(next.scale).toBe(ZOOM_MAX);
+    expect(next.tx).toBe(0 - (0 - vp.tx) * k);
+    expect(next.ty).toBe(0 - (0 - vp.ty) * k);
+  });
+});
+
+describe('ensureVisible', () => {
+  const stage = { width: 1000, height: 800 };
+
+  it('returns the same viewport instance (no-op) when the node is already comfortably visible', () => {
+    const vp: Viewport = { tx: 0, ty: 0, scale: 1 };
+    const n = node({ x: 400, y: 300, w: 50, h: 50 }); // center at (425, 325), well within margins
+    expect(ensureVisible(vp, stage, n)).toBe(vp);
+  });
+
+  it('pans right when the node center is left of the margin', () => {
+    const vp: Viewport = { tx: 0, ty: 0, scale: 1 };
+    const n = node({ x: -100, y: 300, w: 20, h: 20 }); // center x = -90, left of the 90px margin
+    const next = ensureVisible(vp, stage, n);
+    expect(next.tx).toBeGreaterThan(vp.tx);
+    expect(next.ty).toBe(vp.ty);
+  });
+
+  it('pans left when the node center is right of the margin', () => {
+    const vp: Viewport = { tx: 0, ty: 0, scale: 1 };
+    const n = node({ x: 950, y: 300, w: 20, h: 20 }); // center x = 960, past width(1000)-margin(90)=910
+    const next = ensureVisible(vp, stage, n);
+    expect(next.tx).toBeLessThan(vp.tx);
+  });
+
+  it('pans on both axes when the node is off both a horizontal and vertical edge', () => {
+    const vp: Viewport = { tx: 0, ty: 0, scale: 1 };
+    const n = node({ x: -100, y: -100, w: 20, h: 20 });
+    const next = ensureVisible(vp, stage, n);
+    expect(next.tx).toBeGreaterThan(vp.tx);
+    expect(next.ty).toBeGreaterThan(vp.ty);
+  });
+});


### PR DESCRIPTION
## What

#915 and #916 pulled geometry, scroll and easing math out of `ArchitectureMap` and `AgentFleet` into pure modules **specifically so it could be tested**, then deferred the tests. This pays that back — the last of the three follow-ups from that batch.

**90 new cases** across six co-located test files:

| Module | Covers |
| --- | --- |
| `lib/agent-system/belt.ts` | `STATION_COUNT` invariant, `beltProgress` clamp table, `activeStationX` interpolation, `nearestStationIndex` |
| `lib/agent-system/links.ts` | `linkPathD` anchors, cubic control-point structure, degenerate rects |
| `lib/agent-system/reveal.ts` | `easeOutCubic`, `sceneProgress`, `countUp` (both the reduced-motion sync path and the animated one) |
| `lib/agent-system/clipboard.ts` | `copyChip` precedence + timer, `copyChipOnKeyDown` key filtering |
| `lib/architecture-map/geometry.ts` | `edgePath`, `fit`, `screenToVB`, `stageCenter`, `zoomAt`, `ensureVisible` |
| `lib/architecture-map/filter.ts` | `buildAdjacency`, `hasBadge`, `passNodeFilter`, `passEdgeFilter` |

The cases target **boundaries, not happy paths**: zoom clamped at, below and above `ZOOM_MIN`/`ZOOM_MAX`; `easeOutCubic` checked for *deceleration* by comparing deltas across the domain rather than just pinning endpoints; `screenToVB` round-tripped against its forward transform; `nearestStationIndex` swept for a valid index on every input including ±Infinity; `copyChip` driven through the `.copied` timer with fake timers; `edgePath` asserted structurally rather than by brittle full-string match on the `d`.

Landing suite: **167 → 257 tests**.

## Two source quirks documented, not fixed

Both asserted with explanatory comments rather than silently patched, since this is a test-only change:

- `sceneProgress(0, 0, 0)` returns `NaN` — `0/0` escapes both clamp comparisons, because `NaN < 0` and `NaN > 1` are each `false`. Needs a simultaneously zero-height scene *and* viewport, which a real `getBoundingClientRect` never produces.
- `nearestStationIndex([], x)` returns `0`, an invalid index for an empty array. `centers` derives from `STATIONS`, which is never empty.

Neither is reachable through the real callers. A one-line guard on each (`Number.isFinite` clamp, `-1` sentinel) is cheap hardening if you want it — say the word and it's a fast-follow.

## Verification

`test` (257 pass) · `typecheck` · `lint:strict` · `prettier --check` — all clean.

`testing-reviewer` audited and found nothing blocking. It specifically attacked the risk that geometry tests just restate the source formula: it hand-mutated a sign flip into `zoomAt`'s pan term and traced the assertions through, confirming they fail against the broken implementation. It also verified the RAF stub in `reveal.test.ts` drives three explicit frames deterministically rather than firing once, and confirmed `git diff` touches **no production code**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
