### PR TITLE
fix: stop squashing the embeddings checkbox, and unnest the provider row button

### DIFF
--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/EmbeddingsSettings.layout.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/EmbeddingsSettings.layout.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * EmbeddingsSettings — toggle-row layout.
+ *
+ * Both symptoms reported against the shipped UI had ONE cause: the row is
+ * `justify-between` with no gap, and the `<input>` had no `shrink-0`. With the
+ * short semantic-scoring description there is slack and it looks right; with the
+ * longer auto-index description the text block fills the row, so the copy butts
+ * against the checkbox AND flexbox compresses the input below its `h-4 w-4` —
+ * making it look like a different control rather than a squashed one.
+ *
+ * Asserted on the classes because that is where the bug lives: jsdom reports
+ * zero geometry (see the repo's jsdom notes), so a computed-width assertion
+ * would pass against the broken markup.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import type * as AjhUi from '@ajh/ui';
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/services', () => ({
+  useEmbeddingStatus: () => ({ data: undefined, refetch: vi.fn() }),
+  useSetEmbeddingConfig: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useReembedAll: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useJobEvents: (_handler: unknown) => undefined,
+}));
+
+vi.mock('@ajh/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof AjhUi>();
+  return {
+    ...actual,
+    useNotification: () => ({
+      open: vi.fn(),
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+    }),
+  };
+});
+
+import { EmbeddingsSettings } from './index';
+
+describe('EmbeddingsSettings — toggle rows', () => {
+  it('gives every toggle checkbox shrink-0 so a long description cannot squash it', () => {
+    render(<EmbeddingsSettings />);
+
+    const boxes = screen
+      .getAllByRole('checkbox')
+      .filter((el) => el.className.includes('accent-[var(--color-brand)]'));
+    expect(boxes.length).toBeGreaterThanOrEqual(2);
+
+    for (const box of boxes) {
+      expect(box.className).toContain('shrink-0');
+      expect(box.className).toContain('h-4');
+      expect(box.className).toContain('w-4');
+    }
+  });
+
+  it('keeps a gap between the description and the checkbox on every toggle row', () => {
+    render(<EmbeddingsSettings />);
+
+    const rows = screen
+      .getAllByRole('checkbox')
+      .filter((el) => el.className.includes('accent-[var(--color-brand)]'))
+      .map((el) => el.parentElement);
+
+    for (const row of rows) {
+      expect(row).not.toBeNull();
+      // `justify-between` alone collapses to zero once the text fills the row.
+      expect(row?.className).toContain('gap-');
+    }
+  });
+
+  it('labels both toggles for assistive tech', () => {
+    render(<EmbeddingsSettings />);
+    const boxes = screen
+      .getAllByRole('checkbox')
+      .filter((el) => el.className.includes('accent-[var(--color-brand)]'));
+    for (const box of boxes) {
+      expect(box.getAttribute('aria-label')).toBeTruthy();
+    }
+  });
+});

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/index.tsx
@@ -263,7 +263,13 @@ export function EmbeddingsSettings() {
           </Button>
         </div>
 
-        <div className="flex items-center justify-between rounded-lg border border-foreground/10 bg-foreground/[0.03] px-3 py-2.5">
+        {/* `gap-3` + `shrink-0` on the input: `justify-between` alone leaves no
+            space once a description wraps to two lines, and a flex `<input>`
+            without `shrink-0` is COMPRESSED below its `h-4 w-4` — the checkbox
+            then looks like a different control from its neighbour rather than a
+            squashed one. Applied to both rows so a future copy change to either
+            cannot resurrect it. */}
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-foreground/10 bg-foreground/[0.03] px-3 py-2.5">
           <div className="space-y-0.5">
             <p className="text-xs font-semibold text-foreground/70">
               {t('settings.embeddings.autoIndex')}
@@ -276,12 +282,12 @@ export function EmbeddingsSettings() {
             type="checkbox"
             checked={autoIndexOnUpload}
             onChange={(e) => setAutoIndexOnUpload(e.target.checked)}
-            className="h-4 w-4 accent-[var(--color-brand)] cursor-pointer"
+            className="h-4 w-4 shrink-0 accent-[var(--color-brand)] cursor-pointer"
             aria-label={t('settings.embeddings.autoIndex')}
           />
         </div>
 
-        <div className="flex items-center justify-between rounded-lg border border-foreground/10 bg-foreground/[0.03] px-3 py-2.5">
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-foreground/10 bg-foreground/[0.03] px-3 py-2.5">
           <div className="space-y-0.5">
             <p className="text-xs font-semibold text-foreground/70">
               {t('settings.embeddings.semanticScoring')}
@@ -294,7 +300,8 @@ export function EmbeddingsSettings() {
             type="checkbox"
             checked={semanticScoring}
             onChange={(e) => setSemanticScoring(e.target.checked)}
-            className="h-4 w-4 accent-[var(--color-brand)] cursor-pointer"
+            className="h-4 w-4 shrink-0 accent-[var(--color-brand)] cursor-pointer"
+            aria-label={t('settings.embeddings.semanticScoring')}
           />
         </div>
       </div>

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/ProviderRow/ProviderRow.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/ProviderRow/ProviderRow.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * ProviderRow — row activation vs. the nested "test key" action.
+ *
+ * The row is a `role="button"` that expands on click (it cannot be a real
+ * `<button>`: that would nest the test-key `<Button>` inside it, which is
+ * invalid DOM and what React was reporting as "<button> cannot contain a nested
+ * <button>").
+ *
+ * Unnesting alone does NOT fix the behaviour, which is the trap here: the inner
+ * button's click still BUBBLES to the row, so "test key" kept toggling the row's
+ * expand state. These pin the guard, not just the markup.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+import { ProviderRow } from './index';
+
+type Props = React.ComponentProps<typeof ProviderRow>;
+
+const baseProps = (over: Partial<Props> = {}): Props =>
+  ({
+    provider: 'openai',
+    meta: {
+      kind: 'cloud',
+      label: 'OpenAI',
+      description: 'Cloud provider',
+      color: 'text-emerald-400',
+      docsUrl: 'https://example.com',
+    },
+    connected: true,
+    isActive: false,
+    isExpanded: false,
+    onToggleExpand: vi.fn(),
+    onSetActive: vi.fn(),
+    onSelectModel: vi.fn(),
+    onOpenDocs: vi.fn(),
+    onRecheck: vi.fn(),
+    ...over,
+  }) as unknown as Props;
+
+describe('ProviderRow — row vs. test-key activation', () => {
+  it('does not nest a real <button> inside another <button>', () => {
+    // The original defect. Checks actual `<button>` ELEMENTS, not
+    // `getAllByRole('button')` — that also matches the `role="button"` row, and
+    // a real button inside a role-button row is the repo's accepted pattern
+    // (NotificationBell). React's complaint was specifically about tag nesting,
+    // which is what makes the DOM invalid.
+    const { container } = render(<ProviderRow {...baseProps({ onTestKey: vi.fn() })} />);
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const btn of buttons) {
+      expect(btn.querySelector('button')).toBeNull();
+    }
+  });
+
+  it('clicking "test key" does NOT also expand the row', async () => {
+    // The behavioural half. Unnesting removes the invalid DOM but the click
+    // still bubbles to the row's handler — this is what actually broke for the
+    // user, and it survives a markup-only fix.
+    const onTestKey = vi.fn();
+    const onToggleExpand = vi.fn();
+    const user = userEvent.setup();
+    render(<ProviderRow {...baseProps({ onTestKey, onToggleExpand })} />);
+
+    const testKey = screen.getAllByRole('button').find((b) => b.className.includes('px-1.5'));
+    expect(testKey).toBeDefined();
+    await user.click(testKey as HTMLElement);
+
+    expect(onTestKey).toHaveBeenCalledTimes(1);
+    expect(onToggleExpand).not.toHaveBeenCalled();
+  });
+
+  it('clicking the row itself still expands it', async () => {
+    // The differential — a stopPropagation guard that swallowed everything
+    // would pass the test above while breaking the row.
+    const onToggleExpand = vi.fn();
+    const user = userEvent.setup();
+    render(<ProviderRow {...baseProps({ onToggleExpand })} />);
+
+    await user.click(screen.getByText('OpenAI'));
+    expect(onToggleExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the row keyboard-activatable', async () => {
+    const onToggleExpand = vi.fn();
+    const user = userEvent.setup();
+    render(<ProviderRow {...baseProps({ onToggleExpand })} />);
+
+    const row = screen.getByText('OpenAI').closest('[role="button"]');
+    (row as HTMLElement).focus();
+    await user.keyboard('{Enter}');
+    expect(onToggleExpand).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/ProviderRow/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/ProviderRow/index.tsx
@@ -90,11 +90,24 @@ export function ProviderRow({
     <div
       className={`rounded-xl border transition-all ${isExpanded ? 'border-foreground/15 bg-foreground/[0.03]' : 'border-foreground/10 bg-foreground/[0.03]'}`}
     >
-      {/* Row header */}
-      <Button
-        variant="unstyled"
+      {/* Row header.
+          A `<button>` row would nest the "test key" `Button` below inside it —
+          invalid DOM, and the inner click also fires this row's expand. React
+          reports it as "<button> cannot contain a nested <button>"; it showed up
+          in the log file once the renderer console bridge landed. Follows the
+          repo's `role="button"` row pattern (see `NotificationBell`), which
+          keeps keyboard activation without the nesting. */}
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onToggleExpand}
-        className="flex w-full items-center gap-3 px-4 py-3 text-left"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggleExpand();
+          }
+        }}
+        className="flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left"
       >
         <Bot size={15} className={connected ? meta.color : 'text-foreground/25'} />
         <div className="min-w-0 flex-1">
@@ -138,7 +151,7 @@ export function ProviderRow({
         ) : (
           <span className="text-[10px] text-foreground/30">Not connected</span>
         )}
-      </Button>
+      </div>
 
       {/* Expanded config */}
       {isExpanded && (

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/ProviderRow/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/ProviderRow/index.tsx
@@ -141,7 +141,22 @@ export function ProviderRow({
               <Button
                 variant="glass"
                 disabled={isTesting}
-                onClick={() => void onTestKey()}
+                onClick={(e) => {
+                  // The row is a `role="button"` that expands on click, so
+                  // without this a "test key" press ALSO toggles the row —
+                  // which is the behaviour the old nested-<button> markup had
+                  // and that unnesting alone does NOT fix: the click still
+                  // bubbles. Same guard `ApplicationRow` uses for its note chip.
+                  e.stopPropagation();
+                  void onTestKey();
+                }}
+                // Enter/Space on a focused <button> also fires a native click,
+                // so the keydown must be stopped too — otherwise it reaches the
+                // row's own Enter/Space handler, whose `preventDefault()` can
+                // suppress this button's activation entirely.
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+                }}
                 className="h-auto px-1.5 py-0.5 text-[10px]"
               >
                 {isTesting ? <Loader2 size={9} className="animate-spin" /> : <RefreshCw size={9} />}


### PR DESCRIPTION
Three UI defects in Settings → AI. Two reported off a screenshot of the shipped UI, one surfaced by the log bridge, one found while writing the tests.

## The two embeddings toggles looked like different controls

They aren't. **One cause explains both symptoms** ("the checkbox isn't the same" and "the text is too close to it"):

The row is `flex items-center justify-between` with **no gap**, and the `<input>` had **no `shrink-0`**.

- Semantic scoring's one-line description leaves slack in the row → renders correctly.
- The longer auto-index description fills the row → the copy butts against the checkbox, **and** flexbox compresses the input below its own `h-4 w-4`.

So it's not a different checkbox — it's a squashed one. Fixed on **both** rows, so a future copy change to either can't bring it back.

This is precisely the gap I flagged when #951 merged: the copy was never looked at. I reused the semantic-scoring markup and changed the text without checking the layout still held.

## `ProviderRow` nested a `<button>` inside a `<button>`

`ProviderRow` wrapped its header in `<Button variant="unstyled" onClick={onToggleExpand}>` and nested the "test key" `<Button variant="glass">` inside it.

Beyond invalid DOM: **clicking "test key" also fired the row's expand/collapse**, and assistive tech got a nested-control tree it can't express.

React had been reporting this all along — into devtools, where nobody was looking. It only became visible once the renderer console bridge started writing to the log file:

```
[2026-08-06][09:47:56][webview][ERROR] <%s> cannot contain a nested %s. ... button <button>
  <AISettingsTab> → <ProviderRow provider="ollama-cloud"> →
    <_c variant="unstyled" onClick={onToggleExpand}> → <button>
      → <_c variant="glass" onClick={onTestKey}> → <button>
```

Converted to the `role="button"` row pattern the repo already uses — `NotificationBell` carries a comment describing this exact trade-off, so the fix was to follow the existing precedent rather than invent one. Enter/Space activation preserved.

## Found while writing the tests

The semantic-scoring checkbox had **no `aria-label`**. Added.

## On the tests

Asserted on **classes, not geometry**. jsdom reports zero width/height (a documented gotcha in this repo), so a computed-size assertion would have passed happily against the broken markup — it would have been a test that could never fail.

Both layout tests were verified to fail against the shipped version before being kept: reverting `shrink-0` and `gap-3` makes them fail, restoring makes them pass.

Gates: `pnpm test` 4907 · typecheck 13/13 · `lint:strict` clean (incl. the a11y rules, which the `role="button"` conversion has to satisfy).

## Note

The remaining copy from #951 — the stale-documents line — now reads as plain information rather than the old amber warning, but I still haven't seen it rendered. Worth a glance while reviewing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
