### PR TITLE
test(pipeline): phase 5 — the offline eval harness

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -107,6 +107,11 @@ jobs:
               - 'apps/desktop/*.{json,ts,html}'
               - 'apps/landing/**'
               - 'packages/**'
+              # The repo's build/release/dev scripts and their `*.test.mjs`
+              # siblings are a vitest PROJECT (scripts/vitest.config.ts) in the
+              # root suite — a scripts-only change must run it, or those tests
+              # only ever execute on a PR that happens to touch something else.
+              - 'scripts/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'tsconfig*.json'

--- a/apps/desktop/src-tauri/src/pipeline/runs/mod.rs
+++ b/apps/desktop/src-tauri/src/pipeline/runs/mod.rs
@@ -41,6 +41,14 @@
 //! `commands::privacy`), and position-indexed APPEND-ONLY migrations. Tauri-free
 //! (L2, same posture as [`crate::pipeline::cache`]) — the shell resolves it from
 //! managed state and calls in.
+//!
+//! **One reader lives outside this crate.** `scripts/dump-run-metrics.mjs` opens
+//! `pipeline_runs.db` read-only and aggregates `metrics_json` per `depth` for
+//! offline depth A/B (it never touches `pipeline_run_events`, whose
+//! `artifact_json` carries the strategy/evidence detail). It hard-codes this
+//! table's column names and the metrics keys written by
+//! `commands::resume_pipeline::execute`, so renaming either is a change to it as
+//! well — its own tests will fail, but only if `scripts/**` is in the PR.
 
 use std::path::Path;
 

--- a/apps/desktop/src-tauri/src/pipeline/runs/mod.rs
+++ b/apps/desktop/src-tauri/src/pipeline/runs/mod.rs
@@ -16,7 +16,7 @@
 //!   import (see [`ARTIFACT_CAP_BYTES`]/[`METRICS_CAP_BYTES`]) — a truncated
 //!   summary still tells the truth about a run;
 //! * `phase` is a closed vocabulary enforced by a schema CHECK (see
-//!   [`CREATE_PIPELINE_RUNS_SQL`]), which holds on both paths;
+//!   `CREATE_PIPELINE_RUNS_SQL`), which holds on both paths;
 //! * every identity/text column (id, job_url, kind, depth, status,
 //!   stopped_reason, stage) is REJECTED past its byte cap on import — see
 //!   [`check_run`] — because truncating an identity does not shorten it, it
@@ -48,7 +48,7 @@
 //! `artifact_json` carries the strategy/evidence detail).
 //!
 //! That mirror is MACHINE-CHECKED, not a hand copy: `dump-run-metrics.test.mjs`
-//! reads [`CREATE_PIPELINE_RUNS_SQL`] out of THIS FILE to build its fixture, and
+//! reads `CREATE_PIPELINE_RUNS_SQL` out of THIS FILE to build its fixture, and
 //! extracts the `metrics_json` keys out of `RunLedger::metrics` and
 //! `commands::resume_pipeline::execute` to check that every key the dump reads is
 //! still written. So renaming a column, that const, or a metrics key fails the JS

--- a/apps/desktop/src-tauri/src/pipeline/runs/mod.rs
+++ b/apps/desktop/src-tauri/src/pipeline/runs/mod.rs
@@ -45,10 +45,15 @@
 //! **One reader lives outside this crate.** `scripts/dump-run-metrics.mjs` opens
 //! `pipeline_runs.db` read-only and aggregates `metrics_json` per `depth` for
 //! offline depth A/B (it never touches `pipeline_run_events`, whose
-//! `artifact_json` carries the strategy/evidence detail). It hard-codes this
-//! table's column names and the metrics keys written by
-//! `commands::resume_pipeline::execute`, so renaming either is a change to it as
-//! well — its own tests will fail, but only if `scripts/**` is in the PR.
+//! `artifact_json` carries the strategy/evidence detail).
+//!
+//! That mirror is MACHINE-CHECKED, not a hand copy: `dump-run-metrics.test.mjs`
+//! reads [`CREATE_PIPELINE_RUNS_SQL`] out of THIS FILE to build its fixture, and
+//! extracts the `metrics_json` keys out of `RunLedger::metrics` and
+//! `commands::resume_pipeline::execute` to check that every key the dump reads is
+//! still written. So renaming a column, that const, or a metrics key fails the JS
+//! suite — which the `rust` path filter runs, since `pnpm test:coverage` covers
+//! the whole workspace including the `scripts` project.
 
 use std::path::Path;
 

--- a/apps/desktop/src-tauri/tests/architecture.rs
+++ b/apps/desktop/src-tauri/tests/architecture.rs
@@ -3,9 +3,12 @@
 //! Derived from the June 2026 architecture discovery analysis (in git history) and codified in
 //! `docs/architecture-rules.md` (the layer model + rule IDs R1–R8). This is a
 //! **standalone integration test**: it uses only `std` and scans the source tree
-//! under `CARGO_MANIFEST_DIR/src` as text — it does not link the crate's internals
-//! (same pattern as `tests/eval.rs`). The crate is a thin binary (`main.rs`) over a
-//! library (`lib.rs`, which holds the app + the Tauri builder); both are L3 shell.
+//! under `CARGO_MANIFEST_DIR/src` as TEXT, deliberately without linking the crate —
+//! a rule about which module may import which cannot be checked from inside a
+//! build that has already resolved those imports. (`tests/eval.rs` does the
+//! opposite and links `ajh_tauri`, because it runs the validators.) The crate is a
+//! thin binary (`main.rs`) over a library (`lib.rs`, which holds the app + the
+//! Tauri builder); both are L3 shell.
 //!
 //! Each rule has an explicit allowlist of *current* exceptions so the suite is green
 //! today while blocking **new** violations (drift prevention). Allowlists are debt,

--- a/apps/desktop/src-tauri/tests/eval.rs
+++ b/apps/desktop/src-tauri/tests/eval.rs
@@ -81,7 +81,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use ajh_tauri::validate::content::{
-    severity_for, validate_content, ContentInput, ContentReport, DocKind,
+    severity_for, validate_content, ContentInput, ContentReport, DocKind, CONTENT_ISSUE_CODES,
 };
 use ajh_tauri::validate::Severity;
 
@@ -323,9 +323,15 @@ const CASES: &[Case] = &[
 ///
 /// Findings, not codes: one unit here is one line a user is shown about a
 /// document that is fine. The per-code table counts each code once per fixture
-/// — right for "which check over-fires", wrong for a budget, since one code can
-/// fire a dozen times in one document (the AI-tells letter carries 16 warnings
-/// from 2 codes).
+/// — right for "which check over-fires", wrong for a budget, because one code
+/// can fire many times in one document.
+///
+/// That skew is not hypothetical, though the fixture that demonstrates it is
+/// NOT in this budget: the AI-tells letter turns 2 codes into 16 findings, and
+/// it is `Planted`, so it never reaches `warning_fps`. It is the existence
+/// proof that a code-count and a finding-count differ by an order of magnitude
+/// on real output — which is why the budget counts the one a user would see, in
+/// advance of a truthful fixture ever exhibiting it.
 ///
 /// Zero today, and that is a measurement rather than an aspiration: the whole
 /// truthful set comes back completely clean. It is a BUDGET rather than a
@@ -333,6 +339,16 @@ const CASES: &[Case] = &[
 /// and it is asserted so the headline number in the printed table is a guard
 /// instead of a comment.
 const WARNING_FP_BUDGET: usize = 0;
+
+/// How many of the truthful fixtures the UNIT suite already pins to a completely
+/// empty report — the two `*_generated_clean.txt`, one test each
+/// (`clean_resume_produces_no_issues_at_all`,
+/// `clean_german_resume_produces_no_issues_at_all`).
+///
+/// Pinned as a number because the caveat line is computed by substring: without
+/// this, renaming or relabelling a clean fixture would silently shrink the
+/// caveat and make [`WARNING_FP_BUDGET`] read as a stronger result than it is.
+const EXPECTED_PINNED_EMPTY: usize = 2;
 
 /// The posting requirements each language's job ad is analysed into — the same
 /// lists `validate::content::test` passes, so alignment findings here mean what
@@ -429,13 +445,16 @@ fn severity_label(code: &str) -> &'static str {
 fn gradeable_fixture_files() -> BTreeSet<String> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURES_SUBDIR);
     fs::read_dir(&dir)
-        .unwrap_or_else(|e| panic!("read {dir:?}: {e}"))
+        // Repo-relative in the message, never `dir`: that is built from
+        // `CARGO_MANIFEST_DIR`, so printing it puts the developer's home
+        // directory (or the CI workspace root) in the failure output.
+        .unwrap_or_else(|e| panic!("read {FIXTURES_SUBDIR}: {e}"))
         .map(|entry| {
             // NOT `entry.ok()?`: an unreadable entry would silently SHRINK the
             // corpus this guard compares against, which is the one failure it
             // cannot be allowed to have.
             entry
-                .unwrap_or_else(|e| panic!("read a fixture dir entry in {dir:?}: {e}"))
+                .unwrap_or_else(|e| panic!("read a fixture dir entry in {FIXTURES_SUBDIR}: {e}"))
                 .file_name()
                 .to_string_lossy()
                 .into_owned()
@@ -611,9 +630,12 @@ fn validator_metrics_over_labelled_fixtures() {
 
     // FINDINGS, not codes. The per-code table above counts each code once per
     // fixture, which is the right shape for "which check over-fires" and the
-    // WRONG shape for a budget: the letter fixture alone carries 16 warnings from
-    // 2 codes, so a code-based sum understates by 8× exactly where it matters.
-    // What a user is shown is one line per finding, so that is what is budgeted.
+    // WRONG shape for a budget: what a user is shown is one line per finding.
+    // The gap between the two is 8× on the AI-tells letter (2 codes, 16
+    // findings) — a `Planted` fixture, so it is an illustration of the skew and
+    // not an input here. Every truthful fixture is clean today, so the two
+    // counts agree at 0; they would not agree the moment one stops being clean,
+    // and this is the one that would be honest then.
     let warning_fps: usize = outcomes
         .iter()
         .filter(|o| o.label == Label::Negative)
@@ -633,9 +655,35 @@ fn validator_metrics_over_labelled_fixtures() {
     );
 
     // ── Assert ──────────────────────────────────────────────────────────────
+
+    // The caveat sentence above is computed by SUBSTRING, so renaming a clean
+    // fixture (or relabelling one) would quietly shrink the number it prints
+    // rather than fail anything — a caveat that under-reports is worse than no
+    // caveat, because it makes the headline look stronger than it is.
+    assert_eq!(
+        pinned_empty, EXPECTED_PINNED_EMPTY,
+        "the caveat line found {pinned_empty} unit-suite-pinned negatives, expected \
+         {EXPECTED_PINNED_EMPTY} — if the clean fixtures were renamed or relabelled, update \
+         EXPECTED_PINNED_EMPTY and the two test names the caveat credits"
+    );
+
     for outcome in &outcomes {
         if let Label::Planted(codes) = outcome.label {
             for (code, expected) in codes {
+                // Registered AT ALL, before anything is read off the registry.
+                // `severity_for` degrades an unknown code to `Warning` behind a
+                // `debug_assert`, so with debug assertions compiled out the
+                // severity check below would accept a typo'd code labelled
+                // `Warning`. Recall would still fail (a code that does not exist
+                // cannot be reported) — but it would fail as "the validator
+                // missed it", sending the reader after a validator bug instead of
+                // a typo on this line.
+                assert!(
+                    CONTENT_ISSUE_CODES.iter().any(|(c, _)| c == code),
+                    "{}: {code} is not in CONTENT_ISSUE_CODES — a planted label must name a real \
+                     code, not one this file invented",
+                    outcome.file
+                );
                 // The severity this file CLAIMS, checked against the registry.
                 // A demotion (or promotion) is exactly the event this harness
                 // informs, so it must be re-stated here rather than absorbed.

--- a/apps/desktop/src-tauri/tests/eval.rs
+++ b/apps/desktop/src-tauri/tests/eval.rs
@@ -1,17 +1,68 @@
-//! Eval-corpus harness — Phase 1 skeleton.
+//! Offline eval harness — the DETERMINISTIC validator layer, measured.
 //!
-//! Loads the synthetic, no-PII fixtures under `tests/corpus/` and validates the
-//! corpus is well-formed: every resume `.txt` has a `.tags` sidecar, every tag
-//! line parses, the expected fields are present, and emails are synthetic.
+//! Two independent things live here:
 //!
-//! Field-level precision/recall against the real extractor is wired up in
-//! Phase 6 — this stub just guards the corpus shape so later phases can rely on
-//! it. (Standalone integration test: `ajh-tauri` is a binary crate, so this uses
-//! only `std`, not the crate's internals.)
+//! * **The eval corpus shape** (`tests/corpus/`): every resume `.txt` has a
+//!   `.tags` sidecar, every tag line parses, the expected fields are present,
+//!   and emails are synthetic. Extraction-level precision/recall against the
+//!   real extractor is still future work; this guards the corpus so it can be
+//!   built on.
+//! * **Validator precision/recall** on the LABELLED defect fixtures the
+//!   `validate::content` unit tests already own
+//!   (`src/validate/content/fixtures/`). Each fixture differs from its clean
+//!   sibling by roughly one planted edit, so "did the suite report exactly the
+//!   planted code, and what else did it fire?" is a measurable question.
+//!
+//! ## Why this is metrics, not another pass/fail suite
+//!
+//! `validate::content::test` already asserts, per defect, that the right code
+//! fires with the right evidence. Repeating that here would buy nothing. What
+//! nothing measured before is the **Warning-tier false-positive rate on
+//! truthful documents** — the number that has to be known before
+//! `factual.unsourced_term` (or any other Warning) can be escalated to
+//! Critical, and before an LLM judge is given more surface. So this harness
+//! prints a per-code table (`cargo test --test eval -- --nocapture`) and
+//! asserts only the two invariants that must never regress:
+//!
+//! 1. every planted **Critical** defect is reported, under its expected code;
+//! 2. the clean / paraphrased / grounded negatives report **zero Criticals**.
+//!
+//! Warnings on negatives are DATA, not failures — a harness that failed on them
+//! would be a duplicate of the unit suite and would have to be loosened the
+//! first time a threshold moved, which is exactly when the number matters.
+//!
+//! Planted-Warning recall is likewise reported rather than asserted: the unit
+//! suite pins those (`near_duplicate_bullets_warn_once_on_the_later_bullet`,
+//! `project_outside_the_three_tiers_warns`), and duplicating an assertion in two
+//! files means fixing it in two files.
+//!
+//! **Read today's `0%` for what it is.** Two of the five negatives
+//! (`*_generated_clean.txt`) are already pinned to a COMPLETELY empty report by
+//! `clean_resume_produces_no_issues_at_all`, so their contribution to the
+//! false-positive rate is zero by construction; the paraphrased pair and the
+//! grounded letter are the only ones free to move. The rate becomes an
+//! informative measurement as truthful fixtures are ADDED — that, not this
+//! run's number, is what gates the escalation decision.
+//!
+//! Generation itself needs a live model, so depth A/B over REAL runs is not
+//! here: it reads `pipeline_runs.metrics_json` via
+//! `scripts/dump-run-metrics.mjs`.
+//!
+//! This links the crate (`ajh_tauri`, the `[lib]` target) and calls the same
+//! `validate_content` entry point the product calls — never a stitched-together
+//! subset of the individual validators, which would measure a suite that does
+//! not ship.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use ajh_tauri::validate::content::{
+    severity_for, validate_content, ContentInput, ContentReport, DocKind,
+};
+use ajh_tauri::validate::Severity;
+
+// ── Part 1: the extraction corpus's shape ───────────────────────────────────
 
 fn corpus_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/corpus")
@@ -78,4 +129,443 @@ fn corpus_fixtures_are_well_formed() {
         resumes >= 2,
         "expected at least two corpus fixtures, found {resumes}"
     );
+}
+
+// ── Part 2: validator precision / recall on labelled defect fixtures ────────
+
+const FIXTURES_SUBDIR: &str = "src/validate/content/fixtures";
+
+const EN_SOURCE: &str = include_str!("../src/validate/content/fixtures/en_source_resume.txt");
+const EN_JOB_AD: &str = include_str!("../src/validate/content/fixtures/en_job_ad.txt");
+const DE_SOURCE: &str = include_str!("../src/validate/content/fixtures/de_source_resume.txt");
+const DE_JOB_AD: &str = include_str!("../src/validate/content/fixtures/de_job_ad.txt");
+
+/// What a fixture is FOR. The three cases are graded differently, so they are
+/// three variants rather than one "expected codes" list with implicit rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Label {
+    /// A defect was planted; these codes must be reported. Criticals among them
+    /// are asserted, Warnings among them are measured (see the module docs).
+    Planted(&'static [&'static str]),
+    /// A truthful document. Zero Criticals is the invariant; every Warning is a
+    /// false positive and is counted as one.
+    Negative,
+    /// A legal degradation — the source simply carried less. No planted defect
+    /// and no clean-report claim, so it contributes data only. (The unit suite
+    /// owns the "this specific code must stay silent" assertion for these.)
+    Tolerated,
+}
+
+/// One labelled fixture. `file` is the on-disk name so the coverage guard below
+/// can prove the whole corpus is graded, and so a failure names the file.
+struct Case {
+    file: &'static str,
+    text: &'static str,
+    lang: &'static str,
+    kind: DocKind,
+    label: Label,
+}
+
+/// Every labelled fixture, with the code its planted edit is expected to
+/// produce.
+///
+/// The labels are the ones `validate::content::test` already asserts — this
+/// table is a second READER of those fixtures, never a second opinion about
+/// what is planted in them.
+const CASES: &[Case] = &[
+    // Truthful documents — the precision denominator.
+    Case {
+        file: "en_generated_clean.txt",
+        text: include_str!("../src/validate/content/fixtures/en_generated_clean.txt"),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Negative,
+    },
+    Case {
+        file: "de_generated_clean.txt",
+        text: include_str!("../src/validate/content/fixtures/de_generated_clean.txt"),
+        lang: "de",
+        kind: DocKind::Resume,
+        label: Label::Negative,
+    },
+    Case {
+        file: "en_generated_paraphrased.txt",
+        text: include_str!("../src/validate/content/fixtures/en_generated_paraphrased.txt"),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Negative,
+    },
+    Case {
+        file: "de_generated_paraphrased.txt",
+        text: include_str!("../src/validate/content/fixtures/de_generated_paraphrased.txt"),
+        lang: "de",
+        kind: DocKind::Resume,
+        label: Label::Negative,
+    },
+    Case {
+        file: "en_letter_grounded.txt",
+        text: include_str!("../src/validate/content/fixtures/en_letter_grounded.txt"),
+        lang: "en",
+        kind: DocKind::CoverLetter,
+        label: Label::Negative,
+    },
+    // Planted defects — the recall numerator.
+    Case {
+        file: "en_generated_fabricated_metric.txt",
+        text: include_str!("../src/validate/content/fixtures/en_generated_fabricated_metric.txt"),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Planted(&["factual.unsourced_metric"]),
+    },
+    Case {
+        file: "en_generated_dropped_role.txt",
+        text: include_str!("../src/validate/content/fixtures/en_generated_dropped_role.txt"),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Planted(&["factual.dropped_role"]),
+    },
+    Case {
+        file: "en_generated_altered_project_link.txt",
+        text: include_str!(
+            "../src/validate/content/fixtures/en_generated_altered_project_link.txt"
+        ),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Planted(&["factual.altered_project_link"]),
+    },
+    Case {
+        file: "en_generated_wrong_language.txt",
+        text: include_str!("../src/validate/content/fixtures/en_generated_wrong_language.txt"),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Planted(&["content.language_mismatch"]),
+    },
+    Case {
+        file: "en_generated_duplicate_bullets.txt",
+        text: include_str!("../src/validate/content/fixtures/en_generated_duplicate_bullets.txt"),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Planted(&["duplicate.bullet"]),
+    },
+    Case {
+        file: "en_generated_projects_broken.txt",
+        text: include_str!("../src/validate/content/fixtures/en_generated_projects_broken.txt"),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Planted(&["consistency.project_structure"]),
+    },
+    Case {
+        file: "en_letter_ai_tells.txt",
+        text: include_str!("../src/validate/content/fixtures/en_letter_ai_tells.txt"),
+        lang: "en",
+        kind: DocKind::CoverLetter,
+        label: Label::Planted(&["voice.ai_tell_lexical", "voice.template_opener"]),
+    },
+    // Accepted degradations.
+    Case {
+        file: "en_generated_projects_tier2.txt",
+        text: include_str!("../src/validate/content/fixtures/en_generated_projects_tier2.txt"),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Tolerated,
+    },
+    Case {
+        file: "en_generated_projects_tier3.txt",
+        text: include_str!("../src/validate/content/fixtures/en_generated_projects_tier3.txt"),
+        lang: "en",
+        kind: DocKind::Resume,
+        label: Label::Tolerated,
+    },
+];
+
+/// The posting requirements each language's job ad is analysed into — the same
+/// lists `validate::content::test` passes, so alignment findings here mean what
+/// they mean there.
+fn requirements(lang: &str) -> Vec<String> {
+    let raw: &[&str] = if lang == "de" {
+        &["Docker und Kubernetes im Produktivbetrieb"]
+    } else {
+        &[
+            "Strong Rust and Python",
+            "Production Docker and Kubernetes",
+            "PostgreSQL and Redis at scale",
+            "Terraform and AWS",
+        ]
+    };
+    raw.iter().map(|s| (*s).to_string()).collect()
+}
+
+fn run_case(case: &Case) -> ContentReport {
+    let reqs = requirements(case.lang);
+    let (source, job_ad) = if case.lang == "de" {
+        (DE_SOURCE, DE_JOB_AD)
+    } else {
+        (EN_SOURCE, EN_JOB_AD)
+    };
+    validate_content(&ContentInput {
+        generated: case.text,
+        source_resume: source,
+        job_ad,
+        top_requirements: &reqs,
+        target_language: case.lang,
+        doc_kind: case.kind,
+    })
+}
+
+/// One fixture's outcome, kept so the whole table can be PRINTED before any
+/// assertion fires — a harness that panics before it reports is a harness you
+/// have to re-run to read.
+struct Outcome {
+    file: &'static str,
+    label: Label,
+    criticals: usize,
+    warnings: usize,
+    /// Every code the report carried, deduplicated, in stable order.
+    fired: BTreeSet<&'static str>,
+}
+
+/// Per-code tallies across the whole corpus.
+#[derive(Default)]
+struct CodeStats {
+    /// Fixtures where this code was planted.
+    planted: usize,
+    /// …of which the suite actually reported it.
+    recalled: usize,
+    /// Truthful (`Label::Negative`) fixtures that fired it — false positives.
+    fp_negatives: usize,
+    /// `Tolerated` fixtures that fired it — data, not a verdict.
+    fired_tolerated: usize,
+    /// Planted fixtures that fired it while it was NOT the planted code.
+    fired_offtarget: usize,
+}
+
+fn severity_label(code: &str) -> &'static str {
+    match severity_for(code) {
+        Severity::Critical => "critical",
+        Severity::Warning => "warning",
+    }
+}
+
+/// The `.txt` fixtures that are GENERATED output (the gradeable ones) — every
+/// file that is neither a source résumé nor a job ad.
+fn gradeable_fixture_files() -> BTreeSet<String> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURES_SUBDIR);
+    fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read {dir:?}: {e}"))
+        .filter_map(|entry| {
+            let name = entry.ok()?.file_name().to_string_lossy().into_owned();
+            let gradeable = name.ends_with(".txt")
+                && !name.ends_with("_source_resume.txt")
+                && !name.ends_with("_job_ad.txt");
+            gradeable.then_some(name)
+        })
+        .collect()
+}
+
+#[test]
+fn validator_metrics_over_labelled_fixtures() {
+    // ── Measure ─────────────────────────────────────────────────────────────
+    let outcomes: Vec<Outcome> = CASES
+        .iter()
+        .map(|case| {
+            let report = run_case(case);
+            Outcome {
+                file: case.file,
+                label: case.label,
+                criticals: report
+                    .issues
+                    .iter()
+                    .filter(|i| i.severity == Severity::Critical)
+                    .count(),
+                warnings: report
+                    .issues
+                    .iter()
+                    .filter(|i| i.severity == Severity::Warning)
+                    .count(),
+                fired: report.issues.iter().map(|i| i.code).collect(),
+            }
+        })
+        .collect();
+
+    let negatives = outcomes
+        .iter()
+        .filter(|o| o.label == Label::Negative)
+        .count();
+
+    let mut stats: BTreeMap<&str, CodeStats> = BTreeMap::new();
+    for outcome in &outcomes {
+        let planted: &[&str] = match outcome.label {
+            Label::Planted(codes) => codes,
+            _ => &[],
+        };
+        for code in planted {
+            let entry = stats.entry(code).or_default();
+            entry.planted += 1;
+            if outcome.fired.contains(code) {
+                entry.recalled += 1;
+            }
+        }
+        for code in &outcome.fired {
+            let entry = stats.entry(code).or_default();
+            match outcome.label {
+                Label::Negative => entry.fp_negatives += 1,
+                Label::Tolerated => entry.fired_tolerated += 1,
+                Label::Planted(_) if !planted.contains(code) => entry.fired_offtarget += 1,
+                Label::Planted(_) => {}
+            }
+        }
+    }
+
+    // ── Report (visible with `-- --nocapture`) ──────────────────────────────
+    println!("\n=== eval: deterministic content validators on labelled fixtures ===");
+    println!(
+        "{} fixtures — {} planted, {negatives} truthful, {} tolerated-degradation\n",
+        outcomes.len(),
+        outcomes
+            .iter()
+            .filter(|o| matches!(o.label, Label::Planted(_)))
+            .count(),
+        outcomes
+            .iter()
+            .filter(|o| o.label == Label::Tolerated)
+            .count(),
+    );
+
+    println!(
+        "{:<44} {:<10} {:>4} {:>4}  planted → found | other codes fired",
+        "fixture", "label", "crit", "warn"
+    );
+    for outcome in &outcomes {
+        let (label, detail) = match outcome.label {
+            Label::Planted(codes) => {
+                let found: Vec<String> = codes
+                    .iter()
+                    .map(|c| {
+                        format!(
+                            "{c}→{}",
+                            if outcome.fired.contains(c) {
+                                "FOUND"
+                            } else {
+                                "MISSED"
+                            }
+                        )
+                    })
+                    .collect();
+                let others: Vec<&str> = outcome
+                    .fired
+                    .iter()
+                    .filter(|c| !codes.contains(c))
+                    .copied()
+                    .collect();
+                (
+                    "planted",
+                    format!("{} | {}", found.join(" "), join_or_dash(&others)),
+                )
+            }
+            Label::Negative => (
+                "truthful",
+                format!(
+                    "— | {}",
+                    join_or_dash(&outcome.fired.iter().copied().collect::<Vec<_>>())
+                ),
+            ),
+            Label::Tolerated => (
+                "tolerated",
+                format!(
+                    "— | {}",
+                    join_or_dash(&outcome.fired.iter().copied().collect::<Vec<_>>())
+                ),
+            ),
+        };
+        println!(
+            "{:<44} {label:<10} {:>4} {:>4}  {detail}",
+            outcome.file, outcome.criticals, outcome.warnings
+        );
+    }
+
+    println!(
+        "\n{:<36} {:<9} {:>7} {:>8} {:>9} {:>8} {:>9}",
+        "code", "severity", "planted", "recall", "fp/truthful", "fp-rate", "off-target"
+    );
+    for (code, s) in &stats {
+        let recall = if s.planted == 0 {
+            "—".to_string()
+        } else {
+            format!("{}/{}", s.recalled, s.planted)
+        };
+        let fp_rate = if negatives == 0 {
+            "—".to_string()
+        } else {
+            format!("{:.0}%", 100.0 * s.fp_negatives as f64 / negatives as f64)
+        };
+        println!(
+            "{code:<36} {:<9} {:>7} {recall:>8} {:>9} {fp_rate:>8} {:>9}",
+            severity_label(code),
+            s.planted,
+            format!("{}/{negatives}", s.fp_negatives),
+            s.fired_offtarget + s.fired_tolerated,
+        );
+    }
+
+    let warning_fps: usize = stats
+        .iter()
+        .filter(|(code, _)| severity_for(code) == Severity::Warning)
+        .map(|(_, s)| s.fp_negatives)
+        .sum();
+    println!(
+        "\nWarning-tier false positives on truthful documents: {warning_fps} across {negatives} \
+         fixtures — the number that gates any W→C escalation.\n"
+    );
+
+    // ── Assert (only the invariants) ────────────────────────────────────────
+    for outcome in &outcomes {
+        if let Label::Planted(codes) = outcome.label {
+            for code in codes {
+                if severity_for(code) != Severity::Critical {
+                    continue; // Warning recall is measured above, not gated here.
+                }
+                assert!(
+                    outcome.fired.contains(code),
+                    "{}: planted Critical {code} was NOT reported; the report carried {:?}",
+                    outcome.file,
+                    outcome.fired
+                );
+            }
+        }
+        if outcome.label == Label::Negative {
+            assert_eq!(
+                outcome.criticals, 0,
+                "{}: a truthful document must never raise a Critical; it fired {:?}",
+                outcome.file, outcome.fired
+            );
+        }
+    }
+}
+
+/// Every gradeable fixture on disk carries a label, so a fixture added for a new
+/// defect cannot sit in the corpus unmeasured (and a deleted one cannot leave a
+/// row in `CASES` that grades nothing).
+#[test]
+fn every_generated_fixture_is_labelled() {
+    let on_disk = gradeable_fixture_files();
+    let labelled: BTreeSet<String> = CASES.iter().map(|c| c.file.to_string()).collect();
+
+    let unlabelled: Vec<&String> = on_disk.difference(&labelled).collect();
+    assert!(
+        unlabelled.is_empty(),
+        "these fixtures are graded by nothing — add them to `CASES`: {unlabelled:?}"
+    );
+    let missing: Vec<&String> = labelled.difference(&on_disk).collect();
+    assert!(
+        missing.is_empty(),
+        "`CASES` names fixtures that no longer exist: {missing:?}"
+    );
+}
+
+fn join_or_dash(codes: &[&str]) -> String {
+    if codes.is_empty() {
+        "—".to_string()
+    } else {
+        codes.join(", ")
+    }
 }

--- a/apps/desktop/src-tauri/tests/eval.rs
+++ b/apps/desktop/src-tauri/tests/eval.rs
@@ -25,8 +25,9 @@
 //! 1. every planted code is reported, whatever its severity;
 //! 2. every planted code's severity is the one this file's label CLAIMS;
 //! 3. every truthful fixture (`Negative` and `Tolerated`) reports zero
-//!    Criticals;
-//! 4. the Warning-tier false-positive count stays inside
+//!    Criticals, and a planted fixture raises no Critical BEYOND the one
+//!    planted in it;
+//! 4. the number of Warning findings on truthful fixtures stays inside
 //!    [`WARNING_FP_BUDGET`].
 //!
 //! **(1) and (2) deliberately overlap `validate::content::test`** — the same
@@ -53,7 +54,9 @@
 //!
 //! **Read today's `0` for what it is.** Two of the five negatives
 //! (`*_generated_clean.txt`) are already pinned to a COMPLETELY empty report by
-//! `clean_resume_produces_no_issues_at_all`, so their contribution to the
+//! `clean_resume_produces_no_issues_at_all` and
+//! `clean_german_resume_produces_no_issues_at_all` (one test each — the German
+//! fixture is not covered by the English one), so their contribution to the
 //! false-positive count is zero by construction; the paraphrased pair and the
 //! grounded letter are the only ones free to move. The rate becomes an
 //! informative measurement as truthful fixtures are ADDED — that, not this
@@ -316,14 +319,19 @@ const CASES: &[Case] = &[
     ),
 ];
 
-/// How many Warning-tier findings the truthful fixtures may produce in total.
+/// How many Warning FINDINGS the truthful fixtures may produce in total.
+///
+/// Findings, not codes: one unit here is one line a user is shown about a
+/// document that is fine. The per-code table counts each code once per fixture
+/// — right for "which check over-fires", wrong for a budget, since one code can
+/// fire a dozen times in one document (the AI-tells letter carries 16 warnings
+/// from 2 codes).
 ///
 /// Zero today, and that is a measurement rather than an aspiration: the whole
 /// truthful set comes back completely clean. It is a BUDGET rather than a
 /// per-code assertion so that loosening it is one visible edit with a reason,
 /// and it is asserted so the headline number in the printed table is a guard
-/// instead of a comment. Raising it is a real decision: every unit of it is a
-/// warning shown to a user about a document that is fine.
+/// instead of a comment.
 const WARNING_FP_BUDGET: usize = 0;
 
 /// The posting requirements each language's job ad is analysed into — the same
@@ -383,6 +391,11 @@ struct Outcome {
     warnings: usize,
     /// Every code the report carried, deduplicated, in stable order.
     fired: BTreeSet<&'static str>,
+    /// Just the Critical-severity codes. Kept separately because "did this
+    /// document raise a Critical nobody planted" cannot be answered from
+    /// [`Self::fired`] (which has no severities) or from [`Self::criticals`]
+    /// (which has no codes).
+    critical_codes: BTreeSet<&'static str>,
 }
 
 /// Per-code tallies across the whole corpus.
@@ -456,6 +469,12 @@ fn validator_metrics_over_labelled_fixtures() {
                     .filter(|i| i.severity == Severity::Warning)
                     .count(),
                 fired: report.issues.iter().map(|i| i.code).collect(),
+                critical_codes: report
+                    .issues
+                    .iter()
+                    .filter(|i| i.severity == Severity::Critical)
+                    .map(|i| i.code)
+                    .collect(),
             }
         })
         .collect();
@@ -590,21 +609,26 @@ fn validator_metrics_over_labelled_fixtures() {
         );
     }
 
-    let warning_fps: usize = stats
+    // FINDINGS, not codes. The per-code table above counts each code once per
+    // fixture, which is the right shape for "which check over-fires" and the
+    // WRONG shape for a budget: the letter fixture alone carries 16 warnings from
+    // 2 codes, so a code-based sum understates by 8× exactly where it matters.
+    // What a user is shown is one line per finding, so that is what is budgeted.
+    let warning_fps: usize = outcomes
         .iter()
-        .filter(|(code, _)| severity_for(code) == Severity::Warning)
-        .map(|(_, s)| s.fp_negatives)
+        .filter(|o| o.label == Label::Negative)
+        .map(|o| o.warnings)
         .sum();
     let pinned_empty = outcomes
         .iter()
         .filter(|o| o.label == Label::Negative && o.file.contains("_generated_clean"))
         .count();
     println!(
-        "\nWarning-tier false positives on truthful documents: {warning_fps} \
-         (budget {WARNING_FP_BUDGET}) across {negatives} fixtures — the number that gates any \
-         W→C escalation.\nCaveat: {pinned_empty} of those {negatives} are already pinned to a \
-         completely empty report by `clean_resume_produces_no_issues_at_all`, so only {} can \
-         move.\n",
+        "\nWarning findings on truthful documents: {warning_fps} (budget {WARNING_FP_BUDGET}) \
+         across {negatives} fixtures — the number that gates any W→C escalation.\nCaveat: \
+         {pinned_empty} of those {negatives} are already pinned to a completely empty report by \
+         `clean_resume_produces_no_issues_at_all` / \
+         `clean_german_resume_produces_no_issues_at_all`, so only {} can move.\n",
         negatives - pinned_empty
     );
 
@@ -633,6 +657,23 @@ fn validator_metrics_over_labelled_fixtures() {
                     outcome.fired
                 );
             }
+            // A defect fixture is one planted edit away from its clean sibling,
+            // so any OTHER Critical on it is a false accusation against a
+            // document that is truthful in every respect but the planted one —
+            // and nothing else gates that: the zero-Critical rule covers only
+            // the truthful labels, and the off-target column is print-only.
+            let unplanted: Vec<&str> = outcome
+                .critical_codes
+                .iter()
+                .filter(|c| !codes.iter().any(|(planted, _)| planted == *c))
+                .copied()
+                .collect();
+            assert!(
+                unplanted.is_empty(),
+                "{}: raised Critical(s) nobody planted: {unplanted:?}. Everything in this fixture \
+                 except the planted edit is true, so an extra Critical is a false accusation.",
+                outcome.file
+            );
         }
         // Both truthful kinds. A `Tolerated` fixture is a legal degradation, not
         // a defective document: a Critical on one is a regression, and nothing
@@ -658,9 +699,9 @@ fn validator_metrics_over_labelled_fixtures() {
     let within_budget = warning_fps <= WARNING_FP_BUDGET;
     assert!(
         within_budget,
-        "Warning-tier false positives on truthful documents rose to {warning_fps}, over the \
-         budget of {WARNING_FP_BUDGET}. Either the validator over-fires, or the budget moves \
-         WITH a reason — see the table above for which codes fired."
+        "Warning findings on truthful documents rose to {warning_fps}, over the budget of \
+         {WARNING_FP_BUDGET}. Either the validator over-fires, or the budget moves WITH a \
+         reason — see the table above for which codes fired."
     );
 }
 

--- a/apps/desktop/src-tauri/tests/eval.rs
+++ b/apps/desktop/src-tauri/tests/eval.rs
@@ -13,33 +13,48 @@
 //!   sibling by roughly one planted edit, so "did the suite report exactly the
 //!   planted code, and what else did it fire?" is a measurable question.
 //!
-//! ## Why this is metrics, not another pass/fail suite
+//! ## What this measures, and what it asserts
 //!
-//! `validate::content::test` already asserts, per defect, that the right code
-//! fires with the right evidence. Repeating that here would buy nothing. What
-//! nothing measured before is the **Warning-tier false-positive rate on
-//! truthful documents** — the number that has to be known before
+//! The MEASUREMENT is the point: a per-code table of recall (was the planted
+//! defect reported?) and of the **Warning-tier false-positive rate on truthful
+//! documents** — the number that has to be known before
 //! `factual.unsourced_term` (or any other Warning) can be escalated to
-//! Critical, and before an LLM judge is given more surface. So this harness
-//! prints a per-code table (`cargo test --test eval -- --nocapture`) and
-//! asserts only the two invariants that must never regress:
+//! Critical, and before an LLM judge is given more surface. Printing is not
+//! enough to keep a table honest, though, so four things are ASSERTED:
 //!
-//! 1. every planted **Critical** defect is reported, under its expected code;
-//! 2. the clean / paraphrased / grounded negatives report **zero Criticals**.
+//! 1. every planted code is reported, whatever its severity;
+//! 2. every planted code's severity is the one this file's label CLAIMS;
+//! 3. every truthful fixture (`Negative` and `Tolerated`) reports zero
+//!    Criticals;
+//! 4. the Warning-tier false-positive count stays inside
+//!    [`WARNING_FP_BUDGET`].
 //!
-//! Warnings on negatives are DATA, not failures — a harness that failed on them
-//! would be a duplicate of the unit suite and would have to be loosened the
-//! first time a threshold moved, which is exactly when the number matters.
+//! **(1) and (2) deliberately overlap `validate::content::test`** — the same
+//! codes on the same fixtures are asserted there (e.g.
+//! `fabricated_metric_is_critical_and_names_the_number`,
+//! `near_duplicate_bullets_warn_once_on_the_later_bullet`). The first cut of
+//! this harness avoided the duplication by gating only Criticals and treating
+//! planted-Warning recall as data, and that made three of seven labels
+//! DECORATION: relabelling the duplicate-bullets fixture to an unrelated
+//! registered code still passed, and demoting a code from Critical to Warning
+//! silently voided its only assertion here. A label nothing checks is a lie
+//! waiting to happen, and this file's labels are the input to an escalation
+//! decision. So the overlap is accepted on purpose: the unit suite proves the
+//! validator's behaviour, this one proves the LABELS still describe it.
 //!
-//! Planted-Warning recall is likewise reported rather than asserted: the unit
-//! suite pins those (`near_duplicate_bullets_warn_once_on_the_later_bullet`,
-//! `project_outside_the_three_tiers_warns`), and duplicating an assertion in two
-//! files means fixing it in two files.
+//! What stays unique to this harness: the corpus-coverage invariant
+//! ([`every_generated_fixture_is_labelled`]), the cross-fixture metrics table,
+//! and the false-positive budget.
 //!
-//! **Read today's `0%` for what it is.** Two of the five negatives
+//! Warnings on truthful documents are NOT asserted per code — they are summed
+//! against [`WARNING_FP_BUDGET`]. One budget moves in one place with a reason
+//! attached, where two dozen per-code assertions would each get loosened
+//! individually and quietly.
+//!
+//! **Read today's `0` for what it is.** Two of the five negatives
 //! (`*_generated_clean.txt`) are already pinned to a COMPLETELY empty report by
 //! `clean_resume_produces_no_issues_at_all`, so their contribution to the
-//! false-positive rate is zero by construction; the paraphrased pair and the
+//! false-positive count is zero by construction; the paraphrased pair and the
 //! grounded letter are the only ones free to move. The rate becomes an
 //! informative measurement as truthful fixtures are ADDED — that, not this
 //! run's number, is what gates the escalation decision.
@@ -47,6 +62,11 @@
 //! Generation itself needs a live model, so depth A/B over REAL runs is not
 //! here: it reads `pipeline_runs.metrics_json` via
 //! `scripts/dump-run-metrics.mjs`.
+//!
+//! The table is a LOCAL artifact: CI captures stdout for a passing test, so it
+//! is visible only under `cargo test --test eval -- --nocapture`. Nothing
+//! downstream parses it — every claim it makes that must hold is one of the
+//! four assertions above.
 //!
 //! This links the crate (`ajh_tauri`, the `[lib]` target) and calls the same
 //! `validate_content` entry point the product calls — never a stitched-together
@@ -144,26 +164,56 @@ const DE_JOB_AD: &str = include_str!("../src/validate/content/fixtures/de_job_ad
 /// three variants rather than one "expected codes" list with implicit rules.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Label {
-    /// A defect was planted; these codes must be reported. Criticals among them
-    /// are asserted, Warnings among them are measured (see the module docs).
-    Planted(&'static [&'static str]),
+    /// A defect was planted; every code here must be reported, AT the severity
+    /// paired with it.
+    ///
+    /// The severity is carried rather than looked up because it is the thing
+    /// being claimed: this harness exists to inform "should this Warning become
+    /// a Critical?", so a code silently changing tier must fail here and be
+    /// re-stated deliberately, not be absorbed by a `severity_for` call that
+    /// agrees with whatever the table currently says.
+    Planted(&'static [(&'static str, Severity)]),
     /// A truthful document. Zero Criticals is the invariant; every Warning is a
-    /// false positive and is counted as one.
+    /// false positive and counts against [`WARNING_FP_BUDGET`].
     Negative,
-    /// A legal degradation — the source simply carried less. No planted defect
-    /// and no clean-report claim, so it contributes data only. (The unit suite
-    /// owns the "this specific code must stay silent" assertion for these.)
+    /// A legal degradation — the source simply carried less. Also a truthful
+    /// document, so it carries the same zero-Critical invariant; what it does
+    /// NOT carry is a planted code or a clean-report claim, and its Warnings
+    /// are reported without counting against the budget (the unit suite owns
+    /// "this specific code must stay silent" for these).
     Tolerated,
 }
 
-/// One labelled fixture. `file` is the on-disk name so the coverage guard below
-/// can prove the whole corpus is graded, and so a failure names the file.
+/// One labelled fixture.
+///
+/// Built only through [`case!`], which derives `text` FROM `file` — the two
+/// cannot name different fixtures, so the table can never grade one document
+/// twice while reporting it as two.
 struct Case {
     file: &'static str,
     text: &'static str,
     lang: &'static str,
     kind: DocKind,
     label: Label,
+}
+
+/// Declare a [`Case`], reading the fixture named by `$file` and nothing else.
+///
+/// `file` is not decoration: it is what [`every_generated_fixture_is_labelled`]
+/// diffs against the directory and what a failure message names. Spelling the
+/// path a second time inside `include_str!` let the two disagree — a row could
+/// say `tier2` and grade `tier3`, passing every assertion while leaving one
+/// fixture ungraded and another graded twice. One spelling, one fixture.
+macro_rules! case {
+    ($file:literal, $lang:literal, $kind:expr, $label:expr) => {
+        Case {
+            file: $file,
+            text: include_str!(concat!("../src/validate/content/fixtures/", $file)),
+            lang: $lang,
+            kind: $kind,
+            label: $label,
+        }
+    };
 }
 
 /// Every labelled fixture, with the code its planted edit is expected to
@@ -173,114 +223,118 @@ struct Case {
 /// table is a second READER of those fixtures, never a second opinion about
 /// what is planted in them.
 const CASES: &[Case] = &[
-    // Truthful documents — the precision denominator.
-    Case {
-        file: "en_generated_clean.txt",
-        text: include_str!("../src/validate/content/fixtures/en_generated_clean.txt"),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Negative,
-    },
-    Case {
-        file: "de_generated_clean.txt",
-        text: include_str!("../src/validate/content/fixtures/de_generated_clean.txt"),
-        lang: "de",
-        kind: DocKind::Resume,
-        label: Label::Negative,
-    },
-    Case {
-        file: "en_generated_paraphrased.txt",
-        text: include_str!("../src/validate/content/fixtures/en_generated_paraphrased.txt"),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Negative,
-    },
-    Case {
-        file: "de_generated_paraphrased.txt",
-        text: include_str!("../src/validate/content/fixtures/de_generated_paraphrased.txt"),
-        lang: "de",
-        kind: DocKind::Resume,
-        label: Label::Negative,
-    },
-    Case {
-        file: "en_letter_grounded.txt",
-        text: include_str!("../src/validate/content/fixtures/en_letter_grounded.txt"),
-        lang: "en",
-        kind: DocKind::CoverLetter,
-        label: Label::Negative,
-    },
+    // Truthful documents — the false-positive denominator.
+    case!(
+        "en_generated_clean.txt",
+        "en",
+        DocKind::Resume,
+        Label::Negative
+    ),
+    case!(
+        "de_generated_clean.txt",
+        "de",
+        DocKind::Resume,
+        Label::Negative
+    ),
+    case!(
+        "en_generated_paraphrased.txt",
+        "en",
+        DocKind::Resume,
+        Label::Negative
+    ),
+    case!(
+        "de_generated_paraphrased.txt",
+        "de",
+        DocKind::Resume,
+        Label::Negative
+    ),
+    case!(
+        "en_letter_grounded.txt",
+        "en",
+        DocKind::CoverLetter,
+        Label::Negative
+    ),
     // Planted defects — the recall numerator.
-    Case {
-        file: "en_generated_fabricated_metric.txt",
-        text: include_str!("../src/validate/content/fixtures/en_generated_fabricated_metric.txt"),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Planted(&["factual.unsourced_metric"]),
-    },
-    Case {
-        file: "en_generated_dropped_role.txt",
-        text: include_str!("../src/validate/content/fixtures/en_generated_dropped_role.txt"),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Planted(&["factual.dropped_role"]),
-    },
-    Case {
-        file: "en_generated_altered_project_link.txt",
-        text: include_str!(
-            "../src/validate/content/fixtures/en_generated_altered_project_link.txt"
-        ),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Planted(&["factual.altered_project_link"]),
-    },
-    Case {
-        file: "en_generated_wrong_language.txt",
-        text: include_str!("../src/validate/content/fixtures/en_generated_wrong_language.txt"),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Planted(&["content.language_mismatch"]),
-    },
-    Case {
-        file: "en_generated_duplicate_bullets.txt",
-        text: include_str!("../src/validate/content/fixtures/en_generated_duplicate_bullets.txt"),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Planted(&["duplicate.bullet"]),
-    },
-    Case {
-        file: "en_generated_projects_broken.txt",
-        text: include_str!("../src/validate/content/fixtures/en_generated_projects_broken.txt"),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Planted(&["consistency.project_structure"]),
-    },
-    Case {
-        file: "en_letter_ai_tells.txt",
-        text: include_str!("../src/validate/content/fixtures/en_letter_ai_tells.txt"),
-        lang: "en",
-        kind: DocKind::CoverLetter,
-        label: Label::Planted(&["voice.ai_tell_lexical", "voice.template_opener"]),
-    },
-    // Accepted degradations.
-    Case {
-        file: "en_generated_projects_tier2.txt",
-        text: include_str!("../src/validate/content/fixtures/en_generated_projects_tier2.txt"),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Tolerated,
-    },
-    Case {
-        file: "en_generated_projects_tier3.txt",
-        text: include_str!("../src/validate/content/fixtures/en_generated_projects_tier3.txt"),
-        lang: "en",
-        kind: DocKind::Resume,
-        label: Label::Tolerated,
-    },
+    case!(
+        "en_generated_fabricated_metric.txt",
+        "en",
+        DocKind::Resume,
+        Label::Planted(&[("factual.unsourced_metric", Severity::Critical)])
+    ),
+    case!(
+        "en_generated_dropped_role.txt",
+        "en",
+        DocKind::Resume,
+        Label::Planted(&[("factual.dropped_role", Severity::Critical)])
+    ),
+    case!(
+        "en_generated_altered_project_link.txt",
+        "en",
+        DocKind::Resume,
+        Label::Planted(&[("factual.altered_project_link", Severity::Critical)])
+    ),
+    case!(
+        "en_generated_wrong_language.txt",
+        "en",
+        DocKind::Resume,
+        Label::Planted(&[("content.language_mismatch", Severity::Critical)])
+    ),
+    case!(
+        "en_generated_duplicate_bullets.txt",
+        "en",
+        DocKind::Resume,
+        Label::Planted(&[("duplicate.bullet", Severity::Warning)])
+    ),
+    case!(
+        "en_generated_projects_broken.txt",
+        "en",
+        DocKind::Resume,
+        Label::Planted(&[("consistency.project_structure", Severity::Warning)])
+    ),
+    case!(
+        "en_letter_ai_tells.txt",
+        "en",
+        DocKind::CoverLetter,
+        Label::Planted(&[
+            ("voice.ai_tell_lexical", Severity::Warning),
+            ("voice.template_opener", Severity::Warning),
+        ])
+    ),
+    // Accepted degradations — truthful, but with less in the source to work
+    // from. No planted code; still no Critical.
+    case!(
+        "en_generated_projects_tier2.txt",
+        "en",
+        DocKind::Resume,
+        Label::Tolerated
+    ),
+    case!(
+        "en_generated_projects_tier3.txt",
+        "en",
+        DocKind::Resume,
+        Label::Tolerated
+    ),
 ];
+
+/// How many Warning-tier findings the truthful fixtures may produce in total.
+///
+/// Zero today, and that is a measurement rather than an aspiration: the whole
+/// truthful set comes back completely clean. It is a BUDGET rather than a
+/// per-code assertion so that loosening it is one visible edit with a reason,
+/// and it is asserted so the headline number in the printed table is a guard
+/// instead of a comment. Raising it is a real decision: every unit of it is a
+/// warning shown to a user about a document that is fine.
+const WARNING_FP_BUDGET: usize = 0;
 
 /// The posting requirements each language's job ad is analysed into — the same
 /// lists `validate::content::test` passes, so alignment findings here mean what
 /// they mean there.
+///
+/// KNOWN DUPLICATION: these strings are hand-copied from that file's
+/// `en_requirements()` and its German inline list, because they are private to
+/// it. If the two drift, the alignment family's numbers here stop being
+/// comparable with the unit suite's — which is why the lists are small, in one
+/// function, and named.
 fn requirements(lang: &str) -> Vec<String> {
     let raw: &[&str] = if lang == "de" {
         &["Docker und Kubernetes im Produktivbetrieb"]
@@ -296,7 +350,14 @@ fn requirements(lang: &str) -> Vec<String> {
 }
 
 fn run_case(case: &Case) -> ContentReport {
-    let reqs = requirements(case.lang);
+    // A letter never runs the alignment pass, and the unit suite's `en_letter`
+    // helper passes NO requirements — feeding four here would be a different
+    // input than the one this harness claims parity with.
+    let reqs = if case.kind == DocKind::CoverLetter {
+        Vec::new()
+    } else {
+        requirements(case.lang)
+    };
     let (source, job_ad) = if case.lang == "de" {
         (DE_SOURCE, DE_JOB_AD)
     } else {
@@ -331,9 +392,13 @@ struct CodeStats {
     planted: usize,
     /// …of which the suite actually reported it.
     recalled: usize,
-    /// Truthful (`Label::Negative`) fixtures that fired it — false positives.
+    /// Truthful (`Label::Negative`) fixtures that fired it — false positives,
+    /// and the only tally that counts against [`WARNING_FP_BUDGET`].
     fp_negatives: usize,
-    /// `Tolerated` fixtures that fired it — data, not a verdict.
+    /// `Tolerated` fixtures that fired it. Reported in its OWN column: a
+    /// degradation fixture firing a structure warning is a different event from
+    /// a defect fixture firing a code nobody planted, and summing the two hid
+    /// which had happened.
     fired_tolerated: usize,
     /// Planted fixtures that fired it while it was NOT the planted code.
     fired_offtarget: usize,
@@ -352,12 +417,20 @@ fn gradeable_fixture_files() -> BTreeSet<String> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURES_SUBDIR);
     fs::read_dir(&dir)
         .unwrap_or_else(|e| panic!("read {dir:?}: {e}"))
-        .filter_map(|entry| {
-            let name = entry.ok()?.file_name().to_string_lossy().into_owned();
-            let gradeable = name.ends_with(".txt")
+        .map(|entry| {
+            // NOT `entry.ok()?`: an unreadable entry would silently SHRINK the
+            // corpus this guard compares against, which is the one failure it
+            // cannot be allowed to have.
+            entry
+                .unwrap_or_else(|e| panic!("read a fixture dir entry in {dir:?}: {e}"))
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .filter(|name| {
+            name.ends_with(".txt")
                 && !name.ends_with("_source_resume.txt")
-                && !name.ends_with("_job_ad.txt");
-            gradeable.then_some(name)
+                && !name.ends_with("_job_ad.txt")
         })
         .collect()
 }
@@ -394,11 +467,11 @@ fn validator_metrics_over_labelled_fixtures() {
 
     let mut stats: BTreeMap<&str, CodeStats> = BTreeMap::new();
     for outcome in &outcomes {
-        let planted: &[&str] = match outcome.label {
+        let planted: &[(&str, Severity)] = match outcome.label {
             Label::Planted(codes) => codes,
             _ => &[],
         };
-        for code in planted {
+        for (code, _) in planted {
             let entry = stats.entry(code).or_default();
             entry.planted += 1;
             if outcome.fired.contains(code) {
@@ -410,7 +483,9 @@ fn validator_metrics_over_labelled_fixtures() {
             match outcome.label {
                 Label::Negative => entry.fp_negatives += 1,
                 Label::Tolerated => entry.fired_tolerated += 1,
-                Label::Planted(_) if !planted.contains(code) => entry.fired_offtarget += 1,
+                Label::Planted(_) if !planted.iter().any(|(c, _)| c == code) => {
+                    entry.fired_offtarget += 1;
+                }
                 Label::Planted(_) => {}
             }
         }
@@ -440,7 +515,7 @@ fn validator_metrics_over_labelled_fixtures() {
             Label::Planted(codes) => {
                 let found: Vec<String> = codes
                     .iter()
-                    .map(|c| {
+                    .map(|(c, _)| {
                         format!(
                             "{c}→{}",
                             if outcome.fired.contains(c) {
@@ -454,7 +529,7 @@ fn validator_metrics_over_labelled_fixtures() {
                 let others: Vec<&str> = outcome
                     .fired
                     .iter()
-                    .filter(|c| !codes.contains(c))
+                    .filter(|c| !codes.iter().any(|(planted, _)| planted == *c))
                     .copied()
                     .collect();
                 (
@@ -484,8 +559,15 @@ fn validator_metrics_over_labelled_fixtures() {
     }
 
     println!(
-        "\n{:<36} {:<9} {:>7} {:>8} {:>9} {:>8} {:>9}",
-        "code", "severity", "planted", "recall", "fp/truthful", "fp-rate", "off-target"
+        "\n{:<36} {:<9} {:>7} {:>8} {:>9} {:>8} {:>10} {:>9}",
+        "code",
+        "severity",
+        "planted",
+        "recall",
+        "fp/truthful",
+        "fp-rate",
+        "off-target",
+        "tolerated"
     );
     for (code, s) in &stats {
         let recall = if s.planted == 0 {
@@ -499,11 +581,12 @@ fn validator_metrics_over_labelled_fixtures() {
             format!("{:.0}%", 100.0 * s.fp_negatives as f64 / negatives as f64)
         };
         println!(
-            "{code:<36} {:<9} {:>7} {recall:>8} {:>9} {fp_rate:>8} {:>9}",
+            "{code:<36} {:<9} {:>7} {recall:>8} {:>9} {fp_rate:>8} {:>10} {:>9}",
             severity_label(code),
             s.planted,
             format!("{}/{negatives}", s.fp_negatives),
-            s.fired_offtarget + s.fired_tolerated,
+            s.fired_offtarget,
+            s.fired_tolerated,
         );
     }
 
@@ -512,27 +595,49 @@ fn validator_metrics_over_labelled_fixtures() {
         .filter(|(code, _)| severity_for(code) == Severity::Warning)
         .map(|(_, s)| s.fp_negatives)
         .sum();
+    let pinned_empty = outcomes
+        .iter()
+        .filter(|o| o.label == Label::Negative && o.file.contains("_generated_clean"))
+        .count();
     println!(
-        "\nWarning-tier false positives on truthful documents: {warning_fps} across {negatives} \
-         fixtures — the number that gates any W→C escalation.\n"
+        "\nWarning-tier false positives on truthful documents: {warning_fps} \
+         (budget {WARNING_FP_BUDGET}) across {negatives} fixtures — the number that gates any \
+         W→C escalation.\nCaveat: {pinned_empty} of those {negatives} are already pinned to a \
+         completely empty report by `clean_resume_produces_no_issues_at_all`, so only {} can \
+         move.\n",
+        negatives - pinned_empty
     );
 
-    // ── Assert (only the invariants) ────────────────────────────────────────
+    // ── Assert ──────────────────────────────────────────────────────────────
     for outcome in &outcomes {
         if let Label::Planted(codes) = outcome.label {
-            for code in codes {
-                if severity_for(code) != Severity::Critical {
-                    continue; // Warning recall is measured above, not gated here.
-                }
+            for (code, expected) in codes {
+                // The severity this file CLAIMS, checked against the registry.
+                // A demotion (or promotion) is exactly the event this harness
+                // informs, so it must be re-stated here rather than absorbed.
+                assert_eq!(
+                    severity_for(code),
+                    *expected,
+                    "{}: {code} is registered as {:?} but this harness labels it {expected:?} — \
+                     re-state the label if the tier change was deliberate",
+                    outcome.file,
+                    severity_for(code),
+                );
+                // Recall, at EVERY severity: a planted label that nothing checks
+                // is decoration, and three of these were exactly that while only
+                // Criticals were gated.
                 assert!(
                     outcome.fired.contains(code),
-                    "{}: planted Critical {code} was NOT reported; the report carried {:?}",
+                    "{}: planted {expected:?} {code} was NOT reported; the report carried {:?}",
                     outcome.file,
                     outcome.fired
                 );
             }
         }
-        if outcome.label == Label::Negative {
+        // Both truthful kinds. A `Tolerated` fixture is a legal degradation, not
+        // a defective document: a Critical on one is a regression, and nothing
+        // else gates it.
+        if matches!(outcome.label, Label::Negative | Label::Tolerated) {
             assert_eq!(
                 outcome.criticals, 0,
                 "{}: a truthful document must never raise a Critical; it fired {:?}",
@@ -540,11 +645,33 @@ fn validator_metrics_over_labelled_fixtures() {
             );
         }
     }
+
+    // The headline number, as a guard rather than a remark.
+    //
+    // `<=` against a budget that happens to be 0 today is
+    // `absurd_extreme_comparisons`, and the lint is right about the arithmetic
+    // and wrong about the intent: the comparison is the CONTRACT ("at most the
+    // budget"), and rewriting it as `== 0` would have to be rewritten back the
+    // first time the budget moves off zero — exactly the edit most likely to be
+    // made carelessly.
+    #[allow(clippy::absurd_extreme_comparisons)]
+    let within_budget = warning_fps <= WARNING_FP_BUDGET;
+    assert!(
+        within_budget,
+        "Warning-tier false positives on truthful documents rose to {warning_fps}, over the \
+         budget of {WARNING_FP_BUDGET}. Either the validator over-fires, or the budget moves \
+         WITH a reason — see the table above for which codes fired."
+    );
 }
 
 /// Every gradeable fixture on disk carries a label, so a fixture added for a new
-/// defect cannot sit in the corpus unmeasured (and a deleted one cannot leave a
-/// row in `CASES` that grades nothing).
+/// defect cannot sit in the corpus unmeasured.
+///
+/// Only this direction needs a runtime check. The reverse — a `CASES` row naming
+/// a fixture that no longer exists — cannot compile: [`case!`] builds its
+/// `include_str!` path out of the same `file` literal, so a deleted fixture is a
+/// BUILD error, and a runtime assertion for it would be unreachable code
+/// pretending to be a guard.
 #[test]
 fn every_generated_fixture_is_labelled() {
     let on_disk = gradeable_fixture_files();
@@ -554,11 +681,6 @@ fn every_generated_fixture_is_labelled() {
     assert!(
         unlabelled.is_empty(),
         "these fixtures are graded by nothing — add them to `CASES`: {unlabelled:?}"
-    );
-    let missing: Vec<&String> = labelled.difference(&on_disk).collect();
-    assert!(
-        missing.is_empty(),
-        "`CASES` names fixtures that no longer exist: {missing:?}"
     );
 }
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -254,6 +254,19 @@ Embedding vectors live in the `vectors` table of `documents.db` and cosine simil
 runs in-process in Rust — **no LanceDB, no `vectors/` directory**. To reset dev state,
 delete the `*.db` files in that directory and restart the app.
 
+To compare résumé-pipeline depths (`fast` / `quality` / `max`) over runs you have already
+made, dump `pipeline_runs.db`'s per-run `metrics_json` as a per-depth table:
+
+```bash
+node scripts/dump-run-metrics.mjs --help   # options + the default path for your OS
+node scripts/dump-run-metrics.mjs          # the app-data DB, aggregated per depth
+```
+
+Read-only and content-free — counts, codes and durations, never document text or a
+posting URL (ADR-027). It needs Node ≥ 22.5 for the built-in `node:sqlite`. The
+deterministic half of the same question, validator precision/recall on labelled defect
+fixtures, is `cargo test --test eval -- --nocapture` in `apps/desktop/src-tauri`.
+
 ### Migrations and stale dev DBs
 
 Each store owns its own migration list and tracks progress with `PRAGMA user_version`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -254,24 +254,16 @@ Embedding vectors live in the `vectors` table of `documents.db` and cosine simil
 runs in-process in Rust — **no LanceDB, no `vectors/` directory**. To reset dev state,
 delete the `*.db` files in that directory and restart the app.
 
-To compare résumé-pipeline depths (`fast` / `quality` / `max`) over runs you have already
-made, dump `pipeline_runs.db`'s per-run `metrics_json` as a per-depth table:
+Two offline evaluation entry points, one per half of "is a deeper pipeline worth it":
 
 ```bash
-node scripts/dump-run-metrics.mjs --help   # options + the default path for your OS
-node scripts/dump-run-metrics.mjs          # the app-data DB, aggregated per depth
+node scripts/dump-run-metrics.mjs --help   # depth A/B over your own recorded runs
+cargo test --test eval -- --nocapture      # validator precision/recall on fixtures
 ```
 
-Content-free — counts, codes and durations, never document text or a posting URL
-(ADR-027) — and it never writes to the database's CONTENT, though opening a WAL database
-for reading does materialize the usual `-shm`/`-wal` sidecars next to it. It needs Node
-≥ 22.13 for the built-in `node:sqlite`.
-
-The deterministic half of the same question, validator precision/recall on labelled
-defect fixtures, is `cargo test --test eval -- --nocapture` in `apps/desktop/src-tauri`.
-Read its warning-findings line together with the `Caveat:` line printed directly under
-it — some of the truthful fixtures are already pinned to an empty report by the unit
-suite, and the caveat says how many, so the headline is weaker than it looks.
+Both print their own contract — requirements, defaults, caveats and privacy posture live
+in the file headers (`scripts/dump-run-metrics.mjs`, `apps/desktop/src-tauri/tests/eval.rs`)
+and in `--help`, which is where they stay current.
 
 ### Migrations and stale dev DBs
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -269,8 +269,9 @@ for reading does materialize the usual `-shm`/`-wal` sidecars next to it. It nee
 
 The deterministic half of the same question, validator precision/recall on labelled
 defect fixtures, is `cargo test --test eval -- --nocapture` in `apps/desktop/src-tauri`.
-Read its false-positive line with the caveat it prints: two of the five truthful fixtures
-are already pinned to an empty report by the unit suite, so only three of them can move.
+Read its warning-findings line together with the `Caveat:` line printed directly under
+it — some of the truthful fixtures are already pinned to an empty report by the unit
+suite, and the caveat says how many, so the headline is weaker than it looks.
 
 ### Migrations and stale dev DBs
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -262,10 +262,15 @@ node scripts/dump-run-metrics.mjs --help   # options + the default path for your
 node scripts/dump-run-metrics.mjs          # the app-data DB, aggregated per depth
 ```
 
-Read-only and content-free — counts, codes and durations, never document text or a
-posting URL (ADR-027). It needs Node ≥ 22.5 for the built-in `node:sqlite`. The
-deterministic half of the same question, validator precision/recall on labelled defect
-fixtures, is `cargo test --test eval -- --nocapture` in `apps/desktop/src-tauri`.
+Content-free — counts, codes and durations, never document text or a posting URL
+(ADR-027) — and it never writes to the database's CONTENT, though opening a WAL database
+for reading does materialize the usual `-shm`/`-wal` sidecars next to it. It needs Node
+≥ 22.13 for the built-in `node:sqlite`.
+
+The deterministic half of the same question, validator precision/recall on labelled
+defect fixtures, is `cargo test --test eval -- --nocapture` in `apps/desktop/src-tauri`.
+Read its false-positive line with the caveat it prints: two of the five truthful fixtures
+are already pinned to an empty report by the unit suite, so only three of them can move.
 
 ### Migrations and stale dev DBs
 

--- a/scripts/dump-run-metrics.mjs
+++ b/scripts/dump-run-metrics.mjs
@@ -1,0 +1,356 @@
+// Dev-only depth A/B dump: what `fast` / `quality` / `max` runs actually cost and
+// how clean their output was, read out of the app's own `pipeline_runs.db`.
+//
+// The offline harness (`apps/desktop/src-tauri/tests/eval.rs`) measures the
+// DETERMINISTIC validators on labelled fixtures. It cannot say anything about
+// generation, because generation needs a live model — so the depth comparison is
+// this: aggregate the `metrics_json` blob every finished run already writes, per
+// depth, over the runs a developer produced on their own machine.
+//
+// Read-only, and CONTENT-FREE by construction (ADR-027): it reads exactly six
+// columns plus `metrics_json` (counts, durations, codes) and prints counts, codes
+// and milliseconds. It never reads — and cannot print — a résumé, a job ad, an
+// evidence span, or a posting URL. `pipeline_run_events.artifact_json` is where a
+// max run persists its strategy and evidence detail, and this script does not open
+// that table at all.
+//
+// Source of truth for the shape: apps/desktop/src-tauri/src/pipeline/runs/mod.rs
+// (the table) and apps/desktop/src-tauri/src/commands/resume_pipeline/mod.rs
+// (the `metrics_json` keys, written at the one terminal-update site).
+//
+// Usage:  node scripts/dump-run-metrics.mjs --help
+//
+// Requires Node >= 22.5 for the built-in `node:sqlite` (zero new dependencies —
+// the repo carries no JS SQLite driver, and a dev dump script is not worth one).
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const DB_FILE = 'pipeline_runs.db';
+const IDENTIFIER = 'com.ajh.desktop';
+
+/** Depths in pipeline order, so the table reads fast → max regardless of row order. */
+const DEPTH_ORDER = ['fast', 'quality', 'max'];
+
+/**
+ * The app data directory the desktop app resolves at runtime — Tauri's
+ * `app_data_dir()`, overridable by `AJH_DATA_DIR` (which the app itself exports
+ * during setup; see platform/config.rs `resolve_and_export_data_dir`). The
+ * per-OS paths are the ones documented in docs/DEVELOPMENT.md.
+ */
+function defaultDataDir() {
+  if (process.env.AJH_DATA_DIR) return process.env.AJH_DATA_DIR;
+  const home = homedir();
+  if (process.platform === 'win32') {
+    return join(process.env.APPDATA || join(home, 'AppData', 'Roaming'), IDENTIFIER);
+  }
+  if (process.platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', IDENTIFIER);
+  }
+  return join(process.env.XDG_DATA_HOME || join(home, '.local', 'share'), IDENTIFIER);
+}
+
+const HELP = `dump-run-metrics — per-depth aggregates over recorded pipeline runs (dev-only)
+
+  node scripts/dump-run-metrics.mjs [<path-to-${DB_FILE}>] [options]
+
+Options
+  --db <path>     The database to read. Defaults to the app data dir's ${DB_FILE}:
+                    Windows  %APPDATA%\\${IDENTIFIER}\\${DB_FILE}
+                    macOS    ~/Library/Application Support/${IDENTIFIER}/${DB_FILE}
+                    Linux    ~/.local/share/${IDENTIFIER}/${DB_FILE}
+                  \`AJH_DATA_DIR\` overrides the directory, exactly as it does for
+                  the app itself.
+                  Resolved for this machine right now:
+                    ${join(defaultDataDir(), DB_FILE)}
+  --kind <kind>   Run kind to include (default: resume). \`kind\` is the store's
+                  discriminator — these tables also host agent runs.
+  --json          Emit the aggregates as JSON instead of a table.
+  --help, -h      This text.
+
+Output is counts, codes and durations only — never document text (ADR-027).
+Requires Node >= 22.5 (built-in node:sqlite).`;
+
+function parseArgs(argv) {
+  const opts = { db: null, kind: 'resume', json: false, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') opts.help = true;
+    else if (arg === '--json') opts.json = true;
+    else if (arg === '--db') opts.db = argv[(i += 1)];
+    else if (arg === '--kind') opts.kind = argv[(i += 1)];
+    else if (arg.startsWith('-')) throw new Error(`unknown option: ${arg}`);
+    else if (opts.db === null) opts.db = arg;
+    else throw new Error(`unexpected extra argument: ${arg}`);
+  }
+  if (opts.db === undefined || opts.kind === undefined) {
+    throw new Error('--db and --kind each take a value');
+  }
+  return opts;
+}
+
+/**
+ * `p`-th percentile of `values` by nearest-rank, or null for an empty set.
+ *
+ * Nearest-rank (not interpolated) on purpose: these are run durations measured a
+ * handful of times on one machine, and an interpolated p90 over six samples
+ * invents a millisecond value no run ever took.
+ */
+function percentile(values, p) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length);
+  return sorted[Math.min(Math.max(rank, 1), sorted.length) - 1];
+}
+
+function mean(values) {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/** `n` → a fixed-width count string; null → an em dash, never a misleading `0`. */
+function num(value, digits = 1) {
+  if (value === null || value === undefined) return '—';
+  return Number.isInteger(value) ? String(value) : value.toFixed(digits);
+}
+
+function tally(map, key) {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function formatTally(map) {
+  if (map.size === 0) return '—';
+  return [...map.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([key, count]) => `${key}=${count}`)
+    .join(' ');
+}
+
+/**
+ * Fold one depth's rows into the aggregate row the table prints.
+ *
+ * Every field is derived defensively: `metrics_json` is a free-form, CLAMPED
+ * column (`METRICS_CAP_BYTES`), an over-cap value is deliberately left
+ * UNPARSEABLE by the store's truncation marker, and rows written by an older
+ * build simply lack the newer keys. A dump that threw on any of those would be
+ * unusable against exactly the history it exists to read, so unreadable metrics
+ * are COUNTED (`unparsedMetrics`) rather than silently treated as zeros.
+ */
+function aggregate(depth, rows) {
+  const statuses = new Map();
+  const stops = new Map();
+  const durations = [];
+  const issues = [];
+  const criticals = [];
+  const repairs = [];
+  const calls = [];
+  const cached = [];
+  let unparsedMetrics = 0;
+  let reverted = 0;
+  const postings = new Set();
+
+  for (const row of rows) {
+    tally(statuses, row.status);
+    tally(stops, row.stopped_reason ?? '—');
+    // A count of DISTINCT postings, never the urls themselves: "6 runs over 2
+    // postings" is what makes an average meaningful, and the url is the one
+    // column here that is user data.
+    postings.add(row.job_url ?? '');
+
+    let metrics = null;
+    try {
+      metrics = JSON.parse(row.metrics_json ?? '{}');
+    } catch {
+      unparsedMetrics += 1;
+    }
+    if (metrics && typeof metrics === 'object') {
+      if (typeof metrics.ms === 'number') durations.push(metrics.ms);
+      if (typeof metrics.issueCount === 'number') issues.push(metrics.issueCount);
+      if (typeof metrics.criticalCount === 'number') criticals.push(metrics.criticalCount);
+      if (typeof metrics.repairRounds === 'number') repairs.push(metrics.repairRounds);
+      if (typeof metrics.calls === 'number') calls.push(metrics.calls);
+      if (typeof metrics.cached === 'number') cached.push(metrics.cached);
+      if (metrics.reverted === true) reverted += 1;
+    }
+    // `ms` is written only at the terminal update, so a crashed/still-running
+    // row has none. The columns still bound it — but only when it FINISHED;
+    // an open run has no duration, not a duration of "now minus then".
+    if (
+      (!metrics || typeof metrics.ms !== 'number') &&
+      typeof row.finished_at === 'number' &&
+      typeof row.started_at === 'number'
+    ) {
+      durations.push(row.finished_at - row.started_at);
+    }
+  }
+
+  // Warnings = issues − criticals, and ONLY where both halves came from the same
+  // run: subtracting two independently-averaged columns would report a warning
+  // count for runs that never reported one.
+  const warnings = [];
+  for (const row of rows) {
+    try {
+      const m = JSON.parse(row.metrics_json ?? '{}');
+      if (typeof m.issueCount === 'number' && typeof m.criticalCount === 'number') {
+        warnings.push(m.issueCount - m.criticalCount);
+      }
+    } catch {
+      /* already counted in unparsedMetrics */
+    }
+  }
+
+  return {
+    depth,
+    runs: rows.length,
+    postings: postings.size,
+    statuses: Object.fromEntries(statuses),
+    stopReasons: Object.fromEntries(stops),
+    msMedian: percentile(durations, 50),
+    msP90: percentile(durations, 90),
+    issuesMean: mean(issues),
+    criticalsMean: mean(criticals),
+    warningsMean: mean(warnings),
+    repairRoundsMean: mean(repairs),
+    revertedRuns: reverted,
+    callsMean: mean(calls),
+    cachedMean: mean(cached),
+    unparsedMetrics,
+  };
+}
+
+function printTable(aggregates, kind) {
+  const total = aggregates.reduce((sum, a) => sum + a.runs, 0);
+  console.log(
+    `\n=== pipeline run metrics — kind=${kind}, ${total} run${total === 1 ? '' : 's'} ===\n`
+  );
+  const head = [
+    'depth'.padEnd(9),
+    'runs'.padStart(5),
+    'jobs'.padStart(5),
+    'ms p50'.padStart(9),
+    'ms p90'.padStart(9),
+    'issues'.padStart(7),
+    'crit'.padStart(6),
+    'warn'.padStart(6),
+    'repairs'.padStart(8),
+    'revert'.padStart(7),
+    'calls'.padStart(6),
+    'cached'.padStart(7),
+  ].join(' ');
+  console.log(head);
+  for (const a of aggregates) {
+    console.log(
+      [
+        a.depth.padEnd(9),
+        String(a.runs).padStart(5),
+        String(a.postings).padStart(5),
+        num(a.msMedian).padStart(9),
+        num(a.msP90).padStart(9),
+        num(a.issuesMean).padStart(7),
+        num(a.criticalsMean).padStart(6),
+        num(a.warningsMean).padStart(6),
+        num(a.repairRoundsMean).padStart(8),
+        String(a.revertedRuns).padStart(7),
+        num(a.callsMean).padStart(6),
+        num(a.cachedMean).padStart(7),
+      ].join(' ')
+    );
+  }
+  console.log('\nmeans per run; ms p50/p90 are nearest-rank over the runs that finished\n');
+  console.log(`${'depth'.padEnd(9)} ${'status'.padEnd(44)} stopped reason`);
+  for (const a of aggregates) {
+    console.log(
+      `${a.depth.padEnd(9)} ${formatTally(new Map(Object.entries(a.statuses))).padEnd(44)} ` +
+        formatTally(new Map(Object.entries(a.stopReasons)))
+    );
+  }
+  const unparsed = aggregates.reduce((sum, a) => sum + a.unparsedMetrics, 0);
+  if (unparsed > 0) {
+    console.log(
+      `\n${unparsed} run(s) carry unparseable metrics_json (clamped past ` +
+        `METRICS_CAP_BYTES) and contributed to counts only.`
+    );
+  }
+  console.log();
+}
+
+async function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (e) {
+    console.error(`${e.message}\n\n${HELP}`);
+    process.exit(2);
+  }
+  if (opts.help) {
+    console.log(HELP);
+    return;
+  }
+
+  const dbPath = opts.db ?? join(defaultDataDir(), DB_FILE);
+  if (!existsSync(dbPath)) {
+    console.error(
+      `no database at ${dbPath}\n\nRun the résumé pipeline at least once, or pass the path ` +
+        `explicitly. \`node scripts/dump-run-metrics.mjs --help\` lists the defaults.`
+    );
+    process.exit(1);
+  }
+
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import('node:sqlite'));
+  } catch {
+    console.error(
+      `node:sqlite is unavailable on ${process.version} — this dev script needs Node >= 22.5.`
+    );
+    process.exit(1);
+  }
+
+  // Read-only: this may be the LIVE app database, and a dump must never write to
+  // it (nor leave a -wal/-shm behind next to it).
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  let rows;
+  try {
+    rows = db
+      .prepare(
+        `SELECT depth, status, started_at, finished_at, stopped_reason, job_url, metrics_json
+           FROM pipeline_runs
+          WHERE kind = ?
+          ORDER BY started_at`
+      )
+      .all(opts.kind);
+  } catch (e) {
+    console.error(`cannot read pipeline_runs from ${dbPath}: ${e.message}`);
+    process.exit(1);
+  } finally {
+    db.close();
+  }
+
+  if (rows.length === 0) {
+    console.error(`no runs with kind=${opts.kind} in ${dbPath}`);
+    process.exit(1);
+  }
+
+  const byDepth = new Map();
+  for (const row of rows) {
+    const depth = row.depth || '(unset)';
+    if (!byDepth.has(depth)) byDepth.set(depth, []);
+    byDepth.get(depth).push(row);
+  }
+  // Known depths first, in pipeline order; anything else (an older build, a
+  // renamed depth) after them rather than dropped.
+  const depths = [
+    ...DEPTH_ORDER.filter((d) => byDepth.has(d)),
+    ...[...byDepth.keys()].filter((d) => !DEPTH_ORDER.includes(d)).sort(),
+  ];
+  const aggregates = depths.map((depth) => aggregate(depth, byDepth.get(depth)));
+
+  if (opts.json) {
+    console.log(JSON.stringify({ kind: opts.kind, depths: aggregates }, null, 2));
+    return;
+  }
+  printTable(aggregates, opts.kind);
+}
+
+await main();

--- a/scripts/dump-run-metrics.mjs
+++ b/scripts/dump-run-metrics.mjs
@@ -80,10 +80,15 @@ Requires Node >= 22.13 (built-in node:sqlite, unflagged).`;
 /**
  * Parse argv into options.
  *
- * A value that begins with `-` is REFUSED rather than consumed: `--kind --json`
- * is a typo, and silently taking `--json` as the kind name would have queried
- * for runs of kind "--json" (zero rows) and dropped the flag — a wrong answer
- * reported confidently.
+ * Two ways to be wrong are refused rather than resolved:
+ *
+ * * a value that begins with `-` (`--kind --json` is a typo, and taking
+ *   `--json` as the kind name would query for runs of kind "--json" — zero rows
+ *   — AND drop the flag, a wrong answer reported confidently);
+ * * a second database path in EITHER order. `a.db --db b.db` silently read
+ *   b.db while `--db a.db b.db` threw about an "extra argument"; they are the
+ *   same mistake, and a dump that quietly picks one of two paths is the worst
+ *   available answer.
  */
 function parseArgs(argv) {
   const opts = { db: null, kind: 'resume', json: false, help: false };
@@ -92,15 +97,18 @@ function parseArgs(argv) {
     if (raw.startsWith('-')) throw new Error(`${flag} needs a value, got the flag ${raw}`);
     return raw;
   };
+  const once = (path, current) => {
+    if (current.db !== null) throw new Error('the database path was given twice');
+    return path;
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--help' || arg === '-h') opts.help = true;
     else if (arg === '--json') opts.json = true;
-    else if (arg === '--db') opts.db = value('--db', argv[(i += 1)]);
+    else if (arg === '--db') opts.db = once(value('--db', argv[(i += 1)]), opts);
     else if (arg === '--kind') opts.kind = value('--kind', argv[(i += 1)]);
     else if (arg.startsWith('-')) throw new Error(`unknown option: ${arg}`);
-    else if (opts.db === null) opts.db = arg;
-    else throw new Error(`unexpected extra argument: ${arg}`);
+    else opts.db = once(arg, opts);
   }
   return opts;
 }
@@ -341,8 +349,26 @@ async function main() {
   // behaviour, pinned by `a WAL dump leaves the main database byte-identical` in
   // the sibling test; `immutable=1` would avoid the sidecars but is a promise
   // this cannot keep, because the app may be writing while the dump reads.
-  const db = new DatabaseSync(dbPath, { readOnly: true });
-  let rows;
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+  } catch (e) {
+    // A directory instead of a file, a corrupt header, or — the case the comment
+    // above predicts — a WAL database in a directory this process cannot write.
+    // All three arrive as a raw ERR_SQLITE_ERROR throw, and an unhandled stack
+    // trace is not a diagnosis.
+    console.error(
+      `cannot open ${shownPath}: ${e.message}\n\nIt must be a SQLite file, and a WAL database ` +
+        `needs a WRITABLE directory even to be read (see --help).`
+    );
+    process.exit(1);
+  }
+
+  // Read, then close, then decide. A `finally { db.close() }` around a catch that
+  // calls `process.exit` never runs — exit does not unwind — so the handle leaked
+  // on exactly the error path where the file matters most.
+  let rows = null;
+  let readError = null;
   try {
     rows = db
       .prepare(
@@ -353,14 +379,16 @@ async function main() {
       )
       .all(opts.kind);
   } catch (e) {
+    readError = e;
+  }
+  db.close();
+  if (readError) {
     // The only schema-drift alarm in the script: a renamed table or column
     // reaches here, and reporting "no runs" for it would read as "you have not
     // run the pipeline yet" — the one wrong answer that stops the reader
     // looking.
-    console.error(`cannot read pipeline_runs from ${shownPath}: ${e.message}`);
+    console.error(`cannot read pipeline_runs from ${shownPath}: ${readError.message}`);
     process.exit(1);
-  } finally {
-    db.close();
   }
 
   if (rows.length === 0) {

--- a/scripts/dump-run-metrics.mjs
+++ b/scripts/dump-run-metrics.mjs
@@ -7,12 +7,18 @@
 // this: aggregate the `metrics_json` blob every finished run already writes, per
 // depth, over the runs a developer produced on their own machine.
 //
-// Read-only, and CONTENT-FREE by construction (ADR-027): it reads exactly six
-// columns plus `metrics_json` (counts, durations, codes) and prints counts, codes
-// and milliseconds. It never reads — and cannot print — a résumé, a job ad, an
+// CONTENT-FREE by construction (ADR-027): it reads exactly six columns plus
+// `metrics_json` (counts, durations, codes) and prints counts, codes and
+// milliseconds. It never reads — and cannot print — a résumé, a job ad, an
 // evidence span, or a posting URL. `pipeline_run_events.artifact_json` is where a
 // max run persists its strategy and evidence detail, and this script does not open
 // that table at all.
+//
+// It opens the database `readOnly`, so no row can change and the main DB file
+// stays byte-identical — but "read-only" is not "touches nothing on disk": these
+// stores are WAL (ADR-022), and a WAL reader materializes the `-shm`/`-wal`
+// sidecars beside the file. See the open site below for why `immutable=1` is the
+// wrong trade here.
 //
 // Source of truth for the shape: apps/desktop/src-tauri/src/pipeline/runs/mod.rs
 // (the table) and apps/desktop/src-tauri/src/commands/resume_pipeline/mod.rs
@@ -20,7 +26,7 @@
 //
 // Usage:  node scripts/dump-run-metrics.mjs --help
 //
-// Requires Node >= 22.5 for the built-in `node:sqlite` (zero new dependencies —
+// Requires Node >= 22.13 for the built-in `node:sqlite` (zero new dependencies —
 // the repo carries no JS SQLite driver, and a dev dump script is not worth one).
 
 import { existsSync } from 'node:fs';
@@ -62,30 +68,39 @@ Options
                     Linux    ~/.local/share/${IDENTIFIER}/${DB_FILE}
                   \`AJH_DATA_DIR\` overrides the directory, exactly as it does for
                   the app itself.
-                  Resolved for this machine right now:
-                    ${join(defaultDataDir(), DB_FILE)}
   --kind <kind>   Run kind to include (default: resume). \`kind\` is the store's
                   discriminator — these tables also host agent runs.
   --json          Emit the aggregates as JSON instead of a table.
   --help, -h      This text.
 
-Output is counts, codes and durations only — never document text (ADR-027).
-Requires Node >= 22.5 (built-in node:sqlite).`;
+Output is counts, codes and durations only — never document text (ADR-027); the
+template paths above are printed unexpanded for the same reason.
+Requires Node >= 22.13 (built-in node:sqlite, unflagged).`;
 
+/**
+ * Parse argv into options.
+ *
+ * A value that begins with `-` is REFUSED rather than consumed: `--kind --json`
+ * is a typo, and silently taking `--json` as the kind name would have queried
+ * for runs of kind "--json" (zero rows) and dropped the flag — a wrong answer
+ * reported confidently.
+ */
 function parseArgs(argv) {
   const opts = { db: null, kind: 'resume', json: false, help: false };
+  const value = (flag, raw) => {
+    if (raw === undefined) throw new Error(`${flag} needs a value`);
+    if (raw.startsWith('-')) throw new Error(`${flag} needs a value, got the flag ${raw}`);
+    return raw;
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--help' || arg === '-h') opts.help = true;
     else if (arg === '--json') opts.json = true;
-    else if (arg === '--db') opts.db = argv[(i += 1)];
-    else if (arg === '--kind') opts.kind = argv[(i += 1)];
+    else if (arg === '--db') opts.db = value('--db', argv[(i += 1)]);
+    else if (arg === '--kind') opts.kind = value('--kind', argv[(i += 1)]);
     else if (arg.startsWith('-')) throw new Error(`unknown option: ${arg}`);
     else if (opts.db === null) opts.db = arg;
     else throw new Error(`unexpected extra argument: ${arg}`);
-  }
-  if (opts.db === undefined || opts.kind === undefined) {
-    throw new Error('--db and --kind each take a value');
   }
   return opts;
 }
@@ -146,8 +161,14 @@ function aggregate(depth, rows) {
   const repairs = [];
   const calls = [];
   const cached = [];
+  const warnings = [];
   let unparsedMetrics = 0;
   let reverted = 0;
+  // How many rows actually REPORTED a `reverted` flag. Without this, a row whose
+  // metrics parse but carry none of the expected keys made the column print a
+  // confident `0` ("no run reverted") while every neighbouring cell printed `—`
+  // ("nobody measured"). Zero and unmeasured are different answers.
+  let revertedKnown = 0;
   const postings = new Set();
 
   for (const row of rows) {
@@ -158,6 +179,9 @@ function aggregate(depth, rows) {
     // column here that is user data.
     postings.add(row.job_url ?? '');
 
+    // ONE parse per row: the warnings pass used to re-parse every row a second
+    // time, which is two chances for the two passes to disagree about what a
+    // row said.
     let metrics = null;
     try {
       metrics = JSON.parse(row.metrics_json ?? '{}');
@@ -171,7 +195,16 @@ function aggregate(depth, rows) {
       if (typeof metrics.repairRounds === 'number') repairs.push(metrics.repairRounds);
       if (typeof metrics.calls === 'number') calls.push(metrics.calls);
       if (typeof metrics.cached === 'number') cached.push(metrics.cached);
-      if (metrics.reverted === true) reverted += 1;
+      if (typeof metrics.reverted === 'boolean') {
+        revertedKnown += 1;
+        if (metrics.reverted) reverted += 1;
+      }
+      // Warnings = issues − criticals, from the SAME run: subtracting two
+      // independently-averaged columns would report a warning count for runs
+      // that never reported one.
+      if (typeof metrics.issueCount === 'number' && typeof metrics.criticalCount === 'number') {
+        warnings.push(metrics.issueCount - metrics.criticalCount);
+      }
     }
     // `ms` is written only at the terminal update, so a crashed/still-running
     // row has none. The columns still bound it — but only when it FINISHED;
@@ -182,21 +215,6 @@ function aggregate(depth, rows) {
       typeof row.started_at === 'number'
     ) {
       durations.push(row.finished_at - row.started_at);
-    }
-  }
-
-  // Warnings = issues − criticals, and ONLY where both halves came from the same
-  // run: subtracting two independently-averaged columns would report a warning
-  // count for runs that never reported one.
-  const warnings = [];
-  for (const row of rows) {
-    try {
-      const m = JSON.parse(row.metrics_json ?? '{}');
-      if (typeof m.issueCount === 'number' && typeof m.criticalCount === 'number') {
-        warnings.push(m.issueCount - m.criticalCount);
-      }
-    } catch {
-      /* already counted in unparsedMetrics */
     }
   }
 
@@ -212,7 +230,8 @@ function aggregate(depth, rows) {
     criticalsMean: mean(criticals),
     warningsMean: mean(warnings),
     repairRoundsMean: mean(repairs),
-    revertedRuns: reverted,
+    // `null` when no row reported the flag at all — see `revertedKnown`.
+    revertedRuns: revertedKnown > 0 ? reverted : null,
     callsMean: mean(calls),
     cachedMean: mean(cached),
     unparsedMetrics,
@@ -251,7 +270,7 @@ function printTable(aggregates, kind) {
         num(a.criticalsMean).padStart(6),
         num(a.warningsMean).padStart(6),
         num(a.repairRoundsMean).padStart(8),
-        String(a.revertedRuns).padStart(7),
+        num(a.revertedRuns).padStart(7),
         num(a.callsMean).padStart(6),
         num(a.cachedMean).padStart(7),
       ].join(' ')
@@ -288,10 +307,15 @@ async function main() {
     return;
   }
 
+  // An EXPLICIT path is echoed back (the user typed it); a DEFAULTED one is
+  // named by its template rather than expanded, because the resolved form
+  // contains the OS account name and these messages get pasted into issues.
+  const defaulted = opts.db === null;
   const dbPath = opts.db ?? join(defaultDataDir(), DB_FILE);
+  const shownPath = defaulted ? `<app data dir>/${DB_FILE}` : dbPath;
   if (!existsSync(dbPath)) {
     console.error(
-      `no database at ${dbPath}\n\nRun the résumé pipeline at least once, or pass the path ` +
+      `no database at ${shownPath}\n\nRun the résumé pipeline at least once, or pass the path ` +
         `explicitly. \`node scripts/dump-run-metrics.mjs --help\` lists the defaults.`
     );
     process.exit(1);
@@ -302,13 +326,21 @@ async function main() {
     ({ DatabaseSync } = await import('node:sqlite'));
   } catch {
     console.error(
-      `node:sqlite is unavailable on ${process.version} — this dev script needs Node >= 22.5.`
+      `node:sqlite is unavailable on ${process.version} — this dev script needs Node >= 22.13.`
     );
     process.exit(1);
   }
 
-  // Read-only: this may be the LIVE app database, and a dump must never write to
-  // it (nor leave a -wal/-shm behind next to it).
+  // `readOnly` because this may be the LIVE app database: no statement here can
+  // change a row, and the main DB file's bytes are untouched.
+  //
+  // It does NOT mean "leaves the directory alone". Every store opens WAL
+  // (`db::open`, ADR-022), and a WAL READER still maps the shared-memory index
+  // and the log — so `-shm` (and `-wal`, if none exists yet) appear beside the
+  // database and the directory must be writable. That is normal SQLite
+  // behaviour, pinned by `a WAL dump leaves the main database byte-identical` in
+  // the sibling test; `immutable=1` would avoid the sidecars but is a promise
+  // this cannot keep, because the app may be writing while the dump reads.
   const db = new DatabaseSync(dbPath, { readOnly: true });
   let rows;
   try {
@@ -321,14 +353,18 @@ async function main() {
       )
       .all(opts.kind);
   } catch (e) {
-    console.error(`cannot read pipeline_runs from ${dbPath}: ${e.message}`);
+    // The only schema-drift alarm in the script: a renamed table or column
+    // reaches here, and reporting "no runs" for it would read as "you have not
+    // run the pipeline yet" — the one wrong answer that stops the reader
+    // looking.
+    console.error(`cannot read pipeline_runs from ${shownPath}: ${e.message}`);
     process.exit(1);
   } finally {
     db.close();
   }
 
   if (rows.length === 0) {
-    console.error(`no runs with kind=${opts.kind} in ${dbPath}`);
+    console.error(`no runs with kind=${opts.kind} in ${shownPath}`);
     process.exit(1);
   }
 

--- a/scripts/dump-run-metrics.mjs
+++ b/scripts/dump-run-metrics.mjs
@@ -192,11 +192,21 @@ function aggregate(depth, rows) {
     // row said.
     let metrics = null;
     try {
-      metrics = JSON.parse(row.metrics_json ?? '{}');
+      const parsed = JSON.parse(row.metrics_json ?? '{}');
+      // UNREADABLE and NOT-AN-OBJECT are the same outcome here, and both must be
+      // COUNTED. `JSON.parse` does not throw for `null`, `123`, `"x"` or `[]` —
+      // all valid JSON, none of them a metrics object — so testing only for a
+      // throw left those rows contributing to no column AND to no counter, i.e.
+      // invisible, which is the one thing `unparsedMetrics` exists to prevent.
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        metrics = parsed;
+      } else {
+        unparsedMetrics += 1;
+      }
     } catch {
       unparsedMetrics += 1;
     }
-    if (metrics && typeof metrics === 'object') {
+    if (metrics) {
       if (typeof metrics.ms === 'number') durations.push(metrics.ms);
       if (typeof metrics.issueCount === 'number') issues.push(metrics.issueCount);
       if (typeof metrics.criticalCount === 'number') criticals.push(metrics.criticalCount);
@@ -295,8 +305,9 @@ function printTable(aggregates, kind) {
   const unparsed = aggregates.reduce((sum, a) => sum + a.unparsedMetrics, 0);
   if (unparsed > 0) {
     console.log(
-      `\n${unparsed} run(s) carry unparseable metrics_json (clamped past ` +
-        `METRICS_CAP_BYTES) and contributed to counts only.`
+      `\n${unparsed} run(s) carry a metrics_json this dump cannot read — clamped past ` +
+        `METRICS_CAP_BYTES, or valid JSON that is not an object. They contributed to run ` +
+        `counts, statuses and (where timestamps allow) durations only.`
     );
   }
   console.log();

--- a/scripts/dump-run-metrics.test.mjs
+++ b/scripts/dump-run-metrics.test.mjs
@@ -33,32 +33,84 @@ try {
 const describeSqlite = DatabaseSync ? describe : describe.skip;
 
 // Black-box test of the CLI (execFileSync), mirroring check-tech-radar.test.mjs /
-// ci-review-verdict.test.mjs. The fixture DB is created with the schema VERBATIM
-// from `CREATE_PIPELINE_RUNS_SQL` in apps/desktop/src-tauri/src/pipeline/runs/mod.rs
-// — a hand-simplified schema would let the script pass here and fail on a real
-// database.
-const CREATE_SQL = `CREATE TABLE IF NOT EXISTS pipeline_runs (
-        id             TEXT PRIMARY KEY NOT NULL,
-        job_url        TEXT NOT NULL,
-        kind           TEXT NOT NULL,
-        depth          TEXT NOT NULL,
-        status         TEXT NOT NULL,
-        started_at     INTEGER NOT NULL,
-        finished_at    INTEGER,
-        stopped_reason TEXT,
-        metrics_json   TEXT NOT NULL DEFAULT '{}'
-     );
-     CREATE INDEX IF NOT EXISTS idx_pipeline_runs_job
-         ON pipeline_runs(job_url, started_at DESC);
-     CREATE TABLE IF NOT EXISTS pipeline_run_events (
-        run_id        TEXT NOT NULL,
-        seq           INTEGER NOT NULL,
-        ts            INTEGER NOT NULL,
-        stage         TEXT NOT NULL,
-        phase         TEXT NOT NULL CHECK (phase IN ('start', 'finish', 'error')),
-        artifact_json TEXT NOT NULL,
-        PRIMARY KEY (run_id, seq)
-     );`;
+// ci-review-verdict.test.mjs.
+//
+// The fixture DB is created with the PRODUCT's schema, READ OUT OF THE RUST
+// SOURCE at test time rather than hand-copied. A copy would have made this suite
+// green against a shape the app no longer writes — the whole failure mode a
+// cross-language mirror has — so the Rust const is the single definition and this
+// file is a reader of it, the same spirit as
+// `phase_check_matches_the_generated_contract` on the Rust side.
+const REPO_ROOT = join(__dirname, '..');
+const RUNS_MOD = join(REPO_ROOT, 'apps/desktop/src-tauri/src/pipeline/runs/mod.rs');
+const LEDGER_MOD = join(REPO_ROOT, 'apps/desktop/src-tauri/src/pipeline/resume/mod.rs');
+const PIPELINE_CMD = join(REPO_ROOT, 'apps/desktop/src-tauri/src/commands/resume_pipeline/mod.rs');
+
+/**
+ * Extract a `const NAME: &str = "…";` string literal from a Rust source file.
+ *
+ * Deliberately simple, and it VERIFIES its own assumption: the literal must
+ * contain no `"` and no backslash escape, which is true of the SQL consts here
+ * and is what makes "slice to the closing quote" correct. If either shows up the
+ * extraction throws rather than seeding a half-truncated schema and reporting a
+ * confusing SQLite error twenty lines later.
+ */
+function rustStringConst(path, name) {
+  const src = readFileSync(path, 'utf8');
+  const decl = src.indexOf(`const ${name}`);
+  if (decl < 0) throw new Error(`${name} not found in ${path} — was it renamed?`);
+  const open = src.indexOf('"', decl);
+  const close = src.indexOf('";', open);
+  if (open < 0 || close < 0) throw new Error(`could not read the ${name} literal in ${path}`);
+  const value = src.slice(open + 1, close);
+  if (value.includes('\\')) {
+    throw new Error(`${name} now contains an escape; this extractor cannot read it verbatim`);
+  }
+  return value;
+}
+
+const CREATE_SQL = rustStringConst(RUNS_MOD, 'CREATE_PIPELINE_RUNS_SQL');
+
+/**
+ * Every key the app writes into `metrics_json`, read out of the two Rust sites
+ * that write them: `RunLedger::metrics()` and the terminal-update block in
+ * `commands::resume_pipeline::execute`.
+ *
+ * The window around the command's block is deliberate — that file has other
+ * `object.insert` calls against other objects, and a file-wide regex picked one
+ * of them up.
+ */
+function rustMetricsKeys() {
+  const ledger = readFileSync(LEDGER_MOD, 'utf8');
+  const from = ledger.indexOf('pub fn metrics(&self) -> Value {');
+  const to = ledger.indexOf('\n    }', from);
+  if (from < 0 || to < 0) throw new Error(`RunLedger::metrics() not found in ${LEDGER_MOD}`);
+  const ledgerKeys = [...ledger.slice(from, to).matchAll(/"([A-Za-z]+)":/g)].map((m) => m[1]);
+
+  const cmd = readFileSync(PIPELINE_CMD, 'utf8');
+  const wFrom = cmd.indexOf('let mut metrics = ledger.metrics();');
+  const wTo = cmd.indexOf('row.metrics_json = metrics.to_string();', wFrom);
+  if (wFrom < 0 || wTo < 0) throw new Error(`the metrics block was not found in ${PIPELINE_CMD}`);
+  const added = [...cmd.slice(wFrom, wTo).matchAll(/object\.insert\(\s*"([A-Za-z]+)"/g)].map(
+    (m) => m[1]
+  );
+
+  if (ledgerKeys.length === 0 || added.length === 0) {
+    throw new Error('metrics-key extraction found nothing — the Rust shape moved');
+  }
+  return new Set([...ledgerKeys, ...added]);
+}
+
+/** The keys this dump reads. The guard below proves Rust still writes them. */
+const KEYS_THE_DUMP_READS = [
+  'calls',
+  'cached',
+  'criticalCount',
+  'issueCount',
+  'ms',
+  'repairRounds',
+  'reverted',
+];
 
 const workDir = join(tmpdir(), `dump-run-metrics-test-${Date.now()}`);
 const dbPath = join(workDir, 'pipeline_runs.db');
@@ -216,8 +268,11 @@ const ROWS = [
   ['a1', JOB_B, 'agent', 'full', 'completed', T0, T0 + 5_000, 'done', m({ calls: 2 })],
 ];
 
-function run(args) {
-  return execFileSync(process.execPath, [scriptPath, ...args], { encoding: 'utf8' });
+function run(args, env) {
+  return execFileSync(process.execPath, [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: env ? { ...process.env, ...env } : process.env,
+  });
 }
 
 /** Run expecting a non-zero exit; returns `{ status, stderr }`. */
@@ -262,6 +317,44 @@ beforeAll(() => {
 });
 
 afterAll(() => rmSync(workDir, { recursive: true, force: true }));
+
+// Its OWN suite, with no sqlite gate, deliberately: this is the cross-language
+// contract, so it is checked even on a Node without `node:sqlite`, and a renamed
+// metrics KEY is reported as one failing assertion naming the key rather than as
+// fallout somewhere in the seeded suite.
+//
+// A renamed COLUMN is louder still, and not by this suite's doing: `seed()` then
+// cannot insert, vitest fails the FILE from `beforeAll` (message: "table
+// pipeline_runs has no column named …") and tallies the rest as skipped. That is
+// a hard red with the column named in it, which is the diagnosis you want — the
+// case worth spelling out is only that "skipped" in that tally means aborted, not
+// "node:sqlite missing".
+describe('dump-run-metrics ↔ Rust contract', () => {
+  it('reads columns the schema still declares', () => {
+    expect(CREATE_SQL).toContain('CREATE TABLE IF NOT EXISTS pipeline_runs');
+    // The script's own SELECT list. A column renamed on the Rust side lands here
+    // rather than as a puzzling SQLite error inside the seeded suite.
+    for (const column of [
+      'depth',
+      'status',
+      'started_at',
+      'finished_at',
+      'stopped_reason',
+      'job_url',
+      'metrics_json',
+    ]) {
+      expect(CREATE_SQL, `pipeline_runs no longer has a ${column} column`).toContain(column);
+    }
+  });
+
+  it('aggregates only metrics keys Rust still writes', () => {
+    // Renaming e.g. `repairRounds` in Rust leaves this dump averaging a key
+    // nobody writes — every cell would read `—` and nothing would say why.
+    const written = rustMetricsKeys();
+    const orphans = KEYS_THE_DUMP_READS.filter((k) => !written.has(k));
+    expect(orphans, 'metrics keys this dump reads that Rust no longer writes').toEqual([]);
+  });
+});
 
 describeSqlite('dump-run-metrics', () => {
   it('documents the default app-data location in --help', () => {
@@ -365,6 +458,22 @@ describeSqlite('dump-run-metrics', () => {
     expect(run(['--db', dbPath, '--json'])).toBe(run([dbPath, '--json']));
   });
 
+  it('falls back to AJH_DATA_DIR when no path is given', () => {
+    // The no-argument path is the one a developer actually types, and it is the
+    // only route through `defaultDataDir()`. AJH_DATA_DIR is the branch CI can
+    // exercise; the three per-OS branches under it stay hand-verified (they
+    // resolve %APPDATA% / ~/Library/Application Support / ~/.local/share, which
+    // a test could only restate).
+    const dataDir = join(workDir, 'as-app-data');
+    mkdirSync(dataDir, { recursive: true });
+    seed(join(dataDir, 'pipeline_runs.db'), [
+      ['e1', JOB_A, 'resume', 'fast', 'completed', T0, T0 + 7_000, 'done', m({ ms: 7_000 })],
+    ]);
+
+    const out = run(['--json'], { AJH_DATA_DIR: dataDir });
+    expect(JSON.parse(out).depths[0]).toMatchObject({ depth: 'fast', runs: 1, msMedian: 7_000 });
+  });
+
   it('never prints a posting url or a resume id (ADR-027)', () => {
     for (const out of [run([dbPath]), run([dbPath, '--json'])]) {
       expect(out).not.toContain(JOB_A);
@@ -435,5 +544,28 @@ describeSqlite('dump-run-metrics', () => {
       '--kind needs a value, got the flag --json'
     );
     expect(runFailing([dbPath, '--db']).stderr).toContain('--db needs a value');
+  });
+
+  it('refuses two paths in either order rather than silently picking one', () => {
+    // `one.db --db two.db` used to read two.db without a word; the reverse threw
+    // an unrelated "extra argument". Both are the same mistake and both are loud.
+    for (const args of [
+      [dbPath, '--db', dbPath],
+      ['--db', dbPath, dbPath],
+    ]) {
+      const { status, stderr } = runFailing(args);
+      expect(status).toBe(2);
+      expect(stderr).toContain('the database path was given twice');
+    }
+  });
+
+  it('reports an unopenable database instead of dumping a stack', () => {
+    // A directory is the realistic slip (tab-completing the data dir), and the
+    // adjacent case is a WAL database whose directory is not writable — both
+    // surface as an ERR_SQLITE_ERROR throw from the constructor.
+    const { status, stderr } = runFailing([workDir]);
+    expect(status).toBe(1);
+    expect(stderr).toContain('cannot open');
+    expect(stderr).not.toContain('at DatabaseSync');
   });
 });

--- a/scripts/dump-run-metrics.test.mjs
+++ b/scripts/dump-run-metrics.test.mjs
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const scriptPath = join(__dirname, 'dump-run-metrics.mjs');
+
+// Black-box test of the CLI (execFileSync), mirroring check-tech-radar.test.mjs /
+// ci-review-verdict.test.mjs. The fixture DB is created with the schema VERBATIM
+// from `CREATE_PIPELINE_RUNS_SQL` in apps/desktop/src-tauri/src/pipeline/runs/mod.rs
+// — a hand-simplified schema would let the script pass here and fail on a real
+// database.
+const CREATE_SQL = `CREATE TABLE IF NOT EXISTS pipeline_runs (
+        id             TEXT PRIMARY KEY NOT NULL,
+        job_url        TEXT NOT NULL,
+        kind           TEXT NOT NULL,
+        depth          TEXT NOT NULL,
+        status         TEXT NOT NULL,
+        started_at     INTEGER NOT NULL,
+        finished_at    INTEGER,
+        stopped_reason TEXT,
+        metrics_json   TEXT NOT NULL DEFAULT '{}'
+     );
+     CREATE INDEX IF NOT EXISTS idx_pipeline_runs_job
+         ON pipeline_runs(job_url, started_at DESC);
+     CREATE TABLE IF NOT EXISTS pipeline_run_events (
+        run_id        TEXT NOT NULL,
+        seq           INTEGER NOT NULL,
+        ts            INTEGER NOT NULL,
+        stage         TEXT NOT NULL,
+        phase         TEXT NOT NULL CHECK (phase IN ('start', 'finish', 'error')),
+        artifact_json TEXT NOT NULL,
+        PRIMARY KEY (run_id, seq)
+     );`;
+
+const workDir = join(tmpdir(), `dump-run-metrics-test-${Date.now()}`);
+const dbPath = join(workDir, 'pipeline_runs.db');
+const T0 = 1_770_000_000_000;
+
+/** A posting url — the one column in this table that is user data. */
+const JOB_A = 'https://boards.example.com/jane-secret-posting-a';
+const JOB_B = 'https://boards.example.com/jane-secret-posting-b';
+
+const m = (o) => JSON.stringify(o);
+
+const ROWS = [
+  // fast: two finished runs over two postings.
+  [
+    'r1',
+    JOB_A,
+    'resume',
+    'fast',
+    'completed',
+    T0,
+    T0 + 20_000,
+    'done',
+    m({
+      calls: 3,
+      cached: 0,
+      repairRounds: 0,
+      reverted: false,
+      ms: 20_000,
+      issueCount: 2,
+      criticalCount: 0,
+    }),
+  ],
+  [
+    'r2',
+    JOB_B,
+    'resume',
+    'fast',
+    'needsReview',
+    T0,
+    T0 + 30_000,
+    'done',
+    m({
+      calls: 3,
+      cached: 1,
+      repairRounds: 0,
+      reverted: false,
+      ms: 30_000,
+      issueCount: 6,
+      criticalCount: 2,
+    }),
+  ],
+  // max: one finished, one still running (no finished_at, no metrics), one whose
+  // metrics_json was clamped past METRICS_CAP_BYTES and is therefore unparseable
+  // BY DESIGN — but which still has both timestamps.
+  [
+    'r3',
+    JOB_A,
+    'resume',
+    'max',
+    'completed',
+    T0,
+    T0 + 300_000,
+    'max_repairs',
+    m({
+      calls: 18,
+      cached: 4,
+      repairRounds: 3,
+      reverted: true,
+      ms: 300_000,
+      issueCount: 4,
+      criticalCount: 1,
+    }),
+  ],
+  ['r4', JOB_A, 'resume', 'max', 'running', T0, null, null, '{}'],
+  [
+    'r5',
+    JOB_A,
+    'resume',
+    'max',
+    'completed',
+    T0,
+    T0 + 100_000,
+    'done',
+    '{"calls":12,"repairRo…[truncated]',
+  ],
+  // A different `kind` — these tables host every staged run.
+  ['a1', JOB_B, 'agent', 'full', 'completed', T0, T0 + 5_000, 'done', m({ calls: 2 })],
+];
+
+function run(args) {
+  return execFileSync(process.execPath, [scriptPath, ...args], { encoding: 'utf8' });
+}
+
+/** Run expecting a non-zero exit; returns `{ status, stderr }`. */
+function runFailing(args) {
+  try {
+    execFileSync(process.execPath, [scriptPath, ...args], { encoding: 'utf8', stdio: 'pipe' });
+    throw new Error('expected a non-zero exit');
+  } catch (e) {
+    return { status: e.status, stderr: String(e.stderr ?? '') };
+  }
+}
+
+beforeAll(() => {
+  mkdirSync(workDir, { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec(CREATE_SQL);
+  const stmt = db.prepare(
+    `INSERT INTO pipeline_runs
+       (id, job_url, kind, depth, status, started_at, finished_at, stopped_reason, metrics_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  );
+  for (const row of ROWS) stmt.run(...row);
+  db.close();
+});
+
+afterAll(() => rmSync(workDir, { recursive: true, force: true }));
+
+describe('dump-run-metrics', () => {
+  it('documents the default app-data location in --help', () => {
+    const out = run(['--help']);
+    expect(out).toContain('pipeline_runs.db');
+    expect(out).toContain('com.ajh.desktop');
+    expect(out).toContain('AJH_DATA_DIR');
+  });
+
+  it('aggregates per depth, in pipeline order', () => {
+    const { depths } = JSON.parse(run([dbPath, '--json']));
+    expect(depths.map((d) => d.depth)).toEqual(['fast', 'max']);
+
+    const fast = depths[0];
+    expect(fast.runs).toBe(2);
+    expect(fast.postings).toBe(2);
+    expect(fast.issuesMean).toBe(4); // (2 + 6) / 2
+    expect(fast.criticalsMean).toBe(1); // (0 + 2) / 2
+    expect(fast.warningsMean).toBe(3); // ((2-0) + (6-2)) / 2
+    expect(fast.msMedian).toBe(20_000); // nearest-rank p50 of [20k, 30k]
+    expect(fast.msP90).toBe(30_000);
+    expect(fast.statuses).toEqual({ completed: 1, needsReview: 1 });
+    expect(fast.stopReasons).toEqual({ done: 2 });
+  });
+
+  it('counts a run whose metrics_json was clamped unparseable instead of failing', () => {
+    const { depths } = JSON.parse(run([dbPath, '--json']));
+    const max = depths.find((d) => d.depth === 'max');
+    expect(max.runs).toBe(3);
+    expect(max.unparsedMetrics).toBe(1);
+    // The unreadable row still has timestamps, so it contributes a duration; the
+    // RUNNING row has no `finished_at` and must contribute none — a p50 of
+    // [100k, 300k] rather than of [0, 100k, 300k].
+    expect(max.msMedian).toBe(100_000);
+    expect(max.msP90).toBe(300_000);
+    // …but its unreadable counts are absent, not zero: only r3 reported issues.
+    expect(max.issuesMean).toBe(4);
+    expect(max.revertedRuns).toBe(1);
+    expect(max.statuses).toEqual({ completed: 2, running: 1 });
+  });
+
+  it('filters by run kind, so agent runs never enter a résumé-depth average', () => {
+    const resume = JSON.parse(run([dbPath, '--json']));
+    expect(resume.depths.flatMap((d) => Object.keys(d.statuses)).length).toBeGreaterThan(0);
+    expect(resume.depths.map((d) => d.depth)).not.toContain('full');
+
+    const agent = JSON.parse(run([dbPath, '--json', '--kind', 'agent']));
+    expect(agent.depths.map((d) => d.depth)).toEqual(['full']);
+    expect(agent.depths[0].runs).toBe(1);
+  });
+
+  it('never prints a posting url (ADR-027: counts, codes and durations only)', () => {
+    for (const out of [run([dbPath]), run([dbPath, '--json'])]) {
+      expect(out).not.toContain(JOB_A);
+      expect(out).not.toContain(JOB_B);
+      expect(out).not.toContain('boards.example.com');
+    }
+    // The count derived from those urls is what the table carries instead.
+    expect(run([dbPath])).toMatch(/\bjobs\b/);
+  });
+
+  it('exits non-zero with a readable message when the database is missing', () => {
+    const { status, stderr } = runFailing([join(workDir, 'nope.db')]);
+    expect(status).toBe(1);
+    expect(stderr).toContain('no database at');
+  });
+
+  it('rejects an unknown option rather than silently ignoring it', () => {
+    const { status, stderr } = runFailing([dbPath, '--depth', 'max']);
+    expect(status).toBe(2);
+    expect(stderr).toContain('unknown option: --depth');
+  });
+});

--- a/scripts/dump-run-metrics.test.mjs
+++ b/scripts/dump-run-metrics.test.mjs
@@ -330,21 +330,12 @@ afterAll(() => rmSync(workDir, { recursive: true, force: true }));
 // case worth spelling out is only that "skipped" in that tally means aborted, not
 // "node:sqlite missing".
 describe('dump-run-metrics ↔ Rust contract', () => {
-  it('reads columns the schema still declares', () => {
+  it('extracted a schema that creates pipeline_runs', () => {
+    // Cheap sanity on the extraction itself, so a truncated read fails here and
+    // not as a confusing SQLite error later. The COLUMN set is checked against
+    // the created table in the seeded suite, where SQLite can answer exactly.
     expect(CREATE_SQL).toContain('CREATE TABLE IF NOT EXISTS pipeline_runs');
-    // The script's own SELECT list. A column renamed on the Rust side lands here
-    // rather than as a puzzling SQLite error inside the seeded suite.
-    for (const column of [
-      'depth',
-      'status',
-      'started_at',
-      'finished_at',
-      'stopped_reason',
-      'job_url',
-      'metrics_json',
-    ]) {
-      expect(CREATE_SQL, `pipeline_runs no longer has a ${column} column`).toContain(column);
-    }
+    expect(CREATE_SQL.trimEnd().endsWith(';')).toBe(true);
   });
 
   it('aggregates only metrics keys Rust still writes', () => {
@@ -357,6 +348,34 @@ describe('dump-run-metrics ↔ Rust contract', () => {
 });
 
 describeSqlite('dump-run-metrics', () => {
+  it('selects columns the created pipeline_runs table actually has', () => {
+    // `PRAGMA table_info`, not a substring search of the DDL: the literal holds
+    // BOTH tables, and `pipeline_run_events` shares fragments (`ts`, `stage`,
+    // `_json`), so `toContain('status')` could pass on a table that no longer
+    // has one. This asks SQLite what it built, and compares the exact set.
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    const columns = db
+      .prepare('SELECT name FROM pragma_table_info(?)')
+      .all('pipeline_runs')
+      .map((r) => r.name)
+      .sort();
+    db.close();
+
+    // The script's own SELECT list, plus the primary key and the discriminator
+    // it filters on — i.e. everything it depends on existing.
+    expect(columns).toEqual([
+      'depth',
+      'finished_at',
+      'id',
+      'job_url',
+      'kind',
+      'metrics_json',
+      'started_at',
+      'status',
+      'stopped_reason',
+    ]);
+  });
+
   it('documents the default app-data location in --help', () => {
     const out = run(['--help']);
     expect(out).toContain('pipeline_runs.db');
@@ -420,6 +439,35 @@ describeSqlite('dump-run-metrics', () => {
     expect(max.issuesMean).toBe(4);
     expect(max.revertedRuns).toBe(1);
     expect(max.statuses).toEqual({ completed: 2, running: 1 });
+  });
+
+  it('counts valid-JSON-but-not-an-object metrics as unreadable', () => {
+    // `JSON.parse` accepts all four of these. Before they were counted, such a
+    // row contributed to no column AND to no counter — it simply vanished from
+    // the aggregate while still inflating `runs`.
+    const oddDb = join(workDir, 'odd-metrics.db');
+    seed(
+      oddDb,
+      ['null', '123', '"x"', '[]'].map((json, i) => [
+        `o${i}`,
+        JOB_A,
+        'resume',
+        'fast',
+        'completed',
+        T0,
+        T0 + 1_000,
+        'done',
+        json,
+      ])
+    );
+    const [fast] = JSON.parse(run([oddDb, '--json'])).depths;
+    expect(fast.runs).toBe(4);
+    expect(fast.unparsedMetrics).toBe(4);
+    // Timestamps still bound them, so durations survive — that is the point of
+    // "contributed to counts only" rather than "dropped".
+    expect(fast.msMedian).toBe(1_000);
+    expect(fast.issuesMean).toBeNull();
+    expect(run([oddDb])).toContain('cannot read');
   });
 
   it('prints an em dash, not 0, for a flag no row reported', () => {

--- a/scripts/dump-run-metrics.test.mjs
+++ b/scripts/dump-run-metrics.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { DatabaseSync } from 'node:sqlite';
-import { mkdirSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -8,6 +8,29 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const scriptPath = join(__dirname, 'dump-run-metrics.mjs');
+
+// `node:sqlite` needs Node >= 22.13, but the repo's `engines` still permits
+// 20.11 — so a static import would take the WHOLE scripts project down at load
+// on a permitted Node, turning "this one dev script is unavailable" into "the JS
+// suite is broken". Probe instead: skip locally with a reason, and FAIL LOUDLY in
+// CI, where the runner's Node is pinned and a silent skip would quietly retire
+// these tests.
+let DatabaseSync = null;
+try {
+  ({ DatabaseSync } = await import('node:sqlite'));
+} catch (e) {
+  if (process.env.CI) {
+    throw new Error(
+      `node:sqlite is unavailable on ${process.version}; CI must run a Node that has it ` +
+        `(>= 22.13) or dump-run-metrics is untested`,
+      { cause: e }
+    );
+  }
+  console.warn(
+    `[dump-run-metrics.test] skipped: node:sqlite unavailable on ${process.version} (needs >= 22.13)`
+  );
+}
+const describeSqlite = DatabaseSync ? describe : describe.skip;
 
 // Black-box test of the CLI (execFileSync), mirroring check-tech-radar.test.mjs /
 // ci-review-verdict.test.mjs. The fixture DB is created with the schema VERBATIM
@@ -41,50 +64,56 @@ const workDir = join(tmpdir(), `dump-run-metrics-test-${Date.now()}`);
 const dbPath = join(workDir, 'pipeline_runs.db');
 const T0 = 1_770_000_000_000;
 
-/** A posting url — the one column in this table that is user data. */
+/** Posting urls — the one column in this table that is user data. */
 const JOB_A = 'https://boards.example.com/jane-secret-posting-a';
 const JOB_B = 'https://boards.example.com/jane-secret-posting-b';
+/** `sourceResumeId` rides inside metrics_json as provenance; it must not print. */
+const RESUME_ID = 'doc-secret-provenance-1';
 
 const m = (o) => JSON.stringify(o);
 
+// INSERTION ORDER IS PART OF THE FIXTURE: rows go in as legacy → unset → max →
+// quality → fast, and every row shares `started_at`, so the query returns them
+// in that order. The table must still print fast → quality → max → the rest,
+// which is only true if DEPTH_ORDER (and the sorted tail) actually do work.
 const ROWS = [
-  // fast: two finished runs over two postings.
+  // A depth from an older build, and a row with no depth at all.
   [
-    'r1',
+    'x1',
     JOB_A,
     'resume',
-    'fast',
+    'legacy-deep',
     'completed',
     T0,
-    T0 + 20_000,
+    T0 + 9_000,
     'done',
     m({
-      calls: 3,
+      calls: 1,
       cached: 0,
       repairRounds: 0,
       reverted: false,
-      ms: 20_000,
-      issueCount: 2,
+      ms: 9_000,
+      issueCount: 0,
       criticalCount: 0,
     }),
   ],
   [
-    'r2',
-    JOB_B,
+    'x2',
+    JOB_A,
     'resume',
-    'fast',
-    'needsReview',
+    '',
+    'completed',
     T0,
-    T0 + 30_000,
+    T0 + 8_000,
     'done',
     m({
-      calls: 3,
-      cached: 1,
+      calls: 1,
+      cached: 0,
       repairRounds: 0,
       reverted: false,
-      ms: 30_000,
-      issueCount: 6,
-      criticalCount: 2,
+      ms: 8_000,
+      issueCount: 1,
+      criticalCount: 0,
     }),
   ],
   // max: one finished, one still running (no finished_at, no metrics), one whose
@@ -121,6 +150,68 @@ const ROWS = [
     'done',
     '{"calls":12,"repairRo…[truncated]',
   ],
+  // quality: the PRODUCTION shape for a run whose report was never built —
+  // `issueCount` is an Option in Rust and serializes to null.
+  [
+    'q1',
+    JOB_B,
+    'resume',
+    'quality',
+    'failed',
+    T0,
+    T0 + 61_000,
+    'run_timeout',
+    m({
+      calls: 6,
+      cached: 1,
+      repairRounds: 2,
+      reverted: false,
+      ms: 61_000,
+      issueCount: null,
+      criticalCount: 0,
+      sourceResumeId: RESUME_ID,
+    }),
+  ],
+  // fast: two finished runs over two postings.
+  [
+    'r1',
+    JOB_A,
+    'resume',
+    'fast',
+    'completed',
+    T0,
+    T0 + 20_000,
+    'done',
+    m({
+      calls: 3,
+      cached: 0,
+      repairRounds: 0,
+      reverted: false,
+      ms: 20_000,
+      issueCount: 2,
+      criticalCount: 0,
+      sourceResumeId: RESUME_ID,
+    }),
+  ],
+  [
+    'r2',
+    JOB_B,
+    'resume',
+    'fast',
+    'needsReview',
+    T0,
+    T0 + 30_000,
+    'done',
+    m({
+      calls: 3,
+      cached: 1,
+      repairRounds: 0,
+      reverted: false,
+      ms: 30_000,
+      issueCount: 6,
+      criticalCount: 2,
+    }),
+  ],
   // A different `kind` — these tables host every staged run.
   ['a1', JOB_B, 'agent', 'full', 'completed', T0, T0 + 5_000, 'done', m({ calls: 2 })],
 ];
@@ -131,30 +222,48 @@ function run(args) {
 
 /** Run expecting a non-zero exit; returns `{ status, stderr }`. */
 function runFailing(args) {
+  let stdout;
   try {
-    execFileSync(process.execPath, [scriptPath, ...args], { encoding: 'utf8', stdio: 'pipe' });
-    throw new Error('expected a non-zero exit');
+    stdout = execFileSync(process.execPath, [scriptPath, ...args], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
   } catch (e) {
     return { status: e.status, stderr: String(e.stderr ?? '') };
   }
+  // OUTSIDE the catch: a `throw` inside it would be caught by its own handler and
+  // reported as `status: undefined`, i.e. the assertion would pass by accident.
+  throw new Error(`expected a non-zero exit from ${args.join(' ')}; got 0 with: ${stdout}`);
 }
 
-beforeAll(() => {
-  mkdirSync(workDir, { recursive: true });
-  const db = new DatabaseSync(dbPath);
+function md5(path) {
+  return createHash('md5').update(readFileSync(path)).digest('hex');
+}
+
+function seed(path, rows) {
+  const db = new DatabaseSync(path);
+  // The product opens every store in WAL (db.rs `open`, ADR-022), so the fixture
+  // must be WAL too — a rollback-journal fixture would not exercise what a dump
+  // of a real database does to the directory.
+  db.exec('PRAGMA journal_mode = WAL');
   db.exec(CREATE_SQL);
   const stmt = db.prepare(
     `INSERT INTO pipeline_runs
        (id, job_url, kind, depth, status, started_at, finished_at, stopped_reason, metrics_json)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
   );
-  for (const row of ROWS) stmt.run(...row);
+  for (const row of rows) stmt.run(...row);
   db.close();
+}
+
+beforeAll(() => {
+  mkdirSync(workDir, { recursive: true });
+  if (DatabaseSync) seed(dbPath, ROWS);
 });
 
 afterAll(() => rmSync(workDir, { recursive: true, force: true }));
 
-describe('dump-run-metrics', () => {
+describeSqlite('dump-run-metrics', () => {
   it('documents the default app-data location in --help', () => {
     const out = run(['--help']);
     expect(out).toContain('pipeline_runs.db');
@@ -162,11 +271,10 @@ describe('dump-run-metrics', () => {
     expect(out).toContain('AJH_DATA_DIR');
   });
 
-  it('aggregates per depth, in pipeline order', () => {
+  it('aggregates per depth', () => {
     const { depths } = JSON.parse(run([dbPath, '--json']));
-    expect(depths.map((d) => d.depth)).toEqual(['fast', 'max']);
 
-    const fast = depths[0];
+    const fast = depths.find((d) => d.depth === 'fast');
     expect(fast.runs).toBe(2);
     expect(fast.postings).toBe(2);
     expect(fast.issuesMean).toBe(4); // (2 + 6) / 2
@@ -174,13 +282,40 @@ describe('dump-run-metrics', () => {
     expect(fast.warningsMean).toBe(3); // ((2-0) + (6-2)) / 2
     expect(fast.msMedian).toBe(20_000); // nearest-rank p50 of [20k, 30k]
     expect(fast.msP90).toBe(30_000);
+    expect(fast.revertedRuns).toBe(0); // both rows REPORTED false
     expect(fast.statuses).toEqual({ completed: 1, needsReview: 1 });
     expect(fast.stopReasons).toEqual({ done: 2 });
   });
 
-  it('counts a run whose metrics_json was clamped unparseable instead of failing', () => {
+  it('orders depths fast → quality → max, then anything unrecognized', () => {
     const { depths } = JSON.parse(run([dbPath, '--json']));
-    const max = depths.find((d) => d.depth === 'max');
+    // Insertion (and therefore query) order is legacy-deep, (unset), max,
+    // quality, fast — so this equality only holds because the script reorders.
+    expect(depths.map((d) => d.depth)).toEqual([
+      'fast',
+      'quality',
+      'max',
+      '(unset)',
+      'legacy-deep',
+    ]);
+    // A row with an empty `depth` is labelled, not dropped.
+    expect(depths.find((d) => d.depth === '(unset)').runs).toBe(1);
+  });
+
+  it('reports a null issueCount as unmeasured rather than zero', () => {
+    // The Rust side writes `Option<usize>` → `null` whenever the run produced no
+    // report. Averaging that as 0 would claim a clean document.
+    const quality = JSON.parse(run([dbPath, '--json'])).depths.find((d) => d.depth === 'quality');
+    expect(quality.runs).toBe(1);
+    expect(quality.issuesMean).toBeNull();
+    expect(quality.warningsMean).toBeNull(); // the pair is incomplete, so no subtraction
+    expect(quality.criticalsMean).toBe(0); // …but this half WAS reported
+    expect(quality.msMedian).toBe(61_000);
+    expect(quality.stopReasons).toEqual({ run_timeout: 1 });
+  });
+
+  it('counts a run whose metrics_json was clamped unparseable instead of failing', () => {
+    const max = JSON.parse(run([dbPath, '--json'])).depths.find((d) => d.depth === 'max');
     expect(max.runs).toBe(3);
     expect(max.unparsedMetrics).toBe(1);
     // The unreadable row still has timestamps, so it contributes a duration; the
@@ -194,9 +329,31 @@ describe('dump-run-metrics', () => {
     expect(max.statuses).toEqual({ completed: 2, running: 1 });
   });
 
+  it('prints an em dash, not 0, for a flag no row reported', () => {
+    // A row whose metrics parse but carry none of the expected keys (an older
+    // build, a renamed field). `revert 0` would read as "nothing reverted"; the
+    // truth is that nobody measured.
+    const legacyDb = join(workDir, 'legacy.db');
+    seed(legacyDb, [
+      [
+        'l1',
+        JOB_A,
+        'resume',
+        'fast',
+        'completed',
+        T0,
+        T0 + 1_000,
+        'done',
+        '{"repair_rounds":3,"was_reverted":true}',
+      ],
+    ]);
+    const { depths } = JSON.parse(run([legacyDb, '--json']));
+    expect(depths[0].revertedRuns).toBeNull();
+    expect(run([legacyDb])).toMatch(/^fast\s+1\s+1\s+1000\s+1000\s+—\s+—\s+—\s+—\s+—\s/m);
+  });
+
   it('filters by run kind, so agent runs never enter a résumé-depth average', () => {
     const resume = JSON.parse(run([dbPath, '--json']));
-    expect(resume.depths.flatMap((d) => Object.keys(d.statuses)).length).toBeGreaterThan(0);
     expect(resume.depths.map((d) => d.depth)).not.toContain('full');
 
     const agent = JSON.parse(run([dbPath, '--json', '--kind', 'agent']));
@@ -204,14 +361,39 @@ describe('dump-run-metrics', () => {
     expect(agent.depths[0].runs).toBe(1);
   });
 
-  it('never prints a posting url (ADR-027: counts, codes and durations only)', () => {
+  it('accepts the path as --db as well as positionally', () => {
+    expect(run(['--db', dbPath, '--json'])).toBe(run([dbPath, '--json']));
+  });
+
+  it('never prints a posting url or a resume id (ADR-027)', () => {
     for (const out of [run([dbPath]), run([dbPath, '--json'])]) {
       expect(out).not.toContain(JOB_A);
       expect(out).not.toContain(JOB_B);
       expect(out).not.toContain('boards.example.com');
+      expect(out).not.toContain(RESUME_ID);
     }
-    // The count derived from those urls is what the table carries instead.
-    expect(run([dbPath])).toMatch(/\bjobs\b/);
+    // The counts derived from those urls are what the table carries instead:
+    // the `fast` row's 2 runs over 2 distinct postings, with its durations.
+    expect(run([dbPath])).toMatch(/^fast\s+2\s+2\s+20000\s+30000\s/m);
+  });
+
+  it('leaves the database content untouched, WAL sidecars aside', () => {
+    const walDb = join(workDir, 'wal.db');
+    seed(walDb, [
+      ['w1', JOB_A, 'resume', 'fast', 'completed', T0, T0 + 1_000, 'done', m({ ms: 1_000 })],
+    ]);
+    const before = md5(walDb);
+
+    run([walDb]);
+
+    // (a) the database's CONTENT is byte-identical — the actual guarantee.
+    expect(md5(walDb)).toBe(before);
+    // (b) and the sidecars a WAL READER materializes ARE there. Asserted rather
+    // than wished away: the script's comment used to claim it left none, which
+    // is impossible for a WAL reader, and a dump therefore needs a WRITABLE
+    // directory. Pinned so nobody "fixes" the comment back.
+    expect(existsSync(`${walDb}-shm`)).toBe(true);
+    expect(existsSync(`${walDb}-wal`)).toBe(true);
   });
 
   it('exits non-zero with a readable message when the database is missing', () => {
@@ -220,9 +402,38 @@ describe('dump-run-metrics', () => {
     expect(stderr).toContain('no database at');
   });
 
+  it('reports schema drift instead of an empty result', () => {
+    // The table renamed or gone is NOT "you have no runs yet" — that message
+    // would stop the reader looking. This is the script's only drift alarm.
+    const emptyDb = join(workDir, 'no-table.db');
+    const db = new DatabaseSync(emptyDb);
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('CREATE TABLE unrelated (id TEXT PRIMARY KEY)');
+    db.close();
+
+    const { status, stderr } = runFailing([emptyDb]);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/cannot read pipeline_runs/);
+  });
+
+  it('exits non-zero when the kind matches no run', () => {
+    const { status, stderr } = runFailing([dbPath, '--kind', 'nosuch']);
+    expect(status).toBe(1);
+    expect(stderr).toContain('no runs with kind=nosuch');
+  });
+
   it('rejects an unknown option rather than silently ignoring it', () => {
     const { status, stderr } = runFailing([dbPath, '--depth', 'max']);
     expect(status).toBe(2);
     expect(stderr).toContain('unknown option: --depth');
+  });
+
+  it('rejects a flag where a value belongs, and a missing value', () => {
+    // `--kind --json` would otherwise query for runs of kind "--json" (zero
+    // rows) AND drop the flag — a confidently wrong answer.
+    expect(runFailing([dbPath, '--kind', '--json']).stderr).toContain(
+      '--kind needs a value, got the flag --json'
+    );
+    expect(runFailing([dbPath, '--db']).stderr).toContain('--db needs a value');
   });
 });


### PR DESCRIPTION
Phase 5 of the staged résumé pipeline: the **offline eval harness** — the measurement layer that gates judge expansion, `factual.unsourced_term` W→C escalation, and further depth investment. Follows #970 (max depth).

## What it does

- **`tests/eval.rs`** grows from the Phase-1 corpus-shape stub into the real harness: every labelled fixture under `validate/content/fixtures/` (7 planted defects, 5 truthful, 2 tolerated degradations, en+de) runs through the same `validate_content` entry point the product calls, producing a per-code precision/recall table. Reuses the product fixtures — no parallel corpus.
- **Labels are guards, not decoration**: planted codes are asserted found at their registered severity (a Critical→Warning demotion must be acknowledged in the label), Planted fixtures may not raise Criticals nobody planted, truthful *and* tolerated fixtures are pinned to zero Criticals, and a `case!` macro binds each row's file name to its `include_str!` path so they cannot disagree. A two-way coverage invariant means a new fixture cannot sit ungraded and a stale row cannot grade nothing.
- **The headline is honest**: the Warning-tier false-positive budget counts *findings* (not distinct codes — the letter fixture fires 16 warnings from 2 codes), is asserted (`0` today), and prints its own caveat: 2 of the 5 truthful fixtures are already pinned empty by unit tests, so only 3 can move. Current numbers: recall 8/8 planted codes, 0 Warning FPs.
- **`scripts/dump-run-metrics.mjs`**: dev-only per-depth aggregate dump over `pipeline_runs` for real-run A/B (counts, stop reasons, p50/p90 durations, issue/repair/revert tallies). Read-only open with the WAL-sidecar behaviour stated truthfully and pinned by test; ADR-027 throughout — `job_url` is reduced to a distinct count, no document content or resolved home paths in any output path, every failure exit curated and covered.
- **The schema mirror is machine-checked**: the vitest fixture extracts `CREATE_PIPELINE_RUNS_SQL` and the written metrics keys out of the Rust source at test time, so a column or key rename fails the JS suite instead of silently stranding the script. `scripts/**` added to the CI `frontend` filter so a scripts-only PR still runs it.

## Review provenance

Two internal critic rounds (rust-backend-architect, testing-reviewer) + a 3-pass ensemble (PASS): ~40 findings, all fixed red-first with 28 executed mutations or recorded honestly in-code. Highlights: the read-only-SQLite claim was false on WAL databases (a reader materialises `-shm`/`-wal` — proven against a live 400-insert writer race and pinned by a WAL-mode fixture); three-of-seven planted labels were inert decoration; the FP budget counted distinct codes where its prose promised findings (5 vs 23 on the same mutated corpus); a phantom `revert 0` where every other unmeasured cell prints `—`.

## Tests

3 997 Rust lib + 18 architecture + 3 eval; vitest scripts project 77; clippy `--all-targets --all-features --locked -D warnings`, fmt, eslint + prettier — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development tool to summarize pipeline run metrics by depth and run type.
  * Supports table or JSON output, database path selection, help text, and safe handling of incomplete or invalid data.

* **Bug Fixes**
  * Updated CI path detection so script changes trigger the appropriate frontend checks.

* **Documentation**
  * Added guidance for comparing pipeline performance and interpreting validator evaluation results.

* **Tests**
  * Added deterministic validation metrics and comprehensive coverage for metric reporting, privacy, filtering, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->