### PR TITLE
feat(scraping): treat an implausible scraped company name as absent

### DIFF
--- a/apps/desktop/src-tauri/src/commands/resume_pipeline/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/resume_pipeline/mod.rs
@@ -294,6 +294,13 @@ async fn execute(
         |id| crate::commands::match_resume::job_meta_for(app, id),
         || job_meta_from_request(&clamped),
     )?;
+    // A1 (hardening plan): neither source above sanitizes `company` — a
+    // scraped posting's own field least of all — so this is the one place
+    // every run's company name passes through
+    // `crate::scraping::trust::is_implausible_company` before it can reach
+    // `QualityInput::company_name` (company research) or the persisted
+    // `AiGenerationRecord.company_name` below. See `resolve::sanitize_job_meta`.
+    let meta = resolve::sanitize_job_meta(meta);
     // The posting's OWN url wins over the request's: it was resolved
     // server-side from the cache, and it is the AGGREGATE's key
     // (`AiGenerationRecord.job_url` — see `resolve::job_ad_for_persist`'s doc

--- a/apps/desktop/src-tauri/src/commands/resume_pipeline/resolve.rs
+++ b/apps/desktop/src-tauri/src/commands/resume_pipeline/resolve.rs
@@ -273,6 +273,35 @@ pub(crate) fn job_meta_from_request(
     }
 }
 
+/// The generation boundary for an implausible company name (A1 of the
+/// hardening plan). Runs on the MERGED [`crate::commands::match_resume::
+/// JobPostingMeta`] — after [`resolve_job`], so it covers both the `Cache`
+/// arm (`job_meta_for`, a scraped posting's own `company` field, never
+/// sanitized upstream) and the `Text` arm ([`job_meta_from_request`], a
+/// renderer-supplied string) with one call, rather than two call sites that
+/// could drift.
+///
+/// Blanks `meta.company` to `""` — never `Option::None`, because
+/// `JobPostingMeta.company` is a plain `String` and every existing consumer
+/// (`QualityInput::company_name`'s `research_company_brief` admission check,
+/// the cover-letter prompt's own "company name unknown" branch) already
+/// treats an empty string as "company not known", the identical convention
+/// `sanitizeCompanyName` uses on the TS side for AI-extracted metadata. This
+/// is additive enrichment turned into a SUBTRACTION at the generation
+/// boundary, not a `TrustAssessment`-style flag — deliberately: unlike
+/// `scraping::trust`'s flag-only contract (never drop, only badge), letting a
+/// known-implausible string reach the model as if it were a real employer
+/// name is the actual defect (PR #960), so this one field is the one place
+/// blanking is correct. `title`/`url`/`board` are untouched.
+pub(crate) fn sanitize_job_meta(
+    mut meta: crate::commands::match_resume::JobPostingMeta,
+) -> crate::commands::match_resume::JobPostingMeta {
+    if crate::scraping::trust::is_implausible_company(&meta.company) {
+        meta.company = String::new();
+    }
+    meta
+}
+
 /// What `persist_document` (`mod.rs`) should write into the aggregate's
 /// `job_ad` column. `Cache` stays empty — deliberately, per that fn's own doc:
 /// the postings cache is keyed by the live job id, which a finished run no

--- a/apps/desktop/src-tauri/src/commands/resume_pipeline/test.rs
+++ b/apps/desktop/src-tauri/src/commands/resume_pipeline/test.rs
@@ -1538,6 +1538,58 @@ fn resolve_job_errors_on_a_cache_miss_even_though_the_request_also_carried_text(
     assert!(matches!(err, crate::error::AppError::Validation(_)));
 }
 
+// ── sanitize_job_meta — the generation boundary (A1 hardening plan) ────────
+
+/// `sanitize_job_meta` blanks an implausible `company` to `""`, the same
+/// "company not known" convention every existing downstream consumer already
+/// treats an empty string as. Anchored to the CONCRETE resulting `Option`
+/// `research_company_brief`'s own admission expression produces
+/// (`(!company.is_empty()).then_some(company)`, `pipeline/resume/stages/
+/// cover_letter.rs`), not merely to `is_implausible_company`'s own bool — a
+/// garbage company must never reach `CompanyResearch`, and therefore never
+/// reach the model's "why this company" paragraph.
+///
+/// Mutation check: remove the `if crate::scraping::trust::is_implausible_company(…)`
+/// guard from `sanitize_job_meta` (return `meta` unchanged) — this test fails
+/// immediately (`admitted` becomes `Some("Apply now | LinkedIn")`).
+#[test]
+fn sanitize_job_meta_blanks_an_implausible_company_before_it_can_reach_company_research() {
+    let garbage = crate::commands::match_resume::JobPostingMeta {
+        company: "Apply now | LinkedIn".to_string(),
+        title: "Staff Engineer".to_string(),
+        url: "https://boards.example/jobs/1".to_string(),
+        board: "linkedin".to_string(),
+    };
+    let sanitized = super::resolve::sanitize_job_meta(garbage);
+    assert_eq!(sanitized.company, "");
+    // `title`/`url`/`board` must survive untouched — only `company` is in scope.
+    assert_eq!(sanitized.title, "Staff Engineer");
+    assert_eq!(sanitized.url, "https://boards.example/jobs/1");
+    assert_eq!(sanitized.board, "linkedin");
+
+    let admitted = (!sanitized.company.trim().is_empty()).then_some(sanitized.company.as_str());
+    assert_eq!(
+        admitted, None,
+        "a garbage company must never reach CompanyResearch"
+    );
+}
+
+/// The legitimate-name counterpart: a real employer name must reach
+/// `QualityInput::company_name`/the persisted `AiGenerationRecord.company_name`
+/// unchanged, so this boundary can't be satisfied by simply blanking
+/// everything.
+#[test]
+fn sanitize_job_meta_leaves_a_legitimate_company_untouched() {
+    let legit = crate::commands::match_resume::JobPostingMeta {
+        company: "Acme Corp".to_string(),
+        ..Default::default()
+    };
+    let sanitized = super::resolve::sanitize_job_meta(legit);
+    assert_eq!(sanitized.company, "Acme Corp");
+    let admitted = (!sanitized.company.trim().is_empty()).then_some(sanitized.company.as_str());
+    assert_eq!(admitted, Some("Acme Corp"));
+}
+
 /// **The error-echo clamp, guarded.** `resolve::echoed`/`ECHO_CHARS_CAP` bound
 /// a request-supplied id echoed into a validation-error message — at base
 /// the equivalent rule was mutation-checked by `commands/agent.rs`
@@ -1660,6 +1712,12 @@ fn execute_routes_resolution_through_the_pure_resolve_functions() {
         source.contains("resolve::run_store_job_url("),
         "the run row's own job_url must route through resolve::run_store_job_url, \
          not reuse the aggregate's job_url directly"
+    );
+    assert!(
+        source.contains("resolve::sanitize_job_meta("),
+        "execute must sanitize the resolved posting identity through \
+         resolve::sanitize_job_meta before it reaches QualityInput::company_name \
+         or the persisted AiGenerationRecord.company_name (A1 hardening plan)"
     );
 }
 

--- a/apps/desktop/src-tauri/src/export/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/export/commands/mod.rs
@@ -338,6 +338,12 @@ fn generate_filename(request: &ExportRequest, extension: &str) -> String {
         .meta
         .as_ref()
         .and_then(|m| m.company_name.as_ref())
+        // A1 (hardening plan): the renderer builds `GenerationMeta` from
+        // whatever a scraped posting's `company` field held, unsanitized —
+        // an implausible one (`"Apply now | LinkedIn"`) must fall to the same
+        // "Company" default an absent one already does, not land verbatim in
+        // the exported filename a user sees and shares.
+        .filter(|s| !crate::scraping::trust::is_implausible_company(s))
         .map(|s| sanitize_filename(s))
         .unwrap_or_else(|| "Company".to_string());
 

--- a/apps/desktop/src-tauri/src/export/commands/test.rs
+++ b/apps/desktop/src-tauri/src/export/commands/test.rs
@@ -269,6 +269,51 @@ fn test_generate_filename() {
     assert!(filename.ends_with(".docx"));
 }
 
+/// A1 (hardening plan) — end-to-end, anchored to the RENDERED filename a user
+/// actually sees/saves/shares, not to `is_implausible_company`'s own bool: a
+/// scraper-supplied garbage company (the literal PR #960 report) must fall
+/// back to the same `"Company"` default an absent one already produces,
+/// never appear verbatim in the exported file's name.
+///
+/// Mutation check: remove the `.filter(|s| !crate::scraping::trust::
+/// is_implausible_company(s))` line from `generate_filename` — this test
+/// fails immediately (the filename contains the raw garbage instead of
+/// falling back to `"Company"`).
+#[test]
+fn generate_filename_falls_back_to_company_default_for_an_implausible_name() {
+    use super::super::types::{
+        DocumentType, ExportFormat, GenerationMeta, LetterLayout, TemplateId,
+    };
+
+    let request = ExportRequest {
+        text: "Test".to_string(),
+        format: ExportFormat::Docx,
+        document_type: DocumentType::CoverLetter,
+        template_id: TemplateId::SwissMinimal,
+        meta: Some(GenerationMeta {
+            candidate_name: Some("John Doe".to_string()),
+            job_title: Some("Software Engineer".to_string()),
+            company_name: Some("Apply now | LinkedIn".to_string()),
+            target_language: None,
+        }),
+        ats_mode: false,
+        locale: None,
+        contact: None,
+        accent: None,
+        letter_layout: LetterLayout::Classic,
+    };
+
+    let filename = generate_filename(&request, "pdf");
+    assert!(
+        filename.contains("Company"),
+        "expected the absent-company fallback, got {filename:?}"
+    );
+    assert!(
+        !filename.contains("LinkedIn") && !filename.contains("Apply"),
+        "the garbage company must never reach the rendered filename, got {filename:?}"
+    );
+}
+
 /// `meta.candidate_name: Some("")` (the shape TailorFlow actually sends) must
 /// fall through to the attached `ContactProfile`'s name rather than winning
 /// as an empty string — before the non-blank filter, `Some("")` stayed

--- a/apps/desktop/src-tauri/src/scraping/trust/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/trust/mod.rs
@@ -38,6 +38,13 @@ pub enum TrustFlag {
     InvalidUrl,
     SuspiciousDomain,
     CompanyDomainMismatch,
+    /// The "company" field itself is implausible as an employer name — CTA/UI
+    /// debris (`"Apply now"`), a job board's own brand standing in for the
+    /// employer, separator/markup debris, a placeholder, or an unreasonable
+    /// shape. See [`is_implausible_company`]. Additive variant — see that
+    /// function's doc comment for why appending it here is safe for every
+    /// `TrustAssessment`/`FoundJob` record already on disk.
+    ImplausibleCompany,
 }
 
 /// URL-shortener domains — they obscure the real destination, a classic
@@ -126,15 +133,185 @@ pub fn assess_trust(url: &str, company: &str) -> TrustAssessment {
         score -= 25;
     }
 
-    if !company.trim().is_empty()
-        && !matches_domain_list(&host, ATS_ALLOWLIST)
-        && !company_matches_host(company, &host)
-    {
-        flags.push(TrustFlag::CompanyDomainMismatch);
-        score -= 15;
+    if !company.trim().is_empty() {
+        if is_implausible_company(company) {
+            // Same root cause `company_matches_host` would also fail on below
+            // (garbage text rarely matches any host), so this branch takes
+            // priority over `CompanyDomainMismatch` rather than stacking both
+            // flags for one underlying problem.
+            flags.push(TrustFlag::ImplausibleCompany);
+            score -= 20;
+        } else if !matches_domain_list(&host, ATS_ALLOWLIST)
+            && !company_matches_host(company, &host)
+        {
+            flags.push(TrustFlag::CompanyDomainMismatch);
+            score -= 15;
+        }
     }
 
     finish(score, flags)
+}
+
+/// Job-board brands that occasionally leak into the "company" field when a
+/// scraper's selector lands on the hosting board's own chrome instead of the
+/// employer (a nav link, a "Powered by" footer). Judges the COMPANY STRING
+/// itself — distinct from [`ATS_ALLOWLIST`]/[`SUSPICIOUS_DOMAINS`] above,
+/// which judge the apply URL's host. Matched WHOLE-WORD (see
+/// [`is_implausible_company`]) rather than by substring: a substring check
+/// would false-positive real employers like "Boxing Studio" (contains
+/// "xing") or "Monster Energy" (contains "monster") — the latter is a real,
+/// if unlikely, trade this list accepts explicitly, since on a scraped job
+/// board "Monster" alone is overwhelmingly the board itself.
+const JOB_BOARD_NAMES: &[&str] = &[
+    "linkedin",
+    "indeed",
+    "glassdoor",
+    "xing",
+    "stepstone",
+    "monster",
+    "ziprecruiter",
+];
+
+/// Call-to-action / UI copy a broken selector sometimes captures instead of
+/// an employer name — checked as a case-insensitive substring, since the
+/// whole "company" value is usually nothing BUT this text (`"Apply now"`) or
+/// this text concatenated with board chrome (`"Apply now | LinkedIn"`, the
+/// literal PR #960 report). None of these phrases plausibly appears as a
+/// substring inside a real employer's name.
+const CTA_PHRASES: &[&str] = &[
+    "apply now",
+    "view job",
+    "see more",
+    "easy apply",
+    "apply on ",
+];
+
+/// Literal placeholders/nulls a form default or a scraper's own fallback
+/// sometimes writes rather than leaving the field empty. Compared against
+/// the fully-trimmed, lower-cased value, never as a substring.
+const PLACEHOLDER_NAMES: &[&str] = &["n/a", "none", "unknown", "company", "unternehmen"];
+
+/// Longest legitimate employer name observed in the wild is ~48 chars
+/// ("CHECK24 Vergleichsportal für Versicherungen GmbH" — see the identical
+/// note on `sanitizeCompanyName`, this predicate's TS twin for AI-extracted
+/// metadata, `packages/prompts/src/generate/metadata/metadata.ts`). 80 gives
+/// a long-form legal name (umlauts, multiple suffixes) real headroom without
+/// accepting an obvious sentence or paragraph a broken selector scraped —
+/// the character/punctuation/board-name checks below carry most of the
+/// classification weight, this bound only catches the extreme tail.
+const MAX_COMPANY_CHARS: usize = 80;
+
+/// True when `s` contains an HTML character entity (`&amp;`, `&#39;`, …): an
+/// `&` followed, within a short run of non-whitespace characters, by a `;`.
+/// Deliberately narrower than "contains `&`" — a real name may contain a bare
+/// ampersand (`"Johnson & Johnson"`, `"AT&T"`), and neither has a `;`
+/// anywhere near it, so both survive this check untouched.
+fn has_html_entity(s: &str) -> bool {
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &c) in chars.iter().enumerate() {
+        if c != '&' {
+            continue;
+        }
+        let mut j = i + 1;
+        let mut scanned = 0;
+        while j < chars.len() && scanned < 10 {
+            let next = chars[j];
+            if next == ';' {
+                return true;
+            }
+            if next.is_whitespace() || next == '&' {
+                break;
+            }
+            j += 1;
+            scanned += 1;
+        }
+    }
+    false
+}
+
+/// Reject a "company" value that is obviously CTA/UI debris, a job board's
+/// own brand, separator/markup debris, a placeholder, or an implausible
+/// shape — rather than a real employer name. Pure, no I/O, never panics.
+///
+/// Mirrors the intent (and the conservatism) of `sanitizeCompanyName`, the
+/// existing TS gate on AI-EXTRACTED metadata
+/// (`packages/prompts/src/generate/metadata/metadata.ts`) — this is the
+/// Rust-side twin for a value that never goes through that extraction step
+/// at all: a scraper's own `company` field, ingested straight from the
+/// posting. PR #960's postmortem is the reason this exists: a scraper
+/// returned `"Apply now | LinkedIn"` as the company, and the letter
+/// faithfully addressed it — every downstream validator compares generated
+/// text against the job AD, so a garbage company that IS in the ad (because
+/// the ad's own scrape carried the same debris) passes every one of them.
+///
+/// **Deliberately conservative.** A false positive here silently drops a
+/// real company name from a cover letter — worse than the bug this predicate
+/// exists to catch — so every rule below rejects a SHAPE a real employer
+/// name cannot plausibly have, never merely an unusual one. Real names that
+/// must survive: `"Johnson & Johnson"`, `"Ben & Jerry's"`, `"Yahoo!"`,
+/// `"Booking.com"`, `"37signals"`.
+///
+/// **`"X"` (a single character) is deliberately rejected too**, even though
+/// it is the real, current legal name of the company formerly known as
+/// Twitter. A bare single character reaching this predicate is overwhelmingly
+/// scraper truncation (a stray initial, a cut-off selector), not a genuine
+/// application to X Corp — and the false-positive cost for the rare real
+/// case is soft: the letter omits the company line and names only the role,
+/// which the existing prompt contract already handles gracefully (no
+/// placeholder, no crash — see `packages/prompts/src/generate/cover-letter/
+/// cover-letter.ts`). Accepting that one narrow, low-cost trade is what lets
+/// this predicate reject single-character garbage everywhere else.
+pub fn is_implausible_company(name: &str) -> bool {
+    let trimmed = name.trim();
+    let chars: Vec<char> = trimmed.chars().collect();
+
+    if chars.is_empty() {
+        return true;
+    }
+    if chars.len() == 1 {
+        return true;
+    }
+    if chars.len() > MAX_COMPANY_CHARS {
+        return true;
+    }
+
+    // Separator / markup debris a scraper's selector miss commonly leaves
+    // behind (breadcrumbs, a "CTA | Board" concatenation, raw HTML).
+    if trimmed.contains(['|', '·', '<', '>']) {
+        return true;
+    }
+    if has_html_entity(trimmed) {
+        return true;
+    }
+
+    let alnum = chars.iter().filter(|c| c.is_alphanumeric()).count();
+    if alnum == 0 {
+        return true;
+    }
+    let non_space = chars.iter().filter(|c| !c.is_whitespace()).count();
+    // "Mostly punctuation": fewer than half the non-space characters are
+    // alphanumeric. The lightest punctuation-bearing real name above,
+    // "Ben & Jerry's", is still ~80% alphanumeric — comfortably clear of
+    // this floor.
+    if alnum * 2 < non_space {
+        return true;
+    }
+
+    let normalized = trimmed.to_lowercase();
+
+    if PLACEHOLDER_NAMES.contains(&normalized.as_str()) {
+        return true;
+    }
+
+    if CTA_PHRASES.iter().any(|p| normalized.contains(p)) {
+        return true;
+    }
+
+    // Word-boundary match, not substring — see `JOB_BOARD_NAMES`'s doc for why.
+    normalized
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .any(|w| JOB_BOARD_NAMES.contains(&w))
 }
 
 /// Compute [`assess_trust`] for `job` and attach it as `job.extra["trust"]` —

--- a/apps/desktop/src-tauri/src/scraping/trust/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/trust/mod.rs
@@ -265,9 +265,13 @@ fn has_html_entity(s: &str) -> bool {
 /// placeholder, no crash — see `packages/prompts/src/generate/cover-letter/
 /// cover-letter.ts`). Accepting that one narrow, low-cost trade is what lets
 /// this predicate reject single-character garbage everywhere else.
-pub fn is_implausible_company(name: &str) -> bool {
+pub(crate) fn is_implausible_company(name: &str) -> bool {
     let trimmed = name.trim();
-    let chars: Vec<char> = trimmed.chars().collect();
+    // Bounded: a scraped value is arbitrary-length attacker-ish input, and the
+    // only length question asked below is "> MAX_COMPANY_CHARS?", which
+    // MAX + 1 answers. Anything reaching the char-ratio checks further down has
+    // already passed that gate, so the cap is a no-op there.
+    let chars: Vec<char> = trimmed.chars().take(MAX_COMPANY_CHARS + 1).collect();
 
     if chars.is_empty() {
         return true;

--- a/apps/desktop/src-tauri/src/scraping/trust/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/trust/mod.rs
@@ -156,12 +156,17 @@ pub fn assess_trust(url: &str, company: &str) -> TrustAssessment {
 /// scraper's selector lands on the hosting board's own chrome instead of the
 /// employer (a nav link, a "Powered by" footer). Judges the COMPANY STRING
 /// itself — distinct from [`ATS_ALLOWLIST`]/[`SUSPICIOUS_DOMAINS`] above,
-/// which judge the apply URL's host. Matched WHOLE-WORD (see
-/// [`is_implausible_company`]) rather than by substring: a substring check
-/// would false-positive real employers like "Boxing Studio" (contains
-/// "xing") or "Monster Energy" (contains "monster") — the latter is a real,
-/// if unlikely, trade this list accepts explicitly, since on a scraped job
-/// board "Monster" alone is overwhelmingly the board itself.
+/// which judge the apply URL's host. Matched against the ENTIRE normalized
+/// name, not a substring or an isolated word: a bare `"LinkedIn"` is almost
+/// certainly board chrome, but real employers legitimately share a board's
+/// name as one word among several — `"Xing SE"`, `"Indeed Inc"`,
+/// `"Glassdoor Inc"`, `"Monster Worldwide"` all trade under names that
+/// contain a board word, and even a prior word-boundary version of this
+/// check (rejecting the isolated word "xing"/"indeed"/… anywhere in the
+/// name) false-positived every one of them. A false positive here silently
+/// deletes a real employer from a letter — worse than the debris this list
+/// exists to catch — so it only fires when the board name IS the entire
+/// company field, nothing more.
 const JOB_BOARD_NAMES: &[&str] = &[
     "linkedin",
     "indeed",
@@ -173,18 +178,14 @@ const JOB_BOARD_NAMES: &[&str] = &[
 ];
 
 /// Call-to-action / UI copy a broken selector sometimes captures instead of
-/// an employer name — checked as a case-insensitive substring, since the
-/// whole "company" value is usually nothing BUT this text (`"Apply now"`) or
-/// this text concatenated with board chrome (`"Apply now | LinkedIn"`, the
-/// literal PR #960 report). None of these phrases plausibly appears as a
-/// substring inside a real employer's name.
-const CTA_PHRASES: &[&str] = &[
-    "apply now",
-    "view job",
-    "see more",
-    "easy apply",
-    "apply on ",
-];
+/// an employer name, matched against the ENTIRE normalized "company" value
+/// — never as a substring. A substring check against `"apply on "`
+/// previously false-positived the real employer "Apply On Demand Inc". The
+/// board-chrome-appended shape from the literal PR #960 report
+/// (`"Apply now | LinkedIn"`) is caught by the separator rule above instead
+/// of this list, since concatenating a CTA phrase with board chrome no
+/// longer matches any single entry exactly.
+const CTA_PHRASES: &[&str] = &["apply now", "view job", "see more", "easy apply"];
 
 /// Literal placeholders/nulls a form default or a scraper's own fallback
 /// sometimes writes rather than leaving the field empty. Compared against
@@ -249,7 +250,10 @@ fn has_html_entity(s: &str) -> bool {
 /// exists to catch — so every rule below rejects a SHAPE a real employer
 /// name cannot plausibly have, never merely an unusual one. Real names that
 /// must survive: `"Johnson & Johnson"`, `"Ben & Jerry's"`, `"Yahoo!"`,
-/// `"Booking.com"`, `"37signals"`.
+/// `"Booking.com"`, `"37signals"`, and — the reason [`JOB_BOARD_NAMES`] and
+/// [`CTA_PHRASES`] are whole-string matches, not substring/word ones —
+/// `"Xing SE"`, `"Indeed Inc"`, `"Glassdoor Inc"`, `"Monster Worldwide"`,
+/// `"Apply On Demand Inc"`.
 ///
 /// **`"X"` (a single character) is deliberately rejected too**, even though
 /// it is the real, current legal name of the company formerly known as
@@ -303,15 +307,12 @@ pub fn is_implausible_company(name: &str) -> bool {
         return true;
     }
 
-    if CTA_PHRASES.iter().any(|p| normalized.contains(p)) {
+    if CTA_PHRASES.contains(&normalized.as_str()) {
         return true;
     }
 
-    // Word-boundary match, not substring — see `JOB_BOARD_NAMES`'s doc for why.
-    normalized
-        .split(|c: char| !c.is_alphanumeric())
-        .filter(|w| !w.is_empty())
-        .any(|w| JOB_BOARD_NAMES.contains(&w))
+    // Whole-string match, not substring/word — see `JOB_BOARD_NAMES`'s doc.
+    JOB_BOARD_NAMES.contains(&normalized.as_str())
 }
 
 /// Compute [`assess_trust`] for `job` and attach it as `job.extra["trust"]` —

--- a/apps/desktop/src-tauri/src/scraping/trust/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/trust/test.rs
@@ -306,6 +306,98 @@ fn company_matches_host_skips_stop_words() {
 }
 
 // ---------------------------------------------------------------------------
+// is_implausible_company — table-driven (A1 hardening plan)
+// ---------------------------------------------------------------------------
+
+/// Real-world garbage this predicate exists to catch, one row per category
+/// from the hardening plan. `"Apply now | LinkedIn"` is the literal PR #960
+/// report, kept first.
+#[test]
+fn is_implausible_company_rejects_real_world_garbage() {
+    let long_paragraph = "Acme Corp Global Holdings ".repeat(6);
+    let cases: Vec<(&str, &str)> = vec![
+        ("Apply now | LinkedIn", "the literal PR #960 report"),
+        ("Apply Now", "bare CTA debris"),
+        ("View Job", "bare CTA debris"),
+        ("See more", "bare CTA debris"),
+        ("Easy Apply", "bare CTA debris"),
+        ("Apply on Indeed", "\"apply on …\" CTA debris"),
+        ("LinkedIn", "job-board brand standing in for the employer"),
+        ("Indeed", "job-board brand standing in for the employer"),
+        ("Glassdoor", "job-board brand standing in for the employer"),
+        ("Xing", "job-board brand standing in for the employer"),
+        ("StepStone", "job-board brand standing in for the employer"),
+        ("Monster", "job-board brand standing in for the employer"),
+        (
+            "ZipRecruiter",
+            "job-board brand standing in for the employer",
+        ),
+        ("Acme <script>alert(1)</script>", "HTML/markup debris"),
+        ("Acme &amp; Co", "HTML-entity debris"),
+        ("***", "mostly/all punctuation"),
+        ("---", "mostly/all punctuation"),
+        ("", "empty"),
+        ("   ", "whitespace-only"),
+        ("n/a", "placeholder"),
+        ("N/A", "placeholder, case-insensitive"),
+        ("None", "placeholder"),
+        ("Unknown", "placeholder"),
+        ("Company", "placeholder"),
+        ("Unternehmen", "placeholder"),
+        (
+            "X",
+            "single-character shape — see the doc comment's X decision",
+        ),
+        ("A", "single-character shape"),
+        (long_paragraph.as_str(), "absurdly long"),
+    ];
+    for (input, reason) in cases {
+        assert!(
+            is_implausible_company(input),
+            "expected {input:?} to be rejected ({reason})"
+        );
+    }
+}
+
+/// Real employer names — punctuation-bearing ones especially — that must
+/// survive every rule above.
+#[test]
+fn is_implausible_company_accepts_legitimate_names_with_punctuation() {
+    let legit = [
+        "Johnson & Johnson",
+        "Ben & Jerry's",
+        "Yahoo!",
+        "Booking.com",
+        "37signals",
+        "Acme Corp",
+        "Stripe",
+        "CHECK24 Vergleichsportal für Versicherungen GmbH",
+    ];
+    for name in legit {
+        assert!(
+            !is_implausible_company(name),
+            "expected {name:?} to be accepted as a plausible employer name"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// assess_trust — implausible company (A1 hardening plan)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn implausible_company_flagged_and_penalized_instead_of_mismatch() {
+    // The host is neither allowlisted nor a match for the company, so a
+    // pre-A1 build would have flagged `CompanyDomainMismatch` (-15) here —
+    // this asserts the implausible-company branch takes priority instead
+    // (-20, exactly one flag), never both.
+    let a = assess_trust("https://boards.example/jobs/1", "Apply now | LinkedIn");
+    assert_eq!(a.score, 80);
+    assert_eq!(a.level, TrustLevel::Medium);
+    assert_eq!(a.flags, vec![TrustFlag::ImplausibleCompany]);
+}
+
+// ---------------------------------------------------------------------------
 // FoundJob wiring — exercises the REAL `build_found_job` projection (the
 // same one `autopilot_run`'s `postings.iter().map(..)` calls), not a
 // hand-retyped mirror that could silently drift (dropped field, swapped args).

--- a/apps/desktop/src-tauri/src/scraping/trust/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/trust/test.rs
@@ -321,7 +321,6 @@ fn is_implausible_company_rejects_real_world_garbage() {
         ("View Job", "bare CTA debris"),
         ("See more", "bare CTA debris"),
         ("Easy Apply", "bare CTA debris"),
-        ("Apply on Indeed", "\"apply on …\" CTA debris"),
         ("LinkedIn", "job-board brand standing in for the employer"),
         ("Indeed", "job-board brand standing in for the employer"),
         ("Glassdoor", "job-board brand standing in for the employer"),
@@ -372,6 +371,8 @@ fn is_implausible_company_accepts_legitimate_names_with_punctuation() {
         "Acme Corp",
         "Stripe",
         "CHECK24 Vergleichsportal für Versicherungen GmbH",
+        "Boxing Studio",
+        "Müller & Söhne GmbH",
     ];
     for name in legit {
         assert!(
@@ -379,6 +380,55 @@ fn is_implausible_company_accepts_legitimate_names_with_punctuation() {
             "expected {name:?} to be accepted as a plausible employer name"
         );
     }
+}
+
+/// Regression for a HIGH finding on commit ff87e93f: the pre-fix
+/// `JOB_BOARD_NAMES` (word-boundary) and `CTA_PHRASES` (substring) checks
+/// silently deleted real employers from letters, because each one either
+/// shares a board's name as one word among several or opens with the same
+/// prefix as a CTA phrase. Whole-string matching (see both consts' doc
+/// comments) fixes every one of these without reopening the PR #960 hole —
+/// see [`apply_now_pipe_linkedin_is_caught_only_by_the_separator_rule`]
+/// below for proof that report is still caught.
+#[test]
+fn is_implausible_company_accepts_real_employers_sharing_a_board_word_or_cta_prefix() {
+    let real_employers = [
+        "Monster Worldwide",
+        "Xing SE",
+        "Indeed Inc",
+        "Glassdoor Inc",
+        "Apply On Demand Inc",
+    ];
+    for name in real_employers {
+        assert!(
+            !is_implausible_company(name),
+            "expected {name:?} to be accepted as a plausible employer name"
+        );
+    }
+}
+
+/// The literal PR #960 report, isolated from the big garbage table above so
+/// the coverage is provable rather than accidental: after the whole-string
+/// fix, this input is no longer caught by `JOB_BOARD_NAMES`
+/// (`"apply now | linkedin"` != `"linkedin"`) or `CTA_PHRASES`
+/// (`"apply now | linkedin"` != `"apply now"`) — the separator rule
+/// (`trimmed.contains(['|', …])`) is the only remaining rule that fires.
+/// Mutation-tested by temporarily deleting that check (see the PR handoff
+/// for the observed red/green result).
+#[test]
+fn apply_now_pipe_linkedin_is_caught_only_by_the_separator_rule() {
+    assert!(is_implausible_company("Apply now | LinkedIn"));
+}
+
+/// Accepted trade-off, not a bug: making `CTA_PHRASES` an exact whole-string
+/// match (to stop false-positiving "Apply On Demand Inc") also means a CTA
+/// phrase concatenated with a board name — but without a separator
+/// character — no longer matches either list, so this shape now reads as
+/// plausible. Pinned here so a future reader sees the gap was a deliberate
+/// choice, not a rediscovered regression.
+#[test]
+fn cta_plus_board_name_without_a_separator_is_an_accepted_false_negative() {
+    assert!(!is_implausible_company("Apply on Indeed"));
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/renderer/lib/trust-badge.test.tsx
+++ b/apps/desktop/src/renderer/lib/trust-badge.test.tsx
@@ -73,6 +73,21 @@ describe('TrustBadge — resolved level labels', () => {
 // i18n key-drift guard — the point of this file. Every `TrustFlag` must
 // resolve through `jobs.trust.flags.${flag}` to real copy; a broken template
 // string / missing resource entry would leave the raw key visible instead.
+//
+// `FLAG_LABEL: Record<TrustFlag, string>` is deliberately a mapped-type
+// object literal, not a plain `{}` cast — TypeScript requires every member
+// of `TrustFlag` as a key (and rejects unknown ones), so a `TrustFlag`
+// member added to the shared union without a matching entry here fails
+// `pnpm typecheck`, not just this one vitest file. That's real, not
+// incidental: a PR once added `TrustFlag::ImplausibleCompany` on the Rust
+// side, forgot to touch the shared TS union, and this guard had nothing to
+// iterate — its fixture is DERIVED FROM the union, so it can only ever test
+// what the union already knows about. Once the union is current (which is a
+// still-manual step; there's no Rust→TS codegen here), this Record closes
+// the rest of the loop by refusing to compile until every member has real
+// copy. Mutation-tested: deleting one `FLAG_LABEL` entry after adding a
+// union member reproduces exactly this failure mode (`tsc` red); see the PR
+// handoff for the observed result.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const FLAG_LABEL: Record<TrustFlag, string> = {
@@ -80,6 +95,7 @@ const FLAG_LABEL: Record<TrustFlag, string> = {
   invalidUrl: 'Broken apply link',
   suspiciousDomain: 'Suspicious domain',
   companyDomainMismatch: "Domain doesn't match company",
+  implausibleCompany: 'Company name looks implausible',
 };
 
 const ALL_FLAGS = Object.keys(FLAG_LABEL) as TrustFlag[];

--- a/apps/desktop/src/renderer/lib/trust-badge.tsx
+++ b/apps/desktop/src/renderer/lib/trust-badge.tsx
@@ -4,6 +4,25 @@ import type { JobTrustAssessment } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
 import { Button, cn, HoverPopover, Tag } from '@ajh/ui';
 
+type TrustFlag = JobTrustAssessment['flags'][number];
+
+/**
+ * `TrustFlag` → the `jobs.trust.flags.*` key that actually exists. Identity
+ * today, but `Record<TrustFlag, string>` makes this exhaustive at compile
+ * time: a new `TrustFlag` member fails `pnpm typecheck` until mapped here —
+ * the exact class of drift a prior PR shipped (a backend `TrustFlag` variant
+ * reached this union with no locale entry, so `t()` rendered the raw key).
+ * Runtime-checked against the real locale resource by
+ * `trust-badge.test.tsx`'s i18n key-drift guard.
+ */
+const FLAG_KEY: Record<TrustFlag, string> = {
+  missingApplyUrl: 'missingApplyUrl',
+  invalidUrl: 'invalidUrl',
+  suspiciousDomain: 'suspiciousDomain',
+  companyDomainMismatch: 'companyDomainMismatch',
+  implausibleCompany: 'implausibleCompany',
+};
+
 /**
  * Ghost-job trust badge — flag-only, V1: renders NOTHING for `level === 'high'`
  * or a missing `trust` (no badge = trusted, keeps the common case noise-free).
@@ -43,7 +62,7 @@ export function TrustBadge({
 
   const isLow = trust.level === 'low';
   const levelLabel = t(`jobs.trust.level.${trust.level}`);
-  const reasons = trust.flags.map((flag) => t(`jobs.trust.flags.${flag}`)).join(', ');
+  const reasons = trust.flags.map((flag) => t(`jobs.trust.flags.${FLAG_KEY[flag]}`)).join(', ');
   // What the LEVEL means, in plain language. The flag list alone answers "which
   // checks failed" but never "so what?" — "Suspicious domain" doesn't tell a
   // reader whether to skip the posting or just look twice.

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -74,7 +74,13 @@ export interface DocumentRecord {
 export interface JobTrustAssessment {
   score: number;
   level: 'high' | 'medium' | 'low';
-  flags: Array<'missingApplyUrl' | 'invalidUrl' | 'suspiciousDomain' | 'companyDomainMismatch'>;
+  flags: Array<
+    | 'missingApplyUrl'
+    | 'invalidUrl'
+    | 'suspiciousDomain'
+    | 'companyDomainMismatch'
+    | 'implausibleCompany'
+  >;
 }
 
 export interface JobPosting {

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2425,7 +2425,8 @@
         "missingApplyUrl": "Kein Bewerbungslink",
         "invalidUrl": "Bewerbungslink fehlerhaft",
         "suspiciousDomain": "Verdächtige Domain",
-        "companyDomainMismatch": "Domain stimmt nicht mit Unternehmen überein"
+        "companyDomainMismatch": "Domain stimmt nicht mit Unternehmen überein",
+        "implausibleCompany": "Firmenname wirkt unplausibel"
       },
       "levelDesc": {
         "medium": "Einige Angaben dieser Anzeige konnten nicht überprüft werden. Sie kann trotzdem echt sein — vor der Bewerbung genauer ansehen.",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2421,7 +2421,8 @@
         "missingApplyUrl": "Missing apply link",
         "invalidUrl": "Broken apply link",
         "suspiciousDomain": "Suspicious domain",
-        "companyDomainMismatch": "Domain doesn't match company"
+        "companyDomainMismatch": "Domain doesn't match company",
+        "implausibleCompany": "Company name looks implausible"
       },
       "levelDesc": {
         "medium": "Some details of this posting could not be verified. It may still be genuine — worth a second look before applying.",


### PR DESCRIPTION
Closes A1 from the hardening plan — the root cause behind #960, where six generated cover letters carried garbage company names because the scraper returned things like `"Apply now | LinkedIn"` as the employer.

## Why nothing caught it

Every existing guard passed, and correctly. `validate/content/factual.rs` checks generated text **against the job ad**, so faithfully reproducing a garbage company is not a factual error. The hole was upstream of every validator: nothing ever asked whether the ingested posting was sane.

## The fix

`is_implausible_company` + `TrustFlag::ImplausibleCompany` in `scraping::trust`. That module's contract is *"V1 is flag-only: enrich, never drop"*, so it gains signal and blocks nothing.

Acting on it happens at two real boundaries rather than by blocking:

- `commands/resume_pipeline` blanks an implausible company before it can seed company research or the persisted record
- `export/commands::generate_filename` falls back to the same default an absent name already gets

Passing `None` rather than garbage lets the **existing** prompt contract take over — it already says to name only the role when no company is provided — so no prompt text changed.

## A correction to the premise

The task was scoped from #960's postmortem, which describes a letter addressed to the garbage company. **That symptom no longer exists.** Since #997, `complete_letter_text` always inserts a generic salutation regardless of company, so the addressee line is already safe (verified in `export/letter_shape.rs`).

What still leaked is subtler: the garbage company **seeds the company-research web search**, so the "why this company" paragraph is researched against nonsense, and it **persists into the exported record and filename**. Those are the boundaries guarded here. A postmortem describes the bug when it was found, not the code today.

## What review changed

The first pass shipped the failure mode that matters more than the bug — **it rejected real employers**. Confirmed by executing the predicate:

| | before review | after |
| --- | --- | --- |
| `Monster Worldwide` | rejected | accepted |
| `Xing SE` | rejected | accepted |
| `Indeed Inc` | rejected | accepted |
| `Glassdoor Inc` | rejected | accepted |
| `Apply On Demand Inc` | rejected | accepted |
| `LinkedIn` | rejected | rejected |
| `Apply now` | rejected | rejected |
| `Apply now \| LinkedIn` | rejected | rejected |

All five are real companies that hire directly and post under their own names. A false positive silently deletes a real employer from a user's letter, which is worse than the original defect.

Both offending rules matched too loosely: `JOB_BOARD_NAMES` rejected any name *containing* a board token as a word, and `CTA_PHRASES` substring-matched. Both now match only when the **entire normalized name is** the board name or CTA phrase. The originally-reported string is still rejected — by the separator rule, not by either loosened list — and a test pins that so the coverage cannot be accidental. `"Apply on Indeed"` becomes an accepted false negative, pinned as a deliberate choice rather than left to be rediscovered.

## A guard that was blind by construction

The new enum variant serialises as `implausibleCompany`, but the hand-maintained TS union and both locale files still listed four flags, while `TrustBadge` calls `t(...)` unconditionally. The badge would have rendered the literal key `jobs.trust.flags.implausibleCompany` — in both languages, on exactly the postings this branch exists to fix.

The repo's purpose-built *"i18n key-drift guard"* test stayed green through all of it, because its fixture list derives from the same stale union it is meant to guard. A guard sourced from the thing it guards is not a guard.

Fixed structurally rather than by adding a case: an exhaustive `Record<TrustFlag, string>` now lives in **production** code, so a future missing variant fails `pnpm typecheck` for the whole app, not one test file. Mutation-checked in both directions.

## Known, deliberate

A bare single character is rejected, which rejects the real company `X`. At that length truncation overwhelmingly dominates, and the cost of being wrong is soft — the letter names the role instead. Flagging it rather than burying it.

`commands/resume_pipeline/mod.rs` sits at 1398/1400 LOC (R8 hard cap). Not a violation; anything further there needs code moved out first.

## Verification

`cargo test --lib` 4092/0 · `cargo test --test architecture` 18/18 · clippy `-D warnings` clean · fmt clean · `pnpm typecheck` 13/13 · `pnpm test` 478 files / 6899 tests.

Every guard mutation-checked — broken, confirmed red, restored, confirmed green — including independently by me rather than only by the authoring agent. Neutering the predicate kills four tests across three layers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for implausible company names in job postings.
  - Added a trust-badge explanation for suspicious company names, with English and German translations.
  - Added safeguards to prevent invalid company names from appearing in research results or generated filenames.

- **Bug Fixes**
  - Improved handling of job postings containing placeholder, promotional, or job-board text instead of a company name.
  - Preserved valid company names and other job details during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->