### PR TITLE
fix: pay off three deferred correctness defects

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
@@ -443,27 +443,53 @@ fn parse_gemini_frames(buf: &mut String, state: &mut GeminiScanner) -> Vec<Strea
     out
 }
 
+/// Whether Gemini's deprecated sampling knobs — `temperature`, `topP`, and
+/// `topK` (never wired up in this file — `AiGenerateRequest` has no `top_k`
+/// field, so there is nothing to gate for it) — should be withheld for
+/// `model`. ONE predicate decides all of them so a future model can't end up
+/// gated for one and not another: that exact drift is how `topP` shipped
+/// ungated in the first place while `temperature` already had this check.
+///
+/// Verified against two live Google references (fetched 2026-08-05), which
+/// group all three identically rather than singling out `temperature`:
+/// - `ai.google.dev/gemini-api/docs/whats-new-gemini-3.5`, "Parameter updates
+///   and best practices in Gemini 3.x" — explicitly scoped to "all Gemini
+///   3.x models", not just the newest releases: "`temperature`, `top_p`,
+///   `top_k`: we strongly recommend not changing the default values."
+/// - `ai.google.dev/gemini-api/docs/latest-model#sampling-parameter-deprecation`
+///   (scoped to Gemini 3.6 Flash / 3.5 Flash-Lite "and all future Gemini
+///   model releases"): "`temperature`, `top_p`, and `top_k` are deprecated
+///   and ignored. In future model generations, supplying these parameters
+///   returns an HTTP 400 error."
+///
+/// Reuses [`gemini_is_v3_or_later`] — the SAME boundary `thinkingLevel`
+/// gates on — rather than an enumerated model list, so a future Gemini
+/// 4/5/… release inherits the gate with no code change.
+fn gemini_omits_sampling_params(model: &str) -> bool {
+    gemini_is_v3_or_later(model)
+}
+
 /// Effective `temperature` to send, or `None` to omit the field entirely.
 /// `explicit` (the user's own choice, if any) ALWAYS wins, on every model —
-/// this never overrides a deliberate value. Absent that, every call site in
-/// this file used to fall back to its own hardcoded default (`0.7` for chat/
-/// complete, `0.2` for research) regardless of model. Google's live docs
+/// this never overrides a deliberate value; only the app's OWN hardcoded
+/// `fallback` default is gated (see [`gemini_omits_sampling_params`]).
+/// Absent an explicit value, every call site in this file used to fall back
+/// to its own hardcoded default (`0.7` for chat/complete, `0.2` for
+/// research) regardless of model. Google's live docs
 /// (`ai.google.dev/gemini-api/docs/gemini-3`, fetched 2026-08-04): "For all
 /// Gemini 3 models, we strongly recommend keeping the temperature parameter
 /// at its default value of `1.0`... Changing the temperature (setting it
 /// below 1.0) may lead to unexpected behavior, such as looping or degraded
 /// performance, particularly in complex mathematical or reasoning tasks."
-/// This is NOT a 400 — Gemini 3 accepts the field — it is a SILENT quality
-/// regression: injecting either hardcoded default put every Gemini 3+ call
-/// (chat, complete, AND research/synthesis, which is exactly the "complex
+/// Injecting either hardcoded default put every Gemini 3+ call (chat,
+/// complete, AND research/synthesis, which is exactly the "complex
 /// reasoning task" case) into the documented degradation case, including
 /// every new user via the onboarding default (`gemini-3.6-flash`, itself
-/// Gemini 3+). So on a v3+ model ([`gemini_is_v3_or_later`]) with no
-/// explicit value, this omits the field so the API applies its OWN 1.0
-/// default, instead of `fallback`; a pre-v3 model keeps `fallback`
-/// unchanged (Google's guidance is scoped to the 3.x family).
+/// Gemini 3+). So on a gated model with no explicit value, this omits the
+/// field so the API applies its OWN 1.0 default, instead of `fallback`; an
+/// ungated model keeps `fallback` unchanged.
 fn gemini_effective_temperature(model: &str, explicit: Option<f64>, fallback: f64) -> Option<f64> {
-    explicit.or_else(|| (!gemini_is_v3_or_later(model)).then_some(fallback))
+    explicit.or_else(|| (!gemini_omits_sampling_params(model)).then_some(fallback))
 }
 
 /// Build the `streamGenerateContent` request body for a given
@@ -471,7 +497,13 @@ fn gemini_effective_temperature(model: &str, explicit: Option<f64>, fallback: f6
 /// `presencePenalty` are the detector-resistance sampling knobs (RAID, ACL
 /// 2024) the renderer sets only for prose generation surfaces — the v1beta API
 /// supports all three on `generationConfig`, each added only when `Some`
-/// (never sent as `null`).
+/// (never sent as `null`). `topP` additionally never reaches a gated model
+/// (see [`gemini_omits_sampling_params`]) — unlike `temperature`, it has no
+/// app-side fallback to protect and no "explicit user intent" to preserve
+/// (it's a renderer-set anti-detection knob, not a user dial), so a gated
+/// model omits it unconditionally rather than only when unset.
+/// `frequencyPenalty`/`presencePenalty` are NOT covered by Google's
+/// deprecation and stay ungated.
 fn build_chat_stream_body(req: &AiGenerateRequest) -> Value {
     let temperature = gemini_effective_temperature(&req.model, req.temperature, 0.7);
     let system_text: String = req
@@ -499,8 +531,10 @@ fn build_chat_stream_body(req: &AiGenerateRequest) -> Value {
     if let Some(t) = temperature {
         generation_config["temperature"] = json!(t);
     }
-    if let Some(top_p) = req.top_p {
-        generation_config["topP"] = json!(top_p);
+    if !gemini_omits_sampling_params(&req.model) {
+        if let Some(top_p) = req.top_p {
+            generation_config["topP"] = json!(top_p);
+        }
     }
     if let Some(fp) = req.frequency_penalty {
         generation_config["frequencyPenalty"] = json!(fp);

--- a/apps/desktop/src-tauri/src/commands/ai_provider/gemini_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/gemini_tests.rs
@@ -12,10 +12,10 @@
 
 use super::{
     build_chat_stream_body, build_embed_body, gemini_effective_temperature, gemini_effort_levels,
-    gemini_is_v3_or_later, gemini_supports_thinking, join_parts_text, parse_gemini_embed_usage,
-    parse_gemini_frames, parse_gemini_parts, parse_gemini_turn, parse_gemini_usage,
-    parse_model_page, validate_gemini_key, AiProvider, GeminiClient, GeminiScanner, StreamPiece,
-    EMBED_OUTPUT_DIMENSIONALITY,
+    gemini_is_v3_or_later, gemini_omits_sampling_params, gemini_supports_thinking, join_parts_text,
+    parse_gemini_embed_usage, parse_gemini_frames, parse_gemini_parts, parse_gemini_turn,
+    parse_gemini_usage, parse_model_page, validate_gemini_key, AiProvider, GeminiClient,
+    GeminiScanner, StreamPiece, EMBED_OUTPUT_DIMENSIONALITY,
 };
 use crate::commands::ai_provider::{AiGenerateRequest, StopReason, ToolCall};
 use crate::error::AppError;
@@ -163,6 +163,46 @@ fn chat_stream_body_keeps_the_default_temperature_for_a_pre_v3_model_with_no_exp
     assert_eq!(
         body["generationConfig"]["temperature"],
         json!(0.7),
+        "unchanged behavior for pre-v3 models"
+    );
+}
+
+#[test]
+fn gemini_omits_sampling_params_matches_the_v3_gate() {
+    // ONE predicate decides temperature AND topP (and topK, if this file
+    // ever wires one up) — pinned directly so the two parameters can't
+    // drift apart the way `topP` silently did before this fix.
+    assert!(gemini_omits_sampling_params("gemini-3.6-flash"));
+    assert!(gemini_omits_sampling_params("gemini-3-pro-preview"));
+    assert!(!gemini_omits_sampling_params("gemini-1.5-flash"));
+    assert!(!gemini_omits_sampling_params("gemini-2.5-pro"));
+}
+
+#[test]
+fn chat_stream_body_omits_top_p_for_a_v3_model_even_when_explicit() {
+    // Unlike `temperature`, `topP` has no "deliberate user intent" to
+    // preserve — it's the renderer's own anti-detection knob (useless on a
+    // model that ignores it), so a v3+ model omits it unconditionally, even
+    // when the caller set one.
+    let mut req = base_request();
+    req.model = "gemini-3.6-flash".to_string();
+    req.top_p = Some(0.95);
+    let body = build_chat_stream_body(&req);
+    assert!(
+        body["generationConfig"].get("topP").is_none(),
+        "topP must never reach a v3+ model, even when explicitly set"
+    );
+}
+
+#[test]
+fn chat_stream_body_sends_top_p_for_a_pre_v3_model_when_explicit() {
+    let mut req = base_request();
+    req.model = "gemini-1.5-flash".to_string();
+    req.top_p = Some(0.95);
+    let body = build_chat_stream_body(&req);
+    assert_eq!(
+        body["generationConfig"]["topP"],
+        json!(0.95),
         "unchanged behavior for pre-v3 models"
     );
 }

--- a/apps/desktop/src-tauri/src/commands/match_resume.rs
+++ b/apps/desktop/src-tauri/src/commands/match_resume.rs
@@ -4,6 +4,7 @@ use parking_lot::Mutex;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 
+use crate::commands::ai_provider::EMBEDDING_VECTOR_VERSION;
 use crate::documents::keywords::{
     apply_stemmer, display_forms, keyword_coverage, keywords, keywords_normalized, make_stemmer,
     readable_gaps,
@@ -23,13 +24,15 @@ use crate::postings::PostingsCache;
 /// weighted `combined` score, the missing keywords (`gaps`), and short
 /// recommendations. Degrades gracefully to keyword-only when Ollama is offline.
 /// Cache-busting version for the match_scores result cache. Bump whenever the
-/// 0.6/0.4 weighting, the combined-score formula, the keyword/stemmer logic,
-/// or how the underlying VECTORS themselves are produced changes — any of
-/// which would make a previously-cached score stale. Bumped to 2 when
-/// embeddings moved from a naive single truncation to chunk-and-mean-pool
-/// (`EMBEDDING_VECTOR_VERSION`): a cached score computed against the OLD
-/// (truncated-prefix) vector must not be served once the vector itself can
-/// now be a full-document mean-pooled one under the identical space tag.
+/// 0.6/0.4 weighting, the combined-score formula, or the keyword/stemmer logic
+/// changes — any of which would make a previously-cached score stale. Was
+/// bumped to 2 alongside the v1->v2 `EMBEDDING_VECTOR_VERSION` bump (naive
+/// single truncation → chunk-and-mean-pool). A vector-FORMAT change no longer
+/// needs a coincidental bump here to invalidate: [`MatchScoreKey::vector_version`]
+/// carries `EMBEDDING_VECTOR_VERSION` directly, so that axis self-invalidates
+/// on its own (a cached score computed against an OLD-format vector is a miss
+/// once the vector itself can be a new-format one under the identical space
+/// tag) — this constant is now purely about the scoring FORMULA.
 const MATCH_FORMULA_VERSION: i64 = 2;
 
 /// Map the `semantic_scoring_enabled` request flag to the `semantic_enabled`
@@ -103,9 +106,9 @@ async fn score_one(
 
     // Self-invalidating result cache: the key captures every input that can
     // change the score (ids, embedding space, semantic on/off, formula version,
-    // and a hash of the final job text). A hit skips embedding + cosine +
-    // keyword work entirely. The job-not-found error above is returned before
-    // this point and is never cached.
+    // embedding vector version, and a hash of the final job text). A hit skips
+    // embedding + cosine + keyword work entirely. The job-not-found error above
+    // is returned before this point and is never cached.
     let job_text_hash = sha256_hex(&job_text);
     let cache_key = MatchScoreKey {
         resume_id: &resume.id,
@@ -114,6 +117,7 @@ async fn score_one(
         model: &active.model,
         semantic_enabled,
         formula_version: MATCH_FORMULA_VERSION,
+        vector_version: EMBEDDING_VECTOR_VERSION,
         job_text_hash: &job_text_hash,
     };
     if let Some(cached) = store.get_match_score_async(cache_key.to_owned_key()).await {
@@ -574,6 +578,7 @@ mod test {
             model: "nomic-embed-text",
             semantic_enabled: 1,
             formula_version: fv,
+            vector_version: EMBEDDING_VECTOR_VERSION,
             job_text_hash: &hash,
         };
 
@@ -586,6 +591,50 @@ mod test {
         // The next formula version is a different key → miss (stale on bump).
         assert!(store
             .get_match_score(&key(MATCH_FORMULA_VERSION + 1))
+            .is_none());
+    }
+
+    // The defect this pins: a semantic score is derived from embedding vectors,
+    // so a vector-FORMAT bump (`EMBEDDING_VECTOR_VERSION`) changes what a cached
+    // score means even when `formula_version` and the job text are unchanged.
+    // Before `vector_version` joined the key, this bump only self-invalidated
+    // by accident (a coincidental MATCH_FORMULA_VERSION bump, e.g. #933) — a
+    // future vector-format bump with no coincidental formula bump would have
+    // silently served a stale semantic score forever. Two otherwise-identical
+    // keys differing ONLY in `vector_version` must not collide.
+    #[test]
+    fn vector_version_bump_invalidates_cached_score() {
+        use crate::documents::{sha256_hex, DocumentStore, MatchScoreKey};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let store = DocumentStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+        let hash = sha256_hex("job text");
+        let key = |vv: i64| MatchScoreKey {
+            resume_id: "r",
+            job_id: "j",
+            provider: "ollama",
+            model: "nomic-embed-text",
+            semantic_enabled: 1,
+            formula_version: MATCH_FORMULA_VERSION,
+            vector_version: vv,
+            job_text_hash: &hash,
+        };
+
+        // Cache a score under the current vector version → hit.
+        store
+            .upsert_match_score(&key(EMBEDDING_VECTOR_VERSION), "{\"combined\":50}")
+            .unwrap();
+        assert!(store
+            .get_match_score(&key(EMBEDDING_VECTOR_VERSION))
+            .is_some());
+
+        // The next vector version is a different key → miss (stale on bump),
+        // with formula_version and every other field held identical — proves
+        // vector_version alone, not some other field, drives the invalidation.
+        assert!(store
+            .get_match_score(&key(EMBEDDING_VECTOR_VERSION + 1))
             .is_none());
     }
 
@@ -813,6 +862,7 @@ mod test {
             model: "nomic-embed-text",
             semantic_enabled: 1,
             formula_version: MATCH_FORMULA_VERSION,
+            vector_version: EMBEDDING_VECTOR_VERSION,
             job_text_hash: &hash,
         };
 

--- a/apps/desktop/src-tauri/src/documents/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/mod.rs
@@ -125,7 +125,7 @@ fn alias_retired_gemini_text_embedding_004(conn: &Connection) -> rusqlite::Resul
 
 /// Full cache key for the `match_scores` result cache (the table PK). Borrowed
 /// fields keep it allocation-free at the call site; passed by reference to the
-/// store methods. Grouped into a struct because 7 positional args read poorly.
+/// store methods. Grouped into a struct because 8 positional args read poorly.
 pub struct MatchScoreKey<'a> {
     pub resume_id: &'a str,
     pub job_id: &'a str,
@@ -134,6 +134,15 @@ pub struct MatchScoreKey<'a> {
     /// 1 when semantic scoring ran, 0 when it was skipped.
     pub semantic_enabled: i64,
     pub formula_version: i64,
+    /// [`EMBEDDING_VECTOR_VERSION`] at score-compute time. A semantic score is
+    /// derived from embedding vectors, so a vector-format bump changes what the
+    /// cached score MEANS even when neither `formula_version` nor the job text
+    /// changes — without this field a bump could only self-invalidate by
+    /// accident (a coincidental `formula_version` bump, or a maintainer
+    /// remembering to add a `DELETE FROM match_scores` to that release's
+    /// migration). Carrying it in the key makes invalidation structural: a new
+    /// `EMBEDDING_VECTOR_VERSION` is a new key, so it's a miss by construction.
+    pub vector_version: i64,
     /// SHA-256 of the post-translation job text (see [`sha256_hex`]).
     pub job_text_hash: &'a str,
 }
@@ -149,6 +158,7 @@ impl MatchScoreKey<'_> {
             model: self.model.to_string(),
             semantic_enabled: self.semantic_enabled,
             formula_version: self.formula_version,
+            vector_version: self.vector_version,
             job_text_hash: self.job_text_hash.to_string(),
         }
     }
@@ -165,6 +175,7 @@ pub struct OwnedMatchScoreKey {
     pub model: String,
     pub semantic_enabled: i64,
     pub formula_version: i64,
+    pub vector_version: i64,
     pub job_text_hash: String,
 }
 
@@ -179,6 +190,7 @@ impl OwnedMatchScoreKey {
             model: &self.model,
             semantic_enabled: self.semantic_enabled,
             formula_version: self.formula_version,
+            vector_version: self.vector_version,
             job_text_hash: &self.job_text_hash,
         }
     }
@@ -413,6 +425,41 @@ impl DocumentStore {
             // every provider's embeddings, not just Gemini's.
             name: "evict_posting_vectors_for_embedding_format_v2",
             up: |conn| conn.execute_batch("DELETE FROM posting_vectors;"),
+        },
+        Migration {
+            // `match_scores`' PK didn't carry the embedding vector version, only
+            // `formula_version` — so a semantic score computed from an old-format
+            // vector stayed a valid cache hit against new-format vectors unless a
+            // `MATCH_FORMULA_VERSION` bump happened to coincide with the
+            // `EMBEDDING_VECTOR_VERSION` bump (true of the v1->v2 migration above
+            // only by accident — CodeRabbit #933 follow-up). Adds `vector_version`
+            // to the PK so a future format bump invalidates by construction
+            // instead of relying on someone remembering to evict this table too.
+            // Recreated rather than `ALTER TABLE ADD COLUMN` because SQLite can't
+            // add a column to an existing PRIMARY KEY; `match_scores` is a pure
+            // result cache, so dropping its rows only forces a recompute, not a
+            // real data loss.
+            name: "add_vector_version_to_match_scores_key",
+            up: |conn| {
+                conn.execute_batch(
+                    "DROP TABLE IF EXISTS match_scores;
+                     CREATE TABLE match_scores (
+                        resume_id        TEXT NOT NULL,
+                        job_id           TEXT NOT NULL,
+                        provider         TEXT NOT NULL,
+                        model            TEXT NOT NULL,
+                        semantic_enabled INTEGER NOT NULL,
+                        formula_version  INTEGER NOT NULL,
+                        vector_version   INTEGER NOT NULL,
+                        job_text_hash    TEXT NOT NULL,
+                        score_json       TEXT NOT NULL,
+                        created_at       INTEGER NOT NULL,
+                        PRIMARY KEY (resume_id, job_id, provider, model, semantic_enabled,
+                                     formula_version, vector_version, job_text_hash)
+                     );
+                     CREATE INDEX IF NOT EXISTS idx_match_scores_created_at ON match_scores(created_at);",
+                )
+            },
         },
     ];
 
@@ -771,9 +818,10 @@ impl DocumentStore {
     //
     // Caches the full `match_resume` JSON result. The cache key (the table PK)
     // captures every input that can change the score: the resume/job ids, the
-    // embedding space, whether semantic scoring ran, the formula version, and a
-    // hash of the post-translation job text. A change to any of those is a new
-    // key — so the cache self-invalidates without explicit eviction.
+    // embedding space, whether semantic scoring ran, the formula version, the
+    // embedding vector version, and a hash of the post-translation job text. A
+    // change to any of those is a new key — so the cache self-invalidates
+    // without explicit eviction.
 
     /// Fetch a cached match-score JSON result for the given key, if present.
     pub fn get_match_score(&self, key: &MatchScoreKey) -> Option<serde_json::Value> {
@@ -1075,8 +1123,9 @@ fn get_match_score_with_conn(conn: &Connection, key: &MatchScoreKey) -> Option<s
     conn.query_row(
         "SELECT score_json FROM match_scores
          WHERE resume_id = ?1 AND job_id = ?2 AND provider = ?3 AND model = ?4
-           AND semantic_enabled = ?5 AND formula_version = ?6 AND job_text_hash = ?7
-           AND created_at >= ?8",
+           AND semantic_enabled = ?5 AND formula_version = ?6 AND vector_version = ?7
+           AND job_text_hash = ?8
+           AND created_at >= ?9",
         params![
             key.resume_id,
             key.job_id,
@@ -1084,6 +1133,7 @@ fn get_match_score_with_conn(conn: &Connection, key: &MatchScoreKey) -> Option<s
             key.model,
             key.semantic_enabled,
             key.formula_version,
+            key.vector_version,
             key.job_text_hash,
             cutoff,
         ],
@@ -1101,9 +1151,10 @@ fn upsert_match_score_with_conn(
     conn.execute(
         "INSERT INTO match_scores
             (resume_id, job_id, provider, model, semantic_enabled, formula_version,
-             job_text_hash, score_json, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-         ON CONFLICT(resume_id, job_id, provider, model, semantic_enabled, formula_version, job_text_hash)
+             vector_version, job_text_hash, score_json, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+         ON CONFLICT(resume_id, job_id, provider, model, semantic_enabled, formula_version,
+                     vector_version, job_text_hash)
          DO UPDATE SET score_json = excluded.score_json, created_at = excluded.created_at",
         params![
             key.resume_id,
@@ -1112,6 +1163,7 @@ fn upsert_match_score_with_conn(
             key.model,
             key.semantic_enabled,
             key.formula_version,
+            key.vector_version,
             key.job_text_hash,
             score_json,
             ts_to_db(now_ms()),

--- a/apps/desktop/src-tauri/src/documents/test.rs
+++ b/apps/desktop/src-tauri/src/documents/test.rs
@@ -799,8 +799,8 @@ fn alias_retired_gemini_text_embedding_004_evicts_posting_and_match_caches_only_
         conn.execute(
             "INSERT OR REPLACE INTO match_scores
              (resume_id, job_id, provider, model, semantic_enabled, formula_version,
-              job_text_hash, score_json, created_at)
-             VALUES ('r', 'job-1', 'gemini', 'text-embedding-004', 1, 1, ?1, '{\"score\":1}', ?2)",
+              vector_version, job_text_hash, score_json, created_at)
+             VALUES ('r', 'job-1', 'gemini', 'text-embedding-004', 1, 1, 1, ?1, '{\"score\":1}', ?2)",
             params![sha256_hex("job text"), ts_to_db(now_ms())],
         )
         .unwrap();
@@ -942,6 +942,7 @@ fn match_key<'a>(
         model: "nomic-embed-text",
         semantic_enabled,
         formula_version,
+        vector_version: 1,
         job_text_hash,
     }
 }
@@ -964,8 +965,55 @@ fn match_key_in_space<'a>(
         model,
         semantic_enabled,
         formula_version,
+        vector_version: 1,
         job_text_hash,
     }
+}
+
+// Real end-to-end path: seed a `match_scores` row under the OLD (7-column, no
+// `vector_version`) schema on a DB with every migration except this one
+// applied, then open for real. Proves the migration is actually registered in
+// `MIGRATIONS` and recreates the table with `vector_version` as a real PK
+// column backing it at the SQL layer — not just a field that compiles into
+// the Rust struct with nothing enforcing it underneath (SQLite can't `ALTER
+// TABLE` a column into an existing `PRIMARY KEY`, hence the drop+recreate).
+#[test]
+#[serial]
+fn add_vector_version_to_match_scores_key_heals_a_pre_seeded_row_through_a_real_open() {
+    let temp_dir = TempDir::new().unwrap();
+    let dir = temp_dir.path().to_path_buf();
+    std::fs::create_dir_all(&dir).unwrap();
+    let db_path = dir.join("documents.db");
+
+    let all = DocumentStore::MIGRATIONS;
+    let vv_idx = all
+        .iter()
+        .position(|m| m.name == "add_vector_version_to_match_scores_key")
+        .expect("add_vector_version_to_match_scores_key must still be registered");
+    {
+        let mut conn = crate::db::open(&db_path).unwrap();
+        run_migrations(&mut conn, &all[..vv_idx]).unwrap();
+        // Old schema: no `vector_version` column yet.
+        conn.execute(
+            "INSERT INTO match_scores
+                (resume_id, job_id, provider, model, semantic_enabled, formula_version,
+                 job_text_hash, score_json, created_at)
+             VALUES ('r', 'j', 'ollama', 'nomic-embed-text', 1, 1, 'hash', '{}', 0)",
+            [],
+        )
+        .unwrap();
+    }
+
+    let store = DocumentStore::open(&dir).unwrap();
+    // The recreated table starts empty — a pure result cache, so losing a
+    // pre-migration row is safe (it just forces one recompute).
+    assert_eq!(count_table(&store, "match_scores"), 0);
+
+    // The new column is real and part of the PK: writes/reads round-trip
+    // through the ordinary store API on the recreated schema.
+    let key = match_key("r", "j", 1, 1, "hash");
+    store.upsert_match_score(&key, "{\"combined\":1}").unwrap();
+    assert!(store.get_match_score(&key).is_some());
 }
 
 #[test]
@@ -996,6 +1044,14 @@ fn test_match_score_round_trip_and_key_sensitivity() {
     // Changing semantic_enabled → miss.
     let key_s0 = match_key("resume-1", "job-1", 0, 1, &hash);
     assert!(store.get_match_score(&key_s0).is_none());
+
+    // Changing vector_version (with everything else, including
+    // formula_version, held identical) → miss. A semantic score is derived
+    // from embedding vectors, so a vector-format bump must invalidate on its
+    // own, not just piggyback on a coincidental formula_version bump.
+    let mut key_vv2 = match_key("resume-1", "job-1", 1, 1, &hash);
+    key_vv2.vector_version = 2;
+    assert!(store.get_match_score(&key_vv2).is_none());
 }
 
 // Invalidation matrix — the embedding-space axis of the PK. A score cached in the
@@ -1202,8 +1258,8 @@ fn prune_caches_row_cap_keeps_newest_match_scores() {
         conn.execute(
             "INSERT OR REPLACE INTO match_scores
              (resume_id, job_id, provider, model, semantic_enabled, formula_version,
-              job_text_hash, score_json, created_at)
-             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, ?2, ?3, ?4)",
+              vector_version, job_text_hash, score_json, created_at)
+             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, 1, ?2, ?3, ?4)",
             params![
                 format!("job-{i}"),
                 hash,
@@ -1340,8 +1396,8 @@ fn prune_caches_ttl_removes_old_match_scores() {
         conn.execute(
             "INSERT OR REPLACE INTO match_scores
              (resume_id, job_id, provider, model, semantic_enabled, formula_version,
-              job_text_hash, score_json, created_at)
-             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, ?2, '{\"s\":1}', ?3)",
+              vector_version, job_text_hash, score_json, created_at)
+             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, 1, ?2, '{\"s\":1}', ?3)",
             params![job_id, hash, ts_to_db(ts)],
         )
         .unwrap();
@@ -1391,6 +1447,7 @@ fn get_match_score_returns_none_for_expired_row_via_live_ttl() {
         model: "nomic-embed-text",
         semantic_enabled: 1,
         formula_version: 1,
+        vector_version: 1,
         job_text_hash: &hash,
     };
     // Insert with generous limits to avoid per-write eviction interfering.
@@ -1473,6 +1530,7 @@ fn prune_caches_generous_leaves_all_rows_intact() {
             model: "nomic-embed-text",
             semantic_enabled: 1,
             formula_version: 1,
+            vector_version: 1,
             job_text_hash: &hash,
         };
         store.upsert_match_score(&key, "{\"s\":1}").unwrap();
@@ -1529,8 +1587,8 @@ fn prune_caches_cap_zero_keeps_exactly_the_single_newest_row() {
         conn.execute(
             "INSERT OR REPLACE INTO match_scores
              (resume_id, job_id, provider, model, semantic_enabled, formula_version,
-              job_text_hash, score_json, created_at)
-             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, ?2, ?3, ?4)",
+              vector_version, job_text_hash, score_json, created_at)
+             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, 1, ?2, ?3, ?4)",
             params![
                 format!("cap0-job-{i}"),
                 hash,
@@ -1633,8 +1691,8 @@ fn prune_caches_cap_with_tied_timestamps_retains_newest_and_at_least_bound() {
         conn.execute(
             "INSERT OR REPLACE INTO match_scores
              (resume_id, job_id, provider, model, semantic_enabled, formula_version,
-              job_text_hash, score_json, created_at)
-             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, ?2, '{\"s\":1}', ?3)",
+              vector_version, job_text_hash, score_json, created_at)
+             VALUES ('r', ?1, 'ollama', 'nomic-embed-text', 1, 1, 1, ?2, '{\"s\":1}', ?3)",
             params![format!("tie-old-{i}"), hash, ts_to_db(old_ts)],
         )
         .unwrap();
@@ -1645,8 +1703,8 @@ fn prune_caches_cap_with_tied_timestamps_retains_newest_and_at_least_bound() {
         conn.execute(
             "INSERT OR REPLACE INTO match_scores
              (resume_id, job_id, provider, model, semantic_enabled, formula_version,
-              job_text_hash, score_json, created_at)
-             VALUES ('r', 'tie-new', 'ollama', 'nomic-embed-text', 1, 1, ?1, '{\"s\":2}', ?2)",
+              vector_version, job_text_hash, score_json, created_at)
+             VALUES ('r', 'tie-new', 'ollama', 'nomic-embed-text', 1, 1, 1, ?1, '{\"s\":2}', ?2)",
             params![hash, ts_to_db(new_ts)],
         )
         .unwrap();

--- a/apps/desktop/src-tauri/src/scraping/board_login/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/board_login/mod.rs
@@ -386,15 +386,26 @@ pub fn load_cookies(app_data_dir: &Path, board_id: &str) -> Vec<StoredCookie> {
         .unwrap_or_default()
 }
 
-/// Build an authenticated reqwest::Client for `board_id`. The returned client
-/// has a cookie jar pre-populated with the cookies captured during login.
+/// Rebuild a `reqwest` cookie jar from persisted `cookies`, honouring each
+/// cookie's own `Domain` scope instead of collapsing everything to host-only.
 ///
-/// Returns an empty-jar client if no cookies are stored — callers can decide
-/// whether to fall through to a guest flow or surface a "not connected" error.
-pub fn build_authed_client(app_data_dir: &Path, board_id: &str) -> Result<reqwest::Client> {
+/// RFC 6265 §5.2.3: a cookie added with no `Domain` attribute is host-only —
+/// bound to the exact host of the URL it's added against. Chromium's exported
+/// `domain` field carries a leading dot when the cookie was captured *with* a
+/// `Domain` attribute (subdomain-scoped) and no dot when it was host-only. We
+/// mirror that distinction back into the rebuilt cookie string so a
+/// `.example.com` cookie still reaches `www.example.com`, and a host-only
+/// cookie stays bound to exactly the host it was issued for.
+///
+/// Deliberately narrow, not wide: we only ever set `Domain` to the value the
+/// site itself set (`host`, derived from the stored domain), and the jar's
+/// own domain-match check against `url` (also derived from `host`) still
+/// rejects anything that doesn't match — this can't send a cookie to a host
+/// it wasn't issued for.
+pub(crate) fn build_cookie_jar(cookies: &[StoredCookie]) -> std::sync::Arc<reqwest::cookie::Jar> {
     let jar = std::sync::Arc::new(reqwest::cookie::Jar::default());
 
-    for c in load_cookies(app_data_dir, board_id) {
+    for c in cookies {
         // Domains starting with '.' are valid in netscape format but need a
         // concrete host for the URL. Use https://<domain-no-leading-dot>/.
         let host = c.domain.trim_start_matches('.');
@@ -406,6 +417,15 @@ pub fn build_authed_client(app_data_dir: &Path, board_id: &str) -> Result<reqwes
             Err(_) => continue,
         };
         let mut cookie_str = format!("{}={}; Path={}", c.name, c.value, c.path);
+        // A leading dot on the stored domain means the cookie was captured with
+        // an explicit Domain attribute (subdomain-scoped). Add that Domain
+        // attribute back so the jar treats it as a domain cookie (sent to
+        // `host` and its subdomains) instead of silently downgrading it to
+        // host-only. No leading dot means it was already host-only when
+        // captured — omit Domain so it stays bound to exactly `host`.
+        if c.domain.starts_with('.') {
+            cookie_str.push_str(&format!("; Domain={host}"));
+        }
         if c.secure {
             cookie_str.push_str("; Secure");
         }
@@ -414,6 +434,17 @@ pub fn build_authed_client(app_data_dir: &Path, board_id: &str) -> Result<reqwes
         }
         jar.add_cookie_str(&cookie_str, &url);
     }
+
+    jar
+}
+
+/// Build an authenticated reqwest::Client for `board_id`. The returned client
+/// has a cookie jar pre-populated with the cookies captured during login.
+///
+/// Returns an empty-jar client if no cookies are stored — callers can decide
+/// whether to fall through to a guest flow or surface a "not connected" error.
+pub fn build_authed_client(app_data_dir: &Path, board_id: &str) -> Result<reqwest::Client> {
+    let jar = build_cookie_jar(&load_cookies(app_data_dir, board_id));
 
     crate::net::http::build_client(crate::net::http::ClientConfig {
         timeout: Some(std::time::Duration::from_secs(30)),

--- a/apps/desktop/src-tauri/src/scraping/board_login/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/board_login/test.rs
@@ -244,3 +244,78 @@ fn test_board_login_config_copy() {
     assert_eq!(copied.id, "linkedin");
     assert_eq!(copied.display_name, "LinkedIn");
 }
+
+// ── build_cookie_jar: Domain-attribute fidelity ────────────────────────────
+//
+// RFC 6265 §5.3: a cookie added with no Domain attribute is host-only, bound
+// to the exact host it was added against. These assert the rebuilt jar
+// honours each stored cookie's own scope (leading-dot domain vs host-only)
+// instead of collapsing every cookie to host-only.
+
+fn stored_cookie(name: &str, domain: &str) -> StoredCookie {
+    StoredCookie {
+        name: name.to_string(),
+        value: "tok".to_string(),
+        domain: domain.to_string(),
+        path: "/".to_string(),
+        expires: None,
+        http_only: true,
+        secure: true,
+    }
+}
+
+/// `.linkedin.com` (leading dot = captured with an explicit Domain attribute)
+/// must reach both the apex and any subdomain — this is the bug being fixed.
+#[test]
+fn domain_cookie_reaches_apex_and_subdomain() {
+    use reqwest::cookie::CookieStore;
+    let jar = build_cookie_jar(&[stored_cookie("li_at", ".linkedin.com")]);
+
+    let apex = reqwest::Url::parse("https://linkedin.com/").unwrap();
+    let sub = reqwest::Url::parse("https://www.linkedin.com/").unwrap();
+
+    let apex_header = jar.cookies(&apex).expect("must be sent to the apex domain");
+    assert!(apex_header.to_str().unwrap().contains("li_at=tok"));
+    let sub_header = jar
+        .cookies(&sub)
+        .expect("must be sent to a subdomain (the bug this fixes)");
+    assert!(sub_header.to_str().unwrap().contains("li_at=tok"));
+}
+
+/// `linkedin.com` (no leading dot = host-only when captured) must stay bound
+/// to exactly that host and NOT leak to a sibling subdomain.
+#[test]
+fn host_only_cookie_stays_host_only() {
+    use reqwest::cookie::CookieStore;
+    let jar = build_cookie_jar(&[stored_cookie("sess", "linkedin.com")]);
+
+    let exact = reqwest::Url::parse("https://linkedin.com/").unwrap();
+    let sub = reqwest::Url::parse("https://www.linkedin.com/").unwrap();
+
+    assert!(
+        jar.cookies(&exact).is_some(),
+        "must still be sent to its exact host"
+    );
+    assert!(
+        jar.cookies(&sub).is_none(),
+        "must NOT widen to a subdomain it wasn't issued for"
+    );
+}
+
+/// Safety property: regardless of stored scope, the cookie must never reach
+/// an unrelated host. Regression guard — fails if scope is ever widened
+/// beyond what the stored cookie's own Domain says.
+#[test]
+fn cookie_never_sent_to_unrelated_host() {
+    use reqwest::cookie::CookieStore;
+    let jar = build_cookie_jar(&[
+        stored_cookie("li_at", ".linkedin.com"),
+        stored_cookie("sess", "linkedin.com"),
+    ]);
+
+    let unrelated = reqwest::Url::parse("https://evil.example/").unwrap();
+    assert!(
+        jar.cookies(&unrelated).is_none(),
+        "cookie must never reach a host it wasn't issued for"
+    );
+}


### PR DESCRIPTION
Three independent fixes, each deferred from an earlier PR's review. Every one produces a **wrong answer without producing an error**, so none would have surfaced from ordinary use.

## 1. Cached match scores ignored the embedding vector format

`MatchScoreKey` carried provider, model and `formula_version` — not the vector version. Semantic scores are computed *from* embeddings, so a format change left every cached score a valid hit against vectors that no longer mean the same thing.

**It has been safe only by coincidence.** #933's format bump happened to land alongside a `MATCH_FORMULA_VERSION` bump, and *that* field is in the key — so scores were invalidated on the formula axis, by luck rather than by anything reasoning about vectors. The `evict_..._format_v2` migration clears `posting_vectors`, not `match_scores`.

The version is now part of the key **and** the table's primary key, so a format change invalidates by construction. Adding a `DELETE` to each future migration was the alternative, and it depends on whoever writes the next migration remembering — which is exactly what this already survived once on luck.

Raised by CodeRabbit on #933, correctly about the shape and incorrectly that it was live.

> **Found, not fixed:** `posting_vectors` has no persisted version column at all — it synthesises the current one on read, so it can never self-detect staleness and still needs a hand-written eviction per bump. That's a schema change; separate PR.

## 2. Authentication depended on how the URL was spelled

`board_login` rebuilt stored cookies as `name=value; Path=…` with **no `Domain`**, added against the stored domain minus its leading dot. Per RFC 6265 that makes them host-only — discarding the leading dot, which is the very thing marking a cookie as applying to subdomains. A session captured for `.linkedin.com` then never reached `www.linkedin.com`.

Both spellings pass `detect_platform`, so the same account silently produced an authenticated or a guest fetch depending on URL form.

A stored domain with the leading dot now rebuilds with `Domain`; one without stays host-only. **Deliberately narrow** — `Domain` is only ever the cookie's own host. Widening a session credential's scope would send it to a host it was never issued for, which is worse than the bug; where the stored shape is ambiguous it stays host-only.

The safety test (never attached to an unrelated host) was confirmed load-bearing by temporarily broadening the code and watching it fail.

Found during #940's investigation, correctly left out of that PR.

## 3. Gemini's `top_p` escaped the gate `temperature` got

Google deprecates `temperature`, `top_p` and `top_k` **together** for Gemini 3.x — ignored today, documented as a future 400. `temperature` received a per-model gate during the reasoning-effort work; `top_p` was left behind in the same commit, so two halves of one API rule disagreed about the same models.

Both now run through one `gemini_omits_sampling_params` predicate, so a future model can't be gated for one parameter and not the other. **Sharing the rule is the fix, and not sharing it is how the defect was created.**

`top_p` is omitted on v3+ *even when explicit*, deliberately unlike temperature's explicit-always-wins carve-out: temperature is a user dial, so an explicit value is intent worth honouring, whereas `top_p` here is set by our own anti-detection code — no user intent to preserve, nothing worth risking a 400 for. The reasoning is in the doc comments, because a reader would otherwise "correct" the asymmetry.

Verified against Google's current docs rather than inherited from the earlier review. `top_k` is never sent by this adapter, so it needs no gate today.

Raised on #933's review and deferred.

## Verification

`cargo fmt --all --check` clean · `cargo clippy --all-targets --all-features --locked -D warnings` 0 warnings · `cargo test --lib` **3115 passed** · `cargo test --test architecture` 11/11 · `pnpm typecheck` 13/13 · `pnpm lint:strict` clean · `pnpm gen:ipc:check` no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)