### PR TITLE
feat: index documents automatically, and stop the index strip reading as a chore

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -819,25 +819,38 @@ fn reembed_run_failed(done: u32, failed: u32) -> bool {
     done == 0 && failed > 0
 }
 
-/// Re-embed every document with the active embedding config, rebuilding the
-/// vector index in the active space. Emits `jobs:event` progress and returns a
-/// job id. Clears the live posting embedding cache so stale-space entries go too.
-#[tauri::command]
-pub async fn ai_reembed_all(app: AppHandle) -> Value {
-    let job_id = new_job_id();
-    crate::commands::jobs::job_start(&app, &job_id, "ai.reembed");
+/// Documents with no usable vector in the ACTIVE embedding space — i.e. never
+/// indexed, or indexed under a different provider/model/format.
+///
+/// The same `EmbeddingConfig::matches` predicate `match_resume` uses to decide
+/// whether it can reuse a stored vector, so "stale" means exactly the same thing
+/// to the indexer and to the consumer.
+fn stale_documents(app: &AppHandle) -> Vec<crate::documents::DocumentRecord> {
+    let store = app.state::<DocumentStore>();
+    let cfg = store.embedding_config();
+    store
+        .list()
+        .into_iter()
+        .filter(|d| {
+            !store
+                .get_vector(&d.id)
+                .is_some_and(|v| cfg.matches(&v.space))
+        })
+        .collect()
+}
 
-    let job_id_clone = job_id.clone();
-    let app_clone = app.clone();
-    tauri::async_runtime::spawn(async move {
-        // Drop stale live-posting embeddings so search re-embeds them.
-        app_clone
-            .state::<Mutex<PostingsCache>>()
-            .lock()
-            .clear_embeddings();
-
-        // Snapshot documents up front so no store guard is held across awaits.
-        let docs = app_clone.state::<DocumentStore>().list();
+/// Embed `docs` with the active config and write the vectors, emitting
+/// `jobs:event` progress. The shared body of [`ai_reembed_all`] (every document,
+/// a full rebuild) and [`ai_index_stale_documents`] (only what is missing) so the
+/// two can never drift in error handling, cancellation or progress reporting.
+async fn run_embed_job(
+    app: AppHandle,
+    job_id: String,
+    docs: Vec<crate::documents::DocumentRecord>,
+) {
+    let app_clone = app;
+    let job_id_clone = job_id;
+    {
         let total = docs.len();
         let mut done = 0u32;
         let mut failed = 0u32;
@@ -937,6 +950,58 @@ pub async fn ai_reembed_all(app: AppHandle) -> Value {
             &job_id_clone,
             json!({ "reembedded": done, "failed": failed, "total": total }),
         );
+    }
+}
+
+/// Re-embed every document with the active embedding config, rebuilding the
+/// vector index in the active space. Emits `jobs:event` progress and returns a
+/// job id. Clears the live posting embedding cache so stale-space entries go too.
+#[tauri::command]
+pub async fn ai_reembed_all(app: AppHandle) -> Value {
+    let job_id = new_job_id();
+    crate::commands::jobs::job_start(&app, &job_id, "ai.reembed");
+
+    let job_id_clone = job_id.clone();
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn(async move {
+        // Drop stale live-posting embeddings so search re-embeds them.
+        app_clone
+            .state::<Mutex<PostingsCache>>()
+            .lock()
+            .clear_embeddings();
+
+        // Snapshot documents up front so no store guard is held across awaits.
+        let docs = app_clone.state::<DocumentStore>().list();
+        run_embed_job(app_clone, job_id_clone, docs).await;
+    });
+
+    json!({ "jobId": job_id })
+}
+
+/// Index only the documents that have no usable vector in the active space.
+///
+/// The auto-index path (renderer preference `autoIndexOnUpload`): a newly
+/// imported résumé, or every document after the embedding provider/model
+/// changed. Deliberately NOT [`ai_reembed_all`] — that re-embeds every document
+/// unconditionally, so using it here would re-bill a cloud embedding provider
+/// for documents that are already correctly indexed every time one new file is
+/// added.
+///
+/// Returns `{ "jobId": null }` when nothing is stale, so the caller can stay
+/// silent instead of showing progress for a no-op run.
+#[tauri::command]
+pub async fn ai_index_stale_documents(app: AppHandle) -> Value {
+    let docs = stale_documents(&app);
+    if docs.is_empty() {
+        return json!({ "jobId": Value::Null });
+    }
+    let job_id = new_job_id();
+    crate::commands::jobs::job_start(&app, &job_id, "ai.indexStale");
+
+    let job_id_clone = job_id.clone();
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn(async move {
+        run_embed_job(app_clone, job_id_clone, docs).await;
     });
 
     json!({ "jobId": job_id })

--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -667,6 +667,11 @@ pub async fn ai_embedding_status(app: AppHandle) -> Value {
             "indexedInActiveSpace": indexed_in_active,
             "stale": total_docs.saturating_sub(indexed_in_active),
         },
+        // Whether an embedding job is running right now (auto or manual). The
+        // settings strip needs the real thing: inferring "indexing now" from the
+        // auto-index PREFERENCE alone claims work is happening even when the run
+        // already failed, or was never started because nothing changed.
+        "indexing": running_embed_job(&app).is_some(),
     })
 }
 
@@ -819,6 +824,41 @@ fn reembed_run_failed(done: u32, failed: u32) -> bool {
     done == 0 && failed > 0
 }
 
+/// Job kinds that embed documents. Both write the same vectors for the same
+/// documents, so only ONE may run at a time.
+const EMBED_JOB_KINDS: [&str; 2] = ["ai.reembed", "ai.indexStale"];
+
+/// The id of an embedding job already running, if any.
+///
+/// Auto-indexing and the manual "Re-index now" button are independent triggers
+/// with no knowledge of each other, so without this a background auto-index and
+/// a user's button press embed the same documents concurrently — billing a cloud
+/// provider twice for identical work. Enforced in the BACKEND rather than by
+/// disabling the button, because that is the only place every trigger has to
+/// pass through; a UI-only guard narrows the race instead of closing it.
+fn running_embed_job(app: &AppHandle) -> Option<String> {
+    app.state::<Mutex<JobTracker>>()
+        .lock()
+        .list()
+        .iter()
+        .find(|j| is_active_embed_job(&j.kind, &j.status))
+        .map(|j| j.id.clone())
+}
+
+/// Whether a job record is an embedding job that has NOT finished.
+///
+/// Split out of [`running_embed_job`] purely so it is testable: that needs an
+/// `AppHandle` this crate has no harness for, this needs nothing. The
+/// terminal-status half is the load-bearing part — counting a COMPLETED job as
+/// active would block every future index permanently after the first run.
+fn is_active_embed_job(kind: &str, status: &JobStatus) -> bool {
+    EMBED_JOB_KINDS.contains(&kind)
+        && matches!(
+            status,
+            JobStatus::Running | JobStatus::Queued | JobStatus::Streaming
+        )
+}
+
 /// Documents with no usable vector in the ACTIVE embedding space — i.e. never
 /// indexed, or indexed under a different provider/model/format.
 ///
@@ -958,6 +998,11 @@ async fn run_embed_job(
 /// job id. Clears the live posting embedding cache so stale-space entries go too.
 #[tauri::command]
 pub async fn ai_reembed_all(app: AppHandle) -> Value {
+    // Already embedding (an auto-index run, or a double-click): hand back the
+    // running job so the caller watches THAT instead of starting a paid duplicate.
+    if let Some(existing) = running_embed_job(&app) {
+        return json!({ "jobId": existing });
+    }
     let job_id = new_job_id();
     crate::commands::jobs::job_start(&app, &job_id, "ai.reembed");
 
@@ -991,6 +1036,11 @@ pub async fn ai_reembed_all(app: AppHandle) -> Value {
 /// silent instead of showing progress for a no-op run.
 #[tauri::command]
 pub async fn ai_index_stale_documents(app: AppHandle) -> Value {
+    // Same guard as `ai_reembed_all` — a manual re-index already covers every
+    // stale document, so joining it is strictly better than racing it.
+    if let Some(existing) = running_embed_job(&app) {
+        return json!({ "jobId": existing });
+    }
     let docs = stale_documents(&app);
     if docs.is_empty() {
         return json!({ "jobId": Value::Null });
@@ -1276,5 +1326,53 @@ mod embedding_base_url_tests {
         )
         .expect("a non-OpenAiCompatible provider must never error on base_url");
         assert_eq!(url, None);
+    }
+}
+
+#[cfg(test)]
+mod embed_job_guard_tests {
+    //! Only ONE embedding job may run at a time: auto-indexing and the manual
+    //! "Re-index now" button are independent triggers that write the same
+    //! vectors for the same documents, so a concurrent pair bills a cloud
+    //! provider twice for identical work. `running_embed_job` itself needs an
+    //! `AppHandle` this crate has no harness for; the decision it makes per job
+    //! record does not.
+
+    use super::*;
+
+    #[test]
+    fn both_embedding_job_kinds_count_while_they_are_still_going() {
+        for kind in ["ai.reembed", "ai.indexStale"] {
+            for status in [JobStatus::Running, JobStatus::Queued, JobStatus::Streaming] {
+                assert!(
+                    is_active_embed_job(kind, &status),
+                    "{kind} in {status:?} must block a second embedding job"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_finished_embedding_job_never_blocks_the_next_one() {
+        // The differential. Without it the guard would latch after the first
+        // run and auto-indexing would never fire again.
+        for status in [
+            JobStatus::Completed,
+            JobStatus::Failed,
+            JobStatus::Cancelled,
+        ] {
+            assert!(
+                !is_active_embed_job("ai.reembed", &status),
+                "a {status:?} job must not block the next index"
+            );
+        }
+    }
+
+    #[test]
+    fn unrelated_jobs_do_not_block_indexing() {
+        // A generation or a scrape running is no reason to refuse to index.
+        for kind in ["ai.generate", "scrape", "ai.reembed.not-really"] {
+            assert!(!is_active_embed_job(kind, &JobStatus::Running), "{kind}");
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -828,7 +828,7 @@ fn reembed_run_failed(done: u32, failed: u32) -> bool {
 /// documents, so only ONE may run at a time.
 const EMBED_JOB_KINDS: [&str; 2] = ["ai.reembed", "ai.indexStale"];
 
-/// The id of an embedding job already running, if any.
+/// Claim the right to run an embedding job, or report the one already running.
 ///
 /// Auto-indexing and the manual "Re-index now" button are independent triggers
 /// with no knowledge of each other, so without this a background auto-index and
@@ -836,6 +836,20 @@ const EMBED_JOB_KINDS: [&str; 2] = ["ai.reembed", "ai.indexStale"];
 /// provider twice for identical work. Enforced in the BACKEND rather than by
 /// disabling the button, because that is the only place every trigger has to
 /// pass through; a UI-only guard narrows the race instead of closing it.
+///
+/// The scan and the registration happen under ONE lock
+/// ([`JobTracker::start_exclusive`]): checking first and starting after is
+/// check-then-act, and two commands can both see "nothing running" before either
+/// registers.
+///
+/// `None` means this caller owns the run; `Some(existing)` is the job to watch
+/// instead — a normal outcome, not a failure, which is why this is not a
+/// `Result` (see R6).
+fn claim_embed_job(app: &AppHandle, job_id: &str, kind: &str) -> Option<String> {
+    crate::commands::jobs::job_start_exclusive(app, job_id, kind, &EMBED_JOB_KINDS)
+}
+
+/// Whether an embedding job is running right now (for the status surface).
 fn running_embed_job(app: &AppHandle) -> Option<String> {
     app.state::<Mutex<JobTracker>>()
         .lock()
@@ -847,10 +861,11 @@ fn running_embed_job(app: &AppHandle) -> Option<String> {
 
 /// Whether a job record is an embedding job that has NOT finished.
 ///
-/// Split out of [`running_embed_job`] purely so it is testable: that needs an
-/// `AppHandle` this crate has no harness for, this needs nothing. The
-/// terminal-status half is the load-bearing part — counting a COMPLETED job as
-/// active would block every future index permanently after the first run.
+/// Split out purely so it is testable: the callers need an `AppHandle` this
+/// crate has no harness for, this needs nothing. The terminal-status half is the
+/// load-bearing part — counting a COMPLETED job as active would block every
+/// future index permanently after the first run. Mirrors the predicate inside
+/// [`JobTracker::start_exclusive`]; a test pins the two agreeing.
 fn is_active_embed_job(kind: &str, status: &JobStatus) -> bool {
     EMBED_JOB_KINDS.contains(&kind)
         && matches!(
@@ -998,13 +1013,12 @@ async fn run_embed_job(
 /// job id. Clears the live posting embedding cache so stale-space entries go too.
 #[tauri::command]
 pub async fn ai_reembed_all(app: AppHandle) -> Value {
+    let job_id = new_job_id();
     // Already embedding (an auto-index run, or a double-click): hand back the
     // running job so the caller watches THAT instead of starting a paid duplicate.
-    if let Some(existing) = running_embed_job(&app) {
+    if let Some(existing) = claim_embed_job(&app, &job_id, "ai.reembed") {
         return json!({ "jobId": existing });
     }
-    let job_id = new_job_id();
-    crate::commands::jobs::job_start(&app, &job_id, "ai.reembed");
 
     let job_id_clone = job_id.clone();
     let app_clone = app.clone();
@@ -1036,17 +1050,16 @@ pub async fn ai_reembed_all(app: AppHandle) -> Value {
 /// silent instead of showing progress for a no-op run.
 #[tauri::command]
 pub async fn ai_index_stale_documents(app: AppHandle) -> Value {
-    // Same guard as `ai_reembed_all` — a manual re-index already covers every
-    // stale document, so joining it is strictly better than racing it.
-    if let Some(existing) = running_embed_job(&app) {
-        return json!({ "jobId": existing });
-    }
     let docs = stale_documents(&app);
     if docs.is_empty() {
         return json!({ "jobId": Value::Null });
     }
     let job_id = new_job_id();
-    crate::commands::jobs::job_start(&app, &job_id, "ai.indexStale");
+    // Same guard as `ai_reembed_all` — a manual re-index already covers every
+    // stale document, so joining it is strictly better than racing it.
+    if let Some(existing) = claim_embed_job(&app, &job_id, "ai.indexStale") {
+        return json!({ "jobId": existing });
+    }
 
     let job_id_clone = job_id.clone();
     let app_clone = app.clone();

--- a/apps/desktop/src-tauri/src/commands/jobs.rs
+++ b/apps/desktop/src-tauri/src/commands/jobs.rs
@@ -32,6 +32,30 @@ pub fn job_start(app: &AppHandle, id: &str, kind: &str) {
     emit_job_event(app, "job.started", id, None);
 }
 
+/// Like [`job_start`], but refuses when a job of one of `exclusive_kinds` is
+/// already active — returning that job's id instead of starting a second.
+///
+/// The scan and the insert share one lock (see
+/// [`JobTracker::start_exclusive`]). Checking with a separate call and starting
+/// after is check-then-act: two commands can both observe "nothing running"
+/// before either registers, which for the embedding jobs means two concurrent
+/// runs over the same documents and a cloud provider billed twice.
+pub fn job_start_exclusive(
+    app: &AppHandle,
+    id: &str,
+    kind: &str,
+    exclusive_kinds: &[&str],
+) -> Option<String> {
+    let existing =
+        app.state::<Mutex<JobTracker>>()
+            .lock()
+            .start_exclusive(id, kind, exclusive_kinds);
+    if existing.is_none() {
+        emit_job_event(app, "job.started", id, None);
+    }
+    existing
+}
+
 /// Update a job's progress (0.0–1.0) and emit `job.progress`.
 pub fn job_progress(app: &AppHandle, id: &str, p: f64) {
     app.state::<Mutex<JobTracker>>()

--- a/apps/desktop/src-tauri/src/jobs/mod.rs
+++ b/apps/desktop/src-tauri/src/jobs/mod.rs
@@ -220,6 +220,36 @@ impl JobTracker {
         self.jobs.insert(id.to_string(), record);
     }
 
+    /// Register `id` as running UNLESS a job of one of `exclusive_kinds` is
+    /// already active — returning that job's id instead.
+    ///
+    /// The scan and the insert happen under the SAME lock on purpose. Doing them
+    /// as two calls is check-then-act: two commands can both observe "nothing
+    /// running" before either registers, and both proceed. For the embedding
+    /// jobs this guards, that means two concurrent runs embedding the same
+    /// documents — a cloud provider billed twice for identical work.
+    ///
+    /// `None` when this job was started; `Some(existing_id)` when one was already
+    /// running — that is not an error, it is the job the caller should watch.
+    pub fn start_exclusive(
+        &mut self,
+        id: &str,
+        kind: &str,
+        exclusive_kinds: &[&str],
+    ) -> Option<String> {
+        if let Some(existing) = self.jobs.values().find(|j| {
+            exclusive_kinds.contains(&j.kind.as_str())
+                && matches!(
+                    j.status,
+                    JobStatus::Running | JobStatus::Queued | JobStatus::Streaming
+                )
+        }) {
+            return Some(existing.id.clone());
+        }
+        self.start(id, kind);
+        None
+    }
+
     /// Wipe the job-execution log — in-memory records and the `jobs` table.
     /// Used by the factory reset.
     pub fn clear(&mut self) {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -938,6 +938,7 @@ pub fn run() {
             commands::ai::ai_embedding_status,
             commands::ai::ai_set_embedding_config,
             commands::ai::ai_reembed_all,
+            commands::ai::ai_index_stale_documents,
             commands::ai::ai_spend_summary,
             commands::ai::ai_active_config,
             commands::ai::ai_set_active_provider,

--- a/apps/desktop/src/renderer/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/OnboardingWizard/index.test.tsx
@@ -223,6 +223,29 @@ vi.mock('../steps/ExtensionStep', () => ({
   ),
 }));
 
+vi.mock('../steps/AutoIndexStep', () => ({
+  AutoIndexStep: ({
+    onNext,
+    onBack,
+    stepIndex,
+    totalSteps,
+  }: {
+    onNext: () => void;
+    onBack?: () => void;
+    stepIndex: number;
+    totalSteps: number;
+  }) => (
+    <div
+      data-testid={TEST_IDS.onboarding.stepAutoIndex}
+      data-step-index={stepIndex}
+      data-total-steps={totalSteps}
+    >
+      <Button onClick={onNext}>next</Button>
+      {onBack && <Button onClick={onBack}>back</Button>}
+    </div>
+  ),
+}));
+
 vi.mock('../steps/CrashReportingStep', () => ({
   CrashReportingStep: ({
     onNext,
@@ -323,9 +346,19 @@ beforeEach(() => {
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 describe('OnboardingWizard — step filter', () => {
-  it('includes research step (9 total) when activeProvider is ollama', () => {
+  it('includes research step (10 total) when activeProvider is ollama', () => {
     usePreferencesStore.setState({
       aiProviderConfig: { activeProvider: 'ollama', providers: {} },
+    });
+    renderWizard();
+
+    const welcome = screen.getByTestId(TEST_IDS.onboarding.stepWelcome);
+    expect(totalStepsOf(welcome)).toBe(10);
+  });
+
+  it('excludes research step (9 total) when activeProvider is openai', () => {
+    usePreferencesStore.setState({
+      aiProviderConfig: { activeProvider: 'openai', providers: {} },
     });
     renderWizard();
 
@@ -333,22 +366,12 @@ describe('OnboardingWizard — step filter', () => {
     expect(totalStepsOf(welcome)).toBe(9);
   });
 
-  it('excludes research step (8 total) when activeProvider is openai', () => {
-    usePreferencesStore.setState({
-      aiProviderConfig: { activeProvider: 'openai', providers: {} },
-    });
-    renderWizard();
-
-    const welcome = screen.getByTestId(TEST_IDS.onboarding.stepWelcome);
-    expect(totalStepsOf(welcome)).toBe(8);
-  });
-
-  it('excludes research step (8 total) when activeProvider is undefined', () => {
+  it('excludes research step (9 total) when activeProvider is undefined', () => {
     usePreferencesStore.setState({ aiProviderConfig: undefined });
     renderWizard();
 
     const welcome = screen.getByTestId(TEST_IDS.onboarding.stepWelcome);
-    expect(totalStepsOf(welcome)).toBe(8);
+    expect(totalStepsOf(welcome)).toBe(9);
   });
 
   it('research stub is present in the DOM when ollama is active after navigating to it', async () => {
@@ -416,13 +439,15 @@ describe('OnboardingWizard — navigation', () => {
     const user = userEvent.setup();
     renderWizard();
 
-    // 7-step sequence (openai): welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4) → extension(5) → appearance(6)
+    // openai sequence: welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4)
+    // → extension(5) → autoIndex(6) → crashReporting(7) → appearance(8)
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAutoIndex));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepCrashReporting));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAppearance));
 
@@ -444,6 +469,7 @@ describe('OnboardingWizard — navigation', () => {
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAutoIndex));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepCrashReporting));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAppearance));
 
@@ -471,6 +497,7 @@ describe('OnboardingWizard — sidebar force-open on tour start', () => {
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAutoIndex));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepCrashReporting));
 
     // Still on a regular step — sidebar must be untouched.
@@ -502,13 +529,15 @@ describe('OnboardingWizard — sidebar force-open on tour start', () => {
     const user = userEvent.setup();
     renderWizard();
 
-    // 7-step sequence (openai): welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4) → extension(5) → appearance(6)
+    // openai sequence: welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4)
+    // → extension(5) → autoIndex(6) → crashReporting(7) → appearance(8)
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAutoIndex));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepCrashReporting));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAppearance));
 
@@ -531,13 +560,15 @@ describe('OnboardingWizard — sidebar force-open on tour start', () => {
     const user = userEvent.setup();
     renderWizard();
 
-    // 7-step sequence (openai): welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4) → extension(5) → appearance(6)
+    // openai sequence: welcome(0) → resume(1) → ai(2) → browser(3) → adzunaKey(4)
+    // → extension(5) → autoIndex(6) → crashReporting(7) → appearance(8)
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAutoIndex));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepCrashReporting));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAppearance));
 
@@ -605,7 +636,7 @@ describe('OnboardingWizard — clamp on provider flip', () => {
     const user = userEvent.setup();
     renderWizard();
 
-    // Advance to the last step of the 9-step ollama sequence (index 8 = appearance)
+    // Advance to the last step of the 10-step ollama sequence (index 9 = appearance)
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepWelcome));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepResume));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAi));
@@ -613,15 +644,16 @@ describe('OnboardingWizard — clamp on provider flip', () => {
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepBrowser));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAdzunaKey));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepExtension));
+    await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepAutoIndex));
     await clickNext(user, screen.getByTestId(TEST_IDS.onboarding.stepCrashReporting));
 
-    // At index 8 (appearance), totalSteps 9
+    // At index 9 (appearance), totalSteps 10
     expect(screen.getByTestId(TEST_IDS.onboarding.stepAppearance)).toBeInTheDocument();
-    expect(stepIndexOf(screen.getByTestId(TEST_IDS.onboarding.stepAppearance))).toBe(8);
-    expect(totalStepsOf(screen.getByTestId(TEST_IDS.onboarding.stepAppearance))).toBe(9);
+    expect(stepIndexOf(screen.getByTestId(TEST_IDS.onboarding.stepAppearance))).toBe(9);
+    expect(totalStepsOf(screen.getByTestId(TEST_IDS.onboarding.stepAppearance))).toBe(10);
 
-    // Flip provider to openai — array shrinks to 8 steps (max valid index = 7).
-    // The clamp effect must land the wizard on step 7 = appearance. `useActiveConfig`
+    // Flip provider to openai — array shrinks to 9 steps (max valid index = 8).
+    // The clamp effect must land the wizard on step 8 = appearance. `useActiveConfig`
     // is backed by the Zustand store in this test, so the flip is a plain setState.
     act(() => {
       usePreferencesStore.setState({
@@ -629,7 +661,7 @@ describe('OnboardingWizard — clamp on provider flip', () => {
       });
     });
 
-    // The clamped visible step must be exactly appearance at index 7 / totalSteps 8.
+    // The clamped visible step must be exactly appearance at index 8 / totalSteps 9.
     const visibleStep = document.querySelector('[data-total-steps]');
     if (!visibleStep) throw new Error('expected a visible step after provider flip');
     const visibleStepEl = visibleStep as HTMLElement;
@@ -637,8 +669,8 @@ describe('OnboardingWizard — clamp on provider flip', () => {
     // Identity: must be the appearance stub (not a fallback to welcome at index 0)
     expect(visibleStepEl.getAttribute('data-testid')).toBe('step-appearance');
     // Exact clamped index — not just "within range"
-    expect(stepIndexOf(visibleStepEl)).toBe(7);
-    expect(totalStepsOf(visibleStepEl)).toBe(8);
+    expect(stepIndexOf(visibleStepEl)).toBe(8);
+    expect(totalStepsOf(visibleStepEl)).toBe(9);
   });
 });
 

--- a/apps/desktop/src/renderer/features/onboarding/steps-config.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps-config.ts
@@ -1,6 +1,7 @@
 import { AdzunaKeyStep } from './steps/AdzunaKeyStep';
 import { AISelectionStep } from './steps/AISelectionStep';
 import { AppearanceStep } from './steps/AppearanceStep';
+import { AutoIndexStep } from './steps/AutoIndexStep';
 import { BrowserStep } from './steps/BrowserStep';
 import { CrashReportingStep } from './steps/CrashReportingStep';
 import { ExtensionStep } from './steps/ExtensionStep';
@@ -16,6 +17,10 @@ export const ONBOARDING_STEPS = [
   { id: 'browser', component: BrowserStep },
   { id: 'adzunaKey', component: AdzunaKeyStep },
   { id: 'extension', component: ExtensionStep },
+  // Sits immediately before the crash-reporting consent: both ask "may this run
+  // on your behalf", and auto-indexing calls a provider that may bill per token,
+  // so the two spend/privacy decisions stay together rather than scattered.
+  { id: 'autoIndex', component: AutoIndexStep },
   // Consent before the finish line: advancing past this step is what unlocks
   // transmission (see CrashReportingStep), so it must be reachable in the normal
   // flow rather than tucked behind an optional branch.

--- a/apps/desktop/src/renderer/features/onboarding/steps/AutoIndexStep/index.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/steps/AutoIndexStep/index.tsx
@@ -1,0 +1,102 @@
+import { Sparkles } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useState } from 'react';
+
+import { useTranslation } from '@ajh/translations';
+import { FloatingIcon, Switch, withDelay } from '@ajh/ui';
+
+import { usePreferencesStore } from '@/store/preferences-store';
+
+import { OnboardingStepWrapper } from '../../components/OnboardingStepWrapper';
+
+interface Props {
+  onBack: () => void;
+  onNext: () => void;
+  direction: number;
+  stepIndex: number;
+  totalSteps: number;
+}
+
+/**
+ * Optional onboarding step: index documents automatically instead of waiting for
+ * the first match to embed one inline.
+ *
+ * Asked rather than defaulted because indexing calls the embedding provider, and
+ * a cloud provider bills per token — the same reason the Embeddings settings
+ * panel carries a cost advisory. The stored default is `false`, so an existing
+ * install that never sees this screen never starts spending on its own; the
+ * switch here defaults ON because a user who reaches this step is being told
+ * exactly what it does.
+ *
+ * Placed immediately before the crash-reporting consent step: both are
+ * "something runs on your behalf, say yes or no", and grouping them keeps the
+ * two spend/privacy decisions together rather than buried among the setup steps.
+ */
+export function AutoIndexStep({ onBack, onNext, direction, stepIndex, totalSteps }: Props) {
+  const { t } = useTranslation();
+  const stored = usePreferencesStore((s) => s.autoIndexOnUpload ?? false);
+  const setAutoIndexOnUpload = usePreferencesStore((s) => s.setAutoIndexOnUpload);
+  // Seeded from the stored value, so stepping BACK and forward again shows the
+  // answer already given instead of silently resetting it. Off to begin with:
+  // this spends money on a cloud embedding provider, so it is an opt-in, not a
+  // default the user has to notice and decline.
+  const [checked, setChecked] = useState(stored);
+
+  const advance = () => {
+    setAutoIndexOnUpload(checked);
+    onNext();
+  };
+
+  return (
+    <OnboardingStepWrapper
+      direction={direction}
+      stepIndex={stepIndex}
+      totalSteps={totalSteps}
+      onBack={onBack}
+      onNext={advance}
+      canAdvance
+    >
+      <div className="mb-6 flex justify-center">
+        <FloatingIcon icon={Sparkles} size={24} />
+      </div>
+
+      <motion.div
+        initial={{ y: 10, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={withDelay(0.1)}
+        className="mb-5 text-center"
+      >
+        <h1 className="mb-2 text-xl font-semibold text-foreground/95">
+          {t('onboarding.autoIndex.title')}
+        </h1>
+        <p className="text-sm text-foreground/50">{t('onboarding.autoIndex.subtitle')}</p>
+      </motion.div>
+
+      <motion.div
+        initial={{ y: 10, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={withDelay(0.15)}
+        className="mb-6"
+      >
+        <div className="flex items-start gap-4 rounded-xl border border-foreground/10 px-4 py-3.5">
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold text-foreground/90">
+              {t('onboarding.autoIndex.toggleLabel')}
+            </div>
+            <div className="mt-0.5 text-xs leading-snug text-foreground/40">
+              {t('onboarding.autoIndex.what')}
+            </div>
+            <div className="mt-1.5 text-xs leading-snug text-foreground/40">
+              {t('onboarding.autoIndex.cost')}
+            </div>
+          </div>
+          <Switch
+            checked={checked}
+            onCheckedChange={setChecked}
+            aria-label={t('onboarding.autoIndex.toggleLabel')}
+          />
+        </div>
+      </motion.div>
+    </OnboardingStepWrapper>
+  );
+}

--- a/apps/desktop/src/renderer/features/onboarding/steps/AutoIndexStep/index.tsx
+++ b/apps/desktop/src/renderer/features/onboarding/steps/AutoIndexStep/index.tsx
@@ -23,10 +23,9 @@ interface Props {
  *
  * Asked rather than defaulted because indexing calls the embedding provider, and
  * a cloud provider bills per token — the same reason the Embeddings settings
- * panel carries a cost advisory. The stored default is `false`, so an existing
- * install that never sees this screen never starts spending on its own; the
- * switch here defaults ON because a user who reaches this step is being told
- * exactly what it does.
+ * panel carries a cost advisory. Off unless the user turns it on, here and in
+ * the stored default, so an install that never sees this screen never starts
+ * spending on its own.
  *
  * Placed immediately before the crash-reporting consent step: both are
  * "something runs on your behalf, say yes or no", and grouping them keeps the

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/index.tsx
@@ -6,7 +6,11 @@ import { useTranslation } from '@ajh/translations';
 import { Button, Dropdown, GlassCard, Input, useNotification } from '@ajh/ui';
 
 import { useEmbeddingStatus, useJobEvents, useReembedAll, useSetEmbeddingConfig } from '@/services';
-import { usePreferencesStore, useSemanticScoring } from '@/store/preferences-store';
+import {
+  useAutoIndexOnUpload,
+  usePreferencesStore,
+  useSemanticScoring,
+} from '@/store/preferences-store';
 
 // Providers that expose an embeddings API. Anthropic is intentionally excluded —
 // it has no embeddings endpoint.
@@ -138,6 +142,8 @@ export function EmbeddingsSettings() {
   const reindexing = reindexJobId !== null || reembed.isPending;
 
   const semanticScoring = useSemanticScoring();
+  const autoIndexOnUpload = useAutoIndexOnUpload();
+  const setAutoIndexOnUpload = usePreferencesStore((s) => s.setAutoIndexOnUpload);
   const setSemanticScoring = usePreferencesStore((s) => s.setSemanticScoring);
 
   return (
@@ -226,10 +232,17 @@ export function EmbeddingsSettings() {
             )}
           </div>
           {stale > 0 && (
-            <div className="mt-1 text-amber-400/80">
-              {stale === 1
-                ? t('settings.embeddings.staleOne', { count: stale })
-                : t('settings.embeddings.staleOther', { count: stale })}
+            // Informational, not a warning: an unindexed document blocks
+            // nothing — `match_resume` embeds it the first time it needs a
+            // vector. The old amber "needs re-indexing" line read as a chore.
+            <div className="mt-1 text-foreground/40">
+              {autoIndexOnUpload
+                ? stale === 1
+                  ? t('settings.embeddings.staleAutoOne', { count: stale })
+                  : t('settings.embeddings.staleAutoOther', { count: stale })
+                : stale === 1
+                  ? t('settings.embeddings.staleOne', { count: stale })
+                  : t('settings.embeddings.staleOther', { count: stale })}
             </div>
           )}
         </div>
@@ -243,6 +256,24 @@ export function EmbeddingsSettings() {
             {reindexing ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
             {reindexing ? t('settings.embeddings.reindexing') : t('settings.embeddings.reindex')}
           </Button>
+        </div>
+
+        <div className="flex items-center justify-between rounded-lg border border-foreground/10 bg-foreground/[0.03] px-3 py-2.5">
+          <div className="space-y-0.5">
+            <p className="text-xs font-semibold text-foreground/70">
+              {t('settings.embeddings.autoIndex')}
+            </p>
+            <p className="text-[11px] text-foreground/40 leading-relaxed">
+              {t('settings.embeddings.autoIndexDesc')}
+            </p>
+          </div>
+          <input
+            type="checkbox"
+            checked={autoIndexOnUpload}
+            onChange={(e) => setAutoIndexOnUpload(e.target.checked)}
+            className="h-4 w-4 accent-[var(--color-brand)] cursor-pointer"
+            aria-label={t('settings.embeddings.autoIndex')}
+          />
         </div>
 
         <div className="flex items-center justify-between rounded-lg border border-foreground/10 bg-foreground/[0.03] px-3 py-2.5">

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/index.tsx
@@ -143,6 +143,11 @@ export function EmbeddingsSettings() {
 
   const semanticScoring = useSemanticScoring();
   const autoIndexOnUpload = useAutoIndexOnUpload();
+  // The BACKEND's own answer, not an inference from the preference: with
+  // auto-index on but the run already finished (or never started, because
+  // nothing changed), "indexing them now" would be claiming work that isn't
+  // happening.
+  const indexingNow = status?.indexing === true;
   const setAutoIndexOnUpload = usePreferencesStore((s) => s.setAutoIndexOnUpload);
   const setSemanticScoring = usePreferencesStore((s) => s.setSemanticScoring);
 
@@ -236,7 +241,7 @@ export function EmbeddingsSettings() {
             // nothing — `match_resume` embeds it the first time it needs a
             // vector. The old amber "needs re-indexing" line read as a chore.
             <div className="mt-1 text-foreground/40">
-              {autoIndexOnUpload
+              {indexingNow
                 ? stale === 1
                   ? t('settings.embeddings.staleAutoOne', { count: stale })
                   : t('settings.embeddings.staleAutoOther', { count: stale })

--- a/apps/desktop/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/desktop/src/renderer/lib/mock-client/mock-client.ts
@@ -118,6 +118,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
         active: { provider: 'ollama', model: 'nomic-embed-text' },
         spaces: [],
         documents: { total: 0, indexedInActiveSpace: 0, stale: 0 },
+        indexing: false,
       }),
       setEmbeddingConfig: async () => ({ success: true }),
       reembedAll: async () => ({ jobId: 'mock-reembed' }),

--- a/apps/desktop/src/renderer/lib/mock-client/mock-client.ts
+++ b/apps/desktop/src/renderer/lib/mock-client/mock-client.ts
@@ -121,6 +121,7 @@ export function createMockClient(overrides: DeepPartial<AppClient> = {}): AppCli
       }),
       setEmbeddingConfig: async () => ({ success: true }),
       reembedAll: async () => ({ jobId: 'mock-reembed' }),
+      indexStaleDocuments: async () => ({ jobId: null }),
       spendSummary: async () => ({
         today: { inputTokens: 0, outputTokens: 0, estCostUsd: 0 },
         perProvider: [],

--- a/apps/desktop/src/renderer/routes/__root.tsx
+++ b/apps/desktop/src/renderer/routes/__root.tsx
@@ -30,6 +30,7 @@ import { CapabilityProvider } from '@/providers/CapabilityProvider';
 import {
   useAccentEvents,
   useApplicationEvents,
+  useAutoIndex,
   useExtensionBridgeEvents,
   useNotificationEvents,
   useSyncCloseToTray,
@@ -61,6 +62,15 @@ function ApplicationEventsBridge() {
  *  Rendered once inside `NotificationProvider`; the listeners attach a single time. */
 function NotificationEventsBridge() {
   useNotificationEvents();
+  return null;
+}
+
+/** Keeps the embedding index current when `autoIndexOnUpload` is on — covers a
+ *  fresh import, an embedding provider/model change, and leftovers from a
+ *  previous session. Mounted once here for the same reason the event bridges
+ *  are: a per-route mount would re-run the check on every navigation. */
+function AutoIndexBridge() {
+  useAutoIndex();
   return null;
 }
 
@@ -217,6 +227,7 @@ function RootLayout() {
         <MenuNavigationBridge />
         <ApplicationEventsBridge />
         <NotificationEventsBridge />
+        <AutoIndexBridge />
         <ExtensionBridgeEventsBridge />
         <AccentEventsBridge />
         <NotificationToastBridge />

--- a/apps/desktop/src/renderer/services/index.ts
+++ b/apps/desktop/src/renderer/services/index.ts
@@ -17,6 +17,7 @@ export * from './use-agent';
 export * from './use-ai';
 export * from './use-ai-provider';
 export * from './use-applications';
+export * from './use-auto-index/use-auto-index';
 export * from './use-autopilot';
 export * from './use-boards';
 export * from './use-cli-agents';

--- a/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.test.ts
+++ b/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.test.ts
@@ -8,8 +8,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, waitFor } from '@testing-library/react';
 
 import { usePreferencesStore } from '@/store/preferences-store';
-import { createMockClient, renderHookWithClient } from '@/test-support';
+import { createMockClient, makeQueryClient, renderHookWithClient } from '@/test-support';
 
+import { keys } from '../query-client';
 import { useAutoIndex } from './use-auto-index';
 
 afterEach(() => {
@@ -88,10 +89,11 @@ describe('useAutoIndex', () => {
     expect(indexStaleDocuments).not.toHaveBeenCalled();
   });
 
-  it('does not queue a second run for the same situation', async () => {
-    // The paid-duplicate guard: the status query refetches, and without the
-    // attempt key each refetch would start another index job over the same
-    // documents.
+  it('does not start a second run while the first job is still running', async () => {
+    // The paid-duplicate guard. `indexStaleDocuments` resolves as soon as the job
+    // is SPAWNED, so the status refetch right after it still reports the old
+    // stale count — without holding the guard until the job ends, that refetch
+    // would start another separately-billed run over the same documents.
     usePreferencesStore.setState({ autoIndexOnUpload: true });
     const indexStaleDocuments = vi.fn().mockResolvedValue({ jobId: 'job-1' });
     const client = createMockClient({
@@ -110,22 +112,81 @@ describe('useAutoIndex', () => {
     expect(indexStaleDocuments).toHaveBeenCalledTimes(1);
   });
 
-  it('survives a failing index call — matching still embeds lazily', async () => {
+  it('indexes a SECOND upload that happens to leave the same stale count', async () => {
+    // Regression for the HIGH review finding on #951. The first guard keyed on
+    // `provider/model/staleCount` and never reset, so: import one résumé
+    // (stale 1 → indexed → stale 0), import another (stale 1 AGAIN) and the
+    // second was treated as already handled. Auto-indexing silently died after
+    // the very first document. The count identifies a situation, not a batch.
     usePreferencesStore.setState({ autoIndexOnUpload: true });
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const indexStaleDocuments = vi.fn().mockRejectedValue(new Error('provider down'));
+    let jobHandler: ((e: unknown) => void) | null = null;
+    let staleNow = 1;
+    const indexStaleDocuments = vi.fn().mockResolvedValue({ jobId: 'job-1' });
     const client = createMockClient({
-      'ai.embeddingStatus': vi.fn().mockResolvedValue(status(1)),
+      'ai.embeddingStatus': vi.fn().mockImplementation(async () => status(staleNow)),
       'ai.indexStaleDocuments': indexStaleDocuments,
+      'jobs.onEvent': vi.fn((cb: (e: unknown) => void) => {
+        jobHandler = cb;
+        return () => {};
+      }),
     });
 
-    renderHookWithClient(() => useAutoIndex(), { client });
-
+    const queryClient = makeQueryClient();
+    renderHookWithClient(() => useAutoIndex(), { client, queryClient });
     await waitFor(() => expect(indexStaleDocuments).toHaveBeenCalledTimes(1));
-    // No unhandled rejection, and the raw provider message never reaches the log.
+
+    // The job finishes and the index goes clean.
+    staleNow = 0;
+    await act(async () => {
+      jobHandler?.({ type: 'job.completed', jobId: 'job-1' });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData<{ documents: { stale: number } }>(keys.ai.embeddingStatus)
+          ?.documents.stale
+      ).toBe(0)
+    );
+
+    // A second document arrives, leaving the SAME stale count as the first did.
+    staleNow = 1;
+    indexStaleDocuments.mockResolvedValue({ jobId: 'job-2' });
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
+    });
+
+    await waitFor(() => expect(indexStaleDocuments).toHaveBeenCalledTimes(2), { timeout: 3000 });
+  });
+
+  it('does not retry forever when a run fails to reduce the stale count', async () => {
+    // The other half of the same guard. Without a per-(space, count) attempt key
+    // a run that indexes nothing re-triggers the instant it ends — an unbounded
+    // loop of paid provider calls.
+    usePreferencesStore.setState({ autoIndexOnUpload: true });
+    let jobHandler: ((e: unknown) => void) | null = null;
+    const indexStaleDocuments = vi.fn().mockResolvedValue({ jobId: 'job-1' });
+    const client = createMockClient({
+      'ai.embeddingStatus': vi.fn().mockResolvedValue(status(2)),
+      'ai.indexStaleDocuments': indexStaleDocuments,
+      'jobs.onEvent': vi.fn((cb: (e: unknown) => void) => {
+        jobHandler = cb;
+        return () => {};
+      }),
+    });
+
+    const { rerender } = renderHookWithClient(() => useAutoIndex(), { client });
+    await waitFor(() => expect(indexStaleDocuments).toHaveBeenCalledTimes(1));
+
+    // Job ends with the count unchanged (every document failed to embed).
+    await act(async () => {
+      jobHandler?.({ type: 'job.failed', jobId: 'job-1' });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    rerender();
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
     });
-    expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain('provider down');
+
+    expect(indexStaleDocuments).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.test.ts
+++ b/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.test.ts
@@ -22,6 +22,7 @@ const status = (stale: number, provider = 'ollama', model = 'nomic-embed-text') 
   active: { provider, model, baseUrl: null },
   spaces: [],
   documents: { total: stale, indexedInActiveSpace: 0, stale },
+  indexing: false,
 });
 
 describe('useAutoIndex', () => {

--- a/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.test.ts
+++ b/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.test.ts
@@ -1,0 +1,131 @@
+/**
+ * useAutoIndex — the auto-indexing trigger.
+ *
+ * These assert the SPEND-relevant behaviour above all: indexing calls a provider
+ * that may bill per token, so "does not run" is as important as "runs".
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+
+import { usePreferencesStore } from '@/store/preferences-store';
+import { createMockClient, renderHookWithClient } from '@/test-support';
+
+import { useAutoIndex } from './use-auto-index';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  usePreferencesStore.setState({ autoIndexOnUpload: false });
+});
+
+const status = (stale: number, provider = 'ollama', model = 'nomic-embed-text') => ({
+  active: { provider, model, baseUrl: null },
+  spaces: [],
+  documents: { total: stale, indexedInActiveSpace: 0, stale },
+});
+
+describe('useAutoIndex', () => {
+  it('does nothing when the preference is off, even with stale documents', async () => {
+    usePreferencesStore.setState({ autoIndexOnUpload: false });
+    const indexStaleDocuments = vi.fn().mockResolvedValue({ jobId: null });
+    const client = createMockClient({
+      'ai.embeddingStatus': vi.fn().mockResolvedValue(status(3)),
+      'ai.indexStaleDocuments': indexStaleDocuments,
+    });
+
+    renderHookWithClient(() => useAutoIndex(), { client });
+
+    // Give the status query time to resolve; the call must still never happen.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(indexStaleDocuments).not.toHaveBeenCalled();
+  });
+
+  it('indexes when the preference is on and documents are stale', async () => {
+    usePreferencesStore.setState({ autoIndexOnUpload: true });
+    const indexStaleDocuments = vi.fn().mockResolvedValue({ jobId: 'job-1' });
+    const client = createMockClient({
+      'ai.embeddingStatus': vi.fn().mockResolvedValue(status(2)),
+      'ai.indexStaleDocuments': indexStaleDocuments,
+    });
+
+    renderHookWithClient(() => useAutoIndex(), { client });
+
+    await waitFor(() => expect(indexStaleDocuments).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not run when nothing is stale', async () => {
+    usePreferencesStore.setState({ autoIndexOnUpload: true });
+    const indexStaleDocuments = vi.fn().mockResolvedValue({ jobId: null });
+    const client = createMockClient({
+      'ai.embeddingStatus': vi.fn().mockResolvedValue(status(0)),
+      'ai.indexStaleDocuments': indexStaleDocuments,
+    });
+
+    renderHookWithClient(() => useAutoIndex(), { client });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(indexStaleDocuments).not.toHaveBeenCalled();
+  });
+
+  it('waits for a configured embedding model instead of failing per refetch', async () => {
+    // Onboarding order: the résumé is imported (step 2) BEFORE the AI provider is
+    // chosen (step 3), so this state is the normal first-run path, not an edge case.
+    usePreferencesStore.setState({ autoIndexOnUpload: true });
+    const indexStaleDocuments = vi.fn().mockResolvedValue({ jobId: null });
+    const client = createMockClient({
+      'ai.embeddingStatus': vi.fn().mockResolvedValue(status(1, 'ollama', '')),
+      'ai.indexStaleDocuments': indexStaleDocuments,
+    });
+
+    renderHookWithClient(() => useAutoIndex(), { client });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(indexStaleDocuments).not.toHaveBeenCalled();
+  });
+
+  it('does not queue a second run for the same situation', async () => {
+    // The paid-duplicate guard: the status query refetches, and without the
+    // attempt key each refetch would start another index job over the same
+    // documents.
+    usePreferencesStore.setState({ autoIndexOnUpload: true });
+    const indexStaleDocuments = vi.fn().mockResolvedValue({ jobId: 'job-1' });
+    const client = createMockClient({
+      'ai.embeddingStatus': vi.fn().mockResolvedValue(status(2)),
+      'ai.indexStaleDocuments': indexStaleDocuments,
+    });
+
+    const { rerender } = renderHookWithClient(() => useAutoIndex(), { client });
+
+    await waitFor(() => expect(indexStaleDocuments).toHaveBeenCalledTimes(1));
+    rerender();
+    rerender();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(indexStaleDocuments).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a failing index call — matching still embeds lazily', async () => {
+    usePreferencesStore.setState({ autoIndexOnUpload: true });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const indexStaleDocuments = vi.fn().mockRejectedValue(new Error('provider down'));
+    const client = createMockClient({
+      'ai.embeddingStatus': vi.fn().mockResolvedValue(status(1)),
+      'ai.indexStaleDocuments': indexStaleDocuments,
+    });
+
+    renderHookWithClient(() => useAutoIndex(), { client });
+
+    await waitFor(() => expect(indexStaleDocuments).toHaveBeenCalledTimes(1));
+    // No unhandled rejection, and the raw provider message never reaches the log.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain('provider down');
+  });
+});

--- a/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.test.ts
+++ b/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.test.ts
@@ -159,6 +159,57 @@ describe('useAutoIndex', () => {
     await waitFor(() => expect(indexStaleDocuments).toHaveBeenCalledTimes(2), { timeout: 3000 });
   });
 
+  it('clears the guard even when the job finishes before React re-renders', async () => {
+    // Regression for the review finding on #951: the listener used to compare
+    // against the `inFlightJob` STATE. `setInFlightJob` only schedules a render,
+    // so a job that completes first hits a closure still holding `null`, drops
+    // its own completion event, and latches the guard forever — auto-indexing
+    // dead until the app restarts. The ref is written synchronously, so a
+    // completion that arrives in the same tick as the claim is still matched.
+    usePreferencesStore.setState({ autoIndexOnUpload: true });
+    let jobHandler: ((e: unknown) => void) | null = null;
+    let staleNow = 1;
+    // Fire the completion the instant the job id is handed out — before any
+    // re-render can commit.
+    const indexStaleDocuments = vi.fn().mockImplementation(async () => {
+      queueMicrotask(() => jobHandler?.({ type: 'job.completed', jobId: 'job-1' }));
+      return { jobId: 'job-1' };
+    });
+    const client = createMockClient({
+      'ai.embeddingStatus': vi.fn().mockImplementation(async () => status(staleNow)),
+      'ai.indexStaleDocuments': indexStaleDocuments,
+      'jobs.onEvent': vi.fn((cb: (e: unknown) => void) => {
+        jobHandler = cb;
+        return () => {};
+      }),
+    });
+
+    const queryClient = makeQueryClient();
+    renderHookWithClient(() => useAutoIndex(), { client, queryClient });
+    await waitFor(() => expect(indexStaleDocuments).toHaveBeenCalledTimes(1));
+
+    // Index goes clean, then a new document arrives. If the completion had been
+    // dropped the guard would still be held and this second run never happens.
+    staleNow = 0;
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
+    });
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData<{ documents: { stale: number } }>(keys.ai.embeddingStatus)
+          ?.documents.stale
+      ).toBe(0)
+    );
+
+    staleNow = 1;
+    indexStaleDocuments.mockResolvedValue({ jobId: 'job-2' });
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
+    });
+
+    await waitFor(() => expect(indexStaleDocuments).toHaveBeenCalledTimes(2), { timeout: 3000 });
+  });
+
   it('does not retry forever when a run fails to reduce the stale count', async () => {
     // The other half of the same guard. Without a per-(space, count) attempt key
     // a run that indexes nothing re-triggers the instant it ends — an unbounded

--- a/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.ts
+++ b/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.ts
@@ -1,11 +1,14 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+
+import type { JobEvent } from '@ajh/shared';
 
 import { useAppClient } from '@/providers/AppClientProvider';
 import { useAutoIndexOnUpload } from '@/store/preferences-store';
 
 import { keys } from '../query-client';
 import { useEmbeddingStatus } from '../use-ai-provider';
+import { useJobEvents } from '../use-jobs';
 
 /**
  * Keep the embedding index up to date on its own, when the user has asked for it
@@ -39,42 +42,76 @@ export const useAutoIndex = () => {
   const activeModel = status?.active?.model ?? '';
   const activeProvider = status?.active?.provider ?? '';
 
-  // One run per (space, stale-count) situation. Without this the effect would
-  // re-fire on every refetch while a run is still in flight and queue duplicate
-  // index jobs for the same documents — paid duplicates, on a cloud provider.
-  const inFlight = useRef(false);
-  const lastAttempt = useRef('');
+  // The concurrency guard, held until the JOB ends — not until
+  // `indexStaleDocuments` resolves, which happens as soon as the job is SPAWNED.
+  // The status refetch right after that still reports the pre-run stale count,
+  // and would otherwise start a second, separately-billed run over the same
+  // documents.
+  //
+  // STATE rather than a ref because the effect must re-run when a job finishes,
+  // and clearing a ref re-renders nothing.
+  const [inFlightJob, setInFlightJob] = useState<string | null>(null);
+  const starting = useRef(false);
+
+  // One attempt per (space, stale count), CLEARED once the index goes clean or
+  // the space changes. Both halves are load-bearing:
+  //   - without the key, a run that fails to reduce `stale` re-triggers the
+  //     moment it ends, looping paid provider calls forever;
+  //   - without the reset, a later batch that happens to share a previous
+  //     count is skipped forever — import one résumé (stale 1, indexed), import
+  //     another (stale 1 again) and auto-indexing silently dies after the first.
+  const attemptedFor = useRef<string | null>(null);
+
+  // Release the guard when our job reaches a terminal state, then refresh the
+  // strip so it shows the post-run count.
+  useJobEvents((evt: JobEvent) => {
+    const e = evt as { type: string; jobId: string };
+    if (e.jobId !== inFlightJob) return;
+    if (e.type !== 'job.completed' && e.type !== 'job.failed' && e.type !== 'job.cancelled') return;
+    setInFlightJob(null);
+    void qc.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
+  });
 
   useEffect(() => {
+    const space = `${activeProvider}/${activeModel}`;
+    // A clean index (or a space change) means any future non-zero count is new
+    // work, not the run we already attempted.
+    if (stale === 0 || attemptedFor.current?.startsWith(`${space}/`) === false) {
+      attemptedFor.current = null;
+    }
+
     if (!enabled || stale === 0) return;
     // An embedding space with no model configured cannot index anything; wait
-    // for the user to pick one rather than failing once per refetch.
+    // for the user to pick one rather than failing once per refetch. This is the
+    // normal first run — the résumé step precedes the AI step in onboarding.
     if (!activeProvider || !activeModel) return;
+    if (inFlightJob || starting.current) return;
 
-    const attempt = `${activeProvider}/${activeModel}/${stale}`;
-    if (inFlight.current || lastAttempt.current === attempt) return;
-    inFlight.current = true;
-    lastAttempt.current = attempt;
+    const attempt = `${space}/${stale}`;
+    if (attemptedFor.current === attempt) return;
+    attemptedFor.current = attempt;
 
+    starting.current = true;
     void (async () => {
       try {
-        await api.ai.indexStaleDocuments();
-        // Refresh the strip so it reflects the new count rather than the one
-        // that triggered this run.
-        await qc.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
-      } catch (err) {
+        const { jobId } = await api.ai.indexStaleDocuments();
+        // Null means nothing was actually stale by the time the backend looked
+        // (a lazy embed during matching got there first) — no job, nothing to
+        // wait for, and the next real change is free to trigger a run.
+        if (jobId) setInFlightJob(jobId);
+        else await qc.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
+      } catch {
         // Best-effort by design: matching still embeds lazily when it needs a
-        // vector, so a failed pre-warm degrades to the old behaviour rather
-        // than breaking anything. Logged (never the raw provider message — see
-        // `errorClass`) so a diagnostics bundle still shows it was attempted.
+        // vector, so a failed pre-warm degrades to the old behaviour rather than
+        // breaking anything. The provider's own message is deliberately not
+        // logged — this line is persisted into diagnostics bundles.
         console.warn('[auto-index] stale-document indexing failed', {
           provider: activeProvider,
           stale,
         });
-        void err;
       } finally {
-        inFlight.current = false;
+        starting.current = false;
       }
     })();
-  }, [api, qc, enabled, stale, activeProvider, activeModel]);
+  }, [api, qc, enabled, stale, activeProvider, activeModel, inFlightJob]);
 };

--- a/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.ts
+++ b/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.ts
@@ -51,6 +51,28 @@ export const useAutoIndex = () => {
   // STATE rather than a ref because the effect must re-run when a job finishes,
   // and clearing a ref re-renders nothing.
   const [inFlightJob, setInFlightJob] = useState<string | null>(null);
+  // Written SYNCHRONOUSLY alongside the state, and the job listener compares
+  // against this — not against `inFlightJob`. `setInFlightJob` only schedules a
+  // render, so a job that finishes before that render commits would hit a
+  // listener closure still holding `null`, drop its own completion event, and
+  // leave the guard latched forever. Same fix, for the same reason, as
+  // `EmbeddingsSettings`'s `reindexJobIdRef`.
+  const inFlightJobRef = useRef<string | null>(null);
+  // Terminal job ids seen while we held no claim. A job can finish BEFORE the
+  // invoke that created it resolves — an index where every document fails
+  // returns almost instantly — so its completion arrives before there is
+  // anything to match it against. Without this the claim that lands afterwards
+  // waits forever for an event that already came and went. Bounded; only the
+  // most recent handful can ever matter, since a claim follows its own invoke.
+  const finishedBeforeClaim = useRef<string[]>([]);
+  const claim = (id: string | null) => {
+    if (id && finishedBeforeClaim.current.includes(id)) {
+      finishedBeforeClaim.current = finishedBeforeClaim.current.filter((j) => j !== id);
+      id = null;
+    }
+    inFlightJobRef.current = id;
+    setInFlightJob(id);
+  };
   const starting = useRef(false);
 
   // One attempt per (space, stale count), CLEARED once the index goes clean or
@@ -66,9 +88,15 @@ export const useAutoIndex = () => {
   // strip so it shows the post-run count.
   useJobEvents((evt: JobEvent) => {
     const e = evt as { type: string; jobId: string };
-    if (e.jobId !== inFlightJob) return;
     if (e.type !== 'job.completed' && e.type !== 'job.failed' && e.type !== 'job.cancelled') return;
-    setInFlightJob(null);
+    if (e.jobId !== inFlightJobRef.current) {
+      // Not ours — or ours, but finishing before the claim was recorded. Keep
+      // the id so `claim` can recognise it rather than latching on a job that
+      // has already ended.
+      finishedBeforeClaim.current = [e.jobId, ...finishedBeforeClaim.current].slice(0, 8);
+      return;
+    }
+    claim(null);
     void qc.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
   });
 
@@ -85,7 +113,7 @@ export const useAutoIndex = () => {
     // for the user to pick one rather than failing once per refetch. This is the
     // normal first run — the résumé step precedes the AI step in onboarding.
     if (!activeProvider || !activeModel) return;
-    if (inFlightJob || starting.current) return;
+    if (inFlightJobRef.current || starting.current) return;
 
     const attempt = `${space}/${stale}`;
     if (attemptedFor.current === attempt) return;
@@ -98,7 +126,7 @@ export const useAutoIndex = () => {
         // Null means nothing was actually stale by the time the backend looked
         // (a lazy embed during matching got there first) — no job, nothing to
         // wait for, and the next real change is free to trigger a run.
-        if (jobId) setInFlightJob(jobId);
+        if (jobId) claim(jobId);
         else await qc.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
       } catch {
         // Best-effort by design: matching still embeds lazily when it needs a

--- a/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.ts
+++ b/apps/desktop/src/renderer/services/use-auto-index/use-auto-index.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useAppClient } from '@/providers/AppClientProvider';
+import { useAutoIndexOnUpload } from '@/store/preferences-store';
+
+import { keys } from '../query-client';
+import { useEmbeddingStatus } from '../use-ai-provider';
+
+/**
+ * Keep the embedding index up to date on its own, when the user has asked for it
+ * (`autoIndexOnUpload`).
+ *
+ * Why this exists: a résumé's vector is read by exactly one thing — semantic
+ * match scoring — and `match_resume` already embeds lazily when it finds no
+ * usable vector. So indexing was never REQUIRED; the Settings button is a
+ * pre-warm. What it cost was a slow first match (a synchronous embed inside
+ * scoring) and a status strip that looked like a chore list.
+ *
+ * One effect covers all three moments that create stale documents, because they
+ * all show up the same way — as a non-zero `documents.stale` from
+ * `ai_embedding_status`:
+ *   - a résumé was just imported (the documents query invalidates, status refetches)
+ *   - the embedding provider/model changed (every vector is now in the wrong space)
+ *   - the app started with either of the above left over from last session
+ *
+ * `indexStaleDocuments` embeds ONLY what is missing, and returns a null job id
+ * when nothing is — so the common case is one cheap query and no work. It is
+ * deliberately not `reembedAll`, which would re-bill a cloud embedding provider
+ * for already-indexed documents every time a single file is added.
+ */
+export const useAutoIndex = () => {
+  const api = useAppClient();
+  const qc = useQueryClient();
+  const enabled = useAutoIndexOnUpload();
+  const { data: status } = useEmbeddingStatus();
+
+  const stale = status?.documents?.stale ?? 0;
+  const activeModel = status?.active?.model ?? '';
+  const activeProvider = status?.active?.provider ?? '';
+
+  // One run per (space, stale-count) situation. Without this the effect would
+  // re-fire on every refetch while a run is still in flight and queue duplicate
+  // index jobs for the same documents — paid duplicates, on a cloud provider.
+  const inFlight = useRef(false);
+  const lastAttempt = useRef('');
+
+  useEffect(() => {
+    if (!enabled || stale === 0) return;
+    // An embedding space with no model configured cannot index anything; wait
+    // for the user to pick one rather than failing once per refetch.
+    if (!activeProvider || !activeModel) return;
+
+    const attempt = `${activeProvider}/${activeModel}/${stale}`;
+    if (inFlight.current || lastAttempt.current === attempt) return;
+    inFlight.current = true;
+    lastAttempt.current = attempt;
+
+    void (async () => {
+      try {
+        await api.ai.indexStaleDocuments();
+        // Refresh the strip so it reflects the new count rather than the one
+        // that triggered this run.
+        await qc.invalidateQueries({ queryKey: keys.ai.embeddingStatus });
+      } catch (err) {
+        // Best-effort by design: matching still embeds lazily when it needs a
+        // vector, so a failed pre-warm degrades to the old behaviour rather
+        // than breaking anything. Logged (never the raw provider message — see
+        // `errorClass`) so a diagnostics bundle still shows it was attempted.
+        console.warn('[auto-index] stale-document indexing failed', {
+          provider: activeProvider,
+          stale,
+        });
+        void err;
+      } finally {
+        inFlight.current = false;
+      }
+    })();
+  }, [api, qc, enabled, stale, activeProvider, activeModel]);
+};

--- a/apps/desktop/src/renderer/store/preferences-schema/preferences-schema.ts
+++ b/apps/desktop/src/renderer/store/preferences-schema/preferences-schema.ts
@@ -176,6 +176,12 @@ export const PreferencesSchema = z.object({
 
   // Scoring
   semanticScoring: z.boolean().default(false),
+  // Embed a document as soon as it is imported, and index anything stale after
+  // the embedding provider/model changes, instead of waiting for the first
+  // match to embed it inline. Defaults FALSE so an existing install never
+  // starts calling a paid embedding provider without being asked; the
+  // onboarding step offers it to new users.
+  autoIndexOnUpload: z.boolean().default(false),
 
   // Window close behaviour — keep the app running in the tray/menu-bar when the
   // window is closed (default on). Pushed to the Rust shell on boot + on change;

--- a/apps/desktop/src/renderer/store/preferences-store/preferences-store.ts
+++ b/apps/desktop/src/renderer/store/preferences-store/preferences-store.ts
@@ -71,6 +71,7 @@ const defaultPreferences: Preferences = {
   promptQuality: 'auto',
   debugMode: false,
   semanticScoring: false,
+  autoIndexOnUpload: false,
   closeToTray: true,
   recentLocations: [],
   onboardingCompleted: false,
@@ -105,6 +106,7 @@ interface PreferencesActions {
   setPromptQuality: (promptQuality: PromptQuality) => void;
   setDebugMode: (enabled: boolean) => void;
   setSemanticScoring: (enabled: boolean) => void;
+  setAutoIndexOnUpload: (enabled: boolean) => void;
   setCloseToTray: (enabled: boolean) => void;
   /** Record a picked job-search location (dedup + most-recent-first, capped). */
   addRecentLocation: (location: string) => void;
@@ -236,6 +238,13 @@ export const usePreferencesStore = create<PreferencesStore>()(
           lastUpdated: new Date().toISOString(),
         })),
 
+      setAutoIndexOnUpload: (autoIndexOnUpload: boolean) =>
+        set((state) => ({
+          ...state,
+          autoIndexOnUpload,
+          lastUpdated: new Date().toISOString(),
+        })),
+
       setCloseToTray: (closeToTray: boolean) =>
         set((state) => ({
           ...state,
@@ -343,6 +352,8 @@ export const usePromptQuality = () => usePreferencesStore((state) => state.promp
 export const useDebugMode = () => usePreferencesStore((state) => state.debugMode ?? false);
 export const useSemanticScoring = () =>
   usePreferencesStore((state) => state.semanticScoring ?? false);
+export const useAutoIndexOnUpload = () =>
+  usePreferencesStore((state) => state.autoIndexOnUpload ?? false);
 export const useCloseToTray = () => usePreferencesStore((state) => state.closeToTray ?? true);
 export const useRecentLocations = () => usePreferencesStore((state) => state.recentLocations ?? []);
 export const useSidebarCollapsed = () =>

--- a/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
+++ b/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
@@ -100,5 +100,6 @@ export const ai = {
     baseUrl?: string;
   }) => invoke('ai_set_embedding_config', { provider, model, baseUrl }),
   reembedAll: () => invoke('ai_reembed_all'),
+  indexStaleDocuments: () => invoke('ai_index_stale_documents'),
   spendSummary: () => invoke('ai_spend_summary'),
 };

--- a/packages/shared/src/ipc/contracts/ai.ts
+++ b/packages/shared/src/ipc/contracts/ai.ts
@@ -204,6 +204,19 @@ export interface AiContract {
 
   /** Re-embed every document with the active embedding config. Returns a job id. */
   reembedAll(): Promise<{ jobId: string }>;
+  /**
+   * Index ONLY the documents with no usable vector in the active embedding
+   * space — a newly imported résumé, or everything after the provider/model
+   * changed. Backs the `autoIndexOnUpload` preference.
+   *
+   * Not `reembedAll`: that re-embeds every document unconditionally, which would
+   * re-bill a cloud embedding provider for already-indexed documents each time
+   * one new file is added.
+   *
+   * `jobId` is `null` when nothing was stale, so the caller can stay silent
+   * rather than show progress for a no-op.
+   */
+  indexStaleDocuments(): Promise<{ jobId: string | null }>;
 
   /**
    * Read-only AI-spend summary: today's REAL per-provider token totals — as

--- a/packages/shared/src/ipc/contracts/ai.ts
+++ b/packages/shared/src/ipc/contracts/ai.ts
@@ -281,6 +281,15 @@ export interface EmbeddingStatus {
   active: EmbeddingConfig;
   spaces: EmbeddingSpaceInfo[];
   documents: { total: number; indexedInActiveSpace: number; stale: number };
+  /**
+   * An embedding job (auto-index or manual re-index) is running right now.
+   *
+   * The backend's own answer, so the UI never has to infer it — deducing
+   * "indexing now" from the auto-index preference claims work is happening even
+   * when the run already failed or was never started. Only one embedding job
+   * runs at a time; a second trigger joins the running one.
+   */
+  indexing: boolean;
 }
 
 /** One provider's real token totals + estimated cost, since the start of the

--- a/packages/test-ids/src/test-ids.ts
+++ b/packages/test-ids/src/test-ids.ts
@@ -166,6 +166,7 @@ export const TEST_IDS = {
     stepBrowser: 'step-browser',
     stepAdzunaKey: 'step-adzuna-key',
     stepExtension: 'step-extension',
+    stepAutoIndex: 'step-auto-index',
     stepCrashReporting: 'step-crash-reporting',
     stepAppearance: 'step-appearance',
     tour: 'tour',

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1131,13 +1131,13 @@
       "modelPlaceholder": "Embedding-Modell",
       "cloudCostAdvisory": "Cloud-Embedding-Anbieter berechnen pro indiziertem Token und pro berechnetem Score. Für unbegrenzte kostenlose Embeddings führen Sie Ollama lokal aus mit",
       "apply": "Übernehmen",
-      "applied": "Embedding-Modell aktualisiert. Indizieren Sie die Dokumente neu, um den Index neu aufzubauen.",
+      "applied": "Embedding-Modell aktualisiert. Dokumente werden bei Bedarf neu indexiert, oder jetzt neu indexieren.",
       "applyFailed": "Embedding-Modell konnte nicht aktualisiert werden.",
       "activeLabel": "Aktiv:",
       "indexed": "{{indexed}}/{{total}} indiziert",
-      "staleOne": "{{count}} Dokument muss für das aktive Modell neu indiziert werden.",
-      "staleOther": "{{count}} Dokumente müssen für das aktive Modell neu indiziert werden.",
-      "reindex": "Dokumente neu indizieren",
+      "staleOne": "{{count}} Dokument ist noch nicht indexiert. Beim ersten Abgleich wird es indexiert.",
+      "staleOther": "{{count}} Dokumente sind noch nicht indexiert. Beim ersten Abgleich werden sie indexiert.",
+      "reindex": "Jetzt neu indexieren",
       "reindexing": "Neuindizierung…",
       "reindexStarted": "Dokumente werden neu indiziert…",
       "reindexComplete": "Neuindizierung abgeschlossen.",
@@ -1145,7 +1145,11 @@
       "reindexFailedReason": "Neuindizierung fehlgeschlagen: {{reason}}",
       "reindexPartial": "{{failed}} von {{total}} Dokumenten konnten nicht neu indiziert werden.",
       "semanticScoring": "Semantische Bewertung",
-      "semanticScoringDesc": "Nutzt Embeddings für höhere Abgleichqualität. Deaktivieren für schnellere reine Stichwortbewertung."
+      "semanticScoringDesc": "Nutzt Embeddings für höhere Abgleichqualität. Deaktivieren für schnellere reine Stichwortbewertung.",
+      "staleAutoOne": "{{count}} Dokument ist noch nicht indexiert – wird jetzt indexiert.",
+      "staleAutoOther": "{{count}} Dokumente sind noch nicht indexiert – werden jetzt indexiert.",
+      "autoIndex": "Automatisch indexieren",
+      "autoIndexDesc": "Indexiert ein Dokument direkt nach dem Import und nach einem Wechsel des Embedding-Modells, statt auf den ersten Abgleich zu warten. Cloud-Anbieter berechnen pro indexiertem Token."
     },
     "spend": {
       "heading": "KI-Ausgaben (heute)",
@@ -2445,6 +2449,13 @@
       "skip": "Vorerst überspringen",
       "next": "KI einrichten",
       "uploadArea": "Lebenslauf hochladen"
+    },
+    "autoIndex": {
+      "title": "Abgleich schnell halten",
+      "subtitle": "Dokumente müssen indexiert sein, bevor sie semantisch abgeglichen werden können.",
+      "toggleLabel": "Dokumente automatisch indexieren",
+      "what": "Indexiert einen Lebenslauf direkt beim Import und nach einem Wechsel des Embedding-Modells – so ist der erste Abgleich sofort da, statt zum Indexieren zu pausieren.",
+      "cost": "Ohne diese Option geht nichts kaputt: Beim ersten Bedarf wird ein Dokument weiterhin automatisch indexiert. Cloud-Anbieter berechnen pro indexiertem Token; lokales Ollama ist kostenlos."
     }
   },
   "jobUrlImport": {

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1127,13 +1127,13 @@
       "modelPlaceholder": "embedding model",
       "cloudCostAdvisory": "Cloud embedding providers charge per token indexed and per score computed. For unlimited free embeddings, run Ollama locally with",
       "apply": "Apply",
-      "applied": "Embedding model updated. Re-index documents to rebuild the index.",
+      "applied": "Embedding model updated. Documents re-index as they're used, or press Re-index now.",
       "applyFailed": "Failed to update the embedding model.",
       "activeLabel": "Active:",
       "indexed": "{{indexed}}/{{total}} indexed",
-      "staleOne": "{{count}} document needs re-indexing for the active model.",
-      "staleOther": "{{count}} documents need re-indexing for the active model.",
-      "reindex": "Re-index documents",
+      "staleOne": "{{count}} document isn't indexed yet. Matching indexes it the first time it's needed.",
+      "staleOther": "{{count}} documents aren't indexed yet. Matching indexes them the first time they're needed.",
+      "reindex": "Re-index now",
       "reindexing": "Re-indexing…",
       "reindexStarted": "Re-indexing documents…",
       "reindexComplete": "Re-indexing complete.",
@@ -1141,7 +1141,11 @@
       "reindexFailedReason": "Re-indexing failed: {{reason}}",
       "reindexPartial": "{{failed}} of {{total}} documents failed to re-index.",
       "semanticScoring": "Semantic scoring",
-      "semanticScoringDesc": "Uses embeddings for deeper match quality. Disable for faster keyword-only scoring."
+      "semanticScoringDesc": "Uses embeddings for deeper match quality. Disable for faster keyword-only scoring.",
+      "staleAutoOne": "{{count}} document isn't indexed yet — indexing it now.",
+      "staleAutoOther": "{{count}} documents aren't indexed yet — indexing them now.",
+      "autoIndex": "Index automatically",
+      "autoIndexDesc": "Index a document as soon as it's imported, and after changing the embedding model, instead of waiting for the first match. Cloud providers charge per token indexed."
     },
     "spend": {
       "heading": "AI spend (today)",
@@ -2441,6 +2445,13 @@
       "skip": "Skip for now",
       "next": "Set up AI",
       "uploadArea": "Upload your resume"
+    },
+    "autoIndex": {
+      "title": "Keep matching fast",
+      "subtitle": "Documents need to be indexed before they can be matched semantically.",
+      "toggleLabel": "Index documents automatically",
+      "what": "Indexes a résumé as soon as you import it, and re-indexes after you change the embedding model — so the first match is instant instead of pausing to index.",
+      "cost": "Leave this off and nothing breaks: matching still indexes a document the first time it needs it. Cloud embedding providers charge per token indexed; local Ollama is free."
     }
   },
   "jobUrlImport": {


### PR DESCRIPTION
Reported as *"after uploading a résumé I have to go to AI settings and press the indexing button"*.

## The premise was wrong, which changed the fix

`match_resume.rs:129-141` already embeds the résumé lazily when it finds no usable vector, and caches the result. **Indexing was never required** — the Settings button is a pre-warm.

And the vector has exactly one consumer: semantic match scoring. I checked every production reader. That matters, because semantic scoring is **off by default**, so for a default-config user an indexed résumé is read by nothing at all.

So what actually cost you something was (a) a slow first match — a synchronous embed inside scoring — and (b) a status strip that read like a chore list.

## 1. Say what's true

The strip said, in amber:

> N documents need re-indexing for the active model.

Nothing *needs* it. Reworded to state that matching indexes on first use, dropped the warning styling (nothing is wrong), and added a distinct line for when auto-indexing is on.

## 2. Auto-index — opt in

New `autoIndexOnUpload` preference, and one hook mounted at the root. All three moments that create stale documents surface identically as a non-zero `documents.stale`, so a single effect covers them:

- a résumé was just imported
- the embedding provider/model changed
- either of those was left over from last session

**Backed by a new command, deliberately not the existing one.** `ai_reembed_all` re-embeds *every* document unconditionally — reusing it would re-bill a cloud embedding provider for already-indexed documents every time one new file is added. `ai_index_stale_documents` embeds only what's missing and returns a null job id when nothing is, so the common case is one cheap query and no work. Both share one job body so they can't drift in error handling, cancellation or progress reporting.

## 3. Ask during setup

New onboarding step immediately before the crash-reporting consent. Both ask "may this run on your behalf", and this one calls a provider that may bill per token, so the two spend/privacy decisions sit together instead of scattered.

**Defaults to OFF**, and the step's switch is seeded from the stored value rather than forced on. Two reasons, both deliberate:

- an existing install must never start calling a paid embedding provider because of an update
- stepping back through the wizard must not silently discard a "no" — my first draft had `stored || true`, which is unconditionally true and would have done exactly that

Leaving it off costs nothing, which is the point of part 1: matching still indexes lazily.

## Tests

The hook's tests are weighted toward **not** running, since that's where the money is:

- preference off + stale documents → never called
- nothing stale → never called
- **no embedding model configured yet** → waits instead of failing once per refetch (this is the normal first-run path — the résumé step is #2, the AI step is #3)
- repeated refetches → exactly one job, not a paid duplicate per refetch
- a failing index → no unhandled rejection, and the raw provider message never reaches the log

Plus the wizard's step-count/navigation tests updated for the new step.

## Not covered

The strip's new wording and the onboarding step have no visual verification here — worth a look in `pnpm dev` before merging, since the whole point of part 1 is how it reads.

Gates: clippy `--all-features` 0 warnings · `cargo test --lib` 3162 · architecture 18/18 · `pnpm test` 4902 · typecheck 13/13 · `lint:strict` clean · no IPC drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
