### PR TITLE
fix: stop probing api.openai.com for users who never configured it

### DIFF
--- a/apps/desktop/src/renderer/components/ui/ModelSelector/ModelSelector.privacy.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/ModelSelector.privacy.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * ModelSelector — keyless-provider privacy regression tests
+ * (fix/no-unconfigured-openai-probe).
+ *
+ * ModelSelector builds a `useQueries` model fetch for EVERY cloud provider on
+ * every mount (`cloudProviders.map`), gated per-provider by `canFetchModels`.
+ * The #936 carve-out — `connected || provider === 'openai-compatible'` — had
+ * no requirement that `openai-compatible` be pointed anywhere, so a user who
+ * never touched that provider (e.g. a fully-local Ollama user) still fired
+ * `listProviderModels` for it on every page mounting this component; the Rust
+ * side falls back to `https://api.openai.com/v1` when no base URL is
+ * configured, sending an outbound request with no `Authorization` header.
+ *
+ * Unlike `ModelSelector.test.tsx` (which stubs `@tanstack/react-query`'s
+ * `useQueries` entirely, bypassing `enabled`), this file mounts a real
+ * QueryClient + a mocked AppClient transport — mirroring
+ * `useProviderKeys.test.ts` — so the actual `enabled` wiring is what's under
+ * test, not a stubbed query result.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+import { createMockClient, makeQueryClient, withProviders } from '@/test-support';
+
+import { ModelSelector } from './index';
+
+describe('ModelSelector — openai-compatible model-fetch gating', () => {
+  it('never calls listProviderModels for openai-compatible with no stored key and no base URL', async () => {
+    const listProviderModels = vi.fn().mockResolvedValue([]);
+    const client = createMockClient({
+      'ai.listProviderModels': listProviderModels,
+      'ai.activeConfig': vi.fn().mockResolvedValue({ activeProvider: 'ollama', providers: {} }),
+      'ai.hasProviderKey': vi.fn().mockResolvedValue({ has: false }),
+      'ai.listModels': vi.fn().mockResolvedValue([]),
+      'system.health': vi.fn().mockResolvedValue({ ai: { ready: true }, cliAgents: {} }),
+    });
+    const queryClient = makeQueryClient();
+
+    render(<ModelSelector />, { wrapper: withProviders(client, queryClient) });
+
+    // Wait for the openai-compatible key-status query to genuinely settle
+    // (a real steady state) rather than a fixed sleep before the negative
+    // assertion, which fails in the direction that looks like success.
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryState(['ai', 'models', 'provider-key', 'openai-compatible'])?.status
+      ).toBe('success')
+    );
+
+    expect(listProviderModels).not.toHaveBeenCalled();
+  });
+
+  it('calls listProviderModels for openai-compatible once a base URL is configured, with no key', async () => {
+    const listProviderModels = vi.fn().mockResolvedValue([]);
+    const client = createMockClient({
+      'ai.listProviderModels': listProviderModels,
+      'ai.activeConfig': vi.fn().mockResolvedValue({
+        activeProvider: 'ollama',
+        providers: { 'openai-compatible': { baseUrl: 'http://localhost:1234/v1' } },
+      }),
+      'ai.hasProviderKey': vi.fn().mockResolvedValue({ has: false }),
+      'ai.listModels': vi.fn().mockResolvedValue([]),
+      'system.health': vi.fn().mockResolvedValue({ ai: { ready: true }, cliAgents: {} }),
+    });
+    const queryClient = makeQueryClient();
+
+    render(<ModelSelector />, { wrapper: withProviders(client, queryClient) });
+
+    await waitFor(() =>
+      expect(listProviderModels).toHaveBeenCalledWith({
+        provider: 'openai-compatible',
+        baseUrl: 'http://localhost:1234/v1',
+      })
+    );
+  });
+});

--- a/apps/desktop/src/renderer/components/ui/ModelSelector/ModelSelector.privacy.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/ModelSelector.privacy.test.tsx
@@ -42,16 +42,48 @@ describe('ModelSelector — openai-compatible model-fetch gating', () => {
 
     render(<ModelSelector />, { wrapper: withProviders(client, queryClient) });
 
-    // Wait for the openai-compatible key-status query to genuinely settle
-    // (a real steady state) rather than a fixed sleep before the negative
-    // assertion, which fails in the direction that looks like success.
-    await waitFor(() =>
+    // Wait for BOTH inputs `canFetchModels` reads to genuinely settle — the
+    // key-status query AND the active-config query (the source of the base
+    // URL half of the check, via `baseUrlFor`). Gating on the key query
+    // alone would pass vacuously for a future variant that stubs a `baseUrl`
+    // while still expecting no fetch: `activeConfig` could still be
+    // in-flight at that point, so `baseUrlFor` would read `undefined` and the
+    // assertion would pass for the wrong reason.
+    await waitFor(() => {
       expect(
         queryClient.getQueryState(['ai', 'models', 'provider-key', 'openai-compatible'])?.status
-      ).toBe('success')
-    );
+      ).toBe('success');
+      expect(queryClient.getQueryState(['ai', 'activeConfig'])?.status).toBe('success');
+    });
 
     expect(listProviderModels).not.toHaveBeenCalled();
+  });
+
+  it('calls listProviderModels for openai-compatible when a key is stored, even with no base URL (PR #937 finding 2)', async () => {
+    // The other half of "configured" — authenticated by a stored KEY instead
+    // of a base URL. Must fetch same as any other cloud provider with a key;
+    // this is the network-level twin of the message-level regression test in
+    // ModelSelector.test.tsx (finding 2: the key query being irrelevant to
+    // openai-compatible was hardcoded, not conditional on actually having a
+    // base URL to fall back on).
+    const listProviderModels = vi.fn().mockResolvedValue([]);
+    const client = createMockClient({
+      'ai.listProviderModels': listProviderModels,
+      'ai.activeConfig': vi.fn().mockResolvedValue({ activeProvider: 'ollama', providers: {} }),
+      'ai.hasProviderKey': vi.fn().mockResolvedValue({ has: true }),
+      'ai.listModels': vi.fn().mockResolvedValue([]),
+      'system.health': vi.fn().mockResolvedValue({ ai: { ready: true }, cliAgents: {} }),
+    });
+    const queryClient = makeQueryClient();
+
+    render(<ModelSelector />, { wrapper: withProviders(client, queryClient) });
+
+    await waitFor(() =>
+      expect(listProviderModels).toHaveBeenCalledWith({
+        provider: 'openai-compatible',
+        baseUrl: undefined,
+      })
+    );
   });
 
   it('calls listProviderModels for openai-compatible once a base URL is configured, with no key', async () => {

--- a/apps/desktop/src/renderer/components/ui/ModelSelector/ModelSelector.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/ModelSelector.test.tsx
@@ -68,6 +68,10 @@ let stubbedHealth: {
   data: { cliAgents?: Record<string, { detected: boolean }> } | undefined;
   isLoading: boolean;
 } = { data: undefined, isLoading: false };
+// `openai-compatible`'s stored base URL — the second half of `canFetchModels`'s
+// "actually configured" check (a stored key alone isn't enough for it; see
+// `isProviderConfigured`). Undefined by default so a test opts in explicitly.
+let stubbedOpenAiCompatibleBaseUrl: string | undefined;
 
 // ── Service stubs — prevent QueryClient dependency ────────────────────────────
 
@@ -76,7 +80,10 @@ vi.mock('@/services', () => ({
     data: {
       activeProvider: stubbedActiveProvider,
       model: stubbedActiveProviderModel,
-      providers: { [stubbedActiveProvider]: { model: stubbedActiveProviderModel } },
+      providers: {
+        [stubbedActiveProvider]: { model: stubbedActiveProviderModel },
+        'openai-compatible': { baseUrl: stubbedOpenAiCompatibleBaseUrl },
+      },
     },
     isPending: false,
   }),
@@ -159,6 +166,7 @@ beforeEach(() => {
   stubbedHealth = { data: undefined, isLoading: false };
   stubbedCloudKeyQueries = {};
   stubbedCloudModelQueries = {};
+  stubbedOpenAiCompatibleBaseUrl = undefined;
 });
 
 describe('ModelSelector — no model selected (Ollama, model absent)', () => {
@@ -404,10 +412,13 @@ describe('ModelSelector — key-required cloud provider, key query still loading
   });
 });
 
-describe('ModelSelector — openai-compatible, key query loading (irrelevant to a keyless provider)', () => {
+describe('ModelSelector — openai-compatible, key query loading (irrelevant to a keyless-but-configured provider)', () => {
   it('ignores the key query entirely — model-query state alone decides readiness', () => {
     stubbedActiveProvider = 'openai-compatible';
     stubbedActiveProviderModel = '';
+    // Configured via a stored base URL (not a key) — the case #936 exists
+    // for. Without it, "needs configuration" would correctly win instead.
+    stubbedOpenAiCompatibleBaseUrl = 'http://localhost:1234/v1';
     // The key query is still loading, but openai-compatible doesn't need a
     // key at all — this must not gate anything for it.
     stubbedCloudKeyQueries = { 'openai-compatible': { data: undefined, isLoading: true } };

--- a/apps/desktop/src/renderer/components/ui/ModelSelector/ModelSelector.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/ModelSelector.test.tsx
@@ -68,25 +68,39 @@ let stubbedHealth: {
   data: { cliAgents?: Record<string, { detected: boolean }> } | undefined;
   isLoading: boolean;
 } = { data: undefined, isLoading: false };
-// `openai-compatible`'s stored base URL — the second half of `canFetchModels`'s
-// "actually configured" check (a stored key alone isn't enough for it; see
-// `isProviderConfigured`). Undefined by default so a test opts in explicitly.
+// `openai-compatible`'s stored base URL — an ALTERNATIVE to a stored key for
+// `canFetchModels`'s "actually configured" check (either satisfies it; see
+// `isProviderConfigured`), not a second requirement on top of one. Undefined
+// by default so a test opts in explicitly.
 let stubbedOpenAiCompatibleBaseUrl: string | undefined;
 
 // ── Service stubs — prevent QueryClient dependency ────────────────────────────
 
 vi.mock('@/services', () => ({
-  useActiveConfig: () => ({
-    data: {
-      activeProvider: stubbedActiveProvider,
-      model: stubbedActiveProviderModel,
-      providers: {
-        [stubbedActiveProvider]: { model: stubbedActiveProviderModel },
-        'openai-compatible': { baseUrl: stubbedOpenAiCompatibleBaseUrl },
+  useActiveConfig: () => {
+    // Built via two statements, not one object literal with both
+    // `[stubbedActiveProvider]: {...}` and a literal `'openai-compatible':
+    // {...}` key — when `stubbedActiveProvider === 'openai-compatible'`
+    // those are the SAME key, and the second entry would silently win,
+    // dropping `model` and leaving `activeProviderModel` `''` regardless of
+    // `stubbedActiveProviderModel`. Assigning `baseUrl` onto the existing
+    // entry (spreading whatever's already there) merges instead of overwrites.
+    const providers: Record<string, { model?: string; baseUrl?: string }> = {
+      [stubbedActiveProvider]: { model: stubbedActiveProviderModel },
+    };
+    providers['openai-compatible'] = {
+      ...providers['openai-compatible'],
+      baseUrl: stubbedOpenAiCompatibleBaseUrl,
+    };
+    return {
+      data: {
+        activeProvider: stubbedActiveProvider,
+        model: stubbedActiveProviderModel,
+        providers,
       },
-    },
-    isPending: false,
-  }),
+      isPending: false,
+    };
+  },
   useConfigureActiveProvider: () => ({ mutate: vi.fn() }),
   useAIModels: () => ({ data: stubbedOllamaModels, isLoading: false }),
   useHasProviderKey: () => ({ data: { has: false } }),
@@ -434,6 +448,50 @@ describe('ModelSelector — openai-compatible, key query loading (irrelevant to 
 
     expect(screen.queryByText('settings.aiModel.loading')).not.toBeInTheDocument();
     expect(screen.queryByText('models.cloud.addKeyToLoad')).not.toBeInTheDocument();
+  });
+});
+
+describe('ModelSelector — openai-compatible never configured (PR #937 finding 1)', () => {
+  it('tells the user to add a base URL, not an API key — this is the default state for the population #936 exists for', () => {
+    stubbedActiveProvider = 'openai-compatible';
+    stubbedActiveProviderModel = '';
+    // Neither a base URL nor a key — the default state for a user who has
+    // never touched this provider (e.g. a fully-local Ollama user).
+    stubbedOpenAiCompatibleBaseUrl = undefined;
+    stubbedCloudKeyQueries = { 'openai-compatible': { data: { has: false }, isLoading: false } };
+
+    renderSelector();
+
+    // "Add an API key" is the one instruction that can never help here — the
+    // provider only ever needs a base URL, or a key it doesn't have shown.
+    expect(screen.queryByText('models.cloud.addKeyToLoad')).not.toBeInTheDocument();
+    const note = screen.getByText('models.cloud.addUrlToLoad');
+    expect(note).toBeInTheDocument();
+    expect(note).toHaveAttribute('role', 'status');
+  });
+});
+
+describe('ModelSelector — openai-compatible authenticated by a KEY (no base URL), key query loading (PR #937 finding 2)', () => {
+  it('shows the loading hint, not "add a key/URL" — a stored key makes the key query relevant again', () => {
+    stubbedActiveProvider = 'openai-compatible';
+    stubbedActiveProviderModel = '';
+    // No base URL configured — this user authenticates with a stored KEY
+    // instead, so (unlike the keyless-via-base-URL case above) its readiness
+    // DOES depend on the key query settling.
+    stubbedOpenAiCompatibleBaseUrl = undefined;
+    stubbedCloudKeyQueries = { 'openai-compatible': { data: undefined, isLoading: true } };
+
+    renderSelector();
+
+    // Before the fix, `activeKeyRequired` excluded openai-compatible
+    // unconditionally, so `activeKeyLoading` stayed `false` while this query
+    // was still in flight — `canFetchModels` read the not-yet-loaded `false`
+    // default and told a user who has a key to add one (or, after finding 1's
+    // fix, to add a base URL — equally wrong for someone authenticated by key).
+    expect(screen.queryByText('models.cloud.addKeyToLoad')).not.toBeInTheDocument();
+    expect(screen.queryByText('models.cloud.addUrlToLoad')).not.toBeInTheDocument();
+    const loading = screen.getByText('settings.aiModel.loading');
+    expect(loading.closest('[role="status"]')).not.toBeNull();
   });
 });
 

--- a/apps/desktop/src/renderer/components/ui/ModelSelector/index.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from '@ajh/translations';
 import { Dropdown } from '@ajh/ui';
 
 import { getModelGuidance } from '@/lib/ai-providers/model-guidance';
-import { PROVIDER_ORDER, PROVIDERS } from '@/lib/ai-providers/provider-meta';
+import { isProviderConfigured, PROVIDER_ORDER, PROVIDERS } from '@/lib/ai-providers/provider-meta';
 import { useAppClient } from '@/providers/AppClientProvider';
 import {
   fetchProviderModelsWithCache,
@@ -63,10 +63,11 @@ export function ModelSelector({ className }: ModelSelectorProps) {
     cloudProviders.map((p, i) => [p, keyQueries[i]?.data?.has ?? false])
   );
   // `openai-compatible` is the one cloud provider the backend lists models for
-  // without a bearer header (LM Studio / vLLM are keyless) — every other
-  // provider still needs a stored key before it can fetch.
+  // without a bearer header (LM Studio / vLLM are keyless) — but only once
+  // it's actually configured (a stored base URL or key); every other provider
+  // still needs a stored key before it can fetch.
   const canFetchModels = (p: AiProvider): boolean =>
-    (connected.get(p) ?? false) || p === 'openai-compatible';
+    isProviderConfigured(p, connected.get(p) ?? false, baseUrlFor(p));
 
   const modelQueries = useQueries({
     queries: cloudProviders.map((p) => ({

--- a/apps/desktop/src/renderer/components/ui/ModelSelector/index.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/index.tsx
@@ -118,13 +118,19 @@ export function ModelSelector({ className }: ModelSelectorProps) {
   const selectedModelVisible = options.some((o) => o.value === selectedValue);
   const activeCloudIndex = cloudProviders.indexOf(activeProvider);
   const activeIsCloud = PROVIDERS[activeProvider]?.kind === 'cloud';
-  // `openai-compatible` can fetch keylessly, so its readiness never depends
-  // on the key-status query at all — waiting on it would wait on data it
-  // doesn't need. For every OTHER cloud provider, the key query IS relevant,
-  // so its own loading state must be tracked separately from "no key" (below):
-  // while it's still resolving, `canFetchModels` reads the not-yet-loaded
-  // `false` default, which is NOT the same as "we checked — there's no key".
-  const activeKeyRequired = activeIsCloud && activeProvider !== 'openai-compatible';
+  // `openai-compatible` can fetch keylessly ONLY once it has a stored base
+  // URL — in that case its readiness never depends on the key-status query at
+  // all (waiting on it would wait on data it doesn't need). But a user who
+  // authenticated it with a stored KEY instead (no base URL) DOES depend on
+  // that query settling, same as every other cloud provider — so the key
+  // query is irrelevant to `openai-compatible` only when a base URL is
+  // already configured; `isProviderConfigured` mirrors this exact condition.
+  // For every provider where the key query IS relevant, its own loading state
+  // must be tracked separately from "no key" (below): while it's still
+  // resolving, `canFetchModels` reads the not-yet-loaded `false` default,
+  // which is NOT the same as "we checked — there's no key".
+  const activeKeyRequired =
+    activeIsCloud && (activeProvider !== 'openai-compatible' || !baseUrlFor(activeProvider));
   const activeKeyLoading = activeKeyRequired && Boolean(keyQueries[activeCloudIndex]?.isLoading);
   const modelsLoading = (() => {
     switch (PROVIDERS[activeProvider]?.kind) {
@@ -221,7 +227,15 @@ export function ModelSelector({ className }: ModelSelectorProps) {
       </div>
       {activeCloudStatus === 'needsKey' && (
         <p role="status" aria-live="polite" className="mt-1.5 text-[10px] text-foreground/40">
-          {t('models.cloud.addKeyToLoad')}
+          {/* `openai-compatible` needs a base URL, not a key — this is the
+              DEFAULT state for anyone who has never configured it (the
+              population the keyless carve-out exists for), so telling them
+              to add a key instead points at the one thing that won't help. */}
+          {t(
+            activeProvider === 'openai-compatible'
+              ? 'models.cloud.addUrlToLoad'
+              : 'models.cloud.addKeyToLoad'
+          )}
         </p>
       )}
       {activeCloudStatus === 'loading' && (

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/index.tsx
@@ -40,6 +40,7 @@ export function AISettingsTab() {
     savingKey,
     testingKey,
     baseUrlInput,
+    configuredBaseUrl,
     pulling,
     handleSelectModel,
     handleSaveKey,
@@ -104,6 +105,7 @@ export function AISettingsTab() {
                 apiKeyInput={apiKeyInput}
                 showKey={showKey}
                 baseUrlInput={baseUrlInput}
+                configuredBaseUrl={configuredBaseUrl}
                 onToggleExpand={() => toggleExpand(p)}
                 onTestKey={() => void handleTestKey(p)}
                 onRemoveKey={() => void handleRemoveKey(p)}

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.test.ts
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.test.ts
@@ -134,3 +134,70 @@ describe('useProviderKeys — expanded-row model fetch gating', () => {
     expect(listProviderModels).not.toHaveBeenCalled();
   });
 });
+
+describe('useProviderKeys — configuredBaseUrl (PR #937 finding 3)', () => {
+  // `CloudProviderConfig.canPickModel` and `expandedCanFetchModels` used to
+  // compute "the openai-compatible base URL" independently (raw `baseUrlInput`
+  // vs. trimmed-or-saved) — a divergence that could show/hide the picker out
+  // of step with what was actually being fetched. `configuredBaseUrl` is now
+  // resolved once here and handed to both.
+  it('resolves to the saved base URL even though baseUrlInput seeds empty on a cold-boot render', async () => {
+    // On mount, `useState(providerConfig?.providers?.[...]?.baseUrl ?? '')`
+    // reads whatever `useActiveConfig` had at that instant — `undefined`
+    // until the query resolves, so the seed is `''` here regardless of what
+    // ends up saved. `configuredBaseUrl` must self-correct once `providerConfig`
+    // loads (it re-reads the live query every render, not the stale seed).
+    const client = createMockClient({
+      'ai.activeConfig': vi.fn().mockResolvedValue({
+        activeProvider: 'ollama',
+        providers: { 'openai-compatible': { baseUrl: 'http://localhost:1234/v1' } },
+      }),
+      'ai.hasProviderKey': vi.fn().mockResolvedValue({ has: false }),
+      'ai.listModels': vi.fn().mockResolvedValue([]),
+      'system.health': vi.fn().mockResolvedValue({ ai: { ready: false }, cliAgents: {} }),
+    });
+    const { result } = renderHookWithClient(() => useProviderKeys(), { client });
+
+    expect(result.current.baseUrlInput).toBe('');
+
+    await waitFor(() => expect(result.current.configuredBaseUrl).toBe('http://localhost:1234/v1'));
+  });
+
+  it('prefers an in-progress edit over the saved value', async () => {
+    const client = createMockClient({
+      'ai.activeConfig': vi.fn().mockResolvedValue({
+        activeProvider: 'ollama',
+        providers: { 'openai-compatible': { baseUrl: 'http://localhost:1234/v1' } },
+      }),
+      'ai.hasProviderKey': vi.fn().mockResolvedValue({ has: false }),
+      'ai.listModels': vi.fn().mockResolvedValue([]),
+      'system.health': vi.fn().mockResolvedValue({ ai: { ready: false }, cliAgents: {} }),
+    });
+    const { result } = renderHookWithClient(() => useProviderKeys(), { client });
+
+    act(() => result.current.setBaseUrlInput('http://localhost:9999/v1'));
+
+    expect(result.current.configuredBaseUrl).toBe('http://localhost:9999/v1');
+  });
+
+  it('falls back to the saved value when the in-progress edit is cleared without saving', async () => {
+    // The exact divergence the finding reported: select-all + delete in the
+    // input must NOT read as "unconfigured" while a save is still saved.
+    const client = createMockClient({
+      'ai.activeConfig': vi.fn().mockResolvedValue({
+        activeProvider: 'ollama',
+        providers: { 'openai-compatible': { baseUrl: 'http://localhost:1234/v1' } },
+      }),
+      'ai.hasProviderKey': vi.fn().mockResolvedValue({ has: false }),
+      'ai.listModels': vi.fn().mockResolvedValue([]),
+      'system.health': vi.fn().mockResolvedValue({ ai: { ready: false }, cliAgents: {} }),
+    });
+    const { result } = renderHookWithClient(() => useProviderKeys(), { client });
+
+    await waitFor(() => expect(result.current.configuredBaseUrl).toBe('http://localhost:1234/v1'));
+
+    act(() => result.current.setBaseUrlInput(''));
+
+    expect(result.current.configuredBaseUrl).toBe('http://localhost:1234/v1');
+  });
+});

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.test.ts
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.test.ts
@@ -1,11 +1,19 @@
 /**
- * useProviderKeys — model-fetch gating tests (CodeRabbit #936, Major 2).
+ * useProviderKeys — model-fetch gating tests (CodeRabbit #936, Major 2; and
+ * the follow-up privacy regression on `fix/no-unconfigured-openai-probe`).
  *
  * `expandedCanFetchModels` used to gate purely on `keyStatus`, so expanding a
  * keyless `openai-compatible` row (LM Studio / vLLM — #935 made the backend
  * list models for it without a bearer header) never fired the catalogue
  * fetch at all, even though `ModelSelector` was already unblocked for the
  * same case. Every other cloud provider still requires a stored key.
+ *
+ * The #936 fix then over-widened the carve-out to `connected || provider ===
+ * 'openai-compatible'` with no requirement that the provider be pointed
+ * anywhere — an unconfigured `openai-compatible` (no key, no base URL) still
+ * fetched, and the backend silently falls back to `api.openai.com`. The
+ * carve-out now also requires a stored/in-progress base URL
+ * (`isProviderConfigured`, `lib/ai-providers/provider-meta.ts`).
  *
  * Uses `renderHookWithClient` (real QueryClient + AppClient, mock transport)
  * rather than mocking `@/services`, so the actual `enabled` wiring — not a
@@ -36,11 +44,14 @@ vi.mock('@ajh/ui', async (importOriginal) => {
 import { useProviderKeys } from './useProviderKeys';
 
 describe('useProviderKeys — expanded-row model fetch gating', () => {
-  it('fetches models for a keyless openai-compatible row with no stored key', async () => {
+  it('fetches models for a keyless openai-compatible row with a stored base URL, no key', async () => {
     const listProviderModels = vi.fn().mockResolvedValue([]);
     const client = createMockClient({
       'ai.listProviderModels': listProviderModels,
-      'ai.activeConfig': vi.fn().mockResolvedValue({ activeProvider: 'ollama', providers: {} }),
+      'ai.activeConfig': vi.fn().mockResolvedValue({
+        activeProvider: 'ollama',
+        providers: { 'openai-compatible': { baseUrl: 'http://localhost:1234/v1' } },
+      }),
       'ai.hasProviderKey': vi.fn().mockResolvedValue({ has: false }),
       'ai.listModels': vi.fn().mockResolvedValue([]),
       'system.health': vi.fn().mockResolvedValue({ ai: { ready: false }, cliAgents: {} }),
@@ -54,9 +65,42 @@ describe('useProviderKeys — expanded-row model fetch gating', () => {
     await waitFor(() =>
       expect(listProviderModels).toHaveBeenCalledWith({
         provider: 'openai-compatible',
-        baseUrl: undefined,
+        baseUrl: 'http://localhost:1234/v1',
       })
     );
+  });
+
+  // Privacy regression (fix/no-unconfigured-openai-probe): the #936 carve-out
+  // (`connected || provider === 'openai-compatible'`) had no requirement that
+  // the provider be pointed anywhere — expanding an openai-compatible row with
+  // NEITHER a stored key NOR a stored/in-progress base URL still fetched, and
+  // the backend silently falls back to `api.openai.com`, leaking a request to
+  // it even for users who never touched this provider.
+  it('does NOT fetch models for an openai-compatible row with no stored key AND no base URL', async () => {
+    const listProviderModels = vi.fn().mockResolvedValue([]);
+    const client = createMockClient({
+      'ai.listProviderModels': listProviderModels,
+      'ai.activeConfig': vi.fn().mockResolvedValue({ activeProvider: 'ollama', providers: {} }),
+      'ai.hasProviderKey': vi.fn().mockResolvedValue({ has: false }),
+      'ai.listModels': vi.fn().mockResolvedValue([]),
+      'system.health': vi.fn().mockResolvedValue({ ai: { ready: false }, cliAgents: {} }),
+    });
+    const { result, queryClient } = renderHookWithClient(() => useProviderKeys(), { client });
+
+    act(() => {
+      result.current.toggleExpand('openai-compatible');
+    });
+
+    // Same settlement condition as the key-required negative test below — wait
+    // for the key-status query to genuinely resolve rather than a fixed sleep,
+    // which fails in the direction that looks like success.
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryState(['ai', 'models', 'provider-key', 'openai-compatible'])?.status
+      ).toBe('success')
+    );
+
+    expect(listProviderModels).not.toHaveBeenCalled();
   });
 
   it('does NOT fetch models for a key-required cloud provider with no stored key', async () => {

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.ts
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.ts
@@ -3,7 +3,7 @@ import { useQueries, useQueryClient } from '@tanstack/react-query';
 
 import { useNotification } from '@ajh/ui';
 
-import { PROVIDER_ORDER, PROVIDERS } from '@/lib/ai-providers/provider-meta';
+import { isProviderConfigured, PROVIDER_ORDER, PROVIDERS } from '@/lib/ai-providers/provider-meta';
 import { useAppClient } from '@/providers/AppClientProvider';
 import {
   useActiveConfig,
@@ -106,11 +106,17 @@ export function useProviderKeys() {
   // provider the backend lists models for without a bearer header (LM Studio /
   // vLLM are keyless) — gating it on `keyStatus` like every other cloud
   // provider left keyless setups unable to discover a model in Settings at
-  // all, even though `ModelSelector` already unblocked the same case.
+  // all, even though `ModelSelector` already unblocked the same case. But it
+  // must still be configured (a stored/in-progress base URL, or a key) —
+  // otherwise it silently falls back to `api.openai.com` server-side.
   const expandedFetchesModels = expanded !== null && PROVIDERS[expanded].kind !== 'local-server';
   const expandedCanFetchModels =
     expandedFetchesModels &&
-    ((keyStatus[expanded ?? 'openai'] ?? false) || expanded === 'openai-compatible');
+    isProviderConfigured(
+      expanded ?? 'openai',
+      keyStatus[expanded ?? 'openai'] ?? false,
+      baseUrlFor(expanded ?? 'openai')
+    );
   const {
     data: expandedModelsResult,
     isLoading: expandedModelsLoading,

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.ts
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/useProviderKeys.ts
@@ -92,13 +92,24 @@ export function useProviderKeys() {
   );
 
   // Custom base URL only applies to the OpenAI-compatible provider. Prefer the
-  // in-progress edit, fall back to what's saved in config.
+  // in-progress edit, fall back to what's saved in config. Resolved ONCE here
+  // and reused by every consumer below (including the one handed to
+  // `CloudProviderConfig` as `configuredBaseUrl`) — passing the raw
+  // `baseUrlInput` to one call site and this resolved value to another is
+  // exactly the divergence a single predicate was meant to prevent (they can
+  // disagree on whether the provider is "configured" while both claim to
+  // share the same check). Also immune to `baseUrlInput`'s `useState`
+  // initializer being stale on a cold boot (seeded once from `providerConfig`
+  // before it may have loaded): this function re-reads `providerConfig` live
+  // on every call, so it self-corrects once the query resolves even if the
+  // input's seed never does.
   const baseUrlFor = (p: AiProvider): string | undefined =>
     p === 'openai-compatible'
       ? baseUrlInput.trim() ||
         providerConfig?.providers?.['openai-compatible']?.baseUrl ||
         undefined
       : undefined;
+  const configuredBaseUrl = baseUrlFor('openai-compatible');
 
   // Models for the expanded non-local provider (cloud key-based, or CLI agents
   // which "list" their aliases through the same IPC path). Ollama uses its own
@@ -110,23 +121,18 @@ export function useProviderKeys() {
   // must still be configured (a stored/in-progress base URL, or a key) —
   // otherwise it silently falls back to `api.openai.com` server-side.
   const expandedFetchesModels = expanded !== null && PROVIDERS[expanded].kind !== 'local-server';
+  // `expandedFetchesModels` already proves `expanded !== null` — one fallback,
+  // reused below, instead of five copies that could drift from each other.
+  const target = expanded ?? 'openai';
   const expandedCanFetchModels =
     expandedFetchesModels &&
-    isProviderConfigured(
-      expanded ?? 'openai',
-      keyStatus[expanded ?? 'openai'] ?? false,
-      baseUrlFor(expanded ?? 'openai')
-    );
+    isProviderConfigured(target, keyStatus[target] ?? false, baseUrlFor(target));
   const {
     data: expandedModelsResult,
     isLoading: expandedModelsLoading,
     isError: expandedModelsErrored,
     error: expandedModelsErrorObj,
-  } = useListProviderModels(
-    expanded ?? 'openai',
-    expandedCanFetchModels,
-    baseUrlFor(expanded ?? 'openai')
-  );
+  } = useListProviderModels(target, expandedCanFetchModels, baseUrlFor(target));
   const expandedModels = expandedModelsResult?.models ?? [];
   const expandedModelsCached = expandedModelsResult?.cached ?? false;
   // A rejected invoke can reject with a plain string rather than an `Error`
@@ -257,6 +263,7 @@ export function useProviderKeys() {
     savingKey,
     testingKey,
     baseUrlInput,
+    configuredBaseUrl,
     pulling,
     handleSelectModel,
     handleSaveKey,

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/CloudProviderConfig.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/CloudProviderConfig.test.tsx
@@ -280,13 +280,16 @@ describe('CloudProviderConfig — model list states (live-model-lists PR)', () =
   // keyless), and ModelSelector was unblocked to match — but the Settings
   // model-selector block was still gated on `connected` (has a stored key),
   // so a keyless setup could never discover or pick a model here even though
-  // nothing about it actually requires a key.
-  it('shows the model selector for a keyless openai-compatible provider (connected: false)', () => {
+  // nothing about it actually requires a key. It still needs a base URL —
+  // this is the "actually configured" case (see the no-baseUrl regression
+  // test below for the case it must NOT unblock).
+  it('shows the model selector for a keyless openai-compatible provider with a base URL set (connected: false)', () => {
     render(
       <CloudProviderConfig
         {...baseProps}
         provider="openai-compatible"
         connected={false}
+        baseUrlInput="http://localhost:1234/v1"
         expandedModels={[{ name: 'local-model' }]}
         providerModel="local-model"
       />
@@ -295,12 +298,13 @@ describe('CloudProviderConfig — model list states (live-model-lists PR)', () =
     expect(screen.getByRole('button', { name: /local-model/ })).toBeInTheDocument();
   });
 
-  it('shows the loading/error/empty states for a keyless openai-compatible provider too', () => {
+  it('shows the loading/error/empty states for a keyless-but-configured openai-compatible provider too', () => {
     const { rerender } = render(
       <CloudProviderConfig
         {...baseProps}
         provider="openai-compatible"
         connected={false}
+        baseUrlInput="http://localhost:1234/v1"
         expandedModels={[]}
         expandedModelsLoading
       />
@@ -312,6 +316,7 @@ describe('CloudProviderConfig — model list states (live-model-lists PR)', () =
         {...baseProps}
         provider="openai-compatible"
         connected={false}
+        baseUrlInput="http://localhost:1234/v1"
         expandedModels={[]}
         expandedModelsError="connection refused"
       />
@@ -321,6 +326,23 @@ describe('CloudProviderConfig — model list states (live-model-lists PR)', () =
 
   it('still hides the model selector for a key-required provider with no key (unchanged behavior)', () => {
     render(<CloudProviderConfig {...baseProps} provider="openai" connected={false} />);
+    expect(screen.queryByText('settings.aiModel.title')).not.toBeInTheDocument();
+  });
+
+  // Privacy regression (fix/no-unconfigured-openai-probe): an openai-compatible
+  // row with neither a stored key NOR a base URL — the state #936's carve-out
+  // (`connected || provider === 'openai-compatible'`) left unguarded, letting
+  // the backend silently fall back to `api.openai.com`. Must stay hidden, same
+  // as any other never-configured cloud provider.
+  it('hides the model selector for an unconfigured openai-compatible provider (no key, no base URL)', () => {
+    render(
+      <CloudProviderConfig
+        {...baseProps}
+        provider="openai-compatible"
+        connected={false}
+        baseUrlInput=""
+      />
+    );
     expect(screen.queryByText('settings.aiModel.title')).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/CloudProviderConfig.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/CloudProviderConfig.test.tsx
@@ -290,6 +290,7 @@ describe('CloudProviderConfig — model list states (live-model-lists PR)', () =
         provider="openai-compatible"
         connected={false}
         baseUrlInput="http://localhost:1234/v1"
+        configuredBaseUrl="http://localhost:1234/v1"
         expandedModels={[{ name: 'local-model' }]}
         providerModel="local-model"
       />
@@ -305,6 +306,7 @@ describe('CloudProviderConfig — model list states (live-model-lists PR)', () =
         provider="openai-compatible"
         connected={false}
         baseUrlInput="http://localhost:1234/v1"
+        configuredBaseUrl="http://localhost:1234/v1"
         expandedModels={[]}
         expandedModelsLoading
       />
@@ -317,11 +319,37 @@ describe('CloudProviderConfig — model list states (live-model-lists PR)', () =
         provider="openai-compatible"
         connected={false}
         baseUrlInput="http://localhost:1234/v1"
+        configuredBaseUrl="http://localhost:1234/v1"
         expandedModels={[]}
         expandedModelsError="connection refused"
       />
     );
     expect(screen.getByRole('alert')).toHaveTextContent('connection refused');
+  });
+
+  // Finding 3 (PR #937 review): the parent used to compute two DIFFERENT
+  // values for "the openai-compatible base URL" — the raw `baseUrlInput` fed
+  // straight into this component's own check, vs. a trimmed-or-saved value
+  // used everywhere else (the actual model fetch). A user who selects-all and
+  // clears the input WITHOUT saving would then lose the picker (and their
+  // selected model) while the fetch, reading the other value, kept using the
+  // still-saved URL underneath. `configuredBaseUrl` is now the ONLY value fed
+  // to `canPickModel` — this pins that `baseUrlInput` (the raw keystroke) no
+  // longer has any say in it.
+  it('keeps the model selector visible when the input is cleared but the resolved base URL is still saved', () => {
+    render(
+      <CloudProviderConfig
+        {...baseProps}
+        provider="openai-compatible"
+        connected={false}
+        baseUrlInput=""
+        configuredBaseUrl="http://localhost:1234/v1"
+        expandedModels={[{ name: 'local-model' }]}
+        providerModel="local-model"
+      />
+    );
+    expect(screen.getByText('settings.aiModel.title')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /local-model/ })).toBeInTheDocument();
   });
 
   it('still hides the model selector for a key-required provider with no key (unchanged behavior)', () => {

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/index.tsx
@@ -36,6 +36,12 @@ interface Props {
   apiKeyInput: string;
   showKey: boolean;
   baseUrlInput: string;
+  /** The resolved openai-compatible base URL (in-progress edit, else saved) —
+   *  computed once by `useProviderKeys.baseUrlFor`, so this component's
+   *  "is it configured" check can't disagree with the model-fetch it gates.
+   *  `baseUrlInput` above is the raw, un-trimmed value for the `<Input>`
+   *  itself only — never fed into that check directly. */
+  configuredBaseUrl?: string;
   onApiKeyChange: (value: string) => void;
   onToggleShowKey: () => void;
   onBaseUrlChange: (value: string) => void;
@@ -62,6 +68,7 @@ export function CloudProviderConfig({
   apiKeyInput,
   showKey,
   baseUrlInput,
+  configuredBaseUrl,
   onApiKeyChange,
   onToggleShowKey,
   onBaseUrlChange,
@@ -82,8 +89,12 @@ export function CloudProviderConfig({
   // and pick a model without a stored key, so the model section can't be
   // gated on `connected` the same way the key-input section above is. It
   // still needs to be configured (a stored/in-progress base URL), though —
-  // otherwise it silently falls back to `api.openai.com` server-side.
-  const canPickModel = isProviderConfigured(provider, connected, baseUrlInput);
+  // otherwise it silently falls back to `api.openai.com` server-side. Checked
+  // against `configuredBaseUrl` (the parent-resolved value the model fetch
+  // itself uses), NOT the raw `baseUrlInput` — those two can disagree (e.g.
+  // the input cleared but not yet saved) and this must track the fetch, not
+  // the keystroke.
+  const canPickModel = isProviderConfigured(provider, connected, configuredBaseUrl);
 
   const modelOptions = sortModelsNewestFirst(expandedModels).map((m) => ({
     value: m.name,

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/index.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from '@ajh/translations';
 import { Button, Dropdown, EmptyState, ErrorState, Input, useNotification } from '@ajh/ui';
 
 import { sortModelsNewestFirst } from '@/lib/ai-providers/model-sort';
+import { isProviderConfigured } from '@/lib/ai-providers/provider-meta';
 import { useSetProviderSettings } from '@/services';
 import type { AiProvider } from '@/store/preferences-schema';
 
@@ -79,8 +80,10 @@ export function CloudProviderConfig({
 
   // `openai-compatible` is keyless-capable (LM Studio / vLLM) — it can list
   // and pick a model without a stored key, so the model section can't be
-  // gated on `connected` the same way the key-input section above is.
-  const canPickModel = connected || provider === 'openai-compatible';
+  // gated on `connected` the same way the key-input section above is. It
+  // still needs to be configured (a stored/in-progress base URL), though —
+  // otherwise it silently falls back to `api.openai.com` server-side.
+  const canPickModel = isProviderConfigured(provider, connected, baseUrlInput);
 
   const modelOptions = sortModelsNewestFirst(expandedModels).map((m) => ({
     value: m.name,

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/ProviderRow/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/ProviderRow/index.tsx
@@ -33,6 +33,10 @@ interface Props {
   apiKeyInput: string;
   showKey: boolean;
   baseUrlInput: string;
+  /** The resolved openai-compatible base URL (in-progress edit, else saved) —
+   *  computed once in `useProviderKeys`, so the "is this provider configured"
+   *  check downstream never disagrees with the model-fetch it gates. */
+  configuredBaseUrl?: string;
   onToggleExpand: () => void;
   onTestKey?: () => void;
   onRemoveKey: () => void;
@@ -67,6 +71,7 @@ export function ProviderRow({
   apiKeyInput,
   showKey,
   baseUrlInput,
+  configuredBaseUrl,
   onToggleExpand,
   onTestKey,
   onRemoveKey,
@@ -180,6 +185,7 @@ export function ProviderRow({
               apiKeyInput={apiKeyInput}
               showKey={showKey}
               baseUrlInput={baseUrlInput}
+              configuredBaseUrl={configuredBaseUrl}
               onApiKeyChange={onApiKeyChange}
               onToggleShowKey={onToggleShowKey}
               onBaseUrlChange={onBaseUrlChange}

--- a/apps/desktop/src/renderer/lib/ai-providers/provider-meta.test.ts
+++ b/apps/desktop/src/renderer/lib/ai-providers/provider-meta.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isOllamaFamily, PROVIDER_ORDER, PROVIDERS } from './provider-meta';
+import { isOllamaFamily, isProviderConfigured, PROVIDER_ORDER, PROVIDERS } from './provider-meta';
 
 describe('isOllamaFamily', () => {
   it('is true only for the Ollama local + cloud providers', () => {
@@ -38,5 +38,31 @@ describe('Ollama Cloud registration', () => {
     for (const p of PROVIDER_ORDER) {
       if (PROVIDERS[p].kind === 'cloud') expect(PROVIDERS[p].models).toEqual([]);
     }
+  });
+});
+
+describe('isProviderConfigured', () => {
+  it('is true for any provider with a stored key, regardless of base URL', () => {
+    expect(isProviderConfigured('openai', true)).toBe(true);
+    expect(isProviderConfigured('openai-compatible', true, undefined)).toBe(true);
+  });
+
+  it('is false for a non-openai-compatible provider with no stored key, even with a base URL', () => {
+    // The `openai-compatible` keyless carve-out must not leak to any other
+    // provider — every other cloud provider still requires a key, full stop.
+    expect(isProviderConfigured('openai', false, 'https://x')).toBe(false);
+  });
+
+  it('is true for openai-compatible with a non-blank base URL and no key (the #936 keyless case)', () => {
+    expect(isProviderConfigured('openai-compatible', false, 'http://localhost:1234/v1')).toBe(true);
+  });
+
+  it('is false for openai-compatible with neither a key nor a base URL (privacy regression)', () => {
+    // The exact bug fixed on fix/no-unconfigured-openai-probe: an unconfigured
+    // openai-compatible provider must never read as usable — it falls back to
+    // api.openai.com server-side with no requirement to be pointed anywhere.
+    expect(isProviderConfigured('openai-compatible', false, undefined)).toBe(false);
+    expect(isProviderConfigured('openai-compatible', false, '')).toBe(false);
+    expect(isProviderConfigured('openai-compatible', false, '   ')).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/lib/ai-providers/provider-meta.ts
+++ b/apps/desktop/src/renderer/lib/ai-providers/provider-meta.ts
@@ -149,3 +149,22 @@ export const PROVIDER_ORDER: AiProvider[] = [
 export function isOllamaFamily(provider: AiProvider): boolean {
   return provider === 'ollama' || provider === 'ollama-cloud';
 }
+
+/**
+ * Whether a provider is configured to be reached at all — the single gate every
+ * "can we fetch/pick a model for this provider" call site must share. Every
+ * provider needs a stored key (`connected`), EXCEPT `openai-compatible`, whose
+ * backend (LM Studio / vLLM, etc.) is keyless — but ONLY once it's actually
+ * pointed somewhere. Without this second condition, an unconfigured
+ * `openai-compatible` (no key, no base URL) silently falls back to
+ * `api.openai.com` server-side and leaks a request to it on every page that
+ * mounts a model picker — a privacy regression the keyless carve-out must not
+ * reintroduce.
+ */
+export function isProviderConfigured(
+  provider: AiProvider,
+  connected: boolean,
+  baseUrl?: string
+): boolean {
+  return connected || (provider === 'openai-compatible' && Boolean(baseUrl?.trim()));
+}

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -229,6 +229,7 @@
     "modelUnavailable": "Dein ausgewähltes Modell ist nicht verfügbar – wähle eines aus der Liste unten.",
     "cloud": {
       "addKeyToLoad": "Fügen Sie einen API-Schlüssel hinzu, um die Modelle dieses Anbieters zu laden.",
+      "addUrlToLoad": "Fügen Sie eine Basis-URL hinzu, um die Modelle dieses Anbieters zu laden.",
       "fetchFailed": "Modelle konnten nicht geladen werden: {{message}}",
       "cachedList": "Zeigt die zuletzt gespeicherte Liste – die Live-Aktualisierung ist fehlgeschlagen."
     }

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -229,6 +229,7 @@
     "modelUnavailable": "Your selected model isn't available — pick one from the list below.",
     "cloud": {
       "addKeyToLoad": "Add an API key to load this provider's models.",
+      "addUrlToLoad": "Add a base URL to load this provider's models.",
       "fetchFailed": "Couldn't load models: {{message}}",
       "cachedList": "Showing the last saved list — live refresh failed."
     }


### PR DESCRIPTION
**Privacy regression introduced by #936 and currently on `main`.** Found by the post-merge review on #936.

## What happens today

#936 added a keyless carve-out so LM Studio / vLLM users could list models without storing a key:

```ts
const canFetchModels = (p: AiProvider): boolean =>
  (connected.get(p) ?? false) || p === 'openai-compatible';
```

It requires only that the provider *be* `openai-compatible` — not that it be pointed anywhere.

- `baseUrlFor('openai-compatible')` is `undefined` for anyone who never configured it.
- `OpenAiClient::new` falls back to `DEFAULT_BASE = "https://api.openai.com/v1"` on a blank base URL (`openai.rs:463-465`), sending no `Authorization` header.
- `ModelSelector` mounts on six surfaces: `ResumeBuilderPage`, `TailorFlow/StepModel`, `ReferralModal`, `JobAdView`, `AnalyzeLeftPanel`, `ai-generate/LeftPanel`.

So **every user — including a fully local, offline-by-choice Ollama user who has never touched this provider — makes an outbound HTTPS request to `api.openai.com` on every relevant page load.** For an app whose entire posture is local-first, that is the specific thing it promises not to do.

Before #936 the gate was `connected.get(p) ?? false` for every provider, so nothing fired until the user had stored something.

## Fix

`openai-compatible` fetches only once it has actually been configured — a stored base URL **or** a stored key. Every other provider keeps its stored-key gate unchanged.

Expressed as a single `isProviderConfigured(provider, connected, baseUrl)` predicate rather than a boolean special-cased per site, because the carve-out lived at **three** call sites:

- `ModelSelector/index.tsx` — `canFetchModels`
- `AISettingsTab/useProviderKeys.ts` — `expandedCanFetchModels`
- `CloudProviderConfig/index.tsx` — `canPickModel`

A change reaching some siblings and not all has produced this programme's last four defects, so the predicate exists once and the exhaustiveness was verified by grep rather than assumed.

## Preserved

- A **configured keyless** server (base URL set, no key) still lists models — the case #936 existed to enable. Covered by a test.
- A user with a key but no base URL keeps today's behaviour (resolves to the default base with their key). That predates #936 and is untouched.

## Note on the tests

**Five existing tests asserted the buggy behaviour** — fetching with nothing configured — so they were written to match the bug and would have preserved it. They now cover the configured-keyless case they were meant to protect. That's why this diff touches more test files than source files.

The new regression test asserts `listProviderModels` is never called with no key and no base URL, gated on query settlement rather than a timer (a negative assertion on a `setTimeout` fails in the direction that looks like success).

## Verification

`pnpm typecheck` 13/13 · `pnpm lint:strict` clean · desktop 249 files / **2870 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)