### PR TITLE
ui: explain what the job match and trust badges mean on hover

### DIFF
--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/AutopilotCard.test.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/AutopilotCard.test.tsx
@@ -164,14 +164,20 @@ vi.mock('@/lib/match-band', async (importActual) => {
       variant,
       subtle,
       muted,
+      describe = true,
     }: {
       value: number;
       variant?: 'combined' | 'coverage';
       subtle?: boolean;
       muted?: boolean;
+      describe?: boolean;
     }) => {
       const tier = actual.scoreTier(value, variant ?? 'combined').key;
       const isMutedStyle = Boolean(muted) || (Boolean(subtle) && tier !== 'High');
+      // `describe` is echoed, not re-implemented: the question these tests ask
+      // is which value AUTOPILOTCARD passes at each call site (the provisional
+      // wrapper owns the copy and must opt out; the bare band must not). What
+      // the real MatchBand renders for it is match-band.test.tsx's job.
       return (
         <span
           data-testid="match-band"
@@ -179,6 +185,7 @@ vi.mock('@/lib/match-band', async (importActual) => {
           data-variant={variant ?? 'combined'}
           data-tier={tier}
           data-muted={isMutedStyle ? 'true' : 'false'}
+          data-describe={describe ? 'true' : 'false'}
         />
       );
     },
@@ -579,13 +586,27 @@ describe('AutopilotCard — provisional score marker', () => {
       header.click();
     });
 
-    // The native hover hint (title) is present...
-    expect(screen.getByTitle('autopilot.provisionalScoreHint')).toBeInTheDocument();
+    // The native hover hint (title) carries BOTH facts: what the tier claims,
+    // and that the number behind it is only an estimate. They answer different
+    // questions, so neither may be dropped.
+    // The band's own nearest titled ancestor — not just any title on the card.
+    const marker = screen.getByTestId('match-band').closest('[title]') as HTMLElement;
+    expect(marker.title).toContain('jobs.matchBand.desc.coverage.High');
+    expect(marker.title).toContain('autopilot.provisionalScoreHint');
+    // Exactly ONE title on this marker — the band must not render its own
+    // inside this wrapper, or the inner one wins on hover over the badge and
+    // hides the provisional caveat entirely.
+    expect(marker.querySelectorAll('[title]')).toHaveLength(0);
     // ...the "~" estimate prefix is visible...
     expect(screen.getByText('~')).toBeInTheDocument();
-    // ...an always-present sr-only span carries the same hint for screen
-    // readers (a `title` alone isn't reliably announced — TrustBadge precedent)...
-    expect(screen.getByText(': autopilot.provisionalScoreHint')).toHaveClass('sr-only');
+    // ...an always-present sr-only span carries the same words for screen
+    // readers (a `title` alone isn't reliably announced — TrustBadge
+    // precedent), and only ONE of them, not one per nested describer...
+    const srOnly = marker.querySelectorAll('.sr-only');
+    expect(srOnly).toHaveLength(1);
+    expect(srOnly[0]?.textContent).toBe(`: ${marker.title}`);
+    // The band itself must stay silent here — this wrapper speaks for it.
+    expect(screen.getByTestId('match-band')).toHaveAttribute('data-describe', 'false');
     // ...the band IS the High tier (proving this is genuinely a HIGH-score case)...
     const band = screen.getByTestId('match-band');
     expect(band).toHaveAttribute('data-tier', 'High');
@@ -608,6 +629,11 @@ describe('AutopilotCard — provisional score marker', () => {
     const band = screen.getByTestId('match-band');
     expect(band).toHaveAttribute('data-tier', 'High');
     expect(band).toHaveAttribute('data-muted', 'false');
+    // This band has NO wrapper carrying an explanation, so it must describe
+    // itself. Opting out here (as a blanket "opt out at both call sites" fix
+    // would have) leaves the badge a bare, unexplained word — the exact gap
+    // this feature exists to close.
+    expect(band).toHaveAttribute('data-describe', 'true');
   });
 
   it('treats an absent scoreProvisional field (older records) as non-provisional', async () => {

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotCard/index.tsx
@@ -36,7 +36,7 @@ import { AgencyChip } from '@/components/job/AgencyChip';
 import { ClusterSourceChips } from '@/components/job/ClusterSourceChips';
 import { BoardSummaryChips } from '@/components/scrape/BoardSummaryChips';
 import { type AutopilotRunState, RUN_STATE_LABEL } from '@/lib/machines/autopilot-run.machine';
-import { MatchBand } from '@/lib/match-band';
+import { MatchBand, matchBandDescriptionKey, scoreTier } from '@/lib/match-band';
 import { timeAgo } from '@/lib/time';
 import { TrustBadge } from '@/lib/trust-badge';
 import { useInteractions, useMarkNotDuplicate, useOpenExternal, usePersistJob } from '@/services';
@@ -111,6 +111,23 @@ const NEEDS_CONFIG_BADGE = {
   labelKey: 'autopilot.badge.needsConfig',
   className: 'bg-foreground/[0.06] text-foreground/70',
 };
+
+/**
+ * Hover/screen-reader copy for a PROVISIONAL coverage score: what the tier
+ * means, then why it is only an estimate.
+ *
+ * Both, not either. They answer different questions — the tier description says
+ * what "High" is claiming, `provisionalScoreHint` says how much to trust the
+ * number behind it — so dropping one leaves a real gap. Composed here rather
+ * than inside `MatchBand` because this wrapper already owns the `title` and the
+ * sr-only span; letting the band render its own would put a second `title`
+ * inside this one (the inner wins on hover over the badge, hiding the caveat)
+ * and announce twice.
+ */
+function provisionalScoreDetail(t: (key: string) => string, score: number): string {
+  const tier = t(matchBandDescriptionKey(scoreTier(score, 'coverage').key, 'coverage'));
+  return `${tier} ${t('autopilot.provisionalScoreHint')}`;
+}
 
 /** Badges that carry a hover/focus explainer now that the chip strip exists. */
 const BADGE_HINT_KEY = {
@@ -634,7 +651,7 @@ export function AutopilotCard({
                             // above renders interactive=false).
                             <span
                               className="inline-flex shrink-0 items-center gap-0.5"
-                              title={t('autopilot.provisionalScoreHint')}
+                              title={provisionalScoreDetail(t, job.score)}
                             >
                               <span
                                 aria-hidden="true"
@@ -642,9 +659,20 @@ export function AutopilotCard({
                               >
                                 ~
                               </span>
-                              <MatchBand value={job.score} variant="coverage" muted />
+                              {/* describe={false}: this wrapper owns the copy —
+                                  the band's own `title` would otherwise win on
+                                  hover over the badge itself and hide the
+                                  provisional caveat, and its sr-only suffix
+                                  would double up with the one below. Same
+                                  caller-owns-richer-copy split as RowMatchScore. */}
+                              <MatchBand
+                                value={job.score}
+                                variant="coverage"
+                                muted
+                                describe={false}
+                              />
                               <span className="sr-only">
-                                : {t('autopilot.provisionalScoreHint')}
+                                : {provisionalScoreDetail(t, job.score)}
                               </span>
                             </span>
                           ) : (

--- a/apps/desktop/src/renderer/features/jobs/components/RowMatchScore/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/RowMatchScore/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from '@ajh/translations';
 import { Button, HoverPopover } from '@ajh/ui';
 
 import { useRowMatchScore } from '@/features/jobs/providers';
-import { MatchBand } from '@/lib/match-band';
+import { MatchBand, matchBandDescriptionKey, scoreTier } from '@/lib/match-band';
 
 /**
  * Presentational per-row match score. Scores are fetched on-demand when the
@@ -23,13 +23,18 @@ export function RowMatchScore({ jobId }: { jobId: string }) {
   if (!hasResume) return null;
   if (!score) return null;
 
+  // What this tier means, then the estimate disclaimer. The band itself is
+  // `describe={false}` here — its native `title` would otherwise fire on hover
+  // alongside this popover and say a shorter version of the same thing.
+  const tierDescription = t(matchBandDescriptionKey(scoreTier(score.combined).key));
+
   return (
     <HoverPopover
       placement="top"
-      ariaLabel={t('jobs.scoreGuidance')}
+      ariaLabel={`${tierDescription} ${t('jobs.scoreGuidance')}`}
       trigger={
         <div className="flex items-center gap-1">
-          <MatchBand value={score.combined} />
+          <MatchBand value={score.combined} describe={false} />
           {/* Always-visible estimate framing — present without interaction. */}
           <span className="text-fine-print text-foreground/50">{t('jobs.scoreEst')}</span>
           <Button
@@ -42,9 +47,10 @@ export function RowMatchScore({ jobId }: { jobId: string }) {
         </div>
       }
     >
-      <p className="dropdown-surface max-w-[220px] px-3 py-2 text-fine-print leading-snug text-foreground/70">
-        {t('jobs.scoreGuidance')}
-      </p>
+      <div className="dropdown-surface max-w-[240px] space-y-1.5 px-3 py-2 text-fine-print leading-snug text-foreground/70">
+        <p className="text-foreground/85">{tierDescription}</p>
+        <p>{t('jobs.scoreGuidance')}</p>
+      </div>
     </HoverPopover>
   );
 }

--- a/apps/desktop/src/renderer/lib/match-band.i18n.test.tsx
+++ b/apps/desktop/src/renderer/lib/match-band.i18n.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * MatchBand — i18n key-drift guard for the hover description.
+ *
+ * A separate file from `match-band.test.tsx` on purpose: that one stubs
+ * `@ajh/translations` with `t: (k) => k`, which echoes raw keys back and so can
+ * never catch a mistyped or missing resource entry. The description key is
+ * built at runtime from tier + variant (`jobs.matchBand.desc.<variant>.<tier>`),
+ * so TypeScript cannot check it either — only a real `t()` can.
+ *
+ * Same rationale and setup as `trust-badge.test.tsx`: `@ajh/translations`
+ * resolves to real source under vitest and initializes with the real bundled
+ * en/de resources, so a broken key surfaces as the raw key string in the DOM.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { MatchBand, matchBandDescriptionKey, scoreTier } from './match-band';
+
+const VARIANTS = ['combined', 'coverage'] as const;
+const SAMPLES = [
+  { value: 90, tier: 'High' },
+  { value: 52, tier: 'Medium' },
+  { value: 5, tier: 'Low' },
+] as const;
+
+describe('MatchBand description copy resolves for every tier and variant', () => {
+  for (const variant of VARIANTS) {
+    for (const { value, tier } of SAMPLES) {
+      it(`${variant}/${tier} resolves to real copy, not a raw key`, () => {
+        const key = matchBandDescriptionKey(scoreTier(value, variant).key, variant);
+        const { container } = render(<MatchBand value={value} variant={variant} />);
+        const title = container.querySelector('[title]')?.getAttribute('title') ?? '';
+
+        expect(title).not.toBe(key);
+        expect(title).not.toContain('jobs.matchBand');
+        // A description that doesn't say anything is the same failure as a
+        // missing one — a bare word would leave the badge unexplained.
+        expect(title.length).toBeGreaterThan(20);
+      });
+    }
+  }
+
+  it('says something different for coverage than for combined', () => {
+    // The two make genuinely different claims: coverage is keyword overlap with
+    // no AI scoring, combined blends meaning and keywords. Identical copy here
+    // would mean one of them is lying to the user.
+    const read = (variant: (typeof VARIANTS)[number]) =>
+      render(<MatchBand value={90} variant={variant} />)
+        .container.querySelector('[title]')
+        ?.getAttribute('title');
+
+    expect(read('combined')).not.toBe(read('coverage'));
+  });
+
+  it('distinguishes the tiers from each other', () => {
+    const titles = SAMPLES.map(({ value }) =>
+      render(<MatchBand value={value} />)
+        .container.querySelector('[title]')
+        ?.getAttribute('title')
+    );
+    expect(new Set(titles).size).toBe(SAMPLES.length);
+  });
+});

--- a/apps/desktop/src/renderer/lib/match-band.test.tsx
+++ b/apps/desktop/src/renderer/lib/match-band.test.tsx
@@ -212,3 +212,51 @@ describe('MatchBand — muted=true (mutes ALL tiers, unlike subtle)', () => {
     expect(el.className).toContain('bg-muted');
   });
 });
+
+// ── Self-explanatory description ────────────────────────────────────────────
+//
+// The band's visible label is a bare word ("High"), which means nothing to a
+// user who hasn't read the docs. These pin the explanation that hover surfaces.
+//
+// NOTE: `t` is stubbed to echo raw keys in this file, so these assert the KEY
+// SHAPE and the describe/opt-out wiring. That the keys actually resolve to real
+// copy is pinned by `match-band.i18n.test.tsx`, which uses real translations.
+describe('MatchBand — description', () => {
+  it('exposes the explanation on hover and to screen readers by default', () => {
+    const { container } = render(<MatchBand value={80} />);
+    const wrapper = container.querySelector('[title]');
+    expect(wrapper?.getAttribute('title')).toBe('jobs.matchBand.desc.combined.High');
+    expect(screen.getByText(': jobs.matchBand.desc.combined.High')).toHaveClass('sr-only');
+  });
+
+  it('describes the coverage variant differently from combined', () => {
+    // Not cosmetic: a coverage High is keyword overlap with no AI behind it,
+    // a combined High blends meaning and keywords. Same word, different claim.
+    const { container } = render(<MatchBand value={80} variant="coverage" />);
+    expect(container.querySelector('[title]')?.getAttribute('title')).toBe(
+      'jobs.matchBand.desc.coverage.High'
+    );
+  });
+
+  it('omits the native title when the caller supplies its own popover', () => {
+    // describe={false} exists so RowMatchScore's richer popover isn't shadowed
+    // by a browser tooltip saying a shorter version of the same thing.
+    const { container } = render(<MatchBand value={80} describe={false} />);
+    expect(container.querySelector('[title]')).toBeNull();
+    expect(container.querySelector('.sr-only')).toBeNull();
+  });
+
+  it('describes every tier, not just High', () => {
+    for (const [value, tier] of [
+      [80, 'High'],
+      [60, 'Medium'],
+      [10, 'Low'],
+    ] as const) {
+      const { container, unmount } = render(<MatchBand value={value} />);
+      expect(container.querySelector('[title]')?.getAttribute('title')).toBe(
+        `jobs.matchBand.desc.combined.${tier}`
+      );
+      unmount();
+    }
+  });
+});

--- a/apps/desktop/src/renderer/lib/match-band.tsx
+++ b/apps/desktop/src/renderer/lib/match-band.tsx
@@ -24,6 +24,21 @@ export function scoreTier(
   return { key: 'Low', color: 'error' };
 }
 
+/** i18n key for the plain-language explanation of a tier.
+ *
+ *  Keyed on the VARIANT too, because the two say genuinely different things: a
+ *  `combined` High blends meaning + keywords, a `coverage` High is keyword
+ *  overlap alone with no AI scoring behind it. One shared sentence would have
+ *  to be vague enough to be true of both, which is how a tooltip stops being
+ *  worth reading.
+ */
+export function matchBandDescriptionKey(
+  tier: ScoreTier,
+  variant: 'combined' | 'coverage' = 'combined'
+): string {
+  return `jobs.matchBand.desc.${variant}.${tier}`;
+}
+
 /** Low/Medium/High match-score Tag — localized label.
  *
  *  subtle=true: Medium/Low render muted-neutral; High stays bright — the tier
@@ -36,6 +51,16 @@ export function scoreTier(
  *  actually is. Deliberately a separate prop from `subtle`, not an extension
  *  of it — `subtle`'s High-stays-bright contract is pinned by its own tests
  *  and other callers may rely on it.
+ *
+ *  describe=true (default): the bare word "High" means nothing on its own, so
+ *  the band carries a plain-language explanation as a native `title` plus an
+ *  sr-only suffix. Deliberately NOT a `HoverPopover` like TrustBadge uses: this
+ *  band renders inside a `<Button>` on the Autopilot card (a focusable popover
+ *  trigger there is invalid button-in-button HTML) and inside
+ *  aria-activedescendant listbox rows (where it would add a tab stop per row).
+ *  `title` is hover-only and focusable-free, so it is safe in both.
+ *  Pass describe={false} where the caller already surfaces richer copy in its
+ *  own popover — see RowMatchScore — so the two don't both fire on hover.
  */
 export function MatchBand({
   value,
@@ -43,18 +68,22 @@ export function MatchBand({
   variant = 'combined',
   subtle = false,
   muted = false,
+  describe = true,
 }: {
   value: number;
   large?: boolean;
   variant?: 'combined' | 'coverage';
   subtle?: boolean;
   muted?: boolean;
+  describe?: boolean;
 }) {
   const { t } = useTranslation();
   const band = scoreTier(value, variant);
   // `muted` mutes unconditionally (all tiers); `subtle` mutes only Medium/Low.
   const isMutedStyle = muted || (subtle && band.key !== 'High');
-  return (
+  const description = describe ? t(matchBandDescriptionKey(band.key, variant)) : undefined;
+
+  const tag = (
     <Tag
       color={isMutedStyle ? undefined : band.color}
       className={cn(
@@ -65,5 +94,14 @@ export function MatchBand({
     >
       {t(`jobs.matchBand.${band.key}`)}
     </Tag>
+  );
+
+  if (!description) return tag;
+
+  return (
+    <span className="inline-flex items-center" title={description}>
+      {tag}
+      <span className="sr-only">: {description}</span>
+    </span>
   );
 }

--- a/apps/desktop/src/renderer/lib/trust-badge.test.tsx
+++ b/apps/desktop/src/renderer/lib/trust-badge.test.tsx
@@ -138,3 +138,46 @@ describe('TrustBadge — strong prop', () => {
     expect(screen.getByText('Low trust')).toBeInTheDocument();
   });
 });
+
+// ── Level description ───────────────────────────────────────────────────────
+//
+// The flag list answers "which checks failed" but never "so what?" —
+// "Suspicious domain" doesn't tell a reader whether to skip the posting or just
+// look twice. These pin the plain-language verdict that now leads the tooltip.
+// Real translations (see the file header), so a missing `jobs.trust.levelDesc.*`
+// key surfaces as the raw key here.
+describe('TrustBadge — level description', () => {
+  for (const level of ['low', 'medium'] as const) {
+    it(`explains what "${level} trust" means, in resolved copy`, () => {
+      render(<TrustBadge trust={assessment(level, ['suspiciousDomain'])} />);
+      const detail = screen.getByText(/:/).textContent ?? '';
+
+      expect(detail).not.toContain('jobs.trust.levelDesc');
+      expect(detail).not.toContain('jobs.trust.whyPrefix');
+      // The verdict comes before the evidence — a reader needs to know whether
+      // to care before being handed a list of failed checks.
+      expect(detail.indexOf('Suspicious domain')).toBeGreaterThan(10);
+    });
+  }
+
+  it('still explains the level when no flags accompany it', () => {
+    // Previously the whole detail block was gated on `reasons` being non-empty,
+    // so a flagged-but-reasonless assessment rendered a bare badge with nothing
+    // to explain it.
+    render(<TrustBadge trust={assessment('low', [])} />);
+    const detail = screen.getByText(/^:/).textContent ?? '';
+    expect(detail.length).toBeGreaterThan(20);
+    expect(detail).not.toContain('jobs.trust');
+  });
+
+  it('carries the same words on a non-interactive surface, via title', () => {
+    // Listbox rows and in-Button placements can't host a focusable popover, but
+    // must not therefore be silent.
+    const { container } = render(
+      <TrustBadge trust={assessment('low', ['invalidUrl'])} interactive={false} />
+    );
+    const title = container.querySelector('[title]')?.getAttribute('title') ?? '';
+    expect(title).toContain('Broken apply link');
+    expect(title).not.toContain('jobs.trust');
+  });
+});

--- a/apps/desktop/src/renderer/lib/trust-badge.test.tsx
+++ b/apps/desktop/src/renderer/lib/trust-badge.test.tsx
@@ -22,6 +22,7 @@ import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 import type { JobTrustAssessment } from '@ajh/shared';
+import i18n from '@ajh/translations';
 
 import { TrustBadge } from './trust-badge';
 
@@ -146,19 +147,37 @@ describe('TrustBadge — strong prop', () => {
 // look twice. These pin the plain-language verdict that now leads the tooltip.
 // Real translations (see the file header), so a missing `jobs.trust.levelDesc.*`
 // key surfaces as the raw key here.
+// Expected copy is read from the SAME resource the component renders from, so
+// these assert the description is actually present without hardcoding a
+// sentence that would have to be edited every time the wording is tweaked.
+// (Absence-of-raw-key assertions alone were too weak: with `levelDescription`
+// deleted the detail string still contained no raw keys and still placed the
+// flag list past character 10, so every assertion passed with the feature gone.)
+const levelDescriptionFor = (level: 'low' | 'medium') => i18n.t(`jobs.trust.levelDesc.${level}`);
+
 describe('TrustBadge — level description', () => {
   for (const level of ['low', 'medium'] as const) {
     it(`explains what "${level} trust" means, in resolved copy`, () => {
+      const expected = levelDescriptionFor(level);
+      // Guard the guard: if the key ever goes missing, `t` returns the key
+      // itself and every containment check below would trivially pass.
+      expect(expected).not.toContain('jobs.trust');
+
       render(<TrustBadge trust={assessment(level, ['suspiciousDomain'])} />);
       const detail = screen.getByText(/:/).textContent ?? '';
 
-      expect(detail).not.toContain('jobs.trust.levelDesc');
-      expect(detail).not.toContain('jobs.trust.whyPrefix');
+      expect(detail).toContain(expected);
       // The verdict comes before the evidence — a reader needs to know whether
       // to care before being handed a list of failed checks.
-      expect(detail.indexOf('Suspicious domain')).toBeGreaterThan(10);
+      expect(detail.indexOf(expected)).toBeLessThan(detail.indexOf('Suspicious domain'));
     });
   }
+
+  it('gives each level its own words', () => {
+    // A shared sentence would defeat the point: "treat with caution" and "worth
+    // a second look" are different instructions to the reader.
+    expect(levelDescriptionFor('low')).not.toBe(levelDescriptionFor('medium'));
+  });
 
   it('still explains the level when no flags accompany it', () => {
     // Previously the whole detail block was gated on `reasons` being non-empty,
@@ -166,18 +185,22 @@ describe('TrustBadge — level description', () => {
     // to explain it.
     render(<TrustBadge trust={assessment('low', [])} />);
     const detail = screen.getByText(/^:/).textContent ?? '';
-    expect(detail.length).toBeGreaterThan(20);
-    expect(detail).not.toContain('jobs.trust');
+    expect(detail).toContain(levelDescriptionFor('low'));
   });
 
   it('carries the same words on a non-interactive surface, via title', () => {
     // Listbox rows and in-Button placements can't host a focusable popover, but
-    // must not therefore be silent.
+    // must not therefore be silent — and must not say LESS than the popover
+    // does, which is what checking only the flag reason here allowed.
     const { container } = render(
       <TrustBadge trust={assessment('low', ['invalidUrl'])} interactive={false} />
     );
     const title = container.querySelector('[title]')?.getAttribute('title') ?? '';
+    const srText = container.querySelector('.sr-only')?.textContent ?? '';
+
+    expect(title).toContain(levelDescriptionFor('low'));
     expect(title).toContain('Broken apply link');
-    expect(title).not.toContain('jobs.trust');
+    // Sighted-hover and screen-reader paths must not drift apart.
+    expect(srText).toContain(title);
   });
 });

--- a/apps/desktop/src/renderer/lib/trust-badge.tsx
+++ b/apps/desktop/src/renderer/lib/trust-badge.tsx
@@ -44,6 +44,15 @@ export function TrustBadge({
   const isLow = trust.level === 'low';
   const levelLabel = t(`jobs.trust.level.${trust.level}`);
   const reasons = trust.flags.map((flag) => t(`jobs.trust.flags.${flag}`)).join(', ');
+  // What the LEVEL means, in plain language. The flag list alone answers "which
+  // checks failed" but never "so what?" — "Suspicious domain" doesn't tell a
+  // reader whether to skip the posting or just look twice.
+  const levelDescription = t(`jobs.trust.levelDesc.${trust.level}`);
+  // Level meaning first, failed checks second: the reader needs the verdict
+  // before the evidence.
+  const detail = reasons
+    ? `${levelDescription} ${t('jobs.trust.whyPrefix')} ${reasons}`
+    : levelDescription;
 
   const badge = (
     <Tag
@@ -62,11 +71,15 @@ export function TrustBadge({
     </Tag>
   );
 
-  if (!interactive || !reasons) {
+  // Non-interactive surfaces get the same words via a native `title` (hover,
+  // no focusable element) plus the sr-only suffix. Gated on `interactive`
+  // ALONE now, not on `reasons` too: the level description always exists, so
+  // there is always something worth saying even when no flag list accompanies it.
+  if (!interactive) {
     return (
-      <span className="inline-flex items-center gap-1">
+      <span className="inline-flex items-center gap-1" title={detail}>
         {badge}
-        {reasons && <span className="sr-only">: {reasons}</span>}
+        <span className="sr-only">: {detail}</span>
       </span>
     );
   }
@@ -74,16 +87,16 @@ export function TrustBadge({
   return (
     <HoverPopover
       placement="top"
-      ariaLabel={reasons}
+      ariaLabel={detail}
       trigger={
         <Button variant="unstyled" className="inline-flex items-center rounded-full">
           {badge}
-          <span className="sr-only">: {reasons}</span>
+          <span className="sr-only">: {detail}</span>
         </Button>
       }
     >
-      <p className="dropdown-surface max-w-[220px] px-3 py-2 text-fine-print leading-snug text-foreground/70">
-        {reasons}
+      <p className="dropdown-surface max-w-[240px] px-3 py-2 text-fine-print leading-snug text-foreground/70">
+        {detail}
       </p>
     </HoverPopover>
   );

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2037,7 +2037,19 @@
     "matchBand": {
       "High": "Hoch",
       "Medium": "Mittel",
-      "Low": "Niedrig"
+      "Low": "Niedrig",
+      "desc": {
+        "combined": {
+          "High": "Starke Übereinstimmung. Ihr Lebenslauf deckt inhaltlich und bei den Schlüsselwörtern das meiste ab, was diese Anzeige verlangt.",
+          "Medium": "Teilweise Übereinstimmung. Ihr Lebenslauf deckt einiges ab — vor der Bewerbung anpassen.",
+          "Low": "Schwache Übereinstimmung. Ihr Lebenslauf deckt in dieser Fassung wenig von der Anzeige ab."
+        },
+        "coverage": {
+          "High": "Starke Schlüsselwort-Überschneidung mit dieser Anzeige. Nur aus Schlüsselwörtern berechnet — keine KI-Bewertung.",
+          "Medium": "Einige Schlüsselwort-Überschneidungen mit dieser Anzeige. Nur aus Schlüsselwörtern berechnet — keine KI-Bewertung.",
+          "Low": "Wenig Schlüsselwort-Überschneidung mit dieser Anzeige. Nur aus Schlüsselwörtern berechnet — keine KI-Bewertung."
+        }
+      }
     },
     "trust": {
       "level": {
@@ -2049,7 +2061,12 @@
         "invalidUrl": "Bewerbungslink fehlerhaft",
         "suspiciousDomain": "Verdächtige Domain",
         "companyDomainMismatch": "Domain stimmt nicht mit Unternehmen überein"
-      }
+      },
+      "levelDesc": {
+        "medium": "Einige Angaben dieser Anzeige konnten nicht überprüft werden. Sie kann trotzdem echt sein — vor der Bewerbung genauer ansehen.",
+        "low": "Mehrere Angaben dieser Anzeige konnten nicht überprüft werden. Mit Vorsicht behandeln."
+      },
+      "whyPrefix": "Nicht bestanden:"
     }
   },
   "resumes": {

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2033,7 +2033,19 @@
     "matchBand": {
       "High": "High",
       "Medium": "Medium",
-      "Low": "Low"
+      "Low": "Low",
+      "desc": {
+        "combined": {
+          "High": "Strong match. Your résumé covers most of what this posting asks for, by meaning and by keywords.",
+          "Medium": "Partial match. Your résumé covers some of what this posting asks for — worth tailoring before you apply.",
+          "Low": "Weak match. Your résumé covers little of what this posting asks for as written."
+        },
+        "coverage": {
+          "High": "Strong keyword overlap with this posting. Counted from keywords alone — no AI scoring ran.",
+          "Medium": "Some keyword overlap with this posting. Counted from keywords alone — no AI scoring ran.",
+          "Low": "Little keyword overlap with this posting. Counted from keywords alone — no AI scoring ran."
+        }
+      }
     },
     "trust": {
       "level": {
@@ -2045,7 +2057,12 @@
         "invalidUrl": "Broken apply link",
         "suspiciousDomain": "Suspicious domain",
         "companyDomainMismatch": "Domain doesn't match company"
-      }
+      },
+      "levelDesc": {
+        "medium": "Some details of this posting could not be verified. It may still be genuine — worth a second look before applying.",
+        "low": "Several details of this posting could not be verified. Treat it with caution."
+      },
+      "whyPrefix": "What failed:"
     }
   },
   "resumes": {


### PR DESCRIPTION
Both job badges showed a verdict with no way to learn what it meant.

- **`MatchBand`** rendered the bare word `High` with **no description at all** on the Autopilot card. The jobs list did have a popover, but its copy is a disclaimer (*"not the employer's decision"*) that never said what the tier itself means.
- **`TrustBadge`** listed *which checks failed* (`"Suspicious domain"`) but never the verdict — which is the part that tells a reader whether to skip a posting or just look twice.

Now: `MatchBand` carries a plain-language description, and `TrustBadge` leads its tooltip with the level's meaning before the failed-check list.

## Why `title` and not a popover

`TrustBadge` uses a `HoverPopover`, so that was the obvious thing to reach for. It doesn't work for `MatchBand`:

- The Autopilot card renders the band **inside a `<Button>`** — a focusable trigger there is invalid button-in-button HTML.
- `PostingListItem` rows are an **aria-activedescendant listbox** — a trigger would add a tab stop per row.

Both constraints are already documented in comments at those call sites (`TrustBadge` passes `interactive={false}` for the same reasons). A native `title` is hover-capable and focusable-free, so it is safe in both, and it pairs with an sr-only suffix for screen readers.

`RowMatchScore` already owns a real popover, so it opts out with `describe={false}` and folds the tier sentence into its own copy — otherwise a browser tooltip would fire alongside it saying a shorter version of the same thing.

## Per-variant, not just per-tier

A `coverage` High is keyword overlap with **no AI scoring behind it**; a `combined` High blends meaning and keywords. One shared sentence would have to be vague enough to be true of both, which is how a tooltip stops being worth reading. A test asserts the two variants don't say the same thing.

## One latent bug

`TrustBadge`'s detail block was gated on the flag list being non-empty, so a flagged-but-reasonless assessment rendered a bare badge with nothing to explain it. Now gated on `interactive` alone — the level description always exists.

## Testing note

`match-band.test.tsx` stubs `t` to echo raw keys, so it **structurally cannot** catch a missing translation, and the key is built at runtime from tier + variant (`jobs.matchBand.desc.<variant>.<tier>`) so TypeScript can't either. Added `match-band.i18n.test.tsx` using real translations — the same rationale `trust-badge.test.tsx` already documents in its header — and extended the trust-badge suite.

I deleted two keys to check these guards aren't theater: **4 tests went red.** Restored after.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @ajh/desktop test` | 259 files / 2960 pass (14 new) |
| `pnpm typecheck` · `pnpm lint:strict` | clean |
| Pre-push gate | pass |

**Not verified:** not looked at running. The `title` tooltip is the browser's own, so it has a ~1s delay and no styling — on the Autopilot card that's the only option without restructuring the row out of its `<Button>`. If the delay feels wrong there, that restructure is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added clearer translated descriptions for job match scores and trust levels.
  * Improved screen-reader labels, hover descriptions, and popover content.
* **User Experience**
  * Match and trust details now distinguish score tiers and verification results more clearly.
  * Expanded detail popovers for improved readability.
* **Localization**
  * Added English and German translations for score and trust descriptions.
* **Bug Fixes**
  * Prevented raw or missing translation keys from appearing in descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->