### PR TITLE
ci: enforce the Rust toolchain pin instead of asking for it in a comment

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -15,6 +15,8 @@ runs:
       # dtolnay/rust-toolchain doesn't read toolchain files — the @rev IS the
       # version selector (this SHA is the repo's own "1.97.1" branch) — so
       # bump this alongside that file, never independently.
+      # `pnpm check:toolchain-pin` enforces that; the trailing "# <version>"
+      # comment below is what it compares, so keep it accurate.
       uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
       with:
         components: ${{ inputs.components }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -307,10 +307,22 @@ jobs:
           pnpm check:tech-radar
           echo "::endgroup::"
 
-      - name: ❌ Check for Failures
-        if: steps.eslint.outcome == 'failure' || steps.format.outcome == 'failure' || steps.gen_ipc.outcome == 'failure' || steps.gen_prompts.outcome == 'failure' || steps.landing_drift.outcome == 'failure' || steps.agent_system.outcome == 'failure' || steps.tech_radar.outcome == 'failure'
+      # The Rust toolchain pin lives in TWO places that cannot reference each
+      # other: rust-toolchain.toml (rustup, local dev) and the
+      # dtolnay/rust-toolchain @sha in .github (CI). Bumping one without the
+      # other silently un-pins the build without ever going red on its own.
+      - name: 🦀 Check Rust Toolchain Pin Drift
+        id: toolchain_pin
+        continue-on-error: true
         run: |
-          echo "::error file=package.json::Lint, format, IPC codegen, prompts codegen, landing-diagram, agent-system, or tech-radar drift check failed. Run 'pnpm lint:fix', 'pnpm format', 'pnpm gen:ipc', 'pnpm gen:prompts', 'pnpm check:landing-drift', 'pnpm check:agent-system', and 'pnpm check:tech-radar' locally to fix."
+          echo "::group::Checking Rust toolchain pin drift"
+          pnpm check:toolchain-pin
+          echo "::endgroup::"
+
+      - name: ❌ Check for Failures
+        if: steps.eslint.outcome == 'failure' || steps.format.outcome == 'failure' || steps.gen_ipc.outcome == 'failure' || steps.gen_prompts.outcome == 'failure' || steps.landing_drift.outcome == 'failure' || steps.agent_system.outcome == 'failure' || steps.tech_radar.outcome == 'failure' || steps.toolchain_pin.outcome == 'failure'
+        run: |
+          echo "::error file=package.json::Lint, format, IPC codegen, prompts codegen, landing-diagram, agent-system, tech-radar, or toolchain-pin drift check failed. Run 'pnpm lint:fix', 'pnpm format', 'pnpm gen:ipc', 'pnpm gen:prompts', 'pnpm check:landing-drift', 'pnpm check:agent-system', 'pnpm check:tech-radar', and 'pnpm check:toolchain-pin' locally to fix."
           echo "::error::Please fix the issues above before merging."
           exit 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,8 @@ jobs:
 
       - name: 🦀 Setup Rust
         # Pinned to the version in apps/desktop/src-tauri/rust-toolchain.toml
+        # (enforced by `pnpm check:toolchain-pin`, which reads the trailing
+        # "# <version>" comment below — keep it accurate)
         # (same SHA as .github/actions/setup-rust — bump both together).
         uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 

--- a/apps/desktop/src-tauri/rust-toolchain.toml
+++ b/apps/desktop/src-tauri/rust-toolchain.toml
@@ -11,7 +11,10 @@
 # `dtolnay/rust-toolchain` (used in .github/actions/setup-rust and
 # release.yml) does NOT read this file — its @rev selects the version — so
 # CI is pinned to the SAME version below via that action's SHA. Bump both
-# together.
+# together: `pnpm check:toolchain-pin` (scripts/check-toolchain-pin.mjs, run
+# in CI's lint-format job) fails when they disagree, so this is an enforced
+# invariant rather than a comment asking nicely. It reads the `# <version>`
+# comment beside each action SHA, so that comment must stay accurate.
 #
 # No `components` here: each CI job's `dtolnay/rust-toolchain` step already
 # requests exactly the components it needs (see setup-rust's `components`

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check:landing-drift": "node scripts/check-landing-drift.mjs",
     "check:agent-system": "node scripts/check-agent-system.mjs",
     "check:tech-radar": "node scripts/check-tech-radar.mjs",
+    "check:toolchain-pin": "node scripts/check-toolchain-pin.mjs",
     "clean": "pnpm -r exec rimraf dist out .turbo node_modules/.cache",
     "clean:turbo": "pnpm -r exec rimraf .turbo node_modules/.cache/turbo",
     "storybook": "pnpm --filter @ajh/ui storybook",

--- a/scripts/check-toolchain-pin.mjs
+++ b/scripts/check-toolchain-pin.mjs
@@ -21,12 +21,16 @@
 // What this checks:
 //   1. `rust-toolchain.toml` declares an exact `channel` (a pin, not a
 //      floating channel like "stable"/"beta"/"1.97").
-//   2. Every `dtolnay/rust-toolchain@<sha>` use in `.github/` carries a
-//      trailing `# <version>` comment — that comment is the only
-//      human-readable statement of which version the SHA is, so an
+//   2. Every `dtolnay/rust-toolchain@<rev>` use in `.github/` is pinned to a
+//      full 40-hex commit SHA, not a moving reference. `@stable` and `@main`
+//      float exactly the way a `stable` channel does, and a floating action
+//      pin is arguably worse: it silently re-points at a different compiler
+//      with no diff anywhere in this repo.
+//   3. Every such use carries a trailing `# <version>` comment — that comment
+//      is the only human-readable statement of which version the SHA is, so an
 //      uncommented SHA is unreviewable by construction.
-//   3. Every one of those declared versions equals the TOML's channel.
-//   4. `Cargo.toml`'s `rust-version` (the MSRV) is not ABOVE the pinned
+//   4. Every one of those declared versions equals the TOML's channel.
+//   5. `Cargo.toml`'s `rust-version` (the MSRV) is not ABOVE the pinned
 //      toolchain — that combination cannot build at all.
 //
 // What it deliberately does NOT check: that the SHA genuinely is that version.
@@ -74,7 +78,7 @@ if (channel && !/^\d+\.\d+\.\d+$/.test(channel)) {
   );
 }
 
-// ── 2 + 3. Every action pin agrees with it ───────────────────────────────────
+// ── 2-4. Every action pin is a real SHA and agrees with it ───────────────────
 const actionUses = [];
 for (const file of walk(GH_DIR)) {
   if (!/\.ya?ml$/.test(file)) continue;
@@ -97,6 +101,20 @@ if (actionUses.length === 0) {
 }
 
 for (const use of actionUses) {
+  // A moving ref defeats the pin exactly like a floating channel does, and
+  // the version comment beside it is then a claim nothing keeps true: the
+  // action can re-point at a different compiler with no diff in this repo at
+  // all. Checked before the comment, since a `@stable # 1.97.1` line is
+  // perfectly well-commented and still unpinned.
+  if (!/^[0-9a-f]{40}$/i.test(use.rev)) {
+    errors.push(
+      `${use.file}:${use.line}: dtolnay/rust-toolchain@${use.rev} is not a commit ` +
+        `SHA. A moving reference (@stable, @main, @v1) re-points at a different ` +
+        `compiler without any change here, which is the drift this whole file ` +
+        `exists to prevent — pin the full 40-character SHA.`
+    );
+    continue;
+  }
   if (use.version === null) {
     errors.push(
       `${use.file}:${use.line}: dtolnay/rust-toolchain@${use.rev} has no trailing ` +
@@ -144,6 +162,6 @@ if (errors.length > 0) {
 
 console.log(
   `check:toolchain-pin OK — ${TOML} pins ${channel}; ` +
-    `${actionUses.length} dtolnay/rust-toolchain use(s) under ${GH_DIR}/ all declare ` +
-    `the same version${rustVersion ? `; MSRV ${rustVersion} is within it` : ''}.`
+    `${actionUses.length} dtolnay/rust-toolchain use(s) under ${GH_DIR}/ are SHA-pinned ` +
+    `and declare the same version${rustVersion ? `; MSRV ${rustVersion} is within it` : ''}.`
 );

--- a/scripts/check-toolchain-pin.mjs
+++ b/scripts/check-toolchain-pin.mjs
@@ -1,0 +1,149 @@
+// Drift guard for the Rust toolchain pin.
+//
+// The pin exists because local dev, PR CI and release builds previously each
+// resolved whatever "stable" meant on the day, and silently diverged. It is
+// held in two independent places that CANNOT reference each other:
+//
+//   * `apps/desktop/src-tauri/rust-toolchain.toml` — `[toolchain] channel`,
+//     which rustup reads for local dev and for anything invoking cargo
+//     directly;
+//   * `dtolnay/rust-toolchain@<sha>` in `.github/` — that action does NOT read
+//     the toolchain file; its pinned @rev IS the version selector.
+//
+// Today the only thing tying them together is a comment in three files saying
+// "bump both together". This repo's own rule is that a stated invariant with
+// no mechanical enforcement is a defect waiting to happen, and this one has a
+// particularly quiet failure: bump the TOML alone and CI keeps building on the
+// old compiler; bump the action alone and every developer's machine drifts off
+// what CI validates. Neither shows up as a red build — the pin just stops
+// meaning anything, which is the exact state it was created to end.
+//
+// What this checks:
+//   1. `rust-toolchain.toml` declares an exact `channel` (a pin, not a
+//      floating channel like "stable"/"beta"/"1.97").
+//   2. Every `dtolnay/rust-toolchain@<sha>` use in `.github/` carries a
+//      trailing `# <version>` comment — that comment is the only
+//      human-readable statement of which version the SHA is, so an
+//      uncommented SHA is unreviewable by construction.
+//   3. Every one of those declared versions equals the TOML's channel.
+//   4. `Cargo.toml`'s `rust-version` (the MSRV) is not ABOVE the pinned
+//      toolchain — that combination cannot build at all.
+//
+// What it deliberately does NOT check: that the SHA genuinely is that version.
+// That needs a network call to the action repo, and it is not the mistake
+// people make — the realistic error is updating one location and forgetting
+// the other, which is fully catchable offline.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const TOML = 'apps/desktop/src-tauri/rust-toolchain.toml';
+const CARGO = 'apps/desktop/src-tauri/Cargo.toml';
+const GH_DIR = '.github';
+
+const errors = [];
+
+/** Every file under `.github/`, recursively. */
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(join(ROOT, dir))) {
+    const rel = `${dir}/${entry}`;
+    if (statSync(join(ROOT, rel)).isDirectory()) out.push(...walk(rel));
+    else out.push(rel);
+  }
+  return out;
+}
+
+// ── 1. The pinned channel ─────────────────────────────────────────────────────
+const tomlText = readFileSync(join(ROOT, TOML), 'utf8');
+const channelMatch = tomlText.match(/^\s*channel\s*=\s*["']([^"']+)["']/m);
+
+if (!channelMatch) {
+  errors.push(`${TOML}: no [toolchain] channel found — the pin is the point of this file.`);
+}
+
+const channel = channelMatch?.[1];
+// A pin is three dot-separated numbers. "stable", "beta", "nightly" and a
+// two-part "1.97" all float, which defeats the file's stated purpose.
+if (channel && !/^\d+\.\d+\.\d+$/.test(channel)) {
+  errors.push(
+    `${TOML}: channel "${channel}" is not an exact version. A floating channel ` +
+      `(stable/beta/nightly, or a two-part "1.97") re-introduces the drift this ` +
+      `file exists to prevent — pin all three components.`
+  );
+}
+
+// ── 2 + 3. Every action pin agrees with it ───────────────────────────────────
+const actionUses = [];
+for (const file of walk(GH_DIR)) {
+  if (!/\.ya?ml$/.test(file)) continue;
+  const lines = readFileSync(join(ROOT, file), 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    // Only real `uses:` lines — a bare mention inside a comment is prose.
+    const m = line.match(/^\s*(?:-\s*)?uses:\s*dtolnay\/rust-toolchain@(\S+)/);
+    if (!m) return;
+    const version = line.match(/#\s*v?(\d+\.\d+\.\d+)\s*$/)?.[1] ?? null;
+    actionUses.push({ file, line: i + 1, rev: m[1], version });
+  });
+}
+
+if (actionUses.length === 0) {
+  errors.push(
+    `no dtolnay/rust-toolchain use found under ${GH_DIR}/ — either CI stopped ` +
+      `pinning the toolchain, or this check is looking in the wrong place. ` +
+      `Both are worth failing on.`
+  );
+}
+
+for (const use of actionUses) {
+  if (use.version === null) {
+    errors.push(
+      `${use.file}:${use.line}: dtolnay/rust-toolchain@${use.rev} has no trailing ` +
+        `"# <version>" comment. The SHA is opaque, so that comment is the only ` +
+        `way a reviewer (or this check) can tell which compiler CI runs. Add ` +
+        `\`# ${channel ?? 'X.Y.Z'}\`.`
+    );
+    continue;
+  }
+  if (channel && use.version !== channel) {
+    errors.push(
+      `${use.file}:${use.line}: pinned to ${use.version}, but ${TOML} pins ` +
+        `${channel}. Local dev and CI would build on different compilers — the ` +
+        `exact divergence the pin exists to prevent. Bump both together.`
+    );
+  }
+}
+
+// ── 4. MSRV cannot exceed the pinned toolchain ───────────────────────────────
+const rustVersion = readFileSync(join(ROOT, CARGO), 'utf8').match(
+  /^\s*rust-version\s*=\s*["']([^"']+)["']/m
+)?.[1];
+
+if (rustVersion && channel) {
+  const parts = (v) => v.split('.').map(Number);
+  const [msrvMajor = 0, msrvMinor = 0, msrvPatch = 0] = parts(rustVersion);
+  const [pinMajor, pinMinor, pinPatch] = parts(channel);
+  const msrv = msrvMajor * 1e6 + msrvMinor * 1e3 + msrvPatch;
+  const pin = pinMajor * 1e6 + pinMinor * 1e3 + pinPatch;
+  if (msrv > pin) {
+    errors.push(
+      `${CARGO}: rust-version (MSRV) ${rustVersion} is NEWER than the pinned ` +
+        `toolchain ${channel} — that combination cannot compile. Raise the pin ` +
+        `or lower the MSRV.`
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`check:toolchain-pin FAILED — ${errors.length} issue(s):\n`);
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error('\nFix the above, then re-run.');
+  process.exit(1);
+}
+
+console.log(
+  `check:toolchain-pin OK — ${TOML} pins ${channel}; ` +
+    `${actionUses.length} dtolnay/rust-toolchain use(s) under ${GH_DIR}/ all declare ` +
+    `the same version${rustVersion ? `; MSRV ${rustVersion} is within it` : ''}.`
+);

--- a/scripts/check-toolchain-pin.test.mjs
+++ b/scripts/check-toolchain-pin.test.mjs
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const scriptPath = join(__dirname, 'check-toolchain-pin.mjs');
+
+// Black-box test of the CLI against a minimal fake repo tree, mirroring
+// scripts/check-tech-radar.test.mjs. Every case writes its own
+// rust-toolchain.toml / workflow / Cargo.toml and runs the real script with
+// cwd: repoDir, so the script's own hardcoded relative paths resolve.
+const repoDir = join(tmpdir(), `check-toolchain-pin-test-${Date.now()}`);
+
+function writeRepo({ channel = '1.97.1', uses = [], rustVersion = '1.95' } = {}) {
+  mkdirSync(join(repoDir, 'apps', 'desktop', 'src-tauri'), { recursive: true });
+  mkdirSync(join(repoDir, '.github', 'workflows'), { recursive: true });
+  mkdirSync(join(repoDir, '.github', 'actions', 'setup-rust'), { recursive: true });
+
+  writeFileSync(
+    join(repoDir, 'apps', 'desktop', 'src-tauri', 'rust-toolchain.toml'),
+    channel === null ? '# no channel here\n' : `[toolchain]\nchannel = "${channel}"\n`
+  );
+  writeFileSync(
+    join(repoDir, 'apps', 'desktop', 'src-tauri', 'Cargo.toml'),
+    ['[package]', 'name = "fake"', `rust-version = "${rustVersion}"`, ''].join('\n')
+  );
+
+  const steps = uses
+    .map((u) => `      - uses: dtolnay/rust-toolchain@${u.rev ?? 'deadbeef'}${u.comment ?? ''}`)
+    .join('\n');
+  writeFileSync(
+    join(repoDir, '.github', 'workflows', 'ci.yml'),
+    ['jobs:', '  build:', '    steps:', steps, ''].join('\n')
+  );
+}
+
+/** Run the checker; returns {code, out}. */
+function run() {
+  try {
+    const out = execFileSync('node', [scriptPath], { cwd: repoDir, encoding: 'utf8' });
+    return { code: 0, out };
+  } catch (e) {
+    return { code: e.status ?? 1, out: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+  }
+}
+
+beforeEach(() => rmSync(repoDir, { recursive: true, force: true }));
+afterEach(() => rmSync(repoDir, { recursive: true, force: true }));
+
+describe('check-toolchain-pin', () => {
+  it('passes when the toml channel and every action comment agree', () => {
+    writeRepo({ uses: [{ comment: ' # 1.97.1' }, { comment: ' # 1.97.1' }] });
+    const { code, out } = run();
+    expect(code, out).toBe(0);
+    expect(out).toContain('1.97.1');
+  });
+
+  // The mistake the guard exists for: two places, one bumped.
+  it('fails when the toml is bumped but the action pin is not', () => {
+    writeRepo({ channel: '1.98.0', uses: [{ comment: ' # 1.97.1' }] });
+    const { code, out } = run();
+    expect(code).toBe(1);
+    expect(out).toMatch(/pinned to 1\.97\.1, but .*rust-toolchain\.toml pins 1\.98\.0/);
+  });
+
+  it('fails when the action pin is bumped but the toml is not', () => {
+    writeRepo({ channel: '1.97.1', uses: [{ comment: ' # 1.98.0' }] });
+    expect(run().code).toBe(1);
+  });
+
+  // One agreeing use must not excuse a second disagreeing one.
+  it('checks EVERY use, not just the first', () => {
+    writeRepo({ uses: [{ comment: ' # 1.97.1' }, { comment: ' # 1.96.0' }] });
+    const { code, out } = run();
+    expect(code).toBe(1);
+    expect(out).toContain('1.96.0');
+  });
+
+  it('rejects a floating channel, which is what the pin exists to prevent', () => {
+    for (const channel of ['stable', 'beta', 'nightly', '1.97']) {
+      writeRepo({ channel, uses: [{ comment: ' # 1.97.1' }] });
+      const { code, out } = run();
+      expect(code, `channel ${channel} should be rejected`).toBe(1);
+      expect(out).toContain('not an exact version');
+    }
+  });
+
+  it('rejects an opaque SHA with no version comment', () => {
+    writeRepo({ uses: [{ rev: 'abc123', comment: '' }] });
+    const { code, out } = run();
+    expect(code).toBe(1);
+    expect(out).toContain('no trailing');
+  });
+
+  it('accepts a v-prefixed version comment', () => {
+    writeRepo({ uses: [{ comment: ' # v1.97.1' }] });
+    expect(run().code).toBe(0);
+  });
+
+  // Removing CI's pin entirely is a bigger regression than mismatching it,
+  // and would otherwise pass vacuously — nothing to disagree with.
+  it('fails when no use is found at all rather than passing vacuously', () => {
+    writeRepo({ uses: [] });
+    const { code, out } = run();
+    expect(code).toBe(1);
+    expect(out).toContain('no dtolnay/rust-toolchain use found');
+  });
+
+  it('fails when the MSRV is newer than the pinned toolchain', () => {
+    writeRepo({ channel: '1.97.1', rustVersion: '1.99', uses: [{ comment: ' # 1.97.1' }] });
+    const { code, out } = run();
+    expect(code).toBe(1);
+    expect(out).toContain('cannot compile');
+  });
+
+  it('allows an MSRV below the pin — the normal, correct case', () => {
+    writeRepo({ channel: '1.97.1', rustVersion: '1.95', uses: [{ comment: ' # 1.97.1' }] });
+    expect(run().code).toBe(0);
+  });
+
+  // A `uses:` inside a comment is prose about the pin, not a pin.
+  it('ignores a commented-out uses line', () => {
+    writeRepo({ uses: [{ comment: ' # 1.97.1' }] });
+    writeFileSync(
+      join(repoDir, '.github', 'workflows', 'note.yml'),
+      '# uses: dtolnay/rust-toolchain@old # 1.50.0\n'
+    );
+    expect(run().code).toBe(0);
+  });
+});

--- a/scripts/check-toolchain-pin.test.mjs
+++ b/scripts/check-toolchain-pin.test.mjs
@@ -14,6 +14,12 @@ const scriptPath = join(__dirname, 'check-toolchain-pin.mjs');
 // cwd: repoDir, so the script's own hardcoded relative paths resolve.
 const repoDir = join(tmpdir(), `check-toolchain-pin-test-${Date.now()}`);
 
+// A real 40-hex commit SHA shape. The helper originally defaulted to
+// `deadbeef` — 8 chars — and every test passed, which is precisely the hole
+// CodeRabbit found in the checker: it validated the version COMMENT and never
+// the rev itself, so `@stable # 1.97.1` was accepted.
+const VALID_SHA = '032958afbdc797a9164d3bc0b56325c1308924a5';
+
 function writeRepo({ channel = '1.97.1', uses = [], rustVersion = '1.95' } = {}) {
   mkdirSync(join(repoDir, 'apps', 'desktop', 'src-tauri'), { recursive: true });
   mkdirSync(join(repoDir, '.github', 'workflows'), { recursive: true });
@@ -29,7 +35,7 @@ function writeRepo({ channel = '1.97.1', uses = [], rustVersion = '1.95' } = {})
   );
 
   const steps = uses
-    .map((u) => `      - uses: dtolnay/rust-toolchain@${u.rev ?? 'deadbeef'}${u.comment ?? ''}`)
+    .map((u) => `      - uses: dtolnay/rust-toolchain@${u.rev ?? VALID_SHA}${u.comment ?? ''}`)
     .join('\n');
   writeFileSync(
     join(repoDir, '.github', 'workflows', 'ci.yml'),
@@ -89,10 +95,29 @@ describe('check-toolchain-pin', () => {
   });
 
   it('rejects an opaque SHA with no version comment', () => {
-    writeRepo({ uses: [{ rev: 'abc123', comment: '' }] });
+    writeRepo({ uses: [{ rev: VALID_SHA, comment: '' }] });
     const { code, out } = run();
     expect(code).toBe(1);
     expect(out).toContain('no trailing');
+  });
+
+  // A moving ref defeats the pin exactly like a floating channel does, and a
+  // matching version comment makes it LOOK pinned — the comment is then a
+  // claim nothing keeps true.
+  it('rejects a moving action ref even when its version comment matches', () => {
+    for (const rev of ['stable', 'main', 'v1', 'master']) {
+      writeRepo({ uses: [{ rev, comment: ' # 1.97.1' }] });
+      const { code, out } = run();
+      expect(code, `@${rev} should be rejected`).toBe(1);
+      expect(out).toContain('is not a commit');
+    }
+  });
+
+  it('rejects a truncated SHA', () => {
+    writeRepo({ uses: [{ rev: VALID_SHA.slice(0, 7), comment: ' # 1.97.1' }] });
+    const { code, out } = run();
+    expect(code).toBe(1);
+    expect(out).toContain('is not a commit');
   });
 
   it('accepts a v-prefixed version comment', () => {


### PR DESCRIPTION
## The gap

The pin itself already shipped and is correct: `rust-toolchain.toml` pins
1.97.1, and both `dtolnay/rust-toolchain` uses are pinned to the SHA for that
same version. What was missing was any enforcement.

The two halves **cannot reference each other** — that action does not read
toolchain files, its `@rev` *is* the version selector — so the only thing tying
them together was a comment in three files saying "bump both together". This
repo already treats a stated invariant with nothing checking it as a defect.

The failure mode is what makes it worth a check: bump the TOML alone and CI keeps
building on the old compiler; bump the action alone and every developer's machine
drifts off what CI validates. **Neither goes red on its own.** The pin just stops
meaning anything — the exact state it was created to end.

## What the check asserts

1. The channel is an exact three-part version, not a floating one (`stable`,
   `beta`, `nightly`, or a two-part `1.97` all re-introduce the drift).
2. Every `dtolnay/rust-toolchain` use under `.github/` carries a trailing
   `# <version>` comment. A bare SHA is unreviewable by construction, so that
   comment is load-bearing rather than decoration.
3. Every one of those declared versions equals the channel.
4. The Cargo MSRV is not *above* the pin — that pairing cannot compile at all.

It deliberately does **not** verify the SHA genuinely is that version: that needs
a network call, and it isn't the mistake people make. The realistic error is
updating one place and forgetting the other, which is fully catchable offline.

Wired into `lint-format`, which has no path filter and so runs on every PR — a
toolchain guard that only fired when Rust files changed would miss the case where
someone edits only the workflow. The three comments now name their enforcer
instead of asking nicely.

## Verification

Mutation-tested five ways **against the real repo**, each red, tree restored
clean each time:

| mutation | result |
| --- | --- |
| bump `rust-toolchain.toml` only (the realistic mistake) | 🔴 names both versions and both files |
| bump the action's version comment only | 🔴 |
| float the channel back to `stable` | 🔴 "not an exact version" |
| strip a version comment | 🔴 "no trailing `# <version>`" |
| raise the MSRV past the pin | 🔴 "cannot compile" |

Plus 11 black-box CLI tests over a fake repo tree, following
`check-tech-radar.test.mjs`. One covers **removing CI's pin entirely**, which
would otherwise pass vacuously — with nothing to compare, nothing disagrees.
Another checks that every use is examined rather than just the first, and another
that a `uses:` line inside a comment is treated as prose, not a pin.

`pnpm test` 479 files / 6933 tests, `lint:strict --max-warnings 0` clean,
`format:check` clean.

## Note

`rust-toolchain.toml` and edition 2024 were both on the backlog as pending; both
turned out to be already done. This PR closes what was actually left of that item
— the enforcement, not the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated check to verify Rust toolchain versions remain consistent across project configuration and CI/release workflows.
  * Added clear validation output and remediation guidance when toolchain pins drift or are incompatible with the minimum supported Rust version.

* **Tests**
  * Added comprehensive coverage for matching and mismatched versions, missing or invalid pins, compatibility checks, and ignored comments.

* **Documentation**
  * Clarified how Rust toolchain versions should be updated and kept synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->