### PR TITLE
fix(locale): give Spain, Portugal and Brazil the profiles they were already promised

### DIFF
--- a/apps/desktop/src-tauri/src/locale/mod.rs
+++ b/apps/desktop/src-tauri/src/locale/mod.rs
@@ -234,7 +234,7 @@ impl LocaleProfile {
     ///
     /// Every field here numerically matches [`Self::eu()`] — Italy has no
     /// distinct paper size or photo convention beyond the generic-EU/Europass
-    /// baseline, and `locale::resume::IT_ORDER`'s doc comment independently
+    /// baseline, and `locale::resume::EUROPASS_ORDER`'s doc comment independently
     /// grounds the Italian CV in the same Europass reference format that
     /// justifies `eu()`'s 3-page tolerance (German-style itemised history
     /// rather than a US-style 2-page summary).
@@ -243,14 +243,25 @@ impl LocaleProfile {
     /// because the **id** must stay distinct: `recommend::pick_locale`
     /// forwards this id verbatim as the export `market` string, and
     /// `locale::resume::section_order_for` matches the literal `"it"` to
-    /// select `IT_ORDER`. Aliasing to `eu()` (id `"eu"`) would resolve the
+    /// select `EUROPASS_ORDER`. Aliasing to `eu()` (id `"eu"`) would resolve the
     /// page/photo conventions correctly but silently hand an Italian user the
     /// DEFAULT section order again — the exact bug this profile exists to fix.
+    pub fn it() -> LocaleProfile {
+        LocaleProfile {
+            id: "it",
+            page_size: PageSize::A4,
+            photo: PhotoPolicy::Optional,
+            max_pages: 3,
+        }
+    }
+
     /// Spain. A4 + photo, like the other southern-European markets, but capped
     /// at **2 pages**, not Italy's 3 — Spanish CV guidance is consistently
-    /// "máximo dos páginas", and the app's page cap is advice the export
-    /// actually enforces, so inheriting Italy's 3 would quietly license a
-    /// longer document than the market expects.
+    /// "máximo dos páginas". [`Self::max_pages`] is advisory (it decides when
+    /// the trim panel OFFERS suggestions; nothing blocks a longer export), so
+    /// inheriting Italy's 3 would not break anything — it would simply stop
+    /// the app from ever suggesting a trim to a Spanish user whose CV has run
+    /// a page past what the market expects.
     ///
     /// Its own constructor rather than an alias, for the reason Italy's is:
     /// `recommend::pick_locale` forwards this `id` verbatim and
@@ -293,15 +304,6 @@ impl LocaleProfile {
             page_size: PageSize::A4,
             photo: PhotoPolicy::Never,
             max_pages: 2,
-        }
-    }
-
-    pub fn it() -> LocaleProfile {
-        LocaleProfile {
-            id: "it",
-            page_size: PageSize::A4,
-            photo: PhotoPolicy::Optional,
-            max_pages: 3,
         }
     }
 }
@@ -449,7 +451,7 @@ mod tests {
     /// fell through to `intl()` (id "en", photo Never, 2 pages), which made
     /// `recommend::pick_locale` forward "en" downstream — the id
     /// `locale::resume::section_order_for` reads to select a market's section
-    /// order — so an Italian user's already-committed `IT_ORDER` was
+    /// order — so an Italian user's already-committed `EUROPASS_ORDER` was
     /// unreachable on the auto-recommendation path.
     #[test]
     fn italy_resolves_to_a_dedicated_profile_not_the_english_default() {

--- a/apps/desktop/src-tauri/src/locale/mod.rs
+++ b/apps/desktop/src-tauri/src/locale/mod.rs
@@ -110,6 +110,9 @@ impl LocaleProfile {
             "nl" => Self::nl(),
             "eu" => Self::eu(),
             "it" => Self::it(),
+            "es" => Self::es(),
+            "pt" => Self::pt(),
+            "br" => Self::br(),
             _ => Self::intl(),
         }
     }
@@ -118,7 +121,19 @@ impl LocaleProfile {
     fn is_known_region(token: &str) -> bool {
         matches!(
             token,
-            "us" | "uk" | "gb" | "de" | "at" | "ch" | "fr" | "nl" | "eu" | "dach" | "it"
+            "us" | "uk"
+                | "gb"
+                | "de"
+                | "at"
+                | "ch"
+                | "fr"
+                | "nl"
+                | "eu"
+                | "dach"
+                | "it"
+                | "es"
+                | "pt"
+                | "br"
         )
     }
 
@@ -132,6 +147,9 @@ impl LocaleProfile {
             Self::nl(),
             Self::eu(),
             Self::it(),
+            Self::es(),
+            Self::pt(),
+            Self::br(),
             Self::intl(),
         ]
     }
@@ -228,6 +246,56 @@ impl LocaleProfile {
     /// select `IT_ORDER`. Aliasing to `eu()` (id `"eu"`) would resolve the
     /// page/photo conventions correctly but silently hand an Italian user the
     /// DEFAULT section order again — the exact bug this profile exists to fix.
+    /// Spain. A4 + photo, like the other southern-European markets, but capped
+    /// at **2 pages**, not Italy's 3 — Spanish CV guidance is consistently
+    /// "máximo dos páginas", and the app's page cap is advice the export
+    /// actually enforces, so inheriting Italy's 3 would quietly license a
+    /// longer document than the market expects.
+    ///
+    /// Its own constructor rather than an alias, for the reason Italy's is:
+    /// `recommend::pick_locale` forwards this `id` verbatim and
+    /// `locale::resume::section_order_for` matches the literal string, so
+    /// aliasing to `eu()` would hand back the id `"eu"` and silently restore
+    /// the US section order.
+    pub fn es() -> LocaleProfile {
+        LocaleProfile {
+            id: "es",
+            page_size: PageSize::A4,
+            photo: PhotoPolicy::Optional,
+            max_pages: 2,
+        }
+    }
+
+    /// Portugal. Same shape as [`Self::es`] — A4, photo optional, 2 pages.
+    pub fn pt() -> LocaleProfile {
+        LocaleProfile {
+            id: "pt",
+            page_size: PageSize::A4,
+            photo: PhotoPolicy::Optional,
+            max_pages: 2,
+        }
+    }
+
+    /// Brazil — a separate market id in the TS `COUNTRY_TO_MARKET` table
+    /// (`BR: 'br'`, not `'pt'`), so it needs its own profile or it falls
+    /// through to the US-shaped default the way Spain and Portugal did.
+    ///
+    /// **Reviewable call, and the one place it deliberately differs from
+    /// [`Self::pt`]: `photo: Never`.** Brazilian hiring guidance has moved
+    /// against photos on CVs on anti-discrimination grounds, unlike Portugal
+    /// where they remain unremarkable. Same language, same section order,
+    /// different norm — which is exactly why it is a distinct profile rather
+    /// than an alias. If a Brazilian reviewer disagrees, this is a one-line
+    /// change.
+    pub fn br() -> LocaleProfile {
+        LocaleProfile {
+            id: "br",
+            page_size: PageSize::A4,
+            photo: PhotoPolicy::Never,
+            max_pages: 2,
+        }
+    }
+
     pub fn it() -> LocaleProfile {
         LocaleProfile {
             id: "it",
@@ -327,10 +395,25 @@ mod tests {
     #[test]
     fn all_markets_are_distinct_and_present() {
         let all = LocaleProfile::all();
-        assert_eq!(all.len(), 8);
         let ids: std::collections::HashSet<&str> = all.iter().map(|p| p.id).collect();
-        for id in ["us", "uk", "dach", "fr", "nl", "eu", "it", "en"] {
-            assert!(ids.contains(id), "missing market {id}");
+        assert_eq!(ids.len(), all.len(), "two profiles share an id: {ids:?}");
+
+        // The property, rather than a restated list: every profile `all()`
+        // advertises must resolve back to ITSELF through `get`. That is the
+        // contract the rest of the app depends on — `recommend::pick_locale`
+        // forwards a profile's `id` verbatim and downstream code calls `get`
+        // on it — and it is exactly what a missing `get` arm breaks, silently
+        // and with every hardcoded-list test still green. Spain, Portugal and
+        // Brazil each shipped that way until this test stopped naming names.
+        for profile in &all {
+            assert_eq!(
+                LocaleProfile::get(profile.id).id,
+                profile.id,
+                "market {:?} is offered by `all()` but does not round-trip through \
+                 `get` — it falls back to the international default, taking the \
+                 US section order with it",
+                profile.id
+            );
         }
     }
 

--- a/apps/desktop/src-tauri/src/locale/resume.rs
+++ b/apps/desktop/src-tauri/src/locale/resume.rs
@@ -58,29 +58,37 @@ const DE_ORDER: &[SectionId] = &[
     SectionId::Publications,
 ];
 
-/// Italian CV order. Like the German Lebenslauf, `Istruzione e formazione`
-/// (Education) and any `Certificazioni` sit right after `Esperienza
-/// professionale` — Italian hiring reads a titled qualification as core
+/// Southern-European / Europass CV order — Italy, Spain, Portugal, Brazil.
+/// Like the German Lebenslauf, Education and any Certifications sit right
+/// after Experience: these markets read a titled qualification as core
 /// structure, not something to bury under Skills/Projects the way the US
 /// default does.
 ///
+/// **Why these four and not every non-US market:** they are exactly the
+/// markets whose section HEADINGS are already curated in `resume_conventions`
+/// (`de en es fr it nl pt`, minus the ones with their own order). A market
+/// with no curated headings gets English headings, and giving it a
+/// non-English section ORDER would be half a localization — worse than none,
+/// because the document then matches no market's expectations. So the order
+/// axis deliberately tracks the heading axis.
+///
 /// **Reviewable call, not a copy of [`DE_ORDER`]:** Languages runs BEFORE
 /// Skills here — the one position this order deliberately does NOT mirror
-/// the German one. Italy's Europass CV, still the reference format most
-/// Italian hirers recognise, nests "Lingue straniere" (foreign-language
-/// competence) as the FIRST subsection of "Competenze personali", ahead of
-/// any general or digital-skills subsection — the opposite of the German
-/// convention, where a language table is usually the LAST thing in the
-/// skills block. If a native reviewer disagrees, swapping these two back to
-/// the German order is a one-line change, not a rethink of the rest of the
-/// list.
+/// the German one. The Europass CV, still the reference format these markets
+/// recognise, nests foreign-language competence ("Lingue straniere",
+/// "Idiomas", "Línguas") as the FIRST subsection of personal competences,
+/// ahead of any general or digital-skills subsection — the opposite of the
+/// German convention, where a language table is usually the LAST thing in
+/// the skills block. If a native reviewer disagrees, swapping these two back
+/// to the German order is a one-line change, not a rethink of the rest of
+/// the list.
 ///
 /// Projects and the Awards/Publications tail stay last, same reasoning as
 /// every market in this file: neither is a section a traditional Italian CV
 /// has by default, so an application with real content for them still gets
 /// a heading, just not one that crowds out Experience/Education/
 /// Certifications/Languages/Skills for it.
-const IT_ORDER: &[SectionId] = &[
+const EUROPASS_ORDER: &[SectionId] = &[
     SectionId::Summary,
     SectionId::Experience,
     SectionId::Education,
@@ -109,7 +117,10 @@ pub fn section_order_for(market: &str) -> &'static [SectionId] {
         // No alias to accept here — see the module doc comment: unlike
         // Germany, Italy has only one live market-id spelling ("it") on
         // every namespace that actually reaches this function.
-        "it" => IT_ORDER,
+        // Spain, Portugal and Brazil share Italy's shape here; they differ
+        // from each other on page count and photo policy, which is
+        // `LocaleProfile`'s axis, not this one.
+        "it" | "es" | "pt" | "br" => EUROPASS_ORDER,
         _ => DEFAULT_ORDER,
     }
 }
@@ -166,7 +177,7 @@ mod tests {
         // "right AFTER Experience" is half this test's name and was the half
         // it did not assert: every other assertion here is `… < Skills`, so
         // an order burying Experience below Education — the exact opposite of
-        // what `IT_ORDER`'s own doc claims — stayed green.
+        // what `EUROPASS_ORDER`'s own doc claims — stayed green.
         assert!(
             position(order, &SectionId::Experience) < position(order, &SectionId::Education),
             "Experience must lead the Italian order; Education follows it, \
@@ -189,6 +200,34 @@ mod tests {
         );
     }
 
+    /// Spain, Portugal and Brazil share Italy's Europass shape. They shipped
+    /// resolving to the US-shaped default instead: the TS `COUNTRY_TO_MARKET`
+    /// and `LANGUAGE_TO_MARKET` tables have emitted `es`/`pt`/`br` since
+    /// before Italy was fixed, and nothing on the Rust side had an arm for
+    /// them, so a Spanish CV got Spanish HEADINGS in American ORDER.
+    ///
+    /// Asserted against `DEFAULT_ORDER` as well as the positive case, because
+    /// the positive assertion alone would pass if every market were quietly
+    /// pointed at one shared list.
+    ///
+    /// Mutation check: removed `"es" | "pt" | "br"` from the arm — RAN, went
+    /// red on all three, restored.
+    #[test]
+    fn iberian_and_lusophone_markets_resolve_to_the_europass_order() {
+        for market in ["es", "ES", "  pt  ", "br"] {
+            assert_eq!(
+                section_order_for(market),
+                EUROPASS_ORDER,
+                "market {market:?} must resolve to the Europass order"
+            );
+            assert_ne!(
+                section_order_for(market),
+                DEFAULT_ORDER,
+                "market {market:?} must not silently fall back to the US-shaped default"
+            );
+        }
+    }
+
     /// Mirrors `german_market_aliases_all_resolve_to_the_de_order`: Italy has
     /// only ONE live spelling to accept (see the module doc comment), but the
     /// case/whitespace handling still needs covering, and the market must
@@ -198,7 +237,7 @@ mod tests {
         for market in ["it", "IT", "  it  "] {
             assert_eq!(
                 section_order_for(market),
-                IT_ORDER,
+                EUROPASS_ORDER,
                 "market {market:?} must resolve to the Italian order"
             );
         }

--- a/apps/desktop/src-tauri/src/pipeline/resume/test.rs
+++ b/apps/desktop/src-tauri/src/pipeline/resume/test.rs
@@ -1814,7 +1814,7 @@ fn no_localized_heading_lands_in_another_sections_bucket() {
 /// `section_order_for` emits and asserts every curated locale has a real
 /// entry for each.
 ///
-/// Mutation check: added `SectionId::Volunteer` to `IT_ORDER` — RAN, went red
+/// Mutation check: added `SectionId::Volunteer` to `EUROPASS_ORDER` (then `IT_ORDER`) — RAN, went red
 /// (`cargo test` and `pnpm gen:prompts:check` both stayed green, which is the
 /// whole point), reverted.
 #[test]

--- a/apps/desktop/src-tauri/src/recommend/mod.rs
+++ b/apps/desktop/src-tauri/src/recommend/mod.rs
@@ -327,6 +327,8 @@ fn pick_locale(signals: &RecommendSignals) -> String {
         "fr" => "fr",
         "nl" => "nl",
         "it" => "it",
+        "es" => "es",
+        "pt" => "pt",
         _ => "en",
     }
     .to_string()

--- a/apps/desktop/src-tauri/src/recommend/tests.rs
+++ b/apps/desktop/src-tauri/src/recommend/tests.rs
@@ -168,11 +168,39 @@ fn locale_defaults_to_international_english() {
     assert_eq!(r.locale, "en");
 }
 
+/// The same gap for Spain and Portugal, closed one release after Italy's.
+///
+/// Both were already live market ids on the TS side (`COUNTRY_TO_MARKET` maps
+/// `ES`/`PT`, `LANGUAGE_TO_MARKET` maps `es`/`pt`) and both fell through
+/// `match lang` to `"en"`, so a Spanish job ad produced Spanish HEADINGS —
+/// `resume_conventions` has curated es/pt entries — in the US section ORDER,
+/// with `photo: Never` and no Europass page budget. Half a localization,
+/// which reads worse than none.
+///
+/// Asserted `!= "en"` as well as the exact id: the equality alone would pass
+/// if the international default were ever renamed to "es".
+///
+/// Mutation check: removed the `"es"`/`"pt"` arms from `pick_locale` — RAN,
+/// went red on both, restored.
+#[test]
+fn locale_follows_iberian_job_ad_language() {
+    for (lang, want) in [("es", "es"), ("pt", "pt")] {
+        let mut s = signals("Desarrollador de Software", "mid", &["Java"]);
+        s.job_ad_language = Some(lang.to_string());
+        let r = recommend(&s);
+        assert_eq!(r.locale, want, "{lang} must resolve to its own market");
+        assert_ne!(
+            r.locale, "en",
+            "{lang} must not fall through to the international default"
+        );
+    }
+}
+
 /// The Italy gap this arm closes: before it, an Italian job ad's language
 /// fell through the `match lang` default and resolved to "en" — the same id
 /// as the international default — so an Italian job never reached the
 /// dedicated `LocaleProfile::it()` (A4 / photo optional / 3-page budget) or,
-/// downstream, `locale::resume::IT_ORDER`.
+/// downstream, `locale::resume::EUROPASS_ORDER`.
 #[test]
 fn locale_follows_italian_job_ad_language() {
     let mut s = signals("Sviluppatore Software", "mid", &["Java"]);


### PR DESCRIPTION
Follow-up to #1007, which fixed Italy and explicitly deferred the identical gap
for Spain and Portugal. This closes it, and Brazil with it.

## The gap

All three were already live market ids **on the TS side** — `COUNTRY_TO_MARKET`
maps `ES`/`PT`/`BR`, `LANGUAGE_TO_MARKET` maps `es`/`pt` — and the Rust side had
an arm for none of them, so `LocaleProfile::get` dropped them to the
international default and `pick_locale` returned `"en"`.

The visible result was **half a localization**. `resume_conventions` already has
curated `es`/`pt` entries, so the model wrote "Experiencia profesional" and
"Formação" — and then arranged them in the American order, with `photo: Never`
and the 2-page Anglophone budget. A half-localized document reads worse than an
unlocalized one, because it matches no market's expectations at all.

## What changed

`IT_ORDER` becomes `EUROPASS_ORDER` and now serves all four markets. That is
what it always was: its own doc justified the order by pointing at Europass, not
at anything specifically Italian.

**Scope is principled, not arbitrary.** These are exactly the markets whose
section *headings* are already curated. `tr`, `ru`, `cn`, `jp` and `kr` are live
TS ids too, and they are deliberately left alone: they get English headings, so
giving them a non-English section *order* would manufacture the very
half-localized document this PR is fixing. The order axis tracks the heading
axis on purpose.

## Two per-market calls, flagged rather than asserted

- **Spain and Portugal cap at 2 pages, not Italy's 3.** Spanish guidance is
  consistently "máximo dos páginas", and this cap is advice the trim panel acts
  on, so inheriting Italy's 3 would license a longer document than the market
  expects.
- **Brazil gets `photo: Never` where Portugal gets `Optional`.** Brazilian
  hiring guidance has moved against CV photos on anti-discrimination grounds.
  Same language, same section order, different norm — which is exactly why it is
  a distinct profile rather than a `pt` alias. Both are one-line changes if a
  native reviewer disagrees.

## The test that should have caught this

`all_markets_are_distinct_and_present` asserted a hardcoded count and id list, so
it passed throughout — it could not fail for a market it did not name. It now
asserts the property instead: **every profile `all()` advertises must round-trip
through `get()` back to itself.** That is the contract the rest of the app
depends on, since `pick_locale` forwards a profile's `id` verbatim and downstream
code calls `get` on it.

Mutation-checked by deleting the `"es"` arm — the exact shape of the bug that
shipped. The new test goes red; the old one stayed green under the same mutation.

## Verification

`cargo test --all-features --locked`: 4206 lib + 18 architecture + 20 egress + 3
eval. clippy `--all-features --all-targets` clean, `cargo fmt --check` clean,
typecheck 13/13, `lint:strict --max-warnings 0` clean, `check:agent-system` and
`check-landing-drift` green.

Four mutations run, each green at baseline and red with the feature deleted:
dropping `es|pt|br` from the order arm, dropping the `"es"` `get()` arm, giving
two profiles the same id, and dropping the `es`/`pt` `pick_locale` arms.

## Not in scope

`SectionId::from_header` remains English-only — unchanged from #1007, where the
reasoning is recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Spanish, Portuguese, and Brazilian locale profiles.
  * Added localized resume formatting and language detection for Spain and Portugal.
  * Added region-specific page, photo, and resume layout settings.

* **Bug Fixes**
  * Improved locale selection for Spanish and Portuguese job advertisements.

* **Tests**
  * Added coverage for locale resolution, normalization, and regional resume formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->