### PR TITLE
refactor(platform): own the test data-dir override where the rule says it belongs

### DIFF
--- a/apps/desktop/src-tauri/src/platform/config.rs
+++ b/apps/desktop/src-tauri/src/platform/config.rs
@@ -94,6 +94,43 @@ pub fn env_override(key: &str) -> Option<String> {
     std::env::var(key).ok()
 }
 
+/// Test-only RAII scope for the data dir, so a test needing an isolated one
+/// does not have to touch `AJH_DATA_DIR` itself.
+///
+/// This module's own doc calls it the **sole owner** of that variable, and R4
+/// enforces it — but R4's test exempts test files, so the rule was enforceable
+/// everywhere except the place a test would actually reach for it. This closes
+/// that gap: a caller names a directory, never the variable.
+///
+/// Restores on `Drop` rather than at the end of the test body, so a panicking
+/// or early-returning assertion cannot leak the override into whatever runs
+/// next. Callers still need `#[serial]` — the variable is process-global, and
+/// a guard cannot serialize what it cannot see.
+#[cfg(test)]
+pub(crate) struct DataDirGuard(Option<std::ffi::OsString>);
+
+#[cfg(test)]
+impl DataDirGuard {
+    /// Point `data_dir()` at `path` until the guard drops.
+    pub(crate) fn set(path: &std::path::Path) -> Self {
+        let previous = std::env::var_os(DATA_DIR_ENV);
+        // SAFETY: test-only, and callers hold `#[serial]`.
+        unsafe { std::env::set_var(DATA_DIR_ENV, path) };
+        Self(previous)
+    }
+}
+
+#[cfg(test)]
+impl Drop for DataDirGuard {
+    fn drop(&mut self) {
+        // SAFETY: as above — restoring exactly what was read in `set`.
+        match self.0.take() {
+            Some(previous) => unsafe { std::env::set_var(DATA_DIR_ENV, previous) },
+            None => unsafe { std::env::remove_var(DATA_DIR_ENV) },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -101,7 +138,12 @@ mod tests {
     // Env-var override and default are exercised in a single test: `AJH_DATA_DIR`
     // is process-global, so splitting them into parallel tests races (one's
     // remove_var can land between the other's set_var and read).
+    // `#[serial]` because this mutates the process-global var directly (it is
+    // testing the resolver itself, so it cannot go through `DataDirGuard`).
+    // Without it, it races any other `#[serial]` mutator — which was a real
+    // gap once a second test elsewhere began scoping the same variable.
     #[test]
+    #[serial_test::serial]
     fn data_dir_honors_env_then_falls_back() {
         // Override via env var.
         unsafe {

--- a/apps/desktop/src-tauri/src/profile_import/linkedin_ssrf_test.rs
+++ b/apps/desktop/src-tauri/src/profile_import/linkedin_ssrf_test.rs
@@ -5,7 +5,7 @@
 //! Why the split: `fetch_page` calls `has_linkedin_session()` before the
 //! guarded request, which resolves `platform::config::data_dir()` and reads
 //! a real cookie file from disk (diagnostic only — the result never affects
-//! the outcome, but the read itself touches host state unless `AJH_DATA_DIR`
+//! the outcome, but the read itself touches host state unless the data dir
 //! is pointed at a scratch directory for the test's duration). R4
 //! (`tests/architecture.rs::r4_env_access_only_in_platform`) bans that env
 //! var's literal name from any non-`platform/**` source that ISN'T itself a
@@ -32,24 +32,16 @@ use super::*;
 #[tokio::test]
 #[serial_test::serial]
 async fn fetch_page_never_dials_the_loopback_literal_it_rejects() {
-    // Scope AJH_DATA_DIR to an empty temp dir so has_linkedin_session()'s
-    // real-disk read never touches the developer's or CI runner's actual
-    // data dir. `#[serial]` is this crate's established idiom for an
-    // env-mutating test (see platform/chrome/test.rs,
-    // email_watch_scheduler.rs): it prevents racing any OTHER
-    // `#[serial]`-tagged mutator of the same var. It does NOT fully protect
-    // against platform/config.rs's own `data_dir_honors_env_then_falls_back`,
-    // which mutates this same var without `#[serial]` (a pre-existing gap in
-    // that file, outside this file's scope) — harmless here regardless,
-    // since `load_cookies` never panics on a bad/foreign path and this test's
-    // assertions never depend on `has_linkedin_session`'s return value.
+    // Scope the data dir to an empty temp dir so has_linkedin_session()'s
+    // real-disk read never touches the developer's or CI runner's actual data
+    // dir. The guard lives in platform/config.rs because that module is the
+    // sole owner of that env var — this file never names it, which
+    // is what R4 is actually asking for. It restores on drop, so a panicking
+    // assertion below cannot leak the override into the next test.
+    // `#[serial]` is still required: the variable is process-global and the
+    // resolver's own test mutates it directly.
     let tmp = tempfile::TempDir::new().expect("create temp data dir");
-    let previous = std::env::var_os("AJH_DATA_DIR");
-    // SAFETY: test-only; #[serial]-scoped; restored below before any
-    // assertion can early-return past it.
-    unsafe {
-        std::env::set_var("AJH_DATA_DIR", tmp.path());
-    }
+    let _data_dir = crate::platform::config::DataDirGuard::set(tmp.path());
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
     listener
@@ -58,14 +50,6 @@ async fn fetch_page_never_dials_the_loopback_literal_it_rejects() {
     let port = listener.local_addr().unwrap().port();
 
     let result = fetch_page(&format!("http://127.0.0.1:{port}/in/x")).await;
-
-    // SAFETY: test-only; restores the pre-test value.
-    unsafe {
-        match &previous {
-            Some(v) => std::env::set_var("AJH_DATA_DIR", v),
-            None => std::env::remove_var("AJH_DATA_DIR"),
-        }
-    }
 
     let err = result.unwrap_err();
     assert!(matches!(err, AppError::Network(_)), "got {err:?}");


### PR DESCRIPTION
Follow-up to #1005 — one commit that missed the merge. The Stop-gate arch guard flags `std::env::var` in `linkedin_ssrf_test.rs`, which is live on `main` right now.

## The disagreement

Two guards enforce R4 and they disagree about the same file:

- `tests/architecture.rs::r4_env_access_only_in_platform` filters `!f.is_test`, so a file named `*_test.rs` is **exempt** — which is why `cargo test --test architecture` passes 18/18.
- The Stop-gate ast-grep matcher has no such exemption, so it blocks.

The gate is right in spirit. `platform/config.rs`'s own module doc says it is *"the **sole owner** of the application data-directory env var"* and that *"no other module may read"* it — so the rule was enforceable everywhere except the one place a test would actually reach for the variable.

## The fix

Rather than argue the exemption or add an allowlist entry, the override moved to where the rule points. `platform::config::DataDirGuard` is a test-only RAII scope: a caller names a **directory**, never the variable. The test file now contains no env access and does not name the variable in prose either, so both matchers are satisfied for the right reason.

Two things it improves beyond silencing the gate:

- **Restores on `Drop`**, not at the end of the test body. The previous inline version restored after the `await` but before the assertions — a panicking assertion would have leaked the override into whatever ran next.
- **`#[serial]` added to `data_dir_honors_env_then_falls_back`.** It mutates the same process-global variable directly with no serialization, so it could race the new test. Pre-existing, but only became reachable once a second test started scoping that variable.

## Verification

`cargo fmt --check` · `cargo clippy --all-targets --all-features --locked -- -D warnings` · `cargo test --all-features --locked` → **4169 lib + 18 architecture + 20 egress + 3 eval**, 0 failed. `grep -c "std::env"` on the test file: **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)