### PR TITLE
fix: make the how-it-works page reachable and add structured data

### DIFF
--- a/apps/landing/scripts/check-parity.mjs
+++ b/apps/landing/scripts/check-parity.mjs
@@ -65,7 +65,7 @@ const PHRASES = [
   'you opened the console, not the installer',
   'brew install --cask ai-job-hunter',
   // how-it-works (/how-it-works)
-  'How It Works (End to End)',
+  'How It Works, Step by Step',
   'you press send',
   // privacy (/privacy)
   'Privacy Policy',

--- a/apps/landing/src/app/accessibility/page.tsx
+++ b/apps/landing/src/app/accessibility/page.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'AI Job Hunter — Accessibility Statement',
     description: 'WCAG 2.2 AA conformance status, known barriers, and how to report one.',
   },

--- a/apps/landing/src/app/accessibility/page.tsx
+++ b/apps/landing/src/app/accessibility/page.tsx
@@ -16,6 +16,14 @@ export const metadata: Metadata = {
       'The WCAG 2.2 AA conformance status of the AI Job Hunter landing site, desktop app and browser extension, known barriers, and how to report one.',
     url: 'https://aijobhunter.app/accessibility',
     type: 'website',
+    images: [
+      {
+        url: '/og-card.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'AI Job Hunter — WCAG 2.2 AA accessibility statement and known barriers.',
+      },
+    ],
   },
   twitter: {
     card: 'summary',

--- a/apps/landing/src/app/agent-system/page.tsx
+++ b/apps/landing/src/app/agent-system/page.tsx
@@ -16,6 +16,14 @@ export const metadata: Metadata = {
       'Paired author + critic per domain. The .claude/ system that builds and reviews this repo, explained.',
     url: 'https://aijobhunter.app/agent-system',
     type: 'website',
+    images: [
+      {
+        url: '/og-card.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'AI Job Hunter — the .claude/ agent fleet that builds and reviews this repo.',
+      },
+    ],
   },
   twitter: {
     card: 'summary',

--- a/apps/landing/src/app/agent-system/page.tsx
+++ b/apps/landing/src/app/agent-system/page.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'AI Job Hunter — The Agent Fleet',
     description:
       'Paired author + critic per domain. The .claude/ system that builds and reviews this repo.',

--- a/apps/landing/src/app/architecture-map/page.tsx
+++ b/apps/landing/src/app/architecture-map/page.tsx
@@ -16,6 +16,14 @@ export const metadata: Metadata = {
       'Interactive architecture map of the local-first Tauri 2 monorepo — every node maps to a real file.',
     url: 'https://aijobhunter.app/architecture-map',
     type: 'website',
+    images: [
+      {
+        url: '/og-card.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'AI Job Hunter — an interactive architecture map of the local-first Tauri 2 monorepo.',
+      },
+    ],
   },
   twitter: {
     card: 'summary',

--- a/apps/landing/src/app/architecture-map/page.tsx
+++ b/apps/landing/src/app/architecture-map/page.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'AI Job Hunter — Architecture Map',
     description: 'Interactive architecture map — every node maps to a real file.',
   },

--- a/apps/landing/src/app/download/page.tsx
+++ b/apps/landing/src/app/download/page.tsx
@@ -9,21 +9,29 @@ import { readStyle } from '@/lib/styles';
 import type { VersionData } from '@/lib/version';
 
 export const metadata: Metadata = {
-  title: 'AI Job Hunter — Download',
+  title: 'AI Job Hunter — Download for macOS, Windows, Linux',
   description:
     'Download the AI Job Hunter desktop app for macOS, Windows, and Linux. A local-first, AI-native job-hunting assistant. Free for personal use, source-available, unsigned, and unemployed.',
   robots: { index: true, follow: true },
   alternates: { canonical: 'https://aijobhunter.app/download' },
   openGraph: {
-    title: 'AI Job Hunter — Download',
+    title: 'TAKE THE APP.',
     description:
       'Get the desktop app for macOS, Windows, and Linux. Plus the browser extension. Local-first. No accounts. Still unemployed.',
     url: 'https://aijobhunter.app/download',
     type: 'website',
+    images: [
+      {
+        url: '/og-card.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'AI Job Hunter — download the desktop app for macOS, Windows, and Linux.',
+      },
+    ],
   },
   twitter: {
     card: 'summary',
-    title: 'AI Job Hunter — Download',
+    title: 'TAKE THE APP.',
     description: 'Get the desktop app for macOS, Windows, and Linux. Plus the browser extension.',
   },
 };

--- a/apps/landing/src/app/download/page.tsx
+++ b/apps/landing/src/app/download/page.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'TAKE THE APP.',
     description: 'Get the desktop app for macOS, Windows, and Linux. Plus the browser extension.',
   },

--- a/apps/landing/src/app/how-it-works/page.tsx
+++ b/apps/landing/src/app/how-it-works/page.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'SEE THE WHOLE PIPELINE.',
     description: 'Click through every layer, from job board to finished application.',
   },

--- a/apps/landing/src/app/how-it-works/page.tsx
+++ b/apps/landing/src/app/how-it-works/page.tsx
@@ -10,8 +10,30 @@ import { readStyle } from '@/lib/styles';
 // → original styles.css → shell override; last :root wins). The copy, the DOM the
 // 55 KB pipeline player queries, and the console egg are all unchanged.
 export const metadata: Metadata = {
-  title: 'AI Job Hunter — How It Works (End to End)',
+  title: 'AI Job Hunter — How It Works, Step by Step',
+  description:
+    'A layer-by-layer, click-through map of the AI Job Hunter pipeline — React UI, Rust core, AI models, scrapers, and disk — from job board to finished application.',
   alternates: { canonical: 'https://aijobhunter.app/how-it-works' },
+  openGraph: {
+    title: 'SEE THE WHOLE PIPELINE.',
+    description:
+      'Click through every layer of the AI Job Hunter pipeline, from job board to finished application.',
+    url: 'https://aijobhunter.app/how-it-works',
+    type: 'website',
+    images: [
+      {
+        url: '/og-card.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'AI Job Hunter — How It Works, click-through architecture of the whole pipeline.',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary',
+    title: 'SEE THE WHOLE PIPELINE.',
+    description: 'Click through every layer, from job board to finished application.',
+  },
 };
 
 export default function HowItWorksPage() {

--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -3,10 +3,26 @@ import type { Metadata } from 'next';
 import { ClientScripts } from '@/components/ClientScripts';
 import { HomeBody } from '@/components/home/HomeBody';
 import { PageStyle } from '@/components/PageStyle';
+import { GITHUB_REPO } from '@/lib/site-links';
 import { readStyle } from '@/lib/styles';
 
+// Structured data for the homepage only — a SoftwareApplication card for search
+// results. No aggregateRating: there are no real reviews, and fabricating one
+// is a Google penalty as well as a lie.
+const SOFTWARE_APPLICATION_JSON_LD = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'AI Job Hunter',
+  description:
+    'A local-first, AI-native job-hunting desktop app: scrapes 24 job boards, writes cover letters and résumés, and drafts every application — you just press send.',
+  applicationCategory: 'BusinessApplication',
+  operatingSystem: 'macOS, Windows, Linux',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  sameAs: GITHUB_REPO,
+};
+
 export const metadata: Metadata = {
-  title: 'AI Job Hunter — please hire him',
+  title: 'AI Job Hunter — Job Search, Résumé & Cover Letters',
   description:
     'Covers 24 job boards (direct scrapers + Adzuna/JSearch aggregator), writes your cover letters, does everything but hit submit. A real desktop app. Also a cry for help.',
   alternates: { canonical: 'https://aijobhunter.app/' },
@@ -40,6 +56,10 @@ export default function HomePage() {
     <>
       <PageStyle css={readStyle('marketing-tokens.css')} />
       <PageStyle css={readStyle('home.css')} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(SOFTWARE_APPLICATION_JSON_LD) }}
+      />
       <HomeBody />
       <ClientScripts srcs={['/scripts/home-0.js']} />
     </>

--- a/apps/landing/src/app/privacy/page.tsx
+++ b/apps/landing/src/app/privacy/page.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'AI Job Hunter — Privacy Policy',
     description:
       'No accounts, no behavioural analytics. Local-first, with opt-out crash reporting. How your data is handled.',

--- a/apps/landing/src/app/privacy/page.tsx
+++ b/apps/landing/src/app/privacy/page.tsx
@@ -17,6 +17,14 @@ export const metadata: Metadata = {
       'How the AI Job Hunter desktop app and browser extension handle your data. No accounts, no behavioural analytics. Local-first, with opt-out crash reporting.',
     url: 'https://aijobhunter.app/privacy',
     type: 'website',
+    images: [
+      {
+        url: '/og-card.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'AI Job Hunter — privacy policy: no accounts, local-first, opt-out crash reporting.',
+      },
+    ],
   },
   twitter: {
     card: 'summary',

--- a/apps/landing/src/components/SiteFooter.test.tsx
+++ b/apps/landing/src/components/SiteFooter.test.tsx
@@ -15,7 +15,7 @@ afterEach(() => {
 // is identical across variants since only the tag (a vs. plain text) differs
 // for the "current" item, never the word itself.
 const FOOT_LINKS_TEXT =
-  'home · download · privacy · accessibility · ▶ the short film · design system · GitHub · Chrome extension · Firefox extension · ♥ sponsor';
+  'home · how it works · download · privacy · accessibility · ▶ the short film · the agent fleet · architecture · design system · GitHub · Chrome extension · Firefox extension · ♥ sponsor';
 
 describe('SiteFooter', () => {
   it('renders the byline', () => {
@@ -35,10 +35,13 @@ describe('SiteFooter', () => {
     const links = Array.from(container.querySelectorAll('.foot-links a'));
     expect(links.map((a) => [a.getAttribute('href'), a.textContent])).toEqual([
       ['/', 'home'],
+      ['/how-it-works', 'how it works'],
       ['/download', 'download'],
       ['/privacy', 'privacy'],
       ['/accessibility', 'accessibility'],
       ['/creature', '▶ the short film'],
+      ['/agent-system', 'the agent fleet'],
+      ['/architecture-map', 'architecture'],
       ['/storybook/', 'design system'],
       [GITHUB_REPO, 'GitHub'],
       [CHROME_EXT, 'Chrome extension'],
@@ -56,9 +59,12 @@ describe('SiteFooter', () => {
     expect(hrefs).not.toContain('/privacy');
     expect(hrefs).toEqual([
       '/',
+      '/how-it-works',
       '/download',
       '/accessibility',
       '/creature',
+      '/agent-system',
+      '/architecture-map',
       '/storybook/',
       GITHUB_REPO,
       CHROME_EXT,
@@ -76,9 +82,12 @@ describe('SiteFooter', () => {
     expect(hrefs).not.toContain('/download');
     expect(hrefs).toEqual([
       '/',
+      '/how-it-works',
       '/privacy',
       '/accessibility',
       '/creature',
+      '/agent-system',
+      '/architecture-map',
       '/storybook/',
       GITHUB_REPO,
       CHROME_EXT,
@@ -96,9 +105,35 @@ describe('SiteFooter', () => {
     expect(hrefs).not.toContain('/accessibility');
     expect(hrefs).toEqual([
       '/',
+      '/how-it-works',
       '/download',
       '/privacy',
       '/creature',
+      '/agent-system',
+      '/architecture-map',
+      '/storybook/',
+      GITHUB_REPO,
+      CHROME_EXT,
+      FIREFOX_EXT,
+      SPONSOR,
+    ]);
+  });
+
+  it('renders "how it works" as plain text (not a link) when current="how-it-works"', () => {
+    const { container } = render(<SiteFooter current="how-it-works" />);
+    expect(container.querySelector('.foot-links')?.textContent).toBe(FOOT_LINKS_TEXT);
+    const hrefs = Array.from(container.querySelectorAll('.foot-links a')).map((a) =>
+      a.getAttribute('href')
+    );
+    expect(hrefs).not.toContain('/how-it-works');
+    expect(hrefs).toEqual([
+      '/',
+      '/download',
+      '/privacy',
+      '/accessibility',
+      '/creature',
+      '/agent-system',
+      '/architecture-map',
       '/storybook/',
       GITHUB_REPO,
       CHROME_EXT,
@@ -121,10 +156,13 @@ describe('SiteFooter', () => {
     const { container } = render(<SiteFooter />);
     for (const href of [
       '/',
+      '/how-it-works',
       '/download',
       '/privacy',
       '/accessibility',
       '/creature',
+      '/agent-system',
+      '/architecture-map',
       '/storybook/',
     ]) {
       const a = container.querySelector(`.foot-links a[href="${href}"]`);

--- a/apps/landing/src/components/SiteFooter.tsx
+++ b/apps/landing/src/components/SiteFooter.tsx
@@ -7,12 +7,18 @@ import { CHROME_EXT, FIREFOX_EXT, GITHUB_REPO, SPONSOR } from '@/lib/site-links'
 // Separators are explicit `{' · '}` strings — JSX drops whitespace-only text
 // between elements, so relying on newlines here would silently lose the ` · `
 // that scripts/check-parity.mjs checks for.
-export function SiteFooter({ current }: { current?: 'download' | 'privacy' | 'accessibility' }) {
+export function SiteFooter({
+  current,
+}: {
+  current?: 'download' | 'privacy' | 'accessibility' | 'how-it-works';
+}) {
   return (
     <footer>
       <p className="byline">made by Saeed, between rejections.</p>
       <p className="foot-links">
         <a href="/">home</a>
+        {' · '}
+        {current === 'how-it-works' ? 'how it works' : <a href="/how-it-works">how it works</a>}
         {' · '}
         {current === 'download' ? 'download' : <a href="/download">download</a>}
         {' · '}
@@ -21,6 +27,10 @@ export function SiteFooter({ current }: { current?: 'download' | 'privacy' | 'ac
         {current === 'accessibility' ? 'accessibility' : <a href="/accessibility">accessibility</a>}
         {' · '}
         <a href="/creature">▶ the short film</a>
+        {' · '}
+        <a href="/agent-system">the agent fleet</a>
+        {' · '}
+        <a href="/architecture-map">architecture</a>
         {' · '}
         <a href="/storybook/">design system</a>
         {' · '}

--- a/apps/landing/src/components/home/sections/Finale.tsx
+++ b/apps/landing/src/components/home/sections/Finale.tsx
@@ -162,8 +162,9 @@ export function Finale() {
         />
       </svg>
       <p className="foot-nav">
-        home · <a href="/download">download</a> · <a href="/privacy">privacy</a> ·{' '}
-        <a href="/accessibility">accessibility</a> · <a href="/creature">▶ the short film</a> ·{' '}
+        home · <a href="/how-it-works">how it works</a> · <a href="/download">download</a> ·{' '}
+        <a href="/privacy">privacy</a> · <a href="/accessibility">accessibility</a> ·{' '}
+        <a href="/creature">▶ the short film</a> ·{' '}
         <a href={GITHUB_REPO} target="_blank" rel="noopener noreferrer">
           GitHub
         </a>{' '}

--- a/apps/landing/src/components/home/sections/Hero.tsx
+++ b/apps/landing/src/components/home/sections/Hero.tsx
@@ -154,6 +154,9 @@ export function Hero() {
         <a className="filmhint reveal" href="/creature">
           ▶ or don't scroll — watch THE CREATURE. he summons a tiny recruiter. it grows. (2:40)
         </a>
+        <a className="filmhint reveal" href="/how-it-works">
+          skeptical? → see how it works, end to end
+        </a>
         <a className="filmhint reveal" href="/download">
           already sold? → just take the app
         </a>

--- a/apps/landing/src/components/how-it-works/HowItWorksBody.test.tsx
+++ b/apps/landing/src/components/how-it-works/HowItWorksBody.test.tsx
@@ -99,12 +99,15 @@ describe('HowItWorksBody', () => {
     );
   });
 
-  it('renders the footer with all links (no "current" page to omit)', () => {
+  it('wires the footer with "how it works" as plain text and the other items as links', () => {
     const { container } = render(<HowItWorksBody />);
     const footLinks = container.querySelector('.foot-links');
+    expect(footLinks?.textContent).toContain('how it works');
+
     const hrefs = Array.from(footLinks?.querySelectorAll('a') ?? []).map((a) =>
       a.getAttribute('href')
     );
+    expect(hrefs).not.toContain('/how-it-works');
     expect(hrefs).toContain('/');
     expect(hrefs).toContain('/download');
     expect(hrefs).toContain('/privacy');

--- a/apps/landing/src/components/how-it-works/HowItWorksBody.tsx
+++ b/apps/landing/src/components/how-it-works/HowItWorksBody.tsx
@@ -32,7 +32,7 @@ export function HowItWorksBody() {
         <Subsystems />
         <CheatSheet />
       </main>
-      <SiteFooter />
+      <SiteFooter current="how-it-works" />
     </div>
   );
 }


### PR DESCRIPTION
Diagnosed from the live Search Console for `https://aijobhunter.app/`, not from a checklist.

## The problem

Google indexes **4 of 9 pages**. Absent: `/how-it-works`, `/agent-system`, `/architecture-map`, `/world`, `/accessibility`.

Indexing tracks internal link count almost monotonically:

| Route | Inbound internal links | Indexed |
|---|---|---|
| `/download` | 7 | ✅ |
| `/privacy` | 5 | ✅ |
| `/creature` | 4 | ✅ |
| `/accessibility` | 3 | ❌ |
| `/world`, `/architecture-map`, `/agent-system` | 1 each | ❌ |
| `/how-it-works` | **0** | ❌ |

`/how-it-works` had **no `<a href="/how-it-works">` anywhere on the site**. Every other occurrence of the string is a stylesheet name, a test, a comment, or `<code>` prose. The most commercially useful page was unreachable by crawl, while a doodle short film and the privacy policy were indexed.

Compounding it, the sitemap had **never been read** — Search Console listed zero submitted or discovered sitemaps, even though `robots.ts` correctly declares it and #922 ships the file. Declaring a sitemap in `robots.txt` is evidently not sufficient. It has now been submitted manually, so the orphans will be discovered regardless; internal links still matter for crawl priority and link equity.

For context on why this matters: 3 months of traffic is **84 impressions, 2 clicks, average position 39.1**, and all 12 queries are brand-navigational. Nothing in the index answers a question anyone searches.

## Changes

- `/how-it-works` now appears in the shared footer, the homepage's own footer row, and one descriptive in-content hero link. `/agent-system` and `/architecture-map` gain footer links.
- `SoftwareApplication` JSON-LD on the homepage — the site had **no** structured data. No `aggregateRating`: there are no real reviews, and inventing one is both a Google penalty and a lie.
- Titles carry a searchable phrase; the joke moves to `openGraph.title`, which is what people actually see when a link is shared.
- The six pages that declared no `openGraph.images` now reuse the existing card.

### Titles changed — easy to veto

| Page | Was | Now |
|---|---|---|
| `/` | `AI Job Hunter — please hire him` | `AI Job Hunter — Job Search, Résumé & Cover Letters` |
| `/how-it-works` | `— How It Works (End to End)` | `— How It Works, Step by Step` |
| `/download` | `— Download` | `— Download for macOS, Windows, Linux` |

`/creature` untouched — it is a standalone creative piece.

## Not fixed, deliberately

The 4 URLs reporting *"not indexed / Alternate page with proper canonical tag"* are `/index.html`, `/download.html`, `?ref=producthunt` and `?ref=launches.uicomet.com` — correct canonicalization working as intended, not a defect.

## Verification

`pnpm --filter @ajh/landing test` 326 passed · `build` emits all 14 static pages · `check:parity` OK (27 signature phrases, 13 legacy links, 7 installer URLs) · `typecheck` · `lint:strict` clean.

`SiteFooter.test.tsx`, `HowItWorksBody.test.tsx` and `scripts/check-parity.mjs` were updated alongside — each asserts exact footer text or a frozen title phrase, and each exists to catch a silently-dropped link, so their intent is preserved rather than loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)