### PR TITLE
fix(evidence): stop filing academic records as work experience

### DIFF
--- a/apps/desktop/src-tauri/src/documents/evidence/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/mod.rs
@@ -283,6 +283,35 @@ pub enum SectionKind {
 /// experience), which is what makes them unconditional: no other section word
 /// on the same heading can outrank them. The BARE word for "experience" is not
 /// here — it is ambiguous, see [`AMBIGUOUS_EXPERIENCE_HEADINGS`].
+/// Headings that contain an EXPERIENCE stem but unambiguously name an
+/// EDUCATION section, checked BEFORE the experience test so the substring
+/// cannot win.
+///
+/// Found by sweeping every term in the TS `SECTION_LEXICON` through this
+/// classifier: "Akademischer Werdegang" — a standard German heading for an
+/// academic record — contains `werdegang` and so classified as Experience.
+/// That is the expensive direction, not a cosmetic mislabel: prose under an
+/// Experience heading reaches [`extract_evidence`]'s role arm, so degree
+/// entries became work bullets under roles the candidate never held.
+///
+/// A closed list of exact phrases rather than a rule, deliberately. The
+/// general fix — letting [`AMBIGUOUS_EXPERIENCE_HEADINGS`] yield to education
+/// the way it yields to summary and skills — would overturn a documented
+/// decision (see that const: Education and Projects are excluded from the
+/// yield set on purpose, because "Project Experience" really is a work
+/// history in a consultant's CV). These three phrases have no such second
+/// reading, so they need no rule.
+///
+/// This also supersedes one line of [`EXPERIENCE_HEADINGS`]'s `werdegang`
+/// note, which accepted "Ausbildungswerdegang" landing on Experience as
+/// cheaper than losing the section. It now lands on Education, which is
+/// better than either.
+const EDUCATION_OVERRIDES_EXPERIENCE: &[&str] = &[
+    "akademischer werdegang",
+    "akademische laufbahn",
+    "ausbildungswerdegang",
+];
+
 const EXPERIENCE_HEADINGS: &[&str] = &[
     "employment",
     "work experience",
@@ -298,6 +327,10 @@ const EXPERIENCE_HEADINGS: &[&str] = &[
     "expérience professionnelle",
     "experiencia profesional",
     "esperienza professionale",
+    // Sweep finds: German "Praxiserfahrung" is not caught by the
+    // word-bounded `erfahrung` (it is a compound, not a separate word), and
+    // Dutch "Werkervaring" already is. Both name a work history outright.
+    "praxiserfahrung",
     "werkervaring",
     "experiência profissional",
 ];
@@ -353,6 +386,8 @@ const AMBIGUOUS_EXPERIENCE_HEADINGS: &[&str] = &[
     "expérience",
     "experiencia",
     "esperienza",
+    // Plural of the stem above; same ambiguity, so the same yield rules.
+    "esperienze",
     "experiência",
 ];
 const EDUCATION_HEADINGS: &[&str] = &[
@@ -360,6 +395,12 @@ const EDUCATION_HEADINGS: &[&str] = &[
     "academic",
     "ausbildung",
     "bildung",
+    // Sweep finds. German "Studium" and Italian "Istruzione" are the ordinary
+    // words for an education section in their markets and matched nothing;
+    // `istruzione` is the very heading `resume_conventions("it")` teaches the
+    // model to write.
+    "studium",
+    "istruzione",
     "opleiding",
 ];
 
@@ -443,7 +484,11 @@ pub fn classify_section(heading: &str) -> SectionKind {
     let skills = has(SKILLS_HEADINGS);
     let ambiguous_experience =
         has(AMBIGUOUS_EXPERIENCE_HEADINGS) || has_word(EXPERIENCE_HEADINGS_WORD_BOUNDED);
-    if has(EXPERIENCE_HEADINGS) || (ambiguous_experience && !summary && !skills) {
+    // Before the experience test, not after: these carry an experience
+    // SUBSTRING, so anything downstream of that test is unreachable for them.
+    if has(EDUCATION_OVERRIDES_EXPERIENCE) {
+        SectionKind::Education
+    } else if has(EXPERIENCE_HEADINGS) || (ambiguous_experience && !summary && !skills) {
         SectionKind::Experience
     } else if has(EDUCATION_HEADINGS) || has_word(EDUCATION_HEADINGS_WORD_BOUNDED) {
         SectionKind::Education
@@ -866,3 +911,183 @@ pub fn extract_evidence(source_resume: &str, job_text: &str) -> EvidenceSet {
 
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod lexicon_parity {
+    use super::{classify_section, SectionKind};
+
+    /// Every heading term the renderer's `SECTION_LEXICON` knows, swept
+    /// through this classifier.
+    ///
+    /// The two sides answer the same question from different data — the TS
+    /// lexicon drives `detectSections`, this drives `extract_evidence` — and
+    /// nothing compared them until a sweep found German "Akademischer
+    /// Werdegang" classifying as **Experience**, because it contains
+    /// `werdegang`. That is the expensive direction: prose under an Experience
+    /// heading reaches `extract_evidence`'s role arm, so degree entries became
+    /// work bullets under roles the candidate never held.
+    ///
+    /// What this pins, in order of what each costs:
+    ///
+    /// 1. **No term may land in another section's bucket.** This catches the
+    ///    class of bug above and has zero exceptions.
+    /// 2. **The known misses are enumerated, not tolerated in bulk.** A term
+    ///    falling to `Other` is a coverage gap, not a misfile — the
+    ///    section-specific checks simply do not run. Listing all 40 turns a
+    ///    silent gap into a reviewed inventory: adding a lexicon term without
+    ///    teaching this classifier fails here, and FIXING one fails here too,
+    ///    so the list can only shrink deliberately.
+    ///
+    /// The list is dominated by Summary and Skills synonyms in fr/es/it/nl/pt
+    /// (`objectif`, `conoscenze`, `samenvatting`). Closing them is additive
+    /// but not free: every entry in the heading consts is a SUBSTRING test
+    /// against real headings, and `expertise`, `portfolio` and `studi` have
+    /// second readings (Italian "studio" contains `studi`), so they need the
+    /// word-bounded treatment rather than a bare push. Left as a bounded,
+    /// visible task rather than a silent one.
+    const KNOWN_MISSES: &[&str] = &[
+        "à propos",
+        "abilità",
+        "aptitudes",
+        "competenties",
+        "conhecimentos",
+        "conocimientos",
+        "conoscenze",
+        "diplômes",
+        "doelstelling",
+        "educação",
+        "educación",
+        "éducation",
+        "educazione",
+        "ervaring",
+        "escolaridade",
+        "estudios",
+        "études",
+        "expertise",
+        "kennis",
+        "loopbaan",
+        "obiettivo",
+        "objectif",
+        "objetivo",
+        "onderwijs",
+        "over mij",
+        "parcours professionnel",
+        "portfolio",
+        "qualifications",
+        "résumé",
+        "resumen",
+        "resumo",
+        "riassunto",
+        "samenvatting",
+        "savoir-faire",
+        "sobre mí",
+        "sobre mim",
+        "sommario",
+        "studi",
+        "studie",
+        "über mich",
+    ];
+
+    /// `SectionKind` has no `Languages` variant, so a language heading has no
+    /// bucket of its own. Skills is the closest true answer and matches what
+    /// the résumé conventions already rely on — "Sprachkenntnisse" was
+    /// rejected as a German producer heading for exactly this reason.
+    /// Allowlisted explicitly rather than swept under the wrong-bucket rule,
+    /// so adding a `Languages` variant later has to come past this comment.
+    const LANGUAGES_CLASSIFY_AS_SKILLS: &[&str] = &["language skills", "sprachkenntnisse"];
+
+    fn expected(section: &str) -> Option<SectionKind> {
+        match section {
+            "Summary" => Some(SectionKind::Summary),
+            "Experience" => Some(SectionKind::Experience),
+            "Education" => Some(SectionKind::Education),
+            "Skills" => Some(SectionKind::Skills),
+            "Projects" => Some(SectionKind::Projects),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn every_renderer_lexicon_term_classifies_consistently() {
+        #[derive(serde::Deserialize)]
+        struct Case {
+            section: String,
+            term: String,
+        }
+
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../packages/prompts/src/fixtures/section-lexicon.json");
+        let raw = std::fs::read_to_string(&path).expect(
+            "read section-lexicon parity fixture              (packages/prompts/src/fixtures/section-lexicon.json)",
+        );
+        let cases: Vec<Case> =
+            serde_json::from_str(&raw).expect("parse section-lexicon parity fixture");
+        assert!(!cases.is_empty(), "the lexicon fixture must not be empty");
+
+        let mut unexpected_misses = Vec::new();
+        let mut fixed_misses = Vec::new();
+
+        for c in &cases {
+            let kind = classify_section(&c.term);
+            let known_miss = KNOWN_MISSES.contains(&c.term.as_str());
+
+            match expected(&c.section) {
+                Some(want) if kind == want => {
+                    if known_miss {
+                        fixed_misses.push(c.term.as_str());
+                    }
+                }
+                Some(_) if kind == SectionKind::Other => {
+                    if !known_miss {
+                        unexpected_misses.push(c.term.as_str());
+                    }
+                }
+                Some(want) => panic!(
+                    "{:?} term {:?} classifies as {kind:?}, not {want:?} — it landed in                      ANOTHER section's bucket, which MISFILES its content rather than                      merely skipping it",
+                    c.section, c.term
+                ),
+                None => assert!(
+                    kind == SectionKind::Other
+                        || LANGUAGES_CLASSIFY_AS_SKILLS.contains(&c.term.as_str()),
+                    "{:?} term {:?} has no bucket of its own but classified as {kind:?}",
+                    c.section,
+                    c.term
+                ),
+            }
+        }
+
+        assert!(
+            unexpected_misses.is_empty(),
+            "these lexicon terms classify as Other and are not in KNOWN_MISSES — either              teach the classifier or add them there with a reason: {unexpected_misses:?}"
+        );
+        assert!(
+            fixed_misses.is_empty(),
+            "these terms now classify correctly but are still listed in KNOWN_MISSES —              remove them, so the list can only shrink deliberately: {fixed_misses:?}"
+        );
+    }
+
+    /// The precedence exception stated as behaviour rather than list
+    /// membership: each of these carries an EXPERIENCE substring and must
+    /// still reach Education.
+    #[test]
+    fn education_headings_carrying_an_experience_stem_reach_education() {
+        for heading in [
+            "Akademischer Werdegang",
+            "akademische laufbahn",
+            "AUSBILDUNGSWERDEGANG",
+        ] {
+            assert_eq!(
+                classify_section(heading),
+                SectionKind::Education,
+                "{heading:?} names an academic record; classifying it Experience files                  degree entries as work bullets under roles the candidate never held"
+            );
+        }
+        // Control: the same stem WITHOUT an education qualifier is still a work
+        // history, so the exception must not have swallowed the rule.
+        assert_eq!(
+            classify_section("Beruflicher Werdegang"),
+            SectionKind::Experience
+        );
+        assert_eq!(classify_section("Werdegang"), SectionKind::Experience);
+    }
+}

--- a/apps/desktop/src-tauri/src/documents/evidence/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/mod.rs
@@ -283,6 +283,43 @@ pub enum SectionKind {
 /// experience), which is what makes them unconditional: no other section word
 /// on the same heading can outrank them. The BARE word for "experience" is not
 /// here — it is ambiguous, see [`AMBIGUOUS_EXPERIENCE_HEADINGS`].
+const EXPERIENCE_HEADINGS: &[&str] = &[
+    "employment",
+    "work experience",
+    "professional experience",
+    "berufserfahrung",
+    "berufliche erfahrung",
+    "arbeitserfahrung",
+    // "Beruflicher Werdegang" is as standard a German experience heading as
+    // "Berufserfahrung", and classifying it `Other` discarded every bullet
+    // under it. A substring, like the compounds above: "Ausbildungswerdegang"
+    // reaching Experience first is a far smaller error than losing the section.
+    "werdegang",
+    "expérience professionnelle",
+    // Work-qualified, no second reading, no substring risk — same profile as
+    // the other terms this change teaches.
+    "parcours professionnel",
+    "experiencia profesional",
+    "esperienza professionale",
+    // Italian plurals, WORK-QUALIFIED and unconditional — deliberately not the
+    // bare `esperienze`, which a review proved re-creates this very commit's
+    // bug one language over: "Esperienze di formazione" is an EDUCATION
+    // heading, and the ambiguous set yields only to summary/skills, never to
+    // education, so a bare stem there resolves Experience and files a degree
+    // as a job. Qualified spellings also stay out of the section-DELETING
+    // hole the ambiguous list's own doc warns about: "Esperienze
+    // professionali e competenze" reaches Experience here, where the bare
+    // stem would have lost it to Skills.
+    "esperienze professionali",
+    "esperienze lavorative",
+    // Sweep finds: German "Praxiserfahrung" is not caught by the
+    // word-bounded `erfahrung` (it is a compound, not a separate word), and
+    // Dutch "Werkervaring" already is. Both name a work history outright.
+    "praxiserfahrung",
+    "werkervaring",
+    "experiência profissional",
+];
+
 /// Headings that contain an EXPERIENCE stem but unambiguously name an
 /// EDUCATION section, checked BEFORE the experience test so the substring
 /// cannot win.
@@ -308,31 +345,18 @@ pub enum SectionKind {
 /// better than either.
 const EDUCATION_OVERRIDES_EXPERIENCE: &[&str] = &[
     "akademischer werdegang",
+    // German declines and compounds `werdegang` freely, so an exact-phrase
+    // list is only as good as its membership. A review found the next four
+    // already in the wild — "Wissenschaftlicher Werdegang" heads the academic
+    // CV this feature is for — each of them filing a degree as a job on main
+    // and on the first draft of this fix alike.
+    "akademischen werdegang",
+    "wissenschaftlicher werdegang",
+    "wissenschaftlichen werdegang",
+    "schulischer werdegang",
+    "bildungswerdegang",
     "akademische laufbahn",
     "ausbildungswerdegang",
-];
-
-const EXPERIENCE_HEADINGS: &[&str] = &[
-    "employment",
-    "work experience",
-    "professional experience",
-    "berufserfahrung",
-    "berufliche erfahrung",
-    "arbeitserfahrung",
-    // "Beruflicher Werdegang" is as standard a German experience heading as
-    // "Berufserfahrung", and classifying it `Other` discarded every bullet
-    // under it. A substring, like the compounds above: "Ausbildungswerdegang"
-    // reaching Experience first is a far smaller error than losing the section.
-    "werdegang",
-    "expérience professionnelle",
-    "experiencia profesional",
-    "esperienza professionale",
-    // Sweep finds: German "Praxiserfahrung" is not caught by the
-    // word-bounded `erfahrung` (it is a compound, not a separate word), and
-    // Dutch "Werkervaring" already is. Both name a work history outright.
-    "praxiserfahrung",
-    "werkervaring",
-    "experiência profissional",
 ];
 
 /// The bare German word for "experience", matched with [`contains_word`].
@@ -386,8 +410,6 @@ const AMBIGUOUS_EXPERIENCE_HEADINGS: &[&str] = &[
     "expérience",
     "experiencia",
     "esperienza",
-    // Plural of the stem above; same ambiguity, so the same yield rules.
-    "esperienze",
     "experiência",
 ];
 const EDUCATION_HEADINGS: &[&str] = &[
@@ -395,12 +417,10 @@ const EDUCATION_HEADINGS: &[&str] = &[
     "academic",
     "ausbildung",
     "bildung",
-    // Sweep finds. German "Studium" and Italian "Istruzione" are the ordinary
-    // words for an education section in their markets and matched nothing;
-    // `istruzione` is the very heading `resume_conventions("it")` teaches the
-    // model to write.
+    // Sweep find. German "Studium" is the ordinary word for an education
+    // section and matched nothing. Safe as a substring: "Auslandsstudium",
+    // "Selbststudium" and "Studium Generale" are all education headings.
     "studium",
-    "istruzione",
     "opleiding",
 ];
 
@@ -421,6 +441,12 @@ const EDUCATION_HEADINGS: &[&str] = &[
 /// (`Weiterbildung` → `bildung`, `Berufsausbildung` → `ausbildung`), which a
 /// both-ends boundary would break.
 const EDUCATION_HEADINGS_WORD_BOUNDED: &[&str] = &[
+    // Italian "Istruzione" — the very heading `resume_conventions("it")`
+    // teaches the model to write, and it matched nothing. WORD-BOUNDED for
+    // the same reason `formation` below is: `distruzione` contains
+    // `istruzione` exactly as `information` contains `formation`.
+    "istruzione",
+    "istruzioni",
     "formation",
     "formations",
     "formación",
@@ -961,6 +987,11 @@ mod lexicon_parity {
         "educazione",
         "ervaring",
         "escolaridade",
+        // Back on the list after a review proved the bare stem cannot be
+        // taught safely: only the WORK-QUALIFIED plurals ("esperienze
+        // professionali/lavorative") are in `EXPERIENCE_HEADINGS`, so the bare
+        // word is an honest miss rather than a misfile.
+        "esperienze",
         "estudios",
         "études",
         "expertise",
@@ -971,7 +1002,6 @@ mod lexicon_parity {
         "objetivo",
         "onderwijs",
         "over mij",
-        "parcours professionnel",
         "portfolio",
         "qualifications",
         "résumé",
@@ -1060,6 +1090,24 @@ mod lexicon_parity {
             unexpected_misses.is_empty(),
             "these lexicon terms classify as Other and are not in KNOWN_MISSES — either              teach the classifier or add them there with a reason: {unexpected_misses:?}"
         );
+        // Third direction, and the one the first draft left open: an entry
+        // that names no lexicon term at all. Without this, KNOWN_MISSES could
+        // be padded with anything and still "shrink deliberately" — a review
+        // proved it by adding `"zzz-not-a-lexicon-term"` and watching the
+        // suite stay green.
+        let lexicon: std::collections::HashSet<&str> =
+            cases.iter().map(|c| c.term.as_str()).collect();
+        let dead: Vec<&str> = KNOWN_MISSES
+            .iter()
+            .chain(LANGUAGES_CLASSIFY_AS_SKILLS.iter())
+            .copied()
+            .filter(|t| !lexicon.contains(t))
+            .collect();
+        assert!(
+            dead.is_empty(),
+            "these entries name no lexicon term, so they exempt nothing and only              make the list look longer than the real gap: {dead:?}"
+        );
+
         assert!(
             fixed_misses.is_empty(),
             "these terms now classify correctly but are still listed in KNOWN_MISSES —              remove them, so the list can only shrink deliberately: {fixed_misses:?}"

--- a/apps/desktop/src-tauri/src/documents/evidence/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/mod.rs
@@ -336,8 +336,11 @@ const EXPERIENCE_HEADINGS: &[&str] = &[
 /// the way it yields to summary and skills — would overturn a documented
 /// decision (see that const: Education and Projects are excluded from the
 /// yield set on purpose, because "Project Experience" really is a work
-/// history in a consultant's CV). These three phrases have no such second
-/// reading, so they need no rule.
+/// history in a consultant's CV). Every phrase here has an explicit education
+/// qualifier and so has no such second reading, which is what lets membership
+/// stand in for a rule. The cost is that membership must be kept up: a review
+/// found four more already in the wild after the first three were written, so
+/// every entry is asserted individually below rather than sampled.
 ///
 /// This also supersedes one line of [`EXPERIENCE_HEADINGS`]'s `werdegang`
 /// note, which accepted "Ausbildungswerdegang" landing on Experience as
@@ -1119,17 +1122,40 @@ mod lexicon_parity {
     /// still reach Education.
     #[test]
     fn education_headings_carrying_an_experience_stem_reach_education() {
-        for heading in [
-            "Akademischer Werdegang",
-            "akademische laufbahn",
-            "AUSBILDUNGSWERDEGANG",
-        ] {
-            assert_eq!(
-                classify_section(heading),
-                SectionKind::Education,
-                "{heading:?} names an academic record; classifying it Experience files                  degree entries as work bullets under roles the candidate never held"
-            );
+        // TWO lists on purpose, because either alone passes for the wrong
+        // reason. The loop below drives off the const, so a phrase ADDED
+        // without thought is still asserted — but that is self-referential:
+        // deleting an entry deletes its own assertion, and a mutation run
+        // proved exactly that (removing `wissenschaftlicher werdegang` left
+        // this test green). So the membership check comes first and is
+        // written out by hand; it is the half that catches a deletion.
+        assert_eq!(
+            super::EDUCATION_OVERRIDES_EXPERIENCE,
+            &[
+                "akademischer werdegang",
+                "akademischen werdegang",
+                "wissenschaftlicher werdegang",
+                "wissenschaftlichen werdegang",
+                "schulischer werdegang",
+                "bildungswerdegang",
+                "akademische laufbahn",
+                "ausbildungswerdegang",
+            ],
+            "the override list changed — every entry is load-bearing (each one              was found filing a degree as a job), so a removal must be a              deliberate edit here, not a silent side effect"
+        );
+
+        // Case-varied to prove the lowercasing in `classify_section` rather
+        // than assuming it.
+        for phrase in super::EDUCATION_OVERRIDES_EXPERIENCE {
+            for heading in [phrase.to_string(), phrase.to_uppercase()] {
+                assert_eq!(
+                    classify_section(&heading),
+                    SectionKind::Education,
+                    "{heading:?} names an academic record; classifying it Experience                      files degree entries as work bullets under roles the candidate                      never held"
+                );
+            }
         }
+
         // Control: the same stem WITHOUT an education qualifier is still a work
         // history, so the exception must not have swallowed the rule.
         assert_eq!(
@@ -1137,5 +1163,56 @@ mod lexicon_parity {
             SectionKind::Experience
         );
         assert_eq!(classify_section("Werdegang"), SectionKind::Experience);
+    }
+
+    /// The Italian half of the same invariant, and the regression a pre-PR
+    /// review caught in the first draft of this change: putting the BARE stem
+    /// `esperienze` in [`AMBIGUOUS_EXPERIENCE_HEADINGS`] sent "Esperienze di
+    /// formazione" — an education heading — to Experience, because that set
+    /// yields to summary and skills but never to education. A degree entry
+    /// under it became a fabricated job.
+    ///
+    /// Only the WORK-QUALIFIED plurals are taught, so this pins both
+    /// directions at once: the education headings stay Education, the
+    /// qualified plurals reach Experience, and the bare word is an honest
+    /// miss rather than a misfile.
+    #[test]
+    fn italian_experience_plurals_do_not_capture_education_headings() {
+        for heading in [
+            "Esperienze di formazione",
+            "Formazione ed esperienze",
+            "Istruzione ed esperienze",
+        ] {
+            assert_eq!(
+                classify_section(heading),
+                SectionKind::Education,
+                "{heading:?} is an education heading; a bare `esperienze` stem files                  its degrees as work bullets"
+            );
+        }
+
+        for heading in [
+            "Esperienze professionali",
+            "Esperienze lavorative",
+            // Work-qualified spellings must also stay OUT of the
+            // section-deleting Skills hole `AMBIGUOUS_EXPERIENCE_HEADINGS`
+            // documents — nothing in `extract_evidence` reads a Skills
+            // section, so a work history landing there is erased, not
+            // mislabelled.
+            "Esperienze professionali e competenze",
+        ] {
+            assert_eq!(
+                classify_section(heading),
+                SectionKind::Experience,
+                "{heading:?} is work-qualified and must reach Experience"
+            );
+        }
+
+        // The bare stem is deliberately NOT taught: it cannot be, without
+        // re-opening the education capture above. `Other` is the honest
+        // answer and `KNOWN_MISSES` records it.
+        assert_eq!(classify_section("Esperienze"), SectionKind::Other);
+        // Substring control for the word-bounded `istruzione`.
+        assert_eq!(classify_section("Distruzione"), SectionKind::Other);
+        assert_eq!(classify_section("Istruzione"), SectionKind::Education);
     }
 }

--- a/packages/prompts/src/fixtures/section-lexicon.json
+++ b/packages/prompts/src/fixtures/section-lexicon.json
@@ -1,0 +1,790 @@
+[
+  {
+    "section": "Summary",
+    "term": "professional summary"
+  },
+  {
+    "section": "Summary",
+    "term": "summary"
+  },
+  {
+    "section": "Summary",
+    "term": "profile"
+  },
+  {
+    "section": "Summary",
+    "term": "objective"
+  },
+  {
+    "section": "Summary",
+    "term": "about me"
+  },
+  {
+    "section": "Summary",
+    "term": "profil"
+  },
+  {
+    "section": "Summary",
+    "term": "zusammenfassung"
+  },
+  {
+    "section": "Summary",
+    "term": "kurzprofil"
+  },
+  {
+    "section": "Summary",
+    "term": "über mich"
+  },
+  {
+    "section": "Summary",
+    "term": "profil professionnel"
+  },
+  {
+    "section": "Summary",
+    "term": "résumé"
+  },
+  {
+    "section": "Summary",
+    "term": "à propos"
+  },
+  {
+    "section": "Summary",
+    "term": "objectif"
+  },
+  {
+    "section": "Summary",
+    "term": "perfil"
+  },
+  {
+    "section": "Summary",
+    "term": "resumen"
+  },
+  {
+    "section": "Summary",
+    "term": "sobre mí"
+  },
+  {
+    "section": "Summary",
+    "term": "objetivo"
+  },
+  {
+    "section": "Summary",
+    "term": "profilo"
+  },
+  {
+    "section": "Summary",
+    "term": "sommario"
+  },
+  {
+    "section": "Summary",
+    "term": "riassunto"
+  },
+  {
+    "section": "Summary",
+    "term": "obiettivo"
+  },
+  {
+    "section": "Summary",
+    "term": "profiel"
+  },
+  {
+    "section": "Summary",
+    "term": "samenvatting"
+  },
+  {
+    "section": "Summary",
+    "term": "over mij"
+  },
+  {
+    "section": "Summary",
+    "term": "doelstelling"
+  },
+  {
+    "section": "Summary",
+    "term": "resumo"
+  },
+  {
+    "section": "Summary",
+    "term": "sobre mim"
+  },
+  {
+    "section": "Experience",
+    "term": "work experience"
+  },
+  {
+    "section": "Experience",
+    "term": "professional experience"
+  },
+  {
+    "section": "Experience",
+    "term": "experience"
+  },
+  {
+    "section": "Experience",
+    "term": "employment history"
+  },
+  {
+    "section": "Experience",
+    "term": "career"
+  },
+  {
+    "section": "Experience",
+    "term": "berufserfahrung"
+  },
+  {
+    "section": "Experience",
+    "term": "beruflicher werdegang"
+  },
+  {
+    "section": "Experience",
+    "term": "werdegang"
+  },
+  {
+    "section": "Experience",
+    "term": "arbeitserfahrung"
+  },
+  {
+    "section": "Experience",
+    "term": "praxiserfahrung"
+  },
+  {
+    "section": "Experience",
+    "term": "expérience professionnelle"
+  },
+  {
+    "section": "Experience",
+    "term": "expériences professionnelles"
+  },
+  {
+    "section": "Experience",
+    "term": "expérience"
+  },
+  {
+    "section": "Experience",
+    "term": "expériences"
+  },
+  {
+    "section": "Experience",
+    "term": "parcours professionnel"
+  },
+  {
+    "section": "Experience",
+    "term": "experiencia laboral"
+  },
+  {
+    "section": "Experience",
+    "term": "experiencia profesional"
+  },
+  {
+    "section": "Experience",
+    "term": "experiencia"
+  },
+  {
+    "section": "Experience",
+    "term": "esperienza professionale"
+  },
+  {
+    "section": "Experience",
+    "term": "esperienza lavorativa"
+  },
+  {
+    "section": "Experience",
+    "term": "esperienza"
+  },
+  {
+    "section": "Experience",
+    "term": "esperienze"
+  },
+  {
+    "section": "Experience",
+    "term": "werkervaring"
+  },
+  {
+    "section": "Experience",
+    "term": "ervaring"
+  },
+  {
+    "section": "Experience",
+    "term": "loopbaan"
+  },
+  {
+    "section": "Experience",
+    "term": "experiência profissional"
+  },
+  {
+    "section": "Experience",
+    "term": "experiência"
+  },
+  {
+    "section": "Education",
+    "term": "education"
+  },
+  {
+    "section": "Education",
+    "term": "academic background"
+  },
+  {
+    "section": "Education",
+    "term": "qualifications"
+  },
+  {
+    "section": "Education",
+    "term": "ausbildung"
+  },
+  {
+    "section": "Education",
+    "term": "bildung"
+  },
+  {
+    "section": "Education",
+    "term": "studium"
+  },
+  {
+    "section": "Education",
+    "term": "schulbildung"
+  },
+  {
+    "section": "Education",
+    "term": "akademischer werdegang"
+  },
+  {
+    "section": "Education",
+    "term": "formation"
+  },
+  {
+    "section": "Education",
+    "term": "éducation"
+  },
+  {
+    "section": "Education",
+    "term": "études"
+  },
+  {
+    "section": "Education",
+    "term": "diplômes"
+  },
+  {
+    "section": "Education",
+    "term": "educación"
+  },
+  {
+    "section": "Education",
+    "term": "formación"
+  },
+  {
+    "section": "Education",
+    "term": "formación académica"
+  },
+  {
+    "section": "Education",
+    "term": "estudios"
+  },
+  {
+    "section": "Education",
+    "term": "istruzione"
+  },
+  {
+    "section": "Education",
+    "term": "formazione"
+  },
+  {
+    "section": "Education",
+    "term": "educazione"
+  },
+  {
+    "section": "Education",
+    "term": "studi"
+  },
+  {
+    "section": "Education",
+    "term": "opleiding"
+  },
+  {
+    "section": "Education",
+    "term": "onderwijs"
+  },
+  {
+    "section": "Education",
+    "term": "studie"
+  },
+  {
+    "section": "Education",
+    "term": "educação"
+  },
+  {
+    "section": "Education",
+    "term": "formação"
+  },
+  {
+    "section": "Education",
+    "term": "formação acadêmica"
+  },
+  {
+    "section": "Education",
+    "term": "escolaridade"
+  },
+  {
+    "section": "Skills",
+    "term": "skills"
+  },
+  {
+    "section": "Skills",
+    "term": "technical skills"
+  },
+  {
+    "section": "Skills",
+    "term": "core competencies"
+  },
+  {
+    "section": "Skills",
+    "term": "expertise"
+  },
+  {
+    "section": "Skills",
+    "term": "kenntnisse"
+  },
+  {
+    "section": "Skills",
+    "term": "fähigkeiten"
+  },
+  {
+    "section": "Skills",
+    "term": "kompetenzen"
+  },
+  {
+    "section": "Skills",
+    "term": "fachkenntnisse"
+  },
+  {
+    "section": "Skills",
+    "term": "compétences"
+  },
+  {
+    "section": "Skills",
+    "term": "savoir-faire"
+  },
+  {
+    "section": "Skills",
+    "term": "habilidades"
+  },
+  {
+    "section": "Skills",
+    "term": "competencias"
+  },
+  {
+    "section": "Skills",
+    "term": "conocimientos"
+  },
+  {
+    "section": "Skills",
+    "term": "aptitudes"
+  },
+  {
+    "section": "Skills",
+    "term": "competenze"
+  },
+  {
+    "section": "Skills",
+    "term": "abilità"
+  },
+  {
+    "section": "Skills",
+    "term": "conoscenze"
+  },
+  {
+    "section": "Skills",
+    "term": "vaardigheden"
+  },
+  {
+    "section": "Skills",
+    "term": "competenties"
+  },
+  {
+    "section": "Skills",
+    "term": "kennis"
+  },
+  {
+    "section": "Skills",
+    "term": "competências"
+  },
+  {
+    "section": "Skills",
+    "term": "habilidades técnicas"
+  },
+  {
+    "section": "Skills",
+    "term": "conhecimentos"
+  },
+  {
+    "section": "Certifications",
+    "term": "certifications"
+  },
+  {
+    "section": "Certifications",
+    "term": "certificates"
+  },
+  {
+    "section": "Certifications",
+    "term": "licenses"
+  },
+  {
+    "section": "Certifications",
+    "term": "zertifikate"
+  },
+  {
+    "section": "Certifications",
+    "term": "zertifizierungen"
+  },
+  {
+    "section": "Certifications",
+    "term": "lizenzen"
+  },
+  {
+    "section": "Certifications",
+    "term": "certifications"
+  },
+  {
+    "section": "Certifications",
+    "term": "certificats"
+  },
+  {
+    "section": "Certifications",
+    "term": "certificaciones"
+  },
+  {
+    "section": "Certifications",
+    "term": "certificados"
+  },
+  {
+    "section": "Certifications",
+    "term": "licencias"
+  },
+  {
+    "section": "Certifications",
+    "term": "certificazioni"
+  },
+  {
+    "section": "Certifications",
+    "term": "certificati"
+  },
+  {
+    "section": "Certifications",
+    "term": "certificeringen"
+  },
+  {
+    "section": "Certifications",
+    "term": "certificaten"
+  },
+  {
+    "section": "Certifications",
+    "term": "certificações"
+  },
+  {
+    "section": "Projects",
+    "term": "projects"
+  },
+  {
+    "section": "Projects",
+    "term": "portfolio"
+  },
+  {
+    "section": "Projects",
+    "term": "key projects"
+  },
+  {
+    "section": "Projects",
+    "term": "projekte"
+  },
+  {
+    "section": "Projects",
+    "term": "projektübersicht"
+  },
+  {
+    "section": "Projects",
+    "term": "projets"
+  },
+  {
+    "section": "Projects",
+    "term": "proyectos"
+  },
+  {
+    "section": "Projects",
+    "term": "progetti"
+  },
+  {
+    "section": "Projects",
+    "term": "projecten"
+  },
+  {
+    "section": "Projects",
+    "term": "projetos"
+  },
+  {
+    "section": "Publications",
+    "term": "publications"
+  },
+  {
+    "section": "Publications",
+    "term": "research"
+  },
+  {
+    "section": "Publications",
+    "term": "papers"
+  },
+  {
+    "section": "Publications",
+    "term": "publikationen"
+  },
+  {
+    "section": "Publications",
+    "term": "veröffentlichungen"
+  },
+  {
+    "section": "Publications",
+    "term": "forschung"
+  },
+  {
+    "section": "Publications",
+    "term": "recherche"
+  },
+  {
+    "section": "Publications",
+    "term": "publicaciones"
+  },
+  {
+    "section": "Publications",
+    "term": "investigación"
+  },
+  {
+    "section": "Publications",
+    "term": "pubblicazioni"
+  },
+  {
+    "section": "Publications",
+    "term": "ricerca"
+  },
+  {
+    "section": "Publications",
+    "term": "publicaties"
+  },
+  {
+    "section": "Publications",
+    "term": "onderzoek"
+  },
+  {
+    "section": "Publications",
+    "term": "publicações"
+  },
+  {
+    "section": "Publications",
+    "term": "pesquisa"
+  },
+  {
+    "section": "Awards",
+    "term": "awards"
+  },
+  {
+    "section": "Awards",
+    "term": "honors"
+  },
+  {
+    "section": "Awards",
+    "term": "achievements"
+  },
+  {
+    "section": "Awards",
+    "term": "auszeichnungen"
+  },
+  {
+    "section": "Awards",
+    "term": "ehrungen"
+  },
+  {
+    "section": "Awards",
+    "term": "erfolge"
+  },
+  {
+    "section": "Awards",
+    "term": "prix"
+  },
+  {
+    "section": "Awards",
+    "term": "distinctions"
+  },
+  {
+    "section": "Awards",
+    "term": "réalisations"
+  },
+  {
+    "section": "Awards",
+    "term": "premios"
+  },
+  {
+    "section": "Awards",
+    "term": "reconocimientos"
+  },
+  {
+    "section": "Awards",
+    "term": "logros"
+  },
+  {
+    "section": "Awards",
+    "term": "premi"
+  },
+  {
+    "section": "Awards",
+    "term": "riconoscimenti"
+  },
+  {
+    "section": "Awards",
+    "term": "prijzen"
+  },
+  {
+    "section": "Awards",
+    "term": "onderscheidingen"
+  },
+  {
+    "section": "Awards",
+    "term": "prêmios"
+  },
+  {
+    "section": "Awards",
+    "term": "conquistas"
+  },
+  {
+    "section": "Languages",
+    "term": "languages"
+  },
+  {
+    "section": "Languages",
+    "term": "language skills"
+  },
+  {
+    "section": "Languages",
+    "term": "sprachen"
+  },
+  {
+    "section": "Languages",
+    "term": "sprachkenntnisse"
+  },
+  {
+    "section": "Languages",
+    "term": "langues"
+  },
+  {
+    "section": "Languages",
+    "term": "idiomas"
+  },
+  {
+    "section": "Languages",
+    "term": "lenguas"
+  },
+  {
+    "section": "Languages",
+    "term": "lingue"
+  },
+  {
+    "section": "Languages",
+    "term": "talen"
+  },
+  {
+    "section": "Languages",
+    "term": "línguas"
+  },
+  {
+    "section": "Volunteer",
+    "term": "volunteer"
+  },
+  {
+    "section": "Volunteer",
+    "term": "volunteering"
+  },
+  {
+    "section": "Volunteer",
+    "term": "community"
+  },
+  {
+    "section": "Volunteer",
+    "term": "ehrenamt"
+  },
+  {
+    "section": "Volunteer",
+    "term": "freiwilligenarbeit"
+  },
+  {
+    "section": "Volunteer",
+    "term": "bénévolat"
+  },
+  {
+    "section": "Volunteer",
+    "term": "volontariat"
+  },
+  {
+    "section": "Volunteer",
+    "term": "voluntariado"
+  },
+  {
+    "section": "Volunteer",
+    "term": "volontariato"
+  },
+  {
+    "section": "Volunteer",
+    "term": "vrijwilligerswerk"
+  },
+  {
+    "section": "Interests",
+    "term": "interests"
+  },
+  {
+    "section": "Interests",
+    "term": "hobbies"
+  },
+  {
+    "section": "Interests",
+    "term": "interessen"
+  },
+  {
+    "section": "Interests",
+    "term": "hobbys"
+  },
+  {
+    "section": "Interests",
+    "term": "centres d'intérêt"
+  },
+  {
+    "section": "Interests",
+    "term": "loisirs"
+  },
+  {
+    "section": "Interests",
+    "term": "intérêts"
+  },
+  {
+    "section": "Interests",
+    "term": "intereses"
+  },
+  {
+    "section": "Interests",
+    "term": "aficiones"
+  },
+  {
+    "section": "Interests",
+    "term": "pasatiempos"
+  },
+  {
+    "section": "Interests",
+    "term": "interessi"
+  },
+  {
+    "section": "Interests",
+    "term": "hobby"
+  },
+  {
+    "section": "Interests",
+    "term": "interesses"
+  },
+  {
+    "section": "Interests",
+    "term": "passatempos"
+  }
+]

--- a/packages/prompts/src/locale/section-lexicon-fixture.test.ts
+++ b/packages/prompts/src/locale/section-lexicon-fixture.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import fixture from '../fixtures/section-lexicon.json';
+import { SECTION_LEXICON } from './index';
+
+describe('section-lexicon fixture ↔ SECTION_LEXICON', () => {
+  // The fixture is a flattened copy of SECTION_LEXICON, read by Rust's
+  // `documents::evidence::lexicon_parity` sweep — Rust cannot parse the TS
+  // source, so the copy is unavoidable. This is the guard that keeps it from
+  // becoming a stale copy: a term added to SECTION_LEXICON without
+  // regenerating the fixture fails here, which is what stops the Rust sweep
+  // from silently checking yesterday's vocabulary and reporting green.
+  it('matches the live lexicon exactly, in order', () => {
+    const derived = SECTION_LEXICON.flatMap((entry) =>
+      entry.terms.map((term) => ({ section: entry.name, term }))
+    );
+    expect(fixture).toEqual(derived);
+  });
+});


### PR DESCRIPTION
## The bug

`documents::evidence::classify_section` maps a résumé heading to a `SectionKind`.
German **"Akademischer Werdegang"** — an academic record — classified as
`Experience`, because it contains `werdegang`, an unconditional entry in
`EXPERIENCE_HEADINGS`, and that test runs first.

Not a cosmetic mislabel. Prose under an Experience heading reaches
`extract_evidence`'s role arm, so a degree entry became a **fabricated job**:

```
SCHULISCHER WERDEGANG   roles=1  education=[]
  role=("Politecnico di Milano", "Laurea Magistrale in Informatica", "2014 - 2016", …)
```

Found by sweeping all 197 terms of the renderer's TS `SECTION_LEXICON` through
the classifier — two sides answering the same question from different data
(`detectSections` vs `extract_evidence`), which nothing had ever compared.

## What changed

- A closed `EDUCATION_OVERRIDES_EXPERIENCE` list checked **before** the
  experience test, covering `akademischer`/`akademischen`,
  `wissenschaftlicher`/`wissenschaftlichen`, `schulischer`, `bildungs-` and
  `ausbildungswerdegang`. Not a general rule: letting the ambiguous set yield to
  Education would overturn a documented decision ("Project Experience" really is
  a work history in a consultant's CV).
- Four localized headings taught: `praxiserfahrung`, `studium` (de),
  `istruzione` (it, word-bounded), `parcours professionnel` (fr), plus the
  work-qualified Italian plurals `esperienze professionali` / `lavorative`.
  `istruzione` is the very heading `resume_conventions("it")` tells the model to
  write — producer and recogniser disagreed about Italian education.
- The remaining **40 misses are enumerated** in `KNOWN_MISSES`, asserted in
  three directions: a new unrecognised term fails, fixing one without delisting
  it fails, and an entry naming no lexicon term at all fails. A silent gap
  becomes a reviewed inventory that can only shrink deliberately.

## The review blocked the first draft, and it was right

The pre-PR gate reproduced a **HIGH**: my own fix re-created its own bug one
language over. Putting the bare stem `esperienze` in the *ambiguous* set looked
like a free plural — but that set yields to Summary and Skills and **never to
Education**, so "Esperienze di formazione" went `Education → Experience`, with
the same fabricated-role outcome, and it defeated this PR's own new `istruzione`
entry on "Istruzione ed esperienze".

Measured after the fix — strictly better than both `main` and the first draft:

| heading | main | draft | now |
| --- | --- | --- | --- |
| Esperienze di formazione | Education | **Experience** | Education |
| Istruzione ed esperienze | Other | **Experience** | Education |
| Esperienze professionali e competenze | Skills | Skills | **Experience** |
| Esperienze professionali | Other | Experience | Experience |
| Esperienze (bare) | Other | Experience | Other *(honest miss)* |
| Wissenschaftlicher Werdegang | Experience | Experience | **Education** |
| Distruzione | Other | **Education** | Other |

Also fixed from the review: `istruzione` matched `distruzione` (moved to the
word-bounded list that exists in this file for exactly `formation ⊂
information`); `KNOWN_MISSES` accepted entries naming no lexicon term; and
**`EXPERIENCE_HEADINGS` had silently lost its doc comment** — the new const was
inserted between that doc and its item, so the whole run reattached.

Both final corrections were forced **by the guard itself, against its own
author**: removing bare `esperienze` made the sweep demand it back on the list,
and teaching `parcours professionnel` made the sweep demand it be delisted.

## Verification

`cargo test --all-features --locked` 4208 + 18 + 20 + 3, clippy
`--all-features --all-targets` clean, `cargo fmt --check` clean,
`vitest packages/prompts` 18 files / 1179 tests.

Guards mutation-checked: dropping the precedence branch, removing a taught term,
shrinking the inventory without fixing anything, fixing one while leaving it
listed, and (fixture side) reordering, duplicating, or adding a lexicon term
without regenerating — all red.

## Known limits

The 40 remaining misses are mostly Summary/Skills synonyms in fr/es/it/nl/pt.
They are not free: these consts are substring tests, and `expertise`,
`portfolio` and `studi` have second readings (Italian *studio* contains
`studi`), so they need word-bounded handling. Left visible rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved résumé section recognition across French, Italian, German, Dutch, and Portuguese.
  - More reliably extracts work experience, education, projects, and contact details from varied résumé formats.
  - Preserves previously unresolved experience entries and labels instead of losing information.
  - Provides more relevant, consistently ordered skill results.
- **Bug Fixes**
  - Prevents German education headings from being misclassified as work experience.
  - Expanded education and section-term coverage for multilingual résumés.
- **Tests**
  - Added regression coverage to verify multilingual section recognition and lexicon consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->