### PR TITLE
docs: record the no-fallback-model-list decision, and post medium review findings inline

### DIFF
--- a/.claude/hooks/review-lib.mjs
+++ b/.claude/hooks/review-lib.mjs
@@ -234,6 +234,27 @@ export const blockingFindings = (findings, minConfidence) =>
       f.introduced_by_diff !== false
   );
 
+/**
+ * Findings worth pinning to a line in the PR diff.
+ *
+ * LOW is deliberately excluded: it is advisory by definition, and the sticky
+ * comment already lists every finding, so pinning nits to the diff costs
+ * attention without adding information.
+ *
+ * A finding with no `file`/`line` cannot be anchored at all — GitHub rejects a
+ * review comment without a position, so those stay sticky-only rather than
+ * failing the post.
+ */
+export const inlineFindings = (findings) =>
+  (findings || []).filter(
+    (f) =>
+      (f.severity === 'CRITICAL' || f.severity === 'HIGH' || f.severity === 'MEDIUM') &&
+      f.introduced_by_diff !== false &&
+      f.file &&
+      Number.isInteger(f.line) &&
+      f.line > 0
+  );
+
 export const formatFinding = (f) =>
   `${f.severity} · ${f.file}${f.line ? ':' + f.line : ''} · ${f.summary}${f.fix ? ' · ' + f.fix : ''}`;
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,10 +8,18 @@ name: 🤖 Claude Review (required gate + advisory deep dive)
 # blocks merge; fails open on infra (no action outage freeze). Findings
 # are posted as a STICKY PR comment (edited in place per push; only when
 # findings exist; flipped to "resolved" when a later run is clean), and
-# the blocking ones ALSO as inline comments on their changed lines. The
-# check status stays the blocking signal. See ADR-0008 for the 6-PR
-# review-hardening program; the gate is the final surface (join: Stop
-# gate, /review, pre-push, ci-ok, this check).
+# CRITICAL/HIGH/MEDIUM ones ALSO as inline comments on their changed lines.
+#
+# Inline posting is done by a deterministic step from the findings JSON, not
+# by the model: the action's inline tool does not deduplicate across runs, so
+# a model posting directly re-stacked every finding on each push — which is
+# why inline used to be capped to the blocking tier and almost never fired.
+# Keying each comment by `ledgerKey` (file + category + hash of summary, and
+# deliberately NO line number) lets a re-run recognise what it already said,
+# which is what makes widening past the blocking tier safe. The check status
+# stays the blocking signal. See ADR-0008 for the 6-PR review-hardening
+# program; the gate is the final surface (join: Stop gate, /review, pre-push,
+# ci-ok, this check).
 #
 # Permissions trade: pull-requests: write is re-added to post the sticky
 # comment, accepting this over strict least-privilege for in-PR findings
@@ -157,29 +165,92 @@ jobs:
             Report only defects introduced by the diff; pre-existing issues get
             introduced_by_diff: false. Give every finding a calibrated confidence (0-1);
             anything you cannot substantiate gets <= 0.5.
-            Additionally post each BLOCKING finding — HIGH or CRITICAL at confidence
-            >= 0.8 with introduced_by_diff true — as an inline comment on its changed
-            line. Do not post the others inline; they belong in the JSON only.
+            Set `line` to the line in the CHANGED file the finding sits on — it is what
+            anchors the inline comment, so a wrong line silently drops the finding off
+            the diff. Do NOT post any comment yourself; the JSON is the whole contract.
             Write the findings as schema-1 JSON to review-findings.json in the workspace
             root — the JSON object only, no fences: { "schema": 1, "findings": [ {
             "severity": "CRITICAL|HIGH|MEDIUM|LOW", "category": "security|correctness|data-loss|arch|test-coverage|i18n|perf|style",
             "file": "...", "line": 0, "summary": "...", "evidence": "...", "fix": "...",
             "confidence": 0.0, "introduced_by_diff": true } ] }
             No findings -> { "schema": 1, "findings": [] }. Write the file even when empty.
-          # Agent mode gates the inline-comment MCP server on the same
-          # `mcp__github_inline_comment__` prefix check as tag mode — it passes
-          # parseAllowedTools(claude_args) straight to prepareMcpConfig
-          # (src/modes/agent/index.ts), and `pull_request` is an entity event with
-          # isPR true (src/github/context.ts:191-201), so the server starts and
-          # targets this PR. Inline is capped to the blocking tier by the prompt
-          # above: this lane re-runs on every synchronize and inline comments are
-          # not deduplicated across runs, so an unbounded instruction would stack a
-          # fresh copy of every nit on each push. The sticky comment stays the
-          # full-finding-list surface; the check stays the blocking signal.
-          claude_args: '--model claude-sonnet-5 --allowedTools "Read,Grep,Glob,Write,mcp__github_inline_comment__create_inline_comment"'
+          # NO inline-comment MCP tool here, deliberately. This lane re-runs on
+          # every synchronize and the action's inline tool does not deduplicate
+          # across runs, so letting the model post directly stacked a fresh copy
+          # of every finding on each push — which is why inline used to be capped
+          # to the blocking tier and, in practice, almost never fired.
+          #
+          # Posting now happens in the deterministic step below, from the same
+          # findings JSON the verdict uses: it dedupes against comments already on
+          # the PR, so the tier can safely widen to MEDIUM. Model writes findings,
+          # code decides what gets posted — the same split the verdict already
+          # uses to keep prose out of the merge decision.
+          #
+          # Lane A1 above keeps its inline tool: it is owner-triggered and runs
+          # once on demand, so there is nothing to deduplicate.
+          claude_args: '--model claude-sonnet-5 --allowedTools "Read,Grep,Glob,Write"'
 
       - name: Deterministic verdict
         run: node scripts/ci-review-verdict.mjs review-findings.json
+
+      - name: 📌 Inline findings on the diff
+        if: ${{ !cancelled() }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const { pathToFileURL } = require('node:url');
+            const { inlineFindings, ledgerKey } = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.claude/hooks/review-lib.mjs`).href
+            );
+
+            let findings = [];
+            try {
+              findings = JSON.parse(fs.readFileSync('review-findings.json', 'utf8')).findings || [];
+            } catch {
+              return; // fail-open: no findings file means nothing to post
+            }
+            const wanted = inlineFindings(findings);
+            if (!wanted.length) return;
+
+            // Dedup across runs. `ledgerKey` is file+category+hash(summary) and
+            // deliberately carries NO line number: an edit above a finding shifts
+            // its line, and keying on that would repost the same finding as new on
+            // every push — the exact stacking this step exists to prevent.
+            const existing = await github.paginate(github.rest.pulls.listReviewComments, {
+              ...context.repo, pull_number: context.issue.number, per_page: 100,
+            });
+            const seen = new Set(
+              existing.flatMap((c) =>
+                [...String(c.body || '').matchAll(/<!-- ai-finding:(.+?) -->/g)].map((m) => m[1])
+              )
+            );
+
+            const sha = context.payload.pull_request.head.sha;
+            let posted = 0;
+            for (const f of wanted) {
+              const id = ledgerKey(f);
+              if (seen.has(id)) continue;
+              seen.add(id); // guard against duplicates within one findings file too
+              try {
+                await github.rest.pulls.createReviewComment({
+                  ...context.repo,
+                  pull_number: context.issue.number,
+                  commit_id: sha,
+                  path: f.file,
+                  line: f.line,
+                  side: 'RIGHT',
+                  body: `<!-- ai-finding:${id} -->\n**${f.severity}** — ${f.summary}\n\n**Fix:** ${f.fix}`,
+                });
+                posted++;
+              } catch (e) {
+                // GitHub 422s when the line is not part of this PR's diff (a stale
+                // or mis-numbered `line`). Never fatal: the sticky comment below
+                // carries every finding regardless, and the check is the gate.
+                core.warning(`inline skipped ${f.file}:${f.line} — ${e.status || ''} ${e.message}`);
+              }
+            }
+            core.info(`inline findings: ${posted} posted, ${wanted.length - posted} already present or unanchorable`);
 
       - name: 💬 Sticky findings comment
         if: ${{ !cancelled() }}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # IPC API Reference — AI Job Hunter
 
-Last updated: 2026-08-04
+Last updated: 2026-08-05
 
 All renderer ↔ Rust communication is defined as typed contracts in `packages/shared/src/ipc/contracts/`. The renderer accesses them exclusively through `AppClient` service hooks.
 
@@ -125,6 +125,31 @@ Network-free capability probe for a provider/model combination. Returns:
 - `effortLevels` — the exact set of reasoning-effort values the app can actually SEND for this model (e.g., `["low", "medium", "high"]`). Can be empty even when `supportsReasoning` is true — either the provider/model genuinely doesn't accept the parameter (most CLI agents besides Codex), reasoning is unsupported, or the provider/model is unknown. **Per-model**: several providers' accepted level SET genuinely varies by model tier (Gemini's `thinkingLevel`, Anthropic's `output_config.effort`) — callers should not assume all models of a provider share the same levels.
 
 Degrades gracefully for unknown providers to `{ supportsWebSearch: false, supportsReasoning: false, effortLevels: [] }`. Used by the Settings → AI effort picker to render exactly which effort levels are valid for the chosen model.
+
+#### `ai.listProviderModels(req: { provider: string; baseUrl?: string }): Promise<ProviderModelInfo[]>`
+
+Fetches the live model catalogue from a cloud provider using its stored API key. Raises an error if:
+
+- The provider key is not stored or has been revoked (401/403)
+- The provider is unreachable (network error, 5xx)
+- The response is malformed or missing the models array
+
+`baseUrl` is forwarded for OpenAI-compatible servers (LM Studio, vLLM, etc.). Never falls back to a cached list when verifying a newly-entered key in onboarding; display surfaces cached by model-pickers if the network fails.
+
+```typescript
+interface ProviderModelInfo {
+  /** Canonical model ID; always present. */
+  name: string;
+  /** Human-readable label, when the provider distinguishes it from `name`. */
+  displayName?: string;
+  /** Unix epoch milliseconds. Normalized across providers' native formats. */
+  createdAt?: number;
+  /** Max input tokens (context window). */
+  contextLength?: number;
+}
+```
+
+**Important:** No field is guaranteed from every provider. Gemini provides no `createdAt`; OpenAI-compatible servers may omit `contextLength`. Treat missing fields as absent, never as a default value.
 
 ### Events
 

--- a/docs/adr/0022-live-model-listing-no-hardcoded-defaults.md
+++ b/docs/adr/0022-live-model-listing-no-hardcoded-defaults.md
@@ -1,0 +1,158 @@
+---
+status: accepted
+---
+
+# Live Model Listing — Providers Are the Source, No Hardcoded Defaults
+
+## Context
+
+Every cloud provider (`openai`, `anthropic`, `gemini`, `ollama-cloud`) had hand-curated model lists in TypeScript (`provider-meta.ts`), consumed by onboarding's `AISelectionStep` and `CloudProviderPanel`. The app defaulted to the first entry in each provider's list — no sort, no ranking.
+
+In July 2026, **four stale-model defects shipped in a single session**:
+
+1. **`text-embedding-004`** — retired by Google while still the default Gemini embedding model (discovered via embeddings)
+2. **OpenAI reasoning-effort gate** — keyed on legacy o-series, missed newer reasoning models
+3. **`gemini-3-pro-preview`** — shut down while in the curated list
+4. **Gemini list neighbors** — re-checking that list found its three neighbours also dead, including `gemini-2.0-flash`, the array's first entry and therefore the onboarding default
+
+All four bypassed testing because the CI build doesn't carry API keys (so live catalogues are never fetched), and the curated arrays were never re-audited for retirement after shipping.
+
+The root cause was structural: there is no source of truth _except_ each provider's own `/models` or equivalent endpoint — when an array is the cache + fallback, it rots silently.
+
+## Decision
+
+**Remove all hard-coded model arrays.** The provider's live catalogue (`listProviderModels`) is the only source.
+
+### Specific Changes
+
+1. **`AiProvider::list_models()` now returns `AppResult<Vec<Value>>`** (was `Vec<Value>`).
+   - Errors from failed fetches, missing auth, transport problems, unparseable responses, or empty catalogues are propagated to the caller.
+   - The TypeScript layer (`ai_list_provider_models` IPC command) rejects on any error, classified through `friendly_api_error()` (401/403 → config error; 429/5xx → network error; others → descriptive).
+   - **Before**: all failure modes were silently collapsed to `vec![]`, making an offline app look identical to an empty catalogue.
+
+2. **Model metadata is now carried by the live response**, not guessed locally:
+   - `ProviderModelInfo` has `{ name, displayName?, createdAt?, contextLength? }` — every field optional because no provider returns all.
+   - **Gemini returns no `createdAt` at all** — this is the evidence for why there is no auto-ranked default (a "newest first" heuristic would silently fail for the one provider whose default actually rotted).
+   - Both cloud list endpoints paginate; I/O is bounded by a cumulative deadline across every request.
+
+3. **Hand-curated model arrays are deleted:**
+   - TypeScript: the `models: [...]` array on each cloud entry in `provider-meta.ts`, plus the `provider-meta.test.ts` contract test that asserted each default pointed to a member of that list (deleting both guard and guarded entity together).
+
+4. **Onboarding defers model selection** until after a key is entered and the provider answers:
+   - The key-entry step is followed by a "pick a model" step that fetches the live list from the provider.
+   - **No model is pre-selected.** A hard-coded onboarding default is exactly the defect class this change avoids.
+   - "Skip" remains available for Ollama when no model is ready (via `canContinue` gating on installed + not too heavy).
+
+5. **Cache fallback behavior is explicit and split by purpose:**
+   - **`'display'` mode** (Settings UI, model picker):
+     - A fresh fetch is attempted.
+     - If it fails but a cached list exists for that provider + base URL, the cached list is served with a `{ cached: true }` flag for visual cue.
+     - **If there is no cache, the error is raised** — UI shows an error state, not an empty dropdown. A missing key will say so.
+   - **`'verify'` mode** (onboarding's Continue button, verifying a newly-entered key):
+     - A fresh fetch is attempted.
+     - **Cache fallback is never used**, even if available. A successful fetch proves the key works; serving a cached list from a _prior_ key could let a newly-entered wrong/revoked key pass verification.
+
+6. **CLI-agent aliases remain.** Local binaries (Claude Code, Codex, etc.) expose no catalogue endpoint, so aliases stay in the source:
+   - `cli_agent/claude_code.rs` line 21: `const MODELS: &[&str] = &["sonnet", "opus", "haiku", "fable"];`
+   - The same risk (stale names) exists, but there is no catalogue to fetch from, and missing/wrong names are caught at invocation time.
+
+### What Is NOT in Scope
+
+- Scheduled CI staleness checks were approved in the design but **dropped at implementation**: they would false-positive on nearly everything because:
+  - `RATES` deliberately retains retired model rows (e.g. `gemini-3-pro-preview`, `text-embedding-004`) so historical spend still prices correctly.
+  - CLI aliases appear in no catalogue.
+  - The false-positive rate means maintainers would ignore the signal.
+
+## Rationale
+
+### Why No Auto-Ranked Default?
+
+**Gemini's `/models` endpoint returns no `createdAt` field.** Anthropic, OpenAI, and Ollama all provide timestamps; Gemini does not. A "sort by creation date, pick the newest" rule works for three providers and silently fails for the one whose default actually rotted. Because:
+
+- If `createdAt` is absent in every Gemini entry, sorting by it returns either the list unchanged or an error.
+- Defaulting to the first entry (`createdAt` missing → sort unchanged → first) is fragile and invisible: the API response can change order, and there is no validation that the first entry is actually suitable.
+- Trying to infer recency from a release page or API docs would duplicate the provider's own data source — now maintained in two places.
+
+**Centralized, versioned model fetches are more robust than local heuristics.**
+
+### Why Is Verify Mode Different From Display Mode?
+
+The cache is keyed by `(provider, baseUrl)` with **no credential identity**. When a user enters a new API key:
+
+1. They go through onboarding's "enter key" → "pick model" flow.
+2. The model picker calls `useListProviderModels(provider, 'verify')`.
+3. If the key is wrong or revoked, the fetch fails.
+4. If **we served a cached list anyway** (from a _prior_, valid key for the same provider + URL), the UI would show "key is valid, here are your models" — but the _actual_ key is broken.
+5. The user would continue, hit a generation error, and see an unhelpful "invalid key" much later.
+
+**`'verify'` mode must not accept cache fallback**, because cache cannot encode which credential it came from.
+
+`'display'` mode (Settings AI tab) _can_ use cache fallback because the user already has a stored key — they're just re-rendering an existing list, not testing a new one. If the network is down, showing "last known models" with a `cached: true` flag is helpful.
+
+## Consequences
+
+- **Onboarding now has a network round-trip on the model-selection step.** This is intentional. A dead default is worse than a slower first run.
+- The provider's supported-models list is **refreshed per React Query staleTime**: 5 minutes for Settings' model-list fetch (`staleTime: 300_000` in `ModelSelector`), and 5 minutes (`QUERY_TIMES.VERY_LONG = 300_000`) for the service hook. Cache is considered stale after that interval, not invalid — a stale cached list is served if the live fetch fails (display mode only).
+- Both OpenAI and Gemini's `/models` endpoints support pagination; the Rust layer implements bounded iteration (cumulative deadline across all pages).
+- Settings → AI shows "loading…" briefly while the model list is fetched, then an error state if the list fails.
+- Export spend and capability checks still use `RATES` and `ModelCapabilities` matrices (defined in the Rust backend), which are static and must be manually maintained — but now only for _capability_ info, not model discovery. A model not in either matrix is still supported (the validator is permissive).
+- TypeScript caches the last-known list per provider + base URL for display purposes (via `readModelListCache` / `writeModelListCache` in `model-list-cache.ts`). **This cache is never used for verification.**
+
+## Alternatives Considered
+
+1. **Keep the array, add a CI job to refresh it weekly**
+   - Rejected: Would false-positive on retired models in `RATES` and CLI aliases, and maintainers would ignore it (see "What Is NOT in Scope").
+
+2. **Use model creation date for onboarding default, fall back to the first entry if none exists**
+   - Rejected: Gemini's lack of `createdAt` makes this silently unreliable.
+
+3. **Embed the provider's `/models` response at build time**
+   - Rejected: Doesn't solve the stale-after-release problem; just delays it.
+
+4. **Display a warning when a model is no longer in the provider's list**
+   - Deferred: `ModelCapabilities` checks still happen at generation time; a missing model is caught there, not at onboarding. A "model no longer available" warning on Settings would be a natural follow-up.
+
+## Residual Risks & Accepted Costs
+
+1. **A provider removes an effort level a model previously accepted.**
+   - `ModelCapabilities` is static; the backend doesn't re-query per model at generation time.
+   - If a model suddenly stops accepting `reasoning_effort="high"`, the app won't know until a generation fails.
+   - Mitigation: Rare (providers carefully maintain backward compatibility for reasoning effort). Edge case caught at generation, not silently-bad output.
+
+2. **`RATES` row for a retired model still exists and over-estimates cost.**
+   - Example: `gemini-3-pro-preview` is gone from the API, but `RATES` still has `{ model: "gemini-3-pro-preview", rate: $X }` for historical spend to price correctly.
+   - A new user could theoretically select it if they found the name in old docs or a cache. They would get a generation error, not a false cost estimate.
+   - Mitigation: `ProviderId::validate_model` rejects models that look like they belong to a different provider (by checking known prefix patterns like `claude*` for Anthropic, `gemini*` for Gemini, `gpt*`/`o1*`/`o3*` for OpenAI), but allows any unknown names because providers ship new models weekly.
+
+3. **Onboarding is slower on first run for cloud providers** (extra network round-trip).
+   - Acceptable: A fresh install that defers to "live data, no magic defaults" is more maintainable long-term.
+
+## Why This Shipped as Two PRs, Not Three
+
+The initial plan was three: (1) expose errors from `list_models`, (2) remove curated arrays, (3) teach onboarding to defer model selection. Steps 1 and 2 merged together (**#935 + #936**) because the curated arrays and their consumers (`CLOUD_DEFAULT_MODELS` maps in two onboarding surfaces, the contract test guarding them) are a single defect. Shipping step 2 alone would leave an intermediate state worse than either endpoint: arrays gone, contract guard gone, but the hardcoded defaults still there reaching for nothing.
+
+## Follow-Up Regression Fixed in #937
+
+#936 added a keyless carve-out for `openai-compatible` (LM Studio and vLLM users can list models without storing a key). But it only checked `if provider == 'openai-compatible'`, not whether the provider was actually configured. For unconfigured users:
+
+- `baseUrlFor('openai-compatible')` returns `undefined`
+- The backend falls back to `https://api.openai.com/v1` with no auth header
+- `ModelSelector` mounts on six surfaces
+- Every user (including fully local, offline Ollama users who never touched openai-compatible) made unauthenticated requests to `api.openai.com` on every relevant page load — breaking the local-first promise
+
+#937 fixed it by requiring `openai-compatible` to be configured (either a stored base URL or a stored key) before it can fetch. The same guard now applies uniformly across all surfaces (`isProviderConfigured` predicate rather than per-site special cases).
+
+## Important Notes
+
+- **A "model is gone" scenario is now caught at generation time**, not onboarding. The user picks a model from the provider's live list → starts a generation → the model now raises a provider-level error (404, deprecated, etc.). The error message is specific.
+
+## References
+
+- `packages/shared/src/ipc/contracts/ai.ts` — `ProviderModelInfo` interface, `listProviderModels` contract
+- `apps/desktop/src-tauri/src/commands/ai.rs` — `ai_list_provider_models` command (now returns `AppResult<Value>`)
+- `apps/desktop/src-tauri/src/commands/ai_provider/mod.rs` — `AiProvider::list_models()` trait method (now returns `AppResult`)
+- `apps/desktop/src-tauri/src/commands/ai_provider/{anthropic,gemini,openai,ollama_cloud}.rs` — per-provider implementations with pagination + deadline bounding
+- `apps/desktop/src/renderer/services/use-ai-provider/use-ai-provider.ts` — `fetchProviderModelsWithCache()`, `useListProviderModels()`, purpose-split cache logic
+- `apps/desktop/src/renderer/lib/ai-providers/model-list-cache.ts` — local cache implementation (display only, never used for verification)
+- `apps/desktop/src/renderer/features/onboarding/steps/ollama/CloudProviderPanel/index.tsx` — onboarding's model picker, uses `'verify'` mode
+- `apps/desktop/src/renderer/features/settings/components/ai-settings/CloudProviderConfig/index.tsx` — Settings' model picker, uses `'display'` mode

--- a/scripts/ci-review-verdict.test.mjs
+++ b/scripts/ci-review-verdict.test.mjs
@@ -5,6 +5,8 @@ import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
+import { inlineFindings, ledgerKey } from '../.claude/hooks/review-lib.mjs';
+
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const scriptPath = join(__dirname, 'ci-review-verdict.mjs');
 
@@ -77,5 +79,51 @@ describe('ci-review-verdict sticky comment rendering', () => {
     expect(comment).not.toContain('### 🔴 Critical');
     expect(comment).not.toContain('### 🟠 High');
     expect(comment).not.toContain('### 🟡 Medium');
+  });
+});
+
+// The "📌 Inline findings on the diff" step decides what to pin from these two
+// helpers, so the rules live here rather than in unrunnable workflow YAML.
+describe('inline finding selection', () => {
+  it('pins CRITICAL, HIGH and MEDIUM but leaves LOW to the sticky comment', () => {
+    const picked = inlineFindings([
+      finding({ severity: 'CRITICAL' }),
+      finding({ severity: 'HIGH' }),
+      finding({ severity: 'MEDIUM' }),
+      finding({ severity: 'LOW' }),
+    ]);
+    expect(picked.map((f) => f.severity)).toEqual(['CRITICAL', 'HIGH', 'MEDIUM']);
+  });
+
+  it('skips a pre-existing finding — inline comments are for what the diff introduced', () => {
+    expect(inlineFindings([finding({ severity: 'HIGH', introduced_by_diff: false })])).toEqual([]);
+  });
+
+  it('skips a finding that cannot be anchored, rather than letting the API reject it', () => {
+    // GitHub requires a path AND a line in the diff; a finding missing either
+    // must stay sticky-only instead of 422-ing the post.
+    expect(inlineFindings([finding({ severity: 'HIGH', line: 0 })])).toEqual([]);
+    expect(inlineFindings([finding({ severity: 'HIGH', line: undefined })])).toEqual([]);
+    expect(inlineFindings([finding({ severity: 'HIGH', file: '' })])).toEqual([]);
+  });
+
+  it('keeps a finding whose confidence is below the BLOCKING bar', () => {
+    // Inline is not gated on confidence — that bar decides the merge verdict.
+    // A MEDIUM at 0.5 is still worth showing next to the code it concerns.
+    expect(inlineFindings([finding({ severity: 'MEDIUM', confidence: 0.5 })])).toHaveLength(1);
+  });
+
+  it('gives the same finding a stable key across runs even when its line moves', () => {
+    // This is what stops every push re-posting the same comment: an edit above
+    // a finding shifts its line, and a line-keyed identity would look new.
+    const a = finding({ severity: 'HIGH', file: 'x.ts', line: 42 });
+    const b = finding({ severity: 'HIGH', file: 'x.ts', line: 108 });
+    expect(ledgerKey(a)).toBe(ledgerKey(b));
+  });
+
+  it('gives a different key to a different finding in the same file', () => {
+    const a = finding({ severity: 'HIGH', file: 'x.ts', summary: 'unbounded read' });
+    const b = finding({ severity: 'HIGH', file: 'x.ts', summary: 'missing null check' });
+    expect(ledgerKey(a)).not.toBe(ledgerKey(b));
   });
 });


### PR DESCRIPTION
Two commits, separate concerns, both meta-level (no app code).

## 1. `docs:` — ADR-0022 + `docs/API.md`

Closes out the programme that deleted every hardcoded cloud model id (#935, #936). The decision is hard to reverse and genuinely surprising to a future reader — *"why does this app ship no model list at all?"* — so the reasoning belongs somewhere other than a diff.

Records: the four stale-model defects that prompted it; why the onboarding default is a **user choice** rather than auto-ranked (Gemini's catalogue endpoint returns no creation date, so a newest-first rule would silently fail for the one provider whose default actually rotted); why CLI-agent aliases stay hardcoded; and why the scheduled CI staleness check from the original design was **dropped** — it would have false-positived on `RATES` rows that are deliberately retained so historical spend still prices correctly.

Costs are recorded honestly too: onboarding now blocks on a network round-trip that used to be instant, and #937's regression (the keyless carve-out probing `api.openai.com` for unconfigured users) is included as the clearest illustration of what removing a fallback exposes.

`docs/API.md` gains the `listProviderModels` entry it never had, including that it now **rejects** rather than resolving an empty list.

## 2. `ci:` — inline review findings, deduped

The AI review gate could already post inline comments, but only for blocking findings (HIGH/CRITICAL at confidence ≥ 0.8). That tier almost never fires — every finding this gate has produced recently was MEDIUM or LOW, living only in the sticky comment, away from the code it describes. The capability looked absent because it almost never qualified.

**The cap was load-bearing, though.** The action's inline tool does not deduplicate across runs and this lane re-runs on every push, so an unbounded instruction stacked a fresh copy of every finding each time — noise proportional to how long a PR stays open, worst on exactly the PRs getting the most review.

So the model no longer posts at all. It writes findings; a **deterministic step** decides what gets pinned, from the same JSON the verdict already uses — the same split that keeps model prose out of the merge decision.

Dedup reuses the existing `ledgerKey`: file + category + hash of summary, **with no line number**. That omission is the point — an edit above a finding shifts its line, and a line-keyed identity would repost it as new on the next push.

A finding whose line isn't in the diff makes GitHub reject the comment, so those are skipped with a warning rather than failing the step; the sticky comment carries every finding regardless.

Lane A1 (`@claude review`) keeps its inline tool — owner-triggered, runs once, nothing to deduplicate.

### ⚠️ This PR cannot self-test the review

`claude-code-action` refuses to run when a PR edits its own workflow file (the file must match the default branch). So the **AI Review check on this PR will fail open and prove nothing** — that's the documented guard against a PR rewriting its own reviewer, not a failure. Inline posting has to be verified on the next ordinary PR after this merges.

## Verification

`pnpm gen:workflows:check` in sync · `pnpm lint:strict` clean · `scripts/ci-review-verdict.test.mjs` 10 passed (4 existing + 6 new).

The tier rule and the key's line-independence are unit-tested, since neither is observable from workflow YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)