### PR TITLE
chore(deps): sentry 0.49 with tauri-plugin-sentry 0.6, gated at the wire

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4978,7 +4978,7 @@ dependencies = [
  "scroll",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4995,7 +4995,7 @@ dependencies = [
  "parking_lot",
  "polling",
  "scroll",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "uds",
 ]
 
@@ -5007,7 +5007,7 @@ checksum = "1dd1d5c43819abcc73ced5a1287c58fdc715c9f993b7cc9debc6ae7cb8421994"
 dependencies = [
  "crash-handler",
  "minidumper",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "uuid",
 ]
 
@@ -8609,7 +8609,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5520fe8aa00d12fbdb0c290e15f9629f33aaaa1440b1703a01b1cfab44cdf1c"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "schemars 0.8.22",
  "sentry",
  "sentry-rust-minidump",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
  "proptest",
  "rand 0.10.2",
  "regex",
- "reqwest 0.13.1",
+ "reqwest",
  "rusqlite",
  "rust-stemmers",
  "scraper",
@@ -1219,12 +1219,6 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -1275,7 +1269,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "pin-project-lite",
- "reqwest 0.13.1",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -1306,7 +1300,7 @@ checksum = "edd2cc8c9431726edce9f5ceb3ca1b711dde0f818cd6fb34808a00556ce73135"
 dependencies = [
  "anyhow",
  "directories",
- "reqwest 0.13.1",
+ "reqwest",
  "serde",
  "thiserror 2.0.20",
  "tokio",
@@ -1695,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "crash-handler"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2066907075af649bcb8bcb1b9b986329b243677e6918b2d920aa64b0aac5ace3"
+checksum = "0df5c9639f4942eb7702b964b3f9adf03a55724a57558cc177407388a8b936e2"
 dependencies = [
  "cfg-if",
  "crash-context",
@@ -2563,6 +2557,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "error-graph"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b920e777967421aa5f9bf34f842c0ab6ba19b3bdb4a082946093860f5858879"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "euclid"
 version = "0.20.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +2618,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "failspot"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c942e64b20ecd39933d5ff938ca4fdb6ef0d298cc3855b231179a5ef0b24948d"
 
 [[package]]
 name = "fallible-iterator"
@@ -3330,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.8.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
 dependencies = [
  "log",
  "plain",
@@ -4933,9 +4942,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minidump-common"
-version = "0.21.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4d14bcca0fd3ed165a03000480aaa364c6860c34e900cb2dafdf3b95340e77"
+checksum = "2e16d10087ae9e375bad7a40e8ef5504bc08e808ccc6019067ff9de42a84570f"
 dependencies = [
  "bitflags 2.13.0",
  "debugid",
@@ -4948,33 +4957,35 @@ dependencies = [
 
 [[package]]
 name = "minidump-writer"
-version = "0.8.9"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abcd9c8a1e6e1e9d56ce3627851f39a17ea83e17c96bc510f29d7e43d78a7d"
+checksum = "48ef5778fc71c10d6bac1ec6b971ba0cc4b67cd8f3f0f7689dfdaab75884082f"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
  "cfg-if",
  "crash-context",
+ "error-graph",
+ "failspot",
  "goblin",
  "libc",
  "log",
  "mach2",
  "memmap2",
- "memoffset",
  "minidump-common",
- "nix 0.28.0",
+ "nix 0.30.1",
  "procfs-core",
  "scroll",
- "tempfile",
- "thiserror 1.0.69",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "minidumper"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4ebc9d1f8847ec1d078f78b35ed598e0ebefa1f242d5f83cd8d7f03960a7d1"
+checksum = "4d1ab45c501f311e5e4c22232ecdd7e31120174261c42e170d41c6afbd60cc41"
 dependencies = [
  "cfg-if",
  "crash-context",
@@ -4984,19 +4995,19 @@ dependencies = [
  "parking_lot",
  "polling",
  "scroll",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "uds",
 ]
 
 [[package]]
 name = "minidumper-child"
-version = "0.2.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4f23f835dbe67e44ddf884d3802ff549ca5948bf60e9fd70e9a13c96324d1"
+checksum = "1dd1d5c43819abcc73ced5a1287c58fdc715c9f993b7cc9debc6ae7cb8421994"
 dependencies = [
  "crash-handler",
  "minidumper",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "uuid",
 ]
 
@@ -5146,13 +5157,13 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -5164,7 +5175,7 @@ checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -6342,12 +6353,13 @@ dependencies = [
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
  "bitflags 2.13.0",
  "hex",
+ "serde",
 ]
 
 [[package]]
@@ -6477,7 +6489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -6518,7 +6530,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.6.4",
@@ -6816,52 +6828,15 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.2",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "cookie",
  "cookie_store",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -7374,13 +7349,14 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.42.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989425268ab5c011e06400187eed6c298272f8ef913e49fcadc3fda788b45030"
+checksum = "63207365db50cb817402f0ec8097d6dad3d644ef3fffd6ba30c75b3077e514da"
 dependencies = [
+ "cfg_aliases",
  "httpdate",
  "native-tls",
- "reqwest 0.12.28",
+ "reqwest",
  "sentry-actix",
  "sentry-backtrace",
  "sentry-contexts",
@@ -7393,9 +7369,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.42.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c675bdf6118764a8e265c3395c311b4d905d12866c92df52870c0223d2ffc1"
+checksum = "4a0eb1ed18478fb48db007aeaa672a3de176055357feb768eee0c3471802d0ce"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -7406,9 +7382,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.42.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e299dd3f7bcf676875eee852c9941e1d08278a743c32ca528e2debf846a653"
+checksum = "e3bcc2497c2327998146207b7600599ef7592233920f4d4e1d41ddeeba0e4210"
 dependencies = [
  "backtrace",
  "regex",
@@ -7417,9 +7393,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.42.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac0c5d6892cd4c414492fc957477b620026fb3411fca9fa12774831da561c88"
+checksum = "1cb04cba225b38f59d08f9e3c29ab7259d9cc94fbb2c46d613a51cb0a4a7ee05"
 dependencies = [
  "hostname",
  "libc",
@@ -7431,9 +7407,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.42.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa38b94e70820ff3f1f9db3c8b0aef053b667be130f618e615e0ff2492cbcc"
+checksum = "48759bc392fb5e3b36b4efcb485f51074c0ba8479711cd5c8cf79e86f9f75d41"
 dependencies = [
  "rand 0.9.4",
  "sentry-types",
@@ -7444,9 +7420,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.42.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00950648aa0d371c7f57057434ad5671bd4c106390df7e7284739330786a01b6"
+checksum = "0a5bd325059b70b21ca6e42b0f2409821272dddc1cf37923de37269af55389b5"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -7454,9 +7430,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.42.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7a23b13c004873de3ce7db86eb0f59fe4adfc655a31f7bbc17fd10bacc9bfe"
+checksum = "a685d22f672b1562ebeff3f2affceb5960595648cc936dae73da3e1d6a55fbd1"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -7464,9 +7440,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-rust-minidump"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63964525bf74b16233dbcfb307e11485ebd8ff8f87f6ae212b07ca7937cd2db1"
+checksum = "2133269d675e52cb96cdbec8fa1ccb8adc50e74899e53902860f7c3e74fb2550"
 dependencies = [
  "minidumper-child",
  "sentry",
@@ -7475,9 +7451,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.42.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac841c7050aa73fc2bec8f7d8e9cb1159af0b3095757b99820823f3e54e5080"
+checksum = "8aa7d8e0db4cccddbac01ddabd5344ad03b7c2f954b3ff850cecb1d9cf5d4758"
 dependencies = [
  "bitflags 2.13.0",
  "sentry-backtrace",
@@ -7488,9 +7464,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.42.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e477f4d4db08ddb4ab553717a8d3a511bc9e81dde0c808c680feacbb8105c412"
+checksum = "fab146d15a30ab4897a95fd15d6a038b8d7fbf2661c5f8b13738ce8df7a095b7"
 dependencies = [
  "debugid",
  "hex",
@@ -8316,7 +8292,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.1",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -8629,11 +8605,11 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-sentry"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7432b519b6d2d027082a940783c61ba9b684b38d8df7558cd5f924d87009b295"
+checksum = "b5520fe8aa00d12fbdb0c290e15f9629f33aaaa1440b1703a01b1cfab44cdf1c"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.0",
  "schemars 0.8.22",
  "sentry",
  "sentry-rust-minidump",
@@ -8712,7 +8688,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.1",
+ "reqwest",
  "rustls",
  "semver",
  "serde",
@@ -10386,9 +10362,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -6879,7 +6879,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -75,28 +75,43 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-log = "2"
 # Remote crash aggregation (ADR: crash reporting egress class). Pinned to the
-# `sentry` MAJOR the plugin itself depends on — `tauri-plugin-sentry` 0.5 builds
-# against `sentry = "0.42"`, and a newer `sentry` here would link a SECOND,
+# `sentry` MINOR the plugin itself depends on — `tauri-plugin-sentry` 0.6 builds
+# against `sentry = "0.49"`, and a different `sentry` here would link a SECOND,
 # type-incompatible copy of the SDK (the plugin's `init(&client)` would not accept
-# our `Client`). Bump both together or not at all.
+# our `Client`). sentry is pre-1.0, so each minor is a breaking major. Bump both
+# together or not at all: a solo bump of either side duplicates
+# sentry/sentry-core/sentry-types in the lock and fails to build — that is
+# exactly why dependabot's plugin-only PR #972 was closed.
 #
 # The plugin's browser side ships a custom transport that forwards WebView events
 # to the Rust SDK over `invoke`, so the renderer never egresses directly and the
-# CSP `connect-src` allowlist stays untouched.
+# CSP `connect-src` allowlist stays untouched. There is no paired npm package to
+# keep in step — that browser SDK is a `js_init_script` baked into the crate.
 #
-# Explicit features rather than defaults. The default `transport` feature is
-# `reqwest + native-tls`, and sentry 0.42 pins reqwest 0.12 — a SECOND copy
-# alongside the app's own 0.13, in a binary this project deliberately optimizes
-# for size (fat LTO, opt-level "s"). `ureq` is the lighter transport and also the
-# more correct one here: the reqwest transport pulls in tokio, but the minidump
-# supervisor is a bare forked process with no async runtime to send on.
-# `native-tls` is reused rather than adding a second TLS stack — reqwest 0.13
-# already brings that crate in.
+# Explicit features rather than defaults. sentry 0.49's default set is
+# `backtrace + contexts + debug-images + logs + metrics + panic + transport +
+# release-health`; we take neither `transport` nor the two new-in-0.49 telemetry
+# features:
+#   * `transport` = `reqwest + native-tls`, and sentry's `reqwest` feature also
+#     switches on `tokio` — but the minidump supervisor is a bare forked process
+#     with no async runtime to send on, so `ureq` is not merely the lighter
+#     transport, it is the correct one. (Size matters too: sentry 0.49 wants
+#     reqwest `0.13` with `blocking` + `json`. That is the app's own major, so it
+#     would no longer be the duplicate crate sentry 0.42's reqwest 0.12 was — but
+#     feature unification would still bolt `blocking` onto the shared client in a
+#     binary this project optimizes hard for size (fat LTO, opt-level "s").)
+#   * `logs` / `metrics` are structured-log and metric pipelines — new egress
+#     surfaces. ADR-0020 consented to crash reports, and nothing here emits
+#     either, so they stay off.
+# `native-tls` IS on, and is reused rather than adding a second TLS stack —
+# reqwest 0.13 already brings that crate in. In 0.49 the feature resolves to
+# `ureq?/native-tls` for our transport (`reqwest?/native-tls-no-alpn` stays
+# inert because `dep:reqwest` is never activated).
 #
 # Both `tauri-plugin-sentry` and `sentry-rust-minidump` declare sentry with
 # `default-features = false`, so this declaration alone decides which transport
 # the whole tree gets.
-sentry = { version = "0.42", default-features = false, features = [
+sentry = { version = "0.49", default-features = false, features = [
   "backtrace",
   "contexts",
   "debug-images",
@@ -105,10 +120,12 @@ sentry = { version = "0.42", default-features = false, features = [
   "ureq",
   "native-tls",
 ] }
-# `minidump` (default feature) pulls `sentry-rust-minidump`, which supervises the
-# app from a SEPARATE process. That is required, not a nicety: `[profile.release]`
-# sets `panic = "abort"`, so nothing in-process can outlive a crash to flush it.
-tauri-plugin-sentry = "0.5"
+# `minidump` (default feature) pulls `sentry-rust-minidump` — 0.17 for plugin
+# 0.6, transitively; we deliberately do not declare it ourselves — which
+# supervises the app from a SEPARATE process. That is required, not a nicety:
+# `[profile.release]` sets `panic = "abort"`, so nothing in-process can outlive a
+# crash to flush it.
+tauri-plugin-sentry = "0.6"
 tauri-plugin-window-state = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-notification = "2"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -111,6 +111,12 @@ tauri-plugin-log = "2"
 # Both `tauri-plugin-sentry` and `sentry-rust-minidump` declare sentry with
 # `default-features = false`, so this declaration alone decides which transport
 # the whole tree gets.
+#
+# BUMP CHECKLIST addition (0.49): `crash_reporting/transport.rs::is_opaque`
+# keys off a private-repr behavior — `Items::Raw` yields an empty `items()`
+# iterator and `add_item` early-returns on raw envelopes. Version-coupled; on
+# any sentry/sentry-types bump, re-read `protocol/envelope.rs` for both facts
+# (the `is_opaque_separates_raw_from_parsed` test fails loudly if they move).
 sentry = { version = "0.49", default-features = false, features = [
   "backtrace",
   "contexts",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -140,7 +140,15 @@ serde_json = "1"
 
 # HTTP client used by all in-process scrapers and the AI/cover-letter pipeline.
 # rustls-tls is added for the cover_letter pipeline (API calls use rustls client).
-reqwest = { version = "0.13", features = ["json", "native-tls", "rustls", "rustls-native-certs", "cookies", "query", "http2"], default-features = false }
+#
+# No `rustls-native-certs`: in reqwest 0.13.1 that name was only the *implicit*
+# feature of an optional dependency reqwest never references in its own source,
+# so switching it on changed nothing. OS trust roots reach us either way — the
+# `rustls` feature pulls `rustls-platform-verifier` (which depends on
+# rustls-native-certs itself), and `native-tls` uses the system stack. reqwest
+# 0.13.2 dropped the optional dependency outright, so keeping it listed is now a
+# hard resolve error.
+reqwest = { version = "0.13", features = ["json", "native-tls", "rustls", "cookies", "query", "http2"], default-features = false }
 
 log = "0.4"
 tracing = { version = "0.1", features = ["log"] }

--- a/apps/desktop/src-tauri/deny.toml
+++ b/apps/desktop/src-tauri/deny.toml
@@ -73,6 +73,21 @@ multiple-versions = "warn"
 wildcards = "deny"
 allow-wildcard-paths = true
 
+# `failspot` is a FAULT-INJECTION crate. It rides in transitively under the
+# crash reporter (minidump-writer -> minidumper -> minidumper-child ->
+# sentry-rust-minidump -> tauri-plugin-sentry) and is inert as locked: its
+# `enabled` feature is the only thing it has, it gates `dep:flagset`, and
+# failspot's Cargo.lock entry lists no dependencies at all — proof the feature
+# is off. (`flagset` IS in the lock, but via `dom_smoothie`, not this.)
+#
+# Turning it on would let a caller make the minidump writer fail on purpose, in
+# the one component whose entire job is to still work when everything else has
+# crashed. Nothing here should ever want that, so it is denied mechanically
+# rather than left to whoever reads the next dependabot diff.
+[[bans.features]]
+crate = "failspot"
+deny = ["enabled"]
+
 [sources]
 # Only crates.io by default; any git/registry source must be explicitly allowed.
 unknown-registry = "deny"

--- a/apps/desktop/src-tauri/src/crash_reporting/mod.rs
+++ b/apps/desktop/src-tauri/src/crash_reporting/mod.rs
@@ -463,11 +463,18 @@ mod tests {
 
     /// The privacy-relevant half of the client configuration, pinned.
     ///
-    /// Every assertion here is a switch whose wrong value leaks something and
-    /// whose absence is invisible at runtime — `enable_logs`/`enable_metrics`
-    /// default to TRUE in sentry 0.49, `server_name` defaults to the machine
-    /// hostname, and dropping the `.transport(...)` call would silently remove
-    /// the entire wire gate while everything still compiled and shipped.
+    /// These are switches whose wrong value leaks something and whose *absence*
+    /// is invisible at runtime: `enable_logs`/`enable_metrics` default to TRUE
+    /// in sentry 0.49, `server_name` defaults to the machine hostname, and
+    /// deleting the `.transport(...)` call would remove the entire wire gate
+    /// while everything still compiled and shipped. Each of those was checked by
+    /// deleting the builder call and watching this test go red.
+    ///
+    /// One exception, stated rather than glossed: `send_default_pii` is `false`
+    /// in `ClientOptions::default()` too, so that assertion catches someone
+    /// setting it TRUE but not someone deleting our explicit `false`. There is
+    /// nothing observable that would distinguish the two, so it is a value pin,
+    /// not a guard — and this comment is the honest version of that.
     #[test]
     fn client_options_pin_every_privacy_switch() {
         let options = client_options();

--- a/apps/desktop/src-tauri/src/crash_reporting/mod.rs
+++ b/apps/desktop/src-tauri/src/crash_reporting/mod.rs
@@ -41,20 +41,34 @@
 //! is not a choice, and the gap between a consent UI and what the code actually
 //! does is where privacy claims break.
 //!
-//! ## Redaction
+//! ## Redaction, and where it is actually enforced
 //!
 //! Crash payloads are the richest source of accidental PII in the app: panic
 //! messages interpolate paths, and every backtrace frame carries an absolute
-//! source path containing the OS username. Everything leaving this module goes
-//! through [`redact_event`], which reuses the same token redactor the
-//! diagnostics bundle uses (ADR-027) rather than inventing a second, weaker one.
+//! source path containing the OS username.
+//!
+//! Two mechanisms, at two different depths, because one of them is not enough:
+//!
+//! * [`redact_event`] runs as `before_send` and rewrites events on the
+//!   **capture path**, reusing the same token redactor the diagnostics bundle
+//!   uses (ADR-027) rather than inventing a second, weaker one. It is an
+//!   event-shaping hook — it only sees what `capture_event` prepared.
+//! * [`transport`] is the **wire gate**, and it is what the privacy claim
+//!   actually rests on. `before_send` is not the last hop: an envelope handed
+//!   straight to `Client::send_envelope` never reaches it, and
+//!   `tauri-plugin-sentry` 0.6 does exactly that for renderer envelopes it
+//!   cannot parse. The transport re-checks consent and drops anything opaque,
+//!   for every path, on every envelope. See that module for the full chain.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
 use crate::commands::support::redact_lines;
+
+mod transport;
 
 /// Consent + "has the user been asked" state, persisted next to the app data.
 const FILE_NAME: &str = "crash-reporting.json";
@@ -118,21 +132,40 @@ impl Settings {
     }
 }
 
+/// The consent answer as the **wire gate** sees it, mirrored out of the file so
+/// the transport can re-check it per envelope without touching the disk.
+///
+/// Starts `false` so it fails closed: a transport that somehow ran before
+/// [`init`] transmits nothing. Every place that changes the persisted answer
+/// ([`init`], [`save`], [`clear`], [`disable_current`]) updates this too — that
+/// is the whole contract, and it is small enough to keep honest by inspection.
+static TRANSMITS: AtomicBool = AtomicBool::new(false);
+
+/// Read the wire gate. A single relaxed atomic load: no lock, no allocation, no
+/// syscall, so it is safe to call on the transport's sender thread per envelope.
+pub(crate) fn transmits_now() -> bool {
+    TRANSMITS.load(Ordering::Relaxed)
+}
+
 /// Read the persisted settings from the resolved [`state_dir`].
 pub fn load() -> Settings {
     load_from(state_dir())
 }
 
-/// Persist settings to the resolved [`state_dir`].
+/// Persist settings to the resolved [`state_dir`] and move the wire gate with
+/// them, so an opt-out takes effect on the next envelope rather than the next
+/// launch.
 pub fn save(settings: Settings) {
     save_to(state_dir(), settings);
+    TRANSMITS.store(settings.transmits(), Ordering::Relaxed);
 }
 
 /// Remove the persisted flag from the resolved [`state_dir`] (factory reset).
 /// Back to default: enabled, not yet consented — so the wizard asks again
-/// before anything is sent.
+/// before anything is sent, and the wire gate closes immediately.
 pub fn clear() {
     let _ = std::fs::remove_file(state_dir().join(FILE_NAME));
+    TRANSMITS.store(Settings::default().transmits(), Ordering::Relaxed);
 }
 
 /// Read the persisted settings. Any failure — missing file, unreadable file,
@@ -207,55 +240,86 @@ pub fn init() -> Option<sentry::ClientInitGuard> {
     // First call to `state_dir()` in the real app — this is what pins the
     // directory that the privacy commands will later read and write.
     let settings = load();
+    // Open the wire gate here and nowhere else at startup: the transport is
+    // built inside `sentry::init` below, and it must never observe the
+    // fail-closed default while the client it belongs to is live.
+    TRANSMITS.store(settings.transmits(), Ordering::Relaxed);
     if !settings.transmits() {
         return None;
     }
     let dsn = DSN?;
 
-    // Builder rather than a struct literal: `ClientOptions` is `#[non_exhaustive]`
-    // as of sentry 0.49, so `..Default::default()` no longer compiles from a
-    // downstream crate. Every setter below is still one field, set explicitly —
-    // including the two the SDK now happens to default the same way, because a
-    // privacy-relevant value should be readable here, not inferred from an
-    // upstream default that can change under us.
-    Some(sentry::init((
-        dsn,
-        sentry::ClientOptions::new()
-            .release(env!("CARGO_PKG_VERSION"))
-            .environment(if cfg!(debug_assertions) {
-                "development"
-            } else {
-                "production"
-            })
-            // Release health: crash-free rate and version adoption. This is the
-            // "usage" half of the feature — active installs per version — and it
-            // needs no separate analytics vendor.
-            .auto_session_tracking(true)
-            .session_mode(sentry::SessionMode::Application)
-            // Never attach the request/user identity the SDK can infer.
-            .send_default_pii(false)
-            // The SDK defaults this to the machine hostname, which on a personal
-            // device is frequently the user's real name.
-            .server_name("redacted")
-            .before_send(redact_event)
-            .before_breadcrumb(|mut breadcrumb| {
-                breadcrumb.message = breadcrumb.message.map(|m| redact_lines(&m));
-                Some(breadcrumb)
-            }),
-    )))
+    Some(sentry::init((dsn, client_options())))
 }
 
-/// Stop capturing in the current process, immediately.
+/// The client configuration, split out from [`init`] so the privacy-relevant
+/// answers in it are assertable without a DSN or a live client.
 ///
-/// Unbinding the client from the hub drops every subsequent event on the floor
-/// without waiting for a restart — someone who has just switched reporting off
-/// should not keep being reported for the rest of the session.
+/// Builder rather than a struct literal: `ClientOptions` is `#[non_exhaustive]`
+/// as of sentry 0.49, so `..Default::default()` no longer compiles from a
+/// downstream crate. Every setter below is still one field, set explicitly —
+/// including the ones the SDK now happens to default the same way, because a
+/// privacy-relevant value should be readable here, not inferred from an
+/// upstream default that can change under us.
+fn client_options() -> sentry::ClientOptions {
+    sentry::ClientOptions::new()
+        .release(env!("CARGO_PKG_VERSION"))
+        .environment(if cfg!(debug_assertions) {
+            "development"
+        } else {
+            "production"
+        })
+        // Release health: crash-free rate and version adoption. This is the
+        // "usage" half of the feature — active installs per version — and it
+        // needs no separate analytics vendor.
+        .auto_session_tracking(true)
+        .session_mode(sentry::SessionMode::Application)
+        // Never attach the request/user identity the SDK can infer.
+        .send_default_pii(false)
+        // The SDK defaults this to the machine hostname, which on a personal
+        // device is frequently the user's real name.
+        .server_name("redacted")
+        // Structured logs and metrics: two egress pipelines 0.49 turned ON
+        // by default (0.42 defaulted both off). The `logs`/`metrics` cargo
+        // features are off, so today the consumers are cfg'd out — but any
+        // future crate that enables `sentry/logs` would unify the feature
+        // into our build and silently open the pipe. These setters compile
+        // with the features off, so pinning the answer here costs nothing
+        // and stops that from ever being a silent change.
+        .enable_logs(false)
+        .enable_metrics(false)
+        .before_send(redact_event)
+        .before_breadcrumb(|mut breadcrumb| {
+            breadcrumb.message = breadcrumb.message.map(|m| redact_lines(&m));
+            Some(breadcrumb)
+        })
+        // The wire gate. Everything above shapes events; this decides what
+        // is allowed to leave the process at all. See `transport`.
+        .transport(transport::GuardedTransportFactory)
+}
+
+/// Stop transmitting in the current process, immediately.
 ///
-/// This cannot recall the minidump supervisor: it is a separate process forked
-/// before the WebView existed, so a hard native crash before the next restart
-/// may still be delivered. That limitation is stated in the settings copy rather
+/// Closing [`TRANSMITS`] is what actually stops it: the wire gate in
+/// [`transport`] re-reads that flag for every envelope, so the next one is
+/// dropped no matter which path produced it.
+///
+/// The hub unbind is the second, weaker half and is kept only because it also
+/// stops events being *built*. On its own it would not be enough, and the
+/// earlier version of this doc — which claimed unbinding "drops every
+/// subsequent event on the floor" — was simply false on two counts:
+///   * `Hub::current()` is **thread-local**, so this unbinds one thread. Work
+///     on any other thread keeps its own hub, and its own client.
+///   * `tauri-plugin-sentry` hands its own `Client` clone to Tauri state and
+///     calls `send_envelope` on it directly, never consulting a hub at all.
+///
+/// Neither can recall the minidump supervisor: it is a separate process forked
+/// before the WebView existed, holding its own client and its own copy of the
+/// gate's startup value, so a hard native crash before the next restart may
+/// still be delivered. That limitation is stated in the settings copy rather
 /// than papered over.
 pub fn disable_current() {
+    TRANSMITS.store(false, Ordering::Relaxed);
     sentry::Hub::current().bind_client(None);
 }
 
@@ -363,6 +427,31 @@ mod tests {
             "save() must be observable through load() — they resolved to different dirs otherwise"
         );
         assert!(!after.transmits(), "an explicit opt-out must not transmit");
+        // The wire gate must move with the file. If `save` ever stops mirroring
+        // into `TRANSMITS`, an opt-out would persist to disk while the transport
+        // kept sending for the rest of the session.
+        assert!(
+            !transmits_now(),
+            "save(opt-out) must close the wire gate, not just write the file"
+        );
+
+        // Same for the consent-granted direction, so the guard cannot pass by
+        // being stuck closed.
+        save(Settings {
+            enabled: true,
+            consent_shown: true,
+        });
+        assert!(
+            transmits_now(),
+            "save(consent granted) must open the wire gate"
+        );
+
+        // ...and the factory-reset path must close it again.
+        clear();
+        assert!(
+            !transmits_now(),
+            "clear() restores the never-asked default, which must not transmit"
+        );
 
         // Restore whatever the environment had, so this test leaves no trace.
         if before == Settings::default() {
@@ -370,6 +459,48 @@ mod tests {
         } else {
             save(before);
         }
+    }
+
+    /// The privacy-relevant half of the client configuration, pinned.
+    ///
+    /// Every assertion here is a switch whose wrong value leaks something and
+    /// whose absence is invisible at runtime — `enable_logs`/`enable_metrics`
+    /// default to TRUE in sentry 0.49, `server_name` defaults to the machine
+    /// hostname, and dropping the `.transport(...)` call would silently remove
+    /// the entire wire gate while everything still compiled and shipped.
+    #[test]
+    fn client_options_pin_every_privacy_switch() {
+        let options = client_options();
+
+        assert!(
+            options.transport.is_some(),
+            "the wire gate must be installed — without it raw envelopes egress unredacted"
+        );
+        assert!(
+            options.before_send.is_some(),
+            "capture-path events must still be redacted"
+        );
+        assert!(
+            options.before_breadcrumb.is_some(),
+            "breadcrumb messages must still be redacted"
+        );
+        assert!(
+            !options.enable_logs,
+            "0.49 defaults structured logs ON; that is egress we never consented to"
+        );
+        assert!(
+            !options.enable_metrics,
+            "0.49 defaults metrics ON; that is egress we never consented to"
+        );
+        assert!(
+            !options.send_default_pii,
+            "the SDK must never attach inferred user identity"
+        );
+        assert_eq!(
+            options.server_name.as_deref(),
+            Some("redacted"),
+            "server_name defaults to the hostname, which is often the user's real name"
+        );
     }
 
     /// The gate that protects the privacy claim: nothing identifying may survive

--- a/apps/desktop/src-tauri/src/crash_reporting/mod.rs
+++ b/apps/desktop/src-tauri/src/crash_reporting/mod.rs
@@ -50,7 +50,7 @@
 //! diagnostics bundle uses (ADR-027) rather than inventing a second, weaker one.
 
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
@@ -212,32 +212,36 @@ pub fn init() -> Option<sentry::ClientInitGuard> {
     }
     let dsn = DSN?;
 
+    // Builder rather than a struct literal: `ClientOptions` is `#[non_exhaustive]`
+    // as of sentry 0.49, so `..Default::default()` no longer compiles from a
+    // downstream crate. Every setter below is still one field, set explicitly —
+    // including the two the SDK now happens to default the same way, because a
+    // privacy-relevant value should be readable here, not inferred from an
+    // upstream default that can change under us.
     Some(sentry::init((
         dsn,
-        sentry::ClientOptions {
-            release: Some(env!("CARGO_PKG_VERSION").into()),
-            environment: Some(if cfg!(debug_assertions) {
-                "development".into()
+        sentry::ClientOptions::new()
+            .release(env!("CARGO_PKG_VERSION"))
+            .environment(if cfg!(debug_assertions) {
+                "development"
             } else {
-                "production".into()
-            }),
+                "production"
+            })
             // Release health: crash-free rate and version adoption. This is the
             // "usage" half of the feature — active installs per version — and it
             // needs no separate analytics vendor.
-            auto_session_tracking: true,
-            session_mode: sentry::SessionMode::Application,
+            .auto_session_tracking(true)
+            .session_mode(sentry::SessionMode::Application)
             // Never attach the request/user identity the SDK can infer.
-            send_default_pii: false,
+            .send_default_pii(false)
             // The SDK defaults this to the machine hostname, which on a personal
             // device is frequently the user's real name.
-            server_name: Some("redacted".into()),
-            before_send: Some(Arc::new(redact_event)),
-            before_breadcrumb: Some(Arc::new(|mut breadcrumb| {
+            .server_name("redacted")
+            .before_send(redact_event)
+            .before_breadcrumb(|mut breadcrumb| {
                 breadcrumb.message = breadcrumb.message.map(|m| redact_lines(&m));
                 Some(breadcrumb)
-            })),
-            ..Default::default()
-        },
+            }),
     )))
 }
 

--- a/apps/desktop/src-tauri/src/crash_reporting/transport.rs
+++ b/apps/desktop/src-tauri/src/crash_reporting/transport.rs
@@ -9,9 +9,10 @@
 //! transport with no callback in between.
 //!
 //! `tauri-plugin-sentry` 0.6 walks through exactly that door. When a renderer
-//! envelope fails to parse — which happens routinely, because
-//! `@sentry/vite-plugin`'s debug-ID injection writes a `debug_meta` sourcemap
-//! image sentry-rust cannot deserialize (getsentry/sentry-rust#1267) — the
+//! envelope fails to parse — routinely in apps that use `@sentry/vite-plugin`,
+//! whose debug-ID injection writes a `debug_meta` sourcemap image sentry-rust
+//! cannot deserialize (getsentry/sentry-rust#1267); this app ships no
+//! `@sentry/*` package, so the drop path is expected to stay cold here — the
 //! plugin rebuilds it with `Envelope::from_bytes_raw` and calls `send_envelope`
 //! (`commands.rs:30-35`). Such an envelope keeps the original bytes in a
 //! private `Items::Raw`, and `to_writer` copies them to the socket **verbatim**

--- a/apps/desktop/src-tauri/src/crash_reporting/transport.rs
+++ b/apps/desktop/src-tauri/src/crash_reporting/transport.rs
@@ -1,0 +1,312 @@
+//! The wire gate — the last hop before anything reaches Sentry's servers.
+//!
+//! ## Why this exists instead of relying on `before_send`
+//!
+//! `before_send` is **not** the last hop. In sentry-core 0.49.1 it has exactly
+//! one call site — `client/mod.rs:383`, inside the `capture_event` preparation
+//! — so it only ever sees events that took the *capture* path. Anything handed
+//! to `Client::send_envelope` (`client/mod.rs:500`) goes straight to the
+//! transport with no callback in between.
+//!
+//! `tauri-plugin-sentry` 0.6 walks through exactly that door. When a renderer
+//! envelope fails to parse — which happens routinely, because
+//! `@sentry/vite-plugin`'s debug-ID injection writes a `debug_meta` sourcemap
+//! image sentry-rust cannot deserialize (getsentry/sentry-rust#1267) — the
+//! plugin rebuilds it with `Envelope::from_bytes_raw` and calls `send_envelope`
+//! (`commands.rs:30-35`). Such an envelope keeps the original bytes in a
+//! private `Items::Raw`, and `to_writer` copies them to the socket **verbatim**
+//! (sentry-types `protocol/envelope.rs:590`), so nothing we can install on the
+//! event pipeline is able to reach inside it.
+//!
+//! Plugin 0.5 dropped those envelopes on the floor; 0.6 forwards them. That is
+//! new, unredactable egress, so the guarantee moves to the one place that sees
+//! every byte: the transport.
+//!
+//! ## What is enforced here
+//!
+//! 1. **Consent**, re-checked per envelope. `Hub::current()` is thread-local,
+//!    so [`super::disable_current`] only unbinds the calling thread, and the
+//!    plugin holds its own `Client` clone in Tauri state that never consults the
+//!    hub at all. A gate at the transport is the only one both paths must pass.
+//! 2. **Opaque envelopes are dropped**, restoring 0.5's semantics. A payload we
+//!    cannot inspect is a payload we cannot redact, and the privacy guarantee
+//!    outranks the sourcemap edge case the plugin wanted to fix.
+//!
+//! Both drops are counted and logged content-free (a code and a count, never
+//! the payload — the same rule the diagnostics bundle follows).
+//!
+//! `before_send` stays exactly what it was: the event-shaping hook that redacts
+//! events on the capture path, where the structure is still typed and
+//! rewritable.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use sentry::{Envelope, Transport, TransportFactory, TransportOptions};
+
+/// Reads the current transmission consent.
+///
+/// Injected rather than called directly so the guard can be driven in tests
+/// without touching the process-wide consent file (and so two tests can hold
+/// opposite opinions at the same time). Production passes
+/// [`super::transmits_now`], which is a single relaxed atomic load — lock-free,
+/// allocation-free, and safe to call on the transport's own thread.
+type ConsentGate = Box<dyn Fn() -> bool + Send + Sync>;
+
+/// Wraps the SDK's own transport instead of reimplementing HTTP.
+///
+/// Installed via `ClientOptions::transport`, which replaces the factory the SDK
+/// would otherwise have used. We build that same factory
+/// (`sentry::transports::DefaultTransportFactory`, which under our feature set
+/// resolves to the ureq transport) and delegate to it, so retries, rate-limit
+/// handling and the background sender thread stay upstream's problem.
+pub struct GuardedTransportFactory;
+
+impl TransportFactory for GuardedTransportFactory {
+    fn create_transport_with_options(&self, options: TransportOptions) -> Arc<dyn Transport> {
+        let inner =
+            sentry::transports::DefaultTransportFactory.create_transport_with_options(options);
+        Arc::new(GuardedTransport::new(inner, Box::new(super::transmits_now)))
+    }
+}
+
+/// The guard itself. See the module docs for what it enforces and why.
+struct GuardedTransport {
+    inner: Arc<dyn Transport>,
+    transmits: ConsentGate,
+    dropped_without_consent: AtomicU64,
+    dropped_opaque: AtomicU64,
+}
+
+impl GuardedTransport {
+    fn new(inner: Arc<dyn Transport>, transmits: ConsentGate) -> Self {
+        Self {
+            inner,
+            transmits,
+            dropped_without_consent: AtomicU64::new(0),
+            dropped_opaque: AtomicU64::new(0),
+        }
+    }
+}
+
+/// Whether this envelope carries nothing we can inspect.
+///
+/// `Envelope`'s `Items` enum is private, so there is no `is_raw()` to call.
+/// There does not need to be: a raw envelope yields an **empty** item iterator
+/// by construction (`Items::Raw(_) => [].iter()`, sentry-types
+/// `protocol/envelope.rs:480`), because its bytes were never parsed into items.
+/// So "no items" is exactly the set we must not forward — every raw envelope,
+/// plus degenerate empty ones, which carry nothing worth sending anyway.
+///
+/// Parsed envelopes always carry at least one item (an event, a session, a
+/// transaction), so this never swallows a legitimate payload.
+fn is_opaque(envelope: &Envelope) -> bool {
+    envelope.items().next().is_none()
+}
+
+impl Transport for GuardedTransport {
+    fn send_envelope(&self, envelope: Envelope) {
+        if !(self.transmits)() {
+            let n = self.dropped_without_consent.fetch_add(1, Ordering::Relaxed) + 1;
+            log::debug!("[crash-reporting] wire gate closed, envelope not sent (count {n})");
+            return;
+        }
+        if is_opaque(&envelope) {
+            let n = self.dropped_opaque.fetch_add(1, Ordering::Relaxed) + 1;
+            log::warn!(
+                "[crash-reporting] dropped an opaque (unparseable) envelope at the wire; \
+                 it cannot be redacted (count {n})"
+            );
+            return;
+        }
+        self.inner.send_envelope(envelope);
+    }
+
+    // Both lifecycle methods delegate: swallowing them would silently break the
+    // flush the minidump supervisor performs before the crash-reporter process
+    // exits, and the drain `ClientInitGuard` runs on drop.
+    fn flush(&self, timeout: Duration) -> bool {
+        self.inner.flush(timeout)
+    }
+
+    fn shutdown(&self, timeout: Duration) -> bool {
+        self.inner.shutdown(timeout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Mutex;
+
+    use sentry::protocol::Event;
+
+    use super::*;
+
+    /// Stand-in for the ureq transport: records what actually reached the wire.
+    #[derive(Default)]
+    struct RecordingTransport {
+        sent: Mutex<Vec<Envelope>>,
+        flushed: AtomicU64,
+        shut_down: AtomicU64,
+    }
+
+    impl RecordingTransport {
+        fn sent_count(&self) -> usize {
+            self.sent.lock().unwrap().len()
+        }
+    }
+
+    impl Transport for RecordingTransport {
+        fn send_envelope(&self, envelope: Envelope) {
+            self.sent.lock().unwrap().push(envelope);
+        }
+        fn flush(&self, _timeout: Duration) -> bool {
+            self.flushed.fetch_add(1, Ordering::Relaxed);
+            true
+        }
+        fn shutdown(&self, _timeout: Duration) -> bool {
+            self.shut_down.fetch_add(1, Ordering::Relaxed);
+            true
+        }
+    }
+
+    fn guarded(consent: bool) -> (GuardedTransport, Arc<RecordingTransport>) {
+        let inner = Arc::new(RecordingTransport::default());
+        let gate = Arc::new(AtomicBool::new(consent));
+        let transport = GuardedTransport::new(
+            inner.clone(),
+            Box::new(move || gate.load(Ordering::Relaxed)),
+        );
+        (transport, inner)
+    }
+
+    /// A real envelope with a real item, built the way the capture path does.
+    fn parsed_envelope() -> Envelope {
+        let mut envelope = Envelope::new();
+        envelope.add_item(Event::default());
+        envelope
+    }
+
+    /// A real raw envelope — the exact constructor `tauri-plugin-sentry` 0.6
+    /// reaches for when `from_slice` fails.
+    fn raw_envelope() -> Envelope {
+        Envelope::from_bytes_raw(b"{\"event_id\":\"nope\"}\n{\"type\":\"event\"}\n{}".to_vec())
+            .expect("from_bytes_raw never fails")
+    }
+
+    #[test]
+    fn a_raw_envelope_is_dropped_and_counted() {
+        let (transport, inner) = guarded(true);
+
+        // Precondition: this really is an `Items::Raw` envelope, not an empty
+        // one we accidentally built — a raw envelope round-trips its bytes.
+        let mut written = Vec::new();
+        raw_envelope().to_writer(&mut written).unwrap();
+        assert!(
+            !written.is_empty(),
+            "precondition: the raw envelope carries bytes that WOULD reach the wire"
+        );
+
+        transport.send_envelope(raw_envelope());
+
+        assert_eq!(inner.sent_count(), 0, "raw bytes must never reach the wire");
+        assert_eq!(
+            transport.dropped_opaque.load(Ordering::Relaxed),
+            1,
+            "the drop must be counted so it is observable"
+        );
+        assert_eq!(
+            transport.dropped_without_consent.load(Ordering::Relaxed),
+            0,
+            "consent was granted — this must be attributed to opacity, not consent"
+        );
+    }
+
+    #[test]
+    fn nothing_is_forwarded_without_consent() {
+        let (transport, inner) = guarded(false);
+
+        transport.send_envelope(parsed_envelope());
+        transport.send_envelope(raw_envelope());
+
+        assert_eq!(
+            inner.sent_count(),
+            0,
+            "a closed gate must stop a perfectly valid envelope too"
+        );
+        assert_eq!(
+            transport.dropped_without_consent.load(Ordering::Relaxed),
+            2,
+            "consent is checked first, so both drops are attributed to consent"
+        );
+    }
+
+    #[test]
+    fn a_parsed_envelope_is_forwarded_once_when_consent_is_granted() {
+        let (transport, inner) = guarded(true);
+
+        transport.send_envelope(parsed_envelope());
+
+        assert_eq!(
+            inner.sent_count(),
+            1,
+            "the gate must not break ordinary crash reporting"
+        );
+        assert_eq!(transport.dropped_opaque.load(Ordering::Relaxed), 0);
+        assert_eq!(transport.dropped_without_consent.load(Ordering::Relaxed), 0);
+    }
+
+    /// The gate follows consent as it changes — a mid-session opt-out closes it
+    /// for the rest of the session without a restart.
+    #[test]
+    fn the_gate_is_re_read_per_envelope_not_captured_once() {
+        let inner = Arc::new(RecordingTransport::default());
+        let gate = Arc::new(AtomicBool::new(true));
+        let transport = GuardedTransport::new(inner.clone(), {
+            let gate = gate.clone();
+            Box::new(move || gate.load(Ordering::Relaxed))
+        });
+
+        transport.send_envelope(parsed_envelope());
+        assert_eq!(inner.sent_count(), 1, "precondition: open gate forwards");
+
+        gate.store(false, Ordering::Relaxed);
+        transport.send_envelope(parsed_envelope());
+
+        assert_eq!(
+            inner.sent_count(),
+            1,
+            "an opt-out mid-session must take effect on the very next envelope"
+        );
+    }
+
+    /// A wrapper that swallowed these would strand the supervisor's pre-exit
+    /// flush, losing the crash it was forked to report.
+    #[test]
+    fn flush_and_shutdown_reach_the_inner_transport() {
+        let (transport, inner) = guarded(true);
+
+        assert!(transport.flush(Duration::from_secs(1)));
+        assert!(transport.shutdown(Duration::from_secs(1)));
+
+        assert_eq!(inner.flushed.load(Ordering::Relaxed), 1, "flush delegated");
+        assert_eq!(
+            inner.shut_down.load(Ordering::Relaxed),
+            1,
+            "shutdown delegated"
+        );
+    }
+
+    /// Pins the detector itself, so a future refactor of [`is_opaque`] has to
+    /// keep distinguishing the two shapes.
+    #[test]
+    fn is_opaque_separates_raw_from_parsed() {
+        assert!(is_opaque(&raw_envelope()), "raw envelopes are opaque");
+        assert!(
+            !is_opaque(&parsed_envelope()),
+            "an envelope with items is inspectable"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -458,8 +458,14 @@ pub fn run() {
         // `invoke`. The WebView never talks to the network itself, so the CSP
         // `connect-src` allowlist in tauri.conf.json is deliberately untouched
         // (widening it is rated HIGH/CRITICAL — docs/knowledge/security-rules.md).
-        // It also means renderer events inherit the same `before_send` redaction
-        // as Rust events instead of needing a second, parallel scrubber.
+        //
+        // Renderer events do NOT all inherit `before_send`, which this comment
+        // used to claim. The plugin only routes a renderer envelope through
+        // `capture_event` (and therefore through our redaction) when it parses
+        // AND contains an event item; everything else it hands to
+        // `Client::send_envelope`, which reaches the transport directly. That is
+        // why the privacy guarantee is enforced one level lower, in
+        // `crash_reporting::transport` — see that module.
         builder = builder.plugin(tauri_plugin_sentry::init(client));
     }
 


### PR DESCRIPTION
The coordinated Sentry upgrade dependabot #972 could not do alone: `sentry` 0.42 → 0.49.1 and `tauri-plugin-sentry` 0.5 → 0.6 move together (the repo's 0.42 pin existed because the plugin builds against a matched sentry — a solo bump duplicated sentry/sentry-core/sentry-types in the lock and failed 6 checks).

## What's in here

- **The bump**: sentry 0.49.1 + plugin 0.6.0 + sentry-rust-minidump 0.17 — single copy of every sentry crate in the lock, and the `reqwest 0.12` duplicate the old pin dragged along is gone (one fewer HTTP+TLS stack). `ClientOptions` went `non_exhaustive` in 0.49, so `crash_reporting` moved to the builder, field-for-field.
- **A latent no-op removed**: the `rustls-native-certs` reqwest feature we listed was never referenced by reqwest 0.13.1's code and no longer exists in 0.13.2+ — 0.49's resolver made it a hard error. OS trust roots are unaffected (`rustls-platform-verifier` + `native-tls` carry them).
- **The wire gate** (`crash_reporting/transport.rs`, new): security review found plugin 0.6 forwards renderer envelopes that fail to parse as **raw bytes** via `send_envelope`, which never runs `before_send` — an unredacted egress path 0.5 simply dropped. The fix wraps the default (ureq) transport: raw envelopes are dropped and counted, and **consent is enforced per envelope at the wire** — which also closes a pre-existing gap where mid-session opt-out didn't actually stop the plugin's egress (thread-local hub + the plugin's own `Client` clone both bypassed `bind_client(None)`).
- **0.49's new defaults pinned off**: `enable_logs(false)` / `enable_metrics(false)` — upstream flipped both to `true`; consumers are feature-gated today, but feature unification by any future dependency would have turned on new egress invisibly.
- **deny.toml**: `failspot/enabled` (a fault-injection crate arriving via minidump-writer) is now banned, with the ban mechanism mutation-verified live.
- Falsified comments corrected: the module docs now state the transport-level guarantee truthfully instead of claiming `before_send` covers everything.

## Review

Full tauri-security-reviewer pass (BLOCK → fix → delta re-verify → APPROVE). The raw-detection design (`Items::Raw` ⇒ empty `items()` iterator) was verified airtight in 0.49.1 in both directions — including the `envelope_sender::with_item` mutation path between client and transport — and is version-coupled, so it's pinned on the bump checklist in `Cargo.toml` and by a loud test. Known follow-up (recorded, pre-existing, currently PII-free by construction): parsed non-event envelope items (sessions/client reports) pass consent but not redaction; escalates to a blocker only if a browser-SDK integration that emits user-visible non-event items is ever enabled.

## Tests

4004 Rust lib (+7) · 18 architecture · clippy `--all-targets --all-features --locked -D warnings` · fmt · `cargo deny check` (advisories/bans/licenses/sources ok) · `cargo machete` — all green. 12/13 wrapper mutations caught; the survivor (`send_default_pii(false)` deletion equals the default) is disclosed in the test doc rather than overclaimed. macOS compile is CI-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Crash reports are now transmitted only when crash-reporting consent is enabled.
  * Consent changes and factory resets take effect immediately.
  * Personal information and server details receive stronger protection during crash reporting.

* **Bug Fixes**
  * Improved handling of malformed or unsupported crash-reporting data to prevent unintended transmission.
  * Enhanced reliability when enabling or disabling crash reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->