### PR TITLE
fix: upload only our own debug files to sentry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,6 +517,25 @@ jobs:
             echo "::error title=No debug files found::No ajh_tauri* artifacts under $BASE/**/release/deps on ${{ matrix.platform }} — nothing was uploaded, so crash reports from this release will show unresolved addresses."
             exit 1
           fi
+
+          # "Non-empty" is not the same as "symbolicatable". Finding
+          # `ajh_tauri.exe` while its `.pdb` is missing would pass the check
+          # above and still ship unresolvable stack traces — this feature's
+          # recurring failure shape. So assert the DEBUG COMPANION each platform
+          # actually produces, as observed in a real release run:
+          #   windows  a separate .pdb
+          #   macos    a .dSYM bundle
+          #   linux    none — DWARF stays inside the binary, nothing to require
+          case "${{ runner.os }}" in
+            Windows) NEED='\.pdb$';  NEED_DESC='a .pdb debug companion' ;;
+            macOS)   NEED='\.dSYM$'; NEED_DESC='a .dSYM debug companion' ;;
+            *)       NEED='';        NEED_DESC='' ;;
+          esac
+          if [ -n "$NEED" ] && ! printf '%s\n' "${DIFS[@]}" | grep -qE "$NEED"; then
+            echo "::error title=Debug companion missing::Found ajh_tauri artifacts on ${{ matrix.platform }} but not $NEED_DESC, so frames from this release will not resolve. Check the release profile's debug/split-debuginfo settings."
+            exit 1
+          fi
+
           printf 'Uploading debug files:\n'
           printf '  %s\n' "${DIFS[@]}"
           npx --yes @sentry/cli@^2 debug-files upload "${DIFS[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -480,8 +480,46 @@ jobs:
           # `split-debuginfo = "packed"` puts them beside the binary in target/.
           # No `--include-sources`: that would ship our source into Sentry, and
           # line tables alone are enough to resolve a frame.
-          npx --yes @sentry/cli@^2 debug-files upload \
-            apps/desktop/src-tauri/target/
+          #
+          # SCOPED, not a directory walk. Handing sentry-cli the whole `target/`
+          # tree uploaded 474 files per leg (~1900 per release): dependency
+          # build scripts, proc-macro .so files, ring/aws-lc-sys object files,
+          # and every third-party system library bundled into the AppImage — all
+          # to symbolicate one binary.
+          #
+          # Paths below are taken from an actual release run, not inferred. On
+          # every platform the debug artifacts live in `release/deps/` under the
+          # LIBRARY name (`ajh_tauri`, underscore) rather than the bin name
+          # (`ajh-tauri`), and the copies under `release/`, `bundle/appimage/`
+          # and `bundle/deb/` are hardlinks that dedupe to the same debug id:
+          #   linux    deps/ajh_tauri-<hash>
+          #   windows  deps/ajh_tauri.exe + deps/ajh_tauri.pdb
+          #   macos    <triple>/deps/ajh_tauri-<hash> + .dSYM
+          # macOS builds with an explicit --target so it nests under <triple>/;
+          # `matrix.target` is empty on the other two, so that path just misses.
+          # Non-debug siblings caught by the glob (.d dep-info) are ignored by
+          # sentry-cli's own scan.
+          BASE="apps/desktop/src-tauri/target"
+          TRIPLE="${{ matrix.target }}"
+          shopt -s nullglob
+          # Only add the per-triple dir when there IS a triple: with TRIPLE empty
+          # the path collapses to the same directory (`target//release/deps`) and
+          # every file gets enumerated twice.
+          DEPS_DIRS=("$BASE/release/deps")
+          if [ -n "$TRIPLE" ]; then DEPS_DIRS+=("$BASE/$TRIPLE/release/deps"); fi
+          DIFS=()
+          for depsdir in "${DEPS_DIRS[@]}"; do
+            if [ -d "$depsdir" ]; then
+              for f in "$depsdir"/ajh_tauri*; do DIFS+=("$f"); done
+            fi
+          done
+          if [ ${#DIFS[@]} -eq 0 ]; then
+            echo "::error title=No debug files found::No ajh_tauri* artifacts under $BASE/**/release/deps on ${{ matrix.platform }} — nothing was uploaded, so crash reports from this release will show unresolved addresses."
+            exit 1
+          fi
+          printf 'Uploading debug files:\n'
+          printf '  %s\n' "${DIFS[@]}"
+          npx --yes @sentry/cli@^2 debug-files upload "${DIFS[@]}"
           # Renderer sourcemaps — emitted as 'hidden', so they exist on disk here
           # but were never referenced from the shipped bundle.
           npx --yes @sentry/cli@^2 sourcemaps inject apps/desktop/dist/


### PR DESCRIPTION
Found by inspecting the first real release run ([30741386889](https://github.com/saeedkolivand/ai-job-hunter-app/actions/runs/30741386889)).

## The good news first

Everything from #927/#929 worked on all four matrix legs: symbol upload `success`, flag step correctly `skipped`, assets published before symbols, no cascade into the updater jobs, `Created release 0.132.0`. **The auth token is valid** — that was the one thing tests could not prove.

## The bug

```
> Uploaded 474 missing debug information files
```

Per leg. ~1900 per release. What actually went up:

```
release/build/aws-lc-sys-.../out/chacha20_poly1305_x86_64.o
release/build/proc-macro2-.../build-script-build
release/deps/libscroll_derive-....so
AI Job Hunter.AppDir/usr/lib/libicudata.so.70
AI Job Hunter.AppDir/usr/lib/libudev.so.1
AI Job Hunter.AppDir/usr/bin/ajh-tauri          ← the only one that matters
```

Dependency build scripts, proc-macro `.so`s, `ring`/`aws-lc-sys` object files, and the third-party system libraries bundled into the AppImage. I had pointed `sentry-cli debug-files upload` at the whole `target/` tree.

## The fix, and why it is derived rather than guessed

Scoped to `ajh_tauri*` under `release/deps`. I took the paths **from that run's logs instead of inferring them**, which turned out to matter — my first attempt at this patch guessed `target/<triple>/release/ajh-tauri.dSYM` and would have been wrong on two platforms:

| Platform | Actual |
| --- | --- |
| Linux | `release/deps/ajh_tauri-<hash>` |
| Windows | `release\deps\ajh_tauri.exe` + **`ajh_tauri.pdb`** |
| macOS | `<triple>/release/deps/ajh_tauri-<hash>` + `.dSYM` |

On every platform the artifacts carry the **library** name (`ajh_tauri`, underscore) and sit in `deps/` — not the bin name at `release/ajh-tauri`. The guessed path would have uploaded the macOS binary **with no debug companion**: symbolication silently degraded, which is this feature's signature failure.

The copies under `release/`, `bundle/appimage/` and `bundle/deb/` are hardlinks that dedupe to the same debug id, so nothing is lost by ignoring them.

Also guarded the per-triple directory behind a non-empty check — with `matrix.target` empty the path collapses to `target//release/deps`, the same directory, enumerating everything twice.

## Verification

Simulated all three real layouts plus the empty case:

```
linux   -> 2: deps/ajh_tauri-fa4fa53a  deps/ajh_tauri-fa4fa53a.d
windows -> 2: deps/ajh_tauri.exe       deps/ajh_tauri.pdb
macos   -> 2: <triple>/deps/ajh_tauri-d8c3e74  <triple>/deps/ajh_tauri-d8c3e74.dSYM
empty   -> 0  (fails loudly, per the existing guard)
```

474 → 2 per leg, debug companion included in every case. YAML parses, step body passes `bash -n`, `continue-on-error` untouched (see ADR-0020 for why it must stay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
