### PR TITLE
fix(autopilot): stop the double scroll when returning from an application

### DIFF
--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
@@ -78,6 +78,9 @@ const mockSessionState: {
     applyForId: string | null;
   };
   setApplicationApply: typeof mockSetApplicationApply;
+  // Only `lastAppliedId` is read by the component (the resetScroll gate); kept
+  // minimal rather than mirroring the full autopilot slice.
+  autopilot: { lastAppliedId: string | null };
 } = {
   applicationApply: {
     applyWizardStep: 0,
@@ -87,6 +90,7 @@ const mockSessionState: {
     applyForId: null,
   },
   setApplicationApply: mockSetApplicationApply,
+  autopilot: { lastAppliedId: null },
 };
 
 vi.mock('@/store/session-store', () => ({
@@ -257,6 +261,7 @@ import { ApplicationDetailPage } from './index';
 beforeEach(() => {
   mockTab = 'overview';
   mockFrom = undefined;
+  mockSessionState.autopilot.lastAppliedId = null;
   mockUseApplication.mockReset();
   mockUseAiGenerations.mockReset();
   // `mockReset` (not `mockClear`): the contact-rejection tests install an
@@ -846,23 +851,37 @@ describe('ApplicationDetailPage — ?tab= behaviour', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // ApplicationDetailPage — Back navigation `resetScroll` seam
 //
-// `from === 'autopilot'` means Autopilot's own focus effect performs the ONE
-// scroll motion this return trip needs (re-expand + scrollIntoView the applied
-// job). The router's own scroll reset/restore must be skipped for that one
-// hop, or it fires first and produces a visible double-scroll. Mutation check:
-// dropping `resetScroll: from !== 'autopilot'` back to a bare `navigate({ to:
-// backTarget })` turns the first assertion red (no `resetScroll` key at all).
+// `from === 'autopilot'` ALONE isn't proof a compensating scroll will run:
+// `from` is a URL search param that survives native forward-navigation, while
+// `lastAppliedId` is the one-shot session-store field Autopilot's own focus
+// effect consumes on its next mount. The gate requires BOTH — `from ===
+// 'autopilot'` AND a pending `lastAppliedId` — before skipping the router's
+// scroll restoration. Mutation check: dropping either half of the `&&` (back
+// to a bare `from !== 'autopilot'`, or a bare `navigate({ to: backTarget })`)
+// turns the first two assertions below red.
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('ApplicationDetailPage — Back navigation resetScroll seam', () => {
-  it('returning from Autopilot opts the navigation out of scroll restoration', async () => {
+  it('returning from Autopilot WITH a pending focus opts out of scroll restoration', async () => {
     mockFrom = 'autopilot';
+    mockSessionState.autopilot.lastAppliedId = 'ap-1';
     const user = userEvent.setup();
     renderLoaded({ id: 'app-back-autopilot' });
 
     await user.click(screen.getByText('applications.detail.backAutopilot'));
 
     expect(mockNavigate).toHaveBeenCalledWith({ to: '/autopilot', resetScroll: false });
+  });
+
+  it('returning from Autopilot WITHOUT a pending focus (e.g. forward-nav replay) keeps the default reset', async () => {
+    mockFrom = 'autopilot';
+    mockSessionState.autopilot.lastAppliedId = null;
+    const user = userEvent.setup();
+    renderLoaded({ id: 'app-back-autopilot-stale' });
+
+    await user.click(screen.getByText('applications.detail.backAutopilot'));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/autopilot', resetScroll: true });
   });
 
   it('returning from Jobs keeps the default scroll reset (no compensating scroll effect there)', async () => {

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
@@ -53,12 +53,15 @@ vi.mock('@tanstack/react-router', () => ({
 // The active tab returned by `Route.useSearch()`. Defaults to overview; tests
 // that target the Documents tab override it via `mockTab`.
 let mockTab: 'overview' | 'timeline' | 'brief' | 'documents' = 'overview';
+// The `?from=` origin returned by `Route.useSearch()`. Defaults to unset; the
+// Back-navigation tests below override it per case.
+let mockFrom: 'jobs' | 'autopilot' | 'applications' | undefined = undefined;
 
 vi.mock('@/routes/applications.$id', () => ({
   DETAIL_TABS: ['overview', 'timeline', 'brief', 'documents'] as const,
   Route: {
     useParams: () => ({ id: 'app-1' }),
-    useSearch: () => ({ tab: mockTab }),
+    useSearch: () => ({ tab: mockTab, from: mockFrom }),
   },
 }));
 
@@ -253,6 +256,7 @@ import { ApplicationDetailPage } from './index';
 
 beforeEach(() => {
   mockTab = 'overview';
+  mockFrom = undefined;
   mockUseApplication.mockReset();
   mockUseAiGenerations.mockReset();
   // `mockReset` (not `mockClear`): the contact-rejection tests install an
@@ -840,6 +844,49 @@ describe('ApplicationDetailPage — ?tab= behaviour', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// ApplicationDetailPage — Back navigation `resetScroll` seam
+//
+// `from === 'autopilot'` means Autopilot's own focus effect performs the ONE
+// scroll motion this return trip needs (re-expand + scrollIntoView the applied
+// job). The router's own scroll reset/restore must be skipped for that one
+// hop, or it fires first and produces a visible double-scroll. Mutation check:
+// dropping `resetScroll: from !== 'autopilot'` back to a bare `navigate({ to:
+// backTarget })` turns the first assertion red (no `resetScroll` key at all).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ApplicationDetailPage — Back navigation resetScroll seam', () => {
+  it('returning from Autopilot opts the navigation out of scroll restoration', async () => {
+    mockFrom = 'autopilot';
+    const user = userEvent.setup();
+    renderLoaded({ id: 'app-back-autopilot' });
+
+    await user.click(screen.getByText('applications.detail.backAutopilot'));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/autopilot', resetScroll: false });
+  });
+
+  it('returning from Jobs keeps the default scroll reset (no compensating scroll effect there)', async () => {
+    mockFrom = 'jobs';
+    const user = userEvent.setup();
+    renderLoaded({ id: 'app-back-jobs' });
+
+    await user.click(screen.getByText('applications.detail.backJobs'));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/jobs', resetScroll: true });
+  });
+
+  it('returning with no origin (plain applications list) also keeps the default scroll reset', async () => {
+    mockFrom = undefined;
+    const user = userEvent.setup();
+    renderLoaded({ id: 'app-back-default' });
+
+    await user.click(screen.getByText('applications.detail.back'));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/applications', resetScroll: true });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // ApplicationDetailPage — ActionMenu delete flows
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -873,7 +920,7 @@ describe('ApplicationDetailPage — ActionMenu delete flows', () => {
       keepDocuments: true,
     });
     // After deletion navigates back to /applications.
-    expect(mockNavigate).toHaveBeenCalledWith({ to: '/applications' });
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/applications', resetScroll: true });
   });
 
   it('"delete everything" confirms with keepDocuments: false and navigates to /applications', async () => {
@@ -897,7 +944,7 @@ describe('ApplicationDetailPage — ActionMenu delete flows', () => {
       id: 'app-del-all',
       keepDocuments: false,
     });
-    expect(mockNavigate).toHaveBeenCalledWith({ to: '/applications' });
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/applications', resetScroll: true });
   });
 
   it('cancelling the confirm modal does NOT call remove mutate', async () => {

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
@@ -173,12 +173,28 @@ export function ApplicationDetailPage() {
 
   const { from } = Route.useSearch();
   const backTarget = from ? BACK_TO[from] : '/applications';
+  // Gate on the ACTUAL compensating state, not just the `from` label: `from`
+  // is a URL search param that survives native forward-navigation (mouse
+  // forward / Alt+Right — nothing intercepts webview history), while
+  // `lastAppliedId` is the one-shot session-store field AutopilotPage's focus
+  // effect consumes on its NEXT mount. A second arrival at the same
+  // ?from=autopilot URL with no pending focus left must fall back to the
+  // router's default scroll reset — there's no compensating scroll to replace it.
+  const hasPendingAutopilotFocus = useSessionStore((s) => s.autopilot.lastAppliedId !== null);
   // Returning to Autopilot from an Apply: that page's own focus effect
   // re-expands the source card and scrollIntoView's the applied job — the ONE
   // scroll motion this trip needs. Skip the router's own scroll reset/restore
   // for that hop only, or it fires first and the list visibly scrolls twice
-  // (an old/reset position, then the focus jump).
-  const back = () => void navigate({ to: backTarget, resetScroll: from !== 'autopilot' });
+  // (an old/reset position, then the focus jump). `from` alone isn't trusted
+  // here — it's only meaningful alongside `hasPendingAutopilotFocus` above (a
+  // backend/notification-driven `?from=autopilot` with no pending focus, e.g.
+  // routes/__root.tsx or use-notifications.ts, correctly falls through to the
+  // router's default reset since the state gate still requires it).
+  const back = () =>
+    void navigate({
+      to: backTarget,
+      resetScroll: !(from === 'autopilot' && hasPendingAutopilotFocus),
+    });
   const backLabel =
     from === 'jobs'
       ? t('applications.detail.backJobs')

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
@@ -173,7 +173,12 @@ export function ApplicationDetailPage() {
 
   const { from } = Route.useSearch();
   const backTarget = from ? BACK_TO[from] : '/applications';
-  const back = () => void navigate({ to: backTarget });
+  // Returning to Autopilot from an Apply: that page's own focus effect
+  // re-expands the source card and scrollIntoView's the applied job — the ONE
+  // scroll motion this trip needs. Skip the router's own scroll reset/restore
+  // for that hop only, or it fires first and the list visibly scrolls twice
+  // (an old/reset position, then the focus jump).
+  const back = () => void navigate({ to: backTarget, resetScroll: from !== 'autopilot' });
   const backLabel =
     from === 'jobs'
       ? t('applications.detail.backJobs')


### PR DESCRIPTION
Fixes the owner-reported jump on the Autopilot page: with several autopilots and the bottom one expanded, applying to a job and then clicking **Back to autopilot** produced two visible motions — the router's global scroll-restoration pass fired first (reset/restore over the whole list), then the page's own focus effect suddenly centered the previously-expanded autopilot.

## What changed

- **One clean scroll.** The application page's `back()` now passes `resetScroll: false` to `navigate()` for the return-to-autopilot trip, so TanStack Router's restore-and-reset pass (verified against the installed `@tanstack/router-core@1.171.21` source — the flag gates the whole block, restoration included) is skipped exactly where the Autopilot page's existing pending-focus effect takes over and performs the single centered scroll it always did.
- **The skip is gated structurally, not by origin alone.** `from=autopilot` is a URL search param that outlives the one-shot in-memory pending-focus state (native forward-nav can replay it), so the gate reads the session store at call time: `resetScroll: !(from === 'autopilot' && hasPendingAutopilotFocus)`. A stale `?from=autopilot` with no pending focus falls back to the router's default reset instead of silently dropping all motion.
- Other back origins (`jobs`, `applications`, none) keep the default reset-to-top — they have no compensating scroll effect.

## Review provenance

frontend-reviewer APPROVE: it read the router package source to confirm the `resetScroll` semantics claim, live-mutated the gate to confirm the seam tests go red, and surfaced the origin-vs-state correlation gap that the second commit closes (plus a comment documenting the trust boundary where backend-supplied search params reach `navigate()`).

## Tests

Seam-level (jsdom zeroes rects, so the tests pin the `navigate()` call shape, not pixels): `from='autopilot'` with pending focus → `resetScroll: false`; without → `true`; `jobs`/no-origin → `true`. Mutation-checked in both rounds — reverting either the flag or the state gate turns exactly the guarding tests red. Touched file 69/69; applications + autopilot suites 497/497; typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)