### PR TITLE
fix: generation-burst reliability and the silent defects from the 2026-08-08 diagnostics bundle

### DIFF
--- a/apps/desktop/src-tauri/src/agent/tools.rs
+++ b/apps/desktop/src-tauri/src/agent/tools.rs
@@ -290,7 +290,7 @@ fn research_company_handler(
         // base_url are no longer threaded through this shared command.
         // `effort: None` — the agent loop has no per-request effort of its own, so
         // research runs on the unscaled baseline deadline.
-        Ok(crate::commands::ai::ai_research_company(app, job_ad, None, None).await)
+        Ok(crate::commands::ai::ai_research_company(app, job_ad, None, None, None).await)
     })
 }
 

--- a/apps/desktop/src-tauri/src/agent/tools.rs
+++ b/apps/desktop/src-tauri/src/agent/tools.rs
@@ -288,7 +288,9 @@ fn research_company_handler(
         // Routing is backend-owned now (task #16): `ai_research_company` resolves
         // the active provider from the store, so the agent's `ctx` provider/model/
         // base_url are no longer threaded through this shared command.
-        Ok(crate::commands::ai::ai_research_company(app, job_ad, None).await)
+        // `effort: None` — the agent loop has no per-request effort of its own, so
+        // research runs on the unscaled baseline deadline.
+        Ok(crate::commands::ai::ai_research_company(app, job_ad, None, None).await)
     })
 }
 

--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -201,6 +201,59 @@ pub async fn ai_inspect_model(model: String) -> Value {
     ollama::show_model(&model).await
 }
 
+/// Admit one `"ai_research"` call: rate + concurrency cap, resolve the active
+/// provider, then charge the per-provider daily ceiling — in that order, so a
+/// rejected call costs no budget.
+///
+/// Extracted because `ai_research_company`, `ai_lookup_salary` and
+/// `ai_research_answer` each open with the identical ~30-line preamble and each
+/// degrades to its OWN "nothing found" value rather than an error. The guard
+/// rides in the returned tuple so the caller holds the slot for the real work.
+/// `who` only labels the debug log.
+fn admit_research(
+    app: &AppHandle,
+    who: &str,
+) -> Option<(crate::limits::ConcurrencyGuard, crate::pipeline::Completer)> {
+    let limiter = app
+        .state::<std::sync::Arc<crate::limits::Limiter>>()
+        .inner()
+        .clone();
+    // This is a billable provider web search (Ollama fires two calls: search +
+    // synthesis) with no other ceiling, so a looping/compromised renderer
+    // varying its inputs must not drive unbounded paid-API spend. One shared
+    // bucket across all three research commands, deliberately.
+    let guard = match limiter.acquire(
+        "ai_research",
+        crate::limits::AI_RESEARCH_RATE_MAX,
+        crate::limits::AI_RESEARCH_CONCURRENCY_MAX,
+    ) {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::debug!("{who}: rate limited: {e}");
+            return None;
+        }
+    };
+    // Backend-owned routing (task #16): the active provider comes from the store.
+    let completer = match crate::pipeline::Completer::from_active(app) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!("{who}: provider resolution failed: {e}");
+            return None;
+        }
+    };
+    // Per-provider daily ceiling — the same coarse runaway-cost backstop
+    // `ai_generate` charges; the `(day, provider)` bucket is shared across every
+    // AI command against that provider.
+    if let Err(e) = limiter.charge_provider_daily(
+        completer.provider_id().as_str(),
+        crate::limits::PROVIDER_DAILY_MAX,
+    ) {
+        tracing::debug!("{who}: daily budget exceeded: {e}");
+        return None;
+    }
+    Some((guard, completer))
+}
+
 /// Research the company named in a job ad and return a short factual brief for
 /// the cover-letter "fit" paragraph. Reuses the shared [`CompanyResearch`]
 /// enricher — the **active provider's own** web search + synthesis, cached for a
@@ -212,54 +265,25 @@ pub async fn ai_inspect_model(model: String) -> Value {
 /// Returns `{ company, brief }`. The brief is reference context only; the prompt
 /// layer treats it as untrusted and never as a source of candidate facts.
 #[tauri::command]
-pub async fn ai_research_company(app: AppHandle, job_ad: String, company: Option<String>) -> Value {
+pub async fn ai_research_company(
+    app: AppHandle,
+    job_ad: String,
+    company: Option<String>,
+    // Sizes the research deadline (`timeouts::research_deadline`): flat 25s meant
+    // a reasoning model's research never finished — six for six in one session.
+    effort: Option<String>,
+) -> Value {
     use crate::cover_letter::research::CompanyResearch;
-    use crate::pipeline::Completer;
 
-    // Anti-abuse: rate + concurrency cap, sharing the same "ai_research" bucket
-    // as `ai_lookup_salary` — this is a billable provider web search with no
-    // other ceiling, so a looping/compromised renderer varying job_ad/company
-    // must not drive unbounded paid-API spend.
-    let limiter = app
-        .state::<std::sync::Arc<crate::limits::Limiter>>()
-        .inner()
-        .clone();
-    let _guard = match limiter.acquire(
-        "ai_research",
-        crate::limits::AI_RESEARCH_RATE_MAX,
-        crate::limits::AI_RESEARCH_CONCURRENCY_MAX,
-    ) {
-        Ok(g) => g,
-        Err(e) => {
-            tracing::debug!("research_company: rate limited: {e}");
-            return json!({ "company": "", "brief": "" });
-        }
-    };
-
-    // Routing is backend-owned (task #16): resolve the active provider from the
-    // store, never from renderer-supplied provider/base_url (SSRF close).
-    let completer = match Completer::from_active(&app) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::debug!("research_company: provider resolution failed: {e}");
-            return json!({ "company": "", "brief": "" });
-        }
-    };
-
-    // Per-provider daily request ceiling — the same coarse runaway-cost
-    // backstop `ai_generate`/`ai_lookup_salary` charge.
-    if let Err(e) = limiter.charge_provider_daily(
-        completer.provider_id().as_str(),
-        crate::limits::PROVIDER_DAILY_MAX,
-    ) {
-        tracing::debug!("research_company: daily budget exceeded: {e}");
+    let Some((_guard, completer)) = admit_research(&app, "research_company") else {
         return json!({ "company": "", "brief": "" });
-    }
+    };
 
     // Prefer the accurate AI-extracted company name from the generation flow; the
     // enricher falls back to heuristic job-ad extraction only when it's absent.
+    let deadline = super::ai_provider::timeouts::research_deadline(effort.as_deref());
     let result = CompanyResearch
-        .enrich_with(&completer, &job_ad, company.as_deref())
+        .enrich_with(&completer, &job_ad, company.as_deref(), deadline)
         .await;
     json!({ "company": result.key, "brief": result.content })
 }
@@ -462,52 +486,13 @@ pub async fn ai_lookup_salary(
     // preserves the unconstrained "local currency for that location"
     // behavior.
     currency: Option<String>,
+    // Sizes the research deadline (`timeouts::research_deadline`).
+    effort: Option<String>,
 ) -> Option<crate::salary_research::SalaryRange> {
     use crate::pipeline::cache::KvCache;
-    use crate::pipeline::Completer;
     use crate::salary_research::SalaryResearch;
 
-    // Anti-abuse: rate + concurrency cap, mirroring `ai_generate`'s guard
-    // exactly. This is a billable provider web search (Ollama fires two calls:
-    // search + synthesis) with no other ceiling, so a looping/compromised
-    // renderer varying inputs must not drive unbounded paid-API spend. The
-    // `"ai_research"` bucket is shared with `ai_research_company`, which uses
-    // the same guard.
-    let limiter = app
-        .state::<std::sync::Arc<crate::limits::Limiter>>()
-        .inner()
-        .clone();
-    let _guard = match limiter.acquire(
-        "ai_research",
-        crate::limits::AI_RESEARCH_RATE_MAX,
-        crate::limits::AI_RESEARCH_CONCURRENCY_MAX,
-    ) {
-        Ok(g) => g,
-        Err(e) => {
-            tracing::debug!("lookup_salary: rate limited: {e}");
-            return None;
-        }
-    };
-
-    // Backend-owned routing (task #16): the active provider comes from the store.
-    let completer = match Completer::from_active(&app) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::debug!("lookup_salary: provider resolution failed: {e}");
-            return None;
-        }
-    };
-
-    // Per-provider daily request ceiling — the same coarse runaway-cost
-    // backstop `ai_generate` charges; the `(day, provider)` bucket is already
-    // shared across every AI command against that provider.
-    if let Err(e) = limiter.charge_provider_daily(
-        completer.provider_id().as_str(),
-        crate::limits::PROVIDER_DAILY_MAX,
-    ) {
-        tracing::debug!("lookup_salary: daily budget exceeded: {e}");
-        return None;
-    }
+    let (_guard, completer) = admit_research(&app, "lookup_salary")?;
 
     // Resolved once here (the sole production caller) and passed through, so
     // `SalaryResearch::enrich` stays `AppHandle`-free and unit-testable.
@@ -521,6 +506,7 @@ pub async fn ai_lookup_salary(
             location.as_deref().unwrap_or(""),
             country.as_deref().unwrap_or(""),
             currency.as_deref().unwrap_or(""),
+            super::ai_provider::timeouts::research_deadline(effort.as_deref()),
         )
         .await
 }

--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -269,6 +269,9 @@ pub async fn ai_research_company(
     app: AppHandle,
     job_ad: String,
     company: Option<String>,
+    // AI-extracted job title. Like `company`, it beats the heuristic, whose last
+    // resort is the ad's first short line — an apply button on a scraped page.
+    role: Option<String>,
     // Sizes the research deadline (`timeouts::research_deadline`): flat 25s meant
     // a reasoning model's research never finished — six for six in one session.
     effort: Option<String>,
@@ -283,7 +286,13 @@ pub async fn ai_research_company(
     // enricher falls back to heuristic job-ad extraction only when it's absent.
     let deadline = super::ai_provider::timeouts::research_deadline(effort.as_deref());
     let result = CompanyResearch
-        .enrich_with(&completer, &job_ad, company.as_deref(), deadline)
+        .enrich_with(
+            &completer,
+            &job_ad,
+            company.as_deref(),
+            role.as_deref(),
+            deadline,
+        )
         .await;
     json!({ "company": result.key, "brief": result.content })
 }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/anthropic.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/anthropic.rs
@@ -1048,14 +1048,18 @@ impl AiProvider for AnthropicClient {
             .resolve(req);
         let body = build_chat_stream_body(req, sampling);
 
-        let response = crate::net::http::shared()
-            .post(&endpoint)
-            .timeout(timeouts::stream_deadline(req.effort.as_deref()))
-            .header("x-api-key", &api_key)
-            .header("anthropic-version", VERSION)
-            .json(&body)
-            .send()
-            .await;
+        // Retried on a transient 429/5xx: this is only the handshake, so a retry
+        // re-sends a request that emitted no deltas. Treating it as terminal is
+        // what turned a provider rate-limit into a lost multi-minute generation.
+        let response = super::retry::send_stream_with_retry(|| {
+            crate::net::http::shared()
+                .post(&endpoint)
+                .timeout(timeouts::stream_deadline(req.effort.as_deref()))
+                .header("x-api-key", &api_key)
+                .header("anthropic-version", VERSION)
+                .json(&body)
+        })
+        .await;
 
         let response = match response {
             Ok(r) => r,

--- a/apps/desktop/src-tauri/src/commands/ai_provider/anthropic.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/anthropic.rs
@@ -1051,14 +1051,17 @@ impl AiProvider for AnthropicClient {
         // Retried on a transient 429/5xx: this is only the handshake, so a retry
         // re-sends a request that emitted no deltas. Treating it as terminal is
         // what turned a provider rate-limit into a lost multi-minute generation.
-        let response = super::retry::send_stream_with_retry(|| {
-            crate::net::http::shared()
-                .post(&endpoint)
-                .timeout(timeouts::stream_deadline(req.effort.as_deref()))
-                .header("x-api-key", &api_key)
-                .header("anthropic-version", VERSION)
-                .json(&body)
-        })
+        let response = super::retry::send_stream_with_retry(
+            || {
+                crate::net::http::shared()
+                    .post(&endpoint)
+                    .timeout(timeouts::stream_deadline(req.effort.as_deref()))
+                    .header("x-api-key", &api_key)
+                    .header("anthropic-version", VERSION)
+                    .json(&body)
+            },
+            timeouts::stream_deadline(req.effort.as_deref()),
+        )
         .await;
 
         let response = match response {

--- a/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
@@ -1067,13 +1067,17 @@ impl AiProvider for GeminiClient {
         let body = build_chat_stream_body(req, sampling);
 
         let url = format!("{BASE}{endpoint_label}");
-        let response = crate::net::http::shared()
-            .post(&url)
-            .timeout(timeouts::stream_deadline(req.effort.as_deref()))
-            .header("x-goog-api-key", &api_key)
-            .json(&body)
-            .send()
-            .await;
+        // Retried on a transient 429/5xx: this is only the handshake, so a retry
+        // re-sends a request that emitted no deltas. Treating it as terminal is
+        // what turned a provider rate-limit into a lost multi-minute generation.
+        let response = super::retry::send_stream_with_retry(|| {
+            crate::net::http::shared()
+                .post(&url)
+                .timeout(timeouts::stream_deadline(req.effort.as_deref()))
+                .header("x-goog-api-key", &api_key)
+                .json(&body)
+        })
+        .await;
 
         let response = match response {
             Ok(r) => r,

--- a/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/gemini.rs
@@ -1070,13 +1070,16 @@ impl AiProvider for GeminiClient {
         // Retried on a transient 429/5xx: this is only the handshake, so a retry
         // re-sends a request that emitted no deltas. Treating it as terminal is
         // what turned a provider rate-limit into a lost multi-minute generation.
-        let response = super::retry::send_stream_with_retry(|| {
-            crate::net::http::shared()
-                .post(&url)
-                .timeout(timeouts::stream_deadline(req.effort.as_deref()))
-                .header("x-goog-api-key", &api_key)
-                .json(&body)
-        })
+        let response = super::retry::send_stream_with_retry(
+            || {
+                crate::net::http::shared()
+                    .post(&url)
+                    .timeout(timeouts::stream_deadline(req.effort.as_deref()))
+                    .header("x-goog-api-key", &api_key)
+                    .json(&body)
+            },
+            timeouts::stream_deadline(req.effort.as_deref()),
+        )
         .await;
 
         let response = match response {

--- a/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
@@ -28,7 +28,7 @@ mod openai;
 mod research; // shared company-research prompt spec + helpers used by every `research()`
 mod retry; // bounded exponential backoff for the non-streaming complete/embed paths
 mod stream; // shared streaming loop (cancel-check + chunk read + emit + complete) for cloud adapters
-mod timeouts; // semantically-named per-request HTTP timeouts (pure extraction of the magic-number literals)
+pub(crate) mod timeouts; // semantically-named per-request HTTP timeouts (pure extraction of the magic-number literals)
 
 use anthropic::AnthropicClient;
 use cli_agent::CliAgentClient;

--- a/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
@@ -1264,42 +1264,10 @@ pub use crate::vector::cosine;
 
 // ── Request tracing ─────────────────────────────────────────────────────────────
 
-/// Structured per-request log over the shared [`crate::observability::Span`].
-/// Emits a `→` line at dispatch and a `←` line with status + duration at
-/// completion, e.g.:
-/// `[ai] ← provider=openai model=gpt-4o endpoint=/chat/completions … status=200 duration=1842ms ok=true`
-pub struct RequestTrace {
-    span: crate::observability::Span,
-}
-
-impl RequestTrace {
-    pub fn begin(
-        provider: ProviderId,
-        model: &str,
-        endpoint: &str,
-        base_url: &str,
-        streaming: bool,
-    ) -> Self {
-        let fields = format!(
-            "provider={} model={} endpoint={} baseUrl={} streaming={}",
-            provider.as_str(),
-            model,
-            endpoint,
-            base_url,
-            streaming
-        );
-        Self {
-            span: crate::observability::Span::begin("ai", fields),
-        }
-    }
-
-    pub fn end(&self, status: Option<u16>, ok: bool) {
-        let status = status
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "-".to_string());
-        self.span.end_with(&format!("status={status}"), ok);
-    }
-}
+mod trace;
+/// Per-request `[ai] → / ←` tracing. Lives in its own module (this one is at its
+/// LOC cap) but keeps its path here, so no call site moves.
+pub use trace::RequestTrace;
 
 // ── Error mapping ───────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
@@ -1086,12 +1086,16 @@ async fn stream_chat(
 
     let body = build_chat_stream_body(req, sampling);
 
-    let response = crate::net::http::shared()
-        .post(&endpoint)
-        .timeout(timeouts::stream_deadline(req.effort.as_deref()))
-        .json(&body)
-        .send()
-        .await;
+    // Retried on a transient 429/5xx: this is only the handshake, so a retry
+    // re-sends a request that emitted no deltas. Treating it as terminal is what
+    // turned a provider rate-limit into a lost multi-minute generation.
+    let response = super::retry::send_stream_with_retry(|| {
+        crate::net::http::shared()
+            .post(&endpoint)
+            .timeout(timeouts::stream_deadline(req.effort.as_deref()))
+            .json(&body)
+    })
+    .await;
 
     let response = match response {
         Ok(r) => r,

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
@@ -512,7 +512,47 @@ pub async fn list_tag_models() -> Vec<Value> {
     fetch_tag_models().await.unwrap_or_default()
 }
 
-/// `(reachable, first_model_name)` for the system health probe.
+/// Whether a local model name is an EMBEDDING-only model, i.e. one that
+/// `/api/chat` rejects with a 400.
+///
+/// Ollama's `/api/tags` does not mark this: `details.family` is `bert` for some
+/// (`nomic-embed-text`, `mxbai-embed-large`) but the base family for others
+/// (`qwen3-embedding` reports `qwen3`), so the name is the only signal actually
+/// present in the listing. Every embedding model Ollama publishes carries
+/// `embed`/`embedding` in its name, which is what this matches.
+///
+/// ponytail: name heuristic, not a capability probe. The ceiling is a future
+/// embedding model named without `embed` — it would be picked for chat and get
+/// one 400, exactly as today, but now WARN-logged instead of silent. Upgrade
+/// path if that happens: probe `/api/show` per model and read `capabilities`.
+/// Pure + unit-tested.
+pub(super) fn is_embedding_only_model(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    n.contains("embed")
+}
+
+/// The first model in an `/api/tags` body that can actually hold a chat turn.
+/// `None` when the user has ONLY embedding models installed — which is the
+/// honest answer: the caller then skips translation rather than burning a
+/// guaranteed 400 on every job ad. Pure + unit-tested.
+pub(super) fn first_chat_model(body: &Value) -> Option<String> {
+    body.get("models")
+        .and_then(|m| m.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|m| m.get("name").and_then(|n| n.as_str()))
+        .find(|name| !is_embedding_only_model(name))
+        .map(String::from)
+}
+
+/// `(reachable, first_CHAT_model_name)` — the local health probe, and the source
+/// of the model the translation path uses.
+///
+/// The chat filter is not cosmetic: this returned `arr.first()` unconditionally,
+/// so a user whose first `/api/tags` entry was `qwen3-embedding:8b` had every
+/// job-ad translation POST that model to `/api/chat` and take a 400. Eight of
+/// them in one reported session, silently — `translate_text` falls back to the
+/// untranslated original on any error, so the only trace was an `ok=false` span.
 pub async fn reachable_model() -> (bool, Option<String>) {
     match crate::net::http::shared()
         .get(format!("{}/api/tags", host()))
@@ -525,14 +565,7 @@ pub async fn reachable_model() -> (bool, Option<String>) {
                 crate::net::http::read_json_capped(r, crate::net::http::DEFAULT_MAX_BODY_BYTES)
                     .await
                     .unwrap_or_default();
-            let model = body
-                .get("models")
-                .and_then(|m| m.as_array())
-                .and_then(|arr| arr.first())
-                .and_then(|m| m.get("name"))
-                .and_then(|n| n.as_str())
-                .map(String::from);
-            (true, model)
+            (true, first_chat_model(&body))
         }
         _ => (false, None),
     }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
@@ -1089,12 +1089,15 @@ async fn stream_chat(
     // Retried on a transient 429/5xx: this is only the handshake, so a retry
     // re-sends a request that emitted no deltas. Treating it as terminal is what
     // turned a provider rate-limit into a lost multi-minute generation.
-    let response = super::retry::send_stream_with_retry(|| {
-        crate::net::http::shared()
-            .post(&endpoint)
-            .timeout(timeouts::stream_deadline(req.effort.as_deref()))
-            .json(&body)
-    })
+    let response = super::retry::send_stream_with_retry(
+        || {
+            crate::net::http::shared()
+                .post(&endpoint)
+                .timeout(timeouts::stream_deadline(req.effort.as_deref()))
+                .json(&body)
+        },
+        timeouts::stream_deadline(req.effort.as_deref()),
+    )
     .await;
 
     let response = match response {

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama_tests.rs
@@ -573,3 +573,66 @@ fn parse_model_list_errors_when_models_field_is_missing() {
         Err(AppError::Provider(_))
     ));
 }
+
+
+// ── Local chat-model selection (the qwen3-embedding:8b → /api/chat 400) ────────
+//
+// `reachable_model` returned `/api/tags`'s FIRST entry unconditionally, and
+// `reachable_chat_model` forwarded it to `translate_text`, which POSTs it to
+// `/api/chat`. A user whose first entry was an embedding model therefore took a
+// guaranteed 400 per job ad — eight in one reported session, invisible, because
+// translation falls back to the untranslated original on any error.
+
+#[test]
+fn embedding_only_models_are_recognized_by_name() {
+    for name in [
+        "qwen3-embedding:8b",
+        "nomic-embed-text:latest",
+        "mxbai-embed-large",
+        "snowflake-arctic-embed2",
+        "EMBEDDINGGEMMA:300M", // case-insensitive
+    ] {
+        assert!(
+            super::is_embedding_only_model(name),
+            "{name} must be excluded from chat"
+        );
+    }
+}
+
+#[test]
+fn real_chat_models_are_not_mistaken_for_embedding_models() {
+    for name in [
+        "gemma4:31b",
+        "gpt-oss:20b",
+        "llama3.1:8b",
+        "qwen3:32b",
+        "deepseek-v4-flash:0731",
+        "mistral-small:24b",
+    ] {
+        assert!(
+            !super::is_embedding_only_model(name),
+            "{name} must stay eligible for chat"
+        );
+    }
+}
+
+#[test]
+fn first_chat_model_skips_a_leading_embedding_model() {
+    // Exactly the reported shape: the embedding model sorts first in /api/tags.
+    let body = serde_json::json!({
+        "models": [
+            { "name": "qwen3-embedding:8b" },
+            { "name": "gemma4:31b" },
+        ]
+    });
+    assert_eq!(super::first_chat_model(&body).as_deref(), Some("gemma4:31b"));
+}
+
+#[test]
+fn first_chat_model_is_none_when_only_embedding_models_are_installed() {
+    // Better than returning one anyway: the caller skips translation instead of
+    // sending a request the daemon is guaranteed to reject.
+    let body = serde_json::json!({ "models": [{ "name": "qwen3-embedding:8b" }] });
+    assert_eq!(super::first_chat_model(&body), None);
+    assert_eq!(super::first_chat_model(&serde_json::json!({})), None);
+}

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama_tests.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama_tests.rs
@@ -574,7 +574,6 @@ fn parse_model_list_errors_when_models_field_is_missing() {
     ));
 }
 
-
 // ── Local chat-model selection (the qwen3-embedding:8b → /api/chat 400) ────────
 //
 // `reachable_model` returned `/api/tags`'s FIRST entry unconditionally, and
@@ -625,7 +624,10 @@ fn first_chat_model_skips_a_leading_embedding_model() {
             { "name": "gemma4:31b" },
         ]
     });
-    assert_eq!(super::first_chat_model(&body).as_deref(), Some("gemma4:31b"));
+    assert_eq!(
+        super::first_chat_model(&body).as_deref(),
+        Some("gemma4:31b")
+    );
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/commands/ai_provider/openai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/openai.rs
@@ -1039,13 +1039,16 @@ impl AiProvider for OpenAiClient {
         // Retried on a transient 429/5xx: this is only the handshake, so a retry
         // re-sends a request that emitted no deltas. Treating it as terminal is
         // what turned a provider rate-limit into a lost multi-minute generation.
-        let response = super::retry::send_stream_with_retry(|| {
-            crate::net::http::shared()
-                .post(endpoint.clone())
-                .timeout(timeouts::stream_deadline(req.effort.as_deref()))
-                .bearer_auth(&api_key)
-                .json(&body)
-        })
+        let response = super::retry::send_stream_with_retry(
+            || {
+                crate::net::http::shared()
+                    .post(endpoint.clone())
+                    .timeout(timeouts::stream_deadline(req.effort.as_deref()))
+                    .bearer_auth(&api_key)
+                    .json(&body)
+            },
+            timeouts::stream_deadline(req.effort.as_deref()),
+        )
         .await;
 
         let response = match response {

--- a/apps/desktop/src-tauri/src/commands/ai_provider/openai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/openai.rs
@@ -1036,13 +1036,17 @@ impl AiProvider for OpenAiClient {
 
         let body = build_chat_stream_body(req, caps, sampling);
 
-        let response = crate::net::http::shared()
-            .post(endpoint)
-            .timeout(timeouts::stream_deadline(req.effort.as_deref()))
-            .bearer_auth(&api_key)
-            .json(&body)
-            .send()
-            .await;
+        // Retried on a transient 429/5xx: this is only the handshake, so a retry
+        // re-sends a request that emitted no deltas. Treating it as terminal is
+        // what turned a provider rate-limit into a lost multi-minute generation.
+        let response = super::retry::send_stream_with_retry(|| {
+            crate::net::http::shared()
+                .post(endpoint.clone())
+                .timeout(timeouts::stream_deadline(req.effort.as_deref()))
+                .bearer_auth(&api_key)
+                .json(&body)
+        })
+        .await;
 
         let response = match response {
             Ok(r) => r,

--- a/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
@@ -19,7 +19,7 @@
 //! re-sends the request each attempt (a `RequestBuilder` is consumed by `send`,
 //! so the caller supplies a builder factory).
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use reqwest::{RequestBuilder, Response, StatusCode};
 
@@ -101,27 +101,46 @@ pub async fn send_with_retry<F>(build: F) -> reqwest::Result<Response>
 where
     F: FnMut() -> RequestBuilder,
 {
-    send_with_retry_capped(build, MAX_DELAY_MS).await
+    // No total budget: these are one-shot calls whose own `.timeout()` already
+    // bounds each attempt to a fraction of a stream's.
+    send_with_retry_capped(build, MAX_DELAY_MS, None).await
 }
 
 /// [`send_with_retry`] for a STREAM's initial send.
 ///
-/// Identical loop — the only difference is the backoff ceiling
-/// ([`MAX_STREAM_DELAY_MS`]). Safe on the streaming path because this covers
-/// only the request/response handshake: the response STATUS is known before any
-/// delta has been read, so a retry here re-sends a request that emitted nothing.
-/// Nothing restarts a stream that has already produced output.
-pub async fn send_stream_with_retry<F>(build: F) -> reqwest::Result<Response>
+/// Safe on the streaming path because this covers only the request/response
+/// handshake: the response STATUS is known before any delta has been read, so a
+/// retry here re-sends a request that emitted nothing. Nothing restarts a stream
+/// that has already produced output.
+///
+/// `budget` is the request's own `stream_deadline`, and it bounds the WHOLE
+/// sequence, not each attempt. Each attempt rebuilds its `.timeout()` fresh, so
+/// without this three attempts could run to 3x that deadline — past the
+/// renderer's own timeout, which would surface a generic "Generation timed out"
+/// instead of the actionable provider error, inverting the relationship
+/// `computeStreamTimeoutMs`'s test deliberately pins. A retry is only started
+/// while budget remains for it.
+///
+/// The practical effect matches the reported failure: that 429 came back after
+/// the full deadline had already elapsed, so it retries zero times and behaves
+/// exactly as before. Retries only help when a provider rejects promptly, which
+/// is the normal shape of a rate limit.
+pub async fn send_stream_with_retry<F>(build: F, budget: Duration) -> reqwest::Result<Response>
 where
     F: FnMut() -> RequestBuilder,
 {
-    send_with_retry_capped(build, MAX_STREAM_DELAY_MS).await
+    send_with_retry_capped(build, MAX_STREAM_DELAY_MS, Some(budget)).await
 }
 
-async fn send_with_retry_capped<F>(mut build: F, max_delay_ms: u64) -> reqwest::Result<Response>
+async fn send_with_retry_capped<F>(
+    mut build: F,
+    max_delay_ms: u64,
+    budget: Option<Duration>,
+) -> reqwest::Result<Response>
 where
     F: FnMut() -> RequestBuilder,
 {
+    let started = Instant::now();
     let mut attempt = 1u32;
     loop {
         let outcome = build().send().await;
@@ -136,6 +155,20 @@ where
         }
 
         let delay = backoff_delay_capped(attempt, retry_after, max_delay_ms);
+
+        // Only start another attempt if the caller's total budget can still pay
+        // for the backoff AND leave time for the request itself.
+        if let Some(budget) = budget {
+            let elapsed = started.elapsed();
+            if elapsed + delay >= budget {
+                tracing::warn!(
+                    "ai retry: budget spent after attempt {attempt}/{MAX_ATTEMPTS} \
+                     ({elapsed:?} of {budget:?}), returning the last outcome"
+                );
+                return outcome;
+            }
+        }
+
         tracing::warn!(
             // WARN, not DEBUG: a retry means the provider pushed back, which is
             // the context you want when a generation later fails outright.
@@ -224,8 +257,17 @@ mod retry_loop_tests {
         );
     }
 
-    /// [`run_retry`] driven through the STREAMING entry point instead.
+    /// [`run_retry`] driven through the STREAMING entry point instead. `budget`
+    /// is the caller's `stream_deadline`; generous here so the attempt count is
+    /// what is under test, except in the budget test below.
     async fn run_stream_retry(status_codes: Vec<u16>) -> (u32, bool) {
+        run_stream_retry_with_budget(status_codes, std::time::Duration::from_secs(60)).await
+    }
+
+    async fn run_stream_retry_with_budget(
+        status_codes: Vec<u16>,
+        budget: std::time::Duration,
+    ) -> (u32, bool) {
         let server = MockServer::start().await;
         for code in &status_codes {
             Mock::given(method("GET"))
@@ -238,10 +280,13 @@ mod retry_loop_tests {
         let client = crate::net::http::shared();
         let call_count = Arc::new(AtomicU32::new(0));
         let counter = call_count.clone();
-        let result = send_stream_with_retry(|| {
-            counter.fetch_add(1, Ordering::SeqCst);
-            client.get(&url)
-        })
+        let result = send_stream_with_retry(
+            || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                client.get(&url)
+            },
+            budget,
+        )
         .await;
         (call_count.load(Ordering::SeqCst), result.is_ok())
     }
@@ -266,7 +311,32 @@ mod retry_loop_tests {
         // Bounded exactly like the one-shot path — a rate-limited account must
         // not turn into an unbounded retry storm.
         let (calls, _) = run_stream_retry(vec![429u16; MAX_ATTEMPTS as usize]).await;
-        assert_eq!(calls, MAX_ATTEMPTS, "stream retries must stop at the budget");
+        assert_eq!(
+            calls, MAX_ATTEMPTS,
+            "stream retries must stop at the budget"
+        );
+    }
+
+    /// The budget bounds the WHOLE retry sequence, not each attempt.
+    ///
+    /// Each attempt rebuilds its own `.timeout(stream_deadline(..))`, so without
+    /// this three attempts could run to 3x that deadline — past the renderer's
+    /// own timeout, which would replace the actionable provider error with a
+    /// generic "Generation timed out" and invert the relationship
+    /// `computeStreamTimeoutMs`'s test pins.
+    ///
+    /// A zero budget is the reported case in the extreme: that 429 came back
+    /// only after the full deadline had elapsed, so there was never budget for a
+    /// retry and behaviour is unchanged. Retries only help a provider that
+    /// rejects promptly, which is the normal shape of a rate limit.
+    #[tokio::test]
+    async fn stream_handshake_does_not_retry_once_the_budget_is_spent() {
+        let (calls, _) =
+            run_stream_retry_with_budget(vec![429, 200], std::time::Duration::ZERO).await;
+        assert_eq!(
+            calls, 1,
+            "no budget left means no retry, even though the 429 is transient"
+        );
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
@@ -4,10 +4,15 @@
 //! Cloud providers occasionally return transient 429 (rate limit) or 5xx
 //! (service) errors that succeed on a quick retry. This module retries those —
 //! and transport-level send failures — a small, bounded number of times with
-//! exponential backoff, honoring a `Retry-After` header when present. Streaming
-//! is intentionally **not** retried (a mid-stream restart would duplicate already
-//! emitted deltas), so this is only wired into the one-shot `complete`/`embed`
-//! calls.
+//! exponential backoff, honoring a `Retry-After` header when present.
+//!
+//! A stream is never restarted MID-stream (that would duplicate already-emitted
+//! deltas), but the initial `send()` on a streaming request is retried like any
+//! other: the response STATUS arrives before a single delta has been read, so a
+//! 429/5xx there is exactly the transient one-shot failure this module exists
+//! for. Treating it as terminal is what turned a provider rate-limit into a lost
+//! nine-minute generation in a reported session. See [`send_stream_with_retry`],
+//! which is the same loop with a deadline the caller can afford to spend.
 //!
 //! The retry *decision* ([`should_retry`], [`backoff_delay`]) is pure and
 //! unit-tested; [`send_with_retry`] is the thin async wrapper that rebuilds and
@@ -26,6 +31,13 @@ const BASE_DELAY_MS: u64 = 500;
 /// a one-shot completion shouldn't stall the UI for minutes.
 const MAX_DELAY_MS: u64 = 8_000;
 
+/// The same ceiling for a STREAM's initial send. Higher than [`MAX_DELAY_MS`]
+/// because the trade is different: the alternative to waiting is discarding a
+/// generation the user has already been waiting minutes for, and the renderer
+/// shows the job as running throughout. Still bounded, and still capped by the
+/// request's own `stream_deadline`.
+const MAX_STREAM_DELAY_MS: u64 = 30_000;
+
 /// Whether a response status is worth retrying. 429 (rate limit / quota) and 5xx
 /// (service errors) are transient; everything else (success, 4xx client errors)
 /// is terminal and returned to the caller as-is.
@@ -42,11 +54,22 @@ pub fn should_retry(attempt: u32, transient: bool) -> bool {
     transient && attempt < MAX_ATTEMPTS
 }
 
+/// Backoff delay at the default (one-shot) ceiling. Test-only entry point for
+/// the pure schedule — production always goes through [`backoff_delay_capped`],
+/// since the streaming path needs a different ceiling.
+///
 /// Backoff delay before the *next* attempt. Prefers the server's `Retry-After`
 /// (seconds) when present and sane, otherwise an exponential schedule. Always
 /// clamped to `[0, MAX_DELAY_MS]`. `attempt` is the 1-based number of the attempt
 /// that just failed.
+#[cfg(test)]
 pub fn backoff_delay(attempt: u32, retry_after_secs: Option<u64>) -> Duration {
+    backoff_delay_capped(attempt, retry_after_secs, MAX_DELAY_MS)
+}
+
+/// [`backoff_delay`] with an explicit ceiling, so the streaming path can afford
+/// a longer wait than a one-shot completion. Pure + unit-tested.
+pub fn backoff_delay_capped(attempt: u32, retry_after_secs: Option<u64>, max_ms: u64) -> Duration {
     let ms = match retry_after_secs {
         Some(secs) => secs.saturating_mul(1000),
         None => {
@@ -55,7 +78,7 @@ pub fn backoff_delay(attempt: u32, retry_after_secs: Option<u64>) -> Duration {
             BASE_DELAY_MS.saturating_mul(factor)
         }
     };
-    Duration::from_millis(ms.min(MAX_DELAY_MS))
+    Duration::from_millis(ms.min(max_ms))
 }
 
 /// Parse a `Retry-After` header value (RFC 7231) as whole seconds. Only the
@@ -74,7 +97,28 @@ fn parse_retry_after(resp: &Response) -> Option<u64> {
 /// (since `send` consumes it). Returns the first success, the first terminal
 /// (non-retryable) response, or — when every attempt was transient — the last
 /// outcome (response or transport error). Never retries beyond [`MAX_ATTEMPTS`].
-pub async fn send_with_retry<F>(mut build: F) -> reqwest::Result<Response>
+pub async fn send_with_retry<F>(build: F) -> reqwest::Result<Response>
+where
+    F: FnMut() -> RequestBuilder,
+{
+    send_with_retry_capped(build, MAX_DELAY_MS).await
+}
+
+/// [`send_with_retry`] for a STREAM's initial send.
+///
+/// Identical loop — the only difference is the backoff ceiling
+/// ([`MAX_STREAM_DELAY_MS`]). Safe on the streaming path because this covers
+/// only the request/response handshake: the response STATUS is known before any
+/// delta has been read, so a retry here re-sends a request that emitted nothing.
+/// Nothing restarts a stream that has already produced output.
+pub async fn send_stream_with_retry<F>(build: F) -> reqwest::Result<Response>
+where
+    F: FnMut() -> RequestBuilder,
+{
+    send_with_retry_capped(build, MAX_STREAM_DELAY_MS).await
+}
+
+async fn send_with_retry_capped<F>(mut build: F, max_delay_ms: u64) -> reqwest::Result<Response>
 where
     F: FnMut() -> RequestBuilder,
 {
@@ -91,8 +135,10 @@ where
             return outcome;
         }
 
-        let delay = backoff_delay(attempt, retry_after);
-        tracing::debug!(
+        let delay = backoff_delay_capped(attempt, retry_after, max_delay_ms);
+        tracing::warn!(
+            // WARN, not DEBUG: a retry means the provider pushed back, which is
+            // the context you want when a generation later fails outright.
             "ai retry: attempt {attempt}/{MAX_ATTEMPTS} transient, backing off {:?}",
             delay
         );
@@ -124,7 +170,7 @@ mod retry_loop_tests {
     use wiremock::matchers::method;
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use super::{send_with_retry, MAX_ATTEMPTS};
+    use super::{send_stream_with_retry, send_with_retry, MAX_ATTEMPTS};
 
     /// Spin up a wiremock server that serves the given status codes in FIFO order
     /// and drive `send_with_retry` once.  Returns (call_count, is_ok).
@@ -176,6 +222,58 @@ mod retry_loop_tests {
             calls, MAX_ATTEMPTS,
             "loop must stop after exactly MAX_ATTEMPTS ({MAX_ATTEMPTS}) calls; got {calls}"
         );
+    }
+
+    /// [`run_retry`] driven through the STREAMING entry point instead.
+    async fn run_stream_retry(status_codes: Vec<u16>) -> (u32, bool) {
+        let server = MockServer::start().await;
+        for code in &status_codes {
+            Mock::given(method("GET"))
+                .respond_with(ResponseTemplate::new(*code))
+                .up_to_n_times(1)
+                .mount(&server)
+                .await;
+        }
+        let url = server.uri();
+        let client = crate::net::http::shared();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let counter = call_count.clone();
+        let result = send_stream_with_retry(|| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            client.get(&url)
+        })
+        .await;
+        (call_count.load(Ordering::SeqCst), result.is_ok())
+    }
+
+    // A stream's INITIAL send is retried like any other request. This used to be
+    // terminal on the reasoning that "a mid-stream restart would duplicate
+    // deltas" — but the response status is known before a single delta has been
+    // read, so there is nothing to duplicate. Treating it as terminal is what
+    // turned one provider 429 into a discarded nine-minute generation.
+    #[tokio::test]
+    async fn stream_handshake_recovers_from_a_transient_429() {
+        let (calls, is_ok) = run_stream_retry(vec![429, 200]).await;
+        assert_eq!(
+            calls, 2,
+            "a 429 on the stream handshake must be retried; got {calls} calls"
+        );
+        assert!(is_ok, "the eventual 200 must be returned as Ok");
+    }
+
+    #[tokio::test]
+    async fn stream_handshake_stays_bounded_on_a_persistent_429() {
+        // Bounded exactly like the one-shot path — a rate-limited account must
+        // not turn into an unbounded retry storm.
+        let (calls, _) = run_stream_retry(vec![429u16; MAX_ATTEMPTS as usize]).await;
+        assert_eq!(calls, MAX_ATTEMPTS, "stream retries must stop at the budget");
+    }
+
+    #[tokio::test]
+    async fn stream_handshake_does_not_retry_a_terminal_4xx() {
+        // e.g. a bad model name: retrying cannot help and would triple the wait.
+        let (calls, _) = run_stream_retry(vec![400]).await;
+        assert_eq!(calls, 1, "a terminal 400 must not be retried");
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/commands/ai_provider/stream.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/stream.rs
@@ -687,7 +687,8 @@ where
     F: FnMut(&mut String) -> Vec<StreamPiece> + Send,
 {
     log::info!(
-        "[ai] stream start provider={} model={}",
+        "[ai] stream start job={} provider={} model={}",
+        job_id,
         provider.as_str(),
         model
     );

--- a/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
@@ -114,6 +114,29 @@ pub const WEB_SEARCH: Duration = Duration::from_secs(25);
 /// call that backs the Ollama-family research path.
 pub const OLLAMA_WEB_SEARCH: Duration = Duration::from_secs(15);
 
+/// BASELINE for the OUTER bound on a whole research pass — search **plus** the
+/// model's synthesis of the results — held by `CompanyResearch::enrich_with` and
+/// `SalaryResearch`. Every call site uses [`research_deadline`], never this
+/// constant directly, for the same reason [`STREAM`] has [`stream_deadline`]:
+/// synthesis is a model call, so its cost scales with reasoning effort.
+///
+/// This wraps [`WEB_SEARCH`]/[`OLLAMA_WEB_SEARCH`] *and* a completion, so it must
+/// exceed their sum or it becomes the binding constraint and the inner bounds
+/// (which produce actionable errors) never get to fire. The previous flat 25s
+/// was barely above the 25s [`WEB_SEARCH`] bound alone: a 2026-08-08 support
+/// bundle shows a reasoning model taking 9.2s for synthesis at idle, and all six
+/// research calls in a concurrent batch timing out — every one of those cover
+/// letters shipped with no company knowledge at all.
+pub const RESEARCH_BASELINE: Duration = Duration::from_secs(90);
+
+/// The actual deadline for one research pass: [`RESEARCH_BASELINE`] scaled by
+/// [`effort_multiplier`], exactly as [`stream_deadline`] scales [`STREAM`].
+/// Shares the one generated multiplier table, so a new effort tier is picked up
+/// here for free.
+pub fn research_deadline(effort: Option<&str>) -> Duration {
+    Duration::from_secs_f64(RESEARCH_BASELINE.as_secs_f64() * effort_multiplier(effort))
+}
+
 // ── Model discovery & health ────────────────────────────────────────────────────
 
 /// Listing models / validating a key (`list_models`, `test_key`): a quick GET to
@@ -196,5 +219,55 @@ mod tests {
     #[test]
     fn stream_deadline_falls_back_to_baseline_for_an_unrecognized_effort_string() {
         assert_eq!(stream_deadline(Some("ultra-mega-think")), STREAM);
+    }
+
+    // ── research_deadline ───────────────────────────────────────────────────
+    //
+    // Same contract as `stream_deadline`, and for the same reason: the thing it
+    // bounds ends in a model call. A flat 25s here meant every research call in
+    // a reported reasoning-model session timed out, and each cover letter was
+    // written with no company knowledge and no visible failure.
+
+    #[test]
+    fn research_deadline_exceeds_the_inner_search_bounds_it_wraps() {
+        // It wraps a web search AND a synthesis completion. If the outer bound
+        // isn't clear of the inner ones, it fires first and the actionable inner
+        // error never surfaces. The old flat 25s was EQUAL to `WEB_SEARCH`.
+        assert!(
+            research_deadline(None) > WEB_SEARCH,
+            "the outer research bound must clear the cloud web-search bound"
+        );
+        assert!(research_deadline(None) > OLLAMA_WEB_SEARCH);
+    }
+
+    #[test]
+    fn research_deadline_is_monotonically_nondecreasing_by_effort_tier() {
+        // Vendors' ascending order — `max` is the TOP tier, above `xhigh`.
+        let tiers = [
+            None,
+            Some("minimal"),
+            Some("low"),
+            Some("medium"),
+            Some("high"),
+            Some("xhigh"),
+            Some("max"),
+        ];
+        let mut prev = Duration::from_secs(0);
+        for effort in tiers {
+            let d = research_deadline(effort);
+            assert!(
+                d >= prev,
+                "research_deadline({effort:?}) = {d:?} must be >= the previous tier's {prev:?}"
+            );
+            prev = d;
+        }
+        // Not vacuously true: the top tier must actually exceed the baseline.
+        assert!(research_deadline(Some("max")) > research_deadline(None));
+    }
+
+    #[test]
+    fn research_deadline_falls_back_to_baseline_for_an_unrecognized_effort_string() {
+        assert_eq!(research_deadline(Some("ultra-mega-think")), RESEARCH_BASELINE);
+        assert_eq!(research_deadline(None), RESEARCH_BASELINE);
     }
 }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
@@ -267,7 +267,10 @@ mod tests {
 
     #[test]
     fn research_deadline_falls_back_to_baseline_for_an_unrecognized_effort_string() {
-        assert_eq!(research_deadline(Some("ultra-mega-think")), RESEARCH_BASELINE);
+        assert_eq!(
+            research_deadline(Some("ultra-mega-think")),
+            RESEARCH_BASELINE
+        );
         assert_eq!(research_deadline(None), RESEARCH_BASELINE);
     }
 }

--- a/apps/desktop/src-tauri/src/commands/ai_provider/trace.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/trace.rs
@@ -1,0 +1,78 @@
+//! Structured per-request tracing for provider calls.
+//!
+//! Split out of `ai_provider/mod.rs` (which sits at its LOC cap) — this is a
+//! self-contained tracing concern with no provider logic in it. Re-exported from
+//! the parent, so every `RequestTrace::begin` call site is unchanged.
+
+use super::ProviderId;
+
+/// Monotonic id source for [`RequestTrace`]. Process-local and reset on restart —
+/// it only has to disambiguate requests within one log file.
+static REQUEST_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// Structured per-request log over the shared [`crate::observability::Span`].
+/// Emits a `→` line at dispatch and a `←` line with status + duration at
+/// completion, e.g.:
+/// `[ai] ← req=17 provider=openai model=gpt-4o endpoint=/chat/completions … status=200 duration=1842ms ok=true`
+pub struct RequestTrace {
+    span: crate::observability::Span,
+}
+
+impl RequestTrace {
+    pub fn begin(
+        provider: ProviderId,
+        model: &str,
+        endpoint: &str,
+        base_url: &str,
+        streaming: bool,
+    ) -> Self {
+        // Process-local sequence number, stamped on BOTH the `→` and `←` lines.
+        // Without it concurrent requests are unpairable: with several generations
+        // in flight the log is a shuffled interleaving of starts and ends, and
+        // working out which end belongs to which start means subtracting every
+        // reported `duration` from its timestamp by hand. A counter rather than
+        // the job id, because research, embeddings and model listing have no job
+        // of their own — this covers every provider request uniformly.
+        let req = REQUEST_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let fields = format!(
+            "req={} provider={} model={} endpoint={} baseUrl={} streaming={}",
+            req,
+            provider.as_str(),
+            model,
+            endpoint,
+            base_url,
+            streaming
+        );
+        Self {
+            span: crate::observability::Span::begin("ai", fields),
+        }
+    }
+
+    pub fn end(&self, status: Option<u16>, ok: bool) {
+        let status = status
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        self.span.end_with(&format!("status={status}"), ok);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two traces begun in the same process must never share an id — that is the
+    /// entire point of the field, and an `Ordering::Relaxed` fetch_add is only
+    /// correct here because uniqueness (not ordering) is what is required.
+    #[test]
+    fn each_request_gets_a_distinct_id() {
+        let before = REQUEST_SEQ.load(std::sync::atomic::Ordering::Relaxed);
+        let _a = RequestTrace::begin(ProviderId::Ollama, "m", "/e", "http://h", false);
+        let _b = RequestTrace::begin(ProviderId::Ollama, "m", "/e", "http://h", false);
+        let after = REQUEST_SEQ.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            after - before,
+            2,
+            "each begin() must consume exactly one id"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/ai_provider/trace.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/trace.rs
@@ -16,6 +16,10 @@ static REQUEST_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64:
 /// `[ai] ← req=17 provider=openai model=gpt-4o endpoint=/chat/completions … status=200 duration=1842ms ok=true`
 pub struct RequestTrace {
     span: crate::observability::Span,
+    /// The id stamped on both log lines. Kept only so the uniqueness test can
+    /// read it back — the log lines themselves already carry it.
+    #[cfg(test)]
+    id: u64,
 }
 
 impl RequestTrace {
@@ -45,6 +49,8 @@ impl RequestTrace {
         );
         Self {
             span: crate::observability::Span::begin("ai", fields),
+            #[cfg(test)]
+            id: req,
         }
     }
 
@@ -63,16 +69,15 @@ mod tests {
     /// Two traces begun in the same process must never share an id — that is the
     /// entire point of the field, and an `Ordering::Relaxed` fetch_add is only
     /// correct here because uniqueness (not ordering) is what is required.
+    ///
+    /// Asserts the two ids DIFFER rather than a delta on the global counter:
+    /// `REQUEST_SEQ` is process-wide and Rust runs tests in parallel threads, so
+    /// any other test creating a trace between the two reads would fail a
+    /// delta assertion while uniqueness — the actual invariant — still holds.
     #[test]
     fn each_request_gets_a_distinct_id() {
-        let before = REQUEST_SEQ.load(std::sync::atomic::Ordering::Relaxed);
-        let _a = RequestTrace::begin(ProviderId::Ollama, "m", "/e", "http://h", false);
-        let _b = RequestTrace::begin(ProviderId::Ollama, "m", "/e", "http://h", false);
-        let after = REQUEST_SEQ.load(std::sync::atomic::Ordering::Relaxed);
-        assert_eq!(
-            after - before,
-            2,
-            "each begin() must consume exactly one id"
-        );
+        let a = RequestTrace::begin(ProviderId::Ollama, "m", "/e", "http://h", false);
+        let b = RequestTrace::begin(ProviderId::Ollama, "m", "/e", "http://h", false);
+        assert_ne!(a.id, b.id, "two traces must never share a request id");
     }
 }

--- a/apps/desktop/src-tauri/src/commands/jobs.rs
+++ b/apps/desktop/src-tauri/src/commands/jobs.rs
@@ -56,6 +56,25 @@ pub fn job_start_exclusive(
     existing
 }
 
+/// Park a job behind the concurrency limiter: status → `queued`, emitting
+/// `job.queued` with how many callers are ahead of it.
+///
+/// The renderer suspends its stream deadline while a job is `queued` — see
+/// `awaitAiStream`. Without that, a generation waiting its turn in a batch
+/// counts down and fails having never sent a request.
+pub fn job_queued(app: &AppHandle, id: &str, ahead: usize) {
+    app.state::<Mutex<JobTracker>>().lock().set_waiting(id, true);
+    emit_job_event(app, "job.queued", id, Some(json!({ "ahead": ahead })));
+}
+
+/// The counterpart to [`job_queued`]: a slot opened up, status → `running`.
+pub fn job_dequeued(app: &AppHandle, id: &str) {
+    app.state::<Mutex<JobTracker>>()
+        .lock()
+        .set_waiting(id, false);
+    emit_job_event(app, "job.started", id, None);
+}
+
 /// Update a job's progress (0.0–1.0) and emit `job.progress`.
 pub fn job_progress(app: &AppHandle, id: &str, p: f64) {
     app.state::<Mutex<JobTracker>>()

--- a/apps/desktop/src-tauri/src/commands/jobs.rs
+++ b/apps/desktop/src-tauri/src/commands/jobs.rs
@@ -63,7 +63,9 @@ pub fn job_start_exclusive(
 /// `awaitAiStream`. Without that, a generation waiting its turn in a batch
 /// counts down and fails having never sent a request.
 pub fn job_queued(app: &AppHandle, id: &str, ahead: usize) {
-    app.state::<Mutex<JobTracker>>().lock().set_waiting(id, true);
+    app.state::<Mutex<JobTracker>>()
+        .lock()
+        .set_waiting(id, true);
     emit_job_event(app, "job.queued", id, Some(json!({ "ahead": ahead })));
 }
 

--- a/apps/desktop/src-tauri/src/commands/pipeline.rs
+++ b/apps/desktop/src-tauri/src/commands/pipeline.rs
@@ -76,19 +76,10 @@ pub async fn generate_pipeline(app: AppHandle, req: AiGenerateRequest) -> Value 
         Err(e) => return fail(&app, &job_id, e.to_string()),
     };
 
-    // Per-provider daily ceiling — charged here, at admission, exactly like
-    // `ai_generate`. Charging after the queue wait would let an unbounded number
-    // of runs past the ceiling while they park.
     let limiter = app
         .state::<std::sync::Arc<crate::limits::Limiter>>()
         .inner()
         .clone();
-    if let Err(e) = limiter.charge_provider_daily(
-        completer.provider_id().as_str(),
-        crate::limits::PROVIDER_DAILY_MAX,
-    ) {
-        return fail(&app, &job_id, e.to_string());
-    }
 
     let job_id_clone = job_id.clone();
     let app_clone = app.clone();
@@ -122,6 +113,25 @@ pub async fn generate_pipeline(app: AppHandle, req: AiGenerateRequest) -> Value 
                 return;
             }
         };
+
+        // Per-provider daily ceiling — charged AFTER admission, matching
+        // `ai_generate` and `admit_research`. Charging before `acquire_queued`
+        // burned a day's quota on calls the rate window or the queue ceiling
+        // then rejected, which never reached a provider at all.
+        //
+        // The overshoot this ordering allows is bounded, not unbounded: at most
+        // `AI_GENERATE_CONCURRENCY_MAX + AI_GENERATE_QUEUE_MAX` calls can be
+        // admitted-but-uncharged at once, against a ceiling of
+        // `PROVIDER_DAILY_MAX`.
+        if let Err(e) = limiter.charge_provider_daily(
+            completer.provider_id().as_str(),
+            crate::limits::PROVIDER_DAILY_MAX,
+        ) {
+            let msg = e.to_string();
+            emit_stream_error(&app_clone, &job_id_clone, &msg);
+            crate::commands::jobs::job_fail(&app_clone, &job_id_clone, msg);
+            return;
+        }
 
         let mut ctx = GenerationContext {
             job_id: job_id_clone.clone(),

--- a/apps/desktop/src-tauri/src/commands/pipeline.rs
+++ b/apps/desktop/src-tauri/src/commands/pipeline.rs
@@ -8,7 +8,7 @@
 
 use async_trait::async_trait;
 use serde_json::{json, Value};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 use crate::commands::ai_provider::{emit_stream_error, AiGenerateRequest};
 use crate::db::new_job_id;
@@ -41,6 +41,22 @@ impl Stage<GenerationContext> for StreamGenerateStage {
 /// Stream a generation through the pipeline. Provider is required + validated
 /// (no silent fallback), identical to `ai_generate`; the difference is that the
 /// work runs as a `Pipeline` so stages compose consistently across features.
+///
+/// ## Anti-abuse
+///
+/// This is the command the tailoring flow actually calls, so it — not just
+/// `ai_generate` — has to carry the limiter. It previously carried neither the
+/// rate/concurrency cap nor the per-provider daily charge, which meant the
+/// documented `AI_GENERATE_CONCURRENCY_MAX` of 3 was enforced on a path the app
+/// no longer used: a 2026-08-08 support bundle shows **7** concurrent streams
+/// from six user-initiated runs, ending in a provider 429 that discarded nine
+/// minutes of completed generation.
+///
+/// It uses [`Limiter::acquire_queued`] rather than `acquire`: every call here is
+/// a deliberate human action (a click on Generate), so the 4th concurrent one
+/// waits its turn instead of being thrown away. The wait happens inside the
+/// spawned task, after the `jobId` is returned, so the IPC call still resolves
+/// immediately and the renderer can show the job as queued.
 #[tauri::command]
 pub async fn generate_pipeline(app: AppHandle, req: AiGenerateRequest) -> Value {
     let job_id = new_job_id();
@@ -60,9 +76,53 @@ pub async fn generate_pipeline(app: AppHandle, req: AiGenerateRequest) -> Value 
         Err(e) => return fail(&app, &job_id, e.to_string()),
     };
 
+    // Per-provider daily ceiling — charged here, at admission, exactly like
+    // `ai_generate`. Charging after the queue wait would let an unbounded number
+    // of runs past the ceiling while they park.
+    let limiter = app
+        .state::<std::sync::Arc<crate::limits::Limiter>>()
+        .inner()
+        .clone();
+    if let Err(e) = limiter.charge_provider_daily(
+        completer.provider_id().as_str(),
+        crate::limits::PROVIDER_DAILY_MAX,
+    ) {
+        return fail(&app, &job_id, e.to_string());
+    }
+
     let job_id_clone = job_id.clone();
     let app_clone = app.clone();
     tauri::async_runtime::spawn(async move {
+        // Wait (don't reject) for a concurrency slot. `_guard` is held for the
+        // whole pipeline and releases the slot on drop — including on an early
+        // return or a panic inside a stage.
+        let _guard = match limiter
+            .acquire_queued(
+                "ai_generate",
+                crate::limits::AI_GENERATE_RATE_MAX,
+                crate::limits::AI_GENERATE_CONCURRENCY_MAX,
+                crate::limits::AI_GENERATE_QUEUE_MAX,
+                // Fires only if it actually has to wait, and before the wait, so
+                // the renderer can suspend its stream deadline and show the
+                // position instead of an 8-minute-silent "generating".
+                |ahead| crate::commands::jobs::job_queued(&app_clone, &job_id_clone, ahead),
+            )
+            .await
+        {
+            Ok((guard, parked)) => {
+                if parked {
+                    crate::commands::jobs::job_dequeued(&app_clone, &job_id_clone);
+                }
+                guard
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                emit_stream_error(&app_clone, &job_id_clone, &msg);
+                crate::commands::jobs::job_fail(&app_clone, &job_id_clone, msg);
+                return;
+            }
+        };
+
         let mut ctx = GenerationContext {
             job_id: job_id_clone.clone(),
             completer,

--- a/apps/desktop/src-tauri/src/commands/support.rs
+++ b/apps/desktop/src-tauri/src/commands/support.rs
@@ -312,6 +312,39 @@ mod tests {
         assert_eq!(names.len(), 3, "unexpected entries: {names:?}");
     }
 
+    /// Redaction must not destroy the backtrace it is redacting.
+    ///
+    /// A reported bundle's `crashes.log` had two PANIC entries whose backtrace
+    /// was completely empty, making both undiagnosable. Redaction is one of the
+    /// two candidates for that (the other being capture itself), so it gets
+    /// pinned here: symbol names and frame numbers survive, only the paths go.
+    #[test]
+    fn a_backtrace_survives_redaction_with_only_its_paths_removed() {
+        let frame = "   3: ajh_tauri::window::move_state\n                                  at C:\\Users\\alice\\src\\window.rs:42:9";
+        let redacted = redact_lines(frame);
+
+        assert!(
+            redacted.contains("ajh_tauri::window::move_state"),
+            "the SYMBOL is the diagnostic value and must survive; got: {redacted}"
+        );
+        assert!(
+            redacted.contains("3:"),
+            "frame numbering must survive; got: {redacted}"
+        );
+        assert!(
+            redacted.contains("<path-redacted>"),
+            "the absolute path must still be redacted; got: {redacted}"
+        );
+        assert!(!redacted.contains("alice"), "username must not leak: {redacted}");
+    }
+
+    /// The entry separator must survive too — without it, consecutive crashes
+    /// run together and the reader cannot tell where one backtrace ends.
+    #[test]
+    fn the_crash_entry_separator_survives_redaction() {
+        assert_eq!(redact_lines("---"), "---");
+    }
+
     /// Absolute paths and credential tokens in crashes.log must be redacted.
     #[test]
     fn crashes_log_paths_are_redacted() {

--- a/apps/desktop/src-tauri/src/commands/support.rs
+++ b/apps/desktop/src-tauri/src/commands/support.rs
@@ -335,7 +335,10 @@ mod tests {
             redacted.contains("<path-redacted>"),
             "the absolute path must still be redacted; got: {redacted}"
         );
-        assert!(!redacted.contains("alice"), "username must not leak: {redacted}");
+        assert!(
+            !redacted.contains("alice"),
+            "username must not leak: {redacted}"
+        );
     }
 
     /// The entry separator must survive too — without it, consecutive crashes

--- a/apps/desktop/src-tauri/src/commands/translation.rs
+++ b/apps/desktop/src-tauri/src/commands/translation.rs
@@ -123,8 +123,19 @@ pub async fn translate_if_needed(
             }
             translated
         }
-        // Empty or errored translation: safe fallback to the original text.
-        _ => text.to_string(),
+        // Empty or errored translation: safe fallback to the original text — but
+        // NOT a silent one. This degrading quietly is how a local setup with only
+        // an embedding model installed sent that model to `/api/chat` and took a
+        // 400 per job ad for a whole session with nothing but an `ok=false` span
+        // to show for it.
+        Ok(_) => {
+            tracing::warn!(model = %model, "translation: provider returned empty text, keeping the original");
+            text.to_string()
+        }
+        Err(e) => {
+            tracing::warn!(model = %model, "translation failed, keeping the original: {e}");
+            text.to_string()
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/cover_letter/research/extractor.rs
+++ b/apps/desktop/src-tauri/src/cover_letter/research/extractor.rs
@@ -106,7 +106,8 @@ fn extract_company(text: &str) -> String {
             // heading, yielded a company of "You'll Do". The renderer's own
             // fallback regex had the identical bug; this is the same defect, so
             // it gets the same fix on both sides rather than one patch.
-            if let Some(i) = find_ascii_ci(line, prefix).filter(|i| starts_at_word_boundary(line, *i))
+            if let Some(i) =
+                find_ascii_ci(line, prefix).filter(|i| starts_at_word_boundary(line, *i))
             {
                 let rest = &line[i + prefix.len()..];
                 let candidate = rest

--- a/apps/desktop/src-tauri/src/cover_letter/research/extractor.rs
+++ b/apps/desktop/src-tauri/src/cover_letter/research/extractor.rs
@@ -6,9 +6,69 @@ pub struct JobAdMeta {
 }
 
 pub fn extract(job_ad: &str) -> JobAdMeta {
-    let company = extract_company(job_ad);
-    let role = extract_role(job_ad);
+    let company = sanitized(extract_company(job_ad));
+    let role = sanitized(extract_role(job_ad));
     JobAdMeta { company, role }
+}
+
+/// Apply/nav chrome that a scraped ad's first line frequently is. Lowercased,
+/// matched whole — these are the exact strings a heuristic returns instead of a
+/// title, seen verbatim in a support bundle (`Jetzt bewerben`,
+/// `[← Alle offenen Stellen](/karriere)`).
+const CHROME: &[&str] = &[
+    "jetzt bewerben",
+    "bewerben",
+    "apply",
+    "apply now",
+    "apply for this job",
+    "back to jobs",
+    "alle offenen stellen",
+    "view all jobs",
+    "all openings",
+    "open positions",
+    "offene stellen",
+    "share this job",
+    "solliciteer",
+];
+
+/// Drop a candidate that is page chrome, markup, or prose rather than a name or
+/// a job title. Empty means "nothing usable found", which every caller already
+/// handles by skipping research entirely.
+///
+/// Both fields feed the same provider search, and a bad value there is worse
+/// than none: it produces a confident brief about the wrong subject. Observed
+/// values this rejects: `Jetzt bewerben` (an apply button),
+/// `[← Alle offenen Stellen](/karriere)` (a nav link), and
+/// `Please note: Fluent Dutch language skills are required for this role.`
+/// Pure + unit-tested.
+fn sanitized(candidate: String) -> String {
+    let c = candidate.trim();
+    if c.is_empty() {
+        return String::new();
+    }
+    // Markdown/HTML that leaked out of the scraped page.
+    if c.contains("](") || c.starts_with('[') || c.contains("**") || c.contains('<') {
+        return String::new();
+    }
+    // A sentence, not a label.
+    if c.ends_with('.') || c.ends_with('!') || c.ends_with('?') {
+        return String::new();
+    }
+    let lower = c.to_lowercase();
+    if CHROME.contains(&lower.as_str()) {
+        return String::new();
+    }
+    c.to_string()
+}
+
+/// Whether byte offset `at` in `text` begins a word — i.e. it is the start of
+/// the string or the preceding char is not alphanumeric. `at` must be a char
+/// boundary (every caller gets it from [`find_ascii_ci`], which guarantees that).
+fn starts_at_word_boundary(text: &str, at: usize) -> bool {
+    text[..at]
+        .chars()
+        .next_back()
+        .is_none_or(|c| !c.is_alphanumeric())
 }
 
 /// ASCII case-insensitive substring search. `needle` MUST be ASCII.
@@ -41,7 +101,13 @@ fn extract_company(text: &str) -> String {
             // code applied a per-line byte offset (from lower.find) into the
             // FULL `text` string — a completely wrong target — which panics
             // when `text` starts with multibyte chars (e.g. an emoji headline).
-            if let Some(i) = find_ascii_ci(line, prefix) {
+            // `starts_at_word_boundary`: without it the bare `"at "` prefix
+            // matches INSIDE a word — "Wh(at )You'll Do", a near-universal job-ad
+            // heading, yielded a company of "You'll Do". The renderer's own
+            // fallback regex had the identical bug; this is the same defect, so
+            // it gets the same fix on both sides rather than one patch.
+            if let Some(i) = find_ascii_ci(line, prefix).filter(|i| starts_at_word_boundary(line, *i))
+            {
                 let rest = &line[i + prefix.len()..];
                 let candidate = rest
                     .split(['|', '\n', ',', '('])
@@ -228,5 +294,71 @@ mod tests {
             "expected empty company, got {:?}",
             meta.company
         );
+    }
+
+    // ── Chrome / prose rejection (the values a real bundle searched for) ───────
+    //
+    // Every string here was the `role=` or `company=` a 2026-08-08 support bundle
+    // actually sent to the provider's web search. A wrong subject is worse than
+    // none: it returns a confident brief about something that is not the employer.
+
+    #[test]
+    fn apply_buttons_and_nav_links_are_not_roles() {
+        for ad in [
+            "Jetzt bewerben\n\nWir suchen einen Entwickler",
+            "[← Alle offenen Stellen](/karriere)\n\nSoftware Engineer",
+            "Apply now\n\nWe build things",
+        ] {
+            let meta = extract(ad);
+            assert!(
+                meta.role.is_empty() || !meta.role.contains("bewerben"),
+                "chrome must not become the role, got {:?}",
+                meta.role
+            );
+            assert!(
+                !meta.role.contains("]("),
+                "a markdown link must not become the role, got {:?}",
+                meta.role
+            );
+        }
+    }
+
+    #[test]
+    fn a_prose_sentence_is_not_a_role() {
+        let ad = "Please note: Fluent Dutch language skills are required for this role.";
+        assert_eq!(extract(ad).role, "");
+    }
+
+    #[test]
+    fn a_real_first_line_title_is_still_extracted() {
+        // The gate must not eat the common, correct case.
+        let meta = extract("Senior Backend Engineer\n\nWe are a payments company.");
+        assert_eq!(meta.role, "Senior Backend Engineer");
+    }
+
+    #[test]
+    fn labelled_company_and_role_still_win() {
+        let meta = extract("Job title: Staff Engineer\nCompany: Codefield\n");
+        assert_eq!(meta.role, "Staff Engineer");
+        assert_eq!(meta.company, "Codefield");
+    }
+
+    // ── The `at` word-boundary bug (identical to the renderer's own regex) ─────
+
+    #[test]
+    fn at_inside_a_word_is_not_a_company_marker() {
+        // "Wh(at) You'll Do" is a near-universal job-ad heading. The bare `"at "`
+        // prefix matched inside it and yielded a company of "You'll Do", which a
+        // real session then researched three times.
+        let meta = extract("What You'll Do\n\nBuild and ship features.");
+        assert_ne!(meta.company, "You'll Do");
+        assert_eq!(meta.company, "");
+    }
+
+    #[test]
+    fn at_as_a_real_word_still_extracts_the_company() {
+        // The boundary fix must not break the case the prefix exists for.
+        let meta = extract("Senior Engineer at Codefield\n");
+        assert_eq!(meta.company, "Codefield");
     }
 }

--- a/apps/desktop/src-tauri/src/cover_letter/research/mod.rs
+++ b/apps/desktop/src-tauri/src/cover_letter/research/mod.rs
@@ -10,10 +10,6 @@ use crate::pipeline::Completer;
 
 const CACHE_NS: &str = "company_brief";
 const TTL_SECS: i64 = 7 * 24 * 3600;
-/// Hard cap on a single research call so generation never stalls on a slow or
-/// hung provider search. Provider-agnostic — applied once here, around the
-/// active provider's own `research()`.
-const RESEARCH_TIMEOUT_SECS: u64 = 25;
 
 /// Company-research enricher: resolve company → cache check → the **active
 /// provider's own** web search + brief synthesis (via [`Completer::research`]) →
@@ -29,11 +25,21 @@ impl CompanyResearch {
     /// job-ad extraction, which frequently grabs a tagline ("…platform built for
     /// the era of agentic commerce") rather than the company. Falls back to the
     /// heuristic extraction only when the override is absent/empty.
+    ///
+    /// `deadline` bounds the whole pass (search + synthesis) and is INJECTED by
+    /// the L3 caller — which derives it from the request's reasoning effort via
+    /// `timeouts::research_deadline` — rather than resolved here, for the same
+    /// reason `SalaryResearch::enrich` takes its `cache`: this module must not
+    /// reach up into `commands` (R7), and an injected bound is directly
+    /// testable. A FLAT bound was the bug: synthesis is a model call, so its
+    /// cost scales with the model's reasoning budget, and a reasoning model's
+    /// research never finished inside the old fixed 25s.
     pub async fn enrich_with(
         &self,
         completer: &Completer,
         job_ad: &str,
         company_override: Option<&str>,
+        deadline: Duration,
     ) -> EnrichmentResult {
         let meta = extractor::extract(job_ad);
         let company = company_override
@@ -69,7 +75,7 @@ impl CompanyResearch {
         // Provider-native research, bounded so generation never stalls. Any
         // failure / timeout / unconfigured provider yields an empty brief.
         let brief = match tokio::time::timeout(
-            Duration::from_secs(RESEARCH_TIMEOUT_SECS),
+            deadline,
             completer.research(&company, &meta.role),
         )
         .await
@@ -80,7 +86,11 @@ impl CompanyResearch {
                 String::new()
             }
             Err(_) => {
-                tracing::warn!("research: timed out for {company}");
+                tracing::warn!(
+                    company = %company,
+                    deadline_secs = deadline.as_secs(),
+                    "research: timed out"
+                );
                 String::new()
             }
         };

--- a/apps/desktop/src-tauri/src/cover_letter/research/mod.rs
+++ b/apps/desktop/src-tauri/src/cover_letter/research/mod.rs
@@ -76,11 +76,7 @@ impl CompanyResearch {
 
         // Provider-native research, bounded so generation never stalls. Any
         // failure / timeout / unconfigured provider yields an empty brief.
-        let brief = match tokio::time::timeout(
-            deadline,
-            completer.research(&company, &role),
-        )
-        .await
+        let brief = match tokio::time::timeout(deadline, completer.research(&company, &role)).await
         {
             Ok(Ok(b)) => b,
             Ok(Err(e)) => {

--- a/apps/desktop/src-tauri/src/cover_letter/research/mod.rs
+++ b/apps/desktop/src-tauri/src/cover_letter/research/mod.rs
@@ -39,14 +39,16 @@ impl CompanyResearch {
         completer: &Completer,
         job_ad: &str,
         company_override: Option<&str>,
+        role_override: Option<&str>,
         deadline: Duration,
     ) -> EnrichmentResult {
         let meta = extractor::extract(job_ad);
-        let company = company_override
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string)
-            .unwrap_or_else(|| meta.company.clone());
+        let company = pick(company_override, &meta.company);
+        // Same precedence as `company`, and for the same reason: the heuristic's
+        // last resort is "the ad's first short line", which on a scraped page is
+        // routinely an apply button or a nav link. A reported session searched
+        // for role="Jetzt bewerben" and role="[← Alle offenen Stellen](/karriere)".
+        let role = pick(role_override, &meta.role);
         if company.is_empty() {
             tracing::debug!("research: no company name available (override + extraction empty)");
             return EnrichmentResult::empty();
@@ -76,7 +78,7 @@ impl CompanyResearch {
         // failure / timeout / unconfigured provider yields an empty brief.
         let brief = match tokio::time::timeout(
             deadline,
-            completer.research(&company, &meta.role),
+            completer.research(&company, &role),
         )
         .await
         {
@@ -112,7 +114,7 @@ impl CompanyResearch {
 
         tracing::info!(
             company = %company,
-            role = %meta.role,
+            role = %role,
             source = "provider",
             chars = brief.len(),
             "research: company brief\n{brief}"
@@ -126,6 +128,17 @@ impl CompanyResearch {
             content: brief,
         }
     }
+}
+
+/// The AI-extracted value when it is non-empty, else the heuristic one. The
+/// AI extraction sees the whole ad and is simply better; the heuristic exists
+/// for the paths that have no extraction to offer.
+fn pick(override_value: Option<&str>, heuristic: &str) -> String {
+    override_value
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(heuristic)
+        .to_string()
 }
 
 /// A brief the model couldn't actually fill: too short to be a real ~150-word

--- a/apps/desktop/src-tauri/src/extension_bridge/answer_assist.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/answer_assist.rs
@@ -778,7 +778,17 @@ async fn resolve_salary_range<S: crate::salary_research::SalarySearcher>(
     // low-traffic path; `None` still lets `enrich` skip its cache-read branch
     // cleanly rather than erroring.
     crate::salary_research::SalaryResearch
-        .enrich(searcher, None, role, company, "", "", "")
+        .enrich(
+            searcher,
+            None,
+            role,
+            company,
+            "",
+            "",
+            "",
+            // No per-request effort at this call depth — unscaled baseline.
+            crate::commands::ai_provider::timeouts::research_deadline(None),
+        )
         .await
 }
 

--- a/apps/desktop/src-tauri/src/extension_bridge/auth.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/auth.rs
@@ -165,11 +165,22 @@ pub(super) fn warn_rejected_origin_once(origin: &str) {
     use std::collections::HashSet;
     use std::sync::{Mutex, OnceLock};
 
+    /// Ceiling on remembered origins. The `Origin` header is attacker-supplied
+    /// (any loopback client can send one), so an unbounded set is a memory sink
+    /// a hostile local process could grow at will. Past the cap nothing new is
+    /// remembered and further origins log at debug — the suppression is what
+    /// matters, and a real deployment has ONE bad origin, not 64.
+    const MAX_REMEMBERED: usize = 64;
+
     static SEEN: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
     let mut seen = match SEEN.get_or_init(Default::default).lock() {
         Ok(g) => g,
         Err(poisoned) => poisoned.into_inner(),
     };
+    if seen.len() >= MAX_REMEMBERED && !seen.contains(origin) {
+        log::debug!("[extension_bridge] rejected handshake from origin: {origin:?} (cap reached)");
+        return;
+    }
     if seen.insert(origin.to_string()) {
         // First time only, and deliberately actionable: an unpaired extension is
         // otherwise indistinguishable from a desktop that simply isn't running.

--- a/apps/desktop/src-tauri/src/extension_bridge/auth.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/auth.rs
@@ -152,6 +152,58 @@ pub fn is_safe_import_url(url: &str) -> bool {
     }
 }
 
+/// Origins already reported this session, so an extension that can never pair
+/// logs once instead of on every reconnect.
+///
+/// A browser does not expose a failed WebSocket handshake's HTTP status to
+/// script, so the extension genuinely cannot tell "desktop refused my origin"
+/// from "desktop isn't running" — its ~10s reconnect loop is correct behaviour,
+/// not a bug to fix client-side. What was wrong is that each attempt wrote TWO
+/// warnings: one unpairable build produced 1,932 rejections + 1,932 paired
+/// failures in a single reported session.
+pub(super) fn warn_rejected_origin_once(origin: &str) {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+
+    static SEEN: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    let mut seen = match SEEN.get_or_init(Default::default).lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if seen.insert(origin.to_string()) {
+        // First time only, and deliberately actionable: an unpaired extension is
+        // otherwise indistinguishable from a desktop that simply isn't running.
+        log::warn!(
+            "[extension_bridge] rejected handshake from origin: {origin:?} — not an allowed \
+             extension origin. A development build needs its origin in the \
+             `extensionDevOrigins` config; a store build should already match. \
+             Further rejections from this origin are logged at debug."
+        );
+    } else {
+        log::debug!("[extension_bridge] rejected handshake from origin: {origin:?}");
+    }
+}
+
+/// Log a failed WebSocket handshake at the right level.
+///
+/// The 403 this module's own origin check produced is already reported in full
+/// (with the origin) by [`warn_rejected_origin_once`], so re-logging it here
+/// would double every attempt — which is precisely what turned one unpairable
+/// extension into ~3,900 log lines in a single session. Any OTHER handshake
+/// failure (a malformed request line, a torn-down connection) is genuinely new
+/// information and stays at warn.
+pub(super) fn log_handshake_failure(e: &tokio_tungstenite::tungstenite::Error) {
+    use tokio_tungstenite::tungstenite::http::StatusCode;
+    use tokio_tungstenite::tungstenite::Error;
+
+    let forbidden = matches!(e, Error::Http(r) if r.status() == StatusCode::FORBIDDEN);
+    if forbidden {
+        log::debug!("[extension_bridge] handshake refused (forbidden origin): {e}");
+    } else {
+        log::warn!("[extension_bridge] handshake rejected/failed: {e}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -654,7 +654,7 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
         if auth::is_allowed_origin(origin, &dev_origins) {
             Ok(res)
         } else {
-            log::warn!("[extension_bridge] rejected handshake from origin: {origin:?}");
+            auth::warn_rejected_origin_once(origin);
             let resp = ErrorResponse::new(Some("forbidden origin".to_string()));
             let (mut parts, body) = resp.into_parts();
             parts.status = StatusCode::FORBIDDEN;
@@ -675,8 +675,7 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
         {
             Ok(ws) => ws,
             Err(e) => {
-                // Includes the rejected-origin case (handshake refused with 403).
-                log::warn!("[extension_bridge] handshake rejected/failed: {e}");
+                auth::log_handshake_failure(&e);
                 return;
             }
         };

--- a/apps/desktop/src-tauri/src/jobs/mod.rs
+++ b/apps/desktop/src-tauri/src/jobs/mod.rs
@@ -259,6 +259,32 @@ impl JobTracker {
         }
     }
 
+    /// Move a live job between [`JobStatus::Queued`] and [`JobStatus::Running`].
+    ///
+    /// Only those two: a job parked behind the concurrency limiter has not
+    /// started yet, and the renderer must be able to tell that apart from a
+    /// started-but-slow job — otherwise its stream deadline counts down while the
+    /// job is still waiting its turn, and a legitimately queued generation fails
+    /// having never issued a request. Terminal states go through
+    /// [`Self::complete`] / [`Self::fail`] / [`Self::cancel`], which also stamp
+    /// `finished_at`; a no-op here for an already-finished job keeps a late
+    /// transition from resurrecting one.
+    pub fn set_waiting(&mut self, id: &str, queued: bool) {
+        let record = match self.jobs.get_mut(id) {
+            Some(job) if matches!(job.status, JobStatus::Queued | JobStatus::Running) => {
+                job.status = if queued {
+                    JobStatus::Queued
+                } else {
+                    JobStatus::Running
+                };
+                job.updated_at = now_ms();
+                job.clone()
+            }
+            _ => return,
+        };
+        self.persist_upsert(&record);
+    }
+
     pub fn update_progress(&mut self, id: &str, p: f64) {
         let record = match self.jobs.get_mut(id) {
             Some(job) => {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -420,11 +420,25 @@ pub fn run() {
                 .location()
                 .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
                 .unwrap_or_else(|| String::from("<unknown>"));
-            let bt = std::backtrace::Backtrace::force_capture();
-            writeln!(
-                file,
-                "[{timestamp}] PANIC at {location}: {msg}\nBacktrace:\n{bt}\n---"
-            )?;
+            // Rendered to a String BEFORE touching the file, and written in one
+            // call. Formatting a `Backtrace` directly into the file writer means
+            // a failure part-way through leaves a half-written entry on disk —
+            // which is what a reported bundle contained: two PANIC entries that
+            // stopped dead after "Backtrace:", with no frames and not even the
+            // `---` terminator, so neither crash could be diagnosed. This panic
+            // fires during shutdown, when a partial write is exactly what you
+            // would expect.
+            let bt = std::backtrace::Backtrace::force_capture().to_string();
+            let bt = if bt.trim().is_empty() {
+                // Say so explicitly. A blank section is indistinguishable from a
+                // truncated write, and that ambiguity is what cost the last two.
+                "<backtrace unavailable — capture returned no frames>".to_string()
+            } else {
+                bt
+            };
+            let entry = format!("[{timestamp}] PANIC at {location}: {msg}\nBacktrace:\n{bt}\n---\n");
+            file.write_all(entry.as_bytes())?;
+            file.flush()?;
             Ok(())
         })();
     }));

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -436,7 +436,8 @@ pub fn run() {
             } else {
                 bt
             };
-            let entry = format!("[{timestamp}] PANIC at {location}: {msg}\nBacktrace:\n{bt}\n---\n");
+            let entry =
+                format!("[{timestamp}] PANIC at {location}: {msg}\nBacktrace:\n{bt}\n---\n");
             file.write_all(entry.as_bytes())?;
             file.flush()?;
             Ok(())

--- a/apps/desktop/src-tauri/src/limits/mod.rs
+++ b/apps/desktop/src-tauri/src/limits/mod.rs
@@ -11,17 +11,20 @@
 //! 1. **Sliding-window request-rate cap** — at most `max_requests` accepted
 //!    starts of a given command within the last [`RATE_WINDOW`]. Old timestamps
 //!    age out, so it is a true rolling window, not a fixed bucket.
-//! 2. **Concurrency cap** — at most `max_concurrent` in-flight calls of a command.
-//!    Acquired as an RAII [`ConcurrencyGuard`] that decrements the live count on
-//!    drop, so a panicking / early-returning handler can never leak a slot.
+//! 2. **Concurrency cap** — at most `max_concurrent` in-flight calls of a command,
+//!    held as an RAII [`ConcurrencyGuard`] so a panicking / early-returning
+//!    handler can never leak a slot. Two admission styles share one cap:
+//!    [`Limiter::acquire`] REJECTS when the cap is full, [`Limiter::acquire_queued`]
+//!    WAITS. Both draw on the same per-command semaphore, so a command using
+//!    both styles still has exactly one concurrency budget.
 //! 3. **Per-provider daily request ceiling** — a generous runaway-cost backstop on
 //!    total accepted AI requests per provider per UTC day.
 //!
 //! Defaults are intentionally **generous** so normal interactive use never trips
 //! them; they exist to stop pathological loops, not to throttle a human.
 //!
-//! The whole limiter lives in Tauri managed state as `Arc<Limiter>`; the RAII
-//! guard holds its own `Arc<Limiter>` clone so the slot is released even if the
+//! The whole limiter lives in Tauri managed state as `Arc<Limiter>`; the guard
+//! owns its semaphore permit outright, so the slot is released even if the
 //! command's managed-state handle is gone.
 //!
 //! ## Known follow-ups (intentionally out of scope here)
@@ -34,6 +37,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use parking_lot::Mutex;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::error::AppError;
 
@@ -46,6 +50,13 @@ use crate::error::AppError;
 pub const AI_GENERATE_RATE_MAX: usize = 20;
 /// `ai_generate`: at most this many in-flight at once.
 pub const AI_GENERATE_CONCURRENCY_MAX: usize = 3;
+/// `ai_generate`: at most this many callers PARKED waiting for a slot (see
+/// [`Limiter::acquire_queued`]). Tailoring one job fires three sequential
+/// generations, so a user working through a batch of imports legitimately has
+/// several runs outstanding; a runaway loop is what this stops. Beyond the cap
+/// the caller is rejected rather than parked, so the queue itself can never
+/// become the unbounded resource.
+pub const AI_GENERATE_QUEUE_MAX: usize = 20;
 
 /// The `"ai_research"` command bucket: shared by every web-research lookup
 /// (`ai_lookup_salary`, `ai_research_company`, and `ai_research_answer`) so
@@ -78,13 +89,26 @@ pub const PROVIDER_DAILY_MAX: u32 = 4_000;
 
 // ── Limiter state ─────────────────────────────────────────────────────────────
 
-/// Sliding-window + concurrency state for a single command key.
-#[derive(Default)]
+/// Sliding-window + queue state for a single command key. Concurrency itself is
+/// held by [`CommandState::gate`], not a counter — see [`Limiter::acquire`].
 struct CommandState {
     /// Accepted start instants within the current window (oldest at the front).
     recent: VecDeque<Instant>,
-    /// Currently in-flight calls of this command.
-    in_flight: usize,
+    /// The command's concurrency budget. Created on first use with that call's
+    /// `max_concurrent`; every call site passes a per-command constant, so the
+    /// first value is the only value. A later call asking for a DIFFERENT cap on
+    /// the same key keeps the original — asserted by a debug assertion rather
+    /// than silently honoured, since it would mean two call sites disagree about
+    /// one budget.
+    gate: Arc<Semaphore>,
+    /// The cap [`CommandState::gate`] was built with, kept only so a second call
+    /// site asking for a different cap on the same key trips a debug assertion
+    /// instead of silently getting the first one.
+    max_concurrent: usize,
+    /// Callers currently parked in [`Limiter::acquire_queued`] waiting for a
+    /// permit. Bounded by that method's `max_queued`, and reported back so the
+    /// UI can say "queued — N ahead" instead of looking hung.
+    queued: usize,
 }
 
 /// Process-local anti-abuse limiter. Managed in Tauri state as `Arc<Limiter>`.
@@ -98,18 +122,61 @@ pub struct Limiter {
     per_provider_day: Mutex<HashMap<(u64, String), u32>>,
 }
 
-/// RAII concurrency slot. Releasing (drop) decrements the live in-flight count
-/// for its command, so an early `?`/panic in the handler can never leak a slot.
+/// RAII concurrency slot: it OWNS the semaphore permit, so the slot is released
+/// on drop whether the handler returns, `?`s out, or panics. There is no manual
+/// release path to forget — that is the whole point of holding the permit here
+/// rather than decrementing a counter.
 pub struct ConcurrencyGuard {
-    command: &'static str,
-    limiter: Arc<Limiter>,
+    _permit: OwnedSemaphorePermit,
 }
 
-impl Drop for ConcurrencyGuard {
+/// RAII membership in a command's wait queue, held only while parked in
+/// [`Limiter::acquire_queued`].
+///
+/// The decrement lives in `Drop`, not in the statement after the `.await`,
+/// because that await is a cancellation point: a caller whose future is dropped
+/// while parked (user cancels, window closes, task aborted) would otherwise
+/// leave the counter permanently high and eventually wedge the queue closed.
+struct QueueSlot {
+    limiter: Arc<Limiter>,
+    command: &'static str,
+    /// Callers already parked when this one arrived — reported to the UI.
+    ahead: usize,
+}
+
+impl QueueSlot {
+    /// Join `command`'s wait queue, or reject if it is already `max_queued` deep.
+    fn enter(
+        limiter: &Arc<Limiter>,
+        command: &'static str,
+        max_queued: usize,
+    ) -> Result<Self, AppError> {
+        let mut map = limiter.per_command.lock();
+        let Some(state) = map.get_mut(command) else {
+            // `check_rate` always inserts the entry first, so this is unreachable
+            // in practice; treat it as a full queue rather than panicking.
+            return Err(AppError::RateLimited(format!("{command} queue unavailable")));
+        };
+        if state.queued >= max_queued {
+            return Err(AppError::RateLimited(format!(
+                "Too many {command} requests waiting (max {max_queued}). Try again shortly."
+            )));
+        }
+        let ahead = state.queued;
+        state.queued += 1;
+        Ok(Self {
+            limiter: Arc::clone(limiter),
+            command,
+            ahead,
+        })
+    }
+}
+
+impl Drop for QueueSlot {
     fn drop(&mut self) {
         let mut map = self.limiter.per_command.lock();
         if let Some(state) = map.get_mut(self.command) {
-            state.in_flight = state.in_flight.saturating_sub(1);
+            state.queued = state.queued.saturating_sub(1);
         }
     }
 }
@@ -146,43 +213,142 @@ impl Limiter {
         max_concurrent: usize,
         now: Instant,
     ) -> Result<ConcurrencyGuard, AppError> {
-        {
-            let mut map = self.per_command.lock();
-            let state = map.entry(command).or_default();
+        let gate = self.check_rate(command, max_requests, max_concurrent, now)?;
 
-            // Age out timestamps older than the window (front = oldest).
-            let cutoff = now.checked_sub(RATE_WINDOW);
-            while let Some(&front) = state.recent.front() {
-                match cutoff {
-                    Some(c) if front <= c => {
-                        state.recent.pop_front();
-                    }
-                    // `now < RATE_WINDOW` since boot: nothing is old enough to evict.
-                    _ => break,
-                }
-            }
+        // Non-blocking: this admission style REJECTS rather than parks. The
+        // window slot is recorded only after the permit is actually taken, so a
+        // rejected call costs nothing.
+        let permit = gate.try_acquire_owned().map_err(|_| {
+            AppError::RateLimited(format!(
+                "Too many concurrent {command} requests (max {max_concurrent}). Try again shortly."
+            ))
+        })?;
+        self.record_start(command, now);
+        Ok(ConcurrencyGuard { _permit: permit })
+    }
 
-            if state.recent.len() >= max_requests {
-                return Err(AppError::RateLimited(format!(
-                    "Rate limit reached for {command}: max {max_requests} requests per {}s. Try again shortly.",
-                    RATE_WINDOW.as_secs()
-                )));
-            }
-            if state.in_flight >= max_concurrent {
-                return Err(AppError::RateLimited(format!(
-                    "Too many concurrent {command} requests (max {max_concurrent}). Try again shortly."
-                )));
-            }
+    /// [`Self::acquire`], but on a full concurrency cap the caller **waits** for a
+    /// slot instead of being rejected.
+    ///
+    /// For work a human deliberately started and expects to complete — the
+    /// tailoring pipeline, where a user working through imported applications
+    /// clicks Generate several times in a row. Rejecting the 4th click throws
+    /// away an intentional action; parking it does not. Ordering is the
+    /// semaphore's (FIFO), so nobody starves.
+    ///
+    /// The queue is bounded by `max_queued`: past that depth callers are rejected
+    /// outright, so a looping renderer cannot turn "wait" into unbounded parked
+    /// work. The rate window still applies at admission and still fails fast.
+    ///
+    /// `on_park` fires **before** the wait begins, exactly once, and only when
+    /// the call actually has to wait — with how many callers are ahead of it. It
+    /// has to run before the `.await`, not after, or the "queued" signal would
+    /// arrive at the same moment the wait ended and tell the user nothing.
+    ///
+    /// Returns the guard plus whether it parked, so the caller can pair its
+    /// "queued" signal with a matching "started" one.
+    ///
+    /// Cancel-safety: if the returned future is dropped while parked, the
+    /// `queued` counter is still decremented — the decrement lives in a
+    /// [`QueueSlot`] guard, not in the code path after the `.await`.
+    pub async fn acquire_queued(
+        self: &Arc<Self>,
+        command: &'static str,
+        max_requests: usize,
+        max_concurrent: usize,
+        max_queued: usize,
+        on_park: impl FnOnce(usize),
+    ) -> Result<(ConcurrencyGuard, bool), AppError> {
+        let now = Instant::now();
+        let gate = self.check_rate(command, max_requests, max_concurrent, now)?;
 
-            // Admit: record the start and reserve the concurrency slot.
-            state.recent.push_back(now);
-            state.in_flight += 1;
+        // Fast path: a slot is free right now, so never touch the queue counter
+        // and never emit a park signal.
+        if let Ok(permit) = Arc::clone(&gate).try_acquire_owned() {
+            self.record_start(command, now);
+            return Ok((ConcurrencyGuard { _permit: permit }, false));
         }
 
-        Ok(ConcurrencyGuard {
-            command,
-            limiter: Arc::clone(self),
-        })
+        // Full: park, unless the queue itself is at its ceiling (rejected here
+        // costs no window slot, same as any other rejection).
+        let slot = QueueSlot::enter(self, command, max_queued)?;
+        self.record_start(command, now);
+        on_park(slot.ahead);
+
+        let permit = gate
+            .acquire_owned()
+            .await
+            .map_err(|_| AppError::RateLimited(format!("{command} is shutting down")))?;
+        drop(slot);
+
+        Ok((ConcurrencyGuard { _permit: permit }, true))
+    }
+
+    /// The shared first half of both admission styles: age the window and
+    /// enforce the rate cap, then hand back the command's concurrency gate.
+    ///
+    /// Records **nothing** — the window slot is written by [`Self::record_start`]
+    /// only once the call is genuinely admitted, so a *rejected* call never
+    /// consumes a window slot and a hammering loop can't push its own recovery
+    /// time out forever.
+    fn check_rate(
+        &self,
+        command: &'static str,
+        max_requests: usize,
+        max_concurrent: usize,
+        now: Instant,
+    ) -> Result<Arc<Semaphore>, AppError> {
+        let mut map = self.per_command.lock();
+        let state = map.entry(command).or_insert_with(|| CommandState {
+            recent: VecDeque::new(),
+            gate: Arc::new(Semaphore::new(max_concurrent)),
+            max_concurrent,
+            queued: 0,
+        });
+        debug_assert_eq!(
+            state.max_concurrent, max_concurrent,
+            "two call sites disagree about {command}'s concurrency cap"
+        );
+
+        // Age out timestamps older than the window (front = oldest).
+        let cutoff = now.checked_sub(RATE_WINDOW);
+        while let Some(&front) = state.recent.front() {
+            match cutoff {
+                Some(c) if front <= c => {
+                    state.recent.pop_front();
+                }
+                // `now < RATE_WINDOW` since boot: nothing is old enough to evict.
+                _ => break,
+            }
+        }
+
+        if state.recent.len() >= max_requests {
+            return Err(AppError::RateLimited(format!(
+                "Rate limit reached for {command}: max {max_requests} requests per {}s. Try again shortly.",
+                RATE_WINDOW.as_secs()
+            )));
+        }
+
+        Ok(Arc::clone(&state.gate))
+    }
+
+    /// Record an admitted start against the sliding window. Called only after the
+    /// call is committed to running (permit held, or parked with a permit
+    /// guaranteed to arrive).
+    fn record_start(&self, command: &'static str, now: Instant) {
+        if let Some(state) = self.per_command.lock().get_mut(command) {
+            state.recent.push_back(now);
+        }
+    }
+
+    /// How many callers are currently parked waiting for a `command` slot.
+    /// Observability only — the queue ceiling is enforced inside
+    /// [`QueueSlot::enter`] under the same lock, never by reading this first.
+    pub fn queue_depth(&self, command: &'static str) -> usize {
+        self.per_command
+            .lock()
+            .get(command)
+            .map_or(0, |state| state.queued)
     }
 
     /// Charge one accepted request against `provider`'s daily ceiling. Call this

--- a/apps/desktop/src-tauri/src/limits/mod.rs
+++ b/apps/desktop/src-tauri/src/limits/mod.rs
@@ -155,7 +155,9 @@ impl QueueSlot {
         let Some(state) = map.get_mut(command) else {
             // `check_rate` always inserts the entry first, so this is unreachable
             // in practice; treat it as a full queue rather than panicking.
-            return Err(AppError::RateLimited(format!("{command} queue unavailable")));
+            return Err(AppError::RateLimited(format!(
+                "{command} queue unavailable"
+            )));
         };
         if state.queued >= max_queued {
             return Err(AppError::RateLimited(format!(
@@ -213,18 +215,20 @@ impl Limiter {
         max_concurrent: usize,
         now: Instant,
     ) -> Result<ConcurrencyGuard, AppError> {
-        let gate = self.check_rate(command, max_requests, max_concurrent, now)?;
+        let gate = self.admit(command, max_requests, max_concurrent, now)?;
 
-        // Non-blocking: this admission style REJECTS rather than parks. The
-        // window slot is recorded only after the permit is actually taken, so a
-        // rejected call costs nothing.
-        let permit = gate.try_acquire_owned().map_err(|_| {
-            AppError::RateLimited(format!(
-                "Too many concurrent {command} requests (max {max_concurrent}). Try again shortly."
-            ))
-        })?;
-        self.record_start(command, now);
-        Ok(ConcurrencyGuard { _permit: permit })
+        // Non-blocking: this admission style REJECTS rather than parks.
+        match gate.try_acquire_owned() {
+            Ok(permit) => Ok(ConcurrencyGuard { _permit: permit }),
+            Err(_) => {
+                // Give the window slot back — a rejected call must cost nothing,
+                // or a hammering loop pushes its own recovery time out forever.
+                self.undo_admission(command, now);
+                Err(AppError::RateLimited(format!(
+                    "Too many concurrent {command} requests (max {max_concurrent}). Try again shortly."
+                )))
+            }
+        }
     }
 
     /// [`Self::acquire`], but on a full concurrency cap the caller **waits** for a
@@ -260,19 +264,23 @@ impl Limiter {
         on_park: impl FnOnce(usize),
     ) -> Result<(ConcurrencyGuard, bool), AppError> {
         let now = Instant::now();
-        let gate = self.check_rate(command, max_requests, max_concurrent, now)?;
+        let gate = self.admit(command, max_requests, max_concurrent, now)?;
 
         // Fast path: a slot is free right now, so never touch the queue counter
         // and never emit a park signal.
         if let Ok(permit) = Arc::clone(&gate).try_acquire_owned() {
-            self.record_start(command, now);
             return Ok((ConcurrencyGuard { _permit: permit }, false));
         }
 
-        // Full: park, unless the queue itself is at its ceiling (rejected here
-        // costs no window slot, same as any other rejection).
-        let slot = QueueSlot::enter(self, command, max_queued)?;
-        self.record_start(command, now);
+        // Full: park, unless the queue itself is at its ceiling — in which case
+        // give the window slot back, same as any other rejection.
+        let slot = match QueueSlot::enter(self, command, max_queued) {
+            Ok(slot) => slot,
+            Err(e) => {
+                self.undo_admission(command, now);
+                return Err(e);
+            }
+        };
         on_park(slot.ahead);
 
         let permit = gate
@@ -284,14 +292,16 @@ impl Limiter {
         Ok((ConcurrencyGuard { _permit: permit }, true))
     }
 
-    /// The shared first half of both admission styles: age the window and
-    /// enforce the rate cap, then hand back the command's concurrency gate.
+    /// The shared first half of both admission styles: age the window, enforce
+    /// the rate cap, RECORD the start, and hand back the command's concurrency
+    /// gate — all under ONE lock hold.
     ///
-    /// Records **nothing** — the window slot is written by [`Self::record_start`]
-    /// only once the call is genuinely admitted, so a *rejected* call never
-    /// consumes a window slot and a hammering loop can't push its own recovery
-    /// time out forever.
-    fn check_rate(
+    /// Check-and-record must be atomic. Splitting them let two callers both
+    /// observe `recent.len() < max_requests` and then both push, admitting more
+    /// than the cap. The "a rejected call costs no window slot" property is
+    /// preserved instead by [`Self::undo_admission`], which the caller invokes
+    /// when the concurrency or queue admission that follows fails.
+    fn admit(
         &self,
         command: &'static str,
         max_requests: usize,
@@ -329,15 +339,23 @@ impl Limiter {
             )));
         }
 
+        state.recent.push_back(now);
         Ok(Arc::clone(&state.gate))
     }
 
-    /// Record an admitted start against the sliding window. Called only after the
-    /// call is committed to running (permit held, or parked with a permit
-    /// guaranteed to arrive).
-    fn record_start(&self, command: &'static str, now: Instant) {
+    /// Undo one [`Self::admit`] whose caller was then refused a concurrency slot
+    /// or a queue place, so the rejection costs no window slot.
+    ///
+    /// Removes the LAST timestamp equal to `now` rather than popping the back:
+    /// another caller may have been admitted in between, and popping blind would
+    /// refund someone else's slot. Two callers sharing an `Instant` is possible
+    /// but harmless — one entry is removed either way, which is the correct
+    /// accounting.
+    fn undo_admission(&self, command: &'static str, now: Instant) {
         if let Some(state) = self.per_command.lock().get_mut(command) {
-            state.recent.push_back(now);
+            if let Some(pos) = state.recent.iter().rposition(|&t| t == now) {
+                state.recent.remove(pos);
+            }
         }
     }
 

--- a/apps/desktop/src-tauri/src/limits/test.rs
+++ b/apps/desktop/src-tauri/src/limits/test.rs
@@ -94,6 +94,75 @@ fn concurrency_guard_releases_slot_on_drop() {
         .expect("all slots released → acquire succeeds");
 }
 
+/// A call refused by the CONCURRENCY cap must not consume a rate-window slot.
+///
+/// The window check and the window record happen under one lock (they have to:
+/// splitting them let two callers both see room and both take it). The
+/// no-cost-on-rejection property therefore rides on `undo_admission` giving the
+/// slot back — so it gets its own test rather than resting on the old
+/// check-then-reserve shape.
+#[test]
+fn a_concurrency_rejection_refunds_its_rate_window_slot() {
+    let limiter = Arc::new(Limiter::new());
+    let now = std::time::Instant::now();
+    let max_requests = 2;
+    let max_concurrent = 1;
+
+    // Hold the only concurrency slot. One window slot consumed.
+    let _held = limiter
+        .acquire_at(CMD, max_requests, max_concurrent, now)
+        .expect("1st slot");
+
+    // Several calls now bounce off the CONCURRENCY cap. Without the refund each
+    // would also burn a window slot, and the window (cap 2) would be exhausted
+    // after one — locking the command out until the window rolled over.
+    for _ in 0..5 {
+        assert!(
+            limiter
+                .acquire_at(CMD, max_requests, max_concurrent, now)
+                .is_err(),
+            "concurrency is saturated, so every one of these is refused"
+        );
+    }
+
+    // Proof the window still has room: free the concurrency slot and the very
+    // next call must be admitted. It would not be if the refusals had consumed
+    // the window.
+    drop(_held);
+    limiter
+        .acquire_at(CMD, max_requests, max_concurrent, now)
+        .expect("the refused calls must not have consumed the rate window");
+}
+
+/// The QUEUE ceiling is a rejection too, and rejections are free.
+#[tokio::test]
+async fn a_full_queue_rejection_refunds_its_rate_window_slot() {
+    let limiter = Arc::new(Limiter::new());
+    let max_requests = 3;
+
+    let _held = limiter
+        .acquire_queued(CMD, max_requests, 1, 0, |_| ())
+        .await
+        .expect("1st slot");
+
+    // `max_queued = 0`: every further caller is refused at the queue ceiling.
+    for _ in 0..5 {
+        assert!(
+            limiter
+                .acquire_queued(CMD, max_requests, 1, 0, |_| ())
+                .await
+                .is_err(),
+            "queue ceiling is 0, so every one of these is refused"
+        );
+    }
+
+    drop(_held);
+    limiter
+        .acquire_queued(CMD, max_requests, 1, 0, |_| ())
+        .await
+        .expect("queue-ceiling refusals must not have consumed the rate window");
+}
+
 #[test]
 fn provider_daily_ceiling_trips_at_the_cap() {
     let limiter = Arc::new(Limiter::new());
@@ -193,7 +262,9 @@ async fn queued_acquire_rejects_past_the_queue_ceiling() {
         tokio::task::yield_now().await;
     }
 
-    let over = limiter.acquire_queued(CMD, 1000, 1, max_queued, |_| ()).await;
+    let over = limiter
+        .acquire_queued(CMD, 1000, 1, max_queued, |_| ())
+        .await;
     assert!(
         over.is_err(),
         "a caller arriving at a full queue must be rejected, not parked"

--- a/apps/desktop/src-tauri/src/limits/test.rs
+++ b/apps/desktop/src-tauri/src/limits/test.rs
@@ -4,6 +4,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use parking_lot::Mutex;
+
 use super::*;
 
 const CMD: &str = "test.cmd";
@@ -114,6 +116,141 @@ fn provider_daily_ceiling_trips_at_the_cap() {
     limiter
         .charge_provider_daily("anthropic", max_per_day)
         .expect("separate provider has its own daily budget");
+}
+
+// ── acquire_queued: park instead of reject ───────────────────────────────────
+//
+// The behaviour these pin is why `generate_pipeline` uses this path: a user
+// working through imported applications clicks Generate several times in a row,
+// and throwing the 4th click away is worse than making it wait.
+
+#[tokio::test]
+async fn queued_acquire_parks_the_over_cap_caller_until_a_slot_frees() {
+    let limiter = Arc::new(Limiter::new());
+    let max_requests = 1000;
+    let max_concurrent = 1;
+    let max_queued = 10;
+
+    let (first, parked) = limiter
+        .acquire_queued(CMD, max_requests, max_concurrent, max_queued, |_| {
+            panic!("an empty gate must not park")
+        })
+        .await
+        .expect("1st slot is free");
+    assert!(!parked, "the first caller starts immediately");
+
+    // The second caller must PARK, not fail — the whole point of this path.
+    let ahead = Arc::new(Mutex::new(None));
+    let seen = Arc::clone(&ahead);
+    let limiter2 = Arc::clone(&limiter);
+    let waiter = tokio::spawn(async move {
+        limiter2
+            .acquire_queued(CMD, max_requests, max_concurrent, max_queued, |n| {
+                *seen.lock() = Some(n)
+            })
+            .await
+    });
+
+    // It is still parked: it cannot have completed while the only slot is held.
+    tokio::task::yield_now().await;
+    assert!(!waiter.is_finished(), "second caller must still be waiting");
+    assert_eq!(
+        *ahead.lock(),
+        Some(0),
+        "on_park reports 0 callers ahead of it, and fires BEFORE the wait"
+    );
+
+    // Releasing the first guard hands the permit to the waiter.
+    drop(first);
+    let (_second, parked) = waiter
+        .await
+        .expect("waiter task")
+        .expect("a freed slot wakes the parked caller");
+    assert!(parked, "the second caller reports that it waited");
+}
+
+#[tokio::test]
+async fn queued_acquire_rejects_past_the_queue_ceiling() {
+    // The queue must not become the unbounded resource: a looping renderer that
+    // can't be rejected on concurrency has to be rejected on depth.
+    let limiter = Arc::new(Limiter::new());
+    let max_queued = 2;
+
+    let _held = limiter
+        .acquire_queued(CMD, 1000, 1, max_queued, |_| ())
+        .await
+        .expect("1st slot");
+
+    let mut waiters = Vec::new();
+    for _ in 0..max_queued {
+        let l = Arc::clone(&limiter);
+        waiters.push(tokio::spawn(async move {
+            l.acquire_queued(CMD, 1000, 1, max_queued, |_| ()).await
+        }));
+    }
+    // Let both waiters park before testing the ceiling.
+    while limiter.queue_depth(CMD) < max_queued {
+        tokio::task::yield_now().await;
+    }
+
+    let over = limiter.acquire_queued(CMD, 1000, 1, max_queued, |_| ()).await;
+    assert!(
+        over.is_err(),
+        "a caller arriving at a full queue must be rejected, not parked"
+    );
+    assert_eq!(over.err().unwrap().code(), "RATE_LIMITED");
+
+    for w in waiters {
+        w.abort();
+    }
+}
+
+#[tokio::test]
+async fn dropping_a_parked_future_frees_its_queue_slot() {
+    // `.await` is a cancellation point: a user who closes the window or cancels
+    // while queued must not leave the counter high forever, or the queue wedges
+    // shut for the rest of the session.
+    let limiter = Arc::new(Limiter::new());
+    let _held = limiter
+        .acquire_queued(CMD, 1000, 1, 4, |_| ())
+        .await
+        .expect("1st slot");
+
+    {
+        let fut = limiter.acquire_queued(CMD, 1000, 1, 4, |_| ());
+        tokio::pin!(fut);
+        // Poll once so it registers in the queue, then drop it unfinished.
+        tokio::select! {
+            biased;
+            _ = &mut fut => panic!("cannot complete while the only slot is held"),
+            _ = tokio::task::yield_now() => {}
+        }
+        assert_eq!(limiter.queue_depth(CMD), 1, "the parked caller is counted");
+    }
+
+    assert_eq!(
+        limiter.queue_depth(CMD),
+        0,
+        "dropping the future released its queue slot"
+    );
+}
+
+#[tokio::test]
+async fn queued_and_rejecting_acquires_share_one_concurrency_budget() {
+    // `ai_generate` (rejecting) and `generate_pipeline` (queueing) name the same
+    // command key on purpose. Two independent mechanisms would mean two budgets
+    // — which is exactly the bug that let 7 streams run against a cap of 3.
+    let limiter = Arc::new(Limiter::new());
+
+    let _queued_holder = limiter
+        .acquire_queued(CMD, 1000, 1, 4, |_| ())
+        .await
+        .expect("queued path takes the only slot");
+
+    assert!(
+        limiter.acquire(CMD, 1000, 1).is_err(),
+        "the rejecting path must see the slot the queueing path took"
+    );
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/observability.rs
+++ b/apps/desktop/src-tauri/src/observability.rs
@@ -36,14 +36,19 @@ impl Span {
     }
 
     /// End the span: logs `[target] ← fields duration=<n>ms ok=<ok>`.
+    ///
+    /// `ok=false` logs at WARN, not INFO. A failed span is the single most
+    /// useful line in a support bundle and it used to be indistinguishable from
+    /// a successful one at a glance: one 27,601-line bundle carried exactly ONE
+    /// `[ERROR]` line while eight silently-failed provider calls sat at INFO.
     pub fn end(&self, ok: bool) {
-        log::info!(
+        self.log_end(&format!(
             "[{}] ← {} duration={}ms ok={}",
             self.target,
             self.fields,
             self.start.elapsed().as_millis(),
             ok
-        );
+        ), ok);
     }
 
     /// End with trailing fields rendered before `duration` (e.g. `status=200`,
@@ -52,14 +57,24 @@ impl Span {
         if extra.is_empty() {
             return self.end(ok);
         }
-        log::info!(
+        self.log_end(&format!(
             "[{}] ← {} {} duration={}ms ok={}",
             self.target,
             self.fields,
             extra,
             self.start.elapsed().as_millis(),
             ok
-        );
+        ), ok);
+    }
+
+    /// The one place a span's terminal line is emitted, so the success/failure
+    /// level split can never drift between [`Self::end`] and [`Self::end_with`].
+    fn log_end(&self, line: &str, ok: bool) {
+        if ok {
+            log::info!("{line}");
+        } else {
+            log::warn!("{line}");
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/observability.rs
+++ b/apps/desktop/src-tauri/src/observability.rs
@@ -42,13 +42,16 @@ impl Span {
     /// a successful one at a glance: one 27,601-line bundle carried exactly ONE
     /// `[ERROR]` line while eight silently-failed provider calls sat at INFO.
     pub fn end(&self, ok: bool) {
-        self.log_end(&format!(
-            "[{}] ← {} duration={}ms ok={}",
-            self.target,
-            self.fields,
-            self.start.elapsed().as_millis(),
-            ok
-        ), ok);
+        self.log_end(
+            &format!(
+                "[{}] ← {} duration={}ms ok={}",
+                self.target,
+                self.fields,
+                self.start.elapsed().as_millis(),
+                ok
+            ),
+            ok,
+        );
     }
 
     /// End with trailing fields rendered before `duration` (e.g. `status=200`,
@@ -57,14 +60,17 @@ impl Span {
         if extra.is_empty() {
             return self.end(ok);
         }
-        self.log_end(&format!(
-            "[{}] ← {} {} duration={}ms ok={}",
-            self.target,
-            self.fields,
-            extra,
-            self.start.elapsed().as_millis(),
-            ok
-        ), ok);
+        self.log_end(
+            &format!(
+                "[{}] ← {} {} duration={}ms ok={}",
+                self.target,
+                self.fields,
+                extra,
+                self.start.elapsed().as_millis(),
+                ok
+            ),
+            ok,
+        );
     }
 
     /// The one place a span's terminal line is emitted, so the success/failure

--- a/apps/desktop/src-tauri/src/salary_research/mod.rs
+++ b/apps/desktop/src-tauri/src/salary_research/mod.rs
@@ -23,9 +23,6 @@ use crate::pipeline::Completer;
 
 const CACHE_NS: &str = "salary_range";
 const TTL_SECS: i64 = 7 * 24 * 3600;
-/// Hard cap on a single research call so generation never stalls on a slow or
-/// hung provider search. Same bound as `CompanyResearch::RESEARCH_TIMEOUT_SECS`.
-const RESEARCH_TIMEOUT_SECS: u64 = 25;
 /// Sanity ceiling on an annual salary figure, in any currency's minor-unit-free
 /// face value — comfortably above any real annual salary, so a wildly
 /// hallucinated figure is rejected rather than reaching the prompt.
@@ -117,6 +114,12 @@ impl SalaryResearch {
     /// (`commands::ai::ai_lookup_salary`) resolves it once via
     /// `app.try_state::<KvCache>()` and passes it through, which is what keeps
     /// this function testable without an `AppHandle`.
+    ///
+    /// `deadline` is injected for the same reason `cache` is — see
+    /// [`CompanyResearch::enrich_with`](crate::cover_letter::research::CompanyResearch::enrich_with).
+    /// The L3 caller derives it from the request's reasoning effort via
+    /// `timeouts::research_deadline`; a FLAT bound was the bug, since synthesis
+    /// is a model call and costs whatever the chosen model's reasoning costs.
     #[allow(clippy::too_many_arguments)]
     pub async fn enrich<S: SalarySearcher>(
         &self,
@@ -127,6 +130,7 @@ impl SalaryResearch {
         location: &str,
         country: &str,
         currency: &str,
+        deadline: Duration,
     ) -> Option<SalaryRange> {
         // The very first thing this does — before touching `searcher` at all —
         // so a whitespace-only role never reaches it. Factored to a pure
@@ -181,7 +185,7 @@ impl SalaryResearch {
         // Provider-native research, bounded so generation never stalls. Any
         // failure/timeout yields no range.
         let raw = match tokio::time::timeout(
-            Duration::from_secs(RESEARCH_TIMEOUT_SECS),
+            deadline,
             searcher.research_salary(&role, &company, &location, &country, &currency),
         )
         .await
@@ -192,7 +196,11 @@ impl SalaryResearch {
                 return None;
             }
             Err(_) => {
-                tracing::warn!("salary_research: timed out for {role}");
+                tracing::warn!(
+                    role = %role,
+                    deadline_secs = deadline.as_secs(),
+                    "salary_research: timed out"
+                );
                 return None;
             }
         };
@@ -315,6 +323,9 @@ fn extract_json_object(text: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
+    /// The bound every test injects into `enrich`. Arbitrary — production
+    /// derives its own from the request's reasoning effort.
+    const TEST_DEADLINE: Duration = Duration::from_secs(25);
     use tempfile::TempDir;
 
     use super::*;
@@ -569,10 +580,11 @@ mod tests {
             _country: &str,
             _currency: &str,
         ) -> AppResult<String> {
-            // Sleeps past RESEARCH_TIMEOUT_SECS; under `start_paused = true` this
-            // resolves the moment `enrich`'s own timeout timer fires instead of
-            // actually blocking the test for 25+ real seconds.
-            tokio::time::sleep(Duration::from_secs(RESEARCH_TIMEOUT_SECS + 5)).await;
+            // Outsleeps TEST_DEADLINE; under `start_paused = true` this resolves
+            // the moment `enrich`'s own timer fires rather than blocking for
+            // real. Derived from the same constant the call sites pass, so
+            // changing it can never silently turn this test into a no-op.
+            tokio::time::sleep(TEST_DEADLINE + Duration::from_secs(5)).await;
             Ok(r#"{"min":1,"max":2,"currency":"USD"}"#.to_string())
         }
     }
@@ -592,6 +604,7 @@ mod tests {
                 "Berlin",
                 "",
                 "",
+                TEST_DEADLINE,
             )
             .await;
 
@@ -625,6 +638,7 @@ mod tests {
                 "Berlin",
                 "",
                 "",
+                TEST_DEADLINE,
             )
             .await;
 
@@ -648,6 +662,7 @@ mod tests {
                 "Berlin",
                 "",
                 "",
+                TEST_DEADLINE,
             )
             .await;
 
@@ -670,6 +685,7 @@ mod tests {
                 "Berlin",
                 "",
                 "",
+                TEST_DEADLINE,
             )
             .await;
 
@@ -692,6 +708,7 @@ mod tests {
                 "Berlin",
                 "",
                 "",
+                TEST_DEADLINE,
             )
             .await;
 
@@ -761,6 +778,7 @@ mod tests {
                 "Berlin",
                 "DE",
                 "EUR",
+                TEST_DEADLINE,
             )
             .await;
 
@@ -795,6 +813,7 @@ mod tests {
                 "Berlin",
                 "DE",
                 "EUR",
+                TEST_DEADLINE,
             )
             .await;
 
@@ -832,6 +851,7 @@ mod tests {
                 "Berlin",
                 "DE",
                 "EUR",
+                TEST_DEADLINE,
             )
             .await;
 
@@ -855,6 +875,7 @@ mod tests {
                 "",
                 "",
                 "",
+                TEST_DEADLINE,
             )
             .await;
 

--- a/apps/desktop/src/log-bridge.test.ts
+++ b/apps/desktop/src/log-bridge.test.ts
@@ -18,7 +18,7 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: unknown[]) => invoke(...args),
 }));
 
-import { installConsoleLogBridge } from './log-bridge';
+import { installConsoleLogBridge, resetLogBridgeState, shouldForward } from './log-bridge';
 
 describe('installConsoleLogBridge', () => {
   const original = { warn: console.warn, error: console.error };
@@ -106,5 +106,56 @@ describe('installConsoleLogBridge', () => {
     // Let the rejected forward promise's microtask settle — a missing `.catch`
     // in the bridge would surface as an unhandled rejection here.
     await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+});
+
+describe('stale-callback suppression', () => {
+  const original = { warn: console.warn };
+
+  beforeEach(() => {
+    invoke.mockReset().mockResolvedValue(undefined);
+    resetLogBridgeState();
+  });
+
+  afterEach(() => {
+    console.warn = original.warn;
+  });
+
+  // Tauri's runtime warns once per event dispatched to a stale callback id —
+  // one warning PER STREAMED DELTA, from Tauri internals, so there is no call
+  // site to fix. A real support bundle was 27,178 of 27,601 lines (98.5%) this
+  // single message, from two ids, burying eight genuinely-failed provider calls.
+  const STALE =
+    "[TAURI] Couldn't find callback id 220837889. This might happen when the app is reloaded " +
+    'while Rust is running an asynchronous operation.';
+
+  it('forwards the first occurrence — the condition is still worth knowing about', () => {
+    expect(shouldForward(STALE)).toBe(true);
+  });
+
+  it('drops every occurrence after the first, including a different id', () => {
+    expect(shouldForward(STALE)).toBe(true);
+    expect(shouldForward(STALE)).toBe(false);
+    expect(shouldForward(STALE.replace('220837889', '2830120250'))).toBe(false);
+  });
+
+  it('never suppresses an ordinary app warning', () => {
+    expect(shouldForward('[runTailor] failed {"error":"rate limit"}')).toBe(true);
+    expect(shouldForward('[runTailor] failed {"error":"rate limit"}')).toBe(true);
+    // Not even once the stale-callback notice has latched.
+    shouldForward(STALE);
+    expect(shouldForward('[export] done')).toBe(true);
+  });
+
+  it('keeps the suppressed message in devtools — only the IPC copy is dropped', () => {
+    const spy = vi.fn();
+    console.warn = spy;
+    installConsoleLogBridge();
+
+    console.warn(STALE);
+    console.warn(STALE);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/log-bridge.ts
+++ b/apps/desktop/src/log-bridge.ts
@@ -44,6 +44,45 @@ function forward(level: Level, message: string): Promise<void> {
   return invoke('plugin:log|log', { level: PLUGIN_LEVEL[level], message });
 }
 
+/**
+ * Console output that must never reach the log file.
+ *
+ * Tauri's own JS runtime `console.warn`s once per event dispatched to a callback
+ * id it can no longer find. That is one warning PER STREAMED DELTA, and it is
+ * emitted from Tauri internals, so there is no call site to fix. In a real
+ * support bundle it produced **27,178 of 27,601 lines — 98.5% of the file** from
+ * just two stale ids, burying the eight genuinely-failed provider calls in the
+ * same session.
+ *
+ * Dropped HERE rather than in `tauri_plugin_log`'s `filter` because that filter
+ * only receives `log::Metadata` (level + target), never the message body — and
+ * dropping it renderer-side also saves an IPC round-trip per streamed token,
+ * which is the part that actually costs something.
+ *
+ * Kept deliberately narrow: an exact substring of Tauri's own message, not a
+ * pattern that could swallow app warnings. The condition it signals (a listener
+ * outliving its registration) is worth knowing about, so the first occurrence
+ * per session is still forwarded — see `shouldForward`.
+ */
+const TAURI_STALE_CALLBACK = "Couldn't find callback id";
+
+/** Whether the stale-callback notice has already been forwarded this session. */
+let staleCallbackReported = false;
+
+/** Pure: whether `message` should cross the IPC boundary into the log file.
+ *  Exported for tests — this is the whole of the suppression policy. */
+export function shouldForward(message: string): boolean {
+  if (!message.includes(TAURI_STALE_CALLBACK)) return true;
+  if (staleCallbackReported) return false;
+  staleCallbackReported = true;
+  return true;
+}
+
+/** Test-only: reset the once-per-session latch. */
+export function resetLogBridgeState(): void {
+  staleCallbackReported = false;
+}
+
 function stringifyArg(arg: unknown): string {
   if (arg instanceof Error) return `${arg.name}: ${arg.message}`;
   if (typeof arg === 'string') return arg;
@@ -58,9 +97,13 @@ function bridgeLevel(level: Level): void {
   const original = console[level].bind(console);
   console[level] = (...args: unknown[]) => {
     original(...args);
+    const message = args.map(stringifyArg).join(' ');
+    // devtools still shows everything (`original` above ran unconditionally) —
+    // only the file/IPC copy is suppressed.
+    if (!shouldForward(message)) return;
     // Best-effort: a forwarding failure (e.g. IPC not ready yet) must never
     // break the console itself.
-    void forward(level, args.map(stringifyArg).join(' ')).catch(() => {});
+    void forward(level, message).catch(() => {});
   };
 }
 

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GeneratingPanel.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GeneratingPanel.test.tsx
@@ -173,6 +173,32 @@ describe('GeneratingPanel — reasoning-heavy hint', () => {
     expect(screen.getByText('autopilot.apply.generatingHint')).toBeInTheDocument();
   });
 
+  it('pins both thresholds exactly', () => {
+    // 8,000 chars and a 5:1 ratio are the two numbers the behaviour rests on.
+    // Without boundary cases either could be widened away silently.
+    const hint = () => screen.queryByText('autopilot.apply.reasoningHeavyHint');
+
+    // Just under the floor → no hint, even at an enormous ratio.
+    const { unmount } = render(
+      <GeneratingPanel {...makeProps({ thinking: 'x'.repeat(7_999), output: '' })} />
+    );
+    expect(hint()).not.toBeInTheDocument();
+    unmount();
+
+    // At the floor but exactly AT the ratio (not above it) → no hint.
+    const second = render(
+      <GeneratingPanel {...makeProps({ thinking: 'x'.repeat(8_000), output: 'y'.repeat(1_600) })} />
+    );
+    expect(hint()).not.toBeInTheDocument();
+    second.unmount();
+
+    // At the floor and one char past the ratio → hint.
+    render(
+      <GeneratingPanel {...makeProps({ thinking: 'x'.repeat(8_001), output: 'y'.repeat(1_600) })} />
+    );
+    expect(hint()).toBeInTheDocument();
+  });
+
   it('does not fire on a short burst of reasoning', () => {
     // Under the floor: early in ANY reasoning run the ratio is briefly huge
     // (thinking streams before the document does), and flashing the hint for a

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GeneratingPanel.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GeneratingPanel.test.tsx
@@ -141,3 +141,43 @@ describe('GeneratingPanel — content rendering', () => {
     expect(screen.getByRole('button', { name: /autopilot\.apply\.cancel/i })).toBeInTheDocument();
   });
 });
+
+describe('GeneratingPanel — reasoning-heavy hint', () => {
+  // A reasoning model logged 1,039,821 chars of reasoning against 45,416 of
+  // answer and took 8–13 minutes per document, where a non-reasoning model did
+  // the same work in 12–23 seconds. The panel showed the same "this can take a
+  // moment" the whole time, so the run was indistinguishable from a hang.
+
+  it('keeps the normal hint on an ordinary run', () => {
+    render(<GeneratingPanel {...makeProps({ thinking: 'brief thought', output: 'Dear team,' })} />);
+    expect(screen.getByText('autopilot.apply.generatingHint')).toBeInTheDocument();
+  });
+
+  it('switches to the reasoning-heavy hint when reasoning dwarfs the document', () => {
+    render(
+      <GeneratingPanel {...makeProps({ thinking: 'x'.repeat(20_000), output: 'Dear team,' })} />
+    );
+    expect(screen.getByText('autopilot.apply.reasoningHeavyHint')).toBeInTheDocument();
+    expect(screen.queryByText('autopilot.apply.generatingHint')).not.toBeInTheDocument();
+  });
+
+  it('does not fire on a long run whose OUTPUT kept pace', () => {
+    // Both large: the model is producing a document, not just thinking. The
+    // ratio is the signal, not the absolute size — otherwise every long
+    // generation would show a warning that means nothing.
+    render(
+      <GeneratingPanel
+        {...makeProps({ thinking: 'x'.repeat(20_000), output: 'y'.repeat(20_000) })}
+      />
+    );
+    expect(screen.getByText('autopilot.apply.generatingHint')).toBeInTheDocument();
+  });
+
+  it('does not fire on a short burst of reasoning', () => {
+    // Under the floor: early in ANY reasoning run the ratio is briefly huge
+    // (thinking streams before the document does), and flashing the hint for a
+    // second on every run would train the user to ignore it.
+    render(<GeneratingPanel {...makeProps({ thinking: 'x'.repeat(2_000), output: '' })} />);
+    expect(screen.getByText('autopilot.apply.generatingHint')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/GeneratingPanel.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/GeneratingPanel.tsx
@@ -17,6 +17,21 @@ interface Props {
 }
 
 /**
+ * When the live reasoning stream has this many characters AND dwarfs the
+ * document by this ratio, the run is reasoning-heavy — a real gpt-oss:20b
+ * session logged 1,039,821 chars of reasoning against 45,416 of answer (22.9:1)
+ * and took 8–13 minutes per document, where a non-reasoning model did the same
+ * work in 12–23 SECONDS. The floor keeps the hint off short, normal runs.
+ *
+ * ponytail: measured live rather than from a per-model table — a table would go
+ * stale with every model release, and the ratio is the thing that matters
+ * anyway. Upgrade path if this needs to be known BEFORE a run starts: persist
+ * thinking tokens alongside `output_tokens` in the spend store.
+ */
+const REASONING_HEAVY_MIN_CHARS = 8_000;
+const REASONING_HEAVY_RATIO = 5;
+
+/**
  * Streaming stage: a hero icon + dot progress bar (analyze → resume/cover) + the
  * live phase caption, the model's reasoning bubble, and the streaming document
  * text. While output is empty the live region shows skeleton bars so the area
@@ -28,6 +43,12 @@ interface Props {
  */
 export function GeneratingPanel({ target, phase, phaseLabel, thinking, output, onCancel }: Props) {
   const { t } = useTranslation();
+
+  // "Is it stuck?" is the question a multi-minute silent run provokes, and the
+  // honest answer is visible right here in the stream.
+  const reasoningHeavy =
+    thinking.length >= REASONING_HEAVY_MIN_CHARS &&
+    thinking.length > output.length * REASONING_HEAVY_RATIO;
 
   const totalSteps = target === 'both' ? 3 : 2;
   const currentStep =
@@ -47,7 +68,11 @@ export function GeneratingPanel({ target, phase, phaseLabel, thinking, output, o
         <IconBadge icon={Wand2} size="lg" shape="circle" className="animate-pulse" />
         <StepDots currentStep={currentStep} totalSteps={totalSteps} className="mb-2 mt-4" />
         <p className="text-[11px] font-medium text-brand-soft">{phaseLabel}</p>
-        <p className="mt-1 text-[11px] text-foreground/40">{t('autopilot.apply.generatingHint')}</p>
+        <p className="mt-1 text-[11px] text-foreground/40">
+          {reasoningHeavy
+            ? t('autopilot.apply.reasoningHeavyHint')
+            : t('autopilot.apply.generatingHint')}
+        </p>
       </div>
 
       <div className="mx-auto mt-5 flex w-full max-w-2xl min-h-0 flex-1 flex-col overflow-y-auto">

--- a/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.ts
+++ b/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.ts
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react';
 
+import { useTranslation } from '@ajh/translations';
+
 import type { ActivityItem, JobRecord } from '@/features/monitoring/types';
 import { fetchJob, useJobEvents } from '@/services';
 
@@ -18,6 +20,7 @@ interface JobEvent {
 }
 
 export function useActivityFeed(allJobs: JobRecord[], kindLabelMap: Record<string, string>) {
+  const { t } = useTranslation();
   const [liveActivity, setLiveActivity] = useState<ActivityItem[]>([]);
   const [clearedBefore, setClearedBefore] = useState<number>(0);
 
@@ -104,8 +107,8 @@ export function useActivityFeed(allJobs: JobRecord[], kindLabelMap: Record<strin
         const suffix =
           event.type === 'job.queued' && typeof ahead === 'number'
             ? ahead > 0
-              ? ` (queued, ${ahead} ahead)`
-              : ' (queued)'
+              ? ` (${t('monitoring.activity.queuedWithCount', { count: ahead })})`
+              : ` (${t('monitoring.activity.queued')})`
             : '';
         setLiveActivity((prev) =>
           [

--- a/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.ts
+++ b/apps/desktop/src/renderer/features/monitoring/hooks/useActivityFeed.ts
@@ -82,7 +82,11 @@ export function useActivityFeed(allJobs: JobRecord[], kindLabelMap: Record<strin
             ? 'amber'
             : 'blue';
 
-      if (['job.completed', 'job.failed', 'job.cancelled', 'job.started'].includes(event.type)) {
+      if (
+        ['job.completed', 'job.failed', 'job.cancelled', 'job.started', 'job.queued'].includes(
+          event.type
+        )
+      ) {
         const verb =
           event.type === 'job.completed'
             ? '✓'
@@ -90,13 +94,25 @@ export function useActivityFeed(allJobs: JobRecord[], kindLabelMap: Record<strin
               ? '✕'
               : event.type === 'job.cancelled'
                 ? '⊘'
-                : '▸';
+                : event.type === 'job.queued'
+                  ? '⏸'
+                  : '▸';
+        // `job.queued` only ever fires when the job actually parked behind the
+        // concurrency limiter, and carries how many are ahead of it — without
+        // that number a batch of generations looks identical to one hung run.
+        const ahead = (event.data as { ahead?: number } | undefined)?.ahead;
+        const suffix =
+          event.type === 'job.queued' && typeof ahead === 'number'
+            ? ahead > 0
+              ? ` (queued, ${ahead} ahead)`
+              : ' (queued)'
+            : '';
         setLiveActivity((prev) =>
           [
             {
               id: `${event.jobId}-${event.ts}`,
               time: event.ts,
-              text: `${verb} ${kindLabel}`,
+              text: `${verb} ${kindLabel}${suffix}`,
               tone,
             },
             ...prev,

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -801,6 +801,11 @@ export async function researchCompany(jobAd: string, company?: string): Promise<
       // The AI-extracted company name is far more reliable than the backend's
       // heuristic job-ad scan (which can grab a tagline), so send it when known.
       company: company?.trim() || undefined,
+      // Same effort the generation request carries — the backend's deadline
+      // around search + synthesis scales with it. Without this a reasoning model
+      // never finishes research inside the flat bound, and the cover letter is
+      // written with no company knowledge and no visible failure.
+      effort: resolveActiveProvider().providerSettings?.effort,
     });
     return res?.brief ?? '';
   } catch {
@@ -863,6 +868,7 @@ export async function lookupSalaryRange(
       location: location.trim() || undefined,
       country: country?.trim() || undefined,
       currency: currency?.trim() || undefined,
+      effort: resolveActiveProvider().providerSettings?.effort,
     });
     return res ?? undefined;
   } catch {

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -51,6 +51,7 @@ import {
   resolveMarket,
   type RewriteDocType,
   type SalaryRange,
+  sanitizeCompanyName,
   validateMetadata,
 } from '@ajh/prompts/generate';
 import type { ContactProfile, GitHubRepo } from '@ajh/shared';
@@ -191,17 +192,32 @@ export async function extractMetadata(
         mismatch: clientSideDetection.mismatch,
       };
     }
-  } catch {
-    /* fall through */
+    console.warn('[extractMetadata] model returned unparseable JSON — using heuristics', {
+      model,
+      rawLength: raw.length,
+    });
+  } catch (err) {
+    // Never silent: the heuristics below are materially worse than the model,
+    // and a run that quietly took this path produced cover letters addressed to
+    // a job-ad heading. Which path ran has to be visible in the log.
+    console.warn('[extractMetadata] extraction failed — using heuristics', {
+      model,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 
   const nameMatch = resume.match(/^([A-Z][a-z]+ [A-Z][a-z]+(?:\s[A-Z][a-z]+)?)/m);
-  const titleMatch = jobAd.match(/(?:position|role|title|job)[:\s]+([^\n]+)/i);
-  const companyMatch = jobAd.match(/(?:at|@|company|employer|firm)[:\s]+([^\n,]+)/i);
+  // `\b` on every word alternative. Without it `at` matched inside "Wh(at) You'll
+  // Do" / "gre(at) experience" / Dutch "d(at) je zelf", and `job` inside "jobs",
+  // so the capture ran from mid-word to the next comma or newline.
+  const titleMatch = jobAd.match(/\b(?:position|role|title|job)[:\s]+([^\n]+)/i);
+  const companyMatch = jobAd.match(/(?:\b(?:at|company|employer|firm)|@)[:\s]+([^\n,]+)/i);
   return {
     candidateName: nameMatch?.[1] ?? '',
     jobTitle: titleMatch?.[1]?.trim() ?? '',
-    companyName: companyMatch?.[1]?.trim() ?? '',
+    // Same gate the model's own output goes through — this regex is the WORSE
+    // of the two sources, so it certainly does not get to skip validation.
+    companyName: sanitizeCompanyName(companyMatch?.[1]),
     resumeLanguage: clientSideDetection.resumeName,
     jobAdLanguage: clientSideDetection.jobAdName,
     mismatch: clientSideDetection.mismatch,

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -52,6 +52,7 @@ import {
   type RewriteDocType,
   type SalaryRange,
   sanitizeCompanyName,
+  sanitizeJobTitle,
   validateMetadata,
 } from '@ajh/prompts/generate';
 import type { ContactProfile, GitHubRepo } from '@ajh/shared';
@@ -214,7 +215,8 @@ export async function extractMetadata(
   const companyMatch = jobAd.match(/(?:\b(?:at|company|employer|firm)|@)[:\s]+([^\n,]+)/i);
   return {
     candidateName: nameMatch?.[1] ?? '',
-    jobTitle: titleMatch?.[1]?.trim() ?? '',
+    // Same gate as the model's own output — this regex is the worse source.
+    jobTitle: sanitizeJobTitle(titleMatch?.[1]),
     // Same gate the model's own output goes through — this regex is the WORSE
     // of the two sources, so it certainly does not get to skip validation.
     companyName: sanitizeCompanyName(companyMatch?.[1]),

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -792,7 +792,11 @@ export async function synthesizeResume(
  * the cover letter still generates. The returned brief is untrusted reference
  * text — the prompt fences it.
  */
-export async function researchCompany(jobAd: string, company?: string): Promise<string> {
+export async function researchCompany(
+  jobAd: string,
+  company?: string,
+  role?: string
+): Promise<string> {
   try {
     // Routing (provider/model/base_url) is backend-owned (task #16) — the enricher
     // reads the active provider from the store, so nothing is threaded here.
@@ -801,6 +805,9 @@ export async function researchCompany(jobAd: string, company?: string): Promise<
       // The AI-extracted company name is far more reliable than the backend's
       // heuristic job-ad scan (which can grab a tagline), so send it when known.
       company: company?.trim() || undefined,
+      // Same reasoning as `company`: the backend's heuristic falls back to the
+      // ad's first short line, which on a scraped page is an apply button.
+      role: role?.trim() || undefined,
       // Same effort the generation request carries — the backend's deadline
       // around search + synthesis scales with it. Without this a reasoning model
       // never finishes research inside the flat bound, and the cover letter is
@@ -899,7 +906,9 @@ export async function generateCoverLetter(
   const profile = buildProviderProfile(model);
 
   // Opt-in: fetch a company brief and fold it into the prompt's fit paragraph.
-  const companyBrief = opts?.researchCompany ? await researchCompany(jobAd, meta.companyName) : '';
+  const companyBrief = opts?.researchCompany
+    ? await researchCompany(jobAd, meta.companyName, meta.jobTitle)
+    : '';
 
   // Resolve the cover-letter market from the job's country (decision: job
   // location, not ad language) with an optional manual override; the letter is

--- a/apps/desktop/src/renderer/lib/generate/stream-promise.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/stream-promise.test.ts
@@ -124,6 +124,68 @@ describe('awaitAiStream — poll fallback', () => {
   });
 });
 
+describe('awaitAiStream — a queued job does not burn its stream deadline', () => {
+  /** `jobs.get` reports `queued` for the first `queuedPolls` calls, then
+   *  `completed` — the backend shape while a generation is parked behind the
+   *  `ai_generate` concurrency limiter and then finally runs. */
+  function makeQueuedApi(queuedPolls: number, persisted: string) {
+    let calls = 0;
+    return {
+      ai: { onStream: () => () => {} },
+      jobs: {
+        get: vi.fn().mockImplementation(() => {
+          calls += 1;
+          return Promise.resolve(
+            calls <= queuedPolls
+              ? { status: 'queued' }
+              : { status: 'completed', result: { done: true, text: persisted } }
+          );
+        }),
+        cancel: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as AppClient;
+  }
+
+  it('re-arms the timeout while queued, so a wait longer than the deadline still succeeds', async () => {
+    // `timeoutMs` bounds the STREAM, not the wait for a slot. Six generations
+    // fired in a minute meant later ones sat parked for minutes; without
+    // re-arming they would reject on a deadline they never had a chance to
+    // beat, having never sent a request. 5 polls at 4ms with a 10ms deadline is
+    // 20ms of queueing — twice the deadline.
+    const api = makeQueuedApi(5, 'the generation that eventually ran');
+
+    await expect(
+      awaitAiStream(api, 'job-queued', { pollIntervalMs: 4, timeoutMs: 10 })
+    ).resolves.toBe('the generation that eventually ran');
+  });
+
+  it('reports the queued state to the caller while parked', async () => {
+    const onQueued = vi.fn();
+    const api = makeQueuedApi(2, 'done at last');
+
+    await awaitAiStream(api, 'job-queued-cb', { pollIntervalMs: 1, timeoutMs: 5_000, onQueued });
+
+    expect(onQueued).toHaveBeenCalled();
+  });
+
+  it('does NOT re-arm once the job leaves the queue', async () => {
+    // The re-arm must be scoped to `queued` only — a job that reports `running`
+    // forever is genuinely stuck and must still hit its deadline, or the
+    // timeout stops protecting anything.
+    const api = {
+      ai: { onStream: () => () => {} },
+      jobs: {
+        get: vi.fn().mockResolvedValue({ status: 'running' }),
+        cancel: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as AppClient;
+
+    await expect(
+      awaitAiStream(api, 'job-stuck', { pollIntervalMs: 1, timeoutMs: 20 })
+    ).rejects.toThrow('Generation timed out. Please try again.');
+  });
+});
+
 describe('awaitAiStream — empty completion rejects (both resolve paths)', () => {
   // The generation pipeline treated ANY resolve as success, including an empty
   // one — an empty document was then silently persisted and shown with no

--- a/apps/desktop/src/renderer/lib/generate/stream-promise.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/stream-promise.test.ts
@@ -150,12 +150,16 @@ describe('awaitAiStream — a queued job does not burn its stream deadline', () 
     // `timeoutMs` bounds the STREAM, not the wait for a slot. Six generations
     // fired in a minute meant later ones sat parked for minutes; without
     // re-arming they would reject on a deadline they never had a chance to
-    // beat, having never sent a request. 5 polls at 4ms with a 10ms deadline is
-    // 20ms of queueing — twice the deadline.
-    const api = makeQueuedApi(5, 'the generation that eventually ran');
+    // beat, having never sent a request.
+    //
+    // These use REAL timers, so the margins are deliberately generous: 6 polls
+    // at 25ms is ~150ms of queueing against a 60ms deadline. Still 2.5x the
+    // deadline (so the re-arm is genuinely proven) but with enough slack that a
+    // single event-loop stall on a loaded CI runner cannot flip the result.
+    const api = makeQueuedApi(6, 'the generation that eventually ran');
 
     await expect(
-      awaitAiStream(api, 'job-queued', { pollIntervalMs: 4, timeoutMs: 10 })
+      awaitAiStream(api, 'job-queued', { pollIntervalMs: 25, timeoutMs: 60 })
     ).resolves.toBe('the generation that eventually ran');
   });
 
@@ -181,7 +185,7 @@ describe('awaitAiStream — a queued job does not burn its stream deadline', () 
     } as unknown as AppClient;
 
     await expect(
-      awaitAiStream(api, 'job-stuck', { pollIntervalMs: 1, timeoutMs: 20 })
+      awaitAiStream(api, 'job-stuck', { pollIntervalMs: 5, timeoutMs: 60 })
     ).rejects.toThrow('Generation timed out. Please try again.');
   });
 });

--- a/apps/desktop/src/renderer/lib/generate/stream-promise.ts
+++ b/apps/desktop/src/renderer/lib/generate/stream-promise.ts
@@ -72,6 +72,11 @@ export interface AwaitAiStreamOptions {
   onToken?: (tok: string) => void;
   /** Called with each reasoning/thinking token. */
   onThinking?: (tok: string) => void;
+  /** Called on every poll where the backend job is still parked behind the
+   *  concurrency limiter, so the UI can say "queued" instead of showing a
+   *  generation that appears to be running but has sent no request. Fires
+   *  repeatedly while queued — callers should treat it as a state, not an event. */
+  onQueued?: () => void;
   /** AbortSignal — honours both pre-registration and post-registration cancels. */
   signal?: AbortSignal;
   /** Override the poll interval (ms). Defaults to `JOB_POLL_INTERVAL_MS`. */
@@ -113,6 +118,7 @@ export function awaitAiStream(
   const {
     onToken,
     onThinking,
+    onQueued,
     signal,
     pollIntervalMs = JOB_POLL_INTERVAL_MS,
     timeoutMs = computeStreamTimeoutMs(opts.effort),
@@ -211,13 +217,17 @@ export function awaitAiStream(
     // timeout we FAIL the run (never persist truncated output as success) and
     // cancel the backend job so the server-side slot is freed instead of left
     // occupied until the job finishes on its own.
-    timeoutId = setTimeout(() => {
-      off();
-      void api.jobs.cancel(jobId).catch(() => {});
-      splitter.flush();
-      cleanup();
-      reject(new Error('Generation timed out. Please try again.'));
-    }, timeoutMs);
+    const armTimeout = () => {
+      if (timeoutId !== null) clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        off();
+        void api.jobs.cancel(jobId).catch(() => {});
+        splitter.flush();
+        cleanup();
+        reject(new Error('Generation timed out. Please try again.'));
+      }, timeoutMs);
+    };
+    armTimeout();
 
     // Job-status poll — fallback for a missed `done` event (empty final delta).
     poll = setInterval(() => {
@@ -229,6 +239,16 @@ export function awaitAiStream(
           result?: { text: string };
         } | null;
         if (!job) return;
+        if (job.status === 'queued') {
+          // Parked behind the backend concurrency limiter — it has not issued a
+          // request yet, so `timeoutMs` (a STREAM deadline) must not be counting
+          // down. Re-arming each poll keeps a full deadline available from the
+          // moment the job actually starts. Without this a queued generation in
+          // a batch fails on a timeout it never had a chance to beat.
+          armTimeout();
+          onQueued?.();
+          return;
+        }
         if (job.status === 'failed' || job.status === 'cancelled') {
           off();
           cleanup();

--- a/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
+++ b/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
@@ -34,20 +34,32 @@ export const ai = {
       providers: Record<string, { model?: string; baseUrl?: string }>;
     };
   }) => invoke('ai_seed_active_config', { config }),
-  researchCompany: ({ jobAd, company }: { jobAd: string; company?: string }) =>
-    invoke('ai_research_company', { jobAd, company }),
+  // `effort` on both research calls: the backend's deadline around
+  // search + synthesis scales with it, the same way the generation stream
+  // deadline does. Omitting it leaves the unscaled baseline.
+  researchCompany: ({
+    jobAd,
+    company,
+    effort,
+  }: {
+    jobAd: string;
+    company?: string;
+    effort?: string;
+  }) => invoke('ai_research_company', { jobAd, company, effort }),
   lookupSalary: ({
     role,
     company,
     location,
     country,
     currency,
+    effort,
   }: {
     role: string;
     company?: string;
     location?: string;
     country?: string;
     currency?: string;
+    effort?: string;
   }) =>
     invoke('ai_lookup_salary', {
       role,
@@ -55,6 +67,7 @@ export const ai = {
       location,
       country,
       currency,
+      effort,
     }),
   researchAnswer: ({
     question,

--- a/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
+++ b/apps/desktop/src/tauri-client/namespaces/ai/ai.ts
@@ -40,12 +40,14 @@ export const ai = {
   researchCompany: ({
     jobAd,
     company,
+    role,
     effort,
   }: {
     jobAd: string;
     company?: string;
+    role?: string;
     effort?: string;
-  }) => invoke('ai_research_company', { jobAd, company, effort }),
+  }) => invoke('ai_research_company', { jobAd, company, role, effort }),
   lookupSalary: ({
     role,
     company,

--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -2283,13 +2283,45 @@ describe('sanitizeJobTitle', () => {
     expect(sanitizeJobTitle(input)).toBe('');
   });
 
+  it.each(['Senior Backend Engineer', 'Staff Software Engineer, Payments Platform'])(
+    'keeps %j',
+    (input) => {
+      expect(sanitizeJobTitle(input)).toBe(input);
+    }
+  );
+
+  // The band the first version of these tests missed entirely, which is why the
+  // bug survived them: `sanitizeJobTitle` applied its 80-char check on TOP of
+  // the company's 60-char one, so the larger ceiling was dead code and the
+  // 6-word company cap rejected any 7-word title. Every case below sits in
+  // 61-80 chars and/or 7-10 words — none of the original cases did.
   it.each([
-    'Senior Backend Engineer',
-    'Staff Software Engineer, Payments Platform',
-    // Longer than a company name is allowed to be — titles legitimately are.
-    'Senior Staff Software Engineer, Platform Infrastructure',
-  ])('keeps %j', (input) => {
-    expect(sanitizeJobTitle(input)).toBe(input);
+    ['Senior Staff Software Engineer for Platform Infrastructure Group', 64, 9],
+    ['Senior Staff Software Engineer Platform Infrastructure Lead', 59, 8],
+    ['Principal Engineer, Developer Experience and Build Infrastructure', 65, 8],
+  ])('keeps the longer/wordier real title %j (%i chars, %i words)', (input) => {
+    expect(sanitizeJobTitle(input as string)).toBe(input);
+  });
+
+  it('pins the title caps exactly, and that they differ from the company caps', () => {
+    // 80/10 for a title...
+    expect(sanitizeJobTitle('A'.repeat(80))).toBe('A'.repeat(80));
+    expect(sanitizeJobTitle('A'.repeat(81))).toBe('');
+    const tenWords = 'Aa Bb Cc Dd Ee Ff Gg Hh Ii Jj';
+    expect(sanitizeJobTitle(tenWords)).toBe(tenWords);
+    expect(sanitizeJobTitle(`${tenWords} Kk`)).toBe('');
+
+    // ...but 60/6 for a company. If these two ever collapse back onto one set of
+    // limits, the larger ceiling silently becomes dead code again.
+    expect(sanitizeCompanyName('A'.repeat(80))).toBe('');
+    expect(sanitizeCompanyName(tenWords)).toBe('');
+  });
+
+  it('still applies every SHAPE rule to a title, not just the size caps', () => {
+    // The looser limits must not loosen the actual gate.
+    expect(sanitizeJobTitle("What You'll Do")).toBe('');
+    expect(sanitizeJobTitle('**Senior Engineer**')).toBe('');
+    expect(sanitizeJobTitle('about us')).toBe('');
   });
 });
 

--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -28,6 +28,7 @@ import {
   MODES,
   parseLinksFromResume,
   resumeMentions,
+  sanitizeCompanyName,
   urlToFriendlyLabel,
   validateMetadata,
 } from './index';
@@ -2197,7 +2198,76 @@ describe('extractPlainText', () => {
   });
 });
 
+describe('sanitizeCompanyName', () => {
+  // Every string below was pulled verbatim from a real support bundle
+  // (ajh-diagnostics-2026-08-08). Six consecutive generations researched — and
+  // then addressed a cover letter to — one of these instead of the employer.
+  it.each([
+    ["You'll Do", 'the "What You\'ll Do" heading, matched by an unbounded `at`'],
+    ['experience **fast', 'a mid-sentence fragment from "great experience **fast'],
+    [
+      "the core of their product. You'll sit at the intersection of design",
+      'a full sentence spanning a sentence break',
+    ],
+    [
+      'a **bootstrapped AI platform and consulting studio** based in Munich',
+      'markdown-bolded ad copy',
+    ],
+    ['je zelf prettig vindt werken', 'a Dutch fragment matched inside "dat je zelf"'],
+    ['Please note: Fluent Dutch language skills are required for this role.', 'a prose caveat'],
+    ['[← Alle offenen Stellen](/karriere)', 'a markdown nav link'],
+    ['Jetzt bewerben', 'an apply-button label'],
+    ['About Us', 'a section heading'],
+  ])('rejects %j (%s)', (input) => {
+    expect(sanitizeCompanyName(input)).toBe('');
+  });
+
+  // The gate is worthless if it eats real employers. Each of these appeared in
+  // the same bundle as a CORRECTLY extracted company.
+  it.each([
+    'Codefield',
+    'Charité',
+    'Charité – Universitätsmedizin Berlin',
+    'Münz Media',
+    'MLP praxero GmbH',
+    'CHECK24 Vergleichsportal für Versicherungen GmbH',
+    'Redcare Pharmacy',
+    'Holland Casino',
+    'Sensys Gatso',
+    'IntegrityNext',
+    'Acme Corp',
+    // Lowercase-initial brands and possessives must survive the fragment and
+    // contraction tests respectively.
+    'eBay',
+    'iRobot',
+    'xAI',
+    "Macy's",
+    "L'Oréal",
+    // A trailing period is an abbreviation, not a sentence end.
+    'Acme Inc.',
+    'St. Jude Medical',
+  ])('keeps %j', (input) => {
+    expect(sanitizeCompanyName(input)).toBe(input);
+  });
+
+  it('trims surrounding whitespace and rejects non-strings', () => {
+    expect(sanitizeCompanyName('  Codefield  ')).toBe('Codefield');
+    expect(sanitizeCompanyName('')).toBe('');
+    expect(sanitizeCompanyName(undefined)).toBe('');
+    expect(sanitizeCompanyName(null)).toBe('');
+    expect(sanitizeCompanyName(42)).toBe('');
+  });
+});
+
 describe('validateMetadata', () => {
+  it('gates the company name the model itself returns', () => {
+    // The model — not just the regex fallback — is a source of these. Passing
+    // `parsed.companyName ?? ''` straight through is what let "You'll Do" reach
+    // company research.
+    expect(validateMetadata('{"companyName":"You\'ll Do"}')?.companyName).toBe('');
+    expect(validateMetadata('{"companyName":"Codefield"}')?.companyName).toBe('Codefield');
+  });
+
   it('parses well-formed JSON and applies defaults', () => {
     const meta = validateMetadata('{"candidateName":"Jane","jobTitle":"Dev","jobAdLanguage":"de"}');
     expect(meta?.candidateName).toBe('Jane');

--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -29,6 +29,7 @@ import {
   parseLinksFromResume,
   resumeMentions,
   sanitizeCompanyName,
+  sanitizeJobTitle,
   urlToFriendlyLabel,
   validateMetadata,
 } from './index';
@@ -2250,6 +2251,16 @@ describe('sanitizeCompanyName', () => {
     expect(sanitizeCompanyName(input)).toBe(input);
   });
 
+  it('pins the 60-character and 6-word caps', () => {
+    // Both caps carry real rejection load — the word cap is what rejects
+    // 'Please note: Fluent Dutch…'. Without a boundary test, widening or
+    // deleting either stays green.
+    expect(sanitizeCompanyName('A'.repeat(60))).toBe('A'.repeat(60));
+    expect(sanitizeCompanyName('A'.repeat(61))).toBe('');
+    expect(sanitizeCompanyName('Aa Bb Cc Dd Ee Ff')).toBe('Aa Bb Cc Dd Ee Ff'); // 6 words
+    expect(sanitizeCompanyName('Aa Bb Cc Dd Ee Ff Gg')).toBe(''); // 7 words
+  });
+
   it('trims surrounding whitespace and rejects non-strings', () => {
     expect(sanitizeCompanyName('  Codefield  ')).toBe('Codefield');
     expect(sanitizeCompanyName('')).toBe('');
@@ -2259,7 +2270,37 @@ describe('sanitizeCompanyName', () => {
   });
 });
 
+describe('sanitizeJobTitle', () => {
+  // The title is the OTHER half of the subject a provider web search runs on,
+  // so gating only the company left the identical hole open for it — a reported
+  // session searched for role="Jetzt bewerben".
+  it.each([
+    'Jetzt bewerben',
+    '[← Alle offenen Stellen](/karriere)',
+    'Please note: Fluent Dutch language skills are required for this role.',
+    'A'.repeat(81),
+  ])('rejects %j', (input) => {
+    expect(sanitizeJobTitle(input)).toBe('');
+  });
+
+  it.each([
+    'Senior Backend Engineer',
+    'Staff Software Engineer, Payments Platform',
+    // Longer than a company name is allowed to be — titles legitimately are.
+    'Senior Staff Software Engineer, Platform Infrastructure',
+  ])('keeps %j', (input) => {
+    expect(sanitizeJobTitle(input)).toBe(input);
+  });
+});
+
 describe('validateMetadata', () => {
+  it('gates the job title the model itself returns', () => {
+    expect(validateMetadata('{"jobTitle":"Jetzt bewerben"}')?.jobTitle).toBe('');
+    expect(validateMetadata('{"jobTitle":"Senior Backend Engineer"}')?.jobTitle).toBe(
+      'Senior Backend Engineer'
+    );
+  });
+
   it('gates the company name the model itself returns', () => {
     // The model — not just the regex fallback — is a source of these. Passing
     // `parsed.companyName ?? ''` straight through is what let "You'll Do" reach

--- a/packages/prompts/src/generate/metadata/metadata.ts
+++ b/packages/prompts/src/generate/metadata/metadata.ts
@@ -62,6 +62,82 @@ function isBlank(v: unknown): boolean {
   return typeof v !== 'string' || v.trim() === '';
 }
 
+/** Job-ad section headings that a naive extractor (LLM or regex) returns as if
+ *  they were the employer. Normalized to lowercase with apostrophes stripped so
+ *  `You'll Do` / `You´ll Do` / `you ll do` all match one entry. */
+const HEADING_DENYLIST = new Set([
+  'about us',
+  'about the company',
+  'about the role',
+  'apply now',
+  'benefits',
+  'jetzt bewerben',
+  'job description',
+  'our company',
+  'requirements',
+  'responsibilities',
+  'the company',
+  'the position',
+  'the role',
+  'what you ll do',
+  'who we are',
+  'you ll do',
+  'your role',
+  'your tasks',
+]);
+
+/**
+ * Reject a "company name" that is obviously a sentence, a heading, or markup
+ * rather than an employer — returning `''`, which every downstream consumer
+ * already treats as "no company known" (`CompanyResearch::enrich_with` skips
+ * research entirely on an empty name).
+ *
+ * This runs on BOTH sources of the field: the model's own JSON and the regex
+ * fallback in `extractMetadata`. Neither is trustworthy — a 2026-08-08 support
+ * bundle had six consecutive generations research `You'll Do`,
+ * `experience **fast`, and `a **bootstrapped AI platform and consulting
+ * studio** based in Munich`, each of which then anchored a cover letter.
+ *
+ * Deliberately conservative: it only rejects shapes a real employer name cannot
+ * have. Lowercase-initial brands (`eBay`, `iRobot`, `xAI`) and possessives
+ * (`Macy's`, `L'Oréal`) survive; the leading-lowercase test requires a
+ * lowercase SECOND character too, and the contraction test matches only
+ * pronoun contractions.
+ */
+export function sanitizeCompanyName(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const name = value.trim();
+  if (!name) return '';
+
+  // A real employer name is short. The longest legitimate one seen in the wild
+  // ("CHECK24 Vergleichsportal für Versicherungen GmbH") is 48 chars / 5 words.
+  if (name.length > 60) return '';
+  if (name.split(/\s+/).length > 6) return '';
+
+  // Markdown, links, and code fences — the ad's formatting leaked through.
+  if (/[*`_]{2}|\[|\]\(|https?:\/\//.test(name)) return '';
+
+  // Prose, not a name. A trailing `.` is NOT disqualifying — "Acme Inc." is a
+  // real name — but `!?:;` are, and so is an interior sentence break. The
+  // `\w{3,}` before that break is what keeps abbreviations ("St. Jude Medical",
+  // "A.P. Moller") from tripping it.
+  if (/[!?:;]$/.test(name) || /\w{3,}[.!?][\s"']/.test(name)) return '';
+
+  // Pronoun contractions only ever appear in ad copy ("What You'll Do",
+  // "…their product. You'll sit at…"), never in a company name.
+  if (/\b(?:you|we|they|i)['’](?:ll|re|ve|d|m)\b/i.test(name)) return '';
+
+  // Mid-sentence fragment: starts lowercase AND continues lowercase.
+  if (/^\p{Ll}\p{Ll}/u.test(name)) return '';
+  // A single lowercase word ("experience", "je") is a fragment too.
+  if (/^\p{Ll}(?:\s|$)/u.test(name)) return '';
+
+  const normalized = name.toLowerCase().replace(/['’´]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (HEADING_DENYLIST.has(normalized)) return '';
+
+  return name;
+}
+
 export function validateMetadata(raw: string): GenerationMeta | null {
   try {
     const jsonStr = raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1);
@@ -73,7 +149,10 @@ export function validateMetadata(raw: string): GenerationMeta | null {
     return {
       candidateName: parsed.candidateName ?? '',
       jobTitle: parsed.jobTitle ?? '',
-      companyName: parsed.companyName ?? '',
+      // Gated, not trusted: the model returns an ad heading ("You'll Do") as the
+      // employer often enough that an ungated value reaches company research and
+      // the cover letter's opening line.
+      companyName: sanitizeCompanyName(parsed.companyName),
       resumeLanguage,
       jobAdLanguage,
       // Only a mismatch when BOTH sides are known and actually differ. Without

--- a/packages/prompts/src/generate/metadata/metadata.ts
+++ b/packages/prompts/src/generate/metadata/metadata.ts
@@ -105,6 +105,20 @@ const HEADING_DENYLIST = new Set([
  * pronoun contractions.
  */
 export function sanitizeCompanyName(value: unknown): string {
+  return sanitizeSubject(value);
+}
+
+/**
+ * The shared gate behind [`sanitizeCompanyName`] and [`sanitizeJobTitle`].
+ *
+ * Both fields end up as the SUBJECT of a provider web search and as prose in the
+ * cover letter's opening, so both fail the same way: a heading or a sentence
+ * there produces a confident brief about the wrong thing. Gating only the
+ * company left the identical hole open for the title — a reported session
+ * searched for `Jetzt bewerben` and `[← Alle offenen Stellen](/karriere)` as the
+ * ROLE while the company was already being gated.
+ */
+function sanitizeSubject(value: unknown): string {
   if (typeof value !== 'string') return '';
   const name = value.trim();
   if (!name) return '';
@@ -138,6 +152,17 @@ export function sanitizeCompanyName(value: unknown): string {
   return name;
 }
 
+/**
+ * A job title, gated exactly like the company name — see [`sanitizeSubject`].
+ * Slightly more permissive on length: titles are legitimately longer than
+ * company names ("Senior Staff Software Engineer, Payments Platform").
+ */
+export function sanitizeJobTitle(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  if (value.trim().length > 80) return '';
+  return sanitizeSubject(value);
+}
+
 export function validateMetadata(raw: string): GenerationMeta | null {
   try {
     const jsonStr = raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1);
@@ -148,7 +173,9 @@ export function validateMetadata(raw: string): GenerationMeta | null {
     const jobAdLanguage = toLanguage(parsed.jobAdLanguage);
     return {
       candidateName: parsed.candidateName ?? '',
-      jobTitle: parsed.jobTitle ?? '',
+      // Gated for the same reason `companyName` is: it is the other half of the
+      // subject a provider web search runs on.
+      jobTitle: sanitizeJobTitle(parsed.jobTitle),
       // Gated, not trusted: the model returns an ad heading ("You'll Do") as the
       // employer often enough that an ungated value reaches company research and
       // the cover letter's opening line.

--- a/packages/prompts/src/generate/metadata/metadata.ts
+++ b/packages/prompts/src/generate/metadata/metadata.ts
@@ -105,7 +105,15 @@ const HEADING_DENYLIST = new Set([
  * pronoun contractions.
  */
 export function sanitizeCompanyName(value: unknown): string {
-  return sanitizeSubject(value);
+  // A real employer name is short. The longest legitimate one seen in the wild
+  // ("CHECK24 Vergleichsportal für Versicherungen GmbH") is 48 chars / 5 words.
+  return sanitizeSubject(value, { maxChars: 60, maxWords: 6 });
+}
+
+/** Size limits for one [`sanitizeSubject`] caller. */
+interface SubjectLimits {
+  maxChars: number;
+  maxWords: number;
 }
 
 /**
@@ -117,16 +125,18 @@ export function sanitizeCompanyName(value: unknown): string {
  * company left the identical hole open for the title — a reported session
  * searched for `Jetzt bewerben` and `[← Alle offenen Stellen](/karriere)` as the
  * ROLE while the company was already being gated.
+ *
+ * The size limits are per-caller because the two fields genuinely differ: an
+ * employer name is short, a job title routinely is not. They were briefly shared
+ * and it made the title's own (larger) ceiling dead code.
  */
-function sanitizeSubject(value: unknown): string {
+function sanitizeSubject(value: unknown, limits: SubjectLimits): string {
   if (typeof value !== 'string') return '';
   const name = value.trim();
   if (!name) return '';
 
-  // A real employer name is short. The longest legitimate one seen in the wild
-  // ("CHECK24 Vergleichsportal für Versicherungen GmbH") is 48 chars / 5 words.
-  if (name.length > 60) return '';
-  if (name.split(/\s+/).length > 6) return '';
+  if (name.length > limits.maxChars) return '';
+  if (name.split(/\s+/).length > limits.maxWords) return '';
 
   // Markdown, links, and code fences — the ad's formatting leaked through.
   if (/[*`_]{2}|\[|\]\(|https?:\/\//.test(name)) return '';
@@ -153,14 +163,18 @@ function sanitizeSubject(value: unknown): string {
 }
 
 /**
- * A job title, gated exactly like the company name — see [`sanitizeSubject`].
- * Slightly more permissive on length: titles are legitimately longer than
- * company names ("Senior Staff Software Engineer, Payments Platform").
+ * A job title, gated on the same SHAPE rules as the company name but with its
+ * own size limits — see [`sanitizeSubject`].
+ *
+ * Titles are legitimately longer and wordier than employer names ("Senior Staff
+ * Software Engineer, Platform Infrastructure and Developer Experience" is 68
+ * chars / 9 words), so they get 80 chars / 10 words rather than 60 / 6. An
+ * earlier version applied its 80-char check on top of the company's 60-char one,
+ * which made the larger ceiling dead: everything over 60 was still dropped, and
+ * the 6-word company cap rejected any 7-word title.
  */
 export function sanitizeJobTitle(value: unknown): string {
-  if (typeof value !== 'string') return '';
-  if (value.trim().length > 80) return '';
-  return sanitizeSubject(value);
+  return sanitizeSubject(value, { maxChars: 80, maxWords: 10 });
 }
 
 export function validateMetadata(raw: string): GenerationMeta | null {

--- a/packages/shared/src/ipc/contracts/ai.ts
+++ b/packages/shared/src/ipc/contracts/ai.ts
@@ -89,6 +89,11 @@ export interface AiContract {
     jobAd: string;
     /** Accurate AI-extracted company name; preferred over heuristic job-ad extraction. */
     company?: string;
+    /** The SAME reasoning-effort value a generation request carries. Sizes the
+     *  backend's deadline around search + synthesis — synthesis is a model call,
+     *  so its cost scales with the model's reasoning budget. Omit for the
+     *  unscaled baseline. */
+    effort?: string;
   }): Promise<{ company: string; brief: string }>;
 
   /**
@@ -112,6 +117,8 @@ export interface AiContract {
      *  hallucinate one; omitted when the country is unknown, which preserves
      *  today's unconstrained "local currency for that location" behavior. */
     currency?: string;
+    /** See `researchCompany.effort` — the same deadline scaling applies here. */
+    effort?: string;
   }): Promise<SalaryRange | null>;
 
   /**

--- a/packages/shared/src/ipc/contracts/ai.ts
+++ b/packages/shared/src/ipc/contracts/ai.ts
@@ -89,6 +89,10 @@ export interface AiContract {
     jobAd: string;
     /** Accurate AI-extracted company name; preferred over heuristic job-ad extraction. */
     company?: string;
+    /** Accurate AI-extracted job title; preferred over heuristic job-ad
+     *  extraction, whose last resort is the ad's first short line — on a scraped
+     *  page routinely an apply button ("Jetzt bewerben") or a nav link. */
+    role?: string;
     /** The SAME reasoning-effort value a generation request carries. Sizes the
      *  backend's deadline around search + synthesis — synthesis is a model call,
      *  so its cost scales with the model's reasoning budget. Omit for the

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -428,6 +428,10 @@
       "matchResume": "Lebenslauf-Match",
       "autopilotRun": "Autopilot-Lauf"
     },
+    "activity": {
+      "queued": "in Warteschlange",
+      "queuedWithCount": "in Warteschlange, {{count}} davor"
+    },
     "jobKindsShort": {
       "aiGenerate": "KI",
       "aiEmbed": "Embed",

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -1467,6 +1467,7 @@
       "generate": "Generieren",
       "generating": "Generiere…",
       "generatingHint": "Das kann einen Moment dauern – wir passen an die Stellenanzeige an.",
+      "reasoningHeavyHint": "Dieses Modell wendet weit mehr für internes Nachdenken auf als für das Dokument. Rechne mit mehreren Minuten – es arbeitet, es hängt nicht.",
       "cancel": "Abbrechen",
       "analyzing": "Stellenbeschreibung wird analysiert…",
       "writingResume": "Lebenslauf wird geschrieben…",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -1463,6 +1463,7 @@
       "generate": "Generate",
       "generating": "Generating…",
       "generatingHint": "This can take a moment — tailoring against the job posting.",
+      "reasoningHeavyHint": "This model is spending far more on internal reasoning than on the document. Expect several minutes — it is working, not stuck.",
       "cancel": "Cancel",
       "analyzing": "Analyzing job description…",
       "writingResume": "Writing resume…",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -428,6 +428,10 @@
       "matchResume": "Resume match",
       "autopilotRun": "Autopilot run"
     },
+    "activity": {
+      "queued": "queued",
+      "queuedWithCount": "queued, {{count}} ahead"
+    },
     "jobKindsShort": {
       "aiGenerate": "AI",
       "aiEmbed": "Embed",


### PR DESCRIPTION
Everything here comes from one support bundle (`ajh-diagnostics-2026-08-08`, app 0.134.3): six applications imported, six résumé + cover-letter generations fired within 62 seconds on `ollama-cloud` / `gpt-oss:20b`.

## What the log actually showed

| run | started  | outcome                                    |
| --- | -------- | ------------------------------------------ |
| 1   | 19:56:14 | done — 8m37s                               |
| 2   | 19:56:32 | **failed — HTTP 429 after 8m55s**          |
| 3   | 19:56:43 | done — 11m28s                              |
| 4   | 19:56:51 | done — 13m14s                              |
| 5   | 19:57:09 | done — 12m44s                              |
| 6   | 19:57:16 | done — 11m40s                              |

**Peak 7 concurrent AI streams** against a documented cap of 3. The same workload on `gemma4:31b` earlier that day took 12–23 _seconds_ per run; `gpt-oss:20b` emitted 1,039,821 chars of reasoning against 45,416 of answer (22.9:1).

Worse than the one visible failure: **all six cover letters were written for a nonsense company** (`You'll Do` ×3, `experience **fast`, `the core of their product. You'll sit at the intersection of design`, `a **bootstrapped AI platform and consulting studio** based in Munich`) and **all six had zero company research**. None of it surfaced — the 27,601-line log contained exactly one `ERROR`, and 27,178 lines were a single repeated Tauri warning.

## Commits

| commit     | what                                                                                                                                                                                                                                                              |
| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `ac8e0205` | Company name: the fallback regex alternated on a bare `at` with no word boundary, matching inside "Wh**at** You'll Do". `sanitizeCompanyName` now gates both the model's JSON and the regex; the bare `catch {}` that hid which ran is a warn.                       |
| `5074e14e` | **The concurrency cap was enforced on `ai_generate`, which the tailoring flow doesn't call.** `generate_pipeline` acquired nothing — no rate window, no slot, no daily charge. Now takes a slot via a new `acquire_queued` that waits rather than rejects, on the same semaphore. The renderer re-arms its deadline while queued. |
| `fc5863a0` | Research was bounded by a flat 25s around search **and** synthesis — a cap on how much reasoning the model was allowed. Now scales by effort off the same table `stream_deadline` uses. `salary_research` had the identical copy.                                    |
| `ece8d890` | Failed spans logged at INFO; `[ai] →`/`←` had nothing to pair them; 98.5% of the bundle was Tauri's stale-callback warning (one per streamed delta).                                                                                                                |
| `f34bf4c9` | Every HTTP 400 was `qwen3-embedding:8b` on `/api/chat`. `reachable_chat_model` returned `/api/tags`'s first entry — it was a health probe reused as "give me a chat model".                                                                                          |
| `80ace1b5` | A stream's initial 429 was never retried, on the reasoning that "a mid-stream restart duplicates deltas" — but the status arrives before any delta.                                                                                                                 |
| `75e07dc7` | Role extraction searched for `Jetzt bewerben` and `[← Alle offenen Stellen](/karriere)`. Also fixes the Rust twin of the `at` bug.                                                                                                                                  |
| `dd727531` | 1,932 rejected handshakes × 2 log lines each; `crashes.log` entries truncated mid-backtrace.                                                                                                                                                                        |
| `b41de019` | A reasoning-heavy run now says so instead of looking hung.                                                                                                                                                                                                         |

## Verified

`cargo test --all-features` (3265) · `cargo clippy --all-features --all-targets` clean · all 18 architecture rules · `pnpm typecheck` · `pnpm lint:strict --max-warnings 0` · `pnpm test` (5014).

Every guard added here is mutation-tested — neutering `QueueSlot::drop`, leaking a permit, dropping the timeout re-arm, removing the chat-model filter, removing the log suppression, and removing the ratio check each fail a test.

## Not fixed, deliberately

- The `cannot move state from Destroyed` panic is third-party teardown I could not reproduce; a speculative guard would be worse than the next real backtrace, which is now capturable.
- The extension's ~10s reconnect is correct behaviour — browsers don't expose a failed WS handshake's HTTP status, so it genuinely cannot tell "refused" from "not running". Only the logging changed.

## Review notes

- `commands/ai.rs` and `ai_provider/mod.rs` were both at the R8 LOC cap, so this extracts `admit_research` (the ~40-line preamble three research commands repeated verbatim) and moves `RequestTrace` to its own module. Both are pure extractions.
- The architecture test caught an L2→L3 import in my first attempt at the research deadline; it's now injected by the L3 caller, matching how `SalaryResearch::enrich` already takes its cache.
- Pushed with `--no-verify` at the author's request, so the pre-push AI review gate did not run; the checks listed above were run manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI research and salary lookups now adapt time limits to reasoning effort.
  * Long-running AI tasks show queue status and position while waiting.
  * Added clearer guidance when document generation involves extensive reasoning.
  * Local Ollama setups now select chat-capable models more reliably.

* **Bug Fixes**
  * Improved recovery from temporary AI provider and streaming connection failures.
  * Improved company and role extraction by filtering invalid or navigation text.
  * Reduced duplicate warning messages while preserving useful diagnostics.
  * Translation failures now provide clearer warnings while retaining the original text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->