### PR TITLE
test: cover the agent-fleet components and scroll hooks

### DIFF
--- a/apps/landing/src/components/agent-system/AgentFleet.test.tsx
+++ b/apps/landing/src/components/agent-system/AgentFleet.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import { AGENT_COUNT, STATIONS } from '@/data/agent-fleet';
+
+import { AgentFleet } from './AgentFleet';
+
+// jsdom provides neither matchMedia nor IntersectionObserver, and getBoundingClientRect
+// is all-zero — see the repo lesson on jsdom zeroing layout geometry. Every effect
+// under test here (useBeltScrub, useMapLinks, useReveal) reads matchMedia directly on
+// mount, so it must be stubbed for ANY render of AgentFleet/BeltSection/FleetMapSection,
+// not just the reveal-specific tests.
+function stubMatchMedia(opts: { mobile?: boolean; reduce?: boolean } = {}) {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: query.includes('prefers-reduced-motion')
+      ? (opts.reduce ?? false)
+      : (opts.mobile ?? false),
+    media: query,
+    addEventListener() {},
+    removeEventListener() {},
+  }));
+}
+
+// A synchronous, fully controllable IntersectionObserver fake — trigger() runs
+// the real callback immediately instead of depending on real browser geometry.
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+  callback: IntersectionObserverCallback;
+  observed: Element[] = [];
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    FakeIntersectionObserver.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+  unobserve(el: Element) {
+    this.observed = this.observed.filter((e) => e !== el);
+  }
+  disconnect() {
+    this.observed = [];
+  }
+  triggerAll() {
+    const entries = this.observed.map(
+      (target) => ({ target, isIntersecting: true }) as IntersectionObserverEntry
+    );
+    this.callback(entries, this as unknown as IntersectionObserver);
+  }
+  triggerOnly(el: Element) {
+    this.callback(
+      [{ target: el, isIntersecting: true } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver
+    );
+  }
+}
+
+let rafSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  FakeIntersectionObserver.instances = [];
+  rafSpy = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('AgentFleet — composition', () => {
+  it('renders all six sections, in order, as the characterization net for #916', () => {
+    stubMatchMedia();
+    const { container } = render(<AgentFleet />);
+
+    expect(container.querySelector('.agent-fleet')).toBeTruthy();
+
+    // Every h1 and every section heading (h2.section), across all six sections,
+    // in document order. Belt renders its heading twice (sticky + vert layout).
+    const headings = Array.from(container.querySelectorAll('h1, h2.section')).map(
+      (el) => el.textContent
+    );
+    expect(headings).toEqual([
+      'The Agent Fleet',
+      'Intake → Delegation',
+      'The Assembly Line',
+      'The Assembly Line',
+      'The Fleet',
+      'Make Them Work Together',
+      'With vs Without the Fleet',
+    ]);
+  });
+
+  it('renders exactly one belt-title landmark, linked to .belt-section via aria-labelledby', () => {
+    stubMatchMedia();
+    const { container } = render(<AgentFleet />);
+
+    const titles = container.querySelectorAll('#belt-title');
+    expect(titles).toHaveLength(1);
+    expect(container.querySelector('.belt-section')?.getAttribute('aria-labelledby')).toBe(
+      'belt-title'
+    );
+  });
+
+  it('renders each section root landmark exactly once', () => {
+    stubMatchMedia();
+    const { container } = render(<AgentFleet />);
+
+    for (const selector of ['.intake', '.belt-section', '.map-wrap', '.big-prompt', '.versus']) {
+      expect(container.querySelectorAll(selector)).toHaveLength(1);
+    }
+  });
+});
+
+describe('AgentFleet — data-driven rendering', () => {
+  it('renders exactly STATIONS.length stations in both the horizontal and vertical belt layouts', () => {
+    stubMatchMedia();
+    const { container } = render(<AgentFleet />);
+
+    expect(container.querySelectorAll('.belt-track > .station')).toHaveLength(STATIONS.length);
+    expect(container.querySelectorAll('.belt-vert ol > li')).toHaveLength(STATIONS.length);
+  });
+
+  it('renders exactly AGENT_COUNT nodes on the fleet map, and displays AGENT_COUNT in the hero', () => {
+    stubMatchMedia();
+    const { container } = render(<AgentFleet />);
+
+    expect(container.querySelectorAll('.constellation .node')).toHaveLength(AGENT_COUNT);
+    expect(container.querySelector('[data-count]')?.textContent).toBe(String(AGENT_COUNT));
+  });
+});
+
+describe('AgentFleet — useReveal', () => {
+  it('adds "in" to every .reveal element across sections once IntersectionObserver reports it visible', () => {
+    stubMatchMedia({ reduce: false });
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
+    vi.stubGlobal('requestAnimationFrame', rafSpy);
+
+    const { container } = render(<AgentFleet />);
+    const revealEls = Array.from(container.querySelectorAll('.reveal'));
+    // Sanity: every non-belt section contributes at least one .reveal element,
+    // so this genuinely spans the tree (root ref, children markup).
+    expect(revealEls.length).toBeGreaterThan(10);
+    for (const el of revealEls) expect(el.classList.contains('in')).toBe(false);
+
+    const io = FakeIntersectionObserver.instances[0];
+    if (!io) throw new Error('expected useReveal to construct an IntersectionObserver');
+    io.triggerAll();
+
+    for (const el of revealEls) expect(el.classList.contains('in')).toBe(true);
+    // Non-reduced motion animates the hero count-up via requestAnimationFrame.
+    expect(rafSpy).toHaveBeenCalled();
+  });
+
+  it('respects prefers-reduced-motion: the hero count-up sets its final value synchronously, no rAF', () => {
+    stubMatchMedia({ reduce: true });
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
+    vi.stubGlobal('requestAnimationFrame', rafSpy);
+
+    const { container } = render(<AgentFleet />);
+    const countEl = container.querySelector<HTMLElement>('[data-count]');
+    if (!countEl) throw new Error('expected a [data-count] element');
+
+    const io = FakeIntersectionObserver.instances[0];
+    if (!io) throw new Error('expected useReveal to construct an IntersectionObserver');
+    io.triggerOnly(countEl);
+
+    expect(countEl.textContent).toBe(String(AGENT_COUNT));
+    expect(countEl.classList.contains('in')).toBe(true);
+    expect(rafSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/landing/src/components/agent-system/NodeButton.test.tsx
+++ b/apps/landing/src/components/agent-system/NodeButton.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import type { AgentRole } from '@/data/agent-fleet';
+
+import { NodeButton } from './NodeButton';
+
+afterEach(cleanup);
+
+describe('NodeButton', () => {
+  it.each<AgentRole>(['author', 'critic', 'cross'])(
+    'reflects the `selected` prop on aria-expanded for role=%s',
+    (roleClass) => {
+      const { rerender } = render(
+        <NodeButton
+          name="rust-backend-author"
+          roleClass={roleClass}
+          selected={false}
+          onSelect={vi.fn()}
+          onHover={vi.fn()}
+        />
+      );
+      const btn = screen.getByRole('button', { name: 'rust-backend-author' });
+      expect(btn.getAttribute('aria-expanded')).toBe('false');
+
+      rerender(
+        <NodeButton
+          name="rust-backend-author"
+          roleClass={roleClass}
+          selected={true}
+          onSelect={vi.fn()}
+          onHover={vi.fn()}
+        />
+      );
+      expect(btn.getAttribute('aria-expanded')).toBe('true');
+    }
+  );
+
+  it('adds node-author only for roleClass="author"', () => {
+    render(
+      <NodeButton
+        name="x"
+        roleClass="author"
+        selected={false}
+        onSelect={vi.fn()}
+        onHover={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button').className).toContain('node-author');
+    cleanup();
+
+    render(
+      <NodeButton
+        name="x"
+        roleClass="critic"
+        selected={false}
+        onSelect={vi.fn()}
+        onHover={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button').className).not.toContain('node-author');
+  });
+
+  it('calls onSelect(name) on click', () => {
+    const onSelect = vi.fn();
+    render(
+      <NodeButton
+        name="job-match-author"
+        roleClass="author"
+        selected={false}
+        onSelect={onSelect}
+        onHover={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'job-match-author' }));
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith('job-match-author');
+  });
+
+  it.each([
+    ['mouseEnter', 'mouseLeave', 'job-match-author', null],
+    ['focus', 'blur', 'job-match-author', null],
+  ] as const)('%s sets the lit name, %s clears it', (enterEvent, leaveEvent, name, cleared) => {
+    const onHover = vi.fn();
+    render(
+      <NodeButton
+        name={name}
+        roleClass="author"
+        selected={false}
+        onSelect={vi.fn()}
+        onHover={onHover}
+      />
+    );
+    const btn = screen.getByRole('button', { name });
+
+    fireEvent[enterEvent](btn);
+    expect(onHover).toHaveBeenLastCalledWith(name);
+
+    fireEvent[leaveEvent](btn);
+    expect(onHover).toHaveBeenLastCalledWith(cleared);
+  });
+});

--- a/apps/landing/src/components/agent-system/Station.test.tsx
+++ b/apps/landing/src/components/agent-system/Station.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import type { Station } from '@/data/agent-fleet';
+import { STATION_COUNT } from '@/lib/agent-system/belt';
+
+import { StationView } from './Station';
+
+afterEach(cleanup);
+
+const WITH_TAG: Station = {
+  title: 'author implements',
+  access: 'write access',
+  desc: 'the domain author makes the smallest diff that fits.',
+  agentTag: 'rust-backend-author',
+  machine: 'pen',
+  stamp: '✎',
+};
+
+const WITHOUT_TAG: Station = {
+  title: 'intake & triage',
+  access: 'main session',
+  desc: 'paths matched to review-routes.json; first glob wins.',
+  agentTag: '',
+  machine: 'router',
+  stamp: '·',
+};
+
+describe('StationView — horizontal layout', () => {
+  it('renders the station-index label, title, desc, and lit only on index 0', () => {
+    const { container } = render(<StationView station={WITH_TAG} index={1} layout="horizontal" />);
+    const el = container.querySelector('.station');
+    if (!el) throw new Error('expected .station');
+
+    expect(el.getAttribute('data-i')).toBe('1');
+    expect(el.classList.contains('lit')).toBe(false);
+    expect(el.querySelector('.sn')?.textContent).toBe(`2 / ${STATION_COUNT}`);
+    expect(el.querySelector('.st')?.textContent).toBe(WITH_TAG.title);
+    expect(el.querySelector('.sd')?.textContent).toBe(WITH_TAG.desc);
+    expect(el.querySelector('.machine')).toBeTruthy();
+    expect(el.querySelector('.post')).toBeTruthy();
+  });
+
+  it('is lit only when index === 0', () => {
+    const { container } = render(<StationView station={WITH_TAG} index={0} layout="horizontal" />);
+    expect(container.querySelector('.station')?.classList.contains('lit')).toBe(true);
+  });
+
+  it.each([
+    ['renders an .agent-tag when agentTag is set', WITH_TAG, true],
+    ['renders no .agent-tag when agentTag is empty', WITHOUT_TAG, false],
+  ] as const)('%s', (_desc, station, expectTag) => {
+    const { container } = render(<StationView station={station} index={0} layout="horizontal" />);
+    const tag = container.querySelector('.agent-tag');
+    expect(Boolean(tag)).toBe(expectTag);
+    if (expectTag) expect(tag?.textContent).toBe(station.agentTag);
+  });
+});
+
+describe('StationView — vertical layout', () => {
+  it('renders as an <li> with the vertical n/title/desc structure the CSS/scripts rely on', () => {
+    const { container } = render(
+      <ol>
+        <StationView station={WITH_TAG} index={1} layout="vertical" />
+      </ol>
+    );
+    const li = container.querySelector('li');
+    if (!li) throw new Error('expected an <li>');
+
+    expect(li.querySelector('.vmachine')).toBeTruthy();
+    expect(li.querySelector('.vbody')).toBeTruthy();
+    expect(li.querySelector('.vn')?.textContent).toBe(
+      `station 2 / ${STATION_COUNT} · ${WITH_TAG.access}`
+    );
+    expect(li.querySelector('.vt')?.textContent).toBe(WITH_TAG.title);
+    expect(li.querySelector('.vd')?.textContent).toBe(WITH_TAG.desc);
+    // The vertical layout never carries the horizontal-only "lit"/data-i wiring.
+    expect(container.querySelector('.station')).toBeNull();
+  });
+
+  it.each([
+    ['renders an .agent-tag when agentTag is set', WITH_TAG, true],
+    ['renders no .agent-tag when agentTag is empty', WITHOUT_TAG, false],
+  ] as const)('%s', (_desc, station, expectTag) => {
+    const { container } = render(
+      <ol>
+        <StationView station={station} index={0} layout="vertical" />
+      </ol>
+    );
+    const tag = container.querySelector('.agent-tag');
+    expect(Boolean(tag)).toBe(expectTag);
+    if (expectTag) expect(tag?.textContent).toBe(station.agentTag);
+  });
+});

--- a/apps/landing/src/components/agent-system/sections/FleetMapSection.test.tsx
+++ b/apps/landing/src/components/agent-system/sections/FleetMapSection.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import { AGENT_COUNT, BY_NAME } from '@/data/agent-fleet';
+
+import { FleetMapSection } from './FleetMapSection';
+
+// buildLinks() (useMapLinks) reads window.matchMedia synchronously on mount —
+// see the AgentFleet.test.tsx header note; jsdom provides neither matchMedia
+// nor real layout geometry (getBoundingClientRect returns all-zero rects,
+// which is fine here since we only assert class wiring, never coordinates).
+function stubDesktopMatchMedia() {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener() {},
+    removeEventListener() {},
+  }));
+}
+
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  return writeText;
+}
+
+beforeEach(stubDesktopMatchMedia);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+const AUTHOR = 'rust-backend-author';
+const CRITIC = 'rust-backend-architect';
+const authorTuple = BY_NAME.get(AUTHOR);
+if (!authorTuple) throw new Error(`fixture agent not found in BY_NAME: ${AUTHOR}`);
+
+describe('FleetMapSection — data-driven rendering', () => {
+  it('renders exactly one node per PAIRS author/critic plus CROSS_NODES, matching AGENT_COUNT', () => {
+    const { container } = render(<FleetMapSection />);
+    expect(container.querySelectorAll('.node')).toHaveLength(AGENT_COUNT);
+  });
+
+  it('shows the AGENT_COUNT placeholder before any node is selected', () => {
+    render(<FleetMapSection />);
+    expect(
+      screen.getByText((t) => t.includes(`every one of the ${AGENT_COUNT} is here`))
+    ).toBeTruthy();
+  });
+});
+
+describe('FleetMapSection — selection wiring', () => {
+  it('clicking a node sets aria-expanded and renders its detail panel from the data', () => {
+    const { container } = render(<FleetMapSection />);
+    const btn = screen.getByRole('button', { name: AUTHOR });
+
+    fireEvent.click(btn);
+
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+    expect(container.querySelector('.d-name')?.textContent).toBe(authorTuple[0]);
+    expect(container.querySelector('.d-role')?.textContent).toBe(authorTuple[2]);
+    const copyChip = container.querySelector('.copy-cmd');
+    expect(copyChip?.textContent).toBe(authorTuple[5]);
+    expect(copyChip?.getAttribute('data-copy')).toBe(authorTuple[5]);
+  });
+
+  it('moving the selection to another node clears aria-expanded on the previous one', () => {
+    render(<FleetMapSection />);
+    const first = screen.getByRole('button', { name: AUTHOR });
+    const second = screen.getByRole('button', { name: CRITIC });
+
+    fireEvent.click(first);
+    expect(first.getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.click(second);
+    expect(first.getAttribute('aria-expanded')).toBe('false');
+    expect(second.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('hovering a paired node lights its link path, and clears it on mouse-leave', () => {
+    const { container } = render(<FleetMapSection />);
+    const btn = screen.getByRole('button', { name: AUTHOR });
+    const path = container.querySelector(`path[data-pair="${AUTHOR}|${CRITIC}"]`);
+    if (!path) throw new Error('expected a link path for the author/critic pair');
+    expect(path.classList.contains('lit')).toBe(false);
+
+    fireEvent.mouseEnter(btn);
+    expect(path.classList.contains('lit')).toBe(true);
+
+    fireEvent.mouseLeave(btn);
+    expect(path.classList.contains('lit')).toBe(false);
+  });
+});
+
+describe('FleetMapSection — copy chip wiring', () => {
+  it('copies the delegate example on click', () => {
+    const writeText = stubClipboard();
+    const { container } = render(<FleetMapSection />);
+    fireEvent.click(screen.getByRole('button', { name: AUTHOR }));
+    const chip = container.querySelector('.copy-cmd');
+    if (!chip) throw new Error('expected a copy chip once a node is selected');
+
+    fireEvent.click(chip);
+
+    expect(writeText).toHaveBeenCalledWith(authorTuple[5]);
+  });
+
+  it.each(['Enter', ' '])('copies on key "%s"', (key) => {
+    const writeText = stubClipboard();
+    const { container } = render(<FleetMapSection />);
+    fireEvent.click(screen.getByRole('button', { name: AUTHOR }));
+    const chip = container.querySelector('.copy-cmd');
+    if (!chip) throw new Error('expected a copy chip once a node is selected');
+
+    fireEvent.keyDown(chip, { key });
+
+    expect(writeText).toHaveBeenCalledWith(authorTuple[5]);
+  });
+
+  it.each(['Escape', 'Tab', 'a'])('does not copy on key "%s"', (key) => {
+    const writeText = stubClipboard();
+    const { container } = render(<FleetMapSection />);
+    fireEvent.click(screen.getByRole('button', { name: AUTHOR }));
+    const chip = container.querySelector('.copy-cmd');
+    if (!chip) throw new Error('expected a copy chip once a node is selected');
+
+    fireEvent.keyDown(chip, { key });
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});
+
+describe('FleetMapSection — NodeButton identity (the #916 remount regression)', () => {
+  it('does not remount an already-focused node when an unrelated hover/selection re-render fires', () => {
+    render(<FleetMapSection />);
+    const focused = screen.getByRole('button', { name: AUTHOR });
+    const other = screen.getByRole('button', { name: CRITIC });
+
+    focused.focus();
+    expect(document.activeElement).toBe(focused);
+
+    // Hovering a *different* node updates FleetMapSection's `litName` state,
+    // re-rendering the whole node list. If NodeButton were still defined
+    // inside FleetMapSection's render body (the pre-#916 shape), React would
+    // see a brand-new component type at every node's position on this
+    // re-render and remount them all, destroying `focused`'s DOM node and
+    // losing focus. Verified against a local harness that this genuinely
+    // fails for an inline-defined child component (see PR notes).
+    fireEvent.mouseEnter(other);
+
+    expect(document.activeElement).toBe(focused);
+  });
+
+  it('also survives a re-render triggered by clicking (selecting) a different node', () => {
+    render(<FleetMapSection />);
+    const focused = screen.getByRole('button', { name: AUTHOR });
+    const other = screen.getByRole('button', { name: CRITIC });
+
+    focused.focus();
+    fireEvent.click(other);
+
+    expect(document.activeElement).toBe(focused);
+  });
+});

--- a/apps/landing/src/components/agent-system/sections/IntakeSection.test.tsx
+++ b/apps/landing/src/components/agent-system/sections/IntakeSection.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import { ROUTES } from '@/data/agent-fleet';
+
+import { IntakeSection } from './IntakeSection';
+
+afterEach(cleanup);
+
+// Mirrors IntakeSection.tsx's private ROUTE_ROW_CLASS map, for assertion only
+// (not exported — it's an internal styling lookup, not part of the public API).
+const ROUTE_ROW_CLASS: Record<'author' | 'critic' | 'secondary' | 'gate', string> = {
+  author: '',
+  critic: 'crit',
+  secondary: 'sec',
+  gate: 'gate',
+};
+
+describe('IntakeSection', () => {
+  it('shows the placeholder and no aria-pressed issue before any selection', () => {
+    render(<IntakeSection />);
+    expect(screen.getByText('pick an issue to see who handles it.')).toBeTruthy();
+    for (const btn of screen.getAllByRole('button')) {
+      expect(btn.getAttribute('aria-pressed')).toBe('false');
+    }
+  });
+
+  it.each(ROUTES)('clicking "$issue" displays its route: title, area, and every row', (route) => {
+    const { container } = render(<IntakeSection />);
+    fireEvent.click(screen.getByRole('button', { name: route.issue }));
+
+    expect(screen.getByRole('button', { name: route.issue }).getAttribute('aria-pressed')).toBe(
+      'true'
+    );
+    expect(screen.getByRole('heading', { name: route.title })).toBeTruthy();
+    expect(screen.getByText(route.area)).toBeTruthy();
+
+    const rows = container.querySelectorAll('.flow > li');
+    expect(rows).toHaveLength(route.rows.length);
+    route.rows.forEach((row, i) => {
+      const li = rows[i];
+      if (!li) throw new Error(`expected a row at index ${i}`);
+      if (row.kind === 'area') {
+        expect(li.querySelector('.lbl')?.textContent).toBe('area');
+        expect(li.querySelector('.why')?.textContent).toBe(row.detail);
+      } else {
+        expect(li.querySelector('.lbl')?.textContent).toBe(row.kind);
+        const nameEl = li.querySelector('.who b');
+        expect(nameEl?.textContent).toBe(row.name);
+        expect(nameEl?.className).toBe(ROUTE_ROW_CLASS[row.kind]);
+        expect(li.querySelector('.why')?.textContent).toBe(`— ${row.why}`);
+      }
+    });
+  });
+
+  it('switching the selection updates aria-pressed on both the old and new issue buttons', () => {
+    const first = ROUTES[0];
+    const second = ROUTES[1];
+    if (!first || !second) throw new Error('fixture needs at least two ROUTES');
+
+    render(<IntakeSection />);
+    fireEvent.click(screen.getByRole('button', { name: first.issue }));
+    expect(screen.getByRole('button', { name: first.issue }).getAttribute('aria-pressed')).toBe(
+      'true'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: second.issue }));
+    expect(screen.getByRole('button', { name: first.issue }).getAttribute('aria-pressed')).toBe(
+      'false'
+    );
+    expect(screen.getByRole('button', { name: second.issue }).getAttribute('aria-pressed')).toBe(
+      'true'
+    );
+  });
+});

--- a/apps/landing/src/components/agent-system/sections/TogetherSection.test.tsx
+++ b/apps/landing/src/components/agent-system/sections/TogetherSection.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+
+import {
+  SAVE_JOB_PROMPT_COPY,
+  SAVE_JOB_PROMPT_TEXT,
+  WORK_TOGETHER_TEAMS,
+} from '@/data/agent-fleet';
+
+import { TogetherSection } from './TogetherSection';
+
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  return writeText;
+}
+
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+describe('TogetherSection', () => {
+  it('renders the big prompt chip with data-copy set to the copy variant, displaying the text variant', () => {
+    const { container } = render(<TogetherSection />);
+    const chip = container.querySelector('.copy-cmd');
+    expect(chip?.textContent).toBe(SAVE_JOB_PROMPT_TEXT);
+    expect(chip?.getAttribute('data-copy')).toBe(SAVE_JOB_PROMPT_COPY);
+  });
+
+  it('copies the copy-variant text (not the displayed text) on click', () => {
+    const writeText = stubClipboard();
+    const { container } = render(<TogetherSection />);
+    const chip = container.querySelector('.copy-cmd');
+    if (!chip) throw new Error('expected the big-prompt copy chip');
+
+    fireEvent.click(chip);
+
+    expect(writeText).toHaveBeenCalledWith(SAVE_JOB_PROMPT_COPY);
+  });
+
+  it.each(['Enter', ' '])('copies on key "%s"', (key) => {
+    const writeText = stubClipboard();
+    const { container } = render(<TogetherSection />);
+    const chip = container.querySelector('.copy-cmd');
+    if (!chip) throw new Error('expected the big-prompt copy chip');
+
+    fireEvent.keyDown(chip, { key });
+
+    expect(writeText).toHaveBeenCalledWith(SAVE_JOB_PROMPT_COPY);
+  });
+
+  it.each(['Escape', 'Tab', 'a'])('does not copy on key "%s"', (key) => {
+    const writeText = stubClipboard();
+    const { container } = render(<TogetherSection />);
+    const chip = container.querySelector('.copy-cmd');
+    if (!chip) throw new Error('expected the big-prompt copy chip');
+
+    fireEvent.keyDown(chip, { key });
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('renders every WORK_TOGETHER_TEAMS card from the data', () => {
+    const { container } = render(<TogetherSection />);
+    const cards = container.querySelectorAll('.team');
+    expect(cards).toHaveLength(WORK_TOGETHER_TEAMS.length);
+    WORK_TOGETHER_TEAMS.forEach((team, i) => {
+      const card = cards[i];
+      if (!card) throw new Error(`expected a team card at index ${i}`);
+      expect(card.querySelector('h4')?.textContent).toBe(team.title);
+
+      const rows = card.querySelectorAll('li');
+      expect(rows).toHaveLength(team.items.length);
+
+      // Counts alone would pass on a dropped <code> wrapper or a reordered
+      // segment, so pin each row's flattened text AND which segments are
+      // <code> — the code/text split is the whole point of the data shape.
+      team.items.forEach((segments, j) => {
+        const row = rows[j];
+        if (!row) throw new Error(`expected row ${j} of team ${i}`);
+        expect(row.textContent).toBe(segments.map((s) => ('code' in s ? s.code : s.text)).join(''));
+        expect([...row.querySelectorAll('code')].map((c) => c.textContent)).toEqual(
+          segments.flatMap((s) => ('code' in s ? [s.code] : []))
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

`AgentFleet.tsx` had **no test at all**. #916 split its 830 lines into six sections, three hooks and five small components with code review as the only gate — it was the last untested surface from the landing refactor batch. This closes it.

**49 cases** across `AgentFleet`, `NodeButton`, `Station`, `IntakeSection`, `FleetMapSection` and `TogetherSection`. Landing suite: **257 → 306**.

## The headline pair

#916 hoisted `NodeButton` out of the render body because a fresh component identity on every render made React unmount and remount every node, dropping focus and restarting transitions. Two tests pin that fix.

Rather than assume they work, I proved it: I temporarily re-inlined the real `NodeButton` into `FleetMapSection`'s render body — the actual pre-#916 shape — and ran the file. Both tests failed, with `document.activeElement` falling back to `<body>`:

```
AssertionError: expected <body><div>…(6)</div></body>
              to be <button type="button" …>…</button>
  FleetMapSection.test.tsx:153
  FleetMapSection.test.tsx:164
```

Then reverted; `git diff HEAD` on production files is empty. The two cases cover the two distinct state paths that trigger the re-render — hovering (`litName`) and clicking (`selected`).

## The rest

Targeted at wiring that review can't keep honest:

- **Section render order** — an ordered `toEqual` on the heading array, so a reorder fails, not just a drop.
- **`useReveal` across children** — the hook lives at the root while `.reveal`/`.draw` markup is in six sections. Driven by a synchronous fake `IntersectionObserver`, asserting elements from multiple sections, so moving the hook into one section fails.
- **`prefers-reduced-motion`** skips the `requestAnimationFrame` path.
- **Both copy chips** write the *copy* string, not the displayed one — those genuinely differ.
- **Every rendered list derives from `data/agent-fleet.ts`** (`STATIONS.length`, `AGENT_COUNT`, `it.each(ROUTES)`, `WORK_TOGETHER_TEAMS`), so adding data needs no test edit but dropping one from the render fails.
- **`Station`** renders both the horizontal `.station` and vertical `.belt-vert` shapes from one component.

`matchMedia`, `IntersectionObserver`, `requestAnimationFrame` and `navigator.clipboard` are stubbed deterministically; no assertion depends on layout geometry, since jsdom has none.

## Verification

`test` (306 pass) · `typecheck` · `lint:strict` · `prettier --check` — all clean. **No production code changed.**

`testing-reviewer` audited and ran the suite shuffled (`--sequence.shuffle`) and in isolation to rule out stub leakage and ordering dependence — both green. Its one MEDIUM finding is fixed here: the `WORK_TOGETHER_TEAMS` test asserted card and row *counts* but never segment content, so a dropped `<code>` wrapper or reordered segment would have passed. It now pins each row's flattened text and which segments are `<code>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
