### PR TITLE
ci: add a blocking accessibility gate for the landing site

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -524,6 +524,28 @@ jobs:
         continue-on-error: true
         uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2.12.2
 
+      # Build the landing static export once, then reuse it for the a11y gate
+      # below — no separate job, reuses the Chromium already installed above
+      # for the Storybook vitest project. Unlike the desktop's advisory a11y
+      # checks, this one BLOCKS the build (see check-a11y.mjs's header for
+      # why: the landing site's WCAG A/AA baseline is 0, so any violation
+      # found here is a regression on the published /accessibility claim).
+      - name: 🏗️ Build landing (static export)
+        id: landing-build
+        continue-on-error: true
+        run: |
+          echo "::group::Building @ajh/landing (static export)"
+          pnpm --filter @ajh/landing build
+          echo "::endgroup::"
+
+      - name: ♿ Landing Accessibility Gate
+        id: landing-a11y
+        continue-on-error: true
+        run: |
+          echo "::group::Scanning out/ with axe-core (WCAG A/AA)"
+          pnpm --filter @ajh/landing check:a11y
+          echo "::endgroup::"
+
       # cargo-llvm-cov collects coverage; cargo-nextest is the test runner
       # (parallel, flaky-retry, faster, clearer output). `cargo llvm-cov nextest`
       # runs the suite ONCE instrumented; `report` formats it afterward. This
@@ -650,10 +672,11 @@ jobs:
           use-actions-summary: true
 
       - name: ❌ Check for Test Failures
-        if: steps.js-tests.outcome == 'failure' || steps.rust-tests.outcome == 'failure'
+        if: steps.js-tests.outcome == 'failure' || steps.rust-tests.outcome == 'failure' || steps.landing-build.outcome == 'failure' || steps.landing-a11y.outcome == 'failure'
         run: |
-          echo "::error::Tests or coverage thresholds failed. Run 'pnpm test:coverage' locally to reproduce."
-          echo "::error::Check the test output above for specific failures."
+          echo "::error::Tests, coverage thresholds, or the landing a11y gate failed."
+          echo "::error::Repro: 'pnpm test:coverage', or 'pnpm --filter @ajh/landing build && pnpm --filter @ajh/landing check:a11y'."
+          echo "::error::Check the output above for specific failures."
           exit 1
 
       - name: 📊 Upload Test Results on Failure

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "check:parity": "node scripts/check-parity.mjs",
+    "check:a11y": "node scripts/check-a11y.mjs",
     "gen:fonts": "node scripts/selfhost-fonts.mjs"
   },
   "dependencies": {
@@ -18,12 +19,14 @@
   },
   "//typescript": "Pinned to 6.x (newest working): Next 16's build-time verifyTypeScriptSetup does not recognize TS 7's native-compiler package layout — it tries to auto-install typescript and crashes the build worker. Revisit when Next supports the TS 7 compiler.",
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "26.1.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.4",
     "jsdom": "^30.0.0",
+    "playwright": "^1.62.0",
     "typescript": "6.0.3",
     "vite": "^8.1.5",
     "vitest": "^4.1.10"

--- a/apps/landing/scripts/check-a11y.mjs
+++ b/apps/landing/scripts/check-a11y.mjs
@@ -1,0 +1,245 @@
+// PERMANENT, BLOCKING accessibility gate for the built landing site (out/).
+//
+// Why blocking (unlike every other a11y check in this repo): PR #924
+// (2026-08-01) fixed every WCAG A/AA violation this project could find and
+// published /accessibility, which STATES "0 violations across all 9 landing
+// pages". Nothing re-checked that claim before this file existed — every
+// #924 scan ran from a throwaway script under apps/desktop/, the only place
+// @axe-core/playwright already resolved. Because the baseline is already 0,
+// there is no backlog to burn down, so any new violation this gate finds IS
+// a regression — it is allowed to fail the build. That is deliberately
+// DIFFERENT from every other a11y check here, which stays advisory because
+// its surface ISN'T clean yet:
+//   - apps/desktop/e2e/a11y.spec.ts — logs violations, never fails the run
+//   - eslint.a11y.config.mjs        — warn-only jsx-a11y pass, kept out of
+//                                      the strict `--max-warnings 0` lint
+//   - .lighthouserc.json            — accessibility score is a "warn" assertion
+// Do not "harmonise" this file down to advisory to match those — they're
+// advisory because their surface isn't clean; this one's baseline is 0, so
+// blocking is the correct (and only honest) behaviour.
+//
+// How: serve the BUILT out/ with node:http (no server dep — mirrors
+// check-parity.mjs), drive headless Chromium via Playwright + axe-core, and
+// scan EVERY route discovered by globbing out/**/*.html — never a hardcoded
+// list. A hardcoded list is the exact failure mode PR #924's review flagged
+// (a new route had to be added by hand in four places to get covered at
+// all); auto-discovery means a new page is covered the day it exists.
+//
+// Node stdlib + playwright + @axe-core/playwright only. Exits nonzero on ANY
+// WCAG 2a/2aa/21a/21aa/22aa violation on ANY discovered route. Wired as
+// `check:a11y`; run after a build (`next build` emits out/).
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { dirname, extname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import AxeBuilder from '@axe-core/playwright';
+import { chromium } from 'playwright';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appDir = join(here, '..');
+const outDir = join(appDir, 'out');
+
+// The exact tag set /accessibility's numbers were measured with (see
+// Conformance.tsx's "Known barriers" card). Do NOT widen this to axe's
+// `best-practice` rules — the statement targets WCAG A/AA only, and the
+// desktop home view has two known best-practice findings (landmark-unique,
+// region) deliberately left out of scope. Widening here would fail this
+// gate on things the published statement never claimed to have fixed.
+const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'];
+
+const VIEWPORT = { width: 1280, height: 900 };
+
+// Reveal/scroll-driven pages need extra settle time after `load`: /world
+// builds its entire DOM client-side (WorldClient mounts a vendored scroll-
+// scrubbed engine in a useEffect — the static HTML ships an empty container)
+// and /creature runs a doodle reveal sequence on mount. Scanning before that
+// settles would flag the pre-mount/mid-transition state, not the real page.
+// Keyed by route (what page.goto() uses), not file.
+const SETTLE_MS = { '/world': 1500, '/creature': 1000 };
+const DEFAULT_SETTLE_MS = 300;
+
+// Pages intentionally excluded from the gate. Auto-discovery still finds
+// them — nothing is hidden — they're just not held to WCAG A/AA here, each
+// for a stated reason. A trailing '/' excludes the whole subtree. Add an
+// entry ONLY with a comment explaining why: silent exclusion is the exact
+// failure mode this file exists to catch. Disclose every exclusion on
+// /accessibility too (Conformance.tsx's Known barriers section).
+const EXCLUDED_ROUTES = [
+  // Third-party output of `benchmark-action/github-action-benchmark`
+  // v1.22.1, regenerated wholesale by the `benchmark` job in
+  // .github/workflows/quality.yml (`benchmark-data-dir-path:
+  // apps/landing/public/benchmarks`) on every push-to-main perf run — a fix
+  // committed here would be silently overwritten by the next run, so it
+  // isn't fixable in this repo. First scan (2026-08-01) found two
+  // violations, both disclosed as a known barrier on /accessibility:
+  // color-contrast on #dl-button (white on #3298dc, 3.15:1, needs 4.5:1)
+  // and html-has-lang (missing lang on <html>).
+  '/benchmarks/',
+  // Storybook's own static build (`storybook build`, not `next build`) —
+  // copied into out/storybook only at Pages-deploy time (pages.yml, which
+  // runs AFTER this gate's `next build` step), so `next build` alone never
+  // produces it and this script won't discover it in CI. Listed anyway for
+  // anyone who builds the full deploy shape locally and runs this gate
+  // against it: same category as /benchmarks/ — bundled third-party markup
+  // we don't author, never audited.
+  '/storybook/',
+];
+
+function isExcludedRoute(route) {
+  return EXCLUDED_ROUTES.some((r) => route === r || (r.endsWith('/') && route.startsWith(r)));
+}
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.mp4': 'video/mp4',
+  '.mp3': 'audio/mpeg',
+  '.glb': 'model/gltf-binary',
+};
+
+if (!existsSync(outDir)) {
+  console.error('check:a11y FAILED — out/ not found. Run `next build` first.');
+  process.exit(1);
+}
+
+// ── discover routes: glob out/**/*.html, map file path -> served URL ────────
+// An `index.html` (at any depth) serves its directory ('/', '/benchmarks/');
+// every other file serves its path minus '.html' ('/privacy', '/404',
+// '/_not-found'). Mirrors how both this script's own server and GitHub Pages
+// resolve a directory vs. a flat file (next.config.ts: trailingSlash: false).
+function discoverRoutes() {
+  const entries = readdirSync(outDir, { recursive: true, withFileTypes: true });
+  const routes = [];
+  for (const d of entries) {
+    if (!d.isFile() || extname(d.name) !== '.html') continue;
+    const full = join(d.parentPath ?? d.path, d.name);
+    const rel = relative(outDir, full).replaceAll('\\', '/');
+    const route =
+      d.name === 'index.html'
+        ? `/${rel.slice(0, -'index.html'.length)}`
+        : `/${rel.slice(0, -'.html'.length)}`;
+    routes.push({ route, file: full });
+  }
+  routes.sort((a, b) => a.route.localeCompare(b.route));
+  return routes;
+}
+
+// ── static file server over out/ (root-relative asset paths only) ──────────
+function isFile(p) {
+  try {
+    return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function resolveFile(urlPath) {
+  const clean = decodeURIComponent(urlPath.split('?')[0].split('#')[0]).replace(/^\/+/, '');
+  const candidates =
+    clean === '' || clean.endsWith('/')
+      ? [join(outDir, clean, 'index.html')]
+      : [join(outDir, clean), join(outDir, `${clean}.html`)];
+  // isFile (not existsSync): several routes have a same-named directory of
+  // Next RSC prefetch payloads alongside their .html (e.g. out/privacy/ next
+  // to out/privacy.html) — existsSync would match the directory and blow up
+  // readFileSync with EISDIR.
+  return candidates.find(isFile);
+}
+
+const server = createServer((req, res) => {
+  const file = resolveFile(req.url ?? '/');
+  if (!file) {
+    res.writeHead(404).end('not found');
+    return;
+  }
+  res.writeHead(200, { 'Content-Type': MIME_TYPES[extname(file)] ?? 'application/octet-stream' });
+  res.end(readFileSync(file));
+});
+
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const base = `http://127.0.0.1:${server.address().port}`;
+
+// ── scan ──────────────────────────────────────────────────────────────────
+const discovered = discoverRoutes();
+const routes = discovered.filter(({ route }) => !isExcludedRoute(route));
+const skipped = discovered.filter(({ route }) => isExcludedRoute(route));
+if (skipped.length > 0) {
+  console.log(
+    `check:a11y — excluding ${skipped.length} route(s) from the gate (see EXCLUDED_ROUTES): ` +
+      skipped.map((r) => r.route).join(', ')
+  );
+}
+
+const browser = await chromium.launch();
+// @axe-core/playwright refuses a bare browser.newPage() shorthand page (it
+// needs the CDP session a real BrowserContext gives it) — one context, reused
+// across routes since these are independent static pages with no shared state.
+const context = await browser.newContext({ viewport: VIEWPORT });
+const failures = []; // { route, violations }
+
+try {
+  for (const { route } of routes) {
+    const page = await context.newPage();
+    await page.goto(`${base}${route}`, { waitUntil: 'load' });
+    await page.waitForTimeout(SETTLE_MS[route] ?? DEFAULT_SETTLE_MS);
+    const { violations } = await new AxeBuilder({ page }).withTags(TAGS).analyze();
+    await page.close();
+    if (violations.length > 0) failures.push({ route, violations });
+  }
+} finally {
+  await context.close();
+  await browser.close();
+  server.close();
+}
+
+// ── report ────────────────────────────────────────────────────────────────
+// Actionable on its own, no re-run needed: page, rule, impact, node count,
+// every failing selector, and — for color-contrast, the usual offender — the
+// actual fg/bg and measured-vs-required ratio straight from axe's check data.
+if (failures.length > 0) {
+  console.error('check:a11y FAILED — WCAG A/AA violations found:\n');
+  for (const { route, violations } of failures) {
+    for (const v of violations) {
+      console.error(
+        `${route} — [${v.impact ?? 'n/a'}] ${v.id}: ${v.help} (${v.nodes.length} node(s))`
+      );
+      for (const node of v.nodes) {
+        console.error(`    selector: ${node.target.join(' ')}`);
+        for (const check of node.any) {
+          if (check.id !== 'color-contrast' || !check.data) continue;
+          const { fgColor, bgColor, contrastRatio, expectedContrastRatio } = check.data;
+          console.error(
+            `    fg ${fgColor} / bg ${bgColor} — measured ${contrastRatio}, needs ${expectedContrastRatio}`
+          );
+        }
+      }
+    }
+    console.error('');
+  }
+  const violationCount = failures.reduce((n, f) => n + f.violations.length, 0);
+  console.error(
+    `${failures.length} page(s), ${violationCount} violation rule(s). check:a11y is BLOCKING — fix the ` +
+      'regression, do not weaken or skip this gate.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `check:a11y OK — ${routes.length} page(s) scanned, 0 WCAG A/AA violations` +
+    (skipped.length > 0 ? ` (${skipped.length} page(s) excluded, see EXCLUDED_ROUTES).` : '.')
+);

--- a/apps/landing/scripts/check-a11y.mjs
+++ b/apps/landing/scripts/check-a11y.mjs
@@ -29,9 +29,9 @@
 // WCAG 2a/2aa/21a/21aa/22aa violation on ANY discovered route. Wired as
 // `check:a11y`; run after a build (`next build` emits out/).
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { dirname, extname, join, relative, resolve, sep } from 'node:path';
+import { dirname, extname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import AxeBuilder from '@axe-core/playwright';
@@ -140,38 +140,35 @@ function discoverRoutes() {
 }
 
 // ── static file server over out/ (root-relative asset paths only) ──────────
-function isFile(p) {
-  try {
-    return statSync(p).isFile();
-  } catch {
-    return false;
+// The request path NEVER reaches a path expression. Walking out/ once up front
+// and serving only from the resulting allowlist means traversal is impossible
+// by construction, rather than by a check someone can later reorder or drop —
+// `/../../etc/passwd` is simply not a key. (An earlier version built the path
+// with join() and validated it afterwards; CodeQL flagged that as
+// path-injection and was right to, since the tainted value still reached the
+// sink. Removing the sink beats sanitising it.)
+//
+// Only real files are indexed, so a route whose .html sits beside a same-named
+// directory of Next RSC prefetch payloads (out/privacy.html next to
+// out/privacy/) can't resolve to the directory and blow up readFileSync.
+function buildServableFiles() {
+  const files = new Map();
+  for (const d of readdirSync(outDir, { recursive: true, withFileTypes: true })) {
+    if (!d.isFile()) continue;
+    const abs = join(d.parentPath ?? d.path, d.name);
+    const rel = relative(outDir, abs).replaceAll('\\', '/');
+    files.set(`/${rel}`, abs); // /privacy.html, /fonts/fonts.css, /scripts/x.js
+    if (!rel.endsWith('.html')) continue;
+    files.set(`/${rel.slice(0, -'.html'.length)}`, abs); // /privacy (trailingSlash: false)
+    if (d.name === 'index.html') files.set(`/${rel.slice(0, -'index.html'.length)}`, abs); // '/', '/benchmarks/'
   }
+  return files;
 }
 
-// Every served path must resolve to something INSIDE out/. Stripping leading
-// slashes is not enough — `/../../etc/passwd` still escapes via join(). The
-// server is loopback-only on an ephemeral port for the seconds a scan takes,
-// so the real-world risk is negligible, but CodeQL flags the unchecked join
-// as a path-traversal sink and it is right to: this is the containment check,
-// not a suppression.
-const outRoot = resolve(outDir);
-function insideOut(candidate) {
-  const abs = resolve(candidate);
-  return abs === outRoot || abs.startsWith(outRoot + sep);
-}
+const SERVABLE = buildServableFiles();
 
 function resolveFile(urlPath) {
-  const clean = decodeURIComponent(urlPath.split('?')[0].split('#')[0]).replace(/^\/+/, '');
-  const candidates = (
-    clean === '' || clean.endsWith('/')
-      ? [join(outDir, clean, 'index.html')]
-      : [join(outDir, clean), join(outDir, `${clean}.html`)]
-  ).filter(insideOut);
-  // isFile (not existsSync): several routes have a same-named directory of
-  // Next RSC prefetch payloads alongside their .html (e.g. out/privacy/ next
-  // to out/privacy.html) — existsSync would match the directory and blow up
-  // readFileSync with EISDIR.
-  return candidates.find(isFile);
+  return SERVABLE.get(decodeURIComponent(urlPath.split('?')[0].split('#')[0]));
 }
 
 const server = createServer((req, res) => {

--- a/apps/landing/scripts/check-a11y.mjs
+++ b/apps/landing/scripts/check-a11y.mjs
@@ -31,7 +31,7 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { dirname, extname, join, relative } from 'node:path';
+import { dirname, extname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import AxeBuilder from '@axe-core/playwright';
@@ -148,12 +148,25 @@ function isFile(p) {
   }
 }
 
+// Every served path must resolve to something INSIDE out/. Stripping leading
+// slashes is not enough — `/../../etc/passwd` still escapes via join(). The
+// server is loopback-only on an ephemeral port for the seconds a scan takes,
+// so the real-world risk is negligible, but CodeQL flags the unchecked join
+// as a path-traversal sink and it is right to: this is the containment check,
+// not a suppression.
+const outRoot = resolve(outDir);
+function insideOut(candidate) {
+  const abs = resolve(candidate);
+  return abs === outRoot || abs.startsWith(outRoot + sep);
+}
+
 function resolveFile(urlPath) {
   const clean = decodeURIComponent(urlPath.split('?')[0].split('#')[0]).replace(/^\/+/, '');
-  const candidates =
+  const candidates = (
     clean === '' || clean.endsWith('/')
       ? [join(outDir, clean, 'index.html')]
-      : [join(outDir, clean), join(outDir, `${clean}.html`)];
+      : [join(outDir, clean), join(outDir, `${clean}.html`)]
+  ).filter(insideOut);
   // isFile (not existsSync): several routes have a same-named directory of
   // Next RSC prefetch payloads alongside their .html (e.g. out/privacy/ next
   // to out/privacy.html) — existsSync would match the directory and blow up

--- a/apps/landing/src/components/accessibility/sections/Conformance.tsx
+++ b/apps/landing/src/components/accessibility/sections/Conformance.tsx
@@ -50,14 +50,25 @@ export function Conformance() {
         claim of zero barriers — the rest of this section says what's still scoped out, unaudited,
         or otherwise open.
       </p>
+      <p>
+        Both of those were one-off, manually run passes. Since then, a permanent gate (
+        <code>apps/landing/scripts/check-a11y.mjs</code>) re-runs the same axe-core scan on every
+        landing pull request and <b>blocks the merge</b> on any violation — this one doesn't stop
+        repeating. Its auto-discovery found three routes neither manual pass had ever scanned (
+        <code>/404</code>, <code>/_not-found</code>, <code>/mission-control</code>) and, on its
+        first run, caught one real barrier: see <code>/mission-control</code> below.
+      </p>
       <div className="card">
         <span className="label">Landing site</span>
         <p style={{ marginTop: '0' }}>
-          0 violations across all 9 pages (<code>/</code>, <code>/download</code>,{' '}
-          <code>/how-it-works</code>, <code>/privacy</code>, <code>/accessibility</code>,{' '}
-          <code>/creature</code>, <code>/world</code>, <code>/architecture-map</code>,{' '}
-          <code>/agent-system</code>). Three barriers an earlier version of this page listed here
-          have since been fixed:
+          0 violations across the <b>12 routes</b> the permanent gate covers (<code>/</code>,{' '}
+          <code>/download</code>, <code>/how-it-works</code>, <code>/privacy</code>,{' '}
+          <code>/accessibility</code>, <code>/creature</code>, <code>/world</code>,{' '}
+          <code>/architecture-map</code>, <code>/agent-system</code>, <code>/404</code>,{' '}
+          <code>/_not-found</code>, <code>/mission-control</code>). One more public page,{' '}
+          <code>/benchmarks/</code>, is deliberately excluded from the gate — see the card below,
+          not folded into this "0 violations" figure. Four barriers found across the manual passes
+          and the gate's own first run have since been fixed:
         </p>
         <ul>
           <li>
@@ -80,7 +91,29 @@ export function Conformance() {
             the map underneath it. Confirmed by hand in a browser: focus lands on the sidebar, and
             ArrowDown moves its scroll position.
           </li>
+          <li>
+            <code>/mission-control</code> — the row-title links inherited the page's plain accent
+            red at 4.03:1 on the row background; scoped to the same AA-safe token{' '}
+            <code>.mc-badge.is-stale</code> already used on this exact background, landing at 5.7:1.
+            Found and fixed by the permanent gate's first run — this page was never in scope for the
+            two manual passes above.
+          </li>
         </ul>
+      </div>
+      <div className="card">
+        <span className="label">Landing site — excluded page</span>
+        <p style={{ marginTop: '0' }}>
+          <code>/benchmarks/</code> is <b>excluded from the gate, not passing it</b>. It's generated
+          wholesale by a third-party CI action (
+          <code>benchmark-action/github-action-benchmark</code> v1.22.1, run by the{' '}
+          <code>benchmark</code> job in <code>.github/workflows/quality.yml</code>) and overwritten
+          on every push-to-main perf run, so a fix committed here would be silently clobbered by the
+          next run — there is no way to fix it in this repository. As of the gate's first scan it
+          carries two violations: <b>color-contrast</b> (the download button, white text on{' '}
+          <code>#3298dc</code>, 3.15:1, needs 4.5:1) and <b>html-has-lang</b> (the page's{' '}
+          <code>html</code> element has no <code>lang</code> attribute). It's a public page on this
+          domain with real, disclosed barriers, not a clean bill.
+        </p>
       </div>
       <div className="card">
         <span className="label">Desktop app — home view</span>

--- a/apps/landing/src/components/accessibility/sections/InPlace.tsx
+++ b/apps/landing/src/components/accessibility/sections/InPlace.tsx
@@ -40,6 +40,14 @@ export function InPlace() {
           help overlay with a focus trap, and (fixed 1 August 2026) a keyboard-focusable sidebar
           that scrolls on its own arrow keys instead of panning the map underneath it.
         </li>
+        <li>
+          <b>A permanent, blocking accessibility gate for the landing site.</b>{' '}
+          <code>apps/landing/scripts/check-a11y.mjs</code> re-runs the same axe-core WCAG A/AA scan
+          on every landing pull request in CI and <b>fails the build</b> on any violation — unlike
+          the three desktop checks below, which stay advisory. It auto-discovers every built route
+          instead of scanning a hand-maintained list, currently covering 12 routes (all clean) plus
+          one page it deliberately excludes with a stated reason (see Known barriers above).
+        </li>
       </ul>
       <p>
         Three checks exist in CI for the desktop app, and all three are{' '}

--- a/apps/landing/src/styles/mission-control.css
+++ b/apps/landing/src/styles/mission-control.css
@@ -222,6 +222,19 @@
   flex: 1 1 200px;
   min-width: 0;
 }
+.doc-shell .mc-row__title a {
+  /* .doc-shell a's plain --doc-accent (#e24b4a) is only 4.03:1 on this row's
+     --doc-surface-2 background — same failure mode as .mc-badge.is-stale
+     above; reuse its fix, --doc-accent-text (5.7:1 on --doc-surface-2). The
+     extra .doc-shell prefix isn't decorative: mission-control.css's <style>
+     renders before doc-shell.css's in the document (page.tsx puts this
+     page's <PageStyle> ahead of <DocShell>'s own), so a same-specificity
+     `.mc-row__title a` loses the cascade tie to `.doc-shell a` — this needs
+     to out-specify it, not just out-order it. Found by check-a11y.mjs's
+     first run (2026-08-01) — /mission-control was never in scope for the
+     earlier manual PR #924 audit. */
+  color: var(--doc-accent-text);
+}
 .mc-row__meta {
   color: var(--doc-muted);
   font-size: 12px;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.62.0)
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -290,6 +293,9 @@ importers:
       jsdom:
         specifier: ^30.0.0
         version: 30.0.0
+      playwright:
+        specifier: ^1.62.0
+        version: 1.62.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
Follow-up to #924. That PR fixed every WCAG A/AA violation on the landing site and published `/accessibility`, a public page that **states those results**. Nothing re-checked them — so the fixes could regress silently and the statement would start lying. Every scan in #924 ran from throwaway scripts under `apps/desktop/`, the only place `@axe-core/playwright` already resolved. This makes it permanent.

## The gate

`apps/landing/scripts/check-a11y.mjs` serves the built `out/` with `node:http` (no server dep, mirroring `check-parity.mjs`), drives headless Chromium + axe-core, and scans **every route discovered by globbing `out/**/*.html`** — never a hardcoded list. A hardcoded list is the exact failure mode #924's review flagged, where a new route had to be added by hand in four separate places to be covered at all. Auto-discovery means a new page is covered the day it exists.

Tag set is `wcag2a/wcag2aa/wcag21a/wcag21aa/wcag22aa` — the same set `/accessibility`'s published numbers were measured with, deliberately not widened to best-practice rules.

**It blocks.** That differs from the three desktop a11y checks on purpose, and the file header says so in case someone later tries to harmonise it down:

| check | behaviour | why |
| --- | --- | --- |
| `e2e/a11y.spec.ts` | logs, never fails | surface isn't clean yet |
| `eslint.a11y.config.mjs` | warn-only | surface isn't clean yet |
| `.lighthouserc.json` | warn assertion | surface isn't clean yet |
| **`check:a11y`** | **fails the build** | **baseline is 0 — anything found is a regression against a public claim** |

Runs on **pull requests**, inside the existing test job, reusing the Chromium already installed there for the Storybook vitest project. No new job. (Note `check:parity` runs only in `pages.yml` on push-to-main — post-merge, which would be too late for this.)

## What it found on its first run

Auto-discovery turned up **13 routes, not the 9** previously scanned. Three had never been checked:

- **`/404` and `/_not-found`** — clean.
- **`/mission-control`** — `color-contrast` at **4.03:1** on row-title links, 5 nodes. **Fixed.** `docs-tokens.css` already defines `--doc-accent-text` for exactly this case, and `.mc-badge.is-stale` documents the identical failure. Needed `.doc-shell .mc-row__title a` to out-specify the `.doc-shell a` base rule, which wins on source order because the page renders its own `<PageStyle>` before `DocShell`'s. Now **5.7:1**.
- **`/benchmarks/`** — `color-contrast` 3.15:1 on `#dl-button` plus a missing `lang` on `<html>`. **Excluded, not fixed** — it's generated by `benchmark-action` and overwritten wholesale by `quality.yml`'s `benchmark` job on every push-to-main perf run, so an in-repo edit would be reverted by CI. `EXCLUDED_ROUTES` names the generating workflow and both violations, and the gate **logs the exclusion** rather than skipping silently.

## Statement updated to match

A gate finding a barrier it can't fix is exactly the case `/accessibility` exists for, so the page discloses it rather than quietly keeping a clean number:

- "0 violations across all 9 pages" → **12 routes** the permanent gate covers, with `/404`, `/_not-found` and `/mission-control` named.
- `/mission-control`'s contrast failure added to the fixed-barriers list.
- New card disclosing `/benchmarks/` — a public page on the domain with two violations, excluded because it's third-party-generated. Stated as *excluded, not passing*.
- The gate added under "What's in place", explicitly contrasted as **blocking** against the three desktop checks — whose wording is untouched, because they didn't change.

**Every prior disclosure stands.** Both surfaces remain **partially conformant**; the extension is still *not assessed*; PDFs are still not PDF/UA-1 tagged; the desktop contrast fix is still scoped to the home view (~460 sub-AA `text-foreground/NN` usages elsewhere); still no third-party audit and no AT-user testing. No conformance verdict was upgraded — the `partially conformant` and never-`fully conformant` regression tests still pass.

## Proof the gate bites

A gate that can't fail is worse than no gate, so this was verified rather than assumed: lightening `--red` in `privacy.css` made it fail on both `/privacy` and `/accessibility` (which reuses that stylesheet) with exact selectors, fg/bg colours and measured-vs-required ratios, exit code 1. Reverted, back to green.

```
check:a11y — excluding 1 route(s) from the gate (see EXCLUDED_ROUTES): /benchmarks/
check:a11y OK — 12 page(s) scanned, 0 WCAG A/AA violations (1 page(s) excluded, see EXCLUDED_ROUTES).
```

`@axe-core/playwright` is declared explicitly in `apps/landing` rather than relying on `shamefullyHoist: true` — it resolves either way, but a gate's dependencies shouldn't hinge on a global pnpm setting.

## Cost note

The test job now also builds the landing static export. Chromium is already installed and cached there, so the added cost is the Next build. If that becomes a drag, the build output could be cached or the gate split into its own job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
