### PR TITLE
fix: import linkedin profiles anonymously, because signing in is what breaks it

### DIFF
--- a/apps/desktop/src-tauri/src/commands/profile_import.rs
+++ b/apps/desktop/src-tauri/src/commands/profile_import.rs
@@ -9,6 +9,16 @@ pub async fn profile_import_from_url(_app: AppHandle, url: String) -> Value {
             "name": profile.name,
             "platform": profile.platform,
         }),
-        Err(e) => json!({ "error": e }),
+        Err(e) => {
+            // Host only — never the profile path/slug (PII; diagnostics bundles
+            // get shared with support). The deeper fetch/parse layers already log
+            // HTTP status and session state for the LinkedIn path.
+            let host = reqwest::Url::parse(&url)
+                .ok()
+                .and_then(|u| u.host_str().map(str::to_string))
+                .unwrap_or_default();
+            log::warn!("[profile_import] import failed: host={host} error={e}");
+            json!({ "error": e })
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/profile_import/linkedin.rs
+++ b/apps/desktop/src-tauri/src/profile_import/linkedin.rs
@@ -11,15 +11,36 @@ use crate::error::{AppError, AppResult};
 /// as a fallback for experience, education, and skills.
 pub async fn import(url: &str) -> AppResult<ProfileData> {
     let html = fetch_page(url).await?;
-    let document = Html::parse_document(&html);
+    parse_profile(&html)
+}
 
-    // Try JSON-LD first for name/headline/summary
+/// Parse a fetched LinkedIn page into [`ProfileData`]. Pure (no network), so
+/// the parse-strictness gate below is unit-testable without a fetch mock.
+fn parse_profile(html: &str) -> AppResult<ProfileData> {
+    let document = Html::parse_document(html);
+
     let ld = extract_ld_json(&document);
-    let name = ld
+
+    // The `ld+json` Person block is LinkedIn's own signal that this response is
+    // a real, logged-out-visible profile page. An authwall / login redirect /
+    // authenticated SPA shell never carries one — but it DOES still carry a
+    // `<title>`/`og:title` tag (e.g. "LinkedIn Login, Sign in..."), which is why
+    // falling back to `og:title` for `name` used to make an authwall parse as a
+    // "successful" import of an almost-empty resume. Gate on the JSON-LD name
+    // before trusting anything else on the page.
+    let ld_name = ld
         .as_ref()
         .and_then(|v| v.get("name"))
         .and_then(|v| v.as_str())
-        .map(clean);
+        .map(clean)
+        .filter(|n| !n.is_empty());
+    let Some(name) = ld_name else {
+        log::warn!("[profile_import] linkedin parse failed: no ld+json Person block");
+        return Err(AppError::Parse(
+            "linkedin did not return public profile data for this url — it may be private, unavailable, or the request was blocked".to_string(),
+        ));
+    };
+
     let headline = ld
         .as_ref()
         .and_then(|v| v.get("jobTitle"))
@@ -43,19 +64,8 @@ pub async fn import(url: &str) -> AppResult<ProfileData> {
     let education = extract_list_section(&document, "education");
     let skills = extract_skills(&document, &ld);
 
-    // If JSON-LD name is missing, try og:title
-    let name =
-        name.or_else(|| extract_meta(&document, "og:title").map(|t| strip_linkedin_suffix(&t)));
-
-    if name.is_none() && experience.is_empty() && skills.is_empty() {
-        return Err(AppError::Parse(
-            "could not extract profile data — the profile may be private; log in to import it"
-                .to_string(),
-        ));
-    }
-
     Ok(ProfileData {
-        name,
+        name: Some(name),
         headline,
         summary,
         experience,
@@ -69,12 +79,16 @@ pub async fn import(url: &str) -> AppResult<ProfileData> {
 // ── HTTP ─────────────────────────────────────────────────────────────────────
 
 async fn fetch_page(url: &str) -> AppResult<String> {
-    // Use the connected LinkedIn session when available so a private profile
-    // becomes importable after the user logs in. With no session the cookie jar
-    // is empty, so public profiles still import with no login required.
-    let data_dir = crate::platform::config::data_dir();
-    let client = crate::scraping::board_login::build_authed_client(&data_dir, "linkedin")
-        .unwrap_or_else(|_| crate::net::http::shared());
+    // Deliberately anonymous — this is NOT an oversight. LinkedIn only embeds
+    // the `ld+json` Person block this parser depends on in the response served
+    // to logged-out/crawler requests. Once the user connects LinkedIn (Settings
+    // → Accounts) and `li_at` would be attached, the same URL instead returns
+    // the authenticated SPA shell / authwall, which has no `ld+json` to parse —
+    // attaching the session cookie jar here would break the only case that
+    // currently works. Board scraping and the login flow still use
+    // `board_login::build_authed_client` elsewhere; this file just never does.
+    let has_session = has_linkedin_session();
+    let client = crate::net::http::shared();
 
     let resp = client
         .get(url)
@@ -82,18 +96,56 @@ async fn fetch_page(url: &str) -> AppResult<String> {
         .header("Accept-Language", "en-US,en;q=0.9")
         .send()
         .await
-        .map_err(|e| format!("fetch profile: {e}"))?;
+        .map_err(|e| {
+            // `.without_url()` strips the request URL (which carries the profile
+            // slug — PII) from the error before it reaches the log or the UI.
+            log::warn!(
+                "[profile_import] linkedin fetch failed: has_session={has_session} error={}",
+                e.without_url()
+            );
+            AppError::Network("could not reach linkedin".to_string())
+        })?;
 
-    if !resp.status().is_success() {
-        let status = resp.status();
-        return Err(AppError::Provider(format!(
-            "linkedin returned {status} — the profile may be private; log in first"
-        )));
+    let status = resp.status();
+    if !status.is_success() {
+        log::warn!(
+            "[profile_import] linkedin fetch non-2xx: status={} has_session={has_session}",
+            status.as_u16()
+        );
+        return Err(map_status(status.as_u16()));
     }
 
-    resp.text()
-        .await
-        .map_err(|e| AppError::Network(format!("read body: {e}")))
+    resp.text().await.map_err(|e| {
+        log::warn!(
+            "[profile_import] linkedin body read failed: {}",
+            e.without_url()
+        );
+        AppError::Network("could not read the linkedin response".to_string())
+    })
+}
+
+/// Map a non-2xx LinkedIn response status to the appropriate [`AppError`]. Pure
+/// helper so the honest error-mapping that comes with fetching anonymously (no
+/// more "log in first" advice — see [`fetch_page`]) is unit-testable without a
+/// network call.
+fn map_status(status: u16) -> AppError {
+    if status == 429 {
+        AppError::RateLimited(
+            "linkedin rate-limited this request — wait a few minutes and try again".to_string(),
+        )
+    } else {
+        AppError::Provider(
+            "linkedin did not return this profile — it may be unavailable, or the request was blocked".to_string(),
+        )
+    }
+}
+
+/// Whether a LinkedIn session cookie jar is present on disk — diagnostic only.
+/// [`fetch_page`] never attaches it; this just lets the log confirm/refute a
+/// correlation between "connected" and a failed import.
+fn has_linkedin_session() -> bool {
+    let data_dir = crate::platform::config::data_dir();
+    !crate::scraping::board_login::load_cookies(&data_dir, "linkedin").is_empty()
 }
 
 // ── JSON-LD ───────────────────────────────────────────────────────────────────
@@ -185,4 +237,109 @@ fn strip_linkedin_suffix(s: &str) -> String {
         .unwrap_or(s)
         .trim()
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_profile: the strictness gate ────────────────────────────────────
+
+    fn public_profile_html(name: &str) -> String {
+        format!(
+            r#"<html><head>
+                <script type="application/ld+json">
+                {{
+                    "@type": "Person",
+                    "name": "{name}",
+                    "jobTitle": "Senior Engineer at Acme",
+                    "description": "Building great software.",
+                    "address": {{ "addressLocality": "Berlin, Germany" }},
+                    "knowsAbout": ["Rust", "TypeScript"]
+                }}
+                </script>
+            </head><body></body></html>"#
+        )
+    }
+
+    #[test]
+    fn parses_a_real_public_profile() {
+        let profile = parse_profile(&public_profile_html("Jane Doe")).unwrap();
+        assert_eq!(profile.name.as_deref(), Some("Jane Doe"));
+        assert_eq!(profile.headline.as_deref(), Some("Senior Engineer at Acme"));
+        assert_eq!(profile.location.as_deref(), Some("Berlin, Germany"));
+        assert_eq!(profile.skills, vec!["Rust", "TypeScript"]);
+    }
+
+    #[test]
+    fn rejects_authwall_page_with_no_ld_json() {
+        // No `ld+json` Person block at all — only an og:title, the way LinkedIn's
+        // login/authwall page looks. Must NOT fall back to og:title for `name`
+        // (that was the "successful import of nothing" regression).
+        let html = r#"<html><head>
+            <meta property="og:title" content="LinkedIn Login, Sign in | LinkedIn">
+        </head><body></body></html>"#;
+        let err = parse_profile(html).unwrap_err();
+        assert!(
+            matches!(err, AppError::Parse(_)),
+            "expected Parse, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_ld_json_with_empty_name() {
+        // Person block present but `name` is an empty string — must not pass the
+        // gate just because the field exists.
+        let html = r#"<html><head>
+            <script type="application/ld+json">
+            { "@type": "Person", "name": "" }
+            </script>
+        </head><body></body></html>"#;
+        let err = parse_profile(html).unwrap_err();
+        assert!(
+            matches!(err, AppError::Parse(_)),
+            "expected Parse, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_og_title_for_headline_only() {
+        // Headline fallback to og:title is still fine — only `name` is gated on
+        // ld+json.
+        let html = r#"<html><head>
+            <script type="application/ld+json">
+            { "@type": "Person", "name": "Jane Doe" }
+            </script>
+            <meta property="og:title" content="Jane Doe - Senior Engineer | LinkedIn">
+        </head><body></body></html>"#;
+        let profile = parse_profile(html).unwrap();
+        assert_eq!(profile.name.as_deref(), Some("Jane Doe"));
+        assert_eq!(profile.headline.as_deref(), Some("Jane Doe"));
+    }
+
+    // ── map_status: the honest-error-mapping that comes with fetching anon ────
+
+    #[test]
+    fn map_status_429_is_rate_limited() {
+        assert!(matches!(map_status(429), AppError::RateLimited(_)));
+    }
+
+    #[test]
+    fn map_status_other_non_2xx_is_provider_not_auth_advice() {
+        for status in [403, 404, 500, 999] {
+            let err = map_status(status);
+            assert!(
+                matches!(err, AppError::Provider(_)),
+                "status {status} should map to Provider, got {err:?}"
+            );
+            // Regression guard: the message must never tell the user to log in —
+            // we fetch anonymously on purpose, so that advice would be actively
+            // wrong (see `fetch_page`).
+            let msg = err.to_string().to_lowercase();
+            assert!(
+                !msg.contains("log in") && !msg.contains("sign in"),
+                "status {status} message must not suggest logging in: {msg:?}"
+            );
+        }
+    }
 }

--- a/apps/desktop/src/renderer/components/resume/ProfileUrlImport/index.test.tsx
+++ b/apps/desktop/src/renderer/components/resume/ProfileUrlImport/index.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * ProfileUrlImport — profile-fetch vs. save-failure handling.
+ *
+ * `documents_import` resolves (never rejects) on a save failure — an in-band
+ * `{ error }` payload, not a thrown mutation error — so a naive
+ * `await mutateAsync()` followed by unconditional success effects fires the
+ * success toast AND `onImported` on a failed save. These tests pin the fix:
+ * the save result is checked for `error` before either happens.
+ *
+ * They also cover the two backend profile-fetch error strings a real user
+ * will actually hit (rate-limited, no public data) — shown verbatim now that
+ * the dead "connect your LinkedIn account" auth-wall classifier is gone (the
+ * backend fetch is always anonymous; connecting an account is what used to
+ * break this).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type * as AjhUi from '@ajh/ui';
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const mockNotify = {
+  open: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  destroy: vi.fn(),
+};
+
+vi.mock('@ajh/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof AjhUi>();
+  return { ...actual, useNotification: () => mockNotify };
+});
+
+const profileImportMutateAsync = vi.fn();
+const importDocumentMutateAsync = vi.fn();
+
+vi.mock('@/services', () => ({
+  useProfileImport: () => ({ mutateAsync: profileImportMutateAsync, isPending: false }),
+  useImportDocument: () => ({ mutateAsync: importDocumentMutateAsync, isPending: false }),
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+import { ProfileUrlImport } from './index';
+
+const LINKEDIN_URL = 'https://linkedin.com/in/someone';
+
+/** Opens the URL field, types a valid LinkedIn URL, and submits. */
+async function submitUrl(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByText('resumeInput.importFromLinkedin'));
+  await user.type(screen.getByPlaceholderText('resumeInput.profileUrlPlaceholder'), LINKEDIN_URL);
+  await user.click(screen.getByText('resumeInput.profileUrlImport'));
+}
+
+describe('ProfileUrlImport — profile-fetch errors are shown verbatim', () => {
+  it('shows the rate-limited backend message and never attempts a save', async () => {
+    const message = 'linkedin rate-limited this request — wait a few minutes and try again';
+    profileImportMutateAsync.mockResolvedValue({ error: message });
+    const onImported = vi.fn();
+    const user = userEvent.setup();
+    render(<ProfileUrlImport onImported={onImported} />);
+
+    await submitUrl(user);
+
+    expect(mockNotify.error).toHaveBeenCalledWith({ message });
+    expect(importDocumentMutateAsync).not.toHaveBeenCalled();
+    expect(onImported).not.toHaveBeenCalled();
+  });
+
+  it('shows the no-public-data backend message and never attempts a save', async () => {
+    const message =
+      'linkedin did not return public profile data for this url — it may be private, unavailable, or the request was blocked';
+    profileImportMutateAsync.mockResolvedValue({ error: message });
+    const onImported = vi.fn();
+    const user = userEvent.setup();
+    render(<ProfileUrlImport onImported={onImported} />);
+
+    await submitUrl(user);
+
+    expect(mockNotify.error).toHaveBeenCalledWith({ message });
+    expect(onImported).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProfileUrlImport — a failed save does not fire the success toast', () => {
+  it('surfaces the save error and skips onImported when the save resolves { error }', async () => {
+    profileImportMutateAsync.mockResolvedValue({ text: 'resume text', name: 'Jane Doe' });
+    importDocumentMutateAsync.mockResolvedValue({ error: 'text extraction failed: boom' });
+    const onImported = vi.fn();
+    const user = userEvent.setup();
+    render(<ProfileUrlImport onImported={onImported} />);
+
+    await submitUrl(user);
+
+    expect(mockNotify.error).toHaveBeenCalledWith({ message: 'text extraction failed: boom' });
+    expect(mockNotify.success).not.toHaveBeenCalled();
+    expect(onImported).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the human message for a scanned_pdf save failure', async () => {
+    profileImportMutateAsync.mockResolvedValue({ text: 'resume text', name: 'Jane Doe' });
+    importDocumentMutateAsync.mockResolvedValue({
+      error: 'scanned_pdf',
+      message: 'PDF appears to be scanned. Please upload a text-based PDF or DOCX.',
+    });
+    const onImported = vi.fn();
+    const user = userEvent.setup();
+    render(<ProfileUrlImport onImported={onImported} />);
+
+    await submitUrl(user);
+
+    expect(mockNotify.error).toHaveBeenCalledWith({
+      message: 'PDF appears to be scanned. Please upload a text-based PDF or DOCX.',
+    });
+    expect(mockNotify.success).not.toHaveBeenCalled();
+    expect(onImported).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProfileUrlImport — successful import end-to-end', () => {
+  it('fires the success toast and onImported only after a successful save', async () => {
+    profileImportMutateAsync.mockResolvedValue({ text: 'resume text', name: 'Jane Doe' });
+    importDocumentMutateAsync.mockResolvedValue({ id: 'doc-1' });
+    const onImported = vi.fn();
+    const user = userEvent.setup();
+    render(<ProfileUrlImport onImported={onImported} />);
+
+    await submitUrl(user);
+
+    expect(mockNotify.success).toHaveBeenCalledWith({ message: 'resumeInput.profileImported' });
+    expect(onImported).toHaveBeenCalledWith({ id: 'doc-1', name: 'Jane Doe' });
+    expect(mockNotify.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/components/resume/ProfileUrlImport/index.tsx
+++ b/apps/desktop/src/renderer/components/resume/ProfileUrlImport/index.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from '@ajh/translations';
 import { Button, useNotification } from '@ajh/ui';
 
-import { isProfileAuthError, isSupportedProfileUrl } from '@/components/resume/profile-url';
+import { isSupportedProfileUrl } from '@/components/resume/profile-url';
 import { ProfileUrlInput } from '@/components/resume/ProfileUrlInput';
 import { useImportDocument, useProfileImport } from '@/services';
 
@@ -16,8 +16,10 @@ interface Props {
 /**
  * Import a resume from a public LinkedIn profile URL and save it to the document
  * library. Used in onboarding and Settings (contexts that need a saved document,
- * unlike ResumeInputCard which loads the text into the editor). No login is
- * required for public profiles; private ones surface a "log in" hint.
+ * unlike ResumeInputCard which loads the text into the editor). The fetch is
+ * always anonymous (LinkedIn only serves the parsable profile markup to
+ * signed-out requests), so backend failures are shown verbatim — they're
+ * already user-readable strings, not raw exception text.
  */
 export function ProfileUrlImport({ onImported }: Props) {
   const { t } = useTranslation();
@@ -40,11 +42,7 @@ export function ProfileUrlImport({ onImported }: Props) {
     try {
       const result = await profileImport.mutateAsync(url.trim());
       if ('error' in result) {
-        notify.error({
-          message: isProfileAuthError(result.error)
-            ? t('resumeInput.profileLoginRequired')
-            : result.error,
-        });
+        notify.error({ message: result.error });
         return;
       }
       const title = result.name?.trim() || t('resumeInput.linkedinProfileTitle');
@@ -52,9 +50,16 @@ export function ProfileUrlImport({ onImported }: Props) {
         name: `${title}.txt`,
         bytes: new TextEncoder().encode(result.text),
         title,
-      })) as { id?: string };
+      })) as { id?: string; error?: string; message?: string };
+      // `documents_import` resolves (never rejects) on a save failure — it's an
+      // in-band `{ error }` payload, not a thrown mutation error. `scanned_pdf`
+      // carries a human `message`; other failures use `error` itself.
+      if (saved.error) {
+        notify.error({ message: saved.message ?? saved.error });
+        return;
+      }
       notify.success({ message: t('resumeInput.profileImported') });
-      onImported?.({ id: saved?.id, name: result.name });
+      onImported?.({ id: saved.id, name: result.name });
       reset();
     } catch (err) {
       notify.error({

--- a/apps/desktop/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
+++ b/apps/desktop/src/renderer/components/resume/ResumeInputCard/useResumeInput.ts
@@ -17,7 +17,7 @@ import {
   useSetDefaultDocument,
 } from '@/services';
 
-import { isProfileAuthError, isSupportedProfileUrl } from '../profile-url';
+import { isSupportedProfileUrl } from '../profile-url';
 
 const MAX_BYTES = 25 * 1024 * 1024;
 
@@ -195,11 +195,7 @@ export function useResumeInput({ value, onChange }: Params) {
     try {
       const result = await profileImport.mutateAsync(url);
       if ('error' in result) {
-        notify.error({
-          message: isProfileAuthError(result.error)
-            ? t('resumeInput.profileLoginRequired')
-            : result.error,
-        });
+        notify.error({ message: result.error });
         return;
       }
       onChange(result.text);

--- a/apps/desktop/src/renderer/components/resume/profile-url.ts
+++ b/apps/desktop/src/renderer/components/resume/profile-url.ts
@@ -8,19 +8,3 @@
 export function isSupportedProfileUrl(url: string): boolean {
   return url.toLowerCase().includes('linkedin.com/in/');
 }
-
-/**
- * Whether a profile-import backend error is an authentication wall (the page
- * needs a logged-in LinkedIn session). Lets the UI show an actionable
- * "connect your account" hint instead of the raw scraper message.
- */
-export function isProfileAuthError(error: string): boolean {
-  const lower = error.toLowerCase();
-  return (
-    lower.includes('login') ||
-    lower.includes('log in') ||
-    lower.includes('sign in') ||
-    lower.includes('not authenticated') ||
-    lower.includes('unauthorized')
-  );
-}

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2508,7 +2508,6 @@
     "profileUrlImport": "Importieren",
     "profileImported": "Profil importiert",
     "profileImportFailed": "Import fehlgeschlagen",
-    "profileLoginRequired": "Dieses Profil ist möglicherweise privat. Verbinde dein LinkedIn-Konto unter Einstellungen → Konten und versuche es erneut.",
     "importFromLinkedin": "Von LinkedIn importieren",
     "linkedinProfileTitle": "LinkedIn-Profil",
     "profileUrlUnsupported": "Derzeit werden nur LinkedIn-Profil-URLs unterstützt",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2504,7 +2504,6 @@
     "profileUrlImport": "Import",
     "profileImported": "Profile imported",
     "profileImportFailed": "Import failed",
-    "profileLoginRequired": "This profile may be private. Connect your LinkedIn account in Settings → Accounts, then try again.",
     "importFromLinkedin": "Import from LinkedIn",
     "linkedinProfileTitle": "LinkedIn Profile",
     "profileUrlUnsupported": "Only LinkedIn profile URLs are supported right now",


### PR DESCRIPTION
Reported as *"LinkedIn import on welcome step imports resume, but in resume settings returns an error"* — while signed in to LinkedIn.

## The direction is backwards from how it reads

Both surfaces render the same `ProfileUrlImport` and call the same `profile_import_from_url`. **There is no code-level divergence.** The difference is runtime state, and **being signed in is what breaks it**:

- The importer fetches over plain `reqwest` + `scraper` — **no browser** — and needs the `ld+json` Person block LinkedIn serves only to **anonymous crawlers**.
- It built its client from `<app_data>/browser-state/linkedin/cookies.json` whenever that existed.
- Onboarding has no LinkedIn-connect step, so a fresh install fetched as a guest → public page → parsed fine. Connect LinkedIn, and the same URL returns the authenticated SPA shell → no `ld+json` → failure.

An authenticated fetch never yields a parseable profile, so the credentials bought nothing and broke the only case that worked. The profile-import GET now always fetches anonymously, **deliberately**, with the reason in a comment — "don't send the user's credentials" reads as an oversight otherwise.

Scoped to that GET. Board scraping and login keep their cookie jar; `build_authed_client`'s other caller is untouched.

## It was failing invisibly, twice

**The success toast lied.** The *import* result was error-checked; the *save* was cast to `{ id?: string }` and `notify.success` fired unconditionally. But `documents_import` returns `json!({ "error": ... })` **in-band rather than rejecting** — so a scanned PDF or failed extraction resolved, "Profile imported" appeared, and `onImported` ran with an undefined id, silently skipping the résumé write. **The bug report's own premise may never have been true.**

**The parse reported success on garbage.** It failed only when name AND experience AND skills were all empty, with `name` falling back to `og:title` — so an authwall page with a title produced a "successful" import of an empty résumé. Success now requires a real `ld+json` name, which is precisely the field an authenticated fetch withholds.

## The error advice was pointing at the cause

`isProfileAuthError` matched `login|log in|sign in|…` and replaced the backend message with *"Connect your LinkedIn account in Settings → Accounts."* That now tells the user to do the exact thing that breaks their import — and no backend string matches it any more, so it was dead as well as wrong.

**Deleted outright rather than rewritten.** Keeping a substring classifier over messages the backend owns would rebuild the two-places-encode-one-rule drift this repo keeps paying for. The backend strings were rewritten to be user-readable, so they're shown directly, and a test asserts none of them ever says "log in" again. `resumeInput.profileLoginRequired` removed from `en` + `de`.

## Logging

The path had **zero** `tracing` calls — which is why the reporter's diagnostics bundle contained nothing about their own bug (one app line, plus ~50 `chromiumoxide` warnings that are the *login window*, not the import). It now records platform, HTTP status, whether a session was attached, and the error — but **never the URL or slug**: bundles get shared, and a profile URL identifies a person.

## Found, not fixed (out of scope)

- `board_login/mod.rs` builds cookies with no `Domain=`, so reqwest stores them host-only — a cookie for `www.linkedin.com` isn't sent to `linkedin.com`, and both spellings pass `detect_platform`. Confined to the `scrape_url::try_linkedin` paste flow; the main board scraper bypasses the jar entirely.
- `use-import-with-ocr` checks only for `scanned_pdf`, so other `{ error }` shapes are swallowed with no feedback either way.

## Verification

`cargo clippy --all-features -D warnings` clean · `cargo test --lib` 3107 · `cargo test --test architecture` 11/11 · `pnpm typecheck` 13/13 · `pnpm lint:strict` clean · desktop 250 files / 2882 tests.

New tests cover the authwall page no longer parsing, the failed save no longer reporting success, `scanned_pdf` surfacing its message, and the rate-limited / no-public-data strings reaching the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LinkedIn profile imports now work more reliably with stricter profile detection and clearer handling of supported profile URLs.

* **Bug Fixes**
  * Improved import error messages and removed login-required wording for profile imports.
  * LinkedIn imports now fail gracefully when a profile isn’t publicly accessible, with better handling for rate limits and other fetch issues.
  * Successful imports and save failures now surface more consistently in the resume import flow.

* **Chores**
  * Updated translations to remove an obsolete profile login message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->