### PR TITLE
fix(autopilot): keep a run in flight visible after navigating away

### DIFF
--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/AutopilotPage.focus.test.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/AutopilotPage.focus.test.tsx
@@ -65,17 +65,22 @@ vi.mock('@/services', async (importOriginal) => {
 let capturedOnApply: ((job: AutopilotFoundJob) => void) | null = null;
 // Captures the focusedJobUrl prop so the Back-navigation flow can assert it's forwarded.
 let capturedFocusedJobUrl: string | null | undefined = null;
+// Captures the runState prop — the card's ONLY running/idle signal.
+let capturedRunState: string | undefined;
 
 vi.mock('@/features/autopilot/components/AutopilotCard', () => ({
   AutopilotCard: ({
     onApply,
     focusedJobUrl,
+    runState,
   }: {
     onApply: (job: AutopilotFoundJob) => void;
     focusedJobUrl?: string | null;
+    runState?: string;
   }) => {
     capturedOnApply = onApply;
     capturedFocusedJobUrl = focusedJobUrl;
+    capturedRunState = runState;
     return <div data-testid={TEST_IDS.autopilot.card} />;
   },
 }));
@@ -125,6 +130,7 @@ beforeEach(() => {
   mockAutopilotList = [];
   capturedOnApply = null;
   capturedFocusedJobUrl = null;
+  capturedRunState = undefined;
   currentSearch = {};
 });
 
@@ -287,6 +293,55 @@ describe('AutopilotPage — handleApply board provenance', () => {
     });
 
     expect(mockMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ board: 'aggregator' }));
+  });
+});
+
+/**
+ * The mocked `useAutopilotRun` returns `runStates: {}` — which is exactly the
+ * real hook's state on a FRESH MOUNT. That is the reported bug's setup: the user
+ * started a run, navigated to Settings, and came back to a remounted page whose
+ * local run state had been discarded while the run kept executing in Rust.
+ */
+describe('AutopilotPage — a run still in flight survives the remount', () => {
+  const withRunStatus = (runStatus: Autopilot['runStatus']): Autopilot => ({
+    ...makeAutopilot(['indeed']),
+    runStatus,
+  });
+
+  it('reads the persisted inProgress status when this mount has no local run state', async () => {
+    mockAutopilotList = [withRunStatus('inProgress')];
+
+    await act(async () => {
+      render(<AutopilotPage />);
+    });
+
+    // Absolute expectation, not "not idle": 'scraping' is a busyState, which is
+    // what disables the Run button. Landing on 'idle' is the bug — the card
+    // claims the run finished, the button re-arms, and the backend refuses the
+    // click with "a run is already in progress".
+    expect(capturedRunState).toBe('scraping');
+  });
+
+  it('stays idle for a run that is genuinely over', async () => {
+    // The negative half: without this, a fallback that ignored `runStatus` and
+    // always returned 'scraping' would pass the test above.
+    mockAutopilotList = [withRunStatus('completed')];
+
+    await act(async () => {
+      render(<AutopilotPage />);
+    });
+
+    expect(capturedRunState).toBe('idle');
+  });
+
+  it('stays idle for an autopilot that has never run', async () => {
+    mockAutopilotList = [makeAutopilot(['indeed'])]; // no runStatus at all
+
+    await act(async () => {
+      render(<AutopilotPage />);
+    });
+
+    expect(capturedRunState).toBe('idle');
   });
 });
 

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/AutopilotPage.focus.test.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/AutopilotPage.focus.test.tsx
@@ -93,9 +93,13 @@ vi.mock('@/features/autopilot/components/EmptyState', () => ({
   EmptyState: () => <div data-testid={TEST_IDS.autopilot.emptyState} />,
 }));
 
+// Mutable so a test can put the hook in the state a real mount would be in
+// (empty after a navigation; a terminal state once a step event was observed).
+let mockRunStates: Record<string, string> = {};
+
 vi.mock('@/features/autopilot/hooks/useAutopilotRun', () => ({
   useAutopilotRun: () => ({
-    runStates: {},
+    runStates: mockRunStates,
     stepLogs: {},
     error: null,
     setError: vi.fn(),
@@ -131,6 +135,7 @@ beforeEach(() => {
   capturedOnApply = null;
   capturedFocusedJobUrl = null;
   capturedRunState = undefined;
+  mockRunStates = {};
   currentSearch = {};
 });
 
@@ -342,6 +347,35 @@ describe('AutopilotPage — a run still in flight survives the remount', () => {
     });
 
     expect(capturedRunState).toBe('idle');
+  });
+
+  it('does not strand the card when the concurrent run FAILS', async () => {
+    // The path with no terminal step event at all: the Rust failure arm calls
+    // `job_fail` and returns early, so nothing ever announces the end. A card
+    // pinned to a busy state by inference would sit there forever; only
+    // `runStatus` records the outcome, so 'idle' has to hand control back to it.
+    mockRunStates = { 'ap-1': 'idle' }; // what `already-running` leaves behind
+    mockAutopilotList = [withRunStatus('failed')];
+
+    await act(async () => {
+      render(<AutopilotPage />);
+    });
+
+    expect(capturedRunState).toBe('idle');
+  });
+
+  it('keeps a locally-observed terminal state while the list query is still stale', async () => {
+    // The opposite direction: this mount SAW the `complete` step, so it knows
+    // the run is over before the invalidation lands. Reading the backend first
+    // would flip a finished card back to 'scraping' for one render.
+    mockRunStates = { 'ap-1': 'done' };
+    mockAutopilotList = [withRunStatus('inProgress')]; // stale
+
+    await act(async () => {
+      render(<AutopilotPage />);
+    });
+
+    expect(capturedRunState).toBe('done');
   });
 });
 

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
@@ -169,17 +169,33 @@ function AutopilotPage() {
           ) : (
             <div className="space-y-3">
               {autopilots.map((ap) => {
-                // `runStates` is this mount's live event state and starts EMPTY:
-                // navigating to Settings unmounts this page, so a run still in
-                // flight comes back with no local state at all. The backend's
-                // persisted `runStatus` is the durable truth, so fall back to it
-                // — otherwise the card renders 'idle' (no badge exists for
-                // `inProgress`, by design), the Run button re-enables, and the
-                // click is refused by the backend's concurrent-run guard with
-                // "a run is already in progress" for a run the UI just claimed
-                // was finished.
+                // Two authorities, in this order:
+                //
+                //  1. THIS MOUNT'S MACHINE, once it has actually observed the
+                //     run. Anything other than 'idle' means a step event (or
+                //     the click itself) moved it, and it knows the finer phase
+                //     — 'ranking' vs 'scraping', 'done' before the list query
+                //     has caught up.
+                //  2. THE BACKEND'S PERSISTED `runStatus`, otherwise. This
+                //     mount's state starts EMPTY, so a route change to Settings
+                //     and back leaves nothing behind for a run that is still
+                //     executing. Without this the card renders 'idle' (there is
+                //     deliberately no badge for `inProgress`), the Run button
+                //     re-enables, and the click is refused by the backend's
+                //     concurrent-run guard — "a run is already in progress" for
+                //     a run the UI just showed as finished.
+                //
+                // Order matters in both directions: reading the backend first
+                // would flicker a locally-'done' card back to 'scraping' until
+                // the invalidation lands, and reading only the local state is
+                // the bug above.
+                const local = runStates[ap._id];
                 const runState =
-                  runStates[ap._id] ?? (ap.runStatus === 'inProgress' ? 'scraping' : 'idle');
+                  local && local !== 'idle'
+                    ? local
+                    : ap.runStatus === 'inProgress'
+                      ? 'scraping'
+                      : 'idle';
                 return (
                   <AutopilotCard
                     key={ap._id}

--- a/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
+++ b/apps/desktop/src/renderer/features/autopilot/components/AutopilotPage/index.tsx
@@ -169,7 +169,17 @@ function AutopilotPage() {
           ) : (
             <div className="space-y-3">
               {autopilots.map((ap) => {
-                const runState = runStates[ap._id] ?? 'idle';
+                // `runStates` is this mount's live event state and starts EMPTY:
+                // navigating to Settings unmounts this page, so a run still in
+                // flight comes back with no local state at all. The backend's
+                // persisted `runStatus` is the durable truth, so fall back to it
+                // — otherwise the card renders 'idle' (no badge exists for
+                // `inProgress`, by design), the Run button re-enables, and the
+                // click is refused by the backend's concurrent-run guard with
+                // "a run is already in progress" for a run the UI just claimed
+                // was finished.
+                const runState =
+                  runStates[ap._id] ?? (ap.runStatus === 'inProgress' ? 'scraping' : 'idle');
                 return (
                   <AutopilotCard
                     key={ap._id}

--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
@@ -21,6 +21,10 @@ vi.mock('@ajh/translations', () => ({
 
 const runMutateAsync = vi.fn();
 
+/** Stable across renders — the hook lists it in `handleStep`'s dep array, so an
+ *  identity that changed every render would silently re-subscribe each time. */
+const invalidateAutopilots = vi.hoisted(() => vi.fn());
+
 /** Captures the step handler the hook registers, so a test can deliver step
  *  events the way the Tauri event bridge does. */
 const stepEvents = vi.hoisted(() => ({
@@ -36,6 +40,7 @@ vi.mock('@/services', async (importActual) => {
     usePauseAutopilot: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
     useResumeAutopilot: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
     useRemoveAutopilot: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
+    useInvalidateAutopilots: () => invalidateAutopilots,
     useAutopilotStepEvents: (cb: (event: never) => void) => {
       stepEvents.handler = cb as unknown as typeof stepEvents.handler;
     },
@@ -135,7 +140,7 @@ describe('useAutopilotRun — handleRun error-payload handling', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('routes a resolved { skipped: "already-running" } payload to idle (not done, not error) with a distinct message', async () => {
+  it('holds a { skipped: "already-running" } payload at scraping (not done, not error, NOT idle) with a distinct message', async () => {
     runMutateAsync.mockResolvedValueOnce({ skipped: 'already-running' });
     const { result } = renderHookWithClient(() => useAutopilotRun());
 
@@ -143,8 +148,11 @@ describe('useAutopilotRun — handleRun error-payload handling', () => {
       await result.current.handleRun('ap-concurrent');
     });
 
-    // Not the silent-success 'done' state — no run actually happened.
-    expect(result.current.runStates['ap-concurrent']).toBe('idle');
+    // The refusal PROVES a run is in flight, so the card must keep showing one.
+    // 'idle' here is what re-armed the Run button for a run the backend refuses
+    // again — the loop the user hit after navigating away mid-run. Neither the
+    // silent-success 'done' (no run happened from this call) nor 'error'.
+    expect(result.current.runStates['ap-concurrent']).toBe('scraping');
     // Not the red 'error' banner either — a distinct, honest message.
     expect(result.current.error).toBe('autopilot.wizard.alreadyRunning');
   });
@@ -187,5 +195,52 @@ describe('useAutopilotRun — batched step events', () => {
     expect(steps).toEqual(['scrape_start', 'scrape_done']);
     // The machine also advanced through BOTH transitions, not just the last.
     expect(result.current.runStates['ap-batch']).toBe('ranking');
+  });
+});
+
+/**
+ * A run the CURRENT mount never started. `runStates` is component-local, so
+ * navigating away and back — or a scheduled run nobody clicked — delivers steps
+ * with no local state and no preceding `scrape_start`.
+ */
+describe('useAutopilotRun — steps for a run this mount did not start', () => {
+  it('advances an unknown autopilot straight from the mid-run step it first sees', () => {
+    const { result } = renderHookWithClient(() => useAutopilotRun());
+    const deliver = stepEvents.handler;
+
+    // No handleRun, no scrape_start — the first thing this mount ever hears
+    // about `ap-remount` is that scraping already finished.
+    act(() => {
+      deliver?.({ jobId: 'j9', autopilotId: 'ap-remount', step: 'scrape_done', detail: '8 jobs' });
+    });
+    expect(result.current.runStates['ap-remount']).toBe('ranking');
+
+    act(() => {
+      deliver?.({ jobId: 'j9', autopilotId: 'ap-remount', step: 'complete', detail: 'Found 8' });
+    });
+    expect(result.current.runStates['ap-remount']).toBe('done');
+  });
+
+  it('refreshes the autopilot list when a run ends, but not on every step', () => {
+    invalidateAutopilots.mockClear();
+    const { result } = renderHookWithClient(() => useAutopilotRun());
+    const deliver = stepEvents.handler;
+    expect(result.current, 'the hook must render').toBeTruthy();
+
+    // Mid-run chatter must not invalidate — the record has not changed yet, and
+    // a refetch per step would refetch several times a run for nothing.
+    act(() => {
+      deliver?.({ jobId: 'j10', autopilotId: 'ap-inv', step: 'scrape_start', detail: 'boards' });
+      deliver?.({ jobId: 'j10', autopilotId: 'ap-inv', step: 'rank_done', detail: 'ranked' });
+    });
+    expect(invalidateAutopilots).not.toHaveBeenCalled();
+
+    // `complete` is the moment the persisted record gains this run's found jobs
+    // and `runStatus`. Without this the card keeps the pre-run data until the
+    // next navigation — the whole reason a finished run looked unfinished.
+    act(() => {
+      deliver?.({ jobId: 'j10', autopilotId: 'ap-inv', step: 'complete', detail: 'Found 8' });
+    });
+    expect(invalidateAutopilots).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
@@ -140,7 +140,7 @@ describe('useAutopilotRun — handleRun error-payload handling', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('holds a { skipped: "already-running" } payload at scraping (not done, not error, NOT idle) with a distinct message', async () => {
+  it('routes a resolved { skipped: "already-running" } payload to idle (not done, not error) with a distinct message', async () => {
     runMutateAsync.mockResolvedValueOnce({ skipped: 'already-running' });
     const { result } = renderHookWithClient(() => useAutopilotRun());
 
@@ -148,11 +148,16 @@ describe('useAutopilotRun — handleRun error-payload handling', () => {
       await result.current.handleRun('ap-concurrent');
     });
 
-    // The refusal PROVES a run is in flight, so the card must keep showing one.
-    // 'idle' here is what re-armed the Run button for a run the backend refuses
-    // again — the loop the user hit after navigating away mid-run. Neither the
-    // silent-success 'done' (no run happened from this call) nor 'error'.
-    expect(result.current.runStates['ap-concurrent']).toBe('scraping');
+    // Not the silent-success 'done' state — no run actually happened.
+    //
+    // 'idle' specifically, and not the 'scraping' the refusal would seem to
+    // justify: 'idle' is the value that hands the card back to the backend's
+    // persisted `runStatus` (see AutopilotPage), so it still displays as
+    // running while the concurrent run lasts AND clears when that run ends.
+    // Pinning 'scraping' here would strand the card forever whenever the
+    // concurrent run FAILS, because the Rust failure path emits no terminal
+    // step for anything to observe.
+    expect(result.current.runStates['ap-concurrent']).toBe('idle');
     // Not the red 'error' banner either — a distinct, honest message.
     expect(result.current.error).toBe('autopilot.wizard.alreadyRunning');
   });
@@ -242,5 +247,23 @@ describe('useAutopilotRun — steps for a run this mount did not start', () => {
       deliver?.({ jobId: 'j10', autopilotId: 'ap-inv', step: 'complete', detail: 'Found 8' });
     });
     expect(invalidateAutopilots).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes the list on a cancelled run too, not only a completed one', () => {
+    // `cancelled` is the OTHER terminal step, and it changes the record just as
+    // much: `finish_cancelled` clears the live status and wipes the previous
+    // run's summaries, so a card left on pre-cancel data is showing a run that
+    // was abandoned.
+    invalidateAutopilots.mockClear();
+    const { result } = renderHookWithClient(() => useAutopilotRun());
+    const deliver = stepEvents.handler;
+    expect(result.current, 'the hook must render').toBeTruthy();
+
+    act(() => {
+      deliver?.({ jobId: 'j11', autopilotId: 'ap-cancel', step: 'cancelled', detail: 'stopped' });
+    });
+
+    expect(invalidateAutopilots).toHaveBeenCalledTimes(1);
+    expect(result.current.runStates['ap-cancel']).toBe('cancelled');
   });
 });

--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
@@ -8,6 +8,7 @@ import { transition as machineTransition } from '@/lib/machine';
 import { autopilotRunMachine, stepToEvent } from '@/lib/machines/autopilot-run.machine';
 import {
   useAutopilotStepEvents,
+  useInvalidateAutopilots,
   usePauseAutopilot,
   useRemoveAutopilot,
   useResumeAutopilot,
@@ -43,34 +44,45 @@ export function useAutopilotRun() {
   const pauseAutopilot = usePauseAutopilot();
   const resumeAutopilot = useResumeAutopilot();
   const removeAutopilot = useRemoveAutopilot();
+  const invalidateAutopilots = useInvalidateAutopilots();
 
-  const handleStep = useCallback((event: AutopilotStepEvent) => {
-    // Both patches DERIVE from the current value, so they must read the
-    // reducer's `prev` — not the render snapshot this callback closed over.
-    // Two step events for the same autopilotId inside one React batch would
-    // otherwise both start from the same base, and the second would overwrite
-    // the first: a dropped step-log line and a skipped state transition.
-    const ev = stepToEvent(event.step);
-    if (ev) {
-      setRunStates((prev) => ({
-        [event.autopilotId]: machineTransition(
-          autopilotRunMachine,
-          prev[event.autopilotId] ?? 'idle',
-          ev
-        ),
+  const handleStep = useCallback(
+    (event: AutopilotStepEvent) => {
+      // Both patches DERIVE from the current value, so they must read the
+      // reducer's `prev` — not the render snapshot this callback closed over.
+      // Two step events for the same autopilotId inside one React batch would
+      // otherwise both start from the same base, and the second would overwrite
+      // the first: a dropped step-log line and a skipped state transition.
+      const ev = stepToEvent(event.step);
+      if (ev) {
+        setRunStates((prev) => ({
+          [event.autopilotId]: machineTransition(
+            autopilotRunMachine,
+            prev[event.autopilotId] ?? 'idle',
+            ev
+          ),
+        }));
+      }
+      // Read the clock at dispatch time, not inside the reducer body: under
+      // StrictMode dev double-invocation the reducer runs twice from the same base,
+      // and `Date.now()` there would produce two different timestamps (impure).
+      const ts = Date.now();
+      setStepLogs((prev) => ({
+        [event.autopilotId]: [
+          ...(prev[event.autopilotId] ?? []).slice(-49),
+          { step: event.step, detail: event.detail, ts },
+        ],
       }));
-    }
-    // Read the clock at dispatch time, not inside the reducer body: under
-    // StrictMode dev double-invocation the reducer runs twice from the same base,
-    // and `Date.now()` there would produce two different timestamps (impure).
-    const ts = Date.now();
-    setStepLogs((prev) => ({
-      [event.autopilotId]: [
-        ...(prev[event.autopilotId] ?? []).slice(-49),
-        { step: event.step, detail: event.detail, ts },
-      ],
-    }));
-  }, []);
+      // A run that ENDS is the only moment the persisted record changes, and the
+      // `runAutopilot` mutation's own invalidation only fires for a run this mount
+      // started and stayed mounted for. Refresh here so a run that finished while
+      // the user was on another page — and a scheduled run nobody clicked — lands
+      // its found jobs and its `runStatus` on the card instead of waiting for the
+      // next navigation.
+      if (event.step === 'complete' || event.step === 'cancelled') invalidateAutopilots();
+    },
+    [invalidateAutopilots]
+  );
 
   useAutopilotStepEvents(handleStep);
 
@@ -94,10 +106,15 @@ export function useAutopilotRun() {
       // resolves with `{ skipped: "already-running" }` instead of running.
       // Nothing happened from THIS call, so it's neither a failure (no red
       // 'error' state) nor a success ('done' would misreport a run that never
-      // occurred) — revert the optimistic 'scraping' state back to idle and
-      // surface a distinct, honest message via the same banner `error` uses.
+      // occurred) — surface a distinct, honest message via the same banner
+      // `error` uses.
+      //
+      // The optimistic 'scraping' state is KEPT, not reverted. This refusal is
+      // proof that a run IS in flight, so reverting to idle re-armed the Run
+      // button for a run the backend would refuse again — the loop the user hit
+      // after navigating away mid-run. Holding 'scraping' also puts the card
+      // back on the live step stream, which carries it to 'done'.
       if (result.skipped === 'already-running') {
-        setRunStates({ [id]: 'idle' });
         setError(t('autopilot.wizard.alreadyRunning'));
         return;
       }

--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
@@ -106,15 +106,19 @@ export function useAutopilotRun() {
       // resolves with `{ skipped: "already-running" }` instead of running.
       // Nothing happened from THIS call, so it's neither a failure (no red
       // 'error' state) nor a success ('done' would misreport a run that never
-      // occurred) — surface a distinct, honest message via the same banner
-      // `error` uses.
+      // occurred) — revert the optimistic 'scraping' and surface a distinct,
+      // honest message via the same banner `error` uses.
       //
-      // The optimistic 'scraping' state is KEPT, not reverted. This refusal is
-      // proof that a run IS in flight, so reverting to idle re-armed the Run
-      // button for a run the backend would refuse again — the loop the user hit
-      // after navigating away mid-run. Holding 'scraping' also puts the card
-      // back on the live step stream, which carries it to 'done'.
+      // Reverting to 'idle' is safe HERE only because 'idle' is what hands the
+      // card back to the backend's `runStatus` (see AutopilotPage). The refusal
+      // proves a run is in flight, so the card still shows one — but it now
+      // does so on evidence that keeps being re-read, rather than on a local
+      // guess. Pinning 'scraping' here instead would strand the card forever
+      // when that concurrent run FAILS: the Rust failure path returns early
+      // without emitting any step, so no terminal event ever arrives to clear
+      // it. Only `runStatus` records that outcome.
       if (result.skipped === 'already-running') {
+        setRunStates({ [id]: 'idle' });
         setError(t('autopilot.wizard.alreadyRunning'));
         return;
       }

--- a/apps/desktop/src/renderer/lib/machines/autopilot-run.machine/autopilot-run.machine.test.ts
+++ b/apps/desktop/src/renderer/lib/machines/autopilot-run.machine/autopilot-run.machine.test.ts
@@ -29,6 +29,32 @@ describe('autopilotRunMachine', () => {
     expect(stepToEvent('unknown-step')).toBeNull();
   });
 
+  it('accepts every mid-run observation from idle, since idle also means "not seen yet"', () => {
+    // The run lives in the backend; `runStates` is component-local and empty
+    // after any navigation. A card that rejoins mid-run gets these WITHOUT a
+    // preceding SCRAPE_START, and dropping them left it claiming idle while the
+    // backend refused a second run as already in progress.
+    expect(transition(autopilotRunMachine, 'idle', 'SCRAPE_DONE')).toBe('ranking');
+    expect(transition(autopilotRunMachine, 'idle', 'RANK_DONE')).toBe('ranking');
+    expect(transition(autopilotRunMachine, 'idle', 'COMPLETE')).toBe('done');
+    expect(transition(autopilotRunMachine, 'idle', 'CANCEL')).toBe('cancelled');
+    expect(transition(autopilotRunMachine, 'idle', 'ERROR')).toBe('error');
+  });
+
+  it('re-arms from a terminal state when the NEXT run announces itself', () => {
+    // Terminal is terminal for one run, not for the autopilot. The scheduler's
+    // next occurrence (or a run started elsewhere) opens with scrape_start, and
+    // without these the card would sit on the previous outcome while a new run
+    // streamed underneath it.
+    expect(transition(autopilotRunMachine, 'done', 'SCRAPE_START')).toBe('scraping');
+    expect(transition(autopilotRunMachine, 'cancelled', 'SCRAPE_START')).toBe('scraping');
+    expect(transition(autopilotRunMachine, 'error', 'SCRAPE_START')).toBe('scraping');
+    // Still terminal for everything else — a stray late COMPLETE from the run
+    // that already ended must not resurrect it into a new lifecycle.
+    expect(transition(autopilotRunMachine, 'done', 'COMPLETE')).toBe('done');
+    expect(transition(autopilotRunMachine, 'cancelled', 'SCRAPE_DONE')).toBe('cancelled');
+  });
+
   it('provides a label for every state', () => {
     expect(RUN_STATE_LABEL.scraping).toBe('Scraping…');
     expect(RUN_STATE_LABEL.done).toBe('Done');

--- a/apps/desktop/src/renderer/lib/machines/autopilot-run.machine/autopilot-run.machine.ts
+++ b/apps/desktop/src/renderer/lib/machines/autopilot-run.machine/autopilot-run.machine.ts
@@ -32,7 +32,23 @@ export type AutopilotRunEvent =
 
 export const autopilotRunMachine = createMachine<AutopilotRunState, AutopilotRunEvent>({
   transitions: {
-    idle: { START: 'scraping', SCRAPE_START: 'scraping', RESET: 'idle' },
+    // `idle` doubles as "this mount has not seen this autopilot run", which is
+    // the state every card starts in after a navigation — the run state is
+    // component-local while the run itself lives in the backend. So idle accepts
+    // the whole mid-run vocabulary, not just the start: a page remounted during
+    // a run (or a card watching a SCHEDULED run it never clicked) receives
+    // `scrape_done`/`complete` with no preceding `scrape_start`, and dropping
+    // those left the card claiming idle for a run that was still going.
+    idle: {
+      START: 'scraping',
+      SCRAPE_START: 'scraping',
+      SCRAPE_DONE: 'ranking',
+      RANK_DONE: 'ranking',
+      COMPLETE: 'done',
+      CANCEL: 'cancelled',
+      ERROR: 'error',
+      RESET: 'idle',
+    },
     scraping: {
       SCRAPE_DONE: 'ranking',
       RANK_DONE: 'ranking',
@@ -46,9 +62,13 @@ export const autopilotRunMachine = createMachine<AutopilotRunState, AutopilotRun
       CANCEL: 'cancelled',
       ERROR: 'error',
     },
-    done: { RESET: 'idle' },
-    cancelled: { RESET: 'idle' },
-    error: { RESET: 'idle' },
+    // A terminal state is terminal for THIS run only. The next run of the same
+    // autopilot — the scheduler's, or one started from another mount — announces
+    // itself with `scrape_start`, and without this arm the card would sit on the
+    // previous run's outcome while a new one streamed underneath it.
+    done: { SCRAPE_START: 'scraping', RESET: 'idle' },
+    cancelled: { SCRAPE_START: 'scraping', RESET: 'idle' },
+    error: { SCRAPE_START: 'scraping', RESET: 'idle' },
   },
   busyStates: ['scraping', 'ranking'],
   errorStates: ['error'],


### PR DESCRIPTION
## The report

> created and ran an autopilot; while it was running I went to the Settings page; when I came back the autopilot was done, but the app footer said autopilot is running, and clicking Run gave *"a run is already in progress for this autopilot"*.

## Everything except the card was telling the truth

The run was genuinely still executing. The desktop log for that run:

```
[autopilot] → run=… boards=aggregator
[autopilot] semantic re-rank exceeded 300s after rescoring 3 of 4; the remaining jobs stay keyword-only
[autopilot] ← run=… boards=aggregator found=20 applied=0 duration=301406ms ok=true
```

5 minutes, dominated by the 300 s semantic re-rank ceiling. During that window the status-bar activity indicator (which reads the global job registry) was right, and `RunGuard` refusing the second click was right — that guard exists precisely to stop a double-run.

Only the **card** was wrong, and it was wrong because its run state is component-local:

| | |
| --- | --- |
| `useAutopilotRun` keeps `runStates` / `stepLogs` in a `useReducer` inside `AutopilotPage` | a route change discards them, so the card re-renders `'idle'` |
| `AutopilotCard` deliberately renders **no badge** for `inProgress` | so nothing else on the card contradicts the false idle |
| the same hook owns the step-event subscription | every step emitted while away — terminal `complete` included — was dropped |
| `runAutopilot`'s `onSuccess` invalidation belongs to the unmounted observer | the finished run's found jobs never reached the list either |

So the card re-armed its Run button for a run the backend would refuse again, and the user hit exactly that.

## The fix

Every part reads truth that already existed — no new state, no new store.

- **`AutopilotPage`** — fall back to the persisted `runStatus === 'inProgress'` when this mount has no local state. The card shows `Scraping…` and the Run button stays `disabled`.
- **`autopilotRunMachine`** — `idle` also means *"this mount has not seen this autopilot run"*, so it now accepts the whole mid-run vocabulary, not just `SCRAPE_START`. A card rejoining mid-run receives `scrape_done`/`complete` with no preceding start, and dropping those pinned it straight back to idle, shadowing the fallback above.
- **`autopilotRunMachine`** — terminal states re-arm on `SCRAPE_START`. Terminal is terminal for *one run*, not for the autopilot; without this the scheduler's next occurrence streams underneath a card frozen on the previous outcome. Everything else still bounces off a terminal state.
- **`useAutopilotRun`** — invalidate the list when a run ends. This also fixes a second, quieter bug: **a scheduled run's results never appeared until the next navigation**, because nobody was mounted to invalidate.
- **`useAutopilotRun`** — stop reverting to `'idle'` on `already-running`. That refusal is *proof* a run is in flight; reverting re-armed the button for a click the backend refuses again. Holding `'scraping'` also puts the card back on the live step stream, which carries it to `done`.

## Tests

- **Mutation-checked:** reverting the `runStatus` fallback to `?? 'idle'` fails exactly one test. The negative halves are there too — `completed` and *never-run* must both stay `idle`, so a fallback that always returned `'scraping'` would not pass.
- Machine: every mid-run event from `idle`; re-arm from all three terminal states; and terminal states still reject everything else, so a stray late `COMPLETE` can't resurrect a finished run.
- Hook: a run this mount never started advances from the first mid-run step it sees; the list refreshes on `complete` but **not** on every step; `already-running` holds at `scraping`.

## Scope note

The renderer is the whole fix — no Rust changed. The backend's concurrent-run guard, job registry and persisted `runStatus` were all correct throughout, which is why the symptom looked like a backend latch and wasn't one.

An app-wide audit for this same defect class (state lost on navigation) is running separately at the owner's request; anything it confirms lands in its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Autopilot runs now correctly resume as **scraping** after the page is remounted when a run is still in progress.
  - Completed, cancelled, or never-started autopilots remain **idle** as expected.
  - Run status now updates reliably for events received after remounting.
  - Autopilot data refreshes when a run completes or is cancelled.
  - Starting a new run correctly resets terminal states and preserves active progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->